### PR TITLE
Release 0.7.0-rc.3

### DIFF
--- a/charts/curie/Chart.yaml
+++ b/charts/curie/Chart.yaml
@@ -8,8 +8,8 @@ description: >-
   and two install-time preflights ship baked in: a CPU-AVX / ClickHouse-pin
   check and a NetworkPolicy-enforcement probe.
 type: application
-version: 0.7.0-rc.2
-appVersion: "0.7.0-rc.2"
+version: 0.7.0-rc.3
+appVersion: "0.7.0-rc.3"
 kubeVersion: ">=1.25.0-0"
 maintainers:
   - name: Curie

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -749,7 +749,7 @@ dependencies = [
 
 [[package]]
 name = "curie"
-version = "0.7.0-rc.2"
+version = "0.7.0-rc.3"
 dependencies = [
  "anstream",
  "anstyle",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "curie"
-version = "0.7.0-rc.2"
+version = "0.7.0-rc.3"
 edition = "2021"
 description = "Curie CLI: init/start/send/eval a plugin against a local runner (task I1)"
 


### PR DESCRIPTION
rc.2 shipped a `curie diff` that told the operator to paste their model
API key into curie.yaml. Run against the live 0.6.0 sre-bot release from
a shell with no credentials exported it reported

  ! agentSandbox.runner.credentials: <secret> (reset to chart default)

and the legend beside a `!` reads "Declare it in curie.yaml to keep it."
The file already declares it, by name, which is the only form it may
carry. #1440 fixed the report.

Reporting only, in both candidates: rc.2's apply behaviour was correct
and no credential was ever at risk. Cut anyway, on the same reasoning as
rc.2 -- the newest published artifact is the one people pick up, and this
one argued for putting a secret in a file whose whole purpose is that it
holds none.

Third candidate because each was found the same way: running the
published artifact against a real installed release, not against a
fixture. rc.1 found the sealing key, rc.2 found this.

## Delta from rc.2

One commit: [#1440](https://github.com/curie-eng/curie/pull/1440). A declared-but-unresolved model credential stays in the desired state, so `diff` reports it as a change rather than a reset — matching what comms already did for Slack tokens.

## Verification before tagging

- `check-version-consistency.sh` green at `0.7.0-rc.3`.
- `cargo test --locked` (39 suites) and `clippy -D warnings` green.

After tagging: install the published rc.3 on the sre-bot box and re-run the diff with **no credentials exported** — the exact invocation that produced the bad `!` on rc.2. Expect zero spurious resets.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)