### PR TITLE
Parse the connector scope in BootEnv.from_env

### DIFF
--- a/packages/aci-protocol/src/aci_protocol/session.py
+++ b/packages/aci-protocol/src/aci_protocol/session.py
@@ -669,6 +669,9 @@ class BootEnv(_AciModel):
             approval_resumed_kind=_stripped_or_none(env.get("CURIE_APPROVAL_RESUMED_KIND")),
             approval_decision=_stripped_or_none(env.get("CURIE_APPROVAL_DECISION")),
             connector_secret_keys=_list_or_none(env.get("CURIE_CONNECTOR_SECRET_KEYS")),
+            connector_release=_str_or_none(env.get("CURIE_CONNECTOR_RELEASE")),
+            connector_agent=_str_or_none(env.get("CURIE_CONNECTOR_AGENT")),
+            connector_namespace=_str_or_none(env.get("CURIE_CONNECTOR_NAMESPACE")),
             port=_required_int(env.get("CURIE_RUNNER_PORT")),
             base_url=_str_or_none(env.get("ANTHROPIC_BASE_URL")),
             # Empty is "not declared" for both, matching sdk_auth's own

--- a/packages/aci-protocol/tests/test_session.py
+++ b/packages/aci-protocol/tests/test_session.py
@@ -1,6 +1,6 @@
 import pytest
 from aci_protocol import BootEnv, Budget, EnvProducer, OtelConfig, SessionConfig
-from pydantic import ValidationError
+from pydantic import BaseModel, ValidationError
 
 
 def _full_config() -> SessionConfig:
@@ -168,27 +168,80 @@ def _full_boot_env() -> BootEnv:
         model="claude-opus-4-6",
         fake_model=True,
         history_ref=_HISTORY_REF,
-        history_token="st-scoped-token",
-        memory_token="st-scoped-token",
+        history_token="st-history-token",
+        memory_token="st-memory-token",
         state_url="http://api:8000/agents/agent-abc/state",
-        state_token="st-scoped-token",
+        state_token="st-state-token",
         approval_required_tools=["Bash", "mcp__github__create_pr"],
         approval_grant_tool="Bash",
         approval_resumed_kind="policy",
+        approval_decision="approved",
         connector_secret_keys=["GITHUB_TOKEN", "LINEAR_API_KEY"],
+        connector_release="curie",
+        connector_agent="acme-dev",
+        connector_namespace="curie-prod",
         port=9090,
         base_url="http://litellm:4000",
+        api_backend="messages",
+        model_env_key="MY_PROVIDER_KEY",
         max_turns=50,
         history_max_turns=10,
         history_max_bytes=2048,
     )
 
 
+def _unpopulated_fields(model: BaseModel, prefix: str = "") -> list[str]:
+    """Every field on ``model`` still at its declared default, recursing into
+    nested models.
+
+    Enumerated at runtime off ``model_fields`` rather than from a hand-kept
+    list, so a field ADDED to the model tomorrow shows up here the moment the
+    fixture does not populate it. Compared against the field's own declared
+    default (via ``FieldInfo.get_default``), not a hardcoded ``None``, so a
+    future field defaulting to ``False``/``0``/``""`` is still caught. A
+    required field has no default (``get_default`` returns
+    ``PydanticUndefined``), which never equals a real value, so a populated
+    required field is never flagged. Nested lists or dicts of models are not
+    walked; no field on these models has that shape today.
+    """
+
+    unpopulated: list[str] = []
+    for name, field in type(model).model_fields.items():
+        value = getattr(model, name)
+        path = f"{prefix}{name}"
+        default = field.get_default(call_default_factory=True)
+        if value == default:
+            unpopulated.append(path)
+        elif isinstance(value, BaseModel):
+            unpopulated.extend(_unpopulated_fields(value, prefix=f"{path}."))
+    return unpopulated
+
+
 # --- Model shape -------------------------------------------------------------
 
 
 def test_boot_env_roundtrips_every_declared_field() -> None:
+    """The class-closing invariant: nothing ``to_env`` emits may fail to parse back.
+
+    A field that ``to_env`` writes but ``from_env`` never reads comes back
+    ``None``, and nothing errors: the runner boots fine with the feature
+    silently switched off. That is exactly how CURIE_CONNECTOR_RELEASE /
+    _AGENT / _NAMESPACE were lost (#1195), and it is a defect the whole model is
+    exposed to every time a field is added.
+
+    The population guard is what keeps this test from decaying into a
+    tautology. A newly added optional field left unset in the fixture would
+    round trip as ``None == None`` and prove nothing, so the guard fails first
+    and names the field, forcing whoever adds it to give it a real value here.
+    """
+
     boot = _full_boot_env()
+    unpopulated = _unpopulated_fields(boot)
+    assert not unpopulated, (
+        "the round-trip fixture leaves these fields at their declared default, so "
+        "the assertion below would pass over them vacuously; give each a distinct, "
+        f"non-default value in _full_boot_env: {', '.join(unpopulated)}"
+    )
     assert BootEnv.from_env(boot.to_env()) == boot
 
 
@@ -856,6 +909,29 @@ def test_connector_scope_is_emitted_as_a_set_or_not_at_all() -> None:
     assert full["CURIE_CONNECTOR_RELEASE"] == "curie"
     assert full["CURIE_CONNECTOR_AGENT"] == "acme-dev"
     assert full["CURIE_CONNECTOR_NAMESPACE"] == "curie"
+
+
+def test_connector_scope_survives_the_worker_render_and_the_consumer_parse() -> None:
+    # Emitting the scope is only half the contract: the runner is the single
+    # consumer, so a key the worker writes and `from_env` never reads is the
+    # same outcome as never writing it. The agent loses its connector tools and
+    # nothing errors (#1195).
+    #
+    # Three DISTINCT values, because the runner composes
+    # `<release>-<agent>-mcp-<connector>.<namespace>`: a parse that reads one
+    # env key into two fields, or drops one of the three, must not be able to
+    # pass here.
+    boot = BootEnv.from_env(
+        _worker_env(
+            connector_release="curie",
+            connector_agent="acme-dev",
+            connector_namespace="curie-prod",
+        )
+        | _SUBSTRATE_ENV
+    )
+    assert boot.connector_release == "curie"
+    assert boot.connector_agent == "acme-dev"
+    assert boot.connector_namespace == "curie-prod"
 
 
 def test_connector_scope_is_absent_by_default() -> None:

--- a/runner/tests/test_connectors.py
+++ b/runner/tests/test_connectors.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from aci_protocol import BootEnv, Budget
+from curie_runner import RunnerConfig
 from curie_runner.connectors import derive_mcp_servers
 
 HOSTED = "connectors:\n  grafana:\n    image: grafana/mcp-grafana:0.17.2\n    secrets: [T]\n"
@@ -132,5 +134,81 @@ def test_the_cluster_still_uses_the_service_it_created(tmp_path: Path) -> None:
 def test_a_hosted_connector_without_a_fallback_still_mounts_nothing(tmp_path: Path) -> None:
     servers = derive_mcp_servers(
         _bundle(tmp_path, HOSTED), release=None, agent=None, namespace=None
+    )
+    assert servers == {}
+
+
+# --------------------------------------------------------------------------- #
+# The whole chain, worker render to mounted server -- #1195
+#
+# Every test above hands derive_mcp_servers a scope directly, which is the one
+# thing a real boot never does. The scope has to survive BootEnv.render_worker,
+# BootEnv.from_env, and RunnerConfig before it reaches this function, and a
+# break anywhere along that path is invisible: the scope arrives as None, the
+# hosted connector is treated as "not exercisable in this tier", and the agent
+# boots without its tools while nothing errors.
+# --------------------------------------------------------------------------- #
+
+# What the chart/docker substrate contributes; no worker producer writes these.
+_SUBSTRATE_ENV = {"CURIE_SANDBOX_ID": "curie-sandbox-abc123", "CURIE_RUNNER_PORT": "8080"}
+
+
+def _config_for(
+    plugin_dir: Path,
+    *,
+    release: str | None = None,
+    agent: str | None = None,
+    namespace: str | None = None,
+) -> RunnerConfig:
+    """A RunnerConfig built the way a real boot builds one.
+
+    Through the real producer and the real consumer parse, never by
+    constructing the dataclass: a hand-built config would assert on this test's
+    own idea of the boot env instead of on the one the worker actually renders.
+    """
+
+    env = (
+        BootEnv.render_worker(
+            plugin_dir=str(plugin_dir),
+            session_id="agent-abc-thread-1",
+            budget=Budget(max_output_tokens_per_run=4096, max_usd_per_day=5.0),
+            memory_ref="http://api:8000/agents/agent-abc/state/memory",
+            history_ref="http://api:8000/agents/agent-abc/state/transcript/t1",
+            connector_release=release,
+            connector_agent=agent,
+            connector_namespace=namespace,
+        )
+        | _SUBSTRATE_ENV
+    )
+    return RunnerConfig.from_env(env)
+
+
+def test_a_scope_rendered_by_the_worker_reaches_the_mounted_connector(tmp_path: Path) -> None:
+    # The acceptance criterion for #1195: a cluster boot that declares a hosted
+    # connector must end up dialing the Service Curie created for it.
+    config = _config_for(
+        _bundle(tmp_path, HOSTED), release="curie", agent="acme-dev", namespace="curie-prod"
+    )
+    servers = derive_mcp_servers(
+        config.session.plugin_dir,
+        release=config.connector_release,
+        agent=config.connector_agent,
+        namespace=config.connector_namespace,
+    )
+    assert servers["grafana"]["url"] == (
+        "http://curie-acme-dev-mcp-grafana.curie-prod.svc.cluster.local:8000/mcp"
+    )
+
+
+def test_a_boot_that_renders_no_scope_still_mounts_no_hosted_connector(tmp_path: Path) -> None:
+    # The other half. "Declared but not exercisable in this tier" (#1093) is the
+    # honest answer when the worker sends no scope, so the fix must reach the
+    # scope through the boot env and must never invent one.
+    config = _config_for(_bundle(tmp_path, HOSTED))
+    servers = derive_mcp_servers(
+        config.session.plugin_dir,
+        release=config.connector_release,
+        agent=config.connector_agent,
+        namespace=config.connector_namespace,
     )
     assert servers == {}


### PR DESCRIPTION
`BootEnv.from_env` is documented as "the one full parse" of the runner's boot env,
but it never read `CURIE_CONNECTOR_RELEASE`, `CURIE_CONNECTOR_AGENT` or
`CURIE_CONNECTOR_NAMESPACE`. The fields were declared and both emit paths wrote
them, so every gate stayed green while all three parsed back as `None`.
`RunnerConfig` forwarded the `None` values, `derive_mcp_servers` took its no-scope
branch, and a bundle declaring a hosted connector got no MCP server at cluster
tier. The agent lost its tools and nothing errored.

The production fix is three lines. The rest of the diff closes the class.

## What changed

- `from_env` reads the three keys, using the same `_str_or_none` helper as every
  sibling plain-string field in that constructor.
- A consumer-level test drives the real chain, `render_worker` into `from_env` into
  `RunnerConfig` into `derive_mcp_servers`, and asserts the derived Service URL for
  a hosted-only bundle. Release and namespace are distinct values, so transposing
  the two at the forward no longer yields a byte-identical URL.
- The existing declared-field round trip was passing vacuously: its fixture was
  missing six fields, including the connector scope. It is now maximal, and a
  runtime guard compares every field against its declared default and names any
  field left unset, so a field added later cannot round trip as a pair of matching
  defaults.

No wire change, so no protocol version bump and no regenerated artifacts.
`./scripts/check-contracts.sh` reports no drift.

## Verification

Full suite `uv run pytest -q`: 2363 passed, 11 skipped. `ruff`, `mypy` and
`check-contracts.sh` clean.

The tests were written and committed red before the fix, then verified by mutation:

- Deleting any one of the three reads fails 3 tests, and the scope test names the
  specific missing value each time.
- Transposing release and namespace at the `RunnerConfig` forward fails the
  consumer test.
- Removing a field from the round-trip fixture fails the guard, naming that field.
- The guard was exercised directly against fields left at `None`, `False`, `""` and
  `0` defaults, and catches all four while leaving a populated field alone.
- The issue's reproduction prints the three real values on this branch and `None`
  on `main`.

The full production chain is wired: `charts/curie/templates/worker.yaml` sets
`CURIE_RELEASE` and `CURIE_NAMESPACE`, the worker binding emits the scope,
`render_worker` emits it as a set, and the runner forwards it into
`derive_mcp_servers`. This parse was the only broken link. Not verified against a
live cluster mount; the chain is covered by in-repo tests and by execution of the
parse and the derivation.

## Scope note

`runner/tests/test_connectors.py` also gains a no-scope negative test that no
acceptance criterion asked for. It is kept deliberately: the existing negatives
inject `release=None` straight into `derive_mcp_servers`, whereas this one omits the
scope from `render_worker` and proves it stays absent through the real chain, which
is the seam the bug lived on. It also stops the fix over-correcting into fabricating
a URL where the tier hosts nothing.

## Follow-up

#1203 tracks three residual gaps this diff does not reach: `from_env` retypes its
env-key literals instead of deriving them, the generic invariant is anchored on
`to_env` rather than the real producer `render_worker`, and `RunnerConfig` has no
completeness guard of its own.

Closes #1195
