### PR TITLE
Settle the approval card when a resolution arrives through the API

### DIFF
--- a/apps/api/tests/test_resume_turn_text.py
+++ b/apps/api/tests/test_resume_turn_text.py
@@ -1,0 +1,112 @@
+"""The platform-authored resume-turn text (#1084).
+
+``build_resume_turn`` is the one place an approver's note crosses from a durable
+record into a model's context. The claim that "the note reaches the requester"
+rests entirely on the interpolation in this function, and nothing in the tree
+asserted it: the only other reference builds a turn to seed a dead-letter row
+and never reads its text.
+
+That is worth its own file rather than a passing assertion elsewhere. The text
+is a contract with two consumers at once -- the model reading it as platform
+voice, and a skill matching on its ``[approval resolved]`` prefix -- so a
+wording change is a behavior change, and it should fail here rather than in a
+deployment.
+
+Pure unit tests over detached ORM instances: no session, no Valkey, nothing to
+skip on.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from curie_api.models import Approval, ApprovalStatus
+from curie_api.resumequeue import build_expiry_resume_turn, build_resume_turn
+
+
+def _resolved(
+    *,
+    status: str = ApprovalStatus.approved,
+    resolved_by: str | None = "U_MANAGER",
+    note: str | None = None,
+    summary: str = "Give ACME a 20% discount",
+) -> Approval:
+    """A detached, resolved ``Approval``: only the fields the builder reads."""
+
+    return Approval(
+        id=uuid.uuid4(),
+        agent_id=uuid.uuid4(),
+        conversation_id="C1-thread-0",
+        author="U_AE",
+        summary=summary,
+        reply_channel="C1",
+        reply_placeholder="p-1",
+        reply_endpoint=None,
+        dedupe_key="ev-1",
+        status=status,
+        resolved_by=resolved_by,
+        resolution_note=note,
+    )
+
+
+def test_a_noted_resolution_carries_the_note_into_the_resume_turn() -> None:
+    turn = build_resume_turn(_resolved(note="approved for Q3"))
+
+    # The exact clause, not just the substring: the space before and the period
+    # after are what keep it a sentence rather than text jammed against the
+    # attribution.
+    assert " Note: approved for Q3." in turn.text
+    # And the facts around it, so a rewrite cannot drop one while keeping the note.
+    assert turn.text.startswith("[approval resolved]")
+    assert '"Give ACME a 20% discount"' in turn.text
+    assert "was approved by U_MANAGER" in turn.text
+
+
+def test_a_bare_resolution_omits_the_note_clause_entirely() -> None:
+    """No note means no ``Note:`` at all, not an empty one.
+
+    An empty clause would read as "Note: ." to the model, which is a statement
+    that the approver left a blank reason rather than none.
+    """
+
+    turn = build_resume_turn(_resolved(note=None))
+
+    assert "Note:" not in turn.text
+    assert "was approved by U_MANAGER" in turn.text
+
+
+def test_a_rejection_says_rejected_and_still_carries_its_reason() -> None:
+    """The clause is decision-independent, and a rejection is where it matters
+    most: "rejected" without a reason is the half of the decision the requester
+    cannot act on."""
+
+    turn = build_resume_turn(
+        _resolved(status=ApprovalStatus.rejected, note="discount exceeds policy")
+    )
+
+    assert "was rejected by U_MANAGER" in turn.text
+    assert " Note: discount exceeds policy." in turn.text
+
+
+def test_the_resume_turn_is_authored_by_the_resolver() -> None:
+    """The author is the resolver, which is what lets the worker attribute a
+    settled card without parsing the prose (#1084)."""
+
+    turn = build_resume_turn(_resolved(note="fine"))
+    assert turn.author == "U_MANAGER"
+
+
+def test_an_expiry_turn_names_no_decider_and_no_note() -> None:
+    """The sibling path: nobody decided, so there is nobody to attribute and
+    nothing to quote. Asserted here so a shared edit to the two builders cannot
+    leak an approver clause into the expiry wording."""
+
+    turn = build_expiry_resume_turn(
+        _resolved(status=ApprovalStatus.expired, resolved_by=None, note=None)
+    )
+
+    assert turn.text.startswith("[approval expired]")
+    assert "Note:" not in turn.text
+    assert turn.author == "system"
+    # The instruction that makes an expiry safe: do not perform the gated action.
+    assert "Do not perform the gated action." in turn.text

--- a/apps/dispatcher/src/curie_dispatcher/approval_actions.py
+++ b/apps/dispatcher/src/curie_dispatcher/approval_actions.py
@@ -85,6 +85,13 @@ _VERDICT_LINE_MAX = 2900
 # verdict's context-block clamp above no longer covers it.
 _FALLBACK_TEXT_MAX = 39000
 
+# The live card's header, shared with the settled rebuild so the two cannot
+# drift: a rebuild under a different heading is a visibly different card for the
+# same decision. ``curie_worker.blocks.approval_card`` imports this rather than
+# repeating the literal.
+_APPROVAL_CARD_HEADER = "Approval required"
+APPROVAL_CARD_HEADER = _APPROVAL_CARD_HEADER
+
 _APPROVAL_ACTION_IDS = frozenset(
     {
         APPROVE_ACTION_ID,
@@ -242,6 +249,68 @@ class ApprovalResolveClient:
             resolved_by=str(resolved) if resolved else None,
             decision=str(decided) if decided else None,
         )
+
+
+def settled_approval_card(
+    *, summary: str, requested_by: str, verdict: str
+) -> tuple[str, list[dict[str, Any]]]:
+    """The approval card in its SETTLED form, rebuilt rather than edited (#1084).
+
+    Two paths settle a card and they have different inputs. The dispatcher holds
+    the live message and edits it (``_resolved_card_blocks``); the worker's
+    resume path holds only what it remembered at pause time and must rebuild.
+    Left to themselves those two produce different-looking cards for the same
+    decision, which is the divergence #1084 exists to prevent, so this renders
+    the rebuild to match the edit exactly: the same header, the same summary
+    section, the same requested-by context, the actions block gone, and the
+    verdict appended as a context line.
+
+    "Exactly" is asserted rather than asserted-in-a-docstring: a test renders a
+    live card through ``curie_worker.blocks.approval_card``, settles it both
+    ways, and compares. That test is the contract; this docstring only says why
+    it exists.
+
+    Lives here, not in the worker's renderer, because the dependency runs one
+    way: ``curie_worker.blocks`` already imports this module for the action ids,
+    for the same anti-drift reason, and the reverse import would be a cycle.
+    """
+
+    blocks: list[dict[str, Any]] = [
+        {
+            "type": "header",
+            "text": {
+                "type": "plain_text",
+                "text": _APPROVAL_CARD_HEADER,
+                "emoji": True,
+            },
+        },
+        {"type": "section", "text": {"type": "mrkdwn", "text": summary}},
+    ]
+    # Omitted rather than rendered empty when unknown: a card remembered before
+    # #1084 carries no requester, and "Requested by <@>" reads as a bug.
+    if requested_by:
+        blocks.append(
+            {
+                "type": "context",
+                "elements": [{"type": "mrkdwn", "text": f"Requested by <@{requested_by}>"}],
+            }
+        )
+    blocks.append({"type": "context", "elements": [{"type": "mrkdwn", "text": verdict}]})
+    fallback = f"{verdict}\n{summary}".strip()
+    if len(fallback) > _FALLBACK_TEXT_MAX:
+        fallback = fallback[: _FALLBACK_TEXT_MAX - 1] + "\u2026"
+    return fallback, blocks
+
+
+def settled_verdict_line(*, decision: str, resolver: str, note: str | None) -> str:
+    """The verdict line a settled card shows, for callers outside this module.
+
+    The public name for ``_verdict_line``: the worker needs the identical string
+    the click path stamps, and re-deriving it there is how the two surfaces would
+    start wording the same decision differently.
+    """
+
+    return _verdict_line(decision, resolver, note)
 
 
 def _card_is_readable(message: dict[str, Any]) -> bool:

--- a/apps/worker/src/curie_worker/approval_cards.py
+++ b/apps/worker/src/curie_worker/approval_cards.py
@@ -34,12 +34,20 @@ DEFAULT_CARD_TTL_S = 14 * 24 * 60 * 60
 
 @dataclass(frozen=True)
 class ApprovalCardRef:
-    """Where a posted approval card lives, enough to edit it in place later."""
+    """Where a posted approval card lives, enough to REBUILD it in place later.
+
+    ``requested_by`` joined the ref for #1084: the settled rebuild shows the
+    same "Requested by" line the live card did, and the worker has no other copy
+    of it once the sandbox is gone. Defaulted so an entry remembered before
+    #1084 still loads -- these live in Valkey across a deploy, and the settled
+    card simply omits the line rather than failing to render.
+    """
 
     channel: str
     ts: str
     summary: str
     endpoint: str | None = None
+    requested_by: str = ""
 
 
 class ApprovalCardStore:
@@ -60,9 +68,16 @@ class ApprovalCardStore:
         ts: str,
         summary: str,
         endpoint: str | None,
+        requested_by: str = "",
     ) -> None:
         payload = json.dumps(
-            {"channel": channel, "ts": ts, "summary": summary, "endpoint": endpoint}
+            {
+                "channel": channel,
+                "ts": ts,
+                "summary": summary,
+                "endpoint": endpoint,
+                "requested_by": requested_by,
+            }
         )
         await self._redis.set(
             self._config.approval_card_key(thread), payload, ex=self._ttl_s
@@ -86,6 +101,10 @@ class ApprovalCardStore:
                 ts=str(data["ts"]),
                 summary=str(data["summary"]),
                 endpoint=data.get("endpoint"),
+                # ``.get`` not ``[...]``: entries written before #1084 have no
+                # such key, and a KeyError here would be caught by the corrupt
+                # handler below and silently drop a perfectly usable card ref.
+                requested_by=str(data.get("requested_by") or ""),
             )
         except (ValueError, KeyError, TypeError):
             # A corrupt or shape-drifted entry must not break the resume; treat

--- a/apps/worker/src/curie_worker/approvals.py
+++ b/apps/worker/src/curie_worker/approvals.py
@@ -15,6 +15,7 @@ second pending record for one human decision.
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from typing import Protocol
 
@@ -24,12 +25,16 @@ from aci_protocol import ApprovalRequest
 # Re-exported so this module stays the kernel-facing seam for the approval
 # payload: ``ApprovalRequest`` is now the shared wire model (#492), not a
 # lane-local mirror of the API's schema.
+logger = logging.getLogger(__name__)
+
 __all__ = [
     "ApprovalBackendError",
     "ApprovalClient",
     "ApprovalCreator",
+    "ApprovalReader",
     "ApprovalRequest",
     "CreatedApproval",
+    "SettledApproval",
 ]
 
 
@@ -46,10 +51,35 @@ class ApprovalBackendError(Exception):
     than suspending a session no resolution could ever wake."""
 
 
+@dataclass(frozen=True)
+class SettledApproval:
+    """A resolved record's outcome, for stamping its card (#1084).
+
+    Read from the record rather than parsed out of the platform-authored resume
+    turn. That turn does carry all three facts in prose, and the kernel already
+    keys off its ``[approval expired]`` marker, but a marker is a stable literal
+    while "was approved by X. Note: Y." is a sentence -- reconstructing a
+    decision by regex over it would make the card's correctness depend on the
+    wording of a string built for a language model to read.
+    """
+
+    status: str
+    resolved_by: str | None
+    resolution_note: str | None
+
+
 class ApprovalCreator(Protocol):
     """The kernel-facing seam; tests supply a recording fake."""
 
     async def create(self, request: ApprovalRequest) -> CreatedApproval: ...
+
+
+class ApprovalReader(Protocol):
+    """Read one settled record back. Separate from ``ApprovalCreator`` because
+    the kernel's pause path needs only the create half, and a fake for it should
+    not have to grow a method it never calls."""
+
+    async def get(self, approval_id: str) -> SettledApproval | None: ...
 
 
 class ApprovalClient:
@@ -76,3 +106,35 @@ class ApprovalClient:
             )
         body = response.json()
         return CreatedApproval(id=str(body["id"]), status=str(body["status"]))
+
+    async def get(self, approval_id: str) -> SettledApproval | None:
+        """The record's settled outcome, or None when it cannot be read (#1084).
+
+        Never raises. Its only caller is best-effort card teardown on a resume
+        turn: the resolution already happened and the session is already waking,
+        so a failed read costs a stamped card and nothing else. Raising here
+        would turn a cosmetic gap into a dead-lettered resume.
+        """
+
+        try:
+            response = await self._client.get(
+                f"{self._url}/{approval_id}", headers=self._headers
+            )
+        except httpx.HTTPError as exc:
+            logger.warning("approval read failed for %s: %s", approval_id, exc)
+            return None
+        if response.status_code != 200:
+            logger.warning(
+                "approval read failed for %s: HTTP %s", approval_id, response.status_code
+            )
+            return None
+        try:
+            body = response.json()
+            return SettledApproval(
+                status=str(body["status"]),
+                resolved_by=body.get("resolved_by"),
+                resolution_note=body.get("resolution_note"),
+            )
+        except (ValueError, KeyError) as exc:
+            logger.warning("approval read returned an unusable body for %s: %s", approval_id, exc)
+            return None

--- a/apps/worker/src/curie_worker/blocks.py
+++ b/apps/worker/src/curie_worker/blocks.py
@@ -338,6 +338,7 @@ def approval_card(
     # Imported here (not module top) to keep the module importable in isolation;
     # the worker package already depends on the dispatcher for the queue seam.
     from curie_dispatcher.approval_actions import (
+        APPROVAL_CARD_HEADER,
         APPROVE_ACTION_ID,
         APPROVE_NOTE_ACTION_ID,
         REJECT_ACTION_ID,
@@ -354,7 +355,7 @@ def approval_card(
             "type": "header",
             "text": {
                 "type": "plain_text",
-                "text": _truncate("Approval required", _HEADER_MAX),
+                "text": _truncate(APPROVAL_CARD_HEADER, _HEADER_MAX),
                 "emoji": True,
             },
         },
@@ -379,6 +380,34 @@ def approval_card(
         },
     ]
     return fallback, blocks
+
+
+def resolved_approval_card(
+    *, summary: str, requested_by: str, decision: str, resolver: str, note: str | None
+) -> tuple[str, list[dict[str, Any]]]:
+    """The approval card rebuilt in its RESOLVED form (#1084).
+
+    A thin adapter over ``curie_dispatcher.approval_actions.settled_approval_card``
+    and ``settled_verdict_line`` rather than a second renderer: the dispatcher's
+    click path settles the very same card, and two renderers on one surface is
+    exactly the divergence #1084 was filed to stop. Same import direction as the
+    action ids above, for the same reason.
+
+    Unlike ``expired_approval_card`` this needs the requester and the verdict,
+    because a resolved card states who decided and why, where an expired one
+    states only that nobody did.
+    """
+
+    from curie_dispatcher.approval_actions import (
+        settled_approval_card,
+        settled_verdict_line,
+    )
+
+    return settled_approval_card(
+        summary=_truncate(to_mrkdwn(summary), _APPROVAL_SUMMARY_MAX),
+        requested_by=requested_by,
+        verdict=settled_verdict_line(decision=decision, resolver=resolver, note=note),
+    )
 
 
 def expired_approval_card(*, summary: str) -> tuple[str, list[dict[str, Any]]]:

--- a/apps/worker/src/curie_worker/kernel.py
+++ b/apps/worker/src/curie_worker/kernel.py
@@ -53,7 +53,12 @@ from channel_protocol import (
 from pydantic import ValidationError
 
 from .approval_cards import ApprovalCardStore
-from .approvals import ApprovalBackendError, ApprovalCreator, ApprovalRequest
+from .approvals import (
+    ApprovalBackendError,
+    ApprovalCreator,
+    ApprovalReader,
+    ApprovalRequest,
+)
 from .behaviorpacks import (
     BehaviorPacks,
     NavPack,
@@ -69,7 +74,7 @@ from .markers import Markers
 from .runner_client import RunnerClient, RunnerError, TurnStream
 from .sandbox import SandboxSubstrate
 from .sandbox.types import SandboxError, SandboxHandle, SuspendedThreadError
-from .slack_sink import SlackSink
+from .slack_sink import SettledCard, SlackSink
 from .threadlock import ThreadLock
 
 logger = logging.getLogger(__name__)
@@ -88,6 +93,23 @@ RETRYABLE_CLASSIFICATIONS = frozenset({"rate-limit", "runner-error"})
 # get its resolved card wrongly stamped expired. The marker is a stable
 # platform contract on a platform-authored turn -- not user-intent guessing.
 _EXPIRY_RESUME_MARKER = "[approval expired]"
+
+
+def _approval_id_from_resume_event(event_id: str) -> str | None:
+    """The approval id inside a resume turn's deterministic event id (#1084).
+
+    The inverse of ``resumequeue.resume_event_id``: ``approval-<id>-resolved``,
+    a key the API documents as frozen because the worker's done-marker dedupes
+    on it, and which the expiry and resolve paths deliberately share. Reading
+    the id off it beats parsing the platform-authored prose, which is written
+    for a model rather than for a parser. Returns None on any other shape, so a
+    non-resume event never reaches the reader.
+    """
+
+    if not event_id.startswith("approval-") or not event_id.endswith("-resolved"):
+        return None
+    middle = event_id[len("approval-") : -len("-resolved")]
+    return middle or None
 
 # How long an operator-requested reset waits on the courtesy interrupt before
 # giving up and releasing anyway (#739). Deliberately seconds, not minutes: the
@@ -283,6 +305,11 @@ class Kernel:
         binding: BindingResolver | None = None,
         killswitch: KillSwitch | None = None,
         approvals: ApprovalCreator | None = None,
+        # Separate from ``approvals`` on purpose (#1084): the pause path needs
+        # only the create half, and a test fake for it should not have to grow a
+        # read method it never calls. In production both are the one
+        # ``ApprovalClient``.
+        approval_reader: ApprovalReader | None = None,
         card_store: ApprovalCardStore | None = None,
     ) -> None:
         self._substrate = substrate
@@ -300,6 +327,7 @@ class Kernel:
         # deployment without the API), an awaiting-approval run degrades to an
         # escalation instead of suspending a session nothing could ever resume.
         self._approvals = approvals
+        self._approval_reader = approval_reader
         # Remembers where each suspended thread's approval card was posted so an
         # EXPIRY can disable it (#419); absent (unwired tests) simply skips the
         # card teardown -- the resolve-click path still heals a card on click.
@@ -345,12 +373,10 @@ class Kernel:
                 logger.info("event %s already done; skipping", event_id)
                 return
 
-            # If this is the resume turn of an EXPIRED approval, disable its live
-            # approval card before running the continuation (#419). Best-effort and
-            # gated to the platform-authored expiry resume, so it never touches a
-            # resolved card (the dispatcher edits that from the click) or an
-            # ordinary turn.
-            await self._finalize_expired_card(qevent)
+            # If this is an approval resume, settle its live card before running
+            # the continuation: expired (#419) or resolved (#1084). Best-effort,
+            # and gated on the resume event id so an ordinary turn pays nothing.
+            await self._finalize_settled_card(qevent)
 
             # Crash-safety: a prior attempt executed a side effect but never
             # reached done (worker died mid-run). Do not auto-retry the action.
@@ -886,46 +912,106 @@ class Kernel:
         # matching it here does not couple to a mutable string.
         return event_id.startswith("approval-") and event_id.endswith("-resolved")
 
-    async def _finalize_expired_card(self, qevent: QueuedTurn) -> None:
-        """Disable the approval card when an EXPIRED approval resumes (#419).
+    async def _finalize_settled_card(self, qevent: QueuedTurn) -> None:
+        """Settle the approval card when its approval resumes (#419, #1084).
 
-        The two expiry paths -- the #412 sweeper and a resolve attempt that
-        arrives past the SLA -- both flip the record to ``expired`` and enqueue a
-        platform-authored resume turn prefixed ``[approval expired]``; neither
-        ever touched the card, so its Approve/Reject buttons kept looking live.
-        Here the kernel, which owns the card surface, pops the card it remembered
-        at pause time and edits it into its settled ``expired`` form -- the expiry
-        mirror of the dispatcher's resolved-card edit.
+        Every terminal transition ends here, because the card outlives the
+        decision and nothing else in the system owns it. An EXPIRY (#419) has no
+        click at all: the #412 sweeper or a past-SLA resolve flips the record and
+        enqueues a ``[approval expired]`` turn, and the buttons would otherwise
+        keep looking live. A RESOLVE (#1084) has a click only sometimes -- a
+        resolution that arrived through ``POST /approvals/{id}/resolve`` or
+        ``curie <tier> approvals --resolve`` never touched Slack, so the card
+        stayed live there too, and every later click earned a 409.
 
-        A RESOLVE resume (``[approval resolved]``) only pops the memory to clean
-        it up; the dispatcher already edited that card from the click. The
-        expiry-vs-resolve discriminator is the platform-authored text marker, not
-        the turn author -- see ``_EXPIRY_RESUME_MARKER``. Fully best-effort: any
-        failure here must never fail the resume, and the cheap event-id check
-        gates the Valkey pop so ordinary turns pay nothing.
+        Both forms render through the SAME function the dispatcher's click path
+        is pinned against, so a CLI resolve and a button click leave the same
+        card behind. That convergence is the point of #1084; two renderers on one
+        surface is what it was filed to stop.
+
+        Idempotence, and why an unconditional re-stamp is safe: ``pop`` is
+        GETDEL, so exactly one resume turn per thread gets the ref, and a
+        redelivery finds nothing. Within that single pass the stamp may land on a
+        card the dispatcher already stamped from a click, which is a rewrite to
+        an equivalent card rather than a second verdict -- the shared renderer is
+        what makes "equivalent" true, and a test pins it. A card stamped here and
+        then clicked late gets the existing already-resolved refusal from the
+        API, unchanged.
+
+        Fully best-effort: nothing here may fail the resume, the cheap event-id
+        check gates the Valkey pop so ordinary turns pay nothing, and a record
+        that cannot be read leaves the card alone rather than stamping a verdict
+        the kernel had to guess.
         """
 
         if self._card_store is None or not self._is_approval_resume(qevent.event_id):
             return
         try:
             ref = await self._card_store.pop(qevent.conversation_id)
-            if ref is None or not qevent.text.startswith(_EXPIRY_RESUME_MARKER):
+            if ref is None:
                 return
-            # Emit the channel-neutral summary (ADR-0020); the adapter renders the
-            # settled, buttonless expired card below the seam.
+            # Expiry states only that nobody decided, so it needs no record read;
+            # a resolve states what was decided, and that comes from the record.
+            if qevent.text.startswith(_EXPIRY_RESUME_MARKER):
+                settled = SettledCard(requested_by=ref.requested_by)
+            else:
+                outcome = await self._settled_from_record(qevent)
+                if outcome is None:
+                    return
+                settled = SettledCard(
+                    requested_by=ref.requested_by,
+                    decision=outcome.decision,
+                    resolver=outcome.resolver,
+                    note=outcome.note,
+                )
+            # Emit the channel-neutral summary (ADR-0020) plus the semantic
+            # outcome; the adapter renders the buttonless settled card below the
+            # seam.
             await self._sink.update_message(
                 channel=ref.channel,
                 ts=ref.ts,
                 message=OutboundMessage(version=MESSAGE_VERSION, text=ref.summary),
                 endpoint=ref.endpoint,
+                settled=settled,
             )
-            logger.info("disabled expired approval card for thread %s", qevent.conversation_id)
+            logger.info("settled approval card for thread %s", qevent.conversation_id)
         except Exception as exc:  # noqa: BLE001 - card teardown is best-effort
             logger.warning(
-                "expired approval card teardown failed for thread %s: %s",
+                "approval card teardown failed for thread %s: %s",
                 qevent.conversation_id,
                 exc,
             )
+
+    async def _settled_from_record(self, qevent: QueuedTurn) -> SettledCard | None:
+        """The resolved outcome to stamp, read from the durable record.
+
+        Read, not parsed. The resume turn does state the decision, the resolver
+        and the note, but it states them in a sentence written for a language
+        model; reconstructing them by regex would make the card's correctness
+        depend on that wording. The approval id comes out of the resume turn's
+        deterministic ``event_id`` instead, which is a frozen key shared with
+        ``resumequeue.resume_event_id``.
+
+        None means "do not stamp": no reader configured, an id that does not
+        parse, a record that could not be read, or a record that is somehow not
+        resolved. Leaving a live-looking card is a smaller wrong than stamping a
+        verdict nobody confirmed.
+        """
+
+        if self._approval_reader is None:
+            return None
+        approval_id = _approval_id_from_resume_event(qevent.event_id)
+        if approval_id is None:
+            return None
+        record = await self._approval_reader.get(approval_id)
+        if record is None or record.status not in ("approved", "rejected"):
+            return None
+        return SettledCard(
+            requested_by="",
+            decision=record.status,
+            resolver=record.resolved_by,
+            note=record.resolution_note,
+        )
 
     async def _pause_for_approval(
         self,
@@ -1135,6 +1221,10 @@ class Kernel:
                         ts=card_ts,
                         summary=summary,
                         endpoint=card_endpoint,
+                        # The settled rebuild shows the same "Requested by" line
+                        # the live card did, and once the sandbox is gone this
+                        # is the worker's only copy of it (#1084).
+                        requested_by=qevent.author,
                     )
                 except Exception as exc:  # noqa: BLE001 - best-effort memory
                     logger.warning("remembering approval card for %s failed: %s", created.id, exc)

--- a/apps/worker/src/curie_worker/run.py
+++ b/apps/worker/src/curie_worker/run.py
@@ -176,6 +176,9 @@ def build(config: WorkerConfig, env: Mapping[str, str]) -> Runtime:
     # One API-lane HTTP client shared by the approval writer (#244) and the two
     # eval-lane reporters below; httpx.AsyncClient is task-safe.
     eval_http = httpx.AsyncClient(timeout=30.0)
+    approval_client = ApprovalClient(
+        api_base_url=config.api_base_url, api_key=config.api_key, client=eval_http
+    )
     kernel = Kernel(
         substrate=substrate,
         runner=runner,
@@ -191,9 +194,11 @@ def build(config: WorkerConfig, env: Mapping[str, str]) -> Runtime:
         markers=Markers(async_redis, config),
         config=config,
         binding=binding,
-        approvals=ApprovalClient(
-            api_base_url=config.api_base_url, api_key=config.api_key, client=eval_http
-        ),
+        approvals=approval_client,
+        # The same client, handed in twice under the two roles the kernel needs
+        # (#1084). Two parameters rather than one so a test can fake the create
+        # half without also implementing a read it never exercises.
+        approval_reader=approval_client,
         card_store=ApprovalCardStore(async_redis, config),
     )
     killswitch = KillSwitch(async_redis, on_kill=kernel.interrupt_agent)

--- a/apps/worker/src/curie_worker/slack_sink.py
+++ b/apps/worker/src/curie_worker/slack_sink.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 from typing import Protocol, TypeVar, cast
 
 import aiohttp
@@ -20,7 +21,7 @@ from slack_sdk.web.async_client import AsyncWebClient
 from slack_sdk.web.async_slack_response import AsyncSlackResponse
 
 from .behaviorpacks import NavPack
-from .blocks import approval_card, expired_approval_card, render
+from .blocks import approval_card, expired_approval_card, render, resolved_approval_card
 
 logger = logging.getLogger(__name__)
 
@@ -35,6 +36,22 @@ _UNREACHABLE_ERRORS: tuple[type[BaseException], ...] = (
     aiohttp.ClientError,
     asyncio.TimeoutError,
 )
+
+
+@dataclass(frozen=True)
+class SettledCard:
+    """How an approval ended, channel-neutrally, for the settled-card render.
+
+    ``decision`` is None when nobody decided, which is the expiry case; a
+    non-None value is the resolved case and brings ``resolver`` with it. The
+    kernel builds this from the durable record, never from the platform-authored
+    resume prose, so the card states what the record says.
+    """
+
+    requested_by: str
+    decision: str | None = None
+    resolver: str | None = None
+    note: str | None = None
 
 
 class SlackSink(Protocol):
@@ -100,15 +117,24 @@ class SlackSink(Protocol):
         ts: str,
         message: OutboundMessage,
         endpoint: str | None = None,
+        settled: SettledCard | None = None,
     ) -> None:
-        """Edit an already-posted platform message in place (disabling the
-        expired approval card, #419).
+        """Edit an already-posted platform message in place (settling an
+        approval card: expired in #419, resolved in #1084).
 
         Like ``post``, the kernel hands a channel-neutral ``OutboundMessage``
-        (ADR-0020) and the adapter renders the settled form (Slack: the expired
-        approval card, its buttons gone). Distinct from ``update`` (which renders
-        streamed reply Markdown): this replaces a known platform message.
-        Best-effort at the call site."""
+        (ADR-0020) and the adapter renders the settled form. Distinct from
+        ``update`` (which renders streamed reply Markdown): this replaces a known
+        platform message. Best-effort at the call site.
+
+        ``settled`` carries the outcome semantically -- who asked, what was
+        decided, by whom, with what note -- and the adapter turns that into
+        whatever the channel's settled card looks like. ``None`` keeps #419's
+        behavior, the expired form, so an expiry caller needs no change.
+        Deliberately a parameter rather than fields smuggled into
+        ``OutboundMessage``: ``status`` there already means a rendered status
+        line, and overloading it would give one field two meanings depending on
+        which sink method received it."""
         ...
 
 
@@ -337,11 +363,24 @@ class AsyncSlackSink:
         ts: str,
         message: OutboundMessage,
         endpoint: str | None = None,
+        settled: SettledCard | None = None,
     ) -> None:
-        # Render the settled (expired) approval card HERE, below the seam
-        # (ADR-0020): the kernel hands the channel-neutral summary, the adapter
-        # rebuilds the buttonless expired form.
-        text, blocks = expired_approval_card(summary=message.text)
+        # Render the settled approval card HERE, below the seam (ADR-0020): the
+        # kernel hands the channel-neutral summary plus the semantic outcome, and
+        # the adapter picks the Slack form. No decision means nobody made one,
+        # which is the expiry form (#419); a decision means the resolved form
+        # (#1084), rendered by the SAME function the dispatcher's click path is
+        # pinned against, so an API resolve and a click settle a card alike.
+        if settled is None or settled.decision is None:
+            text, blocks = expired_approval_card(summary=message.text)
+        else:
+            text, blocks = resolved_approval_card(
+                summary=message.text,
+                requested_by=settled.requested_by,
+                decision=settled.decision,
+                resolver=settled.resolver or "",
+                note=settled.note,
+            )
 
         # A rejected Block Kit payload falls back to text-only, mirroring
         # ``post``/``update``: disabling the card is best-effort, but a plain-text

--- a/apps/worker/tests/kernel/conftest.py
+++ b/apps/worker/tests/kernel/conftest.py
@@ -44,7 +44,7 @@ from curie_worker.markers import Markers
 from curie_worker.runner_client import RunnerClient
 from curie_worker.sandbox import AffinityStore, SandboxSubstrate, SubstrateConfig
 from curie_worker.sandbox.types import ClaimView, SandboxView
-from curie_worker.slack_sink import SlackSink
+from curie_worker.slack_sink import SettledCard, SlackSink
 from curie_worker.threadlock import ThreadLock
 from redis.asyncio import Redis as AsyncRedis
 
@@ -121,12 +121,14 @@ class FakeSink(SlackSink):
         self.posts: list[
             tuple[str, OutboundMessage, str, str | None, str | None]
         ] = []
-        # In-place edits of an already-posted message (the expired approval card,
-        # #419): (channel, ts, message, endpoint) per update_message. Like posts,
-        # the recorded value is the channel-neutral message; the adapter renders
-        # the buttonless expired card below the seam.
+        # In-place edits of an already-posted message (settling the approval
+        # card: expired in #419, resolved in #1084):
+        # (channel, ts, message, endpoint, settled) per update_message. Like
+        # posts, the recorded value is the channel-neutral message; the adapter
+        # renders the buttonless settled card below the seam. ``settled`` is the
+        # semantic outcome and is what distinguishes the two forms.
         self.card_updates: list[
-            tuple[str, str, OutboundMessage, str | None]
+            tuple[str, str, OutboundMessage, str | None, SettledCard | None]
         ] = []
         # #708 test infra: endpoints whose HOST is dead (a CLI stub that exited).
         # A reply-delivery ``update`` to one models the pure-offline local loop --
@@ -187,8 +189,13 @@ class FakeSink(SlackSink):
         ts: str,
         message: OutboundMessage,
         endpoint: str | None = None,
+        settled: SettledCard | None = None,
     ) -> None:
-        self.card_updates.append((channel, ts, message, endpoint))
+        # ``settled`` is RECORDED, not accepted and dropped (#1084). It carries
+        # the whole difference between an expired card and a resolved one, so a
+        # fake that swallowed it would let the resolve path regress to rendering
+        # an expiry while every assertion in the suite stayed green.
+        self.card_updates.append((channel, ts, message, endpoint, settled))
 
     @property
     def last_text(self) -> str | None:
@@ -403,6 +410,7 @@ async def kernel_harness(
     binding: object | None = None,
     with_killswitch: bool = False,
     approvals: object | None = None,
+    approval_reader: object | None = None,
     **config_overrides: object,
 ) -> AsyncIterator[Harness]:
     """Assemble a live kernel wired to a fake runner and real Valkey."""
@@ -447,6 +455,7 @@ async def kernel_harness(
         config=config,
         binding=binding,  # type: ignore[arg-type]
         approvals=approvals,  # type: ignore[arg-type]
+        approval_reader=approval_reader,  # type: ignore[arg-type]
         card_store=card_store,
     )
     killswitch = None

--- a/apps/worker/tests/kernel/test_approval_lifecycle.py
+++ b/apps/worker/tests/kernel/test_approval_lifecycle.py
@@ -16,7 +16,12 @@ import aiohttp
 import pytest
 from aci_protocol import Final, QueuedTurn, ReplyHandle, SessionStatus, TextDelta
 from channel_protocol import ConfirmIntent
-from curie_worker.approvals import ApprovalBackendError, ApprovalRequest, CreatedApproval
+from curie_worker.approvals import (
+    ApprovalBackendError,
+    ApprovalRequest,
+    CreatedApproval,
+    SettledApproval,
+)
 from curie_worker.sandbox.types import RouteState
 
 DONE = SessionStatus.DONE
@@ -35,6 +40,23 @@ class RecordingApprovals:
             raise ApprovalBackendError("approval API unavailable")
         self.requests.append(request)
         return CreatedApproval(id=f"appr-{len(self.requests)}", status="pending")
+
+
+class RecordingReader:
+    """An ApprovalReader fake: hands back one settled record, records the reads.
+
+    Separate from ``RecordingApprovals`` for the same reason the kernel takes two
+    parameters (#1084): most tests need only the create half, and a combined fake
+    would make every one of them carry a read they never exercise.
+    """
+
+    def __init__(self, record: SettledApproval | None) -> None:
+        self.record = record
+        self.reads: list[str] = []
+
+    async def get(self, approval_id: str) -> SettledApproval | None:
+        self.reads.append(approval_id)
+        return self.record
 
 
 def _qevent(
@@ -711,7 +733,10 @@ def test_expiry_resume_disables_the_approval_card(make_harness) -> None:
             # (no actions block, an expiry line) is the adapter's job below the
             # seam -- asserted in test_slack_sink.py.
             assert len(h.sink.card_updates) == 1
-            channel, ts, message, endpoint = h.sink.card_updates[0]
+            channel, ts, message, endpoint, settled = h.sink.card_updates[0]
+            # Expiry means nobody decided, so the settled outcome carries no
+            # decision and the adapter renders the expired form (#1084).
+            assert settled is not None and settled.decision is None
             assert (channel, ts) == ("C1", card_ts)
             assert endpoint is None
             assert message.text == "Give ACME a 20% discount"
@@ -725,15 +750,30 @@ def test_expiry_resume_disables_the_approval_card(make_harness) -> None:
     asyncio.run(go())
 
 
-def test_resolve_resume_leaves_the_card_to_the_dispatcher(make_harness) -> None:
-    """#419: a RESOLVE resume (author is the resolver) must NOT edit the card --
-    the dispatcher already did from the click -- but it still consumes the
-    remembered card so no stale memory lingers into a later approval."""
+def test_resolve_resume_stamps_the_card_from_the_record(make_harness) -> None:
+    """#1084: a RESOLVE resume settles the card, it no longer leaves it live.
+
+    This asserted the opposite until #1084, on the premise that "the dispatcher
+    already did from the click". That holds only when there WAS a click: a
+    resolution through ``POST /approvals/{id}/resolve`` or ``curie <tier>
+    approvals --resolve`` never touches Slack, so the card kept its buttons and
+    every later click earned a 409. The worker is the only component that still
+    knows where the card is, so settling it belongs here.
+
+    The verdict comes from the durable record, not from the platform-authored
+    resume prose -- that sentence is written for a model, and rebuilding a
+    decision out of it by regex is how the card would start lying after a
+    wording change.
+    """
 
     async def go() -> None:
-        approvals = RecordingApprovals()
+        reader = RecordingReader(
+            SettledApproval(
+                status="approved", resolved_by="U9", resolution_note="approved for Q3"
+            )
+        )
         thread = "th-resolve-card"
-        async with make_harness(approvals=approvals) as h:
+        async with make_harness(approvals=RecordingApprovals(), approval_reader=reader) as h:
             h.runner.default_script = _awaiting_script("Refund order 42")
             await h.kernel.process_event(_qevent("refund?", thread=thread))
             assert await h.async_redis.exists(h.config.approval_card_key(thread))
@@ -748,10 +788,89 @@ def test_resolve_resume_leaves_the_card_to_the_dispatcher(make_harness) -> None:
                 )
             )
 
-            # No worker-side card edit (the dispatcher owns the resolved card)...
-            assert h.sink.card_updates == []
-            # ...but the memory was cleaned up so a later approval cannot collide.
+            # The card was settled, with the outcome read off the record.
+            assert len(h.sink.card_updates) == 1
+            _channel, _ts, message, _endpoint, settled = h.sink.card_updates[0]
+            assert message.text == "Refund order 42", "the summary must survive"
+            assert settled is not None
+            assert settled.decision == "approved"
+            assert settled.resolver == "U9"
+            assert settled.note == "approved for Q3"
+            # And the requester the live card named is carried into the rebuild,
+            # so the settled card is not missing a line the original had.
+            # "U1" is the author `_qevent` stamps on the triggering turn, which
+            # is exactly what `approval_card` rendered as "Requested by".
+            assert settled.requested_by == "U1"
+
+            # The read was keyed off the resume turn's deterministic event id.
+            assert reader.reads == ["appr-1"]
+
+            # The memory is still consumed, so a later approval cannot collide.
             assert not await h.async_redis.exists(h.config.approval_card_key(thread))
+
+    asyncio.run(go())
+
+
+def test_a_resolve_resume_leaves_the_card_alone_when_the_record_cannot_be_read(
+    make_harness,
+) -> None:
+    """No record, no stamp (#1084).
+
+    The kernel would have to invent a decision to render anything, and a card
+    stating a verdict nobody confirmed is worse than one still showing buttons:
+    the buttons are at least honest about the platform not having told Slack
+    yet, and the next click gets the real answer from the API.
+    """
+
+    async def go() -> None:
+        reader = RecordingReader(None)
+        thread = "th-unreadable-record"
+        async with make_harness(approvals=RecordingApprovals(), approval_reader=reader) as h:
+            h.runner.default_script = _awaiting_script("Refund order 42")
+            await h.kernel.process_event(_qevent("refund?", thread=thread))
+
+            h.runner.default_script = [Final(text="Refunded.", status=DONE)]
+            await h.kernel.process_event(
+                _resume_turn(
+                    "[approval resolved] approved by U9",
+                    thread=thread,
+                    approval_id="appr-1",
+                    author="U9",
+                )
+            )
+
+            assert h.sink.card_updates == []
+            # The memory is consumed either way: a ref left behind would be
+            # popped by an unrelated later approval on the same thread.
+            assert not await h.async_redis.exists(h.config.approval_card_key(thread))
+
+    asyncio.run(go())
+
+
+def test_a_resolve_resume_with_no_reader_configured_still_resumes(make_harness) -> None:
+    """Progressive enhancement, per ADR-0020: a deployment with nothing to read
+    the record with settles no card and continues the run normally. The stamp is
+    an enrichment on a decision that already happened."""
+
+    async def go() -> None:
+        thread = "th-no-reader"
+        async with make_harness(approvals=RecordingApprovals()) as h:
+            h.runner.default_script = _awaiting_script("Refund order 42")
+            await h.kernel.process_event(_qevent("refund?", thread=thread))
+
+            h.runner.default_script = [Final(text="Refunded.", status=DONE)]
+            await h.kernel.process_event(
+                _resume_turn(
+                    "[approval resolved] approved by U9",
+                    thread=thread,
+                    approval_id="appr-1",
+                    author="U9",
+                )
+            )
+
+            assert h.sink.card_updates == []
+            # The run itself continued: the resumed reply was delivered.
+            assert h.sink.updates, "the resume must still produce a reply"
 
     asyncio.run(go())
 

--- a/apps/worker/tests/test_blocks.py
+++ b/apps/worker/tests/test_blocks.py
@@ -500,6 +500,74 @@ def test_approval_card_renders_allow_free_text_as_the_note_buttons() -> None:
     assert APPROVE_NOTE_ACTION_ID.startswith(APPROVE_ACTION_ID)
 
 
+def test_the_rebuilt_settled_card_matches_the_edited_one() -> None:
+    """The convergence #1084 asks for, asserted rather than asserted-in-prose.
+
+    Two paths settle a card from different inputs. The dispatcher holds the live
+    message and EDITS it; the worker's resume path holds only what it remembered
+    and REBUILDS. If those drift, a CLI resolve and a button click leave visibly
+    different cards behind for the same decision -- which is the whole reason
+    #1084 was filed rather than just "also stamp on the API path".
+
+    So: render a live card, settle it both ways, compare block for block.
+    """
+
+    from curie_dispatcher.approval_actions import _resolved_card_blocks, settled_verdict_line
+    from curie_worker.blocks import approval_card, resolved_approval_card
+
+    summary = "Give ACME a 20% discount"
+    requested_by = "U_AE"
+    _fallback, live = approval_card(
+        approval_id="appr-1",
+        summary=summary,
+        requested_by=requested_by,
+        allow_free_text=True,
+    )
+
+    verdict = settled_verdict_line(
+        decision="approved", resolver="U_MANAGER", note="approved for Q3"
+    )
+    edited = _resolved_card_blocks({"blocks": live}, verdict)
+    _rebuilt_text, rebuilt = resolved_approval_card(
+        summary=summary,
+        requested_by=requested_by,
+        decision="approved",
+        resolver="U_MANAGER",
+        note="approved for Q3",
+    )
+
+    assert rebuilt == edited, (
+        "the rebuilt settled card must be identical to the edited one, or a CLI "
+        f"resolve and a click leave different cards.\nedited:  {edited}\n"
+        f"rebuilt: {rebuilt}"
+    )
+    # And the thing that makes it a SETTLED card in the first place.
+    assert not any(b.get("type") == "actions" for b in rebuilt)
+
+
+def test_a_settled_card_without_a_remembered_requester_omits_the_line() -> None:
+    """A card remembered before #1084 carries no requester.
+
+    Those refs live in Valkey across a deploy, so the rebuild has to cope. It
+    omits the line rather than rendering "Requested by <@>", which reads as a
+    bug in a channel humans audit.
+    """
+
+    from curie_worker.blocks import resolved_approval_card
+
+    _text, blocks = resolved_approval_card(
+        summary="Refund order 42",
+        requested_by="",
+        decision="rejected",
+        resolver="U_MANAGER",
+        note=None,
+    )
+
+    assert not any("Requested by" in str(b) for b in blocks)
+    assert any("Refund order 42" in str(b) for b in blocks), "the summary still shows"
+    assert any("Rejected by <@U_MANAGER>" in str(b) for b in blocks)
+
+
 def test_approval_card_clamps_oversized_summary() -> None:
     from curie_worker.blocks import approval_card
 


### PR DESCRIPTION
Closes #1084. Third and last code PR of the Wave 2 settled-card sequence, after #1154 (#1076, the always-on decision) and #1157 (#1073, the thread read).

## What this fixes

A resolution that arrived through `POST /approvals/{id}/resolve` or `curie <tier> approvals --resolve` left the card in the approver channel showing **live Approve/Reject buttons**. The record was settled; the buttons still invited clicks; every later click earned a 409.

Stamping existed only on the dispatcher's click path, and that path never runs for an API resolve. The worker is the only component that still knows where the card is — the `ApprovalCardStore` ref it wrote at pause time, which the expiry teardown (#419) already uses for exactly this. The resolve path was the one terminal transition that popped that ref and threw it away, on the premise that *"the dispatcher already did from the click"* — true only when there **was** a click.

## One renderer, and why it lives where it does

`settled_approval_card` is in the **dispatcher** package, because that is the direction the dependency already runs: `curie_worker.blocks` imports the action ids from `curie_dispatcher.approval_actions` for the same anti-drift reason, and the reverse import would be a cycle. The worker's `resolved_approval_card` is a thin adapter over it.

"The same visible outcome" is **asserted, not claimed**. `test_the_rebuilt_settled_card_matches_the_edited_one` renders a live card, settles it both ways — edited from the live blocks as the click path does, rebuilt from the remembered summary as the resume path does — and compares block for block:

```python
assert rebuilt == edited, (
    "the rebuilt settled card must be identical to the edited one, or a CLI "
    "resolve and a click leave different cards."
)
```

That equality is the contract. Without it, convergence is a docstring.

## The verdict is read, not parsed

The resume turn does state the decision, the resolver and the note — but it states them in a sentence written for a language model:

```
[approval resolved] The request "..." was approved by U9. Note: approved for Q3. Continue the task accordingly: ...
```

Rebuilding a decision by regex over that would make the card's correctness depend on prose wording. So the approval id comes off the resume turn's **deterministic event id** (`approval-<id>-resolved`, which `resumequeue` documents as frozen because the worker's done-marker dedupes on it), and the facts come from the record.

## Supporting changes

| Change | Why |
|---|---|
| `ApprovalCardRef.requested_by` | The rebuild shows the same "Requested by" line the live card did. **Defaulted and read with `.get`** — these refs live in Valkey across a deploy, so a pre-#1084 entry must still load; it renders without the line rather than failing. |
| `ApprovalClient.get` behind a new `ApprovalReader` protocol | Separate from `ApprovalCreator` so a test fake for the pause path does not have to grow a read it never calls. In production both parameters get the one client. **Never raises**: its only caller is best-effort teardown on a turn that is already resuming. |
| `SlackSink.update_message(settled=...)` | A channel-neutral value, not fields smuggled into `OutboundMessage` — whose `status` already means a rendered status line, and overloading it would give one field two meanings depending on which sink method received it. `None` keeps #419's expiry behavior byte-identical. |

## Three refusals to stamp, each tested

Progressive enhancement per ADR-0020, and the same asymmetry #1073 established: a card that keeps its buttons is honest about the platform not having told Slack yet, and the next click gets the real answer from the API. A card stating a verdict the kernel had to guess is not.

- No reader configured → resumes normally, stamps nothing, **reply still delivered**.
- Record cannot be read → no stamp, ref still consumed (a ref left behind would be popped by an unrelated later approval on the same thread).
- Record not in a resolved state → no stamp.

## Idempotence

`pop` is GETDEL, so exactly one resume turn per thread gets the ref and a redelivery finds nothing. Within that single pass the stamp may land on a card the dispatcher already stamped from a click — that is a rewrite to an **equivalent** card, not a second verdict, and the shared renderer plus the equality test are what make "equivalent" true rather than hoped. A card stamped here and then clicked late gets the existing already-resolved refusal from the API, unchanged.

## The gap the issue named

> the claim that a note reaches the requester rests on `resumequeue.build_resume_turn` interpolating `Note: {...}`, and no test in the tree asserts that text.

Correct — the only other reference builds a turn to seed a dead-letter row and never reads it. `apps/api/tests/test_resume_turn_text.py` (5 tests) pins the noted clause **exactly** (`" Note: approved for Q3."`, spacing and period included), its total absence on a bare resolution (an empty `Note: .` would tell the model the approver left a blank reason rather than none), the rejection wording, the resolver as author, and that an expiry names no decider and carries the do-not-perform instruction.

## One existing test changed meaning, deliberately

`test_resolve_resume_leaves_the_card_to_the_dispatcher` asserted `h.sink.card_updates == []` as **correct behavior**. It is now `test_resolve_resume_stamps_the_card_from_the_record`, and the docstring states what changed and why. Flagging it as the one inverted assertion in this PR.

Also: `FakeSink.update_message` now **records** `settled` rather than accepting and dropping it. A fake that swallowed it would let the resolve path regress to rendering an expiry while every assertion in the suite stayed green — the exact shape of the hole Brian's audit found in #1059's stub.

## Sacred module

`kernel.py` is touched. Flagging it for the adversarial review `apps/worker/CLAUDE.md` requires. The change stays inside the existing card-store and sink surfaces, adds no kernel state, and the teardown remains best-effort and gated on the resume event id so an ordinary turn pays nothing. `_finalize_expired_card` is renamed `_finalize_settled_card` because it now handles both terminal transitions.

## Verification

Dev-stack Valkey, Postgres **and MinIO** up (the api suite needs the bundle store):

```
uv run ruff check .                             All checks passed
uv run mypy                                     no issues in 166 source files
uv run pytest apps/worker apps/dispatcher       662 passed, 11 skipped
uv run pytest apps/api/tests                    493 passed, 9 skipped, 1 failed (see below)
curie dev docs-lint                             OK
```

The one api failure, `test_control_integration.py::test_cost_composes_metrics_for_the_agent`, **fails identically on a clean tree** (verified by stashing this branch's changes) and is untouched by this PR — nothing here goes near cost or metrics.

## Still outstanding for Wave 2

The **live Slack pass** over the route-binding and note-dialog surfaces, which Brian asked for when #1073 and #1076 were taken. It is a human-in-the-loop run (a modal click cannot be synthesized over Socket Mode) and is scheduled separately. It should also confirm the `views.open` scope assumption in the app manifest, whose interactivity comment currently names only `block_actions` and not `view_submission`.
