### PR TITLE
connectors.yaml: reference an existing Secret instead of minting one (#1163)

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -960,6 +960,18 @@
             "additionalProperties": true,
             "title": "Mcp Entries",
             "type": "object"
+          },
+          "owned_secret_keys": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Owned Secret Keys",
+            "type": "array"
+          },
+          "owned_secret_name": {
+            "default": "",
+            "title": "Owned Secret Name",
+            "type": "string"
           }
         },
         "title": "ConnectorManifests",

--- a/apps/api/src/curie_api/bundles.py
+++ b/apps/api/src/curie_api/bundles.py
@@ -140,6 +140,22 @@ def render_connector_manifests(
     return objects
 
 
+def owned_secret_keys(connectors: ConnectorsFile) -> list[str]:
+    """Declared secrets whose VALUE the caller must supply (#1163).
+
+    Excludes any that reference a Secret provisioned out of band: resolving
+    those would defeat the purpose, and the caller may well not have access to
+    them -- which is exactly why the reference form exists (ADR-0090).
+    """
+
+    keys: list[str] = []
+    for spec in connectors.connectors.values():
+        for name in spec.resolved_secrets():
+            if name not in keys:
+                keys.append(name)
+    return sorted(keys)
+
+
 def connector_mcp_entries(
     connectors: ConnectorsFile, *, release: str, agent: str, namespace: str
 ) -> dict[str, Any]:

--- a/apps/api/src/curie_api/routers/agents.py
+++ b/apps/api/src/curie_api/routers/agents.py
@@ -277,6 +277,11 @@ async def read_version_connectors(
                 mcp_entries=bundles.connector_mcp_entries(
                     declared, release=release, agent=agent_name, namespace=namespace
                 ),
+                # Which keys the CALLER must resolve a value for. Stated rather
+                # than inferable: a referenced Secret's key renders an identical
+                # secretKeyRef, and resolving it would defeat the point (#1163).
+                owned_secret_name=secret_name,
+                owned_secret_keys=bundles.owned_secret_keys(declared),
             )
 
     return await run_in_threadpool(_render)

--- a/apps/api/src/curie_api/schemas.py
+++ b/apps/api/src/curie_api/schemas.py
@@ -508,6 +508,13 @@ class ConnectorManifests(BaseModel):
     """
 
     manifests: list[dict[str, Any]] = Field(default_factory=list)
+    # The Secret Curie owns for this agent, and the keys the CALLER must
+    # resolve values for. Stated explicitly because the caller cannot infer it
+    # from the manifests: since #1163 a connector may also reference a Secret
+    # provisioned out of band, and those keys must NOT be resolved -- the whole
+    # point is that the deploy path never handles them.
+    owned_secret_name: str = ""
+    owned_secret_keys: list[str] = Field(default_factory=list)
     # name -> the `.mcp.json` entry the agent should use. Derived from the
     # Service in `manifests`, so an author never hand-writes a URL that
     # resolves in one tier and not another.

--- a/apps/api/tests/test_bundle_connectors.py
+++ b/apps/api/tests/test_bundle_connectors.py
@@ -121,3 +121,34 @@ def test_two_agents_sharing_a_release_render_distinct_objects(tmp_path: Path) ->
     dev = {o["metadata"]["name"] for o in _render(root, agent="acme-dev")}
     prod = {o["metadata"]["name"] for o in _render(root, agent="sre-prod")}
     assert not dev & prod, f"agents collide: {dev} vs {prod}"
+
+
+REFERENCED = (
+    "connectors:\n"
+    "  grafana:\n"
+    "    image: grafana/mcp-grafana:0.17.2\n"
+    "    secrets:\n"
+    "      - name: GRAFANA_TOKEN\n"
+    "        from_secret: grafana-mcp\n"
+)
+
+
+def test_a_referenced_secret_is_not_something_the_caller_must_resolve(tmp_path: Path) -> None:
+    # The property ADR-0090 depends on: with every credential referenced, the
+    # deploy path handles none, so a reconciler holding no secrets can apply
+    # this connector.
+    declared = bundles.read_connectors(_bundle(tmp_path, REFERENCED))
+    assert bundles.owned_secret_keys(declared) == []
+
+
+def test_a_literal_secret_still_must_be_resolved(tmp_path: Path) -> None:
+    declared = bundles.read_connectors(_bundle(tmp_path, HOSTED))
+    assert bundles.owned_secret_keys(declared) == ["GRAFANA_TOKEN"]
+
+
+def test_a_referenced_secret_points_outside_curies_own_secret(tmp_path: Path) -> None:
+    dep = next(o for o in _render(_bundle(tmp_path, REFERENCED)) if o["kind"] == "Deployment")
+    env = dep["spec"]["template"]["spec"]["containers"][0]["env"]
+    ref = next(e for e in env if e["name"] == "GRAFANA_TOKEN")["valueFrom"]["secretKeyRef"]
+    assert ref["name"] == "grafana-mcp"
+    assert "value" not in next(e for e in env if e["name"] == "GRAFANA_TOKEN")

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -38,6 +38,14 @@ pub struct ResolvedTarget {
 pub struct ConnectorManifests {
     #[serde(default)]
     pub manifests: Vec<serde_json::Value>,
+    /// The Secret Curie owns, and the keys whose VALUES this caller must
+    /// resolve. Declared by the API rather than inferred from the manifests:
+    /// since #1163 a connector may reference a Secret provisioned out of band,
+    /// and resolving those keys locally would both fail and defeat the point.
+    #[serde(default)]
+    pub owned_secret_name: String,
+    #[serde(default)]
+    pub owned_secret_keys: Vec<String>,
     #[serde(default)]
     pub mcp_entries: std::collections::BTreeMap<String, serde_json::Value>,
 }

--- a/cli/src/connectors.rs
+++ b/cli/src/connectors.rs
@@ -110,44 +110,21 @@ pub fn object_names(manifests: &[Value]) -> Vec<String> {
         .collect()
 }
 
-/// The Secret name and credential keys the rendered Deployments reference.
+/// Keys whose VALUES this command must resolve, and the Secret to put them in.
 ///
-/// Read back off the manifests rather than re-derived from the bundle: the API
-/// decides the Secret's name and which keys a connector needs, so re-deriving
-/// here would be a second copy of that rule, free to drift from the one that
-/// actually rendered the `secretKeyRef`.
-pub fn referenced_secrets(manifests: &[Value]) -> Option<(String, Vec<String>)> {
-    let mut name: Option<String> = None;
-    let mut keys: Vec<String> = Vec::new();
-    for obj in manifests {
-        let containers = obj
-            .pointer("/spec/template/spec/containers")
-            .and_then(|c| c.as_array());
-        for c in containers.into_iter().flatten() {
-            for env in c
-                .get("env")
-                .and_then(|e| e.as_array())
-                .into_iter()
-                .flatten()
-            {
-                let Some(r) = env.pointer("/valueFrom/secretKeyRef") else {
-                    continue;
-                };
-                if let Some(n) = r.get("name").and_then(|n| n.as_str()) {
-                    name.get_or_insert_with(|| n.to_string());
-                }
-                if let Some(k) = r.get("key").and_then(|k| k.as_str()) {
-                    if !keys.iter().any(|e| e == k) {
-                        keys.push(k.to_string());
-                    }
-                }
-            }
-        }
+/// Taken from what the API DECLARED, not inferred from the manifests. Since
+/// #1163 a connector may reference a Secret provisioned out of band, and its
+/// key appears in the rendered `secretKeyRef` exactly like an owned one --
+/// indistinguishable by shape. Inferring would try to resolve a credential
+/// this caller may not have, and by design should not: the whole point of the
+/// reference form is that the deploy path never handles it.
+pub fn owned_secret(name: &str, keys: &[String]) -> Option<(String, Vec<String>)> {
+    if name.is_empty() || keys.is_empty() {
+        return None;
     }
-    name.map(|n| {
-        keys.sort();
-        (n, keys)
-    })
+    let mut keys = keys.to_vec();
+    keys.sort();
+    Some((name.to_string(), keys))
 }
 
 /// The Secret carrying resolved connector credentials.
@@ -283,26 +260,28 @@ mod tests {
     }
 
     #[test]
-    fn secret_refs_are_read_back_off_the_rendered_manifests() {
-        // Re-deriving the Secret's name here would be a second copy of a rule
-        // the API already applied, free to drift from the secretKeyRef that was
-        // actually rendered -- and a mismatch means the pod never starts.
-        let dep = json!({"kind":"Deployment","spec":{"template":{"spec":{"containers":[{
-        "env":[
-            {"name":"GRAFANA_URL","value":"https://g"},
-            {"name":"TOKEN","valueFrom":{"secretKeyRef":{"name":"r-a-connector-secrets","key":"TOKEN"}}},
-            {"name":"OTHER","valueFrom":{"secretKeyRef":{"name":"r-a-connector-secrets","key":"OTHER"}}}
-        ]}]}}}});
-        let (name, keys) = referenced_secrets(&[dep]).unwrap();
-        assert_eq!(name, "r-a-connector-secrets");
-        assert_eq!(keys, vec!["OTHER".to_string(), "TOKEN".to_string()]);
+    fn only_curie_owned_keys_are_resolved_locally() {
+        // Since #1163 a referenced Secret's key appears in the rendered
+        // secretKeyRef exactly like an owned one. Resolving it here would try
+        // to read a credential this caller may not have -- and by design
+        // should not, since the reference form exists so the deploy path never
+        // handles it. The API says which keys are ours; we do not guess.
+        let (name, keys) = owned_secret("curie-owned", &["OWNED".to_string()]).unwrap();
+        assert_eq!(name, "curie-owned");
+        assert_eq!(keys, vec!["OWNED".to_string()]);
     }
 
     #[test]
-    fn a_connector_with_no_secrets_needs_no_secret_object() {
-        let dep = json!({"kind":"Deployment","spec":{"template":{"spec":{"containers":[{
-            "env":[{"name":"GRAFANA_URL","value":"https://g"}]}]}}}});
-        assert!(referenced_secrets(&[dep]).is_none());
+    fn a_connector_whose_secrets_are_all_referenced_needs_no_secret_object() {
+        // Every credential lives in a Secret someone else provisioned, so this
+        // deploy creates none -- which is the property that lets a reconciler
+        // apply the same connector without holding any credential (ADR-0090).
+        assert!(owned_secret("curie-owned", &[]).is_none());
+    }
+
+    #[test]
+    fn a_connector_with_no_secrets_at_all_needs_no_secret_object() {
+        assert!(owned_secret("", &[]).is_none());
     }
 
     #[test]
@@ -450,13 +429,15 @@ fn resolve_secret_values(keys: &[String]) -> Result<std::collections::BTreeMap<S
 pub async fn sync(
     manifests: &[Value],
     mcp_entries: &std::collections::BTreeMap<String, Value>,
+    owned_secret_name: &str,
+    owned_secret_keys: &[String],
     namespace: &str,
     agent_name: &str,
 ) -> Result<ConnectorSync> {
     let ui = crate::ui::ui();
     let mut objects = Vec::new();
 
-    if let Some((secret_name, keys)) = referenced_secrets(manifests) {
+    if let Some((secret_name, keys)) = owned_secret(owned_secret_name, owned_secret_keys) {
         if !keys.is_empty() {
             objects.push(render_secret(
                 &secret_name,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -130,6 +130,8 @@ async fn sync_connectors(
     let synced = curie::connectors::sync(
         &rendered.manifests,
         &rendered.mcp_entries,
+        &rendered.owned_secret_name,
+        &rendered.owned_secret_keys,
         namespace,
         agent_name,
     )

--- a/packages/plugin-format/src/plugin_format/connector_render.py
+++ b/packages/plugin-format/src/plugin_format/connector_render.py
@@ -184,13 +184,40 @@ def render_deployment(
         {"name": k, "value": substitute(v, subs)} for k, v in sorted(spec.env.items())
     ]
     # Declared secrets arrive by reference, never as literals in the manifest.
-    env += [
-        {
-            "name": s,
-            "valueFrom": {"secretKeyRef": {"name": secret_name, "key": s, "optional": False}},
-        }
-        for s in spec.secrets
-    ]
+    # A declared secret points either at the Secret Curie owns for this agent,
+    # or at one provisioned out of band (#1163). Both render the same shape --
+    # a secretKeyRef, never a literal -- so the container cannot tell them
+    # apart and nothing downstream needs to.
+    for declared in spec.secrets:
+        if isinstance(declared, str):
+            env.append(
+                {
+                    "name": declared,
+                    "valueFrom": {
+                        "secretKeyRef": {
+                            "name": secret_name,
+                            "key": declared,
+                            "optional": False,
+                        }
+                    },
+                }
+            )
+        else:
+            env.append(
+                {
+                    "name": declared.name,
+                    "valueFrom": {
+                        "secretKeyRef": {
+                            "name": declared.from_secret,
+                            "key": declared.secret_key(),
+                            # Not optional: a referenced Secret that does not
+                            # exist must stop the pod, not start it without the
+                            # credential and 401 on every call.
+                            "optional": False,
+                        }
+                    },
+                }
+            )
     return {
         "apiVersion": "apps/v1",
         "kind": "Deployment",

--- a/packages/plugin-format/src/plugin_format/connectors.py
+++ b/packages/plugin-format/src/plugin_format/connectors.py
@@ -38,6 +38,28 @@ from pydantic import BaseModel, ConfigDict, Field
 _NAME_MAX = 40
 
 
+class SecretRef(BaseModel):
+    """A credential that already exists in the cluster (#1163).
+
+    Curie renders a ``secretKeyRef`` at it and never reads the value, so the
+    deploy identity does not need access to the credential at all. Rotation
+    stops requiring a deploy: update the Secret, restart the connector.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    # The env var the connector reads.
+    name: str
+    # The Kubernetes Secret holding it, provisioned out of band.
+    from_secret: str
+    # The key within that Secret. Defaults to the env var name, which is the
+    # common case and saves repeating it.
+    key: str | None = None
+
+    def secret_key(self) -> str:
+        return self.key or self.name
+
+
 class ConnectorSpec(BaseModel):
     """One declared connector. Exactly one of ``image`` or ``url``.
 
@@ -76,7 +98,37 @@ class ConnectorSpec(BaseModel):
     headers: dict[str, str] = Field(default_factory=dict)
 
     # -- both --
-    secrets: list[str] = Field(default_factory=list)
+    #
+    # Two forms, and the difference is WHO HOLDS THE CREDENTIAL.
+    #
+    #   secrets: [TOKEN]                      Curie resolves TOKEN at deploy
+    #                                         time and owns the Secret.
+    #   secrets:
+    #     - name: TOKEN                       Curie points at a Secret someone
+    #       from_secret: grafana-mcp          else provisioned and never sees
+    #       key: TOKEN                        the value.
+    #
+    # The second exists because the first forces every deploy identity to be
+    # able to read the credential -- CI, the operator, and anything driving a
+    # deploy. For a shared team token that is backwards, and it is what blocks
+    # an in-cluster reconciler from ever applying a connector (ADR-0090): a
+    # reconciler cannot hold every agent's credentials, but it can reference a
+    # Secret that already exists.
+    secrets: list[str | SecretRef] = Field(default_factory=list)
+
+    def secret_names(self) -> list[str]:
+        """Env var names this connector needs, either form."""
+
+        return [s if isinstance(s, str) else s.name for s in self.secrets]
+
+    def resolved_secrets(self) -> list[str]:
+        """Only the names Curie must resolve a VALUE for.
+
+        A referenced secret is excluded: the whole point is that nothing in the
+        deploy path handles it.
+        """
+
+        return [s for s in self.secrets if isinstance(s, str)]
 
     @property
     def is_hosted(self) -> bool:
@@ -191,6 +243,30 @@ def validate_connectors(data: Any) -> tuple[ConnectorsFile | None, list[tuple[st
                     "connector with `env` and `args` instead",
                 )
             )
+        for declared in spec.secrets:
+            if isinstance(declared, str):
+                continue
+            if not declared.from_secret.strip():
+                errors.append(
+                    (
+                        "connectors.empty_secret_ref",
+                        f"{where}: `{declared.name}` sets an empty `from_secret`. An empty "
+                        "reference renders a secretKeyRef at a Secret named '', which the "
+                        "API server rejects at apply -- long after the deploy looked fine.",
+                    )
+                )
+        seen_secret_names: set[str] = set()
+        for secret_name in spec.secret_names():
+            if secret_name in seen_secret_names:
+                errors.append(
+                    (
+                        "connectors.duplicate_secret",
+                        f"{where}: `{secret_name}` is declared twice. Two env entries with "
+                        "one name means the container silently gets whichever the renderer "
+                        "emitted last -- possibly the wrong Secret entirely.",
+                    )
+                )
+            seen_secret_names.add(secret_name)
         if not (1 <= spec.port <= 65535):
             errors.append(("connectors.bad_port", f"{where}: port {spec.port} is out of range"))
         for text in [*spec.args, *spec.env.values()]:

--- a/packages/plugin-format/tests/test_connector_render.py
+++ b/packages/plugin-format/tests/test_connector_render.py
@@ -315,3 +315,57 @@ def test_the_fallback_never_displaces_the_derived_url_where_curie_hosts() -> Non
     hosted = r.mcp_entry("curie", "acme-dev", "curie", "grafana", spec)
     assert "svc.cluster.local" in hosted["url"]
     assert "8765" not in hosted["url"]
+
+
+# --------------------------------------------------------------------------- #
+# A referenced Secret renders the same shape as an owned one -- #1163
+# --------------------------------------------------------------------------- #
+def test_a_referenced_secret_points_at_the_secret_the_author_named() -> None:
+    from plugin_format.connectors import SecretRef
+
+    spec = ConnectorSpec(image="x:1", secrets=[SecretRef(name="TOKEN", from_secret="grafana-mcp")])
+    dep = next(
+        o
+        for o in r.render("rel", "ag", "ns", "app", "g", spec, "curie-owned")
+        if o["kind"] == "Deployment"
+    )
+    entry = next(
+        e for e in dep["spec"]["template"]["spec"]["containers"][0]["env"] if e["name"] == "TOKEN"
+    )
+    ref = entry["valueFrom"]["secretKeyRef"]
+    assert ref["name"] == "grafana-mcp", "must point at the out-of-band Secret, not Curie's"
+    assert ref["key"] == "TOKEN"
+    assert "value" not in entry
+
+
+def test_owned_and_referenced_secrets_are_indistinguishable_to_the_container() -> None:
+    # Both render a secretKeyRef and never a literal. The container cannot tell
+    # which is which, so nothing downstream needs to care.
+    from plugin_format.connectors import SecretRef
+
+    spec = ConnectorSpec(image="x:1", secrets=["OWNED", SecretRef(name="REFD", from_secret="ext")])
+    dep = next(
+        o
+        for o in r.render("rel", "ag", "ns", "app", "g", spec, "curie-owned")
+        if o["kind"] == "Deployment"
+    )
+    env = {e["name"]: e for e in dep["spec"]["template"]["spec"]["containers"][0]["env"]}
+    assert env["OWNED"]["valueFrom"]["secretKeyRef"]["name"] == "curie-owned"
+    assert env["REFD"]["valueFrom"]["secretKeyRef"]["name"] == "ext"
+    for name in ("OWNED", "REFD"):
+        assert "value" not in env[name], f"{name} must never be inlined"
+
+
+def test_a_referenced_secret_is_not_optional() -> None:
+    # A missing referenced Secret must stop the pod, not start it credential-less
+    # and 401 on every call -- which reads as "the tool is broken".
+    from plugin_format.connectors import SecretRef
+
+    spec = ConnectorSpec(image="x:1", secrets=[SecretRef(name="T", from_secret="ext")])
+    dep = next(
+        o for o in r.render("rel", "ag", "ns", "app", "g", spec, "s") if o["kind"] == "Deployment"
+    )
+    entry = next(
+        e for e in dep["spec"]["template"]["spec"]["containers"][0]["env"] if e["name"] == "T"
+    )
+    assert entry["valueFrom"]["secretKeyRef"]["optional"] is False

--- a/packages/plugin-format/tests/test_connectors.py
+++ b/packages/plugin-format/tests/test_connectors.py
@@ -256,3 +256,71 @@ def test_unhosted_url_on_a_remote_connector_is_rejected() -> None:
     assert "connectors.remote_has_unhosted_url" in _codes(
         {"connectors": {"g": {"url": "https://y/mcp", "unhosted_url": "http://z/mcp"}}}
     )
+
+
+# --------------------------------------------------------------------------- #
+# Referencing a Secret Curie did not create -- #1163
+# --------------------------------------------------------------------------- #
+def test_a_connector_may_reference_a_secret_provisioned_out_of_band() -> None:
+    parsed, errors = validate_connectors(
+        {
+            "connectors": {
+                "grafana": {
+                    "image": "x:1",
+                    "secrets": [{"name": "TOKEN", "from_secret": "grafana-mcp"}],
+                }
+            }
+        }
+    )
+    assert errors == []
+    assert parsed is not None
+    spec = parsed.connectors["grafana"]
+    assert spec.secret_names() == ["TOKEN"]
+    # The property the whole change exists for: nothing in the deploy path
+    # needs to hold this credential, which is what lets a reconciler apply a
+    # connector without holding every agent's secrets (ADR-0090).
+    assert spec.resolved_secrets() == []
+
+
+def test_the_literal_form_still_needs_resolving() -> None:
+    parsed, _ = validate_connectors({"connectors": {"g": {"image": "x:1", "secrets": ["TOKEN"]}}})
+    assert parsed is not None
+    assert parsed.connectors["g"].resolved_secrets() == ["TOKEN"]
+
+
+def test_both_forms_can_be_mixed_on_one_connector() -> None:
+    parsed, errors = validate_connectors(
+        {
+            "connectors": {
+                "g": {"image": "x:1", "secrets": ["OWNED", {"name": "REFD", "from_secret": "s"}]}
+            }
+        }
+    )
+    assert errors == []
+    assert parsed is not None
+    assert parsed.connectors["g"].secret_names() == ["OWNED", "REFD"]
+    assert parsed.connectors["g"].resolved_secrets() == ["OWNED"]
+
+
+def test_an_empty_from_secret_is_rejected() -> None:
+    # It renders a secretKeyRef at a Secret named '', which the API server
+    # rejects at APPLY -- long after the deploy looked like it worked.
+    assert "connectors.empty_secret_ref" in _codes(
+        {"connectors": {"g": {"image": "x:1", "secrets": [{"name": "T", "from_secret": ""}]}}}
+    )
+
+
+def test_the_same_env_name_declared_twice_is_rejected() -> None:
+    # Two env entries with one name means the container silently gets whichever
+    # the renderer emitted last -- possibly pointed at the wrong Secret.
+    assert "connectors.duplicate_secret" in _codes(
+        {"connectors": {"g": {"image": "x:1", "secrets": ["T", {"name": "T", "from_secret": "s"}]}}}
+    )
+
+
+def test_key_defaults_to_the_env_var_name() -> None:
+    parsed, _ = validate_connectors(
+        {"connectors": {"g": {"image": "x:1", "secrets": [{"name": "T", "from_secret": "s"}]}}}
+    )
+    assert parsed is not None
+    assert parsed.connectors["g"].secrets[0].secret_key() == "T"  # type: ignore[union-attr]


### PR DESCRIPTION
Fixes #1163. **Prerequisite for [ADR-0090](docs/adr/0090-a-reconciler-applies-connectors-so-agent-repos-need-no-cli.md).** Base `main`.

`secrets:` had one meaning — Curie resolves the value and owns the Secret — which forces **every deploy identity to be able to read the credential**. Backwards for a team token, and it's what stops an in-cluster reconciler from ever applying a connector: a reconciler can't hold every agent's secrets, but it *can* point at a Secret that already exists.

```yaml
secrets:
  - SOME_TOKEN                       # today: Curie resolves and owns it
  - name: GRAFANA_TOKEN              # new: point at an existing Secret
    from_secret: grafana-mcp
```

Both render the **same shape** — a `secretKeyRef`, never a literal — so the container can't tell them apart.

## A real bug this introduced, and the fix

The CLI inferred which keys to resolve by reading `secretKeyRef`s back off the rendered manifests: take the first Secret name, resolve every key against it. With both forms mixed that tries to resolve a *referenced* credential locally — failing, and defeating the purpose.

**Inference cannot work here.** The two forms render identically, by design.

So the API now **declares** `owned_secret_name` and `owned_secret_keys`, and the CLI resolves exactly those. The API knows which is which because it holds the parsed declaration; the CLI never could.

That's the property ADR-0090 needs:

```
referenced-only connector → owned_secret_keys == []  → deploy path handles no credential
```

## Validation for the two new silent failures

| mistake | without the check |
|---|---|
| empty `from_secret` | renders a reference to a Secret named `''` — API server rejects at **apply**, long after the deploy looked fine |
| same env name twice | container silently gets whichever the renderer emitted last, possibly the wrong Secret |

And a referenced Secret is **not optional**: a missing one must stop the pod, not start it credential-less and 401 on every call — which reads as "the tool is broken".

## Verification

```
plugin-format + api    → 417 passed
cargo test             → 0 failed across suites
mypy                   → no issues, 168 files
ruff check             → All checks passed
check-contracts.sh     → all committed artifacts current
field-parity           → passed
openapi                → regenerated
```

## Next

The reconciler itself (ADR-0090). With this merged, a connector whose credentials are all referenced can be applied by something that holds no credentials at all — which is the whole unlock.
