### PR TITLE
Stop `curie diff` claiming apply will reset the sealing key

### DIFF
--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -1136,11 +1136,21 @@ pub(crate) const FAKE_MODEL_KEY: &str = "agentSandbox.runner.fakeModel";
 /// "proposing to delete what it did not create" failure ADR-0097 named.
 ///
 /// Reads the same constants `up` reads, so a new preserved family is picked up
-/// by both or neither.
+/// by both or neither. That claim was false for one release: sealing (ADR-0094)
+/// added a family to [`resolve_preserved_values`] and not to this list, so
+/// `diff` announced that apply would reset `sealing.privateKey` to the chart
+/// default. Apply does no such thing -- it hands the live key straight back.
+///
+/// A false reset here is worse than a missing one. The note `diff` prints on a
+/// reset says to declare the value in `curie.yaml` to keep it, and following
+/// that for this key means pasting a PRIVATE KEY into a file whose own header
+/// says it carries names and never secrets. `sealing_test` below asserts the
+/// two lists agree by construction rather than by a hand-kept fixture.
 pub fn is_preserved_by_up(key: &str) -> bool {
     COMMS_MANAGED_KEYS.contains(&key)
         || GITHUB_APP_MANAGED_KEYS.contains(&key)
         || REQUIRED_SECRETS.iter().any(|(k, _)| *k == key)
+        || crate::sealing::SEALING_MANAGED_KEYS.contains(&key)
 }
 
 /// Substrings that mark a chart key as carrying a credential.
@@ -1585,6 +1595,50 @@ mod sealing_preservation_tests {
         assert_eq!(
             get(&all, crate::sealing::SEALING_PRIVATE_KEY),
             Some("BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=")
+        );
+    }
+
+    /// The seam that actually broke, closed by construction.
+    ///
+    /// `up` re-supplies a set of keys; `diff` decides which keys survive an
+    /// apply via `is_preserved_by_up`. Those two answers must be the same
+    /// answer. They were kept in step by a hand-written list, and sealing was
+    /// added to one and not the other -- so `curie diff` against a real 0.6.0
+    /// release announced `sealing.privateKey (reset to chart default)` for a
+    /// key apply hands straight back.
+    ///
+    /// This drives the REAL resolver over a release carrying every preserved
+    /// family and asserts `diff` agrees about every key it returns. A future
+    /// family added to `resolve_preserved_values` alone fails here instead of
+    /// reaching an operator as a false alarm about their own data.
+    #[test]
+    fn diff_agrees_with_every_key_up_actually_re_supplies() {
+        let existing = values(serde_json::json!({
+            "sealing": {
+                "privateKey": "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC=",
+                "previousPrivateKey": "DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD="
+            },
+            "dispatcher": {"slack": {"appToken": "xapp-EXAMPLE", "botToken": "xoxb-EXAMPLE"}},
+            "api": {
+                "githubAppId": "1",
+                "githubAppExistingSecret": "an-app-secret",
+                "githubAppExistingSecretKey": "privateKey"
+            }
+        }));
+        let supplied = resolve_preserved_values(Some(&existing), &[]);
+        assert!(
+            !supplied.is_empty(),
+            "fixture must exercise the resolver, not pass vacuously"
+        );
+        let disagreements: Vec<&str> = supplied
+            .iter()
+            .map(|(k, _)| k.as_str())
+            .filter(|k| !is_preserved_by_up(k))
+            .collect();
+        assert!(
+            disagreements.is_empty(),
+            "`up` re-supplies these keys but `is_preserved_by_up` says apply drops them, \
+             so `curie diff` would report a reset that never happens: {disagreements:?}"
         );
     }
 


### PR DESCRIPTION
Running the freshly released 0.7.0-rc.1 binary against the live 0.6.0
sre-bot release, `curie diff` reported:

  ! sealing.privateKey: <secret> (reset to chart default)

Apply does no such thing. `resolve_sealing_values` hands the live key
straight back -- deliberately, with a comment saying regenerating it
"would render every sealed credential in every agent repository
permanently unreadable". The value was never at risk; only the report was
wrong.

`diff` decides what survives an apply through `is_preserved_by_up`, which
enumerates the preserved families: comms, the GitHub App, and the
generated store passwords. ADR-0094 added sealing to
`resolve_preserved_values` and not to that list. The doc comment on
`is_preserved_by_up` even claims "a new preserved family is picked up by
both or neither" -- an invariant nothing enforced.

A false reset is worse here than a missed one. The note `diff` prints
alongside a reset says to declare the value in curie.yaml to keep it, and
for this key that means pasting a PRIVATE KEY into a file whose own header
says it carries names and never secrets. An operator who instead believed
the report would conclude an upgrade orphans every sealed credential they
have, and not upgrade at all.

The list now reads `SEALING_MANAGED_KEYS`, which already existed. The
test that should have caught this compared against a hand-written array of
key names, written before sealing existed, so it agreed with whatever the
code did. It is replaced by one that drives the real resolver over a
release carrying every preserved family and asserts `diff` agrees about
every key it returns -- a family added to one side and not the other now
fails in CI instead of reaching an operator as a false alarm about their
own data.

Found by the post-release verification of v0.7.0-rc.1: the released binary, installed from the public release asset onto the sre-bot box, run against the live 0.6.0 release.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)