### PR TITLE
fix(chart): give the worker the object-store env it already reads

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -241,6 +241,20 @@ jobs:
           set -euo pipefail
           bash charts/curie/ci/worker-ttl-bounds-assertions.sh
 
+      # Prove the API and the worker agree about the object store. The API writes
+      # each uploaded plugin bundle to the bundle bucket and the worker reads it
+      # back, so a disagreement -- or an omission -- makes every bundle
+      # unfetchable. worker.yaml set none of the four variables, so the worker
+      # used its compose defaults (localhost:29000) and every fetch in
+      # Kubernetes hit ECONNREFUSED. Both symptoms point elsewhere: the
+      # post-deploy eval goes quiet with "unresolvable suite/bundle", and turns
+      # die as ClaimTimeoutError, whose message blames a CPU-saturated node --
+      # on the install where this was found the node was at 11% CPU.
+      - name: helm render assertions (worker/api object store agree)
+        run: |
+          set -euo pipefail
+          bash charts/curie/ci/worker-object-store-assertions.sh
+
       - name: helm template + kubeconform (values-dev overlay)
         run: |
           set -euo pipefail

--- a/charts/curie/ci/worker-object-store-assertions.sh
+++ b/charts/curie/ci/worker-object-store-assertions.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+#
+# The API and the worker must agree about the object store.
+#
+# The API WRITES each uploaded plugin bundle to the bundle bucket; the worker
+# READS it back to run a turn. If the two disagree -- or if either is simply
+# unset -- the write and the read address different stores and the bundle is
+# unfetchable.
+#
+# This shipped: worker.yaml set none of the four variables, so the worker fell
+# back to its compose defaults (`s3_endpoint_url` = http://localhost:29000) and
+# every bundle fetch in Kubernetes hit ECONNREFUSED.
+#
+# It is asserted here rather than left to review because both symptoms point
+# somewhere else:
+#
+#   * `eval default @ <sha> failed: unresolvable suite/bundle` -- the
+#     post-deploy eval silently stops running. A suite that cannot resolve looks
+#     exactly like a suite nobody asked for, so nothing alerts and the gap can
+#     last for weeks.
+#   * every turn fails as `ClaimTimeoutError` after 90s, and that message names
+#     a CPU-saturated node as the most common cause. On the install where this
+#     was found the node was at 11% CPU with 4% pressure -- the error sent
+#     everyone looking at node size instead of at four missing env vars.
+#
+# A unit test cannot catch it: each Deployment is correct in isolation, and the
+# defect is only visible when the two are compared.
+set -euo pipefail
+
+CHART=${CHART:-charts/curie}
+KEYS=(S3_ENDPOINT_URL S3_ACCESS_KEY S3_SECRET_KEY BUNDLE_BUCKET)
+
+# Render to a FILE. Passing both a script heredoc and the rendered manifests on
+# stdin means two redirections on one command, and the second wins -- python
+# then tries to execute the YAML. That cost a debugging round here already.
+rendered=$(mktemp)
+trap 'rm -f "$rendered"' EXIT
+helm template t "$CHART" > "$rendered"
+
+python3 - "$rendered" "${KEYS[@]}" <<'PY'
+import sys, yaml
+
+path, keys = sys.argv[1], sys.argv[2:]
+with open(path) as fh:
+    docs = list(yaml.safe_load_all(fh))
+
+def env_of(component):
+    """Select by the component LABEL, never by a name suffix.
+
+    `endswith("-worker")` also matches `<release>-curie-langfuse-worker`, which
+    renders earlier and legitimately has no object-store env -- so a suffix
+    match silently inspected Langfuse and reported the curie worker as
+    misconfigured while the chart was correct. The label is unambiguous.
+    """
+
+    for d in docs:
+        if not d or d.get("kind") != "Deployment":
+            continue
+        if d["metadata"].get("labels", {}).get("app.kubernetes.io/component") != component:
+            continue
+        c = d["spec"]["template"]["spec"]["containers"][0]
+        return {e["name"]: e for e in c.get("env", [])}
+    return None
+
+api = env_of("api")
+worker = env_of("worker")
+assert api is not None, "no API Deployment rendered"
+assert worker is not None, "no worker Deployment rendered"
+
+failures = []
+
+for k in keys:
+    if k not in worker:
+        failures.append(f"worker is missing {k} -- it will fall back to the compose default")
+    if k not in api:
+        failures.append(f"api is missing {k}")
+
+# Equality, not merely presence. Two different-but-present endpoints is the
+# subtler version of the same bug and would pass a presence-only check.
+for k in keys:
+    if k in api and k in worker and api[k] != worker[k]:
+        failures.append(
+            f"api and worker disagree on {k}:\n"
+            f"    api    = {api[k]}\n"
+            f"    worker = {worker[k]}"
+        )
+
+# The compose default must never be what a Kubernetes pod receives.
+ep = worker.get("S3_ENDPOINT_URL", {}).get("value", "")
+if "localhost" in ep or "127.0.0.1" in ep:
+    failures.append(f"worker S3_ENDPOINT_URL points at the pod itself: {ep!r}")
+
+# The credential belongs in a secretKeyRef, never inline in the pod spec, where
+# `kubectl get deploy -o yaml` would print it to anyone who can read Deployments.
+sk = worker.get("S3_SECRET_KEY", {})
+if "value" in sk:
+    failures.append("worker S3_SECRET_KEY is an inline value; it must be a secretKeyRef")
+elif not sk.get("valueFrom", {}).get("secretKeyRef"):
+    failures.append("worker S3_SECRET_KEY has no secretKeyRef")
+
+if failures:
+    print("FAIL: api/worker object-store configuration diverges\n")
+    for f in failures:
+        print("  - " + f)
+    raise SystemExit(1)
+
+print("api and worker agree on all four object-store variables:")
+for k in keys:
+    shown = api[k].get("value") or "<secretKeyRef " + \
+        api[k]["valueFrom"]["secretKeyRef"]["name"] + "/" + \
+        api[k]["valueFrom"]["secretKeyRef"]["key"] + ">"
+    print(f"  {k:18} = {shown}")
+PY

--- a/charts/curie/templates/worker.yaml
+++ b/charts/curie/templates/worker.yaml
@@ -219,6 +219,39 @@ spec:
             - name: SLACK_API_BASE_URL
               value: {{ .Values.worker.slackApiBaseUrl | quote }}
             {{- end }}
+            # Object store, for fetching immutable plugin bundles.
+            #
+            # These four were missing entirely, and the worker's config defaults
+            # them to the docker-compose stack -- s3_endpoint_url defaults to
+            # http://localhost:29000. In compose that is correct and in
+            # Kubernetes there is nothing on that port, so bundle_store's boto3
+            # client connected to localhost and got ECONNREFUSED on every fetch.
+            #
+            # It fails in the two places that are hardest to notice:
+            #
+            #   * eval default @ <sha> failed: unresolvable suite/bundle
+            #     -- the post-deploy eval never runs. Nothing alerts, because a
+            #     suite that cannot resolve is indistinguishable from one that
+            #     was not requested.
+            #   * every Slack turn dies as ClaimTimeoutError after 90s, whose
+            #     message blames a CPU-saturated node first. On the install where
+            #     this was found the node was at 11% CPU with 4% pressure, and
+            #     three people read that error as "the box is too small".
+            #
+            # Same values as api.yaml, deliberately: the API WRITES each uploaded
+            # bundle to this bucket and the worker READS it back, so they have to
+            # agree. ci/worker-object-store-assertions.sh asserts they do.
+            - name: S3_ENDPOINT_URL
+              value: http://{{ include "curie.rustfs.host" . }}:{{ .Values.rustfs.port }}
+            - name: S3_ACCESS_KEY
+              value: {{ .Values.rustfs.auth.accessKey | quote }}
+            - name: S3_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.rustfs.existingSecret | default (include "curie.secretName" .) }}
+                  key: rustfsSecretKey
+            - name: BUNDLE_BUCKET
+              value: {{ .Values.agentSandbox.runner.bundleFetch.bucket | quote }}
             {{- with .Values.worker.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}


### PR DESCRIPTION
`worker.yaml` sets **none** of `S3_ENDPOINT_URL`, `S3_ACCESS_KEY`, `S3_SECRET_KEY`, `BUNDLE_BUCKET` — while `api.yaml` sets all four. The worker *reads* them (`bundle_store.py:65` builds its boto3 client from `config.s3_endpoint_url`), and the config defaults them to the compose stack:

```python
# apps/worker/src/curie_worker/config.py:411
s3_endpoint_url: str = "http://localhost:29000"
```

Correct under docker-compose. In Kubernetes nothing listens there, so **every worker bundle fetch hit ECONNREFUSED.**

## Why it went unnoticed

Found on a live install where it had been breaking two things, and **both symptoms point somewhere else**:

**1. The post-deploy eval had silently stopped running.**
```
ERROR:curie_worker.eval.stream:eval default @ <sha> failed: unresolvable suite/bundle
```
Nothing alerts, because a suite that cannot resolve is indistinguishable from one nobody asked for. It was dead for weeks.

**2. Every Slack turn failed** — 12 turns in 24h, 12 failures, all `ClaimTimeoutError` after 90s. That error names a CPU-saturated node as the most common cause, so the install got diagnosed as too small three separate times. The node was at **11% CPU with 4% pressure**, and `rustfs:9000` was reachable from the worker the entire time.

## The fix

Four env vars mirroring `api.yaml`. Copied deliberately rather than parameterised separately — the API **writes** each bundle to this bucket and the worker **reads** it back, so two independent settings could disagree, and a disagreement looks exactly like an omission.

## The assertion

`ci/worker-object-store-assertions.sh`, wired into helm-ci. It checks **equality**, not mere presence (two present-but-different endpoints is the subtler form of the same bug), and additionally refuses a `localhost` endpoint and an inline `S3_SECRET_KEY`.

A unit test cannot catch this: each Deployment is correct in isolation, and the defect exists only in the comparison.

**Verified both ways** — passes with this change, fails when `worker.yaml` is reverted.

Two notes for whoever edits the script, both bugs I hit writing it:

- it selects Deployments by the component **label**, not a name suffix — `endswith("-worker")` also matches `<release>-curie-langfuse-worker`, which renders first and legitimately has no object-store env, so the suffix version reported the worker as broken while the chart was correct
- manifests render to a **file**, not a pipe — a script heredoc plus a herestring is two stdin redirections on one command, and python ends up executing the YAML