### PR TITLE
cluster/local deploy: --agent, so one repo can serve two agents (#1166)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ agents/
 
 # generated CLI manifest module (apps/ui codegen)
 apps/ui/src/generated/
+
+# Cross-build output for the linux/arm64 CLI (docker buildx / rust image).
+cli/target-linux-*/

--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -1137,6 +1137,14 @@ export const commandManifest = {
           "about": "Push the bundle to the local platform API and deploy it",
           "args": [
             {
+              "global": false,
+              "help": "Deploy under this agent name instead of the manifest's `name`",
+              "id": "agent",
+              "long": "agent",
+              "positional": false,
+              "required": false
+            },
+            {
               "default_values": [
                 "."
               ],
@@ -2446,6 +2454,14 @@ export const commandManifest = {
         {
           "about": "Push the bundle to the platform API and deploy it",
           "args": [
+            {
+              "global": false,
+              "help": "Deploy under this agent name instead of the manifest's `name`",
+              "id": "agent",
+              "long": "agent",
+              "positional": false,
+              "required": false
+            },
             {
               "default_values": [
                 "."

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -1134,6 +1134,14 @@
           "about": "Push the bundle to the local platform API and deploy it",
           "args": [
             {
+              "global": false,
+              "help": "Deploy under this agent name instead of the manifest's `name`",
+              "id": "agent",
+              "long": "agent",
+              "positional": false,
+              "required": false
+            },
+            {
               "default_values": [
                 "."
               ],
@@ -2443,6 +2451,14 @@
         {
           "about": "Push the bundle to the platform API and deploy it",
           "args": [
+            {
+              "global": false,
+              "help": "Deploy under this agent name instead of the manifest's `name`",
+              "id": "agent",
+              "long": "agent",
+              "positional": false,
+              "required": false
+            },
             {
               "default_values": [
                 "."

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -722,6 +722,9 @@ pub async fn deploy_named(folder: &str, opts: DeployNamedOpts) -> Result<DeployO
     );
     deploy(DeployOpts {
         plugin_dir,
+        // deploy_named is the multi-agent-folder path: the folder IS the agent
+        // identity there, so there is nothing to override.
+        agent: None,
         api_url: opts.api_url,
         api_key: opts.api_key,
         slack_channel: opts.slack_channel,
@@ -2917,6 +2920,14 @@ pub fn resolve_cases_path(
 }
 
 pub struct DeployOpts {
+    /// Deploy under this agent name instead of the manifest's.
+    ///
+    /// One repository is otherwise structurally one agent (#1166): the name
+    /// comes from `plugin.json`, so a bundle cannot run as both a dev and a
+    /// prod agent. Overriding at deploy keeps the ARTIFACT identical -- the
+    /// bundle bytes are untouched, only the binding differs -- which is the
+    /// property that lets prod promote exactly what dev validated.
+    pub agent: Option<String>,
     pub plugin_dir: PathBuf,
     pub api_url: String,
     pub api_key: String,
@@ -3093,12 +3104,16 @@ pub async fn deploy(opts: DeployOpts) -> Result<DeployOutput> {
         ));
     }
 
+    // The manifest name is the default, not the law (#1166). `plugin_name`
+    // stays the DISPLAY name so the log still says which bundle was deployed;
+    // `agent_name` is what the platform binds.
+    let agent_name = opts.agent.clone().unwrap_or_else(|| plugin_name.clone());
     let client = ApiClient::new(&opts.api_url, &opts.api_key)?;
     let cl = ui.checklist();
-    let step = cl.step(&format!("deploying {plugin_name}"));
+    let step = cl.step(&format!("deploying {plugin_name} as {agent_name}"));
     let outcome = match client
         .deploy(
-            &plugin_name,
+            &agent_name,
             opts.slack_channel.as_deref(),
             &label,
             &created_by,
@@ -5996,6 +6011,7 @@ mod tests {
         crate::scaffold::scaffold(dir.path(), "test-agent").unwrap();
         let hint = "kubectl -n curie port-forward svc/curie-api 8000:8000";
         let opts = super::DeployOpts {
+            agent: None,
             plugin_dir: dir.path().to_path_buf(),
             // port 1 is reserved/closed -> deterministic connection refused
             api_url: "http://127.0.0.1:1".to_string(),
@@ -6067,6 +6083,7 @@ mod tests {
         scaffold_with_secrets(dir.path(), "test-agent", &["GITHUB_PERSONAL_ACCESS_TOKEN"]);
 
         let opts = super::DeployOpts {
+            agent: None,
             plugin_dir: dir.path().to_path_buf(),
             api_url: "http://127.0.0.1:1".to_string(),
             api_key: "k".to_string(),
@@ -6100,6 +6117,7 @@ mod tests {
         scaffold_with_secrets(dir.path(), "test-agent", &["GITHUB_PERSONAL_ACCESS_TOKEN"]);
 
         let opts = super::DeployOpts {
+            agent: None,
             plugin_dir: dir.path().to_path_buf(),
             // port 1 is reserved/closed -> deterministic connection refused
             api_url: "http://127.0.0.1:1".to_string(),

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -908,6 +908,13 @@ enum LocalAction {
     },
     /// Push the bundle to the local platform API and deploy it.
     Deploy {
+        /// Deploy under this agent name instead of the manifest's `name`.
+        ///
+        /// The bundle is unchanged -- only which agent it binds to. This is how
+        /// one repository serves a dev agent and a prod agent from the same
+        /// artifact, so prod promotes exactly what dev validated (#1166).
+        #[arg(long)]
+        agent: Option<String>,
         /// Plugin bundle directory.
         #[arg(long, default_value = ".")]
         plugin_dir: PathBuf,
@@ -1372,6 +1379,13 @@ enum ClusterAction {
     },
     /// Push the bundle to the platform API and deploy it.
     Deploy {
+        /// Deploy under this agent name instead of the manifest's `name`.
+        ///
+        /// The bundle is unchanged -- only which agent it binds to. This is how
+        /// one repository serves a dev agent and a prod agent from the same
+        /// artifact, so prod promotes exactly what dev validated (#1166).
+        #[arg(long)]
+        agent: Option<String>,
         /// Plugin bundle directory.
         #[arg(long, default_value = ".")]
         plugin_dir: PathBuf,
@@ -2020,6 +2034,7 @@ async fn run(command: Option<Command>) -> Result<()> {
             }
             LocalAction::Deploy {
                 plugin_dir,
+                agent,
                 api_url,
                 api_key,
                 slack_channel,
@@ -2034,6 +2049,7 @@ async fn run(command: Option<Command>) -> Result<()> {
                 emit(
                     commands::deploy(DeployOpts {
                         plugin_dir,
+                        agent,
                         api_url,
                         api_key,
                         slack_channel,
@@ -2459,6 +2475,7 @@ async fn run(command: Option<Command>) -> Result<()> {
             }
             ClusterAction::Deploy {
                 plugin_dir,
+                agent,
                 api_url,
                 namespace,
                 release,
@@ -2552,6 +2569,7 @@ async fn run(command: Option<Command>) -> Result<()> {
                 };
                 let deployed = commands::deploy(DeployOpts {
                     plugin_dir,
+                    agent,
                     api_url: api_url.clone(),
                     api_key: api_key.clone(),
                     slack_channel,


### PR DESCRIPTION
Fixes #1166. Base `main`.

The agent name came only from `.claude-plugin/plugin.json`, so **one repository was structurally one agent**.

## The concrete breakage

acme-bot has two deploy workflows that look like a dev/prod split and aren't:

| workflow | branch | agent | env | channel |
|---|---|---|---|---|
| `deploy.yml` | main | `acme-bot` | *unset → **dev*** | hardcoded |
| `deploy-dev.yml` | dev | `acme-bot` | dev | repo variable |

Confirmed on the live cluster — `curie cluster versions acme-bot` shows **one agent, four versions, no `acme-dev`**. Both branches overwrite the same active version and fight over the one channel that agent can bind. Nothing reports it.

## The fix

```bash
curie cluster deploy --plugin-dir . --agent acme-dev  --env dev
curie cluster deploy --plugin-dir . --agent acme-bot  --env prod
```

**The bundle is untouched** — only the binding differs. That's the load-bearing part. `apps/api/CLAUDE.md` requires prod to promote *"the exact artifact that passed on dev,"* and the obvious alternative (rewriting `plugin.json`'s name in CI) would make dev and prod **different artifacts** and quietly break it.

`plugin_name` stays the display name, so the log still says which bundle went out: `deploying acme-bot as acme-dev`.

Absent, the manifest name is used exactly as before — no existing deploy changes behaviour.

## Scope

`deploy_named` (the multi-agent-folder path) passes `None` deliberately: there the folder *is* the agent identity, so there's nothing to override.

**Does not fix #1070**, the binding-side half — one agent still binds one channel. This is the deploy-side half: until now there was no way to even *say* which agent a deploy targets.

## Verification

```
cargo clippy -D warnings → 0 errors
cargo test               → 0 failed across all suites
field-parity             → 4 passed
command manifests        → regenerated (cli + ui), both carry the new flag
```

Also gitignored `cli/target-linux-*/`, the cross-build output directory used to produce a linux/arm64 CLI.
