### PR TITLE
Restore sealed connector refusal

### DIFF
--- a/packages/plugin-format/src/plugin_format/connectors.py
+++ b/packages/plugin-format/src/plugin_format/connectors.py
@@ -130,11 +130,8 @@ class ConnectorSpec(BaseModel):
     # it is unaffected, which is what lets this land as a backward-compatible
     # change to a frozen contract.
     #
-    # The worker's reconciler decrypts these with the cluster's sealing key and
-    # writes the plaintext into the agent's own Secret. A blob it cannot open
-    # SKIPS that agent and leaves the running connector alone -- deploying it
-    # without the credential would produce a pod that passes its health check
-    # and 401s every call, the #1156 shape ADR-0094 exists to avoid.
+    # Validation refuses this field until a production decrypt path exists.
+    # This prevents a connector from deploying without the credential it needs.
     sealed_secrets: dict[str, str] = Field(default_factory=dict)
 
     #   secret_files:                         Project a stored secret as a FILE
@@ -424,6 +421,15 @@ def validate_connectors(data: Any) -> tuple[ConnectorsFile | None, list[tuple[st
                         "the credential it needs.",
                     )
                 )
+        if spec.sealed_secrets:
+            errors.append(
+                (
+                    "connectors.sealed_secrets_unsupported",
+                    f"{where}: `sealed_secrets` is declared but nothing decrypts it yet. "
+                    "Refusing rather than deploying without its credential. "
+                    "Use `secrets:` until then.",
+                )
+            )
         seen_secret_names: set[str] = set()
         for secret_name in spec.secret_names():
             if secret_name in seen_secret_names:

--- a/packages/plugin-format/tests/test_connector_render.py
+++ b/packages/plugin-format/tests/test_connector_render.py
@@ -398,20 +398,16 @@ def test_sealed_secret_names_join_the_other_forms() -> None:
     assert spec.resolved_secrets() == ["PLAIN"]
 
 
-def test_a_declared_sealed_secret_is_accepted_now_that_decryption_exists() -> None:
-    """The refusal was a placeholder while nothing could decrypt.
-
-    It was deliberately strict: accepting the field early would have deployed a
-    connector with no credential -- a pod that starts, passes its health check,
-    and 401s every call. The worker decrypts now, so the field is real.
-    """
-
+def test_a_declared_sealed_secret_is_refused_until_decryption_exists() -> None:
     parsed, errors = validate_connectors(
         {"connectors": {"grafana": {"image": "x", "sealed_secrets": {"TOKEN": "AgB"}}}}
     )
-    assert [code for code, _ in errors] == []
-    assert parsed is not None
-    assert parsed.connectors["grafana"].sealed_secrets == {"TOKEN": "AgB"}
+    assert "connectors.sealed_secrets_unsupported" in [code for code, _ in errors]
+    assert parsed is None
+    diagnostic = next(
+        message for code, message in errors if code == "connectors.sealed_secrets_unsupported"
+    )
+    assert "secrets:" in diagnostic
 
 
 def test_an_empty_sealed_blob_is_reported_on_its_own() -> None:


### PR DESCRIPTION
## Summary

Restore the `sealed_secrets` validation refusal until a production decrypt path exists. `main` is the target because this v0.6.1 correctness fix affects both release lines.

Refusal is the narrower correct choice because #1434 separately owns worker decrypt wiring, and the current worker and CLI deployment paths have no production decrypt caller. This matches ADR 0094 by failing loudly before a new bundle can deploy a connector without its credential. The specific alternative ADR 0094 rejects is allowing a healthy looking connector that fails every authenticated call.

Existing stored versions can still encounter the preexisting consumer behavior that turns later validation failure into empty desired state. This PR does not widen into API or reconciler scope, and the limitation is called out for review.

## Done check

* [x] The regression test was committed and observed failing before production code.
* [x] Production edits were performed in a separate fresh context.
* [x] No return type changed.
* [x] Independent code, scope, and security reviews completed.
* [x] Every diff hunk maps to the refusal restoration or its regression proof.
* [x] The common validation boundary covers new bundle ingestion. #1434 remains the separate decrypt path issue.
* [x] Executed violating input returned `parsed: False`, `connectors.sealed_secrets_unsupported`, and actionable `secrets:` guidance.
* [x] Consolidation was skipped because this is the exact two file guard restoration with no reusable abstraction.
* [x] Affected package tests passed: 433 passed.
* [x] Ruff passed for `packages/` and mypy passed for 178 source files.

Closes #1356