### PR TITLE
Render connectors over the API, apply them from the CLI (#1063)

### DIFF
--- a/apps/api/alembic/env.py
+++ b/apps/api/alembic/env.py
@@ -34,16 +34,12 @@ def _relocate_legacy_version_table(connection: Connection) -> None:
     the transition is a no-op for the app and unblocks a Langfuse co-tenant. On a
     fresh database neither table exists yet and this is a no-op.
     """
-    public_tbl = connection.exec_driver_sql(
-        "SELECT to_regclass('public.alembic_version')"
-    ).scalar()
+    public_tbl = connection.exec_driver_sql("SELECT to_regclass('public.alembic_version')").scalar()
     schema_tbl = connection.exec_driver_sql(
         f"SELECT to_regclass('{SCHEMA}.alembic_version')"
     ).scalar()
     if public_tbl is not None and schema_tbl is None:
-        connection.exec_driver_sql(
-            f'ALTER TABLE public.alembic_version SET SCHEMA "{SCHEMA}"'
-        )
+        connection.exec_driver_sql(f'ALTER TABLE public.alembic_version SET SCHEMA "{SCHEMA}"')
 
 
 def do_run_migrations(connection: Connection) -> None:

--- a/apps/api/alembic/versions/0001_initial.py
+++ b/apps/api/alembic/versions/0001_initial.py
@@ -54,14 +54,10 @@ def upgrade() -> None:
             server_default=sa.func.now(),
             nullable=False,
         ),
-        sa.ForeignKeyConstraint(
-            ["agent_id"], [f"{SCHEMA}.agents.id"], ondelete="CASCADE"
-        ),
+        sa.ForeignKeyConstraint(["agent_id"], [f"{SCHEMA}.agents.id"], ondelete="CASCADE"),
         schema=SCHEMA,
     )
-    op.create_index(
-        "ix_agent_versions_agent_id", "agent_versions", ["agent_id"], schema=SCHEMA
-    )
+    op.create_index("ix_agent_versions_agent_id", "agent_versions", ["agent_id"], schema=SCHEMA)
 
     op.create_table(
         "deployments",
@@ -69,18 +65,14 @@ def upgrade() -> None:
         sa.Column("agent_id", postgresql.UUID(as_uuid=True), nullable=False),
         sa.Column("version_id", postgresql.UUID(as_uuid=True), nullable=False),
         sa.Column("environment", environment, nullable=False),
-        sa.Column(
-            "status", sa.String(), server_default="active", nullable=False
-        ),
+        sa.Column("status", sa.String(), server_default="active", nullable=False),
         sa.Column(
             "deployed_at",
             sa.DateTime(timezone=True),
             server_default=sa.func.now(),
             nullable=False,
         ),
-        sa.ForeignKeyConstraint(
-            ["agent_id"], [f"{SCHEMA}.agents.id"], ondelete="CASCADE"
-        ),
+        sa.ForeignKeyConstraint(["agent_id"], [f"{SCHEMA}.agents.id"], ondelete="CASCADE"),
         sa.ForeignKeyConstraint(
             ["version_id"],
             [f"{SCHEMA}.agent_versions.id"],
@@ -88,19 +80,13 @@ def upgrade() -> None:
         ),
         schema=SCHEMA,
     )
-    op.create_index(
-        "ix_deployments_agent_id", "deployments", ["agent_id"], schema=SCHEMA
-    )
-    op.create_index(
-        "ix_deployments_version_id", "deployments", ["version_id"], schema=SCHEMA
-    )
+    op.create_index("ix_deployments_agent_id", "deployments", ["agent_id"], schema=SCHEMA)
+    op.create_index("ix_deployments_version_id", "deployments", ["version_id"], schema=SCHEMA)
 
 
 def downgrade() -> None:
     op.drop_table("deployments", schema=SCHEMA)
     op.drop_table("agent_versions", schema=SCHEMA)
     op.drop_table("agents", schema=SCHEMA)
-    postgresql.ENUM(name="environment", schema=SCHEMA).drop(
-        op.get_bind(), checkfirst=True
-    )
+    postgresql.ENUM(name="environment", schema=SCHEMA).drop(op.get_bind(), checkfirst=True)
     op.execute(f"DROP SCHEMA IF EXISTS {SCHEMA}")

--- a/apps/api/alembic/versions/0003_gitflow.py
+++ b/apps/api/alembic/versions/0003_gitflow.py
@@ -59,9 +59,7 @@ def upgrade() -> None:
 def downgrade() -> None:
     op.drop_column("deployments", "commit_sha", schema=SCHEMA)
     op.drop_column("deployments", "bot_identity", schema=SCHEMA)
-    op.drop_index(
-        "ix_agent_versions_commit_sha", "agent_versions", schema=SCHEMA
-    )
+    op.drop_index("ix_agent_versions_commit_sha", "agent_versions", schema=SCHEMA)
     op.drop_column("agent_versions", "commit_sha", schema=SCHEMA)
     op.drop_index("ix_agents_repo_full_name", "agents", schema=SCHEMA)
     op.drop_column("agents", "repo_full_name", schema=SCHEMA)

--- a/apps/api/alembic/versions/0006_workflow_state.py
+++ b/apps/api/alembic/versions/0006_workflow_state.py
@@ -28,20 +28,12 @@ def upgrade() -> None:
         sa.Column("key", sa.String(), nullable=False),
         sa.Column("value", postgresql.JSONB(), nullable=False),
         sa.Column("version", sa.Integer(), nullable=False, server_default="1"),
-        sa.Column(
-            "created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False
-        ),
-        sa.Column(
-            "updated_at", sa.DateTime(), server_default=sa.func.now(), nullable=False
-        ),
-        sa.ForeignKeyConstraint(
-            ["agent_id"], [f"{SCHEMA}.agents.id"], ondelete="CASCADE"
-        ),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.ForeignKeyConstraint(["agent_id"], [f"{SCHEMA}.agents.id"], ondelete="CASCADE"),
         # The composite unique constraint's index also serves lookups by
         # agent_id and by (agent_id, namespace) prefix, so no extra index needed.
-        sa.UniqueConstraint(
-            "agent_id", "namespace", "key", name="uq_state_agent_ns_key"
-        ),
+        sa.UniqueConstraint("agent_id", "namespace", "key", name="uq_state_agent_ns_key"),
         schema=SCHEMA,
     )
 

--- a/apps/api/alembic/versions/0008_approvals.py
+++ b/apps/api/alembic/versions/0008_approvals.py
@@ -35,19 +35,13 @@ def upgrade() -> None:
         sa.Column("expires_at", sa.DateTime(), nullable=True),
         sa.Column("resolved_by", sa.String(), nullable=True),
         sa.Column("resolution_note", sa.String(), nullable=True),
-        sa.Column(
-            "created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False
-        ),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
         sa.Column("resolved_at", sa.DateTime(), nullable=True),
-        sa.ForeignKeyConstraint(
-            ["agent_id"], [f"{SCHEMA}.agents.id"], ondelete="CASCADE"
-        ),
+        sa.ForeignKeyConstraint(["agent_id"], [f"{SCHEMA}.agents.id"], ondelete="CASCADE"),
         sa.UniqueConstraint("dedupe_key", name="uq_approvals_dedupe_key"),
         schema=SCHEMA,
     )
-    op.create_index(
-        "ix_approvals_agent_id", "approvals", ["agent_id"], schema=SCHEMA
-    )
+    op.create_index("ix_approvals_agent_id", "approvals", ["agent_id"], schema=SCHEMA)
     op.create_index(
         "ix_approvals_conversation_id",
         "approvals",

--- a/apps/api/alembic/versions/0010_approval_routes_audit.py
+++ b/apps/api/alembic/versions/0010_approval_routes_audit.py
@@ -28,9 +28,7 @@ def upgrade() -> None:
         sa.Column("approval_routes", postgresql.JSONB(), nullable=True),
         schema=SCHEMA,
     )
-    op.add_column(
-        "approvals", sa.Column("route", sa.String(), nullable=True), schema=SCHEMA
-    )
+    op.add_column("approvals", sa.Column("route", sa.String(), nullable=True), schema=SCHEMA)
     op.add_column(
         "approvals",
         sa.Column("card_channel", sa.String(), nullable=True),
@@ -47,12 +45,8 @@ def upgrade() -> None:
         sa.Column("authorizer", sa.String(), nullable=False),
         sa.Column("authorized", sa.Boolean(), nullable=False),
         sa.Column("reason", sa.String(), nullable=True),
-        sa.Column(
-            "created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False
-        ),
-        sa.ForeignKeyConstraint(
-            ["approval_id"], [f"{SCHEMA}.approvals.id"], ondelete="CASCADE"
-        ),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.ForeignKeyConstraint(["approval_id"], [f"{SCHEMA}.approvals.id"], ondelete="CASCADE"),
         schema=SCHEMA,
     )
     op.create_index(
@@ -64,9 +58,7 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.drop_index(
-        "ix_approval_audit_entries_approval_id", "approval_audit_entries", schema=SCHEMA
-    )
+    op.drop_index("ix_approval_audit_entries_approval_id", "approval_audit_entries", schema=SCHEMA)
     op.drop_table("approval_audit_entries", schema=SCHEMA)
     op.drop_column("approvals", "card_channel", schema=SCHEMA)
     op.drop_column("approvals", "route", schema=SCHEMA)

--- a/apps/api/alembic/versions/0015_approval_gate_provenance.py
+++ b/apps/api/alembic/versions/0015_approval_gate_provenance.py
@@ -95,8 +95,6 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     # Drop the CHECK before the columns it references.
-    op.drop_constraint(
-        "ck_approvals_gate_kind", "approvals", schema=SCHEMA, type_="check"
-    )
+    op.drop_constraint("ck_approvals_gate_kind", "approvals", schema=SCHEMA, type_="check")
     op.drop_column("approvals", "granted_tool", schema=SCHEMA)
     op.drop_column("approvals", "gate_kind", schema=SCHEMA)

--- a/apps/api/alembic/versions/0017_agent_channel_unique.py
+++ b/apps/api/alembic/versions/0017_agent_channel_unique.py
@@ -57,9 +57,7 @@ def upgrade() -> None:
             "inert. Re-point them to their own channels or delete them, then re-run "
             "this migration."
         )
-    op.create_unique_constraint(
-        CONSTRAINT, "agents", ["slack_channel"], schema=SCHEMA
-    )
+    op.create_unique_constraint(CONSTRAINT, "agents", ["slack_channel"], schema=SCHEMA)
 
 
 def downgrade() -> None:

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -945,6 +945,26 @@
         "title": "BundleOut",
         "type": "object"
       },
+      "ConnectorManifests": {
+        "description": "Kubernetes objects derived from a version's ``connectors.yaml``.\n\nThe API renders; the caller applies. Rendering is a pure function of the\nbundle plus the deployment context the caller supplies, so producing this\nneeds no cluster access and the API's read-only RBAC is untouched\n(ADR-0086, #1063).",
+        "properties": {
+          "manifests": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "title": "Manifests",
+            "type": "array"
+          },
+          "mcp_entries": {
+            "additionalProperties": true,
+            "title": "Mcp Entries",
+            "type": "object"
+          }
+        },
+        "title": "ConnectorManifests",
+        "type": "object"
+      },
       "CostReport": {
         "description": "Daily spend series + total for an agent (L1 Cost view).",
         "properties": {
@@ -4467,6 +4487,103 @@
         "summary": "Upload Bundle",
         "tags": [
           "bundles"
+        ]
+      }
+    },
+    "/agents/{agent_id}/versions/{version_id}/connectors": {
+      "get": {
+        "description": "Render this version's declared connectors into Kubernetes objects.\n\nRead-only and side-effect free: the API computes the manifests and returns\nthem; the CALLER applies them with its own cluster credentials. That split\nis deliberate -- rendering is a pure function, so the API needs no cluster\naccess for it, and this service (which receives internet webhooks) keeps the\nread-only `pods: list` + `pods/log: get` RBAC it has today (ADR-0086).\n\n`release`, `namespace`, and `app_name` are supplied by the caller because\nthey are install-time facts the API does not know: the Helm release name and\nnameOverride live with whoever ran `cluster up`, not in the bundle.",
+        "operationId": "read_version_connectors_agents__agent_id__versions__version_id__connectors_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Agent Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "version_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Version Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "release",
+            "required": true,
+            "schema": {
+              "title": "Release",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "namespace",
+            "required": true,
+            "schema": {
+              "title": "Namespace",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "app_name",
+            "required": true,
+            "schema": {
+              "title": "App Name",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConnectorManifests"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Read Version Connectors",
+        "tags": [
+          "agents"
         ]
       }
     },

--- a/apps/api/src/curie_api/approvers.py
+++ b/apps/api/src/curie_api/approvers.py
@@ -65,9 +65,7 @@ class ApproverSet(Protocol):
     @property
     def audit_name(self) -> str: ...
 
-    async def contains(
-        self, actor: str, actor_channel: str | None
-    ) -> MembershipVerdict: ...
+    async def contains(self, actor: str, actor_channel: str | None) -> MembershipVerdict: ...
 
 
 class ExplicitUsers:
@@ -86,9 +84,7 @@ class ExplicitUsers:
     def __init__(self, users: Sequence[str]) -> None:
         self._users = tuple(users)
 
-    async def contains(
-        self, actor: str, actor_channel: str | None
-    ) -> MembershipVerdict:
+    async def contains(self, actor: str, actor_channel: str | None) -> MembershipVerdict:
         listed = actor in self._users
         evidence: dict[str, Any] = {
             "kind": "user_list",
@@ -128,9 +124,7 @@ class InvalidApprovers:
     def __init__(self, error: str) -> None:
         self._error = error
 
-    async def contains(
-        self, actor: str, actor_channel: str | None
-    ) -> MembershipVerdict:
+    async def contains(self, actor: str, actor_channel: str | None) -> MembershipVerdict:
         return MembershipVerdict(
             member=False,
             undetermined=True,

--- a/apps/api/src/curie_api/authorizer.py
+++ b/apps/api/src/curie_api/authorizer.py
@@ -42,9 +42,7 @@ from .models import Approval
 
 # The one wording for a self-approval refusal, so the dispatcher's rendering of
 # it does not depend on which set the approval happened to be bound to.
-_SELF_APPROVAL_REASON = (
-    "self-approval is blocked: the requester cannot resolve their own request"
-)
+_SELF_APPROVAL_REASON = "self-approval is blocked: the requester cannot resolve their own request"
 
 
 @dataclass(frozen=True)
@@ -92,7 +90,5 @@ async def authorize_approval(
         # Both refuse, and the set says why: it is the only one that knows
         # whether it could not determine membership or the actor is genuinely
         # outside the set.
-        return name, AuthzDecision(
-            allowed=False, reason=verdict.reason, evidence=verdict.evidence
-        )
+        return name, AuthzDecision(allowed=False, reason=verdict.reason, evidence=verdict.evidence)
     return name, AuthzDecision(allowed=True, evidence=verdict.evidence)

--- a/apps/api/src/curie_api/config.py
+++ b/apps/api/src/curie_api/config.py
@@ -32,9 +32,7 @@ class Settings(BaseSettings):
 
     # Postgres (async driver). Dedicated `curie` schema keeps our tables clear
     # of Langfuse's own tables on the same database.
-    database_url: str = (
-        "postgresql+asyncpg://postgres:postgres@localhost:25432/postgres"
-    )
+    database_url: str = "postgresql+asyncpg://postgres:postgres@localhost:25432/postgres"
     db_schema: str = "curie"
 
     # Single shared API key. Dev-only default; override in any shared deployment.
@@ -146,9 +144,7 @@ class Settings(BaseSettings):
     # graveyard watcher tracks the SAME stream the worker dead-letters to. Empty
     # derives `<runs_stream>:dead`. DISTINCT from `resume_dead_letter_stream` below
     # (the narrower ResumeQueue-only override); this is the general graveyard name.
-    dead_letter_stream: str = Field(
-        default="", validation_alias=DEAD_LETTER_STREAM_ENV
-    )
+    dead_letter_stream: str = Field(default="", validation_alias=DEAD_LETTER_STREAM_ENV)
 
     def dead_letter_stream_name(self) -> str:
         return derive_dead_letter_stream_name(self.runs_stream, self.dead_letter_stream)
@@ -245,9 +241,7 @@ class Settings(BaseSettings):
     def valkey_dsn(self) -> str:
         if self.valkey_url:
             return self.valkey_url
-        return (
-            f"redis://:{self.valkey_password}@{self.valkey_host}:{self.valkey_port}/0"
-        )
+        return f"redis://:{self.valkey_password}@{self.valkey_host}:{self.valkey_port}/0"
 
     @model_validator(mode="after")
     def _refuse_dev_defaults_in_prod(self) -> "Settings":

--- a/apps/api/src/curie_api/crud.py
+++ b/apps/api/src/curie_api/crud.py
@@ -19,9 +19,7 @@ from .models import (
 from .schemas import AgentCreate, ApprovalRequest, DeploymentCreate, VersionCreate
 
 
-async def get_version(
-    session: AsyncSession, version_id: uuid.UUID
-) -> AgentVersion | None:
+async def get_version(session: AsyncSession, version_id: uuid.UUID) -> AgentVersion | None:
     return await session.get(AgentVersion, version_id)
 
 
@@ -45,9 +43,7 @@ async def create_agent(session: AsyncSession, data: AgentCreate) -> Agent:
         repo_full_name=data.repo_full_name,
         model=data.model,
         behavior_packs=(
-            data.behavior_packs.model_dump()
-            if data.behavior_packs is not None
-            else None
+            data.behavior_packs.model_dump() if data.behavior_packs is not None else None
         ),
         approval_required_tools=data.approval_required_tools,
         approval_routes=(
@@ -72,9 +68,7 @@ async def get_agent(session: AsyncSession, agent_id: uuid.UUID) -> Agent | None:
     return await session.get(Agent, agent_id)
 
 
-async def agent_has_active_deployment(
-    session: AsyncSession, agent_id: uuid.UUID
-) -> bool:
+async def agent_has_active_deployment(session: AsyncSession, agent_id: uuid.UUID) -> bool:
     result = await session.scalar(
         select(Deployment.id)
         .where(Deployment.agent_id == agent_id, Deployment.status == "active")
@@ -88,28 +82,20 @@ async def delete_agent(session: AsyncSession, agent_id: uuid.UUID) -> None:
     # relationship cascade (which would emit an async lazy-load during flush) and
     # match the FK ondelete=CASCADE already declared on both child tables. Bundle
     # objects in MinIO are intentionally left in place (out of scope).
-    await session.execute(
-        delete(Deployment).where(Deployment.agent_id == agent_id)
-    )
-    await session.execute(
-        delete(AgentVersion).where(AgentVersion.agent_id == agent_id)
-    )
+    await session.execute(delete(Deployment).where(Deployment.agent_id == agent_id))
+    await session.execute(delete(AgentVersion).where(AgentVersion.agent_id == agent_id))
     await session.execute(delete(Agent).where(Agent.id == agent_id))
     await session.commit()
 
 
-async def update_agent_channel(
-    session: AsyncSession, agent: Agent, slack_channel: str
-) -> Agent:
+async def update_agent_channel(session: AsyncSession, agent: Agent, slack_channel: str) -> Agent:
     agent.slack_channel = slack_channel
     await session.commit()
     await session.refresh(agent)
     return agent
 
 
-async def update_agent_model(
-    session: AsyncSession, agent: Agent, model: str | None
-) -> Agent:
+async def update_agent_model(session: AsyncSession, agent: Agent, model: str | None) -> Agent:
     agent.model = model
     await session.commit()
     await session.refresh(agent)
@@ -172,9 +158,7 @@ async def update_agent_secrets(
     return agent
 
 
-async def get_agent_by_repo(
-    session: AsyncSession, repo_full_name: str
-) -> Agent | None:
+async def get_agent_by_repo(session: AsyncSession, repo_full_name: str) -> Agent | None:
     agent: Agent | None = await session.scalar(
         select(Agent).where(Agent.repo_full_name == repo_full_name)
     )
@@ -226,9 +210,7 @@ async def get_version_by_commit(
     return version
 
 
-async def list_versions(
-    session: AsyncSession, agent_id: uuid.UUID
-) -> list[AgentVersion]:
+async def list_versions(session: AsyncSession, agent_id: uuid.UUID) -> list[AgentVersion]:
     result = await session.scalars(
         select(AgentVersion)
         .where(AgentVersion.agent_id == agent_id)
@@ -258,9 +240,7 @@ async def create_deployment_row(
     return deployment
 
 
-async def create_deployment(
-    session: AsyncSession, data: DeploymentCreate
-) -> Deployment:
+async def create_deployment(session: AsyncSession, data: DeploymentCreate) -> Deployment:
     return await create_deployment_row(
         session,
         agent_id=data.agent_id,
@@ -302,9 +282,7 @@ async def list_deployments(
     return list(result)
 
 
-async def get_deployment(
-    session: AsyncSession, deployment_id: uuid.UUID
-) -> Deployment | None:
+async def get_deployment(session: AsyncSession, deployment_id: uuid.UUID) -> Deployment | None:
     return await session.get(Deployment, deployment_id)
 
 
@@ -347,9 +325,7 @@ async def get_approval(session: AsyncSession, approval_id: uuid.UUID) -> Approva
     return await session.get(Approval, approval_id)
 
 
-async def get_approval_route_binding(
-    session: AsyncSession, approval: Approval
-) -> Any:
+async def get_approval_route_binding(session: AsyncSession, approval: Approval) -> Any:
     """The route binding governing ``approval``, read fresh at resolve time
     (#420), or None when there is none to read.
 
@@ -378,9 +354,7 @@ async def get_approval_route_binding(
     return agent.approval_routes.get(approval.route)
 
 
-async def get_approval_by_dedupe_key(
-    session: AsyncSession, dedupe_key: str
-) -> Approval | None:
+async def get_approval_by_dedupe_key(session: AsyncSession, dedupe_key: str) -> Approval | None:
     result: Approval | None = await session.scalar(
         select(Approval).where(Approval.dedupe_key == dedupe_key)
     )
@@ -467,9 +441,7 @@ async def list_expired_pending_approvals(
     return list(result)
 
 
-async def expire_approval(
-    session: AsyncSession, approval_id: uuid.UUID
-) -> Approval | None:
+async def expire_approval(session: AsyncSession, approval_id: uuid.UUID) -> Approval | None:
     """Flip a pending approval past its SLA to expired (same CAS guard, so an
     in-flight resolution that already won is never overwritten)."""
 
@@ -561,9 +533,7 @@ _RESUMABLE_STATUSES = (
 )
 
 
-async def claim_resume_row(
-    session: AsyncSession, approval_id: uuid.UUID
-) -> Approval | None:
+async def claim_resume_row(session: AsyncSession, approval_id: uuid.UUID) -> Approval | None:
     """Atomically claim one owed-wake row for this reconcile pass (#411).
 
     ``SELECT ... FOR UPDATE SKIP LOCKED`` locks the row for the caller's

--- a/apps/api/src/curie_api/deploy.py
+++ b/apps/api/src/curie_api/deploy.py
@@ -39,9 +39,7 @@ class BundleTooLarge(Exception):
     """
 
 
-def validate_archive(
-    data: bytes, settings: Settings | None = None
-) -> tuple[str, str]:
+def validate_archive(data: bytes, settings: Settings | None = None) -> tuple[str, str]:
     """Validate an archive's bytes. Returns (extension, content_type).
 
     Raises ``bundles.UnsupportedArchive`` if the bytes are not a zip/tar(.gz),

--- a/apps/api/src/curie_api/deps.py
+++ b/apps/api/src/curie_api/deps.py
@@ -89,6 +89,4 @@ EvalQueueDep = Annotated[EvalQueue, Depends(get_eval_queue)]
 GitHubReporterDep = Annotated[GitHubStatusReporter, Depends(get_github_reporter)]
 ResumeQueueDep = Annotated[ResumeQueue, Depends(get_resume_queue)]
 ApproverSetSelectorDep = Annotated[ApproverSetSelector, Depends(get_approver_sets)]
-ThreadResetRequestsDep = Annotated[
-    ThreadResetRequests, Depends(get_thread_reset_requests)
-]
+ThreadResetRequestsDep = Annotated[ThreadResetRequests, Depends(get_thread_reset_requests)]

--- a/apps/api/src/curie_api/evalcase.py
+++ b/apps/api/src/curie_api/evalcase.py
@@ -86,9 +86,7 @@ def _last_user_input(value: Any) -> str:
     return _coerce_text(value)
 
 
-def extract_io(
-    trace: dict[str, Any], observations: list[dict[str, Any]]
-) -> tuple[str, str]:
+def extract_io(trace: dict[str, Any], observations: list[dict[str, Any]]) -> tuple[str, str]:
     """Best-effort (input, output) text for a trace.
 
     Prefers the trace-level ``input``/``output`` fields; falls back to the first

--- a/apps/api/src/curie_api/evals.py
+++ b/apps/api/src/curie_api/evals.py
@@ -115,9 +115,7 @@ def _cost_of(trace: dict[str, Any]) -> float | None:
     return None
 
 
-def _supersedes(
-    trace: dict[str, Any], current: dict[str, Any] | None, ts: str
-) -> bool:
+def _supersedes(trace: dict[str, Any], current: dict[str, Any] | None, ts: str) -> bool:
     """Should ``trace`` replace ``current`` in its cell?
 
     Newest wins, with one exception: a graded result always beats a non-graded one
@@ -165,13 +163,11 @@ def build_matrix(
             version_last_seen[version] = ts
 
     # Columns: the most recently exercised versions, newest first, capped at N.
-    versions = sorted(
-        version_last_seen, key=lambda v: version_last_seen[v], reverse=True
-    )[:limit_versions]
+    versions = sorted(version_last_seen, key=lambda v: version_last_seen[v], reverse=True)[
+        :limit_versions
+    ]
     version_set = set(versions)
-    cases = sorted(
-        {case for (version, case) in latest if version in version_set}
-    )
+    cases = sorted({case for (version, case) in latest if version in version_set})
 
     def _status(version: str, case: str) -> Status:
         trace = latest.get((version, case))
@@ -201,9 +197,7 @@ def build_matrix(
         rows=rows,
         models=[s.model for s in summaries],
         model_summaries=summaries,
-        model_version_summaries=_model_version_summaries(
-            latest_by_model, version_set
-        ),
+        model_version_summaries=_model_version_summaries(latest_by_model, version_set),
     )
 
 

--- a/apps/api/src/curie_api/gitflow.py
+++ b/apps/api/src/curie_api/gitflow.py
@@ -157,9 +157,7 @@ def clone_and_archive(clone_url: str, sha: str, settings: Settings) -> bytes:
                 timeout=120,
             )
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
-            raise GitFlowError(
-                f"could not archive {sha[:12]}: {_git_failure_detail(exc)}"
-            ) from exc
+            raise GitFlowError(f"could not archive {sha[:12]}: {_git_failure_detail(exc)}") from exc
         return archived.stdout
     finally:
         shutil.rmtree(tmp, ignore_errors=True)
@@ -204,9 +202,7 @@ async def process_push(
     bundle_built = version is None or version.bundle_ref is None
     if bundle_built:
         try:
-            data = await run_in_threadpool(
-                clone_and_archive, clone_url, after, settings
-            )
+            data = await run_in_threadpool(clone_and_archive, clone_url, after, settings)
             extension, content_type = deploy.validate_archive(data, settings)
         except GitFlowError as exc:
             return WebhookResult(
@@ -229,9 +225,7 @@ async def process_push(
                 created_by="git-flow",
                 commit_sha=after,
             )
-        await deploy.store_bundle(
-            store, session, agent.id, version, data, extension, content_type
-        )
+        await deploy.store_bundle(store, session, agent.id, version, data, extension, content_type)
 
     # Either the version pre-existed with a bundle, or the block above created
     # or repaired it; it is non-None from here on.

--- a/apps/api/src/curie_api/github_checks.py
+++ b/apps/api/src/curie_api/github_checks.py
@@ -66,8 +66,7 @@ class GitHubStatusReporter:
             # rejects (LocalProtocolError), which would 500 an otherwise
             # successful eval report.
             logger.info(
-                "no GitHub token configured; skipping commit-status post "
-                "for %s@%s (%s)",
+                "no GitHub token configured; skipping commit-status post for %s@%s (%s)",
                 repo_full_name,
                 sha,
                 description,
@@ -92,7 +91,5 @@ class GitHubStatusReporter:
         try:
             resp.raise_for_status()
         except httpx.HTTPStatusError as exc:
-            raise GitHubReportError(
-                exc.response.status_code, exc.response.text.strip()
-            ) from exc
+            raise GitHubReportError(exc.response.status_code, exc.response.text.strip()) from exc
         return state

--- a/apps/api/src/curie_api/k8s.py
+++ b/apps/api/src/curie_api/k8s.py
@@ -47,9 +47,7 @@ class NullPodLogReader:
         tail_lines: int | None,
         previous: bool,
     ) -> str:
-        raise NoClusterConfigured(
-            "no kubernetes cluster configured for runner logs"
-        )
+        raise NoClusterConfigured("no kubernetes cluster configured for runner logs")
 
 
 class KubernetesPodLogReader:
@@ -82,9 +80,7 @@ class KubernetesPodLogReader:
             return logs
         except Exception as exc:  # kubernetes ApiException carries .status
             status = getattr(exc, "status", None)
-            raise PodLogError(
-                str(exc), status if isinstance(status, int) else None
-            ) from exc
+            raise PodLogError(str(exc), status if isinstance(status, int) else None) from exc
 
 
 class _SuppressExecCredentialError(logging.Filter):
@@ -128,9 +124,7 @@ class LazyPodLogReader:
         tail_lines: int | None,
         previous: bool,
     ) -> str:
-        return self._resolve().read(
-            namespace, pod, container, tail_lines, previous
-        )
+        return self._resolve().read(namespace, pod, container, tail_lines, previous)
 
 
 def build_pod_log_reader(kube_config_path: str | None) -> PodLogReader:
@@ -159,8 +153,7 @@ def build_pod_log_reader(kube_config_path: str | None) -> PodLogReader:
         return KubernetesPodLogReader(client.CoreV1Api())
     except Exception as exc:
         logger.warning(
-            "runner-logs proxy: no usable kubernetes cluster (%s); "
-            "pod-log reads will return 503",
+            "runner-logs proxy: no usable kubernetes cluster (%s); pod-log reads will return 503",
             exc,
         )
         return NullPodLogReader()
@@ -188,9 +181,7 @@ class NullPodLister:
     """Used when no cluster is configured; every list degrades to 503."""
 
     def list_runner_pods(self, namespace: str, label_selector: str) -> list[str]:
-        raise NoClusterConfigured(
-            "no kubernetes cluster configured for runner pods"
-        )
+        raise NoClusterConfigured("no kubernetes cluster configured for runner pods")
 
 
 class KubernetesPodLister:
@@ -210,9 +201,7 @@ class KubernetesPodLister:
             return names
         except Exception as exc:  # kubernetes ApiException carries .status
             status = getattr(exc, "status", None)
-            raise PodLogError(
-                str(exc), status if isinstance(status, int) else None
-            ) from exc
+            raise PodLogError(str(exc), status if isinstance(status, int) else None) from exc
 
 
 class LazyPodLister:
@@ -254,8 +243,7 @@ def build_pod_lister(kube_config_path: str | None) -> PodLister:
         return KubernetesPodLister(client.CoreV1Api())
     except Exception as exc:
         logger.warning(
-            "runner-pods list: no usable kubernetes cluster (%s); "
-            "pod listing will return 503",
+            "runner-pods list: no usable kubernetes cluster (%s); pod listing will return 503",
             exc,
         )
         return NullPodLister()

--- a/apps/api/src/curie_api/langfuse.py
+++ b/apps/api/src/curie_api/langfuse.py
@@ -34,11 +34,7 @@ def matching_traces(
     cap keeps the most recent matching runs.
     """
 
-    out = [
-        t
-        for t in traces
-        if isinstance(t.get("name"), str) and name_contains in t["name"]
-    ]
+    out = [t for t in traces if isinstance(t.get("name"), str) and name_contains in t["name"]]
     return out[:limit]
 
 
@@ -79,9 +75,7 @@ def _probe_attr(bag: Any, key: str, *, bare_key: str | None = None) -> str | Non
     return None
 
 
-def hoist_sandbox_id(
-    trace: dict[str, Any], observations: list[dict[str, Any]]
-) -> str | None:
+def hoist_sandbox_id(trace: dict[str, Any], observations: list[dict[str, Any]]) -> str | None:
     """Lift the runner's sandbox id out of a trace, or None when absent.
 
     Checks, in order, the trace-level resource/metadata attributes then the
@@ -135,9 +129,7 @@ def build_tree(observations: list[dict[str, Any]]) -> list[ObservationNode]:
     known_ids = {obs["id"] for obs in observations}
 
     def node_for(obs: dict[str, Any]) -> ObservationNode:
-        kids = sorted(
-            children.get(obs["id"], []), key=lambda o: o.get("startTime") or ""
-        )
+        kids = sorted(children.get(obs["id"], []), key=lambda o: o.get("startTime") or "")
         return ObservationNode(
             id=obs["id"],
             type=obs.get("type", ""),
@@ -151,8 +143,7 @@ def build_tree(observations: list[dict[str, Any]]) -> list[ObservationNode]:
     roots = [
         obs
         for obs in observations
-        if not obs.get("parentObservationId")
-        or obs.get("parentObservationId") not in known_ids
+        if not obs.get("parentObservationId") or obs.get("parentObservationId") not in known_ids
     ]
     roots.sort(key=lambda o: o.get("startTime") or "")
     return [node_for(root) for root in roots]
@@ -167,9 +158,7 @@ class LangfuseClient:
         self._client = client
 
     async def _get(self, path: str, params: dict[str, Any]) -> dict[str, Any]:
-        resp = await self._client.get(
-            f"{self._base}{path}", params=params, auth=self._auth
-        )
+        resp = await self._client.get(f"{self._base}{path}", params=params, auth=self._auth)
         resp.raise_for_status()
         data: dict[str, Any] = resp.json()
         return data
@@ -189,9 +178,7 @@ class LangfuseClient:
 
         items: list[dict[str, Any]] = []
         for page in range(1, max_pages + 1):
-            body = await self._get(
-                path, {**params, "page": page, "limit": _MAX_PAGE_SIZE}
-            )
+            body = await self._get(path, {**params, "page": page, "limit": _MAX_PAGE_SIZE})
             items.extend(body.get("data", []))
             if max_items is not None and len(items) >= max_items:
                 return items[:max_items]
@@ -207,18 +194,14 @@ class LangfuseClient:
             return await self._get_all("/api/public/traces", {}, max_items=limit)
         # Filter to one agent's traces. Langfuse's list API has no substring
         # filter, so scan the most recent traces and match `name contains` here.
-        scanned = await self._get_all(
-            "/api/public/traces", {}, max_items=_TRACE_SCAN_LIMIT
-        )
+        scanned = await self._get_all("/api/public/traces", {}, max_items=_TRACE_SCAN_LIMIT)
         return matching_traces(scanned, name_contains, limit)
 
     async def get_trace(self, trace_id: str) -> dict[str, Any]:
         return await self._get(f"/api/public/traces/{trace_id}", {})
 
     async def get_observations(self, trace_id: str) -> list[dict[str, Any]]:
-        body = await self._get(
-            "/api/public/observations", {"traceId": trace_id, "limit": 100}
-        )
+        body = await self._get("/api/public/observations", {"traceId": trace_id, "limit": 100})
         observations: list[dict[str, Any]] = body.get("data", [])
         return observations
 

--- a/apps/api/src/curie_api/main.py
+++ b/apps/api/src/curie_api/main.py
@@ -73,8 +73,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     app.state.resume_queue = ResumeQueue(
         valkey,
         stream=settings.runs_stream,
-        dead_letter_stream=settings.resume_dead_letter_stream
-        or settings.dead_letter_stream_name(),
+        dead_letter_stream=settings.resume_dead_letter_stream or settings.dead_letter_stream_name(),
     )
     # The composition root for approvals (#420, ADR-0034): the only place that
     # names Slack to build the approver-set selector, so the authorizer and the

--- a/apps/api/src/curie_api/metrics.py
+++ b/apps/api/src/curie_api/metrics.py
@@ -32,6 +32,7 @@ def agent_trace_filter(agent_id: uuid.UUID | str) -> str:
 
     return f"agent-{agent_id}"
 
+
 SCALAR_METRICS = ("runs", "latency_p95_ms", "tokens", "cost_usd")
 ALL_METRICS = (*SCALAR_METRICS, "error_rate")
 
@@ -46,17 +47,11 @@ _SPEC: dict[str, tuple[str, str, str, str, bool]] = {
 }
 
 
-def resolve_window(
-    start: str | None, end: str | None, window_hours: int
-) -> tuple[str, str]:
+def resolve_window(start: str | None, end: str | None, window_hours: int) -> tuple[str, str]:
     """Resolve the [start, end] ISO window, defaulting to the last window_hours."""
 
     end_dt = datetime.fromisoformat(end) if end else datetime.now(UTC)
-    start_dt = (
-        datetime.fromisoformat(start)
-        if start
-        else end_dt - timedelta(hours=window_hours)
-    )
+    start_dt = datetime.fromisoformat(start) if start else end_dt - timedelta(hours=window_hours)
     return start_dt.isoformat(), end_dt.isoformat()
 
 
@@ -157,9 +152,7 @@ async def summary(
 ) -> MetricsSummary:
     scalars: dict[str, float] = {}
     for metric in SCALAR_METRICS:
-        rows = await lf.query_metrics(
-            _scalar_query(metric, start, end, environment, agent)
-        )
+        rows = await lf.query_metrics(_scalar_query(metric, start, end, environment, agent))
         key = _SPEC[metric][3]
         scalars[metric] = _num(rows[0], key) if rows else 0.0
 
@@ -228,9 +221,7 @@ async def series(
             for r in rows
             if r.get("time_dimension")
         ]
-    return MetricSeries(
-        metric=metric, granularity=granularity, start=start, end=end, points=points
-    )
+    return MetricSeries(metric=metric, granularity=granularity, start=start, end=end, points=points)
 
 
 async def _error_rate_series(
@@ -241,9 +232,7 @@ async def _error_rate_series(
     environment: str | None,
     agent: str | None,
 ) -> list[MetricPoint]:
-    rows = await lf.query_metrics(
-        _level_query(start, end, environment, agent, granularity)
-    )
+    rows = await lf.query_metrics(_level_query(start, end, environment, agent, granularity))
     buckets: dict[str, list[dict[str, Any]]] = {}
     for row in rows:
         ts = row.get("time_dimension")

--- a/apps/api/src/curie_api/models.py
+++ b/apps/api/src/curie_api/models.py
@@ -36,18 +36,14 @@ class ApprovalStatus(enum.StrEnum):
 class Agent(Base):
     __tablename__ = "agents"
 
-    id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
-    )
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     name: Mapped[str] = mapped_column(unique=True)
     # One agent per Slack channel (#38). The worker resolves a channel to an
     # agent, so a second agent bound to the same channel could never respond --
     # it would be silently shadowed. Enforced here so it fails at create time.
     slack_channel: Mapped[str] = mapped_column(unique=True)
     # The GitHub repo (owner/name) whose pushes deploy this agent (J1).
-    repo_full_name: Mapped[str | None] = mapped_column(
-        default=None, unique=True, index=True
-    )
+    repo_full_name: Mapped[str | None] = mapped_column(default=None, unique=True, index=True)
     # Per-agent budget (L1). Field names match the frozen ACI SessionConfig
     # CURIE_BUDGET so the worker passes them straight through at sandbox boot;
     # NULL means platform defaults apply.
@@ -64,17 +60,13 @@ class Agent(Base):
     # NULL means no packs (the platform default). The shape is validated by
     # schemas.BehaviorPacksConfig on write and parsed by
     # curie_worker.behaviorpacks.BehaviorPacks on read.
-    behavior_packs: Mapped[dict[str, Any] | None] = mapped_column(
-        JSONB, default=None
-    )
+    behavior_packs: Mapped[dict[str, Any] | None] = mapped_column(JSONB, default=None)
     # Per-agent permission gates (#245, ADR-0010): tool names whose calls
     # require human approval. Forwarded by the worker binding as
     # CURIE_APPROVAL_REQUIRED_TOOLS at sandbox boot; the runner's
     # can_use_tool callback blocks these calls and ends the turn
     # awaiting-approval. NULL means no permission gates (the bypass posture).
-    approval_required_tools: Mapped[list[str] | None] = mapped_column(
-        JSONB, default=None
-    )
+    approval_required_tools: Mapped[list[str] | None] = mapped_column(JSONB, default=None)
     # Per-agent approval route bindings (#247, ADR-0010): the workspace half of
     # the split policy. The bundle manifest declares gate points and route
     # NAMES (versioned with the agent); this maps each declared name to
@@ -83,9 +75,7 @@ class Agent(Base):
     # decide where the approval card goes (and therefore who the
     # channel-membership authorizer counts as approvers). NULL means no
     # bindings; an unbound route falls back to the requesting channel.
-    approval_routes: Mapped[dict[str, Any] | None] = mapped_column(
-        JSONB, default=None
-    )
+    approval_routes: Mapped[dict[str, Any] | None] = mapped_column(JSONB, default=None)
     # Per-agent connector secrets (ADR-0009, #429): the named secret VALUES the
     # bundle's authed MCP servers need (e.g. GITHUB_PERSONAL_ACCESS_TOKEN). The
     # bundle declares the NAMES (plugin-format `secrets`); values are supplied at
@@ -104,9 +94,7 @@ class Agent(Base):
 class AgentVersion(Base):
     __tablename__ = "agent_versions"
 
-    id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
-    )
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     agent_id: Mapped[uuid.UUID] = mapped_column(
         ForeignKey(f"{SCHEMA}.agents.id", ondelete="CASCADE"), index=True
     )
@@ -125,9 +113,7 @@ class AgentVersion(Base):
 class Deployment(Base):
     __tablename__ = "deployments"
 
-    id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
-    )
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     agent_id: Mapped[uuid.UUID] = mapped_column(
         ForeignKey(f"{SCHEMA}.agents.id", ondelete="CASCADE"), index=True
     )
@@ -158,9 +144,7 @@ class Approval(Base):
 
     __tablename__ = "approvals"
 
-    id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
-    )
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     # Nullable: a run without a deployment binding (the generic/dev path) can
     # still gate on a human decision.
     agent_id: Mapped[uuid.UUID | None] = mapped_column(
@@ -229,9 +213,7 @@ class ApprovalAuditEntry(Base):
 
     __tablename__ = "approval_audit_entries"
 
-    id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
-    )
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     approval_id: Mapped[uuid.UUID] = mapped_column(
         ForeignKey(f"{SCHEMA}.approvals.id", ondelete="CASCADE"), index=True
     )
@@ -272,9 +254,7 @@ class WorkflowStateEntry(Base):
         UniqueConstraint("agent_id", "namespace", "key", name="uq_state_agent_ns_key"),
     )
 
-    id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
-    )
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     agent_id: Mapped[uuid.UUID] = mapped_column(
         ForeignKey(f"{SCHEMA}.agents.id", ondelete="CASCADE")
     )
@@ -287,6 +267,4 @@ class WorkflowStateEntry(Base):
     # it last read, and the write is rejected if the stored version moved on.
     version: Mapped[int] = mapped_column(default=1)
     created_at: Mapped[datetime] = mapped_column(server_default=func.now())
-    updated_at: Mapped[datetime] = mapped_column(
-        server_default=func.now(), onupdate=func.now()
-    )
+    updated_at: Mapped[datetime] = mapped_column(server_default=func.now(), onupdate=func.now())

--- a/apps/api/src/curie_api/resumequeue.py
+++ b/apps/api/src/curie_api/resumequeue.py
@@ -80,7 +80,7 @@ def build_resume_turn(approval: Approval) -> QueuedTurn:
     decision = approval.status
     note = f" Note: {approval.resolution_note}." if approval.resolution_note else ""
     text = (
-        f"[approval resolved] The request \"{approval.summary}\" was {decision} "
+        f'[approval resolved] The request "{approval.summary}" was {decision} '
         f"by {approval.resolved_by}.{note} Continue the task accordingly: proceed "
         "with the approved action, or acknowledge the rejection and stop."
     )
@@ -107,7 +107,7 @@ def build_expiry_resume_turn(approval: Approval) -> QueuedTurn:
     """
 
     text = (
-        f"[approval expired] The request \"{approval.summary}\" was not approved "
+        f'[approval expired] The request "{approval.summary}" was not approved '
         "or rejected before its deadline and has expired. Do not perform the "
         "gated action. Continue the task down its timeout path: acknowledge the "
         "expiry and proceed or stop accordingly."
@@ -133,9 +133,7 @@ def resume_turn_for(approval: Approval) -> QueuedTurn:
         return build_expiry_resume_turn(approval)
     if approval.status in (ApprovalStatus.approved, ApprovalStatus.rejected):
         return build_resume_turn(approval)
-    raise ValueError(
-        f"approval {approval.id} status {approval.status} owes no resume turn"
-    )
+    raise ValueError(f"approval {approval.id} status {approval.status} owes no resume turn")
 
 
 class ResumeQueue:
@@ -169,9 +167,7 @@ class ResumeQueue:
         stream_id = await self._client.xadd(self._stream, fields)
         return stream_id.decode() if isinstance(stream_id, bytes) else str(stream_id)
 
-    async def read_dead_letter(
-        self, *, count: int
-    ) -> list[tuple[str, dict[str, str]]]:
+    async def read_dead_letter(self, *, count: int) -> list[tuple[str, dict[str, str]]]:
         """Read up to ``count`` MOST-RECENT graveyard rows, newest-first
         (READ-ONLY; never XDEL/XACK).
 
@@ -189,9 +185,7 @@ class ResumeQueue:
         entries = await self._client.xrevrange(self._dead_letter_stream, count=count)
         result: list[tuple[str, dict[str, str]]] = []
         for entry_id, fields in entries or []:
-            entry_id_str = (
-                entry_id.decode() if isinstance(entry_id, bytes) else str(entry_id)
-            )
+            entry_id_str = entry_id.decode() if isinstance(entry_id, bytes) else str(entry_id)
             fields_str = {
                 (k.decode() if isinstance(k, bytes) else str(k)): (
                     v.decode() if isinstance(v, bytes) else str(v)

--- a/apps/api/src/curie_api/resumereconciler.py
+++ b/apps/api/src/curie_api/resumereconciler.py
@@ -210,9 +210,7 @@ class ResumeReconciler:
 
         count = 0
         try:
-            entries = await self._resume_queue.read_dead_letter(
-                count=self._dead_letter_scan_limit
-            )
+            entries = await self._resume_queue.read_dead_letter(count=self._dead_letter_scan_limit)
         except Exception:
             logger.warning(
                 "resume dead-letter scan read failed, skipping this pass",
@@ -232,8 +230,7 @@ class ResumeReconciler:
             if reopened:
                 count += 1
                 logger.info(
-                    "approval %s resume turn was dead-lettered; re-opened as an "
-                    "owed wake",
+                    "approval %s resume turn was dead-lettered; re-opened as an owed wake",
                     approval_id,
                 )
         return count

--- a/apps/api/src/curie_api/routers/agents.py
+++ b/apps/api/src/curie_api/routers/agents.py
@@ -1,7 +1,9 @@
 """Agents and their versions."""
 
 import functools
+import tempfile
 import uuid
+from pathlib import Path
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.exc import IntegrityError
@@ -17,14 +19,13 @@ from ..schemas import (
     AgentUpdate,
     BundleFile,
     BundleFiles,
+    ConnectorManifests,
     VersionCreate,
     VersionOut,
     enforce_behavior_packs_size,
 )
 
-router = APIRouter(
-    prefix="/agents", tags=["agents"], dependencies=[Depends(require_api_key)]
-)
+router = APIRouter(prefix="/agents", tags=["agents"], dependencies=[Depends(require_api_key)])
 
 # Postgres SQLSTATE for a unique_violation. asyncpg exposes it (and the
 # violated constraint's name) as plain attributes on the wrapped driver
@@ -119,9 +120,7 @@ async def get_agent(agent_id: uuid.UUID, session: SessionDep) -> AgentOut:
 
 
 @router.patch("/{agent_id}", response_model=AgentOut)
-async def update_agent(
-    agent_id: uuid.UUID, data: AgentUpdate, session: SessionDep
-) -> AgentOut:
+async def update_agent(agent_id: uuid.UUID, data: AgentUpdate, session: SessionDep) -> AgentOut:
     # Lets a redeploy move an existing agent's Slack channel (the CLI only sends
     # this when --slack-channel was passed explicitly). An omitted field is a
     # no-op so the agent's current channel is preserved.
@@ -148,9 +147,7 @@ async def update_agent(
         agent = await crud.update_agent_model(session, agent, data.model)
     if data.approval_required_tools is not None:
         # Omitted leaves the gates unchanged; an explicit [] clears them (#245).
-        agent = await crud.update_agent_approval_tools(
-            session, agent, data.approval_required_tools
-        )
+        agent = await crud.update_agent_approval_tools(session, agent, data.approval_required_tools)
     if data.approval_routes is not None:
         # Omitted leaves the bindings unchanged; an explicit {} clears them (#247).
         agent = await crud.update_agent_approval_routes(
@@ -196,18 +193,72 @@ async def create_version(
 
 
 @router.get("/{agent_id}/versions", response_model=list[VersionOut])
-async def list_versions(
-    agent_id: uuid.UUID, session: SessionDep
-) -> list[VersionOut]:
+async def list_versions(agent_id: uuid.UUID, session: SessionDep) -> list[VersionOut]:
     if await crud.get_agent(session, agent_id) is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "agent not found")
     versions = await crud.list_versions(session, agent_id)
     return [VersionOut.model_validate(v) for v in versions]
 
 
-@router.get(
-    "/{agent_id}/versions/{version_id}/files", response_model=BundleFiles
-)
+@router.get("/{agent_id}/versions/{version_id}/connectors", response_model=ConnectorManifests)
+async def read_version_connectors(
+    agent_id: uuid.UUID,
+    version_id: uuid.UUID,
+    session: SessionDep,
+    store: StoreDep,
+    release: str,
+    namespace: str,
+    app_name: str,
+) -> ConnectorManifests:
+    """Render this version's declared connectors into Kubernetes objects.
+
+    Read-only and side-effect free: the API computes the manifests and returns
+    them; the CALLER applies them with its own cluster credentials. That split
+    is deliberate -- rendering is a pure function, so the API needs no cluster
+    access for it, and this service (which receives internet webhooks) keeps the
+    read-only `pods: list` + `pods/log: get` RBAC it has today (ADR-0086).
+
+    `release`, `namespace`, and `app_name` are supplied by the caller because
+    they are install-time facts the API does not know: the Helm release name and
+    nameOverride live with whoever ran `cluster up`, not in the bundle.
+    """
+
+    version = await crud.get_version(session, version_id)
+    if version is None or version.agent_id != agent_id:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "version not found")
+    if version.bundle_ref is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "no bundle stored for this version")
+    data = await store.get(version.bundle_ref)
+    settings = get_settings()
+
+    def _render() -> ConnectorManifests:
+        with tempfile.TemporaryDirectory() as tmp:
+            bundles.extract_and_validate(
+                data,
+                Path(tmp),
+                max_uncompressed_bytes=settings.bundle_max_uncompressed_bytes,
+                max_compression_ratio=settings.bundle_max_compression_ratio,
+                max_members=settings.bundle_max_members,
+            )
+            declared = bundles.read_connectors(Path(tmp))
+            secret_name = f"{release}-connector-secrets"
+            return ConnectorManifests(
+                manifests=bundles.render_connector_manifests(
+                    declared,
+                    release=release,
+                    namespace=namespace,
+                    app_name=app_name,
+                    secret_name=secret_name,
+                ),
+                mcp_entries=bundles.connector_mcp_entries(
+                    declared, release=release, namespace=namespace
+                ),
+            )
+
+    return await run_in_threadpool(_render)
+
+
+@router.get("/{agent_id}/versions/{version_id}/files", response_model=BundleFiles)
 async def read_version_files(
     agent_id: uuid.UUID,
     version_id: uuid.UUID,
@@ -222,9 +273,7 @@ async def read_version_files(
     if version is None or version.agent_id != agent_id:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "version not found")
     if version.bundle_ref is None:
-        raise HTTPException(
-            status.HTTP_404_NOT_FOUND, "no bundle stored for this version"
-        )
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "no bundle stored for this version")
     data = await store.get(version.bundle_ref)
     settings = get_settings()
     read = functools.partial(

--- a/apps/api/src/curie_api/routers/approvals.py
+++ b/apps/api/src/curie_api/routers/approvals.py
@@ -32,18 +32,15 @@ from ..wirebody import ApprovalRequestBody
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(
-    prefix="/approvals", tags=["approvals"], dependencies=[Depends(require_api_key)]
-)
+router = APIRouter(prefix="/approvals", tags=["approvals"], dependencies=[Depends(require_api_key)])
 
 
 def _expired(approval: Approval) -> bool:
     """True when a pending record's SLA has passed (naive-UTC comparison,
     matching the DateTime columns)."""
 
-    return (
-        approval.expires_at is not None
-        and approval.expires_at <= datetime.now(UTC).replace(tzinfo=None)
+    return approval.expires_at is not None and approval.expires_at <= datetime.now(UTC).replace(
+        tzinfo=None
     )
 
 
@@ -99,9 +96,7 @@ async def get_approval(approval_id: uuid.UUID, session: SessionDep) -> ApprovalO
 
 
 @router.get("/{approval_id}/audit", response_model=list[ApprovalAuditOut])
-async def get_approval_audit(
-    approval_id: uuid.UUID, session: SessionDep
-) -> list[ApprovalAuditOut]:
+async def get_approval_audit(approval_id: uuid.UUID, session: SessionDep) -> list[ApprovalAuditOut]:
     """The approval's audit trail (#247), oldest first: every resolution
     attempt with the authorizer snapshot that counted or refused it."""
 

--- a/apps/api/src/curie_api/routers/bundles.py
+++ b/apps/api/src/curie_api/routers/bundles.py
@@ -134,8 +134,6 @@ async def download_bundle(
 ) -> Response:
     version = await _load_version(session, agent_id, version_id)
     if version.bundle_ref is None:
-        raise HTTPException(
-            status.HTTP_404_NOT_FOUND, "no bundle stored for this version"
-        )
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "no bundle stored for this version")
     data = await store.get(version.bundle_ref)
     return Response(content=data, media_type=_content_type_for(version.bundle_ref))

--- a/apps/api/src/curie_api/routers/control.py
+++ b/apps/api/src/curie_api/routers/control.py
@@ -146,9 +146,7 @@ async def put_budget(
 
 
 @router.get("/behavior-packs", response_model=BehaviorPacksConfig)
-async def get_behavior_packs(
-    agent_id: uuid.UUID, session: SessionDep
-) -> BehaviorPacksConfig:
+async def get_behavior_packs(agent_id: uuid.UUID, session: SessionDep) -> BehaviorPacksConfig:
     agent = await _load_agent(session, agent_id)
     # NULL (no packs configured) reads as the all-off default.
     if agent.behavior_packs is None:

--- a/apps/api/src/curie_api/routers/deployments.py
+++ b/apps/api/src/curie_api/routers/deployments.py
@@ -45,9 +45,7 @@ async def list_deployments(
 
 
 @router.get("/{deployment_id}", response_model=DeploymentOut)
-async def get_deployment(
-    deployment_id: uuid.UUID, session: SessionDep
-) -> DeploymentOut:
+async def get_deployment(deployment_id: uuid.UUID, session: SessionDep) -> DeploymentOut:
     deployment = await crud.get_deployment(session, deployment_id)
     if deployment is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "deployment not found")

--- a/apps/api/src/curie_api/routers/evals.py
+++ b/apps/api/src/curie_api/routers/evals.py
@@ -19,9 +19,7 @@ from ..schemas import (
 )
 from ..wirebody import EvalReportBody
 
-router = APIRouter(
-    prefix="/evals", tags=["evals"], dependencies=[Depends(require_api_key)]
-)
+router = APIRouter(prefix="/evals", tags=["evals"], dependencies=[Depends(require_api_key)])
 
 
 @router.post("/trigger", response_model=EvalTriggerResult)
@@ -39,14 +37,10 @@ async def trigger_eval(
     if body.version_id is not None:
         version = await crud.get_version(session, body.version_id)
         if version is None or version.agent_id != agent.id:
-            raise HTTPException(
-                status.HTTP_404_NOT_FOUND, "version not found for this agent"
-            )
+            raise HTTPException(status.HTTP_404_NOT_FOUND, "version not found for this agent")
         sha = version.commit_sha
     else:
-        deployment = await crud.get_active_deployment(
-            session, agent.id, Environment.dev
-        )
+        deployment = await crud.get_active_deployment(session, agent.id, Environment.dev)
         if deployment is None:
             raise HTTPException(
                 status.HTTP_404_NOT_FOUND,
@@ -54,9 +48,7 @@ async def trigger_eval(
             )
         version = await crud.get_version(session, deployment.version_id)
         if version is None:
-            raise HTTPException(
-                status.HTTP_404_NOT_FOUND, "deployed version not found"
-            )
+            raise HTTPException(status.HTTP_404_NOT_FOUND, "deployed version not found")
         sha = version.commit_sha or deployment.commit_sha
 
     if sha is None:
@@ -102,9 +94,7 @@ async def trigger_eval(
 
 
 @router.get("/matrix", response_model=EvalMatrix)
-async def eval_matrix(
-    lf: LangfuseDep, suite: str, versions: int = 5
-) -> EvalMatrix:
+async def eval_matrix(lf: LangfuseDep, suite: str, versions: int = 5) -> EvalMatrix:
     # Filtered by SUITE, the real dimension on eval traces. There is
     # deliberately no agent filter: eval traces are tagged by suite + version,
     # not agent, so an agent param would be dead. Do not re-add one.
@@ -113,9 +103,7 @@ async def eval_matrix(
 
 
 @router.post("/report", response_model=EvalReportResult)
-async def report_eval(
-    report: EvalReportBody, reporter: GitHubReporterDep
-) -> EvalReportResult:
+async def report_eval(report: EvalReportBody, reporter: GitHubReporterDep) -> EvalReportResult:
     # The eval Job (or the fan-out consumer) posts its rollup here on completion;
     # the API turns it into a GitHub commit status. Posting twice is harmless
     # (GitHub statuses are last-write-wins per context), so no dedupe.
@@ -136,14 +124,12 @@ async def report_eval(
         if exc.status_code == status.HTTP_404_NOT_FOUND:
             raise HTTPException(
                 status.HTTP_404_NOT_FOUND,
-                f"repo or commit not found on GitHub: "
-                f"{report.repo_full_name}@{report.sha}",
+                f"repo or commit not found on GitHub: {report.repo_full_name}@{report.sha}",
             ) from exc
         if 400 <= exc.status_code < 500:
             raise HTTPException(
                 status.HTTP_422_UNPROCESSABLE_ENTITY,
-                f"GitHub rejected the commit-status post "
-                f"({exc.status_code}): {exc.detail}",
+                f"GitHub rejected the commit-status post ({exc.status_code}): {exc.detail}",
             ) from exc
         raise HTTPException(
             status.HTTP_502_BAD_GATEWAY,

--- a/apps/api/src/curie_api/routers/github.py
+++ b/apps/api/src/curie_api/routers/github.py
@@ -68,9 +68,7 @@ async def github_webhook(
 ) -> WebhookResult:
     settings = get_settings()
     body = await _read_bounded_body(request, settings.github_webhook_max_body_bytes)
-    if not verify_signature(
-        settings.github_webhook_secret, body, x_hub_signature_256
-    ):
+    if not verify_signature(settings.github_webhook_secret, body, x_hub_signature_256):
         raise HTTPException(status.HTTP_401_UNAUTHORIZED, "invalid signature")
 
     if x_github_event == "ping":
@@ -81,9 +79,7 @@ async def github_webhook(
     try:
         payload = json.loads(body)
     except json.JSONDecodeError as exc:
-        raise HTTPException(
-            status.HTTP_400_BAD_REQUEST, "webhook body is not valid JSON"
-        ) from exc
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, "webhook body is not valid JSON") from exc
 
     result = await process_push(session, store, settings, eval_queue, payload)
     _log_outcome(result, payload)

--- a/apps/api/src/curie_api/routers/memory.py
+++ b/apps/api/src/curie_api/routers/memory.py
@@ -30,9 +30,7 @@ from ..schemas import (
 )
 from .state import _enforce_caps
 
-router = APIRouter(
-    prefix="/agents", tags=["memory"], dependencies=[Depends(require_api_key)]
-)
+router = APIRouter(prefix="/agents", tags=["memory"], dependencies=[Depends(require_api_key)])
 
 # The runner writes memory here (mirrors runner/curie_runner/memory.py: a
 # single log-shaped key inside the reserved ``memory`` namespace).
@@ -45,9 +43,7 @@ async def _require_agent(session: SessionDep, agent_id: uuid.UUID) -> None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "agent not found")
 
 
-async def _get_log_entry(
-    session: SessionDep, agent_id: uuid.UUID
-) -> WorkflowStateEntry | None:
+async def _get_log_entry(session: SessionDep, agent_id: uuid.UUID) -> WorkflowStateEntry | None:
     entry: WorkflowStateEntry | None = await session.scalar(
         select(WorkflowStateEntry).where(
             WorkflowStateEntry.agent_id == agent_id,
@@ -95,9 +91,7 @@ async def list_memory(agent_id: uuid.UUID, session: SessionDep) -> list[MemoryEn
     return [_to_out(i, r, entry.version) for i, r in enumerate(_records_of(entry))]
 
 
-@router.get(
-    "/{agent_id}/memory/{index}/provenance", response_model=MemoryTraceBackOut
-)
+@router.get("/{agent_id}/memory/{index}/provenance", response_model=MemoryTraceBackOut)
 async def memory_trace_back(
     agent_id: uuid.UUID, index: int, session: SessionDep
 ) -> MemoryTraceBackOut:
@@ -120,8 +114,7 @@ async def memory_trace_back(
         learned_from_session_id=prov.get("learned_from_session_id"),
         recorded_at=prov.get("recorded_at", ""),
         source_traces=[
-            SourceTraceOut(trace_id=str(tid), trace_url=_trace_url(str(tid)))
-            for tid in trace_ids
+            SourceTraceOut(trace_id=str(tid), trace_url=_trace_url(str(tid))) for tid in trace_ids
         ],
     )
 
@@ -151,26 +144,21 @@ async def edit_memory(
     if data.expected_version != entry.version:
         raise HTTPException(
             status.HTTP_409_CONFLICT,
-            f"version mismatch: expected {data.expected_version}, "
-            f"stored {entry.version}",
+            f"version mismatch: expected {data.expected_version}, stored {entry.version}",
         )
     records = _records_of(entry)
     if index < 0 or index >= len(records):
         raise HTTPException(status.HTTP_404_NOT_FOUND, "memory entry not found")
     updated = {**records[index], "content": data.content}
     replacement = [*records[:index], updated, *records[index + 1 :]]
-    await _enforce_caps(
-        session, agent_id, MEMORY_NAMESPACE, MEMORY_LOG_KEY, replacement
-    )
+    await _enforce_caps(session, agent_id, MEMORY_NAMESPACE, MEMORY_LOG_KEY, replacement)
     entry.value = replacement
     entry.version += 1
     await session.commit()
     return _to_out(index, updated, entry.version)
 
 
-@router.delete(
-    "/{agent_id}/memory/{index}", status_code=status.HTTP_204_NO_CONTENT
-)
+@router.delete("/{agent_id}/memory/{index}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_memory(
     agent_id: uuid.UUID,
     index: int,

--- a/apps/api/src/curie_api/routers/observability.py
+++ b/apps/api/src/curie_api/routers/observability.py
@@ -73,9 +73,7 @@ async def list_runner_pods(
             lister.list_runner_pods, ns, settings.runner_pod_label_selector
         )
     except NoClusterConfigured as exc:
-        raise HTTPException(
-            status.HTTP_503_SERVICE_UNAVAILABLE, str(exc)
-        ) from exc
+        raise HTTPException(status.HTTP_503_SERVICE_UNAVAILABLE, str(exc)) from exc
     except PodLogError as exc:
         raise HTTPException(status.HTTP_502_BAD_GATEWAY, str(exc)) from exc
     return RunnerPods(namespace=ns, pods=pods)
@@ -95,8 +93,7 @@ async def runner_logs(
     if namespace != settings.runner_namespace:
         raise HTTPException(
             status.HTTP_403_FORBIDDEN,
-            f"logs are only available for the runner namespace "
-            f"{settings.runner_namespace!r}",
+            f"logs are only available for the runner namespace {settings.runner_namespace!r}",
         )
     try:
         runner_pods = await run_in_threadpool(
@@ -105,30 +102,19 @@ async def runner_logs(
             settings.runner_pod_label_selector,
         )
     except NoClusterConfigured as exc:
-        raise HTTPException(
-            status.HTTP_503_SERVICE_UNAVAILABLE, str(exc)
-        ) from exc
+        raise HTTPException(status.HTTP_503_SERVICE_UNAVAILABLE, str(exc)) from exc
     except PodLogError as exc:
         raise HTTPException(status.HTTP_502_BAD_GATEWAY, str(exc)) from exc
     if pod not in runner_pods:
         raise HTTPException(
             status.HTTP_403_FORBIDDEN,
-            f"{pod!r} is not a runner pod in namespace "
-            f"{settings.runner_namespace!r}",
+            f"{pod!r} is not a runner pod in namespace {settings.runner_namespace!r}",
         )
     try:
-        logs = await run_in_threadpool(
-            reader.read, namespace, pod, container, tail_lines, previous
-        )
+        logs = await run_in_threadpool(reader.read, namespace, pod, container, tail_lines, previous)
     except NoClusterConfigured as exc:
-        raise HTTPException(
-            status.HTTP_503_SERVICE_UNAVAILABLE, str(exc)
-        ) from exc
+        raise HTTPException(status.HTTP_503_SERVICE_UNAVAILABLE, str(exc)) from exc
     except PodLogError as exc:
-        code = (
-            status.HTTP_404_NOT_FOUND
-            if exc.status == 404
-            else status.HTTP_502_BAD_GATEWAY
-        )
+        code = status.HTTP_404_NOT_FOUND if exc.status == 404 else status.HTTP_502_BAD_GATEWAY
         raise HTTPException(code, str(exc)) from exc
     return PodLogs(namespace=namespace, pod=pod, container=container, logs=logs)

--- a/apps/api/src/curie_api/routers/runs.py
+++ b/apps/api/src/curie_api/routers/runs.py
@@ -36,14 +36,10 @@ async def list_traces(
 @router.get("/traces/{trace_id}", response_model=TraceTree)
 async def get_trace(trace_id: str, lf: LangfuseDep) -> TraceTree:
     if not _TRACE_ID_RE.match(trace_id):
-        raise HTTPException(
-            status.HTTP_400_BAD_REQUEST, "invalid trace id"
-        )
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, "invalid trace id")
     observations = await lf.get_observations(trace_id)
     if not observations:
-        raise HTTPException(
-            status.HTTP_404_NOT_FOUND, "trace has no observations yet"
-        )
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "trace has no observations yet")
     trace = await lf.get_trace(trace_id)
     return TraceTree(
         trace=trace,
@@ -66,8 +62,6 @@ async def promote_trace_to_eval_case(trace_id: str, lf: LangfuseDep) -> EvalCase
         raise HTTPException(status.HTTP_400_BAD_REQUEST, "invalid trace id")
     observations = await lf.get_observations(trace_id)
     if not observations:
-        raise HTTPException(
-            status.HTTP_404_NOT_FOUND, "trace has no observations yet"
-        )
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "trace has no observations yet")
     trace = await lf.get_trace(trace_id)
     return trace_to_eval_case(trace_id, trace, observations)

--- a/apps/api/src/curie_api/routers/state.py
+++ b/apps/api/src/curie_api/routers/state.py
@@ -84,9 +84,7 @@ async def require_state_access(
             return StateCaller.STATE
         if sandbox_token.verify(x_api_key, api_key, agent=agent, scope=STATE_APP_SCOPE):
             return StateCaller.APP
-    raise HTTPException(
-        status.HTTP_401_UNAUTHORIZED, detail="missing or invalid credential"
-    )
+    raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail="missing or invalid credential")
 
 
 async def forbid_reserved_namespace(
@@ -109,9 +107,7 @@ async def forbid_reserved_namespace(
         )
 
 
-router = APIRouter(
-    prefix="/agents", tags=["state"], dependencies=[Depends(require_state_access)]
-)
+router = APIRouter(prefix="/agents", tags=["state"], dependencies=[Depends(require_state_access)])
 
 
 def _json_size(value: Any) -> int:
@@ -228,8 +224,7 @@ async def put_state(
         if data.expected_version is not None and data.expected_version != entry.version:
             raise HTTPException(
                 status.HTTP_409_CONFLICT,
-                f"version mismatch: expected {data.expected_version}, "
-                f"stored {entry.version}",
+                f"version mismatch: expected {data.expected_version}, stored {entry.version}",
             )
         entry.value = data.value
         entry.version += 1
@@ -270,9 +265,7 @@ async def append_state(
     if entry is None:
         new_value = [data.item]
         await _enforce_caps(session, agent_id, namespace, key, new_value)
-        entry = WorkflowStateEntry(
-            agent_id=agent_id, namespace=namespace, key=key, value=new_value
-        )
+        entry = WorkflowStateEntry(agent_id=agent_id, namespace=namespace, key=key, value=new_value)
         session.add(entry)
     else:
         if not isinstance(entry.value, list):

--- a/apps/api/src/curie_api/sandbox_token.py
+++ b/apps/api/src/curie_api/sandbox_token.py
@@ -33,9 +33,7 @@ def _b64url_decode(seg: str) -> bytes:
 
 
 def _signature(api_key: str, signing_input: str) -> str:
-    digest = hmac.new(
-        api_key.encode(), signing_input.encode(), hashlib.sha256
-    ).digest()
+    digest = hmac.new(api_key.encode(), signing_input.encode(), hashlib.sha256).digest()
     return _b64url(digest)
 
 
@@ -54,9 +52,7 @@ def mint(api_key: str, *, agent: str, scope: str, exp: int) -> str:
     return f"{signing_input}.{_signature(api_key, signing_input)}"
 
 
-def verify(
-    token: str, api_key: str, *, agent: str, scope: str, now: int | None = None
-) -> bool:
+def verify(token: str, api_key: str, *, agent: str, scope: str, now: int | None = None) -> bool:
     """True only when ``token`` is a well-formed token signed by ``api_key`` that
     names exactly this ``agent`` and ``scope`` and has not expired. Returns False
     (never raises) on any malformed, tampered, wrong-key, wrong-claim, or expired

--- a/apps/api/src/curie_api/schemas.py
+++ b/apps/api/src/curie_api/schemas.py
@@ -152,9 +152,7 @@ def enforce_behavior_packs_size(config: BehaviorPacksConfig) -> None:
     byte length of the whole config, the unit ``behavior_packs_max_bytes`` is
     measured in (mirrors the durable-state ``_enforce_caps`` in state.py)."""
     limit = get_settings().behavior_packs_max_bytes
-    size = len(
-        json.dumps(config.model_dump(), separators=(",", ":")).encode("utf-8")
-    )
+    size = len(json.dumps(config.model_dump(), separators=(",", ":")).encode("utf-8"))
     if size > limit:
         raise HTTPException(
             413,
@@ -230,9 +228,7 @@ class _StoredWithoutNulls(BaseModel):
     """
 
     @model_serializer(mode="wrap")
-    def _dump_without_nulls(
-        self, handler: SerializerFunctionWrapHandler
-    ) -> dict[str, Any]:
+    def _dump_without_nulls(self, handler: SerializerFunctionWrapHandler) -> dict[str, Any]:
         return {k: v for k, v in handler(self).items() if v is not None}
 
 
@@ -282,9 +278,7 @@ class ApprovalApprovers(_StoredWithoutNulls):
             # Neither "unset" (omit the key) nor "nobody may approve": as silent
             # config the latter is a footgun, since the approval could then only
             # ever expire.
-            raise ValueError(
-                "approvers users, when present, must contain at least one user ID"
-            )
+            raise ValueError("approvers users, when present, must contain at least one user ID")
         for user in value:
             if not _SLACK_USER_ID.match(user):
                 raise ValueError(
@@ -355,15 +349,9 @@ class AgentCreate(BaseModel):
     # sandbox by the worker binding. None means no connector secrets.
     secrets: dict[str, str] | None = None
 
-    _check_slack_channel = field_validator("slack_channel")(
-        _validate_slack_channel_id
-    )
-    _check_approval_tools = field_validator("approval_required_tools")(
-        _validate_tool_names
-    )
-    _check_approval_routes = field_validator("approval_routes")(
-        _validate_route_names
-    )
+    _check_slack_channel = field_validator("slack_channel")(_validate_slack_channel_id)
+    _check_approval_tools = field_validator("approval_required_tools")(_validate_tool_names)
+    _check_approval_routes = field_validator("approval_routes")(_validate_route_names)
     _check_secrets = field_validator("secrets")(_validate_secret_map)
 
 
@@ -386,15 +374,9 @@ class AgentUpdate(BaseModel):
     # unchanged; an explicit empty dict clears them.
     secrets: dict[str, str] | None = None
 
-    _check_slack_channel = field_validator("slack_channel")(
-        _validate_slack_channel_id
-    )
-    _check_approval_tools = field_validator("approval_required_tools")(
-        _validate_tool_names
-    )
-    _check_approval_routes = field_validator("approval_routes")(
-        _validate_route_names
-    )
+    _check_slack_channel = field_validator("slack_channel")(_validate_slack_channel_id)
+    _check_approval_tools = field_validator("approval_required_tools")(_validate_tool_names)
+    _check_approval_routes = field_validator("approval_routes")(_validate_route_names)
     _check_secrets = field_validator("secrets")(_validate_secret_map)
 
 
@@ -577,6 +559,22 @@ class ApprovalAuditOut(BaseModel):
     # written before the column existed.
     evidence: dict[str, Any] | None
     created_at: datetime
+
+
+class ConnectorManifests(BaseModel):
+    """Kubernetes objects derived from a version's ``connectors.yaml``.
+
+    The API renders; the caller applies. Rendering is a pure function of the
+    bundle plus the deployment context the caller supplies, so producing this
+    needs no cluster access and the API's read-only RBAC is untouched
+    (ADR-0086, #1063).
+    """
+
+    manifests: list[dict[str, Any]] = Field(default_factory=list)
+    # name -> the `.mcp.json` entry the agent should use. Derived from the
+    # Service in `manifests`, so an author never hand-writes a URL that
+    # resolves in one tier and not another.
+    mcp_entries: dict[str, Any] = Field(default_factory=dict)
 
 
 class WebhookResult(BaseModel):

--- a/apps/api/src/curie_api/slack_approvers.py
+++ b/apps/api/src/curie_api/slack_approvers.py
@@ -50,9 +50,7 @@ class SlackChannelMembers:
     def __init__(self, approvers_channel: str | None) -> None:
         self._approvers_channel = approvers_channel
 
-    async def contains(
-        self, actor: str, actor_channel: str | None
-    ) -> MembershipVerdict:
+    async def contains(self, actor: str, actor_channel: str | None) -> MembershipVerdict:
         evidence: dict[str, Any] = {
             "kind": "channel_membership",
             "approvers_channel": self._approvers_channel,
@@ -87,9 +85,7 @@ class SlackUserGroupMembers:
         self._group_id = group_id
         self._source = source
 
-    async def contains(
-        self, actor: str, actor_channel: str | None
-    ) -> MembershipVerdict:
+    async def contains(self, actor: str, actor_channel: str | None) -> MembershipVerdict:
         if self._source is None:
             return self._undetermined("no Slack bot token is configured for the API")
         try:

--- a/apps/api/src/curie_api/slack_usergroups.py
+++ b/apps/api/src/curie_api/slack_usergroups.py
@@ -164,9 +164,7 @@ class SlackUserGroupClient:
             response.raise_for_status()
             body = response.json()
         except httpx.HTTPError as exc:
-            raise UserGroupLookupError(
-                f"usergroup {group_id} lookup failed: {exc}"
-            ) from exc
+            raise UserGroupLookupError(f"usergroup {group_id} lookup failed: {exc}") from exc
         except ValueError as exc:  # a 200 that is not JSON at all
             raise UserGroupLookupError(
                 f"usergroup {group_id} lookup returned a non-JSON body"
@@ -178,9 +176,7 @@ class SlackUserGroupClient:
             )
         users = body.get("users")
         if not isinstance(users, list) or not all(isinstance(u, str) for u in users):
-            raise UserGroupLookupError(
-                f"usergroup {group_id} lookup returned no member list"
-            )
+            raise UserGroupLookupError(f"usergroup {group_id} lookup returned no member list")
         return frozenset(users)
 
 

--- a/apps/api/src/curie_api/storage.py
+++ b/apps/api/src/curie_api/storage.py
@@ -112,9 +112,7 @@ class BundleStore:
         await run_in_threadpool(self._put_sync, key, data, content_type)
 
     def _put_sync(self, key: str, data: bytes, content_type: str) -> None:
-        self._client.put_object(
-            Bucket=self._bucket, Key=key, Body=data, ContentType=content_type
-        )
+        self._client.put_object(Bucket=self._bucket, Key=key, Body=data, ContentType=content_type)
 
     async def get(self, key: str) -> bytes:
         return await run_in_threadpool(self._get_sync, key)

--- a/apps/api/src/curie_api/sweeper.py
+++ b/apps/api/src/curie_api/sweeper.py
@@ -132,8 +132,7 @@ async def sweep_expired_approvals(
                 "the reconciler will re-enqueue it past its grace horizon (a "
                 "redundant wake if it did land, which is the safe direction)"
                 if get_settings().resume_reconciler_enabled
-                else "nothing will retry it (resume reconciler disabled) and "
-                "the wakeup may be lost"
+                else "nothing will retry it (resume reconciler disabled) and the wakeup may be lost"
             )
             logger.exception(
                 "expiry sweep failed for approval %s after the flip; the resume "

--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -98,15 +98,11 @@ def _disposable_db() -> Any:
     # database. Any db-touching fixture (client, migrated, clean_db) pulls this
     # in, which sets DATABASE_URL before the app engine or alembic is created.
     base = make_url(get_settings().database_url)
-    run_db = (
-        f"{DB_PREFIX}{datetime.now(UTC).strftime(TS_FORMAT)}_{secrets.token_hex(3)}"
-    )
+    run_db = f"{DB_PREFIX}{datetime.now(UTC).strftime(TS_FORMAT)}_{secrets.token_hex(3)}"
     asyncio.run(_provision(base, run_db))
 
     # Point the app + alembic at the disposable DB for the rest of the session.
-    os.environ["DATABASE_URL"] = base.set(database=run_db).render_as_string(
-        hide_password=False
-    )
+    os.environ["DATABASE_URL"] = base.set(database=run_db).render_as_string(hide_password=False)
     get_settings.cache_clear()
     try:
         # Inside the try so a failed migration still drops the run's database.

--- a/apps/api/tests/test_agent_model_integration.py
+++ b/apps/api/tests/test_agent_model_integration.py
@@ -8,9 +8,7 @@ null default, PATCH-to-set, and PATCH-leaves-unchanged.
 from typing import Any
 
 
-def _create_agent(
-    client: Any, auth_headers: dict[str, str], **body: Any
-) -> dict[str, Any]:
+def _create_agent(client: Any, auth_headers: dict[str, str], **body: Any) -> dict[str, Any]:
     resp = client.post(
         "/agents",
         json={"name": "model-bot", "slack_channel": "CMODEL001", **body},
@@ -42,9 +40,7 @@ def test_create_with_model_persists(
     assert resp.json()["model"] == "glm-5.2"
 
 
-def test_patch_sets_model(
-    client: Any, auth_headers: dict[str, str], clean_db: None
-) -> None:
+def test_patch_sets_model(client: Any, auth_headers: dict[str, str], clean_db: None) -> None:
     agent = _create_agent(client, auth_headers)
     resp = client.patch(
         f"/agents/{agent['id']}",

--- a/apps/api/tests/test_agents.py
+++ b/apps/api/tests/test_agents.py
@@ -14,9 +14,7 @@ def _create(client: Any, headers: dict[str, str], **fields: Any) -> Any:
     return client.post("/agents", json=fields, headers=headers)
 
 
-def test_duplicate_name_is_409(
-    client: Any, auth_headers: dict[str, str], clean_db: None
-) -> None:
+def test_duplicate_name_is_409(client: Any, auth_headers: dict[str, str], clean_db: None) -> None:
     first = _create(client, auth_headers, name="dup-name", slack_channel="C0AAAAAA1")
     assert first.status_code == 201, first.text
 
@@ -25,9 +23,7 @@ def test_duplicate_name_is_409(
     assert dup.json()["detail"] == "an agent with that name already exists"
 
 
-def test_duplicate_repo_is_409(
-    client: Any, auth_headers: dict[str, str], clean_db: None
-) -> None:
+def test_duplicate_repo_is_409(client: Any, auth_headers: dict[str, str], clean_db: None) -> None:
     first = _create(
         client,
         auth_headers,
@@ -314,9 +310,7 @@ def test_agent_approval_routes_rejects_bad_approvers(
             json={
                 "name": f"bad-approvers-{index}",
                 "slack_channel": "C000000C01",
-                "approval_routes": {
-                    "managers": {"channel": "C000000C02", "approvers": approvers}
-                },
+                "approval_routes": {"managers": {"channel": "C000000C02", "approvers": approvers}},
             },
             headers=auth_headers,
         )
@@ -403,9 +397,7 @@ def test_agent_approval_routes_patch_rejects_bad_approvers(
     patched = client.patch(
         f"/agents/{created.json()['id']}",
         json={
-            "approval_routes": {
-                "managers": {"channel": "C000000D02", "approvers": {"users": []}}
-            }
+            "approval_routes": {"managers": {"channel": "C000000D02", "approvers": {"users": []}}}
         },
         headers=auth_headers,
     )

--- a/apps/api/tests/test_approvals.py
+++ b/apps/api/tests/test_approvals.py
@@ -138,10 +138,7 @@ def _read_provenance(approval_id: uuid.UUID) -> tuple[str | None, str | None]:
         try:
             async with engine.connect() as conn:
                 result = await conn.execute(
-                    text(
-                        "SELECT gate_kind, granted_tool FROM curie.approvals "
-                        "WHERE id = :id"
-                    ),
+                    text("SELECT gate_kind, granted_tool FROM curie.approvals WHERE id = :id"),
                     {"id": approval_id},
                 )
                 row = result.first()
@@ -189,9 +186,7 @@ def test_resolve_endpoint_stays_200_when_enqueue_fails(
     to 500 then 409-forever).
     """
 
-    created = approvals_client.post(
-        "/approvals", json=_payload(), headers=auth_headers
-    ).json()
+    created = approvals_client.post("/approvals", json=_payload(), headers=auth_headers).json()
 
     async def _boom(_turn: Any) -> str:
         raise RuntimeError("valkey unreachable")
@@ -221,9 +216,7 @@ def test_resolve_endpoint_stays_200_when_enqueue_fails(
 
 
 @pytest.fixture
-def reconciler_disabled_client(
-    _disposable_db: Any, runs_stream: str
-) -> Iterator[TestClient]:
+def reconciler_disabled_client(_disposable_db: Any, runs_stream: str) -> Iterator[TestClient]:
     """A TestClient built with the resume reconciler DISABLED, so a failed inline
     enqueue has no backstop. ``raise_server_exceptions=False`` lets the resulting
     500 be asserted as a response rather than re-raised into the test body."""
@@ -264,9 +257,7 @@ def test_resolve_reraises_when_reconciler_disabled(
     async def _boom(_turn: Any) -> str:
         raise RuntimeError("valkey unreachable")
 
-    monkeypatch.setattr(
-        reconciler_disabled_client.app.state.resume_queue, "enqueue", _boom
-    )
+    monkeypatch.setattr(reconciler_disabled_client.app.state.resume_queue, "enqueue", _boom)
 
     resolved = reconciler_disabled_client.post(
         f"/approvals/{created['id']}/resolve",
@@ -277,9 +268,7 @@ def test_resolve_reraises_when_reconciler_disabled(
 
     # The CAS committed -- the record is resolved -- but its wake is unrecoverably
     # owed (no reconciler) and nothing reached the stream.
-    record = reconciler_disabled_client.get(
-        f"/approvals/{created['id']}", headers=auth_headers
-    )
+    record = reconciler_disabled_client.get(f"/approvals/{created['id']}", headers=auth_headers)
     assert record.json()["status"] == "approved"
     assert _read_resumed_at(created["id"]) is None
     assert valkey.xrange(runs_stream) == []
@@ -296,9 +285,7 @@ def test_happy_path_resolve_marks_resumed(
     setting ``resumed_at``, so the reconciler's work-list excludes it. This adds
     to the resolve-once coverage without weakening the existing assertions."""
 
-    created = approvals_client.post(
-        "/approvals", json=_payload(), headers=auth_headers
-    ).json()
+    created = approvals_client.post("/approvals", json=_payload(), headers=auth_headers).json()
 
     resolved = approvals_client.post(
         f"/approvals/{created['id']}/resolve",
@@ -366,9 +353,7 @@ def test_create_still_rejects_an_invalid_modelled_field(
 ) -> None:
     """Tolerance is for UNKNOWN fields only; a modelled field's constraint still binds."""
 
-    resp = approvals_client.post(
-        "/approvals", json=_payload(author=""), headers=auth_headers
-    )
+    resp = approvals_client.post("/approvals", json=_payload(author=""), headers=auth_headers)
     assert resp.status_code == 422, resp.text
     assert resp.json()["detail"][0]["loc"] == ["body", "author"]
 
@@ -443,9 +428,7 @@ def test_concurrent_resolvers_yield_exactly_one_winner(
     valkey: redis.Redis,
     runs_stream: str,
 ) -> None:
-    created = approvals_client.post(
-        "/approvals", json=_payload(), headers=auth_headers
-    ).json()
+    created = approvals_client.post("/approvals", json=_payload(), headers=auth_headers).json()
 
     def attempt(actor: str) -> int:
         response = approvals_client.post(
@@ -472,9 +455,7 @@ def test_expired_approval_resolve_returns_410_and_resumes(
     runs_stream: str,
 ) -> None:
     payload = _payload(expires_in_seconds=1)
-    created = approvals_client.post(
-        "/approvals", json=payload, headers=auth_headers
-    ).json()
+    created = approvals_client.post("/approvals", json=payload, headers=auth_headers).json()
     assert created["expires_at"] is not None
     time.sleep(1.1)
 
@@ -520,9 +501,7 @@ def test_unknown_approval_is_404(
     assert missing.status_code == 404
 
 
-def test_requires_api_key(
-    approvals_client: TestClient, clean_db: None
-) -> None:
+def test_requires_api_key(approvals_client: TestClient, clean_db: None) -> None:
     denied = approvals_client.post("/approvals", json=_payload())
     assert denied.status_code in (401, 403)
 
@@ -538,9 +517,7 @@ def test_scoped_state_token_cannot_resolve_an_approval(
     forward its own state token to /approvals/{id}/resolve and self-approve its
     own gated tool call, defeating the server-side authorizer (ADR-0010)."""
 
-    created = approvals_client.post(
-        "/approvals", json=_payload(), headers=auth_headers
-    ).json()
+    created = approvals_client.post("/approvals", json=_payload(), headers=auth_headers).json()
     resolve_url = f"/approvals/{created['id']}/resolve"
 
     scoped = mint(
@@ -556,9 +533,7 @@ def test_scoped_state_token_cannot_resolve_an_approval(
     )
     assert denied.status_code == 401, denied.text
     # The record is untouched by the rejected attempt.
-    record = approvals_client.get(
-        f"/approvals/{created['id']}", headers=auth_headers
-    )
+    record = approvals_client.get(f"/approvals/{created['id']}", headers=auth_headers)
     assert record.json()["status"] == "pending"
 
     # The platform key still resolves it (no regression).
@@ -581,9 +556,7 @@ def test_authorizer_blocks_non_member_and_self_approval(
     attempt's channel, self-approval is blocked unconditionally, and a denied
     attempt neither resolves the record nor enqueues a resume turn."""
 
-    created = approvals_client.post(
-        "/approvals", json=_payload(), headers=auth_headers
-    ).json()
+    created = approvals_client.post("/approvals", json=_payload(), headers=auth_headers).json()
     resolve_url = f"/approvals/{created['id']}/resolve"
 
     # Wrong channel: not an approver.
@@ -697,9 +670,10 @@ def test_bound_approver_is_accepted_and_requesting_channel_is_not(
         "authority must never widen to the requesting channel when the manifest "
         f"declared a route: {requesting.text}"
     )
-    assert approvals_client.get(
-        f"/approvals/{created['id']}", headers=auth_headers
-    ).json()["status"] == "pending"
+    assert (
+        approvals_client.get(f"/approvals/{created['id']}", headers=auth_headers).json()["status"]
+        == "pending"
+    )
     assert valkey.xrange(runs_stream) == []
 
     # The BOUND approver, from the bound channel: accepted.
@@ -758,9 +732,7 @@ def test_create_approval_persists_gate_kind_and_granted_tool(
 
     # An old runner emits neither: both stay NULL, which is the rolling-deploy
     # window the worker's prefix fallback covers (edge case 7).
-    legacy = approvals_client.post(
-        "/approvals", json=_payload(), headers=auth_headers
-    ).json()
+    legacy = approvals_client.post("/approvals", json=_payload(), headers=auth_headers).json()
     assert legacy["gate_kind"] is None
     assert legacy["granted_tool"] is None
 
@@ -796,9 +768,7 @@ def _isolated_migration_db() -> Iterator[None]:
     saved_url = os.environ.get("DATABASE_URL")
     asyncio.run(_admin(f'CREATE DATABASE "{run_db}"'))
     try:
-        os.environ["DATABASE_URL"] = base.set(database=run_db).render_as_string(
-            hide_password=False
-        )
+        os.environ["DATABASE_URL"] = base.set(database=run_db).render_as_string(hide_password=False)
         get_settings.cache_clear()
         yield
     finally:
@@ -837,9 +807,7 @@ def test_backfill_classifies_existing_rows() -> None:
         command.downgrade(cfg, "0014")
         permission_id = uuid.uuid4()
         policy_id = uuid.uuid4()
-        _seed_raw_approval(
-            permission_id, 'Tool call awaiting approval: Bash {"command": "deploy"}'
-        )
+        _seed_raw_approval(permission_id, 'Tool call awaiting approval: Bash {"command": "deploy"}')
         _seed_raw_approval(policy_id, "Give ACME a 20% discount")
         command.upgrade(cfg, "head")
 
@@ -951,9 +919,7 @@ def test_audit_log_records_attempts_with_authorizer_snapshots(
     an append-only audit entry naming the actor, the channel evidence, and the
     authorizer snapshot that counted (or refused) them."""
 
-    created = approvals_client.post(
-        "/approvals", json=_payload(), headers=auth_headers
-    ).json()
+    created = approvals_client.post("/approvals", json=_payload(), headers=auth_headers).json()
     resolve_url = f"/approvals/{created['id']}/resolve"
 
     denied = approvals_client.post(
@@ -975,9 +941,7 @@ def test_audit_log_records_attempts_with_authorizer_snapshots(
     )
     assert late.status_code == 409
 
-    audit = approvals_client.get(
-        f"/approvals/{created['id']}/audit", headers=auth_headers
-    )
+    audit = approvals_client.get(f"/approvals/{created['id']}/audit", headers=auth_headers)
     assert audit.status_code == 200
     entries = audit.json()
     assert [e["action"] for e in entries] == ["denied", "resolved", "race_lost"]
@@ -998,9 +962,7 @@ def test_audit_log_records_attempts_with_authorizer_snapshots(
     assert "already resolved by U9" in race_entry["reason"]
 
     # The audit endpoint 404s for an unknown approval.
-    missing = approvals_client.get(
-        f"/approvals/{uuid.uuid4()}/audit", headers=auth_headers
-    )
+    missing = approvals_client.get(f"/approvals/{uuid.uuid4()}/audit", headers=auth_headers)
     assert missing.status_code == 404
 
 
@@ -1053,12 +1015,8 @@ def test_sweeper_expires_lapsed_pending_and_enqueues_resume_turn(
     valkey: redis.Redis,
     runs_stream: str,
 ) -> None:
-    payload = _payload(
-        expires_in_seconds=1, reply_endpoint="http://localhost:9999/api/"
-    )
-    created = approvals_client.post(
-        "/approvals", json=payload, headers=auth_headers
-    ).json()
+    payload = _payload(expires_in_seconds=1, reply_endpoint="http://localhost:9999/api/")
+    created = approvals_client.post("/approvals", json=payload, headers=auth_headers).json()
     assert created["expires_at"] is not None
 
     now = _naive_utc(2)
@@ -1072,9 +1030,7 @@ def test_sweeper_expires_lapsed_pending_and_enqueues_resume_turn(
     assert flipped == 1
 
     # DB state: flipped to expired by the platform, no human resolver recorded.
-    got = approvals_client.get(
-        f"/approvals/{created['id']}", headers=auth_headers
-    ).json()
+    got = approvals_client.get(f"/approvals/{created['id']}", headers=auth_headers).json()
     assert got["status"] == "expired"
     assert got["resolved_by"] is None
     assert got["resolved_at"] is not None
@@ -1094,9 +1050,7 @@ def test_sweeper_expires_lapsed_pending_and_enqueues_resume_turn(
     assert payload["summary"] in turn.text
 
     # The autonomous flip is audited consistently with #247.
-    audit = approvals_client.get(
-        f"/approvals/{created['id']}/audit", headers=auth_headers
-    )
+    audit = approvals_client.get(f"/approvals/{created['id']}/audit", headers=auth_headers)
     assert audit.status_code == 200
     entries_audit = audit.json()
     assert len(entries_audit) == 1
@@ -1136,9 +1090,7 @@ def test_sweeper_ignores_unexpired_and_unbounded_records(
     future = approvals_client.post(
         "/approvals", json=_payload(expires_in_seconds=3600), headers=auth_headers
     ).json()
-    unbounded = approvals_client.post(
-        "/approvals", json=_payload(), headers=auth_headers
-    ).json()
+    unbounded = approvals_client.post("/approvals", json=_payload(), headers=auth_headers).json()
     assert unbounded["expires_at"] is None
 
     now = _naive_utc()
@@ -1152,9 +1104,7 @@ def test_sweeper_ignores_unexpired_and_unbounded_records(
     assert flipped == 0
 
     for record in (future, unbounded):
-        got = approvals_client.get(
-            f"/approvals/{record['id']}", headers=auth_headers
-        ).json()
+        got = approvals_client.get(f"/approvals/{record['id']}", headers=auth_headers).json()
         assert got["status"] == "pending"
     assert valkey.xrange(runs_stream) == []
 
@@ -1186,9 +1136,7 @@ def test_sweeper_second_pass_is_a_no_op(
 
     # No double-flip, no second turn, no second audit row.
     assert len(valkey.xrange(runs_stream)) == 1
-    audit = approvals_client.get(
-        f"/approvals/{created['id']}/audit", headers=auth_headers
-    ).json()
+    audit = approvals_client.get(f"/approvals/{created['id']}/audit", headers=auth_headers).json()
     assert [e["action"] for e in audit] == ["expired"]
 
 
@@ -1222,9 +1170,7 @@ def test_sweeper_skips_already_resolved_records(
     flipped = asyncio.run(_scenario())
     assert flipped == 0
 
-    got = approvals_client.get(
-        f"/approvals/{created['id']}", headers=auth_headers
-    ).json()
+    got = approvals_client.get(f"/approvals/{created['id']}", headers=auth_headers).json()
     assert got["status"] == "approved"
 
     # Exactly the one resolve turn, authored by the human resolver; no expiry
@@ -1263,9 +1209,7 @@ def test_resolve_path_expiry_returns_410_even_if_enqueue_fails(
     """
 
     payload = _payload(expires_in_seconds=1)
-    created = approvals_client.post(
-        "/approvals", json=payload, headers=auth_headers
-    ).json()
+    created = approvals_client.post("/approvals", json=payload, headers=auth_headers).json()
     assert created["expires_at"] is not None
     time.sleep(1.1)
 
@@ -1279,9 +1223,7 @@ def test_resolve_path_expiry_returns_410_even_if_enqueue_fails(
     # Observe the real 500 the error middleware returns in production, rather
     # than letting TestClient (raise_server_exceptions=True) re-raise it -- the
     # regression being pinned is precisely "500 leaks out where 410 is owed".
-    monkeypatch.setattr(
-        approvals_client._transport, "raise_server_exceptions", False
-    )
+    monkeypatch.setattr(approvals_client._transport, "raise_server_exceptions", False)
 
     resolved = approvals_client.post(
         f"/approvals/{created['id']}/resolve",
@@ -1335,9 +1277,7 @@ def test_resolve_path_expiry_returns_410_when_the_resumed_mark_fails(
     """
 
     payload = _payload(expires_in_seconds=1)
-    created = approvals_client.post(
-        "/approvals", json=payload, headers=auth_headers
-    ).json()
+    created = approvals_client.post("/approvals", json=payload, headers=auth_headers).json()
     assert created["expires_at"] is not None
     time.sleep(1.1)
 
@@ -1454,9 +1394,7 @@ def test_sweeper_isolates_a_failing_record(
     # Both flips committed -- expire_approval commits before the enqueue runs, so
     # the record whose enqueue failed is still expired.
     for record in (first, second):
-        got = approvals_client.get(
-            f"/approvals/{record['id']}", headers=auth_headers
-        ).json()
+        got = approvals_client.get(f"/approvals/{record['id']}", headers=auth_headers).json()
         assert got["status"] == "expired"
 
     # Exactly one resume turn on the stream, for whichever record was second.
@@ -1513,9 +1451,7 @@ def test_run_expiry_sweeper_loop_sweeps_and_stops(
     async def _scenario() -> None:
         async with _sweeper_stack(runs_stream) as (sessionmaker, queue, client):
             stop = asyncio.Event()
-            task = asyncio.create_task(
-                run_expiry_sweeper(sessionmaker, queue, 0.05, stop)
-            )
+            task = asyncio.create_task(run_expiry_sweeper(sessionmaker, queue, 0.05, stop))
             try:
                 # Poll (bounded) until the loop observes the lapse and flips it.
                 status_deadline = asyncio.get_running_loop().time() + 5.0
@@ -1574,9 +1510,7 @@ _BROAD = "C0BROAD01"
 _ELSEWHERE = "C0ELSE001"
 
 
-def _agent_with_routes(
-    client: TestClient, headers: dict[str, str], routes: dict[str, Any]
-) -> str:
+def _agent_with_routes(client: TestClient, headers: dict[str, str], routes: dict[str, Any]) -> str:
     created = client.post(
         "/agents",
         json={
@@ -1591,9 +1525,7 @@ def _agent_with_routes(
 
 
 def _routed_payload(agent_id: str | None, **overrides: Any) -> dict[str, Any]:
-    return _payload(
-        agent_id=agent_id, route="managers", card_channel=_BROAD, **overrides
-    )
+    return _payload(agent_id=agent_id, route="managers", card_channel=_BROAD, **overrides)
 
 
 def _fake_slack(
@@ -1615,8 +1547,8 @@ def _fake_slack(
         httpx.AsyncClient(transport=httpx.MockTransport(_handler)),
         token="xoxb-test",
     )
-    client.app.dependency_overrides[get_approver_sets] = lambda: (
-        SlackApproverSetSelector(group_client)
+    client.app.dependency_overrides[get_approver_sets] = lambda: SlackApproverSetSelector(
+        group_client
     )
 
 
@@ -1624,9 +1556,7 @@ def _no_slack_configured(client: TestClient) -> None:
     """A deployment with no SLACK_BOT_TOKEN: the selector is still wired (main
     always wires one), it just has no usergroup client behind it."""
 
-    client.app.dependency_overrides[get_approver_sets] = lambda: (
-        SlackApproverSetSelector(None)
-    )
+    client.app.dependency_overrides[get_approver_sets] = lambda: SlackApproverSetSelector(None)
 
 
 def _resolve(
@@ -1699,9 +1629,7 @@ def test_group_member_resolves_and_session_resumes(
         {"managers": {"channel": _BROAD, "approvers": {"group": _GROUP}}},
     )
     payload = _routed_payload(agent_id)
-    created = approvals_client.post(
-        "/approvals", json=payload, headers=auth_headers
-    ).json()
+    created = approvals_client.post("/approvals", json=payload, headers=auth_headers).json()
 
     ok = _resolve(approvals_client, auth_headers, created["id"], _APPROVER)
     assert ok.status_code == 200, ok.text
@@ -1890,9 +1818,7 @@ def test_requester_cannot_self_approve_under_a_bound_channel_authorizer(
     landing on channel membership. The self-approval block must survive that
     route."""
 
-    agent_id = _agent_with_routes(
-        approvals_client, auth_headers, {"managers": {"channel": _BROAD}}
-    )
+    agent_id = _agent_with_routes(approvals_client, auth_headers, {"managers": {"channel": _BROAD}})
     created = approvals_client.post(
         "/approvals",
         json=_routed_payload(agent_id, author=_APPROVER),
@@ -1936,9 +1862,7 @@ def test_audit_names_authorizer_and_membership_evidence(
     assert _resolve(approvals_client, auth_headers, created["id"], _OTHER).status_code == 403
     assert _resolve(approvals_client, auth_headers, created["id"], _APPROVER).status_code == 200
 
-    entries = approvals_client.get(
-        f"/approvals/{created['id']}/audit", headers=auth_headers
-    ).json()
+    entries = approvals_client.get(f"/approvals/{created['id']}/audit", headers=auth_headers).json()
     assert [e["action"] for e in entries] == ["denied", "resolved"]
     denied_entry, resolved_entry = entries
 
@@ -2006,9 +1930,7 @@ def test_audit_evidence_for_a_channel_decision(
     """AC3 + AC4: the unchanged channel path gains evidence too, naming the
     channel that held the authority and the channel the click came from."""
 
-    agent_id = _agent_with_routes(
-        approvals_client, auth_headers, {"managers": {"channel": _BROAD}}
-    )
+    agent_id = _agent_with_routes(approvals_client, auth_headers, {"managers": {"channel": _BROAD}})
     created = approvals_client.post(
         "/approvals", json=_routed_payload(agent_id), headers=auth_headers
     ).json()
@@ -2054,9 +1976,7 @@ def test_expiry_sweeper_audit_rows_carry_no_evidence(
 
     assert asyncio.run(_scenario()) == 1
 
-    entries = approvals_client.get(
-        f"/approvals/{created['id']}/audit", headers=auth_headers
-    ).json()
+    entries = approvals_client.get(f"/approvals/{created['id']}/audit", headers=auth_headers).json()
     assert [e["action"] for e in entries] == ["expired"]
     assert entries[0]["authorizer"] == "ExpirySweeper"
     assert entries[0]["evidence"] is None
@@ -2126,9 +2046,7 @@ def test_group_lookup_failure_denies_and_audits_the_failure(
     assert "not an approver" not in denied.json()["detail"]
     assert calls != []
 
-    entries = approvals_client.get(
-        f"/approvals/{created['id']}/audit", headers=auth_headers
-    ).json()
+    entries = approvals_client.get(f"/approvals/{created['id']}/audit", headers=auth_headers).json()
     assert [e["action"] for e in entries] == ["denied"]
     row = entries[0]
     assert row["authorized"] is False
@@ -2157,9 +2075,7 @@ def test_binding_without_approvers_keeps_channel_membership(
     against ``card_channel`` -- anyone in the card channel, nobody outside it.
     Zero-setup stays zero-setup."""
 
-    agent_id = _agent_with_routes(
-        approvals_client, auth_headers, {"managers": {"channel": _BROAD}}
-    )
+    agent_id = _agent_with_routes(approvals_client, auth_headers, {"managers": {"channel": _BROAD}})
     created = approvals_client.post(
         "/approvals", json=_routed_payload(agent_id), headers=auth_headers
     ).json()
@@ -2229,9 +2145,7 @@ def test_unbound_route_name_keeps_channel_membership(
     ).json()
 
     # The OTHER route's allowlist must not leak onto this one.
-    listed_elsewhere = _resolve(
-        approvals_client, auth_headers, created["id"], _LISTED, _ELSEWHERE
-    )
+    listed_elsewhere = _resolve(approvals_client, auth_headers, created["id"], _LISTED, _ELSEWHERE)
     assert listed_elsewhere.status_code == 403, listed_elsewhere.text
 
     # AC2 survives the unbound-route path too.

--- a/apps/api/tests/test_approvers_port.py
+++ b/apps/api/tests/test_approvers_port.py
@@ -32,18 +32,14 @@ class _EveryoneIsAMember:
 
     audit_name = "FakeApproverSet"
 
-    async def contains(
-        self, actor: str, actor_channel: str | None
-    ) -> MembershipVerdict:
+    async def contains(self, actor: str, actor_channel: str | None) -> MembershipVerdict:
         return MembershipVerdict(member=True, evidence={"kind": "fake", "actor": actor})
 
 
 class _NobodyIsAMember:
     audit_name = "FakeApproverSet"
 
-    async def contains(
-        self, actor: str, actor_channel: str | None
-    ) -> MembershipVerdict:
+    async def contains(self, actor: str, actor_channel: str | None) -> MembershipVerdict:
         return MembershipVerdict(
             member=False, reason="you are not an approver: fake set", evidence=None
         )
@@ -54,9 +50,7 @@ class _CannotTell:
 
     audit_name = "FakeApproverSet"
 
-    async def contains(
-        self, actor: str, actor_channel: str | None
-    ) -> MembershipVerdict:
+    async def contains(self, actor: str, actor_channel: str | None) -> MembershipVerdict:
         return MembershipVerdict(
             member=False,
             undetermined=True,
@@ -71,9 +65,7 @@ class _FakeSelector:
     def __init__(self, approver_set: ApproverSet) -> None:
         self._approver_set = approver_set
 
-    def __call__(
-        self, approval: Approval, binding: Mapping[str, Any] | None
-    ) -> ApproverSet:
+    def __call__(self, approval: Approval, binding: Mapping[str, Any] | None) -> ApproverSet:
         return self._approver_set
 
 

--- a/apps/api/tests/test_auth.py
+++ b/apps/api/tests/test_auth.py
@@ -15,14 +15,10 @@ def test_health_is_open(client: Any) -> None:
 
 def test_agents_require_api_key(client: Any) -> None:
     assert client.get("/agents").status_code == 401
-    assert (
-        client.get("/agents", headers={"X-API-Key": "wrong"}).status_code == 401
-    )
+    assert client.get("/agents", headers={"X-API-Key": "wrong"}).status_code == 401
 
 
-def test_agents_accept_valid_key(
-    client: Any, auth_headers: dict[str, str], clean_db: None
-) -> None:
+def test_agents_accept_valid_key(client: Any, auth_headers: dict[str, str], clean_db: None) -> None:
     assert client.get("/agents", headers=auth_headers).status_code == 200
 
 

--- a/apps/api/tests/test_authorizer.py
+++ b/apps/api/tests/test_authorizer.py
@@ -54,9 +54,7 @@ def _authorize(
 
     select = SlackApproverSetSelector(group_client)
     return asyncio.run(
-        authorize_approval(
-            approval, actor, actor_channel, approver_set=select(approval, binding)
-        )
+        authorize_approval(approval, actor, actor_channel, approver_set=select(approval, binding))
     )
 
 
@@ -135,9 +133,7 @@ def _slack(members: list[str], calls: list[httpx.Request] | None = None) -> Slac
     )
 
 
-def _contains(
-    approver_set: ApproverSet, actor: str, channel: str | None
-) -> MembershipVerdict:
+def _contains(approver_set: ApproverSet, actor: str, channel: str | None) -> MembershipVerdict:
     return asyncio.run(approver_set.contains(actor, channel))
 
 
@@ -427,9 +423,7 @@ def test_authorizer_falls_back_to_channel_membership_without_approvers() -> None
 
     binding = {"channel": _CARD_CHANNEL}
 
-    name, member = _authorize(
-        _bound_approval(), _OUTSIDER, _CARD_CHANNEL, binding=binding
-    )
+    name, member = _authorize(_bound_approval(), _OUTSIDER, _CARD_CHANNEL, binding=binding)
     assert name == "ChannelMembershipAuthorizer"
     assert member.allowed
     assert member.evidence is not None
@@ -437,9 +431,7 @@ def test_authorizer_falls_back_to_channel_membership_without_approvers() -> None
     assert member.evidence["approvers_channel"] == _CARD_CHANNEL
     assert member.evidence["actor_channel"] == _CARD_CHANNEL
 
-    _name, elsewhere = _authorize(
-        _bound_approval(), _OUTSIDER, "C0WRONG01", binding=binding
-    )
+    _name, elsewhere = _authorize(_bound_approval(), _OUTSIDER, "C0WRONG01", binding=binding)
     assert not elsewhere.allowed
     assert "not an approver" in elsewhere.reason
     assert elsewhere.evidence is not None
@@ -450,15 +442,11 @@ def test_authorizer_falls_back_to_channel_membership_without_a_binding() -> None
     """AC4: no binding at all (an agentless or unbound-route approval) is the
     zero-setup path and must keep resolving against the card channel."""
 
-    name, in_channel = _authorize(
-        _bound_approval(), _OUTSIDER, _CARD_CHANNEL, binding=None
-    )
+    name, in_channel = _authorize(_bound_approval(), _OUTSIDER, _CARD_CHANNEL, binding=None)
     assert name == "ChannelMembershipAuthorizer"
     assert in_channel.allowed
 
-    _name, elsewhere = _authorize(
-        _bound_approval(), _OUTSIDER, "C0WRONG01", binding=None
-    )
+    _name, elsewhere = _authorize(_bound_approval(), _OUTSIDER, "C0WRONG01", binding=None)
     assert not elsewhere.allowed
     assert "not an approver" in elsewhere.reason
 

--- a/apps/api/tests/test_behavior_packs_integration.py
+++ b/apps/api/tests/test_behavior_packs_integration.py
@@ -65,9 +65,7 @@ def test_put_then_get_round_trips(
         },
         "nav": {"enabled": True, "hub_label": "Help", "hub_command": "help"},
     }
-    resp = client.put(
-        f"/agents/{agent['id']}/behavior-packs", json=config, headers=auth_headers
-    )
+    resp = client.put(f"/agents/{agent['id']}/behavior-packs", json=config, headers=auth_headers)
     assert resp.status_code == 200, resp.text
 
     resp = client.get(f"/agents/{agent['id']}/behavior-packs", headers=auth_headers)

--- a/apps/api/tests/test_behavior_packs_size_cap.py
+++ b/apps/api/tests/test_behavior_packs_size_cap.py
@@ -81,9 +81,7 @@ def test_put_behavior_packs_within_cap_ok(
         "help": {"enabled": True, "phrases": ["help"], "reply": "here is help"},
         "nav": {"enabled": True, "hub_label": "Help", "hub_command": "help"},
     }
-    resp = client.put(
-        f"/agents/{agent['id']}/behavior-packs", json=config, headers=auth_headers
-    )
+    resp = client.put(f"/agents/{agent['id']}/behavior-packs", json=config, headers=auth_headers)
     assert resp.status_code == 200, resp.text
 
     resp = client.get(f"/agents/{agent['id']}/behavior-packs", headers=auth_headers)
@@ -110,16 +108,12 @@ def test_put_behavior_packs_boundary_of_small_overridden_cap(
 
         # Comfortably under the 1000-byte cap (serialized total ~870 bytes).
         under = {"greeting": {"enabled": True, "phrases": [], "reply": "a" * 600}}
-        resp = client.put(
-            f"/agents/{agent['id']}/behavior-packs", json=under, headers=auth_headers
-        )
+        resp = client.put(f"/agents/{agent['id']}/behavior-packs", json=under, headers=auth_headers)
         assert resp.status_code == 200, resp.text
 
         # Comfortably over the 1000-byte cap (serialized total ~1170 bytes).
         over = {"greeting": {"enabled": True, "phrases": [], "reply": "a" * 900}}
-        resp = client.put(
-            f"/agents/{agent['id']}/behavior-packs", json=over, headers=auth_headers
-        )
+        resp = client.put(f"/agents/{agent['id']}/behavior-packs", json=over, headers=auth_headers)
         assert resp.status_code == 413, resp.text
     finally:
         get_settings.cache_clear()

--- a/apps/api/tests/test_bundle_ingestion_bounds.py
+++ b/apps/api/tests/test_bundle_ingestion_bounds.py
@@ -101,9 +101,7 @@ def test_oversized_upload_is_rejected_before_buffering(
     assert calls == []
 
     # Nothing was stored.
-    version = client.get(
-        f"/agents/{agent_id}/versions", headers=auth_headers
-    ).json()[0]
+    version = client.get(f"/agents/{agent_id}/versions", headers=auth_headers).json()[0]
     assert version["bundle_ref"] is None
 
 
@@ -115,9 +113,7 @@ def test_upload_at_the_limit_is_accepted(
 ) -> None:
     files = {
         ".claude-plugin/plugin.json": MANIFEST.encode(),
-        "skills/greeter/SKILL.md": (
-            b"---\nname: greeter\ndescription: greets\n---\n"
-        ),
+        "skills/greeter/SKILL.md": (b"---\nname: greeter\ndescription: greets\n---\n"),
     }
     archive = _tar_plain(files)
     monkeypatch.setattr(
@@ -161,9 +157,7 @@ def test_zip_bomb_upload_is_refused_with_nothing_written(
     assert resp.status_code == 400, resp.text
     assert "compression ratio" in resp.json()["detail"]
 
-    version = client.get(
-        f"/agents/{agent_id}/versions", headers=auth_headers
-    ).json()[0]
+    version = client.get(f"/agents/{agent_id}/versions", headers=auth_headers).json()[0]
     assert version["bundle_ref"] is None
 
 
@@ -207,9 +201,7 @@ def test_many_member_upload_is_refused_by_member_count_cap(
     assert resp.status_code == 400, resp.text
     assert "member-count" in resp.json()["detail"]
 
-    version = client.get(
-        f"/agents/{agent_id}/versions", headers=auth_headers
-    ).json()[0]
+    version = client.get(f"/agents/{agent_id}/versions", headers=auth_headers).json()[0]
     assert version["bundle_ref"] is None
 
 
@@ -231,9 +223,7 @@ def _store_legacy_bundle(agent_id: str, version_id: str, data: bytes) -> None:
         async with maker() as session:
             version = await crud.get_version(session, uuid.UUID(version_id))
             assert version is not None
-            await crud.attach_bundle(
-                session, version, key, hashlib.sha256(data).hexdigest()
-            )
+            await crud.attach_bundle(session, version, key, hashlib.sha256(data).hexdigest())
         await engine.dispose()
 
     asyncio.run(_run())

--- a/apps/api/tests/test_bundles.py
+++ b/apps/api/tests/test_bundles.py
@@ -51,9 +51,7 @@ def _zip(files: dict[str, str]) -> bytes:
 
 
 def test_valid_tar_gz_passes_validation(tmp_path: Path) -> None:
-    ext, content_type, result = bundles.extract_and_validate(
-        _tar_gz(_valid_files()), tmp_path
-    )
+    ext, content_type, result = bundles.extract_and_validate(_tar_gz(_valid_files()), tmp_path)
     assert ext == ".tar.gz"
     assert content_type == "application/gzip"
     assert result.valid, result.errors
@@ -126,9 +124,7 @@ def test_upload_store_fetch_round_trip(
     archive = _tar_gz(_valid_files())
     url = f"/agents/{agent_id}/versions/{version_id}/bundle"
 
-    resp = client.put(
-        url, files={"file": ("demo.tar.gz", archive)}, headers=auth_headers
-    )
+    resp = client.put(url, files={"file": ("demo.tar.gz", archive)}, headers=auth_headers)
     assert resp.status_code == 201, resp.text
     body = resp.json()
     assert body["bundle_ref"] == f"bundles/{agent_id}/{version_id}.tar.gz"
@@ -136,9 +132,7 @@ def test_upload_store_fetch_round_trip(
     assert body["size_bytes"] == len(archive)
 
     # The version now advertises the stored bundle.
-    version = client.get(
-        f"/agents/{agent_id}/versions", headers=auth_headers
-    ).json()[0]
+    version = client.get(f"/agents/{agent_id}/versions", headers=auth_headers).json()[0]
     assert version["bundle_ref"] == body["bundle_ref"]
     assert version["bundle_sha256"] == body["bundle_sha256"]
 
@@ -149,20 +143,14 @@ def test_upload_store_fetch_round_trip(
     assert hashlib.sha256(got.content).hexdigest() == body["bundle_sha256"]
 
 
-def test_bundles_are_immutable(
-    client: Any, auth_headers: dict[str, str], clean_db: None
-) -> None:
+def test_bundles_are_immutable(client: Any, auth_headers: dict[str, str], clean_db: None) -> None:
     agent_id, version_id = _create_version(client, auth_headers)
     url = f"/agents/{agent_id}/versions/{version_id}/bundle"
     archive = _tar_gz(_valid_files())
 
-    first = client.put(
-        url, files={"file": ("demo.tar.gz", archive)}, headers=auth_headers
-    )
+    first = client.put(url, files={"file": ("demo.tar.gz", archive)}, headers=auth_headers)
     assert first.status_code == 201
-    second = client.put(
-        url, files={"file": ("demo.tar.gz", archive)}, headers=auth_headers
-    )
+    second = client.put(url, files={"file": ("demo.tar.gz", archive)}, headers=auth_headers)
     assert second.status_code == 409
 
 
@@ -188,9 +176,7 @@ def test_fetch_missing_bundle_is_404(
     client: Any, auth_headers: dict[str, str], clean_db: None
 ) -> None:
     agent_id, version_id = _create_version(client, auth_headers)
-    resp = client.get(
-        f"/agents/{agent_id}/versions/{version_id}/bundle", headers=auth_headers
-    )
+    resp = client.get(f"/agents/{agent_id}/versions/{version_id}/bundle", headers=auth_headers)
     assert resp.status_code == 404
 
 
@@ -211,9 +197,7 @@ def test_read_version_files_returns_bundle_text_surfaces(
     )
     assert put.status_code == 201, put.text
 
-    resp = client.get(
-        f"/agents/{agent_id}/versions/{version_id}/files", headers=auth_headers
-    )
+    resp = client.get(f"/agents/{agent_id}/versions/{version_id}/files", headers=auth_headers)
     assert resp.status_code == 200, resp.text
     returned = {f["path"]: f["content"] for f in resp.json()["files"]}
     assert set(returned) == {
@@ -232,9 +216,7 @@ def test_read_version_files_missing_bundle_is_404(
 ) -> None:
     # A version with no bundle stored yet has nothing to read.
     agent_id, version_id = _create_version(client, auth_headers)
-    resp = client.get(
-        f"/agents/{agent_id}/versions/{version_id}/files", headers=auth_headers
-    )
+    resp = client.get(f"/agents/{agent_id}/versions/{version_id}/files", headers=auth_headers)
     assert resp.status_code == 404
 
 
@@ -243,7 +225,5 @@ def test_read_version_files_unknown_version_is_404(
 ) -> None:
     agent_id, _ = _create_version(client, auth_headers)
     missing = "00000000-0000-0000-0000-000000000000"
-    resp = client.get(
-        f"/agents/{agent_id}/versions/{missing}/files", headers=auth_headers
-    )
+    resp = client.get(f"/agents/{agent_id}/versions/{missing}/files", headers=auth_headers)
     assert resp.status_code == 404

--- a/apps/api/tests/test_config_parity.py
+++ b/apps/api/tests/test_config_parity.py
@@ -114,9 +114,7 @@ class TestResumeDeadLetterStreamCoherence:
 
         assert resolved == WorkerConfig().dead_letter_stream_name() == "operations:dead"
 
-    def test_explicit_resume_override_wins(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_explicit_resume_override_wins(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """A narrower RESUME_DEAD_LETTER_STREAM override beats the derived name."""
         _clear_stream_env(monkeypatch)
         monkeypatch.setenv("CURIE_DEAD_LETTER_STREAM", "operations:dead")

--- a/apps/api/tests/test_config_prod_gate.py
+++ b/apps/api/tests/test_config_prod_gate.py
@@ -36,9 +36,7 @@ def test_prod_with_real_secrets_boots() -> None:
         ({"github_webhook_secret": ""}, "GITHUB_WEBHOOK_SECRET"),
     ],
 )
-def test_prod_refuses_dev_default_or_empty_secret(
-    overrides: dict[str, str], offender: str
-) -> None:
+def test_prod_refuses_dev_default_or_empty_secret(overrides: dict[str, str], offender: str) -> None:
     with pytest.raises(ValidationError) as exc:
         _settings(**overrides)
     assert offender in str(exc.value)

--- a/apps/api/tests/test_control_integration.py
+++ b/apps/api/tests/test_control_integration.py
@@ -94,17 +94,13 @@ def test_reset_thread_queues_a_pending_request(
     agent_id = _make_agent(client, auth_headers)
     valkey.srem(THREAD_RESET_SET, "t-reset-1")
     try:
-        resp = client.post(
-            f"/agents/{agent_id}/threads/t-reset-1/reset", headers=auth_headers
-        )
+        resp = client.post(f"/agents/{agent_id}/threads/t-reset-1/reset", headers=auth_headers)
         assert resp.status_code == 200
         assert resp.json() == {"requested": True}
         assert valkey.sismember(THREAD_RESET_SET, "t-reset-1")
 
         # Idempotent: requesting an already-pending thread again is a no-op.
-        again = client.post(
-            f"/agents/{agent_id}/threads/t-reset-1/reset", headers=auth_headers
-        )
+        again = client.post(f"/agents/{agent_id}/threads/t-reset-1/reset", headers=auth_headers)
         assert again.status_code == 200
         assert valkey.scard(THREAD_RESET_SET) >= 1
     finally:
@@ -284,8 +280,7 @@ def test_cost_filters_langfuse_by_the_agent_trace_token(
     assert captured, "cost endpoint issued no Langfuse metrics query"
     filters = captured[0]["filters"]
     assert any(
-        f["operator"] == "contains" and f["value"] == f"agent-{agent_id}"
-        for f in filters
+        f["operator"] == "contains" and f["value"] == f"agent-{agent_id}" for f in filters
     ), f"agent trace-token filter missing from {filters}"
 
 
@@ -294,13 +289,9 @@ def test_control_endpoints_require_api_key(client: Any) -> None:
     assert client.get(f"/agents/{missing}/kill").status_code == 401
 
 
-def test_missing_agent_is_404(
-    client: Any, auth_headers: dict[str, str], clean_db: None
-) -> None:
+def test_missing_agent_is_404(client: Any, auth_headers: dict[str, str], clean_db: None) -> None:
     missing = "00000000-0000-0000-0000-000000000000"
-    assert (
-        client.post(f"/agents/{missing}/kill", headers=auth_headers).status_code == 404
-    )
+    assert client.post(f"/agents/{missing}/kill", headers=auth_headers).status_code == 404
 
 
 def _await_event(pubsub: Any, agent_id: str, action: str) -> dict[str, Any]:

--- a/apps/api/tests/test_control_unit.py
+++ b/apps/api/tests/test_control_unit.py
@@ -11,14 +11,9 @@ from pydantic import ValidationError
 
 def test_valkey_dsn_honors_the_password_override() -> None:
     # The compose VALKEY_PASSWORD knob must reach the DSN the API connects with.
-    assert Settings(valkey_password="s3cret").valkey_dsn() == (
-        "redis://:s3cret@localhost:26379/0"
-    )
+    assert Settings(valkey_password="s3cret").valkey_dsn() == ("redis://:s3cret@localhost:26379/0")
     # An explicit full URL overrides the parts.
-    assert (
-        Settings(valkey_url="redis://:x@other:1/2").valkey_dsn()
-        == "redis://:x@other:1/2"
-    )
+    assert Settings(valkey_url="redis://:x@other:1/2").valkey_dsn() == "redis://:x@other:1/2"
 
 
 def test_kill_key_matches_the_seam_contract() -> None:

--- a/apps/api/tests/test_crud.py
+++ b/apps/api/tests/test_crud.py
@@ -24,9 +24,7 @@ def _count(query: str, agent_id: str) -> int:
     return asyncio.run(run())
 
 
-def test_full_round_trip(
-    client: Any, auth_headers: dict[str, str], clean_db: None
-) -> None:
+def test_full_round_trip(client: Any, auth_headers: dict[str, str], clean_db: None) -> None:
     # create agent
     resp = client.post(
         "/agents",
@@ -74,9 +72,7 @@ def test_full_round_trip(
     assert got_agent.status_code == 200
     assert got_agent.json()["slack_channel"] == "C0TRIAGE01"
 
-    listed_versions = client.get(
-        f"/agents/{agent_id}/versions", headers=auth_headers
-    ).json()
+    listed_versions = client.get(f"/agents/{agent_id}/versions", headers=auth_headers).json()
     assert [v["id"] for v in listed_versions] == [version_id]
 
     listed_deployments = client.get(
@@ -84,9 +80,7 @@ def test_full_round_trip(
     ).json()
     assert [d["id"] for d in listed_deployments] == [deployment_id]
 
-    got_deployment = client.get(
-        f"/deployments/{deployment_id}", headers=auth_headers
-    )
+    got_deployment = client.get(f"/deployments/{deployment_id}", headers=auth_headers)
     assert got_deployment.status_code == 200
     assert got_deployment.json()["version_id"] == version_id
 
@@ -95,9 +89,7 @@ def test_missing_agent_returns_404(
     client: Any, auth_headers: dict[str, str], clean_db: None
 ) -> None:
     missing = "00000000-0000-0000-0000-000000000000"
-    assert (
-        client.get(f"/agents/{missing}", headers=auth_headers).status_code == 404
-    )
+    assert client.get(f"/agents/{missing}", headers=auth_headers).status_code == 404
 
 
 def test_version_for_missing_agent_returns_404(
@@ -145,9 +137,7 @@ def test_patch_agent_omitted_field_is_noop(
         json={"name": "stable", "slack_channel": "C0000KEEP1"},
         headers=auth_headers,
     ).json()
-    resp = client.patch(
-        f"/agents/{agent['id']}", json={}, headers=auth_headers
-    )
+    resp = client.patch(f"/agents/{agent['id']}", json={}, headers=auth_headers)
     assert resp.status_code == 200, resp.text
     assert resp.json()["slack_channel"] == "C0000KEEP1"
 

--- a/apps/api/tests/test_eval_case_schema_parity.py
+++ b/apps/api/tests/test_eval_case_schema_parity.py
@@ -23,11 +23,7 @@ from curie_api.schemas import EvalCaseOut, GraderOut
 from jsonschema import Draft202012Validator
 
 _SCHEMA_PATH = (
-    Path(__file__).resolve().parents[3]
-    / "apps"
-    / "worker"
-    / "schema"
-    / "eval-cases.schema.json"
+    Path(__file__).resolve().parents[3] / "apps" / "worker" / "schema" / "eval-cases.schema.json"
 )
 
 

--- a/apps/api/tests/test_evalqueue_integration.py
+++ b/apps/api/tests/test_evalqueue_integration.py
@@ -163,8 +163,7 @@ def _count_eval_entries_for_agent(agent_id: str) -> int:
         return sum(
             1
             for _id, fields in sync.xrevrange("curie:evals", count=200)
-            if json.loads(fields[STREAM_PAYLOAD_FIELD.encode()]).get("agent_id")
-            == agent_id
+            if json.loads(fields[STREAM_PAYLOAD_FIELD.encode()]).get("agent_id") == agent_id
         )
     finally:
         sync.close()
@@ -180,9 +179,7 @@ def test_dev_push_fans_out_prod_push_does_not(
     ).json()
     clone_url, sha = _build_bare_repo(tmp_path)
 
-    assert _post_push(client, "refs/heads/dev", sha, clone_url).json()["status"] == (
-        "deployed"
-    )
+    assert _post_push(client, "refs/heads/dev", sha, clone_url).json()["status"] == ("deployed")
     entry = _eval_entry_for(sha)
     assert entry is not None, "dev push should fan out an eval job"
     assert entry["agent_id"] == agent["id"]
@@ -194,9 +191,7 @@ def test_dev_push_fans_out_prod_push_does_not(
         before = len(sync.xrange("curie:evals"))
     finally:
         sync.close()
-    assert _post_push(client, "refs/heads/main", sha, clone_url).json()["status"] == (
-        "promoted"
-    )
+    assert _post_push(client, "refs/heads/main", sha, clone_url).json()["status"] == ("promoted")
     sync = redis.from_url(get_settings().valkey_dsn())
     try:
         after = len(sync.xrange("curie:evals"))
@@ -216,14 +211,10 @@ def test_redelivered_dev_push_does_not_refan_out(
     clone_url, sha = _build_bare_repo(tmp_path)
 
     # First delivery builds the bundle and fans out exactly one eval job.
-    assert _post_push(client, "refs/heads/dev", sha, clone_url).json()["status"] == (
-        "deployed"
-    )
+    assert _post_push(client, "refs/heads/dev", sha, clone_url).json()["status"] == ("deployed")
     assert _count_eval_entries_for_agent(agent["id"]) == 1
 
     # GitHub redelivers the same push. The version already has a stored bundle,
     # so the build is skipped and no second eval job may be enqueued.
-    assert _post_push(client, "refs/heads/dev", sha, clone_url).json()["status"] == (
-        "deployed"
-    )
+    assert _post_push(client, "refs/heads/dev", sha, clone_url).json()["status"] == ("deployed")
     assert _count_eval_entries_for_agent(agent["id"]) == 1

--- a/apps/api/tests/test_evals_integration.py
+++ b/apps/api/tests/test_evals_integration.py
@@ -69,9 +69,7 @@ def test_matrix_reflects_seeded_multi_version_scores(
     deadline = time.time() + 60
     cells: dict[tuple[str, str], str] = {}
     while time.time() < deadline:
-        resp = client.get(
-            "/evals/matrix", params={"suite": suite}, headers=auth_headers
-        )
+        resp = client.get("/evals/matrix", params={"suite": suite}, headers=auth_headers)
         assert resp.status_code == 200, resp.text
         body = resp.json()
         cells = {
@@ -79,9 +77,7 @@ def test_matrix_reflects_seeded_multi_version_scores(
             for row in body["rows"]
             for cell in row["cells"]
         }
-        ready = {
-            (c, v) for c in ("c1", "c2") for v in (sha_a, sha_b)
-        } <= set(cells)
+        ready = {(c, v) for c in ("c1", "c2") for v in (sha_a, sha_b)} <= set(cells)
         if ready and all(cells[k] != "missing" for k in cells):
             break
         time.sleep(2)

--- a/apps/api/tests/test_evals_report.py
+++ b/apps/api/tests/test_evals_report.py
@@ -149,9 +149,7 @@ def test_report_unknown_repo_returns_404_not_500(
     # a clear 4xx, never a 500 (the audit MAJOR: report_eval 500s on stale/unknown
     # repo state). GitHub answers 404 -> the API answers 404 with a clear detail.
     app = create_app()
-    app.dependency_overrides[get_github_reporter] = (
-        lambda: _reporter_rejecting_with(404)
-    )
+    app.dependency_overrides[get_github_reporter] = lambda: _reporter_rejecting_with(404)
     with TestClient(app) as client:
         resp = client.post(
             "/evals/report",
@@ -173,9 +171,7 @@ def test_report_github_client_rejection_maps_to_422(
     # A non-404 GitHub client rejection (e.g. 422 bad sha, 403 token) is still a
     # caller/input fault, not an API server fault: map to 422, not 500.
     app = create_app()
-    app.dependency_overrides[get_github_reporter] = (
-        lambda: _reporter_rejecting_with(422)
-    )
+    app.dependency_overrides[get_github_reporter] = lambda: _reporter_rejecting_with(422)
     with TestClient(app) as client:
         resp = client.post(
             "/evals/report",

--- a/apps/api/tests/test_evals_trigger_integration.py
+++ b/apps/api/tests/test_evals_trigger_integration.py
@@ -106,8 +106,7 @@ def _count_eval_entries_for_agent(agent_id: str) -> int:
         return sum(
             1
             for _id, fields in sync.xrevrange("curie:evals", count=200)
-            if json.loads(fields[STREAM_PAYLOAD_FIELD.encode()]).get("agent_id")
-            == agent_id
+            if json.loads(fields[STREAM_PAYLOAD_FIELD.encode()]).get("agent_id") == agent_id
         )
     finally:
         sync.close()
@@ -119,9 +118,7 @@ def test_trigger_enqueues_for_active_dev_deployment(
     agent = _create_agent(client, auth_headers, "trigger-active")
     seeded = _seed(agent["id"])
 
-    resp = client.post(
-        "/evals/trigger", json={"agent_id": agent["id"]}, headers=auth_headers
-    )
+    resp = client.post("/evals/trigger", json={"agent_id": agent["id"]}, headers=auth_headers)
     assert resp.status_code == 200, resp.text
     body = resp.json()
     assert body["stream_id"]
@@ -174,9 +171,7 @@ def test_trigger_unknown_agent_returns_404_and_does_not_enqueue(
     client: Any, auth_headers: dict[str, str], clean_db: None
 ) -> None:
     missing = str(uuid.uuid4())
-    resp = client.post(
-        "/evals/trigger", json={"agent_id": missing}, headers=auth_headers
-    )
+    resp = client.post("/evals/trigger", json={"agent_id": missing}, headers=auth_headers)
     assert resp.status_code == 404, resp.text
     assert _count_eval_entries_for_agent(missing) == 0
 
@@ -187,9 +182,7 @@ def test_trigger_agent_without_active_dev_deployment_returns_404(
     agent = _create_agent(client, auth_headers, "trigger-nodeploy")
     # A version exists but was never deployed to dev.
     _seed(agent["id"], deploy=False)
-    resp = client.post(
-        "/evals/trigger", json={"agent_id": agent["id"]}, headers=auth_headers
-    )
+    resp = client.post("/evals/trigger", json={"agent_id": agent["id"]}, headers=auth_headers)
     assert resp.status_code == 404, resp.text
     assert _count_eval_entries_for_agent(agent["id"]) == 0
 
@@ -270,9 +263,7 @@ def test_trigger_active_dev_deployment_without_bundle_returns_400(
     agent = _create_agent(client, auth_headers, "trigger-no-bundle-deploy")
     _seed(agent["id"], commit_sha="deadbeef", bundle_ref=None)
 
-    resp = client.post(
-        "/evals/trigger", json={"agent_id": agent["id"]}, headers=auth_headers
-    )
+    resp = client.post("/evals/trigger", json={"agent_id": agent["id"]}, headers=auth_headers)
     assert resp.status_code == 400, resp.text
     assert "no built bundle" in resp.json()["detail"]
     assert _count_eval_entries_for_agent(agent["id"]) == 0

--- a/apps/api/tests/test_evals_unit.py
+++ b/apps/api/tests/test_evals_unit.py
@@ -26,11 +26,7 @@ def test_build_matrix_pivots_cases_by_version() -> None:
     assert matrix.versions == ["shaB", "shaA"]  # most recent first
     assert matrix.cases == ["c1", "c2"]
 
-    cells = {
-        (row.case_id, cell.version): cell.status
-        for row in matrix.rows
-        for cell in row.cells
-    }
+    cells = {(row.case_id, cell.version): cell.status for row in matrix.rows for cell in row.cells}
     assert cells[("c1", "shaA")] == "pass"
     assert cells[("c1", "shaB")] == "pass"
     assert cells[("c2", "shaA")] == "fail"
@@ -134,9 +130,7 @@ def test_cells_carry_model_and_unlabelled_runs_sort_last() -> None:
     ]
     matrix = build_matrix(traces, "s", 5)
 
-    cell_models = {
-        cell.version: cell.model for row in matrix.rows for cell in row.cells
-    }
+    cell_models = {cell.version: cell.model for row in matrix.rows for cell in row.cells}
     assert cell_models["shaA"] == "opus"
     assert cell_models["shaB"] is None
     # Unlabelled (None) model rolls up too and sorts after named models.
@@ -191,9 +185,7 @@ def test_a_plumbing_cell_is_never_a_pass() -> None:
     ]
     matrix = build_matrix(traces, "s", 5)
 
-    cells = {
-        (row.case_id, cell.version): cell.status for row in matrix.rows for cell in row.cells
-    }
+    cells = {(row.case_id, cell.version): cell.status for row in matrix.rows for cell in row.cells}
     assert cells[("c1", "shaA")] == "plumbing_ok"
     assert cells[("c2", "shaA")] == "fail"
 
@@ -217,9 +209,7 @@ def test_the_outcome_wins_over_a_stale_passed_and_legacy_traces_still_render() -
     ]
     matrix = build_matrix(traces, "s", 5)
 
-    cells = {
-        (row.case_id, cell.version): cell.status for row in matrix.rows for cell in row.cells
-    }
+    cells = {(row.case_id, cell.version): cell.status for row in matrix.rows for cell in row.cells}
     assert cells[("c1", "shaA")] == "plumbing_ok"  # not "pass"
     assert cells[("c2", "shaA")] == "pass"
 
@@ -238,9 +228,7 @@ def test_a_later_plumbing_run_does_not_erase_an_earlier_graded_result() -> None:
     ]
     matrix = build_matrix(traces, "s", 5)
 
-    cells = {
-        (row.case_id, cell.version): cell for row in matrix.rows for cell in row.cells
-    }
+    cells = {(row.case_id, cell.version): cell for row in matrix.rows for cell in row.cells}
     assert cells[("c1", "shaA")].status == "pass"
     assert cells[("c1", "shaA")].model == "opus"  # the graded run's label, not the fake's
     assert cells[("c2", "shaA")].status == "plumbing_ok"
@@ -303,8 +291,7 @@ def test_a_real_zero_percent_model_is_completed_but_not_passed() -> None:
     assert opus.completed == 2  # every case reached a verdict; it just lost
 
 
-def test_a_model_that_never_completed_a_turn_is_distinct_from_a_real_zero(
-) -> None:
+def test_a_model_that_never_completed_a_turn_is_distinct_from_a_real_zero() -> None:
     """A FAIL whose turn never completed (classified failure, wrong terminal
     status, a transport error) carries `error` in its metadata (issue #622).
     `total > 0` and `completed == 0` is the "never answered" outcome the CLI
@@ -414,9 +401,7 @@ def test_per_version_summaries_scope_completed_to_each_sha() -> None:
     assert blended.total == 4
     assert blended.completed == 2  # the two old-sha completions -- the mask
 
-    per_version = {
-        (s.version, s.model): s for s in matrix.model_version_summaries
-    }
+    per_version = {(s.version, s.model): s for s in matrix.model_version_summaries}
     # The triggered sha's own row: never completed (total > 0, completed == 0).
     new = per_version[("shaNew", "opus")]
     assert new.total == 2
@@ -440,9 +425,7 @@ def test_per_version_summaries_surface_a_plumbing_only_row() -> None:
     ]
     matrix = build_matrix(traces, "s", 5)
 
-    per_version = {
-        (s.version, s.model): s for s in matrix.model_version_summaries
-    }
+    per_version = {(s.version, s.model): s for s in matrix.model_version_summaries}
     fake = per_version[("shaA", "fake")]
     assert fake.total == 0
     assert fake.plumbing == 2

--- a/apps/api/tests/test_gitflow_integration.py
+++ b/apps/api/tests/test_gitflow_integration.py
@@ -66,9 +66,7 @@ def _build_bare_repo(tmp_path: Path, files: dict[str, str]) -> tuple[str, str]:
     return f"file://{bare}", sha
 
 
-def _post(
-    client: Any, event: str, payload: dict[str, Any], secret: str = SECRET
-) -> Any:
+def _post(client: Any, event: str, payload: dict[str, Any], secret: str = SECRET) -> Any:
     body = json.dumps(payload).encode()
     sig = "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
     return client.post(
@@ -140,14 +138,10 @@ def test_dev_push_deploys_dev_bot(
     assert body["commit_sha"] == sha
 
     # The version was built from the commit and its bundle is stored + fetchable.
-    version = client.get(
-        f"/agents/{agent_id}/versions", headers=auth_headers
-    ).json()[0]
+    version = client.get(f"/agents/{agent_id}/versions", headers=auth_headers).json()[0]
     assert version["commit_sha"] == sha
     assert version["bundle_ref"] is not None
-    bundle = client.get(
-        f"/agents/{agent_id}/versions/{version['id']}/bundle", headers=auth_headers
-    )
+    bundle = client.get(f"/agents/{agent_id}/versions/{version['id']}/bundle", headers=auth_headers)
     assert bundle.status_code == 200
     assert len(bundle.content) > 0
 
@@ -165,12 +159,8 @@ def test_main_push_promotes_and_reuses_the_built_version(
     agent_id = _register_agent(client, auth_headers)
     clone_url, sha = _build_bare_repo(tmp_path, VALID_FILES)
 
-    dev = _post(
-        client, "push", _push_payload("refs/heads/dev", sha, clone_url)
-    ).json()
-    prod = _post(
-        client, "push", _push_payload("refs/heads/main", sha, clone_url)
-    ).json()
+    dev = _post(client, "push", _push_payload("refs/heads/dev", sha, clone_url)).json()
+    prod = _post(client, "push", _push_payload("refs/heads/main", sha, clone_url)).json()
 
     assert prod["status"] == "promoted"
     assert prod["environment"] == "prod"
@@ -197,9 +187,7 @@ def test_partial_version_is_rebuilt_not_reused(
     assert resp.status_code == 200
     assert resp.json()["status"] == "deployed"
 
-    versions = client.get(
-        f"/agents/{agent_id}/versions", headers=auth_headers
-    ).json()
+    versions = client.get(f"/agents/{agent_id}/versions", headers=auth_headers).json()
     # The partial row was repaired in place (no duplicate) and now has a bundle.
     assert len(versions) == 1
     assert versions[0]["commit_sha"] == sha
@@ -221,9 +209,7 @@ def test_invalid_signature_is_401(
     assert resp.status_code == 401
 
 
-def test_ping_event_pongs(
-    client: Any, auth_headers: dict[str, str], clean_db: None
-) -> None:
+def test_ping_event_pongs(client: Any, auth_headers: dict[str, str], clean_db: None) -> None:
     resp = _post(client, "ping", {"zen": "hi"})
     assert resp.status_code == 200
     assert resp.json()["status"] == "pong"
@@ -244,9 +230,7 @@ def test_non_deploy_branch_is_ignored(
 ) -> None:
     _register_agent(client, auth_headers)
     clone_url, sha = _build_bare_repo(tmp_path, VALID_FILES)
-    resp = _post(
-        client, "push", _push_payload("refs/heads/feature-x", sha, clone_url)
-    )
+    resp = _post(client, "push", _push_payload("refs/heads/feature-x", sha, clone_url))
     assert resp.status_code == 200
     assert resp.json()["status"] == "ignored"
 

--- a/apps/api/tests/test_github_checks.py
+++ b/apps/api/tests/test_github_checks.py
@@ -46,9 +46,7 @@ def _run_report(passed: int, total: int) -> tuple[httpx.Request, str]:
 def test_report_eval_posts_the_exact_commit_status() -> None:
     request, state = _run_report(34, 36)
     assert state == "failure"
-    assert str(request.url) == (
-        "https://api.github.com/repos/octo/demo/statuses/abc123def"
-    )
+    assert str(request.url) == ("https://api.github.com/repos/octo/demo/statuses/abc123def")
     assert request.method == "POST"
     body: dict[str, Any] = json.loads(request.content)
     assert body == {

--- a/apps/api/tests/test_graveyard_watcher.py
+++ b/apps/api/tests/test_graveyard_watcher.py
@@ -31,9 +31,7 @@ def _client() -> aioredis.Redis:
     )
 
 
-async def _dead_letter(
-    client: aioredis.Redis, stream: str, *, original: str, reason: str
-) -> str:
+async def _dead_letter(client: aioredis.Redis, stream: str, *, original: str, reason: str) -> str:
     return await client.xadd(
         stream,
         {

--- a/apps/api/tests/test_langfuse_integration.py
+++ b/apps/api/tests/test_langfuse_integration.py
@@ -33,12 +33,8 @@ def _stack_up() -> bool:
 
 
 def _emit_three_level_trace() -> str:
-    provider = TracerProvider(
-        resource=Resource.create({"service.name": "b1-integration"})
-    )
-    provider.add_span_processor(
-        SimpleSpanProcessor(OTLPSpanExporter(endpoint=COLLECTOR_ENDPOINT))
-    )
+    provider = TracerProvider(resource=Resource.create({"service.name": "b1-integration"}))
+    provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter(endpoint=COLLECTOR_ENDPOINT)))
     tracer = provider.get_tracer("b1-integration")
     with tracer.start_as_current_span("agent.run", kind=SpanKind.SERVER) as root:
         root.set_attribute("langfuse.trace.name", "b1-integration-demo")
@@ -72,9 +68,7 @@ def test_proxy_returns_reconstructed_tree_for_seeded_trace(
     body: dict[str, Any] | None = None
     with TestClient(create_app()) as client:
         while time.time() < deadline:
-            resp = client.get(
-                f"/langfuse/traces/{trace_id}", headers=auth_headers
-            )
+            resp = client.get(f"/langfuse/traces/{trace_id}", headers=auth_headers)
             if resp.status_code == 200 and _max_depth(resp.json()["tree"]) >= 3:
                 body = resp.json()
                 break

--- a/apps/api/tests/test_langfuse_paging.py
+++ b/apps/api/tests/test_langfuse_paging.py
@@ -30,9 +30,7 @@ class _RecordingBackend:
             {"id": str(i), "name": f"curie-run:agent-A-thread-{i}"}
             for i in range(start, min(start + limit, self._total))
         ]
-        return httpx.Response(
-            200, json={"data": data, "meta": {"totalPages": total_pages}}
-        )
+        return httpx.Response(200, json={"data": data, "meta": {"totalPages": total_pages}})
 
 
 def _client(backend: _RecordingBackend) -> LangfuseClient:

--- a/apps/api/tests/test_managed_pg_swap.py
+++ b/apps/api/tests/test_managed_pg_swap.py
@@ -110,15 +110,12 @@ def test_app_tables_are_schema_qualified(migrated: None) -> None:
     swap places the whole app footprint under `curie` on the managed target.
     """
 
-    public = _query(
-        "SELECT tablename FROM pg_tables WHERE schemaname = 'public'"
-    )
+    public = _query("SELECT tablename FROM pg_tables WHERE schemaname = 'public'")
     assert public == [], f"unexpected public tables: {public}"
 
     for table in _UUID_PK_TABLES:
         rows = _query(
-            "SELECT 1 FROM pg_tables WHERE schemaname = :schema "
-            "AND tablename = :table",
+            "SELECT 1 FROM pg_tables WHERE schemaname = :schema AND tablename = :table",
             schema=SCHEMA,
             table=table,
         )

--- a/apps/api/tests/test_memory.py
+++ b/apps/api/tests/test_memory.py
@@ -88,16 +88,12 @@ async def _remove_memory_update_gate() -> None:
             ON curie.workflow_state_entries
             """
         )
-        await connection.execute(
-            "DROP FUNCTION IF EXISTS curie.test_memory_update_gate()"
-        )
+        await connection.execute("DROP FUNCTION IF EXISTS curie.test_memory_update_gate()")
     finally:
         await connection.close()
 
 
-async def _wait_for_blocked_memory_requests(
-    minimum: int, requests: list[Future[Any]]
-) -> None:
+async def _wait_for_blocked_memory_requests(minimum: int, requests: list[Future[Any]]) -> None:
     connection = await asyncpg.connect(_asyncpg_dsn())
     try:
         deadline = time.monotonic() + 10
@@ -163,11 +159,7 @@ def _run_ordered_memory_requests(
             try:
                 asyncio.run(_wait_for_blocked_memory_requests(1, [first_request]))
                 second_request = executor.submit(second)
-                asyncio.run(
-                    _wait_for_blocked_memory_requests(
-                        2, [first_request, second_request]
-                    )
-                )
+                asyncio.run(_wait_for_blocked_memory_requests(2, [first_request, second_request]))
             finally:
                 release.set()
             first_response = first_request.result(timeout=10)
@@ -208,9 +200,7 @@ def test_list_memory_returns_entries_with_provenance(
             },
         },
     )
-    appended = _remember(
-        client, auth_headers, aid, {"content": "no-provenance lesson"}
-    )
+    appended = _remember(client, auth_headers, aid, {"content": "no-provenance lesson"})
 
     entries = _memory(client, auth_headers, aid)
     assert len(entries) == 2
@@ -396,9 +386,7 @@ def test_runner_append_makes_operator_edit_token_stale_without_losing_append(
     _remember(client, auth_headers, aid, {"content": "original lesson"})
     listed = _memory(client, auth_headers, aid)
 
-    appended = _remember(
-        client, auth_headers, aid, {"content": "runner learned another lesson"}
-    )
+    appended = _remember(client, auth_headers, aid, {"content": "runner learned another lesson"})
     response = client.put(
         f"/agents/{aid}/memory/0",
         json={
@@ -467,9 +455,7 @@ def test_oversized_edit_is_rejected_without_changing_memory(
         )
 
         assert response.status_code == 413, response.text
-        stored = client.get(
-            f"/agents/{aid}/state/memory/log", headers=auth_headers
-        ).json()
+        stored = client.get(f"/agents/{aid}/state/memory/log", headers=auth_headers).json()
         assert stored["version"] == seeded["version"]
         assert stored["value"] == seeded["value"]
     finally:

--- a/apps/api/tests/test_metrics_integration.py
+++ b/apps/api/tests/test_metrics_integration.py
@@ -33,9 +33,8 @@ pytestmark = pytest.mark.skipif(not _stack_up(), reason="dev stack not reachable
 
 def _lf_metric(query: dict[str, Any]) -> list[dict[str, Any]]:
     settings = get_settings()
-    url = (
-        f"{settings.langfuse_host}/api/public/metrics?query="
-        + urllib.parse.quote(json.dumps(query))
+    url = f"{settings.langfuse_host}/api/public/metrics?query=" + urllib.parse.quote(
+        json.dumps(query)
     )
     resp = httpx.get(
         url, auth=(settings.langfuse_public_key, settings.langfuse_secret_key), timeout=10
@@ -130,9 +129,7 @@ def _await_seeded_cost(name: str, start: str, end: str, floor: float) -> None:
     pytest.fail(f"seeded cost for {name!r} never became queryable in Langfuse")
 
 
-def test_summary_matches_langfuse_aggregates(
-    client: Any, auth_headers: dict[str, str]
-) -> None:
+def test_summary_matches_langfuse_aggregates(client: Any, auth_headers: dict[str, str]) -> None:
     # Seed our own cost-bearing workload so the assertions do not depend on
     # ambient data, then wait for Langfuse's async ingestion to reflect it.
     seed_name, seeded_cost = _seed_cost_bearing_trace()
@@ -193,9 +190,7 @@ def test_summary_matches_langfuse_aggregates(
     assert abs(body["cost_usd"] - float(cost[0]["sum_totalCost"])) < 1e-9
 
 
-def test_runs_series_sums_to_the_summary(
-    client: Any, auth_headers: dict[str, str]
-) -> None:
+def test_runs_series_sums_to_the_summary(client: Any, auth_headers: dict[str, str]) -> None:
     start, end = _window()
     summary = client.get(
         "/observability/metrics/summary",
@@ -213,9 +208,7 @@ def test_runs_series_sums_to_the_summary(
     assert sum(p["value"] for p in points) == summary["runs"]
 
 
-def test_environment_filter_passes_through(
-    client: Any, auth_headers: dict[str, str]
-) -> None:
+def test_environment_filter_passes_through(client: Any, auth_headers: dict[str, str]) -> None:
     start, end = _window()
     resp = client.get(
         "/observability/metrics/summary",
@@ -248,9 +241,7 @@ def test_metrics_require_api_key(client: Any) -> None:
     assert client.get("/observability/metrics/summary").status_code == 401
 
 
-def test_unknown_metric_is_422(
-    client: Any, auth_headers: dict[str, str]
-) -> None:
+def test_unknown_metric_is_422(client: Any, auth_headers: dict[str, str]) -> None:
     resp = client.get(
         "/observability/metrics/series",
         params={"metric": "bogus"},
@@ -259,9 +250,7 @@ def test_unknown_metric_is_422(
     assert resp.status_code == 422
 
 
-def test_malformed_date_is_422_not_500(
-    client: Any, auth_headers: dict[str, str]
-) -> None:
+def test_malformed_date_is_422_not_500(client: Any, auth_headers: dict[str, str]) -> None:
     resp = client.get(
         "/observability/metrics/summary",
         params={"start": "not-a-date"},

--- a/apps/api/tests/test_migrations.py
+++ b/apps/api/tests/test_migrations.py
@@ -31,9 +31,7 @@ def _column(sql: str) -> list[str]:
 
 
 def test_alembic_version_lives_in_app_schema(migrated: None) -> None:
-    schemas = _column(
-        "SELECT schemaname FROM pg_tables WHERE tablename = 'alembic_version'"
-    )
+    schemas = _column("SELECT schemaname FROM pg_tables WHERE tablename = 'alembic_version'")
     # Exactly one alembic_version, and it is in the curie schema (never public).
     assert schemas == [SCHEMA], schemas
 
@@ -41,7 +39,5 @@ def test_alembic_version_lives_in_app_schema(migrated: None) -> None:
 def test_public_schema_is_empty_after_migration(migrated: None) -> None:
     # The Langfuse Prisma baseline (P3005) refuses a non-empty public schema, so
     # our migrations must leave zero user tables there.
-    public_tables = _column(
-        "SELECT tablename FROM pg_tables WHERE schemaname = 'public'"
-    )
+    public_tables = _column("SELECT tablename FROM pg_tables WHERE schemaname = 'public'")
     assert public_tables == [], public_tables

--- a/apps/api/tests/test_openapi_drift.py
+++ b/apps/api/tests/test_openapi_drift.py
@@ -6,6 +6,5 @@ from curie_api.export_openapi import openapi_path, render_openapi
 def test_committed_openapi_is_current() -> None:
     committed = openapi_path().read_text(encoding="utf-8")
     assert render_openapi() == committed, (
-        "apps/api/openapi.json is stale; run "
-        "`uv run python -m curie_api.export_openapi` and commit"
+        "apps/api/openapi.json is stale; run `uv run python -m curie_api.export_openapi` and commit"
     )

--- a/apps/api/tests/test_resume_reconciler.py
+++ b/apps/api/tests/test_resume_reconciler.py
@@ -95,9 +95,7 @@ def _run_async[T](
     async def _main() -> T:
         engine = create_async_engine(get_settings().database_url)
         sessionmaker = async_sessionmaker(engine, expire_on_commit=False)
-        client = aioredis.Redis(
-            host=_VALKEY_HOST, port=_VALKEY_PORT, password=_VALKEY_PW or None
-        )
+        client = aioredis.Redis(host=_VALKEY_HOST, port=_VALKEY_PORT, password=_VALKEY_PW or None)
         queue = ResumeQueue(client, stream=stream)
         try:
             return await steps(sessionmaker, queue)
@@ -304,9 +302,7 @@ def test_resume_turn_selector_domain_matches_resumable_statuses() -> None:
     rejected = resume_turn_for(_detached_approval(ApprovalStatus.rejected))
     assert "[approval resolved]" in rejected.text
 
-    expired = resume_turn_for(
-        _detached_approval(ApprovalStatus.expired, resolved_by=None)
-    )
+    expired = resume_turn_for(_detached_approval(ApprovalStatus.expired, resolved_by=None))
     assert "[approval expired]" in expired.text
     assert expired.author == "system"
 
@@ -324,9 +320,7 @@ def test_reconciler_skips_pending_record(
 ) -> None:
     """A still-pending record (no ``resolved_at``) is never on the work-list."""
 
-    async def steps(
-        sessionmaker: async_sessionmaker[AsyncSession], queue: ResumeQueue
-    ) -> int:
+    async def steps(sessionmaker: async_sessionmaker[AsyncSession], queue: ResumeQueue) -> int:
         await _insert_approval(
             sessionmaker,
             status=ApprovalStatus.pending,
@@ -366,9 +360,7 @@ def test_reconciler_ignores_backfilled_historical_row(
     database.
     """
 
-    async def steps(
-        sessionmaker: async_sessionmaker[AsyncSession], queue: ResumeQueue
-    ) -> int:
+    async def steps(sessionmaker: async_sessionmaker[AsyncSession], queue: ResumeQueue) -> int:
         resolved = _naive(7200)
         await _insert_approval(
             sessionmaker,
@@ -427,9 +419,7 @@ def test_reconciler_grace_applies_to_expired_rows(
         # Backdate the expiry well past the grace horizon.
         async with sessionmaker() as session:
             await session.execute(
-                update(Approval)
-                .where(Approval.id == approval_id)
-                .values(resolved_at=_naive(7200))
+                update(Approval).where(Approval.id == approval_id).values(resolved_at=_naive(7200))
             )
             await session.commit()
 
@@ -474,9 +464,7 @@ def test_reconciler_respects_grace_window(
         # Backdate the resolution well past the grace horizon.
         async with sessionmaker() as session:
             await session.execute(
-                update(Approval)
-                .where(Approval.id == approval_id)
-                .values(resolved_at=_naive(7200))
+                update(Approval).where(Approval.id == approval_id).values(resolved_at=_naive(7200))
             )
             await session.commit()
 
@@ -611,9 +599,7 @@ def test_reconciler_skips_row_locked_by_concurrent_claim(
         sessionmaker = async_sessionmaker(engine, expire_on_commit=False)
         lock_engine = create_async_engine(get_settings().database_url)
         lock_sessionmaker = async_sessionmaker(lock_engine, expire_on_commit=False)
-        client = aioredis.Redis(
-            host=_VALKEY_HOST, port=_VALKEY_PORT, password=_VALKEY_PW or None
-        )
+        client = aioredis.Redis(host=_VALKEY_HOST, port=_VALKEY_PORT, password=_VALKEY_PW or None)
         queue = ResumeQueue(client, stream=runs_stream)
         try:
             approval_id = await _insert_approval(
@@ -633,9 +619,7 @@ def test_reconciler_skips_row_locked_by_concurrent_claim(
             # A concurrent replica holds the row under FOR UPDATE, uncommitted.
             async with lock_sessionmaker() as holder:
                 await holder.execute(
-                    select(Approval)
-                    .where(Approval.id == approval_id)
-                    .with_for_update()
+                    select(Approval).where(Approval.id == approval_id).with_for_update()
                 )
                 # This pass must skip the locked row (0, nothing enqueued).
                 try:
@@ -766,9 +750,7 @@ def test_reopen_dead_lettered_resume_reenqueues_owed_wake(
     assert gap_resumed is not None
 
     # A graveyard row dead-lettered AFTER the wake was marked delivered.
-    _seed_graveyard_row(
-        valkey, runs_stream, approval_id, dead_lettered_at=_dl_iso(0)
-    )
+    _seed_graveyard_row(valkey, runs_stream, approval_id, dead_lettered_at=_dl_iso(0))
 
     async def reopen_then_reconcile(
         sessionmaker: async_sessionmaker[AsyncSession], queue: ResumeQueue
@@ -828,9 +810,7 @@ def test_reopen_is_idempotent_against_persistent_graveyard_row(
 
     # Dead-lettered between the original wake (30m ago) and now, so the FIRST
     # reopen matches; the re-enqueue then re-marks resumed_at to now (> this).
-    _seed_graveyard_row(
-        valkey, runs_stream, approval_id, dead_lettered_at=_dl_iso(1500)
-    )
+    _seed_graveyard_row(valkey, runs_stream, approval_id, dead_lettered_at=_dl_iso(1500))
 
     async def reopen_reconcile_reopen(
         sessionmaker: async_sessionmaker[AsyncSession], queue: ResumeQueue
@@ -889,9 +869,7 @@ def test_reopen_ignores_stale_graveyard_row(
         )
 
     approval_id = _run_async(insert, runs_stream)
-    _seed_graveyard_row(
-        valkey, runs_stream, approval_id, dead_lettered_at=_dl_iso(3600)
-    )
+    _seed_graveyard_row(valkey, runs_stream, approval_id, dead_lettered_at=_dl_iso(3600))
 
     async def reopen(
         sessionmaker: async_sessionmaker[AsyncSession], queue: ResumeQueue

--- a/apps/api/tests/test_runner_logs.py
+++ b/apps/api/tests/test_runner_logs.py
@@ -73,9 +73,7 @@ class FakeLister:
     decide whether the pod is a genuine runner pod.
     """
 
-    def __init__(
-        self, pods: list[str], *, raises: Exception | None = None
-    ) -> None:
+    def __init__(self, pods: list[str], *, raises: Exception | None = None) -> None:
         self._pods = pods
         self._raises = raises
         self.calls: list[tuple[str, str]] = []

--- a/apps/api/tests/test_runner_pods.py
+++ b/apps/api/tests/test_runner_pods.py
@@ -49,9 +49,7 @@ def test_lists_runner_pods_with_the_default_namespace_and_selector(
     body = resp.json()
     assert body["namespace"] == "curie"  # settings default
     # The lister was called with the release namespace + runner-sandbox selector.
-    assert body["pods"][0] == (
-        "curie:app.kubernetes.io/component=runner-sandbox:runner-a"
-    )
+    assert body["pods"][0] == ("curie:app.kubernetes.io/component=runner-sandbox:runner-a")
     assert "runner-b" in body["pods"]
 
 

--- a/apps/api/tests/test_sandbox_token.py
+++ b/apps/api/tests/test_sandbox_token.py
@@ -34,9 +34,7 @@ def _sign(api_key: str, payload_obj: object) -> str:
     module produces this byte sequence, and can forge validly-signed tokens with
     arbitrary (even malformed) payloads to probe verify's claim checks.
     """
-    payload_json = json.dumps(
-        payload_obj, separators=(",", ":"), sort_keys=True
-    ).encode()
+    payload_json = json.dumps(payload_obj, separators=(",", ":"), sort_keys=True).encode()
     payload_seg = base64.urlsafe_b64encode(payload_json).rstrip(b"=").decode()
     signing_input = f"sbx.{payload_seg}"
     sig = hmac.new(api_key.encode(), signing_input.encode(), hashlib.sha256).digest()
@@ -144,7 +142,5 @@ def test_the_two_module_copies_are_byte_identical() -> None:
     # this test file (parents[3] is the worktree root) rather than hardcoding.
     root = Path(__file__).resolve().parents[3]
     api_src = root / "apps" / "api" / "src" / "curie_api" / "sandbox_token.py"
-    worker_src = (
-        root / "apps" / "worker" / "src" / "curie_worker" / "sandbox_token.py"
-    )
+    worker_src = root / "apps" / "worker" / "src" / "curie_worker" / "sandbox_token.py"
     assert api_src.read_bytes() == worker_src.read_bytes()

--- a/apps/api/tests/test_slack_usergroups.py
+++ b/apps/api/tests/test_slack_usergroups.py
@@ -295,9 +295,7 @@ def test_concurrent_lookups_of_distinct_groups_do_not_serialize() -> None:
             return httpx.Response(200, json={"ok": True, "users": by_group[group]})
 
         client = _async_client(_handler, calls=calls, ttl_s=60.0)
-        return await asyncio.gather(
-            client.members(_GROUP), client.members(_OTHER_GROUP)
-        )
+        return await asyncio.gather(client.members(_GROUP), client.members(_OTHER_GROUP))
 
     managers, legal = asyncio.run(_main())
 

--- a/apps/api/tests/test_state.py
+++ b/apps/api/tests/test_state.py
@@ -141,9 +141,7 @@ def test_app_scoped_token_is_refused_on_reserved_namespaces(
     headers = {"X-API-Key": app}
 
     for ns in ("memory", "transcript"):
-        put = client.put(
-            f"/agents/{aid}/state/{ns}/k", json={"value": {"n": 1}}, headers=headers
-        )
+        put = client.put(f"/agents/{aid}/state/{ns}/k", json={"value": {"n": 1}}, headers=headers)
         assert put.status_code == 403, f"{ns}: {put.text}"
         assert "reserved" in put.text
         # Every verb over a reserved namespace is refused, not just writes.
@@ -182,8 +180,7 @@ def test_namespace_enumeration_hides_reserved_from_the_app_token(
     assert app_names == {"workflow"}, app_names
 
     platform_names = {
-        row["namespace"]
-        for row in client.get(f"/agents/{aid}/state", headers=auth_headers).json()
+        row["namespace"] for row in client.get(f"/agents/{aid}/state", headers=auth_headers).json()
     }
     assert platform_names == {"memory", "transcript", "workflow"}, platform_names
 
@@ -214,9 +211,7 @@ def test_broad_state_token_and_platform_key_reach_reserved_namespaces(
 
     for headers in ({"X-API-Key": broad}, auth_headers):
         for ns in ("memory", "transcript"):
-            r = client.put(
-                f"/agents/{aid}/state/{ns}/k", json={"value": {"n": 1}}, headers=headers
-            )
+            r = client.put(f"/agents/{aid}/state/{ns}/k", json={"value": {"n": 1}}, headers=headers)
             assert r.status_code == 200, f"{ns}: {r.text}"
 
 
@@ -227,9 +222,7 @@ def test_put_get_list_delete_round_trip(
     base = f"/agents/{aid}/state/approvals"
 
     # put (create) -> version 1
-    r = client.put(
-        f"{base}/thread-1", json={"value": {"status": "pending"}}, headers=auth_headers
-    )
+    r = client.put(f"{base}/thread-1", json={"value": {"status": "pending"}}, headers=auth_headers)
     assert r.status_code == 200, r.text
     assert r.json()["value"] == {"status": "pending"}
     assert r.json()["version"] == 1
@@ -246,9 +239,7 @@ def test_put_get_list_delete_round_trip(
     assert r2.json()["version"] == 2
 
     # list by namespace returns both keys
-    client.put(
-        f"{base}/thread-2", json={"value": {"status": "pending"}}, headers=auth_headers
-    )
+    client.put(f"{base}/thread-2", json={"value": {"status": "pending"}}, headers=auth_headers)
     listed = client.get(base, headers=auth_headers).json()
     assert {e["key"] for e in listed} == {"thread-1", "thread-2"}
 
@@ -268,16 +259,12 @@ def test_compare_and_set_rejects_a_stale_version(
     assert v1["version"] == 1
 
     # CAS with the current version succeeds and bumps to 2.
-    ok = client.put(
-        url, json={"value": {"n": 2}, "expected_version": 1}, headers=auth_headers
-    )
+    ok = client.put(url, json={"value": {"n": 2}, "expected_version": 1}, headers=auth_headers)
     assert ok.status_code == 200
     assert ok.json()["version"] == 2
 
     # CAS with the now-stale version 1 is rejected, and the value is unchanged.
-    stale = client.put(
-        url, json={"value": {"n": 3}, "expected_version": 1}, headers=auth_headers
-    )
+    stale = client.put(url, json={"value": {"n": 3}, "expected_version": 1}, headers=auth_headers)
     assert stale.status_code == 409, stale.text
     assert client.get(url, headers=auth_headers).json()["value"] == {"n": 2}
 
@@ -286,9 +273,7 @@ def test_put_unknown_agent_is_404(
     client: Any, auth_headers: dict[str, str], clean_db: None
 ) -> None:
     missing = "00000000-0000-0000-0000-000000000000"
-    r = client.put(
-        f"/agents/{missing}/state/ns/k", json={"value": {}}, headers=auth_headers
-    )
+    r = client.put(f"/agents/{missing}/state/ns/k", json={"value": {}}, headers=auth_headers)
     assert r.status_code == 404
 
 

--- a/apps/api/tests/test_webhook_body_bound.py
+++ b/apps/api/tests/test_webhook_body_bound.py
@@ -33,9 +33,7 @@ def client(monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
     monkeypatch.setattr(
         github_router,
         "get_settings",
-        lambda: Settings(
-            github_webhook_secret=SECRET, github_webhook_max_body_bytes=MAX
-        ),
+        lambda: Settings(github_webhook_secret=SECRET, github_webhook_max_body_bytes=MAX),
     )
 
     async def _fake_push(*_args: Any, **_kwargs: Any) -> WebhookResult:

--- a/cli/api-mirrors.json
+++ b/cli/api-mirrors.json
@@ -12,10 +12,22 @@
       "struct": "Agent",
       "schema": "AgentOut",
       "omissions": [
-        { "field": "behavior_packs", "why": "No CLI path reads an agent's behavior-pack list; deploy uploads a bundle rather than composing packs, so behavior_packs is never consumed." },
-        { "field": "model", "why": "The CLI never displays or acts on an agent's default model (model routing is server- and claim-time bound, #473); the deploy and lifecycle verbs read only id/name/slack_channel." },
-        { "field": "secrets", "why": "update_agent_secrets WRITES connector-secret names; the CLI never reads the stored secrets list back, so the response field is not modeled." },
-        { "field": "created_at", "why": "No CLI verb prints an agent's creation timestamp; the deploy summary and lifecycle verbs render id/name/slack_channel only." }
+        {
+          "field": "behavior_packs",
+          "why": "No CLI path reads an agent's behavior-pack list; deploy uploads a bundle rather than composing packs, so behavior_packs is never consumed."
+        },
+        {
+          "field": "model",
+          "why": "The CLI never displays or acts on an agent's default model (model routing is server- and claim-time bound, #473); the deploy and lifecycle verbs read only id/name/slack_channel."
+        },
+        {
+          "field": "secrets",
+          "why": "update_agent_secrets WRITES connector-secret names; the CLI never reads the stored secrets list back, so the response field is not modeled."
+        },
+        {
+          "field": "created_at",
+          "why": "No CLI verb prints an agent's creation timestamp; the deploy summary and lifecycle verbs render id/name/slack_channel only."
+        }
       ]
     },
     {
@@ -32,37 +44,76 @@
       "struct": "ApprovalRecord",
       "schema": "ApprovalOut",
       "omissions": [
-        { "field": "agent_id", "why": "The approvals verbs (commands::approvals) already scope the query by --agent, so the record's echoed agent_id is redundant to what the caller passed and is not rendered." },
-        { "field": "reply_channel", "why": "Slack reply-routing (reply_channel) is consumed by the worker to post the approval card, not by the CLI, which renders the record for a human operator." },
-        { "field": "reply_placeholder", "why": "The card placeholder text is a worker/Slack rendering detail; the approvals listing shows summary/gate, not the card body." },
-        { "field": "reply_endpoint", "why": "The reply callback endpoint routes a Slack action back to the API; the CLI resolve path posts to /approvals/{id}/resolve directly and never reads it." },
-        { "field": "dedupe_key", "why": "The idempotency key is a server-side dedupe concern; the CLI neither displays it nor resubmits on it." },
-        { "field": "card_channel", "why": "Where the approval card was posted is a Slack-delivery detail; the operator-facing listing renders conversation_id/summary, not the card channel." },
-        { "field": "resolution_note", "why": "resolve_approval SENDS a note via --note; it does not read back the stored resolution_note when listing pending approvals." },
-        { "field": "created_at", "why": "The listing shows expires_at (the actionable deadline), not the creation timestamp, which the operator does not act on." },
-        { "field": "resolved_at", "why": "list_pending_approvals filters to status=pending, which by definition carry no resolution timestamp, so resolved_at is never populated on the records the CLI renders." }
+        {
+          "field": "agent_id",
+          "why": "The approvals verbs (commands::approvals) already scope the query by --agent, so the record's echoed agent_id is redundant to what the caller passed and is not rendered."
+        },
+        {
+          "field": "reply_channel",
+          "why": "Slack reply-routing (reply_channel) is consumed by the worker to post the approval card, not by the CLI, which renders the record for a human operator."
+        },
+        {
+          "field": "reply_placeholder",
+          "why": "The card placeholder text is a worker/Slack rendering detail; the approvals listing shows summary/gate, not the card body."
+        },
+        {
+          "field": "reply_endpoint",
+          "why": "The reply callback endpoint routes a Slack action back to the API; the CLI resolve path posts to /approvals/{id}/resolve directly and never reads it."
+        },
+        {
+          "field": "dedupe_key",
+          "why": "The idempotency key is a server-side dedupe concern; the CLI neither displays it nor resubmits on it."
+        },
+        {
+          "field": "card_channel",
+          "why": "Where the approval card was posted is a Slack-delivery detail; the operator-facing listing renders conversation_id/summary, not the card channel."
+        },
+        {
+          "field": "resolution_note",
+          "why": "resolve_approval SENDS a note via --note; it does not read back the stored resolution_note when listing pending approvals."
+        },
+        {
+          "field": "created_at",
+          "why": "The listing shows expires_at (the actionable deadline), not the creation timestamp, which the operator does not act on."
+        },
+        {
+          "field": "resolved_at",
+          "why": "list_pending_approvals filters to status=pending, which by definition carry no resolution timestamp, so resolved_at is never populated on the records the CLI renders."
+        }
       ]
     },
     {
       "struct": "MemoryEntry",
       "schema": "MemoryEntryOut",
       "omissions": [
-        { "field": "provenance", "why": "The memory list verb renders index/content/version; provenance is a nested MemoryProvenanceOut $ref with no CLI mirror, and carrying it would require a second struct out of this gate's scope." }
+        {
+          "field": "provenance",
+          "why": "The memory list verb renders index/content/version; provenance is a nested MemoryProvenanceOut $ref with no CLI mirror, and carrying it would require a second struct out of this gate's scope."
+        }
       ]
     },
     {
       "struct": "Bundle",
       "schema": "BundleOut",
       "omissions": [
-        { "field": "version_id", "why": "upload_bundle returns the bundle to the deploy summary, which already holds the Version it just created (ApiClient::deploy), so the bundle's echoed version_id is redundant." }
+        {
+          "field": "version_id",
+          "why": "upload_bundle returns the bundle to the deploy summary, which already holds the Version it just created (ApiClient::deploy), so the bundle's echoed version_id is redundant."
+        }
       ]
     },
     {
       "struct": "Deployment",
       "schema": "DeploymentOut",
       "omissions": [
-        { "field": "agent_id", "why": "list_deployments/create_deployment are already agent-scoped by the caller, so the record's echoed agent_id adds nothing the deploy summary or approvals-gate read uses." },
-        { "field": "commit_sha", "why": "The deploy summary and the approvals gate read resolve the in-force version via version_id; the deployment's commit_sha is not read. Follow-up parity candidate (same family as #548), flagged in the PR body, not added here." }
+        {
+          "field": "agent_id",
+          "why": "list_deployments/create_deployment are already agent-scoped by the caller, so the record's echoed agent_id adds nothing the deploy summary or approvals-gate read uses."
+        },
+        {
+          "field": "commit_sha",
+          "why": "The deploy summary and the approvals gate read resolve the in-force version via version_id; the deployment's commit_sha is not read. Follow-up parity candidate (same family as #548), flagged in the PR body, not added here."
+        }
       ]
     },
     {
@@ -94,9 +145,18 @@
       "struct": "EvalTriggerResult",
       "schema": "EvalTriggerResult",
       "omissions": [
-        { "field": "agent_id", "why": "trigger_eval is called with the agent the caller chose; the sweep pairs the enqueued job to its matrix row by stream_id/sha, so the echoed agent_id is unused." },
-        { "field": "version_id", "why": "The sweep scopes readiness by the run's sha column on the matrix, not by version_id; the trigger's version_id is never read." },
-        { "field": "bundle_ref", "why": "The artifact pointer is surfaced on the version/bundle path, not off the eval trigger; the sweep reads only stream_id/sha/suite/model here." }
+        {
+          "field": "agent_id",
+          "why": "trigger_eval is called with the agent the caller chose; the sweep pairs the enqueued job to its matrix row by stream_id/sha, so the echoed agent_id is unused."
+        },
+        {
+          "field": "version_id",
+          "why": "The sweep scopes readiness by the run's sha column on the matrix, not by version_id; the trigger's version_id is never read."
+        },
+        {
+          "field": "bundle_ref",
+          "why": "The artifact pointer is surfaced on the version/bundle path, not off the eval trigger; the sweep reads only stream_id/sha/suite/model here."
+        }
       ]
     },
     {
@@ -108,11 +168,28 @@
       "struct": "EvalMatrix",
       "schema": "EvalMatrix",
       "omissions": [
-        { "field": "cases", "why": "The sweep reads the per-(version, model) rollup (model_version_summaries) and the version columns (versions); the per-case identifiers (cases) that label the grid are not read by the CLI." },
-        { "field": "rows", "why": "The per-case pass/fail grid (rows) is carried by the endpoint but unused by the sweep, which needs only the per-model rollup; the existing doc comment on EvalMatrix already states this." },
-        { "field": "models", "why": "The model dimension the CLI acts on is model_version_summaries[].model; the separate models label list is not read." },
-        { "field": "model_summaries", "why": "The window-blended per-model rollup sums completed across every in-window sha, which masks a triggered sha's zero-completed outcome (#814); the sweep reads the per-(version, model) model_version_summaries scoped to the triggered sha instead, so the blended rollup is not consumed by the CLI." }
+        {
+          "field": "cases",
+          "why": "The sweep reads the per-(version, model) rollup (model_version_summaries) and the version columns (versions); the per-case identifiers (cases) that label the grid are not read by the CLI."
+        },
+        {
+          "field": "rows",
+          "why": "The per-case pass/fail grid (rows) is carried by the endpoint but unused by the sweep, which needs only the per-model rollup; the existing doc comment on EvalMatrix already states this."
+        },
+        {
+          "field": "models",
+          "why": "The model dimension the CLI acts on is model_version_summaries[].model; the separate models label list is not read."
+        },
+        {
+          "field": "model_summaries",
+          "why": "The window-blended per-model rollup sums completed across every in-window sha, which masks a triggered sha's zero-completed outcome (#814); the sweep reads the per-(version, model) model_version_summaries scoped to the triggered sha instead, so the blended rollup is not consumed by the CLI."
+        }
       ]
+    },
+    {
+      "struct": "ConnectorManifests",
+      "schema": "ConnectorManifests",
+      "omissions": []
     }
   ],
   "non_mirrors": [],
@@ -122,14 +199,20 @@
       "output": "VersionsOutput",
       "struct": "Version",
       "omissions": [
-        { "field": "agent_id", "why": "agent_id is carried on the struct for struct-level parity (#691) but deliberately not emitted by `versions --json`: the payload already carries `agent` (the query was agent-scoped), so echoing agent_id per version is redundant. Pinned by json_emit_contract.rs's versions_output_json_shape_is_pinned." }
+        {
+          "field": "agent_id",
+          "why": "agent_id is carried on the struct for struct-level parity (#691) but deliberately not emitted by `versions --json`: the payload already carries `agent` (the query was agent-scoped), so echoing agent_id per version is redundant. Pinned by json_emit_contract.rs's versions_output_json_shape_is_pinned."
+        }
       ]
     },
     {
       "output": "MemoryOutput",
       "struct": "MemoryEntry",
       "omissions": [
-        { "field": "version", "why": "The memory listing is read-only in the CLI today -- no verb performs a versioned mutation against a memory entry, so the log's optimistic-concurrency version (MemoryEntryOut.version) is not surfaced yet. Pinned by json_emit_contract.rs's memory_output_json_shape_is_pinned, which notes surfacing it later is a contract decision, not an oversight." }
+        {
+          "field": "version",
+          "why": "The memory listing is read-only in the CLI today -- no verb performs a versioned mutation against a memory entry, so the log's optimistic-concurrency version (MemoryEntryOut.version) is not surfaced yet. Pinned by json_emit_contract.rs's memory_output_json_shape_is_pinned, which notes surfacing it later is a contract decision, not an oversight."
+        }
       ]
     },
     {

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -21,6 +21,19 @@ pub struct ApiClient {
 /// so this is a valid Slack channel-ID shape, not a `#name`.
 pub const DEFAULT_SLACK_CHANNEL: &str = "C0LOCALDEV";
 
+/// Kubernetes objects the API derived from a version's `connectors.yaml`.
+///
+/// The API renders these; the CLI applies them. Rendering is a pure function so
+/// the API needs no cluster access for it, and cluster-write authority stays
+/// with the operator running this command (ADR-0086, #1063).
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct ConnectorManifests {
+    #[serde(default)]
+    pub manifests: Vec<serde_json::Value>,
+    #[serde(default)]
+    pub mcp_entries: std::collections::BTreeMap<String, serde_json::Value>,
+}
+
 #[derive(Debug, Clone, Deserialize)]
 pub struct Agent {
     pub id: String,
@@ -751,6 +764,41 @@ impl ApiClient {
     /// List an agent's immutable versions, ascending by `created_at` (oldest
     /// first): `GET /agents/{id}/versions`. `commands::versions` reverses
     /// this to newest-first before display/JSON output.
+    /// Ask the API to render a version's declared connectors.
+    ///
+    /// `release`/`namespace`/`app_name` are install-time facts the API does not
+    /// know -- they live with whoever ran `cluster up` -- so the caller supplies
+    /// them and the API stays a pure function.
+    pub async fn version_connectors(
+        &self,
+        agent_id: &str,
+        version_id: &str,
+        release: &str,
+        namespace: &str,
+        app_name: &str,
+    ) -> Result<ConnectorManifests> {
+        let resp = self
+            .http
+            .get(format!(
+                "{}/agents/{agent_id}/versions/{version_id}/connectors",
+                self.base_url
+            ))
+            .query(&[
+                ("release", release),
+                ("namespace", namespace),
+                ("app_name", app_name),
+            ])
+            .header("X-API-Key", &self.api_key)
+            .send()
+            .await
+            .context("GET /agents/{id}/versions/{vid}/connectors")?;
+        Self::expect_ok(resp, "rendering declared connectors")
+            .await?
+            .json()
+            .await
+            .context("decoding connector manifests")
+    }
+
     pub async fn list_versions(&self, agent_id: &str) -> Result<Vec<Version>> {
         let resp = self
             .http

--- a/cli/src/connectors.rs
+++ b/cli/src/connectors.rs
@@ -1,0 +1,197 @@
+//! Apply the connector objects the API rendered, and prune what is no longer
+//! declared (ADR-0086, #1063).
+//!
+//! The API computes these manifests; this applies them. That split is
+//! deliberate: rendering is a pure function, so the API needs no cluster access
+//! and keeps its deliberately read-only RBAC even though it is the service that
+//! receives internet webhooks. Applying happens here, under the operator's own
+//! kubectl credentials -- where cluster-write authority already lived.
+//!
+//! Pruning is the reason this is not a bare `kubectl apply`. Every object
+//! carries a label naming the agent that declared it, so removing a connector
+//! from `connectors.yaml` removes its Deployment, Service, and NetworkPolicy on
+//! the next deploy. Without that, a deleted connector leaves a pod running with
+//! a credential mounted and nothing referencing it -- the kind of leak nobody
+//! notices because nothing breaks.
+
+use anyhow::{Context, Result};
+use serde_json::Value;
+
+/// Marks every object this command owns, so pruning can find them again.
+pub const OWNER_LABEL: &str = "curie.dev/connector-owner";
+
+/// The label value for an agent's connector objects.
+pub fn owner_value(agent_name: &str) -> String {
+    agent_name.to_string()
+}
+
+/// Stamp the owner label onto each rendered object.
+///
+/// Applied here rather than in the renderer because ownership is a property of
+/// *this deploy*, not of the declaration -- the same bundle deployed as two
+/// agents must not have one prune the other's objects.
+pub fn label_objects(manifests: &[Value], agent_name: &str) -> Vec<Value> {
+    manifests
+        .iter()
+        .cloned()
+        .map(|mut obj| {
+            if let Some(meta) = obj.get_mut("metadata").and_then(|m| m.as_object_mut()) {
+                let labels = meta
+                    .entry("labels")
+                    .or_insert_with(|| Value::Object(Default::default()));
+                if let Some(map) = labels.as_object_mut() {
+                    map.insert(
+                        OWNER_LABEL.to_string(),
+                        Value::String(owner_value(agent_name)),
+                    );
+                }
+            }
+            obj
+        })
+        .collect()
+}
+
+/// `kubectl apply` argv for a JSON document supplied on stdin.
+///
+/// kubectl accepts JSON wherever it accepts YAML, so the manifests travel from
+/// the API as JSON and never need a YAML serializer on this side.
+pub fn apply_args(namespace: &str) -> Vec<String> {
+    vec![
+        "kubectl".into(),
+        "-n".into(),
+        namespace.into(),
+        "apply".into(),
+        "-f".into(),
+        "-".into(),
+    ]
+}
+
+/// `kubectl delete` argv for owned objects of `kind` that are no longer declared.
+///
+/// Scoped by the owner label AND by name, so it can only ever remove objects
+/// this command created for this agent. A prune that selected on the label
+/// alone would delete a concurrently-deploying agent's objects.
+pub fn prune_args(namespace: &str, agent_name: &str, keep: &[String]) -> Vec<String> {
+    let mut args: Vec<String> = vec![
+        "kubectl".into(),
+        "-n".into(),
+        namespace.into(),
+        "delete".into(),
+        "deployment,service,networkpolicy".into(),
+        "-l".into(),
+        format!("{}={}", OWNER_LABEL, owner_value(agent_name)),
+        "--ignore-not-found".into(),
+    ];
+    // `kubectl delete -l` has no "except these" flag, so exclusion rides as a
+    // field selector on name. It MUST be one comma-separated flag: kubectl
+    // takes the last --field-selector and silently discards earlier ones, so
+    // repeating the flag would exclude only the final object and delete the
+    // rest -- pruning away the connectors just applied.
+    if !keep.is_empty() {
+        let excluded: Vec<String> = keep.iter().map(|n| format!("metadata.name!={n}")).collect();
+        args.push(format!("--field-selector={}", excluded.join(",")));
+    }
+    args
+}
+
+/// Object names in a rendered set, used to build the prune exclusion.
+pub fn object_names(manifests: &[Value]) -> Vec<String> {
+    manifests
+        .iter()
+        .filter_map(|o| {
+            o.get("metadata")
+                .and_then(|m| m.get("name"))
+                .and_then(|n| n.as_str())
+                .map(str::to_string)
+        })
+        .collect()
+}
+
+/// Serialize a manifest list as a single JSON `List` for one apply invocation.
+pub fn as_list_document(manifests: &[Value]) -> Result<String> {
+    let doc = serde_json::json!({
+        "apiVersion": "v1",
+        "kind": "List",
+        "items": manifests,
+    });
+    serde_json::to_string(&doc).context("serializing connector manifests")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn objs() -> Vec<Value> {
+        vec![
+            json!({"apiVersion":"v1","kind":"Service","metadata":{"name":"r-mcp-g"}}),
+            json!({"apiVersion":"apps/v1","kind":"Deployment",
+                   "metadata":{"name":"r-mcp-g","labels":{"existing":"kept"}}}),
+        ]
+    }
+
+    #[test]
+    fn owner_label_is_stamped_without_dropping_existing_labels() {
+        let out = label_objects(&objs(), "sre-bot");
+        let dep = &out[1]["metadata"]["labels"];
+        assert_eq!(dep[OWNER_LABEL], "sre-bot");
+        assert_eq!(dep["existing"], "kept", "renderer labels must survive");
+    }
+
+    #[test]
+    fn objects_with_no_labels_map_still_get_the_owner() {
+        let out = label_objects(&objs(), "sre-bot");
+        assert_eq!(out[0]["metadata"]["labels"][OWNER_LABEL], "sre-bot");
+    }
+
+    #[test]
+    fn prune_is_scoped_to_this_agent_not_all_connectors() {
+        // Selecting on the label alone would delete a concurrently-deploying
+        // agent's objects -- both are "connector objects".
+        let args = prune_args("ns", "sre-bot", &[]);
+        assert!(args.contains(&format!("{OWNER_LABEL}=sre-bot")));
+        assert!(!args.iter().any(|a| a == OWNER_LABEL));
+    }
+
+    #[test]
+    fn prune_excludes_every_applied_object_in_one_flag() {
+        // kubectl keeps only the LAST --field-selector and silently drops the
+        // rest, so repeating the flag would exclude one object and prune the
+        // others -- deleting the connectors this deploy just applied.
+        let keep = vec!["a".to_string(), "b".to_string()];
+        let args = prune_args("ns", "sre-bot", &keep);
+        let selectors: Vec<&String> = args
+            .iter()
+            .filter(|a| a.starts_with("--field-selector"))
+            .collect();
+        assert_eq!(selectors.len(), 1, "must be a single flag: {args:?}");
+        assert_eq!(
+            selectors[0],
+            "--field-selector=metadata.name!=a,metadata.name!=b"
+        );
+    }
+
+    #[test]
+    fn prune_with_nothing_declared_removes_everything_owned() {
+        // The connector was deleted from connectors.yaml: its Deployment,
+        // Service, and NetworkPolicy must go, or a pod keeps running with a
+        // credential mounted and nothing referencing it.
+        let args = prune_args("ns", "sre-bot", &[]);
+        assert!(!args.iter().any(|a| a.starts_with("--field-selector")));
+        assert!(args.contains(&"deployment,service,networkpolicy".to_string()));
+    }
+
+    #[test]
+    fn manifests_serialize_as_one_list_document() {
+        let doc = as_list_document(&objs()).unwrap();
+        let parsed: Value = serde_json::from_str(&doc).unwrap();
+        assert_eq!(parsed["kind"], "List");
+        assert_eq!(parsed["items"].as_array().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn apply_reads_from_stdin_so_nothing_touches_disk() {
+        let args = apply_args("ns");
+        assert_eq!(args.last().unwrap(), "-");
+    }
+}

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -11,6 +11,7 @@ pub mod channel;
 pub mod chat;
 pub mod commands;
 pub mod comms;
+pub mod connectors;
 pub mod discover;
 pub mod docker;
 pub mod eval_init;


### PR DESCRIPTION
Fourth piece of ADR-0086. Refs #1063. Stacked on #1113 — merge that first.

Makes the render/apply split concrete.

## API: renders, never applies

New read-only `GET /agents/{id}/versions/{vid}/connectors` returns the derived objects plus the `.mcp.json` entries.

`release`, `namespace`, and `app_name` are **query params** because they're install-time facts the API doesn't know — the Helm release name and `nameOverride` live with whoever ran `cluster up`, not in the bundle. That keeps the API a pure function and its RBAC untouched.

## CLI: applies, with pruning

`cli/src/connectors.rs` stamps an owner label, applies the set as one JSON `List` on stdin (kubectl takes JSON wherever it takes YAML — no YAML crate needed), and prunes owned objects no longer declared.

**Pruning is why this isn't a bare `kubectl apply`.** Delete a connector from `connectors.yaml` and without it the Deployment keeps running with a credential mounted and nothing referencing it — a leak nobody notices because nothing breaks.

## Two silent bugs caught writing the prune

**1. Label-only selection would delete another agent's objects.** They're all "connector objects", so a concurrent deploy would prune its neighbour. Scoped to the agent.

**2. `kubectl` keeps only the last `--field-selector`** and silently discards earlier ones. Repeating the flag per kept object would exclude one and prune the rest — deleting exactly what the deploy just applied. Now one comma-separated flag, with a test asserting there's exactly one.

Both would have passed a casual review and failed in production.

## Gates

`ConnectorManifests` is declared in `api-mirrors.json` with no omissions. The field-parity gate flagged it undeclared on the first run — working as designed.

## Verification

```
cargo test               → 37 suites, 0 failures
cargo clippy -D warnings → clean (fixed one useless-format lint)
cargo fmt --check        → clean
uv run pytest …          → 370 passed
openapi regenerated      → drift test passes
```

## Scope

**Not yet wired into `cluster deploy`.** That's the next change — this lands as reviewable plumbing rather than a half-connected command.
