### PR TITLE
Let an operator put a cleared override back on the platform default

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -227,7 +227,7 @@
         "type": "object"
       },
       "AgentUpdate": {
-        "description": "Partial update of mutable agent fields. An omitted field is unchanged.\n\nThe repo binding stopped being identity in ADR-0091: one repository builds\nmany agents now, so binding is a routing fact, not a name.",
+        "description": "Partial update of mutable agent fields. An omitted field is unchanged.\n\nFor the two nullable operator overrides -- `model` and `thinking` -- omitted\nand explicit JSON null are DIFFERENT requests, and the router tells them\napart with `model_fields_set` (#1310). Omitted leaves the current value;\nexplicit null clears the override back to the platform default. Reading\n`None` alone cannot distinguish the two, which is why setting one of these\nused to be a one-way door.\n\nThe repo binding stopped being identity in ADR-0091: one repository builds\nmany agents now, so binding is a routing fact, not a name.",
         "properties": {
           "approval_required_tools": {
             "anyOf": [

--- a/apps/api/src/curie_api/routers/agents.py
+++ b/apps/api/src/curie_api/routers/agents.py
@@ -152,9 +152,17 @@ async def update_agent(agent_id: uuid.UUID, data: AgentUpdate, session: SessionD
                 raise
             status_code, message = classified
             raise HTTPException(status_code, message) from exc
-    if data.model is not None:
+    # Presence, not truthiness (#1310). `is not None` conflates "the client did
+    # not mention this field" with "the client explicitly sent null", so setting
+    # either override used to be a one-way door: nothing could put it back to the
+    # platform default. `model_fields_set` carries exactly the keys the request
+    # actually contained, which is the distinction the API's own semantics rest
+    # on. Both nullable overrides get it -- they are the same seam, and fixing
+    # one beside the other would leave the sibling broken on an adjacent line.
+    sent = data.model_fields_set
+    if "model" in sent:
         agent = await crud.update_agent_model(session, agent, data.model)
-    if data.thinking is not None:
+    if "thinking" in sent:
         agent = await crud.update_agent_thinking(session, agent, data.thinking)
     if data.approval_required_tools is not None:
         # Omitted leaves the gates unchanged; an explicit [] clears them (#245).

--- a/apps/api/src/curie_api/schemas.py
+++ b/apps/api/src/curie_api/schemas.py
@@ -41,6 +41,34 @@ _SLACK_USERGROUP_ID = re.compile(r"^S[A-Z0-9]{7,}$")
 _SLACK_USER_ID = re.compile(r"^[UW][A-Z0-9]{7,}$")
 
 
+def _validate_thinking_override(value: str | None) -> str | None:
+    """Refuse an empty thinking override (#1310).
+
+    Empty is not a third way to say "no override". It reaches the worker as a
+    falsy value, which emits no boot key at all -- so it selects the MODEL's own
+    default and silently skips the platform default an operator configured, the
+    opposite of what someone typing `""` to clear a value expects. Explicit JSON
+    null is the reset, and the error says so.
+
+    None passes through: on PATCH that is the clear, on create it is "no
+    override". The vocabulary itself (`disabled`/`adaptive`/`enabled:<n>`) is
+    deliberately NOT checked here -- it belongs to the runner
+    (`curie_runner.thinking`), the same division `model` already has, so that
+    swapping the harness is not a schema change.
+    """
+    if value is None:
+        return value
+    if not value.strip():
+        raise ValueError(
+            "thinking must not be empty: an empty value skips the platform "
+            "default and selects the model's own behavior, which is not what "
+            "clearing means. Send null to clear the override back to the "
+            "platform default, or a value like 'disabled', 'adaptive' or "
+            "'enabled:2000'."
+        )
+    return value
+
+
 def _validate_slack_channel_id(value: str | None) -> str | None:
     """Enforce a Slack channel-ID shape on a binding. Slack events carry the
     channel ID (e.g. C0123ABCD) and the worker routes on it, so a #name or
@@ -352,6 +380,7 @@ class AgentCreate(BaseModel):
     # sandbox by the worker binding. None means no connector secrets.
     secrets: dict[str, str] | None = None
 
+    _check_thinking = field_validator("thinking")(_validate_thinking_override)
     _check_slack_channel = field_validator("slack_channel")(_validate_slack_channel_id)
     _check_approval_tools = field_validator("approval_required_tools")(_validate_tool_names)
     _check_approval_routes = field_validator("approval_routes")(_validate_route_names)
@@ -361,16 +390,24 @@ class AgentCreate(BaseModel):
 class AgentUpdate(BaseModel):
     """Partial update of mutable agent fields. An omitted field is unchanged.
 
+    For the two nullable operator overrides -- `model` and `thinking` -- omitted
+    and explicit JSON null are DIFFERENT requests, and the router tells them
+    apart with `model_fields_set` (#1310). Omitted leaves the current value;
+    explicit null clears the override back to the platform default. Reading
+    `None` alone cannot distinguish the two, which is why setting one of these
+    used to be a one-way door.
+
     The repo binding stopped being identity in ADR-0091: one repository builds
     many agents now, so binding is a routing fact, not a name.
     """
 
     slack_channel: str | None = None
-    # New per-agent model id (#254). Omitted (None) leaves the current model
-    # unchanged, matching the slack_channel convention.
+    # New per-agent model id (#254). OMITTED leaves the current model unchanged;
+    # explicit null clears it back to the platform default (#1310).
     model: str | None = None
-    # New per-agent thinking depth (#1182). Omitted (None) leaves the current
-    # value unchanged, the same convention as `model` above.
+    # New per-agent thinking depth (#1182, ADR-0098). Same three-way semantics as
+    # `model` above: omitted is unchanged, explicit null clears to the platform
+    # default.
     thinking: str | None = None
     # New permission gates (#245). Omitted (None) leaves the current gates
     # unchanged; an explicit empty list clears them.
@@ -388,6 +425,7 @@ class AgentUpdate(BaseModel):
     # agent and a target naming it is rejected as unknown.
     repo_full_name: str | None = None
 
+    _check_thinking = field_validator("thinking")(_validate_thinking_override)
     _check_slack_channel = field_validator("slack_channel")(_validate_slack_channel_id)
     _check_approval_tools = field_validator("approval_required_tools")(_validate_tool_names)
     _check_approval_routes = field_validator("approval_routes")(_validate_route_names)

--- a/apps/api/tests/test_agent_thinking_integration.py
+++ b/apps/api/tests/test_agent_thinking_integration.py
@@ -83,3 +83,99 @@ def test_the_api_stores_the_value_verbatim_and_does_not_validate_it(
     # provider accepts either).
     agent = _create_agent(client, auth_headers, thinking="not-a-real-value")
     assert agent["thinking"] == "not-a-real-value"
+
+
+# --- clearing the override back to the platform default (#1310) ---------------
+# The distinction these pin is not cosmetic: before this, setting `thinking` was
+# a one-way door. PATCH with null "succeeded" and changed nothing, so an operator
+# who pinned an agent to `disabled` had no way, through the API, to put it back
+# on the platform default.
+
+
+def test_patch_with_explicit_null_clears_the_override(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    agent = _create_agent(client, auth_headers, thinking="disabled")
+    assert agent["thinking"] == "disabled"
+
+    resp = client.patch(
+        f"/agents/{agent['id']}",
+        json={"thinking": None},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["thinking"] is None, "explicit null must clear the override"
+
+    # And it is durable, not just echoed back by the write response.
+    resp = client.get(f"/agents/{agent['id']}", headers=auth_headers)
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["thinking"] is None
+
+
+def test_omitting_thinking_still_leaves_it_untouched(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    # The other half of the distinction. If this regressed, every PATCH that
+    # renamed a channel would silently wipe the agent's thinking depth.
+    agent = _create_agent(client, auth_headers, thinking="adaptive")
+    resp = client.patch(
+        f"/agents/{agent['id']}",
+        json={"slack_channel": "CTHINK009"},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["thinking"] == "adaptive"
+
+
+def test_the_model_override_clears_the_same_way(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    # `model` is the same seam with the same defect; fixing thinking beside it
+    # and leaving this broken on an adjacent line is the drift the repo's
+    # parity-seam rule exists to stop.
+    agent = _create_agent(client, auth_headers, model="glm-5.2")
+    assert agent["model"] == "glm-5.2"
+
+    resp = client.patch(
+        f"/agents/{agent['id']}", json={"model": None}, headers=auth_headers
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["model"] is None
+
+    # Omission still leaves it alone.
+    agent2 = _create_agent(
+        client, auth_headers, name="model-untouched", slack_channel="CTHINK010",
+        model="kimi-k2.1",
+    )
+    resp = client.patch(
+        f"/agents/{agent2['id']}", json={"thinking": "adaptive"}, headers=auth_headers
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["model"] == "kimi-k2.1"
+
+
+def test_an_empty_thinking_is_refused_and_the_error_points_at_null(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    # An empty string is NOT an alternate reset: it reaches the worker falsy, so
+    # no boot key is emitted at all and the MODEL's default wins -- silently
+    # skipping the platform default the operator configured. Refuse it, and say
+    # what to send instead.
+    agent = _create_agent(client, auth_headers, thinking="adaptive")
+    resp = client.patch(
+        f"/agents/{agent['id']}", json={"thinking": ""}, headers=auth_headers
+    )
+    assert resp.status_code == 422, resp.text
+    assert "null" in resp.text, f"the error must point at the real reset: {resp.text}"
+
+    # And the refusal left the stored value alone.
+    resp = client.get(f"/agents/{agent['id']}", headers=auth_headers)
+    assert resp.json()["thinking"] == "adaptive"
+
+    # Create is refused identically -- same field, same nonsense, same answer.
+    resp = client.post(
+        "/agents",
+        json={"name": "empty-thinking", "slack_channel": "CTHINK011", "thinking": "   "},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 422, resp.text


### PR DESCRIPTION
Closes #1310.

## The one-way door

```python
if data.thinking is not None:      # ← cannot tell omitted from explicit null
```

Pydantic keeps that distinction; the router threw it away. So `PATCH {"thinking": null}` returned **200, changed nothing**, and an agent pinned to `disabled` had no route back to the platform default through the API at all.

`model_fields_set` carries exactly the keys the request contained, which is the question the API's semantics actually rest on:

```python
sent = data.model_fields_set
if "thinking" in sent:
    agent = await crud.update_agent_thinking(session, agent, data.thinking)
```

## `model` is fixed too, deliberately

The identical defect sat on the **adjacent line**. Repairing one nullable override and leaving its twin broken two lines away is exactly the sibling-path drift AGENTS.md's parity-seam rule exists to stop, and the fix is the same predicate. Covered by its own test.

## Empty string is refused

It *looks* like a third way to clear, and it is the opposite of one: empty reaches the worker falsy, so **no boot key is emitted at all** and the model's own default wins — silently skipping the platform default the operator configured. The error names the real reset:

```
thinking must not be empty: an empty value skips the platform default and selects
the model's own behavior, which is not what clearing means. Send null to clear the
override back to the platform default, or a value like 'disabled', 'adaptive' or
'enabled:2000'.
```

Applied to create as well as PATCH — same field, same nonsense, same answer.

The **vocabulary** stays unchecked here on purpose. `disabled` / `adaptive` / `enabled:<n>` belongs to the runner (`curie_runner.thinking`), the same division `model` already has with its provider, so swapping the harness is not a schema change.

## Acceptance criteria

| # | criterion | where |
|---|---|---|
| 1 | explicit null stores NULL and returns null | `test_patch_with_explicit_null_clears_the_override` — also re-reads via GET, so it is durable and not just echoed |
| 2 | omission leaves the value unchanged | `test_omitting_thinking_still_leaves_it_untouched` |
| 3 | a cleared agent inherits `CURIE_THINKING` | NULL → `resolved.thinking is None` → `apply_model_env` falls to `config.thinking`; pinned by the existing `test_thinking_platform_default_is_forwarded` and `test_boot_env_applies_the_same_precedence_on_the_runs_lane` |
| 4 | a cleared agent emits no key when no platform default | same two tests' first case (`THINKING_ENV not in env`) |
| 5 | real-Postgres coverage of set / null / omission / returned values | this file, all against the compose Postgres |
| 6 | empty string rejected or distinct | **rejected**, `test_an_empty_thinking_is_refused_and_the_error_points_at_null` |

3 and 4 are the worker's behavior and were already pinned by #1303's tests; I re-read them rather than duplicating, since the API change here only has to produce NULL for them to hold.

## Proof

Both halves reverted in turn:

| reverted | fails |
|---|---|
| router back to `is not None` | `test_patch_with_explicit_null_clears_the_override`, `test_the_model_override_clears_the_same_way` |
| the empty-string validator removed | `test_an_empty_thinking_is_refused_and_the_error_points_at_null` |

Gates: `ruff check .`, `mypy` (177 files), regenerated `openapi.json` (one line), `pytest apps/api/tests apps/worker/tests` → **1258 passed**.

Nine failures remain and are **unchanged from main** — compared FAILED-for-FAILED with the branch stashed and the two lists are byte-identical (the Langfuse-backed cost test and eight eval-stream tests, all needing services this machine did not have up).
