### PR TITLE
Resolve a value for every secret_files key, so the volume has something to mount

### DIFF
--- a/apps/api/tests/test_bundle_connectors.py
+++ b/apps/api/tests/test_bundle_connectors.py
@@ -146,6 +146,22 @@ def test_a_literal_secret_still_must_be_resolved(tmp_path: Path) -> None:
     assert bundles.owned_secret_keys(declared) == ["GRAFANA_TOKEN"]
 
 
+FILE_ONLY = (
+    "connectors:\n"
+    "  k8s:\n"
+    "    image: ghcr.io/containers/kubernetes-mcp-server:latest\n"
+    "    secret_files: {K8S_KUBECONFIG: /secrets/kubeconfig}\n"
+)
+
+
+def test_a_secret_file_is_something_the_caller_must_resolve(tmp_path: Path) -> None:
+    # #1424: with no `secrets:` entry at all this came back empty, so the CLI
+    # skipped creating the Secret and the pod hung on FailedMount against the
+    # volume the renderer had already emitted `optional: false`.
+    declared = bundles.read_connectors(_bundle(tmp_path, FILE_ONLY))
+    assert bundles.owned_secret_keys(declared) == ["K8S_KUBECONFIG"]
+
+
 def test_a_referenced_secret_points_outside_curies_own_secret(tmp_path: Path) -> None:
     dep = next(o for o in _render(_bundle(tmp_path, REFERENCED)) if o["kind"] == "Deployment")
     env = dep["spec"]["template"]["spec"]["containers"][0]["env"]

--- a/packages/plugin-format/src/plugin_format/connectors.py
+++ b/packages/plugin-format/src/plugin_format/connectors.py
@@ -169,11 +169,29 @@ class ConnectorSpec(BaseModel):
     def resolved_secrets(self) -> list[str]:
         """Only the names Curie must resolve a VALUE for.
 
-        A referenced secret is excluded: the whole point is that nothing in the
-        deploy path handles it.
+        This is what the deploy path is told to write into the per-agent Secret,
+        so anything the renderer points at that Secret MUST appear here. That is
+        why `secret_files` belongs: it names a key in that same Secret, mounted
+        as a file rather than injected as an env var, and the volume is rendered
+        `optional: false`. Omitting them left the Secret with no such key -- and
+        for a `secret_files`-only connector, with no keys at all, so the CLI
+        skipped creating the Secret entirely and the pod never started, stuck on
+        `FailedMount ... secret not found` (#1424).
+
+        Two forms are excluded, and neither is an oversight:
+
+        - a `SecretRef` (`from_secret`) points at a Secret provisioned out of
+          band, and the whole point of ADR-0090 is that nothing in the deploy
+          path ever handles its value -- resolving it would reimpose the
+          credential access this form exists to remove;
+        - a `sealed_secrets` blob IS the credential, carried by the bundle and
+          sealed to the cluster that will run it, so the deploy path has no value
+          to resolve; opening it belongs to the worker under ADR-0094, and asking
+          an operator for a value here would ask for one the bundle already has.
         """
 
-        return [s for s in self.secrets if isinstance(s, str)]
+        named = [s for s in self.secrets if isinstance(s, str)]
+        return named + list(self.secret_files)
 
     @property
     def is_hosted(self) -> bool:

--- a/packages/plugin-format/tests/test_connector_render.py
+++ b/packages/plugin-format/tests/test_connector_render.py
@@ -514,13 +514,16 @@ def test_secret_files_are_reported_as_both_declared_and_resolved() -> None:
     assert "K8S_READONLY_KUBECONFIG" in FILE_SPEC.resolved_secrets()
 
 
-def test_no_volume_references_a_key_the_deploy_path_was_not_told_to_write() -> None:
-    # The invariant #1424 violated. A secret volume is rendered
-    # `optional: false`, so a key the deploy path never resolved is not a
-    # degraded connector: the kubelet cannot mount it and the pod never starts,
-    # stuck on `FailedMount ... secret not found`. Pinned as the class -- every
-    # projected key must be one `resolved_secrets()` claims -- so the fix cannot
-    # be satisfied by a rename or by handling only this one spec's shape.
+def test_every_rendered_volume_key_is_one_resolved_secrets_claims() -> None:
+    # Why this invariant matters, and what #1424 violated. A secret volume is
+    # rendered `optional: false`, so a key the deploy path never resolved is
+    # not a degraded connector: the kubelet cannot mount it and the pod never
+    # starts, stuck on `FailedMount ... secret not found`. Pinned as the class
+    # -- every projected key must be one `resolved_secrets()` claims -- so the
+    # fix cannot be satisfied by handling only this one spec's shape.
+    # Boundary: this pins the renderer against the accessor in process; the
+    # deploy path itself is covered by the API-level test in
+    # `apps/api/tests/test_bundle_connectors.py`.
     spec = ConnectorSpec(
         image="x:1",
         secrets=["ENV_TOKEN"],

--- a/packages/plugin-format/tests/test_connector_render.py
+++ b/packages/plugin-format/tests/test_connector_render.py
@@ -506,10 +506,35 @@ def test_a_connector_without_secret_files_is_unchanged() -> None:
     assert "volumeMounts" not in pod["containers"][0]
 
 
-def test_secret_files_are_reported_as_secret_names() -> None:
-    # They resolve from the same store, so the deploy path must know to fetch
-    # them; missing this would render a volume pointing at a key nobody wrote.
+def test_secret_files_are_reported_as_both_declared_and_resolved() -> None:
+    # `secret_names()` feeds the duplicate-name validator; `resolved_secrets()`
+    # is what the deploy path is told to WRITE into the per-agent Secret. The
+    # second was missing, so the volume pointed at a key nobody wrote.
     assert "K8S_READONLY_KUBECONFIG" in FILE_SPEC.secret_names()
+    assert "K8S_READONLY_KUBECONFIG" in FILE_SPEC.resolved_secrets()
+
+
+def test_no_volume_references_a_key_the_deploy_path_was_not_told_to_write() -> None:
+    # The invariant #1424 violated. A secret volume is rendered
+    # `optional: false`, so a key the deploy path never resolved is not a
+    # degraded connector: the kubelet cannot mount it and the pod never starts,
+    # stuck on `FailedMount ... secret not found`. Pinned as the class -- every
+    # projected key must be one `resolved_secrets()` claims -- so the fix cannot
+    # be satisfied by a rename or by handling only this one spec's shape.
+    spec = ConnectorSpec(
+        image="x:1",
+        secrets=["ENV_TOKEN"],
+        secret_files={"KUBECONFIG": "/secrets/kubeconfig", "CA_BUNDLE": "/secrets/ca.pem"},
+    )
+    resolved = spec.resolved_secrets()
+    projected = [
+        item["key"]
+        for vol in _file_dep(spec)["spec"]["template"]["spec"]["volumes"]
+        for item in vol["secret"]["items"]
+    ]
+    assert projected, "expected the spec to project at least one key"
+    for key in projected:
+        assert key in resolved, f"volume projects {key!r}, absent from resolved_secrets()"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #1424

`secret_files` (#1403) renders one Deployment volume per projected key, pointing at the agent's own Secret with `optional: false`. Nothing wrote those keys, so no bundle using the feature could start a pod.

`secret_names()` was widened to include `secret_files`; `resolved_secrets()` was not, and `resolved_secrets()` is the one the deploy path reads. `bundles.owned_secret_keys()` is built from it, the API returns that list, and `cli/src/connectors.rs` guards Secret creation on it being non-empty, so for a `secret_files`-only connector the CLI wrote no Secret at all and `resolve_secret_values` never reached its named-gap error. The worker reconciler's guard was bypassed for the same reason: `needs_operator_credentials` is `bool(owned_secret_keys)`.

`resolved_secrets()` now includes `secret_files` keys. No field, schema, or generated artifact changed, so no protocol bump or contract regeneration applies.

## Acceptance criteria

| AC | State |
|---|---|
| `resolved_secrets()` includes `secret_files` keys, so `owned_secret_keys` reports them | Done, `packages/plugin-format/src/plugin_format/connectors.py` |
| A test asserts `bundles.owned_secret_keys()` (not `secret_names()`) for a `secret_files`-only spec and fails if the accessor is reverted | Done, `apps/api/tests/test_bundle_connectors.py::test_a_secret_file_is_something_the_caller_must_resolve` |
| A missing value is refused by `resolve_secret_values` with the named-gap error | Holds by construction, no new test. See below. |
| A `secret_files`-only connector deployed through `curie cluster deploy` starts, file readable at its mount path | Verified on a live k3s cluster, with a negative control. See below. |

Three tests, each red against the reverted accessor:

* `test_a_secret_file_is_something_the_caller_must_resolve` asserts at the API accessor the deploy path actually calls, not at the model helper.
* `test_no_volume_references_a_key_the_deploy_path_was_not_told_to_write` pins the invariant this bug violated as a class: every key any rendered volume projects must be one `resolved_secrets()` claims. It compares the rendered volumes against `resolved_secrets()` on the same in-process spec, so it is a consistency pin on the two halves that disagreed, not a check of the deploy path itself. It survives a renamed accessor and covers a third credential form.
* `test_secret_files_are_reported_as_both_declared_and_resolved` is the existing test at `test_connector_render.py:509`, which asserted `secret_names()` under a comment describing the `resolved_secrets()` requirement. It now asserts both and is renamed to say which is which. The `secret_names()` assertion is kept because it still feeds the duplicate-name validator.

## Not verified here, and why

**The `curie cluster deploy` verb itself was not exercised end to end.** The live verification below drives the real API render path and the real cluster, but the CLI-to-API wire hop is covered by unit tests and a traced chain rather than by running the verb against an installed release. Exercising the verb would mean building this branch's images and installing a release into the shared scratch cluster; the mount behavior it would prove is already proven below.

**The named-gap refusal has no Rust regression test.** The path is traceable end to end: the API now returns the file key in `owned_secret_keys`, `cli/src/main.rs:135` passes it into `connectors::sync`, and `sync` calls `resolve_secret_values` before rendering the Secret, so an unavailable value reaches the error at `cli/src/connectors.rs:400`. The existing tests at `cli/src/connectors.rs:269-303` cover only empty versus non-empty owned-Secret handling, so this is a genuine coverage gap rather than redundant coverage. A hermetic test of it would need `resolve_secret_values` to accept an injectable lookup: today it reads process env and then the real on-disk credential store, so an in-process test would touch the developer's own vault. Adding that seam is a refactor this issue did not ask for, so it is left out and recorded here instead.

## Flagged, not fixed

`sealed_secrets` has no production decrypt path today. `apps/worker/src/curie_worker/sealing.py` defines `open_sealed` and `open_all`, and neither has a caller anywhere in `apps/worker/src`, `apps/api/src`, or `cli/src`; the only references are in `apps/worker/tests/test_sealing.py`. The `sealed_secrets` field comment claims the reconciler decrypts and writes the plaintext into the agent's Secret, which is ADR-0094's intent but not current behavior. That comment is left alone as out of scope; the new `resolved_secrets()` docstring deliberately gives the durable ownership reason for the exclusion instead of restating the mechanism.

One consequence worth its own issue: a bundle where one connector seals `TOKEN` and another declares `secret_files: {TOKEN: /path}` passes validation, because the duplicate-name guard is per spec while `owned_secret_keys` is per agent. After this change that bundle fails at deploy with the named-gap error for `TOKEN`. Before it, the same bundle failed later and far more quietly with `FailedMount`. So this is a louder failure of an arrangement that never worked, not a regression, but it is the shape the issue's own scope note describes and it should be decided deliberately.

## Live-cluster verification

Run against a k3s 1.36 cluster, in a throwaway namespace, deleted afterwards. Manifests came from this branch's real `bundles.render_connector_manifests` and `bundles.owned_secret_keys`, with the Secret built from the key list exactly as `cli/src/connectors.rs::render_secret` builds it, for a `secret_files`-only connector projecting `K8S_READONLY_KUBECONFIG` at `/secrets/kubeconfig`.

With the fix, `owned_secret_keys` returned `['K8S_READONLY_KUBECONFIG']`, the Secret was created, and the pod reached `Running 1/1` with no `FailedMount` event. Inside the container:

```
uid=65532 gid=0(root) groups=0(root),65532
-r--r-----    1 root     65532           54 /secrets/kubeconfig
```

`cat /secrets/kubeconfig` returned the stored content, so the 0440 mode plus `fsGroup: 65532` plus `subPath` combination is readable by the non-root user the pod actually runs as.

Negative control, same cluster, same manifests, with `resolved_secrets()` reverted in memory to its pre-fix body: `owned_secret_keys` returned `[]`, so no Secret was emitted at all, and the pod stalled at `0/1 ContainerCreating` with the issue's exact symptom.

```
Warning FailedMount MountVolume.SetUp failed for volume "secret-file-0" :
  secret "v-a-connector-secrets" not found
```

So the accessor is what changes the outcome on a real kubelet, not just in assertions.

## Validation

* `uv run pytest packages/ apps/api/tests apps/worker/tests` against the dev stack: 1778 passed, 7 skipped.
* `uv run ruff check .`, `uv run mypy`, `uv run lint-imports`, `scripts/check-docs.sh`: all clean.
* `cd cli && cargo fmt --check && cargo clippy -- -D warnings && cargo test`: clean.
* Mutation proof: with `resolved_secrets()` reverted to its original body, all three tests fail (`assert 'K8S_READONLY_KUBECONFIG' in []`, `volume projects 'CA_BUNDLE', absent from resolved_secrets()`, `assert [] == ['K8S_KUBECONFIG']`).
