### PR TITLE
Preserve agent thinking in platform evals

### DIFF
--- a/apps/worker/src/curie_worker/binding.py
+++ b/apps/worker/src/curie_worker/binding.py
@@ -721,17 +721,15 @@ def inject_connector_secrets(
     can never clobber it -- even on the default path where ``apply_model_env`` does
     not itself set the base URL after the caller runs this. Drop-and-log rather than
     raise (raising would crash a live claim); a dropped key never carries its value
-    and is kept out of the marker. The log names the key and ``agent_label`` only,
-    never the value.
+    and is kept out of the marker. The warning carries no connector or agent
+    information.
     """
     injected_secret_keys: list[str] = []
     for name, value in (secrets or {}).items():
         if is_reserved_boot_env_name(name):
             logger.warning(
-                "Dropping connector secret with reserved boot-env name %s "
-                "for agent %s (never injected, never marked)",
-                name,
-                agent_label,
+                "Dropping connector secret with reserved boot-env name "
+                "(never injected, never marked)"
             )
             continue
         env[name] = value

--- a/apps/worker/src/curie_worker/binding.py
+++ b/apps/worker/src/curie_worker/binding.py
@@ -479,6 +479,17 @@ class BindingResolver:
             value = json.loads(value)
         return value if isinstance(value, dict) else None
 
+    async def thinking_for(self, agent_id: uuid.UUID) -> str | None:
+        """The agent's thinking depth for eval sandbox boots."""
+        sql = text(f"SELECT thinking FROM {self._config.db_schema}.agents WHERE id = :id")
+        async with self._engine.connect() as conn:
+            result = await conn.execute(sql, {"id": agent_id})
+            row = result.first()
+        if row is None:
+            return None
+        value: str | None = row[0]
+        return value
+
     def packs_for(self, resolved: ResolvedDeployment) -> BehaviorPacks:
         """The agent's parsed behavior packs (all-off when none are configured).
 

--- a/apps/worker/src/curie_worker/eval/stream.py
+++ b/apps/worker/src/curie_worker/eval/stream.py
@@ -352,7 +352,8 @@ class EvalStreamConsumer(StreamConsumer):
         release_key = f"eval-{uuid.uuid4().hex}"
         try:
             connector_secrets = await self._repo_lookup.secrets_for(item.agent_id)
-            env = self._boot_env(item, connector_secrets)
+            thinking = await self._repo_lookup.thinking_for(item.agent_id)
+            env = self._boot_env(item, connector_secrets, thinking)
             # Hold a claim slot only across creation/binding (the flood source),
             # not the whole suite run: the semaphore is released the moment the
             # claim binds, so the bound sandbox runs its cases while the next
@@ -397,7 +398,10 @@ class EvalStreamConsumer(StreamConsumer):
         return self._config.model or None
 
     def _boot_env(
-        self, item: EvalJob, connector_secrets: dict[str, str] | None = None
+        self,
+        item: EvalJob,
+        connector_secrets: dict[str, str] | None = None,
+        thinking: str | None = None,
     ) -> dict[str, str]:
         budget = Budget(
             max_output_tokens_per_run=self._config.default_max_output_tokens_per_run,
@@ -423,7 +427,12 @@ class EvalStreamConsumer(StreamConsumer):
         # provisioned sandbox actually runs the model this sweep row is measuring;
         # _eval_model tags the same value, keeping the boot and the matrix label
         # in lock-step. None falls back to config.model exactly as before.
-        apply_model_env(env, self._config, model_override=item.model)
+        apply_model_env(
+            env,
+            self._config,
+            model_override=item.model,
+            thinking_override=thinking,
+        )
         return env
 
     async def _report_failed(self, item: EvalJob, repo: str | None, reason: str) -> EvalRunResult:

--- a/apps/worker/tests/binding/test_resolver.py
+++ b/apps/worker/tests/binding/test_resolver.py
@@ -873,6 +873,50 @@ def test_resolves_connector_secrets_into_boot_env() -> None:
     asyncio.run(go())
 
 
+def test_reads_thinking_for_eval_boots_by_agent_id() -> None:
+    async def go() -> None:
+        engine = create_async_engine(_DB_URL)
+        try:
+            try:
+                async with engine.connect():
+                    pass
+            except SQLAlchemyError as exc:
+                pytest.skip(f"Postgres not reachable at {_DB_URL}: {exc}")
+
+            token = uuid.uuid4().hex[:8]
+            agent_id = await _seed_agent(
+                engine,
+                channel=f"C-{token}",
+                name=f"agent-{token}",
+                max_usd=None,
+                max_tokens=None,
+            )
+            try:
+                async with engine.begin() as conn:
+                    await conn.execute(
+                        text(f"UPDATE {_SCHEMA}.agents SET thinking = :thinking WHERE id = :id"),
+                        {"thinking": "high", "id": agent_id},
+                    )
+
+                resolver = _resolver(engine)
+                assert await resolver.thinking_for(agent_id) == "high"
+
+                async with engine.begin() as conn:
+                    await conn.execute(
+                        text(f"UPDATE {_SCHEMA}.agents SET thinking = NULL WHERE id = :id"),
+                        {"id": agent_id},
+                    )
+
+                assert await resolver.thinking_for(agent_id) is None
+                assert await resolver.thinking_for(uuid.uuid4()) is None
+            finally:
+                await _cleanup(engine, [agent_id])
+        finally:
+            await engine.dispose()
+
+    asyncio.run(go())
+
+
 def test_reserved_connector_secret_is_dropped_order_independently() -> None:
     # #457 order-independence regression. A connector secret named
     # ANTHROPIC_BASE_URL redirects the model credential. The old `if name not in

--- a/apps/worker/tests/eval/test_stream.py
+++ b/apps/worker/tests/eval/test_stream.py
@@ -37,7 +37,7 @@ from curie_test_support.valkey import (
 from curie_test_support.valkey import (
     VALKEY_PW as _VPW,
 )
-from curie_worker.binding import BUDGET_ENV, BUNDLE_REF_ENV, MODEL_ENV
+from curie_worker.binding import BUDGET_ENV, BUNDLE_REF_ENV, MODEL_ENV, THINKING_ENV
 from curie_worker.bundle_store import BundleStore
 from curie_worker.config import WorkerConfig
 from curie_worker.eval import (
@@ -71,6 +71,10 @@ async def _wait_until(pred: Callable[[], bool], timeout: float = 5.0) -> None:
 class _StubRepo:
     """The B1 repo lookup, stubbed: a channel/agent resolves to a GitHub repo."""
 
+    def __init__(self, *, thinking: str | None = None) -> None:
+        self._thinking = thinking
+        self.thinking_agent_id: uuid.UUID | None = None
+
     async def repo_full_name(self, _agent_id: uuid.UUID) -> str:
         return "owner/repo"
 
@@ -78,6 +82,10 @@ class _StubRepo:
         # No connector secrets in the eval stub; a real BindingResolver returns
         # the agent's secrets so an authed-MCP bundle authenticates during eval.
         return None
+
+    async def thinking_for(self, agent_id: uuid.UUID) -> str | None:
+        self.thinking_agent_id = agent_id
+        return self._thinking
 
 
 class _UnusedSubstrate:
@@ -200,6 +208,7 @@ def _build_consumer(
     reports: list[dict[str, Any]],
     lf_client: httpx.AsyncClient,
     report_status: int = 200,
+    repo_lookup: _StubRepo | None = None,
 ) -> EvalStreamConsumer:
     def handler(request: httpx.Request) -> httpx.Response:
         reports.append(json.loads(request.content))
@@ -226,7 +235,7 @@ def _build_consumer(
         substrate=substrate,
         reporter=reporter,
         recorder=recorder,
-        repo_lookup=_StubRepo(),
+        repo_lookup=repo_lookup or _StubRepo(),
     )
 
 
@@ -634,7 +643,23 @@ def test_entry_is_acked_after_report_even_when_report_fails(make_eval_harness, b
     asyncio.run(go())
 
 
-def test_provisioned_runner_end_to_end(make_eval_harness, bundles) -> None:
+@pytest.mark.parametrize(
+    ("platform_thinking", "agent_thinking", "item_model", "expected_thinking"),
+    [
+        pytest.param("adaptive", "disabled", "requested_model", "disabled"),
+        pytest.param("adaptive", None, None, "adaptive"),
+        pytest.param(None, "high", None, "high"),
+        pytest.param(None, None, None, None),
+    ],
+)
+def test_provisioned_runner_end_to_end(
+    make_eval_harness,
+    bundles,
+    platform_thinking: str | None,
+    agent_thinking: str | None,
+    item_model: str | None,
+    expected_thinking: str | None,
+) -> None:
     """No target_url: the consumer provisions a runner via the G1 substrate (boot
     env carrying the bundle_ref + budget), evals against it, reports, and tears the
     sandbox down in a finally. The fake runner is the model boundary, so no real
@@ -656,7 +681,14 @@ def test_provisioned_runner_end_to_end(make_eval_harness, bundles) -> None:
                 )
             )
             token = uuid.uuid4().hex[:8]
-            cfg = _cfg(f"test:evals:{token}", f"g-{token}")
+            if platform_thinking is None:
+                cfg = _cfg(f"test:evals:{token}", f"g-{token}")
+            else:
+                cfg = _cfg(
+                    f"test:evals:{token}",
+                    f"g-{token}",
+                    thinking=platform_thinking,
+                )
             sandbox_prefix = f"test:curie:sandbox:{token}"
             sync_client = redis.Redis(
                 host=_VH, port=_VP, password=_VPW or None, decode_responses=False
@@ -678,6 +710,7 @@ def test_provisioned_runner_end_to_end(make_eval_harness, bundles) -> None:
             client = AsyncRedis(host=_VH, port=_VP, password=_VPW, decode_responses=True)
             reports: list[dict[str, Any]] = []
             async with httpx.AsyncClient(timeout=30.0) as lf_client:
+                repo_lookup = _StubRepo(thinking=agent_thinking)
                 consumer = _build_consumer(
                     redis_client=client,
                     cfg=cfg,
@@ -685,10 +718,17 @@ def test_provisioned_runner_end_to_end(make_eval_harness, bundles) -> None:
                     substrate=substrate,
                     reports=reports,
                     lf_client=lf_client,
+                    repo_lookup=repo_lookup,
                 )
                 await consumer.ensure_group()
                 sha = f"sha-{token}"
-                item = _item(suite="prov", sha=sha, bundle_ref=bundle_ref, target_url=None)
+                item = _item(
+                    suite="prov",
+                    sha=sha,
+                    bundle_ref=bundle_ref,
+                    target_url=None,
+                    model=item_model,
+                )
                 await client.xadd(cfg.eval_stream, {"payload": item.model_dump_json()})
 
                 await _drain_one(consumer, reports)
@@ -701,6 +741,14 @@ def test_provisioned_runner_end_to_end(make_eval_harness, bundles) -> None:
                 assert fake_k8s.claim_envs, "substrate.claim was never called"
                 assert fake_k8s.claim_envs[0][BUNDLE_REF_ENV] == bundle_ref
                 assert BUDGET_ENV in fake_k8s.claim_envs[0]
+                if expected_thinking is None:
+                    assert THINKING_ENV not in fake_k8s.claim_envs[0]
+                else:
+                    assert fake_k8s.claim_envs[0][THINKING_ENV] == expected_thinking
+                if item_model is not None:
+                    assert fake_k8s.claim_envs[0][MODEL_ENV] == item_model
+                if agent_thinking is not None:
+                    assert repo_lookup.thinking_agent_id == item.agent_id
                 # and the sandbox was torn down after the eval (finally: release).
                 assert fake_k8s.deleted, "provisioned sandbox was never released"
                 assert not fake_k8s.claims


### PR DESCRIPTION
Closes #1314

Platform eval sandboxes now resolve agent thinking before claims, preserving model overrides. Tests cover consumer and database lookup precedence.