### PR TITLE
Unify installation plans for apply and diff

### DIFF
--- a/cli/schema/diff.schema.json
+++ b/cli/schema/diff.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://schemas.curietech.ai/cli/diff/v1.json",
   "title": "curie diff --json",
-  "description": "The agent-facing payload of `curie diff`: every chart value the installation file and the live release disagree about, plus the values the release carries that the file does not declare. Read-only; no credential is resolved. Secret-bearing values are rendered as the literal string `<secret>` and never in the clear.",
+  "description": "The agent-facing payload of `curie diff`: every chart value the effective installation plan and the live release disagree about, plus the values the release carries that the plan does not declare. Read only. Declared credentials and provider addresses are resolved to construct the same plan used by apply, but no cluster state is mutated. Secret-bearing values are rendered as the literal string `<secret>` and never in the clear.",
   "type": "object",
   "additionalProperties": false,
   "properties": {
@@ -37,10 +37,9 @@
               "change",
               "unchanged",
               "preserved",
-              "managed by this file",
               "reset to chart default"
             ],
-            "description": "`preserved` means the release carries this value, the file does not declare it, and a plain `cluster up` re-supplies it anyway (Slack tokens, the GitHub App, generated store passwords). `managed by this file` means the file governs the key but its value is computed at apply time rather than stated literally (a resolved egress CIDR, the model credential and the fake-model switch it rides with). Neither is a pending removal. `reset to chart default` is the genuine loss case: undeclared, not governed, and not carried forward."
+            "description": "`preserved` means the release carries this value, the plan does not declare it, and apply re-supplies it anyway (Slack tokens, the GitHub App, generated store passwords). It is not a pending removal. `reset to chart default` is the genuine loss case: undeclared and not carried forward."
           },
           "from": {
             "type": [

--- a/cli/src/installation.rs
+++ b/cli/src/installation.rs
@@ -214,34 +214,6 @@ impl Installation {
         out
     }
 
-    /// Does `apply` set this chart key from this file, even though the file
-    /// states no literal value for it?
-    ///
-    /// [`Self::helm_sets`] is NOT the whole of what `apply` declares. Three
-    /// families reach the chart through `UpOpts` instead, with values computed
-    /// at apply time: the model credential, the fake-model switch it rides
-    /// with, and the egress rules resolved from named providers.
-    ///
-    /// Without this, `curie diff` reported all three as "reset to chart
-    /// default" for a file that declares them -- telling the operator they
-    /// would LOSE what `apply` is about to SET. Found by running diff against
-    /// the real sre-bot release rather than a fixture.
-    pub fn governs_key(&self, key: &str) -> bool {
-        // Both are pushed inside one `if let Some(credentials)` in
-        // `ops::up_commands`, so a file naming no model credential governs
-        // neither -- and a live value for them really would be reset.
-        if key == crate::ops::MODEL_CREDENTIAL_KEY || key == crate::ops::FAKE_MODEL_KEY {
-            return self.credentials.model.is_some();
-        }
-        // Index-aware on purpose. A file declaring one host governs rule [0];
-        // a release carrying rules [1] and [2] really would lose them, and
-        // saying otherwise would be the same lie in the other direction.
-        match crate::ops::egress_key_index(key) {
-            Some(index) => index < self.platform.egress.len(),
-            None => false,
-        }
-    }
-
     /// Provider names for `--allow-egress-host`, validated downstream by
     /// `ops::parse_egress_provider` so an unknown host is one error message,
     /// not two divergent ones.
@@ -582,9 +554,135 @@ impl crate::ui::CliOutput for ApplyOutput {
 }
 
 pub struct ApplyOpts {
-    pub cfg: Installation,
+    pub local: LocalInstallationPlan,
     pub chart: String,
-    pub dry_run: bool,
+}
+
+pub struct LocalInstallationPlan {
+    cfg: Installation,
+    resolved: BTreeMap<String, String>,
+    up: crate::ops::UpOpts,
+    github_token: Option<String>,
+}
+
+struct EffectiveInstallationPlan {
+    cfg: Installation,
+    up: crate::ops::UpOpts,
+    up_values: crate::ops::UpValuePlan,
+    github_token: Option<String>,
+    comms: Option<crate::comms::CommsOpts>,
+    live: Option<serde_json::Value>,
+    desired: BTreeMap<String, String>,
+    preserves_undeclared_github_token: bool,
+}
+
+pub fn plan_installation(cfg: Installation, dry_run: bool) -> Result<LocalInstallationPlan> {
+    let resolved = resolve_credentials(&cfg, &resolve_credential)?;
+    let github_token = cfg
+        .credentials
+        .github_token
+        .as_ref()
+        .and_then(|name| resolved.get(name).cloned());
+    let up = crate::ops::UpOpts {
+        common: crate::ops::CommonOpts {
+            namespace: cfg.install.namespace.clone(),
+            release: cfg.install.release.clone(),
+            dry_run,
+        },
+        chart: String::new(),
+        no_expose: false,
+        set: cfg.helm_sets(),
+        allow_egress_host: cfg.egress_hosts(),
+        resolved_egress_cidrs: vec![],
+        allow_web_egress: vec![],
+        fake_model: cfg.credentials.model.is_none(),
+        credentials: cfg
+            .credentials
+            .model
+            .as_ref()
+            .and_then(|name| resolved.get(name).cloned()),
+        local_model: None,
+        model: std::env::var("CURIE_MODEL").ok().filter(|s| !s.is_empty()),
+        secrets: vec![],
+        github_token: crate::ops::GithubTokenPlan::Untouched,
+        dev: false,
+    };
+    crate::ops::validate_up_inputs(&up, github_token.as_deref(), false)?;
+    Ok(LocalInstallationPlan {
+        cfg,
+        resolved,
+        up,
+        github_token,
+    })
+}
+
+async fn complete_installation_plan(
+    local: LocalInstallationPlan,
+) -> Result<EffectiveInstallationPlan> {
+    let LocalInstallationPlan {
+        cfg,
+        resolved,
+        up,
+        github_token,
+    } = local;
+    // Apply in dry run mode remains a local preview: no Helm read and no provider
+    // DNS resolution. `diff` builds a live plan, so it still completes the
+    // desired values against the live release.
+    let complete_live_state = !up.common.dry_run;
+    let live = if complete_live_state {
+        crate::ops::fetch_release_values(&up.common).await?
+    } else {
+        None
+    };
+    let preserves_undeclared_github_token = cfg.credentials.github_token.is_none()
+        && !cfg.set.contains_key(crate::ops::GITHUB_TOKEN_KEY)
+        && live
+            .as_ref()
+            .and_then(|values| values.get("api"))
+            .and_then(|api| api.get("githubToken"))
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|token| !token.is_empty());
+    let up = crate::ops::complete_up_opts(
+        up,
+        live.as_ref(),
+        github_token.as_deref(),
+        false,
+        complete_live_state,
+    )?;
+    let up_values = crate::ops::up_value_plan(&up);
+    let mut desired = up_values.effective_values();
+    let comms = cfg
+        .comms
+        .slack
+        .as_ref()
+        .map(|slack| crate::comms::CommsOpts {
+            common: up.common.clone(),
+            chart: up.chart.clone(),
+            app_token: resolved.get(&slack.app_token).cloned().unwrap_or_default(),
+            bot_token: resolved.get(&slack.bot_token).cloned().unwrap_or_default(),
+            disconnect: false,
+        });
+    if let Some(comms) = &comms {
+        desired.insert(
+            "dispatcher.slack.appToken".to_string(),
+            comms.app_token.clone(),
+        );
+        desired.insert(
+            "dispatcher.slack.botToken".to_string(),
+            comms.bot_token.clone(),
+        );
+        desired.insert("worker.slackApiBaseUrl".to_string(), String::new());
+    }
+    Ok(EffectiveInstallationPlan {
+        cfg,
+        up,
+        up_values,
+        github_token,
+        comms,
+        live,
+        desired,
+        preserves_undeclared_github_token,
+    })
 }
 
 /// Converge the cluster to the file.
@@ -595,51 +693,20 @@ pub struct ApplyOpts {
 /// only as a sentence in a runbook, which is exactly what ADR-0097 set out to
 /// fix: the interface could not express it, so prose had to.
 pub async fn apply(opts: ApplyOpts) -> Result<ApplyOutput> {
-    let ApplyOpts {
+    let ApplyOpts { mut local, chart } = opts;
+    local.up.chart = chart;
+    let dry_run = local.up.common.dry_run;
+    let plan = complete_installation_plan(local).await?;
+    let EffectiveInstallationPlan {
         cfg,
-        chart,
-        dry_run,
-    } = opts;
-
-    // Resolve BEFORE mutating anything. A missing Slack token discovered after
-    // the platform install would leave a half-applied cluster, which is the
-    // state this whole file exists to make unreachable.
-    let resolved = resolve_credentials(&cfg, &resolve_credential)?;
-
-    let common = crate::ops::CommonOpts {
-        namespace: cfg.install.namespace.clone(),
-        release: cfg.install.release.clone(),
-        dry_run,
-    };
-
-    let up_out = crate::ops::up(
-        crate::ops::UpOpts {
-            common: common.clone(),
-            chart: chart.clone(),
-            no_expose: false,
-            set: cfg.helm_sets(),
-            allow_egress_host: cfg.egress_hosts(),
-            resolved_egress_cidrs: vec![],
-            allow_web_egress: vec![],
-            fake_model: cfg.credentials.model.is_none(),
-            credentials: cfg
-                .credentials
-                .model
-                .as_ref()
-                .and_then(|n| resolved.get(n).cloned()),
-            local_model: None,
-            model: std::env::var("CURIE_MODEL").ok().filter(|s| !s.is_empty()),
-            secrets: vec![],
-            github_token: crate::ops::GithubTokenPlan::Untouched,
-            dev: false,
-        },
-        cfg.credentials
-            .github_token
-            .as_ref()
-            .and_then(|n| resolved.get(n).cloned()),
-        false,
-    )
-    .await?;
+        up,
+        up_values,
+        github_token,
+        comms,
+        live,
+        ..
+    } = plan;
+    let up_out = crate::ops::up_prepared(up, up_values, live, github_token).await?;
 
     let mut lines = match up_out {
         crate::ops::ClusterUpOutput::DryRun(plan) => plan.lines,
@@ -647,15 +714,8 @@ pub async fn apply(opts: ApplyOpts) -> Result<ApplyOutput> {
     };
 
     let mut configured_comms = false;
-    if let Some(slack) = &cfg.comms.slack {
-        let comms_out = crate::comms::comms(crate::comms::CommsOpts {
-            common,
-            chart,
-            app_token: resolved.get(&slack.app_token).cloned().unwrap_or_default(),
-            bot_token: resolved.get(&slack.bot_token).cloned().unwrap_or_default(),
-            disconnect: false,
-        })
-        .await?;
+    if let Some(comms) = comms {
+        let comms_out = crate::comms::comms(comms).await?;
         configured_comms = true;
         if let crate::comms::CommsOutput::DryRun(plan) = comms_out {
             lines.extend(plan.lines);
@@ -686,10 +746,6 @@ pub enum DiffKind {
     /// Only the release has it, and a plain `up` carries it forward untouched.
     /// NOT a removal -- see [`crate::ops::is_preserved_by_up`].
     Preserved,
-    /// The file governs it, but its value is computed at apply time (a resolved
-    /// egress CIDR, the model credential) rather than stated literally. `apply`
-    /// SETS this -- reporting it as a reset was the bug real data exposed.
-    Managed,
     /// Only the release has it, and `apply` would reset it to the chart default.
     Reset,
 }
@@ -703,7 +759,6 @@ impl DiffKind {
             DiffKind::Change => '~',
             DiffKind::Same => '=',
             DiffKind::Preserved => '=',
-            DiffKind::Managed => '=',
             DiffKind::Reset => '!',
         }
     }
@@ -714,7 +769,6 @@ impl DiffKind {
             DiffKind::Change => "change",
             DiffKind::Same => "unchanged",
             DiffKind::Preserved => "preserved",
-            DiffKind::Managed => "managed by this file",
             DiffKind::Reset => "reset to chart default",
         }
     }
@@ -794,7 +848,6 @@ fn display_value(key: &str, value: &str) -> String {
 pub fn diff_plan(
     declared: &BTreeMap<String, String>,
     live: Option<&serde_json::Value>,
-    governs: &dyn Fn(&str) -> bool,
 ) -> Vec<DiffEntry> {
     let mut current = BTreeMap::new();
     if let Some(values) = live {
@@ -821,11 +874,7 @@ pub fn diff_plan(
         if declared.contains_key(key) {
             continue;
         }
-        // Order matters: a key the file governs is being SET, so it must never
-        // fall through to Reset even though it carries no literal value here.
-        let kind = if governs(key) {
-            DiffKind::Managed
-        } else if crate::ops::is_preserved_by_up(key) {
+        let kind = if crate::ops::is_preserved_by_up(key) {
             DiffKind::Preserved
         } else {
             DiffKind::Reset
@@ -920,37 +969,29 @@ impl crate::ui::CliOutput for DiffOutput {
 }
 
 pub struct DiffOpts {
-    pub cfg: Installation,
+    pub local: LocalInstallationPlan,
 }
 
 /// Compare the file against the live release.
 ///
-/// Read-only by construction: it resolves no credential and runs one
-/// `helm get values`. A missing credential must not stop an operator from
-/// asking what would change -- that question is most urgent precisely when the
-/// install is not yet complete.
+/// Resolves the same local inputs as apply, then performs one values read and
+/// provider resolution to complete the desired plan without mutating it.
 pub async fn diff(opts: DiffOpts) -> Result<DiffOutput> {
-    let cfg = opts.cfg;
-    let common = crate::ops::CommonOpts {
-        namespace: cfg.install.namespace.clone(),
-        release: cfg.install.release.clone(),
-        dry_run: false,
-    };
-
-    let live = crate::ops::fetch_release_values(&common).await?;
-
-    let mut declared = BTreeMap::new();
-    for entry in cfg.helm_sets() {
-        if let Some((k, v)) = entry.split_once('=') {
-            declared.insert(k.to_string(), v.to_string());
+    let plan = complete_installation_plan(opts.local).await?;
+    let mut entries = diff_plan(&plan.desired, plan.live.as_ref());
+    if plan.preserves_undeclared_github_token {
+        if let Some(entry) = entries
+            .iter_mut()
+            .find(|entry| entry.key == crate::ops::GITHUB_TOKEN_KEY)
+        {
+            entry.kind = DiffKind::Preserved;
+            entry.to = None;
         }
     }
-
-    let entries = diff_plan(&declared, live.as_ref(), &|key| cfg.governs_key(key));
     Ok(DiffOutput {
-        namespace: cfg.install.namespace,
-        release: cfg.install.release,
-        release_exists: live.is_some(),
+        namespace: plan.cfg.install.namespace,
+        release: plan.cfg.install.release,
+        release_exists: plan.live.is_some(),
         entries,
     })
 }
@@ -961,11 +1002,6 @@ mod diff_tests {
 
     fn live(json: serde_json::Value) -> serde_json::Value {
         json
-    }
-
-    /// A file that governs no computed key: the baseline most cases want.
-    fn governs_nothing(_: &str) -> bool {
-        false
     }
 
     /// The classification tests below run against the REAL key set of the
@@ -1053,23 +1089,8 @@ mod diff_tests {
         root
     }
 
-    fn sre_bot_like() -> Installation {
-        Installation::parse(
-            "version: 1\ninstall:\n  namespace: sre-bot\n  release: sre-bot\n\
-             platform:\n  ui: false\n  inference: false\n  egress:\n    - host: anthropic\n\
-             credentials:\n  model: ANTHROPIC_API_KEY\n\
-             comms:\n  slack:\n    app_token: SLACK_APP_TOKEN\n    bot_token: SLACK_BOT_TOKEN\n",
-        )
-        .unwrap()
-    }
-
-    fn plan_against_live(cfg: &Installation) -> Vec<DiffEntry> {
-        let mut declared = BTreeMap::new();
-        for entry in cfg.helm_sets() {
-            let (k, v) = entry.split_once('=').unwrap();
-            declared.insert(k.to_string(), v.to_string());
-        }
-        diff_plan(&declared, Some(&live_release()), &|k| cfg.governs_key(k))
+    fn plan_against_live(desired: &BTreeMap<String, String>) -> Vec<DiffEntry> {
+        diff_plan(desired, Some(&live_release()))
     }
 
     fn kind_of<'a>(entries: &'a [DiffEntry], key: &str) -> &'a DiffKind {
@@ -1080,23 +1101,39 @@ mod diff_tests {
             .kind
     }
 
-    /// The bug real data exposed: `apply` SETS these three from a file that
-    /// names a model credential, but diff called them resets -- telling the
-    /// operator they would lose what apply was about to write.
+    /// Values from the shared effective plan carry their literal desired value
+    /// into the diff rather than taking a separate classification path.
     #[test]
-    fn keys_apply_sets_outside_helm_sets_are_managed_not_reset() {
-        let entries = plan_against_live(&sre_bot_like());
-        for key in [
-            "agentSandbox.runner.credentials",
-            "agentSandbox.runner.fakeModel",
-            "security.networkPolicy.allowedEgress[0].cidr",
-            "security.networkPolicy.allowedEgress[0].ports[0].port",
-            "security.networkPolicy.allowedEgress[0].ports[0].protocol",
-        ] {
+    fn shared_effective_values_are_reported_as_literal_changes() {
+        let desired = BTreeMap::from([
+            (
+                "agentSandbox.runner.credentials".to_string(),
+                "resolved-model-credential".to_string(),
+            ),
+            (
+                "agentSandbox.runner.fakeModel".to_string(),
+                "false".to_string(),
+            ),
+            (
+                "security.networkPolicy.allowedEgress[0].cidr".to_string(),
+                "203.0.113.10/32".to_string(),
+            ),
+            (
+                "security.networkPolicy.allowedEgress[0].ports[0].port".to_string(),
+                "443".to_string(),
+            ),
+            (
+                "security.networkPolicy.allowedEgress[0].ports[0].protocol".to_string(),
+                "TCP".to_string(),
+            ),
+        ]);
+        let entries = plan_against_live(&desired);
+        for (key, value) in desired {
+            let entry = entries.iter().find(|entry| entry.key == key).unwrap();
+            assert_eq!(entry.kind, DiffKind::Change, "{key}");
             assert_eq!(
-                kind_of(&entries, key),
-                &DiffKind::Managed,
-                "{key} is set by apply, so diff must not call it a reset"
+                entry.to.as_deref(),
+                Some(display_value(&key, &value).as_str())
             );
         }
     }
@@ -1105,10 +1142,7 @@ mod diff_tests {
     /// claiming otherwise would be the same lie inverted.
     #[test]
     fn without_a_declared_model_credential_those_keys_are_resets() {
-        let cfg =
-            Installation::parse("version: 1\ninstall:\n  namespace: sre-bot\n  release: sre-bot\n")
-                .unwrap();
-        let entries = plan_against_live(&cfg);
+        let entries = plan_against_live(&BTreeMap::new());
         for key in [
             "agentSandbox.runner.credentials",
             "agentSandbox.runner.fakeModel",
@@ -1117,23 +1151,11 @@ mod diff_tests {
         }
     }
 
-    /// Governance is index-bounded: a file declaring one egress host does not
-    /// govern a second rule the release carries, and that one really is lost.
-    #[test]
-    fn egress_governance_stops_at_the_declared_count() {
-        let cfg = sre_bot_like();
-        assert!(cfg.governs_key("security.networkPolicy.allowedEgress[0].cidr"));
-        assert!(
-            !cfg.governs_key("security.networkPolicy.allowedEgress[1].cidr"),
-            "one declared host governs rule [0] only"
-        );
-    }
-
     /// Every credential-bearing key on the real release must be preserved, and
     /// none may print. This is the whole "is it safe to adopt the file" answer.
     #[test]
     fn every_live_secret_is_preserved_and_masked() {
-        let entries = plan_against_live(&sre_bot_like());
+        let entries = plan_against_live(&BTreeMap::new());
         for key in [
             "api.apiKey",
             "api.githubAppId",
@@ -1186,11 +1208,7 @@ mod diff_tests {
     #[test]
     fn a_declared_key_the_release_lacks_is_an_add() {
         let declared = BTreeMap::from([("ui.deploy".to_string(), "false".to_string())]);
-        let entries = diff_plan(
-            &declared,
-            Some(&live(serde_json::json!({}))),
-            &governs_nothing,
-        );
+        let entries = diff_plan(&declared, Some(&live(serde_json::json!({}))));
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].kind, DiffKind::Add);
     }
@@ -1201,7 +1219,6 @@ mod diff_tests {
         let entries = diff_plan(
             &declared,
             Some(&live(serde_json::json!({"ui": {"deploy": false}}))),
-            &governs_nothing,
         );
         assert_eq!(entries[0].kind, DiffKind::Same);
         assert!(!entries[0].kind.is_change());
@@ -1213,7 +1230,6 @@ mod diff_tests {
         let entries = diff_plan(
             &declared,
             Some(&live(serde_json::json!({"ui": {"deploy": true}}))),
-            &governs_nothing,
         );
         assert_eq!(entries[0].kind, DiffKind::Change);
         assert_eq!(entries[0].from.as_deref(), Some("true"));
@@ -1234,7 +1250,6 @@ mod diff_tests {
                 "api": {"githubAppId": "4475970", "apiKey": "generated"},
                 "postgres": {"auth": {"password": "generated"}},
             }))),
-            &governs_nothing,
         );
         assert!(
             !entries.is_empty(),
@@ -1259,7 +1274,6 @@ mod diff_tests {
         let entries = diff_plan(
             &declared,
             Some(&live(serde_json::json!({"ui": {"deploy": false}}))),
-            &governs_nothing,
         );
         assert_eq!(entries[0].kind, DiffKind::Reset);
         assert!(entries[0].kind.is_change(), "a reset is a real change");
@@ -1280,7 +1294,6 @@ mod diff_tests {
                 "postgres": {"auth": {"password": "live_pg_password"}},
                 "agentSandbox": {"runner": {"credentials": "sk-ant-live"}},
             }))),
-            &governs_nothing,
         );
         let rendered = format!("{entries:?}");
         for leaked in [
@@ -1303,11 +1316,7 @@ mod diff_tests {
     #[test]
     fn ordinary_values_are_shown_in_full() {
         let declared = BTreeMap::from([("ui.deploy".to_string(), "false".to_string())]);
-        let entries = diff_plan(
-            &declared,
-            Some(&live(serde_json::json!({}))),
-            &governs_nothing,
-        );
+        let entries = diff_plan(&declared, Some(&live(serde_json::json!({}))));
         assert_eq!(entries[0].to.as_deref(), Some("false"));
     }
 
@@ -1317,7 +1326,7 @@ mod diff_tests {
             ("ui.deploy".to_string(), "false".to_string()),
             ("inference.deploy".to_string(), "false".to_string()),
         ]);
-        let entries = diff_plan(&declared, None, &governs_nothing);
+        let entries = diff_plan(&declared, None);
         assert_eq!(entries.len(), 2);
         assert!(entries.iter().all(|e| e.kind == DiffKind::Add));
     }
@@ -1332,7 +1341,6 @@ mod diff_tests {
             entries: diff_plan(
                 &BTreeMap::from([("ui.deploy".to_string(), "false".to_string())]),
                 Some(&live(serde_json::json!({"ui": {"deploy": true}}))),
-                &governs_nothing,
             ),
         };
         let json = out.to_json();

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -3069,6 +3069,7 @@ async fn run(command: Option<Command>) -> Result<()> {
             chart,
         }) => {
             let cfg = curie::installation::Installation::load(&file)?;
+            let local = curie::installation::plan_installation(cfg, dry_run)?;
             let resolved = artifacts::resolve_chart(
                 chart.as_deref(),
                 artifacts::Channel::current(),
@@ -3077,18 +3078,12 @@ async fn run(command: Option<Command>) -> Result<()> {
                 std::path::Path::new("charts/curie").is_dir(),
             )?;
             let chart = materialize_artifact(resolved, dry_run, "chart").await?;
-            emit(
-                curie::installation::apply(curie::installation::ApplyOpts {
-                    cfg,
-                    chart,
-                    dry_run,
-                })
-                .await?,
-            )
+            emit(curie::installation::apply(curie::installation::ApplyOpts { local, chart }).await?)
         }
         Some(Command::Diff { file }) => {
             let cfg = curie::installation::Installation::load(&file)?;
-            emit(curie::installation::diff(curie::installation::DiffOpts { cfg }).await?)
+            let local = curie::installation::plan_installation(cfg, false)?;
+            emit(curie::installation::diff(curie::installation::DiffOpts { local }).await?)
         }
     }
 }

--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -9,6 +9,8 @@
 //! them. That split keeps the argv construction unit-testable with no cluster
 //! and gives one place to mask secrets before anything is printed.
 
+use std::collections::BTreeMap;
+
 use anyhow::{bail, Context, Result};
 use tokio::process::Command;
 
@@ -254,12 +256,6 @@ pub(crate) fn secret_set(key: &str, value: &str) -> CmdArg {
     }
 }
 
-/// A single secret helm value delivered through a private `-f` values file
-/// rather than an argv `--set`, so the value never reaches the process table.
-pub(crate) fn secret_values_file(key: &str, value: &str) -> CmdArg {
-    CmdArg::SecretValuesFile(vec![(key.to_string(), value.to_string())])
-}
-
 /// Mask a secret for display: the first 8 characters, then `***`. Long enough to
 /// recognise a token by its prefix (e.g. `xoxb-...`), short enough to leak
 /// nothing usable.
@@ -365,25 +361,6 @@ pub struct DownOpts {
 /// Egress port shared by every runner allowlist entry (provider + web): TLS only.
 const EGRESS_TCP_PORT: u16 = 443;
 
-/// Push the three `helm --set` args for one `security.networkPolicy.allowedEgress`
-/// entry (cidr + TCP port) at `idx`. Both the model carve-out and each declared
-/// web destination emit this identical shape, so they share one emitter to keep
-/// the array contiguous and the argv byte-identical across sources.
-fn push_egress_rule(args: &mut Vec<CmdArg>, idx: usize, cidr: &str, port: u16) {
-    args.push(plain("--set"));
-    args.push(plain(format!(
-        "security.networkPolicy.allowedEgress[{idx}].cidr={cidr}"
-    )));
-    args.push(plain("--set"));
-    args.push(plain(format!(
-        "security.networkPolicy.allowedEgress[{idx}].ports[0].protocol=TCP"
-    )));
-    args.push(plain("--set"));
-    args.push(plain(format!(
-        "security.networkPolicy.allowedEgress[{idx}].ports[0].port={port}"
-    )));
-}
-
 /// Resolve the model credential `up` installs with. `--fake-model` forces the
 /// sealed install regardless of the environment; otherwise a non-empty
 /// credential value enables the real model.
@@ -469,6 +446,24 @@ pub fn check_github_token_conflict(flag: Option<&str>, clear: bool, set: &[Strin
              `--set`: it puts the complete token in the process table and shell \
              history, which the dedicated input exists to avoid."
         );
+    }
+    Ok(())
+}
+
+/// Validate every input that must fail before the installer reads cluster
+/// state. `curie apply` and `curie diff` call this through their shared local
+/// planner, while `cluster up` keeps the same validation before its own read.
+pub(crate) fn validate_up_inputs(
+    opts: &UpOpts,
+    github_token: Option<&str>,
+    clear_github_token: bool,
+) -> Result<()> {
+    validate_web_egress_cidrs(&opts.allow_web_egress)
+        .context("invalid --allow-web-egress value")?;
+    check_runner_model_conflict(opts.model.as_deref(), &opts.set)?;
+    check_github_token_conflict(github_token, clear_github_token, &opts.set)?;
+    for host in &opts.allow_egress_host {
+        parse_egress_provider(host)?;
     }
     Ok(())
 }
@@ -678,6 +673,86 @@ pub fn resolve_provider_egress_cidrs(
     cidrs.sort();
     cidrs.dedup();
     Ok(cidrs)
+}
+
+type ProviderAddressResolver = Box<dyn Fn(&str) -> std::io::Result<Vec<std::net::IpAddr>>>;
+
+fn system_provider_address_resolver() -> ProviderAddressResolver {
+    Box::new(|host| {
+        use std::net::ToSocketAddrs;
+        (host, 443u16)
+            .to_socket_addrs()
+            .map(|addresses| addresses.map(|address| address.ip()).collect())
+    })
+}
+
+#[cfg(not(debug_assertions))]
+fn provider_address_resolver() -> Result<ProviderAddressResolver> {
+    Ok(system_provider_address_resolver())
+}
+
+#[cfg(debug_assertions)]
+fn provider_address_resolver() -> Result<ProviderAddressResolver> {
+    let raw = match std::env::var("CURIE_TEST_PROVIDER_EGRESS_JSON") {
+        Ok(raw) => raw,
+        Err(std::env::VarError::NotPresent) => return Ok(system_provider_address_resolver()),
+        Err(error) => {
+            return Err(anyhow::anyhow!(
+                "reading CURIE_TEST_PROVIDER_EGRESS_JSON: {error}"
+            ));
+        }
+    };
+
+    let values: serde_json::Value = serde_json::from_str(&raw).context(
+        "CURIE_TEST_PROVIDER_EGRESS_JSON must be a JSON object mapping hosts to IP lists",
+    )?;
+    let values = values.as_object().ok_or_else(|| {
+        anyhow::anyhow!(
+            "CURIE_TEST_PROVIDER_EGRESS_JSON must be a JSON object mapping hosts to IP lists"
+        )
+    })?;
+    let mut resolved = BTreeMap::new();
+    for (host, addresses) in values {
+        let addresses = addresses.as_array().ok_or_else(|| {
+            anyhow::anyhow!(
+                "CURIE_TEST_PROVIDER_EGRESS_JSON entry for {host} must be an array of IP strings"
+            )
+        })?;
+        let mut parsed = Vec::with_capacity(addresses.len());
+        for address in addresses {
+            let address = address.as_str().ok_or_else(|| {
+                anyhow::anyhow!(
+                    "CURIE_TEST_PROVIDER_EGRESS_JSON entry for {host} must contain only IP strings"
+                )
+            })?;
+            parsed.push(address.parse().with_context(|| {
+                format!(
+                    "CURIE_TEST_PROVIDER_EGRESS_JSON entry for {host} has invalid IP address {address}"
+                )
+            })?);
+        }
+        resolved.insert(host.clone(), parsed);
+    }
+    Ok(Box::new(move |host| {
+        resolved.get(host).cloned().ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                format!(
+                    "CURIE_TEST_PROVIDER_EGRESS_JSON has no address list for declared egress host {host}"
+                ),
+            )
+        })
+    }))
+}
+
+/// Resolve provider egress through the system resolver. Debug builds may inject
+/// deterministic addresses, which still pass through the routability checks in
+/// [`resolve_provider_egress_cidrs`].
+pub(crate) fn resolve_provider_egress_cidrs_for_current_environment(
+    providers: &[String],
+) -> Result<Vec<String>> {
+    let resolver = provider_address_resolver()?;
+    resolve_provider_egress_cidrs(providers, |host| resolver(host))
 }
 
 /// A note naming the model provider(s) whose egress `cluster up` opened, or
@@ -1000,20 +1075,6 @@ pub(crate) const MODEL_CREDENTIAL_KEY: &str = "agentSandbox.runner.credentials";
 /// present -- see `up_commands`, which pushes both inside one `if let`.
 pub(crate) const FAKE_MODEL_KEY: &str = "agentSandbox.runner.fakeModel";
 
-/// The `--set` prefix the egress rules are written under.
-pub(crate) const EGRESS_KEY_PREFIX: &str = "security.networkPolicy.allowedEgress[";
-
-/// The array index of an egress chart key, or `None` if it is not one.
-///
-/// `curie diff` needs this to tell "the file governs this rule" from "the
-/// release has a rule the file dropped": both look like the same key family,
-/// and only the INDEX distinguishes them.
-pub(crate) fn egress_key_index(key: &str) -> Option<usize> {
-    let rest = key.strip_prefix(EGRESS_KEY_PREFIX)?;
-    let (digits, _) = rest.split_once(']')?;
-    digits.parse().ok()
-}
-
 /// Does a plain `cluster up` carry this key forward when nothing re-passes it?
 ///
 /// The honest half of `curie diff`. `up` does a FULL upgrade, so a key present
@@ -1088,6 +1149,33 @@ fn resolve_github_token(
         Some(current) => GithubTokenPlan::Set(current),
         None => GithubTokenPlan::Untouched,
     }
+}
+
+/// Finish an already validated up plan with the one live values read and, when
+/// requested, resolved provider addresses. This is kept separate from command
+/// execution so apply and diff can compare the same completed values.
+pub(crate) fn complete_up_opts(
+    mut opts: UpOpts,
+    existing: Option<&serde_json::Value>,
+    github_token: Option<&str>,
+    clear_github_token: bool,
+    resolve_provider_egress: bool,
+) -> Result<UpOpts> {
+    if !opts.dev {
+        opts.secrets = resolve_generated_secrets(existing, &opts.set)?;
+        opts.secrets
+            .extend(resolve_preserved_values(existing, &opts.set));
+    }
+    opts.github_token = resolve_github_token(existing, &opts.set, github_token, clear_github_token);
+    if resolve_provider_egress
+        && !opts.allow_egress_host.is_empty()
+        && opts.resolved_egress_cidrs.is_empty()
+    {
+        opts.resolved_egress_cidrs =
+            resolve_provider_egress_cidrs_for_current_environment(&opts.allow_egress_host)
+                .context("resolving named provider egress hosts")?;
+    }
+    Ok(opts)
 }
 
 /// Whether an operator `--set` assigns a NON-EMPTY value to
@@ -1183,14 +1271,161 @@ async fn fetch_existing_values(o: &CommonOpts) -> Result<Option<serde_json::Valu
     ))
 }
 
-/// `helm upgrade --install` for the release, exposing the UI and Langfuse on
-/// node ports unless `--no-expose`, plus any pass-through `--set` values. When a
-/// model credential is present it switches the fake model off and forwards the
-/// credential (masked when printed) -- but opens NO egress on its own (#362).
-/// Runner egress comes only from the resolved named-provider host routes
-/// (`resolved_egress_cidrs`, first) and the declared web destinations
-/// (`allow_web_egress`, after), sharing one contiguous array index.
-pub fn up_commands(o: &UpOpts) -> Vec<OpsCommand> {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DiffParticipation {
+    Include,
+    Preserve,
+}
+
+#[derive(Clone, PartialEq, Eq)]
+enum PlannedHelmValues {
+    Set {
+        expression: String,
+        effective: Vec<(String, String)>,
+    },
+    SecretFile {
+        values: Vec<(String, String)>,
+        diff: DiffParticipation,
+    },
+}
+
+#[derive(Clone, Default, PartialEq, Eq)]
+pub(crate) struct UpValuePlan {
+    entries: Vec<PlannedHelmValues>,
+}
+
+impl UpValuePlan {
+    fn set(&mut self, key: impl Into<String>, value: impl Into<String>) {
+        let key = key.into();
+        let value = value.into();
+        self.entries.push(PlannedHelmValues::Set {
+            expression: format!("{key}={value}"),
+            effective: vec![(key, value)],
+        });
+    }
+
+    fn set_expression(&mut self, expression: String) {
+        let effective = operator_set_entries(std::slice::from_ref(&expression))
+            .into_iter()
+            .map(|(key, value)| (key.trim().to_string(), value.to_string()))
+            .collect();
+        self.entries.push(PlannedHelmValues::Set {
+            expression,
+            effective,
+        });
+    }
+
+    fn secret_file(&mut self, values: Vec<(String, String)>, diff: DiffParticipation) {
+        if !values.is_empty() {
+            self.entries
+                .push(PlannedHelmValues::SecretFile { values, diff });
+        }
+    }
+
+    fn append_command_args(&self, args: &mut Vec<CmdArg>) {
+        for entry in &self.entries {
+            match entry {
+                PlannedHelmValues::Set { expression, .. } => {
+                    args.push(plain("--set"));
+                    args.push(plain(expression));
+                }
+                PlannedHelmValues::SecretFile { values, .. } => {
+                    args.push(CmdArg::SecretValuesFile(values.clone()));
+                }
+            }
+        }
+    }
+
+    pub(crate) fn effective_values(&self) -> BTreeMap<String, String> {
+        let mut values = BTreeMap::new();
+        for entry in &self.entries {
+            match entry {
+                PlannedHelmValues::Set { effective, .. } => {
+                    values.extend(effective.iter().cloned());
+                }
+                PlannedHelmValues::SecretFile {
+                    values: secrets,
+                    diff: DiffParticipation::Include,
+                } => {
+                    values.extend(secrets.iter().cloned());
+                }
+                PlannedHelmValues::SecretFile {
+                    diff: DiffParticipation::Preserve,
+                    ..
+                } => {}
+            }
+        }
+        values
+    }
+}
+
+/// The ordered chart values supplied by one `cluster up`. Both the Helm command
+/// and installation diff consume this representation, so adding a value cannot
+/// update one path without updating the other.
+pub(crate) fn up_value_plan(o: &UpOpts) -> UpValuePlan {
+    let mut plan = UpValuePlan::default();
+    if o.dev {
+        plan.set("security.allowDevDefaults", "true");
+    }
+    if !o.no_expose {
+        plan.set("ui.service.type", "NodePort");
+        plan.set("langfuse.web.service.type", "NodePort");
+    }
+    if let Some(model) = &o.local_model {
+        plan.set("inference.deploy", "true");
+        plan.set("inference.model", model);
+    }
+    if let Some(credentials) = &o.credentials {
+        plan.set(FAKE_MODEL_KEY, "false");
+        plan.secret_file(
+            vec![(MODEL_CREDENTIAL_KEY.to_string(), credentials.clone())],
+            DiffParticipation::Include,
+        );
+    }
+    match &o.github_token {
+        GithubTokenPlan::Untouched => {}
+        GithubTokenPlan::Set(token) => {
+            plan.secret_file(
+                vec![(GITHUB_TOKEN_KEY.to_string(), token.clone())],
+                DiffParticipation::Include,
+            );
+        }
+        GithubTokenPlan::Clear => {
+            plan.set(GITHUB_TOKEN_KEY, "");
+        }
+    }
+    for (index, cidr) in o
+        .resolved_egress_cidrs
+        .iter()
+        .chain(o.allow_web_egress.iter())
+        .enumerate()
+    {
+        plan.set(
+            format!("security.networkPolicy.allowedEgress[{index}].cidr"),
+            cidr,
+        );
+        plan.set(
+            format!("security.networkPolicy.allowedEgress[{index}].ports[0].protocol"),
+            "TCP",
+        );
+        plan.set(
+            format!("security.networkPolicy.allowedEgress[{index}].ports[0].port"),
+            EGRESS_TCP_PORT.to_string(),
+        );
+    }
+    plan.secret_file(o.secrets.clone(), DiffParticipation::Preserve);
+    if let Some(model) = &o.model {
+        if explicit_runner_model(&o.set).is_none() {
+            plan.set(RUNNER_MODEL_KEY, model);
+        }
+    }
+    for expression in &o.set {
+        plan.set_expression(expression.clone());
+    }
+    plan
+}
+
+fn up_commands_with_plan(o: &UpOpts, plan: &UpValuePlan) -> Vec<OpsCommand> {
     let mut args = vec![
         plain("upgrade"),
         plain("--install"),
@@ -1200,98 +1435,14 @@ pub fn up_commands(o: &UpOpts) -> Vec<OpsCommand> {
         plain(&o.common.namespace),
         plain("--create-namespace"),
     ];
-    if o.dev {
-        // With #195 the sealed chart auto-generates strong per-release secrets
-        // by default. `--dev` must opt into the chart's deterministic published
-        // defaults so local/CI stacks stay reproducible and match compose.
-        args.push(plain("--set"));
-        args.push(plain("security.allowDevDefaults=true"));
-    }
-    if !o.no_expose {
-        args.push(plain("--set"));
-        args.push(plain("ui.service.type=NodePort"));
-        args.push(plain("--set"));
-        args.push(plain("langfuse.web.service.type=NodePort"));
-    }
-    if let Some(model) = &o.local_model {
-        args.push(plain("--set"));
-        args.push(plain("inference.deploy=true"));
-        args.push(plain("--set"));
-        args.push(plain(format!("inference.model={model}")));
-    }
-    if let Some(credentials) = &o.credentials {
-        args.push(plain("--set"));
-        args.push(plain("agentSandbox.runner.fakeModel=false"));
-        // The model credential is the one high-sensitivity value here (a live API
-        // key). Deliver it through a private 0600 `-f` values file instead of an
-        // argv `--set`, so it never lands in the process table where any local
-        // user / EDR / crash reporter could read it via `ps -ef` or
-        // `/proc/<pid>/cmdline`. `fakeModel` is not secret and stays as plain
-        // `--set`. helm merges `-f` values before `--set`, so a later operator
-        // `--set` still overrides, matching the prior precedence. Enabling the
-        // real model opens NO egress on its own (#362) -- see the egress rules
-        // below, which come only from named providers and declared web ranges.
-        args.push(secret_values_file(
-            "agentSandbox.runner.credentials",
-            credentials,
-        ));
-    }
-    // The GitHub credential is a live bearer token, so it takes the same private
-    // 0600 `-f` values file as the model credential above and never touches the
-    // argv (#1124). An explicit clear is the empty string, which is NOT secret
-    // and rides as a visible plain `--set` -- the same shape
-    // `comms --disconnect` writes -- so the operator can see the removal in the
-    // preview instead of inferring it from an absence. Both sit before the
-    // passthrough `--set`s, so an operator `--set` keeps helm precedence.
-    match &o.github_token {
-        GithubTokenPlan::Untouched => {}
-        GithubTokenPlan::Set(token) => {
-            args.push(secret_values_file(GITHUB_TOKEN_KEY, token));
-        }
-        GithubTokenPlan::Clear => {
-            args.push(plain("--set"));
-            args.push(plain(format!("{GITHUB_TOKEN_KEY}=")));
-        }
-    }
-    // Egress allowlist entries share one running index so the array stays
-    // contiguous no matter which source contributes: the resolved named-provider
-    // host routes take the first slots (in order), then each declared web
-    // destination follows. When both are empty, no `allowedEgress` entry is
-    // emitted and the runner stays fail-closed.
-    let mut egress_idx = 0;
-    for cidr in &o.resolved_egress_cidrs {
-        push_egress_rule(&mut args, egress_idx, cidr, EGRESS_TCP_PORT);
-        egress_idx += 1;
-    }
-    for cidr in &o.allow_web_egress {
-        push_egress_rule(&mut args, egress_idx, cidr, EGRESS_TCP_PORT);
-        egress_idx += 1;
-    }
-    // The generated/reused required secrets travel through one private 0600 `-f`
-    // values file (materialized at run time), so no secret reaches the process
-    // table. Emitted before the passthrough `--set`s below and (like the model
-    // credential above) before them in helm's precedence, so an explicit
-    // operator `--set` still overrides -- though `resolve_generated_secrets`
-    // already skips any key the operator pinned.
-    if !o.secrets.is_empty() {
-        args.push(CmdArg::SecretValuesFile(o.secrets.clone()));
-    }
-    // Default the sandbox runner model from the shell `CURIE_MODEL` for
-    // cross-tier parity with `local up` (#361). Injected before the passthrough
-    // `--set`s so an explicit operator `--set agentSandbox.runner.model=` keeps
-    // helm precedence; suppressed when the operator already pinned it (a
-    // conflicting value fails loud earlier in `up`).
-    if let Some(model) = &o.model {
-        if explicit_runner_model(&o.set).is_none() {
-            args.push(plain("--set"));
-            args.push(plain(format!("{RUNNER_MODEL_KEY}={model}")));
-        }
-    }
-    for s in &o.set {
-        args.push(plain("--set"));
-        args.push(plain(s));
-    }
+    plan.append_command_args(&mut args);
     vec![OpsCommand::new("helm", args)]
+}
+
+/// `helm upgrade --install` for the release. Its chart values are rendered from
+/// [`up_value_plan`], which is also the source of the installation diff.
+pub fn up_commands(o: &UpOpts) -> Vec<OpsCommand> {
+    up_commands_with_plan(o, &up_value_plan(o))
 }
 
 /// The read-only commands `curie cluster status` runs (and prints under `--dry-run`).
@@ -1887,47 +2038,50 @@ fn should_read_existing(dev: bool, dry_run: bool) -> bool {
 }
 
 pub async fn up(
-    mut opts: UpOpts,
+    opts: UpOpts,
     github_token: Option<String>,
     clear_github_token: bool,
 ) -> Result<ClusterUpOutput> {
-    let ui = crate::ui::ui();
-    validate_web_egress_cidrs(&opts.allow_web_egress)
-        .context("invalid --allow-web-egress value")?;
-    // Fail loud (even under --dry-run) if CURIE_MODEL and an explicit
-    // `--set agentSandbox.runner.model=` disagree (#361).
-    check_runner_model_conflict(opts.model.as_deref(), &opts.set)?;
-    // Fail loud (even under --dry-run) when the credential is supplied through
-    // both the private input and the leaky `--set` pass-through (#1124).
-    check_github_token_conflict(github_token.as_deref(), clear_github_token, &opts.set)?;
-    // Each `--allow-egress-host` must name a known provider. An unknown value is
-    // a usage error (exit 2) pointing at `--allow-web-egress`; the `?` carries
-    // the CliError's exit class into the anyhow chain.
-    for h in &opts.allow_egress_host {
-        parse_egress_provider(h)?;
-    }
-
-    // Resolve the required chart secrets so a no-override `cluster up` never
-    // ships the published dev defaults (#196). `--dev` keeps the chart's
-    // deterministic dev defaults; otherwise a fresh install generates strong
-    // per-release randoms and an upgrade re-supplies whatever helm already
-    // recorded (so a live store's credential is never rotated). `--dry-run`
-    // stays offline (it never touches the cluster), so it previews the fresh
-    // install shape -- a live run reuses any existing release's secrets.
-    //
-    // Read once, used by both the generated-secret resolution below (sealed
-    // installs only) and the GitHub-credential resolution (every install --
-    // `--dev` governs the chart's dev DEFAULTS, not an operator's credential).
-    // `--dry-run` stays offline and therefore previews the fresh-install shape.
+    validate_up_inputs(&opts, github_token.as_deref(), clear_github_token)?;
+    let resolve_provider_egress = !opts.common.dry_run;
     let existing = if should_read_existing(opts.dev, opts.common.dry_run) {
         require_on_path("helm")?;
         fetch_existing_values(&opts.common).await?
     } else {
         None
     };
+    let opts = complete_up_opts(
+        opts,
+        existing.as_ref(),
+        github_token.as_deref(),
+        clear_github_token,
+        resolve_provider_egress,
+    )?;
+    let value_plan = up_value_plan(&opts);
+    run_prepared_up(opts, value_plan, existing, github_token.as_deref()).await
+}
+
+/// Execute an up plan whose local validation and live completion already ran.
+/// Installation apply uses this after it has shared that completed plan with
+/// diff, avoiding another values read or provider lookup.
+pub(crate) async fn up_prepared(
+    opts: UpOpts,
+    value_plan: UpValuePlan,
+    existing: Option<serde_json::Value>,
+    github_token: Option<String>,
+) -> Result<ClusterUpOutput> {
+    validate_up_inputs(&opts, github_token.as_deref(), false)?;
+    run_prepared_up(opts, value_plan, existing, github_token.as_deref()).await
+}
+
+async fn run_prepared_up(
+    opts: UpOpts,
+    value_plan: UpValuePlan,
+    existing: Option<serde_json::Value>,
+    github_token: Option<&str>,
+) -> Result<ClusterUpOutput> {
+    let ui = crate::ui::ui();
     if !opts.dev {
-        let fresh = existing.is_none();
-        opts.secrets = resolve_generated_secrets(existing.as_ref(), &opts.set)?;
         let preserved = resolve_preserved_values(existing.as_ref(), &opts.set);
         if !preserved.is_empty() {
             ui.note(&format!(
@@ -1935,25 +2089,14 @@ pub async fn up(
                  re-run those verbs only to change them",
                 preserved.len()
             ));
-            opts.secrets.extend(preserved);
         }
-        if fresh && !opts.secrets.is_empty() && !opts.common.dry_run {
+        if existing.is_none() && !opts.secrets.is_empty() && !opts.common.dry_run {
             ui.note(&format!(
                 "generated strong per-release secrets for {} required chart credential(s); re-running `cluster up` reuses them",
                 opts.secrets.len()
             ));
         }
     }
-
-    // The API's outbound GitHub credential: an explicit `--github-token` /
-    // `--clear-github-token`, otherwise whatever the release already recorded,
-    // so a plain `cluster up` cannot silently reset it (#1124).
-    opts.github_token = resolve_github_token(
-        existing.as_ref(),
-        &opts.set,
-        github_token.as_deref(),
-        clear_github_token,
-    );
     // `existing.is_some()` means this is an UPGRADE: an API pod is already
     // running on the old value and keeps it until it restarts (the api pod
     // template carries no checksum/secret annotation). On a FRESH install the
@@ -1975,9 +2118,9 @@ pub async fn up(
     // An explicit but EMPTY `--github-token` / `CURIE_GITHUB_TOKEN`: a routine
     // shell accident that preserves rather than clears (`resolve_github_token`),
     // so each arm below folds it into its own single note.
-    let empty_flag = github_token.as_deref().is_some_and(str::is_empty);
+    let empty_flag = github_token.is_some_and(str::is_empty);
     match &opts.github_token {
-        GithubTokenPlan::Set(_) if github_token.as_deref().is_some_and(|v| !v.is_empty()) => {
+        GithubTokenPlan::Set(_) if github_token.is_some_and(|v| !v.is_empty()) => {
             if upgrading {
                 ui.note(&format!(
                     "GitHub credential set through the private values path; the running API keeps the old one until it restarts: {restart_hint}"
@@ -2025,40 +2168,25 @@ pub async fn up(
         ui.warn("a GitHub credential passed with --set lands in the process table, shell history and the printed plan; use --github-token, or CURIE_GITHUB_TOKEN to keep it out of shell history too");
     }
 
-    // Resolve the named providers' API host(s) to narrow host-route CIDRs. This
-    // is the only DNS the installer does, and it stays offline under `--dry-run`
-    // (the offline invariant): dry-run previews the intent without resolving,
-    // and a live run resolves and opens exactly the resolved addresses.
-    if !opts.allow_egress_host.is_empty() {
-        if opts.common.dry_run {
-            // Name each provider's host(s) without resolving them, so the
-            // preview stays offline yet shows exactly what a live run reaches.
-            let named = opts
-                .allow_egress_host
-                .iter()
-                .map(|p| match provider_egress_hosts(p) {
-                    Some(hosts) if !hosts.is_empty() => format!("{p} ({})", hosts.join(", ")),
-                    _ => p.clone(),
-                })
-                .collect::<Vec<_>>()
-                .join(", ");
-            ui.note(&format!(
-                "a live run resolves {named} to narrow /32+/128 host routes and opens runner egress to the resolved addresses (skipped here to keep --dry-run offline)"
-            ));
-        } else {
-            let real_resolver = |host: &str| -> std::io::Result<Vec<std::net::IpAddr>> {
-                use std::net::ToSocketAddrs;
-                (host, 443u16)
-                    .to_socket_addrs()
-                    .map(|it| it.map(|s| s.ip()).collect())
-            };
-            opts.resolved_egress_cidrs =
-                resolve_provider_egress_cidrs(&opts.allow_egress_host, real_resolver)
-                    .context("resolving named provider egress hosts")?;
-        }
+    if !opts.allow_egress_host.is_empty()
+        && opts.common.dry_run
+        && opts.resolved_egress_cidrs.is_empty()
+    {
+        let named = opts
+            .allow_egress_host
+            .iter()
+            .map(|provider| match provider_egress_hosts(provider) {
+                Some(hosts) if !hosts.is_empty() => format!("{provider} ({})", hosts.join(", ")),
+                _ => provider.clone(),
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+        ui.note(&format!(
+            "a live run resolves {named} to narrow /32+/128 host routes and opens runner egress to the resolved addresses (skipped here to keep --dry-run offline)"
+        ));
     }
 
-    let mut cmds = up_commands(&opts);
+    let mut cmds = up_commands_with_plan(&opts, &value_plan);
 
     // #707 record ownership only on namespaces THIS run creates, so a later
     // `down` sweeps exactly what `up` made and leaves pre-existing state alone.

--- a/cli/tests/installation_plan_parity.rs
+++ b/cli/tests/installation_plan_parity.rs
@@ -1,0 +1,434 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::PathBuf;
+use std::process::{Command, Output};
+
+use serde_json::{json, Value};
+
+const IPV4: &str = "1.1.1.1";
+const IPV6: &str = "2606:4700:4700::1111";
+const MODEL_VALUE: &str = "model-value-for-plan";
+const GITHUB_VALUE: &str = "github-value-for-plan";
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_curie")
+}
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("cli has a repository parent")
+        .to_path_buf()
+}
+
+struct HelmFixture {
+    temp: tempfile::TempDir,
+    file: PathBuf,
+    live_values: Option<String>,
+}
+
+impl HelmFixture {
+    fn new(config: &str, live_values: Option<Value>) -> Self {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let file = temp.path().join("curie.yaml");
+        fs::write(&file, config).expect("write curie.yaml");
+
+        let bin_dir = temp.path().join("bin");
+        fs::create_dir(&bin_dir).expect("create stub bin directory");
+        let helm = bin_dir.join("helm");
+        fs::write(
+            &helm,
+            r#"#!/bin/sh
+if [ "$1" = get ] && [ "$2" = values ]; then
+    if [ "${CURIE_TEST_HELM_ABSENT:-}" = 1 ]; then
+        printf '%s\n' 'release not found' >&2
+        exit 1
+    fi
+    printf '%s\n' "$CURIE_TEST_HELM_VALUES"
+    exit 0
+fi
+printf 'unexpected helm invocation: %s\n' "$*" >&2
+exit 64
+"#,
+        )
+        .expect("write helm stub");
+        let mut permissions = fs::metadata(&helm).expect("helm metadata").permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&helm, permissions).expect("make helm stub executable");
+
+        Self {
+            temp,
+            file,
+            live_values: live_values.map(|values| values.to_string()),
+        }
+    }
+
+    fn run(&self, args: &[&str], env: &[(&str, &str)]) -> Output {
+        let mut paths = vec![self.temp.path().join("bin")];
+        if let Some(current) = std::env::var_os("PATH") {
+            paths.extend(std::env::split_paths(&current));
+        }
+        let path = std::env::join_paths(paths).expect("join PATH");
+
+        let mut command = Command::new(bin());
+        command
+            .current_dir(repo_root())
+            .arg("--json")
+            .args(args)
+            .env("PATH", path)
+            .env_remove("CURIE_MODEL")
+            .env_remove("CURIE_TEST_PROVIDER_EGRESS_JSON")
+            .env_remove("CURIE_APPLY_TEST_MODEL_KEY")
+            .env_remove("CURIE_APPLY_TEST_GITHUB_TOKEN");
+        match &self.live_values {
+            Some(values) => {
+                command
+                    .env_remove("CURIE_TEST_HELM_ABSENT")
+                    .env("CURIE_TEST_HELM_VALUES", values);
+            }
+            None => {
+                command
+                    .env("CURIE_TEST_HELM_ABSENT", "1")
+                    .env_remove("CURIE_TEST_HELM_VALUES");
+            }
+        }
+        for (key, value) in env {
+            command.env(key, value);
+        }
+        command.output().expect("run curie")
+    }
+
+    fn apply_dry_run(&self, env: &[(&str, &str)]) -> Output {
+        self.run(
+            &[
+                "apply",
+                "--dry-run",
+                "--file",
+                self.file.to_str().expect("UTF 8 path"),
+            ],
+            env,
+        )
+    }
+
+    fn diff(&self, env: &[(&str, &str)]) -> Output {
+        self.run(
+            &["diff", "--file", self.file.to_str().expect("UTF 8 path")],
+            env,
+        )
+    }
+}
+
+fn provider_egress_fixture() -> String {
+    json!({"api.anthropic.com": [IPV4, IPV6]}).to_string()
+}
+
+fn json_output(output: Output, verb: &str) -> Value {
+    assert!(
+        output.status.success(),
+        "{verb} failed with stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "{verb} did not emit JSON: {error}; stdout:\n{}",
+            String::from_utf8_lossy(&output.stdout)
+        )
+    })
+}
+
+fn json_error(output: Output, verb: &str) -> Value {
+    assert!(
+        !output.status.success(),
+        "{verb} unexpectedly succeeded; stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        output.stderr.is_empty(),
+        "{verb} wrote an error to stderr under --json:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "{verb} did not emit structured JSON error: {error}; stdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    assert!(json["error"].is_string(), "{verb} error payload: {json}");
+    assert!(json.get("fix").is_some(), "{verb} error payload: {json}");
+    json
+}
+
+fn plan(output: Output) -> String {
+    let json = json_output(output, "apply --dry-run");
+    json["plan"]
+        .as_array()
+        .expect("dry run plan array")
+        .iter()
+        .map(|line| line.as_str().expect("dry run line"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn shell_tokens(line: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let mut token = String::new();
+    let mut quoted = false;
+    for character in line.chars() {
+        match character {
+            '\'' => quoted = !quoted,
+            character if character.is_whitespace() && !quoted => {
+                if !token.is_empty() {
+                    tokens.push(std::mem::take(&mut token));
+                }
+            }
+            character => token.push(character),
+        }
+    }
+    assert!(!quoted, "unterminated quote in dry run command: {line}");
+    if !token.is_empty() {
+        tokens.push(token);
+    }
+    tokens
+}
+
+fn helm_values(plan: &str) -> BTreeMap<String, String> {
+    let helm = plan
+        .lines()
+        .find(|line| line.starts_with("helm upgrade "))
+        .unwrap_or_else(|| panic!("missing helm upgrade command: {plan}"));
+    let tokens = shell_tokens(helm);
+    let mut values = BTreeMap::new();
+    let mut index = 0;
+    while index < tokens.len() {
+        if tokens[index] == "--set" || tokens[index] == "--set-string" {
+            let setting = tokens.get(index + 1).unwrap_or_else(|| {
+                panic!("{} has no value in dry run command: {helm}", tokens[index])
+            });
+            let (key, value) = setting
+                .split_once('=')
+                .unwrap_or_else(|| panic!("invalid Helm setting {setting}: {helm}"));
+            values.insert(key.to_string(), value.to_string());
+            index += 2;
+            continue;
+        }
+        if tokens[index] == "-f" {
+            let file = tokens
+                .get(index + 1)
+                .unwrap_or_else(|| panic!("-f has no value in dry run command: {helm}"));
+            if let Some(secret_values) = file
+                .strip_prefix("<secret values file: ")
+                .and_then(|value| value.strip_suffix('>'))
+            {
+                for setting in secret_values.split(", ") {
+                    let (key, value) = setting
+                        .split_once('=')
+                        .unwrap_or_else(|| panic!("invalid secret Helm setting {setting}: {helm}"));
+                    if matches!(key, "agentSandbox.runner.credentials" | "api.githubToken") {
+                        values.insert(key.to_string(), value.to_string());
+                    }
+                }
+            }
+            index += 2;
+            continue;
+        }
+        index += 1;
+    }
+    values
+}
+
+fn entry<'a>(diff: &'a Value, key: &str) -> &'a Value {
+    diff["entries"]
+        .as_array()
+        .expect("diff entries array")
+        .iter()
+        .find(|entry| entry["key"] == key)
+        .unwrap_or_else(|| panic!("missing diff entry for {key}: {diff}"))
+}
+
+fn assert_added(diff: &Value, key: &str, value: &str) {
+    let entry = entry(diff, key);
+    assert_eq!(entry["kind"], "add", "{key}: {entry}");
+    assert_eq!(entry["to"].as_str(), Some(value), "{key}: {entry}");
+}
+
+fn assert_diff_keys(diff: &Value, expected: &[&str]) {
+    let actual = diff["entries"]
+        .as_array()
+        .expect("diff entries array")
+        .iter()
+        .map(|entry| entry["key"].as_str().expect("diff entry key"))
+        .collect::<BTreeSet<_>>();
+    let expected = expected.iter().copied().collect::<BTreeSet<_>>();
+    assert_eq!(actual, expected, "diff effective values: {diff}");
+}
+
+fn installation_with_effective_values() -> &'static str {
+    "version: 1\ninstall:\n  namespace: parity\n  release: parity\ncredentials:\n  model: CURIE_APPLY_TEST_MODEL_KEY\n  github_token: CURIE_APPLY_TEST_GITHUB_TOKEN\nplatform:\n  ui: false\n  inference: true\nset:\n  dispatcher.deploy: \"false\"\n  worker.replicas: \"3\"\n"
+}
+
+#[test]
+fn absent_release_diff_matches_apply_dry_run_for_effective_installation_values() {
+    let fixture = HelmFixture::new(installation_with_effective_values(), None);
+    let env = [
+        ("CURIE_APPLY_TEST_MODEL_KEY", MODEL_VALUE),
+        ("CURIE_APPLY_TEST_GITHUB_TOKEN", GITHUB_VALUE),
+        ("CURIE_MODEL", "runner-model-for-plan"),
+    ];
+
+    let apply = plan(fixture.apply_dry_run(&env));
+    let diff = json_output(fixture.diff(&env), "diff");
+
+    assert_eq!(diff["release_exists"], false, "{diff}");
+    assert!(
+        diff["changes"].as_u64().is_some_and(|changes| changes > 0),
+        "an absent release must have create changes: {diff}"
+    );
+    assert!(
+        apply.contains("agentSandbox.runner.credentials=model-va***"),
+        "apply must use and mask the resolved model credential: {apply}"
+    );
+    assert!(
+        apply.contains("api.githubToken=github-v***"),
+        "apply must use and mask the resolved GitHub credential: {apply}"
+    );
+    assert!(
+        !apply.contains(MODEL_VALUE) && !apply.contains(GITHUB_VALUE),
+        "apply must not leak credential values: {apply}"
+    );
+    assert_added(&diff, "agentSandbox.runner.credentials", "<secret>");
+    assert_added(&diff, "api.githubToken", "<secret>");
+
+    let apply_values = helm_values(&apply);
+    for (key, apply_value) in &apply_values {
+        let diff_entry = entry(&diff, key);
+        assert_eq!(diff_entry["kind"], "add", "{key}: {diff_entry}");
+        let diff_value = diff_entry["to"]
+            .as_str()
+            .unwrap_or_else(|| panic!("diff entry has no target value for {key}: {diff_entry}"));
+        if diff_value == "<secret>" {
+            assert!(
+                apply_value.ends_with("***"),
+                "apply must expose only a masked value for {key}: {apply}"
+            );
+        } else {
+            assert_eq!(apply_value, diff_value, "{key}: {diff_entry}");
+        }
+    }
+
+    let diff_keys = diff["entries"]
+        .as_array()
+        .expect("diff entries array")
+        .iter()
+        .filter(|entry| entry["kind"] != "preserved")
+        .map(|entry| entry["key"].as_str().expect("diff entry key"))
+        .collect::<BTreeSet<_>>();
+    let apply_keys = apply_values
+        .keys()
+        .map(String::as_str)
+        .collect::<BTreeSet<_>>();
+    assert_eq!(diff_keys, apply_keys, "apply plan: {apply}; diff: {diff}");
+}
+
+#[test]
+fn empty_github_token_clear_is_shared_by_apply_and_diff() {
+    let fixture = HelmFixture::new(
+        "version: 1\ninstall:\n  namespace: parity\n  release: parity\nset:\n  api.githubToken: \"\"\n",
+        None,
+    );
+
+    let apply = plan(fixture.apply_dry_run(&[]));
+    let diff = json_output(fixture.diff(&[]), "diff");
+
+    let apply_values = helm_values(&apply);
+    assert_eq!(
+        apply_values.get("api.githubToken").map(String::as_str),
+        Some(""),
+        "apply must carry the exact empty GitHub token clear: {apply}"
+    );
+    assert_added(&diff, "api.githubToken", "<secret>");
+    assert_diff_keys(
+        &diff,
+        &[
+            "api.githubToken",
+            "langfuse.web.service.type",
+            "ui.service.type",
+        ],
+    );
+}
+
+#[test]
+fn diff_marks_only_extra_live_egress_for_reset_and_preserves_live_github_token() {
+    let fixture = HelmFixture::new(
+        "version: 1\ninstall:\n  namespace: parity\n  release: parity\nplatform:\n  egress:\n    - host: anthropic\n",
+        Some(json!({
+            "api": {"githubToken": "ghp-live-token"},
+            "security": {"networkPolicy": {"allowedEgress": [
+                {"cidr": "1.1.1.1/32", "ports": [{"port": 443, "protocol": "TCP"}]},
+                {"cidr": "2606:4700:4700::1111/128", "ports": [{"port": 443, "protocol": "TCP"}]},
+                {"cidr": "9.9.9.9/32", "ports": [{"port": 443, "protocol": "TCP"}]}
+            ]}}
+        })),
+    );
+    let egress = provider_egress_fixture();
+    let diff = json_output(
+        fixture.diff(&[("CURIE_TEST_PROVIDER_EGRESS_JSON", egress.as_str())]),
+        "diff",
+    );
+
+    for key in [
+        "security.networkPolicy.allowedEgress[0].cidr",
+        "security.networkPolicy.allowedEgress[1].cidr",
+        "security.networkPolicy.allowedEgress[0].ports[0].port",
+        "security.networkPolicy.allowedEgress[1].ports[0].port",
+    ] {
+        assert_eq!(entry(&diff, key)["kind"], "unchanged", "{key}: {diff}");
+    }
+    for key in [
+        "security.networkPolicy.allowedEgress[2].cidr",
+        "security.networkPolicy.allowedEgress[2].ports[0].port",
+    ] {
+        assert_eq!(
+            entry(&diff, key)["kind"],
+            "reset to chart default",
+            "{key}: {diff}"
+        );
+    }
+    let github = entry(&diff, "api.githubToken");
+    assert_eq!(github["kind"], "preserved", "{github}");
+    assert_eq!(github["from"], "<secret>", "{github}");
+    assert!(
+        !diff.to_string().contains("ghp-live-token"),
+        "diff must not leak the preserved GitHub token: {diff}"
+    );
+}
+
+#[test]
+fn apply_and_diff_report_the_same_curie_model_conflict() {
+    let fixture = HelmFixture::new(
+        "version: 1\ninstall:\n  namespace: parity\n  release: parity\nset:\n  agentSandbox.runner.model: file-model\n",
+        None,
+    );
+    let env = [("CURIE_MODEL", "shell-model")];
+    let apply = fixture.apply_dry_run(&env);
+    let diff = fixture.diff(&env);
+
+    assert_eq!(apply.status.code(), diff.status.code());
+    let apply_error = json_error(apply, "apply --dry-run");
+    let diff_error = json_error(diff, "diff");
+    let apply_message = apply_error["error"]
+        .as_str()
+        .expect("apply error message string");
+    assert!(
+        apply_message.contains("CURIE_MODEL")
+            && apply_message.contains("agentSandbox.runner.model"),
+        "apply returned the wrong conflict error: {apply_error}"
+    );
+    assert_eq!(
+        apply_error, diff_error,
+        "apply and diff must use the same effective-plan conflict validation"
+    );
+}

--- a/cli/tests/json_contract.rs
+++ b/cli/tests/json_contract.rs
@@ -959,14 +959,17 @@ fn diff_output_validates() {
         release: "acme-bot".to_string(),
         release_exists: true,
         entries: curie::installation::diff_plan(
-            &std::collections::BTreeMap::from([("ui.deploy".to_string(), "false".to_string())]),
+            &std::collections::BTreeMap::from([
+                ("inference.deploy".to_string(), "true".to_string()),
+                ("ui.deploy".to_string(), "false".to_string()),
+                ("worker.replicas".to_string(), "2".to_string()),
+            ]),
             Some(&serde_json::json!({
                 "ui": {"deploy": true},
                 "dispatcher": {"slack": {"botToken": "xoxb-live"}},
                 "inference": {"deploy": true},
                 "agentSandbox": {"runner": {"fakeModel": false}},
             })),
-            &|k| k == "agentSandbox.runner.fakeModel",
         ),
     };
     let json = out.to_json();
@@ -981,10 +984,11 @@ fn diff_output_validates() {
         .map(|e| e["kind"].as_str().expect("kind is a string"))
         .collect();
     for expected in [
+        "add",
         "change",
+        "unchanged",
         "preserved",
         "reset to chart default",
-        "managed by this file",
     ] {
         assert!(
             kinds.contains(&expected),


### PR DESCRIPTION
Closes #1313

Unifies apply and diff around a typed installation plan.
Makes desired values concrete for credentials, egress, exposed services, and runner model selection.
Adds binary parity coverage for normal, egress, reset, clear, and conflict paths.