### PR TITLE
deploy --target: execute a declared routing target (ADR-0089)

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -2019,6 +2019,59 @@
         "title": "PodLogs",
         "type": "object"
       },
+      "ResolveTargetRequest": {
+        "description": "A bundle's ``deploy.yaml`` text plus the target to resolve (ADR-0089).\n\nThe CLI sends the file CONTENT rather than parsing it, so there is exactly\none parser for this format. Two would be a drift hazard on a file whose\nwhole job is to be unambiguous about where a deploy lands -- and the Rust\nYAML ecosystem has no maintained successor to serde_yaml to pick from.",
+        "properties": {
+          "content": {
+            "title": "Content",
+            "type": "string"
+          },
+          "target": {
+            "title": "Target",
+            "type": "string"
+          }
+        },
+        "required": [
+          "content",
+          "target"
+        ],
+        "title": "ResolveTargetRequest",
+        "type": "object"
+      },
+      "ResolvedTarget": {
+        "description": "What a named target resolves to. Pure function of the file.",
+        "properties": {
+          "agent": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agent"
+          },
+          "env": {
+            "default": "dev",
+            "title": "Env",
+            "type": "string"
+          },
+          "slack_channel": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Slack Channel"
+          }
+        },
+        "title": "ResolvedTarget",
+        "type": "object"
+      },
       "RunnerPods": {
         "description": "The runner sandbox pods in a namespace (populates the Logs pod dropdown).",
         "properties": {
@@ -5037,6 +5090,66 @@
         "summary": "Get Config",
         "tags": [
           "config"
+        ]
+      }
+    },
+    "/deploy-targets/resolve": {
+      "post": {
+        "description": "Resolve a named target from a bundle's ``deploy.yaml`` (ADR-0089).\n\nPure function of the supplied text: no database, no store, no cluster. It\nlives here rather than in the CLI so there is exactly ONE parser for this\nformat. A second implementation in Rust could disagree with this one about\nthe same file, and the file's entire purpose is to be unambiguous about\nwhere a deploy lands -- a disagreement would route a deploy somewhere the\nauthor did not intend and report success.\n\nValidation errors are returned rather than swallowed, because every one of\nthem describes a deploy that would otherwise succeed against the wrong\nagent, environment, or channel.",
+        "operationId": "resolve_deploy_target_deploy_targets_resolve_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ResolveTargetRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResolvedTarget"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Resolve Deploy Target",
+        "tags": [
+          "deploy-targets"
         ]
       }
     },

--- a/apps/api/src/curie_api/main.py
+++ b/apps/api/src/curie_api/main.py
@@ -28,6 +28,7 @@ from .routers import (
     bundles,
     config,
     control,
+    deploy_targets,
     deployments,
     evals,
     github,
@@ -73,8 +74,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     app.state.resume_queue = ResumeQueue(
         valkey,
         stream=settings.runs_stream,
-        dead_letter_stream=settings.resume_dead_letter_stream
-        or settings.dead_letter_stream_name(),
+        dead_letter_stream=settings.resume_dead_letter_stream or settings.dead_letter_stream_name(),
     )
     # The composition root for approvals (#420, ADR-0034): the only place that
     # names Slack to build the approver-set selector, so the authorizer and the
@@ -193,6 +193,7 @@ def create_app() -> FastAPI:
     app.include_router(agents.router)
     app.include_router(deployments.router)
     app.include_router(bundles.router)
+    app.include_router(deploy_targets.router)
     app.include_router(github.router)
     app.include_router(observability.router)
     app.include_router(control.router)

--- a/apps/api/src/curie_api/routers/deploy_targets.py
+++ b/apps/api/src/curie_api/routers/deploy_targets.py
@@ -1,0 +1,57 @@
+"""Resolve a named deploy target from a bundle's ``deploy.yaml`` (ADR-0089).
+
+Its own router because it belongs to no agent and no version: it is a pure
+function of the text posted to it, with no database, no bundle store, and no
+cluster. Hanging it off the bundle router would have given it the prefix
+``/agents/{agent_id}/versions/{version_id}/bundle/...``, which is exactly
+backwards -- the caller uses this BEFORE an agent exists, to find out which
+agent to create.
+"""
+
+import yaml
+from fastapi import APIRouter, Depends, HTTPException, status
+from plugin_format.deploy_targets import validate_deploy_targets
+
+from ..auth import require_api_key
+from ..schemas import ResolvedTarget, ResolveTargetRequest
+
+router = APIRouter(tags=["deploy-targets"], dependencies=[Depends(require_api_key)])
+
+
+@router.post("/deploy-targets/resolve", response_model=ResolvedTarget)
+async def resolve_deploy_target(body: ResolveTargetRequest) -> ResolvedTarget:
+    """Resolve a named target from a bundle's ``deploy.yaml`` (ADR-0089).
+
+    Pure function of the supplied text: no database, no store, no cluster. It
+    lives here rather than in the CLI so there is exactly ONE parser for this
+    format. A second implementation in Rust could disagree with this one about
+    the same file, and the file's entire purpose is to be unambiguous about
+    where a deploy lands -- a disagreement would route a deploy somewhere the
+    author did not intend and report success.
+
+    Validation errors are returned rather than swallowed, because every one of
+    them describes a deploy that would otherwise succeed against the wrong
+    agent, environment, or channel.
+    """
+
+    try:
+        data = yaml.safe_load(body.content)
+    except yaml.YAMLError as exc:
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST, f"deploy.yaml is unparseable: {exc}"
+        ) from exc
+
+    parsed, errors = validate_deploy_targets(data)
+    if errors:
+        detail = "; ".join(f"{code}: {message}" for code, message in errors)
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, detail)
+    assert parsed is not None
+
+    target = parsed.targets.get(body.target)
+    if target is None:
+        known = ", ".join(sorted(parsed.targets)) or "(none declared)"
+        raise HTTPException(
+            status.HTTP_404_NOT_FOUND,
+            f"no target named {body.target!r} in deploy.yaml. Declared: {known}",
+        )
+    return ResolvedTarget(agent=target.agent, env=target.env, slack_channel=target.slack_channel)

--- a/apps/api/src/curie_api/schemas.py
+++ b/apps/api/src/curie_api/schemas.py
@@ -152,9 +152,7 @@ def enforce_behavior_packs_size(config: BehaviorPacksConfig) -> None:
     byte length of the whole config, the unit ``behavior_packs_max_bytes`` is
     measured in (mirrors the durable-state ``_enforce_caps`` in state.py)."""
     limit = get_settings().behavior_packs_max_bytes
-    size = len(
-        json.dumps(config.model_dump(), separators=(",", ":")).encode("utf-8")
-    )
+    size = len(json.dumps(config.model_dump(), separators=(",", ":")).encode("utf-8"))
     if size > limit:
         raise HTTPException(
             413,
@@ -230,9 +228,7 @@ class _StoredWithoutNulls(BaseModel):
     """
 
     @model_serializer(mode="wrap")
-    def _dump_without_nulls(
-        self, handler: SerializerFunctionWrapHandler
-    ) -> dict[str, Any]:
+    def _dump_without_nulls(self, handler: SerializerFunctionWrapHandler) -> dict[str, Any]:
         return {k: v for k, v in handler(self).items() if v is not None}
 
 
@@ -282,9 +278,7 @@ class ApprovalApprovers(_StoredWithoutNulls):
             # Neither "unset" (omit the key) nor "nobody may approve": as silent
             # config the latter is a footgun, since the approval could then only
             # ever expire.
-            raise ValueError(
-                "approvers users, when present, must contain at least one user ID"
-            )
+            raise ValueError("approvers users, when present, must contain at least one user ID")
         for user in value:
             if not _SLACK_USER_ID.match(user):
                 raise ValueError(
@@ -355,15 +349,9 @@ class AgentCreate(BaseModel):
     # sandbox by the worker binding. None means no connector secrets.
     secrets: dict[str, str] | None = None
 
-    _check_slack_channel = field_validator("slack_channel")(
-        _validate_slack_channel_id
-    )
-    _check_approval_tools = field_validator("approval_required_tools")(
-        _validate_tool_names
-    )
-    _check_approval_routes = field_validator("approval_routes")(
-        _validate_route_names
-    )
+    _check_slack_channel = field_validator("slack_channel")(_validate_slack_channel_id)
+    _check_approval_tools = field_validator("approval_required_tools")(_validate_tool_names)
+    _check_approval_routes = field_validator("approval_routes")(_validate_route_names)
     _check_secrets = field_validator("secrets")(_validate_secret_map)
 
 
@@ -386,15 +374,9 @@ class AgentUpdate(BaseModel):
     # unchanged; an explicit empty dict clears them.
     secrets: dict[str, str] | None = None
 
-    _check_slack_channel = field_validator("slack_channel")(
-        _validate_slack_channel_id
-    )
-    _check_approval_tools = field_validator("approval_required_tools")(
-        _validate_tool_names
-    )
-    _check_approval_routes = field_validator("approval_routes")(
-        _validate_route_names
-    )
+    _check_slack_channel = field_validator("slack_channel")(_validate_slack_channel_id)
+    _check_approval_tools = field_validator("approval_required_tools")(_validate_tool_names)
+    _check_approval_routes = field_validator("approval_routes")(_validate_route_names)
     _check_secrets = field_validator("secrets")(_validate_secret_map)
 
 
@@ -493,6 +475,27 @@ class BundleFiles(BaseModel):
     """The readable text surfaces of a version's stored bundle."""
 
     files: list[BundleFile]
+
+
+class ResolveTargetRequest(BaseModel):
+    """A bundle's ``deploy.yaml`` text plus the target to resolve (ADR-0089).
+
+    The CLI sends the file CONTENT rather than parsing it, so there is exactly
+    one parser for this format. Two would be a drift hazard on a file whose
+    whole job is to be unambiguous about where a deploy lands -- and the Rust
+    YAML ecosystem has no maintained successor to serde_yaml to pick from.
+    """
+
+    content: str
+    target: str
+
+
+class ResolvedTarget(BaseModel):
+    """What a named target resolves to. Pure function of the file."""
+
+    agent: str | None = None
+    env: str = "dev"
+    slack_channel: str | None = None
 
 
 class ConnectorManifests(BaseModel):

--- a/apps/api/tests/test_resolve_deploy_target.py
+++ b/apps/api/tests/test_resolve_deploy_target.py
@@ -1,0 +1,94 @@
+"""Resolving a named deploy target (ADR-0089, #1166).
+
+The endpoint exists so there is exactly ONE parser for deploy.yaml. A second
+implementation in the CLI could disagree with this one about the same file, and
+the file's whole job is to be unambiguous about where a deploy lands -- a
+disagreement routes the deploy somewhere the author did not intend and reports
+success.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture(scope="module")
+def client() -> TestClient:
+    """A client with NO database fixture, deliberately.
+
+    This endpoint is a pure function of the text posted to it. Building the
+    client without the db fixture is the assertion: if resolution ever grew a
+    database dependency, this module would stop importing.
+    """
+
+    from curie_api.main import create_app
+
+    return TestClient(create_app())
+
+
+@pytest.fixture(scope="module")
+def auth_headers() -> dict[str, str]:
+    from curie_api.config import get_settings
+
+    return {"X-API-Key": get_settings().api_key}
+
+
+REAL = (
+    "targets:\n"
+    "  dev:\n"
+    "    agent: acme-dev\n"
+    "    env: dev\n"
+    "    slack_channel: C0EXAMPLE2\n"
+    "  prod:\n"
+    "    agent: acme-bot\n"
+    "    env: prod\n"
+    "    slack_channel: C0EXAMPLE1\n"
+)
+
+
+def _resolve(client: TestClient, headers: dict, content: str, target: str):
+    return client.post(
+        "/deploy-targets/resolve", json={"content": content, "target": target}, headers=headers
+    )
+
+
+def test_resolves_the_named_target(client: TestClient, auth_headers: dict) -> None:
+    r = _resolve(client, auth_headers, REAL, "prod")
+    assert r.status_code == 200, r.text
+    assert r.json() == {"agent": "acme-bot", "env": "prod", "slack_channel": "C0EXAMPLE1"}
+
+
+def test_each_target_resolves_differently(client: TestClient, auth_headers: dict) -> None:
+    dev = _resolve(client, auth_headers, REAL, "dev").json()
+    prod = _resolve(client, auth_headers, REAL, "prod").json()
+    assert dev["agent"] != prod["agent"]
+    assert dev["env"] == "dev" and prod["env"] == "prod"
+
+
+def test_an_unknown_target_404s_and_lists_what_exists(
+    client: TestClient, auth_headers: dict
+) -> None:
+    # Naming a target that is not declared must not fall back to a default --
+    # that would deploy somewhere the caller did not ask for.
+    r = _resolve(client, auth_headers, REAL, "staging")
+    assert r.status_code == 404
+    assert "dev, prod" in r.json()["detail"]
+
+
+def test_a_validation_error_is_returned_not_swallowed(
+    client: TestClient, auth_headers: dict
+) -> None:
+    # Each of these describes a deploy that would otherwise SUCCEED against the
+    # wrong agent, environment, or channel.
+    r = _resolve(client, auth_headers, "targets:\n  p:\n    env: staging\n", "p")
+    assert r.status_code == 400
+    assert "deploy.bad_env" in r.json()["detail"]
+
+
+def test_unparseable_yaml_is_a_400_naming_the_problem(
+    client: TestClient, auth_headers: dict
+) -> None:
+    r = _resolve(client, auth_headers, "targets:\n  p:\n   env: [unclosed\n", "p")
+    assert r.status_code == 400
+    assert "unparseable" in r.json()["detail"]

--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -1138,6 +1138,14 @@ export const commandManifest = {
           "args": [
             {
               "global": false,
+              "help": "Resolve the agent, environment, and channel from a target declared in the bundle's `deploy.yaml` (ADR-0089)",
+              "id": "target",
+              "long": "target",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
               "help": "Deploy under this agent name instead of the manifest's `name`",
               "id": "agent",
               "long": "agent",
@@ -1196,11 +1204,8 @@ export const commandManifest = {
               "required": false
             },
             {
-              "default_values": [
-                "dev"
-              ],
               "global": false,
-              "help": "Target environment",
+              "help": "Target environment. Defaults to dev; a `--target` supplies it instead, and an explicit value here still wins over the target",
               "id": "env",
               "long": "env",
               "positional": false,
@@ -2456,6 +2461,14 @@ export const commandManifest = {
           "args": [
             {
               "global": false,
+              "help": "Resolve the agent, environment, and channel from a target declared in the bundle's `deploy.yaml` (ADR-0089)",
+              "id": "target",
+              "long": "target",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
               "help": "Deploy under this agent name instead of the manifest's `name`",
               "id": "agent",
               "long": "agent",
@@ -2530,11 +2543,8 @@ export const commandManifest = {
               "required": false
             },
             {
-              "default_values": [
-                "dev"
-              ],
               "global": false,
-              "help": "Target environment",
+              "help": "Target environment. Defaults to dev; a `--target` supplies it instead, and an explicit value here still wins over the target",
               "id": "env",
               "long": "env",
               "positional": false,
@@ -3323,11 +3333,8 @@ export const commandManifest = {
           "required": false
         },
         {
-          "default_values": [
-            "dev"
-          ],
           "global": false,
-          "help": "Target environment",
+          "help": "Target environment. Defaults to dev; a `--target` supplies it instead, and an explicit value here still wins over the target",
           "id": "env",
           "long": "env",
           "positional": false,

--- a/cli/api-mirrors.json
+++ b/cli/api-mirrors.json
@@ -125,6 +125,11 @@
       ]
     },
     {
+      "struct": "ResolvedTarget",
+      "schema": "ResolvedTarget",
+      "omissions": []
+    },
+    {
       "struct": "ConnectorManifests",
       "schema": "ConnectorManifests",
       "omissions": []

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -1135,6 +1135,14 @@
           "args": [
             {
               "global": false,
+              "help": "Resolve the agent, environment, and channel from a target declared in the bundle's `deploy.yaml` (ADR-0089)",
+              "id": "target",
+              "long": "target",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
               "help": "Deploy under this agent name instead of the manifest's `name`",
               "id": "agent",
               "long": "agent",
@@ -1193,11 +1201,8 @@
               "required": false
             },
             {
-              "default_values": [
-                "dev"
-              ],
               "global": false,
-              "help": "Target environment",
+              "help": "Target environment. Defaults to dev; a `--target` supplies it instead, and an explicit value here still wins over the target",
               "id": "env",
               "long": "env",
               "positional": false,
@@ -2453,6 +2458,14 @@
           "args": [
             {
               "global": false,
+              "help": "Resolve the agent, environment, and channel from a target declared in the bundle's `deploy.yaml` (ADR-0089)",
+              "id": "target",
+              "long": "target",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
               "help": "Deploy under this agent name instead of the manifest's `name`",
               "id": "agent",
               "long": "agent",
@@ -2527,11 +2540,8 @@
               "required": false
             },
             {
-              "default_values": [
-                "dev"
-              ],
               "global": false,
-              "help": "Target environment",
+              "help": "Target environment. Defaults to dev; a `--target` supplies it instead, and an explicit value here still wins over the target",
               "id": "env",
               "long": "env",
               "positional": false,
@@ -3320,11 +3330,8 @@
           "required": false
         },
         {
-          "default_values": [
-            "dev"
-          ],
           "global": false,
-          "help": "Target environment",
+          "help": "Target environment. Defaults to dev; a `--target` supplies it instead, and an explicit value here still wins over the target",
           "id": "env",
           "long": "env",
           "positional": false,

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -26,6 +26,14 @@ pub const DEFAULT_SLACK_CHANNEL: &str = "C0LOCALDEV";
 /// The API renders these; the CLI applies them. Rendering is a pure function so
 /// the API needs no cluster access for it, and cluster-write authority stays
 /// with the operator running this command (ADR-0086, #1063).
+/// What a named `deploy.yaml` target resolves to (ADR-0089).
+#[derive(Debug, Clone, Deserialize)]
+pub struct ResolvedTarget {
+    pub agent: Option<String>,
+    pub env: String,
+    pub slack_channel: Option<String>,
+}
+
 #[derive(Debug, Clone, Deserialize, Default)]
 pub struct ConnectorManifests {
     #[serde(default)]
@@ -827,6 +835,33 @@ impl ApiClient {
     /// `release`/`namespace`/`app_name` are install-time facts the API does not
     /// know -- they live with whoever ran `cluster up` -- so the caller supplies
     /// them and the API stays a pure function.
+    /// Resolve a named target by POSTing the `deploy.yaml` TEXT.
+    ///
+    /// The CLI deliberately does not parse this file. One parser means the CLI
+    /// and the validator cannot disagree about where a deploy lands, and it
+    /// keeps a YAML crate out of this binary -- serde_yaml is deprecated and
+    /// its half-dozen forks have no clear successor to depend on (ADR-0089).
+    pub async fn resolve_deploy_target(
+        &self,
+        content: &str,
+        target: &str,
+    ) -> Result<ResolvedTarget> {
+        let resp = self
+            .http
+            .post(format!("{}/deploy-targets/resolve", self.base_url))
+            .header("X-API-Key", &self.api_key)
+            .json(&serde_json::json!({"content": content, "target": target}))
+            .send()
+            .await
+            .context("resolving the deploy target")?;
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        if !status.is_success() {
+            anyhow::bail!("resolving target `{target}` failed with {status}: {body}");
+        }
+        serde_json::from_str(&body).context("decoding the resolved deploy target")
+    }
+
     pub async fn version_connectors(
         &self,
         agent_id: &str,

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -725,11 +725,12 @@ pub async fn deploy_named(folder: &str, opts: DeployNamedOpts) -> Result<DeployO
         // deploy_named is the multi-agent-folder path: the folder IS the agent
         // identity there, so there is nothing to override.
         agent: None,
+        target: None,
         api_url: opts.api_url,
         api_key: opts.api_key,
         slack_channel: opts.slack_channel,
         repo: opts.repo,
-        env: opts.env,
+        env: Some(opts.env),
         label: opts.label,
         secret: opts.secret,
         secret_binding_supported: true,
@@ -2928,6 +2929,8 @@ pub struct DeployOpts {
     /// bundle bytes are untouched, only the binding differs -- which is the
     /// property that lets prod promote exactly what dev validated.
     pub agent: Option<String>,
+    /// Resolve agent/env/channel from a `deploy.yaml` target (ADR-0089).
+    pub target: Option<String>,
     pub plugin_dir: PathBuf,
     pub api_url: String,
     pub api_key: String,
@@ -2940,7 +2943,9 @@ pub struct DeployOpts {
     /// so omitting it here leaves the agent permanently unable to use git-flow
     /// (#1064). Ignored with a warning when the agent already exists.
     pub repo: Option<String>,
-    pub env: DeployEnv,
+    /// None means the caller did not pass --env, so a declared target may
+    /// supply it. An explicit flag still wins (ADR-0089).
+    pub env: Option<DeployEnv>,
     pub label: Option<String>,
     /// Per-agent connector secret NAMES to bind on deploy (ADR-0009, #429). Each
     /// value is resolved from the caller's env or the host secret vault and sent
@@ -3068,7 +3073,33 @@ pub async fn deploy(opts: DeployOpts) -> Result<DeployOutput> {
         validate_slack_channel(channel)?;
     }
     let archive = pack_tar_gz(&plugin_dir)?;
-    let env = opts.env.as_str();
+    let client = ApiClient::new(&opts.api_url, &opts.api_key)?;
+    // Resolve a declared target, if one was named (ADR-0089). The file is sent
+    // as TEXT and parsed server-side: one parser means the CLI and the
+    // validator cannot disagree about where this deploy lands.
+    let resolved = match &opts.target {
+        Some(name) => {
+            let path = plugin_dir.join("deploy.yaml");
+            let content = std::fs::read_to_string(&path).map_err(|err| {
+                crate::exit::usage(format!(
+                    "--target {name} needs a deploy.yaml in the bundle, but {} could not be \
+                     read: {err}",
+                    path.display()
+                ))
+            })?;
+            Some(client.resolve_deploy_target(&content, name).await?)
+        }
+        None => None,
+    };
+
+    // A target states its environment, which is the point: the flag's `dev`
+    // default is what let a prod workflow deploy to dev in silence (#1166).
+    let env_owned = opts
+        .env
+        .map(|e| e.as_str().to_string())
+        .or_else(|| resolved.as_ref().map(|r| r.env.clone()))
+        .unwrap_or_else(|| "dev".to_string());
+    let env = env_owned.as_str();
     ui.note(&format!(
         "deploying {plugin_name} ({} bytes) to {} [{env}]",
         archive.len(),
@@ -3106,15 +3137,21 @@ pub async fn deploy(opts: DeployOpts) -> Result<DeployOutput> {
 
     // The manifest name is the default, not the law (#1166). `plugin_name`
     // stays the DISPLAY name so the log still says which bundle was deployed;
-    // `agent_name` is what the platform binds.
-    let agent_name = opts.agent.clone().unwrap_or_else(|| plugin_name.clone());
-    let client = ApiClient::new(&opts.api_url, &opts.api_key)?;
+    // `agent_name` is what the platform binds. Explicit flags beat the target,
+    // so a one-off deploy never requires editing a committed file.
+    let agent_name = opts
+        .agent
+        .clone()
+        .or_else(|| resolved.as_ref().and_then(|r| r.agent.clone()))
+        .unwrap_or_else(|| plugin_name.clone());
     let cl = ui.checklist();
     let step = cl.step(&format!("deploying {plugin_name} as {agent_name}"));
     let outcome = match client
         .deploy(
             &agent_name,
-            opts.slack_channel.as_deref(),
+            opts.slack_channel
+                .as_deref()
+                .or_else(|| resolved.as_ref().and_then(|r| r.slack_channel.as_deref())),
             &label,
             &created_by,
             env,
@@ -6012,13 +6049,14 @@ mod tests {
         let hint = "kubectl -n curie port-forward svc/curie-api 8000:8000";
         let opts = super::DeployOpts {
             agent: None,
+            target: None,
             plugin_dir: dir.path().to_path_buf(),
             // port 1 is reserved/closed -> deterministic connection refused
             api_url: "http://127.0.0.1:1".to_string(),
             api_key: "k".to_string(),
             slack_channel: None,
             repo: None,
-            env: super::DeployEnv::Dev,
+            env: Some(super::DeployEnv::Dev),
             label: Some("v0".to_string()),
             secret: vec![],
             secret_binding_supported: true,
@@ -6084,12 +6122,13 @@ mod tests {
 
         let opts = super::DeployOpts {
             agent: None,
+            target: None,
             plugin_dir: dir.path().to_path_buf(),
             api_url: "http://127.0.0.1:1".to_string(),
             api_key: "k".to_string(),
             slack_channel: None,
             repo: None,
-            env: super::DeployEnv::Dev,
+            env: Some(super::DeployEnv::Dev),
             label: Some("v0".to_string()),
             secret: vec!["GH_TOKEN".to_string()],
             secret_binding_supported: true,
@@ -6118,13 +6157,14 @@ mod tests {
 
         let opts = super::DeployOpts {
             agent: None,
+            target: None,
             plugin_dir: dir.path().to_path_buf(),
             // port 1 is reserved/closed -> deterministic connection refused
             api_url: "http://127.0.0.1:1".to_string(),
             api_key: "k".to_string(),
             slack_channel: None,
             repo: None,
-            env: super::DeployEnv::Dev,
+            env: Some(super::DeployEnv::Dev),
             label: Some("v0".to_string()),
             secret: vec![],
             secret_binding_supported: false,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -282,9 +282,10 @@ enum Command {
         /// agent that already exists warns and changes nothing.
         #[arg(long = "repo", value_name = "OWNER/NAME")]
         repo: Option<String>,
-        /// Target environment.
-        #[arg(long, value_enum, default_value_t = DeployEnv::Dev)]
-        env: DeployEnv,
+        /// Target environment. Defaults to dev; a `--target` supplies it
+        /// instead, and an explicit value here still wins over the target.
+        #[arg(long, value_enum)]
+        env: Option<DeployEnv>,
         /// Version label; defaults to <manifest version>-<unix time>.
         #[arg(long)]
         label: Option<String>,
@@ -908,6 +909,15 @@ enum LocalAction {
     },
     /// Push the bundle to the local platform API and deploy it.
     Deploy {
+        /// Resolve the agent, environment, and channel from a target declared
+        /// in the bundle's `deploy.yaml` (ADR-0089).
+        ///
+        /// Routing lives in the repository and is a reviewable diff, instead of
+        /// flags scattered across whatever invoked this command. Explicit
+        /// --agent/--env/--slack-channel still win, so a one-off deploy needs
+        /// no committed file.
+        #[arg(long, conflicts_with = "agent")]
+        target: Option<String>,
         /// Deploy under this agent name instead of the manifest's `name`.
         ///
         /// The bundle is unchanged -- only which agent it binds to. This is how
@@ -943,9 +953,10 @@ enum LocalAction {
         /// agent that already exists warns and changes nothing.
         #[arg(long = "repo", value_name = "OWNER/NAME")]
         repo: Option<String>,
-        /// Target environment.
-        #[arg(long, value_enum, default_value_t = DeployEnv::Dev)]
-        env: DeployEnv,
+        /// Target environment. Defaults to dev; a `--target` supplies it
+        /// instead, and an explicit value here still wins over the target.
+        #[arg(long, value_enum)]
+        env: Option<DeployEnv>,
         /// Version label; defaults to <manifest version>-<unix time>.
         #[arg(long)]
         label: Option<String>,
@@ -1379,6 +1390,15 @@ enum ClusterAction {
     },
     /// Push the bundle to the platform API and deploy it.
     Deploy {
+        /// Resolve the agent, environment, and channel from a target declared
+        /// in the bundle's `deploy.yaml` (ADR-0089).
+        ///
+        /// Routing lives in the repository and is a reviewable diff, instead of
+        /// flags scattered across whatever invoked this command. Explicit
+        /// --agent/--env/--slack-channel still win, so a one-off deploy needs
+        /// no committed file.
+        #[arg(long, conflicts_with = "agent")]
+        target: Option<String>,
         /// Deploy under this agent name instead of the manifest's `name`.
         ///
         /// The bundle is unchanged -- only which agent it binds to. This is how
@@ -1421,9 +1441,10 @@ enum ClusterAction {
         /// agent that already exists warns and changes nothing.
         #[arg(long = "repo", value_name = "OWNER/NAME")]
         repo: Option<String>,
-        /// Target environment.
-        #[arg(long, value_enum, default_value_t = DeployEnv::Dev)]
-        env: DeployEnv,
+        /// Target environment. Defaults to dev; a `--target` supplies it
+        /// instead, and an explicit value here still wins over the target.
+        #[arg(long, value_enum)]
+        env: Option<DeployEnv>,
         /// Version label; defaults to <manifest version>-<unix time>.
         #[arg(long)]
         label: Option<String>,
@@ -2035,6 +2056,7 @@ async fn run(command: Option<Command>) -> Result<()> {
             LocalAction::Deploy {
                 plugin_dir,
                 agent,
+                target,
                 api_url,
                 api_key,
                 slack_channel,
@@ -2050,6 +2072,7 @@ async fn run(command: Option<Command>) -> Result<()> {
                     commands::deploy(DeployOpts {
                         plugin_dir,
                         agent,
+                        target,
                         api_url,
                         api_key,
                         slack_channel,
@@ -2476,6 +2499,7 @@ async fn run(command: Option<Command>) -> Result<()> {
             ClusterAction::Deploy {
                 plugin_dir,
                 agent,
+                target,
                 api_url,
                 namespace,
                 release,
@@ -2570,6 +2594,7 @@ async fn run(command: Option<Command>) -> Result<()> {
                 let deployed = commands::deploy(DeployOpts {
                     plugin_dir,
                     agent,
+                    target,
                     api_url: api_url.clone(),
                     api_key: api_key.clone(),
                     slack_channel,
@@ -2806,7 +2831,9 @@ async fn run(command: Option<Command>) -> Result<()> {
                     api_key,
                     slack_channel,
                     repo,
-                    env,
+                    // deploy_named has no --target, so the historical default
+                    // applies here rather than deferring to a declared one.
+                    env: env.unwrap_or(commands::DeployEnv::Dev),
                     label,
                     secret,
                 },


### PR DESCRIPTION
Completes [ADR-0089](docs/adr/0089-bundles-declare-their-deploy-targets.md). Refs #1166. Base `main`.

```bash
curie cluster deploy --plugin-dir . --target prod
```

Reads the bundle's `deploy.yaml`, resolves agent + env + channel from the named target.

## The CLI does not parse the file

It posts the **text** to a new read-only endpoint; the API resolves it with `plugin_format` — the validator that already owns the format.

**One parser cannot disagree with itself.** A Rust implementation and the Python validator could reach different conclusions about the same file, and this file's whole job is to be unambiguous about where a deploy lands. A disagreement routes a deploy somewhere the author didn't intend and reports success. Same anti-drift reasoning that made `mcp_entry` shared between the renderer and the runner.

It also keeps YAML out of the binary — `serde_yaml` is deprecated and its forks have no clear successor:

```
serde_yaml = "0.9.34+deprecated"
yaml_serde, serde_yaml_ng, serde_norway, serde_yaml_neo, mk_ext_serde_yaml…
```

Adding one to a public CLI is a supply-chain decision that buys nothing here.

## Its own router, deliberately

Hanging it off `bundles` would have given it the prefix `/agents/{agent_id}/versions/{version_id}/bundle/…` — backwards, since **the caller uses this before an agent exists**, to find out which agent to create. (I made that mistake first; the 404 in the tests caught it.)

It touches no database, no store, no cluster — and the tests build a client **without the db fixture**, so that stays true by construction rather than by comment.

## `--env` had to become optional

Otherwise the flag's `dev` default would silently outrank a target's declared `prod` — the exact failure ADR-0089 exists to remove. Now `None` means "not passed", so a target can supply it and an explicit flag still wins.

`--target` and `--agent` **conflict** rather than override: naming both is a contradiction, not a precedence question.

## Verification

```
cargo clippy -D warnings → 0 errors
cargo test               → 0 failed across suites
field-parity             → passed (ResolvedTarget declared)
command manifests        → regenerated, both carry --target and --agent
api tests                → 5 passed, no database required
plugin-format            → 241 passed
mypy                     → no issues, 168 files
```

Behaviour spot-checked:

```
--target with --agent      → "cannot be used with"
--target, no deploy.yaml   → actionable usage error naming the path
```

## Next

acme-bot adds `deploy.yaml`, both workflows switch to `--target`, and the `acme-dev` agent gets created on its first dev deploy.
