### PR TITLE
Restore first-run documentation to the current CLI contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,10 @@ the same plugin bundle climbs three tiers.
 An environment difference then shows up as a bug while progressing through these tiers, not a surprise
 your users hit - letting you iterate fast locally and ship with confidence.
 
-`local` and `cluster` run immutable versioned bundles; `skill` bind mounts its working directory instead,
-so you can edit and iterate fast while building the plugin bundle.
+All three tiers run an immutable bundle snapshot: `local` and `cluster` assign that snapshot a
+version, while `skill` identifies it by its content digest. What makes `skill` the fast loop is that
+it packs and boots that snapshot straight from your working directory in one command, with no
+platform in front.
 
 Curie provides an environment guarantee while climbing the three tiers. It is not a behavior
 guarantee: production traffic can still behave differently than your test cases, and no platform can
@@ -100,8 +102,9 @@ curie skill up
 curie skill message "hello, are you there?"
 ```
 
-A real reply streams back: no Slack, no platform yet. Edit `skills/my-agent/SKILL.md` and re-run to see your
-change answered. When done run the following command
+A real reply streams back: no Slack, no platform yet. `skill up` runs an immutable snapshot of the
+bundle, so after you edit `skills/my-agent/SKILL.md` the change only reaches a running runner once you
+restart it with `curie skill up --replace`. When done run the following command
 
 ```bash
 curie skill down
@@ -158,9 +161,16 @@ Then:
 
 ```bash
 curie cluster up --allow-egress-host anthropic --set security.gvisor.mode=off
-curie cluster deploy --plugin-dir .
+curie cluster deploy --plugin-dir . --repo <owner>/<name>
 curie cluster message "hello, are you there?"
 ```
+
+`--repo` binds this agent to the GitHub repository you will push this bundle to in step 4. A push
+is matched to an agent by its repo binding, so a push for an agent deployed without the binding
+matches nothing and is answered `ignored`, never becoming a version. That binding is set only when
+the agent is first created and cannot be changed afterwards, so substitute your own `owner/name`
+before running it: getting it wrong means deleting the agent and recreating it. See
+[`cli/README.md`](cli/README.md) for the lifecycle verbs.
 
 `--set security.gvisor.mode=off` skips gVisor's extra kernel isolation, which a real-model install
 otherwise requires and minikube doesn't ship by default - drop it on a cluster that has `runsc`
@@ -185,7 +195,10 @@ curie cluster down --yes
 
 **4. Ship it: your CI/CD**
 
-Connect this bundle's repo once (see [`docs/operations.md`](docs/operations.md#automatically-with-git-flow)), then:
+Git-flow needs the agent created with `--repo`, as step 3 showed. If you tore the cluster down at the
+end of step 3, bring it back up and re-run that same `cluster deploy` line before pushing, because the
+binding lives in the release's database. What is left is exposing the Curie API to GitHub and wiring
+the webhook and its secret (see [`docs/operations.md`](docs/operations.md#automatically-with-git-flow)), then:
 
 ```bash
 git push origin dev
@@ -222,11 +235,13 @@ in [`cli/README.md`](cli/README.md).
 | Target    | What runs                                                                                                    | Slack    | Kubernetes | Verbs                                   | Reach for it to                                                                                                                                    |
 | --------- | ------------------------------------------------------------------------------------------------------------ | -------- | ---------- | --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `skill`   | Just the runner container on the host Docker daemon. No platform, no queue, no API, no Slack. Fully offline. | none     | none       | `up` `down` `status` `message` `eval`   | Iterate a plugin/skill against a local runner, the fastest development loop.                                                                                   |
-| `local`   | The full platform via docker compose (Postgres + Valkey + Langfuse + API + worker).                          | none     | none       | `up` `down` `status` `message` `deploy` | Exercise the real queue -> worker -> sandbox -> reply product loop with zero Slack and zero Kubernetes. Its API is published on host port `28000`. |
-| `cluster` | The platform on Kubernetes (a Helm release).                                                                 | optional | yes        | `up` `down` `status` `message` `deploy` | Operate and drive a deployed cluster release.                                                                                                      |
+| `local`   | The full platform via docker compose (Postgres + Valkey + Langfuse + API + worker).                          | none     | none       | `up` `down` `status` `message` `eval` `deploy` | Exercise the real queue -> worker -> sandbox -> reply product loop with zero Slack and zero Kubernetes. Its API is published on host port `28000`. |
+| `cluster` | The platform on Kubernetes (a Helm release).                                                                 | optional | yes        | `up` `down` `status` `message` `eval` `deploy` | Operate and drive a deployed cluster release.                                                                                                      |
 
-The universal quartet `up`/`down`/`status`/`message` is on all three targets;
-`skill` adds `eval`, and `local`/`cluster` add `deploy`. Parity does not mean
+The table lists the verbs it covers, not every verb a target has: the universal
+quartet `up`/`down`/`status`/`message` is on all three targets, and so is
+`eval`, while `local`/`cluster` add `deploy`. See
+[`cli/README.md`](cli/README.md) for each target's verbs. Parity does not mean
 every capability is implemented at every tier: every verb is answered at every
 tier, with unsupported concepts returning a deterministic reason and an
 alternative, as defined in
@@ -293,4 +308,3 @@ an agent using Curie, not one working in this repo.
 working in this repo: the verify commands, the dev stack, the
 frozen-contract escalation rule, and the build gotchas. Each top-level
 directory also has its own scoped `CLAUDE.md` with rules specific to that area.
-

--- a/README.md
+++ b/README.md
@@ -181,6 +181,13 @@ fail-closed by default (skill/local aren't).
 
 See [`docs/operations.md`](docs/operations.md#installing-and-inspecting-the-curie-platform-on-the-cluster) for cluster prerequisites and the full egress model.
 
+This first cluster is disposable. For production, keep durable data outside the cluster: set
+`postgres.deploy: false` for managed Postgres and `minio.deploy: false` for an S3 compatible object
+store, then supply their credentials through existing Kubernetes Secrets. The chart redirects its
+consumers to those stores, including bundle fetches. See the
+[`charts/curie` production storage configuration](charts/curie/README.md#values-surface-and-the-byo-idiom)
+for the complete backing store settings.
+
 Then continue this conversation thread
 
 ```bash

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -133,13 +133,16 @@ curie cluster deploy --plugin-dir <bundle-dir>
 | Flag / env var | What it does |
 |---|---|
 | `--plugin-dir <dir>` | The bundle directory to package and push. |
+| `--repo <owner/name>` | Bind this agent to a GitHub repo so pushes deploy it; set only on the deploy that creates the agent and unchangeable after. Omit it and the agent can never use git-flow. |
 | `--api-url <url>` / `CURIE_API_URL` | Direct-dial this URL instead of self-plumbing a loopback tunnel. |
 | `--api-key <key>` / `CURIE_API_KEY` | Override the auto-discovered API key. |
 
-Beyond pointing it at your bundle, `cluster deploy` needs no other flags by
-default: it automatically finds a way to reach the Curie API and
-automatically finds the credentials to use, so
-`curie cluster deploy --plugin-dir <bundle-dir>` just works.
+Beyond pointing it at your bundle, `cluster deploy` needs no `--api-url` or
+`--api-key` by default: it automatically finds a way to reach the Curie API
+and automatically finds the credentials to use, so
+`curie cluster deploy --plugin-dir <bundle-dir>` just works. The one flag
+you do need is `--repo`, and only if you want git-flow -- see
+[Automatically, with git-flow](#automatically-with-git-flow) below.
 
 Under the hood, it opens a secure local tunnel to the Curie API (so
 nothing needs to be exposed publicly) and reads the API key straight out


### PR DESCRIPTION
The README first-run flow and the operations guide had drifted from the shipped CLI in five ways. Each is corrected against `cli/command-manifest.json` and the built binary.

1. **The first cluster deploy now binds the repo.** Step 3 passes `--repo <owner>/<name>`, and step 4 no longer promises a later "connect this bundle's repo" step, which has no code path: the binding is set only at agent creation and cannot be changed afterwards. Step 4 also no longer claims the step 3 binding survived the `cluster down --yes` that ends step 3, and it now names API reachability alongside the webhook and secret.
2. **Skill mode is described as the immutable snapshot it runs**, with `curie skill up --replace` named as the way an edit reaches a running runner. The prior "bind mounts its working directory" claim was wrong, and contradicted `QUICKSTART.md` and `cli/CLAUDE.md`.
3. **The literal `curie init` tree shows all seven scaffolded files**, verified against a real `curie init` run. The four that were missing are annotated in the bullet list below it.
4. **`eval` added to the `local` and `cluster` verb cells.** The sentence after the table no longer reads as an exhaustive verb list, since the table is a curated subset.
5. **The operations guide's `cluster deploy` flag table gains a `--repo` row** and states the flag applies only during agent creation. Its "needs no other flags by default" paragraph was telling readers the opposite of the git-flow section in the same file.

Verification: `scripts/check-docs.sh` passes; the scaffold tree was diffed against a real `curie init` run; `--repo`, `skill up --replace`, `local eval`, and `cluster eval` were each confirmed present in the built CLI; the 36 gitflow tests covering the bound-vs-unbound push paths pass.

Scope note: `curie local deploy` in step 2 deliberately keeps no `--repo`, since git-flow is demonstrated at the cluster tier only. The tier table was deliberately kept a curated subset rather than expanded to every verb in the manifest.

Closes #1126
