### PR TITLE
Revert the redundant model-credential insert (#1440)

### DIFF
--- a/cli/src/installation.rs
+++ b/cli/src/installation.rs
@@ -761,26 +761,6 @@ async fn complete_installation_plan(
         );
         desired.insert("worker.slackApiBaseUrl".to_string(), String::new());
     }
-    // The model credential is declared by NAME, and `up_value_plan` only carries
-    // its key when a VALUE resolved. So on an install whose credentials are not
-    // in place yet -- exactly the state `diff` exists to describe -- the key
-    // vanished from the desired state and diff called it a reset: "the release
-    // carries this, your file does not declare it, declare it in curie.yaml to
-    // keep it." For a model API key, in a file whose own header says it holds
-    // NAMES and never secrets. Same defect #1415 fixed for the sealing key,
-    // reached by a different route.
-    //
-    // Comms three lines up already had this right, and this mirrors it: a
-    // DECLARED credential is part of the desired state whether or not it
-    // resolves in this shell, because apply is what supplies it -- and apply
-    // refuses outright while it cannot. `desired` feeds the diff report only;
-    // the argv apply actually runs is built from `up_values`, untouched here.
-    if let Some(name) = cfg.credentials.model.as_ref() {
-        desired.insert(
-            crate::ops::MODEL_CREDENTIAL_KEY.to_string(),
-            resolved.get(name).cloned().unwrap_or_default(),
-        );
-    }
     Ok(EffectiveInstallationPlan {
         cfg,
         up,
@@ -2362,40 +2342,6 @@ mod apply_tests {
             resolve_credentials_lenient(&cfg, &|_| Ok(None)).expect("must not refuse");
         assert!(resolved.is_empty());
         assert_eq!(missing, vec!["MODEL_KEY", "APP_TOK", "BOT_TOK"]);
-    }
-
-    /// The rc.1 -> rc.2 defect, reached by its other route.
-    ///
-    /// Running the published rc.2 against the live release with no credentials
-    /// exported reported
-    ///
-    ///   ! agentSandbox.runner.credentials: <secret> (reset to chart default)
-    ///
-    /// and the legend beside a reset reads "Declare it in curie.yaml to keep
-    /// it." The file DOES declare it -- by name, which is the only thing it may
-    /// carry -- so the advice is both wrong and, followed literally for a model
-    /// API key, the one thing that file's own header forbids.
-    ///
-    /// A declared credential belongs in the desired state whether or not it
-    /// resolves in this shell. Apply supplies it, and refuses while it cannot.
-    #[tokio::test]
-    async fn a_declared_but_unresolved_model_credential_is_not_a_reset() {
-        let cfg = cfg_with_all_names();
-        let (local, missing) = plan_installation_lenient(cfg).expect("lenient plan");
-        assert!(
-            missing.contains(&"MODEL_KEY".to_string()),
-            "fixture must leave the model credential unresolved: {missing:?}"
-        );
-        let plan = complete_installation_plan(local)
-            .await
-            .expect("dry-run plan needs no cluster");
-        assert!(
-            plan.desired.contains_key(crate::ops::MODEL_CREDENTIAL_KEY),
-            "a declared credential must stay in the desired state unresolved, or \
-             diff reports it as a reset and tells the operator to paste the key \
-             into curie.yaml. desired: {:?}",
-            plan.desired.keys().collect::<Vec<_>>()
-        );
     }
 
     /// Apply keeps refusing. Resolving BEFORE mutating is what stops a missing


### PR DESCRIPTION
#1440 fixed a bug that was already fixed. #1437 had landed three PRs
earlier and handles the same case properly: `disclose_unresolved_credentials`
marks every chart key fed by a declared-but-unresolved credential as
`DiffKind::Unknown` (`?`), including `agentSandbox.runner.credentials`,
whether or not the key reached the desired state. It even has the
behaviour-level test for exactly this case --
`an_unresolved_declared_model_credential_without_a_release_is_unknown`.

I diagnosed against the published rc.2 BINARY and never re-read that code
path on main before writing the fix, so I re-solved a solved problem.
Removing the hunk fails exactly one test: the one #1440 added. Every other
test, #1437's included, passes without it -- which is the definition of
redundant.

`?` is also the better answer than the `~` #1440 aimed for. With no
credential value in hand, diff genuinely cannot know whether applying
would change that key; saying "unknown until it resolves" is true, and
"this is a change" would have been a guess.

The test goes with it. It asserted an internal property -- that `desired`
holds the key -- under a comment claiming it guarded the operator-visible
"paste your API key into curie.yaml" defect. It no longer guards that;
#1437's marking does, from either starting state. A test that names a
risk it cannot actually catch is worse than no test, because the next
person reads the comment and believes it.

No behaviour change: rc.3 already shows `?` for this key on the live
release, and it does so via #1437.

## How this surfaced

Verifying the published rc.3 against the live sre-bot release, the diff came back with a `?` marker and the line *"Entries marked `?` are unknown until they resolve"* — which is not what #1440 implements. #1440 aimed for `~`. Tracing that led to #1437, which had already solved it, better.

## Evidence it is redundant

Removing the hunk on main:

```
test installation::apply_tests::a_declared_but_unresolved_model_credential_is_not_a_reset ... FAILED
test result: FAILED. 796 passed; 1 failed
```

The only casualty is #1440's own test.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)