### PR TITLE
Stop re-cloning a commit that already settled

### DIFF
--- a/apps/api/src/curie_api/commitpoller.py
+++ b/apps/api/src/curie_api/commitpoller.py
@@ -260,6 +260,14 @@ WHERE a.repo_full_name IS NOT NULL AND d.commit_sha IS NOT NULL
 ORDER BY a.repo_full_name, d.environment, d.deployed_at DESC
 """
 
+# Rejection codes worth retrying. Everything else `process_push` returns is a
+# property of the commit -- a deploy.yaml naming an unknown agent, an
+# unsupported archive, a branch with no target -- and will fail identically
+# next minute. A clone failure is the exception: the remote was unreachable,
+# not wrong.
+_TRANSIENT_REJECTIONS = frozenset({"git.archive_failed"})
+
+
 # Every repository that has at least one agent bound to it. DISTINCT because
 # several agents legitimately share one repository (ADR-0091), and polling it
 # once per agent would race N deploys of the same commit.
@@ -294,6 +302,13 @@ class CommitPoller:
         self._eval_queue = eval_queue
         self._tips = tips
         self._interval = interval_seconds
+        # (repo, branch) -> sha whose outcome was terminal and NOT a
+        # Deployment. The database cannot answer this: it records successes, so
+        # an ignored or rejected push is indistinguishable from one never
+        # attempted, and the poller re-clones it every interval forever
+        # (#1267). In memory only -- a restart re-attempting once is cheap, and
+        # persisting it would mean a schema for something a process can forget.
+        self._settled: dict[tuple[str, str], str] = {}
 
     async def run_forever(self) -> None:
         logger.info("commit poller started interval=%ss", self._interval)
@@ -346,6 +361,11 @@ class CommitPoller:
         # to_thread because the tip reader is sync httpx: a blocking call in
         # the event loop would stall every request the API is serving.
         moves: list[Move] = await asyncio.to_thread(moves_to_deploy, targets, self._tips, deployed)
+        # Drop anything that already settled without producing a Deployment.
+        # This must happen BEFORE process_push, because the mirror clone is
+        # inside it -- at the recommended 60s interval an unchanged
+        # non-deploying branch is roughly 1,440 full clones a day (#1267).
+        moves = [m for m in moves if self._settled.get((m.repo_full_name, m.branch)) != m.sha]
 
         for move in moves:
             async with self._session_factory() as session:
@@ -356,6 +376,29 @@ class CommitPoller:
             # rejection as "deployed" at INFO is #1066 again, and this is the
             # lane with no GitHub delivery UI to fall back on.
             gitflow.log_push_outcome(result, move.as_push_payload(), source="commit poll")
+
+            if result.status in ("deployed", "promoted"):
+                # A Deployment row exists now, so the database is the memory
+                # and this must not keep a second copy that a rollback would
+                # not clear.
+                self._settled.pop((move.repo_full_name, move.branch), None)
+            elif result.status == "rejected" and any(
+                (e.get("code") or "") in _TRANSIENT_REJECTIONS for e in (result.errors or [])
+            ):
+                # The remote was unreachable, not wrong. Worth another pass --
+                # suppressing this would strand a repository on a network blip
+                # until the API restarted.
+                logger.info(
+                    "commit poll will retry repo=%s branch=%s sha=%s (transient)",
+                    move.repo_full_name,
+                    move.branch,
+                    move.sha[:8],
+                )
+            else:
+                # ignored, or rejected for a reason this commit will keep
+                # having. Remember it, or the next pass clones again (#1267).
+                self._settled[(move.repo_full_name, move.branch)] = move.sha
+
             if result.status != "rejected":
                 logger.info(
                     "commit poll deployed repo=%s branch=%s sha=%s status=%s",

--- a/apps/api/tests/test_commitpoller.py
+++ b/apps/api/tests/test_commitpoller.py
@@ -561,3 +561,93 @@ def test_a_404_is_still_a_missing_branch(monkeypatch) -> None:
     # by raising on everything.
     tip = _tip(monkeypatch, lambda r: httpx.Response(404, json={}))
     assert tip.sha_for(REPO, "nope") is None
+
+
+# Not re-cloning a commit that already settled (#1267)
+# --------------------------------------------------------------------------- #
+async def _passes(monkeypatch, result, n: int = 2) -> int:
+    """Run n consecutive poll_once passes; return how many reached the deploy path.
+
+    Reaching the deploy path is what costs a full mirror clone -- the clone
+    lives inside process_push -- so this counts exactly the thing #1267 is
+    about.
+    """
+    from contextlib import asynccontextmanager
+
+    from curie_api import gitflow
+    from curie_api.commitpoller import CommitPoller
+    from curie_api.config import Settings
+
+    calls = {"n": 0}
+
+    async def counting(session, store, settings, eval_queue, payload):
+        calls["n"] += 1
+        return result
+
+    class Session:
+        async def execute(self, stmt):
+            return [(REPO,)] if "FROM curie.agents" in str(stmt) else []
+
+    @asynccontextmanager
+    async def factory():
+        yield Session()
+
+    monkeypatch.setattr(gitflow, "process_push", counting)
+    poller = CommitPoller(
+        session_factory=factory,
+        store=object(),
+        settings=Settings(github_clone_base="https://github.com"),
+        eval_queue=object(),
+        tips=Tips({(REPO, "dev"): "abc123", (REPO, "main"): None}),
+        interval_seconds=60,
+    )
+    for _ in range(n):
+        await poller.poll_once()
+    return calls["n"]
+
+
+@pytest.mark.anyio
+async def test_an_ignored_branch_is_not_recloned_every_pass(monkeypatch) -> None:
+    """AC2. A branch deploy.yaml has no target for is a blessed configuration.
+
+    The poller's memory is the Deployment table, which records only successes,
+    so an ignored push looked never-attempted and was re-cloned on every
+    interval -- roughly 1,440 full mirror clones a day at the recommended 60s.
+    """
+
+    from curie_api.schemas import WebhookResult
+
+    assert await _passes(monkeypatch, WebhookResult(status="ignored")) == 1
+
+
+@pytest.mark.anyio
+async def test_a_permanently_rejected_commit_is_not_recloned(monkeypatch) -> None:
+    # A deploy.yaml naming an unknown agent fails identically next minute.
+    from curie_api.schemas import WebhookResult
+
+    rejected = WebhookResult(status="rejected", errors=[{"code": "deploy.unknown_agent"}])
+    assert await _passes(monkeypatch, rejected) == 1
+
+
+@pytest.mark.anyio
+async def test_a_transient_clone_failure_IS_retried(monkeypatch) -> None:
+    """The other side: remembering must not make a network blip permanent.
+
+    An unreachable remote is the one rejection that says nothing about the
+    commit, so suppressing its retry would strand a repository until the API
+    restarted.
+    """
+
+    from curie_api.schemas import WebhookResult
+
+    transient = WebhookResult(status="rejected", errors=[{"code": "git.archive_failed"}])
+    assert await _passes(monkeypatch, transient) == 2
+
+
+@pytest.mark.anyio
+async def test_a_successful_deploy_leaves_the_database_in_charge(monkeypatch) -> None:
+    # After a real deploy the Deployment row is the memory. Keeping a private
+    # copy too would mean two sources disagreeing after a rollback.
+    from curie_api.schemas import WebhookResult
+
+    assert await _passes(monkeypatch, WebhookResult(status="deployed")) == 2


### PR DESCRIPTION
The poller's "already seen" memory was the **Deployment table, which records only successes.** So an `ignored` or `rejected` push looked exactly like one never attempted, and every pass cloned it again — roughly **1,440 full mirror clones a day** per affected repository at the 60s interval `values.yaml` recommends.

The configuration that triggers it isn't exotic, it's blessed: a `deploy.yaml` declaring only a prod target while the repo keeps a live `dev` branch. `gitflow` returns `ignored` for that by design — **after** `clone_and_archive` has already run.

## The fix

Remember, per `(repo, branch)`, the sha whose outcome was terminal and produced no Deployment, and filter those **before** `process_push` — the clone is inside it, so filtering afterwards would save nothing (AC1).

## Two things it deliberately does not do

**A clone failure is still retried.** `git.archive_failed` means the remote was unreachable, not that the commit is wrong. Suppressing that retry would strand a repository on a network blip until the API restarted.

**A successful deploy clears the entry** rather than adding one. The Deployment row is the memory at that point; a private second copy would disagree with it after a rollback.

In memory only — a restart re-attempting once is cheap, and persisting it would mean a schema for something a process can safely forget.

## Falsified

```
no filter (the #1267 bug)  -> 2 failed
transient never retried    -> 1 failed
restored                   -> 25 passed
```

Four tests, including the AC2 case: two consecutive passes over an unchanged non-deploying branch reach the deploy path once, not twice.

```
577 passed  (1 pre-existing Langfuse failure)
```

Closes #1267