### PR TITLE
Correct cluster message and connector secret docs

### DIFF
--- a/cli/CLAUDE.md
+++ b/cli/CLAUDE.md
@@ -154,12 +154,11 @@ Helm and the deployed release with `up`, `status`, `down`, `comms`, `message`,
   `secret_env` compose process env channel, and never prints an unmasked token
   in live or dry run output. `--disconnect` clears the real Slack wiring,
   stops the dispatcher, and restores the local stub for `local message`.
-- **`cluster message` self-plumbs and guards against hijacking real Slack.** It manages
-  its own kubectl port-forwards (children killed on exit) and, when wiring the
-  deployed worker to its local stub, refuses if a `<release>-dispatcher`
-  Deployment exists (a real workspace is connected) unless `--force-wire`. Do
-  not drop that guard: the stub wiring is cluster-wide and would divert a live
-  workspace's replies.
+- **`cluster message` follows the deployed transport.** It manages its own
+  kubectl port-forwards (children killed on exit). With a connected dispatcher,
+  it posts a placeholder and routes the reply to the agent's bound Slack
+  channel. Without a dispatcher, it uses the terminal reply stub and waits for
+  the reply.
 - **A new `Deserialize` struct in `cli/src/api.rs` must be declared in
   `cli/api-mirrors.json`** (as a `mirrors` entry with its allowlisted field
   omissions, or a `non_mirrors` entry with a one-line reason). `curie dev

--- a/cli/README.md
+++ b/cli/README.md
@@ -324,7 +324,7 @@ runner container on the host Docker daemon instead of a Kubernetes sandbox.
 Channel comes from `--channel` or, when omitted, the sole deployed agent
 looked up on the compose API. `local message` composes with `--channel`,
 `--thread`, and `--timeout-secs`, and rejects the cluster-only flags
-(`--namespace`, `--release`, `--force-wire`, ...) with a clear error.
+(`--namespace`, `--release`, ...) with a clear error.
 
 The compose worker runs the fake model by default (a canned reply, no
 credentials). Export a credential in your shell, or use `--env-file` (see
@@ -339,7 +339,7 @@ present, fake otherwise). `--disconnect` stops the dispatcher and restores
 the local stub; `--dry-run` prints the compose command only.
 
 `--continue` works the same way here as it does for
-[`cluster message`](#curie-cluster-message-drive-the-deployed-cluster-with-zero-slack):
+[`cluster message`](#curie-cluster-message-drive-the-deployed-cluster):
 it reuses the last successful `local message` context from
 `.curie/last-turn.json` in the current working directory, so only the new text
 is required, explicit flags override the saved channel/thread/transport
@@ -358,7 +358,7 @@ Wraps the umbrella Helm chart and the deployed release, the way `linkerd` or
 | `curie cluster status` | Report release health, pod readiness, and access URLs (read-only). |
 | `curie cluster observability` | Report the release's observability surfaces (Curie Console, Langfuse UI, Curie API base), using the same NodePort discovery as `cluster status`.<br>• Degrades a missing, ClusterIP, or unresolvable surface to a note instead of failing.<br>• URLs are printed only; pass `--open` to also open the browsable ones (Console, Langfuse) in a browser. `--json` never opens a browser.<br>• `--dry-run` prints the read-only discovery commands. |
 | `curie cluster comms --slack` | Connect or disconnect a real Slack workspace with a thin `helm upgrade --reuse-values`; env-backed tokens are masked in dry-run output. |
-| `curie cluster message "..."` | Drive the deployed release end to end with zero Slack: self plumbs kubectl port forwards, points the deployed worker at a local Slack stub (`helm upgrade --reuse-values`), enqueues, and prints the reply.<br>• Auto-discovers the release-generated API key and Valkey password from `<release>-secrets` when `--api-key` / `--valkey-password` (or their env vars) are omitted, so a default strong-secrets install needs no hand-exported credentials (#786). |
+| `curie cluster message "..."` | Drive the deployed release end to end. With a connected dispatcher, it posts a placeholder and routes the reply to the agent's bound Slack channel. Without a dispatcher, it uses the terminal reply stub and waits for the reply.<br>• Auto-discovers the release-generated API key and Valkey password from `<release>-secrets` when `--api-key` / `--valkey-password` (or their env vars) are omitted, so a default strong-secrets install needs no hand-exported credentials (#786). |
 | `curie cluster eval` | Run the bundle's `evals/cases.json` through the deployed release (self-plumbed port-forwards + per-turn reply stub, one synthetic turn per case) and grade each captured reply with the SAME grader `skill eval` uses. Prints the identical per-case table + rollup; nonzero exit on failure.<br>• `--cases` overrides the file.<br>• `--dry-run` prints the plan.<br>• `--concurrency` defaults to 1 (sequential); values above 1 are refused for now (#709).<br>• Only the reply text is observed here, so a `tool_called` case always fails -- see "Using different tiers" above.<br>• Auto-discovers the release-generated API key and Valkey password from `<release>-secrets` when `--api-key` / `--valkey-password` (or their env vars) are omitted, so a default strong-secrets install needs no hand-exported credentials (#790). |
 | `curie cluster deploy` | Package the bundle as tar.gz and push it to the platform API.<br>• When `--api-url` is omitted, self-plumbs a `kubectl port-forward` (loopback tunnel) to the release API service and auto-discovers the release-generated key from `<release>-secrets`, so the strong key never crosses the cleartext UI proxy (ADR-0057).<br>• Pass `--api-url` / `CURIE_API_URL` to direct-dial a URL instead (no tunnel); an explicit `--api-key` / `CURIE_API_KEY` still wins over discovery. |
 | `curie cluster kill <agent> --yes` | Kill an agent (stop its runs) via the platform API (`POST /agents/{id}/kill`). Destructive: refuses without `--yes`. |
@@ -379,39 +379,35 @@ and auto-discovers the release key (ADR-0057), the lifecycle verbs do neither
 `--dry-run` (prints the plan, makes no request); the destructive
 `kill`/`reset-thread`/`delete` also require `--yes`.
 
-##### `curie cluster message`: drive the deployed cluster with zero Slack
+##### `curie cluster message`: drive the deployed cluster
 
-`cluster message` targets a **deployed** Helm release and wires everything
-itself, so a developer building an agent for someone else's Slack workspace can
-exercise the whole deployed machinery (Valkey queue -> worker -> claimed
-sandbox -> the real skill -> the reply) without any Slack access, tokens, or
-workspace.
+`cluster message` targets a **deployed** Helm release and manages its own
+port-forwards. A connected dispatcher sends the placeholder and reply through
+the agent's bound Slack channel. A disconnected release uses the terminal reply
+stub, so a developer can exercise the whole deployed machinery without Slack
+access or tokens.
 
 ```bash
 curie cluster message "summarize the latest deploy"
 curie cluster message --channel CSIM123 "another question"
 ```
 
-What it does: self-manages its own port-forwards and a local reply-stub the
-release can post back to, so no manual `kubectl port-forward` is needed. Then:
+What it does: self-manages its own port-forwards, then follows the release's
+transport. A connected dispatcher receives a placeholder and sends the reply to
+the bound Slack channel. Without a dispatcher, the terminal reply stub receives
+the reply and the command prints it in the terminal.
 
 - **Picks a channel.** With no `--channel`, it looks up the sole deployed
   agent's channel via the API; zero or multiple agents is an error requiring
   `--channel` explicitly (the worker binds a channel to an agent by exact
   equality, so guessing would route nowhere).
-- **Wires the worker at the stub** (`--wire`, the default) via a `helm
-  upgrade`, and waits for the rollout. `--no-wire` instead refuses to run
-  unless the worker is already wired, printing the exact command to apply.
-- **Refuses to hijack a connected workspace.** If the release is already
-  wired to a real Slack workspace, wiring the stub is refused unless you pass
-  `--force-wire` -- this guard exists purely so a stray `cluster message` run
-  can't silently steal a real workspace's replies.
-- **Enqueues the event and waits for the worker's reply**, printing a
-  `continue this conversation: ...` line for follow-ups. A timeout prints
-  stream diagnostics and exits nonzero.
+- **Enqueues the event.** In connected mode, follow the placeholder and reply in
+  the agent's bound Slack channel. In disconnected mode, it waits for the
+  terminal reply and prints a continuation context. A timeout prints stream
+  diagnostics and exits nonzero.
 
-`--dry-run` prints the kubectl/helm command lines, the stub URL, and the enqueue
-description without executing anything.
+`--dry-run` prints the kubectl port-forward details and enqueue description
+without executing anything.
 
 `--continue` reuses the last successful `cluster message` context from
 `.curie/last-turn.json` in the current working directory, so only the new text
@@ -433,25 +429,22 @@ curie cluster deploy --slack-channel CSIM123 ...
 curie cluster message --channel CSIM123 "first question"
 ```
 
-Each turn mints a fresh thread ts (Slack's timestamp-based message id) by
-default. On completion `cluster message` prints a `continue this conversation:
-...` line with the channel and thread ts; copy-paste it, or pass `--thread
-<ts>` yourself, to send the next turn into the same thread:
+In disconnected mode, each turn mints a fresh thread ts by default. On
+completion `cluster message` prints a `continue this conversation: ...` line
+with the channel and thread ts; copy-paste it, or pass `--thread <ts>` yourself,
+to send the next turn into the same thread:
 
 ```bash
 curie cluster message --channel CSIM123 --thread 1720000000.000100 "follow up question"
 ```
 
-Against a **connected** Slack workspace the thread ts is not synthetic: the CLI
-posts a real placeholder message to the channel and the printed thread ts is
-that placeholder's real Slack ts, so you can reply to it in Slack. Passing
-`--thread <ts>` there posts the placeholder into that existing thread, which
-means the ts must name a real message in the channel -- a thread ts carried over
-from a stub run will be rejected by Slack, and the command tells you to drop
-`--thread` to start a new one.
+Against a **connected** Slack workspace the CLI posts a real placeholder to the
+agent's bound channel and routes the reply there. Follow the placeholder in
+Slack for the conversation. A thread ts passed with `--thread <ts>` must name a
+real message in that channel; a thread ts from a disconnected stub run is not
+valid in Slack.
 
-When you're ready to connect a real workspace instead of driving this
-zero-Slack path, use:
+To connect a real workspace so replies route through Slack, use:
 
 ```bash
 SLACK_APP_TOKEN=xapp-... \
@@ -526,6 +519,13 @@ variable instead of prompting:
 ```bash
 curie secrets set GITHUB_PERSONAL_ACCESS_TOKEN --from-env GITHUB_PAT
 ```
+
+During cluster deploy, Curie resolves every connector secret name from the
+environment first and then the host secret store, and delivers the owned keys
+to the agent Kubernetes Secret. This includes connector `secrets` and
+`secret_files`. The host store is install global, so agents using the same
+secret name share one stored value and can collide. Issue #440 tracks the future
+per agent delivery path.
 
 `curie skill up --secret <NAME>` first uses a real environment variable when
 one is already set. If it is missing, the CLI tries the Curie secret store and

--- a/docs/design/multi-dev-shared-cluster.md
+++ b/docs/design/multi-dev-shared-cluster.md
@@ -25,13 +25,10 @@ time**.
 
 The single-operator assumptions that break at team scale, grounded in the code:
 
-- **`curie cluster message` self-plumbs cluster-wide.** It opens its own
-  `kubectl port-forward`s and, to wire a Slack stub, sets `worker.slackApiBaseUrl`
-  via a `helm upgrade --reuse-values` that is **release-wide** — it re-points *the*
-  worker's outbound Slack for everyone. It already guards against hijacking a live
-  workspace (refuses when a `<release>-dispatcher` exists unless `--force-wire`,
-  per `cli/src/message.rs` and `cli/CLAUDE.md`), but two devs stub-wiring at once
-  still contend for the one `slackApiBaseUrl` value.
+- **`curie cluster message` follows the release transport.** It opens its own
+  `kubectl port-forward`s. When a dispatcher is connected, it posts a placeholder
+  and routes replies to the agent's bound Slack channel. Without a dispatcher,
+  it uses a per turn terminal reply stub and prints the reply.
 - **Agent targeting is "the sole deployed agent."** `cluster message` resolves the
   target agent from the single deployed agent's `slack_channel`, and treats zero
   or multiple deployed agents as an error (`message.rs`). With N devs each
@@ -107,10 +104,8 @@ per-dev runtime namespaces for compute and a single shared ingress for exposure.
   of an existing seam, not a new trust model.
 - **RBAC (devs, not pods).** Devs get a scoped kubeconfig/role that permits
   `deploy`/`message` against the shared release and their own runtime namespace,
-  but **not** `helm upgrade` on the platform release (which is how `cluster
-  message`'s cluster-wide `slackApiBaseUrl` rewrite happens today — see Q3). This
-  makes "don't let one dev's stub-wiring clobber everyone" an RBAC guarantee, not
-  just a `--force-wire` prompt.
+  but **not** `helm upgrade` on the platform release. This prevents one dev's
+  message transport changes from affecting everyone else.
 - **NodePort/ingress collisions.** Stop exposing per-dev NodePorts. The shared
   release exposes **one ingress / LoadBalancer**; per-dev/per-agent surfaces are
   **path- or host-routed** (e.g. `…/agent/<owner>/<name>/` or
@@ -119,34 +114,14 @@ per-dev runtime namespaces for compute and a single shared ingress for exposure.
   move: managed clusters get a real LoadBalancer/ingress; local single-node
   (kind/k3s) keeps NodePort but for the **one** shared exposure, not per dev.
 
-### Q3. How does `cluster message` target a *specific* deployed agent without cluster-wide wiring that collides?
+### Q3. How does `cluster message` target a *specific* deployed agent?
 
-This is the sharpest question, because today's mechanism is cluster-wide by
-construction. Two changes:
+The remaining ambiguity is which deployed agent should receive the turn:
 
 1. **Explicit agent targeting.** Add `--agent <name>` (and/or `--owner`) to
    `cluster message`, replacing the "sole deployed agent" resolution. Ambiguity
    (multiple agents) becomes "pass `--agent`," not an error, and targeting is
    exact equality on `(owner, name)`.
-2. **Per-agent reply routing instead of one shared `worker.slackApiBaseUrl`.**
-   The collision is that stub-wiring rewrites *the* worker's outbound Slack base
-   URL for the whole release. Options, in order of preference:
-   - **(Preferred) Per-agent stub routing carried on the turn, not on the worker
-     Deployment.** The reply destination becomes an attribute of the enqueued turn
-     / the agent's deployment record (a per-agent `reply_base_url` the worker reads
-     per message), so dev A driving agent X and dev B driving agent Y never
-     contend for one release-wide value and neither needs `helm upgrade` rights.
-     This is the clean fix and dovetails with per-dev RBAC in Q2.
-   - **(Bridge) Keep the direct-enqueue path as the default multi-dev driver.**
-     `cluster message` already has a "no kubectl/helm/port-forwards — enqueue
-     straight onto the Kubernetes release" form (`message.rs`). For multi-dev, make
-     *that* the default: a dev enqueues a turn for their agent and reads the reply
-     back over their own short-lived port-forward, with **no** release-wide
-     mutation at all. The stub-wiring `helm upgrade` path becomes an
-     admin/`--force-wire` escape hatch, not the everyday loop.
-
-   Either way, the everyday multi-dev `message` must stop performing a
-   release-wide `helm upgrade`.
 
 ### Q4. The "run against a running cluster you did not install" experience.
 
@@ -174,8 +149,8 @@ and it is the natural home for "which cluster / which release / which owner."**
   ADR-0008: an `owner` in the context is a precursor to a `tenant_id` at ingress.
 - **Caveat:** ambient context is a footgun for destructive verbs (the `--local`
   lesson from #40 — a silent default targeting the wrong place). Mitigation: keep
-  destructive/admin verbs (`cluster up`/`down`, `--force-wire`) **explicit and
-  loud** (echo the resolved cluster/release, require `--yes`), and never let the
+  destructive/admin verbs (`cluster up`/`down`) **explicit and loud** (echo the
+  resolved cluster/release, require `--yes`), and never let the
   ambient context silently escalate a dev into an admin action.
 
 ### Q6. Managed-cluster reachability (EKS) vs local single-node (kind/k3s).
@@ -200,7 +175,7 @@ admin, not per dev.**
 | Platform install | Each dev installs a release | **One shared release**, admin/CI-owned |
 | Dev's loop | `cluster up` + deploy + message | **connect (context) → deploy → message**, no install |
 | Agent targeting | "the sole deployed agent" | **`--agent`/`--owner` exact match**, from context |
-| Reply routing | release-wide `worker.slackApiBaseUrl` via `helm upgrade` | **per-agent routing on the turn/deployment**; direct-enqueue default |
+| Reply routing | per turn terminal stub or bound Slack channel | **target the agent by owner and name** |
 | Compute isolation | one runtime namespace | **namespace-per-owner** (reuses ADR-0008/0023) |
 | Exposure | per-release NodePort | **one shared LoadBalancer/ingress**, host/path-routed |
 | "Which cluster/release" | flags per call | **`curie context use`** ambient selector |
@@ -219,22 +194,17 @@ dependency.
 2. **Explicit agent targeting on `cluster message`/`status`.** `--agent`/`--owner`
    exact-match resolution replacing "sole deployed agent"; multiple agents →
    "pass `--agent`", not an error. (Q3.)
-3. **Per-agent reply routing off the release-wide `slackApiBaseUrl`.** Carry the
-   reply destination on the enqueued turn / deployment record so the everyday
-   multi-dev `message` performs **no** release-wide `helm upgrade`; make
-   direct-enqueue the default driver and stub-wiring an admin `--force-wire`
-   escape hatch. (Q3 — the load-bearing one.)
-4. **`owner` scope on agents + namespace-per-owner runtime isolation.** Add an
+3. **`owner` scope on agents + namespace-per-owner runtime isolation.** Add an
    `owner` column, scope uniqueness to `(owner, name)`, and run each owner's
    sandboxes in `curie-run-<owner>`; extend controller RBAC (ADR-0023) to the
    per-owner namespaces. (Q2 — precursor to ADR-0008 `tenant_id`.)
-5. **Per-dev scoped RBAC role / kubeconfig.** A role that permits deploy/message
+4. **Per-dev scoped RBAC role / kubeconfig.** A role that permits deploy/message
    against the shared release and the dev's runtime namespace but **not** `helm
    upgrade` on the platform release. (Q2.)
-6. **Shared ingress / host-path per-agent routing; retire per-dev NodePorts.**
+5. **Shared ingress / host-path per-agent routing; retire per-dev NodePorts.**
    One LoadBalancer+ingress on managed clusters (NodePort only for the single
    shared exposure on kind/k3s), with per-agent host/path routes. (Q2/Q6.)
-7. **`cluster` runbook + connect-to-existing docs.** Document the admin-installs-
+6. **`cluster` runbook + connect-to-existing docs.** Document the admin-installs-
    once / devs-connect model, the context workflow, and the destructive-verb
    guards. (Q4 — depends on 1–3.)
 
@@ -242,10 +212,6 @@ dependency.
 
 - **Ambient-context footgun.** Verify the destructive-verb guards actually prevent
   a dev from admin-escalating via a stale context (the #40 `--local` lesson).
-- **Per-agent reply routing vs the frozen queue contract.** Issue 3 may touch the
-  `QueuedTurn` shape or the worker's Slack sink; if a new field is required it is a
-  frozen-contract change (raise it in an issue/PR first per the repo's
-  frozen-contract rule), not a side channel.
 - **Cooperative-not-adversarial assumption.** This design trusts teammates. If a
   shared *staging* cluster ever hosts semi-trusted users, the boundary must harden
   toward ADR-0008 (RLS, always-on tenant scoping) — the `owner` primitives here

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -257,7 +257,7 @@ The plugin bundle you just deployed is the agent's backend. There are two
 frontends that can talk to it: your terminal (no Slack involved) or a real
 Slack workspace.
 
-### Without Slack, from the terminal
+### Driving the deployed agent
 
 ```bash
 curie cluster message "hello, are you there?"
@@ -267,16 +267,19 @@ curie cluster message "hello, are you there?"
 |---|---|
 | `--continue` | Reuse the same conversation thread as your last `cluster message` call. |
 | `--thread <id>` | Continue a specific earlier conversation thread by ID, instead of the most recent one. |
-| `--force-wire` | `cluster message` normally refuses to run against a release that's already wired to a real Slack workspace, since driving it would send replies into that workspace instead. Pass `--force-wire` to override that guard. |
 
-This exercises a deployed release end to end with no Slack at all. It:
+When the release has no dispatcher, this exercises it end to end from the
+terminal. It:
 
 - simulates the exact Slack event your bot would receive
 - runs it through the real deployed worker and a real Kubernetes sandbox
-- prints the reply
+- prints the reply in the terminal
 
-`cluster message` handles the port-forwards, channel resolution, and stub
-routing itself, so none of that is something you need to set up. `--continue`
+When the release has a dispatcher connected to Slack, `cluster message` posts a
+placeholder and routes the reply to the agent's bound Slack channel. When no
+dispatcher is connected, it uses the terminal reply stub and prints the reply
+in the terminal. The command handles port-forwards and channel resolution
+itself, so none of that is something you need to set up. `--continue`
 reads its saved context from `.curie/last-turn.json` in the current <!-- doclint:ignore-line -->
 directory.
 
@@ -298,9 +301,9 @@ curie cluster comms --slack
 | `--dry-run` | Print the masked `helm` command without executing (env-backed token values are masked, never printed in full). |
 
 `curie cluster comms --slack` wires your release up to a real Slack
-workspace: it stores the tokens you pass, points the release at Slack
-instead of the local `cluster message` stub, and restarts the affected pods
-so the change takes effect immediately.
+workspace: it stores the tokens you pass and restarts the affected pods so the
+change takes effect immediately. Connected `cluster message` replies go to the
+agent's bound Slack channel; disconnected releases use the terminal stub.
 
 For the `local`-target equivalent (`curie local comms --slack`), see
 [`cli/README.md`](../cli/README.md).

--- a/docs/your-first-slack-agent.md
+++ b/docs/your-first-slack-agent.md
@@ -117,12 +117,13 @@ connectors:
 `secrets` are **names only** — the value never enters your repository:
 
 ```bash
-curie secrets set GRAFANA_SERVICE_ACCOUNT_TOKEN
+curie secrets set GRAFANA_SERVICE_ACCOUNT_TOKEN --from-env GRAFANA_SERVICE_ACCOUNT_TOKEN
 ```
 
-Each agent gets its **own** connector Deployment, Service, and Secret, labelled
-with its owner. Two agents in one namespace cannot reach each other's
-credentials.
+At cluster deploy time, Curie delivers both connector `secrets` and
+`secret_files` values into the agent's Kubernetes Secret. The host secret store
+is install global, so agents that use the same secret name share one stored
+value and can collide. Issue #440 tracks the future per agent delivery path.
 
 ---
 


### PR DESCRIPTION
Corrects cluster message guidance to match connected Slack and disconnected terminal routing.

Documents the install global connector secret store path for `secrets` and `secret_files`, including its collision caveat and the future per agent path in #440.

Closes #1537