### PR TITLE
Tighten gitleaks stopword allowlist

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -137,11 +137,13 @@ paths = [
   '''^\.gitleaks\.toml$''',
 ]
 
-# Pre-existing fixture ids. Every one is obviously invented -- it spells a
-# word (C0MANAGERS), repeats a character (C0FFFFFF6), or is mostly zeroes
-# (C000000A01). That is the bar for a new one: a reader must be able to tell
-# at a glance that it is not somebody's channel. Adding to this list should be
-# rare; prefer reusing C0EXAMPLE1.
+# Gitleaks stopwords are case insensitive substring matches, so an entry
+# suppresses any longer identifier containing it, including identifiers
+# prefixed by that entry. Every value is an
+# obviously invented fixture id: it spells a word (C0MANAGERS), repeats a
+# character (C0FFFFFF6), or is mostly zeroes (C000000A01). That is the bar for
+# a new one: a reader must be able to tell at a glance that it is not somebody's
+# channel. Adding to this list should be rare; prefer reusing C0EXAMPLE1.
 stopwords = [
   "C000000A01",
   "C000000A02",
@@ -195,14 +197,12 @@ stopwords = [
   "C01SUPPORT",
   "C024BE91L",
   "C0AAAAAA1",
-  "C0AAAAAAA",
   "C0AGENT001",
   "C0BBBBBB2",
   "C0BOUND01",
   "C0BROAD01",
   "C0CARD001",
   "C0CCCCCC3",
-  "C0DEV2222",
   "C0DDDDDD4",
   "C0EEEEEE5",
   "C0ELSE001",
@@ -216,7 +216,6 @@ stopwords = [
   "C0INTAKE00",
   "C0LOCALDEV",
   "C0MALFORMED",
-  "C0PROD111",
   "C0MANAGERS",
   "C0OLDROOM0",
   "C0REQ0001",

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -28,11 +28,3 @@ be962e4a37f8644539244e2e872937f2fd8371a0:AGENTS.md:curl-auth-user:105
 # allowlisted here. The lines on main carry inline gitleaks:allow markers.
 c8b1ccb28faa51d3ec996d60883fde48a303b0bd:AGENTS.md:curl-auth-user:154
 c8b1ccb28faa51d3ec996d60883fde48a303b0bd:docs/adr/0079-inbound-triggers-as-a-new-event-kind.md:generic-api-key:46
-
-# A private org repo slug that reached a test fixture and was edited away again.
-# Ignored by FINGERPRINT rather than added to an allowlist: the rule exists to
-# catch exactly this shape, and widening it would retire the protection instead
-# of retiring the one occurrence. The slug is absent from the tree; only the
-# commit that introduced it still carries it, and history is not rewritten for a
-# fixture name that was never a credential.
-2adab2fc53b64ca6b80adf794e90c0fdf1e9754e:apps/api/tests/test_gitflow_targets.py:downstream-repo-slug:22


### PR DESCRIPTION
Closes #1504

Summary

1. Remove the three unearned global stopwords and the orphaned fingerprint.
2. Document case insensitive substring matching and restore alphabetical order.

Done check

1. [x] The pinned full history scan passed across 1036 commits.
2. [x] The violating C0DEV2222X fixture was detected as slack conversation id.
3. [x] The earned C000000S06 fixture remained suppressed.
4. [x] Code and scope reviews approved the change.
5. [x] Diff, alphabetical order, and commit message checks passed.
6. [x] Sibling parity, security review, and deployed verification are not applicable.