### PR TITLE
Return every all target deploy result

### DIFF
--- a/cli/CLAUDE.md
+++ b/cli/CLAUDE.md
@@ -36,9 +36,11 @@ Helm and the deployed release with `up`, `status`, `down`, `comms`, `message`,
   typed `CliOutput` whose `to_json` delegates to its unchanged pure builder, so the
   committed schemas stay byte-for-byte identical while the json-vs-human decision
   lives only in `Ui::emit`. The one intentional non-`CliOutput` emit is the
-  centralized error path in `main.rs` (`error_json` under `--json`): errors are not
-  success-path values, so they stay on the error-emit mirror rather than the
-  success-path `CliOutput` contract.
+  centralized error path in `main.rs` (`error_json` under `--json`): generic
+  errors use `error.schema.json`, while `cluster deploy --all-targets`
+  reconciliation failures use `deploy.schema.json`. Errors are not success-path
+  values, so they stay on the error-emit mirror rather than the success-path
+  `CliOutput` contract.
 - **The command manifest is a committed artifact; regenerate it in the same
   change as any command-surface edit (console/CLI parity, epic #145).** Any
   change to a clap `Command`/subcommand or an `*Action` enum — a renamed verb,

--- a/cli/README.md
+++ b/cli/README.md
@@ -121,9 +121,11 @@ state on stdout --
 The five shapes are the `oneOf` in `cli/schema/message.schema.json`. Two
 exceptions still print human text instead of JSON on success (tracked in
 #485): `curie skill message`, and the operator verbs (`up`, `down`,
-`status`, `comms`, `deploy`). On failure under `--json`, the error is
-emitted to stdout as `{"error": "<message>", "fix": "<hint>"|null}` instead of
-a prose message, so an agent can recover without parsing prose.
+`status`, `comms`, `deploy`). On generic failure under `--json`, the error is
+emitted to stdout as `{"error": "<message>", "fix": "<hint>"|null}` and follows
+`cli/schema/error.schema.json`, so an agent can recover without parsing prose.
+The exception is `curie cluster deploy --all-targets`, whose reconciliation
+failures follow `cli/schema/deploy.schema.json`.
 
 **Versioned result schemas.** Every agent-facing `--json` result maps to a
 committed JSON Schema under `cli/schema/`, with an explicit version in its

--- a/cli/schema/baseline/deploy.schema.json
+++ b/cli/schema/baseline/deploy.schema.json
@@ -1,104 +1,226 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://schemas.curietech.ai/cli/deploy/v1.json",
+  "$id": "https://schemas.curietech.ai/cli/deploy/v1.1.json",
   "title": "curie <tier> deploy --json",
-  "description": "The agent-facing payload of `curie local deploy` / `curie cluster deploy`: the deployed agent, version, channel, bundle, and deployment summary.",
-  "type": "object",
-  "additionalProperties": false,
-  "properties": {
-    "plugin": {
-      "type": "string"
+  "description": "The agent facing payload of `curie local deploy` / `curie cluster deploy`: a single target result, ordered results for all targets, or reconciliation failures for all targets.",
+  "oneOf": [
+    {
+      "$ref": "#/$defs/deploy_result"
     },
-    "label": {
-      "type": "string"
+    {
+      "$ref": "#/$defs/aggregate_success"
     },
-    "environment": {
-      "type": "string"
+    {
+      "$ref": "#/$defs/deploy_failure"
     },
-    "agent": {
+    {
+      "$ref": "#/$defs/connector_failure"
+    }
+  ],
+  "$defs": {
+    "deploy_result": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "name": {
+        "plugin": {
           "type": "string"
         },
-        "id": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "name",
-        "id"
-      ]
-    },
-    "version": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
         "label": {
-          "type": "string"
-        },
-        "id": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "label",
-        "id"
-      ]
-    },
-    "channel": {
-      "type": "string"
-    },
-    "bundle": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "ref": {
-          "type": "string"
-        },
-        "sha256": {
-          "type": "string"
-        },
-        "size_bytes": {
-          "type": "integer"
-        }
-      },
-      "required": [
-        "ref",
-        "sha256",
-        "size_bytes"
-      ]
-    },
-    "deployment": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "id": {
           "type": "string"
         },
         "environment": {
           "type": "string"
         },
-        "status": {
+        "agent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "name",
+            "id"
+          ]
+        },
+        "version": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "label": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "label",
+            "id"
+          ]
+        },
+        "channel": {
           "type": "string"
+        },
+        "bundle": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "ref": {
+              "type": "string"
+            },
+            "sha256": {
+              "type": "string"
+            },
+            "size_bytes": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "ref",
+            "sha256",
+            "size_bytes"
+          ]
+        },
+        "deployment": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "environment": {
+              "type": "string"
+            },
+            "status": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "id",
+            "environment",
+            "status"
+          ]
         }
       },
       "required": [
-        "id",
+        "plugin",
+        "label",
         "environment",
-        "status"
+        "agent",
+        "version",
+        "channel",
+        "bundle",
+        "deployment"
+      ]
+    },
+    "target_result": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "target": {
+          "type": "string"
+        },
+        "result": {
+          "$ref": "#/$defs/deploy_result"
+        }
+      },
+      "required": [
+        "target",
+        "result"
+      ]
+    },
+    "aggregate_success": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "results": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/target_result"
+          }
+        }
+      },
+      "required": [
+        "results"
+      ]
+    },
+    "deploy_failure": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "failed_target": {
+          "type": "string"
+        },
+        "stage": {
+          "const": "deploy"
+        },
+        "completed": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/target_result"
+          }
+        },
+        "error": {
+          "type": "string"
+        },
+        "fix": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "failed_target",
+        "stage",
+        "completed",
+        "error",
+        "fix"
+      ]
+    },
+    "connector_failure": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "failed_target": {
+          "type": "string"
+        },
+        "stage": {
+          "const": "connector_sync"
+        },
+        "completed": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/target_result"
+          }
+        },
+        "failed_result": {
+          "$ref": "#/$defs/deploy_result"
+        },
+        "error": {
+          "type": "string"
+        },
+        "fix": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "failed_target",
+        "stage",
+        "completed",
+        "failed_result",
+        "error",
+        "fix"
       ]
     }
-  },
-  "required": [
-    "plugin",
-    "label",
-    "environment",
-    "agent",
-    "version",
-    "channel",
-    "bundle",
-    "deployment"
-  ]
+  }
 }

--- a/cli/schema/deploy.schema.json
+++ b/cli/schema/deploy.schema.json
@@ -1,104 +1,226 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://schemas.curietech.ai/cli/deploy/v1.json",
+  "$id": "https://schemas.curietech.ai/cli/deploy/v1.1.json",
   "title": "curie <tier> deploy --json",
-  "description": "The agent-facing payload of `curie local deploy` / `curie cluster deploy`: the deployed agent, version, channel, bundle, and deployment summary.",
-  "type": "object",
-  "additionalProperties": false,
-  "properties": {
-    "plugin": {
-      "type": "string"
+  "description": "The agent facing payload of `curie local deploy` / `curie cluster deploy`: a single target result, ordered results for all targets, or reconciliation failures for all targets.",
+  "oneOf": [
+    {
+      "$ref": "#/$defs/deploy_result"
     },
-    "label": {
-      "type": "string"
+    {
+      "$ref": "#/$defs/aggregate_success"
     },
-    "environment": {
-      "type": "string"
+    {
+      "$ref": "#/$defs/deploy_failure"
     },
-    "agent": {
+    {
+      "$ref": "#/$defs/connector_failure"
+    }
+  ],
+  "$defs": {
+    "deploy_result": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "name": {
+        "plugin": {
           "type": "string"
         },
-        "id": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "name",
-        "id"
-      ]
-    },
-    "version": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
         "label": {
-          "type": "string"
-        },
-        "id": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "label",
-        "id"
-      ]
-    },
-    "channel": {
-      "type": "string"
-    },
-    "bundle": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "ref": {
-          "type": "string"
-        },
-        "sha256": {
-          "type": "string"
-        },
-        "size_bytes": {
-          "type": "integer"
-        }
-      },
-      "required": [
-        "ref",
-        "sha256",
-        "size_bytes"
-      ]
-    },
-    "deployment": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "id": {
           "type": "string"
         },
         "environment": {
           "type": "string"
         },
-        "status": {
+        "agent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "name",
+            "id"
+          ]
+        },
+        "version": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "label": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "label",
+            "id"
+          ]
+        },
+        "channel": {
           "type": "string"
+        },
+        "bundle": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "ref": {
+              "type": "string"
+            },
+            "sha256": {
+              "type": "string"
+            },
+            "size_bytes": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "ref",
+            "sha256",
+            "size_bytes"
+          ]
+        },
+        "deployment": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "environment": {
+              "type": "string"
+            },
+            "status": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "id",
+            "environment",
+            "status"
+          ]
         }
       },
       "required": [
-        "id",
+        "plugin",
+        "label",
         "environment",
-        "status"
+        "agent",
+        "version",
+        "channel",
+        "bundle",
+        "deployment"
+      ]
+    },
+    "target_result": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "target": {
+          "type": "string"
+        },
+        "result": {
+          "$ref": "#/$defs/deploy_result"
+        }
+      },
+      "required": [
+        "target",
+        "result"
+      ]
+    },
+    "aggregate_success": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "results": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/target_result"
+          }
+        }
+      },
+      "required": [
+        "results"
+      ]
+    },
+    "deploy_failure": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "failed_target": {
+          "type": "string"
+        },
+        "stage": {
+          "const": "deploy"
+        },
+        "completed": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/target_result"
+          }
+        },
+        "error": {
+          "type": "string"
+        },
+        "fix": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "failed_target",
+        "stage",
+        "completed",
+        "error",
+        "fix"
+      ]
+    },
+    "connector_failure": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "failed_target": {
+          "type": "string"
+        },
+        "stage": {
+          "const": "connector_sync"
+        },
+        "completed": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/target_result"
+          }
+        },
+        "failed_result": {
+          "$ref": "#/$defs/deploy_result"
+        },
+        "error": {
+          "type": "string"
+        },
+        "fix": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "failed_target",
+        "stage",
+        "completed",
+        "failed_result",
+        "error",
+        "fix"
       ]
     }
-  },
-  "required": [
-    "plugin",
-    "label",
-    "environment",
-    "agent",
-    "version",
-    "channel",
-    "bundle",
-    "deployment"
-  ]
+  }
 }

--- a/cli/schema/index.json
+++ b/cli/schema/index.json
@@ -4,6 +4,12 @@
   "discovery": "These schema files are bundled into released `curie` CLI binaries and printed on demand: `curie schema-index` emits this index, `curie schema-index <name>` emits a named schema. In a source checkout they live at cli/schema/.",
   "results": [
     {
+      "result": "AllTargetsDeployOutput",
+      "kind": "CliOutput",
+      "schema": "deploy.schema.json",
+      "version": "1.1"
+    },
+    {
       "result": "ApplyOutput",
       "kind": "CliOutput",
       "schema": "apply.schema.json",
@@ -67,7 +73,7 @@
       "result": "DeployOutput",
       "kind": "CliOutput",
       "schema": "deploy.schema.json",
-      "version": "1.0"
+      "version": "1.1"
     },
     {
       "result": "DiffOutput",
@@ -230,6 +236,12 @@
       "kind": "CliOutput",
       "schema": "versions.schema.json",
       "version": "1.0"
+    },
+    {
+      "result": "all_targets_deploy_failure_json",
+      "kind": "builder",
+      "schema": "deploy.schema.json",
+      "version": "1.1"
     },
     {
       "result": "error_json",

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -3474,6 +3474,80 @@ pub struct DeployOutput {
     pub deployment_status: String,
 }
 
+/// One completed entry in a deploy across every declared target, retaining the
+/// target name beside the full deploy result.
+#[derive(Debug)]
+pub struct AllTargetsDeployResult {
+    pub target: String,
+    pub result: DeployOutput,
+}
+
+impl AllTargetsDeployResult {
+    fn to_json(&self) -> serde_json::Value {
+        serde_json::json!({
+            "target": self.target,
+            "result": <DeployOutput as crate::ui::CliOutput>::to_json(&self.result),
+        })
+    }
+}
+
+/// Ordered result of a cluster deploy across every declared target.
+#[derive(Debug)]
+pub struct AllTargetsDeployOutput {
+    pub results: Vec<AllTargetsDeployResult>,
+}
+
+impl crate::ui::CliOutput for AllTargetsDeployOutput {
+    fn to_json(&self) -> serde_json::Value {
+        serde_json::json!({
+            "results": self
+                .results
+                .iter()
+                .map(AllTargetsDeployResult::to_json)
+                .collect::<Vec<_>>(),
+        })
+    }
+
+    fn render(&self, ui: &crate::ui::Ui) {
+        if let Some(last) = self.results.last() {
+            <DeployOutput as crate::ui::CliOutput>::render(&last.result, ui);
+        }
+    }
+}
+
+/// Build the reconciliation payload for a failed cluster deploy across every
+/// target. A connector failure includes the completed deploy result.
+pub fn all_targets_deploy_failure_json(
+    failed_target: &str,
+    completed: &[AllTargetsDeployResult],
+    failed_result: Option<&DeployOutput>,
+    err: &anyhow::Error,
+) -> serde_json::Value {
+    let completed = completed
+        .iter()
+        .map(AllTargetsDeployResult::to_json)
+        .collect::<Vec<_>>();
+    let fix = crate::exit::classify(err).1;
+
+    match failed_result {
+        Some(result) => serde_json::json!({
+            "failed_target": failed_target,
+            "stage": "connector_sync",
+            "completed": completed,
+            "failed_result": <DeployOutput as crate::ui::CliOutput>::to_json(result),
+            "error": format!("{err:#}"),
+            "fix": fix,
+        }),
+        None => serde_json::json!({
+            "failed_target": failed_target,
+            "stage": "deploy",
+            "completed": completed,
+            "error": format!("{err:#}"),
+            "fix": fix,
+        }),
+    }
+}
+
 impl crate::ui::CliOutput for DeployOutput {
     fn to_json(&self) -> serde_json::Value {
         serde_json::json!({

--- a/cli/src/exit.rs
+++ b/cli/src/exit.rs
@@ -20,8 +20,9 @@
 //! an unreachable dependency is detected structurally by walking the error chain
 //! for a `reqwest` connect/timeout error. Everything else is
 //! [`ExitClass::Failure`]. [`classify`] returns the class plus an optional
-//! one-line fix hint, and [`error_json`] renders the whole thing as the `--json`
-//! error payload.
+//! one-line fix hint, and [`error_json`] renders the generic `--json` error
+//! payload. Command-specific wrapped payloads are exposed by
+//! [`wrapped_json_payload`] for the centralized emitter to select.
 
 /// The five semantic exit classes. The `#[repr(i32)]` values are the process
 /// exit codes and are a stable contract agents branch on.
@@ -51,6 +52,24 @@ pub struct CliError {
     pub fix: Option<String>,
     pub class: ExitClass,
 }
+
+/// An error whose JSON rendering is a command specific reconciliation
+/// payload instead of the ordinary `{error, fix}` object.
+#[derive(Debug)]
+struct JsonPayloadError {
+    message: String,
+    payload: serde_json::Value,
+    class: ExitClass,
+    fix: Option<String>,
+}
+
+impl std::fmt::Display for JsonPayloadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for JsonPayloadError {}
 
 impl CliError {
     /// A deterministic input error (exit 2).
@@ -146,6 +165,18 @@ pub fn transient(msg: impl Into<String>) -> anyhow::Error {
     anyhow::Error::from(CliError::transient(msg))
 }
 
+/// Preserve an error's semantic exit classification while replacing only its
+/// centralized JSON rendering with `payload`.
+pub fn with_json_payload(err: anyhow::Error, payload: serde_json::Value) -> anyhow::Error {
+    let (class, fix) = classify(&err);
+    anyhow::Error::from(JsonPayloadError {
+        message: format!("{err:#}"),
+        payload,
+        class,
+        fix,
+    })
+}
+
 /// Classify an error into its exit class plus an optional fix hint. Walks the
 /// `anyhow` chain so a tagged [`CliError`] is found even under context layers; a
 /// `reqwest` connect/timeout failure anywhere in the chain maps to
@@ -153,6 +184,9 @@ pub fn transient(msg: impl Into<String>) -> anyhow::Error {
 /// [`ExitClass::Failure`] with no fix.
 pub fn classify(err: &anyhow::Error) -> (ExitClass, Option<String>) {
     for cause in err.chain() {
+        if let Some(payload) = cause.downcast_ref::<JsonPayloadError>() {
+            return (payload.class, payload.fix.clone());
+        }
         if let Some(cli) = cause.downcast_ref::<CliError>() {
             // A transient error is retryable by definition, so it always carries
             // a retry hint even when the caller did not attach a specific one.
@@ -185,7 +219,7 @@ pub fn is_transient_reqwest(err: &anyhow::Error) -> bool {
 /// The default one-line retry hint for a transient (retryable) failure.
 const RETRY_HINT: &str = "the endpoint was unreachable; retry once it is up";
 
-/// The `--json` error payload: `{"error": <message>, "fix": <hint or null>}`.
+/// The generic `--json` error payload: `{"error": <message>, "fix": <hint or null>}`.
 /// `error` is the top-level rendered error; `fix` comes from [`classify`].
 pub fn error_json(err: &anyhow::Error) -> serde_json::Value {
     let (_class, fix) = classify(err);
@@ -193,6 +227,13 @@ pub fn error_json(err: &anyhow::Error) -> serde_json::Value {
         "error": format!("{err:#}"),
         "fix": fix,
     })
+}
+
+/// Return a command-specific JSON payload carried by a wrapped error, if any.
+pub fn wrapped_json_payload(err: &anyhow::Error) -> Option<serde_json::Value> {
+    err.chain()
+        .find_map(|cause| cause.downcast_ref::<JsonPayloadError>())
+        .map(|payload| payload.payload.clone())
 }
 
 #[cfg(test)]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1941,7 +1941,9 @@ async fn main() {
     if let Err(err) = run(cli.command).await {
         let (class, _fix) = curie::exit::classify(&err);
         if ui::ui().json() {
-            ui::ui().emit_json(&curie::exit::error_json(&err));
+            let payload = curie::exit::wrapped_json_payload(&err)
+                .unwrap_or_else(|| curie::exit::error_json(&err));
+            ui::ui().emit_json(&payload);
         } else {
             eprintln!("Error: {err:#}");
         }
@@ -3037,12 +3039,13 @@ async fn run(command: Option<Command>) -> Result<()> {
                     vec![target]
                 };
 
-                // Emits the LAST deploy, so `--json` still yields one object
-                // (cli/CLAUDE.md: a verb emits exactly one). The per-target
-                // progress is on the note above.
+                // Single target deploy retains its existing output. All target
+                // deploy accumulates complete results in the API's declared order.
                 let mut last_deployed = None;
+                let mut completed = Vec::new();
                 for target in targets {
-                    let deployed = commands::deploy(DeployOpts {
+                    let target_name = target.clone();
+                    let deployed = match commands::deploy(DeployOpts {
                         plugin_dir: plugin_dir.clone(),
                         agent: agent.clone(),
                         target,
@@ -3062,7 +3065,23 @@ async fn run(command: Option<Command>) -> Result<()> {
                         secret_binding_supported: false,
                         connect_hint: connect_hint.clone(),
                     })
-                    .await?;
+                    .await
+                    {
+                        Ok(deployed) => deployed,
+                        Err(err) if all_targets => {
+                            let failed_target = target_name
+                                .as_deref()
+                                .expect("all target entries always have a target name");
+                            let payload = commands::all_targets_deploy_failure_json(
+                                failed_target,
+                                &completed,
+                                None,
+                                &err,
+                            );
+                            return Err(curie::exit::with_json_payload(err, payload));
+                        }
+                        Err(err) => return Err(err),
+                    };
 
                     // Stand up whatever the bundle's connectors.yaml declares
                     // (ADR-0086, #1063). After the deploy, so the objects exist
@@ -3070,7 +3089,7 @@ async fn run(command: Option<Command>) -> Result<()> {
                     // are the CONNECTOR's, resolved locally and written straight to
                     // a K8s Secret, which is a different path from the sandbox
                     // secret delivery #440 tracks.
-                    sync_connectors(
+                    if let Err(err) = sync_connectors(
                         &api_url,
                         &api_key,
                         &namespace,
@@ -3079,10 +3098,37 @@ async fn run(command: Option<Command>) -> Result<()> {
                         &deployed.agent_name,
                         &deployed.version_id,
                     )
-                    .await?;
-                    last_deployed = Some(deployed);
+                    .await
+                    {
+                        if all_targets {
+                            let failed_target = target_name
+                                .as_deref()
+                                .expect("all target entries always have a target name");
+                            let payload = commands::all_targets_deploy_failure_json(
+                                failed_target,
+                                &completed,
+                                Some(&deployed),
+                                &err,
+                            );
+                            return Err(curie::exit::with_json_payload(err, payload));
+                        }
+                        return Err(err);
+                    }
+                    if all_targets {
+                        completed.push(commands::AllTargetsDeployResult {
+                            target: target_name
+                                .expect("all target entries always have a target name"),
+                            result: deployed,
+                        });
+                    } else {
+                        last_deployed = Some(deployed);
+                    }
                 }
-                emit(last_deployed.expect("the target list is never empty"))
+                if all_targets {
+                    emit(commands::AllTargetsDeployOutput { results: completed })
+                } else {
+                    emit(last_deployed.expect("the target list is never empty"))
+                }
             }
             ClusterAction::Kill {
                 agent,

--- a/cli/tests/json_contract.rs
+++ b/cli/tests/json_contract.rs
@@ -950,6 +950,75 @@ fn deploy_output_validates() {
     assert_valid("deploy.schema.json", &out.to_json());
 }
 
+fn deploy_result_for_target(target: &str) -> serde_json::Value {
+    let environment = if target == "prod" { "prod" } else { "dev" };
+    DeployOutput {
+        plugin_name: "acme-bundle".to_string(),
+        label: "v1-test".to_string(),
+        env: environment.to_string(),
+        agent_name: format!("acme-{target}"),
+        agent_id: format!("agent-{target}"),
+        version_label: "v1-test".to_string(),
+        version_id: format!("version-{target}"),
+        channel: if target == "prod" {
+            "C0EXAMPLE1".to_string()
+        } else {
+            "C0EXAMPLE2".to_string()
+        },
+        bundle_ref: format!("bundles/{target}.tar.gz"),
+        bundle_sha256: format!("sha-{target}"),
+        bundle_size_bytes: if target == "prod" { 202 } else { 101 },
+        deployment_id: format!("deployment-{target}"),
+        deployment_environment: environment.to_string(),
+        deployment_status: "active".to_string(),
+    }
+    .to_json()
+}
+
+#[test]
+fn deploy_all_targets_success_output_validates() {
+    let value = serde_json::json!({
+        "results": [
+            {"target": "dev", "result": deploy_result_for_target("dev")},
+            {"target": "prod", "result": deploy_result_for_target("prod")}
+        ]
+    });
+    assert_valid("deploy.schema.json", &value);
+}
+
+#[test]
+fn deploy_all_targets_failure_outputs_validate() {
+    let first_failure = serde_json::json!({
+        "failed_target": "dev",
+        "stage": "deploy",
+        "completed": [],
+        "error": "creating the deployment failed with 500",
+        "fix": null
+    });
+    assert_valid("deploy.schema.json", &first_failure);
+
+    let later_failure = serde_json::json!({
+        "failed_target": "prod",
+        "stage": "deploy",
+        "completed": [
+            {"target": "dev", "result": deploy_result_for_target("dev")}
+        ],
+        "error": "creating the deployment failed with 500",
+        "fix": null
+    });
+    assert_valid("deploy.schema.json", &later_failure);
+
+    let connector_failure = serde_json::json!({
+        "failed_target": "dev",
+        "stage": "connector_sync",
+        "completed": [],
+        "failed_result": deploy_result_for_target("dev"),
+        "error": "connector sync failed",
+        "fix": null
+    });
+    assert_valid("deploy.schema.json", &connector_failure);
+}
+
 #[test]
 fn diff_output_validates() {
     let mut entries = curie::installation::diff_plan(

--- a/cli/tests/json_emit_contract.rs
+++ b/cli/tests/json_emit_contract.rs
@@ -12,7 +12,14 @@
 //! (comms/eval legitimately exit non-zero with a JSON *error* object); the bug
 //! under test is empty stdout, not a nonzero code.
 
-use std::process::Command;
+mod support;
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use support::{serve, Response};
 
 // The eval-concurrency forward-surface (#706): `EvalOpts` gains a
 // `pub concurrency: usize` field, and `eval_dry_run_lines` must emit one plan
@@ -1324,4 +1331,379 @@ fn init_output_next_shell_quotes_a_dir_with_a_space() {
         json!("cd 'my bundle' && curie skill up"),
         "a dir with a space must be shell-quoted in the next command: {out}"
     );
+}
+
+// `cluster deploy --all-targets --json` result and failure contracts (#1308).
+
+const DEPLOY_LABEL: &str = "v1-test";
+const DEPLOY_API_KEY: &str = "test-key";
+
+#[derive(Clone, Copy)]
+enum DeployFixtureFailure {
+    None,
+    Deploy(&'static str),
+}
+
+fn target_from_agent(agent: &str) -> &'static str {
+    if agent.contains("prod") {
+        "prod"
+    } else {
+        "dev"
+    }
+}
+
+fn target_config(target: &str) -> (&'static str, &'static str, &'static str) {
+    match target {
+        "dev" => ("acme-dev", "dev", "C0EXAMPLE2"),
+        "prod" => ("acme-prod", "prod", "C0EXAMPLE1"),
+        other => panic!("unexpected deploy target {other}"),
+    }
+}
+
+fn response_json(status: u16, value: serde_json::Value) -> Response {
+    Response::json(status, &value.to_string())
+}
+
+fn deploy_api_response(req: &support::Request, failure: DeployFixtureFailure) -> Response {
+    match (req.method.as_str(), req.path.as_str()) {
+        ("POST", "/deploy-targets/list") => response_json(
+            200,
+            json!({
+                "targets": [
+                    {"name": "dev", "agent": "acme-dev", "env": "dev", "slack_channel": "C0EXAMPLE2"},
+                    {"name": "prod", "agent": "acme-prod", "env": "prod", "slack_channel": "C0EXAMPLE1"}
+                ]
+            }),
+        ),
+        ("POST", "/deploy-targets/resolve") => {
+            let body: serde_json::Value =
+                serde_json::from_slice(&req.body).expect("target request body is JSON");
+            let target = body["target"].as_str().expect("target is a string");
+            let (agent, env, channel) = target_config(target);
+            response_json(
+                200,
+                json!({"agent": agent, "env": env, "slack_channel": channel}),
+            )
+        }
+        ("GET", "/agents") => Response::json(200, "[]"),
+        ("POST", "/agents") => {
+            let body: serde_json::Value =
+                serde_json::from_slice(&req.body).expect("agent request body is JSON");
+            let name = body["name"].as_str().expect("agent name is a string");
+            let channel = body["slack_channel"]
+                .as_str()
+                .expect("agent channel is a string");
+            let target = target_from_agent(name);
+            response_json(
+                201,
+                json!({
+                    "id": format!("agent-{target}"),
+                    "name": name,
+                    "slack_channel": channel
+                }),
+            )
+        }
+        ("POST", path) if path.starts_with("/agents/") && path.ends_with("/versions") => {
+            let agent_id = path
+                .trim_start_matches("/agents/")
+                .trim_end_matches("/versions")
+                .trim_end_matches('/');
+            let target = target_from_agent(agent_id);
+            response_json(
+                201,
+                json!({"id": format!("version-{target}"), "version_label": DEPLOY_LABEL}),
+            )
+        }
+        ("PUT", path) if path.contains("/versions/") && path.ends_with("/bundle") => {
+            let target = target_from_agent(path);
+            response_json(
+                201,
+                json!({
+                    "bundle_ref": format!("bundles/{target}.tar.gz"),
+                    "bundle_sha256": format!("sha-{target}"),
+                    "size_bytes": if target == "dev" { 101 } else { 202 }
+                }),
+            )
+        }
+        ("POST", "/deployments") => {
+            let body: serde_json::Value =
+                serde_json::from_slice(&req.body).expect("deployment request body is JSON");
+            let agent_id = body["agent_id"]
+                .as_str()
+                .expect("deployment agent is a string");
+            let target = target_from_agent(agent_id);
+            if matches!(failure, DeployFixtureFailure::Deploy(failed) if failed == target) {
+                return Response::json(500, &format!("deployment {target} exploded"));
+            }
+            response_json(
+                201,
+                json!({
+                    "id": format!("deployment-{target}"),
+                    "environment": target,
+                    "status": "active"
+                }),
+            )
+        }
+        ("GET", path) if path.contains("/versions/") && path.contains("/connectors?") => {
+            response_json(
+                200,
+                json!({
+                    "manifests": [],
+                    "owned_secret_name": "",
+                    "owned_secret_keys": [],
+                    "mcp_entries": {}
+                }),
+            )
+        }
+        (method, path) => Response::json(
+            500,
+            &format!("unexpected mock API request: {method} {path}"),
+        ),
+    }
+}
+
+fn write_kubectl_stub(dir: &Path) -> PathBuf {
+    let path = dir.join("kubectl");
+    fs::write(
+        &path,
+        r#"#!/bin/sh
+case "$*" in
+  *"get deployment"*)
+    if [ "${CURIE_TEST_CONNECTOR_FAILURE:-}" = 1 ]; then
+      printf '%s\n' 'connector sync exploded' >&2
+      exit 1
+    fi
+    printf '%s' 'curie'
+    ;;
+  *"delete deployment,service,networkpolicy,secret"*)
+    exit 0
+    ;;
+  *)
+    printf 'unexpected kubectl invocation: %s\n' "$*" >&2
+    exit 64
+    ;;
+esac
+"#,
+    )
+    .expect("write kubectl stub");
+    let mut permissions = fs::metadata(&path)
+        .expect("read kubectl stub metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&path, permissions).expect("make kubectl stub executable");
+    path
+}
+
+fn stub_path(bin_dir: &Path) -> std::ffi::OsString {
+    let mut paths = vec![bin_dir.to_path_buf()];
+    paths.extend(std::env::split_paths(
+        &std::env::var_os("PATH").unwrap_or_default(),
+    ));
+    std::env::join_paths(paths).expect("join stub PATH")
+}
+
+fn run_cluster_deploy_json(
+    all_targets: bool,
+    failure: DeployFixtureFailure,
+    connector_failure: bool,
+) -> Output {
+    let plugin = tempfile::tempdir().expect("plugin tempdir");
+    curie::scaffold::scaffold(plugin.path(), "acme-bundle").expect("scaffold test bundle");
+    fs::write(
+        plugin.path().join("deploy.yaml"),
+        "targets:\n  dev: { agent: acme-dev, env: dev, slack_channel: C0EXAMPLE2 }\n  prod: { agent: acme-prod, env: prod, slack_channel: C0EXAMPLE1 }\n",
+    )
+    .expect("write deploy targets");
+
+    let tools = tempfile::tempdir().expect("tool tempdir");
+    write_kubectl_stub(tools.path());
+    let server = serve(move |req| deploy_api_response(req, failure));
+
+    let mut command = Command::new(bin());
+    command.args([
+        "cluster",
+        "deploy",
+        "--plugin-dir",
+        plugin.path().to_str().expect("plugin path is valid UTF8"),
+        "--api-url",
+        &server.base_url,
+        "--api-key",
+        DEPLOY_API_KEY,
+        "--namespace",
+        "curie",
+        "--release",
+        "curie",
+        "--label",
+        DEPLOY_LABEL,
+    ]);
+    if all_targets {
+        command.arg("--all-targets");
+    } else {
+        command.args(["--target", "dev"]);
+    }
+    command
+        .arg("--json")
+        .env("PATH", stub_path(tools.path()))
+        .env_remove("CURIE_API_URL")
+        .env_remove("CURIE_API_KEY");
+    if connector_failure {
+        command.env("CURIE_TEST_CONNECTOR_FAILURE", "1");
+    } else {
+        command.env_remove("CURIE_TEST_CONNECTOR_FAILURE");
+    }
+    command.output().expect("run cluster deploy JSON contract")
+}
+
+fn one_stdout_object(output: &Output) -> serde_json::Value {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(!stdout.trim().is_empty(), "stdout must not be empty");
+    let mut values =
+        serde_json::Deserializer::from_slice(&output.stdout).into_iter::<serde_json::Value>();
+    let first = values
+        .next()
+        .unwrap_or_else(|| panic!("stdout must contain one JSON object: {stdout}"))
+        .unwrap_or_else(|error| panic!("stdout must start with JSON: {error}\n{stdout}"));
+    assert!(
+        first.is_object(),
+        "stdout must contain a JSON object: {stdout}"
+    );
+    assert!(
+        values.next().is_none(),
+        "stdout must contain exactly one JSON object: {stdout}"
+    );
+    first
+}
+
+fn expected_deploy(target: &str) -> serde_json::Value {
+    let (agent, environment, channel) = target_config(target);
+    json!({
+        "plugin": "acme-bundle",
+        "label": DEPLOY_LABEL,
+        "environment": environment,
+        "agent": {"name": agent, "id": format!("agent-{target}")},
+        "version": {"label": DEPLOY_LABEL, "id": format!("version-{target}")},
+        "channel": channel,
+        "bundle": {
+            "ref": format!("bundles/{target}.tar.gz"),
+            "sha256": format!("sha-{target}"),
+            "size_bytes": if target == "dev" { 101 } else { 202 }
+        },
+        "deployment": {
+            "id": format!("deployment-{target}"),
+            "environment": environment,
+            "status": "active"
+        }
+    })
+}
+
+fn assert_failure_keys(value: &serde_json::Value, includes_failed_result: bool) {
+    let object = value.as_object().expect("failure payload is an object");
+    let expected = if includes_failed_result { 6 } else { 5 };
+    assert_eq!(
+        object.len(),
+        expected,
+        "failure keys must stay exact: {value}"
+    );
+    for key in ["failed_target", "stage", "completed", "error", "fix"] {
+        assert!(
+            object.contains_key(key),
+            "failure is missing {key}: {value}"
+        );
+    }
+    assert_eq!(
+        object.contains_key("failed_result"),
+        includes_failed_result,
+        "failed_result presence must match the failure stage: {value}"
+    );
+    assert!(
+        value["fix"].is_null(),
+        "a permanent failure has no retry fix: {value}"
+    );
+}
+
+#[test]
+fn cluster_deploy_json_all_targets_emits_one_ordered_complete_object() {
+    let output = run_cluster_deploy_json(true, DeployFixtureFailure::None, false);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "all target deploy must succeed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        one_stdout_object(&output),
+        json!({
+            "results": [
+                {"target": "dev", "result": expected_deploy("dev")},
+                {"target": "prod", "result": expected_deploy("prod")}
+            ]
+        })
+    );
+}
+
+#[test]
+fn cluster_deploy_json_later_failure_names_target_and_completed_results() {
+    let output = run_cluster_deploy_json(true, DeployFixtureFailure::Deploy("prod"), false);
+    assert_eq!(output.status.code(), Some(1));
+    let value = one_stdout_object(&output);
+    assert_failure_keys(&value, false);
+    assert_eq!(value["failed_target"], json!("prod"));
+    assert_eq!(value["stage"], json!("deploy"));
+    assert_eq!(
+        value["completed"],
+        json!([{"target": "dev", "result": expected_deploy("dev")}])
+    );
+    assert!(
+        value["error"]
+            .as_str()
+            .is_some_and(|error| error.contains("deployment prod exploded")),
+        "failure must retain the API error: {value}"
+    );
+}
+
+#[test]
+fn cluster_deploy_json_first_failure_has_empty_completed_results() {
+    let output = run_cluster_deploy_json(true, DeployFixtureFailure::Deploy("dev"), false);
+    assert_eq!(output.status.code(), Some(1));
+    let value = one_stdout_object(&output);
+    assert_failure_keys(&value, false);
+    assert_eq!(value["failed_target"], json!("dev"));
+    assert_eq!(value["stage"], json!("deploy"));
+    assert_eq!(value["completed"], json!([]));
+    assert!(
+        value["error"]
+            .as_str()
+            .is_some_and(|error| error.contains("deployment dev exploded")),
+        "failure must retain the API error: {value}"
+    );
+}
+
+#[test]
+fn cluster_deploy_json_connector_sync_failure_carries_failed_result() {
+    let output = run_cluster_deploy_json(true, DeployFixtureFailure::None, true);
+    assert_eq!(output.status.code(), Some(1));
+    let value = one_stdout_object(&output);
+    assert_failure_keys(&value, true);
+    assert_eq!(value["failed_target"], json!("dev"));
+    assert_eq!(value["stage"], json!("connector_sync"));
+    assert_eq!(value["completed"], json!([]));
+    assert_eq!(value["failed_result"], expected_deploy("dev"));
+    assert!(
+        value["error"]
+            .as_str()
+            .is_some_and(|error| error.contains("connector sync exploded")),
+        "failure must retain the connector error: {value}"
+    );
+}
+
+#[test]
+fn cluster_deploy_json_single_target_shape_is_unchanged() {
+    let output = run_cluster_deploy_json(false, DeployFixtureFailure::None, false);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "single target deploy must succeed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(one_stdout_object(&output), expected_deploy("dev"));
 }

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -29,7 +29,7 @@ is documentation of where the code already draws the line, not a new abstraction
 | Memory | CLEAN | 1 loader (StateApiMemoryStore) | not separately graded | #28 | [Memory](interfaces/memory/INTERFACE.md) |
 | Conversation history | CLEAN | 1 loader (StateApiTranscriptStore) | not separately graded | #20 | [Conversation history](interfaces/conversation-history/INTERFACE.md) |
 | Triggers | SOFT | 3 hardcoded (Slack, GH push, commit poll) | not separately graded | #29 | [Triggers](interfaces/triggers/INTERFACE.md) |
-| CLI output (agent-facing `--json`) | CLEAN | 38 outputs behind one trait | not separately graded | #456 | [CLI output (agent-facing `--json`)](interfaces/cli-output/INTERFACE.md) |
+| CLI output (agent-facing `--json`) | CLEAN | 39 outputs behind one trait | not separately graded | #456 | [CLI output (agent-facing `--json`)](interfaces/cli-output/INTERFACE.md) |
 <!-- END GENERATED: seam-table -->
 
 ## Kind legend

--- a/docs/interfaces/cli-output/INTERFACE.md
+++ b/docs/interfaces/cli-output/INTERFACE.md
@@ -117,7 +117,7 @@ That set is not hand-maintained prose: `cli/schema/index.json` carries one
   longer schema-free: there are 39 committed schemas under `cli/schema/` with an
   index (`cli/schema/index.json`), a `syn`-based inventory gate over every `impl
   CliOutput`, and per-family output validation — all 39 are validated against real
-  `to_json()` output across 62 tests in `cli/tests/json_contract.rs`. Those tests
+  `to_json()` output across 64 tests in `cli/tests/json_contract.rs`. Those tests
   drive each output type's `to_json()` once per output variant rather than calling
   the pure builder functions behind it, so a variant whose `to_json()` arm drifts
   from the schema is caught even when the builder it delegates to still validates.

--- a/docs/interfaces/cli-output/INTERFACE.md
+++ b/docs/interfaces/cli-output/INTERFACE.md
@@ -1,7 +1,7 @@
 ---
 seam: CLI output (agent-facing `--json`)
 kind: CLEAN
-impls: 38 outputs behind one trait
+impls: 39 outputs behind one trait
 grade: not separately graded
 epics:
   - "#456"
@@ -13,7 +13,7 @@ order: 18
 > Part of the Curie swappable-seam catalog — see the [seam index](../../interfaces.md).
 
 <!-- BEGIN GENERATED: header (curie dev docs-lint) -->
-> **Kind:** CLEAN &nbsp;·&nbsp; **Implementations today:** 38 outputs behind one trait &nbsp;·&nbsp; **Swap-readiness grade:** not separately graded
+> **Kind:** CLEAN &nbsp;·&nbsp; **Implementations today:** 39 outputs behind one trait &nbsp;·&nbsp; **Swap-readiness grade:** not separately graded
 <!-- END GENERATED: header -->
 
 **Kind legend:** CLEAN = a real `Protocol`/typed port class · SOFT = swap via env/URL/prefix/wire, no code interface · NONE = not built yet.
@@ -65,7 +65,7 @@ This is the catalog's first **Rust** seam. It is listed here because the agent-f
 
 ## Implementations today
 
-38 `CliOutput` implementations, all in the CLI crate, grouped by owning module:
+39 `CliOutput` implementations, all in the CLI crate, grouped by owning module:
 
 - **`DryRunPlan`** (`cli/src/ui.rs`) — the generic `--dry-run` plan; JSON is
   `{"dry_run":true,"plan":[lines]}` and the human render is the same lines verbatim,


### PR DESCRIPTION
## Summary

* Returns one ordered JSON object with every completed deploy result.
* Preserves completed results, the failed target, and connector reconciliation context on partial failure.
* Keeps single target output unchanged and publishes deploy schema version 1.1.

Closes #1308

## Done check

[x] Failing binary and schema tests were committed before implementation.
[x] Product edits were delegated, with no broadened return type.
[x] Code and scope reviews approved the final branch with file evidence.
[x] Single target parity and all target secondary paths are covered.
[x] No guard or security surface changed.
[x] Consolidation was reviewed and preserved behavior.
[x] Binary review observed ordered success, first and later failures, connector failure, exit status, and unchanged single target output.
[x] `cargo fmt --check`, `cargo clippy -- -D warnings`, and `cargo test` pass.