### PR TITLE
Reserve the platform MCP server names for Curie

### DIFF
--- a/packages/plugin-format/src/plugin_format/connectors.py
+++ b/packages/plugin-format/src/plugin_format/connectors.py
@@ -145,6 +145,32 @@ class ConnectorsFile(BaseModel):
 
 _NAME_RE = re.compile(r"[a-z0-9]([a-z0-9-]*[a-z0-9])?")
 
+# The two keys Curie's own platform MCP servers occupy on
+# ``ClaudeAgentOptions.mcp_servers``: the approval server and the durable
+# state server. A connector declaring one of these names replaces a platform
+# server in the agent's session -- silently, since both ride the same map a
+# declared connector rides -- and the agent loses ``request_approval`` or the
+# state tools with nothing logged until a skill calls one.
+#
+# The fence is these two exact names, not the ``curie-`` prefix, so a
+# legitimate connector called ``curie-docs`` stays legal.
+#
+# The real owners are ``runner/src/curie_runner/approval.py``
+# ``APPROVAL_SERVER_NAME`` and ``runner/src/curie_runner/state.py``
+# ``STATE_SERVER_NAME``. ``runner`` depends on ``plugin-format``, never the
+# reverse, so this validator cannot import those constants and re-enumerates
+# them instead. ``runner/tests/test_connectors.py`` is the drift pin that
+# keeps this copy honest.
+#
+# What each reserved name would displace, keyed by name, so the reserved-name
+# error message and the reserved set share one source instead of two hand
+# maintained copies.
+_RESERVED_CONNECTOR_DISPLACES: dict[str, str] = {
+    "curie": "`request_approval`",
+    "curie-state": "the durable-state tools",
+}
+RESERVED_CONNECTOR_NAMES: frozenset[str] = frozenset(_RESERVED_CONNECTOR_DISPLACES)
+
 # ``${CURIE_*}`` placeholders an author may write in args/env. The renderer
 # substitutes these with values only Curie can derive (the Service name it
 # invents, which embeds the release, agent, and namespace). Imported from the
@@ -200,6 +226,17 @@ def validate_connectors(data: Any) -> tuple[ConnectorsFile | None, list[tuple[st
                     f"{where}: a connector name becomes a Kubernetes object and DNS "
                     "label, so it must be lowercase alphanumeric or dashes, start and "
                     f"end alphanumeric, and be at most {_NAME_MAX} characters",
+                )
+            )
+        if name in RESERVED_CONNECTOR_NAMES:
+            lost = _RESERVED_CONNECTOR_DISPLACES[name]
+            errors.append(
+                (
+                    "connectors.reserved_name",
+                    f"{where}: `{name}` is reserved for Curie's own platform MCP server "
+                    "(the approval server / the durable state server), so a connector "
+                    "declaring it would replace that server in the agent's session and "
+                    f"the agent would lose {lost} -- rename the connector",
                 )
             )
         if spec.image and spec.url:

--- a/packages/plugin-format/tests/test_connectors.py
+++ b/packages/plugin-format/tests/test_connectors.py
@@ -324,3 +324,47 @@ def test_key_defaults_to_the_env_var_name() -> None:
     )
     assert parsed is not None
     assert parsed.connectors["g"].secrets[0].secret_key() == "T"  # type: ignore[union-attr]
+
+
+# --------------------------------------------------------------------------- #
+# Names Curie's own platform MCP servers occupy -- #1200
+# --------------------------------------------------------------------------- #
+RESERVED_NAMES = ["curie", "curie-state"]
+
+
+@pytest.mark.parametrize("name", RESERVED_NAMES)
+def test_a_reserved_platform_server_name_is_rejected(name: str) -> None:
+    # `curie` is the approval server and `curie-state` the durable state server.
+    # Both ride the same mcp_servers map a declared connector rides, so a
+    # connector claiming the name replaces the platform server in the agent's
+    # session -- the agent quietly loses request_approval or the state tools,
+    # with nothing logged and nothing failing until a skill calls one.
+    assert "connectors.reserved_name" in _codes({"connectors": {name: {"image": "x:1"}}})
+
+
+@pytest.mark.parametrize("name", RESERVED_NAMES)
+def test_bundle_rejects_a_reserved_connector_name(tmp_path: Path, name: str) -> None:
+    # The shape the issue reports as validating clean today: connectors.yaml
+    # declares the name, no .mcp.json exists, so the #1118 cross-check has
+    # nothing to compare against and the bundle sails through deploy.
+    root = _bundle(tmp_path, f"connectors:\n  {name}:\n    image: x:1\n")
+    result = validate_bundle(str(root))
+    assert not result.valid
+    offending = [e for e in result.errors if e.code == "connectors.reserved_name"]
+    assert offending, [e.code for e in result.errors]
+    assert name in offending[0].message
+
+
+def test_a_name_merely_starting_with_curie_is_accepted() -> None:
+    # The fence is the two exact names, not the `curie-` prefix. Fencing the
+    # prefix would reject a legitimate `curie-docs` connector, which is a worse
+    # accidental collision than the one being prevented.
+    assert _codes({"connectors": {"curie-docs": {"image": "x:1"}}}) == []
+
+
+def test_a_reserved_name_and_a_bad_shape_report_both() -> None:
+    # Every other check in this loop accumulates, so the author sees the whole
+    # file's problems in one pass rather than one rename per deploy attempt.
+    codes = _codes({"connectors": {"curie": {"secrets": ["T"]}}})
+    assert "connectors.reserved_name" in codes
+    assert "connectors.underspecified" in codes

--- a/runner/src/curie_runner/__main__.py
+++ b/runner/src/curie_runner/__main__.py
@@ -18,6 +18,7 @@ from aiohttp import web
 
 from .adapter import ClaudeAgentSession, ModelSession, build_options
 from .approval import (
+    APPROVAL_SERVER_NAME,
     ApprovalPolicyError,
     build_approval_gate,
     build_approval_server,
@@ -25,7 +26,7 @@ from .approval import (
     resolve_approval_policy,
 )
 from .config import RunnerConfig
-from .connectors import derive_mcp_servers
+from .connectors import build_mcp_servers, derive_mcp_servers
 from .fake import FakeModelSession
 from .harness.contribution import HarnessContribution
 from .harness.registry import (
@@ -217,27 +218,31 @@ def build_runner(
             # shipping its own MCP server for it. The ``curie-state`` server
             # (#249) joins it whenever a state store is configured, so a skill
             # reads/writes durable state the same way -- no bundle-shipped server.
-            mcp_servers={
-                "curie": build_approval_server(approval_gate),
-                **(
-                    {STATE_SERVER_NAME: build_state_server(state_client)}
-                    if state_client is not None
-                    else {}
-                ),
+            mcp_servers=build_mcp_servers(
+                platform={
+                    APPROVAL_SERVER_NAME: build_approval_server(approval_gate),
+                    **(
+                        {STATE_SERVER_NAME: build_state_server(state_client)}
+                        if state_client is not None
+                        else {}
+                    ),
+                },
                 # Connectors the bundle DECLARED and Curie hosts (ADR-0086,
                 # #1118). Platform-supplied, exactly like the two above, so they
                 # ride the same channel -- nothing rewrites the read-only
                 # bundle. The URL derives from the Service Curie created via the
                 # same function that rendered it, so the two cannot disagree. A
-                # name clashing with the bundle's own MCP config is already a
-                # deploy-time error (#1149), so this cannot shadow it.
-                **derive_mcp_servers(
+                # name clashing with the bundle's own MCP config is a deploy-time
+                # error (#1118/#1149), a name clashing with a platform server is
+                # a deploy-time error (#1200), and build_mcp_servers resolves any
+                # residual collision toward the platform.
+                derived=derive_mcp_servers(
                     config.session.plugin_dir,
                     release=config.connector_release,
                     agent=config.connector_agent,
                     namespace=config.connector_namespace,
                 ),
-            },
+            ),
             can_use_tool=(
                 build_can_use_tool(approval_gate) if approval_gate is not None else None
             ),

--- a/runner/src/curie_runner/connectors.py
+++ b/runner/src/curie_runner/connectors.py
@@ -23,9 +23,14 @@ and state servers -- platform-supplied servers, which is exactly what these are.
 Nothing rewrites ``.mcp.json``; the bundle stays the read-only artifact that was
 deployed.
 
-Name collisions cannot reach here: ``plugin_format`` rejects a bundle that
-declares one name in both ``connectors.yaml`` and its MCP config (#1118), so
-there is no precedence to resolve at runtime.
+Name collisions are rejected at validation on both axes: ``plugin_format``
+rejects a bundle that declares one name in both ``connectors.yaml`` and its own
+MCP config (#1118), and it rejects a name matching one of Curie's own platform
+servers -- ``curie``, ``curie-state`` -- via
+``plugin_format.connectors.RESERVED_CONNECTOR_NAMES`` (#1200). Precedence is
+nevertheless resolved here, by ``build_mcp_servers``, deliberately toward the
+platform, so a residual collision that somehow reaches the runtime fails safe
+rather than silently displacing the approval server.
 """
 
 from __future__ import annotations
@@ -118,3 +123,17 @@ def derive_mcp_servers(
         name: mcp_entry(release, agent, namespace, name, spec)
         for name, spec in sorted(declared.connectors.items())
     }
+
+
+def build_mcp_servers(platform: dict[str, Any], derived: dict[str, Any]) -> dict[str, Any]:
+    """Merge the platform's own MCP servers with the bundle's, platform winning.
+
+    The order is the safety property, not a style choice (#1200). Both maps are
+    plain dict keys on one channel, so on a collision somebody wins. Losing a
+    connector is a visible, diagnosable failure -- the agent's tool list is
+    missing something the bundle declared. Losing ``request_approval`` is a
+    silent one: a skill that calls it fails, or a self-imposed approval never
+    raises and the turn proceeds ungated. So the platform key wins.
+    """
+
+    return {**derived, **platform}

--- a/runner/tests/test_connectors.py
+++ b/runner/tests/test_connectors.py
@@ -11,7 +11,11 @@ from pathlib import Path
 
 from aci_protocol import BootEnv, Budget
 from curie_runner import RunnerConfig
-from curie_runner.connectors import derive_mcp_servers
+from curie_runner.__main__ import build_runner
+from curie_runner.approval import APPROVAL_SERVER_NAME
+from curie_runner.connectors import build_mcp_servers, derive_mcp_servers
+from curie_runner.state import STATE_SERVER_NAME
+from plugin_format.connectors import RESERVED_CONNECTOR_NAMES
 
 HOSTED = "connectors:\n  grafana:\n    image: grafana/mcp-grafana:0.17.2\n    secrets: [T]\n"
 REMOTE = "connectors:\n  internal:\n    url: https://mcp.internal/mcp\n"
@@ -212,3 +216,119 @@ def test_a_boot_that_renders_no_scope_still_mounts_no_hosted_connector(tmp_path:
         namespace=config.connector_namespace,
     )
     assert servers == {}
+
+
+# --------------------------------------------------------------------------- #
+# A connector name colliding with a platform server -- #1200
+# --------------------------------------------------------------------------- #
+BUDGET = '{"max_output_tokens_per_run": 10000, "max_usd_per_day": 1.0}'
+
+
+def _boot_env(monkeypatch, tmp_path: Path, suffix: str) -> dict[str, str]:
+    monkeypatch.setenv("CURIE_STATE_URL", "http://state.invalid/agents/a/state")
+    monkeypatch.setenv("CURIE_STATE_TOKEN", "t")
+    return {
+        "CURIE_PLUGIN_DIR": str(_bundle(tmp_path)),
+        "CURIE_SESSION_ID": f"s-{suffix}",
+        "CURIE_SANDBOX_ID": f"b-{suffix}",
+        "CURIE_BUDGET": BUDGET,
+    }
+
+
+def test_the_platform_approval_server_survives_a_colliding_connector_name() -> None:
+    # Both maps are plain dict keys on one channel, so somebody wins. Losing a
+    # connector is visible and diagnosable; losing request_approval is silent --
+    # a skill that calls it fails, or a self-imposed approval never raises. The
+    # merge therefore fails safe toward the platform.
+    approval = {"platform": "approval"}
+    state = {"platform": "state"}
+    servers = build_mcp_servers(
+        platform={APPROVAL_SERVER_NAME: approval, STATE_SERVER_NAME: state},
+        derived={
+            "curie": {"type": "http", "url": "http://impostor/mcp"},
+            "curie-state": {"type": "http", "url": "http://impostor/state/mcp"},
+            "grafana": {"type": "http", "url": "http://grafana/mcp"},
+        },
+    )
+    assert servers[APPROVAL_SERVER_NAME] is approval
+    assert servers[STATE_SERVER_NAME] is state
+    assert servers["grafana"]["url"] == "http://grafana/mcp"
+
+
+def test_a_declared_connector_still_mounts_alongside_the_platform_servers() -> None:
+    # The control on the same seam: safety must not be bought by dropping the
+    # connectors the bundle declared.
+    grafana = {"type": "http", "url": "http://grafana/mcp"}
+    servers = build_mcp_servers(
+        platform={APPROVAL_SERVER_NAME: {"platform": "approval"}},
+        derived={"grafana": grafana},
+    )
+    assert servers["grafana"] is grafana
+    assert APPROVAL_SERVER_NAME in servers
+
+
+def test_every_platform_mcp_server_the_boot_path_mounts_is_reserved(tmp_path, monkeypatch) -> None:
+    # Every platform MCP server must be MOUNTED here, not merely importable.
+    # This pin reads the servers this boot actually mounted, so a
+    # conditionally-mounted platform server -- like curie-state, which mounts
+    # only when CURIE_STATE_URL is set -- is invisible to the pin unless its
+    # mounting env is set in _boot_env. If you add a platform server behind its
+    # own condition, set that condition in _boot_env too, or the pin goes blind
+    # to it and the reserved list silently stops being complete.
+    env = _boot_env(monkeypatch, tmp_path, "pin")
+    # fake_model=False: the fake branch never builds mcp_servers at all, so a
+    # fake boot would pin nothing.
+    runner = build_runner(RunnerConfig.from_env(env), fake_model=False)
+    mounted = runner._factory()._options.mcp_servers
+
+    assert APPROVAL_SERVER_NAME in mounted
+    assert STATE_SERVER_NAME in mounted
+    # The bundle declares no connectors, so every remaining key is a platform
+    # key by construction. A third platform server added later reddens this
+    # until it is reserved -- which is why the fence is two exact names and not
+    # the `curie-` prefix.
+    assert set(mounted) == RESERVED_CONNECTOR_NAMES
+
+
+def test_the_boot_path_mounts_the_platform_approval_server_over_a_colliding_connector(
+    tmp_path, monkeypatch
+) -> None:
+    # The pin on the WIRING, not on the helper. build_mcp_servers can stay
+    # perfectly correct while the boot path stops routing through it -- that is
+    # exactly the pre-#1200 defect, an inline literal spreading the derived map
+    # last -- and every other test here stays green, because the boot-path pin
+    # above uses a zero-connector bundle whose set comparison is order-blind.
+    #
+    # The colliding input is unconstructible through a real bundle by
+    # construction: this branch's own validator rejects a connector named
+    # `curie`, so connectors.py:_read logs and returns {} before any merge
+    # happens. So the collision has to be INJECTED, and the injection point is
+    # derive_mcp_servers -- the UPSTREAM INPUT of the closure, at the boundary,
+    # not the thing being asserted. What is under test is the precedence wiring
+    # inside build_runner's factory; that runs for real. The plan rejected
+    # monkeypatching derive_mcp_servers as an ALTERNATIVE to extracting
+    # build_mcp_servers; this is not that. Do not delete this as a mock.
+    impostor = {"type": "http", "url": "http://impostor/mcp"}
+    grafana = {"type": "http", "url": "http://grafana/mcp"}
+    monkeypatch.setattr(
+        "curie_runner.__main__.derive_mcp_servers",
+        lambda *a, **k: {APPROVAL_SERVER_NAME: impostor, "grafana": grafana},
+    )
+    env = _boot_env(monkeypatch, tmp_path, "collide")
+    runner = build_runner(RunnerConfig.from_env(env), fake_model=False)
+    mounted = runner._factory()._options.mcp_servers
+
+    assert mounted[APPROVAL_SERVER_NAME] is not impostor
+    # Positive identification, not merely "not the impostor": the platform's
+    # approval server is the in-process SDK server, which no connector can be.
+    assert mounted[APPROVAL_SERVER_NAME]["type"] == "sdk"
+    # The control on the boot path: the platform winning must not cost the
+    # bundle the connectors it declared.
+    assert mounted["grafana"] is grafana
+
+
+def test_the_reserved_list_matches_the_runner_constants() -> None:
+    # plugin_format re-enumerates these names because runner depends on it and
+    # never the reverse. This is the pin that keeps the copy honest: rename
+    # either constant here and the deploy-time guard stops fencing it.
+    assert RESERVED_CONNECTOR_NAMES == {APPROVAL_SERVER_NAME, STATE_SERVER_NAME}


### PR DESCRIPTION
A bundle declaring a connector named `curie` or `curie-state` silently replaced one of Curie's own platform MCP servers. The runner built `mcp_servers` with the derived connectors spread last, so last spread won, and nothing reported it at deploy or at boot.

Two layers:

- `validate_connectors` rejects both names, naming what the collision would displace (`request_approval` for `curie`, the durable-state tools for `curie-state`). It sits in the pure validator rather than the `.mcp.json` collision guard, so the rule also holds on the runner's own read path, which is what the `skill` and `local` tiers boot from.
- The runner resolves precedence toward the platform via `build_mcp_servers`, so a residual collision costs a connector (visible, diagnosable) instead of `request_approval` (silent).

The reserved list is re-enumerated in `plugin-format` because `runner` depends on it and never the reverse; `APPROVAL_SERVER_NAME` and `STATE_SERVER_NAME` stay authoritative, pinned by a cross-package drift test. A boot-path test asserts the set of servers a real boot mounts equals the reserved set, so a third platform server added later reds CI until it is reserved.

Deliberately not a security change. `SECURITY.md` puts the bundle author inside the trust boundary and the operator gate (`can_use_tool`) is a separate field, untouched. This is an accidental-collision footgun fix.

### Scope notes

- No `curie-` prefix fence. The protected set is exactly the two names the platform mounts; a prefix would reject a legitimate `curie-docs`, which is a worse footgun. A test pins that `curie-docs` stays legal.
- Replacing the bare `"curie"` literal in `__main__.py` with `APPROVAL_SERVER_NAME` is outside the acceptance criteria and kept deliberately: `APPROVAL_TOOL_NAME` is derived from that constant, so a literal that stops tracking it would mount a server key the approval tool name no longer points at.
- `cli/src/scaffold.rs` is untouched. Its scaffolded `connectors.yaml` is `connectors: {}` with an entirely commented example, so it declares no connector and is not a site where this can occur.

### Done-check

- [x] Failing tests committed before implementation (`c3e1c005` preceded `109be1e0`, pre-squash)
- [x] All production edits made by delegated sub-agents; no inline edits by the driver
- [x] No public function broadened its return type; both implementers reported none, and `build_mcp_servers` is new and total
- [x] Code review approved with `file:line` evidence: 0 blocking, 8 advisory
- [x] Spec-vs-impl review found acceptance criterion 3 only partially met (reverting the `__main__.py` fix left the suite green); closed by a boot-path test that reds on exactly that revert
- [x] Scope review: 2 orphan hunks, one removed, one kept with the corrected justification recorded above
- [x] Sibling-path parity: 17 sites enumerated at plan time, 3 in scope, all covered; no new site surfaced at this gate
- [x] Guard demonstrated by execution: a bundle declaring `curie` (the exact shape that validated clean before) returns `valid=False` with `connectors.reserved_name`; `curie-state` likewise; `curie-docs` still validates clean
- [x] Consolidation pass ran; suite and lint green after it; a fresh reviewer re-checked the applied diff and confirmed by execution that no assertion was lost and both gates still bite
- [ ] Security review: N/A, not flagged
- [ ] E2E: N/A, no user-facing or deployed surface flagged; the change is fully in-process
- [x] Full workspace suite green: 2371 passed, 11 skipped. `scripts/check-docs.sh` and `scripts/check-contracts.sh` both clean
- [x] Lint clean on every edited file: `ruff check .` and `mypy` both exit 0

Closes #1200
