### PR TITLE
Add docs/pillars.md for the eight agent-development pillars

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,16 @@ open a GitHub issue describing the change so a maintainer can confirm it fits
 the project's direction. This is especially important for anything that touches
 a cross-component seam or a frozen contract (see below).
 
+## Labeling issues, PRs, and discussions
+
+Work here is organized around eight agent-development pillars (capability
+authoring, model and routing strategy, memory and institutional knowledge,
+connectivity and channels, security and governance, observability and
+auditability, evaluation and continuous improvement, and deployment and
+lifecycle management), each with a `pillar:*` label. See
+[`docs/pillars.md`](docs/pillars.md) for what each pillar covers and how to
+apply the labels to issues, epics, PRs, and discussions.
+
 ## Before you start
 
 - **Be respectful.** All participation is governed by our

--- a/docs/README.md
+++ b/docs/README.md
@@ -58,6 +58,8 @@ git history (`git log -- docs/`).
 - [`slack-local-runbook.md`](slack-local-runbook.md): connect your own Slack
   app to the local compose stack to exercise real mentions and threads without a
   cluster.
+- [`pillars.md`](pillars.md): the eight agent-development pillars issues, PRs,
+  and discussions are labeled against, and how to apply the labels.
 
 Forward-looking work is planned and tracked in
 [GitHub issues](https://github.com/curie-eng/curie/issues), with larger

--- a/docs/pillars.md
+++ b/docs/pillars.md
@@ -1,0 +1,61 @@
+# Agent-development pillars
+
+Curie's issues, pull requests, and discussions are organized around eight
+recurring concerns in agent development, not around the code interfaces or
+components a given change happens to touch. The pillars group work by the
+problem it solves, so a maintainer or contributor can filter to everything
+about, say, model routing or security policy, regardless of which package or
+service the change lives in. The taxonomy was proposed and agreed in
+[discussion #1176](https://github.com/curie-eng/curie/discussions/1176).
+
+## The eight pillars
+
+Each pillar has a corresponding `pillar:*` label.
+
+1. **Capability authoring** (`pillar:capability-authoring`): prompts, tool
+   integration, and subagent decomposition. What an agent can do, and how a
+   contributor builds or tunes that capability.
+2. **Model and routing strategy** (`pillar:model-routing-strategy`): choosing
+   and routing across LLMs for different tasks, and the credentials that go
+   with a given model or provider.
+3. **Memory and institutional knowledge**
+   (`pillar:memory-institutional-knowledge`): durable, persistent memory
+   across agent hierarchies.
+4. **Connectivity and channels** (`pillar:connectivity-channels`): how agents
+   communicate with people and with other agents, across Slack, Teams, email,
+   GitHub, and any other channel humans already use.
+5. **Security and governance** (`pillar:security-governance`): what actions an
+   agent may take on a tool, on behalf of a user or as a service identity; who
+   may invoke an agent and who it may reply to; human-in-the-loop controls and
+   killswitches; and resistance to adversarial input.
+6. **Observability, debugging, and auditability**
+   (`pillar:observability-auditability`): local and production tracing and
+   diagnostics, plus the tamper-proof record of what an agent did and why.
+7. **Evaluation and continuous improvement**
+   (`pillar:evaluation-continuous-improvement`): pre-deploy testing and
+   verification, and the production feedback loop that improves an agent
+   after it ships.
+8. **Deployment and lifecycle management** (`pillar:deployment-lifecycle`):
+   versioning, promotion, rollback, and the rest of an agent's release
+   lifecycle.
+
+## Applying the labels
+
+- **Issues and epics**: always label with the pillar (or pillars) the work
+  belongs to. This is the primary place the taxonomy earns its value, for
+  triage and for filtering a backlog by concern.
+- **Pull requests**: a PR that closes a labeled issue inherits that issue's
+  pillar and does not need its own label. Label a PR directly only when it has
+  no linked issue, such as a drive-by fix, or when it genuinely spans more
+  than one pillar.
+- **Discussions**: an unscoped idea in the `Ideas` category should carry a
+  pillar label when it clearly falls under one. Discussions that are general
+  questions or support requests (the `General` and `Q&A` categories) do not
+  need one.
+
+## Scope and change process
+
+These eight pillars are not guaranteed to be exhaustive forever; new concerns
+may surface as the project grows. Propose a new pillar, or a change to an
+existing one, as a GitHub discussion under `Ideas` before creating the label,
+the same way this taxonomy itself was proposed.


### PR DESCRIPTION
Adds `docs/pillars.md` documenting the eight agent-development pillars agreed in #1176: capability authoring, model and routing strategy, memory and institutional knowledge, connectivity and channels, security and governance, observability and auditability, evaluation and continuous improvement, and deployment and lifecycle management.

Each pillar maps to a `pillar:*` label (already created on this repo). The doc covers how to apply the labels to issues, epics, PRs, and discussions:

- Issues and epics are always labeled.
- A PR inherits its pillar from a linked issue; label directly only when untethered or spanning multiple pillars.
- Discussions in the `Ideas` category get a pillar label when in scope; `General`/`Q&A` do not need one.

Also links the new doc from `CONTRIBUTING.md` and lists it in `docs/README.md` alongside the rest of the living documentation.

Ref #1176