### PR TITLE
Refuse a blank model the way thinking already does, and give the console a clear that works

### DIFF
--- a/apps/api/alembic/versions/0020_blank_overrides_to_null.py
+++ b/apps/api/alembic/versions/0020_blank_overrides_to_null.py
@@ -1,0 +1,74 @@
+"""collapse blank operator overrides to NULL: agents.model, agents.thinking (#1355)
+
+#1334 taught the API to refuse an empty `thinking`, and #1355 extends that to its
+twin `model`. Both fixes guard the WRITE path only, and released images accepted
+a blank on both fields, so rows written before this may already hold `''` (or
+whitespace). Those rows are the defect frozen into data: the validator will never
+see them again, and nothing else repairs them.
+
+A blank override is not a third way to say "no override". `apply_model_env` reads
+each as `override if override is not None else config.<field>`, so `''` is not
+None and wins the ternary, and then `if value:` is falsy and NO boot key is
+emitted -- the agent silently skips the platform default an operator configured
+and takes the model's own built-in instead. On the BYO lane that is worse than
+cosmetic: `CURIE_MODEL_BASE_URL` and `CURIE_MODEL_API_BACKEND` are config-only
+with no override, so they stay set and the SDK dials a custom or OpenRouter
+endpoint asking for a built-in Anthropic model id.
+
+NULL is what those rows meant. This converges them onto the one spelling of "no
+override" the code actually honors, and it is a no-op on any database that never
+took a blank.
+
+Whitespace-only values are collapsed too, by the same predicate the validator
+uses: they are worse than empty, since they survive the falsy check and are
+forwarded as a garbage id.
+
+Revision ID: 0020
+Revises: 0019
+Create Date: 2026-08-06
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0020"
+down_revision: str | None = "0019"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+SCHEMA = "curie"
+
+# The two nullable operator overrides that share `_nullable_override_validator`.
+# Adding a third means adding it here too -- that is the point of naming them in
+# one list rather than writing the statement twice.
+BLANKABLE_OVERRIDES = ("model", "thinking")
+
+
+def upgrade() -> None:
+    for column in BLANKABLE_OVERRIDES:
+        # `~ '^[[:space:]]*$'` is the SQL spelling of the validator's
+        # `not value.strip()`, and the spelling matters: Postgres `TRIM()` strips
+        # SPACES only, so `TRIM(E'\t ') = ''` is false and a tab-indented value
+        # would survive a backfill that claimed to match Python. The POSIX class
+        # covers space, tab, newline, carriage return, form feed and vertical tab,
+        # which is what `str.strip()` removes. Verified on a scratch database
+        # against a seeded `E'\t '` row, which the TRIM spelling did NOT collapse.
+        #
+        # Rows already NULL are untouched, and a real value is only tested, never
+        # rewritten -- an empty match set makes this a no-op.
+        op.execute(
+            f"UPDATE {SCHEMA}.agents SET {column} = NULL "  # noqa: S608 - literal identifiers
+            f"WHERE {column} IS NOT NULL AND {column} ~ '^[[:space:]]*$'"
+        )
+
+
+def downgrade() -> None:
+    # Deliberately a no-op, and this is NOT laziness: the upgrade merges two
+    # states ('' and NULL) into one, so the original cannot be recovered -- there
+    # is no record of which NULLs were blanks. Writing `SET '' WHERE NULL` would
+    # re-break every row that was correctly NULL all along, which is strictly
+    # worse than leaving the repair in place. A downgrade past this revision keeps
+    # the corrected data, which the old code reads as "no override" -- the same
+    # meaning, and the working one.
+    pass

--- a/apps/api/src/curie_api/schemas.py
+++ b/apps/api/src/curie_api/schemas.py
@@ -3,6 +3,7 @@
 import json
 import re
 import uuid
+from collections.abc import Callable
 from datetime import datetime
 from typing import Annotated, Any, Literal
 
@@ -41,32 +42,61 @@ _SLACK_USERGROUP_ID = re.compile(r"^S[A-Z0-9]{7,}$")
 _SLACK_USER_ID = re.compile(r"^[UW][A-Z0-9]{7,}$")
 
 
-def _validate_thinking_override(value: str | None) -> str | None:
-    """Refuse an empty thinking override (#1310).
+def _nullable_override_validator(field: str, examples: str) -> Callable[[str | None], str | None]:
+    """Build the refusal shared by every nullable operator override (#1310, #1355).
 
-    Empty is not a third way to say "no override". It reaches the worker as a
-    falsy value, which emits no boot key at all -- so it selects the MODEL's own
-    default and silently skips the platform default an operator configured, the
-    opposite of what someone typing `""` to clear a value expects. Explicit JSON
-    null is the reset, and the error says so.
+    `model` and `thinking` are the same kind of field consumed the same way, and
+    they must answer an empty string the same way. `apply_model_env` reads each as
+    `override if override is not None else config.<field>`, so `""` is not None and
+    wins the ternary, and then `if value:` is falsy and NO boot key is emitted.
+    An empty override therefore skips the platform default an operator configured
+    and hands the decision to the model's own built-in -- the opposite of what
+    someone typing `""` to clear a value expects. Explicit JSON null is the reset,
+    and the error says so.
 
-    None passes through: on PATCH that is the clear, on create it is "no
-    override". The vocabulary itself (`disabled`/`adaptive`/`enabled:<n>`) is
-    deliberately NOT checked here -- it belongs to the runner
-    (`curie_runner.thinking`), the same division `model` already has, so that
-    swapping the harness is not a schema change.
+    Whitespace is worse than empty and is refused by the same predicate: `"  "`
+    passes the falsy check downstream and is stored AND forwarded as a garbage
+    value.
+
+    #1334 attached this to `thinking` only, and its twin on the adjacent line kept
+    accepting what its sibling refused. One factory, two call sites, so the next
+    nullable override cannot drift either.
+
+    None passes through: on PATCH that is the clear, on create it is "no override".
+    The VOCABULARY of each field is deliberately not checked here -- a model id
+    belongs to whatever harness is configured, and thinking's
+    `disabled`/`adaptive`/`enabled:<n>` belongs to the runner
+    (`curie_runner.thinking`) -- so swapping the harness is not a schema change.
+
+    Args:
+        field: the field name, used to open the error message.
+        examples: a trailing clause naming valid values for this field.
+
+    Returns:
+        A pydantic field validator refusing empty and whitespace-only values.
     """
-    if value is None:
+
+    def _validate(value: str | None) -> str | None:
+        if value is None:
+            return value
+        if not value.strip():
+            raise ValueError(
+                f"{field} must not be empty: an empty value skips the platform "
+                f"default and selects the model's own behavior, which is not what "
+                f"clearing means. Send null to clear the override back to the "
+                f"platform default, or {examples}."
+            )
         return value
-    if not value.strip():
-        raise ValueError(
-            "thinking must not be empty: an empty value skips the platform "
-            "default and selects the model's own behavior, which is not what "
-            "clearing means. Send null to clear the override back to the "
-            "platform default, or a value like 'disabled', 'adaptive' or "
-            "'enabled:2000'."
-        )
-    return value
+
+    return _validate
+
+
+_validate_thinking_override = _nullable_override_validator(
+    "thinking", "a value like 'disabled', 'adaptive' or 'enabled:2000'"
+)
+_validate_model_override = _nullable_override_validator(
+    "model", "a model id like 'claude-sonnet-5' or 'kimi-k2'"
+)
 
 
 def _validate_slack_channel_id(value: str | None) -> str | None:
@@ -380,6 +410,7 @@ class AgentCreate(BaseModel):
     # sandbox by the worker binding. None means no connector secrets.
     secrets: dict[str, str] | None = None
 
+    _check_model = field_validator("model")(_validate_model_override)
     _check_thinking = field_validator("thinking")(_validate_thinking_override)
     _check_slack_channel = field_validator("slack_channel")(_validate_slack_channel_id)
     _check_approval_tools = field_validator("approval_required_tools")(_validate_tool_names)
@@ -425,6 +456,7 @@ class AgentUpdate(BaseModel):
     # agent and a target naming it is rejected as unknown.
     repo_full_name: str | None = None
 
+    _check_model = field_validator("model")(_validate_model_override)
     _check_thinking = field_validator("thinking")(_validate_thinking_override)
     _check_slack_channel = field_validator("slack_channel")(_validate_slack_channel_id)
     _check_approval_tools = field_validator("approval_required_tools")(_validate_tool_names)

--- a/apps/api/tests/test_agent_model_integration.py
+++ b/apps/api/tests/test_agent_model_integration.py
@@ -69,3 +69,78 @@ def test_patch_without_model_leaves_it_unchanged(
     body = resp.json()
     assert body["slack_channel"] == "CMOVED001"
     assert body["model"] == "deepseek-v4"
+
+
+def test_an_empty_model_is_refused_and_the_error_points_at_null(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    # #1355: the twin of the thinking case, on the adjacent line. An empty string
+    # is NOT an alternate reset -- apply_model_env reads
+    # `override if override is not None else config.model`, so "" is not None and
+    # wins the ternary, then `if model:` is falsy and CURIE_MODEL is never
+    # emitted. The SDK then falls back to its own built-in default instead of the
+    # operator's platform model, and on the BYO lane it dials a custom endpoint
+    # asking for a built-in Anthropic model id. Refuse it, and say what to send.
+    agent = _create_agent(client, auth_headers, model="kimi-k2")
+    resp = client.patch(
+        f"/agents/{agent['id']}", json={"model": ""}, headers=auth_headers
+    )
+    assert resp.status_code == 422, resp.text
+    assert "null" in resp.text, f"the error must point at the real reset: {resp.text}"
+
+    # And the refusal left the stored value alone.
+    resp = client.get(f"/agents/{agent['id']}", headers=auth_headers)
+    assert resp.json()["model"] == "kimi-k2"
+
+    # Create is refused identically -- same field, same nonsense, same answer.
+    resp = client.post(
+        "/agents",
+        json={"name": "empty-model", "slack_channel": "CMODEL011", "model": ""},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 422, resp.text
+
+
+def test_a_whitespace_only_model_is_refused_on_both_paths(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    # Whitespace is worse than empty: it passes the falsy check downstream, so it
+    # is stored AND forwarded as a garbage model id the harness cannot resolve.
+    # The same predicate that catches "" has to catch it.
+    resp = client.post(
+        "/agents",
+        json={"name": "ws-model", "slack_channel": "CMODEL012", "model": "   "},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 422, resp.text
+
+    agent = _create_agent(client, auth_headers, model="kimi-k2")
+    resp = client.patch(
+        f"/agents/{agent['id']}", json={"model": "  "}, headers=auth_headers
+    )
+    assert resp.status_code == 422, resp.text
+
+
+def test_model_and_thinking_answer_an_empty_string_identically(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    # The parity assertion itself, not just two tests that happen to agree. #1334
+    # repaired one nullable override and left its twin two lines away accepting
+    # what the first refused; this fails the moment they diverge again.
+    agent = _create_agent(client, auth_headers, model="kimi-k2", thinking="adaptive")
+    for field in ("model", "thinking"):
+        resp = client.patch(
+            f"/agents/{agent['id']}", json={field: ""}, headers=auth_headers
+        )
+        assert resp.status_code == 422, f"{field} must refuse an empty string: {resp.text}"
+        assert "null" in resp.text, f"{field} must point at null: {resp.text}"
+
+    # And both clear to the platform default through the SAME gesture.
+    resp = client.patch(
+        f"/agents/{agent['id']}",
+        json={"model": None, "thinking": None},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["model"] is None
+    assert resp.json()["thinking"] is None

--- a/apps/ui/src/api/client.ts
+++ b/apps/ui/src/api/client.ts
@@ -418,13 +418,20 @@ export async function getConfig(): Promise<AppConfig> {
   return jsonOrThrow<AppConfig>(resp);
 }
 
-// PATCH an agent's mutable fields (currently just its Slack channel). Returns
-// the updated agent. Mirrors createAgent's JSON-body shape; non-2xx throws
-// ApiError. The live worker keeps its channel until the next deploy — this only
-// updates the stored config the next deployment reads.
+// PATCH an agent's mutable fields. Returns the updated agent. Mirrors
+// createAgent's JSON-body shape; non-2xx throws ApiError. The live worker keeps
+// its config until the next deploy; this only updates the stored config the
+// next deployment reads.
+//
+// `model` is a THREE-way field (#1310, #1355): omitted leaves it unchanged,
+// explicit null clears the pin back to the platform default, and a string pins
+// it. `null` has to be in the type or the console cannot express the clear at
+// all: it used to send `""`, which the API now refuses, because an empty
+// override reaches the worker falsy, emits no boot key, and skips the very
+// platform default that clearing is supposed to restore.
 export async function updateAgent(
   agentId: string,
-  patch: { slack_channel?: string; model?: string },
+  patch: { slack_channel?: string; model?: string | null },
 ): Promise<AgentOut> {
   const resp = await fetch(url(`/agents/${agentId}`), {
     method: "PATCH",

--- a/apps/ui/src/views/wired/WiredAgentDetail.test.tsx
+++ b/apps/ui/src/views/wired/WiredAgentDetail.test.tsx
@@ -200,7 +200,12 @@ describe("WiredAgentDetail — model edit (#254)", () => {
     await waitFor(() => expect(getAgents).toHaveBeenCalledTimes(2));
   });
 
-  it("clears the model to the platform default (empty string) on save", async () => {
+  // #1355. Blanking the box is the only clear gesture there is, and it used to
+  // send `""`, which the API now refuses, and which reached the worker falsy
+  // and skipped the platform default this test claims to restore. The assertion
+  // was green through the whole defect because it asserted the bug's behavior,
+  // so pin the wire value, not just "some call happened".
+  it("clears the model to the platform default by sending null on save", async () => {
     const user = userEvent.setup();
     // This agent already has a pinned model, so the field seeds with it.
     vi.mocked(getAgents).mockResolvedValue([{ ...AGENT, model: "kimi-k2" }]);
@@ -211,7 +216,24 @@ describe("WiredAgentDetail — model edit (#254)", () => {
     await user.clear(input);
     await user.click(screen.getByTestId("model-save"));
 
-    await waitFor(() => expect(updateAgent).toHaveBeenCalledWith("a1", { model: "" }));
+    await waitFor(() => expect(updateAgent).toHaveBeenCalledWith("a1", { model: null }));
+  });
+
+  // Whitespace is the same gesture typed differently, and it is worse than empty:
+  // it survives the falsy check downstream and is stored AND forwarded as a
+  // garbage model id. It must reach the wire as the same null, not as "  ".
+  it("treats a whitespace-only box as the same clear", async () => {
+    const user = userEvent.setup();
+    vi.mocked(getAgents).mockResolvedValue([{ ...AGENT, model: "kimi-k2" }]);
+    renderDetail();
+
+    const input = await screen.findByTestId("model-input");
+    await waitFor(() => expect(input).toHaveValue("kimi-k2"));
+    await user.clear(input);
+    await user.type(input, "   ");
+    await user.click(screen.getByTestId("model-save"));
+
+    await waitFor(() => expect(updateAgent).toHaveBeenCalledWith("a1", { model: null }));
   });
 });
 

--- a/apps/ui/src/views/wired/WiredAgentDetail.tsx
+++ b/apps/ui/src/views/wired/WiredAgentDetail.tsx
@@ -170,14 +170,18 @@ export function WiredAgentDetail() {
     setSavingModel(true);
     setModelError(null);
     try {
-      // Trimmed value; empty string clears the pin so the platform default
-      // applies (apply_model_env treats an empty CURIE_MODEL as unset).
-      const next = model.trim();
+      // A blank box is the clear gesture, and the clear is NULL, not "" (#1355).
+      // apply_model_env reads `override if override is not None else config.model`,
+      // so an empty string is not None, wins the ternary, and is then falsy: no
+      // boot key is emitted and the platform default is skipped, which is the
+      // opposite of clearing. Null is the only value that restores it.
+      const trimmed = model.trim();
+      const next = trimmed === "" ? null : trimmed;
       await updateAgent(agent.id, { model: next });
       refetch();
       dispatch({
         type: "toast",
-        message: next === "" ? "Model cleared (platform default)" : `Model set to ${next}`,
+        message: next === null ? "Model cleared (platform default)" : `Model set to ${next}`,
       });
     } catch (e) {
       setModelError(e instanceof ApiError ? e.message : e instanceof Error ? e.message : String(e));


### PR DESCRIPTION
#1334 taught `thinking` to refuse an empty string and attached the validator to that field alone. `model` sits on the adjacent line, is consumed identically, and kept accepting `""` -- and the console produced exactly that value while telling the operator the opposite had happened.

## Why a blank is not a clear

`apply_model_env` reads `override if override is not None else config.model`. `""` is not None, so it wins the ternary; then `if model:` is falsy and `CURIE_MODEL` is never emitted. The SDK falls back to its **own** built-in default rather than the operator's platform model. On the BYO lane it is worse: `CURIE_MODEL_BASE_URL` and `CURIE_MODEL_API_BACKEND` are config-only with no override, so they stay set and the SDK dials a custom or OpenRouter endpoint asking for a built-in Anthropic model id.

Whitespace is worse than empty -- it survives the falsy check and is stored **and forwarded** as a garbage model id.

## Both halves land together

Fixing the API alone would leave an operator blanking the field getting a 422 with still no way to clear, so this is one change:

| | |
|---|---|
| `schemas.py` | `_nullable_override_validator` is now a factory, attached to `model` **and** `thinking` on both `AgentCreate` and `AgentUpdate`. One predicate, so the next nullable override cannot drift the way this one did. |
| `client.ts` | `updateAgent`'s patch type widens to `model?: string \| null`. Without null in the type the console could not express the clear **at all**. |
| `WiredAgentDetail.tsx` | `saveModel` sends `null` for a blank or whitespace-only box, and the toast now describes what actually happened. The old comment stated the mechanism backwards. |
| `WiredAgentDetail.test.tsx` | `:203` asserted `{ model: "" }` and was green through the whole defect. It now pins `null`, plus a sibling case for whitespace. |

A parity test asserts `model` and `thinking` answer an empty string **identically** and clear through the same gesture, so a future divergence fails rather than waiting to be noticed.

## Migration 0020, and the bug it nearly shipped with

The validator guards the write path only, and released images accepted a blank on both fields, so existing rows can hold the defect frozen into data. 0020 collapses them to NULL.

The first draft used `TRIM(col) = ''`, and the docstring claimed it matched the validator's `not value.strip()`. **It does not.** Postgres `TRIM()` strips *spaces only*, so a seeded `E'\t '` row survived a backfill that said it wouldn't -- and my first assertion used `TRIM` too, so it shared the blind spot and reported success. Caught on the scratch database, not in review. The predicate is now `~ '^[[:space:]]*$'`.

Re-verified against seeded `''`, `E'\t '`, `E'\n'` and `E'\r'` rows: all collapse, a pinned `kimi-k2`/`enabled:2000` row is untouched, a row blank in one field keeps its healthy sibling, the migration is idempotent, and `downgrade` → `upgrade` round-trips.

`downgrade` is deliberately a no-op. The upgrade merges `''` and NULL, so the original cannot be recovered -- there is no record of which NULLs were blanks -- and `SET '' WHERE NULL` would re-break every row that was correctly NULL all along.

Developed and verified against a **throwaway Postgres on a separate port** per `apps/api/CLAUDE.md`; the shared compose database is confirmed still on 0019.

## Named rather than silently skipped

Neither field strips a **padded** value (`" qwen3:4b "`), which is stored and forwarded with its padding. That is one defect across *both* fields, not a model-only one, so widening the predicate belongs in its own change -- making `model` stricter than the twin this PR exists to align it with would be the same asymmetry in the other direction.

## Verified

API 620 passed, UI 144 passed (24 files), `ruff check` clean, `mypy` clean, `tsc --noEmit` clean, `eslint --max-warnings 0` clean, OpenAPI drift test green (a `field_validator` does not change the emitted schema).

Closes #1355
