### PR TITLE
Stop `curie diff` telling you to paste the model key into curie.yaml

### DIFF
--- a/cli/src/installation.rs
+++ b/cli/src/installation.rs
@@ -724,6 +724,26 @@ async fn complete_installation_plan(
         );
         desired.insert("worker.slackApiBaseUrl".to_string(), String::new());
     }
+    // The model credential is declared by NAME, and `up_value_plan` only carries
+    // its key when a VALUE resolved. So on an install whose credentials are not
+    // in place yet -- exactly the state `diff` exists to describe -- the key
+    // vanished from the desired state and diff called it a reset: "the release
+    // carries this, your file does not declare it, declare it in curie.yaml to
+    // keep it." For a model API key, in a file whose own header says it holds
+    // NAMES and never secrets. Same defect #1415 fixed for the sealing key,
+    // reached by a different route.
+    //
+    // Comms three lines up already had this right, and this mirrors it: a
+    // DECLARED credential is part of the desired state whether or not it
+    // resolves in this shell, because apply is what supplies it -- and apply
+    // refuses outright while it cannot. `desired` feeds the diff report only;
+    // the argv apply actually runs is built from `up_values`, untouched here.
+    if let Some(name) = cfg.credentials.model.as_ref() {
+        desired.insert(
+            crate::ops::MODEL_CREDENTIAL_KEY.to_string(),
+            resolved.get(name).cloned().unwrap_or_default(),
+        );
+    }
     Ok(EffectiveInstallationPlan {
         cfg,
         up,
@@ -1930,6 +1950,40 @@ mod apply_tests {
             resolve_credentials_lenient(&cfg, &|_| Ok(None)).expect("must not refuse");
         assert!(resolved.is_empty());
         assert_eq!(missing, vec!["MODEL_KEY", "APP_TOK", "BOT_TOK"]);
+    }
+
+    /// The rc.1 -> rc.2 defect, reached by its other route.
+    ///
+    /// Running the published rc.2 against the live release with no credentials
+    /// exported reported
+    ///
+    ///   ! agentSandbox.runner.credentials: <secret> (reset to chart default)
+    ///
+    /// and the legend beside a reset reads "Declare it in curie.yaml to keep
+    /// it." The file DOES declare it -- by name, which is the only thing it may
+    /// carry -- so the advice is both wrong and, followed literally for a model
+    /// API key, the one thing that file's own header forbids.
+    ///
+    /// A declared credential belongs in the desired state whether or not it
+    /// resolves in this shell. Apply supplies it, and refuses while it cannot.
+    #[tokio::test]
+    async fn a_declared_but_unresolved_model_credential_is_not_a_reset() {
+        let cfg = cfg_with_all_names();
+        let (local, missing) = plan_installation_lenient(cfg).expect("lenient plan");
+        assert!(
+            missing.contains(&"MODEL_KEY".to_string()),
+            "fixture must leave the model credential unresolved: {missing:?}"
+        );
+        let plan = complete_installation_plan(local)
+            .await
+            .expect("dry-run plan needs no cluster");
+        assert!(
+            plan.desired.contains_key(crate::ops::MODEL_CREDENTIAL_KEY),
+            "a declared credential must stay in the desired state unresolved, or \
+             diff reports it as a reset and tells the operator to paste the key \
+             into curie.yaml. desired: {:?}",
+            plan.desired.keys().collect::<Vec<_>>()
+        );
     }
 
     /// Apply keeps refusing. Resolving BEFORE mutating is what stops a missing


### PR DESCRIPTION
Verifying the published rc.2 against the live sre-bot release, from a
shell with no credentials exported, produced:

  ! agentSandbox.runner.credentials: <secret> (reset to chart default)

and the legend beside a `!` reads "Declare it in curie.yaml to keep it."

The file already declares it -- `credentials.model: CURIE_CREDENTIALS`,
a NAME, which is the only form that file may carry. Its own header says
so, and the parser enforces it by refusing anything shaped like a secret.
So the advice is wrong twice: the value is not undeclared, and following
it literally means writing a model API key into a file whose whole point
is that it holds none.

Same defect #1415 fixed for the sealing key, reached by another route.
`up_value_plan` carries the credential's chart key only when a VALUE
resolves, so on an install whose credentials are not in place the key
left the desired state and diff read its absence as "undeclared, will be
lost". That is exactly the state #1407 taught diff to answer in, so the
operators who see it are the ones least able to tell it is wrong.

Comms, three lines above, already had it right: a declared Slack token
goes into the desired state whether or not it resolves here, because
apply is what supplies it -- and apply refuses outright while it cannot.
The model credential now does the same. `desired` feeds the diff report
only; the argv apply runs is built from `up_values` and is untouched, so
this changes what diff SAYS and nothing about what apply DOES.

The test drives the real planner rather than a hand-built map, and fails
against the previous behaviour by naming what is missing: the plan holds
both Slack tokens and not the model credential, which is the asymmetry
itself.

A file naming no model credential still reports both keys as resets --
that is a real loss, and the existing test pinning it is unchanged.

## How it was found

The verification promised on the rc.2 release PR: install the published rc.2 on the sre-bot box and re-run the diff that found #1415.

That part passed — `= sealing.privateKey: <secret> (preserved)`, the rc.1 bug is gone. But one `!` remained, and running the same diff twice settled what it was:

| | `agentSandbox.runner.credentials` |
|---|---|
| credentials unresolved | `!` reset to chart default |
| `CURIE_CREDENTIALS` exported | `~` change |

Nothing about the cluster changed between those two runs. The classification was tracking whether the value happened to resolve in that shell, not whether the file declares it.

## Scope

Report only. `desired` feeds the diff output; apply's argv comes from `up_values`, untouched. rc.2's apply behaviour was correct, as rc.1's was.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)