### PR TITLE
Add the console session store and login-code exchange

### DIFF
--- a/apps/api/alembic/versions/0021_console_sessions.py
+++ b/apps/api/alembic/versions/0021_console_sessions.py
@@ -1,0 +1,87 @@
+"""console_sessions: the store behind revocable console sessions (#1044)
+
+ADR-0083. The console holds the shared platform key in browser code today, which
+#630 tracks as a release blocker. This table is the durable half of the
+replacement: a login code the CLI mints, exchanged once for a session token, both
+stored only as SHA-256 hashes so reading this table cannot replay a session, and
+revocation expressed as a column (``revoked_at``) rather than as waiting out a
+self-contained token's expiry.
+
+Nothing reads this table yet. Slice 1 lands the store and the two exchange
+endpoints wired to nothing; ``require_api_key`` starts accepting a session in
+slice 2 (#1045).
+
+Revision ID: 0021
+Revises: 0020
+Create Date: 2026-07-28
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0021"
+down_revision: str | None = "0020"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+SCHEMA = "curie"
+
+
+def upgrade() -> None:
+    op.create_table(
+        "console_sessions",
+        sa.Column(
+            "id",
+            sa.dialects.postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            nullable=False,
+        ),
+        # Hashes, never the credential itself.
+        sa.Column("login_code_hash", sa.String(), nullable=False),
+        sa.Column("login_code_expires_at", sa.DateTime(), nullable=False),
+        # NULL until the code is exchanged.
+        sa.Column("session_token_hash", sa.String(), nullable=True),
+        sa.Column("session_expires_at", sa.DateTime(), nullable=True),
+        sa.Column("consumed_at", sa.DateTime(), nullable=True),
+        sa.Column("revoked_at", sa.DateTime(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        schema=SCHEMA,
+    )
+    # Unique so no two rows can satisfy one credential; indexed because both are
+    # looked up by hash on every exchange and (from slice 2) every session-authed
+    # request.
+    op.create_index(
+        "ix_console_sessions_login_code_hash",
+        "console_sessions",
+        ["login_code_hash"],
+        unique=True,
+        schema=SCHEMA,
+    )
+    op.create_index(
+        "ix_console_sessions_session_token_hash",
+        "console_sessions",
+        ["session_token_hash"],
+        unique=True,
+        schema=SCHEMA,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_console_sessions_session_token_hash",
+        table_name="console_sessions",
+        schema=SCHEMA,
+    )
+    op.drop_index(
+        "ix_console_sessions_login_code_hash",
+        table_name="console_sessions",
+        schema=SCHEMA,
+    )
+    op.drop_table("console_sessions", schema=SCHEMA)

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -1022,6 +1022,56 @@
         "title": "ConnectorManifests",
         "type": "object"
       },
+      "ConsoleLoginCodeOut": {
+        "description": "A freshly minted login code, returned exactly once.\n\nThe code is plaintext here because this response IS the one delivery: the CLI\nprints it for the operator to copy. Only its hash is stored.",
+        "properties": {
+          "code": {
+            "title": "Code",
+            "type": "string"
+          },
+          "expires_at": {
+            "format": "date-time",
+            "title": "Expires At",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "expires_at"
+        ],
+        "title": "ConsoleLoginCodeOut",
+        "type": "object"
+      },
+      "ConsoleSessionExchange": {
+        "description": "The browser's exchange request: a login code and nothing else.",
+        "properties": {
+          "code": {
+            "minLength": 1,
+            "title": "Code",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code"
+        ],
+        "title": "ConsoleSessionExchange",
+        "type": "object"
+      },
+      "ConsoleSessionOut": {
+        "description": "The result of an exchange. Deliberately carries NO token.\n\nThe session token travels only as an `HttpOnly` cookie, so page script cannot\nread it -- putting it in the body would hand the credential straight back to\nthe JavaScript this design exists to keep it away from.",
+        "properties": {
+          "expires_at": {
+            "format": "date-time",
+            "title": "Expires At",
+            "type": "string"
+          }
+        },
+        "required": [
+          "expires_at"
+        ],
+        "title": "ConsoleSessionOut",
+        "type": "object"
+      },
       "CostReport": {
         "description": "Daily spend series + total for an agent (L1 Cost view).",
         "properties": {
@@ -5203,6 +5253,98 @@
         "summary": "Get Config",
         "tags": [
           "config"
+        ]
+      }
+    },
+    "/console/login-codes": {
+      "post": {
+        "description": "Mint a single-use login code for an operator to copy into the console.",
+        "operationId": "create_login_code_console_login_codes_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConsoleLoginCodeOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Login Code",
+        "tags": [
+          "console"
+        ]
+      }
+    },
+    "/console/session": {
+      "post": {
+        "description": "Exchange a login code for a session cookie.\n\nUnauthenticated by design (see the module docstring). Every rejection is the\nsame 401 with the same text: an unknown code, an already-consumed one, an\nexpired one and a revoked row are indistinguishable to the caller, so this\nendpoint cannot be used to enumerate which codes exist.",
+        "operationId": "exchange_login_code_console_session_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ConsoleSessionExchange"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConsoleSessionOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Exchange Login Code",
+        "tags": [
+          "console"
         ]
       }
     },

--- a/apps/api/src/curie_api/crud.py
+++ b/apps/api/src/curie_api/crud.py
@@ -1,5 +1,7 @@
 """Database access helpers for agents, versions, deployments, and approvals."""
 
+import hashlib
+import secrets
 import uuid
 from datetime import UTC, datetime, timedelta
 from typing import Any
@@ -13,6 +15,7 @@ from .models import (
     Approval,
     ApprovalAuditEntry,
     ApprovalStatus,
+    ConsoleSession,
     Deployment,
     Environment,
 )
@@ -675,3 +678,157 @@ async def list_approval_audit(
         .order_by(ApprovalAuditEntry.created_at)
     )
     return list(result)
+
+
+# --- console sessions (ADR-0083, #1044) -------------------------------------
+#
+# The credential never enters the database: every read and write below goes
+# through `hash_console_credential`, so a dump of `console_sessions` is useless to
+# an attacker. Callers hold the plaintext only long enough to hand it to the
+# operator (the code) or the browser (the token).
+
+#: How long a minted login code stays redeemable. Short by design: it exists only
+#: to be copied from a terminal into a browser once.
+LOGIN_CODE_TTL = timedelta(minutes=10)
+
+#: How long an established console session stays valid before a fresh login.
+CONSOLE_SESSION_TTL = timedelta(hours=12)
+
+
+def hash_console_credential(value: str) -> str:
+    """The stored form of a login code or session token.
+
+    SHA-256 rather than a password hash on purpose: these are high-entropy
+    machine-generated values, not user-chosen secrets, so there is nothing to slow
+    down a guessing attack against -- and a lookup happens on every session-authed
+    request, where a deliberately slow KDF would be a denial-of-service surface.
+
+    Args:
+        value: The plaintext code or token.
+
+    Returns:
+        Lowercase hex SHA-256 of ``value``.
+    """
+    return hashlib.sha256(value.encode()).hexdigest()
+
+
+def new_login_code() -> str:
+    """A single-use login code an operator can copy out of a terminal."""
+    return secrets.token_urlsafe(12)
+
+
+def new_session_token() -> str:
+    """A console session token. Longer than the code: it is never typed."""
+    return secrets.token_urlsafe(32)
+
+
+async def create_console_login_code(
+    session: AsyncSession, *, now: datetime | None = None
+) -> tuple[str, ConsoleSession]:
+    """Mint a login code and its pending session row.
+
+    Args:
+        session: The database session.
+        now: Injectable clock, so expiry is testable without sleeping.
+
+    Returns:
+        ``(plaintext code, row)``. The plaintext is returned ONCE and never
+        stored; only its hash is persisted.
+    """
+    moment = now or datetime.now(UTC).replace(tzinfo=None)
+    code = new_login_code()
+    row = ConsoleSession(
+        login_code_hash=hash_console_credential(code),
+        login_code_expires_at=moment + LOGIN_CODE_TTL,
+    )
+    session.add(row)
+    await session.commit()
+    await session.refresh(row)
+    return code, row
+
+
+async def exchange_console_login_code(
+    session: AsyncSession, code: str, *, now: datetime | None = None
+) -> tuple[str, ConsoleSession] | None:
+    """Consume a login code and mint the session token it establishes.
+
+    Single-use and expiry are enforced HERE rather than by the caller, so no
+    endpoint can accidentally skip either. A code that is unknown, already
+    consumed, expired, or whose row was revoked yields ``None`` -- one
+    indistinguishable failure, so a caller cannot probe which codes exist.
+
+    Args:
+        session: The database session.
+        code: The plaintext login code presented by the browser.
+        now: Injectable clock.
+
+    Returns:
+        ``(plaintext session token, row)`` on success, else ``None``.
+    """
+    moment = now or datetime.now(UTC).replace(tzinfo=None)
+    result = await session.execute(
+        select(ConsoleSession).where(
+            ConsoleSession.login_code_hash == hash_console_credential(code)
+        )
+    )
+    row = result.scalar_one_or_none()
+    if row is None:
+        return None
+    if row.consumed_at is not None or row.revoked_at is not None:
+        return None
+    if row.login_code_expires_at <= moment:
+        return None
+
+    token = new_session_token()
+    row.session_token_hash = hash_console_credential(token)
+    row.session_expires_at = moment + CONSOLE_SESSION_TTL
+    row.consumed_at = moment
+    await session.commit()
+    await session.refresh(row)
+    return token, row
+
+
+async def live_console_session(
+    session: AsyncSession, token: str, *, now: datetime | None = None
+) -> ConsoleSession | None:
+    """The session a token authenticates, or ``None`` if it does not authenticate one.
+
+    "Live" means exchanged, unrevoked and unexpired. Slice 2 (#1045) is what calls
+    this from `require_api_key`; it lands here with the store so the store's own
+    tests can prove revocation and expiry are expressed, per #1044's acceptance.
+
+    Args:
+        session: The database session.
+        token: The plaintext session token from the cookie.
+        now: Injectable clock.
+
+    Returns:
+        The live row, else ``None`` -- again one indistinguishable failure.
+    """
+    moment = now or datetime.now(UTC).replace(tzinfo=None)
+    result = await session.execute(
+        select(ConsoleSession).where(
+            ConsoleSession.session_token_hash == hash_console_credential(token)
+        )
+    )
+    row = result.scalar_one_or_none()
+    if row is None or row.revoked_at is not None:
+        return None
+    if row.session_expires_at is None or row.session_expires_at <= moment:
+        return None
+    return row
+
+
+async def revoke_console_session(
+    session: AsyncSession, row: ConsoleSession, *, now: datetime | None = None
+) -> ConsoleSession:
+    """Revoke a session by stamping ``revoked_at``.
+
+    A column write, which is the whole point of a stored session: the operator can
+    kill one without rotating the platform key and restarting the API.
+    """
+    row.revoked_at = now or datetime.now(UTC).replace(tzinfo=None)
+    await session.commit()
+    await session.refresh(row)
+    return row
+

--- a/apps/api/src/curie_api/main.py
+++ b/apps/api/src/curie_api/main.py
@@ -31,6 +31,7 @@ from .routers import (
     approvals,
     bundles,
     config,
+    console,
     control,
     deploy_targets,
     deployments,
@@ -257,6 +258,7 @@ def create_app() -> FastAPI:
         return {"status": "ok"}
 
     app.include_router(config.router)
+    app.include_router(console.router)
     app.include_router(agents.router)
     app.include_router(deployments.router)
     app.include_router(bundles.router)

--- a/apps/api/src/curie_api/models.py
+++ b/apps/api/src/curie_api/models.py
@@ -285,3 +285,39 @@ class WorkflowStateEntry(Base):
     version: Mapped[int] = mapped_column(default=1)
     created_at: Mapped[datetime] = mapped_column(server_default=func.now())
     updated_at: Mapped[datetime] = mapped_column(server_default=func.now(), onupdate=func.now())
+
+
+class ConsoleSession(Base):
+    """One console login: the code that establishes it and the session it becomes.
+
+    ADR-0083. The console authenticates with a server-managed, revocable session
+    instead of holding the platform key in browser code. A row is created when the
+    CLI mints a login code and completed when the browser exchanges that code for a
+    session token.
+
+    Only HASHES of the code and the token are stored, so reading this table cannot
+    replay a session -- the same reason `Approval` does not store credentials. And
+    revocation is `revoked_at`, a column write: a durable row a human can kill,
+    rather than a self-contained signed token that stays valid until it expires.
+    That distinction is why ADR-0083 rejected a stateless JWT-shaped token.
+    """
+
+    __tablename__ = "console_sessions"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    # SHA-256 hex of the single-use login code. Unique so a hash collision or a
+    # duplicate mint cannot produce two rows one code could satisfy.
+    login_code_hash: Mapped[str] = mapped_column(unique=True, index=True)
+    login_code_expires_at: Mapped[datetime]
+    # Set at exchange, so NULL means "minted, never redeemed".
+    session_token_hash: Mapped[str | None] = mapped_column(
+        default=None, unique=True, index=True
+    )
+    session_expires_at: Mapped[datetime | None] = mapped_column(default=None)
+    # Stamped at exchange; its presence is what makes the code single-use.
+    consumed_at: Mapped[datetime | None] = mapped_column(default=None)
+    revoked_at: Mapped[datetime | None] = mapped_column(default=None)
+    created_at: Mapped[datetime] = mapped_column(server_default=func.now())
+

--- a/apps/api/src/curie_api/routers/console.py
+++ b/apps/api/src/curie_api/routers/console.py
@@ -1,0 +1,86 @@
+"""Console session exchange: mint a login code, trade it for a session cookie.
+
+ADR-0083, first slice (#1044) of #630. The console holds the shared platform
+administrator key in browser code today -- resolved from `?api_key=`, a build
+variable, or a published dev default -- which puts a credential that authorizes
+deployments, approvals, budgets and the kill switch into browser history, request
+logs and referrers, revocable only by rotating the Secret and restarting the API.
+
+Two endpoints, deliberately asymmetric:
+
+- ``POST /console/login-codes`` requires the platform key. Minting is an
+  administrative act, and the CLI is the only intended caller.
+- ``POST /console/session`` requires NO credential, because the login code IS the
+  credential being presented. It is the one unauthenticated write in the API, so
+  it is bounded on purpose: the code is single-use and short-lived, a failure is
+  indistinguishable from any other failure (so codes cannot be probed), and
+  success grants a session, never the platform key.
+
+NOTHING CONSUMES A SESSION YET. ``require_api_key`` starts accepting one in slice
+2 (#1045); until then these endpoints are inert and the console is unchanged. That
+is the point of the slicing: the store and the exchange are provable on their own
+before anything depends on them.
+"""
+
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+
+from .. import crud
+from ..auth import require_api_key
+from ..deps import SessionDep
+from ..schemas import ConsoleLoginCodeOut, ConsoleSessionExchange, ConsoleSessionOut
+
+router = APIRouter(prefix="/console", tags=["console"])
+
+#: The cookie the console authenticates with. `HttpOnly` is the property that
+#: makes this strictly stronger than the status quo: page script cannot read it,
+#: so injected script cannot exfiltrate the credential it authenticates with.
+SESSION_COOKIE = "curie_console_session"
+
+
+@router.post(
+    "/login-codes",
+    response_model=ConsoleLoginCodeOut,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(require_api_key)],
+)
+async def create_login_code(session: SessionDep) -> ConsoleLoginCodeOut:
+    """Mint a single-use login code for an operator to copy into the console."""
+    code, row = await crud.create_console_login_code(session)
+    return ConsoleLoginCodeOut(code=code, expires_at=row.login_code_expires_at)
+
+
+@router.post("/session", response_model=ConsoleSessionOut)
+async def exchange_login_code(
+    data: ConsoleSessionExchange, response: Response, session: SessionDep
+) -> ConsoleSessionOut:
+    """Exchange a login code for a session cookie.
+
+    Unauthenticated by design (see the module docstring). Every rejection is the
+    same 401 with the same text: an unknown code, an already-consumed one, an
+    expired one and a revoked row are indistinguishable to the caller, so this
+    endpoint cannot be used to enumerate which codes exist.
+    """
+    exchanged = await crud.exchange_console_login_code(session, data.code)
+    if exchanged is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="invalid or expired login code",
+        )
+    token, row = exchanged
+
+    # The token leaves the server ONLY here and ONLY as a cookie. `httponly`
+    # keeps it away from page script; `secure` keeps it off plaintext hops;
+    # `samesite="strict"` means a cross-site request cannot carry it, which is the
+    # CSRF property that matters for an API whose every write is authorized by it.
+    response.set_cookie(
+        SESSION_COOKIE,
+        token,
+        httponly=True,
+        secure=True,
+        samesite="strict",
+        path="/",
+    )
+    # Note the response body: an expiry, never the token. Returning it would hand
+    # the credential back to the JavaScript this whole design keeps it from.
+    assert row.session_expires_at is not None  # set by the exchange above
+    return ConsoleSessionOut(expires_at=row.session_expires_at)

--- a/apps/api/src/curie_api/schemas.py
+++ b/apps/api/src/curie_api/schemas.py
@@ -1105,3 +1105,35 @@ class MemoryEntryEdit(BaseModel):
 
     content: str
     expected_version: int
+
+
+# --- console sessions (ADR-0083, #1044) -------------------------------------
+
+
+class ConsoleLoginCodeOut(BaseModel):
+    """A freshly minted login code, returned exactly once.
+
+    The code is plaintext here because this response IS the one delivery: the CLI
+    prints it for the operator to copy. Only its hash is stored.
+    """
+
+    code: str
+    expires_at: datetime
+
+
+class ConsoleSessionExchange(BaseModel):
+    """The browser's exchange request: a login code and nothing else."""
+
+    code: str = Field(min_length=1)
+
+
+class ConsoleSessionOut(BaseModel):
+    """The result of an exchange. Deliberately carries NO token.
+
+    The session token travels only as an `HttpOnly` cookie, so page script cannot
+    read it -- putting it in the body would hand the credential straight back to
+    the JavaScript this design exists to keep it away from.
+    """
+
+    expires_at: datetime
+

--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -133,7 +133,8 @@ async def _truncate() -> None:
             await conn.execute(
                 text(
                     "TRUNCATE curie.approvals, curie.deployments, "
-                    "curie.agent_versions, curie.agents CASCADE"
+                    "curie.agent_versions, curie.agents, "
+                    "curie.console_sessions CASCADE"
                 )
             )
     finally:

--- a/apps/api/tests/test_console_sessions.py
+++ b/apps/api/tests/test_console_sessions.py
@@ -1,0 +1,187 @@
+"""The console session store and the login-code exchange (#1044, ADR-0083).
+
+Real Postgres round-trip via the disposable-DB conftest, so migration 0018 is
+exercised too: these tests fail if the table or its unique indexes did not land.
+
+The properties asserted here are the security ones, because they are the reason
+the table exists rather than the console simply holding the platform key:
+
+- the credential is never stored in plaintext, so a database read cannot replay
+  a session;
+- a login code works exactly once;
+- expiry and revocation are both expressed, and revocation is a column write
+  rather than waiting out a token;
+- the exchange response carries no token, only a cookie, so page script never
+  sees the credential it authenticates with.
+
+Nothing consumes a session yet -- `require_api_key` starts accepting one in slice
+2 (#1045) -- so there is deliberately no test here that a session authorizes a
+real request. What IS asserted is that the store can express liveness, which is
+what slice 2 will build on.
+"""
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from datetime import timedelta
+from typing import Any
+
+from curie_api import crud
+from curie_api.config import get_settings
+from curie_api.models import ConsoleSession
+from curie_api.routers.console import SESSION_COOKIE
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+
+
+def with_session[T](body: Callable[[AsyncSession], Awaitable[T]]) -> T:
+    """Run ``body`` against the disposable database.
+
+    Builds its own engine the way conftest's own ``_truncate`` does, rather than
+    via a fixture: this repo configures no pytest-asyncio, so an async test would
+    silently not run. Callers depend on ``clean_db`` for isolation.
+    """
+
+    async def go() -> T:
+        engine = create_async_engine(get_settings().database_url)
+        try:
+            async with AsyncSession(engine) as session:
+                return await body(session)
+        finally:
+            await engine.dispose()
+
+    return asyncio.run(go())
+
+
+# --- the HTTP surface ------------------------------------------------------
+
+
+def test_minting_requires_the_platform_key(client: Any, clean_db: None) -> None:
+    # Minting is an administrative act; only the CLI, holding the platform key,
+    # should be able to do it.
+    assert client.post("/console/login-codes").status_code == 401
+
+
+def test_mint_then_exchange_sets_an_httponly_cookie_and_returns_no_token(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    minted = client.post("/console/login-codes", headers=auth_headers)
+    assert minted.status_code == 201, minted.text
+    code = minted.json()["code"]
+
+    # The exchange needs no credential of its own: the code IS the credential.
+    exchanged = client.post("/console/session", json={"code": code})
+    assert exchanged.status_code == 200, exchanged.text
+
+    # The token must NOT be in the body -- that would hand the credential back to
+    # the JavaScript this design keeps it away from.
+    body = exchanged.json()
+    assert "token" not in body and "session_token" not in body, body
+    assert "expires_at" in body
+
+    # ... and the cookie must be HttpOnly, so page script cannot read it.
+    set_cookie = exchanged.headers.get("set-cookie", "")
+    assert SESSION_COOKIE in set_cookie, set_cookie
+    assert "httponly" in set_cookie.lower(), set_cookie
+    assert "samesite=strict" in set_cookie.lower().replace(" ", ""), set_cookie
+    assert "secure" in set_cookie.lower(), set_cookie
+
+
+def test_a_login_code_works_exactly_once(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    code = client.post("/console/login-codes", headers=auth_headers).json()["code"]
+    assert client.post("/console/session", json={"code": code}).status_code == 200
+    # Second attempt: the code is consumed.
+    again = client.post("/console/session", json={"code": code})
+    assert again.status_code == 401, again.text
+
+
+def test_an_unknown_code_fails_identically_to_a_consumed_one(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    # Indistinguishable failures, so the endpoint cannot be used to learn which
+    # codes exist.
+    used = client.post("/console/login-codes", headers=auth_headers).json()["code"]
+    client.post("/console/session", json={"code": used})
+
+    consumed = client.post("/console/session", json={"code": used})
+    unknown = client.post("/console/session", json={"code": "not-a-real-code"})
+    assert consumed.status_code == unknown.status_code == 401
+    assert consumed.json()["detail"] == unknown.json()["detail"]
+
+
+# --- the store's own properties -------------------------------------------
+
+
+def test_no_plaintext_credential_is_ever_stored(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    """The property that makes a database dump useless to an attacker."""
+
+    code = client.post("/console/login-codes", headers=auth_headers).json()["code"]
+    client.post("/console/session", json={"code": code})
+
+    async def read(session: AsyncSession) -> list[ConsoleSession]:
+        return list((await session.execute(select(ConsoleSession))).scalars().all())
+
+    rows = with_session(read)
+    assert len(rows) == 1
+    row = rows[0]
+    assert code not in f"{row.login_code_hash}{row.session_token_hash}"
+    # Hashes, not values: hex SHA-256 is 64 characters.
+    assert len(row.login_code_hash) == 64
+    assert row.session_token_hash is not None and len(row.session_token_hash) == 64
+    assert row.login_code_hash == crud.hash_console_credential(code)
+
+
+def test_an_expired_code_cannot_be_exchanged(clean_db: None) -> None:
+    async def body(session: AsyncSession) -> None:
+        # Injected clock rather than sleeping: expiry is arithmetic, not a race.
+        code, row = await crud.create_console_login_code(session)
+        past = row.login_code_expires_at + timedelta(seconds=1)
+        assert await crud.exchange_console_login_code(session, code, now=past) is None
+
+    with_session(body)
+
+
+def test_a_live_session_is_recognized_and_expiry_ends_it(clean_db: None) -> None:
+    async def body(session: AsyncSession) -> None:
+        code, _ = await crud.create_console_login_code(session)
+        exchanged = await crud.exchange_console_login_code(session, code)
+        assert exchanged is not None
+        token, row = exchanged
+
+        assert await crud.live_console_session(session, token) is not None
+        assert row.session_expires_at is not None
+        after = row.session_expires_at + timedelta(seconds=1)
+        assert await crud.live_console_session(session, token, now=after) is None
+
+    with_session(body)
+
+
+def test_revocation_kills_a_live_session_without_waiting_for_expiry(
+    clean_db: None,
+) -> None:
+    """The reason this is a table and not a signed stateless token (ADR-0083)."""
+
+    async def body(session: AsyncSession) -> None:
+        code, _ = await crud.create_console_login_code(session)
+        exchanged = await crud.exchange_console_login_code(session, code)
+        assert exchanged is not None
+        token, row = exchanged
+        assert await crud.live_console_session(session, token) is not None
+
+        await crud.revoke_console_session(session, row)
+        # Still well inside its expiry window, and no longer valid.
+        assert await crud.live_console_session(session, token) is None
+
+    with_session(body)
+
+
+def test_a_revoked_row_cannot_still_have_its_code_exchanged(clean_db: None) -> None:
+    async def body(session: AsyncSession) -> None:
+        code, row = await crud.create_console_login_code(session)
+        await crud.revoke_console_session(session, row)
+        assert await crud.exchange_console_login_code(session, code) is None
+
+    with_session(body)


### PR DESCRIPTION
Slice 1 of 5 for #630, per [ADR-0083](docs/adr/0083-console-sessions-and-cli-minted-login-codes.md) (PR #1029).

## Why

The console authenticates to the API with the **shared platform key, resolved in browser code** — from `?api_key=`, a build variable, or the published dev default. That puts a credential authorizing deployments, approvals, budgets and the kill switch into browser history, request logs and referrers, and makes it revocable only by rotating the Secret and restarting the API. #630 tracks this as a release blocker.

#645 attempted the whole replacement in one pass and was closed as too drastic to verify or debug. This is the first of five **additive** slices (#1044 → #1048), ordered so slices 1–3 are invisible to users and the single visible swap lands last with both halves together.

## What this lands

The durable half only, **wired to nothing**:

| | |
|---|---|
| `console_sessions` (migration `0018`) | login code + session token stored as SHA-256 hashes, never as values; both hash columns uniquely indexed |
| Revocation | a column write (`revoked_at`), not waiting out an expiry — the reason this is a table rather than a signed stateless token, and what makes the new credential strictly better than the one it replaces |
| Enforcement site | single-use, expiry and revocation live in `crud`, not the endpoints, so no future caller can skip them |
| `POST /console/login-codes` | **requires the platform key** — minting is administrative, and the CLI is the only intended caller |
| `POST /console/session` | **requires no credential**, because the code *is* the credential being presented. Bounded on purpose: single-use, short-lived, and every rejection is the same 401 with the same text, so codes cannot be probed |
| The token's only exit | an `HttpOnly; Secure; SameSite=strict` cookie. The response body carries an expiry and **no token**, so page script never sees the credential it authenticates with |

`require_api_key` is untouched — nothing consumes a session until slice 2 (#1045). The console is unchanged by this PR.

## On the new-auth-scheme invariant

`apps/api/CLAUDE.md` says not to add a second auth scheme for a new router without raising it first. Raising it here: this is exactly the change ADR-0083 decided, and it is deliberately *not* a second way to authenticate existing routers — `/console/session` authenticates nothing but itself, and the sessions it mints authorize nothing until #1045 extends the one shared dependency (rather than adding a parallel one).

## Verification

- `pytest apps/api/tests/test_console_sessions.py` — 9 tests, all passing, against a **real Postgres**, so migration `0018` is exercised with them. They assert the security properties (no plaintext stored, code works exactly once, indistinguishable failures, expiry, revocation-beats-expiry, revoked row's code is dead) rather than the plumbing.
- `test_openapi_drift` + `test_auth` + `test_agents`: 31 passing — no existing auth path moved.
- ruff + mypy clean.

### Manual verification

Against a **scratch database**, because `apps/api/CLAUDE.md` forbids stamping the shared compose Postgres with an unmerged revision. Run from `apps/api` with the dev stack up. This was run as written; results below.

```bash
PG="docker exec -i $(docker ps --format '{{.Names}}' | grep postgres | head -1)"
$PG psql -U postgres -d postgres -q -c "create database console_verify"
export DATABASE_URL="postgresql+asyncpg://postgres:postgres@localhost:25432/console_verify"
uv run alembic upgrade head
API_KEY=curie-dev-key uv run uvicorn curie_api.main:app --port 28099 &

API=http://localhost:28099
curl -s -o /dev/null -w '%{http_code}\n' -X POST $API/console/login-codes          # 401: minting needs the key
CODE=$(curl -s -X POST $API/console/login-codes -H 'X-API-Key: curie-dev-key' | jq -r .code)
curl -s -i -X POST $API/console/session -H 'content-type: application/json' -d "{\"code\":\"$CODE\"}"
curl -s -o /dev/null -w '%{http_code}\n' -X POST $API/console/session -H 'content-type: application/json' -d "{\"code\":\"$CODE\"}"   # 401: single use
curl -s -X POST $API/console/session -H 'content-type: application/json' -d '{"code":"nope"}'   # identical 401 body
$PG psql -U postgres -d console_verify -x -c 'select login_code_hash, session_token_hash, consumed_at from curie.console_sessions;'
curl -s -o /dev/null -w '%{http_code}\n' $API/agents -H "Cookie: curie_console_session=<token>"  # 401: inert until #1045

$PG psql -U postgres -d postgres -q -c 'drop database console_verify'
```

What it showed:

| Check | Result |
|---|---|
| Migration `0018` applies | table + both unique hash indexes present |
| Mint without the platform key | `401` |
| Mint with it | `201 {"code":"...","expires_at":"..."}` |
| Exchange | `200`, `set-cookie: curie_console_session=...; HttpOnly; Path=/; SameSite=strict; Secure`, body `{"expires_at":"..."}` — **no token** |
| Re-exchange the same code | `401` |
| Unknown code | byte-identical `401 {"detail":"invalid or expired login code"}` |
| Stored values | two 64-char hashes, `consumed_at` set; `pg_dump` of the table contains **0** occurrences of either the plaintext code or the plaintext token, and the stored hash equals `sha256(code)` |
| Session cookie against `/agents` | `401` — this slice authorizes nothing |
| Platform key against `/agents` | `200` — unchanged |

Closes #1044
Ref #630
