### PR TITLE
Collect an optional note when an approval is approved or rejected

### DIFF
--- a/apps/dispatcher/src/curie_dispatcher/approval_actions.py
+++ b/apps/dispatcher/src/curie_dispatcher/approval_actions.py
@@ -18,6 +18,7 @@ because the worker already depends on this package for the queue seam; the
 card renderer imports them so the two sides cannot drift.
 """
 
+import json
 import logging
 from dataclasses import dataclass
 from typing import Any
@@ -35,13 +36,53 @@ logger = logging.getLogger(__name__)
 # be normalized into an ordinary turn).
 APPROVE_ACTION_ID = "curie-approval-approve"
 REJECT_ACTION_ID = "curie-approval-reject"
-_APPROVAL_ACTION_IDS = frozenset({APPROVE_ACTION_ID, REJECT_ACTION_ID})
+
+# The note-collecting variants (#1053). A card rendered from a ``ConfirmIntent``
+# with ``allow_free_text`` carries these instead, and a click on one opens a
+# dialog for an optional note before resolving. They are a SECOND action-id pair
+# rather than a flag inside the button ``value`` so the behavior is visible in
+# the interaction payload itself and so the renderer and the handler keep sharing
+# one set of literals -- the worker's ``blocks.approval_card`` imports these, the
+# same anti-drift arrangement the original pair already uses.
+APPROVE_NOTE_ACTION_ID = "curie-approval-approve-note"
+REJECT_NOTE_ACTION_ID = "curie-approval-reject-note"
+
+# The dialog's ``callback_id`` and the block/action ids of its one input. The
+# approval id, the card's channel and ts, and the decision ride in
+# ``private_metadata`` because a view submission carries no channel or message of
+# its own.
+NOTE_MODAL_CALLBACK_ID = "curie-approval-note"
+_NOTE_BLOCK_ID = "note"
+_NOTE_ACTION_ID = "note-input"
+
+_APPROVAL_ACTION_IDS = frozenset(
+    {
+        APPROVE_ACTION_ID,
+        REJECT_ACTION_ID,
+        APPROVE_NOTE_ACTION_ID,
+        REJECT_NOTE_ACTION_ID,
+    }
+)
+
+# Which decision each action id resolves to, so the two pairs cannot drift on it.
+_DECISION_BY_ACTION_ID = {
+    APPROVE_ACTION_ID: "approved",
+    APPROVE_NOTE_ACTION_ID: "approved",
+    REJECT_ACTION_ID: "rejected",
+    REJECT_NOTE_ACTION_ID: "rejected",
+}
 
 
 def is_approval_action(action_id: str) -> bool:
     """True when a Block Kit action id belongs to the approval card."""
 
     return action_id in _APPROVAL_ACTION_IDS
+
+
+def decision_for_action(action_id: str) -> str | None:
+    """The decision an approval action id resolves to, or None if it is not one."""
+
+    return _DECISION_BY_ACTION_ID.get(action_id)
 
 
 @dataclass(frozen=True)
@@ -71,15 +112,23 @@ class ApprovalResolveClient:
         decision: str,
         resolved_by: str,
         actor_channel: str,
+        note: str | None = None,
     ) -> ResolveOutcome:
+        body: dict[str, Any] = {
+            "decision": decision,
+            "resolved_by": resolved_by,
+            "actor_channel": actor_channel,
+        }
+        # Only send the key when the approver typed something. The field is
+        # optional on ``ApprovalResolve`` and an empty string is not the same
+        # statement as leaving the note blank: it would persist as a
+        # resolution_note the resume turn then interpolates as ``Note: .``.
+        if note:
+            body["note"] = note
         try:
             response = self._client.post(
                 f"{self._base}/approvals/{approval_id}/resolve",
-                json={
-                    "decision": decision,
-                    "resolved_by": resolved_by,
-                    "actor_channel": actor_channel,
-                },
+                json=body,
                 headers=self._headers,
             )
         except httpx.HTTPError as exc:
@@ -128,6 +177,317 @@ def _resolved_card_blocks(original: dict[str, Any], verdict: str) -> list[dict[s
     return blocks
 
 
+def _verdict_line(decision: str, user: str, note: str | None) -> str:
+    """The context line stamped onto a settled card.
+
+    The note is shown HERE as well as on the requester's thread: the approver
+    channel is where the next person looks to understand a decision, and a
+    reason that only reached the requester leaves that channel with a bare
+    verdict.
+    """
+
+    line = f"{decision.capitalize()} by <@{user}>"
+    return f"{line}\nNote: {note}" if note else line
+
+
+def build_note_modal(
+    *, approval_id: str, channel: str, card_ts: str, decision: str
+) -> dict[str, Any]:
+    """The dialog that collects an OPTIONAL note before resolving (#1053).
+
+    A view submission carries no channel and no message of its own, so
+    everything the submit handler needs to finish the job rides in
+    ``private_metadata``. The input block is ``optional``: the note is an
+    enrichment, and requiring one would turn a decision into a form.
+    """
+
+    verb = "Approve" if decision == "approved" else "Reject"
+    label = "Note (optional)" if decision == "approved" else "Reason (optional)"
+    return {
+        "type": "modal",
+        "callback_id": NOTE_MODAL_CALLBACK_ID,
+        "private_metadata": json.dumps(
+            {
+                "approval_id": approval_id,
+                "channel": channel,
+                "card_ts": card_ts,
+                "decision": decision,
+            }
+        ),
+        "title": {"type": "plain_text", "text": f"{verb} request"},
+        "submit": {"type": "plain_text", "text": verb},
+        "close": {"type": "plain_text", "text": "Cancel"},
+        "blocks": [
+            {
+                "type": "input",
+                "block_id": _NOTE_BLOCK_ID,
+                "optional": True,
+                "label": {"type": "plain_text", "text": label},
+                "element": {
+                    "type": "plain_text_input",
+                    "action_id": _NOTE_ACTION_ID,
+                    "multiline": True,
+                },
+            }
+        ],
+    }
+
+
+def open_note_dialog(
+    *,
+    body: dict[str, Any],
+    decision: str,
+    web_client: WebClient,
+    resolver: ApprovalResolveClient,
+    logger: logging.Logger | None = None,
+) -> ResolveOutcome | None:
+    """Open the note dialog for a click, or fall forward and resolve without one.
+
+    A ``trigger_id`` is valid for about three seconds, so ``views.open`` can
+    genuinely fail. When it does this resolves anyway, with no note, and says so
+    in an ephemeral. The human already expressed the decision by clicking;
+    refusing the click because an optional enrichment could not be collected
+    would be the worse failure, and it would leave the record pending with no
+    feedback.
+
+    Returns None on the normal path (nothing is resolved until the dialog is
+    submitted), or the fall-forward resolution's outcome.
+    """
+
+    log = logger or logging.getLogger(__name__)
+
+    actions = body.get("actions") or []
+    approval_id = str(actions[0].get("value") or "") if actions else ""
+    channel = (body.get("channel") or {}).get("id") or ""
+    user = (body.get("user") or {}).get("id") or ""
+    message = body.get("message") or {}
+    card_ts = message.get("ts") or ""
+    trigger_id = body.get("trigger_id") or ""
+    if not approval_id or not channel or not user or not card_ts:
+        log.info("approval action without id/channel/user/message, skipping")
+        return None
+
+    try:
+        web_client.views_open(
+            trigger_id=trigger_id,
+            view=build_note_modal(
+                approval_id=approval_id,
+                channel=channel,
+                card_ts=card_ts,
+                decision=decision,
+            ),
+        )
+        return None
+    except Exception as exc:  # noqa: BLE001 - the decision must still land
+        log.warning("note dialog failed to open for %s: %s", approval_id, exc)
+
+    outcome = _resolve_and_render(
+        approval_id=approval_id,
+        decision=decision,
+        user=user,
+        channel=channel,
+        card_ts=card_ts,
+        message=message,
+        note=None,
+        web_client=web_client,
+        resolver=resolver,
+        log=log,
+    )
+    if outcome.status_code == 200:
+        _ephemeral(
+            web_client,
+            channel=channel,
+            user=user,
+            text=(
+                "The note box could not be opened, so this was resolved without a "
+                "note. Add one with `curie <tier> approvals <agent> --resolve` if "
+                "it matters."
+            ),
+            log=log,
+        )
+    return outcome
+
+
+def process_note_submission(
+    *,
+    body: dict[str, Any],
+    web_client: WebClient,
+    resolver: ApprovalResolveClient,
+    logger: logging.Logger | None = None,
+) -> tuple[ResolveOutcome | None, dict[str, Any] | None]:
+    """Resolve from a submitted note dialog (#1053).
+
+    Returns ``(outcome, response_action)``. The second element is the body Bolt
+    must ack the view with: ``None`` closes the dialog, and an ``errors``
+    response keeps it open with the reason attached to the note field.
+
+    That second channel exists because the claim race widened. Resolution now
+    happens at submit rather than at click, so two approvers can hold open
+    dialogs at once. The compare-and-set still makes exactly one win, but the
+    loser is now standing inside a modal, where an ephemeral is invisible --
+    so every refusal is rendered INTO the view rather than posted behind it.
+    """
+
+    log = logger or logging.getLogger(__name__)
+
+    view = body.get("view") or {}
+    try:
+        meta = json.loads(view.get("private_metadata") or "{}")
+    except ValueError:
+        meta = {}
+    approval_id = str(meta.get("approval_id") or "")
+    channel = str(meta.get("channel") or "")
+    card_ts = str(meta.get("card_ts") or "")
+    decision = str(meta.get("decision") or "")
+    user = (body.get("user") or {}).get("id") or ""
+    if not approval_id or not channel or not user or decision not in ("approved", "rejected"):
+        log.info("note submission with unusable private_metadata, skipping")
+        return None, None
+
+    values = (view.get("state") or {}).get("values") or {}
+    note = ((values.get(_NOTE_BLOCK_ID) or {}).get(_NOTE_ACTION_ID) or {}).get("value")
+    note = (note or "").strip() or None
+
+    # The card's original blocks are not in a view_submission payload, so re-read
+    # the message the card lives on to stamp it in place. Best-effort: a failed
+    # read only costs the in-place edit, never the resolution.
+    message = _fetch_card_message(web_client, channel=channel, card_ts=card_ts, log=log)
+
+    outcome = _resolve_and_render(
+        approval_id=approval_id,
+        decision=decision,
+        user=user,
+        channel=channel,
+        card_ts=card_ts,
+        message=message,
+        note=note,
+        web_client=web_client,
+        resolver=resolver,
+        log=log,
+    )
+    if outcome.status_code == 200:
+        return outcome, None
+    return outcome, {
+        "response_action": "errors",
+        "errors": {_NOTE_BLOCK_ID: _refusal_text(outcome)},
+    }
+
+
+def _fetch_card_message(
+    web_client: WebClient, *, channel: str, card_ts: str, log: logging.Logger
+) -> dict[str, Any]:
+    """The approval card's message, or an empty dict when it cannot be read."""
+
+    try:
+        history = web_client.conversations_history(
+            channel=channel, latest=card_ts, oldest=card_ts, inclusive=True, limit=1
+        )
+        messages = history.get("messages") or []
+        if messages:
+            return dict(messages[0])
+    except Exception as exc:  # noqa: BLE001 - the stamp is best-effort
+        log.warning("could not read approval card %s in %s: %s", card_ts, channel, exc)
+    return {}
+
+
+def _refusal_text(outcome: ResolveOutcome) -> str:
+    """The one wording for a non-200 resolution, shared by both surfaces."""
+
+    if outcome.status_code == 403:
+        # The API already words each refusal class distinctly (non-membership,
+        # self-approval, could-not-verify), so render its reason verbatim rather
+        # than guessing the class. An empty detail stays class-neutral (#453 AC5).
+        return (
+            outcome.detail.strip()
+            or "This click was refused and the platform gave no reason."
+        )
+    if outcome.status_code == 409:
+        return (
+            f"Already resolved by {outcome.resolved_by}."
+            if outcome.resolved_by
+            else (outcome.detail or "This request was already resolved.")
+        )
+    if outcome.status_code == 410:
+        return "This approval expired and can no longer be resolved."
+    if outcome.status_code == 404:
+        return "This approval no longer exists."
+    return "Resolving failed; try again shortly."
+
+
+def _ephemeral(
+    web_client: WebClient, *, channel: str, user: str, text: str, log: logging.Logger
+) -> None:
+    try:
+        web_client.chat_postEphemeral(channel=channel, user=user, text=text)
+    except Exception as exc:  # noqa: BLE001 - the verdict stands regardless
+        log.warning("ephemeral notice failed in %s: %s", channel, exc)
+
+
+def _resolve_and_render(
+    *,
+    approval_id: str,
+    decision: str,
+    user: str,
+    channel: str,
+    card_ts: str,
+    message: dict[str, Any],
+    note: str | None,
+    web_client: WebClient,
+    resolver: ApprovalResolveClient,
+    log: logging.Logger,
+) -> ResolveOutcome:
+    """Resolve one approval and stamp the card, shared by both click paths.
+
+    The immediate-click path and the note-dialog path must agree on what a
+    settled card looks like and on when the ephemeral is skipped, so they share
+    this rather than each rendering their own.
+    """
+
+    outcome = resolver.resolve(
+        approval_id,
+        decision=decision,
+        resolved_by=user,
+        actor_channel=channel,
+        note=note,
+    )
+
+    if outcome.status_code == 200:
+        verdict = _verdict_line(outcome.decision or decision, user, note)
+        # Best-effort: the record is already resolved and the resume turn is
+        # enqueued; a failed card edit must not undo either.
+        try:
+            web_client.chat_update(
+                channel=channel,
+                ts=card_ts,
+                text=verdict,
+                blocks=_resolved_card_blocks(message, verdict),
+            )
+        except Exception as exc:  # noqa: BLE001 - render is best-effort
+            log.warning("approval card update failed for %s: %s", approval_id, exc)
+        log.info("approval %s %s by %s", approval_id, decision, user)
+        return outcome
+
+    if outcome.status_code == 409:
+        # Refresh a stale card so it stops offering buttons for a settled
+        # record (the winner's edit normally did this; a race can leave it).
+        _refresh_settled_card(
+            web_client,
+            channel=channel,
+            card_ts=card_ts,
+            message=message,
+            detail=_refusal_text(outcome),
+            log=log,
+        )
+    log.info(
+        "approval %s click by %s rejected: HTTP %s %s",
+        approval_id,
+        user,
+        outcome.status_code,
+        outcome.detail,
+    )
+    return outcome
+
+
 def process_approval_action(
     *,
     body: dict[str, Any],
@@ -136,7 +496,13 @@ def process_approval_action(
     resolver: ApprovalResolveClient,
     logger: logging.Logger | None = None,
 ) -> ResolveOutcome | None:
-    """Resolve one card click and render the verdict back into Slack.
+    """Resolve one card click immediately and render the verdict back into Slack.
+
+    The no-dialog path, for a card rendered without ``allow_free_text``. It shares
+    ``_resolve_and_render`` with the dialog path so the two cannot disagree about
+    what a settled card looks like; only the surface a refusal is rendered on
+    differs, and that difference is real: here nothing is open, so an ephemeral is
+    the right place for it.
 
     Returns the API outcome (for tests/logging), or None when the interaction
     payload is not a resolvable card click (missing value/channel/message).
@@ -154,66 +520,26 @@ def process_approval_action(
         log.info("approval action without id/channel/user/message, skipping")
         return None
 
-    outcome = resolver.resolve(
-        approval_id, decision=decision, resolved_by=user, actor_channel=channel
+    outcome = _resolve_and_render(
+        approval_id=approval_id,
+        decision=decision,
+        user=user,
+        channel=channel,
+        card_ts=card_ts,
+        message=message,
+        note=None,
+        web_client=web_client,
+        resolver=resolver,
+        log=log,
     )
-
-    if outcome.status_code == 200:
-        verdict = f"{(outcome.decision or decision).capitalize()} by <@{user}>"
-        # Best-effort: the record is already resolved and the resume turn is
-        # enqueued; a failed card edit must not undo either.
-        try:
-            web_client.chat_update(
-                channel=channel,
-                ts=card_ts,
-                text=verdict,
-                blocks=_resolved_card_blocks(message, verdict),
-            )
-        except Exception as exc:  # noqa: BLE001 - render is best-effort
-            log.warning("approval card update failed for %s: %s", approval_id, exc)
-        log.info("approval %s %s by %s", approval_id, decision, user)
-        return outcome
-
-    if outcome.status_code == 403:
-        # Render the API's reason verbatim: it already knows which class of
-        # refusal this is (non-membership, self-approval, or could-not-verify)
-        # and words each one distinctly. When the detail is empty or missing,
-        # the dispatcher cannot know the class, so the fallback must stay
-        # class-neutral rather than guessing at a policy denial (#453 AC5).
-        ephemeral = (
-            outcome.detail.strip()
-            or "This click was refused and the platform gave no reason."
+    if outcome.status_code != 200:
+        _ephemeral(
+            web_client,
+            channel=channel,
+            user=user,
+            text=_refusal_text(outcome),
+            log=log,
         )
-    elif outcome.status_code == 409:
-        ephemeral = (
-            f"Already resolved by {outcome.resolved_by}."
-            if outcome.resolved_by
-            else (outcome.detail or "This request was already resolved.")
-        )
-        # Refresh a stale card so it stops offering buttons for a settled
-        # record (the winner's edit normally did this; a race can leave it).
-        _refresh_settled_card(
-            web_client, channel=channel, card_ts=card_ts, message=message,
-            detail=ephemeral, log=log,
-        )
-    elif outcome.status_code == 410:
-        ephemeral = "This approval expired and can no longer be resolved."
-    elif outcome.status_code == 404:
-        ephemeral = "This approval no longer exists."
-    else:
-        ephemeral = "Resolving failed; try again shortly."
-
-    try:
-        web_client.chat_postEphemeral(channel=channel, user=user, text=ephemeral)
-    except Exception as exc:  # noqa: BLE001 - the verdict stands regardless
-        log.warning("ephemeral notice failed for %s: %s", approval_id, exc)
-    log.info(
-        "approval %s click by %s rejected: HTTP %s %s",
-        approval_id,
-        user,
-        outcome.status_code,
-        outcome.detail,
-    )
     return outcome
 
 

--- a/apps/dispatcher/src/curie_dispatcher/handlers.py
+++ b/apps/dispatcher/src/curie_dispatcher/handlers.py
@@ -28,11 +28,16 @@ from slack_sdk.web import WebClient
 
 from .approval_actions import (
     APPROVE_ACTION_ID,
+    APPROVE_NOTE_ACTION_ID,
+    NOTE_MODAL_CALLBACK_ID,
     REJECT_ACTION_ID,
+    REJECT_NOTE_ACTION_ID,
     ApprovalResolveClient,
     build_resolver,
     is_approval_action,
+    open_note_dialog,
     process_approval_action,
+    process_note_submission,
 )
 from .config import DispatcherConfig
 from .queue import claim_event, enqueue
@@ -270,6 +275,50 @@ def register_handlers(
             resolver=approval_resolver,
             logger=logger,
         )
+
+    # The note-collecting variants (#1053): a click OPENS a dialog and resolves
+    # nothing; the submission below does the resolving. A card carries this pair
+    # only when the kernel emitted its Confirm intent with `allow_free_text`, so
+    # the immediate pair above stays the behavior for every other card.
+    @app.action(APPROVE_NOTE_ACTION_ID)
+    def _on_approve_with_note(ack: Callable[..., None], body: dict[str, Any]) -> None:
+        ack()
+        open_note_dialog(
+            body=body,
+            decision="approved",
+            web_client=web_client,
+            resolver=approval_resolver,
+            logger=logger,
+        )
+
+    @app.action(REJECT_NOTE_ACTION_ID)
+    def _on_reject_with_note(ack: Callable[..., None], body: dict[str, Any]) -> None:
+        ack()
+        open_note_dialog(
+            body=body,
+            decision="rejected",
+            web_client=web_client,
+            resolver=approval_resolver,
+            logger=logger,
+        )
+
+    # The dialog's submit. Unlike an action ack, a view ack CARRIES the response:
+    # ack() closes the dialog, ack(response_action="errors", ...) keeps it open
+    # with the refusal attached to the note field. That is the only surface a
+    # loser of the claim race can actually see, since an ephemeral posts behind
+    # the open modal.
+    @app.view(NOTE_MODAL_CALLBACK_ID)
+    def _on_note_submitted(ack: Callable[..., Any], body: dict[str, Any]) -> None:
+        _outcome, response = process_note_submission(
+            body=body,
+            web_client=web_client,
+            resolver=approval_resolver,
+            logger=logger,
+        )
+        if response is None:
+            ack()
+        else:
+            ack(response_action=response["response_action"], errors=response["errors"])
 
     # Any other Block Kit button click (a reply's action) becomes a turn. The
     # catch-all matches every action_id (including the approval ids above --

--- a/apps/dispatcher/tests/conftest.py
+++ b/apps/dispatcher/tests/conftest.py
@@ -43,9 +43,21 @@ class FakeSocketClient:
     def __init__(self) -> None:
         self.logger = logging.getLogger("fake-socket")
         self.acked_envelope_ids: list[str] = []
+        # The ack BODY, not just the id (#1053). A block_actions ack is empty,
+        # but a view_submission ack is a channel in its own right: it is where a
+        # refused submission's reason is rendered, since the approver is standing
+        # in an open modal and an ephemeral would post behind it. A test cannot
+        # assert that from the envelope id alone.
+        self.ack_payloads: dict[str, Any] = {}
 
     def send_socket_mode_response(self, response: Any) -> None:
         self.acked_envelope_ids.append(response.envelope_id)
+        self.ack_payloads[response.envelope_id] = getattr(response, "payload", None)
+
+    def ack_payload_for(self, envelope_id: str) -> Any:
+        """The body this envelope was acked with, or None."""
+
+        return self.ack_payloads.get(envelope_id)
 
 # Compose defaults and connection params come from the shared curie_test_support.valkey helper.
 

--- a/apps/dispatcher/tests/test_approval_actions.py
+++ b/apps/dispatcher/tests/test_approval_actions.py
@@ -66,14 +66,24 @@ class ScriptedResolver:
         self.calls: list[dict[str, str]] = []
 
     def resolve(
-        self, approval_id: str, *, decision: str, resolved_by: str, actor_channel: str
+        self,
+        approval_id: str,
+        *,
+        decision: str,
+        resolved_by: str,
+        actor_channel: str,
+        note: str | None = None,
     ) -> ResolveOutcome:
+        # `note` is recorded, not ignored: the dialog path's whole point is that
+        # the approver's reason reaches the record, and a stand-in that dropped
+        # it would let that regress silently (#1053).
         self.calls.append(
             {
                 "approval_id": approval_id,
                 "decision": decision,
                 "resolved_by": resolved_by,
                 "actor_channel": actor_channel,
+                "note": note,
             }
         )
         return self.outcome
@@ -150,6 +160,9 @@ def test_authorized_click_resolves_and_stamps_the_card(
             "decision": "approved",
             "resolved_by": "U_MANAGER",
             "actor_channel": "C_MGRS",
+            # The immediate pair carries no note by construction; only the
+            # dialog pair can collect one (#1053).
+            "note": None,
         }
     ]
 

--- a/apps/dispatcher/tests/test_approval_note_dialog.py
+++ b/apps/dispatcher/tests/test_approval_note_dialog.py
@@ -1,0 +1,375 @@
+"""The optional-note dialog on an approval card (#1053).
+
+Same discipline as ``test_approval_actions.py``: driven through Bolt's real
+``SocketModeHandler``, with only the socket, the Web API client, and the
+platform API faked. What is asserted here is the behavior the plain click path
+cannot have:
+
+- a click on a note-carrying card OPENS a dialog and resolves nothing;
+- submitting it resolves WITH the typed note, so the reason reaches the record
+  (and from there the requester, since ``build_resume_turn`` interpolates it);
+- submitting it blank resolves with no note at all, rather than an empty string;
+- cancelling leaves the record pending, which is stricter than the old
+  click-is-the-decision behavior and must not regress;
+- and the widened claim race renders its refusal INSIDE the view, because the
+  loser is standing in an open modal where an ephemeral is invisible.
+"""
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import redis
+from curie_dispatcher.app import build_app
+from curie_dispatcher.approval_actions import (
+    APPROVE_NOTE_ACTION_ID,
+    NOTE_MODAL_CALLBACK_ID,
+    REJECT_NOTE_ACTION_ID,
+    ResolveOutcome,
+)
+from curie_dispatcher.config import DispatcherConfig
+from slack_bolt import App
+from slack_bolt.adapter.socket_mode import SocketModeHandler
+from slack_sdk.socket_mode.request import SocketModeRequest
+from slack_sdk.web import WebClient
+
+from .conftest import FakeSocketClient, _authorize
+
+APPROVAL_ID = "9a1e8a10-0000-0000-0000-000000001053"
+CARD_TS = "1700.0042"
+CARD_CHANNEL = "C_MGRS"
+
+_CARD_MESSAGE: dict[str, Any] = {
+    "ts": CARD_TS,
+    "blocks": [
+        {"type": "header", "text": {"type": "plain_text", "text": "Approval required"}},
+        {"type": "section", "text": {"type": "mrkdwn", "text": "Discount for ACME"}},
+        {"type": "actions", "elements": []},
+    ],
+}
+
+
+class ScriptedResolver:
+    """Stands in for the platform API, recording the note it was handed."""
+
+    def __init__(self, outcome: ResolveOutcome) -> None:
+        self.outcome = outcome
+        self.calls: list[dict[str, str | None]] = []
+
+    def resolve(
+        self,
+        approval_id: str,
+        *,
+        decision: str,
+        resolved_by: str,
+        actor_channel: str,
+        note: str | None = None,
+    ) -> ResolveOutcome:
+        self.calls.append(
+            {
+                "approval_id": approval_id,
+                "decision": decision,
+                "resolved_by": resolved_by,
+                "actor_channel": actor_channel,
+                "note": note,
+            }
+        )
+        return self.outcome
+
+
+def _build(
+    config: DispatcherConfig,
+    redis_client: redis.Redis,
+    resolver: ScriptedResolver,
+    *,
+    views_open_raises: bool = False,
+) -> tuple[App, WebClient]:
+    web_client = WebClient(token="xoxb-test")
+    web_client.chat_postMessage = MagicMock(return_value={"ts": "555.000"})  # type: ignore[method-assign]
+    web_client.chat_update = MagicMock(return_value={"ok": True})  # type: ignore[method-assign]
+    web_client.chat_postEphemeral = MagicMock(return_value={"ok": True})  # type: ignore[method-assign]
+    web_client.conversations_history = MagicMock(  # type: ignore[method-assign]
+        return_value={"messages": [_CARD_MESSAGE]}
+    )
+    web_client.views_open = MagicMock(  # type: ignore[method-assign]
+        side_effect=RuntimeError("trigger_id expired") if views_open_raises else None,
+        return_value={"ok": True},
+    )
+    app = build_app(
+        config,
+        web_client=web_client,
+        redis_client=redis_client,
+        authorize=_authorize,
+        resolver=resolver,
+    )
+    return app, web_client
+
+
+def _drain(app: App) -> None:
+    app.listener_runner.listener_executor.shutdown(wait=True)
+
+
+def _note_click(envelope_id: str, *, action_id: str, user: str = "U_MANAGER") -> SocketModeRequest:
+    return SocketModeRequest(
+        type="interactive",
+        envelope_id=envelope_id,
+        payload={
+            "type": "block_actions",
+            "trigger_id": f"trig-{envelope_id}",
+            "team": {"id": "T1"},
+            "user": {"id": user},
+            "api_app_id": "A1",
+            "token": "verif",
+            "container": {"type": "message", "message_ts": CARD_TS},
+            "channel": {"id": CARD_CHANNEL},
+            "message": _CARD_MESSAGE,
+            "actions": [
+                {
+                    "type": "button",
+                    "action_id": action_id,
+                    "action_ts": "2.0",
+                    "value": APPROVAL_ID,
+                }
+            ],
+        },
+    )
+
+
+def _note_submit(
+    envelope_id: str,
+    *,
+    note: str | None,
+    decision: str = "approved",
+    user: str = "U_MANAGER",
+) -> SocketModeRequest:
+    """A view_submission for the note dialog, carrying the same
+    ``private_metadata`` the open path writes."""
+
+    import json
+
+    state_value: dict[str, Any] = {}
+    if note is not None:
+        state_value = {"note": {"note-input": {"type": "plain_text_input", "value": note}}}
+    return SocketModeRequest(
+        type="interactive",
+        envelope_id=envelope_id,
+        payload={
+            "type": "view_submission",
+            "team": {"id": "T1"},
+            "user": {"id": user},
+            "api_app_id": "A1",
+            "token": "verif",
+            "trigger_id": f"trig-{envelope_id}",
+            "view": {
+                "id": "V1",
+                "type": "modal",
+                "callback_id": NOTE_MODAL_CALLBACK_ID,
+                "private_metadata": json.dumps(
+                    {
+                        "approval_id": APPROVAL_ID,
+                        "channel": CARD_CHANNEL,
+                        "card_ts": CARD_TS,
+                        "decision": decision,
+                    }
+                ),
+                "state": {"values": state_value},
+                "title": {"type": "plain_text", "text": "Approve request"},
+                "blocks": [],
+            },
+        },
+    )
+
+
+def test_a_note_click_opens_a_dialog_and_resolves_nothing(
+    redis_client: redis.Redis, config: DispatcherConfig
+) -> None:
+    resolver = ScriptedResolver(ResolveOutcome(status_code=200, resolved_by="U_MANAGER"))
+    app, web_client = _build(config, redis_client, resolver)
+    handler = SocketModeHandler(app, app_token="xapp-test")
+    sock = FakeSocketClient()
+
+    handler.handle(sock, _note_click("env-n1", action_id=APPROVE_NOTE_ACTION_ID))
+    assert sock.acked_envelope_ids == ["env-n1"]
+    _drain(app)
+
+    # The decision is NOT made on the click: the whole point of the dialog is
+    # that the approver can still cancel.
+    assert resolver.calls == []
+    web_client.views_open.assert_called_once()
+    view = web_client.views_open.call_args.kwargs["view"]
+    assert view["callback_id"] == NOTE_MODAL_CALLBACK_ID
+    # The note field is optional: a decision must never be blocked on typing one.
+    assert view["blocks"][0]["optional"] is True
+    # Everything the submit handler needs rides in private_metadata, since a
+    # view_submission payload carries no channel and no message of its own.
+    import json
+
+    meta = json.loads(view["private_metadata"])
+    assert meta == {
+        "approval_id": APPROVAL_ID,
+        "channel": CARD_CHANNEL,
+        "card_ts": CARD_TS,
+        "decision": "approved",
+    }
+
+
+def test_submitting_the_dialog_resolves_with_the_typed_note(
+    redis_client: redis.Redis, config: DispatcherConfig
+) -> None:
+    resolver = ScriptedResolver(
+        ResolveOutcome(status_code=200, resolved_by="U_MANAGER", decision="approved")
+    )
+    app, web_client = _build(config, redis_client, resolver)
+    handler = SocketModeHandler(app, app_token="xapp-test")
+    sock = FakeSocketClient()
+
+    handler.handle(sock, _note_submit("env-n2", note="  approved for Q3  "))
+    _drain(app)
+
+    assert resolver.calls == [
+        {
+            "approval_id": APPROVAL_ID,
+            "decision": "approved",
+            "resolved_by": "U_MANAGER",
+            "actor_channel": CARD_CHANNEL,
+            "note": "approved for Q3",
+        }
+    ]
+    # The note is stamped onto the card too: the approver channel is where the
+    # next person looks, and a reason that only reached the requester leaves
+    # that channel with a bare verdict.
+    web_client.chat_update.assert_called_once()
+    kwargs = web_client.chat_update.call_args.kwargs
+    assert kwargs["channel"] == CARD_CHANNEL and kwargs["ts"] == CARD_TS
+    assert "approved for Q3" in kwargs["text"]
+    assert not any(b.get("type") == "actions" for b in kwargs["blocks"])
+
+
+def test_a_blank_note_resolves_with_no_note_at_all(
+    redis_client: redis.Redis, config: DispatcherConfig
+) -> None:
+    # An empty string is not the same statement as leaving it blank: it would
+    # persist as a resolution_note the resume turn interpolates as "Note: .".
+    resolver = ScriptedResolver(ResolveOutcome(status_code=200, resolved_by="U_MANAGER"))
+    app, _ = _build(config, redis_client, resolver)
+    handler = SocketModeHandler(app, app_token="xapp-test")
+
+    handler.handle(FakeSocketClient(), _note_submit("env-n3", note="   "))
+    _drain(app)
+
+    assert len(resolver.calls) == 1
+    assert resolver.calls[0]["note"] is None
+
+
+def test_a_reject_dialog_carries_the_rejected_decision(
+    redis_client: redis.Redis, config: DispatcherConfig
+) -> None:
+    resolver = ScriptedResolver(ResolveOutcome(status_code=200, resolved_by="U_MANAGER"))
+    app, web_client = _build(config, redis_client, resolver)
+    handler = SocketModeHandler(app, app_token="xapp-test")
+
+    handler.handle(FakeSocketClient(), _note_click("env-n4", action_id=REJECT_NOTE_ACTION_ID))
+    _drain(app)
+
+    import json
+
+    meta = json.loads(web_client.views_open.call_args.kwargs["view"]["private_metadata"])
+    assert meta["decision"] == "rejected"
+
+
+def test_cancelling_the_dialog_leaves_the_record_pending(
+    redis_client: redis.Redis, config: DispatcherConfig
+) -> None:
+    """A cancel produces no view_submission at all, so nothing resolves.
+
+    Driven as the real sequence -- open the dialog, then deliver nothing -- which
+    is exactly what Slack sends when the approver hits Cancel. This is stricter
+    than the pre-#1053 behavior (a click WAS the decision) and the strictness is
+    the point, so it gets its own guard.
+    """
+
+    resolver = ScriptedResolver(ResolveOutcome(status_code=200, resolved_by="U_MANAGER"))
+    app, web_client = _build(config, redis_client, resolver)
+    handler = SocketModeHandler(app, app_token="xapp-test")
+
+    handler.handle(FakeSocketClient(), _note_click("env-n5", action_id=APPROVE_NOTE_ACTION_ID))
+    _drain(app)
+
+    web_client.views_open.assert_called_once()
+    assert resolver.calls == []
+    web_client.chat_update.assert_not_called()
+
+
+def test_a_claim_race_loser_is_told_inside_the_view(
+    redis_client: redis.Redis, config: DispatcherConfig
+) -> None:
+    """The regression this change could most easily introduce.
+
+    Resolution now happens at submit rather than at click, so two approvers can
+    hold open dialogs. The compare-and-set still makes one win; the loser is
+    inside a modal, where a chat.postEphemeral posts BEHIND the open view and is
+    never seen. The refusal must therefore come back as the view's own ack.
+    """
+
+    resolver = ScriptedResolver(
+        ResolveOutcome(status_code=409, resolved_by="U_FIRST", detail="already resolved")
+    )
+    app, web_client = _build(config, redis_client, resolver)
+    handler = SocketModeHandler(app, app_token="xapp-test")
+    sock = FakeSocketClient()
+
+    handler.handle(sock, _note_submit("env-n6", note="mine"))
+    _drain(app)
+
+    payload = sock.ack_payload_for("env-n6")
+    assert payload is not None, "a refused submission must ack with a response_action"
+    assert payload.get("response_action") == "errors"
+    assert "U_FIRST" in next(iter(payload["errors"].values()))
+    # And it must NOT fall back to the invisible surface.
+    web_client.chat_postEphemeral.assert_not_called()
+
+
+def test_a_refused_submission_does_not_stamp_the_card(
+    redis_client: redis.Redis, config: DispatcherConfig
+) -> None:
+    resolver = ScriptedResolver(
+        ResolveOutcome(status_code=403, detail="self-approval is blocked")
+    )
+    app, web_client = _build(config, redis_client, resolver)
+    handler = SocketModeHandler(app, app_token="xapp-test")
+    sock = FakeSocketClient()
+
+    handler.handle(sock, _note_submit("env-n7", note="please"))
+    _drain(app)
+
+    web_client.chat_update.assert_not_called()
+    payload = sock.ack_payload_for("env-n7")
+    assert payload is not None
+    assert "self-approval is blocked" in next(iter(payload["errors"].values()))
+
+
+def test_a_failed_views_open_falls_forward_and_resolves(
+    redis_client: redis.Redis, config: DispatcherConfig
+) -> None:
+    """A trigger_id is valid for ~3s, so views.open can genuinely fail.
+
+    The human already expressed the decision by clicking; refusing it because an
+    OPTIONAL enrichment could not be collected would leave the record pending
+    with no feedback, which is worse than losing the note. So it resolves, and
+    says so.
+    """
+
+    resolver = ScriptedResolver(
+        ResolveOutcome(status_code=200, resolved_by="U_MANAGER", decision="approved")
+    )
+    app, web_client = _build(config, redis_client, resolver, views_open_raises=True)
+    handler = SocketModeHandler(app, app_token="xapp-test")
+
+    handler.handle(FakeSocketClient(), _note_click("env-n8", action_id=APPROVE_NOTE_ACTION_ID))
+    _drain(app)
+
+    assert len(resolver.calls) == 1
+    assert resolver.calls[0]["note"] is None
+    web_client.chat_update.assert_called_once()
+    # Nothing here is silent: the approver is told the note step was skipped.
+    web_client.chat_postEphemeral.assert_called_once()
+    assert "note" in web_client.chat_postEphemeral.call_args.kwargs["text"].lower()

--- a/apps/worker/src/curie_worker/blocks.py
+++ b/apps/worker/src/curie_worker/blocks.py
@@ -313,7 +313,11 @@ _APPROVAL_SUMMARY_MAX = 2900
 
 
 def approval_card(
-    *, approval_id: str, summary: str, requested_by: str
+    *,
+    approval_id: str,
+    summary: str,
+    requested_by: str,
+    allow_free_text: bool = False,
 ) -> tuple[str, list[dict[str, Any]]]:
     """The Block Kit approval card: what needs approval plus Approve/Reject.
 
@@ -321,14 +325,27 @@ def approval_card(
     (``curie_dispatcher.approval_actions``); each button's ``value`` carries
     the durable record id, so a click resolves exactly this approval. Returns
     ``(fallback_text, blocks)`` for ``chat.postMessage``.
+
+    ``allow_free_text`` is the ``ConfirmIntent`` field of the same name (ADR-0020),
+    rendered HERE because that is where a semantic intent becomes a widget: Slack
+    expresses "this decision may carry free text" as a dialog opened by the click,
+    so the card carries the note-collecting action ids instead of the immediate
+    ones. The terminal renderer expresses the same field as a typed reply
+    (``cli/src/channel.rs``); until now the Slack side ignored it, which left one
+    renderer honoring the field and its twin dropping it.
     """
 
     # Imported here (not module top) to keep the module importable in isolation;
     # the worker package already depends on the dispatcher for the queue seam.
     from curie_dispatcher.approval_actions import (
         APPROVE_ACTION_ID,
+        APPROVE_NOTE_ACTION_ID,
         REJECT_ACTION_ID,
+        REJECT_NOTE_ACTION_ID,
     )
+
+    approve_action = APPROVE_NOTE_ACTION_ID if allow_free_text else APPROVE_ACTION_ID
+    reject_action = REJECT_NOTE_ACTION_ID if allow_free_text else REJECT_ACTION_ID
 
     clamped = _truncate(to_mrkdwn(summary), _APPROVAL_SUMMARY_MAX)
     fallback = _truncate(f"Approval required: {summary}", _SLACK_TEXT_MAX)
@@ -349,13 +366,13 @@ def approval_card(
                 {
                     **_button_shell("Approve"),
                     "style": "primary",
-                    "action_id": _truncate(APPROVE_ACTION_ID, _ACTION_ID_MAX),
+                    "action_id": _truncate(approve_action, _ACTION_ID_MAX),
                     "value": approval_id,
                 },
                 {
                     **_button_shell("Reject"),
                     "style": "danger",
-                    "action_id": _truncate(REJECT_ACTION_ID, _ACTION_ID_MAX),
+                    "action_id": _truncate(reject_action, _ACTION_ID_MAX),
                     "value": approval_id,
                 },
             ],

--- a/apps/worker/src/curie_worker/kernel.py
+++ b/apps/worker/src/curie_worker/kernel.py
@@ -1078,6 +1078,16 @@ class Kernel:
                     prompt=summary,
                     confirm=Action(label="Approve", value=created.id),
                     cancel=Action(label="Reject", value=created.id),
+                    # An approval decision may carry a reason (#1053). This says
+                    # only that, semantically; each adapter decides how to
+                    # collect it (ADR-0020: the interaction is the port, the
+                    # widget is the adapter). Slack renders a dialog on the
+                    # click, the terminal renderer a typed reply. The note is
+                    # optional in every rendering, and the note the approver
+                    # leaves already reaches the requester -- the API stores it
+                    # on the record and build_resume_turn interpolates it into
+                    # the platform-authored resume text.
+                    allow_free_text=True,
                 ),
             )
             card_ts = await self._sink.post(

--- a/apps/worker/src/curie_worker/slack_sink.py
+++ b/apps/worker/src/curie_worker/slack_sink.py
@@ -291,7 +291,13 @@ class AsyncSlackSink:
         intent = message.interaction
         if isinstance(intent, ConfirmIntent):
             text, blocks = approval_card(
-                approval_id=intent.id, summary=message.text, requested_by=requested_by
+                approval_id=intent.id,
+                summary=message.text,
+                requested_by=requested_by,
+                # ADR-0020's semantic field, rendered by this adapter into the
+                # note-dialog buttons (#1053). Reading it here rather than in the
+                # kernel keeps the widget decision below the seam.
+                allow_free_text=intent.allow_free_text,
             )
         else:
             text, blocks = message.text, None

--- a/apps/worker/tests/kernel/test_approval_lifecycle.py
+++ b/apps/worker/tests/kernel/test_approval_lifecycle.py
@@ -409,6 +409,11 @@ def test_pause_emits_a_confirm_intent_for_the_approval_card(make_harness) -> Non
             assert intent.confirm.value == "appr-1"
             assert intent.cancel.value == "appr-1"
             assert (intent.confirm.label, intent.cancel.label) == ("Approve", "Reject")
+            # #1053: the decision may carry a reason. Asserted at the KERNEL,
+            # not only at the renderer, because this is the field that decides
+            # whether the real product path offers a note at all -- a renderer
+            # test alone would stay green with the kernel emitting the default.
+            assert intent.allow_free_text is True
 
     asyncio.run(go())
 

--- a/apps/worker/tests/test_blocks.py
+++ b/apps/worker/tests/test_blocks.py
@@ -449,6 +449,52 @@ def test_approval_card_shape_and_click_contract() -> None:
     assert reject["style"] == "danger"
 
 
+def test_approval_card_renders_allow_free_text_as_the_note_buttons() -> None:
+    """ADR-0020's semantic field, rendered by this adapter (#1053).
+
+    `allow_free_text` says only "this decision may carry free text"; Slack
+    expresses that as a dialog opened by the click, so the card swaps in the
+    note-collecting action ids. Everything else about the card is unchanged --
+    the note is an enrichment, not a different card.
+    """
+
+    from curie_dispatcher.approval_actions import (
+        APPROVE_ACTION_ID,
+        APPROVE_NOTE_ACTION_ID,
+        REJECT_ACTION_ID,
+        REJECT_NOTE_ACTION_ID,
+    )
+    from curie_worker.blocks import approval_card
+
+    _, plain = approval_card(
+        approval_id="appr-1", summary="Give ACME a 20% discount", requested_by="U_AE"
+    )
+    _, with_note = approval_card(
+        approval_id="appr-1",
+        summary="Give ACME a 20% discount",
+        requested_by="U_AE",
+        allow_free_text=True,
+    )
+
+    plain_approve, plain_reject = plain[-1]["elements"]
+    note_approve, note_reject = with_note[-1]["elements"]
+    assert plain_approve["action_id"] == APPROVE_ACTION_ID
+    assert plain_reject["action_id"] == REJECT_ACTION_ID
+    assert note_approve["action_id"] == APPROVE_NOTE_ACTION_ID
+    assert note_reject["action_id"] == REJECT_NOTE_ACTION_ID
+
+    # Only the action ids differ: same record id, same styles, same body blocks.
+    assert note_approve["value"] == note_reject["value"] == "appr-1"
+    assert note_approve["style"] == "primary" and note_reject["style"] == "danger"
+    assert plain[:-1] == with_note[:-1]
+
+    # The CLI's Slack stub detects a posted card by matching the shared prefix
+    # of both Approve ids (cli/src/chat.rs APPROVE_ACTION_ID_PREFIX). Pin that
+    # relationship here: a rename that broke it would blind `local message` to
+    # awaiting-approval turns, and nothing else would fail.
+    assert APPROVE_NOTE_ACTION_ID.startswith(APPROVE_ACTION_ID)
+
+
 def test_approval_card_clamps_oversized_summary() -> None:
     from curie_worker.blocks import approval_card
 

--- a/cli/src/chat.rs
+++ b/cli/src/chat.rs
@@ -87,11 +87,19 @@ fn capped(budget: Duration, deadline: Instant) -> Duration {
     budget.min(deadline.saturating_duration_since(Instant::now()))
 }
 
-/// The Block Kit action id on the approval card's Approve button
-/// (`curie_dispatcher.approval_actions.APPROVE_ACTION_ID`). Its presence in a
-/// captured Slack call body is the unambiguous signal that a turn parked
-/// awaiting approval and posted a card (#529).
-pub const APPROVE_ACTION_ID: &str = "curie-approval-approve";
+/// The shared prefix of every approval-card Approve action id
+/// (`curie_dispatcher.approval_actions`). Its presence in a captured Slack call
+/// body is the unambiguous signal that a turn parked awaiting approval and
+/// posted a card (#529).
+///
+/// A PREFIX, deliberately, not one id: the card renders either
+/// `curie-approval-approve` (resolve on click) or `curie-approval-approve-note`
+/// (open a note dialog first, #1053), and this stub only needs to know a card
+/// was posted, not which variant. Matching the prefix covers both by
+/// construction. Anything that renames the ids must keep them sharing it, or
+/// this detection silently goes blind and `local message` stops reporting an
+/// awaiting-approval turn.
+pub const APPROVE_ACTION_ID_PREFIX: &str = "curie-approval-approve";
 
 /// One captured Slack Web API call at the stub.
 #[derive(Debug, Clone)]
@@ -236,7 +244,7 @@ async fn handle_call(
     // The approval card's Approve button carries this action id in the blocks,
     // which `extract_fields` does not parse -- match it on the raw body so an
     // awaiting-approval turn is detectable regardless of encoding (#529).
-    let approval_card = body.contains(APPROVE_ACTION_ID);
+    let approval_card = body.contains(APPROVE_ACTION_ID_PREFIX);
     // chat.update echoes the existing ts; a hypothetical new-message call has no
     // ts, so synthesize one so the response still looks like Slack.
     let ts_out = ts
@@ -274,7 +282,7 @@ pub enum Outcome {
 ///
 /// The turn counts as awaiting approval on EITHER of two signals:
 ///
-/// 1. An approval card was seen at this stub (the `APPROVE_ACTION_ID` in a
+/// 1. An approval card was seen at this stub (the `APPROVE_ACTION_ID_PREFIX` in a
 ///    captured call). Fastest and unambiguous, but not always present.
 /// 2. The latest placeholder text carries an authoritative trailing approval
 ///    notice ([`parse_approval_id`] validates the id as a UUID).

--- a/cli/src/guide.rs
+++ b/cli/src/guide.rs
@@ -233,9 +233,12 @@ pub fn primer() -> Primer {
                     title: "Declaring a route, then binding it",
                     detail: "A bundle declares routes in .claude-plugin/plugin.json under \
                              approvalPolicy.gates[], each entry {gate: <tool name>, route: \
-                             <route name>}. An operator then binds each route per agent as \
-                             approval_routes[<route>] = {channel, approvers}. `channel` is \
-                             WHERE the card posts; `approvers` is WHO may act on it.",
+                             <route name>}. An operator then binds each route per agent with \
+                             `approvals <AGENT> --route <name>=<channel>` (and optionally \
+                             `--route-approvers <name>=users:U1,U2` or `<name>=group:S1`). \
+                             `channel` is WHERE the card posts; `approvers` is WHO may act \
+                             on it. A write REPLACES the whole route map, so name every \
+                             route it should keep.",
                 },
                 ApprovalFact {
                     title: "Who may resolve is independent of where the card is",
@@ -246,6 +249,14 @@ pub fn primer() -> Primer {
                              room everyone reads while a narrow set decides. Every check runs \
                              server-side: the buttons are visible to all, and a refused click \
                              gets a private reason.",
+                },
+                ApprovalFact {
+                    title: "A decision can carry a reason",
+                    detail: "Approve and Reject open a short dialog for an OPTIONAL note \
+                             before the decision lands; cancelling it resolves nothing. A \
+                             note that is left reaches the requester on its own -- the API \
+                             stores it and the resume turn below interpolates it -- so a \
+                             skill does not collect or forward one itself.",
                 },
                 ApprovalFact {
                     title: "The resume turn is yours to handle",

--- a/docs/approvals.md
+++ b/docs/approvals.md
@@ -93,9 +93,19 @@ posted to the requesting channel. Silently widening a request to whoever happens
 in the requesting channel is exactly the failure the gate exists to prevent, so the
 platform refuses rather than guesses.
 
-> There is no `curie` flag for writing this binding yet; it is a `PATCH /agents/{id}`
-> today. Adding the verb is tracked in
-> [#1052](https://github.com/curie-eng/curie/issues/1052).
+Bind one from the CLI rather than by hand. A write REPLACES the whole map, so name
+every route it should keep:
+
+```bash
+curie local approvals my-agent --route finance=C0BBG383GLF \
+  --route-approvers finance=group:S0123ABCD
+
+curie local approvals my-agent --list-routes
+```
+
+`--route-approvers` also takes `users:U0123ABCD,W0456DEFG`, `--routes-from <file>` reads
+the whole map as JSON, and `--clear-routes` removes every binding. Nothing is written
+unless every entry parses, so a typo cannot leave a half-written map behind.
 
 ## Who may resolve
 
@@ -112,6 +122,12 @@ precedence is fixed: `users` beats `group` beats channel membership.
 Because `users` and `group` ignore the click channel entirely, a card can sit in a room
 everyone can read while only a narrow set may act. That unfusing of *where* from *who*
 is the whole subject of ADR-0034.
+
+Clicking Approve or Reject opens a short dialog for an **optional** note before the
+decision lands. Leave it blank and the decision is recorded with no note; type a reason
+and it is stored on the record, stamped onto the card in the approver channel, and
+carried to the requester in the resume turn below. Cancelling the dialog resolves
+nothing, so a misclick is recoverable.
 
 Three properties worth knowing before you design around this:
 

--- a/docs/interfaces/channel-interaction/INTERFACE.md
+++ b/docs/interfaces/channel-interaction/INTERFACE.md
@@ -114,10 +114,19 @@ back into the contract:
    `apps/worker/src/curie_worker/slack_sink.py::AsyncSlackSink.post` (its
    settled/expired form via
    `apps/worker/src/curie_worker/blocks.py::expired_approval_card`), so no Block
-   Kit is built above the seam.
+   Kit is built above the seam. `allow_free_text` on that intent is rendered here
+   too: Slack expresses "this decision may carry free text" as a dialog opened by
+   the click, so the card carries the note-collecting action ids and the
+   dispatcher's `apps/dispatcher/src/curie_dispatcher/approval_actions.py::open_note_dialog`
+   opens the view.
 2. **Terminal (TUI selector)** — `cli/src/channel.rs`. It parses the same fence
    (`REPLY_FENCE`) into a `TerminalMessage` of plain lines plus actions, which the
-   TUI renders as a numbered selector per the TUI behavior above.
+   TUI renders as a numbered selector per the TUI behavior above. It expresses
+   `allow_free_text` as a typed reply alongside the numbered actions.
+
+Both renderers now honor `allow_free_text`; until #1053 the terminal one did and
+the Slack one silently dropped it, which is the sibling-path drift this catalog
+exists to make visible.
 
 The split is the point: Block Kit lives only in `blocks.py`, the numbered selector
 only in `channel.rs`, and the agent authors neither.


### PR DESCRIPTION
Closes #1053.

## What this fixes

An approver who clicked **Reject** could not say why. The requester received a bare verdict and had to guess what to change. For a deal-approval or spend-approval flow that is the missing half of the decision.

## Why it is small

Almost all of it already existed and only the Slack interaction layer dropped the note:

- `ApprovalResolve.note` and the `approvals.resolution_note` column: present.
- `curie <tier> approvals --resolve --note`: works today.
- `resumequeue.build_resume_turn` **already interpolates** the note into the platform-authored resume turn, so a note that reaches the record reaches the requester with no further work.

The field to hang the UI on existed too. `ConfirmIntent.allow_free_text` is ADR-0020's semantic for *this decision may carry free text*; the terminal renderer (`cli/src/channel.rs`) already honored it and the Slack renderer silently dropped it. So this closes a **renderer asymmetry on a two-implementation seam**, which `AGENTS.md` names as the dominant historical bug class here, rather than adding a feature.

## The change

| Layer | Change |
|---|---|
| `kernel.py` | Sets `allow_free_text=True` on the approval `Confirm` intent. One field; the widget decision stays below the seam. |
| `blocks.py` / `slack_sink.py` | Renders it as a **second action-id pair** so a click opens a dialog instead of resolving. |
| `approval_actions.py` | `open_note_dialog` (views.open) and `process_note_submission` (resolve with the note); both click paths now share one `_resolve_and_render`. |
| `handlers.py` | Two new `@app.action` listeners and the first `@app.view` listener in the dispatcher. |

A second action-id pair rather than a flag inside the button `value`: the behavior is then visible in the interaction payload itself, and the renderer and handler keep sharing one set of literals (`blocks.approval_card` imports them from the dispatcher, the anti-drift arrangement the original pair already uses).

## Three behaviors worth reviewing, each with a test

**Cancelling resolves nothing.** Stricter than the old click-is-the-decision behavior, and the strictness is the point (a misclick is now recoverable), so it is guarded rather than assumed.

**The claim race widened.** Resolution happens at submit, so two approvers can hold open dialogs. The compare-and-set still makes exactly one winner — but the loser is now standing in a modal, where `chat.postEphemeral` posts *behind* the open view and is never seen. Every refusal is therefore rendered **into** the view as the ack's `response_action: "errors"`. This is the regression this change could most easily have introduced, and `test_a_claim_race_loser_is_told_inside_the_view` also asserts the ephemeral fallback is **not** used.

**A failed `views.open` falls forward.** A `trigger_id` lasts about three seconds. If the dialog cannot open, the decision still resolves (without a note) and an ephemeral says so. The human already expressed the decision by clicking; refusing it because an *optional* enrichment could not be collected would leave the record pending with no feedback.

## Notes for review

- **Sacred module.** `kernel.py` is touched, deliberately and minimally — one field on the intent it already emits, which is the core of this change rather than scope creep. Flagging it for the adversarial review `apps/worker/CLAUDE.md` requires.
- **No contract change.** `channel-protocol` is not one of the two frozen packages and `allow_free_text` already existed, so no model edit, no schema regeneration, no `PROTOCOL_VERSION` bump.
- **Always-on for approvals**, which costs one extra click for an approver who does not want to leave a note. That matches the flow this replicates and keeps the note discoverable; `allow_free_text` is the single field to flip if it ever needs to be per-agent.
- **A latent trap made deliberate.** `cli/src/chat.rs` detected a posted approval card with `body.contains("curie-approval-approve")`. That kept working only because the new id happens to *extend* the old one. Renamed to `APPROVE_ACTION_ID_PREFIX`, documented as a prefix on purpose, and pinned by an assertion in `test_blocks.py` — a rename that broke the shared prefix would otherwise blind `local message` to awaiting-approval turns with nothing else failing.
- **A hidden hole in the existing suite.** `ScriptedResolver` in `test_approval_actions.py` did not accept `note`, so every test there raised `TypeError` once the dispatcher started passing it. They did not catch it because **9 of the 10 were silently skipping** with no Valkey running. With the dev-stack Valkey up they failed, then passed after the stand-in was corrected to mirror the real client. The stand-in now records the note so the dialog path's whole point cannot regress silently.
- **The follow-up owed from #1057** rides along: `docs/approvals.md` said binding a route "is a `PATCH /agents/{id}` today", which #1052 made false. It now documents `--route` / `--route-approvers` / `--routes-from` / `--list-routes` / `--clear-routes`. The seam catalog and the `curie guide` primer are updated too (primer: 142 lines, inside the 60-160 bound its drift test pins).

## Deferred out of this PR

Issue #1053's fifth bullet asked to also stamp the card when an approval is resolved **through the API** rather than a click. It is not here, and I would rather name why than half-do it: the worker's resume path pops the card ref but has no way to know whether the dispatcher already stamped it, and the two sides render a settled card from different inputs (the dispatcher from the click payload's original blocks, the worker from a remembered summary). Making them converge is a real design decision about a shared settled-card renderer, and it touches the resume path in the sacred kernel. Filing it separately keeps this PR to the note dialog. Happy to open that issue on request, or to fold it in if you would rather it ship together.

## Verification

Run with the dev-stack Valkey **and** Postgres up (the dispatcher approval suite and the worker binding suite both skip or fail without them):

```
uv run ruff check .                          All checks passed
uv run mypy                                  no issues in 163 source files
uv run pytest apps/dispatcher apps/worker    637 passed, 11 skipped
uv run pytest packages runner                804 passed, 1 skipped, 1 failed (see below)
cargo fmt --check                            OK
cargo clippy --all-targets -- -D warnings    OK
cargo test                                   36 binaries, 893 tests, 0 failures
curie dev docs-lint                          OK
```

New coverage: `apps/dispatcher/tests/test_approval_note_dialog.py` (8 tests) plus a renderer test in `test_blocks.py` and a kernel-level assertion in `test_approval_lifecycle.py`. The kernel assertion matters on its own: a renderer test alone stays green with the kernel emitting the default, so the field that decides whether the real product path offers a note at all is pinned where it is set.

One pre-existing failure, unrelated: `runner/tests/test_live.py::test_live_permission_gate_pauses_awaiting_approval`. It fails **identically on a clean tree** here (verified by stashing this branch's changes), and only runs at all because this machine has a model credential in the environment — CI skips it. Not touched by this change, which does not go near the runner.

Not verified: a hands-on pass against a real Slack workspace. `views.open`, the `view_submission` round trip, and the in-view error rendering are driven through Bolt's real `SocketModeHandler` with the Web API faked, which is the same discipline the existing approval suite uses, but it is not the same as clicking the button. Worth a live click before merge if you have the workspace handy.
