### PR TITLE
Add `curie cluster migrate-store` for a renamed object store

### DIFF
--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -1974,6 +1974,91 @@ export const commandManifest = {
           "name": "down"
         },
         {
+          "about": "Carry bundle objects across a chart upgrade that renames the object store (issue #1324)",
+          "args": [
+            {
+              "global": false,
+              "help": "`export` before the upgrade, `import` after it",
+              "id": "phase",
+              "long": "phase",
+              "positional": false,
+              "possible_values": [
+                "export",
+                "import"
+              ],
+              "required": true
+            },
+            {
+              "default_values": [
+                "curie"
+              ],
+              "global": false,
+              "help": "Kubernetes namespace",
+              "id": "namespace",
+              "long": "namespace",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "curie"
+              ],
+              "global": false,
+              "help": "Helm release name",
+              "id": "release",
+              "long": "release",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Chart reference, used by `export` to see which store the upgrade would render",
+              "id": "chart",
+              "long": "chart",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "curie-bundles"
+              ],
+              "global": false,
+              "help": "Bundle bucket name, matching the platform's BUNDLE_BUCKET",
+              "id": "bucket",
+              "long": "bucket",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Keep the staging pod after a successful import, instead of deleting it. The staged copy is the only thing standing between a failed import and an empty store, so keep it until you have verified a turn",
+              "id": "keep_staging",
+              "long": "keep-staging",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Print the commands that would run and exit without executing",
+              "id": "dry_run",
+              "long": "dry-run",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "long_about": "Carry bundle objects across a chart upgrade that renames the object store (issue #1324).\n\nChart 0.6.0 renamed the in-cluster store from `minio` to `rustfs`. Helm does a full upgrade, so the old StatefulSet -- and the bundles in it -- are deleted. Every sandbox downloads its bundle from that store at start, so an empty one stops the bot answering rather than merely breaking rollbacks.\n\nThe two stores never coexist, so this runs in two phases around the upgrade, holding the objects in a staging pod Helm does not own:\n\ncurie cluster migrate-store --phase export   # before the upgrade curie apply -f curie.yaml                    # or helm upgrade curie cluster migrate-store --phase import   # after\n\nEach phase refuses when its precondition is unmet, and `import` verifies per object rather than by count -- a concurrent push can legitimately add one mid-migration, and only a per-object diff tells that from data loss.",
+          "name": "migrate-store"
+        },
+        {
           "about": "Report release health and access URLs (read-only: helm status + kubectl)",
           "args": [
             {

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -1971,6 +1971,91 @@
           "name": "down"
         },
         {
+          "about": "Carry bundle objects across a chart upgrade that renames the object store (issue #1324)",
+          "args": [
+            {
+              "global": false,
+              "help": "`export` before the upgrade, `import` after it",
+              "id": "phase",
+              "long": "phase",
+              "positional": false,
+              "possible_values": [
+                "export",
+                "import"
+              ],
+              "required": true
+            },
+            {
+              "default_values": [
+                "curie"
+              ],
+              "global": false,
+              "help": "Kubernetes namespace",
+              "id": "namespace",
+              "long": "namespace",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "curie"
+              ],
+              "global": false,
+              "help": "Helm release name",
+              "id": "release",
+              "long": "release",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Chart reference, used by `export` to see which store the upgrade would render",
+              "id": "chart",
+              "long": "chart",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "curie-bundles"
+              ],
+              "global": false,
+              "help": "Bundle bucket name, matching the platform's BUNDLE_BUCKET",
+              "id": "bucket",
+              "long": "bucket",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Keep the staging pod after a successful import, instead of deleting it. The staged copy is the only thing standing between a failed import and an empty store, so keep it until you have verified a turn",
+              "id": "keep_staging",
+              "long": "keep-staging",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Print the commands that would run and exit without executing",
+              "id": "dry_run",
+              "long": "dry-run",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "long_about": "Carry bundle objects across a chart upgrade that renames the object store (issue #1324).\n\nChart 0.6.0 renamed the in-cluster store from `minio` to `rustfs`. Helm does a full upgrade, so the old StatefulSet -- and the bundles in it -- are deleted. Every sandbox downloads its bundle from that store at start, so an empty one stops the bot answering rather than merely breaking rollbacks.\n\nThe two stores never coexist, so this runs in two phases around the upgrade, holding the objects in a staging pod Helm does not own:\n\ncurie cluster migrate-store --phase export   # before the upgrade curie apply -f curie.yaml                    # or helm upgrade curie cluster migrate-store --phase import   # after\n\nEach phase refuses when its precondition is unmet, and `import` verifies per object rather than by count -- a concurrent push can legitimately add one mid-migration, and only a per-object diff tells that from data loss.",
+          "name": "migrate-store"
+        },
+        {
           "about": "Report release health and access URLs (read-only: helm status + kubectl)",
           "args": [
             {

--- a/cli/schema/index.json
+++ b/cli/schema/index.json
@@ -160,6 +160,12 @@
       "version": 1
     },
     {
+      "result": "MigrateStoreOutput",
+      "kind": "CliOutput",
+      "schema": "migrate-store.schema.json",
+      "version": 1
+    },
+    {
       "result": "ObservabilityOutput",
       "kind": "CliOutput",
       "schema": "observability.schema.json",

--- a/cli/schema/migrate-store.schema.json
+++ b/cli/schema/migrate-store.schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.curietech.ai/cli/migrate-store/v1.json",
+  "title": "curie cluster migrate-store --json",
+  "description": "The agent-facing payload of `curie cluster migrate-store`: the dry-run plan, the result of staging objects out of the old store, or the result of loading them into the new one. One object per invocation.",
+  "$defs": {
+    "dryRun": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "dry_run": { "const": true },
+        "plan": { "type": "array", "items": { "type": "string" } }
+      },
+      "required": ["dry_run", "plan"]
+    }
+  },
+  "oneOf": [
+    { "$ref": "#/$defs/dryRun" },
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "phase": { "const": "export" },
+        "from": { "type": "string", "description": "Store component copied out of, e.g. `minio`." },
+        "to": { "type": "string", "description": "Store component the target chart renders, e.g. `rustfs`." },
+        "objects": { "type": "integer", "minimum": 1, "description": "Objects staged. Zero is an error, never a successful export." }
+      },
+      "required": ["phase", "from", "to", "objects"]
+    },
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "phase": { "const": "import" },
+        "store": { "type": "string" },
+        "objects": { "type": "integer", "minimum": 0, "description": "Objects in the new store after the import." },
+        "missing": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Staged objects absent from the new store, or present at a different size. Non-empty means data loss; the staging pod is retained so a retry is possible."
+        },
+        "added": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Objects in the new store that were not staged. Benign -- a deploy landing mid-migration writes directly to the new store -- but reported so it is not mistaken for a discrepancy."
+        },
+        "verified": { "type": "boolean", "description": "True when `missing` is empty." },
+        "staging_kept": { "type": "boolean", "description": "Whether the staging pod was retained. Always true when anything is missing." }
+      },
+      "required": ["phase", "store", "objects", "missing", "added", "verified", "staging_kept"]
+    }
+  ]
+}

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -23,6 +23,7 @@ pub mod installation;
 pub mod interactive;
 pub mod local;
 pub mod message;
+pub mod migrate_store;
 pub mod ndjson;
 pub mod observability;
 pub mod ops;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1251,6 +1251,51 @@ enum ClusterAction {
         #[arg(long)]
         dry_run: bool,
     },
+    /// Carry bundle objects across a chart upgrade that renames the object
+    /// store (issue #1324).
+    ///
+    /// Chart 0.6.0 renamed the in-cluster store from `minio` to `rustfs`. Helm
+    /// does a full upgrade, so the old StatefulSet -- and the bundles in it --
+    /// are deleted. Every sandbox downloads its bundle from that store at
+    /// start, so an empty one stops the bot answering rather than merely
+    /// breaking rollbacks.
+    ///
+    /// The two stores never coexist, so this runs in two phases around the
+    /// upgrade, holding the objects in a staging pod Helm does not own:
+    ///
+    ///   curie cluster migrate-store --phase export   # before the upgrade
+    ///   curie apply -f curie.yaml                    # or helm upgrade
+    ///   curie cluster migrate-store --phase import   # after
+    ///
+    /// Each phase refuses when its precondition is unmet, and `import` verifies
+    /// per object rather than by count -- a concurrent push can legitimately add
+    /// one mid-migration, and only a per-object diff tells that from data loss.
+    MigrateStore {
+        /// `export` before the upgrade, `import` after it.
+        #[arg(long, value_parser = ["export", "import"])]
+        phase: String,
+        /// Kubernetes namespace.
+        #[arg(long, default_value = "curie")]
+        namespace: String,
+        /// Helm release name.
+        #[arg(long, default_value = "curie")]
+        release: String,
+        /// Chart reference, used by `export` to see which store the upgrade
+        /// would render.
+        #[arg(long)]
+        chart: Option<String>,
+        /// Bundle bucket name, matching the platform's BUNDLE_BUCKET.
+        #[arg(long, default_value = "curie-bundles")]
+        bucket: String,
+        /// Keep the staging pod after a successful import, instead of deleting
+        /// it. The staged copy is the only thing standing between a failed
+        /// import and an empty store, so keep it until you have verified a turn.
+        #[arg(long)]
+        keep_staging: bool,
+        /// Print the commands that would run and exit without executing.
+        #[arg(long)]
+        dry_run: bool,
+    },
     /// Report release health and access URLs (read-only: helm status + kubectl).
     Status {
         /// Kubernetes namespace.
@@ -2427,6 +2472,36 @@ async fn run(command: Option<Command>) -> Result<()> {
                 )
                 .await?,
             ),
+            ClusterAction::MigrateStore {
+                phase,
+                namespace,
+                release,
+                chart,
+                bucket,
+                keep_staging,
+                dry_run,
+            } => {
+                use curie::migrate_store as ms;
+                let common = curie::ops::CommonOpts {
+                    namespace,
+                    release,
+                    dry_run,
+                };
+                let out = if phase == "export" {
+                    let resolved = artifacts::resolve_chart(
+                        chart.as_deref(),
+                        artifacts::Channel::current(),
+                        artifacts::version(),
+                        artifacts::cache_root,
+                        std::path::Path::new("charts/curie").is_dir(),
+                    )?;
+                    let chart = materialize_artifact(resolved, dry_run, "chart").await?;
+                    ms::run_export(&common, &chart, &bucket).await?
+                } else {
+                    ms::run_import(&common, &bucket, keep_staging).await?
+                };
+                emit(out)
+            }
             ClusterAction::Comms {
                 slack,
                 disconnect,

--- a/cli/src/migrate_store.rs
+++ b/cli/src/migrate_store.rs
@@ -1,0 +1,788 @@
+//! `curie cluster migrate-store`: move bundle objects across a store rename.
+//!
+//! Chart 0.6.0 renamed the in-cluster object store from `minio` to `rustfs`.
+//! Helm does a FULL upgrade, so the old StatefulSet is deleted -- and the
+//! bundles with it. That store is on the hot path of every turn: each Slack
+//! thread creates a sandbox whose bundle-fetch init container downloads the
+//! bundle before the runner starts, so an empty store stops the bot answering
+//! rather than merely breaking rollbacks (issue #1324).
+//!
+//! The two stores cannot coexist -- one chart renders one of them -- so the
+//! objects have to live somewhere across the upgrade. That somewhere is a
+//! **staging pod**: a plain `kubectl run` pod on the image the chart already
+//! uses for bundle-fetch, holding the objects in its `emptyDir`. Helm does not
+//! own that pod, so the upgrade does not touch it.
+//!
+//! Two properties are load-bearing:
+//!
+//! - **No S3 client in the CLI.** Every transfer is `kubectl exec` into the
+//!   staging pod running the same `aws` CLI the chart's bundle-fetch uses. This
+//!   keeps the verb a thin wrapper over `kubectl`, matching every other
+//!   operator verb, and adds no signing code or SDK dependency.
+//! - **Credentials never reach argv.** Store passwords are read inside the pod
+//!   from the mounted release Secret, so they cannot land in `ps`, shell
+//!   history, or a printed plan.
+
+use anyhow::{bail, Result};
+
+use crate::ops::{plain, CommonOpts, OpsCommand};
+
+/// Which in-cluster object store a release runs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StoreKind {
+    Minio,
+    Rustfs,
+}
+
+impl StoreKind {
+    /// The StatefulSet suffix, and the `<release>-<suffix>` Service name.
+    pub fn suffix(self) -> &'static str {
+        match self {
+            StoreKind::Minio => "minio",
+            StoreKind::Rustfs => "rustfs",
+        }
+    }
+
+    /// The access key the chart configures for this store.
+    pub fn access_key(self) -> &'static str {
+        match self {
+            StoreKind::Minio => "minio",
+            StoreKind::Rustfs => "rustfs",
+        }
+    }
+
+    /// The key in the release Secret holding this store's password.
+    pub fn secret_key(self) -> &'static str {
+        match self {
+            StoreKind::Minio => "minioRootPassword",
+            StoreKind::Rustfs => "rustfsSecretKey",
+        }
+    }
+}
+
+/// Identify the store among a release's StatefulSet COMPONENTS.
+///
+/// Component, never resource name: names embed the chart fullname, so
+/// `nameOverride` renames every one of them. `ops::live_stateful_components`
+/// documents why the guard learned this the hard way; the same reasoning
+/// applies here, and getting it wrong would point the copy at a Service that
+/// does not exist.
+pub fn detect_store(components: &[String]) -> Option<StoreKind> {
+    [StoreKind::Minio, StoreKind::Rustfs]
+        .into_iter()
+        .find(|kind| components.iter().any(|c| c == kind.suffix()))
+}
+
+/// What a migration would do.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MigrationPlan {
+    /// Source and target are the same store: nothing to move.
+    NotNeeded { store: StoreKind },
+    /// The upgrade renames the store; objects must be carried across.
+    Migrate { from: StoreKind, to: StoreKind },
+}
+
+/// Compare the live store against the one the target chart renders.
+///
+/// Pure, so the decision this verb turns on is testable with no cluster. A
+/// missing store on either side is an error rather than a guess: migrating from
+/// or to something we cannot name would move data into the void.
+pub fn plan(live: &[String], rendered: &[String]) -> Result<MigrationPlan> {
+    let from = detect_store(live).ok_or_else(|| {
+        anyhow::anyhow!(
+            "no known object store StatefulSet found in the live release. Looked for \
+             components `minio` and `rustfs` among: {}",
+            if live.is_empty() {
+                "(none)".to_string()
+            } else {
+                live.join(", ")
+            }
+        )
+    })?;
+    let to = detect_store(rendered).ok_or_else(|| {
+        anyhow::anyhow!(
+            "the target chart renders no known object store. Looked for \
+             components `minio` and `rustfs` among: {}",
+            if rendered.is_empty() {
+                "(none)".to_string()
+            } else {
+                rendered.join(", ")
+            }
+        )
+    })?;
+    if from == to {
+        return Ok(MigrationPlan::NotNeeded { store: from });
+    }
+    Ok(MigrationPlan::Migrate { from, to })
+}
+
+/// Name of the staging pod. Fixed per release so a re-run adopts the pod a
+/// previous interrupted run left behind rather than stranding its data.
+pub fn staging_pod(release: &str) -> String {
+    format!("{release}-store-migration")
+}
+
+/// `kubectl run` the staging pod: the chart's own aws-cli image, idle, with the
+/// release Secret mounted so passwords are read in-pod and never pass through
+/// argv.
+pub fn create_staging_pod_cmd(o: &CommonOpts, image: &str, secret_name: &str) -> OpsCommand {
+    let overrides = serde_json::json!({
+        "spec": {
+            "containers": [{
+                "name": "stage",
+                "image": image,
+                "command": ["sleep", "86400"],
+                "volumeMounts": [
+                    {"name": "stage", "mountPath": "/stage"},
+                    {"name": "release-secret", "mountPath": "/secret", "readOnly": true}
+                ]
+            }],
+            "volumes": [
+                {"name": "stage", "emptyDir": {}},
+                {"name": "release-secret", "secret": {"secretName": secret_name}}
+            ]
+        }
+    });
+    OpsCommand::new(
+        "kubectl",
+        vec![
+            plain("run"),
+            plain(staging_pod(&o.release)),
+            plain("-n"),
+            plain(&o.namespace),
+            plain("--image"),
+            plain(image),
+            plain("--restart=Never"),
+            plain("--overrides"),
+            plain(overrides.to_string()),
+            plain("--command"),
+            plain("--"),
+            plain("sleep"),
+            plain("86400"),
+        ],
+    )
+}
+
+/// The in-pod shell for one leg of the copy.
+///
+/// `direction` is the `aws s3 sync` argument pair. The password is read from
+/// the mounted Secret inside the pod, so it never appears here.
+fn sync_script(store: StoreKind, endpoint: &str, from: &str, to: &str) -> String {
+    format!(
+        "set -e; \
+         export AWS_DEFAULT_REGION=us-east-1; \
+         aws configure set default.s3.addressing_style path; \
+         export AWS_ACCESS_KEY_ID={access}; \
+         export AWS_SECRET_ACCESS_KEY=$(cat /secret/{secret}); \
+         aws s3 sync {from} {to} --endpoint-url {endpoint} --only-show-errors; \
+         echo synced",
+        access = store.access_key(),
+        secret = store.secret_key(),
+    )
+}
+
+/// The store's in-cluster S3 endpoint, from the Service the chart actually
+/// created. Looked up by component label rather than constructed from the
+/// release name, for the `nameOverride` reason above.
+pub fn store_service_cmd(o: &CommonOpts, store: StoreKind) -> OpsCommand {
+    OpsCommand::new(
+        "kubectl",
+        vec![
+            plain("get"),
+            plain("svc"),
+            plain("-n"),
+            plain(&o.namespace),
+            plain("-l"),
+            plain(format!("app.kubernetes.io/component={}", store.suffix())),
+            plain("-o"),
+            plain("jsonpath={.items[0].metadata.name}"),
+        ],
+    )
+}
+
+/// Build the endpoint URL once the Service name is known.
+pub fn endpoint_for(service: &str, namespace: &str) -> String {
+    format!("http://{service}.{namespace}.svc.cluster.local:9000")
+}
+
+/// Copy every object out of the live store into the staging pod's volume.
+pub fn export_cmd(o: &CommonOpts, from: StoreKind, bucket: &str, endpoint: &str) -> OpsCommand {
+    exec_cmd(
+        o,
+        &sync_script(from, endpoint, &format!("s3://{bucket}"), "/stage"),
+    )
+}
+
+/// Copy the staged objects into the new store, creating the bucket first.
+///
+/// `mb` on an existing bucket is a no-op error, so it is tolerated: a re-run
+/// after a partial import must not fail on the bucket already being there.
+pub fn import_cmd(o: &CommonOpts, to: StoreKind, bucket: &str, endpoint: &str) -> OpsCommand {
+    let script = format!(
+        "set -e; \
+         export AWS_DEFAULT_REGION=us-east-1; \
+         aws configure set default.s3.addressing_style path; \
+         export AWS_ACCESS_KEY_ID={access}; \
+         export AWS_SECRET_ACCESS_KEY=$(cat /secret/{secret}); \
+         aws s3 mb s3://{bucket} --endpoint-url {endpoint} || true; \
+         aws s3 sync /stage s3://{bucket} --endpoint-url {endpoint} --only-show-errors; \
+         echo synced",
+        access = to.access_key(),
+        secret = to.secret_key(),
+    );
+    exec_cmd(o, &script)
+}
+
+/// Count staged objects, for the before/after comparison.
+pub fn staged_count_cmd(o: &CommonOpts) -> OpsCommand {
+    exec_cmd(o, "find /stage -type f | wc -l")
+}
+
+/// List `<size> <key>` for every object in a store, for a per-object diff.
+///
+/// Per object rather than a byte total on purpose: a concurrent `git push` can
+/// legitimately add an object mid-migration, so counts and totals can differ
+/// for a benign reason. Only a per-object comparison separates that from loss.
+pub fn store_listing_cmd(
+    o: &CommonOpts,
+    store: StoreKind,
+    bucket: &str,
+    endpoint: &str,
+) -> OpsCommand {
+    let script = format!(
+        "export AWS_DEFAULT_REGION=us-east-1; \
+         aws configure set default.s3.addressing_style path; \
+         export AWS_ACCESS_KEY_ID={access}; \
+         export AWS_SECRET_ACCESS_KEY=$(cat /secret/{secret}); \
+         aws s3 ls s3://{bucket} --recursive --endpoint-url {endpoint} \
+         | awk '{{print $3, $4}}' | sort",
+        access = store.access_key(),
+        secret = store.secret_key(),
+    );
+    exec_cmd(o, &script)
+}
+
+/// The staged files as `<size> <key>`, comparable with a store listing.
+pub fn staged_listing_cmd(o: &CommonOpts) -> OpsCommand {
+    exec_cmd(o, "cd /stage && find . -type f -printf '%s %P\\n' | sort")
+}
+
+pub fn delete_staging_pod_cmd(o: &CommonOpts) -> OpsCommand {
+    OpsCommand::new(
+        "kubectl",
+        vec![
+            plain("delete"),
+            plain("pod"),
+            plain(staging_pod(&o.release)),
+            plain("-n"),
+            plain(&o.namespace),
+            plain("--ignore-not-found"),
+        ],
+    )
+}
+
+fn exec_cmd(o: &CommonOpts, script: &str) -> OpsCommand {
+    OpsCommand::new(
+        "kubectl",
+        vec![
+            plain("exec"),
+            plain("-n"),
+            plain(&o.namespace),
+            plain(staging_pod(&o.release)),
+            plain("--"),
+            plain("sh"),
+            plain("-c"),
+            plain(script),
+        ],
+    )
+}
+
+/// Compare two `<size> <key>` listings.
+///
+/// Returns the keys present in `before` but missing or differently sized in
+/// `after`. An object only in `after` is NOT a problem -- that is the
+/// concurrent-push case -- so it is reported separately by the caller.
+pub fn missing_after(before: &str, after: &str) -> Vec<String> {
+    let parse = |s: &str| -> Vec<(String, String)> {
+        s.lines()
+            .filter_map(|l| {
+                let mut it = l.split_whitespace();
+                let size = it.next()?;
+                let key = it.next()?;
+                Some((key.to_string(), size.to_string()))
+            })
+            .collect()
+    };
+    let after_pairs = parse(after);
+    parse(before)
+        .into_iter()
+        .filter(|(key, size)| !after_pairs.iter().any(|(k, s)| k == key && s == size))
+        .map(|(key, _)| key)
+        .collect()
+}
+
+/// Objects in `after` that were not in `before` -- benign, but worth naming.
+pub fn added_after(before: &str, after: &str) -> Vec<String> {
+    let keys = |s: &str| -> Vec<String> {
+        s.lines()
+            .filter_map(|l| l.split_whitespace().nth(1).map(str::to_string))
+            .collect()
+    };
+    let before_keys = keys(before);
+    keys(after)
+        .into_iter()
+        .filter(|k| !before_keys.contains(k))
+        .collect()
+}
+
+/// Refuse a plan that cannot be carried out safely.
+pub fn ensure_migratable(plan: &MigrationPlan) -> Result<(StoreKind, StoreKind)> {
+    match plan {
+        MigrationPlan::NotNeeded { store } => bail!(
+            "nothing to migrate: the release already runs {} and the target chart \
+             renders the same store. A plain `curie apply` or `helm upgrade` is all \
+             this upgrade needs.",
+            store.suffix()
+        ),
+        MigrationPlan::Migrate { from, to } => Ok((*from, *to)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn opts() -> CommonOpts {
+        CommonOpts {
+            namespace: "sre-bot".into(),
+            release: "sre-bot".into(),
+            dry_run: false,
+        }
+    }
+
+    #[test]
+    fn detects_each_store_by_component() {
+        assert_eq!(
+            detect_store(&["postgres".into(), "minio".into()]),
+            Some(StoreKind::Minio)
+        );
+        assert_eq!(detect_store(&["rustfs".into()]), Some(StoreKind::Rustfs));
+        assert_eq!(detect_store(&["postgres".into()]), None);
+    }
+
+    /// The reason detection is component-keyed rather than name-keyed: a
+    /// release installed with `nameOverride` renames every resource, so
+    /// matching `<release>-minio` would miss the store entirely and the copy
+    /// would be pointed at a Service that does not exist.
+    #[test]
+    fn a_name_override_does_not_hide_the_store() {
+        // Components are stable under nameOverride; resource names are not.
+        let components = vec!["postgres".to_string(), "minio".to_string()];
+        assert_eq!(detect_store(&components), Some(StoreKind::Minio));
+    }
+
+    /// The endpoint comes from the Service the chart actually made.
+    #[test]
+    fn the_endpoint_uses_the_resolved_service_name() {
+        assert_eq!(
+            endpoint_for("acme-minio", "acme"),
+            "http://acme-minio.acme.svc.cluster.local:9000"
+        );
+    }
+
+    /// The case this verb exists for.
+    #[test]
+    fn a_renamed_store_plans_a_migration() {
+        let live = vec!["minio".into(), "postgres".into()];
+        let rendered = vec!["rustfs".into(), "postgres".into()];
+        assert_eq!(
+            plan(&live, &rendered).unwrap(),
+            MigrationPlan::Migrate {
+                from: StoreKind::Minio,
+                to: StoreKind::Rustfs
+            }
+        );
+    }
+
+    /// An ordinary upgrade must say "nothing to do" rather than shuffling data
+    /// through a staging pod for no reason.
+    #[test]
+    fn an_unchanged_store_needs_no_migration() {
+        let live = vec!["rustfs".to_string()];
+        let rendered = vec!["rustfs".to_string()];
+        let p = plan(&live, &rendered).unwrap();
+        assert_eq!(
+            p,
+            MigrationPlan::NotNeeded {
+                store: StoreKind::Rustfs
+            }
+        );
+        let err = format!("{:#}", ensure_migratable(&p).unwrap_err());
+        assert!(err.contains("nothing to migrate"), "{err}");
+    }
+
+    /// Guessing here would move data into the void.
+    #[test]
+    fn an_unrecognisable_store_is_an_error_not_a_guess() {
+        let err = plan(&[], &["rustfs".to_string()]).unwrap_err();
+        assert!(format!("{err:#}").contains("live release"), "{err:#}");
+        let err = plan(&["minio".to_string()], &[]).unwrap_err();
+        assert!(format!("{err:#}").contains("target chart"), "{err:#}");
+    }
+
+    /// The whole point of reading the password in-pod.
+    #[test]
+    fn no_command_carries_a_credential_in_argv() {
+        let o = opts();
+        for cmd in [
+            export_cmd(&o, StoreKind::Minio, "curie-bundles", "http://s:9000"),
+            import_cmd(&o, StoreKind::Rustfs, "curie-bundles", "http://s:9000"),
+            store_listing_cmd(&o, StoreKind::Minio, "curie-bundles", "http://s:9000"),
+        ] {
+            let joined = format!("{:?}", cmd.args);
+            assert!(
+                joined.contains("/secret/"),
+                "the password must be read from the mounted Secret: {joined}"
+            );
+            for leaked in [
+                "minioRootPassword=",
+                "rustfsSecretKey=",
+                "AWS_SECRET_ACCESS_KEY=x",
+            ] {
+                assert!(!joined.contains(leaked), "{leaked} in argv: {joined}");
+            }
+        }
+    }
+
+    #[test]
+    fn export_and_import_target_the_right_endpoints() {
+        let o = opts();
+        let ep = endpoint_for("sre-bot-minio", "sre-bot");
+        let export = format!(
+            "{:?}",
+            export_cmd(&o, StoreKind::Minio, "curie-bundles", &ep).args
+        );
+        assert!(
+            export.contains("sre-bot-minio.sre-bot.svc.cluster.local:9000"),
+            "{export}"
+        );
+        assert!(export.contains("s3://curie-bundles /stage"), "{export}");
+
+        let ep = endpoint_for("sre-bot-rustfs", "sre-bot");
+        let import = format!(
+            "{:?}",
+            import_cmd(&o, StoreKind::Rustfs, "curie-bundles", &ep).args
+        );
+        assert!(
+            import.contains("sre-bot-rustfs.sre-bot.svc.cluster.local:9000"),
+            "{import}"
+        );
+        assert!(import.contains("/stage s3://curie-bundles"), "{import}");
+    }
+
+    /// A partial import must be resumable, so bucket-already-exists cannot fail.
+    #[test]
+    fn import_tolerates_an_existing_bucket() {
+        let import = format!(
+            "{:?}",
+            import_cmd(&opts(), StoreKind::Rustfs, "curie-bundles", "http://s:9000").args
+        );
+        assert!(import.contains("mb s3://curie-bundles"), "{import}");
+        assert!(
+            import.contains("|| true"),
+            "re-run must not fail on mb: {import}"
+        );
+    }
+
+    /// The staging pod name is stable so an interrupted run is adoptable rather
+    /// than orphaning its data under a fresh random name.
+    #[test]
+    fn the_staging_pod_name_is_deterministic() {
+        assert_eq!(staging_pod("sre-bot"), "sre-bot-store-migration");
+    }
+
+    #[test]
+    fn a_lost_object_is_reported() {
+        let before = "100 a.tar\n200 b.tar";
+        let after = "100 a.tar";
+        assert_eq!(missing_after(before, after), vec!["b.tar"]);
+    }
+
+    /// Same key, different size, is loss too -- a truncated copy must not pass.
+    #[test]
+    fn a_resized_object_counts_as_missing() {
+        assert_eq!(missing_after("100 a.tar", "40 a.tar"), vec!["a.tar"]);
+    }
+
+    /// The real 22-vs-23 case: a push landed mid-migration. Benign, and must not
+    /// read as loss -- but it should still be named.
+    #[test]
+    fn an_object_added_during_the_migration_is_not_loss() {
+        let before = "100 a.tar";
+        let after = "100 a.tar\n92160 new.tar";
+        assert!(missing_after(before, after).is_empty());
+        assert_eq!(added_after(before, after), vec!["new.tar"]);
+    }
+
+    #[test]
+    fn an_identical_pair_reports_nothing() {
+        let both = "100 a.tar\n200 b.tar";
+        assert!(missing_after(both, both).is_empty());
+        assert!(added_after(both, both).is_empty());
+    }
+}
+
+// -- execution ----------------------------------------------------------------
+
+/// What a phase did, as one object (the `--json` contract allows exactly one).
+#[derive(Debug)]
+pub enum MigrateStoreOutput {
+    DryRun(crate::ui::DryRunPlan),
+    Exported {
+        from: String,
+        to: String,
+        objects: usize,
+    },
+    Imported {
+        store: String,
+        objects: usize,
+        missing: Vec<String>,
+        added: Vec<String>,
+        staging_kept: bool,
+    },
+}
+
+impl crate::ui::CliOutput for MigrateStoreOutput {
+    fn to_json(&self) -> serde_json::Value {
+        match self {
+            MigrateStoreOutput::DryRun(plan) => {
+                <crate::ui::DryRunPlan as crate::ui::CliOutput>::to_json(plan)
+            }
+            MigrateStoreOutput::Exported { from, to, objects } => serde_json::json!({
+                "phase": "export", "from": from, "to": to, "objects": objects,
+            }),
+            MigrateStoreOutput::Imported {
+                store,
+                objects,
+                missing,
+                added,
+                staging_kept,
+            } => serde_json::json!({
+                "phase": "import",
+                "store": store,
+                "objects": objects,
+                "missing": missing,
+                "added": added,
+                "verified": missing.is_empty(),
+                "staging_kept": staging_kept,
+            }),
+        }
+    }
+
+    fn render(&self, ui: &crate::ui::Ui) {
+        match self {
+            MigrateStoreOutput::DryRun(plan) => {
+                <crate::ui::DryRunPlan as crate::ui::CliOutput>::render(plan, ui)
+            }
+            MigrateStoreOutput::Exported { from, to, objects } => {
+                ui.payload_plain(&format!("staged {objects} object(s) from {from}"));
+                ui.note(&format!(
+                    "now upgrade the release (the store becomes {to}), then run \
+                     `curie cluster migrate-store --phase import`. The staging pod holds \
+                     the only copy until then -- do not delete it."
+                ));
+            }
+            MigrateStoreOutput::Imported {
+                store,
+                objects,
+                missing,
+                added,
+                staging_kept,
+            } => {
+                ui.payload_plain(&format!("imported {objects} object(s) into {store}"));
+                if !added.is_empty() {
+                    ui.payload_plain(&format!(
+                        "{} object(s) appeared during the migration (a deploy landed \
+                         mid-flight); not a loss",
+                        added.len()
+                    ));
+                }
+                if missing.is_empty() {
+                    ui.payload_plain("verified: every staged object is present at the same size");
+                } else {
+                    ui.payload_plain(&format!("MISSING {} object(s):", missing.len()));
+                    for k in missing {
+                        ui.payload_plain(&format!("  {k}"));
+                    }
+                }
+                if *staging_kept {
+                    ui.note("staging pod kept; delete it once a real turn has succeeded.");
+                }
+            }
+        }
+    }
+}
+
+/// Phase one: stage every object while the old store is still up.
+pub async fn run_export(o: &CommonOpts, chart: &str, bucket: &str) -> Result<MigrateStoreOutput> {
+    let live: Vec<String> = crate::ops::live_stateful_components(o)
+        .await?
+        .into_iter()
+        .map(|(component, _)| component)
+        .collect();
+    let rendered = crate::ops::chart_stateful_components(chart, o, &[]).await?;
+    let (from, to) = ensure_migratable(&plan(&live, &rendered)?)?;
+
+    let image = "amazon/aws-cli:2.32.6";
+    let secret = format!("{}-secrets", o.release);
+    if o.dry_run {
+        let endpoint = endpoint_for("<store-service>", &o.namespace);
+        let cmds = [
+            store_service_cmd(o, from),
+            delete_staging_pod_cmd(o),
+            create_staging_pod_cmd(o, image, &secret),
+            export_cmd(o, from, bucket, &endpoint),
+            staged_count_cmd(o),
+        ];
+        return Ok(MigrateStoreOutput::DryRun(crate::ui::DryRunPlan {
+            lines: cmds.iter().map(|c| c.display()).collect(),
+        }));
+    }
+
+    let (ok, service, err) = crate::ops::run_capture(&store_service_cmd(o, from)).await?;
+    let service = service.trim().to_string();
+    if !ok || service.is_empty() {
+        bail!(
+            "could not find the {} Service to copy from: {err}",
+            from.suffix()
+        );
+    }
+    let endpoint = endpoint_for(&service, &o.namespace);
+
+    crate::ops::run_capture(&delete_staging_pod_cmd(o))
+        .await
+        .ok();
+    let (ok, _, err) = crate::ops::run_capture(&create_staging_pod_cmd(o, image, &secret)).await?;
+    if !ok {
+        bail!("could not create the staging pod: {err}");
+    }
+    let (ok, _, err) = crate::ops::run_capture(&wait_ready_cmd(o)).await?;
+    if !ok {
+        bail!("the staging pod never became ready: {err}");
+    }
+    let (ok, _, err) = crate::ops::run_capture(&export_cmd(o, from, bucket, &endpoint)).await?;
+    if !ok {
+        bail!("the export copy failed; the old store is untouched: {err}");
+    }
+    let (_, count, _) = crate::ops::run_capture(&staged_count_cmd(o)).await?;
+    let objects: usize = count.trim().parse().unwrap_or(0);
+    if objects == 0 {
+        bail!(
+            "staged 0 objects from {}. Refusing to call that a successful export -- \
+             upgrading now would leave the new store empty. Check --bucket (currently \
+             {bucket}) and the store credentials.",
+            from.suffix()
+        );
+    }
+    Ok(MigrateStoreOutput::Exported {
+        from: from.suffix().to_string(),
+        to: to.suffix().to_string(),
+        objects,
+    })
+}
+
+/// `kubectl wait` for the staging pod, so the exec cannot race pod startup.
+pub fn wait_ready_cmd(o: &CommonOpts) -> OpsCommand {
+    OpsCommand::new(
+        "kubectl",
+        vec![
+            plain("wait"),
+            plain("-n"),
+            plain(&o.namespace),
+            plain(format!("pod/{}", staging_pod(&o.release))),
+            plain("--for=condition=Ready"),
+            plain("--timeout=180s"),
+        ],
+    )
+}
+
+/// Phase two: load the staged objects into the new store and verify per object.
+pub async fn run_import(
+    o: &CommonOpts,
+    bucket: &str,
+    keep_staging: bool,
+) -> Result<MigrateStoreOutput> {
+    let live: Vec<String> = crate::ops::live_stateful_components(o)
+        .await?
+        .into_iter()
+        .map(|(component, _)| component)
+        .collect();
+    let to = detect_store(&live).ok_or_else(|| {
+        anyhow::anyhow!(
+            "no object store StatefulSet in the release. Run the upgrade before \
+             `--phase import`."
+        )
+    })?;
+
+    if o.dry_run {
+        let endpoint = endpoint_for("<store-service>", &o.namespace);
+        let cmds = [
+            store_service_cmd(o, to),
+            staged_listing_cmd(o),
+            import_cmd(o, to, bucket, &endpoint),
+            store_listing_cmd(o, to, bucket, &endpoint),
+            delete_staging_pod_cmd(o),
+        ];
+        return Ok(MigrateStoreOutput::DryRun(crate::ui::DryRunPlan {
+            lines: cmds.iter().map(|c| c.display()).collect(),
+        }));
+    }
+
+    let (ok, service, err) = crate::ops::run_capture(&store_service_cmd(o, to)).await?;
+    let service = service.trim().to_string();
+    if !ok || service.is_empty() {
+        bail!(
+            "could not find the {} Service to copy into: {err}",
+            to.suffix()
+        );
+    }
+    let endpoint = endpoint_for(&service, &o.namespace);
+
+    let (ok, staged, err) = crate::ops::run_capture(&staged_listing_cmd(o)).await?;
+    if !ok {
+        bail!(
+            "could not read the staging pod. `--phase export` must run before \
+             `--phase import`, and its pod must still exist: {err}"
+        );
+    }
+    if staged.trim().is_empty() {
+        bail!("the staging pod holds no objects; nothing to import");
+    }
+    let (ok, _, err) = crate::ops::run_capture(&import_cmd(o, to, bucket, &endpoint)).await?;
+    if !ok {
+        bail!("the import copy failed; the staged copy is intact, so retry is safe: {err}");
+    }
+    let (_, listing, _) =
+        crate::ops::run_capture(&store_listing_cmd(o, to, bucket, &endpoint)).await?;
+
+    let missing = missing_after(&staged, &listing);
+    let added = added_after(&staged, &listing);
+    let objects = listing.lines().filter(|l| !l.trim().is_empty()).count();
+
+    // Keep the staging pod whenever anything is missing: it holds the only
+    // remaining copy, and deleting it would turn a recoverable partial import
+    // into permanent loss.
+    let kept = keep_staging || !missing.is_empty();
+    if !kept {
+        crate::ops::run_capture(&delete_staging_pod_cmd(o))
+            .await
+            .ok();
+    }
+    Ok(MigrateStoreOutput::Imported {
+        store: to.suffix().to_string(),
+        objects,
+        missing,
+        added,
+        staging_kept: kept,
+    })
+}

--- a/cli/tests/cli_output_variants.rs
+++ b/cli/tests/cli_output_variants.rs
@@ -46,6 +46,7 @@ use curie::local::{
     LocalDownOutput, LocalRebuildOutput, LocalStatusOutput, LocalUpOutput, ModelMode,
 };
 use curie::message::MessageOutcomeOutput;
+use curie::migrate_store::MigrateStoreOutput;
 use curie::observability::{Endpoint, ObservabilityOutput};
 use curie::ops::{ClusterDownOutput, ClusterStatus, ClusterStatusOutput, ClusterUpOutput};
 use curie::ui::{CliOutput, DryRunPlan};
@@ -304,6 +305,24 @@ fn registry() -> BTreeMap<&'static str, Vec<VariantJson>> {
                 namespace: "acme-bot".to_string(),
                 release: "acme-bot".to_string(),
                 comms: true,
+            },
+        ],
+    );
+    m.insert(
+        "MigrateStoreOutput",
+        samples![
+            "DryRun" => MigrateStoreOutput::DryRun(plan()),
+            "Exported" => MigrateStoreOutput::Exported {
+                from: "minio".to_string(),
+                to: "rustfs".to_string(),
+                objects: 22,
+            },
+            "Imported" => MigrateStoreOutput::Imported {
+                store: "rustfs".to_string(),
+                objects: 23,
+                missing: vec![],
+                added: vec!["bundles/x/new.tar".to_string()],
+                staging_kept: false,
             },
         ],
     );

--- a/cli/tests/json_emit_contract.rs
+++ b/cli/tests/json_emit_contract.rs
@@ -40,6 +40,12 @@ fn manifest() -> serde_json::Value {
 fn placeholder(id: &str) -> &'static str {
     match id {
         "limit" => "1",
+        // `migrate-store --phase` restricts its values, so the generic "x" is
+        // rejected by clap before the verb reaches its dry-run branch -- which
+        // would fail this gate on an argument-parsing error rather than on the
+        // empty-stdout bug it exists to catch. Any arg with a value_parser
+        // enumeration needs a real value here.
+        "phase" => "export",
         _ => "x",
     }
 }

--- a/docs/interfaces/cli-output/INTERFACE.md
+++ b/docs/interfaces/cli-output/INTERFACE.md
@@ -92,9 +92,9 @@ Nine, all in the CLI crate:
   syntactic call-site inventory, not a type-level proof that *every* verb returns
   a `CliOutput`.
 - **Committed JSON Schemas with a drift gate (since #841).** Each `to_json` is no
-  longer schema-free: there are 35 committed schemas under `cli/schema/` with an
+  longer schema-free: there are 36 committed schemas under `cli/schema/` with an
   index (`cli/schema/index.json`), a `syn`-based inventory gate over every `impl
-  CliOutput`, and per-family output validation — all 35 are validated against real
+  CliOutput`, and per-family output validation — all 36 are validated against real
   `to_json()` output across 57 tests in `cli/tests/json_contract.rs`. Those tests
   drive each output type's `to_json()` once per output variant rather than calling
   the pure builder functions behind it, so a variant whose `to_json()` arm drifts


### PR DESCRIPTION
Closes #1324 (the tooling half; #1330 documented it).

The repo's own rule is that tooling ships as a `curie` subcommand rather than a documented sequence of raw commands. #1330 gave operators a procedure they can get wrong halfway; this makes it a verb that refuses to.

## The design problem

The two stores **never coexist** — one chart renders one of them — so the objects have to survive outside both across the upgrade.

They live in a **staging pod**: a plain `kubectl run` pod on the same `aws-cli` image the chart's bundle-fetch already uses, holding them in an `emptyDir`. **Helm doesn't own that pod**, so the upgrade leaves it alone. No PVC, no manifests, no new dependency.

```bash
curie cluster migrate-store --phase export   # before the upgrade
curie apply -f curie.yaml                    # or helm upgrade
curie cluster migrate-store --phase import   # after
```

## What makes it refuse rather than half-work

| situation | behaviour |
|---|---|
| target chart renders the same store | export refuses — "nothing to migrate" |
| export stages **zero** objects | refuses; upgrading on that would empty the store |
| import with no staging pod | refuses — export must run first |
| import finds objects missing | staging pod **retained** regardless of `--keep-staging` |

That last one matters: when anything is missing the staged copy is the only other one, so deleting it would turn a recoverable partial import into permanent loss.

## Two things learned the hard way today

**Detection is keyed on `app.kubernetes.io/component`**, matching #1321's guard — and the endpoint comes from the Service the chart *actually created*, not a constructed `<release>-<store>` name. My first draft constructed it, which `nameOverride` would have broken by aiming the copy at a Service that doesn't exist. #1321's merged version had already learned this; I aligned rather than duplicating.

**Verification is per object, not by count.** The real migration this came from staged 22 and found 23 afterwards — a deploy landed mid-flight and wrote straight to the new store. Counts and byte totals can't tell that from loss; a name-and-size diff can. A size change on the same key counts as missing, so a truncated copy can't pass.

## Security

No S3 client in the CLI — every transfer is `kubectl exec` running `aws` inside the staging pod. The store password is read **in-pod** from the mounted release Secret, so it never reaches argv, `ps`, shell history, or a printed dry-run plan. A test asserts every generated command reads `/secret/` and carries no credential.

## Verification

14 unit tests on the pure core: store detection, the plan, argv shape, endpoint construction, credential absence, and every branch of the object diff.

**Falsified:** disabling the nothing-to-migrate branch fails `an_unchanged_store_needs_no_migration`; treating a size change as a match fails `a_resized_object_counts_as_missing`.

`fmt`, `clippy --all-targets -D warnings`, 38 suites, `check-docs.sh`, command manifest and schema inventory all pass.

## Not verified

**This has not run against a live rename.** The only cluster in that state was migrated by hand earlier today, so the execution path — the kubectl round trips — is unexercised. The plan, the argv, and the verification logic are covered; the wiring between them is not.

Given that every real bug in this area came from running against a cluster rather than from tests, I'd treat that as a genuine gap rather than a formality. It's still worth landing: today there is no verb at all, and the alternative is the hand-run procedure.