### PR TITLE
Allow runner sandbox egress to the platform API

### DIFF
--- a/charts/curie/ci/render-assertions.sh
+++ b/charts/curie/ci/render-assertions.sh
@@ -20,7 +20,9 @@
 # container and holds its env names to the generated key export; Assertion 7 is
 # the negative control proving Assertion 6 can fail.
 #
-# Issue #1109/#1124 (the API's outbound GitHub credential), Assertion 11 and its
+# Issue #1530 (runner sandbox API egress), Assertion 11.
+#
+# Issue #1109/#1124 (the API's outbound GitHub credential), Assertion 12 and its
 # negative control. api.githubToken is the one OPTIONAL credential in the
 # Secret, so it is a deliberate plain pass-through rather than a
 # curie.managedSecret: empty must render empty ("no GitHub credential, public
@@ -507,7 +509,102 @@ python3 "$NP_CHECK" "$NP_OFF_OUT" "absent" \
   || fail "with security.networkPolicy.enabled=false (Rail 1 off), spec.networkPolicyManagement should be left unset (default Managed) so the controller's own baseline policy still applies, but it was set."
 echo "  ok: with Rail 1 off, networkPolicyManagement is left unset (falls back to the controller's own Managed default rather than nothing)"
 
-echo "=== Assertion 11: api.githubToken is passed through, never generated (#1109, #1124) ==="
+echo "=== Assertion 11: runner sandbox reaches only this release API on TCP 8000 (#1530) ==="
+RUNNER_API_OUT="$(mktemp -d -p "$TMP")"
+helm template runner-api-render "$CHART" --namespace runner-api-namespace \
+  --output-dir "$RUNNER_API_OUT" > /dev/null
+
+RUNNER_API_CHECK="$TMP/check_runner_api_egress.py"
+cat > "$RUNNER_API_CHECK" <<'PYEOF'
+import pathlib
+import sys
+
+import yaml
+
+rendered, expected_state = sys.argv[1], sys.argv[2]
+expected_name = "runner-api-render-curie-runner-allow-api"
+expected_default_deny_name = "runner-api-render-curie-runner-default-deny-egress"
+expected_spec = {
+    "podSelector": {
+        "matchLabels": {
+            "app.kubernetes.io/name": "curie",
+            "app.kubernetes.io/instance": "runner-api-render",
+            "app.kubernetes.io/component": "runner-sandbox",
+        },
+    },
+    "policyTypes": ["Egress"],
+    "egress": [{
+        "to": [{
+            "namespaceSelector": {
+                "matchLabels": {
+                    "kubernetes.io/metadata.name": "runner-api-namespace",
+                },
+            },
+            "podSelector": {
+                "matchLabels": {
+                    "app.kubernetes.io/name": "curie",
+                    "app.kubernetes.io/instance": "runner-api-render",
+                    "app.kubernetes.io/component": "api",
+                },
+            },
+        }],
+        "ports": [{"protocol": "TCP", "port": 8000}],
+    }],
+}
+
+policies = []
+for path in sorted(pathlib.Path(rendered).rglob("*.yaml")):
+    for doc in yaml.safe_load_all(path.read_text()):
+        if isinstance(doc, dict) and doc.get("kind") == "NetworkPolicy":
+            policies.append(doc)
+
+matches = [
+    policy for policy in policies
+    if policy.get("metadata", {}).get("name") == expected_name
+]
+default_deny_matches = [
+    policy for policy in policies
+    if policy.get("metadata", {}).get("name") == expected_default_deny_name
+]
+
+if expected_state == "present":
+    if len(matches) != 1:
+        sys.stderr.write(
+            f"expected exactly one NetworkPolicy named {expected_name!r}; found {len(matches)}\n")
+        sys.exit(1)
+    got = matches[0].get("spec")
+    if got != expected_spec:
+        sys.stderr.write(
+            f"NetworkPolicy {expected_name!r} has spec={got!r}; expected {expected_spec!r}\n")
+        sys.exit(1)
+    print("  ok: runner sandbox API egress is release scoped and TCP 8000 only")
+elif expected_state == "absent":
+    if matches:
+        sys.stderr.write(
+            f"api.deploy=false still renders NetworkPolicy {expected_name!r}\n")
+        sys.exit(1)
+    if len(default_deny_matches) != 1:
+        sys.stderr.write(
+            f"api.deploy=false render must retain exactly one NetworkPolicy named "
+            f"{expected_default_deny_name!r}; found {len(default_deny_matches)}\n")
+        sys.exit(1)
+    print("  ok: api.deploy=false removes the runner sandbox API egress allowance")
+else:
+    sys.stderr.write(f"unknown expected state {expected_state!r}\n")
+    sys.exit(2)
+PYEOF
+
+python3 "$RUNNER_API_CHECK" "$RUNNER_API_OUT" present \
+  || fail "default render is missing the release scoped runner sandbox API egress allowance."
+
+RUNNER_API_OFF_OUT="$(mktemp -d -p "$TMP")"
+helm template runner-api-render "$CHART" --namespace runner-api-namespace \
+  --set api.deploy=false \
+  --output-dir "$RUNNER_API_OFF_OUT" > /dev/null
+python3 "$RUNNER_API_CHECK" "$RUNNER_API_OFF_OUT" absent \
+  || fail "api.deploy=false did not remove the runner sandbox API egress allowance."
+
+echo "=== Assertion 12: api.githubToken is passed through, never generated (#1109, #1124) ==="
 # The one OPTIONAL credential in this Secret. curie.managedSecret GENERATES when
 # the value equals its default, which for an optional token means 32 characters
 # of noise sent to GitHub as a bearer token, failing auth in a way that reads
@@ -553,7 +650,7 @@ for key in "${KEYS[@]}"; do
 done
 echo "  ok: githubToken is not in the generated-key list"
 
-echo "=== Assertion 11 negative control: routing githubToken through curie.managedSecret FAILS ==="
+echo "=== Assertion 12 negative control: routing githubToken through curie.managedSecret FAILS ==="
 # Mandatory, per Assertion 7's convention: an assert that has never been shown
 # failing is not a pin, and the three checks above all pass at base. Mutate a
 # TEMP COPY of the chart (never the real template) into exactly the #1109
@@ -575,7 +672,7 @@ PYEOF
 GHT_MUTANT_RENDER="$TMP/mutant-githubtoken.yaml"
 helm template "$GHT_MUTANT" --show-only templates/secrets.yaml > "$GHT_MUTANT_RENDER"
 if check_github_token_empty "$GHT_MUTANT_RENDER" "mutant (githubToken via curie.managedSecret)" 2>&1; then
-  fail "negative control did not fire: githubToken routed through curie.managedSecret still rendered empty, so Assertion 11 is not actually pinning anything."
+  fail "negative control did not fire: githubToken routed through curie.managedSecret still rendered empty, so Assertion 12 is not actually pinning anything."
 fi
 echo "  ok: a generated githubToken is rejected (the assert can fail)"
 

--- a/charts/curie/templates/security-networkpolicy.yaml
+++ b/charts/curie/templates/security-networkpolicy.yaml
@@ -133,6 +133,35 @@ spec:
         - { protocol: TCP, port: {{ .Values.otelCollector.service.grpcPort }} }
         - { protocol: TCP, port: {{ .Values.otelCollector.service.httpPort }} }
 {{- end }}
+{{- if .Values.api.deploy }}
+---
+{{/* Allow the runner to reach THIS release's in chart API for memory and history calls;
+     without this carve out, rail 1 default deny blocks those calls. TCP 8000 is the API
+     container port, not the configurable Service port. An external or overridden API
+     destination remains governed by the operator's allowedEgress list. */}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "curie.fullname" . }}-runner-allow-api
+  labels:
+    {{- include "curie.labels" . | nindent 4 }}
+    app.kubernetes.io/component: agent-sandbox
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "curie.selectorLabels" (dict "root" . "component" "runner-sandbox") | nindent 6 }}
+  policyTypes: [Egress]
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Release.Namespace }}
+          podSelector:
+            matchLabels:
+              {{- include "curie.selectorLabels" (dict "root" . "component" "api") | nindent 14 }}
+      ports:
+        - { protocol: TCP, port: 8000 }
+{{- end }}
 {{- if and .Values.rustfs.deploy .Values.agentSandbox.runner.bundleFetch.enabled }}
 ---
 {{/* Allow the runner's bundle-fetch init container to reach THIS release's


### PR DESCRIPTION
Adds a release scoped runner sandbox egress allowance to this release API pods on TCP 8000. Adds render coverage for the allowance and the disabled API case.

The local runtime harness was blocked before install by an existing cluster scoped PriorityClass owned by another release.

Closes #1530