### PR TITLE
Match Helm upgrade resource policy exactly

### DIFF
--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -1258,7 +1258,7 @@ pub fn helm_keeps(resource: &serde_json::Value) -> bool {
         .and_then(|m| m.get("annotations"))
         .and_then(|a| a.get("helm.sh/resource-policy"))
         .and_then(|p| p.as_str())
-        .map(|p| p.trim().eq_ignore_ascii_case("keep"))
+        .map(|p| p == "keep")
         .unwrap_or(false)
 }
 
@@ -1827,13 +1827,19 @@ data:
         assert!(removed_stateful_components(&live, &rendered).is_empty());
     }
 
+    /// Helm upgrade honors only the exact lowercase `keep` value.
     #[test]
-    fn a_resource_helm_is_told_to_keep_is_not_at_risk() {
-        for value in ["keep", "Keep", " keep "] {
+    fn helm_upgrade_exact_keep_annotation_is_not_at_risk() {
+        let kept = serde_json::json!({
+            "metadata": {"annotations": {"helm.sh/resource-policy": "keep"}}
+        });
+        assert!(helm_keeps(&kept), "exact lowercase keep must be accepted");
+
+        for value in ["Keep", "KEEP", " keep "] {
             let kept = serde_json::json!({
                 "metadata": {"annotations": {"helm.sh/resource-policy": value}}
             });
-            assert!(helm_keeps(&kept), "{value:?} must read as keep");
+            assert!(!helm_keeps(&kept), "{value:?} must not read as exact keep");
         }
     }
 


### PR DESCRIPTION
Require the stateful deletion guard to recognize only the exact lowercase keep annotation that Helm upgrade honors. Reject case and whitespace variants in the existing regression test.

Closes #1357

Done check

* [x] Locked CLI suite passed.
* [x] Clippy and formatting are clean.
* [x] Code and scope reviews approved with no blocking findings.
* [x] The focused guard test demonstrated rejection of all three invalid values.
* [x] Sibling path parity is not applicable because every consumer uses the same helper.
* [x] Security and deployed verification are not applicable.