### PR TITLE
Worker tells the sandbox where its connectors live (#1118)

### DIFF
--- a/apps/worker/src/curie_worker/binding.py
+++ b/apps/worker/src/curie_worker/binding.py
@@ -153,6 +153,7 @@ def _parse_resume_event_id(event_id: str) -> uuid.UUID | None:
 
 _RESOLVE_SQL = """
 SELECT a.id AS agent_id,
+       a.name AS agent_name,
        a.max_usd_per_day AS max_usd_per_day,
        a.max_output_tokens_per_run AS max_output_tokens_per_run,
        a.behavior_packs AS behavior_packs,
@@ -175,6 +176,10 @@ class ResolvedDeployment(BaseModel):
     """The agent binding for a channel: which version to run and its budget."""
 
     agent_id: uuid.UUID
+    # The agent's NAME, not just its id: connector object names are agent-scoped
+    # (#1116) and use the name, so the runner needs it to derive a URL that
+    # matches the Service that exists.
+    agent_name: str
     version_id: uuid.UUID
     version_label: str
     bundle_ref: str | None
@@ -569,6 +574,13 @@ class BindingResolver:
             # tool calls via can_use_tool and pauses awaiting approval. Names are
             # comma-joined by the render (validated comma-free at the API).
             approval_required_tools=resolved.approval_required_tools,
+            # Where this sandbox's hosted connectors live (ADR-0086, #1118).
+            # render_worker emits these as a SET or not at all, so an install
+            # missing either operator value yields no scope rather than a
+            # partial one naming a Service that cannot exist.
+            connector_release=self._config.connector_release or None,
+            connector_agent=resolved.agent_name,
+            connector_namespace=self._config.connector_namespace or None,
             # The agent's pinned model (#254) overrides the worker default; None
             # falls back to the platform default.
             model=resolved.model if resolved.model is not None else self._config.model,

--- a/apps/worker/src/curie_worker/config.py
+++ b/apps/worker/src/curie_worker/config.py
@@ -150,6 +150,17 @@ class WorkerConfig(BaseSettings):
         default=False, validation_alias="CURIE_FALSE_COMPLETION_CHECK"
     )
 
+    # Where this release's hosted connectors live (ADR-0086, #1118). The runner
+    # derives each declared connector's MCP URL from the Service Curie created,
+    # `<release>-<agent>-mcp-<connector>` in `<namespace>`, and neither value is
+    # knowable inside the sandbox: the Helm release name lives with whoever ran
+    # `cluster up`. Both default empty, and the boot env carries the connector
+    # scope only when the whole set resolves -- so a worker that predates the
+    # chart plumbing simply mounts no hosted connector rather than emitting a
+    # scope that names a Service which cannot exist.
+    connector_release: str = Field(default="", validation_alias="CURIE_RELEASE")
+    connector_namespace: str = Field(default="", validation_alias="CURIE_NAMESPACE")
+
     # When true, clear the Slack assistant-thread status (the "shimmer" the
     # dispatcher set) once a turn ends -- editing the placeholder does not
     # auto-clear it. Off by default; pairs with the dispatcher's CURIE_SHIMMER.

--- a/apps/worker/tests/binding/test_boot_env_golden.py
+++ b/apps/worker/tests/binding/test_boot_env_golden.py
@@ -51,6 +51,7 @@ _STATE_URL = f"http://localhost:8000/agents/{_AGENT}/state"
 
 def _resolved(**kwargs: object) -> ResolvedDeployment:
     base: dict[str, object] = {
+        "agent_name": "test-agent",
         "agent_id": _AGENT,
         "version_id": uuid.UUID("22222222-2222-4222-8222-222222222222"),
         "version_label": "v1",
@@ -313,3 +314,23 @@ def test_inject_connector_secrets_is_the_markers_sole_writer() -> None:
 
     inject_connector_secrets(rendered, {"GITHUB_TOKEN": "ghp-1"}, agent_label=_AGENT)
     assert rendered["CURIE_CONNECTOR_SECRET_KEYS"] == "GITHUB_TOKEN"
+
+
+def test_connector_scope_reaches_the_sandbox_when_the_release_is_configured() -> None:
+    # The runner derives `<release>-<agent>-mcp-<connector>.<namespace>` and can
+    # know none of those three from inside the sandbox (ADR-0086, #1118).
+    env = _boot_env(
+        WorkerConfig(connector_release="curie", connector_namespace="curie"),
+        _resolved(),
+    )
+    assert env["CURIE_CONNECTOR_RELEASE"] == "curie"
+    assert env["CURIE_CONNECTOR_AGENT"] == "test-agent"
+    assert env["CURIE_CONNECTOR_NAMESPACE"] == "curie"
+
+
+def test_no_connector_scope_when_the_release_is_unset() -> None:
+    # An install that predates the chart plumbing emits NO scope rather than a
+    # partial one naming a Service that cannot exist. The runner then mounts no
+    # hosted connector, which is visible, instead of dialing a dead address.
+    env = _boot_env(WorkerConfig(connector_namespace="curie"), _resolved())
+    assert not [k for k in env if k.startswith("CURIE_CONNECTOR_")]

--- a/apps/worker/tests/binding/test_boot_env_single_declaration.py
+++ b/apps/worker/tests/binding/test_boot_env_single_declaration.py
@@ -114,6 +114,11 @@ _NON_BOOT_ALLOWLIST: frozenset[str] = frozenset(
         "CURIE_CLAIM_TIMEOUT_SECONDS",
         "CURIE_DOCKER_NETWORK",
         "CURIE_NAMESPACE",
+        # The Helm release name (ADR-0086, #1118). Read from the WORKER's env by
+        # WorkerConfig, exactly like CURIE_NAMESPACE above, and never injected
+        # into a sandbox: what the runner receives is the derived connector
+        # scope (CURIE_CONNECTOR_RELEASE), which IS a declared BootEnv key.
+        "CURIE_RELEASE",
         "CURIE_RUNNER_IMAGE",
         "CURIE_SANDBOX_SUBSTRATE",
         "CURIE_WARM_POOL",

--- a/apps/worker/tests/binding/test_model_env.py
+++ b/apps/worker/tests/binding/test_model_env.py
@@ -28,6 +28,7 @@ from curie_worker.sandbox_token import verify
 def _resolved(model: str | None = None) -> ResolvedDeployment:
     return ResolvedDeployment(
         agent_id=uuid.uuid4(),
+        agent_name="test-agent",
         version_id=uuid.uuid4(),
         version_label="v1",
         bundle_ref="bundles/x.zip",

--- a/apps/worker/tests/binding/test_resolver.py
+++ b/apps/worker/tests/binding/test_resolver.py
@@ -778,6 +778,7 @@ def test_boot_env_mints_no_token_when_the_signing_key_is_empty() -> None:
         resolver = BindingResolver(engine, WorkerConfig(db_schema=_SCHEMA, api_key=""))
         resolved = ResolvedDeployment(
             agent_id=uuid.uuid4(),
+            agent_name="test-agent",
             version_id=uuid.uuid4(),
             version_label="v",
             bundle_ref=None,

--- a/apps/worker/tests/kernel/test_approval_lifecycle.py
+++ b/apps/worker/tests/kernel/test_approval_lifecycle.py
@@ -239,6 +239,7 @@ class GrantBinding:
 
         return ResolvedDeployment(
             agent_id=self.agent_id,
+            agent_name="test-agent",
             version_id=uuid.uuid4(),
             version_label="v1",
             bundle_ref=None,
@@ -452,6 +453,7 @@ class RoutedBinding:
 
         return ResolvedDeployment(
             agent_id=self.agent_id,
+            agent_name="test-agent",
             version_id=uuid.uuid4(),
             version_label="v1",
             bundle_ref=None,

--- a/apps/worker/tests/kernel/test_binding_integration.py
+++ b/apps/worker/tests/kernel/test_binding_integration.py
@@ -49,6 +49,7 @@ class StubBinding:
 def _resolved(agent_id: uuid.UUID, *, bundle: str | None = "bundles/x.zip") -> ResolvedDeployment:
     return ResolvedDeployment(
         agent_id=agent_id,
+        agent_name="test-agent",
         version_id=uuid.uuid4(),
         version_label="v1",
         bundle_ref=bundle,
@@ -193,6 +194,7 @@ def test_kill_interrupts_a_live_turn(make_harness) -> None:
 def _resolved_with_packs(behavior_packs: dict) -> ResolvedDeployment:
     return ResolvedDeployment(
         agent_id=uuid.uuid4(),
+        agent_name="test-agent",
         version_id=uuid.uuid4(),
         version_label="v1",
         bundle_ref="bundles/x.zip",

--- a/charts/curie/templates/worker.yaml
+++ b/charts/curie/templates/worker.yaml
@@ -96,6 +96,12 @@ spec:
             # pool to claim from, and the ACI port on each claimed sandbox.
             - name: CURIE_NAMESPACE
               value: {{ .Release.Namespace | quote }}
+            # The Helm release name, so the worker can tell the sandbox where
+            # its hosted connectors live (ADR-0086, #1118). Connector object
+            # names are `<release>-<agent>-mcp-<connector>`, and the release
+            # name is knowable only here.
+            - name: CURIE_RELEASE
+              value: {{ .Release.Name | quote }}
             - name: CURIE_WARM_POOL
               value: {{ $warmPool | quote }}
             - name: CURIE_RUNNER_PORT


### PR DESCRIPTION
Last piece of #1118. Refs ADR-0086. Base `main`, **not stacked**.

#1151 taught the runner to derive a connector's MCP URL. It can't know the release, the agent, or the namespace from inside the sandbox. The worker knows all three and builds the boot env.

## Three changes

| Where | What |
|---|---|
| `WorkerConfig` | `CURIE_RELEASE` + `CURIE_NAMESPACE` (operator scope, worker's own env) |
| binding query | `a.name AS agent_name` — it selected the id but not the name |
| `render_worker` | pass the scope through |

The agent **name** matters because connector object names are agent-scoped on the name since #1116, not on the id.

## Why `agent_name` is required, not defaulted

An empty name renders `curie--mcp-grafana` — a double dash. It looks plausible and matches no Service. Failing at construction beats deriving a name nothing answers to.

That made it a required field, which broke 7 test fixtures. Fixed rather than softened.

## Missing config yields no scope, not a partial one

An install predating the chart plumbing emits **nothing**, so the runner mounts no hosted connector — visible — instead of dialing a dead address mid-turn. Pinned by `test_no_connector_scope_when_the_release_is_unset`.

## Two existing guards caught real mistakes, both mine

**`EvalJob` rejected a stray field.** My fixture patch was a blind regex that added `agent_name` to `EvalJob(...)` blocks as well as `ResolvedDeployment(...)` ones. `EvalJob` is a strict ACI wire model and refused it on construction — exactly what "strict producers, tolerant consumers" is for.

**The boot-env single-declaration test refused `CURIE_RELEASE`** as neither a declared `BootEnv` key nor an allowlisted non-boot name. It's the worker's own setting, like `CURIE_NAMESPACE` sitting beside it, so it joins the substrate-wiring group. What reaches a sandbox is the derived `CURIE_CONNECTOR_RELEASE`, which *is* a declared key.

Neither would have been caught by review.

## Baseline verified, not assumed

I stashed and measured `main` rather than trusting that the failures were pre-existing:

```
main    → 27 failed, 67 passed, 3 skipped
this PR → 27 failed, 69 passed, 3 skipped
```

Identical 27 — the local dev Postgres is down (`Connect call failed ... 25432`). The 2 added passes are the new tests. Zero regressions.

```
mypy               → no issues, 165 files
ruff check         → All checks passed
kernel tests       → 5 passed, 98 skipped (no local Valkey/K8s), 0 agent_name errors
helm template      → renders CURIE_RELEASE: "t"
```

## After this, #1118 is closed

`connectors.yaml` → Curie creates the Service → the runner mounts it → the agent calls it, with **no URL anywhere in the bundle**. That completes what ADR-0086 promised.

**Still not live-verified.** No cluster has been reachable while building any of this.
