### PR TITLE
Match compose and otel inputs in the e2e ladder path filter

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -785,8 +785,18 @@ jobs:
           fi
           base="${{ github.base_ref }}"
           git fetch --quiet origin "$base"
+          # The ladder-relevant surface. #906 reused #843's cluster-rung filter
+          # verbatim when it gated all three rungs, but the local and
+          # local-release rungs BOOT COMPOSE, so their input surface is strictly
+          # larger: compose.dev.yaml (local), the generated release compose and
+          # the generator/overlay under compose/ (local-release), and otel/ (the
+          # collector every profile starts). Without those a compose-only PR
+          # skipped the very rungs that exist to test compose -- including the
+          # local-release rung whose stated purpose is closing that parity seam
+          # (#958). compose.release.yaml is generated, not tracked, and is listed
+          # so a future decision to commit it does not silently re-open the hole.
           if git diff --name-only "origin/$base...HEAD" \
-              | grep -qE '^(charts/|cli/|apps/|runner/|packages/|\.github/workflows/ci\.yaml)'; then
+              | grep -qE '^(charts/|cli/|apps/|runner/|packages/|compose/|compose\.dev\.yaml|compose\.release\.yaml|otel/|\.github/workflows/ci\.yaml)'; then
             echo "ladder=true" >> "$GITHUB_OUTPUT"
           else
             echo "ladder=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Closes #958. A correct catch against my own #906.

## What I broke
#906 put all three ladder rungs behind one path filter — but that filter was **#843's**, written for the **kind rung's** input surface, and I reused it verbatim for two rungs with a strictly larger one. The local rung boots `compose.dev.yaml`; the local-release rung boots the generated release compose. **No `compose/` input matched**, so a compose-only PR skipped the very rungs whose job is to boot compose — including the local-release rung whose stated purpose is closing that parity seam.

The always-on `compose` job isn't a substitute: it runs `docker compose config` plus service-count assertions and never boots the stack — as `ci.yaml`'s own comment says. The coverage was genuinely gone.

## Fix
Add `compose/`, `compose.dev.yaml`, `compose.release.yaml` and `otel/` to the filter. (`compose.release.yaml` is generated rather than tracked; it's listed so a future decision to commit it can't silently reopen the hole.)

## Verified by replay, not by reading the regex

| path | before | after |
|---|---|---|
| `compose.dev.yaml` | SKIPS | **RUNS** |
| `compose.release.yaml` | SKIPS | **RUNS** |
| `compose/generate_release_compose.py` | SKIPS | **RUNS** |
| `compose/worker-local.Dockerfile` | SKIPS | **RUNS** |
| `otel/collector-config.yaml` | SKIPS | **RUNS** |
| `cli/scripts/e2e-ladder.sh` | RUNS | RUNS |
| `docs/vision.md` | SKIPS | **SKIPS** |

That last row is the **negative control**: the filter is widened, not defeated. Skipping unrelated PRs is the entire point of #906, so a fix that made everything run would be a regression of a different kind.

**Replayed against real history**, as the issue suggests — both compose-only commits flip:
- `56eb3494` (init containers; `compose.dev.yaml` + a compose test): `ladder=false` → **`true`**
- `7e5a5a45` (healthcheck loopback; `compose.dev.yaml` + `compose.release.yaml`): `ladder=false` → **`true`**

`actionlint` clean. Merge-time signal only, as the issue notes: `push` already forces `ladder=true`, so `main` and the release gate were never affected.
