### PR TITLE
Gate the prose style rule and require an explicit model on agent spawns

### DIFF
--- a/.claude/hooks/require-agent-model.sh
+++ b/.claude/hooks/require-agent-model.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# PreToolUse Agent gate: a sub-agent spawn must name its model explicitly.
+#
+# WHY THIS IS A HOOK AND NOT A LINE IN AGENTS.md. It was a line in AGENTS.md,
+# and it did not hold. A spawn that omits `model` inherits the parent session's
+# model. When the parent is an expensive tier, every sub-agent in the fan-out
+# silently bills at that tier, and nothing in the transcript says so: the spawn
+# looks identical to a correct one. One measured incident ran a fleet on the
+# parent's tier for 24 hours at roughly $109 API-equivalent before anyone
+# noticed, and it was caught by a human asking "have you been using fable or
+# opus to run subagents?", not by any gate. CI cannot see this -- a subagent
+# spawn is a runtime event that leaves no artifact in the diff -- so the only
+# place to catch it is here, at the call.
+#
+# WHY BLOCKING IS SAFE HERE. Blocking gates fail when the signal is ambiguous
+# and the fix is unclear, which is how two of them died in a sibling repo. This
+# signal is neither: the `model` field is present or it is not, and the fix is
+# to add it and retry. There is no state to reconcile and no window to
+# misjudge, so the failure mode costs one turn.
+#
+# ESCAPE HATCH. Export CLAUDE_ALLOW_INHERITED_MODEL=1 in the launching shell
+# for a deliberate inherit. Not in settings.json: an opt-out that lives in
+# committed config is an opt-out for everyone, forever.
+set -uo pipefail
+
+# Negative control. AGENTS.md requires a new gate to demonstrate by execution
+# that it rejects a violating input, so the suite runs the real script over real
+# payloads rather than asserting anything about its source.
+if [ "${1:-}" = "--self-test" ]; then
+  self="${BASH_SOURCE[0]}"
+  fails=0
+  run() { printf '%s' "$1" | env -u CLAUDE_ALLOW_INHERITED_MODEL bash "$self" >/dev/null 2>&1; echo $?; }
+
+  expect() { # expect <want> <label> <payload>
+    got=$(run "$3")
+    if [ "$got" != "$2" ]; then
+      echo "  FAIL $1 (want exit $2, got $got)" >&2
+      fails=$((fails + 1))
+    fi
+  }
+
+  echo "== agent-model gate: self-test (negative control) =="
+  expect "spawn with no model is blocked" 2 \
+    '{"tool_name":"Agent","tool_input":{"prompt":"x","subagent_type":"general-purpose"}}'
+  expect "spawn with empty model is blocked" 2 \
+    '{"tool_name":"Agent","tool_input":{"prompt":"x","model":"   "}}'
+  expect "spawn with a model passes" 0 \
+    '{"tool_name":"Agent","tool_input":{"prompt":"x","model":"opus"}}'
+  expect "a non-Agent tool is untouched" 0 \
+    '{"tool_name":"Bash","tool_input":{"command":"ls"}}'
+  expect "malformed json is untouched" 0 'not json at all'
+  expect "empty stdin is untouched" 0 ''
+
+  got=$(printf '%s' '{"tool_name":"Agent","tool_input":{"prompt":"x"}}' \
+    | CLAUDE_ALLOW_INHERITED_MODEL=1 bash "$self" >/dev/null 2>&1; echo $?)
+  if [ "$got" != "0" ]; then
+    echo "  FAIL escape hatch does not release the gate (got exit $got)" >&2
+    fails=$((fails + 1))
+  fi
+
+  if [ "$fails" -ne 0 ]; then
+    echo "SELF-TEST FAILED: $fails case(s)." >&2
+    exit 1
+  fi
+  echo "OK: self-test passed (7 cases, blocking and non-blocking paths both proven)."
+  exit 0
+fi
+
+input=$(cat 2>/dev/null || true)   # drain stdin first; a closed pipe is not an error
+[ -z "$input" ] && exit 0
+
+[ "${CLAUDE_ALLOW_INHERITED_MODEL:-}" = "1" ] && exit 0
+
+# python3 rather than jq: jq ships on neither a stock macOS nor a stock Ubuntu
+# runner, and this repo already requires python everywhere.
+model=$(printf '%s' "$input" | python3 -c '
+import json, sys
+try:
+    payload = json.load(sys.stdin)
+except (json.JSONDecodeError, ValueError):
+    print("__SKIP__")    # not our payload; stay out of the way
+    sys.exit(0)
+if not isinstance(payload, dict) or payload.get("tool_name") != "Agent":
+    print("__SKIP__")
+    sys.exit(0)
+value = payload.get("tool_input", {}).get("model")
+print(value.strip() if isinstance(value, str) and value.strip() else "")
+' 2>/dev/null) || exit 0
+
+[ "$model" = "__SKIP__" ] && exit 0
+[ -n "$model" ] && exit 0
+
+cat >&2 <<'MSG'
+Blocked: this Agent spawn does not set `model`.
+
+A spawn with no `model` inherits the parent session's model. The whole fan-out
+then bills at the parent's tier with nothing in the transcript to show it. That
+has already cost this project a day of silent spend once.
+
+Fix: pass `model` explicitly on the Agent call.
+  - judgement-bearing work (planning, review, implementation): the default tier
+  - read-only locate, fetch, or report spawns: the cheap tier
+
+An agent definition's frontmatter pin does NOT satisfy this: a spawn-time model
+overrides frontmatter, so the pin is only a default, never a guarantee.
+
+Deliberate inherit: export CLAUDE_ALLOW_INHERITED_MODEL=1 in your shell.
+MSG
+exit 2

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Agent",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/require-agent-model.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -636,6 +636,46 @@ jobs:
           bash scripts/check-commit-messages.sh \
             "${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}"
 
+  # The fourth commit-convention rule in AGENTS.md ("no dashes/emdashes in prose
+  # content; no emojis in code or docs") was the only one with no enforcement,
+  # sitting directly beneath two rules that have it. Same scoping decision as
+  # commit-messages above and for the same reason: 103 tracked .md files already
+  # carry an em-dash, so this checks the lines a PR ADDS and never the tree.
+  # Measured over the 200 commits before it landed, it would have flagged 173
+  # added lines across 23 files, all genuine.
+  prose-style:
+    name: Prose style (no em-dashes, no emoji)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+          # The range needs both endpoints present locally.
+          fetch-depth: 0
+      # Prove the matcher still separates an em-dash from an ASCII hyphen, and
+      # still respects code fences, before trusting its verdict.
+      - name: Gate self-test (negative control)
+        run: bash scripts/check-prose-style.sh --self-test
+      - name: Check the lines this PR adds
+        run: |
+          bash scripts/check-prose-style.sh \
+            "${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}"
+
+  # The agent-model hook is a local PreToolUse gate, so CI cannot exercise the
+  # thing it guards. What CI can do is prove the gate still blocks and still
+  # lets correct spawns through, which is what AGENTS.md's outcome-tested-guards
+  # rule asks of any new gate.
+  agent-model-gate:
+    name: Agent model gate (self-test)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Gate self-test (negative control)
+        run: bash .claude/hooks/require-agent-model.sh --self-test
+
   # The three image builds here are GHA-layer-cached via a buildx builder that
   # is created but NOT made the default (`setup-buildx-action` with
   # `use: false`): two of the tags are consumed as Dockerfile FROM bases by a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,6 +162,14 @@ down` (or `docker compose -f compose.dev.yaml down`) and confirm with
 stack up owns tearing it down — a blocked or crashed test agent never cleans up
 after itself, so do not assume someone else will.
 
+**The inverse is equally not optional: do not tear down what you did not start.**
+Ownership runs both ways. Several threads share this box, so a broad cleanup
+(`docker rm -f $(docker ps -aq)`, `docker volume prune`, killing a process
+holding a well-known port) will take out a stack another session is mid-test on,
+and the victim sees only an inexplicable failure. Before removing anything you
+did not bring up, confirm it is yours. Scope the teardown to the specific
+containers, volumes, and ports your own run created.
+
 **Do stack testing from a worktree, not the main checkout.** If a local test
 requires code edits, make them in a git worktree cut from the release train base
 selected below and land them as a PR. Never edit `main` or `next` in place to
@@ -492,7 +500,22 @@ protection before accepting PRs against it.
   range the script cannot resolve is a hard failure naming the range, not a silent
   pass. It checks only the PR's own commits, so pre-gate history is not
   retroactively enforced.
-- No dashes/emdashes in prose content; no emojis in code or docs.
+- No dashes/emdashes in prose content; no emojis in code or docs. CI enforces
+  this on every PR; check before pushing with:
+
+  ```bash
+  scripts/check-prose-style.sh origin/<base>..HEAD
+  scripts/check-prose-style.sh --self-test
+  ```
+
+  The gate flags the em-dash and the en-dash in markdown prose, and emoji
+  anywhere it looks. It deliberately does not flag the ASCII hyphen, which is
+  every flag, filename, and kebab-case identifier in the repo, and it skips
+  fenced code blocks, where captured CLI output and quoted model responses are
+  not ours to rewrite. Like the commit-message gate it checks only the lines a
+  PR adds, so existing files are not retroactively enforced; clean them up when
+  you are already editing them. For a genuinely quoted or generated line, put
+  `prose:ignore-line` on it or the line above.
 
 ## Ticket implementation
 
@@ -505,6 +528,24 @@ The active provider implements the change. An independently available provider
 performs read only plan or diff review where that improves confidence. The
 repository's instructions remain authoritative for branching, tests, reviews,
 runtime verification, commits, and pull requests.
+
+**Every sub-agent spawn names its model.** A spawn that omits the model
+inherits the parent session's, so an expensive parent silently bills the whole
+fan-out at its own tier and the transcript shows nothing unusual. Pass the model
+explicitly on every spawn: the default tier for judgement-bearing work
+(planning, review, implementation), the cheap tier for read only locate, fetch,
+and report spawns. An agent definition's frontmatter pin does not satisfy this,
+because a spawn-time model overrides frontmatter. A local PreToolUse hook
+enforces it where the harness supports hooks; CI cannot, since a spawn leaves no
+artifact in the diff.
+
+```bash
+.claude/hooks/require-agent-model.sh --self-test
+```
+
+For a deliberate inherit, export `CLAUDE_ALLOW_INHERITED_MODEL=1` in the
+launching shell rather than editing `.claude/settings.json`, which would turn
+the gate off for everyone.
 
 ## Decisions: ADR vs. GitHub issue
 

--- a/scripts/check-prose-style.sh
+++ b/scripts/check-prose-style.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+# Prose style gate: em-dashes/en-dashes in prose, emoji in code and docs.
+#
+# AGENTS.md's commit conventions list four rules. Three of them got enforcement
+# (the AI-attribution gate, the wire-lock gate, the ADR-number check). The
+# fourth -- "No dashes/emdashes in prose content; no emojis in code or docs" --
+# has been prose only, and prose only holds until someone is in a hurry.
+#
+# WHY THIS IS DIFF-SCOPED, NOT TREE-SCOPED. 103 tracked .md files already
+# contain an em-dash, AGENTS.md itself among them. A tree-wide gate would fail
+# on its first run and be deleted the same day. So this checks only the lines a
+# PR ADDS, exactly like scripts/check-commit-messages.sh scopes to base..head:
+# pre-gate content is not retroactively enforced. Clean up existing files when
+# you are already editing them, not because a gate shouted.
+#
+# WHAT IT FLAGS, AND WHAT IT DELIBERATELY DOES NOT.
+#   A. U+2014 EM DASH and U+2013 EN DASH, in added .md lines outside fenced
+#      code blocks. Prose only. The rule is about typography, not punctuation.
+#   B. Emoji, in added lines of any checked file, code included.
+#
+# It does NOT flag the ASCII hyphen. That is the single most important decision
+# in this file. `--profile`, `check-docs.sh`, `| --- |`, `task/some-branch`,
+# and every kebab-case identifier in the repo are hyphens; a gate that flagged
+# them would fire thousands of times on honest lines and be switched off within
+# a week. The rule's own words are "dashes/emdashes in prose", and the ASCII
+# hyphen in a flag or a filename is neither.
+#
+# It also skips fenced code blocks inside markdown. Sample CLI output, captured
+# logs, and quoted model responses land in fences and routinely carry em-dashes
+# that are not ours to rewrite.
+#
+# ESCAPE HATCH. Put `prose:ignore-line` on the offending line or the line
+# before it, mirroring the `<!-- doclint:ignore-line -->` convention the docs
+# gate already uses. In markdown that is `<!-- prose:ignore-line -->`.
+#
+# USAGE
+#   scripts/check-prose-style.sh <base>..<head>   # check a PR's added lines
+#   scripts/check-prose-style.sh --self-test      # negative control
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+matcher() {
+  python3 - "$@" <<'PY'
+import re
+import subprocess
+import sys
+
+# Emoji ranges. Pictographs, regional indicators, misc symbols, dingbats, and
+# the variation selector that turns a text glyph into an emoji one. Deliberately
+# excludes the arrows and box-drawing blocks: this repo draws ASCII diagrams and
+# uses -> in prose constantly.
+#
+# Written as escapes, never as literal characters. This file has to name the
+# things it forbids, and a literal here would make the gate fail on its own
+# source, which is a fine way to discover the escape hatch and a bad way to
+# leave the repo.
+EMOJI = re.compile(
+    "["
+    "\U0001F300-\U0001FAFF"
+    "\U0001F1E6-\U0001F1FF"
+    "\u2600-\u26FF"
+    "\u2700-\u27BF"
+    "\uFE0F"
+    "]"
+)
+EM_EN_DASH = re.compile("[\u2014\u2013]")
+IGNORE = "prose:ignore-line"
+
+# Generated artifacts and captured third-party text. A model response stored as
+# a fixture is evidence, not our prose, and rewriting it would corrupt the test.
+SKIP_PREFIXES = (
+    "docs/interfaces.md",
+    "docs/interfaces/",
+    "docs/adr/README.md",
+)
+SKIP_SUBSTRINGS = ("/fixtures/", "/testdata/", "/__snapshots__/")
+SKIP_SUFFIXES = (".lock", ".svg", ".min.js", ".po", ".pot")
+
+PROSE_SUFFIXES = (".md",)
+
+
+def added_lines(rng):
+    """Map path -> set of added line numbers, from a zero-context diff."""
+    out = subprocess.run(
+        ["git", "diff", "--unified=0", "--diff-filter=d", rng],
+        capture_output=True, text=True, check=True,
+    ).stdout
+    result, path = {}, None
+    for line in out.splitlines():
+        if line.startswith("+++ b/"):
+            path = line[6:]
+        elif line.startswith("@@") and path:
+            m = re.match(r"@@ -\S+ \+(\d+)(?:,(\d+))? @@", line)
+            if m:
+                start = int(m.group(1))
+                count = 1 if m.group(2) is None else int(m.group(2))
+                result.setdefault(path, set()).update(
+                    range(start, start + count)
+                )
+    return result
+
+
+def skipped(path):
+    return (
+        path.startswith(SKIP_PREFIXES)
+        or any(s in path for s in SKIP_SUBSTRINGS)
+        or path.endswith(SKIP_SUFFIXES)
+    )
+
+
+def scan(path, wanted, lines):
+    """Yield (lineno, rule, text) for each violation on a wanted line."""
+    is_prose = path.endswith(PROSE_SUFFIXES)
+    in_fence = False
+    findings = []
+    for idx, text in enumerate(lines, start=1):
+        stripped = text.lstrip()
+        # Track fences on every line, not just wanted ones: fence state is
+        # cumulative and a diff only gives us a subset of the file.
+        if is_prose and (stripped.startswith("```") or stripped.startswith("~~~")):
+            in_fence = not in_fence
+            continue
+        if idx not in wanted:
+            continue
+        if IGNORE in text:
+            continue
+        if idx > 1 and IGNORE in lines[idx - 2]:
+            continue
+        if EMOJI.search(text):
+            findings.append((idx, "emoji", text))
+        elif is_prose and not in_fence and EM_EN_DASH.search(text):
+            findings.append((idx, "em/en dash", text))
+    return findings
+
+
+def check(rng):
+    violations = []
+    for path, wanted in sorted(added_lines(rng).items()):
+        if skipped(path):
+            continue
+        try:
+            with open(path, encoding="utf-8") as fh:
+                lines = fh.read().splitlines()
+        except (OSError, UnicodeDecodeError):
+            continue  # binary or deleted between diff and read
+        for lineno, rule, text in scan(path, wanted, lines):
+            violations.append((path, lineno, rule, text.strip()))
+    return violations
+
+
+def self_test():
+    """Negative control. A gate that cannot fail is not a gate."""
+    must_flag = [
+        ("a.md", "the plan \u2014 as written \u2014 is fine", "em/en dash"),
+        ("a.md", "range 1\u20132 inclusive", "em/en dash"),
+        ("a.md", "shipped \U0001F680 today", "emoji"),
+        ("src/lib.rs", "// done \u2705", "emoji"),
+    ]
+    must_pass = [
+        ("a.md", "run with --profile full"),
+        ("a.md", "see scripts/check-docs.sh for the mirror"),
+        ("a.md", "| --- | --- |"),
+        ("a.md", "branch task/some-fix-here"),
+        ("a.md", "Pydantic -> JSON Schema -> TS"),
+        ("a.md", "the plan \u2014 fine <!-- prose:ignore-line -->"),
+        ("src/lib.rs", "let x = a - b; // plain hyphen"),
+        ("src/lib.rs", "// an em dash \u2014 in code is not prose"),
+    ]
+    failures = []
+    for path, text, want in must_flag:
+        got = scan(path, {1}, [text])
+        if not got or got[0][1] != want:
+            failures.append(f"MISSED  {path}: {text!r} (wanted {want}, got {got})")
+    for path, text in must_pass:
+        got = scan(path, {1}, [text])
+        if got:
+            failures.append(f"FALSE+  {path}: {text!r} -> {got}")
+    # Fence state must suppress a dash inside a code block but not after it.
+    fenced = ["```", "output \u2014 here", "```", "prose \u2014 here"]
+    got = scan("a.md", {2, 4}, fenced)
+    if [g[0] for g in got] != [4]:
+        failures.append(f"FENCE   expected only line 4 flagged, got {got}")
+    if failures:
+        print("SELF-TEST FAILED:", file=sys.stderr)
+        for f in failures:
+            print(f"  {f}", file=sys.stderr)
+        sys.exit(1)
+    print(f"OK: self-test passed ({len(must_flag)} caught, {len(must_pass)} allowed, fences respected).")
+
+
+if sys.argv[1] == "--self-test":
+    self_test()
+else:
+    found = check(sys.argv[1])
+    if found:
+        print("ERROR: prose style violations on lines this change adds:", file=sys.stderr)
+        for path, lineno, rule, text in found:
+            print(f"  {path}:{lineno}  [{rule}]  {text}", file=sys.stderr)
+        print("", file=sys.stderr)
+        print("AGENTS.md: no dashes/emdashes in prose content; no emojis in code", file=sys.stderr)
+        print("or docs. Replace an em-dash with a comma, a colon, or a full stop.", file=sys.stderr)
+        print("If a line is genuinely quoted or generated, mark it with", file=sys.stderr)
+        print("`prose:ignore-line` on that line or the line above.", file=sys.stderr)
+        sys.exit(1)
+    print("OK: no em-dashes, en-dashes, or emoji on added lines.")
+PY
+}
+
+if [ "${1:---self-test}" = "--self-test" ]; then
+  echo "== prose style gate: self-test (negative control) =="
+  matcher --self-test
+else
+  echo "== prose style gate: checking lines added by $1 =="
+  matcher "$1"
+fi


### PR DESCRIPTION
Two of the four commit-convention rules in AGENTS.md had no enforcement. This adds it, plus the missing half of the local-stack cleanup rule.

## Prose style gate

`scripts/check-prose-style.sh` enforces "no dashes/emdashes in prose content; no emojis in code or docs", the only rule in that bullet list that was prose only while its neighbours got `check-commit-messages.sh`.

Scoped to the lines a PR adds, not the tree, for the same reason the commit-message gate scopes to `base..head`: 103 tracked `.md` files already contain an em-dash, AGENTS.md among them, so a tree-wide gate would fail on its first run and be deleted the same day. Clean up existing files when you are already editing them.

It deliberately does not flag the ASCII hyphen. `--profile`, `check-docs.sh`, `| --- |` and every kebab-case identifier are hyphens, and a gate that fired on those would be switched off within a week. It also skips fenced code blocks, where captured CLI output and quoted model responses are not ours to rewrite. Escape hatch is `prose:ignore-line`, mirroring the doclint convention.

Measured over the 200 commits before this branch, it would have flagged 173 added lines across 23 files (170 dashes, 3 emoji), all genuine. Expect roughly one hit per docs-touching PR.

## Agent model gate

`.claude/hooks/require-agent-model.sh` rejects a sub-agent spawn that does not name its model. A spawn without one inherits the parent session's model, so an expensive parent silently bills the whole fan-out at its own tier with nothing unusual in the transcript. One measured incident ran a fleet that way for 24 hours at roughly $109 API-equivalent, caught by a human noticing, not by any check.

This is a PreToolUse hook rather than a CI job because CI cannot see it: a spawn is a runtime event that leaves no artifact in the diff. Blocking is safe here because the signal is unambiguous and the fix is one field, so a false stop costs a single turn. Deliberate inherit is `CLAUDE_ALLOW_INHERITED_MODEL=1` in the launching shell, not in committed config.

This is the repo's first `.claude/hooks/` entry and its first tracked `.claude/settings.json`.

## Cleanup rule inverse

AGENTS.md already says the thread that brings the local stack up owns tearing it down. It did not say the converse. A broad `docker rm -f $(docker ps -aq)` or `docker volume prune` takes out a stack another session is mid-test on, and the victim sees only an inexplicable failure.

## Verification

Both gates ship with a negative-control self-test that CI runs before trusting either verdict, per the outcome-tested-guards rule in AGENTS.md.

- Prose gate: 4 violations caught, 8 honest lines allowed, fence handling proven. Verified end to end by committing a real violating file and confirming exit 1.
- Agent model gate: 7 cases covering blocking, non-blocking, malformed input, and the escape hatch. The self-test caught a real bug during development, where malformed JSON fell through to blocking instead of being ignored.
- `scripts/check-docs.sh` and `scripts/check-commit-messages.sh` both pass on this branch.

## Notes for review

- No linked issue; this came out of a harness review rather than a filed ticket.
- CLAUDE.md prefers new tooling as a `curie` subcommand over a loose script in `scripts/`. This follows the `check-commit-messages.sh` precedent instead, on the grounds that a bare-ubuntu CI job checking text should not need the Rust CLI built first. Worth disagreeing with if you see it differently.
- `apps/worker/CLAUDE.md` mandates an adversarial review by `spec-vs-impl` and `side-effects-detective`, and neither agent definition exists in the repo. Out of scope here, but it means that rule is currently unexecutable.
