### PR TITLE
Stop curie doctor claiming git-push deploys it never checked

### DIFF
--- a/cli/src/doctor.rs
+++ b/cli/src/doctor.rs
@@ -325,6 +325,17 @@ pub fn summary(checks: &[Check]) -> String {
                 missing items above."
             .to_string();
     }
+    // repo-binding reads NotApplicable in two situations that both reach this
+    // point: the platform API was never consulted (no --api-url/--api-key, an
+    // unreachable API, or a rejected key -- indistinguishable from here) or it
+    // was reached and found no agents deployed yet. Neither is evidence a git
+    // push deploys anything, so claiming "Fully wired" here asserted the one
+    // capability the run did not check (#1354).
+    if !has("repo-binding") {
+        return "Answering in Slack. Git-push deploys are unverified -- see the \
+                Repo binding line above."
+            .to_string();
+    }
     "Fully wired: local runs, Slack, and git-push deploys.".to_string()
 }
 
@@ -479,7 +490,10 @@ mod tests {
 
     /// The binding is what makes a push reach an agent. An unbound one fails
     /// SILENTLY: the webhook returns 200, GitHub shows a green delivery, and
-    /// nothing is logged -- so the check has to say that out loud.
+    /// nothing is logged -- so the check has to say that out loud. This also
+    /// pins the Missing versus NotApplicable distinction the verdict turns
+    /// on: a KNOWN unbound agent must reach the actionable "not wired yet"
+    /// summary, not the "unverified" hedge reserved for never having checked.
     #[test]
     fn an_unbound_agent_is_reported_with_what_it_costs() {
         let f = Facts {
@@ -489,13 +503,20 @@ mod tests {
             ]),
             ..wired()
         };
-        let c = find(&evaluate(&f), "repo-binding").clone();
+        let checks = evaluate(&f);
+        let c = find(&checks, "repo-binding").clone();
         assert_eq!(c.state, State::Missing);
         assert!(c.detail.contains("bot-dev"), "must name it: {}", c.detail);
         assert!(
             c.detail.contains("silently ignored"),
             "must say the failure is silent: {}",
             c.detail
+        );
+        assert!(
+            summary(&checks).contains("Git-push deploys are not wired yet"),
+            "a KNOWN unbound agent must route to the actionable verdict, not \
+             the unverified hedge: {}",
+            summary(&checks)
         );
     }
 
@@ -538,6 +559,35 @@ mod tests {
         assert_eq!(find(&evaluate(&f), "repo-binding").state, State::Ok);
     }
 
+    /// Found on a real install (#1354): every other check passed, the platform
+    /// API was never reached (no --api-url/--api-key), and the summary still
+    /// said "Fully wired" -- asserting the one capability the run did not
+    /// check. `wired()` has no `agents` set, so repo-binding is NotApplicable
+    /// here, not Ok.
+    #[test]
+    fn unreached_api_does_not_claim_fully_wired() {
+        let checks = evaluate(&wired());
+        let s = summary(&checks);
+        assert!(!s.contains("Fully wired"), "{s}");
+        assert!(s.contains("Git-push deploys are unverified"), "{s}");
+    }
+
+    /// The sibling NotApplicable path: the platform API WAS reached but no
+    /// agents are deployed yet. A different reason, the same lack of evidence
+    /// that a git push deploys anything, so both paths must land on the same
+    /// hedge rather than one of them slipping through to "Fully wired".
+    #[test]
+    fn no_agents_deployed_does_not_claim_fully_wired() {
+        let f = Facts {
+            agents: Some(vec![]),
+            ..wired()
+        };
+        let checks = evaluate(&f);
+        let s = summary(&checks);
+        assert!(!s.contains("Fully wired"), "{s}");
+        assert!(s.contains("Git-push deploys are unverified"), "{s}");
+    }
+
     /// Found by running this against a real install. sre-bot serves its webhook
     /// on a NodePort with no ingress, and the first version of this check called
     /// that broken -- on a cluster where git-push deploys demonstrably work.
@@ -550,6 +600,7 @@ mod tests {
             slack_configured: true,
             clone_credential: Some("github app".into()),
             api_exposure: Some("NodePort 30799".into()),
+            agents: Some(vec![("sre-bot".into(), Some("acme/sre-bot".into()))]),
             ..laptop()
         };
         let checks = evaluate(&f);


### PR DESCRIPTION
Closes #1354

`summary()` in `cli/src/doctor.rs` rejected only `State::Missing`, so a repo-binding check that never ran fell through to `Fully wired: local runs, Slack, and git-push deploys.` That was the default path: `doctor` takes no `--api-url`/`--api-key` defaults, so the check is skipped unless both are passed, and an unreachable API or a rejected key are indistinguishable from never asking.

A repo-binding check that is not `Ok` now returns `Answering in Slack. Git-push deploys are unverified -- see the Repo binding line above.` The verdict defers to the per-check detail line because that line was already accurate for both causes that reach this point: the platform API was never consulted, or it was reached and reported no agents deployed yet.

Two `NotApplicable` cases cannot reach the new branch, since the `!has("release")` clause above returns first: no kube context and no release. Verified by tracing, not by assumption.

## Verification

Both guards were demonstrated by mutation, not by reading the code.

- Deleting the new branch turns `unreached_api_does_not_claim_fully_wired` and `no_agents_deployed_does_not_claim_fully_wired` red, each printing the exact reported string `Fully wired: local runs, Slack, and git-push deploys.`
- Deleting the pre-existing `State::Missing` clause turns `an_unbound_agent_is_reported_with_what_it_costs` red. That mutation previously survived: the test built the right fixture but asserted only on the check's state and detail, never on the verdict, so a known unbound agent would silently downgrade from the actionable "not wired yet" verdict to the unverified hedge. This diff made that regression quieter, so the assertion is added here.

`cargo test` 1149 passed, `cargo clippy -- -D warnings` clean, `cargo fmt --check` clean.

## Scope

`a_nodeport_counts_as_exposure` gained a bound agent in its fixture. That was necessary, not a passenger: its untouched `contains("Fully wired")` assertion goes red under the new guard without it. The assertion itself is unchanged, so the test is strengthened rather than weakened.

Deliberately out of scope, each raised by review and left for follow-up:

- Defaulting `doctor`'s `--api-key` to `curie-dev-key`, which #1354 offered as optional. It is inert on its own, since `--api-url` has no default either and both are required. The better fix is discovering both from the release the way sibling cluster verbs do, via `ops::discover_api_url`/`ops::discover_api_key`. Note that #524 deliberately removed the `localhost:8000` plus `curie-dev-key` defaults from cluster verbs, so reintroducing them here would undo that.
- The `agents: Some(vec![])` case is a proven negative rather than an unknown, so it arguably deserves its own actionable verdict naming `cluster deploy` rather than sharing the unverified hedge. Changing it means reclassifying #1349's own `skipped()` call, which belongs in its own commit.
- `DoctorOutput::to_json`'s `ready` field still reports `true` for an unverified install. `cli/schema/doctor.schema.json` documents that carve-out deliberately under a versioned `$id`, and the AC never mentions it, so the right shape is a new field rather than redefining `ready`.

A follow-up issue covering these three is filed as the next comment.

## Done-check

- Failing tests committed before implementation: N/A, quick tier. Equivalent evidence is the mutation runs above, which show each test red against the unfixed code.
- All production edits by the delegated executor: checked, sub-agents made every source edit. The one driver edit was the consolidation-pass predicate swap, which that pass explicitly permits.
- Broadened return types: N/A, the executor reported none and no signature changed.
- Code review approved: checked, 0 blocking, 5 advisory, 2 info.
- Scope review approved: checked, one passenger flagged and removed (a positive-control test that duplicated an existing case).
- Sibling-path parity: checked. The sibling `NotApplicable` producer (`agents: Some(vec![])`) is covered by its own test, and the sibling `Missing` path is now pinned.
- Guard demonstration: checked, both mutation runs above.
- Consolidation pass: checked. Ran, applied one change (`state(...) != Some(State::Ok)` to `!has(...)`, matching the five sibling branches); suite and lint green after.
- Security reviewer: N/A, not flagged.
- E2E tester: N/A, not flagged. `summary()` is a pure function of `Facts` by design, so the behavior is fully covered by unit tests.
- Full suite passes: checked, 1149 passed.
- Lint clean: checked, clippy and fmt.
