### PR TITLE
Release 0.7.0-rc.4

### DIFF
--- a/charts/curie/Chart.yaml
+++ b/charts/curie/Chart.yaml
@@ -8,8 +8,8 @@ description: >-
   and two install-time preflights ship baked in: a CPU-AVX / ClickHouse-pin
   check and a NetworkPolicy-enforcement probe.
 type: application
-version: 0.7.0-rc.3
-appVersion: "0.7.0-rc.3"
+version: 0.7.0-rc.4
+appVersion: "0.7.0-rc.4"
 kubeVersion: ">=1.25.0-0"
 maintainers:
   - name: Curie

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -749,7 +749,7 @@ dependencies = [
 
 [[package]]
 name = "curie"
-version = "0.7.0-rc.3"
+version = "0.7.0-rc.4"
 dependencies = [
  "anstream",
  "anstyle",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "curie"
-version = "0.7.0-rc.3"
+version = "0.7.0-rc.4"
 edition = "2021"
 description = "Curie CLI: init/start/send/eval a plugin against a local runner (task I1)"
 


### PR DESCRIPTION
Cuts an RC that carries the worker object-store fix (#1468). **Nothing released does.**

| | |
|---|---|
| v0.7.0-rc.3 published | 2026-08-11T18:24Z |
| #1468 merged | 2026-08-12T18:43Z |

Confirmed by **content**, not timestamp — `S3_ENDPOINT_URL` in `worker.yaml`: **1** on `main`, **0** at `v0.7.0-rc.3`.

## Why this isn't cosmetic

On a 0.6.0 install the worker falls back to its compose default (`http://localhost:29000`) for the bundle store. So:

- every bundle fetch is refused
- every Slack turn dies as `ClaimTimeoutError` — an error whose text blames a **CPU-saturated node**, on a box measured at 11% CPU
- the post-deploy eval stops running with `unresolvable suite/bundle`, alerting nobody, because a suite that can't resolve looks like a suite nobody asked for

The affected install is currently holding the four variables in place **by hand**, and `curie cluster up` there installs the version-pinned 0.6.0 chart, which silently drops them again. An RC is the only way to end that drift.

## The change

Same three files and one string as every prior RC: `Chart.yaml` (`version`, `appVersion`), `cli/Cargo.toml`, and the single `curie` entry in `cli/Cargo.lock`.

The lockfile edit matches on the `[[package]]` block rather than replacing the version string globally, and asserts exactly one substitution — so another crate pinned to the same version can't be bumped by accident.

Verified in-tree: `charts/curie/ci/worker-object-store-assertions.sh` passes, so the RC contains the fix *and* the assertion that keeps it.