### PR TITLE
Superseded Slack placeholder change

### DIFF
--- a/apps/dispatcher/README.md
+++ b/apps/dispatcher/README.md
@@ -72,7 +72,7 @@ Read from the environment by `DispatcherConfig()` (a `pydantic_settings.BaseSett
 | `CURIE_STREAM` | `curie:runs` | Stream the jobs land on |
 | `CURIE_DEDUPE_PREFIX` | `curie:dedupe:` | dedupe key prefix |
 | `CURIE_DEDUPE_TTL_SECONDS` | `3600` | dedupe guard TTL |
-| `CURIE_PLACEHOLDER_TEXT` | `On it. Working on your request.` | placeholder reply text |
+| `CURIE_PLACEHOLDER_TEXT` | `…` | placeholder reply text |
 | `CURIE_BACKOFF_INITIAL_SECONDS` | `1.0` | first reconnect backoff |
 | `CURIE_BACKOFF_MAX_SECONDS` | `30.0` | backoff cap |
 | `CURIE_BACKOFF_MULTIPLIER` | `2.0` | backoff growth factor |

--- a/apps/dispatcher/src/curie_dispatcher/config.py
+++ b/apps/dispatcher/src/curie_dispatcher/config.py
@@ -110,7 +110,7 @@ class DispatcherConfig(BaseSettings):
     )
 
     placeholder_text: str = Field(
-        default="On it. Working on your request.",
+        default="…",
         validation_alias="CURIE_PLACEHOLDER_TEXT",
     )
     # CURIE_SHIMMER and CURIE_STATUS_TEXT are deliberately NOT read here (#1312).

--- a/apps/dispatcher/tests/test_config.py
+++ b/apps/dispatcher/tests/test_config.py
@@ -128,7 +128,7 @@ def test_defaults_parity_with_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
     assert config.stream == "curie:runs"
     assert config.dedupe_prefix == "curie:dedupe:"
     assert config.dedupe_ttl_seconds == 3600
-    assert config.placeholder_text == "On it. Working on your request."
+    assert config.placeholder_text == "…"
     assert config.backoff_initial_seconds == 1.0
     assert config.backoff_max_seconds == 30.0
     assert config.backoff_multiplier == 2.0

--- a/apps/worker/src/curie_worker/config.py
+++ b/apps/worker/src/curie_worker/config.py
@@ -218,7 +218,7 @@ class WorkerConfig(BaseSettings):
     # default (#717) -- an end user talking to an agent should never see curie's
     # own architecture terms in a status line.
     booting_text: str = Field(
-        default="Working on it...",
+        default="…",
         validation_alias="CURIE_BOOTING_TEXT",
     )
 


### PR DESCRIPTION
This change only replaces the visible working message with an ellipsis. That does not satisfy #1526, which now requires no initial message and one final reply after success.

The required frozen reply target migration is tracked in #1528. This PR is superseded and should not merge.