### PR TITLE
Say git-driven instead of git-flow in prose

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -48,7 +48,7 @@ What Curie does, in short:
 - Connect Slack.
 - Author a Claude-Code-format plugin (skills + tools + MCP) in the browser or a repo.
 - Deploy it as a bot identity.
-- Get traces, evals, budgets, and git-flow for free.
+- Get traces, evals, budgets, and git-driven deploys for free.
 
 The core loop: a Slack mention is queued, picked up by a worker that claims a
 sandboxed runner, and the runner's reply is edited back into the Slack thread.
@@ -77,7 +77,7 @@ flowchart TB
         Dispatcher["dispatcher<br/>ingress + dedupe"]
         Queue["Valkey<br/>queue + routing"]
         Worker["worker kernel<br/>one session per thread"]
-        API["api<br/>git-flow · bundles · read proxy"]
+        API["api<br/>git-driven deploy · bundles · read proxy"]
     end
 
     Sandbox["runner pod<br/>Claude Code + skill"]
@@ -343,7 +343,7 @@ sequenceDiagram
   The webhook receiver is at [`apps/api/src/curie_api/routers/github.py::github_webhook`](apps/api/src/curie_api/routers/github.py).
 - **Eval stream** `curie:evals` is produced by the API ([`apps/api/src/curie_api/evalqueue.py::EVAL_STREAM`](apps/api/src/curie_api/evalqueue.py)) and consumed by the worker's eval consumer, which is a **separate** consumer group from the runs kernel ([`apps/worker/src/curie_worker/eval/stream.py::EvalStreamConsumer`](apps/worker/src/curie_worker/eval/stream.py)). It POSTs results to `/evals/report` ([`apps/worker/src/curie_worker/eval/stream.py::EvalReporter`](apps/worker/src/curie_worker/eval/stream.py)).
 - **The eval matrix endpoint** `GET /evals/matrix` reads pass/fail from Langfuse trace tags/metadata, not a scores join ([`apps/api/src/curie_api/routers/evals.py::eval_matrix`](apps/api/src/curie_api/routers/evals.py)).
-- **The manual path** (`GET /agents`, `/agents/{id}/versions`, `/agents/{id}/versions/{vid}/bundle`) and the webhook path terminate at the same `Version`/`Deployment` tables and the same `plugin_format.validate_bundle`. As a result, a plugin authored in the browser, pushed by `curie local deploy`, or promoted by git-flow all go through one pipeline. Bundle store/fetch at [`apps/api/src/curie_api/storage.py::BundleStore`](apps/api/src/curie_api/storage.py) and [`apps/api/src/curie_api/routers/bundles.py::download_bundle`](apps/api/src/curie_api/routers/bundles.py).
+- **The manual path** (`GET /agents`, `/agents/{id}/versions`, `/agents/{id}/versions/{vid}/bundle`) and the webhook path terminate at the same `Version`/`Deployment` tables and the same `plugin_format.validate_bundle`. As a result, a plugin authored in the browser, pushed by `curie local deploy`, or promoted by a git push all go through one pipeline. Bundle store/fetch at [`apps/api/src/curie_api/storage.py::BundleStore`](apps/api/src/curie_api/storage.py) and [`apps/api/src/curie_api/routers/bundles.py::download_bundle`](apps/api/src/curie_api/routers/bundles.py).
 
 ## One worker, two hidden seams: substrate and transport
 
@@ -608,7 +608,7 @@ rehearsal on a fresh k3s cluster (see [Deployment, CI, and release](#deployment-
 The following are built and verified:
 
 - the frozen contracts
-- the API (agents/versions/deployments, git-flow, evals, Langfuse proxy, bundle pipeline)
+- the API (agents/versions/deployments, git-driven deploys, evals, Langfuse proxy, bundle pipeline)
 - the runner
 - the dispatcher
 - the worker kernel and its four invariants

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Slack — the first channel it speaks, with email and Teams next — author a Cl
 plugin bundle (skills + tools + MCP), deploy it as a versioned bot identity and run it anywhere -
 in your development environment on your laptop or in production on your own Kubernetes cluster.
 Configure your model, so you can point an agent at Anthropic, OpenRouter, or a local model through
-Ollama. Get traces, evals, budgets, and git-flow deploys for free. One CLI, `curie`, drives all of
+Ollama. Get traces, evals, budgets, and git-driven deploys for free. One CLI, `curie`, drives all of
 it.
 
 ![Curie: build an agent in Claude Code, run it locally, ship it with git push](docs/demo/demo-loop.gif)

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -10,7 +10,7 @@ serve the vision below, it needs a very good reason to exist.
 
 The open source platform for building, running, and operating production AI
 agents. A developer authors an agent locally, tests it in a loop identical to
-production, and ships it through git flow: a pull request opens a dev agent, a
+production, and ships it through git: a pull request opens a dev agent, a
 merge promotes it to prod. Agents answer in Slack today — the channel is a
 swappable seam, with email and Teams next — run in isolated sandboxes, and
 get observability and evals out of the box. One command brings the whole
@@ -62,7 +62,7 @@ Six commitments that should hold across every feature we build:
 - **The local loop is the production loop.** What a developer tests locally is
   what runs in prod, down to the sandbox and the harness. Local-first is a
   load-bearing promise, not a convenience.
-- **Git flow is the deploy model.** Branches map to bot environments; a PR is a
+- **Git is the deploy model.** Branches map to bot environments; a PR is a
   dev agent, a merge is a promotion. Shipping an agent should feel like shipping
   code, because it is.
 - **Opinionated core, swappable jobs.** One curated default for every job a
@@ -92,7 +92,7 @@ platform that grows the way Supabase and PostHog did: adoption from developers
 who want to own their agent stack instead of renting an expensive black box, a
 comparison the market makes on its own once the box is good enough. We do not
 lead with "the cheap one." We lead with "build agents as code, test them with
-evals, ship them through git flow, run them on your infrastructure with any
+evals, ship them through git, run them on your infrastructure with any
 model," and let owning your stack be the reason people arrive.
 
 The test for any feature is simple: does it make that developer's loop tighter,


### PR DESCRIPTION
## Summary
- The deploy model is two branches (dev, prod) with promote-not-rebuild semantics -- not the classic Driessen Git Flow branching model (develop/feature/release/hotfix)
- "git-flow" traces back to an incidental naming choice in the module's first commit, not a deliberate reference to that methodology -- but it reads like a claim to anyone who knows the established term
- Swapped the user-facing prose in README.md, ARCHITECTURE.md, and vision.md to "git-driven" instead
- Left the `gitflow.py` module name, its direct code-path citations in ARCHITECTURE.md, and the ADRs untouched -- those are accurate historical/code references, not prose claims, and ADRs are treated as immutable once accepted

## Test plan
- [x] Confirmed no remaining generic prose uses of "git-flow"/"git flow" in README.md or vision.md
- [x] Confirmed the one remaining ARCHITECTURE.md mention is paired directly with the `gitflow.py` file citation, not a standalone claim
- [ ] Render the three files locally to confirm the swapped prose still reads naturally in context