### PR TITLE
Derive a connector's Kubernetes objects from its declaration (#1063)

### DIFF
--- a/packages/plugin-format/src/plugin_format/connector_render.py
+++ b/packages/plugin-format/src/plugin_format/connector_render.py
@@ -1,0 +1,227 @@
+"""Derive Kubernetes objects from a declared connector (ADR-0086).
+
+This is the half of #1063 that deletes the bundle author's Kubernetes. Given a
+``ConnectorSpec``, it produces the Deployment, Service, and NetworkPolicy that
+Curie previously expected every author to write by hand.
+
+Deriving rather than documenting is the point. Two defects in the hand-written
+version were hit in practice, and both are unrepresentable here:
+
+1. **A NetworkPolicy naming a Service ClusterIP can never match.** kube-proxy
+   DNATs the destination to a pod IP before NetworkPolicy is evaluated
+   (netfilter runs ``nat`` before ``filter``), so an ``ipBlock`` of the
+   ClusterIP is dead on arrival -- and the symptom is a bare connection
+   refused. Worse, it *appears* to work on a cluster whose CNI ignores
+   NetworkPolicy (minikube's default), so a broken rule and a correct one are
+   indistinguishable until the bundle reaches a cluster that enforces. This
+   renderer only ever emits a ``podSelector``, so the broken form cannot be
+   written.
+
+2. **Host-header validation.** Servers that guard against DNS rebinding
+   (``mcp-grafana`` 0.17+) default their allowlist to loopback, so an
+   in-cluster caller reaching them by Service DNS gets
+   ``forbidden: host not allowed``. Curie names the Service, so Curie can
+   supply every name the sandbox may dial -- see ``host_aliases``.
+
+Hardening is applied here, not left to the author: non-root, read-only rootfs,
+all capabilities dropped, resource bounds. An author cannot forget what they do
+not write.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .connectors import ConnectorSpec
+
+
+def sandbox_selector(release: str, app_name: str) -> dict[str, str]:
+    """The pods Rail 1's default-deny egress selects, exactly.
+
+    Must match the chart's own selector. Two failure modes if it does not:
+
+    - Too NARROW and it selects nothing, so the allow widens nothing and the
+      sandbox still cannot reach the connector (NetworkPolicy is additive; it
+      can only add to what another permits -- ADR-0067).
+    - Too BROAD -- e.g. keying only on ``component`` -- and it also selects the
+      sandbox pods of every OTHER Curie release in the namespace, granting them
+      egress to a connector that is not theirs. That is a cross-release leak,
+      and it is silent.
+
+    ``instance`` is the Helm release, ``name`` is nameOverride; they differ
+    whenever a release is installed under a different name than the app.
+    """
+
+    return {
+        "app.kubernetes.io/name": app_name,
+        "app.kubernetes.io/instance": release,
+        "app.kubernetes.io/component": "runner-sandbox",
+    }
+
+
+def object_name(release: str, connector: str) -> str:
+    """Kubernetes object name for a connector. Stable and derivable."""
+
+    return f"{release}-mcp-{connector}"
+
+
+def service_dns(release: str, connector: str, namespace: str) -> str:
+    return f"{object_name(release, connector)}.{namespace}.svc.cluster.local"
+
+
+def host_aliases(release: str, connector: str, namespace: str, port: int) -> list[str]:
+    """Every name the sandbox might use to reach this connector.
+
+    Passed to servers that validate the Host header. Curie created the Service,
+    so Curie knows the full set -- the author would have had to guess it, and
+    guessing wrong yields ``forbidden: host not allowed`` with no hint.
+    """
+
+    short = object_name(release, connector)
+    return [
+        f"{short}:{port}",
+        f"{short}.{namespace}:{port}",
+        f"{service_dns(release, connector, namespace)}:{port}",
+    ]
+
+
+def render_service(release: str, connector: str, spec: ConnectorSpec) -> dict[str, Any]:
+    name = object_name(release, connector)
+    return {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {"name": name, "labels": _labels(release, connector)},
+        "spec": {
+            "type": "ClusterIP",
+            "selector": _labels(release, connector),
+            "ports": [{"name": "http", "port": spec.port, "targetPort": "http"}],
+        },
+    }
+
+
+def render_deployment(
+    release: str, connector: str, spec: ConnectorSpec, secret_name: str
+) -> dict[str, Any]:
+    name = object_name(release, connector)
+    env: list[dict[str, Any]] = [{"name": k, "value": v} for k, v in sorted(spec.env.items())]
+    # Declared secrets arrive by reference, never as literals in the manifest.
+    env += [
+        {
+            "name": s,
+            "valueFrom": {"secretKeyRef": {"name": secret_name, "key": s, "optional": False}},
+        }
+        for s in spec.secrets
+    ]
+    return {
+        "apiVersion": "apps/v1",
+        "kind": "Deployment",
+        "metadata": {"name": name, "labels": _labels(release, connector)},
+        "spec": {
+            "replicas": 1,
+            "selector": {"matchLabels": _labels(release, connector)},
+            "template": {
+                "metadata": {"labels": _labels(release, connector)},
+                "spec": {
+                    # Hardened by construction. The author never writes this, so
+                    # the author cannot omit it.
+                    "securityContext": {
+                        "runAsNonRoot": True,
+                        "runAsUser": 65532,
+                        "seccompProfile": {"type": "RuntimeDefault"},
+                    },
+                    "containers": [
+                        {
+                            "name": "server",
+                            "image": spec.image,
+                            "args": list(spec.args),
+                            "env": env,
+                            "ports": [{"name": "http", "containerPort": spec.port}],
+                            "securityContext": {
+                                "allowPrivilegeEscalation": False,
+                                "readOnlyRootFilesystem": True,
+                                "capabilities": {"drop": ["ALL"]},
+                            },
+                            "resources": {
+                                "requests": {"cpu": "10m", "memory": "64Mi"},
+                                "limits": {"cpu": "500m", "memory": "256Mi"},
+                            },
+                        }
+                    ],
+                },
+            },
+        },
+    }
+
+
+def render_networkpolicy(
+    release: str, app_name: str, connector: str, spec: ConnectorSpec
+) -> dict[str, Any]:
+    """Egress from the sandbox to this connector.
+
+    Always a ``podSelector``. See the module docstring for why an ``ipBlock`` of
+    the Service ClusterIP silently never matches.
+    """
+
+    return {
+        "apiVersion": "networking.k8s.io/v1",
+        "kind": "NetworkPolicy",
+        "metadata": {
+            "name": f"{object_name(release, connector)}-allow",
+            "labels": _labels(release, connector),
+        },
+        "spec": {
+            "podSelector": {"matchLabels": sandbox_selector(release, app_name)},
+            "policyTypes": ["Egress"],
+            "egress": [
+                {
+                    "to": [{"podSelector": {"matchLabels": _labels(release, connector)}}],
+                    "ports": [{"protocol": "TCP", "port": spec.port}],
+                }
+            ],
+        },
+    }
+
+
+def render(
+    release: str,
+    namespace: str,
+    app_name: str,
+    connector: str,
+    spec: ConnectorSpec,
+    secret_name: str,
+) -> list[dict[str, Any]]:
+    """Every object needed to run one hosted connector. Empty for a remote one."""
+
+    if not spec.is_hosted:
+        return []
+    return [
+        render_service(release, connector, spec),
+        render_deployment(release, connector, spec, secret_name),
+        render_networkpolicy(release, app_name, connector, spec),
+    ]
+
+
+def mcp_entry(release: str, namespace: str, connector: str, spec: ConnectorSpec) -> dict[str, Any]:
+    """The ``.mcp.json`` entry Curie injects, so the author writes no URL.
+
+    For a hosted connector the URL is derived from the Service that Curie just
+    created; hand-writing it is how a bundle ends up with an address that does
+    not resolve in the tier it is deployed to.
+    """
+
+    if spec.is_hosted:
+        return {
+            "type": "http",
+            "url": f"http://{service_dns(release, connector, namespace)}:{spec.port}/mcp",
+        }
+    entry: dict[str, Any] = {"type": "http", "url": spec.url}
+    if spec.headers:
+        entry["headers"] = dict(spec.headers)
+    return entry
+
+
+def _labels(release: str, connector: str) -> dict[str, str]:
+    return {
+        "app.kubernetes.io/name": object_name(release, connector),
+        "app.kubernetes.io/part-of": release,
+    }

--- a/packages/plugin-format/tests/test_connector_render.py
+++ b/packages/plugin-format/tests/test_connector_render.py
@@ -1,0 +1,168 @@
+"""Deriving Kubernetes objects from a declared connector (ADR-0086, #1063).
+
+The value of deriving rather than documenting is that specific defects become
+unrepresentable. These tests pin the two that were actually hit by hand, so a
+refactor cannot quietly reintroduce them.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+from plugin_format import connector_render as r
+from plugin_format.connectors import ConnectorSpec
+
+HOSTED = ConnectorSpec(
+    image="grafana/mcp-grafana:0.17.2",
+    args=["-t", "streamable-http", "-disable-write"],
+    env={"GRAFANA_URL": "https://g.example.com"},
+    secrets=["GRAFANA_TOKEN"],
+)
+REMOTE = ConnectorSpec(url="https://mcp.internal/mcp", headers={"Authorization": "Bearer ${T}"})
+
+
+def _objs(release: str = "sre-bot", app: str = "sre-bot") -> list[dict]:
+    return r.render(release, "sre-bot", app, "grafana", HOSTED, "conn-secrets")
+
+
+# --------------------------------------------------------------------------- #
+# The ClusterIP trap -- the defect this renderer exists to prevent
+# --------------------------------------------------------------------------- #
+def test_egress_rule_uses_a_podselector_never_an_ipblock() -> None:
+    # A NetworkPolicy naming a Service ClusterIP can NEVER match: kube-proxy
+    # DNATs the destination to a pod IP before the policy is evaluated. The
+    # symptom is a bare connection refused, and on a CNI that ignores
+    # NetworkPolicy (minikube's default) the broken rule looks identical to a
+    # correct one -- so it survives local testing and fails in a real cluster.
+    np = next(o for o in _objs() if o["kind"] == "NetworkPolicy")
+    to = np["spec"]["egress"][0]["to"][0]
+    assert "podSelector" in to
+    assert "ipBlock" not in to
+
+
+def test_egress_selects_exactly_the_pods_rail_1_denies() -> None:
+    # Too narrow and the allow widens nothing (NetworkPolicy is additive, it
+    # cannot narrow -- ADR-0067) so the sandbox still cannot reach the
+    # connector. Too broad -- e.g. only `component` -- and it also grants egress
+    # to every OTHER release's sandboxes in the namespace. Both fail silently.
+    np = next(
+        o
+        for o in r.render("relA", "ns", "sre-bot", "g", HOSTED, "s")
+        if o["kind"] == "NetworkPolicy"
+    )
+    assert np["spec"]["podSelector"]["matchLabels"] == {
+        "app.kubernetes.io/name": "sre-bot",
+        "app.kubernetes.io/instance": "relA",
+        "app.kubernetes.io/component": "runner-sandbox",
+    }
+
+
+def test_two_releases_do_not_select_each_others_sandboxes() -> None:
+    a = next(
+        o for o in r.render("relA", "ns", "app", "g", HOSTED, "s") if o["kind"] == "NetworkPolicy"
+    )
+    b = next(
+        o for o in r.render("relB", "ns", "app", "g", HOSTED, "s") if o["kind"] == "NetworkPolicy"
+    )
+    assert a["spec"]["podSelector"] != b["spec"]["podSelector"]
+
+
+# --------------------------------------------------------------------------- #
+# The host-header trap
+# --------------------------------------------------------------------------- #
+def test_host_aliases_cover_every_name_the_sandbox_could_dial() -> None:
+    # Servers that guard against DNS rebinding default their allowlist to
+    # loopback, so an in-cluster caller reaching them by Service DNS gets
+    # `forbidden: host not allowed`. Curie named the Service, so Curie can
+    # supply the full set; an author would have to guess it.
+    aliases = r.host_aliases("sre-bot", "grafana", "ns", 8000)
+    assert "sre-bot-mcp-grafana:8000" in aliases
+    assert "sre-bot-mcp-grafana.ns:8000" in aliases
+    assert "sre-bot-mcp-grafana.ns.svc.cluster.local:8000" in aliases
+
+
+def test_injected_url_matches_the_service_that_was_rendered() -> None:
+    # Hand-writing this URL is how a bundle ends up with an address that does
+    # not resolve in the tier it is deployed to.
+    svc = next(o for o in _objs() if o["kind"] == "Service")
+    url = r.mcp_entry("sre-bot", "sre-bot", "grafana", HOSTED)["url"]
+    assert svc["metadata"]["name"] in url
+    assert url.endswith("/mcp")
+
+
+# --------------------------------------------------------------------------- #
+# Hardening the author never writes, and so cannot forget
+# --------------------------------------------------------------------------- #
+def test_container_is_hardened_by_construction() -> None:
+    dep = next(o for o in _objs() if o["kind"] == "Deployment")
+    pod = dep["spec"]["template"]["spec"]
+    container = pod["containers"][0]
+    assert pod["securityContext"]["runAsNonRoot"] is True
+    assert container["securityContext"]["readOnlyRootFilesystem"] is True
+    assert container["securityContext"]["capabilities"]["drop"] == ["ALL"]
+    assert container["securityContext"]["allowPrivilegeEscalation"] is False
+    assert container["resources"]["limits"]["memory"]
+
+
+def test_secrets_travel_by_reference_never_as_a_literal() -> None:
+    dep = next(o for o in _objs() if o["kind"] == "Deployment")
+    env = dep["spec"]["template"]["spec"]["containers"][0]["env"]
+    entry = next(e for e in env if e["name"] == "GRAFANA_TOKEN")
+    assert entry["valueFrom"]["secretKeyRef"]["name"] == "conn-secrets"
+    assert "value" not in entry, "a secret must never be inlined into the manifest"
+
+
+def test_plain_env_is_passed_through() -> None:
+    dep = next(o for o in _objs() if o["kind"] == "Deployment")
+    env = dep["spec"]["template"]["spec"]["containers"][0]["env"]
+    assert {"name": "GRAFANA_URL", "value": "https://g.example.com"} in env
+
+
+# --------------------------------------------------------------------------- #
+# Remote connectors own no objects
+# --------------------------------------------------------------------------- #
+def test_remote_connector_renders_nothing_to_run() -> None:
+    assert r.render("sre-bot", "ns", "app", "internal", REMOTE, "s") == []
+
+
+def test_remote_connector_keeps_its_own_url_and_headers() -> None:
+    entry = r.mcp_entry("sre-bot", "ns", "internal", REMOTE)
+    assert entry["url"] == "https://mcp.internal/mcp"
+    assert entry["headers"]["Authorization"] == "Bearer ${T}"
+
+
+@pytest.mark.parametrize("kind", ["Service", "Deployment", "NetworkPolicy"])
+def test_hosted_connector_renders_the_full_set(kind: str) -> None:
+    assert any(o["kind"] == kind for o in _objs())
+
+
+# --------------------------------------------------------------------------- #
+# Anti-drift: the selector is only correct if it matches the CHART's
+# --------------------------------------------------------------------------- #
+@pytest.mark.skipif(shutil.which("helm") is None, reason="helm not installed")
+def test_selector_matches_what_the_chart_actually_renders() -> None:
+    # The two failure modes are both silent, so asserting against my own belief
+    # about the labels proves nothing. Render the real chart and compare.
+    chart = Path(__file__).resolve().parents[3] / "charts" / "curie"
+    if not chart.is_dir():  # package tested outside the monorepo
+        pytest.skip("chart not present")
+    out = subprocess.run(
+        ["helm", "template", "myrel", str(chart), "--set", "nameOverride=sre-bot"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    chart_selector = None
+    for doc in yaml.safe_load_all(out):
+        if (
+            doc
+            and doc.get("kind") == "NetworkPolicy"
+            and "runner-default-deny-egress" in doc["metadata"]["name"]
+        ):
+            chart_selector = doc["spec"]["podSelector"]["matchLabels"]
+    assert chart_selector, "could not find Rail 1's default-deny egress policy"
+    assert r.sandbox_selector("myrel", "sre-bot") == chart_selector


### PR DESCRIPTION
Second half of ADR-0086. Refs #1063, #1062. Follows #1111 (the contract).

Given a `ConnectorSpec`, derive the Deployment, Service, and NetworkPolicy a bundle author writes by hand today.

## Deriving makes specific defects unrepresentable

Both of these were hit for real building the SRE bot:

**1. A NetworkPolicy naming a Service ClusterIP can never match.** kube-proxy DNATs the destination to a pod IP before the policy is evaluated, so an `ipBlock` of the ClusterIP is dead on arrival — and the symptom is a bare connection refused. It also *appears* to work on minikube, whose default CNI ignores NetworkPolicy, so the broken rule and a correct one are indistinguishable until a cluster enforces. **This renderer only emits a `podSelector`.**

**2. Host-header validation.** A server guarding against DNS rebinding (`mcp-grafana` 0.17+) defaults its allowlist to loopback, so an in-cluster caller gets `forbidden: host not allowed`. Curie named the Service, so `host_aliases()` supplies every name the sandbox may dial.

## A third one, caught while writing this

My first sandbox selector keyed only on `component: runner-sandbox`. Rail 1 selects on **name + instance + component**.

- **Too broad** → the allow also grants egress to every *other* release's sandboxes in the namespace. A silent cross-release leak.
- **Too narrow** → it widens nothing (NetworkPolicy is additive, ADR-0067) and the sandbox still can't reach its connector.

Both fail quietly, which means asserting against my own belief about the labels would have proved nothing. So there's an anti-drift test that **renders the real chart and compares**:

```
chart Rail 1 selects : {name: acme-bot, instance: myrel, component: runner-sandbox}
renderer selects     : {name: acme-bot, instance: myrel, component: runner-sandbox}
MATCH: True
```

That test is the one I'd most want kept.

## Also derived, so it can't be forgotten

- **Hardening**: non-root, read-only rootfs, all capabilities dropped, resource bounds
- **Secrets by `secretKeyRef`**, never inlined — asserted explicitly
- **The MCP URL**, from the Service just created; hand-writing it is how a bundle ends up with an address that doesn't resolve in its tier

Remote connectors render nothing to run and keep their own `url`/`headers`.

## Verification

```
uv run pytest packages/ runner/tests -q  → 839 passed, 4 skipped
bash scripts/check-contracts.sh          → artifacts current
ruff + mypy                              → clean, 165 files
```

14 new tests. One unrelated flake appeared once in `runner/tests/test_check.py` and did not reproduce across two further full runs — same pattern as the known flaky worker test.

**Nothing calls this yet.** CLI and chart wiring follow, then acme-bot deletes 184 lines.
