### PR TITLE
Allow historical object store disclosure

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -246,4 +246,5 @@ commits = [
   # repository's existence and name as disclosed.
   "39b0bd3990b2e0ea816e4e0a99d1f4159efcefe5",  # ADR-0091 impl: the slug as a test fixture
   "cde1ac43c284b17eb2253af02b50345b808d6711",  # ADR-0090 Draft: the slug + its issue, cited as evidence
+  "33505bd401c915ed7254ab6172a4f337eeeb5f77",  # object store role examples, scrubbed from HEAD
 ]


### PR DESCRIPTION
Records the historical commit that carried real object store role examples.

The commit level exemption restores the full history scan without exempting the account identifier itself, so future disclosures still fail the gate.

Validated with:

`docker run --rm -v "/home/theconnman/git/curietech:/home/theconnman/git/curietech" ghcr.io/gitleaks/gitleaks:v8.30.1@sha256:c00b6bd0aeb3071cbcb79009cb16a60dd9e0a7c60e2be9ab65d25e6bc8abbb7f detect --source /home/theconnman/git/curietech/agentos/.worktrees/secret-scan-main --redact --verbose --exit-code 1 --log-opts="HEAD"`

Result: 1042 commits scanned, no leaks found.