### PR TITLE
Log a rejected webhook push instead of failing silently (#1066)

### DIFF
--- a/apps/api/src/curie_api/routers/github.py
+++ b/apps/api/src/curie_api/routers/github.py
@@ -6,6 +6,7 @@ push to the prod branch promotes; other events are acknowledged and ignored.
 """
 
 import json
+import logging
 
 from fastapi import APIRouter, Header, HTTPException, Request, status
 
@@ -13,6 +14,8 @@ from ..config import get_settings
 from ..deps import EvalQueueDep, SessionDep, StoreDep
 from ..gitflow import process_push, verify_signature
 from ..schemas import WebhookResult
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/github", tags=["github"])
 
@@ -82,4 +85,36 @@ async def github_webhook(
             status.HTTP_400_BAD_REQUEST, "webhook body is not valid JSON"
         ) from exc
 
-    return await process_push(session, store, settings, eval_queue, payload)
+    result = await process_push(session, store, settings, eval_queue, payload)
+    _log_outcome(result, payload)
+    return result
+
+
+def _log_outcome(result: WebhookResult, payload: dict[str, object]) -> None:
+    """Log a rejected push loudly. A 200 is not evidence that anything happened.
+
+    A rejected push is still acknowledged with 200, because GitHub retries and
+    redelivers on a non-2xx and the push is not going to succeed on a retry. The
+    cost is that every dashboard reports success: GitHub shows a green delivery,
+    the access log shows "POST /github/webhook 200 OK", and no agent, version, or
+    deployment appears. The reason exists only in the response body, which
+    nothing surfaces.
+
+    That combination made a broken deploy indistinguishable from a working one
+    until someone thought to open the delivery payload in GitHub's UI. Logging
+    the rejection is what makes it findable from the platform side (#1066).
+    """
+
+    if result.status != "rejected":
+        return
+    repo = payload.get("repository")
+    full_name = repo.get("full_name") if isinstance(repo, dict) else None
+    codes = [e.get("code", "?") for e in (result.errors or [])]
+    logger.warning(
+        "github webhook rejected push: repo=%s ref=%s sha=%s codes=%s errors=%s",
+        full_name,
+        payload.get("ref"),
+        str(payload.get("after"))[:12],
+        ",".join(codes) or "none",
+        result.errors,
+    )

--- a/apps/api/tests/test_gitflow_unit.py
+++ b/apps/api/tests/test_gitflow_unit.py
@@ -115,11 +115,7 @@ def test_clone_and_archive_accepts_valid_hex_and_inserts_dash_dash(
     assert result == b"tar-bytes"
 
     # Locate the `git archive` invocation among the subprocess calls.
-    archive_argv = next(
-        call.args[0]
-        for call in run.call_args_list
-        if "archive" in call.args[0]
-    )
+    archive_argv = next(call.args[0] for call in run.call_args_list if "archive" in call.args[0])
     assert "--" in archive_argv, archive_argv
     dash_index = archive_argv.index("--")
     assert archive_argv[dash_index + 1] == good_sha, archive_argv
@@ -181,3 +177,37 @@ def test_clone_failure_reports_git_stderr_not_the_exit_code() -> None:
         with pytest.raises(GitFlowError) as err:
             clone_and_archive(_ALLOWED_URL, _VALID_SHA1, settings)
     assert "Repository not found" in str(err.value)
+
+
+def test_rejected_push_is_logged_loudly() -> None:
+    # A rejected push still returns 200 -- GitHub would retry a non-2xx and the
+    # push will not succeed on a retry. The cost is that every dashboard reports
+    # success while nothing was deployed, so the platform must say so itself.
+    from curie_api.routers.github import _log_outcome
+    from curie_api.schemas import WebhookResult
+
+    result = WebhookResult(
+        status="rejected",
+        errors=[{"code": "git.archive_failed", "message": "Repository not found"}],
+    )
+    payload = {
+        "ref": "refs/heads/dev",
+        "after": _VALID_SHA1,
+        "repository": {"full_name": "acme/private-bundle"},
+    }
+    with mock.patch("curie_api.routers.github.logger") as log:
+        _log_outcome(result, payload)
+    log.warning.assert_called_once()
+    rendered = log.warning.call_args.args[0] % log.warning.call_args.args[1:]
+    assert "acme/private-bundle" in rendered
+    assert "git.archive_failed" in rendered
+
+
+def test_successful_push_does_not_warn() -> None:
+    from curie_api.routers.github import _log_outcome
+    from curie_api.schemas import WebhookResult
+
+    with mock.patch("curie_api.routers.github.logger") as log:
+        _log_outcome(WebhookResult(status="deployed"), {})
+        _log_outcome(WebhookResult(status="ignored"), {})
+    log.warning.assert_not_called()


### PR DESCRIPTION
Fixes #1066. Refs #1062.

## The problem

A rejected push returns **200** and logs nothing. Every signal says success:

| Where you'd look | What it showed |
|---|---|
| GitHub → Recent Deliveries | ✅ green, 200 |
| API access log | `POST /github/webhook 200 OK` |
| `curie cluster versions` | no new version |
| Anywhere else | nothing |

The reason lived only in the response body, which nothing surfaces:

```json
{"status":"rejected","errors":[{"code":"git.archive_failed","message":"..."}]}
```

Finding that required guessing that a green 200 might not mean success, then opening the delivery payload in GitHub's UI.

## The fix

Keep the 200 — that part is correct. GitHub retries a non-2xx, and a rejected push won't succeed on a retry. What changes is that the platform now says so itself:

```
WARNING github webhook rejected push: repo=acme/private-bundle ref=refs/heads/dev
        sha=5d99f5f8e0cf codes=git.archive_failed errors=[...]
```

## Verification

```
uv run pytest apps/api/tests/test_gitflow_unit.py -q  → 24 passed
uv run ruff check . / uv run mypy                      → clean
```

Two tests: a rejection warns with repo and error code in the message; `deployed` and `ignored` do not warn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)