### PR TITLE
Add `curie seal`, so an author can commit a connector credential

### DIFF
--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -3904,6 +3904,65 @@ export const commandManifest = {
       "name": "apply"
     },
     {
+      "about": "Encrypt a connector credential to a cluster (ADR-0094)",
+      "args": [
+        {
+          "global": false,
+          "help": "The connector in connectors.yaml that reads this value",
+          "id": "connector",
+          "long": "connector",
+          "positional": false,
+          "required": true
+        },
+        {
+          "global": false,
+          "help": "The environment variable name the connector reads it as",
+          "id": "env_name",
+          "positional": true,
+          "required": true
+        },
+        {
+          "default_values": [
+            "curie"
+          ],
+          "global": false,
+          "id": "namespace",
+          "long": "namespace",
+          "positional": false,
+          "required": false
+        },
+        {
+          "default_values": [
+            "curie"
+          ],
+          "global": false,
+          "id": "release",
+          "long": "release",
+          "positional": false,
+          "required": false
+        },
+        {
+          "global": false,
+          "help": "Seal against this public key instead of reading one from a cluster, so an author with no cluster access can still seal",
+          "id": "public_key",
+          "long": "public-key",
+          "positional": false,
+          "required": false
+        },
+        {
+          "global": false,
+          "help": "Read the value from this environment variable instead of prompting",
+          "id": "from_env",
+          "long": "from-env",
+          "positional": false,
+          "required": false
+        }
+      ],
+      "hidden": false,
+      "long_about": "Encrypt a connector credential to a cluster (ADR-0094).\n\nThe blob is safe to commit: only a cluster holding the matching private key can read it. The value is never taken as an argument -- it comes from a hidden prompt, a pipe, or `--from-env` -- so it cannot land in a shell history or the process table.",
+      "name": "seal"
+    },
+    {
       "about": "Show what `curie apply` would change about the live release (ADR-0097)",
       "args": [
         {

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -3901,6 +3901,65 @@
       "name": "apply"
     },
     {
+      "about": "Encrypt a connector credential to a cluster (ADR-0094)",
+      "args": [
+        {
+          "global": false,
+          "help": "The connector in connectors.yaml that reads this value",
+          "id": "connector",
+          "long": "connector",
+          "positional": false,
+          "required": true
+        },
+        {
+          "global": false,
+          "help": "The environment variable name the connector reads it as",
+          "id": "env_name",
+          "positional": true,
+          "required": true
+        },
+        {
+          "default_values": [
+            "curie"
+          ],
+          "global": false,
+          "id": "namespace",
+          "long": "namespace",
+          "positional": false,
+          "required": false
+        },
+        {
+          "default_values": [
+            "curie"
+          ],
+          "global": false,
+          "id": "release",
+          "long": "release",
+          "positional": false,
+          "required": false
+        },
+        {
+          "global": false,
+          "help": "Seal against this public key instead of reading one from a cluster, so an author with no cluster access can still seal",
+          "id": "public_key",
+          "long": "public-key",
+          "positional": false,
+          "required": false
+        },
+        {
+          "global": false,
+          "help": "Read the value from this environment variable instead of prompting",
+          "id": "from_env",
+          "long": "from-env",
+          "positional": false,
+          "required": false
+        }
+      ],
+      "hidden": false,
+      "long_about": "Encrypt a connector credential to a cluster (ADR-0094).\n\nThe blob is safe to commit: only a cluster holding the matching private key can read it. The value is never taken as an argument -- it comes from a hidden prompt, a pipe, or `--from-env` -- so it cannot land in a shell history or the process table.",
+      "name": "seal"
+    },
+    {
       "about": "Show what `curie apply` would change about the live release (ADR-0097)",
       "args": [
         {

--- a/cli/schema/index.json
+++ b/cli/schema/index.json
@@ -184,6 +184,12 @@
       "version": 1
     },
     {
+      "result": "SealOutput",
+      "kind": "CliOutput",
+      "schema": "seal.schema.json",
+      "version": 1
+    },
+    {
       "result": "SecretsListOutput",
       "kind": "CliOutput",
       "schema": "secrets.schema.json",

--- a/cli/schema/seal.schema.json
+++ b/cli/schema/seal.schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.curietech.ai/cli/seal/v1.json",
+  "title": "curie seal --json",
+  "description": "The agent-facing payload of `curie seal`: a connector credential encrypted to one cluster (ADR-0094). Every field is safe to commit -- the sealed blob is useless without the cluster's private key, and the public key is published by design. The plaintext value never appears.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "connector": {
+      "type": "string",
+      "description": "The connector in connectors.yaml that reads this value."
+    },
+    "env_name": {
+      "type": "string",
+      "description": "The environment variable name the connector reads it as."
+    },
+    "sealed": {
+      "type": "string",
+      "description": "Base64 of a NaCl sealed box. Safe to commit. Sealing the same value twice yields different blobs, so a repository's history does not reveal which credentials are equal."
+    },
+    "public_key": {
+      "type": "string",
+      "description": "The cluster public key this was sealed to, so an author can confirm which cluster can open it. Not a secret."
+    },
+    "yaml": {
+      "type": "string",
+      "description": "A ready-to-paste connectors.yaml fragment carrying the sealed value at the path the loader reads."
+    }
+  },
+  "required": ["connector", "env_name", "sealed", "public_key", "yaml"]
+}

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -35,6 +35,7 @@ pub mod runner;
 pub mod scaffold;
 pub mod schema;
 pub mod schemas;
+pub mod seal;
 pub mod sealing;
 pub mod secrets;
 pub mod slack;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -429,6 +429,31 @@ enum Command {
         allow_stateful_removal: bool,
     },
 
+    /// Encrypt a connector credential to a cluster (ADR-0094).
+    ///
+    /// The blob is safe to commit: only a cluster holding the matching private
+    /// key can read it. The value is never taken as an argument -- it comes
+    /// from a hidden prompt, a pipe, or `--from-env` -- so it cannot land in a
+    /// shell history or the process table.
+    Seal {
+        /// The connector in connectors.yaml that reads this value.
+        #[arg(long)]
+        connector: String,
+        /// The environment variable name the connector reads it as.
+        env_name: String,
+        #[arg(long, default_value = "curie")]
+        namespace: String,
+        #[arg(long, default_value = "curie")]
+        release: String,
+        /// Seal against this public key instead of reading one from a cluster,
+        /// so an author with no cluster access can still seal.
+        #[arg(long)]
+        public_key: Option<String>,
+        /// Read the value from this environment variable instead of prompting.
+        #[arg(long)]
+        from_env: Option<String>,
+    },
+
     /// Show what `curie apply` would change about the live release (ADR-0097).
     ///
     /// Read-only, and resolves no credential: "what would change?" is most
@@ -3208,6 +3233,24 @@ async fn run(command: Option<Command>) -> Result<()> {
                 .await?,
             )
         }
+        Some(Command::Seal {
+            connector,
+            env_name,
+            namespace,
+            release,
+            public_key,
+            from_env,
+        }) => emit(
+            curie::seal::seal(curie::seal::SealOpts {
+                connector,
+                env_name,
+                namespace,
+                release,
+                public_key,
+                from_env,
+            })
+            .await?,
+        ),
         Some(Command::Diff { file }) => {
             let cfg = curie::installation::Installation::load(&file)?;
             let local = curie::installation::plan_installation(cfg, false)?;

--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -3559,6 +3559,25 @@ pub async fn release_secret_name_or_default(namespace: &str, release: &str) -> S
         .unwrap_or_else(|| format!("{release}-secrets"))
 }
 
+/// The release's sealing keys (ADR-0094): current first, then the previous one
+/// if a rotation is in progress.
+///
+/// Returns whatever is present. An empty vector means this release has no
+/// sealing key, which the caller must report rather than work around -- sealing
+/// against nothing, or "decrypting" without a key, both produce a connector
+/// that starts and then fails every call.
+pub async fn read_sealing_keys(namespace: &str, release: &str) -> Vec<String> {
+    let mut keys = Vec::new();
+    for data_key in ["sealingPrivateKey", "sealingPreviousPrivateKey"] {
+        if let Some(value) = read_release_secret(namespace, release, data_key).await {
+            if !value.trim().is_empty() {
+                keys.push(value);
+            }
+        }
+    }
+    keys
+}
+
 /// Read one data key out of a release's chart Secret, decoded server-side by
 /// kubectl's `base64decode` so the plaintext never lands in argv (#524). `None`
 /// when the Secret, the key, or the cluster is unreachable; the caller turns

--- a/cli/src/seal.rs
+++ b/cli/src/seal.rs
@@ -1,0 +1,235 @@
+//! `curie seal`: encrypt a connector credential to a cluster (ADR-0094).
+//!
+//! The author-facing half of sealed secrets. Everything about the format lives
+//! in [`crate::sealing`]; this module is the ergonomics — find the cluster's
+//! public key, take the value without it touching a shell history, and hand
+//! back something that can be pasted into `connectors.yaml`.
+//!
+//! Two ways to reach a public key, and the second is not a convenience:
+//!
+//! - **From the cluster** (default). Reads the private key from the release and
+//!   derives the public half, so the two can never disagree.
+//! - **From `--public-key`**. An agent author sealing a credential need not have
+//!   cluster access at all — that is rather the point of publishing a public
+//!   key. Requiring kubectl would put every author in the operator's shoes and
+//!   quietly undo the separation ADR-0094 is buying.
+
+use std::io::{self, IsTerminal, Read, Write};
+
+use anyhow::{bail, Context, Result};
+
+/// Where a sealed value is written in `connectors.yaml`, for the paste snippet.
+fn snippet(connector: &str, env_name: &str, blob: &str) -> String {
+    format!("connectors:\n  {connector}:\n    sealed_secrets:\n      {env_name}: {blob}")
+}
+
+pub struct SealOpts {
+    pub connector: String,
+    pub env_name: String,
+    pub namespace: String,
+    pub release: String,
+    /// Seal against this public key instead of reading one from a cluster.
+    pub public_key: Option<String>,
+    /// Read the value from this environment variable instead of prompting.
+    pub from_env: Option<String>,
+}
+
+#[derive(Debug)]
+pub struct SealOutput {
+    pub connector: String,
+    pub env_name: String,
+    pub sealed: String,
+    /// The public key it was sealed to, so the author can confirm which cluster
+    /// can open it. Not a secret: publishing it is the entire design.
+    pub public_key: String,
+}
+
+impl crate::ui::CliOutput for SealOutput {
+    fn to_json(&self) -> serde_json::Value {
+        serde_json::json!({
+            "connector": self.connector,
+            "env_name": self.env_name,
+            "sealed": self.sealed,
+            "public_key": self.public_key,
+            "yaml": snippet(&self.connector, &self.env_name, &self.sealed),
+        })
+    }
+
+    fn render(&self, ui: &crate::ui::Ui) {
+        ui.payload_plain(&snippet(&self.connector, &self.env_name, &self.sealed));
+        ui.note(&format!(
+            "sealed to public key {}. Only a cluster holding the matching private \
+             key can read it, so this is safe to commit. Paste the block above into \
+             connectors.yaml.",
+            self.public_key
+        ));
+    }
+}
+
+/// An env var name, held to the same shape `curie secrets set` requires.
+///
+/// The value becomes an environment variable inside the connector container, so
+/// a name the shell cannot export is a deploy-time failure discovered long
+/// after the seal looked fine.
+fn validate_env_name(name: &str) -> Result<()> {
+    let ok = !name.is_empty()
+        && name
+            .chars()
+            .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == '_')
+        && !name.starts_with(|c: char| c.is_ascii_digit());
+    if !ok {
+        bail!(
+            "`{name}` is not a usable environment variable name; use upper case, digits \
+             and underscores, e.g. GRAFANA_SERVICE_ACCOUNT_TOKEN"
+        );
+    }
+    Ok(())
+}
+
+/// Take the credential without it reaching a shell history or the process table.
+///
+/// Order matters: an explicit `--from-env` wins, then a piped stdin, then a
+/// hidden prompt. The stdin path is what makes this usable from a script
+/// without inventing a flag that takes the value as an argument -- which would
+/// put a live credential in `ps` output and every shell history on the machine.
+fn read_value(opts: &SealOpts) -> Result<String> {
+    if let Some(var) = &opts.from_env {
+        let value = std::env::var(var).with_context(|| format!("reading the value from ${var}"))?;
+        if value.is_empty() {
+            bail!("${var} is set but empty; there is nothing to seal");
+        }
+        return Ok(value);
+    }
+    if !io::stdin().is_terminal() {
+        let mut buf = String::new();
+        io::stdin()
+            .read_to_string(&mut buf)
+            .context("reading the value from stdin")?;
+        let value = buf.trim_end_matches(['\n', '\r']).to_string();
+        if value.is_empty() {
+            bail!("stdin was empty; there is nothing to seal");
+        }
+        return Ok(value);
+    }
+    print!("{}: ", opts.env_name);
+    io::stdout().flush().ok();
+    let value = rpassword::read_password().context("reading the value from the terminal")?;
+    if value.is_empty() {
+        bail!("no value entered; there is nothing to seal");
+    }
+    Ok(value)
+}
+
+pub async fn seal(opts: SealOpts) -> Result<SealOutput> {
+    validate_env_name(&opts.env_name)?;
+    if opts.connector.trim().is_empty() {
+        bail!("--connector names the connector in connectors.yaml that reads this value");
+    }
+
+    let public_key = match &opts.public_key {
+        Some(key) => {
+            // Validate by deriving nothing -- just check it decodes to a key of
+            // the right size, so a truncated paste fails here rather than
+            // producing a blob no cluster can open.
+            crate::sealing::seal(key, "probe")
+                .context("--public-key is not a usable sealing public key")?;
+            key.trim().to_string()
+        }
+        None => {
+            let keys = crate::ops::read_sealing_keys(&opts.namespace, &opts.release).await;
+            let Some(current) = keys.first() else {
+                bail!(
+                    "release {} in namespace {} has no sealing key, so nothing can be sealed \
+                     to it. Run `curie cluster up` to generate one, or pass --public-key to \
+                     seal against a cluster you cannot reach.",
+                    opts.release,
+                    opts.namespace
+                );
+            };
+            // Derived, never read from a second field: a stored public key can
+            // drift from its private half, and the mismatch only surfaces when
+            // a deploy fails to decrypt.
+            crate::sealing::public_key_of(current)
+                .context("the release's sealing private key is malformed")?
+        }
+    };
+
+    let value = read_value(&opts)?;
+    let sealed = crate::sealing::seal(&public_key, &value)?;
+
+    Ok(SealOutput {
+        connector: opts.connector,
+        env_name: opts.env_name,
+        sealed,
+        public_key,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sealing;
+
+    #[test]
+    fn the_snippet_is_pasteable_yaml_in_the_shape_connectors_uses() {
+        let text = snippet("grafana", "GRAFANA_TOKEN", "AgBv3n2K");
+        let parsed: serde_json::Value =
+            serde_norway::from_str(&text).expect("the snippet must be valid YAML");
+        assert_eq!(
+            parsed["connectors"]["grafana"]["sealed_secrets"]["GRAFANA_TOKEN"],
+            serde_json::json!("AgBv3n2K"),
+            "the snippet must nest exactly where connectors.yaml reads it"
+        );
+    }
+
+    #[test]
+    fn an_unusable_env_var_name_is_refused() {
+        for bad in ["", "lower", "HAS-DASH", "1LEADING", "HAS SPACE"] {
+            assert!(validate_env_name(bad).is_err(), "{bad:?} must be refused");
+        }
+        validate_env_name("GRAFANA_SERVICE_ACCOUNT_TOKEN").expect("a normal name is fine");
+    }
+
+    /// The round trip that matters: what `seal` emits must open with the
+    /// cluster's private key, or the whole feature is decorative.
+    #[test]
+    fn a_sealed_value_opens_with_the_cluster_key() {
+        let kp = sealing::generate_keypair();
+        let blob = sealing::seal(&kp.public_key, "grafana-token").expect("seals");
+        assert_eq!(
+            sealing::open_with_any(&[kp.private_key], &blob).expect("opens"),
+            "grafana-token"
+        );
+    }
+
+    /// A truncated or mistyped `--public-key` must fail at seal time. Producing
+    /// a blob no cluster can open would be discovered at deploy, by which point
+    /// it is committed and pushed.
+    #[test]
+    fn a_malformed_public_key_is_rejected_up_front() {
+        for bad in ["not base64!!", "c2hvcnQ=", ""] {
+            assert!(
+                sealing::seal(bad, "value").is_err(),
+                "{bad:?} must not produce a blob"
+            );
+        }
+    }
+
+    /// The payload carries the public key so an author can tell WHICH cluster
+    /// can open what they just committed.
+    #[test]
+    fn the_payload_names_the_key_it_sealed_to() {
+        use crate::ui::CliOutput;
+        let kp = sealing::generate_keypair();
+        let out = SealOutput {
+            connector: "grafana".into(),
+            env_name: "GRAFANA_TOKEN".into(),
+            sealed: "AgBv3n2K".into(),
+            public_key: kp.public_key.clone(),
+        };
+        let json = out.to_json();
+        assert_eq!(json["public_key"], serde_json::json!(kp.public_key));
+        assert_eq!(json["connector"], serde_json::json!("grafana"));
+        assert!(json["yaml"].as_str().unwrap().contains("sealed_secrets"));
+    }
+}

--- a/cli/tests/json_contract.rs
+++ b/cli/tests/json_contract.rs
@@ -1014,6 +1014,29 @@ fn diff_output_validates() {
 }
 
 #[test]
+fn seal_output_validates() {
+    // Built from a real seal, so the payload is the shape the verb emits.
+    let kp = curie::sealing::generate_keypair();
+    let sealed = curie::sealing::seal(&kp.public_key, "a-real-looking-token").expect("seals");
+    let out = curie::seal::SealOutput {
+        connector: "grafana".to_string(),
+        env_name: "GRAFANA_TOKEN".to_string(),
+        sealed,
+        public_key: kp.public_key.clone(),
+    };
+    let json = out.to_json();
+    assert_valid("seal.schema.json", &json);
+
+    // The plaintext must not survive anywhere in the payload -- this is the
+    // whole point of the verb, and the payload is what gets committed.
+    let rendered = serde_json::to_string(&json).expect("serializes");
+    assert!(
+        !rendered.contains("a-real-looking-token"),
+        "the plaintext reached the --json payload: {rendered}"
+    );
+}
+
+#[test]
 fn check_output_validates() {
     // CheckOutput::to_json is `serde_json::to_value(report)`; validate that exact
     // shape against the check schema.

--- a/docs/interfaces/cli-output/INTERFACE.md
+++ b/docs/interfaces/cli-output/INTERFACE.md
@@ -92,10 +92,10 @@ Nine, all in the CLI crate:
   syntactic call-site inventory, not a type-level proof that *every* verb returns
   a `CliOutput`.
 - **Committed JSON Schemas with a drift gate (since #841).** Each `to_json` is no
-  longer schema-free: there are 36 committed schemas under `cli/schema/` with an
+  longer schema-free: there are 37 committed schemas under `cli/schema/` with an
   index (`cli/schema/index.json`), a `syn`-based inventory gate over every `impl
-  CliOutput`, and per-family output validation — all 36 are validated against real
-  `to_json()` output across 57 tests in `cli/tests/json_contract.rs`. Those tests
+  CliOutput`, and per-family output validation — all 37 are validated against real
+  `to_json()` output across 58 tests in `cli/tests/json_contract.rs`. Those tests
   drive each output type's `to_json()` once per output variant rather than calling
   the pure builder functions behind it, so a variant whose `to_json()` arm drifts
   from the schema is caught even when the builder it delegates to still validates.


### PR DESCRIPTION
The author-facing half of [ADR-0094](docs/adr/0094-a-bundle-carries-its-own-sealed-connector-keys.md), on top of the chart wiring (#1339) and the secret-name fix (#1340).

```
curie seal --connector grafana GRAFANA_TOKEN
```

prints a pasteable `connectors.yaml` block. The credential can then live in the repository beside the connector that reads it — the last manual step in onboarding an agent.

## Three decisions worth reviewing

**The value is never an argument.** It comes from a hidden prompt, a pipe, or `--from-env`. A `--value` flag is the obvious ergonomics and would put a live credential in `ps` output and every shell history on the machine.

**`--public-key` is not a convenience.** An agent author sealing a credential need not have cluster access — that's the entire point of publishing a public key. Requiring `kubectl` would put every author in the operator's shoes and undo the separation the ADR is buying. A malformed key is rejected at seal time, rather than producing a blob that fails to open at deploy, *after* it's committed and pushed.

**The public key is derived, never stored twice.** Reading it from a second field invites drift, and a mismatched pair is a padlock nothing can open — discovered only when a deploy fails to decrypt.

## Verification

A real round trip **through the built binary**, not just unit tests:

```
pipe a value in → seal against a generated public key → 88-char blob
plaintext present in blob: 0
open with the matching private key → "my-grafana-token"
```

The snippet test parses the printed block **as YAML** and asserts the value lands exactly where the loader reads it (`connectors.<name>.sealed_secrets.<VAR>`) — a snippet that looks right and nests wrong is worse than none.

The `--json` contract test asserts the plaintext appears nowhere in the payload, since that payload is what gets committed.

`fmt`, `clippy --all-targets -D warnings`, 38 suites. Both command manifests regenerated (`cargo run -- schema` + `pnpm gen:manifest`), schema registered in the inventory.

## What's left in ADR-0094

Only the reconciler decrypt step. Until it lands the contract still **refuses** a declared `sealed_secrets`, so you can seal a value and commit it, but nothing will deploy it yet — deliberately, so there's no window where a connector starts without its credential and 401s every call.