### PR TITLE
Accept ADR-0097

### DIFF
--- a/docs/adr/0097-one-file-declares-an-installation.md
+++ b/docs/adr/0097-one-file-declares-an-installation.md
@@ -2,7 +2,7 @@
 
 Date: 2026-08-05
 
-Status: Draft
+Status: Accepted
 
 ## Context
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -123,6 +123,6 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0092 | [A GitHub App gives the platform its own repository identity](0092-a-github-app-gives-the-platform-its-own-repository-identity.md) | Accepted |
 | 0093 | [Local-model assets are pre-provisioned, never implicitly downloaded](0093-local-model-assets-are-pre-provisioned-never-implicitly-downloaded.md) | Draft |
 | 0094 | [A bundle carries its own sealed connector keys](0094-a-bundle-carries-its-own-sealed-connector-keys.md) | Draft |
-| 0097 | [One file declares an installation](0097-one-file-declares-an-installation.md) | Draft |
+| 0097 | [One file declares an installation](0097-one-file-declares-an-installation.md) | Accepted |
 | 0098 | [Thinking depth is an operator knob, never a bundle one](0098-thinking-depth-is-an-operator-knob-never-a-bundle-one.md) | Accepted |
 <!-- END GENERATED: adr-index -->


### PR DESCRIPTION
Maintainer accepted the decision in #1297. This publishes the status.

Per [ADR 0045](../blob/main/docs/adr/0045-the-status-line-is-the-mutable-part-of-an-immutable-adr.md), the `Status:` line is the mutable part of an otherwise immutable ADR. The complete diff:

```diff
-Status: Draft
+Status: Accepted
-| 0097 | One file declares an installation | Draft |
+| 0097 | One file declares an installation | Accepted |
```

The second hunk is the generated `docs/adr/README.md` index row, regenerated by `scripts/check-docs.sh`, not hand-edited. No prose changed.

Under [ADR 0085](../blob/main/docs/adr/0085-acceptance-not-implementation-authorizes-an-adr.md) this is what authorizes implementation. Tracking issue linked below.