### PR TITLE
Wire connectors into `cluster deploy` (#1063)

### DIFF
--- a/cli/src/connectors.rs
+++ b/cli/src/connectors.rs
@@ -77,7 +77,10 @@ pub fn prune_args(namespace: &str, agent_name: &str, keep: &[String]) -> Vec<Str
         "-n".into(),
         namespace.into(),
         "delete".into(),
-        "deployment,service,networkpolicy".into(),
+        // `secret` is in here deliberately. Dropping a connector from
+        // connectors.yaml must take its credential with it -- a Secret left
+        // behind is a live token nothing references and nobody notices.
+        "deployment,service,networkpolicy,secret".into(),
         "-l".into(),
         format!("{}={}", OWNER_LABEL, owner_value(agent_name)),
         "--ignore-not-found".into(),
@@ -105,6 +108,86 @@ pub fn object_names(manifests: &[Value]) -> Vec<String> {
                 .map(str::to_string)
         })
         .collect()
+}
+
+/// The Secret name and credential keys the rendered Deployments reference.
+///
+/// Read back off the manifests rather than re-derived from the bundle: the API
+/// decides the Secret's name and which keys a connector needs, so re-deriving
+/// here would be a second copy of that rule, free to drift from the one that
+/// actually rendered the `secretKeyRef`.
+pub fn referenced_secrets(manifests: &[Value]) -> Option<(String, Vec<String>)> {
+    let mut name: Option<String> = None;
+    let mut keys: Vec<String> = Vec::new();
+    for obj in manifests {
+        let containers = obj
+            .pointer("/spec/template/spec/containers")
+            .and_then(|c| c.as_array());
+        for c in containers.into_iter().flatten() {
+            for env in c
+                .get("env")
+                .and_then(|e| e.as_array())
+                .into_iter()
+                .flatten()
+            {
+                let Some(r) = env.pointer("/valueFrom/secretKeyRef") else {
+                    continue;
+                };
+                if let Some(n) = r.get("name").and_then(|n| n.as_str()) {
+                    name.get_or_insert_with(|| n.to_string());
+                }
+                if let Some(k) = r.get("key").and_then(|k| k.as_str()) {
+                    if !keys.iter().any(|e| e == k) {
+                        keys.push(k.to_string());
+                    }
+                }
+            }
+        }
+    }
+    name.map(|n| {
+        keys.sort();
+        (n, keys)
+    })
+}
+
+/// The Secret carrying resolved connector credentials.
+///
+/// `stringData` so kubectl does the base64; values reach it over stdin, never
+/// argv. `kubectl create secret --from-literal` would put every credential in
+/// the process table, where any local user can read it off `ps`.
+pub fn render_secret(
+    name: &str,
+    namespace: &str,
+    values: &std::collections::BTreeMap<String, String>,
+) -> Value {
+    serde_json::json!({
+        "apiVersion": "v1",
+        "kind": "Secret",
+        "type": "Opaque",
+        "metadata": {"name": name, "namespace": namespace},
+        "stringData": values,
+    })
+}
+
+/// `kubectl` argv reading the release's rendered `app.kubernetes.io/name`.
+///
+/// Read from the cluster, not re-derived from chart values. That label is what
+/// Rail 1's default-deny egress selects on, so taking it from the objects the
+/// chart actually rendered means the connector's allow-rule matches by
+/// construction -- a second derivation could disagree, and a NetworkPolicy that
+/// selects nothing fails silently (ADR-0067).
+pub fn app_name_args(namespace: &str, release: &str) -> Vec<String> {
+    vec![
+        "kubectl".into(),
+        "-n".into(),
+        namespace.into(),
+        "get".into(),
+        "deployment".into(),
+        "-l".into(),
+        format!("app.kubernetes.io/instance={release}"),
+        "-o".into(),
+        r"jsonpath={.items[0].metadata.labels.app\.kubernetes\.io/name}".into(),
+    ]
 }
 
 /// Serialize a manifest list as a single JSON `List` for one apply invocation.
@@ -178,7 +261,7 @@ mod tests {
         // credential mounted and nothing referencing it.
         let args = prune_args("ns", "sre-bot", &[]);
         assert!(!args.iter().any(|a| a.starts_with("--field-selector")));
-        assert!(args.contains(&"deployment,service,networkpolicy".to_string()));
+        assert!(args.contains(&"deployment,service,networkpolicy,secret".to_string()));
     }
 
     #[test]
@@ -190,8 +273,231 @@ mod tests {
     }
 
     #[test]
+    fn prune_removes_the_secret_too_when_a_connector_is_dropped() {
+        // A Secret left behind is a live credential nothing references. Deleting
+        // the Deployment but keeping its token is the leak this whole prune
+        // exists to close, so `secret` must be in the kind list.
+        let args = prune_args("ns", "sre-bot", &[]);
+        let kinds = args.iter().find(|a| a.contains("deployment")).unwrap();
+        assert!(kinds.contains("secret"), "kinds were: {kinds}");
+    }
+
+    #[test]
+    fn secret_refs_are_read_back_off_the_rendered_manifests() {
+        // Re-deriving the Secret's name here would be a second copy of a rule
+        // the API already applied, free to drift from the secretKeyRef that was
+        // actually rendered -- and a mismatch means the pod never starts.
+        let dep = json!({"kind":"Deployment","spec":{"template":{"spec":{"containers":[{
+        "env":[
+            {"name":"GRAFANA_URL","value":"https://g"},
+            {"name":"TOKEN","valueFrom":{"secretKeyRef":{"name":"r-a-connector-secrets","key":"TOKEN"}}},
+            {"name":"OTHER","valueFrom":{"secretKeyRef":{"name":"r-a-connector-secrets","key":"OTHER"}}}
+        ]}]}}}});
+        let (name, keys) = referenced_secrets(&[dep]).unwrap();
+        assert_eq!(name, "r-a-connector-secrets");
+        assert_eq!(keys, vec!["OTHER".to_string(), "TOKEN".to_string()]);
+    }
+
+    #[test]
+    fn a_connector_with_no_secrets_needs_no_secret_object() {
+        let dep = json!({"kind":"Deployment","spec":{"template":{"spec":{"containers":[{
+            "env":[{"name":"GRAFANA_URL","value":"https://g"}]}]}}}});
+        assert!(referenced_secrets(&[dep]).is_none());
+    }
+
+    #[test]
+    fn secret_values_ride_string_data_never_argv() {
+        // `kubectl create secret --from-literal` puts every credential in the
+        // process table, readable by any local user off `ps`. This travels on
+        // stdin instead, so the value appears in no argv at all.
+        let mut v = std::collections::BTreeMap::new();
+        v.insert("TOKEN".to_string(), "s3cret".to_string());
+        let obj = render_secret("r-a-connector-secrets", "ns", &v);
+        assert_eq!(obj["stringData"]["TOKEN"], "s3cret");
+        assert!(!apply_args("ns").iter().any(|a| a.contains("s3cret")));
+    }
+
+    #[test]
+    fn the_secret_is_kept_not_pruned_by_the_deploy_that_wrote_it() {
+        let mut v = std::collections::BTreeMap::new();
+        v.insert("TOKEN".to_string(), "x".to_string());
+        let objs = vec![render_secret("r-a-connector-secrets", "ns", &v)];
+        let keep = object_names(&label_objects(&objs, "a"));
+        let args = prune_args("ns", "a", &keep);
+        assert!(args
+            .iter()
+            .any(|a| a.contains("metadata.name!=r-a-connector-secrets")));
+    }
+
+    #[test]
+    fn app_name_is_read_from_the_release_not_guessed() {
+        // Rail 1's default-deny selects on the label the chart rendered. Taking
+        // it from the cluster makes the connector's allow-rule match by
+        // construction; a second derivation could disagree, and a NetworkPolicy
+        // that selects nothing fails silently.
+        let args = app_name_args("ns", "myrel");
+        assert!(args.contains(&"app.kubernetes.io/instance=myrel".to_string()));
+        assert!(args
+            .iter()
+            .any(|a| a.contains("app\\.kubernetes\\.io/name")));
+    }
+
+    #[test]
     fn apply_reads_from_stdin_so_nothing_touches_disk() {
         let args = apply_args("ns");
         assert_eq!(args.last().unwrap(), "-");
     }
+}
+
+// --------------------------------------------------------------------------- #
+// Execution
+// --------------------------------------------------------------------------- #
+
+/// Run a kubectl argv, optionally writing `stdin` to it, capturing output.
+///
+/// Separate from `ops::run_capture` because that has no stdin channel, and
+/// stdin is the whole point here: the applied document carries credentials, so
+/// it must not become a `-f <file>` on disk or a `--from-literal` in argv.
+async fn run(argv: &[String], stdin: Option<&str>) -> Result<(bool, String, String)> {
+    use tokio::io::AsyncWriteExt;
+    let (program, args) = argv.split_first().context("empty command")?;
+    let mut cmd = tokio::process::Command::new(program);
+    cmd.args(args)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .stdin(if stdin.is_some() {
+            std::process::Stdio::piped()
+        } else {
+            std::process::Stdio::null()
+        });
+    let mut child = cmd
+        .spawn()
+        .with_context(|| format!("failed to invoke `{program}`; is it on PATH?"))?;
+    if let Some(doc) = stdin {
+        let mut pipe = child.stdin.take().context("stdin pipe missing")?;
+        pipe.write_all(doc.as_bytes()).await?;
+        pipe.shutdown().await?;
+    }
+    let out = child.wait_with_output().await?;
+    Ok((
+        out.status.success(),
+        String::from_utf8_lossy(&out.stdout).to_string(),
+        String::from_utf8_lossy(&out.stderr).to_string(),
+    ))
+}
+
+/// What a connector sync did, for the deploy summary.
+#[derive(Debug, Default)]
+pub struct ConnectorSync {
+    pub applied: Vec<String>,
+    pub urls: std::collections::BTreeMap<String, String>,
+}
+
+/// Discover the release's rendered app name (the chart's nameOverride).
+pub async fn discover_app_name(namespace: &str, release: &str) -> Result<String> {
+    let (ok, out, err) = run(&app_name_args(namespace, release), None).await?;
+    let name = out.trim();
+    if !ok || name.is_empty() {
+        anyhow::bail!(
+            "could not read the app name for release {release} in namespace {namespace}: no \
+             Deployment carries app.kubernetes.io/instance={release}. Connectors need it to \
+             target the sandbox pods Rail 1 denies by default. Confirm the release is installed \
+             with `curie cluster status`.{}",
+            if err.trim().is_empty() {
+                String::new()
+            } else {
+                format!(" kubectl said: {}", err.trim())
+            }
+        );
+    }
+    Ok(name.to_string())
+}
+
+/// Resolve each declared credential: environment first, then the host vault.
+///
+/// Fails naming every gap at once rather than one per run. A connector that
+/// starts without its credential does not fail at apply -- it comes up and
+/// returns 401s to the agent, which reads as "the tool is broken".
+fn resolve_secret_values(keys: &[String]) -> Result<std::collections::BTreeMap<String, String>> {
+    let mut values = std::collections::BTreeMap::new();
+    let mut missing = Vec::new();
+    for k in keys {
+        match std::env::var(k)
+            .ok()
+            .filter(|v| !v.is_empty())
+            .or(crate::secrets::get_value(k)?)
+        {
+            Some(v) => {
+                values.insert(k.clone(), v);
+            }
+            None => missing.push(k.clone()),
+        }
+    }
+    if !missing.is_empty() {
+        return Err(crate::exit::usage(format!(
+            "connectors.yaml declares secret(s) with no value available: {}. Export each in the \
+             environment, or store it once with `curie secrets set <NAME>`.",
+            missing.join(", ")
+        )));
+    }
+    Ok(values)
+}
+
+/// Apply an agent's declared connectors, and prune what it no longer declares.
+///
+/// Called after the bundle is deployed, so the objects exist before the next
+/// turn reaches for them.
+pub async fn sync(
+    manifests: &[Value],
+    mcp_entries: &std::collections::BTreeMap<String, Value>,
+    namespace: &str,
+    agent_name: &str,
+) -> Result<ConnectorSync> {
+    let ui = crate::ui::ui();
+    let mut objects = Vec::new();
+
+    if let Some((secret_name, keys)) = referenced_secrets(manifests) {
+        if !keys.is_empty() {
+            objects.push(render_secret(
+                &secret_name,
+                namespace,
+                &resolve_secret_values(&keys)?,
+            ));
+        }
+    }
+    objects.extend_from_slice(manifests);
+
+    let mut sync = ConnectorSync::default();
+    for (name, entry) in mcp_entries {
+        if let Some(url) = entry.get("url").and_then(|u| u.as_str()) {
+            sync.urls.insert(name.clone(), url.to_string());
+        }
+    }
+
+    let labelled = label_objects(&objects, agent_name);
+    let keep = object_names(&labelled);
+
+    if !labelled.is_empty() {
+        let doc = as_list_document(&labelled)?;
+        let (ok, _out, err) = run(&apply_args(namespace), Some(&doc)).await?;
+        if !ok {
+            anyhow::bail!("applying connectors failed: {}", err.trim());
+        }
+        sync.applied = keep.clone();
+        ui.note(&format!(
+            "connectors: applied {} object(s) for {agent_name}",
+            keep.len()
+        ));
+    }
+
+    // Runs even with nothing declared -- that is the case where a connector was
+    // REMOVED, and the whole reason this is not a bare `kubectl apply`.
+    let (ok, _out, err) = run(&prune_args(namespace, agent_name, &keep), None).await?;
+    if !ok {
+        ui.warn(&format!(
+            "connectors: pruning stale objects for {agent_name} failed: {}",
+            err.trim()
+        ));
+    }
+    Ok(sync)
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -102,6 +102,45 @@ struct ClusterAgentTarget {
     dry_run: bool,
 }
 
+/// Stand up the connectors this version declares, and prune what it dropped.
+///
+/// Split across the two components on purpose (ADR-0086): the API RENDERS the
+/// Kubernetes objects -- a pure function of the bundle, so it needs no cluster
+/// access and keeps its read-only RBAC on the service that receives internet
+/// webhooks -- and the CLI APPLIES them under the operator's own kubectl
+/// credentials, where cluster-write authority already lived.
+///
+/// A bundle with no `connectors.yaml` still reaches the prune: that is the case
+/// where a connector was REMOVED, and leaving it running with a credential
+/// mounted and nothing referencing it is the leak nobody notices.
+async fn sync_connectors(
+    api_url: &str,
+    api_key: &str,
+    namespace: &str,
+    release: &str,
+    agent_id: &str,
+    agent_name: &str,
+    version_id: &str,
+) -> anyhow::Result<()> {
+    let app_name = curie::connectors::discover_app_name(namespace, release).await?;
+    let client = curie::api::ApiClient::new(api_url, api_key)?;
+    let rendered = client
+        .version_connectors(agent_id, version_id, release, namespace, &app_name)
+        .await?;
+    let synced = curie::connectors::sync(
+        &rendered.manifests,
+        &rendered.mcp_entries,
+        namespace,
+        agent_name,
+    )
+    .await?;
+    let ui = curie::ui::ui();
+    for (name, url) in &synced.urls {
+        ui.note(&format!("connector {name}: {url}"));
+    }
+    Ok(())
+}
+
 /// Resolve a cluster verb's `(api_url, api_key)`: an explicit flag/env value wins;
 /// otherwise discover it from the release (UI `/api` proxy for the URL, the chart
 /// Secret for the key). Discovery failures are actionable errors naming the
@@ -2501,27 +2540,43 @@ async fn run(command: Option<Command>) -> Result<()> {
                         "the platform API at {api_url} (from --api-url/CURIE_API_URL) is unreachable. `cluster deploy` dialed it directly with no port-forward; confirm that URL is reachable and the release is healthy with `curie cluster status`, or omit --api-url to self-plumb a loopback port-forward to svc/{release}-api."
                     )
                 };
-                emit(
-                    commands::deploy(DeployOpts {
-                        plugin_dir,
-                        api_url,
-                        api_key,
-                        slack_channel,
-                        repo,
-                        env,
-                        label,
-                        // Cluster connector-secret delivery is deferred to #440; no
-                        // `--secret` flag on `cluster deploy` (see the note above).
-                        secret: Vec::new(),
-                        // Secret binding is not wired on cluster until #440, so the
-                        // declared-secrets policy gate (#464) is skipped here: it
-                        // would otherwise hard-fail every secrets-declaring bundle
-                        // with a `--secret <NAME>` remediation this tier lacks.
-                        secret_binding_supported: false,
-                        connect_hint,
-                    })
-                    .await?,
+                let deployed = commands::deploy(DeployOpts {
+                    plugin_dir,
+                    api_url: api_url.clone(),
+                    api_key: api_key.clone(),
+                    slack_channel,
+                    repo,
+                    env,
+                    label,
+                    // Cluster connector-secret delivery is deferred to #440; no
+                    // `--secret` flag on `cluster deploy` (see the note above).
+                    secret: Vec::new(),
+                    // Secret binding is not wired on cluster until #440, so the
+                    // declared-secrets policy gate (#464) is skipped here: it
+                    // would otherwise hard-fail every secrets-declaring bundle
+                    // with a `--secret <NAME>` remediation this tier lacks.
+                    secret_binding_supported: false,
+                    connect_hint,
+                })
+                .await?;
+
+                // Stand up whatever the bundle's connectors.yaml declares
+                // (ADR-0086, #1063). After the deploy, so the objects exist
+                // before the next turn reaches for them; the credentials here
+                // are the CONNECTOR's, resolved locally and written straight to
+                // a K8s Secret, which is a different path from the sandbox
+                // secret delivery #440 tracks.
+                sync_connectors(
+                    &api_url,
+                    &api_key,
+                    &namespace,
+                    &release,
+                    &deployed.agent_id,
+                    &deployed.agent_name,
+                    &deployed.version_id,
                 )
+                .await?;
+                emit(deployed)
             }
             ClusterAction::Kill {
                 agent,


### PR DESCRIPTION
Refs #1063, ADR-0086. **Stacked on #1117 — merge that first and confirm it reached `main`.**

The piece that makes the previous four PRs do something. `cluster deploy` now stands up whatever `connectors.yaml` declares, and removes what it stopped declaring.

## Flow

After the bundle deploys:

1. Read the release's app name **off the cluster**
2. Ask the API to render the objects (it renders; it never applies)
3. Resolve declared credentials → a K8s Secret
4. Apply as one JSON `List` on stdin
5. Prune owned objects no longer declared

## Three decisions worth reviewing

**App name is read, not re-derived.** That label is what Rail 1's default-deny egress selects on. Taking it from the objects the chart actually rendered makes the connector's allow-rule match *by construction*. A second derivation from chart values could disagree — and a NetworkPolicy that selects nothing fails **silently**, which is the bug that already cost a debugging session on this work.

**Credentials go over stdin, never argv.** `kubectl create secret --from-literal` puts every token in the process table, readable by any local user off `ps`. This builds the Secret object and pipes it in. Pinned by `secret_values_ride_string_data_never_argv`.

**Missing values fail before anything is applied**, naming every gap at once. A connector that starts without its credential doesn't fail at apply — it comes up and returns 401s, which reads to the operator as "the tool is broken".

## This is not #440

#440 is delivery to the **worker-spawned sandbox** and needs `SandboxTemplate` plumbing. A **connector** credential goes to a pod *this command creates*, under the same kubectl credentials it already uses to create it. Different consumer, different path, no dependency. `cluster deploy --secret` still declines with its existing reason.

## Pruning includes `secret`

Dropping a connector must take its credential with it. A Secret left behind is a live token nothing references and nobody notices.

A bundle with **no** `connectors.yaml` still reaches the prune — that *is* the connector-was-removed case, and skipping it is exactly how the leak survives.

## New tests

| Test | Catches |
|---|---|
| `prune_removes_the_secret_too_when_a_connector_is_dropped` | orphaned live credential |
| `secret_refs_are_read_back_off_the_rendered_manifests` | a second copy of the API's naming rule drifting |
| `a_connector_with_no_secrets_needs_no_secret_object` | an empty Secret for credential-free connectors |
| `secret_values_ride_string_data_never_argv` | tokens leaking to `ps` |
| `the_secret_is_kept_not_pruned_by_the_deploy_that_wrote_it` | deleting the credential just written |
| `app_name_is_read_from_the_release_not_guessed` | the silent no-match NetworkPolicy |

## Known gap

The derived URLs are **printed but not injected** into the sandbox's `.mcp.json`, so an author still copies them by hand — which is the thing ADR-0086 set out to remove. Filed as **#1118** (worker lane).

## Verification

```
cargo fmt --check        → clean
cargo clippy -D warnings → 0 errors
cargo test               → 0 failed suites (579 tests)
field-parity             → 4 passed
command manifest         → no drift (no command-surface change)
```

**Not live-verified** — no cluster reachable from here. Given how many bugs live testing has caught on this work, I'd want a real `cluster deploy` before calling #1063 done.
