### PR TITLE
Cover the resolver's shadow branch without dropping a shared-database constraint

### DIFF
--- a/apps/worker/src/curie_worker/binding.py
+++ b/apps/worker/src/curie_worker/binding.py
@@ -33,6 +33,7 @@ import re
 import secrets
 import time
 import uuid
+from collections.abc import Sequence
 from typing import Any
 from urllib.parse import quote
 
@@ -200,6 +201,46 @@ class ResolvedDeployment(BaseModel):
     secrets: dict[str, str] | None = None
 
 
+def warn_if_multiple_agents_bound(channel: str, rows: Sequence[Any]) -> None:
+    """Warn when a channel resolves to more than one agent, naming the shadowed.
+
+    The ORDER BY picks one deterministic winner (prod-first, then most recent).
+    Since #38 the API enforces one agent per channel (a unique constraint on
+    agents.slack_channel, migration 0017), so this state is no longer reachable
+    through the write paths. It stays as defense in depth for rows predating the
+    constraint or written out of band, and because silently shadowing an agent is
+    the failure mode #38 existed to kill.
+
+    One agent with both a dev and a prod deployment active is two rows but one
+    agent, so count distinct agents, not rows.
+
+    ``rows`` is deliberately typed structurally rather than as SQLAlchemy's
+    ``RowMapping``: the helper only subscripts ``agent_id``, and naming the driver
+    type here would re-couple a function whose whole point is to be DB-free.
+
+    Pure and DB-free on purpose (#959): the branch is unreachable while the
+    constraint holds, so the only honest way to cover it was previously to DROP
+    that constraint against a shared developer database and restore it in a
+    `finally` -- which left the production invariant absent if the process died
+    in between. Taking rows as an argument moves the coverage to a unit test and
+    removes the destructive DDL entirely.
+    """
+
+    distinct_agents = {r["agent_id"] for r in rows}
+    if len(distinct_agents) <= 1:
+        return
+    chosen = rows[0]["agent_id"]
+    shadowed = sorted(str(a) for a in distinct_agents if a != chosen)
+    logger.warning(
+        "channel %s has %d agents bound; routing to agent %s and shadowing "
+        "%s (only one agent per channel responds; see issue #38)",
+        channel,
+        len(distinct_agents),
+        chosen,
+        ", ".join(shadowed),
+    )
+
+
 class BindingResolver:
     """Resolves a Slack channel to its active agent deployment (read-only)."""
 
@@ -215,26 +256,7 @@ class BindingResolver:
             rows = result.mappings().all()
         if not rows:
             return None
-        # The ORDER BY still picks one deterministic winner (prod-first, then most
-        # recent). Since #38 the API enforces one agent per channel (a unique
-        # constraint on agents.slack_channel, migration 0017), so two agents on one
-        # channel is no longer reachable through the write paths -- this stays as
-        # defense in depth for rows predating the constraint or written out of band,
-        # and because silently shadowing an agent is the failure mode #38 existed to
-        # kill. One agent with both a dev and a prod deployment active is two rows
-        # but one agent, so count distinct agents, not rows.
-        distinct_agents = {r["agent_id"] for r in rows}
-        if len(distinct_agents) > 1:
-            chosen = rows[0]["agent_id"]
-            shadowed = sorted(str(a) for a in distinct_agents if a != chosen)
-            logger.warning(
-                "channel %s has %d agents bound; routing to agent %s and shadowing "
-                "%s (only one agent per channel responds; see issue #38)",
-                channel,
-                len(distinct_agents),
-                chosen,
-                ", ".join(shadowed),
-            )
+        warn_if_multiple_agents_bound(channel, rows)
         data = dict(rows[0])
         # asyncpg returns JSONB as a str for a raw-text SELECT (no column type to
         # trigger SQLAlchemy's json deserializer); decode it to the dict/list the

--- a/apps/worker/tests/binding/test_resolver.py
+++ b/apps/worker/tests/binding/test_resolver.py
@@ -10,7 +10,9 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import os
+import unittest.mock
 import uuid
 
 import pytest
@@ -23,6 +25,7 @@ from curie_worker.binding import (
     MEMORY_TOKEN_ENV,
     BindingResolver,
     ResolvedDeployment,
+    warn_if_multiple_agents_bound,
 )
 from curie_worker.config import WorkerConfig
 from curie_worker.sandbox_token import verify
@@ -105,30 +108,6 @@ async def _seed_deployment(
             {"id": uuid.uuid4(), "agent_id": agent_id, "version_id": version_id,
              "env": environment, "status": status},
         )
-
-
-# The unique constraint migration 0017 adds for one-agent-per-channel (#38).
-# Dropping it is how the test below simulates a database whose constraint was
-# removed out of band, the only way the resolver's shadow branch is now
-# reachable. Safe because this suite runs serially (no pytest-xdist).
-_CHANNEL_CONSTRAINT = "agents_slack_channel_key"
-
-
-async def _set_channel_constraint(engine: AsyncEngine, *, present: bool) -> None:
-    async with engine.begin() as conn:
-        if present:
-            await conn.execute(
-                text(
-                    f"ALTER TABLE {_SCHEMA}.agents ADD CONSTRAINT {_CHANNEL_CONSTRAINT} "
-                    "UNIQUE (slack_channel)"
-                )
-            )
-        else:
-            await conn.execute(
-                text(
-                    f"ALTER TABLE {_SCHEMA}.agents DROP CONSTRAINT {_CHANNEL_CONSTRAINT}"
-                )
-            )
 
 
 async def _cleanup(engine: AsyncEngine, agent_ids: list[uuid.UUID]) -> None:
@@ -219,21 +198,18 @@ def test_prod_deployment_wins_over_dev() -> None:
     asyncio.run(go())
 
 
-def test_multiple_agents_on_one_channel_is_refused_and_still_warns_if_forced(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """#38 is fixed by PREVENTION, with the resolver warning kept as a net.
+def test_second_agent_on_a_bound_channel_is_refused() -> None:
+    """#38's invariant, asserted where the worker reads it: the database refuses a
+    second agent on an already-bound channel, so the silent-shadow state cannot be
+    created through any write path. The API asserts the same invariant as a 409.
 
-    Two halves:
-
-    1. The invariant: a second agent bound to an already-bound channel is refused
-       by the database (migration 0017's unique constraint), so the silent-shadow
-       state is unreachable through any write path. This is the worker-side proof
-       of the same invariant the API asserts as a 409.
-    2. Defense in depth: the resolver still warns rather than silently dropping an
-       agent, for a database whose constraint was removed out of band. That branch
-       is only reachable by removing the constraint, which is exactly what this
-       half does (serial suite, restored in the finally).
+    Deliberately does NOT drop the constraint to exercise the shadow branch (#959).
+    That earlier form committed a DROP CONSTRAINT against the shared developer
+    Postgres and restored it in a `finally`, so a killed process left the
+    production invariant absent -- and a concurrent duplicate on any other channel
+    could make the restoring ADD CONSTRAINT fail outright. The shadow branch is now
+    covered by `test_warn_if_multiple_agents_bound_names_the_shadowed_agent`, which
+    needs no database at all.
     """
 
     async def go() -> None:
@@ -247,58 +223,63 @@ def test_multiple_agents_on_one_channel_is_refused_and_still_warns_if_forced(
 
             token = uuid.uuid4().hex[:8]
             channel = f"C-{token}"
-            a_prod = await _seed_agent(
+            agent_id = await _seed_agent(
                 engine, channel=channel, name=f"agent-a-{token}", max_usd=None, max_tokens=None
             )
-
-            # 1. Prevention: the duplicate insert is refused by the constraint.
-            with pytest.raises(IntegrityError):
-                await _seed_agent(
-                    engine,
-                    channel=channel,
-                    name=f"agent-b-{token}",
-                    max_usd=None,
-                    max_tokens=None,
-                )
-
-            # 2. The net: force the state the constraint now prevents.
-            await _set_channel_constraint(engine, present=False)
-            a_dev: uuid.UUID | None = None
             try:
-                a_dev = await _seed_agent(
-                    engine,
-                    channel=channel,
-                    name=f"agent-b-{token}",
-                    max_usd=None,
-                    max_tokens=None,
-                )
-                await _seed_deployment(
-                    engine, agent_id=a_prod, environment="prod", bundle_ref="bundles/a.zip"
-                )
-                await _seed_deployment(
-                    engine, agent_id=a_dev, environment="dev", bundle_ref="bundles/b.zip"
-                )
-
-                with caplog.at_level("WARNING"):
-                    resolved = await _resolver(engine).resolve(channel)
-
-                # Deterministic winner (prod outranks dev) and a warning naming the
-                # shadowed agent, rather than a silent drop (#38).
-                assert resolved is not None
-                assert resolved.agent_id == a_prod
-                assert any(
-                    "agents bound" in r.message and str(a_dev) in r.message
-                    for r in caplog.records
-                )
+                with pytest.raises(IntegrityError):
+                    await _seed_agent(
+                        engine,
+                        channel=channel,
+                        name=f"agent-b-{token}",
+                        max_usd=None,
+                        max_tokens=None,
+                    )
             finally:
-                # Delete the duplicates BEFORE restoring the constraint, or the
-                # ALTER TABLE would fail on the very rows this test created.
-                await _cleanup(engine, [a for a in (a_prod, a_dev) if a is not None])
-                await _set_channel_constraint(engine, present=True)
+                await _cleanup(engine, [agent_id])
         finally:
             await engine.dispose()
 
     asyncio.run(go())
+
+
+def test_warn_if_multiple_agents_bound_names_the_shadowed_agent(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The defense-in-depth branch, covered with no database and no DDL (#959).
+
+    Unreachable while the unique constraint holds, which is exactly why it must be
+    exercised against synthetic rows rather than by removing the constraint from a
+    shared database.
+    """
+
+    chosen = uuid.uuid4()
+    shadowed = uuid.uuid4()
+    rows = [{"agent_id": chosen}, {"agent_id": shadowed}]
+
+    with caplog.at_level("WARNING"):
+        warn_if_multiple_agents_bound("C-shadow", rows)
+
+    assert any(
+        "agents bound" in r.message
+        and str(shadowed) in r.message
+        and str(chosen) in r.message
+        for r in caplog.records
+    ), caplog.records
+
+
+def test_warn_if_multiple_agents_bound_is_quiet_for_one_agent() -> None:
+    """Negative control: one agent with two active deployments is two rows but one
+    agent, so it must NOT warn -- counting rows instead of distinct agents would
+    fire on every prod+dev pair."""
+
+    agent_id = uuid.uuid4()
+    rows = [{"agent_id": agent_id}, {"agent_id": agent_id}]
+
+    logger = logging.getLogger("curie_worker.binding")
+    with unittest.mock.patch.object(logger, "warning") as warned:
+        warn_if_multiple_agents_bound("C-single", rows)
+    warned.assert_not_called()
 
 
 def test_deployment_pointing_at_another_agents_version_does_not_resolve() -> None:


### PR DESCRIPTION
Closes #959. A fair catch against my own #949.

## The hazard
That test committed a `DROP CONSTRAINT` against the **shared** developer Postgres and restored it only in a `finally`. Any abnormal exit between the two — Ctrl-C, OOM, a cancelled CI job, a reboot — left `agents_slack_channel_key` **absent**, so that database silently permitted the exact duplicate binding #38 exists to prevent. Nothing reports it either: a later `alembic upgrade head` is a no-op because revision 0017 is already recorded as applied. A concurrent duplicate on some other channel could also make the restoring `ADD CONSTRAINT` fail, leaving the constraint absent *and* the error pointing at the wrong thing.

My #949 note said the suite runs serially (no `pytest-xdist`). That's true and beside the point — it says nothing about process death, a second pytest process, another developer, or a running `curie local up` stack on the same 25432 instance, all normal here. The issue is right.

## Fix: remove the destructive DDL rather than make it safer
- **Extract** `warn_if_multiple_agents_bound(channel, rows)` as a pure module-level helper. It was *already* a pure function of the queried rows; naming it makes the branch reachable from a unit test. `rows` stays structurally typed rather than SQLAlchemy's `RowMapping`, so a helper whose whole point is to be DB-free doesn't re-import the driver's vocabulary.
- **Unreachable-state coverage moves to unit tests, no database at all:** the warning names the shadowed agent, plus a **negative control** — one agent with two active deployments is two rows but one agent and must *not* warn (counting rows instead of distinct agents would fire on every prod+dev pair).
- **The DB test keeps the half that needs a database and is safe:** a second agent on a bound channel is refused — the worker-side proof of #38's invariant.

## Nothing lost
`test_prod_deployment_wins_over_dev` already covers prod-beats-dev for one agent, and prod-beats-dev *across* agents is unreachable in production by construction now.

## On the acceptance criteria
"Does not leave the constraint absent after an abnormal exit" is met **structurally, not by better cleanup**: there is no `DROP CONSTRAINT` anywhere in the suite any more, so there is no window to die in.

## Verification
- The two new unit tests pass with no database.
- **No regression:** the worker suite reports **32 failures both with and without** these changes (pre-existing — they need the compose stack this box lacks), and **514 passed vs 512** stashed, exactly the two new tests.
- `ruff` and `mypy` clean on both touched files.

I could not run the DB-backed half locally (this box's Postgres is stale, which is what the 32 pre-existing failures are); CI runs it against a properly migrated database.
