### PR TITLE
Say at startup which GitHub credential is live

### DIFF
--- a/apps/api/src/curie_api/github_app.py
+++ b/apps/api/src/curie_api/github_app.py
@@ -72,6 +72,24 @@ def credentials_for(settings: Settings) -> GitHubCredentials:
     return existing
 
 
+def log_credential_path(settings: Settings) -> None:
+    """Say once, at startup, which credential the platform will clone with.
+
+    ADR-0092 said this line existed. It did not (#1262): `describe()` was never
+    called from anywhere, so an operator had no way to tell an App install from
+    a PAT install from one that will 404 on every private clone -- and two
+    tests covered the dead method, which is worse than none.
+    """
+
+    credentials = credentials_for(settings)
+    logger.info("github credential path: %s", credentials.describe())
+    warning = credentials.half_configured()
+    if warning:
+        # Above INFO deliberately: this is the state that looks configured and
+        # is not, and it is the DEFAULT shape of a partly-applied BYO Secret.
+        logger.warning("github app is half-configured: %s", warning)
+
+
 class GitHubAppError(RuntimeError):
     """The App is configured but could not produce a token."""
 
@@ -102,13 +120,47 @@ class GitHubCredentials:
         return bool(self.settings.github_app_id and self.settings.github_app_private_key)
 
     def describe(self) -> str:
-        """Which path is in use, for one startup log line. Names no secret."""
+        """Which path is in use, for one startup log line. Names no secret.
+
+        Called by `log_credential_path` below. ADR-0092 promised this line and
+        it was never emitted -- two tests covered a method nothing invoked
+        (#1262).
+        """
 
         if self.app_configured:
             return f"github app (app_id={self.settings.github_app_id})"
         if self.settings.github_token:
             return "personal access token"
         return "none (public repositories only)"
+
+    def half_configured(self) -> str | None:
+        """The App is partly set up, so the platform silently used something else.
+
+        `app_configured` needs BOTH the id and the key, and the chart always
+        renders GITHUB_APP_PRIVATE_KEY from a secretKeyRef whose default is
+        empty -- so present-but-empty is the DEFAULT state, not an absent one.
+        An operator whose external-secrets sync is still in flight, or who
+        typo'd the key name against a Secret that carries it empty, gets a
+        PAT-or-nothing platform and a 404 on the private clone. The 404 handler
+        writes a good message, but it is unreachable: the App path was never
+        entered (#1262).
+        """
+
+        if self.app_configured:
+            return None
+        if self.settings.github_app_id and not self.settings.github_app_private_key:
+            return (
+                f"github_app_id is set (app_id={self.settings.github_app_id}) but the "
+                "private key is EMPTY, so the App is not in use. A BYO Secret that "
+                "exists but is unpopulated looks exactly like this -- check the key "
+                "name and whether the sync has completed."
+            )
+        if self.settings.github_app_private_key and not self.settings.github_app_id:
+            return (
+                "a GitHub App private key is set but github_app_id is empty, "
+                "so the App is not in use."
+            )
+        return None
 
     def token_for(self, repo_full_name: str) -> str:
         """A credential able to read ``owner/repo``, or "" if none is configured.

--- a/apps/api/src/curie_api/main.py
+++ b/apps/api/src/curie_api/main.py
@@ -18,7 +18,7 @@ from .commitpoller import CommitPoller, GitHubBranchTip
 from .config import get_settings
 from .db import create_engine, create_sessionmaker
 from .evalqueue import EvalQueue
-from .github_app import credentials_for
+from .github_app import credentials_for, log_credential_path
 from .github_checks import GitHubStatusReporter
 from .graveyardwatcher import GraveyardWatcher
 from .k8s import build_lazy_pod_lister, build_lazy_pod_log_reader
@@ -247,6 +247,9 @@ def configure_logging(level: str | None = None) -> logging.Logger:
 
 def create_app() -> FastAPI:
     configure_logging()
+    # Which credential the platform will clone with (ADR-0092, #1262). One
+    # line, no secret, and a warning when the App is set up only halfway.
+    log_credential_path(get_settings())
     app = FastAPI(title="Curie API", version="0.1.0", lifespan=lifespan)
 
     @app.get("/health", tags=["health"])

--- a/apps/api/tests/test_github_app.py
+++ b/apps/api/tests/test_github_app.py
@@ -8,6 +8,7 @@ every push or a dead token served until restart.
 
 from __future__ import annotations
 
+import logging
 import time
 from datetime import UTC, datetime, timedelta
 from typing import Any
@@ -334,3 +335,64 @@ def test_a_different_configuration_gets_a_different_resolver(private_key: str) -
     assert credentials_for(app_settings(private_key)) is not credentials_for(
         Settings(github_token="ghp_other")
     )
+
+
+# --------------------------------------------------------------------------- #
+# Saying which credential is live (#1262)
+# --------------------------------------------------------------------------- #
+def test_the_startup_line_names_the_credential_path(caplog) -> None:
+    """AC1/AC3. ADR-0092 promised this line and it was never emitted.
+
+    `describe()` had two tests and no caller, so an operator could not tell an
+    App install from a PAT install from one that 404s on every private clone.
+    Removing the call from create_app must turn this red.
+    """
+
+    from curie_api.main import create_app
+
+    with caplog.at_level(logging.INFO, logger="curie_api"):
+        create_app()
+    assert any("github credential path" in r.getMessage() for r in caplog.records), (
+        "no startup line names the credential path"
+    )
+
+
+def test_a_half_configured_app_warns_rather_than_looking_unconfigured(caplog) -> None:
+    """AC2. ID set, key empty -- the DEFAULT shape of a partly-applied Secret.
+
+    `app_configured` needs both, and the chart always renders the key from a
+    secretKeyRef defaulting to empty. So a sync still in flight, or a typo'd
+    key name, silently yields a PAT-or-nothing platform and a 404 on the
+    private clone -- with nothing in the log distinguishing it from an install
+    that never configured an App at all.
+    """
+
+    from curie_api.github_app import log_credential_path
+
+    settings = Settings(github_app_id="1234567", github_app_private_key="", github_token="ghp_x")
+    with caplog.at_level(logging.INFO, logger="curie_api"):
+        log_credential_path(settings)
+
+    warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert warnings, "a half-configured App must not look like an unconfigured one"
+    assert "1234567" in warnings[0].getMessage()
+    assert "EMPTY" in warnings[0].getMessage()
+
+
+def test_a_fully_configured_app_does_not_warn(private_key: str, caplog) -> None:
+    # Otherwise "always warn" satisfies the test above and the line becomes noise.
+    from curie_api.github_app import log_credential_path
+
+    with caplog.at_level(logging.INFO, logger="curie_api"):
+        log_credential_path(app_settings(private_key))
+    assert [r for r in caplog.records if r.levelno >= logging.WARNING] == []
+
+
+def test_the_startup_line_carries_no_secret(private_key: str, caplog) -> None:
+    from curie_api.github_app import log_credential_path
+
+    with caplog.at_level(logging.INFO, logger="curie_api"):
+        log_credential_path(app_settings(private_key, github_token="ghp_supersecret"))
+    text = " ".join(r.getMessage() for r in caplog.records)
+    assert "PRIVATE KEY" not in text
+    assert "ghp_supersecret" not in text


### PR DESCRIPTION
ADR-0092 promised a startup line naming the credential path. **It did not exist** — `describe()` had no caller anywhere, and two tests covered the dead method. That's worse than no tests: it read as coverage.

## The state it should have surfaced is the default one

`app_configured` requires **both** the id and the key, and the chart always renders `GITHUB_APP_PRIVATE_KEY` from a `secretKeyRef` whose default is `""`. So present-but-empty isn't an edge case — it's the default shape of a partly-applied BYO Secret:

```
app_id='1234567' key=''  ->  app_configured=False  describe='personal access token'
```

An operator whose external-secrets sync is still in flight, or who typo'd the key name against a Secret that carries it empty, silently gets a PAT-or-nothing platform and a 404 on the private clone. The 404 handler writes a genuinely useful message — and is **unreachable**, because the App path was never entered.

## Now

```
INFO     github credential path: github app (app_id=1234567)
WARNING  github app is half-configured: github_app_id is set (app_id=1234567) but the
         private key is EMPTY, so the App is not in use. A BYO Secret that exists but is
         unpopulated looks exactly like this -- check the key name and whether the sync
         has completed.
```

Above INFO deliberately: this is the state that *looks* configured and isn't.

## Falsified

```
remove the startup call  -> 1 failed
never warn half-config   -> 1 failed
restored                 -> 21 passed
```

Plus a test that a fully-configured App does **not** warn — otherwise "always warn" would satisfy the one above and the line becomes noise — and one asserting neither line carries key material.

Depends on #1286 for the records to actually reach a handler.

Closes #1262