### PR TITLE
Wire worker to chart API service

### DIFF
--- a/charts/curie/ci/connector-reconciler-rbac-assertions.sh
+++ b/charts/curie/ci/connector-reconciler-rbac-assertions.sh
@@ -28,9 +28,11 @@
 #       module's docstring claims this file enforces that; this is the claim.
 #   (f) Nothing the reconciler grants is cluster-scoped, and it never mentions
 #       pods.
-#   (g) The RBAC and the worker's env are switched by the SAME flag. Half the
-#       pair is the worst outcome: the grant without the env is unused
-#       authority, and the env without the grant is a loop that 403s forever.
+#   (g) The reconciler's RBAC and API key are switched by the same flag. A
+#       grant without matching reconciler env is unused authority, and a
+#       credential without matching grant loops on authorization failure. The
+#       worker API URL is intentionally present in both states because worker
+#       API calls do not depend on reconciliation.
 #   (h) The reconciler is pointed at the namespace and release the worker
 #       already tells the runner about, so the Service it creates is the one the
 #       agent dials.
@@ -167,14 +169,17 @@ if grep -q "pods" <<<"$ENABLED_RULES"; then
   fail f "the connector Role mentions pods; it manages objects, never pods directly"
 fi
 
-# (g) The RBAC and the env are switched by the SAME flag. Half of the pair is
-#     the worst outcome: the grant without the env is unused authority, and the
-#     env without the grant is a loop that 403s every pass forever.
-for required in CURIE_CONNECTOR_RECONCILE CURIE_CONNECTOR_APP_NAME CURIE_API_URL CURIE_API_KEY; do
+# (g) The connector gate keeps the extra authority and API credential together.
+# A grant without matching reconciler env is unused authority, and a credential
+# without matching grant loops on authorization failure. The API URL is always
+# present because worker API calls do not depend on reconciliation.
+for required in CURIE_CONNECTOR_RECONCILE CURIE_CONNECTOR_APP_NAME CURIE_API_KEY; do
   grep -q "$required" <<<"$ENABLED" || fail g "enabling the reconciler did not render $required"
   grep -q "$required" <<<"$DISABLED" &&
     fail g "$required renders with the reconciler disabled; the env gate is not working"
 done
+grep -q "CURIE_API_URL" <<<"$ENABLED" || fail g "enabled render is missing CURIE_API_URL"
+grep -q "CURIE_API_URL" <<<"$DISABLED" || fail g "disabled render is missing CURIE_API_URL"
 
 # (h) The worker reconciles the namespace and release it already tells the
 #     runner about. Two settings could disagree, and the symptom would be a

--- a/charts/curie/ci/render-assertions.sh
+++ b/charts/curie/ci/render-assertions.sh
@@ -579,5 +579,81 @@ if check_github_token_empty "$GHT_MUTANT_RENDER" "mutant (githubToken via curie.
 fi
 echo "  ok: a generated githubToken is rejected (the assert can fail)"
 
+echo "=== Assertion 12: worker API URL wiring (#1529) ==="
+WORKER_API_CHECK="$TMP/check_worker_api_url.py"
+cat > "$WORKER_API_CHECK" <<'PYEOF'
+import sys
+
+import yaml
+
+manifest, expected = sys.argv[1:]
+docs = [doc for doc in yaml.safe_load_all(open(manifest)) if doc]
+workers = [
+    doc
+    for doc in docs
+    if doc.get("kind") == "Deployment"
+    and doc.get("metadata", {}).get("labels", {}).get("app.kubernetes.io/component") == "worker"
+]
+if len(workers) != 1:
+    raise SystemExit(f"expected one worker Deployment, found {len(workers)}")
+
+containers = workers[0]["spec"]["template"]["spec"].get("containers", [])
+if len(containers) != 1 or containers[0].get("name") != "worker":
+    raise SystemExit("expected one worker container")
+
+entries = [
+    entry
+    for entry in containers[0].get("env", [])
+    if entry.get("name") == "CURIE_API_URL"
+]
+if len(entries) != 1:
+    raise SystemExit(f"CURIE_API_URL appears {len(entries)} times")
+if entries[0].get("value") != expected:
+    raise SystemExit(
+        f"CURIE_API_URL is {entries[0].get('value')!r}, expected {expected!r}"
+    )
+PYEOF
+
+assert_worker_api_url() {
+  local name="$1" release="$2" expected="$3"
+  shift 3
+  local out="$TMP/worker_api_url_$name"
+  mkdir -p "$out"
+  helm template "$release" "$CHART" --output-dir "$out" "$@" >/dev/null
+  local manifest="$out/curie/templates/worker.yaml"
+  [[ -f "$manifest" ]] || fail "$name: worker.yaml did not render"
+  local error
+  if ! error="$(python3 "$WORKER_API_CHECK" "$manifest" "$expected" 2>&1)"; then
+    fail "$name: $error"
+  fi
+}
+
+assert_worker_api_url default curie http://curie-api:8000
+assert_worker_api_url release other http://other-curie-api:8000
+assert_worker_api_url port curie http://curie-api:9999 --set api.service.port=9999
+
+WORKER_API_BYO="$TMP/worker_api_byo.yaml"
+cat > "$WORKER_API_BYO" <<'EOF'
+api:
+  deploy: false
+dispatcher:
+  apiBaseUrl: https://byo-api.example
+EOF
+assert_worker_api_url byo curie https://byo-api.example -f "$WORKER_API_BYO"
+
+WORKER_API_OVERRIDE="$TMP/worker_api_override.yaml"
+cat > "$WORKER_API_OVERRIDE" <<'EOF'
+dispatcher:
+  apiBaseUrl: https://byo-api.example
+worker:
+  connectorReconciler:
+    enabled: true
+  extraEnv:
+    - name: CURIE_API_URL
+      value: http://operator.example:9000
+EOF
+assert_worker_api_url override curie http://operator.example:9000 -f "$WORKER_API_OVERRIDE"
+echo "  ok: default, release name, configured port, BYO API, and operator override render one worker API URL"
+
 echo
-echo "PASS: sealed render generates strong values for all 9 keys (encryptionKey 64-hex); dev overlay keeps published defaults; explicit override wins on the sealed path; every runner boot-env name is a declared contract key (proven by a failing negative control); every control-plane pod, the agent-sandbox controller, and the sandbox render with the expected priorityClassName, including under operator override; the runner SandboxTemplate opts the controller out of its own permissive NetworkPolicy whenever Rail 1 is on, and leaves it to the controller's default when Rail 1 is off; and api.githubToken stays a plain pass-through (empty renders empty, an explicit value renders verbatim, and it is never generated), proven by a failing negative control."
+echo "PASS: sealed render generates strong values for all 9 keys (encryptionKey 64-hex); dev overlay keeps published defaults; explicit override wins on the sealed path; every runner boot-env name is a declared contract key (proven by a failing negative control); every control-plane pod, the agent-sandbox controller, and the sandbox render with the expected priorityClassName, including under operator override; the runner SandboxTemplate opts the controller out of its own permissive NetworkPolicy whenever Rail 1 is on, and leaves it to the controller's default when Rail 1 is off; api.githubToken stays a plain pass-through (empty renders empty, an explicit value renders verbatim, and it is never generated), proven by a failing negative control; and the worker renders exactly one API URL in the default, release name, configured port, BYO API, and operator override cases."

--- a/charts/curie/templates/_helpers.tpl
+++ b/charts/curie/templates/_helpers.tpl
@@ -333,13 +333,16 @@ service:
       key: valkeyPassword
 {{- end -}}
 
-{{/* Platform-API connection env for the first-party services that CALL the API
-     (today the dispatcher; the chart worker's identical gap is a tracked
-     follow-up). Exists as a helper for the same reason curie.env.postgres and
-     curie.env.valkey do: the API URL env has now been forgotten three
-     times on new callers, while the store envs never recurred, because those had
-     a helper to include and this did not. Wire a new API caller by including
-     this rather than re-deriving the URL inline.
+{{/* Platform API connection env for first party services that call the API.
+     Keep the URL and key as separate helpers so callers can include only the
+     credentials they need. The composed helper preserves the existing
+     dispatcher contract.
+
+     The API URL env has been forgotten three times on new callers because
+     those callers had a shared helper to include and the worker did not.
+     New API callers should include the granular URL helper rather than derive
+     the URL inline. This follows the same shared helper pattern as
+     `curie.env.postgres` and `curie.env.valkey`.
 
      The BYO override is .Values.dispatcher.apiBaseUrl. Note the deliberate
      absence of a `required` call for the api.deploy=false case that the sibling
@@ -347,7 +350,7 @@ service:
      CrashLoopBackOff by design (documented in NOTES.txt and the README), not a
      render-time failure. Include with `nindent 12` to land at a container's env
      column. */}}
-{{- define "curie.env.api" -}}
+{{- define "curie.env.apiUrl" -}}
 # Where the platform API lives. The dispatcher POSTs an approval
 # resolve here when someone clicks Approve in Slack, so an unwired
 # value means the click dead-ends: the code default
@@ -358,6 +361,9 @@ service:
 # api.service.port so the two sides cannot drift.
 - name: CURIE_API_URL
   value: {{ .Values.dispatcher.apiBaseUrl | default (printf "http://%s-api:%v" (include "curie.fullname" .) .Values.api.service.port) | quote }}
+{{- end -}}
+
+{{- define "curie.env.apiKey" -}}
 # The same chart Secret key api.yaml consumes as API_KEY, so the
 # caller and the API cannot drift apart. By reference only: an inline
 # value would put the shared platform key into `helm get manifest`
@@ -367,6 +373,11 @@ service:
     secretKeyRef:
       name: {{ include "curie.secretName" . }}
       key: apiKey
+{{- end -}}
+
+{{- define "curie.env.api" -}}
+{{- include "curie.env.apiUrl" . }}
+{{ include "curie.env.apiKey" . }}
 {{- end -}}
 
 {{/* Heartbeat exec probes for the worker and dispatcher. Neither has an HTTP

--- a/charts/curie/templates/worker.yaml
+++ b/charts/curie/templates/worker.yaml
@@ -107,6 +107,12 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- $hasWorkerApiUrl := false }}
+      {{- range .Values.worker.extraEnv }}
+      {{- if eq .name "CURIE_API_URL" }}
+      {{- $hasWorkerApiUrl = true }}
+      {{- end }}
+      {{- end }}
       containers:
         - name: worker
           image: {{ include "curie.image" (dict "repository" .Values.worker.image.repository "tag" .Values.worker.image.tag "digest" .Values.worker.image.digest "defaultTag" .Chart.AppVersion) | quote }}
@@ -117,6 +123,9 @@ spec:
           env:
             {{- include "curie.env.postgres" . | nindent 12 }}
             {{- include "curie.env.valkey" . | nindent 12 }}
+            {{- if not $hasWorkerApiUrl }}
+            {{- include "curie.env.apiUrl" . | nindent 12 }}
+            {{- end }}
             - name: SLACK_BOT_TOKEN
               valueFrom:
                 secretKeyRef:
@@ -163,11 +172,10 @@ spec:
             - name: CURIE_CONNECTOR_RECONCILE_INTERVAL_S
               value: {{ .Values.worker.connectorReconciler.intervalSeconds | quote }}
             # The reconciler fetches rendered objects from the API rather than
-            # re-deriving them (ADR-0090), so it needs to reach it. Included only
-            # on this branch: wiring it unconditionally would also switch on the
-            # worker's eval reporting, which is unwired today, and that is a
-            # behaviour change this flag did not ask for.
-            {{- include "curie.env.api" . | nindent 12 }}
+            # deriving them again (ADR-0090), so it needs the API key. The general
+            # worker API URL is rendered separately without making this key
+            # unconditional.
+            {{- include "curie.env.apiKey" . | nindent 12 }}
 {{- end }}
             - name: CURIE_WARM_POOL
               value: {{ $warmPool | quote }}


### PR DESCRIPTION
## Summary

Templates CURIE_API_URL into the worker Deployment from the shared API service helper.

Preserves external API and worker.extraEnv override behavior without duplicate entries.

Adds chart assertions for default, custom port, release name, external API, and operator override renders.

Closes #1529