### PR TITLE
Gate the harness doc's module names, not just how many there are

### DIFF
--- a/tools/doclint/src/curie_doclint/__init__.py
+++ b/tools/doclint/src/curie_doclint/__init__.py
@@ -38,7 +38,7 @@ from .citation import (
     scan_raw_line_ban,
 )
 from .commands import check_agent_contract
-from .counts import check_counts
+from .counts import check_counts, check_name_sets
 from .finding import Finding
 from .frontmatter import SeamMeta, parse_and_validate
 from .generate import (
@@ -108,6 +108,10 @@ def _lint_and_count(repo_root: Path) -> tuple[list[Finding], int]:
     # region: the numbers sit mid-sentence, so they are asserted against source
     # rather than rewritten, and `--write` leaves them alone.
     findings.extend(check_counts(repo_root))
+    # The same prose, gated on WHICH modules rather than how many (#1028). A
+    # count and a name set drift independently: swapping one importing module
+    # for another holds the count and makes the list wrong.
+    findings.extend(check_name_sets(repo_root))
     # The published verification contract names commands an agent is told to
     # trust (#1041). Same class as check_counts: prose asserted against
     # machine-readable ground truth, never rewritten, so `--write` leaves it

--- a/tools/doclint/src/curie_doclint/counts.py
+++ b/tools/doclint/src/curie_doclint/counts.py
@@ -127,11 +127,33 @@ def parse_count(token: str) -> int | None:
     return _NUMBER_WORDS.get(token.lower())
 
 
+def _sdk_importing_runner_module_names(repo_root: Path) -> set[str]:
+    """The runner modules that import ``claude_agent_sdk`` at import level.
+
+    This is the leakage the harness seam grades itself on: every module here is
+    one the SDK is not yet walled off from. The prose names them as bare file
+    names (``check.py``), so that is what this returns.
+
+    Args:
+        repo_root: The repository root to resolve ``runner/src`` against.
+
+    Returns:
+        The set of ``.py`` file names under ``runner/src`` carrying an SDK import.
+    """
+    src = repo_root / "runner" / "src"
+    return {
+        path.name
+        for path in sorted(src.rglob("*.py"))
+        if _SDK_IMPORT_RE.search(path.read_text(encoding="utf-8"))
+    }
+
+
 def _count_sdk_importing_runner_modules(repo_root: Path) -> int:
     """Count runner modules that import ``claude_agent_sdk`` at import level.
 
-    This is the leakage the harness seam grades itself on: every module here is
-    one the SDK is not yet walled off from.
+    Derived from [`_sdk_importing_runner_module_names`] rather than counted
+    separately, so the count claim and the name claim below cannot disagree with
+    each other about the same tree (#1019).
 
     Args:
         repo_root: The repository root to resolve ``runner/src`` against.
@@ -139,12 +161,7 @@ def _count_sdk_importing_runner_modules(repo_root: Path) -> int:
     Returns:
         The number of ``.py`` files under ``runner/src`` carrying an SDK import.
     """
-    src = repo_root / "runner" / "src"
-    return sum(
-        1
-        for path in sorted(src.rglob("*.py"))
-        if _SDK_IMPORT_RE.search(path.read_text(encoding="utf-8"))
-    )
+    return len(_sdk_importing_runner_module_names(repo_root))
 
 
 def _count_committed_cli_schemas(repo_root: Path) -> int:
@@ -220,6 +237,120 @@ CLAIMS: tuple[CountClaim, ...] = (
         source="#[test] in cli/tests/json_contract.rs",
     ),
 )
+
+
+@dataclass(frozen=True)
+class NameSetClaim:
+    """One ENUMERATION a seam doc states in prose, tied to its source of truth.
+
+    A count claim above pins how many; this pins which. #952 gated the harness
+    doc's "nine runner modules" but not the nine names listed beside it, so two
+    edits kept the gate green while making the doc wrong: renaming one of the
+    modules, or moving the import from one module to another. The second is the
+    likely one, because confining these imports is #844 Phase 2's refactor and
+    moving imports between modules is precisely what it does (#1019).
+
+    ``pattern`` must capture the region holding the list in group 1; the names
+    are then read out of it as backticked tokens, so re-ordering or re-wrapping
+    the sentence does not matter but changing the membership does.
+    """
+
+    doc: str
+    label: str
+    pattern: re.Pattern[str]
+    lister: Callable[[Path], set[str]]
+    source: str
+
+
+# A backticked file name inside the enumerated region.
+_BACKTICKED_NAME_RE = re.compile(r"`([^`]+\.py)`")
+
+# Every enumeration claim the seam catalog makes.
+NAME_CLAIMS: tuple[NameSetClaim, ...] = (
+    NameSetClaim(
+        doc="docs/interfaces/harness-modelsession/INTERFACE.md",
+        label="the runner modules importing claude_agent_sdk, by name",
+        # The parenthesised run after the claim sentence. DOTALL because the
+        # list wraps across lines in the prose.
+        pattern=re.compile(r"claude_agent_sdk`\s+today\s+\(([^)]*)\)", re.DOTALL),
+        lister=_sdk_importing_runner_module_names,
+        source="`from`/`import claude_agent_sdk` in runner/src/**/*.py",
+    ),
+)
+
+
+def check_name_sets(
+    repo_root: Path, claims: tuple[NameSetClaim, ...] = NAME_CLAIMS
+) -> list[Finding]:
+    """Assert every prose ENUMERATION in the seam catalog against the tree (#1019).
+
+    The count-claim sibling above answers "how many"; this answers "which", so a
+    rename or a swap that preserves the count cannot leave the list wrong while
+    the gate stays green.
+
+    Args:
+        repo_root: The repository root the docs and sources are resolved under.
+        claims: The claims to check; defaults to the catalog's own [`NAME_CLAIMS`].
+
+    Returns:
+        One finding per claim whose listed names disagree with the tree, or whose
+        anchor phrase vanished, and an empty list when every list matches.
+    """
+    findings: list[Finding] = []
+    is_catalog = _is_catalog_root(repo_root)
+
+    for claim in claims:
+        doc = repo_root / claim.doc
+        if not doc.is_file():
+            if is_catalog:
+                findings.append(
+                    Finding(
+                        claim.doc,
+                        claim.label,
+                        f"the seam doc has moved, so this claim ({claim.source}) is "
+                        "no longer verified. Restore the doc at this path, or update "
+                        f"this claim's doc path in {_CATALOG_MARKER}.",
+                    )
+                )
+            continue
+
+        regions = claim.pattern.findall(doc.read_text(encoding="utf-8"))
+        if not regions:
+            # Same anti-vacuity rule the count claims use: a reworded sentence
+            # must fail loudly rather than quietly stop being checked.
+            findings.append(
+                Finding(
+                    claim.doc,
+                    claim.label,
+                    "no sentence enumerates these any more, so the list is no longer "
+                    "verified. Restore the phrasing, or update this claim's pattern "
+                    f"in {_CATALOG_MARKER} "
+                    f"(source of truth: {claim.source}).",
+                )
+            )
+            continue
+
+        expected = claim.lister(repo_root)
+        for region in regions:
+            listed = set(_BACKTICKED_NAME_RE.findall(region))
+            missing = sorted(expected - listed)
+            extra = sorted(listed - expected)
+            if not missing and not extra:
+                continue
+            parts = []
+            if missing:
+                parts.append(f"the tree has {', '.join(missing)} but the prose omits them")
+            if extra:
+                parts.append(f"the prose lists {', '.join(extra)} but the tree does not")
+            findings.append(
+                Finding(
+                    claim.doc,
+                    claim.label,
+                    f"{'; '.join(parts)} ({claim.source}). Update the prose to match.",
+                )
+            )
+
+    return findings
 
 
 def check_counts(repo_root: Path, claims: tuple[CountClaim, ...] = CLAIMS) -> list[Finding]:

--- a/tools/doclint/tests/test_counts.py
+++ b/tools/doclint/tests/test_counts.py
@@ -19,7 +19,13 @@ from __future__ import annotations
 from pathlib import Path
 
 from curie_doclint import counts
-from curie_doclint.counts import CLAIMS, _CATALOG_MARKER, check_counts, parse_count
+from curie_doclint.counts import (
+    CLAIMS,
+    _CATALOG_MARKER,
+    check_counts,
+    check_name_sets,
+    parse_count,
+)
 
 from .conftest import REPO_ROOT, Regenerate, RunLint, write
 
@@ -30,6 +36,18 @@ _CLI_OUTPUT_DOC = "docs/interfaces/cli-output/INTERFACE.md"
 def _sdk_module(name: str) -> tuple[str, str]:
     """A runner module that imports the harness SDK at import level."""
     return f"runner/src/curie_runner/{name}.py", "from claude_agent_sdk import Thing\n"
+
+
+def _harness_names_prose(names: str) -> str:
+    """The harness sentence in the form that ENUMERATES the modules (#1019).
+
+    Matches the real doc's shape: the count, then the parenthesised backticked
+    list after "today", which is what the name claim reads.
+    """
+    return (
+        "CLEAN, but the SDK is not yet confined to one module: two runner modules\n"
+        f"still import `claude_agent_sdk` today ({names}), and the value that crosses.\n"
+    )
 
 
 def _harness_prose(count: str) -> str:
@@ -300,3 +318,70 @@ def test_count_drift_fails_through_the_cli(
     assert code != 0
     assert "runner modules importing claude_agent_sdk" in out
     assert "'six'" in out
+
+
+# --- the enumeration disagrees with the tree (#1019) ------------------------
+#
+# #952 gated the harness doc's COUNT but not the names beside it, so a rename or
+# a swap kept the count right and the list wrong. These drive the real
+# NAME_CLAIMS over miniature trees, same discipline as the count tests above.
+
+
+def test_matching_name_list_passes(tmp_path: Path) -> None:
+    # Positive control: a gate that reported everything would be no gate.
+    write(tmp_path, *_sdk_module("check"))
+    write(tmp_path, *_sdk_module("session"))
+    write(tmp_path, _HARNESS_DOC, _harness_names_prose("`check.py`, `session.py`"))
+    assert check_name_sets(tmp_path) == []
+
+
+def test_renamed_module_is_reported_by_name(tmp_path: Path) -> None:
+    # The tree renamed session.py -> runtime.py; the count is still two, so the
+    # count claim cannot see this.
+    write(tmp_path, *_sdk_module("check"))
+    write(tmp_path, *_sdk_module("runtime"))
+    write(tmp_path, _HARNESS_DOC, _harness_names_prose("`check.py`, `session.py`"))
+
+    findings = check_name_sets(tmp_path)
+    assert len(findings) == 1, findings
+    detail = findings[0].reason
+    assert "runtime.py" in detail and "session.py" in detail, detail
+
+
+def test_swapped_import_is_caught_though_the_count_is_unchanged(tmp_path: Path) -> None:
+    """The motivating case, and the one #952's count gate provably cannot catch.
+
+    One module drops the SDK import and another gains it. The count is identical,
+    so `check_counts` passes; only the enumeration reveals the drift. #844 Phase 2
+    moves imports between exactly these modules, so this is the likely edit.
+    """
+    write(tmp_path, *_sdk_module("check"))
+    write(tmp_path, *_sdk_module("plugin"))  # gained it
+    write(tmp_path, "runner/src/curie_runner/session.py", "import os\n")  # dropped it
+    write(tmp_path, _HARNESS_DOC, _harness_names_prose("`check.py`, `session.py`"))
+
+    # The old gate is blind to it: two modules stated, two modules in the tree.
+    assert check_counts(tmp_path) == []
+
+    findings = check_name_sets(tmp_path)
+    assert len(findings) == 1, findings
+    detail = findings[0].reason
+    assert "plugin.py" in detail and "session.py" in detail, detail
+
+
+def test_removed_enumeration_fails_rather_than_going_vacuous(tmp_path: Path) -> None:
+    # The vacuity guard, mirroring the count claims': a reworded sentence must
+    # fail loudly rather than quietly stop being checked.
+    write(tmp_path, *_sdk_module("check"))
+    write(tmp_path, _HARNESS_DOC, "The SDK is imported in some runner modules.\n")
+
+    findings = check_name_sets(tmp_path)
+    assert len(findings) == 1, findings
+    assert "no longer verified" in findings[0].reason
+
+
+def test_absent_seam_doc_is_skipped_for_names_too(tmp_path: Path) -> None:
+    # A miniature tree that is not the catalog carries no seam docs; that is not
+    # a defect, same rule the count claims follow.
+    write(tmp_path, *_sdk_module("check"))
+    assert check_name_sets(tmp_path) == []


### PR DESCRIPTION
Closes #1019.

## The gap
#952 gated the harness doc's **count** ("nine runner modules import `claude_agent_sdk`"). Beside that number the same sentence **lists the nine by name**, and nothing verified the list. So two edits kept the gate green while making the doc wrong:

- a module is **renamed** — count still nine, list names something that no longer exists;
- one module **drops** the import and another **gains** it — count still nine, list wrong in two places.

The second is the likely one: confining these imports is **#844 Phase 2's refactor**, and moving imports between exactly these modules is what it does.

## Fix
A `NameSetClaim` sibling to `CountClaim`: the pattern captures the parenthesised list, names are read out as backticked tokens, and the truth comes from the same tree scan. Re-ordering or re-wrapping the sentence is fine; changing membership is not. It carries the same two anti-vacuity guards the count claims have — a reworded sentence and a moved doc both fail loudly instead of quietly going unchecked.

**The count is now derived from the name set** rather than scanned separately, so the two claims about the same tree cannot disagree with each other.

## The decisive test
The swap case asserts **both** halves:

```python
# The old gate is blind to it: two modules stated, two modules in the tree.
assert check_counts(tmp_path) == []
findings = check_name_sets(tmp_path)   # ... but this reports it, naming both
```

That's the proof the new gate catches something the old one provably cannot — not just that it happens to pass. A rename and a removed enumeration are covered too, plus a positive control, so the gate can't pass by reporting everything *or* by reporting nothing.

98 doclint tests pass; `ruff` and `mypy` clean; `curie dev docs-lint` green on the tree as it stands.
