### PR TITLE
Draft ADR-0102: a named security posture is computed, not configured

### DIFF
--- a/docs/adr/0104-a-named-security-posture-is-computed-not-configured.md
+++ b/docs/adr/0104-a-named-security-posture-is-computed-not-configured.md
@@ -1,0 +1,143 @@
+# 104. A named security posture is computed from the layers that exist, never configured
+
+Date: 2026-08-10
+
+Status: Draft
+
+Implements [#1226](https://github.com/curie-eng/curie/issues/1226).
+
+Deliberately does NOT depend on [#158](https://github.com/curie-eng/curie/issues/158)
+(multi-tenancy) or [#515](https://github.com/curie-eng/curie/issues/515)
+(monotonic policy resolution). The Decision says why.
+
+## Context
+
+Curie has the machinery: ADR-0010 (gates), ADR-0050 (armed exactly or not at
+all), ADR-0056 (grantability is an operator opt-in), ADR-0035 (bounded one-shot
+allowance), ADR-0067 (NetworkPolicy is additive), ADR-0077 (no skill-tier durable
+approvals). Each is right on its own.
+
+What is missing is the sentence an evaluator needs. "How locked down is this
+before I point it at anything real" is currently assembled by hand from six ADRs
+and four code locations, which is a real adoption cost on exactly the
+security-conscious self-host buyer.
+
+Three facts about the tree, measured rather than assumed, bound what can be
+decided today:
+
+- **No organization tier.** `models.py` declares no `Org`/`Tenant` and no
+  `org_id`; `org_name` is a `Settings` string the console renders. The layers
+  that exist are **deployment** (chart values, process env), **agent** (a row),
+  and **bundle** (the manifest).
+- **No content screening.** No screening, classifier, or provenance-labelling
+  mechanism exists anywhere in the tree.
+- **No policy resolver.** Defaults are scattered by construction: the
+  self-approval block is in the API authorizer, default-deny egress is a chart
+  value, gates are in the bundle manifest, model and thinking are agent columns.
+
+## Decision
+
+**A posture is a NAME for a computed result, not a value an operator sets.** A
+resolver reads the deployment, agent and bundle layers, reports the effective
+answer per axis together with the layer that imposed it, and the posture name
+labels the shape of that answer.
+
+### 1. Computed, never configured
+
+There is no `posture:` setting. An operator changes a posture by changing a
+constraint, so the name can never disagree with what is enforced.
+
+This is the load-bearing choice. A configured posture is a second policy engine:
+it must be reconciled against the settings it claims to summarize, and
+reconciliation is where drift lives. A computed name cannot drift from what it is
+computed from.
+
+### 2. Three layers, tightening only
+
+Composition is monotonic: **deployment** to **agent** to **bundle**. A narrower
+layer may deny or require approval; it may never widen what a broader one denied.
+
+The organization tier is absent rather than stubbed. When #158 lands it becomes
+the outermost layer under the same rule.
+
+One conflict is recorded rather than resolved: `grantableViaPolicy` (ADR-0056) is
+a LOOSENING switch declared in the bundle. ADR-0056 is coherent on its premise
+that the operator authors the manifest, which inverts under a tenant-facing
+lattice where the bundle author is the tenant. That premise is load-bearing, and
+whoever adds the organization tier has to decide it deliberately.
+
+### 3. The floor holds in every posture
+
+Five denials are unconditional. No posture, layer, or bundle can turn one off:
+
+1. **Self-approval is refused**, server-side, under every approver set.
+2. **Sandbox egress is default-deny**, and ADR-0067 keeps NetworkPolicy additive
+   so a second policy cannot widen it.
+3. **A declared approval policy is armed exactly or not at all** (ADR-0050): a
+   partially-armed gate is a failed deploy, not a quiet gap.
+4. **A policy gate is not grantable** unless a manifest opts in per gate
+   (ADR-0056, default false).
+5. **Skill-tier durable approvals are unavailable** (ADR-0077).
+
+The floor is what makes the most permissive posture bounded rather than open.
+
+### 4. Names cover only axes that exist
+
+Three names over approvals, egress, and grantability:
+
+- **Strict** -- every declared gate armed, nothing grantable, egress allowlist
+  empty.
+- **Standard** (default) -- declared gates armed, grantability only where a
+  manifest opted in, egress as configured.
+- **Permissive** -- gates armed only where declared, grantability wherever opted
+  in, egress as configured. Still bounded by the floor.
+
+Screening is **not** an axis, because Curie has none; naming a rung it cannot
+enforce is the documentation label this decision exists to avoid. When screening
+ships it joins as a fourth axis without changing the shape.
+
+The third name is **Permissive, not Dangerous**: the floor makes the stronger
+word untrue, and a name that overstates how far a posture goes is worse than a
+duller accurate one.
+
+### 5. Reporting only
+
+The resolver READS. It adds no denial, changes no enforcement decision, and sits
+on no request path. Everything it reports is already enforced by the code behind
+the floor above; what is missing today is a place to see it in one answer. If it
+later needs to enforce, that is a different decision and a different ADR.
+
+## Alternatives rejected
+
+**Document the postures in `SECURITY.md` and stop.** Cheapest, and what the issue
+body proposes. Rejected: a documented posture is unverifiable, nothing fails when
+the prose and the defaults disagree, and the first divergence is silent.
+
+**Make posture a setting an operator writes.** Rejected: a second source of truth
+needing reconciliation with the constraints it summarizes. A posture whose name
+can be wrong is worse than no posture.
+
+**Wait for #515 and present its resolver.** Architecturally cleanest, rejected on
+sequencing: #515 is unassigned and larger in scope. The resolver here is small and
+scoped to three existing layers; if #515 later generalizes it, this is the
+consumer that proves the shape.
+
+**Wait for #158 and include the organization tier.** Rejected: the core security
+value does not need multi-tenancy, and the lattice admits an outer layer later.
+
+**Adopt Strict / Auto / Dangerous verbatim from the external model.** Rejected
+twice: "Auto" is defined by screening Curie lacks, and "Dangerous" promises an off
+switch the floor denies. The two properties worth borrowing are the unconditional
+floor and the tighten-only lattice, not the names.
+
+## Consequences
+
+- An evaluator gets one answer to "how locked down is this", with every part
+  traceable to the layer that imposed it.
+- The name cannot lie: drift between documented and enforced is not expressible.
+- The floor becomes a published promise. Weakening any of the five is now a
+  visible ADR-level change rather than a quiet default flip.
+- Screening's absence becomes visible rather than implied, which matters once
+  ADR-0100's channel-read verbs give untrusted content a path into context.
+- The organization tier is a known gap with a known shape.
+- This authorizes a READING surface only.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -129,4 +129,5 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0101 | [Closed schemas version on every change: minor for optional, major for required](0101-schema-compatibility-for-closed-schemas.md) | Accepted |
 | 0102 | [Accepted alongside implementation with explicit approval](0102-accepted-alongside-implementation-with-explicit-approval.md) | Accepted |
 | 0103 | [Previous schema shape gate](0103-previous-schema-shape-gate.md) | Accepted |
+| 0104 | [A named security posture is computed from the layers that exist, never configured](0104-a-named-security-posture-is-computed-not-configured.md) | Draft |
 <!-- END GENERATED: adr-index -->


### PR DESCRIPTION
**This PR is a Draft ADR and implements nothing.** ADR-0085 is explicit: a Draft may merge for discussion but cannot authorize implementation, and implementation starts only after an Accepted status published with explicit maintainer approval. I stopped at the decision rather than writing the resolver.

Flagging that plainly because #1226 reads like a naming exercise. Under option B (a resolver, not a `SECURITY.md` paragraph) it closes real alternatives, is cross-cutting, and the same decision now spans four issues (#1226, #515, #1040, #1278) -- past the "promote on the third" bar in AGENTS.md. The issue's own test agrees: *"If it turns out to need new enforcement, that is the signal it wants an ADR rather than an issue."*

## The decision

**A posture is a NAME for a computed result, not a value an operator sets.**

A configured posture is a second policy engine: it has to be reconciled against the settings it claims to summarize, and reconciliation is where drift lives. A computed name cannot disagree with what is enforced, because it is derived from it.

That threads the two constraints that otherwise conflict:

> "a compact presentation of the effective monotonic policy, not a second policy engine [...] auditable rather than a documentation label"

> "this should not depend on adding multi-tenancy [...] the posture names could still be implemented without the org components"

Those pull apart **only if a resolver needs an org tier**. It does not -- deployment, agent and bundle are a lattice already, and the org tier joins as an outer layer later without changing shape.

## Three facts, re-measured today

| | |
|---|---|
| **No org tier** | `models.py` declares no `Org`/`Tenant`, no `org_id`; `org_name` is a `Settings` string. #158 open. |
| **No screening** | No screening, classifier, or provenance-labelling mechanism anywhere in the tree. |
| **No resolver** | Defaults scattered across the API authorizer, a chart value, the bundle manifest, and two `agents` columns. |

## The floor: five denials no posture can turn off

Each verified in place, not recalled: self-approval refused server-side, egress default-deny with ADR-0067 keeping NetworkPolicy additive, ADR-0050's exactly-or-not-at-all arming, ADR-0056's default-false grantability, ADR-0077's unavailable skill-tier approvals.

The floor is what makes the most permissive posture **bounded rather than open**.

## Two deliberate refusals

**Screening is not an axis.** The borrowed model defines its middle rung by it. Naming a rung Curie cannot enforce is exactly the documentation label this decision exists to avoid. When screening ships it becomes a fourth axis under the same rule.

**The third posture is Permissive, not Dangerous.** The floor makes the stronger word untrue, and a name that overstates how far a posture goes is worse than a duller accurate one.

## Two things recorded rather than resolved

`grantableViaPolicy` (ADR-0056) is a **loosening** switch declared in the *bundle*. ADR-0056 is coherent on its premise -- the operator authors the manifest -- which **inverts** under a tenant-facing lattice, where the bundle author is the tenant. This ADR changes nothing about 0056; it writes that premise down as load-bearing so the first tenant-facing change has to face it.

And the resolver **reads only**. No new denial, not on any request path. That boundary is what keeps this reversible; enforcement built on it later is a separate decision.

## What happens next

On acceptance I implement it under #1226: the resolver over the three layers, per-axis source attribution, the posture names, and one documented line each in `SECURITY.md` and the README. If any of the three postures or the floor's contents want changing, that is cheapest here, in review, before code exists.

`curie dev docs-lint` green; `docs/adr/README.md` regenerated by the script rather than by hand.

Refs #1226