### PR TITLE
Draft ADR-0105: an approver is an authenticated principal, never a caller-asserted string

### DIFF
--- a/docs/adr/0106-an-approver-is-an-authenticated-principal.md
+++ b/docs/adr/0106-an-approver-is-an-authenticated-principal.md
@@ -1,0 +1,273 @@
+# 106. An approver is an authenticated principal, never a caller-asserted string
+
+Date: 2026-08-14
+
+Status: Draft
+
+Raised by [#1531](https://github.com/curie-eng/curie/issues/1531) (findings 1
+and 2) and by the 2026-08-14 comment on
+[#1495](https://github.com/curie-eng/curie/issues/1495).
+
+Extends [ADR 0010](0010-approval-gates-and-human-in-the-loop.md) and
+[ADR 0034](0034-approval-authorizers-resolve-membership-in-the-api.md) on the
+one axis neither of them settles. ADR 0010 decided **where** the approval
+decision runs (server side, at resolution time). ADR 0034 decided **which set**
+answers "is this actor a member". Neither decides **what an actor is**, and the
+whole authorizer stands on that unanswered question.
+
+Consumes the canonical principal that
+[Discussion 1049](https://github.com/curie-eng/curie/discussions/1049)
+establishes and that [ADR 0088](0088-per-user-delegated-oauth-for-mcp.md)
+already depends on. Closes the residual
+[ADR 0033](0033-scoped-sandbox-state-token.md) named and
+deferred.
+
+## Context
+
+Three callers reach `POST /approvals/{id}/resolve` today, and **all three put
+the approver's name in the request body**:
+
+| Caller | What it sends as `resolved_by` | What authenticates the call |
+|---|---|---|
+| Slack card click (dispatcher) | `body["user"]["id"]` from the interaction payload (`approval_actions.py:617`, `:802`) | the shared platform API key |
+| Console (`RealApprovals.tsx:139-149`) | a free text box, remembered in the browser | the shared platform API key |
+| `curie cluster approvals --resolve ID --as NAME` (`cli/src/main.rs:1122`, `:1138`) | whatever the operator typed | the shared platform API key |
+
+The wire contract makes it explicit. `ApprovalResolve` is
+`resolved_by: str = Field(min_length=1)` plus an optional `actor_channel`
+(`apps/api/src/curie_api/schemas.py:663-674`), and the router is guarded by
+`require_api_key` and nothing else. Its own module docstring states the position
+without hedging (`apps/api/src/curie_api/routers/approvals.py:10-13`):
+
+> Authorization today is the shared API key, like every router. WHO may resolve
+> (channel membership, self-approval block) is the server-side authorizer of
+> #246 and slots in at this endpoint.
+
+So does the authorizer, which has carried the honest limit in its docstring
+since #420 (`apps/api/src/curie_api/authorizer.py:31-32`):
+
+> One honest limit on that evidence: it proves the ASSERTED identity satisfied
+> policy at click time, not who actually clicked (the ADR-0033 residual, tracked
+> separately).
+
+Everything downstream of that string is built well and rests on nothing. The
+authorizer refuses self-approval, resolves membership through a fail closed
+`ApproverSet`, and writes an append only audit row snapshotting the actor, the
+channel, the authorizer that decided, and the membership evidence
+(`apps/api/src/curie_api/models.py:221-251`). The name in every one of those
+`actor` columns is a value the caller chose. The resume turn then feeds the same
+string back into the agent's prompt as the authority for continuing
+(`apps/api/src/curie_api/resumequeue.py:134-138`), so an asserted identity is
+not only stored, it is model visible.
+
+Only one of the three callers has any authentication behind the name at all.
+The dispatcher runs in Socket Mode, where interactions arrive over Slack's own
+authenticated websocket (`apps/dispatcher/src/curie_dispatcher/app.py:24-27`),
+so Slack really did authenticate the click and the dispatcher really is relaying
+a proven user id. But the API cannot tell that relayed id apart from a typed
+one, because both arrive as the same field on the same credential. **The one
+trustworthy path is indistinguishable from the two untrustworthy ones.**
+
+ADR 0033 is often read as having closed this. It did not. It removed the
+sandbox's copy of the resolve capable platform key, which stopped an agent
+approving its own gate. It left untouched the fact that **any** holder of that
+key, which today includes the dispatcher, the CLI, the console's backend, and
+every operator, can name any approver they like. ADR 0033 said so and deferred
+it; this ADR is that deferral coming due.
+
+### Why now: the gate started blocking real writes
+
+The 2026-08-14 comment on #1495 reports the connector gate fix validated end to
+end on a single node k3s cluster: deploy validation accepts
+`mcp__<connector>__<tool>` gates, the runtime gate fires on the live tool call,
+a durable approval is created, and the one shot grant executes exactly once. The
+full write loop ran twice, and the write in question was **a deployment restart
+behind a human approval**. Before that fix, gates on connector tools armed
+nothing (the manifest path failed open) or bricked the agent (the operator
+path), so the audit trail recorded very little of consequence. It now records
+who authorized a production change, and it records it as a string someone typed.
+
+### The single operator dead end
+
+#1531 finding 1 reports the other end of the same defect. Self-approval is
+blocked structurally and deliberately: the actor who authored the turn may not
+resolve it, whatever channel they click from, under every approver set, and no
+set is ever asked (`authorizer.py`, the AC2 design). That is correct. But in a
+workspace where the requester is the only human in the channel, **no card can
+ever be approved and there is no override**. Single operator is the common dev
+and homelab shape, so the write path is unusable there out of the box.
+
+The two findings are one defect seen from opposite ends. The reporter got past
+the dead end in every approval of that test by resolving through the CLI as a
+second actor. There was no second actor. The assertion hole is the only reason
+the dead end has a workaround, and using the workaround is precisely what turns
+the audit trail into a record of what someone typed. **Fixing either one alone
+makes the other worse**: close the assertion hole and the dead end becomes a
+hard stop, relieve the dead end with an override and the trail stops meaning
+anything at all.
+
+### What this ADR does not decide
+
+#1531 finding 3 (the resolve hint prints the stub channel `C0LOCALDEV` instead
+of the route's bound channel) is a bug, not an identity decision, and stays in
+#1531. The undocumented rule that two `grantableViaPolicy` gates cannot share
+one route is a docs note, likewise. Neither is settled here.
+
+## Decision
+
+**An approver is a principal the platform authenticated. `resolved_by` stops
+being an input and becomes a value the server derives from the credential that
+made the call.**
+
+Three principal kinds, one per caller class, each with its own proof:
+
+1. **`chat`.** The dispatcher is a **trusted attester**, not an asserter. It
+   authenticates with its own credential carrying the claim "may attest chat
+   identities for workspace W", and the Slack user id it relays is accepted as
+   an attested identity because the platform knows which component attested it
+   and what that component is entitled to attest. This is the path that already
+   works; the change is that the API can now tell it apart from the others.
+2. **`console`.** The console session (#630, and the CLI minted login codes
+   proposed in PR #1029) already knows who is logged in. The "who is resolving
+   this approval" text box is **deleted**, and the session subject becomes the
+   approver.
+3. **`operator`.** `--as` on the shared platform key is **removed**. The
+   platform key is a machine credential, and a machine is not an approver. An
+   operator who resolves from a terminal presents a per operator credential:
+   a signed principal token minted exactly the way ADR 0033 mints the sandbox
+   state token (HMAC SHA256 over `api_key`, compact self describing claims,
+   here `sub`, `scope: approve`, `exp`), so this needs no new shared secret, no
+   new config plumbing, and no principal table to start.
+
+The platform key alone resolves nothing. That is the load bearing half of this
+decision: today it resolves anything, as anyone.
+
+**`actor_channel` follows the same rule, or the hole simply moves.** It is
+membership evidence, so an asserted channel defeats a channel bound approver set
+just as an asserted name defeats the self-approval block. A `chat` principal's
+channel is attested by the dispatcher alongside its user id. An `operator`
+principal **asserts no channel at all** and is authorized only by appearing in a
+route's explicit approver list (`ExplicitUsers`, ADR 0034), never by claiming to
+stand in a channel it cannot be seen in.
+
+**The audit row records the proof, not only the actor.** Two columns:
+`principal_kind` (`chat` / `console` / `operator`) and `authenticated: bool`.
+Rows written before this decision migrate as `authenticated: false` with a null
+kind. They are not retro-labeled as anything, because what they actually record
+is an assertion and the trail should keep saying so.
+
+### The single operator dead end is made loud, not opened
+
+**A two party gate cannot be satisfied by one human, and this ADR does not
+pretend otherwise.** No self-approval override flag, no "solo mode" that lets an
+author resolve their own request. What changes is that the platform stops
+accepting a gate it can never satisfy:
+
+- **Arming fails at arm time**, with a named reason, when a route's approver set
+  can resolve to no principal other than the agent's own requesters. Today the
+  gate arms cleanly and every card it produces is stranded, which is the worst
+  available ordering: the operator learns the gate is unusable only after a real
+  turn is suspended behind it.
+- **The refusal names the two real answers**: remove the gate, or add a second
+  principal. Under this decision "add a second principal" is a genuine, cheap
+  option (mint a second operator credential for a colleague) rather than the
+  fiction of typing a different name.
+- **A solo operator who holds both a `chat` and an `operator` credential is
+  still one human**, and where the platform knows two principals map to the same
+  person it must treat them as the same actor for the self-approval check.
+  Where it cannot know, the pair of audit rows (`chat` author, `operator`
+  resolver, both authenticated) at least records what happened truthfully, which
+  is strictly more than today's single fabricated name.
+
+## Consequences
+
+**The audit trail becomes answerable.** "Who approved the restart" gets an
+answer with a proof attached, which is the property #1495's now working write
+loop needs and does not have.
+
+**Every resolve caller changes, so this cannot land as one patch.** The wire
+contract moves (`resolved_by` leaves `ApprovalResolve`), which is a stop and
+escalate contract change under `AGENTS.md` and lands on its own before the
+dependent lanes. Then the dispatcher credential, the console session subject,
+and the CLI credential, in that order. The API must accept both shapes only for
+the length of that sequence and not one release longer; a permanent dual mode
+here is the compatibility path that keeps the hole open behind a green gate.
+
+**`curie cluster approvals --resolve --as` breaks for existing operators.**
+Deliberate. It is the exact affordance #1531 finding 2 reports, and preserving
+it under any name preserves the finding. The replacement (mint an operator
+credential once, then resolve without naming yourself) is a strictly smaller
+thing to type.
+
+**Solo installs get a worse first run and an honest one.** A dev who arms a gate
+in a one person workspace now gets a refusal at arm time instead of a card that
+looks approvable. That is a real regression in the demo path and it is the
+correct one: the alternative is a demo that works because the audit trail is
+fiction. The onboarding docs and `curie init` templates should stop arming a
+gate by default on the solo tier.
+
+**Skill tier is unaffected and stays unaffected.** ADR 0077 already holds that
+durable approvals are unavailable there, so there is no principal to invent for
+a tier that has no approvals.
+
+**This is one principal, not a second one.** Discussion 1049 needs a canonical
+caller identity for invocation authorization, and ADR 0088 consumes that same
+principal to select a delegated MCP credential. Approvals reaching it first is
+sequencing, not a parallel identity system. If approvals instead invented an
+approver specific identity, 1049 would arrive later and have to reconcile two.
+
+**Not decided here: where principals come from at enterprise scale.** The signed
+token above is deliberately the ADR 0033 shape, which needs no storage and no
+lookup. An IdP issued principal (Discussion 1049's requirement 2) replaces the
+minting without changing anything this ADR decides, because what this ADR
+decides is that the server derives the approver from a credential. Which
+credential is a later ADR.
+
+## Alternatives considered
+
+**Chat is the only approver, and non chat callers lose the ability to resolve.**
+The tempting minimal answer: Slack already authenticates the click, so make the
+card the only trustworthy resolution and delete `--as` with no replacement.
+Rejected. It buys the trail with no token machinery at all, but it makes Slack a
+hard dependency of the write path for every install, strands the console
+entirely, leaves the single operator dead end permanently unrecoverable with no
+non chat recourse, and hands the same gap to the first party email channel work
+(#1515) on arrival. Curie's channel port exists precisely so the platform does
+not fuse a capability to one provider, and fusing the approval identity to Slack
+would put the fusion back one layer down.
+
+**Keep assertion, and document it (status quo, made explicit).** Write down that
+the audit trail records an assertion, keep `--as`, and rely on operational
+control of the platform key. Rejected. It costs nothing and it is at least
+honest, but it is honest about a control that does not control anything: one key
+is held by the worker, the dispatcher, the CLI, and every operator, so **no**
+audit row is attributable to a human, and a compromised dispatcher approves as
+anyone. #1531 shows the further problem with documenting it: the workaround is
+so natural that the reporter used it for every approval in the test without
+treating it as a compromise. An approval gate whose trail cannot be trusted is a
+compliance artifact, not a control, and it is worse than no gate because it
+reads as one.
+
+**Add a self-approval override for single operator installs.** A flag, or a
+"solo" install posture, letting the author resolve their own request. Rejected,
+and this is the alternative most likely to be proposed again, because it fixes
+the reported symptom in about ten lines. It is the assertion hole with a nicer
+name: it makes the two party property configurable by the party it constrains,
+and the installs that would enable it are exactly the ones whose operators later
+grow a team and forget it is on. ADR 0034 already refused to let a set skip the
+self-approval check, on the grounds that a convention is not a mechanism; a flag
+is a convention with a config key.
+
+**Bind approvers to Slack identity in the API and drop the concept of a
+principal.** Store Slack user ids as the identity type and have the API verify
+them against the workspace directly. Rejected as the same fusion as the first
+alternative, one layer deeper, and it also puts a Slack Web API call on the
+resolve path that ADR 0034 deliberately kept behind an `ApproverSet` port with
+its connection pool discipline.
+
+**Do nothing until Discussion 1049 lands.** Defensible on sequencing, and
+rejected on exposure. 1049 is scoped to invocation authorization and explicitly
+leaves downstream delegation out; it has no dated plan, while the connector gate
+fix in #1495 means approvals are gating real infrastructure writes now. The
+principal shape decided here is a subset of what 1049 needs, so this is early
+delivery of that work on the path where the exposure is, not a competing design.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -135,5 +135,6 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0103 | [Previous schema shape gate](0103-previous-schema-shape-gate.md) | Accepted |
 | 0104 | [A named security posture is computed from the layers that exist, never configured](0104-a-named-security-posture-is-computed-not-configured.md) | Accepted |
 | 0105 | [External native session checkpoints are a harness capability](0105-external-native-session-checkpoints.md) | Draft |
+| 0106 | [An approver is an authenticated principal, never a caller-asserted string](0106-an-approver-is-an-authenticated-principal.md) | Draft |
 | 0107 | [An agent reads its own runs through a first-party surface, scoped by structured identity](0107-an-agent-reads-its-own-runs-through-a-first-party-scoped-surface.md) | Draft |
 <!-- END GENERATED: adr-index -->


### PR DESCRIPTION
Draft ADR only, no implementation code. Base is `main` per the release train table: this is a decision record shared by both lines, not v0.7 feature work.

## What it decides

Answers the question #1531 finding 2 asks explicitly: what is an approver principal, a Slack member authenticated by the card click, an API key holder asserted via `--as`, or a first class principal.

Recommends the third: the server derives `resolved_by` from the credential that made the call, with three principal kinds (`chat` attested by the dispatcher, `console` from the session subject, `operator` from a per operator signed token in the ADR-0033 shape). `actor_channel` is held to the same rule so the hole does not just move to the membership evidence. The audit row gains `principal_kind` and `authenticated`.

## Evidence

- **#1531** findings 1 and 2: the single operator workspace dead end (self-approval blocked, no override, write path unusable out of the box) and CLI approver identity asserted rather than authenticated. The ADR argues these are one defect seen from opposite ends: the assertion hole is the only reason the dead end has a workaround, and using that workaround is what makes the audit trail untrustworthy.
- **The 2026-08-14 comment on #1495**: with the connector gate fix validated end to end, the full write loop ran twice behind a human approval (a deployment restart). That is why the trail is now load bearing.
- Grounded in file:line evidence from `routers/approvals.py`, `schemas.py`, `authorizer.py`, `models.py`, `resumequeue.py`, `approval_actions.py`, `app.py`, `RealApprovals.tsx`, and `cli/src/main.rs`.

## Alternatives weighed

Chat only (Slack as sole approver), documented status quo, a self-approval override flag for solo installs, binding approvers to Slack identity in the API, and waiting for Discussion 1049. Each with its consequences and why it is rejected. The ADR explicitly rejects an override flag and instead makes the dead end fail loudly at arm time.

## Scoped out

#1531 finding 3 (resolve hint prints the stub channel) and the undocumented two-`grantableViaPolicy`-gates-per-route rule are a bug and a docs note, and stay in #1531.

`scripts/check-docs.sh` passes; the regenerated `docs/adr/README.md` is committed.

Refs #1531, #1495