### PR TITLE
Follow-ups to #1514: version fixture derivation and cluster rung stub trust

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1068,47 +1068,13 @@ jobs:
           for img in curie-api:local curie-worker:local curie-ui:local curie-runner:latest; do
             kind load docker-image "$img" --name curie-e2e
           done
-      # Helm-install the platform through the operator wrapper. --dev pins the
-      # chart's deterministic published secrets (so `cluster message` can read
-      # them back); --fake-model seals the install credential-free. The --set
-      # overrides repoint every first-party image at the just-loaded local tags
-      # with pullPolicy Never (the runner AND its prewarm DaemonSet), force gVisor
-      # off (no runsc on kind nodes), and drop the dispatcher (no Slack; its
-      # presence would trip the `cluster message` reply-hijack guard).
-      - name: Install the platform (curie cluster up)
-        env:
-          CURIE_BIN: cli/target/release/curie
-        run: |
-          set -euo pipefail
-          "$CURIE_BIN" cluster up \
-            --chart charts/curie \
-            --dev \
-            --fake-model \
-            --set security.gvisor.mode=off \
-            --set dispatcher.deploy=false \
-            --set api.image.repository=curie-api --set api.image.tag=local --set api.image.pullPolicy=Never \
-            --set worker.image.repository=curie-worker --set worker.image.tag=local --set worker.image.pullPolicy=Never \
-            --set ui.image.repository=curie-ui --set ui.image.tag=local --set ui.image.pullPolicy=Never \
-            --set agentSandbox.runner.image=curie-runner --set agentSandbox.runner.tag=latest --set agentSandbox.runner.imagePullPolicy=Never \
-            --set agentSandbox.runner.prewarm.imagePullPolicy=Never
-      # `cluster up` does not `helm --wait` (the argv stays a thin wrapper), so
-      # wait for the rollouts the round trip depends on before driving it. The
-      # controller-ready preflight already gated the agent-sandbox controller
-      # during install; these cover the app tier and the prewarm cache. Langfuse
-      # and ClickHouse are intentionally NOT waited on -- a fake-model turn does
-      # not need traces to have flushed, and they are the slowest pods to settle.
-      - name: Wait for the platform to become ready
-        run: |
-          set -euo pipefail
-          kubectl rollout status deploy/curie-api -n curie --timeout=300s
-          kubectl rollout status deploy/curie-worker -n curie --timeout=300s
-          kubectl rollout status deploy/curie-ui -n curie --timeout=300s
-          kubectl rollout status daemonset/curie-runner-prewarm -n curie --timeout=300s
       # The pod-reachable host for the reply stub: the kind Docker network
       # gateway. Every node container sits on this bridge, so a pod egressing
       # through its node reaches the host here; the stub binds 0.0.0.0 and answers
       # on it. See this job's header for why auto-detection (loopback API server)
-      # cannot produce this value on kind.
+      # cannot produce this value on kind. Resolved before the install now that
+      # the install trusts the stub origin, and it only needs the kind node
+      # container, which is already running by here.
       - name: Resolve the pod-reachable host for the reply stub
         run: |
           set -euo pipefail
@@ -1137,6 +1103,46 @@ jobs:
           fi
           echo "kind network gateway (worker->stub reply host): $gw"
           echo "CURIE_E2E_LISTEN_HOST=$gw" >> "$GITHUB_ENV"
+      # Helm-install the platform through the operator wrapper. --dev pins the
+      # chart's deterministic published secrets (so `cluster message` can read
+      # them back); --fake-model seals the install credential-free. The --set
+      # overrides repoint every first-party image at the just-loaded local tags
+      # with pullPolicy Never (the runner AND its prewarm DaemonSet), force gVisor
+      # off (no runsc on kind nodes), and drop the dispatcher (no Slack; its
+      # presence would trip the `cluster message` reply-hijack guard).
+      # worker.slackTrustedOrigins is a CI-only widening that lets the worker
+      # answer the host-side reply stub (port = STUB_PORT in
+      # cli/scripts/e2e-ladder.sh); the chart default stays empty and fail-closed.
+      - name: Install the platform (curie cluster up)
+        env:
+          CURIE_BIN: cli/target/release/curie
+        run: |
+          set -euo pipefail
+          "$CURIE_BIN" cluster up \
+            --chart charts/curie \
+            --dev \
+            --fake-model \
+            --set security.gvisor.mode=off \
+            --set dispatcher.deploy=false \
+            --set worker.slackTrustedOrigins="http://${CURIE_E2E_LISTEN_HOST}:8155" \
+            --set api.image.repository=curie-api --set api.image.tag=local --set api.image.pullPolicy=Never \
+            --set worker.image.repository=curie-worker --set worker.image.tag=local --set worker.image.pullPolicy=Never \
+            --set ui.image.repository=curie-ui --set ui.image.tag=local --set ui.image.pullPolicy=Never \
+            --set agentSandbox.runner.image=curie-runner --set agentSandbox.runner.tag=latest --set agentSandbox.runner.imagePullPolicy=Never \
+            --set agentSandbox.runner.prewarm.imagePullPolicy=Never
+      # `cluster up` does not `helm --wait` (the argv stays a thin wrapper), so
+      # wait for the rollouts the round trip depends on before driving it. The
+      # controller-ready preflight already gated the agent-sandbox controller
+      # during install; these cover the app tier and the prewarm cache. Langfuse
+      # and ClickHouse are intentionally NOT waited on -- a fake-model turn does
+      # not need traces to have flushed, and they are the slowest pods to settle.
+      - name: Wait for the platform to become ready
+        run: |
+          set -euo pipefail
+          kubectl rollout status deploy/curie-api -n curie --timeout=300s
+          kubectl rollout status deploy/curie-worker -n curie --timeout=300s
+          kubectl rollout status deploy/curie-ui -n curie --timeout=300s
+          kubectl rollout status daemonset/curie-runner-prewarm -n curie --timeout=300s
       # The cluster rung only: `cluster status` gate -> `cluster deploy` ->
       # `cluster message` (reply asserted). Fake model, credential-free.
       - name: Parity ladder (cluster rung, fake model, credential-free)

--- a/.github/workflows/nightly-graded-ladder.yaml
+++ b/.github/workflows/nightly-graded-ladder.yaml
@@ -340,55 +340,13 @@ jobs:
           for img in curie-api:local curie-worker:local curie-ui:local curie-runner:latest; do
             kind load docker-image "$img" --name curie-e2e
           done
-      # The graded install. Unlike ci.yaml's cluster job (which seals the
-      # install credential-free, the plumbing-only path ADR-0055 bounds), this
-      # install is armed: no seal flag, the OpenRouter credential supplied via
-      # CURIE_CREDENTIALS env (cluster up masks it and adds fakeModel=false
-      # automatically), CURIE_MODEL env baked into the release as the runner's
-      # model (cluster up reads it from env; it has no --model flag), and
-      # --allow-egress-host openrouter (the provider KEYWORD, resolved to a /32
-      # host route at install time) so the default-deny runner sandbox can
-      # reach OpenRouter. The --set overrides repoint every first-party image at
-      # the just-loaded local tags with pullPolicy Never, force gVisor off (no
-      # runsc on kind nodes -- a real-model install fails closed without this),
-      # and drop the dispatcher (no Slack; its presence would trip the
-      # `cluster message` reply-hijack guard). The secret travels in env, never
-      # on argv.
-      - name: Install the platform (curie cluster up, graded)
-        env:
-          CURIE_BIN: cli/target/release/curie
-          CURIE_CREDENTIALS: ${{ secrets.OPENROUTER_API_KEY }}
-          CURIE_MODEL: ${{ inputs.model || 'z-ai/glm-5.2' }}
-        run: |
-          set -euo pipefail
-          "$CURIE_BIN" cluster up \
-            --chart charts/curie \
-            --dev \
-            --allow-egress-host openrouter \
-            --set security.gvisor.mode=off \
-            --set dispatcher.deploy=false \
-            --set api.image.repository=curie-api --set api.image.tag=local --set api.image.pullPolicy=Never \
-            --set worker.image.repository=curie-worker --set worker.image.tag=local --set worker.image.pullPolicy=Never \
-            --set ui.image.repository=curie-ui --set ui.image.tag=local --set ui.image.pullPolicy=Never \
-            --set agentSandbox.runner.image=curie-runner --set agentSandbox.runner.tag=latest --set agentSandbox.runner.imagePullPolicy=Never \
-            --set agentSandbox.runner.prewarm.imagePullPolicy=Never
-      # `cluster up` does not `helm --wait` (the argv stays a thin wrapper), so
-      # wait for the rollouts the round trip depends on before driving it.
-      # Langfuse and ClickHouse are intentionally NOT waited on -- a single
-      # graded turn does not need traces flushed, and they are the slowest pods
-      # to settle.
-      - name: Wait for the platform to become ready
-        run: |
-          set -euo pipefail
-          kubectl rollout status deploy/curie-api -n curie --timeout=300s
-          kubectl rollout status deploy/curie-worker -n curie --timeout=300s
-          kubectl rollout status deploy/curie-ui -n curie --timeout=300s
-          kubectl rollout status daemonset/curie-runner-prewarm -n curie --timeout=300s
       # The pod-reachable host for the reply stub: the kind Docker network
       # gateway. Every node container sits on this bridge, so a pod egressing
       # through its node reaches the host here; the stub binds 0.0.0.0 and
       # answers on it. Auto-detection (loopback API server) cannot produce this
-      # value on kind.
+      # value on kind. Resolved before the install now that the install trusts
+      # the stub origin, and it only needs the kind node container, which is
+      # already running by here.
       - name: Resolve the pod-reachable host for the reply stub
         run: |
           set -euo pipefail
@@ -417,6 +375,54 @@ jobs:
           fi
           echo "kind network gateway (worker->stub reply host): $gw"
           echo "CURIE_E2E_LISTEN_HOST=$gw" >> "$GITHUB_ENV"
+      # The graded install. Unlike ci.yaml's cluster job (which seals the
+      # install credential-free, the plumbing-only path ADR-0055 bounds), this
+      # install is armed: no seal flag, the OpenRouter credential supplied via
+      # CURIE_CREDENTIALS env (cluster up masks it and adds fakeModel=false
+      # automatically), CURIE_MODEL env baked into the release as the runner's
+      # model (cluster up reads it from env; it has no --model flag), and
+      # --allow-egress-host openrouter (the provider KEYWORD, resolved to a /32
+      # host route at install time) so the default-deny runner sandbox can
+      # reach OpenRouter. The --set overrides repoint every first-party image at
+      # the just-loaded local tags with pullPolicy Never, force gVisor off (no
+      # runsc on kind nodes -- a real-model install fails closed without this),
+      # and drop the dispatcher (no Slack; its presence would trip the
+      # `cluster message` reply-hijack guard). The secret travels in env, never
+      # on argv. worker.slackTrustedOrigins is a CI-only widening that lets the
+      # worker answer the host-side reply stub (port = STUB_PORT in
+      # cli/scripts/e2e-ladder.sh); the chart default stays empty and
+      # fail-closed.
+      - name: Install the platform (curie cluster up, graded)
+        env:
+          CURIE_BIN: cli/target/release/curie
+          CURIE_CREDENTIALS: ${{ secrets.OPENROUTER_API_KEY }}
+          CURIE_MODEL: ${{ inputs.model || 'z-ai/glm-5.2' }}
+        run: |
+          set -euo pipefail
+          "$CURIE_BIN" cluster up \
+            --chart charts/curie \
+            --dev \
+            --allow-egress-host openrouter \
+            --set security.gvisor.mode=off \
+            --set dispatcher.deploy=false \
+            --set worker.slackTrustedOrigins="http://${CURIE_E2E_LISTEN_HOST}:8155" \
+            --set api.image.repository=curie-api --set api.image.tag=local --set api.image.pullPolicy=Never \
+            --set worker.image.repository=curie-worker --set worker.image.tag=local --set worker.image.pullPolicy=Never \
+            --set ui.image.repository=curie-ui --set ui.image.tag=local --set ui.image.pullPolicy=Never \
+            --set agentSandbox.runner.image=curie-runner --set agentSandbox.runner.tag=latest --set agentSandbox.runner.imagePullPolicy=Never \
+            --set agentSandbox.runner.prewarm.imagePullPolicy=Never
+      # `cluster up` does not `helm --wait` (the argv stays a thin wrapper), so
+      # wait for the rollouts the round trip depends on before driving it.
+      # Langfuse and ClickHouse are intentionally NOT waited on -- a single
+      # graded turn does not need traces flushed, and they are the slowest pods
+      # to settle.
+      - name: Wait for the platform to become ready
+        run: |
+          set -euo pipefail
+          kubectl rollout status deploy/curie-api -n curie --timeout=300s
+          kubectl rollout status deploy/curie-worker -n curie --timeout=300s
+          kubectl rollout status deploy/curie-ui -n curie --timeout=300s
+          kubectl rollout status daemonset/curie-runner-prewarm -n curie --timeout=300s
       # The cluster rung only, live: `cluster status` gate -> `cluster deploy`
       # -> `cluster message` (reply asserted). The model is baked at install
       # time, but apply_model_mode still hard-exits under CURIE_E2E_LIVE if no

--- a/packages/aci-protocol/generated/rust/src/lib.rs
+++ b/packages/aci-protocol/generated/rust/src/lib.rs
@@ -423,7 +423,7 @@ mod tests {
     }
 
     #[test]
-    fn rejects_incompatible_minor() {
+    fn rejects_incompatible_near_version() {
         let raw = r#"{"type":"final","version":"0.4.0","text":"x","status":"done"}"#;
         assert!(serde_json::from_str::<OutboundEvent>(raw).is_err());
     }

--- a/packages/aci-protocol/src/aci_protocol/rust_export.py
+++ b/packages/aci-protocol/src/aci_protocol/rust_export.py
@@ -339,8 +339,8 @@ _VERSION_TESTS = """    #[test]
     }
 
     #[test]
-    fn rejects_incompatible_minor() {
-        let raw = r#"{"type":"final","version":"@INCOMPATIBLE_MINOR@","text":"x","status":"done"}"#;
+    fn rejects_incompatible_near_version() {
+        let raw = r#"{"type":"final","version":"@INCOMPATIBLE_NEAR@","text":"x","status":"done"}"#;
         assert!(serde_json::from_str::<OutboundEvent>(raw).is_err());
     }
 
@@ -363,16 +363,19 @@ def _version_tests() -> str:
     """Render the version-gate tests with fixtures derived from PROTOCOL_VERSION.
 
     Compatibility is same ``major.minor`` under 0.x (same ``major`` from 1.0 on),
-    so the compatible fixture differs only in the patch component and the
-    incompatible one bumps the minor. ``9.9.9`` stands in for a version from a
-    wholly different line. Deterministic: every fixture is a pure function of
-    PROTOCOL_VERSION.
+    so the compatible fixture differs only in the patch component. The near-miss
+    incompatible fixture follows the same split: under 0.x a minor bump is the
+    breaking axis, so it is ``{major}.{minor + 1}.0``; from 1.0 on a minor bump
+    is compatible and only a major bump breaks, so it is ``{major + 1}.0.0``.
+    ``9.9.9`` stands in for a version from a wholly different line.
+    Deterministic: every fixture is a pure function of PROTOCOL_VERSION.
     """
 
     major, minor, patch = (int(part) for part in PROTOCOL_VERSION.split("."))
+    near_incompatible = f"{major}.{minor + 1}.0" if major == 0 else f"{major + 1}.0.0"
     return (
         _VERSION_TESTS.replace("@INCOMPATIBLE@", "9.9.9")
-        .replace("@INCOMPATIBLE_MINOR@", f"{major}.{minor + 1}.0")
+        .replace("@INCOMPATIBLE_NEAR@", near_incompatible)
         .replace("@COMPATIBLE_PATCH@", f"{major}.{minor}.{patch + 1}")
         .replace("@CURRENT@", PROTOCOL_VERSION)
     )


### PR DESCRIPTION
Two commits that were pushed to the #1459 branch after #1514 was merged, so they never landed on next.

- Derive the generated Rust near-miss version fixture from the compatibility class (major bump once the protocol reaches 1.0), from the cross-engine review of the consolidation diff; mutation-proofed at a simulated 1.2.0, behavior at 0.3.0 unchanged.
- Trust the reply stub origin in the CI cluster installs: resolve the kind gateway before curie cluster up and pass worker.slackTrustedOrigins with the stub origin, in ci.yaml and the nightly graded ladder. This fixes the one red check on #1514 (the cluster rung timed out because the fail-closed worker refused the untrusted stub). The chart default stays empty.

Ref #1459