### PR TITLE
Move ADR-0078's supersession note to a compliant back-link

### DIFF
--- a/docs/adr/0063-message-driven-approval-reply-surface.md
+++ b/docs/adr/0063-message-driven-approval-reply-surface.md
@@ -3,6 +3,12 @@
 Date: 2026-07-21
 Status: Accepted
 
+**Deferral superseded by [ADR-0078](0078-approval-cards-over-connected-transport.md)**
+(back-link added under [ADR-0045](0045-the-status-line-is-the-mutable-part-of-an-immutable-adr.md)):
+this ADR's Decision defers the connected Slack transport as the approval surface
+("not (yet) the connected Slack transport", its Alternative 1, "Follow-up A").
+0078 adopts it. The zero-Slack keep-alive decision below is unaffected.
+
 ## Context
 
 `curie local message` and `curie cluster message` mint an in-process

--- a/docs/adr/0078-approval-cards-over-connected-transport.md
+++ b/docs/adr/0078-approval-cards-over-connected-transport.md
@@ -4,6 +4,12 @@ Date: 2026-07-23
 
 Status: Accepted
 
+**Mechanism superseded by [ADR-0082](0082-connected-transport-approval-cards-via-a-real-placeholder.md)**
+(back-link added under [ADR-0045](0045-the-status-line-is-the-mutable-part-of-an-immutable-adr.md)):
+the empty-`reply_handle.placeholder` sentinel this ADR's Decision specifies is
+not implementable. 0082 carries this ADR's intent forward unchanged and states
+the mechanism that replaces it, with the reasoning there.
+
 ## Context
 
 ADR-0063 fixed the zero-Slack case of a `message`-driven approval: `curie
@@ -35,14 +41,6 @@ change across a sacred boundary, not a passenger on the offline fix:
   skip minting the stub and let the card and resumed reply ride that transport.
 
 ## Decision
-
-> **Mechanism superseded by ADR-0082.** The empty-`reply_handle.placeholder`
-> sentinel below cannot work: `ApprovalRequest.reply_placeholder` is
-> `min_length=1` in the frozen `packages/aci-protocol`, so such a turn is
-> rejected at approval-create and the pause escalates instead of posting a card.
-> ADR-0082 keeps this ADR's intent (the connected transport is the approval
-> surface) and replaces the mechanism: the CLI posts a REAL placeholder and
-> enqueues against its ts, needing no kernel or wire change.
 
 **When `message` runs against a connected transport (a running dispatcher),
 route the approval card and the resumed reply over the worker's default Slack


### PR DESCRIPTION
Closes #960. Another correct catch against my #927 — this one against the ADR discipline itself.

## What I broke
I recorded ADR-0082's supersession as a blockquote **inside ADR-0078's `## Decision`**. ADR-0045 permits an Accepted ADR to change in exactly three ways, and that's none of them — in three separate respects:

1. **Wrong location** — the back-link belongs immediately after the `Status:` line.
2. **Wrong form** — mine argued the case, near-duplicating ADR-0082's Context, where clause 2 says the back-link *"is a pointer, not an argument"*.
3. **Wrong section** — it rewrote a body ADR-0045 names as never rewritten.

ADR-0045's own rejected alternatives explain why placement is load-bearing: pinning the back-link under `Status:` keeps the mutable region contiguous, so *"a diff touching an Accepted ADR outside those lines is mechanically suspect."* My edit destroyed exactly that property — the thing that makes the rule checkable.

## Fix
- ADR-0078's `## Decision` restored to its pre-#927 text (**verified byte-identical** against `5915eac^`, not eyeballed).
- Back-link added under `Status:` in the ADR-0058 form, reduced to *what* was superseded and *by which* ADR; the reasoning stays in ADR-0082 under normal ADR discipline.
- The status line was already right — ADR-0045 keeps `Status: Accepted` for a partial supersession.

## Also fixed: the same slip one link earlier
The issue flags for context that **ADR-0063 never got a back-link** even though ADR-0078 supersedes its deferral. That's the same rule and the same chain, so leaving it would mean the discipline stays half-broken across `0063 → 0078 → 0082`. Added, noting that 0063's zero-Slack keep-alive decision is unaffected.

## Split out
The remaining acceptance criterion — a doclint check that a change to an Accepted ADR touches only the permitted mutable region — is filed as its own issue, as #960 invites. It's a new gate rather than a repair of this defect, and it would enforce precisely the rule this PR restores.

`curie dev docs-lint` passes; `docs/adr/README.md` regenerated rather than hand-edited.
