### PR TITLE
Document next release train

### DIFF
--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -33,9 +33,23 @@ helper scripts. Repository instructions and available tools are authoritative.
 
 1. Read the ticket and its linked requirements. Do not infer scope from an ID alone.
 2. Read the repository instructions and the relevant architecture or component docs.
-3. Check for an existing branch or worktree for the ticket. Otherwise create a fresh
-   branch and worktree from the repository's current target base, following its own
-   instructions.
+3. Check for an existing branch or worktree for the ticket. Otherwise select the
+   target release train before creating work:
+
+   | Work | Base and PR target |
+   | --- | --- |
+   | General bug, security fix, or shared change | `main` |
+   | v0.7 feature or a bug unique to unreleased v0.7 work | `next` |
+
+   Fetch the chosen base and create the worktree from its remote tip:
+
+   ```bash
+   git fetch origin <base>
+   git worktree add <path> -b task/<short-description> "$(git rev-parse origin/<base>)"
+   ```
+
+   Never commit directly to either release train. If the ticket does not make
+   the target clear, stop and ask.
 4. Run the focused existing tests, type checks, and lint for the affected area. Stop
    on a relevant baseline failure. Record unrelated failures without widening scope.
 
@@ -87,6 +101,9 @@ that a new or modified guard rejects violating input through its real consumer p
 ## Finish
 
 Confirm that the final diff satisfies every acceptance criterion and that validation
-evidence reflects the final code. Present the diff and verification results. Follow
-the repository's commit, push, pull request, and ticket status rules. Do not create
-a pull request or publish changes without the authority required by those rules.
+evidence reflects the final code. Present the diff and verification results. Open
+the PR against the selected release train. For a general fix merged to `main`,
+create or request the follow up PR that merges `main` forward into `next`; do not
+normally cherry pick the fix. Follow the repository's commit, push, pull request,
+and ticket status rules. Do not create a pull request or publish changes without
+the authority required by those rules.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,6 +8,14 @@
 
 Closes #
 
+## Release train
+
+<!-- Use main for general bugs, security fixes, and shared changes. Use next only
+     for v0.7 features or bugs unique to unreleased v0.7 work. -->
+
+- [ ] This PR targets `main`.
+- [ ] This PR targets `next`.
+
 ## Checklist
 
 - [ ] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, next]
   pull_request:
-    branches: [main]
+    branches: [main, next]
 
 # Supersede an in-flight run when a branch is pushed again so runs stop
 # stacking. Keyed per workflow+ref: each PR branch and main have independent
@@ -649,7 +649,8 @@ jobs:
     # Skip on PRs that can't affect what the ladder tests (docs, UI-only, gtools,
     # non-ladder CI). Not a required check, so skipping never blocks a merge; it
     # just stops paying the ~2min image-build + rung cost when nothing it
-    # exercises changed. Always runs on push to main (the changes job forces it).
+    # exercises changed. Always runs on push to either release train branch (the
+    # changes job forces it).
     if: needs.changes.outputs.ladder == 'true'
     steps:
       - uses: actions/checkout@v7
@@ -868,7 +869,7 @@ jobs:
   # Gate the expensive e2e parity ladder rungs so they run ONLY when a change
   # could affect the build/deploy/message path any rung exercises (charts / cli /
   # app+runner images / the ACI wire / this workflow), and always on push to
-  # main. An unrelated PR (docs, UI-only, gtools, etc.) skips every ladder rung
+  # either release train branch. An unrelated PR (docs, UI-only, gtools, etc.) skips every ladder rung
   # entirely -- the ladder's image builds + rungs are ~2min it need not pay when
   # nothing it tests changed. Pure git-diff, no third-party action. (No ladder
   # rung is a required check anyway -- the ruleset requires only
@@ -888,7 +889,7 @@ jobs:
         run: |
           set -euo pipefail
           if [ "${{ github.event_name }}" = "push" ]; then
-            echo "ladder=true" >> "$GITHUB_OUTPUT"   # post-merge gate on main
+            echo "ladder=true" >> "$GITHUB_OUTPUT"   # post-merge gate on a release train branch
             exit 0
           fi
           base="${{ github.base_ref }}"

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -2,9 +2,9 @@ name: CodeQL
 
 on:
   push:
-    branches: [main]
+    branches: [main, next]
   pull_request:
-    branches: [main]
+    branches: [main, next]
   schedule:
     - cron: "0 6 * * 3"
   workflow_dispatch:

--- a/.github/workflows/dependency-audit.yaml
+++ b/.github/workflows/dependency-audit.yaml
@@ -2,9 +2,9 @@ name: Dependency Audit
 
 on:
   push:
-    branches: [main]
+    branches: [main, next]
   pull_request:
-    branches: [main]
+    branches: [main, next]
   schedule:
     # Advisory databases change independently of the code, so re-run weekly to
     # catch newly-published CVEs against dependencies that never changed.

--- a/.github/workflows/gitleaks.yaml
+++ b/.github/workflows/gitleaks.yaml
@@ -2,9 +2,9 @@ name: Secret Scan
 
 on:
   push:
-    branches: [main]
+    branches: [main, next]
   pull_request:
-    branches: [main]
+    branches: [main, next]
   schedule:
     # Weekly full-history sweep so a secret introduced (or surfaced by a future
     # history rewrite) is caught even without a push.

--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -6,12 +6,12 @@ name: Helm CI
 # values overlay, and schema-validate the rendered manifests.
 on:
   push:
-    branches: [main]
+    branches: [main, next]
     paths:
       - "charts/curie/**"
       - ".github/workflows/helm-ci.yaml"
   pull_request:
-    branches: [main]
+    branches: [main, next]
     paths:
       - "charts/curie/**"
       - ".github/workflows/helm-ci.yaml"

--- a/.github/workflows/plugin-compat.yaml
+++ b/.github/workflows/plugin-compat.yaml
@@ -13,7 +13,7 @@ name: Plugin compat
 # The job is a checkout plus one npm install, so running both is cheap.
 on:
   pull_request:
-    branches: [main]
+    branches: [main, next]
     paths:
       - "examples/**"
       - "packages/plugin-format/**"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,10 +163,10 @@ stack up owns tearing it down — a blocked or crashed test agent never cleans u
 after itself, so do not assume someone else will.
 
 **Do stack testing from a worktree, not the main checkout.** If a local test
-requires code edits, make them in a git worktree cut from `origin/main` and land
-them as a PR — never edit `main` in place to make a local run work. Read-only
-runs against the current tree are fine; the moment you need to change code, cut a
-worktree.
+requires code edits, make them in a git worktree cut from the release train base
+selected below and land them as a PR. Never edit `main` or `next` in place to
+make a local run work. Read only runs against the current tree are fine; the
+moment you need to change code, cut a worktree.
 
 Add `--profile slack` through `curie local up --slack` to start the optional dispatcher for real Slack.
 
@@ -432,10 +432,47 @@ satisfy a runtime AC. See
 [`charts/curie/CLAUDE.md`](charts/curie/CLAUDE.md) for the install and probe
 commands.
 
-## Branch and commit conventions
+## Release train, branch, and commit conventions
 
-- Branch per change: `task/<short-description>`, cut from the latest
-  `origin/main`. Never commit to `main`.
+`main` is the stable v0.6.x line. `next` is the v0.7.0 integration branch. It
+is one release train, not a second product line.
+
+| Change | Worktree base and PR target |
+| --- | --- |
+| General bug fix, security fix, or change shared by both lines | `main` |
+| v0.7 feature or a bug unique to unreleased v0.7 work | `next` |
+
+Create a short lived `task/<short-description>` branch from the selected base:
+
+```bash
+git fetch origin <base>
+git worktree add <path> -b task/<short-description> "$(git rev-parse origin/<base>)"
+```
+
+Never commit directly to `main` or `next`. `main` remains the default GitHub
+contributor target. Select `next` only for v0.7 work.
+
+Before accepting PRs against either branch, an administrator must protect both
+`main` and `next` with the same pull request review and required check rules,
+and must prohibit force pushes and branch deletion. Do not use an unprotected
+release train branch.
+
+After a fix merges to `main`, merge `main` forward into `next` promptly through
+a PR. Do not routinely cherry pick fixes between release lines. When v0.7 is
+ready, merge `next` into `main`, then run every parity ladder rung on the
+resulting `main` commit:
+
+```bash
+CURIE_E2E_TIERS=all curie dev e2e-ladder
+CURIE_E2E_TIERS=local-release curie dev e2e-ladder
+```
+
+Tag v0.7.0 from `main` only after both commands pass, then delete `next` or
+recreate it from `main` for the next approved feature train. Only an
+administrator may retire `next`, by temporarily removing protection after the
+tag while `main` remains protected. If `next` is recreated, restore its full
+protection before accepting PRs against it.
+
 - Commit message format: a short imperative summary line, then detail bullets.
 - Reference the relevant issue in the PR body (e.g. `Closes #123`).
 - **Never mention any AI assistant (Claude, Codex, GPT, etc.) or AI in general in
@@ -443,7 +480,7 @@ commands.
   CI enforces this on every PR (issue #962); check before pushing with:
 
   ```bash
-  scripts/check-commit-messages.sh            # defaults to origin/main..HEAD
+  scripts/check-commit-messages.sh origin/<base>..HEAD
   scripts/check-commit-messages.sh --self-test
   ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,14 @@ New tooling ships as a `curie` subcommand (add the clap surface in
 `cli/src/main.rs`, the handler in `cli/src/commands.rs`); a new loose script in
 `scripts/` should be the exception with a reason, not the default.
 
+## Release train selection
+
+`main` is the stable v0.6.x line and `next` is the v0.7.0 integration branch.
+Before starting work, choose the release train from the branch table in
+[`AGENTS.md`](AGENTS.md#release-train-branch-and-commit-conventions), then create
+the worktree and PR against that base. Do not assume `main` is the target for
+every feature.
+
 ## Architecture Decision Records (ADRs)
 
 `docs/adr/` is the system of record for architecture decisions. Each ADR captures

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,9 +62,9 @@ down` (add `-v` to wipe volumes). If you brought it up, you own tearing it
 down. AGENTS.md documents the per-service host ports and the load-bearing
 gotchas.
 
-Do stack testing from a git worktree cut from `origin/main`, not the main
-checkout. Read-only runs against the current tree are fine; the moment you need
-to change code, cut a worktree.
+Do stack testing from a git worktree cut from the release train base, not the
+main checkout. Read only runs against the current tree are fine; the moment you
+need to change code, cut a worktree.
 
 ## Running the checks
 
@@ -157,10 +157,44 @@ observability, convergence, protection, or parity.
   the why; the how lives in the PR.
 - When in doubt, write the issue.
 
-## Branch, commit, and PR conventions
+## Release train, branch, commit, and PR conventions
 
-- **Branch per change**, cut from the latest `origin/main`, named
-  `task/<short-description>`. Keep the slug terse. Never commit to `main`.
+`main` is the stable v0.6.x line. `next` integrates v0.7.0 work. It is one
+time bounded release train, not a permanently divergent branch.
+
+| Change | Worktree base and PR target |
+| --- | --- |
+| General bug fix, security fix, or shared change | `main` |
+| v0.7 feature or a bug unique to unreleased v0.7 work | `next` |
+
+Create each `task/<short-description>` branch from the selected latest base:
+
+```bash
+git fetch origin <base>
+git worktree add <path> -b task/<short-description> "$(git rev-parse origin/<base>)"
+```
+
+Never commit directly to `main` or `next`. `main` stays the default contributor
+target. Choose `next` only for v0.7 work. After a fix merges to `main`, merge
+`main` forward into `next` through a follow up PR. Do not routinely cherry pick
+between the two branches. An administrator must protect both branches with the
+same pull request review and required check rules, and prohibit force pushes and
+branch deletion. Do not use an unprotected release train branch.
+
+When v0.7 is ready, merge `next` into `main`, then run every parity ladder rung
+on the resulting `main` commit:
+
+```bash
+CURIE_E2E_TIERS=all curie dev e2e-ladder
+CURIE_E2E_TIERS=local-release curie dev e2e-ladder
+```
+
+Tag v0.7.0 from `main` only after both commands pass, then delete `next` or
+recreate it from `main` for the next approved feature train. Only an
+administrator may retire `next`, by temporarily removing protection after the
+tag while `main` remains protected. If `next` is recreated, restore its full
+protection before accepting PRs against it.
+
 - **Commit messages**: a short imperative summary line, then detail bullets.
 - **Reference the issue in the PR body** with `Closes #123` (or `Ref #123`). Do
   not put the issue number in the PR or commit title; use a plain descriptive
@@ -168,8 +202,8 @@ observability, convergence, protection, or parity.
 - **No dashes or emdashes in prose; no emojis** in code or docs.
 - **Never mention any AI assistant** (or AI in general) in commit messages, and
   never add `Co-Authored-By` lines referencing an AI.
-- Open a PR against `main`. Keep the change focused; a PR that touches unrelated
-  areas is harder to review and to revert.
+- Open the PR against its selected release train base. Keep the change focused;
+  a PR that touches unrelated areas is harder to review and to revert.
 
 ## Certifying your contribution
 

--- a/cli/CLAUDE.md
+++ b/cli/CLAUDE.md
@@ -238,9 +238,15 @@ selects rungs; `local-release` is NOT folded into `all` since it needs those
 extra images built first, so name it explicitly (e.g.
 `skill,local,local-release`). `CURIE_E2E_LIVE` (default fake, `1` for live)
 governs every named rung, including rung 1 -- `e2e.sh` reads the same env var
-directly rather than being told by the ladder. One-command pre-release gate:
+directly rather than being told by the ladder. The standard pre release gate is:
 ```bash
 CURIE_E2E_TIERS=all curie dev e2e-ladder
+```
+
+A release candidate also runs the separately named release compose rung:
+
+```bash
+CURIE_E2E_TIERS=local-release curie dev e2e-ladder
 ```
 
 Falsifiability gate (issue #619) -- a gate, NOT an E2E test: it never runs a real


### PR DESCRIPTION
## Summary

Documents the stable main and v0.7 next release train, including worktree and PR selection, forward merges, protection, and retirement controls.

Extends CI quality workflows to next while keeping release publication on main only.

## Related issue

None.

## Release train

This PR targets `main`.