### PR TITLE
Bound the worker TTL and timeout knobs at both ends

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -225,6 +225,22 @@ jobs:
           set -euo pipefail
           bash charts/curie/ci/ephemeral-storage-assertions.sh
 
+      # Prove values.schema.json bounds the three worker TTL/timeout knobs at
+      # both ends (issue #1388): 0, a negative, 31536001 and a non-integer are
+      # refused by helm itself, while the shipped defaults, legitimate tuning
+      # and the value exactly at the maximum still render. `routeTtlSeconds: 0`
+      # is valid YAML that installs green and then hangs every turn, leaking a
+      # sandbox per attempt, so the value must never reach worker env. Also the
+      # blast-radius net for the schema: a chart-root values.schema.json is
+      # validated against the WHOLE coalesced values tree on
+      # lint/template/install/upgrade, so an over-specified one breaks every
+      # install, and this asserts every overlay this job already exercises
+      # still lints and renders clean.
+      - name: helm render assertions (worker TTL bounds)
+        run: |
+          set -euo pipefail
+          bash charts/curie/ci/worker-ttl-bounds-assertions.sh
+
       - name: helm template + kubeconform (values-dev overlay)
         run: |
           set -euo pipefail

--- a/apps/worker/src/curie_worker/run.py
+++ b/apps/worker/src/curie_worker/run.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import math
 import os
 import signal
 from collections.abc import Awaitable, Callable, Mapping
@@ -69,14 +70,78 @@ class Runtime:
     connector_loop: ConnectorReconcileLoop | None = None
 
 
+# 365 days, the ceiling shared by all three operator-tunable seconds knobs
+# (#1388). It is the smallest bound unambiguously above every legitimate
+# setting: 365x the shipped suspended_route_ttl_seconds default (86400) and
+# 8760x the route_ttl_seconds default (3600). It also sits ~9 orders of
+# magnitude below the boundary where Valkey's millisecond expiry arithmetic
+# overflows a signed 64-bit value and the store answers "value is not an
+# integer or out of range", so that failure class becomes structurally
+# unreachable rather than merely unlikely. And it doubles as an accumulation
+# guard in the spirit of #1380: route expiry IS the orphan signal reap_orphans
+# keys off, so a year-long route already means "never reaped by TTL" and
+# anything longer is definitionally a leak.
+_MAX_TUNABLE_SECONDS = 31_536_000
+
+
+def _bounded_seconds(
+    env: Mapping[str, str], name: str, cast: Callable[[str], int | float]
+) -> int | float | None:
+    """Read one operator-tunable seconds knob, or None when it is unset.
+
+    None means "leave the SubstrateConfig default in place", so an install that
+    sets nothing is unaffected. Everything else is refused at boot with a
+    ValueError naming the env var and the offending value, because these numbers
+    reach Valkey as expiries: a non-positive TTL makes ``SET ... EX 0`` raise a
+    ResponseError the kernel does not classify, and ``EXPIRE key 0`` silently
+    DELETES the route instead of erroring. Refusing here turns a first-message
+    hang that leaks a sandbox per attempt into a startup failure an operator can
+    read (#1388).
+    """
+    raw = env.get(name)
+    if raw is None:
+        return None
+    if not raw.strip():
+        raise ValueError(
+            f"{name} is set to an empty value ({raw!r}): unset it to take the "
+            f"default, or set a number of seconds greater than 0 and at most "
+            f"{_MAX_TUNABLE_SECONDS}"
+        )
+    try:
+        value = cast(raw)
+    except (TypeError, ValueError) as exc:
+        kind = "a whole number of seconds" if cast is int else "a number of seconds"
+        raise ValueError(f"{name} must be {kind}, got {raw!r}") from exc
+    # inf (from "inf" or an overflowing literal like "1e400") makes the claim
+    # deadline never elapse, so the wait spins forever inside the per-thread
+    # lock; nan compares False against everything, so the wait never runs and
+    # every claim fails instantly. The bounds check below does reject all three
+    # on its own, but only because ``0 < nan`` happens to evaluate False --
+    # implicit IEEE semantics a later "simplification" of that line would break
+    # silently. This branch states the intent and owns the clearer message.
+    # It is scoped to the float path because only a float can be non-finite,
+    # and math.isfinite() on an int too large to convert to float raises
+    # OverflowError, which would escape this helper as something other than a
+    # ValueError naming the knob. Such an int is finite; the bounds check
+    # rejects it, in integer arithmetic, as out of range.
+    if isinstance(value, float) and not math.isfinite(value):
+        raise ValueError(f"{name} must be a finite number of seconds, got {raw!r}")
+    if not 0 < value <= _MAX_TUNABLE_SECONDS:
+        raise ValueError(
+            f"{name} must be greater than 0 and at most {_MAX_TUNABLE_SECONDS} "
+            f"seconds (365 days), got {raw!r}"
+        )
+    return value
+
+
 def _substrate_config(env: Mapping[str, str]) -> SubstrateConfig:
     # claim_timeout is overridable so a slow cluster can raise it; when unset the
     # authoritative default lives in SubstrateConfig. Keep any override below the
     # per-thread lock TTL (WorkerConfig.lock_ttl_ms) -- see that comment.
     overrides: dict[str, Any] = {}
-    claim_timeout = env.get("CURIE_CLAIM_TIMEOUT_SECONDS")
+    claim_timeout = _bounded_seconds(env, "CURIE_CLAIM_TIMEOUT_SECONDS", float)
     if claim_timeout is not None:
-        overrides["claim_timeout_seconds"] = float(claim_timeout)
+        overrides["claim_timeout_seconds"] = claim_timeout
     # The route TTLs govern how long a thread PINS its sandbox, which is the
     # term that decides how many exist at once. Leaving them hardcoded while
     # claim_timeout was tunable gave operators the deadline knob but not the
@@ -84,12 +149,12 @@ def _substrate_config(env: Mapping[str, str]) -> SubstrateConfig:
     # slower (#1380). Both are exposed because they are the same mechanism:
     # capping the live TTL while a suspended route still pins a sandbox for a
     # day would just move the accumulation.
-    route_ttl = env.get("CURIE_ROUTE_TTL_SECONDS")
+    route_ttl = _bounded_seconds(env, "CURIE_ROUTE_TTL_SECONDS", int)
     if route_ttl is not None:
-        overrides["route_ttl_seconds"] = int(route_ttl)
-    suspended_route_ttl = env.get("CURIE_SUSPENDED_ROUTE_TTL_SECONDS")
+        overrides["route_ttl_seconds"] = route_ttl
+    suspended_route_ttl = _bounded_seconds(env, "CURIE_SUSPENDED_ROUTE_TTL_SECONDS", int)
     if suspended_route_ttl is not None:
-        overrides["suspended_route_ttl_seconds"] = int(suspended_route_ttl)
+        overrides["suspended_route_ttl_seconds"] = suspended_route_ttl
     return SubstrateConfig(
         namespace=env.get("CURIE_NAMESPACE", "default"),
         warm_pool=env.get("CURIE_WARM_POOL", "curie-runner-pool"),

--- a/apps/worker/tests/sandbox/test_affinity.py
+++ b/apps/worker/tests/sandbox/test_affinity.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import pytest
 import redis
 from curie_worker.sandbox import AffinityStore, RouteRecord, RouteState, SandboxHandle
 
@@ -75,3 +76,36 @@ def test_live_claim_names_skips_expired_routes(affinity: AffinityStore) -> None:
 
     affinity.delete_if_claim("T2", "claim-b")
     assert affinity.live_claim_names() == {"claim-a"}
+
+
+# --- #1388: why a non-positive TTL is refused at boot rather than at the store ---
+#
+# Observed against the real Valkey 8.1.8 on the compose dev stack
+# (`docker compose -f compose.dev.yaml up -d valkey`, localhost:26379) on
+# 2026-08-07:
+#
+#   SET k v EX 0    -> redis.exceptions.ResponseError: invalid expire time in 'set' command
+#   SET k v EX -1   -> redis.exceptions.ResponseError: invalid expire time in 'set' command
+#   SET k v EX 10**20 -> redis.exceptions.ResponseError: value is not an integer or out of range
+#   EXPIRE k 0      -> 1 (True), and the key is DELETED
+#
+# These two tests pin that behavior, not the guard: they assert what the store
+# does when a bad TTL reaches it, which is the reason CURIE_ROUTE_TTL_SECONDS is
+# bounded in the worker's env loader (run.py) instead. ResponseError is not in
+# the kernel's _attempt catch tuple, so the first form escapes unclassified; the
+# EXPIRE form never raises at all and silently drops the route on a touch.
+
+
+def test_zero_ttl_put_if_absent_raises_valkey_response_error(affinity: AffinityStore) -> None:
+    with pytest.raises(redis.exceptions.ResponseError) as exc:
+        affinity.put_if_absent("T1", RouteRecord(handle=_handle()), ttl_seconds=0)
+    assert "invalid expire time" in str(exc.value)
+
+
+def test_zero_ttl_touch_reports_success_and_deletes_the_route(affinity: AffinityStore) -> None:
+    assert affinity.put_if_absent("T1", RouteRecord(handle=_handle()), ttl_seconds=60)
+
+    # The quietest failure of the three: touch() reports the refresh succeeded
+    # while EXPIRE has already removed the route the thread was pinned to.
+    assert affinity.touch("T1", ttl_seconds=0)
+    assert affinity.get("T1") is None

--- a/apps/worker/tests/test_run.py
+++ b/apps/worker/tests/test_run.py
@@ -8,12 +8,20 @@ CURIE_FAKE_MODEL must fail loudly instead of silently degrading to a fake.
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
+from pathlib import Path
 from typing import Any
 
 import pytest
 from curie_worker.config import WorkerConfig
-from curie_worker.run import _sandbox_client, _substrate_config, _supervise, main
+from curie_worker.run import (
+    _MAX_TUNABLE_SECONDS,
+    _sandbox_client,
+    _substrate_config,
+    _supervise,
+    main,
+)
 from curie_worker.sandbox import DockerSandboxClient, SubstrateConfig
 
 _SUB = SubstrateConfig(namespace="default", warm_pool="pool")
@@ -77,6 +85,194 @@ def test_valkey_socket_timeout_exceeds_the_block_interval() -> None:
     # quiet across any read_block_ms tuning.
     cfg = WorkerConfig()
     assert cfg.valkey_socket_timeout_s > cfg.read_block_ms / 1000
+
+
+# --- #1388: the three operator-tunable seconds knobs are bounded at both ends ---
+#
+# Every assertion below goes through _substrate_config, the loader build() calls
+# at run.py:180 -- never through whatever private helper implements the bound.
+# A test bound to that helper would still pass if the helper were disconnected
+# from the loader, which is the regression these exist to catch.
+
+# The documented ceiling, 365 days. Duplicated as a JSON Schema literal in
+# charts/curie/values.schema.json; the accept/reject pair below is one half of
+# the four-assertion net that keeps the two literals from drifting apart (the
+# chart half is assertions (e) and (h) of
+# charts/curie/ci/worker-ttl-bounds-assertions.sh).
+_MAX_SECONDS = "31536000"
+_OVER_MAX_SECONDS = "31536001"
+
+
+def test_substrate_config_defaults_unchanged_by_the_bounds_guard() -> None:
+    # Full frozen-dataclass equality rather than field-by-field: it pins EVERY
+    # field at once, so bounding the three knobs cannot quietly move a default
+    # for the installs that set nothing.
+    assert _substrate_config({}) == SubstrateConfig(
+        namespace="default", warm_pool="curie-runner-pool"
+    )
+
+
+@pytest.mark.parametrize(
+    ("var", "raw"),
+    [
+        ("CURIE_ROUTE_TTL_SECONDS", "0"),
+        ("CURIE_ROUTE_TTL_SECONDS", "-1"),
+        ("CURIE_ROUTE_TTL_SECONDS", "-5"),
+        ("CURIE_SUSPENDED_ROUTE_TTL_SECONDS", "0"),
+        ("CURIE_SUSPENDED_ROUTE_TTL_SECONDS", "-1"),
+        ("CURIE_SUSPENDED_ROUTE_TTL_SECONDS", "-5"),
+        ("CURIE_CLAIM_TIMEOUT_SECONDS", "0"),
+        ("CURIE_CLAIM_TIMEOUT_SECONDS", "-1"),
+    ],
+)
+def test_substrate_config_refuses_a_non_positive_knob(var: str, raw: str) -> None:
+    # A non-positive value boots healthy today and fails on the FIRST message,
+    # unclassified: route_ttl 0 makes AffinityStore.put_if_absent issue
+    # SET ... NX EX 0, which real Valkey refuses. The refusal must name the env
+    # var so an operator can act on it without reading the traceback.
+    with pytest.raises(ValueError) as exc:
+        _substrate_config({var: raw})
+    assert var in str(exc.value)
+    # repr(raw), not raw: the bare "0" params are a substring of the 31536000 in
+    # the message's range text, so `raw in ...` would pass against a message that
+    # never echoed the operator's value at all. The message formats with {raw!r},
+    # so the quoted form is exact for every param and appears nowhere else.
+    assert repr(raw) in str(exc.value)
+
+
+@pytest.mark.parametrize(
+    "var",
+    [
+        "CURIE_ROUTE_TTL_SECONDS",
+        "CURIE_SUSPENDED_ROUTE_TTL_SECONDS",
+        "CURIE_CLAIM_TIMEOUT_SECONDS",
+    ],
+)
+def test_substrate_config_refuses_above_the_documented_maximum(var: str) -> None:
+    with pytest.raises(ValueError) as exc:
+        _substrate_config({var: _OVER_MAX_SECONDS})
+    assert var in str(exc.value)
+    assert _OVER_MAX_SECONDS in str(exc.value)
+
+
+@pytest.mark.parametrize(
+    ("var", "field", "expected"),
+    [
+        ("CURIE_ROUTE_TTL_SECONDS", "route_ttl_seconds", 31536000),
+        ("CURIE_SUSPENDED_ROUTE_TTL_SECONDS", "suspended_route_ttl_seconds", 31536000),
+        ("CURIE_CLAIM_TIMEOUT_SECONDS", "claim_timeout_seconds", 31536000.0),
+    ],
+)
+def test_substrate_config_accepts_exactly_the_documented_maximum(
+    var: str, field: str, expected: float
+) -> None:
+    # The accept side of the boundary. Paired with the refusal above, it proves
+    # the bound is inclusive at 31536000 and not off by one, and it is what stops
+    # the Python constant and the chart schema's `maximum` from drifting apart.
+    assert getattr(_substrate_config({var: _MAX_SECONDS}), field) == expected
+
+
+def test_chart_schema_bounds_match_the_python_bound() -> None:
+    # The direct pin on the cross-language seam AGENTS.md names: a deploy-time
+    # validator and the runtime loader that re-parses the same value. The
+    # behavioural boundary pairs above and assertions (e)/(h) of
+    # charts/curie/ci/worker-ttl-bounds-assertions.sh read the seam from two
+    # ends; this reads the chart's own JSON and compares the literals, so
+    # moving either side alone fails here rather than shipping a helm that
+    # accepts a value the worker refuses at boot (or the reverse).
+    #
+    # Resolved from this file's location, not the working directory, so it
+    # holds whether pytest runs from the repo root or from apps/worker.
+    repo_root = Path(__file__).resolve().parents[3]
+    schema_path = repo_root / "charts" / "curie" / "values.schema.json"
+    worker = json.loads(schema_path.read_text())["properties"]["worker"]["properties"]
+    drift = (
+        f"{schema_path} and _MAX_TUNABLE_SECONDS in curie_worker/run.py have "
+        f"drifted apart. They are the same bound expressed in two languages and "
+        f"must move together: helm refuses the value at install time, the worker "
+        f"refuses it at boot, and changing one alone makes a chart the worker "
+        f"will not start under."
+    )
+    for knob in ("claimTimeoutSeconds", "routeTtlSeconds", "suspendedRouteTtlSeconds"):
+        maximum = worker[knob]["maximum"]
+        exclusive_minimum = worker[knob]["exclusiveMinimum"]
+        # isinstance(True, int) is True in Python, so a draft-4 style rewrite of
+        # the schema ("minimum": 0, "exclusiveMinimum": false -- which under
+        # draft-4 semantics legalizes the value 0, exactly what this branch
+        # exists to forbid) would satisfy `== 0` / `== _MAX_TUNABLE_SECONDS`
+        # without this bool exclusion, since False == 0 and (depending on the
+        # rewrite) True could stand in for a truthy bound. Require a real
+        # number, not a bool wearing one.
+        assert (
+            isinstance(exclusive_minimum, (int, float))
+            and not isinstance(exclusive_minimum, bool)
+            and exclusive_minimum == 0
+        ), f"{knob}: {drift}"
+        assert (
+            isinstance(maximum, (int, float))
+            and not isinstance(maximum, bool)
+            and maximum == _MAX_TUNABLE_SECONDS
+        ), f"{knob}: {drift}"
+
+
+@pytest.mark.parametrize("raw", ["abc", "3600.5", ""])
+def test_substrate_config_refuses_an_unparseable_ttl_naming_the_env_var(raw: str) -> None:
+    # int("abc") already raises ValueError today, so `pytest.raises(ValueError)`
+    # alone would pass against the unguarded loader. The env-var-name assertion
+    # is the load-bearing half: the bare message
+    # "invalid literal for int() with base 10: 'abc'" names nothing an operator
+    # can act on. The "" case is the only gate on the helm explicit-null path --
+    # `--set worker.routeTtlSeconds=null` renders CURIE_ROUTE_TTL_SECONDS present
+    # with an empty value, which the chart schema structurally cannot see (pinned
+    # from the other end by assertion (i) of
+    # charts/curie/ci/worker-ttl-bounds-assertions.sh).
+    with pytest.raises(ValueError) as exc:
+        _substrate_config({"CURIE_ROUTE_TTL_SECONDS": raw})
+    assert "CURIE_ROUTE_TTL_SECONDS" in str(exc.value)
+
+
+@pytest.mark.parametrize("raw", ["inf", "-inf", "nan", "1e400"])
+def test_substrate_config_refuses_a_non_finite_claim_timeout(raw: str) -> None:
+    # The float-only failure mode a positivity check alone misses. float("inf")
+    # (and float("1e400"), which overflows to inf) makes
+    # `deadline = time.monotonic() + claim_timeout_seconds` at
+    # sandbox/substrate.py:217 never elapse, so the claim wait spins forever
+    # inside the per-thread lock. float("nan") is the mirror image: every `<`
+    # comparison against it is False, so the wait loop never runs and every
+    # claim fails instantly. Neither is caught by `value > 0`.
+    with pytest.raises(ValueError) as exc:
+        _substrate_config({"CURIE_CLAIM_TIMEOUT_SECONDS": raw})
+    assert "CURIE_CLAIM_TIMEOUT_SECONDS" in str(exc.value)
+    # The range check rejects all four on its own (inf fails the upper bound;
+    # -inf and nan fail `0 < value`), so `pytest.raises(ValueError)` plus the
+    # env-var name would pass with the non-finite branch deleted. Pinning the
+    # word "finite" is the only observable difference between the two
+    # implementations, so it is what makes this test discriminate.
+    assert "finite" in str(exc.value)
+    assert repr(raw) in str(exc.value)
+
+
+@pytest.mark.parametrize(
+    "var",
+    [
+        "CURIE_ROUTE_TTL_SECONDS",
+        "CURIE_SUSPENDED_ROUTE_TTL_SECONDS",
+        "CURIE_CLAIM_TIMEOUT_SECONDS",
+    ],
+)
+def test_substrate_config_refuses_a_huge_integer_literal(var: str) -> None:
+    # An operator typo of the leaning-on-the-zero-key kind. int() accepts an
+    # arbitrarily large literal, and math.isfinite() converts its argument to a
+    # C double, so on the int knobs an unnarrowed isfinite() raises
+    # OverflowError -- an ArithmeticError, not a ValueError -- which escapes the
+    # loader entirely and reaches the operator as "int too large to convert to
+    # float", naming no env var and no value. The refusal must stay a ValueError
+    # that names the knob, the same as every other out-of-range input.
+    raw = "9" * 400
+    with pytest.raises(ValueError) as exc:
+        _substrate_config({var: raw})
+    assert var in str(exc.value)
+    assert repr(raw) in str(exc.value)
 
 
 def test_docker_without_credential_or_fake_fails_loudly() -> None:

--- a/charts/curie/CLAUDE.md
+++ b/charts/curie/CLAUDE.md
@@ -69,6 +69,38 @@ component and rail detail in `charts/curie/README.md`.
   install/upgrade instead, and every `helm upgrade` rolls it to refresh the
   cache. Do not flip the runner to `Always` and do not disable the prewarm
   on `:latest`-tag clusters without accepting stale-image risk.
+- **`values.schema.json` is deliberately permissive, not a full contract.**
+  The chart had no values schema at all before issue #1388; Helm now
+  validates the ENTIRE coalesced values tree against `values.schema.json`
+  on lint, template, install, and upgrade -- not just the keys a given
+  operation touches. Because of that blast radius, the schema stays
+  draft-07 with no top-level `required` and no `additionalProperties:
+  false`, and it types only the three bounded worker knobs
+  (`worker.claimTimeoutSeconds`, `worker.routeTtlSeconds`,
+  `worker.suspendedRouteTtlSeconds`). Adding a `required` or
+  `additionalProperties: false` constraint, or typing any other existing
+  key, would fail every install whose values file happens not to match the
+  new shape -- broaden the schema only for a key you are prepared to
+  validate across every current values file and overlay.
+  - Known trap: `api.githubAppId` must stay untyped. It reaches the
+    coalesced values tree as a JSON string when `curie cluster
+    github-app` sets it via `--set-string` (`cli/src/github_app.rs`,
+    deliberately, to dodge Helm's float64 round-trip on a bare numeric
+    `--set`), but as a number if anyone sets it with a plain `--set` or an
+    unquoted YAML override. Typing it either way in the schema breaks the
+    other path.
+  - Corollary: `--set-string` on any of the three bounded worker knobs now
+    fails by design -- a JSON string violates `type: integer` /
+    `type: number` even though the rendered env var is itself a quoted
+    string.
+  - The schema is not the only gate. Helm drops nil-valued keys during
+    values coalescing before schema validation runs, so
+    `--set worker.routeTtlSeconds=null` is not caught by the schema; it
+    renders an empty `CURIE_ROUTE_TTL_SECONDS` env value and is caught
+    instead by the worker's own boot-time refusal. Both checks are
+    load-bearing -- the schema catches a bad value early for the common
+    cases, the worker's refusal is the backstop for the coalescing gap the
+    schema cannot see.
 
 ## Verify
 

--- a/charts/curie/ci/worker-ttl-bounds-assertions.sh
+++ b/charts/curie/ci/worker-ttl-bounds-assertions.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+#
+# Render-assertion test for the worker TTL/timeout bounds (issue #1388).
+#
+# `worker.routeTtlSeconds: 0` is valid YAML, renders cleanly, installs green and
+# passes readiness -- and then fails on the FIRST message, because it reaches
+# Valkey as `SET ... NX EX 0`, which raises `invalid expire time in 'set'
+# command`. That exception is not classified by the kernel, so the turn hangs,
+# the entry is re-delivered to dead-letter, and every attempt leaks a sandbox.
+# `values.schema.json` makes helm refuse the value at install/template time so it
+# never reaches worker env at all. Nine assertions:
+#
+#   (a) POSITIVE, defaults: the render SUCCEEDS and the worker Deployment
+#       carries the three env vars at their shipped defaults.
+#   (b) POSITIVE, valid overrides: legitimate tuning (300 / 7200 / 45, the
+#       literals #1382's own tests use) still reaches worker env. This is the
+#       assertion that catches a schema so strict it refuses real operation.
+#   (c) NEGATIVE, zero: each of the three knobs at 0 fails the render.
+#   (d) NEGATIVE, negative: -5 fails the render, for each of the three knobs.
+#   (e) NEGATIVE, over the documented maximum: MAX + 1 fails the render, for
+#       each of the three knobs. MAX (31536000, one year in seconds) is
+#       defined once below and every executable assertion below derives from
+#       it; this header states the literal once and does not restate it.
+#   (f) NEGATIVE, non-integer TTL: 3600.5 fails the render for routeTtlSeconds
+#       and suspendedRouteTtlSeconds, proving `type: integer` is doing work. A
+#       YAML float renders through `| quote` as "4.47597e+06" for larger values
+#       -- the exact class documented at ci/github-app-credential-assertions.sh:11.
+#       claimTimeoutSeconds is `type: number`, not `integer`, so the same
+#       fractional shape is LEGAL there; (f) also pins that 45.5 renders and
+#       reaches worker env unrefused, so the integer/number split stays real.
+#   (g) BLAST RADIUS: every values combination helm-ci already exercises still
+#       lints and renders clean with the schema present. A chart-root
+#       values.schema.json is validated against the WHOLE coalesced values tree
+#       on lint/template/install/upgrade, so an over-specified schema breaks
+#       every install. This is the regression net for that.
+#   (h) POSITIVE, at max: MAX renders, for each of the three knobs. The
+#       accept side of the boundary. Without it a schema `maximum` that
+#       drifted BELOW MAX would still satisfy (e) while the worker's
+#       Python bound still accepted the value --
+#       the cross-language divergence the paired literal exists to prevent. The
+#       Python twin is test_substrate_config_accepts_exactly_the_documented_maximum
+#       in apps/worker/tests/test_run.py.
+#   (i) OBSERVED-BEHAVIOR PIN, explicit null: `--set worker.routeTtlSeconds=null`
+#       exits 0 and renders CURIE_ROUTE_TTL_SECONDS PRESENT WITH AN EMPTY VALUE
+#       (a bare `value:`, which the API server hands the container as "").
+#       Helm drops nil keys during values coalescing, which happens BEFORE schema
+#       validation, so no `type`, `exclusiveMinimum` or `not: {type: null}` can
+#       ever reach this case. This path is closed only by the worker loader's
+#       empty-string refusal, asserted from the other end by the "" case of
+#       test_substrate_config_refuses_an_unparseable_ttl_naming_the_env_var. (i)
+#       and that case are one seam read from two ends; deleting either removes
+#       half of the only gate on the null path.
+#
+# WORDING IS NOT ASSERTED, AND MUST NOT BECOME ASSERTED. Every negative below
+# checks only (1) that helm exited non-zero and (2) that the captured output
+# contains the bare knob name. The failure text comes from helm's own bundled
+# JSON-Schema validator, whose wording changed between the CI-pinned helm and
+# current helm while the pass/fail outcomes stayed identical:
+#
+#   helm 3.16.4 (the CI pin, .github/workflows/helm-ci.yaml:41):
+#     - worker.routeTtlSeconds: Must be greater than 0
+#     - worker.routeTtlSeconds: Invalid type. Expected: integer, given: string
+#   helm 3.20.0:
+#     - at '/worker/routeTtlSeconds': exclusiveMinimum: got 0, want 0
+#     - at '/worker/routeTtlSeconds': got string, want integer
+#
+# The bare knob name is the only token common to both. Do NOT "improve" these
+# into greps for `Must be greater than`, `exclusiveMinimum`, `Invalid type`,
+# `want integer`, or the `- <path>: ` prefix shape: a wording-locked assertion
+# passes on the author's machine and fails in CI, or the reverse, for a reason
+# that has nothing to do with the chart.
+#
+# Runnable locally (from anywhere) and from CI. Fails loudly.
+set -euo pipefail
+
+CHART="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fail() { echo "FAIL [$1] $2" >&2; exit 1; }
+render() { helm template curie "$CHART" "$@" 2>&1; }
+
+# Reads the worker Deployment's env list by NAME out of a render, rather than
+# grepping: a value moving between containers, or a second container growing a
+# same-named var, is invisible to a grep and caught here.
+WORKER_ENV_PY="$(
+  cat <<'PY'
+import sys, yaml
+want = sys.argv[2:]
+docs = [d for d in yaml.safe_load_all(open(sys.argv[1])) if d]
+deploys = [
+    d for d in docs
+    if d.get("kind") == "Deployment"
+    and (d["metadata"].get("labels") or {}).get("app.kubernetes.io/component") == "worker"
+]
+if len(deploys) != 1:
+    raise SystemExit(f"expected exactly one worker Deployment, rendered {len(deploys)}")
+containers = deploys[0]["spec"]["template"]["spec"]["containers"]
+env = {}
+for c in containers:
+    for e in c.get("env", []):
+        env[e["name"]] = e.get("value")
+for pair in want:
+    name, _, expected = pair.partition("=")
+    if name not in env:
+        raise SystemExit(f"{name} is not in the worker env (got {sorted(env)})")
+    got = env[name]
+    if expected == "":
+        # "present with an empty value". `nil | quote` emits a bare `value:`,
+        # which parses as null and which Kubernetes hands the container as an
+        # empty string; both spellings are the same thing to the worker.
+        if got not in (None, ""):
+            raise SystemExit(f"{name} rendered {got!r}, expected it present and empty")
+    elif got != expected:
+        raise SystemExit(f"{name} rendered {got!r}, expected {expected!r}")
+PY
+)"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# Renders into a file and asserts the named env vars. Fails the assertion when
+# the render itself fails, so a broken schema can never make a content check
+# pass vacuously.
+assert_env() {
+  local letter="$1" out="$TMP/$1.yaml"
+  shift
+  local -a sets=()
+  while [ "$1" != "--" ]; do sets+=("$1"); shift; done
+  shift
+  if ! helm template curie "$CHART" -s templates/worker.yaml "${sets[@]}" >"$out" 2>&1; then
+    fail "$letter" "the render FAILED; it must succeed
+  $(head -5 "$out")"
+  fi
+  local msg
+  if ! msg="$(python3 -c "$WORKER_ENV_PY" "$out" "$@" 2>&1)"; then
+    fail "$letter" "$msg"
+  fi
+}
+
+# Asserts a render fails AND that its output names the knob. Captured rather
+# than piped: helm exits non-zero here by design, and under `set -o pipefail`
+# a pipeline would fail even when the check succeeds.
+assert_refused() {
+  local letter="$1" knob="$2"
+  shift 2
+  local out
+  if out="$(render "$@" 2>&1)"; then
+    fail "$letter" "helm accepted $* -- the schema must refuse it"
+  fi
+  grep -q "$knob" <<<"$out" \
+    || fail "$letter" "the refusal of $* does not name $knob
+  $(head -5 <<<"$out")"
+}
+
+# (a) The DEFAULT render must SUCCEED before anything else is asserted. A schema
+#     with a syntax error fails every render, which would make every negative
+#     below pass for the wrong reason -- the exact trap
+#     ci/api-ingress-assertions.sh:31-34 documents having fallen into. The
+#     negatives below render the WHOLE chart (via `render()`, no `-s`), so the
+#     guard must cover that same render shape, not just the worker template.
+helm template curie "$CHART" >/dev/null 2>&1 \
+  || fail a "the full-chart default render FAILED; every negative below would pass for the wrong reason"
+assert_env a -- \
+  CURIE_CLAIM_TIMEOUT_SECONDS=90 \
+  CURIE_ROUTE_TTL_SECONDS=3600 \
+  CURIE_SUSPENDED_ROUTE_TTL_SECONDS=86400
+
+# (b)
+assert_env b \
+  --set worker.routeTtlSeconds=300 \
+  --set worker.suspendedRouteTtlSeconds=7200 \
+  --set worker.claimTimeoutSeconds=45 \
+  -- \
+  CURIE_CLAIM_TIMEOUT_SECONDS=45 \
+  CURIE_ROUTE_TTL_SECONDS=300 \
+  CURIE_SUSPENDED_ROUTE_TTL_SECONDS=7200
+
+# The documented ceiling, one year in seconds. Defined once; every executable
+# assertion below that touches the bound (c/d/e via the loop, h) derives from
+# this variable rather than restating the literal.
+MAX=31536000
+OVER_MAX=$((MAX + 1))
+
+# (c), (d), (e). All three knobs refuse 0, -5 and OVER_MAX identically, so the
+# per-knob repetition carries no information; the loop keeps the coverage and
+# makes an added knob a one-word edit. (f) below is NOT folded in with them,
+# because its behaviour genuinely differs per knob.
+for knob in routeTtlSeconds suspendedRouteTtlSeconds claimTimeoutSeconds; do
+  assert_refused c "$knob" --set "worker.$knob=0"
+  assert_refused d "$knob" --set "worker.$knob=-5"
+  assert_refused e "$knob" --set "worker.$knob=$OVER_MAX"
+done
+
+# (f) `--set-json`, not `--set`: helm's `--set` parser hands 3600.5 to the
+# schema as the STRING "3600.5", which every type here (integer or number)
+# refuses -- that would pass this assertion even if `type: integer` were
+# edited away, since a string never satisfies `type: number` either.
+# `--set-json` delivers a genuine JSON number, so the refusal is actually
+# about `type: integer` and not about `--set`'s own string coercion.
+assert_refused f routeTtlSeconds --set-json worker.routeTtlSeconds=3600.5
+assert_refused f suspendedRouteTtlSeconds --set-json worker.suspendedRouteTtlSeconds=3600.5
+# claimTimeoutSeconds is `type: number`, so the same fractional JSON number is
+# legal there.
+assert_env f --set-json worker.claimTimeoutSeconds=45.5 -- CURIE_CLAIM_TIMEOUT_SECONDS=45.5
+
+# (g) BLAST RADIUS.
+helm lint "$CHART" >/dev/null 2>&1 \
+  || fail g "helm lint on defaults broke with the schema present"
+helm lint "$CHART" -f "$CHART/values-dev.yaml" >/dev/null 2>&1 \
+  || fail g "helm lint -f values-dev.yaml broke with the schema present"
+helm lint "$CHART" -f "$CHART/values-dev.yaml" -f "$CHART/values-e2e-nogvisor.yaml" \
+  >/dev/null 2>&1 \
+  || fail g "helm lint -f values-dev.yaml -f values-e2e-nogvisor.yaml broke"
+helm template curie "$CHART" -f "$CHART/values-e2e-harness.yaml" >/dev/null 2>&1 \
+  || fail g "helm template -f values-e2e-harness.yaml broke with the schema present"
+# api.githubAppId is an integer in values.yaml and a STRING when the CLI sets it
+# (cli/src/github_app.rs:52 uses --set-string). Typing it either way breaks one
+# of the two paths, so the schema must leave it untyped; this proves it did.
+helm template curie "$CHART" \
+  --set-string api.githubAppId=1234567 \
+  --set api.githubAppPrivateKey=X >/dev/null 2>&1 \
+  || fail g "the --set-string api.githubAppId path broke; the schema over-typed it"
+
+# (h) One chart key paired with the env var it must reach, so the maximum
+# appears once per side of the render rather than six times.
+for pair in \
+  routeTtlSeconds:CURIE_ROUTE_TTL_SECONDS \
+  suspendedRouteTtlSeconds:CURIE_SUSPENDED_ROUTE_TTL_SECONDS \
+  claimTimeoutSeconds:CURIE_CLAIM_TIMEOUT_SECONDS; do
+  assert_env h --set "worker.${pair%%:*}=$MAX" -- "${pair##*:}=$MAX"
+done
+
+# (i)
+assert_env i --set worker.routeTtlSeconds=null -- CURIE_ROUTE_TTL_SECONDS=
+
+echo "worker-ttl-bounds-assertions: all nine assertions passed"

--- a/charts/curie/values.schema.json
+++ b/charts/curie/values.schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "worker": {
+      "type": "object",
+      "properties": {
+        "claimTimeoutSeconds": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "maximum": 31536000,
+          "description": "Seconds claim() waits for a cold sandbox create to bind. Must be greater than 0 and at most 31536000 (one year). 0 or a negative value installs green and then fails on every turn, so helm refuses it here rather than letting it reach worker env (issue #1388)."
+        },
+        "routeTtlSeconds": {
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "maximum": 31536000,
+          "description": "Seconds a thread pins its sandbox after its last message. Must be greater than 0 and at most 31536000 (one year). Integer rather than number on purpose: a YAML float renders through the template's `| quote` as scientific notation for larger values (the class documented at ci/github-app-credential-assertions.sh:11), which the worker then cannot parse."
+        },
+        "suspendedRouteTtlSeconds": {
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "maximum": 31536000,
+          "description": "Seconds a route suspended awaiting an approval pins its sandbox. Must be greater than 0 and at most 31536000 (one year). Integer rather than number for the same reason as routeTtlSeconds: a YAML float renders through `| quote` as scientific notation for larger values (ci/github-app-credential-assertions.sh:11)."
+        }
+      }
+    }
+  }
+}

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -768,6 +768,16 @@ worker:
   # bundle-fetch/extract init containers + runner boot + readiness) to bind
   # before giving up. Must stay below the worker's per-thread lock TTL (120s) so
   # the lock never lapses mid-claim; raise it only on a slow cluster.
+  #
+  # Must be greater than 0 and at most 31536000 (one year); values.schema.json
+  # makes helm refuse anything outside that at install/template time. 0 is
+  # accepted by YAML and renders fine, and makes every claim time out
+  # instantly -- unlike the two TTLs below, that degrades cleanly (a
+  # ClaimTimeoutError, caught and retried within bounds) rather than hanging
+  # and leaking, but it is never a value anyone means. Bounded here for
+  # parity with its siblings, read by the same loader, and because a
+  # non-positive or absurd claim timeout is a configuration error worth
+  # refusing at install time rather than discovering as a per-turn failure.
   claimTimeoutSeconds: 90
   # How long a thread PINS its sandbox after its last message. This is the term
   # that decides how MANY sandboxes exist at once, and it was the one an
@@ -785,11 +795,21 @@ worker:
   #
   # Lower it on a small node or a low-conversation-depth bot; raise it where
   # threads are genuinely conversational and cold creates are expensive.
+  #
+  # Must be greater than 0 and at most 31536000 (one year); values.schema.json
+  # makes helm refuse anything outside that at install/template time, because 0
+  # is accepted by YAML, renders fine, and used to boot healthy and then hang
+  # every turn while leaking a sandbox per attempt (#1388).
   routeTtlSeconds: 3600
   # The same, for a route suspended awaiting an approval -- it waits far longer
   # because the human may answer tomorrow. Exposed alongside the live TTL
   # because capping one while the other still pins a sandbox for a day would
   # only move the accumulation.
+  #
+  # Must be greater than 0 and at most 31536000 (one year); values.schema.json
+  # makes helm refuse anything outside that at install/template time, because 0
+  # is accepted by YAML, renders fine, and used to boot healthy and then hang
+  # every turn while leaking a sandbox per attempt (#1388).
   suspendedRouteTtlSeconds: 86400
   # The Slack assistant-thread "shimmer" (#1182): the animated caption Slack
   # shows next to the app's name while a turn runs. On by default -- the


### PR DESCRIPTION
`worker.routeTtlSeconds: 0` booted healthy and passed readiness, then failed on the first message: `AffinityStore.put_if_absent` issues `SET ... NX EX 0`, which Valkey rejects with a `ResponseError` the kernel does not classify. It escaped `process_event`, the consumer swallowed it, and the entry re-delivered until dead-letter, leaking a bound claim and its sandbox on every attempt.

Bounded at both ends, because the two gates catch different things and neither is redundant:

- **Boot refusal** in the worker's env loader for `CURIE_ROUTE_TTL_SECONDS`, `CURIE_SUSPENDED_ROUTE_TTL_SECONDS` and `CURIE_CLAIM_TIMEOUT_SECONDS`. Rejects non-positive, non-finite, unparseable, empty and over-maximum values with a `ValueError` naming the env var and the offending value. Accepted range is greater than 0 and at most 31536000 seconds (one year).
- **`charts/curie/values.schema.json`**, the chart's first values schema, so helm refuses the value before it renders. Deliberately permissive: draft-07, no `required`, no `additionalProperties: false`, and it types only the three bounded knobs, because helm validates the entire coalesced values tree against it.
- **A render assertion** covering both directions for every knob the schema constrains, wired into helm CI.

## Verification

Both halves proven by execution, not by reading.

The real worker against the live compose stack:

| env | outcome |
|---|---|
| unset | `worker starting`, stays up |
| `CURIE_ROUTE_TTL_SECONDS=0` | exit 1, `ValueError: CURIE_ROUTE_TTL_SECONDS must be greater than 0 and at most 31536000 seconds (365 days), got '0'` |
| `=-5` | exit 1, same shape |
| `CURIE_SUSPENDED_ROUTE_TTL_SECONDS=0` | exit 1, names that var |
| `CURIE_CLAIM_TIMEOUT_SECONDS=0` / `=inf` | exit 1, names that var |
| `CURIE_ROUTE_TTL_SECONDS=` (empty) | exit 1, names the var |
| `=300` | `worker starting`, stays up |

`helm template charts/curie --set worker.routeTtlSeconds=0` exits non-zero naming `routeTtlSeconds`. The whole assertion set passes under both the CI-pinned helm 3.16.4 and 3.20.0; the two versions word schema errors differently, so the assertions grep only the bare knob name.

A bounded value still reaches Valkey correctly: through the real `AffinityStore`, `put_if_absent` writes the route at a 300s TTL and `touch` refreshes it without dropping the key, the two operations that failed at TTL 0.

## Scope notes

`claimTimeoutSeconds` is bounded alongside the two TTLs although the issue names only the TTLs. All three are read by the same loader; guarding two of three ships a half guard and leaves a bare `float()` beside two guarded reads. Its comment states its own reason rather than the hang-and-leak, which that knob does not have.

`--set-string` on the three bounded knobs now fails, since a JSON string violates `type: integer`/`number`. No in-repo caller does this. An install carrying one of these at `0` will now fail `helm upgrade`; that install is already broken today, so failing loudly at upgrade is the better outcome.

Helm drops nil keys during coalescing before schema validation, so `--set worker.routeTtlSeconds=null` is not caught by the schema. It renders an empty env value and is caught by the boot refusal. That is the sharpest reason both gates are needed.

## Deliberately out of scope, worth follow-up issues

1. `kernel.py`'s `_attempt` catch tuple, its `SandboxError`-only catch in `_pause_for_approval`, and the broad handler in `consumer.py` that swallows the escape. Sacred module; an unclassified substrate exception should escalate rather than silently re-deliver to dead-letter.
2. `substrate.py`'s `put_if_absent` sits outside the `try/except` that deletes the claim on failure, so any raise there leaks the claim and its sandbox. This change removes the trigger, not the amplifier.
3. `CURIE_RUNNER_PORT` is the fourth bare `int()` in the same function and is unguarded on both sides: no bound in the loader and no schema property for `agentSandbox.runner.port`. Different failure class (loud and immediate), so deferred, but it is now the odd one out in a function whose other three reads name the knob on refusal.
4. `WorkerConfig.lock_ttl_ms` and `idempotency_ttl_s` are env-settable with no bound and reach a Valkey `PX` and an `ex=` respectively. Same defect class as this issue.
5. A cross-config check that `claim_timeout_seconds` stays under `lock_ttl_ms`. A one-year claim timeout is inside this bound but violates the invariant the code documents in prose.

Closes #1388
