### PR TITLE
Send an empty approval-route map as {} so --clear-routes actually clears

### DIFF
--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -815,24 +815,22 @@ impl ApiClient {
     /// `approval_routes`. Like `set_approval_tools` this is a FULL REPLACEMENT of
     /// the map, not a merge, matching the field's semantics on `AgentUpdate`.
     ///
-    /// An empty map is sent as JSON `null`, which is how the API spells "no
-    /// bindings" (`crud.update_agent_approval_routes` stores `routes or None`).
-    /// Sending `{}` would be a second spelling of the same state.
+    /// An empty map is sent as `{}`, not JSON `null` (#1071). The router clears the
+    /// bindings only behind `if data.approval_routes is not None` (#247), and
+    /// Pydantic decodes an explicit `null` and an omitted key to the same `None`, so
+    /// `null` reads as "field omitted" and the bindings survive. Only `{}` passes
+    /// that guard. `crud.update_agent_approval_routes` storing `routes or None` is
+    /// the STORAGE normalization applied after the guard, not the wire spelling.
     pub async fn set_approval_routes(
         &self,
         agent_id: &str,
         routes: &std::collections::BTreeMap<String, ApprovalRouteBinding>,
     ) -> Result<Agent> {
-        let payload = if routes.is_empty() {
-            serde_json::Value::Null
-        } else {
-            serde_json::to_value(routes).context("encoding approval routes")?
-        };
         let resp = self
             .http
             .patch(format!("{}/agents/{agent_id}", self.base_url))
             .header("X-API-Key", &self.api_key)
-            .json(&json!({ "approval_routes": payload }))
+            .json(&json!({ "approval_routes": routes }))
             .send()
             .await
             .context("PATCH /agents/{id} (approval routes)")?;

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -4005,7 +4005,9 @@ pub async fn approvals(
                 format!(
                     "PATCH {}/agents/<id> approval_routes={} (a FULL REPLACEMENT of the map)",
                     opts.api_url,
-                    serde_json::to_string(&bindings).unwrap_or_else(|_| "{}".into())
+                    // Deliberately not valid JSON. "{}" is the real clear payload, so a
+                    // fallback that looked like "{}" would misreport a full revocation.
+                    serde_json::to_string(&bindings).unwrap_or_else(|_| "<unserializable>".into())
                 )
             } else {
                 format!(

--- a/cli/tests/approval_route_bindings.rs
+++ b/cli/tests/approval_route_bindings.rs
@@ -21,6 +21,7 @@
 mod support;
 
 use curie::commands::{approvals, AgentActionOpts, ApprovalCmd, ApprovalsOutput};
+use std::sync::{Arc, Mutex};
 use support::{serve, MockServer, Response};
 
 const TEST_API_KEY: &str = "test-key";
@@ -49,6 +50,62 @@ fn stub(list_routes: &'static str, patch_echo: &'static str) -> MockServer {
     })
 }
 
+/// How `crud.update_agent_approval_routes` renders stored bindings: an unset
+/// map is the literal `null`, since it stores `routes or None`.
+fn render_routes(state: &Option<serde_json::Value>) -> String {
+    match state {
+        Some(routes) => routes.to_string(),
+        None => "null".to_string(),
+    }
+}
+
+/// A stub that MODELS the router instead of echoing a canned response, so a
+/// clear that does not take is visible in what the next read returns.
+///
+/// It holds the agent's bindings as server-side state and mirrors the guard at
+/// `apps/api/src/curie_api/routers/agents.py:154`, which is
+/// `if data.approval_routes is not None`. Pydantic decodes an omitted key and an
+/// explicit JSON `null` to the same `None`, so both of those spellings skip the
+/// guard and leave the bindings alone; only an explicit object reaches crud, and
+/// an empty one clears. That collapse of `null` into "omitted" is the whole
+/// defect, so the stub encodes it rather than papering over it.
+/// `initial_routes` is the agent's starting bindings and must be a bound map
+/// (e.g. `{}` or `{"deal_desk":{...}}`), not `null`.
+fn router_stub(initial_routes: &str) -> MockServer {
+    let initial: serde_json::Value =
+        serde_json::from_str(initial_routes).expect("the seed bindings must be valid JSON");
+    let state: Arc<Mutex<Option<serde_json::Value>>> = Arc::new(Mutex::new(Some(initial)));
+
+    serve(move |req| match req.path.split('?').next().unwrap() {
+        "/agents" => {
+            let current = render_routes(&state.lock().unwrap());
+            Response::json(200, &agents_list(&current))
+        }
+        p if p.strip_prefix("/agents/") == Some(AGENT_ID) => {
+            let body: serde_json::Value =
+                serde_json::from_slice(&req.body).expect("PATCH body must be valid JSON");
+            let mut current = state.lock().unwrap();
+            match body.get("approval_routes") {
+                // Key absent: the field was omitted, so the guard is skipped and
+                // the bindings are left alone.
+                None => {}
+                // Explicit null: Pydantic hands the router the SAME `None` an
+                // omitted key gives, so the guard is skipped here too and the
+                // bindings survive.
+                Some(serde_json::Value::Null) => {}
+                // An explicit empty object passes the guard and reaches crud,
+                // which stores `routes or None`, i.e. NULL.
+                Some(serde_json::Value::Object(routes)) if routes.is_empty() => *current = None,
+                // Any other explicit value passes the guard and replaces the map.
+                Some(routes) => *current = Some(routes.clone()),
+            }
+            let updated = render_routes(&current);
+            Response::json(200, &patched_agent(&updated))
+        }
+        other => panic!("unexpected request: {other}"),
+    })
+}
+
 async fn run(server: &MockServer, cmd: ApprovalCmd) -> anyhow::Result<ApprovalsOutput> {
     approvals(
         AgentActionOpts {
@@ -71,6 +128,36 @@ fn patch_body(server: &MockServer) -> serde_json::Value {
         .find(|r| r.path.starts_with(&format!("/agents/{AGENT_ID}")))
         .expect("the PATCH endpoint must have been called");
     serde_json::from_slice(&patch.body).expect("PATCH body must be valid JSON")
+}
+
+/// The payload a `--dry-run` plan promises, parsed back out of its
+/// `approval_routes=` clause. Read from the plan the code emitted rather than
+/// restated, so the comparison is against the real plan and not a literal.
+fn planned_routes_payload(lines: &[String]) -> serde_json::Value {
+    let line = lines
+        .iter()
+        .find(|l| l.contains("approval_routes="))
+        .unwrap_or_else(|| panic!("the plan must name the approval_routes payload, got {lines:?}"));
+    let rest = line
+        .split_once("approval_routes=")
+        .expect("the line was chosen for containing it")
+        .1;
+    let payload = rest.split_once(" (").map_or(rest, |(p, _)| p);
+    serde_json::from_str(payload)
+        .unwrap_or_else(|err| panic!("the plan's payload must be JSON, got {payload:?}: {err}"))
+}
+
+/// The shared assertion for both cleared-routes tests: the output must be the
+/// `Routes` variant AND its map must be empty. `context` distinguishes the two
+/// call sites' panic messages (flag-driven vs file-driven).
+fn assert_routes_cleared(out: ApprovalsOutput, context: &str) {
+    match out {
+        ApprovalsOutput::Routes { routes, .. } => assert!(
+            routes.is_empty(),
+            "{context}: the agent still has bindings {routes:?}"
+        ),
+        _ => panic!("expected the Routes output"),
+    }
 }
 
 /// No PATCH reached the server. The assertion for every rejected input: the
@@ -228,10 +315,13 @@ async fn list_routes_reads_without_writing() {
 }
 
 #[tokio::test]
-async fn clear_routes_sends_null_not_an_empty_object() {
-    // `crud.update_agent_approval_routes` stores `routes or None`, so null is how
-    // the API spells "no bindings". Sending `{}` would be a second spelling of the
-    // same state and would round-trip back as null anyway.
+async fn clear_routes_sends_an_empty_object_not_null() {
+    // The router guards with `if data.approval_routes is not None`, and Pydantic
+    // decodes an explicit JSON null and an omitted key to the same `None`, so
+    // both spellings mean "leave the bindings alone" and the clear never runs.
+    // An empty object is the only spelling that passes the guard and reaches
+    // `crud.update_agent_approval_routes`, whose `routes or None` is a STORAGE
+    // normalization applied after the guard, not the wire contract (#1071).
     let server = stub(r#"{"deal_desk":{"channel":"C0MANAGERS"}}"#, "null");
 
     run(
@@ -245,9 +335,108 @@ async fn clear_routes_sends_null_not_an_empty_object() {
     .expect("--clear-routes should succeed");
 
     let body = patch_body(&server);
-    assert!(
-        body["approval_routes"].is_null(),
-        "clear must send an explicit null, got {body:?}"
+    let routes = body.get("approval_routes").unwrap_or_else(|| {
+        panic!("clear must send the approval_routes key; an omitted key reads as \"leave the bindings alone\", got {body:?}")
+    });
+    assert_eq!(
+        routes,
+        &serde_json::json!({}),
+        "clear must send an empty object, got {body:?}"
+    );
+}
+
+#[tokio::test]
+async fn clear_routes_actually_clears_the_bindings() {
+    // The effect, not the bytes: drive the clear against a stub that applies the
+    // router's guard, then read what it hands back. A spelling the guard skips
+    // leaves the binding in place, so the operator is told "updated" while the
+    // approver set they meant to revoke is still live.
+    let server = router_stub(r#"{"deal_desk":{"channel":"C0MANAGERS"}}"#);
+
+    let out = run(
+        &server,
+        ApprovalCmd {
+            clear_routes: true,
+            ..ApprovalCmd::default()
+        },
+    )
+    .await
+    .expect("--clear-routes should succeed");
+
+    assert_routes_cleared(out, "the clear did not take");
+}
+
+#[tokio::test]
+async fn a_routes_file_holding_an_empty_map_clears_the_bindings() {
+    // The second entry point. `--clear-routes` is refused alongside
+    // `--routes-from`, so a `{}` file reaches the empty map through
+    // `build_route_bindings` rather than through the flag's direct empty map.
+    // Both must land on the same wire spelling.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("routes.json");
+    std::fs::write(&path, "{}").expect("write routes file");
+
+    let server = router_stub(r#"{"deal_desk":{"channel":"C0MANAGERS"}}"#);
+
+    let out = run(
+        &server,
+        ApprovalCmd {
+            routes_from: Some(path),
+            ..ApprovalCmd::default()
+        },
+    )
+    .await
+    .expect("a routes file holding an empty map should succeed");
+
+    assert_routes_cleared(out, "the file-driven clear did not take");
+}
+
+#[tokio::test]
+async fn the_dry_run_plan_names_the_payload_the_real_clear_sends() {
+    // A plan an operator reads before running the real thing is only worth
+    // reading if it names the same request. Both halves are read back from what
+    // the code produced; comparing two literals would prove nothing.
+    let planned = {
+        let server = stub(r#"{"deal_desk":{"channel":"C0MANAGERS"}}"#, "null");
+        let out = approvals(
+            AgentActionOpts {
+                api_url: server.base_url.clone(),
+                api_key: TEST_API_KEY.to_string(),
+                agent: "deal-desk".to_string(),
+                dry_run: true,
+            },
+            vec![],
+            false,
+            ApprovalCmd {
+                clear_routes: true,
+                ..ApprovalCmd::default()
+            },
+        )
+        .await
+        .expect("--clear-routes --dry-run should succeed");
+
+        assert_no_write(&server);
+        match out {
+            ApprovalsOutput::DryRun(plan) => planned_routes_payload(&plan.lines),
+            _ => panic!("expected the DryRun output"),
+        }
+    };
+
+    let server = stub(r#"{"deal_desk":{"channel":"C0MANAGERS"}}"#, "null");
+    run(
+        &server,
+        ApprovalCmd {
+            clear_routes: true,
+            ..ApprovalCmd::default()
+        },
+    )
+    .await
+    .expect("--clear-routes should succeed");
+    let sent = patch_body(&server)["approval_routes"].clone();
+
+    assert_eq!(
+        planned, sent,
+        "the plan promised approval_routes={planned} but the request sent {sent}"
     );
 }
 

--- a/docs/approvals.md
+++ b/docs/approvals.md
@@ -104,8 +104,10 @@ curie local approvals my-agent --list-routes
 ```
 
 `--route-approvers` also takes `users:U0123ABCD,W0456DEFG`, `--routes-from <file>` reads
-the whole map as JSON, and `--clear-routes` removes every binding. Nothing is written
-unless every entry parses, so a typo cannot leave a half-written map behind.
+the whole map as JSON, and `--clear-routes` removes every binding. A `--routes-from`
+file containing `{}` clears every binding too, the same as `--clear-routes`. Nothing
+is written unless every entry parses, so a typo cannot leave a half-written map
+behind.
 
 ## Who may resolve
 


### PR DESCRIPTION
`approvals <agent> --clear-routes` exited 0 and reported `updated` while every
route binding survived. The CLI sent `{"approval_routes":null}`, and the router
clears bindings only behind an `is not None` guard, where Pydantic decodes an
explicit null and an omitted key to the same `None`. Route bindings decide who
may approve, so this was a revocation that silently did not take.

The map is now serialized directly, matching the sibling approval-tools setter,
so an empty map spells `{}` and passes the guard. Storing `routes or None` is
the storage normalization applied after the guard, not the wire spelling; the
doc comment claimed otherwise and is corrected. `--routes-from` with a file
holding `{}` took the same path and is now documented as clearing every
binding. The dry-run payload fallback said `{}`, which is now precisely the
revoke payload, so it uses a non-JSON marker instead.

The previous test asserted the null spelling and could not catch this: its stub
matched on path only and returned a canned response, so it could not tell
"cleared" from "unchanged". The new stub models the router's guard with
server-side state, so a clear that does not take is visible in what the next
read returns.

## Verified against a live API

Reproduced the defect and the fix on the `core` compose stack, against real
Postgres and the real ASGI app:

```
PATCH {"approval_routes": null} -> 200, GET after: bindings SURVIVED
PATCH {"approval_routes": {}}   -> 200, GET after: bindings CLEARED
```

Then with a binary built from this branch, where step 6 is a separate process
so it reads persisted state rather than the PATCH response:

```
--route deal_desk=C0MANAGERS --route-approvers deal_desk=group:S0123ABCD  -> bound
--list-routes                                                            -> count 1
--clear-routes                                                           -> exit 0
--list-routes                                                            -> count 0
--routes-from <file containing {}>                                       -> exit 0
--list-routes                                                            -> count 0
```

## Done check

- [x] Failing tests committed before implementation. All four failed against the
      unfixed code, each for the right reason; the effect test failed with "the
      clear did not take: the agent still has bindings", which is the AC-4
      mutation evidence observed rather than reconstructed.
- [x] All production edits made by delegated executors; no inline edits by the driver.
- [x] No broadened return types. `set_approval_routes` keeps its signature; the
      dropped `.context(...)` covered an unreachable serialization failure.
- [x] Code review approved, 0 blocking.
- [x] Scope review approved, 0 scope-creep hunks.
- [x] Sibling-path parity. `cli/src/api.rs` has exactly three clearable-collection
      setters. `set_approval_tools` sends `[]` and `update_agent_secrets` sends
      `{}`, both already correct; only `approval_routes` was wrong. The router
      clears exactly three fields on an explicit empty collection, so the set is
      complete.
- [x] Guard demonstration: not applicable, this change introduces no new guard.
      The existing router guard was demonstrated executing, above.
- [x] Consolidation pass ran and applied three cleanups; suite and lint green
      after it; a fresh reviewer re-checked the applied diff and confirmed it
      behavior-preserving.
- [x] Security review approved, 0 blocking.
- [x] Live verification performed, above.
- [x] `cargo test` passes: 896 tests across 36 suites.
- [x] `cargo fmt --check` clean, `cargo clippy --all-targets` clean on every
      edited file, `scripts/check-docs.sh` passes.

## Out of scope, needs a decision

The security review raised a pre-existing HIGH finding this change does not
introduce but does add one entry point to: clearing a binding degrades a
group-bound or list-bound approver set on an ALREADY-PENDING approval to a
caller-asserted channel check. It is reachable today through any write that
drops a route while keeping others. ADR-0034 records this as accepted, but its
stated rationale is that no new escalation path exists, and that does not hold
for group-bound and list-bound routes given #544 took the opposite position at
approval creation time. Filed separately rather than folded in here.

Closes #1071
