### PR TITLE
Record the always-on note dialog as the decision it is

### DIFF
--- a/apps/dispatcher/src/curie_dispatcher/handlers.py
+++ b/apps/dispatcher/src/curie_dispatcher/handlers.py
@@ -255,6 +255,20 @@ def register_handlers(
 
     # Approval-card clicks (#246): resolve through the API (which enforces the
     # authorizer server-side) and render the verdict; never enqueue a turn.
+    #
+    # MIGRATION-ONLY as of #1059 (#1076). The kernel now emits every approval
+    # Confirm intent with `allow_free_text`, so every card this worker posts
+    # carries the note-collecting pair below. This pair is still registered
+    # because a card posted by a PRE-#1059 worker can still be pending and
+    # clickable, and dropping the listener would answer that click with nothing.
+    #
+    # Removal condition, and it is not a clock: an approval with no SLA never
+    # expires (`crud.create_approval` leaves `expires_at` NULL when the request
+    # named no `expires_in_seconds`, and the sweeper only selects rows where it
+    # is NOT NULL), so pre-#1059 cards do not all drain on their own. This pair
+    # can go once `curie <tier> approvals <AGENT> --list` shows no pending
+    # approval created before the deploy that introduced the note variants --
+    # checked per install, not assumed after some interval.
     @app.action(APPROVE_ACTION_ID)
     def _on_approve(ack: Callable[..., None], body: dict[str, Any]) -> None:
         ack()
@@ -278,9 +292,11 @@ def register_handlers(
         )
 
     # The note-collecting variants (#1053): a click OPENS a dialog and resolves
-    # nothing; the submission below does the resolving. A card carries this pair
-    # only when the kernel emitted its Confirm intent with `allow_free_text`, so
-    # the immediate pair above stays the behavior for every other card.
+    # nothing; the submission below does the resolving. This is the pair EVERY
+    # card posted by this worker carries -- the kernel sets `allow_free_text`
+    # unconditionally, a decision recorded there and in docs/approvals.md
+    # (#1076). The pair above is the migration entry point for older cards, not
+    # a second live behavior; the earlier wording claimed otherwise.
     @app.action(APPROVE_NOTE_ACTION_ID)
     def _on_approve_with_note(ack: Callable[..., None], body: dict[str, Any]) -> None:
         ack()

--- a/apps/worker/src/curie_worker/kernel.py
+++ b/apps/worker/src/curie_worker/kernel.py
@@ -1087,6 +1087,29 @@ class Kernel:
                     # leaves already reaches the requester -- the API stores it
                     # on the record and build_resume_turn interpolates it into
                     # the platform-authored resume text.
+                    #
+                    # UNCONDITIONAL, and that is the decision rather than an
+                    # oversight (#1076). It costs an approver who wants no note
+                    # one extra click, on every approval, in every deployment,
+                    # so it was worth stating rather than leaving as the only
+                    # reachable arm of a branch that looked configurable.
+                    #
+                    # Rejected: exposing a per-agent or env toggle. A reason is
+                    # the half of a rejection the requester actually needs, and
+                    # the dialog is what makes leaving one the default rather
+                    # than a thing you remember to do from the CLI. A toggle
+                    # would also keep TWO settled-card render paths alive
+                    # permanently, which is what #1073 and #1084 exist to
+                    # collapse into one. And the evidence for whether operators
+                    # want the opt-out does not exist yet: discussion #1061
+                    # settles that the approval plane's plumbing gets fixed
+                    # first and governance knobs are decided from evidence
+                    # after, which applies to this knob as much as to #1054's.
+                    #
+                    # If that evidence arrives, this field is still the one flip
+                    # -- but the flip needs an operator-written source, never a
+                    # bundle-declared one (the #520 anti-hollow-out rule: an
+                    # agent must not widen how its own approvals are collected).
                     allow_free_text=True,
                 ),
             )

--- a/apps/worker/tests/kernel/test_approval_lifecycle.py
+++ b/apps/worker/tests/kernel/test_approval_lifecycle.py
@@ -414,7 +414,56 @@ def test_pause_emits_a_confirm_intent_for_the_approval_card(make_harness) -> Non
             # not only at the renderer, because this is the field that decides
             # whether the real product path offers a note at all -- a renderer
             # test alone would stay green with the kernel emitting the default.
+            #
+            # #1076: and asserted UNCONDITIONALLY, because the value being the
+            # same for every card is itself the decision. Nothing here reads
+            # config, so if a toggle is ever added this assertion is where the
+            # change surfaces, rather than the always-on behavior quietly
+            # becoming sometimes-on.
             assert intent.allow_free_text is True
+
+    asyncio.run(go())
+
+
+def test_every_posted_card_carries_the_note_variant(make_harness) -> None:
+    """#1076: always-on is the decision, so pin it across card SHAPES.
+
+    ``allow_free_text`` is set at one call site with no config behind it, which
+    is easy to read as an accident of that call site. This drives the two shapes
+    that differ -- the in-thread card of an UNROUTED approval and the top-level
+    card of a ROUTED one -- and asserts both carry it. A change that made it
+    conditional on the routing branch would fail here rather than surfacing only
+    as a UX difference nobody tests.
+    """
+
+    async def go() -> None:
+        # Unrouted: the card joins the requesting thread.
+        async with make_harness(approvals=RecordingApprovals()) as h:
+            h.runner.default_script = _awaiting_script("Give ACME a 20% discount")
+            await h.kernel.process_event(_qevent("please discount", thread="th-unrouted"))
+            unrouted = h.sink.posts[0]
+
+        # Routed: the card posts top-level in the bound channel.
+        binding = RoutedBinding({"finance": {"channel": "C_FINANCE"}})
+        async with make_harness(approvals=RecordingApprovals(), binding=binding) as h:
+            h.runner.default_script = _awaiting_routed_script("Approve the invoice", "finance")
+            await h.kernel.process_event(_qevent("please invoice", thread="th-routed"))
+            routed = h.sink.posts[0]
+
+        # The two really are different shapes, or this test proves nothing.
+        assert unrouted[3] == "th-unrouted", "the unrouted card must be in-thread"
+        assert routed[3] is None, "the routed card must be top-level"
+
+        for label, (channel, message, _by, _ts, _endpoint) in (
+            ("unrouted", unrouted),
+            ("routed", routed),
+        ):
+            intent = message.interaction
+            assert isinstance(intent, ConfirmIntent)
+            assert intent.allow_free_text is True, (
+                f"the {label} card for {channel} came without the note variant; "
+                "every card carries it (#1076)"
+            )
 
     asyncio.run(go())
 

--- a/docs/approvals.md
+++ b/docs/approvals.md
@@ -131,6 +131,14 @@ and it is stored on the record, stamped onto the card in the approver channel, a
 carried to the requester in the resume turn below. Cancelling the dialog resolves
 nothing, so a misclick is recoverable.
 
+The dialog is not optional the way the note is: **every** approval card opens one, in
+every deployment, with no toggle. That costs an approver who wants no note one extra
+click, and it is deliberate. A reason is the half of a rejection the requester actually
+needs, and the dialog is what makes leaving one the default rather than something you
+remember to do from the CLI. If a deployment turns out to want the opt-out, it would be
+operator-written config, never a bundle-declared field: an agent must not get to widen
+how its own approvals are collected.
+
 Three properties worth knowing before you design around this:
 
 - **Self-approval is refused under every set.** The author of the turn that raised the


### PR DESCRIPTION
Closes #1076. First of three in the Wave 2 settled-card sequence: this one is the **decision**, #1073 is the shared renderer, #1084 puts the worker's resume path on it.

## The problem

#1059 set `allow_free_text=True` with no toggle behind it, and `kernel.py` is the only production `ConfirmIntent` constructor in the tree:

```
$ grep -rn "ConfirmIntent(" apps/ packages/ --include=*.py | grep -v tests
apps/worker/src/curie_worker/kernel.py:1075
packages/channel-protocol/src/channel_protocol/models.py:62   (the model itself)
```

So the renderer's branch has one reachable arm, and the comment defending the other one claimed a population that does not exist:

> the immediate pair above stays the behavior for **every other card**.

There is no every other card. Two things were wrong at once: an unannounced product-wide UX change shipped inside a PR titled "collect an optional note", and a dead-looking branch defended by a false comment.

## The choice, and why this one

Expose the flip, or state that always-on is intended. **This states it**, with the reasoning written at the call site rather than left to be re-derived:

- A reason is the half of a rejection the requester actually needs, and the dialog is what makes leaving one the default rather than something you remember to do from the CLI.
- A toggle would keep **two settled-card render paths alive permanently**, which is exactly what #1073 and #1084 exist to collapse into one.
- The evidence does not exist yet. Discussion #1061 settles that this plane's plumbing gets fixed first and governance knobs are decided from evidence after. That reasoning applies to *this* knob as much as to #1054's, and adding one now would be doing the thing that discussion just decided not to do.

The rejected alternative is recorded with the constraint that would govern it if it comes back: the flip must be **operator-written config, never a bundle-declared field**. An agent must not widen how its own approvals are collected — #520's anti-hollow-out rule, applied on the collection side rather than the gating side.

## The migration pair, described honestly

`_on_approve` / `_on_reject` stay registered, because a card a pre-#1059 worker posted can still be pending and clickable, and dropping the listener would answer that click with silence. That is a real reason; the old comment gave a different, false one.

Its removal condition is now stated, and **deliberately is not a clock**:

> An approval with no SLA never expires — `create_approval` leaves `expires_at` NULL when the request named no `expires_in_seconds`, and the sweeper only selects rows where it is NOT NULL. So pre-#1059 cards do not all drain on their own. This pair can go once `curie <tier> approvals <AGENT> --list` shows no pending approval created before the deploy that introduced the note variants — checked per install, not assumed after some interval.

I went looking for a "wait 24 hours" answer (the suspended-route TTL) and it is the wrong bound: that TTL governs the sandbox route, not the approval record.

## The test

`test_every_posted_card_carries_the_note_variant` drives the two card **shapes** that differ — the in-thread card of an unrouted approval and the top-level card of a routed one — and asserts both carry the note variant.

The shape difference is itself asserted (`thread_ts == "th-unrouted"` vs `thread_ts is None`), so the test cannot pass by accidentally driving the same path twice. That mattered: the value is set at one call site with no config behind it, which is easy to read as an accident of that call site rather than an invariant.

Verified it catches a regression by flipping the field to `False`:

```
FAILED test_pause_emits_a_confirm_intent_for_the_approval_card
FAILED test_every_posted_card_carries_the_note_variant
2 failed, 19 deselected
```

and restored: `2 passed`.

## Scope

**No behavior change.** Comments, one doc paragraph, one test. The runtime is byte-identical.

## Verification

Dev-stack Valkey and Postgres up (the dispatcher approval suites skip without Valkey; the worker binding suite needs Postgres):

```
uv run ruff check .                          All checks passed
uv run mypy                                  no issues in 166 source files
uv run pytest apps/dispatcher apps/worker    654 passed, 11 skipped
curie dev docs-lint                          OK
```

## Notes for review

- If review prefers **exposing the toggle** instead, the change is contained: this PR's value is the recorded reasoning either way, and swapping the conclusion means adding config rather than unpicking anything.
- `kernel.py` is touched, but comment-only. Flagging it anyway since `apps/worker/CLAUDE.md` asks for adversarial review on that module — the diff there is a comment block and nothing else.
