### PR TITLE
Pin connector render argument identity and every port reader

### DIFF
--- a/apps/api/src/curie_api/bundles.py
+++ b/apps/api/src/curie_api/bundles.py
@@ -155,7 +155,15 @@ def render_connector_manifests(
     objects: list[dict[str, Any]] = []
     for name, spec in sorted(connectors.connectors.items()):
         objects.extend(
-            connector_render.render(release, agent, namespace, app_name, name, spec, secret_name)
+            connector_render.render(
+                release=release,
+                agent=agent,
+                namespace=namespace,
+                app_name=app_name,
+                connector=name,
+                spec=spec,
+                secret_name=secret_name,
+            )
         )
     return objects
 

--- a/apps/api/tests/test_bundle_connectors.py
+++ b/apps/api/tests/test_bundle_connectors.py
@@ -41,14 +41,28 @@ HOSTED = (
 )
 
 
-def _render(root: Path, agent: str = "acme-bot") -> list[dict]:
+# These four are forwarded into `connector_render.render` as four bare strings,
+# so they MUST stay distinct from one another. Held equal, the forward is pinned
+# by nothing: swapping any two of them leaves every test in this file green
+# while the rendered NetworkPolicies select no pod at all. A real install
+# already drives at least one apart -- `curie cluster up --namespace my-agent
+# --release my-agent` against a chart whose `nameOverride` is empty leaves
+# app_name `curie` while release and namespace are both `my-agent`.
+RELEASE = "acme-rel"
+AGENT = "acme-bot"
+NAMESPACE = "acme-ns"
+APP_NAME = "curie"
+SECRET_NAME = f"{RELEASE}-{AGENT}-connectors"
+
+
+def _render(root: Path, agent: str = AGENT) -> list[dict]:
     return bundles.render_connector_manifests(
         bundles.read_connectors(root),
-        release="acme-bot",
+        release=RELEASE,
         agent=agent,
-        namespace="acme-bot",
-        app_name="acme-bot",
-        secret_name=f"acme-bot-{agent}-connectors",
+        namespace=NAMESPACE,
+        app_name=APP_NAME,
+        secret_name=f"{RELEASE}-{agent}-connectors",
     )
 
 
@@ -93,7 +107,7 @@ def test_secret_is_referenced_not_inlined(tmp_path: Path) -> None:
     dep = next(o for o in _render(_bundle(tmp_path, HOSTED)) if o["kind"] == "Deployment")
     env = dep["spec"]["template"]["spec"]["containers"][0]["env"]
     token = next(e for e in env if e["name"] == "GRAFANA_TOKEN")
-    assert token["valueFrom"]["secretKeyRef"]["name"] == "acme-bot-acme-bot-connectors"
+    assert token["valueFrom"]["secretKeyRef"]["name"] == SECRET_NAME
     assert "value" not in token
 
 
@@ -138,16 +152,65 @@ def test_mcp_entry_url_matches_the_rendered_service(tmp_path: Path) -> None:
     root = _bundle(tmp_path, HOSTED)
     svc = next(o for o in _render(root) if o["kind"] == "Service")
     entries = bundles.connector_mcp_entries(
-        bundles.read_connectors(root), release="acme-bot", agent="acme-bot", namespace="acme-bot"
+        bundles.read_connectors(root), release=RELEASE, agent=AGENT, namespace=NAMESPACE
     )
     assert svc["metadata"]["name"] in entries["grafana"]["url"]
+
+
+IDENTITY = (
+    "connectors:\n"
+    "  grafana:\n"
+    "    image: grafana/mcp-grafana:0.17.2\n"
+    "    env: {SELF_URL: '${CURIE_CONNECTOR_URL}'}\n"
+)
+
+
+def test_each_of_the_four_names_lands_where_it_belongs(tmp_path: Path) -> None:
+    # `render_connector_manifests` hands release, agent, namespace and app_name
+    # to the renderer as four interchangeable-looking strings. Swapping any two
+    # produces manifests that parse, apply, and are wrong: release for app_name
+    # makes the sandbox selector read `app.kubernetes.io/name: acme-rel` instead
+    # of `curie`, both NetworkPolicies then select no pod, and every connector
+    # tool call dies as a bare connection timeout with no policy error anywhere.
+    # Each of the four is asserted at the place only IT can reach, against whole
+    # values rather than substrings, so no swap survives.
+    root = _bundle(tmp_path, IDENTITY)
+    objs = _render(root)
+    name = f"{RELEASE}-{AGENT}-mcp-grafana"
+    dns = f"{name}.{NAMESPACE}.svc.cluster.local"
+    sandbox = {
+        "app.kubernetes.io/name": APP_NAME,
+        "app.kubernetes.io/instance": RELEASE,
+        "app.kubernetes.io/component": "runner-sandbox",
+    }
+
+    # app_name and release: the sandbox selector, on both policies.
+    assert _policy(objs, "Egress")["spec"]["podSelector"]["matchLabels"] == sandbox
+    ingress_from = _policy(objs, "Ingress")["spec"]["ingress"][0]["from"][0]
+    assert ingress_from["podSelector"]["matchLabels"] == sandbox
+
+    # release and agent: the object name, in that order, plus part-of.
+    dep = next(o for o in objs if o["kind"] == "Deployment")
+    assert {o["metadata"]["name"] for o in objs} == {name, f"{name}-allow", f"{name}-allow-ingress"}
+    assert dep["metadata"]["labels"] == {
+        "app.kubernetes.io/name": name,
+        "app.kubernetes.io/part-of": RELEASE,
+    }
+
+    # namespace: the only place it shows up is the Service DNS Curie derives.
+    env = dep["spec"]["template"]["spec"]["containers"][0]["env"]
+    assert {"name": "SELF_URL", "value": f"http://{dns}:8000"} in env
+    entries = bundles.connector_mcp_entries(
+        bundles.read_connectors(root), release=RELEASE, agent=AGENT, namespace=NAMESPACE
+    )
+    assert entries["grafana"] == {"type": "http", "url": f"http://{dns}:8000/mcp"}
 
 
 def test_remote_connector_contributes_an_entry_but_no_objects(tmp_path: Path) -> None:
     root = _bundle(tmp_path, "connectors:\n  x:\n    url: https://mcp.internal/mcp\n")
     assert _render(root) == []
     entries = bundles.connector_mcp_entries(
-        bundles.read_connectors(root), release="acme-bot", agent="acme-bot", namespace="acme-bot"
+        bundles.read_connectors(root), release=RELEASE, agent=AGENT, namespace=NAMESPACE
     )
     assert entries["x"]["url"] == "https://mcp.internal/mcp"
 

--- a/packages/plugin-format/src/plugin_format/connector_render.py
+++ b/packages/plugin-format/src/plugin_format/connector_render.py
@@ -398,6 +398,7 @@ def render_ingress_networkpolicy(
 
 
 def render(
+    *,
     release: str,
     agent: str,
     namespace: str,
@@ -406,7 +407,20 @@ def render(
     spec: ConnectorSpec,
     secret_name: str,
 ) -> list[dict[str, Any]]:
-    """Every object needed to run one hosted connector. Empty for a remote one."""
+    """Every object needed to run one hosted connector. Empty for a remote one.
+
+    Keyword-only, deliberately. Four of the seven parameters are strings that
+    look interchangeable at a call site -- release, agent, namespace, app_name --
+    and they are not: in a real install `curie cluster up --namespace my-agent
+    --release my-agent` against a chart whose `nameOverride` is empty leaves
+    app_name as `curie` while release and namespace are both `my-agent`, so no
+    one value can stand in for all four. Swapping release and app_name
+    positionally makes `sandbox_selector` emit `app.kubernetes.io/name: my-agent`
+    instead of `curie`, and both NetworkPolicies then parse, apply, and select
+    no pod: every connector tool call dies as a bare connection timeout with no
+    policy error anywhere. A positional call site cannot express that mistake
+    here because there is no positional call site.
+    """
 
     if not spec.is_hosted:
         return []

--- a/packages/plugin-format/tests/test_connector_render.py
+++ b/packages/plugin-format/tests/test_connector_render.py
@@ -25,8 +25,20 @@ HOSTED = ConnectorSpec(
 REMOTE = ConnectorSpec(url="https://mcp.internal/mcp", headers={"Authorization": "Bearer ${T}"})
 
 
-def _objs(release: str = "acme-bot", app: str = "acme-bot") -> list[dict]:
-    return r.render(release, "acme-bot", "acme-bot", app, "grafana", HOSTED, "conn-secrets")
+def _objs(
+    release: str = "acme-bot",
+    app: str = "acme-bot",
+    spec: ConnectorSpec = HOSTED,
+) -> list[dict]:
+    return r.render(
+        release=release,
+        agent="acme-bot",
+        namespace="acme-bot",
+        app_name=app,
+        connector="grafana",
+        spec=spec,
+        secret_name="conn-secrets",
+    )
 
 
 # Two NetworkPolicies ship per connector now, so selecting "the NetworkPolicy"
@@ -64,7 +76,17 @@ def test_egress_selects_exactly_the_pods_rail_1_denies() -> None:
     # cannot narrow -- ADR-0067) so the sandbox still cannot reach the
     # connector. Too broad -- e.g. only `component` -- and it also grants egress
     # to every OTHER release's sandboxes in the namespace. Both fail silently.
-    np = _egress_np(r.render("relA", "a", "ns", "acme-bot", "g", HOSTED, "s"))
+    np = _egress_np(
+        r.render(
+            release="relA",
+            agent="a",
+            namespace="ns",
+            app_name="acme-bot",
+            connector="g",
+            spec=HOSTED,
+            secret_name="s",
+        )
+    )
     assert np["spec"]["podSelector"]["matchLabels"] == {
         "app.kubernetes.io/name": "acme-bot",
         "app.kubernetes.io/instance": "relA",
@@ -73,8 +95,28 @@ def test_egress_selects_exactly_the_pods_rail_1_denies() -> None:
 
 
 def test_two_releases_do_not_select_each_others_sandboxes() -> None:
-    a = _egress_np(r.render("relA", "a", "ns", "app", "g", HOSTED, "s"))
-    b = _egress_np(r.render("relB", "a", "ns", "app", "g", HOSTED, "s"))
+    a = _egress_np(
+        r.render(
+            release="relA",
+            agent="a",
+            namespace="ns",
+            app_name="app",
+            connector="g",
+            spec=HOSTED,
+            secret_name="s",
+        )
+    )
+    b = _egress_np(
+        r.render(
+            release="relB",
+            agent="a",
+            namespace="ns",
+            app_name="app",
+            connector="g",
+            spec=HOSTED,
+            secret_name="s",
+        )
+    )
     assert a["spec"]["podSelector"] != b["spec"]["podSelector"]
 
 
@@ -133,7 +175,18 @@ def test_plain_env_is_passed_through() -> None:
 # Remote connectors own no objects
 # --------------------------------------------------------------------------- #
 def test_remote_connector_renders_nothing_to_run() -> None:
-    assert r.render("acme-bot", "a", "ns", "app", "internal", REMOTE, "s") == []
+    assert (
+        r.render(
+            release="acme-bot",
+            agent="a",
+            namespace="ns",
+            app_name="app",
+            connector="internal",
+            spec=REMOTE,
+            secret_name="s",
+        )
+        == []
+    )
 
 
 def test_remote_connector_keeps_its_own_url_and_headers() -> None:
@@ -189,11 +242,27 @@ def test_two_agents_in_one_release_do_not_share_object_names() -> None:
     # release-scoped too, handed it the prod token. Nothing errored.
     dev = [
         o["metadata"]["name"]
-        for o in r.render("curie", "acme-dev", "ns", "curie", "grafana", DEV, "s")
+        for o in r.render(
+            release="curie",
+            agent="acme-dev",
+            namespace="ns",
+            app_name="curie",
+            connector="grafana",
+            spec=DEV,
+            secret_name="s",
+        )
     ]
     prod = [
         o["metadata"]["name"]
-        for o in r.render("curie", "sre-prod", "ns", "curie", "grafana", PROD, "s")
+        for o in r.render(
+            release="curie",
+            agent="sre-prod",
+            namespace="ns",
+            app_name="curie",
+            connector="grafana",
+            spec=PROD,
+            secret_name="s",
+        )
     ]
     assert not set(dev) & set(prod), f"agents share object names: {dev} vs {prod}"
 
@@ -203,12 +272,28 @@ def test_two_agents_do_not_share_pod_labels() -> None:
     # traffic to the other's pods even with distinct object names.
     dev = next(
         o
-        for o in r.render("curie", "acme-dev", "ns", "curie", "grafana", DEV, "s")
+        for o in r.render(
+            release="curie",
+            agent="acme-dev",
+            namespace="ns",
+            app_name="curie",
+            connector="grafana",
+            spec=DEV,
+            secret_name="s",
+        )
         if o["kind"] == "Service"
     )
     prod = next(
         o
-        for o in r.render("curie", "sre-prod", "ns", "curie", "grafana", PROD, "s")
+        for o in r.render(
+            release="curie",
+            agent="sre-prod",
+            namespace="ns",
+            app_name="curie",
+            connector="grafana",
+            spec=PROD,
+            secret_name="s",
+        )
         if o["kind"] == "Service"
     )
     assert dev["spec"]["selector"] != prod["spec"]["selector"]
@@ -247,7 +332,15 @@ HOSTED_WITH_HOSTS = ConnectorSpec(
 def _dep(agent: str = "acme-dev", spec: ConnectorSpec = HOSTED_WITH_HOSTS) -> dict:
     return next(
         o
-        for o in r.render("acme-bot", agent, "acme-bot", "acme-bot", "grafana", spec, "s")
+        for o in r.render(
+            release="acme-bot",
+            agent=agent,
+            namespace="acme-bot",
+            app_name="acme-bot",
+            connector="grafana",
+            spec=spec,
+            secret_name="s",
+        )
         if o["kind"] == "Deployment"
     )
 
@@ -329,7 +422,15 @@ def test_a_referenced_secret_points_at_the_secret_the_author_named() -> None:
     spec = ConnectorSpec(image="x:1", secrets=[SecretRef(name="TOKEN", from_secret="grafana-mcp")])
     dep = next(
         o
-        for o in r.render("rel", "ag", "ns", "app", "g", spec, "curie-owned")
+        for o in r.render(
+            release="rel",
+            agent="ag",
+            namespace="ns",
+            app_name="app",
+            connector="g",
+            spec=spec,
+            secret_name="curie-owned",
+        )
         if o["kind"] == "Deployment"
     )
     entry = next(
@@ -349,7 +450,15 @@ def test_owned_and_referenced_secrets_are_indistinguishable_to_the_container() -
     spec = ConnectorSpec(image="x:1", secrets=["OWNED", SecretRef(name="REFD", from_secret="ext")])
     dep = next(
         o
-        for o in r.render("rel", "ag", "ns", "app", "g", spec, "curie-owned")
+        for o in r.render(
+            release="rel",
+            agent="ag",
+            namespace="ns",
+            app_name="app",
+            connector="g",
+            spec=spec,
+            secret_name="curie-owned",
+        )
         if o["kind"] == "Deployment"
     )
     env = {e["name"]: e for e in dep["spec"]["template"]["spec"]["containers"][0]["env"]}
@@ -366,7 +475,17 @@ def test_a_referenced_secret_is_not_optional() -> None:
 
     spec = ConnectorSpec(image="x:1", secrets=[SecretRef(name="T", from_secret="ext")])
     dep = next(
-        o for o in r.render("rel", "ag", "ns", "app", "g", spec, "s") if o["kind"] == "Deployment"
+        o
+        for o in r.render(
+            release="rel",
+            agent="ag",
+            namespace="ns",
+            app_name="app",
+            connector="g",
+            spec=spec,
+            secret_name="s",
+        )
+        if o["kind"] == "Deployment"
     )
     entry = next(
         e for e in dep["spec"]["template"]["spec"]["containers"][0]["env"] if e["name"] == "T"
@@ -585,13 +704,13 @@ def test_connector_accepts_traffic_only_from_the_sandbox() -> None:
     # the network is the entire access control.
     np = _ingress_np(
         r.render(
-            "release-r",
-            "agent-a",
-            "namespace-n",
-            "app-name",
-            "connector-c",
-            HOSTED,
-            "connector-secret",
+            release="release-r",
+            agent="agent-a",
+            namespace="namespace-n",
+            app_name="app-name",
+            connector="connector-c",
+            spec=HOSTED,
+            secret_name="connector-secret",
         )
     )
     src = np["spec"]["ingress"][0]["from"]
@@ -610,7 +729,13 @@ def test_ingress_policy_selects_the_connector_not_the_sandbox() -> None:
     # the wrong pod -- the sandbox gains an ingress restriction it does not need
     # while the connector keeps none.
     objs = r.render(
-        "release-r", "agent-a", "namespace-n", "app-name", "connector-c", HOSTED, "connector-secret"
+        release="release-r",
+        agent="agent-a",
+        namespace="namespace-n",
+        app_name="app-name",
+        connector="connector-c",
+        spec=HOSTED,
+        secret_name="connector-secret",
     )
     ing = _ingress_np(objs)
     egr = _egress_np(objs)
@@ -647,8 +772,28 @@ def test_ingress_uses_a_podselector_never_an_ipblock() -> None:
 def test_two_releases_do_not_admit_each_others_sandboxes() -> None:
     # A too-broad source selector would let another release's sandbox read
     # production through this connector, silently.
-    a = _ingress_np(r.render("relA", "a", "ns", "app", "g", HOSTED, "s"))
-    b = _ingress_np(r.render("relB", "a", "ns", "app", "g", HOSTED, "s"))
+    a = _ingress_np(
+        r.render(
+            release="relA",
+            agent="a",
+            namespace="ns",
+            app_name="app",
+            connector="g",
+            spec=HOSTED,
+            secret_name="s",
+        )
+    )
+    b = _ingress_np(
+        r.render(
+            release="relB",
+            agent="a",
+            namespace="ns",
+            app_name="app",
+            connector="g",
+            spec=HOSTED,
+            secret_name="s",
+        )
+    )
     assert a["spec"]["ingress"][0]["from"] != b["spec"]["ingress"][0]["from"]
 
 
@@ -659,4 +804,60 @@ def test_the_two_policies_do_not_collide_on_name() -> None:
 
 def test_a_remote_connector_renders_no_policies() -> None:
     # Nothing is hosted, so there is nothing in-cluster to admit traffic to.
-    assert not [o for o in r.render("rel", "a", "ns", "app", "x", REMOTE, "s")]
+    assert not [
+        o
+        for o in r.render(
+            release="rel",
+            agent="a",
+            namespace="ns",
+            app_name="app",
+            connector="x",
+            spec=REMOTE,
+            secret_name="s",
+        )
+    ]
+
+
+# --------------------------------------------------------------------------- #
+# `spec.port` is read in five places, and every one of them has to read the
+# DECLARED port. The default is 8000, so a reader that hardcodes it keeps
+# working for every connector that never sets `port:` and breaks only for the
+# ones that do -- silently, and with a different symptom per reader. These
+# render at TWO different NON-default ports for exactly that reason: asserting
+# at 8000 would pin nothing, and asserting at one other port would pin nothing
+# against a reader that hardcodes THAT value instead.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("port", [9876, 9999])
+def test_a_wrong_container_port_leaves_the_service_routing_to_a_refused_port(port: int) -> None:
+    # The Service names its targetPort "http", so the container's port NAME is
+    # what resolves it. A containerPort that is not the declared port makes
+    # "http" resolve to a port nothing listens on, and every call is refused.
+    spec = ConnectorSpec(image="grafana/mcp-grafana:0.17.2", port=port)
+    container = next(o for o in _objs(spec=spec) if o["kind"] == "Deployment")["spec"]["template"][
+        "spec"
+    ]["containers"][0]
+    assert container["ports"] == [{"name": "http", "containerPort": port}]
+
+
+@pytest.mark.parametrize("port", [9876, 9999])
+def test_a_wrong_egress_port_leaves_rail_1_denying_the_port_the_connector_listens_on(
+    port: int,
+) -> None:
+    # Rail 1 is default-deny, so this rule is the only thing that opens the hop.
+    # Opened on the wrong port it denies the real one, and the sandbox's call
+    # times out with no policy error anywhere to say why.
+    spec = ConnectorSpec(image="grafana/mcp-grafana:0.17.2", port=port)
+    egress = _egress_np(_objs(spec=spec))["spec"]["egress"][0]
+    assert egress["ports"] == [{"protocol": "TCP", "port": port}]
+
+
+@pytest.mark.parametrize("port", [9876, 9999])
+def test_a_wrong_url_port_makes_the_sandbox_dial_a_port_nothing_serves(port: int) -> None:
+    # The author never writes this URL, so a hardcoded port here is not
+    # correctable from the bundle: the sandbox dials the wrong port on the right
+    # pod and the MCP server never answers.
+    spec = ConnectorSpec(image="grafana/mcp-grafana:0.17.2", port=port)
+    url = r.mcp_entry("acme-rel", "acme-bot", "acme-ns", "grafana", spec)["url"]
+    assert url == f"http://acme-rel-acme-bot-mcp-grafana.acme-ns.svc.cluster.local:{port}/mcp"


### PR DESCRIPTION
Closes #1471

## What

Two pre-existing coverage gaps in the connector render path.

**The consumer fixture could not tell `release` from `app_name`.** The apps/api fixture set `release`, `agent`, `namespace` and `app_name` all to `"acme-bot"`, so the seven-argument forward into `connector_render.render` was pinned by nothing. The fixture now uses four distinct values, mirroring a real install: `curie cluster up --namespace my-agent --release my-agent` against a chart whose `nameOverride` is empty leaves `app_name` as `curie` while release and namespace are both `my-agent`.

**Three of five `spec.port` readers were pinned by no test.** The Deployment `containerPort`, the egress NetworkPolicy port, and the `mcp_entry` URL port each now render at two distinct non-default ports, so a reader hardcoding any literal fails, not just one hardcoding the `8000` default.

## Structural change, called out for review

`connector_render.render` is now keyword-only, and every caller is migrated (one production caller, thirteen in the plugin-format tests, all with their original argument values preserved). This goes beyond a pure coverage change, and it is deliberate: the positional seven-argument forward that carried the defect no longer exists, rather than only being asserted around. No compatibility path, optional-argument fallback, or positional alias was left behind.

## Evidence

All mutations run against the tree at `ea7b93d1`, restored byte-identically after each.

All six pairwise swaps at the `bundles.py` call site, `pytest apps/api/tests/test_bundle_connectors.py`:

| swap | failing tests |
|---|---|
| release/agent | 2, incl. `test_each_of_the_four_names_lands_where_it_belongs` |
| release/namespace | 2 |
| release/app_name | 2 |
| agent/namespace | 3 |
| agent/app_name | 3 |
| namespace/app_name | 1 |

Each `spec.port` reader replaced with a literal, `pytest packages/plugin-format/tests/`:

| reader | literal 8000 | literal 9876 |
|---|---|---|
| `:293` containerPort | 2 failed | 1 failed |
| `:334` egress NetworkPolicy port | 2 failed | 1 failed |
| `:464` mcp_entry URL port | 2 failed | 1 failed |

The two readers PR #1465 already pinned (`:127` Service port, `:393` ingress NetworkPolicy port) still fail on mutation, so that coverage is not regressed. No existing test was weakened or removed; test counts went 13 to 14 and 50 to 53 with zero removals.

## Validation

`apps/api` 639 passed, `packages/` + `runner/` 970 passed 4 skipped, `ruff check` clean, `mypy` clean on 178 files, `lint-imports` 3 contracts kept, `check-docs.sh` and `check-wire-tolerance.sh` both OK.

## Follow-ups, not addressed here

- A sixth `spec.port` reader exists at `connector_render.py:184` (`substitutions`, feeding `CURIE_CONNECTOR_URL`) that survives a literal `8000`. The issue enumerated five readers, so it is left alone rather than widening this PR.
- `:127` survives a literal `9876` because the pre-existing fixture that pins it happens to use that port. Pre-existing and unchanged from `main`.
- `ruff format --check` flags two lines in these files. Identical on `origin/main`, caused by a local ruff newer than CI's, and untouched here.