### PR TITLE
Bundle format: declare connectors in connectors.yaml (ADR-0086, #1063)

### DIFF
--- a/docs/adr/0086-bundles-declare-connectors-the-platform-hosts-them.md
+++ b/docs/adr/0086-bundles-declare-connectors-the-platform-hosts-them.md
@@ -1,7 +1,7 @@
 # 86. Bundles declare connectors; the platform hosts them
 
 Date: 2026-07-29
-Status: Draft
+Status: Accepted
 
 ## Context
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -114,5 +114,5 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0082 | [Connected-transport approval cards ride a real CLI-posted placeholder](0082-connected-transport-approval-cards-via-a-real-placeholder.md) | Accepted |
 | 0084 | [Publish a verification contract for agents driving Curie](0084-publish-a-verification-contract-for-agents-driving-curie.md) | Accepted |
 | 0085 | [Acceptance, not implementation, authorizes an ADR](0085-acceptance-not-implementation-authorizes-an-adr.md) | Accepted |
-| 0086 | [Bundles declare connectors; the platform hosts them](0086-bundles-declare-connectors-the-platform-hosts-them.md) | Draft |
+| 0086 | [Bundles declare connectors; the platform hosts them](0086-bundles-declare-connectors-the-platform-hosts-them.md) | Accepted |
 <!-- END GENERATED: adr-index -->

--- a/packages/plugin-format/src/plugin_format/connectors.py
+++ b/packages/plugin-format/src/plugin_format/connectors.py
@@ -1,0 +1,160 @@
+"""Declared connectors: what a bundle needs running, not how to run it (ADR-0086).
+
+``.mcp.json`` says an MCP server exists and where to reach it. It has never said
+who *runs* it, so every bundle author writing a non-stdio connector had to
+hand-author a Deployment, a Service, a Secret reference, container hardening,
+and a NetworkPolicy -- roughly 180 lines of Kubernetes to stand up one server,
+per bundle, each copy independently right or wrong.
+
+``connectors.yaml`` closes that. A bundle declares intent; the platform derives
+the objects. Two forms:
+
+    connectors:
+      grafana:                                  # hosted: Curie runs the image
+        image: grafana/mcp-grafana:0.17.2
+        args: [-t, streamable-http, -disable-write]
+        env: {GRAFANA_URL: "https://grafana.example.com"}
+        secrets: [GRAFANA_SERVICE_ACCOUNT_TOKEN]
+
+      internal:                                 # remote: already running
+        url: https://mcp.internal/mcp
+        secrets: [INTERNAL_TOKEN]
+
+Secrets are NAMES only. Values arrive at deploy time through the existing
+mechanism (ADR-0009), so this introduces no new way to carry a credential and
+a bundle stays safe to commit.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+# A connector name becomes a Kubernetes object name and a DNS label, so it is
+# held to the stricter of those: lowercase alphanumeric and dashes, starting and
+# ending alphanumeric. Rejecting here beats a confusing apply-time failure.
+_NAME_MAX = 40
+
+
+class ConnectorSpec(BaseModel):
+    """One declared connector. Exactly one of ``image`` or ``url``.
+
+    Strict, unlike the rest of this package. The leniency mandate exists because
+    real Claude Code plugin bundles carry keys this MVP does not model, and
+    rejecting them would reject valid bundles. ``connectors.yaml`` is not a
+    Claude Code artifact -- it is Curie's own file with no external producer, so
+    an unrecognised key is a typo, and silently ignoring it would mean a
+    connector that renders subtly wrong with no diagnostic.
+    """
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    # -- hosted form --
+    image: str | None = None
+    args: list[str] = Field(default_factory=list)
+    env: dict[str, str] = Field(default_factory=dict)
+    port: int = 8000
+
+    # -- remote form --
+    url: str | None = None
+    headers: dict[str, str] = Field(default_factory=dict)
+
+    # -- both --
+    secrets: list[str] = Field(default_factory=list)
+
+    @property
+    def is_hosted(self) -> bool:
+        return self.image is not None
+
+
+class ConnectorsFile(BaseModel):
+    """The parsed ``connectors.yaml``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    connectors: dict[str, ConnectorSpec] = Field(default_factory=dict)
+
+
+_NAME_RE = re.compile(r"[a-z0-9]([a-z0-9-]*[a-z0-9])?")
+
+
+def _is_valid_name(name: str) -> bool:
+    """RFC 1123 label, capped: the name becomes a k8s object and a DNS label."""
+
+    return len(name) <= _NAME_MAX and bool(_NAME_RE.fullmatch(name))
+
+
+def validate_connectors(data: Any) -> tuple[ConnectorsFile | None, list[tuple[str, str]]]:
+    """Validate parsed ``connectors.yaml`` content.
+
+    Returns ``(parsed, errors)`` where each error is ``(code, message)``. A
+    non-empty error list means the file must be rejected -- these are all
+    conditions that would otherwise surface as an opaque Kubernetes apply
+    failure long after the author has stopped looking.
+    """
+
+    errors: list[tuple[str, str]] = []
+    if data is None:
+        return ConnectorsFile(), errors
+    if not isinstance(data, dict):
+        return None, [("connectors.not_object", "connectors.yaml must be a mapping")]
+
+    try:
+        parsed = ConnectorsFile.model_validate(data)
+    except Exception as exc:  # pydantic ValidationError -- surface it verbatim
+        return None, [("connectors.invalid", str(exc)[:400])]
+
+    for name, spec in parsed.connectors.items():
+        where = f"connectors.{name}"
+        if not _is_valid_name(name):
+            errors.append(
+                (
+                    "connectors.bad_name",
+                    f"{where}: a connector name becomes a Kubernetes object and DNS "
+                    "label, so it must be lowercase alphanumeric or dashes, start and "
+                    f"end alphanumeric, and be at most {_NAME_MAX} characters",
+                )
+            )
+        if spec.image and spec.url:
+            errors.append(
+                (
+                    "connectors.ambiguous",
+                    f"{where}: set either `image` (Curie runs it) or `url` (already "
+                    "running), not both -- otherwise it is unclear who owns the process",
+                )
+            )
+        if not spec.image and not spec.url:
+            errors.append(
+                (
+                    "connectors.underspecified",
+                    f"{where}: set `image` for Curie to run it, or `url` to point at "
+                    "something already running",
+                )
+            )
+        if spec.url and (spec.args or spec.env):
+            errors.append(
+                (
+                    "connectors.remote_has_runtime",
+                    f"{where}: `args`/`env` configure a process Curie starts; a `url` "
+                    "connector is already running, so they would be silently ignored",
+                )
+            )
+        if spec.image and spec.headers:
+            errors.append(
+                (
+                    "connectors.hosted_has_headers",
+                    f"{where}: `headers` apply to a remote endpoint; configure a hosted "
+                    "connector with `env` and `args` instead",
+                )
+            )
+        if not (1 <= spec.port <= 65535):
+            errors.append(("connectors.bad_port", f"{where}: port {spec.port} is out of range"))
+        for key in spec.env:
+            if not key.replace("_", "").isalnum() or key[:1].isdigit():
+                errors.append(
+                    ("connectors.bad_env_name", f"{where}: `{key}` is not a valid env var name")
+                )
+
+    return (parsed if not errors else None), errors

--- a/packages/plugin-format/src/plugin_format/manifest.py
+++ b/packages/plugin-format/src/plugin_format/manifest.py
@@ -26,6 +26,4 @@ def resolve_manifest(root: str | Path) -> Path | None:
     over a root ``plugin.json``. Returns ``None`` when neither exists.
     """
     base = Path(root)
-    return next(
-        (base / loc for loc in MANIFEST_LOCATIONS if (base / loc).is_file()), None
-    )
+    return next((base / loc for loc in MANIFEST_LOCATIONS if (base / loc).is_file()), None)

--- a/packages/plugin-format/src/plugin_format/reserved_env.py
+++ b/packages/plugin-format/src/plugin_format/reserved_env.py
@@ -95,9 +95,7 @@ _CURIE_BOOT_KEYS = frozenset(
     }
 )
 
-RESERVED_BOOT_ENV: frozenset[str] = (
-    _CREDENTIAL_KEYS | _REDIRECT_CAPTURE_KEYS | _CURIE_BOOT_KEYS
-)
+RESERVED_BOOT_ENV: frozenset[str] = _CREDENTIAL_KEYS | _REDIRECT_CAPTURE_KEYS | _CURIE_BOOT_KEYS
 
 
 def is_reserved_boot_env_name(name: str) -> bool:

--- a/packages/plugin-format/src/plugin_format/validate.py
+++ b/packages/plugin-format/src/plugin_format/validate.py
@@ -14,6 +14,7 @@ import yaml
 from pydantic import BaseModel, TypeAdapter, ValidationError
 
 from .approval_policy import declared_mcp_server_names, effective_tool_prefix, grantable_routes
+from .connectors import validate_connectors
 from .manifest import resolve_manifest
 from .models import (
     _TRIGGER_TYPES,
@@ -33,7 +34,6 @@ _TRIGGERS_ADAPTER = TypeAdapter(list[TriggerDeclaration])
 
 # Claude Code plugin names are kebab-case: lowercase alphanumerics and hyphens.
 _NAME_RE = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
-
 
 
 class ValidationIssue(BaseModel):
@@ -60,9 +60,7 @@ class _Collector:
         self.warnings.append(ValidationIssue(code=code, message=message, location=location))
 
     def result(self) -> ValidationResult:
-        return ValidationResult(
-            valid=not self.errors, errors=self.errors, warnings=self.warnings
-        )
+        return ValidationResult(valid=not self.errors, errors=self.errors, warnings=self.warnings)
 
 
 def validate_bundle(path: str | Path) -> ValidationResult:
@@ -84,8 +82,33 @@ def validate_bundle(path: str | Path) -> ValidationResult:
         _validate_approval_policy(manifest, mcp_servers, c)
         _validate_secrets(manifest, c)
         _validate_scripts(root, c)
+        _validate_connectors(root, c)
 
     return c.result()
+
+
+CONNECTORS_FILE = "connectors.yaml"
+
+
+def _validate_connectors(root: Path, c: _Collector) -> None:
+    """Validate ``connectors.yaml`` if present (ADR-0086).
+
+    Optional: a bundle with no hosted connectors simply omits it. When present
+    it must parse, because every error it can raise would otherwise surface as
+    an opaque Kubernetes apply failure long after the author stopped looking.
+    """
+
+    path = root / CONNECTORS_FILE
+    if not path.is_file():
+        return
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError) as exc:
+        c.error("connectors.unreadable", f"{CONNECTORS_FILE}: {exc}", CONNECTORS_FILE)
+        return
+    _, errors = validate_connectors(data)
+    for code, message in errors:
+        c.error(code, message, CONNECTORS_FILE)
 
 
 def _validate_manifest(root: Path, c: _Collector) -> PluginManifest | None:

--- a/packages/plugin-format/tests/test_connectors.py
+++ b/packages/plugin-format/tests/test_connectors.py
@@ -1,0 +1,157 @@
+"""Declared-connector validation (ADR-0086, #1063).
+
+Every case here is one an author would otherwise discover as an opaque
+Kubernetes apply failure -- or worse, as a connector that comes up and quietly
+does the wrong thing. Catching them at validation is the point of the file
+existing.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from plugin_format import validate_bundle
+from plugin_format.connectors import validate_connectors
+
+
+def _bundle(root: Path, connectors_yaml: str | None) -> Path:
+    (root / ".claude-plugin").mkdir(parents=True, exist_ok=True)
+    (root / ".claude-plugin" / "plugin.json").write_text(
+        json.dumps({"name": "b", "version": "0.1.0", "description": "t"}), encoding="utf-8"
+    )
+    (root / "skills" / "b").mkdir(parents=True, exist_ok=True)
+    (root / "skills" / "b" / "SKILL.md").write_text(
+        "---\nname: b\ndescription: t\n---\nhi\n", encoding="utf-8"
+    )
+    if connectors_yaml is not None:
+        (root / "connectors.yaml").write_text(connectors_yaml, encoding="utf-8")
+    return root
+
+
+def _codes(data: object) -> list[str]:
+    _, errors = validate_connectors(data)
+    return [c for c, _ in errors]
+
+
+# --------------------------------------------------------------------------- #
+# Accepted shapes
+# --------------------------------------------------------------------------- #
+def test_hosted_connector_is_accepted() -> None:
+    parsed, errors = validate_connectors(
+        {
+            "connectors": {
+                "grafana": {
+                    "image": "grafana/mcp-grafana:0.17.2",
+                    "args": ["-t", "streamable-http"],
+                    "env": {"GRAFANA_URL": "https://g.example.com"},
+                    "secrets": ["GRAFANA_TOKEN"],
+                }
+            }
+        }
+    )
+    assert errors == []
+    assert parsed is not None
+    assert parsed.connectors["grafana"].is_hosted
+
+
+def test_remote_connector_is_accepted() -> None:
+    parsed, errors = validate_connectors(
+        {"connectors": {"internal": {"url": "https://mcp.internal/mcp", "secrets": ["T"]}}}
+    )
+    assert errors == []
+    assert parsed is not None
+    assert not parsed.connectors["internal"].is_hosted
+
+
+def test_absent_file_is_fine(tmp_path: Path) -> None:
+    # A bundle with no hosted connectors simply omits the file.
+    assert validate_bundle(str(_bundle(tmp_path, None))).valid
+
+
+# --------------------------------------------------------------------------- #
+# Rejected shapes -- each would otherwise fail late and obscurely
+# --------------------------------------------------------------------------- #
+def test_both_image_and_url_is_ambiguous() -> None:
+    # Who owns the process? Guessing either way silently ignores half the spec.
+    assert "connectors.ambiguous" in _codes(
+        {"connectors": {"g": {"image": "x:1", "url": "https://y/mcp"}}}
+    )
+
+
+def test_neither_image_nor_url_is_underspecified() -> None:
+    assert "connectors.underspecified" in _codes({"connectors": {"g": {"secrets": ["T"]}}})
+
+
+def test_runtime_config_on_a_remote_connector_is_rejected() -> None:
+    # args/env configure a process Curie starts. On a url connector they would
+    # be accepted and then silently do nothing -- the worst kind of no-op.
+    assert "connectors.remote_has_runtime" in _codes(
+        {"connectors": {"g": {"url": "https://y/mcp", "env": {"A": "b"}}}}
+    )
+
+
+def test_headers_on_a_hosted_connector_are_rejected() -> None:
+    assert "connectors.hosted_has_headers" in _codes(
+        {"connectors": {"g": {"image": "x:1", "headers": {"Authorization": "Bearer x"}}}}
+    )
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "Grafana",  # uppercase -- not a DNS label
+        "grafana_mcp",  # underscore -- not a DNS label
+        "-grafana",  # leading dash
+        "grafana-",  # trailing dash
+        "g" * 41,  # over the cap
+        "",  # empty
+    ],
+)
+def test_name_must_be_a_dns_label(name: str) -> None:
+    # The name becomes a Kubernetes object name and a Service DNS label. A bad
+    # one fails at apply time with a message about the object, not the bundle.
+    assert "connectors.bad_name" in _codes({"connectors": {name: {"image": "x:1"}}})
+
+
+def test_unknown_key_is_rejected_not_ignored() -> None:
+    # This package is lenient elsewhere because real Claude Code bundles carry
+    # keys it does not model. connectors.yaml is Curie's own file with no
+    # external producer, so an unrecognised key is a typo -- and `secretz`
+    # silently ignored means a connector that starts without its credential.
+    assert _codes({"connectors": {"g": {"image": "x:1", "secretz": ["T"]}}}) != []
+
+
+def test_port_out_of_range_is_rejected() -> None:
+    assert "connectors.bad_port" in _codes({"connectors": {"g": {"image": "x:1", "port": 99999}}})
+
+
+def test_non_mapping_file_is_rejected() -> None:
+    assert "connectors.not_object" in _codes(["not", "a", "mapping"])
+
+
+# --------------------------------------------------------------------------- #
+# Reaching it through validate_bundle
+# --------------------------------------------------------------------------- #
+def test_bundle_surfaces_a_connector_error(tmp_path: Path) -> None:
+    root = _bundle(tmp_path, "connectors:\n  Bad_Name:\n    image: x:1\n")
+    result = validate_bundle(str(root))
+    assert not result.valid
+    assert any(e.code == "connectors.bad_name" for e in result.errors)
+
+
+def test_bundle_surfaces_unparseable_yaml(tmp_path: Path) -> None:
+    root = _bundle(tmp_path, "connectors:\n  g:\n   image: [unclosed\n")
+    result = validate_bundle(str(root))
+    assert not result.valid
+    assert any(e.code == "connectors.unreadable" for e in result.errors)
+
+
+def test_bundle_with_a_valid_connector_passes(tmp_path: Path) -> None:
+    root = _bundle(
+        tmp_path,
+        "connectors:\n  grafana:\n    image: grafana/mcp-grafana:0.17.2\n"
+        "    secrets: [GRAFANA_TOKEN]\n",
+    )
+    assert validate_bundle(str(root)).valid


### PR DESCRIPTION
Implements the contract half of ADR-0086 (now Accepted). Refs #1063, #1062.

**Landed on its own**, as `packages/CLAUDE.md` requires: *"a contract change must land as its own reviewed, backward-compatible change first, before dependent lanes proceed."* Rendering, CLI, and chart follow separately.

## What it adds

```yaml
# connectors.yaml
connectors:
  grafana:                                   # hosted -- Curie runs it
    image: grafana/mcp-grafana:0.17.2
    args: [-t, streamable-http, -disable-write]
    env: {GRAFANA_URL: "https://grafana.example.com"}
    secrets: [GRAFANA_SERVICE_ACCOUNT_TOKEN]

  internal:                                  # remote -- already running
    url: https://mcp.internal/mcp
    secrets: [INTERNAL_TOKEN]
```

Twelve lines to replace the ~180 of Kubernetes an author writes today for one connector.

## Validation catches what fails late

Each rejected case is one that would otherwise surface as an opaque apply failure, or — worse — a connector that comes up and quietly misbehaves:

| Rejected | Why it matters |
|---|---|
| `image` **and** `url` | who owns the process? Either guess silently ignores half the spec |
| neither | nothing to run |
| `args`/`env` on a `url` connector | they configure a process Curie starts; on a remote one they are accepted and then do nothing |
| a name that is not a DNS label | it becomes a Service name; the apply error talks about the object, not the bundle |
| an unknown key | see below |

## One deliberate divergence

`extra="forbid"`, against this package's lenient convention.

That leniency exists because real Claude Code bundles carry keys the MVP does not model, and rejecting them would reject valid bundles. **`connectors.yaml` is Curie's own file with no external producer** — so an unrecognised key is a typo, and `secretz` silently ignored means a connector that starts without its credential. The reasoning is in the model docstring so the next reader does not "fix" it.

## Compatibility

Additive and optional. A bundle with no hosted connectors omits the file; every existing bundle validates unchanged. Secrets are **names only** — values still arrive at deploy time via ADR-0009, so no new credential path and a bundle stays safe to commit.

No exported-schema change, so contract artifacts stay in sync.

## Verification

```
uv run pytest packages/ runner/tests -q   → 825 passed, 4 skipped
bash scripts/check-contracts.sh           → all committed artifacts current
uv run ruff check / mypy                  → clean, 164 files
```

15 new tests. Also flips ADR-0086 to `Accepted` on maintainer approval, which ADR-0085 requires before implementation may start.

## Next

Rendering (Deployment/Service/NetworkPolicy derived from the spec), then the CLI and chart wiring. The renderer is where the two defects we hit by hand become unrepresentable: a `podSelector` instead of an `ipBlock` of the ClusterIP, and a derived host allowlist.
