### PR TITLE
Make the App and poller tests actually constrain behaviour

### DIFF
--- a/apps/api/src/curie_api/commitpoller.py
+++ b/apps/api/src/curie_api/commitpoller.py
@@ -293,8 +293,13 @@ class CommitPoller:
         while True:
             try:
                 await self.poll_once()
-            except asyncio.CancelledError:
-                raise
+            # No `except CancelledError: raise` here, deliberately.
+            # CancelledError derives from BaseException, not Exception, so the
+            # handler below never catches it and cancellation propagates on its
+            # own. The clause that used to sit here was dead code that only
+            # looked protective -- and a mutation replacing its `raise` with
+            # `continue` was a real shutdown hang that no test could kill,
+            # because a task ignoring cancellation cannot be stopped (#1263).
             except Exception:
                 # A poll pass must never kill the loop: the next one may well
                 # succeed, and a dead poller on an unreachable cluster means no

--- a/apps/api/tests/test_commitpoller.py
+++ b/apps/api/tests/test_commitpoller.py
@@ -12,6 +12,7 @@ without running the real lifespan.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 
@@ -128,16 +129,24 @@ def test_the_payload_is_shaped_like_a_real_webhook() -> None:
     assert payload["repository"]["clone_url"] == CLONE
 
 
-def test_the_payload_carries_the_derived_clone_url() -> None:
-    # gitflow rejects a push whose clone_url does not match the one derived
-    # from configuration. The poller supplies that derived URL, so a polled
-    # deploy passes the origin check by construction -- not by coincidence.
+@pytest.mark.anyio
+async def test_poll_once_sends_the_derived_clone_url_not_an_arbitrary_one(
+    monkeypatch,
+) -> None:
+    """The origin check must hold for what poll_once ACTUALLY sends.
+
+    This asserted the property against a hand-built `Move`, so replacing the
+    real derivation inside poll_once with `https://evil.example/x.git` left it
+    green (#1263). It was named for a security property and tested a
+    constructor. Driving poll_once is the only version that means anything.
+    """
+
     from curie_api.config import Settings
     from curie_api.gitflow import trusted_clone_url
 
+    seen = await _capture_pushes(monkeypatch)
     derived = trusted_clone_url(REPO, Settings(github_clone_base="https://github.com"))
-    payload = Move(REPO, derived, "dev", "abc123").as_push_payload()
-    assert payload["repository"]["clone_url"] == derived
+    assert [p["repository"]["clone_url"] for p in seen] == [derived]
 
 
 @pytest.mark.parametrize("branches", [(), ("dev",), ("dev", "main")])
@@ -189,7 +198,28 @@ def test_the_lifespan_wires_the_poller_to_the_bundle_store(clean_db: None) -> No
 # --------------------------------------------------------------------------- #
 # Rejections are reported, not called "deployed" (#1268)
 # --------------------------------------------------------------------------- #
-async def _run_poll_once(monkeypatch, result) -> None:
+async def _capture_pushes(monkeypatch, *, deployed=None, tips=None) -> list[dict]:
+    """Run one real poll_once and return every payload it handed the deploy path.
+
+    The point of driving the real method: every mutation the battery found
+    living in poll_once -- a swapped branch mapping, ignored deployed-state, a
+    forged clone_url, deploying nothing at all -- is invisible to a test that
+    builds a Move by hand (#1263).
+    """
+
+    seen: list[dict] = []
+
+    async def capture(session, store, settings, eval_queue, payload):
+        from curie_api.schemas import WebhookResult
+
+        seen.append(payload)
+        return WebhookResult(status="deployed")
+
+    await _run_poll_once(monkeypatch, None, on_push=capture, deployed=deployed, tips=tips)
+    return seen
+
+
+async def _run_poll_once(monkeypatch, result, *, on_push=None, deployed=None, tips=None) -> None:
     """Drive the real poll_once with a stubbed deploy that returns `result`."""
     from contextlib import asynccontextmanager
 
@@ -203,9 +233,11 @@ async def _run_poll_once(monkeypatch, result) -> None:
 
     class Session:
         async def execute(self, stmt):
-            # First query lists repos, second lists deployed shas. Returning
-            # one repo and nothing deployed makes exactly one move.
-            return Rows([(REPO,)]) if "FROM curie.agents" in str(stmt) else Rows([])
+            # First query lists repos, second lists (repo, environment, sha)
+            # already deployed. Both come from the real SQL in the module.
+            if "FROM curie.agents" in str(stmt):
+                return Rows([(REPO,)])
+            return Rows(deployed or [])
 
     @asynccontextmanager
     async def factory():
@@ -214,13 +246,13 @@ async def _run_poll_once(monkeypatch, result) -> None:
     async def fake_process_push(session, store, settings, eval_queue, payload):
         return result
 
-    monkeypatch.setattr(gitflow, "process_push", fake_process_push)
+    monkeypatch.setattr(gitflow, "process_push", on_push or fake_process_push)
     poller = CommitPoller(
         session_factory=factory,
         store=object(),
         settings=Settings(github_clone_base="https://github.com"),
         eval_queue=object(),
-        tips=Tips({(REPO, "dev"): "abc123", (REPO, "main"): None}),
+        tips=tips or Tips({(REPO, "dev"): "abc123", (REPO, "main"): None}),
         interval_seconds=60,
     )
     await poller.poll_once()
@@ -398,3 +430,134 @@ def test_a_throttled_repository_does_not_stop_the_others(monkeypatch) -> None:
         [target("dev", repo="octo/slow"), target("dev", repo="octo/fine")], Throttled(), {}
     )
     assert [m.repo_full_name for m in moves] == ["octo/fine"]
+
+
+# --------------------------------------------------------------------------- #
+# poll_once, driven for real (#1263)
+# --------------------------------------------------------------------------- #
+@pytest.mark.anyio
+async def test_poll_once_actually_deploys_something(monkeypatch) -> None:
+    # The floor. "deploys nothing at all" survived the whole suite, because
+    # nothing drove the method.
+    assert await _capture_pushes(monkeypatch), "poll_once handed the deploy path nothing"
+
+
+@pytest.mark.anyio
+async def test_poll_once_maps_dev_to_the_dev_branch(monkeypatch) -> None:
+    # Swapping the dev/prod branch mapping survived (#1263). The consequence is
+    # the worst kind: a dev push deploying to the prod agent, reported as
+    # success.
+    seen = await _capture_pushes(monkeypatch)
+    assert [p["ref"] for p in seen] == ["refs/heads/dev"]
+
+
+@pytest.mark.anyio
+async def test_poll_once_skips_a_commit_already_deployed(monkeypatch) -> None:
+    """Ignoring already-deployed state survived, and is a redeploy loop.
+
+    Every pass would redeploy every agent at the poll interval -- forever, with
+    each one logged as a success.
+    """
+
+    seen = await _capture_pushes(monkeypatch, deployed=[(REPO, "dev", "abc123")])
+    assert seen == [], f"redeployed a commit already recorded: {seen}"
+
+
+@pytest.mark.anyio
+async def test_poll_once_deploys_when_the_recorded_sha_differs(monkeypatch) -> None:
+    # The other half: "skip everything" must not pass the test above.
+    seen = await _capture_pushes(monkeypatch, deployed=[(REPO, "dev", "OLD0000")])
+    assert [p["after"] for p in seen] == ["abc123"]
+
+
+@pytest.mark.anyio
+async def test_run_forever_stops_when_cancelled() -> None:
+    """Shutdown cancels this task and awaits it; it must actually end.
+
+    Scope, stated honestly: this proves the loop is cancellable. It does NOT
+    prove that a CancelledError handler swallowing the cancellation would be
+    caught -- an idle poller spends nearly all its time in the interval sleep,
+    which sits outside the try, so cancellation there propagates whatever any
+    handler does. A version of this test that cancelled mid-pass could catch
+    that, but only by creating a task that ignores cancellation, which cannot
+    then be stopped and hangs the suite instead of failing it.
+
+    What protects that property is structural instead: run_forever has no
+    CancelledError handler at all, because CancelledError derives from
+    BaseException and the `except Exception` below cannot catch it. There is no
+    live code path to test -- which is why the guard was deleted rather than
+    covered with an assertion it would not earn (#1263).
+    """
+
+    from curie_api.commitpoller import CommitPoller
+    from curie_api.config import Settings
+
+    class Boom:
+        def sha_for(self, repo: str, branch: str) -> str | None:
+            raise RuntimeError("every pass fails; the loop must still be cancellable")
+
+    poller = CommitPoller(
+        session_factory=None,
+        store=None,
+        settings=Settings(),
+        eval_queue=None,
+        tips=Boom(),
+        interval_seconds=0.01,
+    )
+    task = asyncio.create_task(poller.run_forever())
+    await asyncio.sleep(0.05)
+    task.cancel()
+    _, pending = await asyncio.wait([task], timeout=2.0)
+    assert not pending, "run_forever did not stop when cancelled"
+    assert task.cancelled()
+
+
+# --------------------------------------------------------------------------- #
+# GitHubBranchTip's HTTP behaviour (#1263)
+# --------------------------------------------------------------------------- #
+def _tip(monkeypatch, handler, token: str = "ghs_tok"):
+    from curie_api.commitpoller import GitHubBranchTip
+    from curie_api.config import Settings
+
+    real = httpx.Client
+    monkeypatch.setattr(
+        "curie_api.commitpoller.httpx.Client",
+        lambda *a, **kw: real(transport=httpx.MockTransport(handler)),
+    )
+
+    class Creds:
+        def token_for(self, repo: str) -> str:
+            return token
+
+    return GitHubBranchTip(Settings(), Creds())
+
+
+def test_the_tip_reader_authenticates(monkeypatch) -> None:
+    # Never sending Authorization survived (#1263). On a private repo that is a
+    # 404 -- which this code treats as "branch does not exist" -- so the agent
+    # silently stops deploying and nothing reports an auth problem.
+    seen: dict[str, str | None] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["auth"] = request.headers.get("authorization")
+        return httpx.Response(200, json={"sha": "abc123"})
+
+    _tip(monkeypatch, handler).sha_for(REPO, "dev")
+    assert seen["auth"] == "Bearer ghs_tok"
+
+
+def test_a_server_error_is_raised_not_read_as_a_missing_branch(monkeypatch) -> None:
+    # Treating every status as OK survived (#1263). A 500 would parse as an
+    # empty body, yield no sha, and look exactly like a branch that does not
+    # exist -- so an outage reads as "nothing to deploy".
+    tip = _tip(monkeypatch, lambda r: httpx.Response(500, json={}))
+    with pytest.raises(httpx.HTTPStatusError):
+        tip.sha_for(REPO, "dev")
+
+
+def test_a_404_is_still_a_missing_branch(monkeypatch) -> None:
+    # The deliberate exception: a deploy.yaml may name a branch a repo has not
+    # created. This must stay non-fatal, or the test above would be satisfied
+    # by raising on everything.
+    tip = _tip(monkeypatch, lambda r: httpx.Response(404, json={}))
+    assert tip.sha_for(REPO, "nope") is None

--- a/apps/api/tests/test_github_app.py
+++ b/apps/api/tests/test_github_app.py
@@ -8,9 +8,12 @@ every push or a dead token served until restart.
 
 from __future__ import annotations
 
+import time
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import httpx
+import jwt
 import pytest
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
@@ -157,13 +160,119 @@ def test_a_second_push_reuses_the_cached_token(private_key: str, github: Recorde
 
 
 def test_a_near_expiry_token_is_reminted(private_key: str, monkeypatch) -> None:
-    # Serving a token that dies mid-clone is the failure this margin prevents.
-    recorder = Recorder(expires_at="1971-01-01T00:00:00Z")
+    """A token inside the refresh margin is re-minted before it can expire.
+
+    This used `1971-01-01`, already long past, so it proved only that an
+    EXPIRED token is replaced -- deleting the 300s margin entirely left it
+    green (#1263). The margin exists for a token that is still valid now and
+    will not be by the time a clone finishes, so the expiry has to sit in the
+    future and inside the margin for the assertion to mean anything.
+    """
+
+    from curie_api.github_app import _TOKEN_REFRESH_MARGIN_SECONDS
+
+    soon = datetime.now(UTC) + timedelta(seconds=_TOKEN_REFRESH_MARGIN_SECONDS / 2)
+    recorder = Recorder(expires_at=soon.strftime("%Y-%m-%dT%H:%M:%SZ"))
     monkeypatch.setattr("curie_api.github_app.httpx.Client", serve(recorder.handle))
     creds = GitHubCredentials(settings=app_settings(private_key))
     creds.token_for(REPO)
     creds.token_for(REPO)
     assert recorder.minted == 2
+
+
+def test_a_token_comfortably_outside_the_margin_is_reused(private_key: str, monkeypatch) -> None:
+    """The other side of the margin: still-fresh tokens are NOT re-minted.
+
+    Without this, "re-mint whenever asked" also passes the test above, and the
+    cache stops being a cache.
+    """
+
+    from curie_api.github_app import _TOKEN_REFRESH_MARGIN_SECONDS
+
+    later = datetime.now(UTC) + timedelta(seconds=_TOKEN_REFRESH_MARGIN_SECONDS * 4)
+    recorder = Recorder(expires_at=later.strftime("%Y-%m-%dT%H:%M:%SZ"))
+    monkeypatch.setattr("curie_api.github_app.httpx.Client", serve(recorder.handle))
+    creds = GitHubCredentials(settings=app_settings(private_key))
+    creds.token_for(REPO)
+    creds.token_for(REPO)
+    assert recorder.minted == 1
+
+
+def test_an_unparseable_expiry_is_not_treated_as_immortal(private_key: str, monkeypatch) -> None:
+    """A garbled expiry must fall back to an hour, not to forever.
+
+    Caching a token as never-expiring fails every clone after it dies, until
+    someone restarts the pod -- and the log says "authentication", not
+    "expired". Treating it as immortal survived the suite (#1263).
+    """
+
+    recorder = Recorder(expires_at="not-a-timestamp")
+    monkeypatch.setattr("curie_api.github_app.httpx.Client", serve(recorder.handle))
+    creds = GitHubCredentials(settings=app_settings(private_key))
+    creds.token_for(REPO)
+    cached = creds._tokens[REPO]
+    assumed = cached.expires_at - time.time()
+    assert 3000 < assumed < 4200, f"expected the documented ~1h fallback, got {assumed:.0f}s"
+
+
+# --------------------------------------------------------------------------- #
+# The JWT itself -- GitHub rejects a malformed one with a bare 401
+# --------------------------------------------------------------------------- #
+def _decode(token: str, private_key: str) -> dict[str, Any]:
+    """Verify and decode, the way GitHub does."""
+    from cryptography.hazmat.primitives import serialization as ser
+
+    public = ser.load_pem_private_key(private_key.encode(), password=None).public_key()
+    return jwt.decode(token, public, algorithms=["RS256"], options={"verify_aud": False})
+
+
+def test_the_jwt_names_this_app_as_the_issuer(private_key: str) -> None:
+    # `iss` is how GitHub knows which App is calling. Replacing it with "0"
+    # survived every test (#1263); the symptom is a 401 naming nothing.
+    creds = GitHubCredentials(settings=app_settings(private_key))
+    assert _decode(creds._app_jwt(), private_key)["iss"] == "12345"
+
+
+def test_the_jwt_is_backdated_and_not_yet_expired(private_key: str) -> None:
+    """`iat` in the past, `exp` in the future, both within GitHub's bounds.
+
+    GitHub rejects a JWT whose `iat` is in its future -- ordinary clock skew
+    does it -- and one whose `exp` is more than 10 minutes out. Pushing `iat`
+    600s forward, or setting `exp` already-past, both survived (#1263), and
+    both produce a 401 that says nothing about time.
+    """
+
+    creds = GitHubCredentials(settings=app_settings(private_key))
+    now = time.time()
+    claims = _decode(creds._app_jwt(), private_key)
+    assert claims["iat"] < now, "iat must be backdated for clock skew"
+    assert claims["exp"] > now, "exp must be in the future"
+    assert claims["exp"] - claims["iat"] <= 600, "exp must stay inside GitHub's 10-minute cap"
+
+
+# --------------------------------------------------------------------------- #
+# The shared-resolver cache key
+# --------------------------------------------------------------------------- #
+def test_rotating_the_private_key_gets_a_new_resolver(private_key: str) -> None:
+    """The cache key includes the key, so a rotation is not served stale.
+
+    Dropping the private key from the key survived (#1263): after a rotation
+    the old resolver -- and its cached tokens minted with the retired key --
+    would be handed back until the process restarted.
+    """
+
+    from curie_api.github_app import credentials_for
+
+    first = credentials_for(app_settings(private_key))
+    assert credentials_for(app_settings(private_key)) is first, "same config, same resolver"
+
+    other = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    rotated = other.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode()
+    assert credentials_for(app_settings(rotated)) is not first
 
 
 def test_two_repositories_do_not_share_a_token(private_key: str, github: Recorder) -> None:

--- a/cli/src/github_app.rs
+++ b/cli/src/github_app.rs
@@ -252,15 +252,44 @@ mod tests {
         );
     }
 
+    /// A real file holding a PEM-shaped body, so "the contents never reach
+    /// argv" is checked against contents that exist.
+    ///
+    /// The previous version pointed at `/tmp/app.pem`, which was never created.
+    /// Inlining `read_to_string(path)` into argv therefore stayed green -- it
+    /// read `""` -- so the assertion guarded a literal `BEGIN` and not the
+    /// realistic regression (#1263).
+    fn key_fixture() -> (tempfile::TempDir, String) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("app.pem");
+        std::fs::write(
+            &path,
+            "-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAKCAQEAtestkeymaterial\n-----END RSA PRIVATE KEY-----\n",
+        )
+        .expect("write fixture");
+        let as_str = path.to_string_lossy().into_owned();
+        (dir, as_str)
+    }
+
     #[test]
     fn the_private_key_contents_never_reach_argv() {
         // The whole reason for --set-file. A PEM in argv is readable by `ps`
         // and can be echoed by a subprocess error.
-        let cmds = connect_commands(&opts(false), DEFAULT_CLONE_BASE);
-        let flat = argv(&cmds[0]).join(" ");
-        assert!(flat.contains("--set-file"));
-        assert!(flat.contains("api.githubAppPrivateKey=/tmp/app.pem"));
-        assert!(!flat.contains("BEGIN"));
+        let (_dir, path) = key_fixture();
+        let body = std::fs::read_to_string(&path).expect("fixture readable");
+        let mut o = opts(false);
+        o.private_key_path = path.clone();
+
+        let flat = argv(&connect_commands(&o, DEFAULT_CLONE_BASE)[0]).join(" ");
+        assert!(flat.contains("--set-file"), "{flat}");
+        assert!(
+            flat.contains(&format!("api.githubAppPrivateKey={path}")),
+            "{flat}"
+        );
+        // The real assertion: no line of the file's CONTENT appears anywhere.
+        for line in body.lines().filter(|l| !l.trim().is_empty()) {
+            assert!(!flat.contains(line), "key material reached argv: {line}");
+        }
     }
 
     #[test]
@@ -273,10 +302,51 @@ mod tests {
     }
 
     #[test]
+    fn a_custom_clone_base_is_honoured() {
+        // Passing DEFAULT_CLONE_BASE and asserting the default appears also
+        // passes when the parameter is ignored entirely (#1263). A GitHub
+        // Enterprise install would silently get github.com and every clone
+        // would fail an origin check.
+        let flat = argv(&connect_commands(&opts(false), "https://ghe.example.com")[0]).join(" ");
+        assert!(
+            flat.contains("api.githubCloneBase=https://ghe.example.com"),
+            "the supplied clone base was ignored: {flat}"
+        );
+    }
+
+    #[test]
+    fn the_upgrade_reuses_existing_values() {
+        // Dropping --reuse-values resets every other value to chart defaults:
+        // Slack tokens, the model credential, the connector reconciler flag.
+        // Silent, destructive, and uncaught (#1263).
+        for cmds in [
+            connect_commands(&opts(false), DEFAULT_CLONE_BASE),
+            disconnect_commands(&opts(true)),
+        ] {
+            let flat = argv(&cmds[0]).join(" ");
+            assert!(
+                flat.contains("--reuse-values"),
+                "would reset other values: {flat}"
+            );
+        }
+    }
+
+    #[test]
     fn disconnect_clears_both_app_fields_and_touches_nothing_else() {
-        let flat = argv(&disconnect_commands(&opts(true))[0]).join(" ");
-        assert!(flat.contains("api.githubAppId="));
-        assert!(flat.contains("api.githubAppPrivateKey="));
+        // Asserted as whole argv entries, not with `contains` on the joined
+        // string: `contains("api.githubAppId=")` is also satisfied by
+        // `api.githubAppId=999`, so it checked for the presence of a prefix
+        // rather than for clearing (#1263).
+        let args = argv(&disconnect_commands(&opts(true))[0]);
+        assert!(
+            args.iter().any(|a| a == "api.githubAppId="),
+            "the App id was not cleared to empty: {args:?}"
+        );
+        assert!(
+            args.iter().any(|a| a == "api.githubAppPrivateKey="),
+            "the private key was not cleared to empty: {args:?}"
+        );
+        let flat = args.join(" ");
         // The PAT fallback must survive: clearing the App is how an operator
         // goes back to it.
         assert!(!flat.contains("api.githubToken"));


### PR DESCRIPTION
A mutation battery found **20 of 26 mutations surviving a green suite**. Both test files exercised only pure helpers — `poll_once`, `run_forever`, `GitHubBranchTip` and every JWT claim had no coverage at all.

That's the same gap that produced the startup crash: a wrong attribute in the consumer, invisible because no test constructed the class.

## Every listed mutation now dies

Each verified by applying it and watching a test go red:

```
drop the 300s refresh margin        1 failed     inline the key into argv       FAILED
iat pushed 600s into the future     2 failed     ignore --clone-base            FAILED
iss replaced with "0"               1 failed     drop --reuse-values            FAILED
exp already expired                 2 failed     disconnect does not clear      FAILED
unparseable expiry = immortal       1 failed
cache key drops the private key     1 failed
swap the dev/prod mapping           1 failed
ignore already-deployed state       1 failed
forged clone_url                    1 failed
tip never sends Authorization       1 failed
tip treats every status as OK       1 failed
poll_once deploys nothing           1 failed
```

## The two the issue called sharpest

**`test_the_payload_carries_the_derived_clone_url`** built a `Move` by hand, so swapping the real derivation for an attacker URL left it green. It was named for a security property and tested a constructor. Now drives `poll_once` (AC2).

**`test_a_near_expiry_token_is_reminted`** used a 1971 expiry — it proved an *expired* token gets replaced, never exercising the 300s margin it exists to guard. Now uses an expiry inside the margin (AC3), with a companion asserting a still-fresh token is **not** re-minted, so "re-mint always" can't pass both.

**The Rust leak assertion** pointed at a `/tmp/app.pem` that never existed, so inlining `read_to_string` into argv read `""` and stayed green. It now writes a real PEM fixture and asserts no line of its content reaches argv (AC4).

## One handled by deletion, which AC1 allows

`except asyncio.CancelledError: raise` in `run_forever` was **dead code** — `CancelledError` derives from `BaseException`, so the `except Exception` beside it never catches it and cancellation propagates regardless.

Mutating that `raise` to `continue` is a real shutdown hang, and no test can catch it: a task that ignores cancellation cannot be stopped, so the test hangs the suite rather than failing it. I tried three times before recognising that. Removing the clause removes the failure mode, and the remaining test states exactly what it proves and what it does not — rather than leaving an assertion that would not earn its name.

```
586 passed  (1 pre-existing Langfuse failure)
10 passed   (cli github_app)
```

Closes #1263