### PR TITLE
Pin the Linux binaries' glibc floor instead of inheriting the runner's

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -208,6 +208,51 @@ jobs:
           path: cli/target/release/curie
           if-no-files-found: error
 
+  cli-portability:
+    name: CLI runs on old glibc (release build path)
+    runs-on: ubuntu-latest
+    # The release cross-compile path was never exercised before a tag, so a
+    # regression in it was undiscoverable until someone tried the artifact on a
+    # real host. #1341 shipped exactly that way: both Linux targets inherited
+    # the runner's GLIBC_2.39, and every runner that executes them is also
+    # `ubuntu-latest`, so nothing went red. This job runs the same path a tag
+    # would and then runs the result on an OLDER distro, which is the only
+    # check that could have caught it.
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Cargo cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: cli
+      - name: Install zig toolchain
+        run: |
+          set -euo pipefail
+          python3 -m pip install --user --break-system-packages "ziglang==0.16.0"
+          cargo install cargo-zigbuild --locked --version 0.23.0
+      # x86_64 only. The floor is a property of the toolchain, not the
+      # architecture, so building both would double the cost to re-prove the
+      # same thing -- and the arm64 artifact cannot be EXECUTED here without
+      # dragging in qemu. The static assertion below covers arm64 at release
+      # time; this job's job is to prove the floor is real, not merely declared.
+      - name: Build (same path as the release)
+        working-directory: cli
+        env:
+          CURIE_BUILD_CHANNEL: release
+          RUSTFLAGS: -C strip=symbols
+        run: cargo zigbuild --release --target x86_64-unknown-linux-gnu.2.28
+      - name: Assert the glibc floor
+        run: bash scripts/check-glibc-floor.sh cli/target/x86_64-unknown-linux-gnu/release/curie 2.28
+      # The floor asserted above is a claim about symbols. This is the claim
+      # under test: Amazon Linux 2023 is glibc 2.34, it is what the deployment
+      # runbook provisions, and it is where `curie --version` died.
+      - name: Run it on Amazon Linux 2023
+        run: |
+          set -euo pipefail
+          docker run --rm -v "$PWD/cli/target/x86_64-unknown-linux-gnu/release/curie:/curie:ro" \
+            amazonlinux:2023 /curie --version
+
   contracts-ts:
     name: Contracts (generated TypeScript compiles)
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -464,29 +464,43 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # glibc for the MVP: the CLI links rustls (no OpenSSL), but a musl build
-          # needs the musl C cross-toolchain in the runner; glibc is the simple,
-          # portable-enough default. Swap to x86_64-unknown-linux-musl (add
-          # musl-tools) later if a fully static binary is wanted.
+          # `glibc:` pins the SYMBOL FLOOR the binary is built against. It is
+          # not cosmetic and it must not be dropped (#1341).
+          #
+          # These targets used to build with the runner's own libc headers.
+          # `ubuntu-latest` is Ubuntu 24.04, so the artifacts required
+          # GLIBC_2.39, and glibc is backward compatible but NOT forward: the
+          # published binary would not start on anything older. Amazon Linux
+          # 2023 ships 2.34, so `curie --version` on the very host this ARM
+          # target exists to serve died with
+          #   `/lib64/libc.so.6: version GLIBC_2.39 not found`
+          # -- no subcommand reachable, the cluster unoperable by its own CLI.
+          #
+          # Nothing caught it: every runner that executes these artifacts is
+          # also `ubuntu-latest`, so CI and the sre-bot eval lane were green
+          # throughout. The `Assert the glibc floor` step below, and the
+          # `cli-portability` job in ci.yaml, are what close that hole.
+          #
+          # 2.28 covers RHEL/Alma 8, Debian 10, Ubuntu 18.04 and AL2023. Lower
+          # it only with a host in mind; raising it silently is the bug.
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
+            glibc: "2.28"
           # arm64 Linux is the cheap-cloud target: Graviton and equivalents are
           # ~20% less than x86 for this workload, and a single-node k3s box is a
           # normal way to host a bot. Without a published binary the CLI cannot
           # run on the host it is managing -- the only options were compiling it
           # yourself or driving the cluster entirely from a laptop (#1065).
-          # Cross-compiled rather than run on an arm64 runner, so this costs no
-          # extra runner minutes. rustls pulls in `ring`, which compiles C, so a
-          # cross LINKER alone is not enough -- it needs a cross C compiler and
-          # the target libc headers. Without libc6-dev-arm64-cross, ring's build
-          # script reads the HOST /usr/include and dies on
-          # `bits/libc-header-start.h: No such file or directory`. Verified by
-          # reproducing this job in a clean amd64 container.
+          # Still cross-compiled rather than run on an arm64 runner, so this
+          # costs no extra runner minutes.
+          #
+          # The cross gcc + libc6-dev-arm64-cross pair is gone: `zig cc` is the
+          # C compiler now, so `ring` gets a sysroot for the TARGET (with the
+          # pinned glibc) instead of the host's. That was the whole reason those
+          # packages were needed.
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
-            cross_linker: aarch64-linux-gnu-gcc
-            apt_packages: gcc-aarch64-linux-gnu libc6-dev-arm64-cross
-            cross_ar: aarch64-linux-gnu-ar
+            glibc: "2.28"
           - target: aarch64-apple-darwin
             os: macos-latest
     steps:
@@ -495,11 +509,17 @@ jobs:
           persist-credentials: false
       - name: Add target
         run: rustup target add ${{ matrix.target }}
-      - name: Install cross-linker
-        if: matrix.apt_packages != ''
+      # zig replaces the cross gcc AND decouples the glibc floor from the
+      # runner. cargo-zigbuild finds zig through the `ziglang` wheel, so no
+      # third-party action and nothing to add to the action-SHA pin list.
+      # `cargo install` compiles it (a few minutes, twice); the release runs on
+      # tags only, and a prebuilt would mean trusting an unpinned asset name.
+      - name: Install zig toolchain
+        if: matrix.glibc != ''
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends ${{ matrix.apt_packages }}
+          set -euo pipefail
+          python3 -m pip install --user --break-system-packages "ziglang==0.16.0"
+          cargo install cargo-zigbuild --locked --version 0.23.0
       - name: Assert tag matches the release-coupled versions
         run: |
           set -euo pipefail
@@ -517,26 +537,38 @@ jobs:
         working-directory: cli
         env:
           CURIE_BUILD_CHANNEL: release
-          # All empty for a native build. The CC/AR pair is what `ring`'s build
-          # script needs; the linker alone leaves it compiling C against the
-          # host sysroot.
-          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: ${{ matrix.cross_linker }}
-          CC_aarch64_unknown_linux_gnu: ${{ matrix.cross_linker }}
-          AR_aarch64_unknown_linux_gnu: ${{ matrix.cross_ar }}
-        run: cargo build --release --target ${{ matrix.target }}
+          # Strip at LINK time for the cross targets. The host `strip` cannot
+          # process a cross-built aarch64 ELF, and dropping the cross binutils
+          # means there is no aarch64-linux-gnu-strip left to fall back to.
+          RUSTFLAGS: ${{ matrix.glibc != '' && '-C strip=symbols' || '' }}
+        run: |
+          set -euo pipefail
+          if [ -n "${{ matrix.glibc }}" ]; then
+            # The `.<glibc>` suffix is the floor. cargo-zigbuild drops it again
+            # for the output directory, so the path below is unchanged.
+            cargo zigbuild --release --target '${{ matrix.target }}.${{ matrix.glibc }}'
+          else
+            cargo build --release --target '${{ matrix.target }}'
+          fi
       - name: Strip and name the binary
         run: |
           bin="cli/target/${{ matrix.target }}/release/curie"
-          # Host strip cannot process a cross-built arm64 ELF; use the matching
-          # cross binutils when present. `|| true` keeps an unstrippable binary
-          # shippable rather than failing the release over symbol size.
-          if [ -n "${{ matrix.cross_linker }}" ] && command -v aarch64-linux-gnu-strip >/dev/null; then
-            aarch64-linux-gnu-strip "$bin" || true
-          else
+          # The pinned-floor targets are already stripped by
+          # `-C strip=symbols` at link time, which also sidesteps the host
+          # `strip` being unable to read a cross-built arm64 ELF. Only the
+          # native darwin build still needs the external tool. `|| true` keeps
+          # an unstrippable binary shippable rather than failing the release
+          # over symbol size.
+          if [ -z "${{ matrix.glibc }}" ]; then
             strip "$bin" || true
           fi
           mkdir -p dist
           cp "$bin" "dist/curie-${{ matrix.target }}"
+      # The artifact, not the build environment, is what ships. A runner image
+      # bump is exactly how this regressed, and it regressed invisibly.
+      - name: Assert the glibc floor
+        if: matrix.glibc != ''
+        run: bash scripts/check-glibc-floor.sh "cli/dist/curie-${{ matrix.target }}" "${{ matrix.glibc }}"
       # Cataloged from Cargo.lock, not the stripped binary: the lockfile is what
       # actually names every crate that went in, and stripping removes the symbols
       # a binary scan would need. Scanning the cli/ tree instead would also drag in

--- a/scripts/check-glibc-floor.sh
+++ b/scripts/check-glibc-floor.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+#
+# Assert a Linux binary's glibc symbol floor (#1341).
+#
+#   check-glibc-floor.sh <binary> <max-allowed>      e.g. dist/curie-... 2.28
+#
+# glibc is backward compatible, not forward: a binary that references
+# GLIBC_2.39 will not start on a host with 2.34, and the failure is total --
+#
+#   /lib64/libc.so.6: version `GLIBC_2.39' not found (required by curie)
+#
+# no subcommand runs, so a cluster becomes unoperable by its own CLI. That is
+# what shipped, because both Linux targets built against the runner's headers
+# and `ubuntu-latest` moved to Ubuntu 24.04 (glibc 2.39) while Amazon Linux
+# 2023 -- the OS the deployment runbook provisions -- is on 2.34.
+#
+# Nothing caught it. Every runner that executes these artifacts is also
+# `ubuntu-latest`, so CI and downstream eval lanes were green the whole time.
+# The floor is therefore asserted on the artifact rather than trusted to the
+# build environment: this script is the only thing standing between a runner
+# image bump and a silently unusable release.
+set -euo pipefail
+
+BIN="${1:?usage: check-glibc-floor.sh <binary> <max-allowed-glibc>}"
+MAX="${2:?usage: check-glibc-floor.sh <binary> <max-allowed-glibc>}"
+
+[ -f "$BIN" ] || { echo "FAIL: no such binary: $BIN" >&2; exit 1; }
+
+# Versioned symbol references live in .gnu.version_r and survive stripping, so
+# this works on the shipped artifact rather than needing an unstripped copy.
+#
+# Deliberately no `mapfile` / `${arr[-1]}`: both are bash 4+, and macOS still
+# ships 3.2. A guard that only runs in CI is half a guard.
+refs="$(strings "$BIN" | grep -oE 'GLIBC_2\.[0-9]+' | sort -uV || true)"
+
+if [ -z "$refs" ]; then
+  # A static or musl binary references none. That is stricter than the floor,
+  # not a failure.
+  echo "OK: $BIN references no versioned glibc symbols (static or musl)"
+  exit 0
+fi
+
+highest="$(printf '%s\n' "$refs" | tail -1)"
+worst="$(printf '%s\nGLIBC_%s\n' "$highest" "$MAX" | sort -uV | tail -1)"
+
+if [ "$worst" != "GLIBC_$MAX" ]; then
+  cat >&2 <<MSG
+FAIL: $BIN requires $highest, above the GLIBC_$MAX floor.
+
+  references: $(printf "%s " $refs)
+
+This binary will not start on a host with an older glibc, and the error names
+the loader rather than curie, so it reads like a corrupt download. Amazon Linux
+2023 is 2.34; RHEL/Alma 8 and Debian 10 are 2.28.
+
+Most likely cause: the build stopped going through \`cargo zigbuild --target
+<target>.<glibc>\` and fell back to the runner's own libc headers. Check the
+\`glibc:\` key in the release matrix.
+MSG
+  exit 1
+fi
+
+echo "OK: $BIN requires at most $highest (floor GLIBC_$MAX)"


### PR DESCRIPTION
Fixes #1341.

The released Linux CLIs require `GLIBC_2.39` and cannot start on Amazon Linux
2023 — the OS the deployment runbook provisions:

```
curie: /lib64/libc.so.6: version `GLIBC_2.39' not found (required by curie)
```

Not a subcommand failure. The binary does not execute, so `secrets set`,
`cluster up`, `cluster comms` and `cluster deploy` are all unreachable on the
host they are documented to run on.

This blocked real work today: applying #1337 to a live install. The chart was
ready and SHA-pinned, and there was simply no way to invoke `curie` on the box.
The only alternative was raw `helm upgrade` — the chart-internals-as-interface
that ADR-0097 exists to prevent.

## Cause

Both Linux targets cross-compiled against the runner's own libc headers, and
`ubuntu-latest` is Ubuntu 24.04 (glibc 2.39). glibc is backward compatible but
not forward, so that became a hard runtime floor. AL2023 is 2.34.

## Why CI was green the whole time

This is the more interesting half. Every runner that executes these artifacts is
also `ubuntu-latest`, so nothing red — including `curie-eng/sre-bot`'s eval lane,
which downloads and runs the x86_64 binary on each PR. And the release build path
was never exercised before a tag, so the regression was undiscoverable until
someone tried the artifact on a real host.

## The fix

`cargo zigbuild --target <target>.2.28` decouples the floor from the runner.
2.28 covers RHEL/Alma 8, Debian 10, Ubuntu 18.04 and AL2023.

It also **deletes** `gcc-aarch64-linux-gnu` and `libc6-dev-arm64-cross`: `zig cc`
gives `ring` a sysroot for the *target* rather than the host, which was the
entire reason those existed — the matrix comment describing that pain goes away
with them. Stripping moves to `-C strip=symbols` at link time, since dropping the
cross binutils removes the only tool that could strip a cross-built arm64 ELF.

## Two guards, because a fix that regresses silently isn't fixed

**`scripts/check-glibc-floor.sh`** asserts the floor on the **artifact**, not the
build environment — a runner image bump is precisely how this happened. No
`mapfile` or `${arr[-1]}` (both bash 4+), so it runs on a macOS checkout too; a
guard that only runs in CI is half a guard.

**`cli-portability`** in `ci.yaml` builds through the release path on every PR and
then *runs the binary inside `amazonlinux:2023`*. The symbol assertion is a claim
about the ELF; this is that claim under test, on the distro where it actually
died.

## Verification

The guard, locally:

| input | expected | got |
|---|---|---|
| real broken v0.6.0 arm64 artifact vs floor 2.28 | fail | exit 1, reports `GLIBC_2.39` |
| same binary vs floor 2.39 | pass | exit 0 |
| missing file | fail | exit 1 |

**Being straight about what I could not verify:** the zigbuild swap is a
release-path change, and I cannot cut a release. That is exactly why the
`cli-portability` job exists — this PR is the first thing to exercise the new
path, so its own CI is the evidence. If that job goes red, the approach needs
adjusting before merge, not after.

Two choices worth a reviewer's opinion:

- **2.28 as the floor.** Lower is safer but more exotic; 2.28 is the common
  RHEL 8 / Debian 10 line and comfortably clears AL2023's 2.34.
- **`cargo install cargo-zigbuild` costs a few minutes per target.** A prebuilt
  release asset would be faster, but the asset name would be unpinned in a way
  this repo's action-SHA convention would rightly object to. Happy to switch if
  you'd rather take the speed.
