### PR TITLE
Connector reconcile: the plan, before anything applies it (ADR-0090)

### DIFF
--- a/apps/worker/src/curie_worker/connector_reconcile.py
+++ b/apps/worker/src/curie_worker/connector_reconcile.py
@@ -1,0 +1,161 @@
+"""Decide what a connector reconcile should change (ADR-0090).
+
+The pure half. Given what an agent's in-force version DECLARES and what the
+cluster currently HAS, this computes a plan: which objects to apply, which to
+delete, and which are already correct. It touches no cluster and no database,
+so the decision that can delete a running connector is testable without either.
+
+That split is the same one ADR-0087 drew between rendering and applying, for
+the same reason: the dangerous step is the decision, not the API call. A prune
+that selects one object too many takes down a live agent's tools, and a plan is
+something you can assert against exhaustively where a `kubectl delete` is not.
+
+Two properties this must never violate, both learned the hard way on the CLI
+path (#1063):
+
+- **Never touch an object Curie did not create.** Ownership is the
+  ``curie.dev/connector-owner`` label. sre-bot ran a hand-written connector
+  beside a Curie-managed one through its whole migration; an unlabelled object
+  is someone else's and is invisible here.
+- **Never prune across agents.** Ownership is scoped to the agent name, not to
+  "is a connector". Two agents in one release each declare `grafana`, and one
+  removing it must not delete the other's (#1116).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+# Set by whoever created the object, naming the agent that declared it. The CLI
+# applier stamps the same label, so an object created by one path and
+# reconciled by the other is not a special case (ADR-0090).
+OWNER_LABEL = "curie.dev/connector-owner"
+
+
+def owner_of(obj: dict[str, Any]) -> str | None:
+    """The agent that declared this object, or None if Curie did not create it."""
+
+    labels = obj.get("metadata", {}).get("labels") or {}
+    value = labels.get(OWNER_LABEL)
+    return value if isinstance(value, str) and value else None
+
+
+def identity(obj: dict[str, Any]) -> tuple[str, str]:
+    """``(kind, name)`` -- what makes two objects the same object."""
+
+    return (str(obj.get("kind", "")), str(obj.get("metadata", {}).get("name", "")))
+
+
+@dataclass(frozen=True)
+class ReconcilePlan:
+    """What converging this agent's connectors requires."""
+
+    # Objects to create or update: everything declared that is missing or
+    # drifted. An object that already matches is NOT here -- re-applying it
+    # every loop would be a hot loop with extra steps.
+    apply: list[dict[str, Any]] = field(default_factory=list)
+    # Objects Curie owns for this agent that are no longer declared.
+    delete: list[tuple[str, str]] = field(default_factory=list)
+    # Live objects that already match. Reported, not acted on -- a reconciler
+    # that logs "converged 4 objects" every loop is noise nobody reads.
+    unchanged: list[tuple[str, str]] = field(default_factory=list)
+    # Live objects whose spec drifted from what is declared. A subset of
+    # `apply`, surfaced separately because correcting drift is the one thing
+    # here that overrides a human's `kubectl edit` and must be visible.
+    drifted: list[tuple[str, str]] = field(default_factory=list)
+
+    @property
+    def is_noop(self) -> bool:
+        return not self.apply and not self.delete
+
+
+def plan(
+    desired: list[dict[str, Any]],
+    live: list[dict[str, Any]],
+    *,
+    agent: str,
+) -> ReconcilePlan:
+    """Compute the change set for one agent's connectors.
+
+    ``desired`` is what the API rendered for the in-force version, already
+    owner-labelled. ``live`` is every object currently in the namespace that
+    might be relevant -- this filters it rather than trusting the caller's
+    query, because a mis-scoped list here deletes someone else's connector.
+    """
+
+    owned_live = {identity(o): o for o in live if owner_of(o) == agent}
+    desired_by_id = {identity(o): o for o in desired}
+
+    to_apply: list[dict[str, Any]] = []
+    unchanged: list[tuple[str, str]] = []
+    drifted: list[tuple[str, str]] = []
+
+    for obj_id, want in desired_by_id.items():
+        have = owned_live.get(obj_id)
+        if have is None:
+            to_apply.append(want)
+        elif _differs(want, have):
+            to_apply.append(want)
+            drifted.append(obj_id)
+        else:
+            unchanged.append(obj_id)
+
+    # Only ever objects this agent owns AND no longer declares. Both halves
+    # matter: the ownership filter keeps another agent's `grafana` safe, and
+    # the declaration check is what makes removing a connector from
+    # connectors.yaml actually remove it.
+    to_delete = sorted(obj_id for obj_id in owned_live if obj_id not in desired_by_id)
+
+    return ReconcilePlan(
+        apply=to_apply,
+        delete=to_delete,
+        unchanged=sorted(unchanged),
+        drifted=sorted(drifted),
+    )
+
+
+def _differs(want: dict[str, Any], have: dict[str, Any]) -> bool:
+    """Has the live object drifted from what is declared?
+
+    Compares only what Curie sets. A live object carries fields the cluster
+    added -- resourceVersion, uid, creationTimestamp, status, and defaulted
+    spec fields -- and treating those as drift would make every loop rewrite
+    every object forever, which is indistinguishable from a hot loop.
+    """
+
+    return _curie_owned_view(want) != _curie_owned_view(have)
+
+
+# Metadata the API server owns. Present on a live object, absent on a rendered
+# one, and never a reason to re-apply.
+_SERVER_METADATA = frozenset(
+    {
+        "annotations",
+        "creationTimestamp",
+        "generation",
+        "managedFields",
+        "namespace",
+        "ownerReferences",
+        "resourceVersion",
+        "selfLink",
+        "uid",
+    }
+)
+
+
+def _curie_owned_view(obj: dict[str, Any]) -> dict[str, Any]:
+    metadata = {k: v for k, v in (obj.get("metadata") or {}).items() if k not in _SERVER_METADATA}
+    return {
+        "kind": obj.get("kind"),
+        "apiVersion": obj.get("apiVersion"),
+        "metadata": metadata,
+        "spec": obj.get("spec"),
+        # A Secret carries no spec; its payload is data/stringData. Compared so
+        # a rotated credential is picked up, but note the live object returns
+        # base64 `data` where the rendered one sets `stringData` -- the caller
+        # must normalize before comparing or every loop sees drift.
+        "data": obj.get("data"),
+        "stringData": obj.get("stringData"),
+        "type": obj.get("type"),
+    }

--- a/apps/worker/tests/reconcile/test_connector_plan.py
+++ b/apps/worker/tests/reconcile/test_connector_plan.py
@@ -1,0 +1,139 @@
+"""Deciding what a connector reconcile changes (ADR-0090, #1184).
+
+The decision is the dangerous part, not the API call: a plan that names one
+object too many takes down a live agent's tools. These assert the two
+properties that keep that from happening, and the drift-comparison behaviour
+that keeps the loop from rewriting the world forever.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from curie_worker.connector_reconcile import OWNER_LABEL, plan
+
+
+def obj(kind: str, name: str, owner: str | None = None, spec: Any = None) -> dict[str, Any]:
+    labels = {OWNER_LABEL: owner} if owner else {}
+    return {
+        "apiVersion": "v1",
+        "kind": kind,
+        "metadata": {"name": name, "labels": labels},
+        "spec": spec if spec is not None else {"replicas": 1},
+    }
+
+
+def live(o: dict[str, Any], **server_fields: Any) -> dict[str, Any]:
+    """The same object as the cluster would return it."""
+
+    out = {k: v for k, v in o.items()}
+    out["metadata"] = {
+        **o["metadata"],
+        "uid": "abc-123",
+        "resourceVersion": "4711",
+        "creationTimestamp": "2026-07-31T00:00:00Z",
+        "namespace": "curie",
+        **server_fields,
+    }
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# Never touch what Curie did not create
+# --------------------------------------------------------------------------- #
+def test_an_unlabelled_object_is_invisible() -> None:
+    # sre-bot ran a hand-written connector beside a Curie-managed one through
+    # its entire migration. Deleting it would have taken the bot's only working
+    # Grafana path with it.
+    handwritten = obj("Deployment", "grafana-mcp")  # no owner label
+    p = plan(desired=[], live=[handwritten], agent="sre-bot")
+    assert p.delete == []
+    assert p.is_noop
+
+
+def test_another_agents_connector_is_never_pruned() -> None:
+    # Two agents in one release each declare `grafana` (#1116). One removing it
+    # must not delete the other's.
+    mine = obj("Deployment", "rel-sre-bot-mcp-grafana", owner="sre-bot")
+    theirs = obj("Deployment", "rel-sre-dev-mcp-grafana", owner="sre-dev")
+    p = plan(desired=[], live=[live(mine), live(theirs)], agent="sre-bot")
+    assert p.delete == [("Deployment", "rel-sre-bot-mcp-grafana")]
+
+
+# --------------------------------------------------------------------------- #
+# Converge
+# --------------------------------------------------------------------------- #
+def test_a_declared_object_that_does_not_exist_is_applied() -> None:
+    want = obj("Service", "svc", owner="a")
+    p = plan(desired=[want], live=[], agent="a")
+    assert p.apply == [want]
+    assert p.delete == []
+
+
+def test_an_undeclared_owned_object_is_deleted() -> None:
+    # Removing a connector from connectors.yaml must remove it. Without this a
+    # pod keeps running with a credential mounted and nothing referencing it.
+    p = plan(desired=[], live=[live(obj("Service", "svc", owner="a"))], agent="a")
+    assert p.delete == [("Service", "svc")]
+
+
+def test_an_object_that_already_matches_is_left_alone() -> None:
+    want = obj("Service", "svc", owner="a")
+    p = plan(desired=[want], live=[live(want)], agent="a")
+    assert p.apply == []
+    assert p.unchanged == [("Service", "svc")]
+    assert p.is_noop
+
+
+# --------------------------------------------------------------------------- #
+# Drift: the behaviour that overrides a human
+# --------------------------------------------------------------------------- #
+def test_a_drifted_object_is_reapplied_and_reported_as_drift() -> None:
+    # This is the one action that reverts someone's `kubectl edit`. Correct for
+    # a declared system, and it must be visible rather than silent.
+    want = obj("Deployment", "dep", owner="a", spec={"replicas": 1})
+    edited = live(obj("Deployment", "dep", owner="a", spec={"replicas": 5}))
+    p = plan(desired=[want], live=[edited], agent="a")
+    assert p.apply == [want]
+    assert p.drifted == [("Deployment", "dep")]
+
+
+def test_server_added_metadata_is_not_drift() -> None:
+    # uid, resourceVersion, creationTimestamp and friends exist on every live
+    # object and on no rendered one. Counting them as drift would rewrite every
+    # object every loop -- a hot loop wearing a reconciler's clothes.
+    want = obj("Service", "svc", owner="a")
+    p = plan(desired=[want], live=[live(want, managedFields=[{"manager": "kubectl"}])], agent="a")
+    assert p.apply == []
+    assert p.drifted == []
+
+
+def test_a_status_block_is_not_drift() -> None:
+    want = obj("Deployment", "dep", owner="a")
+    running = live(want)
+    running["status"] = {"readyReplicas": 1}
+    p = plan(desired=[want], live=[running], agent="a")
+    assert p.is_noop
+
+
+# --------------------------------------------------------------------------- #
+# The whole set at once
+# --------------------------------------------------------------------------- #
+def test_a_mixed_state_converges_in_one_plan() -> None:
+    keep = obj("Service", "keep", owner="a")
+    drift = obj("Deployment", "drift", owner="a", spec={"replicas": 1})
+    p = plan(
+        desired=[keep, drift, obj("NetworkPolicy", "new", owner="a")],
+        live=[
+            live(keep),
+            live(obj("Deployment", "drift", owner="a", spec={"replicas": 9})),
+            live(obj("Secret", "stale", owner="a")),
+            live(obj("Deployment", "someone-elses", owner="other")),
+            obj("Service", "handwritten"),
+        ],
+        agent="a",
+    )
+    assert [o["metadata"]["name"] for o in p.apply] == ["drift", "new"]
+    assert p.delete == [("Secret", "stale")]
+    assert p.unchanged == [("Service", "keep")]
+    assert p.drifted == [("Deployment", "drift")]


### PR DESCRIPTION
First piece of the reconciler [ADR-0090](docs/adr/0090-a-reconciler-applies-connectors-so-agent-repos-need-no-cli.md) authorizes. Refs #1184. Base `main`.

Given what an agent's in-force version **declares** and what the cluster **has**, compute the change set. No cluster, no database, no API calls.

## Why the decision lands before the applier

Same split ADR-0087 drew between rendering and applying, for the same reason: **the dangerous step is the decision, not the API call.** A plan that names one object too many takes a live agent's tools down — and a plan can be asserted against exhaustively where a `kubectl delete` cannot.

## Two properties it must never violate

Both already paid for on the CLI path:

**An unlabelled object is invisible.** acme-bot ran a hand-written connector beside a Curie-managed one through its whole migration. Deleting it would have removed the bot's only working Grafana path.

**Ownership is scoped to the agent**, not to "is a connector". Two agents in one release each declare `grafana` (#1116); one removing it must not delete the other's.

## Drift, and the hot loop it would otherwise cause

Comparison ignores what the API server owns — `uid`, `resourceVersion`, `creationTimestamp`, `managedFields`, `status`. Counting those as drift would rewrite every object every loop: a hot loop wearing a reconciler's clothes.

A genuine spec change *is* re-applied, and reported separately as `drifted` — because reverting someone's `kubectl edit` is the one action here that **overrides a human** and must be visible rather than silent.

## A hazard noted in place rather than discovered later

A live Secret returns base64 `data` where a rendered one sets `stringData`. The caller must normalize or every loop sees drift. That's written where the comparison happens, not left for whoever hits it.

## Verification

```
apps/worker/tests/reconcile → 9 passed
mypy                        → no issues, 169 files
ruff check                  → All checks passed
```

Tests cover the two safety properties, the three convergence cases, drift vs. server-metadata, and one mixed-state case that exercises all of it at once.

## Scope

**Nothing calls this yet.** The applier, its RBAC, and the loop are the next change — landing the decision separately is what makes it reviewable.