### PR TITLE
Surface configured model identity in runner prompt

### DIFF
--- a/runner/src/curie_runner/__main__.py
+++ b/runner/src/curie_runner/__main__.py
@@ -88,16 +88,20 @@ def _compose_system_prompt(
     base: str | None,
     memory_preamble: str | None,
     conversation_preamble: str | None = None,
+    *,
+    model: str | None,
 ) -> str | None:
-    """Prepend the loaded-memory and conversation preambles to the system prompt.
+    """Compose the system prompt with recovered context and model identity.
 
     State delivered from outside the sandbox becomes durable model context by
     leading the system prompt: durable memory (ADR-0025) first, then this thread's
-    recovered conversation (ADR-0029), then the bundle/env system prompt. Any part
+    recovered conversation (ADR-0029), then the bundle/env system prompt. The
+    configured model identity follows the bundle prompt when present. Any part
     may be absent.
     """
 
-    parts = [p for p in (memory_preamble, conversation_preamble, base) if p]
+    model_preamble = f"Configured model: {model}" if model else None
+    parts = [p for p in (memory_preamble, conversation_preamble, base, model_preamble) if p]
     return "\n\n".join(parts) if parts else None
 
 
@@ -138,8 +142,14 @@ def build_runner(
     system_prompt = compiled.system_prompt
     # Prior memory (#264) and this thread's recovered conversation (#20), both
     # loaded from outside the sandbox, lead the system prompt so the model sees
-    # learned lessons and the prior exchange as durable context.
-    system_prompt = _compose_system_prompt(system_prompt, memory_preamble, conversation_preamble)
+    # learned lessons and the prior exchange as durable context. The configured
+    # model identity is appended after the bundle prompt.
+    system_prompt = _compose_system_prompt(
+        system_prompt,
+        memory_preamble,
+        conversation_preamble,
+        model=config.model,
+    )
     # In-bundle PreToolUse guardrails declared in the manifest hooks field (#272),
     # translated into SDK HookMatcher callbacks. None when the bundle declares none.
     bundle_hooks = load_bundle_hooks(config.session.plugin_dir)

--- a/runner/tests/test_history.py
+++ b/runner/tests/test_history.py
@@ -287,10 +287,45 @@ def test_compose_system_prompt_orders_memory_then_conversation_then_base() -> No
     # conversation, then the bundle/env system prompt. Any part may be absent.
     from curie_runner.__main__ import _compose_system_prompt
 
-    assert _compose_system_prompt("BASE", "MEM", "CONV") == "MEM\n\nCONV\n\nBASE"
-    assert _compose_system_prompt("BASE", None, "CONV") == "CONV\n\nBASE"
-    assert _compose_system_prompt("BASE", "MEM", None) == "MEM\n\nBASE"
-    assert _compose_system_prompt(None, None, None) is None
+    assert _compose_system_prompt("BASE", "MEM", "CONV", model=None) == "MEM\n\nCONV\n\nBASE"
+    assert _compose_system_prompt("BASE", None, "CONV", model=None) == "CONV\n\nBASE"
+    assert _compose_system_prompt("BASE", "MEM", None, model=None) == "MEM\n\nBASE"
+    assert _compose_system_prompt(None, None, None, model=None) is None
+
+
+def test_compose_system_prompt_appends_configured_model() -> None:
+    from curie_runner.__main__ import _compose_system_prompt
+
+    assert (
+        _compose_system_prompt("BASE", "MEM", "CONV", model="z-ai/glm-5.2")
+        == "MEM\n\nCONV\n\nBASE\n\nConfigured model: z-ai/glm-5.2"
+    )
+
+
+def test_build_runner_forwards_configured_model_to_session_prompt(tmp_path) -> None:
+    from curie_runner import RunnerConfig
+    from curie_runner.__main__ import build_runner
+
+    plugin_dir = tmp_path / ".claude-plugin"
+    plugin_dir.mkdir()
+    (plugin_dir / "plugin.json").write_text(
+        '{"name": "modelwiring", "version": "0.1.0", "description": "test"}'
+    )
+    config = RunnerConfig.from_env(
+        {
+            "CURIE_PLUGIN_DIR": str(tmp_path),
+            "CURIE_SESSION_ID": "s-model",
+            "CURIE_SANDBOX_ID": "b-model",
+            "CURIE_BUDGET": (
+                '{"max_output_tokens_per_run": 1000, "max_usd_per_day": 1.0}'
+            ),
+            "CURIE_MODEL": "z-ai/glm-5.2",
+        }
+    )
+    runner = build_runner(config, fake_model=False)
+    options = runner._factory()._options
+
+    assert options.system_prompt == "Configured model: z-ai/glm-5.2"
 
 
 def test_record_turn_swallows_store_failure() -> None:


### PR DESCRIPTION
## Summary

Surface the exact configured model identifier in the runner system prompt so routed models can describe themselves accurately.

Add prompt composition and runner wiring regression coverage.

Closes #1536