### PR TITLE
Wire the commit poller to the bundle store so the API boots with it enabled

### DIFF
--- a/apps/api/src/curie_api/main.py
+++ b/apps/api/src/curie_api/main.py
@@ -157,7 +157,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     if settings.commit_poll_interval_s > 0:
         poller = CommitPoller(
             session_factory=app.state.sessionmaker,
-            store=app.state.store,
+            store=app.state.bundle_store,
             settings=settings,
             eval_queue=app.state.eval_queue,
             tips=GitHubBranchTip(settings, credentials_for(settings)),

--- a/apps/api/tests/test_commitpoller.py
+++ b/apps/api/tests/test_commitpoller.py
@@ -5,12 +5,20 @@ is tested without HTTP or a database. What matters is not that it spots a moved
 branch; that is one comparison. It is that it does not deploy the same commit
 twice, does not stop polling when one repository breaks, and hands the deploy
 path a payload indistinguishable from a real webhook.
+One test, the one that runs the real lifespan (#1250), is the exception and is
+deliberate: the wiring the poller receives from the lifespan cannot be checked
+without running the real lifespan.
 """
 
 from __future__ import annotations
 
+import os
+
 import pytest
 from curie_api.commitpoller import Move, PollTarget, moves_to_deploy
+from curie_api.config import get_settings
+from curie_api.main import create_app
+from fastapi.testclient import TestClient
 
 REPO = "octo/agent-bot"
 CLONE = "https://github.com/octo/agent-bot.git"
@@ -135,3 +143,42 @@ def test_no_targets_or_no_branches_is_quiet(branches: tuple[str, ...]) -> None:
     tips = Tips({})
     assert moves_to_deploy([target(*branches)], tips, {}) == []
     assert moves_to_deploy([], tips, {}) == []
+
+
+# --------------------------------------------------------------------------- #
+# The wiring the lifespan hands it (#1250)
+# --------------------------------------------------------------------------- #
+def test_the_lifespan_wires_the_poller_to_the_bundle_store(clean_db: None) -> None:
+    # The poller was constructed with `store=app.state.store`, an attribute
+    # nothing assigns, so enabling it crashed the API at startup and the feature
+    # never ran once. mypy cannot see it (State.__getattr__ returns Any) and no
+    # test built the poller, so the only thing that catches it is running the
+    # real lifespan with the interval on. The identity assertion is the point:
+    # `is not None` would pass against a poller wired to the wrong object.
+    #
+    # clean_db (not _disposable_db) is load-bearing, not a style choice: on
+    # entering the TestClient's `with` block, run_forever calls poll_once
+    # immediately, before its first sleep, and poll_once queries curie.agents
+    # for rows with a repo_full_name. If an agent row from an earlier test
+    # survived, this pass would call GitHubBranchTip.sha_for and issue a real
+    # httpx request to the GitHub API. clean_db's TRUNCATE is the only reason
+    # that pass is a no-op; do not weaken this to _disposable_db.
+    prior = os.environ.get("COMMIT_POLL_INTERVAL_S")
+    os.environ["COMMIT_POLL_INTERVAL_S"] = "3600"
+    get_settings.cache_clear()
+    try:
+        with TestClient(create_app()) as client:
+            assert client.app.state.commit_poller_task is not None
+            poller = client.app.state.commit_poller
+            assert poller._store is client.app.state.bundle_store
+            # Pins the actual defect: a "fix" that leaves store=app.state.store
+            # in place and adds app.state.store = bundle_store as an alias would
+            # satisfy the identity assertion above while reintroducing the
+            # compatibility path this codebase forbids. Exactly one store name.
+            assert not hasattr(client.app.state, "store")
+    finally:
+        if prior is None:
+            os.environ.pop("COMMIT_POLL_INTERVAL_S", None)
+        else:
+            os.environ["COMMIT_POLL_INTERVAL_S"] = prior
+        get_settings.cache_clear()

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -494,8 +494,15 @@ api:
   # Outbound works where inbound does not.
   #
   # The webhook remains the fast path wherever it reaches; polling is the
-  # floor. A poll for a push the webhook already handled does nothing, so
-  # running both is safe. 60 is a reasonable starting interval.
+  # floor. Each pass costs one API call per repository per branch -- repos x
+  # 2 calls per interval. A branch is skipped only when its tip matches the
+  # sha already recorded as deployed, a snapshot taken at the START of the
+  # pass, before that pass's clone, archive, validate and upload run -- so a
+  # webhook handling the SAME push concurrently can still deploy it twice.
+  # A push gitflow.process_push ignores or rejects is never recorded, so a
+  # stuck branch re-clones and re-archives every pass until fixed (#1267);
+  # raise the interval to reduce that cost meanwhile. 60 is a reasonable
+  # starting interval.
   commitPollIntervalSeconds: 0
   # The one git origin the API clones from for git-flow. A pushed repository
   # whose clone URL does not resolve to `<githubCloneBase>/<repo_full_name>.git`


### PR DESCRIPTION
Closes #1250

`main.py` constructed `CommitPoller` with `store=app.state.store`, an attribute nothing assigns. Starlette's `State` raises rather than falling back, so the lifespan died before `yield` and the API exited at startup. Any install that set `commitPollIntervalSeconds` got a CrashLoopBackOff of the whole control plane, and the affected population is exactly the firewalled installs the polling deploy path was built for. The feature from #1246 had never run anywhere.

## What changed

- `store=app.state.bundle_store`, already typed as the `ObjectStore` that `gitflow.process_push` takes. No alias was added; there stays exactly one name for it.
- A test through the real lifespan, the only thing that could have caught this. mypy sees `Any` through `State.__getattr__`, and the poller branch is the lifespan's only gate defaulting to off, so no existing test ever executed it.
- The `values.yaml` comment claiming that running the webhook and the poller together is safe was wrong, and is corrected.

## Acceptance criteria

**AC1, crash clause: met.** The literal command now reaches startup:

```
$ COMMIT_POLL_INTERVAL_S=60 uvicorn curie_api.main:app
INFO:     Started server process [540348]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://127.0.0.1:28250 (Press CTRL+C to quit)
```

Control run with `store=app.state.store` restored, same command and environment:

```
AttributeError: 'State' object has no attribute 'store'
ERROR:    Application startup failed. Exiting.
EXIT=3
```

**AC1, log clause: partially met, and deliberately not fixed here.** The run above does not print "commit poller started". The record is emitted, not missing: the identical command plus a log config adding a root INFO handler prints

```
INFO: curie_api.commitpoller: commit poller started interval=60.0s
```

Nothing in `curie_api` calls `basicConfig` or `dictConfig`, and uvicorn's default logging config has no `root` entry, so every `curie_api` INFO record is dropped. `apps/api/Dockerfile` runs bare uvicorn, so this is the production path too. That is a service-wide gap this diff did not cause and no correction to the poller wiring could have satisfied, and fixing it needs settings plus chart plumbing plus OTel non-conflict. Filed as #1270.

**AC2: met.** Two mutations were executed, not reasoned about:

| Mutation | Result |
|---|---|
| Rename `bundle_store` across `main.py:60`, `main.py:160`, `deps.py:32` | red: `AttributeError: 'State' object has no attribute 'bundle_store'` |
| Keep `store=app.state.store`, add `app.state.store = store` as an alias | red: `AssertionError: assert not True` on the `not hasattr` line |

The second is why the test asserts `not hasattr(client.app.state, "store")` as well as the identity check: a compatibility alias satisfies identity and is exactly the wrong fix this repo forbids.

**AC3: met.** Latent item 4 is fixed inline, since it was only a wrong claim in a comment. The other three are split out with the mechanism, the triggering configuration, the measurement from #1250, and acceptance criteria: #1267 unbounded re-clone, #1268 polled rejections invisible, #1269 anonymous polling with no backoff. All three become live the moment this merges, because until now the poller has never executed a pass.

## Out of scope, annotated

`gitflow.py` is untouched. The double-deploy race the corrected comment describes is pre-existing there and `api.replicas` defaults to 1; the finding in scope was that the comment overclaimed. No `UniqueConstraint` and no migration were added.

## Done-check

- [x] Failing tests committed before implementation: `dec87f18` (tests only) preceded `659bae54` (src), squashed after review
- [x] All production edits made by delegated sub-agents; driver ran only git, tests and bookkeeping
- [x] Broadened return types: none, confirmed by the implementer
- [x] Code Reviewer approved with file:line evidence, 0 blocking
- [x] Scope Reviewer approved, 0 unjustified hunks
- [x] Sibling-path parity: the other three lifespan components (resume reconciler, expiry sweeper, graveyard watcher) were swept for the same defect class and are clean; the poller was uniquely exposed because its gate is the only one defaulting to off
- [x] Guard demonstration: both mutations above were executed with output captured, not read
- [x] Consolidation pass ran and found nothing to apply, so there was no consolidation diff to re-review
- [N/A] Security Reviewer: not flagged
- [x] E2E: deployed-surface flagged, verified by real uvicorn boot plus control run against live Postgres, MinIO and Valkey
- [x] Full suite: 2470 passed / 11 skipped before, 2471 passed / 11 skipped after
- [x] Lint clean: `ruff check .`, `mypy`, and `scripts/check-docs.sh`