### PR TITLE
Stop the reconciler rewriting every object on every pass

### DIFF
--- a/apps/worker/src/curie_worker/connector_reconcile.py
+++ b/apps/worker/src/curie_worker/connector_reconcile.py
@@ -24,6 +24,9 @@ path (#1063):
 
 from __future__ import annotations
 
+import base64
+import hashlib
+import json
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -31,6 +34,46 @@ from typing import Any
 # applier stamps the same label, so an object created by one path and
 # reconciled by the other is not a special case (ADR-0090).
 OWNER_LABEL = "curie.dev/connector-owner"
+
+# A digest of what Curie declared, stamped on every object it applies. Lets a
+# later pass ask "is this still what we declared?" without having to
+# reconstruct which fields the API server defaulted.
+HASH_ANNOTATION = "curie.dev/connector-hash"
+
+
+def _hash_of(obj: dict[str, Any]) -> str:
+    """Digest of a rendered object, excluding the annotation carrying it."""
+
+    stripped = dict(obj)
+    metadata = {k: v for k, v in (stripped.get("metadata") or {}).items()}
+    annotations = {k: v for k, v in (metadata.get("annotations") or {}).items()}
+    annotations.pop(HASH_ANNOTATION, None)
+    if annotations:
+        metadata["annotations"] = annotations
+    else:
+        metadata.pop("annotations", None)
+    stripped["metadata"] = metadata
+    canonical = json.dumps(stripped, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(canonical.encode()).hexdigest()[:32]
+
+
+def _live_hash(obj: dict[str, Any]) -> str | None:
+    annotations = obj.get("metadata", {}).get("annotations") or {}
+    value = annotations.get(HASH_ANNOTATION)
+    return value if isinstance(value, str) else None
+
+
+def stamp_hash(obj: dict[str, Any]) -> dict[str, Any]:
+    """A copy of ``obj`` carrying its own digest, ready to apply."""
+
+    stamped = dict(obj)
+    metadata = dict(stamped.get("metadata") or {})
+    metadata["annotations"] = {
+        **(metadata.get("annotations") or {}),
+        HASH_ANNOTATION: _hash_of(obj),
+    }
+    stamped["metadata"] = metadata
+    return stamped
 
 
 def owner_of(obj: dict[str, Any]) -> str | None:
@@ -94,9 +137,12 @@ def plan(
     for obj_id, want in desired_by_id.items():
         have = owned_live.get(obj_id)
         if have is None:
-            to_apply.append(want)
+            to_apply.append(stamp_hash(want))
         elif _differs(want, have):
-            to_apply.append(want)
+            # Stamped on the way out, not by the caller: an object applied
+            # without its digest is one the next pass cannot recognize as
+            # converged, which is the hot loop this exists to prevent.
+            to_apply.append(stamp_hash(want))
             drifted.append(obj_id)
         else:
             unchanged.append(obj_id)
@@ -118,13 +164,64 @@ def plan(
 def _differs(want: dict[str, Any], have: dict[str, Any]) -> bool:
     """Has the live object drifted from what is declared?
 
-    Compares only what Curie sets. A live object carries fields the cluster
-    added -- resourceVersion, uid, creationTimestamp, status, and defaulted
-    spec fields -- and treating those as drift would make every loop rewrite
-    every object forever, which is indistinguishable from a hot loop.
+    Two independent questions, because they catch different things and neither
+    subsumes the other:
+
+    1. **Did our declaration change?** The hash annotation answers it exactly,
+       including a field REMOVED from connectors.yaml -- something a
+       does-live-contain-declared check cannot see, since a shrunk declaration
+       is still contained by the larger live object. An object created by the
+       CLI applier carries no hash, reads as drift, and is adopted on the first
+       pass.
+    2. **Did someone change the object underneath us?** A `kubectl edit` of the
+       image leaves our declaration untouched, so the hash still matches. Only
+       comparing values catches it.
+
+    The value comparison is containment, not equality. A live object carries
+    fields the API server defaulted -- `clusterIP`, `ipFamilies`,
+    `progressDeadlineSeconds`, a `protocol: TCP` inserted into a port we
+    declared without one -- and treating those as drift makes every pass rewrite
+    every object forever. That is not hypothetical: plain equality reports a
+    Service and a Deployment as drifted the instant after a successful apply.
+    (A NetworkPolicy happens to acquire no defaults, so it compares equal either
+    way -- which is exactly why it is the wrong object to test this on.)
     """
 
-    return _curie_owned_view(want) != _curie_owned_view(have)
+    if _hash_of(want) != _live_hash(have):
+        return True
+    return not _contains(_curie_owned_view(want), _curie_owned_view(have))
+
+
+def _contains(want: Any, have: Any) -> bool:
+    """Is everything ``want`` declares present and equal in ``have``?
+
+    Keys the server added are ignored; keys we declare must match. Lists compare
+    element-wise and by length, so dropping one entry from an env list or a
+    port list still reads as drift.
+    """
+
+    if isinstance(want, dict):
+        if not isinstance(have, dict):
+            return False
+        for key, value in want.items():
+            if key not in have:
+                # The API server does not persist an empty list or map, so a
+                # rendered `args: []` comes back absent. Declaring nothing and
+                # having nothing is the same state; calling it drift re-applies
+                # the object on every pass forever.
+                if value is None or (isinstance(value, list | dict) and not value):
+                    continue
+                return False
+            if not _contains(value, have[key]):
+                return False
+        return True
+    if isinstance(want, list):
+        return (
+            isinstance(have, list)
+            and len(want) == len(have)
+            and all(_contains(w, h) for w, h in zip(want, have, strict=True))
+        )
+    return bool(want == have)
 
 
 # Metadata the API server owns. Present on a live object, absent on a rendered
@@ -151,11 +248,31 @@ def _curie_owned_view(obj: dict[str, Any]) -> dict[str, Any]:
         "apiVersion": obj.get("apiVersion"),
         "metadata": metadata,
         "spec": obj.get("spec"),
-        # A Secret carries no spec; its payload is data/stringData. Compared so
-        # a rotated credential is picked up, but note the live object returns
-        # base64 `data` where the rendered one sets `stringData` -- the caller
-        # must normalize before comparing or every loop sees drift.
-        "data": obj.get("data"),
-        "stringData": obj.get("stringData"),
+        "secret": _secret_payload(obj),
         "type": obj.get("type"),
     }
+
+
+def _secret_payload(obj: dict[str, Any]) -> dict[str, str] | None:
+    """A Secret's payload in one form, whichever form it arrived in.
+
+    A Secret carries no spec. We render `stringData`; the API server returns
+    the same bytes base64-encoded under `data`. Comparing the two field names
+    directly means a Secret is drifted on every single pass -- so decode to a
+    single representation and compare that. Values are only ever compared here,
+    never logged.
+    """
+
+    if not (obj.get("data") or obj.get("stringData")):
+        return None
+    payload = {str(k): str(v) for k, v in (obj.get("stringData") or {}).items()}
+    for key, encoded in (obj.get("data") or {}).items():
+        if key in payload:
+            continue
+        try:
+            payload[str(key)] = base64.b64decode(str(encoded)).decode()
+        except (ValueError, UnicodeDecodeError):
+            # A binary or malformed value. Compare the encoded form rather than
+            # guessing -- being wrong here re-applies a credential needlessly.
+            payload[str(key)] = str(encoded)
+    return payload

--- a/apps/worker/tests/reconcile/fixtures/live_connector_objects.json
+++ b/apps/worker/tests/reconcile/fixtures/live_connector_objects.json
@@ -1,0 +1,338 @@
+{
+ "desired": [
+  {
+   "apiVersion": "v1",
+   "kind": "Service",
+   "metadata": {
+    "labels": {
+     "app.kubernetes.io/name": "curie-driftcheck-mcp-example",
+     "app.kubernetes.io/part-of": "curie",
+     "curie.dev/connector-owner": "driftcheck"
+    },
+    "name": "curie-driftcheck-mcp-example"
+   },
+   "spec": {
+    "ports": [
+     {
+      "name": "http",
+      "port": 8080,
+      "targetPort": "http"
+     }
+    ],
+    "selector": {
+     "app.kubernetes.io/name": "curie-driftcheck-mcp-example",
+     "app.kubernetes.io/part-of": "curie"
+    },
+    "type": "ClusterIP"
+   }
+  },
+  {
+   "apiVersion": "apps/v1",
+   "kind": "Deployment",
+   "metadata": {
+    "labels": {
+     "app.kubernetes.io/name": "curie-driftcheck-mcp-example",
+     "app.kubernetes.io/part-of": "curie",
+     "curie.dev/connector-owner": "driftcheck"
+    },
+    "name": "curie-driftcheck-mcp-example"
+   },
+   "spec": {
+    "replicas": 1,
+    "selector": {
+     "matchLabels": {
+      "app.kubernetes.io/name": "curie-driftcheck-mcp-example",
+      "app.kubernetes.io/part-of": "curie"
+     }
+    },
+    "template": {
+     "metadata": {
+      "labels": {
+       "app.kubernetes.io/name": "curie-driftcheck-mcp-example",
+       "app.kubernetes.io/part-of": "curie"
+      }
+     },
+     "spec": {
+      "containers": [
+       {
+        "args": [],
+        "env": [],
+        "image": "ghcr.io/example/mcp-example:1",
+        "name": "server",
+        "ports": [
+         {
+          "containerPort": 8080,
+          "name": "http"
+         }
+        ],
+        "resources": {
+         "limits": {
+          "cpu": "500m",
+          "memory": "256Mi"
+         },
+         "requests": {
+          "cpu": "10m",
+          "memory": "64Mi"
+         }
+        },
+        "securityContext": {
+         "allowPrivilegeEscalation": false,
+         "capabilities": {
+          "drop": [
+           "ALL"
+          ]
+         },
+         "readOnlyRootFilesystem": true
+        }
+       }
+      ],
+      "securityContext": {
+       "runAsNonRoot": true,
+       "runAsUser": 65532,
+       "seccompProfile": {
+        "type": "RuntimeDefault"
+       }
+      }
+     }
+    }
+   }
+  },
+  {
+   "apiVersion": "networking.k8s.io/v1",
+   "kind": "NetworkPolicy",
+   "metadata": {
+    "labels": {
+     "app.kubernetes.io/name": "curie-driftcheck-mcp-example",
+     "app.kubernetes.io/part-of": "curie",
+     "curie.dev/connector-owner": "driftcheck"
+    },
+    "name": "curie-driftcheck-mcp-example-allow"
+   },
+   "spec": {
+    "egress": [
+     {
+      "ports": [
+       {
+        "port": 8080,
+        "protocol": "TCP"
+       }
+      ],
+      "to": [
+       {
+        "podSelector": {
+         "matchLabels": {
+          "app.kubernetes.io/name": "curie-driftcheck-mcp-example",
+          "app.kubernetes.io/part-of": "curie"
+         }
+        }
+       }
+      ]
+     }
+    ],
+    "podSelector": {
+     "matchLabels": {
+      "app.kubernetes.io/component": "runner-sandbox",
+      "app.kubernetes.io/instance": "curie",
+      "app.kubernetes.io/name": "driftcheck-app"
+     }
+    },
+    "policyTypes": [
+     "Egress"
+    ]
+   }
+  }
+ ],
+ "live": [
+  {
+   "apiVersion": "v1",
+   "kind": "Service",
+   "metadata": {
+    "annotations": {
+     "curie.dev/connector-hash": "f9f081cc3902a6eb115bc7884a7dc132"
+    },
+    "creationTimestamp": "2026-08-01T00:09:26Z",
+    "labels": {
+     "app.kubernetes.io/name": "curie-driftcheck-mcp-example",
+     "app.kubernetes.io/part-of": "curie",
+     "curie.dev/connector-owner": "driftcheck"
+    },
+    "name": "curie-driftcheck-mcp-example",
+    "namespace": "drifttest",
+    "resourceVersion": "28158",
+    "uid": "fa848359-10cc-4ebe-be3e-43395593fcf6"
+   },
+   "spec": {
+    "clusterIP": "10.105.53.61",
+    "clusterIPs": [
+     "10.105.53.61"
+    ],
+    "internalTrafficPolicy": "Cluster",
+    "ipFamilies": [
+     "IPv4"
+    ],
+    "ipFamilyPolicy": "SingleStack",
+    "ports": [
+     {
+      "name": "http",
+      "port": 8080,
+      "protocol": "TCP",
+      "targetPort": "http"
+     }
+    ],
+    "selector": {
+     "app.kubernetes.io/name": "curie-driftcheck-mcp-example",
+     "app.kubernetes.io/part-of": "curie"
+    },
+    "sessionAffinity": "None",
+    "type": "ClusterIP"
+   }
+  },
+  {
+   "apiVersion": "apps/v1",
+   "kind": "Deployment",
+   "metadata": {
+    "annotations": {
+     "curie.dev/connector-hash": "db1fe5b8eff3f9c28d0e4bd966aaa009",
+     "deployment.kubernetes.io/revision": "4"
+    },
+    "creationTimestamp": "2026-08-01T00:09:26Z",
+    "generation": 5,
+    "labels": {
+     "app.kubernetes.io/name": "curie-driftcheck-mcp-example",
+     "app.kubernetes.io/part-of": "curie",
+     "curie.dev/connector-owner": "driftcheck"
+    },
+    "name": "curie-driftcheck-mcp-example",
+    "namespace": "drifttest",
+    "resourceVersion": "28414",
+    "uid": "62f65448-e678-45b0-8ae7-f35b66c26894"
+   },
+   "spec": {
+    "progressDeadlineSeconds": 600,
+    "replicas": 1,
+    "revisionHistoryLimit": 10,
+    "selector": {
+     "matchLabels": {
+      "app.kubernetes.io/name": "curie-driftcheck-mcp-example",
+      "app.kubernetes.io/part-of": "curie"
+     }
+    },
+    "strategy": {
+     "rollingUpdate": {
+      "maxSurge": "25%",
+      "maxUnavailable": "25%"
+     },
+     "type": "RollingUpdate"
+    },
+    "template": {
+     "metadata": {
+      "labels": {
+       "app.kubernetes.io/name": "curie-driftcheck-mcp-example",
+       "app.kubernetes.io/part-of": "curie"
+      }
+     },
+     "spec": {
+      "containers": [
+       {
+        "image": "ghcr.io/example/mcp-example:1",
+        "imagePullPolicy": "IfNotPresent",
+        "name": "server",
+        "ports": [
+         {
+          "containerPort": 8080,
+          "name": "http",
+          "protocol": "TCP"
+         }
+        ],
+        "resources": {
+         "limits": {
+          "cpu": "500m",
+          "memory": "256Mi"
+         },
+         "requests": {
+          "cpu": "10m",
+          "memory": "64Mi"
+         }
+        },
+        "securityContext": {
+         "allowPrivilegeEscalation": false,
+         "capabilities": {
+          "drop": [
+           "ALL"
+          ]
+         },
+         "readOnlyRootFilesystem": true
+        },
+        "terminationMessagePath": "/dev/termination-log",
+        "terminationMessagePolicy": "File"
+       }
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
+      "schedulerName": "default-scheduler",
+      "securityContext": {
+       "runAsNonRoot": true,
+       "runAsUser": 65532,
+       "seccompProfile": {
+        "type": "RuntimeDefault"
+       }
+      },
+      "terminationGracePeriodSeconds": 30
+     }
+    }
+   }
+  },
+  {
+   "apiVersion": "networking.k8s.io/v1",
+   "kind": "NetworkPolicy",
+   "metadata": {
+    "annotations": {
+     "curie.dev/connector-hash": "dabeae3d8b689a0edc2233177e6bbbc3"
+    },
+    "creationTimestamp": "2026-08-01T00:09:20Z",
+    "generation": 1,
+    "labels": {
+     "app.kubernetes.io/name": "curie-driftcheck-mcp-example",
+     "app.kubernetes.io/part-of": "curie",
+     "curie.dev/connector-owner": "driftcheck"
+    },
+    "name": "curie-driftcheck-mcp-example-allow",
+    "namespace": "drifttest",
+    "resourceVersion": "28162",
+    "uid": "a2b3d54a-adb1-4ec3-8734-6d9ea6240260"
+   },
+   "spec": {
+    "egress": [
+     {
+      "ports": [
+       {
+        "port": 8080,
+        "protocol": "TCP"
+       }
+      ],
+      "to": [
+       {
+        "podSelector": {
+         "matchLabels": {
+          "app.kubernetes.io/name": "curie-driftcheck-mcp-example",
+          "app.kubernetes.io/part-of": "curie"
+         }
+        }
+       }
+      ]
+     }
+    ],
+    "podSelector": {
+     "matchLabels": {
+      "app.kubernetes.io/component": "runner-sandbox",
+      "app.kubernetes.io/instance": "curie",
+      "app.kubernetes.io/name": "driftcheck-app"
+     }
+    },
+    "policyTypes": [
+     "Egress"
+    ]
+   }
+  }
+ ]
+}

--- a/apps/worker/tests/reconcile/test_connector_drift.py
+++ b/apps/worker/tests/reconcile/test_connector_drift.py
@@ -1,0 +1,231 @@
+"""Drift detection against what an API server really returns (ADR-0090, #1184).
+
+Every case here runs against `fixtures/live_connector_objects.json`, captured
+from a real cluster by applying the renderer's own output and reading it back.
+That matters more than it sounds: the bug these tests exist for is invisible to
+hand-written fixtures, because it is caused by fields nobody writes down --
+`clusterIP`, `ipFamilies`, `progressDeadlineSeconds`, a `protocol: TCP` the
+server inserts into a port declared without one, and an `args: []` the server
+drops rather than stores.
+
+Plain equality reported the captured Service and Deployment as drifted the
+instant after a successful apply. The NetworkPolicy compared equal, because it
+acquires no defaults -- so a suite written around a NetworkPolicy would have
+passed while the reconciler rewrote every Deployment in the cluster forever.
+"""
+
+from __future__ import annotations
+
+import base64
+import copy
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from curie_worker.connector_reconcile import (
+    HASH_ANNOTATION,
+    OWNER_LABEL,
+    _contains,
+    _curie_owned_view,
+    plan,
+    stamp_hash,
+)
+
+AGENT = "driftcheck"
+FIXTURE = Path(__file__).parent / "fixtures" / "live_connector_objects.json"
+
+
+@pytest.fixture
+def captured() -> dict[str, list[dict[str, Any]]]:
+    return json.loads(FIXTURE.read_text())
+
+
+@pytest.fixture
+def desired(captured: dict[str, list[dict[str, Any]]]) -> list[dict[str, Any]]:
+    return copy.deepcopy(captured["desired"])
+
+
+@pytest.fixture
+def live(captured: dict[str, list[dict[str, Any]]]) -> list[dict[str, Any]]:
+    return copy.deepcopy(captured["live"])
+
+
+def one(objs: list[dict[str, Any]], kind: str) -> dict[str, Any]:
+    return next(o for o in objs if o["kind"] == kind)
+
+
+# --------------------------------------------------------------------------- #
+# The hot loop
+# --------------------------------------------------------------------------- #
+def test_a_freshly_applied_object_set_is_already_converged(desired, live) -> None:
+    # The whole point. If this fails the reconciler rewrites every object on
+    # every pass and logs "drift corrected" forever.
+    assert plan(desired, live, agent=AGENT).is_noop
+
+
+@pytest.mark.parametrize("kind", ["Service", "Deployment", "NetworkPolicy"])
+def test_no_single_kind_reports_drift_on_its_own(desired, live, kind) -> None:
+    # Parametrized per kind because the kinds fail differently: Service picks up
+    # clusterIP and ipFamilies, Deployment picks up strategy and
+    # progressDeadlineSeconds, NetworkPolicy picks up nothing at all.
+    assert plan([one(desired, kind)], [one(live, kind)], agent=AGENT).is_noop
+
+
+def test_repeated_passes_stay_converged(desired, live) -> None:
+    for _ in range(3):
+        assert plan(desired, live, agent=AGENT).is_noop
+
+
+def test_plain_equality_would_have_missed_this(desired, live) -> None:
+    # A guard on the guard: if the captured fixture ever stops containing
+    # server-defaulted fields, the tests above would pass for the wrong reason
+    # and silently stop protecting anything.
+    naive = [
+        k
+        for k in ("Service", "Deployment")
+        if _curie_owned_view(one(desired, k)) == _curie_owned_view(one(live, k))
+    ]
+    assert not naive, f"fixture no longer carries server defaults for {naive}"
+
+
+def test_an_empty_collection_is_not_drift(desired, live) -> None:
+    # The renderer emits `args: []`; the API server does not persist it. Absent
+    # and declared-empty are the same state.
+    dep = one(desired, "Deployment")
+    container = dep["spec"]["template"]["spec"]["containers"][0]
+    assert container.get("args") == [], "fixture no longer exercises the empty-list case"
+    assert "args" not in one(live, "Deployment")["spec"]["template"]["spec"]["containers"][0]
+    assert plan([dep], [one(live, "Deployment")], agent=AGENT).is_noop
+
+
+# --------------------------------------------------------------------------- #
+# What must still be caught
+# --------------------------------------------------------------------------- #
+def test_a_human_edit_to_a_declared_field_is_drift(desired, live) -> None:
+    # `kubectl set image` leaves our declaration untouched, so the hash still
+    # matches. Only comparing values catches this one.
+    tampered = one(live, "Deployment")
+    tampered["spec"]["template"]["spec"]["containers"][0]["image"] = "ghcr.io/example/tampered:9"
+    assert plan(desired, live, agent=AGENT).drifted == [
+        ("Deployment", tampered["metadata"]["name"])
+    ]
+
+
+def test_a_field_removed_from_the_declaration_is_drift(desired, live) -> None:
+    # The case containment cannot see: a shrunk declaration is still *contained*
+    # by the larger live object. `hostAliases` is not a hypothetical -- a
+    # connector silently missing it is healthy in `kubectl get pods` and 403s
+    # every call (#1156).
+    dep, live_dep = one(desired, "Deployment"), one(live, "Deployment")
+    # Yesterday's declaration had hostAliases and was applied. Today's does not.
+    # The live object therefore carries BOTH the field and yesterday's digest --
+    # getting that second part right is what makes this test mean anything.
+    previously = copy.deepcopy(dep)
+    previously["spec"]["template"]["spec"]["hostAliases"] = [
+        {"ip": "10.0.0.9", "hostnames": ["example.invalid"]}
+    ]
+    live_dep["spec"]["template"]["spec"]["hostAliases"] = previously["spec"]["template"]["spec"][
+        "hostAliases"
+    ]
+    live_dep["metadata"]["annotations"][HASH_ANNOTATION] = stamp_hash(previously)["metadata"][
+        "annotations"
+    ][HASH_ANNOTATION]
+
+    assert _contains(_curie_owned_view(dep), _curie_owned_view(live_dep)), (
+        "containment alone should NOT see this -- that is why the hash exists"
+    )
+    assert plan([dep], [live_dep], agent=AGENT).drifted == [("Deployment", dep["metadata"]["name"])]
+
+
+def test_dropping_one_env_entry_is_drift(desired, live) -> None:
+    live_dep = one(live, "Deployment")
+    env = live_dep["spec"]["template"]["spec"]["containers"][0].setdefault("env", [])
+    env.append({"name": "SNUCK_IN", "value": "1"})
+    assert plan(desired, [live_dep], agent=AGENT).drifted
+
+
+# --------------------------------------------------------------------------- #
+# Secrets, where the two sides do not even use the same field name
+# --------------------------------------------------------------------------- #
+def secret(value: str) -> dict[str, Any]:
+    return {
+        "apiVersion": "v1",
+        "kind": "Secret",
+        "type": "Opaque",
+        "metadata": {"name": "creds", "labels": {OWNER_LABEL: AGENT}},
+        "stringData": {"GRAFANA_TOKEN": value},
+    }
+
+
+def as_stored(obj: dict[str, Any]) -> dict[str, Any]:
+    """A Secret as the API server returns it: `stringData` in, `data` out."""
+
+    stored = stamp_hash(obj)
+    stored["data"] = {
+        k: base64.b64encode(v.encode()).decode() for k, v in stored.pop("stringData").items()
+    }
+    return stored
+
+
+def test_a_secret_is_not_drifted_just_for_coming_back_encoded() -> None:
+    # We write `stringData`; the server returns the same bytes base64 under
+    # `data`. Comparing the field names directly means every pass rewrites every
+    # credential -- verified against a real API server, not assumed.
+    want = secret("not-a-real-token-just-a-fixture")
+    assert plan([want], [as_stored(want)], agent=AGENT).is_noop
+
+
+def test_a_rotated_credential_is_drift() -> None:
+    stored = as_stored(secret("not-a-real-token-just-a-fixture"))
+    assert plan([secret("rotated-fixture-value")], [stored], agent=AGENT).drifted == [
+        ("Secret", "creds")
+    ]
+
+
+def test_an_undecodable_secret_value_does_not_crash_the_pass() -> None:
+    # One malformed Secret must not take down reconciliation for every agent.
+    stored = as_stored(secret("x"))
+    stored["data"]["GRAFANA_TOKEN"] = "!!!not-base64!!!"
+    assert plan([secret("x")], [stored], agent=AGENT).drifted == [("Secret", "creds")]
+
+
+# --------------------------------------------------------------------------- #
+# The stamp itself
+# --------------------------------------------------------------------------- #
+def test_planned_objects_carry_their_digest(desired) -> None:
+    # An object applied without its digest is one the next pass cannot recognize
+    # as converged -- the hot loop, reintroduced.
+    for obj in plan(desired, [], agent=AGENT).apply:
+        assert obj["metadata"]["annotations"][HASH_ANNOTATION]
+
+
+def test_stamping_is_idempotent(desired) -> None:
+    once = stamp_hash(one(desired, "Service"))
+    assert stamp_hash(once) == once
+
+
+def test_stamping_does_not_mutate_its_input(desired) -> None:
+    dep = one(desired, "Deployment")
+    before = copy.deepcopy(dep)
+    stamp_hash(dep)
+    assert dep == before
+
+
+def test_an_object_the_cli_created_is_adopted_not_ignored(desired, live) -> None:
+    # The CLI applier stamps an owner label but no digest. The reconciler should
+    # take it over on the first pass rather than treat it as foreign.
+    live_svc = one(live, "Service")
+    del live_svc["metadata"]["annotations"][HASH_ANNOTATION]
+    result = plan([one(desired, "Service")], [live_svc], agent=AGENT)
+    assert result.drifted == [("Service", live_svc["metadata"]["name"])]
+
+
+def test_ownership_still_gates_everything(desired, live) -> None:
+    # Unchanged from #1187, asserted here because the hash must not become a
+    # second, weaker way to claim an object.
+    for obj in live:
+        obj["metadata"]["labels"][OWNER_LABEL] = "some-other-agent"
+    result = plan(desired, live, agent=AGENT)
+    assert result.delete == [], "another agent's objects are not ours to prune"
+    assert len(result.apply) == len(desired)

--- a/apps/worker/tests/reconcile/test_connector_plan.py
+++ b/apps/worker/tests/reconcile/test_connector_plan.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from curie_worker.connector_reconcile import OWNER_LABEL, plan
+from curie_worker.connector_reconcile import OWNER_LABEL, plan, stamp_hash
 
 
 def obj(kind: str, name: str, owner: str | None = None, spec: Any = None) -> dict[str, Any]:
@@ -24,11 +24,16 @@ def obj(kind: str, name: str, owner: str | None = None, spec: Any = None) -> dic
 
 
 def live(o: dict[str, Any], **server_fields: Any) -> dict[str, Any]:
-    """The same object as the cluster would return it."""
+    """The same object as the cluster would return it after Curie applied it.
 
-    out = {k: v for k, v in o.items()}
+    Carries the digest, because everything the applier writes is stamped. An
+    object WITHOUT one is a different case -- something the CLI applier created
+    -- and reads as drift so the reconciler adopts it.
+    """
+
+    out = stamp_hash(o)
     out["metadata"] = {
-        **o["metadata"],
+        **out["metadata"],
         "uid": "abc-123",
         "resourceVersion": "4711",
         "creationTimestamp": "2026-07-31T00:00:00Z",
@@ -66,7 +71,7 @@ def test_another_agents_connector_is_never_pruned() -> None:
 def test_a_declared_object_that_does_not_exist_is_applied() -> None:
     want = obj("Service", "svc", owner="a")
     p = plan(desired=[want], live=[], agent="a")
-    assert p.apply == [want]
+    assert p.apply == [stamp_hash(want)]
     assert p.delete == []
 
 
@@ -94,7 +99,7 @@ def test_a_drifted_object_is_reapplied_and_reported_as_drift() -> None:
     want = obj("Deployment", "dep", owner="a", spec={"replicas": 1})
     edited = live(obj("Deployment", "dep", owner="a", spec={"replicas": 5}))
     p = plan(desired=[want], live=[edited], agent="a")
-    assert p.apply == [want]
+    assert p.apply == [stamp_hash(want)]
     assert p.drifted == [("Deployment", "dep")]
 
 


### PR DESCRIPTION
A bug in the drift check merged in #1187, found by running it against a real API server rather than by reading it.

## The bug

`_differs` compared a rendered object to a live one with plain equality. Applying the renderer's own output to a cluster and reading it back, **both the Service and the Deployment report as drifted the instant after a successful apply** — from fields nobody wrote down:

```
Service        differs=True
       spec.clusterIP: declared=None  live='10.105.53.61'
       spec.ipFamilies: declared=None live=['IPv4']
       spec.ports: declared=[{'name':'http','port':8080,'targetPort':'http'}]
                        live=[{... 'protocol': 'TCP' ...}]        # server-inserted
Deployment     differs=True
       spec.progressDeadlineSeconds: declared=None live=600
       spec.strategy: declared=None live={'rollingUpdate': {...}}
       spec.template.spec.containers[0].args   # declared [], server stores nothing
NetworkPolicy  differs=False
```

Every pass would re-apply every object and log `drift corrected` forever.

Note the NetworkPolicy. It acquires no defaults and compares equal either way — **a test suite written around a NetworkPolicy would have passed** while the reconciler churned every Deployment in the cluster.

## The fix

Drift becomes two independent questions. Neither subsumes the other, and I verified both on a live cluster:

**Did our declaration change?** A `curie.dev/connector-hash` annotation, stamped on everything the plan applies. This catches a field *removed* from `connectors.yaml` — which containment cannot see, because a shrunk declaration is still contained by the larger live object:

```
live has hostAliases: True
containment alone says converged: True     # <- the gap
with the hash, removal is caught: [('Deployment', 'curie-driftcheck-mcp-example')]
```

`hostAliases` is not a hypothetical here: a connector silently missing it is healthy in `kubectl get pods` and 403s every call (#1156).

**Did someone change the object underneath us?** `kubectl set image` leaves our declaration untouched, so the hash still matches — only comparing values catches it. That comparison is *containment*, not equality, so server defaults are not drift. A declared empty list is treated as satisfied by absence, since the server does not persist one.

**Secrets** are normalized rather than left to the caller as #1187's docstring did. We render `stringData`; the server returns the same bytes base64 under `data`. Comparing field names means rewriting every credential on every pass.

## Verification

Against a real cluster, the loop now converges and stays converged, while still catching what it should:

```
pass 1  apply=[] unchanged=3 noop=True
pass 2  apply=[] unchanged=3 noop=True
pass 3  apply=[] unchanged=3 noop=True
tampered image detected: ['Deployment']
connector removed from the declaration -> delete: [('NetworkPolicy', ...)]
secret: live stores base64 `data` | converged: True | rotation detected: [...]
```

Tests run against `fixtures/live_connector_objects.json`, captured from that cluster by applying the renderer's output and reading it back — hand-written fixtures cannot reproduce this bug, because it is caused by fields nobody writes down. `test_plain_equality_would_have_missed_this` guards the fixture against ever losing that property and passing for the wrong reason.

An object created by the CLI applier carries an owner label but no digest, so it reads as drift once and is adopted rather than treated as foreign.

Independent of #1189 — touches different files, merges in either order.

```
uv run pytest apps/worker/tests/reconcile -q   # 27 passed
```

Refs #1184