### PR TITLE
Give the API's own loggers a level and a handler

### DIFF
--- a/apps/api/src/curie_api/config.py
+++ b/apps/api/src/curie_api/config.py
@@ -42,6 +42,12 @@ class Settings(BaseSettings):
     # brand the app. Overridable via ORG_NAME for a white-labeled deployment.
     org_name: str = "Curie"
 
+    # Level for this service's own loggers (#1270). The API has no entry point
+    # of its own -- uvicorn imports the app -- and uvicorn configures only its
+    # own three loggers with no root entry, so without this every
+    # `curie_api.*` INFO record is discarded by the last-resort handler.
+    log_level: str = "INFO"
+
     # Langfuse proxy target (the dev project keys baked into compose.dev.yaml).
     langfuse_host: str = "http://localhost:23000"
     langfuse_public_key: str = "pk-lf-curie-dev"

--- a/apps/api/src/curie_api/main.py
+++ b/apps/api/src/curie_api/main.py
@@ -5,6 +5,8 @@ startup and stored on app.state; dependencies (deps.py) read them per request.
 """
 
 import asyncio
+import logging
+import sys
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
@@ -213,7 +215,38 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         await engine.dispose()
 
 
+def configure_logging(level: str | None = None) -> logging.Logger:
+    """Give this service's loggers a level and a handler (#1270).
+
+    `uvicorn curie_api.main:app` configures only the `uvicorn*` loggers and no
+    root entry, so `curie_api.*` has an effective level of WARNING and no
+    handler -- every INFO record in the service is dropped by the last-resort
+    handler. That is production, not a local artifact: the Dockerfile runs bare
+    uvicorn.
+
+    Scoped to the `curie_api` logger rather than root, and `propagate` is off:
+    configuring root would fight uvicorn's own dictConfig and anything the OTel
+    wiring later attaches, and leaving propagation on would double-emit every
+    record through whatever root ends up with.
+
+    Idempotent. Tests construct many apps in one process, and a handler added
+    per construction would multiply every line.
+    """
+
+    resolved = (level or get_settings().log_level).upper()
+    logger = logging.getLogger("curie_api")
+    logger.setLevel(resolved)
+    logger.propagate = False
+    if not any(getattr(h, "_curie_api_handler", False) for h in logger.handlers):
+        handler = logging.StreamHandler(sys.stderr)
+        handler.setFormatter(logging.Formatter("%(levelname)s: %(name)s: %(message)s"))
+        handler._curie_api_handler = True  # type: ignore[attr-defined]
+        logger.addHandler(handler)
+    return logger
+
+
 def create_app() -> FastAPI:
+    configure_logging()
     app = FastAPI(title="Curie API", version="0.1.0", lifespan=lifespan)
 
     @app.get("/health", tags=["health"])

--- a/apps/api/tests/test_logging_config.py
+++ b/apps/api/tests/test_logging_config.py
@@ -1,0 +1,69 @@
+"""The service's own INFO records actually reach a handler (#1270).
+
+`uvicorn curie_api.main:app` -- the Dockerfile's literal command -- configures
+only the three `uvicorn*` loggers and no root entry. So `curie_api.*` had an
+effective level of WARNING and no handler, and every INFO record in the service
+was discarded by Python's last-resort handler. Not a local artifact: that is
+the production path.
+
+The lane that suffered most is the one with no fallback. A webhook delivery can
+be inspected in GitHub's UI; a polled deploy has nothing but these records.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from curie_api.main import configure_logging, create_app
+
+
+def test_a_curie_api_info_record_reaches_a_handler(caplog) -> None:
+    # The acceptance criterion, and the thing that was actually broken.
+    create_app()
+    with caplog.at_level(logging.INFO, logger="curie_api"):
+        logging.getLogger("curie_api.commitpoller").info("commit poller started")
+    assert any("commit poller started" in r.getMessage() for r in caplog.records)
+
+
+def test_the_logger_has_a_handler_and_an_info_level_after_construction() -> None:
+    # caplog installs its own handler, so the test above would pass even if
+    # nothing were configured. This asserts the configuration itself.
+    create_app()
+    logger = logging.getLogger("curie_api")
+    assert logger.level == logging.INFO
+    assert logger.handlers, "curie_api has no handler; INFO goes to the last-resort handler"
+    assert logger.isEnabledFor(logging.INFO)
+
+
+def test_constructing_many_apps_does_not_multiply_handlers() -> None:
+    # Tests build dozens of apps in one process. A handler added per
+    # construction would print every line dozens of times, which reads as a
+    # duplicate-work bug rather than a logging one.
+    create_app()
+    first = len(logging.getLogger("curie_api").handlers)
+    for _ in range(5):
+        create_app()
+    assert len(logging.getLogger("curie_api").handlers) == first
+
+
+def test_it_does_not_configure_the_root_logger() -> None:
+    # Root belongs to uvicorn's dictConfig and to whatever the OTel wiring
+    # attaches. Taking it over would fight both.
+    before = list(logging.getLogger().handlers)
+    create_app()
+    assert logging.getLogger().handlers == before
+
+
+def test_records_do_not_propagate_to_root() -> None:
+    # With our own handler AND propagation, a root handler configured later
+    # emits every record a second time.
+    create_app()
+    assert logging.getLogger("curie_api").propagate is False
+
+
+def test_the_level_is_configurable() -> None:
+    configure_logging("WARNING")
+    logger = logging.getLogger("curie_api")
+    assert not logger.isEnabledFor(logging.INFO)
+    configure_logging("INFO")
+    assert logger.isEnabledFor(logging.INFO)

--- a/charts/curie/templates/api.yaml
+++ b/charts/curie/templates/api.yaml
@@ -106,6 +106,11 @@ spec:
                   name: {{ include "curie.secretName" . }}
                   key: githubAppPrivateKey
                   {{- end }}
+            # Without this the service's own INFO records go nowhere (#1270):
+            # uvicorn configures only its own loggers, so curie_api sits at
+            # WARNING with no handler.
+            - name: LOG_LEVEL
+              value: {{ .Values.api.logLevel | quote }}
             - name: ENVIRONMENT
               value: {{ .Values.api.environment | quote }}
             - name: ORG_NAME

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -525,6 +525,10 @@ api:
   # limit becomes a false denial of a legitimate approver, so 0 suits low-volume
   # or strict-revocation deployments.
   slackUsergroupCacheTtlSeconds: 60
+  # Level for the API's own loggers (#1270). INFO surfaces the operator-facing
+  # records -- connector drift corrected, polled deploys, webhook outcomes --
+  # which were silently dropped before. WARNING to quieten it.
+  logLevel: INFO
   service:
     type: ClusterIP
     port: 8000


### PR DESCRIPTION
Every `curie_api.*` INFO record was discarded **in production**.

The Dockerfile runs bare `uvicorn curie_api.main:app`. uvicorn configures only its own three loggers with no `root` entry, and the API has no entry point of its own to call `basicConfig` — so `curie_api` sat at WARNING with no handler and Python's last-resort handler dropped everything below it.

Reproduced with the issue's own command, before and after:

```
before:  (nothing)
after:   INFO: curie_api.commitpoller: commit poller started interval=60.0s
```

## Two decisions worth stating

**Scoped to `curie_api`, not root.** Root belongs to uvicorn's dictConfig and to whatever the OTel wiring attaches later; taking it over would fight both. That's AC3.

**Propagation off.** With our own handler *and* propagation, a root handler configured later emits every record twice.

**Idempotent**, because the suite builds dozens of apps in one process — a handler per construction would print every line dozens of times, which reads as a duplicate-work bug rather than a logging one.

## Why it matters beyond the poller

The lane that suffers most is the one with no fallback. A webhook delivery can be inspected in GitHub's UI; a **polled** deploy has nothing but these records (#1268). On the sre-bot cluster today it also means the reconciler's `drift corrected` lines — the one action that overrides a human's `kubectl edit` — go nowhere.

## Tests

Six, including one that guards against the obvious trap: `caplog` installs its own handler, so an assertion using it alone would pass even with nothing configured. A second test asserts the configuration itself.

```
10 passed
```

Closes #1270