### PR TITLE
API renders connector manifests, and never applies them (#1063)

### DIFF
--- a/apps/api/src/curie_api/bundles.py
+++ b/apps/api/src/curie_api/bundles.py
@@ -11,7 +11,9 @@ import tarfile
 import tempfile
 import zipfile
 from pathlib import Path
+from typing import Any
 
+import yaml
 from plugin_format import (
     DEFAULT_MAX_COMPRESSION_RATIO,
     DEFAULT_MAX_MEMBERS,
@@ -20,9 +22,12 @@ from plugin_format import (
     UnsupportedArchive,
     ValidationResult,
     bundle_root,
+    connector_render,
     safe_extract,
     validate_bundle,
 )
+from plugin_format.connectors import ConnectorsFile, validate_connectors
+from plugin_format.validate import CONNECTORS_FILE
 
 # Re-exported so existing catchers (gitflow.py, routers/bundles.py, tests) keep
 # resolving ``bundles.UnsupportedArchive`` after the extraction logic moved to
@@ -89,6 +94,64 @@ def extract_and_validate(
     )
     result = validate_bundle(bundle_root(dest))
     return extension, content_type, result
+
+
+def read_connectors(root: Path) -> ConnectorsFile:
+    """Parse a validated bundle's ``connectors.yaml``, or an empty set.
+
+    Safe to call only after ``validate_bundle`` has passed: every malformed
+    shape is already rejected there, so this cannot be the place a bad
+    declaration first surfaces.
+    """
+
+    path = bundle_root(root) / CONNECTORS_FILE
+    if not path.is_file():
+        return ConnectorsFile()
+    parsed, errors = validate_connectors(yaml.safe_load(path.read_text(encoding="utf-8")))
+    if errors or parsed is None:  # pragma: no cover -- validate_bundle gates this
+        return ConnectorsFile()
+    return parsed
+
+
+def render_connector_manifests(
+    connectors: ConnectorsFile,
+    *,
+    release: str,
+    namespace: str,
+    app_name: str,
+    secret_name: str,
+) -> list[dict[str, Any]]:
+    """Kubernetes objects for a bundle's hosted connectors (ADR-0086, #1063).
+
+    The API renders but never applies. Rendering is a pure function, so it needs
+    no cluster access, and the API's RBAC stays the deliberately read-only
+    `pods: list` + `pods/log: get` it has today -- which matters because this is
+    the component that receives webhooks from the internet. The CLI applies the
+    result with the operator's own kubectl credentials, so cluster-write
+    authority stays where it already was.
+    """
+
+    objects: list[dict[str, Any]] = []
+    for name, spec in sorted(connectors.connectors.items()):
+        objects.extend(
+            connector_render.render(release, namespace, app_name, name, spec, secret_name)
+        )
+    return objects
+
+
+def connector_mcp_entries(
+    connectors: ConnectorsFile, *, release: str, namespace: str
+) -> dict[str, Any]:
+    """The `.mcp.json` entries for declared connectors, keyed by name.
+
+    Derived from the Service the manifests define, so an author never writes a
+    URL that resolves in one tier and not another.
+    """
+
+    return {
+        name: connector_render.mcp_entry(release, namespace, name, spec)
+        for name, spec in sorted(connectors.connectors.items())
+    }
 
 
 def _collect_text_files(root: Path) -> list[tuple[str, str]]:

--- a/apps/api/tests/test_bundle_connectors.py
+++ b/apps/api/tests/test_bundle_connectors.py
@@ -1,0 +1,112 @@
+"""The API renders connector manifests but never applies them (ADR-0086, #1063).
+
+The split is the security property worth pinning: rendering is a pure function,
+so the API needs no cluster access to do it, and its deliberately read-only RBAC
+(`pods: list`, `pods/log: get`) is untouched. That matters because the API is
+the component that receives webhooks from the internet. Applying happens in the
+CLI, under the operator's own kubectl credentials.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from curie_api import bundles
+
+
+def _bundle(root: Path, connectors_yaml: str | None = None) -> Path:
+    inner = root / "b"
+    (inner / ".claude-plugin").mkdir(parents=True, exist_ok=True)
+    (inner / ".claude-plugin" / "plugin.json").write_text(
+        json.dumps({"name": "sre-bot", "version": "0.1.0", "description": "t"}), encoding="utf-8"
+    )
+    (inner / "skills" / "sre-bot").mkdir(parents=True, exist_ok=True)
+    (inner / "skills" / "sre-bot" / "SKILL.md").write_text(
+        "---\nname: sre-bot\ndescription: t\n---\nhi\n", encoding="utf-8"
+    )
+    if connectors_yaml is not None:
+        (inner / "connectors.yaml").write_text(connectors_yaml, encoding="utf-8")
+    return root
+
+
+HOSTED = (
+    "connectors:\n"
+    "  grafana:\n"
+    "    image: grafana/mcp-grafana:0.17.2\n"
+    "    args: [-t, streamable-http]\n"
+    "    env: {GRAFANA_URL: 'https://g.example.com'}\n"
+    "    secrets: [GRAFANA_TOKEN]\n"
+)
+
+
+def _render(root: Path) -> list[dict]:
+    return bundles.render_connector_manifests(
+        bundles.read_connectors(root),
+        release="sre-bot",
+        namespace="sre-bot",
+        app_name="sre-bot",
+        secret_name="sre-bot-connectors",
+    )
+
+
+def test_bundle_without_connectors_renders_nothing(tmp_path: Path) -> None:
+    assert _render(_bundle(tmp_path)) == []
+
+
+def test_hosted_connector_renders_the_full_object_set(tmp_path: Path) -> None:
+    kinds = [o["kind"] for o in _render(_bundle(tmp_path, HOSTED))]
+    assert kinds == ["Service", "Deployment", "NetworkPolicy"]
+
+
+def test_rendering_needs_no_cluster_access(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # The whole reason the API may do this: it is a pure function. If rendering
+    # ever reached for a kube client, the API would need cluster-write RBAC --
+    # on the service that receives internet webhooks.
+    import curie_api.k8s as k8s_mod
+
+    def _explode(*_a: object, **_k: object) -> None:
+        raise AssertionError("rendering must not touch the cluster")
+
+    for attr in dir(k8s_mod):
+        if attr.startswith("_"):
+            continue
+        obj = getattr(k8s_mod, attr)
+        if callable(obj) and not isinstance(obj, type):
+            monkeypatch.setattr(k8s_mod, attr, _explode, raising=False)
+
+    assert _render(_bundle(tmp_path, HOSTED))  # renders fine with k8s poisoned
+
+
+def test_secret_is_referenced_not_inlined(tmp_path: Path) -> None:
+    dep = next(o for o in _render(_bundle(tmp_path, HOSTED)) if o["kind"] == "Deployment")
+    env = dep["spec"]["template"]["spec"]["containers"][0]["env"]
+    token = next(e for e in env if e["name"] == "GRAFANA_TOKEN")
+    assert token["valueFrom"]["secretKeyRef"]["name"] == "sre-bot-connectors"
+    assert "value" not in token
+
+
+def test_egress_policy_uses_a_podselector(tmp_path: Path) -> None:
+    # The ClusterIP form silently never matches; see connector_render's module
+    # docstring. Pinned here too because this is the path a real deploy takes.
+    np = next(o for o in _render(_bundle(tmp_path, HOSTED)) if o["kind"] == "NetworkPolicy")
+    assert "podSelector" in np["spec"]["egress"][0]["to"][0]
+
+
+def test_mcp_entry_url_matches_the_rendered_service(tmp_path: Path) -> None:
+    root = _bundle(tmp_path, HOSTED)
+    svc = next(o for o in _render(root) if o["kind"] == "Service")
+    entries = bundles.connector_mcp_entries(
+        bundles.read_connectors(root), release="sre-bot", namespace="sre-bot"
+    )
+    assert svc["metadata"]["name"] in entries["grafana"]["url"]
+
+
+def test_remote_connector_contributes_an_entry_but_no_objects(tmp_path: Path) -> None:
+    root = _bundle(tmp_path, "connectors:\n  x:\n    url: https://mcp.internal/mcp\n")
+    assert _render(root) == []
+    entries = bundles.connector_mcp_entries(
+        bundles.read_connectors(root), release="sre-bot", namespace="sre-bot"
+    )
+    assert entries["x"]["url"] == "https://mcp.internal/mcp"


### PR DESCRIPTION
Third piece of ADR-0086. Refs #1063, #1062. Follows #1111 (contract) and #1112 (renderer).

The API turns a bundle's `connectors.yaml` into Kubernetes objects. **Something else applies them.**

## The split is the point

This resolves the design question ADR-0086 left open — *which component does it* — and it's the part with security consequences.

| | API renders, CLI applies | API applies |
|---|---|---|
| API RBAC | unchanged: `pods: list`, `pods/log: get` | needs create/delete on Deployments, Services, NetworkPolicies |
| On the internet-facing service? | no new privilege | **cluster-write on the webhook receiver** |
| Renderer implementations | one | one |

Rendering is a **pure function**, so the API needs no cluster access to do it. Applying happens in the CLI under the operator's own kubectl credentials — where cluster-write authority already lived.

There's a test that pins this: it poisons every callable in `curie_api.k8s` and asserts rendering still succeeds. If rendering ever reaches for a kube client, that test fails and the RBAC question comes back.

## The alternative I rejected

Rendering in the CLI. That meant reimplementing ~120 lines in Rust and maintaining two renderers that can drift — exactly what this repo avoids with codegen elsewhere. Separating render from apply gets one implementation *and* no new privilege.

I'd originally recommended the CLI version. Finding that the API already imports `plugin_format` — it validates every bundle through it — made the better option visible.

## What's here

- `read_connectors` — parses a **validated** bundle's declaration, so a malformed one cannot first surface at render time
- `render_connector_manifests` — Service, Deployment, NetworkPolicy per hosted connector
- `connector_mcp_entries` — the derived URL, so no author hand-writes an address that resolves in one tier and not another

**No endpoint and no schema field yet.** The wiring into the deploy response ships with the CLI change that consumes it, so neither half lands dangling.

## Verification

```
uv run pytest packages/ runner/tests apps/api/tests/… -q  → 874 passed, 4 skipped
uv run mypy                                                → clean, 165 files
uv run ruff check .                                        → clean
bash scripts/check-contracts.sh                            → artifacts current
test_openapi_drift                                         → passed (no router change)
```

7 new tests.
