### PR TITLE
cluster/local deploy: add --repo to bind an agent at creation (#1064)

### DIFF
--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -1180,6 +1180,14 @@ export const commandManifest = {
               "required": false
             },
             {
+              "global": false,
+              "help": "Bind this agent to a GitHub repository (`owner/name`) so pushes to its dev/prod branches deploy it (ADR-0014)",
+              "id": "repo",
+              "long": "repo",
+              "positional": false,
+              "required": false
+            },
+            {
               "default_values": [
                 "dev"
               ],
@@ -2498,6 +2506,14 @@ export const commandManifest = {
               "required": false
             },
             {
+              "global": false,
+              "help": "Bind this agent to a GitHub repository (`owner/name`) so pushes to its dev/prod branches deploy it (ADR-0014)",
+              "id": "repo",
+              "long": "repo",
+              "positional": false,
+              "required": false
+            },
+            {
               "default_values": [
                 "dev"
               ],
@@ -3279,6 +3295,14 @@ export const commandManifest = {
           "help": "Slack channel to bind the agent to. On first create it defaults to C0LOCALDEV; on redeploy it is only moved when you pass this flag, so omitting it leaves the deployed agent's channel untouched",
           "id": "slack_channel",
           "long": "slack-channel",
+          "positional": false,
+          "required": false
+        },
+        {
+          "global": false,
+          "help": "Bind this agent to a GitHub repository (`owner/name`) so pushes to its dev/prod branches deploy it (ADR-0014)",
+          "id": "repo",
+          "long": "repo",
           "positional": false,
           "required": false
         },

--- a/cli/api-mirrors.json
+++ b/cli/api-mirrors.json
@@ -12,7 +12,6 @@
       "struct": "Agent",
       "schema": "AgentOut",
       "omissions": [
-        { "field": "repo_full_name", "why": "The deploy flow (ApiClient::resolve_agent/find_agent) matches and creates agents by name and reconciles slack_channel; it never reads the agent's linked git repo, so repo_full_name is not deserialized." },
         { "field": "behavior_packs", "why": "No CLI path reads an agent's behavior-pack list; deploy uploads a bundle rather than composing packs, so behavior_packs is never consumed." },
         { "field": "model", "why": "The CLI never displays or acts on an agent's default model (model routing is server- and claim-time bound, #473); the deploy and lifecycle verbs read only id/name/slack_channel." },
         { "field": "secrets", "why": "update_agent_secrets WRITES connector-secret names; the CLI never reads the stored secrets list back, so the response field is not modeled." },

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -1177,6 +1177,14 @@
               "required": false
             },
             {
+              "global": false,
+              "help": "Bind this agent to a GitHub repository (`owner/name`) so pushes to its dev/prod branches deploy it (ADR-0014)",
+              "id": "repo",
+              "long": "repo",
+              "positional": false,
+              "required": false
+            },
+            {
               "default_values": [
                 "dev"
               ],
@@ -2495,6 +2503,14 @@
               "required": false
             },
             {
+              "global": false,
+              "help": "Bind this agent to a GitHub repository (`owner/name`) so pushes to its dev/prod branches deploy it (ADR-0014)",
+              "id": "repo",
+              "long": "repo",
+              "positional": false,
+              "required": false
+            },
+            {
               "default_values": [
                 "dev"
               ],
@@ -3276,6 +3292,14 @@
           "help": "Slack channel to bind the agent to. On first create it defaults to C0LOCALDEV; on redeploy it is only moved when you pass this flag, so omitting it leaves the deployed agent's channel untouched",
           "id": "slack_channel",
           "long": "slack-channel",
+          "positional": false,
+          "required": false
+        },
+        {
+          "global": false,
+          "help": "Bind this agent to a GitHub repository (`owner/name`) so pushes to its dev/prod branches deploy it (ADR-0014)",
+          "id": "repo",
+          "long": "repo",
           "positional": false,
           "required": false
         },

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -26,6 +26,11 @@ pub struct Agent {
     pub id: String,
     pub name: String,
     pub slack_channel: String,
+    /// The repository whose pushes deploy this agent (ADR-0014). Identity, set
+    /// only at creation -- `AgentUpdate` deliberately excludes it -- so the CLI
+    /// must send it up front or the agent can never reach git-flow (#1064).
+    #[serde(default)]
+    pub repo_full_name: Option<String>,
     /// Tool names gated behind human approval (#245). Present on `AgentOut`;
     /// `#[serde(default)]` keeps older/leaner responses parsing to None.
     #[serde(default)]
@@ -270,6 +275,10 @@ pub struct DeployOutcome {
     pub bundle: Bundle,
     pub deployment: Deployment,
     pub channel: ChannelOutcome,
+    /// Set when `--repo` could not be applied because the agent already exists
+    /// and its repo binding is immutable. Surfaced so the operator learns it
+    /// silently did nothing (#1064).
+    pub repo_note: Option<String>,
 }
 
 /// Whether this endpoint would send the `X-API-Key` over cleartext HTTP to a
@@ -316,6 +325,22 @@ fn warn_if_insecure(base_url: &str) {
     }
 }
 
+/// The `POST /agents` body. Pure so the shape is testable without a live API.
+///
+/// `repo_full_name` is sent only when asked: it is UNIQUE per agent, so an
+/// unsolicited value would 409 against whichever agent already owns that repo.
+fn agent_create_body(
+    name: &str,
+    slack_channel: &str,
+    repo_full_name: Option<&str>,
+) -> serde_json::Value {
+    let mut body = json!({"name": name, "slack_channel": slack_channel});
+    if let Some(repo) = repo_full_name {
+        body["repo_full_name"] = json!(repo);
+    }
+    body
+}
+
 impl ApiClient {
     /// The server caps `/approvals` results at this many rows
     /// (`apps/api/.../routers/approvals.py`: `min(max(limit, 1), 200)`); the CLI
@@ -360,12 +385,18 @@ impl ApiClient {
             .context("decoding agent list")
     }
 
-    pub async fn create_agent(&self, name: &str, slack_channel: &str) -> Result<Agent> {
+    pub async fn create_agent(
+        &self,
+        name: &str,
+        slack_channel: &str,
+        repo_full_name: Option<&str>,
+    ) -> Result<Agent> {
+        let body = agent_create_body(name, slack_channel, repo_full_name);
         let resp = self
             .http
             .post(format!("{}/agents", self.base_url))
             .header("X-API-Key", &self.api_key)
-            .json(&json!({"name": name, "slack_channel": slack_channel}))
+            .json(&body)
             .send()
             .await
             .context("POST /agents")?;
@@ -385,7 +416,7 @@ impl ApiClient {
         {
             return Ok(existing);
         }
-        self.create_agent(name, slack_channel).await
+        self.create_agent(name, slack_channel, None).await
     }
 
     pub async fn update_agent_channel(&self, agent_id: &str, slack_channel: &str) -> Result<Agent> {
@@ -436,36 +467,53 @@ impl ApiClient {
         &self,
         name: &str,
         slack_channel: Option<&str>,
-    ) -> Result<(Agent, ChannelOutcome)> {
+        repo_full_name: Option<&str>,
+    ) -> Result<(Agent, ChannelOutcome, Option<String>)> {
         let existing = self
             .list_agents()
             .await?
             .into_iter()
             .find(|a| a.name == name);
         match existing {
-            Some(agent) => match slack_channel {
-                Some(channel) if channel != agent.slack_channel => {
-                    let from = agent.slack_channel.clone();
-                    let updated = self.update_agent_channel(&agent.id, channel).await?;
-                    let to = updated.slack_channel.clone();
-                    Ok((updated, ChannelOutcome::Updated { from, to }))
-                }
-                other => {
-                    let channel = agent.slack_channel.clone();
-                    Ok((
-                        agent,
+            Some(agent) => {
+                // The repo binding is identity: `AgentUpdate` excludes it, so a
+                // PATCH would return 200 and change nothing. Say so plainly
+                // rather than let the operator believe it took (#1064).
+                let repo_note = match (repo_full_name, agent.repo_full_name.as_deref()) {
+                    (Some(want), Some(have)) if want == have => None,
+                    (Some(want), Some(have)) => Some(format!(
+                        "agent is already bound to {have}; --repo {want} was NOT applied \
+                         (the repo binding is set at creation and cannot be changed)"
+                    )),
+                    (Some(want), None) => Some(format!(
+                        "agent exists with no repo binding; --repo {want} was NOT applied \
+                         (the binding is set at creation only, so this agent cannot use \
+                         git-flow -- recreate it to bind one)"
+                    )),
+                    (None, _) => None,
+                };
+                let outcome = match slack_channel {
+                    Some(channel) if channel != agent.slack_channel => {
+                        let from = agent.slack_channel.clone();
+                        let updated = self.update_agent_channel(&agent.id, channel).await?;
+                        let to = updated.slack_channel.clone();
+                        return Ok((updated, ChannelOutcome::Updated { from, to }, repo_note));
+                    }
+                    other => {
+                        let channel = agent.slack_channel.clone();
                         ChannelOutcome::Unchanged {
                             channel,
                             passed: other.is_some(),
-                        },
-                    ))
-                }
-            },
+                        }
+                    }
+                };
+                Ok((agent, outcome, repo_note))
+            }
             None => {
                 let channel = slack_channel.unwrap_or(DEFAULT_SLACK_CHANNEL);
-                let agent = self.create_agent(name, channel).await?;
+                let agent = self.create_agent(name, channel, repo_full_name).await?;
                 let outcome = ChannelOutcome::Created(agent.slack_channel.clone());
-                Ok((agent, outcome))
+                Ok((agent, outcome, None))
             }
         }
     }
@@ -557,8 +605,11 @@ impl ApiClient {
         environment: &str,
         archive: Vec<u8>,
         secrets: &std::collections::BTreeMap<String, String>,
+        repo_full_name: Option<&str>,
     ) -> Result<DeployOutcome> {
-        let (agent, channel) = self.resolve_agent(agent_name, slack_channel).await?;
+        let (agent, channel, repo_note) = self
+            .resolve_agent(agent_name, slack_channel, repo_full_name)
+            .await?;
         // Bind per-agent connector secrets (ADR-0009, #429). A PATCH covers both
         // a freshly created agent and a redeploy that rotates a value; an empty
         // map leaves the agent's current secrets untouched.
@@ -578,6 +629,7 @@ impl ApiClient {
             bundle,
             deployment,
             channel,
+            repo_note,
         })
     }
 
@@ -953,7 +1005,25 @@ impl ApiClient {
 
 #[cfg(test)]
 mod tests {
-    use super::is_insecure_endpoint;
+    use super::{agent_create_body, is_insecure_endpoint};
+
+    #[test]
+    fn create_agent_body_omits_repo_unless_asked() {
+        // repo_full_name is UNIQUE per agent, so sending an unsolicited value
+        // would 409 against whichever agent already owns that repo.
+        let body = agent_create_body("bot", "C123", None);
+        assert_eq!(body["name"], "bot");
+        assert_eq!(body["slack_channel"], "C123");
+        assert!(body.get("repo_full_name").is_none());
+    }
+
+    #[test]
+    fn create_agent_body_binds_the_repo_when_asked() {
+        // Creation is the ONLY chance: AgentUpdate excludes repo_full_name, so
+        // an agent created without it can never reach git-flow (#1064).
+        let body = agent_create_body("bot", "C123", Some("acme/bundle"));
+        assert_eq!(body["repo_full_name"], "acme/bundle");
+    }
 
     #[test]
     fn https_is_always_secure() {

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -725,6 +725,7 @@ pub async fn deploy_named(folder: &str, opts: DeployNamedOpts) -> Result<DeployO
         api_url: opts.api_url,
         api_key: opts.api_key,
         slack_channel: opts.slack_channel,
+        repo: opts.repo,
         env: opts.env,
         label: opts.label,
         secret: opts.secret,
@@ -740,6 +741,11 @@ pub struct DeployNamedOpts {
     pub api_url: String,
     pub api_key: String,
     pub slack_channel: Option<String>,
+    /// `owner/name` to bind at agent CREATION so pushes to that repo deploy this
+    /// agent (ADR-0014). Identity, not config: it cannot be changed afterwards,
+    /// so omitting it here leaves the agent permanently unable to use git-flow
+    /// (#1064). Ignored with a warning when the agent already exists.
+    pub repo: Option<String>,
     pub env: DeployEnv,
     pub label: Option<String>,
     pub secret: Vec<String>,
@@ -2918,6 +2924,11 @@ pub struct DeployOpts {
     /// leaves an existing agent's channel untouched instead of masking intent
     /// with a default.
     pub slack_channel: Option<String>,
+    /// `owner/name` to bind at agent CREATION so pushes to that repo deploy this
+    /// agent (ADR-0014). Identity, not config: it cannot be changed afterwards,
+    /// so omitting it here leaves the agent permanently unable to use git-flow
+    /// (#1064). Ignored with a warning when the agent already exists.
+    pub repo: Option<String>,
     pub env: DeployEnv,
     pub label: Option<String>,
     /// Per-agent connector secret NAMES to bind on deploy (ADR-0009, #429). Each
@@ -3094,6 +3105,7 @@ pub async fn deploy(opts: DeployOpts) -> Result<DeployOutput> {
             env,
             archive,
             &secrets,
+            opts.repo.as_deref(),
         )
         .await
     {
@@ -3109,6 +3121,12 @@ pub async fn deploy(opts: DeployOpts) -> Result<DeployOutput> {
             return Err(err);
         }
     };
+
+    // A --repo that could not be applied is a silent no-op otherwise: the deploy
+    // succeeds, the agent looks fine, and git-flow never fires (#1064).
+    if let Some(note) = &outcome.repo_note {
+        ui.warn(note);
+    }
 
     let channel = match &outcome.channel {
         ChannelOutcome::Created(channel) => channel.clone(),
@@ -5956,6 +5974,7 @@ mod tests {
             api_url: "http://127.0.0.1:1".to_string(),
             api_key: "k".to_string(),
             slack_channel: None,
+            repo: None,
             env: super::DeployEnv::Dev,
             label: Some("v0".to_string()),
             secret: vec![],
@@ -6025,6 +6044,7 @@ mod tests {
             api_url: "http://127.0.0.1:1".to_string(),
             api_key: "k".to_string(),
             slack_channel: None,
+            repo: None,
             env: super::DeployEnv::Dev,
             label: Some("v0".to_string()),
             secret: vec!["GH_TOKEN".to_string()],
@@ -6058,6 +6078,7 @@ mod tests {
             api_url: "http://127.0.0.1:1".to_string(),
             api_key: "k".to_string(),
             slack_channel: None,
+            repo: None,
             env: super::DeployEnv::Dev,
             label: Some("v0".to_string()),
             secret: vec![],

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -233,6 +233,16 @@ enum Command {
         /// omitting it leaves the deployed agent's channel untouched.
         #[arg(long)]
         slack_channel: Option<String>,
+        /// Bind this agent to a GitHub repository (`owner/name`) so pushes to
+        /// its dev/prod branches deploy it (ADR-0014).
+        ///
+        /// The binding is IDENTITY, not config: the platform sets it only when
+        /// the agent is created and `AgentUpdate` cannot change it. Deploying
+        /// without it creates an agent that can never use git-flow, and the
+        /// only remedy is recreating the agent (#1064). Passing it for an
+        /// agent that already exists warns and changes nothing.
+        #[arg(long = "repo", value_name = "OWNER/NAME")]
+        repo: Option<String>,
         /// Target environment.
         #[arg(long, value_enum, default_value_t = DeployEnv::Dev)]
         env: DeployEnv,
@@ -870,6 +880,16 @@ enum LocalAction {
         /// omitting it leaves the deployed agent's channel untouched.
         #[arg(long)]
         slack_channel: Option<String>,
+        /// Bind this agent to a GitHub repository (`owner/name`) so pushes to
+        /// its dev/prod branches deploy it (ADR-0014).
+        ///
+        /// The binding is IDENTITY, not config: the platform sets it only when
+        /// the agent is created and `AgentUpdate` cannot change it. Deploying
+        /// without it creates an agent that can never use git-flow, and the
+        /// only remedy is recreating the agent (#1064). Passing it for an
+        /// agent that already exists warns and changes nothing.
+        #[arg(long = "repo", value_name = "OWNER/NAME")]
+        repo: Option<String>,
         /// Target environment.
         #[arg(long, value_enum, default_value_t = DeployEnv::Dev)]
         env: DeployEnv,
@@ -1331,6 +1351,16 @@ enum ClusterAction {
         /// omitting it leaves the deployed agent's channel untouched.
         #[arg(long)]
         slack_channel: Option<String>,
+        /// Bind this agent to a GitHub repository (`owner/name`) so pushes to
+        /// its dev/prod branches deploy it (ADR-0014).
+        ///
+        /// The binding is IDENTITY, not config: the platform sets it only when
+        /// the agent is created and `AgentUpdate` cannot change it. Deploying
+        /// without it creates an agent that can never use git-flow, and the
+        /// only remedy is recreating the agent (#1064). Passing it for an
+        /// agent that already exists warns and changes nothing.
+        #[arg(long = "repo", value_name = "OWNER/NAME")]
+        repo: Option<String>,
         /// Target environment.
         #[arg(long, value_enum, default_value_t = DeployEnv::Dev)]
         env: DeployEnv,
@@ -1944,6 +1974,7 @@ async fn run(command: Option<Command>) -> Result<()> {
                 api_url,
                 api_key,
                 slack_channel,
+                repo,
                 env,
                 label,
                 secret,
@@ -1957,6 +1988,7 @@ async fn run(command: Option<Command>) -> Result<()> {
                         api_url,
                         api_key,
                         slack_channel,
+                        repo,
                         env,
                         label,
                         secret,
@@ -2383,6 +2415,7 @@ async fn run(command: Option<Command>) -> Result<()> {
                 release,
                 api_key,
                 slack_channel,
+                repo,
                 env,
                 label,
                 secret,
@@ -2474,6 +2507,7 @@ async fn run(command: Option<Command>) -> Result<()> {
                         api_url,
                         api_key,
                         slack_channel,
+                        repo,
                         env,
                         label,
                         // Cluster connector-secret delivery is deferred to #440; no
@@ -2677,6 +2711,7 @@ async fn run(command: Option<Command>) -> Result<()> {
             api_url,
             api_key,
             slack_channel,
+            repo,
             env,
             label,
             secret,
@@ -2687,6 +2722,7 @@ async fn run(command: Option<Command>) -> Result<()> {
                     api_url,
                     api_key,
                     slack_channel,
+                    repo,
                     env,
                     label,
                     secret,

--- a/cli/src/message.rs
+++ b/cli/src/message.rs
@@ -2994,6 +2994,7 @@ mod tests {
             id: format!("id-{name}"),
             name: name.to_string(),
             slack_channel: channel.to_string(),
+            repo_full_name: None,
             approval_required_tools: None,
             approval_routes: None,
         }
@@ -3743,6 +3744,7 @@ mod tests {
                 id: "a1".into(),
                 name: "one".into(),
                 slack_channel: "C1".into(),
+                repo_full_name: None,
                 approval_required_tools: None,
                 approval_routes: None,
             },
@@ -3750,6 +3752,7 @@ mod tests {
                 id: "a2".into(),
                 name: "two".into(),
                 slack_channel: "C2".into(),
+                repo_full_name: None,
                 approval_required_tools: None,
                 approval_routes: None,
             },

--- a/cli/tests/api_deploy.rs
+++ b/cli/tests/api_deploy.rs
@@ -63,6 +63,7 @@ async fn deploy_walks_the_full_contract_flow_with_auth() {
             "dev",
             archive,
             &std::collections::BTreeMap::new(),
+            None,
         )
         .await
         .unwrap();
@@ -176,6 +177,7 @@ async fn run_deploy(client: &ApiClient, channel: Option<&str>) -> ChannelOutcome
             "dev",
             archive,
             &std::collections::BTreeMap::new(),
+            None,
         )
         .await
         .unwrap()


### PR DESCRIPTION
Refs #1064, #1062. Partial — see *Scope* below.

## The trap

An agent created by the CLI can **never** use git-flow. Four constraints, each defensible alone:

| | |
|---|---|
| `cluster deploy` | never sent `repo_full_name`, and had no flag to |
| `PATCH /agents/{id}` | `AgentUpdate` excludes it by design — returns **200**, changes nothing |
| `DELETE /agents/{id}` | **409** while a deployment is active |
| deployment deactivation | no API for it — so delete is unreachable |

Together they make the platform's headline deploy model (ADR-0014) unreachable by its own documented onboarding path. Escaping it meant **destroying the namespace and reinstalling the release**.

## The fix

`--repo owner/name`, sent at creation — the only moment it can be set.

```bash
curie cluster deploy --plugin-dir . --repo <downstream-repo> --slack-channel C0EXAMPLE1
```

The omission was previously *declared* in `api-mirrors.json`:

> "it never reads the agent's linked git repo, so repo_full_name is not deserialized"

True when written, and exactly why the gap existed. That entry is now removed — the field-parity test enforces it, and caught the staleness on the first run.

## The case people will actually hit

Passing `--repo` for an **existing** agent cannot work. Rather than appear to succeed, it warns:

```
agent exists with no repo binding; --repo <downstream-repo> was NOT applied
(the binding is set at creation only, so this agent cannot use git-flow --
recreate it to bind one)
```

That is the likely case, since the agent usually exists by the time someone discovers git-flow needs a binding.

## Scope

**This does not close #1064.** An existing agent still cannot be rebound or deleted — that needs deployment deactivation, a schema-level change worth its own PR and review. This removes the trap for every agent created from here on, which is the half that needs no schema change.

## Verification

```
cargo test               → 530 + 53 + 5 + 10 + 17 + 13 + 14 + 4 + 4 + 3, all passing
cargo fmt --check        → clean
cargo clippy -D warnings → clean
curie cluster deploy --help → --repo <OWNER/NAME> present
```

Two new tests on a pure body builder: the key is omitted unless asked (it is unique per agent, so an unsolicited value would 409 against whoever owns that repo), and present when asked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)