### PR TITLE
Complete the approval primer: the group-token landmine, 409/410, and the worked recipe

### DIFF
--- a/cli/src/guide.rs
+++ b/cli/src/guide.rs
@@ -285,8 +285,12 @@ pub fn primer() -> Primer {
                 detail: "The platform blocks the author of the turn that raised a request from resolving it, under every approver set. Testing an approval flow therefore needs a second actor: pass `--as <other-user>` on the resolve.",
             },
             Landmine {
+                title: "A group-bound route with no bot token on the API refuses every click",
+                detail: "`--route-approvers <name>=group:<S...>` makes the API resolve Slack user-group membership, which needs SLACK_BOT_TOKEN with the `usergroups:read` scope on the API process. Without it the lookup is undetermined and the authorizer fails CLOSED, so every resolution is refused as not-an-approver with nothing naming the token as the cause. Bind `users:` instead, or set the token (the scope needs the Slack app reinstalled).",
+            },
+            Landmine {
                 title: "Silence after a request usually means an unbound route",
-                detail: "A route the bundle names but the agent's approval_routes never bound is escalated to a human rather than widened to the requesting channel, so no card appears anywhere. Check the binding before suspecting the gate.",
+                detail: "A route the bundle names but the agent's approval_routes never bound is escalated to a human rather than widened to the requesting channel, so no card appears anywhere and the turn still reports the request as pending. Bind the route with `--route <name>=<channel>` and re-run the turn; check that before suspecting the gate.",
             },
             Landmine {
                 title: "Fake vs live model is symmetric across skill and local",
@@ -335,12 +339,16 @@ pub fn primer() -> Primer {
                 fix: "You are the author of the turn that raised it, which no approver set overrides. Resolve as a different actor with `--as <user>`.",
             },
             Recovery {
-                symptom: "a resolve is refused with \"you are not an approver\"",
-                fix: "The route's approver set does not admit that actor from that channel. With no approvers block the card channel's members are the set, so pass `--actor-channel` with the channel that route is bound to (or the requesting channel when the record names no route).",
+                symptom: "a resolve returns 409 already resolved",
+                fix: "Someone settled it first; resolution is once-only and the loser is told who won. Read the decision off `--list` (or the card) rather than retrying -- a retry cannot change it.",
             },
             Recovery {
-                symptom: "the agent says a request is pending but no approval card appeared",
-                fix: "The route it named is not bound for this agent, so the turn escalated instead of posting. Bind the route in the agent's approval_routes, then re-run the turn.",
+                symptom: "a resolve returns 410 expired",
+                fix: "The record aged out before anyone acted, and the turn already resumed with an `[approval expired]` prefix. Nothing is recoverable on that record: drive the gated action again to raise a fresh one.",
+            },
+            Recovery {
+                symptom: "a resolve is refused with \"you are not an approver\"",
+                fix: "The route's approver set does not admit that actor from that channel. With no approvers block the card channel's members are the set, so pass `--actor-channel` with the channel that route is bound to (or the requesting channel when the record names no route).",
             },
             Recovery {
                 symptom: "a command \"does not exist\"",

--- a/cli/src/recipes.rs
+++ b/cli/src/recipes.rs
@@ -279,6 +279,54 @@ pub(crate) fn recipes() -> Vec<Recipe> {
                 "The server blocks self-approval, so the resolving actor must not be the person whose turn raised the request.",
             ],
         },
+        // #1051 item 4, landed by #1086: the end-to-end flow, not another
+        // single verb. The two recipes above configure a gate and read what it
+        // produced; neither shows an agent author how a declaration becomes a
+        // resolved card. That path was not expressible without curl until
+        // #1057's --route flags merged, which is why the catalog carried only
+        // the --list step.
+        //
+        // Anchored on the bind because that is the step an operator types and
+        // the one the flags are new for; the declaration before it and the
+        // drive/resolve after it are ordered in the notes. Deliberately a
+        // Command rather than a Workflow: a Workflow is an interactive TUI flow
+        // in interactive.rs, which is a feature, not the primer completion this
+        // issue is.
+        Recipe {
+            tabs: &["platform"],
+            title: "Approvals end to end (declare, bind, drive, resolve)",
+            description: "Take a gated tool from its bundle declaration to a resolved card, with no curl.",
+            kind: RecipeKind::Command,
+            args: vec![
+                ArgPart::Tier,
+                ArgPart::Literal("approvals"),
+                ArgPart::Field("agent"),
+                ArgPart::Literal("--route"),
+                ArgPart::Field("route"),
+            ],
+            fields: vec![
+                Field {
+                    key: "agent",
+                    label: "Agent name",
+                    default: None,
+                    required: true,
+                },
+                Field {
+                    key: "route",
+                    label: "Route binding (name=channel)",
+                    default: Some("managers=C0EXAMPLE1"),
+                    required: true,
+                },
+            ],
+            notes: &[
+                "1. Declare the gate in the bundle: .claude-plugin/plugin.json, approvalPolicy.gates[] = {gate: <tool name>, route: <route name>}. Both keys are required and an incomplete gate is rejected at deploy.",
+                "2. Deploy it: `deploy --plugin-dir <dir> --slack-channel <C...>`. The declaration reaches the platform with the bundle, not separately.",
+                "3. Bind the route (the command above). `channel` is WHERE the card posts. Add `--route-approvers <name>=users:U1,U2` to say WHO may act; without it the card channel's members are the approver set.",
+                "4. Drive a turn that calls the gated tool. The call is denied before it runs and the turn ends awaiting approval, with a card in the bound channel.",
+                "5. Resolve it: `approvals <AGENT> --list` for the id, then `--resolve <id> --as <user> --actor-channel <channel>`. Self-approval is refused, so `--as` must name someone other than the author of the turn.",
+                "A route write REPLACES the whole map, so pass every route the agent should keep. `--list-routes` shows what is bound now.",
+            ],
+        },
         Recipe {
             tabs: &["platform"],
             title: "Inspect memory",

--- a/cli/src/scaffold.rs
+++ b/cli/src/scaffold.rs
@@ -591,6 +591,26 @@ mod tests {
         // prose, so a copy here goes stale silently. The `allowed-tools`
         // teaching lives in the correct-by-example scaffolded SKILL.md above.
         assert!(!agents.contains("allowed-tools"));
+        // The approval pointer is pinned, unlike the landmine prose above, and
+        // the difference is which way each can rot. The landmine list is
+        // deliberately NOT copied here, so there is nothing to go stale. The
+        // approval pointer IS content, and it is the one #1051 propagation path
+        // with no gate: SKILL.md is byte-pinned against `guide::primer_markdown`
+        // and the primer has its own drift test, while this file is hand-written
+        // prose that satisfied a done-when item and could quietly lose it (#1086).
+        //
+        // Two facts, both non-derivable from the command tree: the tool that
+        // raises a request, and the prefix the resume turn arrives with. An
+        // agent missing the first never pauses for a human; missing the second,
+        // it silently drops the verdict.
+        assert!(
+            agents.contains("request_approval"),
+            "AGENTS.md must name the tool that raises an approval"
+        );
+        assert!(
+            agents.contains("[approval resolved]"),
+            "AGENTS.md must name the resume-turn prefix a skill has to handle"
+        );
 
         // The installable harness primer skill, discovered by Claude Code.
         let harness_skill =

--- a/cli/tests/guide.rs
+++ b/cli/tests/guide.rs
@@ -219,6 +219,19 @@ fn guide_documents_the_approval_plane() {
             "approvers.group",
             "self-approval",
             "[approval resolved]",
+            // #1086. Each is a fact an agent cannot derive from the command
+            // tree, and each was reachable only from docs/approvals.md, which
+            // the primer's own premise says the agent does not read.
+            //
+            // The token: a group-bound route with no SLACK_BOT_TOKEN on the API
+            // refuses EVERY click, and the refusal names the approver set
+            // rather than the missing token, so the cause is invisible.
+            "SLACK_BOT_TOKEN",
+            "usergroups:read",
+            // The two refusals a second approver actually meets. Everything the
+            // primer covered before was a first-approver problem.
+            "409",
+            "410",
         ] {
             assert!(
                 text.contains(needle),

--- a/docs/approvals.md
+++ b/docs/approvals.md
@@ -71,6 +71,15 @@ Declaring a route says nothing about where it goes. The binding is **operator-ow
 per agent, and read fresh at resolve time so revoking an approver takes effect on the
 next click rather than the next restart:
 
+> **One exception, and it is the one worth knowing.** "Read fresh" holds for the
+> binding itself and for `approvers.users`. Slack **user-group** membership sits
+> behind a per-group TTL cache in the API (`slack_usergroups.py`, 60s by default
+> via `slack_usergroup_cache_ttl_s`), because `usergroups.users.list` is a Slack
+> Tier 2 method and a fetch per click would rate-limit a busy channel. So
+> removing someone from a group can take up to that TTL to bite, where removing
+> them from `approvers.users` bites immediately. Setting the TTL to 0 is the
+> operator lever for a fetch per resolve.
+
 ```json
 {
   "approval_routes": {
@@ -153,8 +162,13 @@ Three properties worth knowing before you design around this:
   membership, because that would silently widen the set an operator narrowed.
 
 Resolving a group-bound route needs `SLACK_BOT_TOKEN` on the API with the
-`usergroups:read` scope (`apps/api/src/curie_api/slack_usergroups.py`). Without it, such
-a route fails closed.
+`usergroups:read` scope. Both requirements are stated in
+[ADR-0034](adr/0034-approval-authorizers-resolve-membership-in-the-api.md) and
+`.env.example`; `apps/api/src/curie_api/slack_usergroups.py` is the lookup that
+consumes them and names neither, so it is the wrong place to send a reader
+checking the claim. The scope needs the Slack app reinstalled. Without the
+token, such a route fails closed: every resolution on it is refused as
+not-an-approver, with nothing naming the missing token as the cause.
 
 ## What your skill must handle on resume
 


### PR DESCRIPTION
#1051's premise is that a coding agent reads the primer and **not** the repo. So every fact that landed only in `docs/approvals.md` is invisible to the agent the primer exists for. Six gaps, each verified against `main` before writing a line.

## 1. The group-token landmine was absent entirely

A route bound to `approvers.group` with no `SLACK_BOT_TOKEN` on the API refuses **every** click: the membership lookup comes back undetermined and the authorizer fails closed. The refusal names the *approver set*, not the missing token, so nothing in the message points at the cause.

`grep -n "SLACK_BOT_TOKEN\|usergroups" cli/src/guide.rs` returned nothing.

## 2. 409 and 410 were missing

The primer's recoveries covered self-approval, not-an-approver and no-card -- all **first**-approver problems. The two refusals a *second* approver actually meets existed only in `docs/approvals.md`.

## 3. The worked recipe

The catalog carried a one-line `--list`. It now carries the flow #1051 asked for: declare the gate, deploy, bind with #1057's `--route`, drive the turn, resolve.

Anchored on the **bind**, because that is the step an operator types and the one the flags are new for; the declaration before it and the drive/resolve after it are ordered in the notes.

**Deliberately a `Command` and not a `Workflow`.** A `Workflow` is an interactive multi-screen TUI flow in `interactive.rs` -- a feature, with its own design questions, rather than the primer completion this issue is.

## 4. The one propagation path with no gate

`AGENTS.md`'s approval pointer satisfied a #1051 done-when item with nothing pinning it, while both siblings are gated: `SKILL.md` is byte-equal to `guide::primer_markdown()`, and the primer has its own drift test. The ungated path is the one that can rot back out.

It now asserts `request_approval` and `[approval resolved]` -- the two facts an agent cannot derive from the command tree. Without the first it never pauses for a human; without the second it silently drops the verdict.

The landmine prose stays **deliberately ungated**, and the test says why: it defers to `curie guide` rather than copying anything, so there is nothing there to go stale.

## 5 and 6. Two docs corrections

The `SLACK_BOT_TOKEN` / `usergroups:read` requirement cited `slack_usergroups.py`, **which names neither**. The statements live in ADR-0034 and `.env.example`; the citation now says which file is which, and notes that the lookup file is the consumer rather than the source.

And "read fresh at resolve time" is true for the binding and for `approvers.users` -- but **not** for group membership, which sits behind a 60s per-group TTL cache (`slack_usergroup_cache_ttl_s`) because `usergroups.users.list` is a Slack Tier 2 method. So a group revocation can lag by up to that TTL where a `users:` revocation bites immediately.

## The line bound

151 of 160. The additions crowded it, so the unrequested no-card-appeared recovery is folded into the unbound-route landmine it duplicated -- exactly the candidate the issue names. The fix half is preserved in the landmine's detail, so nothing an agent needs was dropped.

## Verified

`guide_documents_the_approval_plane` pins `SLACK_BOT_TOKEN`, `usergroups:read`, `409` and `410` in **both** renderings.

Red-proofed twice: removing the new landmine reds the guide test; weakening the `AGENTS.md` sentence reds the scaffold gate with "must name the tool that raises an approval".

`cargo fmt --check`, `clippy --all-targets -D warnings`, full `cargo test` (including `tui_parity`, which validates the new recipe's argv against the real command tree), and `curie dev docs-lint` all green. No command-surface change, so no manifest regeneration.

## Not pulled in

The issue calls #1078 a reasonable same-pass sibling. It is blocked by #1075, and Brian's note there is that the better fix is exposing the field rather than softening the wording -- a decision, not a doc edit. Left alone.

Closes #1086