### PR TITLE
Substitute ${CURIE_*} placeholders so a connector gets its host allowlist (#1156)

### DIFF
--- a/packages/plugin-format/src/plugin_format/connector_render.py
+++ b/packages/plugin-format/src/plugin_format/connector_render.py
@@ -127,11 +127,62 @@ def render_service(release: str, agent: str, connector: str, spec: ConnectorSpec
     }
 
 
+# Placeholders an author may write in `args`/`env`, substituted at render with
+# values only Curie can know. Declared here and re-exported for the validator,
+# so the accepted set and the substituted set cannot drift apart.
+PLACEHOLDERS = (
+    "CURIE_ALLOWED_HOSTS",
+    "CURIE_CONNECTOR_HOST",
+    "CURIE_CONNECTOR_PORT",
+    "CURIE_CONNECTOR_URL",
+)
+
+
+def substitutions(
+    release: str, agent: str, connector: str, namespace: str, port: int
+) -> dict[str, str]:
+    """What each ``${CURIE_*}`` placeholder expands to for this connector.
+
+    Every value here is one the AUTHOR cannot know: they are all derived from
+    the Service name Curie invents, which embeds the release, the agent, and
+    the namespace, and which differs per agent since #1116. A bundle deployed
+    as two agents needs two different answers from the same file.
+    """
+
+    short = object_name(release, agent, connector)
+    return {
+        # Servers that guard against DNS rebinding default their allowlist to
+        # loopback, so an in-cluster caller reaching them by Service DNS gets
+        # `forbidden: host not allowed` (ADR-0086). All three forms, because
+        # which one the sandbox dials depends on how the URL was written.
+        "CURIE_ALLOWED_HOSTS": ",".join(host_aliases(release, agent, connector, namespace, port)),
+        "CURIE_CONNECTOR_HOST": short,
+        "CURIE_CONNECTOR_PORT": str(port),
+        "CURIE_CONNECTOR_URL": f"http://{service_dns(release, agent, connector, namespace)}:{port}",
+    }
+
+
+def substitute(value: str, subs: dict[str, str]) -> str:
+    """Expand ``${CURIE_*}`` placeholders in one arg or env value."""
+
+    for key, replacement in subs.items():
+        value = value.replace(f"${{{key}}}", replacement)
+    return value
+
+
 def render_deployment(
-    release: str, agent: str, connector: str, spec: ConnectorSpec, secret_name: str
+    release: str,
+    agent: str,
+    namespace: str,
+    connector: str,
+    spec: ConnectorSpec,
+    secret_name: str,
 ) -> dict[str, Any]:
     name = object_name(release, agent, connector)
-    env: list[dict[str, Any]] = [{"name": k, "value": v} for k, v in sorted(spec.env.items())]
+    subs = substitutions(release, agent, connector, namespace, spec.port)
+    env: list[dict[str, Any]] = [
+        {"name": k, "value": substitute(v, subs)} for k, v in sorted(spec.env.items())
+    ]
     # Declared secrets arrive by reference, never as literals in the manifest.
     env += [
         {
@@ -161,7 +212,7 @@ def render_deployment(
                         {
                             "name": "server",
                             "image": spec.image,
-                            "args": list(spec.args),
+                            "args": [substitute(a, subs) for a in spec.args],
                             "env": env,
                             "ports": [{"name": "http", "containerPort": spec.port}],
                             "securityContext": {
@@ -225,7 +276,7 @@ def render(
         return []
     return [
         render_service(release, agent, connector, spec),
-        render_deployment(release, agent, connector, spec, secret_name),
+        render_deployment(release, agent, namespace, connector, spec, secret_name),
         render_networkpolicy(release, agent, app_name, connector, spec),
     ]
 

--- a/packages/plugin-format/src/plugin_format/connectors.py
+++ b/packages/plugin-format/src/plugin_format/connectors.py
@@ -79,6 +79,25 @@ class ConnectorsFile(BaseModel):
 
 _NAME_RE = re.compile(r"[a-z0-9]([a-z0-9-]*[a-z0-9])?")
 
+# ``${CURIE_*}`` placeholders an author may write in args/env. The renderer
+# substitutes these with values only Curie can derive (the Service name it
+# invents, which embeds the release, agent, and namespace). Imported from the
+# renderer so the accepted set and the substituted set are one list.
+_PLACEHOLDER_RE = re.compile(r"\$\{(CURIE_[A-Z0-9_]*)\}")
+
+
+def _known_placeholders() -> frozenset[str]:
+    """The placeholder names the renderer substitutes.
+
+    Imported lazily to keep this module free of a render-time dependency; the
+    point is that there is exactly one list, so a placeholder the renderer
+    handles is always one the validator accepts and vice versa.
+    """
+
+    from .connector_render import PLACEHOLDERS
+
+    return frozenset(PLACEHOLDERS)
+
 
 def _is_valid_name(name: str) -> bool:
     """RFC 1123 label, capped: the name becomes a k8s object and a DNS label."""
@@ -151,6 +170,19 @@ def validate_connectors(data: Any) -> tuple[ConnectorsFile | None, list[tuple[st
             )
         if not (1 <= spec.port <= 65535):
             errors.append(("connectors.bad_port", f"{where}: port {spec.port} is out of range"))
+        for text in [*spec.args, *spec.env.values()]:
+            for found in _PLACEHOLDER_RE.findall(text):
+                if found in _known_placeholders():
+                    continue
+                errors.append(
+                    (
+                        "connectors.unknown_placeholder",
+                        f"{where}: `${{{found}}}` is not a Curie placeholder. A typo here is "
+                        "not caught at runtime -- the literal text reaches the container, so "
+                        "the connector starts and then rejects every call. Known: "
+                        + ", ".join(f"${{{p}}}" for p in sorted(_known_placeholders())),
+                    )
+                )
         for key in spec.env:
             if not key.replace("_", "").isalnum() or key[:1].isdigit():
                 errors.append(

--- a/packages/plugin-format/tests/test_connector_render.py
+++ b/packages/plugin-format/tests/test_connector_render.py
@@ -230,3 +230,56 @@ def test_over_long_names_that_share_a_prefix_still_differ() -> None:
     b = r.object_name("release", "agent-with-a-very-long-name-number-two", "grafana")
     assert len(a) <= 63 and len(b) <= 63
     assert a != b
+
+
+# --------------------------------------------------------------------------- #
+# Placeholders: values only Curie can know -- #1156
+# --------------------------------------------------------------------------- #
+HOSTED_WITH_HOSTS = ConnectorSpec(
+    image="grafana/mcp-grafana:0.17.2",
+    args=["-t", "streamable-http", "-allowed-hosts", "${CURIE_ALLOWED_HOSTS}"],
+)
+
+
+def _dep(agent: str = "sre-dev", spec: ConnectorSpec = HOSTED_WITH_HOSTS) -> dict:
+    return next(
+        o
+        for o in r.render("sre-bot", agent, "sre-bot", "sre-bot", "grafana", spec, "s")
+        if o["kind"] == "Deployment"
+    )
+
+
+def test_allowed_hosts_expands_to_every_name_the_sandbox_could_dial() -> None:
+    # Servers that guard against DNS rebinding default their allowlist to
+    # loopback, so without this the connector starts and answers every in-cluster
+    # call with `forbidden: host not allowed` -- healthy in `kubectl get pods`,
+    # working for nobody.
+    args = _dep()["spec"]["template"]["spec"]["containers"][0]["args"]
+    value = args[args.index("-allowed-hosts") + 1]
+    assert "${" not in value, "placeholder reached the container unsubstituted"
+    for alias in r.host_aliases("sre-bot", "sre-dev", "grafana", "sre-bot", 8000):
+        assert alias in value
+
+
+def test_each_agent_gets_its_own_allowlist() -> None:
+    # Since #1116 the Service name is agent-scoped, so one hardcoded allowlist
+    # cannot serve two agents built from the same bundle.
+    def hosts(agent: str) -> str:
+        a = _dep(agent)["spec"]["template"]["spec"]["containers"][0]["args"]
+        return a[a.index("-allowed-hosts") + 1]
+
+    assert hosts("sre-dev") != hosts("sre-prod")
+
+
+def test_placeholders_expand_in_env_too() -> None:
+    spec = ConnectorSpec(image="x:1", env={"SELF_URL": "${CURIE_CONNECTOR_URL}"})
+    env = _dep(spec=spec)["spec"]["template"]["spec"]["containers"][0]["env"]
+    entry = next(e for e in env if e["name"] == "SELF_URL")
+    assert entry["value"].startswith("http://sre-bot-sre-dev-mcp-grafana.sre-bot")
+
+
+def test_text_without_placeholders_is_untouched() -> None:
+    spec = ConnectorSpec(image="x:1", args=["-t", "streamable-http"], env={"A": "b"})
+    c = _dep(spec=spec)["spec"]["template"]["spec"]["containers"][0]
+    assert c["args"] == ["-t", "streamable-http"]
+    assert {"name": "A", "value": "b"} in c["env"]

--- a/packages/plugin-format/tests/test_connectors.py
+++ b/packages/plugin-format/tests/test_connectors.py
@@ -195,3 +195,37 @@ def test_an_unreadable_mcp_config_does_not_add_a_confusing_second_error(tmp_path
     result = validate_bundle(str(root))
     assert not result.valid
     assert not any(e.code == "connectors.duplicate_server" for e in result.errors)
+
+
+def test_a_typo_in_a_placeholder_is_rejected() -> None:
+    # Unsubstituted text reaches the container verbatim, so the connector starts
+    # and rejects every call. Nothing catches that at runtime.
+    codes = _codes({"connectors": {"g": {"image": "x:1", "args": ["-h", "${CURIE_ALOWED_HOSTS}"]}}})
+    assert "connectors.unknown_placeholder" in codes
+
+
+def test_known_placeholders_are_accepted_in_args_and_env() -> None:
+    _, errors = validate_connectors(
+        {
+            "connectors": {
+                "g": {
+                    "image": "x:1",
+                    "args": ["-h", "${CURIE_ALLOWED_HOSTS}", "-p", "${CURIE_CONNECTOR_PORT}"],
+                    "env": {"SELF": "${CURIE_CONNECTOR_URL}", "H": "${CURIE_CONNECTOR_HOST}"},
+                }
+            }
+        }
+    )
+    assert errors == []
+
+
+def test_the_validator_and_the_renderer_share_one_placeholder_list() -> None:
+    # Two lists would drift: the renderer would substitute something the
+    # validator rejects, or accept something that reaches the container raw.
+    from plugin_format.connector_render import PLACEHOLDERS
+
+    for name in PLACEHOLDERS:
+        _, errors = validate_connectors(
+            {"connectors": {"g": {"image": "x:1", "args": ["${" + name + "}"]}}}
+        )
+        assert errors == [], f"renderer substitutes ${{{name}}} but the validator rejects it"


### PR DESCRIPTION
Fixes #1156. Refs ADR-0086. Base `main`, not stacked.

## The gap

`host_aliases()` was written, unit-tested, and **never called**. `render_deployment` emitted `spec.args` verbatim, so a hosted connector got no host allowlist.

ADR-0086 names this as one of the two defects the renderer exists to make unrepresentable:

> **Host-header validation.** Servers that guard against DNS rebinding (`mcp-grafana` 0.17+) default their allowlist to loopback, so an in-cluster caller reaching them by Service DNS gets `forbidden: host not allowed`. Curie names the Service, so Curie can supply every name the sandbox may dial — see `host_aliases`.

The function existed. The wiring did not. The result is a connector that is **healthy in `kubectl get pods` and answers every call with a 403**.

## Why not just inject the flag

It's server-specific. `mcp-grafana` takes `-allowed-hosts`; another server uses `--trusted-hosts` or an env var. Injecting unconditionally breaks every connector that doesn't accept it.

So the author names the flag, Curie fills the value:

```yaml
args: [-t, streamable-http, -allowed-hosts, "${CURIE_ALLOWED_HOSTS}"]
```

renders to

```
-allowed-hosts acme-bot-acme-dev-mcp-grafana:8000,
               acme-bot-acme-dev-mcp-grafana.acme-bot:8000,
               acme-bot-acme-dev-mcp-grafana.acme-bot.svc.cluster.local:8000
```

Also `${CURIE_CONNECTOR_HOST}`, `${CURIE_CONNECTOR_PORT}`, `${CURIE_CONNECTOR_URL}` — servers needing their own address (`--public-url`, `--base-path`) hit the identical wall. Works in `env` too.

## Every value is one the author cannot know

All derive from the Service name Curie invents, which embeds the release, the agent, and the namespace. Since #1116 it differs per agent, so **one bundle deployed as `acme-dev` and `acme-prod` needs two different answers from the same file.** Pinned by `test_each_agent_gets_its_own_allowlist`.

## A typo is a validation error, not a pass-through

```
${CURIE_ALOWED_HOSTS}  →  connectors.unknown_placeholder
```

Unsubstituted text reaches the container verbatim, so the connector starts and rejects everything — and nothing catches that at runtime.

## One list, not two

The validator imports `PLACEHOLDERS` from the renderer rather than restating it, and `test_the_validator_and_the_renderer_share_one_placeholder_list` walks that list asserting each entry validates. Two lists would drift into substituting something the validator rejects, or accepting something that reaches the container raw.

## Verification

```
plugin-format          → 223 passed (9 new)
packages + connectors  → 396 passed
mypy                   → no issues, 166 files
ruff check             → All checks passed
check-contracts.sh     → all committed artifacts current
```

## Why now

This blocks acme-bot's migration off its hand-written `deploy/`. Its current manifest hardcodes the allowlist — which is exactly what adopting `connectors.yaml` is meant to delete, and what the connector cannot work without.