### PR TITLE
Refuse a contradictory apply, and stop reading an unreadable cluster as safe

### DIFF
--- a/cli/src/installation.rs
+++ b/cli/src/installation.rs
@@ -691,16 +691,39 @@ async fn complete_installation_plan(
     })
 }
 
-/// Refuse an apply that would delete a stateful component the release runs.
+/// What the stateful-removal guard learned about this apply.
+///
+/// The verdict is a VALUE, not the `Err` half of a `Result`. While the refusal
+/// was the only error the guard could produce, "Err means a removal was found"
+/// held by construction, and `--migrate-store` read it that way. Once the guard
+/// could also fail because the cluster was unreadable (#1351), that reading
+/// promoted "I could not find out" to "definitely at risk, start moving data",
+/// which is the same ambiguous-signal-turned-into-an-action shape #1351 exists
+/// to close, pointed the other way. So `Err` now means only that the guard could
+/// not reach a verdict, and every caller must propagate it.
+enum GuardVerdict {
+    /// Nothing the release runs would be deleted by this apply.
+    Clear,
+    /// This apply would delete stateful component(s), carrying the operator
+    /// facing refusal text.
+    WouldRemove(String),
+}
+
+/// Decide whether an apply would delete a stateful component the release runs.
 ///
 /// Runs even under `--dry-run`: the plan a dry run prints is exactly the plan
 /// that would destroy the store, so an operator reading it deserves the same
 /// warning the real run would give.
-async fn guard_stateful_removal(up: &crate::ops::UpOpts) -> Result<()> {
-    let live = crate::ops::live_stateful_components(&up.common).await?;
+async fn guard_stateful_removal(up: &crate::ops::UpOpts) -> Result<GuardVerdict> {
+    let live = crate::ops::live_stateful_components(&up.common)
+        .await
+        .context("could not check whether this apply would remove stateful components")?;
     if live.is_empty() {
-        // Fresh install, or no cluster to read. Nothing to lose either way.
-        return Ok(());
+        // Genuinely nothing to lose: a namespaced LIST returns an empty items
+        // array with exit 0 for a fresh install AND for a namespace that does
+        // not exist. A read that FAILED never reaches here; it is an error now
+        // rather than a silent empty answer (#1351).
+        return Ok(GuardVerdict::Clear);
     }
     // The same effective values the upgrade would send, so the render reflects
     // what this apply would actually create rather than the chart's defaults.
@@ -712,9 +735,11 @@ async fn guard_stateful_removal(up: &crate::ops::UpOpts) -> Result<()> {
     let rendered = crate::ops::chart_stateful_components(&up.chart, &up.common, &sets).await?;
     let removed = crate::ops::removed_stateful_components(&live, &rendered);
     if removed.is_empty() {
-        return Ok(());
+        return Ok(GuardVerdict::Clear);
     }
-    bail!("{}", stateful_removal_message(&removed))
+    Ok(GuardVerdict::WouldRemove(stateful_removal_message(
+        &removed,
+    )))
 }
 
 /// The refusal text, factored out so its ordering is testable with no cluster.
@@ -748,6 +773,18 @@ pub async fn apply(opts: ApplyOpts) -> Result<ApplyOutput> {
         allow_stateful_removal,
         migrate_store,
     } = opts;
+    // The parser rejects this pair (`conflicts_with`), but `ApplyOpts` has pub
+    // fields on a library crate, so the invariant is asserted where the
+    // destruction is owned rather than only at the CLI edge. Contradictory
+    // intent is refused, never resolved by picking one: silently dropping
+    // --migrate-store took the data destroying path with exit 0 (#1351).
+    if allow_stateful_removal && migrate_store {
+        bail!(
+            "--migrate-store and --allow-stateful-removal are contradictory: one \
+             carries the object store's data across the upgrade, the other proceeds \
+             WITHOUT it. Pass exactly one."
+        );
+    }
     local.up.chart = chart;
     let dry_run = local.up.common.dry_run;
     let plan = complete_installation_plan(local).await?;
@@ -783,16 +820,18 @@ pub async fn apply(opts: ApplyOpts) -> Result<ApplyOutput> {
     // empty and the bot cannot answer. An `apply` that changes a log level must
     // never silently start moving data. So the refusal NAMES the flag, and
     // passing it makes apply do the whole thing.
+    //
+    // An `Err` here is the guard failing to reach a verdict (an unreadable
+    // cluster, a failed `helm template`), never a removal. It propagates on
+    // EVERY path including `--migrate-store`: "I could not find out" must not
+    // become "start moving data" (#1351).
     let migrating = if allow_stateful_removal {
         false
     } else {
-        match guard_stateful_removal(&up).await {
-            Ok(()) => false,
-            Err(e) if migrate_store => {
-                let _ = e;
-                true
-            }
-            Err(e) => return Err(e),
+        match guard_stateful_removal(&up).await? {
+            GuardVerdict::Clear => false,
+            GuardVerdict::WouldRemove(_) if migrate_store => true,
+            GuardVerdict::WouldRemove(msg) => bail!("{msg}"),
         }
     };
 
@@ -1663,6 +1702,36 @@ mod diff_tests {
 #[cfg(test)]
 mod apply_tests {
     use super::*;
+
+    /// The library-level half of #1351's AC1, and the one invariant here that
+    /// cannot be pinned through the binary: clap's `conflicts_with` rejects the
+    /// pair at parse time, so a test that shells `curie` can only ever prove the
+    /// PARSER refuses it. `ApplyOpts` has pub fields on a crate that also ships
+    /// as a lib, so a consumer can hand `apply` the contradictory pair with clap
+    /// never involved, and that is exactly the caller the refusal has to survive
+    /// for. Asserted with `dry_run` so it needs no cluster; the `bail!` precedes
+    /// `complete_installation_plan` either way.
+    #[tokio::test]
+    async fn apply_refuses_the_contradictory_flag_pair_without_clap() {
+        let cfg = Installation::parse("version: 1\ninstall:\n  namespace: a\n  release: a\n")
+            .expect("minimal installation parses");
+        let opts = ApplyOpts {
+            local: plan_installation(cfg, true).expect("plan the installation"),
+            chart: "curie".to_string(),
+            allow_stateful_removal: true,
+            migrate_store: true,
+        };
+
+        let Err(err) = apply(opts).await else {
+            panic!("contradictory intent must be refused, never resolved by picking one");
+        };
+
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("--migrate-store") && msg.contains("--allow-stateful-removal"),
+            "the refusal must name both colliding flags: {msg}"
+        );
+    }
 
     fn cfg_with_all_names() -> Installation {
         Installation::parse(

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -425,7 +425,7 @@ enum Command {
         /// release is running, WITHOUT its data. Refused by default. Prefer
         /// --migrate-store, which keeps the data; this flag is for a store you
         /// genuinely intend to discard.
-        #[arg(long)]
+        #[arg(long, conflicts_with = "migrate_store")]
         allow_stateful_removal: bool,
     },
 
@@ -3439,6 +3439,47 @@ mod tests {
         );
         assert!(set_only.is_ok(), "--github-token alone must parse");
         assert!(clear_only.is_ok(), "--clear-github-token alone must parse");
+    }
+
+    #[test]
+    fn clap_rejects_migrate_store_with_allow_stateful_removal() {
+        // #1351: the pair states contradictory intent (carry the object store's
+        // data across the upgrade, versus proceed WITHOUT it). Refused at the
+        // parser, so the contradiction never reaches the code that silently
+        // picked one and took the data destroying path with exit 0.
+        //
+        // Both orderings are asserted rather than trusting that a
+        // `conflicts_with` declared on one arg is mutual. Each flag alone must
+        // still parse: a conflict naming an arg id that does not exist panics
+        // at parse time, and the "alone" arms are what catch that.
+        let both = Cli::try_parse_from([
+            "curie",
+            "apply",
+            "--migrate-store",
+            "--allow-stateful-removal",
+        ]);
+        let reversed = Cli::try_parse_from([
+            "curie",
+            "apply",
+            "--allow-stateful-removal",
+            "--migrate-store",
+        ]);
+        let migrate_only = Cli::try_parse_from(["curie", "apply", "--migrate-store"]);
+        let allow_only = Cli::try_parse_from(["curie", "apply", "--allow-stateful-removal"]);
+
+        assert!(
+            both.is_err(),
+            "--migrate-store with --allow-stateful-removal must be a clap conflict"
+        );
+        assert!(
+            reversed.is_err(),
+            "the conflict must hold in either argument order"
+        );
+        assert!(migrate_only.is_ok(), "--migrate-store alone must parse");
+        assert!(
+            allow_only.is_ok(),
+            "--allow-stateful-removal alone must parse"
+        );
     }
 
     #[test]

--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -1275,9 +1275,50 @@ pub async fn live_stateful_components(o: &CommonOpts) -> Result<Vec<(String, Str
             plain("json"),
         ],
     );
-    let (ok, out, _err) = run_capture(&cmd).await?;
+    let (ok, out, err) = run_capture(&cmd).await?;
     if !ok {
-        return Ok(Vec::new());
+        // Fail closed. The ONLY "there is nothing here" answer this argv
+        // produces is exit 0 with an empty items array, which a namespaced LIST
+        // returns even for a namespace that does not exist (verified against a
+        // real apiserver, kubectl v1.36.2). So a nonzero exit always means "I
+        // could not find out", and returning an empty list from it told the
+        // stateful-removal guard "fresh install, nothing to lose" while the
+        // upgrade went on to prune the StatefulSet (#1351). The helm half of
+        // this same guard already bails; this is the symmetric half.
+        //
+        // The wording stays NEUTRAL about why the read was wanted. Three of this
+        // helper's four callers are running a migration rather than the
+        // stateful-removal guard, so naming that guard here reported a check the
+        // caller was not performing (#1351); the guard adds its own framing with
+        // `.context(..)` at its call site.
+        //
+        // kubectl can exit nonzero with an empty stderr (a signal, a wrapper
+        // script), so fall back to stdout and then to a literal rather than
+        // handing the operator a message ending in a bare colon.
+        let detail = [err.trim(), out.trim()]
+            .into_iter()
+            .find(|s| !s.is_empty())
+            .unwrap_or("kubectl exited nonzero with no stderr");
+        let message = format!(
+            "could not list the StatefulSets in namespace {}: {detail}",
+            o.namespace
+        );
+        // The bail is UNCONDITIONAL: every nonzero exit fails, so a Forbidden
+        // still fails (as Failure) and is never swallowed into a vacuous pass.
+        // `is_connectivity_failure` only picks the exit CLASS once that decision
+        // is made. An unreachable apiserver is the retryable condition exit 3
+        // names (`exit.rs`), and the helm half of a teardown already reports it
+        // that way, so an automation loop retries the same argv instead of
+        // reading a rolling restart as permanent (#1351).
+        return Err((if is_connectivity_failure(&err) {
+            crate::exit::CliError::transient(message)
+        } else {
+            crate::exit::CliError::failure(message)
+        }
+        .with_fix(
+            "check the cluster is reachable and the kubeconfig points at the right context: `kubectl config current-context` then `kubectl get ns`",
+        ))
+        .into());
     }
     let parsed: serde_json::Value = match serde_json::from_str(out.trim()) {
         Ok(v) => v,
@@ -2319,6 +2360,15 @@ fn is_connectivity_failure(stderr: &str) -> bool {
         "dial tcp",
         "connection reset",
         "context deadline exceeded",
+        // kubectl's own refusal wording, added when a kubectl call site started
+        // classifying with this (#1351). client-go prints "The connection to
+        // the server <host> was refused - did you specify the right host or
+        // port?", which carries none of the Go-client signatures above: the
+        // words are separated, so the literal "connection refused" never
+        // appears. Without this marker every unreachable-apiserver kubectl read
+        // classified as a permanent Failure. Kept to that one phrasing, which
+        // client-go emits only for a refused connection.
+        "connection to the server",
     ];
     MARKERS.iter().any(|marker| lower.contains(marker))
 }
@@ -5076,7 +5126,9 @@ mod tests {
     // `is_connectivity_failure` lower-cases stderr and matches only concrete
     // network signatures (connection refused, tls handshake, no route to
     // host, i/o timeout, network is unreachable, could not connect, dial tcp,
-    // connection reset, context deadline exceeded). Bare "unreachable" and
+    // connection reset, context deadline exceeded, and -- since a kubectl call
+    // site started classifying with it in #1351 -- client-go's own "connection
+    // to the server" refusal wording). Bare "unreachable" and
     // "timeout" are deliberately excluded: Helm wraps permanent
     // auth/exec-plugin/kubeconfig errors as `Kubernetes cluster unreachable:
     // ...`, so that generic prefix alone is not a reliable transient signal.
@@ -5100,6 +5152,19 @@ mod tests {
         ));
         assert!(is_connectivity_failure("i/o timeout"));
         assert!(is_connectivity_failure("no route to host"));
+    }
+
+    // #1351: kubectl's own refusal wording, verbatim as kubectl v1.36.2 wrote it
+    // to stderr against an unreachable apiserver during this ticket's live
+    // reproduction. client-go separates the words, so the "connection refused"
+    // marker above never appears in it and every unreadable-cluster kubectl read
+    // classified as a permanent Failure until the "connection to the server"
+    // marker was added.
+    #[test]
+    fn is_connectivity_failure_true_for_kubectls_own_refusal_wording() {
+        assert!(is_connectivity_failure(
+            "The connection to the server localhost:8080 was refused - did you specify the right host or port?"
+        ));
     }
 
     // P2: permanent failures (RBAC, authz, invalid) are NOT connectivity, so they

--- a/cli/tests/installation_plan_parity.rs
+++ b/cli/tests/installation_plan_parity.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 
 use serde_json::{json, Value};
@@ -22,10 +22,61 @@ fn repo_root() -> PathBuf {
         .to_path_buf()
 }
 
+/// The answer a real `kubectl get statefulset -n <ns> -o json` gives when the
+/// namespace holds none, and (identically) when the namespace does not exist at
+/// all: an empty List, exit 0. Observed behaviour, not an assumption about the
+/// implementation: recorded against a real apiserver with kubectl v1.36.2 and
+/// written up in the plan for #1351. The whole guard rests on it, so the stub
+/// reproduces the shape verbatim.
+const KUBECTL_EMPTY_LIST: &str =
+    r#"{"apiVersion":"v1","items":[],"kind":"List","metadata":{"resourceVersion":""}}"#;
+
+/// The stderr a real kubectl writes when it cannot reach an apiserver, observed
+/// in the same recording (`KUBECONFIG=/dev/null kubectl get statefulset ...`,
+/// exit 1). This is the shape a CI runner or a laptop with no cluster produces.
+const KUBECTL_UNREACHABLE: &str =
+    "The connection to the server localhost:8080 was refused - did you specify the right host or port?";
+
+/// The stderr a real kubectl writes when the caller's identity is denied by
+/// RBAC rather than the cluster being unreachable, for a namespaced `get
+/// statefulset` list. Verified against a publicly reported operator RBAC
+/// denial of this exact shape (a service account listing statefulsets
+/// without the role), which read: `statefulsets.apps is forbidden: User
+/// "system:serviceaccount:extension-system:keda-operator" cannot list
+/// resource "statefulsets" in API group "apps" at the cluster scope`. This
+/// string swaps in the namespaced tail (`in the namespace "<ns>"`) that a
+/// `-n` scoped list produces instead of "at the cluster scope". Deliberately
+/// carries none of `is_connectivity_failure`'s markers (no "connection",
+/// "refused", "timeout", "unreachable", "dial tcp", etc.): this is the
+/// non-connectivity failure shape the guard must still fail closed on.
+const KUBECTL_FORBIDDEN: &str = "Error from server (Forbidden): statefulsets.apps is forbidden: User \"system:serviceaccount:curie:deployer\" cannot list resource \"statefulsets\" in API group \"apps\" in the namespace \"curie\"";
+
+/// One staged object, as `<size> <key>`, the shape both halves of the
+/// migration's verify compare: the staging pod's `find -printf` listing and the
+/// new store's `aws s3 ls` listing. Identical on both sides means nothing was
+/// lost, which is the successful migration the AC2 test asserts.
+const STAGED_OBJECT: &str = "100 bundle.tar";
+
+/// Writes `body` to `dir/name` and makes it executable (mode 0o755), the
+/// dance both the helm and kubectl stubs need identically. Returns the path
+/// written.
+fn write_exec(dir: &Path, name: &str, body: &str) -> PathBuf {
+    let path = dir.join(name);
+    fs::write(&path, body).unwrap_or_else(|error| panic!("write {name} stub: {error}"));
+    let mut permissions = fs::metadata(&path)
+        .unwrap_or_else(|error| panic!("{name} metadata: {error}"))
+        .permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&path, permissions)
+        .unwrap_or_else(|error| panic!("make {name} stub executable: {error}"));
+    path
+}
+
 struct HelmFixture {
     temp: tempfile::TempDir,
     file: PathBuf,
     live_values: Option<String>,
+    log: PathBuf,
 }
 
 impl HelmFixture {
@@ -36,10 +87,13 @@ impl HelmFixture {
 
         let bin_dir = temp.path().join("bin");
         fs::create_dir(&bin_dir).expect("create stub bin directory");
-        let helm = bin_dir.join("helm");
-        fs::write(
-            &helm,
+        write_exec(
+            &bin_dir,
+            "helm",
             r#"#!/bin/sh
+if [ -n "${CURIE_TEST_CALL_LOG:-}" ]; then
+    printf 'HELM_CALL: %s\n' "$*" >> "$CURIE_TEST_CALL_LOG"
+fi
 if [ "$1" = get ] && [ "$2" = values ]; then
     if [ "${CURIE_TEST_HELM_ABSENT:-}" = 1 ]; then
         printf '%s\n' 'release not found' >&2
@@ -48,20 +102,130 @@ if [ "$1" = get ] && [ "$2" = values ]; then
     printf '%s\n' "$CURIE_TEST_HELM_VALUES"
     exit 0
 fi
+if [ "$1" = template ]; then
+    cat <<'YAML'
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: parity-rustfs
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: rustfs
+YAML
+    exit 0
+fi
+if [ "$1" = upgrade ]; then
+    exit 0
+fi
 printf 'unexpected helm invocation: %s\n' "$*" >&2
 exit 64
 "#,
-        )
-        .expect("write helm stub");
-        let mut permissions = fs::metadata(&helm).expect("helm metadata").permissions();
-        permissions.set_mode(0o755);
-        fs::set_permissions(&helm, permissions).expect("make helm stub executable");
+        );
 
+        write_exec(
+            &bin_dir,
+            "kubectl",
+            &format!(
+                r#"#!/bin/sh
+# Answers only the calls the paths under test actually make, and exits 64 on
+# anything else, the same tripwire convention the helm stub uses. A stub that
+# hands every question the same plausible blob cannot tell "the code asked the
+# right question" from "the code asked a nonsense question and got a nonsense
+# answer": the migration's Service lookup was being answered with the whole
+# StatefulSet List, which then landed inside an endpoint URL (#1351).
+if [ -n "${{CURIE_TEST_CALL_LOG:-}}" ]; then
+    printf 'KUBECTL_CALL: %s\n' "$*" >> "$CURIE_TEST_CALL_LOG"
+fi
+all="$*"
+verb=""
+object=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --) break ;;
+        -n|--namespace|-o|--output|-l|--selector|--image|--overrides) shift 2 ;;
+        -*) shift ;;
+        *)
+            if [ -z "$verb" ]; then
+                verb="$1"
+            elif [ -z "$object" ]; then
+                object="$1"
+            fi
+            shift
+            ;;
+    esac
+done
+unexpected() {{
+    printf 'unexpected kubectl invocation: %s\n' "$all" >&2
+    exit 64
+}}
+case "$verb $object" in
+'get statefulset')
+    if [ "${{CURIE_TEST_KUBECTL_FAIL:-}}" = 1 ]; then
+        printf '%s\n' '{KUBECTL_UNREACHABLE}' >&2
+        exit 1
+    fi
+    if [ "${{CURIE_TEST_KUBECTL_FORBIDDEN:-}}" = 1 ]; then
+        printf '%s\n' '{KUBECTL_FORBIDDEN}' >&2
+        exit 1
+    fi
+    if [ -n "${{CURIE_TEST_KUBECTL_STS:-}}" ]; then
+        printf '%s\n' "$CURIE_TEST_KUBECTL_STS"
+    else
+        printf '%s\n' '{KUBECTL_EMPTY_LIST}'
+    fi
+    ;;
+'get svc')
+    # The jsonpath asks for a Service NAME, so answer with one, for whichever
+    # store component the caller named and nothing else.
+    case "$all" in
+        *'=="minio"'*) printf '%s\n' 'parity-minio' ;;
+        *'=="rustfs"'*) printf '%s\n' 'parity-rustfs' ;;
+        *) unexpected ;;
+    esac
+    ;;
+'get secret')
+    printf '%s\n' 'parity-secrets'
+    ;;
+'run '*|'wait '*|'delete pod')
+    # Staging-pod lifecycle: nothing to say, just succeed.
+    : ;;
+'exec '*)
+    # One answer per in-pod script the migration runs, keyed on the script
+    # itself: a single canned answer here would let the export and the verify
+    # read each other's output.
+    case "$all" in
+        *'wc -l'*) printf '%s\n' '1' ;;
+        *'-printf'*) printf '%s\n' '{STAGED_OBJECT}' ;;
+        *'aws s3 ls'*) printf '%s\n' '{STAGED_OBJECT}' ;;
+        *'aws s3 sync'*) printf '%s\n' 'synced' ;;
+        *) unexpected ;;
+    esac
+    ;;
+*)
+    unexpected
+    ;;
+esac
+exit 0
+"#
+            ),
+        );
+
+        let log = temp.path().join("calls.log");
         Self {
             temp,
             file,
             live_values: live_values.map(|values| values.to_string()),
+            log,
         }
+    }
+
+    /// Every stubbed helm and kubectl invocation this fixture has seen, in
+    /// order. Empty when nothing ran, which is the assertion a run that must
+    /// touch no cluster turns on, so a missing file reads as "no calls" rather
+    /// than panicking.
+    fn calls(&self) -> String {
+        fs::read_to_string(&self.log).unwrap_or_default()
     }
 
     fn run(&self, args: &[&str], env: &[(&str, &str)]) -> Output {
@@ -77,6 +241,10 @@ exit 64
             .arg("--json")
             .args(args)
             .env("PATH", path)
+            .env("CURIE_TEST_CALL_LOG", &self.log)
+            .env_remove("CURIE_TEST_KUBECTL_STS")
+            .env_remove("CURIE_TEST_KUBECTL_FAIL")
+            .env_remove("CURIE_TEST_KUBECTL_FORBIDDEN")
             .env_remove("CURIE_MODEL")
             .env_remove("CURIE_TEST_PROVIDER_EGRESS_JSON")
             .env_remove("CURIE_APPLY_TEST_MODEL_KEY")
@@ -109,6 +277,14 @@ exit 64
             ],
             env,
         )
+    }
+
+    /// The REAL apply path, no `--dry-run`: the guard, the migration branch and
+    /// the upgrade all run against the stubs.
+    fn apply(&self, extra: &[&str], env: &[(&str, &str)]) -> Output {
+        let mut args = vec!["apply", "--file", self.file.to_str().expect("UTF 8 path")];
+        args.extend_from_slice(extra);
+        self.run(&args, env)
     }
 
     fn diff(&self, env: &[(&str, &str)]) -> Output {
@@ -264,6 +440,28 @@ fn assert_diff_keys(diff: &Value, expected: &[&str]) {
         .collect::<BTreeSet<_>>();
     let expected = expected.iter().copied().collect::<BTreeSet<_>>();
     assert_eq!(actual, expected, "diff effective values: {diff}");
+}
+
+/// The smallest installation the stateful-removal guard runs against: it names
+/// only the namespace and release, so the run makes exactly the cluster calls
+/// the guard and the upgrade need and nothing else.
+fn installation_for_the_stateful_guard() -> &'static str {
+    "version: 1\ninstall:\n  namespace: parity\n  release: parity\n"
+}
+
+/// A live release running a `minio` object store, in the shape
+/// `kubectl get statefulset -o json` returns it. The component label is the
+/// identity the guard reads; the resource name is what an operator sees.
+fn live_minio_statefulset() -> String {
+    json!({
+        "apiVersion": "v1",
+        "kind": "List",
+        "items": [{
+            "metadata": {"name": "parity-minio"},
+            "spec": {"selector": {"matchLabels": {"app.kubernetes.io/component": "minio"}}}
+        }]
+    })
+    .to_string()
 }
 
 fn installation_with_effective_values() -> &'static str {
@@ -430,5 +628,265 @@ fn apply_and_diff_report_the_same_curie_model_conflict() {
     assert_eq!(
         apply_error, diff_error,
         "apply and diff must use the same effective-plan conflict validation"
+    );
+}
+
+#[test]
+fn apply_with_both_flags_makes_no_cluster_call() {
+    // #1351: --migrate-store and --allow-stateful-removal state contradictory
+    // intent, and apply resolved the contradiction by silently dropping the
+    // migration and taking the data destroying path. The primary assertion is
+    // the ABSENCE of the mutation, not the wording of the refusal.
+    let fixture = HelmFixture::new(installation_for_the_stateful_guard(), None);
+
+    let output = fixture.apply(&["--migrate-store", "--allow-stateful-removal"], &[]);
+
+    let calls = fixture.calls();
+    assert!(
+        calls.is_empty(),
+        "a contradictory flag pair must touch no cluster at all; recorded calls:\n{calls}"
+    );
+    assert!(
+        !calls.contains("upgrade"),
+        "no upgrade may run for a rejected apply; recorded calls:\n{calls}"
+    );
+    assert!(
+        !output.status.success(),
+        "a contradictory flag pair must not exit successfully; stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    // The two flag names only, never clap's full sentence, and no pinned exit
+    // code: an operator needs to be told which two flags collided, and a clap
+    // patch bump must not fail this.
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--migrate-store") && stderr.contains("--allow-stateful-removal"),
+        "the refusal must name both colliding flags; stderr:\n{stderr}"
+    );
+}
+
+#[test]
+fn migrate_store_alone_still_migrates() {
+    // AC2: the control run. A live minio store plus a chart that renders rustfs
+    // is the rename the guard exists for, and --migrate-store alone must still
+    // take the migration branch.
+    let fixture = HelmFixture::new(installation_for_the_stateful_guard(), None);
+
+    let output = fixture.apply(
+        &["--migrate-store"],
+        &[("CURIE_TEST_KUBECTL_STS", &live_minio_statefulset())],
+    );
+
+    let calls = fixture.calls();
+    assert!(
+        output.status.success(),
+        "--migrate-store alone must carry the migration through; stdout:\n{}\nstderr:\n{}\ncalls:\n{calls}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let live_read = calls
+        .find("KUBECTL_CALL: get statefulset")
+        .unwrap_or_else(|| panic!("the guard must read the live StatefulSets:\n{calls}"));
+    let render = calls
+        .find("HELM_CALL: template")
+        .unwrap_or_else(|| panic!("the guard must render the target chart:\n{calls}"));
+    let store_lookup = calls
+        .find("KUBECTL_CALL: get svc")
+        .unwrap_or_else(|| panic!("the migration must look up the store Service:\n{calls}"));
+    let upgrade = calls
+        .find("HELM_CALL: upgrade")
+        .unwrap_or_else(|| panic!("the migration must upgrade the release:\n{calls}"));
+    assert!(
+        live_read < render && render < store_lookup && store_lookup < upgrade,
+        "the migration branch runs the live read, then the render, then the store lookup, then the upgrade:\n{calls}"
+    );
+    // The export must be COMPLETE before the upgrade deletes the old store, and
+    // the import must run after it. Staging alone, then upgrading, is the
+    // failure mode that empties the store.
+    let staged = calls
+        .find("find /stage -type f | wc -l")
+        .unwrap_or_else(|| panic!("the export must count what it staged:\n{calls}"));
+    let imported = calls
+        .find("aws s3 sync /stage")
+        .unwrap_or_else(|| panic!("the import must load the staged objects back:\n{calls}"));
+    assert!(
+        staged < upgrade && upgrade < imported,
+        "the export completes before the upgrade and the import runs after it:\n{calls}"
+    );
+    assert!(
+        calls.contains("KUBECTL_CALL: delete pod"),
+        "a verified migration releases the staging pod:\n{calls}"
+    );
+}
+
+#[test]
+fn migrate_store_does_not_read_a_failed_cluster_read_as_a_removal() {
+    // #1351, the other face of the same defect. While the refusal was the only
+    // error the guard could raise, `--migrate-store` read any Err as "a removal
+    // was found" and started moving data. Once the guard could also fail
+    // because the cluster was unreadable, that reading promoted "I could not
+    // find out" to "definitely at risk, start staging" -- and the run then died
+    // inside the export with "nothing to migrate", a message about a decision
+    // the operator never made, blaming the wrong thing.
+    let fixture = HelmFixture::new(installation_for_the_stateful_guard(), None);
+
+    let output = fixture.apply(&["--migrate-store"], &[("CURIE_TEST_KUBECTL_FAIL", "1")]);
+
+    let calls = fixture.calls();
+    assert!(
+        calls.contains("KUBECTL_CALL: get statefulset"),
+        "the guard must have tried to read the live StatefulSets:\n{calls}"
+    );
+    assert!(
+        !calls.contains("KUBECTL_CALL: run "),
+        "an unreadable cluster must not start an export:\n{calls}"
+    );
+    assert!(
+        !calls.contains("HELM_CALL: upgrade"),
+        "an unreadable cluster must stop the apply before the upgrade:\n{calls}"
+    );
+    // ADR-0021's exit-code contract: an automation loop branches on the code
+    // rather than parsing prose, so an apiserver rolling restart reports exit 3
+    // Transient (retry the same argv) and not exit 1 Failure, which reads as
+    // "stop".
+    assert_eq!(
+        output.status.code(),
+        Some(3),
+        "an unreachable apiserver is transient; stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let error = json_error(output, "apply --migrate-store");
+    let message = error["error"].as_str().expect("error message string");
+    assert!(
+        message.contains("The connection to the server localhost:8080 was refused"),
+        "the failure must carry kubectl's own words: {error}"
+    );
+    assert!(
+        !message.contains("nothing to migrate"),
+        "a failed read must not be reported as a migration decision: {error}"
+    );
+}
+
+#[test]
+fn allow_stateful_removal_alone_still_proceeds() {
+    // AC3: the override short circuits the guard entirely, so the same live
+    // minio store that stops a plain apply proceeds straight to the upgrade.
+    let fixture = HelmFixture::new(installation_for_the_stateful_guard(), None);
+
+    let output = fixture.apply(
+        &["--allow-stateful-removal"],
+        &[("CURIE_TEST_KUBECTL_STS", &live_minio_statefulset())],
+    );
+
+    let calls = fixture.calls();
+    assert!(
+        output.status.success(),
+        "--allow-stateful-removal alone must still apply; stdout:\n{}\nstderr:\n{}\ncalls:\n{calls}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        calls.contains("HELM_CALL: upgrade"),
+        "the upgrade must run:\n{calls}"
+    );
+    assert!(
+        !calls.contains("KUBECTL_CALL: get statefulset"),
+        "the override skips the guard, so nothing reads the live StatefulSets:\n{calls}"
+    );
+}
+
+#[test]
+fn a_failed_kubectl_read_fails_the_apply() {
+    // AC4, the core anti regression for #1351: a kubectl read that FAILED was
+    // returned as an empty list, which told the guard "fresh install, nothing
+    // to lose" while the upgrade went on to prune the StatefulSet.
+    let fixture = HelmFixture::new(installation_for_the_stateful_guard(), None);
+
+    let output = fixture.apply(&[], &[("CURIE_TEST_KUBECTL_FAIL", "1")]);
+
+    let calls = fixture.calls();
+    assert!(
+        !calls.contains("HELM_CALL: upgrade"),
+        "an unreadable cluster must stop the apply before the upgrade:\n{calls}"
+    );
+    assert!(
+        !output.status.success(),
+        "an unreadable cluster must not exit successfully; stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let reported = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        reported.contains("The connection to the server localhost:8080 was refused"),
+        "the failure must carry kubectl's own words, so a guard failure reads differently from a refusal:\n{reported}"
+    );
+}
+
+#[test]
+fn a_forbidden_kubectl_read_fails_the_apply_as_a_permanent_failure() {
+    // Closes a gap the spec reviewer named for #1351: the only kubectl-failure
+    // stderr both `a_failed_kubectl_read_fails_the_apply` and
+    // `migrate_store_does_not_read_a_failed_cluster_read_as_a_removal` drive is
+    // a CONNECTIVITY failure. Nothing pinned the sibling branch,
+    // `is_connectivity_failure(stderr) == false`, which is what an RBAC
+    // Forbidden denial takes. A regression shaped as "swallow the failure only
+    // when it is NOT a connectivity failure" would leave both of those tests
+    // green while restoring the exact vacuous-pass data-loss bug for a
+    // Forbidden read: exit 0, no error, the guard reading "fresh install,
+    // nothing to lose", and the upgrade pruning a live StatefulSet.
+    let fixture = HelmFixture::new(installation_for_the_stateful_guard(), None);
+
+    let output = fixture.apply(&[], &[("CURIE_TEST_KUBECTL_FORBIDDEN", "1")]);
+
+    let calls = fixture.calls();
+    assert!(
+        !calls.contains("HELM_CALL: upgrade"),
+        "an RBAC denied cluster read must stop the apply before the upgrade:\n{calls}"
+    );
+    // ADR-0021's exit-code contract: exit 3 Transient means "retry the same
+    // argv", which is wrong advice for a permission denial that will not
+    // clear on its own. This is the assertion that actually closes the gap:
+    // it can only pass if the non-connectivity branch runs at all, which the
+    // vacuous-pass shape of the bug would never reach.
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "a Forbidden cluster read is a permanent failure, not transient or a silent success; stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let error = json_error(output, "apply");
+    let message = error["error"].as_str().expect("error message string");
+    assert!(
+        message.contains("cannot list resource \"statefulsets\""),
+        "the failure must carry kubectl's own Forbidden wording, so an operator can tell an RBAC problem from an unreachable cluster: {error}"
+    );
+}
+
+#[test]
+fn a_namespace_with_no_statefulsets_still_passes_the_guard() {
+    // AC5, the trap guard. An empty items array with exit 0 is what a real
+    // namespaced LIST returns for a fresh install AND for a namespace that does
+    // not exist, so it is a genuine "nothing to lose" and must still apply.
+    let fixture = HelmFixture::new(installation_for_the_stateful_guard(), None);
+
+    let output = fixture.apply(&[], &[]);
+
+    let calls = fixture.calls();
+    assert!(
+        output.status.success(),
+        "an empty namespace must still apply; stdout:\n{}\nstderr:\n{}\ncalls:\n{calls}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        calls.contains("HELM_CALL: upgrade"),
+        "the upgrade must run:\n{calls}"
     );
 }

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -323,8 +323,22 @@ component's old keys appear as ordinary resets, which reads far milder than the
 swap it would be.
 
 `curie apply` refuses outright when the upgrade would delete a StatefulSet the
-release is running, and names it. `--allow-stateful-removal` overrides that, and
-should only be passed once the data is migrated or you accept losing it.
+release is running, and names it. `--migrate-store` is the option to reach
+for: apply stages every object, upgrades, loads them back, and verifies per
+object, all in one command, so the data survives. It is opt-in rather than
+automatic because the migration has a window where the store is empty and the
+bot cannot answer, so an apply that only changes a log level must never
+silently start moving data. `--allow-stateful-removal` proceeds WITHOUT the
+data instead, for a store you genuinely intend to discard. The two flags are
+mutually exclusive: passing both is rejected by the parser with a nonzero
+exit, never silently resolved by picking one.
+
+If `curie apply` cannot read the cluster to run this check (an unreachable or
+erroring apiserver), it now fails rather than assuming nothing is at risk. An
+unreachable cluster classifies as transient (exit code 3), so an automation
+loop can retry the same command. This also applies to `--dry-run`: a dry run
+that could not read the cluster cannot honestly claim the store is safe, so it
+now errors instead of printing a plan.
 
 Without the CLI, the same check by hand:
 


### PR DESCRIPTION
Closes #1351

`curie apply` took `--migrate-store` (carry the object store across a chart that renames it) and `--allow-stateful-removal` (proceed without the data). Passing both silently discarded the migration and took the destructive path at exit 0, because `allow_stateful_removal` short circuited before `migrate_store` was consulted. The product's own refusal message names both flags, which is why an operator passes both.

## What changed

- The pair is rejected at the parser (`conflicts_with`), and again at the head of `apply`, where the destruction is owned and `ApplyOpts` fields are `pub` on a lib crate. Contradictory intent is refused, never resolved by picking one.
- `guard_stateful_removal` returns a verdict value rather than using `Result<()>` as a two valued signal, so `Err` always means the check itself failed and never that a removal was found.
- `live_stateful_components` fails closed on any nonzero `kubectl` exit.

## Behavior changes a reviewer should weigh

Three intended changes go slightly beyond the literal ticket text.

1. **`apply --dry-run` against an unreachable cluster now errors instead of printing a plan.** The guard runs under dry run too, and a dry run that could not read the cluster cannot honestly claim the store is safe.
2. **`cluster migrate-store` inherits the same failure.** `run_export`, `run_import`, and `run_auto` all call `live_stateful_components` and now fail on an unreadable cluster instead of proceeding from an empty list.
3. **`is_connectivity_failure` gained one marker**, `connection to the server`. kubectl's real refusal wording matched none of the existing Go client markers, so without it the new transient classification returned exit 1. This also affects `cluster down`'s `teardown_result`, the classifier's other caller, which until now misreported an unreachable-cluster teardown as permanent rather than retryable. Same direction, and a latent bug in its own right.

## The load-bearing factual claim, verified rather than assumed

The fix rests on: `kubectl get statefulset -n <absent-ns> -o json` returns **exit 0 with an empty `items` array**, so a nonzero exit has no legitimate "nothing here" member and can be failed unconditionally. Verified against a real apiserver (kubectl v1.36.2, apiserver v1.36.2+k3s1): the answer is byte identical to an existing namespace with no StatefulSets, while `kubectl get ns <absent>` **is** a nonzero NotFound. A naive fix here breaks every first install; that path is covered by a test and was checked live.

`is_connectivity_failure` was deliberately **not** used to gate whether the failure happens. It only picks the exit class after the decision to fail is made, so an RBAC `Forbidden` still fails (at exit 1) and is never swallowed.

## Note on the test fixture

`cli/tests/installation_plan_parity.rs` stubbed helm but not kubectl, so four pre existing tests were shelling out to the **host's** kubeconfig and passing only because the swallow this PR removes converted that failure into "nothing at risk". Stubbing kubectl was required, not a drive by, and it removes a latent flake where those tests passed or failed based on the developer's kubeconfig. The kubectl stub dispatches per verb and exits 64 on an unexpected invocation, so a wrong question now fails the test instead of being answered.

## Done check

- [x] Failing tests committed before implementation. `c231194d` (tests, 3 failing) precedes `5d945ab2` (fix), verified in `git log` before squash.
- [x] All production edits by delegated sub agents. Driver ran only git, tests, and bookkeeping.
- [x] Broadened return types checked. No signature changed. `live_stateful_components` keeps `Result<Vec<(String, String)>>` but now yields `Err` where it yielded `Ok(vec![])`; all four callers propagate with `?` (`installation.rs:718`, `migrate_store.rs:691,783,960`).
- [ ] **Cross engine code review: NOT RUN.** Codex hit its usage limit until 2026-08-08. Substituted the native reviewer stack (separate mandates, fresh contexts): 1 blocker, 4 major, 2 minor found and all resolved. This is mandate diversity, not engine diversity, and is the one gate this PR does not clear as specified.
- [x] Scope review approved. 16 hunks, 0 files outside the permitted set, 1 orphan found (a dead `CURIE_TEST_HELM_TEMPLATE` branch) and removed. Post review additions annotated above.
- [x] Sibling path parity. Plan enumerated 16 sites (6 in scope, 4 shared helper or already correct, 6 out of scope with a reason); diff matches. One site the plan did not name surfaced at this gate: `is_connectivity_failure`'s second caller, item 3 above. Recorded as a plan time localization miss with a favorable resolution.
- [x] Guard demonstration by execution. Both flag orders rejected at exit 2 with each flag alone still parsing; `exit 64` stub tripwire shown firing; and the RBAC test proven by mutation (reintroducing the bug as "swallow only the non connectivity branch" fails the new test while the connectivity test stays green).
- [x] Consolidation pass ran. `/simplify` across 4 angles; 2 cleanups applied, test count unchanged at 1156. The 2 hunk mechanical result was verified directly rather than re reviewed by an agent.
- [ ] Security reviewer: N/A, not flagged.
- [x] E2E observed deployed behavior. 5 of 5 checks pass against a real cluster, dry run only, no mutation, cluster state identical pre and post.
- [x] Full suite passes: 1157 passed, 0 failed, 38 suites.
- [x] Lint clean: `cargo fmt --check`, `cargo clippy --locked --all-targets -- -D warnings`, and `curie dev docs-lint` all clean.

## Known follow ups, deliberately not in this PR

- `serde_json::from_str` failing in `live_stateful_components` still returns `Ok(Vec::new())`. The ticket tested this and declared it out of scope (exit 0 with unparseable stdout is not a state real kubectl reaches), but it is now the only surviving path by which a failed read becomes "nothing at risk".
- The guard and `run_export` each independently re-read the cluster (2 kubectl and 2 helm template calls per migrating apply). Pre existing and byte identical to before this PR; worth collapsing separately.
- The connectivity classifier is a string denylist. A typed error off the `run_capture` layer would be the deeper fix, well beyond this bugfix.
