### PR TITLE
Make the docs match what the code actually does

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -290,6 +290,14 @@ A **dev-branch** push builds the artifact and fans out its eval suite as a CI
 check. A **prod-branch** push promotes that same artifact without rebuilding.
 One diagram, both branches:
 
+There are **two ways a push reaches this flow**, and they converge immediately.
+The webhook below is the fast path. The second is a timer: `CommitPoller` in the
+API asks GitHub whether the deploy branches moved and hands any new commit to
+the same `process_push`, so the two cannot disagree about what a push means. It
+is off unless `api.commitPollIntervalSeconds` is set, and it exists because a
+webhook is an INBOUND request -- a self-hosted cluster behind a firewall cannot
+receive one, while outbound always works (#1239).
+
 ```mermaid
 sequenceDiagram
     participant Dev as Developer

--- a/apps/api/src/curie_api/commitpoller.py
+++ b/apps/api/src/curie_api/commitpoller.py
@@ -5,9 +5,16 @@ clusters accept no inbound traffic. A GitHub webhook cannot reach such a
 cluster, so today those installs have no push-to-deploy at all -- not a
 degraded one, none.
 
-Outbound always works. So this asks GitHub, on an interval, whether the
-branches an agent's ``deploy.yaml`` targets have moved, and runs the ordinary
-deploy when they have.
+Outbound always works. So this asks GitHub, on an interval, whether the deploy
+branches moved, and runs the ordinary deploy when they have.
+
+**Which branches: the platform's two, not the bundle's targets.** It polls
+``settings.dev_branch`` and ``settings.prod_branch`` for every bound repository
+-- the same two names ``environment_for_ref`` maps on the webhook path, so both
+lanes watch exactly the same refs. It does NOT read each bundle's
+``deploy.yaml`` to decide what to watch; ``deploy.yaml`` still decides which
+AGENT a push deploys to, downstream, inside ``process_push``. An earlier
+version of this docstring claimed otherwise (#1264).
 
 **It does not reimplement deploying.** It synthesizes the same push payload the
 webhook would have delivered and hands it to ``gitflow.process_push``. Two

--- a/charts/curie/README.md
+++ b/charts/curie/README.md
@@ -576,6 +576,34 @@ to install only the control plane + backing stores without the runner substrate.
 - Traces flow to `<release>-otel-collector:4318` (HTTP), per the collector
   rule above; the env block is omitted when `otelCollector.deploy: false`.
 
+## Deploying without inbound access
+
+A deploy is normally triggered by a GitHub webhook — an *inbound* request. A
+cluster behind a firewall or NAT cannot receive one, so on those installs
+push-to-deploy does not work at all. That is the common case for self-hosted.
+
+Outbound always works, so the API can ask instead:
+
+```yaml
+api:
+  commitPollIntervalSeconds: 60     # 0 disables it (the default)
+```
+
+It asks GitHub whether `dev_branch` and `prod_branch` have moved, for every
+repository an agent is bound to, and hands any new commit to the same
+`process_push` the webhook calls — so the two lanes cannot disagree about what a
+push means. `deploy.yaml` still decides which *agent* the push lands on.
+
+The webhook stays the fast path wherever it reaches; polling is the floor.
+Running both is safe: a poll for a push the webhook already handled is a no-op.
+
+Polling is per *repository*, not per agent — several agents share one repository
+(ADR-0091), and per-agent polling would race N deploys of the same commit.
+
+Give the platform a credential even if every repository is public: an
+unauthenticated caller gets 60 GitHub requests an hour, which a handful of
+repositories on a 60s interval exhausts in minutes.
+
 ## Serving the API over TLS
 
 The API is the only endpoint reached from outside the cluster. Two things cross
@@ -633,31 +661,81 @@ Verify it for your distribution:
 
 #### Enabling it on k3s
 
-The order matters, and getting it wrong leaves a half-configured cluster.
+Order matters, and getting it wrong leaves a half-configured cluster.
 
-The server must be started with the flag **before** `enable` is run:
+**1. Start the server with the flag.** This must come *before* `enable`:
 
 ```yaml
 # /etc/rancher/k3s/config.yaml
 secrets-encryption: true
 ```
 
-Then `systemctl restart k3s`, then `k3s secrets-encrypt enable`, then restart
-again, then `k3s secrets-encrypt reencrypt` to rewrite existing Secrets.
+```bash
+systemctl restart k3s
+```
 
-Running `enable` first, on a server started without the flag, half-succeeds:
-it writes a config the server never loads, and reports
-`missing annotation on node` followed by
-`Encryption Status: Disabled, no configuration file found`.
+Running `enable` first, on a server started without the flag, half-succeeds: it
+writes a config the server never loads, and reports `missing annotation on node`
+followed by `Encryption Status: Disabled, no configuration file found`.
 
-On k3s v1.36.2 `enable` fails outright with
-`Put ".../v1-k3s/encrypt/config": EOF` even when the prerequisite is met
-(issue #1243). Hand-writing an `aescbc` EncryptionConfiguration does work —
-the apiserver runs with `--encryption-provider-config-automatic-reload=true`,
-so no restart is needed — but understand the hazard first: **if that file is
-ever reverted to identity-only, every Secret written while encryption was
-active becomes permanently undecryptable.** Prefer keeping the most sensitive
-values out of etcd entirely, as below.
+**2. Try k3s's own command.**
+
+```bash
+k3s secrets-encrypt enable && systemctl restart k3s && k3s secrets-encrypt reencrypt
+k3s secrets-encrypt status     # expect: Encryption Status: Enabled
+```
+
+On **v1.36.2** this fails with `Put ".../v1-k3s/encrypt/config": EOF`, even with
+step 1 done (issue #1243). If it succeeded, you are finished — skip step 3.
+
+**3. If step 2 failed, write the configuration directly.**
+
+Read the hazard below first. Generate a key and write the file k3s already
+points the API server at:
+
+```bash
+head -c 32 /dev/urandom | base64          # the key; keep a copy somewhere safe
+
+cat > /var/lib/rancher/k3s/server/cred/encryption-config.json <<'JSON'
+{
+  "kind": "EncryptionConfiguration",
+  "apiVersion": "apiserver.config.k8s.io/v1",
+  "resources": [
+    {
+      "resources": ["secrets"],
+      "providers": [
+        { "aescbc": { "keys": [ { "name": "key1", "secret": "PASTE_THE_BASE64_KEY" } ] } },
+        { "identity": {} }
+      ]
+    }
+  ]
+}
+JSON
+chmod 600 /var/lib/rancher/k3s/server/cred/encryption-config.json
+```
+
+No restart is needed — k3s runs the API server with
+`--encryption-provider-config-automatic-reload=true`, which you can confirm with
+`journalctl -u k3s | grep encryption-provider-config`.
+
+`aescbc` first means new writes are encrypted; `identity` second means Secrets
+already stored in plaintext are still readable. Re-encrypt the existing ones by
+rewriting them:
+
+```bash
+kubectl get secrets -A -o json | kubectl replace -f -
+```
+
+> **Hazard, before you do this.** Once anything is written under `aescbc`, that
+> file is the only way to read it back. If it is lost, reverted to
+> identity-only, or the key changes, **every Secret written while encryption was
+> active becomes permanently undecryptable** — including the ones holding your
+> Slack tokens and model credential. Back up both the file and the key, and do
+> not let a config-management tool overwrite it.
+
+If that risk is not one you want to carry on a single-node cluster, a reasonable
+alternative is to leave encryption off and keep the most sensitive value out of
+etcd entirely, as below.
 
 ### The GitHub App private key
 

--- a/charts/curie/templates/NOTES.txt
+++ b/charts/curie/templates/NOTES.txt
@@ -180,7 +180,10 @@ Curie cannot detect this from inside the cluster -- please verify it yourself:
            leaves the cluster in an inconsistent state (see #1243).
   kubeadm  --encryption-provider-config on kube-apiserver
   EKS      aws eks describe-cluster --name <c> --query cluster.encryptionConfig
-  GKE      on by default (application-layer secrets encryption for db etcd)
+  GKE      etcd is encrypted at rest by default, but that is Google's own
+           storage-layer encryption. APPLICATION-layer encryption with your own
+           Cloud KMS key is separate and OFF unless you enabled it:
+             gcloud container clusters describe <c> --format='value(databaseEncryption)'
 
 For the most sensitive value -- the GitHub App private key, which can mint read
 tokens for every repository the App is installed on -- prefer a Secret you

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -493,8 +493,13 @@ api:
   #
   # Turn this on when the cluster cannot receive GitHub webhooks -- behind a
   # firewall or NAT, which is the common case for a self-hosted install. The
-  # API then asks GitHub whether the branches deploy.yaml names have moved.
-  # Outbound works where inbound does not.
+  # API then asks GitHub whether dev_branch and prod_branch have moved, for
+  # every repository an agent is bound to. Outbound works where inbound does
+  # not.
+  #
+  # Those are the platform's two branch names, the same ones the webhook path
+  # maps -- not per-bundle names read from deploy.yaml. deploy.yaml still
+  # decides which AGENT a push lands on, downstream.
   #
   # The webhook remains the fast path wherever it reaches; polling is the
   # floor. Each pass costs one API call per repository per branch -- repos x

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -28,7 +28,7 @@ is documentation of where the code already draws the line, not a new abstraction
 | Workflow state store | SOFT | 1 (API state router) | not separately graded | #23, #248 | [Workflow state store](interfaces/workflow-state/INTERFACE.md) |
 | Memory | CLEAN | 1 loader (StateApiMemoryStore) | not separately graded | #28 | [Memory](interfaces/memory/INTERFACE.md) |
 | Conversation history | CLEAN | 1 loader (StateApiTranscriptStore) | not separately graded | #20 | [Conversation history](interfaces/conversation-history/INTERFACE.md) |
-| Triggers | SOFT | 2 hardcoded (Slack, GH push) | not separately graded | #29 | [Triggers](interfaces/triggers/INTERFACE.md) |
+| Triggers | SOFT | 3 hardcoded (Slack, GH push, commit poll) | not separately graded | #29 | [Triggers](interfaces/triggers/INTERFACE.md) |
 | CLI output (agent-facing `--json`) | CLEAN | 9 outputs behind one trait | not separately graded | #456 | [CLI output (agent-facing `--json`)](interfaces/cli-output/INTERFACE.md) |
 <!-- END GENERATED: seam-table -->
 

--- a/docs/interfaces/triggers/INTERFACE.md
+++ b/docs/interfaces/triggers/INTERFACE.md
@@ -1,7 +1,7 @@
 ---
 seam: Triggers
 kind: SOFT
-impls: 2 hardcoded (Slack, GH push)
+impls: 3 hardcoded (Slack, GH push, commit poll)
 grade: not separately graded
 epics:
   - "#29"
@@ -13,7 +13,7 @@ order: 17
 > Part of the Curie swappable-seam catalog — see the [seam index](../../interfaces.md).
 
 <!-- BEGIN GENERATED: header (curie dev docs-lint) -->
-> **Kind:** SOFT &nbsp;·&nbsp; **Implementations today:** 2 hardcoded (Slack, GH push) &nbsp;·&nbsp; **Swap-readiness grade:** not separately graded
+> **Kind:** SOFT &nbsp;·&nbsp; **Implementations today:** 3 hardcoded (Slack, GH push, commit poll) &nbsp;·&nbsp; **Swap-readiness grade:** not separately graded
 <!-- END GENERATED: header -->
 
 **Kind legend:** CLEAN = a real `Protocol`/typed port class · SOFT = swap via env/URL/prefix/wire, no code interface · NONE = not built yet.
@@ -44,8 +44,17 @@ another hardcoded handler. The two that exist:
   `x_github_event`; a `"push"` event is handed to `process_push(...)`,
   everything else is `"ignored"`.
 
-The two share no abstraction: one is a Slack Bolt event listener, the other a FastAPI
-route with GitHub HMAC auth. They converge only downstream (both end up enqueuing work).
+- **Commit poll** — `apps/api/src/curie_api/commitpoller.py::CommitPoller.run_forever`:
+  a timer in the API asks GitHub whether the deploy branches moved and hands any
+  new commit to the same `process_push(...)`. Off unless
+  `api.commitPollIntervalSeconds` is set. It exists because the webhook above is
+  an INBOUND request, and a self-hosted cluster behind a firewall cannot receive
+  one at all -- outbound always works (#1239).
+
+The three share no abstraction: a Slack Bolt event listener, a FastAPI route with
+GitHub HMAC auth, and an asyncio timer. The last two converge one step earlier than
+the others -- both call `process_push`, deliberately, so the two deploy ingresses
+cannot disagree about what a push means.
 
 **Two further wake paths the inventory omitted.** Beyond the two external triggers, two
 platform-internal paths also turn an event into a run on the same `curie:runs` stream,
@@ -72,10 +81,14 @@ shape; it does not yet wire a live wake-up.
 
 ## Implementations today
 
-Two external triggers, both hardcoded, in two different processes:
+Three external triggers, all hardcoded, in two different processes:
 
 1. Slack `app_mention` in the dispatcher (`apps/dispatcher/src/curie_dispatcher/handlers.py::process_event`).
 2. GitHub `push` webhook in the API (`apps/api/src/curie_api/routers/github.py::github_webhook`).
+3. Commit poll in the API (`apps/api/src/curie_api/commitpoller.py::CommitPoller.run_forever`),
+   opt-in via `api.commitPollIntervalSeconds`. Timer-driven wake is therefore no longer
+   entirely unbuilt: this one is real, though it is a single hardcoded platform timer and
+   not the per-agent declared `cron` the trigger DECLARATION surface anticipates.
 
 Plus two platform-internal wake paths that also enqueue a run: the Slack block-action
 handler (`apps/dispatcher/src/curie_dispatcher/handlers.py::process_action`) and the


### PR DESCRIPTION
Four claims that were wrong, plus one sequence that didn't terminate.

## #1265 — the k3s sequence ended in a failing step

The reorder in #1244 fixed the ordering but left the reader at a final step the *same paragraph* says fails on the version it names, with a workaround that gave no file path and no content.

It now runs top to bottom: set the flag → try k3s's command → **if that fails**, write the `EncryptionConfiguration` directly, with the path, the JSON, how to generate the key, and how to re-encrypt what's already stored.

The hazard is stated **before** the step, not after — losing that file makes every Secret written under it permanently undecryptable, including the Slack tokens and model credential.

## #1265 — the GKE claim overstated protection

The notice said application-layer encryption is on by default. Google's default is **storage-layer**; application-layer with your own Cloud KMS key is separate and off unless enabled. An operator could read it as confirming protection they don't have.

## #1264 — two docs still described one deploy ingress

`ARCHITECTURE.md` and the triggers seam both predate #1246's second trigger. Both now name the poller, and the seam's front-matter count goes `2 → 3` so the generated header agrees with the prose.

Timer-driven wake is no longer entirely unbuilt — said without overclaiming: this is one hardcoded platform timer, not the per-agent declared `cron` the declaration surface anticipates.

## #1264 — the poller's docstring described behaviour it doesn't have

It claimed to watch *"the branches `deploy.yaml` names"*. It doesn't — it polls `dev_branch` and `prod_branch` globally, the same two the webhook path maps. **The behaviour is right and the description was wrong.** `deploy.yaml` decides which *agent* a push lands on, downstream; both places now say so.

## #1264 AC3 — the README documented polling nowhere

Now it does, including the credential note: an unauthenticated caller gets 60 GitHub requests an hour, which a handful of repositories on a 60s interval exhausts in minutes.

## Raised but deliberately not acted on

The issue observes that `GET /repos/{repo}/commits/{branch}` is exactly what `git ls-remote` returns over the git protocol — same credential, **no rate limit** — and that `apps/api/CLAUDE.md` says git-flow never calls the GitHub API. That's a real design point and would dissolve the rate-limit problem entirely, but it's a code change outside these ACs. Worth its own issue rather than a silent switch here.

Closes #1264
Closes #1265