### PR TITLE
Run the connector reconciler in the worker

### DIFF
--- a/apps/worker/src/curie_worker/config.py
+++ b/apps/worker/src/curie_worker/config.py
@@ -67,9 +67,7 @@ Bool = Annotated[bool, BeforeValidator(_parse_bool)]
 class WorkerConfig(BaseSettings):
     """Everything the kernel needs, in one typed object."""
 
-    model_config = SettingsConfigDict(
-        frozen=True, populate_by_name=True, extra="ignore"
-    )
+    model_config = SettingsConfigDict(frozen=True, populate_by_name=True, extra="ignore")
 
     @classmethod
     def settings_customise_sources(
@@ -114,9 +112,7 @@ class WorkerConfig(BaseSettings):
     # Deployment-to-runtime binding. The plugin dir is the local path the runner
     # reads; sandbox provisioning fetches CURIE_BUNDLE_REF into it. Platform
     # default budget applies when an agent's budget columns are NULL.
-    bundle_plugin_dir: str = Field(
-        default="/bundles/current", validation_alias="CURIE_PLUGIN_DIR"
-    )
+    bundle_plugin_dir: str = Field(default="/bundles/current", validation_alias="CURIE_PLUGIN_DIR")
     default_max_usd_per_day: float = 10.0
     default_max_output_tokens_per_run: int = 100000
 
@@ -224,9 +220,7 @@ class WorkerConfig(BaseSettings):
     # Empty means "derive ``<stream>:dead``" at the use site; a static Field
     # default cannot reference ``self.stream``. An explicit override equal to
     # ``stream`` is rejected outright -- see ``_reject_self_targeting_graveyard``.
-    dead_letter_stream: str = Field(
-        default="", validation_alias=DEAD_LETTER_STREAM_ENV
-    )
+    dead_letter_stream: str = Field(default="", validation_alias=DEAD_LETTER_STREAM_ENV)
     # The graveyard is capped with an approximate MAXLEN on every XADD. The
     # unparseable-poison path dead-letters per INBOUND entry, so a wire-format
     # drift that makes entries unparseable en masse would otherwise grow the
@@ -256,6 +250,37 @@ class WorkerConfig(BaseSettings):
                 "CURIE_DEAD_LETTER_STREAM must not equal CURIE_STREAM "
                 f"({self.stream!r}): dead-lettering onto the source stream "
                 "re-queues failures forever"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _connector_reconciler_knows_where_it_is(self) -> WorkerConfig:
+        """Fail at construction if the reconciler is on but unaddressed.
+
+        Connector object names are built from the release name and the app name
+        (`<release>-<agent>-mcp-<connector>`). With either missing, every name
+        the reconciler renders differs from the names that actually exist: it
+        would find nothing of its own in the namespace, create a parallel set
+        under wrong names, and leave the real connectors unmanaged. That is
+        silent and looks like it is working, so it is rejected at boot instead.
+        """
+
+        if not self.connector_reconcile_enabled:
+            return self
+        missing = [
+            env
+            for env, value in (
+                ("CURIE_NAMESPACE", self.connector_namespace),
+                ("CURIE_RELEASE", self.connector_release),
+                ("CURIE_CONNECTOR_APP_NAME", self.connector_app_name),
+            )
+            if not value.strip()
+        ]
+        if missing:
+            raise ValueError(
+                f"CURIE_CONNECTOR_RECONCILE is on but {', '.join(missing)} "
+                "is unset; connector object names are derived from these, so "
+                "the reconciler would manage a parallel set under wrong names"
             )
         return self
 
@@ -311,9 +336,7 @@ class WorkerConfig(BaseSettings):
 
     # Eval stream (F3): a separate consumer group on curie:evals runs eval
     # suites and reports results to the platform API and Langfuse.
-    eval_stream: str = Field(
-        default=EVAL_STREAM_DEFAULT, validation_alias="CURIE_EVAL_STREAM"
-    )
+    eval_stream: str = Field(default=EVAL_STREAM_DEFAULT, validation_alias="CURIE_EVAL_STREAM")
     eval_consumer_group: str = Field(
         default=EVAL_CONSUMER_GROUP_DEFAULT,
         validation_alias="CURIE_EVAL_CONSUMER_GROUP",
@@ -386,10 +409,31 @@ class WorkerConfig(BaseSettings):
     # wires neither CURIE_API_URL nor this on the worker, so its runner state
     # refs are the same localhost gap in the opposite substrate, out of #678's
     # docker scope -- see runner_facing_api_base_url.
-    runner_api_base_url: str = Field(
-        default="", validation_alias="CURIE_RUNNER_API_URL"
-    )
+    runner_api_base_url: str = Field(default="", validation_alias="CURIE_RUNNER_API_URL")
     api_key: str = Field(default="curie-dev-key", validation_alias=API_KEY_ENV)
+    # ---------------------------------------------------------------------
+    # Connector reconciler (ADR-0090, #1184). Off by default: enabling it is
+    # what makes the worker's Role grant create/patch/delete on Deployments,
+    # Services, Secrets and NetworkPolicies, and the chart gates that grant on
+    # the same flag. A worker that is not reconciling should not hold it.
+    # ---------------------------------------------------------------------
+    connector_reconcile_enabled: bool = Field(
+        default=False, validation_alias="CURIE_CONNECTOR_RECONCILE"
+    )
+    connector_reconcile_interval_s: float = Field(
+        default=60.0, gt=0, validation_alias="CURIE_CONNECTOR_RECONCILE_INTERVAL_S"
+    )
+    # The reconciler reuses `connector_release` / `connector_namespace` above --
+    # deliberately the same two values the runner's connector scope is built
+    # from. They must agree: the runner dials a Service by the name those
+    # produce, and the reconciler creates the Service by the same name. Two
+    # separate settings could disagree, and the symptom would be a connector
+    # that exists and an agent that cannot reach it.
+    #
+    # `app_name` is the one thing neither of them already needs: it is the
+    # chart's nameOverride, and it appears only in the pod selector the
+    # NetworkPolicy matches on.
+    connector_app_name: str = Field(default="", validation_alias="CURIE_CONNECTOR_APP_NAME")
     report_max_attempts: int = 3
     report_backoff_base_s: float = Field(default=0.5, gt=0)
     # Langfuse for recording eval scores (the matrix reads them back by version).
@@ -403,9 +447,7 @@ class WorkerConfig(BaseSettings):
         default="/tmp/curie-worker.heartbeat",
         validation_alias=HEARTBEAT_FILE_ENV,
     )
-    heartbeat_interval_s: float = Field(
-        default=10.0, validation_alias=HEARTBEAT_INTERVAL_ENV
-    )
+    heartbeat_interval_s: float = Field(default=10.0, validation_alias=HEARTBEAT_INTERVAL_ENV)
 
     key_prefix: str = "curie:worker"
 

--- a/apps/worker/src/curie_worker/connector_loop.py
+++ b/apps/worker/src/curie_worker/connector_loop.py
@@ -1,0 +1,239 @@
+"""The connector reconcile loop (ADR-0090, #1184).
+
+Runs in the worker, which already holds cluster-write authority for
+SandboxClaims and already reads the agents tables. The alternative -- its own
+Deployment -- would need its own ServiceAccount, database credential, API key
+and image for what is a periodic query plus a handful of applies.
+
+Three things make this safe to run unattended, and each is a deliberate choice
+rather than a default:
+
+**One agent's failure ends with that agent.** A pass reconciles every agent with
+an active deployment. An exception in one is caught, logged and counted; the
+rest of the pass continues. A reconciler that aborts the sweep on the first bad
+agent leaves every later agent unreconciled indefinitely, and the ordering is
+arbitrary, so which agents those are changes between passes.
+
+**A pass never kills the worker.** The loop's body is wrapped whole. This shares
+a process with the kernel, whose four correctness rules are not negotiable, so
+the loop is a background task that can fail loudly and repeatedly without taking
+anything else down with it.
+
+**Quiet when converged.** The steady state is "nothing changed", which is most
+passes forever. Only work and failures are logged at INFO; a converged pass
+logs at DEBUG. A loop that narrates every pass trains people to ignore it, and
+then the one pass that mattered scrolls by unread.
+
+The cluster-shaped work is synchronous -- the Kubernetes client is, and so is
+the render fetch -- so a pass runs in a worker thread rather than blocking the
+event loop the kernel is using.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from .connector_agent import (
+    AgentOutcome,
+    ManifestSource,
+    RenderedConnectors,
+    reconcile_agent,
+)
+from .connector_apply import ConnectorClient
+
+logger = logging.getLogger(__name__)
+
+
+# Every agent with an in-force deployment, and the version that deployment
+# points at. Mirrors binding.py's precedence so the connectors a thread gets
+# belong to the same version its sandbox boots: prod outranks dev, then most
+# recent. DISTINCT ON collapses an agent with both active to that one winner --
+# without it an agent would be reconciled twice per pass, the second undoing
+# the first.
+_TARGETS_SQL = """
+SELECT DISTINCT ON (a.id)
+       a.id AS agent_id,
+       a.name AS agent_name,
+       v.id AS version_id
+FROM {schema}.agents a
+JOIN {schema}.deployments d ON d.agent_id = a.id AND d.status = 'active'
+JOIN {schema}.agent_versions v ON v.id = d.version_id AND v.agent_id = a.id
+WHERE v.bundle_ref IS NOT NULL
+ORDER BY a.id, (d.environment = 'prod') DESC, d.deployed_at DESC
+"""
+
+
+@dataclass(frozen=True)
+class AgentTarget:
+    agent_id: uuid.UUID
+    agent_name: str
+    version_id: uuid.UUID
+
+
+class HttpManifestSource:
+    """Fetches rendered connector objects from the platform API.
+
+    Synchronous on purpose: its caller runs in a worker thread, and the
+    Kubernetes client beside it is sync too. Rendering stays in the API by
+    ADR-0090 -- re-deriving the objects here would recreate the drift
+    `connectors.yaml` exists to prevent.
+    """
+
+    def __init__(
+        self,
+        *,
+        api_base_url: str,
+        api_key: str,
+        release: str,
+        namespace: str,
+        app_name: str,
+        timeout: float = 30.0,
+    ) -> None:
+        self._base = api_base_url.rstrip("/")
+        self._headers = {"X-API-Key": api_key} if api_key else {}
+        self._params = {"release": release, "namespace": namespace, "app_name": app_name}
+        self._timeout = timeout
+
+    def rendered(self, *, agent_id: str, version_id: str) -> RenderedConnectors:
+        url = f"{self._base}/agents/{agent_id}/versions/{version_id}/connectors"
+        with httpx.Client(timeout=self._timeout) as client:
+            response = client.get(url, params=self._params, headers=self._headers)
+        response.raise_for_status()
+        body: dict[str, Any] = response.json()
+        return RenderedConnectors(
+            manifests=list(body.get("manifests") or []),
+            owned_secret_name=str(body.get("owned_secret_name") or ""),
+            owned_secret_keys=list(body.get("owned_secret_keys") or []),
+        )
+
+
+@dataclass
+class PassSummary:
+    """What one sweep did. Reported so a pass is auditable without a debugger."""
+
+    reconciled: int = 0
+    applied: int = 0
+    deleted: int = 0
+    skipped: int = 0
+    failed: int = 0
+
+    @property
+    def did_work(self) -> bool:
+        return bool(self.applied or self.deleted or self.skipped or self.failed)
+
+
+class ConnectorReconcileLoop:
+    """Converges every deployed agent's connectors, forever."""
+
+    def __init__(
+        self,
+        *,
+        engine: AsyncEngine,
+        source: ManifestSource,
+        client: ConnectorClient,
+        namespace: str,
+        db_schema: str,
+        interval_seconds: float = 60.0,
+    ) -> None:
+        self._engine = engine
+        self._source = source
+        self._client = client
+        self._namespace = namespace
+        self._interval = interval_seconds
+        # Table identifiers are not user input; the schema comes from config.
+        self._sql = text(_TARGETS_SQL.format(schema=db_schema))
+
+    async def targets(self) -> list[AgentTarget]:
+        async with self._engine.connect() as conn:
+            rows = (await conn.execute(self._sql)).mappings().all()
+        return [
+            AgentTarget(
+                agent_id=row["agent_id"],
+                agent_name=row["agent_name"],
+                version_id=row["version_id"],
+            )
+            for row in rows
+        ]
+
+    def _reconcile_one(self, target: AgentTarget) -> AgentOutcome:
+        return reconcile_agent(
+            self._source,
+            self._client,
+            agent=target.agent_name,
+            agent_id=str(target.agent_id),
+            version_id=str(target.version_id),
+            namespace=self._namespace,
+        )
+
+    async def one_pass(self) -> PassSummary:
+        """Reconcile every deployed agent once."""
+
+        summary = PassSummary()
+        for target in await self.targets():
+            summary.reconciled += 1
+            try:
+                outcome = await asyncio.to_thread(self._reconcile_one, target)
+            except Exception:
+                # Ends with this agent. Aborting the sweep would leave every
+                # later agent unreconciled, and the order is arbitrary.
+                summary.failed += 1
+                logger.exception(
+                    "connector reconcile raised for agent=%s; continuing with the rest",
+                    target.agent_name,
+                )
+                continue
+
+            if outcome.skipped:
+                summary.skipped += 1
+                continue
+            if outcome.report is not None:
+                summary.applied += len(outcome.report.applied)
+                summary.deleted += len(outcome.report.deleted)
+                if not outcome.report.ok:
+                    summary.failed += 1
+
+        log = logger.info if summary.did_work else logger.debug
+        log(
+            "connector reconcile pass: %d agent(s), %d applied, %d deleted, %d skipped, %d failed",
+            summary.reconciled,
+            summary.applied,
+            summary.deleted,
+            summary.skipped,
+            summary.failed,
+        )
+        return summary
+
+    async def run_forever(self, stop: asyncio.Event | None = None) -> None:
+        """Reconcile on an interval until told to stop.
+
+        Never raises. This shares a process with the kernel, so a reconcile
+        problem must not become a worker outage -- it fails loudly, waits, and
+        tries again.
+        """
+
+        stop = stop or asyncio.Event()
+        logger.info(
+            "connector reconcile loop started namespace=%s interval=%ss",
+            self._namespace,
+            self._interval,
+        )
+        while not stop.is_set():
+            try:
+                await self.one_pass()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("connector reconcile pass failed; retrying next interval")
+            try:
+                await asyncio.wait_for(stop.wait(), timeout=self._interval)
+            except TimeoutError:
+                continue
+        logger.info("connector reconcile loop stopped")

--- a/apps/worker/src/curie_worker/run.py
+++ b/apps/worker/src/curie_worker/run.py
@@ -26,6 +26,7 @@ from .approvals import ApprovalClient
 from .binding import BindingResolver
 from .bundle_store import BundleStore
 from .config import WorkerConfig
+from .connector_loop import ConnectorReconcileLoop, HttpManifestSource
 from .consumer import Consumer
 from .dead_letter_alert import install_dead_letter_alerting
 from .eval import EvalReporter, EvalStreamConsumer, LangfuseEvalRecorder
@@ -62,6 +63,10 @@ class Runtime:
     eval_redis: AsyncRedis
     eval_http: httpx.AsyncClient
     engine: AsyncEngine
+    # None unless the connector reconciler is enabled (ADR-0090, #1184). Held
+    # here so `_run` supervises it beside the consumers rather than letting it
+    # run unsupervised.
+    connector_loop: ConnectorReconcileLoop | None = None
 
 
 def _substrate_config(env: Mapping[str, str]) -> SubstrateConfig:
@@ -104,9 +109,7 @@ def _sandbox_client(
     """
     substrate = env.get("CURIE_SANDBOX_SUBSTRATE", "kubernetes").lower()
     if substrate == "docker":
-        has_credential = bool(config.credentials) or any(
-            v in env for v in _MODEL_CREDENTIAL_ENV
-        )
+        has_credential = bool(config.credentials) or any(v in env for v in _MODEL_CREDENTIAL_ENV)
         has_local_model = bool(config.model_base_url)
         if not config.fake_model and not has_credential and not has_local_model:
             raise SystemExit(
@@ -182,9 +185,7 @@ def build(config: WorkerConfig, env: Mapping[str, str]) -> Runtime:
     kernel = Kernel(
         substrate=substrate,
         runner=runner,
-        sink=AsyncSlackSink(
-            config.slack_bot_token, base_url=config.slack_api_base_url or None
-        ),
+        sink=AsyncSlackSink(config.slack_bot_token, base_url=config.slack_api_base_url or None),
         lock=ThreadLock(
             async_redis,
             ttl_ms=config.lock_ttl_ms,
@@ -246,6 +247,7 @@ def build(config: WorkerConfig, env: Mapping[str, str]) -> Runtime:
         eval_redis=eval_redis,
         eval_http=eval_http,
         engine=engine,
+        connector_loop=_build_connector_loop(config, engine),
     )
 
 
@@ -284,6 +286,36 @@ async def _supervise(
                 pass
 
 
+def _build_connector_loop(
+    config: WorkerConfig, engine: AsyncEngine
+) -> ConnectorReconcileLoop | None:
+    """The connector reconcile loop, or None when it is switched off.
+
+    Constructed here rather than inside the loop so a bad kubeconfig fails at
+    boot, next to the flag that asked for it, instead of once per interval in a
+    background task nobody is watching.
+    """
+
+    if not config.connector_reconcile_enabled:
+        return None
+    from .connector_k8s import KubernetesConnectorClient
+
+    return ConnectorReconcileLoop(
+        engine=engine,
+        source=HttpManifestSource(
+            api_base_url=config.api_base_url,
+            api_key=config.api_key,
+            release=config.connector_release,
+            namespace=config.connector_namespace,
+            app_name=config.connector_app_name,
+        ),
+        client=KubernetesConnectorClient(),
+        namespace=config.connector_namespace,
+        db_schema=config.db_schema,
+        interval_seconds=config.connector_reconcile_interval_s,
+    )
+
+
 async def _run(config: WorkerConfig, env: Mapping[str, str]) -> None:
     rt = build(config, env)
 
@@ -313,10 +345,19 @@ async def _run(config: WorkerConfig, env: Mapping[str, str]) -> None:
             _supervise("evals", rt.eval_consumer.run, shutdown),
             _supervise(
                 "heartbeat",
-                lambda: run_heartbeat(
-                    config.heartbeat_file, config.heartbeat_interval_s, shutdown
-                ),
+                lambda: run_heartbeat(config.heartbeat_file, config.heartbeat_interval_s, shutdown),
                 shutdown,
+            ),
+            *(
+                [
+                    _supervise(
+                        "connectors",
+                        lambda: rt.connector_loop.run_forever(shutdown),  # type: ignore[union-attr]
+                        shutdown,
+                    )
+                ]
+                if rt.connector_loop is not None
+                else []
             ),
             return_exceptions=True,
         )

--- a/apps/worker/tests/binding/test_boot_env_single_declaration.py
+++ b/apps/worker/tests/binding/test_boot_env_single_declaration.py
@@ -119,6 +119,16 @@ _NON_BOOT_ALLOWLIST: frozenset[str] = frozenset(
         # into a sandbox: what the runner receives is the derived connector
         # scope (CURIE_CONNECTOR_RELEASE), which IS a declared BootEnv key.
         "CURIE_RELEASE",
+        # The connector reconciler's own switches (ADR-0090, #1184), read from
+        # the WORKER's env by WorkerConfig and consumed by the reconcile loop in
+        # the worker process. Nothing here reaches a sandbox: the reconciler
+        # writes Kubernetes objects, and what the runner learns about connectors
+        # is the derived scope built from CURIE_RELEASE/CURIE_NAMESPACE above.
+        # CURIE_CONNECTOR_APP_NAME is the chart's nameOverride, needed only to
+        # match the pod selector the connector NetworkPolicy uses.
+        "CURIE_CONNECTOR_RECONCILE",
+        "CURIE_CONNECTOR_RECONCILE_INTERVAL_S",
+        "CURIE_CONNECTOR_APP_NAME",
         "CURIE_RUNNER_IMAGE",
         "CURIE_SANDBOX_SUBSTRATE",
         "CURIE_WARM_POOL",

--- a/apps/worker/tests/reconcile/test_connector_loop.py
+++ b/apps/worker/tests/reconcile/test_connector_loop.py
@@ -1,0 +1,253 @@
+"""The reconcile loop's failure containment (ADR-0090, #1184).
+
+The loop shares a process with the kernel, whose four correctness rules are not
+negotiable. So most of what matters here is what happens when something goes
+wrong: one bad agent, a raising client, a database that will not answer.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+from curie_worker.connector_agent import AgentOutcome, RenderedConnectors
+from curie_worker.connector_apply import ApplyReport
+from curie_worker.connector_loop import AgentTarget, ConnectorReconcileLoop, PassSummary
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+def target(name: str) -> AgentTarget:
+    import uuid
+
+    return AgentTarget(agent_id=uuid.uuid4(), agent_name=name, version_id=uuid.uuid4())
+
+
+class Loop(ConnectorReconcileLoop):
+    """The loop with the database and the reconcile step swapped out.
+
+    Subclassed rather than mocked: `one_pass`'s containment logic is the thing
+    under test, and it should be exercised exactly as written.
+    """
+
+    def __init__(self, targets: list[AgentTarget], outcomes: dict[str, Any], **kw: Any) -> None:
+        self._targets = targets
+        self._outcomes = outcomes
+        self.seen: list[str] = []
+        self._namespace = "curie"
+        self._interval = kw.get("interval_seconds", 0.01)
+
+    async def targets(self) -> list[AgentTarget]:  # type: ignore[override]
+        return list(self._targets)
+
+    def _reconcile_one(self, t: AgentTarget) -> AgentOutcome:  # type: ignore[override]
+        self.seen.append(t.agent_name)
+        result = self._outcomes[t.agent_name]
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+
+def ok(agent: str, applied: int = 0, deleted: int = 0) -> AgentOutcome:
+    return AgentOutcome(
+        agent=agent,
+        report=ApplyReport(
+            applied=[("Service", f"s{i}") for i in range(applied)],
+            deleted=[("Service", f"d{i}") for i in range(deleted)],
+        ),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# One agent's failure ends with that agent
+# --------------------------------------------------------------------------- #
+async def test_a_raising_agent_does_not_strand_the_rest() -> None:
+    # Aborting the sweep would leave every later agent unreconciled, and the
+    # order is arbitrary -- so which agents those are changes between passes.
+    loop = Loop(
+        [target("a"), target("boom"), target("c")],
+        {"a": ok("a", applied=1), "boom": RuntimeError("apiserver down"), "c": ok("c", applied=1)},
+    )
+    summary = await loop.one_pass()
+
+    assert loop.seen == ["a", "boom", "c"], "the sweep stopped early"
+    assert summary.reconciled == 3
+    assert summary.applied == 2
+    assert summary.failed == 1
+
+
+async def test_a_failed_report_counts_without_raising() -> None:
+    failing = AgentOutcome(
+        agent="a", report=ApplyReport(failures=[("Service", "svc", "forbidden")])
+    )
+    summary = await Loop([target("a")], {"a": failing}).one_pass()
+    assert summary.failed == 1
+
+
+async def test_a_skipped_agent_is_counted_separately_from_a_failure() -> None:
+    # Skipping is a correct, expected outcome (an operator-supplied credential
+    # that is not provisioned). Counting it as a failure would make the normal
+    # state of a partially-migrated install look broken.
+    skipped = AgentOutcome(agent="a", skipped="credentials not provisioned")
+    summary = await Loop([target("a")], {"a": skipped}).one_pass()
+    assert summary.skipped == 1
+    assert summary.failed == 0
+
+
+async def test_no_agents_is_a_clean_pass() -> None:
+    summary = await Loop([], {}).one_pass()
+    assert summary == PassSummary()
+    assert not summary.did_work
+
+
+# --------------------------------------------------------------------------- #
+# Logging: quiet when converged
+# --------------------------------------------------------------------------- #
+async def test_a_converged_pass_does_not_log_at_info(caplog) -> None:
+    # The steady state is "nothing changed", forever. A loop that narrates every
+    # pass trains people to ignore it, and the one pass that mattered scrolls by.
+    with caplog.at_level("INFO", logger="curie_worker.connector_loop"):
+        await Loop([target("a")], {"a": ok("a")}).one_pass()
+    assert caplog.records == []
+
+
+async def test_a_pass_that_did_work_says_so(caplog) -> None:
+    with caplog.at_level("INFO", logger="curie_worker.connector_loop"):
+        await Loop([target("a")], {"a": ok("a", applied=2, deleted=1)}).one_pass()
+    assert any("2 applied, 1 deleted" in r.getMessage() for r in caplog.records)
+
+
+# --------------------------------------------------------------------------- #
+# The loop never takes the worker down
+# --------------------------------------------------------------------------- #
+async def test_a_pass_that_raises_outright_does_not_end_the_loop() -> None:
+    # `targets()` hitting a dead database is the realistic version of this.
+    passes = 0
+
+    class Broken(Loop):
+        async def one_pass(self):  # type: ignore[override]
+            nonlocal passes
+            passes += 1
+            if passes < 3:
+                raise RuntimeError("database is gone")
+            return PassSummary()
+
+    loop = Broken([], {}, interval_seconds=0.01)
+    stop = asyncio.Event()
+
+    async def run() -> None:
+        await loop.run_forever(stop)
+
+    task = asyncio.create_task(run())
+    while passes < 3:
+        await asyncio.sleep(0.01)
+    stop.set()
+    await asyncio.wait_for(task, timeout=2)
+
+    assert passes >= 3, "the loop gave up after a failing pass"
+
+
+async def test_stop_is_honoured_promptly_rather_than_after_the_interval() -> None:
+    # A worker shutdown must not wait out a 60s sleep.
+    loop = Loop([], {}, interval_seconds=300)
+    stop = asyncio.Event()
+    task = asyncio.create_task(loop.run_forever(stop))
+    await asyncio.sleep(0.05)
+    stop.set()
+    # If stop did not interrupt the interval wait, this times out rather than
+    # sitting for the full 300s.
+    await asyncio.wait_for(task, timeout=2)
+
+
+async def test_cancellation_propagates() -> None:
+    # Cancelled is not an error to swallow; the worker is shutting down.
+    loop = Loop([], {}, interval_seconds=300)
+    task = asyncio.create_task(loop.run_forever(asyncio.Event()))
+    await asyncio.sleep(0.05)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
+# --------------------------------------------------------------------------- #
+# The manifest source
+# --------------------------------------------------------------------------- #
+def test_the_http_source_reads_the_fields_the_agent_step_needs(monkeypatch) -> None:
+    import functools
+
+    import httpx
+    from curie_worker.connector_loop import HttpManifestSource
+
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["key"] = request.headers.get("X-API-Key")
+        return httpx.Response(
+            200,
+            json={
+                "manifests": [{"kind": "Service", "metadata": {"name": "svc"}}],
+                "owned_secret_name": "curie-a-connector-secrets",
+                "owned_secret_keys": ["TOKEN"],
+                "mcp_entries": {},
+            },
+        )
+
+    source = HttpManifestSource(
+        api_base_url="http://api:8000/",
+        api_key="k",
+        release="curie",
+        namespace="curie",
+        app_name="curie",
+    )
+    monkeypatch.setattr(
+        httpx, "Client", functools.partial(httpx.Client, transport=httpx.MockTransport(handler))
+    )
+    rendered = source.rendered(agent_id="a-1", version_id="v-1")
+
+    assert rendered.manifests[0]["metadata"]["name"] == "svc"
+    assert rendered.needs_operator_credentials
+    assert rendered.owned_secret_name == "curie-a-connector-secrets"
+    assert "/agents/a-1/versions/v-1/connectors" in captured["url"]
+    assert "release=curie" in captured["url"], "the caller must supply install-time facts"
+    assert captured["key"] == "k"
+
+
+def test_the_worker_builds_no_loop_when_the_flag_is_off() -> None:
+    # The default path must not touch the Kubernetes client at all -- a worker
+    # with no kubeconfig and no interest in connectors still has to boot.
+    from curie_worker.config import WorkerConfig
+    from curie_worker.run import _build_connector_loop
+
+    assert _build_connector_loop(WorkerConfig(), engine=None) is None  # type: ignore[arg-type]
+
+
+def test_enabling_the_reconciler_without_addressing_it_is_refused() -> None:
+    # Names are built from release + app_name. With either missing, every name
+    # the reconciler renders differs from what exists: it finds nothing of its
+    # own, creates a parallel set under wrong names, and leaves the real
+    # connectors unmanaged -- silently, looking like it works.
+    import pydantic
+    from curie_worker.config import WorkerConfig
+
+    with pytest.raises(pydantic.ValidationError, match="CURIE_CONNECTOR_APP_NAME"):
+        WorkerConfig(
+            connector_reconcile_enabled=True,
+            connector_namespace="curie",
+            connector_release="curie",
+            connector_app_name="",
+        )
+
+
+def test_the_http_source_defaults_are_safe_when_the_api_omits_fields() -> None:
+    # An older API that predates owned_secret_keys must not read as "no
+    # credentials needed", which would let the loop prune one.
+    rendered = RenderedConnectors()
+    assert rendered.manifests == []
+    assert not rendered.needs_operator_credentials

--- a/charts/curie/ci/connector-reconciler-rbac-assertions.sh
+++ b/charts/curie/ci/connector-reconciler-rbac-assertions.sh
@@ -15,7 +15,7 @@
 #     not exist at all when the reconciler is switched off. A component that is
 #     not running should not hold delete-on-Secrets.
 #
-# Six assertions:
+# Eight assertions:
 #   (a) With the reconciler DISABLED (the default), the worker Role grants
 #       nothing on the four connector kinds.
 #   (b) Disabled render still grants the two agent-sandbox CRD rules, so the
@@ -28,6 +28,12 @@
 #       module's docstring claims this file enforces that; this is the claim.
 #   (f) Nothing the reconciler grants is cluster-scoped, and it never mentions
 #       pods.
+#   (g) The RBAC and the worker's env are switched by the SAME flag. Half the
+#       pair is the worst outcome: the grant without the env is unused
+#       authority, and the env without the grant is a loop that 403s forever.
+#   (h) The reconciler is pointed at the namespace and release the worker
+#       already tells the runner about, so the Service it creates is the one the
+#       agent dials.
 #
 # Runnable locally (from anywhere) and from CI. Fails loudly, naming the
 # assertion.
@@ -161,4 +167,19 @@ if grep -q "pods" <<<"$ENABLED_RULES"; then
   fail f "the connector Role mentions pods; it manages objects, never pods directly"
 fi
 
-echo "connector-reconciler-rbac-assertions: all six assertions passed"
+# (g) The RBAC and the env are switched by the SAME flag. Half of the pair is
+#     the worst outcome: the grant without the env is unused authority, and the
+#     env without the grant is a loop that 403s every pass forever.
+for required in CURIE_CONNECTOR_RECONCILE CURIE_CONNECTOR_APP_NAME CURIE_API_URL CURIE_API_KEY; do
+  grep -q "$required" <<<"$ENABLED" || fail g "enabling the reconciler did not render $required"
+  grep -q "$required" <<<"$DISABLED" &&
+    fail g "$required renders with the reconciler disabled; the env gate is not working"
+done
+
+# (h) The worker reconciles the namespace and release it already tells the
+#     runner about. Two settings could disagree, and the symptom would be a
+#     connector that exists and an agent that cannot reach it.
+grep -q "CURIE_NAMESPACE" <<<"$ENABLED" || fail h "CURIE_NAMESPACE is missing from the worker env"
+grep -q "CURIE_RELEASE" <<<"$ENABLED" || fail h "CURIE_RELEASE is missing from the worker env"
+
+echo "connector-reconciler-rbac-assertions: all eight assertions passed"

--- a/charts/curie/templates/worker.yaml
+++ b/charts/curie/templates/worker.yaml
@@ -132,6 +132,28 @@ spec:
             # name is knowable only here.
             - name: CURIE_RELEASE
               value: {{ .Release.Name | quote }}
+{{- if .Values.worker.connectorReconciler.enabled }}
+            # Connector reconciler (ADR-0090, #1184). It reuses CURIE_NAMESPACE
+            # and CURIE_RELEASE above deliberately: the runner dials a connector
+            # Service by the name those two produce, and the reconciler creates
+            # it by the same name. Two separate settings could disagree, and the
+            # symptom would be a connector that exists and an agent that cannot
+            # reach it.
+            - name: CURIE_CONNECTOR_RECONCILE
+              value: "true"
+            # The chart's nameOverride, which appears in the pod selector the
+            # connector NetworkPolicy matches on. The worker cannot derive it.
+            - name: CURIE_CONNECTOR_APP_NAME
+              value: {{ include "curie.name" . | quote }}
+            - name: CURIE_CONNECTOR_RECONCILE_INTERVAL_S
+              value: {{ .Values.worker.connectorReconciler.intervalSeconds | quote }}
+            # The reconciler fetches rendered objects from the API rather than
+            # re-deriving them (ADR-0090), so it needs to reach it. Included only
+            # on this branch: wiring it unconditionally would also switch on the
+            # worker's eval reporting, which is unwired today, and that is a
+            # behaviour change this flag did not ask for.
+            {{- include "curie.env.api" . | nindent 12 }}
+{{- end }}
             - name: CURIE_WARM_POOL
               value: {{ $warmPool | quote }}
             - name: CURIE_RUNNER_PORT

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -591,6 +591,11 @@ worker:
   # not be handed to a component that is not using it.
   connectorReconciler:
     enabled: false
+    # How often a pass runs. The steady state is "nothing changed", and a
+    # converged pass is one list call per object kind per agent, so this is
+    # cheap -- but it is also the worst-case delay between a push landing and
+    # its connectors existing, so do not raise it far without reason.
+    intervalSeconds: 60
   # The SandboxWarmPool the substrate claims from. Empty -> derived as
   # `<release>-runner-pool` (the name templates/agent-sandbox.yaml gives it).
   warmPool: ""


### PR DESCRIPTION
The last piece of [ADR-0090](docs/adr/0090-a-reconciler-applies-connectors-so-agent-repos-need-no-cli.md): a background loop that converges every deployed agent's connectors, so a push updates them with no CLI near the cluster.

> **Stacked.** Contains #1191 and #1192 until they merge; this PR's own diff is `connector_loop.py`, the worker wiring, and the chart env. Merge order: **#1191 → #1192 → this**.

## Where it runs

In the worker, per your call. It already holds cluster-write authority for SandboxClaims and already reads the agents tables; a separate Deployment would need its own ServiceAccount, database credential, API key and image for what is a periodic query plus a handful of applies.

## Containment

Three properties, each with a test named for the failure it prevents:

**One agent's failure ends with that agent.** Aborting the sweep would leave every later agent unreconciled — and the order is arbitrary, so *which* agents those are changes between passes.

**A pass never kills the worker.** This shares a process with the kernel, whose four correctness rules are not negotiable. The loop fails loudly and repeatedly without taking anything else down. `CancelledError` still propagates, and `stop` interrupts the interval wait rather than making shutdown sit out 60 seconds.

**Quiet when converged.** The steady state is "nothing changed", forever. Only work and failures log at INFO. A loop that narrates every pass trains people to ignore it, and then the pass that mattered scrolls by unread.

## Two things I got wrong first

**Duplicate config fields.** I added `connector_release` / `connector_namespace` — both of which already exist, reading `CURIE_RELEASE` / `CURIE_NAMESPACE` for the runner's connector scope. My versions silently shadowed them. They are now reused deliberately: the runner dials a Service by the name those produce and the reconciler *creates* it by that name, so two settings that could disagree would mean a connector that exists and an agent that cannot reach it.

**A misconfiguration that looks like success.** Names derive from release + app_name. With either missing, every name the reconciler renders differs from what exists — it finds nothing of its own, creates a parallel set under wrong names, and leaves the real connectors unmanaged, silently. Now refused at construction:

```
CURIE_CONNECTOR_RECONCILE=1                        -> REFUSED: … CURIE_NAMESPACE, CURIE_RELEASE, CURIE_CONNECTOR_APP_NAME
+ CURIE_NAMESPACE + CURIE_RELEASE                  -> REFUSED: … CURIE_CONNECTOR_APP_NAME is unset
+ CURIE_CONNECTOR_APP_NAME                         -> OK (interval 60.0s)
```

## The query

Mirrors `binding.py`'s precedence (prod outranks dev, then most recent) so the connectors an agent gets belong to the same version its sandbox boots. `DISTINCT ON` collapses an agent with both environments active to that one winner — without it the agent is reconciled twice per pass, the second undoing the first.

## Chart

Env and RBAC are gated on the same flag, and two new assertions pin that pairing, because half of it is the worst outcome: the grant without the env is unused authority; the env without the grant is a loop that 403s every pass forever. Both directions falsified:

| break | result |
|---|---|
| drop the API env | `FAIL [g] enabling the reconciler did not render CURIE_API_URL` |
| ungate the env block | `FAIL [g] CURIE_CONNECTOR_RECONCILE renders with the reconciler disabled` |

The API wiring is included only on that branch. Wiring it unconditionally would also switch on the worker's currently-unwired eval reporting — a behaviour change this flag did not ask for.

```
uv run pytest apps/worker/tests/reconcile -q                     # 62 passed, 6 skipped
bash charts/curie/ci/connector-reconciler-rbac-assertions.sh     # all eight
```

Refs #1184