### PR TITLE
Declare ARM Linux release binary

### DIFF
--- a/release/integrity.py
+++ b/release/integrity.py
@@ -41,6 +41,7 @@ SBOM_SUFFIX = ".spdx.json"
 # The CLI targets built by the `cli-binaries` job. Keep in lockstep with its matrix.
 BINARY_ASSETS = (
     "curie-x86_64-unknown-linux-gnu",
+    "curie-aarch64-unknown-linux-gnu",
     "curie-aarch64-apple-darwin",
 )
 COMPOSE_ASSET = "compose.release.yaml"

--- a/release/tests/test_integrity.py
+++ b/release/tests/test_integrity.py
@@ -25,7 +25,11 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = REPO_ROOT / "release" / "integrity.py"
 
 VERSION = "1.2.3"
-BINARIES = ("curie-x86_64-unknown-linux-gnu", "curie-aarch64-apple-darwin")
+BINARIES = (
+    "curie-x86_64-unknown-linux-gnu",
+    "curie-aarch64-unknown-linux-gnu",
+    "curie-aarch64-apple-darwin",
+)
 CHART = f"curie-{VERSION}.tgz"
 COMPOSE = "compose.release.yaml"
 ASSETS = (*BINARIES, CHART, COMPOSE)


### PR DESCRIPTION
Declares the existing ARM Linux CLI release artifact in the integrity contract so the release manifest covers its binary and SBOM.