### PR TITLE
Runner mounts the connectors a bundle declared (#1118)

### DIFF
--- a/runner/src/curie_runner/__main__.py
+++ b/runner/src/curie_runner/__main__.py
@@ -25,6 +25,7 @@ from .approval import (
     resolve_approval_policy,
 )
 from .config import RunnerConfig
+from .connectors import derive_mcp_servers
 from .fake import FakeModelSession
 from .harness.contribution import HarnessContribution
 from .harness.registry import (
@@ -222,6 +223,19 @@ def build_runner(
                     {STATE_SERVER_NAME: build_state_server(state_client)}
                     if state_client is not None
                     else {}
+                ),
+                # Connectors the bundle DECLARED and Curie hosts (ADR-0086,
+                # #1118). Platform-supplied, exactly like the two above, so they
+                # ride the same channel -- nothing rewrites the read-only
+                # bundle. The URL derives from the Service Curie created via the
+                # same function that rendered it, so the two cannot disagree. A
+                # name clashing with the bundle's own MCP config is already a
+                # deploy-time error (#1149), so this cannot shadow it.
+                **derive_mcp_servers(
+                    config.session.plugin_dir,
+                    release=config.connector_release,
+                    agent=config.connector_agent,
+                    namespace=config.connector_namespace,
                 ),
             },
             can_use_tool=(

--- a/runner/src/curie_runner/config.py
+++ b/runner/src/curie_runner/config.py
@@ -33,6 +33,11 @@ class RunnerConfig:
     # through the harness registry; an unregistered selection fails the boot.
     harness: str
     max_turns: int
+    # Where this sandbox's hosted connectors live (ADR-0086, #1118). Absent as
+    # a set on any tier that hosts nothing -- see connectors.derive_mcp_servers.
+    connector_release: str | None
+    connector_agent: str | None
+    connector_namespace: str | None
     history_ref: str | None
     # Tool names whose calls require human approval (#245, ADR-0010). The
     # runner intercepts these proactively via the SDK can_use_tool callback
@@ -122,6 +127,9 @@ class RunnerConfig:
             model=boot.model,
             harness=harness,
             max_turns=boot.max_turns if boot.max_turns is not None else 20,
+            connector_release=boot.connector_release,
+            connector_agent=boot.connector_agent,
+            connector_namespace=boot.connector_namespace,
             history_ref=boot.history_ref,
             approval_required_tools=boot.approval_required_tools,
             approval_grant_tool=boot.approval_grant_tool,

--- a/runner/src/curie_runner/connectors.py
+++ b/runner/src/curie_runner/connectors.py
@@ -1,0 +1,112 @@
+"""Mount the connectors a bundle declared, so the author writes no URL.
+
+ADR-0086 decided the bundle declares connectors and Curie derives, among other
+things, "the URL it writes into the agent's MCP configuration". This is that
+write. The author declares intent in ``connectors.yaml``; the URL of the Service
+Curie created never appears in the repository.
+
+That matters because the URL is unknowable to the author. It is
+``<release>-<agent>-mcp-<connector>.<namespace>.svc.cluster.local``, and the
+release name, the agent name, and the namespace are all install-time facts
+assigned by whoever ran ``cluster up`` and ``cluster deploy``. Since #1116 the
+name is agent-scoped, so a hand-written URL is now *guaranteed* wrong for at
+least one of two agents sharing a bundle.
+
+Derivation reuses ``plugin_format.connector_render.mcp_entry`` -- the same
+function the API calls when it renders the Service. One function, so the URL the
+agent dials and the Service that exists cannot disagree. Re-deriving the format
+here would be a second copy of that rule, free to drift, and the failure would
+be a connection refused at turn time.
+
+The entries ride ``ClaudeAgentOptions.mcp_servers``, alongside Curie's approval
+and state servers -- platform-supplied servers, which is exactly what these are.
+Nothing rewrites ``.mcp.json``; the bundle stays the read-only artifact that was
+deployed.
+
+Name collisions cannot reach here: ``plugin_format`` rejects a bundle that
+declares one name in both ``connectors.yaml`` and its MCP config (#1118), so
+there is no precedence to resolve at runtime.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+import yaml
+from plugin_format.connector_render import mcp_entry
+from plugin_format.connectors import ConnectorsFile, validate_connectors
+
+logger = logging.getLogger(__name__)
+
+CONNECTORS_FILE = "connectors.yaml"
+
+
+def _read(plugin_dir: str | Path) -> ConnectorsFile | None:
+    path = Path(plugin_dir) / CONNECTORS_FILE
+    if not path.is_file():
+        return None
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError) as exc:
+        # Deploy already validated this file, so reaching here means the bundle
+        # changed underneath us. Log and mount nothing rather than fail the
+        # turn: the agent loses the connector's tools, which is visible, where a
+        # crashed boot loses the whole session.
+        logger.warning("connectors.yaml unreadable, mounting no connectors: %s", exc)
+        return None
+    parsed, errors = validate_connectors(data)
+    if errors or parsed is None:
+        logger.warning(
+            "connectors.yaml did not validate, mounting no connectors: %s",
+            "; ".join(code for code, _ in errors),
+        )
+        return None
+    return parsed
+
+
+def derive_mcp_servers(
+    plugin_dir: str | Path | None,
+    *,
+    release: str | None,
+    agent: str | None,
+    namespace: str | None,
+) -> dict[str, Any]:
+    """The MCP server entries for this bundle's declared connectors.
+
+    Empty when the bundle declares none, or when the connector scope is absent.
+    An absent scope is not a degraded boot: the ``skill`` tier hosts nothing, so
+    there is no Service to point at and a declared connector is correctly not
+    exercisable there (#1093). A hosted connector declared with no scope is
+    logged, because on a cluster that combination means the worker stopped
+    sending the scope and the agent has silently lost its tools.
+    """
+
+    if plugin_dir is None:
+        return {}
+    declared = _read(plugin_dir)
+    if declared is None or not declared.connectors:
+        return {}
+
+    if not (release and agent and namespace):
+        # The scope is emitted as a set or not at all (BootEnv, ACI 0.2.8), so
+        # this is "no scope", never a partial one.
+        if any(spec.is_hosted for spec in declared.connectors.values()):
+            logger.info(
+                "connectors declared but no connector scope on the boot env; "
+                "hosted connectors are not exercisable in this tier (%s)",
+                ", ".join(sorted(declared.connectors)),
+            )
+        # A remote connector carries its own absolute url, so it needs no scope
+        # and stays mountable in every tier.
+        return {
+            name: mcp_entry("", "", "", name, spec)
+            for name, spec in sorted(declared.connectors.items())
+            if not spec.is_hosted
+        }
+
+    return {
+        name: mcp_entry(release, agent, namespace, name, spec)
+        for name, spec in sorted(declared.connectors.items())
+    }

--- a/runner/tests/test_connectors.py
+++ b/runner/tests/test_connectors.py
@@ -1,0 +1,101 @@
+"""Mounting declared connectors into the agent's MCP configuration (#1118).
+
+The property under test is that the author never writes the URL, and that the
+URL the agent dials is the one the Service actually has.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from curie_runner.connectors import derive_mcp_servers
+
+HOSTED = "connectors:\n  grafana:\n    image: grafana/mcp-grafana:0.17.2\n    secrets: [T]\n"
+REMOTE = "connectors:\n  internal:\n    url: https://mcp.internal/mcp\n"
+
+SCOPE = {"release": "curie", "agent": "sre-dev", "namespace": "curie"}
+
+
+def _bundle(root: Path, connectors: str | None = None, mcp: dict | None = None) -> Path:
+    (root / ".claude-plugin").mkdir(parents=True, exist_ok=True)
+    (root / ".claude-plugin" / "plugin.json").write_text(
+        json.dumps({"name": "b", "version": "0.1.0", "description": "t"}), encoding="utf-8"
+    )
+    if connectors is not None:
+        (root / "connectors.yaml").write_text(connectors, encoding="utf-8")
+    if mcp is not None:
+        (root / ".mcp.json").write_text(json.dumps(mcp), encoding="utf-8")
+    return root
+
+
+def test_the_author_never_writes_the_url(tmp_path: Path) -> None:
+    # The whole point of ADR-0086. The URL embeds the release, the agent, and
+    # the namespace -- all assigned at install and deploy, none knowable to
+    # whoever wrote the bundle.
+    servers = derive_mcp_servers(_bundle(tmp_path, HOSTED), **SCOPE)
+    assert servers["grafana"]["url"] == (
+        "http://curie-sre-dev-mcp-grafana.curie.svc.cluster.local:8000/mcp"
+    )
+
+
+def test_two_agents_from_one_bundle_dial_different_servers(tmp_path: Path) -> None:
+    # Since #1116 the Service is agent-scoped, so a hand-written URL is
+    # guaranteed wrong for at least one of two agents sharing a bundle. Deriving
+    # per-boot is what makes one bundle serve both.
+    root = _bundle(tmp_path, HOSTED)
+    dev = derive_mcp_servers(root, release="curie", agent="sre-dev", namespace="curie")
+    prod = derive_mcp_servers(root, release="curie", agent="sre-prod", namespace="curie")
+    assert dev["grafana"]["url"] != prod["grafana"]["url"]
+
+
+def test_no_connectors_file_mounts_nothing(tmp_path: Path) -> None:
+    assert derive_mcp_servers(_bundle(tmp_path), **SCOPE) == {}
+
+
+def test_hosted_connector_without_a_scope_mounts_nothing(tmp_path: Path) -> None:
+    # The skill tier hosts nothing, so there is no Service to point at. Mounting
+    # a URL that resolves nowhere would turn "not available here" into a
+    # connection refused mid-turn.
+    servers = derive_mcp_servers(
+        _bundle(tmp_path, HOSTED), release=None, agent=None, namespace=None
+    )
+    assert servers == {}
+
+
+def test_a_remote_connector_needs_no_scope(tmp_path: Path) -> None:
+    # It carries its own absolute url, so it is exercisable in every tier --
+    # including the ones that host nothing.
+    servers = derive_mcp_servers(
+        _bundle(tmp_path, REMOTE), release=None, agent=None, namespace=None
+    )
+    assert servers["internal"]["url"] == "https://mcp.internal/mcp"
+
+
+def test_remote_and_hosted_together_mount_only_what_this_tier_can_reach(tmp_path: Path) -> None:
+    root = _bundle(tmp_path, HOSTED + REMOTE.replace("connectors:\n", ""))
+    both = derive_mcp_servers(root, **SCOPE)
+    assert set(both) == {"grafana", "internal"}
+    tierless = derive_mcp_servers(root, release=None, agent=None, namespace=None)
+    assert set(tierless) == {"internal"}
+
+
+def test_unreadable_connectors_file_mounts_nothing_rather_than_crashing(tmp_path: Path) -> None:
+    # Deploy already validated this, so reaching here means the bundle changed
+    # underneath us. Losing the connector's tools is visible; losing the whole
+    # session to a boot crash is worse.
+    servers = derive_mcp_servers(
+        _bundle(tmp_path, "connectors:\n  g:\n   image: [unclosed\n"), **SCOPE
+    )
+    assert servers == {}
+
+
+def test_invalid_connectors_file_mounts_nothing(tmp_path: Path) -> None:
+    servers = derive_mcp_servers(
+        _bundle(tmp_path, "connectors:\n  Bad_Name:\n    image: x:1\n"), **SCOPE
+    )
+    assert servers == {}
+
+
+def test_no_plugin_dir_is_not_an_error(tmp_path: Path) -> None:
+    assert derive_mcp_servers(None, **SCOPE) == {}


### PR DESCRIPTION
Third of #1118. Refs ADR-0086. Base `main` (#1150 is merged), **not stacked**.

ADR-0086 decided Curie derives *"the URL it writes into the agent's MCP configuration."* This is that write.

## Why the author can't write it

```
http://<release>-<agent>-mcp-<connector>.<namespace>.svc.cluster.local:8000/mcp
```

Release, agent, and namespace are all assigned at install and deploy. And since #1116 the name is **agent-scoped**, so a hand-written URL is now *guaranteed* wrong for at least one of two agents sharing a bundle — exactly acme-bot's acme-dev/acme-prod split. Pinned by `test_two_agents_from_one_bundle_dial_different_servers`.

## One function, so it can't disagree

Derivation reuses `plugin_format.connector_render.mcp_entry` — the same function the API calls when it renders the Service. Re-deriving the format here would be a second copy of that rule, free to drift, and the failure would be a connection refused at turn time.

## No file rewriting

Entries ride `ClaudeAgentOptions.mcp_servers`, alongside Curie's approval and state servers — platform-supplied servers, which is exactly what these are:

```python
mcp_servers={
    "curie": build_approval_server(approval_gate),
    **({STATE_SERVER_NAME: build_state_server(state_client)} if state_client else {}),
    **derive_mcp_servers(...),          # <- this change
},
```

So the read-only bundle mount is a non-issue and the deployed artifact stays byte-identical to what was validated. #1149 already made a name collision with the bundle's own MCP config a deploy-time error, so there's no precedence to resolve here.

## Degradation is deliberate

| Situation | Behaviour | Why |
|---|---|---|
| hosted connector, no scope | mounts nothing | `skill` tier hosts nothing; a URL resolving nowhere turns "not exercisable here" (#1093) into a mid-turn connection refused |
| **remote** connector, no scope | **mounts** | carries its own absolute url — exercisable in every tier |
| unreadable / invalid `connectors.yaml` | logs, mounts nothing | deploy already validated it, so this means the bundle changed underneath us; losing a connector's tools is visible, losing the session is worse |

## This PR is inert on its own

With all three scope values absent, **nothing changes on any tier.** That's intentional — it makes this safe to merge ahead of the worker half.

## What's left, and why it isn't here

The worker needs to fill the scope in, which needs two things it doesn't have today:

- **the agent name** — `ResolvedDeployment` carries `agent_id` but not `name`; needs a column in the binding query
- **the release name** — nothing in the worker carries it; needs a new config value

`namespace` already exists as `SubstrateConfig.namespace`. I'd rather scope that properly than guess at worker internals I haven't mapped, so it's filed separately.

## Verification

```
runner tests       → 486 passed, 4 skipped (9 new)
mypy               → no issues, 166 files
ruff check         → All checks passed
check-contracts.sh → all committed artifacts current
```