### PR TITLE
Register the fixture ids that only history still carries

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -172,6 +172,14 @@ stopwords = [
   "C000000S03",
   "C000000S04",
   "C000000S05",
+  # S06 to S09 exist only in history: the per-agent secret-delivery work
+  # introduced them and later edited them away, but gitleaks scans every
+  # commit, so an id absent from the tree still fails the scan forever.
+  # Registering them is the only fix that does not rewrite history.
+  "C000000S06",
+  "C000000S07",
+  "C000000S08",
+  "C000000S09",
   "C000000X01",
   "C0000BND1",
   "C0000BND2",
@@ -187,12 +195,14 @@ stopwords = [
   "C01SUPPORT",
   "C024BE91L",
   "C0AAAAAA1",
+  "C0AAAAAAA",
   "C0AGENT001",
   "C0BBBBBB2",
   "C0BOUND01",
   "C0BROAD01",
   "C0CARD001",
   "C0CCCCCC3",
+  "C0DEV2222",
   "C0DDDDDD4",
   "C0EEEEEE5",
   "C0ELSE001",
@@ -206,6 +216,7 @@ stopwords = [
   "C0INTAKE00",
   "C0LOCALDEV",
   "C0MALFORMED",
+  "C0PROD111",
   "C0MANAGERS",
   "C0OLDROOM0",
   "C0REQ0001",

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -28,3 +28,11 @@ be962e4a37f8644539244e2e872937f2fd8371a0:AGENTS.md:curl-auth-user:105
 # allowlisted here. The lines on main carry inline gitleaks:allow markers.
 c8b1ccb28faa51d3ec996d60883fde48a303b0bd:AGENTS.md:curl-auth-user:154
 c8b1ccb28faa51d3ec996d60883fde48a303b0bd:docs/adr/0079-inbound-triggers-as-a-new-event-kind.md:generic-api-key:46
+
+# A private org repo slug that reached a test fixture and was edited away again.
+# Ignored by FINGERPRINT rather than added to an allowlist: the rule exists to
+# catch exactly this shape, and widening it would retire the protection instead
+# of retiring the one occurrence. The slug is absent from the tree; only the
+# commit that introduced it still carries it, and history is not rewritten for a
+# fixture name that was never a credential.
+2adab2fc53b64ca6b80adf794e90c0fdf1e9754e:apps/api/tests/test_gitflow_targets.py:downstream-repo-slug:22


### PR DESCRIPTION
Secret Scan has failed on **every main build** since `e803ae3a`, so every branch cut from main inherits a red check. The findings are fake channel ids in a test fixture, not credentials.

**None of this is my work** -- the ids arrived with other people's changes, and the scan started failing on the merge that happened to follow them.

## Why they cannot be fixed in the tree

**They are not in the tree.** `C000000S06` through `S09` were introduced by the per-agent secret-delivery work and edited away again; `C0AAAAAAA`, `C0DEV2222` and `C0PROD111` likewise. `git grep` finds none of them.

gitleaks scans **every commit**, so an id deleted from the working tree still fails the scan forever. The options are rewrite published history, or register the value -- and rewriting history for an invented fixture name would be a far larger hazard than the thing it removes. The config already keeps a stopword list for exactly this case ("Pre-existing fixture ids"), so six of the seven go there.

## The seventh is deliberately NOT stopworded

`curie-eng/sre-bot` is a private org repo slug, which is precisely the shape `downstream-repo-slug` exists to catch. Its own comment says so:

> A slug in our own org is the case that actually happened: three Accepted ADRs cited a private agent repository by `org/repo` [...] and resolves to a 404 for every reader but us.

Adding it to an allowlist would **retire the protection in order to retire one occurrence**. It is ignored by fingerprint instead: that one commit, that one line, nothing else. A future `curie-eng/<private-repo>` still fails, which is the point.

## Verified by running it, not by reading the config

Same image and arguments as the workflow, against full history:

```
$ docker run --rm -v "$PWD:/repo" ghcr.io/gitleaks/gitleaks:v8.30.1 \
    detect --source /repo --redact --verbose --exit-code 1

1095 commits scanned.
no leaks found
```

Before the change the identical command reported **4**.

## Note for whoever adds the next fixture id

The config's own guidance is `C0EXAMPLE1` first, and a new stopword only when a test genuinely needs distinct values. The bar it states is that a reader can tell at a glance it is not somebody's channel -- it spells a word, repeats a character, or is mostly zeroes.