### PR TITLE
Make `migrate-store` one command, not a four-step procedure

### DIFF
--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -1978,7 +1978,7 @@ export const commandManifest = {
           "args": [
             {
               "global": false,
-              "help": "`export` before the upgrade, `import` after it",
+              "help": "Run only one half. Omit for the whole migration -- export, upgrade, import and verify -- which is the safe default: the halfway state is an empty store, and that stops the bot answering. The split phases exist for recovery, when an upgrade already happened or a run was interrupted",
               "id": "phase",
               "long": "phase",
               "positional": false,
@@ -1986,7 +1986,7 @@ export const commandManifest = {
                 "export",
                 "import"
               ],
-              "required": true
+              "required": false
             },
             {
               "default_values": [
@@ -2055,7 +2055,7 @@ export const commandManifest = {
             }
           ],
           "hidden": false,
-          "long_about": "Carry bundle objects across a chart upgrade that renames the object store (issue #1324).\n\nChart 0.6.0 renamed the in-cluster store from `minio` to `rustfs`. Helm does a full upgrade, so the old StatefulSet -- and the bundles in it -- are deleted. Every sandbox downloads its bundle from that store at start, so an empty one stops the bot answering rather than merely breaking rollbacks.\n\nThe two stores never coexist, so this runs in two phases around the upgrade, holding the objects in a staging pod Helm does not own:\n\ncurie cluster migrate-store --phase export   # before the upgrade curie apply -f curie.yaml                    # or helm upgrade curie cluster migrate-store --phase import   # after\n\nEach phase refuses when its precondition is unmet, and `import` verifies per object rather than by count -- a concurrent push can legitimately add one mid-migration, and only a per-object diff tells that from data loss.",
+          "long_about": "Carry bundle objects across a chart upgrade that renames the object store (issue #1324).\n\nChart 0.6.0 renamed the in-cluster store from `minio` to `rustfs`. Helm does a full upgrade, so the old StatefulSet -- and the bundles in it -- are deleted. Every sandbox downloads its bundle from that store at start, so an empty one stops the bot answering rather than merely breaking rollbacks.\n\nOne command does the whole thing:\n\ncurie cluster migrate-store\n\nIt stages every object into a pod Helm does not own, upgrades the release, loads them into the new store, and verifies per object -- a concurrent push can legitimately add one mid-migration, and only a per-object diff tells that from data loss.\n\nRunning it as one operation is the safe default because the halfway state is an empty store, which stops the bot answering. It also means no `--allow-stateful-removal`: that override exists so a human confirms the data is safe, and here the command staged it itself moments earlier.\n\n`--phase export` / `--phase import` run a single half, for recovery when an upgrade already happened or a run was interrupted.",
           "name": "migrate-store"
         },
         {

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -1975,7 +1975,7 @@
           "args": [
             {
               "global": false,
-              "help": "`export` before the upgrade, `import` after it",
+              "help": "Run only one half. Omit for the whole migration -- export, upgrade, import and verify -- which is the safe default: the halfway state is an empty store, and that stops the bot answering. The split phases exist for recovery, when an upgrade already happened or a run was interrupted",
               "id": "phase",
               "long": "phase",
               "positional": false,
@@ -1983,7 +1983,7 @@
                 "export",
                 "import"
               ],
-              "required": true
+              "required": false
             },
             {
               "default_values": [
@@ -2052,7 +2052,7 @@
             }
           ],
           "hidden": false,
-          "long_about": "Carry bundle objects across a chart upgrade that renames the object store (issue #1324).\n\nChart 0.6.0 renamed the in-cluster store from `minio` to `rustfs`. Helm does a full upgrade, so the old StatefulSet -- and the bundles in it -- are deleted. Every sandbox downloads its bundle from that store at start, so an empty one stops the bot answering rather than merely breaking rollbacks.\n\nThe two stores never coexist, so this runs in two phases around the upgrade, holding the objects in a staging pod Helm does not own:\n\ncurie cluster migrate-store --phase export   # before the upgrade curie apply -f curie.yaml                    # or helm upgrade curie cluster migrate-store --phase import   # after\n\nEach phase refuses when its precondition is unmet, and `import` verifies per object rather than by count -- a concurrent push can legitimately add one mid-migration, and only a per-object diff tells that from data loss.",
+          "long_about": "Carry bundle objects across a chart upgrade that renames the object store (issue #1324).\n\nChart 0.6.0 renamed the in-cluster store from `minio` to `rustfs`. Helm does a full upgrade, so the old StatefulSet -- and the bundles in it -- are deleted. Every sandbox downloads its bundle from that store at start, so an empty one stops the bot answering rather than merely breaking rollbacks.\n\nOne command does the whole thing:\n\ncurie cluster migrate-store\n\nIt stages every object into a pod Helm does not own, upgrades the release, loads them into the new store, and verifies per object -- a concurrent push can legitimately add one mid-migration, and only a per-object diff tells that from data loss.\n\nRunning it as one operation is the safe default because the halfway state is an empty store, which stops the bot answering. It also means no `--allow-stateful-removal`: that override exists so a human confirms the data is safe, and here the command staged it itself moments earlier.\n\n`--phase export` / `--phase import` run a single half, for recovery when an upgrade already happened or a run was interrupted.",
           "name": "migrate-store"
         },
         {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1272,20 +1272,30 @@ enum ClusterAction {
     /// start, so an empty one stops the bot answering rather than merely
     /// breaking rollbacks.
     ///
-    /// The two stores never coexist, so this runs in two phases around the
-    /// upgrade, holding the objects in a staging pod Helm does not own:
+    /// One command does the whole thing:
     ///
-    ///   curie cluster migrate-store --phase export   # before the upgrade
-    ///   curie apply -f curie.yaml                    # or helm upgrade
-    ///   curie cluster migrate-store --phase import   # after
+    ///   curie cluster migrate-store
     ///
-    /// Each phase refuses when its precondition is unmet, and `import` verifies
-    /// per object rather than by count -- a concurrent push can legitimately add
-    /// one mid-migration, and only a per-object diff tells that from data loss.
+    /// It stages every object into a pod Helm does not own, upgrades the
+    /// release, loads them into the new store, and verifies per object -- a
+    /// concurrent push can legitimately add one mid-migration, and only a
+    /// per-object diff tells that from data loss.
+    ///
+    /// Running it as one operation is the safe default because the halfway
+    /// state is an empty store, which stops the bot answering. It also means no
+    /// `--allow-stateful-removal`: that override exists so a human confirms the
+    /// data is safe, and here the command staged it itself moments earlier.
+    ///
+    /// `--phase export` / `--phase import` run a single half, for recovery when
+    /// an upgrade already happened or a run was interrupted.
     MigrateStore {
-        /// `export` before the upgrade, `import` after it.
+        /// Run only one half. Omit for the whole migration -- export, upgrade,
+        /// import and verify -- which is the safe default: the halfway state is
+        /// an empty store, and that stops the bot answering. The split phases
+        /// exist for recovery, when an upgrade already happened or a run was
+        /// interrupted.
         #[arg(long, value_parser = ["export", "import"])]
-        phase: String,
+        phase: Option<String>,
         /// Kubernetes namespace.
         #[arg(long, default_value = "curie")]
         namespace: String,
@@ -2499,18 +2509,23 @@ async fn run(command: Option<Command>) -> Result<()> {
                     release,
                     dry_run,
                 };
-                let out = if phase == "export" {
-                    let resolved = artifacts::resolve_chart(
-                        chart.as_deref(),
-                        artifacts::Channel::current(),
-                        artifacts::version(),
-                        artifacts::cache_root,
-                        std::path::Path::new("charts/curie").is_dir(),
-                    )?;
-                    let chart = materialize_artifact(resolved, dry_run, "chart").await?;
-                    ms::run_export(&common, &chart, &bucket).await?
-                } else {
-                    ms::run_import(&common, &bucket, keep_staging).await?
+                let out = match phase.as_deref() {
+                    Some("import") => ms::run_import(&common, &bucket, keep_staging).await?,
+                    other => {
+                        let resolved = artifacts::resolve_chart(
+                            chart.as_deref(),
+                            artifacts::Channel::current(),
+                            artifacts::version(),
+                            artifacts::cache_root,
+                            std::path::Path::new("charts/curie").is_dir(),
+                        )?;
+                        let chart = materialize_artifact(resolved, dry_run, "chart").await?;
+                        if other == Some("export") {
+                            ms::run_export(&common, &chart, &bucket).await?
+                        } else {
+                            ms::run_auto(&common, &chart, &bucket).await?
+                        }
+                    }
                 };
                 emit(out)
             }

--- a/cli/src/migrate_store.rs
+++ b/cli/src/migrate_store.rs
@@ -786,3 +786,222 @@ pub async fn run_import(
         staging_kept: kept,
     })
 }
+
+// -- one-command path ---------------------------------------------------------
+
+/// `helm get values <release> -n <ns> -o yaml`, the upgrade's whole intent.
+///
+/// A file, never `--reuse-values`: reuse does not merge the NEW chart's
+/// defaults, so a chart that adds a value key fails outright on a nil pointer.
+/// Passing the captured values merges them OVER the new defaults, which also
+/// re-supplies the generated store passwords -- they must be re-passed or the
+/// upgrade rotates them out from under a running database.
+pub fn get_values_cmd(o: &CommonOpts) -> OpsCommand {
+    OpsCommand::new(
+        "helm",
+        vec![
+            plain("get"),
+            plain("values"),
+            plain(&o.release),
+            plain("-n"),
+            plain(&o.namespace),
+            plain("-o"),
+            plain("yaml"),
+        ],
+    )
+}
+
+/// `helm upgrade` with the captured values.
+pub fn upgrade_cmd(o: &CommonOpts, chart: &str, values_path: &str) -> OpsCommand {
+    OpsCommand::new(
+        "helm",
+        vec![
+            plain("upgrade"),
+            plain(&o.release),
+            plain(chart),
+            plain("-n"),
+            plain(&o.namespace),
+            plain("-f"),
+            plain(values_path),
+            plain("--timeout"),
+            plain("10m"),
+        ],
+    )
+}
+
+/// Wait for the new store's StatefulSet to be ready before importing into it.
+pub fn wait_store_cmd(o: &CommonOpts, store: StoreKind) -> OpsCommand {
+    OpsCommand::new(
+        "kubectl",
+        vec![
+            plain("rollout"),
+            plain("status"),
+            plain(format!("statefulset/{}", store.suffix())),
+            plain("-n"),
+            plain(&o.namespace),
+        ],
+    )
+}
+
+/// Write helm values to a fresh 0600 file, created with restrictive permissions
+/// atomically so the secrets inside are never briefly world-readable.
+fn write_private_values(body: &str) -> Result<String> {
+    let mut path = std::env::temp_dir();
+    path.push(format!(
+        "curie-migrate-values-{}.yaml",
+        uuid::Uuid::new_v4()
+    ));
+    let mut opts = std::fs::OpenOptions::new();
+    opts.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        opts.mode(0o600);
+    }
+    let mut file = opts.open(&path)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))?;
+    }
+    use std::io::Write;
+    file.write_all(body.as_bytes())?;
+    Ok(path.to_string_lossy().into_owned())
+}
+
+/// Removes the values file even when the upgrade fails.
+struct ValuesFileCleanup(String);
+
+impl Drop for ValuesFileCleanup {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.0);
+    }
+}
+
+/// Export, upgrade, import and verify as one operation.
+///
+/// The whole point of the verb. Split phases exist for recovery, but a
+/// procedure an operator runs by hand is one they can stop halfway -- and the
+/// halfway state here is an empty store, which stops the bot answering.
+///
+/// This path also removes the need to pass `--allow-stateful-removal`: that
+/// override exists so a human confirms the data is safe, and here the command
+/// staged it itself moments earlier. Making an operator bypass a safety check
+/// as a routine step teaches them to bypass it.
+pub async fn run_auto(o: &CommonOpts, chart: &str, bucket: &str) -> Result<MigrateStoreOutput> {
+    let live: Vec<String> = crate::ops::live_stateful_components(o)
+        .await?
+        .into_iter()
+        .map(|(component, _)| component)
+        .collect();
+    let rendered = crate::ops::chart_stateful_components(chart, o, &[]).await?;
+    let (from, to) = ensure_migratable(&plan(&live, &rendered)?)?;
+
+    let image = "amazon/aws-cli:2.32.6";
+    let secret = format!("{}-secrets", o.release);
+    if o.dry_run {
+        let ep = endpoint_for("<store-service>", &o.namespace);
+        let cmds = [
+            store_service_cmd(o, from),
+            create_staging_pod_cmd(o, image, &secret),
+            export_cmd(o, from, bucket, &ep),
+            get_values_cmd(o),
+            upgrade_cmd(o, chart, "<captured values>"),
+            store_service_cmd(o, to),
+            import_cmd(o, to, bucket, &ep),
+            store_listing_cmd(o, to, bucket, &ep),
+            delete_staging_pod_cmd(o),
+        ];
+        return Ok(MigrateStoreOutput::DryRun(crate::ui::DryRunPlan {
+            lines: cmds.iter().map(|c| c.display()).collect(),
+        }));
+    }
+
+    let ui = crate::ui::ui();
+
+    // 1. Stage, before anything is destroyed.
+    let exported = run_export(o, chart, bucket).await?;
+    let staged = match &exported {
+        MigrateStoreOutput::Exported { objects, .. } => *objects,
+        _ => 0,
+    };
+    ui.note(&format!("staged {staged} object(s) from {}", from.suffix()));
+
+    // 2. Capture whole intent, then upgrade with it.
+    let (ok, values, err) = crate::ops::run_capture(&get_values_cmd(o)).await?;
+    if !ok {
+        bail!("could not read the release's current values: {err}");
+    }
+    // The captured values carry the generated store passwords, so the file gets
+    // the same 0600-at-creation treatment `ops::SecretValuesFileGuard` gives the
+    // model credential, and is removed on the way out.
+    let values_path = write_private_values(&values)?;
+    let _cleanup = ValuesFileCleanup(values_path.clone());
+
+    ui.note("upgrading the release (the staged copy is safe in the staging pod)");
+    let (ok, _, err) = crate::ops::run_capture(&upgrade_cmd(o, chart, &values_path)).await?;
+    if !ok {
+        bail!(
+            "the upgrade failed, so the old store is still in place and nothing was \
+             lost. The staging pod still holds the export; delete it with \
+             `kubectl delete pod {} -n {}` once you have resolved: {err}",
+            staging_pod(&o.release),
+            o.namespace
+        );
+    }
+
+    // 3. Load the staged objects into whatever the upgrade created, and verify.
+    ui.note(&format!("importing into {}", to.suffix()));
+    run_import(o, bucket, false).await
+}
+
+#[cfg(test)]
+mod auto_tests {
+    use super::*;
+
+    fn opts() -> CommonOpts {
+        CommonOpts {
+            namespace: "acme".into(),
+            release: "acme".into(),
+            dry_run: false,
+        }
+    }
+
+    /// The upgrade must pass a values FILE. `--reuse-values` does not merge the
+    /// new chart's defaults, so a chart that adds a value key fails outright --
+    /// which is exactly what a store rename does.
+    #[test]
+    fn the_upgrade_passes_a_values_file_never_reuse_values() {
+        let cmd = upgrade_cmd(&opts(), "/charts/curie", "/tmp/v.yaml");
+        let line = cmd.display();
+        assert!(line.contains("-f /tmp/v.yaml"), "{line}");
+        assert!(
+            !line.contains("--reuse-values"),
+            "reuse-values drops the new chart's defaults: {line}"
+        );
+    }
+
+    /// Captured values carry generated store passwords; the file must not be
+    /// readable by other users, and must not survive the run.
+    #[test]
+    fn the_values_file_is_private_and_removed() {
+        let path = write_private_values("postgres:\n  auth:\n    password: s3cret\n").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+            assert_eq!(
+                mode & 0o777,
+                0o600,
+                "values file must be 0600, got {mode:o}"
+            );
+        }
+        {
+            let _cleanup = ValuesFileCleanup(path.clone());
+        }
+        assert!(
+            !std::path::Path::new(&path).exists(),
+            "the values file must be removed when the run ends"
+        );
+    }
+}


### PR DESCRIPTION
Follow-up to #1333.

## Why

The split phases were still a **procedure an operator runs by hand**, and the halfway state is an empty store — which stops the bot answering, not merely breaking rollbacks. A migration you can stop in the middle is the thing #1324 asked not to build.

**Before** — four steps, and one of them tells you to bypass a safety check:

```bash
curie cluster migrate-store --phase export
curie apply -f curie.yaml --allow-stateful-removal   # ← bypass, as a routine step
curie cluster migrate-store --phase import
```

**After** — one:

```bash
curie cluster migrate-store
```

Stage → upgrade → import → verify. `--phase export` / `--phase import` remain for recovery, when an upgrade already happened or a run was interrupted.

## The habit this fixes

`--allow-stateful-removal` exists so a human confirms the data is safe before a StatefulSet is deleted. Making it step three of the documented happy path trains people to pass it by reflex — which is worse than not having the guard, because it's exactly the flag that protects the one case that's real.

Here the command staged the data itself moments earlier, so it performs the upgrade directly and the override never appears.

## Two details that matter

**The upgrade passes a captured values file, never `--reuse-values`.** Reuse doesn't merge the new chart's defaults, so a chart that *adds* a value key fails outright on a nil pointer — which is precisely what a store rename does. Passing captured values merges them over the new defaults and re-supplies the generated store passwords, which must be re-passed or the upgrade rotates them out from under a running database.

**Those values contain those passwords**, so the file gets the same 0600-at-creation treatment `ops::SecretValuesFileGuard` gives the model credential, and a `Drop` guard removes it even when the upgrade fails.

Failure leaves the old store in place and the staged copy intact — and the error says so, with how to clean up.

## Verification

16 unit tests. **Falsified:** swapping the values file for `--reuse-values` fails `the_upgrade_passes_a_values_file_never_reuse_values`; the 0600/cleanup test fails if either property is dropped.

`fmt`, `clippy --all-targets -D warnings`, 38 suites, `check-docs.sh`, command manifest all pass.

## Unchanged caveat

**Still not run against a live rename.** The only cluster in that state was migrated by hand before any of this existed. The plan, argv, credential handling and verification are tested; the `kubectl`/`helm` round trips are not.