### PR TITLE
Derive external S3 endpoint scheme

### DIFF
--- a/charts/curie/ci/worker-object-store-assertions.sh
+++ b/charts/curie/ci/worker-object-store-assertions.sh
@@ -19,53 +19,115 @@
 set -euo pipefail
 
 CHART=${CHART:-charts/curie}
-RENDERED=$(mktemp); trap 'rm -f "$RENDERED"' EXIT
-helm template t "$CHART" > "$RENDERED"
+DEFAULT_RENDERED=$(mktemp)
+EXTERNAL_RENDERED=$(mktemp)
+EXTERNAL_VALUES=$(mktemp)
+trap 'rm -f "$DEFAULT_RENDERED" "$EXTERNAL_RENDERED" "$EXTERNAL_VALUES"' EXIT
+
+cat > "$EXTERNAL_VALUES" <<'EOF'
+rustfs:
+  deploy: false
+  host: s3.example.com
+  port: 443
+EOF
+
+helm template curie "$CHART" --namespace dev > "$DEFAULT_RENDERED"
+helm template curie "$CHART" --namespace dev \
+  --values "$EXTERNAL_VALUES" > "$EXTERNAL_RENDERED"
 
 # The rendered manifests go via a FILE, not a second stdin redirect: with both
 # `<<'PY'` and `<<<"$out"` on one command the herestring wins and python reads
 # the chart instead of the script.
-python3 - "$RENDERED" <<'PY'
+python3 - \
+  "$DEFAULT_RENDERED" "default" "http://curie-rustfs:9000" \
+  "$EXTERNAL_RENDERED" "external" "https://s3.example.com:443" <<'PY'
 import sys, yaml
-
-api = worker = None
-with open(sys.argv[1]) as fh:
-    for doc in yaml.safe_load_all(fh):
-        if not doc or doc.get("kind") != "Deployment":
-            continue
-        name = doc["metadata"]["name"]
-        env = {e["name"]: e for e in doc["spec"]["template"]["spec"]["containers"][0].get("env", [])}
-        if name.endswith("-api"):
-            api = env
-        elif name.endswith("-worker"):
-            worker = env
-
-assert api is not None, "api Deployment not rendered"
-assert worker is not None, "worker Deployment not rendered"
 
 KEYS = ("S3_ENDPOINT_URL", "S3_ACCESS_KEY", "S3_SECRET_KEY", "BUNDLE_BUCKET")
 
-missing = [k for k in KEYS if k not in worker]
-assert not missing, (
-    f"worker is missing {missing}. Its config defaults these to the compose stack "
-    "(http://localhost:29000), so every bundle fetch fails with ECONNREFUSED -- and "
-    "the symptom is a ClaimTimeoutError that blames the node's CPU."
-)
 
-for k in KEYS:
-    assert api[k] == worker[k], (
-        f"api and worker disagree on {k}:\n  api    = {api[k]}\n  worker = {worker[k]}\n"
-        "The API writes bundles and the worker reads them, so a difference here means "
-        "the write lands somewhere the read never looks."
+def env_for(container):
+    return {entry["name"]: entry for entry in container.get("env", [])}
+
+
+def object_store_envs(path):
+    api = worker = bundle_fetch = None
+    with open(path) as fh:
+        for doc in yaml.safe_load_all(fh):
+            if not doc:
+                continue
+            if doc.get("kind") == "Deployment":
+                name = doc["metadata"]["name"]
+                containers = doc["spec"]["template"]["spec"].get("containers", [])
+                assert containers, f"{name} Deployment has no containers"
+                if name.endswith("-api"):
+                    api = env_for(containers[0])
+                elif name.endswith("-worker"):
+                    worker = env_for(containers[0])
+            elif doc.get("kind") == "SandboxTemplate":
+                pod_spec = doc["spec"]["podTemplate"]["spec"]
+                matches = [
+                    container
+                    for container in pod_spec.get("initContainers", [])
+                    if container.get("name") == "bundle-fetch"
+                ]
+                assert len(matches) == 1, (
+                    "SandboxTemplate must render exactly one bundle-fetch init container"
+                )
+                bundle_fetch = env_for(matches[0])
+
+    assert api is not None, "api Deployment not rendered"
+    assert worker is not None, "worker Deployment not rendered"
+    assert bundle_fetch is not None, "SandboxTemplate bundle-fetch not rendered"
+    return api, worker, bundle_fetch
+
+
+def assert_contract(path, label, expected_endpoint):
+    api, worker, bundle_fetch = object_store_envs(path)
+
+    for service, env in (("api", api), ("worker", worker)):
+        missing = [key for key in KEYS if key not in env]
+        if service == "worker":
+            assert not missing, (
+                f"worker is missing {missing}. Its config defaults these to the compose stack "
+                "(http://localhost:29000), so every bundle fetch fails with ECONNREFUSED -- and "
+                "the symptom is a ClaimTimeoutError that blames the node's CPU."
+            )
+        else:
+            assert not missing, f"{service} is missing object-store keys: {missing}"
+
+    for key in KEYS:
+        assert api[key] == worker[key], (
+            f"api and worker disagree on {key}:\n  api    = {api[key]}\n  worker = {worker[key]}\n"
+            "The API writes bundles and the worker reads them, so a difference here means "
+            "the write lands somewhere the read never looks."
+        )
+
+    assert api["S3_ENDPOINT_URL"].get("value") == expected_endpoint, (
+        f"{label} API endpoint must be {expected_endpoint}, got {api['S3_ENDPOINT_URL']}"
+    )
+    assert worker["S3_ENDPOINT_URL"].get("value") == expected_endpoint, (
+        f"{label} worker endpoint must be {expected_endpoint}, got {worker['S3_ENDPOINT_URL']}"
+    )
+    assert bundle_fetch.get("S3_ENDPOINT", {}).get("value") == expected_endpoint, (
+        f"{label} bundle-fetch endpoint must be {expected_endpoint}, "
+        f"got {bundle_fetch.get('S3_ENDPOINT')}"
     )
 
-# The credential must be a reference, never inline: helm keeps its values in the
-# release Secret, so an inline password is readable in every retained revision.
-entry = worker["S3_SECRET_KEY"]
-ref = entry.get("valueFrom", {}).get("secretKeyRef")
-assert ref, "S3_SECRET_KEY must come from a secretKeyRef"
-assert "value" not in entry, "S3_SECRET_KEY must not be an inline value"
+    # The credential must be a reference, never inline: helm keeps its values in the
+    # release Secret, so an inline password is readable in every retained revision.
+    entry = worker["S3_SECRET_KEY"]
+    ref = entry.get("valueFrom", {}).get("secretKeyRef")
+    assert ref, "S3_SECRET_KEY must come from a secretKeyRef"
+    assert "value" not in entry, "S3_SECRET_KEY must not be an inline value"
 
-print(f"ok: api and worker agree on {', '.join(KEYS)}")
-print(f"ok: S3_SECRET_KEY is a ref -> {ref['name']}/{ref['key']}")
+    print(f"ok: {label}: api and worker agree on {', '.join(KEYS)}")
+    print(f"ok: {label}: all S3 endpoints are {expected_endpoint}")
+    print(f"ok: {label}: S3_SECRET_KEY is a ref -> {ref['name']}/{ref['key']}")
+
+
+arguments = sys.argv[1:]
+assert len(arguments) % 3 == 0, "expected path, label, endpoint triples"
+for index in range(0, len(arguments), 3):
+    assert_contract(*arguments[index:index + 3])
 PY

--- a/charts/curie/templates/_helpers.tpl
+++ b/charts/curie/templates/_helpers.tpl
@@ -101,6 +101,18 @@ ANTHROPIC_BASE_URL ANTHROPIC_API_KEY CLAUDE_CODE_OAUTH_TOKEN ANTHROPIC_AUTH_TOKE
 {{- end -}}
 {{- end -}}
 
+{{- define "curie.rustfs.scheme" -}}
+{{- if and (not .Values.rustfs.deploy) (eq (printf "%v" .Values.rustfs.port) "443") -}}
+https
+{{- else -}}
+http
+{{- end -}}
+{{- end -}}
+
+{{- define "curie.rustfs.endpoint" -}}
+{{- include "curie.rustfs.scheme" . }}://{{ include "curie.rustfs.host" . }}:{{ .Values.rustfs.port }}
+{{- end -}}
+
 {{- define "curie.langfuse.webHost" -}}
 {{- printf "%s-langfuse-web" (include "curie.fullname" .) -}}
 {{- end -}}

--- a/charts/curie/templates/agent-sandbox.yaml
+++ b/charts/curie/templates/agent-sandbox.yaml
@@ -288,7 +288,7 @@ spec:
             - name: CURIE_BUNDLE_REF
               value: ""
             - name: S3_ENDPOINT
-              value: http://{{ include "curie.rustfs.host" . }}:{{ .Values.rustfs.port }}
+              value: {{ include "curie.rustfs.endpoint" . }}
             - name: S3_ACCESS_KEY
               value: {{ .Values.rustfs.auth.accessKey | quote }}
             - name: S3_SECRET_KEY

--- a/charts/curie/templates/api.yaml
+++ b/charts/curie/templates/api.yaml
@@ -129,7 +129,7 @@ spec:
                   name: {{ .Values.langfuse.existingSecret | default (include "curie.secretName" .) }}
                   key: langfuseInitProjectSecretKey
             - name: S3_ENDPOINT_URL
-              value: http://{{ include "curie.rustfs.host" . }}:{{ .Values.rustfs.port }}
+              value: {{ include "curie.rustfs.endpoint" . }}
             - name: S3_ACCESS_KEY
               value: {{ .Values.rustfs.auth.accessKey | quote }}
             - name: S3_SECRET_KEY

--- a/charts/curie/templates/worker.yaml
+++ b/charts/curie/templates/worker.yaml
@@ -242,7 +242,7 @@ spec:
             # bundle to this bucket and the worker READS it back, so they have to
             # agree. ci/worker-object-store-assertions.sh asserts they do.
             - name: S3_ENDPOINT_URL
-              value: http://{{ include "curie.rustfs.host" . }}:{{ .Values.rustfs.port }}
+              value: {{ include "curie.rustfs.endpoint" . }}
             - name: S3_ACCESS_KEY
               value: {{ .Values.rustfs.auth.accessKey | quote }}
             - name: S3_SECRET_KEY

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -392,6 +392,7 @@ rustfs:
   deploy: true
   image: rustfs/rustfs:1.0.0-beta.12
   awsCliImage: amazon/aws-cli:2.32.6
+  # For the API, worker, and sandbox bundle fetch endpoints, an external RustFS on port 443 uses HTTPS. All other configurations use HTTP.
   host: ""
   port: 9000
   consolePort: 9001


### PR DESCRIPTION
Closes #1447

Targets `main` because this is a shared v0.6.1 fix, not behavior unique to unreleased v0.7 work.

Derives one RustFS endpoint and uses it for the API, worker, and sandbox bundle fetcher. External port 443 renders HTTPS while the deployed RustFS default remains HTTP. The render assertion covers both a YAML external values file and the in cluster default.

Langfuse endpoint builders remain outside the three templates explicitly scoped by this issue.

Done check

* [x] The failing render assertion was committed before implementation and reproduced `http://s3.example.com:443`; pipeline commits were squashed after verification.
* [x] Delegated native workers made all production and test edits.
* [x] No public return type changed.
* [x] Independent code review approved with file and line evidence.
* [x] Independent scope review approved every hunk and confirmed issue #1452 was not absorbed.
* [x] API, worker, and sandbox parity is routed through one shared endpoint helper.
* [x] No guard, security surface, or schema changed.
* [x] Consolidation completed, focused checks stayed green, and independent consolidation review approved.
* [x] Live chart verification passed once with successful bundle fetch and runner execution. Two later scratch cluster retries fetched and extracted the bundle but hit the known runner state timeout.
* [x] `bash charts/curie/ci/worker-object-store-assertions.sh` passes.
* [x] `helm lint charts/curie` passes with zero failures.
* [x] `helm template curie charts/curie -f charts/curie/values-dev.yaml` renders 44 documents.
