### PR TITLE
Refresh CLI schema compatibility baselines

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -169,6 +169,8 @@ jobs:
       # is the lockfile-freshness gate for Rust (mirrors uv lock --check above).
       - name: Clippy
         run: cargo clippy --locked -- -D warnings
+      - name: Schema baseline
+        run: bash scripts/refresh-schema-baseline.sh --check
       - name: Test
         run: cargo test --locked
       - name: Generated ACI protocol crate compiles

--- a/cli/schema/baseline/approvals.schema.json
+++ b/cli/schema/baseline/approvals.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://schemas.curietech.ai/cli/approvals/v1.json",
+  "$id": "https://schemas.curietech.ai/cli/approvals/v1.2.json",
   "title": "curie <tier> approvals --json",
   "description": "The agent-facing payload of `curie <tier> approvals <agent>`: the dry-run plan; the gate list (`manifest_unreadable` non-null when the deployed manifest could not be read); the pending approval records (`truncated` true when the server page cap was hit); a single resolved record; or the agent's approval route bindings, where each route's `channel` is where its card posts and its optional `approvers` block is who may resolve it.",
   "$defs": {
@@ -67,6 +67,13 @@
           ]
         },
         "resolved_by": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "card_channel": {
+          "description": "The channel the approval card was posted to, or null when the record names no route (the requesting channel is then the approver set). This is what `--resolve` needs as `--actor-channel`: with no `approvers` block the channel's MEMBERS are the approver set, and the server-side authorizer compares against it, so the value is not derivable by guessing (#1078).\n\nOPTIONAL, and the only optional property in this record, which is deliberate rather than an oversight. Every sibling was required at birth, when no compatibility question existed. ADR-0101 prefers optional for a property added later: a consumer can tolerate its absence in a payload from an older CLI, which keeps this a MINOR bump. Making it required would reject those older payloads and cost a major version for no gain.",
           "type": [
             "string",
             "null"

--- a/cli/schema/baseline/diff.schema.json
+++ b/cli/schema/baseline/diff.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://schemas.curietech.ai/cli/diff/v1.json",
+  "$id": "https://schemas.curietech.ai/cli/diff/v2.0.json",
   "title": "curie diff --json",
   "description": "The agent-facing payload of `curie diff`: every chart value the effective installation plan and the live release disagree about, plus the values the release carries that the plan does not declare. Read only. Declared credentials and provider addresses are resolved to construct the same plan used by apply, but no cluster state is mutated. Secret-bearing values are rendered as the literal string `<secret>` and never in the clear.",
   "type": "object",

--- a/cli/schema/baseline/doctor.schema.json
+++ b/cli/schema/baseline/doctor.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://schemas.curietech.ai/cli/doctor/v1.json",
+  "$id": "https://schemas.curietech.ai/cli/doctor/v2.0.json",
   "title": "curie doctor --json",
   "description": "What is set up, what is missing, and the command that fixes it. Read-only. Credentials appear as the NAME of the variable holding them, never as a value.",
   "type": "object",

--- a/cli/schema/baseline/eval.schema.json
+++ b/cli/schema/baseline/eval.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://schemas.curietech.ai/cli/eval/v1.json",
+  "$id": "https://schemas.curietech.ai/cli/eval/v1.1.json",
   "title": "curie skill eval --json",
   "description": "The agent-facing payload of `curie skill eval --json`: the outcome roll-up plus one row per eval case.",
   "type": "object",

--- a/cli/schema/baseline/guide.schema.json
+++ b/cli/schema/baseline/guide.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://schemas.curietech.ai/cli/guide/v1.json",
+  "$id": "https://schemas.curietech.ai/cli/guide/v1.1.json",
   "title": "curie guide --json",
   "description": "The agent-facing payload of `curie guide`: the self-describing harness primer as structured data (the same content the default Markdown render is built from).",
   "type": "object",

--- a/cli/schema/baseline/message.schema.json
+++ b/cli/schema/baseline/message.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://schemas.curietech.ai/cli/message/v1.json",
+  "$id": "https://schemas.curietech.ai/cli/message/v1.1.json",
   "title": "curie local|cluster message --json",
   "description": "The agent-facing payload of `curie local message --json` and `curie cluster message --json`. Exactly one of five terminal-state shapes is emitted per invocation: a reply object (the model's final reply text, the thread the turn ran under, and whether a reply was captured), an awaiting-approval object (the turn parked on a human approval gate), a timeout object (no reply captured before the deadline), a dry-run descriptor (what a real run would enqueue), or an enqueued object (the turn was enqueued onto the real Valkey stream in connected transport mode and the CLI did not wait for a reply). All keys are CLI-owned and locked.",
   "oneOf": [

--- a/cli/schema/baseline/status.schema.json
+++ b/cli/schema/baseline/status.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://schemas.curietech.ai/cli/status/v1.json",
+  "$id": "https://schemas.curietech.ai/cli/status/v1.1.json",
   "title": "curie skill status --json",
   "description": "The agent-facing payload of `curie skill status --json`: the runner base URL, the serialized ACI SessionStatus, and the recorded bundle digest (#1087). The wrapper keys are what the CLI owns and are locked; the inner `session` is a frozen ACI contract elsewhere, so it is left unconstrained here rather than mirrored field-by-field.",
   "type": "object",

--- a/cli/schema/baseline/sweep.schema.json
+++ b/cli/schema/baseline/sweep.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://schemas.curietech.ai/cli/sweep/v1.json",
+  "$id": "https://schemas.curietech.ai/cli/sweep/v1.1.json",
   "title": "curie <tier> eval --sweep --json",
   "description": "The agent-facing payload of a `curie <tier> eval --sweep` run: one row per model. `pass_rate` is null (not a fabricated 0.0) on a never-completed row; `plumbing_only` flags a fixture-only row whose `passed`/`total` carry no graded signal.",
   "type": "object",

--- a/cli/scripts/refresh-schema-baseline.sh
+++ b/cli/scripts/refresh-schema-baseline.sh
@@ -19,9 +19,30 @@ set -euo pipefail
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 schema_dir="$root/cli/schema"
 baseline_dir="$schema_dir/baseline"
+check=false
+
+if (( $# > 1 )); then
+  echo "usage: $(basename "$0") [--check]" >&2
+  exit 2
+fi
+
+case "${1:-}" in
+  "")
+    ;;
+  --check)
+    check=true
+    ;;
+  *)
+    echo "usage: $(basename "$0") [--check]" >&2
+    exit 2
+    ;;
+esac
+
+shopt -s nullglob
+live_schemas=("$schema_dir"/*.schema.json)
 
 mismatched=()
-for f in "$schema_dir"/*.schema.json; do
+for f in "${live_schemas[@]}"; do
   name="$(basename "$f")"
   base="$baseline_dir/$name"
   [[ -f "$base" ]] || continue
@@ -33,7 +54,7 @@ for f in "$schema_dir"/*.schema.json; do
 done
 
 changed=()
-for f in "$schema_dir"/*.schema.json; do
+for f in "${live_schemas[@]}"; do
   name="$(basename "$f")"
   base="$baseline_dir/$name"
   if [[ ! -f "$base" ]] || ! diff -q "$f" "$base" >/dev/null; then
@@ -41,7 +62,32 @@ for f in "$schema_dir"/*.schema.json; do
   fi
 done
 
-if (( ${#changed[@]} == 0 )); then
+baseline_only=()
+for base in "$baseline_dir"/*.schema.json; do
+  name="$(basename "$base")"
+  [[ -f "$schema_dir/$name" ]] || baseline_only+=("$name")
+done
+
+if "$check"; then
+  if (( ${#changed[@]} == 0 && ${#baseline_only[@]} == 0 )); then
+    echo "baseline matches cli/schema/."
+    exit 0
+  fi
+
+  echo "schema baseline is stale:" >&2
+  if (( ${#changed[@]} > 0 )); then
+    echo "  live schemas differing from their baseline:" >&2
+    printf '    %s\n' "${changed[@]}" >&2
+  fi
+  if (( ${#baseline_only[@]} > 0 )); then
+    echo "  baseline-only schemas:" >&2
+    printf '    %s\n' "${baseline_only[@]}" >&2
+  fi
+  echo "run curie dev schema-baseline to refresh it." >&2
+  exit 1
+fi
+
+if (( ${#changed[@]} == 0 && ${#baseline_only[@]} == 0 )); then
   echo "baseline already matches cli/schema/; nothing to refresh." >&2
   exit 0
 fi
@@ -56,6 +102,18 @@ if (( ${#mismatched[@]} > 0 )); then
   exit 1
 fi
 
-cp "$schema_dir"/*.schema.json "$baseline_dir"/
-echo "schema baseline refreshed for ${#changed[@]} schema(s):"
-printf '  %s\n' "${changed[@]}"
+for name in "${changed[@]}"; do
+  cp "$schema_dir/$name" "$baseline_dir/$name"
+done
+for name in "${baseline_only[@]}"; do
+  rm -- "$baseline_dir/$name"
+done
+
+if (( ${#changed[@]} > 0 )); then
+  echo "schema baseline refreshed for ${#changed[@]} schema(s):"
+  printf '  %s\n' "${changed[@]}"
+fi
+if (( ${#baseline_only[@]} > 0 )); then
+  echo "removed ${#baseline_only[@]} baseline-only schema(s):"
+  printf '  %s\n' "${baseline_only[@]}"
+fi

--- a/cli/tests/schema_inventory.rs
+++ b/cli/tests/schema_inventory.rs
@@ -445,12 +445,16 @@ fn a_schema_may_not_change_shape_while_keeping_its_id() {
         compared + versioned
     );
     assert!(
+        versioned == 0,
+        "These schemas changed their $id without refreshing the compatibility baseline. \
+         Refresh it with `curie dev schema-baseline`.\n\n({compared} compared, {versioned} already versioned)"
+    );
+    assert!(
         problems.is_empty(),
         "These schemas changed shape while keeping their $id, so a conforming \
          consumer is broken under an identifier that promises it is not \
          (ADR-0101). Bump the version, then refresh the baseline with \
-         `curie dev schema-baseline`.\n\n{}\n\n({compared} compared, {versioned} \
-         already versioned)",
+         `curie dev schema-baseline`.\n\n{}\n\n({compared} compared, {versioned} already versioned)",
         problems.join("\n")
     );
 }


### PR DESCRIPTION
Closes #1425\n\nRefreshes the eight stale schema baselines and adds a nonmutating freshness check to the Rust CI job. The refresh helper also detects baseline-only schema files. Assumption: a stale compatibility baseline must fail immediately rather than remain an intentional versioned skip.