### PR TITLE
Runner mounts a hosted connector's unhosted_url where it cannot host (#1160)

### DIFF
--- a/runner/src/curie_runner/connectors.py
+++ b/runner/src/curie_runner/connectors.py
@@ -35,7 +35,7 @@ from pathlib import Path
 from typing import Any
 
 import yaml
-from plugin_format.connector_render import mcp_entry
+from plugin_format.connector_render import mcp_entry, unhosted_mcp_entry
 from plugin_format.connectors import ConnectorsFile, validate_connectors
 
 logger = logging.getLogger(__name__)
@@ -92,19 +92,27 @@ def derive_mcp_servers(
     if not (release and agent and namespace):
         # The scope is emitted as a set or not at all (BootEnv, ACI 0.2.8), so
         # this is "no scope", never a partial one.
-        if any(spec.is_hosted for spec in declared.connectors.values()):
+        stranded = sorted(
+            name
+            for name, spec in declared.connectors.items()
+            if spec.is_hosted and not spec.unhosted_url
+        )
+        if stranded:
             logger.info(
-                "connectors declared but no connector scope on the boot env; "
-                "hosted connectors are not exercisable in this tier (%s)",
-                ", ".join(sorted(declared.connectors)),
+                "no connector scope on the boot env and no unhosted_url; these are "
+                "declared but not exercisable in this tier (%s)",
+                ", ".join(stranded),
             )
-        # A remote connector carries its own absolute url, so it needs no scope
-        # and stays mountable in every tier.
-        return {
-            name: mcp_entry("", "", "", name, spec)
-            for name, spec in sorted(declared.connectors.items())
-            if not spec.is_hosted
-        }
+        # A remote connector carries its own absolute url, and a hosted one may
+        # declare where to reach it when Curie is not hosting it (#1160). Both
+        # stay mountable here; a hosted connector with neither mounts nothing,
+        # which is the honest answer rather than a URL resolving nowhere.
+        entries = {}
+        for name, spec in sorted(declared.connectors.items()):
+            entry = unhosted_mcp_entry(spec)
+            if entry is not None:
+                entries[name] = entry
+        return entries
 
     return {
         name: mcp_entry(release, agent, namespace, name, spec)

--- a/runner/tests/test_connectors.py
+++ b/runner/tests/test_connectors.py
@@ -99,3 +99,38 @@ def test_invalid_connectors_file_mounts_nothing(tmp_path: Path) -> None:
 
 def test_no_plugin_dir_is_not_an_error(tmp_path: Path) -> None:
     assert derive_mcp_servers(None, **SCOPE) == {}
+
+
+# --------------------------------------------------------------------------- #
+# Reaching a hosted connector on a tier that cannot host it -- #1160
+# --------------------------------------------------------------------------- #
+HOSTED_WITH_FALLBACK = (
+    "connectors:\n"
+    "  grafana:\n"
+    "    image: grafana/mcp-grafana:0.17.2\n"
+    "    unhosted_url: http://host.docker.internal:8765/mcp\n"
+)
+
+
+def test_a_fallback_makes_a_hosted_connector_reachable_at_the_skill_tier(tmp_path: Path) -> None:
+    # The skill tier hosts nothing, but the developer has mcp-grafana running.
+    # Without this the eval lane silently loses its connector.
+    servers = derive_mcp_servers(
+        _bundle(tmp_path, HOSTED_WITH_FALLBACK), release=None, agent=None, namespace=None
+    )
+    assert servers["grafana"]["url"] == "http://host.docker.internal:8765/mcp"
+
+
+def test_the_cluster_still_uses_the_service_it_created(tmp_path: Path) -> None:
+    # A fallback that won everywhere would repoint a production agent at
+    # someone's laptop. The derived URL must win wherever Curie hosts.
+    servers = derive_mcp_servers(_bundle(tmp_path, HOSTED_WITH_FALLBACK), **SCOPE)
+    assert "svc.cluster.local" in servers["grafana"]["url"]
+    assert "8765" not in servers["grafana"]["url"]
+
+
+def test_a_hosted_connector_without_a_fallback_still_mounts_nothing(tmp_path: Path) -> None:
+    servers = derive_mcp_servers(
+        _bundle(tmp_path, HOSTED), release=None, agent=None, namespace=None
+    )
+    assert servers == {}


### PR DESCRIPTION
Second half of #1160. **Stacked on #1161** — merge that first; this needs a close/reopen afterwards to fire CI.

Consumes the contract. `derive_mcp_servers` mounted only *remote* connectors when the boot env carried no connector scope; a hosted one declaring where to reach it off-cluster is now mounted too.

## Three behaviours, each pinned

| Situation | Mounts | Why |
|---|---|---|
| scope present (cluster) | **derived URL** | Curie hosts it; the Service it created is the truth |
| no scope + `unhosted_url` | **the fallback** | skill tier hosts nothing, but a copy is running |
| no scope, no fallback | **nothing** | honest "not exercisable here" (#1093) |

**`test_the_cluster_still_uses_the_service_it_created`** is the one that matters most — a fallback that won everywhere would silently repoint a **production** agent at someone's laptop.

## Log-line change

It named every declared connector whenever the scope was absent. Now it names only the genuinely stranded ones — with a fallback present there's nothing to report, and a log that cries wolf gets filtered out and then missed when it's real.

## Verification

```
runner tests   → 489 passed, 4 skipped (3 new)
mypy           → no issues, 166 files
ruff check     → All checks passed
```

## What this unblocks

curie-eng/acme-bot#12. Its `connectors.yaml` gains `unhosted_url: ${GRAFANA_MCP_URL}`, the eval lane keeps reaching the mcp-grafana container it already starts, and the cluster keeps hosting the real one.

That still leaves acme-bot#13 — three Grafana evals pass with no Grafana at all, because every string their graders expect is recited in `SKILL.md`. Fixing this PR's gap makes the connection work again; it does not make those cases able to notice if it breaks.
