### PR TITLE
Wire worker eval reporting services

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -255,6 +255,13 @@ jobs:
           set -euo pipefail
           bash charts/curie/ci/worker-object-store-assertions.sh
 
+      # A default worker missing these values runs eval suites that cannot
+      # record or report results.
+      - name: helm render assertions (worker eval wiring)
+        run: |
+          set -euo pipefail
+          bash charts/curie/ci/worker-eval-wiring-assertions.sh
+
       - name: helm template + kubeconform (values-dev overlay)
         run: |
           set -euo pipefail

--- a/charts/curie/ci/connector-reconciler-rbac-assertions.sh
+++ b/charts/curie/ci/connector-reconciler-rbac-assertions.sh
@@ -28,9 +28,9 @@
 #       module's docstring claims this file enforces that; this is the claim.
 #   (f) Nothing the reconciler grants is cluster-scoped, and it never mentions
 #       pods.
-#   (g) The RBAC and the worker's env are switched by the SAME flag. Half the
-#       pair is the worst outcome: the grant without the env is unused
-#       authority, and the env without the grant is a loop that 403s forever.
+#   (g) The RBAC and connector specific worker env are switched by the same
+#       flag. Shared API env remains present in both renders for the worker's
+#       runs and eval lanes.
 #   (h) The reconciler is pointed at the namespace and release the worker
 #       already tells the runner about, so the Service it creates is the one the
 #       agent dials.
@@ -167,13 +167,20 @@ if grep -q "pods" <<<"$ENABLED_RULES"; then
   fail f "the connector Role mentions pods; it manages objects, never pods directly"
 fi
 
-# (g) The RBAC and the env are switched by the SAME flag. Half of the pair is
-#     the worst outcome: the grant without the env is unused authority, and the
-#     env without the grant is a loop that 403s every pass forever.
-for required in CURIE_CONNECTOR_RECONCILE CURIE_CONNECTOR_APP_NAME CURIE_API_URL CURIE_API_KEY; do
+# (g) The RBAC and connector specific env are switched by the same flag. Half
+#     of the pair is the worst outcome: the grant without the env is unused
+#     authority, and the env without the grant is a loop that 403s every pass.
+for required in CURIE_CONNECTOR_RECONCILE CURIE_CONNECTOR_APP_NAME; do
   grep -q "$required" <<<"$ENABLED" || fail g "enabling the reconciler did not render $required"
   grep -q "$required" <<<"$DISABLED" &&
     fail g "$required renders with the reconciler disabled; the env gate is not working"
+done
+
+# Shared API wiring is not connector specific. The worker needs it in both
+# renders so its runs and eval lanes can call the platform API.
+for required in CURIE_API_URL CURIE_API_KEY; do
+  grep -q "$required" <<<"$ENABLED" || fail g "the enabled render is missing shared API env $required"
+  grep -q "$required" <<<"$DISABLED" || fail g "the disabled render is missing shared API env $required"
 done
 
 # (h) The worker reconciles the namespace and release it already tells the

--- a/charts/curie/ci/worker-eval-wiring-assertions.sh
+++ b/charts/curie/ci/worker-eval-wiring-assertions.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+#
+# A default worker must receive the platform API and Langfuse settings needed
+# to report its eval results. Rendering both connector states prevents a
+# conditional API include from leaving one state unwired or duplicating entries.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+helm template t "$CHART" > "$TMP/default.yaml"
+helm template t "$CHART" \
+  --set worker.connectorReconciler.enabled=true > "$TMP/connector.yaml"
+
+python3 - "$TMP/default.yaml" "$TMP/connector.yaml" <<'PY'
+import sys
+
+import yaml
+
+
+EXPECTED = {
+    "CURIE_API_URL": {
+        "name": "CURIE_API_URL",
+        "value": "http://t-curie-api:8000",
+    },
+    "CURIE_API_KEY": {
+        "name": "CURIE_API_KEY",
+        "valueFrom": {
+            "secretKeyRef": {
+                "name": "t-curie-secrets",
+                "key": "apiKey",
+            },
+        },
+    },
+    "LANGFUSE_HOST": {
+        "name": "LANGFUSE_HOST",
+        "value": "http://t-curie-langfuse-web:3000",
+    },
+    "LANGFUSE_PUBLIC_KEY": {
+        "name": "LANGFUSE_PUBLIC_KEY",
+        "value": "pk-lf-curie-dev",
+    },
+    "LANGFUSE_SECRET_KEY": {
+        "name": "LANGFUSE_SECRET_KEY",
+        "valueFrom": {
+            "secretKeyRef": {
+                "name": "t-curie-secrets",
+                "key": "langfuseInitProjectSecretKey",
+            },
+        },
+    },
+}
+
+
+def failures_for(path, render):
+    with open(path) as handle:
+        docs = [doc for doc in yaml.safe_load_all(handle) if doc]
+
+    workers = [
+        doc
+        for doc in docs
+        if doc.get("kind") == "Deployment"
+        and (doc.get("metadata") or {}).get("labels", {}).get(
+            "app.kubernetes.io/component"
+        )
+        == "worker"
+    ]
+    if len(workers) != 1:
+        return [
+            "%s render found %d worker Deployments by component label, expected exactly one"
+            % (render, len(workers))
+        ]
+
+    containers = (
+        (workers[0].get("spec") or {})
+        .get("template", {})
+        .get("spec", {})
+        .get("containers", [])
+    )
+    if not containers:
+        return ["%s worker Deployment has no containers" % render]
+
+    env = containers[0].get("env", [])
+    if not isinstance(env, list):
+        return ["%s worker container env is not a list" % render]
+
+    failures = []
+    for name, expected in EXPECTED.items():
+        entries = [entry for entry in env if isinstance(entry, dict) and entry.get("name") == name]
+        if len(entries) != 1:
+            failures.append(
+                "%s worker has %d %s entries, expected exactly one"
+                % (render, len(entries), name)
+            )
+            continue
+        if entries[0] != expected:
+            failures.append(
+                "%s worker %s is %r, expected %r"
+                % (render, name, entries[0], expected)
+            )
+    return failures
+
+
+failures = []
+for path, render in zip(sys.argv[1:], ("default", "connector reconciler enabled")):
+    failures.extend(failures_for(path, render))
+
+if failures:
+    print("FAIL: worker eval wiring render assertions failed", file=sys.stderr)
+    for failure in failures:
+        print("  " + failure, file=sys.stderr)
+    raise SystemExit(1)
+
+print("OK: worker eval wiring render assertions passed")
+PY

--- a/charts/curie/templates/worker.yaml
+++ b/charts/curie/templates/worker.yaml
@@ -162,13 +162,17 @@ spec:
               value: {{ include "curie.name" . | quote }}
             - name: CURIE_CONNECTOR_RECONCILE_INTERVAL_S
               value: {{ .Values.worker.connectorReconciler.intervalSeconds | quote }}
-            # The reconciler fetches rendered objects from the API rather than
-            # re-deriving them (ADR-0090), so it needs to reach it. Included only
-            # on this branch: wiring it unconditionally would also switch on the
-            # worker's eval reporting, which is unwired today, and that is a
-            # behaviour change this flag did not ask for.
-            {{- include "curie.env.api" . | nindent 12 }}
 {{- end }}
+            {{- include "curie.env.api" . | nindent 12 }}
+            - name: LANGFUSE_HOST
+              value: http://{{ include "curie.langfuse.webHost" . }}:{{ .Values.langfuse.web.service.port }}
+            - name: LANGFUSE_PUBLIC_KEY
+              value: {{ .Values.langfuse.init.projectPublicKey | quote }}
+            - name: LANGFUSE_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.langfuse.existingSecret | default (include "curie.secretName" .) }}
+                  key: langfuseInitProjectSecretKey
             - name: CURIE_WARM_POOL
               value: {{ $warmPool | quote }}
             - name: CURIE_RUNNER_PORT


### PR DESCRIPTION
Closes #1452

Targets `next` because the maintainer moved this feature shaped wiring to the v0.7.0 milestone. The worker now receives the platform API pair and Langfuse trio on every render, while connector specific environment and RBAC remain feature gated.

Done check

[x] Failing render contract committed before implementation as `368e5ed6`.

[x] Production edits were performed by a fresh delegated implementation context.

[x] No public return type changed.

[x] Cross engine Code Reviewer approved with no blocking findings.

[x] Cross engine Scope Reviewer approved after the unrelated duplicate environment scan was removed.

[x] Connector disabled and enabled sibling renders both carry exactly one API pair and Langfuse trio.

[x] Mutation proof reverted the worker wiring and made the new assertion fail on the required entries.

[x] Consolidation was skipped because the simplify skill is unavailable in this session. Focused review found no further required simplification.

[x] Security review was not applicable because existing Secret references and values were copied without changing auth or secret handling.

[x] A live zero replica worker Deployment on local k3s carried all five entries. The unique namespace was deleted and cleanup confirmed.

[x] All chart render assertions passed. Helm lint passed for default and dev values. Default, dev, and nogvisor templates passed.

[x] Bash syntax, workflow YAML, actionlint, commit message checks, and diff checks passed.
