### PR TITLE
Give the k3s encryption steps in an order that works

### DIFF
--- a/charts/curie/README.md
+++ b/charts/curie/README.md
@@ -592,10 +592,38 @@ Verify it for your distribution:
 
 | | |
 |---|---|
-| k3s | `k3s secrets-encrypt status` — enable with `k3s secrets-encrypt enable` |
+| k3s | `k3s secrets-encrypt status` — see the note below before enabling |
 | kubeadm | `--encryption-provider-config` on kube-apiserver |
 | EKS | `aws eks describe-cluster --name <c> --query cluster.encryptionConfig` |
 | GKE | on by default |
+
+#### Enabling it on k3s
+
+The order matters, and getting it wrong leaves a half-configured cluster.
+
+The server must be started with the flag **before** `enable` is run:
+
+```yaml
+# /etc/rancher/k3s/config.yaml
+secrets-encryption: true
+```
+
+Then `systemctl restart k3s`, then `k3s secrets-encrypt enable`, then restart
+again, then `k3s secrets-encrypt reencrypt` to rewrite existing Secrets.
+
+Running `enable` first, on a server started without the flag, half-succeeds:
+it writes a config the server never loads, and reports
+`missing annotation on node` followed by
+`Encryption Status: Disabled, no configuration file found`.
+
+On k3s v1.36.2 `enable` fails outright with
+`Put ".../v1-k3s/encrypt/config": EOF` even when the prerequisite is met
+(issue #1243). Hand-writing an `aescbc` EncryptionConfiguration does work —
+the apiserver runs with `--encryption-provider-config-automatic-reload=true`,
+so no restart is needed — but understand the hazard first: **if that file is
+ever reverted to identity-only, every Secret written while encryption was
+active becomes permanently undecryptable.** Prefer keeping the most sensitive
+values out of etcd entirely, as below.
 
 ### The GitHub App private key
 

--- a/charts/curie/templates/NOTES.txt
+++ b/charts/curie/templates/NOTES.txt
@@ -173,7 +173,11 @@ This release stores credentials in Kubernetes Secrets. Kubernetes Secrets are
 base64-encoded, NOT encrypted, unless your cluster encrypts them at rest.
 Curie cannot detect this from inside the cluster -- please verify it yourself:
 
-  k3s      k3s secrets-encrypt status          (enable: k3s secrets-encrypt enable)
+  k3s      k3s secrets-encrypt status
+           To ENABLE, the server must first be started with
+           `secrets-encryption: true` in /etc/rancher/k3s/config.yaml --
+           running `secrets-encrypt enable` without it half-succeeds and
+           leaves the cluster in an inconsistent state (see #1243).
   kubeadm  --encryption-provider-config on kube-apiserver
   EKS      aws eks describe-cluster --name <c> --query cluster.encryptionConfig
   GKE      on by default (application-layer secrets encryption for db etcd)


### PR DESCRIPTION
The notice added in #1242 tells operators to run `k3s secrets-encrypt enable`. Run exactly as written on a real k3s v1.36.2 node, it leaves the cluster half-configured:

```
level=info  msg="Enabling secrets encryption with identity provider, restart with secrets-encryption"
level=error msg="secret-encrypt error ID 05738: missing annotation on node"
...after restart...
Encryption Status: Disabled, no configuration file found
```

Advice that produces a half-configured cluster is worse than no advice. The server has to be started with `secrets-encryption: true` **first** — that was missing.

## What this adds

**The right order**, with the failure mode named so an operator who already hit it can recognise the state they're in.

**The v1.36.2 caveat** (#1243): even with the prerequisite met, `enable` fails with `Put ".../v1-k3s/encrypt/config": EOF`.

**The hazard attached to the workaround.** Hand-writing an `aescbc` config does work — the apiserver already runs with `--encryption-provider-config-automatic-reload=true`, so no restart is needed. But if that file is ever reverted to identity-only, **every Secret written while encryption was active becomes permanently undecryptable.** That belongs beside the workaround, not discovered afterwards.

Found by doing it on the acme-bot cluster rather than by reading k3s docs.

Closes #1243