### PR TITLE
Reject missing runner npm globals

### DIFF
--- a/runner/tests/test_dockerfile_dependency_pins.py
+++ b/runner/tests/test_dockerfile_dependency_pins.py
@@ -306,7 +306,9 @@ def test_python_pin_revert_is_rejected() -> None:
 
 def test_npm_version_removal_is_rejected() -> None:
     dockerfile = _DOCKERFILE.read_text(encoding="utf-8")
-    for current in _dockerfile_global_npm_operands(dockerfile):
+    npm_operands = _dockerfile_global_npm_operands(dockerfile)
+    assert len(npm_operands) >= 2
+    for current in npm_operands:
         package, version = _split_npm_operand(current)
         assert version and _EXACT_NPM_VERSION.fullmatch(version)
         assert dockerfile.count(current) == 1


### PR DESCRIPTION
Closes #1506

Require the runner dependency pin gate to retain both existing global npm operands before exercising version removal mutations.

* [x] Unmodified focused suite passes with 10 tests
* [x] Ruff and mypy are clean
* [x] Code review approved with no findings
* [x] Scope review approved with no findings
* [x] Each individual npm line deletion exits 1
* [x] Both npm line deletions exit 1
* [x] Sibling path parity is not applicable
* [x] Consolidation skipped for a direct single file diff
* [x] Security and deployed runtime checks are not applicable