### PR TITLE
Add Discord community link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ it.
 
 New here? [`Quickstart`](#quickstart) gets you a first agent reply in a few minutes.
 
+Join the [Curie Discord community](https://discord.gg/YZASub2d5B) to connect with other builders.
+
 ## Why your agent breaks when it leaves your laptop
 
 Local and production environments are usually different - a different Python version, a missing tool,


### PR DESCRIPTION
Adds the permanent Discord community link to the README so contributors can find the Curie community.