### PR TITLE
Normalize a padded override at the API, so one paste stores one value

### DIFF
--- a/apps/api/src/curie_api/schemas.py
+++ b/apps/api/src/curie_api/schemas.py
@@ -43,7 +43,11 @@ _SLACK_USER_ID = re.compile(r"^[UW][A-Z0-9]{7,}$")
 
 
 def _nullable_override_validator(field: str, examples: str) -> Callable[[str | None], str | None]:
-    """Build the refusal shared by every nullable operator override (#1310, #1355).
+    """Build the gate shared by every nullable operator override (#1310, #1355, #1392).
+
+    Refuses a blank and normalizes what it accepts: the returned value is
+    stripped, so one paste stores one value no matter which surface it came
+    through.
 
     `model` and `thinking` are the same kind of field consumed the same way, and
     they must answer an empty string the same way. `apply_model_env` reads each as
@@ -73,7 +77,8 @@ def _nullable_override_validator(field: str, examples: str) -> Callable[[str | N
         examples: a trailing clause naming valid values for this field.
 
     Returns:
-        A pydantic field validator refusing empty and whitespace-only values.
+        A pydantic field validator that refuses empty and whitespace-only values
+        and returns every other value stripped.
     """
 
     def _validate(value: str | None) -> str | None:
@@ -86,7 +91,20 @@ def _nullable_override_validator(field: str, examples: str) -> Callable[[str | N
                 f"clearing means. Send null to clear the override back to the "
                 f"platform default, or {examples}."
             )
-        return value
+        # Normalize here, not in each client (#1392). Leading or trailing
+        # whitespace is never meaningful in either override, and storing it
+        # verbatim is a bug that surfaces far from its cause: a padded model id
+        # is forwarded as CURIE_MODEL and rejected by the provider at the
+        # agent's NEXT turn, long after the command that stored it exited 0.
+        #
+        # This is the API's job because the API is the gate every client passes
+        # through -- the same reasoning `_validate_slack_channel_id` states for
+        # itself ("the authoritative gate for every caller (UI, API, CLI)"). The
+        # console already trimmed and the CLI did not, so the same paste stored
+        # two different values depending on which surface an operator used;
+        # fixing only the CLI would have left curl and every future client on
+        # the old behavior.
+        return value.strip()
 
     return _validate
 

--- a/apps/api/tests/test_agent_model_integration.py
+++ b/apps/api/tests/test_agent_model_integration.py
@@ -140,3 +140,45 @@ def test_model_and_thinking_clear_through_the_same_gesture(
     assert resp.status_code == 200, resp.text
     assert resp.json()["model"] is None
     assert resp.json()["thinking"] is None
+
+
+def test_a_padded_override_is_stored_trimmed_on_both_paths(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    # #1392: the API is the gate every client passes through, so normalization
+    # belongs here rather than in each surface. The console trimmed and the CLI
+    # did not, so one paste stored two different values; a padded model id is
+    # forwarded as CURIE_MODEL and rejected by the provider at the agent's next
+    # turn, far from the request that stored it.
+    agent = _create_agent(client, auth_headers, model="  kimi-k2  ", thinking="\tadaptive\n")
+    assert agent["model"] == "kimi-k2"
+    assert agent["thinking"] == "adaptive"
+
+    resp = client.patch(
+        f"/agents/{agent['id']}",
+        json={"model": " glm-5.2 ", "thinking": " enabled:2000 "},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["model"] == "glm-5.2"
+    assert resp.json()["thinking"] == "enabled:2000"
+
+    # Stored, not merely echoed: a later read returns the normalized value.
+    resp = client.get(f"/agents/{agent['id']}", headers=auth_headers)
+    assert resp.json()["model"] == "glm-5.2"
+    assert resp.json()["thinking"] == "enabled:2000"
+
+
+def test_trimming_does_not_soften_the_blank_refusal(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    # The obvious way to get this wrong: strip first, then test emptiness, which
+    # turns a whitespace-only value into "" and stores it -- the exact defect
+    # #1355 closed. The refusal must still fire before normalization.
+    for blank in ("", "   ", "\t\n"):
+        resp = client.post(
+            "/agents",
+            json={"name": f"blank-{len(blank)}x", "slack_channel": "CBLANK001", "model": blank},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 422, f"{blank!r} must still be refused: {resp.text}"

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -7595,7 +7595,11 @@ impl OverrideChange {
                  default instead of restoring it. Pass --clear-{field} to clear \
                  the override, or a real value"
             ))),
-            (Some(v), false) => Ok(OverrideChange::Set(v)),
+            // Trimmed before it becomes an intent (#1392). The API strips too
+            // and is the authoritative gate, but doing it here as well is what
+            // makes `--dry-run` honest: it must print the body that would
+            // actually be sent, not the argv the operator typed.
+            (Some(v), false) => Ok(OverrideChange::Set(v.trim().to_string())),
             (None, true) => Ok(OverrideChange::Clear),
             (None, false) => Ok(OverrideChange::Unchanged),
         }
@@ -7894,6 +7898,34 @@ mod overrides_tests {
             super::overrides_summary("a", &None, &Some("adaptive".into()), true),
             "overrides for a now: model platform default, thinking adaptive"
         );
+    }
+
+    // #1392: the CLI stored `" kimi-k2 "` verbatim while the console trimmed, so
+    // the same paste produced two different stored values depending on the
+    // surface. A padded id is then forwarded as CURIE_MODEL and rejected by the
+    // provider at the agent's NEXT turn, far from the command that exited 0.
+    #[test]
+    fn a_padded_value_is_trimmed_before_it_becomes_an_intent() {
+        assert_eq!(
+            OverrideChange::resolve("model", Some("  kimi-k2  ".into()), false).unwrap(),
+            OverrideChange::Set("kimi-k2".into())
+        );
+        assert_eq!(
+            OverrideChange::resolve("thinking", Some("\tadaptive\n".into()), false).unwrap(),
+            OverrideChange::Set("adaptive".into())
+        );
+    }
+
+    // The dry-run plan is the operator's only preview of the write, so it has to
+    // show the body that will actually be sent, not the argv they typed.
+    #[test]
+    fn the_dry_run_body_carries_the_trimmed_value() {
+        let body = overrides_patch_body(
+            &OverrideChange::resolve("model", Some(" kimi-k2 ".into()), false).unwrap(),
+            &OverrideChange::Unchanged,
+        )
+        .expect("a set is a write");
+        assert_eq!(body["model"], "kimi-k2");
     }
 
     #[test]


### PR DESCRIPTION
`curie overrides --model ' kimi-k2 '` stored the padding verbatim and exited 0. The console, the other operator surface for the same field, trimmed. **Same operator, same field, two surfaces, two stored values.**

The padded id is then forwarded as `CURIE_MODEL` and rejected by the provider at the agent's *next* turn, so the failure surfaces far from the command that caused it. The same paste through the console silently works, which makes the CLI look broken rather than the input.

## Fixed at the API, not only in the CLI

The issue suggests trimming in the CLI to match the console. That fixes the reported path and leaves `curl` and every future client on the old behavior.

`_validate_slack_channel_id` already states the pattern for exactly this situation, in the same file:

> This is the **authoritative gate for every caller (UI, API, CLI)**; the CLI keeps a fast local check purely for UX.

So the shared `_nullable_override_validator` now strips what it accepts. One place, both overrides, every surface.

**The CLI trims too, and not redundantly.** `--dry-run` is the operator's only preview of the write, so it has to print the body that will actually be sent rather than the argv they typed:

```
$ curie local overrides deal-desk --model '  kimi-k2  ' --dry-run --json
{"dry_run":true,"plan":["PATCH .../agents/<id>  {\"model\":\"kimi-k2\"}  ..."]}
```

## Order matters, and is tested

The blank refusal fires **before** normalization. Stripping first would turn a whitespace-only value into `""` and store it -- precisely the defect #1355 closed. `test_trimming_does_not_soften_the_blank_refusal` pins that `""`, `"   "` and `"\t\n"` all still 422.

## `--thinking` is fixed too, though it never broke downstream

The issue correctly notes `parse_thinking` strips before parsing, so a padded thinking value already worked. It was still *stored* padded. Fixed anyway: the two fields are one predicate, and leaving one storing padding is how the next reader concludes the padding is meaningful.

## Verified by mutation, both sides

| removed | result |
|---|---|
| the API strip | round-trip test red |
| the CLI trim | intent + dry-run tests red |

API 617 passed, CLI `cargo test` green, `cargo fmt --check`, `clippy -D warnings`, `ruff`, `mypy` (50 files), UI 144 passed. The single API failure (`test_cost_composes_metrics_for_the_agent`) is the pre-existing no-Langfuse environment failure, name-matched against clean `main`.

Closes #1392