### PR TITLE
Refuse an unknown key in a --routes-from file instead of stripping it

### DIFF
--- a/apps/api/src/curie_api/slack_approvers.py
+++ b/apps/api/src/curie_api/slack_approvers.py
@@ -197,9 +197,21 @@ def _parse_approvers(
     binding: malformed approvers content fails closed here rather than becoming
     an unenforceable binding. A typo'd sibling key (``approver`` for
     ``approvers``) is caught at write time instead, by the model's
-    ``extra="forbid"``, which is sufficient because the API is the binding's
-    only writer. Absent and null are treated identically -- bindings written
-    before #420 have no key at all.
+    ``extra="forbid"``.
+
+    That guard used to be described here as sufficient because the API was the
+    binding's only writer. It no longer is: the CLI's ``--routes-from`` (#1057)
+    is a second writer, and because it parsed the operator's file into a struct
+    and re-serialized it, the operator's own bytes never reached this model at
+    all -- an unknown key was dropped before the request was built, and the
+    channel-only binding that survived widened the approver set to the whole
+    card channel (#1072). Each writer now refuses unknown keys on its own input
+    (``cli/src/api.rs``'s ``RouteBindingInput``); this model stays the
+    authoritative gate for anything that does reach it. A future writer that
+    re-serializes rather than forwarding raw bytes owes the same check.
+
+    Absent and null are treated identically -- bindings written before #420
+    have no key at all.
 
     A binding that is present but not a JSON object (a hand-edited JSONB row, a
     future writer bug) fails closed here, distinct from the absent None above: a

--- a/cli/api-mirrors.json
+++ b/cli/api-mirrors.json
@@ -29,6 +29,16 @@
       "omissions": []
     },
     {
+      "struct": "RouteBindingInput",
+      "schema": "ApprovalRouteBinding",
+      "omissions": []
+    },
+    {
+      "struct": "ApproversInput",
+      "schema": "ApprovalApprovers",
+      "omissions": []
+    },
+    {
       "struct": "ApprovalRecord",
       "schema": "ApprovalOut",
       "omissions": [

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -85,6 +85,64 @@ pub struct ApprovalApprovers {
     pub users: Option<Vec<String>>,
 }
 
+// --- The input side of the same contract (#1072) -------------------------------
+//
+// The two structs above decode API RESPONSES and must stay tolerant: a field a
+// newer server adds should not break an older CLI. The two below decode an
+// OPERATOR-AUTHORED `--routes-from` file and must do the opposite.
+//
+// The asymmetry is the whole fix, so the pair lives here next to its lenient
+// twin rather than off in the command module. A typo'd key in a route file is
+// not a harmless unknown: dropping `approver` (for `approvers`) leaves a
+// channel-only binding, and a binding with no approvers block falls back to
+// card-channel membership, so the operator who meant to narrow authority to one
+// group has instead granted it to everyone in the channel.
+//
+// The API already guards this with `extra="forbid"` on `ApprovalRouteBinding`,
+// on the stated premise that it is the binding's only writer. #1057 made the
+// CLI a second writer and re-serialized a parsed struct, so the operator's own
+// bytes never reached that guard. This restores it on the writer that bypassed
+// it, and follows the convention `cli/src/spec.rs` already states for
+// operator-authored files: an authoring typo fails loud rather than silently
+// dropping the intended field.
+
+/// One route binding as written in a `--routes-from` file. Strict by design.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RouteBindingInput {
+    pub channel: String,
+    #[serde(default)]
+    pub approvers: Option<ApproversInput>,
+}
+
+/// An `approvers` block as written in a `--routes-from` file. Strict by design.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ApproversInput {
+    #[serde(default)]
+    pub group: Option<String>,
+    #[serde(default)]
+    pub users: Option<Vec<String>>,
+}
+
+impl From<ApproversInput> for ApprovalApprovers {
+    fn from(input: ApproversInput) -> Self {
+        ApprovalApprovers {
+            group: input.group,
+            users: input.users,
+        }
+    }
+}
+
+impl From<RouteBindingInput> for ApprovalRouteBinding {
+    fn from(input: RouteBindingInput) -> Self {
+        ApprovalRouteBinding {
+            channel: input.channel,
+            approvers: input.approvers.map(Into::into),
+        }
+    }
+}
+
 /// One approval record, hand-mirroring the committed `ApprovalOut` (#506). Only
 /// the fields the CLI renders are modeled; serde ignores the rest of the payload.
 #[derive(Debug, Clone, Deserialize)]

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -3990,19 +3990,46 @@ fn build_route_bindings(
                 path.display()
             ))
         })?;
-        bindings = serde_json::from_str(&text).map_err(|e| {
-            crate::exit::usage(format!(
-                "--routes-from {}: {e}; expected JSON shaped \
-                 {{\"<route>\": {{\"channel\": \"C0123ABCD\", \
-                 \"approvers\": {{\"group\": \"S0123ABCD\"}}}}}}",
-                path.display()
-            ))
-        })?;
-        for (name, binding) in &bindings {
-            validate_route_channel(name, &binding.channel)?;
+        // Decode in two steps rather than straight into the binding map, so an
+        // unknown key can be reported against the ROUTE that carries it. Serde's
+        // own error names the key but not which entry of the map it came from,
+        // and "unknown field `approver`" with no route is a poor thing to hand
+        // someone holding a twenty-route file.
+        let raw: BTreeMap<String, serde_json::Value> =
+            serde_json::from_str(&text).map_err(|e| {
+                crate::exit::usage(format!(
+                    "--routes-from {}: {e}; expected JSON shaped \
+                     {{\"<route>\": {{\"channel\": \"C0123ABCD\", \
+                     \"approvers\": {{\"group\": \"S0123ABCD\"}}}}}}",
+                    path.display()
+                ))
+            })?;
+        for (name, value) in raw {
+            // RouteBindingInput is the strict, operator-file twin of the
+            // response-side type: it refuses an unknown key instead of dropping
+            // it (#1072). A dropped `approver` would leave a channel-only
+            // binding, which widens the approver set to the whole card channel.
+            let input: crate::api::RouteBindingInput =
+                serde_json::from_value(value).map_err(|e| {
+                    anyhow::Error::from(
+                        crate::exit::CliError::usage(format!(
+                            "--routes-from {}: route {name:?}: {e}",
+                            path.display()
+                        ))
+                        .with_fix(
+                            "a route binding takes `channel` and an optional `approvers` \
+                             block of `group` or `users`, and nothing else. A dropped \
+                             sibling key would leave a channel-only binding, which makes \
+                             every member of that channel an approver",
+                        ),
+                    )
+                })?;
+            let binding: crate::api::ApprovalRouteBinding = input.into();
+            validate_route_channel(&name, &binding.channel)?;
             if let Some(approvers) = &binding.approvers {
-                validate_parsed_approvers(name, approvers)?;
+                validate_parsed_approvers(&name, approvers)?;
             }
+            bindings.insert(name, binding);
         }
     }
 

--- a/cli/tests/approval_route_bindings.rs
+++ b/cli/tests/approval_route_bindings.rs
@@ -580,6 +580,107 @@ async fn routes_from_seeds_the_map_and_flags_override_it() {
 }
 
 #[tokio::test]
+async fn a_routes_file_with_an_unknown_binding_key_writes_nothing() {
+    // #1072: the typo that matters. `approver` (for `approvers`) used to be
+    // silently stripped, and the write that landed was a channel-only binding --
+    // which falls back to card-channel membership, so an operator who meant to
+    // narrow authority to one group had instead granted it to everyone in the
+    // channel. The API guards this with `extra="forbid"`; #1057 made the CLI a
+    // second writer that re-serialized a parsed struct, so the operator's bytes
+    // never reached that guard.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("routes.json");
+    std::fs::write(
+        &path,
+        r#"{"deal_desk":{"channel":"C0GENERAL0","approver":{"group":"S0DESKGRP"}}}"#,
+    )
+    .expect("write");
+
+    let server = stub("null", "null");
+
+    let Err(err) = run(
+        &server,
+        ApprovalCmd {
+            routes_from: Some(path),
+            ..ApprovalCmd::default()
+        },
+    )
+    .await
+    else {
+        panic!("an unknown key at the binding level must be refused, not stripped");
+    };
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("approver"),
+        "the error must name the key: {msg}"
+    );
+    assert!(
+        msg.contains("deal_desk"),
+        "the error must name the route carrying it: {msg}"
+    );
+    assert_no_write(&server);
+}
+
+#[tokio::test]
+async fn a_routes_file_with_an_unknown_approvers_key_writes_nothing() {
+    // The sibling case one level down. Already refused before #1072 (the
+    // approvers block was validated when present), and it must stay refused --
+    // the fix moved where parsing happens, so this pins that it did not regress.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("routes.json");
+    std::fs::write(
+        &path,
+        r#"{"finance":{"channel":"C0FINANCE0","approvers":{"grup":"S0FINGRP0"}}}"#,
+    )
+    .expect("write");
+
+    let server = stub("null", "null");
+
+    let Err(err) = run(
+        &server,
+        ApprovalCmd {
+            routes_from: Some(path),
+            ..ApprovalCmd::default()
+        },
+    )
+    .await
+    else {
+        panic!("an unknown key inside approvers must be refused");
+    };
+
+    assert!(err.to_string().contains("grup"), "unexpected error: {err}");
+    assert_no_write(&server);
+}
+
+#[tokio::test]
+async fn an_api_response_tolerates_a_field_the_cli_does_not_model() {
+    // The other half of the #1072 asymmetry, and the reason the fix is a second
+    // struct rather than `deny_unknown_fields` on the existing one: the RESPONSE
+    // side must keep decoding a binding a newer server has added a field to,
+    // or an older CLI breaks against a newer platform.
+    let bound = r#"{"deal_desk":{"channel":"C0MANAGERS","escalation_after_s":3600}}"#;
+    let server = stub(bound, bound);
+
+    let out = run(
+        &server,
+        ApprovalCmd {
+            list_routes: true,
+            ..ApprovalCmd::default()
+        },
+    )
+    .await
+    .expect("an unmodeled server field must not break the read");
+
+    match out {
+        ApprovalsOutput::Routes { routes, .. } => {
+            assert_eq!(routes["deal_desk"].channel, "C0MANAGERS");
+        }
+        _ => panic!("expected the Routes output"),
+    }
+}
+
+#[tokio::test]
 async fn a_malformed_routes_file_writes_nothing() {
     let dir = tempfile::tempdir().expect("tempdir");
     let path = dir.path().join("routes.json");


### PR DESCRIPTION
Closes #1072.

## What this fixes

A `--routes-from` file with a typo'd key was accepted, the key was silently stripped, and the binding that survived was written on exit 0. For `approver` (for `approvers`) what survives is a channel-only binding, and a binding with no approvers block falls back to card-channel membership. An operator who wrote `"approver": {"group": "S0DESKGRP"}` believing only that group could approve had instead made **every member of the card channel an approver**.

The reproduction from the issue, before and after:

```
$ curie local approvals deal-desk --routes-from routes.json     # before
updating approval routes for deal-desk: ok (0.0s)
deal_desk     channel C0GENERAL0
                approvers: members of C0GENERAL0 (the default: no approvers block declared)
EXIT=0        captured PATCH: {"approval_routes":{"deal_desk":{"channel":"C0GENERAL0"}}}

$ curie local approvals deal-desk --routes-from routes.json --json     # after
{"error":"--routes-from routes.json: route \"deal_desk\": unknown field `approver`, expected `channel` or `approvers`",
 "fix":"a route binding takes `channel` and an optional `approvers` block of `group` or `users`, and nothing else. A dropped sibling key would leave a channel-only binding, which makes every member of that channel an approver"}
EXIT=2        no PATCH sent
```

## Why a second struct rather than `deny_unknown_fields`

The issue already called this out and it is the load-bearing part of the design. `ApprovalRouteBinding` and `ApprovalApprovers` decode **API responses** as well, where refusing a field a newer server adds would break an older CLI against a newer platform. Adding `deny_unknown_fields` to them would trade one brittleness for another.

So the input side gets its own pair, `RouteBindingInput` and `ApproversInput`, strict by construction, with `From` conversions into the wire types. They live in `cli/src/api.rs` next to their lenient twins rather than off in the command module, because **the asymmetry between the two directions is the point** and a reader should meet both halves in one place. This also matches the convention `cli/src/spec.rs` already states for operator-authored files: an authoring typo fails loud rather than silently dropping the intended field.

## Why the file is decoded in two steps

Straight into `BTreeMap<String, RouteBindingInput>`, serde's error names the key but not which map entry carried it. `unknown field 'approver'` with no route name is a poor thing to hand someone holding a twenty-route file. Decoding to `serde_json::Value` first and converting per entry lets the refusal name the route.

## The premise this restores, and the comment it corrects

`apps/api/src/curie_api/slack_approvers.py` recorded why `extra="forbid"` was sufficient:

> A typo'd sibling key (`approver` for `approvers`) is caught at write time instead, by the model's `extra="forbid"`, **which is sufficient because the API is the binding's only writer.**

#1057 invalidated that sentence. Rather than delete it, the docstring now records what happened: the CLI became a second writer, re-serializing rather than forwarding meant the operator's bytes never reached the model, each writer now refuses unknown keys on its own input, and **a future writer that re-serializes owes the same check**. The API model stays the authoritative gate for anything that does reach it.

## Tests

Three new cases in `cli/tests/approval_route_bindings.rs`, all asserting the wire (or its absence):

| Test | What it pins |
|---|---|
| `a_routes_file_with_an_unknown_binding_key_writes_nothing` | The issue's reproduction: refused, names both the key and the route, **no PATCH recorded** |
| `a_routes_file_with_an_unknown_approvers_key_writes_nothing` | The sibling one level down was already refused; the fix moved where parsing happens, so this pins it did not regress |
| `an_api_response_tolerates_a_field_the_cli_does_not_model` | The other half of the asymmetry: a response carrying `escalation_after_s` still decodes |

The existing `a_malformed_routes_file_writes_nothing` covered only a bad channel *value*, which is why the key case slipped through.

## Verification

```
cargo fmt --check                            OK
cargo clippy --all-targets -- -D warnings    OK
cargo test                                   37 binaries, 956 tests, 0 failures
curie dev field-parity                       OK  (both new structs declared in api-mirrors.json)
curie dev emit-parity                        OK
uv run ruff check .                          All checks passed
uv run mypy                                  no issues in 165 source files
```

Hands-on against the binary built from this branch: the issue's reproduction exits 2 with the route named, and a well-formed file still plans the identical PATCH it did before.

## Notes for review

- `RouteBindingInput` and `ApproversInput` are declared in `cli/api-mirrors.json` as full mirrors of `ApprovalRouteBinding` / `ApprovalApprovers` with no omissions, so the field-parity gate covers them and a future server-side field addition surfaces on the input side too.
- Scope held deliberately to the file path. `--route` and `--route-approvers` parse from flag syntax and were already refusing bad input (the issue's own scope table confirms this); nothing about them changed.
