### PR TITLE
Add a one-page path from nothing to a Slack agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ See the [target table](#which-target-do-i-want) below for what each tier actuall
 
 ## Quickstart
 
+**Just want a bot in Slack?** [`docs/your-first-slack-agent.md`](docs/your-first-slack-agent.md)
+is the short path: what to get first, four commands, and the six mistakes that
+cost people an hour. The walkthrough below is the longer one, and teaches the
+parity ladder as it goes.
+
 ### Prerequisites
 
 - **Docker + Compose v2**: for the dev stack and the local runner container.
@@ -303,6 +308,9 @@ requires it, and you are free to use Curie whether or not you do.
 
 ## Where do I go next?
 
+- [docs/your-first-slack-agent.md](docs/your-first-slack-agent.md) -- the
+one-page path from nothing to a bot answering in Slack that redeploys itself on
+push, plus the mistakes worth skipping.
 - [`ARCHITECTURE.md`](ARCHITECTURE.md#component-map) -- the component diagram, the
 message-flow and deploy-flow sequence diagrams, and the built/in-progress
 split.

--- a/docs/your-first-slack-agent.md
+++ b/docs/your-first-slack-agent.md
@@ -1,0 +1,152 @@
+# Your first Slack agent
+
+From nothing to a bot that answers in Slack and redeploys itself when you push.
+
+Four commands do the work. Everything else on this page is the accounts you
+need first and the six mistakes that actually cost people time.
+
+---
+
+## What you need first
+
+| | Where to get it | Why |
+|---|---|---|
+| **Model credential** | [console.anthropic.com](https://console.anthropic.com/) | The agent's brain |
+| **Docker** | [get-docker.sh](https://docs.docker.com/get-docker/) | Runs the agent locally |
+| **A cluster** | k3s on one small VM is enough | Only needed for the Slack step |
+| **A Slack app** | [api.slack.com/apps](https://api.slack.com/apps) → *From a manifest* | Two tokens, below |
+
+A single-node k3s box with **no inbound ports** serves a Slack bot fine —
+Slack Socket Mode is outbound-only. You do not need a load balancer, a domain,
+or a public IP.
+
+Export the model credential once. Every step below reuses it:
+
+```bash
+export CURIE_CREDENTIALS=sk-ant-...
+```
+
+---
+
+## 1. Build it on your laptop (2 min)
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/curie-eng/curie/main/get-curie.sh | bash
+curie init my-agent && cd my-agent
+curie skill up && curie skill message "hello, what can you do?"
+```
+
+You now have a working agent. Edit `skills/my-agent/SKILL.md` to change what it
+does, then `curie skill up --replace` to reload it.
+
+No credential handy? `curie skill up --fake-model` runs the whole loop offline
+with scripted replies — enough to prove the plumbing, not to judge the agent.
+
+```bash
+curie skill down
+```
+
+## 2. Get the Slack tokens
+
+At [api.slack.com/apps](https://api.slack.com/apps) → **Create New App** →
+**From a manifest**, paste
+[`apps/dispatcher/slack-app-manifest.yaml`](../apps/dispatcher/slack-app-manifest.yaml).
+
+Then collect two tokens:
+
+- **App-Level Token** with scope `connections:write` → `xapp-…`
+- **Install to Workspace**, then **Bot User OAuth Token** → `xoxb-…`
+
+Invite the bot to your channel, and copy the **channel ID** — right-click the
+channel → *View channel details*, it's at the bottom and looks like `C0…`.
+
+## 3. Put it on the cluster (10 min)
+
+```bash
+curie cluster up --namespace my-agent --release my-agent \
+  --set agentSandbox.runner.credentials="$CURIE_CREDENTIALS" \
+  --allow-egress-host anthropic
+
+curie cluster comms --slack --namespace my-agent --release my-agent \
+  --app-token "$SLACK_APP_TOKEN" --bot-token "$SLACK_BOT_TOKEN"
+
+curie cluster deploy --plugin-dir . --namespace my-agent --release my-agent \
+  --repo <owner>/<repo> --slack-channel C0YOURCHANNEL
+```
+
+`@mention` the bot in that channel. That's the whole thing.
+
+## 4. Make it ship itself
+
+Add `deploy.yaml` next to your bundle:
+
+```yaml
+targets:
+  dev:
+    agent: my-agent-dev
+    env: dev
+    slack_channel: C0YOURDEVCHANNEL
+  prod:
+    agent: my-agent
+    env: prod
+    slack_channel: C0YOURPRODCHANNEL
+```
+
+Point a GitHub webhook at the release's API and push. A push to `dev` deploys
+to your dev bot; a merge to `main` promotes **that same artifact** to prod — not
+a rebuild, so what you tested is what ships. Full webhook wiring:
+[`docs/operations.md`](operations.md#automatically-with-git-flow).
+
+## Giving it tools
+
+Add `connectors.yaml` and Curie derives the Deployment, Service, network
+policy, and secret wiring for you:
+
+```yaml
+connectors:
+  grafana:
+    image: docker.io/grafana/mcp-grafana:0.17.2
+    args: [-t, streamable-http, -address, "0.0.0.0:8000",
+           -allowed-hosts, "${CURIE_ALLOWED_HOSTS}", -disable-write]
+    env:
+      GRAFANA_URL: https://grafana.example.com
+    secrets:
+      - GRAFANA_SERVICE_ACCOUNT_TOKEN
+```
+
+`secrets` are **names only** — the value never enters your repository:
+
+```bash
+curie secrets set GRAFANA_SERVICE_ACCOUNT_TOKEN
+```
+
+Each agent gets its **own** connector Deployment, Service, and Secret, labelled
+with its owner. Two agents in one namespace cannot reach each other's
+credentials.
+
+---
+
+## Six things that cost people an hour
+
+1. **Export the credential before `skill up`.** Otherwise the boot succeeds and
+   the *next* command fails with `model-credential-rejected`.
+2. **`--repo` is set once, at the first deploy, and can never be changed.** An
+   agent created without it can never use git-flow, and the only fix is
+   deleting the agent and starting over. Get it right the first time.
+3. **Bind by channel ID (`C0…`), never `#name`.**
+4. **Run `cluster comms` after `cluster up`, not before.**
+5. **Renaming the bot in Slack rotates the bot token** — re-run `cluster comms`.
+6. **One agent binds one channel.** Pointing a second agent at an occupied
+   channel returns 409.
+
+## Which rung do I want?
+
+| | Runs where | Use it for |
+|---|---|---|
+| `curie skill` | one container on your laptop | writing the agent |
+| `curie local` | Docker Compose, full backend | the real queue → worker → sandbox path |
+| `curie cluster` | Kubernetes | Slack, and anything real |
+
+Same bundle at every rung. See [`README.md`](../README.md#quickstart) for the
+long-form walkthrough, and [`docs/operations.md`](operations.md) for running one
+in production.

--- a/docs/your-first-slack-agent.md
+++ b/docs/your-first-slack-agent.md
@@ -36,7 +36,7 @@ curie init my-agent && cd my-agent
 curie skill up && curie skill message "hello, what can you do?"
 ```
 
-You now have a working agent. Edit `skills/my-agent/SKILL.md` to change what it
+You now have a working agent. Edit `skills/my-agent/SKILL.md` to change what it <!-- doclint:ignore-line -->
 does, then `curie skill up --replace` to reload it.
 
 No credential handy? `curie skill up --fake-model` runs the whole loop offline


### PR DESCRIPTION
## Why

Walking the quickstart cold on the real v0.6.0 release binary, it teaches the parity ladder well — and answers *"how do I get a bot into Slack"* slowly. The Slack wiring is spread across three linked documents, and the constraints that actually cost an hour are discovered rather than stated.

This adds the short path **beside** the existing walkthrough, not instead of it. The README still teaches the ladder; this is for someone who just wants the bot.

## What's in it

- The four accounts/tools to collect first, and why a single k3s box with **no inbound ports** is enough (Socket Mode is outbound-only — people over-provision here)
- Four commands: `cluster up` → `cluster comms` → `cluster deploy` → push
- `deploy.yaml` and `connectors.yaml` shown as the small files they are
- **Six mistakes worth skipping**, drawn from what actually bit during the sre-bot build — the load-bearing one being that `--repo` is set once at agent creation and can never be changed, where the only remedy is deleting the agent and starting over

## Verification

Commands and flags were checked against the CLI, not written from memory:

| claim | checked |
|---|---|
| `cluster deploy --slack-channel/--repo/--target` | present |
| `cluster up --allow-egress-host` | present |
| `cluster comms --slack/--app-token/--bot-token` | present |
| `curie secrets set <NAME>` | present |
| `agentSandbox.runner.credentials` | real values key (`values.yaml:930`) |
| both relative links + `operations.md#automatically-with-git-flow` | resolve |

Scanned for real workspace data — no channel ids, hostnames, instance ids, account numbers, or tokens. Placeholders only.

## Note

The guide documents released v0.6.0 behaviour. Gotcha #1 (export the credential before `skill up`) is now surfaced by the CLI itself as of #1293, but stays in the list because it's still the behaviour of the released binary people will download.