### PR TITLE
Add sealed_secrets to the connector contract

### DIFF
--- a/packages/plugin-format/src/plugin_format/connectors.py
+++ b/packages/plugin-format/src/plugin_format/connectors.py
@@ -116,10 +116,33 @@ class ConnectorSpec(BaseModel):
     # Secret that already exists.
     secrets: list[str | SecretRef] = Field(default_factory=list)
 
-    def secret_names(self) -> list[str]:
-        """Env var names this connector needs, either form."""
+    #   sealed_secrets:                       The bundle CARRIES the credential,
+    #     TOKEN: AgBv3n2K...                  encrypted to the cluster that will
+    #                                         run it (ADR-0094).
+    #
+    # A third holder for the same question. The blob is useless without the
+    # cluster's private key, so it can live in the repository -- public or
+    # private -- beside the connector that reads it, and an agent repo becomes
+    # self-contained: clone it, point a cluster at it, tools work.
+    #
+    # Keyed by the env var name so it reads like `env` and cannot express two
+    # blobs for one variable. Additive and optional: a bundle that does not use
+    # it is unaffected, which is what lets this land as a backward-compatible
+    # change to a frozen contract.
+    #
+    # NOTHING DECRYPTS THIS YET. The field is the contract; the keypair,
+    # `curie seal`, and the reconciler's decrypt step follow separately. Until
+    # they land, `validate_connectors` REFUSES a bundle that declares one rather
+    # than accepting it and quietly starting a connector with no credential --
+    # a pod that passes its health check and 401s every call is the #1156
+    # failure shape ADR-0094 exists to avoid.
+    sealed_secrets: dict[str, str] = Field(default_factory=dict)
 
-        return [s if isinstance(s, str) else s.name for s in self.secrets]
+    def secret_names(self) -> list[str]:
+        """Env var names this connector needs, any form."""
+
+        named = [s if isinstance(s, str) else s.name for s in self.secrets]
+        return named + list(self.sealed_secrets)
 
     def resolved_secrets(self) -> list[str]:
         """Only the names Curie must resolve a VALUE for.
@@ -292,6 +315,34 @@ def validate_connectors(data: Any) -> tuple[ConnectorsFile | None, list[tuple[st
                         "API server rejects at apply -- long after the deploy looked fine.",
                     )
                 )
+        for env_name, blob in spec.sealed_secrets.items():
+            if not env_name.strip():
+                errors.append(
+                    (
+                        "connectors.empty_sealed_name",
+                        f"{where}: a `sealed_secrets` entry has an empty env var name.",
+                    )
+                )
+            if not blob.strip():
+                errors.append(
+                    (
+                        "connectors.empty_sealed_value",
+                        f"{where}: `{env_name}` has an empty sealed value. An empty blob "
+                        "cannot decrypt to anything, so the connector would start without "
+                        "the credential it needs.",
+                    )
+                )
+        if spec.sealed_secrets:
+            errors.append(
+                (
+                    "connectors.sealed_secrets_unsupported",
+                    f"{where}: `sealed_secrets` is declared but nothing decrypts it yet "
+                    "(ADR-0094 is accepted; the keypair, `curie seal`, and the "
+                    "reconciler's decrypt step are still landing). Refusing rather than "
+                    "ignoring it: a connector deployed without its credential starts "
+                    "healthy and fails every call. Use `secrets:` until then.",
+                )
+            )
         seen_secret_names: set[str] = set()
         for secret_name in spec.secret_names():
             if secret_name in seen_secret_names:

--- a/packages/plugin-format/tests/test_connector_render.py
+++ b/packages/plugin-format/tests/test_connector_render.py
@@ -14,7 +14,7 @@ from pathlib import Path
 import pytest
 import yaml
 from plugin_format import connector_render as r
-from plugin_format.connectors import ConnectorSpec
+from plugin_format.connectors import ConnectorSpec, validate_connectors
 
 HOSTED = ConnectorSpec(
     image="grafana/mcp-grafana:0.17.2",
@@ -369,3 +369,54 @@ def test_a_referenced_secret_is_not_optional() -> None:
         e for e in dep["spec"]["template"]["spec"]["containers"][0]["env"] if e["name"] == "T"
     )
     assert entry["valueFrom"]["secretKeyRef"]["optional"] is False
+
+
+# -- sealed_secrets: the ADR-0094 contract slice ------------------------------
+
+
+def test_sealed_secrets_is_optional_and_absent_by_default() -> None:
+    """Additive: an existing bundle must be unaffected by the new field."""
+
+    spec = ConnectorSpec(image="grafana/mcp-grafana:0.17.2")
+    assert spec.sealed_secrets == {}
+    assert spec.secret_names() == []
+
+
+def test_sealed_secret_names_join_the_other_forms() -> None:
+    """All three holders answer the same question, so one list answers it."""
+
+    spec = ConnectorSpec(
+        image="x",
+        secrets=["PLAIN"],
+        sealed_secrets={"SEALED": "AgBv3n2K"},
+    )
+    assert spec.secret_names() == ["PLAIN", "SEALED"]
+    # Only the plain one is Curie's to resolve a value for.
+    assert spec.resolved_secrets() == ["PLAIN"]
+
+
+def test_a_declared_sealed_secret_is_refused_until_decryption_lands() -> None:
+    """Refuse, never ignore.
+
+    Accepting the field while nothing decrypts it would deploy a connector with
+    no credential: a pod that starts, passes its health check, and 401s every
+    call. That is the failure shape ADR-0094 exists to avoid, so the bundle is
+    rejected with a message naming what to use instead.
+    """
+
+    _, errors = validate_connectors(
+        {"connectors": {"grafana": {"image": "x", "sealed_secrets": {"TOKEN": "AgB"}}}}
+    )
+    codes = [code for code, _ in errors]
+    assert "connectors.sealed_secrets_unsupported" in codes
+    message = next(m for c, m in errors if c == "connectors.sealed_secrets_unsupported")
+    assert "secrets:" in message, "must name the form that works today"
+
+
+def test_an_empty_sealed_blob_is_reported_on_its_own() -> None:
+    """A distinct diagnostic, so the eventual decrypt path inherits the check."""
+
+    _, errors = validate_connectors(
+        {"connectors": {"grafana": {"image": "x", "sealed_secrets": {"TOKEN": "  "}}}}
+    )
+    assert "connectors.empty_sealed_value" in [code for code, _ in errors]


### PR DESCRIPTION
The frozen-contract half of [ADR-0094](docs/adr/0094-a-bundle-carries-its-own-sealed-connector-keys.md), landing on its own as AGENTS.md requires before anything reads it. Depends on #1327 (the acceptance).

## What it adds

`sealed_secrets` is a third answer to the question the other two forms already answer — **who holds the credential**:

| form | who holds it |
|---|---|
| `secrets: [TOKEN]` | Curie resolves it at deploy time |
| `secrets: [{name, from_secret}]` | someone else provisioned it; Curie never sees the value |
| `sealed_secrets: {TOKEN: AgB…}` | the bundle carries it, encrypted to the cluster |

Keyed by env var name so it reads like `env` and cannot express two blobs for one variable. Additive and optional — a bundle that doesn't use it parses exactly as before, which is what makes this backward compatible.

`secret_names()` now includes sealed names, since callers use it to ask *what env vars does this connector need* and the answer doesn't depend on who holds them. `resolved_secrets()` deliberately does **not** — a sealed value isn't Curie's to resolve at deploy time, the same reason a `SecretRef` is excluded.

## A declared sealed secret is refused, not ignored

Nothing decrypts one yet. Accepting the field early would deploy a connector with **no credential** — a pod that starts, passes its health check, and 401s every call. That is the #1156 failure shape ADR-0094 exists to avoid, so `validate_connectors` rejects the bundle and names `secrets:` as the form that works today.

That refusal comes out when the decrypt path lands. The empty-blob diagnostic beside it stays, so the eventual decrypt path inherits the check.

## Still to come

Per the ADR, in order: the keypair (generated at install, private half never leaving the cluster), `curie seal`, and the reconciler's decrypt step. The ADR's own hardest constraint rides with them — **two active keys so a rotation can overlap**, and one-command reseal, because rotating a cluster keypair otherwise invalidates every blob every agent repository has committed.

260 tests pass, `ruff` clean, `mypy` clean on 11 source files, and the API's connector tests are unaffected.