### PR TITLE
Give the model and thinking overrides a CLI verb instead of a raw PATCH

### DIFF
--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -1544,6 +1544,94 @@ export const commandManifest = {
           "name": "observability"
         },
         {
+          "about": "Read or change an agent's model and thinking overrides (`PATCH /agents/{id}`)",
+          "args": [
+            {
+              "global": false,
+              "help": "Agent name or id",
+              "id": "agent",
+              "positional": true,
+              "required": true
+            },
+            {
+              "global": false,
+              "help": "Pin this model for the agent (forwarded as CURIE_MODEL at boot)",
+              "id": "model",
+              "long": "model",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Clear the model override back to the platform default",
+              "id": "clear_model",
+              "long": "clear-model",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Pin this thinking depth (e.g. `disabled`, `adaptive`, `enabled:2000`)",
+              "id": "thinking",
+              "long": "thinking",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Clear the thinking override back to the platform default",
+              "id": "clear_thinking",
+              "long": "clear-thinking",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "default_values": [
+                "http://localhost:28000"
+              ],
+              "env": "CURIE_API_URL",
+              "global": false,
+              "id": "api_url",
+              "long": "api-url",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "curie-dev-key"
+              ],
+              "env": "CURIE_API_KEY",
+              "global": false,
+              "id": "api_key",
+              "long": "api-key",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "id": "dry_run",
+              "long": "dry-run",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "long_about": "Read or change an agent's model and thinking overrides (`PATCH /agents/{id}`).\n\nWith no flags this inspects. Both fields are nullable operator overrides of a platform default, so clearing is `--clear-<field>` (which sends JSON null) and never an empty value, which would skip the platform default rather than restore it.",
+          "name": "overrides"
+        },
+        {
           "about": "Set an agent's daily budget (`PUT /agents/{id}/budget`)",
           "args": [
             {
@@ -2953,6 +3041,113 @@ export const commandManifest = {
           ],
           "hidden": false,
           "name": "resume"
+        },
+        {
+          "about": "Read or change an agent's model and thinking overrides (`PATCH /agents/{id}`)",
+          "args": [
+            {
+              "global": false,
+              "help": "Agent name or id",
+              "id": "agent",
+              "positional": true,
+              "required": true
+            },
+            {
+              "global": false,
+              "help": "Pin this model for the agent (forwarded as CURIE_MODEL at boot)",
+              "id": "model",
+              "long": "model",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Clear the model override back to the platform default",
+              "id": "clear_model",
+              "long": "clear-model",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Pin this thinking depth (e.g. `disabled`, `adaptive`, `enabled:2000`)",
+              "id": "thinking",
+              "long": "thinking",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Clear the thinking override back to the platform default",
+              "id": "clear_thinking",
+              "long": "clear-thinking",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "env": "CURIE_API_URL",
+              "global": false,
+              "help": "Platform API base URL. Omit to discover the release's UI `/api` proxy",
+              "id": "api_url",
+              "long": "api-url",
+              "positional": false,
+              "required": false
+            },
+            {
+              "env": "CURIE_API_KEY",
+              "global": false,
+              "help": "Platform API key. Omit to read the release's `api.apiKey` from its Secret",
+              "id": "api_key",
+              "long": "api-key",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "curie"
+              ],
+              "global": false,
+              "help": "Kubernetes namespace of the release. Default: curie",
+              "id": "namespace",
+              "long": "namespace",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "curie"
+              ],
+              "global": false,
+              "help": "Helm release name. Default: curie",
+              "id": "release",
+              "long": "release",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Print what would be done and exit without making a request",
+              "id": "dry_run",
+              "long": "dry-run",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "long_about": "Read or change an agent's model and thinking overrides (`PATCH /agents/{id}`).\n\nWith no flags this inspects. Both fields are nullable operator overrides of a platform default, so clearing is `--clear-<field>` (which sends JSON null) and never an empty value, which would skip the platform default rather than restore it.",
+          "name": "overrides"
         },
         {
           "about": "Set an agent's budget via the platform API (`PUT /agents/{id}/budget`)",

--- a/cli/README.md
+++ b/cli/README.md
@@ -92,7 +92,7 @@ as a structured variant.
 **`--json`** (global) makes every agent-facing verb emit a single
 machine-readable JSON object on **stdout**: the read/query verbs
 (`versions`, `memory`, `approvals`, `observability`), the lifecycle result
-verbs (`kill`, `resume`, `budget`, `reset-thread`, `delete`), and every
+verbs (`kill`, `resume`, `budget`, `overrides`, `reset-thread`, `delete`), and every
 verb's `--dry-run` plan (uniform shape `{"dry_run": true, "plan":
 [<lines>]}`).
 
@@ -236,7 +236,7 @@ disk and targets no environment.
 |---|---|---|---|---|---|
 | `skill` | Just the runner container on the host Docker daemon. No platform, no queue, no API, no Slack. Fully offline. | none | none | `up` `check` `down` `status` `message` `eval` | Iterate a plugin/skill against a local runner, the fastest loop. |
 | `local` | The full platform via docker compose (Postgres + Valkey + Langfuse + API + worker). | stub by default, optional real Slack with `--slack` | none | `up` `down` `status` `comms` `message` `eval` `deploy` `reset-thread` | Exercise the real queue -> worker -> sandbox -> reply product loop with zero Slack and zero Kubernetes. Its API is published on host port `28000`. |
-| `cluster` | The platform on Kubernetes (a Helm release). | optional | yes | `up` `down` `status` `comms` `message` `eval` `deploy` `kill` `resume` `budget` `reset-thread` `delete` | Operate and drive a deployed cluster release, and control its agents' lifecycle. |
+| `cluster` | The platform on Kubernetes (a Helm release). | optional | yes | `up` `down` `status` `comms` `message` `eval` `deploy` `kill` `resume` `budget` `overrides` `reset-thread` `delete` | Operate and drive a deployed cluster release, and control its agents' lifecycle. |
 
 `eval` is on all three, running the SAME `evals/cases.json` with the SAME
 grader at each tier: a text-matcher case (`exact`/`contains`/`regex`) that
@@ -363,10 +363,12 @@ Wraps the umbrella Helm chart and the deployed release, the way `linkerd` or
 | `curie cluster kill <agent> --yes` | Kill an agent (stop its runs) via the platform API (`POST /agents/{id}/kill`). Destructive: refuses without `--yes`. |
 | `curie cluster resume <agent>` | Resume a killed agent via the platform API (`POST /agents/{id}/resume`). |
 | `curie cluster budget <agent> --limit <n>` | Set the agent's daily spend cap in USD via the platform API (`PUT /agents/{id}/budget`, `BudgetConfig.max_usd_per_day`); the per-run token cap is left at the platform default. |
+| `curie cluster overrides <agent> [--model V\|--clear-model] [--thinking V\|--clear-thinking]` | Read or change the agent's two nullable operator overrides via the platform API (`PATCH /agents/{id}`).<br>• With no change flags it INSPECTS and writes nothing.<br>• `--clear-<field>` sends explicit JSON null, restoring the platform default; an omitted field is left alone, which is a different request the API tells apart with `model_fields_set`.<br>• A blank value is refused rather than forwarded: an empty override skips the platform default instead of restoring it. |
 | `curie cluster reset-thread <agent> --thread-key <key> --yes` | Force a stuck thread's sandbox to be released via the platform API (`POST /agents/{id}/threads/{thread_key}/reset`, #737).<br>• The worker's next maintenance tick releases the thread's claim and route, so its next message cold-creates a fresh sandbox; conversation history is not deleted.<br>• Interrupts a live turn on the thread first, so it refuses without `--yes`. |
 | `curie cluster delete <agent> --yes` | Delete an agent via the platform API (`DELETE /agents/{id}`). Destructive and irreversible: refuses without `--yes`. |
 
-The five lifecycle verbs (`kill`, `resume`, `budget`, `reset-thread`, `delete`)
+The six lifecycle verbs (`kill`, `resume`, `budget`, `overrides`, `reset-thread`,
+`delete`)
 act on a deployed release's agents through the same platform API, defaulting
 `--api-url` to `http://localhost:8000` (auth via `--api-key` or
 `CURIE_API_KEY`). Unlike `cluster deploy`, which self-plumbs a port-forward

--- a/cli/api-mirrors.json
+++ b/cli/api-mirrors.json
@@ -17,14 +17,6 @@
           "why": "No CLI path reads an agent's behavior-pack list; deploy uploads a bundle rather than composing packs, so behavior_packs is never consumed."
         },
         {
-          "field": "model",
-          "why": "The CLI never displays or acts on an agent's default model (model routing is server- and claim-time bound, #473); the deploy and lifecycle verbs read only id/name/slack_channel."
-        },
-        {
-          "field": "thinking",
-          "why": "Same reason as model directly above, and the same ownership: thinking depth is resolved server-side at claim time into the sandbox boot env (#1182, ADR-0098). No CLI verb displays or acts on it; an operator sets it through the platform API."
-        },
-        {
           "field": "secrets",
           "why": "update_agent_secrets WRITES connector-secret names; the CLI never reads the stored secrets list back, so the response field is not modeled."
         },
@@ -248,6 +240,36 @@
       "output": "ApprovalsOutput",
       "struct": "ApprovalRecord",
       "omissions": []
+    },
+    {
+      "output": "OverridesOutput",
+      "struct": "Agent",
+      "omissions": [
+        {
+          "field": "approval_required_tools",
+          "why": "Gate configuration, surfaced by `approvals`. Emitting it from the overrides result would duplicate that verb's payload with no way to act on it here."
+        },
+        {
+          "field": "approval_routes",
+          "why": "Same as approval_required_tools: owned by `approvals --list-routes`."
+        },
+        {
+          "field": "id",
+          "why": "The payload identifies the agent by `agent` (its name), the same identifier the operator typed and the same one BudgetOutput/KillOutput emit; echoing the uuid alongside it adds a second key naming the same row. Pinned by json_emit_contract.rs's overrides_output_json_shape_is_pinned."
+        },
+        {
+          "field": "name",
+          "why": "Emitted, under the key `agent` rather than `name`: that is the key BudgetOutput, KillOutput and ResumeOutput already use for the same fact, and an operator identifies an agent by the string they typed. Renaming this result's key to `name` for the gate's benefit would make it the odd one out among its siblings. Pinned by json_emit_contract.rs's overrides_output_json_shape_is_pinned."
+        },
+        {
+          "field": "repo_full_name",
+          "why": "Same reason as slack_channel: a routing fact owned by the git-flow binding (ADR-0091), not part of the override pair this result is about."
+        },
+        {
+          "field": "slack_channel",
+          "why": "The verb reads and writes the two nullable model/thinking overrides; an agent's channel binding is a different concern with its own surface (`deploy --slack-channel`), and emitting it here would imply this verb can change it."
+        }
+      ]
     }
   ]
 }

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -1541,6 +1541,94 @@
           "name": "observability"
         },
         {
+          "about": "Read or change an agent's model and thinking overrides (`PATCH /agents/{id}`)",
+          "args": [
+            {
+              "global": false,
+              "help": "Agent name or id",
+              "id": "agent",
+              "positional": true,
+              "required": true
+            },
+            {
+              "global": false,
+              "help": "Pin this model for the agent (forwarded as CURIE_MODEL at boot)",
+              "id": "model",
+              "long": "model",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Clear the model override back to the platform default",
+              "id": "clear_model",
+              "long": "clear-model",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Pin this thinking depth (e.g. `disabled`, `adaptive`, `enabled:2000`)",
+              "id": "thinking",
+              "long": "thinking",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Clear the thinking override back to the platform default",
+              "id": "clear_thinking",
+              "long": "clear-thinking",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "default_values": [
+                "http://localhost:28000"
+              ],
+              "env": "CURIE_API_URL",
+              "global": false,
+              "id": "api_url",
+              "long": "api-url",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "curie-dev-key"
+              ],
+              "env": "CURIE_API_KEY",
+              "global": false,
+              "id": "api_key",
+              "long": "api-key",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "id": "dry_run",
+              "long": "dry-run",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "long_about": "Read or change an agent's model and thinking overrides (`PATCH /agents/{id}`).\n\nWith no flags this inspects. Both fields are nullable operator overrides of a platform default, so clearing is `--clear-<field>` (which sends JSON null) and never an empty value, which would skip the platform default rather than restore it.",
+          "name": "overrides"
+        },
+        {
           "about": "Set an agent's daily budget (`PUT /agents/{id}/budget`)",
           "args": [
             {
@@ -2950,6 +3038,113 @@
           ],
           "hidden": false,
           "name": "resume"
+        },
+        {
+          "about": "Read or change an agent's model and thinking overrides (`PATCH /agents/{id}`)",
+          "args": [
+            {
+              "global": false,
+              "help": "Agent name or id",
+              "id": "agent",
+              "positional": true,
+              "required": true
+            },
+            {
+              "global": false,
+              "help": "Pin this model for the agent (forwarded as CURIE_MODEL at boot)",
+              "id": "model",
+              "long": "model",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Clear the model override back to the platform default",
+              "id": "clear_model",
+              "long": "clear-model",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Pin this thinking depth (e.g. `disabled`, `adaptive`, `enabled:2000`)",
+              "id": "thinking",
+              "long": "thinking",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Clear the thinking override back to the platform default",
+              "id": "clear_thinking",
+              "long": "clear-thinking",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "env": "CURIE_API_URL",
+              "global": false,
+              "help": "Platform API base URL. Omit to discover the release's UI `/api` proxy",
+              "id": "api_url",
+              "long": "api-url",
+              "positional": false,
+              "required": false
+            },
+            {
+              "env": "CURIE_API_KEY",
+              "global": false,
+              "help": "Platform API key. Omit to read the release's `api.apiKey` from its Secret",
+              "id": "api_key",
+              "long": "api-key",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "curie"
+              ],
+              "global": false,
+              "help": "Kubernetes namespace of the release. Default: curie",
+              "id": "namespace",
+              "long": "namespace",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "curie"
+              ],
+              "global": false,
+              "help": "Helm release name. Default: curie",
+              "id": "release",
+              "long": "release",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Print what would be done and exit without making a request",
+              "id": "dry_run",
+              "long": "dry-run",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "long_about": "Read or change an agent's model and thinking overrides (`PATCH /agents/{id}`).\n\nWith no flags this inspects. Both fields are nullable operator overrides of a platform default, so clearing is `--clear-<field>` (which sends JSON null) and never an empty value, which would skip the platform default rather than restore it.",
+          "name": "overrides"
         },
         {
           "about": "Set an agent's budget via the platform API (`PUT /agents/{id}/budget`)",

--- a/cli/schema/index.json
+++ b/cli/schema/index.json
@@ -178,6 +178,12 @@
       "version": 1
     },
     {
+      "result": "OverridesOutput",
+      "kind": "CliOutput",
+      "schema": "overrides.schema.json",
+      "version": 1
+    },
+    {
       "result": "ResetThreadOutput",
       "kind": "CliOutput",
       "schema": "reset-thread.schema.json",

--- a/cli/schema/overrides.schema.json
+++ b/cli/schema/overrides.schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.curietech.ai/cli/overrides/v1.json",
+  "title": "curie <tier> overrides --json",
+  "description": "The agent-facing payload of `curie <tier> overrides <agent>`: the dry-run plan, or the agent's two nullable operator overrides as the API stored them. `model` and `thinking` are null when no override is pinned, which is the same fact the API returns: the platform default applies. `changed` is false for an inspect (no change flags passed) and true when this invocation wrote, so a consumer can tell \"this is what it is\" from \"this is what it now is\" without diffing.",
+  "$defs": {
+    "dryRun": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "dry_run": {
+          "const": true
+        },
+        "plan": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "dry_run",
+        "plan"
+      ]
+    }
+  },
+  "oneOf": [
+    {
+      "$ref": "#/$defs/dryRun"
+    },
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "agent": {
+          "type": "string"
+        },
+        "model": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "thinking": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "changed": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "agent",
+        "model",
+        "thinking",
+        "changed"
+      ]
+    }
+  ]
+}

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -86,6 +86,19 @@ pub struct Agent {
     /// the same fact as "no routes bound".
     #[serde(default)]
     pub approval_routes: Option<std::collections::BTreeMap<String, ApprovalRouteBinding>>,
+    /// Per-agent model override, forwarded as `CURIE_MODEL` at sandbox boot
+    /// (#254). `None` means no override: the platform default applies. Modeled
+    /// since #1311 gave the CLI a verb that reads and writes it -- until then
+    /// the only way to set it was a raw authenticated PATCH, which is exactly
+    /// the one-entry-point rule this field now satisfies.
+    #[serde(default)]
+    pub model: Option<String>,
+    /// Per-agent thinking-depth override, forwarded as `CURIE_THINKING` at
+    /// sandbox boot (#1182, ADR-0098). `None` means the platform default
+    /// applies. Same three-way PATCH semantics as `model`: omitted leaves it,
+    /// explicit null clears it.
+    #[serde(default)]
+    pub thinking: Option<String>,
 }
 
 /// One route's workspace binding, mirroring the committed `ApprovalRouteBinding`.

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -7549,3 +7549,320 @@ mod tests {
         );
     }
 }
+
+/// Which nullable override a `<tier> overrides` invocation intends to change.
+///
+/// Three states, because the API's PATCH semantics have three (#1310): omitted
+/// leaves the stored value alone, an explicit JSON null clears it back to the
+/// platform default, and a string pins it. A plain `Option<String>` can only
+/// express two of those, and collapsing "clear" onto the empty string is the
+/// exact defect #1355 fixed on the console -- an empty override reaches the
+/// worker falsy, emits no boot key, and skips the platform default that
+/// clearing is supposed to restore. So the CLI never sends `""` either; the
+/// operator says `--clear-model` and the wire carries `null`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OverrideChange {
+    /// Not mentioned on the command line: leave whatever is stored.
+    Unchanged,
+    /// `--clear-<field>`: send explicit null, restoring the platform default.
+    Clear,
+    /// `--<field> <value>`: pin this value for this agent.
+    Set(String),
+}
+
+impl OverrideChange {
+    /// Resolve the `--<field>` / `--clear-<field>` pair into one intent.
+    ///
+    /// Args:
+    ///   field: the field name, used only in the usage error.
+    ///   value: the `--<field>` value, if the operator passed one.
+    ///   clear: whether `--clear-<field>` was passed.
+    ///
+    /// Returns:
+    ///   The intent, or a usage error when both were passed or the value is
+    ///   blank.
+    pub fn resolve(field: &str, value: Option<String>, clear: bool) -> Result<Self> {
+        match (value, clear) {
+            (Some(_), true) => Err(crate::exit::usage(format!(
+                "--{field} and --clear-{field} contradict each other; pass one. \
+                 --clear-{field} restores the platform default"
+            ))),
+            // Refused here rather than forwarded, so the operator gets the fix
+            // from the CLI instead of a 422 from the API. The API refuses it
+            // too (#1355), and for the reason the hint states.
+            (Some(v), false) if v.trim().is_empty() => Err(crate::exit::usage(format!(
+                "--{field} must not be blank: an empty value skips the platform \
+                 default instead of restoring it. Pass --clear-{field} to clear \
+                 the override, or a real value"
+            ))),
+            (Some(v), false) => Ok(OverrideChange::Set(v)),
+            (None, true) => Ok(OverrideChange::Clear),
+            (None, false) => Ok(OverrideChange::Unchanged),
+        }
+    }
+
+    /// The JSON value this intent contributes to a `PATCH /agents/{id}` body,
+    /// or `None` when the field must be OMITTED from the body entirely.
+    ///
+    /// Returns:
+    ///   `Some(Value::Null)` to clear, `Some(Value::String)` to pin, `None` to
+    ///   leave the field out so the API's `model_fields_set` check reads it as
+    ///   unchanged.
+    fn patch_value(&self) -> Option<serde_json::Value> {
+        match self {
+            OverrideChange::Unchanged => None,
+            OverrideChange::Clear => Some(serde_json::Value::Null),
+            OverrideChange::Set(v) => Some(serde_json::Value::String(v.clone())),
+        }
+    }
+}
+
+/// The `PATCH /agents/{id}` body for a `<tier> overrides` write, or `None` when
+/// nothing was asked for (the inspect path).
+///
+/// Pure so the three-way semantics are assertable with no server: the property
+/// that matters is that an Unchanged field is ABSENT from the body rather than
+/// present-and-null, since the API tells those apart with `model_fields_set`
+/// and present-and-null is the clear.
+///
+/// Args:
+///   model: the intent for the model override.
+///   thinking: the intent for the thinking override.
+///
+/// Returns:
+///   The body to PATCH, or `None` when both intents are `Unchanged`.
+pub fn overrides_patch_body(
+    model: &OverrideChange,
+    thinking: &OverrideChange,
+) -> Option<serde_json::Value> {
+    let mut body = serde_json::Map::new();
+    if let Some(v) = model.patch_value() {
+        body.insert("model".to_string(), v);
+    }
+    if let Some(v) = thinking.patch_value() {
+        body.insert("thinking".to_string(), v);
+    }
+    if body.is_empty() {
+        return None;
+    }
+    Some(serde_json::Value::Object(body))
+}
+
+/// Output of `<tier> overrides <agent>`: the dry-run plan, or the agent's two
+/// nullable overrides as the API stored them. Owns its data so it outlives the
+/// `ApiClient`.
+///
+/// `model`/`thinking` are `None` when no override is pinned, which is the same
+/// fact the API returns as JSON null: the platform default applies. `changed`
+/// distinguishes an inspect from a write, so an agent consumer can tell "this
+/// is what it is" from "this is what it now is" without diffing.
+#[derive(Debug)]
+pub enum OverridesOutput {
+    DryRun(crate::ui::DryRunPlan),
+    Done {
+        agent: String,
+        model: Option<String>,
+        thinking: Option<String>,
+        changed: bool,
+    },
+}
+
+impl crate::ui::CliOutput for OverridesOutput {
+    fn to_json(&self) -> serde_json::Value {
+        match self {
+            OverridesOutput::DryRun(plan) => plan.to_json(),
+            OverridesOutput::Done {
+                agent,
+                model,
+                thinking,
+                changed,
+            } => serde_json::json!({
+                "agent": agent,
+                "model": model,
+                "thinking": thinking,
+                "changed": changed,
+            }),
+        }
+    }
+
+    fn render(&self, ui: &crate::ui::Ui) {
+        match self {
+            OverridesOutput::DryRun(plan) => plan.render(ui),
+            OverridesOutput::Done {
+                agent,
+                model,
+                thinking,
+                changed,
+            } => {
+                // "platform default" rather than "none": null here is not an
+                // absence, it is a deferral to the platform-level setting, and
+                // an operator reading "none" would reasonably expect no model.
+                let show = |v: &Option<String>| {
+                    v.clone().unwrap_or_else(|| "platform default".to_string())
+                };
+                let verb = if *changed { "now" } else { "" };
+                ui.payload(&format!(
+                    "overrides for {agent} {verb}: model {}, thinking {}",
+                    show(model),
+                    show(thinking)
+                ));
+            }
+        }
+    }
+}
+
+/// `curie <tier> overrides <agent> [--model V|--clear-model] [--thinking V|--clear-thinking]`.
+///
+/// With no change flags this INSPECTS: one `GET`-resolved agent, no write. With
+/// any change flag it PATCHes only the fields named, then reports the row as the
+/// API stored it, so the operator sees what took rather than what was intended.
+///
+/// Covers both nullable overrides in one verb on purpose. The issue (#1311)
+/// names `thinking` only, but `model` has the identical gap -- also settable
+/// only by raw PATCH, also omitted from the CLI DTO -- and the two share the
+/// API's `_nullable_override_validator` and its three-way semantics. Splitting
+/// them would mean two verbs, two committed schemas and two manifest
+/// regenerations for one concept, and would leave the sibling defect open for
+/// exactly as long as it took someone to file it again.
+///
+/// Args:
+///   opts: api url/key, the agent name or id, and the dry-run flag.
+///   model: the intent for the model override.
+///   thinking: the intent for the thinking override.
+///
+/// Returns:
+///   The stored overrides, or the dry-run plan.
+pub async fn overrides(
+    opts: AgentActionOpts,
+    model: OverrideChange,
+    thinking: OverrideChange,
+) -> Result<OverridesOutput> {
+    let ui = crate::ui::ui();
+    let body = overrides_patch_body(&model, &thinking);
+    if opts.dry_run {
+        let plan = match &body {
+            Some(b) => format!(
+                "PATCH {}/agents/<id>  {b}  (would resolve agent {:?} first)",
+                opts.api_url, opts.agent
+            ),
+            None => format!(
+                "GET {}/agents  (read-only: would resolve agent {:?} and print its overrides)",
+                opts.api_url, opts.agent
+            ),
+        };
+        return Ok(OverridesOutput::DryRun(crate::ui::DryRunPlan {
+            lines: vec![plan],
+        }));
+    }
+    let client = ApiClient::new(&opts.api_url, &opts.api_key)?;
+    let agent = client.find_agent(&opts.agent).await?;
+    let Some(body) = body else {
+        // Inspect: find_agent already carries both fields, so there is nothing
+        // further to fetch and nothing to write.
+        return Ok(OverridesOutput::Done {
+            agent: agent.name,
+            model: agent.model,
+            thinking: agent.thinking,
+            changed: false,
+        });
+    };
+    let cl = ui.checklist();
+    let step = cl.step(&format!("updating overrides for {}", agent.name));
+    let saved = match client.update_agent(&agent.id, &body).await {
+        Ok(saved) => {
+            step.done("updated");
+            saved
+        }
+        Err(err) => {
+            step.fail("failed");
+            return Err(err);
+        }
+    };
+    Ok(OverridesOutput::Done {
+        agent: saved.name,
+        model: saved.model,
+        thinking: saved.thinking,
+        changed: true,
+    })
+}
+
+#[cfg(test)]
+mod overrides_tests {
+    use super::{overrides_patch_body, OverrideChange};
+
+    // The property the whole verb rests on (#1310, #1311): an UNCHANGED field is
+    // absent from the body, a CLEARED field is present and null. The API tells
+    // those apart with `model_fields_set`, so collapsing them means "leave this
+    // alone" silently becomes "reset this to the platform default".
+    #[test]
+    fn an_unchanged_field_is_absent_and_a_cleared_field_is_present_and_null() {
+        let body = overrides_patch_body(&OverrideChange::Unchanged, &OverrideChange::Clear)
+            .expect("a clear is a write");
+        let obj = body.as_object().expect("an object");
+        assert!(
+            !obj.contains_key("model"),
+            "unchanged must be absent: {body}"
+        );
+        assert_eq!(obj.get("thinking"), Some(&serde_json::Value::Null));
+    }
+
+    #[test]
+    fn both_unchanged_is_no_body_at_all_which_is_the_inspect_path() {
+        assert!(
+            overrides_patch_body(&OverrideChange::Unchanged, &OverrideChange::Unchanged).is_none()
+        );
+    }
+
+    #[test]
+    fn a_set_field_carries_its_value() {
+        let body = overrides_patch_body(
+            &OverrideChange::Set("kimi-k2".into()),
+            &OverrideChange::Set("adaptive".into()),
+        )
+        .expect("a set is a write");
+        assert_eq!(body["model"], "kimi-k2");
+        assert_eq!(body["thinking"], "adaptive");
+    }
+
+    // --value and --clear-value are contradictory, not a precedence puzzle:
+    // picking a winner would make one of them silently do nothing.
+    #[test]
+    fn setting_and_clearing_the_same_field_is_a_usage_error() {
+        let err = OverrideChange::resolve("model", Some("m".into()), true)
+            .expect_err("contradictory flags must be refused");
+        let msg = err.to_string();
+        assert!(msg.contains("--model"), "{msg}");
+        assert!(msg.contains("--clear-model"), "{msg}");
+    }
+
+    // Refused at the CLI rather than forwarded to earn a 422: the operator gets
+    // the fix from the tool they typed into, and the message names the flag that
+    // actually does what they meant.
+    #[test]
+    fn a_blank_value_is_refused_and_points_at_the_clear_flag() {
+        for blank in ["", "   ", "\t"] {
+            let err = OverrideChange::resolve("thinking", Some(blank.into()), false)
+                .expect_err("a blank value must be refused");
+            assert!(
+                err.to_string().contains("--clear-thinking"),
+                "the refusal must name the flag that clears: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_three_intents_round_trip_from_their_flag_pairs() {
+        assert_eq!(
+            OverrideChange::resolve("model", None, false).unwrap(),
+            OverrideChange::Unchanged
+        );
+        assert_eq!(
+            OverrideChange::resolve("model", None, true).unwrap(),
+            OverrideChange::Clear
+        );
+        assert_eq!(
+            OverrideChange::resolve("model", Some("m".into()), false).unwrap(),
+            OverrideChange::Set("m".into())
+        );
+    }
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1163,6 +1163,34 @@ enum LocalAction {
         #[arg(long)]
         open: bool,
     },
+    /// Read or change an agent's model and thinking overrides (`PATCH /agents/{id}`).
+    ///
+    /// With no flags this inspects. Both fields are nullable operator
+    /// overrides of a platform default, so clearing is `--clear-<field>`
+    /// (which sends JSON null) and never an empty value, which would skip the
+    /// platform default rather than restore it.
+    Overrides {
+        /// Agent name or id.
+        agent: String,
+        /// Pin this model for the agent (forwarded as CURIE_MODEL at boot).
+        #[arg(long)]
+        model: Option<String>,
+        /// Clear the model override back to the platform default.
+        #[arg(long)]
+        clear_model: bool,
+        /// Pin this thinking depth (e.g. `disabled`, `adaptive`, `enabled:2000`).
+        #[arg(long)]
+        thinking: Option<String>,
+        /// Clear the thinking override back to the platform default.
+        #[arg(long)]
+        clear_thinking: bool,
+        #[arg(long, default_value = "http://localhost:28000", env = "CURIE_API_URL")]
+        api_url: String,
+        #[arg(long, default_value = "curie-dev-key", env = "CURIE_API_KEY", value_parser = message::api_key_or_default)]
+        api_key: String,
+        #[arg(long)]
+        dry_run: bool,
+    },
     /// Set an agent's daily budget (`PUT /agents/{id}/budget`).
     Budget {
         /// Agent name or id.
@@ -1714,6 +1742,33 @@ enum ClusterAction {
     Resume {
         /// Agent name or id to resume.
         agent: String,
+        #[command(flatten)]
+        conn: ClusterConn,
+        /// Print what would be done and exit without making a request.
+        #[arg(long)]
+        dry_run: bool,
+    },
+    /// Read or change an agent's model and thinking overrides (`PATCH /agents/{id}`).
+    ///
+    /// With no flags this inspects. Both fields are nullable operator
+    /// overrides of a platform default, so clearing is `--clear-<field>`
+    /// (which sends JSON null) and never an empty value, which would skip the
+    /// platform default rather than restore it.
+    Overrides {
+        /// Agent name or id.
+        agent: String,
+        /// Pin this model for the agent (forwarded as CURIE_MODEL at boot).
+        #[arg(long)]
+        model: Option<String>,
+        /// Clear the model override back to the platform default.
+        #[arg(long)]
+        clear_model: bool,
+        /// Pin this thinking depth (e.g. `disabled`, `adaptive`, `enabled:2000`).
+        #[arg(long)]
+        thinking: Option<String>,
+        /// Clear the thinking override back to the platform default.
+        #[arg(long)]
+        clear_thinking: bool,
         #[command(flatten)]
         conn: ClusterConn,
         /// Print what would be done and exit without making a request.
@@ -2369,6 +2424,28 @@ async fn run(command: Option<Command>) -> Result<()> {
                 .await?,
             ),
             LocalAction::Observability { open } => emit(commands::observability(open).await?),
+            LocalAction::Overrides {
+                agent,
+                model,
+                clear_model,
+                thinking,
+                clear_thinking,
+                api_url,
+                api_key,
+                dry_run,
+            } => emit(
+                commands::overrides(
+                    AgentActionOpts {
+                        api_url,
+                        api_key,
+                        agent,
+                        dry_run,
+                    },
+                    commands::OverrideChange::resolve("model", model, clear_model)?,
+                    commands::OverrideChange::resolve("thinking", thinking, clear_thinking)?,
+                )
+                .await?,
+            ),
             LocalAction::Budget {
                 agent,
                 limit,
@@ -3033,6 +3110,37 @@ async fn run(command: Option<Command>) -> Result<()> {
                         agent,
                         dry_run,
                     })
+                    .await?,
+                )
+            }
+            ClusterAction::Overrides {
+                agent,
+                model,
+                clear_model,
+                thinking,
+                clear_thinking,
+                conn,
+                dry_run,
+            } => {
+                // Resolve the flag pairs BEFORE discovering the connection: a
+                // contradictory invocation is a usage error, and making the
+                // operator wait on a cluster lookup to be told so is worse than
+                // telling them immediately.
+                let model = commands::OverrideChange::resolve("model", model, clear_model)?;
+                let thinking =
+                    commands::OverrideChange::resolve("thinking", thinking, clear_thinking)?;
+                let (api_url, api_key) = resolve_cluster_conn(conn).await?;
+                emit(
+                    commands::overrides(
+                        AgentActionOpts {
+                            api_url,
+                            api_key,
+                            agent,
+                            dry_run,
+                        },
+                        model,
+                        thinking,
+                    )
                     .await?,
                 )
             }

--- a/cli/src/message.rs
+++ b/cli/src/message.rs
@@ -2997,6 +2997,8 @@ mod tests {
             repo_full_name: None,
             approval_required_tools: None,
             approval_routes: None,
+            model: None,
+            thinking: None,
         }
     }
 
@@ -3747,6 +3749,8 @@ mod tests {
                 repo_full_name: None,
                 approval_required_tools: None,
                 approval_routes: None,
+                model: None,
+                thinking: None,
             },
             Agent {
                 id: "a2".into(),
@@ -3755,6 +3759,8 @@ mod tests {
                 repo_full_name: None,
                 approval_required_tools: None,
                 approval_routes: None,
+                model: None,
+                thinking: None,
             },
         ];
         // Explicit channel picks the matching agent's id.

--- a/cli/tests/api_lifecycle.rs
+++ b/cli/tests/api_lifecycle.rs
@@ -307,3 +307,179 @@ async fn dry_run_makes_no_request_for_any_verb() {
         "no dry-run verb may make a request"
     );
 }
+
+// --- `<tier> overrides`: the two nullable operator overrides (#1311) ---------
+//
+// Both fields were settable only by a raw authenticated PATCH before this verb,
+// and both are three-way on the wire: OMITTED leaves the stored value, explicit
+// JSON null clears it to the platform default, a string pins it. The whole point
+// of the verb is that an operator can express all three, so these assert the
+// BODY, not just that a request happened -- a body that sends null where it
+// meant "leave it" is the failure mode, and it looks identical from the outside.
+
+/// A one-agent list whose overrides are already pinned, for the inspect path.
+fn agent_list_with_overrides() -> Response {
+    Response::json(
+        200,
+        &format!(
+            r##"[{{"id":"{AGENT_ID}","name":"deal-desk","slack_channel":"#x","model":"kimi-k2","thinking":"adaptive","created_at":"2026-07-05T00:00:00Z"}}]"##
+        ),
+    )
+}
+
+#[tokio::test]
+async fn overrides_inspect_reads_both_fields_and_writes_nothing() {
+    let server = serve(|req| match (req.method.as_str(), req.path.as_str()) {
+        ("GET", "/agents") => agent_list_with_overrides(),
+        other => panic!("unexpected request: {other:?}"),
+    });
+
+    let out = commands::overrides(
+        opts(&server.base_url, "deal-desk", false),
+        commands::OverrideChange::Unchanged,
+        commands::OverrideChange::Unchanged,
+    )
+    .await
+    .unwrap();
+
+    match out {
+        commands::OverridesOutput::Done {
+            agent,
+            model,
+            thinking,
+            changed,
+        } => {
+            assert_eq!(agent, "deal-desk");
+            assert_eq!(model.as_deref(), Some("kimi-k2"));
+            assert_eq!(thinking.as_deref(), Some("adaptive"));
+            assert!(!changed, "an inspect must not report itself as a write");
+        }
+        other => panic!("expected Done, got {other:?}"),
+    }
+
+    // The resolve GET and nothing else: inspect is read-only.
+    let rec = server.recorded();
+    assert_eq!(rec.len(), 1, "inspect must issue exactly one request");
+    assert_eq!(rec[0].method, "GET");
+}
+
+#[tokio::test]
+async fn overrides_set_patches_only_the_field_named() {
+    let server = serve(|req| match (req.method.as_str(), req.path.as_str()) {
+        ("GET", "/agents") => agent_list(),
+        ("PATCH", p) if *p == format!("/agents/{AGENT_ID}") => Response::json(
+            200,
+            &format!(
+                r##"{{"id":"{AGENT_ID}","name":"deal-desk","slack_channel":"#x","model":null,"thinking":"enabled:2000"}}"##
+            ),
+        ),
+        other => panic!("unexpected request: {other:?}"),
+    });
+
+    let out = commands::overrides(
+        opts(&server.base_url, "deal-desk", false),
+        commands::OverrideChange::Unchanged,
+        commands::OverrideChange::Set("enabled:2000".to_string()),
+    )
+    .await
+    .unwrap();
+
+    match out {
+        commands::OverridesOutput::Done {
+            thinking, changed, ..
+        } => {
+            assert_eq!(thinking.as_deref(), Some("enabled:2000"));
+            assert!(changed);
+        }
+        other => panic!("expected Done, got {other:?}"),
+    }
+
+    let rec = server.recorded();
+    let patch = rec.iter().find(|r| r.method == "PATCH").expect("a PATCH");
+    let body = String::from_utf8_lossy(&patch.body);
+    assert!(
+        body.contains(r#""thinking":"enabled:2000""#),
+        "body: {body}"
+    );
+    // The load-bearing half: an unmentioned field is ABSENT, not null. The API
+    // tells omitted from explicit-null apart with `model_fields_set` (#1310), so
+    // sending null here would silently clear an override the operator never
+    // touched.
+    assert!(
+        !body.contains("model"),
+        "an unmentioned override must be omitted, not nulled: {body}"
+    );
+}
+
+#[tokio::test]
+async fn overrides_clear_sends_explicit_null_not_an_empty_string() {
+    let server = serve(|req| match (req.method.as_str(), req.path.as_str()) {
+        ("GET", "/agents") => agent_list_with_overrides(),
+        ("PATCH", p) if *p == format!("/agents/{AGENT_ID}") => Response::json(
+            200,
+            &format!(
+                r##"{{"id":"{AGENT_ID}","name":"deal-desk","slack_channel":"#x","model":null,"thinking":null}}"##
+            ),
+        ),
+        other => panic!("unexpected request: {other:?}"),
+    });
+
+    let out = commands::overrides(
+        opts(&server.base_url, "deal-desk", false),
+        commands::OverrideChange::Clear,
+        commands::OverrideChange::Clear,
+    )
+    .await
+    .unwrap();
+
+    match out {
+        commands::OverridesOutput::Done {
+            model,
+            thinking,
+            changed,
+            ..
+        } => {
+            assert!(model.is_none() && thinking.is_none());
+            assert!(changed);
+        }
+        other => panic!("expected Done, got {other:?}"),
+    }
+
+    let patch = server
+        .recorded()
+        .into_iter()
+        .find(|r| r.method == "PATCH")
+        .expect("a PATCH");
+    let body = String::from_utf8_lossy(&patch.body);
+    assert!(body.contains(r#""model":null"#), "body: {body}");
+    assert!(body.contains(r#""thinking":null"#), "body: {body}");
+    // Never the empty string. The API refuses it (#1355) and it would be the
+    // wrong request anyway: an empty override reaches the worker falsy, emits no
+    // boot key, and skips the very platform default clearing restores.
+    assert!(
+        !body.contains(r#""""#),
+        "clear must be null, not empty: {body}"
+    );
+}
+
+#[tokio::test]
+async fn overrides_dry_run_makes_no_request_on_either_path() {
+    let server = serve(|req| panic!("--dry-run must not call the API: {req:?}"));
+
+    for (model, thinking) in [
+        (
+            commands::OverrideChange::Unchanged,
+            commands::OverrideChange::Unchanged,
+        ),
+        (
+            commands::OverrideChange::Clear,
+            commands::OverrideChange::Set("adaptive".to_string()),
+        ),
+    ] {
+        let out = commands::overrides(opts(&server.base_url, "deal-desk", true), model, thinking)
+            .await
+            .unwrap();
+        assert!(matches!(out, commands::OverridesOutput::DryRun(_)));
+    }
+    assert!(server.recorded().is_empty());
+}

--- a/cli/tests/cli_output_variants.rs
+++ b/cli/tests/cli_output_variants.rs
@@ -36,8 +36,8 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use curie::api::{ApprovalRecord, MemoryEntry, Version};
 use curie::commands::{
-    ApprovalsOutput, BudgetOutput, DeleteOutput, KillOutput, MemoryOutput, ResetThreadOutput,
-    ResumeOutput, SkillApprovalsOutput, VersionsOutput,
+    ApprovalsOutput, BudgetOutput, DeleteOutput, KillOutput, MemoryOutput, OverridesOutput,
+    ResetThreadOutput, ResumeOutput, SkillApprovalsOutput, VersionsOutput,
 };
 use curie::comms::CommsOutput;
 use curie::github_app::GithubAppOutput;
@@ -204,6 +204,22 @@ fn registry() -> BTreeMap<&'static str, Vec<VariantJson>> {
         samples![
             "DryRun" => BudgetOutput::DryRun(plan()),
             "Done" => BudgetOutput::Done { agent: "a".to_string(), max_usd_per_day: Some(1.5) },
+        ],
+    );
+    m.insert(
+        "OverridesOutput",
+        samples![
+            "DryRun" => OverridesOutput::DryRun(plan()),
+            // Both nullable fields carry a value here, and the null case rides
+            // the schema's `["string","null"]` type plus the round-trip tests
+            // in api_lifecycle.rs -- a sample per VARIANT is what this gate
+            // wants, not a sample per field state.
+            "Done" => OverridesOutput::Done {
+                agent: "a".to_string(),
+                model: Some("kimi-k2".to_string()),
+                thinking: Some("adaptive".to_string()),
+                changed: true,
+            },
         ],
     );
     m.insert(

--- a/docs/interfaces/cli-output/INTERFACE.md
+++ b/docs/interfaces/cli-output/INTERFACE.md
@@ -73,8 +73,9 @@ Nine, all in the CLI crate:
   from `OpsCommand::display()` (already credential-masked), so this type never
   re-derives argv or reads a raw secret. It is also **composed** rather than
   duplicated: the other outputs carry a `DryRun` variant that delegates to it.
-- **Seven command outputs** (`cli/src/commands.rs`) — `KillOutput`, `ResumeOutput`,
-  `BudgetOutput`, `DeleteOutput`, `VersionsOutput`, `MemoryOutput`, `ApprovalsOutput`.
+- **Eight command outputs** (`cli/src/commands.rs`) — `KillOutput`, `ResumeOutput`,
+  `BudgetOutput`, `OverridesOutput`, `DeleteOutput`, `VersionsOutput`, `MemoryOutput`,
+  `ApprovalsOutput`.
 - **`ObservabilityOutput`** (`cli/src/observability.rs`) — the tier-aware
   observability surfaces (#460). Notable as the shape the seam is for: both the local
   and cluster tiers resolve their own `Endpoint` values and return *the same* output
@@ -92,9 +93,9 @@ Nine, all in the CLI crate:
   syntactic call-site inventory, not a type-level proof that *every* verb returns
   a `CliOutput`.
 - **Committed JSON Schemas with a drift gate (since #841).** Each `to_json` is no
-  longer schema-free: there are 38 committed schemas under `cli/schema/` with an
+  longer schema-free: there are 39 committed schemas under `cli/schema/` with an
   index (`cli/schema/index.json`), a `syn`-based inventory gate over every `impl
-  CliOutput`, and per-family output validation — all 38 are validated against real
+  CliOutput`, and per-family output validation — all 39 are validated against real
   `to_json()` output across 59 tests in `cli/tests/json_contract.rs`. Those tests
   drive each output type's `to_json()` once per output variant rather than calling
   the pure builder functions behind it, so a variant whose `to_json()` arm drifts

--- a/docs/thinking.md
+++ b/docs/thinking.md
@@ -38,14 +38,22 @@ the worker's other env (compose, or `worker.extraEnv` in the chart):
 CURIE_THINKING=disabled
 ```
 
-**Per agent** is the `thinking` column, set through the platform API, and it
-wins over the platform default for that agent only:
+**Per agent** is the `thinking` column, and it wins over the platform default
+for that agent only. Set it with the CLI (#1311); the raw PATCH this used to
+document is what the one-entry-point rule exists to avoid:
 
 ```bash
-curl -X PATCH "$CURIE_API_URL/agents/$AGENT_ID" \
-  -H "X-API-Key: $CURIE_API_KEY" -H 'content-type: application/json' \
-  -d '{"thinking": "adaptive"}'
+curie local overrides deal-desk --thinking adaptive     # or `cluster`
+curie local overrides deal-desk                         # read it back
+curie local overrides deal-desk --clear-thinking        # back to the platform default
 ```
+
+Clearing is `--clear-thinking`, never an empty value: an empty override reaches
+the worker falsy, emits no boot key, and so skips the platform default instead
+of restoring it. The API refuses a blank for that reason, and the CLI refuses it
+one step earlier with a message naming the flag that does work.
+
+The same verb carries `--model` / `--clear-model`, which had the identical gap.
 
 ### The vocabulary
 


### PR DESCRIPTION
Per-agent `thinking` was settable only by a hand-rolled authenticated PATCH. The CLI DTO omitted the field, no verb read or wrote it, and `cli/api-mirrors.json` recorded the omission with this reason:

> No CLI verb displays or acts on it; an operator sets it through the platform API.

That reason **is** the defect. It costs an operator credential discovery, structured JSON, semantic exit codes and discoverability, and contradicts both the one-entry-point rule in `CLAUDE.md` and ADR-0008.

## The verb

```
curie local overrides deal-desk                          # inspect, writes nothing
curie local overrides deal-desk --thinking adaptive      # pin
curie local overrides deal-desk --clear-model            # restore the platform default
```

Present on **both** tiers (AC3), each with its own connection idiom -- `--api-url`/`--api-key` on `local`, the discoverable `ClusterConn` on `cluster` -- so neither has to refuse. On `cluster` the flag pair is resolved *before* connection discovery, so a contradictory invocation fails immediately instead of after a cluster lookup.

## Both fields, deliberately

The issue names `thinking` only. `model` has the identical gap -- also raw-PATCH-only, also omitted from the DTO, also carrying an omission note claiming no CLI acts on it -- and the two share the API's `_nullable_override_validator` and its three-way semantics.

Splitting them would mean two verbs, two committed schemas and two manifest regenerations for one concept, and would leave the twin open until someone filed it again. That is the sibling-path drift the parity-seam rule exists to stop, and it is the same shape as #1363 and #1355.

## The three-way semantics are the load-bearing part

An unmentioned field is **absent** from the PATCH body, not null. The API tells omitted from explicit-null apart with `model_fields_set` (#1310), so sending null for a field the operator never typed would silently clear an override they meant to leave alone -- and the request looks perfectly normal from the outside.

`overrides_patch_body` is pure so that property is assertable with no server. The dry-run shows all three states on the wire:

```
overrides deal-desk                          -> GET  /agents            (read-only)
overrides deal-desk --thinking adaptive      -> PATCH {"thinking":"adaptive"}
overrides deal-desk --clear-model --clear-thinking
                                             -> PATCH {"model":null,"thinking":null}
```

**Clearing is a flag, never an empty value.** A blank `--model`/`--thinking` is refused one step before the API's own 422, with a message naming the flag that does work: an empty override reaches the worker falsy, emits no boot key, and skips the very platform default that clearing restores (#1355). `--model` together with `--clear-model` is a usage error rather than a precedence puzzle -- picking a winner would make one flag silently do nothing. Both exit **2**, matching `budget --limit 0`.

## Verified

**Red proof.** Making `Unchanged` emit null -- the dangerous mistake, since it looks like a working write -- turns **four** tests red across two layers: the two pure-function unit tests and two of the round-trip tests. Restored, all green.

Round trips against the wire-level test server cover inspect (one GET, no write, `changed: false`), set (asserts the *body*: the named field present, the unmentioned one **absent**), clear (asserts `null`, and asserts the body contains no `""` anywhere), and `--dry-run` on both the read and write paths making no request at all.

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, full `cargo test`, UI `tsc --noEmit` / `eslint --max-warnings 0` / 144 vitest, and both manifests re-verified drift-free after regeneration.

## Gates this had to satisfy, and how

| gate | resolution |
|---|---|
| field-parity | `Agent` now models `model` + `thinking`; their two omission entries retired |
| emit-parity | `emits` entry for `OverridesOutput` -> `Agent`. `name` is declared as an omission because it *is* emitted, under the key `agent` -- the key `BudgetOutput`/`KillOutput`/`ResumeOutput` already use. Renaming it for the gate would make this result the odd one out |
| schema inventory | committed `overrides.schema.json` v1, registered in `cli/schema/index.json` |
| variants | one constructed sample per variant in `cli_output_variants.rs` |
| command manifest | both `cli/command-manifest.json` and the committed `commandManifest.ts` regenerated (in that order -- the TS one derives from the JSON) |

`docs/thinking.md` loses the raw `curl` this verb replaces, and `cli/README.md` gains the command-table row.

Closes #1311