### PR TITLE
Onboard a repository in one command

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -1669,6 +1669,21 @@
         "title": "KillState",
         "type": "object"
       },
+      "ListedTargets": {
+        "description": "Every target a ``deploy.yaml`` declares, dev before prod.\n\nOrdered so a caller onboarding a repository deploys dev first. A run that\nfails part-way then leaves prod BEHIND rather than ahead of a dev that\nnever landed -- recoverable in one direction, not the other.",
+        "properties": {
+          "targets": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/NamedTarget"
+            },
+            "title": "Targets",
+            "type": "array"
+          }
+        },
+        "title": "ListedTargets",
+        "type": "object"
+      },
       "LoadPackConfig": {
         "description": "Rotating \"working...\" load lines for one agent. Mirrors the worker's\ncurie_worker.behaviorpacks.LoadPack (packs ride on agent config, not the\nfrozen ACI contract, so the shape is duplicated across the layers the way\nBudgetConfig mirrors the ACI Budget).",
         "properties": {
@@ -1910,6 +1925,47 @@
           "error_rate"
         ],
         "title": "MetricsSummary",
+        "type": "object"
+      },
+      "NamedTarget": {
+        "description": "A resolved target plus the name it is declared under.",
+        "properties": {
+          "agent": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agent"
+          },
+          "env": {
+            "default": "dev",
+            "title": "Env",
+            "type": "string"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "slack_channel": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Slack Channel"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "title": "NamedTarget",
         "type": "object"
       },
       "NavPackConfig": {
@@ -5113,6 +5169,66 @@
         "summary": "Get Config",
         "tags": [
           "config"
+        ]
+      }
+    },
+    "/deploy-targets/list": {
+      "post": {
+        "description": "Every target a ``deploy.yaml`` declares (ADR-0089).\n\nThe sibling of `resolve` above, and here for the same reason: onboarding a\nrepository means deploying ALL its targets, and a caller that had to parse\nthe file to enumerate them would be the second parser this endpoint exists\nto prevent.\n\n``target`` on the request is ignored -- the shape is shared so the CLI has\none request type for both calls.\n\nOrdered dev before prod. A caller deploying in sequence that fails part-way\nthen leaves prod on its previous version rather than ahead of a dev that\nnever landed; recoverable one way and not the other.",
+        "operationId": "list_deploy_targets_deploy_targets_list_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ResolveTargetRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListedTargets"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Deploy Targets",
+        "tags": [
+          "deploy-targets"
         ]
       }
     },

--- a/apps/api/src/curie_api/routers/deploy_targets.py
+++ b/apps/api/src/curie_api/routers/deploy_targets.py
@@ -10,12 +10,35 @@ agent to create.
 
 import yaml
 from fastapi import APIRouter, Depends, HTTPException, status
-from plugin_format.deploy_targets import validate_deploy_targets
+from plugin_format.deploy_targets import DeployTargetsFile, validate_deploy_targets
 
 from ..auth import require_api_key
-from ..schemas import ResolvedTarget, ResolveTargetRequest
+from ..schemas import ListedTargets, NamedTarget, ResolvedTarget, ResolveTargetRequest
 
 router = APIRouter(tags=["deploy-targets"], dependencies=[Depends(require_api_key)])
+
+
+def _parse(content: str) -> DeployTargetsFile:
+    """Parse and validate ``deploy.yaml``, or raise the operator-facing 400.
+
+    Shared by both endpoints so `list` and `resolve` cannot disagree about
+    whether a file is valid -- which would be a second parser by the back door,
+    the exact thing ADR-0089 put this in the API to prevent.
+    """
+
+    try:
+        data = yaml.safe_load(content)
+    except yaml.YAMLError as exc:
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST, f"deploy.yaml is unparseable: {exc}"
+        ) from exc
+
+    parsed, errors = validate_deploy_targets(data)
+    if errors:
+        detail = "; ".join(f"{code}: {message}" for code, message in errors)
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, detail)
+    assert parsed is not None
+    return parsed
 
 
 @router.post("/deploy-targets/resolve", response_model=ResolvedTarget)
@@ -34,18 +57,7 @@ async def resolve_deploy_target(body: ResolveTargetRequest) -> ResolvedTarget:
     agent, environment, or channel.
     """
 
-    try:
-        data = yaml.safe_load(body.content)
-    except yaml.YAMLError as exc:
-        raise HTTPException(
-            status.HTTP_400_BAD_REQUEST, f"deploy.yaml is unparseable: {exc}"
-        ) from exc
-
-    parsed, errors = validate_deploy_targets(data)
-    if errors:
-        detail = "; ".join(f"{code}: {message}" for code, message in errors)
-        raise HTTPException(status.HTTP_400_BAD_REQUEST, detail)
-    assert parsed is not None
+    parsed = _parse(body.content)
 
     target = parsed.targets.get(body.target)
     if target is None:
@@ -55,3 +67,30 @@ async def resolve_deploy_target(body: ResolveTargetRequest) -> ResolvedTarget:
             f"no target named {body.target!r} in deploy.yaml. Declared: {known}",
         )
     return ResolvedTarget(agent=target.agent, env=target.env, slack_channel=target.slack_channel)
+
+
+@router.post("/deploy-targets/list", response_model=ListedTargets)
+async def list_deploy_targets(body: ResolveTargetRequest) -> ListedTargets:
+    """Every target a ``deploy.yaml`` declares (ADR-0089).
+
+    The sibling of `resolve` above, and here for the same reason: onboarding a
+    repository means deploying ALL its targets, and a caller that had to parse
+    the file to enumerate them would be the second parser this endpoint exists
+    to prevent.
+
+    ``target`` on the request is ignored -- the shape is shared so the CLI has
+    one request type for both calls.
+
+    Ordered dev before prod. A caller deploying in sequence that fails part-way
+    then leaves prod on its previous version rather than ahead of a dev that
+    never landed; recoverable one way and not the other.
+    """
+
+    parsed = _parse(body.content)
+    order = {"dev": 0, "prod": 1}
+    named = [
+        NamedTarget(name=name, agent=t.agent, env=t.env, slack_channel=t.slack_channel)
+        for name, t in parsed.targets.items()
+    ]
+    named.sort(key=lambda t: (order.get(t.env, 2), t.name))
+    return ListedTargets(targets=named)

--- a/apps/api/src/curie_api/schemas.py
+++ b/apps/api/src/curie_api/schemas.py
@@ -506,6 +506,23 @@ class ResolvedTarget(BaseModel):
     slack_channel: str | None = None
 
 
+class NamedTarget(ResolvedTarget):
+    """A resolved target plus the name it is declared under."""
+
+    name: str
+
+
+class ListedTargets(BaseModel):
+    """Every target a ``deploy.yaml`` declares, dev before prod.
+
+    Ordered so a caller onboarding a repository deploys dev first. A run that
+    fails part-way then leaves prod BEHIND rather than ahead of a dev that
+    never landed -- recoverable in one direction, not the other.
+    """
+
+    targets: list[NamedTarget] = []
+
+
 class ConnectorManifests(BaseModel):
     """Kubernetes objects derived from a version's ``connectors.yaml``.
 

--- a/apps/api/tests/test_resolve_deploy_target.py
+++ b/apps/api/tests/test_resolve_deploy_target.py
@@ -92,3 +92,69 @@ def test_unparseable_yaml_is_a_400_naming_the_problem(
     r = _resolve(client, auth_headers, "targets:\n  p:\n   env: [unclosed\n", "p")
     assert r.status_code == 400
     assert "unparseable" in r.json()["detail"]
+
+
+# --------------------------------------------------------------------------- #
+# Listing every target (onboarding)
+# --------------------------------------------------------------------------- #
+_TWO_TARGETS = """
+targets:
+  prod: { agent: my-bot,     env: prod, slack_channel: C000000A01 }
+  dev:  { agent: my-bot-dev, env: dev,  slack_channel: C000000A02 }
+"""
+
+
+def test_list_returns_every_target(client: TestClient, auth_headers: dict) -> None:
+    # Onboarding a repository means deploying ALL its targets. A caller that
+    # had to parse deploy.yaml to enumerate them would be the second parser
+    # ADR-0089 put this endpoint here to prevent.
+    r = client.post(
+        "/deploy-targets/list",
+        json={"content": _TWO_TARGETS, "target": "ignored"},
+        headers=auth_headers,
+    )
+    assert r.status_code == 200
+    assert {t["agent"] for t in r.json()["targets"]} == {"my-bot", "my-bot-dev"}
+
+
+def test_list_orders_dev_before_prod(client: TestClient, auth_headers: dict) -> None:
+    # A sequential onboarding run that fails part-way must leave prod BEHIND,
+    # not ahead of a dev that never landed. The file declares prod first, so
+    # this is ordering rather than luck.
+    r = client.post(
+        "/deploy-targets/list", json={"content": _TWO_TARGETS, "target": ""}, headers=auth_headers
+    )
+    assert [t["env"] for t in r.json()["targets"]] == ["dev", "prod"]
+
+
+def test_list_carries_the_declared_name(client: TestClient, auth_headers: dict) -> None:
+    r = client.post(
+        "/deploy-targets/list", json={"content": _TWO_TARGETS, "target": ""}, headers=auth_headers
+    )
+    assert {t["name"] for t in r.json()["targets"]} == {"dev", "prod"}
+
+
+def test_list_and_resolve_agree_on_an_invalid_file(client: TestClient, auth_headers: dict) -> None:
+    # Both go through one parser. If they diverged, a file could list cleanly
+    # and resolve as broken -- a second parser by the back door.
+    bad = "targets: {dev: {agent: x, env: nonsense, slack_channel: C000000B01}}"
+    a = client.post(
+        "/deploy-targets/list", json={"content": bad, "target": "dev"}, headers=auth_headers
+    )
+    b = client.post(
+        "/deploy-targets/resolve", json={"content": bad, "target": "dev"}, headers=auth_headers
+    )
+    assert a.status_code == b.status_code == 400
+    assert a.json()["detail"] == b.json()["detail"]
+
+
+def test_list_of_an_empty_file_is_empty_not_an_error(
+    client: TestClient, auth_headers: dict
+) -> None:
+    # Nothing declared is a legitimate state for a bundle that predates
+    # deploy.yaml; the caller decides what to do about it.
+    r = client.post(
+        "/deploy-targets/list", json={"content": "targets: {}", "target": ""}, headers=auth_headers
+    )
+    assert r.status_code == 200
+    assert r.json()["targets"] == []

--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -2608,6 +2608,18 @@ export const commandManifest = {
             },
             {
               "global": false,
+              "help": "Deploy EVERY target `deploy.yaml` declares, dev before prod",
+              "id": "all_targets",
+              "long": "all-targets",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "global": false,
               "help": "Deploy under this agent name instead of the manifest's `name`",
               "id": "agent",
               "long": "agent",

--- a/cli/api-mirrors.json
+++ b/cli/api-mirrors.json
@@ -12,10 +12,22 @@
       "struct": "Agent",
       "schema": "AgentOut",
       "omissions": [
-        { "field": "behavior_packs", "why": "No CLI path reads an agent's behavior-pack list; deploy uploads a bundle rather than composing packs, so behavior_packs is never consumed." },
-        { "field": "model", "why": "The CLI never displays or acts on an agent's default model (model routing is server- and claim-time bound, #473); the deploy and lifecycle verbs read only id/name/slack_channel." },
-        { "field": "secrets", "why": "update_agent_secrets WRITES connector-secret names; the CLI never reads the stored secrets list back, so the response field is not modeled." },
-        { "field": "created_at", "why": "No CLI verb prints an agent's creation timestamp; the deploy summary and lifecycle verbs render id/name/slack_channel only." }
+        {
+          "field": "behavior_packs",
+          "why": "No CLI path reads an agent's behavior-pack list; deploy uploads a bundle rather than composing packs, so behavior_packs is never consumed."
+        },
+        {
+          "field": "model",
+          "why": "The CLI never displays or acts on an agent's default model (model routing is server- and claim-time bound, #473); the deploy and lifecycle verbs read only id/name/slack_channel."
+        },
+        {
+          "field": "secrets",
+          "why": "update_agent_secrets WRITES connector-secret names; the CLI never reads the stored secrets list back, so the response field is not modeled."
+        },
+        {
+          "field": "created_at",
+          "why": "No CLI verb prints an agent's creation timestamp; the deploy summary and lifecycle verbs render id/name/slack_channel only."
+        }
       ]
     },
     {
@@ -42,37 +54,76 @@
       "struct": "ApprovalRecord",
       "schema": "ApprovalOut",
       "omissions": [
-        { "field": "agent_id", "why": "The approvals verbs (commands::approvals) already scope the query by --agent, so the record's echoed agent_id is redundant to what the caller passed and is not rendered." },
-        { "field": "reply_channel", "why": "Slack reply-routing (reply_channel) is consumed by the worker to post the approval card, not by the CLI, which renders the record for a human operator." },
-        { "field": "reply_placeholder", "why": "The card placeholder text is a worker/Slack rendering detail; the approvals listing shows summary/gate, not the card body." },
-        { "field": "reply_endpoint", "why": "The reply callback endpoint routes a Slack action back to the API; the CLI resolve path posts to /approvals/{id}/resolve directly and never reads it." },
-        { "field": "dedupe_key", "why": "The idempotency key is a server-side dedupe concern; the CLI neither displays it nor resubmits on it." },
-        { "field": "card_channel", "why": "Where the approval card was posted is a Slack-delivery detail; the operator-facing listing renders conversation_id/summary, not the card channel." },
-        { "field": "resolution_note", "why": "resolve_approval SENDS a note via --note; it does not read back the stored resolution_note when listing pending approvals." },
-        { "field": "created_at", "why": "The listing shows expires_at (the actionable deadline), not the creation timestamp, which the operator does not act on." },
-        { "field": "resolved_at", "why": "list_pending_approvals filters to status=pending, which by definition carry no resolution timestamp, so resolved_at is never populated on the records the CLI renders." }
+        {
+          "field": "agent_id",
+          "why": "The approvals verbs (commands::approvals) already scope the query by --agent, so the record's echoed agent_id is redundant to what the caller passed and is not rendered."
+        },
+        {
+          "field": "reply_channel",
+          "why": "Slack reply-routing (reply_channel) is consumed by the worker to post the approval card, not by the CLI, which renders the record for a human operator."
+        },
+        {
+          "field": "reply_placeholder",
+          "why": "The card placeholder text is a worker/Slack rendering detail; the approvals listing shows summary/gate, not the card body."
+        },
+        {
+          "field": "reply_endpoint",
+          "why": "The reply callback endpoint routes a Slack action back to the API; the CLI resolve path posts to /approvals/{id}/resolve directly and never reads it."
+        },
+        {
+          "field": "dedupe_key",
+          "why": "The idempotency key is a server-side dedupe concern; the CLI neither displays it nor resubmits on it."
+        },
+        {
+          "field": "card_channel",
+          "why": "Where the approval card was posted is a Slack-delivery detail; the operator-facing listing renders conversation_id/summary, not the card channel."
+        },
+        {
+          "field": "resolution_note",
+          "why": "resolve_approval SENDS a note via --note; it does not read back the stored resolution_note when listing pending approvals."
+        },
+        {
+          "field": "created_at",
+          "why": "The listing shows expires_at (the actionable deadline), not the creation timestamp, which the operator does not act on."
+        },
+        {
+          "field": "resolved_at",
+          "why": "list_pending_approvals filters to status=pending, which by definition carry no resolution timestamp, so resolved_at is never populated on the records the CLI renders."
+        }
       ]
     },
     {
       "struct": "MemoryEntry",
       "schema": "MemoryEntryOut",
       "omissions": [
-        { "field": "provenance", "why": "The memory list verb renders index/content/version; provenance is a nested MemoryProvenanceOut $ref with no CLI mirror, and carrying it would require a second struct out of this gate's scope." }
+        {
+          "field": "provenance",
+          "why": "The memory list verb renders index/content/version; provenance is a nested MemoryProvenanceOut $ref with no CLI mirror, and carrying it would require a second struct out of this gate's scope."
+        }
       ]
     },
     {
       "struct": "Bundle",
       "schema": "BundleOut",
       "omissions": [
-        { "field": "version_id", "why": "upload_bundle returns the bundle to the deploy summary, which already holds the Version it just created (ApiClient::deploy), so the bundle's echoed version_id is redundant." }
+        {
+          "field": "version_id",
+          "why": "upload_bundle returns the bundle to the deploy summary, which already holds the Version it just created (ApiClient::deploy), so the bundle's echoed version_id is redundant."
+        }
       ]
     },
     {
       "struct": "Deployment",
       "schema": "DeploymentOut",
       "omissions": [
-        { "field": "agent_id", "why": "list_deployments/create_deployment are already agent-scoped by the caller, so the record's echoed agent_id adds nothing the deploy summary or approvals-gate read uses." },
-        { "field": "commit_sha", "why": "The deploy summary and the approvals gate read resolve the in-force version via version_id; the deployment's commit_sha is not read. Follow-up parity candidate (same family as #548), flagged in the PR body, not added here." }
+        {
+          "field": "agent_id",
+          "why": "list_deployments/create_deployment are already agent-scoped by the caller, so the record's echoed agent_id adds nothing the deploy summary or approvals-gate read uses."
+        },
+        {
+          "field": "commit_sha",
+          "why": "The deploy summary and the approvals gate read resolve the in-force version via version_id; the deployment's commit_sha is not read. Follow-up parity candidate (same family as #548), flagged in the PR body, not added here."
+        }
       ]
     },
     {
@@ -104,9 +155,18 @@
       "struct": "EvalTriggerResult",
       "schema": "EvalTriggerResult",
       "omissions": [
-        { "field": "agent_id", "why": "trigger_eval is called with the agent the caller chose; the sweep pairs the enqueued job to its matrix row by stream_id/sha, so the echoed agent_id is unused." },
-        { "field": "version_id", "why": "The sweep scopes readiness by the run's sha column on the matrix, not by version_id; the trigger's version_id is never read." },
-        { "field": "bundle_ref", "why": "The artifact pointer is surfaced on the version/bundle path, not off the eval trigger; the sweep reads only stream_id/sha/suite/model here." }
+        {
+          "field": "agent_id",
+          "why": "trigger_eval is called with the agent the caller chose; the sweep pairs the enqueued job to its matrix row by stream_id/sha, so the echoed agent_id is unused."
+        },
+        {
+          "field": "version_id",
+          "why": "The sweep scopes readiness by the run's sha column on the matrix, not by version_id; the trigger's version_id is never read."
+        },
+        {
+          "field": "bundle_ref",
+          "why": "The artifact pointer is surfaced on the version/bundle path, not off the eval trigger; the sweep reads only stream_id/sha/suite/model here."
+        }
       ]
     },
     {
@@ -118,10 +178,22 @@
       "struct": "EvalMatrix",
       "schema": "EvalMatrix",
       "omissions": [
-        { "field": "cases", "why": "The sweep reads the per-(version, model) rollup (model_version_summaries) and the version columns (versions); the per-case identifiers (cases) that label the grid are not read by the CLI." },
-        { "field": "rows", "why": "The per-case pass/fail grid (rows) is carried by the endpoint but unused by the sweep, which needs only the per-model rollup; the existing doc comment on EvalMatrix already states this." },
-        { "field": "models", "why": "The model dimension the CLI acts on is model_version_summaries[].model; the separate models label list is not read." },
-        { "field": "model_summaries", "why": "The window-blended per-model rollup sums completed across every in-window sha, which masks a triggered sha's zero-completed outcome (#814); the sweep reads the per-(version, model) model_version_summaries scoped to the triggered sha instead, so the blended rollup is not consumed by the CLI." }
+        {
+          "field": "cases",
+          "why": "The sweep reads the per-(version, model) rollup (model_version_summaries) and the version columns (versions); the per-case identifiers (cases) that label the grid are not read by the CLI."
+        },
+        {
+          "field": "rows",
+          "why": "The per-case pass/fail grid (rows) is carried by the endpoint but unused by the sweep, which needs only the per-model rollup; the existing doc comment on EvalMatrix already states this."
+        },
+        {
+          "field": "models",
+          "why": "The model dimension the CLI acts on is model_version_summaries[].model; the separate models label list is not read."
+        },
+        {
+          "field": "model_summaries",
+          "why": "The window-blended per-model rollup sums completed across every in-window sha, which masks a triggered sha's zero-completed outcome (#814); the sweep reads the per-(version, model) model_version_summaries scoped to the triggered sha instead, so the blended rollup is not consumed by the CLI."
+        }
       ]
     },
     {
@@ -133,6 +205,16 @@
       "struct": "ConnectorManifests",
       "schema": "ConnectorManifests",
       "omissions": []
+    },
+    {
+      "struct": "NamedTarget",
+      "schema": "NamedTarget",
+      "omissions": []
+    },
+    {
+      "struct": "ListedTargets",
+      "schema": "ListedTargets",
+      "omissions": []
     }
   ],
   "non_mirrors": [],
@@ -142,14 +224,20 @@
       "output": "VersionsOutput",
       "struct": "Version",
       "omissions": [
-        { "field": "agent_id", "why": "agent_id is carried on the struct for struct-level parity (#691) but deliberately not emitted by `versions --json`: the payload already carries `agent` (the query was agent-scoped), so echoing agent_id per version is redundant. Pinned by json_emit_contract.rs's versions_output_json_shape_is_pinned." }
+        {
+          "field": "agent_id",
+          "why": "agent_id is carried on the struct for struct-level parity (#691) but deliberately not emitted by `versions --json`: the payload already carries `agent` (the query was agent-scoped), so echoing agent_id per version is redundant. Pinned by json_emit_contract.rs's versions_output_json_shape_is_pinned."
+        }
       ]
     },
     {
       "output": "MemoryOutput",
       "struct": "MemoryEntry",
       "omissions": [
-        { "field": "version", "why": "The memory listing is read-only in the CLI today -- no verb performs a versioned mutation against a memory entry, so the log's optimistic-concurrency version (MemoryEntryOut.version) is not surfaced yet. Pinned by json_emit_contract.rs's memory_output_json_shape_is_pinned, which notes surfacing it later is a contract decision, not an oversight." }
+        {
+          "field": "version",
+          "why": "The memory listing is read-only in the CLI today -- no verb performs a versioned mutation against a memory entry, so the log's optimistic-concurrency version (MemoryEntryOut.version) is not surfaced yet. Pinned by json_emit_contract.rs's memory_output_json_shape_is_pinned, which notes surfacing it later is a contract decision, not an oversight."
+        }
       ]
     },
     {

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -2605,6 +2605,18 @@
             },
             {
               "global": false,
+              "help": "Deploy EVERY target `deploy.yaml` declares, dev before prod",
+              "id": "all_targets",
+              "long": "all-targets",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "global": false,
               "help": "Deploy under this agent name instead of the manifest's `name`",
               "id": "agent",
               "long": "agent",

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -34,6 +34,21 @@ pub struct ResolvedTarget {
     pub slack_channel: Option<String>,
 }
 
+/// One target plus the name it is declared under (ADR-0089).
+#[derive(Debug, Clone, Deserialize)]
+pub struct NamedTarget {
+    pub name: String,
+    pub agent: Option<String>,
+    pub env: String,
+    pub slack_channel: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct ListedTargets {
+    #[serde(default)]
+    pub targets: Vec<NamedTarget>,
+}
+
 #[derive(Debug, Clone, Deserialize, Default)]
 pub struct ConnectorManifests {
     #[serde(default)]
@@ -969,6 +984,39 @@ impl ApiClient {
             anyhow::bail!("resolving target `{target}` failed with {status}: {body}");
         }
         serde_json::from_str(&body).context("decoding the resolved deploy target")
+    }
+
+    /// Every target a `deploy.yaml` declares, dev before prod.
+    ///
+    /// The file CONTENT goes to the API rather than being parsed here, for the
+    /// same reason `resolve_deploy_target` does: ADR-0089 keeps exactly one
+    /// parser for this format, and a second in Rust could disagree with it
+    /// about where a deploy lands.
+    pub async fn list_deploy_targets(&self, content: &str) -> Result<ListedTargets> {
+        let resp = self
+            .http
+            .post(format!("{}/deploy-targets/list", self.base_url))
+            .header("X-API-Key", &self.api_key)
+            .json(&serde_json::json!({"content": content, "target": ""}))
+            .send()
+            .await
+            .context("listing the deploy targets")?;
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        // Same skew guard as `resolve_deploy_target`: a platform predating this
+        // endpoint answers with FastAPI's bare 404 body, which is otherwise
+        // indistinguishable from a real error and sends an operator hunting.
+        if is_unrouted(status, &body) {
+            anyhow::bail!(
+                "this platform release cannot list deploy targets, so onboarding every \
+                 target at once will not work against it. Upgrade the release, or deploy \
+                 each target with `cluster deploy --target <name>`."
+            );
+        }
+        if !status.is_success() {
+            anyhow::bail!("listing the deploy targets failed ({status}): {body}");
+        }
+        serde_json::from_str(&body).context("decoding the deploy target list")
     }
 
     pub async fn version_connectors(

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1464,6 +1464,14 @@ enum ClusterAction {
         /// no committed file.
         #[arg(long, conflicts_with = "agent")]
         target: Option<String>,
+        /// Deploy EVERY target `deploy.yaml` declares, dev before prod.
+        ///
+        /// Onboarding a repository otherwise means one invocation per target,
+        /// and forgetting one leaves an agent that exists and never updates.
+        /// Ordered dev-first so a run that fails part-way leaves prod on its
+        /// previous version rather than ahead of a dev that never landed.
+        #[arg(long, conflicts_with_all = ["target", "agent", "env", "slack_channel"])]
+        all_targets: bool,
         /// Deploy under this agent name instead of the manifest's `name`.
         ///
         /// The bundle is unchanged -- only which agent it binds to. This is how
@@ -2156,7 +2164,7 @@ async fn run(command: Option<Command>) -> Result<()> {
                         // `local deploy` offers `--secret`, so enforce the
                         // declared-secrets policy gate (#464).
                         secret_binding_supported: true,
-                        connect_hint,
+                        connect_hint: connect_hint.clone(),
                     })
                     .await?,
                 )
@@ -2619,6 +2627,7 @@ async fn run(command: Option<Command>) -> Result<()> {
                 plugin_dir,
                 agent,
                 target,
+                all_targets,
                 api_url,
                 namespace,
                 release,
@@ -2710,45 +2719,90 @@ async fn run(command: Option<Command>) -> Result<()> {
                         "the platform API at {api_url} (from --api-url/CURIE_API_URL) is unreachable. `cluster deploy` dialed it directly with no port-forward; confirm that URL is reachable and the release is healthy with `curie cluster status`, or omit --api-url to self-plumb a loopback port-forward to svc/{release}-api."
                     )
                 };
-                let deployed = commands::deploy(DeployOpts {
-                    plugin_dir,
-                    agent,
-                    target,
-                    api_url: api_url.clone(),
-                    api_key: api_key.clone(),
-                    slack_channel,
-                    repo,
-                    env,
-                    label,
-                    // Cluster connector-secret delivery is deferred to #440; no
-                    // `--secret` flag on `cluster deploy` (see the note above).
-                    secret: Vec::new(),
-                    // Secret binding is not wired on cluster until #440, so the
-                    // declared-secrets policy gate (#464) is skipped here: it
-                    // would otherwise hard-fail every secrets-declaring bundle
-                    // with a `--secret <NAME>` remediation this tier lacks.
-                    secret_binding_supported: false,
-                    connect_hint,
-                })
-                .await?;
+                // --all-targets onboards a repository in one invocation.
+                // The list comes from the API, not a Rust YAML parse: ADR-0089
+                // keeps exactly one parser for this file, and a second could
+                // disagree with it about where a deploy lands.
+                let targets: Vec<Option<String>> = if all_targets {
+                    let path = plugin_dir.join("deploy.yaml");
+                    let content = std::fs::read_to_string(&path).map_err(|err| {
+                        curie::exit::usage(format!(
+                            "--all-targets needs a deploy.yaml in the bundle, but {} could \
+                             not be read: {err}",
+                            path.display()
+                        ))
+                    })?;
+                    let listed = api::ApiClient::new(&api_url, &api_key)?
+                        .list_deploy_targets(&content)
+                        .await?;
+                    if listed.targets.is_empty() {
+                        bail!(
+                            "deploy.yaml declares no targets, so --all-targets has nothing to \
+                             deploy. Declare at least one (ADR-0089), or drop the flag and pass \
+                             --agent/--env/--slack-channel."
+                        );
+                    }
+                    ui::ui().note(&format!(
+                        "onboarding {} target(s): {}",
+                        listed.targets.len(),
+                        listed
+                            .targets
+                            .iter()
+                            .map(|t| t.name.as_str())
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    ));
+                    listed.targets.into_iter().map(|t| Some(t.name)).collect()
+                } else {
+                    vec![target]
+                };
 
-                // Stand up whatever the bundle's connectors.yaml declares
-                // (ADR-0086, #1063). After the deploy, so the objects exist
-                // before the next turn reaches for them; the credentials here
-                // are the CONNECTOR's, resolved locally and written straight to
-                // a K8s Secret, which is a different path from the sandbox
-                // secret delivery #440 tracks.
-                sync_connectors(
-                    &api_url,
-                    &api_key,
-                    &namespace,
-                    &release,
-                    &deployed.agent_id,
-                    &deployed.agent_name,
-                    &deployed.version_id,
-                )
-                .await?;
-                emit(deployed)
+                // Emits the LAST deploy, so `--json` still yields one object
+                // (cli/CLAUDE.md: a verb emits exactly one). The per-target
+                // progress is on the note above.
+                let mut last_deployed = None;
+                for target in targets {
+                    let deployed = commands::deploy(DeployOpts {
+                        plugin_dir: plugin_dir.clone(),
+                        agent: agent.clone(),
+                        target,
+                        api_url: api_url.clone(),
+                        api_key: api_key.clone(),
+                        slack_channel: slack_channel.clone(),
+                        repo: repo.clone(),
+                        env,
+                        label: label.clone(),
+                        // Cluster connector-secret delivery is deferred to #440; no
+                        // `--secret` flag on `cluster deploy` (see the note above).
+                        secret: Vec::new(),
+                        // Secret binding is not wired on cluster until #440, so the
+                        // declared-secrets policy gate (#464) is skipped here: it
+                        // would otherwise hard-fail every secrets-declaring bundle
+                        // with a `--secret <NAME>` remediation this tier lacks.
+                        secret_binding_supported: false,
+                        connect_hint: connect_hint.clone(),
+                    })
+                    .await?;
+
+                    // Stand up whatever the bundle's connectors.yaml declares
+                    // (ADR-0086, #1063). After the deploy, so the objects exist
+                    // before the next turn reaches for them; the credentials here
+                    // are the CONNECTOR's, resolved locally and written straight to
+                    // a K8s Secret, which is a different path from the sandbox
+                    // secret delivery #440 tracks.
+                    sync_connectors(
+                        &api_url,
+                        &api_key,
+                        &namespace,
+                        &release,
+                        &deployed.agent_id,
+                        &deployed.agent_name,
+                        &deployed.version_id,
+                    )
+                    .await?;
+                    last_deployed = Some(deployed);
+                }
+                emit(last_deployed.expect("the target list is never empty"))
             }
             ClusterAction::Kill {
                 agent,


### PR DESCRIPTION
Standing up an agent repository meant one `cluster deploy` per target, plus a trip to GitHub's webhook settings. Forgetting a target leaves an agent that exists and never updates — a failure with no error attached to it.

```bash
curie cluster deploy --all-targets
```

Deploys every target `deploy.yaml` declares. **Dev before prod**, so a run that fails part-way leaves prod on its previous version rather than ahead of a dev that never landed — recoverable in one direction only.

## The webhook step is gone, not automated

I started building a `curie cluster onboard` that would create the GitHub webhook for you. Then I realised commit polling (#1239, merged) makes the webhook **optional entirely**:

```yaml
api:
  commitPollIntervalSeconds: 60
```

Removing a setup step beats automating one. And automating it would have meant either widening the App beyond `Contents: Read` — giving Curie standing permission to rewrite webhooks on every repo it can see — or handling the operator's own GitHub token. Neither is worth it for something polling makes unnecessary.

So onboarding is now: **write `deploy.yaml`, run one command.**

## No second YAML parser

The target list comes from a new `POST /deploy-targets/list`, not from parsing `deploy.yaml` in Rust. ADR-0089 put the parser in the API precisely so the CLI and the validator cannot disagree about where a deploy lands, and the schema notes the Rust YAML ecosystem has no maintained `serde_yaml` successor to depend on.

I nearly added one anyway — caught it before writing the dependency.

Both endpoints now share one `_parse`, with a test asserting they reject an invalid file *identically*, so a second parser cannot creep back in through the new endpoint:

```
test_list_and_resolve_agree_on_an_invalid_file
```

## Verification

```
10 passed   deploy-target endpoints
37 test binaries pass, 0 failures   (Rust)
ruff + mypy clean
```

Behaviour checked by running it:

```
--all-targets with --target  -> error: cannot be used with '--target <TARGET>'
--all-targets, no deploy.yaml -> Error: --all-targets needs a deploy.yaml in the
                                 bundle, but ./deploy.yaml could not be read
```

Both committed manifests regenerated (`cli/command-manifest.json`, `apps/ui/src/generated/commandManifest.ts`), and the new mirror structs declared in `cli/api-mirrors.json` for the field-parity gate.

Refs #1239