### PR TITLE
Ack the approval note dialog before any Slack call

### DIFF
--- a/apps/dispatcher/CLAUDE.md
+++ b/apps/dispatcher/CLAUDE.md
@@ -36,6 +36,17 @@ summary.
   failures, unrecoverable exits) and owns graceful shutdown (`request_stop`
   wired to SIGINT/SIGTERM). Do not add ad hoc retry logic elsewhere for a
   connection failure -- it belongs in the supervisor's `BackoffPolicy`.
+- **Slack allows a `view_submission` three seconds to be acked, and the ack
+  body is load-bearing.** It carries `response_action: errors` on a refusal,
+  the only surface a claim-race loser can see behind an open modal. The only
+  thing permitted before `ack()` on that path is the resolve call itself;
+  both Slack calls (the card read and the card stamp, in
+  `render_note_submission`) run after the ack. The enforcement is structural,
+  not discipline: `resolve_note_submission` takes no `web_client` parameter
+  at all, so the pre-ack half physically cannot call Slack -- a future change
+  must preserve that property rather than relying on call ordering. The
+  post-ack half runs on Bolt's shared listener executor, which is why the
+  Slack client carries an explicit short timeout.
 
 ## Config surface
 

--- a/apps/dispatcher/src/curie_dispatcher/app.py
+++ b/apps/dispatcher/src/curie_dispatcher/app.py
@@ -26,6 +26,23 @@ from .supervisor import Connection
 # construction. A placeholder is therefore harmless.
 _SOCKET_MODE_SIGNING_PLACEHOLDER = "unused-in-socket-mode"
 
+# How long any one phase of a Slack Web API call may take (#1077). slack_sdk
+# defaults this to 30 seconds (measured on slack_sdk 3.43.0,
+# ``slack_sdk.web.base_client.BaseClient.__init__``), an order of magnitude past
+# Slack's three second interaction deadline, so a single slow call could hold one
+# of Bolt's five shared listener-executor workers for most of a minute.
+#
+# What two seconds buys is that bounded hold, and nothing stronger. It is NOT a
+# two second ceiling on a call: slack_sdk's default ``retry_handlers`` include a
+# ``ConnectionErrorRetryHandler(max_retry_count=1)``, and urllib raises a
+# connect/send-phase timeout as a ``URLError``, which that handler retries once
+# after a jittered backoff. The worst case for such a call is therefore about
+# 2 + 0.5 + 2 = 4.5s, past the three second deadline. (A read-phase timeout
+# surfaces as ``TimeoutError``, which the handler does not match, so that phase
+# is not retried.) Do not read this constant as making a Web API call safe to put
+# back on a pre-ack path -- nothing on the ack path may call Slack at all.
+_SLACK_API_TIMEOUT_SECONDS = 2
+
 
 def build_redis(config: DispatcherConfig) -> redis.Redis:
     """A decode_responses Valkey client (str in, str out) for stream + dedupe ops."""
@@ -40,7 +57,7 @@ def build_redis(config: DispatcherConfig) -> redis.Redis:
 
 def build_web_client(config: DispatcherConfig) -> WebClient:
     """The dispatcher's own Web API client, authenticated with the bot token."""
-    return WebClient(token=config.slack_bot_token)
+    return WebClient(token=config.slack_bot_token, timeout=_SLACK_API_TIMEOUT_SECONDS)
 
 
 def build_app(

--- a/apps/dispatcher/src/curie_dispatcher/approval_actions.py
+++ b/apps/dispatcher/src/curie_dispatcher/approval_actions.py
@@ -55,6 +55,29 @@ NOTE_MODAL_CALLBACK_ID = "curie-approval-note"
 _NOTE_BLOCK_ID = "note"
 _NOTE_ACTION_ID = "note-input"
 
+# The human-facing note limit, declared on the modal's input so Slack shows a
+# counter and blocks submit (#1077). Slack would otherwise accept up to 3000, and
+# the verdict line concatenates the note onto an attribution prefix, so an
+# unbounded note produces a text object over the cap and ``chat_update`` raises.
+_NOTE_MAX_LENGTH = 2000
+
+# The structural backstop on the stamped context line, applied in
+# ``_verdict_line`` so a non-modal caller is guarded too. It mirrors the value
+# the codebase already settled on for the same class of problem: the worker's
+# ``_APPROVAL_SUMMARY_MAX`` and ``_CHUNK_TARGET``, both in
+# ``curie_worker.blocks``, are the same 2900 (copied rather than imported: the
+# dispatcher must not depend on apps/worker). The three share a derivation from
+# Slack's text-object limit, not a coupling to each other -- two of them guard
+# different block types in a different service, and nothing gates any of the
+# three against the others; this comment naming the other two is the only
+# cross-reference there is.
+#
+# Assumption, stated because it is inferred rather than cited: Slack documents
+# 3000 as the general maximum for a text object's ``text``, but documents no
+# per-element cap for the elements of a CONTEXT block specifically. 2900 is
+# therefore a deliberate margin under an inferred limit, not a documented one.
+_VERDICT_LINE_MAX = 2900
+
 _APPROVAL_ACTION_IDS = frozenset(
     {
         APPROVE_ACTION_ID,
@@ -95,6 +118,63 @@ class ResolveOutcome:
     decision: str | None = None
 
 
+@dataclass(frozen=True)
+class NoteSubmission:
+    """A note dialog that has already been resolved, carried across the ack.
+
+    Everything the render half needs travels in here so that no Slack call has
+    to precede the ack (#1077): ``resolve_note_submission`` fills it in and
+    ``render_note_submission`` consumes it, with ``ack()`` in between.
+    ``response_action`` is the body Bolt must ack the view with -- None closes
+    the dialog, and an ``errors`` response keeps it open with the reason
+    attached to the note field.
+    """
+
+    approval_id: str
+    decision: str
+    user: str
+    channel: str
+    card_ts: str
+    note: str | None
+    outcome: ResolveOutcome
+    response_action: dict[str, Any] | None
+
+
+# The resolve POST is the only network round trip left inside the
+# ``view_submission`` ack budget (#1077), so it must give up well inside Slack's
+# three seconds. All four phases are named explicitly because httpx timeouts are
+# PER PHASE and the phases are sequential: any phase left at its default silently
+# joins the sum. A single-argument ``httpx.Timeout(1.0, connect=0.5)`` reads like
+# 1.5s and is actually 3.5s, over the deadline this constant exists to fit inside.
+#
+# Be precise about what the four numbers bound: each caps INACTIVITY inside its own
+# I/O operation, not elapsed wall clock. pool 0.1 + connect 0.4 + write 0.3 + read
+# 1.4 = 2.2s is the worst case for a response that arrives in the normal way, which
+# leaves real margin inside the three seconds for websocket transit and Bolt's own
+# dispatch. It is NOT a guaranteed ceiling. A slowly-streaming response resets the
+# read clock on every chunk, so it can run past the ack budget without ever
+# tripping a timeout, and httpx cannot express a total-request deadline at all.
+# What makes that acceptable is the peer rather than the setting: this talks to the
+# platform API, which answers with one small JSON body that lands in a single read,
+# so there is no trickle for the read clock to keep forgiving.
+#
+# The shape of the split is deliberate. Read gets the largest share because it is
+# the phase that legitimately waits on the authorizer doing work: a group-bound
+# approval whose membership cache has expired makes the API perform a live Slack
+# lookup inside this request. Connect is tighter because a platform API that has
+# not accepted the socket in 0.4s is down, not busy. Pool is tiny because pool
+# exhaustion is near-impossible here (five Bolt listener workers against httpx's
+# default pool of 100), so failing fast is the right answer if it ever happens.
+#
+# Timing out yields ``ResolveOutcome(status_code=0)``. Be clear about what that
+# does and does not mean: for anything past the connect phase the request WAS
+# delivered, so the outcome is UNKNOWN to the dispatcher and the server may well
+# have committed the resolution. What keeps a retry safe is the server-side
+# compare-and-set, not the record being untouched -- a retry of a decision that
+# did land comes back 409 instead of resolving it a second time.
+_RESOLVE_TIMEOUT = httpx.Timeout(connect=0.4, read=1.4, write=0.3, pool=0.1)
+
+
 class ApprovalResolveClient:
     """Thin client for POST /approvals/{id}/resolve (shared API key auth)."""
 
@@ -103,7 +183,7 @@ class ApprovalResolveClient:
     ) -> None:
         self._base = api_base_url.rstrip("/")
         self._headers = {"X-API-Key": api_key} if api_key else {}
-        self._client = client or httpx.Client(timeout=10.0)
+        self._client = client or httpx.Client(timeout=_RESOLVE_TIMEOUT)
 
     def resolve(
         self,
@@ -186,8 +266,20 @@ def _verdict_line(decision: str, user: str, note: str | None) -> str:
     verdict.
     """
 
+    # Build the whole line, then cut only if it does not fit. The cut takes from
+    # the tail, which is the note, so the attribution survives in preference to
+    # it: who decided is the part of this line that must survive. The cut is
+    # marked so a reader can tell the card is showing an excerpt; the durable
+    # record still holds the whole note, and the requester's resume turn
+    # interpolates that one. The marker is the same single ellipsis character
+    # the worker's ``_truncate`` in ``curie_worker.blocks`` uses, so a truncated
+    # note ends the same way whichever service stamped the card.
     line = f"{decision.capitalize()} by <@{user}>"
-    return f"{line}\nNote: {note}" if note else line
+    if note:
+        line = f"{line}\nNote: {note}"
+    if len(line) <= _VERDICT_LINE_MAX:
+        return line
+    return line[: _VERDICT_LINE_MAX - 1] + "…"
 
 
 def build_note_modal(
@@ -227,6 +319,7 @@ def build_note_modal(
                     "type": "plain_text_input",
                     "action_id": _NOTE_ACTION_ID,
                     "multiline": True,
+                    "max_length": _NOTE_MAX_LENGTH,
                 },
             }
         ],
@@ -308,24 +401,30 @@ def open_note_dialog(
     return outcome
 
 
-def process_note_submission(
+def resolve_note_submission(
     *,
     body: dict[str, Any],
-    web_client: WebClient,
     resolver: ApprovalResolveClient,
     logger: logging.Logger | None = None,
-) -> tuple[ResolveOutcome | None, dict[str, Any] | None]:
-    """Resolve from a submitted note dialog (#1053).
+) -> NoteSubmission | None:
+    """Decide a submitted note dialog, making no Slack call at all (#1053, #1077).
 
-    Returns ``(outcome, response_action)``. The second element is the body Bolt
-    must ack the view with: ``None`` closes the dialog, and an ``errors``
-    response keeps it open with the reason attached to the note field.
+    The pre-ack half. It parses ``private_metadata``, extracts the note, and
+    resolves; the returned ``NoteSubmission`` carries the body Bolt must ack the
+    view with, so the caller can ack immediately and render afterwards. Returns
+    None when the payload is unusable, in which case there is nothing to render.
 
-    That second channel exists because the claim race widened. Resolution now
-    happens at submit rather than at click, so two approvers can hold open
-    dialogs at once. The compare-and-set still makes exactly one win, but the
-    loser is now standing inside a modal, where an ephemeral is invisible --
-    so every refusal is rendered INTO the view rather than posted behind it.
+    The resolve genuinely cannot move past the ack: a view ack CARRIES the
+    response. That second channel exists because the claim race widened.
+    Resolution now happens at submit rather than at click, so two approvers can
+    hold open dialogs at once. The compare-and-set still makes exactly one win,
+    but the loser is now standing inside a modal, where an ephemeral is
+    invisible -- so every refusal is rendered INTO the view rather than posted
+    behind it.
+
+    It takes no ``web_client``: that is what makes "nothing talks to Slack before
+    the ack" a structural property of the signature rather than a matter of
+    ordering discipline inside the body.
     """
 
     log = logger or logging.getLogger(__name__)
@@ -342,35 +441,101 @@ def process_note_submission(
     user = (body.get("user") or {}).get("id") or ""
     if not approval_id or not channel or not user or decision not in ("approved", "rejected"):
         log.info("note submission with unusable private_metadata, skipping")
-        return None, None
+        return None
 
     values = (view.get("state") or {}).get("values") or {}
     note = ((values.get(_NOTE_BLOCK_ID) or {}).get(_NOTE_ACTION_ID) or {}).get("value")
     note = (note or "").strip() or None
 
-    # The card's original blocks are not in a view_submission payload, so re-read
-    # the message the card lives on to stamp it in place. Best-effort: a failed
-    # read only costs the in-place edit, never the resolution.
-    message = _fetch_card_message(web_client, channel=channel, card_ts=card_ts, log=log)
-
-    outcome = _resolve_and_render(
+    outcome = resolver.resolve(
+        approval_id,
+        decision=decision,
+        resolved_by=user,
+        actor_channel=channel,
+        note=note,
+    )
+    response_action = (
+        None
+        if outcome.status_code == 200
+        else {
+            "response_action": "errors",
+            "errors": {_NOTE_BLOCK_ID: _refusal_text(outcome)},
+        }
+    )
+    return NoteSubmission(
         approval_id=approval_id,
         decision=decision,
         user=user,
         channel=channel,
         card_ts=card_ts,
-        message=message,
         note=note,
-        web_client=web_client,
-        resolver=resolver,
-        log=log,
+        outcome=outcome,
+        response_action=response_action,
     )
-    if outcome.status_code == 200:
-        return outcome, None
-    return outcome, {
-        "response_action": "errors",
-        "errors": {_NOTE_BLOCK_ID: _refusal_text(outcome)},
-    }
+
+
+def render_note_submission(
+    submission: NoteSubmission,
+    *,
+    web_client: WebClient,
+    logger: logging.Logger | None = None,
+) -> None:
+    """Stamp the card for an already-decided submission (#1077).
+
+    The post-ack half, and the only place the dialog path talks to Slack. It
+    never raises: by the time it runs the view has been acked and there is no
+    surface left to report an error on.
+
+    Note the deliberate consequence of running here: the card is now read AFTER
+    the resolve rather than before, so a claim-race loser commonly reads a card
+    the winner has already stamped and appends a second context line under it.
+    That is a redundant extra line, not a lost decision.
+    """
+
+    log = logger or logging.getLogger(__name__)
+
+    # The outer net that makes "never raises" structural rather than incidental.
+    # Every Slack call below already carries its own best-effort handler, so
+    # totality holds by inspection today -- but only by inspection, and the cost
+    # of it lapsing is not a logged traceback. Bolt's thread runner, on a raise
+    # from a post-ack listener, sets ``ack.response`` back to None while the
+    # dispatch thread is still polling it, so a raise inside that window eats the
+    # ack entirely and the view never closes: the exact failure #1077 exists to
+    # remove. A future edit that adds a call here must not be able to
+    # reintroduce it by forgetting a handler.
+    try:
+        # The card's original blocks are not in a view_submission payload, so
+        # re-read the message the card lives on to stamp it in place.
+        # Best-effort: a failed read only costs the in-place edit, never the
+        # resolution. Skip the read entirely on the outcomes that discard it --
+        # only the 200 and 409 branches of ``_render_outcome`` use ``message``,
+        # and a fetch nobody reads still costs a Slack round trip and holds one
+        # of Bolt's five shared listener workers.
+        message: dict[str, Any] = {}
+        if submission.outcome.status_code in (200, 409):
+            message = _fetch_card_message(
+                web_client,
+                channel=submission.channel,
+                card_ts=submission.card_ts,
+                log=log,
+            )
+
+        _render_outcome(
+            approval_id=submission.approval_id,
+            decision=submission.decision,
+            user=submission.user,
+            channel=submission.channel,
+            card_ts=submission.card_ts,
+            message=message,
+            note=submission.note,
+            outcome=submission.outcome,
+            web_client=web_client,
+            log=log,
+        )
+    except Exception as exc:  # noqa: BLE001 - a raise past the ack eats the ack
+        log.warning(
+            "post-ack render failed for approval %s: %s", submission.approval_id, exc
+        )
 
 
 def _fetch_card_message(
@@ -436,11 +601,13 @@ def _resolve_and_render(
     resolver: ApprovalResolveClient,
     log: logging.Logger,
 ) -> ResolveOutcome:
-    """Resolve one approval and stamp the card, shared by both click paths.
+    """Resolve one approval and hand the verdict to ``_render_outcome``.
 
-    The immediate-click path and the note-dialog path must agree on what a
-    settled card looks like and on when the ephemeral is skipped, so they share
-    this rather than each rendering their own.
+    The resolve-then-render pair for a caller that is free to talk to Slack
+    inline: the immediate-click path, and the note-dialog path's fall-forward
+    when the dialog could not be opened. The rendering itself lives in
+    ``_render_outcome``, which the post-ack dialog path calls on its own, so
+    this is only the ordering of the two halves plus the returned outcome.
     """
 
     outcome = resolver.resolve(
@@ -450,6 +617,45 @@ def _resolve_and_render(
         actor_channel=channel,
         note=note,
     )
+    _render_outcome(
+        approval_id=approval_id,
+        decision=decision,
+        user=user,
+        channel=channel,
+        card_ts=card_ts,
+        message=message,
+        note=note,
+        outcome=outcome,
+        web_client=web_client,
+        log=log,
+    )
+    return outcome
+
+
+def _render_outcome(
+    *,
+    approval_id: str,
+    decision: str,
+    user: str,
+    channel: str,
+    card_ts: str,
+    message: dict[str, Any],
+    note: str | None,
+    outcome: ResolveOutcome,
+    web_client: WebClient,
+    log: logging.Logger,
+) -> None:
+    """Render an already-decided outcome back into Slack.
+
+    Split out of ``_resolve_and_render`` so the note-dialog path can run it
+    AFTER ``ack()`` (#1077): every call in here talks to Slack, and none of it
+    feeds the ack body. It must never raise -- past the ack a raise does not just
+    go unreported, it can eat the ack: Bolt's thread runner sets ``ack.response``
+    back to None on a listener exception while the dispatch thread is still
+    polling it, so the view is left open with no response at all. Every Slack
+    call therefore keeps its own best-effort handler, and the caller wraps the
+    whole of this in an outer net.
+    """
 
     if outcome.status_code == 200:
         verdict = _verdict_line(outcome.decision or decision, user, note)
@@ -465,7 +671,7 @@ def _resolve_and_render(
         except Exception as exc:  # noqa: BLE001 - render is best-effort
             log.warning("approval card update failed for %s: %s", approval_id, exc)
         log.info("approval %s %s by %s", approval_id, decision, user)
-        return outcome
+        return
 
     if outcome.status_code == 409:
         # Refresh a stale card so it stops offering buttons for a settled
@@ -485,7 +691,6 @@ def _resolve_and_render(
         outcome.status_code,
         outcome.detail,
     )
-    return outcome
 
 
 def process_approval_action(
@@ -499,8 +704,8 @@ def process_approval_action(
     """Resolve one card click immediately and render the verdict back into Slack.
 
     The no-dialog path, for a card rendered without ``allow_free_text``. It shares
-    ``_resolve_and_render`` with the dialog path so the two cannot disagree about
-    what a settled card looks like; only the surface a refusal is rendered on
+    ``_render_outcome`` with the dialog path so the two cannot disagree about what
+    a settled card looks like; only the surface a refusal is rendered on
     differs, and that difference is real: here nothing is open, so an ephemeral is
     the right place for it.
 

--- a/apps/dispatcher/src/curie_dispatcher/handlers.py
+++ b/apps/dispatcher/src/curie_dispatcher/handlers.py
@@ -37,7 +37,8 @@ from .approval_actions import (
     is_approval_action,
     open_note_dialog,
     process_approval_action,
-    process_note_submission,
+    render_note_submission,
+    resolve_note_submission,
 )
 from .config import DispatcherConfig
 from .queue import claim_event, enqueue
@@ -309,16 +310,29 @@ def register_handlers(
     # the open modal.
     @app.view(NOTE_MODAL_CALLBACK_ID)
     def _on_note_submitted(ack: Callable[..., Any], body: dict[str, Any]) -> None:
-        _outcome, response = process_note_submission(
+        # Decide first, with no Slack round trip in the way: Slack allows three
+        # seconds for the ack and the resolve POST is the only network hop the
+        # decision needs (#1077).
+        submission = resolve_note_submission(
             body=body,
-            web_client=web_client,
             resolver=approval_resolver,
             logger=logger,
         )
+        if submission is None:
+            # Unusable private_metadata: nothing resolved, nothing to render.
+            ack()
+            return
+        response = submission.response_action
         if response is None:
             ack()
         else:
             ack(response_action=response["response_action"], errors=response["errors"])
+
+        # Continue inline. Bolt returns the ack the moment ack() sets its
+        # response and keeps running the listener body on its own executor, so
+        # the card stamp needs no extra thread pool and no shutdown story of its
+        # own -- the same arrangement _on_action below already relies on.
+        render_note_submission(submission, web_client=web_client, logger=logger)
 
     # Any other Block Kit button click (a reply's action) becomes a turn. The
     # catch-all matches every action_id (including the approval ids above --

--- a/apps/dispatcher/tests/conftest.py
+++ b/apps/dispatcher/tests/conftest.py
@@ -1,10 +1,13 @@
 """Shared fixtures. Stream/dedupe tests run against the REAL Valkey from the
-compose stack (per repo test discipline: never mock Valkey). Only the Slack Web
-API and socket transport are faked."""
+compose stack (per repo test discipline: never mock Valkey). The Slack Web API
+and socket transport are faked; `_black_hole_api` is not a fake but a real
+loopback socket standing in for an endpoint that never answers."""
 
 import logging
+import socket
 import uuid
 from collections.abc import Iterator
+from contextlib import contextmanager
 from typing import Any
 
 import pytest
@@ -58,6 +61,28 @@ class FakeSocketClient:
         """The body this envelope was acked with, or None."""
 
         return self.ack_payloads.get(envelope_id)
+
+
+@contextmanager
+def _black_hole_api() -> Iterator[str]:
+    """A real port that completes the TCP handshake and then never answers.
+
+    Nothing accepts the connection; the kernel's listen backlog completes the
+    handshake, so `connect` succeeds and the client is left reading from a
+    socket no one writes to. A refused connection fails instantly and can
+    never show a probe running past its deadline, so this is the fixture for
+    the opposite case: a probe whose read phase is what has to give up,
+    exactly the scenario an unbounded probe overshoots on. The preflight
+    suite is one consumer of this.
+    """
+    sock = socket.socket()
+    sock.bind(("127.0.0.1", 0))
+    sock.listen(1)
+    try:
+        yield f"http://127.0.0.1:{sock.getsockname()[1]}"
+    finally:
+        sock.close()
+
 
 # Compose defaults and connection params come from the shared curie_test_support.valkey helper.
 

--- a/apps/dispatcher/tests/test_approval_note_dialog.py
+++ b/apps/dispatcher/tests/test_approval_note_dialog.py
@@ -13,26 +13,38 @@ cannot have:
   click-is-the-decision behavior and must not regress;
 - and the widened claim race renders its refusal INSIDE the view, because the
   loser is standing in an open modal where an ephemeral is invisible.
+
+Plus the ack budget (#1077): the submit ack must reach the socket before any
+Slack round trip, and the note must stay small enough that the card stamp
+cannot bounce.
 """
 
+import threading
+import time
+from collections.abc import Callable
 from typing import Any
 from unittest.mock import MagicMock
 
+import httpx
 import redis
-from curie_dispatcher.app import build_app
+from curie_dispatcher.app import build_app, build_web_client
 from curie_dispatcher.approval_actions import (
+    _VERDICT_LINE_MAX,
     APPROVE_NOTE_ACTION_ID,
     NOTE_MODAL_CALLBACK_ID,
     REJECT_NOTE_ACTION_ID,
+    ApprovalResolveClient,
     ResolveOutcome,
+    _refusal_text,
 )
 from curie_dispatcher.config import DispatcherConfig
 from slack_bolt import App
 from slack_bolt.adapter.socket_mode import SocketModeHandler
+from slack_sdk.errors import SlackApiError
 from slack_sdk.socket_mode.request import SocketModeRequest
 from slack_sdk.web import WebClient
 
-from .conftest import FakeSocketClient, _authorize
+from .conftest import FakeSocketClient, _authorize, _black_hole_api
 
 APPROVAL_ID = "9a1e8a10-0000-0000-0000-000000001053"
 CARD_TS = "1700.0042"
@@ -76,19 +88,47 @@ class ScriptedResolver:
         return self.outcome
 
 
+def _gated_history(gate: threading.Event) -> Callable[..., dict[str, Any]]:
+    """A ``conversations.history`` that blocks until the test releases ``gate``.
+
+    How the ack-ordering tests turn "the ack did not wait on a Slack call" into a
+    structural fact rather than a timing hope.
+    """
+
+    def _history(**_kwargs: Any) -> dict[str, Any]:
+        gate.wait(5)
+        return {"messages": [_CARD_MESSAGE]}
+
+    return _history
+
+
 def _build(
     config: DispatcherConfig,
     redis_client: redis.Redis,
     resolver: ScriptedResolver,
     *,
     views_open_raises: bool = False,
+    history_side_effect: Callable[..., Any] | BaseException | None = None,
 ) -> tuple[App, WebClient]:
+    """Build the app under test.
+
+    ``history_side_effect`` is handed straight to the ``conversations.history``
+    mock, so a test picks the failure mode it needs: a callable that blocks (see
+    ``_gated_history``) for a Slack call that is SLOW, or an exception instance
+    for one that FAILS. ``slack_sdk`` 3.43.0 raises ``SlackApiError`` from
+    ``WebClient`` whenever Slack answers ``ok: false``
+    (``slack_sdk.web.base_client.BaseClient.api_call`` ends in
+    ``validate_slack_response``), so that is the exception a real
+    ``conversations.history`` failure arrives as.
+    """
+
     web_client = WebClient(token="xoxb-test")
     web_client.chat_postMessage = MagicMock(return_value={"ts": "555.000"})  # type: ignore[method-assign]
     web_client.chat_update = MagicMock(return_value={"ok": True})  # type: ignore[method-assign]
     web_client.chat_postEphemeral = MagicMock(return_value={"ok": True})  # type: ignore[method-assign]
     web_client.conversations_history = MagicMock(  # type: ignore[method-assign]
-        return_value={"messages": [_CARD_MESSAGE]}
+        side_effect=history_side_effect,
+        return_value={"messages": [_CARD_MESSAGE]},
     )
     web_client.views_open = MagicMock(  # type: ignore[method-assign]
         side_effect=RuntimeError("trigger_id expired") if views_open_raises else None,
@@ -373,3 +413,351 @@ def test_a_failed_views_open_falls_forward_and_resolves(
     # Nothing here is silent: the approver is told the note step was skipped.
     web_client.chat_postEphemeral.assert_called_once()
     assert "note" in web_client.chat_postEphemeral.call_args.kwargs["text"].lower()
+
+
+def test_the_ack_lands_before_any_slack_call_on_the_submit_path(
+    redis_client: redis.Redis, config: DispatcherConfig
+) -> None:
+    """The ack must not be waiting on a Slack round trip (#1077).
+
+    Slack gives an interaction three seconds to be acknowledged
+    (https://api.slack.com/interactivity/handling#acknowledgment_response),
+    which slack_bolt 1.30.0 mirrors as ``ack_timeout: int = 3`` on
+    ``slack_bolt.listener.custom_listener.CustomListener``. The ack itself is a
+    two-thread affair: the listener body runs on Bolt's ``listener_executor`` and
+    only sets ``ack.response``, while the dispatch thread polls for it
+    (``slack_bolt.listener.thread_runner.ThreadListenerRunner.run``) and then
+    writes the envelope response
+    (``slack_bolt.adapter.socket_mode.internals.send_response``).
+
+    So the proof is the assertion made WHILE ``conversations.history`` is still
+    blocked: the ack reached the socket before that call returned, therefore it
+    cannot have been waiting on it. A "who was recorded first" list would not
+    prove this -- the listener thread starts the fetch the instant it acks, well
+    before the dispatch thread's 10ms poll wakes up to send the response.
+    """
+
+    resolver = ScriptedResolver(
+        ResolveOutcome(status_code=200, resolved_by="U_MANAGER", decision="approved")
+    )
+    gate = threading.Event()
+    app, web_client = _build(
+        config, redis_client, resolver, history_side_effect=_gated_history(gate)
+    )
+    handler = SocketModeHandler(app, app_token="xapp-test")
+    sock = FakeSocketClient()
+
+    try:
+        handler.handle(sock, _note_submit("env-slow", note="shipping it"))
+        assert sock.acked_envelope_ids == ["env-slow"], (
+            "the submit was not acked while the Slack call was still outstanding"
+        )
+    finally:
+        # In a finally so a failed assertion cannot leave the listener parked.
+        gate.set()
+    _drain(app)
+
+    # The fetch still happens; it just happens after the ack.
+    web_client.conversations_history.assert_called_once()
+
+
+def test_a_refused_submission_acks_before_the_card_read_and_still_refreshes_it(
+    redis_client: redis.Redis, config: DispatcherConfig
+) -> None:
+    """The claim-race loser's refusal is on time AND the stale card is refreshed.
+
+    The refusal rides on the view ack, so it is subject to the same three second
+    deadline as the happy path: a loser who is told late is told nothing, because
+    Slack has already closed the interaction. And the 409 branch's card refresh
+    is the piece most likely to be dropped when the pre-ack work is split off, so
+    it gets asserted after the gate is released.
+    """
+
+    resolver = ScriptedResolver(
+        ResolveOutcome(
+            status_code=409,
+            resolved_by=None,
+            detail="already resolved by U_FIRST (approved)",
+        )
+    )
+    gate = threading.Event()
+    app, web_client = _build(
+        config, redis_client, resolver, history_side_effect=_gated_history(gate)
+    )
+    handler = SocketModeHandler(app, app_token="xapp-test")
+    sock = FakeSocketClient()
+
+    try:
+        handler.handle(sock, _note_submit("env-slow-409", note="mine"))
+        payload = sock.ack_payload_for("env-slow-409")
+        assert payload is not None, (
+            "a refused submission must ack with a response_action before any Slack call"
+        )
+        assert payload.get("response_action") == "errors"
+        assert (
+            next(iter(payload["errors"].values())) == "already resolved by U_FIRST (approved)"
+        )
+    finally:
+        gate.set()
+    _drain(app)
+
+    # _refresh_settled_card must survive the split: a settled record must stop
+    # offering buttons.
+    web_client.chat_update.assert_called_once()
+
+
+def test_a_failing_card_read_still_acks_and_still_stamps_the_card(
+    redis_client: redis.Redis, config: DispatcherConfig
+) -> None:
+    """The other half of the post-ack hazard: a Slack call that FAILS (#1077).
+
+    A raise from the post-ack half is not a logged traceback, it is a lost ack.
+    slack_bolt 1.30.0 handles an exception out of a non-auto-ack listener by
+    setting ``ack.response = None`` when the listener had already acked
+    (``slack_bolt.listener.thread_runner.ThreadListenerRunner.run``, the
+    ``run_ack_function_asynchronously`` branch), while the dispatch thread is
+    still polling ``ack.response`` in its 10ms loop. Lose that race and the
+    dispatch thread polls to its three second timeout and sends nothing at all,
+    leaving the modal open on an interaction Slack considers unacknowledged.
+
+    That executor also SWALLOWS the exception, so calling the listener and
+    checking that nothing propagated proves nothing. The observation that has
+    teeth is the socket's: the envelope was acked, and the card was still
+    stamped from the empty message the failed read falls back to.
+    """
+
+    resolver = ScriptedResolver(
+        ResolveOutcome(status_code=200, resolved_by="U_MANAGER", decision="approved")
+    )
+    app, web_client = _build(
+        config,
+        redis_client,
+        resolver,
+        history_side_effect=SlackApiError(
+            "channel_not_found", {"ok": False, "error": "channel_not_found"}
+        ),
+    )
+    handler = SocketModeHandler(app, app_token="xapp-test")
+    sock = FakeSocketClient()
+
+    handler.handle(sock, _note_submit("env-hist-fail", note="shipping it"))
+    assert sock.acked_envelope_ids == ["env-hist-fail"], (
+        "a failing post-ack Slack call ate the submit's ack"
+    )
+    _drain(app)
+
+    web_client.conversations_history.assert_called_once()
+    # Fall forward: the read is best-effort, so the verdict still lands on the
+    # card built from an empty original rather than being dropped with the read.
+    web_client.chat_update.assert_called_once()
+    assert "shipping it" in web_client.chat_update.call_args.kwargs["text"]
+
+
+def test_a_conflict_from_another_approver_still_names_that_approver(
+    redis_client: redis.Redis, config: DispatcherConfig
+) -> None:
+    """The loser of a claim race must be told WHO holds the decision.
+
+    Grounded on the outcome ``ApprovalResolveClient`` really builds from the
+    platform API's conflict (see the test below): ``resolved_by`` is None and the
+    winning approver's id lives inside the detail string. So the id reaches the
+    submitter only if the detail is rendered verbatim; a wording that dropped it
+    would leave the loser of a race told nothing about who took the decision.
+    """
+
+    resolver = ScriptedResolver(
+        ResolveOutcome(
+            status_code=409,
+            resolved_by=None,
+            detail="already resolved by U_FIRST (approved)",
+        )
+    )
+    app, _ = _build(config, redis_client, resolver)
+    handler = SocketModeHandler(app, app_token="xapp-test")
+    sock = FakeSocketClient()
+
+    handler.handle(sock, _note_submit("env-409-other", note="mine", user="U_MANAGER"))
+    _drain(app)
+
+    payload = sock.ack_payload_for("env-409-other")
+    assert payload is not None
+    assert next(iter(payload["errors"].values())) == "already resolved by U_FIRST (approved)"
+
+
+def test_a_real_api_conflict_carries_no_resolver_id_and_names_the_approver_in_its_detail() -> None:
+    """The conflict the platform API actually sends, parsed by the real client.
+
+    ``curie_api.routers.approvals.resolve_approval`` raises its resolve-path
+    conflict as ``HTTPException(status.HTTP_409_CONFLICT, f"already resolved by
+    {current.resolved_by} ({current.status})")``, and FastAPI serializes an
+    ``HTTPException`` as ``{"detail": <str>}`` and nothing else. There is no
+    ``resolved_by`` key in the body, so ``ResolveOutcome.resolved_by`` is None on
+    every real conflict and the winning approver's id survives only inside the
+    detail text.
+
+    Driven through ``ApprovalResolveClient.resolve`` itself, over an
+    ``httpx.MockTransport`` injected via its existing ``client`` parameter, so
+    nothing between the wire body and the outcome is faked. Every other test in
+    this file hands a ``ResolveOutcome`` straight to the app, which is why they
+    cannot see the gap between the shape the API sends and the shape the
+    dispatcher assumes.
+    """
+
+    def _conflict(request: httpx.Request) -> httpx.Response:
+        assert request.url.path.endswith(f"/approvals/{APPROVAL_ID}/resolve")
+        return httpx.Response(409, json={"detail": "already resolved by U_MANAGER (approved)"})
+
+    client = ApprovalResolveClient(
+        api_base_url="http://platform.invalid",
+        api_key="k",
+        client=httpx.Client(transport=httpx.MockTransport(_conflict)),
+    )
+    try:
+        outcome = client.resolve(
+            APPROVAL_ID,
+            decision="approved",
+            resolved_by="U_MANAGER",
+            actor_channel=CARD_CHANNEL,
+            note="mine",
+        )
+    finally:
+        client._client.close()
+
+    assert outcome.status_code == 409
+    assert outcome.resolved_by is None
+    assert outcome.detail == "already resolved by U_MANAGER (approved)"
+    # So the only thing there is to tell the approver is what the API said. A
+    # wording composed from ``resolved_by`` would render "Already resolved by
+    # None." here, which is why that field must not be trusted on a 409.
+    assert _refusal_text(outcome) == "already resolved by U_MANAGER (approved)"
+
+
+def test_a_discarded_outcome_does_not_read_the_card_at_all(
+    redis_client: redis.Redis, config: DispatcherConfig
+) -> None:
+    """Only the 200 and 409 renders use the fetched message, so every other
+    outcome pays a Slack round trip for a message nobody reads -- and pays it by
+    holding one of Bolt's five shared listener workers while it waits.
+
+    The contrast is asserted on the paths that DO need it: the 200 case in
+    ``test_the_ack_lands_before_any_slack_call_on_the_submit_path`` and the 409
+    case in ``test_a_refused_submission_acks_before_the_card_read_and_still_refreshes_it``.
+    """
+
+    resolver = ScriptedResolver(ResolveOutcome(status_code=403, detail="self-approval is blocked"))
+    app, web_client = _build(config, redis_client, resolver)
+    handler = SocketModeHandler(app, app_token="xapp-test")
+
+    handler.handle(FakeSocketClient(), _note_submit("env-403-no-fetch", note="please"))
+    _drain(app)
+
+    web_client.conversations_history.assert_not_called()
+
+
+def test_the_web_client_gives_up_inside_the_ack_budget(config: DispatcherConfig) -> None:
+    """slack_sdk 3.43.0 defaults ``timeout`` to 30 seconds
+    (``slack_sdk.web.base_client.BaseClient.__init__``), an order of magnitude
+    past Slack's three second interaction deadline
+    (https://api.slack.com/interactivity/handling#acknowledgment_response).
+
+    Asserted against the deadline rather than pinned to an exact number, so
+    retuning the value does not red this test.
+    """
+
+    assert build_web_client(config).timeout < 3
+
+
+def test_the_resolver_gives_up_inside_the_ack_budget() -> None:
+    """The resolve call is the only network hop left inside the ack budget.
+
+    Behavioral, against a real loopback listener that accepts the connection and
+    never replies -- a local server, not a mocked dependency. Asserting the
+    elapsed wall clock rather than a private timeout attribute means the test
+    survives an internal rename and still fails if the budget is blown by some
+    other means (a retry loop, a second hop).
+    """
+
+    with _black_hole_api() as url:
+        client = ApprovalResolveClient(api_base_url=url, api_key="k")
+        try:
+            started = time.monotonic()
+            outcome = client.resolve(
+                APPROVAL_ID,
+                decision="approved",
+                resolved_by="U_MANAGER",
+                actor_channel=CARD_CHANNEL,
+            )
+            elapsed = time.monotonic() - started
+        finally:
+            # The client owns an httpx.Client (and its connection pool) and
+            # exposes no close(), so releasing it here is the only deterministic
+            # teardown; left to the garbage collector it leaks a socket into the
+            # rest of the session. Reached through the attribute deliberately: if
+            # that attribute is renamed this test should red rather than quietly
+            # leak again.
+            client._client.close()
+
+    # The httpx.HTTPError path: the approver gets "try again shortly" inside the
+    # still-open modal instead of a blown ack.
+    assert outcome.status_code == 0
+    assert elapsed < 3.0, f"the resolver held the ack budget for {elapsed:.1f}s"
+
+
+def test_an_over_long_note_cannot_break_the_card_stamp(
+    redis_client: redis.Redis, config: DispatcherConfig
+) -> None:
+    """Slack caps a text object's ``text`` at 3000 characters
+    (https://api.slack.com/reference/block-kit/composition-objects#text), so a
+    long note concatenated onto the attribution produces a card edit real Slack
+    rejects. ``chat_update`` is a MagicMock here and accepts anything, so the
+    assertion that catches it is the LENGTH, not an exception.
+    """
+
+    note = "x" * 3000
+    resolver = ScriptedResolver(
+        ResolveOutcome(status_code=200, resolved_by="U_MANAGER", decision="approved")
+    )
+    app, web_client = _build(config, redis_client, resolver)
+    handler = SocketModeHandler(app, app_token="xapp-test")
+
+    handler.handle(FakeSocketClient(), _note_submit("env-long", note=note))
+    _drain(app)
+
+    web_client.chat_update.assert_called_once()
+    text = web_client.chat_update.call_args.kwargs["text"]
+    assert len(text) <= 2900
+    # The note is what gets cut, never the attribution.
+    assert text.startswith("Approved by <@U_MANAGER>")
+    # A single U+2026, not three periods: the marker is shared with the worker's
+    # ``_truncate`` in ``curie_worker.blocks``, so the same Slack card surface
+    # does not end truncated text two ways depending on which service stamped it.
+    assert text.endswith("…")
+    assert not any(
+        b.get("type") == "actions" for b in web_client.chat_update.call_args.kwargs["blocks"]
+    )
+    # Only the display is clamped: the durable record keeps the whole note, which
+    # is what the requester's resume turn interpolates.
+    assert resolver.calls[0]["note"] == note
+
+
+def test_the_note_modal_declares_a_limit_below_the_card_clamp(
+    redis_client: redis.Redis, config: DispatcherConfig
+) -> None:
+    """The human-facing guard and the structural backstop must not converge.
+
+    Slack shows a counter and blocks submit at the input's ``max_length``. If it
+    equalled the verdict-line clamp the truncation branch would be unreachable
+    through the modal, so the two are asserted to be ordered rather than equal.
+    """
+
+    resolver = ScriptedResolver(ResolveOutcome(status_code=200, resolved_by="U_MANAGER"))
+    app, web_client = _build(config, redis_client, resolver)
+    handler = SocketModeHandler(app, app_token="xapp-test")
+
+    handler.handle(FakeSocketClient(), _note_click("env-lim", action_id=APPROVE_NOTE_ACTION_ID))
+    _drain(app)
+
+    element = web_client.views_open.call_args.kwargs["view"]["blocks"][0]["element"]
+    assert "max_length" in element, "the modal must declare the note limit to the human"
+    assert element["max_length"] > 0
+    assert element["max_length"] < _VERDICT_LINE_MAX

--- a/apps/dispatcher/tests/test_preflight.py
+++ b/apps/dispatcher/tests/test_preflight.py
@@ -23,15 +23,14 @@ one that ships.
 from __future__ import annotations
 
 import logging
-import socket
 import time
-from collections.abc import Iterator
-from contextlib import contextmanager
 
 import httpx
 import pytest
 from curie_dispatcher.config import DispatcherConfig
 from curie_dispatcher.preflight import ApiUnreachableError, check_api_reachable
+
+from .conftest import _black_hole_api
 
 API_URL = "http://curie-api:8000"
 
@@ -211,25 +210,6 @@ def test_the_loop_spends_its_whole_budget_with_production_backoff_ratios() -> No
         f"the error must report the time actually elapsed, not the configured "
         f"deadline; got {str(excinfo.value)!r}"
     )
-
-
-@contextmanager
-def _black_hole_api() -> Iterator[str]:
-    """A real port that completes the TCP handshake and then never answers.
-
-    The counterpart to `_refusing`: a refused connection fails instantly, so it
-    can never show a probe running past the deadline. This one hangs until some
-    timeout fires, which is exactly the case where an unbounded probe overshoots.
-    Nothing accepts the socket; the kernel's listen backlog completes the
-    handshake, so `connect` succeeds and the read blocks.
-    """
-    sock = socket.socket()
-    sock.bind(("127.0.0.1", 0))
-    sock.listen(1)
-    try:
-        yield f"http://127.0.0.1:{sock.getsockname()[1]}"
-    finally:
-        sock.close()
 
 
 def test_the_loop_does_not_probe_past_its_deadline() -> None:


### PR DESCRIPTION
Closes #1077

Slack gives a `view_submission` three seconds to be acked. The submit listener ran a card read, the resolve, and a card stamp to completion before `ack()`, on a Web client carrying the SDK's 30 second default and a resolver carrying 10 seconds. Worst case was about seventy seconds against a three second deadline, and the symptom was the approver being told their decision failed while the resolution had already landed.

The resolve cannot move after the ack: the ack body carries the refusal, and behind an open modal that is the only surface a claim-race loser can see. So this splits rather than reorders. `resolve_note_submission` takes no `web_client` at all, which makes "nothing calls Slack before the ack" structural rather than a matter of ordering discipline; `render_note_submission` does the read and the stamp afterwards.

## Acceptance criteria

| AC | Where |
|---|---|
| AC1 explicit Web client timeout | `app.py`, the single `WebClient(` construction |
| AC2 best-effort calls off the pre-ack path | `handlers.py` acks between the two halves; `resolve_note_submission` cannot call Slack by signature |
| AC3 resolver timeout inside the budget | all four httpx phases named, worst case 2.2s |
| AC4 note bounded at both ends | `max_length` on the modal input, unconditional clamp in `_verdict_line` |
| AC5 test covers slow and failing Slack calls | the ack is asserted while a blocked card read has not returned, plus a raising card read |

## Review notes

Reviewers found and this PR fixed three things worth naming, since each was the ticket's own bug reappearing:

- The first timeout left httpx's `pool` phase at its default. Phases are sequential, so the real worst case was 3.5s: over the deadline the ticket exists to fit inside. All four are now explicit.
- A same-actor conflict branch was added and then removed: the resolve endpoint's only 409 is `{"detail": ...}` with no `resolved_by`, so it could never fire. The tests had not caught it because the fixture hand-built a `ResolveOutcome`, asserting a shape the client never produces. Conflict tests now carry the real response and one drives the client itself.
- Two comments asserted bounds the code did not enforce. Both corrected; the httpx values cap inactivity per operation, not the request as a whole.

## Known gap, deliberately not fixed here

With five renders already slow, a sixth submission still queues behind Bolt's shared five-worker listener executor and misses the deadline. Reproduced by execution: five envelopes acked, the sixth blocked 3.01s with no ack. This is strictly better than before (worst-case worker hold drops from about 70s to about 5.5s) but not eliminated. Closing it needs post-ack work on a dedicated executor with a shutdown owner in `Supervisor`, which is a larger change than this ticket and was explicitly weighed and rejected during planning.

## Follow-ups worth issues

- The resolve endpoint does a live Slack user-group lookup on the hot path behind a 60 second cache, so a cold resolve can outlast any budget that fits three seconds. The dispatcher cannot fix this.
- `_refusal_text`'s pre-existing `Already resolved by` branch is dead for the same reason the removed branch was, and is left byte-identical.
- The approver note reaches the agent's resume turn uninterpolated and unescaped, and the settled card without mrkdwn escaping. Both pre-existing.
- The 2 second client timeout applies to every dispatcher Slack call, including the placeholder post. In Socket Mode the envelope is already acked before that runs, so a failure there drops the turn with no redelivery. Pre-existing shape, now likelier.

## Out-of-AC hunks

`apps/dispatcher/CLAUDE.md` gains one invariant bullet recording the ack-path ordering rule, matching the existing dedupe-ordering bullet. `test_preflight.py` shrinks because its loopback helper moved to `conftest.py` and is now shared rather than duplicated.

93 dispatcher tests pass, 71 cross-package worker tests pass, ruff, mypy, and the docs gate clean.
