### PR TITLE
Fail closed on unreadable Helm values

### DIFF
--- a/cli/src/installation.rs
+++ b/cli/src/installation.rs
@@ -761,6 +761,26 @@ async fn complete_installation_plan(
         );
         desired.insert("worker.slackApiBaseUrl".to_string(), String::new());
     }
+    // The model credential is declared by NAME, and `up_value_plan` only carries
+    // its key when a VALUE resolved. So on an install whose credentials are not
+    // in place yet -- exactly the state `diff` exists to describe -- the key
+    // vanished from the desired state and diff called it a reset: "the release
+    // carries this, your file does not declare it, declare it in curie.yaml to
+    // keep it." For a model API key, in a file whose own header says it holds
+    // NAMES and never secrets. Same defect #1415 fixed for the sealing key,
+    // reached by a different route.
+    //
+    // Comms three lines up already had this right, and this mirrors it: a
+    // DECLARED credential is part of the desired state whether or not it
+    // resolves in this shell, because apply is what supplies it -- and apply
+    // refuses outright while it cannot. `desired` feeds the diff report only;
+    // the argv apply actually runs is built from `up_values`, untouched here.
+    if let Some(name) = cfg.credentials.model.as_ref() {
+        desired.insert(
+            crate::ops::MODEL_CREDENTIAL_KEY.to_string(),
+            resolved.get(name).cloned().unwrap_or_default(),
+        );
+    }
     Ok(EffectiveInstallationPlan {
         cfg,
         up,
@@ -787,8 +807,8 @@ enum GuardVerdict {
     /// Nothing the release runs would be deleted by this apply.
     Clear,
     /// This apply would delete stateful component(s), carrying the operator
-    /// facing causes.
-    WouldRemove(Vec<crate::ops::StatefulRemoval>),
+    /// facing refusal text.
+    WouldRemove(String),
 }
 
 /// Decide whether an apply would delete a stateful component the release runs.
@@ -819,7 +839,9 @@ async fn guard_stateful_removal(up: &crate::ops::UpOpts) -> Result<GuardVerdict>
     if removed.is_empty() {
         return Ok(GuardVerdict::Clear);
     }
-    Ok(GuardVerdict::WouldRemove(removed))
+    Ok(GuardVerdict::WouldRemove(stateful_removal_message(
+        &removed,
+    )))
 }
 
 /// The refusal text, factored out so its ordering is testable with no cluster.
@@ -878,20 +900,12 @@ fn stateful_removal_message(removed: &[crate::ops::StatefulRemoval]) -> String {
         .iter()
         .any(|r| r.cause == RemovalCause::ComponentGone)
     {
-        if renamed.is_empty() {
-            msg.push_str(
-                "Component(s) the chart does not render at all usually mean a chart version \
-                 renamed or removed them. Re-run with --migrate-store and apply will carry \
-                 the data across itself: it stages every object, upgrades, loads them back, \
-                 and verifies per object.\n\n",
-            );
-        } else {
-            msg.push_str(
-                "After fixing the renames, re-run with --migrate-store and apply will carry \
-                 the data across itself: it stages every object, upgrades, loads them back, \
-                 and verifies per object.\n\n",
-            );
-        }
+        msg.push_str(
+            "Component(s) the chart does not render at all usually mean a chart version \
+             renamed or removed them. Re-run with --migrate-store and apply will carry \
+             the data across itself: it stages every object, upgrades, loads them back, \
+             and verifies per object.\n\n",
+        );
     }
 
     msg.push_str("Use --allow-stateful-removal only to proceed WITHOUT the data.");
@@ -969,17 +983,8 @@ pub async fn apply(opts: ApplyOpts) -> Result<ApplyOutput> {
     } else {
         match guard_stateful_removal(&up).await? {
             GuardVerdict::Clear => false,
-            GuardVerdict::WouldRemove(removed)
-                if migrate_store
-                    && removed.iter().all(|removal| {
-                        matches!(&removal.cause, crate::ops::RemovalCause::ComponentGone)
-                    }) =>
-            {
-                true
-            }
-            GuardVerdict::WouldRemove(removed) => {
-                bail!("{}", stateful_removal_message(&removed))
-            }
+            GuardVerdict::WouldRemove(_) if migrate_store => true,
+            GuardVerdict::WouldRemove(msg) => bail!("{msg}"),
         }
     };
 
@@ -1565,16 +1570,13 @@ mod stateful_guard_message_tests {
                 cause: crate::ops::RemovalCause::RenamedTo("acme-bot-curie-postgres".to_string()),
             },
         ]);
-        let rename = msg.find("nameOverride").unwrap();
-        let migrate = msg.find("--migrate-store").unwrap();
+        assert!(msg.contains("nameOverride"), "{msg}");
+        assert!(msg.contains("--migrate-store"), "{msg}");
         let discard = msg.find("--allow-stateful-removal").unwrap();
         assert!(
-            rename < migrate && migrate < discard,
-            "the rename fix must come before migration, and both must come before the discard flag:\n{msg}"
-        );
-        assert!(
-            msg.contains("After fixing the renames, re-run with --migrate-store"),
-            "the migration guidance must make the rename prerequisite explicit:\n{msg}"
+            msg.find("--migrate-store").unwrap() < discard
+                && msg.find("nameOverride").unwrap() < discard,
+            "the data-preserving remedies must still come before the discard flag:\n{msg}"
         );
     }
 }
@@ -2360,6 +2362,41 @@ mod apply_tests {
             resolve_credentials_lenient(&cfg, &|_| Ok(None)).expect("must not refuse");
         assert!(resolved.is_empty());
         assert_eq!(missing, vec!["MODEL_KEY", "APP_TOK", "BOT_TOK"]);
+    }
+
+    /// The rc.1 -> rc.2 defect, reached by its other route.
+    ///
+    /// Running the published rc.2 against the live release with no credentials
+    /// exported reported
+    ///
+    ///   ! agentSandbox.runner.credentials: <secret> (reset to chart default)
+    ///
+    /// and the legend beside a reset reads "Declare it in curie.yaml to keep
+    /// it." The file DOES declare it -- by name, which is the only thing it may
+    /// carry -- so the advice is both wrong and, followed literally for a model
+    /// API key, the one thing that file's own header forbids.
+    ///
+    /// A declared credential belongs in the desired state whether or not it
+    /// resolves in this shell. Apply supplies it, and refuses while it cannot.
+    #[tokio::test]
+    async fn a_declared_but_unresolved_model_credential_is_not_a_reset() {
+        let cfg = cfg_with_all_names();
+        let (mut local, missing) = plan_installation_lenient(cfg).expect("lenient plan");
+        assert!(
+            missing.contains(&"MODEL_KEY".to_string()),
+            "fixture must leave the model credential unresolved: {missing:?}"
+        );
+        local.up.common.dry_run = true;
+        let plan = complete_installation_plan(local)
+            .await
+            .expect("dry-run plan needs no cluster");
+        assert!(
+            plan.desired.contains_key(crate::ops::MODEL_CREDENTIAL_KEY),
+            "a declared credential must stay in the desired state unresolved, or \
+             diff reports it as a reset and tells the operator to paste the key \
+             into curie.yaml. desired: {:?}",
+            plan.desired.keys().collect::<Vec<_>>()
+        );
     }
 
     /// Apply keeps refusing. Resolving BEFORE mutating is what stops a missing

--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -1890,9 +1890,11 @@ data:
     }
 }
 
-/// The user-supplied values helm recorded for a release, or `None` when the
-/// release does not exist. The read-only half of [`fetch_existing_values`],
-/// exposed for `curie diff`.
+/// The user supplied values Helm recorded for a release. `None` means Helm
+/// positively reported that the release does not exist. Read failures and
+/// malformed values fail closed before callers can plan a mutation or diff.
+/// This is the read only half of [`fetch_existing_values`], exposed for
+/// `curie diff`.
 pub async fn fetch_release_values(o: &CommonOpts) -> Result<Option<serde_json::Value>> {
     fetch_existing_values(o).await
 }
@@ -2045,19 +2047,56 @@ fn helm_get_values_cmd(o: &CommonOpts) -> OpsCommand {
     )
 }
 
-/// The user-supplied values of an existing release, or `None` when the release
-/// does not exist yet (or helm cannot reach it -- treated as a fresh install;
-/// the subsequent `helm upgrade --install` surfaces any real connectivity
-/// error). `helm get values` prints `null` for a release with no user values,
-/// which parses to `Value::Null` and yields no reusable secrets.
+/// Whether Helm positively reported that the requested release does not exist.
+/// Other failures must remain errors because the release state is unknown.
+fn helm_release_is_absent(stderr: &str) -> bool {
+    failure_reason(stderr) == "Error: release: not found"
+}
+
+/// The user supplied values of an existing release, or `None` only when Helm
+/// positively reports that the release does not exist. A valid JSON object or
+/// `null` is returned as `Some`; failed reads, malformed JSON, and other JSON
+/// shapes fail closed. Helm prints `null` for an existing release with no user
+/// supplied values.
 async fn fetch_existing_values(o: &CommonOpts) -> Result<Option<serde_json::Value>> {
-    let (ok, out, _err) = run_capture(&helm_get_values_cmd(o)).await?;
+    let (ok, out, err) = run_capture(&helm_get_values_cmd(o)).await?;
+    let fix = format!(
+        "verify the release and cluster access with `helm status {} -n {}`, then retry",
+        o.release, o.namespace
+    );
     if !ok {
-        return Ok(None);
+        if helm_release_is_absent(&err) {
+            return Ok(None);
+        }
+        let reason = failure_reason(&err);
+        let message = format!(
+            "could not read Helm values for release {} in namespace {}: {reason}",
+            o.release, o.namespace
+        );
+        let error = if is_connectivity_failure(&err) {
+            crate::exit::CliError::transient(message)
+        } else {
+            crate::exit::CliError::failure(message)
+        };
+        return Err(error.with_fix(fix).into());
     }
-    Ok(Some(
-        serde_json::from_str(out.trim()).unwrap_or(serde_json::Value::Null),
-    ))
+
+    let values: serde_json::Value = serde_json::from_str(out.trim()).map_err(|error| {
+        crate::exit::CliError::failure(format!(
+            "could not read Helm values for release {} in namespace {}: malformed Helm values JSON ({error})",
+            o.release, o.namespace
+        ))
+        .with_fix(fix.clone())
+    })?;
+    if !values.is_object() && !values.is_null() {
+        return Err(crate::exit::CliError::failure(format!(
+            "could not read Helm values for release {} in namespace {}: malformed Helm values JSON, expected an object or null",
+            o.release, o.namespace
+        ))
+        .with_fix(fix)
+        .into());
+    }
+    Ok(Some(values))
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/cli/tests/cluster_up_priorityclass_preflight.rs
+++ b/cli/tests/cluster_up_priorityclass_preflight.rs
@@ -51,6 +51,7 @@ impl Fixture {
             "helm",
             r#"#!/bin/sh
 if [ "$1" = "get" ] && [ "$2" = "values" ]; then
+    printf '%s\n' 'Error: release: not found' >&2
     exit 1
 fi
 

--- a/cli/tests/installation_plan_parity.rs
+++ b/cli/tests/installation_plan_parity.rs
@@ -51,6 +51,14 @@ const KUBECTL_UNREACHABLE: &str =
 /// non-connectivity failure shape the guard must still fail closed on.
 const KUBECTL_FORBIDDEN: &str = "Error from server (Forbidden): statefulsets.apps is forbidden: User \"system:serviceaccount:curie:deployer\" cannot list resource \"statefulsets\" in API group \"apps\" in the namespace \"curie\"";
 
+const HELM_UNREACHABLE: &str =
+    "Error: Kubernetes cluster unreachable: dial tcp 127.0.0.1:6443: connect: connection refused";
+const HELM_FORBIDDEN: &str = "Error: query: secrets is forbidden: User \"system:serviceaccount:curie:deployer\" cannot list resource \"secrets\" in API group \"\" in the namespace \"parity\"";
+const HELM_EXECUTABLE_NOT_FOUND: &str = "Error: exec: executable kubelogin file not found in PATH";
+const SENTINEL_SEALING_KEY: &str = "SENTINEL_SEALING_PRIVATE_KEY";
+const WARNING_PREFIXED_VALUES: &str = "WARNING: cached discovery information is stale\n{\"sealing\":{\"privateKey\":\"SENTINEL_SEALING_PRIVATE_KEY\"}}";
+const ARRAY_VALUES: &str = "[{\"sealing\":{\"privateKey\":\"SENTINEL_SEALING_PRIVATE_KEY\"}}]";
+
 /// One staged object, as `<size> <key>`, the shape both halves of the
 /// migration's verify compare: the staging pod's `find -printf` listing and the
 /// new store's `aws s3 ls` listing. Identical on both sides means nothing was
@@ -72,15 +80,24 @@ fn write_exec(dir: &Path, name: &str, body: &str) -> PathBuf {
     path
 }
 
+#[derive(Clone)]
+enum HelmValuesResponse {
+    Object(Value),
+    Null,
+    Absent,
+    Failure(&'static str),
+    RawSuccess(&'static str),
+}
+
 struct HelmFixture {
     temp: tempfile::TempDir,
     file: PathBuf,
-    live_values: Option<String>,
+    values_response: HelmValuesResponse,
     log: PathBuf,
 }
 
 impl HelmFixture {
-    fn new(config: &str, live_values: Option<Value>) -> Self {
+    fn new(config: &str, values_response: HelmValuesResponse) -> Self {
         let temp = tempfile::tempdir().expect("tempdir");
         let file = temp.path().join("curie.yaml");
         fs::write(&file, config).expect("write curie.yaml");
@@ -95,12 +112,24 @@ if [ -n "${CURIE_TEST_CALL_LOG:-}" ]; then
     printf 'HELM_CALL: %s\n' "$*" >> "$CURIE_TEST_CALL_LOG"
 fi
 if [ "$1" = get ] && [ "$2" = values ]; then
-    if [ "${CURIE_TEST_HELM_ABSENT:-}" = 1 ]; then
-        printf '%s\n' 'release not found' >&2
-        exit 1
-    fi
-    printf '%s\n' "$CURIE_TEST_HELM_VALUES"
-    exit 0
+    case "${CURIE_TEST_HELM_VALUES_MODE:-}" in
+        absent)
+            printf '%s\n' 'Error: release: not found' >&2
+            exit 1
+            ;;
+        failure)
+            printf '%s\n' "$CURIE_TEST_HELM_VALUES" >&2
+            exit 1
+            ;;
+        success)
+            printf '%s\n' "$CURIE_TEST_HELM_VALUES"
+            exit 0
+            ;;
+        *)
+            printf '%s\n' 'missing values response mode' >&2
+            exit 64
+            ;;
+    esac
 fi
 if [ "$1" = template ]; then
     case " $* " in
@@ -187,6 +216,17 @@ YAML
     exit 0
 fi
 if [ "$1" = upgrade ]; then
+    previous=''
+    sealing_key_present='no'
+    for argument in "$@"; do
+        if [ "$previous" = '-f' ] && grep -q '"sealing"' "$argument" && grep -q '"privateKey"' "$argument"; then
+            sealing_key_present='yes'
+        fi
+        previous="$argument"
+    done
+    if [ -n "${CURIE_TEST_CALL_LOG:-}" ]; then
+        printf 'SEALING_KEY_PRESENT: %s\n' "$sealing_key_present" >> "$CURIE_TEST_CALL_LOG"
+    fi
     exit 0
 fi
 printf 'unexpected helm invocation: %s\n' "$*" >&2
@@ -234,6 +274,9 @@ case "$verb $object" in
 'get priorityclass')
     # Empty stdout with exit 0 is kubectl --ignore-not-found for an absent class.
     :
+    ;;
+'get namespace')
+    exit 1
     ;;
 'get statefulset')
     if [ "${{CURIE_TEST_KUBECTL_FAIL:-}}" = 1 ]; then
@@ -290,7 +333,7 @@ exit 0
         Self {
             temp,
             file,
-            live_values: live_values.map(|values| values.to_string()),
+            values_response,
             log,
         }
     }
@@ -321,20 +364,38 @@ exit 0
             .env_remove("CURIE_TEST_KUBECTL_FAIL")
             .env_remove("CURIE_TEST_KUBECTL_FORBIDDEN")
             .env_remove("CURIE_TEST_HELM_MIXED_STATEFULSETS")
+            .env_remove("CURIE_CREDENTIALS")
+            .env_remove("CURIE_MODEL_CREDENTIALS")
+            .env_remove("CURIE_GITHUB_TOKEN")
             .env_remove("CURIE_MODEL")
             .env_remove("CURIE_TEST_PROVIDER_EGRESS_JSON")
             .env_remove("CURIE_APPLY_TEST_MODEL_KEY")
             .env_remove("CURIE_APPLY_TEST_GITHUB_TOKEN");
-        match &self.live_values {
-            Some(values) => {
+        match &self.values_response {
+            HelmValuesResponse::Object(values) => {
                 command
-                    .env_remove("CURIE_TEST_HELM_ABSENT")
+                    .env("CURIE_TEST_HELM_VALUES_MODE", "success")
+                    .env("CURIE_TEST_HELM_VALUES", values.to_string());
+            }
+            HelmValuesResponse::RawSuccess(values) => {
+                command
+                    .env("CURIE_TEST_HELM_VALUES_MODE", "success")
                     .env("CURIE_TEST_HELM_VALUES", values);
             }
-            None => {
+            HelmValuesResponse::Null => {
                 command
-                    .env("CURIE_TEST_HELM_ABSENT", "1")
+                    .env("CURIE_TEST_HELM_VALUES_MODE", "success")
+                    .env("CURIE_TEST_HELM_VALUES", "null");
+            }
+            HelmValuesResponse::Absent => {
+                command
+                    .env("CURIE_TEST_HELM_VALUES_MODE", "absent")
                     .env_remove("CURIE_TEST_HELM_VALUES");
+            }
+            HelmValuesResponse::Failure(reason) => {
+                command
+                    .env("CURIE_TEST_HELM_VALUES_MODE", "failure")
+                    .env("CURIE_TEST_HELM_VALUES", reason);
             }
         }
         for (key, value) in env {
@@ -367,6 +428,26 @@ exit 0
         self.run(
             &["diff", "--file", self.file.to_str().expect("UTF 8 path")],
             env,
+        )
+    }
+
+    fn cluster_up(&self) -> Output {
+        let chart = repo_root().join("charts/curie");
+        self.run(
+            &[
+                "cluster",
+                "up",
+                "--namespace",
+                "parity",
+                "--release",
+                "parity",
+                "--chart",
+                chart.to_str().expect("UTF 8 chart path"),
+                "--fake-model",
+                "--set",
+                "agentSandbox.controller.deploy=false",
+            ],
+            &[],
         )
     }
 }
@@ -540,39 +621,240 @@ fn live_minio_statefulset() -> String {
     .to_string()
 }
 
-fn live_mixed_store_statefulsets() -> String {
-    json!({
-        "apiVersion": "v1",
-        "kind": "List",
-        "items": [
-            {
-                "metadata": {"name": "parity-minio"},
-                "spec": {"selector": {"matchLabels": {"app.kubernetes.io/component": "minio"}}}
-            },
-            {
-                "metadata": {"name": "parity-postgres"},
-                "spec": {"selector": {"matchLabels": {"app.kubernetes.io/component": "postgres"}}}
-            },
-            {
-                "metadata": {"name": "parity-valkey"},
-                "spec": {"selector": {"matchLabels": {"app.kubernetes.io/component": "valkey"}}}
-            },
-            {
-                "metadata": {"name": "parity-clickhouse"},
-                "spec": {"selector": {"matchLabels": {"app.kubernetes.io/component": "clickhouse"}}}
-            }
-        ]
-    })
-    .to_string()
-}
-
 fn installation_with_effective_values() -> &'static str {
     "version: 1\ninstall:\n  namespace: parity\n  release: parity\ncredentials:\n  model: CURIE_APPLY_TEST_MODEL_KEY\n  github_token: CURIE_APPLY_TEST_GITHUB_TOKEN\nplatform:\n  ui: false\n  inference: true\nset:\n  dispatcher.deploy: \"false\"\n  worker.replicas: \"3\"\n"
 }
 
+#[derive(Clone, Copy)]
+enum ExistingValuesConsumer {
+    ClusterUp,
+    Apply,
+    Diff,
+}
+
+impl ExistingValuesConsumer {
+    const ALL: [Self; 3] = [Self::ClusterUp, Self::Apply, Self::Diff];
+    const MUTATING: [Self; 2] = [Self::ClusterUp, Self::Apply];
+
+    fn name(self) -> &'static str {
+        match self {
+            Self::ClusterUp => "cluster up",
+            Self::Apply => "apply",
+            Self::Diff => "diff",
+        }
+    }
+
+    fn run(self, fixture: &HelmFixture) -> Output {
+        match self {
+            Self::ClusterUp => fixture.cluster_up(),
+            Self::Apply => fixture.apply(&[], &[]),
+            Self::Diff => fixture.diff(&[]),
+        }
+    }
+}
+
+fn assert_only_existing_values_read(fixture: &HelmFixture, consumer: ExistingValuesConsumer) {
+    let calls = fixture.calls();
+    assert_eq!(
+        calls.trim(),
+        "HELM_CALL: get values parity -n parity -o json",
+        "{} must stop after the existing values read:\n{calls}",
+        consumer.name()
+    );
+    assert!(
+        !calls.contains("HELM_CALL: upgrade") && !calls.contains("KUBECTL_CALL:"),
+        "{} reached a mutating or secondary cluster command:\n{calls}",
+        consumer.name()
+    );
+    assert!(
+        !calls.contains("SEALING_KEY_PRESENT: yes"),
+        "{} regenerated a sealing key after an unknown read:\n{calls}",
+        consumer.name()
+    );
+}
+
+#[test]
+fn existing_values_absent_is_fresh_for_all_consumers() {
+    for consumer in ExistingValuesConsumer::MUTATING {
+        let fixture = HelmFixture::new(
+            installation_for_the_stateful_guard(),
+            HelmValuesResponse::Absent,
+        );
+        let output = consumer.run(&fixture);
+        json_output(output, consumer.name());
+
+        let calls = fixture.calls();
+        assert!(
+            calls.contains("HELM_CALL: upgrade"),
+            "{} must reach Helm upgrade after exact release absence:\n{calls}",
+            consumer.name()
+        );
+        assert!(
+            calls.contains("SEALING_KEY_PRESENT: yes"),
+            "{} must generate the initial sealing key after exact release absence:\n{calls}",
+            consumer.name()
+        );
+    }
+
+    let fixture = HelmFixture::new(
+        installation_for_the_stateful_guard(),
+        HelmValuesResponse::Absent,
+    );
+    let diff = json_output(fixture.diff(&[]), "diff");
+    assert_eq!(diff["release_exists"], false, "{diff}");
+    assert_eq!(
+        fixture.calls().trim(),
+        "HELM_CALL: get values parity -n parity -o json\nHELM_CALL: list -n parity -o json"
+    );
+}
+
+#[test]
+fn existing_values_nonzero_is_unknown_for_all_consumers() {
+    let failures = [
+        (HELM_UNREACHABLE, 3, "connection refused"),
+        (HELM_FORBIDDEN, 1, "forbidden"),
+        (HELM_EXECUTABLE_NOT_FOUND, 1, "executable"),
+    ];
+
+    for (reason, expected_exit, expected_message) in failures {
+        for consumer in ExistingValuesConsumer::ALL {
+            let fixture = HelmFixture::new(
+                installation_for_the_stateful_guard(),
+                HelmValuesResponse::Failure(reason),
+            );
+            let output = consumer.run(&fixture);
+            assert_eq!(
+                output.status.code(),
+                Some(expected_exit),
+                "{} classified an unknown values read incorrectly; stdout:\n{}\nstderr:\n{}",
+                consumer.name(),
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+            let error = json_error(output, consumer.name());
+            assert!(
+                error["error"]
+                    .as_str()
+                    .is_some_and(|message| message.contains(expected_message)),
+                "{} did not preserve the Helm diagnosis: {error}",
+                consumer.name()
+            );
+            assert!(
+                error["fix"]
+                    .as_str()
+                    .is_some_and(|fix| fix.contains("helm status")),
+                "{} did not provide the safe release access check: {error}",
+                consumer.name()
+            );
+            assert!(
+                error.get("release_exists").is_none(),
+                "{} reported an unknown release as known: {error}",
+                consumer.name()
+            );
+            assert_only_existing_values_read(&fixture, consumer);
+        }
+    }
+}
+
+#[test]
+fn existing_values_malformed_is_unknown_for_all_consumers() {
+    for malformed in [WARNING_PREFIXED_VALUES, ARRAY_VALUES] {
+        for consumer in ExistingValuesConsumer::ALL {
+            let fixture = HelmFixture::new(
+                installation_for_the_stateful_guard(),
+                HelmValuesResponse::RawSuccess(malformed),
+            );
+            let output = consumer.run(&fixture);
+            let visible = format!(
+                "{}{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+            assert!(
+                !visible.contains(SENTINEL_SEALING_KEY),
+                "{} exposed Helm values output:\n{visible}",
+                consumer.name()
+            );
+            assert!(
+                !visible.contains("generated strong per-release secrets"),
+                "{} reported sealing key generation after malformed values:\n{visible}",
+                consumer.name()
+            );
+            let error = json_error(output, consumer.name());
+            assert!(
+                error["error"]
+                    .as_str()
+                    .is_some_and(|message| message.contains("malformed")),
+                "{} did not identify malformed Helm values: {error}",
+                consumer.name()
+            );
+            assert!(
+                error.get("release_exists").is_none(),
+                "{} reported a malformed release read as known: {error}",
+                consumer.name()
+            );
+            assert_only_existing_values_read(&fixture, consumer);
+            assert!(
+                !fixture.calls().contains(SENTINEL_SEALING_KEY),
+                "{} exposed the sentinel in the command log:\n{}",
+                consumer.name(),
+                fixture.calls()
+            );
+        }
+    }
+}
+
+#[test]
+fn existing_values_null_is_an_existing_release() {
+    for consumer in ExistingValuesConsumer::MUTATING {
+        let fixture = HelmFixture::new(
+            installation_for_the_stateful_guard(),
+            HelmValuesResponse::Null,
+        );
+        let output = consumer.run(&fixture);
+        let visible = format!(
+            "{}{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(
+            !visible.contains("generated strong per-release secrets"),
+            "{} mislabeled a valid null release as fresh:\n{visible}",
+            consumer.name()
+        );
+        json_output(output, consumer.name());
+
+        let calls = fixture.calls();
+        assert!(
+            calls.contains("HELM_CALL: upgrade"),
+            "{} must accept valid null values:\n{calls}",
+            consumer.name()
+        );
+        assert!(
+            calls.contains("SEALING_KEY_PRESENT: yes"),
+            "{} may add sealing to an existing release with no values:\n{calls}",
+            consumer.name()
+        );
+    }
+
+    let fixture = HelmFixture::new(
+        installation_for_the_stateful_guard(),
+        HelmValuesResponse::Null,
+    );
+    let diff = json_output(fixture.diff(&[]), "diff");
+    assert_eq!(diff["release_exists"], true, "{diff}");
+    assert!(
+        diff["entries"].is_array(),
+        "valid null values must produce a completed diff for the existing release: {diff}"
+    );
+}
+
 #[test]
 fn absent_release_diff_matches_apply_dry_run_for_effective_installation_values() {
-    let fixture = HelmFixture::new(installation_with_effective_values(), None);
+    let fixture = HelmFixture::new(
+        installation_with_effective_values(),
+        HelmValuesResponse::Absent,
+    );
     let env = [
         ("CURIE_APPLY_TEST_MODEL_KEY", MODEL_VALUE),
         ("CURIE_APPLY_TEST_GITHUB_TOKEN", GITHUB_VALUE),
@@ -637,7 +919,7 @@ fn absent_release_diff_matches_apply_dry_run_for_effective_installation_values()
 fn empty_github_token_clear_is_shared_by_apply_and_diff() {
     let fixture = HelmFixture::new(
         "version: 1\ninstall:\n  namespace: parity\n  release: parity\nset:\n  api.githubToken: \"\"\n",
-        None,
+        HelmValuesResponse::Absent,
     );
 
     let apply = plan(fixture.apply_dry_run(&[]));
@@ -664,7 +946,7 @@ fn empty_github_token_clear_is_shared_by_apply_and_diff() {
 fn diff_marks_only_extra_live_egress_for_reset_and_preserves_live_github_token() {
     let fixture = HelmFixture::new(
         "version: 1\ninstall:\n  namespace: parity\n  release: parity\nplatform:\n  egress:\n    - host: anthropic\n",
-        Some(json!({
+        HelmValuesResponse::Object(json!({
             "api": {"githubToken": "ghp-live-token"},
             "security": {"networkPolicy": {"allowedEgress": [
                 {"cidr": "1.1.1.1/32", "ports": [{"port": 443, "protocol": "TCP"}]},
@@ -710,7 +992,7 @@ fn diff_marks_only_extra_live_egress_for_reset_and_preserves_live_github_token()
 fn apply_and_diff_report_the_same_curie_model_conflict() {
     let fixture = HelmFixture::new(
         "version: 1\ninstall:\n  namespace: parity\n  release: parity\nset:\n  agentSandbox.runner.model: file-model\n",
-        None,
+        HelmValuesResponse::Absent,
     );
     let env = [("CURIE_MODEL", "shell-model")];
     let apply = fixture.apply_dry_run(&env);
@@ -739,7 +1021,10 @@ fn apply_with_both_flags_makes_no_cluster_call() {
     // intent, and apply resolved the contradiction by silently dropping the
     // migration and taking the data destroying path. The primary assertion is
     // the ABSENCE of the mutation, not the wording of the refusal.
-    let fixture = HelmFixture::new(installation_for_the_stateful_guard(), None);
+    let fixture = HelmFixture::new(
+        installation_for_the_stateful_guard(),
+        HelmValuesResponse::Absent,
+    );
 
     let output = fixture.apply(&["--migrate-store", "--allow-stateful-removal"], &[]);
 
@@ -773,7 +1058,10 @@ fn migrate_store_alone_still_migrates() {
     // AC2: the control run. A live minio store plus a chart that renders rustfs
     // is the rename the guard exists for, and --migrate-store alone must still
     // take the migration branch.
-    let fixture = HelmFixture::new(installation_for_the_stateful_guard(), None);
+    let fixture = HelmFixture::new(
+        installation_for_the_stateful_guard(),
+        HelmValuesResponse::Absent,
+    );
 
     let output = fixture.apply(
         &["--migrate-store"],
@@ -823,42 +1111,6 @@ fn migrate_store_alone_still_migrates() {
 }
 
 #[test]
-fn migrate_store_refuses_a_mixed_removed_and_renamed_batch() {
-    let fixture = HelmFixture::new(installation_for_the_stateful_guard(), None);
-    let live_statefulsets = live_mixed_store_statefulsets();
-
-    let output = fixture.apply(
-        &["--migrate-store"],
-        &[
-            ("CURIE_TEST_HELM_MIXED_STATEFULSETS", "1"),
-            ("CURIE_TEST_KUBECTL_STS", &live_statefulsets),
-        ],
-    );
-
-    let calls = fixture.calls();
-    let error = json_error(output, "apply --migrate-store");
-    let message = error["error"].as_str().expect("apply error message string");
-    assert!(
-        message.contains("nameOverride"),
-        "a renamed StatefulSet must direct the operator to nameOverride:\n{message}"
-    );
-    assert!(
-        message.contains("parity-minio")
-            && message.contains("parity-postgres")
-            && message.contains("parity-curie-postgres"),
-        "the refusal must include the removed store and renamed StatefulSet:\n{message}"
-    );
-    assert!(
-        !calls.contains("KUBECTL_CALL: run "),
-        "a mixed batch must stop before the migration export:\n{calls}"
-    );
-    assert!(
-        !calls.contains("HELM_CALL: upgrade"),
-        "a mixed batch must stop before the upgrade:\n{calls}"
-    );
-}
-
-#[test]
 fn migrate_store_does_not_read_a_failed_cluster_read_as_a_removal() {
     // #1351, the other face of the same defect. While the refusal was the only
     // error the guard could raise, `--migrate-store` read any Err as "a removal
@@ -867,7 +1119,10 @@ fn migrate_store_does_not_read_a_failed_cluster_read_as_a_removal() {
     // find out" to "definitely at risk, start staging" -- and the run then died
     // inside the export with "nothing to migrate", a message about a decision
     // the operator never made, blaming the wrong thing.
-    let fixture = HelmFixture::new(installation_for_the_stateful_guard(), None);
+    let fixture = HelmFixture::new(
+        installation_for_the_stateful_guard(),
+        HelmValuesResponse::Absent,
+    );
 
     let output = fixture.apply(&["--migrate-store"], &[("CURIE_TEST_KUBECTL_FAIL", "1")]);
 
@@ -911,7 +1166,10 @@ fn migrate_store_does_not_read_a_failed_cluster_read_as_a_removal() {
 fn allow_stateful_removal_alone_still_proceeds() {
     // AC3: the override short circuits the guard entirely, so the same live
     // minio store that stops a plain apply proceeds straight to the upgrade.
-    let fixture = HelmFixture::new(installation_for_the_stateful_guard(), None);
+    let fixture = HelmFixture::new(
+        installation_for_the_stateful_guard(),
+        HelmValuesResponse::Absent,
+    );
 
     let output = fixture.apply(
         &["--allow-stateful-removal"],
@@ -940,7 +1198,10 @@ fn a_failed_kubectl_read_fails_the_apply() {
     // AC4, the core anti regression for #1351: a kubectl read that FAILED was
     // returned as an empty list, which told the guard "fresh install, nothing
     // to lose" while the upgrade went on to prune the StatefulSet.
-    let fixture = HelmFixture::new(installation_for_the_stateful_guard(), None);
+    let fixture = HelmFixture::new(
+        installation_for_the_stateful_guard(),
+        HelmValuesResponse::Absent,
+    );
 
     let output = fixture.apply(&[], &[("CURIE_TEST_KUBECTL_FAIL", "1")]);
 
@@ -978,7 +1239,10 @@ fn a_forbidden_kubectl_read_fails_the_apply_as_a_permanent_failure() {
     // green while restoring the exact vacuous-pass data-loss bug for a
     // Forbidden read: exit 0, no error, the guard reading "fresh install,
     // nothing to lose", and the upgrade pruning a live StatefulSet.
-    let fixture = HelmFixture::new(installation_for_the_stateful_guard(), None);
+    let fixture = HelmFixture::new(
+        installation_for_the_stateful_guard(),
+        HelmValuesResponse::Absent,
+    );
 
     let output = fixture.apply(&[], &[("CURIE_TEST_KUBECTL_FORBIDDEN", "1")]);
 
@@ -1012,7 +1276,10 @@ fn a_namespace_with_no_statefulsets_still_passes_the_guard() {
     // AC5, the trap guard. An empty items array with exit 0 is what a real
     // namespaced LIST returns for a fresh install AND for a namespace that does
     // not exist, so it is a genuine "nothing to lose" and must still apply.
-    let fixture = HelmFixture::new(installation_for_the_stateful_guard(), None);
+    let fixture = HelmFixture::new(
+        installation_for_the_stateful_guard(),
+        HelmValuesResponse::Absent,
+    );
 
     let output = fixture.apply(&[], &[]);
 

--- a/cli/tests/json_contract.rs
+++ b/cli/tests/json_contract.rs
@@ -1251,6 +1251,7 @@ fn credentialless_diff_without_a_release_does_not_claim_every_declared_value_is_
         &helm,
         r##"#!/bin/sh
 if [ "$1" = get ] && [ "$2" = values ]; then
+    printf '%s\n' 'Error: release: not found' >&2
     exit 1
 fi
 if [ "$1" = list ]; then


### PR DESCRIPTION
Fails closed when Helm cannot reliably read existing release values, preventing secret regeneration and false release absence reports.

Targets main because issue 1136 is in the v0.6.1 milestone and the defect affects the stable release line.

Closes #1136

Done check

[x] Failing behavioral tests were committed before production code.

[x] Delegated native workers performed every code and test edit.

[x] No public return type was broadened.

[x] Independent code review approved with file and line evidence.

[x] Independent scope review mapped every hunk to the issue or a required fixture correction.

[x] Cluster up, apply, diff, and the read only doctor consumer were enumerated.

[x] Executed command surface tests proved failed and malformed reads stop before mutation.

[x] Consolidation completed, full validation passed, and the consolidation review approved.

[x] Security review approved secret handling and exact absence matching.

[x] Observed subprocess verification passed all four existing values states.

[x] Full CLI formatting, clippy, and test validation passed after rebasing onto current main.

[x] Every edited file is lint clean.