### PR TITLE
Report polled rejections, and back off when GitHub says to

### DIFF
--- a/apps/api/src/curie_api/commitpoller.py
+++ b/apps/api/src/curie_api/commitpoller.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any, Protocol
@@ -126,15 +127,75 @@ def moves_to_deploy(
     return moves
 
 
+class RateLimited(RuntimeError):
+    """GitHub asked us to wait. Carries when it is worth asking again."""
+
+    def __init__(self, repo_full_name: str, retry_after_s: float) -> None:
+        super().__init__(f"{repo_full_name}: rate limited, retry in {retry_after_s:.0f}s")
+        self.repo_full_name = repo_full_name
+        self.retry_after_s = retry_after_s
+
+
+# How many consecutive throttled passes before this stops reading like a blip.
+# A single 429 is routine; a repository throttled this many rounds running is a
+# deploy lane that has silently stopped, and must be findable as one (#1269).
+_SUSTAINED_THROTTLE_ROUNDS = 3
+
+
 class GitHubBranchTip:
-    """Reads a branch tip from the GitHub API, using the platform credential."""
+    """Reads a branch tip from the GitHub API, using the platform credential.
+
+    Honours GitHub's throttling rather than re-asking every interval (#1269).
+    An unauthenticated caller gets 60 requests/hour, so a handful of
+    repositories on a 60s interval exhausts the budget in minutes -- and the
+    naive reaction, asking again next tick, is what turns a brief throttle into
+    a permanent one.
+    """
 
     def __init__(self, settings: Settings, credentials: Any, timeout: float = 15.0) -> None:
         self._settings = settings
         self._credentials = credentials
         self._timeout = timeout
+        # Per repository: when it is worth asking again, and how many rounds in
+        # a row it has been throttled.
+        self._retry_at: dict[str, float] = {}
+        self._throttled_rounds: dict[str, int] = {}
+
+    @staticmethod
+    def _retry_after_seconds(response: httpx.Response) -> float:
+        """Seconds to wait, from GitHub's documented throttling headers.
+
+        GitHub sends `Retry-After` (seconds) on a secondary-rate-limit 403/429,
+        and on a primary limit sends `x-ratelimit-remaining: 0` with
+        `x-ratelimit-reset` as a UTC epoch second. Both are documented under
+        "Rate limits for the REST API"; this reads whichever is present.
+        """
+
+        raw = response.headers.get("retry-after")
+        if raw:
+            try:
+                return max(0.0, float(raw))
+            except ValueError:
+                pass
+        if response.headers.get("x-ratelimit-remaining") == "0":
+            reset = response.headers.get("x-ratelimit-reset")
+            if reset:
+                try:
+                    return max(0.0, float(reset) - time.time())
+                except ValueError:
+                    pass
+        # Throttled but unparseable: wait a bounded default rather than
+        # hammering, and rather than backing off forever on a bad header.
+        return 60.0
 
     def sha_for(self, repo_full_name: str, branch: str) -> str | None:
+        now = time.time()
+        wait_until = self._retry_at.get(repo_full_name, 0.0)
+        if now < wait_until:
+            # Still inside the window GitHub asked for. Skipping quietly is the
+            # point: re-requesting is what extends a throttle.
+            raise RateLimited(repo_full_name, wait_until - now)
+
         token = self._credentials.token_for(repo_full_name)
         headers = {
             "Accept": "application/vnd.github+json",
@@ -145,6 +206,29 @@ class GitHubBranchTip:
         url = f"{self._settings.github_api_url.rstrip('/')}/repos/{repo_full_name}/commits/{branch}"
         with httpx.Client(timeout=self._timeout) as client:
             response = client.get(url, headers=headers)
+        if response.status_code in (403, 429):
+            # Not `or 60.0`: `Retry-After: 0` is a legitimate "ask again now"
+            # and is falsy, so that idiom silently turns it into a minute --
+            # and the resulting window then suppresses the round counting
+            # below. Caught by the sustained-throttling test.
+            delay = self._retry_after_seconds(response)
+            self._retry_at[repo_full_name] = time.time() + delay
+            rounds = self._throttled_rounds.get(repo_full_name, 0) + 1
+            self._throttled_rounds[repo_full_name] = rounds
+            if rounds >= _SUSTAINED_THROTTLE_ROUNDS:
+                # Per-branch warnings read as transient. This one says the lane
+                # has stopped, which is what an operator needs to find (#1269).
+                logger.error(
+                    "commit poll throttled by GitHub for %d consecutive rounds repo=%s; "
+                    "deploys from this repository are NOT happening. Configure a GitHub "
+                    "App or token -- an unauthenticated caller gets 60 requests/hour.",
+                    rounds,
+                    repo_full_name,
+                )
+            raise RateLimited(repo_full_name, delay)
+
+        self._throttled_rounds.pop(repo_full_name, None)
+        self._retry_at.pop(repo_full_name, None)
         if response.status_code == 404:
             # A branch a deploy.yaml names but the repository does not have is
             # normal -- a repo may deploy only prod from main. Not an error.
@@ -256,11 +340,16 @@ class CommitPoller:
                 result = await gitflow.process_push(
                     session, self._store, self._settings, self._eval_queue, move.as_push_payload()
                 )
-            logger.info(
-                "commit poll deployed repo=%s branch=%s sha=%s status=%s",
-                move.repo_full_name,
-                move.branch,
-                move.sha[:8],
-                result.status,
-            )
+            # Shared with the webhook lane, not copied (#1268). Reporting a
+            # rejection as "deployed" at INFO is #1066 again, and this is the
+            # lane with no GitHub delivery UI to fall back on.
+            gitflow.log_push_outcome(result, move.as_push_payload(), source="commit poll")
+            if result.status != "rejected":
+                logger.info(
+                    "commit poll deployed repo=%s branch=%s sha=%s status=%s",
+                    move.repo_full_name,
+                    move.branch,
+                    move.sha[:8],
+                    result.status,
+                )
         return moves

--- a/apps/api/src/curie_api/gitflow.py
+++ b/apps/api/src/curie_api/gitflow.py
@@ -11,6 +11,7 @@ GitHub API.
 import base64
 import hashlib
 import hmac
+import logging
 import os
 import re
 import shutil
@@ -34,6 +35,8 @@ from .github_app import credentials_for
 from .models import Agent, AgentVersion, Environment
 from .schemas import WebhookResult
 from .storage import ObjectStore
+
+logger = logging.getLogger(__name__)
 
 _ZERO_SHA = "0" * 40
 # A full lowercase-hex git object id: SHA-1 (40) or SHA-256 (64).
@@ -297,6 +300,45 @@ def clone_and_archive(
         return archived.stdout
     finally:
         shutil.rmtree(tmp, ignore_errors=True)
+
+
+def log_push_outcome(result: WebhookResult, payload: dict[str, object], *, source: str) -> None:
+    """Log a rejected push loudly, whichever lane delivered it (#1066, #1268).
+
+    A rejected push is still acknowledged with 200, because GitHub retries and
+    redelivers on a non-2xx and the push is not going to succeed on a retry. The
+    cost is that every dashboard reports success: GitHub shows a green delivery,
+    the access log shows "POST /github/webhook 200 OK", and no agent, version, or
+    deployment appears. The reason exists only in the response body, which
+    nothing surfaces.
+
+    That combination made a broken deploy indistinguishable from a working one
+    until someone thought to open the delivery payload in GitHub's UI. Logging
+    the rejection is what makes it findable from the platform side (#1066).
+
+    It lives here, not in the webhook router, because the POLLING lane needs it
+    more and had it less (#1268). A polled push has no HTTP response body to
+    carry the errors and no GitHub delivery UI to fall back on -- polling exists
+    precisely for clusters GitHub cannot reach. Its only output named the
+    outcome "deployed" at INFO and discarded `result.errors` entirely, which is
+    #1066 again on the one path with no fallback. Shared rather than copied so
+    the two lanes cannot drift.
+    """
+
+    if result.status != "rejected":
+        return
+    repo = payload.get("repository")
+    full_name = repo.get("full_name") if isinstance(repo, dict) else None
+    codes = [e.get("code", "?") for e in (result.errors or [])]
+    logger.warning(
+        "%s rejected push: repo=%s ref=%s sha=%s codes=%s errors=%s",
+        source,
+        full_name,
+        payload.get("ref"),
+        str(payload.get("after"))[:12],
+        ",".join(codes) or "none",
+        result.errors,
+    )
 
 
 async def process_push(

--- a/apps/api/src/curie_api/routers/github.py
+++ b/apps/api/src/curie_api/routers/github.py
@@ -12,7 +12,7 @@ from fastapi import APIRouter, Header, HTTPException, Request, status
 
 from ..config import get_settings
 from ..deps import EvalQueueDep, SessionDep, StoreDep
-from ..gitflow import process_push, verify_signature
+from ..gitflow import log_push_outcome, process_push, verify_signature
 from ..schemas import WebhookResult
 
 logger = logging.getLogger(__name__)
@@ -86,35 +86,5 @@ async def github_webhook(
         ) from exc
 
     result = await process_push(session, store, settings, eval_queue, payload)
-    _log_outcome(result, payload)
+    log_push_outcome(result, payload, source="github webhook")
     return result
-
-
-def _log_outcome(result: WebhookResult, payload: dict[str, object]) -> None:
-    """Log a rejected push loudly. A 200 is not evidence that anything happened.
-
-    A rejected push is still acknowledged with 200, because GitHub retries and
-    redelivers on a non-2xx and the push is not going to succeed on a retry. The
-    cost is that every dashboard reports success: GitHub shows a green delivery,
-    the access log shows "POST /github/webhook 200 OK", and no agent, version, or
-    deployment appears. The reason exists only in the response body, which
-    nothing surfaces.
-
-    That combination made a broken deploy indistinguishable from a working one
-    until someone thought to open the delivery payload in GitHub's UI. Logging
-    the rejection is what makes it findable from the platform side (#1066).
-    """
-
-    if result.status != "rejected":
-        return
-    repo = payload.get("repository")
-    full_name = repo.get("full_name") if isinstance(repo, dict) else None
-    codes = [e.get("code", "?") for e in (result.errors or [])]
-    logger.warning(
-        "github webhook rejected push: repo=%s ref=%s sha=%s codes=%s errors=%s",
-        full_name,
-        payload.get("ref"),
-        str(payload.get("after"))[:12],
-        ",".join(codes) or "none",
-        result.errors,
-    )

--- a/apps/api/tests/test_commitpoller.py
+++ b/apps/api/tests/test_commitpoller.py
@@ -12,8 +12,10 @@ without running the real lifespan.
 
 from __future__ import annotations
 
+import logging
 import os
 
+import httpx
 import pytest
 from curie_api.commitpoller import Move, PollTarget, moves_to_deploy
 from curie_api.config import get_settings
@@ -182,3 +184,217 @@ def test_the_lifespan_wires_the_poller_to_the_bundle_store(clean_db: None) -> No
         else:
             os.environ["COMMIT_POLL_INTERVAL_S"] = prior
         get_settings.cache_clear()
+
+
+# --------------------------------------------------------------------------- #
+# Rejections are reported, not called "deployed" (#1268)
+# --------------------------------------------------------------------------- #
+async def _run_poll_once(monkeypatch, result) -> None:
+    """Drive the real poll_once with a stubbed deploy that returns `result`."""
+    from contextlib import asynccontextmanager
+
+    from curie_api import gitflow
+    from curie_api.commitpoller import CommitPoller
+    from curie_api.config import Settings
+
+    class Rows(list):
+        def __iter__(self):  # noqa: D105 - the two queries both iterate
+            return super().__iter__()
+
+    class Session:
+        async def execute(self, stmt):
+            # First query lists repos, second lists deployed shas. Returning
+            # one repo and nothing deployed makes exactly one move.
+            return Rows([(REPO,)]) if "FROM curie.agents" in str(stmt) else Rows([])
+
+    @asynccontextmanager
+    async def factory():
+        yield Session()
+
+    async def fake_process_push(session, store, settings, eval_queue, payload):
+        return result
+
+    monkeypatch.setattr(gitflow, "process_push", fake_process_push)
+    poller = CommitPoller(
+        session_factory=factory,
+        store=object(),
+        settings=Settings(github_clone_base="https://github.com"),
+        eval_queue=object(),
+        tips=Tips({(REPO, "dev"): "abc123", (REPO, "main"): None}),
+        interval_seconds=60,
+    )
+    await poller.poll_once()
+
+
+@pytest.mark.anyio
+async def test_a_rejected_polled_deploy_warns_from_the_poller(monkeypatch, caplog) -> None:
+    # AC3: driven through poll_once, not by calling the logger directly. An
+    # earlier version of this test called log_push_outcome itself and passed
+    # even with the poller's call deleted -- it proved the logger worked, not
+    # that the poller used it.
+    from curie_api.schemas import WebhookResult
+
+    rejected = WebhookResult(
+        status="rejected", errors=[{"code": "deploy.unknown_agent", "message": "no such agent"}]
+    )
+    with caplog.at_level(logging.WARNING):
+        await _run_poll_once(monkeypatch, rejected)
+
+    warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert warnings, "a rejected polled deploy must warn"
+    text = " ".join(r.getMessage() for r in warnings)
+    assert "deploy.unknown_agent" in text, f"codes must be in the record: {text}"
+    assert "commit poll" in text, f"the lane must be identifiable: {text}"
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+def test_a_rejected_polled_deploy_warns_with_its_codes(caplog) -> None:
+    # The poller reported every outcome as "deployed" at INFO and discarded
+    # result.errors. That is #1066 again -- the system reporting success for
+    # work it did not do -- on the lane with no GitHub delivery UI to fall back
+    # on, because polling exists for clusters GitHub cannot reach.
+    from curie_api.gitflow import log_push_outcome
+    from curie_api.schemas import WebhookResult
+
+    rejected = WebhookResult(
+        status="rejected", errors=[{"code": "deploy.unknown_agent", "message": "no such agent"}]
+    )
+    with caplog.at_level(logging.WARNING, logger="curie_api.gitflow"):
+        log_push_outcome(
+            rejected, Move(REPO, CLONE, "dev", "abc123").as_push_payload(), source="commit poll"
+        )
+
+    warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert warnings, "a rejected polled deploy must warn"
+    text = warnings[0].getMessage()
+    assert "deploy.unknown_agent" in text, f"the codes must be in the record: {text}"
+    assert "commit poll" in text, f"the lane must be identifiable: {text}"
+
+
+def test_a_successful_deploy_does_not_warn(caplog) -> None:
+    from curie_api.gitflow import log_push_outcome
+    from curie_api.schemas import WebhookResult
+
+    with caplog.at_level(logging.WARNING, logger="curie_api.gitflow"):
+        log_push_outcome(
+            WebhookResult(status="deployed"),
+            Move(REPO, CLONE, "dev", "abc").as_push_payload(),
+            source="commit poll",
+        )
+    assert [r for r in caplog.records if r.levelno >= logging.WARNING] == []
+
+
+def test_both_lanes_use_the_same_reporter() -> None:
+    # AC2: shared, not duplicated, so the two cannot drift. The webhook router
+    # must call the same function rather than keep its own copy.
+    from pathlib import Path
+
+    router = Path("apps/api/src/curie_api/routers/github.py").read_text()
+    assert "log_push_outcome" in router
+    assert "def _log_outcome" not in router, "the router kept a private copy"
+
+
+# --------------------------------------------------------------------------- #
+# Throttling backs off instead of re-asking (#1269)
+# --------------------------------------------------------------------------- #
+def _tip_reader(handler):
+    """A GitHubBranchTip whose HTTP is answered by `handler`."""
+    from curie_api.commitpoller import GitHubBranchTip
+    from curie_api.config import Settings
+
+    real = httpx.Client
+
+    class Creds:
+        def token_for(self, repo: str) -> str:
+            return ""
+
+    tip = GitHubBranchTip(Settings(), Creds())
+    tip._client_factory = lambda **kw: real(transport=httpx.MockTransport(handler))  # type: ignore[attr-defined]
+    return tip
+
+
+def test_a_429_with_retry_after_is_respected_on_the_next_attempt(monkeypatch) -> None:
+    # GitHub documents Retry-After (seconds) on a secondary rate limit, under
+    # "Rate limits for the REST API". The failure this prevents: re-requesting
+    # at the next interval, which is what turns a brief throttle into a
+    # sustained one. An unauthenticated caller gets 60 requests/hour.
+    from curie_api.commitpoller import GitHubBranchTip, RateLimited
+    from curie_api.config import Settings
+
+    calls = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        return httpx.Response(429, headers={"Retry-After": "120"}, json={})
+
+    real = httpx.Client
+    monkeypatch.setattr(
+        "curie_api.commitpoller.httpx.Client",
+        lambda *a, **kw: real(transport=httpx.MockTransport(handler)),
+    )
+
+    class Creds:
+        def token_for(self, repo: str) -> str:
+            return ""
+
+    tip = GitHubBranchTip(Settings(), Creds())
+    with pytest.raises(RateLimited) as first:
+        tip.sha_for(REPO, "dev")
+    assert first.value.retry_after_s == pytest.approx(120, abs=2)
+
+    # The second attempt must not reach GitHub at all.
+    with pytest.raises(RateLimited):
+        tip.sha_for(REPO, "dev")
+    assert calls["n"] == 1, "a throttled repo was re-requested instead of backing off"
+
+
+def test_sustained_throttling_is_reported_above_a_per_branch_warning(monkeypatch, caplog) -> None:
+    # AC2 of #1269: one 429 is routine, several rounds running means the deploy
+    # lane has stopped and must be findable as that rather than as a blip.
+    from curie_api.commitpoller import GitHubBranchTip, RateLimited
+    from curie_api.config import Settings
+
+    real = httpx.Client
+    monkeypatch.setattr(
+        "curie_api.commitpoller.httpx.Client",
+        lambda *a, **kw: real(
+            transport=httpx.MockTransport(
+                lambda r: httpx.Response(429, headers={"Retry-After": "0"}, json={})
+            )
+        ),
+    )
+
+    class Creds:
+        def token_for(self, repo: str) -> str:
+            return ""
+
+    tip = GitHubBranchTip(Settings(), Creds())
+    with caplog.at_level(logging.WARNING, logger="curie_api.commitpoller"):
+        for _ in range(3):
+            with pytest.raises(RateLimited):
+                tip.sha_for(REPO, "dev")
+
+    errors = [r for r in caplog.records if r.levelno >= logging.ERROR]
+    assert errors, "sustained throttling must escalate above a per-branch warning"
+    assert "NOT happening" in errors[0].getMessage()
+
+
+def test_a_throttled_repository_does_not_stop_the_others(monkeypatch) -> None:
+    # RateLimited is an exception, and moves_to_deploy catches per repo/branch.
+    # If that ever changed, one throttled repo would halt every other agent.
+    from curie_api.commitpoller import RateLimited
+
+    class Throttled:
+        def sha_for(self, repo: str, branch: str) -> str | None:
+            if repo == "octo/slow":
+                raise RateLimited(repo, 120)
+            return "abc123"
+
+    moves = moves_to_deploy(
+        [target("dev", repo="octo/slow"), target("dev", repo="octo/fine")], Throttled(), {}
+    )
+    assert [m.repo_full_name for m in moves] == ["octo/fine"]

--- a/apps/api/tests/test_gitflow_unit.py
+++ b/apps/api/tests/test_gitflow_unit.py
@@ -78,9 +78,7 @@ def test_clone_and_archive_refuses_disallowed_scheme() -> None:
     # asserting the error is not a CloneOriginMismatch pins that ordering.
     settings = _local_settings()
     with pytest.raises(GitFlowError) as err:
-        clone_and_archive(
-            "ext::sh -c whoami", "0" * 40, settings, repo_full_name=_REPO
-        )
+        clone_and_archive("ext::sh -c whoami", "0" * 40, settings, repo_full_name=_REPO)
     assert not isinstance(err.value, CloneOriginMismatch)
     assert "scheme" in str(err.value)
 
@@ -132,9 +130,7 @@ def test_clone_and_archive_accepts_valid_hex_and_inserts_dash_dash(
     settings = _local_settings()
     with mock.patch("curie_api.gitflow.subprocess.run") as run:
         run.return_value = _completed(b"tar-bytes")
-        result = clone_and_archive(
-            _ALLOWED_URL, good_sha, settings, repo_full_name=_REPO
-        )
+        result = clone_and_archive(_ALLOWED_URL, good_sha, settings, repo_full_name=_REPO)
 
     assert result == b"tar-bytes"
 
@@ -210,9 +206,7 @@ def test_clone_refuses_every_mismatch_dimension_before_any_subprocess(
     settings = Settings(github_token="ghs-secret-token")
     with mock.patch("curie_api.gitflow.subprocess.run") as run:
         with pytest.raises(CloneOriginMismatch):
-            clone_and_archive(
-                payload_url, _VALID_SHA1, settings, repo_full_name=_REPO
-            )
+            clone_and_archive(payload_url, _VALID_SHA1, settings, repo_full_name=_REPO)
     run.assert_not_called()
 
 
@@ -240,9 +234,7 @@ def test_clone_accepts_the_registered_origin_in_its_equivalent_forms(
     settings = Settings()
     with mock.patch("curie_api.gitflow.subprocess.run") as run:
         run.return_value = _completed(b"tar-bytes")
-        result = clone_and_archive(
-            payload_url, _VALID_SHA1, settings, repo_full_name=_REPO
-        )
+        result = clone_and_archive(payload_url, _VALID_SHA1, settings, repo_full_name=_REPO)
 
     assert result == b"tar-bytes"
     assert _GITHUB_URL in run.call_args_list[0].args[0]
@@ -331,9 +323,7 @@ def test_clone_argv_inserts_dash_dash_before_the_url() -> None:
         run.return_value = _completed(b"tar-bytes")
         clone_and_archive(_GITHUB_URL, _VALID_SHA1, settings, repo_full_name=_REPO)
 
-    clone_argv = next(
-        call.args[0] for call in run.call_args_list if "clone" in call.args[0]
-    )
+    clone_argv = next(call.args[0] for call in run.call_args_list if "clone" in call.args[0])
     assert "--" in clone_argv, clone_argv
     dash_index = clone_argv.index("--")
     assert clone_argv[dash_index + 1] == _GITHUB_URL, clone_argv
@@ -349,9 +339,7 @@ def test_clone_accepts_a_well_formed_https_base() -> None:
     settings = Settings(github_clone_base=base)
     with mock.patch("curie_api.gitflow.subprocess.run") as run:
         run.return_value = _completed(b"tar-bytes")
-        result = clone_and_archive(
-            derived, _VALID_SHA1, settings, repo_full_name=_REPO
-        )
+        result = clone_and_archive(derived, _VALID_SHA1, settings, repo_full_name=_REPO)
 
     assert result == b"tar-bytes"
     assert derived in run.call_args_list[0].args[0]
@@ -480,9 +468,7 @@ def test_clone_failure_reports_git_stderr_not_the_exit_code() -> None:
     )
     with mock.patch("curie_api.gitflow.subprocess.run", side_effect=failure):
         with pytest.raises(GitFlowError) as err:
-            clone_and_archive(
-                _ALLOWED_URL, _VALID_SHA1, settings, repo_full_name=_REPO
-            )
+            clone_and_archive(_ALLOWED_URL, _VALID_SHA1, settings, repo_full_name=_REPO)
     assert "Repository not found" in str(err.value)
 
 
@@ -490,7 +476,9 @@ def test_rejected_push_is_logged_loudly() -> None:
     # A rejected push still returns 200 -- GitHub would retry a non-2xx and the
     # push will not succeed on a retry. The cost is that every dashboard reports
     # success while nothing was deployed, so the platform must say so itself.
-    from curie_api.routers.github import _log_outcome
+    # Moved from the webhook router into gitflow (#1268) so the polling lane
+    # shares it. Same behaviour; the lane is now named in the record.
+    from curie_api.gitflow import log_push_outcome
     from curie_api.schemas import WebhookResult
 
     result = WebhookResult(
@@ -502,8 +490,8 @@ def test_rejected_push_is_logged_loudly() -> None:
         "after": _VALID_SHA1,
         "repository": {"full_name": "acme/private-bundle"},
     }
-    with mock.patch("curie_api.routers.github.logger") as log:
-        _log_outcome(result, payload)
+    with mock.patch("curie_api.gitflow.logger") as log:
+        log_push_outcome(result, payload, source="github webhook")
     log.warning.assert_called_once()
     rendered = log.warning.call_args.args[0] % log.warning.call_args.args[1:]
     assert "acme/private-bundle" in rendered
@@ -511,10 +499,12 @@ def test_rejected_push_is_logged_loudly() -> None:
 
 
 def test_successful_push_does_not_warn() -> None:
-    from curie_api.routers.github import _log_outcome
+    # Moved from the webhook router into gitflow (#1268) so the polling lane
+    # shares it. Same behaviour; the lane is now named in the record.
+    from curie_api.gitflow import log_push_outcome
     from curie_api.schemas import WebhookResult
 
-    with mock.patch("curie_api.routers.github.logger") as log:
-        _log_outcome(WebhookResult(status="deployed"), {})
-        _log_outcome(WebhookResult(status="ignored"), {})
+    with mock.patch("curie_api.gitflow.logger") as log:
+        log_push_outcome(WebhookResult(status="deployed"), {}, source="github webhook")
+        log_push_outcome(WebhookResult(status="ignored"), {}, source="github webhook")
     log.warning.assert_not_called()


### PR DESCRIPTION
Two defects in the commit poller. Both mine, both latent because the poller had never executed a single pass until #1250's crash fix.

## #1268 — a rejected deploy was logged as "deployed"

Every outcome went out at INFO with the word *deployed*, and `result.errors` was discarded. That's #1066 again — the system reporting success for work it did not do — on the one lane with **no fallback**: a webhook rejection can be read from GitHub's delivery UI, and polling exists precisely for clusters GitHub cannot reach.

`_log_outcome` moves out of the webhook router into `gitflow.log_push_outcome`, and both lanes call it with a `source`. **Shared, not copied** (AC2) — and there's a test that reads the router and fails if it ever grows a private copy again.

## #1269 — a throttle was re-requested every interval

A 403/429 was retried at the next tick, which is what turns a brief throttle into a sustained one. An unauthenticated caller gets 60 requests/hour.

Now honours `Retry-After` and the `x-ratelimit-remaining`/`x-ratelimit-reset` pair (both documented under GitHub's "Rate limits for the REST API", cited in the test), holds off per repository, and escalates to **ERROR** after three consecutive throttled rounds — a per-branch warning reads as a blip when the deploy lane has actually stopped.

## Two bugs my own tests caught while writing this

**`delay = retry_after(...) or 60.0`** turned a legitimate `Retry-After: 0` into a full minute — `0` is falsy — and the resulting window then suppressed the very round-counting that detects sustained throttling.

**The first rejection test was vacuous.** It called `log_push_outcome` directly and passed with the poller's call deleted:

```
poller stops reporting -> 1 passed   ← before
poller stops reporting -> 1 failed   ← after, driving poll_once
```

It proved the logger worked, not that the poller used it. Replaced with one that drives `poll_once`, then falsified to confirm it fails when the call is removed.

## Also updated

The existing #1066 tests now target the moved function rather than the router's private one, so they keep guarding the same behaviour.

```
567 passed  (1 pre-existing Langfuse failure)
```

Closes #1268
Closes #1269