### PR TITLE
Publish installable per-commit binaries for both Linux targets

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -209,7 +209,7 @@ jobs:
           if-no-files-found: error
 
   cli-portability:
-    name: CLI runs on old glibc (release build path)
+    name: CLI runs on old glibc (and publishes per-commit binaries)
     runs-on: ubuntu-latest
     # The release cross-compile path was never exercised before a tag, so a
     # regression in it was undiscoverable until someone tried the artifact on a
@@ -236,14 +236,24 @@ jobs:
       # same thing -- and the arm64 artifact cannot be EXECUTED here without
       # dragging in qemu. The static assertion below covers arm64 at release
       # time; this job's job is to prove the floor is real, not merely declared.
+      # Both Linux targets, the same way a tag builds them. arm64 is here as
+      # much for the artifact as for the check: it is the target that cannot be
+      # obtained any other way between releases, and the one a Graviton cluster
+      # host needs.
       - name: Build (same path as the release)
         working-directory: cli
         env:
           CURIE_BUILD_CHANNEL: release
           RUSTFLAGS: -C strip=symbols
-        run: cargo zigbuild --release --target x86_64-unknown-linux-gnu.2.28
+        run: |
+          set -euo pipefail
+          cargo zigbuild --release --target x86_64-unknown-linux-gnu.2.28
+          cargo zigbuild --release --target aarch64-unknown-linux-gnu.2.28
       - name: Assert the glibc floor
-        run: bash scripts/check-glibc-floor.sh cli/target/x86_64-unknown-linux-gnu/release/curie 2.28
+        run: |
+          set -euo pipefail
+          bash scripts/check-glibc-floor.sh cli/target/x86_64-unknown-linux-gnu/release/curie 2.28
+          bash scripts/check-glibc-floor.sh cli/target/aarch64-unknown-linux-gnu/release/curie 2.28
       # The floor asserted above is a claim about symbols. This is the claim
       # under test: Amazon Linux 2023 is glibc 2.34, it is what the deployment
       # runbook provisions, and it is where `curie --version` died.
@@ -252,6 +262,31 @@ jobs:
           set -euo pipefail
           docker run --rm -v "$PWD/cli/target/x86_64-unknown-linux-gnu/release/curie:/curie:ro" \
             amazonlinux:2023 /curie --version
+
+      # Installable binaries for any commit, not just tagged releases, so a
+      # cluster can run an unreleased fix without building Rust on the host.
+      #
+      # NOT the same as `curie-x86_64-linux-<sha>` from the build job above:
+      # that one is a native build with the runner's glibc floor, exists to feed
+      # the e2e jobs on ubuntu-latest, and will NOT start on an older distro.
+      # These two carry the 2.28 floor and are the ones to install anywhere real.
+      # Named like the release assets so `--chart`/install flows read the same.
+      #
+      #   gh run download <run-id> -R curie-eng/curie \
+      #     -n curie-aarch64-unknown-linux-gnu-<sha>
+      #   chmod +x curie && sudo install -m 0755 curie /usr/local/bin/curie
+      - name: Publish per-commit portable binaries
+        uses: actions/upload-artifact@v7
+        with:
+          name: curie-x86_64-unknown-linux-gnu-${{ github.sha }}
+          path: cli/target/x86_64-unknown-linux-gnu/release/curie
+          if-no-files-found: error
+      - name: Publish per-commit portable binaries (arm64)
+        uses: actions/upload-artifact@v7
+        with:
+          name: curie-aarch64-unknown-linux-gnu-${{ github.sha }}
+          path: cli/target/aarch64-unknown-linux-gnu/release/curie
+          if-no-files-found: error
 
   contracts-ts:
     name: Contracts (generated TypeScript compiles)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -226,9 +226,14 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: cli
-      - name: Install zig toolchain
+      # rustup for the std/core rlibs, zig for the C toolchain and the glibc
+      # floor. Both are needed: without the target added, the cross build dies
+      # on `can't find crate for core` while the host target quietly succeeds --
+      # which is why adding arm64 here caught something x86_64-only never could.
+      - name: Install cross toolchain
         run: |
           set -euo pipefail
+          rustup target add x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu
           python3 -m pip install --user --break-system-packages "ziglang==0.16.0"
           cargo install cargo-zigbuild --locked --version 0.23.0
       # x86_64 only. The floor is a property of the toolchain, not the

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -41,6 +41,37 @@ kubectl config use-context <your-production-context>
 
 ## Installing and inspecting the Curie platform on the cluster
 
+### Running a build from a commit, without waiting for a release
+
+Every CI run publishes an installable Linux binary for both architectures,
+built the same way a tag builds them and carrying the same glibc 2.28 floor, so
+a cluster can run an unreleased fix without compiling Rust on the host.
+
+```bash
+run=$(gh run list -R curie-eng/curie --commit <sha> \
+        --workflow CI --json databaseId -q '.[0].databaseId')
+gh run download "$run" -R curie-eng/curie -n curie-aarch64-unknown-linux-gnu-<sha>
+chmod +x curie && sudo install -m 0755 curie /usr/local/bin/curie
+curie --version
+```
+
+Swap `aarch64` for `x86_64` as needed. The chart is version-pinned to the
+binary, so pass the matching chart when the commit changes it:
+
+```bash
+curie cluster up --chart /path/to/checkout/charts/curie ...
+```
+
+Two things to know:
+
+- **Artifacts expire** (90 days by default) and are not signed or SBOM'd the way
+  release assets are. This is for testing a fix and for hosts that cannot wait
+  for a tag -- prefer a release for anything long-lived.
+- **`curie-x86_64-linux-<sha>` is a different artifact** and not this one. That
+  is a native build used by the e2e jobs; it inherits the runner's glibc and
+  will not start on an older distro. The ones named for a full Rust target
+  triple (`curie-<target>-<sha>`) are the portable pair.
+
 ### `curie cluster up`
 
 Installs (or upgrades) Curie's Helm chart onto the cluster you're pointed at:


### PR DESCRIPTION
Follow-on to #1344. Between releases there is no way to get a runnable `curie`
onto a cluster host short of compiling Rust there.

That bit today: #1337 was merged and needed testing on a real box, and there was
no path to it. The only per-commit artifact, `curie-x86_64-linux-<sha>`, is a
**native** build that exists to feed the e2e jobs on `ubuntu-latest` — wrong
architecture for a Graviton host, and carrying the runner's glibc floor, so it
would not have started there anyway.

## What changes

`cli-portability` already builds x86_64 through the release path to prove the
floor holds. It now builds **aarch64 the same way and uploads both**. The zig
install is the expensive part and is already paid for, so this adds one
cross-build.

arm64 is here as much for the artifact as for the check: it is the target that
**cannot be obtained any other way between releases**, and the one a Graviton
cluster host actually needs.

```bash
gh run download <run-id> -R curie-eng/curie -n curie-aarch64-unknown-linux-gnu-<sha>
chmod +x curie && sudo install -m 0755 curie /usr/local/bin/curie
```

## Naming, and the trap it avoids

Named `curie-<rust-target-triple>-<sha>`, matching the release assets, so
installing from a commit reads the same as installing from a tag.

The existing native artifact **keeps its name and its four downstream
consumers** — I checked before touching it. The job comment spells out which is
which, because *"there are two curie artifacts and one of them will not run on
your host"* is exactly the trap worth naming in the file rather than leaving for
someone to rediscover.

## Documented

`docs/operations.md`, next to `cluster up`, including the honest caveats: these
**expire** (90 days) and are **neither signed nor SBOM'd** the way release assets
are. They're for testing a fix and for hosts that can't wait for a tag — not a
substitute for a release. Also notes the chart is version-pinned to the binary,
so `--chart` should point at the matching checkout when the commit changes it.

## Verification

The new build/assert steps are the same ones #1344 already proved green on this
runner; this PR's own `cli-portability` run exercises the added arm64 path and
both uploads. Worth a look at that job before merging, since the arm64 artifact
is the part that has never been built in CI before.
