### PR TITLE
Say what a bundle actually requires

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -32,6 +32,51 @@ runbooks, or working on Curie itself — see [Where to go next](#where-to-go-nex
   builds the CLI instead of downloading it — see
   [Where to go next](#where-to-go-next).
 
+## The minimum bundle
+
+`curie init` scaffolds seven files. Only these are required, and it is worth
+knowing which — when a deploy is rejected or an agent behaves oddly, this is
+what actually has to be true.
+
+**One file, one field** is a complete, valid bundle:
+
+```
+my-agent/
+└── .claude-plugin/
+    └── plugin.json     {"name": "my-agent"}
+```
+
+It boots and answers. Everything else in the format is optional and validated
+only when present.
+
+That agent has no instructions, though. **Two files, three fields** is the
+smallest useful one:
+
+```
+my-agent/
+├── .claude-plugin/
+│   └── plugin.json          {"name": "my-agent"}
+└── skills/
+    └── my-agent/
+        └── SKILL.md
+```
+
+```markdown
+---
+name: my-agent
+description: Answers questions about deployment status.
+---
+
+You are a deployment helper. Answer briefly and plainly.
+```
+
+`name` and `description` are the only required frontmatter fields; the body is
+the agent's instructions.
+
+Everything the scaffold adds beyond this — `evals/cases.json`, `.mcp.json`,
+`AGENTS.md`, the `using-curie` primer — is useful and optional. Delete any of
+it and the bundle still deploys.
+
 ## Your first agent reply
 
 1. **Scaffold a bundle.** This creates a starter skill named for your agent,


### PR DESCRIPTION
## Why

`curie init` scaffolds seven files and the quickstart walks through all of them, so nothing tells a reader which are load-bearing. That matters when a deploy is rejected or an agent behaves oddly — the useful question is *what has to be true*, not *what the scaffold happened to write*.

## The answer, verified by running it

**One file, one field** is a complete, valid bundle:

```
my-agent/
└── .claude-plugin/
    └── plugin.json     {"name": "my-agent"}
```

I built exactly that and booted it:

```
│  Version   tiny @ 0.0.0                      │
│  Bundle    91c1554fc06a (snapshot)           │
all done
-- final (done)
```

Everything else in the format is optional and validated only when present.

**Two files, three fields** is the smallest *useful* one — the bundle above has no instructions. Adding `skills/<name>/SKILL.md` with `name` and `description` frontmatter, also built and booted.

Both were run, not inferred from the validator.

## Where it went

Into the existing `QUICKSTART.md`, not a new page. There are already two quickstarts — this one for the `skill` tier and `docs/your-first-slack-agent.md` for Slack — and a third would be the opposite of maintainable. This is 45 lines added to the doc a reader is already in.

`scripts/check-docs.sh` passes. No real channel IDs, hosts, or account identifiers.

## Note

Built in a separate worktree — another session is working in the shared checkout, so this touches only `QUICKSTART.md`.