### PR TITLE
`curie diff` reports what apply would change, honestly

### DIFF
--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -3793,6 +3793,26 @@ export const commandManifest = {
       "hidden": false,
       "long_about": "Converge a cluster to a `curie.yaml` installation file (ADR-0097).\n\nThe file states the whole intent, so `apply` never has to be told what it was told last time -- the gap behind the dropped-settings failures the `--set`/`--reuse-values` shape kept producing.",
       "name": "apply"
+    },
+    {
+      "about": "Show what `curie apply` would change about the live release (ADR-0097)",
+      "args": [
+        {
+          "default_values": [
+            "curie.yaml"
+          ],
+          "global": false,
+          "help": "Path to the installation file",
+          "id": "file",
+          "long": "file",
+          "positional": false,
+          "required": false,
+          "short": "f"
+        }
+      ],
+      "hidden": false,
+      "long_about": "Show what `curie apply` would change about the live release (ADR-0097).\n\nRead-only, and resolves no credential: \"what would change?\" is most urgent while an install is still incomplete. A value the release carries that the file does not declare is reported as preserved or as a reset according to what `up` actually does with it, never guessed.",
+      "name": "diff"
     }
   ]
 } as const;

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -3790,6 +3790,26 @@
       "hidden": false,
       "long_about": "Converge a cluster to a `curie.yaml` installation file (ADR-0097).\n\nThe file states the whole intent, so `apply` never has to be told what it was told last time -- the gap behind the dropped-settings failures the `--set`/`--reuse-values` shape kept producing.",
       "name": "apply"
+    },
+    {
+      "about": "Show what `curie apply` would change about the live release (ADR-0097)",
+      "args": [
+        {
+          "default_values": [
+            "curie.yaml"
+          ],
+          "global": false,
+          "help": "Path to the installation file",
+          "id": "file",
+          "long": "file",
+          "positional": false,
+          "required": false,
+          "short": "f"
+        }
+      ],
+      "hidden": false,
+      "long_about": "Show what `curie apply` would change about the live release (ADR-0097).\n\nRead-only, and resolves no credential: \"what would change?\" is most urgent while an install is still incomplete. A value the release carries that the file does not declare is reported as preserved or as a reset according to what `up` actually does with it, never guessed.",
+      "name": "diff"
     }
   ]
 }

--- a/cli/schema/diff.schema.json
+++ b/cli/schema/diff.schema.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.curietech.ai/cli/diff/v1.json",
+  "title": "curie diff --json",
+  "description": "The agent-facing payload of `curie diff`: every chart value the installation file and the live release disagree about, plus the values the release carries that the file does not declare. Read-only; no credential is resolved. Secret-bearing values are rendered as the literal string `<secret>` and never in the clear.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "namespace": {
+      "type": "string"
+    },
+    "release": {
+      "type": "string"
+    },
+    "release_exists": {
+      "type": "boolean",
+      "description": "False when helm has no record of the release, in which case every declared value is an `add`."
+    },
+    "changes": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "How many entries would actually change the cluster: add, change, and reset. Deliberately excludes `unchanged` and `preserved`, so zero means applying the file is a no-op."
+    },
+    "entries": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "key": {
+            "type": "string",
+            "description": "The dotted chart value path, in helm `--set` syntax including `[i]` array indexing."
+          },
+          "kind": {
+            "enum": [
+              "add",
+              "change",
+              "unchanged",
+              "preserved",
+              "reset to chart default"
+            ],
+            "description": "`preserved` means the release carries this value, the file does not declare it, and a plain `cluster up` re-supplies it anyway (Slack tokens, the GitHub App, generated store passwords). It is NOT a pending removal. `reset to chart default` is the genuine loss case: undeclared and not carried forward."
+          },
+          "from": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The live value, or null when the release does not have this key. `<secret>` when the key carries a credential."
+          },
+          "to": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The declared value, or null when the file does not declare this key. `<secret>` when the key carries a credential."
+          }
+        },
+        "required": [
+          "key",
+          "kind",
+          "from",
+          "to"
+        ]
+      }
+    }
+  },
+  "required": [
+    "namespace",
+    "release",
+    "release_exists",
+    "changes",
+    "entries"
+  ]
+}

--- a/cli/schema/index.json
+++ b/cli/schema/index.json
@@ -70,6 +70,12 @@
       "version": 1
     },
     {
+      "result": "DiffOutput",
+      "kind": "CliOutput",
+      "schema": "diff.schema.json",
+      "version": 1
+    },
+    {
       "result": "DryRunPlan",
       "kind": "CliOutput",
       "schema": "dry-run.schema.json",

--- a/cli/src/installation.rs
+++ b/cli/src/installation.rs
@@ -644,6 +644,460 @@ pub async fn apply(opts: ApplyOpts) -> Result<ApplyOutput> {
     })
 }
 
+// -- curie diff ---------------------------------------------------------------
+
+/// How one chart value relates the file to the live release.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiffKind {
+    /// The file declares it; the release has no record of it.
+    Add,
+    /// Both have it, with different values.
+    Change,
+    /// Both agree. Reported so `diff` can show the whole intent, not just deltas.
+    Same,
+    /// Only the release has it, and a plain `up` carries it forward untouched.
+    /// NOT a removal -- see [`crate::ops::is_preserved_by_up`].
+    Preserved,
+    /// Only the release has it, and `apply` would reset it to the chart default.
+    Reset,
+}
+
+impl DiffKind {
+    /// The leading glyph. `~`/`+` are diff conventions; `!` marks the one kind
+    /// that loses configuration, so it does not read as ordinary noise.
+    pub fn marker(self) -> char {
+        match self {
+            DiffKind::Add => '+',
+            DiffKind::Change => '~',
+            DiffKind::Same => '=',
+            DiffKind::Preserved => '=',
+            DiffKind::Reset => '!',
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            DiffKind::Add => "add",
+            DiffKind::Change => "change",
+            DiffKind::Same => "unchanged",
+            DiffKind::Preserved => "preserved",
+            DiffKind::Reset => "reset to chart default",
+        }
+    }
+
+    /// Would applying this file change the cluster?
+    pub fn is_change(self) -> bool {
+        matches!(self, DiffKind::Add | DiffKind::Change | DiffKind::Reset)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiffEntry {
+    pub key: String,
+    pub kind: DiffKind,
+    /// The live value, already masked when the key carries a secret.
+    pub from: Option<String>,
+    /// The declared value, already masked when the key carries a secret.
+    pub to: Option<String>,
+}
+
+/// Flatten `helm get values -o json` into the dotted keys `--set` speaks.
+///
+/// Helm returns nested objects; the file and `up` both express values as dotted
+/// paths. Comparing the two shapes directly would report every key as missing.
+///
+/// Arrays are rendered with helm's own `key[i]` indexing rather than descended
+/// into as objects, so a declared `security.networkPolicy.allowedEgress[0].cidr`
+/// lines up with what a prior `--set` recorded.
+pub fn flatten_values(value: &serde_json::Value, prefix: &str, out: &mut BTreeMap<String, String>) {
+    match value {
+        serde_json::Value::Object(map) => {
+            for (k, v) in map {
+                let key = if prefix.is_empty() {
+                    k.clone()
+                } else {
+                    format!("{prefix}.{k}")
+                };
+                flatten_values(v, &key, out);
+            }
+        }
+        serde_json::Value::Array(items) => {
+            for (i, v) in items.iter().enumerate() {
+                flatten_values(v, &format!("{prefix}[{i}]"), out);
+            }
+        }
+        serde_json::Value::Null => {}
+        other => {
+            let rendered = match other {
+                serde_json::Value::String(s) => s.clone(),
+                v => v.to_string(),
+            };
+            out.insert(prefix.to_string(), rendered);
+        }
+    }
+}
+
+/// What a value may be shown as. A secret is never rendered, not even partially:
+/// this output goes to a terminal, a log, and a `--json` consumer.
+fn display_value(key: &str, value: &str) -> String {
+    if crate::ops::is_secret_value_key(key) {
+        "<secret>".to_string()
+    } else {
+        value.to_string()
+    }
+}
+
+/// Compare what the file declares against what the release records.
+///
+/// Pure: no cluster, no helm, no clock. The caller supplies both sides.
+///
+/// The `Preserved` classification is the point of the whole function. A cluster
+/// stood up by flags carries Slack tokens, a GitHub App, and generated store
+/// passwords that `curie.yaml` does not mention -- and `up` re-supplies every
+/// one of them. Calling those removals would make `diff` lie in the one
+/// situation it exists for: the operator deciding whether it is safe to adopt
+/// the file at all.
+pub fn diff_plan(
+    declared: &BTreeMap<String, String>,
+    live: Option<&serde_json::Value>,
+) -> Vec<DiffEntry> {
+    let mut current = BTreeMap::new();
+    if let Some(values) = live {
+        flatten_values(values, "", &mut current);
+    }
+
+    let mut entries: Vec<DiffEntry> = Vec::new();
+
+    for (key, want) in declared {
+        let kind = match current.get(key) {
+            None => DiffKind::Add,
+            Some(have) if have == want => DiffKind::Same,
+            Some(_) => DiffKind::Change,
+        };
+        entries.push(DiffEntry {
+            key: key.clone(),
+            kind,
+            from: current.get(key).map(|v| display_value(key, v)),
+            to: Some(display_value(key, want)),
+        });
+    }
+
+    for (key, have) in &current {
+        if declared.contains_key(key) {
+            continue;
+        }
+        let kind = if crate::ops::is_preserved_by_up(key) {
+            DiffKind::Preserved
+        } else {
+            DiffKind::Reset
+        };
+        entries.push(DiffEntry {
+            key: key.clone(),
+            kind,
+            from: Some(display_value(key, have)),
+            to: None,
+        });
+    }
+
+    entries.sort_by(|a, b| a.key.cmp(&b.key));
+    entries
+}
+
+/// What `curie diff` found.
+#[derive(Debug)]
+pub struct DiffOutput {
+    pub namespace: String,
+    pub release: String,
+    /// `false` when helm has no record of the release: everything is a create.
+    pub release_exists: bool,
+    pub entries: Vec<DiffEntry>,
+}
+
+impl DiffOutput {
+    pub fn changes(&self) -> usize {
+        self.entries.iter().filter(|e| e.kind.is_change()).count()
+    }
+}
+
+impl crate::ui::CliOutput for DiffOutput {
+    fn to_json(&self) -> serde_json::Value {
+        serde_json::json!({
+            "namespace": self.namespace,
+            "release": self.release,
+            "release_exists": self.release_exists,
+            "changes": self.changes(),
+            "entries": self.entries.iter().map(|e| serde_json::json!({
+                "key": e.key,
+                "kind": e.kind.label(),
+                "from": e.from,
+                "to": e.to,
+            })).collect::<Vec<_>>(),
+        })
+    }
+
+    fn render(&self, ui: &crate::ui::Ui) {
+        if !self.release_exists {
+            ui.payload_plain(&format!(
+                "release '{}' does not exist in namespace '{}' -- every value below would be created",
+                self.release, self.namespace
+            ));
+        }
+        for e in &self.entries {
+            let line = match (&e.from, &e.to) {
+                (Some(from), Some(to)) if e.kind == DiffKind::Change => {
+                    format!("{} {}: {} -> {}", e.kind.marker(), e.key, from, to)
+                }
+                (_, Some(to)) if e.kind == DiffKind::Add => {
+                    format!("{} {}: {}", e.kind.marker(), e.key, to)
+                }
+                (Some(from), None) => {
+                    format!(
+                        "{} {}: {} ({})",
+                        e.kind.marker(),
+                        e.key,
+                        from,
+                        e.kind.label()
+                    )
+                }
+                (_, Some(to)) => format!("{} {}: {}", e.kind.marker(), e.key, to),
+                _ => format!("{} {}", e.kind.marker(), e.key),
+            };
+            ui.payload_plain(&line);
+        }
+        let changes = self.changes();
+        if changes == 0 {
+            ui.payload_plain("no changes: the cluster already matches this file");
+        } else {
+            ui.payload_plain(&format!("{changes} change(s) would be applied"));
+        }
+        if self.entries.iter().any(|e| e.kind == DiffKind::Reset) {
+            ui.note(
+                "`!` marks a value the release carries that this file does not declare. \
+                 `curie apply` does a full upgrade, so it would go back to the chart \
+                 default. Declare it in curie.yaml to keep it.",
+            );
+        }
+    }
+}
+
+pub struct DiffOpts {
+    pub cfg: Installation,
+}
+
+/// Compare the file against the live release.
+///
+/// Read-only by construction: it resolves no credential and runs one
+/// `helm get values`. A missing credential must not stop an operator from
+/// asking what would change -- that question is most urgent precisely when the
+/// install is not yet complete.
+pub async fn diff(opts: DiffOpts) -> Result<DiffOutput> {
+    let cfg = opts.cfg;
+    let common = crate::ops::CommonOpts {
+        namespace: cfg.install.namespace.clone(),
+        release: cfg.install.release.clone(),
+        dry_run: false,
+    };
+
+    let live = crate::ops::fetch_release_values(&common).await?;
+
+    let mut declared = BTreeMap::new();
+    for entry in cfg.helm_sets() {
+        if let Some((k, v)) = entry.split_once('=') {
+            declared.insert(k.to_string(), v.to_string());
+        }
+    }
+
+    let entries = diff_plan(&declared, live.as_ref());
+    Ok(DiffOutput {
+        namespace: cfg.install.namespace,
+        release: cfg.install.release,
+        release_exists: live.is_some(),
+        entries,
+    })
+}
+
+#[cfg(test)]
+mod diff_tests {
+    use super::*;
+
+    fn live(json: serde_json::Value) -> serde_json::Value {
+        json
+    }
+
+    #[test]
+    fn nested_values_flatten_to_the_dotted_keys_set_speaks() {
+        let mut out = BTreeMap::new();
+        flatten_values(
+            &serde_json::json!({"ui": {"deploy": false}, "api": {"apiKey": "x"}}),
+            "",
+            &mut out,
+        );
+        assert_eq!(out.get("ui.deploy").map(String::as_str), Some("false"));
+        assert_eq!(out.get("api.apiKey").map(String::as_str), Some("x"));
+    }
+
+    /// Helm indexes arrays; descending into them as objects would misalign every
+    /// declared `allowedEgress[0].cidr` against what a prior --set recorded.
+    #[test]
+    fn arrays_flatten_with_helm_index_syntax() {
+        let mut out = BTreeMap::new();
+        flatten_values(
+            &serde_json::json!({"security": {"networkPolicy": {"allowedEgress": [{"cidr": "10.0.0.0/8"}]}}}),
+            "",
+            &mut out,
+        );
+        assert_eq!(
+            out.get("security.networkPolicy.allowedEgress[0].cidr")
+                .map(String::as_str),
+            Some("10.0.0.0/8")
+        );
+    }
+
+    #[test]
+    fn a_declared_key_the_release_lacks_is_an_add() {
+        let declared = BTreeMap::from([("ui.deploy".to_string(), "false".to_string())]);
+        let entries = diff_plan(&declared, Some(&live(serde_json::json!({}))));
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].kind, DiffKind::Add);
+    }
+
+    #[test]
+    fn matching_values_are_unchanged_and_count_as_no_change() {
+        let declared = BTreeMap::from([("ui.deploy".to_string(), "false".to_string())]);
+        let entries = diff_plan(
+            &declared,
+            Some(&live(serde_json::json!({"ui": {"deploy": false}}))),
+        );
+        assert_eq!(entries[0].kind, DiffKind::Same);
+        assert!(!entries[0].kind.is_change());
+    }
+
+    #[test]
+    fn a_differing_value_is_a_change_and_shows_both_sides() {
+        let declared = BTreeMap::from([("ui.deploy".to_string(), "false".to_string())]);
+        let entries = diff_plan(
+            &declared,
+            Some(&live(serde_json::json!({"ui": {"deploy": true}}))),
+        );
+        assert_eq!(entries[0].kind, DiffKind::Change);
+        assert_eq!(entries[0].from.as_deref(), Some("true"));
+        assert_eq!(entries[0].to.as_deref(), Some("false"));
+    }
+
+    /// The honesty requirement ADR-0097 named: a cluster stood up by flags
+    /// carries tokens and generated passwords the file never mentions, and `up`
+    /// re-supplies every one. Calling them removals would be a lie in exactly
+    /// the situation diff exists for.
+    #[test]
+    fn values_up_carries_forward_are_preserved_never_removals() {
+        let declared = BTreeMap::new();
+        let entries = diff_plan(
+            &declared,
+            Some(&live(serde_json::json!({
+                "dispatcher": {"slack": {"appToken": "xapp-x", "botToken": "xoxb-y"}},
+                "api": {"githubAppId": "4475970", "apiKey": "generated"},
+                "postgres": {"auth": {"password": "generated"}},
+            }))),
+        );
+        assert!(
+            !entries.is_empty(),
+            "the fixture declares several preserved keys"
+        );
+        for e in &entries {
+            assert_eq!(
+                e.kind,
+                DiffKind::Preserved,
+                "{} must not be reported as lost",
+                e.key
+            );
+            assert!(!e.kind.is_change(), "{} must not count as a change", e.key);
+        }
+    }
+
+    /// The other half: an undeclared key that `up` does NOT carry forward really
+    /// would be reset, and staying quiet about it would be the same lie inverted.
+    #[test]
+    fn an_undeclared_unpreserved_value_is_reported_as_a_reset() {
+        let declared = BTreeMap::new();
+        let entries = diff_plan(
+            &declared,
+            Some(&live(serde_json::json!({"ui": {"deploy": false}}))),
+        );
+        assert_eq!(entries[0].kind, DiffKind::Reset);
+        assert!(entries[0].kind.is_change(), "a reset is a real change");
+    }
+
+    /// `helm get values` returns real passwords. None may reach the output.
+    #[test]
+    fn secret_values_are_never_rendered() {
+        let declared = BTreeMap::from([(
+            "api.githubToken".to_string(),
+            "ghp_declared_secret".to_string(),
+        )]);
+        let entries = diff_plan(
+            &declared,
+            Some(&live(serde_json::json!({
+                "api": {"githubToken": "ghp_live_secret", "apiKey": "live_api_key"},
+                "dispatcher": {"slack": {"botToken": "xoxb-live"}},
+                "postgres": {"auth": {"password": "live_pg_password"}},
+                "agentSandbox": {"runner": {"credentials": "sk-ant-live"}},
+            }))),
+        );
+        let rendered = format!("{entries:?}");
+        for leaked in [
+            "ghp_declared_secret",
+            "ghp_live_secret",
+            "live_api_key",
+            "xoxb-live",
+            "live_pg_password",
+            "sk-ant-live",
+        ] {
+            assert!(
+                !rendered.contains(leaked),
+                "{leaked} must never appear in diff output: {rendered}"
+            );
+        }
+        assert!(rendered.contains("<secret>"), "must mask, not omit");
+    }
+
+    /// A non-secret value must still be shown, or the mask is useless noise.
+    #[test]
+    fn ordinary_values_are_shown_in_full() {
+        let declared = BTreeMap::from([("ui.deploy".to_string(), "false".to_string())]);
+        let entries = diff_plan(&declared, Some(&live(serde_json::json!({}))));
+        assert_eq!(entries[0].to.as_deref(), Some("false"));
+    }
+
+    #[test]
+    fn a_missing_release_makes_every_declared_value_an_add() {
+        let declared = BTreeMap::from([
+            ("ui.deploy".to_string(), "false".to_string()),
+            ("inference.deploy".to_string(), "false".to_string()),
+        ]);
+        let entries = diff_plan(&declared, None);
+        assert_eq!(entries.len(), 2);
+        assert!(entries.iter().all(|e| e.kind == DiffKind::Add));
+    }
+
+    #[test]
+    fn output_is_one_json_object_with_a_change_count() {
+        use crate::ui::CliOutput;
+        let out = DiffOutput {
+            namespace: "acme".into(),
+            release: "acme".into(),
+            release_exists: true,
+            entries: diff_plan(
+                &BTreeMap::from([("ui.deploy".to_string(), "false".to_string())]),
+                Some(&live(serde_json::json!({"ui": {"deploy": true}}))),
+            ),
+        };
+        let json = out.to_json();
+        assert_eq!(json["changes"], serde_json::json!(1));
+        assert_eq!(json["release_exists"], serde_json::json!(true));
+        assert_eq!(json["entries"][0]["kind"], serde_json::json!("change"));
+    }
+}
+
 #[cfg(test)]
 mod apply_tests {
     use super::*;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -404,6 +404,18 @@ enum Command {
         #[arg(long)]
         chart: Option<String>,
     },
+
+    /// Show what `curie apply` would change about the live release (ADR-0097).
+    ///
+    /// Read-only, and resolves no credential: "what would change?" is most
+    /// urgent while an install is still incomplete. A value the release carries
+    /// that the file does not declare is reported as preserved or as a reset
+    /// according to what `up` actually does with it, never guessed.
+    Diff {
+        /// Path to the installation file.
+        #[arg(short = 'f', long = "file", default_value = "curie.yaml")]
+        file: std::path::PathBuf,
+    },
 }
 
 #[derive(Subcommand)]
@@ -3073,6 +3085,10 @@ async fn run(command: Option<Command>) -> Result<()> {
                 })
                 .await?,
             )
+        }
+        Some(Command::Diff { file }) => {
+            let cfg = curie::installation::Installation::load(&file)?;
+            emit(curie::installation::diff(curie::installation::DiffOpts { cfg }).await?)
         }
     }
 }

--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -992,6 +992,43 @@ fn resolve_preserved_values(
     all
 }
 
+/// The chart value holding the model credential. Named here so the secret
+/// classifier below cannot drift from the key `up_commands` actually masks.
+pub(crate) const MODEL_CREDENTIAL_KEY: &str = "agentSandbox.runner.credentials";
+
+/// Does a plain `cluster up` carry this key forward when nothing re-passes it?
+///
+/// The honest half of `curie diff`. `up` does a FULL upgrade, so a key present
+/// on the release but absent from `curie.yaml` is normally reset to the chart
+/// default -- except for the families [`resolve_preserved_values`] re-supplies,
+/// which survive untouched. Reporting those as removals would be the exact
+/// "proposing to delete what it did not create" failure ADR-0097 named.
+///
+/// Reads the same constants `up` reads, so a new preserved family is picked up
+/// by both or neither.
+pub fn is_preserved_by_up(key: &str) -> bool {
+    COMMS_MANAGED_KEYS.contains(&key)
+        || GITHUB_APP_MANAGED_KEYS.contains(&key)
+        || REQUIRED_SECRETS.iter().any(|(k, _)| *k == key)
+}
+
+/// Does this key's VALUE carry a secret?
+///
+/// `helm get values` returns real passwords and tokens, so anything rendering a
+/// live release has to know which values must never reach a terminal, a log, or
+/// a `--json` consumer. Deliberately broader than [`is_preserved_by_up`]: the
+/// PAT and the model credential are secret but not preserved.
+pub fn is_secret_value_key(key: &str) -> bool {
+    is_preserved_by_up(key) || key == GITHUB_TOKEN_KEY || key == MODEL_CREDENTIAL_KEY
+}
+
+/// The user-supplied values helm recorded for a release, or `None` when the
+/// release does not exist. The read-only half of [`fetch_existing_values`],
+/// exposed for `curie diff`.
+pub async fn fetch_release_values(o: &CommonOpts) -> Result<Option<serde_json::Value>> {
+    fetch_existing_values(o).await
+}
+
 /// Resolve [`GITHUB_TOKEN_KEY`] for this run.
 ///
 /// - `flag` is the `--github-token` value: `None` when the flag and

--- a/cli/tests/json_contract.rs
+++ b/cli/tests/json_contract.rs
@@ -951,6 +951,49 @@ fn deploy_output_validates() {
 }
 
 #[test]
+fn diff_output_validates() {
+    // Built through `diff_plan` rather than hand-listing entries, so this
+    // validates the shape the real verb emits and not a parallel one.
+    let out = curie::installation::DiffOutput {
+        namespace: "acme-bot".to_string(),
+        release: "acme-bot".to_string(),
+        release_exists: true,
+        entries: curie::installation::diff_plan(
+            &std::collections::BTreeMap::from([("ui.deploy".to_string(), "false".to_string())]),
+            Some(&serde_json::json!({
+                "ui": {"deploy": true},
+                "dispatcher": {"slack": {"botToken": "xoxb-live"}},
+                "inference": {"deploy": true},
+            })),
+        ),
+    };
+    let json = out.to_json();
+    assert_valid("diff.schema.json", &json);
+
+    // Every classification the schema enumerates must be reachable from a real
+    // plan, or the enum is documenting states the code cannot produce.
+    let kinds: Vec<&str> = json["entries"]
+        .as_array()
+        .expect("entries is an array")
+        .iter()
+        .map(|e| e["kind"].as_str().expect("kind is a string"))
+        .collect();
+    for expected in ["change", "preserved", "reset to chart default"] {
+        assert!(
+            kinds.contains(&expected),
+            "fixture should exercise {expected}: got {kinds:?}"
+        );
+    }
+
+    // The live bot token is in the fixture; it must not be in the payload.
+    let rendered = serde_json::to_string(&json).expect("payload serializes");
+    assert!(
+        !rendered.contains("xoxb-live"),
+        "a live secret reached the --json payload: {rendered}"
+    );
+}
+
+#[test]
 fn check_output_validates() {
     // CheckOutput::to_json is `serde_json::to_value(report)`; validate that exact
     // shape against the check schema.

--- a/docs/interfaces/cli-output/INTERFACE.md
+++ b/docs/interfaces/cli-output/INTERFACE.md
@@ -92,9 +92,9 @@ Nine, all in the CLI crate:
   syntactic call-site inventory, not a type-level proof that *every* verb returns
   a `CliOutput`.
 - **Committed JSON Schemas with a drift gate (since #841).** Each `to_json` is no
-  longer schema-free: there are 34 committed schemas under `cli/schema/` with an
+  longer schema-free: there are 35 committed schemas under `cli/schema/` with an
   index (`cli/schema/index.json`), a `syn`-based inventory gate over every `impl
-  CliOutput`, and per-family output validation — all 34 are validated against real
+  CliOutput`, and per-family output validation — all 35 are validated against real
   `to_json()` output across 56 tests in `cli/tests/json_contract.rs`. Those tests
   drive each output type's `to_json()` once per output variant rather than calling
   the pure builder functions behind it, so a variant whose `to_json()` arm drifts

--- a/docs/interfaces/cli-output/INTERFACE.md
+++ b/docs/interfaces/cli-output/INTERFACE.md
@@ -95,7 +95,7 @@ Nine, all in the CLI crate:
   longer schema-free: there are 35 committed schemas under `cli/schema/` with an
   index (`cli/schema/index.json`), a `syn`-based inventory gate over every `impl
   CliOutput`, and per-family output validation — all 35 are validated against real
-  `to_json()` output across 56 tests in `cli/tests/json_contract.rs`. Those tests
+  `to_json()` output across 57 tests in `cli/tests/json_contract.rs`. Those tests
   drive each output type's `to_json()` once per output variant rather than calling
   the pure builder functions behind it, so a variant whose `to_json()` arm drifts
   from the schema is caught even when the builder it delegates to still validates.


### PR DESCRIPTION
The third verb [ADR-0097](https://github.com/curie-eng/curie/blob/main/docs/adr/0097-one-file-declares-an-installation.md) specified, and the one that makes the other two trustworthy — the ADR argued `--dry-run`/`diff` are not conveniences but the falsifiability requirement.

## The whole difficulty is one classification

`cluster up` does a **full** upgrade, so a value present on the release but absent from `curie.yaml` is normally reset to the chart default — *except* for the families `resolve_preserved_values` re-supplies: Slack tokens, the GitHub App, and the generated store passwords.

Reporting those as pending removals would be exactly the *"proposing to delete what it did not create"* failure the ADR named — and it would land on the precise keys whose loss caused #1067 and #1256.

So `diff` reads **the same constants `up` reads**, via two new classifiers in `ops.rs` (`is_preserved_by_up`, `is_secret_value_key`) rather than a second copy of the lists. A new preserved family is picked up by both or neither.

Real output, against a release stood up by flags:

```
= api.apiKey: <secret> (preserved)
= api.githubAppId: <secret> (preserved)
= dispatcher.slack.appToken: <secret> (preserved)
= dispatcher.slack.botToken: <secret> (preserved)
+ inference.deploy: false
= postgres.auth.password: <secret> (preserved)
! security.gvisor.mode: off (reset to chart default)
~ ui.deploy: true -> false
3 change(s) would be applied
```

The count excludes `preserved` and `unchanged`, so **zero means applying is a no-op**. `!` is the genuine loss case and gets an explicit note telling you to declare the key to keep it.

## Secrets

`helm get values` returns real passwords. Every secret-bearing key renders as `<secret>` in both the human and `--json` paths. The classifier is deliberately **wider** than the preserved set — the PAT and the model credential are secret without being preserved.

`diff` is read-only and resolves **no** credential on purpose: "what would change?" is most urgent while an install is still incomplete.

## Verification

Unit tests alone would pass with `main.rs` never calling `diff`, so I ran the real binary against a stub `helm`:

| case | result |
|---|---|
| preserved keys on a flag-built release | reported preserved, not removals |
| undeclared `security.gvisor.mode` | flagged `!` reset |
| changed value | both sides shown |
| release absent (helm exits 1) | "every value below would be created" |
| no credential exported | exits 0 and answers |
| 5 planted secrets, both output modes | none appear |

**Falsified by mutation**: making `is_preserved_by_up` always false fails 2 tests; rendering secrets in the clear fails 1. Restored clean.

`cargo fmt --check`, `clippy --all-targets -D warnings`, and all 20 test suites pass. Manifest regenerated via `cargo run -- schema` + `pnpm gen:manifest`; `diff.schema.json` added to the inventory in sorted position and the committed-schema count updated 34 → 35.