### PR TITLE
Close the commit-message gate's fail-open range path and pin its self-test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -313,8 +313,10 @@ commands.
   assistant, the robot-emoji "Generated with" footer, or an attribution phrase next
   to a bare assistant name. Technical references (`CLAUDE.md`, `claude_agent_sdk`,
   `claude-sonnet-5`, `harness.claude`) are deliberately fine, and the script's
-  `--self-test` pins both halves so the distinction cannot silently rot. It checks
-  only the PR's own commits, so pre-gate history is not retroactively enforced.
+  `--self-test` pins both halves so the distinction cannot silently rot. A commit
+  range the script cannot resolve is a hard failure naming the range, not a silent
+  pass. It checks only the PR's own commits, so pre-gate history is not
+  retroactively enforced.
 - No dashes/emdashes in prose content; no emojis in code or docs.
 
 ## Decisions: ADR vs. GitHub issue

--- a/scripts/check-commit-messages.sh
+++ b/scripts/check-commit-messages.sh
@@ -14,23 +14,36 @@
 #     Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
 #
 # So three rules, each aimed at a claim of authorship:
-#   A. a `Co-Authored-By:` trailer naming an assistant or a vendor no-reply address
-#   B. the robot-emoji "Generated with" footer these tools append
-#   C. an attribution phrase ("generated with", "written by", ...) on the same line
-#      as a BARE assistant name -- bare meaning not part of an identifier, so
+#   A. a `Co-Authored-By:` trailer naming an assistant or an AI vendor. Its vendor
+#      set is deliberately WIDER than rule C's, because a trailer is an
+#      unambiguous authorship claim where a bare name is not.
+#   B. the robot-emoji footer these tools append
+#   C. an attribution phrase (one of generated|authored|written|created|assisted|
+#      produced followed by one of with|by|using) on the same line as a BARE
+#      assistant name -- bare meaning not part of an identifier, so
 #      `claude_agent_sdk`, `CLAUDE.md`, `claude-sonnet-5` and `harness.claude`
 #      never trip it.
 #
 # Usage:
 #   scripts/check-commit-messages.sh [<range>]   # default: origin/main..HEAD
 #   scripts/check-commit-messages.sh --self-test # prove the matcher is not vacuous
+#
+# An unresolvable range is a hard failure, never a silent pass, so `--self-test`
+# re-invokes this script once with a bogus range and must run inside a git repo.
 set -euo pipefail
+
+# Absolute path to this script, so the self-test can re-invoke it from any cwd.
+SCRIPT_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
 
 # A bare assistant name: not preceded by [._/-] and not followed by [._-], so
 # every technical identifier form is excluded by construction.
 BARE_ASSISTANT='(^|[^A-Za-z0-9_./-])(claude|codex|copilot|chatgpt|gemini|devin)([^A-Za-z0-9_.-]|$)'
-ATTRIBUTION_PHRASE='(generated|authored|written|created|assisted|produced)[[:space:]]+(with|by)'
-COAUTHOR_AI='^[[:space:]]*co-authored-by:.*(claude|codex|copilot|chatgpt|gemini|devin|anthropic|openai|noreply@anthropic\.com)'
+ATTRIBUTION_PHRASE='(generated|authored|written|created|assisted|produced)[[:space:]]+(with|by|using)'
+# Cursor is trailer only because bare cursor is a common technical noun.
+# No address alternative here on purpose: the pattern is unanchored, so `anthropic`
+# already subsumes `noreply@anthropic.com`. Re-adding the address would be dead
+# regex that no self-test case can ever pin.
+COAUTHOR_AI='^[[:space:]]*co-authored-by:.*(claude|codex|copilot|chatgpt|gemini|devin|anthropic|openai|cursor)'
 ROBOT_FOOTER=$'\xf0\x9f\xa4\x96'  # the robot emoji these tools append
 
 # Echo the reason a line violates the convention, or nothing when it is clean.
@@ -55,12 +68,40 @@ self_test() {
     local failures=0
 
     # MUST be flagged: real attribution, including the exact trailer that landed.
+    # Every case is an independent literal: nothing here is built from the same
+    # variable the matcher greps, so deleting a matcher token cannot delete its
+    # own coverage and leave this control green.
     local bad=(
         "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+        "Co-Authored-By: Claude Assistant <helper@example.com>"
+        "Co-Authored-By: Codex Assistant <helper@example.com>"
+        "Co-Authored-By: Copilot Assistant <helper@example.com>"
+        "Co-Authored-By: ChatGPT Assistant <helper@example.com>"
+        "Co-Authored-By: Gemini Assistant <helper@example.com>"
+        "Co-Authored-By: Devin Assistant <helper@example.com>"
+        "Co-Authored-By: Anthropic Assistant <helper@example.com>"
+        "Co-Authored-By: OpenAI Assistant <helper@example.com>"
+        "Co-authored-by: Cursor Agent <cursoragent@cursor.com>"
         "co-authored-by: Codex <noreply@openai.com>"
         "${ROBOT_FOOTER} Generated with [Claude Code](https://claude.com/claude-code)"
+        # Rule B alone must catch this: the emoji is a byte literal rather than
+        # ${ROBOT_FOOTER}, and there is no vendor name or attribution phrase for
+        # rule A or rule C to fall back on.
+        $'\xf0\x9f\xa4\x96 automated tool footer'
         "Generated with Claude"
+        "Generated using Claude"
+        "Generated with Codex"
+        "Generated with Copilot"
+        "Generated with ChatGPT"
+        "Generated with Gemini"
+        "Generated with Devin"
+        # One case per remaining attribution verb and preposition, so no token of
+        # ATTRIBUTION_PHRASE can be dropped with this control still green.
         "This patch was written by GitHub Copilot"
+        "Docs authored by Claude"
+        "Fixture created with Codex"
+        "Refactor assisted by Gemini"
+        "Baseline produced using Devin"
     )
     # MUST NOT be flagged: real lines from this repo's history and its vocabulary.
     local good=(
@@ -88,6 +129,16 @@ self_test() {
         fi
     done
 
+    # The range guard is a gate too: an unresolvable range must fail loudly rather
+    # than report "nothing to check". The recursive argument is a literal bogus
+    # range and never --self-test, so recursion depth is exactly one.
+    local guard_rc=0
+    bash "$SCRIPT_PATH" 'curie-no-such-ref-1033..HEAD' >/dev/null 2>&1 || guard_rc=$?
+    if ((guard_rc == 0)); then
+        echo "self-test FAIL: unresolvable range exited 0 instead of failing loudly" >&2
+        failures=$((failures + 1))
+    fi
+
     if ((failures)); then
         echo "commit-message gate self-test: $failures case(s) wrong" >&2
         exit 1
@@ -101,7 +152,31 @@ if [[ "${1:-}" == "--self-test" ]]; then
 fi
 
 range="${1:-origin/main..HEAD}"
-mapfile -t commits < <(git log --format=%H "$range" 2>/dev/null || true)
+# git consumes an option-shaped argument (`-0`, `--max-count=0`, `--since=...`)
+# before the `--` end-of-revisions marker below, so it never reaches `git log`
+# as a range at all; left unchecked it silently narrows or empties the log and
+# reports success having inspected nothing. No legitimate commit range starts
+# with `-`, so reject it up front the same way an unresolvable range is rejected.
+if [[ "$range" == -* ]]; then
+    echo "unable to resolve commit range '$range': looks like an option, not a range" >&2
+    exit 1
+fi
+# An empty endpoint (`..HEAD`, `HEAD..`) is a range git accepts and resolves to
+# zero commits, which is the same fail-open shape as an unresolvable range.
+if [[ "$range" == *".."* && ( -z "${range%%..*}" || -z "${range##*..}" ) ]]; then
+    echo "unable to resolve commit range '$range': endpoint is empty" >&2
+    exit 1
+fi
+commits=()
+# The trailing `--` forces the argument to be read as a revision range: without
+# it a path like AGENTS.md resolves and the gate scans commits it does not own.
+if ! commit_output="$(git log --format=%H "$range" --)"; then
+    echo "unable to resolve commit range '$range'" >&2
+    exit 1
+fi
+if [[ -n "$commit_output" ]]; then
+    mapfile -t commits <<<"$commit_output"
+fi
 if ((${#commits[@]} == 0)); then
     echo "no commits in range '$range'; nothing to check"
     exit 0


### PR DESCRIPTION
Closes #1033

`scripts/check-commit-messages.sh` had a vacuous-pass path and a negative control that did not control. Both are closed.

## Range resolution fails loudly

`git log`'s failure was swallowed by `2>/dev/null || true`, so a range whose endpoints were not present resolved to zero commits and the gate exited 0 having inspected nothing. Now non-zero with a diagnostic naming the range, for each of: an unresolvable revision, a path argument mistaken for a range (`AGENTS.md` previously scanned 25 unrelated commits), an empty endpoint (`..HEAD`), and an option-shaped argument (`--since=2099-01-01`, which git consumes before the `--` marker).

A range that resolves but is genuinely empty still exits 0 unchanged.

The empty-endpoint and option cases matter because CI interpolates both endpoints from the event payload: an unset `base.sha` would have expanded to `..HEAD` and passed vacuously.

## The self-test now pins the matcher

Previously, removing `gemini` from both regexes left `--self-test` green. It now carries an independent literal case per vendor token in both the trailer and bare-name rules, per verb and preposition in the attribution phrase, and for the robot-footer rule alone. All 24 single-token deletions across the three patterns now red the control, as does deleting either the footer rule or the range guard; before this change most of those deletions were silent.

The cases are deliberately not generated from a shared token list. One source feeding both matcher and control would delete a token's coverage along with the token, which is the bug being fixed.

The robot-footer case is written as a byte escape rather than interpolating `ROBOT_FOOTER`, so mutating the matcher no longer mutates its own control, and it carries no vendor name so the attribution rule cannot mask a regression in it.

## Two missed attribution forms

`using` joins the accepted attribution prepositions, and cursor joins the trailer rule. Cursor is deliberately absent from the bare-name rule: it is an ordinary technical noun (a database cursor, a pagination cursor), so a bare match beside an attribution phrase would cost false positives, whereas a `Co-Authored-By` trailer naming Cursor is unambiguous. A comment records that asymmetry.

The redundant `noreply@anthropic\.com` alternative is dropped. The pattern is unanchored, so any string containing the address also contains `anthropic`, meaning the address could never match on its own. Removing it is coverage-neutral by construction and is the precondition for pinning `anthropic`: on the old script, deleting `anthropic` left the self-test green because the address alternative covered for it, which was defect 2's own shape.

## Precision is unchanged

Over the preceding 400 commits the matcher produces byte-identical output to before, with zero attribution-phrase matches. Widened to all 896 commits it is still byte-identical, so neither new token adds a single match anywhere in history. The 16 findings in that range are genuine pre-gate co-author trailers, present identically before and after, which is why the gate is scoped to a PR's own commits.

## Out of scope, deliberately

- Making this a required status check, tracked in #1016.
- The `AGENTS.md` "CI enforces this on every PR" wording, which the issue notes overstates the current advisory status but does not ask to fix. Untouched. The one `AGENTS.md` clause added here documents the new hard-fail, which is drift caused by this change.
- Verb-list gaps such as "Implemented by Claude", which the issue calls a deliberate precision tradeoff.

Two changes go slightly beyond the letter of the acceptance criteria, both same-class and reviewer-prompted: pinning the attribution-phrase verbs and prepositions (test-only, no production behaviour change; leaving them unpinned reproduced the ticket's defect for a different token class), and rejecting path- and option-shaped arguments (the criteria say an *invalid* range must fail, and these were silent-pass paths in the same function).
