### PR TITLE
Enforce connector NetworkPolicy checks

### DIFF
--- a/examples/tests/test_netpol_enforcement.py
+++ b/examples/tests/test_netpol_enforcement.py
@@ -1,0 +1,390 @@
+"""Black box coverage for the cluster NetworkPolicy enforcement gate."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import urlparse
+
+import yaml
+from plugin_format.connectors import validate_connectors
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "check-netpol-enforcement.sh"
+WEATHER_CONNECTORS = REPO_ROOT / "examples" / "weather" / "connectors.yaml"
+
+
+@dataclass(frozen=True)
+class GateRun:
+    stdout: str
+    stderr: str
+    returncode: int
+    kubectl_calls: list[list[str]]
+
+
+def _run_gate(
+    tmp_path: Path,
+    *,
+    connectors: tuple[str, ...],
+    sandbox_unreachable: tuple[str, ...] = (),
+    outside_reachable: tuple[str, ...] = (),
+    sandbox_dns_unreachable: bool = False,
+    outside_dns_unreachable: bool = False,
+    sandbox_to_deny_target_reachable: bool = False,
+    outside_to_deny_target_reachable: bool = True,
+    connector_not_ready: tuple[str, ...] = (),
+) -> GateRun:
+    fake = tmp_path / "kubectl"
+    log = tmp_path / "kubectl.jsonl"
+    fake.write_text(
+        """#!/usr/bin/env python3
+import json
+import os
+import sys
+from urllib.parse import urlparse
+
+args = sys.argv[1:]
+with open(os.environ["FAKE_KUBECTL_LOG"], "a", encoding="utf-8") as stream:
+    stream.write(json.dumps(args) + "\\n")
+
+connectors = tuple(filter(None, os.environ.get("FAKE_CONNECTORS", "").split(",")))
+sandbox_unreachable = set(
+    filter(None, os.environ.get("FAKE_SANDBOX_UNREACHABLE", "").split(","))
+)
+outside_reachable = set(
+    filter(None, os.environ.get("FAKE_OUTSIDE_REACHABLE", "").split(","))
+)
+sandbox_dns_unreachable = os.environ.get("FAKE_SANDBOX_DNS_UNREACHABLE") == "1"
+outside_dns_unreachable = os.environ.get("FAKE_OUTSIDE_DNS_UNREACHABLE") == "1"
+sandbox_to_deny_target_reachable = (
+    os.environ.get("FAKE_SANDBOX_TO_DENY_TARGET_REACHABLE") == "1"
+)
+outside_to_deny_target_reachable = (
+    os.environ.get("FAKE_OUTSIDE_TO_DENY_TARGET_REACHABLE") == "1"
+)
+connector_not_ready = set(
+    filter(None, os.environ.get("FAKE_CONNECTOR_NOT_READY", "").split(","))
+)
+
+
+def connector_deployment() -> str | None:
+    for connector in connectors:
+        if f"deployment/{connector}" in args or f"deploy/{connector}" in args:
+            return connector
+        for resource in ("deployment", "deploy"):
+            if resource in args and args.index(resource) + 1 < len(args):
+                if args[args.index(resource) + 1] == connector:
+                    return connector
+    return None
+
+if "delete" in args or "apply" in args:
+    raise SystemExit(0)
+
+if "wait" in args or ("rollout" in args and "status" in args):
+    deployment = connector_deployment()
+    if deployment is not None:
+        raise SystemExit(1 if deployment in connector_not_ready else 0)
+    raise SystemExit(0)
+
+if "get" in args and "networkpolicy" in args:
+    raise SystemExit(0)
+
+if "get" in args and "pod" in args:
+    print("192.0.2.10", end="")
+    raise SystemExit(0)
+
+if "get" in args and "svc" in args:
+    if "-l" in args:
+        if connectors:
+            print("\\n".join(connectors))
+        raise SystemExit(0)
+    print("8000", end="")
+    raise SystemExit(0)
+
+if "exec" in args:
+    exec_index = args.index("exec")
+    pod = args[exec_index + 1]
+    command = args[args.index("--") + 1 :]
+    if command and command[0] == "getent":
+        if pod == "netpol-probe-sandbox":
+            raise SystemExit(1 if sandbox_dns_unreachable else 0)
+        if pod == "netpol-probe-outside":
+            raise SystemExit(1 if outside_dns_unreachable else 0)
+        raise SystemExit(1)
+    urls = [value for value in command if value.startswith("http://")]
+    if urls:
+        service = urlparse(urls[0]).hostname or ""
+        if service == "192.0.2.10":
+            if pod == "netpol-probe-sandbox":
+                raise SystemExit(0 if sandbox_to_deny_target_reachable else 1)
+            if pod == "netpol-probe-outside":
+                raise SystemExit(0 if outside_to_deny_target_reachable else 1)
+            raise SystemExit(1)
+        if service not in connectors:
+            raise SystemExit(1)
+        if pod == "netpol-probe-sandbox":
+            raise SystemExit(1 if service in sandbox_unreachable else 0)
+        if pod == "netpol-probe-outside":
+            raise SystemExit(0 if service in outside_reachable else 1)
+
+print(f"unexpected kubectl invocation: {args!r}", file=sys.stderr)
+raise SystemExit(90)
+""",
+        encoding="utf-8",
+    )
+    fake.chmod(0o755)
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{tmp_path}{os.pathsep}{env['PATH']}",
+            "FAKE_KUBECTL_LOG": str(log),
+            "FAKE_CONNECTORS": ",".join(connectors),
+            "FAKE_SANDBOX_UNREACHABLE": ",".join(sandbox_unreachable),
+            "FAKE_OUTSIDE_REACHABLE": ",".join(outside_reachable),
+            "FAKE_SANDBOX_DNS_UNREACHABLE": (
+                "1" if sandbox_dns_unreachable else "0"
+            ),
+            "FAKE_OUTSIDE_DNS_UNREACHABLE": (
+                "1" if outside_dns_unreachable else "0"
+            ),
+            "FAKE_SANDBOX_TO_DENY_TARGET_REACHABLE": (
+                "1" if sandbox_to_deny_target_reachable else "0"
+            ),
+            "FAKE_OUTSIDE_TO_DENY_TARGET_REACHABLE": (
+                "1" if outside_to_deny_target_reachable else "0"
+            ),
+            "FAKE_CONNECTOR_NOT_READY": ",".join(connector_not_ready),
+        }
+    )
+    result = subprocess.run(
+        ["bash", str(SCRIPT), "curie", "curie", "curie"],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    calls = [json.loads(line) for line in log.read_text().splitlines()]
+    return GateRun(result.stdout, result.stderr, result.returncode, calls)
+
+
+def _connector_curl_calls(calls: list[list[str]]) -> set[tuple[str, str]]:
+    attempts: set[tuple[str, str]] = set()
+    for call in calls:
+        if "exec" not in call or "--" not in call:
+            continue
+        command = call[call.index("--") + 1 :]
+        urls = [value for value in command if value.startswith("http://")]
+        if not urls:
+            continue
+        service = urlparse(urls[0]).hostname or ""
+        if "-mcp-" in service:
+            attempts.add((call[call.index("exec") + 1], service))
+    return attempts
+
+
+def _curl_events(calls: list[list[str]]) -> list[tuple[int, str, str]]:
+    events: list[tuple[int, str, str]] = []
+    probe_roles = {
+        "netpol-probe-sandbox": "sandbox",
+        "netpol-probe-outside": "outside",
+    }
+    for index, call in enumerate(calls):
+        if "exec" not in call or "--" not in call:
+            continue
+        command = call[call.index("--") + 1 :]
+        urls = [value for value in command if value.startswith("http://")]
+        if not urls:
+            continue
+        pod = call[call.index("exec") + 1]
+        role = probe_roles.get(pod, pod)
+        host = urlparse(urls[0]).hostname or ""
+        target = "deny_target" if host == "192.0.2.10" else host
+        events.append((index, role, target))
+    return events
+
+
+def _dns_events(calls: list[list[str]]) -> list[tuple[int, str]]:
+    events: list[tuple[int, str]] = []
+    for index, call in enumerate(calls):
+        if "exec" not in call or "--" not in call:
+            continue
+        command = call[call.index("--") + 1 :]
+        if command[:2] == ["getent", "hosts"]:
+            events.append((index, call[call.index("exec") + 1]))
+    return events
+
+
+def _deployment_readiness_events(
+    calls: list[list[str]], connectors: tuple[str, ...]
+) -> list[tuple[int, str]]:
+    events: list[tuple[int, str]] = []
+    for index, call in enumerate(calls):
+        if "wait" not in call and not ("rollout" in call and "status" in call):
+            continue
+        for connector in connectors:
+            direct_resource = any(
+                value in call for value in (f"deployment/{connector}", f"deploy/{connector}")
+            )
+            separate_resource = any(
+                resource in call
+                and call.index(resource) + 1 < len(call)
+                and call[call.index(resource) + 1] == connector
+                for resource in ("deployment", "deploy")
+            )
+            if direct_resource or separate_resource:
+                events.append((index, connector))
+    return events
+
+
+def test_weather_ladder_bundle_declares_a_hosted_connector() -> None:
+    assert WEATHER_CONNECTORS.is_file(), "the fixed weather ladder bundle has no connectors.yaml"
+    parsed, errors = validate_connectors(yaml.safe_load(WEATHER_CONNECTORS.read_text()))
+
+    assert errors == []
+    assert parsed is not None
+    assert any(connector.is_hosted for connector in parsed.connectors.values())
+
+
+def test_zero_connector_services_fails(tmp_path: Path) -> None:
+    result = _run_gate(tmp_path, connectors=())
+
+    assert result.returncode != 0
+    assert "found 0 connector Services" in result.stdout + result.stderr
+
+
+def test_non_enforcing_cni_fails_before_connector_checks(tmp_path: Path) -> None:
+    result = _run_gate(
+        tmp_path,
+        connectors=("curie-mcp-alpha",),
+        sandbox_to_deny_target_reachable=True,
+    )
+
+    assert result.returncode != 0
+    assert "CNI is not enforcing NetworkPolicy" in result.stderr
+    assert not any(
+        target.startswith("curie-mcp-")
+        for _, _, target in _curl_events(result.kubectl_calls)
+    )
+
+
+def test_outside_probe_must_reach_known_listener_before_connector_denial(tmp_path: Path) -> None:
+    connector = "curie-mcp-alpha"
+    result = _run_gate(
+        tmp_path,
+        connectors=(connector,),
+        outside_to_deny_target_reachable=False,
+    )
+
+    assert result.returncode != 0
+    assert "outside probe" in result.stderr
+    assert "deny target" in result.stderr
+    assert ("outside", "deny_target") in {
+        (role, target) for _, role, target in _curl_events(result.kubectl_calls)
+    }
+    assert ("outside", connector) not in {
+        (role, target) for _, role, target in _curl_events(result.kubectl_calls)
+    }
+
+
+def test_outside_probe_must_resolve_dns_before_connector_denial(tmp_path: Path) -> None:
+    connector = "curie-mcp-alpha"
+    result = _run_gate(
+        tmp_path,
+        connectors=(connector,),
+        outside_dns_unreachable=True,
+    )
+
+    assert result.returncode != 0
+    assert "outside probe cannot resolve DNS" in result.stderr
+    dns_events = _dns_events(result.kubectl_calls)
+    assert any(pod == "netpol-probe-outside" for _, pod in dns_events)
+    outside_connector_curls = [
+        index
+        for index, role, target in _curl_events(result.kubectl_calls)
+        if role == "outside" and target == connector
+    ]
+    assert outside_connector_curls == []
+
+
+def test_every_connector_checks_sandbox_allow_and_outside_deny(tmp_path: Path) -> None:
+    connectors = ("curie-mcp-alpha", "curie-mcp-beta")
+    result = _run_gate(tmp_path, connectors=connectors)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "connector Service count: 2" in result.stdout
+    assert _connector_curl_calls(result.kubectl_calls) == {
+        ("netpol-probe-sandbox", "curie-mcp-alpha"),
+        ("netpol-probe-outside", "curie-mcp-alpha"),
+        ("netpol-probe-sandbox", "curie-mcp-beta"),
+        ("netpol-probe-outside", "curie-mcp-beta"),
+    }
+
+
+def test_connector_denials_follow_outside_control_and_deployment_readiness(
+    tmp_path: Path,
+) -> None:
+    connectors = ("curie-mcp-alpha", "curie-mcp-beta")
+    result = _run_gate(tmp_path, connectors=connectors)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    curl_indexes = {
+        (role, target): index for index, role, target in _curl_events(result.kubectl_calls)
+    }
+    readiness_indexes = {
+        connector: index
+        for index, connector in _deployment_readiness_events(result.kubectl_calls, connectors)
+    }
+    assert ("sandbox", "deny_target") in curl_indexes
+    assert ("outside", "deny_target") in curl_indexes
+    assert set(readiness_indexes) == set(connectors)
+    for connector in connectors:
+        assert readiness_indexes[connector] < curl_indexes[("sandbox", connector)]
+        assert readiness_indexes[connector] < curl_indexes[("outside", connector)]
+        assert curl_indexes[("outside", "deny_target")] < curl_indexes[("outside", connector)]
+
+
+def test_connector_readiness_failure_is_not_reported_as_policy_failure(tmp_path: Path) -> None:
+    connectors = ("curie-mcp-alpha", "curie-mcp-beta")
+    result = _run_gate(
+        tmp_path,
+        connectors=connectors,
+        connector_not_ready=("curie-mcp-beta",),
+    )
+
+    assert result.returncode != 0
+    assert "Deployment curie-mcp-beta" in result.stderr
+    assert "ready" in result.stderr
+    assert "sandbox cannot reach connector Service curie-mcp-beta" not in result.stderr
+    assert ("sandbox", "curie-mcp-beta") not in {
+        (role, target) for _, role, target in _curl_events(result.kubectl_calls)
+    }
+
+
+def test_outside_access_to_any_connector_fails(tmp_path: Path) -> None:
+    connectors = ("curie-mcp-alpha", "curie-mcp-beta")
+    result = _run_gate(
+        tmp_path,
+        connectors=connectors,
+        outside_reachable=("curie-mcp-beta",),
+    )
+
+    assert result.returncode != 0
+    assert "outside probe reached connector Service curie-mcp-beta:8000" in result.stderr
+
+
+def test_sandbox_access_loss_fails(tmp_path: Path) -> None:
+    connectors = ("curie-mcp-alpha", "curie-mcp-beta")
+    result = _run_gate(
+        tmp_path,
+        connectors=connectors,
+        sandbox_unreachable=("curie-mcp-beta",),
+    )
+
+    assert result.returncode != 0
+    assert "sandbox cannot reach connector Service curie-mcp-beta:8000" in result.stderr

--- a/examples/weather/connectors.yaml
+++ b/examples/weather/connectors.yaml
@@ -1,0 +1,20 @@
+# The weather bundle carries this hosted connector so the cluster NetworkPolicy
+# enforcement gate exercises a real connector Service. It is a probe fixture,
+# not part of the weather skill's forecast behavior.
+connectors:
+  netpol-probe:
+    image: grafana/mcp-grafana@sha256:d5b51db0c8eaafc6ed3fede5bfcc8d67b2384a40cf3d493086e378855ceba882
+    args:
+      [
+        "-t",
+        "streamable-http",
+        "--address",
+        "0.0.0.0:8000",
+        "--endpoint-path",
+        "/mcp",
+        "--allowed-hosts",
+        "${CURIE_ALLOWED_HOSTS}",
+        "-disable-write",
+      ]
+    env:
+      GRAFANA_URL: "http://grafana.example.com"

--- a/scripts/check-netpol-enforcement.sh
+++ b/scripts/check-netpol-enforcement.sh
@@ -27,10 +27,11 @@ TARGET_IMAGE="${CURIE_NETPOL_TARGET_IMAGE:-hashicorp/http-echo:1.0}"
 
 SANDBOX_POD="netpol-probe-sandbox"
 OUTSIDE_POD="netpol-probe-outside"
+DENY_TARGET_POD="netpol-probe-deny-target"
 
 # Non-blocking on the way out: the run is over, nothing waits on the pods.
 cleanup() {
-  kubectl -n "$NS" delete pod "$SANDBOX_POD" "$OUTSIDE_POD" \
+  kubectl -n "$NS" delete pod "$SANDBOX_POD" "$OUTSIDE_POD" "$DENY_TARGET_POD" \
     --ignore-not-found --wait=false >/dev/null 2>&1 || true
 }
 # BLOCKING before the apply. A previous run's pod may still be terminating, and
@@ -38,7 +39,7 @@ cleanup() {
 # `wait --for=Ready` then passes on a pod that is on its way out and every exec
 # after it fails for reasons that have nothing to do with policy.
 cleanup_and_settle() {
-  kubectl -n "$NS" delete pod "$SANDBOX_POD" "$OUTSIDE_POD" \
+  kubectl -n "$NS" delete pod "$SANDBOX_POD" "$OUTSIDE_POD" "$DENY_TARGET_POD" \
     --ignore-not-found --wait=true --timeout=90s >/dev/null 2>&1 || true
 }
 trap cleanup EXIT
@@ -51,8 +52,8 @@ kubectl -n "$NS" get networkpolicy "${RELEASE}-runner-default-deny-egress" >/dev
   || fail "no ${RELEASE}-runner-default-deny-egress in $NS; is the chart installed?"
 
 # The sandbox probe wears exactly the labels Rail 1 selects, so the policies
-# under test apply to it. The outside probe wears none, and is the target the
-# sandbox must NOT reach.
+# under test apply to it. The outside probe and deny target wear none of the
+# runner sandbox labels.
 cleanup_and_settle
 kubectl -n "$NS" apply -f - >/dev/null <<YAML
 apiVersion: v1
@@ -80,23 +81,37 @@ spec:
   restartPolicy: Never
   containers:
     - name: probe
+      image: $PROBE_IMAGE
+      command: ["sleep", "600"]
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: $DENY_TARGET_POD
+  labels:
+    app.kubernetes.io/name: netpol-probe-deny-target
+spec:
+  restartPolicy: Never
+  containers:
+    - name: probe
       image: $TARGET_IMAGE
       args: ["-listen=:8000", "-text=reachable"]
 YAML
 
-kubectl -n "$NS" wait --for=condition=Ready "pod/$SANDBOX_POD" "pod/$OUTSIDE_POD" --timeout=180s >/dev/null \
+kubectl -n "$NS" wait --for=condition=Ready \
+  "pod/$SANDBOX_POD" "pod/$OUTSIDE_POD" "pod/$DENY_TARGET_POD" --timeout=180s >/dev/null \
   || fail "probe pods did not become ready"
 
-OUTSIDE_IP="$(kubectl -n "$NS" get pod "$OUTSIDE_POD" -o jsonpath='{.status.podIP}')"
-[ -n "$OUTSIDE_IP" ] || fail "could not read the outside probe's pod IP"
+DENY_TARGET_IP="$(kubectl -n "$NS" get pod "$DENY_TARGET_POD" -o jsonpath='{.status.podIP}')"
+[ -n "$DENY_TARGET_IP" ] || fail "could not read the deny target's pod IP"
 
 # ---------------------------------------------------------------------------
 # GATE: the deny must hold. Everything below is meaningless without this.
 # ---------------------------------------------------------------------------
 # Rail 1 denies all sandbox egress except what an allow policy adds, and nothing
-# allows the outside probe. Reaching it means policy is not being evaluated.
+# allows the deny target. Reaching it means policy is not being evaluated.
 if kubectl -n "$NS" exec "$SANDBOX_POD" -- \
-     curl -s -m 8 -o /dev/null "http://${OUTSIDE_IP}:8000/" 2>/dev/null; then
+     curl -s -m 8 -o /dev/null "http://${DENY_TARGET_IP}:8000/" 2>/dev/null; then
   fail "the sandbox reached a pod Rail 1 denies.
 
 This is NOT a policy bug -- it means the CNI is not enforcing NetworkPolicy at
@@ -112,9 +127,27 @@ Re-run against a cluster whose CNI enforces."
 fi
 echo "  ok  deny holds -- the CNI enforces NetworkPolicy (non-vacuity gate)"
 
+# The outside probe must reach the same known listener before its inability to
+# reach a connector can prove ingress enforcement. Otherwise a broken outside
+# network would make every connector ingress denial pass vacuously.
+if ! kubectl -n "$NS" exec "$OUTSIDE_POD" -- \
+      curl -s -m 8 -o /dev/null "http://${DENY_TARGET_IP}:8000/" 2>/dev/null; then
+  fail "the outside probe cannot reach the deny target; a broken outside network cannot certify connector ingress"
+fi
+echo "  ok  outside positive control reaches the deny target"
+
 # ---------------------------------------------------------------------------
 # Now the allow direction means something.
 # ---------------------------------------------------------------------------
+# The outside probe must resolve Service DNS before its inability to reach a
+# connector can prove ingress enforcement. Otherwise a broken outside DNS
+# path would make every connector ingress denial pass vacuously.
+if ! kubectl -n "$NS" exec "$OUTSIDE_POD" -- \
+      getent hosts kubernetes.default.svc.cluster.local >/dev/null 2>&1; then
+  fail "the outside probe cannot resolve DNS; connector ingress denial would be vacuous"
+fi
+echo "  ok  outside positive control resolves DNS"
+
 # DNS is the allow every sandbox depends on (curie-runner-allow-dns); without it
 # a sandbox cannot resolve any Service name, which surfaces as a confusing
 # connection failure rather than a policy error.
@@ -124,25 +157,40 @@ if ! kubectl -n "$NS" exec "$SANDBOX_POD" -- \
 fi
 echo "  ok  allow holds -- the sandbox can resolve DNS"
 
-# Any connector Service present is exercised too: this is the rule that was
-# silently broken by the ipBlock form, so it is the one most worth asserting.
-CONNECTORS="$(kubectl -n "$NS" get svc -l app.kubernetes.io/part-of="$RELEASE" \
-  -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null | grep -- "-mcp-" || true)"
-if [ -z "$CONNECTORS" ]; then
-  echo "  --  no connector Services in $NS; skipping the connector reachability leg"
-else
-  while IFS= read -r svc; do
-    [ -n "$svc" ] || continue
-    PORT="$(kubectl -n "$NS" get svc "$svc" -o jsonpath='{.spec.ports[0].port}')"
-    kubectl -n "$NS" exec "$SANDBOX_POD" -- \
-      curl -s -m 10 -o /dev/null "http://${svc}:${PORT}/" 2>/dev/null \
-      || fail "the sandbox cannot reach connector Service $svc:$PORT.
+# Every connector Service is exercised in both directions. A missing Service
+# makes the connector policy check vacuous and is therefore fatal.
+CONNECTORS=()
+while IFS= read -r svc; do
+  [ -n "$svc" ] && CONNECTORS+=("$svc")
+done < <(
+  kubectl -n "$NS" get svc -l app.kubernetes.io/part-of="$RELEASE" \
+    -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null \
+    | grep -- "-mcp-" || true
+)
+CONNECTOR_COUNT="${#CONNECTORS[@]}"
+(( CONNECTOR_COUNT > 0 )) \
+  || fail "found 0 connector Services in $NS; connector NetworkPolicy enforcement would be vacuous"
+echo "  ok  connector Service count: $CONNECTOR_COUNT"
+
+for svc in "${CONNECTORS[@]}"; do
+  kubectl -n "$NS" rollout status "deployment/$svc" --timeout=180s >/dev/null 2>&1 \
+    || fail "connector Deployment $svc did not become ready"
+
+  PORT="$(kubectl -n "$NS" get svc "$svc" -o jsonpath='{.spec.ports[0].port}')"
+  kubectl -n "$NS" exec "$SANDBOX_POD" -- \
+    curl -s -m 10 -o /dev/null "http://${svc}:${PORT}/" 2>/dev/null \
+    || fail "the sandbox cannot reach connector Service $svc:$PORT.
 
 Its egress rule is applied but not matching. The usual cause is an ipBlock of
 the Service ClusterIP: kube-proxy DNATs the destination to a pod IP before
 NetworkPolicy is evaluated, so such a rule can never match (ADR-0086)."
-    echo "  ok  sandbox reaches connector $svc:$PORT"
-  done <<<"$CONNECTORS"
-fi
+  echo "  ok  sandbox reaches connector $svc:$PORT"
 
-echo "== Rail 1 enforces, and every allowed path is reachable =="
+  if kubectl -n "$NS" exec "$OUTSIDE_POD" -- \
+       curl -s -m 10 -o /dev/null "http://${svc}:${PORT}/" 2>/dev/null; then
+    fail "the outside probe reached connector Service $svc:$PORT; connector ingress is not restricted to runner sandboxes"
+  fi
+  echo "  ok  outside probe cannot reach connector $svc:$PORT"
+done
+
+echo "== Rail 1, connector egress, and connector ingress enforce =="


### PR DESCRIPTION
## Summary

* Deploy a digest pinned hosted MCP connector in the fixed weather ladder bundle.
* Fail when connector Services are absent and wait for each connector Deployment.
* Prove the outside source can reach a known listener and resolve Service DNS before requiring every connector request to fail.

Base choice: main because this v0.6.1 security fix applies to both release lines.

## Done check

* [x] Focused tests failed before implementation and passed afterward.
* [x] All production and test edits were delegated to fresh native executor contexts.
* [x] No return type changed.
* [x] Independent code, scope, and security reviews approved the final diff.
* [x] The fixed bundle and both connector reachability directions are covered together.
* [x] Zero connector Services and widened outside access both execute and exit 1.
* [x] Consolidation findings were applied; the unavailable simplify capability made no edits to review.
* [x] The accepted dry run fallback executed the real script through the kubectl process boundary because local kind is unavailable.
* [x] The final affected suite passed with 313 tests and plugin compatibility passed.
* [x] Bash syntax and Ruff are clean on every edited file.

Closes #1449