### PR TITLE
Override nanoid past GHSA-2v37-7h3g-55p8

### DIFF
--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -44,7 +44,8 @@
   },
   "pnpm": {
     "overrides": {
-      "postcss": ">=8.5.23"
+      "postcss": ">=8.5.23",
+      "nanoid": "^3.3.17"
     }
   }
 }

--- a/apps/ui/pnpm-lock.yaml
+++ b/apps/ui/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   postcss: '>=8.5.23'
+  nanoid: ^3.3.17
 
 importers:
 
@@ -1024,8 +1025,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -2302,7 +2303,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   natural-compare@1.4.0: {}
 
@@ -2353,7 +2354,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 


### PR DESCRIPTION
`pnpm audit` started failing **every** PR on a high-severity advisory in `nanoid`, reached transitively through `postcss`. Surfaced on #1400, which touches no JavaScript at all.

Nothing depends on `nanoid` directly, so the fix is an override — the same mechanism, in the same block, that `postcss` itself already uses here for the same reason.

## `^3.3.17`, not `>=3.3.17`

The open range is what I wrote first, and pnpm resolved it to **6.0.1** — a major bump of a transitive dependency, to fix an advisory whose patched version is 3.3.17.

That's a far larger change than the problem calls for, and nothing in the tree was asked whether it wants 6.x. The caret keeps the fix inside the line the advisory names; the lockfile lands on **3.3.18**.

## Its own PR

This blocks every open PR, so it should be mergeable immediately rather than riding along with a change that needs a human to look at a TUI.

`pnpm audit --audit-level high` clean · `pnpm build` succeeds · 144 UI tests pass.