### PR TITLE
Make a projected secret file readable by the non-root user that must open it

### DIFF
--- a/packages/plugin-format/src/plugin_format/connector_render.py
+++ b/packages/plugin-format/src/plugin_format/connector_render.py
@@ -234,10 +234,14 @@ def render_deployment(
                 "secret": {
                     "secretName": secret_name,
                     "items": [{"key": secret_key, "path": PurePosixPath(mount_path).name}],
-                    # 0400: readable by the container's user, nobody else. These
-                    # are credentials in a pod that already runs non-root with a
-                    # read-only rootfs.
-                    "defaultMode": 0o400,
+                    # 0440, not 0400, and paired with the pod's fsGroup below.
+                    # Secret volume files are owned by root:fsGroup -- NOT by
+                    # runAsUser -- so an owner-only 0400 is unreadable by the
+                    # 65532 the container actually runs as, and the server dies
+                    # with `permission denied` on a file that is right there.
+                    # Group-readable plus a matching fsGroup is the narrowest
+                    # mode that a non-root container can actually open.
+                    "defaultMode": 0o440,
                     # Not optional, matching `secrets:` -- a missing key must
                     # stop the pod rather than start a server that 401s on every
                     # call.
@@ -270,6 +274,13 @@ def render_deployment(
                         "runAsNonRoot": True,
                         "runAsUser": 65532,
                         "seccompProfile": {"type": "RuntimeDefault"},
+                        # Only when a secret is projected as a file: it makes
+                        # the kubelet chgrp the volume so the non-root user can
+                        # read a 0440 credential. Omitted otherwise, because
+                        # fsGroup applies to every volume in the pod and there
+                        # is no reason to widen ownership for a connector that
+                        # mounts nothing.
+                        **({"fsGroup": 65532} if spec.secret_files else {}),
                     },
                     "containers": [
                         {

--- a/packages/plugin-format/tests/test_connector_render.py
+++ b/packages/plugin-format/tests/test_connector_render.py
@@ -457,13 +457,29 @@ def test_secret_file_reads_the_same_per_agent_secret_as_env_secrets() -> None:
     assert vol["items"] == [{"key": "K8S_READONLY_KUBECONFIG", "path": "kubeconfig"}]
 
 
-def test_secret_file_is_0400_and_not_optional() -> None:
-    # A credential, in a pod that already runs non-root with a read-only
-    # rootfs. `optional: False` matches `secrets:`: a missing key must stop the
-    # pod rather than start a server that 401s on every call.
+def test_secret_file_is_readable_by_the_nonroot_user_that_must_open_it() -> None:
+    # Regression: this shipped as 0400 and the server died with
+    #   open /secrets/kubeconfig: permission denied
+    # on a file that was mounted correctly. Secret volume files are owned by
+    # root:fsGroup, NOT by runAsUser, so owner-only is unreadable by the 65532
+    # the container runs as. 0440 + a matching fsGroup is the narrowest pair
+    # that actually opens.
+    pod = _file_dep(FILE_SPEC)["spec"]["template"]["spec"]
+    assert pod["volumes"][0]["secret"]["defaultMode"] == 0o440
+    assert pod["securityContext"]["fsGroup"] == pod["securityContext"]["runAsUser"]
+
+
+def test_secret_file_is_not_optional() -> None:
+    # Matches `secrets:`: a missing key must stop the pod rather than start a
+    # server that 401s on every call.
     vol = _file_dep(FILE_SPEC)["spec"]["template"]["spec"]["volumes"][0]["secret"]
-    assert vol["defaultMode"] == 0o400
     assert vol["optional"] is False
+
+
+def test_fsgroup_is_absent_when_nothing_is_projected() -> None:
+    # fsGroup applies to EVERY volume in the pod, so it is set only when a
+    # secret is actually projected as a file.
+    assert "fsGroup" not in _file_dep(HOSTED)["spec"]["template"]["spec"]["securityContext"]
 
 
 def test_each_secret_file_gets_its_own_volume() -> None:


### PR DESCRIPTION
Follow-up to #1403, which I shipped with a mode that doesn't work.

The first real connector to use `secret_files` died:

```
Error: unable to create kubernetes target provider: failed to load kubeconfig:
  error loading config file "/secrets/kubeconfig": open /secrets/kubeconfig: permission denied
```

The file was mounted, at the right path, with the right content. **Secret volume files are owned by `root:fsGroup` — not by `runAsUser`** — so an owner-only `0400` is unreadable by the 65532 the connector runs as. I was reasoning about permissions as though the container owned the file. It doesn't.

`0440` plus a matching `fsGroup` is the narrowest pair a non-root container can actually open. `fsGroup` is set **only when a secret is projected as a file** — it applies to every volume in the pod, so there's no reason to widen ownership for a connector that mounts nothing.

Two regression tests: one asserts the mode and that `fsGroup == runAsUser`, one asserts `fsGroup` stays absent otherwise. **274 pass.**

Worth naming: **the render tests could not have caught this.** They assert the manifest, and the manifest was correct — `0400` is a valid mode and a valid file was written. Only a running container reveals it can't be opened.