### PR TITLE
Read the approval card from its thread, and never stamp one we could not read

### DIFF
--- a/apps/dispatcher/src/curie_dispatcher/approval_actions.py
+++ b/apps/dispatcher/src/curie_dispatcher/approval_actions.py
@@ -78,6 +78,13 @@ _NOTE_MAX_LENGTH = 2000
 # therefore a deliberate margin under an inferred limit, not a documented one.
 _VERDICT_LINE_MAX = 2900
 
+# The ``chat_update`` ``text`` argument is the notification/preview/screen-reader
+# fallback, NOT a block text object, and Slack caps it far higher (the worker's
+# own renderer clamps at 39000 in ``curie_worker.blocks``). It gets its own bound
+# because #1073 made it carry the card summary as well as the verdict, so the
+# verdict's context-block clamp above no longer covers it.
+_FALLBACK_TEXT_MAX = 39000
+
 _APPROVAL_ACTION_IDS = frozenset(
     {
         APPROVE_ACTION_ID,
@@ -237,12 +244,69 @@ class ApprovalResolveClient:
         )
 
 
+def _card_is_readable(message: dict[str, Any]) -> bool:
+    """Whether ``message`` carries enough to stamp WITHOUT losing the card body.
+
+    The defense in depth behind the ``conversations.replies`` fix (#1073). That
+    fix makes the read work for both card shapes; this makes the failure mode
+    survivable if it ever stops working, because the two costs are wildly
+    asymmetric. Skipping a stamp leaves a settled record with live-looking
+    buttons, which the next click reports as already-resolved. Stamping from an
+    unread card DESTROYS the only Slack-side record of what was approved, and
+    the resumed run then streams over the thread's other copy of it.
+
+    So: no blocks, no stamp. A card with only its actions block is equally
+    unstampable -- filtering that leaves nothing but the verdict.
+    """
+
+    return any(b.get("type") != "actions" for b in message.get("blocks") or [])
+
+
+def _card_summary_text(message: dict[str, Any]) -> str:
+    """The card's body as plain text, for the ``chat_update`` ``text`` fallback.
+
+    ``text`` is what notifications, previews, and screen readers use, so
+    stamping with the verdict alone loses the summary from all three even when
+    the blocks keep it (#1073). Pulls the section blocks' text and leaves the
+    header and the context lines out: the header is a constant and the context
+    is the "requested by" line, neither of which is the thing being approved.
+    """
+
+    parts = [
+        text
+        for block in message.get("blocks") or []
+        if block.get("type") == "section"
+        for text in [(block.get("text") or {}).get("text")]
+        if text
+    ]
+    return "\n".join(parts)
+
+
+def _fallback_text(verdict: str, message: dict[str, Any]) -> str:
+    """The ``chat_update`` ``text`` for a settled card: verdict then summary.
+
+    Clamped as a whole. The verdict is already bounded by ``_VERDICT_LINE_MAX``,
+    but the summary appended after it is not, so the pair needs its own bound or
+    a long card body can push the fallback past what Slack accepts and lose the
+    edit entirely -- which would leave the live buttons up, the failure this
+    whole change exists to avoid.
+    """
+
+    combined = f"{verdict}\n{_card_summary_text(message)}".strip()
+    if len(combined) <= _FALLBACK_TEXT_MAX:
+        return combined
+    return combined[: _FALLBACK_TEXT_MAX - 1] + "\u2026"
+
+
 def _resolved_card_blocks(original: dict[str, Any], verdict: str) -> list[dict[str, Any]]:
     """The clicked card with its buttons replaced by the verdict line.
 
     Every non-actions block of the original message is kept (the summary stays
     readable in place); the actions block is swapped for a context line naming
     the decision and the resolver, so the card cannot be clicked twice.
+
+    Callers must gate this on ``_card_is_readable``: handed an unread message it
+    returns the verdict alone, which as a ``chat_update`` payload is a wipe.
     """
 
     blocks = [
@@ -547,15 +611,37 @@ def render_note_submission(
 def _fetch_card_message(
     web_client: WebClient, *, channel: str, card_ts: str, log: logging.Logger
 ) -> dict[str, Any]:
-    """The approval card's message, or an empty dict when it cannot be read."""
+    """The approval card's message, or an empty dict when it cannot be read.
+
+    ``conversations.replies``, not ``conversations.history`` (#1073). The default
+    card is a THREAD REPLY -- with no route bound the card posts into the
+    requesting thread -- and ``conversations.history`` walks the channel
+    timeline, which does not include thread replies. It answered with an empty
+    list for every unrouted card, and the caller then wrote a "settled" card
+    rebuilt from nothing, destroying the summary.
+
+    ``conversations.replies`` accepts either a thread parent's ts or a reply's
+    own ts, so it reads BOTH card shapes: the in-thread card of an unrouted
+    approval and the top-level card of a routed one (a top-level message is the
+    parent of its own, possibly empty, thread). Same history scope family as the
+    call it replaces (`channels:history` / `groups:history` / `im:history`), so
+    no manifest change.
+
+    The ts match is explicit rather than assumed. ``limit=1`` bounds the page,
+    but for a parent ts the first entry IS the parent, and returning the wrong
+    message would stamp a verdict onto someone else's post.
+    """
 
     try:
-        history = web_client.conversations_history(
-            channel=channel, latest=card_ts, oldest=card_ts, inclusive=True, limit=1
+        replies = web_client.conversations_replies(
+            channel=channel, ts=card_ts, inclusive=True, limit=1
         )
-        messages = history.get("messages") or []
-        if messages:
-            return dict(messages[0])
+        for message in replies.get("messages") or []:
+            if message.get("ts") == card_ts:
+                return dict(message)
+        log.warning(
+            "approval card %s not found in %s; leaving it unstamped", card_ts, channel
+        )
     except Exception as exc:  # noqa: BLE001 - the stamp is best-effort
         log.warning("could not read approval card %s in %s: %s", card_ts, channel, exc)
     return {}
@@ -666,16 +752,26 @@ def _render_outcome(
     if outcome.status_code == 200:
         verdict = _verdict_line(outcome.decision or decision, user, note)
         # Best-effort: the record is already resolved and the resume turn is
-        # enqueued; a failed card edit must not undo either.
-        try:
-            web_client.chat_update(
-                channel=channel,
-                ts=card_ts,
-                text=verdict,
-                blocks=_resolved_card_blocks(message, verdict),
+        # enqueued; a failed card edit must not undo either. And an UNREAD card
+        # is not stamped at all (#1073): writing the verdict over a body we
+        # could not read replaces the record of what was approved with a single
+        # line, which is worse than leaving the buttons looking live.
+        if _card_is_readable(message):
+            try:
+                web_client.chat_update(
+                    channel=channel,
+                    ts=card_ts,
+                    text=_fallback_text(verdict, message),
+                    blocks=_resolved_card_blocks(message, verdict),
+                )
+            except Exception as exc:  # noqa: BLE001 - render is best-effort
+                log.warning("approval card update failed for %s: %s", approval_id, exc)
+        else:
+            log.warning(
+                "approval %s resolved but its card could not be read; leaving it "
+                "unstamped rather than overwriting the summary",
+                approval_id,
             )
-        except Exception as exc:  # noqa: BLE001 - render is best-effort
-            log.warning("approval card update failed for %s: %s", approval_id, exc)
         log.info("approval %s %s by %s", approval_id, decision, user)
         return
 
@@ -763,11 +859,17 @@ def _refresh_settled_card(
     detail: str,
     log: logging.Logger,
 ) -> None:
+    # Same guard as the 200 path (#1073): a refresh exists to REMOVE stale
+    # buttons, and doing that at the cost of the card body is not a trade worth
+    # making on a race the winner has usually already settled.
+    if not _card_is_readable(message):
+        log.debug("settled-card refresh skipped: the card could not be read")
+        return
     try:
         web_client.chat_update(
             channel=channel,
             ts=card_ts,
-            text=detail,
+            text=_fallback_text(detail, message),
             blocks=_resolved_card_blocks(message, detail),
         )
     except Exception as exc:  # noqa: BLE001 - best-effort refresh

--- a/apps/dispatcher/tests/test_approval_note_dialog.py
+++ b/apps/dispatcher/tests/test_approval_note_dialog.py
@@ -89,7 +89,7 @@ class ScriptedResolver:
 
 
 def _gated_history(gate: threading.Event) -> Callable[..., dict[str, Any]]:
-    """A ``conversations.history`` that blocks until the test releases ``gate``.
+    """A card read that blocks until the test releases ``gate``.
 
     How the ack-ordering tests turn "the ack did not wait on a Slack call" into a
     structural fact rather than a timing hope.
@@ -112,21 +112,21 @@ def _build(
 ) -> tuple[App, WebClient]:
     """Build the app under test.
 
-    ``history_side_effect`` is handed straight to the ``conversations.history``
+    ``history_side_effect`` is handed straight to the ``conversations.replies``
     mock, so a test picks the failure mode it needs: a callable that blocks (see
     ``_gated_history``) for a Slack call that is SLOW, or an exception instance
     for one that FAILS. ``slack_sdk`` 3.43.0 raises ``SlackApiError`` from
     ``WebClient`` whenever Slack answers ``ok: false``
     (``slack_sdk.web.base_client.BaseClient.api_call`` ends in
     ``validate_slack_response``), so that is the exception a real
-    ``conversations.history`` failure arrives as.
+    ``conversations.replies`` failure arrives as.
     """
 
     web_client = WebClient(token="xoxb-test")
     web_client.chat_postMessage = MagicMock(return_value={"ts": "555.000"})  # type: ignore[method-assign]
     web_client.chat_update = MagicMock(return_value={"ok": True})  # type: ignore[method-assign]
     web_client.chat_postEphemeral = MagicMock(return_value={"ok": True})  # type: ignore[method-assign]
-    web_client.conversations_history = MagicMock(  # type: ignore[method-assign]
+    web_client.conversations_replies = MagicMock(  # type: ignore[method-assign]
         side_effect=history_side_effect,
         return_value={"messages": [_CARD_MESSAGE]},
     )
@@ -534,7 +534,7 @@ def test_the_ack_lands_before_any_slack_call_on_the_submit_path(
     _drain(app)
 
     # The fetch still happens; it just happens after the ack.
-    web_client.conversations_history.assert_called_once()
+    web_client.conversations_replies.assert_called_once()
 
 
 def test_a_refused_submission_acks_before_the_card_read_and_still_refreshes_it(
@@ -582,7 +582,7 @@ def test_a_refused_submission_acks_before_the_card_read_and_still_refreshes_it(
     web_client.chat_update.assert_called_once()
 
 
-def test_a_failing_card_read_still_acks_and_still_stamps_the_card(
+def test_a_failing_card_read_still_acks_and_leaves_the_card_intact(
     redis_client: redis.Redis, config: DispatcherConfig
 ) -> None:
     """The other half of the post-ack hazard: a Slack call that FAILS (#1077).
@@ -598,8 +598,15 @@ def test_a_failing_card_read_still_acks_and_still_stamps_the_card(
 
     That executor also SWALLOWS the exception, so calling the listener and
     checking that nothing propagated proves nothing. The observation that has
-    teeth is the socket's: the envelope was acked, and the card was still
-    stamped from the empty message the failed read falls back to.
+    teeth is the socket's: the envelope was acked.
+
+    #1073 changed what happens to the CARD here, and the change is the point.
+    This used to assert the verdict was stamped from the empty message a failed
+    read falls back to -- which is the wipe: it replaces the record of what was
+    approved with one line. An unread card is now left alone. The resolution
+    still stands (it happened before the ack), the ack still lands, and the only
+    cost is that the buttons stay up until the next click reports the record as
+    already resolved.
     """
 
     resolver = ScriptedResolver(
@@ -622,11 +629,122 @@ def test_a_failing_card_read_still_acks_and_still_stamps_the_card(
     )
     _drain(app)
 
-    web_client.conversations_history.assert_called_once()
-    # Fall forward: the read is best-effort, so the verdict still lands on the
-    # card built from an empty original rather than being dropped with the read.
-    web_client.chat_update.assert_called_once()
-    assert "shipping it" in web_client.chat_update.call_args.kwargs["text"]
+    web_client.conversations_replies.assert_called_once()
+    # The card is NOT stamped from an unread original (#1073): destroying the
+    # summary is a worse outcome than leaving a settled record looking clickable.
+    web_client.chat_update.assert_not_called()
+    # And the decision itself was never in doubt -- it landed before the ack.
+    assert len(resolver.calls) == 1
+    assert resolver.calls[0]["note"] == "shipping it"
+
+
+def test_an_unreadable_card_is_left_intact_rather_than_wiped(
+    redis_client: redis.Redis, config: DispatcherConfig
+) -> None:
+    """#1073's core regression, as the empty READ rather than a failing one.
+
+    ``conversations.history`` does not return thread replies, and the DEFAULT
+    card is one: with no route bound the card posts into the requesting thread.
+    So the read came back ``{"messages": []}`` for every unrouted approval, and
+    the stamp then wrote a card rebuilt from nothing -- header, summary and
+    "Requested by" all replaced by a single verdict line.
+
+    Two things now prevent that, and this pins the second: the read moved to
+    ``conversations.replies`` (which returns both card shapes), AND an unread
+    card is not stamped at all. The guard matters on its own because the whole
+    failure was invisible -- both assertions the shipped test made passed
+    identically against the wiped output.
+    """
+
+    resolver = ScriptedResolver(
+        ResolveOutcome(status_code=200, resolved_by="U_MANAGER", decision="approved")
+    )
+    app, web_client = _build(config, redis_client, resolver)
+    # The pre-#1073 symptom exactly: a read that succeeds and returns nothing.
+    web_client.conversations_replies = MagicMock(return_value={"messages": []})  # type: ignore[method-assign]
+    handler = SocketModeHandler(app, app_token="xapp-test")
+
+    handler.handle(FakeSocketClient(), _note_submit("env-wipe", note="approved for Q3"))
+    _drain(app)
+
+    assert len(resolver.calls) == 1, "the decision must still land"
+    web_client.chat_update.assert_not_called()
+
+
+def test_the_card_read_asks_for_the_thread_not_the_channel_timeline(
+    redis_client: redis.Redis, config: DispatcherConfig
+) -> None:
+    """The read must be ``conversations.replies`` keyed on the card's own ts.
+
+    The unrouted card is a thread REPLY. ``conversations.history`` walks the
+    channel timeline and never returns one, which is why it answered empty;
+    ``conversations.replies`` accepts a reply's own ts as well as a parent's, so
+    it reads both card shapes. Asserting the call SHAPE, not just the outcome,
+    because a later refactor back onto ``history`` would pass every
+    outcome-level assertion in this file against a stubbed client.
+    """
+
+    resolver = ScriptedResolver(
+        ResolveOutcome(status_code=200, resolved_by="U_MANAGER", decision="approved")
+    )
+    app, web_client = _build(config, redis_client, resolver)
+    handler = SocketModeHandler(app, app_token="xapp-test")
+
+    handler.handle(FakeSocketClient(), _note_submit("env-replies", note="ok"))
+    _drain(app)
+
+    web_client.conversations_replies.assert_called_once()
+    kwargs = web_client.conversations_replies.call_args.kwargs
+    assert kwargs["channel"] == CARD_CHANNEL
+    assert kwargs["ts"] == CARD_TS, "the card's OWN ts, not a parent's"
+
+
+def test_a_stamped_card_keeps_its_summary_in_blocks_and_in_the_fallback(
+    redis_client: redis.Redis, config: DispatcherConfig
+) -> None:
+    """The positive half: a readable card keeps its body, and so does ``text``.
+
+    ``text`` is what notifications, previews and screen readers show, so a stamp
+    that kept the blocks but overwrote the fallback with the verdict alone still
+    loses the summary from all three (#1073's third AC).
+    """
+
+    resolver = ScriptedResolver(
+        ResolveOutcome(status_code=200, resolved_by="U_MANAGER", decision="approved")
+    )
+    app, web_client = _build(config, redis_client, resolver)
+    handler = SocketModeHandler(app, app_token="xapp-test")
+
+    handler.handle(FakeSocketClient(), _note_submit("env-keep", note="approved for Q3"))
+    _drain(app)
+
+    kwargs = web_client.chat_update.call_args.kwargs
+    rendered = list(kwargs["blocks"])
+    assert rendered[0]["type"] == "header", "the header must survive the stamp"
+    assert any(
+        "Discount for ACME" in (b.get("text") or {}).get("text", "") for b in rendered
+    ), f"the summary block must survive the stamp, got {rendered}"
+    assert not any(b.get("type") == "actions" for b in rendered), "buttons must go"
+    assert "Discount for ACME" in kwargs["text"], "the fallback must carry the summary"
+    assert "approved for Q3" in kwargs["text"]
+
+
+def test_a_claim_race_refresh_does_not_wipe_an_unreadable_card(
+    redis_client: redis.Redis, config: DispatcherConfig
+) -> None:
+    """The 409 path runs the same rebuild, so it carries the same hazard
+    (#1073's second AC). A stale-button refresh is worth strictly less than the
+    card body it would cost."""
+
+    resolver = ScriptedResolver(ResolveOutcome(status_code=409, resolved_by="U_FIRST"))
+    app, web_client = _build(config, redis_client, resolver)
+    web_client.conversations_replies = MagicMock(return_value={"messages": []})  # type: ignore[method-assign]
+    handler = SocketModeHandler(app, app_token="xapp-test")
+
+    handler.handle(FakeSocketClient(), _note_submit("env-race-wipe", note="mine"))
+    _drain(app)
+
+    web_client.chat_update.assert_not_called()
 
 
 def test_a_conflict_from_another_approver_still_names_that_approver(
@@ -727,7 +845,7 @@ def test_a_discarded_outcome_does_not_read_the_card_at_all(
     handler.handle(FakeSocketClient(), _note_submit("env-403-no-fetch", note="please"))
     _drain(app)
 
-    web_client.conversations_history.assert_not_called()
+    web_client.conversations_replies.assert_not_called()
 
 
 def test_the_web_client_gives_up_inside_the_ack_budget(config: DispatcherConfig) -> None:
@@ -800,14 +918,27 @@ def test_an_over_long_note_cannot_break_the_card_stamp(
     _drain(app)
 
     web_client.chat_update.assert_called_once()
-    text = web_client.chat_update.call_args.kwargs["text"]
-    assert len(text) <= 2900
+    kwargs = web_client.chat_update.call_args.kwargs
+
+    # The capped object is the CONTEXT BLOCK's text, which is what Slack
+    # documents a limit for. Since #1073 the ``text=`` kwarg is the notification
+    # fallback and deliberately carries the card summary as well, so asserting
+    # the block cap there would be testing the wrong object.
+    verdict = kwargs["blocks"][-1]["elements"][0]["text"]
+    assert len(verdict) <= 2900
     # The note is what gets cut, never the attribution.
-    assert text.startswith("Approved by <@U_MANAGER>")
+    assert verdict.startswith("Approved by <@U_MANAGER>")
     # A single U+2026, not three periods: the marker is shared with the worker's
     # ``_truncate`` in ``curie_worker.blocks``, so the same Slack card surface
     # does not end truncated text two ways depending on which service stamped it.
-    assert text.endswith("…")
+    assert verdict.endswith("…")
+
+    # The fallback is bounded too, or a long body loses the edit entirely.
+    text = kwargs["text"]
+    assert len(text) <= 39000
+    assert text.startswith("Approved by <@U_MANAGER>")
+    # And it still carries the summary, which is the point of #1073's change.
+    assert "Discount for ACME" in text
     assert not any(
         b.get("type") == "actions" for b in web_client.chat_update.call_args.kwargs["blocks"]
     )

--- a/docs/interfaces/channel-interaction/INTERFACE.md
+++ b/docs/interfaces/channel-interaction/INTERFACE.md
@@ -118,7 +118,11 @@ back into the contract:
    too: Slack expresses "this decision may carry free text" as a dialog opened by
    the click, so the card carries the note-collecting action ids and the
    dispatcher's `apps/dispatcher/src/curie_dispatcher/approval_actions.py::open_note_dialog`
-   opens the view.
+   opens the view. Stamping a settled card re-reads the original through
+   `conversations.replies` rather than `conversations.history`, because the
+   default card is a thread reply and the channel timeline does not carry one
+   (#1073); a card that cannot be read is left unstamped rather than rebuilt
+   from nothing.
 2. **Terminal (TUI selector)** — `cli/src/channel.rs`. It parses the same fence
    (`REPLY_FENCE`) into a `TerminalMessage` of plain lines plus actions, which the
    TUI renders as a numbered selector per the TUI behavior above. It expresses


### PR DESCRIPTION
Closes #1073. Second of three in the Wave 2 settled-card sequence, after #1154 (#1076, the always-on decision) and before #1084 (the worker's resolve-driven stamp).

## What this fixes

Resolving an approval on an **unrouted** card, which is the zero-config default, replaced it in Slack with a bare one-line verdict. Header, summary, and "Requested by" all destroyed:

```
before:  Approval required
         Discount for ACME
         Requested by @ae
         [Approve] [Reject]

after:   Approved by @manager
         Note: approved for Q3          ← the whole message
```

The card is re-read at stamp time because a `view_submission` payload carries no message, and the read used `conversations.history` — which walks the **channel timeline** and does not return thread replies. The default card *is* a thread reply: with no route bound, `card_channel == reply_handle.channel`, so the card posts with `thread_ts`. The read answered empty for every unrouted approval, and the rebuild wrote a card assembled from nothing.

## Two changes, because the costs are asymmetric

**1. The read moves to `conversations.replies`,** keyed on the card's own ts. Slack accepts a reply's ts there as well as a parent's, so it reads **both** card shapes: the in-thread card of an unrouted approval, and the top-level card of a routed one (a top-level message is the parent of its own, possibly empty, thread). Same history scope family (`channels:history` / `groups:history` / `im:history`), so **no app-manifest change**. The returned ts is matched explicitly rather than assumed — stamping the wrong message would put a verdict on someone else's post.

**2. An unread card is not stamped at all.** This is the floor under the fix, and it is worth having on its own:

| | cost |
|---|---|
| skip the stamp | a settled record keeps live-looking buttons; the next click reports it already resolved |
| stamp from an unread card | **destroys the only Slack-side record of what was approved**, and the resumed run then streams over the thread's other copy of it |

Those are not close. `_card_is_readable` gates both write sites (the 200 stamp and the 409 refresh), and the 200 path logs when it declines.

## The `text=` fallback

Third AC: `text` is what notifications, previews, and screen readers show, so keeping the blocks while overwriting the fallback with the verdict alone still loses the summary from all three. It now carries both.

That made the fallback unbounded, so it gets its own clamp. **The existing 2900 limit is the context block's**, which Slack documents a cap for; the `text=` argument is a different object with a much higher limit (the worker's own renderer uses 39000). Conflating them is what the old test did, and fixing that is why one existing assertion moved — see below.

## Tests

Four new, **two of which fail on the pre-fix code**. Verified by stashing only the source change and pointing the harness back at `conversations.history`, so the old code ran exactly as it shipped:

```
FAILED test_an_unreadable_card_is_left_intact_rather_than_wiped
FAILED test_a_claim_race_refresh_does_not_wipe_an_unreadable_card
2 failed, 23 deselected
```

| Test | What it pins |
|---|---|
| `an_unreadable_card_is_left_intact_rather_than_wiped` | The exact pre-fix symptom: a read that **succeeds and returns nothing**. Decision still lands, card untouched. |
| `a_claim_race_refresh_does_not_wipe_an_unreadable_card` | The 409 path runs the same rebuild and carries the same hazard (second AC). |
| `the_card_read_asks_for_the_thread_not_the_channel_timeline` | Asserts the **call shape**, not the outcome. A refactor back onto `history` would pass every outcome-level assertion in the file against a stubbed client. |
| `a_stamped_card_keeps_its_summary_in_blocks_and_in_the_fallback` | The positive half: header survives, summary survives, buttons go, and the fallback carries both. |

## One existing test changed meaning, deliberately

`test_a_failing_card_read_still_acks_and_still_stamps_the_card` asserted the wipe **as intended behavior**:

> Fall forward: the read is best-effort, so the verdict still lands on the card built from an empty original rather than being dropped with the read.

Its reason for existing — a failing post-ack Slack call must not eat the ack (#1077) — is unchanged and still asserted. What it expects of the *card* is now the opposite, and the docstring says so and says why. Renamed to `..._and_leaves_the_card_intact`. Flagging it explicitly because it is the one place this PR inverts an assertion rather than adding one.

Also updated: `test_an_over_long_note_cannot_break_the_card_stamp` now asserts the clamp on the **context block element** (the object Slack caps) and separately bounds the fallback. Strictly more than it checked before, on the right targets.

## Why not the "rebuild from the remembered summary" option

The issue offered that as Option 2, partly because it "also removes the pre-ack Slack round trip". **That benefit is already gone**: #1077 moved the read after the ack, so it is no longer on the ack budget. What remains of Option 2 is a rebuild from a summary the dispatcher would have to carry in `private_metadata`, which caps at 3000 while the summary alone caps at 2900 — so it would need a second, smaller clamp and would render a **truncated** body where the click path renders the full one. That is a new divergence on the seam #1084 is trying to converge.

`conversations.replies` keeps the original blocks byte-for-byte on both paths, which leaves #1084 free to converge the worker onto whatever shape review prefers without first undoing a lossy dispatcher render.

## Verification

Dev-stack Valkey and Postgres up:

```
uv run ruff check .                          All checks passed
uv run mypy                                  no issues in 166 source files
uv run pytest apps/dispatcher apps/worker    657 passed, 11 skipped
curie dev docs-lint                          OK
```

Not verified: the live Slack pass. It is queued for #1084, which touches the same surface, so the two get one hands-on run rather than two. The behavior this PR changes is exactly what that pass exists to confirm, so it should land before the pass rather than after.
