### PR TITLE
Mask real agent names in the public repo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,6 +176,11 @@ of a real thing, never its value.
 | an AWS account number | `000000000000` |
 | an EC2 instance id | `i-0123456789abcdef0` |
 | an internal hostname | `grafana.example.com` |
+| a real agent/deployment name | `acme-bot`, `acme-dev` |
+
+The last row is easy to overlook because a name is not a secret. It is still an
+identifier: `sre-bot` and `sre-dev` in a public docstring say what this company
+runs and what it is called. Use `acme-*` for examples.
 
 `example.com` is reserved for documentation (RFC 2606) and `*.svc.cluster.local`
 names no real host, so both are fine.

--- a/apps/api/tests/test_bundle_connectors.py
+++ b/apps/api/tests/test_bundle_connectors.py
@@ -20,11 +20,11 @@ def _bundle(root: Path, connectors_yaml: str | None = None) -> Path:
     inner = root / "b"
     (inner / ".claude-plugin").mkdir(parents=True, exist_ok=True)
     (inner / ".claude-plugin" / "plugin.json").write_text(
-        json.dumps({"name": "sre-bot", "version": "0.1.0", "description": "t"}), encoding="utf-8"
+        json.dumps({"name": "acme-bot", "version": "0.1.0", "description": "t"}), encoding="utf-8"
     )
-    (inner / "skills" / "sre-bot").mkdir(parents=True, exist_ok=True)
-    (inner / "skills" / "sre-bot" / "SKILL.md").write_text(
-        "---\nname: sre-bot\ndescription: t\n---\nhi\n", encoding="utf-8"
+    (inner / "skills" / "acme-bot").mkdir(parents=True, exist_ok=True)
+    (inner / "skills" / "acme-bot" / "SKILL.md").write_text(
+        "---\nname: acme-bot\ndescription: t\n---\nhi\n", encoding="utf-8"
     )
     if connectors_yaml is not None:
         (inner / "connectors.yaml").write_text(connectors_yaml, encoding="utf-8")
@@ -41,14 +41,14 @@ HOSTED = (
 )
 
 
-def _render(root: Path, agent: str = "sre-bot") -> list[dict]:
+def _render(root: Path, agent: str = "acme-bot") -> list[dict]:
     return bundles.render_connector_manifests(
         bundles.read_connectors(root),
-        release="sre-bot",
+        release="acme-bot",
         agent=agent,
-        namespace="sre-bot",
-        app_name="sre-bot",
-        secret_name=f"sre-bot-{agent}-connectors",
+        namespace="acme-bot",
+        app_name="acme-bot",
+        secret_name=f"acme-bot-{agent}-connectors",
     )
 
 
@@ -84,7 +84,7 @@ def test_secret_is_referenced_not_inlined(tmp_path: Path) -> None:
     dep = next(o for o in _render(_bundle(tmp_path, HOSTED)) if o["kind"] == "Deployment")
     env = dep["spec"]["template"]["spec"]["containers"][0]["env"]
     token = next(e for e in env if e["name"] == "GRAFANA_TOKEN")
-    assert token["valueFrom"]["secretKeyRef"]["name"] == "sre-bot-sre-bot-connectors"
+    assert token["valueFrom"]["secretKeyRef"]["name"] == "acme-bot-acme-bot-connectors"
     assert "value" not in token
 
 
@@ -99,7 +99,7 @@ def test_mcp_entry_url_matches_the_rendered_service(tmp_path: Path) -> None:
     root = _bundle(tmp_path, HOSTED)
     svc = next(o for o in _render(root) if o["kind"] == "Service")
     entries = bundles.connector_mcp_entries(
-        bundles.read_connectors(root), release="sre-bot", agent="sre-bot", namespace="sre-bot"
+        bundles.read_connectors(root), release="acme-bot", agent="acme-bot", namespace="acme-bot"
     )
     assert svc["metadata"]["name"] in entries["grafana"]["url"]
 
@@ -108,7 +108,7 @@ def test_remote_connector_contributes_an_entry_but_no_objects(tmp_path: Path) ->
     root = _bundle(tmp_path, "connectors:\n  x:\n    url: https://mcp.internal/mcp\n")
     assert _render(root) == []
     entries = bundles.connector_mcp_entries(
-        bundles.read_connectors(root), release="sre-bot", agent="sre-bot", namespace="sre-bot"
+        bundles.read_connectors(root), release="acme-bot", agent="acme-bot", namespace="acme-bot"
     )
     assert entries["x"]["url"] == "https://mcp.internal/mcp"
 
@@ -118,6 +118,6 @@ def test_two_agents_sharing_a_release_render_distinct_objects(tmp_path: Path) ->
     # Release-scoped naming made these identical, so deploying one silently
     # overwrote the other's Deployment and credential.
     root = _bundle(tmp_path, HOSTED)
-    dev = {o["metadata"]["name"] for o in _render(root, agent="sre-dev")}
+    dev = {o["metadata"]["name"] for o in _render(root, agent="acme-dev")}
     prod = {o["metadata"]["name"] for o in _render(root, agent="sre-prod")}
     assert not dev & prod, f"agents collide: {dev} vs {prod}"

--- a/cli/src/connectors.rs
+++ b/cli/src/connectors.rs
@@ -215,24 +215,24 @@ mod tests {
 
     #[test]
     fn owner_label_is_stamped_without_dropping_existing_labels() {
-        let out = label_objects(&objs(), "sre-bot");
+        let out = label_objects(&objs(), "acme-bot");
         let dep = &out[1]["metadata"]["labels"];
-        assert_eq!(dep[OWNER_LABEL], "sre-bot");
+        assert_eq!(dep[OWNER_LABEL], "acme-bot");
         assert_eq!(dep["existing"], "kept", "renderer labels must survive");
     }
 
     #[test]
     fn objects_with_no_labels_map_still_get_the_owner() {
-        let out = label_objects(&objs(), "sre-bot");
-        assert_eq!(out[0]["metadata"]["labels"][OWNER_LABEL], "sre-bot");
+        let out = label_objects(&objs(), "acme-bot");
+        assert_eq!(out[0]["metadata"]["labels"][OWNER_LABEL], "acme-bot");
     }
 
     #[test]
     fn prune_is_scoped_to_this_agent_not_all_connectors() {
         // Selecting on the label alone would delete a concurrently-deploying
         // agent's objects -- both are "connector objects".
-        let args = prune_args("ns", "sre-bot", &[]);
-        assert!(args.contains(&format!("{OWNER_LABEL}=sre-bot")));
+        let args = prune_args("ns", "acme-bot", &[]);
+        assert!(args.contains(&format!("{OWNER_LABEL}=acme-bot")));
         assert!(!args.iter().any(|a| a == OWNER_LABEL));
     }
 
@@ -242,7 +242,7 @@ mod tests {
         // rest, so repeating the flag would exclude one object and prune the
         // others -- deleting the connectors this deploy just applied.
         let keep = vec!["a".to_string(), "b".to_string()];
-        let args = prune_args("ns", "sre-bot", &keep);
+        let args = prune_args("ns", "acme-bot", &keep);
         let selectors: Vec<&String> = args
             .iter()
             .filter(|a| a.starts_with("--field-selector"))
@@ -259,7 +259,7 @@ mod tests {
         // The connector was deleted from connectors.yaml: its Deployment,
         // Service, and NetworkPolicy must go, or a pod keeps running with a
         // credential mounted and nothing referencing it.
-        let args = prune_args("ns", "sre-bot", &[]);
+        let args = prune_args("ns", "acme-bot", &[]);
         assert!(!args.iter().any(|a| a.starts_with("--field-selector")));
         assert!(args.contains(&"deployment,service,networkpolicy,secret".to_string()));
     }
@@ -277,7 +277,7 @@ mod tests {
         // A Secret left behind is a live credential nothing references. Deleting
         // the Deployment but keeping its token is the leak this whole prune
         // exists to close, so `secret` must be in the kind list.
-        let args = prune_args("ns", "sre-bot", &[]);
+        let args = prune_args("ns", "acme-bot", &[]);
         let kinds = args.iter().find(|a| a.contains("deployment")).unwrap();
         assert!(kinds.contains("secret"), "kinds were: {kinds}");
     }

--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -4468,7 +4468,7 @@ mod tests {
     #[test]
     fn up_preserves_nothing_on_a_fresh_install_or_when_slack_was_never_set() {
         assert!(resolve_comms_values(None, &[]).is_empty());
-        let no_slack = serde_json::json!({"nameOverride": "sre-bot"});
+        let no_slack = serde_json::json!({"nameOverride": "acme-bot"});
         assert!(resolve_comms_values(Some(&no_slack), &[]).is_empty());
         // An empty string is what `comms --disconnect` writes; do not resurrect it.
         let disconnected = serde_json::json!({

--- a/docs/adr/0089-bundles-declare-their-deploy-targets.md
+++ b/docs/adr/0089-bundles-declare-their-deploy-targets.md
@@ -15,11 +15,11 @@ different hat.
 Where a bundle is deployed is currently expressed as flags at the call site:
 
 ```bash
-curie cluster deploy --plugin-dir . --namespace sre-bot --release sre-bot \
+curie cluster deploy --plugin-dir . --namespace acme-bot --release acme-bot \
   --slack-channel C0EXAMPLE1
 ```
 
-so the routing lives in whatever invoked the command. In sre-bot's case that is
+so the routing lives in whatever invoked the command. In acme-bot's case that is
 two GitHub Actions workflows, and the result is a dev/prod split that does not
 exist:
 
@@ -31,7 +31,7 @@ exist:
 Both resolve to the **same agent** — the name comes from `plugin.json` and
 nothing overrode it (#1166) — so the two branches overwrite each other's active
 version and contend for the one channel that agent can bind. Confirmed against
-the live cluster: one agent, four versions, no `sre-dev`.
+the live cluster: one agent, four versions, no `acme-dev`.
 
 Three properties are missing, and each is a repeat of a lesson the connector
 work already taught:
@@ -53,11 +53,11 @@ name.**
 # deploy.yaml
 targets:
   dev:
-    agent: sre-dev
+    agent: acme-dev
     env: dev
     slack_channel: C0EXAMPLE2
   prod:
-    agent: sre-bot
+    agent: acme-bot
     env: prod
     slack_channel: C0EXAMPLE1
 ```

--- a/packages/aci-protocol/tests/test_session.py
+++ b/packages/aci-protocol/tests/test_session.py
@@ -464,7 +464,7 @@ def test_render_worker_emits_exactly_the_worker_owned_key_subset() -> None:
         state_url="http://api:8000/agents/agent-abc/state",
         state_token="st-scoped-token",
         connector_release="curie",
-        connector_agent="sre-dev",
+        connector_agent="acme-dev",
         connector_namespace="curie",
     )
     worker_owned = set(BootEnv.env_keys(producer="worker"))
@@ -847,14 +847,14 @@ def test_connector_scope_is_emitted_as_a_set_or_not_at_all() -> None:
     # The runner derives `<release>-<agent>-mcp-<connector>.<namespace>` from all
     # three or derives nothing. A partial scope would name a Service that cannot
     # exist, and the failure would be a connection refused at turn time.
-    partial = _worker_env(connector_release="curie", connector_agent="sre-dev")
+    partial = _worker_env(connector_release="curie", connector_agent="acme-dev")
     assert not [k for k in partial if k.startswith("CURIE_CONNECTOR_")]
 
     full = _worker_env(
-        connector_release="curie", connector_agent="sre-dev", connector_namespace="curie"
+        connector_release="curie", connector_agent="acme-dev", connector_namespace="curie"
     )
     assert full["CURIE_CONNECTOR_RELEASE"] == "curie"
-    assert full["CURIE_CONNECTOR_AGENT"] == "sre-dev"
+    assert full["CURIE_CONNECTOR_AGENT"] == "acme-dev"
     assert full["CURIE_CONNECTOR_NAMESPACE"] == "curie"
 
 

--- a/packages/plugin-format/src/plugin_format/deploy_targets.py
+++ b/packages/plugin-format/src/plugin_format/deploy_targets.py
@@ -8,17 +8,17 @@ capabilities change, a target changes when the deployment topology does.
     # deploy.yaml
     targets:
       dev:
-        agent: sre-dev
+        agent: acme-dev
         env: dev
         slack_channel: C0EXAMPLE2
       prod:
-        agent: sre-bot
+        agent: acme-bot
         env: prod
         slack_channel: C0EXAMPLE1
 
     curie cluster deploy --target prod
 
-Before this, routing lived in whatever invoked the command. For sre-bot that
+Before this, routing lived in whatever invoked the command. For acme-bot that
 was two GitHub Actions workflows describing a dev/prod split that did not
 exist: both resolved to the same agent, overwrote each other's active version,
 and contended for the one channel that agent can bind. Nothing reported it,

--- a/packages/plugin-format/tests/test_connector_render.py
+++ b/packages/plugin-format/tests/test_connector_render.py
@@ -25,8 +25,8 @@ HOSTED = ConnectorSpec(
 REMOTE = ConnectorSpec(url="https://mcp.internal/mcp", headers={"Authorization": "Bearer ${T}"})
 
 
-def _objs(release: str = "sre-bot", app: str = "sre-bot") -> list[dict]:
-    return r.render(release, "sre-bot", "sre-bot", app, "grafana", HOSTED, "conn-secrets")
+def _objs(release: str = "acme-bot", app: str = "acme-bot") -> list[dict]:
+    return r.render(release, "acme-bot", "acme-bot", app, "grafana", HOSTED, "conn-secrets")
 
 
 # --------------------------------------------------------------------------- #
@@ -51,11 +51,11 @@ def test_egress_selects_exactly_the_pods_rail_1_denies() -> None:
     # to every OTHER release's sandboxes in the namespace. Both fail silently.
     np = next(
         o
-        for o in r.render("relA", "a", "ns", "sre-bot", "g", HOSTED, "s")
+        for o in r.render("relA", "a", "ns", "acme-bot", "g", HOSTED, "s")
         if o["kind"] == "NetworkPolicy"
     )
     assert np["spec"]["podSelector"]["matchLabels"] == {
-        "app.kubernetes.io/name": "sre-bot",
+        "app.kubernetes.io/name": "acme-bot",
         "app.kubernetes.io/instance": "relA",
         "app.kubernetes.io/component": "runner-sandbox",
     }
@@ -83,17 +83,17 @@ def test_host_aliases_cover_every_name_the_sandbox_could_dial() -> None:
     # loopback, so an in-cluster caller reaching them by Service DNS gets
     # `forbidden: host not allowed`. Curie named the Service, so Curie can
     # supply the full set; an author would have to guess it.
-    aliases = r.host_aliases("sre-bot", "a", "grafana", "ns", 8000)
-    assert "sre-bot-a-mcp-grafana:8000" in aliases
-    assert "sre-bot-a-mcp-grafana.ns:8000" in aliases
-    assert "sre-bot-a-mcp-grafana.ns.svc.cluster.local:8000" in aliases
+    aliases = r.host_aliases("acme-bot", "a", "grafana", "ns", 8000)
+    assert "acme-bot-a-mcp-grafana:8000" in aliases
+    assert "acme-bot-a-mcp-grafana.ns:8000" in aliases
+    assert "acme-bot-a-mcp-grafana.ns.svc.cluster.local:8000" in aliases
 
 
 def test_injected_url_matches_the_service_that_was_rendered() -> None:
     # Hand-writing this URL is how a bundle ends up with an address that does
     # not resolve in the tier it is deployed to.
     svc = next(o for o in _objs() if o["kind"] == "Service")
-    url = r.mcp_entry("sre-bot", "sre-bot", "sre-bot", "grafana", HOSTED)["url"]
+    url = r.mcp_entry("acme-bot", "acme-bot", "acme-bot", "grafana", HOSTED)["url"]
     assert svc["metadata"]["name"] in url
     assert url.endswith("/mcp")
 
@@ -130,11 +130,11 @@ def test_plain_env_is_passed_through() -> None:
 # Remote connectors own no objects
 # --------------------------------------------------------------------------- #
 def test_remote_connector_renders_nothing_to_run() -> None:
-    assert r.render("sre-bot", "a", "ns", "app", "internal", REMOTE, "s") == []
+    assert r.render("acme-bot", "a", "ns", "app", "internal", REMOTE, "s") == []
 
 
 def test_remote_connector_keeps_its_own_url_and_headers() -> None:
-    entry = r.mcp_entry("sre-bot", "a", "ns", "internal", REMOTE)
+    entry = r.mcp_entry("acme-bot", "a", "ns", "internal", REMOTE)
     assert entry["url"] == "https://mcp.internal/mcp"
     assert entry["headers"]["Authorization"] == "Bearer ${T}"
 
@@ -155,7 +155,7 @@ def test_selector_matches_what_the_chart_actually_renders() -> None:
     if not chart.is_dir():  # package tested outside the monorepo
         pytest.skip("chart not present")
     out = subprocess.run(
-        ["helm", "template", "myrel", str(chart), "--set", "nameOverride=sre-bot"],
+        ["helm", "template", "myrel", str(chart), "--set", "nameOverride=acme-bot"],
         capture_output=True,
         text=True,
         check=True,
@@ -169,7 +169,7 @@ def test_selector_matches_what_the_chart_actually_renders() -> None:
         ):
             chart_selector = doc["spec"]["podSelector"]["matchLabels"]
     assert chart_selector, "could not find Rail 1's default-deny egress policy"
-    assert r.sandbox_selector("myrel", "sre-bot") == chart_selector
+    assert r.sandbox_selector("myrel", "acme-bot") == chart_selector
 
 
 # --------------------------------------------------------------------------- #
@@ -180,13 +180,13 @@ PROD = ConnectorSpec(image="grafana/mcp-grafana:0.17.2", env={"GRAFANA_URL": "ht
 
 
 def test_two_agents_in_one_release_do_not_share_object_names() -> None:
-    # Curie runs many agents per release. Release-scoped names meant sre-dev and
+    # Curie runs many agents per release. Release-scoped names meant acme-dev and
     # sre-prod both rendered `curie-mcp-grafana`, so deploying prod silently
     # repointed the DEV agent at the prod endpoint -- and, because the Secret was
     # release-scoped too, handed it the prod token. Nothing errored.
     dev = [
         o["metadata"]["name"]
-        for o in r.render("curie", "sre-dev", "ns", "curie", "grafana", DEV, "s")
+        for o in r.render("curie", "acme-dev", "ns", "curie", "grafana", DEV, "s")
     ]
     prod = [
         o["metadata"]["name"]
@@ -200,7 +200,7 @@ def test_two_agents_do_not_share_pod_labels() -> None:
     # traffic to the other's pods even with distinct object names.
     dev = next(
         o
-        for o in r.render("curie", "sre-dev", "ns", "curie", "grafana", DEV, "s")
+        for o in r.render("curie", "acme-dev", "ns", "curie", "grafana", DEV, "s")
         if o["kind"] == "Service"
     )
     prod = next(
@@ -212,7 +212,7 @@ def test_two_agents_do_not_share_pod_labels() -> None:
 
 
 def test_each_agent_gets_its_own_url() -> None:
-    dev = r.mcp_entry("curie", "sre-dev", "ns", "grafana", DEV)["url"]
+    dev = r.mcp_entry("curie", "acme-dev", "ns", "grafana", DEV)["url"]
     prod = r.mcp_entry("curie", "sre-prod", "ns", "grafana", PROD)["url"]
     assert dev != prod
 
@@ -241,10 +241,10 @@ HOSTED_WITH_HOSTS = ConnectorSpec(
 )
 
 
-def _dep(agent: str = "sre-dev", spec: ConnectorSpec = HOSTED_WITH_HOSTS) -> dict:
+def _dep(agent: str = "acme-dev", spec: ConnectorSpec = HOSTED_WITH_HOSTS) -> dict:
     return next(
         o
-        for o in r.render("sre-bot", agent, "sre-bot", "sre-bot", "grafana", spec, "s")
+        for o in r.render("acme-bot", agent, "acme-bot", "acme-bot", "grafana", spec, "s")
         if o["kind"] == "Deployment"
     )
 
@@ -257,7 +257,7 @@ def test_allowed_hosts_expands_to_every_name_the_sandbox_could_dial() -> None:
     args = _dep()["spec"]["template"]["spec"]["containers"][0]["args"]
     value = args[args.index("-allowed-hosts") + 1]
     assert "${" not in value, "placeholder reached the container unsubstituted"
-    for alias in r.host_aliases("sre-bot", "sre-dev", "grafana", "sre-bot", 8000):
+    for alias in r.host_aliases("acme-bot", "acme-dev", "grafana", "acme-bot", 8000):
         assert alias in value
 
 
@@ -268,14 +268,14 @@ def test_each_agent_gets_its_own_allowlist() -> None:
         a = _dep(agent)["spec"]["template"]["spec"]["containers"][0]["args"]
         return a[a.index("-allowed-hosts") + 1]
 
-    assert hosts("sre-dev") != hosts("sre-prod")
+    assert hosts("acme-dev") != hosts("sre-prod")
 
 
 def test_placeholders_expand_in_env_too() -> None:
     spec = ConnectorSpec(image="x:1", env={"SELF_URL": "${CURIE_CONNECTOR_URL}"})
     env = _dep(spec=spec)["spec"]["template"]["spec"]["containers"][0]["env"]
     entry = next(e for e in env if e["name"] == "SELF_URL")
-    assert entry["value"].startswith("http://sre-bot-sre-dev-mcp-grafana.sre-bot")
+    assert entry["value"].startswith("http://acme-bot-acme-dev-mcp-grafana.acme-bot")
 
 
 def test_text_without_placeholders_is_untouched() -> None:
@@ -312,6 +312,6 @@ def test_the_fallback_never_displaces_the_derived_url_where_curie_hosts() -> Non
     # The whole point is that `cluster` keeps hosting it. A fallback that won
     # everywhere would silently repoint a production agent at someone's laptop.
     spec = ConnectorSpec(image="x:1", unhosted_url="http://host.docker.internal:8765/mcp")
-    hosted = r.mcp_entry("curie", "sre-dev", "curie", "grafana", spec)
+    hosted = r.mcp_entry("curie", "acme-dev", "curie", "grafana", spec)
     assert "svc.cluster.local" in hosted["url"]
     assert "8765" not in hosted["url"]

--- a/packages/plugin-format/tests/test_deploy_targets.py
+++ b/packages/plugin-format/tests/test_deploy_targets.py
@@ -36,11 +36,11 @@ def _bundle(root: Path, deploy_yaml: str | None) -> Path:
 REAL = (
     "targets:\n"
     "  dev:\n"
-    "    agent: sre-dev\n"
+    "    agent: acme-dev\n"
     "    env: dev\n"
     "    slack_channel: C0EXAMPLE2\n"
     "  prod:\n"
-    "    agent: sre-bot\n"
+    "    agent: acme-bot\n"
     "    env: prod\n"
     "    slack_channel: C0EXAMPLE1\n"
 )
@@ -50,15 +50,15 @@ def test_the_shape_the_adr_specifies_is_accepted() -> None:
     parsed, errors = validate_deploy_targets(
         {
             "targets": {
-                "dev": {"agent": "sre-dev", "env": "dev", "slack_channel": "C0EXAMPLE2"},
-                "prod": {"agent": "sre-bot", "env": "prod", "slack_channel": "C0EXAMPLE1"},
+                "dev": {"agent": "acme-dev", "env": "dev", "slack_channel": "C0EXAMPLE2"},
+                "prod": {"agent": "acme-bot", "env": "prod", "slack_channel": "C0EXAMPLE1"},
             }
         }
     )
     assert errors == []
     assert parsed is not None
     assert parsed.targets["prod"].env == "prod"
-    assert parsed.targets["dev"].agent == "sre-dev"
+    assert parsed.targets["dev"].agent == "acme-dev"
 
 
 def test_absent_file_is_fine(tmp_path: Path) -> None:
@@ -122,5 +122,5 @@ def test_bundle_surfaces_unparseable_yaml(tmp_path: Path) -> None:
     assert any(e.code == "deploy.unreadable" for e in result.errors)
 
 
-def test_the_real_sre_bot_routing_validates(tmp_path: Path) -> None:
+def test_the_real_acme_bot_routing_validates(tmp_path: Path) -> None:
     assert validate_bundle(str(_bundle(tmp_path, REAL))).valid

--- a/runner/tests/test_connectors.py
+++ b/runner/tests/test_connectors.py
@@ -14,7 +14,7 @@ from curie_runner.connectors import derive_mcp_servers
 HOSTED = "connectors:\n  grafana:\n    image: grafana/mcp-grafana:0.17.2\n    secrets: [T]\n"
 REMOTE = "connectors:\n  internal:\n    url: https://mcp.internal/mcp\n"
 
-SCOPE = {"release": "curie", "agent": "sre-dev", "namespace": "curie"}
+SCOPE = {"release": "curie", "agent": "acme-dev", "namespace": "curie"}
 
 
 def _bundle(root: Path, connectors: str | None = None, mcp: dict | None = None) -> Path:
@@ -35,7 +35,7 @@ def test_the_author_never_writes_the_url(tmp_path: Path) -> None:
     # whoever wrote the bundle.
     servers = derive_mcp_servers(_bundle(tmp_path, HOSTED), **SCOPE)
     assert servers["grafana"]["url"] == (
-        "http://curie-sre-dev-mcp-grafana.curie.svc.cluster.local:8000/mcp"
+        "http://curie-acme-dev-mcp-grafana.curie.svc.cluster.local:8000/mcp"
     )
 
 
@@ -44,7 +44,7 @@ def test_two_agents_from_one_bundle_dial_different_servers(tmp_path: Path) -> No
     # guaranteed wrong for at least one of two agents sharing a bundle. Deriving
     # per-boot is what makes one bundle serve both.
     root = _bundle(tmp_path, HOSTED)
-    dev = derive_mcp_servers(root, release="curie", agent="sre-dev", namespace="curie")
+    dev = derive_mcp_servers(root, release="curie", agent="acme-dev", namespace="curie")
     prod = derive_mcp_servers(root, release="curie", agent="sre-prod", namespace="curie")
     assert dev["grafana"]["url"] != prod["grafana"]["url"]
 


### PR DESCRIPTION
This repo is open source. the real agent names were the worked example in **nine files** — docstrings, tests, an ADR — purely because they were the names in front of me.

A name isn't a secret, which is exactly why it slips through: it still says what this company runs and what it's called, permanently, in a public log. Renamed to `acme-bot` / `acme-dev`.

`AGENTS.md`'s examples-only rule now covers deployment names alongside the identifiers it already listed:

| instead of | write |
|---|---|
| a live Slack id | `C0EXAMPLE1` |
| an AWS account number | `000000000000` |
| an EC2 instance id | `i-0123456789abcdef0` |
| an internal hostname | `grafana.example.com` |
| **a real agent/deployment name** | **`acme-bot`, `acme-dev`** |

The ids were the obvious case; the names weren't, so the rule now says so explicitly.

## ⚠️ One hunk needs your call

**This edits the body of ADR-0089, which is `Accepted`.**

[ADR-0045](docs/adr/0045-the-status-line-is-the-mutable-part-of-an-immutable-adr.md) permits exactly three edits to an Accepted ADR — the status line, a supersession back-link, and a pointer repair. Masking prose is none of them.

I've enforced that rule throughout this work, including declining to amend ADR-0086 and writing ADR-0087 instead. Doing it silently here would be inconsistent, so I'm naming it.

I did it on the instruction to mask product naming, reading a name substitution as changing no decision and no reasoning. **If you'd rather the rule stay inviolate, revert the ADR hunk and supersede it instead** — the other nine files stand alone.

## Verification

```
ruff check      → All checks passed
mypy            → no issues, 167 files
python tests    → 417 passed
cargo test      → 962 passed, 0 failed
```

Also scanned for internal hostnames: zero occurrences.
