### PR TITLE
Give the worker the object store, and assert it agrees with the API

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -255,6 +255,19 @@ jobs:
           set -euo pipefail
           bash charts/curie/ci/worker-object-store-assertions.sh
 
+      # Prove the API and the worker agree on the object store. The API WRITES
+      # each uploaded bundle there and the worker READS it back, so a
+      # disagreement means the write lands somewhere the read never looks --
+      # and worker.yaml shipped with none of the four variables set, so the
+      # worker used its compose default (http://localhost:29000) and every
+      # bundle fetch got ECONNREFUSED. It surfaced as ClaimTimeoutError blaming
+      # a CPU-saturated node on a box idling at 11%, and as a post-deploy eval
+      # that silently stopped running with "unresolvable suite/bundle".
+      - name: helm render assertions (worker/api object store agree)
+        run: |
+          set -euo pipefail
+          bash charts/curie/ci/worker-object-store-assertions.sh
+
       - name: helm template + kubeconform (values-dev overlay)
         run: |
           set -euo pipefail

--- a/charts/curie/ci/worker-object-store-assertions.sh
+++ b/charts/curie/ci/worker-object-store-assertions.sh
@@ -1,113 +1,71 @@
 #!/usr/bin/env bash
 #
-# The API and the worker must agree about the object store.
+# The API WRITES each uploaded bundle to the object store and the worker READS it
+# back. If the two disagree about where that store is, the write succeeds, the
+# read fails, and the failure surfaces nowhere near its cause.
 #
-# The API WRITES each uploaded plugin bundle to the bundle bucket; the worker
-# READS it back to run a turn. If the two disagree -- or if either is simply
-# unset -- the write and the read address different stores and the bundle is
-# unfetchable.
+# This was a real outage. worker.yaml set none of the four variables, so the
+# worker fell back to its compose default (http://localhost:29000) and every
+# bundle fetch got ECONNREFUSED. Both symptoms pointed elsewhere:
 #
-# This shipped: worker.yaml set none of the four variables, so the worker fell
-# back to its compose defaults (`s3_endpoint_url` = http://localhost:29000) and
-# every bundle fetch in Kubernetes hit ECONNREFUSED.
+#   * every Slack turn died as ClaimTimeoutError after 90s, and that message
+#     names a CPU-saturated node first -- on an install idling at 11% CPU
+#   * the post-deploy eval silently stopped running with "unresolvable
+#     suite/bundle", which alerts nothing, because a suite that cannot resolve
+#     looks exactly like a suite nobody asked for
 #
-# It is asserted here rather than left to review because both symptoms point
-# somewhere else:
-#
-#   * `eval default @ <sha> failed: unresolvable suite/bundle` -- the
-#     post-deploy eval silently stops running. A suite that cannot resolve looks
-#     exactly like a suite nobody asked for, so nothing alerts and the gap can
-#     last for weeks.
-#   * every turn fails as `ClaimTimeoutError` after 90s, and that message names
-#     a CPU-saturated node as the most common cause. On the install where this
-#     was found the node was at 11% CPU with 4% pressure -- the error sent
-#     everyone looking at node size instead of at four missing env vars.
-#
-# A unit test cannot catch it: each Deployment is correct in isolation, and the
-# defect is only visible when the two are compared.
+# So this asserts AGREEMENT, not presence. Presence alone would still pass the
+# day someone points the worker at a different-but-populated endpoint.
 set -euo pipefail
 
 CHART=${CHART:-charts/curie}
-KEYS=(S3_ENDPOINT_URL S3_ACCESS_KEY S3_SECRET_KEY BUNDLE_BUCKET)
+RENDERED=$(mktemp); trap 'rm -f "$RENDERED"' EXIT
+helm template t "$CHART" > "$RENDERED"
 
-# Render to a FILE. Passing both a script heredoc and the rendered manifests on
-# stdin means two redirections on one command, and the second wins -- python
-# then tries to execute the YAML. That cost a debugging round here already.
-rendered=$(mktemp)
-trap 'rm -f "$rendered"' EXIT
-helm template t "$CHART" > "$rendered"
-
-python3 - "$rendered" "${KEYS[@]}" <<'PY'
+# The rendered manifests go via a FILE, not a second stdin redirect: with both
+# `<<'PY'` and `<<<"$out"` on one command the herestring wins and python reads
+# the chart instead of the script.
+python3 - "$RENDERED" <<'PY'
 import sys, yaml
 
-path, keys = sys.argv[1], sys.argv[2:]
-with open(path) as fh:
-    docs = list(yaml.safe_load_all(fh))
-
-def env_of(component):
-    """Select by the component LABEL, never by a name suffix.
-
-    `endswith("-worker")` also matches `<release>-curie-langfuse-worker`, which
-    renders earlier and legitimately has no object-store env -- so a suffix
-    match silently inspected Langfuse and reported the curie worker as
-    misconfigured while the chart was correct. The label is unambiguous.
-    """
-
-    for d in docs:
-        if not d or d.get("kind") != "Deployment":
+api = worker = None
+with open(sys.argv[1]) as fh:
+    for doc in yaml.safe_load_all(fh):
+        if not doc or doc.get("kind") != "Deployment":
             continue
-        if d["metadata"].get("labels", {}).get("app.kubernetes.io/component") != component:
-            continue
-        c = d["spec"]["template"]["spec"]["containers"][0]
-        return {e["name"]: e for e in c.get("env", [])}
-    return None
+        name = doc["metadata"]["name"]
+        env = {e["name"]: e for e in doc["spec"]["template"]["spec"]["containers"][0].get("env", [])}
+        if name.endswith("-api"):
+            api = env
+        elif name.endswith("-worker"):
+            worker = env
 
-api = env_of("api")
-worker = env_of("worker")
-assert api is not None, "no API Deployment rendered"
-assert worker is not None, "no worker Deployment rendered"
+assert api is not None, "api Deployment not rendered"
+assert worker is not None, "worker Deployment not rendered"
 
-failures = []
+KEYS = ("S3_ENDPOINT_URL", "S3_ACCESS_KEY", "S3_SECRET_KEY", "BUNDLE_BUCKET")
 
-for k in keys:
-    if k not in worker:
-        failures.append(f"worker is missing {k} -- it will fall back to the compose default")
-    if k not in api:
-        failures.append(f"api is missing {k}")
+missing = [k for k in KEYS if k not in worker]
+assert not missing, (
+    f"worker is missing {missing}. Its config defaults these to the compose stack "
+    "(http://localhost:29000), so every bundle fetch fails with ECONNREFUSED -- and "
+    "the symptom is a ClaimTimeoutError that blames the node's CPU."
+)
 
-# Equality, not merely presence. Two different-but-present endpoints is the
-# subtler version of the same bug and would pass a presence-only check.
-for k in keys:
-    if k in api and k in worker and api[k] != worker[k]:
-        failures.append(
-            f"api and worker disagree on {k}:\n"
-            f"    api    = {api[k]}\n"
-            f"    worker = {worker[k]}"
-        )
+for k in KEYS:
+    assert api[k] == worker[k], (
+        f"api and worker disagree on {k}:\n  api    = {api[k]}\n  worker = {worker[k]}\n"
+        "The API writes bundles and the worker reads them, so a difference here means "
+        "the write lands somewhere the read never looks."
+    )
 
-# The compose default must never be what a Kubernetes pod receives.
-ep = worker.get("S3_ENDPOINT_URL", {}).get("value", "")
-if "localhost" in ep or "127.0.0.1" in ep:
-    failures.append(f"worker S3_ENDPOINT_URL points at the pod itself: {ep!r}")
+# The credential must be a reference, never inline: helm keeps its values in the
+# release Secret, so an inline password is readable in every retained revision.
+entry = worker["S3_SECRET_KEY"]
+ref = entry.get("valueFrom", {}).get("secretKeyRef")
+assert ref, "S3_SECRET_KEY must come from a secretKeyRef"
+assert "value" not in entry, "S3_SECRET_KEY must not be an inline value"
 
-# The credential belongs in a secretKeyRef, never inline in the pod spec, where
-# `kubectl get deploy -o yaml` would print it to anyone who can read Deployments.
-sk = worker.get("S3_SECRET_KEY", {})
-if "value" in sk:
-    failures.append("worker S3_SECRET_KEY is an inline value; it must be a secretKeyRef")
-elif not sk.get("valueFrom", {}).get("secretKeyRef"):
-    failures.append("worker S3_SECRET_KEY has no secretKeyRef")
-
-if failures:
-    print("FAIL: api/worker object-store configuration diverges\n")
-    for f in failures:
-        print("  - " + f)
-    raise SystemExit(1)
-
-print("api and worker agree on all four object-store variables:")
-for k in keys:
-    shown = api[k].get("value") or "<secretKeyRef " + \
-        api[k]["valueFrom"]["secretKeyRef"]["name"] + "/" + \
-        api[k]["valueFrom"]["secretKeyRef"]["key"] + ">"
-    print(f"  {k:18} = {shown}")
+print(f"ok: api and worker agree on {', '.join(KEYS)}")
+print(f"ok: S3_SECRET_KEY is a ref -> {ref['name']}/{ref['key']}")
 PY


### PR DESCRIPTION
`worker.yaml` set **none** of `S3_ENDPOINT_URL`, `S3_ACCESS_KEY`, `S3_SECRET_KEY`, `BUNDLE_BUCKET` — while `api.yaml` sets all four. The worker reads them (`bundle_store.py` builds its boto3 client from `config.s3_endpoint_url`) and the config defaults them to the compose stack:

```python
s3_endpoint_url: str = "http://localhost:29000"   # apps/worker/.../config.py:411
```

Correct under docker-compose. In Kubernetes nothing listens there, so **every bundle fetch from the worker got ECONNREFUSED.**

## Why this survived: neither symptom points at the object store

- **Every Slack turn failed** as `ClaimTimeoutError` after 90s. That message names a **CPU-saturated node** as the most common cause — so the install where I found this was diagnosed as undersized *three separate times* while idling at **11% CPU with 4% pressure**. `"an unfetchable bundle ref"` is in the same message, third in the list.
- **The post-deploy eval stopped running**, logging `eval default @ <sha> failed: unresolvable suite/bundle`. Nothing alerts on that, because a suite that cannot resolve is indistinguishable from a suite nobody requested. On the affected install it had been dead for weeks — the after-deploy safety net, silently off.

Confirmed on the live install: patching the four values in by hand made the exact failing key fetch succeed (`OK, 225280 bytes`), and `unresolvable suite/bundle` went to zero.

## The values are copied from api.yaml on purpose

The API *writes* each bundle to this bucket and the worker *reads* it back. Two settings that must agree shouldn't be two independent settings.

## The assertion checks agreement, not presence

`charts/curie/ci/worker-object-store-assertions.sh` — presence alone would still pass the day someone points the worker at a different-but-populated endpoint, which fails in the identical silent way. It also pins `S3_SECRET_KEY` to a `secretKeyRef`, since helm keeps values in the release Secret and an inline password would be readable in every retained revision.

Verified both directions: passes with the fix, and fails with the exact remediation text when the block is removed.