### PR TITLE
Preserve stateful removal causes during apply

### DIFF
--- a/cli/src/installation.rs
+++ b/cli/src/installation.rs
@@ -807,8 +807,8 @@ enum GuardVerdict {
     /// Nothing the release runs would be deleted by this apply.
     Clear,
     /// This apply would delete stateful component(s), carrying the operator
-    /// facing refusal text.
-    WouldRemove(String),
+    /// facing causes.
+    WouldRemove(Vec<crate::ops::StatefulRemoval>),
 }
 
 /// Decide whether an apply would delete a stateful component the release runs.
@@ -839,9 +839,7 @@ async fn guard_stateful_removal(up: &crate::ops::UpOpts) -> Result<GuardVerdict>
     if removed.is_empty() {
         return Ok(GuardVerdict::Clear);
     }
-    Ok(GuardVerdict::WouldRemove(stateful_removal_message(
-        &removed,
-    )))
+    Ok(GuardVerdict::WouldRemove(removed))
 }
 
 /// The refusal text, factored out so its ordering is testable with no cluster.
@@ -900,12 +898,20 @@ fn stateful_removal_message(removed: &[crate::ops::StatefulRemoval]) -> String {
         .iter()
         .any(|r| r.cause == RemovalCause::ComponentGone)
     {
-        msg.push_str(
-            "Component(s) the chart does not render at all usually mean a chart version \
-             renamed or removed them. Re-run with --migrate-store and apply will carry \
-             the data across itself: it stages every object, upgrades, loads them back, \
-             and verifies per object.\n\n",
-        );
+        if renamed.is_empty() {
+            msg.push_str(
+                "Component(s) the chart does not render at all usually mean a chart version \
+                 renamed or removed them. Re-run with --migrate-store and apply will carry \
+                 the data across itself: it stages every object, upgrades, loads them back, \
+                 and verifies per object.\n\n",
+            );
+        } else {
+            msg.push_str(
+                "After fixing the renames, re-run with --migrate-store and apply will carry \
+                 the data across itself: it stages every object, upgrades, loads them back, \
+                 and verifies per object.\n\n",
+            );
+        }
     }
 
     msg.push_str("Use --allow-stateful-removal only to proceed WITHOUT the data.");
@@ -983,8 +989,17 @@ pub async fn apply(opts: ApplyOpts) -> Result<ApplyOutput> {
     } else {
         match guard_stateful_removal(&up).await? {
             GuardVerdict::Clear => false,
-            GuardVerdict::WouldRemove(_) if migrate_store => true,
-            GuardVerdict::WouldRemove(msg) => bail!("{msg}"),
+            GuardVerdict::WouldRemove(removed)
+                if migrate_store
+                    && removed.iter().all(|removal| {
+                        matches!(&removal.cause, crate::ops::RemovalCause::ComponentGone)
+                    }) =>
+            {
+                true
+            }
+            GuardVerdict::WouldRemove(removed) => {
+                bail!("{}", stateful_removal_message(&removed))
+            }
         }
     };
 
@@ -1570,13 +1585,16 @@ mod stateful_guard_message_tests {
                 cause: crate::ops::RemovalCause::RenamedTo("acme-bot-curie-postgres".to_string()),
             },
         ]);
-        assert!(msg.contains("nameOverride"), "{msg}");
-        assert!(msg.contains("--migrate-store"), "{msg}");
+        let rename = msg.find("nameOverride").unwrap();
+        let migrate = msg.find("--migrate-store").unwrap();
         let discard = msg.find("--allow-stateful-removal").unwrap();
         assert!(
-            msg.find("--migrate-store").unwrap() < discard
-                && msg.find("nameOverride").unwrap() < discard,
-            "the data-preserving remedies must still come before the discard flag:\n{msg}"
+            rename < migrate && migrate < discard,
+            "the rename fix must come before migration, and both must come before the discard flag:\n{msg}"
+        );
+        assert!(
+            msg.contains("After fixing the renames, re-run with --migrate-store"),
+            "the migration guidance must make the rename prerequisite explicit:\n{msg}"
         );
     }
 }

--- a/cli/tests/installation_plan_parity.rs
+++ b/cli/tests/installation_plan_parity.rs
@@ -103,6 +103,46 @@ if [ "$1" = get ] && [ "$2" = values ]; then
     exit 0
 fi
 if [ "$1" = template ]; then
+    if [ "${CURIE_TEST_HELM_MIXED_STATEFULSETS:-}" = 1 ]; then
+        cat <<'YAML'
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: parity-rustfs
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: rustfs
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: parity-curie-postgres
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: postgres
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: parity-curie-valkey
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: valkey
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: parity-curie-clickhouse
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: clickhouse
+YAML
+        exit 0
+    fi
     cat <<'YAML'
 apiVersion: apps/v1
 kind: StatefulSet
@@ -245,6 +285,7 @@ exit 0
             .env_remove("CURIE_TEST_KUBECTL_STS")
             .env_remove("CURIE_TEST_KUBECTL_FAIL")
             .env_remove("CURIE_TEST_KUBECTL_FORBIDDEN")
+            .env_remove("CURIE_TEST_HELM_MIXED_STATEFULSETS")
             .env_remove("CURIE_MODEL")
             .env_remove("CURIE_TEST_PROVIDER_EGRESS_JSON")
             .env_remove("CURIE_APPLY_TEST_MODEL_KEY")
@@ -460,6 +501,32 @@ fn live_minio_statefulset() -> String {
             "metadata": {"name": "parity-minio"},
             "spec": {"selector": {"matchLabels": {"app.kubernetes.io/component": "minio"}}}
         }]
+    })
+    .to_string()
+}
+
+fn live_mixed_store_statefulsets() -> String {
+    json!({
+        "apiVersion": "v1",
+        "kind": "List",
+        "items": [
+            {
+                "metadata": {"name": "parity-minio"},
+                "spec": {"selector": {"matchLabels": {"app.kubernetes.io/component": "minio"}}}
+            },
+            {
+                "metadata": {"name": "parity-postgres"},
+                "spec": {"selector": {"matchLabels": {"app.kubernetes.io/component": "postgres"}}}
+            },
+            {
+                "metadata": {"name": "parity-valkey"},
+                "spec": {"selector": {"matchLabels": {"app.kubernetes.io/component": "valkey"}}}
+            },
+            {
+                "metadata": {"name": "parity-clickhouse"},
+                "spec": {"selector": {"matchLabels": {"app.kubernetes.io/component": "clickhouse"}}}
+            }
+        ]
     })
     .to_string()
 }
@@ -717,6 +784,42 @@ fn migrate_store_alone_still_migrates() {
     assert!(
         calls.contains("KUBECTL_CALL: delete pod"),
         "a verified migration releases the staging pod:\n{calls}"
+    );
+}
+
+#[test]
+fn migrate_store_refuses_a_mixed_removed_and_renamed_batch() {
+    let fixture = HelmFixture::new(installation_for_the_stateful_guard(), None);
+    let live_statefulsets = live_mixed_store_statefulsets();
+
+    let output = fixture.apply(
+        &["--migrate-store"],
+        &[
+            ("CURIE_TEST_HELM_MIXED_STATEFULSETS", "1"),
+            ("CURIE_TEST_KUBECTL_STS", &live_statefulsets),
+        ],
+    );
+
+    let calls = fixture.calls();
+    let error = json_error(output, "apply --migrate-store");
+    let message = error["error"].as_str().expect("apply error message string");
+    assert!(
+        message.contains("nameOverride"),
+        "a renamed StatefulSet must direct the operator to nameOverride:\n{message}"
+    );
+    assert!(
+        message.contains("parity-minio")
+            && message.contains("parity-postgres")
+            && message.contains("parity-curie-postgres"),
+        "the refusal must include the removed store and renamed StatefulSet:\n{message}"
+    );
+    assert!(
+        !calls.contains("KUBECTL_CALL: run "),
+        "a mixed batch must stop before the migration export:\n{calls}"
+    );
+    assert!(
+        !calls.contains("HELM_CALL: upgrade"),
+        "a mixed batch must stop before the upgrade:\n{calls}"
     );
 }
 


### PR DESCRIPTION
Closes #1427

Targets main because this v0.6.1 fix applies to the stable and future release lines.

Carries structured removal causes into apply control flow. A mixed ComponentGone and RenamedTo batch now refuses before migration export or Helm upgrade, while an all ComponentGone batch can still use `--migrate-store`.

Done check

1. [x] Regression test failed before implementation with exit 101 and passed after.
2. [x] Independent code review approved the final diff.
3. [x] Independent scope review mapped every hunk and found no passengers.
4. [x] The sole verdict consumer handles the structured cause type.
5. [x] The mixed batch guard rejection was demonstrated through the real apply process test.
6. [x] `cargo test` passed for the complete CLI suite.
7. [x] `cargo fmt --check` and `cargo clippy -- -D warnings` passed.