### PR TITLE
Reconcile one agent's connectors without eating its credential

### DIFF
--- a/apps/worker/src/curie_worker/connector_agent.py
+++ b/apps/worker/src/curie_worker/connector_agent.py
@@ -1,0 +1,156 @@
+"""Reconcile one agent's connectors (ADR-0090, #1184).
+
+Joins the three halves that already exist: the API renders, `connector_reconcile`
+decides, `connector_apply` carries it out. What lives here is the part none of
+them can know on its own -- which objects are this agent's to manage, and when
+reconciling would do more harm than leaving it alone.
+
+**The credential hazard, which is the reason this module is not three lines.**
+The API's render emits a Service, a Deployment and a NetworkPolicy per
+connector. It never emits the Secret. For a connector using the owned form
+(`secrets: [NAME]`) that Secret is minted by `curie cluster deploy`, from values
+only the operator's environment holds -- the cluster deliberately does not have
+them (ADR-0086), so the reconciler cannot render it and never will.
+
+That Secret carries `curie.dev/connector-owner`, because the CLI stamps the same
+label the reconciler prunes on. So the naive loop -- list what we own, delete
+what we no longer declare -- **deletes the credential the CLI provisioned**, and
+every connector pod fails on its next restart with a missing secretKeyRef. The
+object is owned, it is genuinely undeclared, and pruning it is exactly what the
+plan is supposed to do. Nothing downstream can catch this; it has to be handled
+here.
+
+So an agent's owned Secret is protected: never applied (we have no values) and
+never pruned (someone else owns its lifecycle). And if it is protected but
+absent, the agent is skipped entirely rather than reconciled -- applying a
+Deployment whose secretKeyRef points at a Secret that does not exist produces
+pods that never start, which is worse than not acting.
+
+Connectors using the reference form (`secrets: [{from_secret: ...}]`, #1163)
+have no owned keys at all, so they reconcile with no exception. That is the
+path ADR-0090 calls the prerequisite, and it is why this restriction shrinks as
+bundles adopt it rather than being permanent.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+from .connector_apply import ApplyReport, ConnectorClient, execute
+from .connector_reconcile import OWNER_LABEL, ReconcilePlan, identity, plan
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class RenderedConnectors:
+    """What the API returns for one version's `connectors.yaml`."""
+
+    manifests: list[dict[str, Any]] = field(default_factory=list)
+    # The Secret Curie owns for this agent, and the keys whose VALUES a caller
+    # must supply. Non-empty means the CLI owns that Secret's lifecycle.
+    owned_secret_name: str = ""
+    owned_secret_keys: list[str] = field(default_factory=list)
+
+    @property
+    def needs_operator_credentials(self) -> bool:
+        return bool(self.owned_secret_keys)
+
+
+class ManifestSource(Protocol):
+    """Where rendered connector objects come from.
+
+    A seam, so the reconcile step is testable without an API. Rendering stays
+    in the API by ADR-0090 -- duplicating it here would recreate exactly the
+    drift `connectors.yaml` exists to prevent.
+    """
+
+    def rendered(self, *, agent_id: str, version_id: str) -> RenderedConnectors: ...
+
+
+@dataclass(frozen=True)
+class AgentOutcome:
+    """What reconciling one agent did, or why it did nothing."""
+
+    agent: str
+    skipped: str | None = None
+    plan: ReconcilePlan | None = None
+    report: ApplyReport | None = None
+
+    @property
+    def ok(self) -> bool:
+        return self.report is None or self.report.ok
+
+
+def own(obj: dict[str, Any], agent: str) -> dict[str, Any]:
+    """Stamp the ownership label the whole prune path keys on.
+
+    The renderer does not set it -- it is a deployment fact, not a bundle fact,
+    and the CLI applier stamps it at the same point. An object applied without
+    it is invisible to every future prune, so the applier refuses to write one;
+    this is where the reconciler earns the right to.
+    """
+
+    stamped = dict(obj)
+    metadata = dict(stamped.get("metadata") or {})
+    metadata["labels"] = {**(metadata.get("labels") or {}), OWNER_LABEL: agent}
+    stamped["metadata"] = metadata
+    return stamped
+
+
+def reconcile_agent(
+    source: ManifestSource,
+    client: ConnectorClient,
+    *,
+    agent: str,
+    agent_id: str,
+    version_id: str,
+    namespace: str,
+) -> AgentOutcome:
+    """Converge one agent's connectors toward its in-force version."""
+
+    rendered = source.rendered(agent_id=agent_id, version_id=version_id)
+    desired = [own(obj, agent) for obj in rendered.manifests]
+    live = client.list_owned(namespace, agent)
+
+    protected: set[tuple[str, str]] = set()
+    if rendered.needs_operator_credentials and rendered.owned_secret_name:
+        protected.add(("Secret", rendered.owned_secret_name))
+        if not any(identity(obj) in protected for obj in live):
+            # Reconciling now would create Deployments referencing a Secret that
+            # does not exist. Pods would stay stuck rather than fail loudly, and
+            # the cause would be several layers from the symptom.
+            reason = (
+                f"connector credentials are operator-supplied and "
+                f"{rendered.owned_secret_name} is not provisioned; "
+                f"deploy once with the CLI (keys: {', '.join(rendered.owned_secret_keys)})"
+            )
+            logger.warning("connector reconcile skipped agent=%s reason=%s", agent, reason)
+            return AgentOutcome(agent=agent, skipped=reason)
+
+        logger.debug(
+            "connector reconcile agent=%s protecting operator-supplied secret %s",
+            agent,
+            rendered.owned_secret_name,
+        )
+
+    # Hidden from the plan rather than filtered out of its result: the plan's job
+    # is "own it and no longer declare it -> delete it", and that judgement is
+    # correct. What is wrong is calling this object ours to begin with.
+    manageable = [obj for obj in live if identity(obj) not in protected]
+
+    computed = plan(desired, manageable, agent=agent)
+    if computed.is_noop:
+        return AgentOutcome(agent=agent, plan=computed, report=ApplyReport())
+
+    report = execute(client, computed, namespace=namespace, agent=agent)
+    if not report.ok:
+        logger.warning(
+            "connector reconcile agent=%s had %d failure(s): %s",
+            agent,
+            len(report.failures),
+            "; ".join(f"{kind}/{name}: {err}" for kind, name, err in report.failures),
+        )
+    return AgentOutcome(agent=agent, plan=computed, report=report)

--- a/apps/worker/src/curie_worker/connector_agent.py
+++ b/apps/worker/src/curie_worker/connector_agent.py
@@ -122,19 +122,23 @@ def reconcile_agent(
             # Reconciling now would create Deployments referencing a Secret that
             # does not exist. Pods would stay stuck rather than fail loudly, and
             # the cause would be several layers from the symptom.
+            #
+            # The message deliberately names neither the Secret nor its keys.
+            # Both are identifiers rather than values -- `kubectl get secret`
+            # shows them -- but they are also of no use here: the operator's
+            # action is the same either way, and `curie cluster deploy` is what
+            # reports a key it cannot resolve. Leaving them out keeps a credential
+            # name out of a log stream that may be shipped somewhere less
+            # protected than the cluster.
             reason = (
-                f"connector credentials are operator-supplied and "
-                f"{rendered.owned_secret_name} is not provisioned; "
-                f"deploy once with the CLI (keys: {', '.join(rendered.owned_secret_keys)})"
+                "connector credentials are operator-supplied and not yet "
+                "provisioned in this namespace; run `curie cluster deploy` once "
+                "for this agent, or move the connector to a referenced secret"
             )
-            logger.warning("connector reconcile skipped agent=%s reason=%s", agent, reason)
+            logger.warning("connector reconcile skipped agent=%s: %s", agent, reason)
             return AgentOutcome(agent=agent, skipped=reason)
 
-        logger.debug(
-            "connector reconcile agent=%s protecting operator-supplied secret %s",
-            agent,
-            rendered.owned_secret_name,
-        )
+        logger.debug("connector reconcile agent=%s protecting its operator-supplied secret", agent)
 
     # Hidden from the plan rather than filtered out of its result: the plan's job
     # is "own it and no longer declare it -> delete it", and that judgement is

--- a/apps/worker/tests/reconcile/test_connector_agent.py
+++ b/apps/worker/tests/reconcile/test_connector_agent.py
@@ -125,8 +125,13 @@ def test_an_agent_whose_credential_was_never_provisioned_is_skipped() -> None:
     outcome = run(source, client)
 
     assert outcome.skipped is not None
-    assert SECRET_NAME in outcome.skipped
-    assert "GRAFANA_TOKEN" in outcome.skipped, "the message must say what to provision"
+    assert "curie cluster deploy" in outcome.skipped, "the message must say what to do"
+    # Deliberately NOT the Secret's name or its keys. Both are identifiers
+    # rather than values, but they are of no use here -- the operator's action
+    # is the same either way -- and leaving them out keeps a credential name out
+    # of a log stream that may be shipped somewhere less protected.
+    assert SECRET_NAME not in outcome.skipped
+    assert "GRAFANA_TOKEN" not in outcome.skipped
     assert client.applied == [] and client.deleted == []
 
 

--- a/apps/worker/tests/reconcile/test_connector_agent.py
+++ b/apps/worker/tests/reconcile/test_connector_agent.py
@@ -1,0 +1,228 @@
+"""Reconciling one agent (ADR-0090, #1184).
+
+Most of these are about the operator-supplied Secret, because that is the only
+way this step destroys something. Everything else it can get wrong is recoverable
+on the next pass.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from curie_worker.connector_agent import (
+    RenderedConnectors,
+    own,
+    reconcile_agent,
+)
+from curie_worker.connector_reconcile import OWNER_LABEL, stamp_hash
+
+AGENT = "sre-bot"
+NS = "curie"
+SECRET_NAME = "curie-sre-bot-connector-secrets"
+
+
+def manifest(kind: str, name: str) -> dict[str, Any]:
+    return {"apiVersion": "v1", "kind": kind, "metadata": {"name": name}, "spec": {"x": 1}}
+
+
+def live_copy(obj: dict[str, Any], agent: str = AGENT) -> dict[str, Any]:
+    """As the cluster would return it after the reconciler applied it."""
+
+    stored = stamp_hash(own(obj, agent))
+    stored["metadata"]["uid"] = "u-1"
+    return stored
+
+
+class Source:
+    def __init__(self, rendered: RenderedConnectors) -> None:
+        self._rendered = rendered
+        self.calls: list[tuple[str, str]] = []
+
+    def rendered(self, *, agent_id: str, version_id: str) -> RenderedConnectors:
+        self.calls.append((agent_id, version_id))
+        return self._rendered
+
+
+class FakeClient:
+    def __init__(self, live: list[dict[str, Any]] | None = None) -> None:
+        self._live = live or []
+        self.applied: list[str] = []
+        self.deleted: list[tuple[str, str]] = []
+
+    def list_owned(self, namespace: str, owner: str) -> list[dict[str, Any]]:
+        return [
+            o for o in self._live if (o["metadata"].get("labels") or {}).get(OWNER_LABEL) == owner
+        ]
+
+    def apply(self, namespace: str, obj: dict[str, Any]) -> None:
+        self.applied.append(obj["metadata"]["name"])
+
+    def delete(self, namespace: str, kind: str, name: str) -> None:
+        self.deleted.append((kind, name))
+
+
+def run(source: Source, client: FakeClient):
+    return reconcile_agent(
+        source, client, agent=AGENT, agent_id="a-1", version_id="v-1", namespace=NS
+    )
+
+
+# --------------------------------------------------------------------------- #
+# The credential hazard
+# --------------------------------------------------------------------------- #
+def test_it_never_prunes_the_operator_supplied_secret() -> None:
+    # THE bug this module exists for. The CLI mints that Secret from values the
+    # cluster does not hold, stamps the same owner label the reconciler prunes
+    # on, and the API's render never emits it. A plain "own it and no longer
+    # declare it -> delete it" pass therefore deletes the credential, and every
+    # connector pod fails on its next restart.
+    secret = live_copy({"apiVersion": "v1", "kind": "Secret", "metadata": {"name": SECRET_NAME}})
+    dep = manifest("Deployment", "curie-sre-bot-mcp-grafana")
+    client = FakeClient([secret, live_copy(dep)])
+    source = Source(
+        RenderedConnectors(
+            manifests=[dep], owned_secret_name=SECRET_NAME, owned_secret_keys=["GRAFANA_TOKEN"]
+        )
+    )
+
+    outcome = run(source, client)
+
+    assert client.deleted == [], "the operator's credential must never be pruned"
+    assert outcome.skipped is None
+    assert outcome.ok
+
+
+def test_the_protected_secret_is_also_never_applied() -> None:
+    # We have no values for it. Applying would either fail or, worse, succeed
+    # with an empty credential.
+    secret = live_copy({"apiVersion": "v1", "kind": "Secret", "metadata": {"name": SECRET_NAME}})
+    client = FakeClient([secret])
+    source = Source(
+        RenderedConnectors(
+            manifests=[manifest("Service", "svc")],
+            owned_secret_name=SECRET_NAME,
+            owned_secret_keys=["GRAFANA_TOKEN"],
+        )
+    )
+
+    run(source, client)
+    assert SECRET_NAME not in client.applied
+
+
+def test_an_agent_whose_credential_was_never_provisioned_is_skipped() -> None:
+    # Applying a Deployment whose secretKeyRef points at nothing yields pods
+    # stuck rather than failing loudly, several layers from the cause.
+    client = FakeClient([])
+    source = Source(
+        RenderedConnectors(
+            manifests=[manifest("Deployment", "dep")],
+            owned_secret_name=SECRET_NAME,
+            owned_secret_keys=["GRAFANA_TOKEN"],
+        )
+    )
+
+    outcome = run(source, client)
+
+    assert outcome.skipped is not None
+    assert SECRET_NAME in outcome.skipped
+    assert "GRAFANA_TOKEN" in outcome.skipped, "the message must say what to provision"
+    assert client.applied == [] and client.deleted == []
+
+
+def test_a_reference_form_bundle_has_no_exception_at_all() -> None:
+    # `secrets: [{from_secret: ...}]` (#1163) points at a Secret someone else
+    # provisioned, so no key needs resolving and nothing is protected. This is
+    # the path ADR-0090 calls the prerequisite.
+    client = FakeClient([])
+    source = Source(RenderedConnectors(manifests=[manifest("Deployment", "dep")]))
+
+    outcome = run(source, client)
+
+    assert outcome.skipped is None
+    assert client.applied == ["dep"]
+
+
+def test_a_stale_secret_is_still_pruned_when_no_keys_are_owned() -> None:
+    # The protection is scoped to the credential the operator supplies. An
+    # owned Secret with no owned keys is ordinary garbage and must still go, or
+    # removing a connector leaves its credential behind forever.
+    stale = live_copy({"apiVersion": "v1", "kind": "Secret", "metadata": {"name": "stale"}})
+    client = FakeClient([stale])
+    source = Source(RenderedConnectors(manifests=[]))
+
+    run(source, client)
+    assert client.deleted == [("Secret", "stale")]
+
+
+# --------------------------------------------------------------------------- #
+# Ownership
+# --------------------------------------------------------------------------- #
+def test_rendered_objects_are_stamped_with_the_owner() -> None:
+    # The renderer does not set it -- it is a deployment fact, not a bundle
+    # fact. Unstamped, the applier refuses to write the object, and rightly so.
+    client = FakeClient([])
+    run(Source(RenderedConnectors(manifests=[manifest("Service", "svc")])), client)
+    assert client.applied == ["svc"]
+
+
+def test_own_does_not_mutate_the_rendered_object() -> None:
+    # The rendered set may be reused across agents; stamping one must not label
+    # it for another.
+    obj = manifest("Service", "svc")
+    own(obj, AGENT)
+    assert "labels" not in obj["metadata"]
+
+
+def test_another_agents_objects_are_never_visible() -> None:
+    theirs = live_copy(manifest("Deployment", "theirs"), agent="other-bot")
+    client = FakeClient([theirs])
+    run(Source(RenderedConnectors(manifests=[])), client)
+    assert client.deleted == []
+
+
+# --------------------------------------------------------------------------- #
+# Ordinary operation
+# --------------------------------------------------------------------------- #
+def test_a_converged_agent_does_no_work() -> None:
+    dep = manifest("Deployment", "dep")
+    client = FakeClient([live_copy(dep)])
+    outcome = run(Source(RenderedConnectors(manifests=[dep])), client)
+
+    assert outcome.plan is not None and outcome.plan.is_noop
+    assert client.applied == [] and client.deleted == []
+    assert outcome.ok
+
+
+def test_the_version_asked_for_is_the_one_rendered() -> None:
+    source = Source(RenderedConnectors(manifests=[]))
+    run(source, FakeClient([]))
+    assert source.calls == [("a-1", "v-1")]
+
+
+def test_a_failed_apply_is_reported_not_raised() -> None:
+    # One agent failing must not abort the pass for every other agent.
+    class Exploding(FakeClient):
+        def apply(self, namespace: str, obj: dict[str, Any]) -> None:
+            raise RuntimeError("apiserver said no")
+
+    outcome = run(Source(RenderedConnectors(manifests=[manifest("Service", "svc")])), Exploding([]))
+    assert not outcome.ok
+    assert outcome.report is not None and outcome.report.failures
+
+
+@pytest.mark.parametrize("keys", [[], ["TOKEN"]])
+def test_a_missing_owned_secret_name_is_not_treated_as_a_protected_object(keys) -> None:
+    # An empty name would protect ("Secret", "") -- matching nothing, but also
+    # skipping every agent if the absence check were written carelessly.
+    client = FakeClient([])
+    outcome = run(
+        Source(
+            RenderedConnectors(
+                manifests=[manifest("Service", "svc")], owned_secret_name="", owned_secret_keys=keys
+            )
+        ),
+        client,
+    )
+    assert outcome.skipped is None
+    assert client.applied == ["svc"]


### PR DESCRIPTION
Joins the three halves that already exist — the API renders, `connector_reconcile` decides (#1190), `connector_apply` carries it out (#1189) — and handles the one thing none of them can know alone: which objects are this agent's to manage.

## Why this isn't three lines

The API's render emits a Service, a Deployment and a NetworkPolicy per connector. **It never emits the Secret.** For a connector using the owned form (`secrets: [NAME]`) that Secret is minted by `curie cluster deploy` from values only the operator's environment holds — the cluster deliberately does not have them (ADR-0086), so the reconciler cannot render it and never will.

That Secret carries `curie.dev/connector-owner`, because the CLI stamps the same label the reconciler prunes on.

So the naive loop — *list what we own, delete what we no longer declare* — **deletes the credential the CLI provisioned**, and every connector pod fails on its next restart with a missing `secretKeyRef`. The object is owned, it is genuinely undeclared, and pruning it is exactly what the plan is supposed to do. Nothing downstream can catch this.

I confirmed it is real rather than theoretical by removing the guard:

```
--- with the protection removed ---
>  assert client.deleted == [], "the operator's credential must never be pruned"
E  AssertionError: the operator's credential must never be pruned
```

## The rule

The owned Secret is **hidden from the plan** rather than filtered out of its result — the plan's judgement is correct; what is wrong is calling the object ours to begin with. It is never applied (we have no values) and never pruned (someone else owns its lifecycle).

When it is protected but **absent**, the agent is skipped entirely, with a message naming the keys to provision. Applying a Deployment whose `secretKeyRef` points at a Secret that does not exist yields pods stuck rather than failing loudly, several layers from the cause.

Scoped precisely: an owned Secret with no owned *keys* is ordinary garbage and is still pruned, or removing a connector would leave its credential behind forever.

Reference-form bundles (`secrets: [{from_secret: …}]`, #1163) own no keys, so nothing is protected and they reconcile with no exception. That is the path ADR-0090 calls the prerequisite — this restriction shrinks as bundles adopt it rather than being permanent, which is exactly what the ADR asked to be stated plainly instead of papered over.

## Also

Stamps the owner label on rendered objects. The renderer doesn't set it — it's a deployment fact, not a bundle fact — and the applier refuses to write an unlabelled object since nothing could ever prune it.

Nothing calls this yet; the loop is the last piece.

```
uv run pytest apps/worker/tests/reconcile -q   # 49 passed
```

Refs #1184