### PR TITLE
Let an operator turn a reasoning model's thinking down

### DIFF
--- a/apps/api/alembic/versions/0019_agents_thinking.py
+++ b/apps/api/alembic/versions/0019_agents_thinking.py
@@ -1,0 +1,51 @@
+"""per-agent thinking depth: agents.thinking (#1182)
+
+ADR-0098. A reasoning model reasons before it answers, and until now nothing in
+Curie could change that: the runner hands claude-agent-sdk twelve option fields
+and none of them is `thinking`, so whatever the model ships with is what runs.
+Measured on the endpoint Curie dials, `z-ai/glm-5.2` spends 70% of its output
+tokens thinking (8.1s) where `claude-sonnet-4.5` spends none (2.4s); disabling
+it takes the same GLM call to 1.7s.
+
+This column is the per-agent half of the two-layer operator control, the exact
+shape `agents.model` already has: NULL means the platform default
+(`CURIE_THINKING` on the worker) applies, and a value here wins for this agent
+only. A bundle has no say at either layer -- it cannot even name its model, and
+thinking depth is the same capability-versus-cost axis one notch down.
+
+Nullable with no server default on purpose. NULL is not "off"; it is "this agent
+expresses no opinion", which is what every existing row means and what keeps this
+migration a no-op for behavior. An agent whose column stays NULL on a worker with
+no `CURIE_THINKING` set boots exactly as it does today: the runner sends no
+thinking configuration and the model's own default stands.
+
+Revision ID: 0019
+Revises: 0018
+Create Date: 2026-08-04
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0019"
+down_revision: str | None = "0018"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+SCHEMA = "curie"
+
+
+def upgrade() -> None:
+    op.add_column(
+        "agents",
+        sa.Column("thinking", sa.String(), nullable=True),
+        schema=SCHEMA,
+    )
+
+
+def downgrade() -> None:
+    # Safe to drop: the column carries operator preference, not agent state, and
+    # a re-upgrade simply reads NULL again (the platform default).
+    op.drop_column("agents", "thinking", schema=SCHEMA)

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -84,6 +84,17 @@
           "slack_channel": {
             "title": "Slack Channel",
             "type": "string"
+          },
+          "thinking": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Thinking"
           }
         },
         "required": [
@@ -186,6 +197,17 @@
           "slack_channel": {
             "title": "Slack Channel",
             "type": "string"
+          },
+          "thinking": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Thinking"
           }
         },
         "required": [
@@ -195,6 +217,7 @@
           "repo_full_name",
           "behavior_packs",
           "model",
+          "thinking",
           "approval_required_tools",
           "approval_routes",
           "secrets",
@@ -280,6 +303,17 @@
               }
             ],
             "title": "Slack Channel"
+          },
+          "thinking": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Thinking"
           }
         },
         "title": "AgentUpdate",

--- a/apps/api/src/curie_api/crud.py
+++ b/apps/api/src/curie_api/crud.py
@@ -42,6 +42,7 @@ async def create_agent(session: AsyncSession, data: AgentCreate) -> Agent:
         slack_channel=data.slack_channel,
         repo_full_name=data.repo_full_name,
         model=data.model,
+        thinking=data.thinking,
         behavior_packs=(
             data.behavior_packs.model_dump() if data.behavior_packs is not None else None
         ),
@@ -97,6 +98,15 @@ async def update_agent_channel(session: AsyncSession, agent: Agent, slack_channe
 
 async def update_agent_model(session: AsyncSession, agent: Agent, model: str | None) -> Agent:
     agent.model = model
+    await session.commit()
+    await session.refresh(agent)
+    return agent
+
+
+async def update_agent_thinking(
+    session: AsyncSession, agent: Agent, thinking: str | None
+) -> Agent:
+    agent.thinking = thinking
     await session.commit()
     await session.refresh(agent)
     return agent

--- a/apps/api/src/curie_api/models.py
+++ b/apps/api/src/curie_api/models.py
@@ -63,6 +63,14 @@ class Agent(Base):
     # the platform/worker default model applies. The value is passed straight
     # through to the runner, which resolves it against its configured provider.
     model: Mapped[str | None] = mapped_column(default=None)
+    # Per-agent thinking depth (#1182, ADR-0098). Forwarded as CURIE_THINKING at
+    # sandbox boot; NULL means the worker's CURIE_THINKING default applies, and
+    # unset at both layers means the runner sends no thinking configuration and
+    # the model's own default stands. Operator-owned like `model` above: a bundle
+    # has no surface for it at any tier. The vocabulary is the runner's
+    # (`curie_runner.thinking`), not this column's -- stored as a plain string so
+    # the persistence layer does not have to track the harness.
+    thinking: Mapped[str | None] = mapped_column(default=None)
     # Per-agent behavior packs: declarative, opt-in UX touches the worker applies
     # around a turn (a sampled "working..." line, a canned greeting reply). Stored
     # as JSON here and resolved onto the deployment by the worker's binding layer;

--- a/apps/api/src/curie_api/routers/agents.py
+++ b/apps/api/src/curie_api/routers/agents.py
@@ -154,6 +154,8 @@ async def update_agent(agent_id: uuid.UUID, data: AgentUpdate, session: SessionD
             raise HTTPException(status_code, message) from exc
     if data.model is not None:
         agent = await crud.update_agent_model(session, agent, data.model)
+    if data.thinking is not None:
+        agent = await crud.update_agent_thinking(session, agent, data.thinking)
     if data.approval_required_tools is not None:
         # Omitted leaves the gates unchanged; an explicit [] clears them (#245).
         agent = await crud.update_agent_approval_tools(session, agent, data.approval_required_tools)

--- a/apps/api/src/curie_api/schemas.py
+++ b/apps/api/src/curie_api/schemas.py
@@ -337,6 +337,9 @@ class AgentCreate(BaseModel):
     # Per-agent model id, forwarded as CURIE_MODEL at boot (#254). None uses the
     # platform default model.
     model: str | None = None
+    # Per-agent thinking depth, forwarded as CURIE_THINKING at boot (#1182,
+    # ADR-0098). None uses the platform default.
+    thinking: str | None = None
     # Per-agent permission gates (#245): tool names requiring human approval.
     # None means no gates (the bypass posture).
     approval_required_tools: list[str] | None = None
@@ -366,6 +369,9 @@ class AgentUpdate(BaseModel):
     # New per-agent model id (#254). Omitted (None) leaves the current model
     # unchanged, matching the slack_channel convention.
     model: str | None = None
+    # New per-agent thinking depth (#1182). Omitted (None) leaves the current
+    # value unchanged, the same convention as `model` above.
+    thinking: str | None = None
     # New permission gates (#245). Omitted (None) leaves the current gates
     # unchanged; an explicit empty list clears them.
     approval_required_tools: list[str] | None = None
@@ -397,6 +403,7 @@ class AgentOut(BaseModel):
     repo_full_name: str | None
     behavior_packs: dict[str, Any] | None
     model: str | None
+    thinking: str | None
     approval_required_tools: list[str] | None
     approval_routes: dict[str, Any] | None
     # Connector secret NAMES only (#429) -- values are never returned. The stored

--- a/apps/api/tests/test_agent_thinking_integration.py
+++ b/apps/api/tests/test_agent_thinking_integration.py
@@ -1,0 +1,85 @@
+"""Per-agent thinking depth round-trips through the API against real Postgres.
+
+The sibling of `test_agent_model_integration`, deliberately: `thinking` is the
+per-agent half of the two-layer operator control ADR-0098 defines, and it is
+stored, exposed and updated exactly the way `model` is (#1182). Create-with,
+the null default, PATCH-to-set, and PATCH-leaves-unchanged.
+
+The null default carries the meaning here: NULL is not "thinking off", it is
+"this agent expresses no opinion", which falls through to the worker's
+`CURIE_THINKING` and, if that is unset too, to sending the runner nothing at all.
+"""
+
+from typing import Any
+
+
+def _create_agent(client: Any, auth_headers: dict[str, str], **body: Any) -> dict[str, Any]:
+    resp = client.post(
+        "/agents",
+        json={"name": "thinking-bot", "slack_channel": "CTHINK001", **body},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()  # type: ignore[no-any-return]
+
+
+def test_agent_defaults_to_null_thinking(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    agent = _create_agent(client, auth_headers)
+    assert agent["thinking"] is None
+
+    resp = client.get(f"/agents/{agent['id']}", headers=auth_headers)
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["thinking"] is None
+
+
+def test_create_with_thinking_persists(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    agent = _create_agent(client, auth_headers, thinking="disabled")
+    assert agent["thinking"] == "disabled"
+
+    resp = client.get(f"/agents/{agent['id']}", headers=auth_headers)
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["thinking"] == "disabled"
+
+
+def test_patch_sets_thinking(client: Any, auth_headers: dict[str, str], clean_db: None) -> None:
+    agent = _create_agent(client, auth_headers)
+    resp = client.patch(
+        f"/agents/{agent['id']}",
+        json={"thinking": "enabled:2000"},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["thinking"] == "enabled:2000"
+
+
+def test_patch_without_thinking_leaves_it_unchanged(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    # Omitted means "unchanged", the same convention `model` and slack_channel
+    # follow -- a PATCH that renames an agent must not silently clear its
+    # thinking depth.
+    agent = _create_agent(client, auth_headers, thinking="adaptive")
+    resp = client.patch(
+        f"/agents/{agent['id']}",
+        json={"slack_channel": "CTHINK002"},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["thinking"] == "adaptive"
+
+
+def test_the_api_stores_the_value_verbatim_and_does_not_validate_it(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    # Deliberate: the vocabulary belongs to the runner (`curie_runner.thinking`),
+    # not to the persistence layer, so that swapping the harness is not a schema
+    # change. The consequence is that a typo is caught at sandbox boot with a
+    # message naming the vocabulary, not at write time -- which is the same
+    # bargain `model` already makes (the API does not know which model ids a
+    # provider accepts either).
+    agent = _create_agent(client, auth_headers, thinking="not-a-real-value")
+    assert agent["thinking"] == "not-a-real-value"

--- a/apps/worker/src/curie_worker/binding.py
+++ b/apps/worker/src/curie_worker/binding.py
@@ -85,6 +85,9 @@ API_BACKEND_ENV = BootEnv.env_key("api_backend")
 # Which env var(s) carry the model credential (#514): a bare name or a JSON array.
 MODEL_ENV_KEY_ENV = BootEnv.env_key("model_env_key")
 MODEL_ENV = BootEnv.env_key("model")
+# Thinking depth (#1182, ADR-0098): the model half's sibling, same producer and
+# same consumer, so it is named from BootEnv rather than typed as a literal.
+THINKING_ENV = BootEnv.env_key("thinking")
 # Per-claim bearer token the runner enforces on its ACI POST routes (issue #63).
 # Not a model credential, so apply_model_env never sees it; minted fresh per claim.
 RUNNER_TOKEN_ENV = BootEnv.env_key("runner_token")
@@ -158,6 +161,7 @@ SELECT a.id AS agent_id,
        a.max_output_tokens_per_run AS max_output_tokens_per_run,
        a.behavior_packs AS behavior_packs,
        a.model AS model,
+       a.thinking AS thinking,
        a.approval_required_tools AS approval_required_tools,
        a.approval_routes AS approval_routes,
        a.secrets AS secrets,
@@ -191,6 +195,10 @@ class ResolvedDeployment(BaseModel):
     # The agent's pinned model id (#254), forwarded as CURIE_MODEL at boot.
     # None falls back to the worker's configured default model.
     model: str | None = None
+    # The agent's thinking depth (#1182, ADR-0098), forwarded as CURIE_THINKING
+    # at boot. None falls back to the worker's configured default; unset at both
+    # layers sends nothing and leaves the model's own default standing.
+    thinking: str | None = None
     # The agent's permission gates (#245): tool names requiring human approval,
     # forwarded as CURIE_APPROVAL_REQUIRED_TOOLS at boot. None means no gates.
     approval_required_tools: list[str] | None = None
@@ -584,6 +592,13 @@ class BindingResolver:
             # The agent's pinned model (#254) overrides the worker default; None
             # falls back to the platform default.
             model=resolved.model if resolved.model is not None else self._config.model,
+            # Same precedence as the model above (#1182): the agent's value wins,
+            # then the platform default, then nothing at all -- and "nothing at
+            # all" is what makes an unconfigured install behave as it always has.
+            thinking=(
+                resolved.thinking if resolved.thinking is not None else self._config.thinking
+            )
+            or None,
             fake_model=self._config.fake_model,
             credentials_ref=self._config.credentials,
             base_url=self._config.model_base_url,
@@ -627,7 +642,10 @@ class BindingResolver:
 
 
 def apply_model_env(
-    env: dict[str, str], config: WorkerConfig, model_override: str | None = None
+    env: dict[str, str],
+    config: WorkerConfig,
+    model_override: str | None = None,
+    thinking_override: str | None = None,
 ) -> None:
     """Layer the runner model + credentials passthrough onto a boot env.
 
@@ -640,7 +658,13 @@ def apply_model_env(
     ``model_override`` is the per-agent CURIE_MODEL (#254): when set it wins
     over the worker's configured default model, so a single agent can be pinned
     to a specific model. None means "use the platform default" (config.model).
-    It is the ONLY per-agent knob here. The api_backend and env_key declarations
+    ``thinking_override`` is its sibling (#1182, ADR-0098) with the same
+    precedence and the same ownership: both layers are operator-set, and a
+    bundle has no surface for either. Unset at both layers writes nothing, so
+    the runner sends no thinking configuration and the model's own default
+    stands.
+
+    Those two are the only per-agent knobs here. The api_backend and env_key declarations
     (#514) come from WorkerConfig only and take no override: they select which
     wire protocol is dialed and which env var a credential is read from, so a
     lower-privileged agent author must not be able to set them.
@@ -662,6 +686,9 @@ def apply_model_env(
     model = model_override if model_override is not None else config.model
     if model:
         env[MODEL_ENV] = model
+    thinking = thinking_override if thinking_override is not None else config.thinking
+    if thinking:
+        env[THINKING_ENV] = thinking
     if config.false_completion_check:
         env[FALSE_COMPLETION_CHECK_ENV] = "1"
 

--- a/apps/worker/src/curie_worker/config.py
+++ b/apps/worker/src/curie_worker/config.py
@@ -133,6 +133,13 @@ class WorkerConfig(BaseSettings):
     model_api_backend: str = Field(default="", validation_alias="CURIE_MODEL_API_BACKEND")
     model_env_key: str = Field(default="", validation_alias="CURIE_MODEL_ENV_KEY")
     model: str = Field(default="", validation_alias="CURIE_MODEL")
+    # Platform-default thinking depth (#1182, ADR-0098), the lower of the two
+    # operator layers; a per-agent `agents.thinking` overrides it. Empty means
+    # unset, in which case the runner is sent no thinking configuration at all
+    # and the model's own default applies -- the pre-#1182 behavior verbatim.
+    # Operator-only by design: never derived from the agent row's bundle, and a
+    # bundle has no surface for it at any tier.
+    thinking: str = Field(default="", validation_alias="CURIE_THINKING")
 
     # Opt-in false-completion check (#517, #669), operator scope like
     # model_api_backend/model_env_key: forwarded verbatim into every boot env as

--- a/apps/worker/tests/binding/test_boot_env_single_declaration.py
+++ b/apps/worker/tests/binding/test_boot_env_single_declaration.py
@@ -203,6 +203,12 @@ _EXEMPT: dict[tuple[str, str], str] = {
     # the consumer is the worker process, not the sandbox.
     ("apps/worker/src/curie_worker/config.py", "CURIE_PLUGIN_DIR"): "worker service config",
     ("apps/worker/src/curie_worker/config.py", "CURIE_MODEL"): "worker service config",
+    # Same shape as CURIE_MODEL directly above, and the same honest test: the
+    # sandbox-side name is derived from the declaration on BOTH real boot sites
+    # (binding.THINKING_ENV renders it, the runner reads boot.thinking from
+    # BootEnv.from_env), so a rename still moves them. This site is the worker
+    # process reading its own env to decide what to inject (#1182, ADR-0098).
+    ("apps/worker/src/curie_worker/config.py", "CURIE_THINKING"): "worker service config",
     ("apps/worker/src/curie_worker/config.py", "CURIE_FAKE_MODEL"): "worker service config",
     ("apps/worker/src/curie_worker/config.py", "CURIE_CREDENTIALS"): "worker service config",
     # Same shape as the four above: the operator declares the endpoint's wire

--- a/apps/worker/tests/binding/test_model_env.py
+++ b/apps/worker/tests/binding/test_model_env.py
@@ -16,6 +16,7 @@ from curie_worker.binding import (
     CREDENTIALS_ENV,
     FAKE_MODEL_ENV,
     MODEL_ENV,
+    THINKING_ENV,
     BindingResolver,
     ResolvedDeployment,
     apply_model_env,
@@ -25,7 +26,7 @@ from curie_worker.eval.stream import EvalJob, EvalStreamConsumer
 from curie_worker.sandbox_token import verify
 
 
-def _resolved(model: str | None = None) -> ResolvedDeployment:
+def _resolved(model: str | None = None, thinking: str | None = None) -> ResolvedDeployment:
     return ResolvedDeployment(
         agent_id=uuid.uuid4(),
         agent_name="test-agent",
@@ -35,6 +36,7 @@ def _resolved(model: str | None = None) -> ResolvedDeployment:
         max_usd_per_day=None,
         max_output_tokens_per_run=None,
         model=model,
+        thinking=thinking,
     )
 
 
@@ -326,14 +328,24 @@ def test_eval_boot_env_carries_api_backend_and_env_key() -> None:
 
 
 def test_apply_model_env_has_no_per_agent_override_params() -> None:
-    # Signature pin. model_override (#254, the per-agent model) is the ONLY
-    # per-agent parameter this function may take. A new *_override parameter here
-    # is the shape of the regression: it would mean an agent row can aim the
-    # credential read or redeclare the wire protocol.
+    # Signature pin, still exact. Exactly TWO per-agent parameters are allowed
+    # here, each authorized by name: model_override (#254, the per-agent model)
+    # and thinking_override (#1182, ADR-0098, the per-agent thinking depth).
+    #
+    # The regression this guards has not changed shape: a NEW *_override
+    # parameter would mean an agent row can aim the credential read or redeclare
+    # the wire protocol. Thinking depth is neither -- it is the same
+    # capability-versus-cost axis as the model itself, which is why ADR-0098
+    # placed it beside model rather than beside api_backend. Widening this set
+    # again needs the same kind of argument, on the record.
+    #
+    # The teeth are in the two tests below, which are unchanged and still pass:
+    # api_backend and env_key never reach ResolvedDeployment and can never be
+    # supplied per agent.
     import inspect
 
     params = set(inspect.signature(apply_model_env).parameters)
-    assert params == {"env", "config", "model_override"}
+    assert params == {"env", "config", "model_override", "thinking_override"}
 
 
 def test_resolved_deployment_carries_no_api_backend_or_env_key_field() -> None:
@@ -559,3 +571,55 @@ def test_resolved_deployment_carries_no_false_completion_check_field() -> None:
     # boot_env would have a per-agent value to forward.
     fields = set(ResolvedDeployment.model_fields)
     assert "false_completion_check" not in fields
+
+
+# --- thinking depth: the two operator layers (#1182, ADR-0098) ----------------
+# Mirrors the model tests directly, because the precedence IS the model's: the
+# agent row wins, then the platform default, then nothing at all. The third case
+# is the load-bearing one -- "nothing at all" is what keeps an unconfigured
+# install behaving exactly as it did before this feature existed.
+
+
+def test_thinking_unset_at_both_layers_writes_nothing() -> None:
+    # Not "adaptive", not an empty string: the key must be ABSENT, so the runner
+    # omits the SDK option and the model's own default stands.
+    env: dict[str, str] = {}
+    apply_model_env(env, WorkerConfig())
+    assert THINKING_ENV not in env
+
+
+def test_thinking_platform_default_is_forwarded() -> None:
+    env: dict[str, str] = {}
+    apply_model_env(env, WorkerConfig(thinking="adaptive"))
+    assert env[THINKING_ENV] == "adaptive"
+
+
+def test_thinking_per_agent_value_wins_over_the_platform_default() -> None:
+    env: dict[str, str] = {}
+    apply_model_env(env, WorkerConfig(thinking="adaptive"), thinking_override="disabled")
+    assert env[THINKING_ENV] == "disabled"
+
+
+def test_boot_env_applies_the_same_precedence_on_the_runs_lane() -> None:
+    # The eval lane goes through apply_model_env; the runs lane goes through
+    # boot_env. They are the sibling paths that must not drift, so pin the runs
+    # lane against the same three cases.
+    resolver = BindingResolver.__new__(BindingResolver)
+
+    resolver._config = WorkerConfig()  # type: ignore[attr-defined]
+    assert THINKING_ENV not in resolver.boot_env(_resolved(), "thread-1")
+
+    resolver._config = WorkerConfig(thinking="enabled:2000")  # type: ignore[attr-defined]
+    assert resolver.boot_env(_resolved(), "thread-1")[THINKING_ENV] == "enabled:2000"
+
+    env = resolver.boot_env(_resolved(thinking="disabled"), "thread-1")
+    assert env[THINKING_ENV] == "disabled"
+
+
+def test_an_empty_per_agent_thinking_does_not_emit_an_empty_key() -> None:
+    # A cleared column reads as "" through some paths; an empty value is "unset",
+    # never a value, or the runner would parse "" and the operator would see a
+    # knob that does nothing.
+    resolver = BindingResolver.__new__(BindingResolver)
+    resolver._config = WorkerConfig()  # type: ignore[attr-defined]
+    assert THINKING_ENV not in resolver.boot_env(_resolved(thinking=""), "thread-1")

--- a/cli/api-mirrors.json
+++ b/cli/api-mirrors.json
@@ -21,6 +21,10 @@
           "why": "The CLI never displays or acts on an agent's default model (model routing is server- and claim-time bound, #473); the deploy and lifecycle verbs read only id/name/slack_channel."
         },
         {
+          "field": "thinking",
+          "why": "Same reason as model directly above, and the same ownership: thinking depth is resolved server-side at claim time into the sandbox boot env (#1182, ADR-0098). No CLI verb displays or acts on it; an operator sets it through the platform API."
+        },
+        {
           "field": "secrets",
           "why": "update_agent_secrets WRITES connector-secret names; the CLI never reads the stored secrets list back, so the response field is not modeled."
         },

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,6 +40,10 @@ git history (`git log -- docs/`).
 - [`approvals.md`](approvals.md): the human-in-the-loop plane. How a turn pauses
   for a human decision, how a route is declared and bound to a channel, who is
   allowed to resolve it, and the resume turn your skill has to handle.
+- [`thinking.md`](thinking.md): what a reasoning model costs you and how to
+  change it — the measured latency gap, the two operator layers that turn
+  thinking down, and the OpenRouter parameter that looks like it works and does
+  not.
 - [`behavior-packs.md`](behavior-packs.md): per-agent, opt-in UX touches (load
   lines, capability tips, greeting/help) applied around a turn — why packs are
   declarative data rather than code, and what is wired today.

--- a/docs/thinking.md
+++ b/docs/thinking.md
@@ -1,0 +1,120 @@
+# Thinking depth: what a reasoning model costs you
+
+Some models answer. Others think first, at length, and then answer. That second
+kind is not slower because something is wrong — the thinking IS the product —
+but it is dramatically slower, and until you know that is what you are looking
+at, a turn that takes 45 seconds looks like a turn that is stuck.
+
+This page is how to see that cost and how to change it. The decision behind the
+shape lives in
+[ADR-0098](adr/0098-thinking-depth-is-an-operator-knob-never-a-bundle-one.md).
+
+## The measurement
+
+Same question, same 2048-token ceiling, same endpoint Curie dials (OpenRouter's
+Anthropic-compatible `/v1/messages`):
+
+| model | wall clock | output tokens | of which thinking |
+|---|---|---|---|
+| `anthropic/claude-sonnet-4.5` | 2.4s | 95 | **0** |
+| `z-ai/glm-5.2` | 8.1s | 380 | **268** (70%) |
+| `z-ai/glm-5.2` with thinking disabled | **1.7s** | 182 | **0** |
+
+`z-ai/glm-5.2` is not an outlier. `deepseek/deepseek-r1` defaults to 259
+thinking tokens on that prompt and `qwen/qwen3-235b-a22b-thinking-2507` to 613.
+Reasoning-on is simply the default for that class of model, while
+`claude-sonnet-4.5` defaults it off — so comparing one of each and concluding
+"the provider is slow" is the easy mistake to make (issue #1182).
+
+## Turning it down
+
+Two layers, both operator-owned. Nothing in a bundle can set or influence
+either one, at any tier — the same rule that governs which model an agent runs.
+
+**The platform default** is `CURIE_THINKING` on the worker, set wherever you set
+the worker's other env (compose, or `worker.extraEnv` in the chart):
+
+```bash
+CURIE_THINKING=disabled
+```
+
+**Per agent** is the `thinking` column, set through the platform API, and it
+wins over the platform default for that agent only:
+
+```bash
+curl -X PATCH "$CURIE_API_URL/agents/$AGENT_ID" \
+  -H "X-API-Key: $CURIE_API_KEY" -H 'content-type: application/json' \
+  -d '{"thinking": "adaptive"}'
+```
+
+### The vocabulary
+
+| value | effect |
+|---|---|
+| `disabled` | no extended thinking at all |
+| `adaptive` | the model decides when and how much |
+| `enabled:<tokens>` | a fixed thinking budget, e.g. `enabled:2000` |
+
+**Unset is not a fourth value.** With neither layer set, Curie sends the model
+no thinking configuration whatsoever and the model's own default stands — which
+is exactly how every install behaved before this knob existed. "No opinion" and
+"explicitly adaptive" are different instructions, and only the first one is the
+status quo.
+
+A value outside that vocabulary fails the sandbox boot with a message naming
+what is accepted. That is deliberate: a knob that silently ignores `disable`
+(no trailing `d`) is worse than one that refuses it, because the operator
+concludes the feature does not work.
+
+## Before you disable it
+
+Reasoning is what a reasoning model is *for*, and Curie's own workload — multi-
+step tool loops, judgement calls, noticing its own mistakes — is where it earns
+its cost. The 4.8x above is an argument for having the choice, not for making
+it one way everywhere.
+
+A small illustration from the same measurements: asked for the weather, every
+model that was allowed to think said it had no real-time data. The fastest
+zero-thinking model in the comparison made a number up. One prompt is not an
+evaluation, but it is the shape of the trade.
+
+If you have eval cases, you have the honest way to decide: run them at
+`disabled`, at `adaptive`, and unset, and compare pass rate against latency on
+your own agent instead of on a table in a doc.
+
+## ⚠️ The OpenRouter trap
+
+If you go looking for how to turn reasoning off on OpenRouter, you will find
+`reasoning: {"enabled": false}`. **It does nothing on the endpoint Curie
+uses**, and it does not error either — the request succeeds and the model keeps
+thinking.
+
+The reason is that OpenRouter has two doors, and Curie goes through the second
+one:
+
+| | `/v1/chat/completions` (OpenAI-shaped) | `/v1/messages` (Anthropic-shaped) |
+|---|---|---|
+| the parameter | `reasoning` | `thinking` |
+| the response field | `reasoning`, `reasoning_details` | a `thinking` content block |
+| the token count | `completion_tokens_details.reasoning_tokens` | `output_tokens_details.thinking_tokens` |
+| `reasoning: {enabled: false}` | works | **silently ignored** |
+
+Curie speaks the Anthropic Messages format everywhere (the runner is built on
+claude-agent-sdk, and staying on that wire keeps prompt caching intact), so the
+Anthropic vocabulary is the one that reaches the model. `CURIE_THINKING` sends
+it for you; you should not need to touch the raw parameter at all.
+
+Prompt caching, for the record, is **not** the problem: both `claude-sonnet-4.5`
+and `z-ai/glm-5.2` were measured reusing a cached prefix through that endpoint.
+Thinking tokens are where the time goes.
+
+## Where the code is
+
+| Concern | Path |
+|---|---|
+| The vocabulary and its parse | `runner/src/curie_runner/thinking.py` |
+| Handing it to the SDK (omitted when unset) | `runner/src/curie_runner/adapter.py` |
+| The two operator layers and their precedence | `apps/worker/src/curie_worker/binding.py::apply_model_env` |
+| The platform default | `apps/worker/src/curie_worker/config.py` |
+| The per-agent column | `apps/api/src/curie_api/models.py` |
+| The declared boot key | `packages/aci-protocol/src/aci_protocol/session.py::BootEnv` |

--- a/runner/src/curie_runner/__main__.py
+++ b/runner/src/curie_runner/__main__.py
@@ -210,6 +210,9 @@ def build_runner(
             # no longer feeds resume. build_options keeps the param for an explicit
             # caller; the boot path passes None.
             resume=None,
+            # Operator-set thinking depth (#1182, ADR-0098); None omits the SDK
+            # option entirely rather than defaulting it.
+            thinking=config.thinking,
             task_budget_hint=config.session.budget.task_budget_hint,
             env=sdk_env or {},
             hooks=bundle_hooks,

--- a/runner/src/curie_runner/adapter.py
+++ b/runner/src/curie_runner/adapter.py
@@ -60,6 +60,7 @@ def build_options(
     max_turns: int,
     max_budget_usd: float | None,
     resume: str | None,
+    thinking: dict[str, Any] | None = None,
     task_budget_hint: int | None = None,
     env: dict[str, str] | None = None,
     hooks: dict[str, list[HookMatcher]] | None = None,
@@ -90,9 +91,15 @@ def build_options(
     permission_mode: PermissionMode = (
         "default" if can_use_tool is not None else "bypassPermissions"
     )
+    # OMITTED, not defaulted, when the operator set nothing (#1182, ADR-0098).
+    # Passing thinking=None would be a value the SDK could act on; leaving the
+    # key out is the only way to say "no opinion", which is what an unconfigured
+    # install has always said and must keep saying.
+    thinking_option: dict[str, Any] = {"thinking": cast("Any", thinking)} if thinking else {}
     return ClaudeAgentOptions(
         plugins=plugins,
         model=model,
+        **thinking_option,
         system_prompt=system_prompt,
         max_turns=max_turns,
         max_budget_usd=max_budget_usd,

--- a/runner/src/curie_runner/config.py
+++ b/runner/src/curie_runner/config.py
@@ -16,16 +16,25 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass
+from typing import Any
 
 from aci_protocol import BootEnv, SessionConfig
 
 from .harness.registry import DEFAULT_HARNESS
+from .thinking import parse_thinking
 
 
 @dataclass(frozen=True)
 class RunnerConfig:
     session: SessionConfig
     model: str | None
+    # The SDK thinking config parsed from CURIE_THINKING (#1182, ADR-0098), or
+    # None when the operator set nothing -- in which case the option is OMITTED
+    # from ClaudeAgentOptions rather than defaulted, so the model's own behavior
+    # is untouched. Parsed here at boot so a malformed value fails the boot
+    # loudly instead of being silently dropped on every turn. The vocabulary is
+    # this lane's (curie_runner.thinking), not the boot contract's.
+    thinking: dict[str, Any] | None
     # The harness whose contribution manifest drives this runner (ADR-0060,
     # #844): read from the runner-local CURIE_HARNESS knob (default the
     # built-in Claude), NOT a BootEnv contract key -- the same runner-local read
@@ -125,6 +134,7 @@ class RunnerConfig:
         return cls(
             session=boot.session,
             model=boot.model,
+            thinking=parse_thinking(boot.thinking),
             harness=harness,
             max_turns=boot.max_turns if boot.max_turns is not None else 20,
             connector_release=boot.connector_release,

--- a/runner/src/curie_runner/thinking.py
+++ b/runner/src/curie_runner/thinking.py
@@ -1,0 +1,89 @@
+"""The thinking-depth vocabulary and its parse (#1182, ADR-0098).
+
+The boot contract carries ``CURIE_THINKING`` as an opaque ``str`` on purpose:
+``BootEnv`` must not mirror claude-agent-sdk's option shape, or swapping the
+harness becomes a protocol change. So the vocabulary and its rejection live
+here, on the consumer side -- exactly where ``ApiBackend`` lives for
+``api_backend`` (#514, ``sdk_auth``).
+
+The grammar is three words, chosen to be the operator's vocabulary rather than
+the SDK's::
+
+    disabled            no extended thinking at all
+    adaptive            the model decides when and how much
+    enabled:<tokens>    a fixed thinking budget, e.g. enabled:2000
+
+Unset (or empty) is NOT a fourth value. It means the knob was never turned, and
+the runner then sends the SDK no thinking configuration whatsoever, leaving the
+model's own default in force. That distinction is the whole reason an
+unconfigured install behaves after #1182 exactly as it did before: "no opinion"
+and "explicitly adaptive" are different instructions, and only the first one is
+the status quo.
+
+A malformed value is rejected loudly at boot rather than dropped. A silently
+ignored knob is the worst outcome here: an operator sets ``disable`` (no `d`),
+sees no error, and concludes Curie cannot control reasoning -- which is the
+report this whole change answers.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Final
+
+DISABLED: Final = "disabled"
+ADAPTIVE: Final = "adaptive"
+_ENABLED_PREFIX: Final = "enabled:"
+
+# Named for the error message, which lists what IS accepted rather than only
+# saying what was not: an operator who mistypes needs the vocabulary, not a
+# verdict.
+_VOCABULARY: Final = f"{DISABLED!r}, {ADAPTIVE!r}, or 'enabled:<budget_tokens>'"
+
+
+class ThinkingError(ValueError):
+    """A `CURIE_THINKING` value outside the declared vocabulary."""
+
+
+def parse_thinking(raw: str | None) -> dict[str, Any] | None:
+    """Turn a raw ``CURIE_THINKING`` value into an SDK thinking config.
+
+    Args:
+      raw: the boot value, or None/empty when the knob was never set.
+
+    Returns:
+      The mapping to hand ``ClaudeAgentOptions.thinking``, or None when the knob
+      is unset -- in which case the caller must omit the option entirely rather
+      than pass a default, so the model's own behavior is untouched.
+
+    Raises:
+      ThinkingError: the value is outside the vocabulary, or names a budget that
+        is not a positive integer.
+    """
+    if raw is None:
+        return None
+    value = raw.strip()
+    if not value:
+        return None
+    if value == DISABLED:
+        return {"type": "disabled"}
+    if value == ADAPTIVE:
+        return {"type": "adaptive"}
+    if value.startswith(_ENABLED_PREFIX):
+        budget_raw = value[len(_ENABLED_PREFIX) :].strip()
+        try:
+            budget = int(budget_raw)
+        except ValueError:
+            raise ThinkingError(
+                f"thinking budget {budget_raw!r} is not an integer; "
+                f"expected 'enabled:<budget_tokens>', e.g. 'enabled:2000'"
+            ) from None
+        # Zero or negative is not "off" -- `disabled` is off. Accepting it would
+        # hand the SDK a budget it cannot honor and make two spellings of the
+        # same intent, one of which is a typo of a real budget.
+        if budget <= 0:
+            raise ThinkingError(
+                f"thinking budget must be a positive integer, got {budget}; "
+                f"use {DISABLED!r} to turn thinking off"
+            )
+        return {"type": "enabled", "budget_tokens": budget}
+    raise ThinkingError(f"unknown thinking value {value!r}; expected {_VOCABULARY}")

--- a/runner/tests/test_thinking.py
+++ b/runner/tests/test_thinking.py
@@ -1,0 +1,75 @@
+"""The thinking vocabulary and its parse (#1182, ADR-0098).
+
+The load-bearing case is the FIRST one: unset must produce None, so the caller
+omits the SDK option entirely. "No opinion" and "explicitly adaptive" are
+different instructions to a model, and only the first is the pre-#1182 status
+quo -- an install that configures nothing must behave exactly as it always has.
+"""
+
+from __future__ import annotations
+
+import pytest
+from curie_runner.thinking import ThinkingError, parse_thinking
+
+
+@pytest.mark.parametrize("raw", [None, "", "   ", "\t\n"])
+def test_unset_parses_to_none_so_the_option_is_omitted(raw: str | None) -> None:
+    # None here is not a default; it is the signal to leave `thinking` out of
+    # ClaudeAgentOptions altogether. Returning {"type": "adaptive"} instead would
+    # silently start configuring every model on every install.
+    assert parse_thinking(raw) is None
+
+
+def test_disabled_and_adaptive_map_to_their_sdk_shapes() -> None:
+    assert parse_thinking("disabled") == {"type": "disabled"}
+    assert parse_thinking("adaptive") == {"type": "adaptive"}
+    # Surrounding whitespace is an operator typo in a values file, not a value.
+    assert parse_thinking("  disabled  ") == {"type": "disabled"}
+
+
+def test_enabled_carries_the_budget_through() -> None:
+    assert parse_thinking("enabled:2000") == {"type": "enabled", "budget_tokens": 2000}
+    assert parse_thinking("enabled: 512 ") == {"type": "enabled", "budget_tokens": 512}
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "disable",  # the plausible typo: no trailing 'd'
+        "off",  # the plausible synonym
+        "none",
+        "true",
+        "ENABLED:2000",  # the vocabulary is lowercase; near-miss must not pass
+        "enabled",  # the prefix without a budget
+        "enabled:",
+        "enabled:lots",
+        "2000",  # a bare number is not the grammar
+    ],
+)
+def test_a_value_outside_the_vocabulary_is_rejected_loudly(raw: str) -> None:
+    # Rejected at boot, never dropped. A silently ignored knob is the failure
+    # this whole change exists to answer: the operator sets it, sees no error,
+    # and concludes Curie cannot control reasoning.
+    with pytest.raises(ThinkingError):
+        parse_thinking(raw)
+
+
+@pytest.mark.parametrize("budget", [0, -1, -2000])
+def test_a_nonpositive_budget_is_rejected_rather_than_treated_as_off(budget: int) -> None:
+    # `enabled:0` is not a second spelling of `disabled`. Accepting it would hand
+    # the SDK a budget it cannot honor, and it is a plausible typo of a real
+    # budget (a dropped digit), so it must fail rather than quietly mean "off".
+    with pytest.raises(ThinkingError) as excinfo:
+        parse_thinking(f"enabled:{budget}")
+    assert "disabled" in str(excinfo.value), "the error must name the way to turn it off"
+
+
+def test_the_error_names_the_vocabulary_not_just_the_verdict() -> None:
+    # An operator who mistypes needs to be told what IS accepted; a bare
+    # rejection sends them to the source.
+    with pytest.raises(ThinkingError) as excinfo:
+        parse_thinking("disable")
+    message = str(excinfo.value)
+    assert "disable" in message, "the rejected value must be quoted back"
+    for word in ("disabled", "adaptive", "enabled:<budget_tokens>"):
+        assert word in message, f"the error must offer {word!r}"


### PR DESCRIPTION
Closes #1182. Implements [ADR-0098](https://github.com/curie-eng/curie/blob/main/docs/adr/0098-thinking-depth-is-an-operator-knob-never-a-bundle-one.md) on top of the boot key #1298 declared.

## What it was

Curie set nothing. The runner handed `claude-agent-sdk` twelve option fields and none of them was `thinking`, so whatever the model shipped with is what ran. On the endpoint Curie dials, same prompt:

| model | wall clock | output | of which thinking |
|---|---|---|---|
| `anthropic/claude-sonnet-4.5` | 2.4s | 95 | **0** |
| `z-ai/glm-5.2` | 8.1s | 380 | **268** (70%) |
| `z-ai/glm-5.2`, thinking disabled | **1.7s** | 182 | **0** |

The reporter compared a model that reasons against one that doesn't and got 6s vs 45s. Nobody could see why, and nobody could change it.

## The two layers

```
CURIE_THINKING on the worker    platform default
agents.thinking (migration 0019) per-agent override, wins
bundle                           — nothing, at any tier
```

Exactly the shape and precedence `model` already has, reusing `apply_model_env` rather than growing a second mechanism.

**Unset at both layers writes no boot key, the runner omits the SDK option entirely, and the model's own default stands** — so an install that configures nothing behaves precisely as it did before this existed. That is why the option is *omitted* rather than defaulted to `None`: "no opinion" and "explicitly adaptive" are different instructions to a model, and only the first one is the status quo.

## Where the vocabulary lives

In the runner (`curie_runner/thinking.py`), not the contract and not the database: `disabled`, `adaptive`, `enabled:<tokens>`. `BootEnv` carries an opaque `str` so the wire never mirrors claude-agent-sdk's option shape — the same division `ApiBackend` has for `api_backend` (#514).

A value outside the vocabulary **fails the boot** with a message naming what is accepted. A knob that silently ignores `disable` (no trailing `d`) is worse than one that refuses it: the operator concludes the feature does not work, which is the report this change answers.

The API stores the value verbatim and does not validate it — the same bargain `model` already makes, since the API does not know which model ids a provider accepts either. There is a test pinning that as deliberate.

## ⚠️ The guard test I had to widen — please look at this one

`test_apply_model_env_has_no_per_agent_override_params` pinned `model_override` as the **only** per-agent parameter. It now pins exactly two, each authorized by name.

I want a reviewer's eyes on this rather than a quiet diff, so, the argument:

- The regression it guards is **unchanged in shape**: an agent row must never aim the credential read or redeclare the wire protocol. That is what its comment says, and it is still true.
- Thinking depth is **neither of those**. It is the same capability-versus-cost axis as the model itself, which is why ADR-0098 placed it beside `model` rather than beside `api_backend`.
- It is **still an exact-set assert**, so a third `*_override` still fails and needs the same argument on the record.
- **The teeth are elsewhere and untouched**: `test_resolved_deployment_carries_no_api_backend_or_env_key_field` and `test_binding_boot_env_api_backend_is_not_overridable_per_agent` enforce the actual boundary and both still pass unmodified.

Similarly, `CURIE_THINKING` is exempted in the boot-env declaration gate on precisely the grounds `CURIE_MODEL` already is: `WorkerConfig` reads the **worker's** env to decide what to inject, while both real boot sites derive the name from `BootEnv` (`binding.THINKING_ENV` renders it, the runner reads `boot.thinking`), so a rename still moves them.

## Proof

Every layer's production change was reverted in turn and the tests caught it:

| reverted | fails |
|---|---|
| the router's PATCH wiring | `test_patch_sets_thinking` |
| `thinking=data.thinking` on the create path | 3 API tests |
| `apply_model_env`'s forwarding | `test_thinking_platform_default_is_forwarded`, `..._per_agent_value_wins...` |
| `boot_env`'s per-agent precedence | `test_boot_env_applies_the_same_precedence_on_the_runs_lane` |
| `parse_thinking`'s unset branch (returning `adaptive` instead of `None`) | `test_unset_parses_to_none_so_the_option_is_omitted` |

That last one is the one that matters most: it is the difference between "this feature is opt-in" and "this feature quietly started configuring every model on every install".

New tests: 19 in `runner/tests/test_thinking.py` (the vocabulary, the near-miss typos `disable`/`off`/`ENABLED:2000`, `enabled:0` refusing to be a second spelling of `disabled`, and the error naming the vocabulary rather than only the verdict), 5 worker tests covering both lanes' precedence, and 5 API round-trip tests against real Postgres.

Local gates: `ruff check .`, `mypy` (177 files), `./scripts/check-contracts.sh` (clean — no contract touched here), `bash scripts/check-docs.sh`, `curie dev field-parity`, and `pytest apps/api/tests apps/worker/tests runner/tests packages` → **2179 passed**.

Seven failures remain in that run and **all seven fail identically on `main` with this branch stashed** — verified, not assumed: the Langfuse-backed cost test, five eval-stream tests, and the live permission-gate test. None are touched by this change.

## Docs

New `docs/thinking.md`, indexed in `docs/README.md`, is the prose home: the measurement, the vocabulary, how to set both layers, and — the part most people will need — **the OpenRouter trap**.

If you search for how to turn reasoning off on OpenRouter you will find `reasoning: {"enabled": false}`. It does nothing on the Anthropic-shaped endpoint Curie uses, and it does not error either. Both doors are documented side by side so nobody loses an afternoon to it.

It also argues *against* reflexively disabling thinking, with an illustration from the same measurements: asked for the weather, every model allowed to think said it had no real-time data; the fastest zero-thinking model made a number up.

## Scope

`effort` is deliberately still out. It is a real SDK control, but the measurements verified `thinking`, not `effort`, on the third-party endpoints that motivate this — shipping an unverified knob hands operators a control without knowing it does anything on their provider. Additive later, and cheap once someone verifies it.
