### PR TITLE
Carry out a connector reconcile plan

### DIFF
--- a/apps/worker/src/curie_worker/connector_apply.py
+++ b/apps/worker/src/curie_worker/connector_apply.py
@@ -1,0 +1,128 @@
+"""Execute a connector reconcile plan against the cluster (ADR-0090).
+
+The half that mutates. ``connector_reconcile`` decides; this carries the
+decision out. Written against a protocol seam so the logic that can delete a
+live connector is testable with an in-memory fake, the same discipline the
+sandbox substrate uses for the K8s control plane.
+
+Two orderings and one refusal are load-bearing:
+
+**Apply before delete.** A failure part-way through leaves EXTRA objects rather
+than missing ones. Extra objects are inert -- an orphaned Service nobody
+references -- while a missing Deployment is an agent whose tools stopped
+working. Deleting first would make a transient API error during apply into an
+outage.
+
+**Delete one at a time, continuing past failures.** A single object that will
+not delete (finalizer, RBAC gap) must not strand the rest as orphans. Every
+failure is reported; none aborts the sweep.
+
+**Refuse to act without an owner.** Every object this touches carries
+``curie.dev/connector-owner``. The plan already filters on it, but the applier
+checks again before deleting, because a plan built from a mis-scoped list is
+exactly the bug that would delete someone else's connector and the check is
+one line.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+from .connector_reconcile import OWNER_LABEL, ReconcilePlan, identity, owner_of
+
+logger = logging.getLogger(__name__)
+
+
+class ConnectorClient(Protocol):
+    """The cluster operations a reconcile needs, and no more.
+
+    Deliberately four verbs. A wider seam invites the reconciler to grow
+    cluster access it does not need, and the RBAC that backs this is scoped to
+    exactly the object kinds a connector consists of.
+    """
+
+    def list_owned(self, namespace: str, owner: str) -> list[dict[str, Any]]:
+        """Every connector object labelled for this owner."""
+
+    def apply(self, namespace: str, obj: dict[str, Any]) -> None:
+        """Create or update one object."""
+
+    def delete(self, namespace: str, kind: str, name: str) -> None:
+        """Remove one object. Missing is success, not an error."""
+
+
+@dataclass
+class ApplyReport:
+    """What actually happened, as opposed to what was planned."""
+
+    applied: list[tuple[str, str]] = field(default_factory=list)
+    deleted: list[tuple[str, str]] = field(default_factory=list)
+    # (kind, name, error). Collected rather than raised so one bad object does
+    # not strand the rest.
+    failures: list[tuple[str, str, str]] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return not self.failures
+
+
+def execute(
+    client: ConnectorClient,
+    plan: ReconcilePlan,
+    *,
+    namespace: str,
+    agent: str,
+) -> ApplyReport:
+    """Carry out a plan. Returns what happened; raises only on programmer error."""
+
+    report = ApplyReport()
+
+    # Drift correction is the one action here that overrides a human's
+    # `kubectl edit`. Correct for a declared system, and it must be visible --
+    # a reconciler that silently reverts an operator is indistinguishable from
+    # a cluster that ignores them.
+    for obj_id in plan.drifted:
+        logger.info(
+            "connector drift corrected agent=%s kind=%s name=%s", agent, obj_id[0], obj_id[1]
+        )
+
+    for obj in plan.apply:
+        kind, name = identity(obj)
+        if owner_of(obj) != agent:
+            # A rendered object reaching here without this agent's owner label
+            # is a bug upstream, not a cluster condition. Refuse rather than
+            # write an object nothing can later prune.
+            report.failures.append(
+                (kind, name, f"refusing to apply: missing or wrong {OWNER_LABEL}")
+            )
+            continue
+        try:
+            client.apply(namespace, obj)
+            report.applied.append((kind, name))
+        except Exception as exc:  # cluster errors are data here, not control flow
+            report.failures.append((kind, name, str(exc)))
+
+    # Only after every apply has been attempted. A failure above leaves extra
+    # objects, which are inert; deleting first would turn the same failure into
+    # an agent with no connector.
+    if report.failures:
+        logger.warning(
+            "connector apply had %d failure(s) for agent=%s; skipping prune so a "
+            "transient error cannot remove a working connector",
+            len(report.failures),
+            agent,
+        )
+        return report
+
+    for kind, name in plan.delete:
+        try:
+            client.delete(namespace, kind, name)
+            report.deleted.append((kind, name))
+            logger.info("connector removed agent=%s kind=%s name=%s", agent, kind, name)
+        except Exception as exc:
+            # Keep going: one undeletable object must not strand the others.
+            report.failures.append((kind, name, str(exc)))
+
+    return report

--- a/apps/worker/tests/reconcile/test_connector_apply.py
+++ b/apps/worker/tests/reconcile/test_connector_apply.py
@@ -1,0 +1,132 @@
+"""Carrying out a reconcile plan (ADR-0090, #1184).
+
+These target the orderings, not the happy path. The happy path is one line;
+the orderings are what decide whether a transient cluster error degrades into
+an outage.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from curie_worker.connector_apply import ApplyReport, ConnectorClient, execute
+from curie_worker.connector_reconcile import OWNER_LABEL, ReconcilePlan
+
+
+def obj(kind: str, name: str, owner: str | None = "a") -> dict[str, Any]:
+    labels = {OWNER_LABEL: owner} if owner else {}
+    return {"kind": kind, "metadata": {"name": name, "labels": labels}}
+
+
+class FakeClient:
+    """In-memory model of the cluster. Fails whatever it is told to."""
+
+    def __init__(self, fail_apply: set[str] | None = None, fail_delete: set[str] | None = None):
+        self.applied: list[str] = []
+        self.deleted: list[str] = []
+        self.order: list[str] = []
+        self._fail_apply = fail_apply or set()
+        self._fail_delete = fail_delete or set()
+
+    def list_owned(self, namespace: str, owner: str) -> list[dict[str, Any]]:
+        return []
+
+    def apply(self, namespace: str, o: dict[str, Any]) -> None:
+        name = o["metadata"]["name"]
+        if name in self._fail_apply:
+            raise RuntimeError(f"apply {name} exploded")
+        self.applied.append(name)
+        self.order.append(f"apply:{name}")
+
+    def delete(self, namespace: str, kind: str, name: str) -> None:
+        if name in self._fail_delete:
+            raise RuntimeError(f"delete {name} exploded")
+        self.deleted.append(name)
+        self.order.append(f"delete:{name}")
+
+
+def test_it_satisfies_the_protocol() -> None:
+    client: ConnectorClient = FakeClient()
+    assert client is not None
+
+
+# --------------------------------------------------------------------------- #
+# Apply strictly before delete
+# --------------------------------------------------------------------------- #
+def test_applies_before_deleting() -> None:
+    # Extra objects are inert; missing ones are a broken agent. Ordering is the
+    # difference between those two outcomes when something fails.
+    c = FakeClient()
+    plan = ReconcilePlan(apply=[obj("Service", "new")], delete=[("Secret", "stale")])
+    execute(c, plan, namespace="ns", agent="a")
+    assert c.order == ["apply:new", "delete:stale"]
+
+
+def test_a_failed_apply_cancels_the_prune_entirely() -> None:
+    # The failure this prevents: a transient API error while applying, followed
+    # by a prune that removes the working connector the apply failed to
+    # replace. The agent would lose its tools because of a blip.
+    c = FakeClient(fail_apply={"new"})
+    plan = ReconcilePlan(apply=[obj("Service", "new")], delete=[("Secret", "stale")])
+    report = execute(c, plan, namespace="ns", agent="a")
+    assert c.deleted == [], "nothing may be pruned after a failed apply"
+    assert not report.ok
+    assert report.failures[0][0:2] == ("Service", "new")
+
+
+# --------------------------------------------------------------------------- #
+# One bad object must not strand the rest
+# --------------------------------------------------------------------------- #
+def test_a_failed_delete_does_not_abandon_the_others() -> None:
+    # A finalizer or an RBAC gap on one object would otherwise leave every
+    # later object orphaned -- a pod still running with a credential mounted.
+    c = FakeClient(fail_delete={"stuck"})
+    plan = ReconcilePlan(delete=[("Secret", "stuck"), ("Service", "next")])
+    report = execute(c, plan, namespace="ns", agent="a")
+    assert c.deleted == ["next"]
+    assert [f[1] for f in report.failures] == ["stuck"]
+
+
+def test_every_apply_is_attempted_even_after_one_fails() -> None:
+    c = FakeClient(fail_apply={"bad"})
+    plan = ReconcilePlan(apply=[obj("Service", "bad"), obj("Service", "good")])
+    report = execute(c, plan, namespace="ns", agent="a")
+    assert c.applied == ["good"]
+    assert len(report.failures) == 1
+
+
+# --------------------------------------------------------------------------- #
+# Refuse to write what cannot later be pruned
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("owner", [None, "someone-else"])
+def test_refuses_to_apply_an_object_it_could_not_own(owner: str | None) -> None:
+    # An object without this agent's owner label is invisible to every future
+    # prune. Writing one creates something Curie can never clean up.
+    c = FakeClient()
+    report = execute(
+        c, ReconcilePlan(apply=[obj("Service", "orphan", owner=owner)]), namespace="ns", agent="a"
+    )
+    assert c.applied == []
+    assert OWNER_LABEL in report.failures[0][2]
+
+
+# --------------------------------------------------------------------------- #
+# Nothing to do
+# --------------------------------------------------------------------------- #
+def test_an_empty_plan_touches_nothing() -> None:
+    c = FakeClient()
+    report = execute(c, ReconcilePlan(), namespace="ns", agent="a")
+    assert c.order == []
+    assert report.ok
+    assert report == ApplyReport()
+
+
+def test_drift_correction_is_logged_because_it_overrides_a_human(caplog) -> None:
+    # The one action here that reverts someone's kubectl edit. Silent would be
+    # indistinguishable from a cluster ignoring them.
+    c = FakeClient()
+    plan = ReconcilePlan(apply=[obj("Deployment", "dep")], drifted=[("Deployment", "dep")])
+    with caplog.at_level("INFO"):
+        execute(c, plan, namespace="ns", agent="a")
+    assert any("drift corrected" in r.getMessage() for r in caplog.records)


### PR DESCRIPTION
The mutating half of [ADR-0090](docs/adr/0090-a-reconciler-applies-connectors-so-agent-repos-need-no-cli.md)'s reconciler. `connector_reconcile` (#1187) decides what should change; this carries the decision out.

It sits behind a four-verb `ConnectorClient` protocol, so the logic that can delete a live connector is testable with an in-memory fake — the same seam `sandbox/k8s.py` already uses for the K8s control plane.

## What is load-bearing

Two orderings and one refusal. Each has a test named for the failure it prevents, because the happy path here is one line and the orderings are what decide whether a transient cluster error degrades into an outage.

**Apply strictly before delete.** A failure part-way through leaves *extra* objects rather than *missing* ones. An orphaned Service nobody references is inert; a missing Deployment is an agent whose tools stopped working. Any apply failure cancels the prune entirely — otherwise a blip during apply, followed by a prune, removes the working connector the apply failed to replace.

**Delete one at a time, continuing past failures.** A single object that will not delete (finalizer, RBAC gap) must not strand the rest as orphans — a pod still running with a credential mounted.

**Refuse to apply an object without this agent's owner label.** Such an object is invisible to every future prune, so writing one creates something Curie can never clean up. The plan already filters on ownership; this checks again, because a plan built from a mis-scoped list is exactly the bug that deletes someone else's connector (#1116) and the check is one line.

Drift correction is logged. It is the one action here that overrides a human's `kubectl edit`, and a reconciler that silently reverts an operator is indistinguishable from a cluster that ignores them.

## Scope

Unreferenced until the real Kubernetes `ConnectorClient` and its RBAC land — deliberately, so the code that holds cluster-write authority gets reviewed as its own change rather than as a passenger on the loop wiring.

```
uv run pytest apps/worker/tests/reconcile -q   # 18 passed
```

Refs #1184