### PR TITLE
ADR 0100: agents search their own surface

### DIFF
--- a/docs/adr/0100-agents-search-their-own-surface-through-the-channel-port.md
+++ b/docs/adr/0100-agents-search-their-own-surface-through-the-channel-port.md
@@ -1,0 +1,191 @@
+# 100. Agents search their own surface through the channel port
+
+Date: 2026-08-06
+
+Status: Draft
+
+## Context
+
+Claude Code is effective in a repository because the filesystem is a surface
+it can read and search: `Read` and `Grep` are cheap, bounded, and always
+available. A Curie agent's working surface is the channel it is bound to, and
+today it cannot read that surface at all. The channel port
+([ADR-0020](0020-message-port-rendering-free-channel-interface.md)) is
+write-only: the `SlackSink` protocol
+(`apps/worker/src/curie_worker/slack_sink.py`) exposes post, update, and
+status verbs and nothing else. There is no verb to fetch a message by
+permalink, read a window of history, or search the channel. An agent asked
+"what did we decide about this in March" has only its own memory document and
+whatever the current thread contains.
+
+This capability is independent of memory. ADR-0095 (Draft, in review) names a
+bounded escape valve into raw history as one consumer, but the primary
+consumer is the live turn: agentic search over the bound surface as part of
+the normal skill, the way Claude Code greps a repo mid-task.
+
+The permission argument is what makes a bounded version safe: anyone who can
+invoke the agent in a channel can already read that channel, so the agent
+reading the same history back adds no access. Crossing the channel boundary
+is what would add access, so the channel boundary is the security line, and
+it must be the platform's line, because (researched 2026-08) Slack does not
+draw it: Slack's search APIs are workspace-wide by default,
+`search:read.public` explicitly does not require channel membership, and the
+Real-time Search API's `context_channel_id` is a scoping hint, not a
+boundary. No surveyed system (Slack's own APIs, MCP Slack servers, enterprise
+search vendors) implements a true single-channel search primitive; the only
+hard fence found in the ecosystem is a config-level channel allowlist with no
+search verb at all.
+
+Two more external facts shape the decision. First, Slack now mandates the
+zero-copy posture Curie already chose in ADR-0095: the API Terms of Service
+ban persistent copies or indexes of other organizations' API data, and the
+Marketplace guidelines say "zero-copy" outright, so federating rather than
+indexing is the platform-required design, with Glean, Onyx, Microsoft 365
+Copilot, and Gemini Enterprise all shipping federated Slack modes. Second,
+the 2024 Slack AI exfiltration is the threat model for any history-reading
+tool: instructions planted as an ordinary message were later retrieved into
+the assistant's context and steered it. Anyone who can post in the channel,
+including anyone who ever could, can plant content the agent will someday
+read.
+
+## Decision
+
+**Reading and searching the bound surface's history are channel-port verbs:
+implemented by each adapter, hard-bounded to the bound scope by construction,
+enabled per bundle as an option, budgeted below the model, and never
+persisted by the platform.**
+
+### The verbs
+
+Four read verbs join the port contract, siblings of the outbound sink and as
+rendering-free as it is:
+
+- `read_window`: a slice of the bound scope's history (time window or
+  cursor, capped count, newest first).
+- `read_thread`: one thread by its surface identity.
+- `resolve_reference`: dereference a surface permalink or message id into
+  the message plus minimal surrounding context. Refuses references outside
+  the bound scope.
+- `search`: keyword or pattern match over the bound scope's history, with
+  window and count caps.
+
+A surface that cannot implement a verb declares the capability absent, the
+existing `ChannelCapability` pattern. An email adapter later maps the same
+verbs onto a mailbox: a window is a date slice, a thread is a message chain,
+search is a server-side or local match. The verbs are the contract; the
+mechanics are the adapter's.
+
+### The Slack adapter
+
+Reads use `conversations.history` and `conversations.replies` under the
+`channels:history` and `groups:history` scopes, the same scopes ADR-0095's
+bootstrap already requires. `search` is implemented adapter-side: paginate
+the bound channel's history and match locally. No Slack search API is
+involved (see alternatives), which is what makes the channel bound
+structural rather than filtered: the adapter can only page channels the bot
+is a member of, and the platform hands it only the bound channel id.
+
+This works at acceptable cost only because of a distribution assumption this
+ADR records as load-bearing: **each agent is its own workspace-internal
+Slack app**, with its own bot user, mention handle, and token. Internal apps
+keep standard rate limits (Tier 3, 50+ requests per minute on
+`conversations.history`). A single Curie-distributed app outside the Slack
+Marketplace would fall under the May 2025 limits, 1 request per minute and
+15 messages per page, and this ADR's cost model collapses. Distribution is
+therefore an architectural commitment, not an onboarding convenience.
+
+### Exposure and enablement
+
+The verbs surface to the agent as tools in ordinary turns, part of the
+normal skill. Enablement is a bundle option, off by default in v1: the
+author who wants their agent to search its channel declares it, next to
+everything else the bundle declares. Background turns get the same tools
+under the same flag; nothing here is memory-specific, and ADR-0095's escape
+valve becomes one caller of `resolve_reference` and `search` rather than its
+own mechanism.
+
+The agent reaches the verbs through the platform API with the turn's scoped
+state token ([ADR-0033](0033-scoped-sandbox-state-token.md)), the same
+brokered path as memory state. The runner never holds surface credentials;
+the credential-forwarding posture is unchanged.
+
+### Bounds, all enforced below the model
+
+- **Scope**: the bound channel only, structural per the adapter design
+  above.
+- **Result cap**: default 20 items per call. The ecosystem converges here
+  (Slack's own agent search API caps at 20; comparable federated connectors
+  default to 25).
+- **Window default**: bounded lookback per call unless the agent asks for a
+  specific range, so an unqualified search does not page years of history.
+- **Per-turn budget**: a ceiling on read calls and on total returned tokens
+  per turn, with oversized results truncated. Long-context research is
+  unambiguous that piling marginally-relevant history into context degrades
+  the turn that asked for it; the cap is a quality bound, not just a cost
+  bound.
+- **Provenance framing**: retrieved content enters the model only as tool
+  results labeled as channel history, data rather than instruction. This is
+  the documented mitigation lane for the Slack AI incident class. A
+  classifier screen over retrieved content is named as future hardening,
+  not built in v1.
+
+### Zero-copy
+
+Results are returned to the turn and never written to platform state. The
+platform stores no message bodies, no search indexes, and no embeddings of
+surface content, consistent with ADR-0095's retention posture and with
+Slack's mandated posture for apps. The honest cost, stated plainly: federated
+paging has worse recall than an index, and the vendor that ships both says
+so. Curie accepts that because standing recall is the memory document's job;
+this valve serves point lookups. If recall pressure grows, the answer is
+better memory, never an index.
+
+## Consequences
+
+- The channel protocol package gains read-side models; a reader protocol
+  lands beside `SlackSink` in the worker; the platform API grows the
+  brokered tool endpoints.
+- The Slack app manifest for an agent adds the two history scopes;
+  operators of existing agents reinstall to grant them, the same consent
+  step ADR-0095's bootstrap already requires.
+- ADR-0095's escape-valve wording ("scoped search, operator opt-in")
+  resolves to this ADR's enablement flag; that Draft gets a one-line
+  deferral here rather than its own search semantics.
+- Cost is O(pages) in the searched window and capped by the budget; a
+  capped search can miss old history, and that miss is accepted rather than
+  worked around with an index.
+- The invoker-visibility argument holds only while the boundary holds:
+  any future cross-channel capability (multi-channel agents, Epic #27)
+  cannot inherit these verbs without a new decision, because reading a
+  channel the invoker cannot read is exactly the escalation this design
+  excludes.
+
+## Alternatives considered
+
+- **Slack's Real-time Search API** (`assistant.search.context`). Rejected
+  for v1. It is workspace-wide by default and its channel scoping is a
+  hint; using it would move the boundary from structural to filtered. Bot
+  tokens additionally require an `action_token` minted from a live message
+  event, which background turns do not have, and semantic mode is gated to
+  Slack AI plans. Revisit only as an optimization behind the same
+  platform-enforced channel filter.
+- **`search.messages`**. User-token-only, and Slack now explicitly steers
+  apps away from it.
+- **Indexing or embedding channel history.** Rejected in ADR-0095 for
+  retention reasons (a second derived copy with no deletion propagation)
+  and now also contrary to Slack's zero-copy terms for distributed apps.
+- **Workspace-wide search.** Rejected. The invoker-visibility argument does
+  not cover channels the invoker cannot read. The closest comparable
+  product ships workspace search with no operator off-switch and a
+  documentation-only injection warning; that is the cautionary reference,
+  not the model.
+- **A Slack MCP server wired into the bundle instead of a port
+  capability.** Rejected as the path for this capability. An MCP
+  integration authenticates with whatever token its author wires and
+  reaches whatever that token reaches; the platform can neither bound it to
+  the channel nor budget it, and it is Slack-shaped rather than
+  surface-agnostic. Authors remain free to add MCP servers for other
+  reasons; they are not how the agent reads its own surface.
+- **Default-on.** Deferred. The capability is safe under the
+  invoker-visibility argument, but it changes an agent's cost and context
+  profile, so the author opts in per bundle in v1.

--- a/docs/adr/0100-agents-search-their-own-surface-through-the-channel-port.md
+++ b/docs/adr/0100-agents-search-their-own-surface-through-the-channel-port.md
@@ -94,15 +94,49 @@ Marketplace would fall under the May 2025 limits, 1 request per minute and
 15 messages per page, and this ADR's cost model collapses. Distribution is
 therefore an architectural commitment, not an onboarding convenience.
 
+Because the assumption is load-bearing, the adapter states what it does when
+the assumption is false: it detects the constrained case and refuses the verb,
+declaring the capability absent through the existing `ChannelCapability` path.
+Under the constrained limits a paginated search would not fail. It would return
+whatever it managed to page before the budget ran out, and a partial result
+presented as a search result is worse than a refusal, because the agent cannot
+tell the difference and will answer confidently from a fraction of the history.
+A broken deployment must report a missing capability instead.
+
 ### Exposure and enablement
 
 The verbs surface to the agent as tools in ordinary turns, part of the
 normal skill. Enablement is a bundle option, off by default in v1: the
 author who wants their agent to search its channel declares it, next to
-everything else the bundle declares. Background turns get the same tools
-under the same flag; nothing here is memory-specific, and ADR-0095's escape
-valve becomes one caller of `resolve_reference` and `search` rather than its
-own mechanism.
+everything else the bundle declares. Nothing here is memory-specific, and
+ADR-0095's escape valve becomes one caller of `resolve_reference` and `search`
+rather than its own mechanism.
+
+### Background turns get the verbs, on a different argument
+
+Background turns (ADR-0099) get the same tools under the same flag. Reading the
+bound surface is much of the point of background work, and the same bundle
+author writes the hook, its standing prompt, and this enablement flag, so the
+platform does not fence one against the other. But the safety case above does
+not extend to them unchanged, and inheriting it silently would be the error.
+
+The permission argument is replaced, not carried over. Invoker visibility
+bounds nothing when there is no invoker. What authorizes a hook turn's read is
+the bundle author's declared standing prompt, deployed and reviewed as part of
+the bundle, running against a channel an operator deliberately bound the agent
+to. That is a real authorization and it is a different one, so it is stated
+here rather than assumed.
+
+The injection mitigation is weaker for these turns, and this ADR records that
+rather than papering it. Provenance framing works partly because a user-started
+turn produces a reply a human reads, so a steered turn has a witness. A hook
+turn has no reply handle, so an unattended turn can read planted history and
+act through its tools with nothing appearing in the channel. That is the 2024
+incident shape with the witness removed, and v1 accepts it: the author who
+enabled both surfaces is the party who chose it, the run record makes the fire
+itself visible, and the classifier screen named below is the hardening lane
+when this stops being acceptable. What v1 does not do is claim the
+invoker-visibility argument covers it.
 
 The agent reaches the verbs through the platform API with the turn's scoped
 state token ([ADR-0033](0033-scoped-sandbox-state-token.md)), the same
@@ -113,6 +147,11 @@ the credential-forwarding posture is unchanged.
 
 - **Scope**: the bound channel only, structural per the adapter design
   above.
+- **Refusal is not an oracle**: a reference outside the bound scope and a
+  reference that does not exist return the same result. A distinguishable
+  refusal would confirm the existence of out-of-scope messages to anyone who
+  can get the agent to dereference a guessed permalink, and it is one sentence
+  now against an awkward change later.
 - **Result cap**: default 20 items per call. The ecosystem converges here
   (Slack's own agent search API caps at 20; comparable federated connectors
   default to 25).
@@ -158,7 +197,13 @@ better memory, never an index.
   any future cross-channel capability (multi-channel agents, Epic #27)
   cannot inherit these verbs without a new decision, because reading a
   channel the invoker cannot read is exactly the escalation this design
-  excludes.
+  excludes. It is also scoped to user-started turns, so a path that reaches
+  these verbs with no invoker carries the standing-prompt authorization stated
+  above and not this one.
+- An unattended turn that reads history, acts through tools, and posts nothing
+  is reachable in v1 by enabling one bundle flag on a hook. That is a known and
+  accepted exposure, owned by the author who enabled both, and it is the
+  concrete trigger for promoting the classifier screen out of future hardening.
 
 ## Alternatives considered
 

--- a/docs/adr/0100-agents-search-their-own-surface-through-the-channel-port.md
+++ b/docs/adr/0100-agents-search-their-own-surface-through-the-channel-port.md
@@ -6,231 +6,108 @@ Status: Draft
 
 ## Context
 
-Claude Code is effective in a repository because the filesystem is a surface
-it can read and search: `Read` and `Grep` are cheap, bounded, and always
-available. A Curie agent's working surface is the channel it is bound to, and
-today it cannot read that surface at all. The channel port
-([ADR-0020](0020-message-port-rendering-free-channel-interface.md)) is
-write-only: the `SlackSink` protocol
-(`apps/worker/src/curie_worker/slack_sink.py`) exposes post, update, and
-status verbs and nothing else. There is no verb to fetch a message by
-permalink, read a window of history, or search the channel. An agent asked
-"what did we decide about this in March" has only its own memory document and
-whatever the current thread contains.
+An agent needs to recover decisions and context from the place where it works.
+For a channel bound agent, that place is its installed surface and its current
+channel. It is not the workspace, another channel, or a general company search
+surface.
 
-This capability is independent of memory. ADR-0095 (Draft, in review) names a
-bounded escape valve into raw history as one consumer, but the primary
-consumer is the live turn: agentic search over the bound surface as part of
-the normal skill, the way Claude Code greps a repo mid-task.
+Today that readable surface is undefined. The channel port in
+[ADR 0020](0020-message-port-rendering-free-channel-interface.md) sends
+messages, but an agent cannot read a known message, a thread, or a bounded
+history window. That leaves a live turn unable to answer a question such as
+what the channel decided earlier without depending on its current context or
+an independently maintained memory file.
 
-The permission argument is what makes a bounded version safe: anyone who can
-invoke the agent in a channel can already read that channel, so the agent
-reading the same history back adds no access. Crossing the channel boundary
-is what would add access, so the channel boundary is the security line, and
-it must be the platform's line, because (researched 2026-08) Slack does not
-draw it: Slack's search APIs are workspace-wide by default,
-`search:read.public` explicitly does not require channel membership, and the
-Real-time Search API's `context_channel_id` is a scoping hint, not a
-boundary. No surveyed system (Slack's own APIs, MCP Slack servers, enterprise
-search vendors) implements a true single-channel search primitive; the only
-hard fence found in the ecosystem is a config-level channel allowlist with no
-search verb at all.
+[ADR 0095](0095-tiered-memory-lifecycle.md) has a related unresolved
+requirement. Memory must stay scoped to an agent or channel tier and must have
+an escape valve to the fuller source material. That escape valve needs a
+properly bounded readable surface, but surface search is not memory itself.
 
-Two more external facts shape the decision. First, Slack now mandates the
-zero-copy posture Curie already chose in ADR-0095: the API Terms of Service
-ban persistent copies or indexes of other organizations' API data, and the
-Marketplace guidelines say "zero-copy" outright, so federating rather than
-indexing is the platform-required design, with Glean, Onyx, Microsoft 365
-Copilot, and Gemini Enterprise all shipping federated Slack modes. Second,
-the 2024 Slack AI exfiltration is the threat model for any history-reading
-tool: instructions planted as an ordinary message were later retrieved into
-the assistant's context and steered it. Anyone who can post in the channel,
-including anyone who ever could, can plant content the agent will someday
-read.
+The architecture review on 2026 08 17 made the intended boundary explicit:
+an agent may search only the surface and channel where it is installed. The
+outcome of building that capability is not yet known, so this ADR authorizes a
+small experimental spike rather than a production implementation.
 
 ## Decision
 
-**Reading and searching the bound surface's history are channel-port verbs:
-implemented by each adapter, hard-bounded to the bound scope by construction,
-enabled per bundle as an option, budgeted below the model, and never
-persisted by the platform.**
+**The candidate capability is an agent searching its own installed surface and
+current channel. The platform, not a bundle supplied credential or a search
+query, enforces that boundary. We will prove the capability with a bounded MCP
+server spike before deciding its permanent port contract or implementation.**
 
-### The verbs
+### The boundary
 
-Four read verbs join the port contract, siblings of the outbound sink and as
-rendering-free as it is:
+For a channel oriented adapter, the bound surface is the channel identity from
+the agent installation. Every read or search request is constrained to that
+identity before it reaches the adapter. A request cannot select a different
+channel, surface, or workspace.
 
-- `read_window`: a slice of the bound scope's history (time window or
-  cursor, capped count, newest first).
-- `read_thread`: one thread by its surface identity.
-- `resolve_reference`: dereference a surface permalink or message id into
-  the message plus minimal surrounding context. Refuses references outside
-  the bound scope.
-- `search`: keyword or pattern match over the bound scope's history, with
-  window and count caps.
+This is a structural capability boundary. It must not depend on model
+instructions, query filtering, a user supplied channel identifier, or a claim
+that the caller probably has access. A result outside the bound surface is not
+available to the agent.
 
-A surface that cannot implement a verb declares the capability absent, the
-existing `ChannelCapability` pattern. An email adapter later maps the same
-verbs onto a mailbox: a window is a date slice, a thread is a message chain,
-search is a server-side or local match. The verbs are the contract; the
-mechanics are the adapter's.
+The capability is deliberately narrower than enterprise search. It does not
+provide cross channel recall, a workspace corpus, or ambient access to every
+surface reachable by an integration token.
 
-### The Slack adapter
+### The spike
 
-Reads use `conversations.history` and `conversations.replies` under the
-`channels:history` and `groups:history` scopes, the same scopes ADR-0095's
-bootstrap already requires. `search` is implemented adapter-side: paginate
-the bound channel's history and match locally. No Slack search API is
-involved (see alternatives), which is what makes the channel bound
-structural rather than filtered: the adapter can only page channels the bot
-is a member of, and the platform hands it only the bound channel id.
+The spike exposes a minimal MCP server for an installed agent to search and
+read its bound surface. It must establish whether an adapter can provide useful
+bounded reads without widening the boundary or retaining a second copy of
+surface content.
 
-This works at acceptable cost only because of a distribution assumption this
-ADR records as load-bearing: **each agent is its own workspace-internal
-Slack app**, with its own bot user, mention handle, and token. Internal apps
-keep standard rate limits (Tier 3, 50+ requests per minute on
-`conversations.history`). A single Curie-distributed app outside the Slack
-Marketplace would fall under the May 2025 limits, 1 request per minute and
-15 messages per page, and this ADR's cost model collapses. Distribution is
-therefore an architectural commitment, not an onboarding convenience.
+The spike must demonstrate all of the following through its real consumer path:
 
-Because the assumption is load-bearing, the adapter states what it does when
-the assumption is false: it detects the constrained case and refuses the verb,
-declaring the capability absent through the existing `ChannelCapability` path.
-Under the constrained limits a paginated search would not fail. It would return
-whatever it managed to page before the budget ran out, and a partial result
-presented as a search result is worse than a refusal, because the agent cannot
-tell the difference and will answer confidently from a fraction of the history.
-A broken deployment must report a missing capability instead.
+1. A bound agent can find and read relevant content in its own current channel.
+2. The same agent cannot use any request input to read or search another
+   channel or surface.
+3. Retrieved content is returned as data with source provenance, not as
+   trusted instructions to the agent.
+4. The implementation does not persist message bodies, a search index, or
+   embeddings as platform state.
+5. The result and per turn resource bounds are enforced below the model.
 
-### Exposure and enablement
+The spike may determine that the proposed shape is not viable. In that case it
+records the constraint and returns no production interface. It must not quietly
+substitute a broader search capability to make the experiment appear useful.
 
-The verbs surface to the agent as tools in ordinary turns, part of the
-normal skill. Enablement is a bundle option, off by default in v1: the
-author who wants their agent to search its channel declares it, next to
-everything else the bundle declares. Nothing here is memory-specific, and
-ADR-0095's escape valve becomes one caller of `resolve_reference` and `search`
-rather than its own mechanism.
+### Relationship to memory and lifecycle work
 
-### Background turns get the verbs, on a different argument
+The resulting readable surface may become ADR 0095's escape valve. It does not
+make channel history into memory, and it does not decide memory retention,
+compaction, or cross tier promotion.
 
-Background turns (ADR-0099) get the same tools under the same flag. Reading the
-bound surface is much of the point of background work, and the same bundle
-author writes the hook, its standing prompt, and this enablement flag, so the
-platform does not fence one against the other. But the safety case above does
-not extend to them unchanged, and inheriting it silently would be the error.
-
-The permission argument is replaced, not carried over. Invoker visibility
-bounds nothing when there is no invoker. What authorizes a hook turn's read is
-the bundle author's declared standing prompt, deployed and reviewed as part of
-the bundle, running against a channel an operator deliberately bound the agent
-to. That is a real authorization and it is a different one, so it is stated
-here rather than assumed.
-
-The injection mitigation is weaker for these turns, and this ADR records that
-rather than papering it. Provenance framing works partly because a user-started
-turn produces a reply a human reads, so a steered turn has a witness. A hook
-turn has no reply handle, so an unattended turn can read planted history and
-act through its tools with nothing appearing in the channel. That is the 2024
-incident shape with the witness removed, and v1 accepts it: the author who
-enabled both surfaces is the party who chose it, the run record makes the fire
-itself visible, and the classifier screen named below is the hardening lane
-when this stops being acceptable. What v1 does not do is claim the
-invoker-visibility argument covers it.
-
-The agent reaches the verbs through the platform API with the turn's scoped
-state token ([ADR-0033](0033-scoped-sandbox-state-token.md)), the same
-brokered path as memory state. The runner never holds surface credentials;
-the credential-forwarding posture is unchanged.
-
-### Bounds, all enforced below the model
-
-- **Scope**: the bound channel only, structural per the adapter design
-  above.
-- **Refusal is not an oracle**: a reference outside the bound scope and a
-  reference that does not exist return the same result. A distinguishable
-  refusal would confirm the existence of out-of-scope messages to anyone who
-  can get the agent to dereference a guessed permalink, and it is one sentence
-  now against an awkward change later.
-- **Result cap**: default 20 items per call. The ecosystem converges here
-  (Slack's own agent search API caps at 20; comparable federated connectors
-  default to 25).
-- **Window default**: bounded lookback per call unless the agent asks for a
-  specific range, so an unqualified search does not page years of history.
-- **Per-turn budget**: a ceiling on read calls and on total returned tokens
-  per turn, with oversized results truncated. Long-context research is
-  unambiguous that piling marginally-relevant history into context degrades
-  the turn that asked for it; the cap is a quality bound, not just a cost
-  bound.
-- **Provenance framing**: retrieved content enters the model only as tool
-  results labeled as channel history, data rather than instruction. This is
-  the documented mitigation lane for the Slack AI incident class. A
-  classifier screen over retrieved content is named as future hardening,
-  not built in v1.
-
-### Zero-copy
-
-Results are returned to the turn and never written to platform state. The
-platform stores no message bodies, no search indexes, and no embeddings of
-surface content, consistent with ADR-0095's retention posture and with
-Slack's mandated posture for apps. The honest cost, stated plainly: federated
-paging has worse recall than an index, and the vendor that ships both says
-so. Curie accepts that because standing recall is the memory document's job;
-this valve serves point lookups. If recall pressure grows, the answer is
-better memory, never an index.
+Likewise, hooks and memory files may later form a default compaction algorithm.
+That connector deserves its own decision because its authorization and
+unattended execution semantics are different from a live agent turn. This ADR
+does not grant hooks additional read authority.
 
 ## Consequences
 
-- The channel protocol package gains read-side models; a reader protocol
-  lands beside `SlackSink` in the worker; the platform API grows the
-  brokered tool endpoints.
-- The Slack app manifest for an agent adds the two history scopes;
-  operators of existing agents reinstall to grant them, the same consent
-  step ADR-0095's bootstrap already requires.
-- ADR-0095's escape-valve wording ("scoped search, operator opt-in")
-  resolves to this ADR's enablement flag; that Draft gets a one-line
-  deferral here rather than its own search semantics.
-- Cost is O(pages) in the searched window and capped by the budget; a
-  capped search can miss old history, and that miss is accepted rather than
-  worked around with an index.
-- The invoker-visibility argument holds only while the boundary holds:
-  any future cross-channel capability (multi-channel agents, Epic #27)
-  cannot inherit these verbs without a new decision, because reading a
-  channel the invoker cannot read is exactly the escalation this design
-  excludes. It is also scoped to user-started turns, so a path that reaches
-  these verbs with no invoker carries the standing-prompt authorization stated
-  above and not this one.
-- An unattended turn that reads history, acts through tools, and posts nothing
-  is reachable in v1 by enabling one bundle flag on a hook. That is a known and
-  accepted exposure, owned by the author who enabled both, and it is the
-  concrete trigger for promoting the classifier screen out of future hardening.
+1. The product definition is clear before an implementation shape is chosen:
+   agents search their own installed surface, never a larger ambient corpus.
+2. The work remains experimental until the spike demonstrates both useful
+   retrieval and the negative boundary proof.
+3. A production follow up must name the adapter contract, enablement model,
+   result limits, authorization for unattended turns, and durable tests. It
+   must not inherit those details from this Draft.
+4. ADR 0095 remains responsible for deciding how memory is scoped and for
+   incorporating any proven escape valve.
 
 ## Alternatives considered
 
-- **Slack's Real-time Search API** (`assistant.search.context`). Rejected
-  for v1. It is workspace-wide by default and its channel scoping is a
-  hint; using it would move the boundary from structural to filtered. Bot
-  tokens additionally require an `action_token` minted from a live message
-  event, which background turns do not have, and semantic mode is gated to
-  Slack AI plans. Revisit only as an optimization behind the same
-  platform-enforced channel filter.
-- **`search.messages`**. User-token-only, and Slack now explicitly steers
-  apps away from it.
-- **Indexing or embedding channel history.** Rejected in ADR-0095 for
-  retention reasons (a second derived copy with no deletion propagation)
-  and now also contrary to Slack's zero-copy terms for distributed apps.
-- **Workspace-wide search.** Rejected. The invoker-visibility argument does
-  not cover channels the invoker cannot read. The closest comparable
-  product ships workspace search with no operator off-switch and a
-  documentation-only injection warning; that is the cautionary reference,
-  not the model.
-- **A Slack MCP server wired into the bundle instead of a port
-  capability.** Rejected as the path for this capability. An MCP
-  integration authenticates with whatever token its author wires and
-  reaches whatever that token reaches; the platform can neither bound it to
-  the channel nor budget it, and it is Slack-shaped rather than
-  surface-agnostic. Authors remain free to add MCP servers for other
-  reasons; they are not how the agent reads its own surface.
-- **Default-on.** Deferred. The capability is safe under the
-  invoker-visibility argument, but it changes an agent's cost and context
-  profile, so the author opts in per bundle in v1.
+1. **Workspace search.** Rejected. It gives an installed agent access beyond
+   the place where it works and makes the security boundary dependent on search
+   filters or a broad integration credential.
+2. **Cross channel search.** Rejected. This is a different product capability
+   with different authorization and consent requirements.
+3. **Treat memory as the readable surface.** Rejected. Memory is a curated,
+   retained artifact. Search must be able to retrieve source material that was
+   not promoted into memory.
+4. **Commit to channel port verbs now.** Deferred. The spike must first prove
+   the concrete adapter can preserve the boundary and provide useful retrieval.
+5. **Build a persistent search index.** Rejected for the spike. It creates a
+   second retained copy of surface content before the value and deletion model
+   are understood.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -129,6 +129,7 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0097 | [One file declares an installation](0097-one-file-declares-an-installation.md) | Accepted |
 | 0098 | [Thinking depth is an operator knob, never a bundle one](0098-thinking-depth-is-an-operator-knob-never-a-bundle-one.md) | Accepted |
 | 0099 | [Hooks are bundle-declared turns the system starts](0099-hooks-are-bundle-declared-turns-the-system-starts.md) | Draft |
+| 0100 | [Agents search their own surface through the channel port](0100-agents-search-their-own-surface-through-the-channel-port.md) | Draft |
 | 0101 | [Closed schemas version on every change: minor for optional, major for required](0101-schema-compatibility-for-closed-schemas.md) | Accepted |
 | 0102 | [Accepted alongside implementation with explicit approval](0102-accepted-alongside-implementation-with-explicit-approval.md) | Accepted |
 | 0103 | [Previous schema shape gate](0103-previous-schema-shape-gate.md) | Accepted |


### PR DESCRIPTION
Draft ADR defining a narrow experiment: an agent may search only its installed surface and current channel.\n\nThe platform must enforce that boundary. The MCP spike must prove useful retrieval, deny reads outside the bound surface, preserve provenance, retain no copied corpus, and enforce bounds below the model.\n\nMemory and lifecycle compaction remain separate decisions.\n\nCloses #1371