### PR TITLE
plugin-format: deploy.yaml, the declared deploy targets (ADR-0089)

### DIFF
--- a/docs/adr/0089-bundles-declare-their-deploy-targets.md
+++ b/docs/adr/0089-bundles-declare-their-deploy-targets.md
@@ -1,0 +1,135 @@
+# 89. Bundles declare their deploy targets
+
+Date: 2026-07-31
+
+Status: Accepted
+
+## Context
+
+Issue #1166. A bundle declares what it needs to run —
+[ADR 0086](0086-bundles-declare-connectors-the-platform-hosts-them.md) moved
+connectors into `connectors.yaml` on exactly that principle. It does not declare
+**where it gets deployed**, and that turns out to be the same problem wearing a
+different hat.
+
+Where a bundle is deployed is currently expressed as flags at the call site:
+
+```bash
+curie cluster deploy --plugin-dir . --namespace sre-bot --release sre-bot \
+  --slack-channel C0BL766QCR0
+```
+
+so the routing lives in whatever invoked the command. In sre-bot's case that is
+two GitHub Actions workflows, and the result is a dev/prod split that does not
+exist:
+
+| workflow | branch | agent | env | channel |
+|---|---|---|---|---|
+| `deploy.yml` | main | from `plugin.json` | *unset → `dev`* | a literal in the file |
+| `deploy-dev.yml` | dev | from `plugin.json` | `dev` | a repo variable |
+
+Both resolve to the **same agent** — the name comes from `plugin.json` and
+nothing overrode it (#1166) — so the two branches overwrite each other's active
+version and contend for the one channel that agent can bind. Confirmed against
+the live cluster: one agent, four versions, no `sre-dev`.
+
+Three properties are missing, and each is a repeat of a lesson the connector
+work already taught:
+
+- **It is not reviewable.** A channel id in a workflow heredoc is not something
+  anyone diffs with intent. The same was true of the 184 lines of hand-written
+  Kubernetes that `connectors.yaml` replaced.
+- **It is not reproducible.** A rebuilt CI, or a human running the command by
+  hand, has to know the routing from somewhere other than the repository.
+- **It fails silently.** `--env` defaults to `dev`, so a prod workflow that
+  simply omits it deploys to dev and says nothing. That is what shipped.
+
+## Decision
+
+**A bundle declares its deploy targets in a file; `deploy` executes one by
+name.**
+
+```yaml
+# deploy.yaml
+targets:
+  dev:
+    agent: sre-dev
+    env: dev
+    slack_channel: C0BLL2PK3PW
+  prod:
+    agent: sre-bot
+    env: prod
+    slack_channel: C0BL766QCR0
+```
+
+```bash
+curie cluster deploy --plugin-dir . --target dev
+curie cluster deploy --plugin-dir . --target prod
+```
+
+The three properties above follow directly: the routing is a reviewable diff, it
+is reproducible from the repository alone, and a target either resolves or the
+deploy fails naming what is missing.
+
+Four things this decision fixes by construction:
+
+**`env` becomes explicit.** A target states its environment. The silent
+`--env` default cannot produce a prod workflow that deploys to dev, because the
+target says which it is.
+
+**The artifact stays identical across targets.** Only the binding differs. This
+is the load-bearing constraint: `apps/api/CLAUDE.md` requires prod to promote
+"the exact artifact that passed on dev." The obvious alternative — rewriting
+`plugin.json`'s `name` per environment in CI — produces *different bundles* for
+dev and prod and quietly breaks that guarantee.
+
+**Flags stay as overrides, not the interface.** `--agent`, `--env`, and
+`--slack-channel` continue to work and win over the target when passed. A
+one-off deploy to a scratch agent must not require editing a committed file.
+
+**Absent `deploy.yaml` changes nothing.** Bundles that pass flags today keep
+working unchanged; the file is additive, exactly as `connectors.yaml` was.
+
+## Consequences
+
+The bundle now carries workspace-specific values — Slack channel ids. That is a
+real coupling: the same bundle deployed into a different Slack workspace needs
+different targets, so the file is only portable within the workspace it names.
+Accepted deliberately, because the alternative is the status quo where those ids
+live in CI configuration nobody reviews. A bundle that wants portability keeps
+using flags.
+
+Two files now describe deployment, with different lifetimes: `connectors.yaml`
+is *what the agent needs wherever it runs*, `deploy.yaml` is *where this
+repository sends it*. Collapsing them would put a channel id next to a container
+image, which are not the same kind of fact and do not change together.
+
+Nothing here relaxes [#1070](https://github.com/curie-eng/curie/issues/1070) —
+one agent still binds one channel. Declaring two targets creates two agents;
+it does not let one agent serve two channels.
+
+A target names an agent, so a typo mints a new agent rather than failing. That
+is the same hazard `cluster deploy` already has, and it is worse here because
+the name is in a file rather than typed at the prompt. The validator should
+reject a target whose agent name is not a valid agent name, and `--dry-run`
+should print the resolved binding before anything is created.
+
+## Alternatives considered
+
+- **Flags only, plus documentation.** Rejected: it is the current state, and it
+  produced a dev/prod split that silently did not exist for weeks. Documentation
+  does not diff.
+- **Rewrite `plugin.json`'s name per environment in CI.** Rejected: it makes dev
+  and prod different artifacts, breaking promote-what-you-validated. It also
+  hides the routing in a `jq` expression, which is strictly less reviewable than
+  a flag.
+- **Put targets inside `connectors.yaml`.** Rejected: different concerns with
+  different lifetimes. A connector changes when the agent's capabilities change;
+  a target changes when the deployment topology does.
+- **Put targets in `plugin.json`.** Rejected: that file is the verbatim Claude
+  Code plugin manifest (`packages/CLAUDE.md`), and Curie-specific deployment
+  routing has no place in a format Curie does not own.
+- **A `curie target add` CLI verb.** Rejected for the reason ADR 0086 rejected
+  `curie connect`: it stores state the repository cannot see, so a rebuilt
+  cluster does not reproduce from the repo and the change is invisible in
+  review.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -117,4 +117,5 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0086 | [Bundles declare connectors; the platform hosts them](0086-bundles-declare-connectors-the-platform-hosts-them.md) | Accepted |
 | 0087 | [The API renders connector objects; the CLI applies them](0087-the-api-renders-connector-objects-the-cli-applies-them.md) | Draft |
 | 0088 | [Per user delegated OAuth for MCP](0088-per-user-delegated-oauth-for-mcp.md) | Draft |
+| 0089 | [Bundles declare their deploy targets](0089-bundles-declare-their-deploy-targets.md) | Accepted |
 <!-- END GENERATED: adr-index -->

--- a/packages/plugin-format/src/plugin_format/deploy_targets.py
+++ b/packages/plugin-format/src/plugin_format/deploy_targets.py
@@ -1,0 +1,139 @@
+"""Declared deploy targets: where a bundle gets sent (ADR-0089).
+
+``connectors.yaml`` says what a bundle needs wherever it runs. ``deploy.yaml``
+says where THIS repository sends it. Two files because they are different kinds
+of fact with different lifetimes: a connector changes when the agent's
+capabilities change, a target changes when the deployment topology does.
+
+    # deploy.yaml
+    targets:
+      dev:
+        agent: sre-dev
+        env: dev
+        slack_channel: C0BLL2PK3PW
+      prod:
+        agent: sre-bot
+        env: prod
+        slack_channel: C0BL766QCR0
+
+    curie cluster deploy --target prod
+
+Before this, routing lived in whatever invoked the command. For sre-bot that
+was two GitHub Actions workflows describing a dev/prod split that did not
+exist: both resolved to the same agent, overwrote each other's active version,
+and contended for the one channel that agent can bind. Nothing reported it,
+because ``--env`` defaults to ``dev`` and a prod workflow that omits it deploys
+to dev silently.
+
+The bundle is IDENTICAL across targets. Only the binding differs -- which is
+what lets prod promote the exact artifact dev validated, and why rewriting
+``plugin.json``'s name per environment was rejected.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+# Curie's two deployment environments. Not open-ended: the worker's binding
+# query ranks prod over dev explicitly, so a third value would silently never
+# be selected.
+_ENVS = ("dev", "prod")
+
+# A target name is a label a human types after `--target`; an agent name becomes
+# a platform identity. They are held to the same shape for the same reason
+# connector names are -- predictable, no surprises at the boundary.
+_NAME_RE = re.compile(r"[a-z0-9]([a-z0-9-]*[a-z0-9])?")
+_NAME_MAX = 40
+
+# Slack conversation ids are uppercase alphanumeric starting with C (channel),
+# G (private group) or D (DM). Checked because a mistyped id binds the agent to
+# a channel nobody is watching, and the deploy reports success.
+_SLACK_RE = re.compile(r"[CGD][A-Z0-9]{6,}")
+
+
+class DeployTarget(BaseModel):
+    """One named destination for this bundle."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    # Which agent this target binds. Defaults to the manifest name, so a
+    # single-agent bundle need not repeat itself.
+    agent: str | None = None
+    env: str = "dev"
+    slack_channel: str | None = None
+
+
+class DeployTargetsFile(BaseModel):
+    """The parsed ``deploy.yaml``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    targets: dict[str, DeployTarget] = Field(default_factory=dict)
+
+
+def _is_valid_name(name: str) -> bool:
+    return len(name) <= _NAME_MAX and bool(_NAME_RE.fullmatch(name))
+
+
+def validate_deploy_targets(data: Any) -> tuple[DeployTargetsFile | None, list[tuple[str, str]]]:
+    """Validate parsed ``deploy.yaml`` content.
+
+    Returns ``(parsed, errors)`` where each error is ``(code, message)``. Every
+    check here exists because the failure it prevents is SILENT: a bad target
+    otherwise deploys successfully to the wrong place and says so cheerfully.
+    """
+
+    errors: list[tuple[str, str]] = []
+    if data is None:
+        return DeployTargetsFile(), errors
+    if not isinstance(data, dict):
+        return None, [("deploy.not_object", "deploy.yaml must be a mapping")]
+
+    try:
+        parsed = DeployTargetsFile.model_validate(data)
+    except Exception as exc:  # pydantic ValidationError -- surface it verbatim
+        return None, [("deploy.invalid", str(exc)[:400])]
+
+    for name, target in parsed.targets.items():
+        where = f"targets.{name}"
+        if not _is_valid_name(name):
+            errors.append(
+                (
+                    "deploy.bad_target_name",
+                    f"{where}: a target name is typed after `--target`, so it must be "
+                    "lowercase alphanumeric or dashes, start and end alphanumeric, and be "
+                    f"at most {_NAME_MAX} characters",
+                )
+            )
+        if target.env not in _ENVS:
+            errors.append(
+                (
+                    "deploy.bad_env",
+                    f"{where}: env must be one of {', '.join(_ENVS)} (got {target.env!r}). "
+                    "The worker ranks prod over dev explicitly, so any other value would "
+                    "never be selected.",
+                )
+            )
+        if target.agent is not None and not _is_valid_name(target.agent):
+            errors.append(
+                (
+                    "deploy.bad_agent_name",
+                    f"{where}: `{target.agent}` is not a valid agent name. A typo here does "
+                    "not fail -- it MINTS A NEW AGENT and the deploy reports success, so the "
+                    "name is checked before anything is created (ADR-0089).",
+                )
+            )
+        if target.slack_channel is not None and not _SLACK_RE.fullmatch(target.slack_channel):
+            errors.append(
+                (
+                    "deploy.bad_slack_channel",
+                    f"{where}: `{target.slack_channel}` is not a Slack conversation id. Use "
+                    "the id (starts with C, G, or D), not the #name -- a mistyped id binds "
+                    "the agent to a channel nobody is watching and the deploy still succeeds.",
+                )
+            )
+
+    return (parsed if not errors else None), errors

--- a/packages/plugin-format/src/plugin_format/validate.py
+++ b/packages/plugin-format/src/plugin_format/validate.py
@@ -15,6 +15,7 @@ from pydantic import BaseModel, TypeAdapter, ValidationError
 
 from .approval_policy import declared_mcp_server_names, effective_tool_prefix, grantable_routes
 from .connectors import ConnectorsFile, validate_connectors
+from .deploy_targets import validate_deploy_targets
 from .manifest import resolve_manifest
 from .models import (
     _TRIGGER_TYPES,
@@ -83,11 +84,35 @@ def validate_bundle(path: str | Path) -> ValidationResult:
         _validate_secrets(manifest, c)
         _validate_scripts(root, c)
         _validate_connectors(root, c)
+        _validate_deploy_targets(root, c)
 
     return c.result()
 
 
 CONNECTORS_FILE = "connectors.yaml"
+DEPLOY_FILE = "deploy.yaml"
+
+
+def _validate_deploy_targets(root: Path, c: _Collector) -> None:
+    """Validate ``deploy.yaml`` if present (ADR-0089).
+
+    Optional: a bundle that passes routing as flags simply omits it. When
+    present it must parse, because every error it can raise is one that would
+    otherwise deploy SUCCESSFULLY to the wrong place -- a mistyped agent mints a
+    new agent, a mistyped channel binds a channel nobody watches, and neither
+    reports anything.
+    """
+
+    path = root / DEPLOY_FILE
+    if not path.is_file():
+        return
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError) as exc:
+        c.error("deploy.unreadable", f"{DEPLOY_FILE}: {exc}", DEPLOY_FILE)
+        return
+    for code, message in validate_deploy_targets(data)[1]:
+        c.error(code, message, DEPLOY_FILE)
 
 
 def _validate_connectors(root: Path, c: _Collector) -> None:

--- a/packages/plugin-format/tests/test_deploy_targets.py
+++ b/packages/plugin-format/tests/test_deploy_targets.py
@@ -1,0 +1,126 @@
+"""Declared deploy targets (ADR-0089, #1166).
+
+Every case here is one that would otherwise deploy SUCCESSFULLY to the wrong
+place. That is the whole reason the file is validated rather than trusted: a
+mistyped agent mints a new agent, a mistyped channel binds a conversation nobody
+watches, and both report success.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from plugin_format import validate_bundle
+from plugin_format.deploy_targets import validate_deploy_targets
+
+
+def _codes(data: object) -> list[str]:
+    return [c for c, _ in validate_deploy_targets(data)[1]]
+
+
+def _bundle(root: Path, deploy_yaml: str | None) -> Path:
+    (root / ".claude-plugin").mkdir(parents=True, exist_ok=True)
+    (root / ".claude-plugin" / "plugin.json").write_text(
+        json.dumps({"name": "b", "version": "0.1.0", "description": "t"}), encoding="utf-8"
+    )
+    (root / "skills" / "b").mkdir(parents=True, exist_ok=True)
+    (root / "skills" / "b" / "SKILL.md").write_text(
+        "---\nname: b\ndescription: t\n---\nhi\n", encoding="utf-8"
+    )
+    if deploy_yaml is not None:
+        (root / "deploy.yaml").write_text(deploy_yaml, encoding="utf-8")
+    return root
+
+
+REAL = (
+    "targets:\n"
+    "  dev:\n"
+    "    agent: sre-dev\n"
+    "    env: dev\n"
+    "    slack_channel: C0BLL2PK3PW\n"
+    "  prod:\n"
+    "    agent: sre-bot\n"
+    "    env: prod\n"
+    "    slack_channel: C0BL766QCR0\n"
+)
+
+
+def test_the_shape_the_adr_specifies_is_accepted() -> None:
+    parsed, errors = validate_deploy_targets(
+        {
+            "targets": {
+                "dev": {"agent": "sre-dev", "env": "dev", "slack_channel": "C0BLL2PK3PW"},
+                "prod": {"agent": "sre-bot", "env": "prod", "slack_channel": "C0BL766QCR0"},
+            }
+        }
+    )
+    assert errors == []
+    assert parsed is not None
+    assert parsed.targets["prod"].env == "prod"
+    assert parsed.targets["dev"].agent == "sre-dev"
+
+
+def test_absent_file_is_fine(tmp_path: Path) -> None:
+    # Bundles that pass routing as flags keep working; the file is additive.
+    assert validate_bundle(str(_bundle(tmp_path, None))).valid
+
+
+def test_an_unknown_env_is_rejected() -> None:
+    # The worker ranks prod over dev explicitly, so a third value would never be
+    # selected -- the deploy would succeed and the agent would never serve.
+    assert "deploy.bad_env" in _codes({"targets": {"stg": {"env": "staging"}}})
+
+
+def test_a_channel_name_instead_of_an_id_is_rejected() -> None:
+    # `#sre` is what a human says; the platform needs `C...`. Binding a bad id
+    # succeeds and the bot answers into nothing.
+    assert "deploy.bad_slack_channel" in _codes({"targets": {"p": {"slack_channel": "#sre"}}})
+
+
+def test_a_malformed_agent_name_is_rejected() -> None:
+    # The failure this prevents: a typo does not error, it MINTS A NEW AGENT and
+    # the deploy reports success against it.
+    assert "deploy.bad_agent_name" in _codes({"targets": {"p": {"agent": "Sre_Bot"}}})
+
+
+def test_env_defaults_to_dev_so_a_target_must_opt_in_to_prod() -> None:
+    parsed, errors = validate_deploy_targets({"targets": {"p": {"agent": "a"}}})
+    assert errors == []
+    assert parsed is not None
+    assert parsed.targets["p"].env == "dev"
+
+
+def test_agent_may_be_omitted_to_mean_the_manifest_name() -> None:
+    parsed, _ = validate_deploy_targets({"targets": {"p": {"env": "prod"}}})
+    assert parsed is not None
+    assert parsed.targets["p"].agent is None
+
+
+def test_unknown_key_is_rejected_not_ignored() -> None:
+    # Same reasoning as connectors.yaml: this is Curie's own file with no
+    # external producer, so an unrecognised key is a typo. `chanel` silently
+    # ignored means an agent bound to the wrong conversation.
+    assert _codes({"targets": {"p": {"chanel": "C0123456"}}}) != []
+
+
+def test_non_mapping_file_is_rejected() -> None:
+    assert "deploy.not_object" in _codes(["not", "a", "mapping"])
+
+
+def test_bundle_surfaces_a_target_error(tmp_path: Path) -> None:
+    root = _bundle(tmp_path, "targets:\n  p:\n    env: staging\n")
+    result = validate_bundle(str(root))
+    assert not result.valid
+    assert any(e.code == "deploy.bad_env" for e in result.errors)
+
+
+def test_bundle_surfaces_unparseable_yaml(tmp_path: Path) -> None:
+    root = _bundle(tmp_path, "targets:\n  p:\n   env: [unclosed\n")
+    result = validate_bundle(str(root))
+    assert not result.valid
+    assert any(e.code == "deploy.unreadable" for e in result.errors)
+
+
+def test_the_real_sre_bot_routing_validates(tmp_path: Path) -> None:
+    assert validate_bundle(str(_bundle(tmp_path, REAL))).valid


### PR DESCRIPTION
Implements [ADR-0089](docs/adr/0089-bundles-declare-their-deploy-targets.md) (Accepted). Refs #1166. Base `main`.

A bundle declares where it gets sent; `deploy --target <name>` executes one.

```yaml
# deploy.yaml
targets:
  dev:
    agent: acme-dev
    env: dev
    slack_channel: C0EXAMPLE2
  prod:
    agent: acme-bot
    env: prod
    slack_channel: C0EXAMPLE1
```

## Every check exists because the failure is silent

That's the through-line, and it's why this file is *validated* rather than trusted:

| mistake | what happens without the check |
|---|---|
| bad agent name | doesn't error — **mints a new agent**, deploy reports success |
| `#sre` instead of `C0EXAMPLE1` | binds a conversation nobody watches, deploy succeeds |
| `env: staging` | worker ranks prod over dev explicitly, so it's **never selected** — agent deploys and never serves |
| `chanel:` typo | silently ignored → agent bound somewhere else entirely |

None of these fail loudly on their own. All of them look like a working deploy.

## Two deliberate defaults

**`agent` is optional** and means the manifest name, so a single-agent bundle doesn't repeat itself.

**`env` defaults to `dev`.** Reaching prod is an explicit act — the *opposite* of the CLI flag default, which made dev the silent fallback for a prod workflow and caused #1166 in the first place.

## `extra="forbid"`

Same reasoning as `connectors.yaml`, and against this package's otherwise-lenient convention: `deploy.yaml` is Curie's own file with no external producer, so an unrecognised key is a typo — not a format Curie doesn't model.

## Verification

```
plugin-format      → 241 passed (12 new)
mypy               → no issues, 167 files
ruff check         → All checks passed
check-contracts.sh → all committed artifacts current
```

Includes `test_the_real_sre_bot_routing_validates` — acme-bot's actual dev/prod routing, validated as a fixture, so the file this was designed for is proven to parse.

## Next

`--target` in the CLI (resolves a target, flags still override), then acme-bot adopts it.
