### PR TITLE
Release 0.7.0-rc.2

### DIFF
--- a/charts/curie/Chart.yaml
+++ b/charts/curie/Chart.yaml
@@ -8,8 +8,8 @@ description: >-
   and two install-time preflights ship baked in: a CPU-AVX / ClickHouse-pin
   check and a NetworkPolicy-enforcement probe.
 type: application
-version: 0.7.0-rc.1
-appVersion: "0.7.0-rc.1"
+version: 0.7.0-rc.2
+appVersion: "0.7.0-rc.2"
 kubeVersion: ">=1.25.0-0"
 maintainers:
   - name: Curie

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -749,7 +749,7 @@ dependencies = [
 
 [[package]]
 name = "curie"
-version = "0.7.0-rc.1"
+version = "0.7.0-rc.2"
 dependencies = [
  "anstream",
  "anstyle",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "curie"
-version = "0.7.0-rc.1"
+version = "0.7.0-rc.2"
 edition = "2021"
 description = "Curie CLI: init/start/send/eval a plugin against a local runner (task I1)"
 


### PR DESCRIPTION
rc.1 shipped a `curie diff` that lied about one key. Run against the live
0.6.0 sre-bot release it reported

  ! sealing.privateKey: <secret> (reset to chart default)

for a key apply hands straight back. #1415 fixed the report and replaced
the test that missed it. The rc.1 binary's apply BEHAVIOUR was correct
throughout -- nothing sealed was ever at risk -- but the note printed
beside a reset tells the operator to declare the value in curie.yaml to
keep it, and following that for a private key is the one thing that file
must never carry. Worth a second candidate rather than leaving that in
the newest published artifact.

No other change: same three coupled fields, set by `curie dev
bump-version`.

## Delta from rc.1

One commit: [#1415](https://github.com/curie-eng/curie/pull/1415), `is_preserved_by_up` now consults `SEALING_MANAGED_KEYS`, plus a test that derives from the real resolver instead of a hand-kept key list.

## Verification before tagging

- `check-version-consistency.sh` green at `0.7.0-rc.2`.
- `helm lint` clean; the prerelease version packages as `curie-0.7.0-rc.2.tgz`, the asset name `artifacts.rs` resolves.
- `cargo test --locked` and `clippy -D warnings` green.

After tagging I will install the published rc.2 on the sre-bot box and re-run the diff that found the bug, to confirm `sealing.privateKey` now reports as preserved rather than reset.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)