### PR TITLE
`curie apply` refuses to delete a stateful component

### DIFF
--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -3788,6 +3788,18 @@ export const commandManifest = {
           "long": "chart",
           "positional": false,
           "required": false
+        },
+        {
+          "global": false,
+          "help": "Proceed even when the upgrade would DELETE a stateful component the release is running, losing its data. Refused by default: a chart that renames a store (minio -> rustfs in 0.6.0) drops the old one, and every sandbox reads the bundle store at start, so the next turn fails rather than merely a rollback",
+          "id": "allow_stateful_removal",
+          "long": "allow-stateful-removal",
+          "positional": false,
+          "possible_values": [
+            "true",
+            "false"
+          ],
+          "required": false
         }
       ],
       "hidden": false,

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -3785,6 +3785,18 @@
           "long": "chart",
           "positional": false,
           "required": false
+        },
+        {
+          "global": false,
+          "help": "Proceed even when the upgrade would DELETE a stateful component the release is running, losing its data. Refused by default: a chart that renames a store (minio -> rustfs in 0.6.0) drops the old one, and every sandbox reads the bundle store at start, so the next turn fails rather than merely a rollback",
+          "id": "allow_stateful_removal",
+          "long": "allow-stateful-removal",
+          "positional": false,
+          "possible_values": [
+            "true",
+            "false"
+          ],
+          "required": false
         }
       ],
       "hidden": false,

--- a/cli/src/installation.rs
+++ b/cli/src/installation.rs
@@ -556,6 +556,9 @@ impl crate::ui::CliOutput for ApplyOutput {
 pub struct ApplyOpts {
     pub local: LocalInstallationPlan,
     pub chart: String,
+    /// Proceed even when the upgrade would delete a stateful component. The
+    /// operator asserting the data is migrated, or expendable.
+    pub allow_stateful_removal: bool,
 }
 
 pub struct LocalInstallationPlan {
@@ -685,6 +688,43 @@ async fn complete_installation_plan(
     })
 }
 
+/// Refuse an apply that would delete a stateful component the release runs.
+///
+/// Runs even under `--dry-run`: the plan a dry run prints is exactly the plan
+/// that would destroy the store, so an operator reading it deserves the same
+/// warning the real run would give.
+async fn guard_stateful_removal(up: &crate::ops::UpOpts) -> Result<()> {
+    let live = crate::ops::live_statefulsets(&up.common).await?;
+    if live.is_empty() {
+        // Fresh install, or no cluster to read. Nothing to lose either way.
+        return Ok(());
+    }
+    // The same effective values the upgrade would send, so the render reflects
+    // what this apply would actually create rather than the chart's defaults.
+    let sets: Vec<String> = crate::ops::up_value_plan(up)
+        .effective_values()
+        .into_iter()
+        .map(|(k, v)| format!("{k}={v}"))
+        .collect();
+    let rendered = crate::ops::chart_statefulsets(&up.chart, &up.common, &sets).await?;
+    let removed = crate::ops::removed_stateful_components(&live, &rendered);
+    if removed.is_empty() {
+        return Ok(());
+    }
+    bail!(
+        "refusing to apply: this would DELETE {} stateful component(s) the release is \
+         running, and the persistent data with them:\n  {}\n\n\
+         The target chart does not render them, which usually means a chart version \
+         renamed or removed the component. Migrate the data first -- for the bundle \
+         store, every sandbox reads from it at start, so losing it breaks the next turn \
+         and not merely a rollback.\n\n\
+         Re-run with --allow-stateful-removal once the data is migrated or you accept \
+         losing it.",
+        removed.len(),
+        removed.join("\n  "),
+    )
+}
+
 /// Converge the cluster to the file.
 ///
 /// The ordering -- platform install, THEN comms -- is handled here rather than
@@ -693,7 +733,11 @@ async fn complete_installation_plan(
 /// only as a sentence in a runbook, which is exactly what ADR-0097 set out to
 /// fix: the interface could not express it, so prose had to.
 pub async fn apply(opts: ApplyOpts) -> Result<ApplyOutput> {
-    let ApplyOpts { mut local, chart } = opts;
+    let ApplyOpts {
+        mut local,
+        chart,
+        allow_stateful_removal,
+    } = opts;
     local.up.chart = chart;
     let dry_run = local.up.common.dry_run;
     let plan = complete_installation_plan(local).await?;
@@ -706,6 +750,21 @@ pub async fn apply(opts: ApplyOpts) -> Result<ApplyOutput> {
         live,
         ..
     } = plan;
+
+    // Refuse before the first mutation, not after.
+    //
+    // `up` does a FULL upgrade, so a component the target chart no longer
+    // renders is DELETED -- and for a StatefulSet that is the data with it.
+    // This is not hypothetical: chart 0.6.0 renamed the object store from
+    // `minio` to `rustfs`, and applying it to a 0.5.1 release would remove the
+    // store every sandbox's bundle-fetch init container reads from. The next
+    // Slack message would fail, not merely a rollback.
+    //
+    // `curie diff` learned to warn about the chart mismatch; `apply` had no
+    // guard at all and would have gone ahead silently.
+    if !allow_stateful_removal {
+        guard_stateful_removal(&up).await?;
+    }
     let up_out = crate::ops::up_prepared(up, up_values, live, github_token).await?;
 
     let mut lines = match up_out {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -403,6 +403,13 @@ enum Command {
         /// Chart reference override, as `cluster up` takes.
         #[arg(long)]
         chart: Option<String>,
+        /// Proceed even when the upgrade would DELETE a stateful component the
+        /// release is running, losing its data. Refused by default: a chart
+        /// that renames a store (minio -> rustfs in 0.6.0) drops the old one,
+        /// and every sandbox reads the bundle store at start, so the next turn
+        /// fails rather than merely a rollback.
+        #[arg(long)]
+        allow_stateful_removal: bool,
     },
 
     /// Show what `curie apply` would change about the live release (ADR-0097).
@@ -3067,6 +3074,7 @@ async fn run(command: Option<Command>) -> Result<()> {
             file,
             dry_run,
             chart,
+            allow_stateful_removal,
         }) => {
             let cfg = curie::installation::Installation::load(&file)?;
             let local = curie::installation::plan_installation(cfg, dry_run)?;
@@ -3078,7 +3086,14 @@ async fn run(command: Option<Command>) -> Result<()> {
                 std::path::Path::new("charts/curie").is_dir(),
             )?;
             let chart = materialize_artifact(resolved, dry_run, "chart").await?;
-            emit(curie::installation::apply(curie::installation::ApplyOpts { local, chart }).await?)
+            emit(
+                curie::installation::apply(curie::installation::ApplyOpts {
+                    local,
+                    chart,
+                    allow_stateful_removal,
+                })
+                .await?,
+            )
         }
         Some(Command::Diff { file }) => {
             let cfg = curie::installation::Installation::load(&file)?;

--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -1182,6 +1182,192 @@ pub async fn fetch_release_chart(o: &CommonOpts) -> Result<Option<String>> {
         .map(str::to_string))
 }
 
+/// StatefulSet names the release currently owns.
+///
+/// StatefulSets specifically, not every workload: they are the ones carrying a
+/// PersistentVolumeClaim, so they are the ones whose disappearance loses data
+/// rather than merely restarting a process.
+pub async fn live_statefulsets(o: &CommonOpts) -> Result<Vec<String>> {
+    let cmd = OpsCommand::new(
+        "kubectl",
+        vec![
+            plain("get"),
+            plain("statefulset"),
+            plain("-n"),
+            plain(&o.namespace),
+            plain("-o"),
+            plain("json"),
+        ],
+    );
+    let (ok, out, _err) = run_capture(&cmd).await?;
+    if !ok {
+        return Ok(Vec::new());
+    }
+    let parsed: serde_json::Value = match serde_json::from_str(out.trim()) {
+        Ok(v) => v,
+        Err(_) => return Ok(Vec::new()),
+    };
+    let prefix = format!("{}-", o.release);
+    Ok(parsed
+        .get("items")
+        .and_then(|i| i.as_array())
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|i| {
+                    i.get("metadata")
+                        .and_then(|m| m.get("name"))
+                        .and_then(|n| n.as_str())
+                })
+                .filter(|name| name.starts_with(&prefix))
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default())
+}
+
+/// StatefulSet names the target chart would render for this release.
+///
+/// `helm template` rather than a dry-run upgrade: it needs no cluster and
+/// cannot mutate, so the guard is safe to run before deciding whether to
+/// proceed.
+pub async fn chart_statefulsets(
+    chart: &str,
+    o: &CommonOpts,
+    value_sets: &[String],
+) -> Result<Vec<String>> {
+    let mut args = vec![
+        plain("template"),
+        plain(&o.release),
+        plain(chart),
+        plain("-n"),
+        plain(&o.namespace),
+    ];
+    for entry in value_sets {
+        args.push(plain("--set"));
+        args.push(plain(entry));
+    }
+    let (ok, out, err) = run_capture(&OpsCommand::new("helm", args)).await?;
+    if !ok {
+        bail!("could not render the target chart to check for removed stateful components: {err}");
+    }
+    Ok(parse_statefulset_names(&out))
+}
+
+/// StatefulSet names in a multi-document helm render.
+///
+/// Split-and-parse rather than a regex: a `kind: StatefulSet` line can appear
+/// inside an annotation or a ConfigMap payload, and matching that would invent
+/// a component the chart does not actually create.
+pub fn parse_statefulset_names(rendered: &str) -> Vec<String> {
+    let mut names = Vec::new();
+    for doc in rendered.split("\n---") {
+        let Ok(value) = serde_norway::from_str::<serde_json::Value>(doc) else {
+            continue;
+        };
+        if value.get("kind").and_then(|k| k.as_str()) != Some("StatefulSet") {
+            continue;
+        }
+        if let Some(name) = value
+            .get("metadata")
+            .and_then(|m| m.get("name"))
+            .and_then(|n| n.as_str())
+        {
+            if !names.iter().any(|n: &String| n == name) {
+                names.push(name.to_string());
+            }
+        }
+    }
+    names
+}
+
+/// Live stateful components the target chart would not recreate.
+///
+/// Pure, so the decision this guard turns on is testable without a cluster.
+pub fn removed_stateful_components(live: &[String], rendered: &[String]) -> Vec<String> {
+    live.iter()
+        .filter(|name| !rendered.iter().any(|r| r == *name))
+        .cloned()
+        .collect()
+}
+
+#[cfg(test)]
+mod stateful_guard_tests {
+    use super::*;
+
+    /// A helm render is multi-document, and the guard has to read it as one.
+    #[test]
+    fn statefulset_names_come_from_the_render() {
+        let rendered = "\
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: sre-bot-rustfs
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sre-bot-rustfs
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: sre-bot-postgres
+";
+        let names = parse_statefulset_names(rendered);
+        assert_eq!(names, vec!["sre-bot-rustfs", "sre-bot-postgres"]);
+    }
+
+    /// `kind: StatefulSet` inside a ConfigMap payload is data, not a component.
+    /// A regex over the render would invent one; parsing cannot.
+    #[test]
+    fn a_kind_line_inside_another_document_is_not_a_component() {
+        let rendered = "\
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sre-bot-docs
+data:
+  example: |
+    kind: StatefulSet
+    metadata:
+      name: not-a-real-component
+";
+        assert!(parse_statefulset_names(rendered).is_empty());
+    }
+
+    /// The exact shape that would have destroyed the bundle store: the release
+    /// runs minio, the target chart renders rustfs, so minio is a removal.
+    #[test]
+    fn a_renamed_store_is_reported_as_a_removal() {
+        let live = vec!["sre-bot-minio".to_string(), "sre-bot-postgres".to_string()];
+        let rendered = vec!["sre-bot-rustfs".to_string(), "sre-bot-postgres".to_string()];
+        assert_eq!(
+            removed_stateful_components(&live, &rendered),
+            vec!["sre-bot-minio"]
+        );
+    }
+
+    /// The guard must stay quiet on an ordinary upgrade, or it becomes a flag
+    /// everyone passes by reflex and protects nothing.
+    #[test]
+    fn an_unchanged_component_set_is_not_a_removal() {
+        let same = vec!["sre-bot-postgres".to_string(), "sre-bot-minio".to_string()];
+        assert!(removed_stateful_components(&same, &same).is_empty());
+    }
+
+    /// A chart ADDING a store is not a removal.
+    #[test]
+    fn a_new_component_is_not_a_removal() {
+        let live = vec!["sre-bot-postgres".to_string()];
+        let rendered = vec![
+            "sre-bot-postgres".to_string(),
+            "sre-bot-clickhouse".to_string(),
+        ];
+        assert!(removed_stateful_components(&live, &rendered).is_empty());
+    }
+}
+
 /// The user-supplied values helm recorded for a release, or `None` when the
 /// release does not exist. The read-only half of [`fetch_existing_values`],
 /// exposed for `curie diff`.


### PR DESCRIPTION
`curie diff` learned to warn when the deployed chart differs from the one the CLI would apply (#1306). **`apply` itself had no guard and would have gone ahead.**

## The case is live, not hypothetical

sre-bot runs chart **0.5.1**, whose object store is `minio`. Chart **0.6.0** renamed it to `rustfs` and renders no minio at all. `up` does a *full* upgrade, so applying would **delete the running StatefulSet**.

And that store is not incidental: every sandbox pod has a **`bundle-fetch` init container**, and a sandbox is created **per Slack thread**. Every `bundle_ref` in Postgres points into that store. So the failure isn't a broken rollback — **the next Slack message fails.**

## The guard

`apply` now reads the release's StatefulSets, renders the target chart with the *same effective values the upgrade would send*, and refuses when a live one is absent from the render:

```
refusing to apply: this would DELETE 1 stateful component(s) the release is
running, and the persistent data with them:
  sre-bot-minio
...
Re-run with --allow-stateful-removal once the data is migrated or you accept losing it.
```

Three deliberate choices:

- **StatefulSets specifically**, not every workload. They carry the PVCs, so they're the ones whose removal loses data rather than restarting a process. Guarding everything would make the flag reflexive and protect nothing.
- **Runs under `--dry-run` too.** The plan a dry run prints is exactly the plan that would destroy the store, so the reader deserves the same refusal.
- **Parses the render; does not grep it.** `kind: StatefulSet` appears inside ConfigMap payloads, and matching that would invent a component the chart never creates. There's a test for exactly that.

## Verification

Five unit tests on the pure decision — the rename case, an unchanged set, an added component, multi-doc parsing, and the ConfigMap false positive.

**Falsified:** stubbing the removal comparison to return nothing fails `a_renamed_store_is_reported_as_a_removal`.

`fmt`, `clippy --all-targets -D warnings`, 38 suites green, command manifest regenerated.

## What is *not* verified

**This has not run against the live cluster.** I built the linux binary and was staging it when the AWS session expired. The pure decision is covered; the `kubectl get statefulset` and `helm template` reads around it are not.

Given that every real bug this session came from running against the actual cluster rather than from tests, I'd treat that as a genuine gap — the guard is worth landing regardless, since today `apply` has no protection at all, but it deserves a live run before anyone trusts it.