### PR TITLE
Tell the clicker when a fall-forward resolve is refused

### DIFF
--- a/apps/dispatcher/src/curie_dispatcher/approval_actions.py
+++ b/apps/dispatcher/src/curie_dispatcher/approval_actions.py
@@ -386,18 +386,24 @@ def open_note_dialog(
         resolver=resolver,
         log=log,
     )
+    # Every outcome is rendered, not just the success (#1085). The in-view error
+    # channel the submit path uses cannot fire here -- there is no view, that is
+    # why we are on this path at all -- so the ephemeral is the ONLY surface left.
+    # Reporting only the 200 left a refused clicker with total silence, which for
+    # a non-approver is indistinguishable from the platform being down, and for an
+    # expired approval hides the one fact they need.
     if outcome.status_code == 200:
-        _ephemeral(
-            web_client,
-            channel=channel,
-            user=user,
-            text=(
-                "The note box could not be opened, so this was resolved without a "
-                "note. Add one with `curie <tier> approvals <agent> --resolve` if "
-                "it matters."
-            ),
-            log=log,
+        text = (
+            "The note box could not be opened, so this was resolved without a "
+            "note. Add one with `curie <tier> approvals <agent> --resolve` if "
+            "it matters."
         )
+    else:
+        # The same wording the in-view path renders, so a refusal reads
+        # identically whether or not the dialog managed to open, and the three
+        # refusal classes stay distinguishable (#453 AC5).
+        text = _refusal_text(outcome)
+    _ephemeral(web_client, channel=channel, user=user, text=text, log=log)
     return outcome
 
 

--- a/apps/dispatcher/tests/test_approval_note_dialog.py
+++ b/apps/dispatcher/tests/test_approval_note_dialog.py
@@ -415,6 +415,82 @@ def test_a_failed_views_open_falls_forward_and_resolves(
     assert "note" in web_client.chat_postEphemeral.call_args.kwargs["text"].lower()
 
 
+def test_a_failed_views_open_reports_a_403_refusal_to_the_clicker(
+    redis_client: redis.Redis, config: DispatcherConfig
+) -> None:
+    """#1085: the fall-forward handled one failure but not two.
+
+    When ``views.open`` fails AND the fall-forward resolve is then refused, the
+    in-view error channel cannot fire (there is no view, that is why we are on
+    this path) and the ephemeral used to be gated on a 200. The clicker got
+    nothing at all, which for a non-approver is indistinguishable from the
+    platform being down.
+    """
+
+    resolver = ScriptedResolver(
+        ResolveOutcome(
+            status_code=403,
+            detail="self-approval is blocked: the requester cannot resolve their own request",
+        )
+    )
+    app, web_client = _build(config, redis_client, resolver, views_open_raises=True)
+    handler = SocketModeHandler(app, app_token="xapp-test")
+
+    handler.handle(FakeSocketClient(), _note_click("env-n9", action_id=APPROVE_NOTE_ACTION_ID))
+    _drain(app)
+
+    assert len(resolver.calls) == 1, "the fall-forward must still attempt the resolve"
+    web_client.chat_postEphemeral.assert_called_once()
+    text = web_client.chat_postEphemeral.call_args.kwargs["text"]
+    # The API's own reason, verbatim: the refusal classes stay distinguishable
+    # (#453 AC5), so this must not read like a generic failure.
+    assert "self-approval is blocked" in text, text
+    # A refusal is not a resolution: the card keeps its live buttons.
+    web_client.chat_update.assert_not_called()
+
+
+def test_a_failed_views_open_reports_an_expiry_to_the_clicker(
+    redis_client: redis.Redis, config: DispatcherConfig
+) -> None:
+    """The 410 sibling of the case above, and the one where silence costs most:
+    the clicker's only question is why nothing happened, and expiry is the
+    answer."""
+
+    resolver = ScriptedResolver(ResolveOutcome(status_code=410, detail="approval expired"))
+    app, web_client = _build(config, redis_client, resolver, views_open_raises=True)
+    handler = SocketModeHandler(app, app_token="xapp-test")
+
+    handler.handle(FakeSocketClient(), _note_click("env-n10", action_id=REJECT_NOTE_ACTION_ID))
+    _drain(app)
+
+    web_client.chat_postEphemeral.assert_called_once()
+    text = web_client.chat_postEphemeral.call_args.kwargs["text"]
+    assert "expired" in text.lower(), text
+    web_client.chat_update.assert_not_called()
+
+
+def test_the_fall_forward_ephemeral_matches_the_in_view_wording(
+    redis_client: redis.Redis, config: DispatcherConfig
+) -> None:
+    """One refusal, one wording, whichever surface it lands on.
+
+    The two paths differ only in WHERE a refusal is rendered (an ephemeral when
+    no view opened, the view's own ack when one did). If they worded it
+    differently, the same refusal would read as two different problems.
+    """
+
+    outcome = ResolveOutcome(status_code=409, resolved_by="U_FIRST")
+    resolver = ScriptedResolver(outcome)
+    app, web_client = _build(config, redis_client, resolver, views_open_raises=True)
+    handler = SocketModeHandler(app, app_token="xapp-test")
+
+    handler.handle(FakeSocketClient(), _note_click("env-n11", action_id=APPROVE_NOTE_ACTION_ID))
+    _drain(app)
+
+    web_client.chat_postEphemeral.assert_called_once()
+    assert web_client.chat_postEphemeral.call_args.kwargs["text"] == _refusal_text(outcome)
+
+
 def test_the_ack_lands_before_any_slack_call_on_the_submit_path(
     redis_client: redis.Redis, config: DispatcherConfig
 ) -> None:


### PR DESCRIPTION
Closes #1085.

## What this fixes

The note dialog's fall-forward handled one failure but not two.

`views.open` fails (a `trigger_id` lasts about three seconds), so `open_note_dialog` resolves without a note and posts an ephemeral explaining the note step was skipped. But that ephemeral was gated on success:

```python
if outcome.status_code == 200:
    _ephemeral(... "The note box could not be opened, so this was resolved without a note. ...")
```

If the fall-forward resolve was then **refused**, the human got nothing at all. The in-view error rendering #1059 built cannot cover this case: there is no view, which is precisely why this path is running. So the ephemeral was the only surface left, and it was the one being skipped. Only a 409 produced anything visible, and only indirectly, by refreshing the shared card rather than telling the clicker.

They clicked a button and got silence. For a non-approver that is indistinguishable from the platform being down; for an expired approval it hides the one fact they need.

## The change

Nine lines. Every outcome renders; a refusal reuses `_refusal_text`, the same function the in-view path already uses:

```python
if outcome.status_code == 200:
    text = "The note box could not be opened, so this was resolved without a note. ..."
else:
    text = _refusal_text(outcome)
_ephemeral(web_client, channel=channel, user=user, text=text, log=log)
```

Sharing `_refusal_text` is deliberate rather than convenient: the two paths differ only in **where** a refusal is rendered, so if they worded it differently the same refusal would read as two different problems. It also keeps the three refusal classes distinguishable (#453 AC5) instead of collapsing into a generic failure.

## Tests

Three new cases, each of which **fails on the pre-fix code**. Verified by stashing only the source change and re-running:

```
FAILED test_a_failed_views_open_reports_a_403_refusal_to_the_clicker
FAILED test_a_failed_views_open_reports_an_expiry_to_the_clicker
FAILED test_the_fall_forward_ephemeral_matches_the_in_view_wording
3 failed, 18 deselected
```

then with the fix restored: `3 passed`.

| Test | What it pins |
|---|---|
| `..._reports_a_403_refusal_to_the_clicker` | The self-approval reason reaches the clicker **verbatim**, not as a generic failure. Also asserts `chat_update` is **not** called: a refusal is not a resolution, so the card keeps its live buttons. |
| `..._reports_an_expiry_to_the_clicker` | The 410 names the expiry. Same no-stamp assertion. |
| `the_fall_forward_ephemeral_matches_the_in_view_wording` | The ephemeral text **equals** `_refusal_text(outcome)` for the same outcome, so the two surfaces cannot drift apart in wording later. |

The existing `test_a_failed_views_open_falls_forward_and_resolves` (the 200 path) is unchanged and still passes, so the success ephemeral keeps its current text as the issue's ACs require.

## Verification

Run with the dev-stack Valkey and Postgres up (the dispatcher approval suites skip without Valkey, and the worker binding suite needs Postgres):

```
uv run ruff check .                          All checks passed
uv run mypy                                  no issues in 165 source files
uv run pytest apps/dispatcher apps/worker    651 passed, 11 skipped
```

## Notes for review

- **Scope is one file.** `approval_actions.py` only, as the issue scoped it. The in-view rendering path is untouched: refusals with an open view still come back as `response_action: "errors"`.
- **No new wording was invented.** The refusal text is whatever `_refusal_text` already produces, so nothing here needs to be kept in sync with the API's reason strings by hand.
