### PR TITLE
ADR-0089 (Draft): bundles declare their deploy targets

### DIFF
--- a/docs/adr/0089-bundles-declare-their-deploy-targets.md
+++ b/docs/adr/0089-bundles-declare-their-deploy-targets.md
@@ -1,0 +1,135 @@
+# 89. Bundles declare their deploy targets
+
+Date: 2026-07-31
+
+Status: Draft
+
+## Context
+
+Issue #1166. A bundle declares what it needs to run —
+[ADR 0086](0086-bundles-declare-connectors-the-platform-hosts-them.md) moved
+connectors into `connectors.yaml` on exactly that principle. It does not declare
+**where it gets deployed**, and that turns out to be the same problem wearing a
+different hat.
+
+Where a bundle is deployed is currently expressed as flags at the call site:
+
+```bash
+curie cluster deploy --plugin-dir . --namespace sre-bot --release sre-bot \
+  --slack-channel C0BL766QCR0
+```
+
+so the routing lives in whatever invoked the command. In sre-bot's case that is
+two GitHub Actions workflows, and the result is a dev/prod split that does not
+exist:
+
+| workflow | branch | agent | env | channel |
+|---|---|---|---|---|
+| `deploy.yml` | main | from `plugin.json` | *unset → `dev`* | a literal in the file |
+| `deploy-dev.yml` | dev | from `plugin.json` | `dev` | a repo variable |
+
+Both resolve to the **same agent** — the name comes from `plugin.json` and
+nothing overrode it (#1166) — so the two branches overwrite each other's active
+version and contend for the one channel that agent can bind. Confirmed against
+the live cluster: one agent, four versions, no `sre-dev`.
+
+Three properties are missing, and each is a repeat of a lesson the connector
+work already taught:
+
+- **It is not reviewable.** A channel id in a workflow heredoc is not something
+  anyone diffs with intent. The same was true of the 184 lines of hand-written
+  Kubernetes that `connectors.yaml` replaced.
+- **It is not reproducible.** A rebuilt CI, or a human running the command by
+  hand, has to know the routing from somewhere other than the repository.
+- **It fails silently.** `--env` defaults to `dev`, so a prod workflow that
+  simply omits it deploys to dev and says nothing. That is what shipped.
+
+## Decision
+
+**A bundle declares its deploy targets in a file; `deploy` executes one by
+name.**
+
+```yaml
+# deploy.yaml
+targets:
+  dev:
+    agent: sre-dev
+    env: dev
+    slack_channel: C0BLL2PK3PW
+  prod:
+    agent: sre-bot
+    env: prod
+    slack_channel: C0BL766QCR0
+```
+
+```bash
+curie cluster deploy --plugin-dir . --target dev
+curie cluster deploy --plugin-dir . --target prod
+```
+
+The three properties above follow directly: the routing is a reviewable diff, it
+is reproducible from the repository alone, and a target either resolves or the
+deploy fails naming what is missing.
+
+Four things this decision fixes by construction:
+
+**`env` becomes explicit.** A target states its environment. The silent
+`--env` default cannot produce a prod workflow that deploys to dev, because the
+target says which it is.
+
+**The artifact stays identical across targets.** Only the binding differs. This
+is the load-bearing constraint: `apps/api/CLAUDE.md` requires prod to promote
+"the exact artifact that passed on dev." The obvious alternative — rewriting
+`plugin.json`'s `name` per environment in CI — produces *different bundles* for
+dev and prod and quietly breaks that guarantee.
+
+**Flags stay as overrides, not the interface.** `--agent`, `--env`, and
+`--slack-channel` continue to work and win over the target when passed. A
+one-off deploy to a scratch agent must not require editing a committed file.
+
+**Absent `deploy.yaml` changes nothing.** Bundles that pass flags today keep
+working unchanged; the file is additive, exactly as `connectors.yaml` was.
+
+## Consequences
+
+The bundle now carries workspace-specific values — Slack channel ids. That is a
+real coupling: the same bundle deployed into a different Slack workspace needs
+different targets, so the file is only portable within the workspace it names.
+Accepted deliberately, because the alternative is the status quo where those ids
+live in CI configuration nobody reviews. A bundle that wants portability keeps
+using flags.
+
+Two files now describe deployment, with different lifetimes: `connectors.yaml`
+is *what the agent needs wherever it runs*, `deploy.yaml` is *where this
+repository sends it*. Collapsing them would put a channel id next to a container
+image, which are not the same kind of fact and do not change together.
+
+Nothing here relaxes [#1070](https://github.com/curie-eng/curie/issues/1070) —
+one agent still binds one channel. Declaring two targets creates two agents;
+it does not let one agent serve two channels.
+
+A target names an agent, so a typo mints a new agent rather than failing. That
+is the same hazard `cluster deploy` already has, and it is worse here because
+the name is in a file rather than typed at the prompt. The validator should
+reject a target whose agent name is not a valid agent name, and `--dry-run`
+should print the resolved binding before anything is created.
+
+## Alternatives considered
+
+- **Flags only, plus documentation.** Rejected: it is the current state, and it
+  produced a dev/prod split that silently did not exist for weeks. Documentation
+  does not diff.
+- **Rewrite `plugin.json`'s name per environment in CI.** Rejected: it makes dev
+  and prod different artifacts, breaking promote-what-you-validated. It also
+  hides the routing in a `jq` expression, which is strictly less reviewable than
+  a flag.
+- **Put targets inside `connectors.yaml`.** Rejected: different concerns with
+  different lifetimes. A connector changes when the agent's capabilities change;
+  a target changes when the deployment topology does.
+- **Put targets in `plugin.json`.** Rejected: that file is the verbatim Claude
+  Code plugin manifest (`packages/CLAUDE.md`), and Curie-specific deployment
+  routing has no place in a format Curie does not own.
+- **A `curie target add` CLI verb.** Rejected for the reason ADR 0086 rejected
+  `curie connect`: it stores state the repository cannot see, so a rebuilt
+  cluster does not reproduce from the repo and the change is invisible in
+  review.

--- a/docs/adr/0089-bundles-declare-their-deploy-targets.md
+++ b/docs/adr/0089-bundles-declare-their-deploy-targets.md
@@ -2,7 +2,7 @@
 
 Date: 2026-07-31
 
-Status: Draft
+Status: Accepted
 
 ## Context
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -117,4 +117,5 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0086 | [Bundles declare connectors; the platform hosts them](0086-bundles-declare-connectors-the-platform-hosts-them.md) | Accepted |
 | 0087 | [The API renders connector objects; the CLI applies them](0087-the-api-renders-connector-objects-the-cli-applies-them.md) | Draft |
 | 0088 | [Per user delegated OAuth for MCP](0088-per-user-delegated-oauth-for-mcp.md) | Draft |
+| 0089 | [Bundles declare their deploy targets](0089-bundles-declare-their-deploy-targets.md) | Draft |
 <!-- END GENERATED: adr-index -->

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -117,5 +117,5 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0086 | [Bundles declare connectors; the platform hosts them](0086-bundles-declare-connectors-the-platform-hosts-them.md) | Accepted |
 | 0087 | [The API renders connector objects; the CLI applies them](0087-the-api-renders-connector-objects-the-cli-applies-them.md) | Draft |
 | 0088 | [Per user delegated OAuth for MCP](0088-per-user-delegated-oauth-for-mcp.md) | Draft |
-| 0089 | [Bundles declare their deploy targets](0089-bundles-declare-their-deploy-targets.md) | Draft |
+| 0089 | [Bundles declare their deploy targets](0089-bundles-declare-their-deploy-targets.md) | Accepted |
 <!-- END GENERATED: adr-index -->


### PR DESCRIPTION
Refs #1166. **Docs only — no code.** Draft; per ADR-0085 only your acceptance authorizes implementation.

You asked for a file-based approach like kubectl. This writes down the decision before I build it, because it adds a new bundle contract surface.

## The shape

```yaml
# deploy.yaml
targets:
  dev:
    agent: acme-dev
    env: dev
    slack_channel: C0EXAMPLE2
  prod:
    agent: acme-bot
    env: prod
    slack_channel: C0EXAMPLE1
```

```bash
curie cluster deploy --plugin-dir . --target prod
```

## Three failures it fixes by construction

- **Not reviewable** — a channel id in a workflow heredoc is not something anyone diffs with intent. Same as the 184 lines of Kubernetes `connectors.yaml` replaced.
- **Not reproducible** — a rebuilt CI, or a human running the command by hand, has to learn the routing from somewhere other than the repo.
- **Fails silently** — `--env` defaults to `dev`, so a prod workflow that omits it deploys to dev and says nothing. **That is what shipped**, and it ran that way for weeks.

## The load-bearing constraint

The artifact stays **byte-identical** across targets; only the binding differs.

The obvious alternative — rewriting `plugin.json`'s `name` per environment in CI — produces *different bundles* for dev and prod, breaking the rule `apps/api/CLAUDE.md` states: prod promotes *"the exact artifact that passed on dev."*

## Costs recorded, not elided

**The bundle gains workspace-specific Slack ids.** The same bundle in a different workspace needs different targets, so the file is portable only within the workspace it names. Accepted deliberately — the alternative is those ids living in CI config nobody reviews. Bundles wanting portability keep using flags.

**A typo mints a new agent rather than failing.** The name is now in a file rather than typed at a prompt, which makes it worse than today. The ADR calls for validating the agent name and a `--dry-run` that prints the resolved binding before anything is created.

**Two files, deliberately.** `connectors.yaml` is *what the agent needs wherever it runs*; `deploy.yaml` is *where this repo sends it*. Collapsing them puts a channel id next to a container image — not the same kind of fact, and they don't change together.

## Not fixed

#1070 — one agent still binds one channel. Declaring two targets creates two agents; it doesn't let one agent serve two.

## If you accept

Implementation is three PRs: the `deploy.yaml` contract in `plugin-format` (frozen, lands first), `--target` in the CLI, then acme-bot adopting it. #1167 (`--agent`) is the prerequisite and is already open.
