### PR TITLE
Tell the operator when the platform is older than the CLI

### DIFF
--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -420,6 +420,25 @@ fn agent_create_body(
     body
 }
 
+/// Is this 404 a MISSING ENDPOINT rather than a missing resource?
+///
+/// FastAPI answers an unrouted path with exactly `{"detail":"Not Found"}`,
+/// while a handler that ran and found nothing sets its own detail ("version
+/// not found"). That difference is the only signal available for "this CLI is
+/// newer than the platform it is talking to" -- and without it the operator
+/// sees a bare 404 and has no way to tell a stale release from a typo.
+///
+/// Both of the failures this guards against happened for real: a CLI with
+/// `--target` against an API that predated the resolver, and a CLI that
+/// applied connectors against an API that could not render them.
+fn is_unrouted(status: reqwest::StatusCode, body: &str) -> bool {
+    status == reqwest::StatusCode::NOT_FOUND
+        && serde_json::from_str::<serde_json::Value>(body)
+            .ok()
+            .and_then(|v| v.get("detail").and_then(|d| d.as_str()).map(str::to_string))
+            .is_some_and(|d| d == "Not Found")
+}
+
 impl ApiClient {
     /// The server caps `/approvals` results at this many rows
     /// (`apps/api/.../routers/approvals.py`: `min(max(limit, 1), 200)`); the CLI
@@ -446,6 +465,15 @@ impl ApiClient {
         }
         let status = resp.status();
         let body = resp.text().await.unwrap_or_default();
+        // An unrouted path means the platform is older than this CLI, which is
+        // a different problem from a missing resource and has a different fix.
+        // Saying so here covers every caller at once rather than one call site.
+        if is_unrouted(status, &body) {
+            bail!(
+                "{what} failed: this platform release does not have that endpoint, so it is \
+                 older than this CLI. Upgrade the release, or use a CLI matching it."
+            );
+        }
         bail!("{what} failed with {status}: {}", body.trim());
     }
 
@@ -856,6 +884,13 @@ impl ApiClient {
             .context("resolving the deploy target")?;
         let status = resp.status();
         let body = resp.text().await.unwrap_or_default();
+        if is_unrouted(status, &body) {
+            anyhow::bail!(
+                "this platform release has no deploy-target resolver, so `--target` cannot \
+                 work against it. The API predates ADR-0089. Upgrade the release, or drop \
+                 `--target` and pass `--agent`/`--env`/`--slack-channel` directly."
+            );
+        }
         if !status.is_success() {
             anyhow::bail!("resolving target `{target}` failed with {status}: {body}");
         }
@@ -1195,5 +1230,53 @@ mod tests {
         ] {
             assert!(is_insecure_endpoint(url), "expected {url} to warn");
         }
+    }
+}
+
+#[cfg(test)]
+mod skew_tests {
+    use super::is_unrouted;
+    use reqwest::StatusCode;
+
+    #[test]
+    fn a_bare_fastapi_404_is_read_as_a_missing_endpoint() {
+        // This is exactly what an older platform returns for a path it does not
+        // route, and it is the only signal that the CLI is newer than the API.
+        assert!(is_unrouted(
+            StatusCode::NOT_FOUND,
+            r#"{"detail":"Not Found"}"#
+        ));
+    }
+
+    #[test]
+    fn a_handler_404_is_not_mistaken_for_a_missing_endpoint() {
+        // The endpoint exists and ran; the resource is absent. Telling the
+        // operator to upgrade here would send them down entirely the wrong path.
+        assert!(!is_unrouted(
+            StatusCode::NOT_FOUND,
+            r#"{"detail":"version not found"}"#
+        ));
+        assert!(!is_unrouted(
+            StatusCode::NOT_FOUND,
+            r#"{"detail":"no target named 'prod' in deploy.yaml. Declared: dev"}"#
+        ));
+    }
+
+    #[test]
+    fn other_statuses_are_never_a_skew_signal() {
+        for s in [
+            StatusCode::OK,
+            StatusCode::UNAUTHORIZED,
+            StatusCode::BAD_GATEWAY,
+        ] {
+            assert!(!is_unrouted(s, r#"{"detail":"Not Found"}"#));
+        }
+    }
+
+    #[test]
+    fn a_non_json_body_is_not_a_skew_signal() {
+        // A proxy or ingress can return an HTML 404 that means something else
+        // entirely; guessing "upgrade your platform" from it would be wrong.
+        assert!(!is_unrouted(StatusCode::NOT_FOUND, "<html>404</html>"));
     }
 }


### PR DESCRIPTION
Base `main`. Refs #1063, ADR-0089. **Worth landing before the release** — it changes a class of confusing failure into a clear sentence.

## The failures this fixes

Both of this week's deploy breakages were CLI/platform version skew, and both surfaced as a bare 404:

```
Error: resolving target `prod` failed with 404 Not Found: {"detail":"Not Found"}
Error: rendering declared connectors failed with 404 Not Found: {"detail":"Not Found"}
```

The fix in each case was *"upgrade the platform"* and nothing said so. One cost twenty minutes of log-reading.

## The signal

FastAPI answers an **unrouted path** with exactly `{"detail":"Not Found"}`. A handler that ran and found nothing sets its own detail (`"version not found"`). That difference is the whole thing:

| response | means | told to the operator |
|---|---|---|
| `{"detail":"Not Found"}` | endpoint absent → platform older than CLI | *"upgrade the release, or use a CLI matching it"* |
| `{"detail":"version not found"}` | resource absent | unchanged |

The check lives in `expect_ok`, so **every caller is covered at once** rather than one call site at a time. `--target` gets an extra message on top, because its fix has a second option: drop the flag and pass `--agent`/`--env`/`--slack-channel` directly.

## Deliberately not a version handshake

That would need a version endpoint, a comparison policy, and a rule for what counts as compatible — and it **would not have caught either failure any earlier than this does**. The endpoint's absence *is* the fact worth reporting.

## Tested on the discrimination, not the happy path

The risk isn't failing to detect skew — it's crying skew when something else broke:

- a handler 404 (`"version not found"`) must **not** be read as skew — telling someone to upgrade when they typo'd a version id sends them down entirely the wrong path
- a non-JSON 404 (a proxy or ingress page) is likewise not a skew signal
- non-404 statuses never are

## Verification

```
cargo test               → 0 failed across suites (4 new)
cargo clippy -D warnings → 0 errors
field-parity             → passed
```
