### PR TITLE
Add a key-free auth path for a BYO object store

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -259,6 +259,21 @@ jobs:
           set -euo pipefail
           bash charts/curie/ci/worker-object-store-assertions.sh
 
+      # Prove the key-free object store path (#1325). Pointing the bundle store
+      # at a real cloud object store used to REQUIRE static access keys: all
+      # three consumers supplied explicit credentials unconditionally, so an
+      # ambient role was never consulted. Clearing rustfs.auth.accessKey now
+      # omits every credential env and shell export, which only works if the
+      # omission is COMPLETE -- an empty AWS_ACCESS_KEY_ID is still a credential
+      # to the SDK, so it stops the provider chain and the web-identity provider
+      # is never reached. Also asserts the instance-role shortcut stays shut:
+      # NetworkPolicy selects pods and not containers, so opening IMDS for
+      # bundle-fetch would hand the node's IAM role to the runner as well.
+      - name: helm render assertions (object store web identity)
+        run: |
+          set -euo pipefail
+          bash charts/curie/ci/object-store-web-identity-assertions.sh
+
       - name: helm template + kubeconform (values-dev overlay)
         run: |
           set -euo pipefail

--- a/charts/curie/README.md
+++ b/charts/curie/README.md
@@ -250,6 +250,73 @@ UI; the project key also feeds the OTel Collector auth header). Override those
 values or supply `langfuse.existingSecret` to clear the gate. It is off by
 default so the zero-secret bare install stays green.
 
+### Key-free object store auth
+
+Pointing the bundle store at a real cloud object store (`rustfs.deploy: false`)
+normally means a scoped IAM user and long-lived keys in a Secret. That works and
+is genuinely least-privilege, but it is not the only option: clearing
+`rustfs.auth.accessKey` selects a key-free path (#1325) in which the chart omits
+every S3 credential from the API, the worker, and the sandbox bundle-fetch init
+container, so the AWS SDK falls through its provider chain to the **web-identity
+provider** (`AWS_ROLE_ARN` + `AWS_WEB_IDENTITY_TOKEN_FILE`) fed by a projected
+ServiceAccount token.
+
+Bind the role through the ServiceAccount annotations. On EKS with IRSA the
+pod-identity webhook reads the annotation and injects the projected token and
+both env vars:
+
+```yaml
+rustfs:
+  deploy: false
+  host: my-bucket.s3.us-east-1.amazonaws.com
+  port: 443
+  auth:
+    accessKey: ""            # selects the key-free path
+api:
+  serviceAccount:
+    annotations:
+      eks.amazonaws.com/role-arn: arn:aws:iam::000000000000:role/curie-api
+worker:
+  serviceAccount:
+    annotations:
+      eks.amazonaws.com/role-arn: arn:aws:iam::000000000000:role/curie-worker
+agentSandbox:
+  runner:
+    serviceAccount:
+      annotations:
+        eks.amazonaws.com/role-arn: arn:aws:iam::000000000000:role/curie-runner
+```
+
+Scope the runner's role to the bundle bucket, **read-only**. NetworkPolicy
+selects pods rather than containers, so any identity the bundle-fetch init
+container can assume is equally reachable by the runner beside it, and the
+runner is prompt-injectable by design.
+
+Two constraints are worth stating plainly.
+
+**Clearing the key with `rustfs.deploy: true` is refused at render.** The
+in-chart RustFS is configured with those same static credentials and has no
+web-identity path, so the combination would install green and then fail every
+bundle read and write. The chart fails with a message naming both options
+instead.
+
+**The instance role is deliberately unavailable, and this is not an oversight
+to work around.** The instinct on AWS is to drop the keys and let the node's
+IAM role answer via the metadata endpoint. Rail 1 denies `169.254.169.254` by
+construction, and `security-networkpolicy.yaml` computes an `except` so that a
+broad operator `allowedEgress` CIDR cannot re-permit it. Opening it would hand
+the node's IAM role to a prompt-injectable agent, which is strictly worse than a
+bucket-scoped IAM user. Web identity reads a **mounted token** rather than a
+network endpoint, so it needs no metadata access and leaves Rail 1 intact --
+which is exactly why it is the key-free path this chart supports.
+
+Off EKS, there is no pod-identity webhook, so a self-managed cluster (k3s
+included) needs an OIDC provider wired to IAM and the projected token volume
+supplied by the operator before the key-free path resolves to anything. Until
+that is in place, static keys in a Secret remain the supported choice, and they
+are the safer of the two available options rather than a limitation to route
+around.
+
 ## The two preflights
 
 Both run as Helm hooks (blocking a broken install) and are re-runnable via

--- a/charts/curie/ci/object-store-web-identity-assertions.sh
+++ b/charts/curie/ci/object-store-web-identity-assertions.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+#
+# Pointing the bundle store at a real cloud object store used to REQUIRE static
+# access keys: the api, the worker, and the sandbox bundle-fetch init container
+# each supplied explicit credentials unconditionally, so an ambient role was
+# never consulted (#1325).
+#
+# Clearing `rustfs.auth.accessKey` now selects a key-free path: every credential
+# env var is omitted so the AWS SDK falls through its provider chain to the
+# web-identity provider, fed by a projected ServiceAccount token.
+#
+# Two properties make that safe, and both are asserted here rather than trusted:
+#
+#   * OMISSION IS COMPLETE. A half-omitted credential is worse than either
+#     state. `AWS_ACCESS_KEY_ID` set to the empty string is not the same as
+#     unset -- the SDK treats an empty explicit credential as a credential and
+#     stops walking the chain, so the web-identity provider is never reached and
+#     the fetch fails with a signature error rather than falling through.
+#
+#   * IMDS STAYS DENIED. The obvious workaround on AWS is the node's instance
+#     role, and it must not be made to work. Rail 1 denies 169.254.169.254 by
+#     construction and computes an `except` so a broad operator `allowedEgress`
+#     CIDR cannot re-permit it. NetworkPolicy selects pods, not containers, so
+#     opening IMDS for bundle-fetch would also open it for the runner -- a
+#     prompt-injectable agent -- handing it the node's IAM role. That is
+#     strictly worse than a bucket-scoped IAM user, so this asserts the deny
+#     survives the key-free path.
+#
+# The static path is asserted unchanged alongside, because the failure this
+# guards against is a regression in the DEFAULT install, not in the new one.
+set -euo pipefail
+
+CHART=${CHART:-charts/curie}
+STATIC_RENDERED=$(mktemp)
+WEB_IDENTITY_RENDERED=$(mktemp)
+WEB_IDENTITY_VALUES=$(mktemp)
+trap 'rm -f "$STATIC_RENDERED" "$WEB_IDENTITY_RENDERED" "$WEB_IDENTITY_VALUES"' EXIT
+
+cat > "$WEB_IDENTITY_VALUES" <<'EOF'
+rustfs:
+  deploy: false
+  host: s3.example.com
+  port: 443
+  auth:
+    accessKey: ""
+# A key-free BYO store still has to be REACHABLE, so this overlay carries the
+# broad allowlist such an install realistically sets. That is also the only
+# configuration in which Rail 1's IMDS carve-out is observable: with an empty
+# allowlist there is no ipBlock permitting anything, so default-deny covers the
+# metadata address and there is nothing to except. The interesting case is
+# precisely this one -- an operator opens egress wide, and the metadata address
+# must stay denied anyway.
+security:
+  networkPolicy:
+    allowedEgress:
+      - cidr: 0.0.0.0/0
+        ports: [{ protocol: TCP, port: 443 }]
+api:
+  serviceAccount:
+    annotations:
+      eks.amazonaws.com/role-arn: arn:aws:iam::000000000000:role/curie-api
+worker:
+  serviceAccount:
+    annotations:
+      eks.amazonaws.com/role-arn: arn:aws:iam::000000000000:role/curie-worker
+agentSandbox:
+  runner:
+    serviceAccount:
+      annotations:
+        eks.amazonaws.com/role-arn: arn:aws:iam::000000000000:role/curie-runner
+EOF
+
+helm template curie "$CHART" --namespace dev > "$STATIC_RENDERED"
+helm template curie "$CHART" --namespace dev \
+  --values "$WEB_IDENTITY_VALUES" > "$WEB_IDENTITY_RENDERED"
+
+# Assertion 1: clearing the access key while the in-chart RustFS is deployed is
+# refused at render. That store is configured with those very credentials and
+# has no web-identity path, so the combination would install green and then fail
+# every bundle read and write -- the exact silent-misconfiguration shape this
+# issue is about. Negative control: the refusal must fire, so a render that
+# SUCCEEDS here is the failure.
+if helm template curie "$CHART" --namespace dev \
+  --set rustfs.auth.accessKey="" > /dev/null 2>&1; then
+  echo "FAIL: clearing rustfs.auth.accessKey with rustfs.deploy=true must be refused" >&2
+  exit 1
+fi
+echo "ok: an empty access key with the in-chart RustFS is refused at render"
+
+python3 - "$STATIC_RENDERED" "$WEB_IDENTITY_RENDERED" <<'PY'
+import ipaddress, sys, yaml
+
+CREDENTIAL_KEYS = ("S3_ACCESS_KEY", "S3_SECRET_KEY")
+# The metadata address Rail 1 denies. An instance-role path would need this
+# reachable; the web-identity path must not make it so.
+IMDS = ipaddress.ip_address("169.254.169.254")
+
+
+def env_for(container):
+    return {entry["name"]: entry for entry in container.get("env", [])}
+
+
+def read(path):
+    api = worker = bundle_fetch = None
+    fetch_command = ""
+    service_accounts = {}
+    egress_excepts = []
+    with open(path) as fh:
+        for doc in yaml.safe_load_all(fh):
+            if not doc:
+                continue
+            kind = doc.get("kind")
+            name = doc.get("metadata", {}).get("name", "")
+            if kind == "Deployment":
+                containers = doc["spec"]["template"]["spec"].get("containers", [])
+                assert containers, f"{name} Deployment has no containers"
+                if name.endswith("-api"):
+                    api = env_for(containers[0])
+                elif name.endswith("-worker"):
+                    worker = env_for(containers[0])
+            elif kind == "ServiceAccount":
+                service_accounts[name] = doc["metadata"].get("annotations") or {}
+            elif kind == "SandboxTemplate":
+                pod_spec = doc["spec"]["podTemplate"]["spec"]
+                matches = [
+                    container
+                    for container in pod_spec.get("initContainers", [])
+                    if container.get("name") == "bundle-fetch"
+                ]
+                assert len(matches) == 1, (
+                    "SandboxTemplate must render exactly one bundle-fetch init container"
+                )
+                bundle_fetch = env_for(matches[0])
+                fetch_command = " ".join(matches[0].get("command", []))
+            elif kind == "NetworkPolicy":
+                for rule in doc.get("spec", {}).get("egress", []) or []:
+                    for peer in rule.get("to", []) or []:
+                        block = peer.get("ipBlock") or {}
+                        egress_excepts.extend(block.get("except", []) or [])
+
+    assert api is not None, "api Deployment not rendered"
+    assert worker is not None, "worker Deployment not rendered"
+    assert bundle_fetch is not None, "SandboxTemplate bundle-fetch not rendered"
+    return api, worker, bundle_fetch, fetch_command, service_accounts, egress_excepts
+
+
+def assert_static(path):
+    api, worker, bundle_fetch, fetch_command, _, _ = read(path)
+    for label, env in (("api", api), ("worker", worker), ("bundle-fetch", bundle_fetch)):
+        missing = [key for key in CREDENTIAL_KEYS if key not in env]
+        assert not missing, (
+            f"the DEFAULT install must keep static credentials; {label} is missing {missing}. "
+            "The in-chart RustFS accepts nothing else."
+        )
+    assert "AWS_ACCESS_KEY_ID" in fetch_command, (
+        "the default bundle-fetch must still export AWS_ACCESS_KEY_ID"
+    )
+    print("ok: static: api, worker, and bundle-fetch all carry S3_ACCESS_KEY and S3_SECRET_KEY")
+
+
+def assert_web_identity(path):
+    api, worker, bundle_fetch, fetch_command, service_accounts, egress_excepts = read(path)
+
+    # Omission is complete: not present, not empty-valued. An empty explicit
+    # credential stops the provider chain just as a real one does, so it would
+    # defeat the whole path while looking like it had been removed.
+    for label, env in (("api", api), ("worker", worker), ("bundle-fetch", bundle_fetch)):
+        present = [key for key in CREDENTIAL_KEYS if key in env]
+        assert not present, (
+            f"{label} still carries {present} on the key-free path. The env var must be "
+            "ABSENT, not empty: the SDK treats an empty explicit credential as a credential "
+            "and never reaches the web-identity provider."
+        )
+
+    for name in ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"):
+        assert name not in fetch_command, (
+            f"bundle-fetch still exports {name} on the key-free path; the shell export is a "
+            "second credential source the env-var check alone would not catch."
+        )
+
+    # The endpoint still has to be configured -- omitting credentials must not
+    # omit the address, or the fetch fails for an unrelated reason.
+    assert bundle_fetch.get("S3_ENDPOINT", {}).get("value") == "https://s3.example.com:443", (
+        f"bundle-fetch lost its endpoint: {bundle_fetch.get('S3_ENDPOINT')}"
+    )
+    assert api.get("S3_ENDPOINT_URL", {}).get("value") == "https://s3.example.com:443", (
+        f"api lost its endpoint: {api.get('S3_ENDPOINT_URL')}"
+    )
+
+    # The role binds on the ServiceAccount, so an annotation that does not render
+    # means there is no way to name an identity at all.
+    annotated = {
+        name: annotations["eks.amazonaws.com/role-arn"]
+        for name, annotations in service_accounts.items()
+        if "eks.amazonaws.com/role-arn" in annotations
+    }
+    for suffix in ("-api", "-worker", "-runner"):
+        matches = [name for name in annotated if name.endswith(suffix)]
+        assert matches, (
+            f"no ServiceAccount ending in {suffix} carries eks.amazonaws.com/role-arn. "
+            "Without it the key-free path has no identity to assume."
+        )
+    print(f"ok: web-identity: {len(annotated)} ServiceAccounts carry a role-arn annotation")
+
+    # Rail 1 must be untouched by any of the above. Assert CONTAINMENT rather
+    # than a literal: the chart sizes the except to stay a strict subset of the
+    # allowed CIDR, so a /0 allowlist yields the 169.254.0.0/16 link-local block
+    # while a narrower one yields the /32 host. Both deny the metadata address;
+    # string-matching one of them would fail the moment an operator narrowed
+    # their allowlist, for no security reason.
+    covering = [
+        entry
+        for entry in egress_excepts
+        if IMDS in ipaddress.ip_network(entry, strict=False)
+    ]
+    assert covering, (
+        f"no egress `except` covers {IMDS}; the rendered excepts were {egress_excepts}. "
+        "Web identity reads a mounted token and needs no metadata access, so the key-free "
+        "path must not have opened IMDS -- NetworkPolicy selects pods, so opening it for "
+        "bundle-fetch opens it for the prompt-injectable runner too."
+    )
+    print(f"ok: web-identity: Rail 1 still excepts {IMDS} via {covering}; no instance-role path")
+    print("ok: web-identity: no S3 credential env or shell export reaches any consumer")
+
+
+assert_static(sys.argv[1])
+assert_web_identity(sys.argv[2])
+PY
+
+echo
+echo "PASS: the default install keeps static object-store credentials; clearing rustfs.auth.accessKey omits every credential env and shell export across api, worker, and bundle-fetch, binds identity through ServiceAccount annotations, is refused against the in-chart RustFS, and leaves Rail 1's IMDS denial intact."

--- a/charts/curie/templates/_helpers.tpl
+++ b/charts/curie/templates/_helpers.tpl
@@ -162,6 +162,34 @@ http
 {{- include "curie.rustfs.scheme" . }}://{{ include "curie.rustfs.host" . }}:{{ .Values.rustfs.port }}
 {{- end -}}
 
+{{/* Whether the object-store clients (api, worker, and the sandbox
+     bundle-fetch init container) present static credentials.
+
+     Non-empty when `rustfs.auth.accessKey` is set, which is the default and the
+     only mode the in-chart RustFS supports. Empty when the operator cleared it,
+     which is the BYO key-free path (#1325): every credential env var is omitted
+     so the AWS SDK falls through its provider chain to the web-identity
+     provider (`AWS_ROLE_ARN` + `AWS_WEB_IDENTITY_TOKEN_FILE`), fed by a
+     projected ServiceAccount token.
+
+     Web identity is the ONLY key-free path this chart supports, deliberately.
+     The instinct on AWS is to drop the keys and let the node's instance role
+     answer, and that must not be made to work here: Rail 1 denies
+     169.254.169.254 by construction, and `security-networkpolicy.yaml` computes
+     an `except` so a broad operator `allowedEgress` CIDR cannot re-permit the
+     metadata address. NetworkPolicy selects pods, not containers, so opening
+     IMDS for the bundle-fetch init container would also open it for the runner
+     -- a prompt-injectable agent -- handing it the node's IAM role. Web
+     identity reads a mounted token instead of a network endpoint, so it needs
+     no metadata access and leaves Rail 1 intact. */}}
+{{- define "curie.rustfs.staticCredentials" -}}
+{{- if .Values.rustfs.auth.accessKey -}}
+true
+{{- else if .Values.rustfs.deploy -}}
+{{- fail "rustfs.auth.accessKey is empty but rustfs.deploy is true. The in-chart RustFS is configured with those static credentials and has no web-identity path, so clearing the key would leave every bundle read and write unauthenticated against it. Either set rustfs.auth.accessKey, or set rustfs.deploy=false and point rustfs.host at an external store that accepts the ServiceAccount's projected token (see the chart README, 'Key-free object store auth')." -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "curie.langfuse.webHost" -}}
 {{- printf "%s-langfuse-web" (include "curie.fullname" .) -}}
 {{- end -}}

--- a/charts/curie/templates/agent-sandbox.yaml
+++ b/charts/curie/templates/agent-sandbox.yaml
@@ -279,8 +279,16 @@ spec:
                 echo "no CURIE_BUNDLE_REF; skipping bundle fetch"
                 exit 0
               fi
+              {{- if include "curie.rustfs.staticCredentials" . }}
               export AWS_ACCESS_KEY_ID="$S3_ACCESS_KEY"
               export AWS_SECRET_ACCESS_KEY="$S3_SECRET_KEY"
+              {{- else }}
+              # Key-free path (#1325): no credential env is set, so the AWS CLI
+              # falls through its provider chain to the web-identity provider
+              # (AWS_ROLE_ARN + AWS_WEB_IDENTITY_TOKEN_FILE) fed by a projected
+              # ServiceAccount token. That reads a mounted file rather than the
+              # metadata endpoint, so Rail 1's IMDS denial stays intact.
+              {{- end }}
               aws configure set default.s3.addressing_style path
               aws --endpoint-url "$S3_ENDPOINT" s3 cp "s3://${BUNDLE_BUCKET}/${REF}" {{ $bf.mountPath }}/.bundle-archive
               echo "fetched bundle '$REF' from ${BUNDLE_BUCKET}"
@@ -289,6 +297,7 @@ spec:
               value: ""
             - name: S3_ENDPOINT
               value: {{ include "curie.rustfs.endpoint" . }}
+            {{- if include "curie.rustfs.staticCredentials" . }}
             - name: S3_ACCESS_KEY
               value: {{ .Values.rustfs.auth.accessKey | quote }}
             - name: S3_SECRET_KEY
@@ -296,6 +305,7 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.rustfs.existingSecret | default (include "curie.secretName" .) }}
                   key: rustfsSecretKey
+            {{- end }}
             - name: BUNDLE_BUCKET
               value: {{ $bf.bucket | quote }}
             - name: AWS_DEFAULT_REGION

--- a/charts/curie/templates/api-rbac.yaml
+++ b/charts/curie/templates/api-rbac.yaml
@@ -16,6 +16,13 @@ metadata:
   labels:
     {{- include "curie.labels" . | nindent 4 }}
     app.kubernetes.io/component: api
+  {{- with .Values.api.serviceAccount.annotations }}
+  # Where a key-free object store binds its identity (#1325): an IRSA install
+  # annotates this SA with `eks.amazonaws.com/role-arn`, and the pod-identity
+  # webhook injects the projected token and the two web-identity env vars.
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/charts/curie/templates/api.yaml
+++ b/charts/curie/templates/api.yaml
@@ -130,6 +130,7 @@ spec:
                   key: langfuseInitProjectSecretKey
             - name: S3_ENDPOINT_URL
               value: {{ include "curie.rustfs.endpoint" . }}
+            {{- if include "curie.rustfs.staticCredentials" . }}
             - name: S3_ACCESS_KEY
               value: {{ .Values.rustfs.auth.accessKey | quote }}
             - name: S3_SECRET_KEY
@@ -137,6 +138,7 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.rustfs.existingSecret | default (include "curie.secretName" .) }}
                   key: rustfsSecretKey
+            {{- end }}
             # Immutable plugin-bundle bucket. Single source of truth with the
             # runner sandbox's bundle-fetch init container: the API writes each
             # uploaded bundle here, the fetcher reads it from the same bucket, so

--- a/charts/curie/templates/security-rbac.yaml
+++ b/charts/curie/templates/security-rbac.yaml
@@ -19,5 +19,18 @@ metadata:
   labels:
     {{- include "curie.labels" . | nindent 4 }}
     app.kubernetes.io/component: agent-sandbox
+  {{- with .Values.agentSandbox.runner.serviceAccount.annotations }}
+  # Where a key-free object store binds the bundle-fetch identity (#1325): an
+  # IRSA install annotates this SA with `eks.amazonaws.com/role-arn`. The
+  # projected web-identity token is a separate volume from the SA's own API
+  # token, so this composes with `automountToken: false` below -- the runner
+  # still cannot reach the Kubernetes API.
+  #
+  # Scope this role to the bundle bucket, read-only. NetworkPolicy selects pods
+  # and not containers, so any identity reachable by the bundle-fetch init
+  # container is also reachable by the runner, which is prompt-injectable.
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 automountServiceAccountToken: {{ .Values.agentSandbox.runner.serviceAccount.automountToken }}
 {{- end }}

--- a/charts/curie/templates/worker.yaml
+++ b/charts/curie/templates/worker.yaml
@@ -16,6 +16,13 @@ metadata:
   labels:
     {{- include "curie.labels" . | nindent 4 }}
     app.kubernetes.io/component: worker
+  {{- with .Values.worker.serviceAccount.annotations }}
+  # Where a key-free object store binds its identity (#1325): an IRSA install
+  # annotates this SA with `eks.amazonaws.com/role-arn`, and the pod-identity
+  # webhook injects the projected token and the two web-identity env vars.
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -251,6 +258,7 @@ spec:
             # agree. ci/worker-object-store-assertions.sh asserts they do.
             - name: S3_ENDPOINT_URL
               value: {{ include "curie.rustfs.endpoint" . }}
+            {{- if include "curie.rustfs.staticCredentials" . }}
             - name: S3_ACCESS_KEY
               value: {{ .Values.rustfs.auth.accessKey | quote }}
             - name: S3_SECRET_KEY
@@ -258,6 +266,7 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.rustfs.existingSecret | default (include "curie.secretName" .) }}
                   key: rustfsSecretKey
+            {{- end }}
             - name: BUNDLE_BUCKET
               value: {{ .Values.agentSandbox.runner.bundleFetch.bucket | quote }}
             {{- with .Values.worker.extraEnv }}

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -397,6 +397,25 @@ rustfs:
   port: 9000
   consolePort: 9001
   bucket: langfuse
+  # Static credentials, and the only mode the in-chart RustFS supports.
+  #
+  # Clearing `accessKey` selects the key-free path (#1325), valid only with
+  # `deploy: false` and an external store: every S3 credential env var is
+  # omitted from the api, the worker, and the sandbox bundle-fetch init
+  # container, so the AWS SDK falls through its provider chain to the
+  # web-identity provider (`AWS_ROLE_ARN` + `AWS_WEB_IDENTITY_TOKEN_FILE`) fed
+  # by a projected ServiceAccount token. Bind the role with the
+  # `serviceAccount.annotations` blocks on `api`, `worker`, and
+  # `agentSandbox.runner`. Clearing it with `deploy: true` is refused at render.
+  #
+  # The instance role is NOT an option here, deliberately. Rail 1 denies
+  # 169.254.169.254 by construction and computes an `except` so a broad
+  # `allowedEgress` CIDR cannot re-permit it. NetworkPolicy selects pods rather
+  # than containers, so opening IMDS for the bundle-fetch init container also
+  # opens it for the runner -- a prompt-injectable agent -- which would hand it
+  # the node's IAM role. Web identity reads a mounted token instead, needs no
+  # metadata access, and so leaves Rail 1 intact. Chart README, "Key-free object
+  # store auth", has the full setup.
   auth:
     accessKey: rustfs
     secretKey: rustfssecret
@@ -513,6 +532,14 @@ api:
     digest: ""
     pullPolicy: Always
   imagePullSecrets: []
+  # The API gets a ServiceAccount with a narrow read-only Role for the runner-log
+  # observability proxy (see templates/api-rbac.yaml). It is created with the
+  # API, so there is no `create` toggle here.
+  serviceAccount:
+    # Extra annotations on the API ServiceAccount. The key-free object store
+    # path (#1325) binds its IAM role here, e.g.
+    # `eks.amazonaws.com/role-arn: arn:aws:iam::<account>:role/<role>`.
+    annotations: {}
   # Deploy environment the API boots as (`dev` or `prod`), rendered as
   # ENVIRONMENT on the api container. `prod` arms the API production boot gate,
   # which refuses to start on the dev-default `apiKey`/`githubWebhookSecret`
@@ -746,6 +773,10 @@ worker:
   # (see templates/worker.yaml). Its token IS mounted (unlike the runner SA).
   serviceAccount:
     create: true
+    # Extra annotations on the worker ServiceAccount. The key-free object store
+    # path (#1325) binds its IAM role here, e.g.
+    # `eks.amazonaws.com/role-arn: arn:aws:iam::<account>:role/<role>`.
+    annotations: {}
   # Declarative connector hosting (ADR-0090): the worker converges each agent's
   # connector Deployment/Service/Secret/NetworkPolicy toward what its in-force
   # bundle declares, so an agent repo needs no CLI near the cluster.
@@ -1226,6 +1257,16 @@ agentSandbox:
       create: true
       # The runner does not call the K8s API, so its token is not mounted.
       automountToken: false
+      # Extra annotations on the runner ServiceAccount. The key-free object
+      # store path (#1325) binds the bundle-fetch IAM role here, e.g.
+      # `eks.amazonaws.com/role-arn: arn:aws:iam::<account>:role/<role>`. The
+      # projected web-identity token is a separate volume from the SA's own API
+      # token, so this composes with `automountToken: false`.
+      #
+      # Scope that role to the bundle bucket, read-only: NetworkPolicy selects
+      # pods and not containers, so an identity the bundle-fetch init container
+      # can reach is also reachable by the runner, which is prompt-injectable.
+      annotations: {}
 
 # ---------------------------------------------------------------------------
 # Security rails. The four security-boundary rails shipped ON by default. They


### PR DESCRIPTION
Pointing the bundle store at a real cloud object store (`rustfs.deploy: false`,
the documented production path) **required static access keys**. `api.yaml`,
`worker.yaml`, and the sandbox `bundle-fetch` init container each supplied
explicit credentials unconditionally, so an ambient role was never consulted.

## What changed

- **Clearing `rustfs.auth.accessKey` selects a key-free path.** Every S3
  credential env var is omitted from the API, the worker, and the bundle-fetch
  init container, along with bundle-fetch's `export AWS_ACCESS_KEY_ID` /
  `AWS_SECRET_ACCESS_KEY` lines, so the AWS SDK falls through its provider chain
  to the web-identity provider (`AWS_ROLE_ARN` + `AWS_WEB_IDENTITY_TOKEN_FILE`)
  fed by a projected ServiceAccount token.
- **`serviceAccount.annotations` on `api`, `worker`, and `agentSandbox.runner`**
  — where an IRSA install binds its role. The projected web-identity token is a
  separate volume from the SA's own API token, so the runner keeps
  `automountToken: false` and still cannot reach the Kubernetes API.
- **Clearing the key with `rustfs.deploy: true` is refused at render.** The
  in-chart RustFS is configured with those same credentials and has no
  web-identity path, so that combination would install green and then fail every
  bundle read and write. The refusal names both ways out.
- **Documented that IMDS is deliberately unavailable, and why** — in
  `values.yaml`, in the helper, and in a new chart README section, so an
  operator reading any of the three finds the reasoning rather than reaching for
  the instance role.

## Why not the instance role

Rail 1 denies `169.254.169.254` by construction, and
`security-networkpolicy.yaml` computes an `except` so a broad operator
`allowedEgress` CIDR cannot re-permit it. NetworkPolicy selects pods, not
containers, so opening IMDS for `bundle-fetch` also opens it for the runner —
a prompt-injectable agent — handing it the node's IAM role. That is strictly
worse than a bucket-scoped IAM user. Web identity reads a mounted token instead
of a network endpoint, so it needs no metadata access and leaves Rail 1 intact.
That is exactly why it is the key-free path this chart supports.

The chart README says so explicitly, and says that where no OIDC provider is
wired (a self-managed k3s install), static keys in a Secret remain the supported
choice and are the safer of the two available options rather than a limitation
to route around.

## Verification

New `charts/curie/ci/object-store-web-identity-assertions.sh`, wired into
helm-ci, asserts:

- the **default** install still carries static credentials on all three
  consumers (the regression this change could cause);
- omission on the key-free path is **complete** — absent, not empty. An empty
  explicit credential stops the SDK's provider chain just as a real one does, so
  an empty-valued env var would defeat the whole path while looking removed;
- neither `AWS_ACCESS_KEY_ID` nor `AWS_SECRET_ACCESS_KEY` survives as a shell
  export, which the env-var check alone would not catch;
- the endpoint still renders, so omitting credentials does not omit the address;
- the role annotations render on all three ServiceAccounts;
- the in-chart refusal fires (a render that *succeeds* there is the failure);
- an egress `except` still covers the metadata address under a broad
  `0.0.0.0/0` allowlist. Asserted by containment rather than string match: the
  chart sizes the except to stay a strict subset, so `/0` yields
  `169.254.0.0/16` and a narrower CIDR yields the `/32` host.

The guard was **negative controlled**: reverting the `api.yaml` gating makes the
script fail with `api still carries ['S3_ACCESS_KEY', 'S3_SECRET_KEY'] on the
key-free path`, so it rejects by execution rather than by inspection.

**The default install is unchanged.** Rendering before and after this change is
byte-identical against `values-dev.yaml`, and identical against the default
values apart from the per-render generated secrets. Since the default path's
manifests do not move, its runtime behavior cannot have changed — which is the
regression risk here, and better evidence for it than a cluster run.

All 18 chart assertion scripts pass and all three `helm lint` overlays are clean.

## What is not verified here

The key-free path is **render-verified only**. Exercising it needs a cluster with
an OIDC provider wired to IAM plus a real bucket; `scripts/chart-runtime-e2e.sh`
targets the `k8scratch` scratch cluster and has neither, so it cannot prove the
credential actually resolves. Stating that plainly rather than implying a runtime
pass: what is proven is that the chart emits the right shape and takes nothing
away from Rail 1.

## Note for the reviewer

This branch and `task/1481-chart-check-all-scripts` (#1481) both edit
`.github/workflows/helm-ci.yaml` and will conflict textually — that one removes
the duplicated `worker-object-store-assertions.sh` step, this one adds a step.
Either merge order works once the conflict is resolved; #1481's divergence gate
requires every script in `charts/curie/ci/` to have exactly one helm-ci step,
which holds in both orders.

Closes #1325
