### PR TITLE
Let the API be served over TLS

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -123,6 +123,15 @@ jobs:
           set -euo pipefail
           bash charts/curie/ci/connector-secrets-assertions.sh
 
+      # Prove the API ingress (issue #1238): opt-in, fails loudly without a
+      # host rather than matching every request, and honours tls.enabled and
+      # api.service.port. The API is the one endpoint reached from outside the
+      # cluster, and X-API-Key crosses it on every authenticated call.
+      - name: helm render assertions (api ingress)
+        run: |
+          set -euo pipefail
+          bash charts/curie/ci/api-ingress-assertions.sh
+
       # Prove the GitHub App credential (ADR-0092): the App ID reaches the API
       # as digits (a float renders as "4.47597e+06" and 401s every call), and a
       # BYO existingSecret is REFERENCED rather than copied into helm's stored

--- a/charts/curie/README.md
+++ b/charts/curie/README.md
@@ -576,6 +576,40 @@ to install only the control plane + backing stores without the runner substrate.
 - Traces flow to `<release>-otel-collector:4318` (HTTP), per the collector
   rule above; the env block is omitted when `otelCollector.deploy: false`.
 
+## Serving the API over TLS
+
+The API is the only endpoint reached from outside the cluster. Two things cross
+it in the clear without TLS: the `X-API-Key` header, on every authenticated
+call, and the GitHub webhook delivery, whose HMAC protects integrity but not
+confidentiality.
+
+Off by default, because it cannot be defaulted honestly — an ingress needs a
+controller, a hostname, and a certificate source, none of which the chart can
+invent. A default-on Ingress with no controller renders an object that silently
+does nothing.
+
+```yaml
+api:
+  ingress:
+    enabled: true
+    host: curie.example.com
+    className: nginx
+    annotations:
+      cert-manager.io/cluster-issuer: letsencrypt-prod
+      # Match the webhook body cap; a smaller proxy limit rejects a large push
+      # before the API can apply its own bound.
+      nginx.ingress.kubernetes.io/proxy-body-size: 25m
+    tls:
+      enabled: true
+      secretName: curie-api-tls     # empty = the controller's default cert
+```
+
+Then point the GitHub webhook at `https://curie.example.com/github/webhook`.
+
+Set `tls.enabled: false` only when something upstream already terminates TLS —
+it renders the routing rules without a `tls` block, rather than silently
+keeping one.
+
 ## Secrets at rest
 
 Curie holds real credentials in Kubernetes Secrets: the model credential, the

--- a/charts/curie/ci/api-ingress-assertions.sh
+++ b/charts/curie/ci/api-ingress-assertions.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+#
+# Render-assertion test for the API ingress (issue #1238).
+#
+# The API is the one endpoint reached from outside the cluster: every
+# authenticated call carries `X-API-Key` as a plain header, and GitHub posts
+# webhooks to it. Without TLS both cross the network in the clear.
+#
+# The failure this guards against is not "TLS is missing" -- it is an Ingress
+# that LOOKS configured and protects nothing. Six assertions:
+#
+#   (a) Off by default. An ingress needs a controller, a hostname and a cert
+#       source; none can be invented, so a default-on ingress would render an
+#       object that silently does nothing.
+#   (b) Enabling without a host FAILS the render, rather than producing a
+#       host-less rule that matches every request reaching the controller.
+#   (c) Enabled with a host renders a TLS block for that host.
+#   (d) tls.enabled=false renders the rules WITHOUT a tls block -- for a
+#       controller terminating TLS upstream. It must not silently keep tls.
+#   (e) An empty secretName omits the field entirely. `secretName: ""` makes a
+#       controller hunt for a Secret literally named "", which fails in a way
+#       that looks like a missing certificate rather than a config error.
+#   (f) The backend points at the api Service and its configured port, not a
+#       hardcoded 8000 that drifts when api.service.port changes.
+set -euo pipefail
+
+CHART="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fail() { echo "FAIL [$1] $2" >&2; exit 1; }
+render() { helm template curie "$CHART" "$@" 2>&1; }
+
+# (a) The default render must SUCCEED and contain no Ingress. Both halves
+#     matter: counting Ingress objects in output that failed to render at all
+#     reports zero and passes for the wrong reason -- which is exactly what
+#     this assertion did before a falsification probe caught it.
+if ! DEFAULT_OUT="$(helm template curie "$CHART" 2>&1)"; then
+  fail a "the DEFAULT render failed; enabling the ingress must not be required
+  $(head -3 <<<"$DEFAULT_OUT")"
+fi
+[ "$(grep -c '^kind: Ingress' <<<"$DEFAULT_OUT" || true)" -eq 0 ] \
+  || fail a "an Ingress renders by default; it must be opt-in"
+
+# (b)
+if render --set api.ingress.enabled=true -s templates/api-ingress.yaml >/dev/null 2>&1; then
+  fail b "enabling the ingress without a host succeeded; it must fail the render"
+fi
+# Captured rather than piped: helm exits non-zero here by design, and under
+# `set -o pipefail` that would fail the pipeline even when grep matches.
+MISSING_HOST="$(render --set api.ingress.enabled=true -s templates/api-ingress.yaml || true)"
+grep -q "api.ingress.host is required" <<<"$MISSING_HOST" \
+  || fail b "the missing-host failure does not name the value to set"
+
+BASE=(--set api.ingress.enabled=true --set api.ingress.host=curie.example.com)
+
+# (c)
+OUT="$(render "${BASE[@]}" -s templates/api-ingress.yaml)"
+python3 - "$OUT" <<'PY' || exit 1
+import sys, yaml
+d = [x for x in yaml.safe_load_all(sys.argv[1]) if x][0]
+tls = d["spec"].get("tls")
+if not tls or tls[0]["hosts"] != ["curie.example.com"]:
+    print(f"FAIL [c] tls block wrong: {tls}", file=sys.stderr); sys.exit(1)
+PY
+
+# (d)
+OUT="$(render "${BASE[@]}" --set api.ingress.tls.enabled=false -s templates/api-ingress.yaml)"
+python3 - "$OUT" <<'PY' || exit 1
+import sys, yaml
+d = [x for x in yaml.safe_load_all(sys.argv[1]) if x][0]
+if "tls" in d["spec"]:
+    print("FAIL [d] tls.enabled=false still rendered a tls block", file=sys.stderr); sys.exit(1)
+if not d["spec"].get("rules"):
+    print("FAIL [d] rules disappeared with tls disabled", file=sys.stderr); sys.exit(1)
+PY
+
+# (e)
+OUT="$(render "${BASE[@]}" -s templates/api-ingress.yaml)"
+grep -q 'secretName: ""' <<<"$OUT" \
+  && fail e 'an empty secretName rendered as secretName: "" -- omit the field instead'
+OUT="$(render "${BASE[@]}" --set api.ingress.tls.secretName=my-cert -s templates/api-ingress.yaml)"
+grep -q 'secretName: "my-cert"' <<<"$OUT" || fail e "a supplied secretName was not rendered"
+
+# (f)
+OUT="$(render "${BASE[@]}" --set api.service.port=9999 -s templates/api-ingress.yaml)"
+python3 - "$OUT" <<'PY' || exit 1
+import sys, yaml
+d = [x for x in yaml.safe_load_all(sys.argv[1]) if x][0]
+b = d["spec"]["rules"][0]["http"]["paths"][0]["backend"]["service"]
+if b["port"]["number"] != 9999:
+    print(f"FAIL [f] backend port {b['port']['number']} ignores api.service.port", file=sys.stderr)
+    sys.exit(1)
+if not b["name"].endswith("-api"):
+    print(f"FAIL [f] backend service {b['name']} is not the api service", file=sys.stderr)
+    sys.exit(1)
+PY
+
+echo "api-ingress-assertions: all six assertions passed"

--- a/charts/curie/templates/api-ingress.yaml
+++ b/charts/curie/templates/api-ingress.yaml
@@ -1,0 +1,57 @@
+{{- if and .Values.api.deploy .Values.api.ingress.enabled }}
+{{/*
+TLS for the platform API (issue #1238).
+
+Two things reach this endpoint from outside the cluster, and both are exposed
+without it:
+
+  - Every authenticated call carries `X-API-Key` as a plain header. Over a
+    NodePort on a public IP -- how a k3s install is typically reached -- that
+    key crosses the internet in cleartext on every request.
+  - The GitHub webhook. Its HMAC protects integrity, not confidentiality, and a
+    captured delivery can be replayed.
+
+This is opt-in rather than default-on because it cannot be defaulted honestly:
+it needs an ingress controller, a hostname, and a certificate source, none of
+which the chart can invent. A default-on ingress with no controller renders an
+object that silently does nothing, which is the "looks configured, isn't"
+failure the NetworkPolicy probe exists to prevent elsewhere in this chart.
+*/}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "curie.fullname" . }}-api
+  labels:
+    {{- include "curie.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+  {{- with .Values.api.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.api.ingress.className }}
+  ingressClassName: {{ . | quote }}
+  {{- end }}
+  {{- if .Values.api.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        - {{ required "api.ingress.host is required when the ingress is enabled" .Values.api.ingress.host | quote }}
+      {{- /* An empty secretName is meaningful: it tells the controller to use
+             its own default certificate. Rendering `secretName: ""` would make
+             it look for a Secret literally named "", so it is omitted. */}}
+      {{- with .Values.api.ingress.tls.secretName }}
+      secretName: {{ . | quote }}
+      {{- end }}
+  {{- end }}
+  rules:
+    - host: {{ required "api.ingress.host is required when the ingress is enabled" .Values.api.ingress.host | quote }}
+      http:
+        paths:
+          - path: {{ .Values.api.ingress.path }}
+            pathType: {{ .Values.api.ingress.pathType }}
+            backend:
+              service:
+                name: {{ include "curie.fullname" . }}-api
+                port:
+                  number: {{ .Values.api.service.port }}
+{{- end }}

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -507,6 +507,34 @@ api:
   service:
     type: ClusterIP
     port: 8000
+  # TLS for the API (issue #1238). Off by default because it cannot be
+  # defaulted honestly -- it needs an ingress controller, a hostname, and a
+  # certificate source, none of which the chart can invent. Rendering an
+  # Ingress with no controller present would look configured and do nothing.
+  #
+  # Turn this on for anything reachable from outside the cluster. Without it,
+  # the `X-API-Key` header crosses the network in cleartext on every
+  # authenticated call, and the GitHub webhook delivery is readable and
+  # replayable.
+  ingress:
+    enabled: false
+    # Required when enabled; the chart fails the render rather than producing
+    # a host-less Ingress that matches every request reaching the controller.
+    host: ""
+    className: ""
+    path: /
+    pathType: Prefix
+    # Annotations for your controller and certificate issuer, e.g.
+    #   cert-manager.io/cluster-issuer: letsencrypt-prod
+    #   nginx.ingress.kubernetes.io/proxy-body-size: 25m   # matches the
+    #     webhook body cap (github_webhook_max_body_bytes); a smaller proxy
+    #     limit rejects a large push before the API can apply its own.
+    annotations: {}
+    tls:
+      enabled: true
+      # A Secret you supply, or one cert-manager creates from the annotation
+      # above. Empty means "use the controller's default certificate".
+      secretName: ""
   # Run `alembic upgrade head` in an init container before the server starts, so
   # a fresh Postgres gets the `curie` schema + tables. Disable only when an
   # external migration step owns the DB.


### PR DESCRIPTION
The API is the one endpoint reached from outside the cluster, and the chart had no way to put it behind HTTPS. On the acme-bot install it's a NodePort on a public IP over plain HTTP:

- **`X-API-Key` crosses the internet in cleartext** on every authenticated call
- the **GitHub webhook** delivery is readable and replayable (its HMAC protects integrity, not confidentiality)

## Opt-in, deliberately

An ingress needs a controller, a hostname, and a certificate source — none of which the chart can invent. A default-on Ingress with no controller renders an object that *looks* configured and protects nothing. That's the same looks-configured-isn't failure the NetworkPolicy probe exists to catch elsewhere in this chart, so it stays off until an operator supplies the pieces.

Enabling it without a host **fails the render**, rather than producing a host-less rule that matches every request reaching the controller.

```yaml
api:
  ingress:
    enabled: true
    host: curie.example.com
    className: nginx
    annotations:
      cert-manager.io/cluster-issuer: letsencrypt-prod
      nginx.ingress.kubernetes.io/proxy-body-size: 25m   # match the webhook cap
    tls:
      enabled: true
      secretName: curie-api-tls    # empty = controller's default cert
```

## One assertion was wrong, and falsification caught it

Assertion (a) — "no Ingress by default" — originally counted `kind: Ingress` in the default render. When I probed it by making the ingress default-on, **it passed**. The render was erroring on the missing host, so grep counted zero and the test reported success.

It now requires the default render to *succeed* **and** contain no Ingress:

```
default-on -> FAIL [a] the DEFAULT render failed; enabling the ingress must not be required
                Error: api.ingress.host is required when the ingress is enabled
restored   -> all six assertions passed
```

Other probes, each confirmed to fail before restoring:

```
tls always on   -> FAIL [d] tls.enabled=false still rendered a tls block
hardcoded port  -> FAIL [f] backend port 8000 ignores api.service.port
```

Refs #1238