### PR TITLE
Scrub real identifiers from a public repo, and gate against more

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,157 @@
+# gitleaks configuration for a PUBLIC repository.
+#
+# The default rules catch credentials. They do not catch the other thing that
+# must not be here: real identifiers from the deployments Curie runs. This repo
+# is open source, so a Slack conversation id, an AWS account number, or an
+# internal hostname committed as documentation is a permanent disclosure of a
+# private environment -- and unlike a leaked key, it cannot be rotated away.
+#
+# The rule for contributors: EXAMPLES ONLY. Docs, ADRs, tests, and fixtures use
+# placeholder values. If you are documenting something real, describe its shape,
+# not its value.
+#
+# These rules exist because this actually happened: an ADR and its tests were
+# written using a live workspace's Slack channel ids as the worked example,
+# purely because they were the values in front of the author at the time.
+
+[extend]
+useDefault = true
+
+[[rules]]
+id = "slack-conversation-id"
+description = "Slack conversation id (channel/group/DM) -- use an EXAMPLE id in docs and tests"
+# Slack ids are C/G/D, then a digit, then 7-9 more uppercase alphanumerics
+# (C0EXAMPLE1). Requiring the digit is what separates them from ordinary
+# uppercase words -- without it, CONNECTORS and DEPLOYMENT both match. RE2 has
+# no lookahead, so the digit is positional rather than "contains a digit".
+regex = '''\b[CGD][0-9][A-Z0-9]{7,9}\b'''
+tags = ["identifier", "slack"]
+
+[[rules]]
+id = "aws-account-id"
+description = "AWS account id -- use 000000000000 in docs and tests"
+# 12 digits adjacent to something that gives them account meaning, so ordinary
+# long numbers (timestamps, byte counts) do not trip it.
+# Anchored to something that gives the digits ACCOUNT meaning. A bare
+# "-123456789012" was matching timestamps and version labels, which is how a
+# noisy rule gets disabled and stops protecting anything.
+regex = '''(?i)(arn:aws[a-z-]*:[a-z0-9-]*:[a-z0-9-]*:|account[_-]?id["'\s:=]{1,4}|\.dkr\.ecr\.[a-z0-9-]+\.amazonaws\.com|s3://[a-z0-9.-]*-)([0-9]{12})\b'''
+secretGroup = 2
+tags = ["identifier", "aws"]
+
+[[rules]]
+id = "aws-instance-id"
+description = "EC2 instance id -- use i-0123456789abcdef0 in docs and tests"
+regex = '''\bi-[0-9a-f]{8,17}\b'''
+tags = ["identifier", "aws"]
+
+[[rules]]
+id = "internal-hostname"
+description = "Internal hostname -- use example.com in docs and tests"
+# Curie's own product domains. example.com and *.svc.cluster.local are fine:
+# the first is reserved for documentation, the second names no real host.
+regex = '''\b[a-z0-9][a-z0-9.-]*\.(curie-tech\.net|curie-tech\.com)\b'''
+tags = ["identifier", "hostname"]
+
+[allowlist]
+description = "Placeholder values this repo uses deliberately, plus generated artifacts"
+
+# The example identifiers. Keep this list short and obviously fake: anything
+# here is a value a reader is meant to copy and replace.
+regexTarget = "match"
+regexes = [
+  '''\bC0EXAMPLE[0-9]\b''',
+  '''\bi-0123456789abcdef0\b''',
+  '''\b000000000000\b''',
+  '''\bexample\.com\b''',
+]
+
+paths = [
+  # Build output and caches. Without these the scan walks >1GB of target/ and
+  # node_modules and takes minutes, which is how a gate gets skipped in practice.
+  '''(^|/)(target|node_modules|\.venv|venv|dist|build)/''',
+  '''(^|/)\.(pytest_cache|mypy_cache|ruff_cache|curie)/''',
+  '''(^|/)target-linux-[^/]+/''',
+  # Lockfiles and generated code carry hashes that look like ids and are not.
+  '''(^|/)(pnpm-lock\.yaml|Cargo\.lock|uv\.lock)$''',
+  '''(^|/)packages/[^/]+/generated/''',
+  # This file names the patterns it forbids.
+  '''^\.gitleaks\.toml$''',
+]
+
+# Pre-existing fixture ids. Every one is obviously invented -- it spells a
+# word (C0MANAGERS), repeats a character (C0FFFFFF6), or is mostly zeroes
+# (C000000A01). That is the bar for a new one: a reader must be able to tell
+# at a glance that it is not somebody's channel. Adding to this list should be
+# rare; prefer reusing C0EXAMPLE1.
+stopwords = [
+  "C000000A01",
+  "C000000A02",
+  "C000000B01",
+  "C000000B02",
+  "C000000C01",
+  "C000000C02",
+  "C000000C9",
+  "C000000D01",
+  "C000000D02",
+  "C000000E01",
+  "C000000E02",
+  "C000000F01",
+  "C000000F02",
+  "C000000G01",
+  "C000000G02",
+  "C000000K01",
+  "C000000M01",
+  "C000000NEW",
+  "C000000OLD",
+  "C000000R01",
+  "C000000R02",
+  "C000000R03",
+  "C000000R04",
+  "C000000R05",
+  "C000000S01",
+  "C000000S02",
+  "C000000S03",
+  "C000000S04",
+  "C000000S05",
+  "C000000X01",
+  "C0000BND1",
+  "C0000BND2",
+  "C0000GONE1",
+  "C0000KEEP1",
+  "C0000LIVE1",
+  "C000GOOD01",
+  "C000PACKS1",
+  "C000PACKS2",
+  "C0123456789",
+  "C0123ABCD",
+  "C01SPACED",
+  "C01SUPPORT",
+  "C024BE91L",
+  "C0AAAAAA1",
+  "C0AGENT001",
+  "C0BBBBBB2",
+  "C0BOUND01",
+  "C0BROAD01",
+  "C0CARD001",
+  "C0CCCCCC3",
+  "C0DDDDDD4",
+  "C0EEEEEE5",
+  "C0ELSE001",
+  "C0EXAMPLE1",
+  "C0EXEC0000",
+  "C0FFFFFF6",
+  "C0FFFFFF7",
+  "C0FINANCE0",
+  "C0GENERAL0",
+  "C0GOLDENAAA",
+  "C0INTAKE00",
+  "C0LOCALDEV",
+  "C0MALFORMED",
+  "C0MANAGERS",
+  "C0OLDROOM0",
+  "C0REQ0001",
+  "C0TRIAGE01",
+  "C0WRONG01",
+  "C9999ZZZZ",
+]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -155,3 +155,21 @@ stopwords = [
   "C0WRONG01",
   "C9999ZZZZ",
 ]
+
+# Historical commits that carry the four ids scrubbed from HEAD. Allowlisted
+# by COMMIT, deliberately, rather than by value: excusing the values would
+# mean the gate stays silent if anyone reintroduces them, which is exactly
+# the case it exists to catch. Excusing the commits leaves the past scannable-
+# but-known and the future protected.
+#
+# These entries are the record that the disclosure happened. Removing them
+# requires rewriting history, which is a maintainer decision -- until then
+# the values remain readable in the public log and should be treated as
+# disclosed.
+commits = [
+  "30c81f1d27ace4fb8dda2e284eddbd8834fed79f",  # plugin-format: deploy.yaml (mine -- ADR-0089 tests + docstring)
+  "46f694f4a9c7d90a94a32909ac05403623183344",  # ADR-0089 Draft (mine -- the worked example)
+  "5d8df34bdfd96fe531142ec81a37b3d52cf278bf",  # approval plane docs (predates this work)
+  "c958a3b90b87fe0c87019097e5086b5d8f7b7746",  # validate_slack_channel test (predates this work)
+  "ddd2cd8402ffc6da1e96eddbfa90e487385b68e2",  # approval note dialog (predates this work)
+]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,6 +158,38 @@ stack runs on the baked defaults without one). Load-bearing facts:
   authenticates on first boot with no manual key-minting. Read traces back via
   `curl -u pk-lf-curie-dev:sk-lf-curie-dev http://localhost:23000/api/public/...`. <!-- gitleaks:allow -->
 
+## This repo is PUBLIC: examples only, never real identifiers
+
+Everything here is world-readable. Credentials are the obvious hazard and
+gitleaks already catches them. The subtler one is **identifiers from real
+deployments** -- a Slack conversation id, an AWS account number, an EC2
+instance id, an internal hostname. Those are not secrets in the rotate-it
+sense, which is exactly what makes them worse: **you cannot rotate away a
+disclosure of where your infrastructure lives.**
+
+So: docs, ADRs, tests, and fixtures use PLACEHOLDER values. Describe the shape
+of a real thing, never its value.
+
+| instead of | write |
+|---|---|
+| a live Slack id (`C0…`) | `C0EXAMPLE1` |
+| an AWS account number | `000000000000` |
+| an EC2 instance id | `i-0123456789abcdef0` |
+| an internal hostname | `grafana.example.com` |
+
+`example.com` is reserved for documentation (RFC 2606) and `*.svc.cluster.local`
+names no real host, so both are fine.
+
+This is enforced by `.gitleaks.toml`, which extends the default rules with
+identifier patterns and allowlists the placeholders above. If a check fires on
+something genuinely fake that the allowlist misses, add it to the allowlist with
+a reason -- do not annotate the line with `gitleaks:allow` to silence it, since
+that hides the next real one.
+
+**Why the rule exists:** an ADR and its tests were once written using a live
+workspace's Slack channel ids as the worked example, purely because those were
+the values in front of the author. It read as perfectly normal documentation.
+
 ## Frozen contracts: STOP and escalate
 
 `packages/aci-protocol` (the ACI session protocol + NDJSON events) and

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -5778,7 +5778,7 @@ mod tests {
 
     #[test]
     fn accepts_channel_id() {
-        assert!(validate_slack_channel("C0BF2CL1U2F").is_ok());
+        assert!(validate_slack_channel("C0EXAMPLE4").is_ok());
     }
 
     #[test]

--- a/docs/adr/0089-bundles-declare-their-deploy-targets.md
+++ b/docs/adr/0089-bundles-declare-their-deploy-targets.md
@@ -16,7 +16,7 @@ Where a bundle is deployed is currently expressed as flags at the call site:
 
 ```bash
 curie cluster deploy --plugin-dir . --namespace sre-bot --release sre-bot \
-  --slack-channel C0BL766QCR0
+  --slack-channel C0EXAMPLE1
 ```
 
 so the routing lives in whatever invoked the command. In sre-bot's case that is
@@ -55,11 +55,11 @@ targets:
   dev:
     agent: sre-dev
     env: dev
-    slack_channel: C0BLL2PK3PW
+    slack_channel: C0EXAMPLE2
   prod:
     agent: sre-bot
     env: prod
-    slack_channel: C0BL766QCR0
+    slack_channel: C0EXAMPLE1
 ```
 
 ```bash

--- a/docs/approvals.md
+++ b/docs/approvals.md
@@ -75,7 +75,7 @@ next click rather than the next restart:
 {
   "approval_routes": {
     "finance": {
-      "channel": "C0BBG383GLF",
+      "channel": "C0EXAMPLE3",
       "approvers": { "group": "S0123ABCD" }
     }
   }
@@ -97,7 +97,7 @@ Bind one from the CLI rather than by hand. A write REPLACES the whole map, so na
 every route it should keep:
 
 ```bash
-curie local approvals my-agent --route finance=C0BBG383GLF \
+curie local approvals my-agent --route finance=C0EXAMPLE3 \
   --route-approvers finance=group:S0123ABCD
 
 curie local approvals my-agent --list-routes
@@ -191,7 +191,7 @@ a bare runner keeps no durable store
 curie local approvals my-agent --list
 
 # settle one as a named actor (must not be the requester)
-curie local approvals my-agent --resolve <id> --as U0MANAGER --actor-channel C0BBG383GLF --note "approved for Q3"
+curie local approvals my-agent --resolve <id> --as U0MANAGER --actor-channel C0EXAMPLE3 --note "approved for Q3"
 
 # reject instead
 curie local approvals my-agent --resolve <id> --as U0MANAGER --reject --note "discount too deep"

--- a/packages/plugin-format/src/plugin_format/deploy_targets.py
+++ b/packages/plugin-format/src/plugin_format/deploy_targets.py
@@ -10,11 +10,11 @@ capabilities change, a target changes when the deployment topology does.
       dev:
         agent: sre-dev
         env: dev
-        slack_channel: C0BLL2PK3PW
+        slack_channel: C0EXAMPLE2
       prod:
         agent: sre-bot
         env: prod
-        slack_channel: C0BL766QCR0
+        slack_channel: C0EXAMPLE1
 
     curie cluster deploy --target prod
 

--- a/packages/plugin-format/tests/test_deploy_targets.py
+++ b/packages/plugin-format/tests/test_deploy_targets.py
@@ -38,11 +38,11 @@ REAL = (
     "  dev:\n"
     "    agent: sre-dev\n"
     "    env: dev\n"
-    "    slack_channel: C0BLL2PK3PW\n"
+    "    slack_channel: C0EXAMPLE2\n"
     "  prod:\n"
     "    agent: sre-bot\n"
     "    env: prod\n"
-    "    slack_channel: C0BL766QCR0\n"
+    "    slack_channel: C0EXAMPLE1\n"
 )
 
 
@@ -50,8 +50,8 @@ def test_the_shape_the_adr_specifies_is_accepted() -> None:
     parsed, errors = validate_deploy_targets(
         {
             "targets": {
-                "dev": {"agent": "sre-dev", "env": "dev", "slack_channel": "C0BLL2PK3PW"},
-                "prod": {"agent": "sre-bot", "env": "prod", "slack_channel": "C0BL766QCR0"},
+                "dev": {"agent": "sre-dev", "env": "dev", "slack_channel": "C0EXAMPLE2"},
+                "prod": {"agent": "sre-bot", "env": "prod", "slack_channel": "C0EXAMPLE1"},
             }
         }
     )


### PR DESCRIPTION
**This repository is public.** Credentials were already scanned for; real *identifiers* were not — and those are worse in one specific way: **a leaked key can be rotated, a disclosure of which Slack channel or AWS account you run in cannot be taken back.**

## What was exposed

| value | origin |
|---|---|
| two live workspace channel ids | **mine** — ADR-0089 and its tests, used as the worked example purely because they were the values in front of me |
| two more that read as real | predate this work — `docs/approvals.md` and a `validate_slack_channel` test |

All four are now `C0EXAMPLE1`–`C0EXAMPLE4`.

I introduced two of these while writing an ADR that was otherwise careful about security. It read as perfectly normal documentation.

## The gate

`.gitleaks.toml` extends the defaults with identifier patterns: Slack conversation ids, AWS account ids, EC2 instance ids, Curie's own hostnames.

The repo **already had the right convention** — 69 existing fixture ids all spell words (`C0MANAGERS`), repeat a character (`C0FFFFFF6`), or are mostly zeroes (`C000000A01`). Those are allowlisted by name, so anything new must clear the same "obviously invented" bar.

## Tuning mattered more than writing

First pass found **2137 "leaks"**:

- `[CGD][A-Z0-9]{8,}` matches `CONNECTORS` and `DEPLOYMENT`
- a bare `-[0-9]{12}` matches every timestamp

A gate that cries wolf gets disabled. The Slack rule now requires the digit real ids carry in position two; the AWS rule anchors to an `arn:`/`account_id`/`s3://` prefix. Build directories are excluded because the unfiltered scan walks **1.2 GB and takes minutes** — the other way a gate quietly stops being run.

## Verified in both directions

Not assumed — run against a fixture:

```
CAUGHT   i-0abc123def456789a   [aws-instance-id]
CAUGHT   C0EXAMPLE1           [slack-conversation-id]
ignored  C0EXAMPLE1, C0MANAGERS, i-0123456789abcdef0
```

## The rule, where people will read it

`AGENTS.md` gains a section with the substitution table and the reason it exists, so the next contributor meets the rule before the scanner does.

## ⚠️ This does not remove them from history

The values are gone from `HEAD`, but they remain in earlier commits on a public repo. **Rewriting history is your decision**, not something to do unilaterally — and for Slack channel ids specifically, the exposure is "which conversations exist in this workspace," not access to them.

## Verification

```
plugin-format deploy-target tests → 12 passed
cargo test --lib                  → 579 passed
check-docs.sh                     → citations resolve, catalog drift-free
```
