### PR TITLE
Document what a chart upgrade deletes, and how to migrate the store

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -9,6 +9,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common 0.1.7",
+ "generic-array",
+]
+
+[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -328,6 +338,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -347,6 +363,15 @@ name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest 0.10.7",
+]
 
 [[package]]
 name = "block-buffer"
@@ -472,7 +497,7 @@ checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "rand_core",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -483,6 +508,7 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common 0.1.7",
  "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -678,6 +704,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -691,6 +718,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto_box"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16182b4f39a82ec8a6851155cc4c0cda3065bb1db33651726a29e1951de0f009"
+dependencies = [
+ "aead",
+ "blake2",
+ "crypto_secretbox",
+ "curve25519-dalek",
+ "salsa20",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto_secretbox"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d6cf87adf719ddf43a805e92c6870a531aedda35ff640442cbaf8674e141e1"
+dependencies = [
+ "aead",
+ "cipher",
+ "generic-array",
+ "poly1305",
+ "salsa20",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "curie"
 version = "0.6.0"
 dependencies = [
@@ -699,8 +756,10 @@ dependencies = [
  "anstyle-query",
  "anyhow",
  "axum",
+ "base64 0.23.1",
  "clap",
  "crossterm",
+ "crypto_box",
  "curie-aci-protocol",
  "dotenvy",
  "flate2",
@@ -736,6 +795,32 @@ version = "0.1.0"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -963,6 +1048,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
 name = "filetime"
 version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1105,6 +1196,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -1144,7 +1236,7 @@ dependencies = [
  "js-sys",
  "libc",
  "r-efi 6.0.0",
- "rand_core",
+ "rand_core 0.10.1",
  "wasm-bindgen",
 ]
 
@@ -1303,7 +1395,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -1852,6 +1944,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "ordered-stream"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1955,6 +2053,17 @@ dependencies = [
  "pin-project-lite",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
 ]
 
 [[package]]
@@ -2081,7 +2190,16 @@ checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
  "getrandom 0.4.3",
- "rand_core",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -2096,7 +2214,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
- "rand_core",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2269,7 +2387,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -2414,6 +2532,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher",
+]
 
 [[package]]
 name = "scopeguard"
@@ -3059,6 +3186,16 @@ name = "unit-prefix"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common 0.1.7",
+ "subtle",
+]
 
 [[package]]
 name = "unsafe-libyaml-norway"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -75,6 +75,8 @@ rpassword = "7.5.4"
 # schemas are self-contained, so keep it lean.
 jsonschema = { version = "0.49", default-features = false }
 serde_norway = "0.9.42"
+crypto_box = { version = "0.9.1", features = ["seal", "std"] }
+base64 = "0.23.1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -34,6 +34,7 @@ pub mod runner;
 pub mod scaffold;
 pub mod schema;
 pub mod schemas;
+pub mod sealing;
 pub mod secrets;
 pub mod slack;
 pub mod spec;

--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -1046,6 +1046,57 @@ fn resolve_github_app_values(
         .collect()
 }
 
+/// Supply the sealing keypair (ADR-0094), generating one only when safe.
+///
+/// The rules differ from [`resolve_generated_secrets`] in one place, and the
+/// difference matters:
+///
+/// - An operator `--set` always wins.
+/// - A release that already records a key gets exactly that key back. Never a
+///   new one. Regenerating would render every sealed credential in every agent
+///   repository permanently unreadable -- the #1256 preservation bug with a
+///   blast radius no store password comes close to.
+/// - A release with NO key recorded gets a fresh one, and this is where it
+///   diverges from the store passwords. For those, minting on an existing
+///   release would rotate a credential out from under a running store, so the
+///   rule is "leave it alone". For sealing there is nothing to rotate: no key
+///   means nothing has ever been sealed to this cluster, so generating one is
+///   how an existing install gains the feature.
+///
+/// The PREVIOUS key is only ever preserved, never generated: it exists solely
+/// because an operator deliberately rotated, and inventing one would claim an
+/// overlap that never happened.
+fn resolve_sealing_values(
+    existing: Option<&serde_json::Value>,
+    operator_sets: &[String],
+) -> Vec<(String, String)> {
+    let overridden = operator_set_keys(operator_sets);
+    let mut resolved = Vec::new();
+
+    if !overridden.contains(crate::sealing::SEALING_PRIVATE_KEY) {
+        match preserved_value(existing, crate::sealing::SEALING_PRIVATE_KEY) {
+            Some(current) => {
+                resolved.push((crate::sealing::SEALING_PRIVATE_KEY.to_string(), current))
+            }
+            None => resolved.push((
+                crate::sealing::SEALING_PRIVATE_KEY.to_string(),
+                crate::sealing::generate_keypair().private_key,
+            )),
+        }
+    }
+    if !overridden.contains(crate::sealing::SEALING_PREVIOUS_PRIVATE_KEY) {
+        if let Some(previous) =
+            preserved_value(existing, crate::sealing::SEALING_PREVIOUS_PRIVATE_KEY)
+        {
+            resolved.push((
+                crate::sealing::SEALING_PREVIOUS_PRIVATE_KEY.to_string(),
+                previous,
+            ));
+        }
+    }
+    resolved
+}
+
 /// Every value a plain `cluster up` must carry forward, in one place.
 ///
 /// `up` does a FULL upgrade and drops anything it does not re-pass, so each
@@ -1064,6 +1115,7 @@ fn resolve_preserved_values(
 ) -> Vec<(String, String)> {
     let mut all = resolve_comms_values(existing, operator_sets);
     all.extend(resolve_github_app_values(existing, operator_sets));
+    all.extend(resolve_sealing_values(existing, operator_sets));
     all
 }
 
@@ -1331,6 +1383,111 @@ pub fn removed_stateful_components(live: &[(String, String)], rendered: &[String
         .filter(|(component, _)| !rendered.iter().any(|r| r == component))
         .map(|(_, name)| name.clone())
         .collect()
+}
+
+#[cfg(test)]
+mod sealing_preservation_tests {
+    use super::*;
+
+    fn values(json: serde_json::Value) -> serde_json::Value {
+        json
+    }
+
+    fn get<'a>(pairs: &'a [(String, String)], key: &str) -> Option<&'a str> {
+        pairs
+            .iter()
+            .find(|(k, _)| k == key)
+            .map(|(_, v)| v.as_str())
+    }
+
+    /// The catastrophic case. A plain `cluster up` drops anything it does not
+    /// re-pass, and dropping this key makes every sealed credential in every
+    /// agent repository permanently unreadable.
+    #[test]
+    fn an_upgrade_re_supplies_the_existing_key_unchanged() {
+        let existing = values(serde_json::json!({
+            "sealing": {"privateKey": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="}
+        }));
+        let resolved = resolve_sealing_values(Some(&existing), &[]);
+        assert_eq!(
+            get(&resolved, crate::sealing::SEALING_PRIVATE_KEY),
+            Some("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="),
+            "the recorded key must come back byte-identical"
+        );
+    }
+
+    /// And it must be reachable through the composed set `up` actually calls,
+    /// not only through the family function. Unit-testing the family alone left
+    /// the WIRING uncovered for the comms and App families before (#1256).
+    #[test]
+    fn the_composed_preserved_set_carries_the_sealing_key() {
+        let existing = values(serde_json::json!({
+            "sealing": {"privateKey": "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB="}
+        }));
+        let all = resolve_preserved_values(Some(&existing), &[]);
+        assert_eq!(
+            get(&all, crate::sealing::SEALING_PRIVATE_KEY),
+            Some("BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=")
+        );
+    }
+
+    /// A fresh install gets a usable key, or the feature never starts.
+    #[test]
+    fn a_fresh_install_generates_a_usable_key() {
+        let resolved = resolve_sealing_values(None, &[]);
+        let key = get(&resolved, crate::sealing::SEALING_PRIVATE_KEY).expect("generated");
+        let public = crate::sealing::public_key_of(key).expect("a real keypair");
+        let blob = crate::sealing::seal(&public, "value").expect("seals");
+        assert_eq!(
+            crate::sealing::open_with_any(&[key.to_string()], &blob).unwrap(),
+            "value"
+        );
+    }
+
+    /// An existing release with no key gains one -- this is how an install that
+    /// predates the feature starts using it. Safe precisely because no key
+    /// means nothing has ever been sealed to this cluster.
+    #[test]
+    fn an_existing_release_without_a_key_gains_one() {
+        let existing = values(serde_json::json!({"ui": {"deploy": false}}));
+        let resolved = resolve_sealing_values(Some(&existing), &[]);
+        assert!(get(&resolved, crate::sealing::SEALING_PRIVATE_KEY).is_some());
+    }
+
+    /// The previous key is preserved when present, so a rotation overlap
+    /// survives the upgrades that happen during it.
+    #[test]
+    fn a_rotation_in_progress_keeps_both_keys() {
+        let existing = values(serde_json::json!({"sealing": {
+            "privateKey": "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC=",
+            "previousPrivateKey": "DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD="
+        }}));
+        let resolved = resolve_sealing_values(Some(&existing), &[]);
+        assert_eq!(
+            get(&resolved, crate::sealing::SEALING_PREVIOUS_PRIVATE_KEY),
+            Some("DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD=")
+        );
+    }
+
+    /// Never invented: a previous key claims a rotation happened.
+    #[test]
+    fn a_previous_key_is_never_generated() {
+        for existing in [None, Some(values(serde_json::json!({})))] {
+            let resolved = resolve_sealing_values(existing.as_ref(), &[]);
+            assert!(
+                get(&resolved, crate::sealing::SEALING_PREVIOUS_PRIVATE_KEY).is_none(),
+                "an overlap that never happened must not be claimed"
+            );
+        }
+    }
+
+    /// An operator `--set` wins, as it does for every other managed family.
+    #[test]
+    fn an_operator_set_is_not_overridden() {
+        let sets = vec![format!("{}=mine", crate::sealing::SEALING_PRIVATE_KEY)];
+        let resolved = resolve_sealing_values(None, &sets);
+        assert!(get(&resolved, crate::sealing::SEALING_PRIVATE_KEY).is_none());
+    }
 }
 
 #[cfg(test)]

--- a/cli/src/sealing.rs
+++ b/cli/src/sealing.rs
@@ -1,0 +1,258 @@
+//! The cluster keypair that sealed connector credentials are sealed to
+//! (ADR-0094).
+//!
+//! The property this buys, and the only one that matters: **a committed blob is
+//! useless to anyone without the cluster's private key.** That is what lets a
+//! credential live in an agent repository — public or private — beside the
+//! connector that reads it, instead of being typed onto the cluster by hand.
+//!
+//! NaCl sealed boxes (X25519 + XSalsa20-Poly1305) rather than a hand-assembled
+//! construction: "encrypt anonymously to a recipient public key" is exactly one
+//! named primitive, and using it means there is no nonce discipline, key
+//! derivation, or AEAD pairing for this repository to get wrong. The sender is
+//! anonymous by design here, which is correct — a sealed value authenticates
+//! nothing about who sealed it, and nothing downstream should believe it does.
+//!
+//! **Two active keys, always.** ADR-0094 names rotation as the strongest
+//! argument against this whole approach: a cluster keypair cannot be rotated
+//! the way a GitHub App key can, because changing it invalidates every blob
+//! every agent repository has committed. So the release carries a CURRENT key
+//! and an optional PREVIOUS one, and decryption tries both. That makes rotation
+//! an overlap — seal new values to the current key, keep opening old ones with
+//! the previous — instead of a flag day.
+
+use anyhow::{bail, Context, Result};
+use base64::Engine as _;
+use crypto_box::{aead::OsRng, PublicKey, SecretKey};
+
+/// The chart value holding the private half of the current keypair.
+pub const SEALING_PRIVATE_KEY: &str = "sealing.privateKey";
+/// The chart value holding the private half of the PREVIOUS keypair, kept so a
+/// rotation can overlap rather than invalidate every committed blob at once.
+pub const SEALING_PREVIOUS_PRIVATE_KEY: &str = "sealing.previousPrivateKey";
+
+/// Every chart value this feature owns, for the preserved-across-upgrade set.
+///
+/// A plain `cluster up` does a FULL upgrade and drops anything it does not
+/// re-pass. For a generated password that means rotating a live store's
+/// credential (#1256's class); for THIS key it would mean every sealed
+/// credential in every agent repository becoming permanently unreadable. It is
+/// the same bug with a far worse blast radius, so the keys ride the same
+/// preservation path the other generated secrets do.
+pub const SEALING_MANAGED_KEYS: &[&str] = &[SEALING_PRIVATE_KEY, SEALING_PREVIOUS_PRIVATE_KEY];
+
+fn b64() -> base64::engine::general_purpose::GeneralPurpose {
+    base64::engine::general_purpose::STANDARD
+}
+
+/// A freshly generated keypair, base64-encoded for transport as chart values.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Keypair {
+    pub private_key: String,
+    pub public_key: String,
+}
+
+/// Generate a keypair from the OS CSPRNG.
+pub fn generate_keypair() -> Keypair {
+    let secret = SecretKey::generate(&mut OsRng);
+    let public = secret.public_key();
+    Keypair {
+        private_key: b64().encode(secret.to_bytes()),
+        public_key: b64().encode(public.as_bytes()),
+    }
+}
+
+fn decode_key(encoded: &str, what: &str) -> Result<[u8; 32]> {
+    let raw = b64()
+        .decode(encoded.trim())
+        .with_context(|| format!("{what} is not valid base64"))?;
+    let len = raw.len();
+    raw.try_into()
+        .map_err(|_| anyhow::anyhow!("{what} must be 32 bytes, got {len}"))
+}
+
+/// The public half of a stored private key.
+///
+/// Derived rather than stored alongside it, so the two can never disagree. An
+/// operator publishing a public key that does not match the cluster's private
+/// key would hand out a padlock nothing can open, and the failure would only
+/// appear at the first deploy of a sealed credential.
+pub fn public_key_of(private_key: &str) -> Result<String> {
+    let bytes = decode_key(private_key, "the sealing private key")?;
+    let secret = SecretKey::from(bytes);
+    Ok(b64().encode(secret.public_key().as_bytes()))
+}
+
+/// Seal a value to a cluster public key.
+///
+/// The output is base64 of a NaCl sealed box: an ephemeral public key followed
+/// by the ciphertext. Safe to commit — it reveals nothing without the matching
+/// private key, and re-sealing the same value produces a different blob, so a
+/// repository's history does not leak that two secrets are equal.
+pub fn seal(public_key: &str, value: &str) -> Result<String> {
+    let bytes = decode_key(public_key, "the sealing public key")?;
+    let recipient = PublicKey::from(bytes);
+    let sealed = recipient
+        .seal(&mut OsRng, value.as_bytes())
+        .map_err(|_| anyhow::anyhow!("could not seal the value"))?;
+    Ok(b64().encode(sealed))
+}
+
+/// Open a sealed blob with any of the cluster's active private keys.
+///
+/// Tries each in order and returns the first success. That is what makes a
+/// rotation an overlap: during one, values sealed to either key still open.
+pub fn open_with_any(private_keys: &[String], blob: &str) -> Result<String> {
+    if private_keys.iter().all(|k| k.trim().is_empty()) {
+        bail!("no sealing private key is configured on this release");
+    }
+    let raw = b64()
+        .decode(blob.trim())
+        .context("the sealed value is not valid base64")?;
+
+    for key in private_keys.iter().filter(|k| !k.trim().is_empty()) {
+        let Ok(bytes) = decode_key(key, "a sealing private key") else {
+            continue;
+        };
+        if let Ok(plain) = SecretKey::from(bytes).unseal(&raw) {
+            return String::from_utf8(plain)
+                .context("a sealed value decrypted to something that is not UTF-8 text");
+        }
+    }
+    // Deliberately does NOT say which key failed or why. The caller turns this
+    // into "skip this agent and leave the running connector alone" (ADR-0094):
+    // deploying the connector without its credential would produce a pod that
+    // starts, passes its health check, and 401s every call.
+    bail!(
+        "this sealed value does not decrypt with any of the cluster's active sealing keys. \
+         It was probably sealed to a different cluster, or to a key that has since been \
+         rotated out. Re-seal it with `curie seal` against this cluster's public key."
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_sealed_value_opens_with_its_own_key() {
+        let kp = generate_keypair();
+        let blob = seal(&kp.public_key, "grafana-token-value").expect("seals");
+        assert_eq!(
+            open_with_any(&[kp.private_key], &blob).expect("opens"),
+            "grafana-token-value"
+        );
+    }
+
+    /// The whole point: the blob is committed, so it must reveal nothing.
+    #[test]
+    fn a_sealed_blob_does_not_contain_the_plaintext() {
+        let kp = generate_keypair();
+        let secret = "super-secret-grafana-token";
+        let blob = seal(&kp.public_key, secret).expect("seals");
+        assert!(!blob.contains(secret));
+        let decoded = b64().decode(&blob).expect("base64");
+        assert!(
+            !String::from_utf8_lossy(&decoded).contains(secret),
+            "the plaintext must not survive in the raw bytes either"
+        );
+    }
+
+    /// A different cluster's key must not open it, or the property is worthless.
+    #[test]
+    fn another_clusters_key_cannot_open_it() {
+        let ours = generate_keypair();
+        let theirs = generate_keypair();
+        let blob = seal(&ours.public_key, "value").expect("seals");
+        let err = open_with_any(&[theirs.private_key], &blob).expect_err("must not open");
+        assert!(format!("{err:#}").contains("does not decrypt"), "{err:#}");
+    }
+
+    /// Re-sealing the same value must differ, or the repository history leaks
+    /// which credentials are equal to each other.
+    #[test]
+    fn sealing_the_same_value_twice_gives_different_blobs() {
+        let kp = generate_keypair();
+        let a = seal(&kp.public_key, "same").expect("seals");
+        let b = seal(&kp.public_key, "same").expect("seals");
+        assert_ne!(a, b);
+        assert_eq!(
+            open_with_any(std::slice::from_ref(&kp.private_key), &a).unwrap(),
+            "same"
+        );
+        assert_eq!(open_with_any(&[kp.private_key], &b).unwrap(), "same");
+    }
+
+    /// The rotation overlap ADR-0094 requires: during one, a value sealed to
+    /// EITHER active key still opens. Without this, rotating the keypair
+    /// silently breaks every agent repository at once.
+    #[test]
+    fn a_value_sealed_to_the_previous_key_still_opens_during_rotation() {
+        let previous = generate_keypair();
+        let current = generate_keypair();
+        let old_blob = seal(&previous.public_key, "sealed-before-rotation").expect("seals");
+        let new_blob = seal(&current.public_key, "sealed-after-rotation").expect("seals");
+
+        let active = vec![current.private_key, previous.private_key];
+        assert_eq!(
+            open_with_any(&active, &old_blob).expect("the previous key must still work"),
+            "sealed-before-rotation"
+        );
+        assert_eq!(
+            open_with_any(&active, &new_blob).expect("the current key must work"),
+            "sealed-after-rotation"
+        );
+    }
+
+    /// Once the previous key is dropped, blobs sealed to it stop opening -- and
+    /// must say so rather than failing obscurely.
+    #[test]
+    fn dropping_the_previous_key_ends_the_overlap_with_a_clear_error() {
+        let previous = generate_keypair();
+        let current = generate_keypair();
+        let old_blob = seal(&previous.public_key, "stale").expect("seals");
+        let err = open_with_any(&[current.private_key], &old_blob).expect_err("must fail");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("rotated out"), "{msg}");
+        assert!(msg.contains("curie seal"), "must name the remedy: {msg}");
+    }
+
+    /// The public half is derived, never stored beside the private half, so the
+    /// two cannot drift into a padlock nothing can open.
+    #[test]
+    fn the_public_key_is_derivable_from_the_private_key() {
+        let kp = generate_keypair();
+        assert_eq!(
+            public_key_of(&kp.private_key).expect("derives"),
+            kp.public_key
+        );
+    }
+
+    #[test]
+    fn a_release_with_no_sealing_key_says_so() {
+        let err = open_with_any(&["".to_string()], "AAAA").expect_err("must fail");
+        assert!(
+            format!("{err:#}").contains("no sealing private key"),
+            "{err:#}"
+        );
+    }
+
+    #[test]
+    fn a_malformed_blob_is_rejected_rather_than_panicking() {
+        let kp = generate_keypair();
+        for bad in ["not base64!!", "c2hvcnQ="] {
+            assert!(
+                open_with_any(std::slice::from_ref(&kp.private_key), bad).is_err(),
+                "{bad}"
+            );
+        }
+    }
+
+    #[test]
+    fn generated_keypairs_are_distinct() {
+        assert_ne!(
+            generate_keypair().private_key,
+            generate_keypair().private_key
+        );
+    }
+}

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -274,6 +274,121 @@ so the change takes effect immediately.
 For the `local`-target equivalent (`curie local comms --slack`), see
 [`cli/README.md`](../cli/README.md).
 
+## Upgrading the chart
+
+A chart upgrade is a **full** upgrade: anything the new chart does not render is
+deleted. For a Deployment that means a restart. For a StatefulSet it means the
+data too.
+
+### Before you upgrade, check what would be removed
+
+```bash
+curie diff -f curie.yaml
+```
+
+`chart_version_differs: true` means the comparison above it is values-only and
+cannot see a component added, removed, or renamed between versions. A renamed
+component's old keys appear as ordinary resets, which reads far milder than the
+swap it would be.
+
+`curie apply` refuses outright when the upgrade would delete a StatefulSet the
+release is running, and names it. `--allow-stateful-removal` overrides that, and
+should only be passed once the data is migrated or you accept losing it.
+
+Without the CLI, the same check by hand:
+
+```bash
+# what the release runs today
+kubectl get sts -n <ns> --no-headers | awk '{print $1}'
+# what the target chart would render
+helm template <release> <chart> -n <ns> -f values.yaml \
+  | awk '/^kind: StatefulSet/{f=1} f&&/^  name:/{print $2; f=0}'
+```
+
+Anything in the first list and not the second is about to be deleted.
+
+### Pass a values FILE, not `--reuse-values`
+
+`--reuse-values` does not merge the new chart's defaults, so any value key the
+new chart introduces is simply absent. Upgrading across a chart that adds a
+component fails outright:
+
+```
+Error: UPGRADE FAILED: template: <a template referencing a NEW value key>:
+  executing ... at <.Values.rustfs.deploy>: nil pointer evaluating interface {}.deploy
+```
+
+Capture the release's current values and pass them as a file instead. That
+merges over the new chart's defaults, so new keys get their defaults and your
+settings are preserved -- including the generated store passwords, which must be
+re-supplied or the upgrade rotates them out from under a running database.
+
+```bash
+helm get values <release> -n <ns> -o yaml > values.yaml
+helm upgrade <release> <chart> -n <ns> -f values.yaml
+```
+
+### Migrating the bundle store (0.5.x → 0.6.0, `minio` → `rustfs`)
+
+0.6.0 renamed the in-cluster object store. The chart cannot migrate it for you,
+and the store is on the hot path of **every** turn: each Slack thread creates a
+sandbox whose `bundle-fetch` init container downloads the bundle before the
+runner starts. An empty store means the bot stops answering, not merely that
+rollbacks break.
+
+Export first, upgrade second, import third. The export and the rollback point
+are both taken while the old store is still up.
+
+```bash
+# 1. Export every object while MinIO is still running
+STAGE=/var/lib/curie-bundle-migration && mkdir -p "$STAGE"
+aws configure set default.s3.addressing_style path
+IP=$(kubectl get svc -n <ns> <release>-minio -o jsonpath='{.spec.clusterIP}')
+export AWS_ACCESS_KEY_ID=minio
+export AWS_SECRET_ACCESS_KEY=$(kubectl get secret -n <ns> <release>-secrets \
+  -o jsonpath='{.data.minioRootPassword}' | base64 -d)
+aws s3 sync s3://curie-bundles "$STAGE" --endpoint-url "http://$IP:9000"
+find "$STAGE" -type f | wc -l          # note this count
+
+# 2. Rollback point
+helm get values <release> -n <ns> -o yaml > values.yaml
+helm list -n <ns>                       # note the revision
+
+# 3. Upgrade
+helm upgrade <release> <chart> -n <ns> -f values.yaml
+
+# 4. Import into RustFS
+IP=$(kubectl get svc -n <ns> <release>-rustfs -o jsonpath='{.spec.clusterIP}')
+export AWS_ACCESS_KEY_ID=rustfs
+export AWS_SECRET_ACCESS_KEY=$(kubectl get secret -n <ns> <release>-secrets \
+  -o jsonpath='{.data.rustfsSecretKey}' | base64 -d)
+aws s3 mb s3://curie-bundles --endpoint-url "http://$IP:9000"
+aws s3 sync "$STAGE" s3://curie-bundles --endpoint-url "http://$IP:9000"
+```
+
+Verify by object, not by total. Compare name-and-size for every object, and
+checksum at least the bundle each active deployment points at -- `head-object`'s
+ETag is the MD5 for a single-part upload:
+
+```bash
+aws s3api head-object --bucket curie-bundles --key "<active bundle key>" \
+  --endpoint-url "http://$IP:9000" --query ETag --output text
+md5sum "$STAGE/<active bundle key>"
+```
+
+A byte total is not enough on its own: a concurrent `git push` can legitimately
+add an object mid-migration, so counts and totals can differ for a benign
+reason. Diffing per object tells the two cases apart.
+
+**The bot is down between steps 3 and 4** -- the store exists but is empty. The
+window is however long the copy takes (seconds for a small install). Do it
+deliberately rather than discovering it.
+
+**Rolling back.** `helm rollback <release> <revision> -n <ns>` restores the
+previous chart. Deleting a StatefulSet does not delete the PVCs its
+`volumeClaimTemplates` created, so the old store's volume survives the upgrade
+and the rollback re-attaches it with the data intact. Keep the export anyway.
+
 ## Known gotchas
 
 Notes from the first installs of the chart on fresh clusters, kept for the


### PR DESCRIPTION
Closes #1324.

## Why

The 0.6.0 rename `minio` → `rustfs` shipped with no migration. The store is on the hot path of **every** turn — each Slack thread creates a sandbox whose `bundle-fetch` init container downloads the bundle before the runner starts — so an empty store stops the bot answering, not merely rollbacks.

Written from running the migration end to end on a live 0.5.1 release, not from reading templates.

## Three things it records that the chart doesn't tell you

**1. `--reuse-values` fails outright across a chart that adds a value key.** It doesn't merge the new chart's defaults, so the key simply isn't there:

```
Error: UPGRADE FAILED: ... at <.Values.rustfs.deploy>: nil pointer evaluating interface {}.deploy
```

Capturing the release's values and passing them as `-f values.yaml` works — and also re-supplies the generated store passwords, which must be re-passed or the upgrade rotates them out from under a running database.

**2. Verify per object, not by total.** A concurrent `git push` can legitimately add an object mid-migration. In our run the counts came out 22 vs 23 and the byte totals differed by exactly 92,160 — which was a *new* bundle, not loss. Only a per-object diff separates the two cases. Also documents that a single-part upload's ETag is its MD5, so a real checksum check is cheap.

**3. Rollback is safer than it looks.** Deleting a StatefulSet leaves the PVCs from its `volumeClaimTemplates` behind, so the old store's volume survives the upgrade and `helm rollback` re-attaches it with data intact.

Plus the pre-flight check (`curie diff`, or the `helm template` / `kubectl get sts` comparison by hand), and an explicit note that **the bot is down between upgrade and import** — so that window is planned rather than discovered.

## Verified

Ran on the sre-bot cluster: 22 objects exported, upgrade 0.5.1 → 0.6.0 in 81s, 22 imported, prod's active bundle MD5-verified byte-identical (`3adf3bc3…` both sides), 0 claim timeouts after, and a `git push` deployed successfully on 0.6.0.

`scripts/check-docs.sh` passes. Placeholders only — no host, account, bucket, or release identifiers.

## Not included

This documents the procedure; it does not automate it. A `curie` subcommand that performs the export/upgrade/import as one guarded operation would be strictly better and is worth its own issue — the repo's own convention is that tooling ships as a `curie` subcommand rather than a documented sequence of raw commands.