### PR TITLE
skill check: explain a remote server's red instead of implying a defect (#1093)

### DIFF
--- a/runner/src/curie_runner/check.py
+++ b/runner/src/curie_runner/check.py
@@ -59,6 +59,23 @@ _EXIT_CODES = {"green": 0, "red": 1, "invalid_bundle": 2}
 _HEADER_VAR_RE = re.compile(r"\$\{([^}]+)\}")
 
 
+def _remote_advisory(name: str, cred_vars: list[str]) -> str:
+    # A remote (``url``) server is unreachable by construction here: the check
+    # container runs with ``--network none`` so a bundle cannot pass by phoning
+    # home. That makes a red for a remote server ambiguous -- it may mean the
+    # declaration is broken, or simply that the offline contract did its job --
+    # and previously nothing said which (#1093).
+    suffix = ""
+    if cred_vars:
+        suffix = " " + " ".join(f"--secret {var}" for var in cred_vars)
+    return (
+        f"remote server {name} cannot be reached offline; this check runs with "
+        "no network on purpose, so a red here is expected and is NOT evidence "
+        "the bundle is broken -- run `curie skill up"
+        f"{suffix}` for the real end-to-end test"
+    )
+
+
 def _authed_advisory(name: str, cred_vars: list[str]) -> str:
     # ``--secret`` forwards an environment-variable NAME, not the server name, so
     # name the real credential var(s) when we could extract them; otherwise fall
@@ -79,7 +96,7 @@ def _authed_advisory(name: str, cred_vars: list[str]) -> str:
 # Declared-server extraction (bundle intent)
 # --------------------------------------------------------------------------- #
 def extract_declared(plugin_dir: str) -> list[dict[str, Any]]:
-    """Parse declared MCP servers into ``{name, source, form, authed, cred_vars}`` rows.
+    """Parse declared MCP servers into ``{name, source, form, authed, cred_vars, remote}`` rows.
 
     Covers all three declaration forms (plan Section 3): a ``plugin.json``
     ``mcpServers`` object (``inline``), a ``mcpServers`` string pointer resolved
@@ -101,7 +118,12 @@ def extract_declared(plugin_dir: str) -> list[dict[str, Any]]:
     seen: set[str] = set()
 
     def _add(
-        name: str, source: str, form: str, authed: bool, cred_vars: list[str]
+        name: str,
+        source: str,
+        form: str,
+        authed: bool,
+        cred_vars: list[str],
+        remote: bool = False,
     ) -> None:
         if name not in seen:
             declared.append(
@@ -110,6 +132,7 @@ def extract_declared(plugin_dir: str) -> list[dict[str, Any]]:
                     "source": source,
                     "form": form,
                     "authed": authed,
+                    "remote": remote,
                     "cred_vars": cred_vars,
                 }
             )
@@ -121,7 +144,14 @@ def extract_declared(plugin_dir: str) -> list[dict[str, Any]]:
 
     if isinstance(mcp, dict):
         for name, server in mcp.items():
-            _add(str(name), "plugin.json", "inline", _is_authed(server), _cred_vars(server))
+            _add(
+                str(name),
+                "plugin.json",
+                "inline",
+                _is_authed(server),
+                _cred_vars(server),
+                _is_remote(server),
+            )
     elif isinstance(mcp, str):
         pointed = _servers_map(_read_json(root / mcp))
         if pointed:
@@ -132,6 +162,7 @@ def extract_declared(plugin_dir: str) -> list[dict[str, Any]]:
                     "string_pointer",
                     _is_authed(server),
                     _cred_vars(server),
+                    _is_remote(server),
                 )
         else:
             # Pointed file missing/unparseable: the intent (a string-pointer
@@ -143,7 +174,14 @@ def extract_declared(plugin_dir: str) -> list[dict[str, Any]]:
 
     bare = _servers_map(_read_json(root / ".mcp.json"))
     for name, server in bare.items():
-        _add(str(name), ".mcp.json", "bare_file", _is_authed(server), _cred_vars(server))
+        _add(
+            str(name),
+            ".mcp.json",
+            "bare_file",
+            _is_authed(server),
+            _cred_vars(server),
+            _is_remote(server),
+        )
 
     return declared
 
@@ -154,6 +192,18 @@ def _servers_map(payload: Any) -> dict[str, Any]:
         if isinstance(servers, dict):
             return servers
     return {}
+
+
+def _is_remote(server: Any) -> bool:
+    """True for a server the check can never reach: it is declared by ``url``.
+
+    The check container runs with ``--network none`` (a bundle must not be able
+    to pass by phoning home), so a remote server cannot connect here no matter
+    how it is configured. Recording it lets the report explain the red instead
+    of leaving it indistinguishable from a genuine bundle defect.
+    """
+
+    return isinstance(server, dict) and bool(server.get("url"))
 
 
 def _is_authed(server: Any) -> bool:
@@ -190,16 +240,25 @@ def _cred_vars(server: Any) -> list[str]:
     env = server.get("env")
     if isinstance(env, dict) and env:
         return [str(key) for key in env]
+    found: list[str] = []
     headers = server.get("headers")
     if isinstance(headers, dict) and headers:
-        found: list[str] = []
         for value in headers.values():
             if isinstance(value, str):
                 for var in _HEADER_VAR_RE.findall(value):
                     if var not in found:
                         found.append(var)
-        return found
-    return []
+    # A remote server often carries no headers at all and instead parameterises
+    # the endpoint itself -- `"url": "${GRAFANA_MCP_URL}"`. That var is what the
+    # operator must forward, so name it rather than falling back to a generic
+    # placeholder. Strips any `:-default` shell-style suffix.
+    url = server.get("url")
+    if isinstance(url, str):
+        for var in _HEADER_VAR_RE.findall(url):
+            var = var.split(":-", 1)[0].strip()
+            if var and var not in found:
+                found.append(var)
+    return found
 
 
 def _read_json(path: Path) -> Any:
@@ -212,9 +271,7 @@ def _read_json(path: Path) -> Any:
 # --------------------------------------------------------------------------- #
 # Verdict (pure: no I/O, no SDK)
 # --------------------------------------------------------------------------- #
-def evaluate(
-    declared: list[dict[str, Any]], registered: list[dict[str, Any]]
-) -> dict[str, Any]:
+def evaluate(declared: list[dict[str, Any]], registered: list[dict[str, Any]]) -> dict[str, Any]:
     """Compute the verdict from declared intent vs registered MCP servers.
 
     The registered list is ``McpServerStatus``-shaped. Only the bundle's **own**
@@ -236,10 +293,13 @@ def evaluate(
     # forwards, so a green here proves only wiring and a red may be just a missing
     # token. Advise regardless of verdict so a demo-watcher cannot misread either.
     for row in declared:
-        if row.get("authed"):
-            hints.append(
-                _authed_advisory(str(row["name"]), list(row.get("cred_vars") or []))
-            )
+        cred_vars = list(row.get("cred_vars") or [])
+        if row.get("remote"):
+            # Takes precedence over the authed advisory: unreachable-by-design is
+            # the more specific and more actionable explanation of the red.
+            hints.append(_remote_advisory(str(row["name"]), cred_vars))
+        elif row.get("authed"):
+            hints.append(_authed_advisory(str(row["name"]), cred_vars))
 
     connected_with_tools = 0
     for row in declared:
@@ -261,9 +321,7 @@ def evaluate(
         )
 
     if declared and connected_with_tools == 0:
-        reasons.append(
-            f"declared {len(declared)} MCP server(s); none registered with tools"
-        )
+        reasons.append(f"declared {len(declared)} MCP server(s); none registered with tools")
 
     verdict = "red" if reasons else "green"
     return {"matches": matches, "verdict": verdict, "reasons": reasons, "hints": hints}
@@ -320,9 +378,7 @@ async def run_check(plugin_dir: str) -> dict[str, Any]:
     try:
         registered = await asyncio.wait_for(_connect_and_poll(plugins), timeout_s)
     except TimeoutError:
-        return _red_result(
-            plugin_dir, declared, f"MCP init did not complete within {timeout_s}s"
-        )
+        return _red_result(plugin_dir, declared, f"MCP init did not complete within {timeout_s}s")
     except Exception as exc:
         # A non-timeout failure while setting up the MCP client (Claude CLI
         # subprocess fails to start, an incompatible --image, an SDK error)
@@ -339,9 +395,7 @@ async def run_check(plugin_dir: str) -> dict[str, Any]:
     return _assemble(plugin_dir, declared, registered, evaluate(declared, registered))
 
 
-def _red_result(
-    plugin_dir: str, declared: list[dict[str, Any]], reason: str
-) -> dict[str, Any]:
+def _red_result(plugin_dir: str, declared: list[dict[str, Any]], reason: str) -> dict[str, Any]:
     """Assemble a RED result (no registered servers) with a single override reason.
 
     Shared by the timeout and MCP-client-startup failure paths in ``run_check``:
@@ -377,11 +431,7 @@ async def _connect_and_poll(plugins: list[Any]) -> list[dict[str, Any]]:
         while True:
             status = await client.get_mcp_status()
             servers = [dict(s) for s in status.get("mcpServers", [])]
-            pending = [
-                s
-                for s in servers
-                if _plugin_owned(s) and s.get("status") == "pending"
-            ]
+            pending = [s for s in servers if _plugin_owned(s) and s.get("status") == "pending"]
             if not pending:
                 return servers
             await asyncio.sleep(_POLL_INTERVAL_S)
@@ -440,9 +490,7 @@ def main() -> int:
     logging.basicConfig(level=logging.INFO, stream=sys.stderr)
     plugin_dir = os.environ.get(PLUGIN_DIR_ENV)
     if not plugin_dir or not Path(plugin_dir).is_dir():
-        result = _invalid_bundle_result(
-            plugin_dir or "", [f"plugin dir not found: {plugin_dir!r}"]
-        )
+        result = _invalid_bundle_result(plugin_dir or "", [f"plugin dir not found: {plugin_dir!r}"])
         print(json.dumps(result))
         return _EXIT_CODES["invalid_bundle"]
 

--- a/runner/tests/test_check.py
+++ b/runner/tests/test_check.py
@@ -48,6 +48,7 @@ def _declared(
     *,
     authed: bool = False,
     cred_vars: list[str] | None = None,
+    remote: bool = False,
 ) -> dict:
     return {
         "name": name,
@@ -55,6 +56,7 @@ def _declared(
         "form": form,
         "authed": authed,
         "cred_vars": list(cred_vars or []),
+        "remote": remote,
     }
 
 
@@ -78,13 +80,9 @@ def _status(
     return entry
 
 
-def _write_bundle(
-    root: Path, manifest: dict, *, mcp_files: dict[str, dict] | None = None
-) -> Path:
+def _write_bundle(root: Path, manifest: dict, *, mcp_files: dict[str, dict] | None = None) -> Path:
     (root / ".claude-plugin").mkdir(parents=True, exist_ok=True)
-    (root / ".claude-plugin" / "plugin.json").write_text(
-        json.dumps(manifest), encoding="utf-8"
-    )
+    (root / ".claude-plugin" / "plugin.json").write_text(json.dumps(manifest), encoding="utf-8")
     for rel, payload in (mcp_files or {}).items():
         target = root / rel
         target.parent.mkdir(parents=True, exist_ok=True)
@@ -96,7 +94,8 @@ def _write_bundle(
 # Test 1 -- declared extraction over real bundle dirs (no mocks)
 # --------------------------------------------------------------------------- #
 def test_extract_inline_object_form() -> None:
-    # Canonical declared shape: exactly {name, source, form, authed, cred_vars},
+    # Canonical declared shape: exactly {name, source, form, authed, cred_vars,
+    # remote},
     # nothing else. A plain stdio server with no env is authed=False, cred_vars=[].
     assert extract_declared(str(_MCP_GREEN)) == [
         {
@@ -105,6 +104,7 @@ def test_extract_inline_object_form() -> None:
             "form": "inline",
             "authed": False,
             "cred_vars": [],
+            "remote": False,
         }
     ]
 
@@ -410,9 +410,7 @@ def test_authed_advisory_in_hints_when_registered_green() -> None:
     # Authed server connected with tools -> verdict green, yet the advisory must
     # still fire so the green is not read as "auth verified".
     declared = [_declared("github", authed=True, cred_vars=["GITHUB_PERSONAL_ACCESS_TOKEN"])]
-    result = evaluate(
-        declared, [_status("plugin:x:github", tools=[_tool("list_issues")])]
-    )
+    result = evaluate(declared, [_status("plugin:x:github", tools=[_tool("list_issues")])])
     assert result["verdict"] == "green"
     assert result["reasons"] == []
     advisory = _authed_hint(result)
@@ -537,3 +535,78 @@ def test_run_check_red_pointer_bundle_is_invalid_bundle() -> None:
     # bundle error: the stable diagnostic code plus the offending path.
     assert "[mcp.declared_pointer]" in joined, joined
     assert "config/mcp.json" in joined, joined
+
+
+# --------------------------------------------------------------------------- #
+# Remote servers: unreachable by design, not a bundle defect (#1093)
+# --------------------------------------------------------------------------- #
+def test_remote_server_declared_by_url_only_is_marked_remote(tmp_path: Path) -> None:
+    # The common remote shape carries neither `env` nor `headers` -- the endpoint
+    # itself is the parameterised part -- so it was invisible to both the authed
+    # flag and cred-var extraction, and produced a bare red with no explanation.
+    root = _write_bundle(
+        tmp_path,
+        {"name": "b", "version": "0.1.0"},
+        mcp_files={
+            ".mcp.json": {"mcpServers": {"grafana": {"type": "http", "url": "${GRAFANA_MCP_URL}"}}}
+        },
+    )
+    rows = extract_declared(str(root))
+    assert rows == [
+        _declared(
+            "grafana",
+            source=".mcp.json",
+            form="bare_file",
+            cred_vars=["GRAFANA_MCP_URL"],
+            remote=True,
+        )
+    ]
+
+
+def test_remote_url_var_strips_a_shell_style_default(tmp_path: Path) -> None:
+    # `${VAR:-fallback}` is how a bundle keeps one declaration working across
+    # tiers; the operator still forwards VAR, so name VAR and not the default.
+    root = _write_bundle(
+        tmp_path,
+        {"name": "b", "version": "0.1.0"},
+        mcp_files={
+            ".mcp.json": {
+                "mcpServers": {
+                    "grafana": {"type": "http", "url": "${GRAFANA_MCP_URL:-http://svc:8000/mcp}"}
+                }
+            }
+        },
+    )
+    assert extract_declared(str(root))[0]["cred_vars"] == ["GRAFANA_MCP_URL"]
+
+
+def test_remote_advisory_says_the_red_is_expected_and_names_the_secret() -> None:
+    from curie_runner.check import _remote_advisory
+
+    hint = _remote_advisory("grafana", ["GRAFANA_MCP_URL"])
+    # The point of the advisory: distinguish "offline contract did its job" from
+    # "your bundle is broken", which both rendered as red before.
+    assert "cannot be reached offline" in hint
+    assert "NOT evidence" in hint
+    assert "--secret GRAFANA_MCP_URL" in hint
+
+
+def test_remote_advisory_takes_precedence_over_the_authed_one() -> None:
+    # A remote server WITH headers is both remote and authed. Unreachable-by-
+    # design is the more specific explanation, so it should be the one shown.
+    from curie_runner.check import evaluate
+
+    declared = [
+        {
+            "name": "grafana",
+            "source": ".mcp.json",
+            "form": "bare_file",
+            "authed": True,
+            "cred_vars": ["TOKEN"],
+            "remote": True,
+        }
+    ]
+    result = evaluate(declared, [])
+    hints = " ".join(result["hints"])
+    assert "cannot be reached offline" in hints
+    assert "was not exercised offline" not in hints


### PR DESCRIPTION
Fixes #1093. Refs #1062.

## What this is *not*

I originally filed #1093 asking for `--secret` on `skill check`. Reading the code first showed that would have been wrong — the offline behaviour is deliberate:

```rust
// Offline contract: the check must never reach the network. A bundle
// with a remote (`url:`) MCP server ... must fail (red) rather than
// pass by connecting out.
"--network".into(), "none".into(),
```

That rule is correct and stays. A check that can pass by reaching the network isn't verifying the bundle.

## The actual problem

`red` conflated two very different things:

| Meaning | Author action |
|---|---|
| a declared stdio server failed to load | **fix your bundle** |
| a remote server can't be reached offline | **nothing — expected** |

Both printed the same word, with no hint distinguishing them.

The existing authed advisory didn't cover it: `authed` keys off a non-empty `env` or `headers` map, and the common remote shape has neither —

```json
{"grafana": {"type": "http", "url": "${GRAFANA_MCP_URL}"}}
```

The endpoint itself is the parameterised part, so the server was invisible to both the advisory and cred-var extraction.

## The fix

- a `url` marks the row **remote**
- `${VAR}` in the url contributes a cred var, stripping any `:-default` (the operator still forwards `VAR`)
- remote rows get their own advisory: *"cannot be reached offline; a red here is expected and is NOT evidence the bundle is broken — run `curie skill up --secret GRAFANA_MCP_URL`"*
- it takes precedence over the authed advisory when both apply

## Verification

```
uv run pytest runner/tests -q  → 38 passed
uv run ruff check / format      → clean
uv run mypy                     → 163 files, no issues
```

Four new tests. The declared-row shape gained a key, so the canonical-shape test was **updated deliberately** rather than loosened — that test exists to catch exactly this kind of change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)