### PR TITLE
Report the card channel on --list, the one field --resolve cannot be driven without

### DIFF
--- a/cli/api-mirrors.json
+++ b/cli/api-mirrors.json
@@ -71,10 +71,6 @@
           "why": "The idempotency key is a server-side dedupe concern; the CLI neither displays it nor resubmits on it."
         },
         {
-          "field": "card_channel",
-          "why": "Where the approval card was posted is a Slack-delivery detail; the operator-facing listing renders conversation_id/summary, not the card channel."
-        },
-        {
           "field": "resolution_note",
           "why": "resolve_approval SENDS a note via --note; it does not read back the stored resolution_note when listing pending approvals."
         },

--- a/cli/schema/approvals.schema.json
+++ b/cli/schema/approvals.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://schemas.curietech.ai/cli/approvals/v1.1.json",
+  "$id": "https://schemas.curietech.ai/cli/approvals/v1.2.json",
   "title": "curie <tier> approvals --json",
   "description": "The agent-facing payload of `curie <tier> approvals <agent>`: the dry-run plan; the gate list (`manifest_unreadable` non-null when the deployed manifest could not be read); the pending approval records (`truncated` true when the server page cap was hit); a single resolved record; or the agent's approval route bindings, where each route's `channel` is where its card posts and its optional `approvers` block is who may resolve it.",
   "$defs": {
@@ -67,6 +67,13 @@
           ]
         },
         "resolved_by": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "card_channel": {
+          "description": "The channel the approval card was posted to, or null when the record names no route (the requesting channel is then the approver set). This is what `--resolve` needs as `--actor-channel`: with no `approvers` block the channel's MEMBERS are the approver set, and the server-side authorizer compares against it, so the value is not derivable by guessing (#1078).\n\nOPTIONAL, and the only optional property in this record, which is deliberate rather than an oversight. Every sibling was required at birth, when no compatibility question existed. ADR-0101 prefers optional for a property added later: a consumer can tolerate its absence in a payload from an older CLI, which keeps this a MINOR bump. Making it required would reject those older payloads and cost a major version for no gain.",
           "type": [
             "string",
             "null"

--- a/cli/schema/index.json
+++ b/cli/schema/index.json
@@ -13,7 +13,7 @@
       "result": "ApprovalsOutput",
       "kind": "CliOutput",
       "schema": "approvals.schema.json",
-      "version": "1.1"
+      "version": "1.2"
     },
     {
       "result": "BudgetOutput",

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -207,6 +207,16 @@ pub struct ApprovalRecord {
     pub expires_at: Option<String>,
     #[serde(default)]
     pub resolved_by: Option<String>,
+    /// The channel the approval card was posted to (#1078). Load-bearing, not
+    /// a delivery detail: with no `approvers` block on the route this channel's
+    /// MEMBERS are the approver set, and `--resolve` needs it as
+    /// `--actor-channel` because that is what the server-side authorizer
+    /// compares against. Without it the value is underivable from the CLI and
+    /// a guess is a refusal. `#[serde(default)]` keeps a record that predates
+    /// route bindings parsing to None, which is the same fact as "no route, so
+    /// the requesting channel applies".
+    #[serde(default)]
+    pub card_channel: Option<String>,
 }
 
 /// What a deploy did with the agent's Slack channel, for the summary printout.

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -4327,6 +4327,10 @@ fn approval_record_json(r: &crate::api::ApprovalRecord) -> serde_json::Value {
         "summary": r.summary,
         "expires_at": r.expires_at,
         "resolved_by": r.resolved_by,
+        // #1078: the one field --resolve cannot be driven without. Null when
+        // the record names no route, which means the requesting channel is the
+        // approver set rather than a bound one.
+        "card_channel": r.card_channel,
     })
 }
 

--- a/cli/src/recipes.rs
+++ b/cli/src/recipes.rs
@@ -275,7 +275,8 @@ pub(crate) fn recipes() -> Vec<Recipe> {
                 required: true,
             }],
             notes: &[
-                "Each record reports the id and the channel its route bound the card to; resolve one with `--resolve <id> --as <user> --actor-channel <channel>`.",
+                "Each record reports its id and `card_channel`, the channel its route bound the card to; pass that as `--actor-channel` when resolving: `--resolve <id> --as <user> --actor-channel <card_channel>`.",
+                "A null `card_channel` means the record names no route, so the REQUESTING channel is the approver set; pass that one instead.",
                 "The server blocks self-approval, so the resolving actor must not be the person whose turn raised the request.",
             ],
         },

--- a/cli/tests/approvals_resolve_actor_channel.rs
+++ b/cli/tests/approvals_resolve_actor_channel.rs
@@ -190,3 +190,68 @@ async fn actor_channel_present_alongside_reject_decision() {
     assert_eq!(body["decision"], "rejected");
     assert_eq!(body["resolved_by"], "brian");
 }
+
+// ─── #1078: the recipe promises this field; --list must actually emit it ─────
+
+/// The card channel must reach the operator through `--list --json`, because
+/// `--resolve` cannot be driven without it.
+///
+/// #1056's recipe told an agent that `--list` reports the channel a route bound
+/// the card to. It did not: `approval_record_json` projected ten fields and
+/// dropped `card_channel`, while the API had carried it all along. With no
+/// `approvers` block on the route, that channel's MEMBERS are the approver set
+/// and `slack_approvers.py` compares `actor_channel` against it, so a guess is a
+/// 403 and the value was underivable from the CLI.
+///
+/// Asserted end to end through the real handler rather than by constructing an
+/// `ApprovalRecord`: the defect was in the PROJECTION, which a hand-built record
+/// walks straight past.
+#[tokio::test]
+async fn list_json_reports_the_card_channel_the_recipe_promises() {
+    let server = serve(|req| match (req.method.as_str(), req.path.as_str()) {
+        ("GET", "/agents") => Response::json(
+            200,
+            r##"[{"id":"11111111-1111-1111-1111-111111111111","name":"weather","slack_channel":"CREQUEST01","created_at":"2026-07-05T00:00:00Z"}]"##,
+        ),
+        ("GET", p) if p.starts_with("/approvals") => Response::json(
+            200,
+            r##"[{"id":"22222222-2222-2222-2222-222222222222","agent_id":"11111111-1111-1111-1111-111111111111","author":"U-REQUESTER","route":"finance","gate_kind":"policy","granted_tool":null,"status":"pending","conversation_id":"thread-1","summary":"approve invoice","expires_at":null,"resolved_by":null,"card_channel":"CFINANCE01","reply_channel":"CREQUEST01"}]"##,
+        ),
+        other => panic!("unexpected request: {other:?}"),
+    });
+
+    let out = approvals(
+        AgentActionOpts {
+            api_url: server.base_url.clone(),
+            api_key: TEST_API_KEY.to_string(),
+            agent: "weather".to_string(),
+            dry_run: false,
+        },
+        vec![],
+        false,
+        ApprovalCmd {
+            list: true,
+            ..ApprovalCmd::default()
+        },
+    )
+    .await
+    .expect("list succeeds");
+
+    let json = curie::ui::CliOutput::to_json(&out);
+    let record = &json["pending"][0];
+
+    assert_eq!(
+        record["card_channel"], "CFINANCE01",
+        "--list --json must report the card channel; without it --actor-channel \
+         is underivable and every resolve on a channel-authorized route 403s. \
+         Payload: {json}"
+    );
+    // The requesting channel is a DIFFERENT channel, which is the whole reason
+    // guessing fails: an agent that assumed the two were the same would send the
+    // wrong one and read the refusal as an authorization problem.
+    assert_ne!(
+        record["card_channel"], "CREQUEST01",
+        "the fixture must keep card and reply channels distinct, or this test \
+         cannot tell a correct value from a lucky one"
+    );
+}

--- a/cli/tests/json_contract.rs
+++ b/cli/tests/json_contract.rs
@@ -1312,6 +1312,8 @@ fn approval_record() -> ApprovalRecord {
         summary: "run tests".to_string(),
         expires_at: Some("2026-01-01T00:00:00Z".to_string()),
         resolved_by: None,
+        // #1078: the field --actor-channel is derived from.
+        card_channel: Some("CFINANCE01".to_string()),
     }
 }
 

--- a/cli/tests/json_emit_contract.rs
+++ b/cli/tests/json_emit_contract.rs
@@ -753,6 +753,8 @@ fn approvals_pending_and_resolved_json_shapes_are_pinned() {
         summary: "Deploy the thing".to_string(),
         expires_at: Some("2026-07-16T00:00:00Z".to_string()),
         resolved_by: None,
+        // #1078: the field --actor-channel is derived from.
+        card_channel: Some("CFINANCE01".to_string()),
     };
     assert_eq!(
         ApprovalsOutput::Pending {
@@ -774,6 +776,11 @@ fn approvals_pending_and_resolved_json_shapes_are_pinned() {
                 "summary": "Deploy the thing",
                 "expires_at": "2026-07-16T00:00:00Z",
                 "resolved_by": null,
+                // #1078. Pinned here because this assertion is the reason the
+                // omission was noticeable at all: the projection is spelled out
+                // key by key, so a field the API carries and the CLI drops is
+                // visible in the diff rather than inferred.
+                "card_channel": "CFINANCE01",
             }],
             "count": 1,
             "truncated": false,

--- a/cli/tests/schema_inventory.rs
+++ b/cli/tests/schema_inventory.rs
@@ -296,30 +296,62 @@ fn rejects_an_undeclared_raw_emit_json_site() {
 
 // ─── ADR-0101: an unchanged $id must stay compatible ─────────────────────────
 
-/// Every property name a schema accepts at its root, including inside `oneOf`
-/// branches, plus the `required` set. Enough to decide the two compatibility
-/// questions ADR-0101 turns on and nothing more.
+/// Every property a schema accepts, and every property it requires, ANYWHERE in
+/// the document. Enough to decide the two compatibility questions ADR-0101 turns
+/// on and nothing more.
+///
+/// Names are qualified by their JSON Pointer path, so a `card_channel` added
+/// under `$defs/approvalRecord` is a different name from one added at the root.
+/// Without that, moving a property between two objects would cancel out and read
+/// as no change at all.
+///
+/// Walks the whole tree rather than the root plus `oneOf`. The first version of
+/// this gate did only those two, and 20 of 39 schemas keep their real content in
+/// `$defs` -- including `approvals`, whose entire record shape lives there. The
+/// gap surfaced on the very next change to land (#1078, adding
+/// `$defs/approvalRecord/card_channel`), which the gate waved straight through.
 fn shape(schema: &serde_json::Value) -> (BTreeSet<String>, BTreeSet<String>) {
     let mut props = BTreeSet::new();
     let mut required = BTreeSet::new();
-    let mut collect = |v: &serde_json::Value| {
-        if let Some(p) = v.get("properties").and_then(|p| p.as_object()) {
-            props.extend(p.keys().cloned());
-        }
-        if let Some(r) = v.get("required").and_then(|r| r.as_array()) {
-            required.extend(r.iter().filter_map(|x| x.as_str().map(str::to_string)));
-        }
-    };
-    collect(schema);
-    for branch in schema
-        .get("oneOf")
-        .and_then(|b| b.as_array())
-        .into_iter()
-        .flatten()
-    {
-        collect(branch);
-    }
+    walk(schema, String::new(), &mut props, &mut required);
     (props, required)
+}
+
+/// Recursive half of [`shape`]. `path` is the JSON Pointer to `node`.
+fn walk(
+    node: &serde_json::Value,
+    path: String,
+    props: &mut BTreeSet<String>,
+    required: &mut BTreeSet<String>,
+) {
+    match node {
+        serde_json::Value::Object(map) => {
+            if let Some(p) = map.get("properties").and_then(|p| p.as_object()) {
+                props.extend(p.keys().map(|k| format!("{path}/properties/{k}")));
+            }
+            if let Some(r) = map.get("required").and_then(|r| r.as_array()) {
+                required.extend(
+                    r.iter()
+                        .filter_map(|x| x.as_str())
+                        .map(|k| format!("{path}/required/{k}")),
+                );
+            }
+            for (k, v) in map {
+                // Prose, not shape: skipping it keeps a reworded description
+                // from reading as a compatibility event.
+                if matches!(k.as_str(), "description" | "title" | "$comment") {
+                    continue;
+                }
+                walk(v, format!("{path}/{k}"), props, required);
+            }
+        }
+        serde_json::Value::Array(items) => {
+            for (i, v) in items.iter().enumerate() {
+                walk(v, format!("{path}/{i}"), props, required);
+            }
+        }
+        _ => {}
+    }
 }
 
 fn schema_id(v: &serde_json::Value) -> String {

--- a/docs/approvals.md
+++ b/docs/approvals.md
@@ -244,7 +244,7 @@ or `approvers.group` ignores the channel entirely, so passing it there is harmle
 | Symptom | Cause and fix |
 |---|---|
 | `403 self-approval is blocked` | You are the author of the turn that raised it. Resolve as a different actor. |
-| `403 you are not an approver` | The route's set does not admit that actor from that channel. Pass the `--actor-channel` the record reports, or check the `approvers` block. |
+| `403 you are not an approver` | The route's set does not admit that actor from that channel. Pass the record's `card_channel` as `--actor-channel` (`--list --json` reports it since #1078), or check the `approvers` block. A null `card_channel` means the record names no route, so the requesting channel is the set. |
 | `403 could not verify approvers` | A group lookup failed or the approvers block does not parse. Check `SLACK_BOT_TOKEN` and the `usergroups:read` scope; this never falls back to channel membership. |
 | `409 already resolved by ...` | Someone else won the claim. The decision stands. |
 | `410 expired` | The record passed its deadline. The session was already woken down its timeout branch. |


### PR DESCRIPTION
#1056's recipe told an agent that `approvals --list` reports the channel a route bound the card to. **It did not.** `approval_record_json` projected ten fields and dropped `card_channel`, which the API had carried all along.

That field is not a delivery detail, which is what its omission entry in `api-mirrors.json` claimed. With no `approvers` block on a route, the card channel's **members** are the approver set, and `slack_approvers.py` compares `actor_channel` against exactly that. So `--resolve` needs it, a guess is a 403, and the value was underivable from the CLI -- which makes the primer *wrong* rather than merely incomplete, the failure #1051's premise makes expensive.

## ADR-0101's first instance

Blocked on #1075 until now, because the fix is the exact change shape that issue was about: an added **optional** property, so `approvals` goes **v1.1 to v1.2**, a minor bump. Baseline untouched -- the version moved instead of the goalposts.

**Optional deliberately**, though every sibling in `approvalRecord` is `required`. They were required at birth, when no compatibility question existed. ADR-0101 prefers optional for a property added later: a consumer tolerates its absence in a payload from an older CLI, which keeps this minor. Required would reject those payloads and cost a major for no gain. The schema records that reasoning where the next reader will look.

## The gate did not catch it, and that is the bigger half of this PR

The #1075 gate's `shape()` walked the root and `oneOf` branches only. `card_channel` lives in `$defs/approvalRecord`, and **20 of 39 schemas keep their real content in `$defs`** -- `approvals` among them, where the entire record shape lives.

So the gate waved through the very next change it existed to catch. I found it by reverting the bump as a sanity check and watching the gate stay green.

It now walks the whole document and qualifies each name by its JSON Pointer path, so a property moved between two objects cannot silently cancel out. Verified:

```
approvals.schema.json at UNCHANGED $id .../approvals/v1.json
  adds ["/$defs/approvalRecord/properties/card_channel"]
    A consumer holding this $id rejects the new payload
    (additionalProperties: false). Bump the MINOR version.
```

## The rest

The recipe and `docs/approvals.md` now **name the key** rather than describing it, and both state what a null means: no route on the record, so the requesting channel is the approver set.

The drift test (#1078's third AC) runs the real handler against a wire stub whose card and reply channels **differ**, so it cannot pass on a lucky value. Red-proofed: dropping the projection line fails it with the whole payload printed.

`json_emit_contract.rs`'s pinned shape caught the change and is updated -- that assertion spells the projection out key by key, which is exactly why a dropped field is visible in a diff rather than inferred.

## Verified

`cargo fmt --check`, `clippy --all-targets -D warnings`, full `cargo test`, `curie dev docs-lint` green. No command-surface change, so no manifest regeneration.

Closes #1078