### PR TITLE
Use placeholder values in the installation fixtures

### DIFF
--- a/cli/src/installation.rs
+++ b/cli/src/installation.rs
@@ -1112,7 +1112,7 @@ mod diff_tests {
     }
 
     /// The classification tests below run against the REAL key set of the
-    /// sre-bot release (`helm get values`, key names only -- no values were
+    /// adopting agent's release (`helm get values`, key names only -- no values were
     /// read). A fixture I invented would have agreed with whatever I wrote;
     /// this one disagreed, and that is how the `Managed` bug was found.
     const LIVE_KEYS: &[&str] = &[
@@ -1354,7 +1354,7 @@ mod diff_tests {
             &declared,
             Some(&live(serde_json::json!({
                 "dispatcher": {"slack": {"appToken": "xapp-x", "botToken": "xoxb-y"}},
-                "api": {"githubAppId": "4475970", "apiKey": "generated"},
+                "api": {"githubAppId": "000000", "apiKey": "generated"},
                 "postgres": {"auth": {"password": "generated"}},
             }))),
         );
@@ -1424,12 +1424,13 @@ mod diff_tests {
     /// store to `rustfs`, so the live key matched no managed list. The store
     /// was still running.
     ///
-    /// The value here is a real-shaped random hex string rather than a token
-    /// the assertion could trivially find, because the original test's
-    /// "no secret in output" check passed against a plaintext it chose itself.
+    /// The value is a PLACEHOLDER of the same shape as a generated secret. It
+    /// must never be a real one: this repository is public, and a fixture is
+    /// exactly where a live credential gets committed by accident (it did --
+    /// see AGENTS.md on placeholder values).
     #[test]
     fn a_credential_key_no_managed_list_knows_is_still_masked() {
-        let leaked = "395f633e7f72be60b36cb19ced9d0889b1d55ede40c78893";
+        let leaked = "000000000000000000000000000000000000000000000000";
         let entries = diff_plan(
             &BTreeMap::new(),
             Some(&live(serde_json::json!({
@@ -1486,8 +1487,8 @@ mod diff_tests {
     #[test]
     fn a_chart_version_mismatch_is_reported() {
         let out = DiffOutput {
-            namespace: "sre-bot".into(),
-            release: "sre-bot".into(),
+            namespace: "acme-bot".into(),
+            release: "acme-bot".into(),
             release_exists: true,
             chart_deployed: Some("curie-0.5.1".into()),
             chart_target: "0.6.0".into(),
@@ -1504,8 +1505,8 @@ mod diff_tests {
     #[test]
     fn a_matching_chart_version_does_not_warn() {
         let out = DiffOutput {
-            namespace: "sre-bot".into(),
-            release: "sre-bot".into(),
+            namespace: "acme-bot".into(),
+            release: "acme-bot".into(),
             release_exists: true,
             chart_deployed: Some("curie-0.6.0".into()),
             chart_target: "0.6.0".into(),
@@ -1518,8 +1519,8 @@ mod diff_tests {
     #[test]
     fn an_unknown_deployed_chart_does_not_claim_a_mismatch() {
         let out = DiffOutput {
-            namespace: "sre-bot".into(),
-            release: "sre-bot".into(),
+            namespace: "acme-bot".into(),
+            release: "acme-bot".into(),
             release_exists: false,
             chart_deployed: None,
             chart_target: "0.6.0".into(),

--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -1348,8 +1348,8 @@ mod stateful_guard_tests {
     fn components_come_from_the_render() {
         let rendered = format!(
             "{}\n---\n{}",
-            render("rustfs", "sre-bot-curie-rustfs"),
-            render("postgres", "sre-bot-curie-postgres")
+            render("rustfs", "acme-bot-curie-rustfs"),
+            render("postgres", "acme-bot-curie-postgres")
         );
         assert_eq!(
             parse_statefulset_components(&rendered),
@@ -1365,7 +1365,7 @@ mod stateful_guard_tests {
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: sre-bot-docs
+  name: acme-bot-docs
 data:
   example: |
     kind: StatefulSet
@@ -1379,31 +1379,32 @@ data:
     #[test]
     fn a_renamed_store_is_reported_as_a_removal() {
         let live = vec![
-            ("minio".to_string(), "sre-bot-minio".to_string()),
-            ("postgres".to_string(), "sre-bot-postgres".to_string()),
+            ("minio".to_string(), "acme-bot-minio".to_string()),
+            ("postgres".to_string(), "acme-bot-postgres".to_string()),
         ];
         let rendered = vec!["rustfs".to_string(), "postgres".to_string()];
         assert_eq!(
             removed_stateful_components(&live, &rendered),
-            vec!["sre-bot-minio"],
+            vec!["acme-bot-minio"],
             "only the renamed store is lost, and it is named as the operator sees it"
         );
     }
 
     /// The false positive that a live run exposed, pinned so it cannot return.
     ///
-    /// This release was installed with `nameOverride=sre-bot`, so every resource
-    /// is `sre-bot-<component>` while the chart renders `sre-bot-curie-<component>`.
+    /// The release was installed with a `nameOverride`, so every resource is
+    /// `<override>-<component>` while the chart renders
+    /// `<override>-curie-<component>`.
     /// Comparing NAMES reported all four as removals -- postgres, valkey and
     /// clickhouse included -- which would have taught the operator to pass
     /// --allow-stateful-removal by reflex and lose minio for real.
     #[test]
     fn a_name_override_does_not_make_every_component_look_removed() {
         let live = vec![
-            ("clickhouse".to_string(), "sre-bot-clickhouse".to_string()),
-            ("minio".to_string(), "sre-bot-minio".to_string()),
-            ("postgres".to_string(), "sre-bot-postgres".to_string()),
-            ("valkey".to_string(), "sre-bot-valkey".to_string()),
+            ("clickhouse".to_string(), "acme-bot-clickhouse".to_string()),
+            ("minio".to_string(), "acme-bot-minio".to_string()),
+            ("postgres".to_string(), "acme-bot-postgres".to_string()),
+            ("valkey".to_string(), "acme-bot-valkey".to_string()),
         ];
         // What the chart renders WITHOUT the override: different names entirely.
         let rendered = vec![
@@ -1414,7 +1415,7 @@ data:
         ];
         assert_eq!(
             removed_stateful_components(&live, &rendered),
-            vec!["sre-bot-minio"],
+            vec!["acme-bot-minio"],
             "differing resource names must not be mistaken for removed components"
         );
     }
@@ -1427,20 +1428,20 @@ data:
         let list = serde_json::json!({"items": [
             {
                 "metadata": {
-                    "name": "sre-bot-minio",
+                    "name": "acme-bot-minio",
                     "annotations": {"helm.sh/resource-policy": "keep"}
                 },
                 "spec": {"selector": {"matchLabels": {"app.kubernetes.io/component": "minio"}}}
             },
             {
-                "metadata": {"name": "sre-bot-postgres"},
+                "metadata": {"name": "acme-bot-postgres"},
                 "spec": {"selector": {"matchLabels": {"app.kubernetes.io/component": "postgres"}}}
             }
         ]});
         let at_risk = stateful_components_from_list(&list);
         assert_eq!(
             at_risk,
-            vec![("postgres".to_string(), "sre-bot-postgres".to_string())],
+            vec![("postgres".to_string(), "acme-bot-postgres".to_string())],
             "a component annotated keep is not at risk and must not be listed"
         );
     }
@@ -1451,13 +1452,13 @@ data:
     fn an_unannotated_component_is_still_at_risk() {
         let list = serde_json::json!({"items": [
             {
-                "metadata": {"name": "sre-bot-minio"},
+                "metadata": {"name": "acme-bot-minio"},
                 "spec": {"selector": {"matchLabels": {"app.kubernetes.io/component": "minio"}}}
             }
         ]});
         assert_eq!(
             stateful_components_from_list(&list),
-            vec![("minio".to_string(), "sre-bot-minio".to_string())]
+            vec![("minio".to_string(), "acme-bot-minio".to_string())]
         );
     }
 


### PR DESCRIPTION
## A live credential is in this public repository

`AGENTS.md` requires placeholder values in docs, ADRs, tests and fixtures. The fixtures I added for `curie apply` / `curie diff` broke that rule three ways:

| what | where |
|---|---|
| A downstream agent's name, 25 times | namespaces, releases, rendered resource names |
| A real GitHub App id | a `diff` fixture |
| **A real generated store password** | the masking test |

The third is the serious one. It was used as the "leaked value" in **the very test that exists to prove credentials never reach the output** — and the comment above it claimed the value was synthetic. It wasn't. I read it off a live release minutes earlier.

All three are now placeholders: `acme-bot` per the AGENTS.md convention, a zeroed app id, and a zeroed secret of the same shape.

## This does not undo the disclosure

**Replacing the value here does not remove it from history.** It is in commit `9b0bc37`, merged to `main`, in a public repository. `git log -S` finds it today.

Two consequences, both the maintainer's call and neither mine to make:

1. **The credential should be rotated.** It was previously only in an SSM invocation and a session transcript, where "leave it" was reasonable. A public git history is a different exposure.
2. **Purging it from history** means rewriting public `main` — invalidating every fork and clone. Usually not worth it once rotation has happened, but it should be a decision rather than a default.

## Why it happened

The masking test asserts a secret does *not* appear in the output. To make that assertion meaningful I wanted a realistic value — and reached for the real one I had just seen, which is precisely the reflex AGENTS.md's placeholder rule exists to stop. The comment now says so plainly, so the next person reading that fixture sees why it must stay synthetic.

`fmt`, `clippy --all-targets -D warnings`, 38 suites green. No behaviour change — fixtures and comments only.