### PR TITLE
Use an example App ID in the tests, not the real one

### DIFF
--- a/charts/curie/ci/github-app-credential-assertions.sh
+++ b/charts/curie/ci/github-app-credential-assertions.sh
@@ -6,7 +6,7 @@
 #
 #   (a) The App ID must reach the API as the DIGITS. helm's `--set` parses a
 #       bare number and a --reuse-values round trip turns it into a float64, so
-#       app id 4475970 renders as "4.47597e+06", the JWT's `iss` claim is wrong,
+#       app id 1234567 renders as "1.234567e+06", the JWT's `iss` claim is wrong,
 #       and every GitHub call answers 401. The chart must quote whatever it is
 #       given rather than emit a bare number, and the CLI must use --set-string.
 #   (b) A BYO `githubAppExistingSecret` must make the chart REFERENCE a Secret
@@ -32,16 +32,16 @@ PY
 }
 
 # (a) The App ID is emitted as a quoted string, never a bare number.
-OUT="$(render --set-string api.githubAppId=4475970 --set api.githubAppPrivateKey=X)"
+OUT="$(render --set-string api.githubAppId=1234567 --set api.githubAppPrivateKey=X)"
 grep -q 'name: GITHUB_APP_ID' <<<"$OUT" || fail a "GITHUB_APP_ID is missing"
 python3 - "$OUT" <<'PY' || exit 1
 import sys, yaml
 doc = [d for d in yaml.safe_load_all(sys.argv[1]) if d and d.get("kind") == "Deployment"][0]
 env = {e["name"]: e for e in doc["spec"]["template"]["spec"]["containers"][0]["env"]}
 value = env["GITHUB_APP_ID"].get("value")
-if value != "4475970":
-    print(f"FAIL [a] GITHUB_APP_ID rendered as {value!r}, expected '4475970'. "
-          "A float here becomes '4.47597e+06' and every GitHub call 401s.",
+if value != "1234567":
+    print(f"FAIL [a] GITHUB_APP_ID rendered as {value!r}, expected '1234567'. "
+          "A float here becomes '1.234567e+06' and every GitHub call 401s.",
           file=sys.stderr)
     sys.exit(1)
 PY

--- a/cli/src/github_app.rs
+++ b/cli/src/github_app.rs
@@ -44,8 +44,8 @@ pub fn connect_commands(opts: &GithubAppOpts, clone_base: &str) -> Vec<OpsComman
             plain("--reuse-values"),
             // --set-string, NOT --set. A numeric App ID round-trips through
             // helm's stored values as a float64, and `| quote` then renders it
-            // in scientific notation: app id 4475970 reaches the API as
-            // "4.47597e+06", the JWT's `iss` claim is wrong, and GitHub answers
+            // in scientific notation: app id 1234567 reaches the API as
+            // "1.234567e+06", the JWT's `iss` claim is wrong, and GitHub answers
             // 401 on every call. Found on a live cluster; a chart-render test
             // cannot see it, because it only appears once a real numeric value
             // has been through a --reuse-values round trip.
@@ -239,8 +239,8 @@ mod tests {
     #[test]
     fn the_app_id_is_set_as_a_string() {
         // helm's `--set` parses a bare number, and a --reuse-values round trip
-        // turns it into a float64. App id 4475970 then renders as
-        // "4.47597e+06", the JWT's `iss` claim is wrong, and EVERY GitHub call
+        // turns it into a float64. App id 1234567 then renders as
+        // "1.234567e+06", the JWT's `iss` claim is wrong, and EVERY GitHub call
         // answers 401. Found on a live cluster -- a chart-render test cannot
         // see it, because it only appears once a real numeric value has been
         // through helm's stored values.


### PR DESCRIPTION
I documented the float-coercion bug in #1236 using the **actual App ID** from the acme-bot installation.

It isn't a secret — an App ID is public and travels in every JWT — but [AGENTS.md](AGENTS.md) is explicit that the hazard in a public repo is real-deployment *identifiers*, not only credentials:

> The subtler one is **identifiers from real deployments** — a Slack conversation id, an AWS account number, an EC2 …

A real App ID ties this public repository to one specific private installation. That's the thing the rule exists to prevent.

`1234567` exercises the bug identically. Re-falsified after the swap:

```
all five assertions passed

# with the quote removed from the template:
FAIL [a] GITHUB_APP_ID rendered as 1234567, expected '1234567'.
         A float here becomes '1.234567e+06' and every GitHub call 401s.
```

Rust side unchanged in behaviour — 8 tests pass.

Found while answering a question about where the private key is stored, which prompted me to grep both repos for real values.