### PR TITLE
`curie apply` migrates the store itself

### DIFF
--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -3876,7 +3876,19 @@ export const commandManifest = {
         },
         {
           "global": false,
-          "help": "Proceed even when the upgrade would DELETE a stateful component the release is running, losing its data. Refused by default: a chart that renames a store (minio -> rustfs in 0.6.0) drops the old one, and every sandbox reads the bundle store at start, so the next turn fails rather than merely a rollback",
+          "help": "Carry the object store's contents across a chart that renames it, instead of refusing. Apply then stages every object, upgrades, loads them back, and verifies per object -- one command, no separate procedure and no safety override",
+          "id": "migrate_store",
+          "long": "migrate-store",
+          "positional": false,
+          "possible_values": [
+            "true",
+            "false"
+          ],
+          "required": false
+        },
+        {
+          "global": false,
+          "help": "Proceed even when the upgrade would DELETE a stateful component the release is running, WITHOUT its data. Refused by default. Prefer --migrate-store, which keeps the data; this flag is for a store you genuinely intend to discard",
           "id": "allow_stateful_removal",
           "long": "allow-stateful-removal",
           "positional": false,

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -3873,7 +3873,19 @@
         },
         {
           "global": false,
-          "help": "Proceed even when the upgrade would DELETE a stateful component the release is running, losing its data. Refused by default: a chart that renames a store (minio -> rustfs in 0.6.0) drops the old one, and every sandbox reads the bundle store at start, so the next turn fails rather than merely a rollback",
+          "help": "Carry the object store's contents across a chart that renames it, instead of refusing. Apply then stages every object, upgrades, loads them back, and verifies per object -- one command, no separate procedure and no safety override",
+          "id": "migrate_store",
+          "long": "migrate-store",
+          "positional": false,
+          "possible_values": [
+            "true",
+            "false"
+          ],
+          "required": false
+        },
+        {
+          "global": false,
+          "help": "Proceed even when the upgrade would DELETE a stateful component the release is running, WITHOUT its data. Refused by default. Prefer --migrate-store, which keeps the data; this flag is for a store you genuinely intend to discard",
           "id": "allow_stateful_removal",
           "long": "allow-stateful-removal",
           "positional": false,

--- a/cli/src/installation.rs
+++ b/cli/src/installation.rs
@@ -559,6 +559,9 @@ pub struct ApplyOpts {
     /// Proceed even when the upgrade would delete a stateful component. The
     /// operator asserting the data is migrated, or expendable.
     pub allow_stateful_removal: bool,
+    /// Carry the object store's contents across a rename, instead of refusing.
+    /// `apply` then stages every object, upgrades, and loads them back.
+    pub migrate_store: bool,
 }
 
 pub struct LocalInstallationPlan {
@@ -711,15 +714,21 @@ async fn guard_stateful_removal(up: &crate::ops::UpOpts) -> Result<()> {
     if removed.is_empty() {
         return Ok(());
     }
-    bail!(
+    bail!("{}", stateful_removal_message(&removed))
+}
+
+/// The refusal text, factored out so its ordering is testable with no cluster.
+fn stateful_removal_message(removed: &[String]) -> String {
+    format!(
         "refusing to apply: this would DELETE {} stateful component(s) the release is \
          running, and the persistent data with them:\n  {}\n\n\
          The target chart does not render them, which usually means a chart version \
-         renamed or removed the component. Migrate the data first -- for the bundle \
-         store, every sandbox reads from it at start, so losing it breaks the next turn \
-         and not merely a rollback.\n\n\
-         Re-run with --allow-stateful-removal once the data is migrated or you accept \
-         losing it.",
+         renamed or removed the component. For the bundle store, every sandbox reads \
+         from it at start, so losing it breaks the next turn and not merely a \
+         rollback.\n\n\
+         Re-run with --migrate-store and apply will carry the data across itself: it \
+         stages every object, upgrades, loads them back, and verifies per object.\n\n\
+         Use --allow-stateful-removal only to proceed WITHOUT the data.",
         removed.len(),
         removed.join("\n  "),
     )
@@ -737,6 +746,7 @@ pub async fn apply(opts: ApplyOpts) -> Result<ApplyOutput> {
         mut local,
         chart,
         allow_stateful_removal,
+        migrate_store,
     } = opts;
     local.up.chart = chart;
     let dry_run = local.up.common.dry_run;
@@ -762,9 +772,36 @@ pub async fn apply(opts: ApplyOpts) -> Result<ApplyOutput> {
     //
     // `curie diff` learned to warn about the chart mismatch; `apply` had no
     // guard at all and would have gone ahead silently.
-    if !allow_stateful_removal {
-        guard_stateful_removal(&up).await?;
+    // `apply` handles the migration itself rather than sending the operator to a
+    // separate verb. ADR-0097's premise is that the file states whole intent and
+    // apply computes the delta; "go run this other command first, then come back
+    // and pass an override" is the opposite of that -- and it made the
+    // documented happy path include `--allow-stateful-removal`, training an
+    // operator to bypass the one guard that protects the case that is real.
+    //
+    // Still opt-in, because a store migration has a window where the store is
+    // empty and the bot cannot answer. An `apply` that changes a log level must
+    // never silently start moving data. So the refusal NAMES the flag, and
+    // passing it makes apply do the whole thing.
+    let migrating = if allow_stateful_removal {
+        false
+    } else {
+        match guard_stateful_removal(&up).await {
+            Ok(()) => false,
+            Err(e) if migrate_store => {
+                let _ = e;
+                true
+            }
+            Err(e) => return Err(e),
+        }
+    };
+
+    // Stage BEFORE the upgrade deletes the old store. A failure here leaves the
+    // cluster untouched.
+    if migrating {
+        crate::migrate_store::run_export(&up.common, &up.chart, BUNDLE_BUCKET).await?;
     }
+
     let up_out = crate::ops::up_prepared(up, up_values, live, github_token).await?;
 
     let mut lines = match up_out {
@@ -784,12 +821,39 @@ pub async fn apply(opts: ApplyOpts) -> Result<ApplyOutput> {
     if dry_run {
         return Ok(ApplyOutput::DryRun(crate::ui::DryRunPlan { lines }));
     }
+
+    // Load the staged objects into whatever the upgrade created, and verify per
+    // object. `run_import` retains the staging pod when anything is missing, so
+    // a partial load stays recoverable.
+    if migrating {
+        let common = crate::ops::CommonOpts {
+            namespace: cfg.install.namespace.clone(),
+            release: cfg.install.release.clone(),
+            dry_run: false,
+        };
+        let imported = crate::migrate_store::run_import(&common, BUNDLE_BUCKET, false).await?;
+        if let crate::migrate_store::MigrateStoreOutput::Imported { missing, .. } = &imported {
+            if !missing.is_empty() {
+                bail!(
+                    "the upgrade applied, but {} staged object(s) did not reach the new \
+                     store. The staging pod has been kept -- it holds the only other \
+                     copy. Re-run `curie cluster migrate-store --phase import` before \
+                     deleting it.",
+                    missing.len()
+                );
+            }
+        }
+    }
+
     Ok(ApplyOutput::Applied {
         namespace: cfg.install.namespace,
         release: cfg.install.release,
         comms: configured_comms,
     })
 }
+
+/// The bundle bucket the platform reads, mirroring the chart's `BUNDLE_BUCKET`.
+const BUNDLE_BUCKET: &str = "curie-bundles";
 
 // -- curie diff ---------------------------------------------------------------
 
@@ -1101,6 +1165,33 @@ pub async fn diff(opts: DiffOpts) -> Result<DiffOutput> {
         chart_target: crate::artifacts::version().to_string(),
         entries,
     })
+}
+
+#[cfg(test)]
+mod stateful_guard_message_tests {
+    /// The refusal is the only place an operator learns what to do next, so it
+    /// has to lead with the flag that KEEPS the data. Leading with
+    /// `--allow-stateful-removal` is what made the documented happy path a
+    /// safety-override, which trains the habit the guard exists to prevent.
+    #[test]
+    fn the_refusal_offers_migration_before_discarding() {
+        let msg = super::stateful_removal_message(&["acme-minio".to_string()]);
+        let migrate = msg
+            .find("--migrate-store")
+            .expect("must offer --migrate-store");
+        let discard = msg
+            .find("--allow-stateful-removal")
+            .expect("must still mention the discard flag");
+        assert!(
+            migrate < discard,
+            "the data-preserving flag must come first:\n{msg}"
+        );
+        assert!(
+            msg.contains("WITHOUT the data"),
+            "the discard flag must say what it costs:\n{msg}"
+        );
+        assert!(msg.contains("acme-minio"), "must name the component: {msg}");
+    }
 }
 
 #[cfg(test)]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -411,11 +411,20 @@ enum Command {
         /// Chart reference override, as `cluster up` takes.
         #[arg(long)]
         chart: Option<String>,
+        /// Carry the object store's contents across a chart that renames it,
+        /// instead of refusing. Apply then stages every object, upgrades, loads
+        /// them back, and verifies per object -- one command, no separate
+        /// procedure and no safety override.
+        ///
+        /// Opt-in rather than automatic because the migration has a window
+        /// where the store is empty and the bot cannot answer: an apply that
+        /// changes a log level must never silently start moving data.
+        #[arg(long)]
+        migrate_store: bool,
         /// Proceed even when the upgrade would DELETE a stateful component the
-        /// release is running, losing its data. Refused by default: a chart
-        /// that renames a store (minio -> rustfs in 0.6.0) drops the old one,
-        /// and every sandbox reads the bundle store at start, so the next turn
-        /// fails rather than merely a rollback.
+        /// release is running, WITHOUT its data. Refused by default. Prefer
+        /// --migrate-store, which keeps the data; this flag is for a store you
+        /// genuinely intend to discard.
         #[arg(long)]
         allow_stateful_removal: bool,
     },
@@ -3161,6 +3170,7 @@ async fn run(command: Option<Command>) -> Result<()> {
             file,
             dry_run,
             chart,
+            migrate_store,
             allow_stateful_removal,
         }) => {
             let cfg = curie::installation::Installation::load(&file)?;
@@ -3178,6 +3188,7 @@ async fn run(command: Option<Command>) -> Result<()> {
                     local,
                     chart,
                     allow_stateful_removal,
+                    migrate_store,
                 })
                 .await?,
             )


### PR DESCRIPTION
Follow-up to #1333/#1336, and closer to what ADR-0097 actually says.

## The problem with what I built

ADR-0097's premise is that **the file states whole intent and apply computes the delta.** "Refuse, go run a different command, come back and pass an override" is the opposite of that — and it's what apply did:

```bash
curie cluster migrate-store --phase export
curie apply -f curie.yaml --allow-stateful-removal   # ← override, in the happy path
curie cluster migrate-store --phase import
```

`--allow-stateful-removal` exists so a human confirms the data is safe before a StatefulSet is deleted. Putting it in the documented happy path trains an operator to pass it by reflex — **worse than not having the guard**, because it's exactly the flag protecting the case that's real.

## Now

```bash
curie apply -f curie.yaml --migrate-store
```

Stage every object while the old store is up → run **apply's own upgrade** (the file's intent, not captured values) → load them into whatever it created → verify per object.

If anything is missing, the staging pod is retained and apply **fails loudly** rather than reporting success over a half-loaded store.

## Why opt-in rather than automatic

The migration has a window where the store is empty and the bot can't answer. An `apply` that changes a log level must never silently start moving data.

But discovery is automatic: **the refusal names the flag**, so it costs one failed run and no documentation.

## The message ordering is the point, so it's tested

```
Re-run with --migrate-store and apply will carry the data across itself...

Use --allow-stateful-removal only to proceed WITHOUT the data.
```

Data-preserving flag first; the discard flag says what it costs. That's the whole fix, so it's pinned by a test rather than left to prose — the message is factored out and asserted on.

**Falsified:** reordering it to lead with the discard flag fails `the_refusal_offers_migration_before_discarding`.

## Also

`curie cluster migrate-store` stays, for recovery — an upgrade that already happened, or a run interrupted midway. It's no longer the path anyone follows deliberately.

`fmt`, `clippy --all-targets -D warnings`, 38 suites, `check-docs.sh`, command manifest all pass.

## Unchanged caveat

**Still not exercised against a live rename.** The only cluster in that state was migrated by hand before any of this existed.