### PR TITLE
Catch a store that is about to be renamed, not just one that is gone

### DIFF
--- a/cli/schema/diff.schema.json
+++ b/cli/schema/diff.schema.json
@@ -78,6 +78,13 @@
     "chart_version_differs": {
       "type": "boolean",
       "description": "True when the deployed chart version differs from the one this CLI would apply. The entry comparison is VALUES-ONLY and cannot see a component added, removed, or renamed between chart versions -- a renamed component's old keys appear as ordinary resets. Treat a true here as 'this diff does not describe a safe apply'."
+    },
+    "unresolved_credentials": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Credential NAMES the file declares that have no value in this environment. Never fatal for diff, which mutates nothing; the entries are unaffected because none depends on a credential VALUE. A non-empty list means `curie apply` would refuse until they resolve."
     }
   },
   "required": [
@@ -88,6 +95,7 @@
     "chart_target",
     "chart_version_differs",
     "changes",
-    "entries"
+    "entries",
+    "unresolved_credentials"
   ]
 }

--- a/cli/src/installation.rs
+++ b/cli/src/installation.rs
@@ -481,6 +481,34 @@ pub fn resolve_credentials(
     cfg: &Installation,
     resolver: &dyn Fn(&str) -> Result<Option<String>>,
 ) -> Result<BTreeMap<String, String>> {
+    let (resolved, missing) = resolve_credentials_lenient(cfg, resolver)?;
+    if !missing.is_empty() {
+        bail!(
+            "curie.yaml names credential(s) with no value available: {}. \
+             Export each in the environment, or save it with `curie secrets set <NAME>`. \
+             The file names them; it never carries their values.",
+            missing.join(", ")
+        );
+    }
+    Ok(resolved)
+}
+
+/// Resolve what is available and REPORT what is not, rather than refusing.
+///
+/// `curie diff` needs the credential NAMES to know which chart values the file
+/// governs; it never needs the values, because it mutates nothing. Refusing
+/// there withheld the answer exactly when it is most wanted -- on an install
+/// that is not finished yet, which is the state an operator is in when they ask
+/// "what would this change?".
+///
+/// That is what the verb was for, and a shared-plan refactor (#1319) quietly
+/// took it away: `diff` started going through `plan_installation`, which bails.
+/// Nothing caught it, because the tests cover the pure planner and not this
+/// seam. Found by running `curie diff` against a real cluster.
+pub fn resolve_credentials_lenient(
+    cfg: &Installation,
+    resolver: &dyn Fn(&str) -> Result<Option<String>>,
+) -> Result<(BTreeMap<String, String>, Vec<String>)> {
     let mut resolved = BTreeMap::new();
     let mut missing = Vec::new();
     for name in cfg.credential_names() {
@@ -491,15 +519,7 @@ pub fn resolve_credentials(
             None => missing.push(name),
         }
     }
-    if !missing.is_empty() {
-        bail!(
-            "curie.yaml names credential(s) with no value available: {}. \
-             Export each in the environment, or save it with `curie secrets set <NAME>`. \
-             The file names them; it never carries their values.",
-            missing.join(", ")
-        );
-    }
-    Ok(resolved)
+    Ok((resolved, missing))
 }
 
 /// What `curie apply` did, as one object (the `--json` contract allows exactly
@@ -583,7 +603,32 @@ struct EffectiveInstallationPlan {
 }
 
 pub fn plan_installation(cfg: Installation, dry_run: bool) -> Result<LocalInstallationPlan> {
-    let resolved = resolve_credentials(&cfg, &resolve_credential)?;
+    plan_installation_inner(cfg, dry_run, false)
+}
+
+/// The same plan, but tolerating credentials that are not available yet.
+///
+/// Only `curie diff` uses this. `apply` must keep refusing: resolving BEFORE
+/// mutating is what stops a missing Slack token being discovered after the
+/// platform install has already run, leaving a half-applied cluster.
+pub fn plan_installation_lenient(
+    cfg: Installation,
+) -> Result<(LocalInstallationPlan, Vec<String>)> {
+    let (_, missing) = resolve_credentials_lenient(&cfg, &resolve_credential)?;
+    let plan = plan_installation_inner(cfg, false, true)?;
+    Ok((plan, missing))
+}
+
+fn plan_installation_inner(
+    cfg: Installation,
+    dry_run: bool,
+    lenient: bool,
+) -> Result<LocalInstallationPlan> {
+    let resolved = if lenient {
+        resolve_credentials_lenient(&cfg, &resolve_credential)?.0
+    } else {
+        resolve_credentials(&cfg, &resolve_credential)?
+    };
     let github_token = cfg
         .credentials
         .github_token
@@ -1056,6 +1101,10 @@ pub fn diff_plan(
 /// What `curie diff` found.
 #[derive(Debug)]
 pub struct DiffOutput {
+    /// Declared credential names with no value available. A non-empty list
+    /// means `apply` would refuse until they resolve -- the entries below are
+    /// still accurate, because none of them depends on a credential VALUE.
+    pub unresolved_credentials: Vec<String>,
     pub namespace: String,
     pub release: String,
     /// `false` when helm has no record of the release: everything is a create.
@@ -1099,6 +1148,7 @@ impl crate::ui::CliOutput for DiffOutput {
             "namespace": self.namespace,
             "release": self.release,
             "release_exists": self.release_exists,
+            "unresolved_credentials": self.unresolved_credentials,
             "chart_deployed": self.chart_deployed,
             "chart_target": self.chart_target,
             "chart_version_differs": self.chart_version_differs(),
@@ -1158,6 +1208,15 @@ impl crate::ui::CliOutput for DiffOutput {
         // says nothing about components a chart bump adds, removes, or renames
         // -- and a renamed component's old keys appear above as ordinary
         // resets, which reads far milder than the swap it would actually be.
+        if !self.unresolved_credentials.is_empty() {
+            ui.note(&format!(
+                "{} declared credential(s) have no value here: {}. The comparison above \
+                 is unaffected -- no entry depends on a credential VALUE -- but `curie \
+                 apply` will refuse until they resolve.",
+                self.unresolved_credentials.len(),
+                self.unresolved_credentials.join(", "),
+            ));
+        }
         if self.chart_version_differs() {
             ui.note(&format!(
                 "CHART VERSION MISMATCH: the release runs {} but this curie applies {}. \
@@ -1173,6 +1232,9 @@ impl crate::ui::CliOutput for DiffOutput {
 }
 
 pub struct DiffOpts {
+    /// Credential NAMES the file declares that have no value available here.
+    /// Reported, never fatal: diff mutates nothing.
+    pub unresolved_credentials: Vec<String>,
     pub local: LocalInstallationPlan,
 }
 
@@ -1180,6 +1242,11 @@ pub struct DiffOpts {
 ///
 /// Resolves the same local inputs as apply, then performs one values read and
 /// provider resolution to complete the desired plan without mutating it.
+///
+/// **A credential it cannot resolve is reported, never fatal.** The question
+/// "what would this change?" is most urgent on an install that is not finished,
+/// and refusing to answer it there was the behaviour a shared-plan refactor
+/// introduced and a real run against a cluster exposed.
 pub async fn diff(opts: DiffOpts) -> Result<DiffOutput> {
     let plan = complete_installation_plan(opts.local).await?;
     // A second, independent read: the values plan says nothing about WHICH
@@ -1197,6 +1264,7 @@ pub async fn diff(opts: DiffOpts) -> Result<DiffOutput> {
         }
     }
     Ok(DiffOutput {
+        unresolved_credentials: opts.unresolved_credentials,
         namespace: plan.cfg.install.namespace,
         release: plan.cfg.install.release,
         release_exists: plan.live.is_some(),
@@ -1617,6 +1685,7 @@ mod diff_tests {
     #[test]
     fn a_chart_version_mismatch_is_reported() {
         let out = DiffOutput {
+            unresolved_credentials: Vec::new(),
             namespace: "acme-bot".into(),
             release: "acme-bot".into(),
             release_exists: true,
@@ -1635,6 +1704,7 @@ mod diff_tests {
     #[test]
     fn a_matching_chart_version_does_not_warn() {
         let out = DiffOutput {
+            unresolved_credentials: Vec::new(),
             namespace: "acme-bot".into(),
             release: "acme-bot".into(),
             release_exists: true,
@@ -1649,6 +1719,7 @@ mod diff_tests {
     #[test]
     fn an_unknown_deployed_chart_does_not_claim_a_mismatch() {
         let out = DiffOutput {
+            unresolved_credentials: Vec::new(),
             namespace: "acme-bot".into(),
             release: "acme-bot".into(),
             release_exists: false,
@@ -1682,6 +1753,7 @@ mod diff_tests {
     fn output_is_one_json_object_with_a_change_count() {
         use crate::ui::CliOutput;
         let out = DiffOutput {
+            unresolved_credentials: Vec::new(),
             namespace: "acme".into(),
             release: "acme".into(),
             release_exists: true,
@@ -1740,6 +1812,38 @@ mod apply_tests {
              comms:\n  slack:\n    app_token: APP_TOK\n    bot_token: BOT_TOK\n",
         )
         .unwrap()
+    }
+
+    /// The property a real run against a cluster proved was gone: `diff` must
+    /// answer on an install whose credentials are not in place yet. That is
+    /// precisely when "what would this change?" is worth asking.
+    #[test]
+    fn the_lenient_resolver_reports_gaps_instead_of_refusing() {
+        let cfg = cfg_with_all_names();
+        let (resolved, missing) =
+            resolve_credentials_lenient(&cfg, &|_| Ok(None)).expect("must not refuse");
+        assert!(resolved.is_empty());
+        assert_eq!(missing, vec!["MODEL_KEY", "APP_TOK", "BOT_TOK"]);
+    }
+
+    /// Apply keeps refusing. Resolving BEFORE mutating is what stops a missing
+    /// Slack token being discovered after the platform install already ran,
+    /// leaving a half-applied cluster.
+    #[test]
+    fn the_strict_resolver_still_refuses_so_apply_cannot_half_apply() {
+        let cfg = cfg_with_all_names();
+        assert!(resolve_credentials(&cfg, &|_| Ok(None)).is_err());
+    }
+
+    /// A partial resolution reports only what is absent, in both modes.
+    #[test]
+    fn the_lenient_resolver_keeps_what_it_found() {
+        let cfg = cfg_with_all_names();
+        let (resolved, missing) =
+            resolve_credentials_lenient(&cfg, &|n| Ok((n == "MODEL_KEY").then(|| "v".to_string())))
+                .expect("must not refuse");
+        assert_eq!(resolved.get("MODEL_KEY").map(String::as_str), Some("v"));
+        assert_eq!(missing, vec!["APP_TOK", "BOT_TOK"]);
     }
 
     /// One round trip, not four. An operator standing up a new install is

--- a/cli/src/installation.rs
+++ b/cli/src/installation.rs
@@ -788,20 +788,71 @@ async fn guard_stateful_removal(up: &crate::ops::UpOpts) -> Result<GuardVerdict>
 }
 
 /// The refusal text, factored out so its ordering is testable with no cluster.
-fn stateful_removal_message(removed: &[String]) -> String {
-    format!(
+///
+/// Branches on the CAUSE, because the two causes need opposite advice and a
+/// refusal an operator cannot act on is a wall, not a guard. A rename in
+/// particular has a one-line fix in their own file -- if the message withheld
+/// that and offered `--migrate-store` instead, the only way past would be
+/// `--allow-stateful-removal`, i.e. the guard would talk them into the
+/// destruction it exists to prevent.
+fn stateful_removal_message(removed: &[crate::ops::StatefulRemoval]) -> String {
+    use crate::ops::RemovalCause;
+
+    let listed = removed
+        .iter()
+        .map(|r| match &r.cause {
+            RemovalCause::ComponentGone => {
+                format!("{} ({}, not rendered at all)", r.name, r.component)
+            }
+            RemovalCause::RenamedTo(to) => format!("{} -> {}", r.name, to),
+        })
+        .collect::<Vec<_>>()
+        .join("\n  ");
+
+    let mut msg = format!(
         "refusing to apply: this would DELETE {} stateful component(s) the release is \
-         running, and the persistent data with them:\n  {}\n\n\
-         The target chart does not render them, which usually means a chart version \
-         renamed or removed the component. For the bundle store, every sandbox reads \
-         from it at start, so losing it breaks the next turn and not merely a \
-         rollback.\n\n\
-         Re-run with --migrate-store and apply will carry the data across itself: it \
-         stages every object, upgrades, loads them back, and verifies per object.\n\n\
-         Use --allow-stateful-removal only to proceed WITHOUT the data.",
+         running, and the persistent data with them:\n  {listed}\n\n\
+         For the bundle store, every sandbox reads from it at start, so losing it \
+         breaks the next turn and not merely a rollback.\n\n",
         removed.len(),
-        removed.join("\n  "),
-    )
+    );
+
+    let renamed: Vec<&crate::ops::StatefulRemoval> = removed
+        .iter()
+        .filter(|r| matches!(r.cause, RemovalCause::RenamedTo(_)))
+        .collect();
+    if !renamed.is_empty() {
+        // Deliberately concrete. The operator is looking at a resource named
+        // `<something>-postgres` and a plan that creates `<something>-curie-postgres`;
+        // "your values disagree" is true and useless. The name the chart uses
+        // is derived from `nameOverride`, so hand them that line.
+        msg.push_str(
+            "These components still exist in the chart -- they would just be recreated \
+             under NEW names, empty, beside the orphaned volumes. That is a values \
+             difference, not a chart change: the release was installed with a \
+             `nameOverride` your curie.yaml does not declare.\n\n\
+             Fix it in the file rather than overriding the guard -- add the release's \
+             own name:\n\n\
+             \x20 set:\n\
+             \x20   nameOverride: <the name the live resources start with>\n\n\
+             then re-run `curie diff` and confirm the rename entries are gone.\n\n",
+        );
+    }
+
+    if removed
+        .iter()
+        .any(|r| r.cause == RemovalCause::ComponentGone)
+    {
+        msg.push_str(
+            "Component(s) the chart does not render at all usually mean a chart version \
+             renamed or removed them. Re-run with --migrate-store and apply will carry \
+             the data across itself: it stages every object, upgrades, loads them back, \
+             and verifies per object.\n\n",
+        );
+    }
+
+    msg.push_str("Use --allow-stateful-removal only to proceed WITHOUT the data.");
+    msg
 }
 
 /// Converge the cluster to the file.
@@ -1282,7 +1333,11 @@ mod stateful_guard_message_tests {
     /// safety-override, which trains the habit the guard exists to prevent.
     #[test]
     fn the_refusal_offers_migration_before_discarding() {
-        let msg = super::stateful_removal_message(&["acme-minio".to_string()]);
+        let msg = super::stateful_removal_message(&[crate::ops::StatefulRemoval {
+            name: "acme-minio".to_string(),
+            component: "minio".to_string(),
+            cause: crate::ops::RemovalCause::ComponentGone,
+        }]);
         let migrate = msg
             .find("--migrate-store")
             .expect("must offer --migrate-store");
@@ -1298,6 +1353,57 @@ mod stateful_guard_message_tests {
             "the discard flag must say what it costs:\n{msg}"
         );
         assert!(msg.contains("acme-minio"), "must name the component: {msg}");
+    }
+
+    /// A rename has a one-line fix in the operator's OWN file. If the refusal
+    /// does not say so, the only way past it is `--allow-stateful-removal` --
+    /// the guard would be arguing for the destruction it exists to prevent.
+    #[test]
+    fn a_rename_is_pointed_at_the_file_not_at_a_flag() {
+        let msg = super::stateful_removal_message(&[crate::ops::StatefulRemoval {
+            name: "acme-bot-postgres".to_string(),
+            component: "postgres".to_string(),
+            cause: crate::ops::RemovalCause::RenamedTo("acme-bot-curie-postgres".to_string()),
+        }]);
+        assert!(
+            msg.contains("nameOverride"),
+            "must name the value that causes it:\n{msg}"
+        );
+        assert!(
+            msg.contains("acme-bot-postgres") && msg.contains("acme-bot-curie-postgres"),
+            "must show both names, so the operator can see it IS their release:\n{msg}"
+        );
+        assert!(
+            !msg.contains("--migrate-store"),
+            "--migrate-store cannot fix a rename -- both sides run the same store, so \
+             there is nothing to migrate between. Offering it sends the operator down a \
+             path that dead-ends at --allow-stateful-removal:\n{msg}"
+        );
+    }
+
+    /// Both causes at once must not lose either remedy.
+    #[test]
+    fn a_mixed_batch_carries_both_remedies() {
+        let msg = super::stateful_removal_message(&[
+            crate::ops::StatefulRemoval {
+                name: "acme-bot-minio".to_string(),
+                component: "minio".to_string(),
+                cause: crate::ops::RemovalCause::ComponentGone,
+            },
+            crate::ops::StatefulRemoval {
+                name: "acme-bot-postgres".to_string(),
+                component: "postgres".to_string(),
+                cause: crate::ops::RemovalCause::RenamedTo("acme-bot-curie-postgres".to_string()),
+            },
+        ]);
+        assert!(msg.contains("nameOverride"), "{msg}");
+        assert!(msg.contains("--migrate-store"), "{msg}");
+        let discard = msg.find("--allow-stateful-removal").unwrap();
+        assert!(
+            msg.find("--migrate-store").unwrap() < discard
+                && msg.find("nameOverride").unwrap() < discard,
+            "the data-preserving remedies must still come before the discard flag:\n{msg}"
+        );
     }
 }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -3394,8 +3394,17 @@ async fn run(command: Option<Command>) -> Result<()> {
         }
         Some(Command::Diff { file }) => {
             let cfg = curie::installation::Installation::load(&file)?;
-            let local = curie::installation::plan_installation(cfg, false)?;
-            emit(curie::installation::diff(curie::installation::DiffOpts { local }).await?)
+            // Lenient on purpose: `diff` mutates nothing, so a credential it
+            // cannot resolve must not withhold the answer. See
+            // installation::resolve_credentials_lenient.
+            let (local, missing) = curie::installation::plan_installation_lenient(cfg)?;
+            emit(
+                curie::installation::diff(curie::installation::DiffOpts {
+                    local,
+                    unresolved_credentials: missing,
+                })
+                .await?,
+            )
         }
     }
 }

--- a/cli/src/migrate_store.rs
+++ b/cli/src/migrate_store.rs
@@ -693,7 +693,13 @@ pub async fn run_export(o: &CommonOpts, chart: &str, bucket: &str) -> Result<Mig
         .into_iter()
         .map(|(component, _)| component)
         .collect();
-    let rendered = crate::ops::chart_stateful_components(chart, o, &[]).await?;
+    // migrate_store reasons about COMPONENTS only (which store is which); the
+    // resource names the guard also needs are irrelevant here.
+    let rendered: Vec<String> = crate::ops::chart_stateful_components(chart, o, &[])
+        .await?
+        .into_iter()
+        .map(|(component, _)| component)
+        .collect();
     let (from, to) = ensure_migratable(&plan(&live, &rendered)?)?;
 
     let image = "amazon/aws-cli:2.32.6";
@@ -962,7 +968,13 @@ pub async fn run_auto(o: &CommonOpts, chart: &str, bucket: &str) -> Result<Migra
         .into_iter()
         .map(|(component, _)| component)
         .collect();
-    let rendered = crate::ops::chart_stateful_components(chart, o, &[]).await?;
+    // migrate_store reasons about COMPONENTS only (which store is which); the
+    // resource names the guard also needs are irrelevant here.
+    let rendered: Vec<String> = crate::ops::chart_stateful_components(chart, o, &[])
+        .await?
+        .into_iter()
+        .map(|(component, _)| component)
+        .collect();
     let (from, to) = ensure_migratable(&plan(&live, &rendered)?)?;
 
     let image = "amazon/aws-cli:2.32.6";

--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -1365,7 +1365,7 @@ pub async fn chart_stateful_components(
     chart: &str,
     o: &CommonOpts,
     value_sets: &[String],
-) -> Result<Vec<String>> {
+) -> Result<Vec<(String, String)>> {
     let mut args = vec![
         plain("template"),
         plain(&o.release),
@@ -1389,8 +1389,8 @@ pub async fn chart_stateful_components(
 /// Split-and-parse rather than a regex: a `kind: StatefulSet` line can appear
 /// inside an annotation or a ConfigMap payload, and matching that would invent
 /// a component the chart does not actually create.
-pub fn parse_statefulset_components(rendered: &str) -> Vec<String> {
-    let mut components = Vec::new();
+pub fn parse_statefulset_components(rendered: &str) -> Vec<(String, String)> {
+    let mut out: Vec<(String, String)> = Vec::new();
     for doc in rendered.split("\n---") {
         let Ok(value) = serde_norway::from_str::<serde_json::Value>(doc) else {
             continue;
@@ -1404,25 +1404,82 @@ pub fn parse_statefulset_components(rendered: &str) -> Vec<String> {
             .and_then(|s| s.get("matchLabels"))
             .and_then(|l| l.get("app.kubernetes.io/component"))
             .and_then(|c| c.as_str());
-        if let Some(component) = component {
-            if !components.iter().any(|c: &String| c == component) {
-                components.push(component.to_string());
+        let name = value
+            .get("metadata")
+            .and_then(|m| m.get("name"))
+            .and_then(|n| n.as_str());
+        if let (Some(component), Some(name)) = (component, name) {
+            if !out.iter().any(|(c, _)| c == component) {
+                out.push((component.to_string(), name.to_string()));
             }
         }
     }
-    components
+    out
+}
+
+/// Why a live stateful component would not survive the apply.
+///
+/// Carried rather than collapsed to a bare name because the two causes have
+/// DIFFERENT remedies, and the refusal is the only place an operator learns
+/// which one they need. Offering `--migrate-store` for a rename would send
+/// them to a flag that cannot help: both releases run the same store, so
+/// there is nothing to migrate between.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RemovalCause {
+    /// The component is absent from the render entirely -- a chart version
+    /// renamed or dropped it (minio -> rustfs). The data must be carried
+    /// across, which is what `--migrate-store` does.
+    ComponentGone,
+    /// The component survives, under a different resource name. Nothing about
+    /// the chart changed; the values did.
+    RenamedTo(String),
+}
+
+/// A live stateful component the target chart would not recreate in place.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StatefulRemoval {
+    /// The live resource name, which is what an operator recognises in their
+    /// own cluster.
+    pub name: String,
+    pub component: String,
+    pub cause: RemovalCause,
 }
 
 /// Live stateful components the target chart would not recreate.
 ///
-/// Compares COMPONENTS; reports the resource NAMES, which is what an operator
-/// recognises in their own cluster.
-///
 /// Pure, so the decision this guard turns on is testable without a cluster.
-pub fn removed_stateful_components(live: &[(String, String)], rendered: &[String]) -> Vec<String> {
+pub fn removed_stateful_components(
+    live: &[(String, String)],
+    rendered: &[(String, String)],
+) -> Vec<StatefulRemoval> {
     live.iter()
-        .filter(|(component, _)| !rendered.iter().any(|r| r == component))
-        .map(|(_, name)| name.clone())
+        .filter_map(|(component, name)| {
+            let cause = match rendered.iter().find(|(c, _)| c == component) {
+                // The component is gone entirely: a rename or removal between
+                // chart versions. This is the case the guard was built for.
+                None => RemovalCause::ComponentGone,
+                // The component survives under a DIFFERENT resource name. Helm
+                // deletes the old object and creates the new one, so the
+                // StatefulSet's volumes are orphaned and it comes up EMPTY.
+                // Just as destructive, and far likelier: any curie.yaml that
+                // does not reproduce the release's `nameOverride` renames every
+                // object at once.
+                //
+                // Comparing components alone missed this, and comparing names
+                // alone produced a 4-of-4 false positive on a release that
+                // merely uses an override (#1323). Neither is the rule; the
+                // rule is "same component, same name".
+                Some((_, rendered_name)) if rendered_name != name => {
+                    RemovalCause::RenamedTo(rendered_name.clone())
+                }
+                Some(_) => return None,
+            };
+            Some(StatefulRemoval {
+                name: name.clone(),
+                component: component.clone(),
+                cause,
+            })
+        })
         .collect()
 }
 
@@ -1601,8 +1658,12 @@ mod stateful_guard_tests {
         )
     }
 
+    fn pair(component: &str, name: &str) -> (String, String) {
+        (component.to_string(), name.to_string())
+    }
+
     #[test]
-    fn components_come_from_the_render() {
+    fn components_and_names_both_come_from_the_render() {
         let rendered = format!(
             "{}\n---\n{}",
             render("rustfs", "acme-bot-curie-rustfs"),
@@ -1610,12 +1671,14 @@ mod stateful_guard_tests {
         );
         assert_eq!(
             parse_statefulset_components(&rendered),
-            vec!["rustfs", "postgres"]
+            vec![
+                pair("rustfs", "acme-bot-curie-rustfs"),
+                pair("postgres", "acme-bot-curie-postgres"),
+            ]
         );
     }
 
     /// `kind: StatefulSet` inside a ConfigMap payload is data, not a component.
-    /// A regex over the render would invent one; parsing cannot.
     #[test]
     fn a_kind_line_inside_another_document_is_not_a_component() {
         let rendered = "\
@@ -1632,54 +1695,105 @@ data:
         assert!(parse_statefulset_components(rendered).is_empty());
     }
 
-    /// The real case: the release runs minio, chart 0.6.0 renders rustfs.
+    /// The original case: the release runs minio, the chart renders rustfs.
     #[test]
-    fn a_renamed_store_is_reported_as_a_removal() {
+    fn a_renamed_component_is_reported_as_a_removal() {
         let live = vec![
-            ("minio".to_string(), "acme-bot-minio".to_string()),
-            ("postgres".to_string(), "acme-bot-postgres".to_string()),
+            pair("minio", "acme-bot-minio"),
+            pair("postgres", "acme-bot-postgres"),
         ];
-        let rendered = vec!["rustfs".to_string(), "postgres".to_string()];
-        assert_eq!(
-            removed_stateful_components(&live, &rendered),
-            vec!["acme-bot-minio"],
-            "only the renamed store is lost, and it is named as the operator sees it"
-        );
-    }
-
-    /// The false positive that a live run exposed, pinned so it cannot return.
-    ///
-    /// The release was installed with a `nameOverride`, so every resource is
-    /// `<override>-<component>` while the chart renders
-    /// `<override>-curie-<component>`.
-    /// Comparing NAMES reported all four as removals -- postgres, valkey and
-    /// clickhouse included -- which would have taught the operator to pass
-    /// --allow-stateful-removal by reflex and lose minio for real.
-    #[test]
-    fn a_name_override_does_not_make_every_component_look_removed() {
-        let live = vec![
-            ("clickhouse".to_string(), "acme-bot-clickhouse".to_string()),
-            ("minio".to_string(), "acme-bot-minio".to_string()),
-            ("postgres".to_string(), "acme-bot-postgres".to_string()),
-            ("valkey".to_string(), "acme-bot-valkey".to_string()),
-        ];
-        // What the chart renders WITHOUT the override: different names entirely.
         let rendered = vec![
-            "clickhouse".to_string(),
-            "postgres".to_string(),
-            "rustfs".to_string(),
-            "valkey".to_string(),
+            pair("rustfs", "acme-bot-rustfs"),
+            pair("postgres", "acme-bot-postgres"),
         ];
+        let removed = removed_stateful_components(&live, &rendered);
         assert_eq!(
-            removed_stateful_components(&live, &rendered),
-            vec!["acme-bot-minio"],
-            "differing resource names must not be mistaken for removed components"
+            removed,
+            vec![StatefulRemoval {
+                name: "acme-bot-minio".to_string(),
+                component: "minio".to_string(),
+                cause: RemovalCause::ComponentGone,
+            }]
         );
     }
 
-    /// The WIRING, not just the predicate. Removing the `helm_keeps` filter from
-    /// `stateful_components_from_list` leaves every `helm_keeps` unit test green
-    /// -- that mutation survived, so this test exists to kill it.
+    /// The case a live `apply --dry-run` exposed, and the reason this rule is
+    /// not "same component".
+    ///
+    /// A curie.yaml that does not reproduce the release's `nameOverride`
+    /// renames EVERY object. The component labels are identical either way, so
+    /// a component-only comparison sees nothing wrong -- while helm deletes
+    /// `acme-bot-postgres` and creates an empty `acme-bot-curie-postgres`
+    /// beside the orphaned volume. All four data stores, silently.
+    #[test]
+    fn the_same_component_under_a_new_name_is_still_a_deletion() {
+        let live = vec![
+            pair("clickhouse", "acme-bot-clickhouse"),
+            pair("postgres", "acme-bot-postgres"),
+            pair("rustfs", "acme-bot-rustfs"),
+            pair("valkey", "acme-bot-valkey"),
+        ];
+        // What the chart renders when nameOverride is absent from the file.
+        let rendered = vec![
+            pair("clickhouse", "acme-bot-curie-clickhouse"),
+            pair("postgres", "acme-bot-curie-postgres"),
+            pair("rustfs", "acme-bot-curie-rustfs"),
+            pair("valkey", "acme-bot-curie-valkey"),
+        ];
+        let removed = removed_stateful_components(&live, &rendered);
+        assert_eq!(
+            removed.len(),
+            4,
+            "every store is deleted and recreated empty; none may be missed"
+        );
+        // The cause is what steers the operator to `nameOverride` instead of
+        // `--migrate-store`, so it is part of the answer, not a detail.
+        assert_eq!(
+            removed[1].cause,
+            RemovalCause::RenamedTo("acme-bot-curie-postgres".to_string())
+        );
+    }
+
+    /// And the false positive #1323 fixed must not come back: matching names
+    /// under matching components is not a removal.
+    #[test]
+    fn an_unchanged_component_set_is_not_a_removal() {
+        let live = vec![pair("postgres", "r-postgres"), pair("minio", "r-minio")];
+        let rendered = vec![pair("postgres", "r-postgres"), pair("minio", "r-minio")];
+        assert!(removed_stateful_components(&live, &rendered).is_empty());
+    }
+
+    #[test]
+    fn a_new_component_is_not_a_removal() {
+        let live = vec![pair("postgres", "r-postgres")];
+        let rendered = vec![
+            pair("postgres", "r-postgres"),
+            pair("clickhouse", "r-clickhouse"),
+        ];
+        assert!(removed_stateful_components(&live, &rendered).is_empty());
+    }
+
+    #[test]
+    fn a_resource_helm_is_told_to_keep_is_not_at_risk() {
+        for value in ["keep", "Keep", " keep "] {
+            let kept = serde_json::json!({
+                "metadata": {"annotations": {"helm.sh/resource-policy": value}}
+            });
+            assert!(helm_keeps(&kept), "{value:?} must read as keep");
+        }
+    }
+
+    #[test]
+    fn other_resource_policies_do_not_count_as_kept() {
+        for value in ["delete", "", "keepalive"] {
+            let r = serde_json::json!({
+                "metadata": {"annotations": {"helm.sh/resource-policy": value}}
+            });
+            assert!(!helm_keeps(&r), "{value:?} must not read as keep");
+        }
+        assert!(!helm_keeps(&serde_json::json!({"metadata": {}})));
+    }
+
     #[test]
     fn a_kept_component_is_excluded_from_the_at_risk_list() {
         let list = serde_json::json!({"items": [
@@ -1695,16 +1809,12 @@ data:
                 "spec": {"selector": {"matchLabels": {"app.kubernetes.io/component": "postgres"}}}
             }
         ]});
-        let at_risk = stateful_components_from_list(&list);
         assert_eq!(
-            at_risk,
-            vec![("postgres".to_string(), "acme-bot-postgres".to_string())],
-            "a component annotated keep is not at risk and must not be listed"
+            stateful_components_from_list(&list),
+            vec![pair("postgres", "acme-bot-postgres")]
         );
     }
 
-    /// And the same list WITHOUT the annotation must still surface it, or the
-    /// test above would pass against a function that returns nothing at all.
     #[test]
     fn an_unannotated_component_is_still_at_risk() {
         let list = serde_json::json!({"items": [
@@ -1715,53 +1825,8 @@ data:
         ]});
         assert_eq!(
             stateful_components_from_list(&list),
-            vec![("minio".to_string(), "acme-bot-minio".to_string())]
+            vec![pair("minio", "acme-bot-minio")]
         );
-    }
-
-    /// Helm's own opt-out. A store annotated `keep` survives the upgrade, so
-    /// flagging it is a false alarm -- and annotating it is precisely how an
-    /// operator detaches a store before a chart renames it.
-    #[test]
-    fn a_resource_helm_is_told_to_keep_is_not_at_risk() {
-        for value in ["keep", "Keep", " keep "] {
-            let kept = serde_json::json!({
-                "metadata": {"annotations": {"helm.sh/resource-policy": value}}
-            });
-            assert!(helm_keeps(&kept), "{value:?} must read as keep");
-        }
-    }
-
-    /// The escape must be narrow: everything else is still at risk.
-    #[test]
-    fn other_resource_policies_do_not_count_as_kept() {
-        for value in ["delete", "", "keepalive"] {
-            let r = serde_json::json!({
-                "metadata": {"annotations": {"helm.sh/resource-policy": value}}
-            });
-            assert!(!helm_keeps(&r), "{value:?} must not read as keep");
-        }
-        assert!(!helm_keeps(&serde_json::json!({"metadata": {}})));
-    }
-
-    /// The guard must stay quiet on an ordinary upgrade, or it becomes a flag
-    /// everyone passes by reflex and protects nothing.
-    #[test]
-    fn an_unchanged_component_set_is_not_a_removal() {
-        let live = vec![
-            ("postgres".to_string(), "r-postgres".to_string()),
-            ("minio".to_string(), "r-minio".to_string()),
-        ];
-        let rendered = vec!["postgres".to_string(), "minio".to_string()];
-        assert!(removed_stateful_components(&live, &rendered).is_empty());
-    }
-
-    /// A chart ADDING a store is not a removal.
-    #[test]
-    fn a_new_component_is_not_a_removal() {
-        let live = vec![("postgres".to_string(), "r-postgres".to_string())];
-        let rendered = vec!["postgres".to_string(), "clickhouse".to_string()];
-        assert!(removed_stateful_components(&live, &rendered).is_empty());
     }
 }
 

--- a/cli/tests/json_contract.rs
+++ b/cli/tests/json_contract.rs
@@ -955,6 +955,7 @@ fn diff_output_validates() {
     // Built through `diff_plan` rather than hand-listing entries, so this
     // validates the shape the real verb emits and not a parallel one.
     let out = curie::installation::DiffOutput {
+        unresolved_credentials: vec!["SLACK_BOT_TOKEN".to_string()],
         namespace: "acme-bot".to_string(),
         release: "acme-bot".to_string(),
         release_exists: true,


### PR DESCRIPTION
`curie apply --dry-run` against the live sre-bot release exited 0 and
printed a plan that would have deleted all four data stores.

The plan was a `helm upgrade` with no `--set nameOverride`. Every resource
name in this chart embeds the fullname, so dropping the override renames
all of them at once: `sre-bot-postgres` -> `sre-bot-curie-postgres`, and
the same for clickhouse, rustfs and valkey. Helm deletes the old
StatefulSets and creates new ones, which come up EMPTY beside four
orphaned volumes. Postgres, the bundle store, langfuse's clickhouse and
the queue -- in one command, reported as success.

The stateful guard is built to stop exactly this and stayed silent,
because of how it was taught to compare. It first compared resource
NAMES, which made a release that merely uses `nameOverride` look like
4-of-4 removals -- a false positive, fixed in #1323 by comparing
component LABELS instead. But `nameOverride` does not change a component
label. Component-only comparison is blind to precisely the case that
motivated the change.

Neither is the rule. The rule is "same component, SAME NAME": a live
component is at risk if the render lacks its component, or renders it
under a different name.

The two causes need opposite advice, so the removal now carries its
cause and the refusal branches on it. `--migrate-store` cannot fix a
rename -- both sides run the same store, so there is nothing to migrate
between -- and offering it would dead-end the operator at
`--allow-stateful-removal`, i.e. the guard would talk them into the
destruction it exists to prevent. A rename is pointed at the one-line
fix in their own file instead:

  set:
    nameOverride: <the name the live resources start with>

Verified against the live cluster, same file and chart, only the binary
differing: the old build exits 0 with the renaming plan; this one exits 1
and names all four transitions. The unit test that pins it fails against
the previous rule.

---

**Stacked on #1407.** CI here only runs against `main`, so this PR targets `main` and therefore also carries #1407's commit. Merge #1407 first and this collapses to the single guard commit; merging in either order lands both correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)