### PR TITLE
Retry commit polling after routing repair

### DIFF
--- a/apps/api/src/curie_api/commitpoller.py
+++ b/apps/api/src/curie_api/commitpoller.py
@@ -260,22 +260,35 @@ WHERE a.repo_full_name IS NOT NULL AND d.commit_sha IS NOT NULL
 ORDER BY a.repo_full_name, d.environment, d.deployed_at DESC
 """
 
-# Rejection codes worth retrying. Everything else `process_push` returns is a
-# property of the commit -- a deploy.yaml naming an unknown agent, an
-# unsupported archive, a branch with no target -- and will fail identically
-# next minute. A clone failure is the exception: the remote was unreachable,
-# not wrong.
-_TRANSIENT_REJECTIONS = frozenset({"git.archive_failed"})
+# These rejections depend on which agents are bound to the repository. They
+# settle against that binding snapshot, then get one new attempt when an
+# operator changes it without pushing a new commit (#1307).
+_TOPOLOGY_REJECTIONS = frozenset(
+    {
+        "deploy.agent_bound_elsewhere",
+        "deploy.no_targets",
+        "deploy.unknown_agent",
+    }
+)
+_ARCHIVE_FAILURE = "git.archive_failed"
 
 
-# Every repository that has at least one agent bound to it. DISTINCT because
-# several agents legitimately share one repository (ADR-0091), and polling it
-# once per agent would race N deploys of the same commit.
-_REPOS_SQL = """
-SELECT DISTINCT repo_full_name
+# Every repository binding. Grouping these rows produces both the unique poll
+# targets and the routing snapshot used to reopen a settled topology rejection.
+_BINDINGS_SQL = """
+SELECT repo_full_name, name
 FROM {schema}.agents
 WHERE repo_full_name IS NOT NULL AND repo_full_name <> ''
+ORDER BY repo_full_name, name
 """
+
+
+@dataclass(frozen=True)
+class Settled:
+    """A terminal sha, optionally only for one routing topology."""
+
+    sha: str
+    bindings: tuple[str, ...] | None
 
 
 class CommitPoller:
@@ -302,13 +315,13 @@ class CommitPoller:
         self._eval_queue = eval_queue
         self._tips = tips
         self._interval = interval_seconds
-        # (repo, branch) -> sha whose outcome was terminal and NOT a
-        # Deployment. The database cannot answer this: it records successes, so
-        # an ignored or rejected push is indistinguishable from one never
-        # attempted, and the poller re-clones it every interval forever
-        # (#1267). In memory only -- a restart re-attempting once is cheap, and
-        # persisting it would mean a schema for something a process can forget.
-        self._settled: dict[tuple[str, str], str] = {}
+        # The database records successes only. Intrinsic failures settle for
+        # the sha, while routing failures settle until the repository binding
+        # snapshot changes. In memory only, so restart can retry once.
+        self._settled: dict[tuple[str, str], Settled] = {}
+        # Archive failure gets one retry on the next pass, then settles. This
+        # bounds network failure clones without making a single blip terminal.
+        self._archive_retry: dict[tuple[str, str], str] = {}
 
     async def run_forever(self) -> None:
         logger.info("commit poller started interval=%ss", self._interval)
@@ -341,14 +354,18 @@ class CommitPoller:
         }
 
         async with self._session_factory() as session:
-            repos = [
-                str(r) for (r,) in (await session.execute(text(_REPOS_SQL.format(schema=schema))))
-            ]
+            bindings: dict[str, list[str]] = {}
+            for repo, agent_name in await session.execute(
+                text(_BINDINGS_SQL.format(schema=schema))
+            ):
+                bindings.setdefault(str(repo), []).append(str(agent_name))
             deployed: dict[tuple[str, str], str] = {}
             for repo, env, sha in await session.execute(text(_DEPLOYED_SQL.format(schema=schema))):
                 branch = branch_for_env.get(str(env))
                 if branch:
                     deployed[(str(repo), branch)] = str(sha)
+
+        binding_snapshots = {repo: tuple(names) for repo, names in bindings.items()}
 
         targets = [
             PollTarget(
@@ -356,7 +373,7 @@ class CommitPoller:
                 clone_url=gitflow.trusted_clone_url(repo, self._settings),
                 branches=tuple(branch_for_env.values()),
             )
-            for repo in repos
+            for repo in bindings
         ]
         # to_thread because the tip reader is sync httpx: a blocking call in
         # the event loop would stall every request the API is serving.
@@ -365,9 +382,21 @@ class CommitPoller:
         # This must happen BEFORE process_push, because the mirror clone is
         # inside it -- at the recommended 60s interval an unchanged
         # non-deploying branch is roughly 1,440 full clones a day (#1267).
-        moves = [m for m in moves if self._settled.get((m.repo_full_name, m.branch)) != m.sha]
+        unsettled: list[Move] = []
+        for move in moves:
+            settled = self._settled.get((move.repo_full_name, move.branch))
+            if settled is None or settled.sha != move.sha:
+                unsettled.append(move)
+                continue
+            if (
+                settled.bindings is not None
+                and settled.bindings != binding_snapshots[move.repo_full_name]
+            ):
+                unsettled.append(move)
+        moves = unsettled
 
         for move in moves:
+            key = (move.repo_full_name, move.branch)
             async with self._session_factory() as session:
                 result = await gitflow.process_push(
                     session, self._store, self._settings, self._eval_queue, move.as_push_payload()
@@ -381,23 +410,31 @@ class CommitPoller:
                 # A Deployment row exists now, so the database is the memory
                 # and this must not keep a second copy that a rollback would
                 # not clear.
-                self._settled.pop((move.repo_full_name, move.branch), None)
-            elif result.status == "rejected" and any(
-                (e.get("code") or "") in _TRANSIENT_REJECTIONS for e in (result.errors or [])
-            ):
-                # The remote was unreachable, not wrong. Worth another pass --
-                # suppressing this would strand a repository on a network blip
-                # until the API restarted.
-                logger.info(
-                    "commit poll will retry repo=%s branch=%s sha=%s (transient)",
-                    move.repo_full_name,
-                    move.branch,
-                    move.sha[:8],
-                )
+                self._settled.pop(key, None)
+                self._archive_retry.pop(key, None)
+            elif result.status == "rejected":
+                codes = {(error.get("code") or "") for error in (result.errors or [])}
+                if codes & _TOPOLOGY_REJECTIONS:
+                    self._settled[key] = Settled(
+                        move.sha, binding_snapshots[move.repo_full_name]
+                    )
+                    self._archive_retry.pop(key, None)
+                elif _ARCHIVE_FAILURE in codes and self._archive_retry.get(key) != move.sha:
+                    self._archive_retry[key] = move.sha
+                    logger.info(
+                        "commit poll will retry repo=%s branch=%s sha=%s (transient)",
+                        move.repo_full_name,
+                        move.branch,
+                        move.sha[:8],
+                    )
+                else:
+                    self._settled[key] = Settled(move.sha, None)
+                    self._archive_retry.pop(key, None)
             else:
-                # ignored, or rejected for a reason this commit will keep
-                # having. Remember it, or the next pass clones again (#1267).
-                self._settled[(move.repo_full_name, move.branch)] = move.sha
+                # An ignored outcome will keep repeating for this commit.
+                # Remember it, or the next pass clones again (#1267).
+                self._settled[key] = Settled(move.sha, None)
+                self._archive_retry.pop(key, None)
 
             if result.status != "rejected":
                 logger.info(

--- a/apps/api/tests/test_commitpoller.py
+++ b/apps/api/tests/test_commitpoller.py
@@ -233,10 +233,10 @@ async def _run_poll_once(monkeypatch, result, *, on_push=None, deployed=None, ti
 
     class Session:
         async def execute(self, stmt):
-            # First query lists repos, second lists (repo, environment, sha)
-            # already deployed. Both come from the real SQL in the module.
+            # First query lists bindings, second lists deployed state. Both
+            # come from the real SQL in the module.
             if "FROM curie.agents" in str(stmt):
-                return Rows([(REPO,)])
+                return Rows([(REPO, "agent")])
             return Rows(deployed or [])
 
     @asynccontextmanager
@@ -565,7 +565,12 @@ def test_a_404_is_still_a_missing_branch(monkeypatch) -> None:
 
 # Not re-cloning a commit that already settled (#1267)
 # --------------------------------------------------------------------------- #
-async def _passes(monkeypatch, result, n: int = 2) -> int:
+async def _passes(
+    monkeypatch,
+    result,
+    n: int = 2,
+    binding_snapshots: list[tuple[str, ...]] | None = None,
+) -> int:
     """Run n consecutive poll_once passes; return how many reached the deploy path.
 
     Reaching the deploy path is what costs a full mirror clone -- the clone
@@ -584,9 +589,14 @@ async def _passes(monkeypatch, result, n: int = 2) -> int:
         calls["n"] += 1
         return result
 
+    snapshots = binding_snapshots or [("agent",)] * n
+    pass_index = {"value": 0}
+
     class Session:
         async def execute(self, stmt):
-            return [(REPO,)] if "FROM curie.agents" in str(stmt) else []
+            if "FROM curie.agents" in str(stmt):
+                return [(REPO, name) for name in snapshots[pass_index["value"]]]
+            return []
 
     @asynccontextmanager
     async def factory():
@@ -603,6 +613,7 @@ async def _passes(monkeypatch, result, n: int = 2) -> int:
     )
     for _ in range(n):
         await poller.poll_once()
+        pass_index["value"] += 1
     return calls["n"]
 
 
@@ -621,12 +632,44 @@ async def test_an_ignored_branch_is_not_recloned_every_pass(monkeypatch) -> None
 
 
 @pytest.mark.anyio
-async def test_a_permanently_rejected_commit_is_not_recloned(monkeypatch) -> None:
-    # A deploy.yaml naming an unknown agent fails identically next minute.
+async def test_an_intrinsically_rejected_commit_is_not_recloned(monkeypatch) -> None:
+    # An ambiguous environment is fixed only by changing the commit.
     from curie_api.schemas import WebhookResult
 
-    rejected = WebhookResult(status="rejected", errors=[{"code": "deploy.unknown_agent"}])
-    assert await _passes(monkeypatch, rejected) == 1
+    rejected = WebhookResult(status="rejected", errors=[{"code": "deploy.ambiguous_env"}])
+    assert await _passes(
+        monkeypatch,
+        rejected,
+        n=3,
+        binding_snapshots=[("agent",), ("agent", "new"), ("agent", "new")],
+    ) == 1
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "code",
+    [
+        "deploy.agent_bound_elsewhere",
+        "deploy.no_targets",
+        "deploy.unknown_agent",
+    ],
+)
+async def test_a_topology_rejection_waits_for_a_binding_change(monkeypatch, code: str) -> None:
+    """Stable topology suppresses clones and one binding change reopens it."""
+    from curie_api.schemas import WebhookResult
+
+    rejected = WebhookResult(status="rejected", errors=[{"code": code}])
+    assert await _passes(
+        monkeypatch,
+        rejected,
+        n=4,
+        binding_snapshots=[
+            ("agent",),
+            ("agent",),
+            ("agent", "repaired"),
+            ("agent", "repaired"),
+        ],
+    ) == 2
 
 
 @pytest.mark.anyio
@@ -641,7 +684,7 @@ async def test_a_transient_clone_failure_IS_retried(monkeypatch) -> None:
     from curie_api.schemas import WebhookResult
 
     transient = WebhookResult(status="rejected", errors=[{"code": "git.archive_failed"}])
-    assert await _passes(monkeypatch, transient) == 2
+    assert await _passes(monkeypatch, transient, n=4) == 2
 
 
 @pytest.mark.anyio

--- a/apps/api/tests/test_gitflow_integration.py
+++ b/apps/api/tests/test_gitflow_integration.py
@@ -651,6 +651,79 @@ def test_a_target_naming_another_repos_agent_is_rejected_end_to_end(
     )
 
 
+def test_commit_poller_retries_after_routing_topology_is_repaired(
+    client: Any,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    trusted_clone_base: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A rejected sha deploys on the next pass after its target is created."""
+    from curie_api.commitpoller import CommitPoller
+    from curie_api.schemas import AgentCreate
+
+    _register(client, auth_headers, "bootstrap_agent", "C000000R01")
+    files = {
+        **VALID_FILES,
+        "deploy.yaml": (
+            "targets:\n  dev:\n    agent: repairedagent\n"
+            "    env: dev\n    slack_channel: C000000R02\n"
+        ),
+    }
+    _, sha = _build_bare_repo(trusted_clone_base, REPO, files)
+    settings = get_settings()
+
+    class Tips:
+        def sha_for(self, repo_full_name: str, branch: str) -> str | None:
+            assert repo_full_name == REPO
+            return sha if branch == settings.dev_branch else None
+
+    class NoopEvalQueue:
+        async def enqueue(self, _job: Any) -> None:
+            pass
+
+    async def exercise() -> str:
+        engine = create_async_engine(settings.database_url)
+        maker = async_sessionmaker(engine, expire_on_commit=False)
+        poller = CommitPoller(
+            session_factory=maker,
+            store=client.app.state.bundle_store,
+            settings=settings,
+            eval_queue=NoopEvalQueue(),
+            tips=Tips(),
+            interval_seconds=60,
+        )
+        try:
+            first = await poller.poll_once()
+            assert [move.sha for move in first] == [sha]
+            assert "deploy.unknown_agent" in caplog.text
+
+            async with maker() as session:
+                assert await crud.list_deployments(session) == []
+                repaired = await crud.create_agent(
+                    session,
+                    AgentCreate(
+                        name="repairedagent",
+                        slack_channel="C000000R02",
+                        repo_full_name=REPO,
+                    ),
+                )
+
+            second = await poller.poll_once()
+            assert [move.sha for move in second] == [sha]
+            return str(repaired.id)
+        finally:
+            await engine.dispose()
+
+    repaired_id = asyncio.run(exercise())
+    deployments = client.get(
+        "/deployments", params={"agent_id": repaired_id}, headers=auth_headers
+    ).json()
+    assert len(deployments) == 1, deployments
+    assert deployments[0]["commit_sha"] == sha
+    assert deployments[0]["environment"] == "dev"
+
+
 # --------------------------------------------------------------------------- #
 # A scaffolded deploy.yaml declares nothing (#1210)
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Retry a settled routing rejection only when repository bindings change, while bounding archive failure retries.

Closes #1307