### PR TITLE
Name the guided path from doctor, and from the non-TTY error

### DIFF
--- a/cli/schema/doctor.schema.json
+++ b/cli/schema/doctor.schema.json
@@ -24,9 +24,15 @@
             "type": "string",
             "description": "Stable identifier, for a consumer gating on one specific check."
           },
-          "title": { "type": "string" },
+          "title": {
+            "type": "string"
+          },
           "state": {
-            "enum": ["ok", "missing", "not_applicable"],
+            "enum": [
+              "ok",
+              "missing",
+              "not_applicable"
+            ],
             "description": "`not_applicable` means the check does not apply at this install's rung, not that it failed."
           },
           "detail": {
@@ -38,9 +44,26 @@
             "description": "The exact command that resolves it. Absent when there is nothing to fix."
           }
         },
-        "required": ["id", "title", "state", "detail"]
+        "required": [
+          "id",
+          "title",
+          "state",
+          "detail"
+        ]
       }
+    },
+    "guidance": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "Present only when two or more checks are missing: a pointer to the guided walkthrough (`curie` with no arguments). Null for zero or one gap, where the per-check `fix` is the whole answer and a walkthrough would be more work than the fix."
     }
   },
-  "required": ["summary", "ready", "checks"]
+  "required": [
+    "summary",
+    "ready",
+    "checks",
+    "guidance"
+  ]
 }

--- a/cli/src/doctor.rs
+++ b/cli/src/doctor.rs
@@ -289,6 +289,28 @@ pub fn evaluate(f: &Facts) -> Vec<Check> {
     out
 }
 
+/// Point at the guided path when there is more than one thing to fix.
+///
+/// A single missing item needs no signpost: the `→ fix` line beside it is the
+/// whole answer. Several is different -- the fixes have an order, some depend
+/// on values the operator has not collected yet, and reading eight lines and
+/// sequencing them is exactly the work the guided workflow already does.
+///
+/// `curie` with no arguments opens that workflow. It is discoverable in
+/// principle and invisible in practice, because a first-time user reaching for
+/// help types `curie --help` and gets an alphabetical list of eighteen verbs
+/// with `interactive` eleventh.
+pub fn guidance(checks: &[Check]) -> Option<String> {
+    let missing = checks.iter().filter(|c| c.state == State::Missing).count();
+    if missing < 2 {
+        return None;
+    }
+    Some(format!(
+        "{missing} things to set up. Run `curie` with no arguments for a guided \
+         walkthrough, or fix them one at a time with the commands above."
+    ))
+}
+
 /// The one-line verdict: what this install can do right now.
 ///
 /// Deliberately capability-shaped rather than a count. "3 of 8 checks passed"
@@ -349,6 +371,61 @@ mod tests {
             bundle_name: Some("my-agent".into()),
             ..Default::default()
         }
+    }
+
+    fn checks_with(missing: usize) -> Vec<Check> {
+        (0..missing)
+            .map(|i| Check {
+                id: "x",
+                title: "t",
+                state: State::Missing,
+                detail: format!("{i}"),
+                fix: None,
+            })
+            .collect()
+    }
+
+    /// One gap needs no signpost -- the `-> fix` beside it is the whole answer.
+    /// Sending someone to a TUI to set one environment variable is worse than
+    /// telling them the variable.
+    #[test]
+    fn a_single_gap_does_not_advertise_the_walkthrough() {
+        assert_eq!(guidance(&checks_with(0)), None);
+        assert_eq!(guidance(&checks_with(1)), None);
+    }
+
+    /// Several gaps have an ORDER and depend on values not yet collected, which
+    /// is the work the guided workflow exists to do.
+    #[test]
+    fn several_gaps_name_the_guided_path() {
+        let hint = guidance(&checks_with(3)).expect("should advertise");
+        assert!(hint.contains("3 things"), "{hint}");
+        assert!(hint.contains("`curie`"), "must name the command: {hint}");
+        assert!(
+            hint.contains("one at a time"),
+            "must leave the manual path open: {hint}"
+        );
+    }
+
+    /// A check that is NotApplicable is not a gap. Counting it would advertise
+    /// a walkthrough for a cluster the operator does not have.
+    #[test]
+    fn checks_that_do_not_apply_are_not_counted_as_gaps() {
+        let mut checks = checks_with(1);
+        for i in 0..4 {
+            checks.push(Check {
+                id: "n",
+                title: "t",
+                state: State::NotApplicable,
+                detail: format!("{i}"),
+                fix: None,
+            });
+        }
+        assert_eq!(
+            guidance(&checks),
+            None,
+            "one real gap plus four n/a is one gap"
+        );
     }
 
     /// Cluster, release, Slack and clone credential all in place.
@@ -794,6 +871,7 @@ impl crate::ui::CliOutput for DoctorOutput {
             "summary": self.summary,
             "ready": self.checks.iter().all(|c| c.state != State::Missing),
             "checks": self.checks,
+            "guidance": guidance(&self.checks),
         })
     }
 
@@ -811,6 +889,9 @@ impl crate::ui::CliOutput for DoctorOutput {
         }
         ui.payload_plain("");
         ui.payload_plain(&self.summary);
+        if let Some(hint) = guidance(&self.checks) {
+            ui.payload_plain(&hint);
+        }
     }
 }
 

--- a/cli/src/interactive.rs
+++ b/cli/src/interactive.rs
@@ -76,7 +76,8 @@ struct App {
 pub async fn run() -> Result<()> {
     if !io::stdin().is_terminal() || !io::stdout().is_terminal() {
         return Err(crate::exit::usage(
-            "curie interactive requires an interactive terminal; use the regular curie subcommands in non-interactive sessions",
+            "curie interactive requires an interactive terminal. In a non-interactive session, \
+             run `curie doctor` to see what is set up and the command that fixes each gap.",
         ));
     }
     let mut app = App::new();


### PR DESCRIPTION
Second of three onboarding changes.

## The finding that reshaped this

I originally planned to add signposting because I believed bare `curie` printed a help wall. **It doesn't** — `main.rs:1906` is `None => interactive::run()`. Bare `curie` already opens the guided workflow browser, including *"How to deploy to Slack"*.

So the gap isn't missing capability. It's that the guided path is **discoverable in principle and invisible in practice**: a first-time user reaching for help types `curie --help` and gets eighteen verbs alphabetically, with `interactive` eleventh.

Two places already know the operator is stuck and said nothing.

## 1. `doctor` names it — but only when it's worth it

```
No bundle here. Start with `curie init my-agent`.
2 things to set up. Run `curie` with no arguments for a guided walkthrough,
or fix them one at a time with the commands above.
```

**Threshold is two.** A single gap needs no signpost — the `→ fix` beside it is the whole answer, and sending someone into a TUI to set one environment variable is worse than telling them the variable. Several gaps are different: the fixes have an order, some depend on values not yet collected, and sequencing them is the work the workflow does.

**A `NotApplicable` check is not a gap.** Counting it would advertise a walkthrough for a cluster the operator doesn't have — which is how a helpful line becomes noise everyone learns to skip. A test pins that one real gap plus four n/a stays quiet.

## 2. The non-TTY error names a command

Before: *"use the regular curie subcommands in non-interactive sessions"* — without naming one.

After: it names `curie doctor`, which reports what's set up and the fix for each gap. That's the genuinely useful thing in a session where the TUI can't run.

## Also

`guidance` is in the `--json` payload, so an agent consumer sees the same signal rather than a human-only string. The committed schema is updated — without it the contract test rejects the new key.

**Falsified** by removing the two-gap threshold: both the single-gap and not-applicable tests fail. `fmt`, `clippy --all-targets -D warnings`, 38 suites, docs gate clean.