### PR TITLE
chart: plumb api.githubToken so private-repo git-flow is reachable (#1058)

### DIFF
--- a/charts/curie/templates/api.yaml
+++ b/charts/curie/templates/api.yaml
@@ -78,6 +78,14 @@ spec:
                 secretKeyRef:
                   name: {{ include "curie.secretName" . }}
                   key: githubWebhookSecret
+            # Outbound GitHub credential: the eval commit status AND the
+            # git-flow bundle clone, without which a private repo cannot
+            # deploy (#1058).
+            - name: GITHUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "curie.secretName" . }}
+                  key: githubToken
             - name: ENVIRONMENT
               value: {{ .Values.api.environment | quote }}
             - name: ORG_NAME

--- a/charts/curie/templates/secrets.yaml
+++ b/charts/curie/templates/secrets.yaml
@@ -58,6 +58,13 @@ stringData:
   # First-party app credentials.
   apiKey: {{ include "curie.managedSecret" (dict "root" . "key" "apiKey" "value" .Values.api.apiKey "default" "curie-dev-key" "hex" false "existingData" $existingSecret) | quote }}
   githubWebhookSecret: {{ include "curie.managedSecret" (dict "root" . "key" "githubWebhookSecret" "value" .Values.api.githubWebhookSecret "default" "dev-webhook-secret" "hex" false "existingData" $existingSecret) | quote }}
+  {{/* NOT curie.managedSecret: that helper generates a random when the value
+       matches its default, which is right for a credential the install must
+       have. This one is optional -- empty means "no GitHub credential", and
+       git-flow then works on public repos only. Generating a random here would
+       send 32 characters of noise to GitHub as a bearer token and fail auth in
+       a way that looks like a permissions problem rather than a missing one. */}}
+  githubToken: {{ .Values.api.githubToken | default "" | quote }}
   slackAppToken: {{ .Values.dispatcher.slack.appToken | quote }}
   slackBotToken: {{ .Values.dispatcher.slack.botToken | quote }}
   slackSigningSecret: {{ .Values.dispatcher.slack.signingSecret | quote }}

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -447,6 +447,15 @@ api:
   orgName: Curie
   # HMAC secret the GitHub git-flow webhook authenticates inbound events with.
   githubWebhookSecret: dev-webhook-secret
+  # GitHub credential the API uses OUTBOUND: posting the eval commit status, and
+  # authenticating the git-flow bundle clone. Without it git-flow can only deploy
+  # a PUBLIC repository -- a private one is rejected with git.archive_failed
+  # (#1058). Empty by default, which keeps public-repo installs unchanged.
+  #
+  # Scope it to reading the bundle repositories this install deploys; a
+  # fine-grained PAT or a GitHub App installation token is preferable to a
+  # personal classic token, which carries the whole user's access.
+  githubToken: ""
   # How often (seconds) the API scans for lapsed pending approvals and resumes
   # their stranded sessions (#412). Set to 0 (or any value <= 0) to disable the
   # expiry sweeper entirely. Default matches the app's built-in 30s cadence.


### PR DESCRIPTION
Completes #1058. #1097 fixed the code path; this makes it reachable.

## The gap

#1097 taught the git-flow clone to authenticate via `settings.github_token`. **The chart has no way to set it.**

`GITHUB_WEBHOOK_SECRET` is wired values → Secret → env. `GITHUB_TOKEN` was never plumbed at all, so a Helm install — the deployment that actually needs private-repo cloning — could not supply the credential. The fix worked only if you set the env var by hand.

Found by trying to use it on a real cluster.

## The interesting part

I first wired it through `curie.managedSecret`, matching the webhook secret. Rendering the empty case showed why that's wrong:

```yaml
githubToken: "TWtEJVR5IGNQZpTcmD4jtL2hGTjWGGD9"
```

That helper **generates a random when the value matches its default** — correct for a credential the install must have, wrong for an optional one. A random here means 32 characters of noise sent to GitHub as a bearer token, failing auth in a way that reads like a permissions problem rather than a missing credential.

So this renders directly instead. Empty stays empty, which means "no GitHub credential" and git-flow on public repos only.

## Verified

```
empty default        → githubToken: ""
--set api.githubToken=x → githubToken: "x"
GITHUB_TOKEN in api container → 1 ref
helm lint → 0 failed
```

`charts/curie/ci/render-assertions.sh` fails locally on macOS bash 3.2 (`declare -A` unsupported) — identically on main, so pre-existing and environmental. CI runs bash 5.

## Note on scope

The values comment steers operators toward a **fine-grained PAT or GitHub App installation token** scoped to the bundle repositories, rather than a personal classic token — which would hand the cluster the whole user's GitHub access.
