### PR TITLE
Hash ClickHouse config content for rollouts

### DIFF
--- a/charts/curie/ci/clickhouse-logging-assertions.sh
+++ b/charts/curie/ci/clickhouse-logging-assertions.sh
@@ -53,30 +53,95 @@ CHART="$(cd "$SCRIPT_DIR/.." && pwd)"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
-TPL=templates/clickhouse.yaml
-
 fail() { echo "FAIL: $*" >&2; exit 1; }
 
-DEFAULT="$TMP/default.yaml"
-VERBOSE="$TMP/verbose.yaml"
-NOPERSIST="$TMP/nopersist.yaml"
-OFF="$TMP/off.yaml"
+render() {
+  local name="$1"
+  local chart="$2"
+  shift 2
+
+  RENDER_DIR="$TMP/$name"
+  helm template rel "$chart" --output-dir "$RENDER_DIR" "$@"
+}
+
+manifest_for() {
+  local manifest
+  manifest="$(find "$1" -type f -path "*/templates/clickhouse.yaml" -print -quit)"
+  [[ -n "$manifest" ]] || fail "ClickHouse template was not written to $1"
+  printf '%s\n' "$manifest"
+}
 
 echo "=== Rendering ClickHouse (defaults) ==="
-helm template rel "$CHART" --show-only "$TPL" > "$DEFAULT"
+render default "$CHART"
+DEFAULT="$(manifest_for "$RENDER_DIR")"
 
 echo "=== Rendering ClickHouse (systemLogs.enabled=true, retentionDays=7) ==="
-helm template rel "$CHART" --show-only "$TPL" \
+render verbose "$CHART" \
   --set clickhouse.systemLogs.enabled=true \
-  --set clickhouse.systemLogs.retentionDays=7 > "$VERBOSE"
+  --set clickhouse.systemLogs.retentionDays=7
+VERBOSE="$(manifest_for "$RENDER_DIR")"
 
 echo "=== Rendering ClickHouse (persistence disabled) ==="
-helm template rel "$CHART" --show-only "$TPL" \
-  --set clickhouse.persistence.enabled=false > "$NOPERSIST"
+render nopersist "$CHART" --set clickhouse.persistence.enabled=false
+NOPERSIST="$(manifest_for "$RENDER_DIR")"
 
 echo "=== Rendering ClickHouse (deploy=false) ==="
-helm template rel "$CHART" --show-only "$TPL" \
-  --set clickhouse.deploy=false > "$OFF" 2>/dev/null || true
+render off "$CHART" \
+  --set clickhouse.deploy=false \
+  --set clickhouse.host=clickhouse.example.com
+OFF="$RENDER_DIR"
+
+CHECKSUM_VALUES=(
+  --set clickhouse.logLevel=warning
+  --set clickhouse.systemLogs.enabled=false
+  --set clickhouse.systemLogs.retentionDays=30
+)
+MUTATED_CHART="$TMP/checksum-chart"
+cp -a "$CHART" "$MUTATED_CHART"
+
+echo "=== Rendering ClickHouse checksum baseline ==="
+render checksum-original "$MUTATED_CHART" "${CHECKSUM_VALUES[@]}"
+CHECKSUM_ORIGINAL="$(manifest_for "$RENDER_DIR")"
+
+python3 - "$MUTATED_CHART/templates/_helpers.tpl" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+original = path.read_text()
+mutated = original.replace("<console>1</console>", "<console>0</console>", 1)
+assert mutated != original, "checksum mutation target was not found"
+path.write_text(mutated)
+PY
+
+echo "=== Rendering ClickHouse checksum mutation ==="
+render checksum-mutated "$MUTATED_CHART" "${CHECKSUM_VALUES[@]}"
+CHECKSUM_MUTATED="$(manifest_for "$RENDER_DIR")"
+
+python3 - "$CHECKSUM_ORIGINAL" "$CHECKSUM_MUTATED" <<'PY'
+import sys, yaml
+
+def config_and_checksum(path):
+    docs = [d for d in yaml.safe_load_all(open(path)) if d]
+    cm = next((d for d in docs if d["kind"] == "ConfigMap"), None)
+    sts = next((d for d in docs if d["kind"] == "StatefulSet"), None)
+    assert cm is not None, f"{path}: no ClickHouse config ConfigMap rendered"
+    assert sts is not None, f"{path}: no ClickHouse StatefulSet rendered"
+    annotations = sts["spec"]["template"]["metadata"].get("annotations") or {}
+    checksum = annotations.get("checksum/config")
+    assert checksum, f"{path}: no checksum/config annotation rendered"
+    return cm["data"]["curie-logging.xml"], checksum
+
+original_body, original_checksum = config_and_checksum(sys.argv[1])
+mutated_body, mutated_checksum = config_and_checksum(sys.argv[2])
+
+assert original_body != mutated_body, "checksum mutation did not change the ConfigMap body"
+assert original_checksum != mutated_checksum, (
+    "ConfigMap body changed but checksum/config did not. The pod would not roll."
+)
+
+print("  ConfigMap body mutation updates checksum: OK")
+PY
 
 # ---------------------------------------------------------------- 1, 2, 4, 6
 python3 - "$DEFAULT" "$VERBOSE" <<'PY'
@@ -204,10 +269,10 @@ assert "volumeClaimTemplates" not in sts["spec"], "persistence=false must not re
 print("  persistence=false still gets its data emptyDir: OK")
 PY
 
-if grep -q "kind:" "$OFF" 2>/dev/null; then
-  fail "clickhouse.deploy=false still rendered objects"
+if [[ -d "$OFF" ]] && [[ -n "$(find "$OFF" -type f -path "*/templates/clickhouse.yaml" -print -quit)" ]]; then
+  fail "clickhouse.deploy=false still rendered the ClickHouse manifest"
 fi
-echo "  clickhouse.deploy=false renders nothing: OK"
+echo "  clickhouse.deploy=false renders no ClickHouse manifest: OK"
 
 echo
 echo "PASS: ClickHouse self-telemetry defaults are bounded."

--- a/charts/curie/templates/_helpers.tpl
+++ b/charts/curie/templates/_helpers.tpl
@@ -93,6 +93,55 @@ ANTHROPIC_BASE_URL ANTHROPIC_API_KEY CLAUDE_CODE_OAUTH_TOKEN ANTHROPIC_AUTH_TOKE
 {{- end -}}
 {{- end -}}
 
+{{- define "curie.clickhouse.loggingConfig" -}}
+<clickhouse>
+  <logger>
+    <level>{{ .Values.clickhouse.logLevel }}</level>
+    <!-- Also to stdout, so `kubectl logs` works. The image logs only to
+         files under /var/log/clickhouse-server/, which in Kubernetes means
+         the diagnostics live inside the container and die with the pod,
+         exactly when you most want them. Cheap at `warning`. -->
+    <console>1</console>
+  </logger>
+  <!-- text_log is KEPT, and level-filtered rather than removed.
+       The image ships <text_log><level>trace</level></text_log>, and that
+       `level` is the whole problem: an hour of it produced 253,727 Debug
+       and 58,186 Trace rows against 15 Information. Filtering to
+       `{{ .Values.clickhouse.logLevel }}` drops the volume by ~4 orders of
+       magnitude while keeping the table queryable, and a queryable
+       text_log is precisely what diagnosed the incident this fixes. It also
+       outlives the pod, which the log file does not. -->
+  <text_log>
+    <level>{{ .Values.clickhouse.logLevel }}</level>
+    <ttl>event_date + INTERVAL {{ .Values.clickhouse.systemLogs.retentionDays }} DAY DELETE</ttl>
+  </text_log>
+{{- if .Values.clickhouse.systemLogs.enabled }}
+  <!-- Profiling and per-second resource sampling, on but TTL-bounded. -->
+  <trace_log><ttl>event_date + INTERVAL {{ .Values.clickhouse.systemLogs.retentionDays }} DAY DELETE</ttl></trace_log>
+  <metric_log><ttl>event_date + INTERVAL {{ .Values.clickhouse.systemLogs.retentionDays }} DAY DELETE</ttl></metric_log>
+  <asynchronous_metric_log><ttl>event_date + INTERVAL {{ .Values.clickhouse.systemLogs.retentionDays }} DAY DELETE</ttl></asynchronous_metric_log>
+{{- else }}
+  <!-- Removed. Unlike text_log these have no level filter; they sample on
+       a timer regardless of whether anything is happening, so the only
+       lever is on/off. metric_log was the table whose merge wedged and
+       started the spiral. Prometheus and node metrics already cover what
+       they measure, from outside the process that is failing. -->
+  <trace_log remove="1"/>
+  <metric_log remove="1"/>
+  <asynchronous_metric_log remove="1"/>
+{{- end }}
+  <!-- Kept regardless: low volume, useful when ClickHouse itself
+       misbehaves. TTL'd so none can become the next text_log.
+       processors_profile_log is here because a live boot showed the image
+       creates it too. It is easy to miss precisely because it is small
+       today, which is what text_log also was once. -->
+  <query_log><ttl>event_date + INTERVAL {{ .Values.clickhouse.systemLogs.retentionDays }} DAY DELETE</ttl></query_log>
+  <part_log><ttl>event_date + INTERVAL {{ .Values.clickhouse.systemLogs.retentionDays }} DAY DELETE</ttl></part_log>
+  <error_log><ttl>event_date + INTERVAL {{ .Values.clickhouse.systemLogs.retentionDays }} DAY DELETE</ttl></error_log>
+  <processors_profile_log><ttl>event_date + INTERVAL {{ .Values.clickhouse.systemLogs.retentionDays }} DAY DELETE</ttl></processors_profile_log>
+</clickhouse>
+{{- end }}
+
 {{- define "curie.rustfs.host" -}}
 {{- if .Values.rustfs.deploy -}}
 {{- printf "%s-rustfs" (include "curie.fullname" .) -}}

--- a/charts/curie/templates/clickhouse.yaml
+++ b/charts/curie/templates/clickhouse.yaml
@@ -17,52 +17,7 @@ data:
   # into an infinite retry. See the clickhouse block in values.yaml for the
   # measured numbers.
   curie-logging.xml: |
-    <clickhouse>
-      <logger>
-        <level>{{ .Values.clickhouse.logLevel }}</level>
-        <!-- Also to stdout, so `kubectl logs` works. The image logs only to
-             files under /var/log/clickhouse-server/, which in Kubernetes means
-             the diagnostics live inside the container and die with the pod,
-             exactly when you most want them. Cheap at `warning`. -->
-        <console>1</console>
-      </logger>
-      <!-- text_log is KEPT, and level-filtered rather than removed.
-           The image ships <text_log><level>trace</level></text_log>, and that
-           `level` is the whole problem: an hour of it produced 253,727 Debug
-           and 58,186 Trace rows against 15 Information. Filtering to
-           `{{ .Values.clickhouse.logLevel }}` drops the volume by ~4 orders of
-           magnitude while keeping the table queryable, and a queryable
-           text_log is precisely what diagnosed the incident this fixes. It also
-           outlives the pod, which the log file does not. -->
-      <text_log>
-        <level>{{ .Values.clickhouse.logLevel }}</level>
-        <ttl>event_date + INTERVAL {{ .Values.clickhouse.systemLogs.retentionDays }} DAY DELETE</ttl>
-      </text_log>
-    {{- if .Values.clickhouse.systemLogs.enabled }}
-      <!-- Profiling and per-second resource sampling, on but TTL-bounded. -->
-      <trace_log><ttl>event_date + INTERVAL {{ .Values.clickhouse.systemLogs.retentionDays }} DAY DELETE</ttl></trace_log>
-      <metric_log><ttl>event_date + INTERVAL {{ .Values.clickhouse.systemLogs.retentionDays }} DAY DELETE</ttl></metric_log>
-      <asynchronous_metric_log><ttl>event_date + INTERVAL {{ .Values.clickhouse.systemLogs.retentionDays }} DAY DELETE</ttl></asynchronous_metric_log>
-    {{- else }}
-      <!-- Removed. Unlike text_log these have no level filter; they sample on
-           a timer regardless of whether anything is happening, so the only
-           lever is on/off. metric_log was the table whose merge wedged and
-           started the spiral. Prometheus and node metrics already cover what
-           they measure, from outside the process that is failing. -->
-      <trace_log remove="1"/>
-      <metric_log remove="1"/>
-      <asynchronous_metric_log remove="1"/>
-    {{- end }}
-      <!-- Kept regardless: low volume, useful when ClickHouse itself
-           misbehaves. TTL'd so none can become the next text_log.
-           processors_profile_log is here because a live boot showed the image
-           creates it too. It is easy to miss precisely because it is small
-           today, which is what text_log also was once. -->
-      <query_log><ttl>event_date + INTERVAL {{ .Values.clickhouse.systemLogs.retentionDays }} DAY DELETE</ttl></query_log>
-      <part_log><ttl>event_date + INTERVAL {{ .Values.clickhouse.systemLogs.retentionDays }} DAY DELETE</ttl></part_log>
-      <error_log><ttl>event_date + INTERVAL {{ .Values.clickhouse.systemLogs.retentionDays }} DAY DELETE</ttl></error_log>
-      <processors_profile_log><ttl>event_date + INTERVAL {{ .Values.clickhouse.systemLogs.retentionDays }} DAY DELETE</ttl></processors_profile_log>
-    </clickhouse>
+{{ include "curie.clickhouse.loggingConfig" . | indent 4 }}
 ---
 apiVersion: v1
 kind: Service
@@ -97,11 +52,11 @@ spec:
   template:
     metadata:
       annotations:
-        # Roll the pod when the logging overlay changes. Without this a
-        # `logLevel` or `systemLogs` edit renders a new ConfigMap and the
+        # Roll the pod when the rendered logging overlay changes. Without this a
+        # ConfigMap edit renders a new ConfigMap and the
         # running server keeps the old config until something else restarts it
         # -- i.e. the fix would appear applied while the node kept starving.
-        checksum/config: {{ printf "%s|%v|%v" .Values.clickhouse.logLevel .Values.clickhouse.systemLogs.enabled .Values.clickhouse.systemLogs.retentionDays | sha256sum }}
+        checksum/config: {{ include "curie.clickhouse.loggingConfig" . | sha256sum }}
       labels:
         {{- include "curie.labels" . | nindent 8 }}
         {{- include "curie.selectorLabels" (dict "root" . "component" "clickhouse") | nindent 8 }}


### PR DESCRIPTION
Closes #1362\n\nHashes the exact rendered ClickHouse logging overlay used by the ConfigMap so overlay body changes update the StatefulSet pod annotation. Adds an output directory render comparison that pins the prior three checksum inputs and changes only the overlay body.\n\n## Done check\n\n* [x] ClickHouse assertion script passes on the unmutated chart\n* [x] Three value checksum mutation and all five existing mutations exit 1\n* [x] Helm lint and commit message checks pass\n* [x] Independent code and scope reviews approved\n* [x] ConfigMap and annotation share one rendering helper\n* [x] Modified guard rejected violating inputs by execution\n* [x] Consolidation applied no retained changes\n* [ ] Runtime chart harness is environment blocked on disposable cluster runner readiness after two attempts; both runs tore down and restored the original context