### PR TITLE
Deploy a scaffolded bundle instead of ignoring its pushes

### DIFF
--- a/apps/api/src/curie_api/bundles.py
+++ b/apps/api/src/curie_api/bundles.py
@@ -115,11 +115,13 @@ def read_connectors(root: Path) -> ConnectorsFile:
 
 
 def read_deploy_targets(root: Path) -> DeployTargetsFile | None:
-    """Parse a validated bundle's ``deploy.yaml``, or None when it declares none.
+    """Parse a validated bundle's ``deploy.yaml``, or None when the file is ABSENT.
 
     None is not an error. A bundle without ``deploy.yaml`` predates ADR-0089
     and still deploys to the single agent its repository binds -- the caller
-    must keep working for it, not reject it.
+    must keep working for it, not reject it. A present file that declares no
+    targets is a different case: it returns a non null ``DeployTargetsFile``
+    with an empty ``targets`` map, not None.
     """
 
     path = bundle_root(root) / DEPLOY_FILE

--- a/apps/api/src/curie_api/gitflow.py
+++ b/apps/api/src/curie_api/gitflow.py
@@ -479,19 +479,28 @@ def resolve_target_agent(
     to a different repository. That case is the sharpest edge in ADR-0091 and
     the reason this function takes an argument for it: without the check, one
     repository's push deploys over another repository's agent. It is refused.
+
+    What decides the fallback is whether any target is DECLARED, not whether a
+    ``deploy.yaml`` exists: a bundle with no such file and a bundle whose
+    ``targets:`` map is empty say exactly the same thing about routing (#1210).
     """
 
-    if targets is None:
-        # A bundle predating ADR-0089. It deploys where it always did: to the
-        # single agent this repository binds. With several bound there is no
-        # basis to choose, and guessing would deploy to the wrong bot silently.
+    if targets is None or not targets.targets:
+        # An empty map is what `curie init` scaffolds, so it is the ordinary
+        # case rather than the legacy one (#1210). With several agents bound,
+        # nothing says which, and guessing deploys to the wrong bot silently.
         if len(repo_agents) == 1:
             return repo_agents[0]
+        missing = (
+            "the bundle has no deploy.yaml"
+            if targets is None
+            else "the bundle's deploy.yaml declares an empty `targets:` map"
+        )
         raise TargetUnresolved(
             "deploy.no_targets",
-            f"{len(repo_agents)} agents are built from this repository but the "
-            "bundle declares no deploy.yaml, so there is nothing to say which "
-            "one this branch deploys to. Add deploy.yaml (ADR-0089).",
+            f"{len(repo_agents)} agents are built from this repository but "
+            f"{missing}, so there is nothing to say which one this branch "
+            "deploys to. Declare a target (ADR-0089).",
         )
 
     matching = [t for t in targets.targets.values() if t.env == environment.value]

--- a/apps/api/tests/test_gitflow_integration.py
+++ b/apps/api/tests/test_gitflow_integration.py
@@ -23,8 +23,9 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-from curie_api import crud
+from curie_api import bundles, crud
 from curie_api.config import get_settings
+from curie_test_support.scaffold import scaffolded_deploy_yaml
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 SECRET = get_settings().github_webhook_secret
@@ -647,3 +648,51 @@ def test_a_target_naming_another_repos_agent_is_rejected_end_to_end(
         client.get("/deployments", params={"agent_id": foreign["id"]}, headers=auth_headers).json()
         == []
     )
+
+
+# --------------------------------------------------------------------------- #
+# A scaffolded deploy.yaml declares nothing (#1210)
+# --------------------------------------------------------------------------- #
+# `curie init` writes a commented-out example plus a literal empty map, so the
+# value below is the payload a fresh repository actually pushes, read from
+# `DEPLOY_YAML` in cli/src/scaffold.rs rather than restated here.
+SCAFFOLDED_DEPLOY_YAML = scaffolded_deploy_yaml()
+
+SCAFFOLD_FILES = {**VALID_FILES, "deploy.yaml": SCAFFOLDED_DEPLOY_YAML}
+
+
+def test_a_scaffolded_deploy_yaml_still_deploys(
+    client: Any,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    trusted_clone_base: Path,
+) -> None:
+    # #1210 through the real webhook: `curie init` scaffolds `targets: {}`, so
+    # every first push from a scaffolded repository carried a deploy.yaml that
+    # declared no routing, and the resolver ignored the push instead of
+    # deploying to the one agent the repository binds. The unit tests reproduce
+    # the deploy.yaml read by hand; this one runs the production read path
+    # (gitflow._read_targets -> bundles.read_deploy_targets).
+    agent_id = _register_agent(client, auth_headers)
+    clone_url, sha = _build_bare_repo(trusted_clone_base, REPO, SCAFFOLD_FILES)
+
+    body = _post(client, "push", _push_payload("refs/heads/dev", sha, clone_url)).json()
+    assert body["status"] == "deployed", body
+    assert body["deployment_id"] is not None
+    assert body["agent_id"] == agent_id
+
+
+def test_a_scaffolded_deploy_yaml_reads_back_as_an_empty_map(tmp_path: Path) -> None:
+    # The premise the whole of #1210 rests on, pinned directly. None from
+    # `read_deploy_targets` means the file is ABSENT; a non-null file whose
+    # `targets` map is empty means it is PRESENT and declares nothing.
+    # Conflating the two is the bug: had a scaffolded deploy.yaml read back as
+    # None, the old `if targets is None:` gate would already have deployed it.
+    for rel, content in SCAFFOLD_FILES.items():
+        path = tmp_path / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+
+    targets = bundles.read_deploy_targets(tmp_path)
+    assert targets is not None, "a present deploy.yaml must not read back as absent"
+    assert targets.targets == {}

--- a/apps/api/tests/test_gitflow_targets.py
+++ b/apps/api/tests/test_gitflow_targets.py
@@ -17,6 +17,7 @@ import uuid
 import pytest
 from curie_api.gitflow import TargetUnresolved, resolve_target_agent
 from curie_api.models import Agent, Environment
+from curie_test_support.scaffold import scaffolded_deploy_yaml
 from plugin_format.deploy_targets import validate_deploy_targets
 
 REPO = "curie-eng/sre-bot"
@@ -135,4 +136,54 @@ def test_a_bundle_without_deploy_yaml_and_several_agents_is_refused() -> None:
     with pytest.raises(TargetUnresolved) as caught:
         resolve_target_agent(None, Environment.prod, [agent("a"), agent("b")], None)
     assert caught.value.code == "deploy.no_targets"
-    assert "deploy.yaml" in str(caught.value)
+    assert "the bundle has no deploy.yaml" in str(caught.value)
+
+
+# --------------------------------------------------------------------------- #
+# Bundles WITH deploy.yaml that declare no targets (#1210)
+# --------------------------------------------------------------------------- #
+def test_an_empty_targets_map_still_deploys_its_single_agent() -> None:
+    # `curie init` scaffolds `targets: {}`. Gating the fallback on the FILE's
+    # presence instead of its CONTENT made every push from a scaffolded bundle
+    # a silent no-op -- no deploy, no log line, no rejection.
+    only = agent("sre-bot")
+    assert resolve_target_agent(targets("targets: {}\n"), Environment.dev, [only], None) is only
+
+
+def test_an_empty_targets_map_with_several_agents_is_refused() -> None:
+    # Same reason the no-deploy.yaml case is refused: nothing declares which of
+    # the two this branch deploys to, and guessing deploys to the wrong bot.
+    with pytest.raises(TargetUnresolved) as caught:
+        resolve_target_agent(
+            targets("targets: {}\n"), Environment.dev, [agent("a"), agent("b")], None
+        )
+    assert caught.value.code == "deploy.no_targets"
+    assert "the bundle's deploy.yaml declares an empty `targets:` map" in str(caught.value)
+
+
+def test_a_deploy_yaml_of_only_comments_still_deploys_its_single_agent() -> None:
+    # Broader than the literal `targets: {}` key: a file whose every line is
+    # commented out parses to None, which validates to the same empty map. The
+    # operator sees a deploy.yaml full of guidance and a push that does nothing.
+    only = agent("sre-bot")
+    commented = "# targets:\n#   dev:\n#     agent: sre-bot-dev\n#     env: dev\n"
+    parsed = targets(commented)
+    assert parsed.targets == {}
+    assert resolve_target_agent(parsed, Environment.dev, [only], None) is only
+
+
+def test_the_scaffolded_deploy_yaml_is_valid_and_declares_no_targets() -> None:
+    # The premise the routing test below rests on, asserted separately so a
+    # reshaped scaffold fails HERE, naming the shape that changed, rather than
+    # deep inside a routing assertion that would look like a routing bug.
+    parsed = targets(scaffolded_deploy_yaml())
+    assert parsed.targets == {}, "the scaffold is expected to ship no declared targets"
+
+
+def test_the_scaffolded_deploy_yaml_deploys_the_repositorys_single_agent() -> None:
+    # The regression as an operator meets it: `curie init`, push, nothing
+    # happens. Pinned against the scaffold's real bytes so a change to what
+    # ships lands here.
+    only = agent("sre-bot")
+    parsed = targets(scaffolded_deploy_yaml())
+    assert resolve_target_agent(parsed, Environment.dev, [only], None) is only

--- a/cli/src/scaffold.rs
+++ b/cli/src/scaffold.rs
@@ -175,13 +175,18 @@ connectors: {}
 /// Declared deploy targets (ADR-0089). Also commented out, and for a sharper
 /// reason than connectors: a target names a Slack channel and an agent, and a
 /// scaffolded placeholder that looked real would deploy somewhere nobody
-/// intended. An empty `targets:` map is valid and does nothing.
+/// intended. An empty `targets:` map declares no routing, so a git flow push
+/// falls back to the single agent this repository binds (#1210); with
+/// several agents bound the push is refused rather than guessed.
 const DEPLOY_YAML: &str = r#"# Where this bundle gets deployed. `curie cluster deploy --target prod` reads
 # this, so the routing is a reviewable diff in the repository instead of flags
 # scattered across whatever invokes the command.
 #
 # The BUNDLE is identical for every target -- only the binding differs, which
 # is what lets prod promote the exact artifact dev validated.
+#
+# Left empty, a push deploys to the single agent this repository binds.
+# Declare targets once the repository binds more than one.
 #
 # Uncomment and edit. Use Slack channel IDs (starting with C), not #names:
 #

--- a/packages/test-support/src/curie_test_support/scaffold.py
+++ b/packages/test-support/src/curie_test_support/scaffold.py
@@ -1,0 +1,36 @@
+"""Shared access to the `curie init` scaffold's literal bytes for the tests.
+
+Reading the Rust const's raw-string literal rather than running the CLI lets a
+Python test pin the SHIPPED scaffold with no cargo build. There is one such
+helper so the API's unit and integration suites cannot answer "what does `curie
+init` write" two different ways, one of which quietly goes stale.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+# packages/test-support/src/curie_test_support/<this file> -- root is five up.
+REPO_ROOT = Path(__file__).parents[4]
+
+SCAFFOLD_RS = REPO_ROOT / "cli" / "src" / "scaffold.rs"
+
+_DEPLOY_YAML = re.compile(r'const DEPLOY_YAML: &str = r#"(.*?)"#;', re.S)
+
+
+def scaffolded_deploy_yaml() -> str:
+    """The literal `deploy.yaml` bytes `curie init` writes.
+
+    Raises if `cli/src/scaffold.rs` is missing, moved, or reshaped (a bump to
+    `r##"`, say). That is the point: the pin must break loudly, naming the file
+    to re-point it at, never quietly stop pinning anything.
+    """
+
+    source = SCAFFOLD_RS.read_text(encoding="utf-8")
+    match = _DEPLOY_YAML.search(source)
+    assert match is not None, (
+        f"{SCAFFOLD_RS} no longer declares `const DEPLOY_YAML: &str = r#\"...\"#;`; "
+        "re-point this pin at it"
+    )
+    return match.group(1)


### PR DESCRIPTION
Closes #1210

`curie init` scaffolds a `deploy.yaml` ending in a literal `targets: {}`. Since #1194 the presence of that file, not its content, disabled git-flow's single-agent fallback, so every push from a freshly scaffolded bundle was a silent no-op: green webhook delivery, 200 OK, and no agent, version, or deployment. `deploy.no_targets` could not cover it, because that code lived inside the branch being skipped.

The gate now turns on whether any target is **declared** rather than on whether the file exists. That also covers a `deploy.yaml` that is entirely comments, which validates to the same empty map, so commenting the line out was never a workaround either. A `deploy.yaml` that does declare targets routes exactly as before; all four ADR-0091 refusals are untouched.

## Verification

The mutation the issue asks for, executed on the final tree. Reverting the gate to `if targets is None:` fails 5 tests, including the webhook one:

```
FAILED test_gitflow_targets.py::test_an_empty_targets_map_still_deploys_its_single_agent
FAILED test_gitflow_targets.py::test_an_empty_targets_map_with_several_agents_is_refused
FAILED test_gitflow_targets.py::test_a_deploy_yaml_of_only_comments_still_deploys_its_single_agent
FAILED test_gitflow_targets.py::test_the_scaffolded_deploy_yaml_deploys_the_repositorys_single_agent
FAILED test_gitflow_integration.py::test_a_scaffolded_deploy_yaml_still_deploys
  AssertionError: {'status': 'ignored', 'environment': None, 'agent_id': None, ...}
```

`uv run pytest -q apps/api/tests`: 532 passed, 1 skipped. The skip is `test_langfuse_integration.py` "dev compose stack not reachable", pre-existing and environmental (the compose `curie-migrate` service exits 255 on this box, so otel-collector never starts). Baseline on `main` was 526 passed.
`uv run ruff check .`, `uv run mypy` (174 files), `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test` (61 tests): all clean.

Manual check: scaffold a bundle with `curie init`, leave `deploy.yaml` untouched, bind one agent to the repo, push to `dev`. The webhook returns `status="deployed"` with a non-null `deployment_id`.

## Out-of-scope hunks, intentionally bundled

Both were authorized during review rather than sneaking in, and both are caused by the fix rather than adjacent to it:

1. **The `deploy.no_targets` message text.** Once one branch serves both an absent `deploy.yaml` and an empty map, the old message ("the bundle declares no deploy.yaml ... Add deploy.yaml") is false for the new case, telling an operator to add a file they already have. The two situations have different remedies and the webhook returns 200 either way, so this string is the only signal. The `TargetUnresolved` code is unchanged.
2. **Pinning the scaffold's shipped bytes.** `scaffolded_deploy_yaml()` in `curie_test_support` reads the `DEPLOY_YAML` const out of `cli/src/scaffold.rs`, so both tests exercise what `curie init` actually writes instead of a hand-written guess. It is a standing gate on that const, and it fails loudly naming the file if the const moves or is reshaped.

## Done-check

- [x] Tests present and green. 7 new tests across four layers: parse premise, unit routing, `read_deploy_targets` premise, real webhook.
- [x] Code Reviewer approved with file:line spec-vs-impl evidence. Two blocking findings raised (behavioural AC untested, scaffold doc comment falsified) and both fixed.
- [x] Spec-vs-impl reviewer: all 5 acceptance criteria met, 0 unmet or partial. AC2 is met by composition rather than literally; the tests cover a strict superset of the expression the issue names.
- [x] Scope Reviewer approved. 0 scope-creep hunks; the two items above are annotated here as required.
- [x] Guard demonstration: the gate was demonstrated by execution, not by reading. Output above.
- [x] Sibling-path parity: the only other consumer of `DeployTargetsFile | None` is `_target_agent_name`, which already yields `None` for both representations via its own `len(matching) != 1` return, so it needs no matching change. The `/deploy-targets/resolve` router and the CLI `--target` path call `validate_deploy_targets` directly and never see the `None` arm.
- [x] Consolidation pass ran. `/simplify` applied 4 cleanups; suite and lint green after; a fresh Code Reviewer re-checked only the consolidation diff and approved with 0 blocking.
- [x] Lint clean on every edited file.
- [ ] N/A: failing-tests-committed-first and the build-tier plan doc. This ran quick tier.
- [ ] N/A: Security Reviewer and E2E Tester. Neither scale-up fired.

## Deferred

- `cli/src/scaffold.rs` could hold `DEPLOY_YAML` as `include_str!` of a real file, which would delete the Rust-source parser in the test entirely and has precedent at 5 sites in `cli/`. Not done here: extracting one of five sibling scaffold consts to a file inside a bugfix PR is an inconsistency that invites its own follow-up, and the current pin fails loudly rather than silently.
- `routers/github.py` still early-returns on any non-rejected outcome, so an `ignored` result produces no log line and no machine-readable code. The issue names this as what made the bug invisible. It is a separate defect and this PR deliberately leaves it alone.
