### PR TITLE
Authenticate the git-flow clone so a private repo can deploy (#1058)

### DIFF
--- a/apps/api/src/curie_api/config.py
+++ b/apps/api/src/curie_api/config.py
@@ -90,7 +90,10 @@ class Settings(BaseSettings):
     github_webhook_secret: str = "dev-webhook-secret"
     dev_branch: str = "dev"
     prod_branch: str = "main"
-    # Outbound GitHub commit-status API for the eval PR check (K1).
+    # Outbound GitHub credential. Used for the eval PR check's commit-status
+    # API (K1) AND to authenticate the git-flow bundle clone, without which
+    # a private repository cannot deploy at all (#1058). Sent as a scoped
+    # http.extraheader, never embedded in the clone URL.
     github_api_url: str = "https://api.github.com"
     github_token: str = ""
     # Upper bound on the GitHub webhook request body, enforced before the body is

--- a/apps/api/src/curie_api/gitflow.py
+++ b/apps/api/src/curie_api/gitflow.py
@@ -8,6 +8,7 @@ only git-protocol access to the remote (local bare repos in tests) and never the
 GitHub API.
 """
 
+import base64
 import hashlib
 import hmac
 import os
@@ -15,6 +16,7 @@ import re
 import shutil
 import subprocess
 import tempfile
+from urllib.parse import urlsplit
 
 from aci_protocol import EvalJob
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -70,6 +72,55 @@ def environment_for_ref(ref: str | None, settings: Settings) -> Environment | No
     return None
 
 
+def _clone_credential_env(clone_url: str, settings: Settings) -> dict[str, str]:
+    """Git config env that authenticates the clone, or empty if not applicable.
+
+    Private repositories are the norm for a bundle -- it names internal hosts and
+    services -- so an unauthenticated clone makes git-flow unusable for most real
+    agents (#1058).
+
+    The credential travels as git config supplied through ``GIT_CONFIG_*``
+    environment variables rather than embedded in the URL. That keeps it out of
+    ``argv`` (so it cannot be read from ``ps`` or leak through a subprocess error
+    that echoes the command) and out of the cloned repo's ``.git/config``, which
+    URL-embedded credentials are persisted into.
+
+    The header is scoped to the clone URL's own host, so a webhook naming some
+    other host cannot make us send the token there.
+    """
+
+    token = settings.github_token
+    if not token or not clone_url.startswith("https://"):
+        return {}
+    host = urlsplit(clone_url).netloc
+    if not host:
+        return {}
+    basic = base64.b64encode(f"x-access-token:{token}".encode()).decode()
+    return {
+        "GIT_CONFIG_COUNT": "1",
+        "GIT_CONFIG_KEY_0": f"http.https://{host}/.extraheader",
+        "GIT_CONFIG_VALUE_0": f"Authorization: Basic {basic}",
+    }
+
+
+def _git_failure_detail(exc: BaseException) -> str:
+    """git's stderr, which says *why* -- 'Repository not found' vs a timeout.
+
+    The old message interpolated the exception, whose repr is the argv and an
+    exit code: 'returned non-zero exit status 128' told an operator nothing, and
+    the actual reason was discarded despite being captured. argv is credential-
+    free by construction here (see ``_clone_credential_env``), but the tail is
+    bounded anyway so a hostile remote cannot flood the response.
+    """
+
+    stderr = getattr(exc, "stderr", None)
+    if isinstance(stderr, bytes):
+        stderr = stderr.decode("utf-8", "replace")
+    if isinstance(stderr, str) and stderr.strip():
+        return stderr.strip()[-400:]
+    return str(exc)[:200]
+
+
 def clone_and_archive(clone_url: str, sha: str, settings: Settings) -> bytes:
     """Mirror-clone the repo and return a tar of the tree at ``sha``.
 
@@ -87,6 +138,7 @@ def clone_and_archive(clone_url: str, sha: str, settings: Settings) -> bytes:
         **os.environ,
         "GIT_ALLOW_PROTOCOL": "file:https:http",
         "GIT_TERMINAL_PROMPT": "0",
+        **_clone_credential_env(clone_url, settings),
     }
     try:
         try:
@@ -105,7 +157,9 @@ def clone_and_archive(clone_url: str, sha: str, settings: Settings) -> bytes:
                 timeout=120,
             )
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
-            raise GitFlowError(f"could not archive {sha[:12]}: {exc}") from exc
+            raise GitFlowError(
+                f"could not archive {sha[:12]}: {_git_failure_detail(exc)}"
+            ) from exc
         return archived.stdout
     finally:
         shutil.rmtree(tmp, ignore_errors=True)

--- a/apps/api/tests/test_gitflow_unit.py
+++ b/apps/api/tests/test_gitflow_unit.py
@@ -1,5 +1,6 @@
 """Unit tests for git-flow signature, ref mapping, and clone-url guarding."""
 
+import base64
 import hashlib
 import hmac
 import subprocess
@@ -122,3 +123,61 @@ def test_clone_and_archive_accepts_valid_hex_and_inserts_dash_dash(
     assert "--" in archive_argv, archive_argv
     dash_index = archive_argv.index("--")
     assert archive_argv[dash_index + 1] == good_sha, archive_argv
+
+
+def test_clone_authenticates_a_private_https_remote_without_touching_argv() -> None:
+    # A private repo is the normal case for a bundle -- it names internal hosts
+    # and services -- so an unauthenticated clone made git-flow unusable (#1058).
+    # The credential must ride in git config env, never in argv: argv is visible
+    # in `ps` and is echoed verbatim by CalledProcessError.
+    settings = Settings(github_token="ghs-secret-token")
+    url = "https://github.com/acme/private-bundle.git"
+    with mock.patch("curie_api.gitflow.subprocess.run") as run:
+        run.return_value = _completed(b"tar-bytes")
+        clone_and_archive(url, _VALID_SHA1, settings)
+
+    clone_call = run.call_args_list[0]
+    argv = clone_call.args[0]
+    env = clone_call.kwargs["env"]
+
+    assert "ghs-secret-token" not in " ".join(argv)
+    assert url in argv  # the URL itself is unmodified -- no embedded credential
+    assert env["GIT_CONFIG_COUNT"] == "1"
+    # Scoped to this host, so a webhook naming another remote cannot harvest it.
+    assert env["GIT_CONFIG_KEY_0"] == "http.https://github.com/.extraheader"
+    assert env["GIT_CONFIG_VALUE_0"].startswith("Authorization: Basic ")
+    decoded = base64.b64decode(env["GIT_CONFIG_VALUE_0"].split()[-1]).decode()
+    assert decoded == "x-access-token:ghs-secret-token"
+
+
+def test_clone_sends_no_credential_when_none_is_configured() -> None:
+    settings = Settings(github_token="")
+    with mock.patch("curie_api.gitflow.subprocess.run") as run:
+        run.return_value = _completed(b"tar-bytes")
+        clone_and_archive("https://github.com/acme/public.git", _VALID_SHA1, settings)
+    env = run.call_args_list[0].kwargs["env"]
+    assert "GIT_CONFIG_COUNT" not in env
+
+
+def test_clone_does_not_send_the_credential_over_plain_http() -> None:
+    # http:// is in the transport allowlist for local/test remotes; a bearer
+    # token must not be handed to a cleartext endpoint.
+    settings = Settings(github_token="ghs-secret-token")
+    with mock.patch("curie_api.gitflow.subprocess.run") as run:
+        run.return_value = _completed(b"tar-bytes")
+        clone_and_archive("http://insecure.example/repo.git", _VALID_SHA1, settings)
+    assert "GIT_CONFIG_COUNT" not in run.call_args_list[0].kwargs["env"]
+
+
+def test_clone_failure_reports_git_stderr_not_the_exit_code() -> None:
+    # The old message interpolated the exception, so an operator saw only
+    # "returned non-zero exit status 128" while the actual reason -- captured in
+    # stderr -- was discarded. That cost real debugging time on a private repo.
+    settings = Settings()
+    failure = subprocess.CalledProcessError(
+        128, ["git", "clone"], stderr=b"remote: Repository not found.\nfatal: could not read\n"
+    )
+    with mock.patch("curie_api.gitflow.subprocess.run", side_effect=failure):
+        with pytest.raises(GitFlowError) as err:
+            clone_and_archive(_ALLOWED_URL, _VALID_SHA1, settings)
+    assert "Repository not found" in str(err.value)


### PR DESCRIPTION
Fixes #1058. Refs #1062.

git-flow rejected every push from a private repository — the bundle clone carried no credentials at all, so ADR-0014 worked only on public repos. Every real bundle is private.

```
git.archive_failed: git clone --mirror https://github.com/<org>/<repo>.git
returned non-zero exit status 128
```

## Approach

The credential rides in **git config via `GIT_CONFIG_*` env vars**, not in the clone URL. A URL-embedded credential lands in `argv` — readable from `ps`, and echoed by any subprocess error that prints the command — and git persists it into the mirror's `.git/config`.

Scoped to the clone URL's own host, so a webhook naming another remote can't harvest the token. Withheld entirely over plain `http://`, which is in the transport allowlist for local test remotes and must never receive a bearer token.

## Also: the error message

The old one interpolated the exception, so you got `returned non-zero exit status 128` while git's actual explanation — `remote: Repository not found.` — was captured and thrown away. That discarded string is exactly what identifies this bug. Now surfaced, bounded to 400 chars.

## Verification

```
uv run pytest apps/api/tests/test_gitflow_unit.py -q   → 26 passed
uv run ruff check .                                     → clean
uv run mypy                                             → 162 files, no issues
```

Wider suite is unchanged: `36 failed / 200 errors` both with and without this branch (asyncpg connection errors — the dev stack isn't up). Delta is `196 → 200 passed`, exactly the four new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)