### PR TITLE
Deploy from a poll, for clusters that cannot receive a webhook

### DIFF
--- a/apps/api/src/curie_api/commitpoller.py
+++ b/apps/api/src/curie_api/commitpoller.py
@@ -1,0 +1,266 @@
+"""Notice new commits without being told (issue #1239).
+
+Curie is self-hosted: adopters run it in their own cluster, and many of those
+clusters accept no inbound traffic. A GitHub webhook cannot reach such a
+cluster, so today those installs have no push-to-deploy at all -- not a
+degraded one, none.
+
+Outbound always works. So this asks GitHub, on an interval, whether the
+branches an agent's ``deploy.yaml`` targets have moved, and runs the ordinary
+deploy when they have.
+
+**It does not reimplement deploying.** It synthesizes the same push payload the
+webhook would have delivered and hands it to ``gitflow.process_push``. Two
+deploy paths that could disagree about what a push means would be worse than
+one path that sometimes runs late -- and the webhook remains the fast path
+wherever it can reach.
+
+Three properties worth stating, because each is a way this could go wrong:
+
+- **It polls per REPOSITORY, not per agent.** Several agents share one
+  repository (ADR-0091), so per-agent polling would make N identical API calls
+  and race N deploys of the same commit against each other.
+- **It never deploys a commit it has already deployed.** The check is the
+  ``commit_sha`` already recorded for that repository, so a restart does not
+  redeploy the current HEAD, and a webhook that already handled a push makes
+  the next poll a no-op.
+- **One failing repository does not stop the others.** A repo whose credential
+  has been revoked, or that has been deleted, must not silently halt polling
+  for every other agent on the cluster.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+import httpx
+
+from .config import Settings
+
+logger = logging.getLogger(__name__)
+
+
+class BranchTip(Protocol):
+    """Reads the current sha of a branch. Narrow so tests need no HTTP."""
+
+    def sha_for(self, repo_full_name: str, branch: str) -> str | None: ...
+
+
+@dataclass(frozen=True)
+class PollTarget:
+    """One repository and the branches worth watching on it."""
+
+    repo_full_name: str
+    clone_url: str
+    branches: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class Move:
+    """A branch that has moved to a commit we have not deployed."""
+
+    repo_full_name: str
+    clone_url: str
+    branch: str
+    sha: str
+
+    def as_push_payload(self) -> dict[str, Any]:
+        """The webhook payload this would have arrived as.
+
+        Deliberately the same shape `process_push` already parses, so polling
+        and the webhook cannot diverge on what a push means. The clone_url is
+        the one derived from configuration, which is also what the origin check
+        compares against -- so a polled deploy passes that check by
+        construction rather than by coincidence.
+        """
+
+        return {
+            "ref": f"refs/heads/{self.branch}",
+            "after": self.sha,
+            "repository": {"full_name": self.repo_full_name, "clone_url": self.clone_url},
+        }
+
+
+def moves_to_deploy(
+    targets: Sequence[PollTarget],
+    tips: BranchTip,
+    already_deployed: dict[tuple[str, str], str],
+) -> list[Move]:
+    """Which branches have moved since we last deployed them.
+
+    Pure: no HTTP, no database. ``already_deployed`` maps
+    ``(repo_full_name, branch)`` to the sha last deployed from it.
+    """
+
+    moves: list[Move] = []
+    for target in targets:
+        for branch in target.branches:
+            try:
+                sha = tips.sha_for(target.repo_full_name, branch)
+            except Exception as exc:
+                # One unreachable or unauthorized repository must not stop the
+                # rest. Logged per repo/branch so the cause is attributable.
+                logger.warning(
+                    "commit poll failed repo=%s branch=%s: %s",
+                    target.repo_full_name,
+                    branch,
+                    exc,
+                )
+                continue
+            if not sha:
+                continue
+            if already_deployed.get((target.repo_full_name, branch)) == sha:
+                continue
+            moves.append(
+                Move(
+                    repo_full_name=target.repo_full_name,
+                    clone_url=target.clone_url,
+                    branch=branch,
+                    sha=sha,
+                )
+            )
+    return moves
+
+
+class GitHubBranchTip:
+    """Reads a branch tip from the GitHub API, using the platform credential."""
+
+    def __init__(self, settings: Settings, credentials: Any, timeout: float = 15.0) -> None:
+        self._settings = settings
+        self._credentials = credentials
+        self._timeout = timeout
+
+    def sha_for(self, repo_full_name: str, branch: str) -> str | None:
+        token = self._credentials.token_for(repo_full_name)
+        headers = {
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+        url = f"{self._settings.github_api_url.rstrip('/')}/repos/{repo_full_name}/commits/{branch}"
+        with httpx.Client(timeout=self._timeout) as client:
+            response = client.get(url, headers=headers)
+        if response.status_code == 404:
+            # A branch a deploy.yaml names but the repository does not have is
+            # normal -- a repo may deploy only prod from main. Not an error.
+            return None
+        response.raise_for_status()
+        sha = response.json().get("sha")
+        return str(sha) if isinstance(sha, str) else None
+
+
+# The last commit deployed per (repository, environment). Environment rather
+# than branch because that is what a Deployment records; the caller maps
+# environments back to branch names via Settings, the same mapping
+# `environment_for_ref` uses in the other direction.
+_DEPLOYED_SQL = """
+SELECT DISTINCT ON (a.repo_full_name, d.environment)
+       a.repo_full_name AS repo_full_name,
+       d.environment    AS environment,
+       d.commit_sha     AS commit_sha
+FROM {schema}.deployments d
+JOIN {schema}.agents a ON a.id = d.agent_id
+WHERE a.repo_full_name IS NOT NULL AND d.commit_sha IS NOT NULL
+ORDER BY a.repo_full_name, d.environment, d.deployed_at DESC
+"""
+
+# Every repository that has at least one agent bound to it. DISTINCT because
+# several agents legitimately share one repository (ADR-0091), and polling it
+# once per agent would race N deploys of the same commit.
+_REPOS_SQL = """
+SELECT DISTINCT repo_full_name
+FROM {schema}.agents
+WHERE repo_full_name IS NOT NULL AND repo_full_name <> ''
+"""
+
+
+class CommitPoller:
+    """Asks GitHub whether the deploy branches moved, and deploys when they did.
+
+    Runs in the API rather than the worker because the deploy path, the bundle
+    store and the credential resolver all already live here. Its only job is to
+    notice; ``gitflow.process_push`` does the deploying.
+    """
+
+    def __init__(
+        self,
+        *,
+        session_factory: Any,
+        store: Any,
+        settings: Settings,
+        eval_queue: Any,
+        tips: BranchTip,
+        interval_seconds: float,
+    ) -> None:
+        self._session_factory = session_factory
+        self._store = store
+        self._settings = settings
+        self._eval_queue = eval_queue
+        self._tips = tips
+        self._interval = interval_seconds
+
+    async def run_forever(self) -> None:
+        logger.info("commit poller started interval=%ss", self._interval)
+        while True:
+            try:
+                await self.poll_once()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                # A poll pass must never kill the loop: the next one may well
+                # succeed, and a dead poller on an unreachable cluster means no
+                # deploys at all with nothing saying so.
+                logger.exception("commit poll pass failed; continuing")
+            await asyncio.sleep(self._interval)
+
+    async def poll_once(self) -> list[Move]:
+        from sqlalchemy import text
+
+        from . import gitflow
+
+        schema = self._settings.db_schema
+        branch_for_env = {
+            "dev": self._settings.dev_branch,
+            "prod": self._settings.prod_branch,
+        }
+
+        async with self._session_factory() as session:
+            repos = [
+                str(r) for (r,) in (await session.execute(text(_REPOS_SQL.format(schema=schema))))
+            ]
+            deployed: dict[tuple[str, str], str] = {}
+            for repo, env, sha in await session.execute(text(_DEPLOYED_SQL.format(schema=schema))):
+                branch = branch_for_env.get(str(env))
+                if branch:
+                    deployed[(str(repo), branch)] = str(sha)
+
+        targets = [
+            PollTarget(
+                repo_full_name=repo,
+                clone_url=gitflow.trusted_clone_url(repo, self._settings),
+                branches=tuple(branch_for_env.values()),
+            )
+            for repo in repos
+        ]
+        # to_thread because the tip reader is sync httpx: a blocking call in
+        # the event loop would stall every request the API is serving.
+        moves: list[Move] = await asyncio.to_thread(moves_to_deploy, targets, self._tips, deployed)
+
+        for move in moves:
+            async with self._session_factory() as session:
+                result = await gitflow.process_push(
+                    session, self._store, self._settings, self._eval_queue, move.as_push_payload()
+                )
+            logger.info(
+                "commit poll deployed repo=%s branch=%s sha=%s status=%s",
+                move.repo_full_name,
+                move.branch,
+                move.sha[:8],
+                result.status,
+            )
+        return moves

--- a/apps/api/src/curie_api/config.py
+++ b/apps/api/src/curie_api/config.py
@@ -110,6 +110,15 @@ class Settings(BaseSettings):
     # never place it in argv.
     github_app_private_key: str = ""
     github_app_timeout_seconds: float = 15.0
+    # Commit polling (issue #1239). A self-hosted cluster that accepts no
+    # inbound traffic cannot receive a GitHub webhook, so without this it has
+    # no push-to-deploy at all. Outbound always works, so the API asks GitHub
+    # whether the deploy branches moved.
+    #
+    # 0 disables it. The webhook stays the fast path wherever it can reach;
+    # this is the floor, not a replacement, and a poll after a webhook already
+    # handled the push is a no-op.
+    commit_poll_interval_s: float = 0.0
     # The one git origin this installation deploys from. The webhook payload's
     # `clone_url` is compared against `<base>/<repo_full_name>.git` and a
     # mismatch is rejected before any subprocess starts; git is then handed the

--- a/apps/api/src/curie_api/main.py
+++ b/apps/api/src/curie_api/main.py
@@ -12,9 +12,11 @@ import httpx
 import redis.asyncio as redis
 from fastapi import FastAPI
 
+from .commitpoller import CommitPoller, GitHubBranchTip
 from .config import get_settings
 from .db import create_engine, create_sessionmaker
 from .evalqueue import EvalQueue
+from .github_app import credentials_for
 from .github_checks import GitHubStatusReporter
 from .graveyardwatcher import GraveyardWatcher
 from .k8s import build_lazy_pod_lister, build_lazy_pod_log_reader
@@ -146,6 +148,25 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         app.state.graveyard_watcher_task = asyncio.create_task(watcher.run_forever())
     else:
         app.state.graveyard_watcher_task = None
+    # Commit polling (#1239): the deploy path for a cluster that cannot receive
+    # a GitHub webhook. Interval <= 0 disables it, which is the default -- an
+    # install whose webhook works needs nothing here, and polling would only
+    # add GitHub API calls. It reuses the credential resolver and the ordinary
+    # process_push, so it cannot disagree with the webhook about what a push
+    # means.
+    if settings.commit_poll_interval_s > 0:
+        poller = CommitPoller(
+            session_factory=app.state.sessionmaker,
+            store=app.state.store,
+            settings=settings,
+            eval_queue=app.state.eval_queue,
+            tips=GitHubBranchTip(settings, credentials_for(settings)),
+            interval_seconds=settings.commit_poll_interval_s,
+        )
+        app.state.commit_poller = poller
+        app.state.commit_poller_task = asyncio.create_task(poller.run_forever())
+    else:
+        app.state.commit_poller_task = None
     try:
         yield
     finally:
@@ -175,6 +196,16 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
             watcher_task.cancel()
             try:
                 await watcher_task
+            except asyncio.CancelledError:
+                pass
+        # Cancelled before engine.dispose(): a poll pass mid-deploy holds a
+        # session, and disposing the engine underneath it would raise on the
+        # way out rather than shutting down cleanly.
+        poller_task = getattr(app.state, "commit_poller_task", None)
+        if poller_task is not None:
+            poller_task.cancel()
+            try:
+                await poller_task
             except asyncio.CancelledError:
                 pass
         await valkey.aclose()

--- a/apps/api/tests/test_commitpoller.py
+++ b/apps/api/tests/test_commitpoller.py
@@ -1,0 +1,137 @@
+"""Noticing new commits without a webhook (issue #1239).
+
+The decision -- which branches moved and are worth deploying -- is pure, so it
+is tested without HTTP or a database. What matters is not that it spots a moved
+branch; that is one comparison. It is that it does not deploy the same commit
+twice, does not stop polling when one repository breaks, and hands the deploy
+path a payload indistinguishable from a real webhook.
+"""
+
+from __future__ import annotations
+
+import pytest
+from curie_api.commitpoller import Move, PollTarget, moves_to_deploy
+
+REPO = "octo/agent-bot"
+CLONE = "https://github.com/octo/agent-bot.git"
+
+
+class Tips:
+    """Branch tips, and optionally a repository that raises."""
+
+    def __init__(self, shas: dict[tuple[str, str], str | None], explode: set[str] | None = None):
+        self._shas = shas
+        self._explode = explode or set()
+        self.asked: list[tuple[str, str]] = []
+
+    def sha_for(self, repo_full_name: str, branch: str) -> str | None:
+        self.asked.append((repo_full_name, branch))
+        if repo_full_name in self._explode:
+            raise RuntimeError("credential revoked")
+        return self._shas.get((repo_full_name, branch))
+
+
+def target(*branches: str, repo: str = REPO) -> PollTarget:
+    return PollTarget(repo_full_name=repo, clone_url=CLONE, branches=branches)
+
+
+# --------------------------------------------------------------------------- #
+# Not deploying the same commit twice
+# --------------------------------------------------------------------------- #
+def test_an_unchanged_branch_is_not_redeployed() -> None:
+    # The steady state. A poll every minute against an idle repo must produce
+    # nothing at all, or the agent is redeployed once a minute forever.
+    tips = Tips({(REPO, "dev"): "abc123"})
+    assert moves_to_deploy([target("dev")], tips, {(REPO, "dev"): "abc123"}) == []
+
+
+def test_a_moved_branch_is_deployed() -> None:
+    tips = Tips({(REPO, "dev"): "def456"})
+    moves = moves_to_deploy([target("dev")], tips, {(REPO, "dev"): "abc123"})
+    assert [m.sha for m in moves] == ["def456"]
+
+
+def test_a_branch_never_deployed_before_is_deployed() -> None:
+    tips = Tips({(REPO, "dev"): "abc123"})
+    assert len(moves_to_deploy([target("dev")], tips, {})) == 1
+
+
+def test_a_restart_does_not_redeploy_current_head() -> None:
+    # The poller holds no memory of its own; "already deployed" comes from what
+    # is recorded against the repository. If it did not, every API restart
+    # would redeploy every agent.
+    tips = Tips({(REPO, "dev"): "abc123", (REPO, "main"): "zzz999"})
+    state = {(REPO, "dev"): "abc123", (REPO, "main"): "zzz999"}
+    assert moves_to_deploy([target("dev", "main")], tips, state) == []
+
+
+def test_dev_and_prod_are_tracked_separately() -> None:
+    # Same repository, two branches, two agents (ADR-0091). A dev push must not
+    # mark prod as deployed.
+    tips = Tips({(REPO, "dev"): "new111", (REPO, "main"): "old222"})
+    state = {(REPO, "dev"): "old000", (REPO, "main"): "old222"}
+    moves = moves_to_deploy([target("dev", "main")], tips, state)
+    assert [(m.branch, m.sha) for m in moves] == [("dev", "new111")]
+
+
+# --------------------------------------------------------------------------- #
+# One broken repository must not stop the rest
+# --------------------------------------------------------------------------- #
+def test_a_failing_repository_does_not_stop_the_others() -> None:
+    # A revoked credential or a deleted repo is a per-repo condition. Letting it
+    # propagate would silently halt deploys for every other agent on the
+    # cluster -- with no error anyone would look at.
+    broken, fine = "octo/broken", "octo/fine"
+    tips = Tips({(fine, "dev"): "abc123"}, explode={broken})
+    targets = [target("dev", repo=broken), target("dev", repo=fine)]
+    moves = moves_to_deploy(targets, tips, {})
+    assert [m.repo_full_name for m in moves] == [fine]
+
+
+def test_a_branch_the_repository_does_not_have_is_skipped() -> None:
+    # A deploy.yaml may name a prod branch a repo has not created yet. Normal,
+    # not an error.
+    tips = Tips({(REPO, "dev"): "abc123", (REPO, "main"): None})
+    moves = moves_to_deploy([target("dev", "main")], tips, {})
+    assert [m.branch for m in moves] == ["dev"]
+
+
+def test_polling_is_per_repository_not_per_agent() -> None:
+    # Several agents share one repository. Asking once per branch is the
+    # difference between one API call and N racing deploys of the same commit.
+    tips = Tips({(REPO, "dev"): "abc123"})
+    moves_to_deploy([target("dev")], tips, {})
+    assert tips.asked == [(REPO, "dev")]
+
+
+# --------------------------------------------------------------------------- #
+# The payload the deploy path receives
+# --------------------------------------------------------------------------- #
+def test_the_payload_is_shaped_like_a_real_webhook() -> None:
+    # Reusing process_push is what keeps polling and the webhook from
+    # disagreeing about what a push means, and that only holds if the payload
+    # carries the fields it parses.
+    payload = Move(REPO, CLONE, "dev", "abc123").as_push_payload()
+    assert payload["ref"] == "refs/heads/dev"
+    assert payload["after"] == "abc123"
+    assert payload["repository"]["full_name"] == REPO
+    assert payload["repository"]["clone_url"] == CLONE
+
+
+def test_the_payload_carries_the_derived_clone_url() -> None:
+    # gitflow rejects a push whose clone_url does not match the one derived
+    # from configuration. The poller supplies that derived URL, so a polled
+    # deploy passes the origin check by construction -- not by coincidence.
+    from curie_api.config import Settings
+    from curie_api.gitflow import trusted_clone_url
+
+    derived = trusted_clone_url(REPO, Settings(github_clone_base="https://github.com"))
+    payload = Move(REPO, derived, "dev", "abc123").as_push_payload()
+    assert payload["repository"]["clone_url"] == derived
+
+
+@pytest.mark.parametrize("branches", [(), ("dev",), ("dev", "main")])
+def test_no_targets_or_no_branches_is_quiet(branches: tuple[str, ...]) -> None:
+    tips = Tips({})
+    assert moves_to_deploy([target(*branches)], tips, {}) == []
+    assert moves_to_deploy([], tips, {}) == []

--- a/charts/curie/templates/api.yaml
+++ b/charts/curie/templates/api.yaml
@@ -110,6 +110,8 @@ spec:
               value: {{ .Values.api.environment | quote }}
             - name: ORG_NAME
               value: {{ .Values.api.orgName | quote }}
+            - name: COMMIT_POLL_INTERVAL_S
+              value: {{ .Values.api.commitPollIntervalSeconds | quote }}
             - name: GITHUB_CLONE_BASE
               value: {{ .Values.api.githubCloneBase | quote }}
             - name: LANGFUSE_HOST

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -486,6 +486,17 @@ api:
   # External Secrets or Sealed Secrets. Wins over githubAppPrivateKey when set.
   githubAppExistingSecret: ""
   githubAppExistingSecretKey: privateKey
+  # Commit polling (issue #1239), in seconds; 0 disables it.
+  #
+  # Turn this on when the cluster cannot receive GitHub webhooks -- behind a
+  # firewall or NAT, which is the common case for a self-hosted install. The
+  # API then asks GitHub whether the branches deploy.yaml names have moved.
+  # Outbound works where inbound does not.
+  #
+  # The webhook remains the fast path wherever it reaches; polling is the
+  # floor. A poll for a push the webhook already handled does nothing, so
+  # running both is safe. 60 is a reasonable starting interval.
+  commitPollIntervalSeconds: 0
   # The one git origin the API clones from for git-flow. A pushed repository
   # whose clone URL does not resolve to `<githubCloneBase>/<repo_full_name>.git`
   # is rejected with git.origin_mismatch. Set it to a GitHub Enterprise Server


### PR DESCRIPTION
Curie is self-hosted: adopters run it in their own cluster, and many of those accept no inbound traffic. A GitHub webhook cannot reach such a cluster, so **those installs have no push-to-deploy at all** — not a degraded one, none.

| | cluster behind a firewall |
|---|---|
| GitHub webhook → Curie | cannot reach it |
| Actions POST → Curie | cannot reach it |
| **Curie → GitHub** | **works — plain egress** |

Argo CD and Flux poll by default for exactly this reason, treating webhooks as an optimization.

## It does not reimplement deploying

It synthesizes the payload the webhook would have delivered and hands it to `gitflow.process_push`. Two deploy paths that could disagree about what a push means would be worse than one that sometimes runs late.

The `clone_url` it supplies is the one **derived from configuration** — the same value `trusted_clone_url` produces and the origin check compares against — so a polled deploy passes that check by construction rather than coincidence. There's a test asserting exactly that.

## Off by default

An install whose webhook reaches it needs nothing here; polling would only add GitHub API calls. The webhook stays the fast path, and running both is safe — a poll for a push the webhook already handled is a no-op.

```yaml
api:
  commitPollIntervalSeconds: 60    # 0 = off, the default
```

## What the tests are for

Not "does it spot a moved branch" — that's one comparison. The three ways it could go wrong:

```
test_a_restart_does_not_redeploy_current_head
test_a_failing_repository_does_not_stop_the_others
test_polling_is_per_repository_not_per_agent
test_dev_and_prod_are_tracked_separately
test_the_payload_carries_the_derived_clone_url
```

Per *repository*, not per agent — several agents share one repository (ADR-0091), and per-agent polling would race N deploys of the same commit.

```
13 passed                          (poller)
554 passed, 1 pre-existing failure (full API suite)
```

Refs #1239