### PR TITLE
Forward-merge main into next (ADR-0096 acceptance)

### DIFF
--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -64,7 +64,11 @@ Classify from the work, not from a requested process size.
 | Build | Multiple streams, architecture, security, deployment, or unclear interactions | Written plan, separate test and implementation contexts, reviews, and real surface verification when applicable |
 
 Promote a direct or quick change when its real scope exceeds the selected path. Do
-not add a planning artifact for a trivial mechanical change.
+not add a planning artifact for a trivial mechanical change. If a quick change
+turns up an assumption that qualifies for the de risk gate below, promote it to
+build before its first edit. If that assumption only appears after an edit, stop
+and either escalate or restart as a build path change; do not carry those edits
+forward.
 
 ## Build rules
 
@@ -82,6 +86,52 @@ For a build path, write a short plan that identifies behavior sites, affected fi
 test strategy, edge cases, and observable done conditions before implementation.
 Have an independent available provider review the plan when the change is
 architectural or crosses a contract boundary.
+
+## De risk gate
+
+Default to no spike. Evaluate this gate only on the build path, after the plan and
+any plan review, and before the first test is written. A direct or quick change
+never runs a spike.
+
+Run a spike only when all four of these hold:
+
+1. The plan depends on a specific claim that has not been observed.
+2. If that claim is false, the plan, scope, a dependency, or the architecture
+   materially changes.
+3. Documentation, source, existing tests, and prior observed evidence cannot settle
+   the claim confidently.
+4. A bounded experiment is materially cheaper than discovering the false claim
+   during implementation.
+
+If a failed assumption would not change an implementation decision, do not spike.
+Treat the economics as a high bar, not a calculation. There should be a plausible
+chance the assumption is wrong, failure should cost about a day of work or
+invalidate a whole stream, the probe should fit inside thirty minutes, and the
+avoided waste should clearly exceed the probe cost. Do not compute a numeric
+probability.
+
+Choose one of two kinds:
+
+- Tracer, preferred whenever the experiment can safely be the first narrow
+  production slice. It is kept production code and follows the normal test first,
+  review, and verification rules. Run that slice alone: write its test, implement
+  it, and harvest its observable result before releasing any remaining stream.
+- Throwaway, allowed only when execution is required and the evidence cannot come
+  from a safe production slice. Brief exactly one uncertainty, one observable pass
+  or fail result, a scope limited to that question, a cap of thirty minutes, and a
+  written finding. Run it outside the committed tree, never commit it, harvest the
+  evidence, then delete it. Code existing is not a finding.
+
+Run at most two throwaway spikes in one run without explicit user approval. If a
+spike does not settle its question inside the cap, stop it and either halt or
+escalate. Do not let it drift into implementation.
+
+Every finding must confirm, revise, or reject the plan. When a finding materially
+changes the plan, revise the plan and repeat whichever plan review applied to it. A
+throwaway must settle before any test for the change is written. After a tracer, no
+remaining stream proceeds until a revised plan clears that same review. When a
+finding exposes unclear acceptance criteria or product behavior, stop and ask. A
+spike gathers technical evidence and never makes a product decision.
 
 ## Review and verification
 

--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -5,11 +5,10 @@ name: Helm CI
 # job gives the chart the CI it otherwise lacks -- lint, render every shipped
 # values overlay, and schema-validate the rendered manifests.
 on:
+  # Push runs for every releasable commit because release authorization
+  # requires this check. Pull requests remain filtered to chart changes.
   push:
     branches: [main, next]
-    paths:
-      - "charts/curie/**"
-      - ".github/workflows/helm-ci.yaml"
   pull_request:
     branches: [main, next]
     paths:

--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -255,6 +255,19 @@ jobs:
           set -euo pipefail
           bash charts/curie/ci/worker-object-store-assertions.sh
 
+      # Prove the API and the worker agree on the object store. The API WRITES
+      # each uploaded bundle there and the worker READS it back, so a
+      # disagreement means the write lands somewhere the read never looks --
+      # and worker.yaml shipped with none of the four variables set, so the
+      # worker used its compose default (http://localhost:29000) and every
+      # bundle fetch got ECONNREFUSED. It surfaced as ClaimTimeoutError blaming
+      # a CPU-saturated node on a box idling at 11%, and as a post-deploy eval
+      # that silently stopped running with "unresolvable suite/bundle".
+      - name: helm render assertions (worker/api object store agree)
+        run: |
+          set -euo pipefail
+          bash charts/curie/ci/worker-object-store-assertions.sh
+
       - name: helm template + kubeconform (values-dev overlay)
         run: |
           set -euo pipefail

--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -109,6 +109,11 @@ jobs:
           set -euo pipefail
           bash charts/curie/ci/clickhouse-logging-assertions.sh
 
+      - name: helm render assertions (otel collector checksum)
+        run: |
+          set -euo pipefail
+          bash charts/curie/ci/otel-collector-checksum-assertions.sh
+
       # Prove the Langfuse web+worker containers carry a numeric runAsUser
       # alongside runAsNonRoot (issue #351) so the kubelet can verify non-root
       # and the pods actually start on an enforcing cluster.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,7 +1,8 @@
 name: Release images and binaries
 
 # Two triggers, one workflow, so a single ref carries both artifacts:
-#  - push to main            -> publish images tagged sha + latest (continuous).
+#  - push to main or next    -> publish images tagged sha (continuous); main
+#                               also publishes latest.
 #  - push a v* tag           -> publish images tagged with the version AND build,
 #                               strip, and attach the curie CLI binaries to a
 #                               GitHub Release with generated notes.
@@ -20,7 +21,7 @@ name: Release images and binaries
 
 on:
   push:
-    branches: [main]
+    branches: [&release_main main, &release_next next]
     tags: ["v*"]
 
 permissions:
@@ -30,7 +31,8 @@ permissions:
 jobs:
   # Gates the ENTIRE tag-triggered publish pipeline (issue #628). A `v*` tag push
   # proves nothing about the tagged commit on its own, so nothing below may run
-  # for one until this job says the commit is reviewed, on main, and green.
+  # for one until this job says the commit is reviewed, on an allowed release
+  # branch, and green.
   # See ADR-0058 for the ancestry/checks design and ADR-0065 for the trust
   # boundary this job actually sits behind: it stops an accidentally-tagged
   # commit, not a write actor willing to edit the gate itself, because both
@@ -40,8 +42,8 @@ jobs:
   # environment -- are admin-only settings, unconfigured, and tracked as
   # blocking work in ADR-0065, not as a hardening follow-up.
   #
-  # `if:` makes this a no-op (skipped) for ordinary pushes to `main`, so the
-  # continuous sha/latest image builds below are unaffected. `environment:` has
+  # `if:` makes this a no-op (skipped) for ordinary pushes to `main` or `next`,
+  # so the continuous image builds below are unaffected. `environment:` has
   # no effect until required reviewers are added to it; the day they are, every
   # tag push pauses for approval right here, before anything else runs.
   authorize-release:
@@ -49,17 +51,20 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     environment: release-publish
+    env:
+      RELEASE_MAIN_BRANCH: *release_main
+      RELEASE_NEXT_BRANCH: *release_next
     permissions:
       contents: read
       checks: read
     steps:
       - uses: actions/checkout@v7
         with:
-          # Full history: an ancestor commit deep in main's log must stay
-          # reachable, which a shallow clone would hide. This materializes the
-          # TAGGED commit's tree (GitHub Actions checks out the triggering ref
-          # on a push trigger), origin/main included as a remote-tracking ref
-          # by the same fetch-depth: 0.
+          # Full history: an ancestor commit deep in either release branch's
+          # log must stay reachable, which a shallow clone would hide. This
+          # materializes the TAGGED commit's tree (GitHub Actions checks out
+          # the triggering ref on a push trigger), with both release branches
+          # included as remote-tracking refs by the same fetch-depth: 0.
           fetch-depth: 0
           persist-credentials: false
       - name: Resolve release/ from origin/main, not the tagged ref
@@ -76,11 +81,14 @@ jobs:
         # is unaffected by which copy of authorize.py exists, because their
         # tampered workflow never calls it. See ADR-0065 for the full trust
         # boundary this does and does not cover.
-        run: git checkout origin/main -- release/
-      - name: Tag's commit must be reviewed, on main, and fully checked
+        run: git checkout origin/${{ env.RELEASE_MAIN_BRANCH }} -- release/
+      - name: Tag's commit must be reviewed, on an allowed branch, and fully checked
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: python3 release/authorize.py "$GITHUB_SHA" --repo "$GITHUB_REPOSITORY"
+        run: |
+          python3 release/authorize.py "$GITHUB_SHA" --repo "$GITHUB_REPOSITORY" \
+            --reviewed-ref origin/${{ env.RELEASE_MAIN_BRANCH }} \
+            --reviewed-ref origin/${{ env.RELEASE_NEXT_BRANCH }}
 
   build:
     name: Build ${{ matrix.name }} image (${{ matrix.platform }})
@@ -88,9 +96,10 @@ jobs:
     needs: [authorize-release]
     # `always()` overrides the default needs-propagation (which would skip this
     # job whenever authorize-release is merely skipped, i.e. on every ordinary
-    # main push): a `skipped` authorize-release means "not a tag push, nothing to
-    # authorize" and this job proceeds; a `failure` result means an unauthorized
-    # tag, and this job -- and everything downstream of it -- does not run.
+    # branch push): a `skipped` authorize-release means "not a tag push, nothing
+    # to authorize" and this job proceeds; a `failure` result means an
+    # unauthorized tag, and this job -- and everything downstream of it -- does
+    # not run.
     if: |
       always() &&
       (needs.authorize-release.result == 'success' || needs.authorize-release.result == 'skipped')
@@ -193,9 +202,10 @@ jobs:
     name: Merge ${{ matrix.name }} manifest
     needs: [build]
     # A skip propagates through the WHOLE ancestor graph, not just the direct
-    # `needs:` edge: with authorize-release skipped on an ordinary main push,
-    # this job was skipped too even though `build` reported success, which froze
-    # the sha/latest manifests at the last tag push (#787). Naming a status
+    # `needs:` edge: with authorize-release skipped on an ordinary main or next
+    # push, this job was skipped too even though `build` reported success, which
+    # froze the SHA manifest and the main only latest manifest at the last tag
+    # push (#787). Naming a status
     # function opts the job out of that propagation, and the explicit result
     # check keeps it as strict as the implicit one: a `build` that failed or was
     # cancelled still stops the manifest, and on the tag path a refused
@@ -307,7 +317,7 @@ jobs:
           if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
             echo "v=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
           else
-            echo "v=latest" >> "$GITHUB_OUTPUT"
+            echo "v=sha-${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
           fi
       - name: Set up Buildx
         id: setup_buildx

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -246,4 +246,5 @@ commits = [
   # repository's existence and name as disclosed.
   "39b0bd3990b2e0ea816e4e0a99d1f4159efcefe5",  # ADR-0091 impl: the slug as a test fixture
   "cde1ac43c284b17eb2253af02b50345b808d6711",  # ADR-0090 Draft: the slug + its issue, cited as evidence
+  "33505bd401c915ed7254ab6172a4f337eeeb5f77",  # object store role examples, scrubbed from HEAD
 ]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -137,11 +137,13 @@ paths = [
   '''^\.gitleaks\.toml$''',
 ]
 
-# Pre-existing fixture ids. Every one is obviously invented -- it spells a
-# word (C0MANAGERS), repeats a character (C0FFFFFF6), or is mostly zeroes
-# (C000000A01). That is the bar for a new one: a reader must be able to tell
-# at a glance that it is not somebody's channel. Adding to this list should be
-# rare; prefer reusing C0EXAMPLE1.
+# Gitleaks stopwords are case insensitive substring matches, so an entry
+# suppresses any longer identifier containing it, including identifiers
+# prefixed by that entry. Every value is an
+# obviously invented fixture id: it spells a word (C0MANAGERS), repeats a
+# character (C0FFFFFF6), or is mostly zeroes (C000000A01). That is the bar for
+# a new one: a reader must be able to tell at a glance that it is not somebody's
+# channel. Adding to this list should be rare; prefer reusing C0EXAMPLE1.
 stopwords = [
   "C000000A01",
   "C000000A02",
@@ -195,14 +197,12 @@ stopwords = [
   "C01SUPPORT",
   "C024BE91L",
   "C0AAAAAA1",
-  "C0AAAAAAA",
   "C0AGENT001",
   "C0BBBBBB2",
   "C0BOUND01",
   "C0BROAD01",
   "C0CARD001",
   "C0CCCCCC3",
-  "C0DEV2222",
   "C0DDDDDD4",
   "C0EEEEEE5",
   "C0ELSE001",
@@ -216,7 +216,6 @@ stopwords = [
   "C0INTAKE00",
   "C0LOCALDEV",
   "C0MALFORMED",
-  "C0PROD111",
   "C0MANAGERS",
   "C0OLDROOM0",
   "C0REQ0001",

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -172,6 +172,14 @@ stopwords = [
   "C000000S03",
   "C000000S04",
   "C000000S05",
+  # S06 to S09 exist only in history: the per-agent secret-delivery work
+  # introduced them and later edited them away, but gitleaks scans every
+  # commit, so an id absent from the tree still fails the scan forever.
+  # Registering them is the only fix that does not rewrite history.
+  "C000000S06",
+  "C000000S07",
+  "C000000S08",
+  "C000000S09",
   "C000000X01",
   "C0000BND1",
   "C0000BND2",
@@ -187,12 +195,14 @@ stopwords = [
   "C01SUPPORT",
   "C024BE91L",
   "C0AAAAAA1",
+  "C0AAAAAAA",
   "C0AGENT001",
   "C0BBBBBB2",
   "C0BOUND01",
   "C0BROAD01",
   "C0CARD001",
   "C0CCCCCC3",
+  "C0DEV2222",
   "C0DDDDDD4",
   "C0EEEEEE5",
   "C0ELSE001",
@@ -206,6 +216,7 @@ stopwords = [
   "C0INTAKE00",
   "C0LOCALDEV",
   "C0MALFORMED",
+  "C0PROD111",
   "C0MANAGERS",
   "C0OLDROOM0",
   "C0REQ0001",

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -28,11 +28,3 @@ be962e4a37f8644539244e2e872937f2fd8371a0:AGENTS.md:curl-auth-user:105
 # allowlisted here. The lines on main carry inline gitleaks:allow markers.
 c8b1ccb28faa51d3ec996d60883fde48a303b0bd:AGENTS.md:curl-auth-user:154
 c8b1ccb28faa51d3ec996d60883fde48a303b0bd:docs/adr/0079-inbound-triggers-as-a-new-event-kind.md:generic-api-key:46
-
-# A private org repo slug that reached a test fixture and was edited away again.
-# Ignored by FINGERPRINT rather than added to an allowlist: the rule exists to
-# catch exactly this shape, and widening it would retire the protection instead
-# of retiring the one occurrence. The slug is absent from the tree; only the
-# commit that introduced it still carries it, and history is not rewritten for a
-# fixture name that was never a credential.
-2adab2fc53b64ca6b80adf794e90c0fdf1e9754e:apps/api/tests/test_gitflow_targets.py:downstream-repo-slug:22

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -28,3 +28,11 @@ be962e4a37f8644539244e2e872937f2fd8371a0:AGENTS.md:curl-auth-user:105
 # allowlisted here. The lines on main carry inline gitleaks:allow markers.
 c8b1ccb28faa51d3ec996d60883fde48a303b0bd:AGENTS.md:curl-auth-user:154
 c8b1ccb28faa51d3ec996d60883fde48a303b0bd:docs/adr/0079-inbound-triggers-as-a-new-event-kind.md:generic-api-key:46
+
+# A private org repo slug that reached a test fixture and was edited away again.
+# Ignored by FINGERPRINT rather than added to an allowlist: the rule exists to
+# catch exactly this shape, and widening it would retire the protection instead
+# of retiring the one occurrence. The slug is absent from the tree; only the
+# commit that introduced it still carries it, and history is not rewritten for a
+# fixture name that was never a credential.
+2adab2fc53b64ca6b80adf794e90c0fdf1e9754e:apps/api/tests/test_gitflow_targets.py:downstream-repo-slug:22

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -467,11 +467,20 @@ CURIE_E2E_TIERS=all curie dev e2e-ladder
 CURIE_E2E_TIERS=local-release curie dev e2e-ladder
 ```
 
-Tag v0.7.0 from `main` only after both commands pass, then delete `next` or
-recreate it from `main` for the next approved feature train. Only an
-administrator may retire `next`, by temporarily removing protection after the
-tag while `main` remains protected. If `next` is recreated, restore its full
-protection before accepting PRs against it.
+Tag v0.7.0 from `main` only after both commands pass. Only an administrator may
+retire `next`. Before deleting it, the administrator must merge one release
+workflow and contract test change that removes `next` from the workflow trigger
+branch list, removes the `RELEASE_NEXT_BRANCH` environment alias, removes the
+`--reviewed-ref origin/$RELEASE_NEXT_BRANCH` argument, and updates
+`release/tests/test_authorize.py`. After that change lands, the administrator
+may temporarily remove protection and delete `next`, while keeping `main`
+protected. To recreate `next` for the next approved feature train, the
+administrator must first restore full protection for `next`, then create it
+from `main`. Only after those steps may the administrator merge one release
+workflow and contract test change that adds `next` to the workflow trigger
+branch list, restores the `RELEASE_NEXT_BRANCH` environment alias and the
+`--reviewed-ref origin/$RELEASE_NEXT_BRANCH` argument, and updates
+`release/tests/test_authorize.py` before accepting PRs against it.
 
 - Commit message format: a short imperative summary line, then detail bullets.
 - Reference the relevant issue in the PR body (e.g. `Closes #123`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -189,11 +189,20 @@ CURIE_E2E_TIERS=all curie dev e2e-ladder
 CURIE_E2E_TIERS=local-release curie dev e2e-ladder
 ```
 
-Tag v0.7.0 from `main` only after both commands pass, then delete `next` or
-recreate it from `main` for the next approved feature train. Only an
-administrator may retire `next`, by temporarily removing protection after the
-tag while `main` remains protected. If `next` is recreated, restore its full
-protection before accepting PRs against it.
+Tag v0.7.0 from `main` only after both commands pass. Only an administrator may
+retire `next`. Before deleting it, the administrator must merge one release
+workflow and contract test change that removes `next` from the workflow trigger
+branch list, removes the `RELEASE_NEXT_BRANCH` environment alias, removes the
+`--reviewed-ref origin/$RELEASE_NEXT_BRANCH` argument, and updates
+`release/tests/test_authorize.py`. After that change lands, the administrator
+may temporarily remove protection and delete `next`, while keeping `main`
+protected. To recreate `next` for the next approved feature train, the
+administrator must first restore full protection for `next`, then create it
+from `main`. Only after those steps may the administrator merge one release
+workflow and contract test change that adds `next` to the workflow trigger
+branch list, restores the `RELEASE_NEXT_BRANCH` environment alias and the
+`--reviewed-ref origin/$RELEASE_NEXT_BRANCH` argument, and updates
+`release/tests/test_authorize.py` before accepting PRs against it.
 
 - **Commit messages**: a short imperative summary line, then detail bullets.
 - **Reference the issue in the PR body** with `Closes #123` (or `Ref #123`). Do

--- a/apps/api/src/curie_api/bundles.py
+++ b/apps/api/src/curie_api/bundles.py
@@ -155,7 +155,15 @@ def render_connector_manifests(
     objects: list[dict[str, Any]] = []
     for name, spec in sorted(connectors.connectors.items()):
         objects.extend(
-            connector_render.render(release, agent, namespace, app_name, name, spec, secret_name)
+            connector_render.render(
+                release=release,
+                agent=agent,
+                namespace=namespace,
+                app_name=app_name,
+                connector=name,
+                spec=spec,
+                secret_name=secret_name,
+            )
         )
     return objects
 

--- a/apps/api/tests/test_bundle_connectors.py
+++ b/apps/api/tests/test_bundle_connectors.py
@@ -116,10 +116,22 @@ def test_ingress_policy_admits_only_the_sandbox(tmp_path: Path) -> None:
     # Same ClusterIP trap on the way in, and the same reason it matters: this is
     # the path a real deploy takes, so a rule that parses but never matches
     # would leave the connector open while looking closed.
-    np = _policy(_render(_bundle(tmp_path, HOSTED)), "Ingress")
+    connectors = HOSTED.replace(
+        "    args: [-t, streamable-http]\n",
+        "    args: [-t, streamable-http]\n    port: 9876\n",
+    )
+    root = _bundle(tmp_path, connectors)
+    objs = _render(root)
+    np = _policy(objs, "Ingress")
     src = np["spec"]["ingress"][0]["from"]
     assert len(src) == 1
     assert "podSelector" in src[0] and "ipBlock" not in src[0]
+    svc = next(o for o in objs if o["kind"] == "Service")
+    assert (
+        svc["spec"]["ports"][0]["port"]
+        == np["spec"]["ingress"][0]["ports"][0]["port"]
+        == 9876
+    )
 
 
 def test_mcp_entry_url_matches_the_rendered_service(tmp_path: Path) -> None:

--- a/apps/api/tests/test_bundle_connectors.py
+++ b/apps/api/tests/test_bundle_connectors.py
@@ -41,14 +41,28 @@ HOSTED = (
 )
 
 
-def _render(root: Path, agent: str = "acme-bot") -> list[dict]:
+# These four are forwarded into `connector_render.render` as four bare strings,
+# so they MUST stay distinct from one another. Held equal, the forward is pinned
+# by nothing: swapping any two of them leaves every test in this file green
+# while the rendered NetworkPolicies select no pod at all. A real install
+# already drives at least one apart -- `curie cluster up --namespace my-agent
+# --release my-agent` against a chart whose `nameOverride` is empty leaves
+# app_name `curie` while release and namespace are both `my-agent`.
+RELEASE = "acme-rel"
+AGENT = "acme-bot"
+NAMESPACE = "acme-ns"
+APP_NAME = "curie"
+SECRET_NAME = f"{RELEASE}-{AGENT}-connectors"
+
+
+def _render(root: Path, agent: str = AGENT) -> list[dict]:
     return bundles.render_connector_manifests(
         bundles.read_connectors(root),
-        release="acme-bot",
+        release=RELEASE,
         agent=agent,
-        namespace="acme-bot",
-        app_name="acme-bot",
-        secret_name=f"acme-bot-{agent}-connectors",
+        namespace=NAMESPACE,
+        app_name=APP_NAME,
+        secret_name=f"{RELEASE}-{agent}-connectors",
     )
 
 
@@ -93,7 +107,7 @@ def test_secret_is_referenced_not_inlined(tmp_path: Path) -> None:
     dep = next(o for o in _render(_bundle(tmp_path, HOSTED)) if o["kind"] == "Deployment")
     env = dep["spec"]["template"]["spec"]["containers"][0]["env"]
     token = next(e for e in env if e["name"] == "GRAFANA_TOKEN")
-    assert token["valueFrom"]["secretKeyRef"]["name"] == "acme-bot-acme-bot-connectors"
+    assert token["valueFrom"]["secretKeyRef"]["name"] == SECRET_NAME
     assert "value" not in token
 
 
@@ -138,16 +152,65 @@ def test_mcp_entry_url_matches_the_rendered_service(tmp_path: Path) -> None:
     root = _bundle(tmp_path, HOSTED)
     svc = next(o for o in _render(root) if o["kind"] == "Service")
     entries = bundles.connector_mcp_entries(
-        bundles.read_connectors(root), release="acme-bot", agent="acme-bot", namespace="acme-bot"
+        bundles.read_connectors(root), release=RELEASE, agent=AGENT, namespace=NAMESPACE
     )
     assert svc["metadata"]["name"] in entries["grafana"]["url"]
+
+
+IDENTITY = (
+    "connectors:\n"
+    "  grafana:\n"
+    "    image: grafana/mcp-grafana:0.17.2\n"
+    "    env: {SELF_URL: '${CURIE_CONNECTOR_URL}'}\n"
+)
+
+
+def test_each_of_the_four_names_lands_where_it_belongs(tmp_path: Path) -> None:
+    # `render_connector_manifests` hands release, agent, namespace and app_name
+    # to the renderer as four interchangeable-looking strings. Swapping any two
+    # produces manifests that parse, apply, and are wrong: release for app_name
+    # makes the sandbox selector read `app.kubernetes.io/name: acme-rel` instead
+    # of `curie`, both NetworkPolicies then select no pod, and every connector
+    # tool call dies as a bare connection timeout with no policy error anywhere.
+    # Each of the four is asserted at the place only IT can reach, against whole
+    # values rather than substrings, so no swap survives.
+    root = _bundle(tmp_path, IDENTITY)
+    objs = _render(root)
+    name = f"{RELEASE}-{AGENT}-mcp-grafana"
+    dns = f"{name}.{NAMESPACE}.svc.cluster.local"
+    sandbox = {
+        "app.kubernetes.io/name": APP_NAME,
+        "app.kubernetes.io/instance": RELEASE,
+        "app.kubernetes.io/component": "runner-sandbox",
+    }
+
+    # app_name and release: the sandbox selector, on both policies.
+    assert _policy(objs, "Egress")["spec"]["podSelector"]["matchLabels"] == sandbox
+    ingress_from = _policy(objs, "Ingress")["spec"]["ingress"][0]["from"][0]
+    assert ingress_from["podSelector"]["matchLabels"] == sandbox
+
+    # release and agent: the object name, in that order, plus part-of.
+    dep = next(o for o in objs if o["kind"] == "Deployment")
+    assert {o["metadata"]["name"] for o in objs} == {name, f"{name}-allow", f"{name}-allow-ingress"}
+    assert dep["metadata"]["labels"] == {
+        "app.kubernetes.io/name": name,
+        "app.kubernetes.io/part-of": RELEASE,
+    }
+
+    # namespace: the only place it shows up is the Service DNS Curie derives.
+    env = dep["spec"]["template"]["spec"]["containers"][0]["env"]
+    assert {"name": "SELF_URL", "value": f"http://{dns}:8000"} in env
+    entries = bundles.connector_mcp_entries(
+        bundles.read_connectors(root), release=RELEASE, agent=AGENT, namespace=NAMESPACE
+    )
+    assert entries["grafana"] == {"type": "http", "url": f"http://{dns}:8000/mcp"}
 
 
 def test_remote_connector_contributes_an_entry_but_no_objects(tmp_path: Path) -> None:
     root = _bundle(tmp_path, "connectors:\n  x:\n    url: https://mcp.internal/mcp\n")
     assert _render(root) == []
     entries = bundles.connector_mcp_entries(
-        bundles.read_connectors(root), release="acme-bot", agent="acme-bot", namespace="acme-bot"
+        bundles.read_connectors(root), release=RELEASE, agent=AGENT, namespace=NAMESPACE
     )
     assert entries["x"]["url"] == "https://mcp.internal/mcp"
 

--- a/charts/curie/Chart.yaml
+++ b/charts/curie/Chart.yaml
@@ -8,8 +8,8 @@ description: >-
   and two install-time preflights ship baked in: a CPU-AVX / ClickHouse-pin
   check and a NetworkPolicy-enforcement probe.
 type: application
-version: 0.7.0-rc.3
-appVersion: "0.7.0-rc.3"
+version: 0.7.0-rc.4
+appVersion: "0.7.0-rc.4"
 kubeVersion: ">=1.25.0-0"
 maintainers:
   - name: Curie

--- a/charts/curie/ci/clickhouse-logging-assertions.sh
+++ b/charts/curie/ci/clickhouse-logging-assertions.sh
@@ -53,30 +53,95 @@ CHART="$(cd "$SCRIPT_DIR/.." && pwd)"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
-TPL=templates/clickhouse.yaml
-
 fail() { echo "FAIL: $*" >&2; exit 1; }
 
-DEFAULT="$TMP/default.yaml"
-VERBOSE="$TMP/verbose.yaml"
-NOPERSIST="$TMP/nopersist.yaml"
-OFF="$TMP/off.yaml"
+render() {
+  local name="$1"
+  local chart="$2"
+  shift 2
+
+  RENDER_DIR="$TMP/$name"
+  helm template rel "$chart" --output-dir "$RENDER_DIR" "$@"
+}
+
+manifest_for() {
+  local manifest
+  manifest="$(find "$1" -type f -path "*/templates/clickhouse.yaml" -print -quit)"
+  [[ -n "$manifest" ]] || fail "ClickHouse template was not written to $1"
+  printf '%s\n' "$manifest"
+}
 
 echo "=== Rendering ClickHouse (defaults) ==="
-helm template rel "$CHART" --show-only "$TPL" > "$DEFAULT"
+render default "$CHART"
+DEFAULT="$(manifest_for "$RENDER_DIR")"
 
 echo "=== Rendering ClickHouse (systemLogs.enabled=true, retentionDays=7) ==="
-helm template rel "$CHART" --show-only "$TPL" \
+render verbose "$CHART" \
   --set clickhouse.systemLogs.enabled=true \
-  --set clickhouse.systemLogs.retentionDays=7 > "$VERBOSE"
+  --set clickhouse.systemLogs.retentionDays=7
+VERBOSE="$(manifest_for "$RENDER_DIR")"
 
 echo "=== Rendering ClickHouse (persistence disabled) ==="
-helm template rel "$CHART" --show-only "$TPL" \
-  --set clickhouse.persistence.enabled=false > "$NOPERSIST"
+render nopersist "$CHART" --set clickhouse.persistence.enabled=false
+NOPERSIST="$(manifest_for "$RENDER_DIR")"
 
 echo "=== Rendering ClickHouse (deploy=false) ==="
-helm template rel "$CHART" --show-only "$TPL" \
-  --set clickhouse.deploy=false > "$OFF" 2>/dev/null || true
+render off "$CHART" \
+  --set clickhouse.deploy=false \
+  --set clickhouse.host=clickhouse.example.com
+OFF="$RENDER_DIR"
+
+CHECKSUM_VALUES=(
+  --set clickhouse.logLevel=warning
+  --set clickhouse.systemLogs.enabled=false
+  --set clickhouse.systemLogs.retentionDays=30
+)
+MUTATED_CHART="$TMP/checksum-chart"
+cp -a "$CHART" "$MUTATED_CHART"
+
+echo "=== Rendering ClickHouse checksum baseline ==="
+render checksum-original "$MUTATED_CHART" "${CHECKSUM_VALUES[@]}"
+CHECKSUM_ORIGINAL="$(manifest_for "$RENDER_DIR")"
+
+python3 - "$MUTATED_CHART/templates/_helpers.tpl" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+original = path.read_text()
+mutated = original.replace("<console>1</console>", "<console>0</console>", 1)
+assert mutated != original, "checksum mutation target was not found"
+path.write_text(mutated)
+PY
+
+echo "=== Rendering ClickHouse checksum mutation ==="
+render checksum-mutated "$MUTATED_CHART" "${CHECKSUM_VALUES[@]}"
+CHECKSUM_MUTATED="$(manifest_for "$RENDER_DIR")"
+
+python3 - "$CHECKSUM_ORIGINAL" "$CHECKSUM_MUTATED" <<'PY'
+import sys, yaml
+
+def config_and_checksum(path):
+    docs = [d for d in yaml.safe_load_all(open(path)) if d]
+    cm = next((d for d in docs if d["kind"] == "ConfigMap"), None)
+    sts = next((d for d in docs if d["kind"] == "StatefulSet"), None)
+    assert cm is not None, f"{path}: no ClickHouse config ConfigMap rendered"
+    assert sts is not None, f"{path}: no ClickHouse StatefulSet rendered"
+    annotations = sts["spec"]["template"]["metadata"].get("annotations") or {}
+    checksum = annotations.get("checksum/config")
+    assert checksum, f"{path}: no checksum/config annotation rendered"
+    return cm["data"]["curie-logging.xml"], checksum
+
+original_body, original_checksum = config_and_checksum(sys.argv[1])
+mutated_body, mutated_checksum = config_and_checksum(sys.argv[2])
+
+assert original_body != mutated_body, "checksum mutation did not change the ConfigMap body"
+assert original_checksum != mutated_checksum, (
+    "ConfigMap body changed but checksum/config did not. The pod would not roll."
+)
+
+print("  ConfigMap body mutation updates checksum: OK")
+PY
 
 # ---------------------------------------------------------------- 1, 2, 4, 6
 python3 - "$DEFAULT" "$VERBOSE" <<'PY'
@@ -204,10 +269,10 @@ assert "volumeClaimTemplates" not in sts["spec"], "persistence=false must not re
 print("  persistence=false still gets its data emptyDir: OK")
 PY
 
-if grep -q "kind:" "$OFF" 2>/dev/null; then
-  fail "clickhouse.deploy=false still rendered objects"
+if [[ -d "$OFF" ]] && [[ -n "$(find "$OFF" -type f -path "*/templates/clickhouse.yaml" -print -quit)" ]]; then
+  fail "clickhouse.deploy=false still rendered the ClickHouse manifest"
 fi
-echo "  clickhouse.deploy=false renders nothing: OK"
+echo "  clickhouse.deploy=false renders no ClickHouse manifest: OK"
 
 echo
 echo "PASS: ClickHouse self-telemetry defaults are bounded."

--- a/charts/curie/ci/otel-collector-checksum-assertions.sh
+++ b/charts/curie/ci/otel-collector-checksum-assertions.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART="$(cd "$SCRIPT_DIR/.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+render() {
+  local name="$1"
+  shift
+  helm template curie "$CHART" --output-dir "$TMP/$name" "$@" >/dev/null
+}
+
+manifest_for() {
+  local manifest
+  manifest="$(find "$1" -type f -path '*/templates/otel-collector.yaml' -print -quit)"
+  [[ -n "$manifest" ]] || fail "OTel Collector manifest was not written to $1"
+  printf '%s\n' "$manifest"
+}
+
+render default
+render port-3001 --set langfuse.web.service.port=3001
+render auth-header --set otelCollector.otlpAuthHeader='Basic YXNzZXJ0OmFzc2VydA=='
+
+python3 - "$(manifest_for "$TMP/default")" "$(manifest_for "$TMP/port-3001")" "$(manifest_for "$TMP/auth-header")" <<'PY'
+import sys
+import yaml
+
+def config_and_checksum(path):
+    docs = [doc for doc in yaml.safe_load_all(open(path)) if doc]
+    config_map = next((doc for doc in docs if doc.get("kind") == "ConfigMap"), None)
+    deployment = next((doc for doc in docs if doc.get("kind") == "Deployment"), None)
+    assert config_map is not None, f"{path}: no ConfigMap rendered"
+    assert deployment is not None, f"{path}: no Deployment rendered"
+    config = config_map.get("data", {}).get("collector-config.yaml")
+    checksum = deployment["spec"]["template"]["metadata"].get("annotations", {}).get("checksum/config")
+    assert config, f"{path}: collector ConfigMap body was not rendered"
+    assert checksum, f"{path}: Deployment checksum/config was not rendered"
+    return config, checksum
+
+default_config, default_checksum = config_and_checksum(sys.argv[1])
+changed_config, changed_checksum = config_and_checksum(sys.argv[2])
+auth_config, auth_checksum = config_and_checksum(sys.argv[3])
+
+assert default_config != changed_config, "Langfuse service port did not change the collector ConfigMap body"
+assert default_checksum != changed_checksum, (
+    "ConfigMap body changed but Deployment checksum/config stayed identical. The pod would not roll."
+)
+assert default_config == auth_config, "OTLP auth header changed the collector ConfigMap body"
+assert default_checksum != auth_checksum, (
+    "OTLP auth header changed but Deployment checksum/config stayed identical. The pod would not roll."
+)
+
+print("ConfigMap changes roll the pod and OTLP auth header changes still roll it: OK")
+PY

--- a/charts/curie/ci/worker-object-store-assertions.sh
+++ b/charts/curie/ci/worker-object-store-assertions.sh
@@ -19,53 +19,115 @@
 set -euo pipefail
 
 CHART=${CHART:-charts/curie}
-RENDERED=$(mktemp); trap 'rm -f "$RENDERED"' EXIT
-helm template t "$CHART" > "$RENDERED"
+DEFAULT_RENDERED=$(mktemp)
+EXTERNAL_RENDERED=$(mktemp)
+EXTERNAL_VALUES=$(mktemp)
+trap 'rm -f "$DEFAULT_RENDERED" "$EXTERNAL_RENDERED" "$EXTERNAL_VALUES"' EXIT
+
+cat > "$EXTERNAL_VALUES" <<'EOF'
+rustfs:
+  deploy: false
+  host: s3.example.com
+  port: 443
+EOF
+
+helm template curie "$CHART" --namespace dev > "$DEFAULT_RENDERED"
+helm template curie "$CHART" --namespace dev \
+  --values "$EXTERNAL_VALUES" > "$EXTERNAL_RENDERED"
 
 # The rendered manifests go via a FILE, not a second stdin redirect: with both
 # `<<'PY'` and `<<<"$out"` on one command the herestring wins and python reads
 # the chart instead of the script.
-python3 - "$RENDERED" <<'PY'
+python3 - \
+  "$DEFAULT_RENDERED" "default" "http://curie-rustfs:9000" \
+  "$EXTERNAL_RENDERED" "external" "https://s3.example.com:443" <<'PY'
 import sys, yaml
-
-api = worker = None
-with open(sys.argv[1]) as fh:
-    for doc in yaml.safe_load_all(fh):
-        if not doc or doc.get("kind") != "Deployment":
-            continue
-        name = doc["metadata"]["name"]
-        env = {e["name"]: e for e in doc["spec"]["template"]["spec"]["containers"][0].get("env", [])}
-        if name.endswith("-api"):
-            api = env
-        elif name.endswith("-worker"):
-            worker = env
-
-assert api is not None, "api Deployment not rendered"
-assert worker is not None, "worker Deployment not rendered"
 
 KEYS = ("S3_ENDPOINT_URL", "S3_ACCESS_KEY", "S3_SECRET_KEY", "BUNDLE_BUCKET")
 
-missing = [k for k in KEYS if k not in worker]
-assert not missing, (
-    f"worker is missing {missing}. Its config defaults these to the compose stack "
-    "(http://localhost:29000), so every bundle fetch fails with ECONNREFUSED -- and "
-    "the symptom is a ClaimTimeoutError that blames the node's CPU."
-)
 
-for k in KEYS:
-    assert api[k] == worker[k], (
-        f"api and worker disagree on {k}:\n  api    = {api[k]}\n  worker = {worker[k]}\n"
-        "The API writes bundles and the worker reads them, so a difference here means "
-        "the write lands somewhere the read never looks."
+def env_for(container):
+    return {entry["name"]: entry for entry in container.get("env", [])}
+
+
+def object_store_envs(path):
+    api = worker = bundle_fetch = None
+    with open(path) as fh:
+        for doc in yaml.safe_load_all(fh):
+            if not doc:
+                continue
+            if doc.get("kind") == "Deployment":
+                name = doc["metadata"]["name"]
+                containers = doc["spec"]["template"]["spec"].get("containers", [])
+                assert containers, f"{name} Deployment has no containers"
+                if name.endswith("-api"):
+                    api = env_for(containers[0])
+                elif name.endswith("-worker"):
+                    worker = env_for(containers[0])
+            elif doc.get("kind") == "SandboxTemplate":
+                pod_spec = doc["spec"]["podTemplate"]["spec"]
+                matches = [
+                    container
+                    for container in pod_spec.get("initContainers", [])
+                    if container.get("name") == "bundle-fetch"
+                ]
+                assert len(matches) == 1, (
+                    "SandboxTemplate must render exactly one bundle-fetch init container"
+                )
+                bundle_fetch = env_for(matches[0])
+
+    assert api is not None, "api Deployment not rendered"
+    assert worker is not None, "worker Deployment not rendered"
+    assert bundle_fetch is not None, "SandboxTemplate bundle-fetch not rendered"
+    return api, worker, bundle_fetch
+
+
+def assert_contract(path, label, expected_endpoint):
+    api, worker, bundle_fetch = object_store_envs(path)
+
+    for service, env in (("api", api), ("worker", worker)):
+        missing = [key for key in KEYS if key not in env]
+        if service == "worker":
+            assert not missing, (
+                f"worker is missing {missing}. Its config defaults these to the compose stack "
+                "(http://localhost:29000), so every bundle fetch fails with ECONNREFUSED -- and "
+                "the symptom is a ClaimTimeoutError that blames the node's CPU."
+            )
+        else:
+            assert not missing, f"{service} is missing object-store keys: {missing}"
+
+    for key in KEYS:
+        assert api[key] == worker[key], (
+            f"api and worker disagree on {key}:\n  api    = {api[key]}\n  worker = {worker[key]}\n"
+            "The API writes bundles and the worker reads them, so a difference here means "
+            "the write lands somewhere the read never looks."
+        )
+
+    assert api["S3_ENDPOINT_URL"].get("value") == expected_endpoint, (
+        f"{label} API endpoint must be {expected_endpoint}, got {api['S3_ENDPOINT_URL']}"
+    )
+    assert worker["S3_ENDPOINT_URL"].get("value") == expected_endpoint, (
+        f"{label} worker endpoint must be {expected_endpoint}, got {worker['S3_ENDPOINT_URL']}"
+    )
+    assert bundle_fetch.get("S3_ENDPOINT", {}).get("value") == expected_endpoint, (
+        f"{label} bundle-fetch endpoint must be {expected_endpoint}, "
+        f"got {bundle_fetch.get('S3_ENDPOINT')}"
     )
 
-# The credential must be a reference, never inline: helm keeps its values in the
-# release Secret, so an inline password is readable in every retained revision.
-entry = worker["S3_SECRET_KEY"]
-ref = entry.get("valueFrom", {}).get("secretKeyRef")
-assert ref, "S3_SECRET_KEY must come from a secretKeyRef"
-assert "value" not in entry, "S3_SECRET_KEY must not be an inline value"
+    # The credential must be a reference, never inline: helm keeps its values in the
+    # release Secret, so an inline password is readable in every retained revision.
+    entry = worker["S3_SECRET_KEY"]
+    ref = entry.get("valueFrom", {}).get("secretKeyRef")
+    assert ref, "S3_SECRET_KEY must come from a secretKeyRef"
+    assert "value" not in entry, "S3_SECRET_KEY must not be an inline value"
 
-print(f"ok: api and worker agree on {', '.join(KEYS)}")
-print(f"ok: S3_SECRET_KEY is a ref -> {ref['name']}/{ref['key']}")
+    print(f"ok: {label}: api and worker agree on {', '.join(KEYS)}")
+    print(f"ok: {label}: all S3 endpoints are {expected_endpoint}")
+    print(f"ok: {label}: S3_SECRET_KEY is a ref -> {ref['name']}/{ref['key']}")
+
+
+arguments = sys.argv[1:]
+assert len(arguments) % 3 == 0, "expected path, label, endpoint triples"
+for index in range(0, len(arguments), 3):
+    assert_contract(*arguments[index:index + 3])
 PY

--- a/charts/curie/ci/worker-object-store-assertions.sh
+++ b/charts/curie/ci/worker-object-store-assertions.sh
@@ -1,113 +1,71 @@
 #!/usr/bin/env bash
 #
-# The API and the worker must agree about the object store.
+# The API WRITES each uploaded bundle to the object store and the worker READS it
+# back. If the two disagree about where that store is, the write succeeds, the
+# read fails, and the failure surfaces nowhere near its cause.
 #
-# The API WRITES each uploaded plugin bundle to the bundle bucket; the worker
-# READS it back to run a turn. If the two disagree -- or if either is simply
-# unset -- the write and the read address different stores and the bundle is
-# unfetchable.
+# This was a real outage. worker.yaml set none of the four variables, so the
+# worker fell back to its compose default (http://localhost:29000) and every
+# bundle fetch got ECONNREFUSED. Both symptoms pointed elsewhere:
 #
-# This shipped: worker.yaml set none of the four variables, so the worker fell
-# back to its compose defaults (`s3_endpoint_url` = http://localhost:29000) and
-# every bundle fetch in Kubernetes hit ECONNREFUSED.
+#   * every Slack turn died as ClaimTimeoutError after 90s, and that message
+#     names a CPU-saturated node first -- on an install idling at 11% CPU
+#   * the post-deploy eval silently stopped running with "unresolvable
+#     suite/bundle", which alerts nothing, because a suite that cannot resolve
+#     looks exactly like a suite nobody asked for
 #
-# It is asserted here rather than left to review because both symptoms point
-# somewhere else:
-#
-#   * `eval default @ <sha> failed: unresolvable suite/bundle` -- the
-#     post-deploy eval silently stops running. A suite that cannot resolve looks
-#     exactly like a suite nobody asked for, so nothing alerts and the gap can
-#     last for weeks.
-#   * every turn fails as `ClaimTimeoutError` after 90s, and that message names
-#     a CPU-saturated node as the most common cause. On the install where this
-#     was found the node was at 11% CPU with 4% pressure -- the error sent
-#     everyone looking at node size instead of at four missing env vars.
-#
-# A unit test cannot catch it: each Deployment is correct in isolation, and the
-# defect is only visible when the two are compared.
+# So this asserts AGREEMENT, not presence. Presence alone would still pass the
+# day someone points the worker at a different-but-populated endpoint.
 set -euo pipefail
 
 CHART=${CHART:-charts/curie}
-KEYS=(S3_ENDPOINT_URL S3_ACCESS_KEY S3_SECRET_KEY BUNDLE_BUCKET)
+RENDERED=$(mktemp); trap 'rm -f "$RENDERED"' EXIT
+helm template t "$CHART" > "$RENDERED"
 
-# Render to a FILE. Passing both a script heredoc and the rendered manifests on
-# stdin means two redirections on one command, and the second wins -- python
-# then tries to execute the YAML. That cost a debugging round here already.
-rendered=$(mktemp)
-trap 'rm -f "$rendered"' EXIT
-helm template t "$CHART" > "$rendered"
-
-python3 - "$rendered" "${KEYS[@]}" <<'PY'
+# The rendered manifests go via a FILE, not a second stdin redirect: with both
+# `<<'PY'` and `<<<"$out"` on one command the herestring wins and python reads
+# the chart instead of the script.
+python3 - "$RENDERED" <<'PY'
 import sys, yaml
 
-path, keys = sys.argv[1], sys.argv[2:]
-with open(path) as fh:
-    docs = list(yaml.safe_load_all(fh))
-
-def env_of(component):
-    """Select by the component LABEL, never by a name suffix.
-
-    `endswith("-worker")` also matches `<release>-curie-langfuse-worker`, which
-    renders earlier and legitimately has no object-store env -- so a suffix
-    match silently inspected Langfuse and reported the curie worker as
-    misconfigured while the chart was correct. The label is unambiguous.
-    """
-
-    for d in docs:
-        if not d or d.get("kind") != "Deployment":
+api = worker = None
+with open(sys.argv[1]) as fh:
+    for doc in yaml.safe_load_all(fh):
+        if not doc or doc.get("kind") != "Deployment":
             continue
-        if d["metadata"].get("labels", {}).get("app.kubernetes.io/component") != component:
-            continue
-        c = d["spec"]["template"]["spec"]["containers"][0]
-        return {e["name"]: e for e in c.get("env", [])}
-    return None
+        name = doc["metadata"]["name"]
+        env = {e["name"]: e for e in doc["spec"]["template"]["spec"]["containers"][0].get("env", [])}
+        if name.endswith("-api"):
+            api = env
+        elif name.endswith("-worker"):
+            worker = env
 
-api = env_of("api")
-worker = env_of("worker")
-assert api is not None, "no API Deployment rendered"
-assert worker is not None, "no worker Deployment rendered"
+assert api is not None, "api Deployment not rendered"
+assert worker is not None, "worker Deployment not rendered"
 
-failures = []
+KEYS = ("S3_ENDPOINT_URL", "S3_ACCESS_KEY", "S3_SECRET_KEY", "BUNDLE_BUCKET")
 
-for k in keys:
-    if k not in worker:
-        failures.append(f"worker is missing {k} -- it will fall back to the compose default")
-    if k not in api:
-        failures.append(f"api is missing {k}")
+missing = [k for k in KEYS if k not in worker]
+assert not missing, (
+    f"worker is missing {missing}. Its config defaults these to the compose stack "
+    "(http://localhost:29000), so every bundle fetch fails with ECONNREFUSED -- and "
+    "the symptom is a ClaimTimeoutError that blames the node's CPU."
+)
 
-# Equality, not merely presence. Two different-but-present endpoints is the
-# subtler version of the same bug and would pass a presence-only check.
-for k in keys:
-    if k in api and k in worker and api[k] != worker[k]:
-        failures.append(
-            f"api and worker disagree on {k}:\n"
-            f"    api    = {api[k]}\n"
-            f"    worker = {worker[k]}"
-        )
+for k in KEYS:
+    assert api[k] == worker[k], (
+        f"api and worker disagree on {k}:\n  api    = {api[k]}\n  worker = {worker[k]}\n"
+        "The API writes bundles and the worker reads them, so a difference here means "
+        "the write lands somewhere the read never looks."
+    )
 
-# The compose default must never be what a Kubernetes pod receives.
-ep = worker.get("S3_ENDPOINT_URL", {}).get("value", "")
-if "localhost" in ep or "127.0.0.1" in ep:
-    failures.append(f"worker S3_ENDPOINT_URL points at the pod itself: {ep!r}")
+# The credential must be a reference, never inline: helm keeps its values in the
+# release Secret, so an inline password is readable in every retained revision.
+entry = worker["S3_SECRET_KEY"]
+ref = entry.get("valueFrom", {}).get("secretKeyRef")
+assert ref, "S3_SECRET_KEY must come from a secretKeyRef"
+assert "value" not in entry, "S3_SECRET_KEY must not be an inline value"
 
-# The credential belongs in a secretKeyRef, never inline in the pod spec, where
-# `kubectl get deploy -o yaml` would print it to anyone who can read Deployments.
-sk = worker.get("S3_SECRET_KEY", {})
-if "value" in sk:
-    failures.append("worker S3_SECRET_KEY is an inline value; it must be a secretKeyRef")
-elif not sk.get("valueFrom", {}).get("secretKeyRef"):
-    failures.append("worker S3_SECRET_KEY has no secretKeyRef")
-
-if failures:
-    print("FAIL: api/worker object-store configuration diverges\n")
-    for f in failures:
-        print("  - " + f)
-    raise SystemExit(1)
-
-print("api and worker agree on all four object-store variables:")
-for k in keys:
-    shown = api[k].get("value") or "<secretKeyRef " + \
-        api[k]["valueFrom"]["secretKeyRef"]["name"] + "/" + \
-        api[k]["valueFrom"]["secretKeyRef"]["key"] + ">"
-    print(f"  {k:18} = {shown}")
+print(f"ok: api and worker agree on {', '.join(KEYS)}")
+print(f"ok: S3_SECRET_KEY is a ref -> {ref['name']}/{ref['key']}")
 PY

--- a/charts/curie/ci/worker-ttl-bounds-assertions.sh
+++ b/charts/curie/ci/worker-ttl-bounds-assertions.sh
@@ -57,7 +57,7 @@
 # JSON-Schema validator, whose wording changed between the CI-pinned helm and
 # current helm while the pass/fail outcomes stayed identical:
 #
-#   helm 3.16.4 (the CI pin, .github/workflows/helm-ci.yaml:41):
+#   helm 3.16.4 (the CI pin, .github/workflows/helm-ci.yaml:40):
 #     - worker.routeTtlSeconds: Must be greater than 0
 #     - worker.routeTtlSeconds: Invalid type. Expected: integer, given: string
 #   helm 3.20.0:

--- a/charts/curie/templates/_helpers.tpl
+++ b/charts/curie/templates/_helpers.tpl
@@ -101,6 +101,18 @@ ANTHROPIC_BASE_URL ANTHROPIC_API_KEY CLAUDE_CODE_OAUTH_TOKEN ANTHROPIC_AUTH_TOKE
 {{- end -}}
 {{- end -}}
 
+{{- define "curie.rustfs.scheme" -}}
+{{- if and (not .Values.rustfs.deploy) (eq (printf "%v" .Values.rustfs.port) "443") -}}
+https
+{{- else -}}
+http
+{{- end -}}
+{{- end -}}
+
+{{- define "curie.rustfs.endpoint" -}}
+{{- include "curie.rustfs.scheme" . }}://{{ include "curie.rustfs.host" . }}:{{ .Values.rustfs.port }}
+{{- end -}}
+
 {{- define "curie.langfuse.webHost" -}}
 {{- printf "%s-langfuse-web" (include "curie.fullname" .) -}}
 {{- end -}}

--- a/charts/curie/templates/_helpers.tpl
+++ b/charts/curie/templates/_helpers.tpl
@@ -177,6 +177,42 @@ http
 {{- end -}}
 {{- end -}}
 
+{{- define "curie.otelCollector.config" -}}
+# Receives OTLP over gRPC (4317) and HTTP (4318) from app services and
+# forwards to Langfuse over HTTP. Langfuse OTLP ingest is HTTP-only (gRPC is
+# silently unsupported), so the collector is the adapter. Langfuse appends
+# /v1/traces to the otlphttp base path itself.
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+processors:
+  batch: {}
+exporters:
+  otlphttp/langfuse:
+    endpoint: http://{{ include "curie.langfuse.webHost" . }}:{{ .Values.langfuse.web.service.port }}/api/public/otel
+    headers:
+      Authorization: ${env:LANGFUSE_OTLP_AUTH_HEADER}
+  debug:
+    verbosity: normal
+extensions:
+  health_check:
+    endpoint: 0.0.0.0:13133
+service:
+  extensions: [health_check]
+  telemetry:
+    metrics:
+      level: none
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlphttp/langfuse, debug]
+{{- end }}
+
 {{/* ---- Default-credential gate (issue #198) ----
      When security.checkDefaultCredentials is on, refuse to render if a Langfuse
      bootstrap identity still carries the published dev default from values.yaml.

--- a/charts/curie/templates/_helpers.tpl
+++ b/charts/curie/templates/_helpers.tpl
@@ -93,6 +93,55 @@ ANTHROPIC_BASE_URL ANTHROPIC_API_KEY CLAUDE_CODE_OAUTH_TOKEN ANTHROPIC_AUTH_TOKE
 {{- end -}}
 {{- end -}}
 
+{{- define "curie.clickhouse.loggingConfig" -}}
+<clickhouse>
+  <logger>
+    <level>{{ .Values.clickhouse.logLevel }}</level>
+    <!-- Also to stdout, so `kubectl logs` works. The image logs only to
+         files under /var/log/clickhouse-server/, which in Kubernetes means
+         the diagnostics live inside the container and die with the pod,
+         exactly when you most want them. Cheap at `warning`. -->
+    <console>1</console>
+  </logger>
+  <!-- text_log is KEPT, and level-filtered rather than removed.
+       The image ships <text_log><level>trace</level></text_log>, and that
+       `level` is the whole problem: an hour of it produced 253,727 Debug
+       and 58,186 Trace rows against 15 Information. Filtering to
+       `{{ .Values.clickhouse.logLevel }}` drops the volume by ~4 orders of
+       magnitude while keeping the table queryable, and a queryable
+       text_log is precisely what diagnosed the incident this fixes. It also
+       outlives the pod, which the log file does not. -->
+  <text_log>
+    <level>{{ .Values.clickhouse.logLevel }}</level>
+    <ttl>event_date + INTERVAL {{ .Values.clickhouse.systemLogs.retentionDays }} DAY DELETE</ttl>
+  </text_log>
+{{- if .Values.clickhouse.systemLogs.enabled }}
+  <!-- Profiling and per-second resource sampling, on but TTL-bounded. -->
+  <trace_log><ttl>event_date + INTERVAL {{ .Values.clickhouse.systemLogs.retentionDays }} DAY DELETE</ttl></trace_log>
+  <metric_log><ttl>event_date + INTERVAL {{ .Values.clickhouse.systemLogs.retentionDays }} DAY DELETE</ttl></metric_log>
+  <asynchronous_metric_log><ttl>event_date + INTERVAL {{ .Values.clickhouse.systemLogs.retentionDays }} DAY DELETE</ttl></asynchronous_metric_log>
+{{- else }}
+  <!-- Removed. Unlike text_log these have no level filter; they sample on
+       a timer regardless of whether anything is happening, so the only
+       lever is on/off. metric_log was the table whose merge wedged and
+       started the spiral. Prometheus and node metrics already cover what
+       they measure, from outside the process that is failing. -->
+  <trace_log remove="1"/>
+  <metric_log remove="1"/>
+  <asynchronous_metric_log remove="1"/>
+{{- end }}
+  <!-- Kept regardless: low volume, useful when ClickHouse itself
+       misbehaves. TTL'd so none can become the next text_log.
+       processors_profile_log is here because a live boot showed the image
+       creates it too. It is easy to miss precisely because it is small
+       today, which is what text_log also was once. -->
+  <query_log><ttl>event_date + INTERVAL {{ .Values.clickhouse.systemLogs.retentionDays }} DAY DELETE</ttl></query_log>
+  <part_log><ttl>event_date + INTERVAL {{ .Values.clickhouse.systemLogs.retentionDays }} DAY DELETE</ttl></part_log>
+  <error_log><ttl>event_date + INTERVAL {{ .Values.clickhouse.systemLogs.retentionDays }} DAY DELETE</ttl></error_log>
+  <processors_profile_log><ttl>event_date + INTERVAL {{ .Values.clickhouse.systemLogs.retentionDays }} DAY DELETE</ttl></processors_profile_log>
+</clickhouse>
+{{- end }}
+
 {{- define "curie.rustfs.host" -}}
 {{- if .Values.rustfs.deploy -}}
 {{- printf "%s-rustfs" (include "curie.fullname" .) -}}

--- a/charts/curie/templates/agent-sandbox.yaml
+++ b/charts/curie/templates/agent-sandbox.yaml
@@ -288,7 +288,7 @@ spec:
             - name: CURIE_BUNDLE_REF
               value: ""
             - name: S3_ENDPOINT
-              value: http://{{ include "curie.rustfs.host" . }}:{{ .Values.rustfs.port }}
+              value: {{ include "curie.rustfs.endpoint" . }}
             - name: S3_ACCESS_KEY
               value: {{ .Values.rustfs.auth.accessKey | quote }}
             - name: S3_SECRET_KEY

--- a/charts/curie/templates/api.yaml
+++ b/charts/curie/templates/api.yaml
@@ -129,7 +129,7 @@ spec:
                   name: {{ .Values.langfuse.existingSecret | default (include "curie.secretName" .) }}
                   key: langfuseInitProjectSecretKey
             - name: S3_ENDPOINT_URL
-              value: http://{{ include "curie.rustfs.host" . }}:{{ .Values.rustfs.port }}
+              value: {{ include "curie.rustfs.endpoint" . }}
             - name: S3_ACCESS_KEY
               value: {{ .Values.rustfs.auth.accessKey | quote }}
             - name: S3_SECRET_KEY

--- a/charts/curie/templates/clickhouse.yaml
+++ b/charts/curie/templates/clickhouse.yaml
@@ -17,52 +17,7 @@ data:
   # into an infinite retry. See the clickhouse block in values.yaml for the
   # measured numbers.
   curie-logging.xml: |
-    <clickhouse>
-      <logger>
-        <level>{{ .Values.clickhouse.logLevel }}</level>
-        <!-- Also to stdout, so `kubectl logs` works. The image logs only to
-             files under /var/log/clickhouse-server/, which in Kubernetes means
-             the diagnostics live inside the container and die with the pod,
-             exactly when you most want them. Cheap at `warning`. -->
-        <console>1</console>
-      </logger>
-      <!-- text_log is KEPT, and level-filtered rather than removed.
-           The image ships <text_log><level>trace</level></text_log>, and that
-           `level` is the whole problem: an hour of it produced 253,727 Debug
-           and 58,186 Trace rows against 15 Information. Filtering to
-           `{{ .Values.clickhouse.logLevel }}` drops the volume by ~4 orders of
-           magnitude while keeping the table queryable, and a queryable
-           text_log is precisely what diagnosed the incident this fixes. It also
-           outlives the pod, which the log file does not. -->
-      <text_log>
-        <level>{{ .Values.clickhouse.logLevel }}</level>
-        <ttl>event_date + INTERVAL {{ .Values.clickhouse.systemLogs.retentionDays }} DAY DELETE</ttl>
-      </text_log>
-    {{- if .Values.clickhouse.systemLogs.enabled }}
-      <!-- Profiling and per-second resource sampling, on but TTL-bounded. -->
-      <trace_log><ttl>event_date + INTERVAL {{ .Values.clickhouse.systemLogs.retentionDays }} DAY DELETE</ttl></trace_log>
-      <metric_log><ttl>event_date + INTERVAL {{ .Values.clickhouse.systemLogs.retentionDays }} DAY DELETE</ttl></metric_log>
-      <asynchronous_metric_log><ttl>event_date + INTERVAL {{ .Values.clickhouse.systemLogs.retentionDays }} DAY DELETE</ttl></asynchronous_metric_log>
-    {{- else }}
-      <!-- Removed. Unlike text_log these have no level filter; they sample on
-           a timer regardless of whether anything is happening, so the only
-           lever is on/off. metric_log was the table whose merge wedged and
-           started the spiral. Prometheus and node metrics already cover what
-           they measure, from outside the process that is failing. -->
-      <trace_log remove="1"/>
-      <metric_log remove="1"/>
-      <asynchronous_metric_log remove="1"/>
-    {{- end }}
-      <!-- Kept regardless: low volume, useful when ClickHouse itself
-           misbehaves. TTL'd so none can become the next text_log.
-           processors_profile_log is here because a live boot showed the image
-           creates it too. It is easy to miss precisely because it is small
-           today, which is what text_log also was once. -->
-      <query_log><ttl>event_date + INTERVAL {{ .Values.clickhouse.systemLogs.retentionDays }} DAY DELETE</ttl></query_log>
-      <part_log><ttl>event_date + INTERVAL {{ .Values.clickhouse.systemLogs.retentionDays }} DAY DELETE</ttl></part_log>
-      <error_log><ttl>event_date + INTERVAL {{ .Values.clickhouse.systemLogs.retentionDays }} DAY DELETE</ttl></error_log>
-      <processors_profile_log><ttl>event_date + INTERVAL {{ .Values.clickhouse.systemLogs.retentionDays }} DAY DELETE</ttl></processors_profile_log>
-    </clickhouse>
+{{ include "curie.clickhouse.loggingConfig" . | indent 4 }}
 ---
 apiVersion: v1
 kind: Service
@@ -97,11 +52,11 @@ spec:
   template:
     metadata:
       annotations:
-        # Roll the pod when the logging overlay changes. Without this a
-        # `logLevel` or `systemLogs` edit renders a new ConfigMap and the
+        # Roll the pod when the rendered logging overlay changes. Without this a
+        # ConfigMap edit renders a new ConfigMap and the
         # running server keeps the old config until something else restarts it
         # -- i.e. the fix would appear applied while the node kept starving.
-        checksum/config: {{ printf "%s|%v|%v" .Values.clickhouse.logLevel .Values.clickhouse.systemLogs.enabled .Values.clickhouse.systemLogs.retentionDays | sha256sum }}
+        checksum/config: {{ include "curie.clickhouse.loggingConfig" . | sha256sum }}
       labels:
         {{- include "curie.labels" . | nindent 8 }}
         {{- include "curie.selectorLabels" (dict "root" . "component" "clickhouse") | nindent 8 }}

--- a/charts/curie/templates/otel-collector.yaml
+++ b/charts/curie/templates/otel-collector.yaml
@@ -7,39 +7,7 @@ metadata:
     {{- include "curie.labels" . | nindent 4 }}
 data:
   collector-config.yaml: |
-    # Receives OTLP over gRPC (4317) and HTTP (4318) from app services and
-    # forwards to Langfuse over HTTP. Langfuse OTLP ingest is HTTP-only (gRPC is
-    # silently unsupported), so the collector is the adapter. Langfuse appends
-    # /v1/traces to the otlphttp base path itself.
-    receivers:
-      otlp:
-        protocols:
-          grpc:
-            endpoint: 0.0.0.0:4317
-          http:
-            endpoint: 0.0.0.0:4318
-    processors:
-      batch: {}
-    exporters:
-      otlphttp/langfuse:
-        endpoint: http://{{ include "curie.langfuse.webHost" . }}:{{ .Values.langfuse.web.service.port }}/api/public/otel
-        headers:
-          Authorization: ${env:LANGFUSE_OTLP_AUTH_HEADER}
-      debug:
-        verbosity: normal
-    extensions:
-      health_check:
-        endpoint: 0.0.0.0:13133
-    service:
-      extensions: [health_check]
-      telemetry:
-        metrics:
-          level: none
-      pipelines:
-        traces:
-          receivers: [otlp]
-          processors: [batch]
-          exporters: [otlphttp/langfuse, debug]
+{{ include "curie.otelCollector.config" . | indent 4 }}
 ---
 apiVersion: v1
 kind: Service
@@ -72,7 +40,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: {{ printf "%s|%s" (include "curie.langfuse.webHost" .) (include "curie.otlpAuthHeader" .) | sha256sum }}
+        checksum/config: {{ printf "%s|%s" (include "curie.otelCollector.config" .) (include "curie.otlpAuthHeader" .) | sha256sum }}
       labels:
         {{- include "curie.labels" . | nindent 8 }}
         {{- include "curie.selectorLabels" (dict "root" . "component" "otel-collector") | nindent 8 }}

--- a/charts/curie/templates/worker.yaml
+++ b/charts/curie/templates/worker.yaml
@@ -242,7 +242,7 @@ spec:
             # bundle to this bucket and the worker READS it back, so they have to
             # agree. ci/worker-object-store-assertions.sh asserts they do.
             - name: S3_ENDPOINT_URL
-              value: http://{{ include "curie.rustfs.host" . }}:{{ .Values.rustfs.port }}
+              value: {{ include "curie.rustfs.endpoint" . }}
             - name: S3_ACCESS_KEY
               value: {{ .Values.rustfs.auth.accessKey | quote }}
             - name: S3_SECRET_KEY

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -392,6 +392,7 @@ rustfs:
   deploy: true
   image: rustfs/rustfs:1.0.0-beta.12
   awsCliImage: amazon/aws-cli:2.32.6
+  # For the API, worker, and sandbox bundle fetch endpoints, an external RustFS on port 443 uses HTTPS. All other configurations use HTTP.
   host: ""
   port: 9000
   consolePort: 9001

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -749,7 +749,7 @@ dependencies = [
 
 [[package]]
 name = "curie"
-version = "0.7.0-rc.3"
+version = "0.7.0-rc.4"
 dependencies = [
  "anstream",
  "anstyle",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "curie"
-version = "0.7.0-rc.3"
+version = "0.7.0-rc.4"
 edition = "2021"
 description = "Curie CLI: init/start/send/eval a plugin against a local runner (task I1)"
 

--- a/cli/src/installation.rs
+++ b/cli/src/installation.rs
@@ -807,8 +807,8 @@ enum GuardVerdict {
     /// Nothing the release runs would be deleted by this apply.
     Clear,
     /// This apply would delete stateful component(s), carrying the operator
-    /// facing refusal text.
-    WouldRemove(String),
+    /// facing causes.
+    WouldRemove(Vec<crate::ops::StatefulRemoval>),
 }
 
 /// Decide whether an apply would delete a stateful component the release runs.
@@ -839,9 +839,7 @@ async fn guard_stateful_removal(up: &crate::ops::UpOpts) -> Result<GuardVerdict>
     if removed.is_empty() {
         return Ok(GuardVerdict::Clear);
     }
-    Ok(GuardVerdict::WouldRemove(stateful_removal_message(
-        &removed,
-    )))
+    Ok(GuardVerdict::WouldRemove(removed))
 }
 
 /// The refusal text, factored out so its ordering is testable with no cluster.
@@ -900,12 +898,20 @@ fn stateful_removal_message(removed: &[crate::ops::StatefulRemoval]) -> String {
         .iter()
         .any(|r| r.cause == RemovalCause::ComponentGone)
     {
-        msg.push_str(
-            "Component(s) the chart does not render at all usually mean a chart version \
-             renamed or removed them. Re-run with --migrate-store and apply will carry \
-             the data across itself: it stages every object, upgrades, loads them back, \
-             and verifies per object.\n\n",
-        );
+        if renamed.is_empty() {
+            msg.push_str(
+                "Component(s) the chart does not render at all usually mean a chart version \
+                 renamed or removed them. Re-run with --migrate-store and apply will carry \
+                 the data across itself: it stages every object, upgrades, loads them back, \
+                 and verifies per object.\n\n",
+            );
+        } else {
+            msg.push_str(
+                "After fixing the renames, re-run with --migrate-store and apply will carry \
+                 the data across itself: it stages every object, upgrades, loads them back, \
+                 and verifies per object.\n\n",
+            );
+        }
     }
 
     msg.push_str("Use --allow-stateful-removal only to proceed WITHOUT the data.");
@@ -983,8 +989,17 @@ pub async fn apply(opts: ApplyOpts) -> Result<ApplyOutput> {
     } else {
         match guard_stateful_removal(&up).await? {
             GuardVerdict::Clear => false,
-            GuardVerdict::WouldRemove(_) if migrate_store => true,
-            GuardVerdict::WouldRemove(msg) => bail!("{msg}"),
+            GuardVerdict::WouldRemove(removed)
+                if migrate_store
+                    && removed.iter().all(|removal| {
+                        matches!(&removal.cause, crate::ops::RemovalCause::ComponentGone)
+                    }) =>
+            {
+                true
+            }
+            GuardVerdict::WouldRemove(removed) => {
+                bail!("{}", stateful_removal_message(&removed))
+            }
         }
     };
 
@@ -1570,13 +1585,16 @@ mod stateful_guard_message_tests {
                 cause: crate::ops::RemovalCause::RenamedTo("acme-bot-curie-postgres".to_string()),
             },
         ]);
-        assert!(msg.contains("nameOverride"), "{msg}");
-        assert!(msg.contains("--migrate-store"), "{msg}");
+        let rename = msg.find("nameOverride").unwrap();
+        let migrate = msg.find("--migrate-store").unwrap();
         let discard = msg.find("--allow-stateful-removal").unwrap();
         assert!(
-            msg.find("--migrate-store").unwrap() < discard
-                && msg.find("nameOverride").unwrap() < discard,
-            "the data-preserving remedies must still come before the discard flag:\n{msg}"
+            rename < migrate && migrate < discard,
+            "the rename fix must come before migration, and both must come before the discard flag:\n{msg}"
+        );
+        assert!(
+            msg.contains("After fixing the renames, re-run with --migrate-store"),
+            "the migration guidance must make the rename prerequisite explicit:\n{msg}"
         );
     }
 }

--- a/cli/tests/installation_plan_parity.rs
+++ b/cli/tests/installation_plan_parity.rs
@@ -103,6 +103,46 @@ if [ "$1" = get ] && [ "$2" = values ]; then
     exit 0
 fi
 if [ "$1" = template ]; then
+    if [ "${CURIE_TEST_HELM_MIXED_STATEFULSETS:-}" = 1 ]; then
+        cat <<'YAML'
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: parity-rustfs
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: rustfs
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: parity-curie-postgres
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: postgres
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: parity-curie-valkey
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: valkey
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: parity-curie-clickhouse
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: clickhouse
+YAML
+        exit 0
+    fi
     cat <<'YAML'
 apiVersion: apps/v1
 kind: StatefulSet
@@ -245,6 +285,7 @@ exit 0
             .env_remove("CURIE_TEST_KUBECTL_STS")
             .env_remove("CURIE_TEST_KUBECTL_FAIL")
             .env_remove("CURIE_TEST_KUBECTL_FORBIDDEN")
+            .env_remove("CURIE_TEST_HELM_MIXED_STATEFULSETS")
             .env_remove("CURIE_MODEL")
             .env_remove("CURIE_TEST_PROVIDER_EGRESS_JSON")
             .env_remove("CURIE_APPLY_TEST_MODEL_KEY")
@@ -460,6 +501,32 @@ fn live_minio_statefulset() -> String {
             "metadata": {"name": "parity-minio"},
             "spec": {"selector": {"matchLabels": {"app.kubernetes.io/component": "minio"}}}
         }]
+    })
+    .to_string()
+}
+
+fn live_mixed_store_statefulsets() -> String {
+    json!({
+        "apiVersion": "v1",
+        "kind": "List",
+        "items": [
+            {
+                "metadata": {"name": "parity-minio"},
+                "spec": {"selector": {"matchLabels": {"app.kubernetes.io/component": "minio"}}}
+            },
+            {
+                "metadata": {"name": "parity-postgres"},
+                "spec": {"selector": {"matchLabels": {"app.kubernetes.io/component": "postgres"}}}
+            },
+            {
+                "metadata": {"name": "parity-valkey"},
+                "spec": {"selector": {"matchLabels": {"app.kubernetes.io/component": "valkey"}}}
+            },
+            {
+                "metadata": {"name": "parity-clickhouse"},
+                "spec": {"selector": {"matchLabels": {"app.kubernetes.io/component": "clickhouse"}}}
+            }
+        ]
     })
     .to_string()
 }
@@ -717,6 +784,42 @@ fn migrate_store_alone_still_migrates() {
     assert!(
         calls.contains("KUBECTL_CALL: delete pod"),
         "a verified migration releases the staging pod:\n{calls}"
+    );
+}
+
+#[test]
+fn migrate_store_refuses_a_mixed_removed_and_renamed_batch() {
+    let fixture = HelmFixture::new(installation_for_the_stateful_guard(), None);
+    let live_statefulsets = live_mixed_store_statefulsets();
+
+    let output = fixture.apply(
+        &["--migrate-store"],
+        &[
+            ("CURIE_TEST_HELM_MIXED_STATEFULSETS", "1"),
+            ("CURIE_TEST_KUBECTL_STS", &live_statefulsets),
+        ],
+    );
+
+    let calls = fixture.calls();
+    let error = json_error(output, "apply --migrate-store");
+    let message = error["error"].as_str().expect("apply error message string");
+    assert!(
+        message.contains("nameOverride"),
+        "a renamed StatefulSet must direct the operator to nameOverride:\n{message}"
+    );
+    assert!(
+        message.contains("parity-minio")
+            && message.contains("parity-postgres")
+            && message.contains("parity-curie-postgres"),
+        "the refusal must include the removed store and renamed StatefulSet:\n{message}"
+    );
+    assert!(
+        !calls.contains("KUBECTL_CALL: run "),
+        "a mixed batch must stop before the migration export:\n{calls}"
+    );
+    assert!(
+        !calls.contains("HELM_CALL: upgrade"),
+        "a mixed batch must stop before the upgrade:\n{calls}"
     );
 }
 

--- a/docs/adr/0085-acceptance-not-implementation-authorizes-an-adr.md
+++ b/docs/adr/0085-acceptance-not-implementation-authorizes-an-adr.md
@@ -4,6 +4,12 @@ Date: 2026-07-29
 
 Status: Accepted
 
+**Amended by [ADR-0102](0102-accepted-alongside-implementation-with-explicit-approval.md)**
+(back link added under [ADR-0045](0045-the-status-line-is-the-mutable-part-of-an-immutable-adr.md)):
+the third Decision clause is overtaken. An ADR may be Accepted alongside its
+implementation only with explicit maintainer approval and a named code path
+that realizes the decision. The remaining acceptance and history rules stand.
+
 **Amends [ADR 0045](0045-the-status-line-is-the-mutable-part-of-an-immutable-adr.md).**
 This ADR replaces only these two clauses in ADR 0045:
 

--- a/docs/adr/0096-port-adapters-are-deployed-services.md
+++ b/docs/adr/0096-port-adapters-are-deployed-services.md
@@ -1,0 +1,354 @@
+# 96. A third-party port adapter is a deployed service, not a loaded plugin
+
+Date: 2026-08-04
+
+Status: Draft
+
+Generalizes the harness trio to every port.
+[ADR-0060](0060-the-harness-is-a-declared-package.md) decides what a harness is
+(a declared package), [ADR-0061](0061-out-of-process-harness-boundary.md)
+decides where its boundary sits (a process, not a Protocol), and
+[ADR-0062](0062-harness-conformance-has-teeth.md) decides how we find out
+whether one works. Those three answer the question for one seam. ADR-0061 and
+ADR-0062 are both still Drafts, and 0061 is gated on a spike by its own decision
+5, so nothing here waits on either being accepted: decisions 2 and 3 below stand
+on the shipped composition precedents in Context, and if 0061 and 0062 land they
+extend the same pattern to the harness port. This ADR answers that same question
+for the rest: how a third party plugs its own implementation into any
+of the swappable seams in [the interface catalog](../interfaces.md). It inherits
+the trust rule from [ADR-0040](0040-adopt-acp-as-an-edge-projection.md) decision
+4 and leaves the frozen contracts of
+[ADR-0036](0036-aci-semver-and-reader-policy.md) untouched.
+
+## Context
+
+Two concrete asks motivate this. A company running an internal Slack-alike wants
+Curie's whole surface (mentions in, streamed replies out, approval cards, hub
+buttons) to run on their tool instead of Slack. A second wants a specialized
+email surface. Neither is asking to change the kernel. Both are asking the same
+question: **where do I put my code so the platform uses it instead of the
+default?** Today the repo has no general answer, and the partial answers it does
+have point in two different directions.
+
+**The only plugin mechanism in the codebase is the harness registry.** A harness
+registers a Python entry point in the group `"curie.harness"`
+(`runner/src/curie_runner/harness/registry.py:58`), and the built-in Claude
+harness registers itself the same way
+(`runner/pyproject.toml:16-17`). The guards are real and fail closed: a flat
+package path is refused, a built-in name claimed under any other path is
+refused, and both post-load key rules run against what the loaded contribution
+actually claims (`runner/src/curie_runner/harness/registry.py:105-192`).
+Selection is an env read defaulting to the built-in
+(`runner/src/curie_runner/config.py:122-124`), and a built-in name never goes
+through discovery at all, so a malformed or import-crashing sibling entry point
+cannot take the Claude harness down
+(`runner/src/curie_runner/__main__.py:58-84`, issue #865).
+
+**No other subsystem works this way.** Nothing else in the repo uses entry
+points, imports a module named in config, or keeps a registry. The other ports
+are Protocol classes with exactly one implementation, or collaborators the
+caller supplies: the `ObjectStore` port, the queue broker, the eval scorers, and
+the `ApproverSet` port behind one authorizer. That is the standing restraint of
+[architecture-vision.md](../architecture-vision.md) working as intended: the
+second implementation teaches the interface, so no adapter layer is written
+ahead of a real second implementation.
+
+**Agent bundles look like the obvious plugin vehicle and are deliberately not
+one.** `packages/plugin-format/README.md:1-5` states the reason: the bundle is
+the Claude Code plugin shape verbatim, compatibility is the distribution wedge,
+and "this package does not invent format extensions." A bundle also runs in the
+wrong place for platform code. It is delivered into the sandbox as
+`CURIE_PLUGIN_DIR` and carries agent content: skills, MCP servers, hooks,
+per-agent triggers, secrets, and approval policy.
+
+**Everywhere a second implementation actually exists, the swap is composition,
+not code loading.** ADR-0061 chose an HTTP process boundary for the harness
+rather than an in-process Protocol. The substrate is chosen by
+`CURIE_SANDBOX_SUBSTRATE` over a `SandboxClient` Protocol with two real
+implementations (`apps/worker/src/curie_worker/run.py:96-111`). The vendored
+agent-sandbox controller can be turned off for a BYO one
+(`charts/curie/templates/preflight-controller.yaml:1-16`). Multi-model routing
+is an optional sidecar serving the Anthropic wire shape on localhost, with the
+runner's base URL repointed at it (`charts/curie/values.yaml:941-957`). Every
+backing store follows one toggle-plus-BYO idiom (`charts/curie/CLAUDE.md:14-19`),
+and every service image is independently repointable in the chart. The channel
+seam already has a second implementation on exactly this pattern: a turn's
+`ReplyHandle.endpoint` routes that turn's reply back to the ingress that
+enqueued it (`packages/aci-protocol/src/aci_protocol/turn.py:31-51`, issue #19),
+which is what lets the CLI's no-Slack stub and a real Slack workspace coexist on
+one worker.
+
+**The channel seam is where the demand is, and it is the catalog's weakest.**
+Ingress is already channel-neutral: `QueuedTurn` carries `event_id`,
+`conversation_id`, `author`, `text`, `reply_handle`, and `received_at`
+(`packages/aci-protocol/src/aci_protocol/turn.py:54-68`, issue #7). Reply
+content is the adapter-neutral `OutboundMessage` with semantic interaction
+intents (`packages/channel-protocol/src/channel_protocol/models.py:76-88`), and
+two renderers already consume it (Slack Block Kit and the terminal). What is
+still Slack-shaped is delivery and binding. The egress model is edit-a-
+placeholder over `chat.update`
+(`apps/worker/src/curie_worker/slack_sink.py:1-7` and
+`apps/worker/src/curie_worker/slack_sink.py:57-75`), the deployment binding is a
+literal `slack_channel` column (`apps/api/src/curie_api/models.py:41-44`), and
+agent create and update validate Slack `C.../S.../U...` id shapes
+(`apps/api/src/curie_api/schemas.py:35-41` and
+`apps/api/src/curie_api/schemas.py:44-61`). The catalog grades this seam `C` and
+names the cheapest next step as a channel-neutral `ReplySink` post/update port.
+
+## Decision
+
+**1. There are two plugin kinds and they do not merge.** An **agent bundle**
+extends one agent: it is the Claude plugin shape verbatim, it runs inside the
+sandbox trust domain, and it versions with the agent. A **platform adapter**
+implements a platform port: it runs in the platform trust domain, holds
+platform-adjacent credentials, and versions with the deployment. A request to
+"plug in a new channel, store, or harness" is never answered by the bundle
+format. This is not a new restriction, it is the existing one stated once for
+all ports (`packages/plugin-format/README.md:1-5`).
+
+There is a third position, and it is already decided rather than invented here:
+a **connector** is bundle-declared, platform-hosted, and agent-scoped. Under
+[ADR-0086](0086-bundles-declare-connectors-the-platform-hosts-them.md) a bundle
+names an image and the platform runs it as a service outside the sandbox, and
+under [ADR-0037](0037-opt-in-binding-hook-and-pareto-model-routing.md) decision
+2 a manifest declares routing intent while the platform owns the adapter. So
+the split is not "the bundle format never grows a field the platform reads."
+It is narrower and sharper: **a bundle's files never execute as platform code**,
+while declaring an implementation for the platform to host is allowed, already
+shipped, and additive. Declaring intent is a bundle's job; being the platform's
+implementation is not.
+
+**2. The default shape of a third-party platform adapter is a deployed service
+speaking the port's versioned wire contract, selected by composition (chart
+values, compose, or endpoint config) rather than by runtime code loading.** Four
+reasons, in order of weight. It is **language-neutral**: an internal-tools team
+writes its Slack-alike adapter in whatever stack that tool already lives in,
+rather than being conscripted into Python. Its **blast radius is a process**: a
+crash, a hang, or a memory leak in third-party code is a failed dependency, not
+a wedged worker. It is **independently upgradable**: the adapter and the
+platform release on their own cadences behind a versioned wire. And it is
+**what the system already does** everywhere a second implementation exists, per
+the composition precedents in Context, so it adds no new operational concept.
+
+**3. A port is pluggable when its wire contract is published, versioned,
+drift-gated, and carries a conformance kit, not when a registry exists.** This
+generalizes ADR-0062: a registry proves an object was loaded, and a conformance
+kit proves the object behaves. The promotion path for a seam has three rungs.
+An `INTERFACE.md` documents where the code already draws the line. A contract
+package makes the line a schema, as `aci-protocol` and `channel-protocol`
+already do, which brings ADR-0017's tri-language drift gate and ADR-0036's
+reader policy with it. A conformance suite is then something a third party runs
+against its own adapter before it ever talks to us. Two rules bound every rung.
+The trust rule from ADR-0040 decision 4 applies verbatim: **an adapter is a
+rendering and transport contract, never a trust boundary.** Approvals resolve
+solely through the API authorizer, an adapter's report of who clicked is input
+rather than authority, and an adapter holds its own channel credentials and
+never the platform's model credentials. This ADR extends it in one direction
+0040 did not have to face, because it had one channel: **a reply endpoint never
+receives any credential other than its own**, so per-endpoint authentication is
+part of the egress contract a promoted port publishes, not an afterthought
+bolted on later. Today's code violates that rule, which is why it is written
+down. The worker delivers every per-turn reply through a single
+`AsyncWebClient(token=self._token, base_url=endpoint)`, so the same Slack bot
+token is presented to whatever endpoint the turn names
+(`apps/worker/src/curie_worker/slack_sink.py:152-175`), and the #530
+unreachable-endpoint fallback re-sends that reply's content to the default
+transport, real Slack, when the per-turn endpoint is down
+(`apps/worker/src/curie_worker/slack_sink.py:216-232`). Both behaviors are
+correct for a one-workspace install and wrong the moment a vendor endpoint
+coexists with real Slack: the vendor would be handed the platform's Slack token
+today, and an outage would leak a vendor turn's reply into Slack.
+
+The adapter-to-platform direction is bounded too. A third-party adapter's
+ingress path is the API's authenticated hook surface, ADR-0079's HMAC-verified
+`POST /hooks/{agent}/{hook}`, never direct broker enqueue: raw produce access
+can mint a turn for any agent and forge `author`, which bypasses exactly the
+dedupe and authentication the API ingress exists to provide. Direct enqueue
+stays a first-party-only path, and the CLI stub is first-party code. The
+interactivity return path is the mirror of it: approval clicks and button
+actions arriving through the vendor's own tool resolve through the API with a
+scoped, adapter-issued credential. Today the whole approvals router, resolve
+included, sits behind the single platform-wide key
+(`apps/api/src/curie_api/routers/approvals.py:35-36` and
+`apps/api/src/curie_api/routers/approvals.py:115`), and the scoped state token
+ADR-0033 minted for the sandbox is deliberately rejected everywhere but the
+state router (`apps/api/CLAUDE.md`). A scoped adapter credential in that same
+shape is therefore a prerequisite of a second channel adapter, not a follow-up
+to one. The scope rule from ADR-0060 decision 5
+applies too: a port whose contract cannot be stated is not promoted, and saying
+no does not require a spike.
+
+**4. In-process entry-point contributions are the exception, reserved for ports
+that cannot cross a process boundary.** Some hooks are latency- or
+transaction-coupled to a turn and would be absurd behind HTTP: ADR-0037's
+binding hook, which runs at task-to-sandbox claim time before the sandbox boots
+and returns a typed `BindingDecision`; approver-set membership on the approval
+path; eval scorers running inside a graded sweep. For these the mechanism is the
+harness registry generalized to per-port `curie.<port>` entry-point groups
+carrying the same fail-closed guard rules, including the built-in-resolved-by-
+direct-import rule that keeps a broken sibling from taking down a built-in
+(`runner/src/curie_runner/harness/registry.py:105-192`,
+`runner/src/curie_runner/__main__.py:58-84`). Those groups span service images
+rather than living in one: the binding hook loads in the worker
+(`apps/worker/src/curie_worker/binding.py`) while approver sets load in the API
+(`apps/api/src/curie_api/approvers.py`), so "install a package into the image"
+means a different image per port. The cost is the reason it is the
+exception: the contribution must be a Python package pip-installed into the
+service image, which means a derived image built on ours, per service, and
+rebuilt on every platform release (`runner/Dockerfile:65-74`). That is a
+documented pattern, not the third-party default.
+
+**5. No generic plugin framework is built now. Ports are promoted one at a time,
+on demand, and the channel port is first.** The second implementation teaches
+the interface, and fifteen of the eighteen catalog seams have exactly one
+implementation and no asking party. Promoting all of them now would produce the
+speculative adapter layers the vision doc forbids, shaped by guesses about
+second implementations that do not exist. The channel port is first because it
+is the only seam with two named third-party askers and the only one graded `C`.
+Its concrete lifts are follow-up issue material, not specified here: a
+channel-neutral egress port with post and update semantics replacing the
+Slack-only edit-in-place assumption (per-turn endpoint routing already exists);
+per-endpoint egress credentials, replacing the one-token-for-every-endpoint
+client decision 3 names; a scoped adapter credential for the interactivity
+return path, so approval resolution does not require the platform-wide key;
+a channel-neutral rename of the `slack_channel` binding surface and its
+validators; approval-card delivery through the neutral `OutboundMessage` path;
+assistant-thread status, which is `assistant_threads_setStatus` and Slack-only
+today with no neutral equivalent and no endpoint fallback
+(`apps/worker/src/curie_worker/slack_sink.py:404-423`); and trigger ingestion
+per [ADR-0079](0079-inbound-triggers-as-a-new-event-kind.md), whose
+`POST /hooks/{agent}/{hook}` is accepted but not yet built. Each lift owes an
+answer at every tier, the way ADR-0086 had to answer connector hosting for
+`skill` with *declared but not exercisable here* rather than a red result: a
+promoted channel port that only works on `cluster` fails the parity ladder.
+The CLI stub is
+promoted in status by this decision: it is the existing second channel
+implementation, and it becomes the reference adapter the conformance kit grows
+from.
+
+Worked example, so the shape is not abstract. A Slack-alike vendor ships **one
+container**. It runs an ingress that receives its own tool's events and turns
+each into a `QueuedTurn` whose `reply_handle.endpoint` points back at itself. It
+serves an egress endpoint at that address implementing the reply contract, so
+the worker delivers that turn's reply to the vendor rather than to Slack. Two
+caveats keep that honest. Enqueue-with-endpoint is how the first-party CLI stub
+works today; the third-party ingress path is the ADR-0079 hook, and that hook is
+accepted-but-unbuilt and carries no per-turn reply endpoint, so hook ingress
+plus reply-endpoint carriage is part of the trigger-ingestion lift rather than
+something a vendor can use now. And nothing binds the vendor's conversation to
+an agent except equality on `agents.slack_channel`
+(`apps/worker/src/curie_worker/binding.py:170` in the resolve SQL, run by
+`apps/worker/src/curie_worker/binding.py:258-264`), while the API's validators
+reject any id that is not Slack-shaped
+(`apps/api/src/curie_api/schemas.py:35` and
+`apps/api/src/curie_api/schemas.py:44-61`), so today the vendor has to mint
+Slack-shaped channel ids exactly as the CLI stub does. That is precisely what
+the binding-rename lift removes.
+
+The credential property is a destination property, not a description of today.
+The vendor's own channel credentials never leave its container, and it receives
+neither a platform model credential nor another channel's credentials. Decision
+3 names what stands in the way: the worker's single-token egress client is
+exactly the thing the promoted contract has to fix before this example is safe
+in a coexistence install.
+
+Hosting is the vendor's choice, because the contract is the wire and not the
+deployment. It can run the container itself and hand the operator a URL. When
+the operator would rather Curie ran it, the intended path is not a new
+mechanism: it is the connector-hosting substrate ADR-0086 already built, the
+derived Deployment and Service, the NetworkPolicy, the container hardening, and
+the sealed keys of [ADR-0094](0094-a-bundle-carries-its-own-sealed-connector-keys.md)
+(itself still Draft), used deployment-scoped instead of agent-scoped. That
+distinction is also the answer to "why is a channel adapter not just an MCP
+connector": a connector serves one agent's tools, while a platform adapter
+implements a port the whole install shares. Today the pragmatic egress compat
+surface is the small Slack Web API subset the CLI stub already proves, and the
+channel-neutral reply contract is the destination, not the starting point.
+
+## Alternatives considered and rejected
+
+- **Extend the agent bundle format with platform extensions.** The obvious move,
+  since bundles are already the thing users author and ship. Rejected on trust
+  domain and lifecycle, not on the format's purity. It is the wrong trust
+  domain: bundle content is delivered into the sandbox, while a channel adapter
+  sits on the ingress path holding channel credentials and feeding the binding
+  resolver. And it is the wrong lifecycle: a bundle versions per agent, while a
+  channel or a store is deployment-scoped and shared by every agent in the
+  install. The distribution wedge is a real constraint on the format
+  (`packages/plugin-format/README.md:1-5`) but it is not the argument here, and
+  claiming any platform-facing field is an invented extension would prove too
+  much: `connectors.yaml` and `deploy.yaml` are additive platform-facing
+  declarations that already shipped, and they are fine because they declare
+  intent rather than supply the platform's implementation.
+
+- **In-process dynamic loading as the general mechanism, that is, entry points
+  everywhere.** This is the harness registry generalized without the exception
+  clause of decision 4. Rejected because it forces every third party into
+  Python, which disqualifies the internal-tools team whose Slack-alike is a Go
+  or TypeScript service. It forces a derived service image and a rebuild on
+  every platform release (`runner/Dockerfile:65-74`). It puts third-party code
+  inside the worker kernel's process, where a crash or a hang is a wedged kernel
+  rather than a failed dependency. And it makes every adapter a supply-chain
+  dependency of the platform process. The guard rules mitigate name collisions,
+  not any of that. Retained only for the narrow ports decision 4 names.
+
+- **Build the universal registry and framework across all eighteen catalog
+  seams now.** Rejected as the exact failure the standing restraint exists to
+  prevent. Most seams have one implementation and no asking party, so a
+  framework would encode guesses about second implementations that do not exist
+  and would be wrong in the ways that matter. The vision doc names speculative
+  `StorageInterface` and `ChannelAdapter` layers as things we deliberately do
+  not write. The cost of promoting a port on demand is one port's contract work;
+  the cost of a wrong framework is paid by every port that has to fit it.
+
+- **A bespoke RPC plugin protocol, in the style of HashiCorp's go-plugin.** Real
+  prior art, and it does solve process isolation and language neutrality.
+  Rejected because it buys those two properties at the price of a new runtime,
+  a handshake, a codegen toolchain, and a second wire vocabulary, when the
+  platform already composes over HTTP and queue contracts that are versioned,
+  drift-gated, and understood by every lane. Revisit only if a specific port's
+  contract genuinely cannot be expressed as HTTP or a queue payload, which no
+  port in the catalog currently is.
+
+## Consequences
+
+**This ADR authorizes no code**, and it deliberately ships without a reference
+third-party adapter. That is the honest weakness: decision 2 asserts the
+deployed-service shape is right for a third party on the strength of internal
+precedent, and the precedents (harness, substrate, controller, model sidecar,
+stores) are all things we wrote or vendored ourselves. The first external
+channel adapter is what converts that into evidence, and it may well teach us
+the egress contract needs a field nobody predicted.
+
+**The bundle format gets an explicit non-goal.** Decision 1 means the answer to
+"can I put my channel adapter in a bundle" is no, permanently, and written down
+rather than rediscovered per request. Bundles keep growing along their own axis
+(connectors under ADR-0086, deploy targets under ADR-0089), which is agent
+content, not platform implementation.
+
+**The channel seam owes the work, and it is not free.** Promoting it means a
+neutral egress contract, per-endpoint egress credentials, a binding surface that
+is not a Slack column, approval-card delivery that does not assume Block Kit,
+and an answer for assistant-thread status. The binding column and
+its validators sit in the API's schema, so the rename is a migration plus a
+contract change, not a refactor. Each piece owes a `skill`/`local`/`cluster`
+answer as well, since the parity ladder grades a tier that cannot exercise a
+feature honestly rather than silently. What this ADR buys is that the work is
+done once against a published contract rather than once per asking vendor.
+
+**Conformance becomes an obligation before the second adapter, not after.**
+Decision 3 makes the kit part of promoting a port rather than a follow-up, and
+ADR-0062 already priced that honestly for the harness: it adds work in the short
+term, deliberately. The CLI stub being the reference adapter is what keeps the
+first channel kit from being written from nothing.
+
+**Multi-tenancy is assumed away, deliberately.** Decision 1's "versions with the
+deployment" reads channel identity as single-tenant, which is what the install
+looks like today. The multi-tenancy epic (#158) may want an adapter scoped per
+tenant instead, and nothing here decides against that; it is simply out of scope
+until that epic settles what a tenant owns.
+
+**Not decided here.** Where a promoted port's contract package lives, whether it
+is frozen (with the ADR-0017 and ADR-0036 obligations that come with freezing),
+and what the neutral egress contract's actual shape is. Those are the second
+implementation's job to teach, which is the point of decision 5.

--- a/docs/adr/0096-port-adapters-are-deployed-services.md
+++ b/docs/adr/0096-port-adapters-are-deployed-services.md
@@ -130,6 +130,29 @@ platform release on their own cadences behind a versioned wire. And it is
 **what the system already does** everywhere a second implementation exists, per
 the composition precedents in Context, so it adds no new operational concept.
 
+Composition is the mechanism, not the install experience, and the two must not
+be confused. What a third party ships is not a set of chart edits handed to an
+operator. It is an **adapter manifest**: a declarative description the platform
+composes from, naming which port the adapter implements, the contract version it
+targets, its container image reference, its config and secret schema, and the
+endpoints it exposes. The platform performs the composition, doing the same
+values wiring an operator could do by hand, so installing an adapter feels like
+bringing a plugin to your installation while the mechanism underneath stays a
+deployed service behind a wire contract. This is not a new idea here; it is
+[ADR-0086](0086-bundles-declare-connectors-the-platform-hosts-them.md)'s
+declare-and-host split moved up one scope, from agent-scoped connectors declared
+in a bundle to deployment-scoped adapters declared to the install, and
+[ADR-0090](0090-a-reconciler-applies-connectors-so-agent-repos-need-no-cli.md)'s
+reconciler is the delivery precedent for applying such a declaration without a
+`kubectl`-capable operator standing next to the cluster. Per the one-entry-point
+rule in `CLAUDE.md`, the operator surface is a `curie adapter` verb family (add,
+list, remove); its clap surface is issue material and is not specified here. The
+manifest is the product surface, not the only surface: hand-composed chart
+values, compose files, and endpoint config stay valid, because the contract is
+the wire and not the deployment, per the hosting paragraph below. Bring-your-own
+deployment remains a first-class way to run an adapter; the manifest is what
+makes the common case an install rather than a project.
+
 **3. A port is pluggable when its wire contract is published, versioned,
 drift-gated, and carries a conformance kit, not when a registry exists.** This
 generalizes ADR-0062: a registry proves an object was loaded, and a conformance
@@ -138,7 +161,12 @@ An `INTERFACE.md` documents where the code already draws the line. A contract
 package makes the line a schema, as `aci-protocol` and `channel-protocol`
 already do, which brings ADR-0017's tri-language drift gate and ADR-0036's
 reader policy with it. A conformance suite is then something a third party runs
-against its own adapter before it ever talks to us. Two rules bound every rung.
+against its own adapter before it ever talks to us. Alongside those three rungs a
+promoted port owes a fourth deliverable, its entry in decision 2's
+adapter-manifest schema, naming the config, secrets, and endpoints an
+implementation of that port declares; without it a third party can be conformant
+and still not installable, which is a port promoted on paper only. Two rules
+bound every rung.
 The trust rule from ADR-0040 decision 4 applies verbatim: **an adapter is a
 rendering and transport contract, never a trust boundary.** Approvals resolve
 solely through the API authorizer, an adapter's report of who clicked is input
@@ -215,7 +243,10 @@ a channel-neutral rename of the `slack_channel` binding surface and its
 validators; approval-card delivery through the neutral `OutboundMessage` path;
 assistant-thread status, which is `assistant_threads_setStatus` and Slack-only
 today with no neutral equivalent and no endpoint fallback
-(`apps/worker/src/curie_worker/slack_sink.py:404-423`); and trigger ingestion
+(`apps/worker/src/curie_worker/slack_sink.py:404-423`); the channel port's entry
+in the adapter-manifest schema of decision 2, plus the `curie adapter` install
+verb that consumes it, so a channel adapter is brought to an installation rather
+than wired into one; and trigger ingestion
 per [ADR-0079](0079-inbound-triggers-as-a-new-event-kind.md), whose
 `POST /hooks/{agent}/{hook}` is accepted but not yet built. Each lift owes an
 answer at every tier, the way ADR-0086 had to answer connector hosting for
@@ -279,7 +310,11 @@ channel-neutral reply contract is the destination, not the starting point.
   claiming any platform-facing field is an invented extension would prove too
   much: `connectors.yaml` and `deploy.yaml` are additive platform-facing
   declarations that already shipped, and they are fine because they declare
-  intent rather than supply the platform's implementation.
+  intent rather than supply the platform's implementation. What survives from
+  this alternative is its experience goal, that you bring a plugin to your
+  installation and it works; decision 2's adapter manifest delivers that
+  experience without inheriting the bundle format, the sandbox trust domain, or
+  the per-agent lifecycle.
 
 - **In-process dynamic loading as the general mechanism, that is, entry points
   everywhere.** This is the harness registry generalized without the exception
@@ -335,6 +370,15 @@ contract change, not a refactor. Each piece owes a `skill`/`local`/`cluster`
 answer as well, since the parity ladder grades a tier that cannot exercise a
 feature honestly rather than silently. What this ADR buys is that the work is
 done once against a published contract rather than once per asking vendor.
+
+**The install experience is part of the promise, not a nicety after it.** A port
+whose contract is published, versioned, and conformance-tested but which has no
+entry in the adapter-manifest schema is conformant and not adoptable, and decision
+3 counts that as an unfinished promotion rather than a finished one. That also
+gives decision 2 its acceptance test: the first external adapter's install flow,
+a manifest in and a running adapter out with zero chart edits and no operator
+hand-wiring. If that flow still requires editing values by hand, the manifest
+half of decision 2 has not been delivered, whatever the wire contract says.
 
 **Conformance becomes an obligation before the second adapter, not after.**
 Decision 3 makes the kit part of promoting a port rather than a follow-up, and

--- a/docs/adr/0096-port-adapters-are-deployed-services.md
+++ b/docs/adr/0096-port-adapters-are-deployed-services.md
@@ -2,7 +2,13 @@
 
 Date: 2026-08-04
 
-Status: Draft
+Status: Accepted
+
+Accepted alongside its implementation under [ADR-0102](0102-accepted-alongside-implementation-with-explicit-approval.md).
+Realizing code path: `apps/api/src/curie_api/models.py` (the channel-neutral
+binding), `apps/worker/src/curie_worker/binding.py` (the resolver),
+`packages/channel-protocol/` (the neutral egress port and its conformance
+kit), and `cli/src/main.rs` (the `curie adapter` verb family).
 
 Generalizes the harness trio to every port.
 [ADR-0060](0060-the-harness-is-a-declared-package.md) decides what a harness is

--- a/docs/adr/0101-schema-compatibility-for-closed-schemas.md
+++ b/docs/adr/0101-schema-compatibility-for-closed-schemas.md
@@ -4,6 +4,13 @@ Date: 2026-08-10
 
 Status: Accepted
 
+**Amended by [ADR-0103](0103-previous-schema-shape-gate.md)**
+(back link added under [ADR-0045](0045-the-status-line-is-the-mutable-part-of-an-immutable-adr.md)):
+the gate described in Decision section 4 is overtaken. The shipped gate uses a
+name based comparison of `properties` and `required` against the previous
+committed revision. Type changes, enum narrowings, and const flips are out of
+scope. The rest of this ADR stands.
+
 Implements [#1075](https://github.com/curie-eng/curie/issues/1075).
 
 **Amends ADR-0074** ("Versioned JSON Schemas for every agent-facing CLI result").

--- a/docs/adr/0102-accepted-alongside-implementation-with-explicit-approval.md
+++ b/docs/adr/0102-accepted-alongside-implementation-with-explicit-approval.md
@@ -1,0 +1,42 @@
+# 102. Accepted alongside implementation with explicit approval
+
+Date: 2026-08-11
+
+Status: Accepted
+
+**Amends [ADR-0085](0085-acceptance-not-implementation-authorizes-an-adr.md)**
+by replacing Decision clause 3. All other clauses and the history rules remain
+unchanged.
+
+## Context
+
+ADR 0085 correctly separates maintainer acceptance from implementation evidence.
+Its third clause is too strict for an explicitly approved change whose realizing
+code path is landing at the same time. This clause was violated for six
+consecutive review windows, and ADR 0101 landed Accepted in implementing commit `5d20f547`. A
+status transition gate was considered and rejected because the approval decision,
+not a doclint workflow, is the authority.
+
+## Decision
+
+An ADR may be published as Accepted alongside its implementation only when
+explicit maintainer approval is recorded and the ADR names the code path that
+realizes its decision. The implementation does not itself authorize acceptance.
+Without both approval and a named realizing code path, implementation must wait
+until acceptance.
+
+## Consequences
+
+Maintainers may accept and implement one decision in a coordinated change while
+keeping approval visible and auditable. The repository does not gain a status
+transition gate, and code evidence remains supporting evidence rather than
+authority.
+
+## Alternatives considered
+
+1. Require acceptance before every implementation. Rejected because it blocks a
+   coordinated, explicitly approved change.
+2. Gate status transitions with doclint. Rejected because a workflow cannot
+   replace explicit maintainer approval.
+3. Let implementation evidence authorize acceptance. Rejected because it
+   reverses the authority this amendment preserves.

--- a/docs/adr/0103-previous-schema-shape-gate.md
+++ b/docs/adr/0103-previous-schema-shape-gate.md
@@ -1,0 +1,40 @@
+# 103. Previous schema shape gate
+
+Date: 2026-08-11
+
+Status: Accepted
+
+**Amends [ADR-0101](0101-schema-compatibility-for-closed-schemas.md)**
+by replacing Decision section 4. All other sections remain unchanged.
+
+## Context
+
+ADR 0101 called for comparing a sample payload with the previous schema
+revision. Issues #1056, #1057, and #1306 were property additions. The shipped
+protection addresses that class directly through its realizing code path,
+`cli/tests/schema_inventory.rs`. Only 23 of 47 schema families have a sample,
+so a payload gate cannot be universal. Issue #1430 records executed evidence of
+what the gate catches and misses.
+
+## Decision
+
+The gate in `cli/tests/schema_inventory.rs` uses a name based comparison of
+`properties` and `required` against the previous committed revision. It fails
+for an unchanged identifier when either shape changes. Type changes, enum
+narrowings, and const flips are explicitly out of scope for this gate.
+
+## Consequences
+
+Property additions and required membership changes are caught across every
+schema family, including families without a sample payload. Payload comparison
+and broader semantic comparison are rejected or deferred because they require
+coverage and policy beyond this gate.
+
+## Alternatives considered
+
+1. Compare a sample payload against the previous revision. Rejected because
+   only some schema families have samples.
+2. Compare all semantic schema changes. Deferred because this amendment targets
+   the demonstrated property shape defect class.
+3. Leave the current schema only gate unchanged. Rejected because it cannot
+   detect an unchanged identifier with a changed previous shape.

--- a/docs/adr/0104-a-named-security-posture-is-computed-not-configured.md
+++ b/docs/adr/0104-a-named-security-posture-is-computed-not-configured.md
@@ -1,0 +1,143 @@
+# 104. A named security posture is computed from the layers that exist, never configured
+
+Date: 2026-08-10
+
+Status: Draft
+
+Implements [#1226](https://github.com/curie-eng/curie/issues/1226).
+
+Deliberately does NOT depend on [#158](https://github.com/curie-eng/curie/issues/158)
+(multi-tenancy) or [#515](https://github.com/curie-eng/curie/issues/515)
+(monotonic policy resolution). The Decision says why.
+
+## Context
+
+Curie has the machinery: ADR-0010 (gates), ADR-0050 (armed exactly or not at
+all), ADR-0056 (grantability is an operator opt-in), ADR-0035 (bounded one-shot
+allowance), ADR-0067 (NetworkPolicy is additive), ADR-0077 (no skill-tier durable
+approvals). Each is right on its own.
+
+What is missing is the sentence an evaluator needs. "How locked down is this
+before I point it at anything real" is currently assembled by hand from six ADRs
+and four code locations, which is a real adoption cost on exactly the
+security-conscious self-host buyer.
+
+Three facts about the tree, measured rather than assumed, bound what can be
+decided today:
+
+- **No organization tier.** `models.py` declares no `Org`/`Tenant` and no
+  `org_id`; `org_name` is a `Settings` string the console renders. The layers
+  that exist are **deployment** (chart values, process env), **agent** (a row),
+  and **bundle** (the manifest).
+- **No content screening.** No screening, classifier, or provenance-labelling
+  mechanism exists anywhere in the tree.
+- **No policy resolver.** Defaults are scattered by construction: the
+  self-approval block is in the API authorizer, default-deny egress is a chart
+  value, gates are in the bundle manifest, model and thinking are agent columns.
+
+## Decision
+
+**A posture is a NAME for a computed result, not a value an operator sets.** A
+resolver reads the deployment, agent and bundle layers, reports the effective
+answer per axis together with the layer that imposed it, and the posture name
+labels the shape of that answer.
+
+### 1. Computed, never configured
+
+There is no `posture:` setting. An operator changes a posture by changing a
+constraint, so the name can never disagree with what is enforced.
+
+This is the load-bearing choice. A configured posture is a second policy engine:
+it must be reconciled against the settings it claims to summarize, and
+reconciliation is where drift lives. A computed name cannot drift from what it is
+computed from.
+
+### 2. Three layers, tightening only
+
+Composition is monotonic: **deployment** to **agent** to **bundle**. A narrower
+layer may deny or require approval; it may never widen what a broader one denied.
+
+The organization tier is absent rather than stubbed. When #158 lands it becomes
+the outermost layer under the same rule.
+
+One conflict is recorded rather than resolved: `grantableViaPolicy` (ADR-0056) is
+a LOOSENING switch declared in the bundle. ADR-0056 is coherent on its premise
+that the operator authors the manifest, which inverts under a tenant-facing
+lattice where the bundle author is the tenant. That premise is load-bearing, and
+whoever adds the organization tier has to decide it deliberately.
+
+### 3. The floor holds in every posture
+
+Five denials are unconditional. No posture, layer, or bundle can turn one off:
+
+1. **Self-approval is refused**, server-side, under every approver set.
+2. **Sandbox egress is default-deny**, and ADR-0067 keeps NetworkPolicy additive
+   so a second policy cannot widen it.
+3. **A declared approval policy is armed exactly or not at all** (ADR-0050): a
+   partially-armed gate is a failed deploy, not a quiet gap.
+4. **A policy gate is not grantable** unless a manifest opts in per gate
+   (ADR-0056, default false).
+5. **Skill-tier durable approvals are unavailable** (ADR-0077).
+
+The floor is what makes the most permissive posture bounded rather than open.
+
+### 4. Names cover only axes that exist
+
+Three names over approvals, egress, and grantability:
+
+- **Strict** -- every declared gate armed, nothing grantable, egress allowlist
+  empty.
+- **Standard** (default) -- declared gates armed, grantability only where a
+  manifest opted in, egress as configured.
+- **Permissive** -- gates armed only where declared, grantability wherever opted
+  in, egress as configured. Still bounded by the floor.
+
+Screening is **not** an axis, because Curie has none; naming a rung it cannot
+enforce is the documentation label this decision exists to avoid. When screening
+ships it joins as a fourth axis without changing the shape.
+
+The third name is **Permissive, not Dangerous**: the floor makes the stronger
+word untrue, and a name that overstates how far a posture goes is worse than a
+duller accurate one.
+
+### 5. Reporting only
+
+The resolver READS. It adds no denial, changes no enforcement decision, and sits
+on no request path. Everything it reports is already enforced by the code behind
+the floor above; what is missing today is a place to see it in one answer. If it
+later needs to enforce, that is a different decision and a different ADR.
+
+## Alternatives rejected
+
+**Document the postures in `SECURITY.md` and stop.** Cheapest, and what the issue
+body proposes. Rejected: a documented posture is unverifiable, nothing fails when
+the prose and the defaults disagree, and the first divergence is silent.
+
+**Make posture a setting an operator writes.** Rejected: a second source of truth
+needing reconciliation with the constraints it summarizes. A posture whose name
+can be wrong is worse than no posture.
+
+**Wait for #515 and present its resolver.** Architecturally cleanest, rejected on
+sequencing: #515 is unassigned and larger in scope. The resolver here is small and
+scoped to three existing layers; if #515 later generalizes it, this is the
+consumer that proves the shape.
+
+**Wait for #158 and include the organization tier.** Rejected: the core security
+value does not need multi-tenancy, and the lattice admits an outer layer later.
+
+**Adopt Strict / Auto / Dangerous verbatim from the external model.** Rejected
+twice: "Auto" is defined by screening Curie lacks, and "Dangerous" promises an off
+switch the floor denies. The two properties worth borrowing are the unconditional
+floor and the tighten-only lattice, not the names.
+
+## Consequences
+
+- An evaluator gets one answer to "how locked down is this", with every part
+  traceable to the layer that imposed it.
+- The name cannot lie: drift between documented and enforced is not expressible.
+- The floor becomes a published promise. Weakening any of the five is now a
+  visible ADR-level change rather than a quiet default flip.
+- Screening's absence becomes visible rather than implied, which matters once
+  ADR-0100's channel-read verbs give untrusted content a path into context.
+- The organization tier is a known gap with a known shape.
+- This authorizes a READING surface only.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -129,4 +129,5 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0101 | [Closed schemas version on every change: minor for optional, major for required](0101-schema-compatibility-for-closed-schemas.md) | Accepted |
 | 0102 | [Accepted alongside implementation with explicit approval](0102-accepted-alongside-implementation-with-explicit-approval.md) | Accepted |
 | 0103 | [Previous schema shape gate](0103-previous-schema-shape-gate.md) | Accepted |
+| 0104 | [A named security posture is computed from the layers that exist, never configured](0104-a-named-security-posture-is-computed-not-configured.md) | Draft |
 <!-- END GENERATED: adr-index -->

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -124,6 +124,7 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0093 | [Local-model assets are pre-provisioned, never implicitly downloaded](0093-local-model-assets-are-pre-provisioned-never-implicitly-downloaded.md) | Draft |
 | 0094 | [A bundle carries its own sealed connector keys](0094-a-bundle-carries-its-own-sealed-connector-keys.md) | Accepted |
 | 0095 | [One tiered memory lifecycle for agent and channel memory](0095-tiered-memory-lifecycle.md) | Draft |
+| 0096 | [A third-party port adapter is a deployed service, not a loaded plugin](0096-port-adapters-are-deployed-services.md) | Draft |
 | 0097 | [One file declares an installation](0097-one-file-declares-an-installation.md) | Accepted |
 | 0098 | [Thinking depth is an operator knob, never a bundle one](0098-thinking-depth-is-an-operator-knob-never-a-bundle-one.md) | Accepted |
 | 0101 | [Closed schemas version on every change: minor for optional, major for required](0101-schema-compatibility-for-closed-schemas.md) | Accepted |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -127,4 +127,6 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0097 | [One file declares an installation](0097-one-file-declares-an-installation.md) | Accepted |
 | 0098 | [Thinking depth is an operator knob, never a bundle one](0098-thinking-depth-is-an-operator-knob-never-a-bundle-one.md) | Accepted |
 | 0101 | [Closed schemas version on every change: minor for optional, major for required](0101-schema-compatibility-for-closed-schemas.md) | Accepted |
+| 0102 | [Accepted alongside implementation with explicit approval](0102-accepted-alongside-implementation-with-explicit-approval.md) | Accepted |
+| 0103 | [Previous schema shape gate](0103-previous-schema-shape-gate.md) | Accepted |
 <!-- END GENERATED: adr-index -->

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -124,7 +124,7 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0093 | [Local-model assets are pre-provisioned, never implicitly downloaded](0093-local-model-assets-are-pre-provisioned-never-implicitly-downloaded.md) | Draft |
 | 0094 | [A bundle carries its own sealed connector keys](0094-a-bundle-carries-its-own-sealed-connector-keys.md) | Accepted |
 | 0095 | [One tiered memory lifecycle for agent and channel memory](0095-tiered-memory-lifecycle.md) | Draft |
-| 0096 | [A third-party port adapter is a deployed service, not a loaded plugin](0096-port-adapters-are-deployed-services.md) | Draft |
+| 0096 | [A third-party port adapter is a deployed service, not a loaded plugin](0096-port-adapters-are-deployed-services.md) | Accepted |
 | 0097 | [One file declares an installation](0097-one-file-declares-an-installation.md) | Accepted |
 | 0098 | [Thinking depth is an operator knob, never a bundle one](0098-thinking-depth-is-an-operator-knob-never-a-bundle-one.md) | Accepted |
 | 0101 | [Closed schemas version on every change: minor for optional, major for required](0101-schema-compatibility-for-closed-schemas.md) | Accepted |

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -79,6 +79,9 @@ Six commitments that should hold across every feature we build:
   human at a prompt. Commands are structured, non-interactive, idempotent, and
   self-describing, and the harness tells the agent exactly how to use it, so a
   coding agent can drive the whole loop and a human rarely needs to.
+  The guided walkthrough, invoked by `curie` with no arguments, is a committed
+  surface beside the agent facing CLI, so developer cold start work is on
+  strategy.
 
 ## What it could become
 

--- a/examples/tests/test_netpol_enforcement.py
+++ b/examples/tests/test_netpol_enforcement.py
@@ -1,0 +1,390 @@
+"""Black box coverage for the cluster NetworkPolicy enforcement gate."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import urlparse
+
+import yaml
+from plugin_format.connectors import validate_connectors
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "check-netpol-enforcement.sh"
+WEATHER_CONNECTORS = REPO_ROOT / "examples" / "weather" / "connectors.yaml"
+
+
+@dataclass(frozen=True)
+class GateRun:
+    stdout: str
+    stderr: str
+    returncode: int
+    kubectl_calls: list[list[str]]
+
+
+def _run_gate(
+    tmp_path: Path,
+    *,
+    connectors: tuple[str, ...],
+    sandbox_unreachable: tuple[str, ...] = (),
+    outside_reachable: tuple[str, ...] = (),
+    sandbox_dns_unreachable: bool = False,
+    outside_dns_unreachable: bool = False,
+    sandbox_to_deny_target_reachable: bool = False,
+    outside_to_deny_target_reachable: bool = True,
+    connector_not_ready: tuple[str, ...] = (),
+) -> GateRun:
+    fake = tmp_path / "kubectl"
+    log = tmp_path / "kubectl.jsonl"
+    fake.write_text(
+        """#!/usr/bin/env python3
+import json
+import os
+import sys
+from urllib.parse import urlparse
+
+args = sys.argv[1:]
+with open(os.environ["FAKE_KUBECTL_LOG"], "a", encoding="utf-8") as stream:
+    stream.write(json.dumps(args) + "\\n")
+
+connectors = tuple(filter(None, os.environ.get("FAKE_CONNECTORS", "").split(",")))
+sandbox_unreachable = set(
+    filter(None, os.environ.get("FAKE_SANDBOX_UNREACHABLE", "").split(","))
+)
+outside_reachable = set(
+    filter(None, os.environ.get("FAKE_OUTSIDE_REACHABLE", "").split(","))
+)
+sandbox_dns_unreachable = os.environ.get("FAKE_SANDBOX_DNS_UNREACHABLE") == "1"
+outside_dns_unreachable = os.environ.get("FAKE_OUTSIDE_DNS_UNREACHABLE") == "1"
+sandbox_to_deny_target_reachable = (
+    os.environ.get("FAKE_SANDBOX_TO_DENY_TARGET_REACHABLE") == "1"
+)
+outside_to_deny_target_reachable = (
+    os.environ.get("FAKE_OUTSIDE_TO_DENY_TARGET_REACHABLE") == "1"
+)
+connector_not_ready = set(
+    filter(None, os.environ.get("FAKE_CONNECTOR_NOT_READY", "").split(","))
+)
+
+
+def connector_deployment() -> str | None:
+    for connector in connectors:
+        if f"deployment/{connector}" in args or f"deploy/{connector}" in args:
+            return connector
+        for resource in ("deployment", "deploy"):
+            if resource in args and args.index(resource) + 1 < len(args):
+                if args[args.index(resource) + 1] == connector:
+                    return connector
+    return None
+
+if "delete" in args or "apply" in args:
+    raise SystemExit(0)
+
+if "wait" in args or ("rollout" in args and "status" in args):
+    deployment = connector_deployment()
+    if deployment is not None:
+        raise SystemExit(1 if deployment in connector_not_ready else 0)
+    raise SystemExit(0)
+
+if "get" in args and "networkpolicy" in args:
+    raise SystemExit(0)
+
+if "get" in args and "pod" in args:
+    print("192.0.2.10", end="")
+    raise SystemExit(0)
+
+if "get" in args and "svc" in args:
+    if "-l" in args:
+        if connectors:
+            print("\\n".join(connectors))
+        raise SystemExit(0)
+    print("8000", end="")
+    raise SystemExit(0)
+
+if "exec" in args:
+    exec_index = args.index("exec")
+    pod = args[exec_index + 1]
+    command = args[args.index("--") + 1 :]
+    if command and command[0] == "getent":
+        if pod == "netpol-probe-sandbox":
+            raise SystemExit(1 if sandbox_dns_unreachable else 0)
+        if pod == "netpol-probe-outside":
+            raise SystemExit(1 if outside_dns_unreachable else 0)
+        raise SystemExit(1)
+    urls = [value for value in command if value.startswith("http://")]
+    if urls:
+        service = urlparse(urls[0]).hostname or ""
+        if service == "192.0.2.10":
+            if pod == "netpol-probe-sandbox":
+                raise SystemExit(0 if sandbox_to_deny_target_reachable else 1)
+            if pod == "netpol-probe-outside":
+                raise SystemExit(0 if outside_to_deny_target_reachable else 1)
+            raise SystemExit(1)
+        if service not in connectors:
+            raise SystemExit(1)
+        if pod == "netpol-probe-sandbox":
+            raise SystemExit(1 if service in sandbox_unreachable else 0)
+        if pod == "netpol-probe-outside":
+            raise SystemExit(0 if service in outside_reachable else 1)
+
+print(f"unexpected kubectl invocation: {args!r}", file=sys.stderr)
+raise SystemExit(90)
+""",
+        encoding="utf-8",
+    )
+    fake.chmod(0o755)
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{tmp_path}{os.pathsep}{env['PATH']}",
+            "FAKE_KUBECTL_LOG": str(log),
+            "FAKE_CONNECTORS": ",".join(connectors),
+            "FAKE_SANDBOX_UNREACHABLE": ",".join(sandbox_unreachable),
+            "FAKE_OUTSIDE_REACHABLE": ",".join(outside_reachable),
+            "FAKE_SANDBOX_DNS_UNREACHABLE": (
+                "1" if sandbox_dns_unreachable else "0"
+            ),
+            "FAKE_OUTSIDE_DNS_UNREACHABLE": (
+                "1" if outside_dns_unreachable else "0"
+            ),
+            "FAKE_SANDBOX_TO_DENY_TARGET_REACHABLE": (
+                "1" if sandbox_to_deny_target_reachable else "0"
+            ),
+            "FAKE_OUTSIDE_TO_DENY_TARGET_REACHABLE": (
+                "1" if outside_to_deny_target_reachable else "0"
+            ),
+            "FAKE_CONNECTOR_NOT_READY": ",".join(connector_not_ready),
+        }
+    )
+    result = subprocess.run(
+        ["bash", str(SCRIPT), "curie", "curie", "curie"],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    calls = [json.loads(line) for line in log.read_text().splitlines()]
+    return GateRun(result.stdout, result.stderr, result.returncode, calls)
+
+
+def _connector_curl_calls(calls: list[list[str]]) -> set[tuple[str, str]]:
+    attempts: set[tuple[str, str]] = set()
+    for call in calls:
+        if "exec" not in call or "--" not in call:
+            continue
+        command = call[call.index("--") + 1 :]
+        urls = [value for value in command if value.startswith("http://")]
+        if not urls:
+            continue
+        service = urlparse(urls[0]).hostname or ""
+        if "-mcp-" in service:
+            attempts.add((call[call.index("exec") + 1], service))
+    return attempts
+
+
+def _curl_events(calls: list[list[str]]) -> list[tuple[int, str, str]]:
+    events: list[tuple[int, str, str]] = []
+    probe_roles = {
+        "netpol-probe-sandbox": "sandbox",
+        "netpol-probe-outside": "outside",
+    }
+    for index, call in enumerate(calls):
+        if "exec" not in call or "--" not in call:
+            continue
+        command = call[call.index("--") + 1 :]
+        urls = [value for value in command if value.startswith("http://")]
+        if not urls:
+            continue
+        pod = call[call.index("exec") + 1]
+        role = probe_roles.get(pod, pod)
+        host = urlparse(urls[0]).hostname or ""
+        target = "deny_target" if host == "192.0.2.10" else host
+        events.append((index, role, target))
+    return events
+
+
+def _dns_events(calls: list[list[str]]) -> list[tuple[int, str]]:
+    events: list[tuple[int, str]] = []
+    for index, call in enumerate(calls):
+        if "exec" not in call or "--" not in call:
+            continue
+        command = call[call.index("--") + 1 :]
+        if command[:2] == ["getent", "hosts"]:
+            events.append((index, call[call.index("exec") + 1]))
+    return events
+
+
+def _deployment_readiness_events(
+    calls: list[list[str]], connectors: tuple[str, ...]
+) -> list[tuple[int, str]]:
+    events: list[tuple[int, str]] = []
+    for index, call in enumerate(calls):
+        if "wait" not in call and not ("rollout" in call and "status" in call):
+            continue
+        for connector in connectors:
+            direct_resource = any(
+                value in call for value in (f"deployment/{connector}", f"deploy/{connector}")
+            )
+            separate_resource = any(
+                resource in call
+                and call.index(resource) + 1 < len(call)
+                and call[call.index(resource) + 1] == connector
+                for resource in ("deployment", "deploy")
+            )
+            if direct_resource or separate_resource:
+                events.append((index, connector))
+    return events
+
+
+def test_weather_ladder_bundle_declares_a_hosted_connector() -> None:
+    assert WEATHER_CONNECTORS.is_file(), "the fixed weather ladder bundle has no connectors.yaml"
+    parsed, errors = validate_connectors(yaml.safe_load(WEATHER_CONNECTORS.read_text()))
+
+    assert errors == []
+    assert parsed is not None
+    assert any(connector.is_hosted for connector in parsed.connectors.values())
+
+
+def test_zero_connector_services_fails(tmp_path: Path) -> None:
+    result = _run_gate(tmp_path, connectors=())
+
+    assert result.returncode != 0
+    assert "found 0 connector Services" in result.stdout + result.stderr
+
+
+def test_non_enforcing_cni_fails_before_connector_checks(tmp_path: Path) -> None:
+    result = _run_gate(
+        tmp_path,
+        connectors=("curie-mcp-alpha",),
+        sandbox_to_deny_target_reachable=True,
+    )
+
+    assert result.returncode != 0
+    assert "CNI is not enforcing NetworkPolicy" in result.stderr
+    assert not any(
+        target.startswith("curie-mcp-")
+        for _, _, target in _curl_events(result.kubectl_calls)
+    )
+
+
+def test_outside_probe_must_reach_known_listener_before_connector_denial(tmp_path: Path) -> None:
+    connector = "curie-mcp-alpha"
+    result = _run_gate(
+        tmp_path,
+        connectors=(connector,),
+        outside_to_deny_target_reachable=False,
+    )
+
+    assert result.returncode != 0
+    assert "outside probe" in result.stderr
+    assert "deny target" in result.stderr
+    assert ("outside", "deny_target") in {
+        (role, target) for _, role, target in _curl_events(result.kubectl_calls)
+    }
+    assert ("outside", connector) not in {
+        (role, target) for _, role, target in _curl_events(result.kubectl_calls)
+    }
+
+
+def test_outside_probe_must_resolve_dns_before_connector_denial(tmp_path: Path) -> None:
+    connector = "curie-mcp-alpha"
+    result = _run_gate(
+        tmp_path,
+        connectors=(connector,),
+        outside_dns_unreachable=True,
+    )
+
+    assert result.returncode != 0
+    assert "outside probe cannot resolve DNS" in result.stderr
+    dns_events = _dns_events(result.kubectl_calls)
+    assert any(pod == "netpol-probe-outside" for _, pod in dns_events)
+    outside_connector_curls = [
+        index
+        for index, role, target in _curl_events(result.kubectl_calls)
+        if role == "outside" and target == connector
+    ]
+    assert outside_connector_curls == []
+
+
+def test_every_connector_checks_sandbox_allow_and_outside_deny(tmp_path: Path) -> None:
+    connectors = ("curie-mcp-alpha", "curie-mcp-beta")
+    result = _run_gate(tmp_path, connectors=connectors)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "connector Service count: 2" in result.stdout
+    assert _connector_curl_calls(result.kubectl_calls) == {
+        ("netpol-probe-sandbox", "curie-mcp-alpha"),
+        ("netpol-probe-outside", "curie-mcp-alpha"),
+        ("netpol-probe-sandbox", "curie-mcp-beta"),
+        ("netpol-probe-outside", "curie-mcp-beta"),
+    }
+
+
+def test_connector_denials_follow_outside_control_and_deployment_readiness(
+    tmp_path: Path,
+) -> None:
+    connectors = ("curie-mcp-alpha", "curie-mcp-beta")
+    result = _run_gate(tmp_path, connectors=connectors)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    curl_indexes = {
+        (role, target): index for index, role, target in _curl_events(result.kubectl_calls)
+    }
+    readiness_indexes = {
+        connector: index
+        for index, connector in _deployment_readiness_events(result.kubectl_calls, connectors)
+    }
+    assert ("sandbox", "deny_target") in curl_indexes
+    assert ("outside", "deny_target") in curl_indexes
+    assert set(readiness_indexes) == set(connectors)
+    for connector in connectors:
+        assert readiness_indexes[connector] < curl_indexes[("sandbox", connector)]
+        assert readiness_indexes[connector] < curl_indexes[("outside", connector)]
+        assert curl_indexes[("outside", "deny_target")] < curl_indexes[("outside", connector)]
+
+
+def test_connector_readiness_failure_is_not_reported_as_policy_failure(tmp_path: Path) -> None:
+    connectors = ("curie-mcp-alpha", "curie-mcp-beta")
+    result = _run_gate(
+        tmp_path,
+        connectors=connectors,
+        connector_not_ready=("curie-mcp-beta",),
+    )
+
+    assert result.returncode != 0
+    assert "Deployment curie-mcp-beta" in result.stderr
+    assert "ready" in result.stderr
+    assert "sandbox cannot reach connector Service curie-mcp-beta" not in result.stderr
+    assert ("sandbox", "curie-mcp-beta") not in {
+        (role, target) for _, role, target in _curl_events(result.kubectl_calls)
+    }
+
+
+def test_outside_access_to_any_connector_fails(tmp_path: Path) -> None:
+    connectors = ("curie-mcp-alpha", "curie-mcp-beta")
+    result = _run_gate(
+        tmp_path,
+        connectors=connectors,
+        outside_reachable=("curie-mcp-beta",),
+    )
+
+    assert result.returncode != 0
+    assert "outside probe reached connector Service curie-mcp-beta:8000" in result.stderr
+
+
+def test_sandbox_access_loss_fails(tmp_path: Path) -> None:
+    connectors = ("curie-mcp-alpha", "curie-mcp-beta")
+    result = _run_gate(
+        tmp_path,
+        connectors=connectors,
+        sandbox_unreachable=("curie-mcp-beta",),
+    )
+
+    assert result.returncode != 0
+    assert "sandbox cannot reach connector Service curie-mcp-beta:8000" in result.stderr

--- a/examples/weather/connectors.yaml
+++ b/examples/weather/connectors.yaml
@@ -1,0 +1,20 @@
+# The weather bundle carries this hosted connector so the cluster NetworkPolicy
+# enforcement gate exercises a real connector Service. It is a probe fixture,
+# not part of the weather skill's forecast behavior.
+connectors:
+  netpol-probe:
+    image: grafana/mcp-grafana@sha256:d5b51db0c8eaafc6ed3fede5bfcc8d67b2384a40cf3d493086e378855ceba882
+    args:
+      [
+        "-t",
+        "streamable-http",
+        "--address",
+        "0.0.0.0:8000",
+        "--endpoint-path",
+        "/mcp",
+        "--allowed-hosts",
+        "${CURIE_ALLOWED_HOSTS}",
+        "-disable-write",
+      ]
+    env:
+      GRAFANA_URL: "http://grafana.example.com"

--- a/packages/plugin-format/src/plugin_format/connector_render.py
+++ b/packages/plugin-format/src/plugin_format/connector_render.py
@@ -398,6 +398,7 @@ def render_ingress_networkpolicy(
 
 
 def render(
+    *,
     release: str,
     agent: str,
     namespace: str,
@@ -406,7 +407,20 @@ def render(
     spec: ConnectorSpec,
     secret_name: str,
 ) -> list[dict[str, Any]]:
-    """Every object needed to run one hosted connector. Empty for a remote one."""
+    """Every object needed to run one hosted connector. Empty for a remote one.
+
+    Keyword-only, deliberately. Four of the seven parameters are strings that
+    look interchangeable at a call site -- release, agent, namespace, app_name --
+    and they are not: in a real install `curie cluster up --namespace my-agent
+    --release my-agent` against a chart whose `nameOverride` is empty leaves
+    app_name as `curie` while release and namespace are both `my-agent`, so no
+    one value can stand in for all four. Swapping release and app_name
+    positionally makes `sandbox_selector` emit `app.kubernetes.io/name: my-agent`
+    instead of `curie`, and both NetworkPolicies then parse, apply, and select
+    no pod: every connector tool call dies as a bare connection timeout with no
+    policy error anywhere. A positional call site cannot express that mistake
+    here because there is no positional call site.
+    """
 
     if not spec.is_hosted:
         return []

--- a/packages/plugin-format/src/plugin_format/connectors.py
+++ b/packages/plugin-format/src/plugin_format/connectors.py
@@ -130,11 +130,8 @@ class ConnectorSpec(BaseModel):
     # it is unaffected, which is what lets this land as a backward-compatible
     # change to a frozen contract.
     #
-    # The worker's reconciler decrypts these with the cluster's sealing key and
-    # writes the plaintext into the agent's own Secret. A blob it cannot open
-    # SKIPS that agent and leaves the running connector alone -- deploying it
-    # without the credential would produce a pod that passes its health check
-    # and 401s every call, the #1156 shape ADR-0094 exists to avoid.
+    # Validation refuses this field until a production decrypt path exists.
+    # This prevents a connector from deploying without the credential it needs.
     sealed_secrets: dict[str, str] = Field(default_factory=dict)
 
     #   secret_files:                         Project a stored secret as a FILE
@@ -424,6 +421,15 @@ def validate_connectors(data: Any) -> tuple[ConnectorsFile | None, list[tuple[st
                         "the credential it needs.",
                     )
                 )
+        if spec.sealed_secrets:
+            errors.append(
+                (
+                    "connectors.sealed_secrets_unsupported",
+                    f"{where}: `sealed_secrets` is declared but nothing decrypts it yet. "
+                    "Refusing rather than deploying without its credential. "
+                    "Use `secrets:` until then.",
+                )
+            )
         seen_secret_names: set[str] = set()
         for secret_name in spec.secret_names():
             if secret_name in seen_secret_names:

--- a/packages/plugin-format/tests/test_connector_render.py
+++ b/packages/plugin-format/tests/test_connector_render.py
@@ -25,8 +25,20 @@ HOSTED = ConnectorSpec(
 REMOTE = ConnectorSpec(url="https://mcp.internal/mcp", headers={"Authorization": "Bearer ${T}"})
 
 
-def _objs(release: str = "acme-bot", app: str = "acme-bot") -> list[dict]:
-    return r.render(release, "acme-bot", "acme-bot", app, "grafana", HOSTED, "conn-secrets")
+def _objs(
+    release: str = "acme-bot",
+    app: str = "acme-bot",
+    spec: ConnectorSpec = HOSTED,
+) -> list[dict]:
+    return r.render(
+        release=release,
+        agent="acme-bot",
+        namespace="acme-bot",
+        app_name=app,
+        connector="grafana",
+        spec=spec,
+        secret_name="conn-secrets",
+    )
 
 
 # Two NetworkPolicies ship per connector now, so selecting "the NetworkPolicy"
@@ -64,7 +76,17 @@ def test_egress_selects_exactly_the_pods_rail_1_denies() -> None:
     # cannot narrow -- ADR-0067) so the sandbox still cannot reach the
     # connector. Too broad -- e.g. only `component` -- and it also grants egress
     # to every OTHER release's sandboxes in the namespace. Both fail silently.
-    np = _egress_np(r.render("relA", "a", "ns", "acme-bot", "g", HOSTED, "s"))
+    np = _egress_np(
+        r.render(
+            release="relA",
+            agent="a",
+            namespace="ns",
+            app_name="acme-bot",
+            connector="g",
+            spec=HOSTED,
+            secret_name="s",
+        )
+    )
     assert np["spec"]["podSelector"]["matchLabels"] == {
         "app.kubernetes.io/name": "acme-bot",
         "app.kubernetes.io/instance": "relA",
@@ -73,8 +95,28 @@ def test_egress_selects_exactly_the_pods_rail_1_denies() -> None:
 
 
 def test_two_releases_do_not_select_each_others_sandboxes() -> None:
-    a = _egress_np(r.render("relA", "a", "ns", "app", "g", HOSTED, "s"))
-    b = _egress_np(r.render("relB", "a", "ns", "app", "g", HOSTED, "s"))
+    a = _egress_np(
+        r.render(
+            release="relA",
+            agent="a",
+            namespace="ns",
+            app_name="app",
+            connector="g",
+            spec=HOSTED,
+            secret_name="s",
+        )
+    )
+    b = _egress_np(
+        r.render(
+            release="relB",
+            agent="a",
+            namespace="ns",
+            app_name="app",
+            connector="g",
+            spec=HOSTED,
+            secret_name="s",
+        )
+    )
     assert a["spec"]["podSelector"] != b["spec"]["podSelector"]
 
 
@@ -133,7 +175,18 @@ def test_plain_env_is_passed_through() -> None:
 # Remote connectors own no objects
 # --------------------------------------------------------------------------- #
 def test_remote_connector_renders_nothing_to_run() -> None:
-    assert r.render("acme-bot", "a", "ns", "app", "internal", REMOTE, "s") == []
+    assert (
+        r.render(
+            release="acme-bot",
+            agent="a",
+            namespace="ns",
+            app_name="app",
+            connector="internal",
+            spec=REMOTE,
+            secret_name="s",
+        )
+        == []
+    )
 
 
 def test_remote_connector_keeps_its_own_url_and_headers() -> None:
@@ -189,11 +242,27 @@ def test_two_agents_in_one_release_do_not_share_object_names() -> None:
     # release-scoped too, handed it the prod token. Nothing errored.
     dev = [
         o["metadata"]["name"]
-        for o in r.render("curie", "acme-dev", "ns", "curie", "grafana", DEV, "s")
+        for o in r.render(
+            release="curie",
+            agent="acme-dev",
+            namespace="ns",
+            app_name="curie",
+            connector="grafana",
+            spec=DEV,
+            secret_name="s",
+        )
     ]
     prod = [
         o["metadata"]["name"]
-        for o in r.render("curie", "sre-prod", "ns", "curie", "grafana", PROD, "s")
+        for o in r.render(
+            release="curie",
+            agent="sre-prod",
+            namespace="ns",
+            app_name="curie",
+            connector="grafana",
+            spec=PROD,
+            secret_name="s",
+        )
     ]
     assert not set(dev) & set(prod), f"agents share object names: {dev} vs {prod}"
 
@@ -203,12 +272,28 @@ def test_two_agents_do_not_share_pod_labels() -> None:
     # traffic to the other's pods even with distinct object names.
     dev = next(
         o
-        for o in r.render("curie", "acme-dev", "ns", "curie", "grafana", DEV, "s")
+        for o in r.render(
+            release="curie",
+            agent="acme-dev",
+            namespace="ns",
+            app_name="curie",
+            connector="grafana",
+            spec=DEV,
+            secret_name="s",
+        )
         if o["kind"] == "Service"
     )
     prod = next(
         o
-        for o in r.render("curie", "sre-prod", "ns", "curie", "grafana", PROD, "s")
+        for o in r.render(
+            release="curie",
+            agent="sre-prod",
+            namespace="ns",
+            app_name="curie",
+            connector="grafana",
+            spec=PROD,
+            secret_name="s",
+        )
         if o["kind"] == "Service"
     )
     assert dev["spec"]["selector"] != prod["spec"]["selector"]
@@ -247,7 +332,15 @@ HOSTED_WITH_HOSTS = ConnectorSpec(
 def _dep(agent: str = "acme-dev", spec: ConnectorSpec = HOSTED_WITH_HOSTS) -> dict:
     return next(
         o
-        for o in r.render("acme-bot", agent, "acme-bot", "acme-bot", "grafana", spec, "s")
+        for o in r.render(
+            release="acme-bot",
+            agent=agent,
+            namespace="acme-bot",
+            app_name="acme-bot",
+            connector="grafana",
+            spec=spec,
+            secret_name="s",
+        )
         if o["kind"] == "Deployment"
     )
 
@@ -329,7 +422,15 @@ def test_a_referenced_secret_points_at_the_secret_the_author_named() -> None:
     spec = ConnectorSpec(image="x:1", secrets=[SecretRef(name="TOKEN", from_secret="grafana-mcp")])
     dep = next(
         o
-        for o in r.render("rel", "ag", "ns", "app", "g", spec, "curie-owned")
+        for o in r.render(
+            release="rel",
+            agent="ag",
+            namespace="ns",
+            app_name="app",
+            connector="g",
+            spec=spec,
+            secret_name="curie-owned",
+        )
         if o["kind"] == "Deployment"
     )
     entry = next(
@@ -349,7 +450,15 @@ def test_owned_and_referenced_secrets_are_indistinguishable_to_the_container() -
     spec = ConnectorSpec(image="x:1", secrets=["OWNED", SecretRef(name="REFD", from_secret="ext")])
     dep = next(
         o
-        for o in r.render("rel", "ag", "ns", "app", "g", spec, "curie-owned")
+        for o in r.render(
+            release="rel",
+            agent="ag",
+            namespace="ns",
+            app_name="app",
+            connector="g",
+            spec=spec,
+            secret_name="curie-owned",
+        )
         if o["kind"] == "Deployment"
     )
     env = {e["name"]: e for e in dep["spec"]["template"]["spec"]["containers"][0]["env"]}
@@ -366,7 +475,17 @@ def test_a_referenced_secret_is_not_optional() -> None:
 
     spec = ConnectorSpec(image="x:1", secrets=[SecretRef(name="T", from_secret="ext")])
     dep = next(
-        o for o in r.render("rel", "ag", "ns", "app", "g", spec, "s") if o["kind"] == "Deployment"
+        o
+        for o in r.render(
+            release="rel",
+            agent="ag",
+            namespace="ns",
+            app_name="app",
+            connector="g",
+            spec=spec,
+            secret_name="s",
+        )
+        if o["kind"] == "Deployment"
     )
     entry = next(
         e for e in dep["spec"]["template"]["spec"]["containers"][0]["env"] if e["name"] == "T"
@@ -585,13 +704,13 @@ def test_connector_accepts_traffic_only_from_the_sandbox() -> None:
     # the network is the entire access control.
     np = _ingress_np(
         r.render(
-            "release-r",
-            "agent-a",
-            "namespace-n",
-            "app-name",
-            "connector-c",
-            HOSTED,
-            "connector-secret",
+            release="release-r",
+            agent="agent-a",
+            namespace="namespace-n",
+            app_name="app-name",
+            connector="connector-c",
+            spec=HOSTED,
+            secret_name="connector-secret",
         )
     )
     src = np["spec"]["ingress"][0]["from"]
@@ -610,7 +729,13 @@ def test_ingress_policy_selects_the_connector_not_the_sandbox() -> None:
     # the wrong pod -- the sandbox gains an ingress restriction it does not need
     # while the connector keeps none.
     objs = r.render(
-        "release-r", "agent-a", "namespace-n", "app-name", "connector-c", HOSTED, "connector-secret"
+        release="release-r",
+        agent="agent-a",
+        namespace="namespace-n",
+        app_name="app-name",
+        connector="connector-c",
+        spec=HOSTED,
+        secret_name="connector-secret",
     )
     ing = _ingress_np(objs)
     egr = _egress_np(objs)
@@ -647,8 +772,28 @@ def test_ingress_uses_a_podselector_never_an_ipblock() -> None:
 def test_two_releases_do_not_admit_each_others_sandboxes() -> None:
     # A too-broad source selector would let another release's sandbox read
     # production through this connector, silently.
-    a = _ingress_np(r.render("relA", "a", "ns", "app", "g", HOSTED, "s"))
-    b = _ingress_np(r.render("relB", "a", "ns", "app", "g", HOSTED, "s"))
+    a = _ingress_np(
+        r.render(
+            release="relA",
+            agent="a",
+            namespace="ns",
+            app_name="app",
+            connector="g",
+            spec=HOSTED,
+            secret_name="s",
+        )
+    )
+    b = _ingress_np(
+        r.render(
+            release="relB",
+            agent="a",
+            namespace="ns",
+            app_name="app",
+            connector="g",
+            spec=HOSTED,
+            secret_name="s",
+        )
+    )
     assert a["spec"]["ingress"][0]["from"] != b["spec"]["ingress"][0]["from"]
 
 
@@ -659,4 +804,60 @@ def test_the_two_policies_do_not_collide_on_name() -> None:
 
 def test_a_remote_connector_renders_no_policies() -> None:
     # Nothing is hosted, so there is nothing in-cluster to admit traffic to.
-    assert not [o for o in r.render("rel", "a", "ns", "app", "x", REMOTE, "s")]
+    assert not [
+        o
+        for o in r.render(
+            release="rel",
+            agent="a",
+            namespace="ns",
+            app_name="app",
+            connector="x",
+            spec=REMOTE,
+            secret_name="s",
+        )
+    ]
+
+
+# --------------------------------------------------------------------------- #
+# `spec.port` is read in five places, and every one of them has to read the
+# DECLARED port. The default is 8000, so a reader that hardcodes it keeps
+# working for every connector that never sets `port:` and breaks only for the
+# ones that do -- silently, and with a different symptom per reader. These
+# render at TWO different NON-default ports for exactly that reason: asserting
+# at 8000 would pin nothing, and asserting at one other port would pin nothing
+# against a reader that hardcodes THAT value instead.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("port", [9876, 9999])
+def test_a_wrong_container_port_leaves_the_service_routing_to_a_refused_port(port: int) -> None:
+    # The Service names its targetPort "http", so the container's port NAME is
+    # what resolves it. A containerPort that is not the declared port makes
+    # "http" resolve to a port nothing listens on, and every call is refused.
+    spec = ConnectorSpec(image="grafana/mcp-grafana:0.17.2", port=port)
+    container = next(o for o in _objs(spec=spec) if o["kind"] == "Deployment")["spec"]["template"][
+        "spec"
+    ]["containers"][0]
+    assert container["ports"] == [{"name": "http", "containerPort": port}]
+
+
+@pytest.mark.parametrize("port", [9876, 9999])
+def test_a_wrong_egress_port_leaves_rail_1_denying_the_port_the_connector_listens_on(
+    port: int,
+) -> None:
+    # Rail 1 is default-deny, so this rule is the only thing that opens the hop.
+    # Opened on the wrong port it denies the real one, and the sandbox's call
+    # times out with no policy error anywhere to say why.
+    spec = ConnectorSpec(image="grafana/mcp-grafana:0.17.2", port=port)
+    egress = _egress_np(_objs(spec=spec))["spec"]["egress"][0]
+    assert egress["ports"] == [{"protocol": "TCP", "port": port}]
+
+
+@pytest.mark.parametrize("port", [9876, 9999])
+def test_a_wrong_url_port_makes_the_sandbox_dial_a_port_nothing_serves(port: int) -> None:
+    # The author never writes this URL, so a hardcoded port here is not
+    # correctable from the bundle: the sandbox dials the wrong port on the right
+    # pod and the MCP server never answers.
+    spec = ConnectorSpec(image="grafana/mcp-grafana:0.17.2", port=port)
+    url = r.mcp_entry("acme-rel", "acme-bot", "acme-ns", "grafana", spec)["url"]
+    assert url == f"http://acme-rel-acme-bot-mcp-grafana.acme-ns.svc.cluster.local:{port}/mcp"

--- a/packages/plugin-format/tests/test_connector_render.py
+++ b/packages/plugin-format/tests/test_connector_render.py
@@ -398,20 +398,16 @@ def test_sealed_secret_names_join_the_other_forms() -> None:
     assert spec.resolved_secrets() == ["PLAIN"]
 
 
-def test_a_declared_sealed_secret_is_accepted_now_that_decryption_exists() -> None:
-    """The refusal was a placeholder while nothing could decrypt.
-
-    It was deliberately strict: accepting the field early would have deployed a
-    connector with no credential -- a pod that starts, passes its health check,
-    and 401s every call. The worker decrypts now, so the field is real.
-    """
-
+def test_a_declared_sealed_secret_is_refused_until_decryption_exists() -> None:
     parsed, errors = validate_connectors(
         {"connectors": {"grafana": {"image": "x", "sealed_secrets": {"TOKEN": "AgB"}}}}
     )
-    assert [code for code, _ in errors] == []
-    assert parsed is not None
-    assert parsed.connectors["grafana"].sealed_secrets == {"TOKEN": "AgB"}
+    assert "connectors.sealed_secrets_unsupported" in [code for code, _ in errors]
+    assert parsed is None
+    diagnostic = next(
+        message for code, message in errors if code == "connectors.sealed_secrets_unsupported"
+    )
+    assert "secrets:" in diagnostic
 
 
 def test_an_empty_sealed_blob_is_reported_on_its_own() -> None:

--- a/packages/plugin-format/tests/test_connector_render.py
+++ b/packages/plugin-format/tests/test_connector_render.py
@@ -587,18 +587,37 @@ def test_connector_accepts_traffic_only_from_the_sandbox() -> None:
     # call a connector that holds a production credential and authenticates
     # nobody -- because the sandbox has no credential to authenticate WITH, so
     # the network is the entire access control.
-    np = _ingress_np(_objs())
+    np = _ingress_np(
+        r.render(
+            "release-r",
+            "agent-a",
+            "namespace-n",
+            "app-name",
+            "connector-c",
+            HOSTED,
+            "connector-secret",
+        )
+    )
     src = np["spec"]["ingress"][0]["from"]
     assert len(src) == 1, "exactly one source: the sandbox"
-    assert src[0]["podSelector"]["matchLabels"] == r.sandbox_selector("acme-bot", "acme-bot")
+    assert src[0]["podSelector"]["matchLabels"] == {
+        "app.kubernetes.io/name": "app-name",
+        "app.kubernetes.io/instance": "release-r",
+        "app.kubernetes.io/component": "runner-sandbox",
+    }
+    assert set(src[0]) == {"podSelector"}
+    assert src[0]["podSelector"]["matchLabels"] == r.sandbox_selector("release-r", "app-name")
 
 
 def test_ingress_policy_selects_the_connector_not_the_sandbox() -> None:
     # Getting this backwards yields a policy that parses, applies, and protects
     # the wrong pod -- the sandbox gains an ingress restriction it does not need
     # while the connector keeps none.
-    ing = _ingress_np(_objs())
-    egr = _egress_np(_objs())
+    objs = r.render(
+        "release-r", "agent-a", "namespace-n", "app-name", "connector-c", HOSTED, "connector-secret"
+    )
+    ing = _ingress_np(objs)
+    egr = _egress_np(objs)
     # The two policies must select OPPOSITE ends of the same hop: egress is
     # attached to the sandbox, ingress to the connector. Swapping them still
     # parses and still applies -- it just protects the wrong pod.
@@ -611,6 +630,10 @@ def test_ingress_policy_selects_the_connector_not_the_sandbox() -> None:
         egr["spec"]["podSelector"]["matchLabels"]
         == ing["spec"]["ingress"][0]["from"][0]["podSelector"]["matchLabels"]
     ), "ingress must admit the pod the egress rule is attached to"
+    dep = next(o for o in objs if o["kind"] == "Deployment")
+    assert ing["spec"]["podSelector"]["matchLabels"] == dep["spec"]["template"]["metadata"][
+        "labels"
+    ]
 
 
 def test_ingress_is_port_scoped_to_the_connector_port() -> None:

--- a/release/authorize.py
+++ b/release/authorize.py
@@ -11,12 +11,19 @@ pipeline, and it fails closed on either of two questions:
             merged PR is refused here, before any image builds.
 
   checks    Does that commit's check-runs list show every REQUIRED_CHECK_NAMES
-            entry successful (or neutral/skipped)? An explicit allowlist,
+            entry successful (or neutral)? An explicit allowlist,
             not "some checks, all green" (issue #733): a commit with only an
             unrelated passing check-run and no sign its real CI ever ran
             must be refused, the same as one that is on main but was never
             checked, or was checked and failed. Zero check-runs is also a
-            failure -- absence of checks is not evidence they passed. The
+            failure -- absence of checks is not evidence they passed. A
+            required check-run that concluded `skipped` is refused too
+            (issue #1470): a job-level `if:` on the job, or a failed job in
+            its `needs:`, both make GitHub record that required check as
+            `skipped`, and a chart that was never rendered, linted, or
+            kubeconform-validated must not authorize a release. A skipped
+            check-run whose name is NOT required is still ignored, like any
+            other non-required check. The
             gate's own workflow run is excluded from that list (issue #732):
             it is itself an in-progress check-run on the tagged SHA and
             would otherwise wait on itself forever.
@@ -37,7 +44,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-PASSING_CONCLUSIONS = {"success", "neutral", "skipped"}
+PASSING_CONCLUSIONS = {"success", "neutral"}
 
 # The check-run names that must be present and green before a tag may
 # publish (issue #733). These are the job `name:` fields from
@@ -109,8 +116,13 @@ def missing_required_checks(
     """Which `required_names` have no passing check-run for this commit?
 
     A name only counts as satisfied if some check-run with that exact `name`
-    concluded `success`/`neutral`/`skipped` AND no check-run with that name is
-    still running, failed, or otherwise non-passing. A required name with two
+    concluded `success`/`neutral` AND no check-run with that name is
+    still running, failed, skipped, or otherwise non-passing. `skipped` is not
+    a pass for a required name (issue #1470): GitHub records that conclusion
+    both when a job-level `if:` excludes the job and when a job in its
+    `needs:` failed, so treating it as passing authorized releases whose chart
+    was never rendered, linted, or kubeconform-validated, and whose ladder
+    jobs never ran because their upstream build failed. A required name with two
     check-runs -- one success and one failure (a re-run with mixed states) --
     is left in the returned set: for a fail-closed release gate any non-passing
     run of a required name masks nothing and blocks the tag. A same-named entry
@@ -118,7 +130,9 @@ def missing_required_checks(
     the returned set. Names outside `required_names` are ignored entirely -- an
     unrelated check-run, passing or not, has no bearing on this gate (issue
     #733): the point is asserting the checks that matter actually ran and
-    passed, not that everything present happened to be green.
+    passed, not that everything present happened to be green. That still holds
+    for a `skipped` NON-required check-run, which is ignored like any other
+    non-required entry; only a skipped *required* name blocks.
 
     `required_names` defaults to the module-level `REQUIRED_CHECK_NAMES`,
     looked up here rather than bound as the parameter's default value so that

--- a/release/authorize.py
+++ b/release/authorize.py
@@ -6,9 +6,10 @@ just a ref; pushing one proves nothing about the commit it points at. This
 script is the gate `authorize-release` runs before any other job in that
 pipeline, and it fails closed on either of two questions:
 
-  ancestry  Is the tagged commit reachable from `origin/main`? A tag on a
-            feature branch, a rebased-away commit, or anything that bypassed a
-            merged PR is refused here, before any image builds.
+  ancestry  Is the tagged commit reachable from an explicitly supplied
+            reviewed branch? A tag on a feature branch, a rebased commit, or
+            anything that bypassed a merged PR is refused here, before any
+            image builds.
 
   checks    Does that commit's check-runs list show every REQUIRED_CHECK_NAMES
             entry successful (or neutral)? An explicit allowlist,
@@ -42,14 +43,15 @@ import json
 import os
 import subprocess
 import sys
+from collections.abc import Sequence
 from pathlib import Path
 
 PASSING_CONCLUSIONS = {"success", "neutral"}
 
 # The check-run names that must be present and green before a tag may
 # publish (issue #733). These are the job `name:` fields from
-# `.github/workflows/ci.yaml` -- the workflow that gates every PR/push to
-# `main` -- restricted to the jobs that speak to release confidence: the
+# `.github/workflows/ci.yaml`, the workflow that gates every PR and push to
+# a reviewed branch, restricted to jobs that speak to release confidence: the
 # three language/test jobs, the generated-artifact drift checks, the
 # release-compose validation, every first-party image actually building
 # (including the worker-local overlay and the dispatcher's own import
@@ -92,21 +94,39 @@ class AuthorizationError(Exception):
     """A tagged commit is not authorized to publish a release."""
 
 
-def commit_is_on_reviewed_main(
-    sha: str, main_ref: str = "origin/main", *, cwd: Path | None = None
+def commit_is_on_reviewed_branch(
+    sha: str, reviewed_ref: str, *, cwd: Path | None = None
 ) -> bool:
-    """Is `sha` reachable from `main_ref` in the checked-out repo at `cwd`?
+    """Is `sha` reachable from `reviewed_ref` in the repo at `cwd`?
 
     Requires full history (`fetch-depth: 0` in the workflow checkout); a
     shallow clone would make an ancestor commit unreachable and read as absent.
     """
-    result = subprocess.run(
-        ["git", "merge-base", "--is-ancestor", sha, main_ref],
-        cwd=cwd,
-        capture_output=True,
-        check=False,
+    try:
+        result = subprocess.run(
+            ["git", "merge-base", "--is-ancestor", sha, reviewed_ref],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError as exc:
+        raise AuthorizationError(
+            f"could not determine whether commit {sha} is reachable from "
+            f"{reviewed_ref}: {exc}"
+        ) from exc
+
+    if result.returncode == 0:
+        return True
+    if result.returncode == 1:
+        return False
+
+    detail = result.stderr.strip()
+    suffix = f": {detail}" if detail else ""
+    raise AuthorizationError(
+        f"could not determine whether commit {sha} is reachable from "
+        f"{reviewed_ref}; git merge-base returned {result.returncode}{suffix}"
     )
-    return result.returncode == 0
 
 
 def missing_required_checks(
@@ -182,18 +202,27 @@ def exclude_current_workflow_run(
 def authorize(
     sha: str,
     check_runs: list[dict[str, object]],
-    main_ref: str = "origin/main",
+    reviewed_refs: Sequence[str],
     *,
     cwd: Path | None = None,
     exclude_run_id: str | None = None,
     required_names: frozenset[str] | None = None,
 ) -> None:
     """Raise AuthorizationError unless `sha` may publish a release."""
-    if not commit_is_on_reviewed_main(sha, main_ref, cwd=cwd):
+    if not reviewed_refs:
         raise AuthorizationError(
-            f"commit {sha} is not reachable from {main_ref}. A release can only "
-            "publish from a commit that reached main through a reviewed, merged "
-            "PR; refusing to authorize this tag."
+            "at least one reviewed ref is required; refusing to authorize this tag"
+        )
+
+    reachability = [
+        commit_is_on_reviewed_branch(sha, reviewed_ref, cwd=cwd)
+        for reviewed_ref in reviewed_refs
+    ]
+    if not any(reachability):
+        checked_refs = ", ".join(reviewed_refs)
+        raise AuthorizationError(
+            f"commit {sha} is not reachable from any reviewed ref "
+            f"({checked_refs}); refusing to authorize this tag"
         )
     other_runs = exclude_current_workflow_run(check_runs, exclude_run_id)
     missing = missing_required_checks(other_runs, required_names)
@@ -270,7 +299,12 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     parser.add_argument("sha", help="the tagged commit to authorize")
     parser.add_argument("--repo", required=True, help="owner/name, e.g. curie-eng/curie")
-    parser.add_argument("--main-ref", default="origin/main", help="the reviewed-main ref")
+    parser.add_argument(
+        "--reviewed-ref",
+        action="append",
+        required=True,
+        help="a reviewed branch ref; repeat for every allowed branch",
+    )
     parser.add_argument(
         "--run-id",
         default=os.environ.get("GITHUB_RUN_ID"),
@@ -280,7 +314,7 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         check_runs = fetch_check_runs(args.sha, args.repo)
-        authorize(args.sha, check_runs, args.main_ref, exclude_run_id=args.run_id)
+        authorize(args.sha, check_runs, args.reviewed_ref, exclude_run_id=args.run_id)
     except AuthorizationError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 1
@@ -298,7 +332,11 @@ def main(argv: list[str] | None = None) -> int:
             file=sys.stderr,
         )
         return 1
-    print(f"OK: {args.sha} is reviewed, on {args.main_ref}, and checked -- authorized")
+    checked_refs = ", ".join(args.reviewed_ref)
+    print(
+        f"OK: {args.sha} is reachable from a reviewed ref "
+        f"({checked_refs}) and checked; authorized"
+    )
     return 0
 
 

--- a/release/authorize.py
+++ b/release/authorize.py
@@ -15,9 +15,9 @@ pipeline, and it fails closed on either of two questions:
             entry successful (or neutral)? An explicit allowlist,
             not "some checks, all green" (issue #733): a commit with only an
             unrelated passing check-run and no sign its real CI ever ran
-            must be refused, the same as one that is on main but was never
-            checked, or was checked and failed. Zero check-runs is also a
-            failure -- absence of checks is not evidence they passed. A
+            must be refused, the same as one that is on a reviewed branch but
+            was never checked, or was checked and failed. Zero check-runs is
+            also a failure -- absence of checks is not evidence they passed. A
             required check-run that concluded `skipped` is refused too
             (issue #1470): a job-level `if:` on the job, or a failed job in
             its `needs:`, both make GitHub record that required check as

--- a/release/authorize.py
+++ b/release/authorize.py
@@ -52,11 +52,13 @@ PASSING_CONCLUSIONS = {"success", "neutral", "skipped"}
 # dependency/secret scanners, release.yaml's own jobs) are deliberately
 # excluded -- they matter, but are not what this gate is asserting about
 # *this* commit's CI.
+# The chart check is included despite living in another workflow because it
+# validates the release chart itself.
 #
-# This list is a plain constant, not derived from ci.yaml at runtime -- the
-# simpler of the two options ADR-0058 left open (issue #733). A renamed or
-# removed ci.yaml job needs a matching edit here; there is no drift check
-# tying the two together yet.
+# This list is a plain constant, not derived from ci.yaml or helm-ci.yaml at
+# runtime. It is the simpler of the two options ADR-0058 left open (issue
+# #733). Tests pin its required names to jobs in both workflows, so a job
+# rename or removal requires a matching edit here.
 REQUIRED_CHECK_NAMES = frozenset(
     {
         "Python (ruff + mypy + pytest)",
@@ -74,6 +76,7 @@ REQUIRED_CHECK_NAMES = frozenset(
         "Eval falsifiability gate (fake model, offline)",
         "E2E parity ladder (skill + local, fake model)",
         "E2E parity ladder (local-release, fake model)",
+        "Chart (lint + template + kubeconform)",
     }
 )
 

--- a/release/tests/test_authorize.py
+++ b/release/tests/test_authorize.py
@@ -12,6 +12,7 @@ check-run lists -- plus `authorize()`, which combines them and is what
 
 import importlib.util
 import json
+import os
 import re
 import subprocess
 from pathlib import Path
@@ -897,3 +898,234 @@ class TestMixedPassFailRequiredCheck:
                 cwd=git_repo,
                 required_names=TEST_REQUIRED_NAMES,
             )
+
+
+class TestSkippedRequiredCheck:
+    """A required check-run that concluded `skipped` is not a pass (#1470).
+
+    `skipped` used to sit in `PASSING_CONCLUSIONS` alongside `success` and
+    `neutral`, so a required check that never actually ran authorized a
+    release. Two routes produce it, and both are live risks here:
+
+      * a job-level `if:` added to the job. Adding one to helm-ci.yaml's
+        `helm` job would make GitHub record
+        `Chart (lint + template + kubeconform)` as `skipped` on every
+        releasable push, and the gate would then authorize a release whose
+        chart was never rendered, linted, or kubeconform-validated.
+      * a failed job in the job's `needs:`. ci.yaml's `rust-build` and
+        `changes` are not themselves required names, so a FAILED `rust-build`
+        skips the three ladder jobs -- which ARE required names -- into
+        `conclusion: skipped`, and that authorized a release too.
+
+    Measured live against the real `authorize()` before this change, with the
+    chart check varied and all 15 other required checks `success`:
+    `success` authorized, `failure` raised, `skipped` AUTHORIZED (the defect),
+    `cancelled` raised, `neutral` authorized, `None` raised, and an absent
+    entry raised. Only the `skipped` row changes here; a workflow whose
+    triggers never match produces NO check-run at all and is still correctly
+    refused as absent.
+    """
+
+    def test_a_required_name_whose_only_run_was_skipped_is_reported_missing(self):
+        runs = [
+            {"name": "CI", "conclusion": "success"},
+            {"name": "CodeQL", "conclusion": "skipped"},
+        ]
+
+        assert authorize_module.missing_required_checks(
+            runs, TEST_REQUIRED_NAMES
+        ) == {"CodeQL"}
+
+    def test_authorize_refuses_a_skipped_chart_check_when_every_other_check_passes(
+        self, git_repo
+    ):
+        # The exact scenario a job-level `if:` on helm-ci.yaml's `helm` job
+        # would produce, driven against the real production
+        # REQUIRED_CHECK_NAMES.
+        sha = run_git(git_repo, "rev-parse", "HEAD")
+        chart_check = "Chart (lint + template + kubeconform)"
+        runs = [
+            {
+                "name": name,
+                "conclusion": "skipped" if name == chart_check else "success",
+            }
+            for name in authorize_module.REQUIRED_CHECK_NAMES
+        ]
+
+        with pytest.raises(
+            authorize_module.AuthorizationError, match="required check-run"
+        ):
+            authorize_module.authorize(sha, runs, "main", cwd=git_repo)
+
+    def test_a_required_name_with_both_a_success_and_a_skipped_run_is_refused(
+        self, git_repo
+    ):
+        # Fail-closed, consistent with the mixed pass/fail behavior above: one
+        # green run does not excuse a same-named run that never executed.
+        sha = run_git(git_repo, "rev-parse", "HEAD")
+        runs = [
+            {"name": "CI", "conclusion": "success"},
+            {"name": "CI", "conclusion": "skipped"},
+            {"name": "CodeQL", "conclusion": "success"},
+        ]
+
+        assert "CI" in authorize_module.missing_required_checks(
+            runs, TEST_REQUIRED_NAMES
+        )
+        with pytest.raises(
+            authorize_module.AuthorizationError, match="required check-run"
+        ):
+            authorize_module.authorize(
+                sha, runs, "main", cwd=git_repo, required_names=TEST_REQUIRED_NAMES
+            )
+
+
+class TestLegitimateSkips:
+    """Why refusing skipped required checks does not over-reject (#1470).
+
+    There is exactly ONE legitimate `skipped` conclusion, enumerated below: a
+    check-run whose name is not in the required set, which the gate ignores
+    entirely. It needs no blanket allowance and does not put `skipped` back in
+    `PASSING_CONCLUSIONS`.
+
+    The two ci.yaml tests here are not a second legitimate skip. They pin the
+    only place a required job carries a job-level `if:` -- the conditional
+    ladder jobs -- so that it cannot conclude `skipped` on a releasable push,
+    which is what keeps the stricter gate from blocking every release.
+    """
+
+    def test_a_skipped_check_run_outside_the_required_set_does_not_block(
+        self, git_repo
+    ):
+        # CHECK_RUNS_ALL_GREEN carries `Secret Scan` at `skipped`, which is not
+        # a required name. Non-required entries are ignored entirely, so this
+        # still authorizes -- the only legitimate skip.
+        sha = run_git(git_repo, "rev-parse", "HEAD")
+
+        authorize_module.authorize(
+            sha,
+            CHECK_RUNS_ALL_GREEN,
+            "main",
+            cwd=git_repo,
+            required_names=TEST_REQUIRED_NAMES,
+        )
+
+    def test_every_conditional_required_ci_job_gates_only_on_the_ladder_output(self):
+        """A required ci.yaml job may carry no `if:` but the ladder gate.
+
+        Exactly two required jobs are conditional today -- `e2e-ladder`
+        (`E2E parity ladder (skill + local, fake model)`) and
+        `e2e-ladder-release` (`E2E parity ladder (local-release, fake model)`)
+        -- and both gate solely on `needs.changes.outputs.ladder == 'true'`,
+        which the `changes` job forces true on push (pinned behaviorally by the
+        test below). Any other expression reopens the hole: adding a
+        `github.event_name == 'pull_request'` conjunct, for instance, would
+        conclude those required checks `skipped` on every push and block every
+        release, while the `changes` job still faithfully wrote `ladder=true`.
+
+        Filtered on `REQUIRED_CHECK_NAMES` rather than over all jobs because
+        `e2e-ladder-cluster` and `commit-messages` also declare an `if:` but
+        their names are not required, so a skip there cannot reach the gate;
+        they are out of this assertion by construction. Asserted over every
+        matching job rather than the two known ids, so a newly-added
+        conditional required job is covered without editing this test.
+        """
+        doc = yaml.safe_load(CI_YAML.read_text())
+        offenders = {
+            job_id: str(job["if"]).strip()
+            for job_id, job in doc["jobs"].items()
+            if job.get("name") in authorize_module.REQUIRED_CHECK_NAMES
+            and "if" in job
+            and str(job["if"]).strip() != "needs.changes.outputs.ladder == 'true'"
+        }
+
+        assert not offenders, (
+            "ci.yaml required job(s) carry a job-level `if:` other than the "
+            "ladder gate, so their required check-run can conclude `skipped` on "
+            f"a release train push and block every release: {sorted(offenders.items())}"
+        )
+
+    def test_the_changes_filter_step_emits_ladder_true_when_executed_as_a_push(
+        self, tmp_path
+    ):
+        """The push short-circuit is what makes the conditional jobs safe.
+
+        The `changes` job's filter step emits `ladder=true` unconditionally on
+        a push to a release train branch, before ever consulting the
+        changed-file filter, so the required ladder jobs gated on that output
+        always run and never report `skipped` on a releasable push. Remove the
+        short-circuit and a docs-only push skips both required checks, and this
+        gate refuses every release.
+
+        Executed rather than grepped: a harmless shell rewrite of the same
+        behavior would fail a text scan, and a scan that finds the literal
+        `ladder=true` in a branch that no longer runs would pass while the
+        safety was gone. Interpolations are substituted first --
+        `github.event_name` becomes `push`, every other expression becomes
+        empty -- so without the short-circuit the script falls through to
+        `git fetch --quiet origin ""` under `set -euo pipefail` and exits
+        non-zero. It runs in `tmp_path` so it cannot touch this repo.
+        """
+        doc = yaml.safe_load(CI_YAML.read_text())
+        filter_step = next(
+            step
+            for step in doc["jobs"]["changes"]["steps"]
+            if step.get("id") == "filter"
+        )
+        script = re.sub(
+            r"\$\{\{\s*(.*?)\s*\}\}",
+            lambda m: "push" if m.group(1) == "github.event_name" else "",
+            filter_step["run"],
+        )
+        script_path = tmp_path / "filter.sh"
+        script_path.write_text(script)
+        github_output = tmp_path / "github_output"
+        github_output.touch()
+
+        result = subprocess.run(
+            ["bash", str(script_path)],
+            cwd=tmp_path,
+            env={**os.environ, "GITHUB_OUTPUT": str(github_output)},
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.returncode == 0, (
+            "ci.yaml's `changes` filter step no longer short-circuits on push -- "
+            "it fell through to the changed-file filter and failed: "
+            f"{result.stderr}"
+        )
+        assert "ladder=true" in github_output.read_text(), (
+            "ci.yaml's `changes` job no longer forces ladder=true on push, so the "
+            "`if: needs.changes.outputs.ladder == 'true'` required jobs can report "
+            f"`skipped` on a release train push: {github_output.read_text()!r}"
+        )
+
+
+class TestHelmCiJobsCarryNoJobLevelIf:
+    """No helm-ci.yaml job may carry a job-level `if:` (#1470).
+
+    A job-level `if:` on the `helm` job makes GitHub record
+    `Chart (lint + template + kubeconform)` -- a required check name -- with
+    `conclusion: skipped` on every releasable push. The gate now refuses a
+    skipped required check, so every release would be blocked with the chart
+    never rendered; before that change it silently AUTHORIZED instead, which is
+    strictly worse. Either way the job must simply run on push.
+
+    `TestHelmCiWorkflowTriggers` pins the trigger-level route into the same
+    hole (a filtered `push:` trigger produces no check-run at all); this pins
+    the job-level route. Asserted over every job in the workflow, not just
+    `helm`, so a future job added there is covered without editing this test.
+    """
+
+    def test_no_helm_ci_job_declares_a_job_level_if(self):
+        doc = yaml.safe_load(HELM_CI_YAML.read_text())
+        conditional = sorted(
+            job_id for job_id, job in doc["jobs"].items() if "if" in job
+        )
+
+        assert not conditional, (
+            "helm-ci.yaml job(s) carry a job-level `if:`, which makes their "
+            "check-run `skipped` on releasable pushes and blocks every release "
+            f"with the chart never rendered: {conditional}"
+        )

--- a/release/tests/test_authorize.py
+++ b/release/tests/test_authorize.py
@@ -2,8 +2,8 @@
 
 The gate is the deterministic check behind issue #628: a `v*` tag must not be
 able to start the publish pipeline unless its commit is reachable from
-`origin/main` and that commit's required checks are all green. These tests
-drive both functions directly -- `commit_is_on_reviewed_main` against a real,
+`origin/main` or `origin/next` and that commit's required checks are all green. These tests
+drive both functions directly -- `commit_is_on_reviewed_branch` against a real,
 disposable git repo (no network needed for ancestry) and
 `missing_required_checks` against constructed
 check-run lists -- plus `authorize()`, which combines them and is what
@@ -11,6 +11,7 @@ check-run lists -- plus `authorize()`, which combines them and is what
 """
 
 import importlib.util
+import inspect
 import json
 import os
 import re
@@ -62,12 +63,32 @@ def git_repo(tmp_path) -> Path:
     return repo
 
 
+@pytest.fixture
+def reviewed_refs_repo(git_repo) -> tuple[Path, dict[str, str]]:
+    """A history with commits unique to main, next, and an unmerged feature."""
+    base = run_git(git_repo, "rev-parse", "HEAD")
+
+    run_git(git_repo, "checkout", "-q", "-b", "next")
+    next_commit = commit(git_repo, "next-only.txt")
+    run_git(git_repo, "update-ref", "refs/remotes/origin/next", next_commit)
+
+    run_git(git_repo, "checkout", "-q", "main")
+    main_commit = commit(git_repo, "main-only.txt")
+    run_git(git_repo, "update-ref", "refs/remotes/origin/main", main_commit)
+
+    run_git(git_repo, "checkout", "-q", "-b", "feature", base)
+    feature_commit = commit(git_repo, "feature-only.txt")
+
+    return git_repo, {"main": main_commit, "next": next_commit, "feature": feature_commit}
+
+
 # A required-name set distinct from the real, larger production
 # REQUIRED_CHECK_NAMES (issue #733). Most tests in this file exercise the
 # *logic* of required-check matching and should not need updating every time
 # a ci.yaml job is renamed or added; the production constant itself gets its
 # own coverage in TestRequiredCheckAllowlist below.
 TEST_REQUIRED_NAMES = frozenset({"CI", "CodeQL"})
+REVIEWED_REFS = ("origin/main", "origin/next")
 
 CHECK_RUNS_ALL_GREEN = [
     {"name": "CI", "conclusion": "success"},
@@ -104,30 +125,41 @@ GATE_OWN_IN_PROGRESS = check_run(
 )
 
 
-class TestCommitIsOnReviewedMain:
+class TestCommitIsOnReviewedBranch:
+    def test_reviewed_branch_ref_has_no_default(self):
+        parameters = inspect.signature(
+            authorize_module.commit_is_on_reviewed_branch
+        ).parameters
+
+        assert parameters["reviewed_ref"].default is inspect.Parameter.empty
+
     def test_head_of_main_is_reachable(self, git_repo):
         sha = run_git(git_repo, "rev-parse", "HEAD")
 
-        assert authorize_module.commit_is_on_reviewed_main(sha, "main", cwd=git_repo)
+        assert authorize_module.commit_is_on_reviewed_branch(sha, "main", cwd=git_repo)
 
     def test_ancestor_of_main_is_reachable(self, git_repo):
         first = run_git(git_repo, "rev-parse", "HEAD")
         commit(git_repo, "later-on-main.txt")
 
-        assert authorize_module.commit_is_on_reviewed_main(first, "main", cwd=git_repo)
+        assert authorize_module.commit_is_on_reviewed_branch(first, "main", cwd=git_repo)
 
     def test_commit_only_on_an_unmerged_branch_is_refused(self, git_repo):
         run_git(git_repo, "checkout", "-q", "-b", "feature")
         unmerged = commit(git_repo, "feature-only.txt")
 
-        assert not authorize_module.commit_is_on_reviewed_main(
+        assert not authorize_module.commit_is_on_reviewed_branch(
             unmerged, "main", cwd=git_repo
         )
 
-    def test_unknown_sha_is_refused_not_raised(self, git_repo):
-        assert not authorize_module.commit_is_on_reviewed_main(
-            "0" * 40, "main", cwd=git_repo
-        )
+    def test_unknown_sha_refuses_as_indeterminate_reachability(self, git_repo):
+        sha = "0" * 40
+
+        with pytest.raises(authorize_module.AuthorizationError) as exc_info:
+            authorize_module.commit_is_on_reviewed_branch(sha, "main", cwd=git_repo)
+
+        assert sha in str(exc_info.value)
+        assert "main" in str(exc_info.value)
 
 
 class TestRequiredCheckSatisfaction:
@@ -206,22 +238,78 @@ class TestMissingRequiredChecks:
 
 
 class TestAuthorize:
-    def test_reviewed_and_green_commit_is_authorized(self, git_repo):
-        sha = run_git(git_repo, "rev-parse", "HEAD")
+    def test_reviewed_ref_collection_has_no_default(self):
+        parameters = inspect.signature(authorize_module.authorize).parameters
 
+        assert "main_ref" not in parameters
+        assert parameters["reviewed_refs"].default is inspect.Parameter.empty
+
+    def test_commit_reachable_only_from_next_is_authorized(
+        self, reviewed_refs_repo
+    ):
+        git_repo, commits = reviewed_refs_repo
         authorize_module.authorize(
-            sha, CHECK_RUNS_ALL_GREEN, "main", cwd=git_repo, required_names=TEST_REQUIRED_NAMES
+            commits["next"],
+            CHECK_RUNS_ALL_GREEN,
+            REVIEWED_REFS,
+            cwd=git_repo,
+            required_names=TEST_REQUIRED_NAMES,
         )
 
-    def test_unreviewed_commit_is_refused_even_with_green_checks(self, git_repo):
-        run_git(git_repo, "checkout", "-q", "-b", "feature")
-        unmerged = commit(git_repo, "feature-only.txt")
+    def test_commit_reachable_only_from_main_is_authorized(
+        self, reviewed_refs_repo
+    ):
+        git_repo, commits = reviewed_refs_repo
 
-        with pytest.raises(authorize_module.AuthorizationError, match="not reachable"):
+        authorize_module.authorize(
+            commits["main"],
+            CHECK_RUNS_ALL_GREEN,
+            REVIEWED_REFS,
+            cwd=git_repo,
+            required_names=TEST_REQUIRED_NAMES,
+        )
+
+    def test_commit_reachable_from_neither_reviewed_ref_is_refused(
+        self, reviewed_refs_repo
+    ):
+        git_repo, commits = reviewed_refs_repo
+
+        with pytest.raises(authorize_module.AuthorizationError) as exc_info:
             authorize_module.authorize(
-                unmerged,
+                commits["feature"],
                 CHECK_RUNS_ALL_GREEN,
-                "main",
+                REVIEWED_REFS,
+                cwd=git_repo,
+                required_names=TEST_REQUIRED_NAMES,
+            )
+
+        assert "origin/main" in str(exc_info.value)
+        assert "origin/next" in str(exc_info.value)
+
+    def test_matching_ref_does_not_hide_an_unresolvable_ref(self, reviewed_refs_repo):
+        git_repo, commits = reviewed_refs_repo
+        unresolvable_ref = "origin/not-a-ref"
+
+        with pytest.raises(authorize_module.AuthorizationError) as exc_info:
+            authorize_module.authorize(
+                commits["main"],
+                CHECK_RUNS_ALL_GREEN,
+                ("origin/main", unresolvable_ref),
+                cwd=git_repo,
+                required_names=TEST_REQUIRED_NAMES,
+            )
+
+        assert commits["main"] in str(exc_info.value)
+        assert unresolvable_ref in str(exc_info.value)
+
+    def test_empty_reviewed_ref_collection_is_refused(self, git_repo):
+        sha = run_git(git_repo, "rev-parse", "HEAD")
+
+        with pytest.raises(authorize_module.AuthorizationError, match="reviewed ref"):
+            authorize_module.authorize(
+                sha,
+                CHECK_RUNS_ALL_GREEN,
+                (),
                 cwd=git_repo,
                 required_names=TEST_REQUIRED_NAMES,
             )
@@ -233,7 +321,7 @@ class TestAuthorize:
             authorize_module.authorize(
                 sha,
                 CHECK_RUNS_ONE_FAILED,
-                "main",
+                ("main",),
                 cwd=git_repo,
                 required_names=TEST_REQUIRED_NAMES,
             )
@@ -269,7 +357,9 @@ class TestRequiredCheckAllowlist:
         with pytest.raises(
             authorize_module.AuthorizationError, match="required check-run"
         ):
-            authorize_module.authorize(sha, self.UNRELATED_BUT_GREEN, "main", cwd=git_repo)
+            authorize_module.authorize(
+                sha, self.UNRELATED_BUT_GREEN, ("main",), cwd=git_repo
+            )
 
     def test_every_required_check_present_and_green_authorizes(self, git_repo):
         sha = run_git(git_repo, "rev-parse", "HEAD")
@@ -278,7 +368,7 @@ class TestRequiredCheckAllowlist:
             for name in authorize_module.REQUIRED_CHECK_NAMES
         ]
 
-        authorize_module.authorize(sha, runs, "main", cwd=git_repo)
+        authorize_module.authorize(sha, runs, ("main",), cwd=git_repo)
 
     def test_a_single_missing_required_check_among_an_otherwise_full_set_is_refused(
         self, git_repo
@@ -291,7 +381,7 @@ class TestRequiredCheckAllowlist:
         with pytest.raises(
             authorize_module.AuthorizationError, match=re.escape(dropped)
         ):
-            authorize_module.authorize(sha, runs, "main", cwd=git_repo)
+            authorize_module.authorize(sha, runs, ("main",), cwd=git_repo)
 
     def test_authorize_refuses_a_failed_chart_check_when_every_other_check_passes(
         self, git_repo
@@ -309,7 +399,7 @@ class TestRequiredCheckAllowlist:
         with pytest.raises(
             authorize_module.AuthorizationError, match=re.escape(chart_check)
         ):
-            authorize_module.authorize(sha, runs, "main", cwd=git_repo)
+            authorize_module.authorize(sha, runs, ("main",), cwd=git_repo)
 
 
 class TestFetchCheckRuns:
@@ -429,7 +519,7 @@ class TestFetchCheckRunsPagination:
             )
 
         authorize_module.authorize(
-            sha, runs, "main", cwd=git_repo, required_names=TEST_REQUIRED_NAMES
+            sha, runs, ("main",), cwd=git_repo, required_names=TEST_REQUIRED_NAMES
         )
 
     def test_stops_when_a_page_reports_nothing_even_if_total_count_implied_more(
@@ -486,7 +576,7 @@ class TestAuthorizeExcludesCurrentRun:
         authorize_module.authorize(
             sha,
             runs,
-            "main",
+            ("main",),
             cwd=git_repo,
             exclude_run_id=CURRENT_RUN_ID,
             required_names=TEST_REQUIRED_NAMES,
@@ -508,7 +598,7 @@ class TestAuthorizeExcludesCurrentRun:
         authorize_module.authorize(
             sha,
             runs,
-            "main",
+            ("main",),
             cwd=git_repo,
             exclude_run_id=CURRENT_RUN_ID,
             required_names=TEST_REQUIRED_NAMES,
@@ -526,7 +616,7 @@ class TestAuthorizeExcludesCurrentRun:
             authorize_module.authorize(
                 sha,
                 runs,
-                "main",
+                ("main",),
                 cwd=git_repo,
                 exclude_run_id=CURRENT_RUN_ID,
                 required_names=TEST_REQUIRED_NAMES,
@@ -544,7 +634,7 @@ class TestAuthorizeExcludesCurrentRun:
             authorize_module.authorize(
                 sha,
                 runs,
-                "main",
+                ("main",),
                 cwd=git_repo,
                 exclude_run_id=CURRENT_RUN_ID,
                 required_names=TEST_REQUIRED_NAMES,
@@ -563,7 +653,7 @@ class TestAuthorizeExcludesCurrentRun:
             authorize_module.authorize(
                 sha,
                 runs,
-                "main",
+                ("main",),
                 cwd=git_repo,
                 exclude_run_id=CURRENT_RUN_ID,
                 required_names=TEST_REQUIRED_NAMES,
@@ -622,7 +712,7 @@ class TestMain:
         monkeypatch.setenv("GITHUB_RUN_ID", CURRENT_RUN_ID)
 
         exit_code = authorize_module.main(
-            [sha, "--repo", "curie-eng/curie", "--main-ref", "main"]
+            [sha, "--repo", "curie-eng/curie", "--reviewed-ref", "main"]
         )
 
         assert exit_code == 0
@@ -640,7 +730,7 @@ class TestMain:
         monkeypatch.delenv("GITHUB_RUN_ID", raising=False)
 
         exit_code = authorize_module.main(
-            [sha, "--repo", "curie-eng/curie", "--main-ref", "main"]
+            [sha, "--repo", "curie-eng/curie", "--reviewed-ref", "main"]
         )
 
         assert exit_code == 0
@@ -661,7 +751,7 @@ class TestMain:
         monkeypatch.setenv("GITHUB_RUN_ID", OTHER_RUN_ID)
 
         exit_code = authorize_module.main(
-            [sha, "--repo", "curie-eng/curie", "--main-ref", "main"]
+            [sha, "--repo", "curie-eng/curie", "--reviewed-ref", "main"]
         )
 
         assert exit_code == 1
@@ -691,7 +781,7 @@ class TestMainLookupFailures:
         monkeypatch.chdir(git_repo)
         monkeypatch.setenv("GITHUB_RUN_ID", CURRENT_RUN_ID)
         return authorize_module.main(
-            [sha, "--repo", "curie-eng/curie", "--main-ref", "main"]
+            [sha, "--repo", "curie-eng/curie", "--reviewed-ref", "main"]
         )
 
     def test_gh_api_failure_refuses_with_a_message_naming_the_lookup(
@@ -759,6 +849,7 @@ class TestMainLookupFailures:
 
 CI_YAML = REPO_ROOT / ".github" / "workflows" / "ci.yaml"
 HELM_CI_YAML = REPO_ROOT / ".github" / "workflows" / "helm-ci.yaml"
+RELEASE_YAML = REPO_ROOT / ".github" / "workflows" / "release.yaml"
 
 _MATRIX_REF = re.compile(r"\$\{\{\s*matrix\.([A-Za-z0-9_]+)\s*\}\}")
 
@@ -795,6 +886,96 @@ def ci_job_check_run_names() -> set[str]:
 def helm_ci_job_check_run_names() -> set[str]:
     doc = yaml.safe_load(HELM_CI_YAML.read_text())
     return {job["name"] for job in doc["jobs"].values() if job.get("name")}
+
+
+class TestReleaseWorkflowContract:
+    def test_release_branch_sources_are_anchored_and_wired_to_authorization(self):
+        source = RELEASE_YAML.read_text()
+        workflow = yaml.load(source, Loader=yaml.BaseLoader)
+        trigger = workflow["on"]["push"]
+
+        assert trigger["branches"] == ["main", "next"]
+        assert trigger["tags"] == ["v*"]
+
+        trigger_source = re.search(
+            r"(?ms)^on:\n  push:\n(?P<body>.*?)(?=^permissions:)", source
+        )
+        assert trigger_source is not None
+        anchors = {}
+        for branch in ("main", "next"):
+            anchor = re.search(
+                rf"&(?P<name>[A-Za-z_][A-Za-z0-9_-]*)\s+['\"]?{branch}['\"]?",
+                trigger_source.group("body"),
+            )
+            assert anchor is not None
+            anchors[branch] = anchor.group("name")
+        assert len(set(anchors.values())) == 2
+
+        authorization_source = re.search(
+            r"(?ms)^  authorize-release:\n(?P<body>.*?)(?=^  build:)", source
+        )
+        assert authorization_source is not None
+        env_source = re.search(
+            r"(?ms)^    env:\n(?P<body>(?:^      [^\n]+\n)+)",
+            authorization_source.group("body"),
+        )
+        assert env_source is not None
+        aliases = dict(
+            re.findall(
+                r"^      (?P<name>[A-Za-z_][A-Za-z0-9_]*): \*(?P<anchor>[^\s]+)\s*$",
+                env_source.group("body"),
+                re.MULTILINE,
+            )
+        )
+        assert set(aliases.values()) == set(anchors.values())
+
+        authorization = workflow["jobs"]["authorize-release"]
+        authorization_env = authorization["env"]
+        assert set(authorization_env) == set(aliases)
+        assert {authorization_env[name] for name in aliases} == {"main", "next"}
+
+        command = next(
+            step["run"]
+            for step in authorization["steps"]
+            if "release/authorize.py" in step.get("run", "")
+        )
+        reviewed_ref_envs = re.findall(
+            r"--reviewed-ref\s+origin/\$\{\{\s*env\.([A-Za-z_][A-Za-z0-9_]*)\s*\}\}",
+            command,
+        )
+        assert "--main-ref" not in command
+        assert set(reviewed_ref_envs) == set(authorization_env)
+        assert len(reviewed_ref_envs) == len(authorization_env) == 2
+        assert {authorization_env[name] for name in reviewed_ref_envs} == {"main", "next"}
+
+        overlay = re.search(
+            r"git checkout origin/\$\{\{\s*env\.([A-Za-z_][A-Za-z0-9_]*)\s*\}\}\s+-- release/",
+            authorization_source.group("body"),
+        )
+        assert overlay is not None
+        assert authorization_env[overlay.group(1)] == "main"
+
+    def test_continuous_metadata_and_worker_local_base_use_the_push_sha(self):
+        workflow = yaml.load(RELEASE_YAML.read_text(), Loader=yaml.BaseLoader)
+
+        for job_name in ("merge", "worker-local-merge"):
+            metadata = next(
+                step
+                for step in workflow["jobs"][job_name]["steps"]
+                if step.get("name") == "Image metadata"
+            )
+            tags = metadata["with"]["tags"]
+            assert "type=sha,format=long" in tags
+            assert "type=raw,value=latest,enable={{is_default_branch}}" in tags
+
+        base_tag_script = next(
+            step["run"]
+            for step in workflow["jobs"]["worker-local-build"]["steps"]
+            if step.get("name") == "Compute base tag"
+        )
+        assert 'echo "v=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"' in base_tag_script
+        assert 'echo "v=sha-${GITHUB_SHA}" >> "$GITHUB_OUTPUT"' in base_tag_script
+        assert 'echo "v=latest" >> "$GITHUB_OUTPUT"' not in base_tag_script
 
 
 class TestRequiredNamesMatchCiWorkflows:
@@ -894,7 +1075,7 @@ class TestMixedPassFailRequiredCheck:
             authorize_module.authorize(
                 sha,
                 self.MIXED_CI,
-                "main",
+                ("main",),
                 cwd=git_repo,
                 required_names=TEST_REQUIRED_NAMES,
             )
@@ -955,7 +1136,7 @@ class TestSkippedRequiredCheck:
         with pytest.raises(
             authorize_module.AuthorizationError, match="required check-run"
         ):
-            authorize_module.authorize(sha, runs, "main", cwd=git_repo)
+            authorize_module.authorize(sha, runs, ("main",), cwd=git_repo)
 
     def test_a_required_name_with_both_a_success_and_a_skipped_run_is_refused(
         self, git_repo
@@ -976,7 +1157,7 @@ class TestSkippedRequiredCheck:
             authorize_module.AuthorizationError, match="required check-run"
         ):
             authorize_module.authorize(
-                sha, runs, "main", cwd=git_repo, required_names=TEST_REQUIRED_NAMES
+                sha, runs, ("main",), cwd=git_repo, required_names=TEST_REQUIRED_NAMES
             )
 
 
@@ -1005,7 +1186,7 @@ class TestLegitimateSkips:
         authorize_module.authorize(
             sha,
             CHECK_RUNS_ALL_GREEN,
-            "main",
+            ("main",),
             cwd=git_repo,
             required_names=TEST_REQUIRED_NAMES,
         )

--- a/release/tests/test_authorize.py
+++ b/release/tests/test_authorize.py
@@ -292,6 +292,24 @@ class TestRequiredCheckAllowlist:
         ):
             authorize_module.authorize(sha, runs, "main", cwd=git_repo)
 
+    def test_authorize_refuses_a_failed_chart_check_when_every_other_check_passes(
+        self, git_repo
+    ):
+        sha = run_git(git_repo, "rev-parse", "HEAD")
+        chart_check = "Chart (lint + template + kubeconform)"
+        runs = [
+            {
+                "name": name,
+                "conclusion": "failure" if name == chart_check else "success",
+            }
+            for name in authorize_module.REQUIRED_CHECK_NAMES
+        ]
+
+        with pytest.raises(
+            authorize_module.AuthorizationError, match=re.escape(chart_check)
+        ):
+            authorize_module.authorize(sha, runs, "main", cwd=git_repo)
+
 
 class TestFetchCheckRuns:
     """`gh api` must be pinned to GET (issue #732, defect 1).
@@ -739,6 +757,7 @@ class TestMainLookupFailures:
 
 
 CI_YAML = REPO_ROOT / ".github" / "workflows" / "ci.yaml"
+HELM_CI_YAML = REPO_ROOT / ".github" / "workflows" / "helm-ci.yaml"
 
 _MATRIX_REF = re.compile(r"\$\{\{\s*matrix\.([A-Za-z0-9_]+)\s*\}\}")
 
@@ -772,29 +791,51 @@ def ci_job_check_run_names() -> set[str]:
     return names
 
 
-class TestRequiredNamesMatchCiYaml:
-    """`REQUIRED_CHECK_NAMES` must not drift from ci.yaml's job names (#811).
+def helm_ci_job_check_run_names() -> set[str]:
+    doc = yaml.safe_load(HELM_CI_YAML.read_text())
+    return {job["name"] for job in doc["jobs"].values() if job.get("name")}
 
-    The gate is fail-closed: a required name that no ci.yaml job produces can
+
+class TestRequiredNamesMatchCiWorkflows:
+    """`REQUIRED_CHECK_NAMES` must not drift from CI workflow job names (#811).
+
+    The gate is fail-closed: a required name that no CI workflow job produces can
     never appear among a commit's real check-runs, so it is reported missing on
     every otherwise-legitimate commit and blocks the release. Conversely a
     stale name masks the loss of the check it was meant to assert. This pins the
-    constant as a subset of the concrete check-run names the current ci.yaml
-    actually emits, parsed live (never derived from the constant itself).
+    constant as a subset of the concrete check-run names the current CI workflows
+    actually emit, parsed live (never derived from the constant itself).
 
-    So renaming or splitting a required job in ci.yaml without updating
+    So renaming or splitting a required job in a CI workflow without updating
     `REQUIRED_CHECK_NAMES` fails here (with the drifted names listed), rather
     than silently dropping a release gate.
     """
 
-    def test_every_required_name_is_a_real_ci_yaml_check_run_name(self):
-        ci_names = ci_job_check_run_names()
+    def test_every_required_name_is_a_real_ci_workflow_check_run_name(self):
+        ci_names = ci_job_check_run_names() | helm_ci_job_check_run_names()
         stale = authorize_module.REQUIRED_CHECK_NAMES - ci_names
 
         assert authorize_module.REQUIRED_CHECK_NAMES <= ci_names, (
-            "REQUIRED_CHECK_NAMES has drifted from ci.yaml -- these required "
+            "REQUIRED_CHECK_NAMES has drifted from the CI workflows -- these required "
             f"names match no current job check-run: {sorted(stale)}"
         )
+
+
+class TestHelmCiWorkflowTriggers:
+    """Pin the deliberate push and pull request trigger asymmetry."""
+
+    def test_push_trigger_is_unfiltered_for_releasable_branches(self):
+        doc = yaml.safe_load(HELM_CI_YAML.read_text())
+        triggers = doc[True]
+
+        assert triggers["push"]["branches"] == ["main", "next"]
+        assert "paths" not in triggers["push"]
+        assert "paths-ignore" not in triggers["push"]
+        assert triggers["pull_request"]["branches"] == ["main", "next"]
+        assert triggers["pull_request"]["paths"] == [
+            "charts/curie/**",
+            ".github/workflows/helm-ci.yaml",
+        ]
 
 
 class TestMixedPassFailRequiredCheck:

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -36,7 +36,7 @@ RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
     && rm -rf /var/lib/apt/lists/*
 
 # The Claude Code CLI the SDK spawns for a real (non-fake) session.
-RUN npm install -g @anthropic-ai/claude-code
+RUN npm install -g @anthropic-ai/claude-code@2.1.231
 
 # Off-the-shelf MCP servers pre-installed at build time so a bundle that
 # declares one starts it from the on-disk binary with NO runtime network fetch
@@ -44,7 +44,7 @@ RUN npm install -g @anthropic-ai/claude-code
 # anyway). Bundles reference these by the package's bin name, e.g.
 # `"command": "mcp-server-github"` -- see examples/github-issues. Add a line here
 # to bless another authed third-party MCP server for the same shape.
-RUN npm install -g @modelcontextprotocol/server-github
+RUN npm install -g @modelcontextprotocol/server-github@2025.4.8
 
 WORKDIR /app
 
@@ -67,8 +67,8 @@ RUN python3 -m venv /app/.venv \
     && /app/.venv/bin/pip install --no-cache-dir ./packages/aci-protocol ./packages/plugin-format \
     && /app/.venv/bin/pip install --no-cache-dir --no-deps ./runner \
     && /app/.venv/bin/pip install --no-cache-dir \
-        "claude-agent-sdk==0.2.115" \
-        "aiohttp==3.14.1" \
+        "claude-agent-sdk==0.2.126" \
+        "aiohttp==3.14.3" \
         "opentelemetry-sdk==1.44.0" \
         "opentelemetry-exporter-otlp-proto-http==1.44.0" \
         "anyio==4.14.1"

--- a/runner/tests/test_dockerfile_dependency_pins.py
+++ b/runner/tests/test_dockerfile_dependency_pins.py
@@ -306,7 +306,9 @@ def test_python_pin_revert_is_rejected() -> None:
 
 def test_npm_version_removal_is_rejected() -> None:
     dockerfile = _DOCKERFILE.read_text(encoding="utf-8")
-    for current in _dockerfile_global_npm_operands(dockerfile):
+    npm_operands = _dockerfile_global_npm_operands(dockerfile)
+    assert len(npm_operands) >= 2
+    for current in npm_operands:
         package, version = _split_npm_operand(current)
         assert version and _EXACT_NPM_VERSION.fullmatch(version)
         assert dockerfile.count(current) == 1

--- a/runner/tests/test_dockerfile_dependency_pins.py
+++ b/runner/tests/test_dockerfile_dependency_pins.py
@@ -1,0 +1,365 @@
+from __future__ import annotations
+
+import re
+import shlex
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_DOCKERFILE = _REPO_ROOT / "runner" / "Dockerfile"
+_UV_LOCK = _REPO_ROOT / "uv.lock"
+_EXACT_NPM_VERSION = re.compile(
+    r"\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?"
+)
+_NPM_PACKAGE = re.compile(r"(?:@[0-9A-Za-z._-]+/)?[0-9A-Za-z._-]+")
+_PIP_EXECUTABLE = re.compile(r"pip(?:\d+(?:\.\d+)?)?$")
+_NPM_INSTALL_ALIASES = {"install", "i", "add"}
+
+
+@dataclass(frozen=True)
+class Violation:
+    package: str
+    message: str
+
+
+def _normalize_python_name(name: str) -> str:
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def _logical_instructions(dockerfile_text: str) -> list[str]:
+    instructions: list[str] = []
+    pending: list[str] = []
+    for raw_line in dockerfile_text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        continues = line.endswith("\\")
+        pending.append(line[:-1].rstrip() if continues else line)
+        if not continues:
+            instructions.append(" ".join(pending))
+            pending = []
+    assert not pending, "Dockerfile ends with an unfinished continuation"
+    return instructions
+
+
+def _shell_tokens(instruction: str) -> list[str]:
+    lexer = shlex.shlex(instruction, posix=True, punctuation_chars=";&|")
+    lexer.commenters = ""
+    lexer.whitespace_split = True
+    return list(lexer)
+
+
+def _locked_runner_dependencies(lock_text: str) -> dict[str, str]:
+    lock = tomllib.loads(lock_text)
+    packages = lock.get("package")
+    assert isinstance(packages, list), "uv.lock must contain package records"
+    assert all(isinstance(package, dict) for package in packages), (
+        "uv.lock package records must be tables"
+    )
+
+    runner_records = [
+        package
+        for package in packages
+        if _normalize_python_name(str(package.get("name", ""))) == "curie-runner"
+    ]
+    assert len(runner_records) == 1, "uv.lock must contain exactly one curie-runner record"
+
+    dependencies = runner_records[0].get("dependencies")
+    assert isinstance(dependencies, list), "curie-runner must declare dependencies in uv.lock"
+    expected: dict[str, str] = {}
+    for dependency in dependencies:
+        assert isinstance(dependency, dict) and isinstance(dependency.get("name"), str), (
+            "each curie-runner dependency must have a name"
+        )
+        name = _normalize_python_name(dependency["name"])
+        resolved = [
+            package
+            for package in packages
+            if _normalize_python_name(str(package.get("name", ""))) == name
+        ]
+        assert len(resolved) == 1, f"uv.lock must resolve {name} exactly once"
+        source = resolved[0].get("source")
+        assert isinstance(source, dict), f"uv.lock package {name} must declare its source"
+        if "registry" not in source:
+            continue
+        version = resolved[0].get("version")
+        assert isinstance(version, str) and version, (
+            f"uv.lock registry package {name} must declare a version"
+        )
+        assert name not in expected, f"curie-runner dependency {name} is duplicated"
+        expected[name] = version
+    return expected
+
+
+def _dockerfile_python_pins(instructions: list[str]) -> dict[str, list[str]]:
+    pins: dict[str, list[str]] = {}
+    controls = {"&&", "||", ";"}
+    for instruction in instructions:
+        tokens = _shell_tokens(instruction)
+        if not tokens or tokens[0].upper() != "RUN":
+            continue
+        for index, token in enumerate(tokens[:-1]):
+            if not _PIP_EXECUTABLE.fullmatch(token.rsplit("/", 1)[-1]) or (
+                tokens[index + 1] != "install"
+            ):
+                continue
+            for operand in tokens[index + 2 :]:
+                if operand in controls:
+                    break
+                if operand.startswith("-") or "==" not in operand:
+                    continue
+                name, version = operand.split("==", 1)
+                if name:
+                    pins.setdefault(_normalize_python_name(name), []).append(version)
+    return pins
+
+
+def _dockerfile_python_operands(dockerfile_text: str) -> dict[str, str]:
+    operands: dict[str, str] = {}
+    controls = {"&&", "||", ";"}
+    for instruction in _logical_instructions(dockerfile_text):
+        tokens = _shell_tokens(instruction)
+        if not tokens or tokens[0].upper() != "RUN":
+            continue
+        for index, token in enumerate(tokens[:-1]):
+            if not _PIP_EXECUTABLE.fullmatch(token.rsplit("/", 1)[-1]) or (
+                tokens[index + 1] != "install"
+            ):
+                continue
+            for operand in tokens[index + 2 :]:
+                if operand in controls:
+                    break
+                if operand.startswith("-") or "==" not in operand:
+                    continue
+                name, _ = operand.split("==", 1)
+                package = _normalize_python_name(name)
+                assert package not in operands, f"Dockerfile must pin {package} exactly once"
+                operands[package] = operand
+    return operands
+
+
+def _split_npm_operand(operand: str) -> tuple[str, str | None]:
+    version_at = operand.rfind("@")
+    if version_at <= 0:
+        return operand, None
+    return operand[:version_at], operand[version_at + 1 :]
+
+
+def _npm_violations(instructions: list[str]) -> list[Violation]:
+    violations: list[Violation] = []
+    controls = {"&&", "||", ";"}
+    for instruction in instructions:
+        tokens = _shell_tokens(instruction)
+        if not tokens or tokens[0].upper() != "RUN":
+            continue
+        for index, token in enumerate(tokens[:-1]):
+            if token.rsplit("/", 1)[-1] != "npm" or (
+                tokens[index + 1] not in _NPM_INSTALL_ALIASES
+            ):
+                continue
+            command: list[str] = []
+            for operand in tokens[index + 2 :]:
+                if operand in controls:
+                    break
+                command.append(operand)
+            if not ({"-g", "--global"} & set(command)):
+                continue
+            for operand in command:
+                if operand.startswith("-"):
+                    continue
+                package, version = _split_npm_operand(operand)
+                if not _NPM_PACKAGE.fullmatch(package) or not (
+                    version and _EXACT_NPM_VERSION.fullmatch(version)
+                ):
+                    violations.append(
+                        Violation(package, "global npm install is missing an exact version")
+                    )
+    return violations
+
+
+def _dockerfile_global_npm_operands(dockerfile_text: str) -> list[str]:
+    operands: list[str] = []
+    controls = {"&&", "||", ";"}
+    for instruction in _logical_instructions(dockerfile_text):
+        tokens = _shell_tokens(instruction)
+        if not tokens or tokens[0].upper() != "RUN":
+            continue
+        for index, token in enumerate(tokens[:-1]):
+            if token.rsplit("/", 1)[-1] != "npm" or (
+                tokens[index + 1] not in _NPM_INSTALL_ALIASES
+            ):
+                continue
+            command: list[str] = []
+            for operand in tokens[index + 2 :]:
+                if operand in controls:
+                    break
+                command.append(operand)
+            if {"-g", "--global"} & set(command):
+                operands.extend(
+                    operand for operand in command if not operand.startswith("-")
+                )
+    return operands
+
+
+def _find_violations(lock_text: str, dockerfile_text: str) -> list[Violation]:
+    expected = _locked_runner_dependencies(lock_text)
+    instructions = _logical_instructions(dockerfile_text)
+    pins = _dockerfile_python_pins(instructions)
+    violations = _npm_violations(instructions)
+
+    for package, versions in pins.items():
+        if len(versions) > 1:
+            violations.append(Violation(package, "duplicate exact Dockerfile pin"))
+
+    for package in expected.keys() - pins.keys():
+        violations.append(
+            Violation(
+                package,
+                f"missing exact Dockerfile pin for lock version {expected[package]}",
+            )
+        )
+    for package in pins.keys() - expected.keys():
+        for version in pins[package]:
+            violations.append(
+                Violation(
+                    package,
+                    f"exact Dockerfile pin {version} is not a direct registry dependency",
+                )
+            )
+    for package in expected.keys() & pins.keys():
+        for version in set(pins[package]):
+            if version != expected[package]:
+                violations.append(
+                    Violation(
+                        package,
+                        f"expected lock version {expected[package]}, "
+                        f"found Dockerfile version {version}",
+                    )
+                )
+
+    return sorted(violations, key=lambda violation: (violation.package, violation.message))
+
+
+def test_actual_runner_dockerfile_matches_locked_dependencies() -> None:
+    violations = _find_violations(
+        _UV_LOCK.read_text(encoding="utf-8"),
+        _DOCKERFILE.read_text(encoding="utf-8"),
+    )
+    assert violations == []
+
+
+def test_prechange_drift_reports_all_four_violations() -> None:
+    dockerfile = """\
+RUN npm install -g @anthropic-ai/claude-code
+RUN npm install -g @modelcontextprotocol/server-github
+RUN /app/.venv/bin/pip install \\
+    "claude-agent-sdk==0.2.115" \\
+    "aiohttp==3.14.1" \\
+    "opentelemetry-sdk==1.44.0" \\
+    "opentelemetry-exporter-otlp-proto-http==1.44.0" \\
+    "anyio==4.14.1"
+"""
+    lock_text = _UV_LOCK.read_text(encoding="utf-8")
+    expected = _locked_runner_dependencies(lock_text)
+    violations = _find_violations(lock_text, dockerfile)
+    assert violations == [
+        Violation(
+            "@anthropic-ai/claude-code",
+            "global npm install is missing an exact version",
+        ),
+        Violation(
+            "@modelcontextprotocol/server-github",
+            "global npm install is missing an exact version",
+        ),
+        Violation(
+            "aiohttp",
+            "expected lock version "
+            f"{expected['aiohttp']}, found Dockerfile version 3.14.1",
+        ),
+        Violation(
+            "claude-agent-sdk",
+            "expected lock version "
+            f"{expected['claude-agent-sdk']}, found Dockerfile version 0.2.115",
+        ),
+    ]
+
+
+def test_python_pin_revert_is_rejected() -> None:
+    lock_text = _UV_LOCK.read_text(encoding="utf-8")
+    expected = _locked_runner_dependencies(lock_text)
+    dockerfile = _DOCKERFILE.read_text(encoding="utf-8")
+    current = _dockerfile_python_operands(dockerfile)["claude-agent-sdk"]
+    assert dockerfile.count(current) == 1
+    stale_version = f"{expected['claude-agent-sdk']}.stale"
+    mutated = dockerfile.replace(current, f"claude-agent-sdk=={stale_version}")
+
+    violations = _find_violations(lock_text, mutated)
+    assert Violation(
+        "claude-agent-sdk",
+        "expected lock version "
+        f"{expected['claude-agent-sdk']}, found Dockerfile version {stale_version}",
+    ) in violations
+
+
+def test_npm_version_removal_is_rejected() -> None:
+    dockerfile = _DOCKERFILE.read_text(encoding="utf-8")
+    for current in _dockerfile_global_npm_operands(dockerfile):
+        package, version = _split_npm_operand(current)
+        assert version and _EXACT_NPM_VERSION.fullmatch(version)
+        assert dockerfile.count(current) == 1
+        mutated = dockerfile.replace(current, package)
+
+        violations = _find_violations(_UV_LOCK.read_text(encoding="utf-8"), mutated)
+        assert Violation(
+            package, "global npm install is missing an exact version"
+        ) in violations
+
+
+@pytest.mark.parametrize("command", sorted(_NPM_INSTALL_ALIASES))
+def test_npm_global_install_aliases_require_exact_versions(command: str) -> None:
+    violations = _find_violations(
+        _UV_LOCK.read_text(encoding="utf-8"),
+        f"RUN npm {command} -g @example/tool\n",
+    )
+    assert Violation(
+        "@example/tool", "global npm install is missing an exact version"
+    ) in violations
+
+
+@pytest.mark.parametrize("executable", ["pip", "pip3"])
+def test_pip_executable_forms_are_compared_with_the_lock(executable: str) -> None:
+    lock_text = _UV_LOCK.read_text(encoding="utf-8")
+    dockerfile = _DOCKERFILE.read_text(encoding="utf-8")
+    operands = _dockerfile_python_operands(dockerfile)
+    synthetic = "RUN " + executable + " install " + " ".join(
+        f'"{operand}"' for operand in operands.values()
+    )
+
+    assert _find_violations(lock_text, synthetic) == []
+
+
+def test_python_pin_set_must_match_all_direct_registry_dependencies() -> None:
+    lock_text = _UV_LOCK.read_text(encoding="utf-8")
+    dockerfile = _DOCKERFILE.read_text(encoding="utf-8")
+    expected = _locked_runner_dependencies(lock_text)
+    operands = _dockerfile_python_operands(dockerfile)
+    assert operands.keys() == expected.keys()
+    baseline = "RUN pip install " + " ".join(
+        f'"{operand}"' for operand in operands.values()
+    )
+    missing = baseline.replace(f' "{operands["anyio"]}"', "")
+    extra = baseline + ' "httpx==1.0.0"'
+    duplicate = baseline + f' "{operands["aiohttp"]}"'
+
+    assert Violation(
+        "anyio", f"missing exact Dockerfile pin for lock version {expected['anyio']}"
+    ) in _find_violations(lock_text, missing)
+    assert Violation(
+        "httpx", "exact Dockerfile pin 1.0.0 is not a direct registry dependency"
+    ) in _find_violations(lock_text, extra)
+    assert Violation("aiohttp", "duplicate exact Dockerfile pin") in _find_violations(
+        lock_text, duplicate
+    )

--- a/scripts/check-netpol-enforcement.sh
+++ b/scripts/check-netpol-enforcement.sh
@@ -27,10 +27,11 @@ TARGET_IMAGE="${CURIE_NETPOL_TARGET_IMAGE:-hashicorp/http-echo:1.0}"
 
 SANDBOX_POD="netpol-probe-sandbox"
 OUTSIDE_POD="netpol-probe-outside"
+DENY_TARGET_POD="netpol-probe-deny-target"
 
 # Non-blocking on the way out: the run is over, nothing waits on the pods.
 cleanup() {
-  kubectl -n "$NS" delete pod "$SANDBOX_POD" "$OUTSIDE_POD" \
+  kubectl -n "$NS" delete pod "$SANDBOX_POD" "$OUTSIDE_POD" "$DENY_TARGET_POD" \
     --ignore-not-found --wait=false >/dev/null 2>&1 || true
 }
 # BLOCKING before the apply. A previous run's pod may still be terminating, and
@@ -38,7 +39,7 @@ cleanup() {
 # `wait --for=Ready` then passes on a pod that is on its way out and every exec
 # after it fails for reasons that have nothing to do with policy.
 cleanup_and_settle() {
-  kubectl -n "$NS" delete pod "$SANDBOX_POD" "$OUTSIDE_POD" \
+  kubectl -n "$NS" delete pod "$SANDBOX_POD" "$OUTSIDE_POD" "$DENY_TARGET_POD" \
     --ignore-not-found --wait=true --timeout=90s >/dev/null 2>&1 || true
 }
 trap cleanup EXIT
@@ -51,8 +52,8 @@ kubectl -n "$NS" get networkpolicy "${RELEASE}-runner-default-deny-egress" >/dev
   || fail "no ${RELEASE}-runner-default-deny-egress in $NS; is the chart installed?"
 
 # The sandbox probe wears exactly the labels Rail 1 selects, so the policies
-# under test apply to it. The outside probe wears none, and is the target the
-# sandbox must NOT reach.
+# under test apply to it. The outside probe and deny target wear none of the
+# runner sandbox labels.
 cleanup_and_settle
 kubectl -n "$NS" apply -f - >/dev/null <<YAML
 apiVersion: v1
@@ -80,23 +81,37 @@ spec:
   restartPolicy: Never
   containers:
     - name: probe
+      image: $PROBE_IMAGE
+      command: ["sleep", "600"]
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: $DENY_TARGET_POD
+  labels:
+    app.kubernetes.io/name: netpol-probe-deny-target
+spec:
+  restartPolicy: Never
+  containers:
+    - name: probe
       image: $TARGET_IMAGE
       args: ["-listen=:8000", "-text=reachable"]
 YAML
 
-kubectl -n "$NS" wait --for=condition=Ready "pod/$SANDBOX_POD" "pod/$OUTSIDE_POD" --timeout=180s >/dev/null \
+kubectl -n "$NS" wait --for=condition=Ready \
+  "pod/$SANDBOX_POD" "pod/$OUTSIDE_POD" "pod/$DENY_TARGET_POD" --timeout=180s >/dev/null \
   || fail "probe pods did not become ready"
 
-OUTSIDE_IP="$(kubectl -n "$NS" get pod "$OUTSIDE_POD" -o jsonpath='{.status.podIP}')"
-[ -n "$OUTSIDE_IP" ] || fail "could not read the outside probe's pod IP"
+DENY_TARGET_IP="$(kubectl -n "$NS" get pod "$DENY_TARGET_POD" -o jsonpath='{.status.podIP}')"
+[ -n "$DENY_TARGET_IP" ] || fail "could not read the deny target's pod IP"
 
 # ---------------------------------------------------------------------------
 # GATE: the deny must hold. Everything below is meaningless without this.
 # ---------------------------------------------------------------------------
 # Rail 1 denies all sandbox egress except what an allow policy adds, and nothing
-# allows the outside probe. Reaching it means policy is not being evaluated.
+# allows the deny target. Reaching it means policy is not being evaluated.
 if kubectl -n "$NS" exec "$SANDBOX_POD" -- \
-     curl -s -m 8 -o /dev/null "http://${OUTSIDE_IP}:8000/" 2>/dev/null; then
+     curl -s -m 8 -o /dev/null "http://${DENY_TARGET_IP}:8000/" 2>/dev/null; then
   fail "the sandbox reached a pod Rail 1 denies.
 
 This is NOT a policy bug -- it means the CNI is not enforcing NetworkPolicy at
@@ -112,9 +127,27 @@ Re-run against a cluster whose CNI enforces."
 fi
 echo "  ok  deny holds -- the CNI enforces NetworkPolicy (non-vacuity gate)"
 
+# The outside probe must reach the same known listener before its inability to
+# reach a connector can prove ingress enforcement. Otherwise a broken outside
+# network would make every connector ingress denial pass vacuously.
+if ! kubectl -n "$NS" exec "$OUTSIDE_POD" -- \
+      curl -s -m 8 -o /dev/null "http://${DENY_TARGET_IP}:8000/" 2>/dev/null; then
+  fail "the outside probe cannot reach the deny target; a broken outside network cannot certify connector ingress"
+fi
+echo "  ok  outside positive control reaches the deny target"
+
 # ---------------------------------------------------------------------------
 # Now the allow direction means something.
 # ---------------------------------------------------------------------------
+# The outside probe must resolve Service DNS before its inability to reach a
+# connector can prove ingress enforcement. Otherwise a broken outside DNS
+# path would make every connector ingress denial pass vacuously.
+if ! kubectl -n "$NS" exec "$OUTSIDE_POD" -- \
+      getent hosts kubernetes.default.svc.cluster.local >/dev/null 2>&1; then
+  fail "the outside probe cannot resolve DNS; connector ingress denial would be vacuous"
+fi
+echo "  ok  outside positive control resolves DNS"
+
 # DNS is the allow every sandbox depends on (curie-runner-allow-dns); without it
 # a sandbox cannot resolve any Service name, which surfaces as a confusing
 # connection failure rather than a policy error.
@@ -124,25 +157,40 @@ if ! kubectl -n "$NS" exec "$SANDBOX_POD" -- \
 fi
 echo "  ok  allow holds -- the sandbox can resolve DNS"
 
-# Any connector Service present is exercised too: this is the rule that was
-# silently broken by the ipBlock form, so it is the one most worth asserting.
-CONNECTORS="$(kubectl -n "$NS" get svc -l app.kubernetes.io/part-of="$RELEASE" \
-  -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null | grep -- "-mcp-" || true)"
-if [ -z "$CONNECTORS" ]; then
-  echo "  --  no connector Services in $NS; skipping the connector reachability leg"
-else
-  while IFS= read -r svc; do
-    [ -n "$svc" ] || continue
-    PORT="$(kubectl -n "$NS" get svc "$svc" -o jsonpath='{.spec.ports[0].port}')"
-    kubectl -n "$NS" exec "$SANDBOX_POD" -- \
-      curl -s -m 10 -o /dev/null "http://${svc}:${PORT}/" 2>/dev/null \
-      || fail "the sandbox cannot reach connector Service $svc:$PORT.
+# Every connector Service is exercised in both directions. A missing Service
+# makes the connector policy check vacuous and is therefore fatal.
+CONNECTORS=()
+while IFS= read -r svc; do
+  [ -n "$svc" ] && CONNECTORS+=("$svc")
+done < <(
+  kubectl -n "$NS" get svc -l app.kubernetes.io/part-of="$RELEASE" \
+    -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null \
+    | grep -- "-mcp-" || true
+)
+CONNECTOR_COUNT="${#CONNECTORS[@]}"
+(( CONNECTOR_COUNT > 0 )) \
+  || fail "found 0 connector Services in $NS; connector NetworkPolicy enforcement would be vacuous"
+echo "  ok  connector Service count: $CONNECTOR_COUNT"
+
+for svc in "${CONNECTORS[@]}"; do
+  kubectl -n "$NS" rollout status "deployment/$svc" --timeout=180s >/dev/null 2>&1 \
+    || fail "connector Deployment $svc did not become ready"
+
+  PORT="$(kubectl -n "$NS" get svc "$svc" -o jsonpath='{.spec.ports[0].port}')"
+  kubectl -n "$NS" exec "$SANDBOX_POD" -- \
+    curl -s -m 10 -o /dev/null "http://${svc}:${PORT}/" 2>/dev/null \
+    || fail "the sandbox cannot reach connector Service $svc:$PORT.
 
 Its egress rule is applied but not matching. The usual cause is an ipBlock of
 the Service ClusterIP: kube-proxy DNATs the destination to a pod IP before
 NetworkPolicy is evaluated, so such a rule can never match (ADR-0086)."
-    echo "  ok  sandbox reaches connector $svc:$PORT"
-  done <<<"$CONNECTORS"
-fi
+  echo "  ok  sandbox reaches connector $svc:$PORT"
 
-echo "== Rail 1 enforces, and every allowed path is reachable =="
+  if kubectl -n "$NS" exec "$OUTSIDE_POD" -- \
+       curl -s -m 10 -o /dev/null "http://${svc}:${PORT}/" 2>/dev/null; then
+    fail "the outside probe reached connector Service $svc:$PORT; connector ingress is not restricted to runner sandboxes"
+  fi
+  echo "  ok  outside probe cannot reach connector $svc:$PORT"
+done
+
+echo "== Rail 1, connector egress, and connector ingress enforce =="

--- a/tools/ci-retry-gate/tests/test_retry_eligibility.py
+++ b/tools/ci-retry-gate/tests/test_retry_eligibility.py
@@ -106,7 +106,7 @@ PROTECTED_STEPS = frozenset(
         (
             "release.yaml",
             "authorize-release",
-            "Tag's commit must be reviewed, on main, and fully checked",
+            "Tag's commit must be reviewed, on an allowed branch, and fully checked",
         ),
         ("release.yaml", "release", "Gate the asset set and build the checksum manifest"),
         ("release.yaml", "release", "Refuse to re-release an already-published tag"),


### PR DESCRIPTION
Brings main (v0.6.x line) forward into next after #1513 merged, so next carries the accepted ADR-0096 and the v0.6.x fixes that landed since the last sync.

One conflict, in .github/workflows/helm-ci.yaml: both lines added the worker/api object-store render assertion; next already had it plus the eval-wiring assertion, so the merge keeps next's side and drops main's duplicate block.