### PR TITLE
Accept ADR-0094

### DIFF
--- a/docs/adr/0094-a-bundle-carries-its-own-sealed-connector-keys.md
+++ b/docs/adr/0094-a-bundle-carries-its-own-sealed-connector-keys.md
@@ -2,7 +2,7 @@
 
 Date: 2026-08-04
 
-Status: Draft
+Status: Accepted
 
 ## Context
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -122,7 +122,7 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0091 | [Git-flow resolves deploy targets, so one repo serves many agents](0091-git-flow-resolves-deploy-targets-so-one-repo-serves-many-agents.md) | Accepted |
 | 0092 | [A GitHub App gives the platform its own repository identity](0092-a-github-app-gives-the-platform-its-own-repository-identity.md) | Accepted |
 | 0093 | [Local-model assets are pre-provisioned, never implicitly downloaded](0093-local-model-assets-are-pre-provisioned-never-implicitly-downloaded.md) | Draft |
-| 0094 | [A bundle carries its own sealed connector keys](0094-a-bundle-carries-its-own-sealed-connector-keys.md) | Draft |
+| 0094 | [A bundle carries its own sealed connector keys](0094-a-bundle-carries-its-own-sealed-connector-keys.md) | Accepted |
 | 0097 | [One file declares an installation](0097-one-file-declares-an-installation.md) | Accepted |
 | 0098 | [Thinking depth is an operator knob, never a bundle one](0098-thinking-depth-is-an-operator-knob-never-a-bundle-one.md) | Accepted |
 <!-- END GENERATED: adr-index -->


### PR DESCRIPTION
Maintainer approval given for [ADR-0094: A bundle carries its own sealed connector keys](docs/adr/0094-a-bundle-carries-its-own-sealed-connector-keys.md). Only the status line changes, per [ADR-0045](docs/adr/0045-the-status-line-is-the-mutable-part-of-an-immutable-adr.md).

## Implementation order

`sealed_secrets` is a new field on `ConnectorSpec` in `packages/plugin-format` — a **frozen contract**. AGENTS.md requires that to land as its own reviewed, backward-compatible change before anything depends on it, so the work stages as:

1. **The contract** — schema, generated TypeScript and Rust, and the CLI's mirror declaration, moving together so the lanes cannot drift. Additive and optional, so no existing bundle is affected.
2. **The keypair** — generated at install, private half never leaving the cluster, public half published so authors can seal against it.
3. **`curie seal`** — so nobody hand-rolls the format.
4. **The reconciler's decrypt step** — including the fail-loud behaviour the ADR insists on: a blob that will not decrypt skips that agent and leaves the running connector alone, rather than deploying a connector that starts healthy and 401s every call.

## The constraint that came with acceptance

The ADR names its own weakest point and I want it visible here rather than buried:

> rotating it invalidates every blob every agent repository has committed, and each must be resealed and pushed. This ADR does not solve that. It is the strongest argument against the whole approach and the thing to get right in the implementation — at minimum, support two active keys so a rotation can overlap, and make `curie seal` able to reseal a repository in one command.

Two active keys and one-command reseal are part of what was accepted, not optional polish. Also inherited: losing the private key loses every credential sealed to it, and nothing outside the cluster can reconstruct it — so the install has to say so, and the key belongs in whatever the operator already uses for durable secrets (`existingSecret`).

`bash scripts/check-docs.sh` passes; `docs/adr/README.md` regenerated, not hand-edited.