### PR TITLE
Shimmer by default, with a caption written for the surface it lands on

### DIFF
--- a/apps/dispatcher/README.md
+++ b/apps/dispatcher/README.md
@@ -73,6 +73,8 @@ Read from the environment by `DispatcherConfig()` (a `pydantic_settings.BaseSett
 | `CURIE_DEDUPE_PREFIX` | `curie:dedupe:` | dedupe key prefix |
 | `CURIE_DEDUPE_TTL_SECONDS` | `3600` | dedupe guard TTL |
 | `CURIE_PLACEHOLDER_TEXT` | `On it. Working on your request.` | placeholder reply text |
+| `CURIE_STATUS_TEXT` | `is working on your request...` | the shimmer caption, NOT the message. Slack renders it as `<App Name> <status>` and inserts the app name, so write it as a continuation, not a sentence |
+| `CURIE_SHIMMER` | `true` | set the Slack assistant-thread status (the animated caption by the app name) while a turn runs. Also read by the worker, which clears it when the turn ends. Needs the app's **Agents & AI Apps** feature enabled by hand; without it the call is rejected and swallowed best-effort |
 | `CURIE_BACKOFF_INITIAL_SECONDS` | `1.0` | first reconnect backoff |
 | `CURIE_BACKOFF_MAX_SECONDS` | `30.0` | backoff cap |
 | `CURIE_BACKOFF_MULTIPLIER` | `2.0` | backoff growth factor |

--- a/apps/dispatcher/src/curie_dispatcher/config.py
+++ b/apps/dispatcher/src/curie_dispatcher/config.py
@@ -19,6 +19,7 @@ Env mapping:
     CURIE_DEDUPE_PREFIX      -> dedupe_prefix
     CURIE_DEDUPE_TTL_SECONDS -> dedupe_ttl_seconds
     CURIE_PLACEHOLDER_TEXT   -> placeholder_text
+    CURIE_STATUS_TEXT        -> status_text (the shimmer caption, NOT the message)
     CURIE_SHIMMER            -> shimmer (assistant-thread status while working)
     CURIE_BACKOFF_INITIAL_SECONDS -> backoff_initial_seconds
     CURIE_BACKOFF_MAX_SECONDS     -> backoff_max_seconds
@@ -134,11 +135,32 @@ class DispatcherConfig(BaseSettings):
         default="On it. Working on your request.",
         validation_alias="CURIE_PLACEHOLDER_TEXT",
     )
+    # The shimmer caption, kept SEPARATE from placeholder_text because the two
+    # surfaces have different grammar. Slack renders an assistant-thread status
+    # as "<App Name> <status>" and inserts the app name itself, so the status has
+    # to read as a CONTINUATION of the app name ("Curie is working on your
+    # request...") while the message body is a standalone sentence ("On it.
+    # Working on your request."). Reusing one string for both produced "Curie On
+    # it. Working on your request." in the shimmer.
+    # https://docs.slack.dev/reference/methods/assistant.threads.setStatus
+    status_text: str = Field(
+        default="is working on your request...",
+        validation_alias="CURIE_STATUS_TEXT",
+    )
     # When true, also set a Slack assistant-thread status (the native "shimmer"
-    # on the app name) to placeholder_text while a turn runs. The worker clears it
-    # when the turn ends. Off by default; requires the app's assistant feature +
-    # assistant:write scope (see slack-app-manifest.yaml).
-    shimmer: Bool = Field(default=False, validation_alias=SHIMMER_ENV)
+    # on the app name) to status_text while a turn runs. The worker clears it
+    # when the turn ends.
+    #
+    # ON by default: during a turn the placeholder only changes when the model
+    # emits text, so a model that spends 30s reasoning before its first token
+    # leaves the thread visibly frozen, and an operator cannot tell that from a
+    # wedge (issue #1182). The shimmer is Slack's own affordance for exactly
+    # that, and it is strictly additive -- it neither edits the message nor
+    # notifies anyone. A workspace whose app lacks the "Agents & AI Apps"
+    # feature just skips it (the call is best-effort and logs at debug), so
+    # defaulting it on cannot break a deployment; see slack-app-manifest.yaml
+    # for the one-click enablement that has no manifest key.
+    shimmer: Bool = Field(default=True, validation_alias=SHIMMER_ENV)
 
     backoff_initial_seconds: float = Field(
         default=1.0, gt=0, validation_alias="CURIE_BACKOFF_INITIAL_SECONDS"

--- a/apps/dispatcher/src/curie_dispatcher/handlers.py
+++ b/apps/dispatcher/src/curie_dispatcher/handlers.py
@@ -107,9 +107,11 @@ def process_event(
         # Native Slack "shimmer": set the assistant-thread status so the app name
         # shimmers while we work. Best-effort -- a workspace without the assistant
         # feature just skips it; the worker clears the status when the turn ends.
+        # Uses status_text, not placeholder_text: Slack prefixes the status with
+        # the app name, so this surface needs a continuation, not a sentence.
         try:
             web_client.assistant_threads_setStatus(
-                channel_id=channel, thread_ts=thread_ts, status=config.placeholder_text
+                channel_id=channel, thread_ts=thread_ts, status=config.status_text
             )
         except Exception as exc:  # noqa: BLE001 -- shimmer is best-effort, never fatal
             log.debug("assistant setStatus skipped for %s: %s", slack_event_id, exc)

--- a/apps/dispatcher/tests/test_config.py
+++ b/apps/dispatcher/tests/test_config.py
@@ -57,7 +57,10 @@ _DISPATCHER_OVERRIDES: dict[str, tuple[str, str, object]] = {
         "Sentinel placeholder.",
         "Sentinel placeholder.",
     ),
-    "CURIE_SHIMMER": ("shimmer", "true", True),
+    # Deliberately the NON-default value: shimmer now defaults to True, so a
+    # "true" -> True case would pass even if the alias were never read at all.
+    "CURIE_SHIMMER": ("shimmer", "false", False),
+    "CURIE_STATUS_TEXT": ("status_text", "is sentinel-working...", "is sentinel-working..."),
     "CURIE_BACKOFF_INITIAL_SECONDS": ("backoff_initial_seconds", "2.5", 2.5),
     "CURIE_BACKOFF_MAX_SECONDS": ("backoff_max_seconds", "45.5", 45.5),
     "CURIE_BACKOFF_MULTIPLIER": ("backoff_multiplier", "3.5", 3.5),
@@ -130,7 +133,8 @@ def test_defaults_parity_with_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
     assert config.dedupe_prefix == "curie:dedupe:"
     assert config.dedupe_ttl_seconds == 3600
     assert config.placeholder_text == "On it. Working on your request."
-    assert config.shimmer is False
+    assert config.status_text == "is working on your request..."
+    assert config.shimmer is True
     assert config.backoff_initial_seconds == 1.0
     assert config.backoff_max_seconds == 30.0
     assert config.backoff_multiplier == 2.0

--- a/apps/dispatcher/tests/test_dispatch.py
+++ b/apps/dispatcher/tests/test_dispatch.py
@@ -142,12 +142,40 @@ def test_shimmer_sets_assistant_status_after_placeholder(
     handler.handle(sock, _events_api_request("env-1", "Ev-shim", _mention_event()))
     _drain(app)
 
-    # The shimmer status is set on the same thread as the placeholder.
+    # The shimmer status is set on the same thread as the placeholder, and it
+    # carries status_text -- NOT placeholder_text. Slack renders the status as
+    # "<App Name> <status>" and inserts the app name itself, so reusing the
+    # message body produced "Curie On it. Working on your request.".
     web_client.assistant_threads_setStatus.assert_called_once_with(
-        channel_id="C123", thread_ts="1700.0001", status=shimmer_config.placeholder_text
+        channel_id="C123", thread_ts="1700.0001", status=shimmer_config.status_text
     )
+    assert shimmer_config.status_text != shimmer_config.placeholder_text
     # And the normal placeholder + enqueue still happen.
     assert redis_client.xlen(config.stream) == 1
+
+
+def test_shimmer_is_on_by_default_with_no_explicit_config(
+    redis_client: redis.Redis, config: DispatcherConfig
+) -> None:
+    """The shipped default shimmers (#1182), not just an explicitly-enabled config.
+
+    Deliberately does NOT model_copy the flag on: the point is that an operator
+    who configures nothing still gets the liveness caption, because during a turn
+    the placeholder only moves when the model emits text and a reasoning model can
+    stay silent for tens of seconds before its first token.
+    """
+    assert config.shimmer is True, "the fixture must carry the shipped default"
+    app, web_client = _build(config, redis_client)
+    web_client.assistant_threads_setStatus = MagicMock()  # type: ignore[method-assign]
+    handler = SocketModeHandler(app, app_token="xapp-test")
+    sock = FakeSocketClient()
+
+    handler.handle(sock, _events_api_request("env-1", "Ev-default-shim", _mention_event()))
+    _drain(app)
+
+    web_client.assistant_threads_setStatus.assert_called_once_with(
+        channel_id="C123", thread_ts="1700.0001", status=config.status_text
+    )
 
 
 def test_duplicate_delivery_enqueues_exactly_once(

--- a/apps/worker/src/curie_worker/config.py
+++ b/apps/worker/src/curie_worker/config.py
@@ -159,8 +159,16 @@ class WorkerConfig(BaseSettings):
 
     # When true, clear the Slack assistant-thread status (the "shimmer" the
     # dispatcher set) once a turn ends -- editing the placeholder does not
-    # auto-clear it. Off by default; pairs with the dispatcher's CURIE_SHIMMER.
-    shimmer: Bool = Field(default=False, validation_alias=SHIMMER_ENV)
+    # auto-clear it, because Slack only auto-clears a status when the app POSTS
+    # a message and this pipeline edits the placeholder instead.
+    #
+    # ON by default, and it must track the dispatcher's CURIE_SHIMMER (same env
+    # name, read by both services): the dispatcher sets the status and the worker
+    # is the only side holding the reply handle when the turn ends, so leaving
+    # this off while the dispatcher shimmers means nothing clears the status on
+    # our side and the caption lingers until Slack's own two-minute status
+    # timeout expires.
+    shimmer: Bool = Field(default=True, validation_alias=SHIMMER_ENV)
 
     # When true, suppress intermediate placeholder edits while streaming so the
     # placeholder gets exactly one chat.update (the final) -- rate-limit friendly

--- a/apps/worker/tests/kernel/test_binding_integration.py
+++ b/apps/worker/tests/kernel/test_binding_integration.py
@@ -239,7 +239,9 @@ def test_shimmer_off_never_sets_a_caption(make_harness) -> None:
     async def go() -> None:
         packs = {"load": {"enabled": True, "lines": ["Working..."]}}
         binding = StubBinding({"C-bound": _resolved_with_packs(packs)})
-        async with make_harness(binding=binding) as h:  # shimmer defaults off
+        # Explicitly OFF: shimmer now defaults ON (#1182), so leaning on the
+        # default here would silently stop exercising the off path.
+        async with make_harness(binding=binding, shimmer=False) as h:
             h.runner.default_script = [Final(text="done", status=DONE)]
             await h.kernel.process_event(_qevent("hi", channel="C-bound"))
             assert h.sink.status_sets == []
@@ -294,16 +296,17 @@ def test_bound_agent_with_enabled_nav_gets_hub_button_on_final_reply(make_harnes
 def test_malformed_packs_blob_still_completes_the_turn(make_harness) -> None:
     # Regression: a malformed behavior_packs blob must NOT brick the channel.
     # from_config is total, so packs_for can't raise; process_event resolves an
-    # all-off default and the turn finishes normally (no poison-loop). shimmer is
-    # off (the default config), so this exercises the every-bound-turn path where
-    # packs_for now runs.
+    # all-off default and the turn finishes normally (no poison-loop). This
+    # exercises the every-bound-turn path where packs_for now runs; the shimmer
+    # flag is left at its default (now ON, #1182) because the defensiveness under
+    # test does not depend on it either way.
     async def go() -> None:
         # A nested field of the wrong type would raise pydantic.ValidationError
         # if from_config were not defensive.
         binding = StubBinding(
             {"C-bound": _resolved_with_packs({"nav": {"enabled": "banana"}})}
         )
-        async with make_harness(binding=binding) as h:  # shimmer defaults off
+        async with make_harness(binding=binding) as h:
             h.runner.default_script = [Final(text="answer", status=DONE)]
             ev = _qevent("hi", channel="C-bound", thread="tBad")
 

--- a/apps/worker/tests/kernel/test_kernel.py
+++ b/apps/worker/tests/kernel/test_kernel.py
@@ -89,12 +89,28 @@ def test_shimmer_clears_status_when_the_turn_ends(make_harness) -> None:
 
 
 def test_no_status_clear_when_shimmer_is_off(make_harness) -> None:
-    # Default (shimmer off): the kernel never touches the assistant status.
+    # With shimmer OFF the kernel never touches the assistant status. Pinned
+    # explicitly: shimmer now defaults ON (#1182), so leaning on the default here
+    # would silently stop exercising the off path.
+    async def go() -> None:
+        async with make_harness(shimmer=False) as h:
+            h.runner.default_script = [Final(text="done", status=DONE)]
+            await h.kernel.process_event(_qevent("hi"))
+            assert h.sink.status_clears == []
+
+    asyncio.run(go())
+
+
+def test_status_is_cleared_by_default(make_harness) -> None:
+    # The mirror of the test above, and the reason the default flipped (#1182):
+    # the dispatcher shimmers by default, and editing the placeholder does not
+    # auto-clear a Slack status, so the worker must clear it on the way out or
+    # the caption lingers until Slack's own timeout.
     async def go() -> None:
         async with make_harness() as h:
             h.runner.default_script = [Final(text="done", status=DONE)]
             await h.kernel.process_event(_qevent("hi"))
-            assert h.sink.status_clears == []
+            assert h.sink.status_clears, "the shipped default must clear the caption"
 
     asyncio.run(go())
 

--- a/apps/worker/tests/test_config.py
+++ b/apps/worker/tests/test_config.py
@@ -56,7 +56,9 @@ _WORKER_OVERRIDES: dict[str, tuple[str, str, object]] = {
     "DB_SCHEMA": ("db_schema", "myschema", "myschema"),
     "CURIE_PLUGIN_DIR": ("bundle_plugin_dir", "/custom/bundles", "/custom/bundles"),
     "CURIE_FAKE_MODEL": ("fake_model", "true", True),
-    "CURIE_SHIMMER": ("shimmer", "yes", True),
+    # Deliberately the NON-default value: shimmer now defaults to True, so a
+    # truthy-token case would pass even if the alias were never read at all.
+    "CURIE_SHIMMER": ("shimmer", "no", False),
     "CURIE_CREDENTIALS": ("credentials", "cred-sentinel", "cred-sentinel"),
     "CURIE_MODEL_BASE_URL": (
         "model_base_url",
@@ -205,8 +207,10 @@ def test_defaults_parity_with_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
     assert config.credentials == ""
     assert config.model_base_url == ""
     assert config.model == ""
-    # Shimmer
-    assert config.shimmer is False
+    # Shimmer: on by default so a reasoning model's pre-token silence is not
+    # indistinguishable from a wedge (#1182). Must agree with the dispatcher's
+    # default -- one env name drives both services.
+    assert config.shimmer is True
     # Stream / consumer group
     assert config.stream == "curie:runs"
     assert config.consumer_group == "curie-workers"

--- a/docs/behavior-packs.md
+++ b/docs/behavior-packs.md
@@ -57,6 +57,54 @@ The substrate, end to end, minus the kernel call sites:
   now selects `behavior_packs`, carries it on `ResolvedDeployment`, and exposes
   `BindingResolver.packs_for(resolved) -> BehaviorPacks`.
 
+## Where a load line actually appears: the Slack shimmer
+
+A load line is not a message. It is rendered through Slack's **assistant-thread
+status** — the caption that sits next to the app's name and animates while the
+app works ([`assistant.threads.setStatus`](https://docs.slack.dev/reference/methods/assistant.threads.setStatus)).
+Three things follow from that, and the first one decides how you should write
+your load lines.
+
+**Slack prefixes the caption with the app name, and you supply only the rest.**
+The rendered result is `<App Name> <status>`, so a caption has to read as a
+*continuation*, not as a standalone sentence:
+
+| load line | renders as | |
+|---|---|---|
+| `is crunching the numbers...` | `Curie is crunching the numbers...` | ✅ |
+| `Crunching the numbers...` | `Curie Crunching the numbers...` | ❌ |
+
+The platform default for the pack-free case follows the same rule
+(`CURIE_STATUS_TEXT`, default `is working on your request...`). It is a separate
+setting from `CURIE_PLACEHOLDER_TEXT` precisely because the two surfaces have
+different grammar: the placeholder is a message body and stands alone, the
+caption is a sentence fragment glued to the app name.
+
+**The caption is not the message, and never touches it.** The placeholder
+message the dispatcher posts is edited in place as the model streams; the
+caption lives outside it. It leaves no `(edited)` marker, notifies nobody, and
+disappears on its own. That is why it is safe to leave on: it is strictly
+additive to whatever the message is doing.
+
+**It is on by default, but a workspace has to enable one thing by hand.**
+`CURIE_SHIMMER` (read by both the dispatcher, which sets the caption, and the
+worker, which clears it) now defaults to on. The `assistant:write` scope ships in
+[`slack-app-manifest.yaml`](../apps/dispatcher/slack-app-manifest.yaml), but the
+app-level **Agents & AI Apps** feature has no manifest key and must be switched
+on once in the app config. Until it is, `setStatus` is rejected, the call is
+swallowed as best-effort (a debug log, never a failed turn), and you simply see
+no caption. Nothing else changes.
+
+**Slack expires a caption after about two minutes.** The status clears
+automatically when the app *posts* a message — but this pipeline **edits** the
+placeholder rather than posting a second message, so that auto-clear never
+fires and the worker clears the caption explicitly at the end of the turn.
+The other half of Slack's rule still applies: if nothing refreshes the caption,
+Slack drops it roughly two minutes in. A turn longer than that loses its
+caption partway through. Refreshing it on a timer is a follow-up (it has to run
+inside the kernel while the turn awaits the runner, so it carries the
+sacred-module review), tracked separately from this substrate.
+
 ## What is NOT built: the deferred runtimes
 
 Two pieces are intentionally out of this PR, each a natural follow-up on top of
@@ -102,8 +150,10 @@ The intended integration points, once that review is scheduled:
 2. **Load/tips first-edit** -- in `Kernel._consume`, seed the `_ThrottledReply`
    with the sampled load line (optionally plus a tip) so the dispatcher's generic
    placeholder is replaced by the per-agent line before the first `text_delta`
-   arrives. (This is also the surface the shimmer status can draw from instead of
-   generic text, once wired.)
+   arrives. (The *shimmer* half of this is now wired —
+   `apps/worker/src/curie_worker/kernel.py::Kernel._set_shimmer` replaces the
+   dispatcher's generic caption with the sampled load line plus tip. What remains
+   deferred is seeding the placeholder **message** itself.)
 
    ```python
    load = sample_load(packs, qevent.thread_ts)

--- a/docs/slack-local-runbook.md
+++ b/docs/slack-local-runbook.md
@@ -52,10 +52,22 @@ subscriptions are correct from the start.
 4. `SLACK_SIGNING_SECRET` is optional and unused in Socket Mode (kept only for
    Bolt app construction); leave it empty.
 
-The `assistant:write` scope in the manifest is only exercised if you enable the
-shimmer status indicator (`CURIE_SHIMMER`), which ALSO requires manually
-toggling **Agents & AI Apps** in the app config. That is a one-click manual step
-with no manifest key. Skip both if you are not using shimmer.
+5. **Turn on Agents & AI Apps** (your app -> **Agents & AI Apps** -> enable).
+   This one has no manifest key, so creating the app from the manifest does not
+   set it — it is a one-click manual step, and it is the only thing standing
+   between you and the shimmer.
+
+That last step is worth doing. The **shimmer** is the animated caption Slack
+shows next to the app's name while a turn runs (`CURIE_SHIMMER`, **on by
+default**, and the `assistant:write` scope it needs is already in the manifest).
+Without it, the only sign the agent is working is the placeholder message — and
+that message does not change until the model emits its first token, so a model
+that reasons for thirty seconds before answering leaves the thread looking
+frozen (issue #1182).
+
+Skipping the toggle is safe, just quiet: `assistant.threads.setStatus` is
+rejected, the call is swallowed best-effort (a debug log, never a failed turn),
+and you get no caption. Set `CURIE_SHIMMER=false` to stop attempting it at all.
 
 ## 2. Bind an agent to your channel
 


### PR DESCRIPTION
Refs #1182. Does **not** close it — see *Scope* at the bottom.

## The gap

During a turn, the only thing that moves in a Slack thread is the placeholder message, and it only moves when the model emits text. A reasoning model reasons *before* it answers, so the whole pre-token stretch is visibly frozen — and an operator cannot tell that from a wedge.

Measured on the path curie actually dials (OpenRouter's Anthropic-compatible endpoint), same prompt:

| model | wall clock | thinking tokens |
|---|---|---|
| `anthropic/claude-sonnet-4.5` | 2.4s | **0** |
| `z-ai/glm-5.2` | 8.1s | **268** (70% of output) |

That is not GLM being unusual — `deepseek/deepseek-r1` defaults to 259 and `qwen/qwen3-235b-a22b-thinking-2507` to 613. curie sets no thinking configuration at all; these are the models' own defaults. The reporter compared a model that reasons against one that doesn't and saw 6s vs 45s.

## What this does

Slack already has the affordance for exactly this: the **assistant-thread status**, the animated caption beside the app name ([`assistant.threads.setStatus`](https://docs.slack.dev/reference/methods/assistant.threads.setStatus)). Its own docs describe it as *"setting expectations for potentially slow responses."*

The plumbing has been in the tree since the shimmer landed, only switched off. This turns it on by default, and fixes the caption it carries.

**1. `CURIE_SHIMMER` defaults to on, on both services.** The dispatcher sets the caption; the worker is the only side holding the reply handle when the turn ends, so if it doesn't clear, nothing does. Slack's own auto-clear fires when the app **posts** a message, and this pipeline **edits** the placeholder instead, so that path never triggers. One env name drives both, and the two defaults now agree.

**2. The caption gets its own text.** It was being fed `placeholder_text`, but Slack renders a status as `<App Name> <status>` and inserts the app name itself, so the shimmer read:

```
Curie On it. Working on your request.
```

`CURIE_STATUS_TEXT` (default `is working on your request...`) splits the two surfaces. They have genuinely different grammar — the placeholder is a message body and stands alone, the caption is a fragment glued to the app name — so one string could never be right for both.

## Why defaulting it on is safe

The caption is **strictly additive**: it is not the message, it leaves no `(edited)` marker, and it notifies nobody. Live-edit streaming is untouched — the placeholder still streams as before, this just adds a second signal for the stretch where there is nothing to stream.

Where the feature isn't enabled, `setStatus` is rejected, the call is already best-effort (`except` → debug log), and the turn is unaffected. The operator sees no caption and nothing else changes.

The one thing that can't be automated is Slack's app-level **Agents & AI Apps** toggle — it has no manifest key. The `assistant:write` scope was already in the manifest; only the toggle is manual. The runbook now names it as a numbered setup step instead of an aside addressed to people who had opted into shimmer, because that framing went stale the moment the default flipped.

## Tests

Every production change is covered by a test that **fails without it**. Verified by reverting each one in turn:

| reverted | fails |
|---|---|
| `handlers.py` back to `placeholder_text` | `test_shimmer_sets_assistant_status_after_placeholder` |
| dispatcher default back to `False` | `test_defaults_parity_with_from_env`, `test_shimmer_is_on_by_default_with_no_explicit_config` |
| worker default back to `False` | `test_defaults_parity_with_from_env` (worker) |

New: `test_shimmer_is_on_by_default_with_no_explicit_config` drives the real dispatch path with an unmodified config — the existing test `model_copy`s the flag on, which no longer proves anything — and `test_status_is_cleared_by_default` is its worker-side mirror.

**Two test-quality fixes ride along, both consequences of the flip:**

- The `CURIE_SHIMMER` env-read cases (dispatcher and worker) asserted the value that is now the default, so they would have passed against an alias that was never read at all. Both now probe the non-default value.
- The two shimmer-*off* kernel tests leaned on the default instead of pinning the flag they exist to exercise. Both now pass `shimmer=False` explicitly. Their assertions are unchanged — only the fixture is, which is the point.

Gates: `ruff check`, `mypy` (176 files), `pytest apps/dispatcher/tests apps/worker/tests` (**743 passed, 17 skipped**), `bash scripts/check-docs.sh`. No kernel logic changed — the kernel edits are test fixtures and comments only.

## Docs

- **`docs/behavior-packs.md`** — a new section on where a load line actually appears, since load lines feed this same caption. Includes the `<App Name>` grammar rule as a ✅/❌ table, because a pack author writing `Crunching the numbers...` gets `Curie Crunching the numbers...`.
- **`docs/slack-local-runbook.md`** — the Agents & AI Apps toggle promoted to a setup step. The old paragraph ("skip both if you are not using shimmer") was stale as of this change.
- **`apps/dispatcher/README.md`** — `CURIE_STATUS_TEXT` and `CURIE_SHIMMER` added to the env table. `CURIE_SHIMMER` was missing from it entirely.
- One **pre-existing** stale line fixed: behavior-packs said the shimmer surface could draw from load lines *"once wired"*. It has been wired — `Kernel._set_shimmer` — while the other half it describes (seeding the placeholder **message**) genuinely is still deferred. Corrected to say which half is which.

## Scope

Deliberately **not** here:

- **Refreshing the caption on a timer.** Slack expires a status after ~2 minutes if nothing refreshes it, so a turn longer than that loses its caption partway through. The fix has to run inside the kernel while the turn awaits the runner, which makes it a sacred-module change with the escalated review — its own PR, not a passenger on a config-and-docs change.
- **The thinking/effort knob.** `ClaudeAgentOptions` exposes `thinking`, `effort` and `max_thinking_tokens`; curie sets none of them. Letting an operator turn the reasoning *down*, rather than only watch it happen, is what actually answers #1182's title, and it needs its own ADR (operator-owned, no bundle override) first. **That change closes #1182; this one only makes the wait legible.**
