### PR TITLE
Stop ClickHouse starving the sandboxes it observes

### DIFF
--- a/apps/worker/src/curie_worker/sandbox/substrate.py
+++ b/apps/worker/src/curie_worker/sandbox/substrate.py
@@ -267,8 +267,26 @@ class SandboxSubstrate:
             if claim is not None and claim.ready and claim.sandbox_name:
                 return claim.sandbox_name
             time.sleep(self._config.poll_interval_seconds)
+        # Name the likeliest cause and where to look. This message is the only
+        # thread an operator has: the turn surfaces to the user as an opaque
+        # `runner-error`, and the shape that produces it most often -- a
+        # CPU-starved node -- sets NO node condition, so pods read Running,
+        # probes green, disk fine, and every dashboard says healthy.
+        #
+        # Seen in production: a Langfuse/ClickHouse merge burst took a 2-vCPU
+        # node to 0.0% idle. The sandbox pod was created and its bundle-fetch
+        # init container started, but nothing finished inside the deadline, so
+        # all three attempts timed out identically with nothing to go on.
         raise ClaimTimeoutError(
-            f"claim {claim_name} not bound within {self._config.claim_timeout_seconds}s"
+            f"claim {claim_name} not bound within {self._config.claim_timeout_seconds}s. "
+            "The sandbox pod was created but did not become ready in time. The most "
+            "common cause is a CPU-saturated node -- which reports no node condition, "
+            "so pods still look Running and probes still pass. Check `top`/`kubectl top "
+            "node` for idle CPU (not just node conditions), and whether a component "
+            "whose CPU LIMIT approaches the node's capacity is bursting; under "
+            "contention the kernel divides CPU by requests, and bundle-fetch and the "
+            "runner request only 50m each. Other causes: the agent-sandbox controller "
+            "not reconciling, or an unfetchable bundle ref."
         )
 
     def _await_service_fqdn(self, sandbox_name: str, deadline: float) -> SandboxView:

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -286,9 +286,26 @@ clickhouse:
   persistence:
     enabled: true
     size: 3Gi
+  # The CPU limit deliberately leaves headroom rather than matching a node.
+  #
+  # This was `cpu: "2"`, and on a 2-vCPU node that is the WHOLE machine. A
+  # Langfuse merge burst then took ~175% CPU with 0.0% idle, and every new
+  # sandbox pod -- one per Slack thread, on a hard 90s claim-bind deadline --
+  # missed it. Three attempts timed out and the turn escalated to a human as an
+  # opaque `runner-error`. Nothing flagged it: CPU starvation sets no node
+  # condition, so pods were Running, probes green, disk fine.
+  #
+  # ClickHouse serves Langfuse (observability). It must not be able to starve
+  # the product it is observing. Raise this on a node with cores to spare.
+  #
+  # Note the asymmetry that makes a generous limit dangerous here: under
+  # contention the kernel divides CPU in proportion to REQUESTS, not limits, and
+  # the critical-path containers (bundle-fetch, runner) request 50m each. A
+  # limit is a ceiling, never a guarantee -- so a component that requests little
+  # and may burst to everything is exactly the shape that starves a deadline.
   resources:
     requests: { cpu: 200m, memory: 512Mi }
-    limits: { cpu: "2", memory: 1536Mi }
+    limits: { cpu: "1", memory: 1536Mi }
   # Container securityContext (issue #67). Safe subset only -- the ClickHouse
   # image entrypoint starts as root to own /var/lib/clickhouse and drops to the
   # `clickhouse` user, so runAsNonRoot / capabilities.drop are left unset. See


### PR DESCRIPTION
Live incident. sre-bot answered three Slack turns with *"The run failed (runner-error) after 3 attempt(s). Flagging for a human."*

## Root cause

```
clickhouse.resources.limits.cpu: "2"     ← on a 2-vCPU node
```

A Langfuse merge burst (4 concurrent merges) took ClickHouse to **~175% CPU, 0.0% idle, load average 6.2**. A sandbox pod is created per Slack thread against a hard **90s claim-bind deadline**; starved, it never got there.

The worker log is unambiguous:

```
turn start failed: ClaimTimeoutError('claim curie-thread-873096ea22-87e915 not bound within 90.0s')
turn start failed: ClaimTimeoutError('claim curie-thread-873096ea22-4bb9c2 not bound within 90.0s')
turn start failed: ClaimTimeoutError('claim curie-thread-873096ea22-a6551c not bound within 90.0s')
escalating event Ev0BN98BH290: The run failed (runner-error) after 3 attempt(s).
```

And the failing pod's events show exactly how far it got: `minio/mc` pulled, `bundle-fetch` killed, **no runner image pull at all**.

## Why nothing caught it

**CPU starvation sets no node condition.** Every surface an operator checks said healthy:

| check | reading |
|---|---|
| pods | all Running |
| deployments | 1/1 |
| readiness probes | green |
| disk | 66% |
| MemoryPressure / DiskPressure / PIDPressure | all False |
| sandbox controller | up 7d, 0 restarts |

## The fix

ClickHouse serves Langfuse, which *observes* the product. It must not be able to starve it. **Capped to 1 CPU**, leaving half the node.

Plus the blindness: `ClaimTimeoutError` said only `claim X not bound within 90.0s` — the one thread an operator has, naming none of this. It now names CPU saturation as the likeliest cause, states that it sets no node condition so the usual checks will look fine, and points at idle CPU and the requests/limits asymmetry.

That asymmetry is the part worth writing down: **under contention the kernel divides CPU in proportion to requests**, and `bundle-fetch` and the runner request 50m each. A limit is a ceiling, never a guarantee — so a component that requests little and may burst to the whole node is exactly the shape that starves a deadline.

## Verified on the cluster

| | before | after |
|---|---|---|
| idle CPU | **0.0%** | **38–53%** |
| claim timeouts | 3/3 attempts | **0 since** |
| sandbox created → Ready | timed out at 90s | 20s |

The running release was patched directly with `kubectl patch` rather than helm: it is on chart **0.5.1**, and a helm upgrade there would delete MinIO (#1321). This PR changes the default so that patch isn't silently reverted by the next upgrade.

## Not in scope

The node is undersized for platform + ClickHouse + per-thread sandboxes (requests already 74% allocated, limits **440% overcommitted**). Moving Langfuse/ClickHouse off-box via the chart's BYO idiom, or a bigger instance, is the structural answer — this PR only stops the observability stack from being *able* to take the whole machine.