### PR TITLE
Test migration 0020's backfill, and stop the comment overclaiming what it catches

### DIFF
--- a/apps/api/alembic/versions/0020_blank_overrides_to_null.py
+++ b/apps/api/alembic/versions/0020_blank_overrides_to_null.py
@@ -47,13 +47,23 @@ BLANKABLE_OVERRIDES = ("model", "thinking")
 
 def upgrade() -> None:
     for column in BLANKABLE_OVERRIDES:
-        # `~ '^[[:space:]]*$'` is the SQL spelling of the validator's
-        # `not value.strip()`, and the spelling matters: Postgres `TRIM()` strips
+        # `~ '^[[:space:]]*$'`, not `TRIM(col) = ''`: Postgres `TRIM()` strips
         # SPACES only, so `TRIM(E'\t ') = ''` is false and a tab-indented value
-        # would survive a backfill that claimed to match Python. The POSIX class
-        # covers space, tab, newline, carriage return, form feed and vertical tab,
-        # which is what `str.strip()` removes. Verified on a scratch database
-        # against a seeded `E'\t '` row, which the TRIM spelling did NOT collapse.
+        # survives a backfill that claims to catch it. Proven by mutation --
+        # swapping this line back to the TRIM spelling reds
+        # test_migration_0020_blank_overrides.py with "'tab' was not cleared".
+        #
+        # The POSIX class is close to the validator's `not value.strip()` but is
+        # NOT equal to it, and the earlier version of this comment claimed it was.
+        # Measured on postgres:16-alpine at en_US.utf8: the class matches space,
+        # tab, LF, CR, VT, FF, U+0085, U+2000, U+2028 and U+3000, while
+        # `str.strip()` additionally removes U+001C..U+001F, U+00A0, U+1680 and
+        # U+202F, which therefore survive. Accepted rather than widened: no
+        # shipped client can write one (the console trims, the create modal trims
+        # and omits, the CLI refuses a blank), and such a row behaves identically
+        # before and after #1374. The boundary is pinned by
+        # test_a_unicode_blank_survives_and_that_boundary_is_deliberate, so
+        # widening the predicate later is a decision rather than a drift.
         #
         # Rows already NULL are untouched, and a real value is only tested, never
         # rewritten -- an empty match set makes this a no-op.

--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -11,6 +11,7 @@ real Postgres (and real Valkey/Langfuse); nothing here mocks them.
 import asyncio
 import os
 import secrets
+from collections.abc import Iterator
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
@@ -155,3 +156,53 @@ def client(_disposable_db: Any) -> Any:
 @pytest.fixture
 def auth_headers() -> dict[str, str]:
     return {"X-API-Key": get_settings().api_key}
+
+
+@pytest.fixture
+def isolated_migration_db() -> Iterator[None]:
+    """A throwaway database ALL to itself, for a test that downgrades/upgrades.
+
+    The session ``_disposable_db`` is shared across every test in the run, so
+    running ``alembic downgrade`` against it mid-suite disrupts siblings (the
+    approval sweeper tests seed rows and count them). apps/api/CLAUDE.md is
+    explicit: migrations are tested against a database of their own, never
+    shared state. This provisions one, points DATABASE_URL + alembic at it for
+    the test, and drops it after, restoring the session URL so nothing else is
+    perturbed.
+
+    Lives here rather than in one test module because it now has a second
+    consumer (the 0015 provenance backfill and the 0020 blank-override
+    backfill). A private copy per migration test is how the next one silently
+    diverges from whichever version its author happened to find.
+    """
+    base = make_url(get_settings().database_url)
+    run_db = f"curie_test_mig_{secrets.token_hex(4)}"
+
+    async def _admin(sql: str) -> None:
+        conn = await asyncpg.connect(
+            user=base.username,
+            password=base.password,
+            host=base.host,
+            port=base.port,
+            database="postgres",
+        )
+        try:
+            await conn.execute(sql)
+        finally:
+            await conn.close()
+
+    saved_url = os.environ.get("DATABASE_URL")
+    asyncio.run(_admin(f'CREATE DATABASE "{run_db}"'))
+    try:
+        os.environ["DATABASE_URL"] = base.set(database=run_db).render_as_string(
+            hide_password=False
+        )
+        get_settings.cache_clear()
+        yield
+    finally:
+        if saved_url is None:
+            os.environ.pop("DATABASE_URL", None)
+        else:
+            os.environ["DATABASE_URL"] = saved_url
+        get_settings.cache_clear()
+        asyncio.run(_admin(f'DROP DATABASE IF EXISTS "{run_db}" WITH (FORCE)'))

--- a/apps/api/tests/test_approvals.py
+++ b/apps/api/tests/test_approvals.py
@@ -8,10 +8,8 @@ test-isolated runs stream as a valid frozen-contract QueuedTurn.
 """
 
 import asyncio
-import contextlib
 import json
 import os
-import secrets
 import time
 import uuid
 from collections.abc import AsyncIterator, Iterator
@@ -21,7 +19,6 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
-import asyncpg
 import httpx
 import pytest
 import redis
@@ -44,7 +41,7 @@ from curie_test_support.valkey import (
     connect_or_skip,
 )
 from fastapi.testclient import TestClient
-from sqlalchemy import make_url, text
+from sqlalchemy import text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
@@ -765,52 +762,7 @@ def test_create_approval_persists_gate_kind_and_granted_tool(
     assert legacy["granted_tool"] is None
 
 
-@contextlib.contextmanager
-def _isolated_migration_db() -> Iterator[None]:
-    """A throwaway database ALL to itself, for a test that downgrades/upgrades.
-
-    The session ``_disposable_db`` is shared across every test in this file, so
-    running ``alembic downgrade`` against it mid-suite disrupts siblings (the
-    sweeper tests seed rows and count them). apps/api/CLAUDE.md is explicit:
-    migrations are tested against a database of their own, never shared state.
-    This provisions one, points DATABASE_URL + alembic at it for the body, and
-    drops it after, restoring the session URL so no other test is perturbed.
-    """
-
-    base = make_url(get_settings().database_url)
-    run_db = f"curie_test_mig_{secrets.token_hex(4)}"
-
-    async def _admin(sql: str) -> None:
-        conn = await asyncpg.connect(
-            user=base.username,
-            password=base.password,
-            host=base.host,
-            port=base.port,
-            database="postgres",
-        )
-        try:
-            await conn.execute(sql)
-        finally:
-            await conn.close()
-
-    saved_url = os.environ.get("DATABASE_URL")
-    asyncio.run(_admin(f'CREATE DATABASE "{run_db}"'))
-    try:
-        os.environ["DATABASE_URL"] = base.set(database=run_db).render_as_string(
-            hide_password=False
-        )
-        get_settings.cache_clear()
-        yield
-    finally:
-        if saved_url is None:
-            os.environ.pop("DATABASE_URL", None)
-        else:
-            os.environ["DATABASE_URL"] = saved_url
-        get_settings.cache_clear()
-        asyncio.run(_admin(f'DROP DATABASE IF EXISTS "{run_db}" WITH (FORCE)'))
-
-
-def test_backfill_classifies_existing_rows() -> None:
+def test_backfill_classifies_existing_rows(isolated_migration_db: None) -> None:
     """(18) The migration backfills rows at rest, then round-trips.
 
     A prefixed summary is a genuine permission-gate block (the runner is the
@@ -827,31 +779,32 @@ def test_backfill_classifies_existing_rows() -> None:
     cfg = Config()
     cfg.set_main_option("script_location", str(ALEMBIC_DIR))
 
-    with _isolated_migration_db():
-        # Bring the fresh DB up to the full schema, then step back to BEFORE the
-        # provenance migration (0015) to the state an existing deployment holds.
-        # Target 0014 explicitly rather than a relative "-1": a later migration
-        # (e.g. 0016) moving head would make "-1" stop short of undoing 0015, and
-        # the backfill would never re-run on the seeded rows.
-        command.upgrade(cfg, "head")
-        command.downgrade(cfg, "0014")
-        permission_id = uuid.uuid4()
-        policy_id = uuid.uuid4()
-        _seed_raw_approval(
-            permission_id, 'Tool call awaiting approval: Bash {"command": "deploy"}'
-        )
-        _seed_raw_approval(policy_id, "Give ACME a 20% discount")
-        command.upgrade(cfg, "head")
+    # Bring the fresh DB up to the full schema, then step back to BEFORE the
+    # provenance migration (0015) to the state an existing deployment holds.
+    # Target 0014 explicitly rather than a relative "-1": a later migration
+    # (e.g. 0016) moving head would make "-1" stop short of undoing 0015, and
+    # the backfill would never re-run on the seeded rows.
+    command.upgrade(cfg, "head")
+    command.downgrade(cfg, "0014")
+    permission_id = uuid.uuid4()
+    policy_id = uuid.uuid4()
+    _seed_raw_approval(
+        permission_id, 'Tool call awaiting approval: Bash {"command": "deploy"}'
+    )
+    _seed_raw_approval(policy_id, "Give ACME a 20% discount")
+    command.upgrade(cfg, "head")
 
-        assert _read_provenance(permission_id) == ("permission", "Bash")
-        assert _read_provenance(policy_id) == ("policy", None)
+    assert _read_provenance(permission_id) == ("permission", "Bash")
+    assert _read_provenance(policy_id) == ("policy", None)
 
-        # And the revision round-trips cleanly rather than only migrating forward.
-        command.downgrade(cfg, "-1")
-        command.upgrade(cfg, "head")
+    # And the revision round-trips cleanly rather than only migrating forward.
+    command.downgrade(cfg, "-1")
+    command.upgrade(cfg, "head")
 
 
-def test_gate_kind_check_constraint_rejects_unknown_values() -> None:
+def test_gate_kind_check_constraint_rejects_unknown_values(
+    isolated_migration_db: None,
+) -> None:
     """(#544) The DB-layer guard on the security-load-bearing gate_kind column.
 
     ``gate_kind`` is trusted in a worker security branch (binding.py:
@@ -891,16 +844,15 @@ def test_gate_kind_check_constraint_rejects_unknown_values() -> None:
         finally:
             await engine.dispose()
 
-    with _isolated_migration_db():
-        command.upgrade(cfg, "head")
-        # Accepted: the two literals plus NULL (NULL IN (...) is NULL, not
-        # FALSE, so the CHECK passes -- the old-runner / pre-backfill case).
-        asyncio.run(_insert("permission"))
-        asyncio.run(_insert("policy"))
-        asyncio.run(_insert(None))
-        # Rejected: anything outside the closed set trips ck_approvals_gate_kind.
-        with pytest.raises(IntegrityError):
-            asyncio.run(_insert("bogus"))
+    command.upgrade(cfg, "head")
+    # Accepted: the two literals plus NULL (NULL IN (...) is NULL, not
+    # FALSE, so the CHECK passes -- the old-runner / pre-backfill case).
+    asyncio.run(_insert("permission"))
+    asyncio.run(_insert("policy"))
+    asyncio.run(_insert(None))
+    # Rejected: anything outside the closed set trips ck_approvals_gate_kind.
+    with pytest.raises(IntegrityError):
+        asyncio.run(_insert("bogus"))
 
 
 def test_route_bound_approval_authorizes_against_card_channel(

--- a/apps/api/tests/test_migration_0020_blank_overrides.py
+++ b/apps/api/tests/test_migration_0020_blank_overrides.py
@@ -1,0 +1,249 @@
+"""Migration 0020 repairs blank operator overrides at rest; this proves it does.
+
+`0020_blank_overrides_to_null.py` collapses `agents.model` and `agents.thinking`
+rows holding a blank string to NULL. The predicate IS the migration -- there is
+no schema change to fall back on -- and until #1391 nothing exercised it:
+replacing `upgrade()`'s body with `return None` was silent across the full API
+suite, so the largest possible mutation went unnoticed.
+
+Why the repair matters: `apply_model_env` reads each override as
+``override if override is not None else config.<field>``. A blank is not None,
+so it wins the ternary, and is then falsy, so NO boot key is emitted -- the agent
+silently skips the platform default an operator configured and takes the model's
+own built-in instead. #1355 taught the API to refuse a blank on write, but
+released images accepted one, so rows written before it hold the defect frozen
+in data where no validator will ever see them again.
+
+The seed values are chosen deliberately rather than mirroring the two the
+migration's author had in mind, since a test built from the author's own mental
+model can only confirm it (#1391 makes exactly this point).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from pathlib import Path
+from typing import Any
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from curie_api.config import get_settings
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlalchemy.sql import text
+
+ALEMBIC_DIR = Path(__file__).resolve().parents[1] / "alembic"
+
+# Blanks the migration is responsible for. ASCII whitespace an operator or a
+# pre-#1355 client could realistically have stored: an empty value, spaces, and
+# the three characters a paste or a heredoc drags in.
+CLEARED = {
+    "empty": "",
+    "spaces": "   ",
+    "tab": "\t ",
+    "newline": "\n",
+    "carriage-return": "\r",
+}
+
+# Real values, present to prove the predicate only TESTS a value and never
+# rewrites one. `enabled:2000` is included because it contains a colon and a
+# digit run, which a sloppier predicate might treat as structure.
+KEPT = {"model": "kimi-k2", "thinking": "enabled:2000"}
+
+# The measured edge of the SQL predicate, pinned so it is a known boundary
+# rather than an unknown gap. See the migration's own note: Postgres's
+# `[[:space:]]` is narrower than Python's `str.strip()`. Measured on
+# postgres:16-alpine at en_US.utf8, U+00A0 is NOT matched and therefore
+# survives. That is accepted, not a defect: no shipped client can write it (the
+# console trims, the create modal trims and omits, the CLI refuses a blank), and
+# such a row behaves identically before and after #1374. Pinned so a future
+# predicate change has to face the decision instead of drifting into it.
+SURVIVES_BY_DESIGN = " "
+
+
+def _seed_agent(name: str, channel: str, model: str | None, thinking: str | None) -> uuid.UUID:
+    """Insert one agent row with raw override values, bypassing the API validator.
+
+    The point is to create rows the validator would refuse today, which is
+    exactly the state a database written by a released image can be in.
+
+    Args:
+        name: agent name (unique).
+        channel: Slack channel id (unique).
+        model: the raw `model` value to store.
+        thinking: the raw `thinking` value to store.
+
+    Returns:
+        The new agent's id.
+    """
+    agent_id = uuid.uuid4()
+
+    async def _go() -> None:
+        engine = create_async_engine(get_settings().database_url)
+        try:
+            async with engine.begin() as conn:
+                await conn.execute(
+                    text(
+                        "INSERT INTO curie.agents (id, name, slack_channel, model, thinking) "
+                        "VALUES (:id, :name, :ch, :model, :thinking)"
+                    ),
+                    {
+                        "id": agent_id,
+                        "name": name,
+                        "ch": channel,
+                        "model": model,
+                        "thinking": thinking,
+                    },
+                )
+        finally:
+            await engine.dispose()
+
+    asyncio.run(_go())
+    return agent_id
+
+
+def _read_overrides(agent_id: uuid.UUID) -> tuple[str | None, str | None]:
+    """Read one agent's stored overrides straight from the table.
+
+    Args:
+        agent_id: the row to read.
+
+    Returns:
+        `(model, thinking)` exactly as stored, NULL included.
+    """
+
+    async def _go() -> tuple[str | None, str | None]:
+        engine = create_async_engine(get_settings().database_url)
+        try:
+            async with engine.connect() as conn:
+                row = (
+                    await conn.execute(
+                        text("SELECT model, thinking FROM curie.agents WHERE id = :id"),
+                        {"id": agent_id},
+                    )
+                ).one()
+            return (row[0], row[1])
+        finally:
+            await engine.dispose()
+
+    return asyncio.run(_go())
+
+
+def _alembic_config() -> Config:
+    cfg = Config()
+    cfg.set_main_option("script_location", str(ALEMBIC_DIR))
+    return cfg
+
+
+def test_the_backfill_clears_blank_overrides_and_leaves_real_values_alone(
+    isolated_migration_db: None,
+) -> None:
+    """The whole substance of 0020, on rows seeded before it runs.
+
+    Targets 0019 explicitly rather than a relative "-1": a later migration moving
+    head would make "-1" stop short of undoing 0020, and the backfill would never
+    re-run on the seeded rows -- the failure mode that makes a green migration
+    test meaningless.
+    """
+    cfg = _alembic_config()
+    command.upgrade(cfg, "head")
+    command.downgrade(cfg, "0019")
+
+    blank_ids: dict[str, uuid.UUID] = {}
+    for i, (label, blank) in enumerate(CLEARED.items()):
+        # Both columns blank on the same row, so neither is proved only by its
+        # sibling's statement having run.
+        blank_ids[label] = _seed_agent(f"blank-{label}", f"CMIGBLNK{i}", blank, blank)
+
+    healthy = _seed_agent("healthy", "CMIGHEAL0", KEPT["model"], KEPT["thinking"])
+    # One column blank, the other real: the per-column WHERE has to spare the
+    # sibling on the SAME row, which a row-level repair would not.
+    mixed = _seed_agent("mixed", "CMIGMIXD0", "", KEPT["thinking"])
+    already_null = _seed_agent("already-null", "CMIGNULL0", None, None)
+
+    command.upgrade(cfg, "head")
+
+    for label, agent_id in blank_ids.items():
+        assert _read_overrides(agent_id) == (None, None), f"{label!r} was not cleared"
+    assert _read_overrides(healthy) == (KEPT["model"], KEPT["thinking"])
+    assert _read_overrides(mixed) == (None, KEPT["thinking"])
+    assert _read_overrides(already_null) == (None, None)
+
+
+def test_the_backfill_is_idempotent_and_the_revision_round_trips(
+    isolated_migration_db: None,
+) -> None:
+    """Re-running must be a no-op, and the downgrade must not undo the repair.
+
+    The downgrade is deliberately empty: the upgrade merges `''` and NULL, so
+    which NULLs were once blanks is unrecoverable, and re-blanking every
+    correctly-NULL row would be strictly worse than leaving the repair standing.
+    This pins that as intended rather than as an omission.
+    """
+    cfg = _alembic_config()
+    command.upgrade(cfg, "head")
+    command.downgrade(cfg, "0019")
+
+    blanked = _seed_agent("round-trip", "CMIGRTRP0", "  ", "")
+    healthy = _seed_agent("round-trip-ok", "CMIGRTOK0", KEPT["model"], None)
+
+    command.upgrade(cfg, "head")
+    assert _read_overrides(blanked) == (None, None)
+
+    command.downgrade(cfg, "0019")
+    assert _read_overrides(blanked) == (None, None), "the downgrade must not re-blank"
+
+    command.upgrade(cfg, "head")
+    assert _read_overrides(blanked) == (None, None)
+    assert _read_overrides(healthy) == (KEPT["model"], None)
+
+
+def test_a_unicode_blank_survives_and_that_boundary_is_deliberate(
+    isolated_migration_db: None,
+) -> None:
+    """Pin the measured edge of the predicate instead of leaving it unknown.
+
+    Postgres's `[[:space:]]` is NARROWER than Python's `str.strip()`. Measured on
+    postgres:16-alpine at en_US.utf8, `str.strip()` treats all of U+001C..U+001F,
+    U+00A0, U+1680 and U+202F as whitespace while the SQL class does not, so a
+    row holding one of those is not collapsed.
+
+    Accepted, for a reason that has to keep holding: no shipped client can write
+    such a value. If one ever can, this test is where that assumption is written
+    down, and it fails loudly the moment someone widens the predicate without
+    deciding to.
+    """
+    cfg = _alembic_config()
+    command.upgrade(cfg, "head")
+    command.downgrade(cfg, "0019")
+
+    exotic = _seed_agent("nbsp", "CMIGNBSP0", SURVIVES_BY_DESIGN, SURVIVES_BY_DESIGN)
+    # Python agrees it is blank; the SQL predicate does not. That disagreement is
+    # the whole point of pinning it.
+    assert SURVIVES_BY_DESIGN.strip() == ""
+
+    command.upgrade(cfg, "head")
+
+    assert _read_overrides(exotic) == (SURVIVES_BY_DESIGN, SURVIVES_BY_DESIGN)
+
+
+@pytest.mark.parametrize("column", ["model", "thinking"])
+def test_each_column_is_repaired_independently(
+    isolated_migration_db: None, column: str
+) -> None:
+    """Both columns, asserted separately, so one statement covering the other is
+    not mistaken for both working. 0020 loops over a NAMED list; a third override
+    added to the schema and not to that list would slip through, and this is the
+    shape that notices."""
+    cfg = _alembic_config()
+    command.upgrade(cfg, "head")
+    command.downgrade(cfg, "0019")
+
+    values: dict[str, Any] = {"model": None, "thinking": None}
+    values[column] = "   "
+    agent_id = _seed_agent(f"only-{column}", f"CMIGONLY{column[0].upper()}", **values)
+
+    command.upgrade(cfg, "head")
+
+    assert _read_overrides(agent_id) == (None, None)


### PR DESCRIPTION
The predicate **is** the migration -- there is no schema change to fall back on -- and nothing exercised it. Replacing `upgrade()`'s body with `return None`, the largest possible mutation, was silent across the full API suite.

## Two mutations now fail

| mutation | result |
|---|---|
| delete the backfill entirely | 4 of 5 new tests red |
| swap the predicate back to `TRIM(col) = ''` | red with `'tab' was not cleared` |

That second one is the exact defect the shipped spelling exists to avoid: Postgres `TRIM()` strips **spaces only**, so a tab-indented value walks past a backfill that claims to catch it.

## Seed values chosen *against* the author's model, not *from* it

The issue's caveat is the sharpest part of it: a test seeded with the two values the author already reasoned about would pass no matter what, because it can only confirm the mental model that produced the bug. So:

- **blanks**: empty string, spaces, tab, newline, carriage return
- **a mixed row** (one column blank, one real) -- proves the per-column `WHERE` spares the healthy sibling on the *same* row, which a row-level repair would not
- **an already-NULL row** and **two real values** -- prove the predicate only *tests* a value and never rewrites one
- **both columns asserted separately** -- 0020 loops over a NAMED list, so a third override added to the schema and not to that list would slip through, and this is the shape that notices

## The comment was overclaiming, so it is now measurements

It said the POSIX class "is what `str.strip()` removes". It is not. This is the second overclaim of the same kind in this file's short history, so the fix is measured facts rather than a tighter assertion.

Measured on `postgres:16-alpine` at `en_US.utf8`:

- `[[:space:]]` matches: space, tab, LF, CR, VT, FF, U+0085, U+2000, U+2028, U+3000
- `str.strip()` **additionally** removes: U+001C..U+001F, U+00A0, U+1680, U+202F

**The gap is accepted, not widened.** No shipped client can write such a value -- the console trims, the create modal trims and omits, the CLI refuses a blank -- and such a row behaves identically before and after #1374.

But it is no longer *unknown*: `test_a_unicode_blank_survives_and_that_boundary_is_deliberate` seeds a U+00A0 row, asserts Python considers it blank, and asserts it **survives**. The boundary is now a documented decision, and widening the predicate later has to face it instead of drifting into it.

## The harness moves

`_isolated_migration_db` goes from `test_approvals.py` to `conftest.py` as a fixture. It had one consumer and now has two, which is when this repo abstracts; leaving a private copy behind is how the next migration test diverges from whichever version its author happens to find first.

Both existing callers move to the fixture. Worth noting: there were **two**, and the second was found by `ruff` (F821) rather than by reading -- which is the same lesson as the rest of this window.

## Verified

`ruff check .` clean, `mypy` clean on 50 files, 5 new tests green. Full API suite: 620 passed, 9 skipped. The single failure (`test_cost_composes_metrics_for_the_agent`) is a pre-existing environment failure with no Langfuse running locally -- attributed by name-for-name diff against a stashed clean `main`, not by comparing counts.

Closes #1391