### PR TITLE
Scope connector object names to the agent, not the release (#1116)

### DIFF
--- a/apps/api/src/curie_api/bundles.py
+++ b/apps/api/src/curie_api/bundles.py
@@ -117,6 +117,7 @@ def render_connector_manifests(
     connectors: ConnectorsFile,
     *,
     release: str,
+    agent: str,
     namespace: str,
     app_name: str,
     secret_name: str,
@@ -134,13 +135,13 @@ def render_connector_manifests(
     objects: list[dict[str, Any]] = []
     for name, spec in sorted(connectors.connectors.items()):
         objects.extend(
-            connector_render.render(release, namespace, app_name, name, spec, secret_name)
+            connector_render.render(release, agent, namespace, app_name, name, spec, secret_name)
         )
     return objects
 
 
 def connector_mcp_entries(
-    connectors: ConnectorsFile, *, release: str, namespace: str
+    connectors: ConnectorsFile, *, release: str, agent: str, namespace: str
 ) -> dict[str, Any]:
     """The `.mcp.json` entries for declared connectors, keyed by name.
 
@@ -149,7 +150,7 @@ def connector_mcp_entries(
     """
 
     return {
-        name: connector_render.mcp_entry(release, namespace, name, spec)
+        name: connector_render.mcp_entry(release, agent, namespace, name, spec)
         for name, spec in sorted(connectors.connectors.items())
     }
 

--- a/apps/api/src/curie_api/routers/agents.py
+++ b/apps/api/src/curie_api/routers/agents.py
@@ -240,8 +240,17 @@ async def read_version_connectors(
         raise HTTPException(
             status.HTTP_404_NOT_FOUND, "no bundle stored for this version"
         )
+    # Object names are scoped to the agent, not just the release (#1116). Curie
+    # runs many agents per release, so a release-scoped name lets two agents
+    # that each declare `grafana` overwrite one another's Deployment, Service,
+    # and credential with no error. The agent NAME (not the id) is used so the
+    # objects stay recognisable in `kubectl get`.
+    agent = await crud.get_agent(session, agent_id)
+    if agent is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "agent not found")
     data = await store.get(version.bundle_ref)
     settings = get_settings()
+    agent_name = agent.name
 
     def _render() -> ConnectorManifests:
         with tempfile.TemporaryDirectory() as tmp:
@@ -253,17 +262,20 @@ async def read_version_connectors(
                 max_members=settings.bundle_max_members,
             )
             declared = bundles.read_connectors(Path(tmp))
-            secret_name = f"{release}-connector-secrets"
+            # Per-agent too: a release-scoped Secret means deploying the prod
+            # agent overwrites the dev agent's token in place (#1116).
+            secret_name = f"{release}-{agent_name}-connector-secrets"
             return ConnectorManifests(
                 manifests=bundles.render_connector_manifests(
                     declared,
                     release=release,
+                    agent=agent_name,
                     namespace=namespace,
                     app_name=app_name,
                     secret_name=secret_name,
                 ),
                 mcp_entries=bundles.connector_mcp_entries(
-                    declared, release=release, namespace=namespace
+                    declared, release=release, agent=agent_name, namespace=namespace
                 ),
             )
 

--- a/apps/api/tests/test_bundle_connectors.py
+++ b/apps/api/tests/test_bundle_connectors.py
@@ -41,13 +41,14 @@ HOSTED = (
 )
 
 
-def _render(root: Path) -> list[dict]:
+def _render(root: Path, agent: str = "sre-bot") -> list[dict]:
     return bundles.render_connector_manifests(
         bundles.read_connectors(root),
         release="sre-bot",
+        agent=agent,
         namespace="sre-bot",
         app_name="sre-bot",
-        secret_name="sre-bot-connectors",
+        secret_name=f"sre-bot-{agent}-connectors",
     )
 
 
@@ -83,7 +84,7 @@ def test_secret_is_referenced_not_inlined(tmp_path: Path) -> None:
     dep = next(o for o in _render(_bundle(tmp_path, HOSTED)) if o["kind"] == "Deployment")
     env = dep["spec"]["template"]["spec"]["containers"][0]["env"]
     token = next(e for e in env if e["name"] == "GRAFANA_TOKEN")
-    assert token["valueFrom"]["secretKeyRef"]["name"] == "sre-bot-connectors"
+    assert token["valueFrom"]["secretKeyRef"]["name"] == "sre-bot-sre-bot-connectors"
     assert "value" not in token
 
 
@@ -98,7 +99,7 @@ def test_mcp_entry_url_matches_the_rendered_service(tmp_path: Path) -> None:
     root = _bundle(tmp_path, HOSTED)
     svc = next(o for o in _render(root) if o["kind"] == "Service")
     entries = bundles.connector_mcp_entries(
-        bundles.read_connectors(root), release="sre-bot", namespace="sre-bot"
+        bundles.read_connectors(root), release="sre-bot", agent="sre-bot", namespace="sre-bot"
     )
     assert svc["metadata"]["name"] in entries["grafana"]["url"]
 
@@ -107,6 +108,16 @@ def test_remote_connector_contributes_an_entry_but_no_objects(tmp_path: Path) ->
     root = _bundle(tmp_path, "connectors:\n  x:\n    url: https://mcp.internal/mcp\n")
     assert _render(root) == []
     entries = bundles.connector_mcp_entries(
-        bundles.read_connectors(root), release="sre-bot", namespace="sre-bot"
+        bundles.read_connectors(root), release="sre-bot", agent="sre-bot", namespace="sre-bot"
     )
     assert entries["x"]["url"] == "https://mcp.internal/mcp"
+
+
+def test_two_agents_sharing_a_release_render_distinct_objects(tmp_path: Path) -> None:
+    # The deploy path's half of #1116: same bundle, same release, two agents.
+    # Release-scoped naming made these identical, so deploying one silently
+    # overwrote the other's Deployment and credential.
+    root = _bundle(tmp_path, HOSTED)
+    dev = {o["metadata"]["name"] for o in _render(root, agent="sre-dev")}
+    prod = {o["metadata"]["name"] for o in _render(root, agent="sre-prod")}
+    assert not dev & prod, f"agents collide: {dev} vs {prod}"

--- a/packages/plugin-format/src/plugin_format/connector_render.py
+++ b/packages/plugin-format/src/plugin_format/connector_render.py
@@ -30,9 +30,17 @@ not write.
 
 from __future__ import annotations
 
+import hashlib
 from typing import Any
 
 from .connectors import ConnectorSpec
+
+# Service names are DNS labels, so 63 characters is the hard ceiling. Names that
+# would exceed it are truncated and disambiguated with a digest rather than
+# clipped, since clipping alone can collide two distinct connectors back
+# together -- the exact failure this module's naming is meant to prevent.
+_DNS_LABEL_MAX = 63
+_DIGEST_LEN = 8
 
 
 def sandbox_selector(release: str, app_name: str) -> dict[str, str]:
@@ -59,17 +67,39 @@ def sandbox_selector(release: str, app_name: str) -> dict[str, str]:
     }
 
 
-def object_name(release: str, connector: str) -> str:
-    """Kubernetes object name for a connector. Stable and derivable."""
+def object_name(release: str, agent: str, connector: str) -> str:
+    """Kubernetes object name for a connector. Stable and derivable.
 
-    return f"{release}-mcp-{connector}"
+    Scoped to the AGENT, not just the release. Curie runs many agents per
+    release, so a release-scoped name means two agents that each declare a
+    connector called ``grafana`` render byte-identical objects and silently
+    overwrite one another -- with different images, different env, and a
+    different credential. The dev-tier agent ends up pointed at the prod
+    endpoint holding the prod token, and nothing errors (#1116).
+
+    It also makes pruning safe. Objects are pruned by an owner label; with
+    colliding names, ownership silently transfers to whoever deployed last, and
+    one agent removing a connector deletes another agent's running server.
+    """
+
+    base = f"{release}-{agent}-mcp-{connector}"
+    if len(base) <= _DNS_LABEL_MAX:
+        return base
+    # Truncate WITH a digest of the full name: clipping alone would map two long
+    # names that share a prefix onto the same object, reintroducing the very
+    # collision this function exists to prevent.
+    digest = hashlib.sha256(base.encode()).hexdigest()[:_DIGEST_LEN]
+    keep = _DNS_LABEL_MAX - _DIGEST_LEN - 1
+    return f"{base[:keep].rstrip('-')}-{digest}"
 
 
-def service_dns(release: str, connector: str, namespace: str) -> str:
-    return f"{object_name(release, connector)}.{namespace}.svc.cluster.local"
+def service_dns(release: str, agent: str, connector: str, namespace: str) -> str:
+    return f"{object_name(release, agent, connector)}.{namespace}.svc.cluster.local"
 
 
-def host_aliases(release: str, connector: str, namespace: str, port: int) -> list[str]:
+def host_aliases(
+    release: str, agent: str, connector: str, namespace: str, port: int
+) -> list[str]:
     """Every name the sandbox might use to reach this connector.
 
     Passed to servers that validate the Host header. Curie created the Service,
@@ -77,32 +107,34 @@ def host_aliases(release: str, connector: str, namespace: str, port: int) -> lis
     guessing wrong yields ``forbidden: host not allowed`` with no hint.
     """
 
-    short = object_name(release, connector)
+    short = object_name(release, agent, connector)
     return [
         f"{short}:{port}",
         f"{short}.{namespace}:{port}",
-        f"{service_dns(release, connector, namespace)}:{port}",
+        f"{service_dns(release, agent, connector, namespace)}:{port}",
     ]
 
 
-def render_service(release: str, connector: str, spec: ConnectorSpec) -> dict[str, Any]:
-    name = object_name(release, connector)
+def render_service(
+    release: str, agent: str, connector: str, spec: ConnectorSpec
+) -> dict[str, Any]:
+    name = object_name(release, agent, connector)
     return {
         "apiVersion": "v1",
         "kind": "Service",
-        "metadata": {"name": name, "labels": _labels(release, connector)},
+        "metadata": {"name": name, "labels": _labels(release, agent, connector)},
         "spec": {
             "type": "ClusterIP",
-            "selector": _labels(release, connector),
+            "selector": _labels(release, agent, connector),
             "ports": [{"name": "http", "port": spec.port, "targetPort": "http"}],
         },
     }
 
 
 def render_deployment(
-    release: str, connector: str, spec: ConnectorSpec, secret_name: str
+    release: str, agent: str, connector: str, spec: ConnectorSpec, secret_name: str
 ) -> dict[str, Any]:
-    name = object_name(release, connector)
+    name = object_name(release, agent, connector)
     env: list[dict[str, Any]] = [{"name": k, "value": v} for k, v in sorted(spec.env.items())]
     # Declared secrets arrive by reference, never as literals in the manifest.
     env += [
@@ -115,12 +147,12 @@ def render_deployment(
     return {
         "apiVersion": "apps/v1",
         "kind": "Deployment",
-        "metadata": {"name": name, "labels": _labels(release, connector)},
+        "metadata": {"name": name, "labels": _labels(release, agent, connector)},
         "spec": {
             "replicas": 1,
-            "selector": {"matchLabels": _labels(release, connector)},
+            "selector": {"matchLabels": _labels(release, agent, connector)},
             "template": {
-                "metadata": {"labels": _labels(release, connector)},
+                "metadata": {"labels": _labels(release, agent, connector)},
                 "spec": {
                     # Hardened by construction. The author never writes this, so
                     # the author cannot omit it.
@@ -154,7 +186,7 @@ def render_deployment(
 
 
 def render_networkpolicy(
-    release: str, app_name: str, connector: str, spec: ConnectorSpec
+    release: str, agent: str, app_name: str, connector: str, spec: ConnectorSpec
 ) -> dict[str, Any]:
     """Egress from the sandbox to this connector.
 
@@ -166,15 +198,15 @@ def render_networkpolicy(
         "apiVersion": "networking.k8s.io/v1",
         "kind": "NetworkPolicy",
         "metadata": {
-            "name": f"{object_name(release, connector)}-allow",
-            "labels": _labels(release, connector),
+            "name": f"{object_name(release, agent, connector)}-allow",
+            "labels": _labels(release, agent, connector),
         },
         "spec": {
             "podSelector": {"matchLabels": sandbox_selector(release, app_name)},
             "policyTypes": ["Egress"],
             "egress": [
                 {
-                    "to": [{"podSelector": {"matchLabels": _labels(release, connector)}}],
+                    "to": [{"podSelector": {"matchLabels": _labels(release, agent, connector)}}],
                     "ports": [{"protocol": "TCP", "port": spec.port}],
                 }
             ],
@@ -184,6 +216,7 @@ def render_networkpolicy(
 
 def render(
     release: str,
+    agent: str,
     namespace: str,
     app_name: str,
     connector: str,
@@ -195,13 +228,15 @@ def render(
     if not spec.is_hosted:
         return []
     return [
-        render_service(release, connector, spec),
-        render_deployment(release, connector, spec, secret_name),
-        render_networkpolicy(release, app_name, connector, spec),
+        render_service(release, agent, connector, spec),
+        render_deployment(release, agent, connector, spec, secret_name),
+        render_networkpolicy(release, agent, app_name, connector, spec),
     ]
 
 
-def mcp_entry(release: str, namespace: str, connector: str, spec: ConnectorSpec) -> dict[str, Any]:
+def mcp_entry(
+    release: str, agent: str, namespace: str, connector: str, spec: ConnectorSpec
+) -> dict[str, Any]:
     """The ``.mcp.json`` entry Curie injects, so the author writes no URL.
 
     For a hosted connector the URL is derived from the Service that Curie just
@@ -212,7 +247,7 @@ def mcp_entry(release: str, namespace: str, connector: str, spec: ConnectorSpec)
     if spec.is_hosted:
         return {
             "type": "http",
-            "url": f"http://{service_dns(release, connector, namespace)}:{spec.port}/mcp",
+            "url": f"http://{service_dns(release, agent, connector, namespace)}:{spec.port}/mcp",
         }
     entry: dict[str, Any] = {"type": "http", "url": spec.url}
     if spec.headers:
@@ -220,8 +255,8 @@ def mcp_entry(release: str, namespace: str, connector: str, spec: ConnectorSpec)
     return entry
 
 
-def _labels(release: str, connector: str) -> dict[str, str]:
+def _labels(release: str, agent: str, connector: str) -> dict[str, str]:
     return {
-        "app.kubernetes.io/name": object_name(release, connector),
+        "app.kubernetes.io/name": object_name(release, agent, connector),
         "app.kubernetes.io/part-of": release,
     }

--- a/packages/plugin-format/tests/test_connector_render.py
+++ b/packages/plugin-format/tests/test_connector_render.py
@@ -26,7 +26,7 @@ REMOTE = ConnectorSpec(url="https://mcp.internal/mcp", headers={"Authorization":
 
 
 def _objs(release: str = "sre-bot", app: str = "sre-bot") -> list[dict]:
-    return r.render(release, "sre-bot", app, "grafana", HOSTED, "conn-secrets")
+    return r.render(release, "sre-bot", "sre-bot", app, "grafana", HOSTED, "conn-secrets")
 
 
 # --------------------------------------------------------------------------- #
@@ -51,7 +51,7 @@ def test_egress_selects_exactly_the_pods_rail_1_denies() -> None:
     # to every OTHER release's sandboxes in the namespace. Both fail silently.
     np = next(
         o
-        for o in r.render("relA", "ns", "sre-bot", "g", HOSTED, "s")
+        for o in r.render("relA", "a", "ns", "sre-bot", "g", HOSTED, "s")
         if o["kind"] == "NetworkPolicy"
     )
     assert np["spec"]["podSelector"]["matchLabels"] == {
@@ -63,10 +63,14 @@ def test_egress_selects_exactly_the_pods_rail_1_denies() -> None:
 
 def test_two_releases_do_not_select_each_others_sandboxes() -> None:
     a = next(
-        o for o in r.render("relA", "ns", "app", "g", HOSTED, "s") if o["kind"] == "NetworkPolicy"
+        o
+        for o in r.render("relA", "a", "ns", "app", "g", HOSTED, "s")
+        if o["kind"] == "NetworkPolicy"
     )
     b = next(
-        o for o in r.render("relB", "ns", "app", "g", HOSTED, "s") if o["kind"] == "NetworkPolicy"
+        o
+        for o in r.render("relB", "a", "ns", "app", "g", HOSTED, "s")
+        if o["kind"] == "NetworkPolicy"
     )
     assert a["spec"]["podSelector"] != b["spec"]["podSelector"]
 
@@ -79,17 +83,17 @@ def test_host_aliases_cover_every_name_the_sandbox_could_dial() -> None:
     # loopback, so an in-cluster caller reaching them by Service DNS gets
     # `forbidden: host not allowed`. Curie named the Service, so Curie can
     # supply the full set; an author would have to guess it.
-    aliases = r.host_aliases("sre-bot", "grafana", "ns", 8000)
-    assert "sre-bot-mcp-grafana:8000" in aliases
-    assert "sre-bot-mcp-grafana.ns:8000" in aliases
-    assert "sre-bot-mcp-grafana.ns.svc.cluster.local:8000" in aliases
+    aliases = r.host_aliases("sre-bot", "a", "grafana", "ns", 8000)
+    assert "sre-bot-a-mcp-grafana:8000" in aliases
+    assert "sre-bot-a-mcp-grafana.ns:8000" in aliases
+    assert "sre-bot-a-mcp-grafana.ns.svc.cluster.local:8000" in aliases
 
 
 def test_injected_url_matches_the_service_that_was_rendered() -> None:
     # Hand-writing this URL is how a bundle ends up with an address that does
     # not resolve in the tier it is deployed to.
     svc = next(o for o in _objs() if o["kind"] == "Service")
-    url = r.mcp_entry("sre-bot", "sre-bot", "grafana", HOSTED)["url"]
+    url = r.mcp_entry("sre-bot", "sre-bot", "sre-bot", "grafana", HOSTED)["url"]
     assert svc["metadata"]["name"] in url
     assert url.endswith("/mcp")
 
@@ -126,11 +130,11 @@ def test_plain_env_is_passed_through() -> None:
 # Remote connectors own no objects
 # --------------------------------------------------------------------------- #
 def test_remote_connector_renders_nothing_to_run() -> None:
-    assert r.render("sre-bot", "ns", "app", "internal", REMOTE, "s") == []
+    assert r.render("sre-bot", "a", "ns", "app", "internal", REMOTE, "s") == []
 
 
 def test_remote_connector_keeps_its_own_url_and_headers() -> None:
-    entry = r.mcp_entry("sre-bot", "ns", "internal", REMOTE)
+    entry = r.mcp_entry("sre-bot", "a", "ns", "internal", REMOTE)
     assert entry["url"] == "https://mcp.internal/mcp"
     assert entry["headers"]["Authorization"] == "Bearer ${T}"
 
@@ -166,3 +170,63 @@ def test_selector_matches_what_the_chart_actually_renders() -> None:
             chart_selector = doc["spec"]["podSelector"]["matchLabels"]
     assert chart_selector, "could not find Rail 1's default-deny egress policy"
     assert r.sandbox_selector("myrel", "sre-bot") == chart_selector
+
+
+# --------------------------------------------------------------------------- #
+# Cross-AGENT collision -- #1116
+# --------------------------------------------------------------------------- #
+DEV = ConnectorSpec(image="grafana/mcp-grafana:0.17.2", env={"GRAFANA_URL": "https://dev.g"})
+PROD = ConnectorSpec(image="grafana/mcp-grafana:0.17.2", env={"GRAFANA_URL": "https://prod.g"})
+
+
+def test_two_agents_in_one_release_do_not_share_object_names() -> None:
+    # Curie runs many agents per release. Release-scoped names meant sre-dev and
+    # sre-prod both rendered `curie-mcp-grafana`, so deploying prod silently
+    # repointed the DEV agent at the prod endpoint -- and, because the Secret was
+    # release-scoped too, handed it the prod token. Nothing errored.
+    dev = [
+        o["metadata"]["name"]
+        for o in r.render("curie", "sre-dev", "ns", "curie", "grafana", DEV, "s")
+    ]
+    prod = [
+        o["metadata"]["name"]
+        for o in r.render("curie", "sre-prod", "ns", "curie", "grafana", PROD, "s")
+    ]
+    assert not set(dev) & set(prod), f"agents share object names: {dev} vs {prod}"
+
+
+def test_two_agents_do_not_share_pod_labels() -> None:
+    # The Service selector is these labels. Sharing them would route one agent's
+    # traffic to the other's pods even with distinct object names.
+    dev = next(
+        o
+        for o in r.render("curie", "sre-dev", "ns", "curie", "grafana", DEV, "s")
+        if o["kind"] == "Service"
+    )
+    prod = next(
+        o
+        for o in r.render("curie", "sre-prod", "ns", "curie", "grafana", PROD, "s")
+        if o["kind"] == "Service"
+    )
+    assert dev["spec"]["selector"] != prod["spec"]["selector"]
+
+
+def test_each_agent_gets_its_own_url() -> None:
+    dev = r.mcp_entry("curie", "sre-dev", "ns", "grafana", DEV)["url"]
+    prod = r.mcp_entry("curie", "sre-prod", "ns", "grafana", PROD)["url"]
+    assert dev != prod
+
+
+def test_over_long_names_stay_valid_dns_labels() -> None:
+    name = r.object_name("a" * 30, "b" * 30, "c" * 40)
+    assert len(name) <= 63
+    assert name[0].isalnum() and name[-1].isalnum()
+
+
+def test_over_long_names_that_share_a_prefix_still_differ() -> None:
+    # Clipping alone would map these onto one object, reintroducing the very
+    # collision the agent scoping exists to prevent.
+    a = r.object_name("release", "agent-with-a-very-long-name-number-one", "grafana")
+    b = r.object_name("release", "agent-with-a-very-long-name-number-two", "grafana")
+    assert len(a) <= 63 and len(b) <= 63
+    assert a != b


### PR DESCRIPTION
Fixes #1116. Refs ADR-0086, #1063. **Stacked on #1115 — merge that first, and confirm it reached `main` before merging this** (see the stacking hazard below).

## The bug

`object_name()` keyed only on the **release**. Curie runs many agents per release.

```
acme-dev  objects: [Service curie-mcp-grafana, Deployment curie-mcp-grafana, NetworkPolicy curie-mcp-grafana-allow]
acme-prod objects: [Service curie-mcp-grafana, Deployment curie-mcp-grafana, NetworkPolicy curie-mcp-grafana-allow]
names identical: True

dev  GRAFANA_URL: https://dev.grafana
prod GRAFANA_URL: https://prod.grafana
```

Identical names, different config, last deploy wins, no error.

## Why it's a security bug

The Secret name was release-scoped too (`{release}-connector-secrets`). Deploying `acme-prod` repoints the **dev** agent's connector at prod Grafana *and* overwrites the shared Secret with the prod token.

**A dev-tier agent silently acquires prod credentials.** Nothing fails, nothing logs, and the sandbox NetworkPolicy still passes because it selects the release's sandbox pods either way.

This is precisely the dev/prod split #1063 exists to support.

## It also makes pruning unsafe

Pruning is scoped by owner label. With colliding names:

- Each deploy re-labels the shared object, so ownership silently transfers to whoever deployed last.
- If `acme-dev` later **removes** its `grafana` connector, its prune deletes the object `acme-prod` is actively using. **Cross-agent deletion.**

Wiring `cluster deploy` on top of this would turn a silent overwrite into a silent outage — which is why that wiring waits on this PR.

## The fix

`{release}-{agent}-mcp-{connector}`, threaded through `object_name`, `service_dns`, `host_aliases`, `render_*`, `render`, `mcp_entry`, `_labels`, and the API's render call. Secret becomes `{release}-{agent}-connector-secrets`.

Over-long names truncate **with a digest of the full name**, not a bare clip:

```python
digest = hashlib.sha256(base.encode()).hexdigest()[:8]
return f"{base[:54].rstrip('-')}-{digest}"
```

Clipping alone maps two long names sharing a prefix back onto one object — reintroducing the exact collision this prevents. Pinned by `test_over_long_names_that_share_a_prefix_still_differ`.

`_labels` is agent-scoped too, so the **Service selector** differs — without that, distinct Services would still route to each other's pods.

## New regression tests

| Test | Catches |
|---|---|
| `test_two_agents_in_one_release_do_not_share_object_names` | the reported collision |
| `test_two_agents_do_not_share_pod_labels` | Service selector cross-routing |
| `test_each_agent_gets_its_own_url` | `.mcp.json` pointing at the wrong agent's server |
| `test_over_long_names_stay_valid_dns_labels` | truncation producing an invalid label |
| `test_over_long_names_that_share_a_prefix_still_differ` | clip-only collision |
| `test_two_agents_sharing_a_release_render_distinct_objects` | same, through the API's deploy path |

Each fails against the pre-fix code.

## Frozen contract

`packages/plugin-format` is frozen (`packages/CLAUDE.md`): a change lands as its own reviewed PR before dependent lanes. That's what this is — raising it rather than folding it into the deploy wiring.

**Nothing calls the render path in production yet**, so this is cheap now and expensive after the first real connector deploy.

## Verification

```
ruff check              → All checks passed
mypy                    → no issues, 165 files
check-contracts.sh      → all committed artifacts current
openapi                 → no drift (signature unchanged)
plugin-format tests     → 213 passed
connector_render tests  → 19 passed, incl. the live-helm chart anti-drift check
bundle connector tests  → 8 passed
```

7 errors in `test_bundles.py` are pre-existing — the dev Postgres stack isn't running locally; identical on `main`.

## Stacking hazard

#1114 merged in the same two seconds as its base #1113, so GitHub's auto-retarget never fired and it landed on a stale branch instead of `main` — while showing MERGED. #1115 re-lands it. **Let #1115 land and confirm it's on `main` before merging this one.**