### PR TITLE
Discover the release's chart Secret instead of guessing its name

### DIFF
--- a/cli/src/migrate_store.rs
+++ b/cli/src/migrate_store.rs
@@ -163,27 +163,54 @@ pub fn create_staging_pod_cmd(o: &CommonOpts, image: &str, secret_name: &str) ->
     )
 }
 
+/// Wait for a Secret key to appear in the staging pod's mount.
+///
+/// The pod mounts the release Secret when it is CREATED, before the upgrade
+/// exists. A mounted Secret is refreshed by kubelet on a sync period, not
+/// instantly, so the key the NEW store uses is typically absent for up to a
+/// minute after the upgrade adds it. The first live run of this verb failed
+/// exactly there: `cat: /secret/rustfsSecretKey: No such file or directory`,
+/// with the staged copy intact.
+///
+/// Waiting rather than re-creating the pod: its `emptyDir` holds the only copy
+/// of the objects at that moment, so recreating it would destroy them.
+fn await_secret_key(key: &str) -> String {
+    format!(
+        "for i in $(seq 1 90); do [ -s /secret/{key} ] && break; sleep 2; done; \
+         [ -s /secret/{key} ] || {{ echo \"secret key {key} never appeared in the \
+         staging pod mount; the staged copy is intact -- retry the import\" >&2; exit 1; }}; "
+    )
+}
+
 /// The in-pod shell for one leg of the copy.
 ///
 /// `direction` is the `aws s3 sync` argument pair. The password is read from
 /// the mounted Secret inside the pod, so it never appears here.
 fn sync_script(store: StoreKind, endpoint: &str, from: &str, to: &str) -> String {
     format!(
-        "set -e; \
+        "set -e; {wait}\
          export AWS_DEFAULT_REGION=us-east-1; \
          aws configure set default.s3.addressing_style path; \
          export AWS_ACCESS_KEY_ID={access}; \
          export AWS_SECRET_ACCESS_KEY=$(cat /secret/{secret}); \
          aws s3 sync {from} {to} --endpoint-url {endpoint} --only-show-errors; \
          echo synced",
+        wait = await_secret_key(store.secret_key()),
         access = store.access_key(),
         secret = store.secret_key(),
     )
 }
 
 /// The store's in-cluster S3 endpoint, from the Service the chart actually
-/// created. Looked up by component label rather than constructed from the
-/// release name, for the `nameOverride` reason above.
+/// created. Looked up by component rather than constructed from the release
+/// name, for the `nameOverride` reason above.
+///
+/// The component lives in the Service's `spec.selector`, NOT in its
+/// `metadata.labels` -- the chart's `selectorLabels` helper puts it there, and
+/// the object-level labels carry only name/instance/version. A `-l` label
+/// selector therefore matches nothing, which is how the first live run of this
+/// verb failed: `array index out of bounds: index 0, length 0`. Filtering on
+/// `spec.selector` is what actually finds it.
 pub fn store_service_cmd(o: &CommonOpts, store: StoreKind) -> OpsCommand {
     OpsCommand::new(
         "kubectl",
@@ -192,10 +219,11 @@ pub fn store_service_cmd(o: &CommonOpts, store: StoreKind) -> OpsCommand {
             plain("svc"),
             plain("-n"),
             plain(&o.namespace),
-            plain("-l"),
-            plain(format!("app.kubernetes.io/component={}", store.suffix())),
             plain("-o"),
-            plain("jsonpath={.items[0].metadata.name}"),
+            plain(format!(
+                r#"jsonpath={{.items[?(@.spec.selector.app\.kubernetes\.io/component=="{}")].metadata.name}}"#,
+                store.suffix()
+            )),
         ],
     )
 }
@@ -219,7 +247,7 @@ pub fn export_cmd(o: &CommonOpts, from: StoreKind, bucket: &str, endpoint: &str)
 /// after a partial import must not fail on the bucket already being there.
 pub fn import_cmd(o: &CommonOpts, to: StoreKind, bucket: &str, endpoint: &str) -> OpsCommand {
     let script = format!(
-        "set -e; \
+        "set -e; {wait}\
          export AWS_DEFAULT_REGION=us-east-1; \
          aws configure set default.s3.addressing_style path; \
          export AWS_ACCESS_KEY_ID={access}; \
@@ -227,6 +255,7 @@ pub fn import_cmd(o: &CommonOpts, to: StoreKind, bucket: &str, endpoint: &str) -
          aws s3 mb s3://{bucket} --endpoint-url {endpoint} || true; \
          aws s3 sync /stage s3://{bucket} --endpoint-url {endpoint} --only-show-errors; \
          echo synced",
+        wait = await_secret_key(to.secret_key()),
         access = to.access_key(),
         secret = to.secret_key(),
     );
@@ -250,12 +279,13 @@ pub fn store_listing_cmd(
     endpoint: &str,
 ) -> OpsCommand {
     let script = format!(
-        "export AWS_DEFAULT_REGION=us-east-1; \
+        "{wait}export AWS_DEFAULT_REGION=us-east-1; \
          aws configure set default.s3.addressing_style path; \
          export AWS_ACCESS_KEY_ID={access}; \
          export AWS_SECRET_ACCESS_KEY=$(cat /secret/{secret}); \
          aws s3 ls s3://{bucket} --recursive --endpoint-url {endpoint} \
          | awk '{{print $3, $4}}' | sort",
+        wait = await_secret_key(store.secret_key()),
         access = store.access_key(),
         secret = store.secret_key(),
     );
@@ -634,7 +664,12 @@ pub async fn run_export(o: &CommonOpts, chart: &str, bucket: &str) -> Result<Mig
     let (from, to) = ensure_migratable(&plan(&live, &rendered)?)?;
 
     let image = "amazon/aws-cli:2.32.6";
-    let secret = format!("{}-secrets", o.release);
+    // Discovered, not computed. `<release>-secrets` is only the chart Secret's
+    // name when the release name contains the chart name; a default install
+    // renders `<release>-curie-secrets`, and the staging pod would then mount a
+    // Secret that does not exist -- failing mid-migration, with the export
+    // already taken and the store half moved.
+    let secret = crate::ops::release_secret_name_or_default(&o.namespace, &o.release).await;
     if o.dry_run {
         let endpoint = endpoint_for("<store-service>", &o.namespace);
         let cmds = [

--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -1386,6 +1386,65 @@ pub fn removed_stateful_components(live: &[(String, String)], rendered: &[String
 }
 
 #[cfg(test)]
+mod release_secret_name_tests {
+    use super::*;
+
+    /// The bug: `<release>-secrets` is only right when the release name
+    /// contains the chart name. A default install renders
+    /// `<release>-curie-secrets`, and every read silently found nothing.
+    #[test]
+    fn a_default_install_secret_is_found() {
+        let listed = "t-curie-secrets\nsh.helm.release.v1.t.v1\n";
+        assert_eq!(
+            pick_release_secret(listed),
+            Some("t-curie-secrets".to_string())
+        );
+    }
+
+    /// The shape that hid the bug: with `nameOverride` equal to the release
+    /// name, both forms collapse to the same string.
+    #[test]
+    fn a_name_override_install_secret_is_found() {
+        assert_eq!(
+            pick_release_secret("acme-bot-secrets\n"),
+            Some("acme-bot-secrets".to_string())
+        );
+    }
+
+    /// The collision the exclusion exists for. Per-agent connector Secrets
+    /// carry the same release labels, so without it the selector could return
+    /// one -- a confidently WRONG answer, which is worse than an empty one.
+    #[test]
+    fn a_connector_secret_is_never_mistaken_for_the_chart_secret() {
+        let listed = "acme-bot-acme-bot-connector-secrets\n                      acme-bot-acme-dev-connector-secrets\n                      acme-bot-secrets\n";
+        assert_eq!(
+            pick_release_secret(listed),
+            Some("acme-bot-secrets".to_string())
+        );
+    }
+
+    /// Ordering must not decide it: the connector Secret sorting first is the
+    /// realistic case, since kubectl lists alphabetically.
+    #[test]
+    fn ordering_does_not_change_the_answer() {
+        let connector_first = "a-connector-secrets\nz-curie-secrets\n";
+        assert_eq!(
+            pick_release_secret(connector_first),
+            Some("z-curie-secrets".to_string())
+        );
+    }
+
+    /// An absent release must yield nothing, not a guess. The callers turn
+    /// `None` into an actionable error naming their escape-hatch flag.
+    #[test]
+    fn no_matching_secret_yields_none() {
+        assert_eq!(pick_release_secret(""), None);
+        assert_eq!(pick_release_secret("sh.helm.release.v1.t.v1\n"), None);
+        assert_eq!(pick_release_secret("only-connector-secrets\n"), None);
+    }
+}
+
+#[cfg(test)]
 mod sealing_preservation_tests {
     use super::*;
 
@@ -3325,7 +3384,7 @@ pub async fn discover_api_key(namespace: &str, release: &str) -> Result<String> 
         .await
         .ok_or_else(|| {
             api_key_usage_err(format!(
-                "could not read the API key from secret {release}-secrets in namespace {namespace}; \
+                "could not read the API key from the chart Secret for release {release} in namespace {namespace}; \
                  pass --api-key or set CURIE_API_KEY to the release's api.apiKey"
             ))
         })
@@ -3352,7 +3411,7 @@ pub async fn discover_valkey_password(namespace: &str, release: &str) -> Result<
         .await
         .ok_or_else(|| {
             valkey_password_usage_err(format!(
-                "could not read the Valkey password from secret {release}-secrets in namespace \
+                "could not read the Valkey password from the chart Secret for release {release} in namespace \
                  {namespace}; pass --valkey-password or set CURIE_VALKEY_PASSWORD to the \
                  release's valkey.password"
             ))
@@ -3380,7 +3439,7 @@ pub async fn discover_slack_bot_token(namespace: &str, release: &str) -> Result<
         .filter(|token| !token.is_empty())
         .ok_or_else(|| {
             slack_bot_token_usage_err(format!(
-                "could not read a Slack bot token from secret {release}-secrets in namespace \
+                "could not read a Slack bot token from the chart Secret for release {release} in namespace \
                  {namespace}; the workspace may not be connected (run `curie cluster comms \
                  --slack`), or set CURIE_SLACK_BOT_TOKEN"
             ))
@@ -3436,11 +3495,24 @@ pub async fn dispatcher_connected(namespace: &str, release: &str) -> bool {
     }
 }
 
-/// Read one data key out of a release's chart Secret, decoded server-side by
-/// kubectl's `base64decode` so the plaintext never lands in argv (#524). `None`
-/// when the Secret, the key, or the cluster is unreachable; the caller turns
-/// that into an actionable error naming its own escape-hatch flag.
-async fn read_release_secret(namespace: &str, release: &str, data_key: &str) -> Option<String> {
+/// The name of the release's chart Secret, discovered rather than computed.
+///
+/// It was computed as `<release>-secrets`, which is only right when the release
+/// name happens to contain the chart name. The chart uses helm's standard
+/// `fullname`, so a default install renders `<release>-curie-secrets` and every
+/// read silently found nothing. It went unnoticed because the installs that
+/// exercise these paths set `nameOverride` to the release name, which collapses
+/// the two forms.
+///
+/// Discovered because it cannot be computed from what the CLI knows: both
+/// `nameOverride` and `fullnameOverride` change the answer, and neither is
+/// visible from the release name alone. Selecting on the instance label works
+/// whatever the operator set.
+///
+/// The `-connector-secrets` exclusion is load-bearing: per-agent connector
+/// Secrets carry the same release labels, and one of those would be a
+/// confidently wrong answer rather than an empty one.
+async fn release_secret_name(namespace: &str, release: &str) -> Option<String> {
     let cmd = OpsCommand::new(
         "kubectl",
         vec![
@@ -3448,7 +3520,59 @@ async fn read_release_secret(namespace: &str, release: &str, data_key: &str) -> 
             plain(namespace),
             plain("get"),
             plain("secret"),
-            plain(format!("{release}-secrets")),
+            plain("-l"),
+            plain(format!("app.kubernetes.io/instance={release}")),
+            plain("-o"),
+            plain("jsonpath={range .items[*]}{.metadata.name}{\"\\n\"}{end}"),
+        ],
+    );
+    let (ok, out, _err) = run_capture(&cmd).await.ok()?;
+    if !ok {
+        return None;
+    }
+    pick_release_secret(&out)
+}
+
+/// The chart Secret among a release's Secrets, or `None` if it is not there.
+///
+/// Pure, so the selection rule is testable without a cluster -- which is how
+/// the `-connector-secrets` collision was caught before it could pick one.
+pub fn pick_release_secret(names: &str) -> Option<String> {
+    names
+        .lines()
+        .map(str::trim)
+        .filter(|n| !n.is_empty())
+        .find(|n| n.ends_with("-secrets") && !n.ends_with("-connector-secrets"))
+        .map(str::to_string)
+}
+
+/// The chart Secret's name, falling back to the historical guess.
+///
+/// A caller that must NAME the Secret (rather than read through it) still needs
+/// a string when the cluster is unreachable -- a `--dry-run` plan, for
+/// instance. The fallback is the old computed form, which is right for the
+/// installs that set `nameOverride` and wrong in exactly the way this function
+/// exists to fix, so it is a last resort and never silent in a live run.
+pub async fn release_secret_name_or_default(namespace: &str, release: &str) -> String {
+    release_secret_name(namespace, release)
+        .await
+        .unwrap_or_else(|| format!("{release}-secrets"))
+}
+
+/// Read one data key out of a release's chart Secret, decoded server-side by
+/// kubectl's `base64decode` so the plaintext never lands in argv (#524). `None`
+/// when the Secret, the key, or the cluster is unreachable; the caller turns
+/// that into an actionable error naming its own escape-hatch flag.
+async fn read_release_secret(namespace: &str, release: &str, data_key: &str) -> Option<String> {
+    let secret = release_secret_name(namespace, release).await?;
+    let cmd = OpsCommand::new(
+        "kubectl",
+        vec![
+            plain("-n"),
+            plain(namespace),
+            plain("get"),
+            plain("secret"),
+            plain(secret),
             plain("-o"),
             plain(format!(
                 "go-template={{{{ index .data \"{data_key}\" | base64decode }}}}"


### PR DESCRIPTION
Found while building `curie seal` on top of `read_release_secret` — I stopped rather than inherit it.

## The bug

```
the CLI computed:      <release>-secrets
the chart renders:     <release>-curie-secrets     (helm's standard fullname)
```

Every read silently found nothing on a default install. It returns `None`, and the callers turn that into *"could not read the API key"* — pointing the operator at **permissions** rather than at a name that never existed.

**Why nobody noticed:** the installs that exercise these paths set `nameOverride` to the release name, which collapses both forms into the same string. It works on the cluster it was built against and fails for a first-time user.

## Discovered, not computed

I can't compute it: both `nameOverride` and `fullnameOverride` change the answer, and neither is visible from the release name. Selecting on the instance label works whatever the operator set.

## The exclusion is load-bearing

Per-agent connector Secrets carry the **same release labels**, and kubectl lists alphabetically:

```
acme-bot-acme-bot-connector-secrets     ← sorts first
acme-bot-secrets                        ← the one we want
```

Without `!ends_with("-connector-secrets")` the selector confidently returns a connector Secret — worse than an empty answer, because the caller then reads a key genuinely absent from it and reports the wrong cause again.

**Falsified** by dropping the exclusion: two tests fail, including the alphabetical-ordering one.

## Also fixed: the same bug in `cluster migrate-store`

#1333 named the Secret the same way for its staging pod. There the failure mode is worse — it fails **mid-migration**, with the export already taken and the store half moved.

Three error messages also stop naming a Secret they may have been wrong about.

`fmt`, `clippy --all-targets -D warnings`, 38 suites green. No behaviour change on installs that set `nameOverride` — which is every install that currently works.