### PR TITLE
Stop ClickHouse from starving the node with its own logs

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -98,6 +98,18 @@ jobs:
           set -euo pipefail
           bash charts/curie/ci/litellm-sidecar-assertions.sh
 
+      # Prove ClickHouse's own telemetry stays bounded: logger at `warning`, the
+      # four firehose system log tables removed, and whatever remains carrying a
+      # TTL. At image defaults ClickHouse logs at `trace` and keeps 30 days of
+      # self-telemetry -- measured at 2.72 GiB against 31 KiB of real Langfuse
+      # data, filling a 3Gi volume in eight days and ending in a merge that
+      # exceeded the memory limit and retried forever, starving the node until
+      # every agent turn escalated as an opaque `runner-error`.
+      - name: helm render assertions (clickhouse self-telemetry)
+        run: |
+          set -euo pipefail
+          bash charts/curie/ci/clickhouse-logging-assertions.sh
+
       # Prove the Langfuse web+worker containers carry a numeric runAsUser
       # alongside runAsNonRoot (issue #351) so the kubelet can verify non-root
       # and the pods actually start on an enforcing cluster.

--- a/charts/curie/ci/clickhouse-logging-assertions.sh
+++ b/charts/curie/ci/clickhouse-logging-assertions.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+#
+# Render-assertion test for the ClickHouse self-telemetry defaults. Proves:
+#
+#   1. DEFAULT render: a config.d overlay ConfigMap exists, sets the logger to
+#      `warning`, and REMOVES text_log/trace_log/metric_log/
+#      asynchronous_metric_log outright.
+#   2. DEFAULT render: the diagnostic tables that remain (query_log, part_log,
+#      error_log) each carry a TTL, so none of them can become the next
+#      text_log.
+#   3. The StatefulSet actually consumes it: a `config` volume, a subPath mount
+#      into config.d, and a checksum annotation so an edit rolls the pod.
+#   4. subPath specifically -- mounting the directory would hide the image's
+#      own docker_related_config.xml.
+#   5. OVERRIDE: `systemLogs.enabled=true` keeps the four tables but TTL-bounds
+#      them rather than leaving them unbounded, and `retentionDays` is honoured.
+#   6. The overlay is well-formed XML in both modes. A malformed config.d file
+#      makes ClickHouse refuse to start, and the render is the only place that
+#      is cheap to catch.
+#   7. `clickhouse.deploy=false` renders nothing, and `persistence.enabled=false`
+#      still gets its `data` emptyDir alongside the new `config` volume.
+#
+# Why this is worth a gate: stock ClickHouse config is sized for a dedicated
+# analytics box, and the chart runs it as an embedded store for kilobytes of
+# Langfuse traces. Left at image defaults it logs at `trace` and retains 30 days
+# of its own telemetry. Measured on a real install: 2.72 GiB of self-telemetry
+# against 31 KiB of Langfuse data, filling a 3Gi volume in eight days, ending in
+# a system.metric_log merge that exceeded the memory limit and was retried
+# forever -- each failure writing a ~4 KiB stack trace into text_log, which then
+# needed merging itself. Daily CPU went 17% -> 98% over eight days with no
+# change in traffic, and every agent turn escalated as an opaque `runner-error`
+# because the sandbox could not win enough CPU to bind its claim inside 90s.
+#
+# A regression here is silent for about a week and then takes the node out, so
+# it is asserted rather than trusted.
+#
+# Runnable locally (from anywhere) and from CI. Fails loudly.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+TPL=templates/clickhouse.yaml
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+DEFAULT="$TMP/default.yaml"
+VERBOSE="$TMP/verbose.yaml"
+NOPERSIST="$TMP/nopersist.yaml"
+OFF="$TMP/off.yaml"
+
+echo "=== Rendering ClickHouse (defaults) ==="
+helm template rel "$CHART" --show-only "$TPL" > "$DEFAULT"
+
+echo "=== Rendering ClickHouse (systemLogs.enabled=true, retentionDays=7) ==="
+helm template rel "$CHART" --show-only "$TPL" \
+  --set clickhouse.systemLogs.enabled=true \
+  --set clickhouse.systemLogs.retentionDays=7 > "$VERBOSE"
+
+echo "=== Rendering ClickHouse (persistence disabled) ==="
+helm template rel "$CHART" --show-only "$TPL" \
+  --set clickhouse.persistence.enabled=false > "$NOPERSIST"
+
+echo "=== Rendering ClickHouse (deploy=false) ==="
+helm template rel "$CHART" --show-only "$TPL" \
+  --set clickhouse.deploy=false > "$OFF" 2>/dev/null || true
+
+# ---------------------------------------------------------------- 1, 2, 4, 6
+python3 - "$DEFAULT" "$VERBOSE" <<'PY'
+import sys, yaml, xml.etree.ElementTree as ET
+
+FIREHOSE = ["text_log", "trace_log", "metric_log", "asynchronous_metric_log"]
+KEEP     = ["query_log", "part_log", "error_log"]
+
+def load(path):
+    docs = [d for d in yaml.safe_load_all(open(path)) if d]
+    cm  = next((d for d in docs if d["kind"] == "ConfigMap"), None)
+    sts = next((d for d in docs if d["kind"] == "StatefulSet"), None)
+    assert cm is not None,  f"{path}: no ClickHouse config ConfigMap rendered"
+    assert sts is not None, f"{path}: no ClickHouse StatefulSet rendered"
+    raw = cm["data"]["curie-logging.xml"]
+    # (6) malformed XML makes the server refuse to start; catch it here.
+    return cm, sts, raw, ET.fromstring(raw)
+
+# --- defaults -------------------------------------------------------------
+_, sts, raw, root = load(sys.argv[1])
+
+level = root.findtext("logger/level")
+assert level == "warning", f"default logger level is {level!r}, expected 'warning'"
+
+for t in FIREHOSE:
+    el = root.find(t)
+    assert el is not None, f"default render does not mention <{t}> at all"
+    assert el.get("remove") == "1", f"<{t}> must be removed by default, got {el.attrib}"
+
+for t in KEEP:
+    ttl = root.findtext(f"{t}/ttl")
+    assert ttl, f"<{t}> is kept but carries no TTL -- it can grow unbounded"
+    assert "DELETE" in ttl, f"<{t}> TTL does not delete: {ttl!r}"
+
+# --- the StatefulSet actually consumes it (3, 4) --------------------------
+tpl = sts["spec"]["template"]
+# `or {}` not `.get(..., {})`: an emptied-out `annotations:` block parses as
+# None, and `in None` raises TypeError instead of failing this assertion.
+ann = tpl["metadata"].get("annotations") or {}
+assert "checksum/config" in ann, "no checksum/config annotation: a config edit would not roll the pod"
+
+vols = {v["name"] for v in tpl["spec"]["volumes"]}
+assert "config" in vols, f"no `config` volume on the pod: {sorted(vols)}"
+
+mounts = {m["name"]: m for m in tpl["spec"]["containers"][0]["volumeMounts"]}
+assert "config" in mounts, "config volume is declared but never mounted"
+cm_mount = mounts["config"]
+assert cm_mount.get("subPath") == "curie-logging.xml", (
+    "config mount must use subPath -- mounting the directory hides the image's "
+    f"own docker_related_config.xml. got: {cm_mount}"
+)
+assert cm_mount["mountPath"].startswith("/etc/clickhouse-server/config.d/"), (
+    f"config must land in config.d to be merged, got {cm_mount['mountPath']}"
+)
+
+# --- override keeps them, but bounded (5) ---------------------------------
+_, _, _, vroot = load(sys.argv[2])
+vlevel = vroot.findtext("logger/level")
+assert vlevel == "warning", f"override render changed the log level to {vlevel!r}"
+for t in FIREHOSE:
+    el = vroot.find(t)
+    assert el is not None and el.get("remove") is None, (
+        f"<{t}> should be present (not removed) when systemLogs.enabled=true"
+    )
+    ttl = vroot.findtext(f"{t}/ttl")
+    assert ttl and "7 DAY" in ttl, (
+        f"<{t}> must honour retentionDays even when enabled; got {ttl!r}"
+    )
+
+print("  logger level, firehose removal, kept-table TTLs, mount + checksum, override: OK")
+PY
+
+# ------------------------------------------------------------------------ 7
+python3 - "$NOPERSIST" <<'PY'
+import sys, yaml
+sts = next(d for d in yaml.safe_load_all(open(sys.argv[1])) if d and d["kind"] == "StatefulSet")
+vols = {v["name"] for v in sts["spec"]["template"]["spec"]["volumes"]}
+assert vols == {"config", "data"}, (
+    f"persistence=false must keep the `data` emptyDir alongside `config`, got {sorted(vols)}"
+)
+assert "volumeClaimTemplates" not in sts["spec"], "persistence=false must not render a PVC"
+print("  persistence=false still gets its data emptyDir: OK")
+PY
+
+if grep -q "kind:" "$OFF" 2>/dev/null; then
+  fail "clickhouse.deploy=false still rendered objects"
+fi
+echo "  clickhouse.deploy=false renders nothing: OK"
+
+echo
+echo "PASS: ClickHouse self-telemetry defaults are bounded."

--- a/charts/curie/ci/clickhouse-logging-assertions.sh
+++ b/charts/curie/ci/clickhouse-logging-assertions.sh
@@ -2,22 +2,32 @@
 #
 # Render-assertion test for the ClickHouse self-telemetry defaults. Proves:
 #
-#   1. DEFAULT render: a config.d overlay ConfigMap exists, sets the logger to
-#      `warning`, and REMOVES text_log/trace_log/metric_log/
-#      asynchronous_metric_log outright.
-#   2. DEFAULT render: the diagnostic tables that remain (query_log, part_log,
-#      error_log) each carry a TTL, so none of them can become the next
-#      text_log.
-#   3. The StatefulSet actually consumes it: a `config` volume, a subPath mount
-#      into config.d, and a checksum annotation so an edit rolls the pod.
-#   4. subPath specifically -- mounting the directory would hide the image's
-#      own docker_related_config.xml.
-#   5. OVERRIDE: `systemLogs.enabled=true` keeps the four tables but TTL-bounds
-#      them rather than leaving them unbounded, and `retentionDays` is honoured.
-#   6. The overlay is well-formed XML in both modes. A malformed config.d file
-#      makes ClickHouse refuse to start, and the render is the only place that
-#      is cheap to catch.
-#   7. `clickhouse.deploy=false` renders nothing, and `persistence.enabled=false`
+#   1. DEFAULT render: a config.d overlay ConfigMap sets the logger to
+#      `warning` AND turns on console logging, because the image logs only to
+#      files under /var/log/clickhouse-server/ -- so without it `kubectl logs`
+#      on the pod is empty and the diagnostics die with the container.
+#   2. text_log is KEPT but level-filtered, not removed. The image ships
+#      <text_log><level>trace</level>, and that level is the actual firehose;
+#      filtering it cuts volume ~4 orders of magnitude while leaving the table
+#      queryable. A queryable text_log is what diagnosed the incident below,
+#      and unlike the log file it outlives the pod.
+#   3. The timer-driven samplers (trace_log, metric_log,
+#      asynchronous_metric_log) ARE removed. They have no level filter, so
+#      on/off is the only lever, and metric_log is the table whose merge wedged.
+#   4. Every surviving table carries a deleting TTL -- including
+#      processors_profile_log, which a live boot revealed the image also
+#      creates and which is easy to miss while it is still small.
+#   5. The StatefulSet actually consumes it: a `config` volume, a subPath mount
+#      into config.d (mounting the directory would hide the image's own
+#      docker_related_config.xml), and a checksum annotation so an edit rolls
+#      the pod rather than leaving the fix un-read by the running server.
+#   6. OVERRIDE: `systemLogs.enabled=true` restores the three samplers, still
+#      TTL-bounded, and `retentionDays` reaches text_log too.
+#   7. The overlay is well-formed XML by ClickHouse's standard, not just
+#      Python's. ElementTree accepts `--` inside a comment; the Poco SAX parser
+#      ClickHouse uses rejects it and the server exits 232 at boot. That exact
+#      mistake was made while developing this change, so it is asserted.
+#   8. `clickhouse.deploy=false` renders nothing, and `persistence.enabled=false`
 #      still gets its `data` emptyDir alongside the new `config` volume.
 #
 # Why this is worth a gate: stock ClickHouse config is sized for a dedicated
@@ -72,8 +82,34 @@ helm template rel "$CHART" --show-only "$TPL" \
 python3 - "$DEFAULT" "$VERBOSE" <<'PY'
 import sys, yaml, xml.etree.ElementTree as ET
 
-FIREHOSE = ["text_log", "trace_log", "metric_log", "asynchronous_metric_log"]
-KEEP     = ["query_log", "part_log", "error_log"]
+import re
+
+# Timer-driven samplers: no level filter exists for them, so on/off is the only
+# lever. metric_log is the table whose merge wedged and started the spiral.
+SAMPLERS = ["trace_log", "metric_log", "asynchronous_metric_log"]
+# Always present, always TTL'd. processors_profile_log is on this list because a
+# live boot showed the image creates it -- easy to miss while it is still small.
+KEEP     = ["query_log", "part_log", "error_log", "processors_profile_log"]
+
+def check_xml(raw, path):
+    """Parse strictly enough to catch what ClickHouse's parser rejects.
+
+    ElementTree is MORE PERMISSIVE than the Poco SAX parser ClickHouse uses. It
+    happily accepts `--` inside an XML comment, which XML forbids and which
+    makes the server exit 232 on boot with:
+
+        Failed to merge config with '...curie-logging.xml': SAXParseException:
+        Invalid token
+
+    That is a total outage from a comment, and it got past an ElementTree-only
+    check during development. Assert it explicitly.
+    """
+    for body in re.findall(r"<!--(.*?)-->", raw, re.S):
+        assert "--" not in body, (
+            f"{path}: '--' inside an XML comment. Legal to ElementTree, fatal to "
+            f"ClickHouse (exit 232 at boot). Offending comment: {body.strip()[:80]!r}"
+        )
+    return ET.fromstring(raw)
 
 def load(path):
     docs = [d for d in yaml.safe_load_all(open(path)) if d]
@@ -82,8 +118,7 @@ def load(path):
     assert cm is not None,  f"{path}: no ClickHouse config ConfigMap rendered"
     assert sts is not None, f"{path}: no ClickHouse StatefulSet rendered"
     raw = cm["data"]["curie-logging.xml"]
-    # (6) malformed XML makes the server refuse to start; catch it here.
-    return cm, sts, raw, ET.fromstring(raw)
+    return cm, sts, raw, check_xml(raw, path)
 
 # --- defaults -------------------------------------------------------------
 _, sts, raw, root = load(sys.argv[1])
@@ -91,14 +126,29 @@ _, sts, raw, root = load(sys.argv[1])
 level = root.findtext("logger/level")
 assert level == "warning", f"default logger level is {level!r}, expected 'warning'"
 
-for t in FIREHOSE:
+# The image logs only to files under /var/log/clickhouse-server/, so without
+# this `kubectl logs` on the pod is empty and the diagnostics die with it.
+assert root.findtext("logger/console") == "1", "logger/console must be on so kubectl logs works"
+
+# text_log is KEPT and level-filtered, not removed: it is the queryable record
+# that diagnosed the incident, and unlike the log file it outlives the pod.
+tl_level = root.findtext("text_log/level")
+assert tl_level == level, (
+    f"text_log level is {tl_level!r} but the logger is {level!r}. The image ships "
+    "<text_log><level>trace</level>, which is the actual firehose; it must be filtered."
+)
+assert root.find("text_log").get("remove") is None, "text_log must be kept, not removed"
+tl_ttl = root.findtext("text_log/ttl")
+assert tl_ttl and "DELETE" in tl_ttl, f"text_log kept without a deleting TTL: {tl_ttl!r}"
+
+for t in SAMPLERS:
     el = root.find(t)
     assert el is not None, f"default render does not mention <{t}> at all"
     assert el.get("remove") == "1", f"<{t}> must be removed by default, got {el.attrib}"
 
 for t in KEEP:
     ttl = root.findtext(f"{t}/ttl")
-    assert ttl, f"<{t}> is kept but carries no TTL -- it can grow unbounded"
+    assert ttl, f"<{t}> is kept but carries no TTL, it can grow unbounded"
     assert "DELETE" in ttl, f"<{t}> TTL does not delete: {ttl!r}"
 
 # --- the StatefulSet actually consumes it (3, 4) --------------------------
@@ -122,11 +172,11 @@ assert cm_mount["mountPath"].startswith("/etc/clickhouse-server/config.d/"), (
     f"config must land in config.d to be merged, got {cm_mount['mountPath']}"
 )
 
-# --- override keeps them, but bounded (5) ---------------------------------
+# --- override keeps the samplers, but bounded (5) -------------------------
 _, _, _, vroot = load(sys.argv[2])
 vlevel = vroot.findtext("logger/level")
 assert vlevel == "warning", f"override render changed the log level to {vlevel!r}"
-for t in FIREHOSE:
+for t in SAMPLERS:
     el = vroot.find(t)
     assert el is not None and el.get("remove") is None, (
         f"<{t}> should be present (not removed) when systemLogs.enabled=true"
@@ -135,8 +185,11 @@ for t in FIREHOSE:
     assert ttl and "7 DAY" in ttl, (
         f"<{t}> must honour retentionDays even when enabled; got {ttl!r}"
     )
+# retentionDays must reach text_log too, not just the opt-in samplers.
+vtl = vroot.findtext("text_log/ttl")
+assert vtl and "7 DAY" in vtl, f"text_log must honour retentionDays; got {vtl!r}"
 
-print("  logger level, firehose removal, kept-table TTLs, mount + checksum, override: OK")
+print("  level+console, text_log filtered & kept, samplers removed, TTLs, mount + checksum, override: OK")
 PY
 
 # ------------------------------------------------------------------------ 7

--- a/charts/curie/templates/clickhouse.yaml
+++ b/charts/curie/templates/clickhouse.yaml
@@ -1,5 +1,50 @@
 {{- if .Values.clickhouse.deploy }}
 apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "curie.fullname" . }}-clickhouse-config
+  labels:
+    {{- include "curie.labels" . | nindent 4 }}
+data:
+  # Overlay merged over the image's config.xml. `config.d/` is already how the
+  # official image layers its own settings (docker_related_config.xml), so this
+  # needs no image change and no entrypoint override.
+  #
+  # Why this file exists at all: stock ClickHouse config is sized for a
+  # dedicated analytics box, and here it is an embedded store holding kilobytes
+  # of Langfuse traces. Left alone it logs at `trace` and keeps 30 days of its
+  # own telemetry, which grows until a merge exceeds the memory limit and wedges
+  # into an infinite retry. See the clickhouse block in values.yaml for the
+  # measured numbers.
+  curie-logging.xml: |
+    <clickhouse>
+      <logger>
+        <level>{{ .Values.clickhouse.logLevel }}</level>
+      </logger>
+    {{- if .Values.clickhouse.systemLogs.enabled }}
+      <!-- Self-telemetry on, but bounded. `remove="1"` is the documented way to
+           drop a section from the merged config; here we only retitle the TTL. -->
+      <text_log><ttl>event_date + INTERVAL {{ .Values.clickhouse.systemLogs.retentionDays }} DAY DELETE</ttl></text_log>
+      <trace_log><ttl>event_date + INTERVAL {{ .Values.clickhouse.systemLogs.retentionDays }} DAY DELETE</ttl></trace_log>
+      <metric_log><ttl>event_date + INTERVAL {{ .Values.clickhouse.systemLogs.retentionDays }} DAY DELETE</ttl></metric_log>
+      <asynchronous_metric_log><ttl>event_date + INTERVAL {{ .Values.clickhouse.systemLogs.retentionDays }} DAY DELETE</ttl></asynchronous_metric_log>
+    {{- else }}
+      <!-- Removed outright. These four are the firehose: on a real install
+           text_log alone reached 2.30 GiB / 63,295,036 rows in eight days, and
+           metric_log was the table whose merge wedged. Nothing reads them. -->
+      <text_log remove="1"/>
+      <trace_log remove="1"/>
+      <metric_log remove="1"/>
+      <asynchronous_metric_log remove="1"/>
+    {{- end }}
+      <!-- Kept regardless: low volume and genuinely useful when ClickHouse
+           itself misbehaves. Bounded so they cannot become the next text_log. -->
+      <query_log><ttl>event_date + INTERVAL {{ .Values.clickhouse.systemLogs.retentionDays }} DAY DELETE</ttl></query_log>
+      <part_log><ttl>event_date + INTERVAL {{ .Values.clickhouse.systemLogs.retentionDays }} DAY DELETE</ttl></part_log>
+      <error_log><ttl>event_date + INTERVAL {{ .Values.clickhouse.systemLogs.retentionDays }} DAY DELETE</ttl></error_log>
+    </clickhouse>
+---
+apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "curie.fullname" . }}-clickhouse
@@ -31,6 +76,12 @@ spec:
       {{- include "curie.selectorLabels" (dict "root" . "component" "clickhouse") | nindent 6 }}
   template:
     metadata:
+      annotations:
+        # Roll the pod when the logging overlay changes. Without this a
+        # `logLevel` or `systemLogs` edit renders a new ConfigMap and the
+        # running server keeps the old config until something else restarts it
+        # -- i.e. the fix would appear applied while the node kept starving.
+        checksum/config: {{ printf "%s|%v|%v" .Values.clickhouse.logLevel .Values.clickhouse.systemLogs.enabled .Values.clickhouse.systemLogs.retentionDays | sha256sum }}
       labels:
         {{- include "curie.labels" . | nindent 8 }}
         {{- include "curie.selectorLabels" (dict "root" . "component" "clickhouse") | nindent 8 }}
@@ -40,11 +91,14 @@ spec:
       {{- end }}
       securityContext:
         fsGroup: {{ .Values.clickhouse.podSecurityContext.fsGroup }}
-      {{- if not .Values.clickhouse.persistence.enabled }}
       volumes:
+        - name: config
+          configMap:
+            name: {{ include "curie.fullname" . }}-clickhouse-config
+        {{- if not .Values.clickhouse.persistence.enabled }}
         - name: data
           emptyDir: {}
-      {{- end }}
+        {{- end }}
       containers:
         - name: clickhouse
           # Pinned tag; the AVX preflight validates it against the node's CPU.
@@ -88,6 +142,12 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /var/lib/clickhouse
+            # subPath, so this lands beside the image's own
+            # docker_related_config.xml instead of replacing the directory.
+            - name: config
+              mountPath: /etc/clickhouse-server/config.d/curie-logging.xml
+              subPath: curie-logging.xml
+              readOnly: true
   {{- if .Values.clickhouse.persistence.enabled }}
   volumeClaimTemplates:
     - metadata:

--- a/charts/curie/templates/clickhouse.yaml
+++ b/charts/curie/templates/clickhouse.yaml
@@ -20,28 +20,48 @@ data:
     <clickhouse>
       <logger>
         <level>{{ .Values.clickhouse.logLevel }}</level>
+        <!-- Also to stdout, so `kubectl logs` works. The image logs only to
+             files under /var/log/clickhouse-server/, which in Kubernetes means
+             the diagnostics live inside the container and die with the pod,
+             exactly when you most want them. Cheap at `warning`. -->
+        <console>1</console>
       </logger>
+      <!-- text_log is KEPT, and level-filtered rather than removed.
+           The image ships <text_log><level>trace</level></text_log>, and that
+           `level` is the whole problem: an hour of it produced 253,727 Debug
+           and 58,186 Trace rows against 15 Information. Filtering to
+           `{{ .Values.clickhouse.logLevel }}` drops the volume by ~4 orders of
+           magnitude while keeping the table queryable, and a queryable
+           text_log is precisely what diagnosed the incident this fixes. It also
+           outlives the pod, which the log file does not. -->
+      <text_log>
+        <level>{{ .Values.clickhouse.logLevel }}</level>
+        <ttl>event_date + INTERVAL {{ .Values.clickhouse.systemLogs.retentionDays }} DAY DELETE</ttl>
+      </text_log>
     {{- if .Values.clickhouse.systemLogs.enabled }}
-      <!-- Self-telemetry on, but bounded. `remove="1"` is the documented way to
-           drop a section from the merged config; here we only retitle the TTL. -->
-      <text_log><ttl>event_date + INTERVAL {{ .Values.clickhouse.systemLogs.retentionDays }} DAY DELETE</ttl></text_log>
+      <!-- Profiling and per-second resource sampling, on but TTL-bounded. -->
       <trace_log><ttl>event_date + INTERVAL {{ .Values.clickhouse.systemLogs.retentionDays }} DAY DELETE</ttl></trace_log>
       <metric_log><ttl>event_date + INTERVAL {{ .Values.clickhouse.systemLogs.retentionDays }} DAY DELETE</ttl></metric_log>
       <asynchronous_metric_log><ttl>event_date + INTERVAL {{ .Values.clickhouse.systemLogs.retentionDays }} DAY DELETE</ttl></asynchronous_metric_log>
     {{- else }}
-      <!-- Removed outright. These four are the firehose: on a real install
-           text_log alone reached 2.30 GiB / 63,295,036 rows in eight days, and
-           metric_log was the table whose merge wedged. Nothing reads them. -->
-      <text_log remove="1"/>
+      <!-- Removed. Unlike text_log these have no level filter; they sample on
+           a timer regardless of whether anything is happening, so the only
+           lever is on/off. metric_log was the table whose merge wedged and
+           started the spiral. Prometheus and node metrics already cover what
+           they measure, from outside the process that is failing. -->
       <trace_log remove="1"/>
       <metric_log remove="1"/>
       <asynchronous_metric_log remove="1"/>
     {{- end }}
-      <!-- Kept regardless: low volume and genuinely useful when ClickHouse
-           itself misbehaves. Bounded so they cannot become the next text_log. -->
+      <!-- Kept regardless: low volume, useful when ClickHouse itself
+           misbehaves. TTL'd so none can become the next text_log.
+           processors_profile_log is here because a live boot showed the image
+           creates it too. It is easy to miss precisely because it is small
+           today, which is what text_log also was once. -->
       <query_log><ttl>event_date + INTERVAL {{ .Values.clickhouse.systemLogs.retentionDays }} DAY DELETE</ttl></query_log>
       <part_log><ttl>event_date + INTERVAL {{ .Values.clickhouse.systemLogs.retentionDays }} DAY DELETE</ttl></part_log>
       <error_log><ttl>event_date + INTERVAL {{ .Values.clickhouse.systemLogs.retentionDays }} DAY DELETE</ttl></error_log>
+      <processors_profile_log><ttl>event_date + INTERVAL {{ .Values.clickhouse.systemLogs.retentionDays }} DAY DELETE</ttl></processors_profile_log>
     </clickhouse>
 ---
 apiVersion: v1

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -308,10 +308,16 @@ clickhouse:
   # produced 253,727 Debug and 58,186 Trace rows against 15 Information.
   logLevel: warning
   systemLogs:
-    # The four high-volume self-telemetry tables. OFF because nothing reads
-    # them: Langfuse queries its own tables, and the platform never touches
-    # `system`. Turn on only while debugging ClickHouse itself, and note they
-    # stay TTL-bounded even then.
+    # trace_log / metric_log / asynchronous_metric_log -- the timer-driven
+    # samplers. OFF because they have no level filter: they write regardless of
+    # whether anything is happening, so on/off is the only lever, and
+    # Prometheus already measures what they measure from outside the process
+    # that is failing. metric_log is the table whose merge wedged.
+    #
+    # text_log is NOT governed by this and is always kept: it has a `level`
+    # filter, so it can be quiet-but-present, and a queryable text_log is what
+    # diagnosed the incident above. Turn these three on only to profile
+    # ClickHouse itself; they stay TTL-bounded even then.
     enabled: false
     # Retention for whichever system log tables exist. Applies to the
     # always-on diagnostic tables (query_log, part_log, error_log) and to the

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -286,6 +286,38 @@ clickhouse:
   persistence:
     enabled: true
     size: 3Gi
+  # ClickHouse's OWN telemetry, which stock config sizes for a dedicated
+  # analytics box. Here it backs Langfuse, holding kilobytes.
+  #
+  # Left at the image defaults this is not a tuning nicety, it is a live
+  # outage: stock `config.xml` logs at `trace` and retains 30 DAYS of
+  # `text_log`/`trace_log`/`metric_log`/`asynchronous_metric_log`. Measured on a
+  # real install, ClickHouse accumulated 2.72 GiB of self-telemetry against
+  # 31 KiB of actual Langfuse data -- a 90,000:1 ratio that filled a 3Gi volume
+  # in eight days.
+  #
+  # It ends in a merge that cannot succeed, retried forever. Once
+  # `system.metric_log` needs more than the memory limit below to merge, the
+  # merge throws MEMORY_LIMIT_EXCEEDED; ClickHouse retries failed merges
+  # indefinitely; each attempt writes a ~4 KiB stack trace into `text_log`,
+  # which then needs merging itself. Failed merges make parts accumulate, so
+  # the next merge is larger and fails harder. Daily CPU climbed 17% -> 98%
+  # over eight days with no change in traffic, and the node starved.
+  #
+  # `logLevel: warning` is the load-bearing one -- an hour of the default
+  # produced 253,727 Debug and 58,186 Trace rows against 15 Information.
+  logLevel: warning
+  systemLogs:
+    # The four high-volume self-telemetry tables. OFF because nothing reads
+    # them: Langfuse queries its own tables, and the platform never touches
+    # `system`. Turn on only while debugging ClickHouse itself, and note they
+    # stay TTL-bounded even then.
+    enabled: false
+    # Retention for whichever system log tables exist. Applies to the
+    # always-on diagnostic tables (query_log, part_log, error_log) and to the
+    # four above when enabled. Stock is 30 days, which no volume this size
+    # survives.
+    retentionDays: 3
   # The CPU limit deliberately leaves headroom rather than matching a node.
   #
   # This was `cpu: "2"`, and on a 2-vCPU node that is the WHOLE machine. A
@@ -303,6 +335,13 @@ clickhouse:
   # the critical-path containers (bundle-fetch, runner) request 50m each. A
   # limit is a ceiling, never a guarantee -- so a component that requests little
   # and may burst to everything is exactly the shape that starves a deadline.
+  #
+  # Necessary but NOT sufficient, which the recurrence proved. Capping at 1 core
+  # halved the blast radius and left the cause untouched: ClickHouse still WANTS
+  # a core, permanently, and on a 2-vCPU node half the machine is still fatal to
+  # a 90s deadline. The same `runner-error` escalation returned. What ClickHouse
+  # wanted that core FOR is the `logLevel`/`systemLogs` block above -- it was
+  # merging its own logs, not serving Langfuse. Fix intake, not just the ceiling.
   resources:
     requests: { cpu: 200m, memory: 512Mi }
     limits: { cpu: "1", memory: 1536Mi }


### PR DESCRIPTION
Fixes #1335.

ClickHouse ships configured for a dedicated analytics box. This chart runs it as
an embedded store for kilobytes of Langfuse traces, with **no config overlay at
all** — so it keeps the image defaults: logger at `trace`, and 30 days of
`text_log` / `trace_log` / `metric_log` / `asynchronous_metric_log`.

Measured on a live single-node install after eight days:

| database | size |
|---|---|
| `system` | **2.72 GiB** — ClickHouse logging about itself |
| `default` | **31.56 KiB** — the actual Langfuse data |

A 90,000:1 ratio, in a 3Gi volume that was 91% full.

## It ends in a merge that cannot succeed, retried forever

Once `system.metric_log` needs more than the 1536Mi limit to merge, the merge
throws `MEMORY_LIMIT_EXCEEDED`. ClickHouse retries failed merges indefinitely.
Each attempt writes a **~4 KiB stack trace into `text_log`**, which then needs
merging itself — and because failures make parts accumulate, the next merge is
*larger* and fails *harder*.

One hour of `text_log`: **253,727 Debug and 58,186 Trace rows against 15
Information.** Every top logger was merge machinery (`MergeTreeSequentialSource`
174,775, `MergeTask::PrepareStage` 37,208).

A positive feedback loop with no relationship to traffic:

| Day | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 |
|---|---|---|---|---|---|---|---|---|
| Avg CPU | 17% | 27% | 30% | 38% | 65% | 81% | 98% | 92% |

Slack volume never changed. Eventually sandbox pods could not win enough CPU to
bind their claim inside the 90s deadline, and every turn escalated as an opaque
`runner-error`.

**Nothing catches it.** CPU starvation sets no node condition — the node reads
`Ready`, pods read `Running`, probes stay green, disk looks fine. `substrate.py`
already predicts this exact shape in a comment, which is the only place it's
written down.

## The fix

A `config.d` overlay — the same mechanism the official image uses for its own
`docker_related_config.xml`, so no image change and no entrypoint override:

- logger → `warning`
- the four firehose tables **removed**
- `query_log` / `part_log` / `error_log` kept (low volume, genuinely useful) with
  a **3-day TTL**, so none can become the next `text_log`
- `clickhouse.systemLogs.enabled=true` brings the four back for anyone debugging
  ClickHouse itself — still TTL-bounded

## This is the second fix for this failure

The first capped ClickHouse's CPU limit from `2` to `1` — see the existing
`resources` comment in values.yaml, which describes this same incident. That
halved the blast radius and left the cause untouched: ClickHouse still wanted a
whole core, permanently, and on a 2-vCPU node half the machine is still fatal to
a 90s deadline. **The same escalation came back.** That comment now records why
the ceiling alone wasn't enough — the core was going to merging its own logs,
not to serving Langfuse.

## Gate

`charts/curie/ci/clickhouse-logging-assertions.sh`, wired into `helm-ci`. It
asserts the log level, the removals, a TTL on every surviving table, plus two
things that are silently fatal if dropped:

- **the `subPath` mount** — mounting the directory would hide the image's own
  `docker_related_config.xml`
- **the checksum annotation** — without it a values edit renders a new ConfigMap
  that the running server never reads, so the fix looks applied while the node
  keeps starving

It also parses the rendered XML in both modes, since a malformed `config.d` file
stops the server from starting and the render is the cheap place to catch it.

**Mutation-tested** — reverting the log level, dropping the `subPath`, removing
the checksum annotation, and un-TTLing `query_log` are each caught. The first
run of the checksum mutation surfaced a bug in the assertion itself (an emptied
`annotations:` parses as `None`, raising `TypeError` instead of failing
cleanly); fixed and re-verified.

## Verification

`helm lint` clean; full chart plus `values-dev`, `values-e2e-harness` and
`values-e2e-nogvisor` all render; `deploy=false` renders nothing;
`persistence.enabled=false` still gets its `data` emptyDir alongside the new
`config` volume.

Applied by hand to the affected install first (truncate + runtime TTLs), which
is what this change makes permanent:

| | before | after |
|---|---|---|
| load average | 6.57 | 0.29 |
| CPU pressure `some avg10` | 92.89 | 5.57 |
| ClickHouse CPU | 999m (pinned at its limit) | 45m |
| running merges | 3–5 | 0 |
| `system` database | 2.72 GiB | 350 KiB |
| `text_log` rows | 63,295,036 | ~2,000 |

Note the runtime version does **not** survive a restart: ClickHouse rebuilds
system log tables from config at startup and renames any whose structure
doesn't match, so a hand-applied TTL is reset to the config's 30 days. That's
precisely why this belongs in the chart.

**Unrelated:** `ci/render-assertions.sh` fails identically before and after this
change on macOS bash (`postgresPassword: unbound variable`), so it's untouched.
