### PR TITLE
Make the sandbox route TTLs configurable

### DIFF
--- a/apps/worker/src/curie_worker/run.py
+++ b/apps/worker/src/curie_worker/run.py
@@ -77,6 +77,19 @@ def _substrate_config(env: Mapping[str, str]) -> SubstrateConfig:
     claim_timeout = env.get("CURIE_CLAIM_TIMEOUT_SECONDS")
     if claim_timeout is not None:
         overrides["claim_timeout_seconds"] = float(claim_timeout)
+    # The route TTLs govern how long a thread PINS its sandbox, which is the
+    # term that decides how many exist at once. Leaving them hardcoded while
+    # claim_timeout was tunable gave operators the deadline knob but not the
+    # accumulation knob -- and raising a deadline only makes a doomed turn fail
+    # slower (#1380). Both are exposed because they are the same mechanism:
+    # capping the live TTL while a suspended route still pins a sandbox for a
+    # day would just move the accumulation.
+    route_ttl = env.get("CURIE_ROUTE_TTL_SECONDS")
+    if route_ttl is not None:
+        overrides["route_ttl_seconds"] = int(route_ttl)
+    suspended_route_ttl = env.get("CURIE_SUSPENDED_ROUTE_TTL_SECONDS")
+    if suspended_route_ttl is not None:
+        overrides["suspended_route_ttl_seconds"] = int(suspended_route_ttl)
     return SubstrateConfig(
         namespace=env.get("CURIE_NAMESPACE", "default"),
         warm_pool=env.get("CURIE_WARM_POOL", "curie-runner-pool"),

--- a/apps/worker/tests/binding/test_boot_env_single_declaration.py
+++ b/apps/worker/tests/binding/test_boot_env_single_declaration.py
@@ -122,6 +122,12 @@ _NON_BOOT_ALLOWLIST: frozenset[str] = frozenset(
         # Substrate wiring: how the worker provisions sandboxes, not what it puts
         # inside one. SubstrateConfig reads these from the worker's env.
         "CURIE_CLAIM_TIMEOUT_SECONDS",
+        # How long a thread pins its sandbox, and how long a suspended one waits
+        # (#1380). Same family as the claim timeout above: the worker's own
+        # provisioning policy, decided before any sandbox exists, so never a
+        # boot key.
+        "CURIE_ROUTE_TTL_SECONDS",
+        "CURIE_SUSPENDED_ROUTE_TTL_SECONDS",
         "CURIE_DOCKER_NETWORK",
         "CURIE_NAMESPACE",
         # The Helm release name (ADR-0086, #1118). Read from the WORKER's env by

--- a/apps/worker/tests/test_run.py
+++ b/apps/worker/tests/test_run.py
@@ -34,6 +34,36 @@ def test_substrate_config_claim_timeout_reads_env() -> None:
     assert cfg.claim_timeout_seconds == 45.0
 
 
+def test_substrate_config_route_ttls_default_unchanged() -> None:
+    # Exposing these must not change behaviour for anyone who sets nothing.
+    cfg = _substrate_config({})
+    assert cfg.route_ttl_seconds == 3600
+    assert cfg.suspended_route_ttl_seconds == 86400
+
+
+def test_substrate_config_route_ttl_reads_env() -> None:
+    cfg = _substrate_config({"CURIE_ROUTE_TTL_SECONDS": "300"})
+    assert cfg.route_ttl_seconds == 300
+
+
+def test_substrate_config_suspended_route_ttl_reads_env() -> None:
+    cfg = _substrate_config({"CURIE_SUSPENDED_ROUTE_TTL_SECONDS": "7200"})
+    assert cfg.suspended_route_ttl_seconds == 7200
+
+
+def test_route_ttl_override_is_independent_of_claim_timeout() -> None:
+    # The regression this whole change exists for (#1380): an operator could
+    # reach the DEADLINE but not the ACCUMULATION term, so the only available
+    # lever made a doomed turn fail slower instead of reducing how many
+    # sandboxes were alive. Setting one must not disturb the other.
+    cfg = _substrate_config(
+        {"CURIE_ROUTE_TTL_SECONDS": "300", "CURIE_CLAIM_TIMEOUT_SECONDS": "45"}
+    )
+    assert cfg.route_ttl_seconds == 300
+    assert cfg.claim_timeout_seconds == 45.0
+    assert cfg.suspended_route_ttl_seconds == 86400
+
+
 def test_claim_timeout_default_stays_under_lock_ttl() -> None:
     # The claim is the dominant term in the per-thread critical section; it must
     # stay below the lock TTL so the lock never lapses mid-claim.

--- a/charts/curie/templates/worker.yaml
+++ b/charts/curie/templates/worker.yaml
@@ -182,6 +182,13 @@ spec:
             # gives up. Must stay below the worker's per-thread lock TTL (120s).
             - name: CURIE_CLAIM_TIMEOUT_SECONDS
               value: {{ .Values.worker.claimTimeoutSeconds | quote }}
+            # How long a thread pins its sandbox after its last message -- the
+            # term that governs how many exist at once, and the one that used
+            # to be unreachable while the deadline above was tunable (#1380).
+            - name: CURIE_ROUTE_TTL_SECONDS
+              value: {{ .Values.worker.routeTtlSeconds | quote }}
+            - name: CURIE_SUSPENDED_ROUTE_TTL_SECONDS
+              value: {{ .Values.worker.suspendedRouteTtlSeconds | quote }}
             # Slack assistant-thread "shimmer" (#1182). Rendered on the WORKER
             # only: it both raises the caption and lowers it, so one value
             # governs the feature release-wide and the two halves cannot be

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -769,6 +769,28 @@ worker:
   # before giving up. Must stay below the worker's per-thread lock TTL (120s) so
   # the lock never lapses mid-claim; raise it only on a slow cluster.
   claimTimeoutSeconds: 90
+  # How long a thread PINS its sandbox after its last message. This is the term
+  # that decides how MANY sandboxes exist at once, and it was the one an
+  # operator could not reach (#1380): claimTimeoutSeconds was tunable, this was
+  # a bare default in the worker.
+  #
+  # Thread affinity is the point -- a follow-up should reuse the warm sandbox
+  # rather than pay a ~30s cold create again. But traffic to a triage bot is
+  # mostly ONE-SHOT: someone asks, reads the answer, never replies. At the
+  # 3600s default that sandbox holds a slot for the remaining ~59 minutes, and
+  # with `agentSandbox.warmPool.replicas: 0` every new thread cold-creates
+  # alongside it. On a small node enough of them accumulate that a cold create
+  # stops fitting inside claimTimeoutSeconds, and the turn escalates as an
+  # opaque `runner-error`.
+  #
+  # Lower it on a small node or a low-conversation-depth bot; raise it where
+  # threads are genuinely conversational and cold creates are expensive.
+  routeTtlSeconds: 3600
+  # The same, for a route suspended awaiting an approval -- it waits far longer
+  # because the human may answer tomorrow. Exposed alongside the live TTL
+  # because capping one while the other still pins a sandbox for a day would
+  # only move the accumulation.
+  suspendedRouteTtlSeconds: 86400
   # The Slack assistant-thread "shimmer" (#1182): the animated caption Slack
   # shows next to the app's name while a turn runs. On by default -- the
   # placeholder message only changes when the model emits text, so a model that


### PR DESCRIPTION
Closes #1380.

An operator could reach the claim **deadline** (`CURIE_CLAIM_TIMEOUT_SECONDS`)
but not the term that decides how many sandboxes exist at once.
`route_ttl_seconds` was a bare default in `SubstrateConfig` — no env alias, no
chart value — so the only available lever made a doomed turn fail *slower*
rather than reducing the pressure that doomed it.

## The failure it explains

A thread pins its sandbox for an hour after its last message. Right for a
conversation; poor for a triage bot, where most threads are one-shot — someone
asks, reads the answer, never replies, and the sandbox holds a slot for the
remaining ~59 minutes. With `warmPool.replicas: 0` (the documented default)
every new thread cold-creates alongside those.

Measured on the install where this surfaced:

| | |
|---|---|
| Cold boot, node quiet | **36s** |
| Cold boot, 5 retained sandboxes | **two consecutive 90s timeouts** |
| CPU pressure at the time | `some avg10=8.70` |
| CPU requests | 1480m / 2000m (74%) |
| `FailedScheduling` events | **zero** |

The node was healthy. The accumulation was the problem — which is why raising
the deadline was never going to fix it.

## Why both TTLs

`suspended_route_ttl_seconds` (86400) is exposed too. Capping how long an
*active* thread pins a sandbox while a *suspended* route still pins one for a
day would just move the accumulation to the rarer path.

## Inert by default

Defaults unchanged: `3600` / `86400`. Anyone who sets nothing sees no
behaviour change, and a test asserts exactly that.

There's also a test that the two knobs stay **independent** — setting the route
TTL must not disturb the claim timeout — because having one without the other
*is* the defect.

## Verification

`helm lint` clean; the chart renders both env vars:

```
- name: CURIE_ROUTE_TTL_SECONDS
  value: "3600"
- name: CURIE_SUSPENDED_ROUTE_TTL_SECONDS
  value: "86400"
```

**Honest about test execution:** I could not run the worker suite locally — it
needs the full monorepo dev environment (`aci_protocol`, `plugin_format`,
`curie_dispatcher`, `redis`). Instead I loaded the real `SubstrateConfig` and
executed the real override block from `run.py` against it, asserting all four
cases (defaults, each override, independence). CI runs the actual tests.

## Suggested follow-up, not in this PR

#1380 also asks that the escalation say *why* a claim failed — never scheduled,
never became Ready, or timed out mid-boot. From Slack those are
indistinguishable, and `substrate.py` already reasons about the CPU-starved case
in a comment that never reaches an operator. That's a separate change and worth
its own review.
