### PR TITLE
Say plainly that Curie's secrets are only as safe as the cluster

### DIFF
--- a/charts/curie/README.md
+++ b/charts/curie/README.md
@@ -575,3 +575,61 @@ to install only the control plane + backing stores without the runner substrate.
   rather than a pre-warmed one; the fast path (no env) binds warm.
 - Traces flow to `<release>-otel-collector:4318` (HTTP), per the collector
   rule above; the env block is omitted when `otelCollector.deploy: false`.
+
+## Secrets at rest
+
+Curie holds real credentials in Kubernetes Secrets: the model credential, the
+Slack tokens, the GitHub App private key, and every agent's connector secrets.
+
+**Kubernetes Secrets are base64-encoded, not encrypted**, unless the cluster
+encrypts them at rest. That is a property of the cluster, not of this chart, and
+it is not detectable from inside one — a pod can read neither etcd nor the
+apiserver's `EncryptionConfiguration`. There is therefore no preflight for it,
+deliberately: a check that cannot fail correctly is worse than none, because it
+reports a pass it did not earn. The install notice says so instead.
+
+Verify it for your distribution:
+
+| | |
+|---|---|
+| k3s | `k3s secrets-encrypt status` — enable with `k3s secrets-encrypt enable` |
+| kubeadm | `--encryption-provider-config` on kube-apiserver |
+| EKS | `aws eks describe-cluster --name <c> --query cluster.encryptionConfig` |
+| GKE | on by default |
+
+### The GitHub App private key
+
+This is the most sensitive value the chart handles: it can mint read tokens for
+every repository the App is installed on. Two ways to supply it.
+
+**Recommended — a Secret you manage.** The chart only references it, so the key
+never passes through helm values and never lands in release history (helm
+retains 10 revisions by default, and `helm get values` can print them):
+
+```yaml
+api:
+  githubAppId: "1234567"
+  githubAppExistingSecret: my-github-app
+  githubAppExistingSecretKey: privateKey    # the default
+```
+
+Create that Secret however you like — `kubectl create secret generic`, External
+Secrets Operator against AWS Secrets Manager or Vault, or Sealed Secrets. This
+is the same bring-your-own idiom every backing store in this chart uses.
+
+**Quick trial — let the chart hold it.** `curie cluster github-app --app-id …
+--private-key …` puts the PEM in the chart's own Secret. Fine to prove the flow
+works; move to `githubAppExistingSecret` before you rely on it.
+
+### Rotating the key
+
+A GitHub App can hold several private keys at once, so rotation has no downtime
+and needs no coordination with any repository:
+
+1. Generate a second private key on the App's settings page — both are now valid
+2. Deploy the new one (update your Secret, or re-run `curie cluster github-app`)
+3. Delete the first key on GitHub
+
+Installations, permissions, and the App ID are untouched. This is a real
+advantage over a personal access token, where rotation means re-issuing the
+credential *and* re-authorizing what it could reach.

--- a/charts/curie/templates/NOTES.txt
+++ b/charts/curie/templates/NOTES.txt
@@ -157,3 +157,33 @@ The nodePort is pinned in values (langfuse.web.service.nodePort) so it survives 
 App services send OTLP traces to the collector, NOT directly to Langfuse:
   {{ include "curie.fullname" . }}-otel-collector:{{ .Values.otelCollector.service.grpcPort }} (gRPC) / :{{ .Values.otelCollector.service.httpPort }} (HTTP)
 {{- end }}
+
+{{/*
+Curie holds real credentials in Kubernetes Secrets -- the model credential, the
+Slack tokens, the GitHub App key, and every agent's connector secrets. Whether
+those are encrypted at rest is a property of the CLUSTER, not of this chart,
+and it is invisible from inside: a pod cannot read etcd or the apiserver's
+EncryptionConfiguration, so there is no honest preflight for it. An install-time
+notice is the most this chart can truthfully do.
+*/}}
+─────────────────────────────────────────────────────────────────────────────
+SECRETS AT REST
+
+This release stores credentials in Kubernetes Secrets. Kubernetes Secrets are
+base64-encoded, NOT encrypted, unless your cluster encrypts them at rest.
+Curie cannot detect this from inside the cluster -- please verify it yourself:
+
+  k3s      k3s secrets-encrypt status          (enable: k3s secrets-encrypt enable)
+  kubeadm  --encryption-provider-config on kube-apiserver
+  EKS      aws eks describe-cluster --name <c> --query cluster.encryptionConfig
+  GKE      on by default (application-layer secrets encryption for db etcd)
+
+For the most sensitive value -- the GitHub App private key, which can mint read
+tokens for every repository the App is installed on -- prefer a Secret you
+manage yourself, so it never passes through helm values or release history:
+
+  api.githubAppExistingSecret: my-github-app
+
+  Create it with kubectl, External Secrets, or Sealed Secrets. See
+  charts/curie/README.md#secrets-at-rest.
+─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Curie stores the model credential, Slack tokens, the GitHub App private key, and every agent's connector secrets in Kubernetes Secrets. Those are **base64, not encrypted**, unless the cluster encrypts them at rest — and nothing in the chart, README, or install output said so.

## Why there's no preflight

`charts/curie/CLAUDE.md` is explicit:

> do not add a new cluster-dependent assumption … without a matching preflight

This is such an assumption, and it deliberately does **not** get a preflight. A pod can read neither etcd nor the apiserver's `EncryptionConfiguration`, so any in-cluster check would report a pass it did not earn. For a security property that is worse than no check at all — it converts "unknown" into "verified", which is the failure mode the NetworkPolicy probe exists to prevent elsewhere in this chart.

So the chart does what it honestly can: says so at install time, and gives the per-distribution command to check.

```
─────────────────────────────────────────────────────────────────────────────
SECRETS AT REST

This release stores credentials in Kubernetes Secrets. Kubernetes Secrets are
base64-encoded, NOT encrypted, unless your cluster encrypts them at rest.
Curie cannot detect this from inside the cluster -- please verify it yourself:

  k3s      k3s secrets-encrypt status          (enable: k3s secrets-encrypt enable)
  kubeadm  --encryption-provider-config on kube-apiserver
  EKS      aws eks describe-cluster --name <c> --query cluster.encryptionConfig
  GKE      on by default
─────────────────────────────────────────────────────────────────────────────
```

## Also documented

**Which way to supply the App key, and why.** An inline `githubAppPrivateKey` is copied into every retained helm revision (10 by default) and `helm get values` can print it. `githubAppExistingSecret` — the same BYO idiom every backing store here uses — keeps it out entirely and works with External Secrets or Sealed Secrets.

**Rotation.** A GitHub App holds several private keys at once, so rotation is zero-downtime and touches no repository: generate the second, deploy it, delete the first. That's a concrete operational advantage over a PAT that wasn't written down anywhere.

Follows the App work in ADR-0092.