### PR TITLE
Bind an unbound agent's repo on deploy instead of advising a recreate

### DIFF
--- a/apps/api/tests/test_gitflow_integration.py
+++ b/apps/api/tests/test_gitflow_integration.py
@@ -189,6 +189,109 @@ def test_dev_push_deploys_dev_bot(
     assert deployments[0]["environment"] == "dev"
 
 
+def test_patched_repo_binding_routes_a_push(
+    client: Any,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    trusted_clone_base: Path,
+) -> None:
+    """A binding applied by PATCH must actually route that repository's pushes.
+
+    Before migration 0018, create-time was the only place `repo_full_name`
+    could ever be set, so an agent bound after creation had no way to become
+    reachable by git-flow. This drives the push through the single-agent
+    fallback in `resolve_target_agent` (no `deploy.yaml` in the pushed files,
+    exactly one agent bound to the repository), which is the path an agent
+    bound entirely by PATCH depends on.
+
+    Asserting that `AgentUpdate` has the field proves none of that. Only a real
+    signed push landing a deployment on the patched agent does.
+    """
+
+    created = client.post(
+        "/agents",
+        json={"name": "patched-agent", "slack_channel": "C000000G02"},
+        headers=auth_headers,
+    )
+    assert created.status_code == 201, created.text
+    agent_id = str(created.json()["id"])
+    assert created.json()["repo_full_name"] is None, "created deliberately unbound"
+
+    patched = client.patch(
+        f"/agents/{agent_id}",
+        json={"repo_full_name": REPO},
+        headers=auth_headers,
+    )
+    assert patched.status_code == 200, patched.text
+    assert patched.json()["repo_full_name"] == REPO
+
+    # Read back through a separate request, so the assertion cannot be satisfied
+    # by the PATCH response echoing its own input.
+    fetched = client.get(f"/agents/{agent_id}", headers=auth_headers)
+    assert fetched.status_code == 200, fetched.text
+    assert fetched.json()["repo_full_name"] == REPO
+
+    clone_url, sha = _build_bare_repo(trusted_clone_base, REPO, VALID_FILES)
+    resp = _post(client, "push", _push_payload("refs/heads/dev", sha, clone_url))
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["status"] == "deployed", body
+    assert body["environment"] == "dev"
+    assert body["commit_sha"] == sha
+
+    # The push reached THIS agent, which is the whole point of the binding: a
+    # push succeeding somewhere else would prove nothing.
+    deployments = client.get(
+        "/deployments", params={"agent_id": agent_id}, headers=auth_headers
+    ).json()
+    assert len(deployments) == 1, deployments
+    assert deployments[0]["environment"] == "dev"
+
+
+def test_patch_omitting_repo_full_name_leaves_the_binding_intact(
+    client: Any,
+    auth_headers: dict[str, str],
+    clean_db: None,
+) -> None:
+    """A PATCH that omits repo_full_name must leave an existing binding alone.
+
+    This is the guarantee a channel-only redeploy PATCH depends on: the CLI
+    sends slack_channel by itself whenever --repo was not passed, and that
+    must never wipe the repository the agent is already bound to.
+    """
+
+    created = client.post(
+        "/agents",
+        json={
+            "name": "omit-repo-agent",
+            "slack_channel": "C0EXAMPLE3",
+            "repo_full_name": REPO,
+        },
+        headers=auth_headers,
+    )
+    assert created.status_code == 201, created.text
+    agent_id = str(created.json()["id"])
+    assert created.json()["repo_full_name"] == REPO, "bound at creation"
+
+    patched = client.patch(
+        f"/agents/{agent_id}",
+        json={"slack_channel": "C0EXAMPLE4"},
+        headers=auth_headers,
+    )
+    assert patched.status_code == 200, patched.text
+
+    # Read back through a separate request, so the assertion cannot be
+    # satisfied by the PATCH response echoing stale input.
+    fetched = client.get(f"/agents/{agent_id}", headers=auth_headers)
+    assert fetched.status_code == 200, fetched.text
+    assert fetched.json()["repo_full_name"] == REPO, (
+        "omitting repo_full_name from the PATCH must leave the binding unchanged"
+    )
+    assert fetched.json()["slack_channel"] == "C0EXAMPLE4", (
+        "the channel PATCH must still take effect"
+    )
+
+
 def test_main_push_promotes_and_reuses_the_built_version(
     client: Any,
     auth_headers: dict[str, str],

--- a/apps/api/tests/test_gitflow_targets.py
+++ b/apps/api/tests/test_gitflow_targets.py
@@ -136,23 +136,3 @@ def test_a_bundle_without_deploy_yaml_and_several_agents_is_refused() -> None:
         resolve_target_agent(None, Environment.prod, [agent("a"), agent("b")], None)
     assert caught.value.code == "deploy.no_targets"
     assert "deploy.yaml" in str(caught.value)
-
-
-# --------------------------------------------------------------------------- #
-# Binding an existing agent to a repository
-# --------------------------------------------------------------------------- #
-def test_repo_full_name_is_patchable() -> None:
-    """Without this, ADR-0091 is unreachable for the repos that need it most.
-
-    A repository's SECOND agent could not carry `repo_full_name` before
-    migration 0018 -- the unique index forbade it -- so it exists today bound to
-    nothing. `AgentUpdate` had no field for it, and create-time was the only
-    place it could ever be set. Git-flow would therefore never find that agent,
-    and a `deploy.yaml` naming it would be rejected as unknown.
-    """
-
-    from curie_api.schemas import AgentUpdate
-
-    assert "repo_full_name" in AgentUpdate.model_fields
-    assert AgentUpdate().repo_full_name is None, "omitted must leave the binding unchanged"
-    assert AgentUpdate(repo_full_name="octo/x").repo_full_name == "octo/x"

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -55,9 +55,10 @@ pub struct Agent {
     pub id: String,
     pub name: String,
     pub slack_channel: String,
-    /// The repository whose pushes deploy this agent (ADR-0014). Identity, set
-    /// only at creation -- `AgentUpdate` deliberately excludes it -- so the CLI
-    /// must send it up front or the agent can never reach git-flow (#1064).
+    /// The repository whose pushes deploy this agent (ADR-0014). Set at
+    /// creation via `--repo`, or bound later by PATCH since `AgentUpdate`
+    /// carries the field (#1194). ADR-0091 dropped the unique index, so
+    /// several agents may share one repository.
     #[serde(default)]
     pub repo_full_name: Option<String>,
     /// Tool names gated behind human approval (#245). Present on `AgentOut`;
@@ -362,9 +363,12 @@ pub struct DeployOutcome {
     pub bundle: Bundle,
     pub deployment: Deployment,
     pub channel: ChannelOutcome,
-    /// Set when `--repo` could not be applied because the agent already exists
-    /// and its repo binding is immutable. Surfaced so the operator learns it
-    /// silently did nothing (#1064).
+    /// The warning about what `--repo` did, if any: either the binding was
+    /// declined because the agent is already bound to a different repository,
+    /// or a bind was requested and the platform's response did not carry it
+    /// back. `None` on a successful bind or when `--repo` was not passed.
+    /// Surfaced so the operator never believes a binding that is not there
+    /// (#1064, #1212).
     pub repo_note: Option<String>,
 }
 
@@ -414,14 +418,39 @@ fn warn_if_insecure(base_url: &str) {
 
 /// The `POST /agents` body. Pure so the shape is testable without a live API.
 ///
-/// `repo_full_name` is sent only when asked: it is UNIQUE per agent, so an
-/// unsolicited value would 409 against whichever agent already owns that repo.
+/// `repo_full_name` is sent only when asked, because a value the caller did not
+/// pass is not a binding the caller intended. Since ADR-0091 and migration 0018
+/// the column is no longer unique, so an unsolicited value would silently bind
+/// the new agent to that repository rather than 409, which is worse.
 fn agent_create_body(
     name: &str,
     slack_channel: &str,
     repo_full_name: Option<&str>,
 ) -> serde_json::Value {
     let mut body = json!({"name": name, "slack_channel": slack_channel});
+    if let Some(repo) = repo_full_name {
+        body["repo_full_name"] = json!(repo);
+    }
+    body
+}
+
+/// The `PATCH /agents/{id}` body for the fields deploy reconciles. Pure so the
+/// shape is testable without a live API.
+///
+/// Each key appears only when its argument is `Some`: omission is the wire
+/// spelling for "leave this field unchanged". Neither key is ever emitted as an
+/// explicit JSON `null`, because the router guards both behind `is not None`
+/// and Pydantic decodes a `null` and an absent key to the same `None`, so a
+/// `null` would read as "omitted" while looking on the wire like an intent to
+/// clear (#1071, the same trap documented on [`ApiClient::set_approval_routes`]).
+fn agent_update_body(
+    slack_channel: Option<&str>,
+    repo_full_name: Option<&str>,
+) -> serde_json::Value {
+    let mut body = json!({});
+    if let Some(channel) = slack_channel {
+        body["slack_channel"] = json!(channel);
+    }
     if let Some(repo) = repo_full_name {
         body["repo_full_name"] = json!(repo);
     }
@@ -534,16 +563,19 @@ impl ApiClient {
         self.create_agent(name, slack_channel, None).await
     }
 
-    pub async fn update_agent_channel(&self, agent_id: &str, slack_channel: &str) -> Result<Agent> {
+    /// `PATCH /agents/{id}` with a body the caller already built (see
+    /// [`agent_update_body`]). The returned `Agent` is the row as the API
+    /// stored it, so callers report what took rather than what they intended.
+    pub async fn update_agent(&self, agent_id: &str, body: &serde_json::Value) -> Result<Agent> {
         let resp = self
             .http
             .patch(format!("{}/agents/{agent_id}", self.base_url))
             .header("X-API-Key", &self.api_key)
-            .json(&json!({"slack_channel": slack_channel}))
+            .json(body)
             .send()
             .await
             .context("PATCH /agents/{id}")?;
-        Self::expect_ok(resp, "updating the agent channel")
+        Self::expect_ok(resp, "updating the agent")
             .await?
             .json()
             .await
@@ -573,11 +605,16 @@ impl ApiClient {
             .context("decoding updated agent")
     }
 
-    /// Find the agent by name (or create it), reconciling its Slack channel with
-    /// an explicitly-passed `--slack-channel`. A new agent binds to the passed
-    /// channel (or the default); an existing agent's channel is moved via PATCH
-    /// only when a channel was passed and differs -- an omitted channel never
-    /// silently overwrites what is already set.
+    /// Find the agent by name (or create it), reconciling its Slack channel and
+    /// its repo binding with an explicitly-passed `--slack-channel`/`--repo`.
+    ///
+    /// A new agent binds to the passed channel (or the default); an existing
+    /// agent's channel is moved via PATCH only when a channel was passed and
+    /// differs -- an omitted channel never silently overwrites what is already
+    /// set. An existing agent with no repo binding is bound to `--repo` in that
+    /// same PATCH; one already bound elsewhere is left alone. The third return
+    /// value is the operator note, set when the repo binding did not end up
+    /// where `--repo` asked and left `None` when it did.
     async fn resolve_agent(
         &self,
         name: &str,
@@ -591,36 +628,65 @@ impl ApiClient {
             .find(|a| a.name == name);
         match existing {
             Some(agent) => {
-                // The repo binding is identity: `AgentUpdate` excludes it, so a
-                // PATCH would return 200 and change nothing. Say so plainly
-                // rather than let the operator believe it took (#1064).
-                let repo_note = match (repo_full_name, agent.repo_full_name.as_deref()) {
-                    (Some(want), Some(have)) if want == have => None,
-                    (Some(want), Some(have)) => Some(format!(
-                        "agent is already bound to {have}; --repo {want} was NOT applied \
-                         (the repo binding is set at creation and cannot be changed)"
-                    )),
-                    (Some(want), None) => Some(format!(
-                        "agent exists with no repo binding; --repo {want} was NOT applied \
-                         (the binding is set at creation only, so this agent cannot use \
-                         git-flow -- recreate it to bind one)"
-                    )),
-                    (None, _) => None,
+                // `AgentUpdate` has carried `repo_full_name` since ADR-0091 and
+                // #1194, so an agent with no binding is bound right here rather
+                // than sent away to be built again from scratch (#1212). An
+                // agent already bound elsewhere is NOT moved: a deploy must not
+                // silently reroute which repository's pushes reach it.
+                let channel_move = slack_channel.filter(|c| *c != agent.slack_channel.as_str());
+                let current_repo = agent.repo_full_name.as_deref();
+                let (repo_bind, mut repo_note) = match (repo_full_name, current_repo) {
+                    (Some(want), None) => (Some(want), None),
+                    (Some(want), Some(have)) if want != have => (
+                        None,
+                        Some(format!(
+                            "agent is already bound to {have}; --repo {want} was NOT \
+                             applied. A deploy does not move an existing repo binding, \
+                             because that reroutes which repository's pushes deploy this \
+                             agent. To rebind deliberately, PATCH repo_full_name on \
+                             /agents/{id} against the platform API.",
+                            id = agent.id
+                        )),
+                    ),
+                    _ => (None, None),
                 };
-                let outcome = match slack_channel {
-                    Some(channel) if channel != agent.slack_channel => {
-                        let from = agent.slack_channel.clone();
-                        let updated = self.update_agent_channel(&agent.id, channel).await?;
-                        let to = updated.slack_channel.clone();
-                        return Ok((updated, ChannelOutcome::Updated { from, to }, repo_note));
-                    }
-                    other => {
-                        let channel = agent.slack_channel.clone();
-                        ChannelOutcome::Unchanged {
-                            channel,
-                            passed: other.is_some(),
-                        }
-                    }
+                // One request rather than two removes the client-side window
+                // where the channel moved and a second call then failed, and
+                // the channel-uniqueness 409 aborts before repo_full_name is
+                // reached. The server still commits per field, so the two
+                // fields are not applied atomically.
+                let previous_channel = channel_move.map(|_| agent.slack_channel.clone());
+                let agent = if channel_move.is_some() || repo_bind.is_some() {
+                    let body = agent_update_body(channel_move, repo_bind);
+                    self.update_agent(&agent.id, &body).await?
+                } else {
+                    agent
+                };
+                // `AgentUpdate` ignores unknown keys, so a platform older than
+                // #1194 answers the bind with 200 and stores nothing. The
+                // response is the only place that shows up: without this check
+                // the deploy reports a binding the platform never made, which
+                // is the exact failure #1064 put an operator warning here for.
+                let bound = agent.repo_full_name.as_deref();
+                if let Some(want) = repo_bind.filter(|&w| bound != Some(w)) {
+                    repo_note = Some(format!(
+                        "--repo {want} was sent but the platform did not apply it (the agent \
+                         reports {stored}). That usually means the platform release predates \
+                         the AgentUpdate.repo_full_name field (#1194) and ignored the key. \
+                         git-flow will not route pushes to this agent until the platform is \
+                         upgraded or the binding is set another way.",
+                        stored = bound.unwrap_or("no binding")
+                    ));
+                }
+                let outcome = match previous_channel {
+                    Some(from) => ChannelOutcome::Updated {
+                        from,
+                        to: agent.slack_channel.clone(),
+                    },
+                    None => ChannelOutcome::Unchanged {
+                        channel: agent.slack_channel.clone(),
+                        passed: slack_channel.is_some(),
+                    },
                 };
                 Ok((agent, outcome, repo_note))
             }
@@ -1189,12 +1255,13 @@ impl ApiClient {
 
 #[cfg(test)]
 mod tests {
-    use super::{agent_create_body, is_insecure_endpoint};
+    use super::{agent_create_body, agent_update_body, is_insecure_endpoint};
 
     #[test]
     fn create_agent_body_omits_repo_unless_asked() {
-        // repo_full_name is UNIQUE per agent, so sending an unsolicited value
-        // would 409 against whichever agent already owns that repo.
+        // A value the caller did not pass is not a binding the caller intended.
+        // The column is no longer unique (ADR-0091, migration 0018), so an
+        // unsolicited value would silently bind rather than 409.
         let body = agent_create_body("bot", "C123", None);
         assert_eq!(body["name"], "bot");
         assert_eq!(body["slack_channel"], "C123");
@@ -1203,10 +1270,40 @@ mod tests {
 
     #[test]
     fn create_agent_body_binds_the_repo_when_asked() {
-        // Creation is the ONLY chance: AgentUpdate excludes repo_full_name, so
-        // an agent created without it can never reach git-flow (#1064).
+        // Creation is the first chance to bind, and the only one that needs no
+        // second request: AgentUpdate carries repo_full_name too (#1194).
         let body = agent_create_body("bot", "C123", Some("acme/bundle"));
         assert_eq!(body["repo_full_name"], "acme/bundle");
+    }
+
+    #[test]
+    fn agent_update_body_omits_both_when_neither_is_asked() {
+        // Omission is how the wire says "leave this alone", so a PATCH with
+        // nothing to change carries nothing at all.
+        let body = agent_update_body(None, None);
+        assert!(
+            body.as_object().expect("an object").is_empty(),
+            "was {body}"
+        );
+    }
+
+    #[test]
+    fn agent_update_body_carries_only_what_was_asked() {
+        // Each absent key must be ABSENT, never an explicit null: the router
+        // guards both fields behind `is not None`, and Pydantic decodes a null
+        // and an omitted key identically, so a null would read as "omitted"
+        // while looking on the wire like an intent to clear (#1071).
+        let channel = agent_update_body(Some("C123"), None);
+        assert_eq!(channel["slack_channel"], "C123");
+        assert!(channel.get("repo_full_name").is_none(), "was {channel}");
+
+        let repo = agent_update_body(None, Some("acme/bundle"));
+        assert_eq!(repo["repo_full_name"], "acme/bundle");
+        assert!(repo.get("slack_channel").is_none(), "was {repo}");
+
+        let both = agent_update_body(Some("C123"), Some("acme/bundle"));
+        assert_eq!(both["slack_channel"], "C123");
+        assert_eq!(both["repo_full_name"], "acme/bundle");
     }
 
     #[test]

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -745,10 +745,11 @@ pub struct DeployNamedOpts {
     pub api_url: String,
     pub api_key: String,
     pub slack_channel: Option<String>,
-    /// `owner/name` to bind at agent CREATION so pushes to that repo deploy this
-    /// agent (ADR-0014). Identity, not config: it cannot be changed afterwards,
-    /// so omitting it here leaves the agent permanently unable to use git-flow
-    /// (#1064). Ignored with a warning when the agent already exists.
+    /// `owner/name` binding the repository whose pushes deploy this agent
+    /// (ADR-0014). Bound when the agent is created, or on a later deploy if the
+    /// agent has no binding yet (#1194). An agent already bound to a DIFFERENT
+    /// repository is left alone and warned about, because a deploy does not
+    /// reroute an existing binding.
     pub repo: Option<String>,
     pub env: DeployEnv,
     pub label: Option<String>,
@@ -2938,10 +2939,11 @@ pub struct DeployOpts {
     /// leaves an existing agent's channel untouched instead of masking intent
     /// with a default.
     pub slack_channel: Option<String>,
-    /// `owner/name` to bind at agent CREATION so pushes to that repo deploy this
-    /// agent (ADR-0014). Identity, not config: it cannot be changed afterwards,
-    /// so omitting it here leaves the agent permanently unable to use git-flow
-    /// (#1064). Ignored with a warning when the agent already exists.
+    /// `owner/name` binding the repository whose pushes deploy this agent
+    /// (ADR-0014). Bound when the agent is created, or on a later deploy if the
+    /// agent has no binding yet (#1194). An agent already bound to a DIFFERENT
+    /// repository is left alone and warned about, because a deploy does not
+    /// reroute an existing binding.
     pub repo: Option<String>,
     /// None means the caller did not pass --env, so a declared target may
     /// supply it. An explicit flag still wins (ADR-0089).
@@ -3174,10 +3176,24 @@ pub async fn deploy(opts: DeployOpts) -> Result<DeployOutput> {
         }
     };
 
-    // A --repo that could not be applied is a silent no-op otherwise: the deploy
-    // succeeds, the agent looks fine, and git-flow never fires (#1064).
+    // A declined --repo is otherwise silent: the deploy succeeds, the agent
+    // looks fine, and the operator believes the rebind took (#1064, #1212).
     if let Some(note) = &outcome.repo_note {
         ui.warn(note);
+    }
+
+    // An APPLIED --repo was equally silent: writing the field that decides
+    // which repository's pushes deploy this agent produced no output at all.
+    // The value read here is the one the API stored, not the one asked for, so
+    // a bind the platform dropped falls to the warning above instead (#1212).
+    let bound_repo = opts
+        .repo
+        .as_deref()
+        .filter(|want| outcome.agent.repo_full_name.as_deref() == Some(*want));
+    if let Some(repo) = bound_repo {
+        ui.note(&format!(
+            "repo binding: git-flow pushes to {repo} deploy this agent"
+        ));
     }
 
     let channel = match &outcome.channel {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -277,11 +277,12 @@ enum Command {
         /// Bind this agent to a GitHub repository (`owner/name`) so pushes to
         /// its dev/prod branches deploy it (ADR-0014).
         ///
-        /// The binding is IDENTITY, not config: the platform sets it only when
-        /// the agent is created and `AgentUpdate` cannot change it. Deploying
-        /// without it creates an agent that can never use git-flow, and the
-        /// only remedy is recreating the agent (#1064). Passing it for an
-        /// agent that already exists warns and changes nothing.
+        /// A new agent is created bound to it, and an existing agent with no
+        /// binding is bound now (#1194 made `repo_full_name` PATCHable and
+        /// ADR-0091 dropped the uniqueness, so one repository can build several
+        /// agents). An agent already bound to a DIFFERENT repository is NOT
+        /// moved, because that would reroute which repository's pushes deploy
+        /// it; a warning names the binding it kept.
         #[arg(long = "repo", value_name = "OWNER/NAME")]
         repo: Option<String>,
         /// Target environment. Defaults to dev; a `--target` supplies it
@@ -948,11 +949,12 @@ enum LocalAction {
         /// Bind this agent to a GitHub repository (`owner/name`) so pushes to
         /// its dev/prod branches deploy it (ADR-0014).
         ///
-        /// The binding is IDENTITY, not config: the platform sets it only when
-        /// the agent is created and `AgentUpdate` cannot change it. Deploying
-        /// without it creates an agent that can never use git-flow, and the
-        /// only remedy is recreating the agent (#1064). Passing it for an
-        /// agent that already exists warns and changes nothing.
+        /// A new agent is created bound to it, and an existing agent with no
+        /// binding is bound now (#1194 made `repo_full_name` PATCHable and
+        /// ADR-0091 dropped the uniqueness, so one repository can build several
+        /// agents). An agent already bound to a DIFFERENT repository is NOT
+        /// moved, because that would reroute which repository's pushes deploy
+        /// it; a warning names the binding it kept.
         #[arg(long = "repo", value_name = "OWNER/NAME")]
         repo: Option<String>,
         /// Target environment. Defaults to dev; a `--target` supplies it
@@ -1436,11 +1438,12 @@ enum ClusterAction {
         /// Bind this agent to a GitHub repository (`owner/name`) so pushes to
         /// its dev/prod branches deploy it (ADR-0014).
         ///
-        /// The binding is IDENTITY, not config: the platform sets it only when
-        /// the agent is created and `AgentUpdate` cannot change it. Deploying
-        /// without it creates an agent that can never use git-flow, and the
-        /// only remedy is recreating the agent (#1064). Passing it for an
-        /// agent that already exists warns and changes nothing.
+        /// A new agent is created bound to it, and an existing agent with no
+        /// binding is bound now (#1194 made `repo_full_name` PATCHable and
+        /// ADR-0091 dropped the uniqueness, so one repository can build several
+        /// agents). An agent already bound to a DIFFERENT repository is NOT
+        /// moved, because that would reroute which repository's pushes deploy
+        /// it; a warning names the binding it kept.
         #[arg(long = "repo", value_name = "OWNER/NAME")]
         repo: Option<String>,
         /// Target environment. Defaults to dev; a `--target` supplies it

--- a/cli/tests/api_deploy.rs
+++ b/cli/tests/api_deploy.rs
@@ -3,12 +3,13 @@
 
 mod support;
 
-use curie::api::{ApiClient, ChannelOutcome};
+use curie::api::{ApiClient, ChannelOutcome, DeployOutcome};
 use curie::bundle::pack_tar_gz;
 use curie::scaffold::scaffold;
-use support::{serve, Response};
+use support::{serve, MockServer, Response};
 
 const AGENT_ID: &str = "11111111-1111-1111-1111-111111111111";
+const AGENT_NAME: &str = "deal-desk";
 const VERSION_ID: &str = "22222222-2222-2222-2222-222222222222";
 const DEPLOYMENT_ID: &str = "33333333-3333-3333-3333-333333333333";
 
@@ -155,33 +156,89 @@ fn deploy_tail(method: &str, path: &str) -> Option<Response> {
     }
 }
 
-fn existing_agent(channel: &str) -> Response {
-    Response::json(
-        200,
-        &format!(
-            r#"[{{"id":"{AGENT_ID}","name":"deal-desk","slack_channel":"{channel}","created_at":"2026-07-05T00:00:00Z"}}]"#
-        ),
+/// One agent's wire JSON. `repo` emits the `repo_full_name` key only when the
+/// agent is bound, so an unbound agent travels as an ABSENT key and exercises
+/// the field's real `#[serde(default)]` path rather than an explicit null.
+fn agent_json(id: &str, name: &str, channel: &str, repo: Option<&str>) -> String {
+    let bound = match repo {
+        Some(repo) => format!(r#","repo_full_name":"{repo}""#),
+        None => String::new(),
+    };
+    format!(
+        r#"{{"id":"{id}","name":"{name}","slack_channel":"{channel}","created_at":"2026-07-05T00:00:00Z"{bound}}}"#
     )
 }
 
-async fn run_deploy(client: &ApiClient, channel: Option<&str>) -> ChannelOutcome {
+/// The `GET /agents` listing that resolution reads: the one agent under test,
+/// as the platform would report it.
+fn existing_agents(agent: &str) -> Response {
+    Response::json(200, &format!("[{agent}]"))
+}
+
+/// The `PATCH /agents/{id}` response: the agent as the API stored it. The
+/// deploy must report THIS row, never a locally patched copy of the listed one,
+/// or the CLI can claim a binding the API never took.
+fn patched_agent(channel: &str, repo: Option<&str>) -> Response {
+    Response::json(200, &agent_json(AGENT_ID, AGENT_NAME, channel, repo))
+}
+
+/// Every recorded `PATCH /agents/{id}` body, parsed. The body on the wire is
+/// the contract under test: what the CLI SENT, not what it decided internally.
+fn patch_bodies(server: &MockServer) -> Vec<serde_json::Value> {
+    server
+        .recorded()
+        .into_iter()
+        .filter(|r| r.method == "PATCH" && r.path == format!("/agents/{AGENT_ID}"))
+        .map(|r| serde_json::from_slice(&r.body).expect("PATCH body should be JSON"))
+        .collect()
+}
+
+/// Assert that the deploy issued no `PATCH /agents/{id}` at all.
+///
+/// This assertion is only load-bearing because the no-PATCH tests ANSWER an
+/// unexpected PATCH instead of panicking on it. The mock records a request
+/// only AFTER its handler returns (`cli/tests/support/mod.rs`), so a handler
+/// that panics on a PATCH means the PATCH is never recorded: the check then
+/// runs over a list that could not contain the thing it looks for and passes
+/// no matter what the CLI did. Such a test goes red only through the socket
+/// error the unwound handler thread causes, which is red for the wrong reason
+/// and is equally red for unrelated breakage. Answering keeps the request in
+/// the recording, so "the CLI sent a PATCH it must not send" is what fails,
+/// and the offending body is the failure message.
+fn assert_no_patch(server: &MockServer) {
+    let patches: Vec<String> = server
+        .recorded()
+        .iter()
+        .filter(|r| r.method == "PATCH")
+        .map(|r| format!("{} {}", r.path, String::from_utf8_lossy(&r.body)))
+        .collect();
+    assert!(
+        patches.is_empty(),
+        "no PATCH should have been issued, got {patches:?}"
+    );
+}
+
+async fn run_deploy(
+    client: &ApiClient,
+    channel: Option<&str>,
+    repo: Option<&str>,
+) -> DeployOutcome {
     let dir = tempfile::tempdir().unwrap();
-    scaffold(dir.path(), "deal-desk").unwrap();
+    scaffold(dir.path(), AGENT_NAME).unwrap();
     let archive = pack_tar_gz(dir.path()).unwrap();
     client
         .deploy(
-            "deal-desk",
+            AGENT_NAME,
             channel,
             "0.1.0-1",
             "tester",
             "dev",
             archive,
             &std::collections::BTreeMap::new(),
-            None,
+            repo,
         )
         .await
         .unwrap()
-        .channel
 }
 
 #[tokio::test]
@@ -189,20 +246,15 @@ async fn redeploy_with_explicit_channel_patches_the_existing_agent() {
     // An existing agent on #old + `--slack-channel #new` must PATCH the agent to
     // move the channel (the audit MAJOR: the channel was silently ignored).
     let server = serve(|req| match (req.method.as_str(), req.path.as_str()) {
-        ("GET", "/agents") => existing_agent("#old"),
-        ("PATCH", p) if *p == format!("/agents/{AGENT_ID}") => Response::json(
-            200,
-            &format!(
-                r##"{{"id":"{AGENT_ID}","name":"deal-desk","slack_channel":"#new","created_at":"2026-07-05T00:00:00Z"}}"##
-            ),
-        ),
+        ("GET", "/agents") => existing_agents(&agent_json(AGENT_ID, AGENT_NAME, "#old", None)),
+        ("PATCH", p) if *p == format!("/agents/{AGENT_ID}") => patched_agent("#new", None),
         (m, p) => deploy_tail(m, p).unwrap_or_else(|| panic!("unexpected request: {m} {p}")),
     });
     let client = ApiClient::new(&server.base_url, "k").unwrap();
 
-    let outcome = run_deploy(&client, Some("#new")).await;
+    let outcome = run_deploy(&client, Some("#new"), None).await;
     assert_eq!(
-        outcome,
+        outcome.channel,
         ChannelOutcome::Updated {
             from: "#old".to_string(),
             to: "#new".to_string(),
@@ -224,23 +276,247 @@ async fn redeploy_without_channel_does_not_patch() {
     // Omitting `--slack-channel` on a redeploy must leave the agent's channel
     // untouched: no PATCH is issued at all.
     let server = serve(|req| match (req.method.as_str(), req.path.as_str()) {
-        ("GET", "/agents") => existing_agent("#old"),
-        ("PATCH", _) => panic!("redeploy without --slack-channel must not PATCH"),
+        ("GET", "/agents") => existing_agents(&agent_json(AGENT_ID, AGENT_NAME, "#old", None)),
+        // Answered, never panicked, so the PATCH would be RECORDED and
+        // `assert_no_patch` is what fails. See its doc comment.
+        ("PATCH", p) if *p == format!("/agents/{AGENT_ID}") => patched_agent("#old", None),
         (m, p) => deploy_tail(m, p).unwrap_or_else(|| panic!("unexpected request: {m} {p}")),
     });
     let client = ApiClient::new(&server.base_url, "k").unwrap();
 
-    let outcome = run_deploy(&client, None).await;
+    let outcome = run_deploy(&client, None, None).await;
     assert_eq!(
-        outcome,
+        outcome.channel,
         ChannelOutcome::Unchanged {
             channel: "#old".to_string(),
             passed: false,
         }
     );
+    assert_no_patch(&server);
+}
+
+#[tokio::test]
+async fn deploy_binds_an_unbound_agents_repo() {
+    // An agent that already exists with NO repo binding is bound by this
+    // deploy, not told to recreate itself: `AgentUpdate` has carried
+    // `repo_full_name` since ADR-0091 / #1194, and until #1212 the CLI kept
+    // behaving as though it did not.
+    let server = serve(|req| match (req.method.as_str(), req.path.as_str()) {
+        ("GET", "/agents") => existing_agents(&agent_json(AGENT_ID, AGENT_NAME, "#old", None)),
+        ("PATCH", p) if *p == format!("/agents/{AGENT_ID}") => {
+            patched_agent("#old", Some("acme/bundle"))
+        }
+        (m, p) => deploy_tail(m, p).unwrap_or_else(|| panic!("unexpected request: {m} {p}")),
+    });
+    let client = ApiClient::new(&server.base_url, "k").unwrap();
+
+    let outcome = run_deploy(&client, None, Some("acme/bundle")).await;
+
+    let patches = patch_bodies(&server);
+    assert_eq!(
+        patches.len(),
+        1,
+        "expected exactly one PATCH, got {patches:?}"
+    );
+    assert_eq!(patches[0]["repo_full_name"], "acme/bundle");
     assert!(
-        server.recorded().iter().all(|r| r.method != "PATCH"),
-        "no PATCH should have been issued"
+        patches[0].get("slack_channel").is_none(),
+        "no channel was passed, so the PATCH must not carry one: {}",
+        patches[0]
+    );
+    assert!(
+        outcome.repo_note.is_none(),
+        "a binding that was applied must not warn: {:?}",
+        outcome.repo_note
+    );
+    // Read back from the PATCH response, so the CLI cannot report a binding
+    // the API never stored.
+    assert_eq!(outcome.agent.repo_full_name.as_deref(), Some("acme/bundle"));
+}
+
+#[tokio::test]
+async fn deploy_binds_the_repo_while_also_moving_the_channel() {
+    // The channel move and the repo bind travel in ONE PATCH. The old code
+    // returned early out of the channel-updated branch, so a fix applied only
+    // to the channel-unchanged branch would move the channel and silently drop
+    // the binding on exactly this path.
+    let server = serve(|req| match (req.method.as_str(), req.path.as_str()) {
+        ("GET", "/agents") => existing_agents(&agent_json(AGENT_ID, AGENT_NAME, "#old", None)),
+        ("PATCH", p) if *p == format!("/agents/{AGENT_ID}") => {
+            patched_agent("#new", Some("acme/bundle"))
+        }
+        (m, p) => deploy_tail(m, p).unwrap_or_else(|| panic!("unexpected request: {m} {p}")),
+    });
+    let client = ApiClient::new(&server.base_url, "k").unwrap();
+
+    let outcome = run_deploy(&client, Some("#new"), Some("acme/bundle")).await;
+
+    let patches = patch_bodies(&server);
+    assert_eq!(
+        patches.len(),
+        1,
+        "one PATCH carries both changes: {patches:?}"
+    );
+    assert_eq!(patches[0]["slack_channel"], "#new");
+    assert_eq!(patches[0]["repo_full_name"], "acme/bundle");
+    assert_eq!(
+        outcome.channel,
+        ChannelOutcome::Updated {
+            from: "#old".to_string(),
+            to: "#new".to_string(),
+        }
+    );
+    assert_eq!(outcome.agent.repo_full_name.as_deref(), Some("acme/bundle"));
+    assert!(
+        outcome.repo_note.is_none(),
+        "a binding that was applied must not warn: {:?}",
+        outcome.repo_note
+    );
+}
+
+#[tokio::test]
+async fn deploy_warns_when_the_platform_drops_the_repo_binding() {
+    // A platform older than `AgentUpdate.repo_full_name` (#1194) answers this
+    // PATCH 200 with the unknown key IGNORED: the agent comes back still
+    // unbound. `AgentUpdate` declares no `extra="forbid"`, so there is no 4xx
+    // and no unrouted-path 404 for the skew detector to key on -- the only
+    // evidence is the row that came back. Reporting a clean success here is
+    // exactly the failure #1064 exists to prevent: the operator believes the
+    // binding took, and git-flow never routes a push.
+    let server = serve(|req| match (req.method.as_str(), req.path.as_str()) {
+        ("GET", "/agents") => existing_agents(&agent_json(AGENT_ID, AGENT_NAME, "#old", None)),
+        ("PATCH", p) if *p == format!("/agents/{AGENT_ID}") => patched_agent("#old", None),
+        (m, p) => deploy_tail(m, p).unwrap_or_else(|| panic!("unexpected request: {m} {p}")),
+    });
+    let client = ApiClient::new(&server.base_url, "k").unwrap();
+
+    let outcome = run_deploy(&client, None, Some("acme/bundle")).await;
+
+    // The CLI did its half: the key went out on the wire.
+    let patches = patch_bodies(&server);
+    assert_eq!(
+        patches.len(),
+        1,
+        "expected exactly one PATCH, got {patches:?}"
+    );
+    assert_eq!(patches[0]["repo_full_name"], "acme/bundle");
+    // And it reports the row the API returned, not the one it asked for.
+    assert_eq!(outcome.agent.repo_full_name, None);
+    let note = outcome
+        .repo_note
+        .expect("a binding the platform did not store must warn");
+    assert!(note.contains("acme/bundle"), "note was: {note}");
+    // The load-bearing half of this test is the `expect` above (no warning at
+    // all is the defect); these two pin that the note is about the PLATFORM
+    // dropping it, not about a declined rebind.
+    assert!(note.contains("platform"), "note was: {note}");
+    assert!(
+        !note.contains("already bound"),
+        "this is version skew, not a declined rebind: {note}"
+    );
+}
+
+#[tokio::test]
+async fn deploy_does_not_rebind_an_agent_bound_elsewhere() {
+    // Moving a live binding reroutes which repository's pushes deploy the
+    // agent, which is ADR-0091's whole threat model. A routine deploy declines
+    // and says so instead.
+    let server = serve(|req| match (req.method.as_str(), req.path.as_str()) {
+        ("GET", "/agents") => existing_agents(&agent_json(
+            AGENT_ID,
+            AGENT_NAME,
+            "#old",
+            Some("other/repo"),
+        )),
+        // Answered, never panicked, so a rebinding PATCH would be RECORDED and
+        // `assert_no_patch` is what fails. See its doc comment.
+        ("PATCH", p) if *p == format!("/agents/{AGENT_ID}") => {
+            patched_agent("#old", Some("other/repo"))
+        }
+        (m, p) => deploy_tail(m, p).unwrap_or_else(|| panic!("unexpected request: {m} {p}")),
+    });
+    let client = ApiClient::new(&server.base_url, "k").unwrap();
+
+    let outcome = run_deploy(&client, None, Some("acme/bundle")).await;
+
+    assert_no_patch(&server);
+    let note = outcome.repo_note.expect("a declined --repo must warn");
+    assert!(note.contains("other/repo"), "note was: {note}");
+    assert!(note.contains("acme/bundle"), "note was: {note}");
+    // The binding CAN be changed now; a deploy just refuses to be the thing
+    // that changes it. The old wording sent operators off to recreate the
+    // agent, which is the false claim #1212 exists to retire.
+    assert!(!note.contains("cannot be changed"), "note was: {note}");
+    assert!(!note.contains("recreate"), "note was: {note}");
+}
+
+#[tokio::test]
+async fn deploy_with_a_matching_repo_does_not_patch() {
+    // Already bound to exactly what was asked for. A no-op PATCH would add a
+    // write to every routine redeploy and buy nothing.
+    let server = serve(|req| match (req.method.as_str(), req.path.as_str()) {
+        ("GET", "/agents") => existing_agents(&agent_json(
+            AGENT_ID,
+            AGENT_NAME,
+            "#old",
+            Some("acme/bundle"),
+        )),
+        // Answered, never panicked, so a no-op PATCH would be RECORDED and
+        // `assert_no_patch` is what fails. See its doc comment.
+        ("PATCH", p) if *p == format!("/agents/{AGENT_ID}") => {
+            patched_agent("#old", Some("acme/bundle"))
+        }
+        (m, p) => deploy_tail(m, p).unwrap_or_else(|| panic!("unexpected request: {m} {p}")),
+    });
+    let client = ApiClient::new(&server.base_url, "k").unwrap();
+
+    let outcome = run_deploy(&client, None, Some("acme/bundle")).await;
+
+    assert_no_patch(&server);
+    assert!(
+        outcome.repo_note.is_none(),
+        "nothing was declined, so nothing to warn about: {:?}",
+        outcome.repo_note
+    );
+}
+
+#[tokio::test]
+async fn deploy_without_repo_never_sends_the_field() {
+    // Omission is the wire spelling for "leave the binding alone". An explicit
+    // null would read as omitted at the router today, but absence is the
+    // contract we actually want on the wire (#1071).
+    let server = serve(|req| match (req.method.as_str(), req.path.as_str()) {
+        ("GET", "/agents") => existing_agents(&agent_json(
+            AGENT_ID,
+            AGENT_NAME,
+            "#old",
+            Some("acme/bundle"),
+        )),
+        ("PATCH", p) if *p == format!("/agents/{AGENT_ID}") => {
+            patched_agent("#new", Some("acme/bundle"))
+        }
+        (m, p) => deploy_tail(m, p).unwrap_or_else(|| panic!("unexpected request: {m} {p}")),
+    });
+    let client = ApiClient::new(&server.base_url, "k").unwrap();
+
+    let outcome = run_deploy(&client, Some("#new"), None).await;
+
+    let patches = patch_bodies(&server);
+    assert_eq!(
+        patches.len(),
+        1,
+        "expected exactly one PATCH, got {patches:?}"
+    );
+    assert_eq!(patches[0]["slack_channel"], "#new");
+    assert!(
+        patches[0].get("repo_full_name").is_none(),
+        "the key must be ABSENT, not null: {}",
+        patches[0]
+    );
+    assert!(
+        outcome.repo_note.is_none(),
+        "no --repo was passed, so nothing to warn about: {:?}",
+        outcome.repo_note
     );
 }
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -165,12 +165,16 @@ promote:
 
 1. **The agent's repo is set.** The webhook resolves which agent a push
    belongs to by matching the payload's `repo.full_name` (owner/name)
-   against that agent's `repo_full_name`. This field is set when the agent
-   is created (console or Curie API); `curie cluster deploy` only pushes a
-   bundle to an agent that already exists and does not set this field. The
-   match is case sensitive, so the stored `repo_full_name` must match
-   GitHub's canonical owner and repository casing exactly, or the lookup
-   finds no agent, the push is silently ignored, and (unlike a rejection)
+   against that agent's `repo_full_name`. This field is set when the
+   agent is created (`curie <tier> deploy --repo owner/name`, or the
+   Curie API), and a later `curie <tier> deploy --repo owner/name` binds
+   an agent that has none yet. If the agent is already bound to a
+   different repository, the deploy declines to rebind it and prints a
+   warning naming the repository it kept, so `--repo` never silently
+   reroutes which repository's pushes deploy an agent. The match is
+   case sensitive, so the stored `repo_full_name` must match GitHub's
+   canonical owner and repository casing exactly, or the lookup finds
+   no agent, the push is silently ignored, and (unlike a rejection)
    nothing is logged, so the only symptom is a green delivery in GitHub
    with nothing deployed.
 2. **GitHub can reach the Curie API.** Add a webhook, in the repo's GitHub


### PR DESCRIPTION
Closes #1212

#1194 made `repo_full_name` PATCHable and migration 0018 dropped its unique index, but the CLI was never updated. Its `--repo` help, a runtime warning, and several comments still told operators the binding was set at creation only and that the only remedy was recreating the agent, which per #1064 is often impossible while a deployment is active. A one line PATCH now works.

## What changed

- The deploy PATCH carries `repo_full_name` when the agent has no binding. The early return in `resolve_agent` is gone, so one request carries a channel move and a repo bind together and neither can be dropped.
- An agent already bound to a **different** repository is not rebound. A deploy must not silently reroute which repository's pushes deploy it, so it warns and names the binding it kept.
- A bind whose PATCH response does not carry it now warns. `AgentUpdate` has no `extra="forbid"`, so a platform predating #1194 accepts the unknown key, returns 200, and stores nothing; without this the CLI reports a binding that was never made, which is the silent no-op #1064 exists to prevent.
- A successful bind prints a confirmation instead of nothing.
- The three `--repo` help copies, `docs/operations.md`, and the stale comments are corrected. Repo wide grep for the old claims returns only deliberate negative assertions in tests.

## Tests

`test_repo_full_name_is_patchable` only introspected `AgentUpdate.model_fields` and never issued a request, so replacing the handler body with `pass` left the whole suite green. It is replaced by `test_patched_repo_binding_routes_a_push`, which creates an unbound agent, PATCHes the binding, re-reads it through a separate GET, then drives a real HMAC signed push against a real bare repo and asserts the deployment landed on **that** agent. A second test covers that an omitted `repo_full_name` leaves an existing binding intact.

Every guard was proved by executing a mutation and watching a named test go red, then reverting:

| Mutation | Test that went red |
| --- | --- |
| `agents.py` repo block to `pass` | `test_patched_repo_binding_routes_a_push` (51 sibling tests stayed green) |
| `agents.py` guard to `if True:` | `test_patch_omitting_repo_full_name_leaves_the_binding_intact` |
| drop the repo key from the PATCH body | both `deploy_binds_*` tests |
| drop the repo bind when the channel also moves | `deploy_binds_the_repo_while_also_moving_the_channel` |
| bind unconditionally | `deploy_does_not_rebind_an_agent_bound_elsewhere` |
| emit `null` rather than omitting the key | `deploy_without_repo_never_sends_the_field` |
| remove the response check | `deploy_warns_when_the_platform_drops_the_repo_binding` |

The no-PATCH assertions were unfalsifiable before this branch: the mock records a request only after its handler returns, so a handler that panicked on a PATCH meant the PATCH was never recorded and `all(|r| r.method != "PATCH")` ran over a list that could not contain it. Those arms now answer instead of panicking, so the assertion is the real signal.

Verified live against a running API: an agent created with `repo_full_name: null` came back `octo/final-probe` on a separate GET after `deploy --repo`, with no "was NOT applied" output; redeploying with a different `--repo` printed the decline warning and the binding held.

## Out of scope, deliberately

- **Shared repository warning, withdrawn.** An earlier revision warned when binding to a repository that already had agents. It covered only the already-exists path, while creating a new agent with the same `--repo` binds a second agent with no warning at all, and it restated a git-flow resolver rule inside the client. A guard that fires on one path and stays silent on its sibling teaches operators that silence means safe. The hazard is pre-existing and both paths are tracked in #1221.
- **`--json` output.** `repo_note` and the binding are stderr only. `deploy`'s unstructured success output under `--json` is a known exception tracked in #485, so widening it here was declined.
- **UI.** `apps/ui/` contains no occurrence of `repo_full_name` and is untouched, as the issue specifies.
- **`docs/adr/0008-multi-tenancy.md:15`** still calls `repo_full_name` globally unique, which 0018 made false. ADRs are immutable once Accepted, so it is reported rather than edited.

## Known gap

The success confirmation line is rendered at the deploy print site, which has no automated coverage in `cli/tests/` for any of its output, including the pre-existing channel rendering. The data behind it is unit tested and the line itself was confirmed in the live run, but deleting the render block fails no test. Adding a print capture harness would be new test infrastructure beyond this change.

## Gates

`cargo test`, `cargo clippy --all-targets -D warnings`, `cargo fmt --check`, `ruff check`, `mypy`, `lint-imports`, and `scripts/check-docs.sh` all pass. `pytest apps/api/tests` is 517 passed / 9 skipped, with one failure in `test_control_integration.py::test_cost_composes_metrics_for_the_agent` that needs a metrics service not running locally; that test is not in this diff and `apps/api/src/` is byte identical to `main`.

No request DTO parity gate exists to have caught this drift. `cli/tests/api_field_parity.rs` walks `Deserialize` response structs, and CLI request bodies are `serde_json::Value` built by `json!`, so they are invisible to it by construction.