### PR TITLE
Let connectors receive a secret as a file, not only as an env var

### DIFF
--- a/packages/plugin-format/src/plugin_format/connector_render.py
+++ b/packages/plugin-format/src/plugin_format/connector_render.py
@@ -31,6 +31,7 @@ not write.
 from __future__ import annotations
 
 import hashlib
+from pathlib import PurePosixPath
 from typing import Any
 
 from .connectors import ConnectorSpec
@@ -218,6 +219,41 @@ def render_deployment(
                     },
                 }
             )
+    # secret_files project the SAME per-agent Secret as a file instead of an
+    # env var, for servers that authenticate from disk (#1402). One volume per
+    # file so each carries only its own key: a single volume with several items
+    # would put every credential in one directory, and a server that reads a
+    # directory would see the others.
+    volumes: list[dict[str, Any]] = []
+    volume_mounts: list[dict[str, Any]] = []
+    for index, (secret_key, mount_path) in enumerate(sorted(spec.secret_files.items())):
+        vol = f"secret-file-{index}"
+        volumes.append(
+            {
+                "name": vol,
+                "secret": {
+                    "secretName": secret_name,
+                    "items": [{"key": secret_key, "path": PurePosixPath(mount_path).name}],
+                    # 0400: readable by the container's user, nobody else. These
+                    # are credentials in a pod that already runs non-root with a
+                    # read-only rootfs.
+                    "defaultMode": 0o400,
+                    # Not optional, matching `secrets:` -- a missing key must
+                    # stop the pod rather than start a server that 401s on every
+                    # call.
+                    "optional": False,
+                },
+            }
+        )
+        volume_mounts.append(
+            {
+                "name": vol,
+                "mountPath": mount_path,
+                "subPath": PurePosixPath(mount_path).name,
+                "readOnly": True,
+            }
+        )
+
     return {
         "apiVersion": "apps/v1",
         "kind": "Deployment",
@@ -241,6 +277,7 @@ def render_deployment(
                             "image": spec.image,
                             "args": [substitute(a, subs) for a in spec.args],
                             "env": env,
+                            **({"volumeMounts": volume_mounts} if volume_mounts else {}),
                             "ports": [{"name": "http", "containerPort": spec.port}],
                             "securityContext": {
                                 "allowPrivilegeEscalation": False,
@@ -253,6 +290,7 @@ def render_deployment(
                             },
                         }
                     ],
+                    **({"volumes": volumes} if volumes else {}),
                 },
             },
         },

--- a/packages/plugin-format/src/plugin_format/connectors.py
+++ b/packages/plugin-format/src/plugin_format/connectors.py
@@ -137,11 +137,34 @@ class ConnectorSpec(BaseModel):
     # and 401s every call, the #1156 shape ADR-0094 exists to avoid.
     sealed_secrets: dict[str, str] = Field(default_factory=dict)
 
+    #   secret_files:                         Project a stored secret as a FILE
+    #     K8S_KUBECONFIG: /secrets/kubeconfig instead of an environment variable.
+    #
+    # Same stored secret, same resolution, same per-agent Secret -- only the
+    # delivery differs. It exists because `secrets:` renders a secretKeyRef and
+    # nothing else, so a server that authenticates from a FILE has no way in:
+    # kubeconfigs, TLS client certs, GCP service-account JSON, a CA bundle.
+    # `connectors.yaml` forbids extra keys and has no `command`, so a bundle
+    # cannot write $VAR out to a path itself either -- the credential was
+    # simply unreachable (#1402).
+    #
+    # Keyed by SECRET NAME so the same name cannot be projected to two paths,
+    # and so the key reads identically to `secrets:` -- a bundle moving from one
+    # to the other changes the delivery, not the credential.
+    #
+    # Mounted 0400 and read-only into a container that already runs as non-root
+    # with a read-only rootfs. Paths must be absolute and must not collide with
+    # each other; `/tmp` is refused because a server's scratch space is a poor
+    # place for a credential and an emptyDir there would shadow the mount.
+    secret_files: dict[str, str] = Field(default_factory=dict)
+
     def secret_names(self) -> list[str]:
         """Env var names this connector needs, any form."""
 
         named = [s if isinstance(s, str) else s.name for s in self.secrets]
-        return named + list(self.sealed_secrets)
+        # secret_files are resolved from the same store and land in the same
+        # per-agent Secret; only the projection differs, so they belong here.
+        return named + list(self.sealed_secrets) + list(self.secret_files)
 
     def resolved_secrets(self) -> list[str]:
         """Only the names Curie must resolve a VALUE for.
@@ -292,6 +315,58 @@ def validate_connectors(data: Any) -> tuple[ConnectorsFile | None, list[tuple[st
                     f"{where}: `unhosted_url` is the hosted form's fallback for tiers that "
                     "cannot run the image. A `url` connector is already reachable everywhere, "
                     "so this would never apply",
+                )
+            )
+        if spec.url and spec.secret_files:
+            errors.append(
+                (
+                    "connectors.remote_has_secret_files",
+                    f"{where}: `secret_files` project a file into a container Curie "
+                    "starts; a `url` connector is already running elsewhere, so the "
+                    "file would go nowhere",
+                )
+            )
+        seen_paths: dict[str, str] = {}
+        for sname, path in spec.secret_files.items():
+            if not path.startswith("/"):
+                errors.append(
+                    (
+                        "connectors.secret_file_relative_path",
+                        f"{where}: secret_files[{sname}] is {path!r}; the mount path must "
+                        "be absolute, because it is a container path and not relative to "
+                        "anything the bundle controls",
+                    )
+                )
+            # /tmp is a server's scratch space. A credential does not belong
+            # there, and an emptyDir mounted at /tmp would shadow the file.
+            if path == "/tmp" or path.startswith("/tmp/"):
+                errors.append(
+                    (
+                        "connectors.secret_file_in_tmp",
+                        f"{where}: secret_files[{sname}] mounts under /tmp, which is "
+                        "scratch space -- pick a dedicated path such as /secrets/...",
+                    )
+                )
+            if path in seen_paths:
+                errors.append(
+                    (
+                        "connectors.secret_file_path_collision",
+                        f"{where}: secret_files[{sname}] and secret_files"
+                        f"[{seen_paths[path]}] both mount at {path}; one would silently "
+                        "win and the other credential would never appear",
+                    )
+                )
+            seen_paths[path] = sname
+        overlap = set(spec.secret_files) & {
+            s if isinstance(s, str) else s.name for s in spec.secrets
+        }
+        for name in sorted(overlap):
+            errors.append(
+                (
+                    "connectors.secret_both_env_and_file",
+                    f"{where}: {name} is declared in both `secrets` and `secret_files`. "
+                    "Pick one delivery -- a credential in an env var AND on disk doubles "
+                    "the places it can leak from for no benefit",
                 )
             )
         if spec.image and spec.headers:

--- a/packages/plugin-format/tests/test_connector_render.py
+++ b/packages/plugin-format/tests/test_connector_render.py
@@ -418,3 +418,107 @@ def test_an_empty_sealed_blob_is_reported_on_its_own() -> None:
         {"connectors": {"grafana": {"image": "x", "sealed_secrets": {"TOKEN": "  "}}}}
     )
     assert "connectors.empty_sealed_value" in [code for code, _ in errors]
+
+
+# --- secret_files (#1402) ---------------------------------------------------
+#
+# `secrets:` renders a secretKeyRef and nothing else, so a server that
+# authenticates from a FILE -- a kubeconfig, a TLS client cert, GCP
+# service-account JSON -- had no way to receive its credential at all. These
+# pin the projection, and the guards that keep it from becoming a second, worse
+# way to leak one.
+
+FILE_SPEC = ConnectorSpec(
+    image="ghcr.io/containers/kubernetes-mcp-server:latest",
+    args=["--kubeconfig", "/secrets/kubeconfig", "--read-only"],
+    secret_files={"K8S_READONLY_KUBECONFIG": "/secrets/kubeconfig"},
+)
+
+
+def _file_dep(spec: ConnectorSpec) -> dict:
+    return r.render_deployment("acme-bot", "acme-bot", "acme-bot", "k8s", spec, "conn-secrets")
+
+
+def test_secret_file_lands_at_the_declared_path_not_a_directory() -> None:
+    # subPath is what makes the mount a FILE at exactly the declared path.
+    # Without it Kubernetes mounts a DIRECTORY there, and `--kubeconfig
+    # /secrets/kubeconfig` would open a directory and fail in a way that reads
+    # like a malformed credential.
+    mount = _file_dep(FILE_SPEC)["spec"]["template"]["spec"]["containers"][0]["volumeMounts"][0]
+    assert mount["mountPath"] == "/secrets/kubeconfig"
+    assert mount["subPath"] == "kubeconfig"
+    assert mount["readOnly"] is True
+
+
+def test_secret_file_reads_the_same_per_agent_secret_as_env_secrets() -> None:
+    # Same store, same Secret, same resolution -- only the delivery differs.
+    vol = _file_dep(FILE_SPEC)["spec"]["template"]["spec"]["volumes"][0]["secret"]
+    assert vol["secretName"] == "conn-secrets"
+    assert vol["items"] == [{"key": "K8S_READONLY_KUBECONFIG", "path": "kubeconfig"}]
+
+
+def test_secret_file_is_0400_and_not_optional() -> None:
+    # A credential, in a pod that already runs non-root with a read-only
+    # rootfs. `optional: False` matches `secrets:`: a missing key must stop the
+    # pod rather than start a server that 401s on every call.
+    vol = _file_dep(FILE_SPEC)["spec"]["template"]["spec"]["volumes"][0]["secret"]
+    assert vol["defaultMode"] == 0o400
+    assert vol["optional"] is False
+
+
+def test_each_secret_file_gets_its_own_volume() -> None:
+    # One volume per file, so each carries only its own key. A single volume
+    # with several items would put every credential in one directory, where a
+    # server that reads a directory would see the others.
+    spec = ConnectorSpec(
+        image="x:1",
+        secret_files={"A": "/secrets/a.pem", "B": "/secrets/b.json"},
+    )
+    pod = _file_dep(spec)["spec"]["template"]["spec"]
+    assert len(pod["volumes"]) == 2
+    keys = sorted(v["secret"]["items"][0]["key"] for v in pod["volumes"])
+    assert keys == ["A", "B"]
+    for v in pod["volumes"]:
+        assert len(v["secret"]["items"]) == 1
+
+
+def test_a_connector_without_secret_files_is_unchanged() -> None:
+    # Additive to a frozen contract: a bundle that does not use this must
+    # render exactly what it rendered before, with no empty volumes key.
+    pod = _file_dep(HOSTED)["spec"]["template"]["spec"]
+    assert "volumes" not in pod
+    assert "volumeMounts" not in pod["containers"][0]
+
+
+def test_secret_files_are_reported_as_secret_names() -> None:
+    # They resolve from the same store, so the deploy path must know to fetch
+    # them; missing this would render a volume pointing at a key nobody wrote.
+    assert "K8S_READONLY_KUBECONFIG" in FILE_SPEC.secret_names()
+
+
+@pytest.mark.parametrize(
+    "data,code",
+    [
+        ({"image": "x:1", "secret_files": {"A": "secrets/x"}},
+         "connectors.secret_file_relative_path"),
+        ({"image": "x:1", "secret_files": {"A": "/tmp/x"}},
+         "connectors.secret_file_in_tmp"),
+        ({"image": "x:1", "secret_files": {"A": "/s/x", "B": "/s/x"}},
+         "connectors.secret_file_path_collision"),
+        ({"image": "x:1", "secrets": ["A"], "secret_files": {"A": "/s/x"}},
+         "connectors.secret_both_env_and_file"),
+        ({"url": "https://m/mcp", "secret_files": {"A": "/s/x"}},
+         "connectors.remote_has_secret_files"),
+    ],
+)
+def test_secret_file_misuse_is_refused(data: dict, code: str) -> None:
+    _, errors = validate_connectors({"connectors": {"k": data}})
+    assert code in [c for c, _ in errors]
+
+
+def test_a_well_formed_secret_file_validates() -> None:
+    parsed, errors = validate_connectors(
+        {"connectors": {"k": {"image": "x:1", "secret_files": {"A": "/secrets/kubeconfig"}}}}
+    )
+    assert errors == []
+    assert parsed is not None


### PR DESCRIPTION
Closes #1402.

`secrets:` renders a `secretKeyRef` and nothing else, so a connector whose
server authenticates from a **file** had no way to receive its credential at
all — kubeconfigs, TLS client certs and keys, GCP service-account JSON, CA
bundles. And a bundle can't work around it: `connectors.yaml` forbids extra keys
and has no `command`, so it can't write `$VAR` to a path and exec the server
itself.

Found wiring a read-only Kubernetes connector where everything else was already
right — correct image, correct flags, a ServiceAccount bound to an enumerated
read-only ClusterRole. It couldn't start, because `kubernetes-mcp-server` takes
`--kubeconfig <path>` and nothing else:

```
CreateContainerConfigError — couldn't find key K8S_READONLY_KUBECONFIG
```

```yaml
secret_files:
  K8S_READONLY_KUBECONFIG: /secrets/kubeconfig
```

Same stored secret, same resolution, same per-agent Secret — **only the delivery
differs**, which is why it's keyed by secret name and reads like `secrets:`.

## Choices worth a reviewer's eye

**`subPath` makes it a FILE at exactly the declared path.** Without it Kubernetes
mounts a *directory* there, and `--kubeconfig /secrets/kubeconfig` would open a
directory and fail in a way that reads like a malformed credential rather than a
mounting mistake.

**One volume per file**, each carrying only its own key. A single volume with
several items would put every credential in one directory, where a server that
reads a directory would see the others.

**`0400` + `readOnly`**, in a pod that already runs non-root with a read-only
rootfs. `optional: False` matches `secrets:` — a missing key must stop the pod,
not start a server that 401s on every call.

## Four refusals, because a file is a second place a credential can leak from

| refused | why |
|---|---|
| relative path | it's a container path, relative to nothing the bundle controls |
| under `/tmp` | scratch space, and an emptyDir there would shadow the mount |
| two names, one path | one would silently win, the other never appears |
| same secret in `secrets` **and** `secret_files` | two copies, no benefit |

Plus `url` connectors declaring `secret_files` — they run elsewhere, so the file
would go nowhere.

## Compatibility

Additive to a frozen contract. A connector without `secret_files` renders
**exactly** what it rendered before — no empty `volumes` key — and there's a test
asserting it.

**272 tests pass** in plugin-format, including 9 new. The worker's `reconcile`
suite fails to collect on a missing `aci_protocol` module **both before and
after** this change — pre-existing, verified against a clean tree.

## Follow-on

`curie-eng/sre-bot` has the Kubernetes connector committed and commented out,
with its credential already minted and verified read-only. It needs no changes
once this lands — just uncommenting, with `--kubeconfig` pointing at the mount.
