### PR TITLE
Widen the e2e ladder path filter to examples/, pyproject.toml and uv.lock

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -795,8 +795,14 @@ jobs:
           # local-release rung whose stated purpose is closing that parity seam
           # (#958). compose.release.yaml is generated, not tracked, and is listed
           # so a future decision to commit it does not silently re-open the hole.
+          # #1032 widened the surface again: examples/ is the fixed bundle every
+          # rung deploys (cli/scripts/e2e-ladder.sh hardcodes BUNDLE_SRC to
+          # examples/weather and copies it into both the local and local-release
+          # workdirs), and the root pyproject.toml / uv.lock are what every
+          # ladder image builds and boots. A PR editing any of the three changed
+          # what the rungs exercise while skipping every rung.
           if git diff --name-only "origin/$base...HEAD" \
-              | grep -qE '^(charts/|cli/|apps/|runner/|packages/|compose/|compose\.dev\.yaml|compose\.release\.yaml|otel/|\.github/workflows/ci\.yaml)'; then
+              | grep -qE '^(charts/|cli/|apps/|runner/|packages/|examples/|compose/|compose\.dev\.yaml|compose\.release\.yaml|otel/|pyproject\.toml|uv\.lock|\.github/workflows/ci\.yaml)'; then
             echo "ladder=true" >> "$GITHUB_OUTPUT"
           else
             echo "ladder=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Widens the `changes` job's ladder path filter so the three remaining real ladder inputs stop skipping every rung.

- `examples/` -- `cli/scripts/e2e-ladder.sh:68` hardcodes `BUNDLE_SRC="$REPO_ROOT/examples/weather"` and copies it into both the local and local-release workdirs (`:641-642`). The script's own comment calls it a fixed input of the test, so a PR editing `examples/weather` changed what every rung deploys while skipping every rung.
- root `pyproject.toml` and `uv.lock` -- every ladder image builds from them, so a workspace dependency change or a lock re-resolution altered what the rungs boot.

The explanatory comment above the filter is extended in the same voice, citing #1032 alongside the existing #906 / #958 / #843 history.

## Replay

Pattern read back out of the edited `ci.yaml` rather than retyped, so this exercises the shipped expression:

```
$ pattern=$(grep -oE "\^\(charts/[^']*\)" .github/workflows/ci.yaml)
$ echo "$pattern"
^(charts/|cli/|apps/|runner/|packages/|examples/|compose/|compose\.dev\.yaml|compose\.release\.yaml|otel/|pyproject\.toml|uv\.lock|\.github/workflows/ci\.yaml)
$ for path in compose/x.py otel/config.yaml uv.lock pyproject.toml examples/weather/plugin.json docs/vision.md; do
    printf '%s => ladder=%s\n' "$path" "$(printf '%s\n' "$path" | grep -qE "$pattern" && echo true || echo false)"
  done
compose/x.py => ladder=true
otel/config.yaml => ladder=true
uv.lock => ladder=true
pyproject.toml => ladder=true
examples/weather/plugin.json => ladder=true
docs/vision.md => ladder=false
```

Negative controls beyond the one the issue names, confirming the filter is still a filter and not a rubber stamp:

```
docs/adr/0075-agent-proxy.md => ladder=false
README.md                    => ladder=false
ui/src/App.tsx               => ladder=false
gtools/foo.go                => ladder=false
.github/workflows/release.yaml => ladder=false
.github/ISSUE_TEMPLATE/bug.yaml => ladder=false
```

`actionlint .github/workflows/ci.yaml` passes and the file parses under `yaml.safe_load`.

Merge-time signal only: `push` already forces `ladder=true`, so `main` and the release gate were never affected.

Closes #1032
