### PR TITLE
Add fix pin verification

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,6 +128,8 @@ services (Slack, Anthropic, GitHub); NEVER mock Postgres/Valkey/Langfuse -- run
 integration tests against the dev stack below. A change that only makes tests
 pass by weakening assertions is a regression. At parity seams, include at least
 one negative or secondary-path test per AC (see the parity-seam registry).
+A fix PR changing `apps/*/tests/`, `packages/*/tests/`, `cli/tests/`, or `charts/curie/ci/` is expected to be verifiable with the exact command
+`curie dev verify-fix-pin <CHANGE> <SELECTOR>`.
 Assertions about an external API or SDK's shape or auth must be grounded in
 provider docs or observed behavior, cited in a test comment, never in the
 implementation's own assumption. Any read-modify-write on a versioned row needs a

--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -3925,6 +3925,27 @@ export const commandManifest = {
           "name": "chart-check"
         },
         {
+          "about": "Prove a changed test fails when only the change's product hunks are reversed",
+          "args": [
+            {
+              "global": false,
+              "help": "Commit or pull request to verify",
+              "id": "change",
+              "positional": true,
+              "required": true
+            },
+            {
+              "global": false,
+              "help": "Changed test selector to run before and after reversal",
+              "id": "selector",
+              "positional": true,
+              "required": true
+            }
+          ],
+          "hidden": false,
+          "name": "verify-fix-pin"
+        },
+        {
           "about": "Run the scripted CLI end-to-end test (`bash cli/scripts/e2e.sh`)",
           "hidden": false,
           "name": "e2e"

--- a/cli/README.md
+++ b/cli/README.md
@@ -579,11 +579,33 @@ release binary has no dev scripts.
 |---|---|
 | `curie dev contracts` | `bash scripts/check-contracts.sh` -- check the frozen contracts. |
 | `curie dev chart-check` | Discover direct executable chart assertions under `charts/curie/ci`, run every one, report each result, and return aggregate failure after all scripts finish. |
+| `curie dev verify-fix-pin <CHANGE> <SELECTOR>` | Prove that a fix makes the selected test fail when only its product files are reversed. |
 | `curie dev e2e` | `bash cli/scripts/e2e.sh` -- the scripted CLI end-to-end test. |
 | `curie dev e2e-ladder` | `bash cli/scripts/e2e-ladder.sh` -- the cold-start parity ladder (skill, local, cluster rungs). |
 | `curie dev field-parity` | `bash cli/scripts/check-field-parity.sh` -- assert CLI `api.rs` mirror structs cover their platform API model fields (#691), and CLI `commands.rs`/`spec.rs` mirror structs cover the frozen `packages/plugin-format` schema's fields (#701). |
 | `curie dev emit-parity` | `bash cli/scripts/check-emit-parity.sh` -- assert a `CliOutput::to_json` that hand-projects a mirror struct into a `json!` literal covers that struct's fields, one hop downstream of `field-parity` (#699). |
 | `curie dev wire-tolerance` | `bash scripts/check-wire-tolerance.sh` -- assert every direct `ClassName.model_validate*(...)` call on an `_AciModel` subclass threads `READER_CONTEXT` or is a declared exception (#625). |
+
+Use `curie dev verify-fix-pin <CHANGE> <SELECTOR>` from a source checkout to
+verify a fix commit or pull request. `<CHANGE>` accepts a committed change
+resolvable by Git or a pull request number or URL. The selector must be one of
+these forms:
+
+1. `apps/.../tests/test_x.py::test_y` or `packages/.../tests/test_x.py::test_y`
+   for a Python test.
+2. `cli/tests/name.rs::test_name` for a Rust integration test.
+3. `charts/curie/ci/name.sh` for a chart check script.
+
+The command runs the selector at the current `HEAD`, reverses only the change's
+non test files in a disposable worktree, then runs the selector again. `PINNED`
+is printed and exits successfully for any nonzero selector result after a clean
+reversal, including compile or import failures. `UNPINNED` is
+printed and exits nonzero when it remains green.
+
+It refuses invalid commit or pull request references, root commits, changes
+without classified test files or product files, selectors outside the three
+forms or not changed by the reference, a red baseline, and reverse patch
+conflicts. Inline tests in product files are not inferred.
 
 ### Building the runner image from source
 

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -3922,6 +3922,27 @@
           "name": "chart-check"
         },
         {
+          "about": "Prove a changed test fails when only the change's product hunks are reversed",
+          "args": [
+            {
+              "global": false,
+              "help": "Commit or pull request to verify",
+              "id": "change",
+              "positional": true,
+              "required": true
+            },
+            {
+              "global": false,
+              "help": "Changed test selector to run before and after reversal",
+              "id": "selector",
+              "positional": true,
+              "required": true
+            }
+          ],
+          "hidden": false,
+          "name": "verify-fix-pin"
+        },
+        {
           "about": "Run the scripted CLI end-to-end test (`bash cli/scripts/e2e.sh`)",
           "hidden": false,
           "name": "e2e"

--- a/cli/scripts/verify-fix-pin.sh
+++ b/cli/scripts/verify-fix-pin.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "usage: verify-fix-pin.sh <change> <selector>" >&2
+  exit 2
+}
+
+fail() {
+  echo "$*" >&2
+  exit 1
+}
+
+if [[ $# -ne 2 ]]; then
+  usage
+fi
+
+change=$1
+selector=$2
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || fail "not inside a git repository"
+
+temp_root=$(mktemp -d)
+scratch="$temp_root/worktree"
+patch_file="$temp_root/change.patch"
+names_file="$temp_root/changed-files"
+worktree_added=0
+
+cleanup() {
+  local status=$?
+  local cleanup_status=0
+  trap - EXIT
+
+  if (( worktree_added )); then
+    git -C "$repo_root" worktree remove --force "$scratch" >/dev/null 2>&1 || cleanup_status=1
+  fi
+  rm -rf -- "$temp_root" || cleanup_status=1
+
+  if (( cleanup_status != 0 )); then
+    echo "failed to clean up the verification worktree" >&2
+    exit 1
+  fi
+  exit "$status"
+}
+trap cleanup EXIT
+
+changed_files=()
+change_kind=pull_request
+if [[ ! "$change" =~ ^[0-9]+$ && ! "$change" =~ ^https://github\.com/[^/]+/[^/]+/pull/[0-9]+/?$ ]] && \
+  commit=$(git -C "$repo_root" rev-parse --verify "${change}^{commit}" 2>/dev/null); then
+  change_kind=commit
+fi
+
+if [[ "$change_kind" == commit ]]; then
+  parent=$(git -C "$repo_root" rev-parse --verify "${commit}^1" 2>/dev/null) || \
+    fail "commit $commit has no first parent"
+  git -C "$repo_root" diff --binary "$parent" "$commit" -- >"$patch_file"
+  git -C "$repo_root" diff --name-only -z "$parent" "$commit" -- >"$names_file"
+  while IFS= read -r -d '' path; do
+    changed_files+=("$path")
+  done <"$names_file"
+else
+  gh pr view "$change" >/dev/null || \
+    fail "change is neither a commit nor a pull request: $change"
+  gh pr diff "$change" >"$patch_file" || \
+    fail "could not read pull request patch: $change"
+  gh pr diff "$change" --name-only >"$names_file" || \
+    fail "could not read pull request files: $change"
+  while IFS= read -r path || [[ -n "$path" ]]; do
+    [[ -n "$path" ]] && changed_files+=("$path")
+  done <"$names_file"
+fi
+
+if [[ ${#changed_files[@]} -eq 0 ]]; then
+  fail "change contains no files"
+fi
+
+is_test_path() {
+  case "$1" in
+    apps/*/tests/* | packages/*/tests/* | cli/tests/* | charts/curie/ci/*)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+test_files=()
+product_files=()
+for path in "${changed_files[@]}"; do
+  if is_test_path "$path"; then
+    test_files+=("$path")
+  else
+    product_files+=("$path")
+  fi
+done
+
+if [[ ${#test_files[@]} -eq 0 ]]; then
+  fail "change contains no test files"
+fi
+if [[ ${#product_files[@]} -eq 0 ]]; then
+  fail "change contains no product files to reverse"
+fi
+
+selector_file=
+selector_kind=
+rust_target=
+rust_test=
+case "$selector" in
+  apps/*/tests/*.py::* | packages/*/tests/*.py::*)
+    selector_file=${selector%%::*}
+    if [[ "$selector" == "$selector_file" || -z "${selector#*::}" ]]; then
+      fail "unsupported selector: $selector"
+    fi
+    selector_kind=python
+    ;;
+  cli/tests/*.rs::*)
+    selector_file=${selector%%::*}
+    rust_test=${selector#*::}
+    if [[ -z "$rust_test" || "$rust_test" == *::* ]]; then
+      fail "unsupported selector: $selector"
+    fi
+    rust_target=${selector_file##*/}
+    rust_target=${rust_target%.rs}
+    selector_kind=rust
+    ;;
+  charts/curie/ci/*.sh)
+    selector_file=$selector
+    selector_kind=chart
+    ;;
+  *)
+    fail "unsupported selector: $selector"
+    ;;
+esac
+
+selector_changed=0
+for path in "${test_files[@]}"; do
+  if [[ "$path" == "$selector_file" ]]; then
+    selector_changed=1
+    break
+  fi
+done
+if (( selector_changed == 0 )); then
+  fail "selector file was not changed by $change: $selector_file"
+fi
+
+head_commit=$(git -C "$repo_root" rev-parse --verify 'HEAD^{commit}') || \
+  fail "could not resolve current HEAD"
+git -C "$repo_root" worktree add --detach "$scratch" "$head_commit" >/dev/null
+worktree_added=1
+
+run_selector() {
+  case "$selector_kind" in
+    python)
+      (cd "$scratch" && uv run --python 3.13 pytest "$selector")
+      ;;
+    rust)
+      (
+        cd "$scratch"
+        cargo test --manifest-path cli/Cargo.toml --test "$rust_target" "$rust_test"
+      )
+      ;;
+    chart)
+      (cd "$scratch" && bash "$selector")
+      ;;
+  esac
+}
+
+if ! run_selector; then
+  fail "baseline selector is red: $selector"
+fi
+
+include_args=()
+for path in "${product_files[@]}"; do
+  include_args+=("--include=$path")
+done
+
+if ! git -C "$scratch" apply --check --reverse "${include_args[@]}" "$patch_file"; then
+  echo "could not reverse the changed product files:" >&2
+  printf '  %s\n' "${product_files[@]}" >&2
+  exit 1
+fi
+git -C "$scratch" apply --reverse "${include_args[@]}" "$patch_file"
+
+if run_selector; then
+  echo "UNPINNED"
+  exit 1
+fi
+
+echo "PINNED"

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -591,10 +591,10 @@ fn seed_env_if_missing(root: &Path) -> Result<EnvSeed> {
 }
 
 /// `curie dev <script>`: run a repo dev script by relative path. Thin wrapper
-/// -- finds the repo root, confirms the script exists, shells `bash <script>`
+/// -- finds the repo root, confirms the script exists, shells `bash <script> [args]`
 /// from the root, streams its output, and propagates its exit code. A release
 /// binary has no scripts, so this errors clearly outside a checkout.
-pub async fn dev_script(rel_path: &str) -> Result<()> {
+pub async fn dev_script(rel_path: &str, args: &[&str]) -> Result<()> {
     let ui = crate::ui::ui();
     let root = find_repo_root().context(
         "runner/Dockerfile not found here or in any parent directory. Run `curie dev` \
@@ -607,6 +607,7 @@ pub async fn dev_script(rel_path: &str) -> Result<()> {
     ui.note(&format!("=== bash {rel_path} (in {}) ===", root.display()));
     let status = tokio::process::Command::new("bash")
         .arg(rel_path)
+        .args(args)
         .current_dir(&root)
         .status()
         .await

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -497,6 +497,13 @@ enum DevAction {
     Contracts,
     /// Discover and run every executable shell assertion directly in charts/curie/ci.
     ChartCheck,
+    /// Prove a changed test fails when only the change's product hunks are reversed.
+    VerifyFixPin {
+        /// Commit or pull request to verify.
+        change: String,
+        /// Changed test selector to run before and after reversal.
+        selector: String,
+    },
     /// Run the scripted CLI end-to-end test (`bash cli/scripts/e2e.sh`).
     E2e,
     /// Run the cold-start parity ladder across the skill, local, and cluster
@@ -1980,33 +1987,44 @@ async fn run(command: Option<Command>) -> Result<()> {
             SecretsAction::Unset { name } => secrets::unset(secrets::UnsetSecretOpts { name }),
         },
         Some(Command::Dev { action }) => match action {
-            DevAction::Contracts => commands::dev_script("scripts/check-contracts.sh").await,
+            DevAction::Contracts => commands::dev_script("scripts/check-contracts.sh", &[]).await,
             DevAction::ChartCheck => commands::chart_check().await,
-            DevAction::E2e => commands::dev_script("cli/scripts/e2e.sh").await,
-            DevAction::E2eLadder => commands::dev_script("cli/scripts/e2e-ladder.sh").await,
-            DevAction::ChartRuntimeE2e => {
-                commands::dev_script("scripts/chart-runtime-e2e.sh").await
+            DevAction::VerifyFixPin { change, selector } => {
+                commands::dev_script(
+                    "cli/scripts/verify-fix-pin.sh",
+                    &[change.as_str(), selector.as_str()],
+                )
+                .await
             }
-            DevAction::DocsLint => commands::dev_script("scripts/check-docs.sh").await,
-            DevAction::PluginCompat => commands::dev_script("scripts/check-plugin-compat.sh").await,
+            DevAction::E2e => commands::dev_script("cli/scripts/e2e.sh", &[]).await,
+            DevAction::E2eLadder => commands::dev_script("cli/scripts/e2e-ladder.sh", &[]).await,
+            DevAction::ChartRuntimeE2e => {
+                commands::dev_script("scripts/chart-runtime-e2e.sh", &[]).await
+            }
+            DevAction::DocsLint => commands::dev_script("scripts/check-docs.sh", &[]).await,
+            DevAction::PluginCompat => {
+                commands::dev_script("scripts/check-plugin-compat.sh", &[]).await
+            }
             DevAction::EvalFalsifiability => {
-                commands::dev_script("cli/scripts/eval-falsifiability.sh").await
+                commands::dev_script("cli/scripts/eval-falsifiability.sh", &[]).await
             }
             DevAction::FieldParity => {
-                commands::dev_script("cli/scripts/check-field-parity.sh").await
+                commands::dev_script("cli/scripts/check-field-parity.sh", &[]).await
             }
-            DevAction::EmitParity => commands::dev_script("cli/scripts/check-emit-parity.sh").await,
+            DevAction::EmitParity => {
+                commands::dev_script("cli/scripts/check-emit-parity.sh", &[]).await
+            }
             DevAction::SchemaBaseline => {
-                commands::dev_script("cli/scripts/refresh-schema-baseline.sh").await
+                commands::dev_script("cli/scripts/refresh-schema-baseline.sh", &[]).await
             }
             DevAction::NetpolCheck => {
-                commands::dev_script("scripts/check-netpol-enforcement.sh").await
+                commands::dev_script("scripts/check-netpol-enforcement.sh", &[]).await
             }
             DevAction::VersionCheck => {
-                commands::dev_script("scripts/check-version-consistency.sh").await
+                commands::dev_script("scripts/check-version-consistency.sh", &[]).await
             }
             DevAction::WireTolerance => {
-                commands::dev_script("scripts/check-wire-tolerance.sh").await
+                commands::dev_script("scripts/check-wire-tolerance.sh", &[]).await
             }
             DevAction::BumpVersion { version, dry_run } => {
                 commands::bump_version(&version, dry_run).await

--- a/cli/tests/command_surface.rs
+++ b/cli/tests/command_surface.rs
@@ -169,6 +169,33 @@ fn process_dev_help_lists_the_plugin_compat_gate() {
     );
 }
 
+#[test]
+fn process_dev_help_lists_verify_fix_pin() {
+    let output = run_help(&["dev"]);
+    assert!(
+        output.status.success(),
+        "expected success for dev help\n{}",
+        output_text(&output)
+    );
+    let text = output_text(&output);
+    assert!(
+        help_lists_subcommand(&text, "verify-fix-pin"),
+        "missing verify-fix-pin\n{text}"
+    );
+
+    let leaf = run_help(&["dev", "verify-fix-pin"]);
+    assert!(
+        leaf.status.success(),
+        "expected success for verify-fix-pin help\n{}",
+        output_text(&leaf)
+    );
+    let leaf_text = output_text(&leaf);
+    assert!(
+        leaf_text.contains("<CHANGE>") && leaf_text.contains("<SELECTOR>"),
+        "verify-fix-pin help must require a change and selector\n{leaf_text}"
+    );
+}
+
 /// The checked-in manifest must equal what `curie schema` emits from the live
 /// clap grammar. This is the generated-artifact + CI drift gate (mirroring the
 /// schema-export discipline for `packages/aci-protocol` / `packages/plugin-format`):

--- a/cli/tests/verify_fix_pin.rs
+++ b/cli/tests/verify_fix_pin.rs
@@ -1,0 +1,675 @@
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_curie")
+}
+
+fn output_text(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stdout).into_owned() + &String::from_utf8_lossy(&output.stderr)
+}
+
+fn write_file(root: &Path, rel: &str, body: &str) {
+    let path = root.join(rel);
+    fs::create_dir_all(path.parent().expect("file has a parent")).expect("create parent");
+    fs::write(path, body).expect("write fixture file");
+}
+
+fn write_exec(root: &Path, name: &str, body: &str) {
+    let path = root.join(name);
+    fs::write(&path, body).expect("write executable");
+    let mut permissions = fs::metadata(&path)
+        .expect("executable metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(path, permissions).expect("make executable");
+}
+
+fn git(root: &Path, args: &[&str]) -> Output {
+    let output = Command::new("git")
+        .arg("-c")
+        .arg("commit.gpgsign=false")
+        .arg("-c")
+        .arg("core.hooksPath=/dev/null")
+        .arg("-C")
+        .arg(root)
+        .args(args)
+        .output()
+        .expect("run git");
+    assert!(
+        output.status.success(),
+        "git command failed\n{}",
+        output_text(&output)
+    );
+    output
+}
+
+fn stdout_has_result(output: &Output, result: &str) -> bool {
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .any(|line| line.trim() == result)
+}
+
+struct Fixture {
+    temp: tempfile::TempDir,
+    root: PathBuf,
+    tools: PathBuf,
+}
+
+impl Fixture {
+    fn new(test_path: &str, test_body: &str) -> Self {
+        let temp = tempfile::tempdir().expect("create temporary directory");
+        let root = temp.path().join("repo");
+        let tools = temp.path().join("tools");
+        fs::create_dir_all(&root).expect("create repository");
+        fs::create_dir_all(&tools).expect("create tools directory");
+
+        write_file(&root, "runner/Dockerfile", "value=old\n");
+        write_file(&root, test_path, test_body);
+        let source_script =
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("scripts/verify-fix-pin.sh");
+        let script = fs::read_to_string(source_script).expect("read checked in verify script");
+        write_file(&root, "cli/scripts/verify-fix-pin.sh", &script);
+
+        git(&root, &["init", "-q"]);
+        git(&root, &["config", "user.name", "Curie Test"]);
+        git(&root, &["config", "user.email", "curie@example.com"]);
+        git(&root, &["add", "."]);
+        git(&root, &["commit", "-q", "-m", "Initial fixture"]);
+
+        Self { temp, root, tools }
+    }
+
+    fn write(&self, rel: &str, body: &str) {
+        write_file(&self.root, rel, body);
+    }
+
+    fn commit(&self, changes: &[(&str, &str)], message: &str) -> String {
+        for (path, body) in changes {
+            self.write(path, body);
+        }
+        git(&self.root, &["add", "."]);
+        git(&self.root, &["commit", "-q", "-m", message]);
+        self.head()
+    }
+
+    fn head(&self) -> String {
+        String::from_utf8(git(&self.root, &["rev-parse", "HEAD"]).stdout)
+            .expect("head is UTF 8")
+            .trim()
+            .to_owned()
+    }
+
+    fn patch(&self, base: &str, head: &str) -> Vec<u8> {
+        git(&self.root, &["diff", base, head]).stdout
+    }
+
+    fn command(&self, change: &str, selector: &str) -> Command {
+        let mut paths = vec![self.tools.clone()];
+        if let Some(path) = std::env::var_os("PATH") {
+            paths.extend(std::env::split_paths(&path));
+        }
+        let path = std::env::join_paths(paths).expect("join PATH");
+
+        let mut command = Command::new(bin());
+        command
+            .current_dir(&self.root)
+            .args(["dev", "verify-fix-pin", change, selector])
+            .env("PATH", path);
+        command
+    }
+
+    fn assert_clean_and_single_worktree(&self) {
+        let status = git(&self.root, &["status", "--porcelain"]);
+        assert!(
+            status.stdout.is_empty(),
+            "the source repository changed\n{}",
+            String::from_utf8_lossy(&status.stdout)
+        );
+        let worktrees = git(&self.root, &["worktree", "list", "--porcelain"]);
+        let count = String::from_utf8_lossy(&worktrees.stdout)
+            .lines()
+            .filter(|line| line.starts_with("worktree "))
+            .count();
+        assert_eq!(count, 1, "the scratch worktree was not removed");
+    }
+
+    fn external_path(&self, name: &str) -> PathBuf {
+        self.temp.path().join(name)
+    }
+}
+
+const CHART_OLD: &str = r#"#!/bin/sh
+set -eu
+grep -qx 'value=old' runner/Dockerfile
+"#;
+
+const CHART_FIXED: &str = r#"#!/bin/sh
+set -eu
+grep -qx 'value=fixed' runner/Dockerfile
+"#;
+
+#[test]
+fn commit_is_pinned_only_when_reversing_product_code_breaks_the_changed_chart_assertion() {
+    let fixture = Fixture::new("charts/curie/ci/assert-pin.sh", CHART_OLD);
+    let change = fixture.commit(
+        &[
+            ("runner/Dockerfile", "value=fixed\n"),
+            ("charts/curie/ci/assert-pin.sh", CHART_FIXED),
+        ],
+        "Fix chart behavior",
+    );
+
+    let output = fixture
+        .command(&change, "charts/curie/ci/assert-pin.sh")
+        .output()
+        .expect("run verify fix pin");
+    assert!(
+        output.status.success(),
+        "a pinned change must succeed\n{}",
+        output_text(&output)
+    );
+    assert!(
+        stdout_has_result(&output, "PINNED"),
+        "stdout must report PINNED\n{}",
+        output_text(&output)
+    );
+    assert_eq!(
+        fs::read_to_string(fixture.root.join("runner/Dockerfile")).expect("read source behavior"),
+        "value=fixed\n"
+    );
+    fixture.assert_clean_and_single_worktree();
+}
+
+#[test]
+fn commit_is_unpinned_when_the_changed_assertion_stays_green_after_product_reversal() {
+    let fixture = Fixture::new(
+        "charts/curie/ci/assert-pin.sh",
+        "#!/bin/sh\nset -eu\ntest -s runner/Dockerfile\n",
+    );
+    let change = fixture.commit(
+        &[
+            ("runner/Dockerfile", "value=fixed\n"),
+            (
+                "charts/curie/ci/assert-pin.sh",
+                "#!/bin/sh\nset -eu\ntest -f runner/Dockerfile\n",
+            ),
+        ],
+        "Add weak chart assertion",
+    );
+
+    let output = fixture
+        .command(&change, "charts/curie/ci/assert-pin.sh")
+        .output()
+        .expect("run verify fix pin");
+    assert!(
+        !output.status.success(),
+        "an unpinned change must fail\n{}",
+        output_text(&output)
+    );
+    assert!(
+        stdout_has_result(&output, "UNPINNED"),
+        "stdout must report UNPINNED\n{}",
+        output_text(&output)
+    );
+    fixture.assert_clean_and_single_worktree();
+}
+
+#[test]
+fn change_without_a_test_hunk_refuses_before_running_the_selector() {
+    let fixture = Fixture::new(
+        "charts/curie/ci/assert-pin.sh",
+        "#!/bin/sh\nset -eu\nprintf 'run\\n' >> \"$VERIFY_RUN_LOG\"\n",
+    );
+    let change = fixture.commit(
+        &[("runner/Dockerfile", "value=fixed\n")],
+        "Change behavior only",
+    );
+    let run_log = fixture.external_path("run.log");
+
+    let output = fixture
+        .command(&change, "charts/curie/ci/assert-pin.sh")
+        .env("VERIFY_RUN_LOG", &run_log)
+        .output()
+        .expect("run verify fix pin");
+    let shown = output_text(&output);
+    let lower = shown.to_lowercase();
+    assert!(
+        !output.status.success(),
+        "missing test hunks must fail\n{shown}"
+    );
+    assert!(
+        lower.contains("no test") && lower.contains("file"),
+        "the refusal must explain that the change has no test files\n{shown}"
+    );
+    assert!(!run_log.exists(), "the selector must not run");
+    assert!(!stdout_has_result(&output, "PINNED"));
+    assert!(!stdout_has_result(&output, "UNPINNED"));
+    fixture.assert_clean_and_single_worktree();
+}
+
+#[test]
+fn overlapping_later_edit_refuses_before_the_post_reversal_selector_run() {
+    let fixture = Fixture::new(
+        "charts/curie/ci/assert-pin.sh",
+        "#!/bin/sh\nset -eu\nprintf 'run\\n' >> \"$VERIFY_RUN_LOG\"\ntest -s runner/Dockerfile\n",
+    );
+    let change = fixture.commit(
+        &[
+            ("runner/Dockerfile", "value=fixed\n"),
+            (
+                "charts/curie/ci/assert-pin.sh",
+                "#!/bin/sh\nset -eu\nprintf 'run\\n' >> \"$VERIFY_RUN_LOG\"\ngrep -q '^value=' runner/Dockerfile\n",
+            ),
+        ],
+        "Fix behavior with assertion",
+    );
+    fixture.commit(
+        &[("runner/Dockerfile", "value=later\n")],
+        "Change the same behavior later",
+    );
+    let run_log = fixture.external_path("run.log");
+
+    let output = fixture
+        .command(&change, "charts/curie/ci/assert-pin.sh")
+        .env("VERIFY_RUN_LOG", &run_log)
+        .output()
+        .expect("run verify fix pin");
+    let shown = output_text(&output);
+    assert!(
+        !output.status.success(),
+        "a reverse conflict must fail\n{shown}"
+    );
+    assert!(
+        shown.contains("runner/Dockerfile") && shown.to_lowercase().contains("reverse"),
+        "the refusal must name the path that cannot be reversed\n{shown}"
+    );
+    assert_eq!(
+        fs::read_to_string(&run_log).expect("read selector log"),
+        "run\n",
+        "only the baseline selector may run"
+    );
+    assert!(!stdout_has_result(&output, "PINNED"));
+    assert!(!stdout_has_result(&output, "UNPINNED"));
+    fixture.assert_clean_and_single_worktree();
+}
+
+#[test]
+fn red_baseline_refuses_before_reversing_product_code() {
+    let fixture = Fixture::new("charts/curie/ci/assert-pin.sh", CHART_OLD);
+    let change = fixture.commit(
+        &[
+            ("runner/Dockerfile", "value=fixed\n"),
+            (
+                "charts/curie/ci/assert-pin.sh",
+                "#!/bin/sh\nset -eu\nprintf 'run\\n' >> \"$VERIFY_RUN_LOG\"\ngrep -qx 'value=missing' runner/Dockerfile\n",
+            ),
+        ],
+        "Add a red assertion",
+    );
+    let run_log = fixture.external_path("run.log");
+
+    let output = fixture
+        .command(&change, "charts/curie/ci/assert-pin.sh")
+        .env("VERIFY_RUN_LOG", &run_log)
+        .output()
+        .expect("run verify fix pin");
+    let shown = output_text(&output);
+    assert!(
+        !output.status.success(),
+        "a red baseline must fail\n{shown}"
+    );
+    assert!(
+        shown.to_lowercase().contains("baseline"),
+        "the refusal must identify the red baseline\n{shown}"
+    );
+    assert_eq!(
+        fs::read_to_string(run_log).expect("read selector log"),
+        "run\n",
+        "the red selector must run only once"
+    );
+    assert!(!stdout_has_result(&output, "PINNED"));
+    assert!(!stdout_has_result(&output, "UNPINNED"));
+    fixture.assert_clean_and_single_worktree();
+}
+
+#[test]
+fn selector_not_changed_by_the_reference_refuses_before_running_it() {
+    let fixture = Fixture::new(
+        "charts/curie/ci/selected.sh",
+        "#!/bin/sh\nset -eu\nprintf 'run\\n' >> \"$VERIFY_RUN_LOG\"\ngrep -qx 'value=fixed' runner/Dockerfile\n",
+    );
+    let change = fixture.commit(
+        &[
+            ("runner/Dockerfile", "value=fixed\n"),
+            ("charts/curie/ci/other.sh", "#!/bin/sh\nset -eu\nexit 0\n"),
+        ],
+        "Change behavior with another assertion",
+    );
+    let run_log = fixture.external_path("run.log");
+
+    let output = fixture
+        .command(&change, "charts/curie/ci/selected.sh")
+        .env("VERIFY_RUN_LOG", &run_log)
+        .output()
+        .expect("run verify fix pin");
+    let shown = output_text(&output);
+    assert!(
+        !output.status.success(),
+        "an unchanged selector must fail\n{shown}"
+    );
+    assert!(
+        shown.to_lowercase().contains("selector") && shown.to_lowercase().contains("changed"),
+        "the refusal must identify the unchanged selector\n{shown}"
+    );
+    assert!(!run_log.exists(), "the unchanged selector must not run");
+    assert!(!stdout_has_result(&output, "PINNED"));
+    assert!(!stdout_has_result(&output, "UNPINNED"));
+    fixture.assert_clean_and_single_worktree();
+}
+
+#[test]
+fn change_with_only_test_files_refuses_before_running_the_selector() {
+    let fixture = Fixture::new("charts/curie/ci/assert-pin.sh", CHART_OLD);
+    let change = fixture.commit(
+        &[(
+            "charts/curie/ci/assert-pin.sh",
+            "#!/bin/sh\nset -eu\nprintf 'run\\n' >> \"$VERIFY_RUN_LOG\"\ngrep -qx 'value=old' runner/Dockerfile\n",
+        )],
+        "Change assertion only",
+    );
+    let run_log = fixture.external_path("run.log");
+
+    let output = fixture
+        .command(&change, "charts/curie/ci/assert-pin.sh")
+        .env("VERIFY_RUN_LOG", &run_log)
+        .output()
+        .expect("run verify fix pin");
+    let shown = output_text(&output);
+    assert!(
+        !output.status.success(),
+        "a change without product files must fail\n{shown}"
+    );
+    assert!(
+        shown.to_lowercase().contains("no product files"),
+        "the refusal must identify the missing product files\n{shown}"
+    );
+    assert!(!run_log.exists(), "the selector must not run");
+    assert!(!stdout_has_result(&output, "PINNED"));
+    assert!(!stdout_has_result(&output, "UNPINNED"));
+    fixture.assert_clean_and_single_worktree();
+}
+
+fn assert_tool_selector_route(test_path: &str, selector: &str, tool: &str, argv: &[&str]) {
+    let fixture = Fixture::new(test_path, "old assertion\n");
+    let change = fixture.commit(
+        &[
+            ("runner/Dockerfile", "value=fixed\n"),
+            (test_path, "new assertion\n"),
+        ],
+        "Fix behavior with routed assertion",
+    );
+    let route_log = fixture.external_path("route.log");
+    write_exec(
+        &fixture.tools,
+        tool,
+        r#"#!/bin/sh
+{
+    printf 'call\n'
+    printf 'cwd=%s\n' "$PWD"
+    printf 'argc=%s\n' "$#"
+    for arg in "$@"; do
+        printf 'arg=%s\n' "$arg"
+    done
+} >> "$VERIFY_ROUTE_LOG"
+grep -qx 'value=fixed' runner/Dockerfile
+"#,
+    );
+
+    let output = fixture
+        .command(&change, selector)
+        .env("VERIFY_ROUTE_LOG", &route_log)
+        .output()
+        .expect("run verify fix pin");
+    assert!(
+        output.status.success(),
+        "the routed selector must prove the pin\n{}",
+        output_text(&output)
+    );
+    assert!(stdout_has_result(&output, "PINNED"));
+
+    let log = fs::read_to_string(route_log).expect("read route log");
+    let calls: Vec<Vec<&str>> = log
+        .split("call\n")
+        .filter(|call| !call.is_empty())
+        .map(|call| call.lines().collect())
+        .collect();
+    assert_eq!(
+        calls.len(),
+        2,
+        "the selector must run before and after reversal"
+    );
+    let mut scratch_cwd: Option<&str> = None;
+    for call in calls {
+        let cwd = call[0].strip_prefix("cwd=").expect("cwd record");
+        assert_ne!(Path::new(cwd), fixture.root.as_path());
+        if let Some(expected) = scratch_cwd {
+            assert_eq!(cwd, expected, "both runs must use one scratch repository");
+        } else {
+            scratch_cwd = Some(cwd);
+        }
+        assert_eq!(call[1], format!("argc={}", argv.len()));
+        let actual: Vec<&str> = call[2..]
+            .iter()
+            .map(|line| line.strip_prefix("arg=").expect("argument record"))
+            .collect();
+        assert_eq!(actual, argv);
+    }
+    fixture.assert_clean_and_single_worktree();
+}
+
+#[test]
+fn python_app_selector_uses_uv_with_the_exact_root_command() {
+    let selector = "apps/api/tests/test_pin.py::test_pin";
+    assert_tool_selector_route(
+        "apps/api/tests/test_pin.py",
+        selector,
+        "uv",
+        &["run", "--python", "3.13", "pytest", selector],
+    );
+}
+
+#[test]
+fn python_package_selector_uses_uv_with_the_exact_root_command() {
+    let selector = "packages/example/tests/test_pin.py::test_pin";
+    assert_tool_selector_route(
+        "packages/example/tests/test_pin.py",
+        selector,
+        "uv",
+        &["run", "--python", "3.13", "pytest", selector],
+    );
+}
+
+#[test]
+fn rust_selector_uses_cargo_with_the_exact_manifest_and_test_name() {
+    assert_tool_selector_route(
+        "cli/tests/verify_pin.rs",
+        "cli/tests/verify_pin.rs::pin_breaks",
+        "cargo",
+        &[
+            "test",
+            "--manifest-path",
+            "cli/Cargo.toml",
+            "--test",
+            "verify_pin",
+            "pin_breaks",
+        ],
+    );
+}
+
+#[test]
+fn unsupported_selector_path_is_refused() {
+    let fixture = Fixture::new("charts/curie/ci/assert-pin.sh", CHART_OLD);
+    let change = fixture.commit(
+        &[
+            ("runner/Dockerfile", "value=fixed\n"),
+            ("charts/curie/ci/assert-pin.sh", CHART_FIXED),
+        ],
+        "Fix chart behavior",
+    );
+
+    let output = fixture
+        .command(&change, "tests/assert-pin.sh")
+        .output()
+        .expect("run verify fix pin");
+    let shown = output_text(&output);
+    assert!(
+        !output.status.success(),
+        "an unsupported selector must fail\n{shown}"
+    );
+    assert!(
+        shown.to_lowercase().contains("selector"),
+        "the refusal must identify the selector\n{shown}"
+    );
+    assert!(!stdout_has_result(&output, "PINNED"));
+    assert!(!stdout_has_result(&output, "UNPINNED"));
+    fixture.assert_clean_and_single_worktree();
+}
+
+#[test]
+fn pr_url_uses_the_resolved_patch_and_reports_the_same_pinned_result() {
+    let fixture = Fixture::new("charts/curie/ci/assert-pin.sh", CHART_OLD);
+    let base = fixture.head();
+    let head = fixture.commit(
+        &[
+            ("runner/Dockerfile", "value=fixed\n"),
+            ("charts/curie/ci/assert-pin.sh", CHART_FIXED),
+        ],
+        "Fix chart behavior",
+    );
+    let patch_path = fixture.external_path("pr.patch");
+    fs::write(&patch_path, fixture.patch(&base, &head)).expect("write PR patch");
+    let gh_log = fixture.external_path("gh.log");
+    write_exec(
+        &fixture.tools,
+        "gh",
+        r#"#!/bin/sh
+printf '%s\n' "$*" >> "$VERIFY_GH_LOG"
+if [ "$1" = pr ] && [ "$2" = view ]; then
+    exit 0
+fi
+if [ "$1" = pr ] && [ "$2" = diff ]; then
+    # The GitHub CLI manual says --patch requests patch format. This verifier needs the default combined diff so one reverse apply covers later edits: https://cli.github.com/manual/gh_pr_diff
+    case "$*" in
+        *--patch*) exit 65 ;;
+    esac
+    case "$*" in
+        *--name-only*)
+            printf '%s\n' 'charts/curie/ci/assert-pin.sh' 'runner/Dockerfile'
+            ;;
+        *) cat "$VERIFY_GH_PATCH" ;;
+    esac
+    exit 0
+fi
+exit 64
+"#,
+    );
+
+    let output = fixture
+        .command(
+            "https://github.com/curie-eng/curie/pull/1479",
+            "charts/curie/ci/assert-pin.sh",
+        )
+        .env("VERIFY_GH_PATCH", &patch_path)
+        .env("VERIFY_GH_LOG", &gh_log)
+        .output()
+        .expect("run verify fix pin for PR");
+    assert!(
+        output.status.success(),
+        "the PR patch must prove the pin\n{}",
+        output_text(&output)
+    );
+    assert!(stdout_has_result(&output, "PINNED"));
+    let calls = fs::read_to_string(gh_log).expect("read gh calls");
+    assert!(calls.lines().any(|line| line.starts_with("pr view ")));
+    assert!(calls.lines().any(|line| line.starts_with("pr diff ")));
+    fixture.assert_clean_and_single_worktree();
+}
+
+#[test]
+fn numeric_pr_uses_gh_even_when_git_would_resolve_the_number_as_a_commit() {
+    let fixture = Fixture::new("charts/curie/ci/assert-pin.sh", CHART_OLD);
+    let base = fixture.head();
+    let head = fixture.commit(
+        &[
+            ("runner/Dockerfile", "value=fixed\n"),
+            ("charts/curie/ci/assert-pin.sh", CHART_FIXED),
+        ],
+        "Fix chart behavior",
+    );
+    let patch_path = fixture.external_path("pr.patch");
+    fs::write(&patch_path, fixture.patch(&base, &head)).expect("write PR patch");
+    let gh_log = fixture.external_path("gh.log");
+    let git_log = fixture.external_path("git.log");
+    write_exec(
+        &fixture.tools,
+        "gh",
+        r#"#!/bin/sh
+printf '%s\n' "$*" >> "$VERIFY_GH_LOG"
+if [ "$1" = pr ] && [ "$2" = view ]; then
+    exit 0
+fi
+if [ "$1" = pr ] && [ "$2" = diff ]; then
+    # The GitHub CLI manual says --patch requests patch format. This verifier needs the default combined diff so one reverse apply covers later edits: https://cli.github.com/manual/gh_pr_diff
+    case "$*" in
+        *--patch*) exit 65 ;;
+    esac
+    case "$*" in
+        *--name-only*)
+            printf '%s\n' 'charts/curie/ci/assert-pin.sh' 'runner/Dockerfile'
+            ;;
+        *) cat "$VERIFY_GH_PATCH" ;;
+    esac
+    exit 0
+fi
+exit 64
+"#,
+    );
+    write_exec(
+        &fixture.tools,
+        "git",
+        r#"#!/bin/sh
+if [ "$1" = -C ] && [ "$3" = rev-parse ] && [ "$4" = --verify ] && [ "$5" = '1479^{commit}' ]; then
+    printf 'numeric probe\n' >> "$VERIFY_GIT_LOG"
+    printf '%s\n' "$VERIFY_COLLIDING_COMMIT"
+    exit 0
+fi
+command -p git "$@"
+"#,
+    );
+
+    let output = fixture
+        .command("1479", "charts/curie/ci/assert-pin.sh")
+        .env("VERIFY_COLLIDING_COMMIT", &head)
+        .env("VERIFY_GH_PATCH", &patch_path)
+        .env("VERIFY_GH_LOG", &gh_log)
+        .env("VERIFY_GIT_LOG", &git_log)
+        .output()
+        .expect("run verify fix pin for numeric PR");
+    assert!(
+        output.status.success(),
+        "the numeric PR patch must prove the pin\n{}",
+        output_text(&output)
+    );
+    assert!(stdout_has_result(&output, "PINNED"));
+    let calls = fs::read_to_string(gh_log).expect("read gh calls");
+    assert!(calls.lines().any(|line| line.starts_with("pr view 1479")));
+    assert!(calls.lines().any(|line| line.starts_with("pr diff 1479")));
+    assert!(
+        !git_log.exists(),
+        "a numeric PR must not be resolved as a Git commit"
+    );
+    fixture.assert_clean_and_single_worktree();
+}


### PR DESCRIPTION
Closes #1479

Adds `curie dev verify-fix-pin <CHANGE> <SELECTOR>` for commit and pull request changes. It runs a changed selector at `HEAD`, reverses only product files in a disposable worktree, and reports `PINNED` or `UNPINNED` with failing refusals for unverifiable changes.

## Done check

1. [x] Failing process tests were committed before implementation, then preserved through the final squash.
2. [x] All production edits were performed by delegated native executors.
3. [x] No public return type was broadened.
4. [x] Independent code review approved the final diff with file and line evidence.
5. [x] Independent scope review mapped every hunk to an acceptance criterion or mechanical necessity.
6. [x] Dev command callers and both command manifests preserve entry point parity.
7. [x] Thirteen process tests execute every new refusal and result guard, including combined pull request diffs.
8. [x] Consolidation found no safe simplification, and final reviews remained clean.
9. [x] Security review was not applicable because no security surface changed.
10. [x] Deployed E2E was not applicable; hands on offline CLI runs observed `PINNED` exit 0 and `UNPINNED` exit 1.
11. [x] Full affected validation passed: CLI format, clippy, all tests; UI lint, typecheck, and 144 tests.
12. [x] Diff checks and commit message checks are clean.