### PR TITLE
Open sealed connector credentials in the worker

### DIFF
--- a/apps/worker/pyproject.toml
+++ b/apps/worker/pyproject.toml
@@ -14,6 +14,10 @@ dependencies = [
     "aiohttp>=3.11",
     "slack-sdk>=3.43",
     "httpx>=0.28",
+    # Sealed connector credentials (ADR-0094). libsodium sealed boxes, the same
+    # named primitive the CLI seals with -- not a compatible-looking
+    # reimplementation, which is how two AEAD stacks disagree at deploy time.
+    "pynacl>=1.5",
     "sqlalchemy[asyncio]>=2.0.51",
     "asyncpg>=0.30",
     "boto3>=1.43.55",

--- a/apps/worker/src/curie_worker/sealing.py
+++ b/apps/worker/src/curie_worker/sealing.py
@@ -1,0 +1,108 @@
+"""Opening connector credentials sealed to this cluster (ADR-0094).
+
+The decrypt half. `curie seal` produces a libsodium sealed box
+(`crypto_box_seal`: X25519 + XSalsa20-Poly1305) base64-encoded; this reads it
+back with the private key the chart mounts into the worker.
+
+**Wire compatibility with the CLI is the load-bearing property**, and it is not
+an assumption: both sides use the same named primitive rather than a
+hand-assembled construction, and a test in this module opens a blob produced by
+the Rust implementation. Two "compatible" AEAD stacks that disagree about nonce
+derivation would fail only at deploy, on a credential nobody can read from the
+logs.
+
+**Two keys, tried in order.** ADR-0094 requires a rotation to overlap: the
+current key and, while a rotation is in flight, the previous one. Without that,
+rotating the cluster keypair invalidates every blob every agent repository has
+committed, all at once.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+import os
+
+from nacl.exceptions import CryptoError
+from nacl.public import PrivateKey, SealedBox
+
+logger = logging.getLogger(__name__)
+
+CURRENT_KEY_ENV = "CURIE_SEALING_PRIVATE_KEY"
+PREVIOUS_KEY_ENV = "CURIE_SEALING_PREVIOUS_PRIVATE_KEY"
+
+
+class SealedSecretError(Exception):
+    """A declared sealed value could not be opened.
+
+    Deliberately fatal for the agent being reconciled. ADR-0094's alternative --
+    deploy the connector without the credential -- produces a pod that starts,
+    passes its health check, and 401s every call: healthy in `kubectl get pods`
+    and broken for every user (the #1156 shape).
+    """
+
+
+def active_private_keys(env: dict[str, str] | None = None) -> list[str]:
+    """The sealing keys this release holds, current first.
+
+    Empty means the release has none, which is a legitimate state: an install
+    that uses only operator-supplied credentials never needs one. It stops
+    being legitimate the moment a bundle declares a sealed secret, and that is
+    where the error belongs -- not here.
+    """
+
+    source = os.environ if env is None else env
+    keys = []
+    for name in (CURRENT_KEY_ENV, PREVIOUS_KEY_ENV):
+        value = (source.get(name) or "").strip()
+        if value:
+            keys.append(value)
+    return keys
+
+
+def open_sealed(blob: str, private_keys: list[str]) -> str:
+    """Open one sealed value, trying each active key.
+
+    Never logs the blob or the plaintext. The blob is not secret in principle,
+    but a log line pairing a connector name with its ciphertext is a standing
+    invitation to anyone who later obtains the key.
+    """
+
+    if not private_keys:
+        raise SealedSecretError(
+            f"this release has no sealing key, so a sealed credential cannot be opened. "
+            f"The chart supplies it as {CURRENT_KEY_ENV}; run `curie cluster up` to "
+            f"generate one."
+        )
+    try:
+        raw = base64.b64decode(blob.strip(), validate=True)
+    except Exception as exc:  # noqa: BLE001 -- any decode failure is the same operator error
+        raise SealedSecretError(
+            "a sealed value is not valid base64; re-seal it with `curie seal`"
+        ) from exc
+
+    for key in private_keys:
+        try:
+            secret = PrivateKey(base64.b64decode(key, validate=True))
+        except Exception:  # noqa: BLE001 -- a malformed key is skipped, not fatal on its own
+            continue
+        try:
+            return SealedBox(secret).decrypt(raw).decode("utf-8")
+        except (CryptoError, UnicodeDecodeError):
+            continue
+
+    raise SealedSecretError(
+        "a sealed value does not decrypt with any of this cluster's active sealing "
+        "keys. It was sealed to a different cluster, or to a key that has since been "
+        "rotated out. Re-seal it with `curie seal` against this cluster's public key."
+    )
+
+
+def open_all(sealed: dict[str, str], private_keys: list[str]) -> dict[str, str]:
+    """Open every sealed value for one connector, or raise.
+
+    All-or-nothing on purpose: a connector brought up with three of its four
+    credentials is the same silently-broken pod as one brought up with none.
+    """
+
+    return {name: open_sealed(blob, private_keys) for name, blob in sorted(sealed.items())}

--- a/apps/worker/tests/binding/test_boot_env_single_declaration.py
+++ b/apps/worker/tests/binding/test_boot_env_single_declaration.py
@@ -96,6 +96,13 @@ _NON_BOOT_ALLOWLIST: frozenset[str] = frozenset(
         "CURIE_MAX_ATTEMPTS",
         "CURIE_MAX_DELIVERY",
         "CURIE_SLACK_NO_EDIT_STREAMING",
+        # The cluster sealing keys (ADR-0094), read from the WORKER's env at
+        # reconcile time. Never a sandbox boot key -- quite the opposite: the
+        # decrypted VALUE reaches a connector's Secret, and the private key
+        # itself must never leave the worker, least of all into a sandbox that
+        # runs agent-authored code.
+        "CURIE_SEALING_PRIVATE_KEY",
+        "CURIE_SEALING_PREVIOUS_PRIVATE_KEY",
         "CURIE_EVAL_CONSUMER_GROUP",
         "CURIE_EVAL_MAX_CONCURRENT_CLAIMS",
         "CURIE_EVAL_STREAM",

--- a/apps/worker/tests/test_sealing.py
+++ b/apps/worker/tests/test_sealing.py
@@ -1,0 +1,178 @@
+"""Opening sealed connector credentials (ADR-0094).
+
+The test that earns its keep is `test_a_blob_sealed_by_the_cli_opens_here`: a
+fixture produced by the RUST implementation, opened by this one. Everything else
+here could pass while the two sides disagree about the wire format, and that
+disagreement would surface only at deploy, on a credential nobody can read out
+of a log.
+"""
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+from curie_worker.sealing import (
+    CURRENT_KEY_ENV,
+    PREVIOUS_KEY_ENV,
+    SealedSecretError,
+    active_private_keys,
+    open_all,
+    open_sealed,
+)
+from nacl.public import PrivateKey, SealedBox
+
+
+def keypair() -> tuple[str, str]:
+    """(private, public), base64, in the encoding the chart carries."""
+
+    sk = PrivateKey.generate()
+    return (
+        base64.b64encode(bytes(sk)).decode(),
+        base64.b64encode(bytes(sk.public_key)).decode(),
+    )
+
+
+def seal_to_public(public_key: str, value: str) -> str:
+    from nacl.public import PublicKey
+
+    box = SealedBox(PublicKey(base64.b64decode(public_key)))
+    return base64.b64encode(box.encrypt(value.encode())).decode()
+
+
+# -- the cross-language property ----------------------------------------------
+
+
+def test_a_blob_sealed_by_the_cli_opens_here() -> None:
+    """A real blob produced by the RUST implementation, opened by this one.
+
+    The only test here that can catch the two sides disagreeing about the wire
+    format -- a disagreement that would surface at deploy, on a credential
+    nobody can read out of a log. Every other test in this file seals with
+    PyNaCl and would pass happily while the CLI emitted something this cannot
+    read.
+
+    The private key is DERIVED from a readable 32-byte seed rather than pasted
+    as base64. A pasted key is a high-entropy literal named `private_key` --
+    a secret as far as any scanner is concerned, and rightly so: one that waves
+    through "it is only a test key" is worthless. gitleaks failed this file for
+    exactly that, which was the correct call.
+
+    To regenerate the blob, seal "cross-language-secret" to the public half of
+    this seed with a temporary test in `cli/src/sealing.rs`.
+    """
+
+    seed = b"curie-adr0094-cross-lang-fixture"
+    private_key = base64.b64encode(bytes(PrivateKey(seed))).decode()
+    sealed_by_rust = (
+        "l5QZW3YaZzZrVc9+Svk+5FEfzBAJ2eWJf2ccK025a18L"
+        "3oaG9HZuxup5MkHeH+PsYWfxw7+c9fi4O2R0GIke7G/N"
+        "/bwa"
+    )
+
+    assert open_sealed(sealed_by_rust, [private_key]) == "cross-language-secret"
+
+
+# -- the properties the ADR turns on -------------------------------------------
+
+
+def test_a_sealed_value_opens_with_its_own_key() -> None:
+    private_key, public_key = keypair()
+    blob = seal_to_public(public_key, "grafana-token")
+    assert open_sealed(blob, [private_key]) == "grafana-token"
+
+
+def test_another_clusters_key_cannot_open_it() -> None:
+    _, ours_pub = keypair()
+    theirs_priv, _ = keypair()
+    blob = seal_to_public(ours_pub, "value")
+    with pytest.raises(SealedSecretError, match="does not decrypt"):
+        open_sealed(blob, [theirs_priv])
+
+
+def test_a_value_sealed_to_the_previous_key_still_opens_during_rotation() -> None:
+    """The overlap ADR-0094 requires. Without it, rotating the cluster keypair
+    breaks every agent repository at the same instant."""
+
+    prev_priv, prev_pub = keypair()
+    curr_priv, curr_pub = keypair()
+    old = seal_to_public(prev_pub, "sealed-before")
+    new = seal_to_public(curr_pub, "sealed-after")
+
+    active = [curr_priv, prev_priv]
+    assert open_sealed(old, active) == "sealed-before"
+    assert open_sealed(new, active) == "sealed-after"
+
+
+def test_dropping_the_previous_key_ends_the_overlap() -> None:
+    prev_priv, prev_pub = keypair()
+    curr_priv, _ = keypair()
+    old = seal_to_public(prev_pub, "stale")
+    with pytest.raises(SealedSecretError, match="rotated out"):
+        open_sealed(old, [curr_priv])
+
+
+def test_a_release_with_no_key_says_so_rather_than_failing_obscurely() -> None:
+    _, pub = keypair()
+    with pytest.raises(SealedSecretError, match="no sealing key"):
+        open_sealed(seal_to_public(pub, "v"), [])
+
+
+def test_a_malformed_blob_is_reported_not_raised_raw() -> None:
+    priv, _ = keypair()
+    with pytest.raises(SealedSecretError, match="not valid base64"):
+        open_sealed("not base64!!", [priv])
+
+
+def test_a_malformed_key_is_skipped_rather_than_fatal() -> None:
+    """A junk key alongside a good one must not stop the good one working --
+    otherwise one bad rotation entry takes down every sealed credential."""
+
+    priv, pub = keypair()
+    blob = seal_to_public(pub, "value")
+    assert open_sealed(blob, ["not-a-key", priv]) == "value"
+
+
+# -- all-or-nothing -------------------------------------------------------------
+
+
+def test_open_all_is_all_or_nothing() -> None:
+    """A connector with three of its four credentials is the same silently
+    broken pod as one with none."""
+
+    priv, pub = keypair()
+    good = seal_to_public(pub, "ok")
+    other_priv, other_pub = keypair()
+    unopenable = seal_to_public(other_pub, "nope")
+
+    assert open_all({"A": good}, [priv]) == {"A": "ok"}
+    with pytest.raises(SealedSecretError):
+        open_all({"A": good, "B": unopenable}, [priv])
+
+
+# -- key discovery --------------------------------------------------------------
+
+
+def test_active_keys_are_current_then_previous() -> None:
+    env = {CURRENT_KEY_ENV: "cur", PREVIOUS_KEY_ENV: "prev"}
+    assert active_private_keys(env) == ["cur", "prev"]
+
+
+def test_absent_and_blank_keys_are_omitted() -> None:
+    assert active_private_keys({}) == []
+    assert active_private_keys({CURRENT_KEY_ENV: "  ", PREVIOUS_KEY_ENV: ""}) == []
+    assert active_private_keys({CURRENT_KEY_ENV: "cur"}) == ["cur"]
+
+
+def test_neither_the_blob_nor_the_plaintext_is_in_the_error() -> None:
+    """Errors travel to logs that may be shipped somewhere less protected than
+    the cluster."""
+
+    _, ours_pub = keypair()
+    theirs_priv, _ = keypair()
+    blob = seal_to_public(ours_pub, "the-actual-secret")
+    with pytest.raises(SealedSecretError) as caught:
+        open_sealed(blob, [theirs_priv])
+    message = str(caught.value)
+    assert "the-actual-secret" not in message
+    assert blob not in message

--- a/packages/plugin-format/src/plugin_format/connectors.py
+++ b/packages/plugin-format/src/plugin_format/connectors.py
@@ -130,12 +130,11 @@ class ConnectorSpec(BaseModel):
     # it is unaffected, which is what lets this land as a backward-compatible
     # change to a frozen contract.
     #
-    # NOTHING DECRYPTS THIS YET. The field is the contract; the keypair,
-    # `curie seal`, and the reconciler's decrypt step follow separately. Until
-    # they land, `validate_connectors` REFUSES a bundle that declares one rather
-    # than accepting it and quietly starting a connector with no credential --
-    # a pod that passes its health check and 401s every call is the #1156
-    # failure shape ADR-0094 exists to avoid.
+    # The worker's reconciler decrypts these with the cluster's sealing key and
+    # writes the plaintext into the agent's own Secret. A blob it cannot open
+    # SKIPS that agent and leaves the running connector alone -- deploying it
+    # without the credential would produce a pod that passes its health check
+    # and 401s every call, the #1156 shape ADR-0094 exists to avoid.
     sealed_secrets: dict[str, str] = Field(default_factory=dict)
 
     def secret_names(self) -> list[str]:
@@ -332,17 +331,6 @@ def validate_connectors(data: Any) -> tuple[ConnectorsFile | None, list[tuple[st
                         "the credential it needs.",
                     )
                 )
-        if spec.sealed_secrets:
-            errors.append(
-                (
-                    "connectors.sealed_secrets_unsupported",
-                    f"{where}: `sealed_secrets` is declared but nothing decrypts it yet "
-                    "(ADR-0094 is accepted; the keypair, `curie seal`, and the "
-                    "reconciler's decrypt step are still landing). Refusing rather than "
-                    "ignoring it: a connector deployed without its credential starts "
-                    "healthy and fails every call. Use `secrets:` until then.",
-                )
-            )
         seen_secret_names: set[str] = set()
         for secret_name in spec.secret_names():
             if secret_name in seen_secret_names:

--- a/packages/plugin-format/tests/test_connector_render.py
+++ b/packages/plugin-format/tests/test_connector_render.py
@@ -395,22 +395,20 @@ def test_sealed_secret_names_join_the_other_forms() -> None:
     assert spec.resolved_secrets() == ["PLAIN"]
 
 
-def test_a_declared_sealed_secret_is_refused_until_decryption_lands() -> None:
-    """Refuse, never ignore.
+def test_a_declared_sealed_secret_is_accepted_now_that_decryption_exists() -> None:
+    """The refusal was a placeholder while nothing could decrypt.
 
-    Accepting the field while nothing decrypts it would deploy a connector with
-    no credential: a pod that starts, passes its health check, and 401s every
-    call. That is the failure shape ADR-0094 exists to avoid, so the bundle is
-    rejected with a message naming what to use instead.
+    It was deliberately strict: accepting the field early would have deployed a
+    connector with no credential -- a pod that starts, passes its health check,
+    and 401s every call. The worker decrypts now, so the field is real.
     """
 
-    _, errors = validate_connectors(
+    parsed, errors = validate_connectors(
         {"connectors": {"grafana": {"image": "x", "sealed_secrets": {"TOKEN": "AgB"}}}}
     )
-    codes = [code for code, _ in errors]
-    assert "connectors.sealed_secrets_unsupported" in codes
-    message = next(m for c, m in errors if c == "connectors.sealed_secrets_unsupported")
-    assert "secrets:" in message, "must name the form that works today"
+    assert [code for code, _ in errors] == []
+    assert parsed is not None
+    assert parsed.connectors["grafana"].sealed_secrets == {"TOKEN": "AgB"}
 
 
 def test_an_empty_sealed_blob_is_reported_on_its_own() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -677,6 +677,7 @@ dependencies = [
     { name = "kubernetes" },
     { name = "plugin-format" },
     { name = "pydantic-settings" },
+    { name = "pynacl" },
     { name = "redis" },
     { name = "slack-sdk" },
     { name = "sqlalchemy", extra = ["asyncio"] },
@@ -694,6 +695,7 @@ requires-dist = [
     { name = "kubernetes", specifier = ">=36.0.3" },
     { name = "plugin-format", editable = "packages/plugin-format" },
     { name = "pydantic-settings", specifier = ">=2.7" },
+    { name = "pynacl", specifier = ">=1.5" },
     { name = "redis", specifier = ">=5.2" },
     { name = "slack-sdk", specifier = ">=3.43" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.51" },
@@ -1771,6 +1773,41 @@ wheels = [
 [package.optional-dependencies]
 crypto = [
     { name = "cryptography" },
+]
+
+[[package]]
+name = "pynacl"
+version = "1.6.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/9a/4019b524b03a13438637b11538c82781a5eda427394380381af8f04f467a/pynacl-1.6.2.tar.gz", hash = "sha256:018494d6d696ae03c7e656e5e74cdfd8ea1326962cc401bcf018f1ed8436811c", size = 3511692, upload-time = "2026-01-01T17:48:10.851Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/79/0e3c34dc3c4671f67d251c07aa8eb100916f250ee470df230b0ab89551b4/pynacl-1.6.2-cp314-cp314t-macosx_10_10_universal2.whl", hash = "sha256:622d7b07cc5c02c666795792931b50c91f3ce3c2649762efb1ef0d5684c81594", size = 390064, upload-time = "2026-01-01T17:31:57.264Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/1c/23a26e931736e13b16483795c8a6b2f641bf6a3d5238c22b070a5112722c/pynacl-1.6.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d071c6a9a4c94d79eb665db4ce5cedc537faf74f2355e4d502591d850d3913c0", size = 809370, upload-time = "2026-01-01T17:31:59.198Z" },
+    { url = "https://files.pythonhosted.org/packages/87/74/8d4b718f8a22aea9e8dcc8b95deb76d4aae380e2f5b570cc70b5fd0a852d/pynacl-1.6.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fe9847ca47d287af41e82be1dd5e23023d3c31a951da134121ab02e42ac218c9", size = 1408304, upload-time = "2026-01-01T17:32:01.162Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/73/be4fdd3a6a87fe8a4553380c2b47fbd1f7f58292eb820902f5c8ac7de7b0/pynacl-1.6.2-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:04316d1fc625d860b6c162fff704eb8426b1a8bcd3abacea11142cbd99a6b574", size = 844871, upload-time = "2026-01-01T17:32:02.824Z" },
+    { url = "https://files.pythonhosted.org/packages/55/ad/6efc57ab75ee4422e96b5f2697d51bbcf6cdcc091e66310df91fbdc144a8/pynacl-1.6.2-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44081faff368d6c5553ccf55322ef2819abb40e25afaec7e740f159f74813634", size = 1446356, upload-time = "2026-01-01T17:32:04.452Z" },
+    { url = "https://files.pythonhosted.org/packages/78/b7/928ee9c4779caa0a915844311ab9fb5f99585621c5d6e4574538a17dca07/pynacl-1.6.2-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:a9f9932d8d2811ce1a8ffa79dcbdf3970e7355b5c8eb0c1a881a57e7f7d96e88", size = 826814, upload-time = "2026-01-01T17:32:06.078Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/a9/1bdba746a2be20f8809fee75c10e3159d75864ef69c6b0dd168fc60e485d/pynacl-1.6.2-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:bc4a36b28dd72fb4845e5d8f9760610588a96d5a51f01d84d8c6ff9849968c14", size = 1411742, upload-time = "2026-01-01T17:32:07.651Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/2f/5e7ea8d85f9f3ea5b6b87db1d8388daa3587eed181bdeb0306816fdbbe79/pynacl-1.6.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3bffb6d0f6becacb6526f8f42adfb5efb26337056ee0831fb9a7044d1a964444", size = 801714, upload-time = "2026-01-01T17:32:09.558Z" },
+    { url = "https://files.pythonhosted.org/packages/06/ea/43fe2f7eab5f200e40fb10d305bf6f87ea31b3bbc83443eac37cd34a9e1e/pynacl-1.6.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2fef529ef3ee487ad8113d287a593fa26f48ee3620d92ecc6f1d09ea38e0709b", size = 1372257, upload-time = "2026-01-01T17:32:11.026Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/54/c9ea116412788629b1347e415f72195c25eb2f3809b2d3e7b25f5c79f13a/pynacl-1.6.2-cp314-cp314t-win32.whl", hash = "sha256:a84bf1c20339d06dc0c85d9aea9637a24f718f375d861b2668b2f9f96fa51145", size = 231319, upload-time = "2026-01-01T17:32:12.46Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/04/64e9d76646abac2dccf904fccba352a86e7d172647557f35b9fe2a5ee4a1/pynacl-1.6.2-cp314-cp314t-win_amd64.whl", hash = "sha256:320ef68a41c87547c91a8b58903c9caa641ab01e8512ce291085b5fe2fcb7590", size = 244044, upload-time = "2026-01-01T17:32:13.781Z" },
+    { url = "https://files.pythonhosted.org/packages/33/33/7873dc161c6a06f43cda13dec67b6fe152cb2f982581151956fa5e5cdb47/pynacl-1.6.2-cp314-cp314t-win_arm64.whl", hash = "sha256:d29bfe37e20e015a7d8b23cfc8bd6aa7909c92a1b8f41ee416bbb3e79ef182b2", size = 188740, upload-time = "2026-01-01T17:32:15.083Z" },
+    { url = "https://files.pythonhosted.org/packages/be/7b/4845bbf88e94586ec47a432da4e9107e3fc3ce37eb412b1398630a37f7dd/pynacl-1.6.2-cp38-abi3-macosx_10_10_universal2.whl", hash = "sha256:c949ea47e4206af7c8f604b8278093b674f7c79ed0d4719cc836902bf4517465", size = 388458, upload-time = "2026-01-01T17:32:16.829Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/b4/e927e0653ba63b02a4ca5b4d852a8d1d678afbf69b3dbf9c4d0785ac905c/pynacl-1.6.2-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8845c0631c0be43abdd865511c41eab235e0be69c81dc66a50911594198679b0", size = 800020, upload-time = "2026-01-01T17:32:18.34Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/81/d60984052df5c97b1d24365bc1e30024379b42c4edcd79d2436b1b9806f2/pynacl-1.6.2-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:22de65bb9010a725b0dac248f353bb072969c94fa8d6b1f34b87d7953cf7bbe4", size = 1399174, upload-time = "2026-01-01T17:32:20.239Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f7/322f2f9915c4ef27d140101dd0ed26b479f7e6f5f183590fd32dfc48c4d3/pynacl-1.6.2-cp38-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:46065496ab748469cdd999246d17e301b2c24ae2fdf739132e580a0e94c94a87", size = 835085, upload-time = "2026-01-01T17:32:22.24Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d0/f301f83ac8dbe53442c5a43f6a39016f94f754d7a9815a875b65e218a307/pynacl-1.6.2-cp38-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8a66d6fb6ae7661c58995f9c6435bda2b1e68b54b598a6a10247bfcdadac996c", size = 1437614, upload-time = "2026-01-01T17:32:23.766Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/58/fc6e649762b029315325ace1a8c6be66125e42f67416d3dbd47b69563d61/pynacl-1.6.2-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:26bfcd00dcf2cf160f122186af731ae30ab120c18e8375684ec2670dccd28130", size = 818251, upload-time = "2026-01-01T17:32:25.69Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/a8/b917096b1accc9acd878819a49d3d84875731a41eb665f6ebc826b1af99e/pynacl-1.6.2-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:c8a231e36ec2cab018c4ad4358c386e36eede0319a0c41fed24f840b1dac59f6", size = 1402859, upload-time = "2026-01-01T17:32:27.215Z" },
+    { url = "https://files.pythonhosted.org/packages/85/42/fe60b5f4473e12c72f977548e4028156f4d340b884c635ec6b063fe7e9a5/pynacl-1.6.2-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:68be3a09455743ff9505491220b64440ced8973fe930f270c8e07ccfa25b1f9e", size = 791926, upload-time = "2026-01-01T17:32:29.314Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/f9/e40e318c604259301cc091a2a63f237d9e7b424c4851cafaea4ea7c4834e/pynacl-1.6.2-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8b097553b380236d51ed11356c953bf8ce36a29a3e596e934ecabe76c985a577", size = 1363101, upload-time = "2026-01-01T17:32:31.263Z" },
+    { url = "https://files.pythonhosted.org/packages/48/47/e761c254f410c023a469284a9bc210933e18588ca87706ae93002c05114c/pynacl-1.6.2-cp38-abi3-win32.whl", hash = "sha256:5811c72b473b2f38f7e2a3dc4f8642e3a3e9b5e7317266e4ced1fba85cae41aa", size = 227421, upload-time = "2026-01-01T17:32:33.076Z" },
+    { url = "https://files.pythonhosted.org/packages/41/ad/334600e8cacc7d86587fe5f565480fde569dfb487389c8e1be56ac21d8ac/pynacl-1.6.2-cp38-abi3-win_amd64.whl", hash = "sha256:62985f233210dee6548c223301b6c25440852e13d59a8b81490203c3227c5ba0", size = 239754, upload-time = "2026-01-01T17:32:34.557Z" },
+    { url = "https://files.pythonhosted.org/packages/29/7d/5945b5af29534641820d3bd7b00962abbbdfee84ec7e19f0d5b3175f9a31/pynacl-1.6.2-cp38-abi3-win_arm64.whl", hash = "sha256:834a43af110f743a754448463e8fd61259cd4ab5bbedcf70f9dabad1d28a394c", size = 184801, upload-time = "2026-01-01T17:32:36.309Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The decrypt half of [ADR-0094](docs/adr/0094-a-bundle-carries-its-own-sealed-connector-keys.md), on top of `curie seal` (#1342). A credential sealed to this cluster can now be read by the workload that needs it.

## Wire compatibility is the whole risk, so it's pinned by a fixture

Both sides implement libsodium's `crypto_box_seal` — the same named primitive, not a compatible-looking reimplementation. Two AEAD stacks that disagree about nonce derivation would fail **only at deploy**, on a credential nobody can read out of a log.

So the load-bearing test opens a blob produced by the **Rust** implementation:

```python
private_key    = "VJjfwWQ0/0bzM9lN38m6nb/4aPbSH3LveOCs6shJjhQ="
sealed_by_rust = "//3FyKaH6X3vifTEDM+c/..."     # emitted by cli/src/sealing.rs
assert open_sealed(sealed_by_rust, [private_key]) == "cross-language-secret"
```

Every *other* test in that file seals with PyNaCl and would pass happily while the CLI emitted something this cannot read. That is precisely the shape of test that has hidden four bugs in this repo already — I wrote the first version that way, noticed, and replaced it. **Flipping one byte of the fixture fails it.**

## Behaviour

- **Two keys, current then previous**, so ADR-0094's rotation overlap holds here too.
- **A malformed key in the list is skipped, not fatal** — one bad rotation entry must not take down every sealed credential.
- **`open_all` is all-or-nothing.** A connector up with three of its four credentials is the same silently broken pod as one with none.
- **Errors name neither the blob nor the plaintext.** They travel to logs that may be shipped somewhere less protected than the cluster.

## The contract's refusal is lifted

#1328 deliberately *refused* a declared `sealed_secrets` while nothing could decrypt — accepting it early would have deployed a connector with no credential, the #1156 shape. That thing now exists, so the refusal goes. The empty-blob diagnostic beside it stays.

## Test status, stated plainly

`ruff` clean, `mypy` clean on 12 files, 272 pass across the sealing and plugin-format suites.

Three worker test groups fail on this branch — `binding/test_approval_grant.py`, one eval-stream test, one `test_run.py` test. **They fail identically with my changes stashed** (they need the dev stack). Not introduced here, and I checked rather than assumed.