### PR TITLE
Fix two migration bugs a live rename found

### DIFF
--- a/cli/src/migrate_store.rs
+++ b/cli/src/migrate_store.rs
@@ -531,6 +531,39 @@ mod tests {
         assert_eq!(staging_pod("sre-bot"), "sre-bot-store-migration");
     }
 
+    /// Found by the first live run. The component is in the Service's
+    /// `spec.selector`, not `metadata.labels`, so a `-l` label selector matched
+    /// nothing and the run died with `array index out of bounds: index 0,
+    /// length 0` before copying anything.
+    #[test]
+    fn the_service_lookup_filters_on_spec_selector_not_labels() {
+        let line = store_service_cmd(&opts(), StoreKind::Minio).display();
+        assert!(
+            line.contains("spec.selector"),
+            "must filter on spec.selector, where the chart puts the component: {line}"
+        );
+        assert!(
+            !line.contains(" -l "),
+            "a label selector matches nothing here: {line}"
+        );
+        assert!(line.contains("minio"), "{line}");
+    }
+
+    /// Also found live. The staging pod mounts the release Secret when it is
+    /// CREATED -- before the upgrade exists -- and kubelet refreshes a mounted
+    /// Secret on a sync period, so the NEW store's key is absent for up to a
+    /// minute after the upgrade adds it. The import must wait rather than fail
+    /// on `cat: /secret/rustfsSecretKey: No such file or directory`.
+    #[test]
+    fn the_import_waits_for_the_new_stores_secret_key() {
+        let line =
+            import_cmd(&opts(), StoreKind::Rustfs, "curie-bundles", "http://s:9000").display();
+        assert!(
+            line.contains("rustfsSecretKey") && line.contains("seq 1"),
+            "import must poll for the key the upgrade adds: {line}"
+        );
+    }
+
     #[test]
     fn a_lost_object_is_reported() {
         let before = "100 a.tar\n200 b.tar";


### PR DESCRIPTION
You asked me to validate it. I did, on minikube, and it failed twice before it worked.

## The test

Chart **0.5.1 with `minio`** (the true pre-rename chart — see note below), seeded with known objects and their MD5s recorded, then `curie apply --migrate-store` onto **0.6.0 with `rustfs`**.

## Bug 1 — the Service lookup found nothing

```
Error: could not find the minio Service to copy from: error executing jsonpath
"{.items[0].metadata.name}": array index out of bounds: index 0, length 0
```

It filtered `kubectl get svc` with a `-l` label selector. But the chart puts `app.kubernetes.io/component` in the Service's **`spec.selector`**, not its `metadata.labels` — object-level labels carry only name/instance/version:

```
labels:       {instance: mt, managed-by: Helm, name: mt, version: 0.5.1}
spec.selector:{app.kubernetes.io/component: minio, instance: mt, name: mt}
```

Now filters on `spec.selector` — where `live_stateful_components` was already reading it from. I had aligned detection with that in #1333 and then got the Service lookup wrong the other way.

## Bug 2 — the staging pod couldn't read the new store's password

```
Error: the import copy failed; the staged copy is intact, so retry is safe:
cat: /secret/rustfsSecretKey: No such file or directory
```

The pod mounts the release Secret when it's **created** — before the upgrade exists. kubelet refreshes a mounted Secret on a sync period, not instantly, so the new store's key was absent for about a minute after the upgrade added it. The import now polls with a bounded wait.

Waiting rather than recreating the pod: its `emptyDir` holds the **only copy** of the objects at that moment.

## What held up

The staged copy survived both failures intact, and `--phase import` recovered the first one. The retain-on-failure design was exercised by a real fault rather than a simulated one — which is the part I couldn't have tested any other way.

## Verified after the fix, twice

```
$ curie apply -f curie.yaml --chart charts/curie
refusing to apply: this would DELETE 1 stateful component(s)...
  mt-minio
Re-run with --migrate-store...

$ curie apply -f curie.yaml --chart charts/curie --migrate-store
installing release mt: ok (160s)
applied mt in mt
```

```
mt-minio gone → mt-rustfs present
staging pod: NotFound (cleaned up on success)
alpha.tar  d070eab1df1692eefac8ff18185b58ea  ← equals the seeded MD5
beta.tar   1e51f693f7763c88e50732b024bbe445  ← equals the seeded MD5
```

Objects already present in the target were reported as **added** rather than missing, so the run still verified — the concurrent-write case, hit unplanned.

## A correction worth recording

I've been saying "0.6.0 renamed minio → rustfs". The rename commit landed on 2026-08-04 **while the chart was already version 0.5.1**, then shipped in 0.6.0. So two different charts both call themselves `0.5.1` — one with minio, one with rustfs. From a released-version standpoint the docs are right; but the rename itself went in under an unchanged version number, which is its own problem.

## Notes

Two regression tests pin both bugs. `fmt`, `clippy --all-targets -D warnings`, 38 suites green.

Built in a separate worktree: another session is mid-work on ADR-0094 sealing in the shared checkout, so this touches only `migrate_store.rs` and nothing of theirs.