### PR TITLE
Clarify ADR acceptance process

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -332,6 +332,12 @@ commands.
 
 Two different tools; do not conflate them.
 
+Draft ADRs may merge for discussion, but they cannot authorize implementation.
+Implementation may start only after the ADR is published as `Accepted` with
+explicit maintainer approval, and it is tracked in a linked GitHub issue and
+pull request. Follow [`docs/adr/AGENTS.md`](docs/adr/AGENTS.md) for the complete
+procedure.
+
 - Write an **ADR** (`docs/adr/`, see ADR-0001) only for a **cross-cutting
   architectural decision that closes the door on alternatives.** It is a choice
   about the *shape* of the system (a contract, a seam, a substrate, an invariant)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,11 +31,16 @@ snapshot of the current state.
 
 Workflow for non-trivial work:
 
-- **Write an ADR for the decision** before or alongside the work, numbered
-  sequentially in `docs/adr/`.
-- **Issues reference their ADR(s).** A GitHub issue that implements a decision
-  links the ADR, so an agent picking up the issue reads the decision's intent
-  first and builds to it.
+- **For an architectural decision that qualifies for an ADR under
+  [`AGENTS.md`](AGENTS.md), write a Draft ADR**, numbered sequentially in
+  `docs/adr/`. A Draft may merge for discussion but cannot authorize
+  implementation.
+- **Obtain explicit maintainer acceptance before implementation.** Acceptance
+  means the ADR is published with `Status: Accepted`.
+- **Issues reference their Accepted ADR(s).** A GitHub issue that implements a
+  decision links the ADR, so an agent picking up the issue reads the decision's
+  intent first and builds to it.
 - Division of labor: **ADRs are the "why + when"**, **issues are the "what + track
   the work"**, and **`ARCHITECTURE.md` is the "what talks to what."** Keep decision
-  rationale in the ADR, not duplicated across issues.
+  rationale in the ADR, not duplicated across issues. Follow
+  [`docs/adr/AGENTS.md`](docs/adr/AGENTS.md) for the complete procedure.

--- a/docs/adr/0030-proactive-within-episode-memory-agent.md
+++ b/docs/adr/0030-proactive-within-episode-memory-agent.md
@@ -2,7 +2,7 @@
 
 Date: 2026-07-14
 
-Status: Proposed
+Status: Draft
 
 Extends [ADR-0025](0025-memory-port-and-first-loader.md) (the memory port and its
 passive cross-session preamble) and [ADR-0003](0003-stateless-first-rehydrate-on-resume.md)
@@ -59,7 +59,7 @@ Terminal-Bench 2.0** and **+6.8pp on τ²-Bench** for a Sonnet-class action agen
 **Add a proactive memory agent as an optional, plug-and-play layer over the frozen
 ACI injection seam. It is a *within-episode* execution-state layer that composes
 with, and does not replace, ADR-0025's cross-session lessons and ADR-0003's
-resume.** Proposed; the validation gate below governs promotion to Accepted.
+resume.** Draft. The validation gate below informs maintainer acceptance.
 
 - **A separate memory agent, not a harness change.** The memory agent runs as its
   own process alongside the action-agent runner (our one-process-per-sandbox shape
@@ -93,15 +93,15 @@ resume.** Proposed; the validation gate below governs promotion to Accepted.
   is out of scope here and named as future work. This ADR lands the within-episode
   layer only.
 
-### Validation gate (before this moves to Accepted)
+### Validation gate for maintainer acceptance
 
-Per ADR-0001, evidence-driven. Proposed until a spike shows, on a real bundle
-driven through `local`/`cluster`: (1) the reminder actually lands as a steer at the
-next loop boundary via the existing ACI path with no harness modification; (2) an
-eval delta on a long-horizon case set attributable to the memory layer (graded by
-ADR-0022's trajectory graders or ADR-0042's verifier); and (3) a token and latency
-accounting for the second (memory-agent) model call, which the paper acknowledges
-but never benchmarks.
+Per ADR-0001, a maintainer considers evidence from a spike on a real bundle
+driven through `local`/`cluster` before accepting this Draft: (1) the reminder
+actually lands as a steer at the next loop boundary via the existing ACI path with
+no harness modification; (2) an eval delta on a long-horizon case set attributable
+to the memory layer (graded by ADR-0022's trajectory graders or ADR-0042's
+verifier); and (3) a token and latency accounting for the second (memory-agent)
+model call, which the paper acknowledges but never benchmarks.
 
 ## Alternatives considered
 

--- a/docs/adr/0040-adopt-acp-as-an-edge-projection.md
+++ b/docs/adr/0040-adopt-acp-as-an-edge-projection.md
@@ -2,7 +2,7 @@
 
 Date: 2026-07-16
 
-Status: Proposed
+Status: Draft
 
 ## Context
 

--- a/docs/adr/0044-workflow-controlled-agents-callable-substrate.md
+++ b/docs/adr/0044-workflow-controlled-agents-callable-substrate.md
@@ -2,7 +2,7 @@
 
 Date: 2026-07-16
 
-Status: Proposed
+Status: Draft
 
 This is a **decision, not code**: it settles whether, and how deeply, Curie
 supports *workflow-controlled* agents — developer-authored orchestration

--- a/docs/adr/0060-the-harness-is-a-declared-package.md
+++ b/docs/adr/0060-the-harness-is-a-declared-package.md
@@ -2,7 +2,7 @@
 
 Date: 2026-07-21
 
-Status: Proposed
+Status: Accepted
 
 **Supersedes [ADR-0011](0011-opencode-second-harness.md)** ("OpenCode as the
 second harness behind the ACI"). Together with

--- a/docs/adr/0061-out-of-process-harness-boundary.md
+++ b/docs/adr/0061-out-of-process-harness-boundary.md
@@ -2,7 +2,7 @@
 
 Date: 2026-07-21
 
-Status: Proposed (gated on a spike, see Decision 5)
+Status: Draft
 
 Together with [ADR-0060](0060-the-harness-is-a-declared-package.md) this replaces
 the Proposed [ADR-0031](0031-harness-neutral-runner-seams.md). 0059 decides

--- a/docs/adr/0062-harness-conformance-has-teeth.md
+++ b/docs/adr/0062-harness-conformance-has-teeth.md
@@ -2,7 +2,7 @@
 
 Date: 2026-07-21
 
-Status: Proposed
+Status: Draft
 
 Follows [ADR-0060](0060-the-harness-is-a-declared-package.md) (a harness is a
 declared package) and [ADR-0061](0061-out-of-process-harness-boundary.md) (the

--- a/docs/adr/0075-the-agent-proxy-credential-and-egress-boundary.md
+++ b/docs/adr/0075-the-agent-proxy-credential-and-egress-boundary.md
@@ -184,7 +184,7 @@ its own decision when it lands:
 ## Status note
 
 Draft. Once Accepted, this ADR supersedes ADR-0032, and ADR-0032's status line is
-updated to point here. It is Draft, not Proposed, because the substrate and
+updated to point here. It remains Draft because the substrate and
 TLS-termination decisions above are unresolved and the shape of the credential
 injection contract is not yet pinned; it records the direction both reviews
 converged on so the future ADRs build to it.

--- a/docs/adr/0079-inbound-triggers-as-a-new-event-kind.md
+++ b/docs/adr/0079-inbound-triggers-as-a-new-event-kind.md
@@ -1,14 +1,14 @@
 # 79. Inbound triggers as a new event kind, ingested by the API
 
 Date: 2026-07-10
-Status: Proposed
+Status: Accepted
 
 Proposes how "triggers beyond chat" (issue
 [#29](https://github.com/curie-eng/curie/issues/29)) enter the system: which
 service accepts a non-Slack trigger, and how a triggered turn produces output
-when there is no Slack placeholder to edit. This ADR is **Proposed**, not
-Accepted — it exists to get a decision from the worker/kernel owner before any
-code lands, because the mechanism touches the sacred kernel/dispatcher seam
+when there is no Slack placeholder to edit. This ADR is **Accepted**; the
+worker/kernel owner's decision authorizes the remaining implementation because
+the mechanism touches the sacred kernel/dispatcher seam
 (`apps/worker/CLAUDE.md`) and the hand-mirrored queue payload
 (`docs/roadmap.md` §2).
 
@@ -39,7 +39,7 @@ guessed in a PR:
    "post-instead-of-edit" output path for placeholder-less events (a kernel
    change).
 
-## Decision (proposed)
+## Decision
 
 1. **The API accepts inbound triggers.** Add `POST /hooks/{agent}/{hook}` to
    `apps/api`, reusing the existing HMAC verification pattern (per-agent hook
@@ -64,9 +64,8 @@ guessed in a PR:
    the new field by hand in the dispatcher (Python) and CLI (Rust).
 
 Decisions (2) and (3) are **kernel/contract changes owned by the worker
-single-owner** (Yichen); this ADR is the request to accept or amend the shape
-before that work starts. Decision (1) is API-lane and can proceed once the event
-shape in (2) is agreed.
+single-owner** (Yichen); this ADR records the accepted shape for that work.
+Decision (1) is API-lane and can proceed under the accepted event shape in (2).
 
 ## Alternatives considered
 
@@ -86,5 +85,5 @@ shape in (2) is agreed.
 - The kernel gains a placeholder-less output path, exercised by a provoking
   test alongside its existing invariants.
 - The turn payload becomes a first-class contract, retiring a known drift risk.
-- Until this is Accepted and the kernel side lands, the webhook cannot complete a
+- Until the kernel side lands, the webhook cannot complete a
   turn end to end, so no partial webhook code should merge.

--- a/docs/adr/0085-acceptance-not-implementation-authorizes-an-adr.md
+++ b/docs/adr/0085-acceptance-not-implementation-authorizes-an-adr.md
@@ -1,0 +1,83 @@
+# 85. Acceptance, not implementation, authorizes an ADR
+
+Date: 2026-07-29
+
+Status: Accepted
+
+**Amends [ADR 0045](0045-the-status-line-is-the-mutable-part-of-an-immutable-adr.md).**
+This ADR replaces only these two clauses in ADR 0045:
+
+1. Decision clause 1 at lines 60 through 62, which permits a status correction
+   when a Proposed decision has shipped.
+2. The Decision status evidence paragraph at lines 95 through 100, which makes
+   implementation evidence the authority for promotion to Accepted.
+
+Every other rule in ADR 0045 remains in force.
+
+## Context
+
+ADR 0045 makes implementation evidence the authority for acceptance. That
+couples two separate decisions: whether maintainers approve an architectural
+direction and whether its implementation is complete.
+
+The distinction matters as the repository becomes more open. Contributors need
+to merge Draft ADRs for visible discussion without creating an authorization to
+build them. Maintainers also need to accept a direction before implementation
+starts so issues and pull requests can work from an approved architectural
+constraint.
+
+Implementation evidence remains useful for auditing the corpus. It cannot be
+the decision authority because code may exist before review, may implement only
+part of a decision, or may have landed without awareness of the ADR.
+
+## Decision
+
+The active authoring statuses are `Draft` and `Accepted`. `Superseded` remains
+the terminal historical status.
+
+1. A `Draft` ADR may merge for discussion. It remains open for revision and
+   cannot authorize implementation.
+2. An ADR becomes `Accepted` only when its Accepted status is published with
+   explicit maintainer approval.
+3. Implementation may start only after acceptance. The implementing GitHub
+   issue and pull request link the Accepted ADR.
+4. Existing implementation cannot retroactively accept a Draft. Partial or
+   complete implementation is audit context, not acceptance authority.
+5. Acceptance approves the decision. It does not claim that implementation is
+   started or complete. Issues and pull requests carry that state.
+
+This amendment preserves the history rules in ADR 0045:
+
+1. Once an ADR is Accepted, its context, decision, alternatives, consequences,
+   evidence, and citations remain immutable.
+2. An Accepted ADR may change only through its status line, a superseded by back
+   link, or a same referent pointer repair. The status line may change to
+   `Superseded` only when the decision has been replaced in whole.
+3. Partial supersession keeps the older ADR `Accepted` and adds the precise back
+   link required by ADR 0045.
+4. A changed decision requires a new ADR. The new ADR records the supersession,
+   and the older reasoning is never rewritten.
+
+## Consequences
+
+1. A merged Draft is a discussion artifact with no implementation authority.
+2. Maintainer approval is visible before implementation begins.
+3. Decision status and delivery status no longer stand in for each other.
+4. Implementation evidence still supports corpus audits but never changes
+   status by itself.
+5. ADRs 0060 and 0079 become Accepted through explicit maintainer
+   approval in this migration. Their existing implementation evidence does not
+   create a precedent for future acceptance.
+
+## Alternatives considered
+
+1. **Keep implementation evidence as the acceptance authority.** Rejected
+   because it accepts decisions after code exists and lets implementation bypass
+   architectural approval.
+2. **Keep Draft ADRs out of the repository.** Rejected because visible review
+   and open discussion benefit from merged Drafts.
+3. **Allow work to begin from a merged Draft.** Rejected because discussion
+   would become implicit authorization and rejected directions could acquire
+   implementation momentum.
+4. **Retain Proposed as a third active status.** Rejected because Draft already
+   represents every architectural decision that lacks maintainer acceptance.

--- a/docs/adr/AGENTS.md
+++ b/docs/adr/AGENTS.md
@@ -1,0 +1,30 @@
+# ADR contributor procedure
+
+[ADR 0085](0085-acceptance-not-implementation-authorizes-an-adr.md) defines
+when an ADR authorizes implementation. [ADR 0045](0045-the-status-line-is-the-mutable-part-of-an-immutable-adr.md)
+defines how Accepted ADR history is preserved.
+
+## Status vocabulary
+
+1. `Draft` is open for discussion and revision. It may merge, but it does not
+   authorize implementation.
+2. `Accepted` means the decision is published with an Accepted status and has
+   explicit maintainer approval. Only this status authorizes implementation.
+3. `Superseded` is the terminal historical status for an Accepted decision that
+   a later ADR replaces in whole.
+
+## Procedure
+
+1. Create the ADR as `Draft` with the next unused four digit number. Record the
+   context, decision, consequences, and rejected alternatives.
+2. Merge a Draft when publishing it for discussion is useful. Do not begin
+   implementation from a merged Draft.
+3. Obtain explicit maintainer approval, then publish the status as `Accepted`.
+   Existing code and implementation evidence cannot retroactively accept a
+   Draft.
+4. Begin implementation only after acceptance. Track the work in a linked
+   GitHub issue and pull request.
+5. Revise a Draft through review. Once Accepted, preserve its body. Apply only
+   the status, back link, pointer repair, and supersession rules in ADR 0045.
+6. Run `bash scripts/check-docs.sh` after any ADR change. Commit the regenerated
+   `docs/adr/README.md`; never edit that index by hand.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -59,7 +59,7 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0027 | [A thin broker port at the non-sacred seams; defer the second broker](0027-thin-broker-port-defer-second-broker.md) | Accepted |
 | 0028 | [The sandbox substrate is a resilience-only fallback, not a product swap axis](0028-substrate-is-resilience-fallback-not-product-swap-axis.md) | Accepted |
 | 0029 | [The conversation-history port and its first loader: transcript replay over the durable state store](0029-conversation-history-port-and-first-loader.md) | Accepted |
-| 0030 | [A proactive within-episode memory agent over the frozen ACI injection seam](0030-proactive-within-episode-memory-agent.md) | Proposed |
+| 0030 | [A proactive within-episode memory agent over the frozen ACI injection seam](0030-proactive-within-episode-memory-agent.md) | Draft |
 | 0031 | [Harness-neutral runner seams for the second harness](0031-harness-neutral-runner-seams.md) | Superseded by [ADR-0060](0060-the-harness-is-a-declared-package.md) and [ADR-0061](0061-out-of-process-harness-boundary.md) (decisions 2/3/5 become manifest fields in 0060; decision 4 carries forward unchanged; decision 1 becomes 0061's recorded fallback) |
 | 0032 | [Explicit named-provider egress, resolved at install](0032-explicit-provider-egress.md) | Accepted |
 | 0033 | [Scoped, least-privilege sandbox state token](0033-scoped-sandbox-state-token.md) | Accepted |
@@ -69,11 +69,11 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0037 | [Opt-in binding hook and Pareto model routing](0037-opt-in-binding-hook-and-pareto-model-routing.md) | Accepted |
 | 0038 | [An observability CLI helper for the agent-dev loop](0038-observability-cli-helper-for-the-agent-dev-loop.md) | Accepted |
 | 0039 | [Bounded delivery: a delivery cap and a dead-letter graveyard](0039-bounded-delivery-and-a-dead-letter-graveyard.md) | Accepted |
-| 0040 | [Adopt the Agent Client Protocol as an edge projection](0040-adopt-acp-as-an-edge-projection.md) | Proposed |
+| 0040 | [Adopt the Agent Client Protocol as an edge projection](0040-adopt-acp-as-an-edge-projection.md) | Draft |
 | 0041 | [Every verb is answered at every tier](0041-every-verb-is-answered-at-every-tier.md) | Accepted |
 | 0042 | [Adopt LLM-as-a-Verifier: a continuous-score semantic grader and a live progress signal](0042-llm-as-a-verifier-grader-and-progress-signal.md) | Accepted |
 | 0043 | [The interface catalog is generated from declared front-matter and gated in CI](0043-generated-interface-catalog-and-doc-lint-gate.md) | Accepted |
-| 0044 | [Workflow-controlled agents run on Curie as a callable substrate first, a unified plane only on demand](0044-workflow-controlled-agents-callable-substrate.md) | Proposed |
+| 0044 | [Workflow-controlled agents run on Curie as a callable substrate first, a unified plane only on demand](0044-workflow-controlled-agents-callable-substrate.md) | Draft |
 | 0045 | [The status line is the mutable part of an immutable ADR](0045-the-status-line-is-the-mutable-part-of-an-immutable-adr.md) | Accepted |
 | 0046 | [Converged approval gates: durable provenance, loud route resolution, and observe-only resume reconciliation](0046-converged-approval-gates-and-durable-provenance.md) | Accepted |
 | 0047 | [ADR-0047: Canonical env-var names for the API base URL and model credential](0047-canonical-env-var-names.md) | Accepted |
@@ -89,9 +89,9 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0057 | [`cluster deploy` self-plumbs a port-forward so the generated key stays off the cleartext proxy](0057-cluster-deploy-self-plumbs-port-forward-for-generated-key.md) | Accepted |
 | 0058 | [A pushed tag is not release authority: ancestry, checks, and an approval environment gate publication](0058-tag-push-is-not-release-authority.md) | Accepted |
 | 0059 | [The sandbox is a bounded resource envelope; capacity is a tenant boundary](0059-sandbox-is-a-bounded-resource-envelope.md) | Accepted |
-| 0060 | [The harness is a declared package, not a class](0060-the-harness-is-a-declared-package.md) | Proposed |
-| 0061 | [The harness boundary is an out-of-process adapter, wire-compatible with Omnigent](0061-out-of-process-harness-boundary.md) | Proposed (gated on a spike, see Decision 5) |
-| 0062 | [Harness conformance has teeth](0062-harness-conformance-has-teeth.md) | Proposed |
+| 0060 | [The harness is a declared package, not a class](0060-the-harness-is-a-declared-package.md) | Accepted |
+| 0061 | [The harness boundary is an out-of-process adapter, wire-compatible with Omnigent](0061-out-of-process-harness-boundary.md) | Draft |
+| 0062 | [Harness conformance has teeth](0062-harness-conformance-has-teeth.md) | Draft |
 | 0063 | [Message-driven approval reply surface](0063-message-driven-approval-reply-surface.md) | Accepted |
 | 0064 | [Fail-forward cluster teardown](0064-fail-forward-cluster-teardown.md) | Accepted |
 | 0065 | [Tag protection, not the workflow gate, binds a write actor](0065-tag-protection-not-the-workflow-gate-binds-a-write-actor.md) | Accepted |
@@ -108,9 +108,10 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0076 | [A closed, versioned attribute schema for the runner's OTel span stream](0076-closed-typed-telemetry-attribute-schema.md) | Accepted |
 | 0077 | [Skill-tier durable approvals stay unavailable, reported not absent](0077-skill-tier-durable-approvals-stay-unavailable.md) | Accepted |
 | 0078 | [Route message-driven approval cards through the connected Slack transport](0078-approval-cards-over-connected-transport.md) | Accepted |
-| 0079 | [Inbound triggers as a new event kind, ingested by the API](0079-inbound-triggers-as-a-new-event-kind.md) | Proposed |
+| 0079 | [Inbound triggers as a new event kind, ingested by the API](0079-inbound-triggers-as-a-new-event-kind.md) | Accepted |
 | 0080 | [Rename the project to Curie](0080-rename-to-curie.md) | Accepted |
 | 0081 | [A nightly graded parity ladder verifies the real-model promise CI cannot](0081-nightly-graded-parity-ladder.md) | Accepted |
 | 0082 | [Connected-transport approval cards ride a real CLI-posted placeholder](0082-connected-transport-approval-cards-via-a-real-placeholder.md) | Accepted |
 | 0084 | [Publish a verification contract for agents driving Curie](0084-publish-a-verification-contract-for-agents-driving-curie.md) | Accepted |
+| 0085 | [Acceptance, not implementation, authorizes an ADR](0085-acceptance-not-implementation-authorizes-an-adr.md) | Accepted |
 <!-- END GENERATED: adr-index -->


### PR DESCRIPTION
Defines `Draft` as a mergeable discussion state that cannot authorize implementation, and `Accepted` as the explicit maintainer approval gate.

Adds the local ADR contributor procedure and ADR 0085, then normalizes the existing corpus to six Draft ADRs, 76 Accepted ADRs, and two Superseded ADRs.

This separates architectural approval from implementation progress, which remains tracked in linked issues and pull requests.

Validation: `bash scripts/check-docs.sh`, `uv run ruff check .`, and `uv run mypy` pass.