### PR TITLE
Restrict connector ingress to the sandbox (ADR-0086)

### DIFF
--- a/apps/api/tests/test_bundle_connectors.py
+++ b/apps/api/tests/test_bundle_connectors.py
@@ -57,8 +57,17 @@ def test_bundle_without_connectors_renders_nothing(tmp_path: Path) -> None:
 
 
 def test_hosted_connector_renders_the_full_object_set(tmp_path: Path) -> None:
-    kinds = [o["kind"] for o in _render(_bundle(tmp_path, HOSTED))]
-    assert kinds == ["Service", "Deployment", "NetworkPolicy"]
+    objs = _render(_bundle(tmp_path, HOSTED))
+    kinds = [o["kind"] for o in objs]
+    # TWO NetworkPolicies, and asserting the count alone would not say why:
+    # egress attached to the sandbox (where it may go) and ingress attached to
+    # the connector (who may arrive). The connector is unauthenticated by
+    # design -- the sandbox has no credential to authenticate with -- so
+    # without the ingress half every pod in the namespace can reach something
+    # holding a production credential.
+    assert kinds == ["Service", "Deployment", "NetworkPolicy", "NetworkPolicy"]
+    directions = sorted(p["spec"]["policyTypes"][0] for p in objs if p["kind"] == "NetworkPolicy")
+    assert directions == ["Egress", "Ingress"]
 
 
 def test_rendering_needs_no_cluster_access(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -88,11 +97,29 @@ def test_secret_is_referenced_not_inlined(tmp_path: Path) -> None:
     assert "value" not in token
 
 
+def _policy(objs: list[dict], direction: str) -> dict:
+    # Selecting "the NetworkPolicy" by kind picks whichever sorts first now that
+    # two ship, so a rename or a reorder would silently test the wrong object.
+    return next(
+        o for o in objs if o["kind"] == "NetworkPolicy" and o["spec"]["policyTypes"] == [direction]
+    )
+
+
 def test_egress_policy_uses_a_podselector(tmp_path: Path) -> None:
     # The ClusterIP form silently never matches; see connector_render's module
     # docstring. Pinned here too because this is the path a real deploy takes.
-    np = next(o for o in _render(_bundle(tmp_path, HOSTED)) if o["kind"] == "NetworkPolicy")
+    np = _policy(_render(_bundle(tmp_path, HOSTED)), "Egress")
     assert "podSelector" in np["spec"]["egress"][0]["to"][0]
+
+
+def test_ingress_policy_admits_only_the_sandbox(tmp_path: Path) -> None:
+    # Same ClusterIP trap on the way in, and the same reason it matters: this is
+    # the path a real deploy takes, so a rule that parses but never matches
+    # would leave the connector open while looking closed.
+    np = _policy(_render(_bundle(tmp_path, HOSTED)), "Ingress")
+    src = np["spec"]["ingress"][0]["from"]
+    assert len(src) == 1
+    assert "podSelector" in src[0] and "ipBlock" not in src[0]
 
 
 def test_mcp_entry_url_matches_the_rendered_service(tmp_path: Path) -> None:

--- a/packages/plugin-format/src/plugin_format/connector_render.py
+++ b/packages/plugin-format/src/plugin_format/connector_render.py
@@ -1,7 +1,8 @@
 """Derive Kubernetes objects from a declared connector (ADR-0086).
 
 This is the half of #1063 that deletes the bundle author's Kubernetes. Given a
-``ConnectorSpec``, it produces the Deployment, Service, and NetworkPolicy that
+``ConnectorSpec``, it produces the Deployment, Service, and the two
+NetworkPolicies -- egress from the sandbox, ingress to the connector -- that
 Curie previously expected every author to write by hand.
 
 Deriving rather than documenting is the point. Two defects in the hand-written
@@ -337,6 +338,65 @@ def render_networkpolicy(
     }
 
 
+def render_ingress_networkpolicy(
+    release: str, agent: str, app_name: str, connector: str, spec: ConnectorSpec
+) -> dict[str, Any]:
+    """Ingress to this connector: the sandbox, and nothing else.
+
+    The egress policy above says where the sandbox may GO. It says nothing
+    about who may ARRIVE, and those are not the same question. Without this,
+    every pod in the namespace can call the connector -- and the connector is
+    deliberately unauthenticated, because the sandbox holds no credential to
+    authenticate WITH. So the network is not one layer of the access control
+    here, it is the whole of it.
+
+    What that is worth is concrete: a connector holds a production credential
+    and answers anyone who asks. In a namespace that also runs Postgres,
+    ClickHouse, Valkey, an object store and an OTLP collector, "any neighbour
+    can read production through it" is a real step in a compromise, and those
+    datastores already carry a default-deny of their own. The connector holding
+    the credential should not be the one object without one.
+
+    One policy, not the customary deny/allow PAIR. A NetworkPolicy that selects
+    a pod and declares ``policyTypes: [Ingress]`` already denies every source it
+    does not list (ADR-0067: policies are additive, and selecting a pod at all
+    switches it from allow-by-default to deny-by-default for that direction).
+    A separate default-deny object would be inert.
+
+    Safe here specifically because the connector Deployment declares no probes:
+    an ingress policy that omits the kubelet would otherwise fail readiness and
+    take the connector out of its Service endpoints -- the failure mode being a
+    connector that is healthy, running, and unreachable. If probes are ever
+    added to ``render_deployment``, this rule has to grow a companion for them
+    in the same commit.
+    """
+
+    return {
+        "apiVersion": "networking.k8s.io/v1",
+        "kind": "NetworkPolicy",
+        # Not "-allow-ingress" paired with a renamed "-allow-egress": the
+        # existing object ships as "-allow" on every live install, and renaming
+        # it strands a policy that still grants egress under a name nothing
+        # reconciles any more. Additive is the safe shape for a rule whose
+        # failure mode is silent.
+        "metadata": {
+            "name": f"{object_name(release, agent, connector)}-allow-ingress",
+            "labels": _labels(release, agent, connector),
+        },
+        "spec": {
+            # Selects the CONNECTOR, where the egress policy selects the sandbox.
+            "podSelector": {"matchLabels": _labels(release, agent, connector)},
+            "policyTypes": ["Ingress"],
+            "ingress": [
+                {
+                    "from": [{"podSelector": {"matchLabels": sandbox_selector(release, app_name)}}],
+                    "ports": [{"protocol": "TCP", "port": spec.port}],
+                }
+            ],
+        },
+    }
+
+
 def render(
     release: str,
     agent: str,
@@ -354,6 +414,7 @@ def render(
         render_service(release, agent, connector, spec),
         render_deployment(release, agent, namespace, connector, spec, secret_name),
         render_networkpolicy(release, agent, app_name, connector, spec),
+        render_ingress_networkpolicy(release, agent, app_name, connector, spec),
     ]
 
 

--- a/packages/plugin-format/tests/test_connector_render.py
+++ b/packages/plugin-format/tests/test_connector_render.py
@@ -29,6 +29,21 @@ def _objs(release: str = "acme-bot", app: str = "acme-bot") -> list[dict]:
     return r.render(release, "acme-bot", "acme-bot", app, "grafana", HOSTED, "conn-secrets")
 
 
+# Two NetworkPolicies ship per connector now, so selecting "the NetworkPolicy"
+# by kind picks whichever happens to be first and silently tests the wrong
+# object. Select by direction.
+def _egress_np(objs: list) -> dict:
+    return next(
+        o for o in objs if o["kind"] == "NetworkPolicy" and o["spec"]["policyTypes"] == ["Egress"]
+    )
+
+
+def _ingress_np(objs: list) -> dict:
+    return next(
+        o for o in objs if o["kind"] == "NetworkPolicy" and o["spec"]["policyTypes"] == ["Ingress"]
+    )
+
+
 # --------------------------------------------------------------------------- #
 # The ClusterIP trap -- the defect this renderer exists to prevent
 # --------------------------------------------------------------------------- #
@@ -38,7 +53,7 @@ def test_egress_rule_uses_a_podselector_never_an_ipblock() -> None:
     # symptom is a bare connection refused, and on a CNI that ignores
     # NetworkPolicy (minikube's default) the broken rule looks identical to a
     # correct one -- so it survives local testing and fails in a real cluster.
-    np = next(o for o in _objs() if o["kind"] == "NetworkPolicy")
+    np = _egress_np(_objs())
     to = np["spec"]["egress"][0]["to"][0]
     assert "podSelector" in to
     assert "ipBlock" not in to
@@ -49,11 +64,7 @@ def test_egress_selects_exactly_the_pods_rail_1_denies() -> None:
     # cannot narrow -- ADR-0067) so the sandbox still cannot reach the
     # connector. Too broad -- e.g. only `component` -- and it also grants egress
     # to every OTHER release's sandboxes in the namespace. Both fail silently.
-    np = next(
-        o
-        for o in r.render("relA", "a", "ns", "acme-bot", "g", HOSTED, "s")
-        if o["kind"] == "NetworkPolicy"
-    )
+    np = _egress_np(r.render("relA", "a", "ns", "acme-bot", "g", HOSTED, "s"))
     assert np["spec"]["podSelector"]["matchLabels"] == {
         "app.kubernetes.io/name": "acme-bot",
         "app.kubernetes.io/instance": "relA",
@@ -62,16 +73,8 @@ def test_egress_selects_exactly_the_pods_rail_1_denies() -> None:
 
 
 def test_two_releases_do_not_select_each_others_sandboxes() -> None:
-    a = next(
-        o
-        for o in r.render("relA", "a", "ns", "app", "g", HOSTED, "s")
-        if o["kind"] == "NetworkPolicy"
-    )
-    b = next(
-        o
-        for o in r.render("relB", "a", "ns", "app", "g", HOSTED, "s")
-        if o["kind"] == "NetworkPolicy"
-    )
+    a = _egress_np(r.render("relA", "a", "ns", "app", "g", HOSTED, "s"))
+    b = _egress_np(r.render("relB", "a", "ns", "app", "g", HOSTED, "s"))
     assert a["spec"]["podSelector"] != b["spec"]["podSelector"]
 
 
@@ -543,16 +546,23 @@ def test_every_rendered_volume_key_is_one_resolved_secrets_claims() -> None:
 @pytest.mark.parametrize(
     "data,code",
     [
-        ({"image": "x:1", "secret_files": {"A": "secrets/x"}},
-         "connectors.secret_file_relative_path"),
-        ({"image": "x:1", "secret_files": {"A": "/tmp/x"}},
-         "connectors.secret_file_in_tmp"),
-        ({"image": "x:1", "secret_files": {"A": "/s/x", "B": "/s/x"}},
-         "connectors.secret_file_path_collision"),
-        ({"image": "x:1", "secrets": ["A"], "secret_files": {"A": "/s/x"}},
-         "connectors.secret_both_env_and_file"),
-        ({"url": "https://m/mcp", "secret_files": {"A": "/s/x"}},
-         "connectors.remote_has_secret_files"),
+        (
+            {"image": "x:1", "secret_files": {"A": "secrets/x"}},
+            "connectors.secret_file_relative_path",
+        ),
+        ({"image": "x:1", "secret_files": {"A": "/tmp/x"}}, "connectors.secret_file_in_tmp"),
+        (
+            {"image": "x:1", "secret_files": {"A": "/s/x", "B": "/s/x"}},
+            "connectors.secret_file_path_collision",
+        ),
+        (
+            {"image": "x:1", "secrets": ["A"], "secret_files": {"A": "/s/x"}},
+            "connectors.secret_both_env_and_file",
+        ),
+        (
+            {"url": "https://m/mcp", "secret_files": {"A": "/s/x"}},
+            "connectors.remote_has_secret_files",
+        ),
     ],
 )
 def test_secret_file_misuse_is_refused(data: dict, code: str) -> None:
@@ -566,3 +576,68 @@ def test_a_well_formed_secret_file_validates() -> None:
     )
     assert errors == []
     assert parsed is not None
+
+
+# --------------------------------------------------------------------------- #
+# Ingress: who may REACH the connector
+# --------------------------------------------------------------------------- #
+def test_connector_accepts_traffic_only_from_the_sandbox() -> None:
+    # The egress policy governs where the sandbox may go; it places no limit on
+    # who may arrive. Without an ingress rule every pod in the namespace can
+    # call a connector that holds a production credential and authenticates
+    # nobody -- because the sandbox has no credential to authenticate WITH, so
+    # the network is the entire access control.
+    np = _ingress_np(_objs())
+    src = np["spec"]["ingress"][0]["from"]
+    assert len(src) == 1, "exactly one source: the sandbox"
+    assert src[0]["podSelector"]["matchLabels"] == r.sandbox_selector("acme-bot", "acme-bot")
+
+
+def test_ingress_policy_selects_the_connector_not_the_sandbox() -> None:
+    # Getting this backwards yields a policy that parses, applies, and protects
+    # the wrong pod -- the sandbox gains an ingress restriction it does not need
+    # while the connector keeps none.
+    ing = _ingress_np(_objs())
+    egr = _egress_np(_objs())
+    # The two policies must select OPPOSITE ends of the same hop: egress is
+    # attached to the sandbox, ingress to the connector. Swapping them still
+    # parses and still applies -- it just protects the wrong pod.
+    assert ing["spec"]["podSelector"] != egr["spec"]["podSelector"]
+    assert (
+        ing["spec"]["podSelector"]["matchLabels"]
+        == egr["spec"]["egress"][0]["to"][0]["podSelector"]["matchLabels"]
+    ), "ingress must select the pod the egress rule points AT"
+    assert (
+        egr["spec"]["podSelector"]["matchLabels"]
+        == ing["spec"]["ingress"][0]["from"][0]["podSelector"]["matchLabels"]
+    ), "ingress must admit the pod the egress rule is attached to"
+
+
+def test_ingress_is_port_scoped_to_the_connector_port() -> None:
+    ports = _ingress_np(_objs())["spec"]["ingress"][0]["ports"]
+    assert ports == [{"protocol": "TCP", "port": HOSTED.port}]
+
+
+def test_ingress_uses_a_podselector_never_an_ipblock() -> None:
+    # Same trap as the egress rule: a ClusterIP ipBlock can never match, and it
+    # looks correct on a CNI that ignores NetworkPolicy.
+    src = _ingress_np(_objs())["spec"]["ingress"][0]["from"][0]
+    assert "podSelector" in src and "ipBlock" not in src
+
+
+def test_two_releases_do_not_admit_each_others_sandboxes() -> None:
+    # A too-broad source selector would let another release's sandbox read
+    # production through this connector, silently.
+    a = _ingress_np(r.render("relA", "a", "ns", "app", "g", HOSTED, "s"))
+    b = _ingress_np(r.render("relB", "a", "ns", "app", "g", HOSTED, "s"))
+    assert a["spec"]["ingress"][0]["from"] != b["spec"]["ingress"][0]["from"]
+
+
+def test_the_two_policies_do_not_collide_on_name() -> None:
+    names = [o["metadata"]["name"] for o in _objs() if o["kind"] == "NetworkPolicy"]
+    assert len(names) == len(set(names)) == 2
+
+
+def test_a_remote_connector_renders_no_policies() -> None:
+    # Nothing is hosted, so there is nothing in-cluster to admit traffic to.
+    assert not [o for o in r.render("rel", "a", "ns", "app", "x", REMOTE, "s")]


### PR DESCRIPTION
## The gap

`connector_render` emitted **one** NetworkPolicy: egress, attached to the sandbox, governing where it may go. Nothing governed who may **arrive**. Any pod in the namespace could call a connector.

That matters more than usual here, because **the connector is deliberately unauthenticated** — the sandbox holds no credential to authenticate *with*, which is the whole point of the shape (ADR-0086). So the network isn't one layer of the connector's access control. It's all of it. A connector holds a production credential and answers anyone who asks.

In the namespace this ships into, that isn't theoretical — Postgres, ClickHouse, Valkey, rustfs and an OTLP collector are neighbours, and **each already carries a default-deny ingress**. The one object holding a production credential shouldn't be the only one without.

Found while tracing sre-bot's live topology; `sre-bot` has exactly this shape in production today.

## The change

```yaml
kind: NetworkPolicy
metadata:
  name: <release>-<agent>-mcp-<connector>-allow-ingress
spec:
  podSelector: { matchLabels: <the connector> }     # ← selects the CONNECTOR
  policyTypes: [Ingress]
  ingress:
    - from: [{ podSelector: { matchLabels: <the sandbox> } }]
      ports: [{ protocol: TCP, port: <spec.port> }]
```

**One policy, not the customary deny/allow pair.** A policy that selects a pod and declares `policyTypes: [Ingress]` already denies every source it doesn't list — selecting the pod flips that direction from allow-by-default to deny-by-default (ADR-0067). A separate default-deny object would be inert, so it isn't rendered.

**Named `-allow-ingress`, not a rename of `-allow` to `-allow-egress`.** The old name is live on every existing install; renaming strands a policy that still grants egress under a name nothing reconciles any more.

**No RBAC change** — `NetworkPolicy` is already one of the reconciler's four kinds; this is a second object of an existing kind.

## The probe trap

This is only safe because `render_deployment` declares no probes. An ingress rule that omits the kubelet fails readiness and drops the connector out of its Service endpoints — *healthy, running, and unreachable*. Verified against the live Deployment (`livenessProbe` and `readinessProbe` both empty). The docstring states that adding probes requires a companion rule **in the same commit**.

## Tests — 56 pass

The existing helpers selected *"the NetworkPolicy"* by kind. With two policies that silently picks whichever sorts first and asserts against the wrong object, so they now select **by direction**. New coverage:

- source is the sandbox, and **only** the sandbox
- port-scoped to `spec.port`
- `podSelector`, never `ipBlock` — the same trap the egress rule already documents
- two releases don't admit each other's sandboxes
- the two policy names don't collide
- **the policies select opposite ends of the same hop** — swapping them parses, applies, and protects the wrong pod

Full package suite: 282 passed.