### PR TITLE
Run every chart assertion script in chart-check

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -254,19 +254,6 @@ jobs:
           set -euo pipefail
           bash charts/curie/ci/worker-object-store-assertions.sh
 
-      # Prove the API and the worker agree on the object store. The API WRITES
-      # each uploaded bundle there and the worker READS it back, so a
-      # disagreement means the write lands somewhere the read never looks --
-      # and worker.yaml shipped with none of the four variables set, so the
-      # worker used its compose default (http://localhost:29000) and every
-      # bundle fetch got ECONNREFUSED. It surfaced as ClaimTimeoutError blaming
-      # a CPU-saturated node on a box idling at 11%, and as a post-deploy eval
-      # that silently stopped running with "unresolvable suite/bundle".
-      - name: helm render assertions (worker/api object store agree)
-        run: |
-          set -euo pipefail
-          bash charts/curie/ci/worker-object-store-assertions.sh
-
       - name: helm template + kubeconform (values-dev overlay)
         run: |
           set -euo pipefail

--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -3920,7 +3920,7 @@ export const commandManifest = {
           "name": "contracts"
         },
         {
-          "about": "Render-assert the Helm chart (`bash charts/curie/ci/render-assertions.sh`)",
+          "about": "Render-assert the Helm chart: run every assertion script in `charts/curie/ci/`, the same set helm-ci runs on a `charts/curie/**` change (#1481). Reports per-script pass or fail and exits non-zero if any failed, so one run surfaces every problem",
           "hidden": false,
           "name": "chart-check"
         },

--- a/cli/README.md
+++ b/cli/README.md
@@ -575,7 +575,7 @@ they error clearly -- a release binary has no dev scripts.
 | Command | What it does |
 |---|---|
 | `curie dev contracts` | `bash scripts/check-contracts.sh` -- check the frozen contracts. |
-| `curie dev chart-check` | `bash charts/curie/ci/render-assertions.sh` -- render-assert the Helm chart. |
+| `curie dev chart-check` | Run every assertion script in `charts/curie/ci/`, the same set helm-ci runs -- render-assert the Helm chart. Reports per-script pass or fail and exits non-zero if any failed. |
 | `curie dev e2e` | `bash cli/scripts/e2e.sh` -- the scripted CLI end-to-end test. |
 | `curie dev e2e-ladder` | `bash cli/scripts/e2e-ladder.sh` -- the cold-start parity ladder (skill, local, cluster rungs). |
 | `curie dev field-parity` | `bash cli/scripts/check-field-parity.sh` -- assert CLI `api.rs` mirror structs cover their platform API model fields (#691), and CLI `commands.rs`/`spec.rs` mirror structs cover the frozen `packages/plugin-format` schema's fields (#701). |

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -3917,7 +3917,7 @@
           "name": "contracts"
         },
         {
-          "about": "Render-assert the Helm chart (`bash charts/curie/ci/render-assertions.sh`)",
+          "about": "Render-assert the Helm chart: run every assertion script in `charts/curie/ci/`, the same set helm-ci runs on a `charts/curie/**` change (#1481). Reports per-script pass or fail and exits non-zero if any failed, so one run surfaces every problem",
           "hidden": false,
           "name": "chart-check"
         },

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -616,6 +616,146 @@ pub async fn dev_script(rel_path: &str) -> Result<()> {
     Ok(())
 }
 
+/// The chart assertion scripts live here, and helm-ci runs every one of them on
+/// any `charts/curie/**` change.
+pub const CHART_CI_DIR: &str = "charts/curie/ci";
+
+/// One chart assertion script and how it fared.
+pub struct ChartCheckOutcome {
+    /// The script's file name, e.g. `render-assertions.sh`.
+    pub name: String,
+    pub passed: bool,
+}
+
+/// Discover the assertion scripts `curie dev chart-check` runs: every executable
+/// `*.sh` in `dir`, sorted by name so the run order is stable.
+///
+/// Discovery is a directory listing rather than a hardcoded list, so a script
+/// added to `charts/curie/ci/` is picked up with no edit to `cli/` (#1481). That
+/// matters because helm-ci runs the whole directory and is release-blocking, so
+/// a verb that knows about only some of it reports a local green CI will refuse.
+pub fn discover_chart_check_scripts(dir: &Path) -> Result<Vec<PathBuf>> {
+    let entries = std::fs::read_dir(dir)
+        .with_context(|| format!("failed to read chart assertion directory {}", dir.display()))?;
+    let mut scripts: Vec<PathBuf> = Vec::new();
+    for entry in entries {
+        let path = entry
+            .with_context(|| format!("failed to read an entry in {}", dir.display()))?
+            .path();
+        if path.is_file() && path.extension().is_some_and(|ext| ext == "sh") && is_executable(&path)
+        {
+            scripts.push(path);
+        }
+    }
+    scripts.sort();
+    Ok(scripts)
+}
+
+#[cfg(unix)]
+fn is_executable(path: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::metadata(path).is_ok_and(|m| m.permissions().mode() & 0o111 != 0)
+}
+
+#[cfg(not(unix))]
+fn is_executable(_path: &Path) -> bool {
+    true
+}
+
+/// Run every discovered script from `root`, streaming its output, and report how
+/// each one fared.
+///
+/// A failure does not stop the run: the point of the verb is that one invocation
+/// surfaces every problem, rather than making a contributor fix, re-run, and
+/// discover the next failure one at a time.
+pub async fn run_chart_check_scripts(
+    root: &Path,
+    scripts: &[PathBuf],
+) -> Result<Vec<ChartCheckOutcome>> {
+    let ui = crate::ui::ui();
+    let mut outcomes = Vec::with_capacity(scripts.len());
+    for (index, script) in scripts.iter().enumerate() {
+        let name = script
+            .file_name()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .into_owned();
+        let rel = script.strip_prefix(root).unwrap_or(script);
+        ui.note(&format!(
+            "=== [{}/{}] bash {} ===",
+            index + 1,
+            scripts.len(),
+            rel.display()
+        ));
+        let status = tokio::process::Command::new("bash")
+            .arg(script)
+            .current_dir(root)
+            .status()
+            .await
+            .with_context(|| format!("failed to invoke bash for {name}"))?;
+        outcomes.push(ChartCheckOutcome {
+            name,
+            passed: status.success(),
+        });
+    }
+    Ok(outcomes)
+}
+
+/// `curie dev chart-check`: run the chart assertion suite helm-ci runs.
+///
+/// helm-ci executes every script in `charts/curie/ci/` on any `charts/curie/**`
+/// change and is release-blocking (#1466), so this verb covers the same set. It
+/// reports per-script pass or fail, runs them all before deciding, and exits
+/// non-zero if any failed. A release binary has no checkout, so this errors
+/// clearly outside one, same as `dev_script`.
+pub async fn dev_chart_check() -> Result<()> {
+    let ui = crate::ui::ui();
+    let root = find_repo_root().context(
+        "runner/Dockerfile not found here or in any parent directory. Run `curie dev` \
+         from a curie source checkout -- a release binary has no dev scripts.",
+    )?;
+    let ci_dir = root.join(CHART_CI_DIR);
+    let scripts = discover_chart_check_scripts(&ci_dir)?;
+    if scripts.is_empty() {
+        bail!(
+            "no executable *.sh assertion scripts found in {}",
+            ci_dir.display()
+        );
+    }
+
+    ui.note(&format!(
+        "=== {} chart assertion scripts from {CHART_CI_DIR} (in {}) ===",
+        scripts.len(),
+        root.display()
+    ));
+    let outcomes = run_chart_check_scripts(&root, &scripts).await?;
+
+    ui.note("=== chart-check summary ===");
+    for outcome in &outcomes {
+        let mark = if outcome.passed { "PASS" } else { "FAIL" };
+        ui.note(&format!("{mark}  {}", outcome.name));
+    }
+
+    let failed: Vec<&str> = outcomes
+        .iter()
+        .filter(|o| !o.passed)
+        .map(|o| o.name.as_str())
+        .collect();
+    if !failed.is_empty() {
+        bail!(
+            "{} of {} chart assertion scripts failed: {}",
+            failed.len(),
+            outcomes.len(),
+            failed.join(", ")
+        );
+    }
+    ui.success(&format!(
+        "all {} chart assertion scripts passed",
+        outcomes.len()
+    ));
+    Ok(())
+}
+
 /// `curie list-agents`: list the plugin bundles under `agents/`, a personal,
 /// gitignored directory (sibling of `examples/`) for in-progress agent
 /// projects ready to hand to `curie deploy-local <folder>`. A release binary has

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -495,7 +495,10 @@ enum Command {
 enum DevAction {
     /// Check the frozen contracts (`bash scripts/check-contracts.sh`).
     Contracts,
-    /// Render-assert the Helm chart (`bash charts/curie/ci/render-assertions.sh`).
+    /// Render-assert the Helm chart: run every assertion script in
+    /// `charts/curie/ci/`, the same set helm-ci runs on a `charts/curie/**`
+    /// change (#1481). Reports per-script pass or fail and exits non-zero if any
+    /// failed, so one run surfaces every problem.
     ChartCheck,
     /// Run the scripted CLI end-to-end test (`bash cli/scripts/e2e.sh`).
     E2e,
@@ -1981,9 +1984,7 @@ async fn run(command: Option<Command>) -> Result<()> {
         },
         Some(Command::Dev { action }) => match action {
             DevAction::Contracts => commands::dev_script("scripts/check-contracts.sh").await,
-            DevAction::ChartCheck => {
-                commands::dev_script("charts/curie/ci/render-assertions.sh").await
-            }
+            DevAction::ChartCheck => commands::dev_chart_check().await,
             DevAction::E2e => commands::dev_script("cli/scripts/e2e.sh").await,
             DevAction::E2eLadder => commands::dev_script("cli/scripts/e2e-ladder.sh").await,
             DevAction::ChartRuntimeE2e => {

--- a/cli/tests/chart_check.rs
+++ b/cli/tests/chart_check.rs
@@ -1,0 +1,264 @@
+//! `curie dev chart-check` covers what helm-ci covers (#1481).
+//!
+//! helm-ci runs every script in `charts/curie/ci/` on any `charts/curie/**`
+//! change, and #1466 made that job release-blocking. The verb used to shell one
+//! script, so a contributor could run the documented local chart gate, see
+//! green, push, and be refused by CI on any of the other sixteen.
+//!
+//! The gap was structural, not a missing entry in a list: the verb named its one
+//! script literally, so every script added since was invisible to it. These
+//! tests pin the two properties that close it -- discovery from the directory,
+//! and a run that reports every failure rather than the first -- plus the
+//! divergence gate that keeps the verb and helm-ci describing the same set.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use curie::commands::{discover_chart_check_scripts, run_chart_check_scripts, CHART_CI_DIR};
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"), "/.."))
+}
+
+/// Write `body` to `dir/name` and mark it executable, the shape the discovery
+/// walk selects on.
+fn write_script(dir: &Path, name: &str, body: &str) -> PathBuf {
+    let path = dir.join(name);
+    std::fs::write(&path, body).expect("write scratch script");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755))
+            .expect("chmod scratch script");
+    }
+    path
+}
+
+/// AC3: a script added to `charts/curie/ci/` is picked up with no edit to `cli/`.
+///
+/// The scratch copy stands in for the real directory so the assertion is about
+/// discovery rather than about any particular chart assertion. A deliberately
+/// failing script is the load-bearing half: it proves the new file was actually
+/// executed, not merely listed.
+#[tokio::test]
+async fn a_newly_added_script_is_discovered_and_run_with_no_cli_edit() {
+    let scratch = tempfile::tempdir().expect("scratch dir");
+    write_script(
+        scratch.path(),
+        "aaa-existing-assertions.sh",
+        "#!/bin/bash\nexit 0\n",
+    );
+
+    let before = discover_chart_check_scripts(scratch.path()).expect("discover");
+    assert_eq!(
+        before.len(),
+        1,
+        "expected the one seeded script, got {before:?}"
+    );
+
+    // The edit a contributor makes: drop a new script in the directory, touch
+    // nothing in cli/.
+    write_script(
+        scratch.path(),
+        "zzz-newly-added-assertions.sh",
+        "#!/bin/bash\nexit 1\n",
+    );
+
+    let after = discover_chart_check_scripts(scratch.path()).expect("discover");
+    assert_eq!(
+        after
+            .iter()
+            .map(|p| p.file_name().unwrap().to_string_lossy().into_owned())
+            .collect::<Vec<_>>(),
+        vec![
+            "aaa-existing-assertions.sh".to_string(),
+            "zzz-newly-added-assertions.sh".to_string(),
+        ],
+        "the new script must be discovered, in sorted order"
+    );
+
+    let outcomes = run_chart_check_scripts(scratch.path(), &after)
+        .await
+        .expect("run the discovered scripts");
+    let failed: Vec<&str> = outcomes
+        .iter()
+        .filter(|o| !o.passed)
+        .map(|o| o.name.as_str())
+        .collect();
+    assert_eq!(
+        failed,
+        vec!["zzz-newly-added-assertions.sh"],
+        "the newly added failing script must be run and reported as failed"
+    );
+}
+
+/// AC2: one run surfaces every problem, so a failure does not stop the run.
+///
+/// Ordered fail / pass / fail on purpose: stopping at the first failure would
+/// report one failure and never reach the third script, which is the behavior
+/// that makes a contributor fix-and-rerun once per broken assertion.
+#[tokio::test]
+async fn a_failing_script_does_not_stop_the_run() {
+    let scratch = tempfile::tempdir().expect("scratch dir");
+    write_script(
+        scratch.path(),
+        "1-fails-assertions.sh",
+        "#!/bin/bash\nexit 1\n",
+    );
+    write_script(
+        scratch.path(),
+        "2-passes-assertions.sh",
+        "#!/bin/bash\nexit 0\n",
+    );
+    write_script(
+        scratch.path(),
+        "3-also-fails-assertions.sh",
+        "#!/bin/bash\nexit 3\n",
+    );
+
+    let scripts = discover_chart_check_scripts(scratch.path()).expect("discover");
+    let outcomes = run_chart_check_scripts(scratch.path(), &scripts)
+        .await
+        .expect("run the discovered scripts");
+
+    assert_eq!(
+        outcomes.len(),
+        3,
+        "every script must run, not just up to the first failure"
+    );
+    let failed: Vec<&str> = outcomes
+        .iter()
+        .filter(|o| !o.passed)
+        .map(|o| o.name.as_str())
+        .collect();
+    assert_eq!(
+        failed,
+        vec!["1-fails-assertions.sh", "3-also-fails-assertions.sh"],
+        "both failures must be reported from a single run"
+    );
+}
+
+/// Discovery selects executable `*.sh` only: a README or a non-executable
+/// fragment sitting in the directory is not an assertion script, and running one
+/// would fail the whole verb for a file that never was a check.
+#[tokio::test]
+async fn discovery_skips_non_scripts_and_non_executable_files() {
+    let scratch = tempfile::tempdir().expect("scratch dir");
+    write_script(
+        scratch.path(),
+        "real-assertions.sh",
+        "#!/bin/bash\nexit 0\n",
+    );
+    std::fs::write(scratch.path().join("README.md"), "not a script\n").expect("write readme");
+    std::fs::write(scratch.path().join("fragment.sh"), "#!/bin/bash\nexit 1\n")
+        .expect("write non-executable fragment");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(
+            scratch.path().join("fragment.sh"),
+            std::fs::Permissions::from_mode(0o644),
+        )
+        .expect("chmod fragment non-executable");
+    }
+
+    let scripts = discover_chart_check_scripts(scratch.path()).expect("discover");
+    assert_eq!(
+        scripts
+            .iter()
+            .map(|p| p.file_name().unwrap().to_string_lossy().into_owned())
+            .collect::<Vec<_>>(),
+        vec!["real-assertions.sh".to_string()],
+        "only executable *.sh files are assertion scripts"
+    );
+}
+
+/// The set of scripts helm-ci names, recovered from the workflow rather than
+/// from a second hardcoded list.
+fn helm_ci_referenced_scripts() -> Vec<String> {
+    let workflow = std::fs::read_to_string(repo_root().join(".github/workflows/helm-ci.yaml"))
+        .expect(".github/workflows/helm-ci.yaml is committed");
+    let needle = format!("{CHART_CI_DIR}/");
+    let mut found: Vec<String> = Vec::new();
+    for line in workflow.lines() {
+        let Some(start) = line.find(&needle) else {
+            continue;
+        };
+        let rest = &line[start + needle.len()..];
+        let end = rest.find(".sh").expect("a referenced script ends in .sh");
+        found.push(rest[..end + 3].to_string());
+    }
+    found
+}
+
+/// AC5: the verb and helm-ci cannot silently diverge.
+///
+/// The verb discovers the directory and helm-ci names each script in its own
+/// step, so the two agree only by construction if something asserts it. Without
+/// this, a script added to the directory is run locally and never in CI (a check
+/// that blocks no release), or a helm-ci step outlives the script it names (a
+/// step that fails for a missing file). Exact 1:1 is assertable because this
+/// change also removed the duplicated `worker-object-store-assertions.sh` step
+/// that #1473 filed.
+#[test]
+fn helm_ci_and_the_chart_ci_directory_cannot_diverge() {
+    let ci_dir = repo_root().join(CHART_CI_DIR);
+    let mut on_disk: Vec<String> = discover_chart_check_scripts(&ci_dir)
+        .expect("the committed chart assertion directory is readable")
+        .iter()
+        .map(|p| p.file_name().unwrap().to_string_lossy().into_owned())
+        .collect();
+    on_disk.sort();
+
+    let referenced = helm_ci_referenced_scripts();
+    let mut unique = referenced.clone();
+    unique.sort();
+    unique.dedup();
+
+    assert_eq!(
+        referenced.len(),
+        unique.len(),
+        "helm-ci names a script more than once; a duplicated step costs CI time and \
+         hides which assertion actually covers the change"
+    );
+    assert_eq!(
+        unique, on_disk,
+        "helm-ci and {CHART_CI_DIR} disagree. Every script in the directory needs a \
+         helm-ci step, and every helm-ci step needs a script that exists."
+    );
+}
+
+/// AC4: the verb passes on the unmodified chart.
+///
+/// This runs the real assertion suite, so it needs `helm` on PATH and takes
+/// single-digit seconds. It skips rather than fails where helm is absent, the
+/// same posture as the Valkey-backed tests: a missing local tool is not a
+/// regression in the chart. helm-ci itself is the environment where the suite is
+/// guaranteed to run.
+#[tokio::test]
+async fn chart_check_passes_on_the_unmodified_chart() {
+    if Command::new("helm").arg("version").output().is_err() {
+        eprintln!("skipping: helm is not on PATH");
+        return;
+    }
+
+    let root = repo_root();
+    let scripts = discover_chart_check_scripts(&root.join(CHART_CI_DIR)).expect("discover");
+    assert!(
+        !scripts.is_empty(),
+        "the chart assertion directory must not be empty"
+    );
+
+    let outcomes = run_chart_check_scripts(&root, &scripts)
+        .await
+        .expect("run the committed chart assertion scripts");
+    let failed: Vec<&str> = outcomes
+        .iter()
+        .filter(|o| !o.passed)
+        .map(|o| o.name.as_str())
+        .collect();
+    assert!(
+        failed.is_empty(),
+        "chart-check must pass on the unmodified chart; failed: {failed:?}"
+    );
+}


### PR DESCRIPTION
`curie dev chart-check` shelled a single script, `render-assertions.sh`, while
helm-ci runs all 17 scripts in `charts/curie/ci/` on any `charts/curie/**`
change. Since #1466 made helm-ci release-blocking, the gap sat on the path that
can block a release: run the documented local chart gate, see green, push, and
get refused by CI on any of the other sixteen.

## What changed

- The verb **discovers** every executable `*.sh` in `charts/curie/ci/` by
  listing the directory, so a new script is picked up with no edit to `cli/`.
- It **runs them all before deciding** rather than stopping at the first
  failure, and prints a per-script PASS/FAIL summary, so one run surfaces every
  problem instead of one per fix-and-rerun cycle.
- It **exits non-zero** when any script failed, naming which.
- Removed the duplicated `worker-object-store-assertions.sh` step in helm-ci
  (#1473), which leaves an exact 1:1 between the directory and the workflow and
  means the divergence gate below needs no exception.

## Acceptance criteria

| AC | Where |
|---|---|
| 1. Discovered from the directory, not a hardcoded list | `discover_chart_check_scripts`, `cli/src/commands.rs` |
| 2. Per-script pass/fail, non-zero exit, no stop at first failure | `a_failing_script_does_not_stop_the_run` |
| 3. New script picked up with no `cli/` edit | `a_newly_added_script_is_discovered_and_run_with_no_cli_edit` |
| 4. Passes on the unmodified chart | `chart_check_passes_on_the_unmodified_chart` |
| 5. helm-ci and the directory cannot diverge | `helm_ci_and_the_chart_ci_directory_cannot_diverge` |

## Verification

Ran the verb itself, not just the tests:

- **Success path:** 17 scripts, all PASS, 8.4s, exit 0.
- **Failure path:** dropped a deliberately failing script into the directory.
  All 18 ran — the failure did not halt the run — the summary marked the one
  FAIL, and the verb exited 1 with
  `1 of 18 chart assertion scripts failed: aa-broken-assertions.sh`.
- **Divergence gate, negative controlled:** adding an unreferenced script to
  `charts/curie/ci/` turns `helm_ci_and_the_chart_ci_directory_cannot_diverge`
  red, so it rejects by execution rather than by inspection.

CI cost is unchanged — helm-ci already ran all 17. The local run is 8.4s, which
matches the issue's single-digit-seconds estimate.

`cargo fmt --check`, `cargo clippy --all-targets`, the full `cargo test` suite,
and `scripts/check-docs.sh` all pass. Both command manifests
(`cli/command-manifest.json` and `apps/ui/src/generated/commandManifest.ts`) are
regenerated, and `cli/README.md`'s dev-verb table is updated.

## Note for the reviewer

This branch and `task/1325-object-store-web-identity` (#1325) both edit
`.github/workflows/helm-ci.yaml` and will conflict textually — this one removes
the duplicated step, that one adds a new step for a new assertion script. Either
merge order works once the conflict is resolved; the divergence gate holds in
both, since #1325 adds its script and its helm-ci step together.

Closes #1481
