### PR TITLE
Make the commit-message gate run on macOS bash 3.2

### DIFF
--- a/scripts/check-commit-messages.sh
+++ b/scripts/check-commit-messages.sh
@@ -175,7 +175,15 @@ if ! commit_output="$(git log --format=%H "$range" --)"; then
     exit 1
 fi
 if [[ -n "$commit_output" ]]; then
-    mapfile -t commits <<<"$commit_output"
+    # A read loop rather than `mapfile`, which is bash 4+. macOS ships bash 3.2
+    # (the last GPLv2 release) as /bin/bash, and `#!/usr/bin/env bash` finds it
+    # unless the contributor installed a newer one -- so on a stock Mac the
+    # `mapfile` form aborted with "command not found" and the gate never ran.
+    # The usage text advertises this script as the pre-push check, so a Mac
+    # contributor got no answer where CI gives a hard one.
+    while IFS= read -r sha; do
+        commits+=("$sha")
+    done <<<"$commit_output"
 fi
 if ((${#commits[@]} == 0)); then
     echo "no commits in range '$range'; nothing to check"


### PR DESCRIPTION
## The bug

`scripts/check-commit-messages.sh` used `mapfile`, which is bash 4+. macOS ships bash 3.2 as `/bin/bash` — the last GPLv2 release, frozen in 2007 — and the script's `#!/usr/bin/env bash` finds it unless the contributor installed a newer one. On a stock Mac:

```
scripts/check-commit-messages.sh: line 178: mapfile: command not found
```

The script's own usage text advertises it as the pre-push check, and CI's failure message points at it by name:

> Check locally before pushing: scripts/check-commit-messages.sh

So a Mac contributor who follows that pointer gets a crash instead of an answer, and finds out from CI instead — the exact round trip the local check exists to save. I hit this on #1293.

## The fix

One line: `mapfile -t commits <<<"$commit_output"` → a `while IFS= read -r` loop, which bash 3.2 has. It's the only bash-4 construct in the file (checked for `readarray`, `declare -A`, `${var^^}`, `${var,,}`, `&>>` too).

## Why the existing self-test didn't catch this

`--self-test` exercises `offending_reason` on a fixed corpus and returns **before** reaching the commit-enumeration path where `mapfile` lived — so it passed on bash 3.2 both before and after this change. Trusting it here would have proved nothing.

Verified against a real commit range under `/bin/bash` (3.2.57) specifically:

| case | before | after |
|---|---|---|
| range with an AI `Co-Authored-By` trailer | `mapfile: command not found` | **exit 1**, names the offending line |
| empty range | crash | exit 0 (fail-open, unchanged) |
| `--self-test` | 25 caught / 6 ignored | 25 caught / 6 ignored |

The before-column is a real run: I restored the `mapfile` form and re-ran it on the same violating range to confirm the crash was what this change removes, rather than assuming it.