### PR TITLE
Prepare v0.6.0 release

### DIFF
--- a/charts/curie/Chart.yaml
+++ b/charts/curie/Chart.yaml
@@ -8,8 +8,8 @@ description: >-
   and two install-time preflights ship baked in: a CPU-AVX / ClickHouse-pin
   check and a NetworkPolicy-enforcement probe.
 type: application
-version: 0.5.1
-appVersion: "0.5.1"
+version: 0.6.0
+appVersion: "0.6.0"
 kubeVersion: ">=1.25.0-0"
 maintainers:
   - name: Curie

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -692,7 +692,7 @@ dependencies = [
 
 [[package]]
 name = "curie"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anstream",
  "anstyle",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "curie"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2021"
 description = "Curie CLI: init/start/send/eval a plugin against a local runner (task I1)"
 


### PR DESCRIPTION
Updates the CLI and Helm chart release versions to 0.6.0.\n\nValidation completed for version consistency, CLI formatting, linting, tests, release build, and Helm rendering.