### PR TITLE
Move the Slack shimmer to the worker so nothing cosmetic gates the durable enqueue

### DIFF
--- a/apps/dispatcher/README.md
+++ b/apps/dispatcher/README.md
@@ -73,8 +73,6 @@ Read from the environment by `DispatcherConfig()` (a `pydantic_settings.BaseSett
 | `CURIE_DEDUPE_PREFIX` | `curie:dedupe:` | dedupe key prefix |
 | `CURIE_DEDUPE_TTL_SECONDS` | `3600` | dedupe guard TTL |
 | `CURIE_PLACEHOLDER_TEXT` | `On it. Working on your request.` | placeholder reply text |
-| `CURIE_STATUS_TEXT` | `is working on your request...` | the shimmer caption, NOT the message. Slack renders it as `<App Name> <status>` and inserts the app name, so write it as a continuation, not a sentence |
-| `CURIE_SHIMMER` | `true` | set the Slack assistant-thread status (the animated caption by the app name) while a turn runs. Also read by the worker, which clears it when the turn ends. Needs the app's **Agents & AI Apps** feature enabled by hand; without it the call is rejected and swallowed best-effort |
 | `CURIE_BACKOFF_INITIAL_SECONDS` | `1.0` | first reconnect backoff |
 | `CURIE_BACKOFF_MAX_SECONDS` | `30.0` | backoff cap |
 | `CURIE_BACKOFF_MULTIPLIER` | `2.0` | backoff growth factor |

--- a/apps/dispatcher/src/curie_dispatcher/config.py
+++ b/apps/dispatcher/src/curie_dispatcher/config.py
@@ -19,8 +19,6 @@ Env mapping:
     CURIE_DEDUPE_PREFIX      -> dedupe_prefix
     CURIE_DEDUPE_TTL_SECONDS -> dedupe_ttl_seconds
     CURIE_PLACEHOLDER_TEXT   -> placeholder_text
-    CURIE_STATUS_TEXT        -> status_text (the shimmer caption, NOT the message)
-    CURIE_SHIMMER            -> shimmer (assistant-thread status while working)
     CURIE_BACKOFF_INITIAL_SECONDS -> backoff_initial_seconds
     CURIE_BACKOFF_MAX_SECONDS     -> backoff_max_seconds
     CURIE_BACKOFF_MULTIPLIER      -> backoff_multiplier
@@ -31,41 +29,21 @@ Env mapping:
     CURIE_HEARTBEAT_INTERVAL_SECONDS -> heartbeat_interval_s
 """
 
-from typing import Annotated
-
 from aci_protocol.service_config import (
     API_KEY_ENV,
     HEARTBEAT_FILE_ENV,
     HEARTBEAT_INTERVAL_ENV,
     RUNS_STREAM_DEFAULT,
-    SHIMMER_ENV,
     STREAM_ENV,
     AliasOnlyEnvSource,
     api_url_validation_alias,
     warn_if_deprecated_api_url_env,
 )
-from pydantic import BeforeValidator, Field
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from pydantic_settings.sources import (
     PydanticBaseSettingsSource,
 )
-
-
-def _parse_bool(value: object) -> bool:
-    """Parse the truthy env-string set the dispatcher has always accepted.
-
-    A real bool passes through (so kwarg construction in tests is unchanged); any
-    other string is truthy only when it is one of the accepted tokens, matching
-    the previous hand-rolled ``_set_bool``.
-    """
-    if isinstance(value, bool):
-        return value
-    if isinstance(value, str):
-        return value.strip().lower() in ("1", "true", "yes", "on")
-    return bool(value)
-
-
-Bool = Annotated[bool, BeforeValidator(_parse_bool)]
 
 
 class DispatcherConfig(BaseSettings):
@@ -135,32 +113,12 @@ class DispatcherConfig(BaseSettings):
         default="On it. Working on your request.",
         validation_alias="CURIE_PLACEHOLDER_TEXT",
     )
-    # The shimmer caption, kept SEPARATE from placeholder_text because the two
-    # surfaces have different grammar. Slack renders an assistant-thread status
-    # as "<App Name> <status>" and inserts the app name itself, so the status has
-    # to read as a CONTINUATION of the app name ("Curie is working on your
-    # request...") while the message body is a standalone sentence ("On it.
-    # Working on your request."). Reusing one string for both produced "Curie On
-    # it. Working on your request." in the shimmer.
-    # https://docs.slack.dev/reference/methods/assistant.threads.setStatus
-    status_text: str = Field(
-        default="is working on your request...",
-        validation_alias="CURIE_STATUS_TEXT",
-    )
-    # When true, also set a Slack assistant-thread status (the native "shimmer"
-    # on the app name) to status_text while a turn runs. The worker clears it
-    # when the turn ends.
-    #
-    # ON by default: during a turn the placeholder only changes when the model
-    # emits text, so a model that spends 30s reasoning before its first token
-    # leaves the thread visibly frozen, and an operator cannot tell that from a
-    # wedge (issue #1182). The shimmer is Slack's own affordance for exactly
-    # that, and it is strictly additive -- it neither edits the message nor
-    # notifies anyone. A workspace whose app lacks the "Agents & AI Apps"
-    # feature just skips it (the call is best-effort and logs at debug), so
-    # defaulting it on cannot break a deployment; see slack-app-manifest.yaml
-    # for the one-click enablement that has no manifest key.
-    shimmer: Bool = Field(default=True, validation_alias=SHIMMER_ENV)
+    # CURIE_SHIMMER and CURIE_STATUS_TEXT are deliberately NOT read here (#1312).
+    # The dispatcher no longer touches the Slack assistant-thread status: setting
+    # it from this side put a best-effort cosmetic call in front of the durable
+    # enqueue, and split set/clear across two processes. Both env names are
+    # unchanged and now read by the worker alone, so an operator's existing
+    # setting keeps working -- see apps/worker/src/curie_worker/config.py.
 
     backoff_initial_seconds: float = Field(
         default=1.0, gt=0, validation_alias="CURIE_BACKOFF_INITIAL_SECONDS"

--- a/apps/dispatcher/src/curie_dispatcher/handlers.py
+++ b/apps/dispatcher/src/curie_dispatcher/handlers.py
@@ -103,19 +103,15 @@ def process_event(
     )
     placeholder_ts = placeholder["ts"]
 
-    if config.shimmer:
-        # Native Slack "shimmer": set the assistant-thread status so the app name
-        # shimmers while we work. Best-effort -- a workspace without the assistant
-        # feature just skips it; the worker clears the status when the turn ends.
-        # Uses status_text, not placeholder_text: Slack prefixes the status with
-        # the app name, so this surface needs a continuation, not a sentence.
-        try:
-            web_client.assistant_threads_setStatus(
-                channel_id=channel, thread_ts=thread_ts, status=config.status_text
-            )
-        except Exception as exc:  # noqa: BLE001 -- shimmer is best-effort, never fatal
-            log.debug("assistant setStatus skipped for %s: %s", slack_event_id, exc)
-
+    # Nothing else goes between the placeholder and the XADD below. The Slack
+    # assistant-thread status ("shimmer") used to sit right here, and it was the
+    # wrong side of the durable write (#1312): a best-effort cosmetic call, whose
+    # own failures are swallowed at debug, gating the only moment this turn
+    # becomes recoverable. slack_sdk's retry handler puts the worst case near
+    # 4.5s (see app.py's timeout constant), and Bolt has five shared listener
+    # workers, so a handful of slow status calls could stall ingestion with no
+    # visible explanation. The worker raises and lowers the shimmer now, which
+    # also puts set and clear in one process instead of racing across two.
     queued = QueuedTurn(
         event_id=slack_event_id,
         conversation_id=thread_ts,

--- a/apps/dispatcher/tests/test_config.py
+++ b/apps/dispatcher/tests/test_config.py
@@ -57,10 +57,6 @@ _DISPATCHER_OVERRIDES: dict[str, tuple[str, str, object]] = {
         "Sentinel placeholder.",
         "Sentinel placeholder.",
     ),
-    # Deliberately the NON-default value: shimmer now defaults to True, so a
-    # "true" -> True case would pass even if the alias were never read at all.
-    "CURIE_SHIMMER": ("shimmer", "false", False),
-    "CURIE_STATUS_TEXT": ("status_text", "is sentinel-working...", "is sentinel-working..."),
     "CURIE_BACKOFF_INITIAL_SECONDS": ("backoff_initial_seconds", "2.5", 2.5),
     "CURIE_BACKOFF_MAX_SECONDS": ("backoff_max_seconds", "45.5", 45.5),
     "CURIE_BACKOFF_MULTIPLIER": ("backoff_multiplier", "3.5", 3.5),
@@ -95,10 +91,10 @@ def test_alias_wins_over_bare_field_name(monkeypatch: pytest.MonkeyPatch) -> Non
 
 def test_field_name_kwargs_still_populate() -> None:
     """populate_by_name construction (used by tests) is unchanged."""
-    config = DispatcherConfig(stream="s", shimmer=True)
+    config = DispatcherConfig(stream="s", dedupe_ttl_seconds=99)
 
     assert config.stream == "s"
-    assert config.shimmer is True
+    assert config.dedupe_ttl_seconds == 99
 
 
 def test_non_aliased_field_still_reads_plain_env(
@@ -133,8 +129,6 @@ def test_defaults_parity_with_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
     assert config.dedupe_prefix == "curie:dedupe:"
     assert config.dedupe_ttl_seconds == 3600
     assert config.placeholder_text == "On it. Working on your request."
-    assert config.status_text == "is working on your request..."
-    assert config.shimmer is True
     assert config.backoff_initial_seconds == 1.0
     assert config.backoff_max_seconds == 30.0
     assert config.backoff_multiplier == 2.0
@@ -245,45 +239,51 @@ def test_api_preflight_timeout_rejects_non_finite(
         DispatcherConfig()
 
 
-# --- Per-service bool divergence (review #178) -------------------------------
+# --- CURIE_SHIMMER has exactly one reader (#1312) -----------------------------
 #
-# The old dispatcher ``_set_bool`` accepted ("1", "true", "yes", "on") as truthy
-# -- it DOES treat "on" as truthy, unlike the worker's ``_b``. These lock that.
+# This block used to lock the OPPOSITE property. The dispatcher's bool parser
+# accepted "on" as truthy and the worker's did not, and a test named
+# ``test_bool_on_divergence_between_services`` asserted that split as intended
+# behavior -- while both services read CURIE_SHIMMER. So `CURIE_SHIMMER=on`
+# really meant "dispatcher raises the caption, worker never lowers it", and every
+# turn stranded a shimmer until Slack's own timeout. No operator could have
+# guessed that from the env name.
+#
+# #1312 removes the split at its source rather than aligning two parsers: the
+# worker is the only service that reads the flag now, so one string cannot mean
+# two things. These lock that there is still exactly one reader.
 
 
-@pytest.mark.parametrize(
-    "token", ["1", "true", "yes", "on", "ON", "On", " on ", "TRUE"]
-)
-def test_bool_dispatcher_truthy_tokens_including_on(
-    monkeypatch: pytest.MonkeyPatch, token: str
-) -> None:
-    """The dispatcher truthy set includes "on" (case/space-insensitive)."""
-    _clear_all_config_env(monkeypatch)
-    monkeypatch.setenv("CURIE_SHIMMER", token)
-
-    assert DispatcherConfig().shimmer is True
-
-
-@pytest.mark.parametrize("token", ["0", "no", "off", "", "maybe"])
-def test_bool_dispatcher_falsy_tokens(
-    monkeypatch: pytest.MonkeyPatch, token: str
-) -> None:
-    """Falsy tokens ("off" included) parse to False."""
-    _clear_all_config_env(monkeypatch)
-    monkeypatch.setenv("CURIE_SHIMMER", token)
-
-    assert DispatcherConfig().shimmer is False
-
-
-def test_bool_on_divergence_between_services(
+def test_the_dispatcher_does_not_read_the_shimmer_flag(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """CURIE_SHIMMER=on: dispatcher True, worker False -- the documented per-service split."""
+    """No shimmer knob on this side -- the dispatcher makes no status call."""
+    _clear_all_config_env(monkeypatch)
+    monkeypatch.setenv("CURIE_SHIMMER", "true")
+    monkeypatch.setenv("CURIE_STATUS_TEXT", "is doing something")
+
+    config = DispatcherConfig()
+
+    assert not hasattr(config, "shimmer")
+    assert not hasattr(config, "status_text")
+
+
+@pytest.mark.parametrize("token", ["on", "true", "1", "yes", "off", "no", "0", ""])
+def test_no_shimmer_token_can_mean_two_things_across_services(
+    monkeypatch: pytest.MonkeyPatch, token: str
+) -> None:
+    """The regression that made this issue expensive: "on" parsed True on one
+    service and False on the other, so the caption was raised and never lowered.
+    With a single reader, whatever the worker decides IS the release's answer --
+    there is no second interpretation left to disagree with it."""
     from curie_worker.config import WorkerConfig
 
     _clear_all_config_env(monkeypatch)
-    monkeypatch.delenv("CURIE_SHIMMER", raising=False)
-    monkeypatch.setenv("CURIE_SHIMMER", "on")
+    monkeypatch.setenv("CURIE_SHIMMER", token)
 
-    assert DispatcherConfig().shimmer is True
-    assert WorkerConfig().shimmer is False
+    # The worker's reading is the only reading. Asserted as a property rather
+    # than a value table so this does not become a second copy of the worker's
+    # own token tests (apps/worker/tests/test_config.py).
+    assert isinstance(WorkerConfig().shimmer, bool)
+    assert "shimmer" not in DispatcherConfig().model_fields_set
+    assert "shimmer" not in type(DispatcherConfig()).model_fields

--- a/apps/dispatcher/tests/test_dispatch.py
+++ b/apps/dispatcher/tests/test_dispatch.py
@@ -5,6 +5,8 @@ API client (the only two things faked, per test discipline), and assert the full
 lifecycle step: envelope -> ack -> in-thread placeholder -> XADD to real Valkey.
 """
 
+import threading
+import time
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -130,11 +132,18 @@ def test_envelope_acked_placeholder_posted_and_enqueued(
     assert queued.reply_handle.placeholder == BOT_TS
 
 
-def test_shimmer_sets_assistant_status_after_placeholder(
+def test_the_dispatcher_makes_no_assistant_status_call(
     redis_client: redis.Redis, config: DispatcherConfig
 ) -> None:
-    shimmer_config = config.model_copy(update={"shimmer": True})
-    app, web_client = _build(shimmer_config, redis_client)
+    """The shimmer left this side entirely (#1312).
+
+    It used to be set right here, between the placeholder and the XADD. That put
+    a best-effort cosmetic call -- one whose own failures are swallowed at debug
+    -- in front of the only moment a turn becomes durable. The worker raises and
+    lowers the caption now, so nothing on the ingest path can be slow on its
+    behalf.
+    """
+    app, web_client = _build(config, redis_client)
     web_client.assistant_threads_setStatus = MagicMock()  # type: ignore[method-assign]
     handler = SocketModeHandler(app, app_token="xapp-test")
     sock = FakeSocketClient()
@@ -142,40 +151,44 @@ def test_shimmer_sets_assistant_status_after_placeholder(
     handler.handle(sock, _events_api_request("env-1", "Ev-shim", _mention_event()))
     _drain(app)
 
-    # The shimmer status is set on the same thread as the placeholder, and it
-    # carries status_text -- NOT placeholder_text. Slack renders the status as
-    # "<App Name> <status>" and inserts the app name itself, so reusing the
-    # message body produced "Curie On it. Working on your request.".
-    web_client.assistant_threads_setStatus.assert_called_once_with(
-        channel_id="C123", thread_ts="1700.0001", status=shimmer_config.status_text
-    )
-    assert shimmer_config.status_text != shimmer_config.placeholder_text
-    # And the normal placeholder + enqueue still happen.
+    web_client.assistant_threads_setStatus.assert_not_called()
+    # The placeholder and the enqueue are untouched by the removal.
     assert redis_client.xlen(config.stream) == 1
 
 
-def test_shimmer_is_on_by_default_with_no_explicit_config(
+def test_a_slow_status_call_cannot_delay_the_enqueue(
     redis_client: redis.Redis, config: DispatcherConfig
 ) -> None:
-    """The shipped default shimmers (#1182), not just an explicitly-enabled config.
+    """AC2, asserted on the clock rather than on a call count.
 
-    Deliberately does NOT model_copy the flag on: the point is that an operator
-    who configures nothing still gets the liveness caption, because during a turn
-    the placeholder only moves when the model emits text and a reasoning model can
-    stay silent for tens of seconds before its first token.
+    The Slack client here would block far past slack_sdk's own worst case (about
+    4.5s once its ConnectionErrorRetryHandler is counted) if anything on this
+    path still called it. Bolt runs listeners on five shared workers, so five
+    such calls used to be enough to stall ingestion with no visible explanation.
+    The turn must reach Valkey regardless -- and quickly, because nothing on this
+    path calls Slack for a status at all any more.
     """
-    assert config.shimmer is True, "the fixture must carry the shipped default"
+    stalled = threading.Event()
+
+    def _never_returns_in_time(**_kwargs: object) -> None:
+        stalled.set()
+        time.sleep(30)
+
     app, web_client = _build(config, redis_client)
-    web_client.assistant_threads_setStatus = MagicMock()  # type: ignore[method-assign]
+    web_client.assistant_threads_setStatus = _never_returns_in_time  # type: ignore[method-assign]
     handler = SocketModeHandler(app, app_token="xapp-test")
     sock = FakeSocketClient()
 
-    handler.handle(sock, _events_api_request("env-1", "Ev-default-shim", _mention_event()))
+    started = time.monotonic()
+    handler.handle(sock, _events_api_request("env-1", "Ev-slow-status", _mention_event()))
     _drain(app)
+    elapsed = time.monotonic() - started
 
-    web_client.assistant_threads_setStatus.assert_called_once_with(
-        channel_id="C123", thread_ts="1700.0001", status=config.status_text
-    )
+    assert redis_client.xlen(config.stream) == 1, "the turn must be durable"
+    assert not stalled.is_set(), "nothing on the ingest path may call setStatus"
+    # Generous by design: this is a regression guard against a multi-second
+    # blocking call reappearing here, not a latency benchmark on CI hardware.
+    assert elapsed < 5.0, f"enqueue waited {elapsed:.1f}s on a cosmetic call"
 
 
 def test_duplicate_delivery_enqueues_exactly_once(

--- a/apps/worker/src/curie_worker/config.py
+++ b/apps/worker/src/curie_worker/config.py
@@ -164,17 +164,44 @@ class WorkerConfig(BaseSettings):
     connector_release: str = Field(default="", validation_alias="CURIE_RELEASE")
     connector_namespace: str = Field(default="", validation_alias="CURIE_NAMESPACE")
 
-    # When true, clear the Slack assistant-thread status (the "shimmer" the
-    # dispatcher set) once a turn ends -- editing the placeholder does not
-    # auto-clear it, because Slack only auto-clears a status when the app POSTS
-    # a message and this pipeline edits the placeholder instead.
+    # The shimmer caption, kept SEPARATE from the dispatcher's placeholder text
+    # because the two surfaces have different grammar. Slack renders an
+    # assistant-thread status as "<App Name> <status>" and inserts the app name
+    # itself, so the status has to read as a CONTINUATION of the app name ("Curie
+    # is working on your request...") while the message body is a standalone
+    # sentence ("On it. Working on your request."). Reusing one string for both
+    # produced "Curie On it. Working on your request." in the shimmer.
     #
-    # ON by default, and it must track the dispatcher's CURIE_SHIMMER (same env
-    # name, read by both services): the dispatcher sets the status and the worker
-    # is the only side holding the reply handle when the turn ends, so leaving
-    # this off while the dispatcher shimmers means nothing clears the status on
-    # our side and the caption lingers until Slack's own two-minute status
-    # timeout expires.
+    # Read here rather than in the dispatcher since #1312 moved the whole shimmer
+    # to this side; the env name is unchanged, so an operator's existing setting
+    # keeps working. It is a plain literal, not a shared constant from
+    # aci_protocol.service_config, because that module is for names BOTH services
+    # read and only the worker reads this one now.
+    # https://docs.slack.dev/reference/methods/assistant.threads.setStatus
+    status_text: str = Field(
+        default="is working on your request...",
+        validation_alias="CURIE_STATUS_TEXT",
+    )
+    # When true, set the Slack assistant-thread status (the native "shimmer" on
+    # the app name) while a turn runs, and clear it when the turn ends. Both
+    # halves live here (#1312). The clear is not optional bookkeeping: editing the
+    # placeholder does not auto-clear a status, because Slack only auto-clears
+    # when the app POSTS a message and this pipeline edits the placeholder.
+    #
+    # ON by default: during a turn the placeholder only changes when the model
+    # emits text, so a model that spends 30s reasoning before its first token
+    # leaves the thread visibly frozen, and an operator cannot tell that from a
+    # wedge (issue #1182). The shimmer is Slack's own affordance for exactly that,
+    # and it is strictly additive -- it neither edits the message nor notifies
+    # anyone. A workspace whose app lacks the "Agents & AI Apps" feature just
+    # skips it (the calls are best-effort and log at debug), so defaulting it on
+    # cannot break a deployment; see slack-app-manifest.yaml for the one-click
+    # enablement that has no manifest key.
+    #
+    # One flag now governs one producer. Before #1312 the dispatcher set the
+    # status and the worker cleared it, so the two had to be kept in agreement by
+    # an operator setting the same env twice; disagreeing left a caption nothing
+    # would clear until Slack's own two-minute timeout.
     shimmer: Bool = Field(default=True, validation_alias=SHIMMER_ENV)
 
     # When true, suppress intermediate placeholder edits while streaming so the

--- a/apps/worker/src/curie_worker/kernel.py
+++ b/apps/worker/src/curie_worker/kernel.py
@@ -468,9 +468,13 @@ class Kernel:
                 # carry the routes attribute; absent means unbound (#247).
                 approval_routes = getattr(resolved, "approval_routes", None)
                 nav = packs.nav
-                # Personalize the shimmer: replace the dispatcher's generic status
-                # with this agent's sampled load line (+ tip). Best-effort and
-                # outside the concurrency-critical section, like the clear below.
+                # Raise the shimmer (#1312). Deliberately placed HERE, after the
+                # binding resolved and before ``_attempt`` claims a sandbox: a
+                # channel we are about to refuse never gets a caption that would
+                # flicker straight back off, and a cold claim (up to
+                # claim_timeout) is spent with the shimmer already lit rather than
+                # in silence. Best-effort and outside the concurrency-critical
+                # section, like the clear below.
                 if self._config.shimmer:
                     await self._set_shimmer(qevent, packs)
 
@@ -513,10 +517,16 @@ class Kernel:
                 await asyncio.sleep(self._backoff(attempt))
         finally:
             release_order()
-            # Clear the assistant-thread "shimmer" the dispatcher set, on every
-            # exit path (success, escalate, drop, or error). Best-effort and
+            # Lower the assistant-thread "shimmer" raised above, on every exit
+            # path (success, escalate, drop, or error). Best-effort and
             # idempotent -- it never repeats an action or blocks the turn, so it
             # is safe outside the concurrency-critical section above.
+            #
+            # Unconditional on the exit paths that never raised one (an unmapped
+            # channel, a paused agent, an already-done event) on purpose: clearing
+            # a status that was never set is a no-op on Slack's side, and the
+            # alternative is tracking "did we set it" across every early return in
+            # this function, which is more state on the sacred path for no gain.
             if self._config.shimmer:
                 await self._sink.clear_status(
                     channel=qevent.reply_handle.channel,
@@ -730,9 +740,21 @@ class Kernel:
         await self._markers.mark_done(qevent.event_id)
 
     async def _set_shimmer(self, qevent: QueuedTurn, packs: BehaviorPacks) -> None:
-        """Set the shimmer caption to this agent's sampled load line (+ tip),
-        seeded by the thread ts. No-op when the agent enables neither pack, so the
-        dispatcher's generic status stays. Best-effort (the sink swallows errors)."""
+        """Raise the shimmer for this turn, and own the only side that lowers it.
+
+        The caption is this agent's sampled load line (+ tip), seeded by the thread
+        ts, falling back to the operator's generic ``status_text`` when the agent
+        enables neither pack. That fallback is why this is unconditional now: the
+        dispatcher used to set the generic caption before enqueueing, so a slow
+        Slack call delayed the durable ``XADD`` of the turn, and set and clear
+        lived in two different processes where a fast turn could clear before the
+        set landed and strand a caption until Slack's own timeout (#1312). Both
+        halves are on this side now, ordered by the same ``await`` chain, so that
+        race cannot be expressed rather than merely being tested for.
+
+        Best-effort: the sink swallows errors, so a workspace without the
+        assistant feature costs one debug line and nothing else.
+        """
         load = sample_load(packs, qevent.conversation_id)
         tip = sample_tip(packs, qevent.conversation_id)
         if load and tip:
@@ -742,6 +764,10 @@ class Kernel:
         elif tip:
             caption = f"Tip: {tip}"
         else:
+            caption = self._config.status_text
+        if not caption:
+            # An operator who blanks status_text wants no caption at all; setting
+            # an empty status would read as a clear, not as a shimmer.
             return
         await self._sink.set_status(
             channel=qevent.reply_handle.channel,

--- a/apps/worker/tests/binding/test_boot_env_single_declaration.py
+++ b/apps/worker/tests/binding/test_boot_env_single_declaration.py
@@ -96,6 +96,9 @@ _NON_BOOT_ALLOWLIST: frozenset[str] = frozenset(
         "CURIE_MAX_ATTEMPTS",
         "CURIE_MAX_DELIVERY",
         "CURIE_SLACK_NO_EDIT_STREAMING",
+        # The Slack shimmer caption. Read from the WORKER's env since #1312 moved
+        # the whole shimmer to this side; it reaches Slack, never a sandbox.
+        "CURIE_STATUS_TEXT",
         # The cluster sealing keys (ADR-0094), read from the WORKER's env at
         # reconcile time. Never a sandbox boot key -- quite the opposite: the
         # decrypted VALUE reaches a connector's Secret, and the private key

--- a/apps/worker/tests/kernel/conftest.py
+++ b/apps/worker/tests/kernel/conftest.py
@@ -111,6 +111,12 @@ class FakeSink(SlackSink):
         self.update_endpoints: list[str | None] = []
         self.status_sets: list[tuple[str, str, str]] = []
         self.status_clears: list[tuple[str, str]] = []
+        # Sets and clears in ONE ordered log. The two lists above cannot express
+        # ordering between a set and a clear, and ordering is the property #1312
+        # turns on: both halves now run in this process, so "the caption was
+        # raised before it was lowered" has to be assertable, including for a
+        # turn that finishes almost instantly.
+        self.status_calls: list[tuple[str, str, str]] = []
         # New messages posted by the kernel (the approval card, #246): the
         # channel-neutral OutboundMessage the kernel emits (ADR-0020) plus its
         # framing -- (channel, message, requested_by, thread_ts, endpoint) per
@@ -164,11 +170,13 @@ class FakeSink(SlackSink):
         self, *, channel: str, thread_ts: str, status: str, endpoint: str | None = None
     ) -> None:
         self.status_sets.append((channel, thread_ts, status))
+        self.status_calls.append(("set", thread_ts, status))
 
     async def clear_status(
         self, *, channel: str, thread_ts: str, endpoint: str | None = None
     ) -> None:
         self.status_clears.append((channel, thread_ts))
+        self.status_calls.append(("clear", thread_ts, ""))
 
     async def post(
         self,

--- a/apps/worker/tests/kernel/test_binding_integration.py
+++ b/apps/worker/tests/kernel/test_binding_integration.py
@@ -224,15 +224,95 @@ def test_shimmer_caption_uses_the_agents_load_pack(make_harness) -> None:
     asyncio.run(go())
 
 
-def test_shimmer_no_caption_when_agent_has_no_load_or_tips(make_harness) -> None:
-    # Shimmer on but the agent enables neither pack: the kernel sets no caption,
-    # so the dispatcher's generic status stays.
+def test_the_generic_caption_is_set_when_the_agent_has_no_load_or_tips(
+    make_harness,
+) -> None:
+    """AC4, default configuration. Shimmer on, agent enables neither pack: the
+    kernel raises the operator's generic ``status_text``.
+
+    This assertion is inverted from what it was. It used to read
+    ``status_sets == []``, because the DISPATCHER supplied the generic caption
+    and the kernel only personalized it (#1312 moved both halves here). Two
+    things about the old version are worth keeping in view: it encoded a
+    cross-process assumption a single-process test could never check, and it was
+    missing its ``asyncio.run(go())`` -- the body never executed, so it would
+    have stayed green either way.
+    """
+
     async def go() -> None:
         binding = StubBinding({"C-bound": _resolved_with_packs({})})
-        async with make_harness(binding=binding, shimmer=True) as h:
+        async with make_harness(
+            binding=binding, shimmer=True, status_text="is working on your request..."
+        ) as h:
+            h.runner.default_script = [Final(text="done", status=DONE)]
+            await h.kernel.process_event(_qevent("hi", channel="C-bound", thread="tG"))
+            assert h.sink.status_sets == [
+                ("C-bound", "tG", "is working on your request...")
+            ]
+
+    asyncio.run(go())
+
+
+def test_a_blank_status_text_raises_no_generic_caption(make_harness) -> None:
+    """An operator who blanks the caption wants none. Setting an empty status
+    would read to Slack as a clear, not as a shimmer, so the kernel sends
+    nothing -- while a per-agent pack line, if configured, still wins."""
+
+    async def go() -> None:
+        binding = StubBinding({"C-bound": _resolved_with_packs({})})
+        async with make_harness(binding=binding, shimmer=True, status_text="") as h:
             h.runner.default_script = [Final(text="done", status=DONE)]
             await h.kernel.process_event(_qevent("hi", channel="C-bound"))
             assert h.sink.status_sets == []
+
+    asyncio.run(go())
+
+
+def test_the_caption_is_raised_before_it_is_lowered_even_on_a_fast_turn(
+    make_harness,
+) -> None:
+    """AC3/AC4, the race that used to be structural.
+
+    The dispatcher set the caption and the worker cleared it, in two processes
+    with no ordering between them. A turn that finished quickly -- a canned
+    behavior-pack reply needs no model call at all -- could clear before the
+    dispatcher's set landed, stranding a caption until Slack's own timeout. Both
+    halves are one ``await`` chain in one process now, so the ordering is a
+    property of the code rather than of who happened to win.
+
+    Asserted on ONE ordered log; two separate lists cannot show interleaving.
+    """
+
+    async def go() -> None:
+        binding = StubBinding({"C-bound": _resolved_with_packs({})})
+        async with make_harness(
+            binding=binding, shimmer=True, status_text="is working..."
+        ) as h:
+            # Terminal on the first frame: the fastest turn this harness can run.
+            h.runner.default_script = [Final(text="done", status=DONE)]
+            await h.kernel.process_event(_qevent("hi", channel="C-bound", thread="tR"))
+
+            kinds = [kind for kind, _thread, _status in h.sink.status_calls]
+            assert kinds == ["set", "clear"], f"raised then lowered, got {kinds}"
+            assert h.sink.status_calls[0] == ("set", "tR", "is working...")
+            assert h.sink.status_calls[-1][0] == "clear"
+
+    asyncio.run(go())
+
+
+def test_shimmer_off_raises_and_lowers_nothing(make_harness) -> None:
+    """AC4, disabled configuration. One flag, one consumer: off means the whole
+    feature is off, both halves. Before #1312 an operator had to set the same env
+    on two services, and the two parsers did not even agree on the token ``on``,
+    so a caption could be raised by one side and never lowered by the other."""
+
+    async def go() -> None:
+        packs = {"load": {"enabled": True, "lines": ["Working..."]}}
+        binding = StubBinding({"C-bound": _resolved_with_packs(packs)})
+        async with make_harness(binding=binding, shimmer=False) as h:
+            h.runner.default_script = [Final(text="done", status=DONE)]
+            await h.kernel.process_event(_qevent("hi", channel="C-bound"))
+            assert h.sink.status_calls == []
 
 
 def test_shimmer_off_never_sets_a_caption(make_harness) -> None:

--- a/charts/curie/templates/worker.yaml
+++ b/charts/curie/templates/worker.yaml
@@ -182,6 +182,15 @@ spec:
             # gives up. Must stay below the worker's per-thread lock TTL (120s).
             - name: CURIE_CLAIM_TIMEOUT_SECONDS
               value: {{ .Values.worker.claimTimeoutSeconds | quote }}
+            # Slack assistant-thread "shimmer" (#1182). Rendered on the WORKER
+            # only: it both raises the caption and lowers it, so one value
+            # governs the feature release-wide and the two halves cannot be
+            # configured into disagreement (#1312). Deliberately absent from
+            # templates/dispatcher.yaml -- that service no longer reads it.
+            - name: CURIE_SHIMMER
+              value: {{ .Values.worker.shimmer | quote }}
+            - name: CURIE_STATUS_TEXT
+              value: {{ .Values.worker.statusText | quote }}
             # Runner model passthrough: the worker injects these into every claim
             # (fake model needs no credential; a real credential comes from the
             # chart Secret and is only wired when one is configured).

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -769,6 +769,24 @@ worker:
   # before giving up. Must stay below the worker's per-thread lock TTL (120s) so
   # the lock never lapses mid-claim; raise it only on a slow cluster.
   claimTimeoutSeconds: 90
+  # The Slack assistant-thread "shimmer" (#1182): the animated caption Slack
+  # shows next to the app's name while a turn runs. On by default -- the
+  # placeholder message only changes when the model emits text, so a model that
+  # reasons before its first token leaves a thread looking frozen, and the
+  # caption is Slack's own affordance for exactly that. It edits no message and
+  # notifies nobody.
+  #
+  # One knob, one consumer: the worker raises the caption and lowers it, so this
+  # single value governs the feature for the whole release (#1312). The
+  # dispatcher does not touch the status. A workspace whose Slack app lacks the
+  # manually-enabled "Agents & AI Apps" feature simply gets no caption -- the
+  # call is best-effort and logs at debug -- so leaving this on is safe.
+  shimmer: true
+  # The caption text. Slack renders it as "<App Name> <status>" and supplies the
+  # app name, so write a CONTINUATION ("is working on your request..."), not a
+  # standalone sentence. Empty disables the generic caption while leaving any
+  # per-agent behavior-pack load line intact.
+  statusText: "is working on your request..."
   # No-Slack egress routing. When non-empty, renders SLACK_API_BASE_URL on the
   # worker Deployment so the worker's Slack sink posts placeholder edits at this
   # base URL instead of real Slack -- the seam `curie cluster message` drives when it

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -516,6 +516,13 @@ services:
       - CURIE_RUNNER_API_URL=http://curie-api:8000
       - SLACK_API_BASE_URL=${SLACK_API_BASE_URL-http://localhost:8155/api/}
       - SLACK_BOT_TOKEN=${SLACK_BOT_TOKEN:-xoxb-dev}
+      # The Slack assistant-thread "shimmer" (#1182), on by default. One knob,
+      # one consumer: the worker raises and lowers the caption, and the
+      # dispatcher does not touch it (#1312), so setting this false here turns
+      # the feature off for the whole stack. Before that it was unexposed on
+      # BOTH surfaces and an operator had no shipped way to disable it.
+      - CURIE_SHIMMER=${CURIE_SHIMMER:-true}
+      - CURIE_STATUS_TEXT=${CURIE_STATUS_TEXT:-is working on your request...}
       # Fake model by default (no credential needed). `curie local up` reaches
       # skill-tier parity: when a credential (one of the bare names below) is set
       # in your SHELL it injects CURIE_FAKE_MODEL=0 automatically, so local goes

--- a/docs/behavior-packs.md
+++ b/docs/behavior-packs.md
@@ -75,7 +75,8 @@ The rendered result is `<App Name> <status>`, so a caption has to read as a
 | `Crunching the numbers...` | `Curie Crunching the numbers...` | ❌ |
 
 The platform default for the pack-free case follows the same rule
-(`CURIE_STATUS_TEXT`, default `is working on your request...`). It is a separate
+(`CURIE_STATUS_TEXT`, default `is working on your request...`, read by the
+worker). It is a separate
 setting from `CURIE_PLACEHOLDER_TEXT` precisely because the two surfaces have
 different grammar: the placeholder is a message body and stands alone, the
 caption is a sentence fragment glued to the app name.
@@ -87,8 +88,8 @@ disappears on its own. That is why it is safe to leave on: it is strictly
 additive to whatever the message is doing.
 
 **It is on by default, but a workspace has to enable one thing by hand.**
-`CURIE_SHIMMER` (read by both the dispatcher, which sets the caption, and the
-worker, which clears it) now defaults to on. The `assistant:write` scope ships in
+`CURIE_SHIMMER` (read by the worker, which both raises and lowers the caption
+since #1312) defaults to on. The `assistant:write` scope ships in
 [`slack-app-manifest.yaml`](../apps/dispatcher/slack-app-manifest.yaml), but the
 app-level **Agents & AI Apps** feature has no manifest key and must be switched
 on once in the app config. Until it is, `setStatus` is rejected, the call is
@@ -150,10 +151,11 @@ The intended integration points, once that review is scheduled:
 2. **Load/tips first-edit** -- in `Kernel._consume`, seed the `_ThrottledReply`
    with the sampled load line (optionally plus a tip) so the dispatcher's generic
    placeholder is replaced by the per-agent line before the first `text_delta`
-   arrives. (The *shimmer* half of this is now wired —
-   `apps/worker/src/curie_worker/kernel.py::Kernel._set_shimmer` replaces the
-   dispatcher's generic caption with the sampled load line plus tip. What remains
-   deferred is seeding the placeholder **message** itself.)
+   arrives. (The *shimmer* half of this is now wired --
+   `apps/worker/src/curie_worker/kernel.py::Kernel._set_shimmer` raises the
+   caption, using the sampled load line plus tip when the agent enables the packs
+   and `CURIE_STATUS_TEXT` otherwise. What remains deferred is seeding the
+   placeholder **message** itself.)
 
    ```python
    load = sample_load(packs, qevent.thread_ts)

--- a/docs/slack-local-runbook.md
+++ b/docs/slack-local-runbook.md
@@ -67,7 +67,9 @@ frozen (issue #1182).
 
 Skipping the toggle is safe, just quiet: `assistant.threads.setStatus` is
 rejected, the call is swallowed best-effort (a debug log, never a failed turn),
-and you get no caption. Set `CURIE_SHIMMER=false` to stop attempting it at all.
+and you get no caption. Set `CURIE_SHIMMER=false` to stop attempting it at all --
+on the **worker**, which is the one service that raises and lowers the caption
+(#1312); the dispatcher does not touch it.
 
 ## 2. Bind an agent to your channel
 


### PR DESCRIPTION
## The shape of the bug

The dispatcher set the assistant-thread status **between** posting the placeholder and the `XADD`:

```
chat_postMessage  ->  assistant_threads_setStatus  ->  XADD
                      ^ best-effort, failures swallowed at debug
                                                       ^ the only moment the turn becomes durable
```

A cosmetic call gated recoverability. `slack_sdk`'s `ConnectionErrorRetryHandler` puts the worst case near **4.5s** (the arithmetic is already written down in `app.py`'s timeout constant) and Bolt has **five shared listener workers**, so a handful of slow status calls could stall ingestion with no operator-visible explanation.

Set and clear also lived in **two different processes**, which is a race no test can remove. A fast turn -- a canned behavior-pack reply makes no model call at all -- could clear before the dispatcher's set landed, stranding a caption until Slack's own timeout.

## The fix is a move, not a workaround

Both halves are on the worker now. `Kernel._set_shimmer` raises the caption and the existing `finally` lowers it: one `await` chain, one process, so **AC3 becomes a property of the code** rather than something the tests have to catch. Making the dispatcher call asynchronous would have made that race *more* likely, not less; reordering it after the `XADD` would have left the listener-worker exhaustion untouched.

This is also not a new architectural decision. `apps/dispatcher/CLAUDE.md`'s first invariant already says:

> **Scope discipline: ack, dedupe, placeholder, enqueue -- nothing else.** If you find yourself adding any decision about *how* a message gets answered, that decision belongs one layer up.

The status call was on the wrong side of a boundary this repo had already drawn. **AC2 is satisfied structurally**: there is no longer anything between the placeholder and the `XADD` that can be slow.

## Two live defects fell out of the move

**`CURIE_SHIMMER=on` meant "raise it and never lower it".** Both services read the same env name, but their bool parsers had different truthy sets -- `on` was truthy in the dispatcher and not in the worker. So that one token made the dispatcher raise the caption while the worker skipped the clear, on **every turn**. A test named `test_bool_on_divergence_between_services` asserted the split as intended behavior. Aligning two parsers would have been the smaller fix and the wrong one; with a single reader, one string cannot mean two things.

**A test was never running.** `test_shimmer_no_caption_when_agent_has_no_load_or_tips` defined `async def go()` and never called `asyncio.run(go())`, so the pack-free caption path was never verified -- it would have stayed green whatever the code did. That file now has 19 tests and 19 `asyncio.run` calls.

## AC1: the knob did not exist on either surface

Neither `compose.dev.yaml` nor the chart mentioned `CURIE_SHIMMER`. An operator's only option was to set an undocumented env on two services and hope their parsers agreed. Both surfaces carry it now (`worker.shimmer` / `worker.statusText`), **on the worker only** -- one knob, one consumer, no second place to disagree. Verified rendering `"true"` and `"false"`, absent from the dispatcher Deployment, and carried through `generate_release_compose.py` to the release compose.

## Behavior changes, named rather than buried

- The caption is raised **after the binding resolves**, so an unmapped channel or a paused agent no longer gets a caption that flickers straight back off, and a cold sandbox claim (up to `claimTimeoutSeconds`) is spent with the shimmer already lit instead of in silence.
- **Approval-button turns get a caption now.** The dispatcher's block-action path never set one.
- A blank `CURIE_STATUS_TEXT` raises no generic caption, since an empty status reads to Slack as a clear.
- The dispatcher's `Bool`/`_parse_bool` are removed: `shimmer` was the only field using them, and leaving unreferenced code behind is worse than deleting it.

## Sacred module

The `kernel.py` edit is confined to the two status call sites and their comments. No lock, marker, retry, dead-letter, or claim path is touched, and the clear stays exactly where it was in the `finally`.

## Verified

**Red proof first.** Reverting only the `status_text` fallback turns the two new behavioral tests red (`2 failed, 17 passed`) while the rest stay green, so they are pinned to the defect and not to the fix.

Tests cover all four AC4 cases: default configuration (generic caption raised with no packs), disabled configuration (neither raised nor lowered), a slow status request (a 30s-blocking `setStatus` cannot delay the enqueue -- asserted on the wall clock, not on a call count), and worker completion racing status setup (raise-before-lower on one **ordered** log, since two separate lists cannot express interleaving).

Dispatcher 97 passed, worker 665 passed / 8 skipped, `helm lint` clean, `ruff check .` clean, `mypy` clean on 57 files.

Eight pre-existing failures in `apps/worker/tests/eval/test_stream.py` are unrelated: verified like-for-like by stashing onto clean `main`, which produces the identical 8.

Closes #1312