### PR TITLE
Accept ADR-0096: third-party port adapters

### DIFF
--- a/docs/adr/0096-port-adapters-are-deployed-services.md
+++ b/docs/adr/0096-port-adapters-are-deployed-services.md
@@ -2,7 +2,13 @@
 
 Date: 2026-08-04
 
-Status: Draft
+Status: Accepted
+
+Accepted alongside its implementation under [ADR-0102](0102-accepted-alongside-implementation-with-explicit-approval.md).
+Realizing code path: `apps/api/src/curie_api/models.py` (the channel-neutral
+binding), `apps/worker/src/curie_worker/binding.py` (the resolver),
+`packages/channel-protocol/` (the neutral egress port and its conformance
+kit), and `cli/src/main.rs` (the `curie adapter` verb family).
 
 Generalizes the harness trio to every port.
 [ADR-0060](0060-the-harness-is-a-declared-package.md) decides what a harness is

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -124,7 +124,7 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0093 | [Local-model assets are pre-provisioned, never implicitly downloaded](0093-local-model-assets-are-pre-provisioned-never-implicitly-downloaded.md) | Draft |
 | 0094 | [A bundle carries its own sealed connector keys](0094-a-bundle-carries-its-own-sealed-connector-keys.md) | Accepted |
 | 0095 | [One tiered memory lifecycle for agent and channel memory](0095-tiered-memory-lifecycle.md) | Draft |
-| 0096 | [A third-party port adapter is a deployed service, not a loaded plugin](0096-port-adapters-are-deployed-services.md) | Draft |
+| 0096 | [A third-party port adapter is a deployed service, not a loaded plugin](0096-port-adapters-are-deployed-services.md) | Accepted |
 | 0097 | [One file declares an installation](0097-one-file-declares-an-installation.md) | Accepted |
 | 0098 | [Thinking depth is an operator knob, never a bundle one](0098-thinking-depth-is-an-operator-knob-never-a-bundle-one.md) | Accepted |
 | 0101 | [Closed schemas version on every change: minor for optional, major for required](0101-schema-compatibility-for-closed-schemas.md) | Accepted |


### PR DESCRIPTION
Publishes ADR-0096 (port adapters are deployed services) with Status: Accepted, per the docs/adr acceptance procedure. Acceptance authorizes the phase 2 implementation, which follows in a separate PR against next.