### PR TITLE
`curie diff` masks by key name, and reports a chart mismatch

### DIFF
--- a/cli/schema/diff.schema.json
+++ b/cli/schema/diff.schema.json
@@ -63,12 +63,30 @@
           "to"
         ]
       }
+    },
+    "chart_deployed": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "The chart the release was installed with, e.g. `curie-0.5.1`. Null when helm has no record of the release or the version could not be read."
+    },
+    "chart_target": {
+      "type": "string",
+      "description": "The chart version this CLI would apply."
+    },
+    "chart_version_differs": {
+      "type": "boolean",
+      "description": "True when the deployed chart version differs from the one this CLI would apply. The entry comparison is VALUES-ONLY and cannot see a component added, removed, or renamed between chart versions -- a renamed component's old keys appear as ordinary resets. Treat a true here as 'this diff does not describe a safe apply'."
     }
   },
   "required": [
     "namespace",
     "release",
     "release_exists",
+    "chart_deployed",
+    "chart_target",
+    "chart_version_differs",
     "changes",
     "entries"
   ]

--- a/cli/src/installation.rs
+++ b/cli/src/installation.rs
@@ -898,12 +898,36 @@ pub struct DiffOutput {
     pub release: String,
     /// `false` when helm has no record of the release: everything is a create.
     pub release_exists: bool,
+    /// The chart the release was installed with (`curie-0.5.1`), if readable.
+    pub chart_deployed: Option<String>,
+    /// The chart version this CLI would apply.
+    pub chart_target: String,
     pub entries: Vec<DiffEntry>,
 }
 
 impl DiffOutput {
     pub fn changes(&self) -> usize {
         self.entries.iter().filter(|e| e.kind.is_change()).count()
+    }
+
+    /// The deployed chart's version, stripped of the `curie-` name prefix.
+    fn deployed_version(&self) -> Option<&str> {
+        self.chart_deployed
+            .as_deref()
+            .map(|c| c.rsplit_once('-').map(|(_, v)| v).unwrap_or(c))
+    }
+
+    /// Would `apply` change the chart under these values, not just the values?
+    ///
+    /// A value-level diff cannot see a component being added, removed, or
+    /// renamed between chart versions -- and when that happens its output is
+    /// not merely incomplete but misleading, since a renamed component's old
+    /// keys render as ordinary resets.
+    pub fn chart_version_differs(&self) -> bool {
+        match self.deployed_version() {
+            Some(deployed) => deployed != self.chart_target,
+            None => false,
+        }
     }
 }
 
@@ -913,6 +937,9 @@ impl crate::ui::CliOutput for DiffOutput {
             "namespace": self.namespace,
             "release": self.release,
             "release_exists": self.release_exists,
+            "chart_deployed": self.chart_deployed,
+            "chart_target": self.chart_target,
+            "chart_version_differs": self.chart_version_differs(),
             "changes": self.changes(),
             "entries": self.entries.iter().map(|e| serde_json::json!({
                 "key": e.key,
@@ -965,6 +992,21 @@ impl crate::ui::CliOutput for DiffOutput {
                  default. Declare it in curie.yaml to keep it.",
             );
         }
+        // Last, so it is the line left on screen. This diff is value-level and
+        // says nothing about components a chart bump adds, removes, or renames
+        // -- and a renamed component's old keys appear above as ordinary
+        // resets, which reads far milder than the swap it would actually be.
+        if self.chart_version_differs() {
+            ui.note(&format!(
+                "CHART VERSION MISMATCH: the release runs {} but this curie applies {}. \
+                 The comparison above is values-only -- it cannot see a component added, \
+                 removed, or renamed between those versions, and a renamed one shows up \
+                 as an ordinary reset. Do not read this as a safe apply. Reconcile the \
+                 chart version first, or apply with the matching chart.",
+                self.chart_deployed.as_deref().unwrap_or("unknown"),
+                self.chart_target,
+            ));
+        }
     }
 }
 
@@ -978,6 +1020,10 @@ pub struct DiffOpts {
 /// provider resolution to complete the desired plan without mutating it.
 pub async fn diff(opts: DiffOpts) -> Result<DiffOutput> {
     let plan = complete_installation_plan(opts.local).await?;
+    // A second, independent read: the values plan says nothing about WHICH
+    // chart consumes them, and a component renamed between chart versions
+    // shows up in the entries below as an ordinary reset.
+    let chart_deployed = crate::ops::fetch_release_chart(&plan.up.common).await?;
     let mut entries = diff_plan(&plan.desired, plan.live.as_ref());
     if plan.preserves_undeclared_github_token {
         if let Some(entry) = entries
@@ -992,6 +1038,8 @@ pub async fn diff(opts: DiffOpts) -> Result<DiffOutput> {
         namespace: plan.cfg.install.namespace,
         release: plan.cfg.install.release,
         release_exists: plan.live.is_some(),
+        chart_deployed,
+        chart_target: crate::artifacts::version().to_string(),
         entries,
     })
 }
@@ -1312,6 +1360,115 @@ mod diff_tests {
         assert!(rendered.contains("<secret>"), "must mask, not omit");
     }
 
+    /// The leak, as it actually happened. `curie diff` against a live release
+    /// printed `minio.auth.rootPassword` in full: the chart had renamed that
+    /// store to `rustfs`, so the live key matched no managed list. The store
+    /// was still running.
+    ///
+    /// The value here is a real-shaped random hex string rather than a token
+    /// the assertion could trivially find, because the original test's
+    /// "no secret in output" check passed against a plaintext it chose itself.
+    #[test]
+    fn a_credential_key_no_managed_list_knows_is_still_masked() {
+        let leaked = "395f633e7f72be60b36cb19ced9d0889b1d55ede40c78893";
+        let entries = diff_plan(
+            &BTreeMap::new(),
+            Some(&live(serde_json::json!({
+                "minio": {"auth": {"rootPassword": leaked}},
+            }))),
+        );
+        let rendered = format!("{entries:?}");
+        assert!(
+            !rendered.contains(leaked),
+            "a renamed chart's credential key must still mask: {rendered}"
+        );
+        assert!(rendered.contains("<secret>"), "{rendered}");
+    }
+
+    /// The class, not just the one instance: any key naming itself a credential
+    /// masks, whether or not this chart version manages it.
+    #[test]
+    fn credential_shaped_key_names_mask_by_name_alone() {
+        for key in [
+            "minio.auth.rootPassword",
+            "somevendor.apiToken",
+            "legacy.encryptionKey",
+            "custom.thing.secret",
+            "old.store.passwd",
+            "whatever.salt",
+        ] {
+            assert!(
+                crate::ops::is_secret_value_key(key),
+                "{key} names a credential and must mask"
+            );
+        }
+    }
+
+    /// Over-masking is safe but not free: if everything masks, diff is useless.
+    #[test]
+    fn ordinary_keys_still_show_their_values() {
+        for key in [
+            "ui.deploy",
+            "api.image.tag",
+            "security.gvisor.mode",
+            "priorityClasses.platform.name",
+            "worker.connectorReconciler.intervalSeconds",
+        ] {
+            assert!(
+                !crate::ops::is_secret_value_key(key),
+                "{key} is not a credential and must stay readable"
+            );
+        }
+    }
+
+    /// A value-level diff cannot see a component renamed between chart
+    /// versions, and on the real cluster it rendered exactly that as a set of
+    /// ordinary resets. It has to say so.
+    #[test]
+    fn a_chart_version_mismatch_is_reported() {
+        let out = DiffOutput {
+            namespace: "sre-bot".into(),
+            release: "sre-bot".into(),
+            release_exists: true,
+            chart_deployed: Some("curie-0.5.1".into()),
+            chart_target: "0.6.0".into(),
+            entries: vec![],
+        };
+        assert!(out.chart_version_differs());
+        let json = <DiffOutput as crate::ui::CliOutput>::to_json(&out);
+        assert_eq!(json["chart_version_differs"], serde_json::json!(true));
+        assert_eq!(json["chart_deployed"], serde_json::json!("curie-0.5.1"));
+    }
+
+    /// The matching case must stay quiet, or the warning becomes background
+    /// noise that gets ignored on the run that matters.
+    #[test]
+    fn a_matching_chart_version_does_not_warn() {
+        let out = DiffOutput {
+            namespace: "sre-bot".into(),
+            release: "sre-bot".into(),
+            release_exists: true,
+            chart_deployed: Some("curie-0.6.0".into()),
+            chart_target: "0.6.0".into(),
+            entries: vec![],
+        };
+        assert!(!out.chart_version_differs());
+    }
+
+    /// An unreadable chart version must not fabricate a mismatch.
+    #[test]
+    fn an_unknown_deployed_chart_does_not_claim_a_mismatch() {
+        let out = DiffOutput {
+            namespace: "sre-bot".into(),
+            release: "sre-bot".into(),
+            release_exists: false,
+            chart_deployed: None,
+            chart_target: "0.6.0".into(),
+            entries: vec![],
+        };
+        assert!(!out.chart_version_differs());
+    }
+
     /// A non-secret value must still be shown, or the mask is useless noise.
     #[test]
     fn ordinary_values_are_shown_in_full() {
@@ -1338,6 +1495,8 @@ mod diff_tests {
             namespace: "acme".into(),
             release: "acme".into(),
             release_exists: true,
+            chart_deployed: Some("curie-0.6.0".into()),
+            chart_target: "0.6.0".into(),
             entries: diff_plan(
                 &BTreeMap::from([("ui.deploy".to_string(), "false".to_string())]),
                 Some(&live(serde_json::json!({"ui": {"deploy": true}}))),

--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -1091,14 +1091,95 @@ pub fn is_preserved_by_up(key: &str) -> bool {
         || REQUIRED_SECRETS.iter().any(|(k, _)| *k == key)
 }
 
+/// Substrings that mark a chart key as carrying a credential.
+///
+/// The masking rule has to be deny-by-default, and this is what makes it so.
+/// Matching on NAME rather than on membership of a managed list is the whole
+/// point: a list only knows the keys THIS chart version manages, and anything
+/// outside it -- a key an older chart used, a key an operator set by hand --
+/// gets printed.
+///
+/// Over-masking is the safe direction. Masking `api.githubCloneBase` costs a
+/// reader one lookup; printing a password costs a rotation.
+const SECRET_KEY_MARKERS: &[&str] = &[
+    "password",
+    "passwd",
+    "secret",
+    "token",
+    "credential",
+    "salt",
+    "key",
+    "auth",
+];
+
 /// Does this key's VALUE carry a secret?
 ///
 /// `helm get values` returns real passwords and tokens, so anything rendering a
 /// live release has to know which values must never reach a terminal, a log, or
-/// a `--json` consumer. Deliberately broader than [`is_preserved_by_up`]: the
-/// PAT and the model credential are secret but not preserved.
+/// a `--json` consumer.
+///
+/// This was an allowlist of managed keys, and it leaked. Run against a real
+/// release, `curie diff` printed `minio.auth.rootPassword` in full: the chart
+/// had since renamed that store to `rustfs`, so the live key matched no managed
+/// list and fell through to "ordinary value". The store was still running. The
+/// unit tests could not have caught it -- they chose their own fixture values,
+/// so the "no secret in the output" assertion compared against a plaintext the
+/// test itself invented.
+///
+/// The question is now "does this key NAME say it holds a credential?", which
+/// is true of a renamed key, a legacy key, and an operator's own `--set`, none
+/// of which any list can enumerate in advance.
 pub fn is_secret_value_key(key: &str) -> bool {
-    is_preserved_by_up(key) || key == GITHUB_TOKEN_KEY || key == MODEL_CREDENTIAL_KEY
+    if is_preserved_by_up(key) || key == GITHUB_TOKEN_KEY || key == MODEL_CREDENTIAL_KEY {
+        return true;
+    }
+    let lowered = key.to_ascii_lowercase();
+    SECRET_KEY_MARKERS
+        .iter()
+        .any(|marker| lowered.contains(marker))
+}
+
+/// `helm list -n <ns> -o json`, for reading the deployed chart version.
+fn helm_list_cmd(o: &CommonOpts) -> OpsCommand {
+    OpsCommand::new(
+        "helm",
+        vec![
+            plain("list"),
+            plain("-n"),
+            plain(&o.namespace),
+            plain("-o"),
+            plain("json"),
+        ],
+    )
+}
+
+/// The chart the release was last installed with, e.g. `curie-0.5.1`.
+///
+/// `curie diff` compares VALUES, which says nothing about whether the chart
+/// those values feed is the same chart. On a real release this mattered: the
+/// cluster ran `curie-0.5.1`, whose object store is MinIO, while the CLI would
+/// apply `0.6.0`, where that component is `rustfs` and does not exist under the
+/// old name. A value-level diff renders that as a handful of `minio.*` resets
+/// when it is really a component swap.
+pub async fn fetch_release_chart(o: &CommonOpts) -> Result<Option<String>> {
+    let (ok, out, _err) = run_capture(&helm_list_cmd(o)).await?;
+    if !ok {
+        return Ok(None);
+    }
+    let parsed: serde_json::Value = match serde_json::from_str(out.trim()) {
+        Ok(v) => v,
+        Err(_) => return Ok(None),
+    };
+    Ok(parsed
+        .as_array()
+        .and_then(|releases| {
+            releases
+                .iter()
+                .find(|r| r.get("name").and_then(|n| n.as_str()) == Some(o.release.as_str()))
+        })
+        .and_then(|r| r.get("chart"))
+        .and_then(|c| c.as_str())
+        .map(str::to_string))
 }
 
 /// The user-supplied values helm recorded for a release, or `None` when the

--- a/cli/tests/json_contract.rs
+++ b/cli/tests/json_contract.rs
@@ -958,6 +958,10 @@ fn diff_output_validates() {
         namespace: "acme-bot".to_string(),
         release: "acme-bot".to_string(),
         release_exists: true,
+        // Mismatched on purpose: the real cluster ran 0.5.1 against a 0.6.0
+        // CLI, and that is the state the warning exists for.
+        chart_deployed: Some("curie-0.5.1".to_string()),
+        chart_target: "0.6.0".to_string(),
         entries: curie::installation::diff_plan(
             &std::collections::BTreeMap::from([
                 ("inference.deploy".to_string(), "true".to_string()),
@@ -1002,6 +1006,11 @@ fn diff_output_validates() {
         !rendered.contains("xoxb-live"),
         "a live secret reached the --json payload: {rendered}"
     );
+
+    // The mismatch must be machine-readable, not only a human note: an agent
+    // consumer gating on this diff has to be able to see that it does not
+    // describe a safe apply.
+    assert_eq!(json["chart_version_differs"], serde_json::json!(true));
 }
 
 #[test]


### PR DESCRIPTION
Both bugs came from one run of `curie diff` against the real sre-bot cluster. Neither was reachable from a fixture.

## 1. It printed a live credential

```
! minio.auth.rootPassword: 395f633e…  (reset to chart default)
```

Masking was an **allowlist of keys the current chart manages**. Chart 0.6.0 renamed that object store to `rustfs`; the release runs **0.5.1**, where MinIO is still up with 29 references. So the live key matched no managed list and fell through to "ordinary value, print it".

**Why the tests passed:** they chose their own fixture values. `assert!(!rendered.contains("xoxb-live"))` compares against a plaintext the test itself invented — it can only catch leaks of strings the author already thought to plant.

The rule now asks *"does this key **name** say it holds a credential?"* — `password`, `passwd`, `secret`, `token`, `credential`, `salt`, `key`, `auth` — with the managed lists kept as a floor. A list can only enumerate keys it knows; a renamed key, a legacy key, and an operator's own `--set api.someToken=` are all outside it by construction.

Over-masking is the safe direction: masking a clone-base URL costs a reader one lookup, printing a password costs a rotation. A companion test pins that ordinary keys — image tags, gvisor mode, reconciler intervals — stay readable, so the rule can't quietly degrade into masking everything.

## 2. It compared values while ignoring the chart

Same run. `diff` had no notion of *which chart* those values feed. A 0.5.1 release read by an 0.6.0 CLI rendered a component that no longer exists under that name as a few ordinary `minio.*` resets — far milder than the object-store swap it would actually be.

It now reads the deployed chart via `helm list`, carries `chart_deployed` / `chart_target` / `chart_version_differs` in the JSON payload, and ends the human output with:

> **CHART VERSION MISMATCH:** the release runs curie-0.5.1 but this curie applies 0.6.0. The comparison above is values-only … Do not read this as a safe apply.

Last line on purpose, so it's what's left on screen.

## Verified where it broke

Re-ran against the same live release:

```
! minio.auth.rootPassword: <secret>  (reset to chart default)
CHART VERSION MISMATCH: the release runs curie-0.5.1 but this curie applies 0.6.0
```

**Falsified both:** neutering the name check fails `a_credential_key_no_managed_list_knows_is_still_masked` and `credential_shaped_key_names_mask_by_name_alone`; making the chart comparison always-equal fails `a_chart_version_mismatch_is_reported`. `fmt`, `clippy --all-targets -D warnings`, and 37 test suites green.

## Note on the exposure

The MinIO root password was printed into an SSM command invocation stored in the AWS account, and into the session that ran it. The store is live. I'd rotate it — that's a production credential change, so I haven't.