### PR TITLE
Assert Rail 1 actually enforces, and give CI a CNI that can (#1153)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -906,11 +906,24 @@ jobs:
       # kind config: map the UI NodePort (chart default 30080) to the host so
       # `cluster deploy`'s UI `/api` NodePort discovery -- which resolves the
       # loopback kubeconfig host (127.0.0.1) -- reaches the in-cluster API.
+      #
+      # disableDefaultCNI is load-bearing (#1153). kind's default kindnet
+      # implements NO NetworkPolicy controller, so every policy the chart ships
+      # -- including Rail 1's default-deny egress for runner sandboxes
+      # (ADR-0067) -- is applied and then silently never evaluated. A totally
+      # broken policy is indistinguishable from a correct one, which is how an
+      # egress rule naming a Service ClusterIP (unmatchable: kube-proxy DNATs
+      # to a pod IP before policy runs) reached a real cluster. Calico is
+      # installed below so this cluster behaves like the k3s and EKS clusters
+      # Curie actually runs on.
       - name: Write the kind cluster config
         run: |
           cat > kind-config.yaml <<'EOF'
           kind: Cluster
           apiVersion: kind.x-k8s.io/v1alpha4
+          networking:
+            disableDefaultCNI: true
+            podSubnet: "192.168.0.0/16"
           nodes:
             - role: control-plane
               extraPortMappings:
@@ -951,6 +964,14 @@ jobs:
           node_image: kindest/node:v1.31.0
           cluster_name: curie-e2e
           config: kind-config.yaml
+      # The cluster has no CNI until this lands (disableDefaultCNI above), so
+      # every node stays NotReady and nothing schedules until Calico is up.
+      - name: Install Calico so NetworkPolicy is actually enforced
+        run: |
+          set -euo pipefail
+          kubectl apply -f https://raw.githubusercontent.com/projectcalico/calico/v3.28.2/manifests/calico.yaml
+          kubectl -n kube-system rollout status daemonset/calico-node --timeout=300s
+          kubectl wait --for=condition=Ready node --all --timeout=300s
       # Load the four locally-built images into the node store so the install's
       # pullPolicy Never overrides bind them with no registry pull.
       - name: Load images into the kind cluster
@@ -1035,6 +1056,16 @@ jobs:
           CURIE_BIN: cli/target/release/curie
           CURIE_E2E_TIERS: cluster
         run: bash cli/scripts/e2e-ladder.sh
+      # Rail 1 (ADR-0067) is a load-bearing security control that nothing else
+      # here asserts ENFORCES -- only that its policies exist (#1153). Runs
+      # after the round trip so a genuine turn failure surfaces first, and is
+      # itself a non-vacuity check: it proves a DENIED direction is blocked
+      # before trusting any allowed one, so it fails rather than passes green
+      # if the CNI ever stops enforcing.
+      - name: Rail 1 enforces (not just applied)
+        env:
+          CURIE_BIN: cli/target/release/curie
+        run: bash scripts/check-netpol-enforcement.sh curie curie curie
       # Surface why on any failure above: pod states, recent events, and the
       # worker/runner logs are what localize a reachability or scheduling break.
       - name: Dump cluster diagnostics on failure

--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -3511,6 +3511,11 @@ export const commandManifest = {
           "name": "emit-parity"
         },
         {
+          "about": "Assert Rail 1 (ADR-0067) actually ENFORCES on the cluster kubectl points at, not merely that its NetworkPolicies are applied (#1153, `bash scripts/check-netpol-enforcement.sh`). Structured as a non-vacuity check: it proves a DENIED direction is genuinely blocked before trusting any allowed one, so a CNI that ignores NetworkPolicy (kindnet, minikube's default) FAILS rather than passing green",
+          "hidden": false,
+          "name": "netpol-check"
+        },
+        {
           "about": "Assert the release-coupled versions agree: cli/Cargo.toml, Chart.yaml version, and appVersion (`bash scripts/check-version-consistency.sh`)",
           "hidden": false,
           "name": "version-check"

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -3508,6 +3508,11 @@
           "name": "emit-parity"
         },
         {
+          "about": "Assert Rail 1 (ADR-0067) actually ENFORCES on the cluster kubectl points at, not merely that its NetworkPolicies are applied (#1153, `bash scripts/check-netpol-enforcement.sh`). Structured as a non-vacuity check: it proves a DENIED direction is genuinely blocked before trusting any allowed one, so a CNI that ignores NetworkPolicy (kindnet, minikube's default) FAILS rather than passing green",
+          "hidden": false,
+          "name": "netpol-check"
+        },
+        {
           "about": "Assert the release-coupled versions agree: cli/Cargo.toml, Chart.yaml version, and appVersion (`bash scripts/check-version-consistency.sh`)",
           "hidden": false,
           "name": "version-check"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -419,6 +419,13 @@ enum DevAction {
     /// downstream of `field-parity`, `bash cli/scripts/check-emit-parity.sh`).
     /// Offline, no credential.
     EmitParity,
+    /// Assert Rail 1 (ADR-0067) actually ENFORCES on the cluster kubectl points
+    /// at, not merely that its NetworkPolicies are applied (#1153,
+    /// `bash scripts/check-netpol-enforcement.sh`). Structured as a
+    /// non-vacuity check: it proves a DENIED direction is genuinely blocked
+    /// before trusting any allowed one, so a CNI that ignores NetworkPolicy
+    /// (kindnet, minikube's default) FAILS rather than passing green.
+    NetpolCheck,
     /// Assert the release-coupled versions agree: cli/Cargo.toml, Chart.yaml
     /// version, and appVersion (`bash scripts/check-version-consistency.sh`).
     VersionCheck,
@@ -1663,6 +1670,9 @@ async fn run(command: Option<Command>) -> Result<()> {
                 commands::dev_script("cli/scripts/check-field-parity.sh").await
             }
             DevAction::EmitParity => commands::dev_script("cli/scripts/check-emit-parity.sh").await,
+            DevAction::NetpolCheck => {
+                commands::dev_script("scripts/check-netpol-enforcement.sh").await
+            }
             DevAction::VersionCheck => {
                 commands::dev_script("scripts/check-version-consistency.sh").await
             }

--- a/scripts/check-netpol-enforcement.sh
+++ b/scripts/check-netpol-enforcement.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# Assert Rail 1 (ADR-0067) actually ENFORCES, not merely that it is applied.
+#
+# The distinction is the whole point. Every NetworkPolicy the chart ships is
+# applied on any cluster; whether it is EVALUATED depends on the CNI. kindnet
+# (kind's default) and minikube's default bridge implement no NetworkPolicy
+# controller, so a totally broken Rail 1 is indistinguishable from a correct one
+# -- both let everything through, and every "can the sandbox reach X?" assertion
+# passes. That is how an egress rule naming a Service ClusterIP, which can never
+# match because kube-proxy DNATs to a pod IP before policy is evaluated, reached
+# a real cluster (#1153).
+#
+# So this is structured as a NON-VACUITY check. It asserts a denied direction is
+# genuinely blocked BEFORE trusting any allowed direction. If the deny does not
+# hold, the CNI is not enforcing and the script FAILS -- it does not skip and it
+# does not pass. A green run on a non-enforcing cluster would be worse than no
+# check at all, because it reads as proof.
+set -euo pipefail
+
+NS="${1:-${CURIE_NETPOL_NS:-curie}}"
+RELEASE="${2:-${CURIE_NETPOL_RELEASE:-curie}}"
+APP="${3:-${CURIE_NETPOL_APP:-curie}}"
+PROBE_IMAGE="${CURIE_NETPOL_PROBE_IMAGE:-curlimages/curl:8.10.1}"
+# The deny target must actually LISTEN, so a blocked attempt is a timeout rather
+# than an ambiguous connection-refused that a missing listener would also give.
+TARGET_IMAGE="${CURIE_NETPOL_TARGET_IMAGE:-hashicorp/http-echo:1.0}"
+
+SANDBOX_POD="netpol-probe-sandbox"
+OUTSIDE_POD="netpol-probe-outside"
+
+# Non-blocking on the way out: the run is over, nothing waits on the pods.
+cleanup() {
+  kubectl -n "$NS" delete pod "$SANDBOX_POD" "$OUTSIDE_POD" \
+    --ignore-not-found --wait=false >/dev/null 2>&1 || true
+}
+# BLOCKING before the apply. A previous run's pod may still be terminating, and
+# re-applying the same name against a deleting pod silently binds the OLD one --
+# `wait --for=Ready` then passes on a pod that is on its way out and every exec
+# after it fails for reasons that have nothing to do with policy.
+cleanup_and_settle() {
+  kubectl -n "$NS" delete pod "$SANDBOX_POD" "$OUTSIDE_POD" \
+    --ignore-not-found --wait=true --timeout=90s >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+echo "== Rail 1 enforcement check (namespace=$NS release=$RELEASE app=$APP) =="
+
+kubectl -n "$NS" get networkpolicy "${RELEASE}-runner-default-deny-egress" >/dev/null 2>&1 \
+  || fail "no ${RELEASE}-runner-default-deny-egress in $NS; is the chart installed?"
+
+# The sandbox probe wears exactly the labels Rail 1 selects, so the policies
+# under test apply to it. The outside probe wears none, and is the target the
+# sandbox must NOT reach.
+cleanup_and_settle
+kubectl -n "$NS" apply -f - >/dev/null <<YAML
+apiVersion: v1
+kind: Pod
+metadata:
+  name: $SANDBOX_POD
+  labels:
+    app.kubernetes.io/name: $APP
+    app.kubernetes.io/instance: $RELEASE
+    app.kubernetes.io/component: runner-sandbox
+spec:
+  restartPolicy: Never
+  containers:
+    - name: probe
+      image: $PROBE_IMAGE
+      command: ["sleep", "600"]
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: $OUTSIDE_POD
+  labels:
+    app.kubernetes.io/name: netpol-probe-outside
+spec:
+  restartPolicy: Never
+  containers:
+    - name: probe
+      image: $TARGET_IMAGE
+      args: ["-listen=:8000", "-text=reachable"]
+YAML
+
+kubectl -n "$NS" wait --for=condition=Ready "pod/$SANDBOX_POD" "pod/$OUTSIDE_POD" --timeout=180s >/dev/null \
+  || fail "probe pods did not become ready"
+
+OUTSIDE_IP="$(kubectl -n "$NS" get pod "$OUTSIDE_POD" -o jsonpath='{.status.podIP}')"
+[ -n "$OUTSIDE_IP" ] || fail "could not read the outside probe's pod IP"
+
+# ---------------------------------------------------------------------------
+# GATE: the deny must hold. Everything below is meaningless without this.
+# ---------------------------------------------------------------------------
+# Rail 1 denies all sandbox egress except what an allow policy adds, and nothing
+# allows the outside probe. Reaching it means policy is not being evaluated.
+if kubectl -n "$NS" exec "$SANDBOX_POD" -- \
+     curl -s -m 8 -o /dev/null "http://${OUTSIDE_IP}:8000/" 2>/dev/null; then
+  fail "the sandbox reached a pod Rail 1 denies.
+
+This is NOT a policy bug -- it means the CNI is not enforcing NetworkPolicy at
+all, so every other assertion here would pass vacuously and this suite would
+certify a broken Rail 1 as working.
+
+  kind      needs 'disableDefaultCNI: true' plus a policy-enforcing CNI;
+            the default kindnet implements no NetworkPolicy controller.
+  minikube  needs 'minikube start --cni=calico'.
+  k3s/k3d   enforce by default via kube-router.
+
+Re-run against a cluster whose CNI enforces."
+fi
+echo "  ok  deny holds -- the CNI enforces NetworkPolicy (non-vacuity gate)"
+
+# ---------------------------------------------------------------------------
+# Now the allow direction means something.
+# ---------------------------------------------------------------------------
+# DNS is the allow every sandbox depends on (curie-runner-allow-dns); without it
+# a sandbox cannot resolve any Service name, which surfaces as a confusing
+# connection failure rather than a policy error.
+if ! kubectl -n "$NS" exec "$SANDBOX_POD" -- \
+      getent hosts kubernetes.default.svc.cluster.local >/dev/null 2>&1; then
+  fail "the sandbox cannot resolve DNS; ${RELEASE}-runner-allow-dns is not effective"
+fi
+echo "  ok  allow holds -- the sandbox can resolve DNS"
+
+# Any connector Service present is exercised too: this is the rule that was
+# silently broken by the ipBlock form, so it is the one most worth asserting.
+CONNECTORS="$(kubectl -n "$NS" get svc -l app.kubernetes.io/part-of="$RELEASE" \
+  -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null | grep -- "-mcp-" || true)"
+if [ -z "$CONNECTORS" ]; then
+  echo "  --  no connector Services in $NS; skipping the connector reachability leg"
+else
+  while IFS= read -r svc; do
+    [ -n "$svc" ] || continue
+    PORT="$(kubectl -n "$NS" get svc "$svc" -o jsonpath='{.spec.ports[0].port}')"
+    kubectl -n "$NS" exec "$SANDBOX_POD" -- \
+      curl -s -m 10 -o /dev/null "http://${svc}:${PORT}/" 2>/dev/null \
+      || fail "the sandbox cannot reach connector Service $svc:$PORT.
+
+Its egress rule is applied but not matching. The usual cause is an ipBlock of
+the Service ClusterIP: kube-proxy DNATs the destination to a pod IP before
+NetworkPolicy is evaluated, so such a rule can never match (ADR-0086)."
+    echo "  ok  sandbox reaches connector $svc:$PORT"
+  done <<<"$CONNECTORS"
+fi
+
+echo "== Rail 1 enforces, and every allowed path is reachable =="


### PR DESCRIPTION
Fixes #1153. Base `main`, not stacked.

Rail 1 (ADR-0067) is a load-bearing security control that **nothing verified enforces** — only that its policies exist. CI's kind cluster runs kindnet, which implements no NetworkPolicy controller, so every policy the chart ships is applied and then silently never evaluated.

**A totally broken Rail 1 goes green today.**

## Not theoretical

This is how an egress rule naming a Service ClusterIP reached a real cluster — kube-proxy DNATs to a pod IP before policy is evaluated, so the rule can never match. Verified live on `minikube --cni=calico`, same manifests both ways:

```
podSelector form (correct)         →  HTTP 200
ipBlock of the Service ClusterIP   →  TIMEOUT
```

On a non-enforcing CNI **both return 200** and the bug is invisible.

## Three changes

**1. CI's kind cluster gets a CNI that enforces.** `disableDefaultCNI: true` plus Calico, so it behaves like the k3s and EKS clusters Curie actually runs on rather than a permissive stub.

**2. `scripts/check-netpol-enforcement.sh` asserts enforcement**, structured as a **non-vacuity check** — it proves a DENIED direction is genuinely blocked *before* trusting any allowed one:

```
ok  deny holds -- the CNI enforces NetworkPolicy (non-vacuity gate)
ok  allow holds -- the sandbox can resolve DNS
ok  sandbox reaches connector curie-acme-dev-mcp-grafana:8000
```

Asserting only that the sandbox *can* reach the connector passes on a cluster enforcing nothing — worse than no check, because it reads as proof. When the deny doesn't hold it **fails**, naming the per-tool fix, rather than skipping.

**3. It runs as `curie dev netpol-check`**, so local and CI drive the identical path. The cluster config was a heredoc inside `ci.yaml` that nothing outside CI could reach — exactly what `CLAUDE.md`'s one-entry-point rule exists to prevent.

## Proven in both directions before commit

```
minikube --cni=calico   →  exit 0
minikube --cni=bridge   →  exit 1, with the diagnostic
```

A gate that has never been observed to fail isn't a gate. I stood up a second, deliberately non-enforcing cluster to watch this one fail.

## Two bugs found by running it, not reasoning about it

- **The deny target needs a real listener.** Without one you get connection-refused, not the timeout a block gives — so the gate would have "passed" for the wrong reason.
- **The pre-run pod cleanup must block.** Re-applying a pod name against a still-terminating pod silently binds the *old* one; `wait --for=Ready` then passes on a pod on its way out and every exec after it fails for reasons unrelated to policy.

## Tradeoff

Calico costs cluster startup time (~30-60s) and some flake surface versus kindnet. Stated plainly because it's real. But the bug this catches already escaped to a live cluster once, and a slower rung that *can* fail beats a fast one that can't.

If per-PR cost proves too high, the fallback is enforcing-CNI on the nightly ladder plus a fast policy-only job on PRs. What shouldn't stand is "no tier enforces."

## Verification

```
cargo fmt --check / clippy -D warnings / test   → clean, 0 failed suites
bash -n on the script                            → ok
ci.yaml parses                                   → ok
command manifests regenerated                    → cli/command-manifest.json + commandManifest.ts
```
