### PR TITLE
Run the local-model preflight before the --replace teardown

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -1266,6 +1266,34 @@ pub async fn start(opts: StartOpts) -> Result<()> {
         ))
     })?;
 
+    // The sidecar's container name, derived once here so the preflight probe
+    // below and the sidecar setup after the teardown derive their volume from
+    // one name and cannot drift.
+    let ollama = format!("{}-ollama", opts.name);
+
+    // ADR 0093: preflight --local-model before ANY teardown below, since
+    // refusing is free but replacing tears down a live runner (the #747
+    // invariant above). This is the same refusal `local up` gives, so both
+    // tiers answer `--local-model` identically (ADR 0041). The skill tier's
+    // model cache is the sidecar's own volume, not compose's -- and
+    // stop_recorded explicitly keeps that volume, so this preflight returns
+    // the identical answer whether it runs here or after the teardown;
+    // moving it earlier is purely about ordering, not about its verdict.
+    if let Some(local_model) = &opts.local_model {
+        if !opts.pull_model {
+            docker::preflight_local_model(
+                DEFAULT_OLLAMA_IMAGE,
+                &docker::ollama_volume(&ollama),
+                local_model,
+                &format!(
+                    "curie skill up --local-model {local_model} --pull-model --name {}",
+                    opts.name
+                ),
+            )
+            .await?;
+        }
+    }
+
     // The replacement itself, once every cheap validation has passed. Tearing
     // down the record means EVERYTHING it describes -- container, ollama sidecar,
     // network, then the file -- because clearing the record while its runner is
@@ -1299,24 +1327,10 @@ pub async fn start(opts: StartOpts) -> Result<()> {
 
     if let Some(local_model) = &opts.local_model {
         // The sidecar is derived from the same --name, so a leftover
-        // `<name>-ollama` is the same wedge one step over (#747). Preflight it
-        // before creating anything, and let --replace cover it too.
-        let ollama = format!("{}-ollama", opts.name);
-        // ADR 0093: the same refusal `local up` gives, so both tiers answer
-        // `--local-model` identically (ADR 0041). The skill tier's model cache
-        // is the sidecar's own volume, not compose's.
-        if !opts.pull_model {
-            docker::preflight_local_model(
-                DEFAULT_OLLAMA_IMAGE,
-                &docker::ollama_volume(&ollama),
-                local_model,
-                &format!(
-                    "curie skill up --local-model {local_model} --pull-model --name {}",
-                    opts.name
-                ),
-            )
-            .await?;
-        }
+        // `<name>-ollama` is the same wedge one step over (#747). Catch it
+        // before creating anything, and let --replace cover it too. (The
+        // --local-model preflight itself, when --pull-model is absent, already
+        // ran above the teardown against this same binding.)
         // No host port on the sidecar, so the remedy never offers --port.
         docker::ensure_container_name_free(
             &ollama,

--- a/cli/tests/skill_up_replace.rs
+++ b/cli/tests/skill_up_replace.rs
@@ -139,3 +139,41 @@ fn replacing_a_recorded_local_model_run_tears_down_its_sidecar_and_network() {
         "the record is cleared once what it described is gone"
     );
 }
+
+/// The ADR-0093 local-model asset preflight is exactly the kind of cheap abort
+/// the CLI's own ordering invariant (commands.rs, #747) describes: it never
+/// touches the network, only `docker image inspect` and a throwaway probe
+/// container against a volume this test guarantees cannot exist. So a refusal
+/// here must be free, the same as the `--budget` bail above, and the recorded
+/// runner must never be torn down to reach it.
+///
+/// The fabricated model reference is pid-unique so no host can ever have it
+/// pulled, and the sidecar volume name is derived from the pid-unique
+/// `--name`, so it cannot exist either: the preflight is guaranteed to refuse
+/// regardless of what is already cached on the machine running this test.
+#[test]
+fn a_local_model_preflight_refusal_leaves_the_recorded_runner_on_record() {
+    let (dir, recorded) = bundle_with_recorded_runner(false);
+    let absent_model = format!("curie-1252-absent-model-{}:latest", std::process::id());
+    let out = skill_up(&dir, &recorded, &["--local-model", &absent_model]);
+    let stderr = err_str(&out);
+
+    assert!(
+        !out.status.success(),
+        "missing local-model assets must fail the run, got success"
+    );
+    assert!(
+        stderr.contains(
+            "local model assets are not on this machine, and curie does not download them implicitly"
+        ),
+        "expected the ADR-0093 asset refusal, got stderr: {stderr}"
+    );
+    assert!(
+        !stderr.contains("tearing down the recorded runner"),
+        "the preflight is a cheap abort and must run before any teardown; got stderr: {stderr}"
+    );
+    let still_recorded = state::load(&dir.path().join("bundle"))
+        .expect("load state")
+        .expect("--replace must not clear the record before the local-model preflight can still abort it");
+    assert_eq!(still_recorded.container_name, recorded.container_name);
+}


### PR DESCRIPTION
`curie skill up --replace --local-model <absent>` tore down the live runner, cleared `.curie/runner.json`, and only then refused, leaving nothing running. The teardown ran before the ADR-0093 asset preflight.

That violates the invariant the code states about itself (`cli/src/commands.rs`, from #747): refusing is free, but replacing tears down a live runner and must not happen until nothing cheap can still abort. The preflight is exactly such a cheap abort, strictly offline and measured at 32ms.

This hoists the preflight above the teardown, alongside the other cheap validations. `stop_recorded` explicitly keeps the ollama model-cache volume the preflight probes, so the verdict is identical in either position; only the ordering changes.

The hoist would have introduced a second derivation of `<name>-ollama`, one feeding the volume the preflight probes and one feeding the volume the sidecar mounts. That is now derived once so the two cannot drift.

## Done-check

- Failing tests committed before implementation: checked. `1297b6b2` (test) preceded `7294cd24` (fix); both squashed into this branch's single commit.
- All production edits by delegated sub-agents, none inline by the driver: checked.
- Broadened return types: N/A. The Implementer reported none; the change moves a call and adds no new error arm.
- Code Reviewer approved: checked. 11 findings, 0 blockers; it independently verified the identical-verdict claim on three legs (`stop_recorded` never removes the volume on any branch, the `ClearAndProceed` guard forces the volume names to match, no path removes images).
- Scope Reviewer approved: checked. 0 unjustified hunks across 5 non-trivial hunks; the four preflight arguments are byte identical to the removed call.
- Spec-vs-impl approved: checked. 3/3 acceptance criteria met.
- Sibling-path parity: checked. The other `preflight_local_model` call site is `cli/src/local.rs` `up()`, which already preflights before anything is brought up and has no `--replace` teardown, so the tier-parity sibling needed no change.
- Guard demonstration: checked. The preflight was executed rejecting a violating input, not read. Reverting `cli/src/commands.rs` to `origin/main` turns `a_local_model_preflight_refusal_leaves_the_recorded_runner_on_record` red, with `--replace: tearing down the recorded runner` present in stderr and the record cleared; restoring turns it green. That is acceptance criterion 2, run rather than reasoned about.
- Consolidation pass ran: checked. Applied by a Fixer rather than `/simplify` (the duplication was one expression with an identified drift risk), suite and lint green after it, and a fresh Code Reviewer re-checked the applied diff (2 minor comment-accuracy findings, both fixed).
- Security Reviewer: N/A, no security scale-up.
- E2E Tester: N/A. See the coverage limit below.
- Full test suite passes: checked. `cargo test` 1015 passed across 37 suites.
- Lint clean: checked. `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` both clean.

## Coverage limit

Acceptance criterion 3 (assets present, so the replace still happens) has no positive control, and is met by construction rather than by test. The obvious cheap lever is wrong: `--local-model X --pull-model` skips the preflight but then walks into the unconditional sidecar block, which really runs `docker network create`, `docker run -d ollama/ollama:0.24.0` (an 8.9 GB pull), and `ollama pull`. A killed test process would strand a detached container, so that test is not worth its side effects. What is covered instead: the preflight's refusal arm is pinned by the new test, and the non-local-model replace path is pinned by the pre-existing teardown test.

Closes #1252
