### PR TITLE
Align ADR amendments and guided walkthrough

### DIFF
--- a/docs/adr/0085-acceptance-not-implementation-authorizes-an-adr.md
+++ b/docs/adr/0085-acceptance-not-implementation-authorizes-an-adr.md
@@ -4,6 +4,12 @@ Date: 2026-07-29
 
 Status: Accepted
 
+**Amended by [ADR-0102](0102-accepted-alongside-implementation-with-explicit-approval.md)**
+(back link added under [ADR-0045](0045-the-status-line-is-the-mutable-part-of-an-immutable-adr.md)):
+the third Decision clause is overtaken. An ADR may be Accepted alongside its
+implementation only with explicit maintainer approval and a named code path
+that realizes the decision. The remaining acceptance and history rules stand.
+
 **Amends [ADR 0045](0045-the-status-line-is-the-mutable-part-of-an-immutable-adr.md).**
 This ADR replaces only these two clauses in ADR 0045:
 

--- a/docs/adr/0101-schema-compatibility-for-closed-schemas.md
+++ b/docs/adr/0101-schema-compatibility-for-closed-schemas.md
@@ -4,6 +4,13 @@ Date: 2026-08-10
 
 Status: Accepted
 
+**Amended by [ADR-0103](0103-previous-schema-shape-gate.md)**
+(back link added under [ADR-0045](0045-the-status-line-is-the-mutable-part-of-an-immutable-adr.md)):
+the gate described in Decision section 4 is overtaken. The shipped gate uses a
+name based comparison of `properties` and `required` against the previous
+committed revision. Type changes, enum narrowings, and const flips are out of
+scope. The rest of this ADR stands.
+
 Implements [#1075](https://github.com/curie-eng/curie/issues/1075).
 
 **Amends ADR-0074** ("Versioned JSON Schemas for every agent-facing CLI result").

--- a/docs/adr/0102-accepted-alongside-implementation-with-explicit-approval.md
+++ b/docs/adr/0102-accepted-alongside-implementation-with-explicit-approval.md
@@ -1,0 +1,42 @@
+# 102. Accepted alongside implementation with explicit approval
+
+Date: 2026-08-11
+
+Status: Accepted
+
+**Amends [ADR-0085](0085-acceptance-not-implementation-authorizes-an-adr.md)**
+by replacing Decision clause 3. All other clauses and the history rules remain
+unchanged.
+
+## Context
+
+ADR 0085 correctly separates maintainer acceptance from implementation evidence.
+Its third clause is too strict for an explicitly approved change whose realizing
+code path is landing at the same time. This clause was violated for six
+consecutive review windows, and ADR 0101 landed Accepted in implementing commit `5d20f547`. A
+status transition gate was considered and rejected because the approval decision,
+not a doclint workflow, is the authority.
+
+## Decision
+
+An ADR may be published as Accepted alongside its implementation only when
+explicit maintainer approval is recorded and the ADR names the code path that
+realizes its decision. The implementation does not itself authorize acceptance.
+Without both approval and a named realizing code path, implementation must wait
+until acceptance.
+
+## Consequences
+
+Maintainers may accept and implement one decision in a coordinated change while
+keeping approval visible and auditable. The repository does not gain a status
+transition gate, and code evidence remains supporting evidence rather than
+authority.
+
+## Alternatives considered
+
+1. Require acceptance before every implementation. Rejected because it blocks a
+   coordinated, explicitly approved change.
+2. Gate status transitions with doclint. Rejected because a workflow cannot
+   replace explicit maintainer approval.
+3. Let implementation evidence authorize acceptance. Rejected because it
+   reverses the authority this amendment preserves.

--- a/docs/adr/0103-previous-schema-shape-gate.md
+++ b/docs/adr/0103-previous-schema-shape-gate.md
@@ -1,0 +1,40 @@
+# 103. Previous schema shape gate
+
+Date: 2026-08-11
+
+Status: Accepted
+
+**Amends [ADR-0101](0101-schema-compatibility-for-closed-schemas.md)**
+by replacing Decision section 4. All other sections remain unchanged.
+
+## Context
+
+ADR 0101 called for comparing a sample payload with the previous schema
+revision. Issues #1056, #1057, and #1306 were property additions. The shipped
+protection addresses that class directly through its realizing code path,
+`cli/tests/schema_inventory.rs`. Only 23 of 47 schema families have a sample,
+so a payload gate cannot be universal. Issue #1430 records executed evidence of
+what the gate catches and misses.
+
+## Decision
+
+The gate in `cli/tests/schema_inventory.rs` uses a name based comparison of
+`properties` and `required` against the previous committed revision. It fails
+for an unchanged identifier when either shape changes. Type changes, enum
+narrowings, and const flips are explicitly out of scope for this gate.
+
+## Consequences
+
+Property additions and required membership changes are caught across every
+schema family, including families without a sample payload. Payload comparison
+and broader semantic comparison are rejected or deferred because they require
+coverage and policy beyond this gate.
+
+## Alternatives considered
+
+1. Compare a sample payload against the previous revision. Rejected because
+   only some schema families have samples.
+2. Compare all semantic schema changes. Deferred because this amendment targets
+   the demonstrated property shape defect class.
+3. Leave the current schema only gate unchanged. Rejected because it cannot
+   detect an unchanged identifier with a changed previous shape.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -127,4 +127,6 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0097 | [One file declares an installation](0097-one-file-declares-an-installation.md) | Accepted |
 | 0098 | [Thinking depth is an operator knob, never a bundle one](0098-thinking-depth-is-an-operator-knob-never-a-bundle-one.md) | Accepted |
 | 0101 | [Closed schemas version on every change: minor for optional, major for required](0101-schema-compatibility-for-closed-schemas.md) | Accepted |
+| 0102 | [Accepted alongside implementation with explicit approval](0102-accepted-alongside-implementation-with-explicit-approval.md) | Accepted |
+| 0103 | [Previous schema shape gate](0103-previous-schema-shape-gate.md) | Accepted |
 <!-- END GENERATED: adr-index -->

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -79,6 +79,9 @@ Six commitments that should hold across every feature we build:
   human at a prompt. Commands are structured, non-interactive, idempotent, and
   self-describing, and the harness tells the agent exactly how to use it, so a
   coding agent can drive the whole loop and a human rarely needs to.
+  The guided walkthrough, invoked by `curie` with no arguments, is a committed
+  surface beside the agent facing CLI, so developer cold start work is on
+  strategy.
 
 ## What it could become
 


### PR DESCRIPTION
## Summary

* Adds Accepted ADR 0102 and a permitted back link from ADR 0085. This records the maintainer decision from 2026 08 11 that explicit approval may publish an ADR as Accepted alongside implementation when the ADR names the realizing code path. It aligns the rule with six review windows and ADR 0101 commit `5d20f547`. A status transition gate remains rejected.
* Adds Accepted ADR 0103 and a permitted back link from ADR 0101. This records the shipped name based comparison of `properties` and `required`, with type changes, enum narrowings, and const flips explicitly out of scope. It reflects the property addition failures in #1056, #1057, and #1306 plus the executed evidence and separate coverage work in #1430.
* Commits the guided walkthrough, invoked by `curie` with no arguments, as a vision surface beside the agent facing CLI.

The Accepted ADR bodies remain immutable. Each changed decision therefore uses a new amendment ADR plus the back link form authorized by ADR 0045.

## Done check

* [x] Affected documentation suite passed with `bash scripts/check-docs.sh`.
* [x] Documentation lint passed with `curie dev docs-lint`.