### PR TITLE
Prune undeclared connector objects on the unprovisioned skip

### DIFF
--- a/apps/worker/src/curie_worker/connector_agent.py
+++ b/apps/worker/src/curie_worker/connector_agent.py
@@ -20,11 +20,24 @@ object is owned, it is genuinely undeclared, and pruning it is exactly what the
 plan is supposed to do. Nothing downstream can catch this; it has to be handled
 here.
 
-So an agent's owned Secret is protected: never applied (we have no values) and
-never pruned (someone else owns its lifecycle). And if it is protected but
-absent, the agent is skipped entirely rather than reconciled -- applying a
-Deployment whose secretKeyRef points at a Secret that does not exist produces
-pods that never start, which is worse than not acting.
+So the owned Secret THE CURRENT RENDER NAMES is protected: never applied (we
+have no values) and never pruned (someone else owns its lifecycle). And if it is
+protected but absent, the pass suppresses every apply -- applying a Deployment
+whose secretKeyRef points at a Secret that does not exist produces pods that
+never start, which is worse than not acting. It still prunes: objects the
+in-force version no longer declares are deleted as usual, because removing an
+object is never harmed by a missing Secret. Holding those deletes back only left
+a withdrawn connector running for as long as the agent stayed unprovisioned
+(#1214).
+
+That prune has one exclusion, and only on that branch: no Secret of ANY name is
+manageable there. The branch is entered because the named Secret is absent, so
+an owner-labelled Secret still live at that moment is by construction one whose
+name the render no longer matches -- and the name is release-scoped, so a
+re-release, or drift between the worker's `CURIE_RELEASE` and the CLI's
+`--release`, is enough to produce exactly that. It is the operator's real
+credential under a stale name, not garbage, and it is unrecoverable. On the
+normal path a stale-named owned Secret is still pruned as usual.
 
 Connectors using the reference form (`secrets: [{from_secret: ...}]`, #1163)
 have no owned keys at all, so they reconcile with no exception. That is the
@@ -72,7 +85,9 @@ class ManifestSource(Protocol):
 
 @dataclass(frozen=True)
 class AgentOutcome:
-    """What reconciling one agent did, or why it did nothing."""
+    """What reconciling one agent did. `skipped` names a suppressed apply half,
+    not an inert pass -- it still carries the deletes that ran and any failures.
+    """
 
     agent: str
     skipped: str | None = None
@@ -116,40 +131,77 @@ def reconcile_agent(
     live = client.list_owned(namespace, agent)
 
     protected: set[tuple[str, str]] = set()
+    unprovisioned = False
     if rendered.needs_operator_credentials and rendered.owned_secret_name:
         protected.add(("Secret", rendered.owned_secret_name))
-        if not any(identity(obj) in protected for obj in live):
-            # Reconciling now would create Deployments referencing a Secret that
-            # does not exist. Pods would stay stuck rather than fail loudly, and
-            # the cause would be several layers from the symptom.
-            #
-            # The message deliberately names neither the Secret nor its keys.
-            # Both are identifiers rather than values -- `kubectl get secret`
-            # shows them -- but they are also of no use here: the operator's
-            # action is the same either way, and `curie cluster deploy` is what
-            # reports a key it cannot resolve. Leaving them out keeps a credential
-            # name out of a log stream that may be shipped somewhere less
-            # protected than the cluster.
-            reason = (
-                "connector credentials are operator-supplied and not yet "
-                "provisioned in this namespace; run `curie cluster deploy` once "
-                "for this agent, or move the connector to a referenced secret"
+        unprovisioned = not any(identity(obj) in protected for obj in live)
+        if not unprovisioned:
+            logger.debug(
+                "connector reconcile agent=%s protecting its operator-supplied secret", agent
             )
-            logger.warning("connector reconcile skipped agent=%s: %s", agent, reason)
-            return AgentOutcome(agent=agent, skipped=reason)
-
-        logger.debug("connector reconcile agent=%s protecting its operator-supplied secret", agent)
 
     # Hidden from the plan rather than filtered out of its result: the plan's job
     # is "own it and no longer declare it -> delete it", and that judgement is
     # correct. What is wrong is calling this object ours to begin with.
     manageable = [obj for obj in live if identity(obj) not in protected]
 
-    computed = plan(desired, manageable, agent=agent)
-    if computed.is_noop:
-        return AgentOutcome(agent=agent, plan=computed, report=ApplyReport())
+    if unprovisioned:
+        # Widened past `protected` (only THIS render's Secret name) for the
+        # reason the module docstring gives. Kind is the safe discriminator
+        # here, and only here: on this branch no Secret is ours.
+        manageable = [obj for obj in manageable if identity(obj)[0] != "Secret"]
 
-    report = execute(client, computed, namespace=namespace, agent=agent)
+    computed = plan(desired, manageable, agent=agent)
+
+    skipped: str | None = None
+    if unprovisioned:
+        # Applying now would create Deployments referencing a Secret that does
+        # not exist. Pods would stay stuck rather than fail loudly, and the
+        # cause would be several layers from the symptom. So the applies are
+        # dropped and only the delete half runs -- an object being removed does
+        # not care whether a credential exists. `computed.delete` is decided
+        # against the FULL render, so a still-declared connector's objects are
+        # never in it, and no Secret of any name reaches it (above).
+        #
+        # A RENAMED connector, or a changed release name, is the case this does
+        # not spare: its old objects are undeclared and get pruned while their
+        # replacements are apply-suppressed, so the pass ends with no connector
+        # where before it kept the stale one. Accepted, deliberately. The old
+        # connector is already gone from the agent's MCP config, which is
+        # rendered from the same in-force version, so those objects were
+        # unreachable rather than working -- and leaving them live is exactly the
+        # leak #1214 exists to close. Do NOT gate the prune on `computed.apply`
+        # being empty to dodge this: a never-yet-deployed agent has every object
+        # pending apply, so that gate suppresses pruning in the common case.
+        #
+        # The message deliberately names neither the Secret nor its keys.
+        # Both are identifiers rather than values -- `kubectl get secret`
+        # shows them -- but they are also of no use here: the operator's
+        # action is the same either way, and `curie cluster deploy` is what
+        # reports a key it cannot resolve. Leaving them out keeps a credential
+        # name out of a log stream that may be shipped somewhere less
+        # protected than the cluster.
+        reason = (
+            "connector credentials are operator-supplied and not yet "
+            "provisioned in this namespace; run `curie cluster deploy` once "
+            "for this agent, or move the connector to a referenced secret"
+        )
+        logger.warning("connector reconcile skipped agent=%s: %s", agent, reason)
+        skipped = reason
+        # The plan carried is the one actually executed, not the one computed --
+        # reporting applies that were never attempted would make the outcome
+        # describe a pass that did not happen.
+        carried = ReconcilePlan(delete=computed.delete)
+    elif computed.is_noop:
+        return AgentOutcome(agent=agent, plan=computed, report=ApplyReport())
+    else:
+        carried = computed
+
+    report = execute(client, carried, namespace=namespace, agent=agent)
+    # Shared with the skip branch on purpose: that branch deletes, so it can fail
+    # deletes, and a finalizer or an RBAC gap there recurs every pass. Returning
+    # straight off `execute()` left the object name and the error in no log
+    # stream at all -- `connector_apply` does not log delete failures either.
     if not report.ok:
         logger.warning(
             "connector reconcile agent=%s had %d failure(s): %s",
@@ -157,4 +209,4 @@ def reconcile_agent(
             len(report.failures),
             "; ".join(f"{kind}/{name}: {err}" for kind, name, err in report.failures),
         )
-    return AgentOutcome(agent=agent, plan=computed, report=report)
+    return AgentOutcome(agent=agent, skipped=skipped, plan=carried, report=report)

--- a/apps/worker/src/curie_worker/connector_apply.py
+++ b/apps/worker/src/curie_worker/connector_apply.py
@@ -44,7 +44,12 @@ class ConnectorClient(Protocol):
     """
 
     def list_owned(self, namespace: str, owner: str) -> list[dict[str, Any]]:
-        """Every connector object labelled for this owner."""
+        """Every connector object labelled for this owner.
+
+        Every returned object must carry ``kind`` and ``metadata.name``:
+        ``identity()`` keys ownership and every prune decision on that pair, so
+        an object missing either is invisible to those checks.
+        """
 
     def apply(self, namespace: str, obj: dict[str, Any]) -> None:
         """Create or update one object."""

--- a/apps/worker/src/curie_worker/connector_loop.py
+++ b/apps/worker/src/curie_worker/connector_loop.py
@@ -117,7 +117,13 @@ class HttpManifestSource:
 
 @dataclass
 class PassSummary:
-    """What one sweep did. Reported so a pass is auditable without a debugger."""
+    """What one sweep did. Reported so a pass is auditable without a debugger.
+
+    Counters are per-event, not a partition of agents -- a skipped agent whose
+    delete-only prune still ran can add to both ``skipped`` and ``deleted``,
+    or to both ``skipped`` and ``failed`` if that prune errored. Do not expect
+    them to sum to ``reconciled``.
+    """
 
     reconciled: int = 0
     applied: int = 0
@@ -193,7 +199,10 @@ class ConnectorReconcileLoop:
 
             if outcome.skipped:
                 summary.skipped += 1
-                continue
+                # A skip means "no operator-supplied Secret", not "nothing
+                # happened": #1214 still runs a delete-only prune in that case,
+                # so the report below (if any) can carry real deletes or a
+                # real failure that must not vanish along with the skip.
             if outcome.report is not None:
                 summary.applied += len(outcome.report.applied)
                 summary.deleted += len(outcome.report.deleted)

--- a/apps/worker/tests/reconcile/test_connector_agent.py
+++ b/apps/worker/tests/reconcile/test_connector_agent.py
@@ -132,7 +132,108 @@ def test_an_agent_whose_credential_was_never_provisioned_is_skipped() -> None:
     # of a log stream that may be shipped somewhere less protected.
     assert SECRET_NAME not in outcome.skipped
     assert "GRAFANA_TOKEN" not in outcome.skipped
+    # Vacuous on the delete half: this FakeClient starts with nothing live, so
+    # deleted == [] proves nothing about pruning. The delete-half assertion
+    # that would actually catch a regression lives in
+    # test_an_unprovisioned_agent_still_prunes_what_it_no_longer_declares below.
     assert client.applied == [] and client.deleted == []
+
+
+def test_an_unprovisioned_agent_still_prunes_what_it_no_longer_declares() -> None:
+    # #1214: the skip above exists to stop a Deployment being applied with a
+    # secretKeyRef pointing at nothing. It does NOT need to stop a delete --
+    # removing an object is never harmed by a missing Secret. The old
+    # `return AgentOutcome(agent=agent, skipped=reason)` stopped both, so an
+    # agent that removed a connector while also missing its operator secret
+    # leaked that connector's objects until someone happened to run
+    # `curie cluster deploy` for an unrelated reason. `kept` stays declared
+    # (so the still-owed pass must leave it alone); `new_dep` is declared but
+    # not yet live, so if applies were not actually suppressed it would show
+    # up in `client.applied` -- proving the suppression rather than assuming it.
+    kept = manifest("Deployment", "kept-dep")
+    new_dep = manifest("Deployment", "new-dep")
+    stale_dep = live_copy(manifest("Deployment", "stale-dep"))
+    stale_netpol = live_copy(manifest("NetworkPolicy", "stale-netpol"))
+    stale_svc = live_copy(manifest("Service", "stale-svc"))
+    client = FakeClient([live_copy(kept), stale_dep, stale_netpol, stale_svc])
+    source = Source(
+        RenderedConnectors(
+            manifests=[kept, new_dep],
+            owned_secret_name=SECRET_NAME,
+            owned_secret_keys=["TOKEN"],
+        )
+    )
+
+    outcome = run(source, client)
+
+    assert outcome.skipped is not None
+    assert "curie cluster deploy" in outcome.skipped
+    assert SECRET_NAME not in outcome.skipped and "TOKEN" not in outcome.skipped
+
+    assert outcome.report is not None
+    assert outcome.report.applied == []
+    assert outcome.report.deleted == [
+        ("Deployment", "stale-dep"),
+        ("NetworkPolicy", "stale-netpol"),
+        ("Service", "stale-svc"),
+    ]
+    assert client.applied == [], "no values exist for the missing secret -- applying stays off"
+    assert ("Deployment", "kept-dep") not in client.deleted, "still declared, not this pass's job"
+
+
+def test_no_secret_of_any_name_is_pruned_on_the_unprovisioned_branch() -> None:
+    # Why no Secret of any name is manageable here: the `connector_agent` module
+    # docstring. `stale-svc` keeps the test honest -- pruning still happens on
+    # this branch (#1214), it is Secrets specifically that are held back.
+    stale_secret = live_copy(
+        {"apiVersion": "v1", "kind": "Secret", "metadata": {"name": "old-connector-secret"}}
+    )
+    stale_svc = live_copy(manifest("Service", "stale-svc"))
+    client = FakeClient([stale_secret, stale_svc])
+    source = Source(
+        RenderedConnectors(manifests=[], owned_secret_name=SECRET_NAME, owned_secret_keys=["TOKEN"])
+    )
+
+    outcome = run(source, client)
+
+    assert outcome.skipped is not None
+    pruned = client.deleted
+    assert [d for d in pruned if d[0] == "Secret"] == [], "no Secret may be pruned on this branch"
+    assert ("Service", "stale-svc") in pruned, "non-Secret objects must still prune (#1214)"
+
+
+def test_a_failed_prune_on_the_skip_path_is_reported_and_logged(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # The skip branch runs deletes, so it can FAIL deletes -- a finalizer or an
+    # RBAC gap leaves the object live and the same failure recurs every pass.
+    # Returning straight off `execute()` makes that invisible: the only record
+    # of the pass is the skip reason, which names neither the object nor the
+    # error, so the operator sees a routine skip while a prune silently never
+    # lands. It stays a skip and it stays non-raising -- one agent's stuck
+    # delete must not abort the pass for the rest.
+    class ExplodingDelete(FakeClient):
+        def delete(self, namespace: str, kind: str, name: str) -> None:
+            raise RuntimeError("apiserver refused: forbidden")
+
+    stale_svc = live_copy(manifest("Service", "stale-svc"))
+    client = ExplodingDelete([stale_svc])
+    source = Source(
+        RenderedConnectors(manifests=[], owned_secret_name=SECRET_NAME, owned_secret_keys=["TOKEN"])
+    )
+
+    with caplog.at_level("WARNING", logger="curie_worker.connector_agent"):
+        outcome = run(source, client)
+
+    assert outcome.skipped is not None, "a failed prune does not turn the skip into a normal pass"
+    assert outcome.report is not None and outcome.report.failures
+    assert not outcome.ok
+    assert any(
+        "Service" in r.getMessage()
+        and "stale-svc" in r.getMessage()
+        and "apiserver refused: forbidden" in r.getMessage()
+        for r in caplog.records
+    ), "the failing object and its error must reach a log stream, not just the outcome"
 
 
 def test_a_reference_form_bundle_has_no_exception_at_all() -> None:
@@ -158,6 +259,29 @@ def test_a_stale_secret_is_still_pruned_when_no_keys_are_owned() -> None:
 
     run(source, client)
     assert client.deleted == [("Secret", "stale")]
+
+
+def test_the_secret_exclusion_does_not_reach_the_provisioned_path() -> None:
+    # Pins the SCOPE of the by-kind exclusion, which the test above cannot: that
+    # one has no owned keys, so `needs_operator_credentials` is False and
+    # widening the guard to `unprovisioned or rendered.needs_operator_credentials`
+    # survives it. Here the render-named Secret IS live, so the branch is not
+    # taken and a stale-named owned Secret is ordinary garbage that must still
+    # go -- under the widened guard it would be held back and leak forever.
+    keeper = live_copy({"apiVersion": "v1", "kind": "Secret", "metadata": {"name": SECRET_NAME}})
+    stale = live_copy(
+        {"apiVersion": "v1", "kind": "Secret", "metadata": {"name": "old-connector-secret"}}
+    )
+    client = FakeClient([keeper, stale])
+    source = Source(
+        RenderedConnectors(manifests=[], owned_secret_name=SECRET_NAME, owned_secret_keys=["TOKEN"])
+    )
+
+    outcome = run(source, client)
+
+    assert outcome.skipped is None, "the render-named Secret is live -- this is the normal path"
+    # Exact list: the stale name went, and the render-named one did not.
+    assert client.deleted == [("Secret", "old-connector-secret")]
 
 
 # --------------------------------------------------------------------------- #

--- a/apps/worker/tests/reconcile/test_connector_loop.py
+++ b/apps/worker/tests/reconcile/test_connector_loop.py
@@ -100,6 +100,37 @@ async def test_a_skipped_agent_is_counted_separately_from_a_failure() -> None:
     assert summary.failed == 0
 
 
+async def test_a_skipped_agents_deletes_are_counted(caplog) -> None:
+    # #1214: an unprovisioned-Secret agent no longer early-returns -- it still
+    # runs a delete-only plan, so a skipped outcome can carry a report with
+    # real deletes. The `continue` on `outcome.skipped` drops that report on
+    # the floor: a pass that pruned three objects would claim zero deletes, in
+    # the summary and in the pass log operators actually read.
+    skipped = AgentOutcome(
+        agent="a",
+        skipped="credentials not provisioned",
+        report=ApplyReport(deleted=[("Service", "d0"), ("Service", "d1"), ("Service", "d2")]),
+    )
+    with caplog.at_level("INFO", logger="curie_worker.connector_loop"):
+        summary = await Loop([target("a")], {"a": skipped}).one_pass()
+    assert summary.skipped == 1
+    assert summary.deleted == 3
+    assert any("3 deleted" in r.getMessage() for r in caplog.records)
+
+
+async def test_a_failed_delete_on_a_skipped_agent_still_counts_as_a_failure() -> None:
+    # Same gap, the failure side: a delete that errors on a skipped agent must
+    # not vanish from `summary.failed` along with the rest of its report.
+    skipped = AgentOutcome(
+        agent="a",
+        skipped="credentials not provisioned",
+        report=ApplyReport(failures=[("Service", "d0", "forbidden")]),
+    )
+    summary = await Loop([target("a")], {"a": skipped}).one_pass()
+    assert summary.skipped == 1
+    assert summary.failed == 1
+
+
 async def test_no_agents_is_a_clean_pass() -> None:
     summary = await Loop([], {}).one_pass()
     assert summary == PassSummary()


### PR DESCRIPTION
Closes #1214

The reconciler's missing-Secret branch returned before planning, so it suppressed deletes as well as applies. Objects a previous bundle version declared and the current one does not stayed live for as long as the agent held that state, reachable through git-flow by two ordinary pushes with no operator action.

## What changed

- `reconcile_agent` now executes a delete-only plan on that branch. Applies stay fully suppressed and the pass is still reported and logged as skipped.
- **Every Secret is held back from that prune.** Review caught that the fix as specified in the issue would delete the operator's credential: `protected` carries only the name the current render produces, the API never renders a Secret, and that name is release-scoped (`{release}-{agent}-connector-secrets`). A Helm re-release, or drift between the worker's `CURIE_RELEASE` and the CLI's `--release`, leaves the real credential live under the old name, undeclared and prunable. Its values exist only in the operator's environment (ADR-0086), so the delete is unrecoverable and would repeat every pass. The exclusion is scoped to this branch only; the provisioned path still prunes a stale-named owned Secret as before, and a test now pins that scope.
- `ConnectorReconcileLoop.one_pass` stopped reading the report once a skip could carry one, so a pass that pruned three objects logged `0 deleted` and a failed delete never reached `failed`.
- The failure warning is now shared with the skip branch, so a blocked delete reaches a log stream instead of nowhere.

## Accepted trade-off

For a renamed connector or a changed release name, the old objects are pruned while their replacements stay apply-suppressed, so that pass ends with no connector. Taken deliberately: the old connector is already absent from the agent's MCP config, which renders from the same in-force version, so those objects were unreachable rather than working. Gating the prune on `apply` being empty was rejected because a never-yet-deployed agent has every object pending apply, which would suppress pruning in the common case.

## Done-check

- [x] Failing tests committed before implementation (test-first across all four stages; visible pre-squash)
- [x] All production edits delegated to sub-agents; no inline driver edits
- [x] Broadened value set handled at every caller: a `skipped` outcome can now carry a `report`; `one_pass` is the sole consumer and was migrated
- [x] Code Reviewer approved (round 2, after a blocker fix), with file:line spec-vs-impl evidence
- [x] Scope Reviewer approved, 0 creep hunks across 17 logical hunks
- [x] Spec-vs-impl: 6/6 acceptance criteria met, including the issue's mutation requirement
- [x] Security Reviewer: the one blocking finding is fixed; remaining items are pre-existing and listed below
- [x] Sibling-path parity: the CLI prune (`cli/src/connectors.rs`) includes `secret` deliberately, but it mints the credential in the same run so the current Secret is always in `keep`. The asymmetry is by construction, not a gap
- [x] Guard demonstration, executed not read: neutralising the exclusion fails `test_no_secret_of_any_name_is_pruned_on_the_unprovisioned_branch`; widening it to every credential-bearing render fails `test_the_secret_exclusion_does_not_reach_the_provisioned_path`; restoring the original early return fails the AC's named test
- [x] Consolidation pass ran; comment-only, verified by AST comparison that no executable line changed
- [x] Full suite green (1063 passed, 7 skipped); ruff, ruff format, and mypy clean

## Out of scope, pre-existing

Surfaced by review, deliberately not fixed here. Worth issues:

1. `owned_secret_name` and `owned_secret_keys` are read from the API response without validation and fail open on the normal path.
2. `connector_apply.execute` never re-checks ownership before deleting, though its module docstring says it does.
3. The ownership label is release-unscoped and self-asserted, backed by namespace-wide delete.
4. On the provisioned path a pruned Secret's name is logged at INFO, which the skip path deliberately avoids.