### PR TITLE
Hash OTel collector config content for rollouts

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -109,6 +109,11 @@ jobs:
           set -euo pipefail
           bash charts/curie/ci/clickhouse-logging-assertions.sh
 
+      - name: helm render assertions (otel collector checksum)
+        run: |
+          set -euo pipefail
+          bash charts/curie/ci/otel-collector-checksum-assertions.sh
+
       # Prove the Langfuse web+worker containers carry a numeric runAsUser
       # alongside runAsNonRoot (issue #351) so the kubelet can verify non-root
       # and the pods actually start on an enforcing cluster.

--- a/charts/curie/ci/otel-collector-checksum-assertions.sh
+++ b/charts/curie/ci/otel-collector-checksum-assertions.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART="$(cd "$SCRIPT_DIR/.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+render() {
+  local name="$1"
+  shift
+  helm template curie "$CHART" --output-dir "$TMP/$name" "$@" >/dev/null
+}
+
+manifest_for() {
+  local manifest
+  manifest="$(find "$1" -type f -path '*/templates/otel-collector.yaml' -print -quit)"
+  [[ -n "$manifest" ]] || fail "OTel Collector manifest was not written to $1"
+  printf '%s\n' "$manifest"
+}
+
+render default
+render port-3001 --set langfuse.web.service.port=3001
+render auth-header --set otelCollector.otlpAuthHeader='Basic YXNzZXJ0OmFzc2VydA=='
+
+python3 - "$(manifest_for "$TMP/default")" "$(manifest_for "$TMP/port-3001")" "$(manifest_for "$TMP/auth-header")" <<'PY'
+import sys
+import yaml
+
+def config_and_checksum(path):
+    docs = [doc for doc in yaml.safe_load_all(open(path)) if doc]
+    config_map = next((doc for doc in docs if doc.get("kind") == "ConfigMap"), None)
+    deployment = next((doc for doc in docs if doc.get("kind") == "Deployment"), None)
+    assert config_map is not None, f"{path}: no ConfigMap rendered"
+    assert deployment is not None, f"{path}: no Deployment rendered"
+    config = config_map.get("data", {}).get("collector-config.yaml")
+    checksum = deployment["spec"]["template"]["metadata"].get("annotations", {}).get("checksum/config")
+    assert config, f"{path}: collector ConfigMap body was not rendered"
+    assert checksum, f"{path}: Deployment checksum/config was not rendered"
+    return config, checksum
+
+default_config, default_checksum = config_and_checksum(sys.argv[1])
+changed_config, changed_checksum = config_and_checksum(sys.argv[2])
+auth_config, auth_checksum = config_and_checksum(sys.argv[3])
+
+assert default_config != changed_config, "Langfuse service port did not change the collector ConfigMap body"
+assert default_checksum != changed_checksum, (
+    "ConfigMap body changed but Deployment checksum/config stayed identical. The pod would not roll."
+)
+assert default_config == auth_config, "OTLP auth header changed the collector ConfigMap body"
+assert default_checksum != auth_checksum, (
+    "OTLP auth header changed but Deployment checksum/config stayed identical. The pod would not roll."
+)
+
+print("ConfigMap changes roll the pod and OTLP auth header changes still roll it: OK")
+PY

--- a/charts/curie/templates/_helpers.tpl
+++ b/charts/curie/templates/_helpers.tpl
@@ -177,6 +177,42 @@ http
 {{- end -}}
 {{- end -}}
 
+{{- define "curie.otelCollector.config" -}}
+# Receives OTLP over gRPC (4317) and HTTP (4318) from app services and
+# forwards to Langfuse over HTTP. Langfuse OTLP ingest is HTTP-only (gRPC is
+# silently unsupported), so the collector is the adapter. Langfuse appends
+# /v1/traces to the otlphttp base path itself.
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+processors:
+  batch: {}
+exporters:
+  otlphttp/langfuse:
+    endpoint: http://{{ include "curie.langfuse.webHost" . }}:{{ .Values.langfuse.web.service.port }}/api/public/otel
+    headers:
+      Authorization: ${env:LANGFUSE_OTLP_AUTH_HEADER}
+  debug:
+    verbosity: normal
+extensions:
+  health_check:
+    endpoint: 0.0.0.0:13133
+service:
+  extensions: [health_check]
+  telemetry:
+    metrics:
+      level: none
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlphttp/langfuse, debug]
+{{- end }}
+
 {{/* ---- Default-credential gate (issue #198) ----
      When security.checkDefaultCredentials is on, refuse to render if a Langfuse
      bootstrap identity still carries the published dev default from values.yaml.

--- a/charts/curie/templates/otel-collector.yaml
+++ b/charts/curie/templates/otel-collector.yaml
@@ -7,39 +7,7 @@ metadata:
     {{- include "curie.labels" . | nindent 4 }}
 data:
   collector-config.yaml: |
-    # Receives OTLP over gRPC (4317) and HTTP (4318) from app services and
-    # forwards to Langfuse over HTTP. Langfuse OTLP ingest is HTTP-only (gRPC is
-    # silently unsupported), so the collector is the adapter. Langfuse appends
-    # /v1/traces to the otlphttp base path itself.
-    receivers:
-      otlp:
-        protocols:
-          grpc:
-            endpoint: 0.0.0.0:4317
-          http:
-            endpoint: 0.0.0.0:4318
-    processors:
-      batch: {}
-    exporters:
-      otlphttp/langfuse:
-        endpoint: http://{{ include "curie.langfuse.webHost" . }}:{{ .Values.langfuse.web.service.port }}/api/public/otel
-        headers:
-          Authorization: ${env:LANGFUSE_OTLP_AUTH_HEADER}
-      debug:
-        verbosity: normal
-    extensions:
-      health_check:
-        endpoint: 0.0.0.0:13133
-    service:
-      extensions: [health_check]
-      telemetry:
-        metrics:
-          level: none
-      pipelines:
-        traces:
-          receivers: [otlp]
-          processors: [batch]
-          exporters: [otlphttp/langfuse, debug]
+{{ include "curie.otelCollector.config" . | indent 4 }}
 ---
 apiVersion: v1
 kind: Service
@@ -72,7 +40,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: {{ printf "%s|%s" (include "curie.langfuse.webHost" .) (include "curie.otlpAuthHeader" .) | sha256sum }}
+        checksum/config: {{ printf "%s|%s" (include "curie.otelCollector.config" .) (include "curie.otlpAuthHeader" .) | sha256sum }}
       labels:
         {{- include "curie.labels" . | nindent 8 }}
         {{- include "curie.selectorLabels" (dict "root" . "component" "otel-collector") | nindent 8 }}


### PR DESCRIPTION
Closes #1503

Shares the rendered collector configuration between the ConfigMap and rollout checksum while preserving auth header rotation. Adds an executable Helm assertion with matching CI wiring.

Validated with `bash charts/curie/ci/otel-collector-checksum-assertions.sh` and `helm lint charts/curie`. The requested `cargo test --test chart_check` target is not present on `main`. Runtime verification was blocked before install by a cluster scoped PriorityClass owned by another release, and the harness cleaned its namespace.