### PR TITLE
Git-flow routes a push through deploy.yaml, so one repo serves many agents

### DIFF
--- a/apps/api/alembic/versions/0018_agents_repo_not_unique.py
+++ b/apps/api/alembic/versions/0018_agents_repo_not_unique.py
@@ -1,0 +1,72 @@
+"""one repository, many agents: drop the unique on agents.repo_full_name (#1070)
+
+ADR-0091. `ix_agents_repo_full_name` was created UNIQUE by 0003, which encoded
+"one repository builds one agent" into the schema. That is the last thing
+standing between ADR-0090 and its acceptance test: a repo with a dev bot and a
+prod bot -- the same bundle on two channels, which is what a dev/prod split of a
+Slack bot IS -- cannot exist, so the repository has to keep deploy workflows to
+create the second one out of band.
+
+`repo_full_name` becomes what it always described: which repository an agent is
+built from, with several agents legitimately sharing one. Which agent a given
+push deploys to is answered by the bundle's `deploy.yaml`, not by the schema.
+
+The index itself is kept, non-unique. Git-flow looks agents up by this column on
+every webhook delivery, so dropping it outright would turn each push into a
+sequential scan of the agents table.
+
+Note the asymmetry with 0017, which ADDED a unique constraint on slack_channel:
+one agent still owns one channel. Two agents sharing a repository is intended;
+two agents sharing a channel is the silent-shadowing bug 0017 closed. Downgrade
+therefore restores the unique index and can fail on data this migration made
+legal -- which is the honest behaviour, since ADR-0091 notes re-adding it later
+means resolving whatever duplicates exist by then.
+
+Revision ID: 0018
+Revises: 0017
+Create Date: 2026-08-01
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0018"
+down_revision: str | None = "0017"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+SCHEMA = "curie"
+INDEX = "ix_agents_repo_full_name"
+
+
+def upgrade() -> None:
+    op.drop_index(INDEX, table_name="agents", schema=SCHEMA)
+    op.create_index(INDEX, "agents", ["repo_full_name"], unique=False, schema=SCHEMA)
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    duplicates = conn.execute(
+        sa.text(
+            f"""
+            SELECT repo_full_name, count(*) AS n,
+                   string_agg(name, ', ' ORDER BY name) AS agents
+            FROM {SCHEMA}.agents
+            WHERE repo_full_name IS NOT NULL
+            GROUP BY repo_full_name
+            HAVING count(*) > 1
+            ORDER BY repo_full_name
+            """
+        )
+    ).all()
+    if duplicates:
+        listed = "; ".join(f"{row.repo_full_name} ({row.agents})" for row in duplicates)
+        raise RuntimeError(
+            "cannot restore the unique index: these repositories build more than "
+            f"one agent -- {listed}. Re-point or delete the extra agents first. "
+            "This is the one-way edge ADR-0091 called out."
+        )
+    op.drop_index(INDEX, table_name="agents", schema=SCHEMA)
+    op.create_index(INDEX, "agents", ["repo_full_name"], unique=True, schema=SCHEMA)

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -204,7 +204,7 @@
         "type": "object"
       },
       "AgentUpdate": {
-        "description": "Partial update of mutable agent fields. slack_channel, model, and\napproval_required_tools are updatable (name and repo binding are identity);\nan omitted field is left unchanged.",
+        "description": "Partial update of mutable agent fields. An omitted field is unchanged.\n\nThe repo binding stopped being identity in ADR-0091: one repository builds\nmany agents now, so binding is a routing fact, not a name.",
         "properties": {
           "approval_required_tools": {
             "anyOf": [
@@ -244,6 +244,17 @@
               }
             ],
             "title": "Model"
+          },
+          "repo_full_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Repo Full Name"
           },
           "secrets": {
             "anyOf": [

--- a/apps/api/src/curie_api/bundles.py
+++ b/apps/api/src/curie_api/bundles.py
@@ -27,7 +27,8 @@ from plugin_format import (
     validate_bundle,
 )
 from plugin_format.connectors import ConnectorsFile, validate_connectors
-from plugin_format.validate import CONNECTORS_FILE
+from plugin_format.deploy_targets import DeployTargetsFile, validate_deploy_targets
+from plugin_format.validate import CONNECTORS_FILE, DEPLOY_FILE
 
 # Re-exported so existing catchers (gitflow.py, routers/bundles.py, tests) keep
 # resolving ``bundles.UnsupportedArchive`` after the extraction logic moved to
@@ -110,6 +111,23 @@ def read_connectors(root: Path) -> ConnectorsFile:
     parsed, errors = validate_connectors(yaml.safe_load(path.read_text(encoding="utf-8")))
     if errors or parsed is None:  # pragma: no cover -- validate_bundle gates this
         return ConnectorsFile()
+    return parsed
+
+
+def read_deploy_targets(root: Path) -> DeployTargetsFile | None:
+    """Parse a validated bundle's ``deploy.yaml``, or None when it declares none.
+
+    None is not an error. A bundle without ``deploy.yaml`` predates ADR-0089
+    and still deploys to the single agent its repository binds -- the caller
+    must keep working for it, not reject it.
+    """
+
+    path = bundle_root(root) / DEPLOY_FILE
+    if not path.is_file():
+        return None
+    parsed, errors = validate_deploy_targets(yaml.safe_load(path.read_text(encoding="utf-8")))
+    if errors or parsed is None:  # pragma: no cover -- validate_bundle gates this
+        return None
     return parsed
 
 

--- a/apps/api/src/curie_api/crud.py
+++ b/apps/api/src/curie_api/crud.py
@@ -19,9 +19,7 @@ from .models import (
 from .schemas import AgentCreate, ApprovalRequest, DeploymentCreate, VersionCreate
 
 
-async def get_version(
-    session: AsyncSession, version_id: uuid.UUID
-) -> AgentVersion | None:
+async def get_version(session: AsyncSession, version_id: uuid.UUID) -> AgentVersion | None:
     return await session.get(AgentVersion, version_id)
 
 
@@ -45,9 +43,7 @@ async def create_agent(session: AsyncSession, data: AgentCreate) -> Agent:
         repo_full_name=data.repo_full_name,
         model=data.model,
         behavior_packs=(
-            data.behavior_packs.model_dump()
-            if data.behavior_packs is not None
-            else None
+            data.behavior_packs.model_dump() if data.behavior_packs is not None else None
         ),
         approval_required_tools=data.approval_required_tools,
         approval_routes=(
@@ -72,9 +68,7 @@ async def get_agent(session: AsyncSession, agent_id: uuid.UUID) -> Agent | None:
     return await session.get(Agent, agent_id)
 
 
-async def agent_has_active_deployment(
-    session: AsyncSession, agent_id: uuid.UUID
-) -> bool:
+async def agent_has_active_deployment(session: AsyncSession, agent_id: uuid.UUID) -> bool:
     result = await session.scalar(
         select(Deployment.id)
         .where(Deployment.agent_id == agent_id, Deployment.status == "active")
@@ -88,28 +82,20 @@ async def delete_agent(session: AsyncSession, agent_id: uuid.UUID) -> None:
     # relationship cascade (which would emit an async lazy-load during flush) and
     # match the FK ondelete=CASCADE already declared on both child tables. Bundle
     # objects in MinIO are intentionally left in place (out of scope).
-    await session.execute(
-        delete(Deployment).where(Deployment.agent_id == agent_id)
-    )
-    await session.execute(
-        delete(AgentVersion).where(AgentVersion.agent_id == agent_id)
-    )
+    await session.execute(delete(Deployment).where(Deployment.agent_id == agent_id))
+    await session.execute(delete(AgentVersion).where(AgentVersion.agent_id == agent_id))
     await session.execute(delete(Agent).where(Agent.id == agent_id))
     await session.commit()
 
 
-async def update_agent_channel(
-    session: AsyncSession, agent: Agent, slack_channel: str
-) -> Agent:
+async def update_agent_channel(session: AsyncSession, agent: Agent, slack_channel: str) -> Agent:
     agent.slack_channel = slack_channel
     await session.commit()
     await session.refresh(agent)
     return agent
 
 
-async def update_agent_model(
-    session: AsyncSession, agent: Agent, model: str | None
-) -> Agent:
+async def update_agent_model(session: AsyncSession, agent: Agent, model: str | None) -> Agent:
     agent.model = model
     await session.commit()
     await session.refresh(agent)
@@ -172,12 +158,37 @@ async def update_agent_secrets(
     return agent
 
 
-async def get_agent_by_repo(
-    session: AsyncSession, repo_full_name: str
-) -> Agent | None:
+async def get_agent_by_repo(session: AsyncSession, repo_full_name: str) -> Agent | None:
     agent: Agent | None = await session.scalar(
         select(Agent).where(Agent.repo_full_name == repo_full_name)
     )
+    return agent
+
+
+async def update_agent_repo(session: AsyncSession, agent: Agent, repo_full_name: str) -> Agent:
+    agent.repo_full_name = repo_full_name
+    await session.commit()
+    await session.refresh(agent)
+    return agent
+
+
+async def get_agents_by_repo(session: AsyncSession, repo_full_name: str) -> list[Agent]:
+    """Every agent built from this repository (ADR-0091).
+
+    One repository legitimately binds several agents -- a dev bot and a prod
+    bot are the same bundle on two channels. Ordered by name so a caller that
+    must pick one without a target (a bundle predating ``deploy.yaml``) picks
+    the same one every time rather than whatever the planner returned.
+    """
+
+    result = await session.scalars(
+        select(Agent).where(Agent.repo_full_name == repo_full_name).order_by(Agent.name)
+    )
+    return list(result)
+
+
+async def get_agent_by_name(session: AsyncSession, name: str) -> Agent | None:
+    agent: Agent | None = await session.scalar(select(Agent).where(Agent.name == name))
     return agent
 
 
@@ -226,9 +237,7 @@ async def get_version_by_commit(
     return version
 
 
-async def list_versions(
-    session: AsyncSession, agent_id: uuid.UUID
-) -> list[AgentVersion]:
+async def list_versions(session: AsyncSession, agent_id: uuid.UUID) -> list[AgentVersion]:
     result = await session.scalars(
         select(AgentVersion)
         .where(AgentVersion.agent_id == agent_id)
@@ -258,9 +267,7 @@ async def create_deployment_row(
     return deployment
 
 
-async def create_deployment(
-    session: AsyncSession, data: DeploymentCreate
-) -> Deployment:
+async def create_deployment(session: AsyncSession, data: DeploymentCreate) -> Deployment:
     return await create_deployment_row(
         session,
         agent_id=data.agent_id,
@@ -302,9 +309,7 @@ async def list_deployments(
     return list(result)
 
 
-async def get_deployment(
-    session: AsyncSession, deployment_id: uuid.UUID
-) -> Deployment | None:
+async def get_deployment(session: AsyncSession, deployment_id: uuid.UUID) -> Deployment | None:
     return await session.get(Deployment, deployment_id)
 
 
@@ -347,9 +352,7 @@ async def get_approval(session: AsyncSession, approval_id: uuid.UUID) -> Approva
     return await session.get(Approval, approval_id)
 
 
-async def get_approval_route_binding(
-    session: AsyncSession, approval: Approval
-) -> Any:
+async def get_approval_route_binding(session: AsyncSession, approval: Approval) -> Any:
     """The route binding governing ``approval``, read fresh at resolve time
     (#420), or None when there is none to read.
 
@@ -378,9 +381,7 @@ async def get_approval_route_binding(
     return agent.approval_routes.get(approval.route)
 
 
-async def get_approval_by_dedupe_key(
-    session: AsyncSession, dedupe_key: str
-) -> Approval | None:
+async def get_approval_by_dedupe_key(session: AsyncSession, dedupe_key: str) -> Approval | None:
     result: Approval | None = await session.scalar(
         select(Approval).where(Approval.dedupe_key == dedupe_key)
     )
@@ -467,9 +468,7 @@ async def list_expired_pending_approvals(
     return list(result)
 
 
-async def expire_approval(
-    session: AsyncSession, approval_id: uuid.UUID
-) -> Approval | None:
+async def expire_approval(session: AsyncSession, approval_id: uuid.UUID) -> Approval | None:
     """Flip a pending approval past its SLA to expired (same CAS guard, so an
     in-flight resolution that already won is never overwritten)."""
 
@@ -561,9 +560,7 @@ _RESUMABLE_STATUSES = (
 )
 
 
-async def claim_resume_row(
-    session: AsyncSession, approval_id: uuid.UUID
-) -> Approval | None:
+async def claim_resume_row(session: AsyncSession, approval_id: uuid.UUID) -> Approval | None:
     """Atomically claim one owed-wake row for this reconcile pass (#411).
 
     ``SELECT ... FOR UPDATE SKIP LOCKED`` locks the row for the caller's

--- a/apps/api/src/curie_api/gitflow.py
+++ b/apps/api/src/curie_api/gitflow.py
@@ -16,16 +16,20 @@ import re
 import shutil
 import subprocess
 import tempfile
+import uuid
+from collections.abc import Sequence
+from pathlib import Path
 from urllib.parse import urlsplit
 
 from aci_protocol import EvalJob
+from plugin_format.deploy_targets import DeployTargetsFile
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.concurrency import run_in_threadpool
 
 from . import bundles, crud, deploy
 from .config import Settings
 from .evalqueue import EvalQueue, now_iso
-from .models import Environment
+from .models import Agent, AgentVersion, Environment
 from .schemas import WebhookResult
 from .storage import ObjectStore
 
@@ -273,9 +277,7 @@ def clone_and_archive(
                 timeout=120,
             )
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
-            raise GitFlowError(
-                f"could not archive {sha[:12]}: {_git_failure_detail(exc)}"
-            ) from exc
+            raise GitFlowError(f"could not archive {sha[:12]}: {_git_failure_detail(exc)}") from exc
         return archived.stdout
     finally:
         shutil.rmtree(tmp, ignore_errors=True)
@@ -306,11 +308,64 @@ async def process_push(
     if not isinstance(full_name, str) or not isinstance(clone_url, str):
         return WebhookResult(status="ignored")
 
-    agent = await crud.get_agent_by_repo(session, full_name)
+    # Every agent built from this repository (ADR-0091). A repository binds
+    # several on purpose: a dev bot and a prod bot are the same bundle on two
+    # channels. Which one THIS push deploys to comes from the bundle's
+    # deploy.yaml, so the bundle has to be fetched before the agent is known.
+    repo_agents = await crud.get_agents_by_repo(session, full_name)
     # The second clause is unreachable in practice (the lookup's predicate is
     # `Agent.repo_full_name == full_name` with a non-None argument); it exists
     # solely to narrow `str | None` to `str` for the origin derivation below.
-    if agent is None or agent.repo_full_name is None:
+    repo_agents = [a for a in repo_agents if a.repo_full_name is not None]
+    if not repo_agents:
+        return WebhookResult(status="ignored")
+
+    # The trust model does not move (ADR-0091). The origin is still derived from
+    # what the DATABASE holds, never the payload -- and with several agents it
+    # stays unambiguous, because every agent bound to a repository carries the
+    # same repo_full_name, so the derived origin is identical whichever row is
+    # read. The clone is authorized by the repository binding; the target only
+    # decides which agent receives the resulting Version.
+    trusted_repo_full_name = str(repo_agents[0].repo_full_name)
+
+    try:
+        archive = await run_in_threadpool(
+            clone_and_archive,
+            clone_url,
+            after,
+            settings,
+            repo_full_name=trusted_repo_full_name,
+        )
+        extension, content_type = deploy.validate_archive(archive, settings)
+    except CloneOriginMismatch as exc:
+        return WebhookResult(
+            status="rejected", errors=[{"code": "git.origin_mismatch", "message": str(exc)}]
+        )
+    except GitFlowError as exc:
+        return WebhookResult(
+            status="rejected", errors=[{"code": "git.archive_failed", "message": str(exc)}]
+        )
+    except bundles.UnsupportedArchive as exc:
+        return WebhookResult(
+            status="rejected", errors=[{"code": "bundle.unsupported", "message": str(exc)}]
+        )
+    except deploy.BundleInvalid as exc:
+        return WebhookResult(status="rejected", errors=exc.errors)
+
+    targets = await run_in_threadpool(_read_targets, archive, settings)
+    named = _target_agent_name(targets, environment)
+    named_elsewhere = (
+        await crud.get_agent_by_name(session, named)
+        if named and not any(a.name == named for a in repo_agents)
+        else None
+    )
+    try:
+        agent = resolve_target_agent(targets, environment, repo_agents, named_elsewhere)
+    except TargetUnresolved as exc:
+        return WebhookResult(status="rejected", errors=[{"code": exc.code, "message": str(exc)}])
+    if agent is None:
+        # A branch this bundle declares no target for. Silently doing nothing is
+        # correct and is what an unmatched branch already does.
         return WebhookResult(status="ignored")
 
     version = await crud.get_version_by_commit(session, agent.id, after)
@@ -322,38 +377,6 @@ async def process_push(
     # version must not enqueue a second job for the same version.
     bundle_built = version is None or version.bundle_ref is None
     if bundle_built:
-        try:
-            # The stored binding, never the payload's full_name: AC1 says the
-            # origin is derived from what the database holds.
-            data = await run_in_threadpool(
-                clone_and_archive,
-                clone_url,
-                after,
-                settings,
-                repo_full_name=agent.repo_full_name,
-            )
-            extension, content_type = deploy.validate_archive(data, settings)
-        # CloneOriginMismatch is a GitFlowError subclass, so it must be caught
-        # first or its clause is dead code. An operator has to be able to tell a
-        # forged push apart from a network failure.
-        except CloneOriginMismatch as exc:
-            return WebhookResult(
-                status="rejected",
-                errors=[{"code": "git.origin_mismatch", "message": str(exc)}],
-            )
-        except GitFlowError as exc:
-            return WebhookResult(
-                status="rejected",
-                errors=[{"code": "git.archive_failed", "message": str(exc)}],
-            )
-        except bundles.UnsupportedArchive as exc:
-            return WebhookResult(
-                status="rejected",
-                errors=[{"code": "bundle.unsupported", "message": str(exc)}],
-            )
-        except deploy.BundleInvalid as exc:
-            return WebhookResult(status="rejected", errors=exc.errors)
-
         if version is None:
             version = await crud.create_version_row(
                 session,
@@ -362,9 +385,21 @@ async def process_push(
                 created_by="git-flow",
                 commit_sha=after,
             )
-        await deploy.store_bundle(
-            store, session, agent.id, version, data, extension, content_type
-        )
+        # Bundle-once, bind-many (ADR-0091). A sibling agent in this repository
+        # may already hold this exact commit -- the dev push that ran minutes
+        # ago. Reuse its stored object rather than uploading the same bytes
+        # again: prod then promotes not merely an identical artifact but the
+        # SAME one, which is what makes "promote what you validated" a property
+        # of the schema rather than of discipline.
+        sibling = await _sibling_bundle(session, repo_agents, agent.id, after)
+        if sibling is not None:
+            version = await crud.attach_bundle(
+                session, version, str(sibling.bundle_ref), str(sibling.bundle_sha256)
+            )
+        else:
+            await deploy.store_bundle(
+                store, session, agent.id, version, archive, extension, content_type
+            )
 
     # Either the version pre-existed with a bundle, or the block above created
     # or repaired it; it is non-None from here on.
@@ -416,3 +451,122 @@ async def process_push(
         deployment_id=deployment.id,
         commit_sha=after,
     )
+
+
+class TargetUnresolved(Exception):
+    """A push cannot be routed to an agent, with an operator-facing reason."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+def resolve_target_agent(
+    targets: "DeployTargetsFile | None",
+    environment: Environment,
+    repo_agents: "Sequence[Agent]",
+    named_elsewhere: "Agent | None",
+) -> "Agent | None":
+    """Which agent this push deploys to (ADR-0091).
+
+    Returns None when the push should be ignored -- a branch with no matching
+    target, exactly as an unmatched branch is ignored today. Raises
+    ``TargetUnresolved`` when it should be REJECTED, which is a different thing:
+    the author declared a target and it cannot be honoured, so silence would
+    look like a deploy that worked.
+
+    ``named_elsewhere`` is the agent the target names IF it exists but is bound
+    to a different repository. That case is the sharpest edge in ADR-0091 and
+    the reason this function takes an argument for it: without the check, one
+    repository's push deploys over another repository's agent. It is refused.
+    """
+
+    if targets is None:
+        # A bundle predating ADR-0089. It deploys where it always did: to the
+        # single agent this repository binds. With several bound there is no
+        # basis to choose, and guessing would deploy to the wrong bot silently.
+        if len(repo_agents) == 1:
+            return repo_agents[0]
+        raise TargetUnresolved(
+            "deploy.no_targets",
+            f"{len(repo_agents)} agents are built from this repository but the "
+            "bundle declares no deploy.yaml, so there is nothing to say which "
+            "one this branch deploys to. Add deploy.yaml (ADR-0089).",
+        )
+
+    matching = [t for t in targets.targets.values() if t.env == environment.value]
+    if not matching:
+        # Not an error: a repository may deploy only prod from main and leave
+        # dev to the CLI. Ignoring matches how an unmatched branch behaves.
+        return None
+    if len(matching) > 1:
+        raise TargetUnresolved(
+            "deploy.ambiguous_env",
+            f"deploy.yaml declares {len(matching)} targets with env "
+            f"{environment.value!r} ({', '.join(sorted(str(t.agent) for t in matching))}); "
+            "one branch cannot deploy to two agents in one push.",
+        )
+
+    wanted = matching[0].agent
+    for agent in repo_agents:
+        if agent.name == wanted:
+            return agent
+
+    if named_elsewhere is not None:
+        # One repository's push would otherwise deploy over another's agent.
+        raise TargetUnresolved(
+            "deploy.agent_bound_elsewhere",
+            f"deploy.yaml names agent {wanted!r}, which is built from a "
+            "different repository. Refusing: a push must not deploy over an "
+            "agent another repository owns.",
+        )
+    raise TargetUnresolved(
+        "deploy.unknown_agent",
+        f"deploy.yaml names agent {wanted!r}, which does not exist. Create it "
+        "once (`curie cluster deploy`, or the console) so the push has "
+        "something to deploy to; a webhook does not mint agents.",
+    )
+
+
+def _read_targets(archive: bytes, settings: Settings) -> DeployTargetsFile | None:
+    """Read ``deploy.yaml`` out of an already-validated archive.
+
+    Extracted to a temp dir because that is the only way to read one file out
+    of the bundle, and run in a threadpool by the caller since it is blocking.
+    """
+
+    with tempfile.TemporaryDirectory() as tmp:
+        bundles.extract_and_validate(
+            archive,
+            Path(tmp),
+            max_uncompressed_bytes=settings.bundle_max_uncompressed_bytes,
+            max_compression_ratio=settings.bundle_max_compression_ratio,
+            max_members=settings.bundle_max_members,
+        )
+        return bundles.read_deploy_targets(Path(tmp))
+
+
+def _target_agent_name(targets: DeployTargetsFile | None, environment: Environment) -> str | None:
+    """The agent name this environment's target names, if exactly one does."""
+
+    if targets is None:
+        return None
+    matching = [t for t in targets.targets.values() if t.env == environment.value]
+    return str(matching[0].agent) if len(matching) == 1 else None
+
+
+async def _sibling_bundle(
+    session: AsyncSession,
+    repo_agents: "Sequence[Agent]",
+    agent_id: uuid.UUID,
+    commit_sha: str,
+) -> "AgentVersion | None":
+    """A version another agent of this repo already stored for this commit."""
+
+    for sibling in repo_agents:
+        if sibling.id == agent_id:
+            continue
+        existing = await crud.get_version_by_commit(session, sibling.id, commit_sha)
+        if existing is not None and existing.bundle_ref:
+            return existing
+    return None

--- a/apps/api/src/curie_api/models.py
+++ b/apps/api/src/curie_api/models.py
@@ -36,18 +36,23 @@ class ApprovalStatus(enum.StrEnum):
 class Agent(Base):
     __tablename__ = "agents"
 
-    id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
-    )
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     name: Mapped[str] = mapped_column(unique=True)
     # One agent per Slack channel (#38). The worker resolves a channel to an
     # agent, so a second agent bound to the same channel could never respond --
     # it would be silently shadowed. Enforced here so it fails at create time.
     slack_channel: Mapped[str] = mapped_column(unique=True)
     # The GitHub repo (owner/name) whose pushes deploy this agent (J1).
-    repo_full_name: Mapped[str | None] = mapped_column(
-        default=None, unique=True, index=True
-    )
+    #
+    # NOT unique (ADR-0091, #1070). One repository legitimately builds several
+    # agents -- a dev bot and a prod bot are the same bundle on two channels,
+    # which is what a dev/prod split of a Slack bot is. Which agent a push
+    # deploys to is answered by the bundle's `deploy.yaml`, not by the schema.
+    # Indexed because git-flow looks agents up by this column on every webhook.
+    #
+    # Deliberately asymmetric with `slack_channel` above: two agents sharing a
+    # repository is intended, two sharing a channel is silent shadowing.
+    repo_full_name: Mapped[str | None] = mapped_column(default=None, index=True)
     # Per-agent budget (L1). Field names match the frozen ACI SessionConfig
     # CURIE_BUDGET so the worker passes them straight through at sandbox boot;
     # NULL means platform defaults apply.
@@ -64,17 +69,13 @@ class Agent(Base):
     # NULL means no packs (the platform default). The shape is validated by
     # schemas.BehaviorPacksConfig on write and parsed by
     # curie_worker.behaviorpacks.BehaviorPacks on read.
-    behavior_packs: Mapped[dict[str, Any] | None] = mapped_column(
-        JSONB, default=None
-    )
+    behavior_packs: Mapped[dict[str, Any] | None] = mapped_column(JSONB, default=None)
     # Per-agent permission gates (#245, ADR-0010): tool names whose calls
     # require human approval. Forwarded by the worker binding as
     # CURIE_APPROVAL_REQUIRED_TOOLS at sandbox boot; the runner's
     # can_use_tool callback blocks these calls and ends the turn
     # awaiting-approval. NULL means no permission gates (the bypass posture).
-    approval_required_tools: Mapped[list[str] | None] = mapped_column(
-        JSONB, default=None
-    )
+    approval_required_tools: Mapped[list[str] | None] = mapped_column(JSONB, default=None)
     # Per-agent approval route bindings (#247, ADR-0010): the workspace half of
     # the split policy. The bundle manifest declares gate points and route
     # NAMES (versioned with the agent); this maps each declared name to
@@ -83,9 +84,7 @@ class Agent(Base):
     # decide where the approval card goes (and therefore who the
     # channel-membership authorizer counts as approvers). NULL means no
     # bindings; an unbound route falls back to the requesting channel.
-    approval_routes: Mapped[dict[str, Any] | None] = mapped_column(
-        JSONB, default=None
-    )
+    approval_routes: Mapped[dict[str, Any] | None] = mapped_column(JSONB, default=None)
     # Per-agent connector secrets (ADR-0009, #429): the named secret VALUES the
     # bundle's authed MCP servers need (e.g. GITHUB_PERSONAL_ACCESS_TOKEN). The
     # bundle declares the NAMES (plugin-format `secrets`); values are supplied at
@@ -104,9 +103,7 @@ class Agent(Base):
 class AgentVersion(Base):
     __tablename__ = "agent_versions"
 
-    id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
-    )
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     agent_id: Mapped[uuid.UUID] = mapped_column(
         ForeignKey(f"{SCHEMA}.agents.id", ondelete="CASCADE"), index=True
     )
@@ -125,9 +122,7 @@ class AgentVersion(Base):
 class Deployment(Base):
     __tablename__ = "deployments"
 
-    id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
-    )
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     agent_id: Mapped[uuid.UUID] = mapped_column(
         ForeignKey(f"{SCHEMA}.agents.id", ondelete="CASCADE"), index=True
     )
@@ -158,9 +153,7 @@ class Approval(Base):
 
     __tablename__ = "approvals"
 
-    id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
-    )
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     # Nullable: a run without a deployment binding (the generic/dev path) can
     # still gate on a human decision.
     agent_id: Mapped[uuid.UUID | None] = mapped_column(
@@ -229,9 +222,7 @@ class ApprovalAuditEntry(Base):
 
     __tablename__ = "approval_audit_entries"
 
-    id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
-    )
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     approval_id: Mapped[uuid.UUID] = mapped_column(
         ForeignKey(f"{SCHEMA}.approvals.id", ondelete="CASCADE"), index=True
     )
@@ -272,9 +263,7 @@ class WorkflowStateEntry(Base):
         UniqueConstraint("agent_id", "namespace", "key", name="uq_state_agent_ns_key"),
     )
 
-    id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
-    )
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     agent_id: Mapped[uuid.UUID] = mapped_column(
         ForeignKey(f"{SCHEMA}.agents.id", ondelete="CASCADE")
     )
@@ -287,6 +276,4 @@ class WorkflowStateEntry(Base):
     # it last read, and the write is rejected if the stored version moved on.
     version: Mapped[int] = mapped_column(default=1)
     created_at: Mapped[datetime] = mapped_column(server_default=func.now())
-    updated_at: Mapped[datetime] = mapped_column(
-        server_default=func.now(), onupdate=func.now()
-    )
+    updated_at: Mapped[datetime] = mapped_column(server_default=func.now(), onupdate=func.now())

--- a/apps/api/src/curie_api/routers/agents.py
+++ b/apps/api/src/curie_api/routers/agents.py
@@ -25,9 +25,7 @@ from ..schemas import (
     enforce_behavior_packs_size,
 )
 
-router = APIRouter(
-    prefix="/agents", tags=["agents"], dependencies=[Depends(require_api_key)]
-)
+router = APIRouter(prefix="/agents", tags=["agents"], dependencies=[Depends(require_api_key)])
 
 # Postgres SQLSTATE for a unique_violation. asyncpg exposes it (and the
 # violated constraint's name) as plain attributes on the wrapped driver
@@ -39,7 +37,16 @@ _UNIQUE_VIOLATION = "23505"
 # generic message.
 _UNIQUE_CONSTRAINT_MESSAGES = {
     "agents_name_key": "an agent with that name already exists",
-    "ix_agents_repo_full_name": "an agent for that repository already exists",
+    # ix_agents_repo_full_name stopped being unique in 0018 (ADR-0091): one
+    # repository builds many agents now. The mapping is kept because a
+    # pre-0018 database still has the unique index, and an operator hitting it
+    # deserves the actionable message rather than the generic fallback. It
+    # names the fix, since the constraint is no longer intended behaviour.
+    "ix_agents_repo_full_name": (
+        "an agent for that repository already exists. One repository may build "
+        "several agents (ADR-0091) -- run `alembic upgrade head` to apply "
+        "migration 0018, which drops this constraint"
+    ),
     # #38: one agent per channel. Without this the create succeeded and the
     # second agent was silently shadowed by the worker's resolver at runtime.
     "agents_slack_channel_key": (
@@ -122,9 +129,7 @@ async def get_agent(agent_id: uuid.UUID, session: SessionDep) -> AgentOut:
 
 
 @router.patch("/{agent_id}", response_model=AgentOut)
-async def update_agent(
-    agent_id: uuid.UUID, data: AgentUpdate, session: SessionDep
-) -> AgentOut:
+async def update_agent(agent_id: uuid.UUID, data: AgentUpdate, session: SessionDep) -> AgentOut:
     # Lets a redeploy move an existing agent's Slack channel (the CLI only sends
     # this when --slack-channel was passed explicitly). An omitted field is a
     # no-op so the agent's current channel is preserved.
@@ -151,9 +156,7 @@ async def update_agent(
         agent = await crud.update_agent_model(session, agent, data.model)
     if data.approval_required_tools is not None:
         # Omitted leaves the gates unchanged; an explicit [] clears them (#245).
-        agent = await crud.update_agent_approval_tools(
-            session, agent, data.approval_required_tools
-        )
+        agent = await crud.update_agent_approval_tools(session, agent, data.approval_required_tools)
     if data.approval_routes is not None:
         # Omitted leaves the bindings unchanged; an explicit {} clears them (#247).
         agent = await crud.update_agent_approval_routes(
@@ -161,6 +164,10 @@ async def update_agent(
             agent,
             {name: b.model_dump() for name, b in data.approval_routes.items()},
         )
+    if data.repo_full_name is not None:
+        # Binds this agent to a repository so git-flow can route pushes to it
+        # (ADR-0091). Several agents may share one, so this cannot collide.
+        agent = await crud.update_agent_repo(session, agent, data.repo_full_name)
     if data.secrets is not None:
         # Omitted leaves the secrets unchanged; an explicit {} clears them (#429).
         agent = await crud.update_agent_secrets(session, agent, data.secrets)
@@ -199,18 +206,14 @@ async def create_version(
 
 
 @router.get("/{agent_id}/versions", response_model=list[VersionOut])
-async def list_versions(
-    agent_id: uuid.UUID, session: SessionDep
-) -> list[VersionOut]:
+async def list_versions(agent_id: uuid.UUID, session: SessionDep) -> list[VersionOut]:
     if await crud.get_agent(session, agent_id) is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "agent not found")
     versions = await crud.list_versions(session, agent_id)
     return [VersionOut.model_validate(v) for v in versions]
 
 
-@router.get(
-    "/{agent_id}/versions/{version_id}/connectors", response_model=ConnectorManifests
-)
+@router.get("/{agent_id}/versions/{version_id}/connectors", response_model=ConnectorManifests)
 async def read_version_connectors(
     agent_id: uuid.UUID,
     version_id: uuid.UUID,
@@ -237,9 +240,7 @@ async def read_version_connectors(
     if version is None or version.agent_id != agent_id:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "version not found")
     if version.bundle_ref is None:
-        raise HTTPException(
-            status.HTTP_404_NOT_FOUND, "no bundle stored for this version"
-        )
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "no bundle stored for this version")
     # Object names are scoped to the agent, not just the release (#1116). Curie
     # runs many agents per release, so a release-scoped name lets two agents
     # that each declare `grafana` overwrite one another's Deployment, Service,
@@ -287,9 +288,7 @@ async def read_version_connectors(
     return await run_in_threadpool(_render)
 
 
-@router.get(
-    "/{agent_id}/versions/{version_id}/files", response_model=BundleFiles
-)
+@router.get("/{agent_id}/versions/{version_id}/files", response_model=BundleFiles)
 async def read_version_files(
     agent_id: uuid.UUID,
     version_id: uuid.UUID,
@@ -304,9 +303,7 @@ async def read_version_files(
     if version is None or version.agent_id != agent_id:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "version not found")
     if version.bundle_ref is None:
-        raise HTTPException(
-            status.HTTP_404_NOT_FOUND, "no bundle stored for this version"
-        )
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "no bundle stored for this version")
     data = await store.get(version.bundle_ref)
     settings = get_settings()
     read = functools.partial(

--- a/apps/api/src/curie_api/schemas.py
+++ b/apps/api/src/curie_api/schemas.py
@@ -356,9 +356,11 @@ class AgentCreate(BaseModel):
 
 
 class AgentUpdate(BaseModel):
-    """Partial update of mutable agent fields. slack_channel, model, and
-    approval_required_tools are updatable (name and repo binding are identity);
-    an omitted field is left unchanged."""
+    """Partial update of mutable agent fields. An omitted field is unchanged.
+
+    The repo binding stopped being identity in ADR-0091: one repository builds
+    many agents now, so binding is a routing fact, not a name.
+    """
 
     slack_channel: str | None = None
     # New per-agent model id (#254). Omitted (None) leaves the current model
@@ -373,6 +375,12 @@ class AgentUpdate(BaseModel):
     # New connector secrets (#429). Omitted (None) leaves current secrets
     # unchanged; an explicit empty dict clears them.
     secrets: dict[str, str] | None = None
+    # Which repository's pushes deploy this agent (ADR-0091). PATCHable because
+    # an agent created before its repo existed -- or, until migration 0018, the
+    # SECOND agent of a repo, which the unique index forbade from carrying it --
+    # has no other way to be bound. Without this, git-flow cannot find that
+    # agent and a target naming it is rejected as unknown.
+    repo_full_name: str | None = None
 
     _check_slack_channel = field_validator("slack_channel")(_validate_slack_channel_id)
     _check_approval_tools = field_validator("approval_required_tools")(_validate_tool_names)

--- a/apps/api/tests/test_agents.py
+++ b/apps/api/tests/test_agents.py
@@ -14,9 +14,7 @@ def _create(client: Any, headers: dict[str, str], **fields: Any) -> Any:
     return client.post("/agents", json=fields, headers=headers)
 
 
-def test_duplicate_name_is_409(
-    client: Any, auth_headers: dict[str, str], clean_db: None
-) -> None:
+def test_duplicate_name_is_409(client: Any, auth_headers: dict[str, str], clean_db: None) -> None:
     first = _create(client, auth_headers, name="dup-name", slack_channel="C0AAAAAA1")
     assert first.status_code == 201, first.text
 
@@ -25,9 +23,18 @@ def test_duplicate_name_is_409(
     assert dup.json()["detail"] == "an agent with that name already exists"
 
 
-def test_duplicate_repo_is_409(
+def test_two_agents_may_share_one_repository(
     client: Any, auth_headers: dict[str, str], clean_db: None
 ) -> None:
+    """ADR-0091: one repository builds many agents.
+
+    This asserted a 409 until migration 0018. That constraint is what forced a
+    repo wanting a dev bot AND a prod bot -- the same bundle on two channels,
+    which is what a dev/prod split IS -- to create the second one out of band
+    and carry deploy workflows to do it. Which agent a push deploys to is now
+    answered by the bundle's `deploy.yaml`, not by the schema.
+    """
+
     first = _create(
         client,
         auth_headers,
@@ -37,15 +44,42 @@ def test_duplicate_repo_is_409(
     )
     assert first.status_code == 201, first.text
 
-    dup = _create(
+    second = _create(
         client,
         auth_headers,
         name="repo-agent-b",
         slack_channel="C0DDDDDD4",
         repo_full_name="octo/shared-repo",
     )
-    assert dup.status_code == 409, dup.text
-    assert dup.json()["detail"] == "an agent for that repository already exists"
+    assert second.status_code == 201, second.text
+    assert second.json()["repo_full_name"] == "octo/shared-repo"
+
+
+def test_two_agents_may_not_share_one_channel(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    """The deliberate asymmetry (#38). Sharing a repo is intended; sharing a
+    channel is the silent-shadowing bug -- the worker resolves a channel to one
+    agent, so the loser is deployed, healthy-looking, and never answering."""
+
+    assert (
+        _create(
+            client,
+            auth_headers,
+            name="chan-agent-a",
+            slack_channel="C0EEEEEE5",
+            repo_full_name="octo/one-repo",
+        ).status_code
+        == 201
+    )
+    clash = _create(
+        client,
+        auth_headers,
+        name="chan-agent-b",
+        slack_channel="C0EEEEEE5",
+        repo_full_name="octo/other-repo",
+    )
+    assert clash.status_code == 409, clash.text
 
 
 def test_duplicate_slack_channel_is_409(
@@ -314,9 +348,7 @@ def test_agent_approval_routes_rejects_bad_approvers(
             json={
                 "name": f"bad-approvers-{index}",
                 "slack_channel": "C000000C01",
-                "approval_routes": {
-                    "managers": {"channel": "C000000C02", "approvers": approvers}
-                },
+                "approval_routes": {"managers": {"channel": "C000000C02", "approvers": approvers}},
             },
             headers=auth_headers,
         )
@@ -403,9 +435,7 @@ def test_agent_approval_routes_patch_rejects_bad_approvers(
     patched = client.patch(
         f"/agents/{created.json()['id']}",
         json={
-            "approval_routes": {
-                "managers": {"channel": "C000000D02", "approvers": {"users": []}}
-            }
+            "approval_routes": {"managers": {"channel": "C000000D02", "approvers": {"users": []}}}
         },
         headers=auth_headers,
     )

--- a/apps/api/tests/test_gitflow_integration.py
+++ b/apps/api/tests/test_gitflow_integration.py
@@ -38,9 +38,7 @@ VALID_FILES = {
 
 
 @pytest.fixture
-def trusted_clone_base(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> Iterator[Path]:
+def trusted_clone_base(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Iterator[Path]:
     """Point `GITHUB_CLONE_BASE` at a per-test `file://` base and yield it.
 
     `routers/github.py` calls `get_settings()` per request rather than through a
@@ -77,9 +75,7 @@ def _git(*args: str, cwd: Path | None = None) -> str:
     return out.stdout.strip()
 
 
-def _build_bare_repo(
-    base_dir: Path, repo_full_name: str, files: dict[str, str]
-) -> tuple[str, str]:
+def _build_bare_repo(base_dir: Path, repo_full_name: str, files: dict[str, str]) -> tuple[str, str]:
     """Create a bare repo at `<base_dir>/<repo_full_name>.git`. Returns (url, sha).
 
     The returned URL is byte-identical to the origin the API derives from
@@ -103,9 +99,7 @@ def _build_bare_repo(
     return f"file://{bare}", sha
 
 
-def _post(
-    client: Any, event: str, payload: dict[str, Any], secret: str = SECRET
-) -> Any:
+def _post(client: Any, event: str, payload: dict[str, Any], secret: str = SECRET) -> Any:
     body = json.dumps(payload).encode()
     sig = "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
     return client.post(
@@ -180,14 +174,10 @@ def test_dev_push_deploys_dev_bot(
     assert body["commit_sha"] == sha
 
     # The version was built from the commit and its bundle is stored + fetchable.
-    version = client.get(
-        f"/agents/{agent_id}/versions", headers=auth_headers
-    ).json()[0]
+    version = client.get(f"/agents/{agent_id}/versions", headers=auth_headers).json()[0]
     assert version["commit_sha"] == sha
     assert version["bundle_ref"] is not None
-    bundle = client.get(
-        f"/agents/{agent_id}/versions/{version['id']}/bundle", headers=auth_headers
-    )
+    bundle = client.get(f"/agents/{agent_id}/versions/{version['id']}/bundle", headers=auth_headers)
     assert bundle.status_code == 200
     assert len(bundle.content) > 0
 
@@ -208,12 +198,8 @@ def test_main_push_promotes_and_reuses_the_built_version(
     agent_id = _register_agent(client, auth_headers)
     clone_url, sha = _build_bare_repo(trusted_clone_base, REPO, VALID_FILES)
 
-    dev = _post(
-        client, "push", _push_payload("refs/heads/dev", sha, clone_url)
-    ).json()
-    prod = _post(
-        client, "push", _push_payload("refs/heads/main", sha, clone_url)
-    ).json()
+    dev = _post(client, "push", _push_payload("refs/heads/dev", sha, clone_url)).json()
+    prod = _post(client, "push", _push_payload("refs/heads/main", sha, clone_url)).json()
 
     assert prod["status"] == "promoted"
     assert prod["environment"] == "prod"
@@ -243,9 +229,7 @@ def test_partial_version_is_rebuilt_not_reused(
     assert resp.status_code == 200
     assert resp.json()["status"] == "deployed"
 
-    versions = client.get(
-        f"/agents/{agent_id}/versions", headers=auth_headers
-    ).json()
+    versions = client.get(f"/agents/{agent_id}/versions", headers=auth_headers).json()
     # The partial row was repaired in place (no duplicate) and now has a bundle.
     assert len(versions) == 1
     assert versions[0]["commit_sha"] == sha
@@ -267,9 +251,7 @@ def test_invalid_signature_is_401(
     assert resp.status_code == 401
 
 
-def test_ping_event_pongs(
-    client: Any, auth_headers: dict[str, str], clean_db: None
-) -> None:
+def test_ping_event_pongs(client: Any, auth_headers: dict[str, str], clean_db: None) -> None:
     resp = _post(client, "ping", {"zen": "hi"})
     assert resp.status_code == 200
     assert resp.json()["status"] == "pong"
@@ -296,9 +278,7 @@ def test_non_deploy_branch_is_ignored(
 ) -> None:
     _register_agent(client, auth_headers)
     clone_url, sha = _build_bare_repo(trusted_clone_base, REPO, VALID_FILES)
-    resp = _post(
-        client, "push", _push_payload("refs/heads/feature-x", sha, clone_url)
-    )
+    resp = _post(client, "push", _push_payload("refs/heads/feature-x", sha, clone_url))
     assert resp.status_code == 200
     assert resp.json()["status"] == "ignored"
 
@@ -345,9 +325,7 @@ def test_signed_push_with_a_foreign_clone_url_is_rejected(
     resp = _post(
         client,
         "push",
-        _push_payload(
-            "refs/heads/dev", sha, f"https://evil.example/{REPO}.git"
-        ),
+        _push_payload("refs/heads/dev", sha, f"https://evil.example/{REPO}.git"),
     )
     assert resp.status_code == 200, resp.text
     body = resp.json()
@@ -358,10 +336,7 @@ def test_signed_push_with_a_foreign_clone_url_is_rejected(
     # Nothing was built and nothing was deployed.
     assert client.get(f"/agents/{agent_id}/versions", headers=auth_headers).json() == []
     assert (
-        client.get(
-            "/deployments", params={"agent_id": agent_id}, headers=auth_headers
-        ).json()
-        == []
+        client.get("/deployments", params={"agent_id": agent_id}, headers=auth_headers).json() == []
     )
 
 
@@ -430,8 +405,142 @@ def test_signed_push_with_a_foreign_url_fallback_is_rejected(
 
     assert client.get(f"/agents/{agent_id}/versions", headers=auth_headers).json() == []
     assert (
-        client.get(
+        client.get("/deployments", params={"agent_id": agent_id}, headers=auth_headers).json() == []
+    )
+
+
+# --------------------------------------------------------------------------- #
+# One repository, two agents (ADR-0091, #1070)
+# --------------------------------------------------------------------------- #
+DEPLOY_YAML = """
+targets:
+  dev:
+    agent: two-agent-dev
+    env: dev
+    slack_channel: C000000D01
+  prod:
+    agent: two-agent-prod
+    env: prod
+    slack_channel: C000000E01
+"""
+
+TWO_TARGET_FILES = {**VALID_FILES, "deploy.yaml": DEPLOY_YAML}
+
+
+def _register(client: Any, headers: dict[str, str], name: str, channel: str) -> str:
+    resp = client.post(
+        "/agents",
+        json={"name": name, "slack_channel": channel, "repo_full_name": REPO},
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    return str(resp.json()["id"])
+
+
+def test_one_repo_binds_two_agents(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    # Before 0018 the second create was a 409 from the unique index, which is
+    # what forced sre-bot to make its second agent out of band.
+    _register(client, auth_headers, "two-agent-dev", "C000000D01")
+    _register(client, auth_headers, "two-agent-prod", "C000000E01")
+
+
+def test_dev_push_and_main_push_reach_different_agents(
+    client: Any,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    trusted_clone_base: Path,
+) -> None:
+    """The thing #1070 is for: dev -> the dev bot, main -> the prod bot."""
+
+    dev_id = _register(client, auth_headers, "two-agent-dev", "C000000D01")
+    prod_id = _register(client, auth_headers, "two-agent-prod", "C000000E01")
+    clone_url, sha = _build_bare_repo(trusted_clone_base, REPO, TWO_TARGET_FILES)
+
+    dev = _post(client, "push", _push_payload("refs/heads/dev", sha, clone_url)).json()
+    assert dev["status"] == "deployed", dev
+    assert dev["agent_id"] == dev_id, "a dev push must reach the dev agent"
+
+    prod = _post(client, "push", _push_payload("refs/heads/main", sha, clone_url)).json()
+    assert prod["status"] == "promoted", prod
+    assert prod["agent_id"] == prod_id, "a main push must reach the prod agent"
+
+    # Each agent holds exactly its own deployment, in its own environment.
+    for agent_id, expected in ((dev_id, "dev"), (prod_id, "prod")):
+        deployments = client.get(
             "/deployments", params={"agent_id": agent_id}, headers=auth_headers
         ).json()
+        assert [d["environment"] for d in deployments] == [expected]
+
+
+def test_prod_promotes_the_exact_artifact_dev_validated(
+    client: Any,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    trusted_clone_base: Path,
+) -> None:
+    # Bundle-once, bind-many. The two agents get their own Version ROWS (the
+    # worker's binding join requires a version to belong to its agent), but both
+    # rows point at the SAME stored object -- so prod promotes not merely
+    # identical bytes but the same artifact, by construction rather than by
+    # discipline.
+    dev_id = _register(client, auth_headers, "two-agent-dev", "C000000D01")
+    prod_id = _register(client, auth_headers, "two-agent-prod", "C000000E01")
+    clone_url, sha = _build_bare_repo(trusted_clone_base, REPO, TWO_TARGET_FILES)
+
+    _post(client, "push", _push_payload("refs/heads/dev", sha, clone_url))
+    _post(client, "push", _push_payload("refs/heads/main", sha, clone_url))
+
+    def only_version(agent_id: str) -> dict[str, Any]:
+        versions = client.get(f"/agents/{agent_id}/versions", headers=auth_headers).json()
+        assert len(versions) == 1, versions
+        return dict(versions[0])
+
+    dev_version, prod_version = only_version(dev_id), only_version(prod_id)
+    assert dev_version["id"] != prod_version["id"], "each agent owns its own version row"
+    assert dev_version["bundle_ref"] == prod_version["bundle_ref"], (
+        "prod must promote the artifact dev validated, not a re-upload of it"
+    )
+    assert dev_version["commit_sha"] == prod_version["commit_sha"] == sha
+
+
+def test_a_target_naming_another_repos_agent_is_rejected_end_to_end(
+    client: Any,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    trusted_clone_base: Path,
+) -> None:
+    # ADR-0091's sharpest edge, through the real webhook: `foreign-bot` belongs
+    # to somebody else's repository, so this push must not deploy over it.
+    _register(client, auth_headers, "two-agent-dev", "C000000D01")
+    client.post(
+        "/agents",
+        json={
+            "name": "foreign-bot",
+            "slack_channel": "C000000F01",
+            "repo_full_name": "someone-else/their-repo",
+        },
+        headers=auth_headers,
+    )
+    files = {
+        **VALID_FILES,
+        "deploy.yaml": (
+            "targets:\n  prod:\n    agent: foreign-bot\n"
+            "    env: prod\n    slack_channel: C000000F01\n"
+        ),
+    }
+    clone_url, sha = _build_bare_repo(trusted_clone_base, REPO, files)
+
+    body = _post(client, "push", _push_payload("refs/heads/main", sha, clone_url)).json()
+    assert body["status"] == "rejected", body
+    assert body["errors"][0]["code"] == "deploy.agent_bound_elsewhere"
+
+    # And nothing was deployed to the foreign agent.
+    foreign = next(
+        a for a in client.get("/agents", headers=auth_headers).json() if a["name"] == "foreign-bot"
+    )
+    assert (
+        client.get("/deployments", params={"agent_id": foreign["id"]}, headers=auth_headers).json()
         == []
     )

--- a/apps/api/tests/test_gitflow_targets.py
+++ b/apps/api/tests/test_gitflow_targets.py
@@ -1,0 +1,158 @@
+"""Routing a push through the bundle's deploy.yaml (ADR-0091, #1070).
+
+ADR-0091 named its own sharpest edge and said it "should be the first test
+written, not the last": a `deploy.yaml` naming an agent bound to a DIFFERENT
+repository would let one repository's push deploy over another's agent. It is
+the first test here.
+
+These cover `resolve_target_agent` directly -- it is a pure function of
+(targets, environment, the repo's agents, the possibly-foreign named agent), so
+every routing decision is testable with no webhook, no clone and no database.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from curie_api.gitflow import TargetUnresolved, resolve_target_agent
+from curie_api.models import Agent, Environment
+from plugin_format.deploy_targets import validate_deploy_targets
+
+REPO = "curie-eng/sre-bot"
+
+
+def agent(name: str, repo: str | None = REPO) -> Agent:
+    return Agent(id=uuid.uuid4(), name=name, slack_channel=f"C-{name}", repo_full_name=repo)
+
+
+def targets(text: str):
+    import yaml
+
+    parsed, errors = validate_deploy_targets(yaml.safe_load(text))
+    assert not errors, errors
+    return parsed
+
+
+DEV_AND_PROD = """
+targets:
+  dev:
+    agent: sre-bot-dev
+    env: dev
+    slack_channel: C000000A01
+  prod:
+    agent: sre-bot
+    env: prod
+    slack_channel: C000000A02
+"""
+
+
+# --------------------------------------------------------------------------- #
+# The sharpest edge, first
+# --------------------------------------------------------------------------- #
+def test_a_target_naming_another_repositorys_agent_is_refused() -> None:
+    # Without this, anyone who can push to repo A deploys over repo B's bot by
+    # naming it in their deploy.yaml.
+    foreign = agent("sre-bot", repo="someone-else/their-bot")
+    with pytest.raises(TargetUnresolved) as caught:
+        resolve_target_agent(
+            targets(DEV_AND_PROD), Environment.prod, [agent("sre-bot-dev")], foreign
+        )
+    assert caught.value.code == "deploy.agent_bound_elsewhere"
+    assert "another repository" in str(caught.value)
+
+
+def test_an_unknown_agent_is_refused_rather_than_created() -> None:
+    # A webhook does not mint agents. Creating one would let a push conjure a
+    # bot on a channel of its choosing.
+    with pytest.raises(TargetUnresolved) as caught:
+        resolve_target_agent(targets(DEV_AND_PROD), Environment.prod, [agent("sre-bot-dev")], None)
+    assert caught.value.code == "deploy.unknown_agent"
+    assert "does not exist" in str(caught.value)
+
+
+# --------------------------------------------------------------------------- #
+# The thing this is for: dev push -> dev agent, main push -> prod agent
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    ("environment", "expected"),
+    [(Environment.dev, "sre-bot-dev"), (Environment.prod, "sre-bot")],
+)
+def test_each_branch_reaches_its_own_agent(environment, expected) -> None:
+    both = [agent("sre-bot"), agent("sre-bot-dev")]
+    resolved = resolve_target_agent(targets(DEV_AND_PROD), environment, both, None)
+    assert resolved is not None and resolved.name == expected
+
+
+def test_the_two_targets_resolve_to_different_agents() -> None:
+    # The whole point of #1070. Before this, both branches resolved to whichever
+    # single agent the repository row named, so a dev merge and a main merge
+    # overwrote each other's active version.
+    both = [agent("sre-bot"), agent("sre-bot-dev")]
+    dev = resolve_target_agent(targets(DEV_AND_PROD), Environment.dev, both, None)
+    prod = resolve_target_agent(targets(DEV_AND_PROD), Environment.prod, both, None)
+    assert dev is not None and prod is not None
+    assert dev.id != prod.id
+
+
+# --------------------------------------------------------------------------- #
+# Ignore vs reject -- a distinction that decides whether silence is correct
+# --------------------------------------------------------------------------- #
+def test_a_branch_with_no_matching_target_is_ignored_not_rejected() -> None:
+    # A repo may deploy only prod from main and leave dev to the CLI. Ignoring
+    # matches how an unmatched branch already behaves.
+    prod_only = targets(
+        "targets:\n  prod:\n    agent: sre-bot\n    env: prod\n    slack_channel: C000000A02\n"
+    )
+    assert resolve_target_agent(prod_only, Environment.dev, [agent("sre-bot")], None) is None
+
+
+def test_two_targets_for_one_environment_are_refused() -> None:
+    # One push cannot deploy to two agents. Picking one silently would deploy
+    # to an agent the author did not intend half the time.
+    ambiguous = targets(
+        "targets:\n"
+        "  a:\n    agent: sre-bot\n    env: prod\n    slack_channel: C000000B01\n"
+        "  b:\n    agent: other-bot\n    env: prod\n    slack_channel: C000000B02\n"
+    )
+    with pytest.raises(TargetUnresolved) as caught:
+        resolve_target_agent(ambiguous, Environment.prod, [agent("sre-bot")], None)
+    assert caught.value.code == "deploy.ambiguous_env"
+
+
+# --------------------------------------------------------------------------- #
+# Bundles that predate deploy.yaml
+# --------------------------------------------------------------------------- #
+def test_a_bundle_without_deploy_yaml_still_deploys_its_single_agent() -> None:
+    # Back-compat. Every repo that worked before ADR-0089 must keep working.
+    only = agent("sre-bot")
+    assert resolve_target_agent(None, Environment.prod, [only], None) is only
+
+
+def test_a_bundle_without_deploy_yaml_and_several_agents_is_refused() -> None:
+    # There is no basis to choose, and guessing deploys to the wrong bot
+    # silently -- which is the #1070 bug, not a fallback for it.
+    with pytest.raises(TargetUnresolved) as caught:
+        resolve_target_agent(None, Environment.prod, [agent("a"), agent("b")], None)
+    assert caught.value.code == "deploy.no_targets"
+    assert "deploy.yaml" in str(caught.value)
+
+
+# --------------------------------------------------------------------------- #
+# Binding an existing agent to a repository
+# --------------------------------------------------------------------------- #
+def test_repo_full_name_is_patchable() -> None:
+    """Without this, ADR-0091 is unreachable for the repos that need it most.
+
+    A repository's SECOND agent could not carry `repo_full_name` before
+    migration 0018 -- the unique index forbade it -- so it exists today bound to
+    nothing. `AgentUpdate` had no field for it, and create-time was the only
+    place it could ever be set. Git-flow would therefore never find that agent,
+    and a `deploy.yaml` naming it would be rejected as unknown.
+    """
+
+    from curie_api.schemas import AgentUpdate
+
+    assert "repo_full_name" in AgentUpdate.model_fields
+    assert AgentUpdate().repo_full_name is None, "omitted must leave the binding unchanged"
+    assert AgentUpdate(repo_full_name="octo/x").repo_full_name == "octo/x"

--- a/apps/api/tests/test_integrity_mapping.py
+++ b/apps/api/tests/test_integrity_mapping.py
@@ -89,11 +89,12 @@ def test_classifies_name_unique_violation() -> None:
 
 
 def test_classifies_repo_full_name_unique_violation() -> None:
+    # Kept after 0018 dropped the constraint (ADR-0091): a pre-0018 database
+    # still carries it, and that operator deserves the fix, not the fallback.
     exc = _integrity_error(_UNIQUE_VIOLATION, "ix_agents_repo_full_name")
-    assert classify_integrity_error(exc) == (
-        409,
-        "an agent for that repository already exists",
-    )
+    code, message = classify_integrity_error(exc)
+    assert code == 409
+    assert "several agents" in message and "0018" in message
 
 
 def test_classifies_unrecognized_unique_violation_with_generic_message() -> None:
@@ -134,7 +135,6 @@ def test_classifies_name_unique_violation_via_cause_chain() -> None:
 
 def test_classifies_repo_full_name_unique_violation_via_cause_chain() -> None:
     exc = _layered_integrity_error(_UNIQUE_VIOLATION, "ix_agents_repo_full_name")
-    assert classify_integrity_error(exc) == (
-        409,
-        "an agent for that repository already exists",
-    )
+    code, message = classify_integrity_error(exc)
+    assert code == 409
+    assert "several agents" in message

--- a/docs/adr/0091-git-flow-resolves-deploy-targets-so-one-repo-serves-many-agents.md
+++ b/docs/adr/0091-git-flow-resolves-deploy-targets-so-one-repo-serves-many-agents.md
@@ -2,7 +2,7 @@
 
 Date: 2026-07-31
 
-Status: Draft
+Status: Accepted
 
 ## Context
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -119,5 +119,5 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0088 | [Per user delegated OAuth for MCP](0088-per-user-delegated-oauth-for-mcp.md) | Draft |
 | 0089 | [Bundles declare their deploy targets](0089-bundles-declare-their-deploy-targets.md) | Accepted |
 | 0090 | [A reconciler applies connectors, so agent repos need no CLI](0090-a-reconciler-applies-connectors-so-agent-repos-need-no-cli.md) | Accepted |
-| 0091 | [Git-flow resolves deploy targets, so one repo serves many agents](0091-git-flow-resolves-deploy-targets-so-one-repo-serves-many-agents.md) | Draft |
+| 0091 | [Git-flow resolves deploy targets, so one repo serves many agents](0091-git-flow-resolves-deploy-targets-so-one-repo-serves-many-agents.md) | Accepted |
 <!-- END GENERATED: adr-index -->


### PR DESCRIPTION
ADR-0091, now **Accepted**. This is the other half of ADR-0090 — with it, a push to `dev` updates the dev agent and a push to `main` deploys prod, with no CLI and no deploy workflow in the agent repo.

## The blocker

Git-flow resolved the agent for a push *by repository*, and `ix_agents_repo_full_name` was UNIQUE. One repository built exactly one agent. A repo wanting a dev bot **and** a prod bot — the same bundle on two channels, which is what a dev/prod split of a Slack bot *is* — had to create the second out of band and carry deploy workflows to do it.

## The trust model does not move

This is the part worth reviewing closely. `clone_and_archive` still derives the origin from `Settings.github_clone_base` + the `repo_full_name` **read from the database**, never the payload. That stays unambiguous with several agents, because every agent bound to a repository carries the same `repo_full_name` — so the derived origin is identical whichever row is read.

The clone is authorized by the *repository binding*; the target only decides which agent receives the resulting Version. Those stay separate questions. The one structural change: the bundle is fetched **before** the agent is known, because `deploy.yaml` lives inside it.

## Bundle-once, bind-many — with a correction to the ADR

ADR-0091 said "creates a Version once". That turns out not to be implementable as written: the worker's binding query joins

```sql
JOIN agent_versions v ON v.id = d.version_id AND v.agent_id = a.id
```

so a Version belongs to exactly one agent, and a shared row would be **invisible** to the second agent — it would deploy and never boot. Instead each agent gets its own Version row pointing at the **same stored object**. Prod therefore promotes not merely identical bytes but the same artifact, by construction rather than by discipline, with no second upload.

## Refusals, each with a code

| code | when |
|---|---|
| `deploy.agent_bound_elsewhere` | target names an agent built from a **different** repository |
| `deploy.unknown_agent` | target names an agent that does not exist |
| `deploy.ambiguous_env` | two targets share one environment |
| `deploy.no_targets` | several agents, no `deploy.yaml` |

The first is what ADR-0091 called its sharpest edge — "should be the first test written, not the last". It is, twice: as a unit test and end-to-end through the real webhook, asserting nothing was deployed to the foreign agent. Without it, anyone who can push to repo A deploys over repo B's bot by naming it.

`deploy.unknown_agent` refuses rather than creating: a webhook that mints agents could conjure a bot onto a channel of its choosing.

A branch with **no matching target is ignored, not rejected** — a repo may deploy only prod from main and leave dev to the CLI, and ignoring is what an unmatched branch already does.

## Migration 0018

Keeps the index, drops its uniqueness (git-flow looks agents up by that column on every delivery). `slack_channel` stays unique — the asymmetry is deliberate: two agents sharing a repository is intended, two sharing a channel is the silent-shadowing bug #38 closed. Downgrade names the offending repositories instead of failing on a bare duplicate-key.

## Verified against the real stack

Postgres + MinIO + real bare git repos, not mocks:

```
test_one_repo_binds_two_agents                              PASSED
test_dev_push_and_main_push_reach_different_agents          PASSED   # ← the ask
test_prod_promotes_the_exact_artifact_dev_validated         PASSED
test_a_target_naming_another_repos_agent_is_rejected_e2e    PASSED
```

```
uv run pytest apps/api/tests -q    # 515 passed (1 pre-existing Langfuse failure, fails on main too)
```

Closes #1070