### PR TITLE
Restrict authenticated git-flow clones to the registered repository

### DIFF
--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -33,6 +33,17 @@ worker, Postgres, MinIO/S3, Langfuse, and GitHub.
   independent of GitHub API rate limits and scopes. Do not introduce a GitHub
   API client into `gitflow.py` for something the git protocol already gives
   you.
+- **The webhook's HMAC signature authenticates the sender, not the payload's
+  clone URL.** A valid signature proves the sender holds the shared secret,
+  exactly the attacker the threat model assumes, so `clone_and_archive`
+  (`gitflow.py`) never hands git `repository.clone_url` from the payload.
+  It hands git `trusted_clone_url`, derived from `Settings.github_clone_base`
+  plus the `repo_full_name` read from the database row; the payload URL is
+  only compared against that derived one, to reject and log a forged push
+  (`CloneOriginMismatch`), before being discarded. `repo_full_name` is a
+  required keyword-only parameter for this reason and must not get a default.
+  The clone also pins `http.followRedirects=false`, since git's default
+  follows a redirect on the very request carrying the auth header.
 - **Prod push reuses the dev-built bundle; it does not rebuild.** A push to
   the prod branch looks up the `Version` already created for that sha (from
   the dev push) and only creates a new `Deployment` row. If you find yourself

--- a/apps/api/src/curie_api/config.py
+++ b/apps/api/src/curie_api/config.py
@@ -96,6 +96,13 @@ class Settings(BaseSettings):
     # http.extraheader, never embedded in the clone URL.
     github_api_url: str = "https://api.github.com"
     github_token: str = ""
+    # The one git origin this installation deploys from. The webhook payload's
+    # `clone_url` is compared against `<base>/<repo_full_name>.git` and a
+    # mismatch is rejected before any subprocess starts; git is then handed the
+    # derived URL rather than the payload's, so the credential above can only
+    # ever reach this host (#1122). Point it at a GitHub Enterprise Server base
+    # to deploy from GHE, exactly as with `github_api_url` above.
+    github_clone_base: str = "https://github.com"
     # Upper bound on the GitHub webhook request body, enforced before the body is
     # fully buffered, parsed, or HMAC-authenticated (#633) so an unauthenticated
     # oversized request cannot exhaust memory. GitHub caps webhook payloads at

--- a/apps/api/src/curie_api/gitflow.py
+++ b/apps/api/src/curie_api/gitflow.py
@@ -46,6 +46,10 @@ class GitFlowError(Exception):
     """The repo could not be fetched or archived at the requested commit."""
 
 
+class CloneOriginMismatch(GitFlowError):
+    """The payload's clone URL is not the registered repository's origin."""
+
+
 def verify_signature(secret: str, body: bytes, header: str | None) -> bool:
     """Constant-time check of GitHub's X-Hub-Signature-256 over the raw body."""
 
@@ -72,7 +76,71 @@ def environment_for_ref(ref: str | None, settings: Settings) -> Environment | No
     return None
 
 
-def _clone_credential_env(clone_url: str, settings: Settings) -> dict[str, str]:
+_DEFAULT_PORTS = {"https": 443, "http": 80}
+
+
+def trusted_clone_url(repo_full_name: str, settings: Settings) -> str:
+    """The one origin this installation is allowed to clone for that repo.
+
+    Derived from configuration plus the repository binding stored on the agent
+    row, never from the webhook payload, so the platform GitHub credential can
+    only ever travel to the configured host (#1122).
+    """
+
+    return f"{settings.github_clone_base.rstrip('/')}/{repo_full_name}.git"
+
+
+def _origin_key(url: str) -> tuple[str, str, str, str, int | None, str, str, str]:
+    """A normalized comparison key for a clone URL.
+
+    Covers every dimension that decides where a request actually goes: scheme,
+    user information, host, port (with the scheme's default applied so an
+    explicit ``:443`` matches), path modulo a trailing ``.git`` and trailing
+    slashes, query, and fragment. User information is carried IN the key rather
+    than rejected separately, so any credential in the payload URL mismatches
+    automatically against a derived URL that never carries one.
+
+    Keys are compared as WHOLE TUPLES for equality. No element may ever be
+    compared with ``startswith`` or a substring test: that is exactly what would
+    let ``owner/repo-evil`` pass against a registered ``owner/repo``.
+    """
+
+    parts = urlsplit(url)
+    scheme = parts.scheme.lower()
+    port = parts.port
+    if port is None:
+        port = _DEFAULT_PORTS.get(scheme)
+    path = parts.path.rstrip("/")
+    if path.endswith(".git"):
+        path = path[: -len(".git")]
+    path = path.rstrip("/")
+    return (
+        scheme,
+        parts.username or "",
+        parts.password or "",
+        parts.hostname or "",
+        port,
+        path,
+        parts.query,
+        parts.fragment,
+    )
+
+
+def _origins_match(requested: str, trusted: str) -> bool:
+    """Whole-key equality between a requested clone URL and the trusted origin.
+
+    An unparseable URL reads as a mismatch rather than crashing inside the
+    threadpool: ``urlsplit().port`` raises ``ValueError`` on a non-numeric port
+    and ``urlsplit`` itself raises on a malformed IPv6 literal.
+    """
+
+    try:
+        return _origin_key(requested) == _origin_key(trusted)
+    except ValueError:
+        return False
+
+
+def _clone_credential_env(trusted_url: str, settings: Settings) -> dict[str, str]:
     """Git config env that authenticates the clone, or empty if not applicable.
 
     Private repositories are the norm for a bundle -- it names internal hosts and
@@ -85,14 +153,16 @@ def _clone_credential_env(clone_url: str, settings: Settings) -> dict[str, str]:
     that echoes the command) and out of the cloned repo's ``.git/config``, which
     URL-embedded credentials are persisted into.
 
-    The header is scoped to the clone URL's own host, so a webhook naming some
-    other host cannot make us send the token there.
+    The URL reaching this function is the origin derived from the stored
+    repository binding (``trusted_clone_url``), never the webhook payload's
+    ``clone_url``, so the header is scoped to the one host this installation
+    deploys from (#1122).
     """
 
     token = settings.github_token
-    if not token or not clone_url.startswith("https://"):
+    if not token or not trusted_url.startswith("https://"):
         return {}
-    host = urlsplit(clone_url).netloc
+    host = urlsplit(trusted_url).netloc
     if not host:
         return {}
     basic = base64.b64encode(f"x-access-token:{token}".encode()).decode()
@@ -121,11 +191,19 @@ def _git_failure_detail(exc: BaseException) -> str:
     return str(exc)[:200]
 
 
-def clone_and_archive(clone_url: str, sha: str, settings: Settings) -> bytes:
+def clone_and_archive(
+    clone_url: str, sha: str, settings: Settings, *, repo_full_name: str
+) -> bytes:
     """Mirror-clone the repo and return a tar of the tree at ``sha``.
 
     Refuses clone URLs outside the configured scheme allowlist and restricts git
     to safe transports, so a webhook cannot coerce an arbitrary git command.
+
+    ``clone_url`` is the untrusted webhook payload value: it is compared against
+    the origin derived from ``repo_full_name`` (which the caller must have read
+    from the agent row) and then discarded. Git is handed the derived origin,
+    for both the clone argv and the credential header, so a signed-but-forged
+    payload cannot choose where the platform GitHub token travels (#1122).
     """
 
     if not clone_url.startswith(settings.git_allowed_schemes):
@@ -133,17 +211,55 @@ def clone_and_archive(clone_url: str, sha: str, settings: Settings) -> bytes:
     if not _is_valid_sha(sha):
         raise GitFlowError(f"invalid commit sha: {sha!r}")
 
+    trusted_url = trusted_clone_url(repo_full_name, settings)
+    if not trusted_url.startswith(settings.git_allowed_schemes):
+        # The derived URL, not the payload, is what git actually clones. The
+        # comparison below is not a substitute for this check: it is safe
+        # today only by transitivity, and a misconfigured `github_clone_base`
+        # must fail as a deployment configuration error, not be reported as a
+        # forged push. Never interpolate the credential here; this URL never
+        # carries one (see `_clone_credential_env`), but keep it that way.
+        raise GitFlowError(
+            f"configured github_clone_base produces a clone url outside the "
+            f"allowed schemes {settings.git_allowed_schemes!r}: {trusted_url!r}"
+        )
+    if not _origins_match(clone_url, trusted_url):
+        # Truncated: this lands in the webhook response body and in the warning
+        # log, and a forged payload must not be able to flood either.
+        raise CloneOriginMismatch(
+            f"clone url does not match the registered repository "
+            f"{repo_full_name!r}: {clone_url[:200]!r}"
+        )
+
     tmp = tempfile.mkdtemp(prefix="gitflow-")
     env = {
         **os.environ,
         "GIT_ALLOW_PROTOCOL": "file:https:http",
         "GIT_TERMINAL_PROMPT": "0",
-        **_clone_credential_env(clone_url, settings),
+        **_clone_credential_env(trusted_url, settings),
     }
     try:
         try:
+            # `git help config` (git 2.43.0): "http.followRedirects: Whether git
+            # should follow HTTP redirects. ... If set to false, git will treat
+            # all redirects as errors. If set to initial, git will follow
+            # redirects only for the initial request to a remote, but not for
+            # subsequent follow-up HTTP requests. ... The default is initial."
+            # The initial request is precisely the one carrying the extraheader,
+            # so the default would let a redirect target receive the credential.
+            # `-c` must precede the `clone` subcommand to take effect.
             subprocess.run(
-                ["git", "clone", "--quiet", "--mirror", clone_url, tmp],
+                [
+                    "git",
+                    "-c",
+                    "http.followRedirects=false",
+                    "clone",
+                    "--quiet",
+                    "--mirror",
+                    "--",
+                    trusted_url,
+                    tmp,
+                ],
                 check=True,
                 capture_output=True,
                 env=env,
@@ -191,7 +307,10 @@ async def process_push(
         return WebhookResult(status="ignored")
 
     agent = await crud.get_agent_by_repo(session, full_name)
-    if agent is None:
+    # The second clause is unreachable in practice (the lookup's predicate is
+    # `Agent.repo_full_name == full_name` with a non-None argument); it exists
+    # solely to narrow `str | None` to `str` for the origin derivation below.
+    if agent is None or agent.repo_full_name is None:
         return WebhookResult(status="ignored")
 
     version = await crud.get_version_by_commit(session, agent.id, after)
@@ -204,10 +323,24 @@ async def process_push(
     bundle_built = version is None or version.bundle_ref is None
     if bundle_built:
         try:
+            # The stored binding, never the payload's full_name: AC1 says the
+            # origin is derived from what the database holds.
             data = await run_in_threadpool(
-                clone_and_archive, clone_url, after, settings
+                clone_and_archive,
+                clone_url,
+                after,
+                settings,
+                repo_full_name=agent.repo_full_name,
             )
             extension, content_type = deploy.validate_archive(data, settings)
+        # CloneOriginMismatch is a GitFlowError subclass, so it must be caught
+        # first or its clause is dead code. An operator has to be able to tell a
+        # forged push apart from a network failure.
+        except CloneOriginMismatch as exc:
+            return WebhookResult(
+                status="rejected",
+                errors=[{"code": "git.origin_mismatch", "message": str(exc)}],
+            )
         except GitFlowError as exc:
             return WebhookResult(
                 status="rejected",

--- a/apps/api/tests/test_evalqueue_integration.py
+++ b/apps/api/tests/test_evalqueue_integration.py
@@ -12,9 +12,11 @@ import os
 import secrets
 import subprocess
 import uuid
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
+import pytest
 import redis
 import redis.asyncio as aioredis
 from aci_protocol import STREAM_PAYLOAD_FIELD, EvalJob
@@ -110,9 +112,38 @@ def _git(*args: str, cwd: Path | None = None) -> str:
     return out.stdout.strip()
 
 
-def _build_bare_repo(tmp_path: Path) -> tuple[str, str]:
-    work = tmp_path / "work"
-    work.mkdir()
+@pytest.fixture
+def trusted_clone_base(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> Iterator[Path]:
+    """Point `GITHUB_CLONE_BASE` at a per-test `file://` base and yield it.
+
+    This file carries its own copy rather than importing
+    `test_gitflow_integration`'s. `routers/github.py` calls `get_settings()` per
+    request, so the app needs no rebuild; the clear-AFTER-undo ordering at
+    teardown is load-bearing, since clearing first would re-cache the still-set
+    env value into a later test.
+    """
+
+    base = tmp_path / "remotes"
+    base.mkdir()
+    monkeypatch.setenv("GITHUB_CLONE_BASE", f"file://{base}")
+    get_settings.cache_clear()
+    yield base
+    monkeypatch.undo()
+    get_settings.cache_clear()
+
+
+def _build_bare_repo(base_dir: Path, repo_full_name: str) -> tuple[str, str]:
+    """Create a bare repo at `<base_dir>/<repo_full_name>.git`. Returns (url, sha).
+
+    The returned URL is byte-identical to the origin the API derives from
+    `GITHUB_CLONE_BASE` plus the agent's stored `repo_full_name`, so the fan-out
+    path exercises the derivation instead of bypassing it.
+    """
+
+    work = base_dir / "_work" / repo_full_name
+    work.mkdir(parents=True)
     _git("init", "-q", "-b", "dev", cwd=work)
     for rel, content in VALID_FILES.items():
         path = work / rel
@@ -121,7 +152,8 @@ def _build_bare_repo(tmp_path: Path) -> tuple[str, str]:
     _git("add", "-A", cwd=work)
     _git("commit", "-q", "-m", "init", cwd=work)
     sha = _git("rev-parse", "HEAD", cwd=work)
-    bare = tmp_path / "bare.git"
+    bare = base_dir / f"{repo_full_name}.git"
+    bare.parent.mkdir(parents=True, exist_ok=True)
     _git("clone", "--quiet", "--bare", str(work), str(bare))
     return f"file://{bare}", sha
 
@@ -171,14 +203,17 @@ def _count_eval_entries_for_agent(agent_id: str) -> int:
 
 
 def test_dev_push_fans_out_prod_push_does_not(
-    client: Any, auth_headers: dict[str, str], clean_db: None, tmp_path: Path
+    client: Any,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    trusted_clone_base: Path,
 ) -> None:
     agent = client.post(
         "/agents",
         json={"name": "k1-fanout", "slack_channel": "C000000K01", "repo_full_name": REPO},
         headers=auth_headers,
     ).json()
-    clone_url, sha = _build_bare_repo(tmp_path)
+    clone_url, sha = _build_bare_repo(trusted_clone_base, REPO)
 
     assert _post_push(client, "refs/heads/dev", sha, clone_url).json()["status"] == (
         "deployed"
@@ -206,14 +241,17 @@ def test_dev_push_fans_out_prod_push_does_not(
 
 
 def test_redelivered_dev_push_does_not_refan_out(
-    client: Any, auth_headers: dict[str, str], clean_db: None, tmp_path: Path
+    client: Any,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    trusted_clone_base: Path,
 ) -> None:
     agent = client.post(
         "/agents",
         json={"name": "k1-redeliver", "slack_channel": "C000000K01", "repo_full_name": REPO},
         headers=auth_headers,
     ).json()
-    clone_url, sha = _build_bare_repo(tmp_path)
+    clone_url, sha = _build_bare_repo(trusted_clone_base, REPO)
 
     # First delivery builds the bundle and fans out exactly one eval job.
     assert _post_push(client, "refs/heads/dev", sha, clone_url).json()["status"] == (

--- a/apps/api/tests/test_gitflow_integration.py
+++ b/apps/api/tests/test_gitflow_integration.py
@@ -3,6 +3,12 @@
 No github.com and no network: the "remote" is a local bare repository and the
 webhook payloads are HMAC-signed exactly as GitHub signs them. This exercises
 the real deploy/promote path (git archive -> validate -> store -> deploy row).
+
+The bare repositories live under a per-test `file://` clone base laid out as
+`<base>/<owner>/<name>.git`, and `GITHUB_CLONE_BASE` points at that base, so the
+URL git is handed is the derived origin the production code computes -- the same
+way a GitHub Enterprise operator points the setting at their own host. Nothing
+here is a test-only code branch.
 """
 
 import asyncio
@@ -12,9 +18,11 @@ import json
 import os
 import subprocess
 import uuid
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
+import pytest
 from curie_api import crud
 from curie_api.config import get_settings
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
@@ -27,6 +35,27 @@ VALID_FILES = {
     "skills/alpha/SKILL.md": "---\nname: alpha\ndescription: does alpha\n---\n",
     "skills/beta/SKILL.md": "---\nname: beta\ndescription: does beta\n---\n",
 }
+
+
+@pytest.fixture
+def trusted_clone_base(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> Iterator[Path]:
+    """Point `GITHUB_CLONE_BASE` at a per-test `file://` base and yield it.
+
+    `routers/github.py` calls `get_settings()` per request rather than through a
+    cached dependency, so the app does not need rebuilding. The clear-AFTER-undo
+    ordering at teardown is load-bearing: clearing first would let the still-set
+    env value be re-cached and leak into a later test.
+    """
+
+    base = tmp_path / "remotes"
+    base.mkdir()
+    monkeypatch.setenv("GITHUB_CLONE_BASE", f"file://{base}")
+    get_settings.cache_clear()
+    yield base
+    monkeypatch.undo()
+    get_settings.cache_clear()
 
 
 def _git(*args: str, cwd: Path | None = None) -> str:
@@ -48,11 +77,18 @@ def _git(*args: str, cwd: Path | None = None) -> str:
     return out.stdout.strip()
 
 
-def _build_bare_repo(tmp_path: Path, files: dict[str, str]) -> tuple[str, str]:
-    """Create a local bare repo with `files` committed on dev. Returns (url, sha)."""
+def _build_bare_repo(
+    base_dir: Path, repo_full_name: str, files: dict[str, str]
+) -> tuple[str, str]:
+    """Create a bare repo at `<base_dir>/<repo_full_name>.git`. Returns (url, sha).
 
-    work = tmp_path / "work"
-    work.mkdir()
+    The returned URL is byte-identical to the origin the API derives from
+    `GITHUB_CLONE_BASE` plus the agent's stored `repo_full_name`, so these tests
+    exercise the derivation instead of bypassing it.
+    """
+
+    work = base_dir / "_work" / repo_full_name
+    work.mkdir(parents=True)
     _git("init", "-q", "-b", "dev", cwd=work)
     for rel, content in files.items():
         path = work / rel
@@ -61,7 +97,8 @@ def _build_bare_repo(tmp_path: Path, files: dict[str, str]) -> tuple[str, str]:
     _git("add", "-A", cwd=work)
     _git("commit", "-q", "-m", "init", cwd=work)
     sha = _git("rev-parse", "HEAD", cwd=work)
-    bare = tmp_path / "bare.git"
+    bare = base_dir / f"{repo_full_name}.git"
+    bare.parent.mkdir(parents=True, exist_ok=True)
     _git("clone", "--quiet", "--bare", str(work), str(bare))
     return f"file://{bare}", sha
 
@@ -127,10 +164,13 @@ def _register_agent(client: Any, headers: dict[str, str]) -> str:
 
 
 def test_dev_push_deploys_dev_bot(
-    client: Any, auth_headers: dict[str, str], clean_db: None, tmp_path: Path
+    client: Any,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    trusted_clone_base: Path,
 ) -> None:
     agent_id = _register_agent(client, auth_headers)
-    clone_url, sha = _build_bare_repo(tmp_path, VALID_FILES)
+    clone_url, sha = _build_bare_repo(trusted_clone_base, REPO, VALID_FILES)
 
     resp = _post(client, "push", _push_payload("refs/heads/dev", sha, clone_url))
     assert resp.status_code == 200, resp.text
@@ -160,10 +200,13 @@ def test_dev_push_deploys_dev_bot(
 
 
 def test_main_push_promotes_and_reuses_the_built_version(
-    client: Any, auth_headers: dict[str, str], clean_db: None, tmp_path: Path
+    client: Any,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    trusted_clone_base: Path,
 ) -> None:
     agent_id = _register_agent(client, auth_headers)
-    clone_url, sha = _build_bare_repo(tmp_path, VALID_FILES)
+    clone_url, sha = _build_bare_repo(trusted_clone_base, REPO, VALID_FILES)
 
     dev = _post(
         client, "push", _push_payload("refs/heads/dev", sha, clone_url)
@@ -187,10 +230,13 @@ def test_main_push_promotes_and_reuses_the_built_version(
 
 
 def test_partial_version_is_rebuilt_not_reused(
-    client: Any, auth_headers: dict[str, str], clean_db: None, tmp_path: Path
+    client: Any,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    trusted_clone_base: Path,
 ) -> None:
     agent_id = _register_agent(client, auth_headers)
-    clone_url, sha = _build_bare_repo(tmp_path, VALID_FILES)
+    clone_url, sha = _build_bare_repo(trusted_clone_base, REPO, VALID_FILES)
     _insert_partial_version(agent_id, sha)
 
     resp = _post(client, "push", _push_payload("refs/heads/dev", sha, clone_url))
@@ -230,20 +276,26 @@ def test_ping_event_pongs(
 
 
 def test_unknown_repo_is_ignored(
-    client: Any, auth_headers: dict[str, str], clean_db: None, tmp_path: Path
+    client: Any,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    trusted_clone_base: Path,
 ) -> None:
     # No agent registered for REPO.
-    clone_url, sha = _build_bare_repo(tmp_path, VALID_FILES)
+    clone_url, sha = _build_bare_repo(trusted_clone_base, REPO, VALID_FILES)
     resp = _post(client, "push", _push_payload("refs/heads/dev", sha, clone_url))
     assert resp.status_code == 200
     assert resp.json()["status"] == "ignored"
 
 
 def test_non_deploy_branch_is_ignored(
-    client: Any, auth_headers: dict[str, str], clean_db: None, tmp_path: Path
+    client: Any,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    trusted_clone_base: Path,
 ) -> None:
     _register_agent(client, auth_headers)
-    clone_url, sha = _build_bare_repo(tmp_path, VALID_FILES)
+    clone_url, sha = _build_bare_repo(trusted_clone_base, REPO, VALID_FILES)
     resp = _post(
         client, "push", _push_payload("refs/heads/feature-x", sha, clone_url)
     )
@@ -252,12 +304,15 @@ def test_non_deploy_branch_is_ignored(
 
 
 def test_malformed_bundle_push_is_rejected(
-    client: Any, auth_headers: dict[str, str], clean_db: None, tmp_path: Path
+    client: Any,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    trusted_clone_base: Path,
 ) -> None:
     agent_id = _register_agent(client, auth_headers)
     files = dict(VALID_FILES)
     files["skills/beta/SKILL.md"] = "# no frontmatter\n"
-    clone_url, sha = _build_bare_repo(tmp_path, files)
+    clone_url, sha = _build_bare_repo(trusted_clone_base, REPO, files)
 
     resp = _post(client, "push", _push_payload("refs/heads/dev", sha, clone_url))
     assert resp.status_code == 200
@@ -271,3 +326,112 @@ def test_malformed_bundle_push_is_rejected(
         "/deployments", params={"agent_id": agent_id}, headers=auth_headers
     ).json()
     assert deployments == []
+
+
+def test_signed_push_with_a_foreign_clone_url_is_rejected(
+    client: Any,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    trusted_clone_base: Path,
+) -> None:
+    # The ticket's attack driven through the real consumer path: a correctly
+    # HMAC-signed push naming the registered repository, with an attacker's
+    # clone URL. A real bare repo exists at the trusted path and the same push
+    # deploys fine when the URL matches (test_dev_push_deploys_dev_bot), so the
+    # rejection here is the origin pin and nothing else.
+    agent_id = _register_agent(client, auth_headers)
+    _url, sha = _build_bare_repo(trusted_clone_base, REPO, VALID_FILES)
+
+    resp = _post(
+        client,
+        "push",
+        _push_payload(
+            "refs/heads/dev", sha, f"https://evil.example/{REPO}.git"
+        ),
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["status"] == "rejected"
+    codes = {e["code"] for e in body["errors"]}
+    assert "git.origin_mismatch" in codes
+
+    # Nothing was built and nothing was deployed.
+    assert client.get(f"/agents/{agent_id}/versions", headers=auth_headers).json() == []
+    assert (
+        client.get(
+            "/deployments", params={"agent_id": agent_id}, headers=auth_headers
+        ).json()
+        == []
+    )
+
+
+def test_push_using_the_repository_url_fallback_still_deploys(
+    client: Any,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    trusted_clone_base: Path,
+) -> None:
+    # `repository.url` is the rarely-executed sibling of `repository.clone_url`
+    # at gitflow.py:189. GitHub's push payload carries `clone_url` WITH the .git
+    # suffix and `url` WITHOUT it, so this arms the guard via the secondary path
+    # only and proves it agrees with the primary path (AGENTS.md parity-seam
+    # rule).
+    agent_id = _register_agent(client, auth_headers)
+    clone_url, sha = _build_bare_repo(trusted_clone_base, REPO, VALID_FILES)
+
+    resp = _post(
+        client,
+        "push",
+        {
+            "ref": "refs/heads/dev",
+            "after": sha,
+            "repository": {
+                "full_name": REPO,
+                "url": clone_url.removesuffix(".git"),
+            },
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["status"] == "deployed"
+
+    deployments = client.get(
+        "/deployments", params={"agent_id": agent_id}, headers=auth_headers
+    ).json()
+    assert len(deployments) == 1
+
+
+def test_signed_push_with_a_foreign_url_fallback_is_rejected(
+    client: Any,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    trusted_clone_base: Path,
+) -> None:
+    # The fallback must not be an unguarded back door: the same comparison
+    # applies whichever payload field supplied the URL.
+    agent_id = _register_agent(client, auth_headers)
+    _url, sha = _build_bare_repo(trusted_clone_base, REPO, VALID_FILES)
+
+    resp = _post(
+        client,
+        "push",
+        {
+            "ref": "refs/heads/dev",
+            "after": sha,
+            "repository": {
+                "full_name": REPO,
+                "url": f"https://evil.example/{REPO}",
+            },
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["status"] == "rejected"
+    assert "git.origin_mismatch" in {e["code"] for e in body["errors"]}
+
+    assert client.get(f"/agents/{agent_id}/versions", headers=auth_headers).json() == []
+    assert (
+        client.get(
+            "/deployments", params={"agent_id": agent_id}, headers=auth_headers
+        ).json()
+        == []
+    )

--- a/apps/api/tests/test_gitflow_redirect.py
+++ b/apps/api/tests/test_gitflow_redirect.py
@@ -44,11 +44,12 @@ def _origin_handler(
         protocol_version = "HTTP/1.1"
 
         def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler's contract
-            recorded.append(self.path)
+            safe_path = self.path.replace("\r", "").replace("\n", "")
+            recorded.append(safe_path)
             # A different HOSTNAME, same loopback address: cross-host from git's
             # point of view, and reachable without any external network.
             self.send_response(302)
-            self.send_header("Location", f"http://localhost:{target_port}{self.path}")
+            self.send_header("Location", f"http://localhost:{target_port}{safe_path}")
             self.send_header("Content-Length", "0")
             self.end_headers()
 

--- a/apps/api/tests/test_gitflow_redirect.py
+++ b/apps/api/tests/test_gitflow_redirect.py
@@ -1,0 +1,186 @@
+"""AC4 proof by execution: a cross-host redirect gets no request from the clone.
+
+A separate file because this pair needs a REAL `git` subprocess and two loopback
+HTTP servers, and needs neither Postgres nor MinIO. `test_gitflow_unit.py` mocks
+`subprocess.run` as its contract, and `test_gitflow_integration.py` requires the
+database fixtures and declares "no github.com and no network" in its header.
+Everything here binds 127.0.0.1 only; nothing leaves the box.
+
+The setup is an *origin* server that 302-redirects every request to a *different
+hostname* (`localhost`, which resolves to the same loopback address but is a
+distinct host to git), and a *target* server that records every request it
+receives. The load-bearing assertion is that the target's request list is empty:
+strictly stronger than "the target received no Authorization header".
+"""
+
+import os
+import subprocess
+import threading
+from collections.abc import Iterator
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import pytest
+from curie_api.config import Settings
+from curie_api.gitflow import GitFlowError, clone_and_archive
+
+_REPO = "octo/demo-agent"
+_VALID_SHA1 = "a" * 40
+
+
+@dataclass
+class _Servers:
+    origin_port: int
+    target_port: int
+    origin_requests: list[str]
+    target_requests: list[str]
+
+
+def _origin_handler(
+    recorded: list[str], target_port: int
+) -> type[BaseHTTPRequestHandler]:
+    class _Origin(BaseHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
+
+        def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler's contract
+            recorded.append(self.path)
+            # A different HOSTNAME, same loopback address: cross-host from git's
+            # point of view, and reachable without any external network.
+            self.send_response(302)
+            self.send_header("Location", f"http://localhost:{target_port}{self.path}")
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+
+        def log_message(self, format: str, *args: object) -> None:
+            pass
+
+    return _Origin
+
+
+def _target_handler(recorded: list[str]) -> type[BaseHTTPRequestHandler]:
+    class _Target(BaseHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
+
+        def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler's contract
+            recorded.append(self.path)
+            body = b"not found"
+            self.send_response(404)
+            self.send_header("Content-Type", "text/plain")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, format: str, *args: object) -> None:
+            pass
+
+    return _Target
+
+
+@pytest.fixture(autouse=True)
+def _hermetic_git(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep a developer's proxy or personal gitconfig out of these assertions.
+
+    A proxy or a global `http.followRedirects` would otherwise decide where the
+    loopback requests actually go, and both tests would be measuring the machine
+    rather than the code.
+    """
+
+    for var in ("http_proxy", "HTTP_PROXY", "all_proxy", "ALL_PROXY"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("no_proxy", "*")
+    monkeypatch.setenv("NO_PROXY", "*")
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", os.devnull)
+    monkeypatch.setenv("GIT_CONFIG_SYSTEM", os.devnull)
+
+
+@pytest.fixture
+def redirect_servers() -> Iterator[_Servers]:
+    origin_requests: list[str] = []
+    target_requests: list[str] = []
+
+    target = ThreadingHTTPServer(("127.0.0.1", 0), _target_handler(target_requests))
+    target_port = int(target.server_address[1])
+    origin = ThreadingHTTPServer(
+        ("127.0.0.1", 0), _origin_handler(origin_requests, target_port)
+    )
+    origin_port = int(origin.server_address[1])
+
+    threads = [
+        threading.Thread(target=server.serve_forever, daemon=True)
+        for server in (target, origin)
+    ]
+    for thread in threads:
+        thread.start()
+    try:
+        yield _Servers(origin_port, target_port, origin_requests, target_requests)
+    finally:
+        for server in (origin, target):
+            server.shutdown()
+            server.server_close()
+        for thread in threads:
+            thread.join(timeout=5)
+
+
+def test_a_cross_host_redirect_receives_no_request_from_the_clone(
+    redirect_servers: _Servers,
+) -> None:
+    """The pinned clone treats a redirect as an error, so nothing reaches the target.
+
+    Grounded in `git help config` (git version 2.43.0, the version in this
+    worktree), on `http.followRedirects`: "If set to initial, git will follow
+    redirects only for the initial request to a remote, but not for subsequent
+    follow-up HTTP requests. ... The default is initial." The request that
+    carries the `http.<url>.extraheader` credential IS that initial request, so
+    git's default is not safe here; `-c http.followRedirects=false` makes any
+    redirect a hard error instead.
+
+    Deliberately NOT asserted: that the target saw no Authorization header.
+    `_clone_credential_env` withholds the credential from every non-`https://`
+    URL, so over loopback http that assertion would pass without exercising
+    anything. The https case is covered by the chain: zero redirects followed
+    (this test), the credential is https-only
+    (`test_clone_does_not_send_the_credential_over_plain_http`), the header is
+    keyed to the derived origin
+    (`test_clone_credential_is_keyed_to_the_derived_origin`), and git is only
+    ever handed the derived URL
+    (`test_clone_hands_git_the_derived_origin_not_the_payload_url`).
+    """
+
+    base = f"http://127.0.0.1:{redirect_servers.origin_port}"
+    settings = Settings(github_clone_base=base, github_token="ghs-secret-token")
+    payload_url = f"{base}/{_REPO}.git"
+
+    with pytest.raises(GitFlowError):
+        clone_and_archive(payload_url, _VALID_SHA1, settings, repo_full_name=_REPO)
+
+    # Non-vacuity: git really did reach the origin and really was handed a 302.
+    assert redirect_servers.origin_requests != [], "git never reached the origin"
+    assert redirect_servers.target_requests == []
+
+
+def test_git_follows_the_initial_redirect_without_the_pin(
+    redirect_servers: _Servers, tmp_path: Path
+) -> None:
+    """Control: an unpinned git DOES reach the other host, so the pin is the cause.
+
+    Same grounding as above: `git help config` says of `http.followRedirects`
+    that "The default is initial", and the clone's first request to a remote is
+    exactly an initial request. This test is the observed behavior the fix
+    defends against. Without it, the pinned test would pass just as happily
+    against a server that never redirected at all.
+    """
+
+    origin_url = f"http://127.0.0.1:{redirect_servers.origin_port}/{_REPO}.git"
+    subprocess.run(
+        ["git", "clone", "--quiet", "--mirror", origin_url, str(tmp_path / "mirror")],
+        check=False,
+        capture_output=True,
+        env={**os.environ, "GIT_TERMINAL_PROMPT": "0"},
+        timeout=60,
+    )
+
+    # Both assertions matter: the first proves the redirect actually fired, so a
+    # green run can never mean "the servers were never exercised".
+    assert redirect_servers.origin_requests != [], "git never reached the origin"
+    assert redirect_servers.target_requests != []

--- a/apps/api/tests/test_gitflow_unit.py
+++ b/apps/api/tests/test_gitflow_unit.py
@@ -9,6 +9,7 @@ from unittest import mock
 import pytest
 from curie_api.config import Settings
 from curie_api.gitflow import (
+    CloneOriginMismatch,
     GitFlowError,
     clone_and_archive,
     environment_for_ref,
@@ -19,7 +20,20 @@ from curie_api.models import Environment
 SECRET = "top-secret"
 _VALID_SHA1 = "a" * 40
 _VALID_SHA256 = "a" * 64
-_ALLOWED_URL = "file:///tmp/nonexistent-gitflow-repo"
+# The repository binding these tests are pinned to, and a clone base whose
+# derived origin is `_ALLOWED_URL`. Every call site supplies `repo_full_name`,
+# because the trusted origin is derived from the stored binding plus config and
+# the payload's clone URL is only ever compared against it (#1122).
+_REPO = "octo/demo-agent"
+_LOCAL_BASE = "file:///tmp/gitflow-none"
+_ALLOWED_URL = f"{_LOCAL_BASE}/{_REPO}.git"
+_GITHUB_URL = f"https://github.com/{_REPO}.git"
+
+
+def _local_settings() -> Settings:
+    """Settings whose derived origin for `_REPO` is exactly `_ALLOWED_URL`."""
+
+    return Settings(github_clone_base=_LOCAL_BASE)
 
 
 def _sign(body: bytes) -> str:
@@ -59,10 +73,16 @@ def test_environment_for_ref_requires_exact_head_ref() -> None:
 
 def test_clone_and_archive_refuses_disallowed_scheme() -> None:
     # ext:: is git's arbitrary-command transport; it must be refused before any
-    # subprocess runs, regardless of the allowlist.
-    settings = Settings()
-    with pytest.raises(GitFlowError):
-        clone_and_archive("ext::sh -c whoami", "0" * 40, settings)
+    # subprocess runs, regardless of the allowlist. The scheme allowlist runs
+    # BEFORE the origin comparator, so this must still fail on the scheme --
+    # asserting the error is not a CloneOriginMismatch pins that ordering.
+    settings = _local_settings()
+    with pytest.raises(GitFlowError) as err:
+        clone_and_archive(
+            "ext::sh -c whoami", "0" * 40, settings, repo_full_name=_REPO
+        )
+    assert not isinstance(err.value, CloneOriginMismatch)
+    assert "scheme" in str(err.value)
 
 
 @pytest.mark.parametrize(
@@ -89,10 +109,12 @@ def test_clone_and_archive_rejects_invalid_sha_before_any_subprocess(
 ) -> None:
     # An invalid ref must be refused by the format gate BEFORE git ever runs, so
     # a leading-dash sha can never reach `git archive` as an injected option.
-    settings = Settings()
+    # The clone URL here matches the derived origin, so the sha gate is provably
+    # what rejects, not the origin comparator.
+    settings = _local_settings()
     with mock.patch("curie_api.gitflow.subprocess.run") as run:
         with pytest.raises(GitFlowError):
-            clone_and_archive(_ALLOWED_URL, bad_sha, settings)
+            clone_and_archive(_ALLOWED_URL, bad_sha, settings, repo_full_name=_REPO)
     run.assert_not_called()
 
 
@@ -107,10 +129,12 @@ def test_clone_and_archive_accepts_valid_hex_and_inserts_dash_dash(
     # A full lowercase-hex SHA-1 or SHA-256 passes the format gate, and the
     # `git archive` argv must place a `--` separator immediately before the sha
     # so a value can never be parsed as a git option.
-    settings = Settings()
+    settings = _local_settings()
     with mock.patch("curie_api.gitflow.subprocess.run") as run:
         run.return_value = _completed(b"tar-bytes")
-        result = clone_and_archive(_ALLOWED_URL, good_sha, settings)
+        result = clone_and_archive(
+            _ALLOWED_URL, good_sha, settings, repo_full_name=_REPO
+        )
 
     assert result == b"tar-bytes"
 
@@ -121,47 +145,328 @@ def test_clone_and_archive_accepts_valid_hex_and_inserts_dash_dash(
     assert archive_argv[dash_index + 1] == good_sha, archive_argv
 
 
-def test_clone_authenticates_a_private_https_remote_without_touching_argv() -> None:
+def test_clone_refuses_a_foreign_host_before_any_subprocess() -> None:
+    # The ticket's exact attack (#1122): a correctly signed payload names a
+    # registered repository and an attacker-controlled clone URL. Before this
+    # guard the platform GitHub token was scoped to -- and therefore delivered
+    # to -- that attacker's host on the very first request.
+    settings = Settings(github_token="ghs-secret-token")
+    with mock.patch("curie_api.gitflow.subprocess.run") as run:
+        with pytest.raises(CloneOriginMismatch):
+            clone_and_archive(
+                f"https://evil.example/{_REPO}.git",
+                _VALID_SHA1,
+                settings,
+                repo_full_name=_REPO,
+            )
+    run.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "payload_url",
+    [
+        # Userinfo of any kind: a credential in the payload URL is never honored.
+        f"https://x-access-token:t@github.com/{_REPO}.git",
+        # The classic reviewer-fooling URL: hostname is evil.example, the
+        # "github.com" is the username. Fails on both host and userinfo.
+        f"https://github.com@evil.example/{_REPO}.git",
+        # A non-default port reaches a different service on the same host.
+        f"https://github.com:8443/{_REPO}.git",
+        # Scheme downgrade: a cleartext clone of a substituted bundle is still a
+        # deploy of attacker code under a registered agent's identity.
+        f"http://github.com/{_REPO}.git",
+        # Path prefix. Whole-key equality, never startswith -- this is the single
+        # most likely implementation bug in the change.
+        "https://github.com/octo/demo-agent-evil.git",
+        # Path suffix.
+        "https://github.com/octo/demo-agent/evil.git",
+        # Different owner.
+        "https://github.com/evil/demo-agent.git",
+        # IDN homograph: Cyrillic small i (U+0456) in "github". hostname
+        # lowercases but does not IDNA-normalize, so the strings simply differ.
+        f"https://gіthub.com/{_REPO}.git",
+        # Percent-encoded host: urlsplit does not decode escapes in the netloc.
+        f"https://%67ithub.com/{_REPO}.git",
+        # Trailing-dot host: resolves identically in DNS, mismatches here. Over
+        # strict on purpose; no real GitHub payload carries it.
+        f"https://github.com./{_REPO}.git",
+        # Query and fragment are both in the comparison key.
+        f"https://github.com/{_REPO}.git?x=1",
+        f"https://github.com/{_REPO}.git#x",
+        # Unparseable port: urlsplit().port raises ValueError, which must read as
+        # a mismatch rather than escaping the threadpool as a 500.
+        f"https://github.com:notaport/{_REPO}.git",
+        # Malformed IPv6 literal: urlsplit itself raises ValueError.
+        f"https://[::1/{_REPO}.git",
+    ],
+)
+def test_clone_refuses_every_mismatch_dimension_before_any_subprocess(
+    payload_url: str,
+) -> None:
+    # Every dimension AC1 names -- host, user information, port, normalized path
+    # -- plus the parse failures, rejected before tempfile.mkdtemp and before any
+    # subprocess. Anything not provably identical to the derived origin is a
+    # mismatch; that default is the design.
+    settings = Settings(github_token="ghs-secret-token")
+    with mock.patch("curie_api.gitflow.subprocess.run") as run:
+        with pytest.raises(CloneOriginMismatch):
+            clone_and_archive(
+                payload_url, _VALID_SHA1, settings, repo_full_name=_REPO
+            )
+    run.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "payload_url",
+    [
+        # GitHub's push payload sets clone_url with .git and url without it.
+        f"https://github.com/{_REPO}.git",
+        f"https://github.com/{_REPO}",
+        # Trailing slash, with and without .git before it. Stripping order
+        # matters: slashes, then one .git, then slashes again.
+        f"https://github.com/{_REPO}.git/",
+        f"https://github.com/{_REPO}/",
+        # An explicit default port is the same origin.
+        f"https://github.com:443/{_REPO}.git",
+        # urlsplit().hostname lowercases ASCII hosts.
+        f"https://GitHub.com/{_REPO}.git",
+    ],
+)
+def test_clone_accepts_the_registered_origin_in_its_equivalent_forms(
+    payload_url: str,
+) -> None:
+    # A legitimate push must not break. Each accepted form still results in git
+    # being handed the derived origin, never the payload string.
+    settings = Settings()
+    with mock.patch("curie_api.gitflow.subprocess.run") as run:
+        run.return_value = _completed(b"tar-bytes")
+        result = clone_and_archive(
+            payload_url, _VALID_SHA1, settings, repo_full_name=_REPO
+        )
+
+    assert result == b"tar-bytes"
+    assert _GITHUB_URL in run.call_args_list[0].args[0]
+
+
+def test_clone_refuses_a_mixed_case_scheme() -> None:
+    # `HTTPS://` is rejected by the PRE-EXISTING case-sensitive scheme allowlist
+    # at gitflow.py:131 (`clone_url.startswith(settings.git_allowed_schemes)`),
+    # which runs BEFORE the origin comparator -- not by the comparator, whose own
+    # scheme .lower() never gets the chance to accept this form. Asserting the
+    # error is not a CloneOriginMismatch is what pins that.
+    #
+    # This is deliberately a rejection, not an acceptance: no real GitHub webhook
+    # payload carries a mixed-case scheme, and case-folding that allowlist to
+    # make an accept-case go green would be widening a security gate to pass a
+    # test. Nobody may do that.
+    settings = Settings()
+    with mock.patch("curie_api.gitflow.subprocess.run") as run:
+        with pytest.raises(GitFlowError) as err:
+            clone_and_archive(
+                f"HTTPS://github.com/{_REPO}.git",
+                _VALID_SHA1,
+                settings,
+                repo_full_name=_REPO,
+            )
+    assert not isinstance(err.value, CloneOriginMismatch)
+    run.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "clone_base",
+    [
+        "github.com",  # no scheme at all
+        "ssh://git@github.com",  # a scheme outside the allowlist
+    ],
+)
+def test_clone_refuses_a_configured_base_outside_the_scheme_allowlist(
+    clone_base: str,
+) -> None:
+    # The scheme allowlist validates the PAYLOAD string, which is compared and
+    # then discarded. The string git actually receives is the derived
+    # `trusted_url`, and it is never checked against `git_allowed_schemes`. That
+    # is safe today only by transitivity through the origin comparison, and the
+    # design's own argument is that the comparison is not the protection.
+    #
+    # No payload can be constructed that both passes the payload allowlist AND
+    # matches a derived URL whose scheme is disallowed: the comparison key holds
+    # the scheme, so matching would require the payload to carry the disallowed
+    # scheme too, which the payload allowlist already refuses. That impossibility
+    # is exactly why the derived URL needs a check of its own, and it is why the
+    # assertion that matters here is the error TYPE. A misconfigured base must
+    # fail as a configuration error, not be mistaken for a forged push.
+    settings = Settings(github_token="ghs-secret-token", github_clone_base=clone_base)
+    with mock.patch("curie_api.gitflow.subprocess.run") as run:
+        with pytest.raises(GitFlowError) as err:
+            clone_and_archive(_GITHUB_URL, _VALID_SHA1, settings, repo_full_name=_REPO)
+    assert not isinstance(err.value, CloneOriginMismatch)
+    run.assert_not_called()
+
+
+def test_clone_refuses_a_configured_base_git_would_read_as_an_option() -> None:
+    # A `github_clone_base` beginning with a dash reaches argv construction as a
+    # positional that git parses as an option. `--upload-pack=` is the live
+    # payload: git clone runs it as a command against the remote. Operator
+    # supplied config is not attacker supplied, but a value that turns into a
+    # git option must be refused before any subprocess, exactly as a leading dash
+    # sha already is.
+    settings = Settings(
+        github_token="ghs-secret-token",
+        github_clone_base="--upload-pack=touch /tmp/pwned",
+    )
+    with mock.patch("curie_api.gitflow.subprocess.run") as run:
+        with pytest.raises(GitFlowError) as err:
+            clone_and_archive(_GITHUB_URL, _VALID_SHA1, settings, repo_full_name=_REPO)
+    assert not isinstance(err.value, CloneOriginMismatch)
+    run.assert_not_called()
+
+
+def test_clone_argv_inserts_dash_dash_before_the_url() -> None:
+    # Belt to the previous test's braces, and the half that survives someone
+    # relaxing the scheme gate later: `git clone` accepts `--` before its
+    # positional, so the URL can never be parsed as an option regardless of what
+    # configuration produced it. `git archive` already does this for the sha.
+    settings = Settings()
+    with mock.patch("curie_api.gitflow.subprocess.run") as run:
+        run.return_value = _completed(b"tar-bytes")
+        clone_and_archive(_GITHUB_URL, _VALID_SHA1, settings, repo_full_name=_REPO)
+
+    clone_argv = next(
+        call.args[0] for call in run.call_args_list if "clone" in call.args[0]
+    )
+    assert "--" in clone_argv, clone_argv
+    dash_index = clone_argv.index("--")
+    assert clone_argv[dash_index + 1] == _GITHUB_URL, clone_argv
+    assert dash_index > clone_argv.index("clone"), clone_argv
+
+
+def test_clone_accepts_a_well_formed_https_base() -> None:
+    # The control on the two rejection tests above: a guard that refused every
+    # configured base would satisfy them and break every real deploy. A
+    # well-formed https base must still reach git, carrying the derived URL.
+    base = "https://ghe.corp.example"
+    derived = f"{base}/{_REPO}.git"
+    settings = Settings(github_clone_base=base)
+    with mock.patch("curie_api.gitflow.subprocess.run") as run:
+        run.return_value = _completed(b"tar-bytes")
+        result = clone_and_archive(
+            derived, _VALID_SHA1, settings, repo_full_name=_REPO
+        )
+
+    assert result == b"tar-bytes"
+    assert derived in run.call_args_list[0].args[0]
+
+
+def test_clone_hands_git_the_derived_origin_not_the_payload_url() -> None:
+    # The load-bearing property: there is no code path from the payload's
+    # clone_url to subprocess.run. The payload value is compared and discarded;
+    # git receives a URL computed from configuration plus the stored binding, so
+    # even a normalization bug that wrongly ACCEPTS a hostile URL cannot leak the
+    # credential. This fails if an implementer keeps clone_url in the argv even
+    # with a correct comparison, which is the likeliest partial implementation.
+    payload_url = f"https://github.com/{_REPO}/"  # accepted, but not byte-equal
+    settings = Settings(github_token="ghs-secret-token")
+    with mock.patch("curie_api.gitflow.subprocess.run") as run:
+        run.return_value = _completed(b"tar-bytes")
+        clone_and_archive(payload_url, _VALID_SHA1, settings, repo_full_name=_REPO)
+
+    argv = run.call_args_list[0].args[0]
+    assert _GITHUB_URL in argv
+    assert payload_url not in argv
+    assert payload_url not in " ".join(argv)
+
+
+@pytest.mark.parametrize(
+    ("clone_base", "expected_key"),
+    [
+        ("https://github.com", "http.https://github.com/.extraheader"),
+        ("https://ghe.corp.example", "http.https://ghe.corp.example/.extraheader"),
+    ],
+)
+def test_clone_credential_is_keyed_to_the_derived_origin(
+    clone_base: str, expected_key: str
+) -> None:
     # A private repo is the normal case for a bundle -- it names internal hosts
     # and services -- so an unauthenticated clone made git-flow unusable (#1058).
     # The credential must ride in git config env, never in argv: argv is visible
     # in `ps` and is echoed verbatim by CalledProcessError.
-    settings = Settings(github_token="ghs-secret-token")
-    url = "https://github.com/acme/private-bundle.git"
+    #
+    # The GHE case is the half that proves the header is keyed to the DERIVED
+    # origin rather than coincidentally to github.com: change the configured
+    # base and the extraheader key follows it.
+    repo = "acme/private-bundle"
+    derived = f"{clone_base}/{repo}.git"
+    settings = Settings(github_token="ghs-secret-token", github_clone_base=clone_base)
     with mock.patch("curie_api.gitflow.subprocess.run") as run:
         run.return_value = _completed(b"tar-bytes")
-        clone_and_archive(url, _VALID_SHA1, settings)
+        clone_and_archive(derived, _VALID_SHA1, settings, repo_full_name=repo)
 
     clone_call = run.call_args_list[0]
     argv = clone_call.args[0]
     env = clone_call.kwargs["env"]
 
     assert "ghs-secret-token" not in " ".join(argv)
-    assert url in argv  # the URL itself is unmodified -- no embedded credential
+    assert derived in argv  # the derived URL, unmodified -- no embedded credential
     assert env["GIT_CONFIG_COUNT"] == "1"
-    # Scoped to this host, so a webhook naming another remote cannot harvest it.
-    assert env["GIT_CONFIG_KEY_0"] == "http.https://github.com/.extraheader"
+    assert env["GIT_CONFIG_KEY_0"] == expected_key
     assert env["GIT_CONFIG_VALUE_0"].startswith("Authorization: Basic ")
     decoded = base64.b64decode(env["GIT_CONFIG_VALUE_0"].split()[-1]).decode()
     assert decoded == "x-access-token:ghs-secret-token"
+
+
+def test_clone_pins_redirect_following_off() -> None:
+    # git 2.43.0. `git help config` on http.followRedirects: "If set to initial,
+    # git will follow redirects only for the initial request to a remote, but not
+    # for subsequent follow-up HTTP requests. [...] The default is initial." The
+    # request that carries the extraheader IS that initial request, so the
+    # default would let a redirect target receive it. `-c` must precede the
+    # `clone` subcommand to take effect.
+    #
+    # This is an argv-shape check and explicitly NOT the AC4 proof;
+    # test_gitflow_redirect.py proves it by executing git. This test exists to
+    # localize the failure when that one goes red.
+    settings = _local_settings()
+    with mock.patch("curie_api.gitflow.subprocess.run") as run:
+        run.return_value = _completed(b"tar-bytes")
+        clone_and_archive(_ALLOWED_URL, _VALID_SHA1, settings, repo_full_name=_REPO)
+
+    argv = run.call_args_list[0].args[0]
+    assert "-c" in argv, argv
+    flag_index = argv.index("-c")
+    assert argv[flag_index + 1] == "http.followRedirects=false", argv
+    assert flag_index + 1 < argv.index("clone"), argv
 
 
 def test_clone_sends_no_credential_when_none_is_configured() -> None:
     settings = Settings(github_token="")
     with mock.patch("curie_api.gitflow.subprocess.run") as run:
         run.return_value = _completed(b"tar-bytes")
-        clone_and_archive("https://github.com/acme/public.git", _VALID_SHA1, settings)
+        clone_and_archive(
+            "https://github.com/acme/public.git",
+            _VALID_SHA1,
+            settings,
+            repo_full_name="acme/public",
+        )
     env = run.call_args_list[0].kwargs["env"]
     assert "GIT_CONFIG_COUNT" not in env
 
 
 def test_clone_does_not_send_the_credential_over_plain_http() -> None:
     # http:// is in the transport allowlist for local/test remotes; a bearer
-    # token must not be handed to a cleartext endpoint.
-    settings = Settings(github_token="ghs-secret-token")
+    # token must not be handed to a cleartext endpoint. This is also why the AC4
+    # redirect proof must not assert on an absent Authorization header: over
+    # loopback http there was never going to be one.
+    settings = Settings(
+        github_token="ghs-secret-token", github_clone_base="http://insecure.example"
+    )
     with mock.patch("curie_api.gitflow.subprocess.run") as run:
         run.return_value = _completed(b"tar-bytes")
-        clone_and_archive("http://insecure.example/repo.git", _VALID_SHA1, settings)
+        clone_and_archive(
+            "http://insecure.example/repo.git",
+            _VALID_SHA1,
+            settings,
+            repo_full_name="repo",
+        )
     assert "GIT_CONFIG_COUNT" not in run.call_args_list[0].kwargs["env"]
 
 
@@ -169,13 +474,15 @@ def test_clone_failure_reports_git_stderr_not_the_exit_code() -> None:
     # The old message interpolated the exception, so an operator saw only
     # "returned non-zero exit status 128" while the actual reason -- captured in
     # stderr -- was discarded. That cost real debugging time on a private repo.
-    settings = Settings()
+    settings = _local_settings()
     failure = subprocess.CalledProcessError(
         128, ["git", "clone"], stderr=b"remote: Repository not found.\nfatal: could not read\n"
     )
     with mock.patch("curie_api.gitflow.subprocess.run", side_effect=failure):
         with pytest.raises(GitFlowError) as err:
-            clone_and_archive(_ALLOWED_URL, _VALID_SHA1, settings)
+            clone_and_archive(
+                _ALLOWED_URL, _VALID_SHA1, settings, repo_full_name=_REPO
+            )
     assert "Repository not found" in str(err.value)
 
 

--- a/charts/curie/templates/api.yaml
+++ b/charts/curie/templates/api.yaml
@@ -90,6 +90,8 @@ spec:
               value: {{ .Values.api.environment | quote }}
             - name: ORG_NAME
               value: {{ .Values.api.orgName | quote }}
+            - name: GITHUB_CLONE_BASE
+              value: {{ .Values.api.githubCloneBase | quote }}
             - name: LANGFUSE_HOST
               value: http://{{ include "curie.langfuse.webHost" . }}:{{ .Values.langfuse.web.service.port }}
             - name: LANGFUSE_PUBLIC_KEY

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -456,6 +456,11 @@ api:
   # fine-grained PAT or a GitHub App installation token is preferable to a
   # personal classic token, which carries the whole user's access.
   githubToken: ""
+  # The one git origin the API clones from for git-flow. A pushed repository
+  # whose clone URL does not resolve to `<githubCloneBase>/<repo_full_name>.git`
+  # is rejected with git.origin_mismatch. Set it to a GitHub Enterprise Server
+  # base to deploy from GHE.
+  githubCloneBase: "https://github.com"
   # How often (seconds) the API scans for lapsed pending approvals and resumes
   # their stranded sessions (#412). Set to 0 (or any value <= 0) to disable the
   # expiry sweeper entirely. Default matches the app's built-in 30s cadence.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -160,14 +160,19 @@ nothing's been deployed yet, `curie cluster message` will say so plainly.
 ### Automatically, with git-flow
 
 Beyond `curie cluster deploy`, a bundle can also deploy automatically on
-every `git push`. Three things need to be true for a push to actually
+every `git push`. Four things need to be true for a push to actually
 promote:
 
 1. **The agent's repo is set.** The webhook resolves which agent a push
    belongs to by matching the payload's `repo.full_name` (owner/name)
    against that agent's `repo_full_name`. This field is set when the agent
    is created (console or Curie API); `curie cluster deploy` only pushes a
-   bundle to an agent that already exists and does not set this field.
+   bundle to an agent that already exists and does not set this field. The
+   match is case sensitive, so the stored `repo_full_name` must match
+   GitHub's canonical owner and repository casing exactly, or the lookup
+   finds no agent, the push is silently ignored, and (unlike a rejection)
+   nothing is logged, so the only symptom is a green delivery in GitHub
+   with nothing deployed.
 2. **GitHub can reach the Curie API.** Add a webhook, in the repo's GitHub
    settings, to `<your-api-url>/github/webhook`. This requires the
    Curie API to be reachable from GitHub's servers (an ingress, a load
@@ -181,6 +186,14 @@ promote:
    kubectl get secret <release>-secrets -o jsonpath='{.data.githubWebhookSecret}' | base64 -d
    ```
    and paste it into the webhook's secret field.
+4. **The push comes from the configured clone origin.** The API derives the
+   trusted clone URL from `GITHUB_CLONE_BASE` (chart value
+   `api.githubCloneBase`), which defaults to `https://github.com`, and
+   rejects any push whose `clone_url` doesn't match with the error code
+   `git.origin_mismatch` -- the webhook still returns 200, so this fails
+   silently from GitHub's side. The default covers github.com with no extra setup; set
+   `GITHUB_CLONE_BASE` (or the chart's `api.githubCloneBase`) if your repos
+   live elsewhere, such as GitHub Enterprise Server.
 
 Once wired, a push to the agent's dev branch builds and deploys under its
 dev bot identity; a push or merge to its prod branch promotes that same


### PR DESCRIPTION
Closes #1122

## What changed

`process_push` validated the payload's `repository.full_name` against the bound agent but handed the same payload's `repository.clone_url` to a clone carrying the platform GitHub token in an `http.<host>/.extraheader` header, scoped to that URL's own host. A holder of the shared webhook signing secret could name a legitimately registered repository and point `clone_url` at a host they control.

git is now handed a clone origin **derived** from the new `github_clone_base` setting plus the `repo_full_name` read from the database row. The payload URL is compared against the derived one under a normalizing key (host, user information, port, normalized path, query, fragment) and then discarded.

The comparison is not what protects the credential. The protection is that the URL git receives and the URL the auth header is keyed to are both computed from configuration plus a database row, so there is no code path from `payload["repository"]["clone_url"]` to `subprocess.run`. A normalization bug could mis-report an outcome but cannot leak the token. `clone_and_archive` takes `repo_full_name` as a required keyword-only parameter so a caller cannot invoke it without supplying the identity the origin derives from.

`http.followRedirects=false` is pinned because git's default is `initial`, meaning it follows the redirect on the very request carrying the header. Verified against `git help config` on git 2.43.0.

## Acceptance criteria

1. Origin derived from the stored binding, mismatch rejected before a subprocess. Met.
2. Signed mismatched payload returns rejected, no git process starts. Met, asserted through the HMAC-signed webhook endpoint plus `run.assert_not_called()`.
3. A matching private GitHub repository still clones. Met by a live pass, since the suite has no github.com access by design. A real private repo cloned through `clone_and_archive` with a real token and the redirect pin in place, returning a 30720 byte archive.
4. Cross host redirects cannot receive the credential. Met by `test_gitflow_redirect.py`, which runs real git against two loopback servers and asserts the redirect target received zero requests, with a control proving an unpinned git does reach it.

Guard demonstrated by execution: foreign host, user information, path prefix, and port mismatches, plus a misconfigured base, each rejected with zero git processes spawned.

## Out-of-scope hunks, annotated

- **`--` separator in the clone argv.** Inert on every currently reachable input, since the derived-URL scheme check already refuses any base not starting with an allowlisted scheme and none of the three permitted schemes admits a leading dash. Kept as defense in depth at a credential-bearing subprocess boundary, specifically for the case where the scheme gate is later relaxed. Flagged LOW creep in review and retained deliberately.
- **Chart exposure of `GITHUB_CLONE_BASE`.** Initially deferred, then pulled in when review showed the deferral's premise was false. Before this change a GitHub Enterprise install deployed through git-flow with zero configuration because the payload's `clone_url` was used verbatim; after it, every such push is rejected and the api container has no `extraEnv` lever. That made it a regression introduced here, not a missing feature, so it is fixed in the same PR per the parity-seam rule.

## Follow-ups filed

- #1139 (HIGH, pre-existing): a signed push can deploy any commit in the repository, including an untrusted fork's PR head, because `--mirror` fetches `refs/pull/*/head` and the sha is never proven reachable from the pushed branch. This PR closes the credential exfiltration path only; the secret-holder threat is not fully closed.
- #1140: validate and encode `repo_full_name` before interpolating it into URLs.
- #1141: expose `GITHUB_API_URL` as a chart value, the unplumbed sibling of `githubCloneBase`.

## Done-check

- Failing tests committed before implementation: yes, tests in `4454f57a` preceded implementation in `ef948619` before squash.
- All production-code edits delegated, no inline driver edits: yes.
- Broadened return types: none reported; `clone_and_archive` still returns `bytes` and `CloneOriginMismatch` subclasses `GitFlowError`, so existing handlers still catch it.
- Code review: findings closed, including a re-review that caught a wrong attribution in the case-sensitivity documentation. A mis-cased binding fails the agent lookup, so the push is ignored and never logged, rather than rejected; the docs now say that.
- Scope review: 0 unmapped hunks on the first pass; the one LOW item from the delta pass is annotated above.
- Sibling-path parity: the credentialed-clone sibling set is one, confirmed independently by two reviewers. The chart sibling is covered here; `GITHUB_API_URL` is #1141.
- Guard demonstration by execution: done, output above.
- Consolidation pass: ran across reuse, simplification, efficiency, and altitude. Efficiency and altitude clean. Two findings skipped: extracting a shared test fixture into `packages/test-support` would widen a security fix into a shared package, and parametrizing the two integration rejection tests would trade duplication for a conditional inside the test body.
- Security review: no blocking findings. The claimed property was independently falsified and held.
- E2E: live private-repo clone plus live guard rejection.
- Full suite: 2240 passed, 5 skipped.
- Lint: `ruff`, `mypy` (165 files), `scripts/check-docs.sh`, and `scripts/check-commit-messages.sh` all clean.
