### PR TITLE
connectors.yaml: unhosted_url, for tiers that cannot host (#1160)

### DIFF
--- a/packages/plugin-format/src/plugin_format/connector_render.py
+++ b/packages/plugin-format/src/plugin_format/connector_render.py
@@ -281,6 +281,21 @@ def render(
     ]
 
 
+def unhosted_mcp_entry(spec: ConnectorSpec) -> dict[str, Any] | None:
+    """The entry for a tier that cannot host this connector, or None.
+
+    None is a real answer, not a failure: a hosted connector with nowhere to
+    point at IS "declared but not exercisable here" (#1093). Mounting a URL that
+    resolves nowhere would turn that into a connection refused mid-turn.
+    """
+
+    if not spec.is_hosted:
+        return mcp_entry("", "", "", "", spec)
+    if not spec.unhosted_url:
+        return None
+    return {"type": "http", "url": spec.unhosted_url}
+
+
 def mcp_entry(
     release: str, agent: str, namespace: str, connector: str, spec: ConnectorSpec
 ) -> dict[str, Any]:

--- a/packages/plugin-format/src/plugin_format/connectors.py
+++ b/packages/plugin-format/src/plugin_format/connectors.py
@@ -57,6 +57,20 @@ class ConnectorSpec(BaseModel):
     env: dict[str, str] = Field(default_factory=dict)
     port: int = 8000
 
+    # Where to reach this connector on a tier that CANNOT host it (#1160).
+    #
+    # The hosted form's escape hatch, not a second remote form. `cluster` runs
+    # the image and derives the URL from the Service it created; `skill` hosts
+    # nothing at all, and `local` does not host connectors yet (#1159). Without
+    # this a bundle whose only connector is hosted simply has no connector on
+    # those rungs, which is right when there is genuinely nothing to point at
+    # and wrong when the developer has a copy running on port 8765.
+    #
+    # `${VAR}` is expanded from the sandbox environment by the MCP client, the
+    # same expansion `.mcp.json` has always used -- so the value can be supplied
+    # per machine with `--secret`, and the bundle stays safe to commit.
+    unhosted_url: str | None = None
+
     # -- remote form --
     url: str | None = None
     headers: dict[str, str] = Field(default_factory=dict)
@@ -158,6 +172,15 @@ def validate_connectors(data: Any) -> tuple[ConnectorsFile | None, list[tuple[st
                     "connectors.remote_has_runtime",
                     f"{where}: `args`/`env` configure a process Curie starts; a `url` "
                     "connector is already running, so they would be silently ignored",
+                )
+            )
+        if spec.url and spec.unhosted_url:
+            errors.append(
+                (
+                    "connectors.remote_has_unhosted_url",
+                    f"{where}: `unhosted_url` is the hosted form's fallback for tiers that "
+                    "cannot run the image. A `url` connector is already reachable everywhere, "
+                    "so this would never apply",
                 )
             )
         if spec.image and spec.headers:

--- a/packages/plugin-format/tests/test_connector_render.py
+++ b/packages/plugin-format/tests/test_connector_render.py
@@ -283,3 +283,35 @@ def test_text_without_placeholders_is_untouched() -> None:
     c = _dep(spec=spec)["spec"]["template"]["spec"]["containers"][0]
     assert c["args"] == ["-t", "streamable-http"]
     assert {"name": "A", "value": "b"} in c["env"]
+
+
+# --------------------------------------------------------------------------- #
+# What an unhostable tier mounts -- #1160
+# --------------------------------------------------------------------------- #
+def test_a_hosted_connector_with_a_fallback_is_reachable_where_it_cannot_be_hosted() -> None:
+    spec = ConnectorSpec(image="x:1", unhosted_url="http://host.docker.internal:8765/mcp")
+    assert r.unhosted_mcp_entry(spec) == {
+        "type": "http",
+        "url": "http://host.docker.internal:8765/mcp",
+    }
+
+
+def test_a_hosted_connector_with_no_fallback_mounts_nothing_rather_than_a_dead_url() -> None:
+    # None is a real answer: "declared but not exercisable here" (#1093). A URL
+    # that resolves nowhere would turn that into a connection refused mid-turn.
+    assert r.unhosted_mcp_entry(ConnectorSpec(image="x:1")) is None
+
+
+def test_a_remote_connector_needs_no_fallback_to_stay_reachable() -> None:
+    entry = r.unhosted_mcp_entry(REMOTE)
+    assert entry is not None
+    assert entry["url"] == "https://mcp.internal/mcp"
+
+
+def test_the_fallback_never_displaces_the_derived_url_where_curie_hosts() -> None:
+    # The whole point is that `cluster` keeps hosting it. A fallback that won
+    # everywhere would silently repoint a production agent at someone's laptop.
+    spec = ConnectorSpec(image="x:1", unhosted_url="http://host.docker.internal:8765/mcp")
+    hosted = r.mcp_entry("curie", "sre-dev", "curie", "grafana", spec)
+    assert "svc.cluster.local" in hosted["url"]
+    assert "8765" not in hosted["url"]

--- a/packages/plugin-format/tests/test_connectors.py
+++ b/packages/plugin-format/tests/test_connectors.py
@@ -229,3 +229,30 @@ def test_the_validator_and_the_renderer_share_one_placeholder_list() -> None:
             {"connectors": {"g": {"image": "x:1", "args": ["${" + name + "}"]}}}
         )
         assert errors == [], f"renderer substitutes ${{{name}}} but the validator rejects it"
+
+
+# --------------------------------------------------------------------------- #
+# The hosted form's escape hatch for tiers that cannot host -- #1160
+# --------------------------------------------------------------------------- #
+def test_a_hosted_connector_may_declare_where_to_reach_it_when_unhosted() -> None:
+    parsed, errors = validate_connectors(
+        {
+            "connectors": {
+                "grafana": {
+                    "image": "grafana/mcp-grafana:0.17.2",
+                    "unhosted_url": "${GRAFANA_MCP_URL}",
+                }
+            }
+        }
+    )
+    assert errors == []
+    assert parsed is not None
+    assert parsed.connectors["grafana"].is_hosted, "still hosted where Curie can host"
+
+
+def test_unhosted_url_on_a_remote_connector_is_rejected() -> None:
+    # A `url` connector is already reachable on every tier, so the fallback
+    # could never apply -- accepting it would be a silent no-op.
+    assert "connectors.remote_has_unhosted_url" in _codes(
+        {"connectors": {"g": {"url": "https://y/mcp", "unhosted_url": "http://z/mcp"}}}
+    )


### PR DESCRIPTION
Fixes #1160. Refs ADR-0086. Base `main`.

## The missing rung

ADR-0086 promised the parity ladder an answer at every tier. Two of three exist — `cluster` hosts a Deployment, `skill` reports *declared but not exercisable*. The case in between has no answer: **the platform hosts it on the cluster, and on a rung that cannot host, the developer already has a copy running.**

```yaml
connectors:
  grafana:
    image: grafana/mcp-grafana:0.17.2
    unhosted_url: ${GRAFANA_MCP_URL}
```

## It broke something real

acme-bot's `.mcp.json` consumed `${GRAFANA_MCP_URL}`. Adopting `connectors.yaml` deletes that file — correctly, since keeping both is a validation error (#1149) — so its eval lane lost Grafana with nothing to replace it. Declaring the connector `url:` instead isn't a fix: the cluster would stop hosting it.

That's what blocks curie-eng/acme-bot#12.

## Three decisions worth reviewing

**The derived URL still wins where Curie hosts.** Pinned by `test_the_fallback_never_displaces_the_derived_url_where_curie_hosts` — a fallback that won everywhere would silently repoint a **production** agent at someone's laptop. That test is the one I'd least want deleted.

**Absent means `None`, not a placeholder.** A hosted connector with nowhere to point at genuinely *is* "not exercisable here" (#1093). Mounting a URL that resolves nowhere converts an honest limitation into a connection refused mid-turn.

**`unhosted_url` on a `url:` connector is rejected.** A remote connector is already reachable everywhere, so the fallback could never apply — accepting it would be a silent no-op. Same reasoning that already rejects `args`/`env` on a remote connector.

## `${VAR}` expansion is unchanged

Still client-expanded from the sandbox env — the mechanism `.mcp.json` has always used. So the value is supplied per machine with `--secret` and the bundle stays safe to commit. No new way to carry a value.

## Verification

```
packages            → 385 passed (6 new)
mypy                → no issues, 166 files
ruff check          → All checks passed
check-contracts.sh  → all committed artifacts current
```

## Next

The runner lane consumes this: `derive_mcp_servers` currently mounts only remote connectors when the connector scope is absent, and should mount a hosted-with-`unhosted_url` one too. Frozen contract, so it lands separately.
