### PR TITLE
Give the connector reconciler a real cluster client and its RBAC

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -123,6 +123,16 @@ jobs:
           set -euo pipefail
           bash charts/curie/ci/connector-secrets-assertions.sh
 
+      # Prove the connector reconciler's RBAC (ADR-0090, #1184): absent when the
+      # reconciler is off, and when on, exactly {create,list,patch,delete} on
+      # exactly the four kinds the client handles. `create` is load-bearing --
+      # a server-side apply of a missing object is authorized as a create, so
+      # dropping it breaks first-run while leaving updates working.
+      - name: helm render assertions (connector reconciler RBAC)
+        run: |
+          set -euo pipefail
+          bash charts/curie/ci/connector-reconciler-rbac-assertions.sh
+
       # Prove every container in the untrusted sandbox pod renders the identical
       # Rail 3 hardened securityContext from the shared helper (issue #493), so a
       # helper edit that weakens the lockdown -- or a container that skips it --

--- a/apps/worker/src/curie_worker/connector_k8s.py
+++ b/apps/worker/src/curie_worker/connector_k8s.py
@@ -1,0 +1,131 @@
+"""The `ConnectorClient` against a real cluster (ADR-0090).
+
+Four object kinds, three verbs, one namespace. Everything Kubernetes-shaped in
+the connector reconciler stops here; `connector_reconcile` and
+`connector_apply` never import this module, which is what lets the dangerous
+half be tested without a cluster.
+
+**Writes are server-side applies.** Not create-then-replace-on-409, which is
+where the obvious implementation goes wrong: a rendered Service declares no
+`clusterIP`, and replacing a live Service without one is rejected outright
+(`spec.clusterIP: Invalid value: "": field is immutable`). Server-side apply
+also removes a field we previously set and no longer declare, which a merge
+patch cannot express -- so dropping `hostAliases` from connectors.yaml actually
+drops it from the pod, rather than leaving it in place forever.
+
+**`force=True` is deliberate.** It means a field a human took ownership of with
+`kubectl edit` comes back to us. That IS the drift correction ADR-0090 asks
+for; without it, an edited field stays edited and the reconciler reports
+converged while the cluster disagrees with the declaration.
+
+**Reads go out as raw JSON, not typed models.** The rest of the reconciler
+compares against what the API rendered, which is camelCase; the generated
+models would hand back snake_case attributes and quietly compare unequal on
+every field. Asking for the wire format is what keeps the two halves speaking
+the same language.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from kubernetes import client as k8s_client
+from kubernetes import config as k8s_config
+
+from .connector_reconcile import OWNER_LABEL
+
+# Identifies this writer to the API server's field-ownership tracking. A stable
+# name matters: change it and the server treats every field as newly claimed by
+# a stranger, leaving the old manager's entries behind forever.
+FIELD_MANAGER = "curie-connector-reconciler"
+
+# The only kinds a connector is made of, and the only kinds the Role grants.
+# Adding one here without adding it to the chart's RBAC produces a reconciler
+# that silently fails to prune -- so they are listed in one place each and
+# asserted against each other in the chart tests.
+_KINDS: dict[str, tuple[type[Any], str, str]] = {
+    "Deployment": (k8s_client.AppsV1Api, "deployment", "apps/v1"),
+    "Service": (k8s_client.CoreV1Api, "service", "v1"),
+    "Secret": (k8s_client.CoreV1Api, "secret", "v1"),
+    "NetworkPolicy": (k8s_client.NetworkingV1Api, "network_policy", "networking.k8s.io/v1"),
+}
+
+CONNECTOR_KINDS = tuple(_KINDS)
+
+
+class UnsupportedKind(ValueError):
+    """A plan named an object kind connectors are not made of."""
+
+
+class KubernetesConnectorClient:
+    """ConnectorClient against a real cluster (in-cluster or kubeconfig auth)."""
+
+    def __init__(self, *, kubeconfig: str | None = None) -> None:
+        try:
+            k8s_config.load_incluster_config()
+        except k8s_config.ConfigException:
+            k8s_config.load_kube_config(config_file=kubeconfig)
+        self._apis: dict[str, Any] = {}
+
+    def _api(self, kind: str) -> tuple[Any, str]:
+        if kind not in _KINDS:
+            raise UnsupportedKind(f"{kind} is not a connector object kind")
+        api_cls, suffix, _ = _KINDS[kind]
+        if kind not in self._apis:
+            self._apis[kind] = api_cls()
+        return self._apis[kind], suffix
+
+    # -- reads ---------------------------------------------------------------
+
+    def list_owned(self, namespace: str, owner: str) -> list[dict[str, Any]]:
+        """Every connector object in the namespace labelled for this agent.
+
+        The label selector is the ownership boundary, and it is applied by the
+        API server rather than by us: a client-side filter over a wider list is
+        a filter that can be forgotten, and forgetting it here prunes another
+        agent's connectors (#1116).
+        """
+
+        found: list[dict[str, Any]] = []
+        for kind in _KINDS:
+            api, suffix = self._api(kind)
+            response = getattr(api, f"list_namespaced_{suffix}")(
+                namespace,
+                label_selector=f"{OWNER_LABEL}={owner}",
+                _preload_content=False,
+            )
+            for item in json.loads(response.data).get("items", []):
+                # Items inside a List carry no `kind` or `apiVersion` of their
+                # own -- the server states them once on the envelope. The plan
+                # identifies objects by (kind, name), so an unstamped item is an
+                # object with an empty kind that matches nothing and gets
+                # planned for deletion.
+                item["kind"] = kind
+                item["apiVersion"] = _KINDS[kind][2]
+                found.append(item)
+        return found
+
+    # -- writes --------------------------------------------------------------
+
+    def apply(self, namespace: str, obj: dict[str, Any]) -> None:
+        kind = str(obj.get("kind", ""))
+        api, suffix = self._api(kind)
+        getattr(api, f"patch_namespaced_{suffix}")(
+            obj["metadata"]["name"],
+            namespace,
+            obj,
+            field_manager=FIELD_MANAGER,
+            force=True,
+            _content_type="application/apply-patch+yaml",
+            _preload_content=False,
+        )
+
+    def delete(self, namespace: str, kind: str, name: str) -> None:
+        api, suffix = self._api(kind)
+        try:
+            getattr(api, f"delete_namespaced_{suffix}")(name, namespace, _preload_content=False)
+        except k8s_client.ApiException as exc:
+            # Already gone is the state we wanted. Anything else is real.
+            if exc.status != 404:
+                raise

--- a/apps/worker/tests/reconcile/test_e2e_connector_cluster.py
+++ b/apps/worker/tests/reconcile/test_e2e_connector_cluster.py
@@ -1,0 +1,201 @@
+"""The connector reconciler against a real cluster (ADR-0090, #1184).
+
+Gated: runs only with ``CURIE_CONNECTOR_E2E=1`` and a reachable cluster, the
+same shape as ``sandbox/test_e2e_k8scratch.py``. Everything else in this
+directory runs against a fake, which is right for the decision logic and
+useless for the questions here -- whether a server-side apply of a Service
+without a clusterIP is accepted, whether items in a List carry a `kind`,
+whether a Secret survives the stringData/data round trip. A fake answers all
+three however it was written to.
+
+Creates and destroys its own namespace, so it collides with nothing.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import uuid
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+from curie_worker.connector_apply import execute
+from curie_worker.connector_k8s import KubernetesConnectorClient
+from curie_worker.connector_reconcile import OWNER_LABEL, plan
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("CURIE_CONNECTOR_E2E") != "1",
+    reason="cluster e2e; set CURIE_CONNECTOR_E2E=1 with a reachable KUBECONFIG",
+)
+
+AGENT = "e2e-agent"
+OTHER_AGENT = "e2e-other"
+
+
+def kubectl(*args: str) -> str:
+    return subprocess.run(
+        ["kubectl", *args], capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+
+@pytest.fixture(scope="module")
+def namespace() -> Iterator[str]:
+    name = f"curie-conn-e2e-{uuid.uuid4().hex[:8]}"
+    kubectl("create", "namespace", name)
+    try:
+        yield name
+    finally:
+        subprocess.run(
+            ["kubectl", "delete", "namespace", name, "--wait=false"], capture_output=True
+        )
+
+
+@pytest.fixture(scope="module")
+def client() -> KubernetesConnectorClient:
+    return KubernetesConnectorClient()
+
+
+def connector_objects(agent: str, name: str) -> list[dict[str, Any]]:
+    """One connector's worth of objects: the four kinds, minimally shaped."""
+
+    labels = {OWNER_LABEL: agent}
+    selector = {"app.kubernetes.io/name": name}
+    return [
+        {
+            "apiVersion": "v1",
+            "kind": "Service",
+            "metadata": {"name": name, "labels": labels},
+            # No clusterIP -- the field a create-then-replace applier cannot
+            # round-trip, since the server assigns it and then rejects "".
+            "spec": {"selector": selector, "ports": [{"name": "http", "port": 8080}]},
+        },
+        {
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+            "metadata": {"name": name, "labels": labels},
+            "spec": {
+                "replicas": 1,
+                "selector": {"matchLabels": selector},
+                "template": {
+                    "metadata": {"labels": {**selector, **labels}},
+                    "spec": {
+                        "containers": [
+                            {
+                                "name": "server",
+                                "image": "ghcr.io/example/mcp-example:1",
+                                "ports": [{"name": "http", "containerPort": 8080}],
+                            }
+                        ]
+                    },
+                },
+            },
+        },
+        {
+            "apiVersion": "networking.k8s.io/v1",
+            "kind": "NetworkPolicy",
+            "metadata": {"name": f"{name}-allow", "labels": labels},
+            "spec": {"podSelector": {"matchLabels": selector}, "policyTypes": ["Ingress"]},
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "Secret",
+            "type": "Opaque",
+            "metadata": {"name": f"{name}-secrets", "labels": labels},
+            "stringData": {"EXAMPLE_TOKEN": "fixture-value-not-real"},
+        },
+    ]
+
+
+def reconcile(
+    client: KubernetesConnectorClient, namespace: str, desired: list[dict[str, Any]], agent: str
+) -> tuple[Any, Any]:
+    live = client.list_owned(namespace, agent)
+    computed = plan(desired, live, agent=agent)
+    return computed, execute(client, computed, namespace=namespace, agent=agent)
+
+
+def test_the_reconciler_converges_and_stays_converged(client, namespace) -> None:
+    desired = connector_objects(AGENT, "conn-a")
+
+    computed, report = reconcile(client, namespace, desired, AGENT)
+    assert report.ok, report.failures
+    assert len(report.applied) == 4
+
+    # The property the whole drift design exists for. A second pass that still
+    # applies is a loop that rewrites the cluster forever.
+    for _ in range(2):
+        computed, report = reconcile(client, namespace, desired, AGENT)
+        assert computed.is_noop, f"not converged: apply={computed.apply} drift={computed.drifted}"
+
+
+def test_a_human_edit_is_detected_and_reverted(client, namespace) -> None:
+    desired = connector_objects(AGENT, "conn-a")
+    reconcile(client, namespace, desired, AGENT)
+
+    kubectl("-n", namespace, "set", "image", "deploy/conn-a", "server=ghcr.io/example/tampered:9")
+    computed, report = reconcile(client, namespace, desired, AGENT)
+
+    assert computed.drifted == [("Deployment", "conn-a")]
+    assert report.ok, report.failures
+    live_image = kubectl(
+        "-n",
+        namespace,
+        "get",
+        "deploy",
+        "conn-a",
+        "-o",
+        "jsonpath={.spec.template.spec.containers[0].image}",
+    )
+    assert live_image == "ghcr.io/example/mcp-example:1"
+
+
+def test_a_secret_does_not_drift_on_the_encoding_round_trip(client, namespace) -> None:
+    desired = connector_objects(AGENT, "conn-a")
+    reconcile(client, namespace, desired, AGENT)
+
+    stored = json.loads(kubectl("-n", namespace, "get", "secret", "conn-a-secrets", "-o", "json"))
+    assert "data" in stored and "stringData" not in stored, (
+        "the server re-encodes; that is the point"
+    )
+
+    computed, _ = reconcile(client, namespace, desired, AGENT)
+    assert computed.is_noop
+
+
+def test_list_owned_returns_objects_the_plan_can_identify(client, namespace) -> None:
+    # Items inside a List carry no `kind` of their own. Unstamped, every object
+    # has an empty kind, matches nothing declared, and is planned for deletion.
+    reconcile(client, namespace, connector_objects(AGENT, "conn-a"), AGENT)
+    live = client.list_owned(namespace, AGENT)
+    assert {o["kind"] for o in live} == {"Service", "Deployment", "NetworkPolicy", "Secret"}
+    assert all(o.get("apiVersion") for o in live)
+
+
+def test_one_agent_never_prunes_anothers_connector(client, namespace) -> None:
+    # Two agents in one namespace each own a connector (#1116). The first
+    # dropping its own must not touch the second's.
+    mine = connector_objects(AGENT, "conn-a")
+    theirs = connector_objects(OTHER_AGENT, "conn-b")
+    for desired, agent in ((mine, AGENT), (theirs, OTHER_AGENT)):
+        # Asserted rather than assumed: a flaky apply during setup otherwise
+        # surfaces below as "the other agent's connector was disturbed", which
+        # points at the wrong thing entirely.
+        _, setup = reconcile(client, namespace, desired, agent)
+        assert setup.ok, f"setup for {agent} did not apply cleanly: {setup.failures}"
+
+    _, report = reconcile(client, namespace, [], AGENT)
+    assert len(report.deleted) == 4
+
+    computed, _ = reconcile(client, namespace, theirs, OTHER_AGENT)
+    assert computed.is_noop, "the other agent's connector was disturbed"
+    assert len(client.list_owned(namespace, OTHER_AGENT)) == 4
+
+
+def test_a_handwritten_object_is_never_touched(client, namespace) -> None:
+    # sre-bot ran a hand-written connector beside a Curie-managed one through
+    # its whole migration. An unlabelled object must be invisible.
+    kubectl("-n", namespace, "create", "service", "clusterip", "handwritten", "--tcp=8080:8080")
+    reconcile(client, namespace, [], AGENT)
+    assert kubectl("-n", namespace, "get", "svc", "handwritten", "-o", "name")

--- a/charts/curie/ci/connector-reconciler-rbac-assertions.sh
+++ b/charts/curie/ci/connector-reconciler-rbac-assertions.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+#
+# Render-assertion test for the connector reconciler's RBAC (ADR-0090, #1184).
+#
+# The worker's Role is the authority that lets a background loop DELETE
+# Deployments, Services, Secrets and NetworkPolicies. Two ways that goes wrong,
+# and this pins both:
+#
+#   - Too little. A server-side apply of an object that does not exist yet is
+#     authorized as a CREATE, so a Role with only `patch` lets the reconciler
+#     update existing connectors while failing to create any -- the first-run
+#     path. Rendering alone cannot catch that; it was found by running
+#     `kubectl apply --server-side --as=<the worker SA>` and reading the 403.
+#   - Too much. The grant must stay namespaced, must not reach pods, and must
+#     not exist at all when the reconciler is switched off. A component that is
+#     not running should not hold delete-on-Secrets.
+#
+# Six assertions:
+#   (a) With the reconciler DISABLED (the default), the worker Role grants
+#       nothing on the four connector kinds.
+#   (b) Disabled render still grants the two agent-sandbox CRD rules, so the
+#       gate did not swallow the pre-existing rules.
+#   (c) Enabled render grants exactly {create,list,patch,delete} on each of the
+#       four kinds -- create present, and no extra verb sneaking in.
+#   (d) No `get` and no `watch`: nothing in the client reads a single object or
+#       opens a watch, and an unused verb is an unexplained one.
+#   (e) The four kinds match CONNECTOR_KINDS in the worker source. The Python
+#       module's docstring claims this file enforces that; this is the claim.
+#   (f) Nothing the reconciler grants is cluster-scoped, and it never mentions
+#       pods.
+#
+# Runnable locally (from anywhere) and from CI. Fails loudly, naming the
+# assertion.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+CHART="$REPO_ROOT/charts/curie"
+SOURCE="$REPO_ROOT/apps/worker/src/curie_worker/connector_k8s.py"
+NS="curie-rbac-assert"
+
+fail() {
+  echo "FAIL [$1] $2" >&2
+  exit 1
+}
+
+render() {
+  helm template curie "$CHART" -n "$NS" \
+    -f "$CHART/values-dev.yaml" \
+    --set "worker.connectorReconciler.enabled=$1" \
+    -s templates/worker.yaml
+}
+
+worker_role_rules() {
+  # Only the Role document; the Deployment in the same template mentions none
+  # of these strings, but scoping keeps the greps honest.
+  python3 - "$1" <<'PY'
+import sys, yaml
+docs = [d for d in yaml.safe_load_all(sys.argv[1]) if d]
+roles = [d for d in docs if d.get("kind") == "Role"]
+if len(roles) != 1:
+    print(f"expected exactly one Role, got {len(roles)}", file=sys.stderr)
+    sys.exit(2)
+print(yaml.safe_dump(roles[0].get("rules", [])))
+PY
+}
+
+DISABLED="$(render false)"
+ENABLED="$(render true)"
+DISABLED_RULES="$(worker_role_rules "$DISABLED")"
+ENABLED_RULES="$(worker_role_rules "$ENABLED")"
+
+# (a) Off by default means no grant at all.
+for resource in deployments services secrets networkpolicies; do
+  if grep -q "$resource" <<<"$DISABLED_RULES"; then
+    fail a "worker Role grants $resource with the reconciler disabled; the RBAC gate is not working"
+  fi
+done
+
+# (b) ...without having eaten the rules that were already there.
+grep -q "sandboxclaims" <<<"$DISABLED_RULES" || fail b "the disabled render lost the sandboxclaims rule"
+grep -q "sandboxes" <<<"$DISABLED_RULES" || fail b "the disabled render lost the sandboxes rule"
+
+# (c) Enabled: exactly the four verbs on each of the four kinds.
+python3 - "$ENABLED_RULES" <<'PY' || exit 1
+import sys, yaml
+rules = yaml.safe_load(sys.argv[1])
+want = {
+    ("apps", "deployments"),
+    ("", "services"),
+    ("", "secrets"),
+    ("networking.k8s.io", "networkpolicies"),
+}
+verbs = {"create", "list", "patch", "delete"}
+seen = {}
+for rule in rules:
+    for group in rule["apiGroups"]:
+        for resource in rule["resources"]:
+            if (group, resource) in want:
+                seen[(group, resource)] = set(rule["verbs"])
+missing = want - set(seen)
+if missing:
+    print(f"FAIL [c] no rule grants {sorted(missing)}", file=sys.stderr)
+    sys.exit(1)
+for key, got in sorted(seen.items()):
+    if got != verbs:
+        print(
+            f"FAIL [c] {key} grants {sorted(got)}, expected {sorted(verbs)}. "
+            "`create` is required: a server-side apply of a missing object is "
+            "authorized as a create.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+PY
+
+# (d) No verb the client does not call.
+python3 - "$ENABLED_RULES" <<'PY' || exit 1
+import sys, yaml
+for rule in yaml.safe_load(sys.argv[1]):
+    if "networkpolicies" in rule["resources"] or "secrets" in rule["resources"]:
+        for verb in ("get", "watch", "update", "*"):
+            if verb in rule["verbs"]:
+                print(f"FAIL [d] unexpected verb '{verb}' on {rule['resources']}", file=sys.stderr)
+                sys.exit(1)
+PY
+
+# (e) The chart and the client agree on which kinds a connector is made of.
+python3 - "$SOURCE" "$ENABLED_RULES" <<'PY' || exit 1
+import re, sys, yaml
+
+source = open(sys.argv[1]).read()
+kinds = set(re.findall(r'^\s{4}"(\w+)": \(k8s_client', source, re.M))
+if not kinds:
+    print("FAIL [e] could not read the kind table out of connector_k8s.py", file=sys.stderr)
+    sys.exit(1)
+
+plural = {
+    "Deployment": "deployments",
+    "Service": "services",
+    "Secret": "secrets",
+    "NetworkPolicy": "networkpolicies",
+}
+granted = {r for rule in yaml.safe_load(sys.argv[2]) for r in rule["resources"]}
+for kind in sorted(kinds):
+    if kind not in plural:
+        print(f"FAIL [e] {kind} is a new connector kind with no plural mapped here", file=sys.stderr)
+        sys.exit(1)
+    if plural[kind] not in granted:
+        print(
+            f"FAIL [e] connector_k8s.py handles {kind} but the Role does not grant "
+            f"{plural[kind]}; the reconciler would fail to prune it",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+PY
+
+# (f) Namespaced only, and never pods.
+if grep -qE '^kind: ClusterRole' <<<"$ENABLED"; then
+  fail f "the worker template rendered a ClusterRole; connector RBAC must stay namespaced"
+fi
+if grep -q "pods" <<<"$ENABLED_RULES"; then
+  fail f "the connector Role mentions pods; it manages objects, never pods directly"
+fi
+
+echo "connector-reconciler-rbac-assertions: all six assertions passed"

--- a/charts/curie/templates/worker.yaml
+++ b/charts/curie/templates/worker.yaml
@@ -31,6 +31,36 @@ rules:
   - apiGroups: ["agents.x-k8s.io"]
     resources: ["sandboxes"]
     verbs: ["get", "patch"]
+{{- if .Values.worker.connectorReconciler.enabled }}
+{{/*
+ADR-0090: the connector reconciler converges each agent's connector objects
+toward its in-force bundle. Exactly the four kinds a connector is made of --
+the same list as CONNECTOR_KINDS in curie_worker/connector_k8s.py -- and
+exactly the verbs the three-verb ConnectorClient calls:
+  list_owned -> list            (scoped by the curie.dev/connector-owner label)
+  apply      -> patch + create  (server-side apply)
+  delete     -> delete
+`create` is NOT redundant next to `patch`. A server-side apply of an object
+that does not exist yet is authorized as a create, so a Role with only `patch`
+lets the reconciler update existing connectors while failing to create any --
+the first-run path, and the one most likely to be exercised. Verified with
+`kubectl apply --server-side --as=<the worker SA>`, which is forbidden without
+it. No `get` (nothing reads a single object), no cluster scope, no other kinds.
+
+This is a genuine privilege increase over the CRD-only rules above -- it
+includes delete on Secrets -- which is why it renders only when the reconciler
+is actually enabled.
+*/}}
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["create", "list", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["services", "secrets"]
+    verbs: ["create", "list", "patch", "delete"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["networkpolicies"]
+    verbs: ["create", "list", "patch", "delete"]
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -580,6 +580,17 @@ worker:
   # (see templates/worker.yaml). Its token IS mounted (unlike the runner SA).
   serviceAccount:
     create: true
+  # Declarative connector hosting (ADR-0090): the worker converges each agent's
+  # connector Deployment/Service/Secret/NetworkPolicy toward what its in-force
+  # bundle declares, so an agent repo needs no CLI near the cluster.
+  #
+  # Off by default, and the RBAC is gated on this same flag rather than granted
+  # unconditionally. Enabling it widens the worker's Role from "read/patch two
+  # CRDs" to "create, update and DELETE Deployments, Services, Secrets and
+  # NetworkPolicies in this namespace" -- a real privilege increase that should
+  # not be handed to a component that is not using it.
+  connectorReconciler:
+    enabled: false
   # The SandboxWarmPool the substrate claims from. Empty -> derived as
   # `<release>-runner-pool` (the name templates/agent-sandbox.yaml gives it).
   warmPool: ""


### PR DESCRIPTION
Implements the `ConnectorClient` protocol from #1189 against a live API server, plus the namespaced Role that authorizes it. Both verified on a cluster, not by rendering.

## Writes are server-side applies

Create-then-replace-on-409 is where the obvious implementation goes wrong: a rendered Service declares no `clusterIP`, and replacing a live Service without one is rejected outright (`spec.clusterIP: Invalid value: "": field is immutable`). SSA also removes a field we previously set and no longer declare — so dropping `hostAliases` from `connectors.yaml` drops it from the pod rather than leaving it in place forever.

`force=True` is deliberate: it brings a field a human took with `kubectl edit` back under the declaration. That *is* the drift correction ADR-0090 asks for.

Reads request raw JSON rather than typed models — the rest of the reconciler compares against what the API rendered, which is camelCase, and the generated models hand back snake_case that would compare unequal on every field. Items inside a List also carry no `kind` of their own, so they're stamped; unstamped, every live object has an empty kind, matches nothing declared, and gets **planned for deletion**.

## `create` is not redundant next to `patch`

The Role grants `create, list, patch, delete` on exactly the four connector kinds, namespaced. I initially wrote it without `create`, reasoning that SSA only ever patches. That was wrong, and wrong in the dangerous direction:

```
$ kubectl apply --server-side --as=system:serviceaccount:…:curie-worker -f svc.yaml
Error from server (Forbidden): services "ssa-create-probe" is forbidden:
  … cannot create resource "services" in API group "" in the namespace …
```

A server-side apply of an object that does not exist yet is authorized as a **create**. A patch-only Role lets the reconciler update existing connectors while failing to create any — the first-run path, and the one most likely to be hit. No amount of chart rendering would have shown this; it took impersonating the ServiceAccount.

After the fix, as the worker SA: SSA create ✅, SSA update of a Service with no clusterIP ✅, delete ✅, and still denied `delete pods`, `patch deployments` in another namespace, and anything cluster-scoped.

## The grant is gated

`worker.connectorReconciler.enabled` (default `false`) gates the RBAC as well as the feature. Enabling it widens the worker's Role from "read/patch two CRDs" to "create, update and **delete** Deployments, Services, Secrets and NetworkPolicies in this namespace". A component that isn't running shouldn't hold delete-on-Secrets.

## Verified against a live cluster

```
1 create                 live=0 apply=4 -> applied=4 ok=True
2 should be noop         live=4 apply=0 -> converged
3 still noop             live=4 apply=0 -> converged

tampered -> ghcr.io/example/tampered:9
drifted=[('Deployment', ...)]  applied=[('Deployment', ...)]
corrected -> ghcr.io/example/mcp-example:1
converged again: True

pruned=[Deployment, NetworkPolicy, Service]     # Secret still declared, kept
other agent still has: [Deployment, NetworkPolicy, Service]  and is converged
```

The gated e2e (`CURIE_CONNECTOR_E2E=1`, own throwaway namespace) captures all of it, including the Secret's `stringData`→`data` round trip and the unlabelled hand-written Service that must stay untouched.

## The chart assertions were falsified

A passing assertion script proves nothing until it fails when it should. Each was broken deliberately:

| break | result |
|---|---|
| drop `create` | `FAIL [c] … expected ['create','delete','list','patch']` |
| drop a whole kind | `FAIL [c] no rule grants [('networking.k8s.io','networkpolicies')]` |
| ungate the RBAC block | `FAIL [a] worker Role grants deployments with the reconciler disabled` |
| add a kind to the client, not the Role | `FAIL [e] ConfigMap is a new connector kind with no plural mapped here` |

Assertion (e) is what makes `connector_k8s.py`'s docstring claim true: the chart and the client cannot disagree about which kinds a connector is made of, because disagreeing means the reconciler silently fails to prune.

Nothing is wired to run yet — the reconcile loop is the last piece.

```
uv run pytest apps/worker/tests/reconcile -q            # 36 passed, 6 skipped (e2e gated)
bash charts/curie/ci/connector-reconciler-rbac-assertions.sh
```

Refs #1184