### PR TITLE
Reject a server declared in both connectors.yaml and MCP config (#1118)

### DIFF
--- a/packages/plugin-format/README.md
+++ b/packages/plugin-format/README.md
@@ -73,6 +73,7 @@ returns actionable, path-qualified issues instead of raising:
 
 ```python
 from plugin_format import validate_bundle
+
 result = validate_bundle("path/to/bundle")
 if not result.valid:
     for issue in result.errors:

--- a/packages/plugin-format/src/plugin_format/connector_render.py
+++ b/packages/plugin-format/src/plugin_format/connector_render.py
@@ -97,9 +97,7 @@ def service_dns(release: str, agent: str, connector: str, namespace: str) -> str
     return f"{object_name(release, agent, connector)}.{namespace}.svc.cluster.local"
 
 
-def host_aliases(
-    release: str, agent: str, connector: str, namespace: str, port: int
-) -> list[str]:
+def host_aliases(release: str, agent: str, connector: str, namespace: str, port: int) -> list[str]:
     """Every name the sandbox might use to reach this connector.
 
     Passed to servers that validate the Host header. Curie created the Service,
@@ -115,9 +113,7 @@ def host_aliases(
     ]
 
 
-def render_service(
-    release: str, agent: str, connector: str, spec: ConnectorSpec
-) -> dict[str, Any]:
+def render_service(release: str, agent: str, connector: str, spec: ConnectorSpec) -> dict[str, Any]:
     name = object_name(release, agent, connector)
     return {
         "apiVersion": "v1",

--- a/packages/plugin-format/src/plugin_format/validate.py
+++ b/packages/plugin-format/src/plugin_format/validate.py
@@ -14,7 +14,7 @@ import yaml
 from pydantic import BaseModel, TypeAdapter, ValidationError
 
 from .approval_policy import declared_mcp_server_names, effective_tool_prefix, grantable_routes
-from .connectors import validate_connectors
+from .connectors import ConnectorsFile, validate_connectors
 from .manifest import resolve_manifest
 from .models import (
     _TRIGGER_TYPES,
@@ -106,9 +106,43 @@ def _validate_connectors(root: Path, c: _Collector) -> None:
     except (OSError, yaml.YAMLError) as exc:
         c.error("connectors.unreadable", f"{CONNECTORS_FILE}: {exc}", CONNECTORS_FILE)
         return
-    _, errors = validate_connectors(data)
+    parsed, errors = validate_connectors(data)
     for code, message in errors:
         c.error(code, message, CONNECTORS_FILE)
+    if parsed is not None:
+        _reject_connector_name_collisions(root, parsed, c)
+
+
+def _reject_connector_name_collisions(root: Path, parsed: ConnectorsFile, c: _Collector) -> None:
+    """Reject a server name declared in BOTH ``connectors.yaml`` and MCP config.
+
+    Curie injects the connector's entry into the agent's MCP configuration
+    (ADR-0086) alongside whatever the bundle declares. When both name the same
+    server, which one the agent ends up talking to is decided downstream, and
+    the loser is overridden with no diagnostic -- so the author's committed
+    ``.mcp.json`` entry could be silently ignored, or could silently win over
+    the objects Curie actually created.
+
+    Neither outcome should be discoverable only at turn time, and a precedence
+    rule would just be a thing to remember. One name, one owner: say so here,
+    where the fix is a one-line edit.
+    """
+
+    declared = declared_mcp_server_names(root)
+    if declared is None:
+        # A declaration exists but is unreadable. `_validate_mcp` already errors
+        # on that; cross-checking a partial set would add a confusing second
+        # error about a name we cannot actually confirm.
+        return
+    for name in sorted(set(parsed.connectors) & declared):
+        c.error(
+            "connectors.duplicate_server",
+            f"connectors.{name}: `{name}` is declared in both {CONNECTORS_FILE} and the "
+            "bundle's MCP config. Curie derives this server's URL from the Service it "
+            f"creates, so remove the `{name}` entry from the MCP config and let "
+            f"{CONNECTORS_FILE} own it.",
+            CONNECTORS_FILE,
+        )
 
 
 def _validate_manifest(root: Path, c: _Collector) -> PluginManifest | None:

--- a/packages/plugin-format/tests/test_approval_policy.py
+++ b/packages/plugin-format/tests/test_approval_policy.py
@@ -24,9 +24,7 @@ def test_empty_input_yields_empty_map_and_no_ambiguity() -> None:
 
 
 def test_single_grantable_gate_maps_route_to_tool() -> None:
-    routes, ambiguous = grantable_routes(
-        [_gate("close_issue", "deal-desk", grantable=True)]
-    )
+    routes, ambiguous = grantable_routes([_gate("close_issue", "deal-desk", grantable=True)])
     assert routes == {"deal-desk": "close_issue"}
     assert ambiguous == set()
 

--- a/packages/plugin-format/tests/test_connectors.py
+++ b/packages/plugin-format/tests/test_connectors.py
@@ -155,3 +155,43 @@ def test_bundle_with_a_valid_connector_passes(tmp_path: Path) -> None:
         "    secrets: [GRAFANA_TOKEN]\n",
     )
     assert validate_bundle(str(root)).valid
+
+
+# --------------------------------------------------------------------------- #
+# One name, one owner (#1118)
+# --------------------------------------------------------------------------- #
+def test_a_name_in_both_connectors_yaml_and_mcp_json_is_rejected(tmp_path: Path) -> None:
+    # Curie injects the connector's entry alongside whatever the bundle declares.
+    # With both naming `grafana`, which one the agent talks to is decided
+    # downstream and the loser is overridden with no diagnostic -- either the
+    # author's committed entry is ignored, or it silently wins over the objects
+    # Curie actually created. Caught here, the fix is a one-line edit.
+    root = _bundle(tmp_path, "connectors:\n  grafana:\n    image: x:1\n")
+    (root / ".mcp.json").write_text(
+        json.dumps({"mcpServers": {"grafana": {"type": "http", "url": "http://hand-written/mcp"}}}),
+        encoding="utf-8",
+    )
+    result = validate_bundle(str(root))
+    assert not result.valid
+    assert any(e.code == "connectors.duplicate_server" for e in result.errors)
+
+
+def test_distinct_names_across_the_two_files_are_fine(tmp_path: Path) -> None:
+    # The files are complementary by design: connectors.yaml for what Curie
+    # hosts, .mcp.json for anything else (a stdio server, say).
+    root = _bundle(tmp_path, "connectors:\n  grafana:\n    image: x:1\n")
+    (root / ".mcp.json").write_text(
+        json.dumps({"mcpServers": {"local-tool": {"command": "./bin/tool"}}}),
+        encoding="utf-8",
+    )
+    assert validate_bundle(str(root)).valid
+
+
+def test_an_unreadable_mcp_config_does_not_add_a_confusing_second_error(tmp_path: Path) -> None:
+    # `_validate_mcp` already errors on the unreadable declaration. Cross-checking
+    # a partial set would name a collision we cannot actually confirm.
+    root = _bundle(tmp_path, "connectors:\n  grafana:\n    image: x:1\n")
+    (root / ".mcp.json").write_text("{not json", encoding="utf-8")
+    result = validate_bundle(str(root))
+    assert not result.valid
+    assert not any(e.code == "connectors.duplicate_server" for e in result.errors)

--- a/packages/plugin-format/tests/test_effective_operator_gate.py
+++ b/packages/plugin-format/tests/test_effective_operator_gate.py
@@ -78,9 +78,7 @@ def test_already_prefixed_name_for_undeclared_prefix_fails_closed() -> None:
     # expected_prefixes check. A typo'd wrongbundle/wrongserver name arms a literal
     # the runtime never matches -> fail OPEN; this must fail CLOSED (None).
     assert (
-        effective_operator_gate(
-            "b", {"github"}, "mcp__plugin_wrongbundle_wrongserver__tool"
-        )
+        effective_operator_gate("b", {"github"}, "mcp__plugin_wrongbundle_wrongserver__tool")
         is None
     )
 
@@ -102,10 +100,7 @@ def test_poisoned_servers_fail_mcp_names_closed_but_pass_builtins_verbatim() -> 
     # override, so "cannot verify" must fail closed, not pass through. Only a
     # built-in (no mcp__ prefix, no server lookup) still passes verbatim.
     assert effective_operator_gate("b", None, "mcp__github__update_issue") is None
-    assert (
-        effective_operator_gate("b", None, "mcp__plugin_b_github__update_issue")
-        is None
-    )
+    assert effective_operator_gate("b", None, "mcp__plugin_b_github__update_issue") is None
     assert effective_operator_gate("b", None, "Bash") == "Bash"
 
 
@@ -113,10 +108,7 @@ def test_falsy_bundle_name_fails_mcp_names_closed() -> None:
     # No bundle name means the effective prefix cannot be constructed to verify an
     # mcp__ name -> fail closed. Built-ins still pass verbatim.
     assert effective_operator_gate("", {"github"}, "mcp__github__update_issue") is None
-    assert (
-        effective_operator_gate("", {"github"}, "mcp__plugin_b_github__update_issue")
-        is None
-    )
+    assert effective_operator_gate("", {"github"}, "mcp__plugin_b_github__update_issue") is None
     assert effective_operator_gate("", {"github"}, "Bash") == "Bash"
 
 

--- a/packages/plugin-format/tests/test_models.py
+++ b/packages/plugin-format/tests/test_models.py
@@ -66,9 +66,7 @@ def test_manifest_secrets_field() -> None:
     # Absent -> None (backward compatible; bundles without it still validate).
     assert PluginManifest.model_validate({"name": "demo"}).secrets is None
     # Serializes back under the verbatim key.
-    assert manifest.model_dump(exclude_none=True)["secrets"] == [
-        "GITHUB_PERSONAL_ACCESS_TOKEN"
-    ]
+    assert manifest.model_dump(exclude_none=True)["secrets"] == ["GITHUB_PERSONAL_ACCESS_TOKEN"]
 
 
 def test_manifest_trigger_and_approval_policy_fields() -> None:

--- a/packages/plugin-format/tests/test_name_mcp_corpus.py
+++ b/packages/plugin-format/tests/test_name_mcp_corpus.py
@@ -10,9 +10,7 @@ from plugin_format import validate_bundle
 from plugin_format.validate import _NAME_RE
 
 _CORPUS = json.loads(
-    (Path(__file__).parents[1] / "schema" / "name-mcp.fixture.json").read_text(
-        encoding="utf-8"
-    )
+    (Path(__file__).parents[1] / "schema" / "name-mcp.fixture.json").read_text(encoding="utf-8")
 )
 
 
@@ -28,13 +26,9 @@ def _mcp_codes(tmp_path: Path, connector: object) -> set[str]:
     error codes (empty = the connector object is accepted)."""
     manifest = json.dumps({"name": "demo", "mcpServers": {"conn": connector}})
     (tmp_path / ".claude-plugin").mkdir(parents=True)
-    (tmp_path / ".claude-plugin" / "plugin.json").write_text(
-        manifest, encoding="utf-8"
-    )
+    (tmp_path / ".claude-plugin" / "plugin.json").write_text(manifest, encoding="utf-8")
     return {
-        issue.code
-        for issue in validate_bundle(tmp_path).errors
-        if issue.code.startswith("mcp.")
+        issue.code for issue in validate_bundle(tmp_path).errors if issue.code.startswith("mcp.")
     }
 
 

--- a/packages/plugin-format/tests/test_validate.py
+++ b/packages/plugin-format/tests/test_validate.py
@@ -62,9 +62,7 @@ def test_mcp_server_without_command_or_url_is_reported() -> None:
 
 def test_inline_object_mcp_declaration_stays_valid(tmp_path: Path) -> None:
     # The fix the string-pointer error names. It must keep validating clean.
-    bundle = _bundle(
-        tmp_path, '{"name": "demo", "mcpServers": {"crm": {"command": "crm-server"}}}'
-    )
+    bundle = _bundle(tmp_path, '{"name": "demo", "mcpServers": {"crm": {"command": "crm-server"}}}')
     result = validate_bundle(bundle)
     assert result.valid, result.errors
 
@@ -212,18 +210,14 @@ _REDIRECT_CAPTURE_KEYS = [
 
 
 @pytest.mark.parametrize("name", _REDIRECT_CAPTURE_KEYS)
-def test_reserved_redirect_capture_secret_name_is_rejected(
-    tmp_path: Path, name: str
-) -> None:
+def test_reserved_redirect_capture_secret_name_is_rejected(tmp_path: Path, name: str) -> None:
     bundle = _bundle(tmp_path, f'{{"name": "demo", "secrets": ["{name}"]}}')
     assert "secrets.name_reserved" in _codes(bundle)
 
 
 def test_legitimate_connector_secret_name_is_not_reserved(tmp_path: Path) -> None:
     # Negative control: a real connector token name still validates clean.
-    bundle = _bundle(
-        tmp_path, '{"name": "demo", "secrets": ["GITHUB_PERSONAL_ACCESS_TOKEN"]}'
-    )
+    bundle = _bundle(tmp_path, '{"name": "demo", "secrets": ["GITHUB_PERSONAL_ACCESS_TOKEN"]}')
     assert "secrets.name_reserved" not in _codes(bundle)
 
 
@@ -465,9 +459,7 @@ def test_string_pointer_mcp_declaration_does_not_add_a_gate_error(tmp_path: Path
         '"approvalPolicy": {"gates": ['
         '{"gate": "mcp__plugin_demo_crm__send_contract", "route": "legal"}]}}',
     )
-    _write_mcp(
-        bundle, '{"mcpServers": {"crm": {"command": "crm-server"}}}', "config/servers.json"
-    )
+    _write_mcp(bundle, '{"mcpServers": {"crm": {"command": "crm-server"}}}', "config/servers.json")
 
     codes = _codes(bundle)
     assert _POINTER_CODE in codes
@@ -567,9 +559,7 @@ def test_hyphenated_bundle_and_underscored_server_names_resolve(tmp_path: Path) 
     )
     good_dir = tmp_path / "good"
     good_dir.mkdir()
-    good = _bundle(
-        good_dir, manifest.format(gate="mcp__plugin_github-issues_local_tools__x")
-    )
+    good = _bundle(good_dir, manifest.format(gate="mcp__plugin_github-issues_local_tools__x"))
     assert validate_bundle(good).valid, validate_bundle(good).errors
 
     bad_dir = tmp_path / "bad"
@@ -585,8 +575,7 @@ def test_malformed_mcp_gate_is_rejected(tmp_path: Path) -> None:
     # to the general rule; no special case exists for it.
     bundle = _bundle(
         tmp_path,
-        '{"name": "demo", "approvalPolicy": {"gates": ['
-        '{"gate": "mcp__", "route": "legal"}]}}',
+        '{"name": "demo", "approvalPolicy": {"gates": [{"gate": "mcp__", "route": "legal"}]}}',
     )
     _write_mcp(bundle, '{"mcpServers": {"crm": {"command": "crm-server"}}}')
 
@@ -634,9 +623,7 @@ def test_each_offending_gate_is_reported_at_its_own_location(tmp_path: Path) -> 
     )
     _write_mcp(bundle, '{"mcpServers": {"crm": {"command": "crm-server"}}}')
 
-    locations = [
-        i.location for i in validate_bundle(bundle).errors if i.code == _GATE_CODE
-    ]
+    locations = [i.location for i in validate_bundle(bundle).errors if i.code == _GATE_CODE]
     # Both entries are reported, each anchored to its own gates[i].
     assert len(locations) == 2, locations
     assert any("gates[0]" in loc for loc in locations)
@@ -654,9 +641,7 @@ def test_each_offending_gate_is_reported_at_its_own_location(tmp_path: Path) -> 
 def test_string_pointer_mcp_declaration_is_rejected(tmp_path: Path) -> None:
     # File present AND itself valid -- the case that validates clean today.
     bundle = _bundle(tmp_path, '{"name": "demo", "mcpServers": "config/servers.json"}')
-    _write_mcp(
-        bundle, '{"mcpServers": {"crm": {"command": "crm-server"}}}', "config/servers.json"
-    )
+    _write_mcp(bundle, '{"mcpServers": {"crm": {"command": "crm-server"}}}', "config/servers.json")
 
     result = validate_bundle(bundle)
     assert not result.valid
@@ -696,9 +681,7 @@ def _write_skill(bundle: Path, frontmatter: str) -> Path:
 
 
 @pytest.mark.parametrize("key", _CONFUSABLE_KEYS)
-def test_confusable_tools_key_without_allowed_tools_is_rejected(
-    tmp_path: Path, key: str
-) -> None:
+def test_confusable_tools_key_without_allowed_tools_is_rejected(tmp_path: Path, key: str) -> None:
     bundle = _bundle(tmp_path, '{"name": "demo"}')
     _write_skill(bundle, f"{key}:\n  - Bash\n")
 
@@ -744,9 +727,7 @@ def test_unknown_key_without_allowed_tools_validates_clean(tmp_path: Path) -> No
 
 
 @pytest.mark.parametrize("key", _CONFUSABLE_KEYS)
-def test_confusable_key_alongside_allowed_tools_validates_clean(
-    tmp_path: Path, key: str
-) -> None:
+def test_confusable_key_alongside_allowed_tools_validates_clean(tmp_path: Path, key: str) -> None:
     # An author who already has the right key is not confused, whatever else the
     # bundle carries. Erroring here would reject real Claude Code bundles.
     bundle = _bundle(tmp_path, '{"name": "demo"}')


### PR DESCRIPTION
First of two for #1118. Refs ADR-0086. Base `main` — **not stacked**, so CI fires normally this time.

Groundwork for injecting the derived connector entry into the agent's MCP configuration.

## The ambiguity being removed

Curie writes the derived entry into the agent's MCP config *alongside* whatever the bundle declares. When both name the same server, precedence is decided downstream by the Claude Code CLI's `--mcp-config` handling — and the loser is overridden **with no diagnostic**:

- the author's committed `.mcp.json` entry is silently ignored, **or**
- it silently wins over the objects Curie actually created

I could have picked a precedence rule and documented it. That's one more thing to remember, and it's still silent when it bites. Making the ambiguity **unrepresentable** is simpler and scales: one name, one owner, said where the fix is a one-line edit.

## This is the migration path, not a hypothetical

acme-bot's `.mcp.json` today:

```json
{"mcpServers": {"grafana": {
  "type": "http",
  "url": "${GRAFANA_MCP_URL:-http://grafana-mcp.acme-bot.svc.cluster.local:8000/mcp}"
}}}
```

Hand-written, and correct *only* for the hand-written Deployment in its `deploy/`. The moment it declares the same connector in `connectors.yaml`, Curie names the Service itself and that URL is wrong.

Verified against that exact bundle shape:

```
valid: False
 -> connectors.duplicate_server | connectors.grafana: `grafana` is declared in both
    connectors.yaml and the bundle's MCP config. Curie derives this server's URL from
    the Service it creates, so remove the `grafana` entry from the MCP config and let
    connectors.yaml own it.
```

Fails at deploy naming the file to edit, instead of coming up pointed at a Service that doesn't exist.

## Details

**Unreadable MCP config skips the cross-check** rather than adding a second error about a name that can't be confirmed — `_validate_mcp` already reports the unreadable declaration itself.

**Reuses `declared_mcp_server_names`**, the same union of the manifest's inline `mcpServers` and the root `.mcp.json` that the runtime loader and the approval-gate cross-check already read. No second notion of "what the bundle declares."

**Distinct names still pass** — the two files are complementary by design: `connectors.yaml` for what Curie hosts, `.mcp.json` for anything else (a stdio server, say).

## Frozen contract

`packages/plugin-format` is frozen, so this lands as its own reviewed change before the runner and worker lanes consume it.

## Verification

```
ruff check         → All checks passed
mypy               → no issues, 165 files
check-contracts.sh → all committed artifacts current
plugin-format      → 216 passed
```

## What's next (second PR)

The runner derives each entry with the same `mcp_entry()` the API uses and passes them via `ClaudeAgentOptions.mcp_servers` — the channel that already carries Curie's approval and state servers. No file rewriting, so the read-only bundle mount is a non-issue. The worker injects the three identity strings (release, agent, namespace); absent them the runner skips injection, which is the correct degradation for the `skill` tier where there's no cluster.
