### PR TITLE
BootEnv: declare the connector scope the runner derives URLs from (ACI 0.2.8, #1118)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,6 +70,9 @@ VALKEY_PASSWORD=valkeypass
 # CURIE_APPROVAL_RESUMED_KIND    producers: kernel
 # CURIE_BUDGET                   producers: worker, substrate
 # CURIE_BUNDLE_REF               producers: worker
+# CURIE_CONNECTOR_AGENT          producers: worker
+# CURIE_CONNECTOR_NAMESPACE      producers: worker
+# CURIE_CONNECTOR_RELEASE        producers: worker
 # CURIE_CONNECTOR_SECRET_KEYS    producers: worker
 # CURIE_CREDENTIALS              producers: worker, substrate
 # CURIE_FAKE_MODEL               producers: worker, substrate

--- a/packages/aci-protocol/generated/rust/src/lib.rs
+++ b/packages/aci-protocol/generated/rust/src/lib.rs
@@ -6,7 +6,7 @@
 
 use serde::{Deserialize, Serialize};
 
-pub const PROTOCOL_VERSION: &str = "0.2.7";
+pub const PROTOCOL_VERSION: &str = "0.2.8";
 
 pub const RUNS_STREAM_DEFAULT: &str = "curie:runs";
 
@@ -156,6 +156,12 @@ pub struct BootEnv {
     #[serde(default)]
     pub connector_secret_keys: Option<Vec<String>>,
     #[serde(default)]
+    pub connector_release: Option<String>,
+    #[serde(default)]
+    pub connector_agent: Option<String>,
+    #[serde(default)]
+    pub connector_namespace: Option<String>,
+    #[serde(default)]
     pub port: Option<i64>,
     #[serde(default)]
     pub base_url: Option<String>,
@@ -182,6 +188,9 @@ pub mod env_keys {
     pub const CURIE_APPROVAL_RESUMED_KIND: &str = "CURIE_APPROVAL_RESUMED_KIND";
     pub const CURIE_BUDGET: &str = "CURIE_BUDGET";
     pub const CURIE_BUNDLE_REF: &str = "CURIE_BUNDLE_REF";
+    pub const CURIE_CONNECTOR_AGENT: &str = "CURIE_CONNECTOR_AGENT";
+    pub const CURIE_CONNECTOR_NAMESPACE: &str = "CURIE_CONNECTOR_NAMESPACE";
+    pub const CURIE_CONNECTOR_RELEASE: &str = "CURIE_CONNECTOR_RELEASE";
     pub const CURIE_CONNECTOR_SECRET_KEYS: &str = "CURIE_CONNECTOR_SECRET_KEYS";
     pub const CURIE_CREDENTIALS: &str = "CURIE_CREDENTIALS";
     pub const CURIE_FAKE_MODEL: &str = "CURIE_FAKE_MODEL";

--- a/packages/aci-protocol/generated/ts/aci-protocol.ts
+++ b/packages/aci-protocol/generated/ts/aci-protocol.ts
@@ -20,7 +20,7 @@ export type ExpiresInSeconds = number | null;
  * authority-bearing per #544/ADR-0046, so the value domain is a named, exported
  * part of the contract rather than an inline annotation.
  *
- * This interface was referenced by `ACIProtocolV027`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV028`'s JSON-Schema
  * via the `definition` "GateKind".
  */
 export type GateKind = "permission" | "policy";
@@ -37,6 +37,9 @@ export type ApprovalRequiredTools = string[] | null;
 export type ApprovalResumedKind = string | null;
 export type BaseUrl = string | null;
 export type BundleRef = string | null;
+export type ConnectorAgent = string | null;
+export type ConnectorNamespace = string | null;
+export type ConnectorRelease = string | null;
 export type ConnectorSecretKeys = string[] | null;
 export type FakeModel = boolean | null;
 export type HistoryMaxBytes = number | null;
@@ -101,14 +104,14 @@ export type Text1 = string;
 export type Type2 = "final";
 export type Version1 = string;
 /**
- * This interface was referenced by `ACIProtocolV027`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV028`'s JSON-Schema
  * via the `definition` "InboundMessage".
  */
 export type InboundMessage = Event | Interrupt;
 export type Kind1 = "interrupt";
 export type Reason = string;
 /**
- * This interface was referenced by `ACIProtocolV027`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV028`'s JSON-Schema
  * via the `definition` "OutboundEvent".
  */
 export type OutboundEvent = TextDelta | ToolNote | Final | ErrorEvent | SideEffectFlag;
@@ -137,12 +140,12 @@ export type Text4 = string;
  * Wire tokens follow the section 0 spelling; ``classified failure`` in prose
  * becomes the token ``classified-failure`` on the wire.
  *
- * This interface was referenced by `ACIProtocolV027`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV028`'s JSON-Schema
  * via the `definition` "SessionStatus".
  */
 export type SessionStatus1 = "done" | "idle-awaiting-input" | "classified-failure" | "awaiting-approval";
 
-export interface ACIProtocolV027 {
+export interface ACIProtocolV028 {
   [k: string]: unknown;
 }
 /**
@@ -157,7 +160,7 @@ export interface ACIProtocolV027 {
  * provenance (#544, Decision C) written by the runner; both stay optional for
  * the rolling-deploy window.
  *
- * This interface was referenced by `ACIProtocolV027`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV028`'s JSON-Schema
  * via the `definition` "ApprovalRequest".
  */
 export interface ApprovalRequest {
@@ -202,7 +205,7 @@ export interface ApprovalRequest {
  * baked template default, the worker's value is per-agent model routing. Do not
  * collapse either producer list to a single value.
  *
- * This interface was referenced by `ACIProtocolV027`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV028`'s JSON-Schema
  * via the `definition` "BootEnv".
  */
 export interface BootEnv {
@@ -213,6 +216,9 @@ export interface BootEnv {
   approval_resumed_kind?: ApprovalResumedKind;
   base_url?: BaseUrl;
   bundle_ref?: BundleRef;
+  connector_agent?: ConnectorAgent;
+  connector_namespace?: ConnectorNamespace;
+  connector_release?: ConnectorRelease;
   connector_secret_keys?: ConnectorSecretKeys;
   fake_model?: FakeModel;
   history_max_bytes?: HistoryMaxBytes;
@@ -237,7 +243,7 @@ export interface BootEnv {
  * section 0 describes these as per-tool secrets via K8s Secret refs, so the
  * contract carries the reference, not the secret material itself.
  *
- * This interface was referenced by `ACIProtocolV027`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV028`'s JSON-Schema
  * via the `definition` "SessionConfig".
  */
 export interface SessionConfig {
@@ -256,7 +262,7 @@ export interface SessionConfig {
  * ``task_budget_hint`` is the optional hint passed through to the model so it
  * self paces (section 6b); it is not a hard ceiling.
  *
- * This interface was referenced by `ACIProtocolV027`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV028`'s JSON-Schema
  * via the `definition` "Budget".
  */
 export interface Budget {
@@ -272,7 +278,7 @@ export interface Budget {
  * fields the prototype used (endpoint, headers, protocol); any others pass
  * through as raw env vars untouched and are out of scope for this typed view.
  *
- * This interface was referenced by `ACIProtocolV027`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV028`'s JSON-Schema
  * via the `definition` "OtelConfig".
  */
 export interface OtelConfig {
@@ -284,7 +290,7 @@ export interface OtelConfig {
 /**
  * A classified failure surfaced to the platform.
  *
- * This interface was referenced by `ACIProtocolV027`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV028`'s JSON-Schema
  * via the `definition` "ErrorEvent".
  */
 export interface ErrorEvent {
@@ -301,7 +307,7 @@ export interface ErrorEvent {
  * worker consumes off it (formerly the API's ``EvalJobRequest`` and the
  * worker's ``EvalWorkItem``, which had drifted on ``bundle_ref``).
  *
- * This interface was referenced by `ACIProtocolV027`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV028`'s JSON-Schema
  * via the `definition` "EvalJob".
  */
 export interface EvalJob {
@@ -321,7 +327,7 @@ export interface EvalJob {
  * Byte-identical across both lanes before this promotion, so it carries no
  * semantic decisions.
  *
- * This interface was referenced by `ACIProtocolV027`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV028`'s JSON-Schema
  * via the `definition` "EvalReport".
  */
 export interface EvalReport {
@@ -335,7 +341,7 @@ export interface EvalReport {
 /**
  * An inbound event delivered into a live session (initial or follow-up).
  *
- * This interface was referenced by `ACIProtocolV027`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV028`'s JSON-Schema
  * via the `definition` "Event".
  */
 export interface Event {
@@ -380,7 +386,7 @@ export interface Event {
  * scalars: a tolerant consumer decoding an older producer's ``final`` simply
  * sees them absent.
  *
- * This interface was referenced by `ACIProtocolV027`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV028`'s JSON-Schema
  * via the `definition` "Final".
  */
 export interface Final {
@@ -399,7 +405,7 @@ export interface Final {
 /**
  * A hard stop delivered on the control channel, distinct from a steer.
  *
- * This interface was referenced by `ACIProtocolV027`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV028`'s JSON-Schema
  * via the `definition` "Interrupt".
  */
 export interface Interrupt {
@@ -410,7 +416,7 @@ export interface Interrupt {
 /**
  * A streamed chunk of assistant text.
  *
- * This interface was referenced by `ACIProtocolV027`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV028`'s JSON-Schema
  * via the `definition` "TextDelta".
  */
 export interface TextDelta {
@@ -422,7 +428,7 @@ export interface TextDelta {
 /**
  * A human readable note about a tool call the harness is making.
  *
- * This interface was referenced by `ACIProtocolV027`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV028`'s JSON-Schema
  * via the `definition` "ToolNote".
  */
 export interface ToolNote {
@@ -438,7 +444,7 @@ export interface ToolNote {
  * Its presence gates the no-retry-after-side-effects rule (section 2b): a
  * failed run carrying this flag escalates to a human instead of retrying.
  *
- * This interface was referenced by `ACIProtocolV027`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV028`'s JSON-Schema
  * via the `definition` "SideEffectFlag".
  */
 export interface SideEffectFlag {
@@ -456,7 +462,7 @@ export interface SideEffectFlag {
  * stream-encoding helpers live with the producer (the dispatcher), not on this
  * frozen model, so the contract stays transport-agnostic.
  *
- * This interface was referenced by `ACIProtocolV027`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV028`'s JSON-Schema
  * via the `definition` "QueuedTurn".
  */
 export interface QueuedTurn {
@@ -485,7 +491,7 @@ export interface QueuedTurn {
  * (its ``slack_api_base_url``, i.e. real Slack), so a producer that does not set
  * it keeps the pre-#19 behavior.
  *
- * This interface was referenced by `ACIProtocolV027`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV028`'s JSON-Schema
  * via the `definition` "ReplyHandle".
  */
 export interface ReplyHandle {

--- a/packages/aci-protocol/schema/aci-protocol.schema.json
+++ b/packages/aci-protocol/schema/aci-protocol.schema.json
@@ -249,6 +249,54 @@
           ],
           "title": "Bundle Ref"
         },
+        "connector_agent": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "env": "CURIE_CONNECTOR_AGENT",
+          "producer": [
+            "worker"
+          ],
+          "title": "Connector Agent"
+        },
+        "connector_namespace": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "env": "CURIE_CONNECTOR_NAMESPACE",
+          "producer": [
+            "worker"
+          ],
+          "title": "Connector Namespace"
+        },
+        "connector_release": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "env": "CURIE_CONNECTOR_RELEASE",
+          "producer": [
+            "worker"
+          ],
+          "title": "Connector Release"
+        },
         "connector_secret_keys": {
           "anyOf": [
             {
@@ -1179,6 +1227,6 @@
   },
   "$id": "https://curietech.ai/schemas/aci-protocol.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "protocolVersion": "0.2.7",
-  "title": "ACI Protocol v0.2.7"
+  "protocolVersion": "0.2.8",
+  "title": "ACI Protocol v0.2.8"
 }

--- a/packages/aci-protocol/schema/wire.lock
+++ b/packages/aci-protocol/schema/wire.lock
@@ -1,4 +1,4 @@
 {
-  "protocol_version": "0.2.7",
-  "wire_sha256": "71ed680f225818c9e9eb59ffdd913b316aa84f1b20429b5e90b8995ee0ffd405"
+  "protocol_version": "0.2.8",
+  "wire_sha256": "b63f75dd5fa871cc01098eaa3db7d9be7d2316301a8a9dba0b27df6565fbfba5"
 }

--- a/packages/aci-protocol/src/aci_protocol/env_example_export.py
+++ b/packages/aci-protocol/src/aci_protocol/env_example_export.py
@@ -61,9 +61,7 @@ def render_block() -> str:
         lines.append(f"#   {producer:<9} {note}")
     lines.append("#")
     for key in BootEnv.env_keys():
-        producers = ", ".join(
-            p for p in _PRODUCER_NOTES if key in BootEnv.env_keys(producer=p)
-        )
+        producers = ", ".join(p for p in _PRODUCER_NOTES if key in BootEnv.env_keys(producer=p))
         lines.append(f"# {key:<{width}}  producers: {producers}")
     lines.append(_END)
     return "\n".join(lines)

--- a/packages/aci-protocol/src/aci_protocol/reference.py
+++ b/packages/aci-protocol/src/aci_protocol/reference.py
@@ -26,9 +26,7 @@ def reference_producer(message: Event | Interrupt) -> Iterable[str]:
 
     if isinstance(message, Interrupt):
         return [
-            to_ndjson_line(
-                Final(text="run interrupted", status=SessionStatus.IDLE_AWAITING_INPUT)
-            )
+            to_ndjson_line(Final(text="run interrupted", status=SessionStatus.IDLE_AWAITING_INPUT))
         ]
 
     if message.type == "eval_case":

--- a/packages/aci-protocol/src/aci_protocol/rust_export.py
+++ b/packages/aci-protocol/src/aci_protocol/rust_export.py
@@ -167,9 +167,7 @@ def _struct_fields(model: type[BaseModel], skip: set[str], public: bool) -> list
             # matching the NDJSON decoder. Detected by name (WIRE_VERSION_FIELD),
             # not by type, so dropping the old Literal does not silently remove
             # the guard and let #[serde(default)] make version optional.
-            out.append(
-                '    #[serde(deserialize_with = "require_compatible_protocol_version")]'
-            )
+            out.append('    #[serde(deserialize_with = "require_compatible_protocol_version")]')
         elif not field.is_required():
             # Any other field with a Pydantic default is omittable on the wire,
             # so Rust accepts it missing too.

--- a/packages/aci-protocol/src/aci_protocol/service_config.py
+++ b/packages/aci-protocol/src/aci_protocol/service_config.py
@@ -105,8 +105,7 @@ def warn_if_deprecated_api_url_env(env: Mapping[str, str] | None = None) -> None
     environ = os.environ if env is None else env
     if API_URL_ENV_DEPRECATED in environ and API_URL_ENV not in environ:
         logger.warning(
-            "%s is deprecated and will be removed in a future release; "
-            "set %s instead.",
+            "%s is deprecated and will be removed in a future release; set %s instead.",
             API_URL_ENV_DEPRECATED,
             API_URL_ENV,
         )
@@ -130,9 +129,7 @@ class AliasOnlyEnvSource(EnvSettingsSource):
     only the field-name fallback is filtered, so both names keep resolving.
     """
 
-    def _extract_field_info(
-        self, field: FieldInfo, field_name: str
-    ) -> list[tuple[str, str, bool]]:
+    def _extract_field_info(self, field: FieldInfo, field_name: str) -> list[tuple[str, str, bool]]:
         infos = super()._extract_field_info(field, field_name)
         if field.validation_alias is not None:
             infos = [info for info in infos if info[0] != field_name]

--- a/packages/aci-protocol/src/aci_protocol/session.py
+++ b/packages/aci-protocol/src/aci_protocol/session.py
@@ -321,9 +321,7 @@ class BootEnv(_AciModel):
     # ``/<namespace>/<key>`` onto it. state_token is the scoped ``state`` token
     # (ADR-0033) the caller presents as X-API-Key -- the same per-turn scoped
     # derivative used for memory/history, never the raw platform key.
-    state_url: str | None = Field(
-        default=None, json_schema_extra=_env("CURIE_STATE_URL", "worker")
-    )
+    state_url: str | None = Field(default=None, json_schema_extra=_env("CURIE_STATE_URL", "worker"))
     state_token: str | None = Field(
         default=None, json_schema_extra=_env("CURIE_STATE_TOKEN", "worker")
     )
@@ -357,10 +355,29 @@ class BootEnv(_AciModel):
     connector_secret_keys: list[str] | None = Field(
         default=None, json_schema_extra=_env("CURIE_CONNECTOR_SECRET_KEYS", "worker")
     )
-    # Substrate-authoritative; see the class docstring's anti-clobber note.
-    port: int | None = Field(
-        default=None, json_schema_extra=_env("CURIE_RUNNER_PORT", "substrate")
+    # Where this sandbox's hosted connectors live (ADR-0086, #1063/#1118).
+    # Curie derives each declared connector's MCP URL from the Service it
+    # created, whose name is `<release>-<agent>-mcp-<connector>` in
+    # `<namespace>`. Those three are install-time facts the bundle cannot know:
+    # the Helm release name and nameOverride live with whoever ran `cluster up`,
+    # and the agent name is assigned at deploy.
+    #
+    # Optional as a set, and absent is MEANINGFUL rather than a degraded
+    # cluster boot: the skill tier hosts nothing, so there is no Service to
+    # derive a URL from and a declared connector is correctly reported as
+    # "declared but not exercisable here" (#1093). The runner treats all three
+    # missing as "no hosted connectors in this tier" and derives nothing.
+    connector_release: str | None = Field(
+        default=None, json_schema_extra=_env("CURIE_CONNECTOR_RELEASE", "worker")
     )
+    connector_agent: str | None = Field(
+        default=None, json_schema_extra=_env("CURIE_CONNECTOR_AGENT", "worker")
+    )
+    connector_namespace: str | None = Field(
+        default=None, json_schema_extra=_env("CURIE_CONNECTOR_NAMESPACE", "worker")
+    )
+    # Substrate-authoritative; see the class docstring's anti-clobber note.
+    port: int | None = Field(default=None, json_schema_extra=_env("CURIE_RUNNER_PORT", "substrate"))
     # Worker-authoritative with a chart fallback default.
     base_url: str | None = Field(
         default=None, json_schema_extra=_env("ANTHROPIC_BASE_URL", "worker", "substrate")
@@ -464,8 +481,7 @@ class BootEnv(_AciModel):
         declared = cls._declared()
         if field not in declared:
             raise KeyError(
-                f"{field!r} is not a declared boot-env field; "
-                f"known fields: {sorted(declared)}"
+                f"{field!r} is not a declared boot-env field; known fields: {sorted(declared)}"
             )
         return declared[field][0]
 
@@ -491,6 +507,9 @@ class BootEnv(_AciModel):
         state_url: str | None = None,
         state_token: str | None = None,
         approval_required_tools: Sequence[str] | None = None,
+        connector_release: str | None = None,
+        connector_agent: str | None = None,
+        connector_namespace: str | None = None,
     ) -> dict[str, str]:
         """Render the worker binding's boot-env subset.
 
@@ -547,6 +566,13 @@ class BootEnv(_AciModel):
             env[cls.env_key("state_url")] = state_url
         if state_token:
             env[cls.env_key("state_token")] = state_token
+        # Emitted as a SET or not at all: the runner derives a connector URL
+        # from all three or derives nothing, so a partial scope would name a
+        # Service that cannot exist.
+        if connector_release and connector_agent and connector_namespace:
+            env[cls.env_key("connector_release")] = connector_release
+            env[cls.env_key("connector_agent")] = connector_agent
+            env[cls.env_key("connector_namespace")] = connector_namespace
         return env
 
     def to_env(self) -> dict[str, str]:
@@ -576,6 +602,12 @@ class BootEnv(_AciModel):
             env[self.env_key("history_token")] = self.history_token
         if self.memory_token is not None:
             env[self.env_key("memory_token")] = self.memory_token
+        if self.connector_release is not None:
+            env[self.env_key("connector_release")] = self.connector_release
+        if self.connector_agent is not None:
+            env[self.env_key("connector_agent")] = self.connector_agent
+        if self.connector_namespace is not None:
+            env[self.env_key("connector_namespace")] = self.connector_namespace
         if self.state_url is not None:
             env[self.env_key("state_url")] = self.state_url
         if self.state_token is not None:

--- a/packages/aci-protocol/src/aci_protocol/version.py
+++ b/packages/aci-protocol/src/aci_protocol/version.py
@@ -20,7 +20,7 @@ the guard.
 import re
 from typing import Final
 
-PROTOCOL_VERSION: Final = "0.2.7"
+PROTOCOL_VERSION: Final = "0.2.8"
 
 # The wire field carrying the protocol version on every outbound event. Both
 # exporters special-case this field by name; do not rename without updating them.

--- a/packages/aci-protocol/src/aci_protocol/wire_lock.py
+++ b/packages/aci-protocol/src/aci_protocol/wire_lock.py
@@ -114,9 +114,7 @@ def wire_fingerprint(models: tuple[type[BaseModel], ...] | None = None) -> str:
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
 
-def check_wire_lock(
-    *, fingerprint: str, version: str, lock: dict[str, str]
-) -> None:
+def check_wire_lock(*, fingerprint: str, version: str, lock: dict[str, str]) -> None:
     """Fail an unbumped wire change; pass a version-only bump or an unchanged wire.
 
     Truth table (plan decision 4):
@@ -153,9 +151,7 @@ def check_against_base(base_lock: dict[str, str] | None) -> None:
 
     if base_lock is None:
         return
-    check_wire_lock(
-        fingerprint=wire_fingerprint(), version=PROTOCOL_VERSION, lock=base_lock
-    )
+    check_wire_lock(fingerprint=wire_fingerprint(), version=PROTOCOL_VERSION, lock=base_lock)
 
 
 def _lock_path() -> Path:

--- a/packages/aci-protocol/tests/test_ndjson.py
+++ b/packages/aci-protocol/tests/test_ndjson.py
@@ -55,9 +55,7 @@ def test_missing_version_is_rejected() -> None:
 
 
 def test_current_version_is_accepted() -> None:
-    good = json.dumps(
-        {"type": "final", "version": PROTOCOL_VERSION, "text": "x", "status": "done"}
-    )
+    good = json.dumps({"type": "final", "version": PROTOCOL_VERSION, "text": "x", "status": "done"})
     assert parse_ndjson_line(good) == Final(text="x")
 
 
@@ -118,9 +116,7 @@ def test_unknown_field_is_ignored_on_inbound_read() -> None:
 def test_compatible_patch_version_is_accepted() -> None:
     # AC: a same-major-minor patch difference is not an error. Build speaks
     # 0.2.0; a 0.2.7 line decodes fine.
-    line = json.dumps(
-        {"type": "final", "version": "0.2.7", "text": "x", "status": "done"}
-    )
+    line = json.dumps({"type": "final", "version": "0.2.7", "text": "x", "status": "done"})
     decoded = parse_ndjson_line(line)
     assert isinstance(decoded, Final)
     assert decoded.text == "x"
@@ -129,9 +125,7 @@ def test_compatible_patch_version_is_accepted() -> None:
 def test_incompatible_minor_is_rejected_naming_both_versions() -> None:
     # AC: rejects an incompatible version with a message naming both versions.
     # The assertion is on the message content, not just the exception type.
-    line = json.dumps(
-        {"type": "final", "version": "0.3.0", "text": "x", "status": "done"}
-    )
+    line = json.dumps({"type": "final", "version": "0.3.0", "text": "x", "status": "done"})
     with pytest.raises(ProtocolVersionError) as excinfo:
         parse_ndjson_line(line)
     message = str(excinfo.value)
@@ -140,9 +134,7 @@ def test_incompatible_minor_is_rejected_naming_both_versions() -> None:
 
 
 def test_incompatible_major_is_rejected() -> None:
-    line = json.dumps(
-        {"type": "final", "version": "1.0.0", "text": "x", "status": "done"}
-    )
+    line = json.dumps({"type": "final", "version": "1.0.0", "text": "x", "status": "done"})
     with pytest.raises(ProtocolVersionError):
         parse_ndjson_line(line)
 
@@ -168,8 +160,6 @@ def test_malformed_version_is_rejected_via_the_decoder_contract(bad_version: str
     # Edge 5: a malformed version must reject through the decoder's own error
     # contract (ProtocolVersionError), never escape as an IndexError/ValueError
     # out of a bare .split(".").
-    line = json.dumps(
-        {"type": "final", "version": bad_version, "text": "x", "status": "done"}
-    )
+    line = json.dumps({"type": "final", "version": bad_version, "text": "x", "status": "done"})
     with pytest.raises(ProtocolVersionError):
         parse_ndjson_line(line)

--- a/packages/aci-protocol/tests/test_session.py
+++ b/packages/aci-protocol/tests/test_session.py
@@ -463,6 +463,9 @@ def test_render_worker_emits_exactly_the_worker_owned_key_subset() -> None:
         model_env_key="MY_PROVIDER_KEY",
         state_url="http://api:8000/agents/agent-abc/state",
         state_token="st-scoped-token",
+        connector_release="curie",
+        connector_agent="sre-dev",
+        connector_namespace="curie",
     )
     worker_owned = set(BootEnv.env_keys(producer="worker"))
     assert set(maximal) <= worker_owned
@@ -695,6 +698,9 @@ def test_env_keys_declares_the_whole_flattened_boot_surface() -> None:
         "CURIE_APPROVAL_RESUMED_KIND",
         "CURIE_APPROVAL_DECISION",
         "CURIE_CONNECTOR_SECRET_KEYS",
+        "CURIE_CONNECTOR_RELEASE",
+        "CURIE_CONNECTOR_AGENT",
+        "CURIE_CONNECTOR_NAMESPACE",
         "CURIE_RUNNER_PORT",
         "ANTHROPIC_BASE_URL",
         "CURIE_MODEL_API_BACKEND",
@@ -835,3 +841,24 @@ def test_every_rendered_key_is_a_declared_env_key() -> None:
     """
     assert set(_full_boot_env().to_env()) <= set(BootEnv.env_keys())
     assert set(_worker_env(fake_model=True, base_url="http://x")) <= set(BootEnv.env_keys())
+
+
+def test_connector_scope_is_emitted_as_a_set_or_not_at_all() -> None:
+    # The runner derives `<release>-<agent>-mcp-<connector>.<namespace>` from all
+    # three or derives nothing. A partial scope would name a Service that cannot
+    # exist, and the failure would be a connection refused at turn time.
+    partial = _worker_env(connector_release="curie", connector_agent="sre-dev")
+    assert not [k for k in partial if k.startswith("CURIE_CONNECTOR_")]
+
+    full = _worker_env(
+        connector_release="curie", connector_agent="sre-dev", connector_namespace="curie"
+    )
+    assert full["CURIE_CONNECTOR_RELEASE"] == "curie"
+    assert full["CURIE_CONNECTOR_AGENT"] == "sre-dev"
+    assert full["CURIE_CONNECTOR_NAMESPACE"] == "curie"
+
+
+def test_connector_scope_is_absent_by_default() -> None:
+    # Absent is meaningful, not degraded: the skill tier hosts nothing, so there
+    # is no Service to derive a URL from.
+    assert not [k for k in _worker_env() if k.startswith("CURIE_CONNECTOR_")]


### PR DESCRIPTION
Second of three for #1118. Refs ADR-0086. Base `main`, **not stacked**.

**Frozen contract change: ACI `0.2.7` → `0.2.8`** (patch).

## What and why

Curie derives each connector's MCP URL from the Service it created — `<release>-<agent>-mcp-<connector>` in `<namespace>` (ADR-0086, #1116). Those three are install-time facts the bundle cannot know: the Helm release name and `nameOverride` live with whoever ran `cluster up`, and the agent name is assigned at deploy.

The runner can't derive anything without them, so they have to arrive on the boot env.

## Why a patch bump is right

Per `packages/CLAUDE.md`, **new optional field** is the one backward-compatible class under 0.x — a tolerant consumer ignores it, so an old runner keeps decoding a new worker's boot env unchanged. No consumer is required to read these.

## Why BootEnv rather than a runner-local knob

There's an established pattern for runner-local `CURIE_*` reads (`harness`, `false_completion_check`) and it would have been less work. But `BootEnv`'s docstring is explicit that it models *"the ACI session plus platform ops"*, and connector scope is platform ops.

The runner-local pattern exists for knobs the contract deliberately doesn't govern. Using it here would give up precisely the protection `BootEnv` was built for — its own docstring names the failure: a rename leaving *"the sandbox booting fine with a silently dropped feature."* Connector injection silently vanishing is exactly that.

## Two deliberate behaviours

**Emitted as a set or not at all.** A partial scope would name a Service that cannot exist, and the failure would be a connection refused at turn time — nothing a deploy could catch. Pinned by `test_connector_scope_is_emitted_as_a_set_or_not_at_all`.

**Absent is meaningful, not degraded.** The `skill` tier hosts nothing, so there's no Service to derive from and a declared connector is correctly *declared but not exercisable here* (#1093). Pinned by `test_connector_scope_is_absent_by_default`.

## The guards did their job

Both contract guard tests failed before any pin did:

```
test_render_worker_emits_exactly_the_worker_owned_key_subset
  Extra items: CURIE_CONNECTOR_RELEASE, CURIE_CONNECTOR_AGENT, CURIE_CONNECTOR_NAMESPACE
test_env_keys_declares_the_whole_flattened_boot_surface
  Extra items: (same)
```

I'd declared three worker-owned keys without wiring `render_worker`. Updated deliberately — enumerating that surface is what those tests are for.

## Chart render-assert

Unaffected. It asserts the chart's rendered runner env is a **subset** of declared keys, so adding keys only loosens it — and the chart doesn't set these; the worker does.

## Verification

```
check-contracts.sh   → all committed artifacts current (schema, Rust, TS, wire.lock)
aci-protocol tests   → 150 passed
packages (all)       → 369 passed
runner tests         → 477 passed, 4 skipped
cargo test           → 0 failed suites
ruff check / mypy    → clean, 165 files
```

Regenerated together in one commit: JSON Schema, generated Rust, generated TS, `wire.lock`, `.env.example`.

## Next (third PR)

The runner reads `connectors.yaml`, derives each entry with the same `mcp_entry()` the API uses, and passes them via `ClaudeAgentOptions.mcp_servers` — the channel already carrying Curie's approval and state servers. The worker fills in this scope. #1149 already made a name collision between `connectors.yaml` and `.mcp.json` a deploy-time error, so there's no precedence ambiguity left to resolve at runtime.
