### PR TITLE
Render the sealing keypair, and give it only to the worker

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -153,6 +153,18 @@ jobs:
           set -euo pipefail
           bash charts/curie/ci/github-app-credential-assertions.sh
 
+      # Prove the sealing keypair's handling (ADR-0094). It is the one credential
+      # in this chart nobody can regenerate: losing it does not rotate anything,
+      # it makes every value sealed to it -- in every agent repository --
+      # permanently unreadable. So the chart must never GENERATE one (a
+      # chart-side random would mint a new key on every upgrade, since there is
+      # no lookup-persist), only the worker may receive it, and both the current
+      # and previous keys must render so a rotation can overlap.
+      - name: helm render assertions (sealing keypair)
+        run: |
+          set -euo pipefail
+          bash charts/curie/ci/sealing-key-assertions.sh
+
       # Prove the connector reconciler's RBAC (ADR-0090, #1184): absent when the
       # reconciler is off, and when on, exactly {create,list,patch,delete} on
       # exactly the four kinds the client handles. `create` is load-bearing --

--- a/charts/curie/ci/sealing-key-assertions.sh
+++ b/charts/curie/ci/sealing-key-assertions.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+#
+# Render-assertion test for the cluster sealing keypair (ADR-0094).
+#
+# The keypair is the one credential in this chart that cannot be regenerated.
+# Losing it does not rotate anything -- it makes every value sealed to it, in
+# every agent repository, permanently unreadable. Nothing outside the cluster
+# can reconstruct it. So the properties below are not style preferences:
+#
+#   (a) The chart NEVER generates it. `curie.managedSecret` mints a random when
+#       a value matches its default, which is right for a store password and
+#       catastrophic here: the chart has no lookup-persist (#195), so a
+#       chart-side random would mint a NEW key on every `helm upgrade`. The CLI
+#       owns generation and preservation (ops::resolve_sealing_values).
+#   (b) Only the WORKER receives it. The connector reconciler runs there and is
+#       the only thing that decrypts. Every other workload that does not need a
+#       decryption key must not be handed one.
+#   (c) The previous key renders independently, so a rotation overlap survives
+#       the upgrades that happen during it.
+#
+# Four assertions.
+set -euo pipefail
+
+# NOTE: read variables with a herestring, never `printf ... | cmd`. Under
+# `pipefail` an early-exiting reader (grep -q, awk with `exit`) SIGPIPEs the
+# printf, so the pipeline reports failure on a match that SUCCEEDED -- which is
+# exactly how this script first reported a passing property as broken.
+
+CHART="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FAILED=0
+
+fail() {
+    echo "FAIL: $1" >&2
+    FAILED=1
+}
+
+# -- (a) never generated -------------------------------------------------------
+#
+# A default install must leave both empty. If this ever renders a value, the
+# chart has started minting keys and every upgrade silently destroys sealed
+# credentials.
+DEFAULT="$(helm template t "$CHART" -n t)"
+CURRENT="$(printf '%s' "$DEFAULT" | awk '/^  sealingPrivateKey:/{print $2}')"
+if [[ "$CURRENT" != '""' ]]; then
+    fail "a default install rendered a sealing private key ($CURRENT); the chart must never generate one"
+else
+    echo "ok: a default install renders no sealing key"
+fi
+
+# -- (b) supplied key reaches the worker, and only the worker ------------------
+SUPPLIED="$(helm template t "$CHART" -n t --set sealing.privateKey=QUJDREVG)"
+REFS="$(grep -c 'name: CURIE_SEALING_PRIVATE_KEY' <<<"$SUPPLIED" || true)"
+if [[ "$REFS" != "1" ]]; then
+    fail "expected exactly one workload to receive the sealing key, found $REFS"
+else
+    echo "ok: exactly one workload receives the sealing key"
+fi
+
+# Confirm that one workload is the worker. Splitting on the document separator
+# rather than grepping the whole render: a match anywhere would otherwise pass
+# even if the key landed in the API or the dispatcher.
+WORKER_DOC="$(awk '
+    /^---/ { doc = ""; next }
+    { doc = doc "\n" $0 }
+    /CURIE_SEALING_PRIVATE_KEY/ { holder = doc }
+    END { print holder }
+' <<<"$SUPPLIED")"
+if ! grep -q 'component: worker' <<<"$WORKER_DOC"; then
+    fail "the sealing key went to a workload that is not the worker"
+else
+    echo "ok: the worker is the workload that receives it"
+fi
+
+# -- (c) the previous key renders independently --------------------------------
+#
+# Rotation is the weakest point of this design (ADR-0094). If the previous key
+# could not be set alongside the current one, a rotation would break every
+# repository the moment it started.
+BOTH="$(helm template t "$CHART" -n t \
+    --set-string sealing.privateKey=CURRENTKEY \
+    --set-string sealing.previousPrivateKey=PREVIOUSKEY)"
+# Extract the field rather than matching a rendered line literally: the value is
+# base64 in real use, whose `=` padding makes a literal `--set` and a literal
+# grep both quietly fragile.
+PREV="$(awk -F'"' '/^  sealingPreviousPrivateKey:/{print $2; exit}' <<<"$BOTH")"
+CURR="$(awk -F'"' '/^  sealingPrivateKey:/{print $2; exit}' <<<"$BOTH")"
+if [[ "$PREV" != "PREVIOUSKEY" || "$CURR" != "CURRENTKEY" ]]; then
+    fail "both keys must render together for a rotation to overlap; got current=[$CURR] previous=[$PREV]"
+else
+    echo "ok: both keys render together, so a rotation can overlap"
+fi
+
+if ((FAILED)); then
+    echo "sealing-key assertions FAILED" >&2
+    exit 1
+fi
+echo "sealing-key assertions passed"

--- a/charts/curie/templates/secrets.yaml
+++ b/charts/curie/templates/secrets.yaml
@@ -71,6 +71,18 @@ stringData:
        in this Secret; it is only ever read into the API's env, never logged and
        never placed in argv. */}}
   githubAppPrivateKey: {{ .Values.api.githubAppPrivateKey | default "" | quote }}
+  {{/* The cluster sealing keypair (ADR-0094). Optional and NEVER generated
+       here: the CLI mints it and preserves it across upgrades, because the
+       chart has no lookup-persist (#195) and a chart-side random would mint a
+       NEW key on every `helm upgrade`. That would not merely rotate a
+       credential -- it would make every sealed value in every agent repository
+       permanently unreadable, since nothing outside this cluster can
+       reconstruct the key. `curie cluster up` re-supplies whatever the release
+       already recorded; see ops::resolve_sealing_values. */}}
+  sealingPrivateKey: {{ .Values.sealing.privateKey | default "" | quote }}
+  {{/* Present only during a rotation, so a value sealed to the old key still
+       opens while repositories are resealed to the new one. */}}
+  sealingPreviousPrivateKey: {{ .Values.sealing.previousPrivateKey | default "" | quote }}
   slackAppToken: {{ .Values.dispatcher.slack.appToken | quote }}
   slackBotToken: {{ .Values.dispatcher.slack.botToken | quote }}
   slackSigningSecret: {{ .Values.dispatcher.slack.signingSecret | quote }}

--- a/charts/curie/templates/worker.yaml
+++ b/charts/curie/templates/worker.yaml
@@ -122,6 +122,21 @@ spec:
                 secretKeyRef:
                   name: {{ include "curie.secretName" . }}
                   key: slackBotToken
+            # The sealing keys (ADR-0094). The connector reconciler runs here,
+            # so this is the only workload that needs to DECRYPT a sealed
+            # value; nothing else in the release gets them. Both are optional:
+            # empty means no sealed credential can be opened, which the
+            # reconciler reports rather than working around.
+            - name: CURIE_SEALING_PRIVATE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "curie.secretName" . }}
+                  key: sealingPrivateKey
+            - name: CURIE_SEALING_PREVIOUS_PRIVATE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "curie.secretName" . }}
+                  key: sealingPreviousPrivateKey
             # Substrate wiring: which namespace to claim sandboxes in, the warm
             # pool to claim from, and the ACI port on each claimed sandbox.
             - name: CURIE_NAMESPACE

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -373,6 +373,21 @@ clickhouse:
 # service in production with deploy=false plus host, port, auth, and an
 # existingSecret containing rustfsSecretKey.
 # ---------------------------------------------------------------------------
+# The cluster keypair that sealed connector credentials are sealed to
+# (ADR-0094). Both are supplied by `curie cluster up`, which generates the
+# private key on first install and re-supplies the recorded one on every
+# upgrade. Do NOT set these by hand unless you are restoring a backup: a
+# different key makes every value sealed to the old one unreadable, and nothing
+# outside this cluster can reconstruct it.
+#
+# For durable storage, treat this like any other credential you cannot
+# regenerate and keep it in whatever holds your other irreplaceable secrets.
+sealing:
+  privateKey: ""
+  # Set only during a rotation, so values sealed to the old key keep opening
+  # while repositories are resealed. Remove it once every repository is resealed.
+  previousPrivateKey: ""
+
 rustfs:
   deploy: true
   image: rustfs/rustfs:1.0.0-beta.12


### PR DESCRIPTION
The chart half of [ADR-0094](docs/adr/0094-a-bundle-carries-its-own-sealed-connector-keys.md), on top of the keypair (#1329). The keys the CLI generates now actually reach the cluster.

## Three properties, three assertions

This is the one credential in the chart **nobody can regenerate**. Losing it doesn't rotate anything — it makes every value sealed to it, in every agent repository, permanently unreadable.

**1. The chart never generates it.** `curie.managedSecret` mints a random when a value matches its default — right for a store password, catastrophic here. The chart has no lookup-persist (#195), so a chart-side random would mint a **new key on every `helm upgrade`**. Generation and preservation stay in the CLI.

**2. Only the worker receives it.** The reconciler runs there and is the only thing that decrypts. The assertion checks the count *and* that the holder is the worker — splitting the render on document boundaries, because grepping the whole output would pass even if the key also landed in the API.

**3. Both keys render together**, so a rotation can overlap. If the previous key couldn't be set alongside the current one, rotating would break every repository the moment it started.

**Falsified:** making the chart generate a default key, and adding the env var to the API, each fail their own assertion.

## A bug in my own test worth flagging

The script first reported a **working** property as broken. The cause:

```bash
printf '%s' "$VAR" | grep -q 'pattern'     # exit 141
```

Under `set -o pipefail`, `grep -q` exits on first match, `printf` dies of SIGPIPE, and the pipeline reports failure — **on a match that succeeded**. The pattern and the rendered line were byte-identical; I checked with `od`.

Every read is a herestring now, with a comment saying why. Worth knowing for the next assertion script in that directory — they all use `set -euo pipefail`.

`helm lint` clean, workflow YAML validates, all four assertions pass.