### PR TITLE
Allow releases from main and next

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,7 +1,8 @@
 name: Release images and binaries
 
 # Two triggers, one workflow, so a single ref carries both artifacts:
-#  - push to main            -> publish images tagged sha + latest (continuous).
+#  - push to main or next    -> publish images tagged sha (continuous); main
+#                               also publishes latest.
 #  - push a v* tag           -> publish images tagged with the version AND build,
 #                               strip, and attach the curie CLI binaries to a
 #                               GitHub Release with generated notes.
@@ -20,7 +21,7 @@ name: Release images and binaries
 
 on:
   push:
-    branches: [main]
+    branches: [&release_main main, &release_next next]
     tags: ["v*"]
 
 permissions:
@@ -30,7 +31,8 @@ permissions:
 jobs:
   # Gates the ENTIRE tag-triggered publish pipeline (issue #628). A `v*` tag push
   # proves nothing about the tagged commit on its own, so nothing below may run
-  # for one until this job says the commit is reviewed, on main, and green.
+  # for one until this job says the commit is reviewed, on an allowed release
+  # branch, and green.
   # See ADR-0058 for the ancestry/checks design and ADR-0065 for the trust
   # boundary this job actually sits behind: it stops an accidentally-tagged
   # commit, not a write actor willing to edit the gate itself, because both
@@ -40,8 +42,8 @@ jobs:
   # environment -- are admin-only settings, unconfigured, and tracked as
   # blocking work in ADR-0065, not as a hardening follow-up.
   #
-  # `if:` makes this a no-op (skipped) for ordinary pushes to `main`, so the
-  # continuous sha/latest image builds below are unaffected. `environment:` has
+  # `if:` makes this a no-op (skipped) for ordinary pushes to `main` or `next`,
+  # so the continuous image builds below are unaffected. `environment:` has
   # no effect until required reviewers are added to it; the day they are, every
   # tag push pauses for approval right here, before anything else runs.
   authorize-release:
@@ -49,17 +51,20 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     environment: release-publish
+    env:
+      RELEASE_MAIN_BRANCH: *release_main
+      RELEASE_NEXT_BRANCH: *release_next
     permissions:
       contents: read
       checks: read
     steps:
       - uses: actions/checkout@v7
         with:
-          # Full history: an ancestor commit deep in main's log must stay
-          # reachable, which a shallow clone would hide. This materializes the
-          # TAGGED commit's tree (GitHub Actions checks out the triggering ref
-          # on a push trigger), origin/main included as a remote-tracking ref
-          # by the same fetch-depth: 0.
+          # Full history: an ancestor commit deep in either release branch's
+          # log must stay reachable, which a shallow clone would hide. This
+          # materializes the TAGGED commit's tree (GitHub Actions checks out
+          # the triggering ref on a push trigger), with both release branches
+          # included as remote-tracking refs by the same fetch-depth: 0.
           fetch-depth: 0
           persist-credentials: false
       - name: Resolve release/ from origin/main, not the tagged ref
@@ -76,11 +81,14 @@ jobs:
         # is unaffected by which copy of authorize.py exists, because their
         # tampered workflow never calls it. See ADR-0065 for the full trust
         # boundary this does and does not cover.
-        run: git checkout origin/main -- release/
-      - name: Tag's commit must be reviewed, on main, and fully checked
+        run: git checkout origin/${{ env.RELEASE_MAIN_BRANCH }} -- release/
+      - name: Tag's commit must be reviewed, on an allowed branch, and fully checked
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: python3 release/authorize.py "$GITHUB_SHA" --repo "$GITHUB_REPOSITORY"
+        run: |
+          python3 release/authorize.py "$GITHUB_SHA" --repo "$GITHUB_REPOSITORY" \
+            --reviewed-ref origin/${{ env.RELEASE_MAIN_BRANCH }} \
+            --reviewed-ref origin/${{ env.RELEASE_NEXT_BRANCH }}
 
   build:
     name: Build ${{ matrix.name }} image (${{ matrix.platform }})
@@ -88,9 +96,10 @@ jobs:
     needs: [authorize-release]
     # `always()` overrides the default needs-propagation (which would skip this
     # job whenever authorize-release is merely skipped, i.e. on every ordinary
-    # main push): a `skipped` authorize-release means "not a tag push, nothing to
-    # authorize" and this job proceeds; a `failure` result means an unauthorized
-    # tag, and this job -- and everything downstream of it -- does not run.
+    # branch push): a `skipped` authorize-release means "not a tag push, nothing
+    # to authorize" and this job proceeds; a `failure` result means an
+    # unauthorized tag, and this job -- and everything downstream of it -- does
+    # not run.
     if: |
       always() &&
       (needs.authorize-release.result == 'success' || needs.authorize-release.result == 'skipped')
@@ -193,9 +202,10 @@ jobs:
     name: Merge ${{ matrix.name }} manifest
     needs: [build]
     # A skip propagates through the WHOLE ancestor graph, not just the direct
-    # `needs:` edge: with authorize-release skipped on an ordinary main push,
-    # this job was skipped too even though `build` reported success, which froze
-    # the sha/latest manifests at the last tag push (#787). Naming a status
+    # `needs:` edge: with authorize-release skipped on an ordinary main or next
+    # push, this job was skipped too even though `build` reported success, which
+    # froze the SHA manifest and the main only latest manifest at the last tag
+    # push (#787). Naming a status
     # function opts the job out of that propagation, and the explicit result
     # check keeps it as strict as the implicit one: a `build` that failed or was
     # cancelled still stops the manifest, and on the tag path a refused
@@ -307,7 +317,7 @@ jobs:
           if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
             echo "v=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
           else
-            echo "v=latest" >> "$GITHUB_OUTPUT"
+            echo "v=sha-${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
           fi
       - name: Set up Buildx
         id: setup_buildx

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -467,11 +467,20 @@ CURIE_E2E_TIERS=all curie dev e2e-ladder
 CURIE_E2E_TIERS=local-release curie dev e2e-ladder
 ```
 
-Tag v0.7.0 from `main` only after both commands pass, then delete `next` or
-recreate it from `main` for the next approved feature train. Only an
-administrator may retire `next`, by temporarily removing protection after the
-tag while `main` remains protected. If `next` is recreated, restore its full
-protection before accepting PRs against it.
+Tag v0.7.0 from `main` only after both commands pass. Only an administrator may
+retire `next`. Before deleting it, the administrator must merge one release
+workflow and contract test change that removes `next` from the workflow trigger
+branch list, removes the `RELEASE_NEXT_BRANCH` environment alias, removes the
+`--reviewed-ref origin/$RELEASE_NEXT_BRANCH` argument, and updates
+`release/tests/test_authorize.py`. After that change lands, the administrator
+may temporarily remove protection and delete `next`, while keeping `main`
+protected. To recreate `next` for the next approved feature train, the
+administrator must first restore full protection for `next`, then create it
+from `main`. Only after those steps may the administrator merge one release
+workflow and contract test change that adds `next` to the workflow trigger
+branch list, restores the `RELEASE_NEXT_BRANCH` environment alias and the
+`--reviewed-ref origin/$RELEASE_NEXT_BRANCH` argument, and updates
+`release/tests/test_authorize.py` before accepting PRs against it.
 
 - Commit message format: a short imperative summary line, then detail bullets.
 - Reference the relevant issue in the PR body (e.g. `Closes #123`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -189,11 +189,20 @@ CURIE_E2E_TIERS=all curie dev e2e-ladder
 CURIE_E2E_TIERS=local-release curie dev e2e-ladder
 ```
 
-Tag v0.7.0 from `main` only after both commands pass, then delete `next` or
-recreate it from `main` for the next approved feature train. Only an
-administrator may retire `next`, by temporarily removing protection after the
-tag while `main` remains protected. If `next` is recreated, restore its full
-protection before accepting PRs against it.
+Tag v0.7.0 from `main` only after both commands pass. Only an administrator may
+retire `next`. Before deleting it, the administrator must merge one release
+workflow and contract test change that removes `next` from the workflow trigger
+branch list, removes the `RELEASE_NEXT_BRANCH` environment alias, removes the
+`--reviewed-ref origin/$RELEASE_NEXT_BRANCH` argument, and updates
+`release/tests/test_authorize.py`. After that change lands, the administrator
+may temporarily remove protection and delete `next`, while keeping `main`
+protected. To recreate `next` for the next approved feature train, the
+administrator must first restore full protection for `next`, then create it
+from `main`. Only after those steps may the administrator merge one release
+workflow and contract test change that adds `next` to the workflow trigger
+branch list, restores the `RELEASE_NEXT_BRANCH` environment alias and the
+`--reviewed-ref origin/$RELEASE_NEXT_BRANCH` argument, and updates
+`release/tests/test_authorize.py` before accepting PRs against it.
 
 - **Commit messages**: a short imperative summary line, then detail bullets.
 - **Reference the issue in the PR body** with `Closes #123` (or `Ref #123`). Do

--- a/release/authorize.py
+++ b/release/authorize.py
@@ -6,9 +6,10 @@ just a ref; pushing one proves nothing about the commit it points at. This
 script is the gate `authorize-release` runs before any other job in that
 pipeline, and it fails closed on either of two questions:
 
-  ancestry  Is the tagged commit reachable from `origin/main`? A tag on a
-            feature branch, a rebased-away commit, or anything that bypassed a
-            merged PR is refused here, before any image builds.
+  ancestry  Is the tagged commit reachable from an explicitly supplied
+            reviewed branch? A tag on a feature branch, a rebased commit, or
+            anything that bypassed a merged PR is refused here, before any
+            image builds.
 
   checks    Does that commit's check-runs list show every REQUIRED_CHECK_NAMES
             entry successful (or neutral)? An explicit allowlist,
@@ -42,14 +43,15 @@ import json
 import os
 import subprocess
 import sys
+from collections.abc import Sequence
 from pathlib import Path
 
 PASSING_CONCLUSIONS = {"success", "neutral"}
 
 # The check-run names that must be present and green before a tag may
 # publish (issue #733). These are the job `name:` fields from
-# `.github/workflows/ci.yaml` -- the workflow that gates every PR/push to
-# `main` -- restricted to the jobs that speak to release confidence: the
+# `.github/workflows/ci.yaml`, the workflow that gates every PR and push to
+# a reviewed branch, restricted to jobs that speak to release confidence: the
 # three language/test jobs, the generated-artifact drift checks, the
 # release-compose validation, every first-party image actually building
 # (including the worker-local overlay and the dispatcher's own import
@@ -92,21 +94,39 @@ class AuthorizationError(Exception):
     """A tagged commit is not authorized to publish a release."""
 
 
-def commit_is_on_reviewed_main(
-    sha: str, main_ref: str = "origin/main", *, cwd: Path | None = None
+def commit_is_on_reviewed_branch(
+    sha: str, reviewed_ref: str, *, cwd: Path | None = None
 ) -> bool:
-    """Is `sha` reachable from `main_ref` in the checked-out repo at `cwd`?
+    """Is `sha` reachable from `reviewed_ref` in the repo at `cwd`?
 
     Requires full history (`fetch-depth: 0` in the workflow checkout); a
     shallow clone would make an ancestor commit unreachable and read as absent.
     """
-    result = subprocess.run(
-        ["git", "merge-base", "--is-ancestor", sha, main_ref],
-        cwd=cwd,
-        capture_output=True,
-        check=False,
+    try:
+        result = subprocess.run(
+            ["git", "merge-base", "--is-ancestor", sha, reviewed_ref],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError as exc:
+        raise AuthorizationError(
+            f"could not determine whether commit {sha} is reachable from "
+            f"{reviewed_ref}: {exc}"
+        ) from exc
+
+    if result.returncode == 0:
+        return True
+    if result.returncode == 1:
+        return False
+
+    detail = result.stderr.strip()
+    suffix = f": {detail}" if detail else ""
+    raise AuthorizationError(
+        f"could not determine whether commit {sha} is reachable from "
+        f"{reviewed_ref}; git merge-base returned {result.returncode}{suffix}"
     )
-    return result.returncode == 0
 
 
 def missing_required_checks(
@@ -182,18 +202,27 @@ def exclude_current_workflow_run(
 def authorize(
     sha: str,
     check_runs: list[dict[str, object]],
-    main_ref: str = "origin/main",
+    reviewed_refs: Sequence[str],
     *,
     cwd: Path | None = None,
     exclude_run_id: str | None = None,
     required_names: frozenset[str] | None = None,
 ) -> None:
     """Raise AuthorizationError unless `sha` may publish a release."""
-    if not commit_is_on_reviewed_main(sha, main_ref, cwd=cwd):
+    if not reviewed_refs:
         raise AuthorizationError(
-            f"commit {sha} is not reachable from {main_ref}. A release can only "
-            "publish from a commit that reached main through a reviewed, merged "
-            "PR; refusing to authorize this tag."
+            "at least one reviewed ref is required; refusing to authorize this tag"
+        )
+
+    reachability = [
+        commit_is_on_reviewed_branch(sha, reviewed_ref, cwd=cwd)
+        for reviewed_ref in reviewed_refs
+    ]
+    if not any(reachability):
+        checked_refs = ", ".join(reviewed_refs)
+        raise AuthorizationError(
+            f"commit {sha} is not reachable from any reviewed ref "
+            f"({checked_refs}); refusing to authorize this tag"
         )
     other_runs = exclude_current_workflow_run(check_runs, exclude_run_id)
     missing = missing_required_checks(other_runs, required_names)
@@ -270,7 +299,12 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     parser.add_argument("sha", help="the tagged commit to authorize")
     parser.add_argument("--repo", required=True, help="owner/name, e.g. curie-eng/curie")
-    parser.add_argument("--main-ref", default="origin/main", help="the reviewed-main ref")
+    parser.add_argument(
+        "--reviewed-ref",
+        action="append",
+        required=True,
+        help="a reviewed branch ref; repeat for every allowed branch",
+    )
     parser.add_argument(
         "--run-id",
         default=os.environ.get("GITHUB_RUN_ID"),
@@ -280,7 +314,7 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         check_runs = fetch_check_runs(args.sha, args.repo)
-        authorize(args.sha, check_runs, args.main_ref, exclude_run_id=args.run_id)
+        authorize(args.sha, check_runs, args.reviewed_ref, exclude_run_id=args.run_id)
     except AuthorizationError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 1
@@ -298,7 +332,11 @@ def main(argv: list[str] | None = None) -> int:
             file=sys.stderr,
         )
         return 1
-    print(f"OK: {args.sha} is reviewed, on {args.main_ref}, and checked -- authorized")
+    checked_refs = ", ".join(args.reviewed_ref)
+    print(
+        f"OK: {args.sha} is reachable from a reviewed ref "
+        f"({checked_refs}) and checked; authorized"
+    )
     return 0
 
 

--- a/release/authorize.py
+++ b/release/authorize.py
@@ -15,9 +15,9 @@ pipeline, and it fails closed on either of two questions:
             entry successful (or neutral)? An explicit allowlist,
             not "some checks, all green" (issue #733): a commit with only an
             unrelated passing check-run and no sign its real CI ever ran
-            must be refused, the same as one that is on main but was never
-            checked, or was checked and failed. Zero check-runs is also a
-            failure -- absence of checks is not evidence they passed. A
+            must be refused, the same as one that is on a reviewed branch but
+            was never checked, or was checked and failed. Zero check-runs is
+            also a failure -- absence of checks is not evidence they passed. A
             required check-run that concluded `skipped` is refused too
             (issue #1470): a job-level `if:` on the job, or a failed job in
             its `needs:`, both make GitHub record that required check as

--- a/release/tests/test_authorize.py
+++ b/release/tests/test_authorize.py
@@ -2,8 +2,8 @@
 
 The gate is the deterministic check behind issue #628: a `v*` tag must not be
 able to start the publish pipeline unless its commit is reachable from
-`origin/main` and that commit's required checks are all green. These tests
-drive both functions directly -- `commit_is_on_reviewed_main` against a real,
+`origin/main` or `origin/next` and that commit's required checks are all green. These tests
+drive both functions directly -- `commit_is_on_reviewed_branch` against a real,
 disposable git repo (no network needed for ancestry) and
 `missing_required_checks` against constructed
 check-run lists -- plus `authorize()`, which combines them and is what
@@ -11,6 +11,7 @@ check-run lists -- plus `authorize()`, which combines them and is what
 """
 
 import importlib.util
+import inspect
 import json
 import os
 import re
@@ -62,12 +63,32 @@ def git_repo(tmp_path) -> Path:
     return repo
 
 
+@pytest.fixture
+def reviewed_refs_repo(git_repo) -> tuple[Path, dict[str, str]]:
+    """A history with commits unique to main, next, and an unmerged feature."""
+    base = run_git(git_repo, "rev-parse", "HEAD")
+
+    run_git(git_repo, "checkout", "-q", "-b", "next")
+    next_commit = commit(git_repo, "next-only.txt")
+    run_git(git_repo, "update-ref", "refs/remotes/origin/next", next_commit)
+
+    run_git(git_repo, "checkout", "-q", "main")
+    main_commit = commit(git_repo, "main-only.txt")
+    run_git(git_repo, "update-ref", "refs/remotes/origin/main", main_commit)
+
+    run_git(git_repo, "checkout", "-q", "-b", "feature", base)
+    feature_commit = commit(git_repo, "feature-only.txt")
+
+    return git_repo, {"main": main_commit, "next": next_commit, "feature": feature_commit}
+
+
 # A required-name set distinct from the real, larger production
 # REQUIRED_CHECK_NAMES (issue #733). Most tests in this file exercise the
 # *logic* of required-check matching and should not need updating every time
 # a ci.yaml job is renamed or added; the production constant itself gets its
 # own coverage in TestRequiredCheckAllowlist below.
 TEST_REQUIRED_NAMES = frozenset({"CI", "CodeQL"})
+REVIEWED_REFS = ("origin/main", "origin/next")
 
 CHECK_RUNS_ALL_GREEN = [
     {"name": "CI", "conclusion": "success"},
@@ -104,30 +125,41 @@ GATE_OWN_IN_PROGRESS = check_run(
 )
 
 
-class TestCommitIsOnReviewedMain:
+class TestCommitIsOnReviewedBranch:
+    def test_reviewed_branch_ref_has_no_default(self):
+        parameters = inspect.signature(
+            authorize_module.commit_is_on_reviewed_branch
+        ).parameters
+
+        assert parameters["reviewed_ref"].default is inspect.Parameter.empty
+
     def test_head_of_main_is_reachable(self, git_repo):
         sha = run_git(git_repo, "rev-parse", "HEAD")
 
-        assert authorize_module.commit_is_on_reviewed_main(sha, "main", cwd=git_repo)
+        assert authorize_module.commit_is_on_reviewed_branch(sha, "main", cwd=git_repo)
 
     def test_ancestor_of_main_is_reachable(self, git_repo):
         first = run_git(git_repo, "rev-parse", "HEAD")
         commit(git_repo, "later-on-main.txt")
 
-        assert authorize_module.commit_is_on_reviewed_main(first, "main", cwd=git_repo)
+        assert authorize_module.commit_is_on_reviewed_branch(first, "main", cwd=git_repo)
 
     def test_commit_only_on_an_unmerged_branch_is_refused(self, git_repo):
         run_git(git_repo, "checkout", "-q", "-b", "feature")
         unmerged = commit(git_repo, "feature-only.txt")
 
-        assert not authorize_module.commit_is_on_reviewed_main(
+        assert not authorize_module.commit_is_on_reviewed_branch(
             unmerged, "main", cwd=git_repo
         )
 
-    def test_unknown_sha_is_refused_not_raised(self, git_repo):
-        assert not authorize_module.commit_is_on_reviewed_main(
-            "0" * 40, "main", cwd=git_repo
-        )
+    def test_unknown_sha_refuses_as_indeterminate_reachability(self, git_repo):
+        sha = "0" * 40
+
+        with pytest.raises(authorize_module.AuthorizationError) as exc_info:
+            authorize_module.commit_is_on_reviewed_branch(sha, "main", cwd=git_repo)
+
+        assert sha in str(exc_info.value)
+        assert "main" in str(exc_info.value)
 
 
 class TestRequiredCheckSatisfaction:
@@ -206,22 +238,78 @@ class TestMissingRequiredChecks:
 
 
 class TestAuthorize:
-    def test_reviewed_and_green_commit_is_authorized(self, git_repo):
-        sha = run_git(git_repo, "rev-parse", "HEAD")
+    def test_reviewed_ref_collection_has_no_default(self):
+        parameters = inspect.signature(authorize_module.authorize).parameters
 
+        assert "main_ref" not in parameters
+        assert parameters["reviewed_refs"].default is inspect.Parameter.empty
+
+    def test_commit_reachable_only_from_next_is_authorized(
+        self, reviewed_refs_repo
+    ):
+        git_repo, commits = reviewed_refs_repo
         authorize_module.authorize(
-            sha, CHECK_RUNS_ALL_GREEN, "main", cwd=git_repo, required_names=TEST_REQUIRED_NAMES
+            commits["next"],
+            CHECK_RUNS_ALL_GREEN,
+            REVIEWED_REFS,
+            cwd=git_repo,
+            required_names=TEST_REQUIRED_NAMES,
         )
 
-    def test_unreviewed_commit_is_refused_even_with_green_checks(self, git_repo):
-        run_git(git_repo, "checkout", "-q", "-b", "feature")
-        unmerged = commit(git_repo, "feature-only.txt")
+    def test_commit_reachable_only_from_main_is_authorized(
+        self, reviewed_refs_repo
+    ):
+        git_repo, commits = reviewed_refs_repo
 
-        with pytest.raises(authorize_module.AuthorizationError, match="not reachable"):
+        authorize_module.authorize(
+            commits["main"],
+            CHECK_RUNS_ALL_GREEN,
+            REVIEWED_REFS,
+            cwd=git_repo,
+            required_names=TEST_REQUIRED_NAMES,
+        )
+
+    def test_commit_reachable_from_neither_reviewed_ref_is_refused(
+        self, reviewed_refs_repo
+    ):
+        git_repo, commits = reviewed_refs_repo
+
+        with pytest.raises(authorize_module.AuthorizationError) as exc_info:
             authorize_module.authorize(
-                unmerged,
+                commits["feature"],
                 CHECK_RUNS_ALL_GREEN,
-                "main",
+                REVIEWED_REFS,
+                cwd=git_repo,
+                required_names=TEST_REQUIRED_NAMES,
+            )
+
+        assert "origin/main" in str(exc_info.value)
+        assert "origin/next" in str(exc_info.value)
+
+    def test_matching_ref_does_not_hide_an_unresolvable_ref(self, reviewed_refs_repo):
+        git_repo, commits = reviewed_refs_repo
+        unresolvable_ref = "origin/not-a-ref"
+
+        with pytest.raises(authorize_module.AuthorizationError) as exc_info:
+            authorize_module.authorize(
+                commits["main"],
+                CHECK_RUNS_ALL_GREEN,
+                ("origin/main", unresolvable_ref),
+                cwd=git_repo,
+                required_names=TEST_REQUIRED_NAMES,
+            )
+
+        assert commits["main"] in str(exc_info.value)
+        assert unresolvable_ref in str(exc_info.value)
+
+    def test_empty_reviewed_ref_collection_is_refused(self, git_repo):
+        sha = run_git(git_repo, "rev-parse", "HEAD")
+
+        with pytest.raises(authorize_module.AuthorizationError, match="reviewed ref"):
+            authorize_module.authorize(
+                sha,
+                CHECK_RUNS_ALL_GREEN,
+                (),
                 cwd=git_repo,
                 required_names=TEST_REQUIRED_NAMES,
             )
@@ -233,7 +321,7 @@ class TestAuthorize:
             authorize_module.authorize(
                 sha,
                 CHECK_RUNS_ONE_FAILED,
-                "main",
+                ("main",),
                 cwd=git_repo,
                 required_names=TEST_REQUIRED_NAMES,
             )
@@ -269,7 +357,9 @@ class TestRequiredCheckAllowlist:
         with pytest.raises(
             authorize_module.AuthorizationError, match="required check-run"
         ):
-            authorize_module.authorize(sha, self.UNRELATED_BUT_GREEN, "main", cwd=git_repo)
+            authorize_module.authorize(
+                sha, self.UNRELATED_BUT_GREEN, ("main",), cwd=git_repo
+            )
 
     def test_every_required_check_present_and_green_authorizes(self, git_repo):
         sha = run_git(git_repo, "rev-parse", "HEAD")
@@ -278,7 +368,7 @@ class TestRequiredCheckAllowlist:
             for name in authorize_module.REQUIRED_CHECK_NAMES
         ]
 
-        authorize_module.authorize(sha, runs, "main", cwd=git_repo)
+        authorize_module.authorize(sha, runs, ("main",), cwd=git_repo)
 
     def test_a_single_missing_required_check_among_an_otherwise_full_set_is_refused(
         self, git_repo
@@ -291,7 +381,7 @@ class TestRequiredCheckAllowlist:
         with pytest.raises(
             authorize_module.AuthorizationError, match=re.escape(dropped)
         ):
-            authorize_module.authorize(sha, runs, "main", cwd=git_repo)
+            authorize_module.authorize(sha, runs, ("main",), cwd=git_repo)
 
     def test_authorize_refuses_a_failed_chart_check_when_every_other_check_passes(
         self, git_repo
@@ -309,7 +399,7 @@ class TestRequiredCheckAllowlist:
         with pytest.raises(
             authorize_module.AuthorizationError, match=re.escape(chart_check)
         ):
-            authorize_module.authorize(sha, runs, "main", cwd=git_repo)
+            authorize_module.authorize(sha, runs, ("main",), cwd=git_repo)
 
 
 class TestFetchCheckRuns:
@@ -429,7 +519,7 @@ class TestFetchCheckRunsPagination:
             )
 
         authorize_module.authorize(
-            sha, runs, "main", cwd=git_repo, required_names=TEST_REQUIRED_NAMES
+            sha, runs, ("main",), cwd=git_repo, required_names=TEST_REQUIRED_NAMES
         )
 
     def test_stops_when_a_page_reports_nothing_even_if_total_count_implied_more(
@@ -486,7 +576,7 @@ class TestAuthorizeExcludesCurrentRun:
         authorize_module.authorize(
             sha,
             runs,
-            "main",
+            ("main",),
             cwd=git_repo,
             exclude_run_id=CURRENT_RUN_ID,
             required_names=TEST_REQUIRED_NAMES,
@@ -508,7 +598,7 @@ class TestAuthorizeExcludesCurrentRun:
         authorize_module.authorize(
             sha,
             runs,
-            "main",
+            ("main",),
             cwd=git_repo,
             exclude_run_id=CURRENT_RUN_ID,
             required_names=TEST_REQUIRED_NAMES,
@@ -526,7 +616,7 @@ class TestAuthorizeExcludesCurrentRun:
             authorize_module.authorize(
                 sha,
                 runs,
-                "main",
+                ("main",),
                 cwd=git_repo,
                 exclude_run_id=CURRENT_RUN_ID,
                 required_names=TEST_REQUIRED_NAMES,
@@ -544,7 +634,7 @@ class TestAuthorizeExcludesCurrentRun:
             authorize_module.authorize(
                 sha,
                 runs,
-                "main",
+                ("main",),
                 cwd=git_repo,
                 exclude_run_id=CURRENT_RUN_ID,
                 required_names=TEST_REQUIRED_NAMES,
@@ -563,7 +653,7 @@ class TestAuthorizeExcludesCurrentRun:
             authorize_module.authorize(
                 sha,
                 runs,
-                "main",
+                ("main",),
                 cwd=git_repo,
                 exclude_run_id=CURRENT_RUN_ID,
                 required_names=TEST_REQUIRED_NAMES,
@@ -622,7 +712,7 @@ class TestMain:
         monkeypatch.setenv("GITHUB_RUN_ID", CURRENT_RUN_ID)
 
         exit_code = authorize_module.main(
-            [sha, "--repo", "curie-eng/curie", "--main-ref", "main"]
+            [sha, "--repo", "curie-eng/curie", "--reviewed-ref", "main"]
         )
 
         assert exit_code == 0
@@ -640,7 +730,7 @@ class TestMain:
         monkeypatch.delenv("GITHUB_RUN_ID", raising=False)
 
         exit_code = authorize_module.main(
-            [sha, "--repo", "curie-eng/curie", "--main-ref", "main"]
+            [sha, "--repo", "curie-eng/curie", "--reviewed-ref", "main"]
         )
 
         assert exit_code == 0
@@ -661,7 +751,7 @@ class TestMain:
         monkeypatch.setenv("GITHUB_RUN_ID", OTHER_RUN_ID)
 
         exit_code = authorize_module.main(
-            [sha, "--repo", "curie-eng/curie", "--main-ref", "main"]
+            [sha, "--repo", "curie-eng/curie", "--reviewed-ref", "main"]
         )
 
         assert exit_code == 1
@@ -691,7 +781,7 @@ class TestMainLookupFailures:
         monkeypatch.chdir(git_repo)
         monkeypatch.setenv("GITHUB_RUN_ID", CURRENT_RUN_ID)
         return authorize_module.main(
-            [sha, "--repo", "curie-eng/curie", "--main-ref", "main"]
+            [sha, "--repo", "curie-eng/curie", "--reviewed-ref", "main"]
         )
 
     def test_gh_api_failure_refuses_with_a_message_naming_the_lookup(
@@ -759,6 +849,7 @@ class TestMainLookupFailures:
 
 CI_YAML = REPO_ROOT / ".github" / "workflows" / "ci.yaml"
 HELM_CI_YAML = REPO_ROOT / ".github" / "workflows" / "helm-ci.yaml"
+RELEASE_YAML = REPO_ROOT / ".github" / "workflows" / "release.yaml"
 
 _MATRIX_REF = re.compile(r"\$\{\{\s*matrix\.([A-Za-z0-9_]+)\s*\}\}")
 
@@ -795,6 +886,96 @@ def ci_job_check_run_names() -> set[str]:
 def helm_ci_job_check_run_names() -> set[str]:
     doc = yaml.safe_load(HELM_CI_YAML.read_text())
     return {job["name"] for job in doc["jobs"].values() if job.get("name")}
+
+
+class TestReleaseWorkflowContract:
+    def test_release_branch_sources_are_anchored_and_wired_to_authorization(self):
+        source = RELEASE_YAML.read_text()
+        workflow = yaml.load(source, Loader=yaml.BaseLoader)
+        trigger = workflow["on"]["push"]
+
+        assert trigger["branches"] == ["main", "next"]
+        assert trigger["tags"] == ["v*"]
+
+        trigger_source = re.search(
+            r"(?ms)^on:\n  push:\n(?P<body>.*?)(?=^permissions:)", source
+        )
+        assert trigger_source is not None
+        anchors = {}
+        for branch in ("main", "next"):
+            anchor = re.search(
+                rf"&(?P<name>[A-Za-z_][A-Za-z0-9_-]*)\s+['\"]?{branch}['\"]?",
+                trigger_source.group("body"),
+            )
+            assert anchor is not None
+            anchors[branch] = anchor.group("name")
+        assert len(set(anchors.values())) == 2
+
+        authorization_source = re.search(
+            r"(?ms)^  authorize-release:\n(?P<body>.*?)(?=^  build:)", source
+        )
+        assert authorization_source is not None
+        env_source = re.search(
+            r"(?ms)^    env:\n(?P<body>(?:^      [^\n]+\n)+)",
+            authorization_source.group("body"),
+        )
+        assert env_source is not None
+        aliases = dict(
+            re.findall(
+                r"^      (?P<name>[A-Za-z_][A-Za-z0-9_]*): \*(?P<anchor>[^\s]+)\s*$",
+                env_source.group("body"),
+                re.MULTILINE,
+            )
+        )
+        assert set(aliases.values()) == set(anchors.values())
+
+        authorization = workflow["jobs"]["authorize-release"]
+        authorization_env = authorization["env"]
+        assert set(authorization_env) == set(aliases)
+        assert {authorization_env[name] for name in aliases} == {"main", "next"}
+
+        command = next(
+            step["run"]
+            for step in authorization["steps"]
+            if "release/authorize.py" in step.get("run", "")
+        )
+        reviewed_ref_envs = re.findall(
+            r"--reviewed-ref\s+origin/\$\{\{\s*env\.([A-Za-z_][A-Za-z0-9_]*)\s*\}\}",
+            command,
+        )
+        assert "--main-ref" not in command
+        assert set(reviewed_ref_envs) == set(authorization_env)
+        assert len(reviewed_ref_envs) == len(authorization_env) == 2
+        assert {authorization_env[name] for name in reviewed_ref_envs} == {"main", "next"}
+
+        overlay = re.search(
+            r"git checkout origin/\$\{\{\s*env\.([A-Za-z_][A-Za-z0-9_]*)\s*\}\}\s+-- release/",
+            authorization_source.group("body"),
+        )
+        assert overlay is not None
+        assert authorization_env[overlay.group(1)] == "main"
+
+    def test_continuous_metadata_and_worker_local_base_use_the_push_sha(self):
+        workflow = yaml.load(RELEASE_YAML.read_text(), Loader=yaml.BaseLoader)
+
+        for job_name in ("merge", "worker-local-merge"):
+            metadata = next(
+                step
+                for step in workflow["jobs"][job_name]["steps"]
+                if step.get("name") == "Image metadata"
+            )
+            tags = metadata["with"]["tags"]
+            assert "type=sha,format=long" in tags
+            assert "type=raw,value=latest,enable={{is_default_branch}}" in tags
+
+        base_tag_script = next(
+            step["run"]
+            for step in workflow["jobs"]["worker-local-build"]["steps"]
+            if step.get("name") == "Compute base tag"
+        )
+        assert 'echo "v=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"' in base_tag_script
+        assert 'echo "v=sha-${GITHUB_SHA}" >> "$GITHUB_OUTPUT"' in base_tag_script
+        assert 'echo "v=latest" >> "$GITHUB_OUTPUT"' not in base_tag_script
 
 
 class TestRequiredNamesMatchCiWorkflows:
@@ -894,7 +1075,7 @@ class TestMixedPassFailRequiredCheck:
             authorize_module.authorize(
                 sha,
                 self.MIXED_CI,
-                "main",
+                ("main",),
                 cwd=git_repo,
                 required_names=TEST_REQUIRED_NAMES,
             )
@@ -955,7 +1136,7 @@ class TestSkippedRequiredCheck:
         with pytest.raises(
             authorize_module.AuthorizationError, match="required check-run"
         ):
-            authorize_module.authorize(sha, runs, "main", cwd=git_repo)
+            authorize_module.authorize(sha, runs, ("main",), cwd=git_repo)
 
     def test_a_required_name_with_both_a_success_and_a_skipped_run_is_refused(
         self, git_repo
@@ -976,7 +1157,7 @@ class TestSkippedRequiredCheck:
             authorize_module.AuthorizationError, match="required check-run"
         ):
             authorize_module.authorize(
-                sha, runs, "main", cwd=git_repo, required_names=TEST_REQUIRED_NAMES
+                sha, runs, ("main",), cwd=git_repo, required_names=TEST_REQUIRED_NAMES
             )
 
 
@@ -1005,7 +1186,7 @@ class TestLegitimateSkips:
         authorize_module.authorize(
             sha,
             CHECK_RUNS_ALL_GREEN,
-            "main",
+            ("main",),
             cwd=git_repo,
             required_names=TEST_REQUIRED_NAMES,
         )

--- a/tools/ci-retry-gate/tests/test_retry_eligibility.py
+++ b/tools/ci-retry-gate/tests/test_retry_eligibility.py
@@ -106,7 +106,7 @@ PROTECTED_STEPS = frozenset(
         (
             "release.yaml",
             "authorize-release",
-            "Tag's commit must be reviewed, on main, and fully checked",
+            "Tag's commit must be reviewed, on an allowed branch, and fully checked",
         ),
         ("release.yaml", "release", "Gate the asset set and build the checksum manifest"),
         ("release.yaml", "release", "Refuse to re-release an already-published tag"),


### PR DESCRIPTION
Closes #1476

Release tags now authorize from exactly `main` or `next`, while missing or unresolvable refs still refuse. Continuous image publication now runs on both release branches, and worker local images consume the base image from the same pushed SHA. The release train runbooks also preserve authorization safety when `next` is retired or recreated.

## Done check

1. [x] Failing authorization and workflow tests were committed before implementation. Verified before squash with commits 81b02b6d then 8fac3045.
2. [x] All production and test edits were performed in isolated delegated contexts.
3. [x] Public return types are unchanged. New authorization error cases fail closed.
4. [x] Independent code review approved after the runbook fix.
5. [x] Independent scope review mapped every hunk to issue criteria or required documentation safety.
6. [x] Main and next parity is constructed from one anchored branch set and covered through both direct authorization paths.
7. [x] The refusal guard was executed against neither branch and against a valid ref paired with an unresolvable ref. All three targeted guard tests passed.
8. [x] Consolidation applied no cleanup because no simplify capability was available and repeated review found no blocking simplification.
9. [x] Security review approved the fail closed behavior and retirement ordering.
10. [ ] Live next image publication is pending. This change must first merge to `main` and then reach `next`; the first next push must confirm all six long SHA manifests and that `latest` is absent. Actionlint parsing passes now.
11. [x] Full affected validation passes: 88 release tests, Ruff, mypy, Actionlint, lock check, and documentation checks.
12. [x] Lint is clean on every edited code and workflow file.