### PR TITLE
Release 0.7.0-rc.1

### DIFF
--- a/charts/curie/Chart.yaml
+++ b/charts/curie/Chart.yaml
@@ -8,8 +8,8 @@ description: >-
   and two install-time preflights ship baked in: a CPU-AVX / ClickHouse-pin
   check and a NetworkPolicy-enforcement probe.
 type: application
-version: 0.6.0
-appVersion: "0.6.0"
+version: 0.7.0-rc.1
+appVersion: "0.7.0-rc.1"
 kubeVersion: ">=1.25.0-0"
 maintainers:
   - name: Curie

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -749,7 +749,7 @@ dependencies = [
 
 [[package]]
 name = "curie"
-version = "0.6.0"
+version = "0.7.0-rc.1"
 dependencies = [
  "anstream",
  "anstyle",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "curie"
-version = "0.6.0"
+version = "0.7.0-rc.1"
 edition = "2021"
 description = "Curie CLI: init/start/send/eval a plugin against a local runner (task I1)"
 


### PR DESCRIPTION
A release candidate, not 0.7.0 itself: `release.yaml` marks any tag
containing a hyphen as a GitHub pre-release, so this publishes the full
signed asset set without claiming to be the stable minor.

0.7.0 rather than 0.6.1 because the surface grew. Since v0.6.0 four new
top-level commands landed -- `apply`, `diff`, `doctor`, `seal` -- along
with new chart values and new result schemas. Nothing was removed or
renamed, so the bump is additive, but a patch number would tell an
operator "fixes only" and then hand them `curie apply`.

Three fields, set by `curie dev bump-version` rather than by hand:
cli/Cargo.toml, Chart.yaml version, and Chart.yaml appVersion. They must
agree with each other and with the tag or the release job refuses --
appVersion is the runner image-tag fallback, so a stale one ships a chart
that pulls the wrong image (#489).

## What is in it, since v0.6.0

~50 merged PRs. The headline additions:

- **`curie apply` / `curie diff`** (ADR-0097) — one file declares an installation; diff shows what applying it would change.
- **`curie seal`** (ADR-0094) — sealed connector credentials, NaCl sealed boxes, Rust seals and Python opens.
- **`curie doctor`** — a single readiness verdict instead of a scavenger hunt across four commands.
- **`curie cluster migrate-store`** — carries bundle objects across the 0.6.0 minio→rustfs rename.
- Channel-scoped memory (ADR-0095), connector secret files, the connector reconciler.

## Verification before tagging

- `check-version-consistency.sh` green: Cargo.toml, Chart.yaml `version`, and `appVersion` all `0.7.0-rc.1`.
- `helm lint` + `helm package` accept the prerelease version and produce `curie-0.7.0-rc.1.tgz`, which is exactly the asset name `artifacts.rs` resolves.
- Full `cargo test --locked` and `clippy -D warnings` green locally.

## Known gap

The upgrade path from an installed 0.6.0 has **not** been verified end to end. ADR-0094's sealing and the connector secret files (#1403) both touched the chart's Secret wiring. I will run `curie diff` against the live sre-bot release with the published rc chart once this is tagged, and report what it says before anyone treats the rc as upgradeable.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)