### PR TITLE
Require Helm CI before releases

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -5,11 +5,10 @@ name: Helm CI
 # job gives the chart the CI it otherwise lacks -- lint, render every shipped
 # values overlay, and schema-validate the rendered manifests.
 on:
+  # Push runs for every releasable commit because release authorization
+  # requires this check. Pull requests remain filtered to chart changes.
   push:
     branches: [main, next]
-    paths:
-      - "charts/curie/**"
-      - ".github/workflows/helm-ci.yaml"
   pull_request:
     branches: [main, next]
     paths:

--- a/charts/curie/ci/worker-ttl-bounds-assertions.sh
+++ b/charts/curie/ci/worker-ttl-bounds-assertions.sh
@@ -57,7 +57,7 @@
 # JSON-Schema validator, whose wording changed between the CI-pinned helm and
 # current helm while the pass/fail outcomes stayed identical:
 #
-#   helm 3.16.4 (the CI pin, .github/workflows/helm-ci.yaml:41):
+#   helm 3.16.4 (the CI pin, .github/workflows/helm-ci.yaml:40):
 #     - worker.routeTtlSeconds: Must be greater than 0
 #     - worker.routeTtlSeconds: Invalid type. Expected: integer, given: string
 #   helm 3.20.0:

--- a/release/authorize.py
+++ b/release/authorize.py
@@ -52,11 +52,13 @@ PASSING_CONCLUSIONS = {"success", "neutral", "skipped"}
 # dependency/secret scanners, release.yaml's own jobs) are deliberately
 # excluded -- they matter, but are not what this gate is asserting about
 # *this* commit's CI.
+# The chart check is included despite living in another workflow because it
+# validates the release chart itself.
 #
-# This list is a plain constant, not derived from ci.yaml at runtime -- the
-# simpler of the two options ADR-0058 left open (issue #733). A renamed or
-# removed ci.yaml job needs a matching edit here; there is no drift check
-# tying the two together yet.
+# This list is a plain constant, not derived from ci.yaml or helm-ci.yaml at
+# runtime. It is the simpler of the two options ADR-0058 left open (issue
+# #733). Tests pin its required names to jobs in both workflows, so a job
+# rename or removal requires a matching edit here.
 REQUIRED_CHECK_NAMES = frozenset(
     {
         "Python (ruff + mypy + pytest)",
@@ -74,6 +76,7 @@ REQUIRED_CHECK_NAMES = frozenset(
         "Eval falsifiability gate (fake model, offline)",
         "E2E parity ladder (skill + local, fake model)",
         "E2E parity ladder (local-release, fake model)",
+        "Chart (lint + template + kubeconform)",
     }
 )
 

--- a/release/tests/test_authorize.py
+++ b/release/tests/test_authorize.py
@@ -292,6 +292,24 @@ class TestRequiredCheckAllowlist:
         ):
             authorize_module.authorize(sha, runs, "main", cwd=git_repo)
 
+    def test_authorize_refuses_a_failed_chart_check_when_every_other_check_passes(
+        self, git_repo
+    ):
+        sha = run_git(git_repo, "rev-parse", "HEAD")
+        chart_check = "Chart (lint + template + kubeconform)"
+        runs = [
+            {
+                "name": name,
+                "conclusion": "failure" if name == chart_check else "success",
+            }
+            for name in authorize_module.REQUIRED_CHECK_NAMES
+        ]
+
+        with pytest.raises(
+            authorize_module.AuthorizationError, match=re.escape(chart_check)
+        ):
+            authorize_module.authorize(sha, runs, "main", cwd=git_repo)
+
 
 class TestFetchCheckRuns:
     """`gh api` must be pinned to GET (issue #732, defect 1).
@@ -739,6 +757,7 @@ class TestMainLookupFailures:
 
 
 CI_YAML = REPO_ROOT / ".github" / "workflows" / "ci.yaml"
+HELM_CI_YAML = REPO_ROOT / ".github" / "workflows" / "helm-ci.yaml"
 
 _MATRIX_REF = re.compile(r"\$\{\{\s*matrix\.([A-Za-z0-9_]+)\s*\}\}")
 
@@ -772,29 +791,51 @@ def ci_job_check_run_names() -> set[str]:
     return names
 
 
-class TestRequiredNamesMatchCiYaml:
-    """`REQUIRED_CHECK_NAMES` must not drift from ci.yaml's job names (#811).
+def helm_ci_job_check_run_names() -> set[str]:
+    doc = yaml.safe_load(HELM_CI_YAML.read_text())
+    return {job["name"] for job in doc["jobs"].values() if job.get("name")}
 
-    The gate is fail-closed: a required name that no ci.yaml job produces can
+
+class TestRequiredNamesMatchCiWorkflows:
+    """`REQUIRED_CHECK_NAMES` must not drift from CI workflow job names (#811).
+
+    The gate is fail-closed: a required name that no CI workflow job produces can
     never appear among a commit's real check-runs, so it is reported missing on
     every otherwise-legitimate commit and blocks the release. Conversely a
     stale name masks the loss of the check it was meant to assert. This pins the
-    constant as a subset of the concrete check-run names the current ci.yaml
-    actually emits, parsed live (never derived from the constant itself).
+    constant as a subset of the concrete check-run names the current CI workflows
+    actually emit, parsed live (never derived from the constant itself).
 
-    So renaming or splitting a required job in ci.yaml without updating
+    So renaming or splitting a required job in a CI workflow without updating
     `REQUIRED_CHECK_NAMES` fails here (with the drifted names listed), rather
     than silently dropping a release gate.
     """
 
-    def test_every_required_name_is_a_real_ci_yaml_check_run_name(self):
-        ci_names = ci_job_check_run_names()
+    def test_every_required_name_is_a_real_ci_workflow_check_run_name(self):
+        ci_names = ci_job_check_run_names() | helm_ci_job_check_run_names()
         stale = authorize_module.REQUIRED_CHECK_NAMES - ci_names
 
         assert authorize_module.REQUIRED_CHECK_NAMES <= ci_names, (
-            "REQUIRED_CHECK_NAMES has drifted from ci.yaml -- these required "
+            "REQUIRED_CHECK_NAMES has drifted from the CI workflows -- these required "
             f"names match no current job check-run: {sorted(stale)}"
         )
+
+
+class TestHelmCiWorkflowTriggers:
+    """Pin the deliberate push and pull request trigger asymmetry."""
+
+    def test_push_trigger_is_unfiltered_for_releasable_branches(self):
+        doc = yaml.safe_load(HELM_CI_YAML.read_text())
+        triggers = doc[True]
+
+        assert triggers["push"]["branches"] == ["main", "next"]
+        assert "paths" not in triggers["push"]
+        assert "paths-ignore" not in triggers["push"]
+        assert triggers["pull_request"]["branches"] == ["main", "next"]
+        assert triggers["pull_request"]["paths"] == [
+            "charts/curie/**",
+            ".github/workflows/helm-ci.yaml",
+        ]
 
 
 class TestMixedPassFailRequiredCheck:


### PR DESCRIPTION
Closes #1448

Requires the chart validation check before release authorization and runs Helm CI on every releasable branch push. Pull request filtering remains limited to chart changes.

Done check

* [x] Failing tests committed first: N/A for quick tier
* [x] Delegated production edits: N/A for quick tier
* [x] Broadened return types: N/A
* [x] Cross engine code review: approved with zero blocking findings
* [x] Cross engine scope review: all hunks justified
* [x] Sibling parity: workflow producer and release consumer changed together
* [x] Guard demonstration: both source and workflow reversions make their regressions fail
* [x] Consolidation: N/A for quick tier; final review approved the finding fixes
* [x] Security review: N/A
* [x] Runtime E2E: N/A
* [x] Full affected tests: 48 passed
* [x] Lint: Python, workflow, and shell syntax checks passed