### PR TITLE
Recognize connectors.yaml servers in approval gate naming

### DIFF
--- a/apps/api/src/curie_api/bundles.py
+++ b/apps/api/src/curie_api/bundles.py
@@ -26,9 +26,9 @@ from plugin_format import (
     safe_extract,
     validate_bundle,
 )
-from plugin_format.connectors import ConnectorsFile, validate_connectors
+from plugin_format.connectors import CONNECTORS_FILE, ConnectorsFile, validate_connectors
 from plugin_format.deploy_targets import DeployTargetsFile, validate_deploy_targets
-from plugin_format.validate import CONNECTORS_FILE, DEPLOY_FILE
+from plugin_format.validate import DEPLOY_FILE
 
 # Re-exported so existing catchers (gitflow.py, routers/bundles.py, tests) keep
 # resolving ``bundles.UnsupportedArchive`` after the extraction logic moved to

--- a/packages/plugin-format/src/plugin_format/__init__.py
+++ b/packages/plugin-format/src/plugin_format/__init__.py
@@ -7,6 +7,8 @@ escalates to the orchestrator.
 """
 
 from .approval_policy import (
+    connector_server_names,
+    connector_tool_prefix,
     declared_mcp_server_names,
     effective_operator_gate,
     grantable_routes,
@@ -56,6 +58,8 @@ __all__ = [
     "ApprovalGate",
     "grantable_routes",
     "declared_mcp_server_names",
+    "connector_server_names",
+    "connector_tool_prefix",
     "effective_operator_gate",
     "validate_bundle",
     "ValidationResult",

--- a/packages/plugin-format/src/plugin_format/approval_policy.py
+++ b/packages/plugin-format/src/plugin_format/approval_policy.py
@@ -17,8 +17,10 @@ import json
 from collections.abc import Callable
 from pathlib import Path
 
+import yaml
 from pydantic import ValidationError
 
+from .connectors import CONNECTORS_FILE, validate_connectors
 from .manifest import resolve_manifest
 from .models import ApprovalGate, McpConfig, PluginManifest
 
@@ -84,6 +86,25 @@ def effective_tool_prefix(bundle_name: str, server: str) -> str:
     """
 
     return f"mcp__plugin_{bundle_name}_{server}__"
+
+
+def connector_tool_prefix(server: str) -> str:
+    """The live tool-name prefix a ``connectors.yaml`` server produces (#1495).
+
+    A connector is NOT a plugin-loaded MCP server. The runner mounts it directly
+    on ``ClaudeAgentOptions.mcp_servers`` (``curie_runner.connectors``,
+    ADR-0086), on the same channel as Curie's own platform servers ``curie`` and
+    ``curie-state``, so the SDK names its tools ``mcp__<server>__<tool>`` with NO
+    ``plugin_<bundle>_`` infix -- exactly like
+    ``approval.APPROVAL_TOOL_NAME``. Giving connectors the plugin prefix would
+    arm a literal the runtime never produces: a gate that validates green and
+    silently never fires, the #453 fail-open shape.
+
+    One definition, shared by the deploy validator and the runtime loader, for
+    the same anti-drift reason as ``effective_tool_prefix``.
+    """
+
+    return f"mcp__{server}__"
 
 
 def _longest_matching_server(
@@ -179,8 +200,50 @@ def declared_mcp_server_names(root: str | Path) -> set[str] | None:
     return servers
 
 
+def connector_server_names(root: str | Path) -> set[str] | None:
+    """The MCP server names the bundle's ``connectors.yaml`` supplies, or ``None`` (#1495).
+
+    The THIRD source of a bundle's tool surface, alongside the manifest's inline
+    ``mcpServers`` and the root ``.mcp.json`` that ``declared_mcp_server_names``
+    reads. It is a separate function, not another branch of that one, because a
+    connector's live tool name is namespaced DIFFERENTLY
+    (``connector_tool_prefix``, no ``plugin_<bundle>_`` infix): folding the two
+    name sets together would build the wrong prefix for one of them.
+
+    Parsing goes through ``connectors.validate_connectors`` -- the same parser the
+    deploy validator and the runner's connector mount use -- so the names a gate
+    may be namespaced to are exactly the names Curie will mount.
+
+    ``None`` is the same poison value ``declared_mcp_server_names`` returns: a
+    ``connectors.yaml`` exists but could not be read or did not validate, so the
+    connector-server set is unknowable and a gate cross-check must fail closed
+    rather than assert against a partial set. ``_validate_connectors`` already
+    errors on that file, so the gate check stays silent rather than stacking a
+    second, misleading error. An empty set is the distinct fact that the bundle
+    declares no connectors.
+    """
+
+    path = Path(root) / CONNECTORS_FILE
+    if not path.is_file():
+        return set()
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, yaml.YAMLError):
+        return None
+    parsed, errors = validate_connectors(data)
+    if parsed is None or errors:
+        # A rejected connectors.yaml is never mounted, so its names are not a
+        # tool surface a gate may be namespaced to.
+        return None
+    return set(parsed.connectors)
+
+
 def effective_operator_gate(
-    bundle_name: str | None, servers: set[str] | None, name: str
+    bundle_name: str | None,
+    servers: set[str] | None,
+    name: str,
+    *,
+    connector_servers: set[str] | None,
 ) -> str | None:
     """Map an operator gate name to its effective runtime tool name (#703).
 
@@ -197,6 +260,11 @@ def effective_operator_gate(
       ``mcp__foo__bar__do`` as server ``foo``); the longest matching server name
       wins when one is a prefix of another. The effective prefix is built exactly
       as ``validate.py`` constructs ``expected_prefixes``;
+    - ``name`` verbatim for an ``mcp__<connector>__<tool>`` naming a connector the
+      bundle declares in ``connectors.yaml`` (#1495). A connector rides the SDK's
+      ``mcp_servers`` map directly, so that shorthand IS already the live runtime
+      name: it is verified against the declared connectors and returned unchanged,
+      never rewritten to the plugin form the runtime never produces;
     - ``name`` verbatim only for a built-in with no ``mcp__`` prefix (armed by raw
       name), OR for an already ``mcp__plugin_``-prefixed name that MATCHES an
       expected prefix ``mcp__plugin_<bundle>_<server>__`` for a declared server
@@ -205,9 +273,10 @@ def effective_operator_gate(
       (a typo'd ``mcp__plugin_wrongbundle_wrongserver__tool`` would arm a literal the
       runtime never matches, a fail-open);
     - ``None`` when ``name`` is ``mcp__``-shaped and cannot be verified against a
-      declared server: an undeclared server, no declared servers, ``servers is
-      None`` or a falsy ``bundle_name`` (cannot construct the prefix to verify), an
-      empty tool remainder, or an already-prefixed name matching no expected
+      declared server or connector: an undeclared server, no declared servers,
+      ``servers`` or ``connector_servers`` being ``None`` (unknowable), a falsy
+      ``bundle_name`` (cannot construct the plugin prefix to verify), an empty tool
+      remainder, or an already-prefixed name matching no expected
       prefix. The operator override is never deploy-validated, so this runtime
       check is its sole defense -- "cannot verify" fails CLOSED, not through. The
       caller fails closed on ``None``.
@@ -217,11 +286,22 @@ def effective_operator_gate(
     # name, never rewritten and never server-checked.
     if not name.startswith("mcp__"):
         return name
-    # Every mcp__-shaped name is verified against the declared-server set. Without
-    # it (unreadable declaration, or no bundle name to build the prefix) nothing can
-    # be verified, so fail closed -- this runtime check is the operator override's
-    # only defense.
-    if servers is None or not bundle_name:
+    # Every mcp__-shaped name is verified against the declared-server sets. Without
+    # them (an unreadable MCP or connectors declaration) nothing can be verified, so
+    # fail closed -- this runtime check is the operator override's only defense.
+    if servers is None or connector_servers is None:
+        return None
+    # A connectors.yaml server is mounted straight onto the SDK's mcp_servers map
+    # (ADR-0086), so mcp__<connector>__<tool> is ALREADY the live runtime name.
+    # Checked BEFORE the plugin branch: a connector may legally be named `plugin`,
+    # and its mcp__plugin__<tool> would otherwise fall into the plugin branch and be
+    # rejected. The reverse cannot happen -- a connector name is an RFC 1123 label,
+    # so it never contains the `_` that mcp__plugin_<bundle>_<server>__ requires.
+    if _longest_matching_server(name, connector_servers, connector_tool_prefix) is not None:
+        return name
+    # The plugin form needs the bundle name to construct the prefix to verify
+    # against; without it nothing can be verified, so fail closed.
+    if not bundle_name:
         return None
     # Already the effective plugin-namespaced form: verify it matches an expected
     # prefix mcp__plugin_<bundle>_<server>__ for a declared server (with a non-empty

--- a/packages/plugin-format/src/plugin_format/connectors.py
+++ b/packages/plugin-format/src/plugin_format/connectors.py
@@ -32,6 +32,11 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
 
+# The file this module parses. Defined here, with the parser, so every reader
+# (the deploy validator, the approval-policy gate-name derivation, the API's
+# bundle reader) names one constant rather than its own copy of the string.
+CONNECTORS_FILE = "connectors.yaml"
+
 # A connector name becomes a Kubernetes object name and a DNS label, so it is
 # held to the stricter of those: lowercase alphanumeric and dashes, starting and
 # ending alphanumeric. Rejecting here beats a confusing apply-time failure.

--- a/packages/plugin-format/src/plugin_format/validate.py
+++ b/packages/plugin-format/src/plugin_format/validate.py
@@ -13,8 +13,14 @@ from typing import Any
 import yaml
 from pydantic import BaseModel, TypeAdapter, ValidationError
 
-from .approval_policy import declared_mcp_server_names, effective_tool_prefix, grantable_routes
-from .connectors import ConnectorsFile, validate_connectors
+from .approval_policy import (
+    connector_server_names,
+    connector_tool_prefix,
+    declared_mcp_server_names,
+    effective_tool_prefix,
+    grantable_routes,
+)
+from .connectors import CONNECTORS_FILE, ConnectorsFile, validate_connectors
 from .deploy_targets import validate_deploy_targets
 from .manifest import resolve_manifest
 from .models import (
@@ -80,7 +86,7 @@ def validate_bundle(path: str | Path) -> ValidationResult:
         mcp_servers = _validate_mcp(root, manifest, c)
         _validate_hooks(root, manifest, c)
         _validate_triggers(manifest, c)
-        _validate_approval_policy(manifest, mcp_servers, c)
+        _validate_approval_policy(manifest, mcp_servers, connector_server_names(root), c)
         _validate_secrets(manifest, c)
         _validate_scripts(root, c)
         _validate_connectors(root, c)
@@ -89,7 +95,6 @@ def validate_bundle(path: str | Path) -> ValidationResult:
     return c.result()
 
 
-CONNECTORS_FILE = "connectors.yaml"
 DEPLOY_FILE = "deploy.yaml"
 
 
@@ -425,7 +430,10 @@ def _validate_triggers(manifest: PluginManifest, c: _Collector) -> None:
 
 
 def _validate_approval_policy(
-    manifest: PluginManifest, mcp_servers: set[str] | None, c: _Collector
+    manifest: PluginManifest,
+    mcp_servers: set[str] | None,
+    connector_servers: set[str] | None,
+    c: _Collector,
 ) -> None:
     """Validate the manifest ``approvalPolicy`` declaration (deploy-time, #273).
 
@@ -441,6 +449,17 @@ def _validate_approval_policy(
     reject it here. ``None`` means the MCP declaration could not be read, so the
     cross-check stays silent rather than stacking a misleading error on top of the
     MCP error that already fired.
+
+    ``connector_servers`` is the ``connectors.yaml`` half of the same tool surface
+    (#1495). A connector is mounted on the SDK's ``mcp_servers`` map rather than
+    loaded as a plugin, so its live tool name is ``mcp__<connector>__<tool>`` with
+    NO ``plugin_<bundle>_`` infix -- a DIFFERENT namespacing rule, which is why the
+    two sets stay separate and each builds its own prefix
+    (``connector_tool_prefix`` vs ``effective_tool_prefix``). Without this source a
+    bundle that declares its whole tool surface through ``connectors.yaml`` has an
+    empty accepted set, so every gate it could write is rejected here and no
+    connector tool can be gated at all. ``None`` carries the same
+    read-it-or-stay-silent meaning as ``mcp_servers``.
     """
 
     declared = manifest.approvalPolicy
@@ -465,9 +484,15 @@ def _validate_approval_policy(
     # parsing the gate to extract a server name: a bundle name cannot contain '_'
     # (_NAME_RE) but a server key can, so parsing mcp__plugin_a_b_c__t is
     # ambiguous. Constructing and testing startswith sidesteps that entirely.
+    # Each source contributes its OWN prefix form: a plugin-loaded server gets
+    # mcp__plugin_<bundle>_<server>__, a connectors.yaml server gets the bare
+    # mcp__<connector>__ the SDK produces for a directly-mounted server (#1495).
+    # A single unreadable source makes the accepted set unknowable, so either
+    # being None suppresses the check rather than asserting against half of it.
     expected_prefixes: set[str] | None = (
         {effective_tool_prefix(manifest.name, s) for s in mcp_servers}
-        if mcp_servers is not None
+        | {connector_tool_prefix(s) for s in connector_servers}
+        if mcp_servers is not None and connector_servers is not None
         else None
     )
 
@@ -499,7 +524,12 @@ def _validate_approval_policy(
         ):
             c.error(
                 "approval_policy.gate_not_namespaced",
-                _gate_not_namespaced_message(stripped_gate, manifest.name, mcp_servers or set()),
+                _gate_not_namespaced_message(
+                    stripped_gate,
+                    manifest.name,
+                    mcp_servers or set(),
+                    connector_servers or set(),
+                ),
                 loc,
             )
 
@@ -520,18 +550,25 @@ def _validate_approval_policy(
         )
 
 
-def _gate_not_namespaced_message(gate: str, bundle: str, mcp_servers: set[str]) -> str:
+def _gate_not_namespaced_message(
+    gate: str, bundle: str, mcp_servers: set[str], connector_servers: set[str]
+) -> str:
     """Actionable message for a gate whose mcp__ name is not a live tool name."""
 
-    if mcp_servers:
-        declared = "Expected one of: " + ", ".join(
-            sorted(f"{effective_tool_prefix(bundle, s)}<tool>" for s in mcp_servers)
-        )
+    expected = sorted(
+        [f"{effective_tool_prefix(bundle, s)}<tool>" for s in mcp_servers]
+        + [f"{connector_tool_prefix(s)}<tool>" for s in connector_servers]
+    )
+    if expected:
+        declared = "Expected one of: " + ", ".join(expected)
     else:
-        declared = "This bundle declares no MCP servers"
+        declared = f"This bundle declares no MCP servers and no {CONNECTORS_FILE} connectors"
     return (
         f"approval gate {gate!r} is not a live MCP tool name. A bundle-declared "
-        f"MCP tool's live name is mcp__plugin_{bundle}_<server>__<tool>. "
+        f"MCP tool's live name is mcp__plugin_{bundle}_<server>__<tool>. A "
+        f"{CONNECTORS_FILE} connector is mounted directly instead of loaded as a "
+        "plugin, so ITS live name is mcp__<connector>__<tool>, with no "
+        f"plugin_{bundle}_ infix. "
         f"{declared}. A built-in tool gate (e.g. Bash) carries no mcp__ prefix. "
         "A MANIFEST approvalPolicy gate must be the fully-namespaced live name "
         "(this deploy gate does not normalize it). The per-agent "

--- a/packages/plugin-format/tests/test_effective_operator_gate.py
+++ b/packages/plugin-format/tests/test_effective_operator_gate.py
@@ -1,30 +1,43 @@
 """Unit table for the shared operator-gate normalization helpers (#703).
 
-``effective_operator_gate(bundle_name, servers, name)`` maps an operator-supplied
+``effective_operator_gate(bundle_name, servers, name, connector_servers=...)`` maps
+an operator-supplied
 ``CURIE_APPROVAL_REQUIRED_TOOLS`` name to the effective runtime tool name the SDK
 plugin-prefixes a bundle MCP tool to, returning the rewritten effective name, the
-name verbatim when it needs no rewrite (a built-in or an already-effective name),
-or ``None`` when it is an unresolvable ``mcp__`` shorthand (the caller fails
+name verbatim when it needs no rewrite (a built-in, an already-effective name, or a
+``connectors.yaml`` connector tool), or ``None`` when it is an unresolvable
+``mcp__`` shorthand (the caller fails
 closed). ``declared_mcp_server_names(root)`` reads the bundle's declared MCP server
 names (inline manifest ``mcpServers`` + root ``.mcp.json``) with the same
-poison-to-``None`` semantics as ``validate._validate_mcp``.
+poison-to-``None`` semantics as ``validate._validate_mcp``;
+``connector_server_names(root)`` reads the ``connectors.yaml`` half with the same
+semantics (#1495).
 
 The ``mcp__plugin_<bundle>_<server>__`` prefix is the exact shape the deploy
 validator asserts (validate.py:
     ``expected_prefixes = {f"mcp__plugin_{manifest.name}_{s}__" for s in mcp_servers}``
 ), so this helper and the validator normalize identically by construction (#453).
+The connector half asserts the OTHER prefix, the bare ``mcp__<connector>__``, since
+the runner mounts a connector on ``ClaudeAgentOptions.mcp_servers`` instead of
+loading it as a plugin.
 """
 
 import json
 
-from plugin_format import declared_mcp_server_names, effective_operator_gate
+from plugin_format import (
+    connector_server_names,
+    declared_mcp_server_names,
+    effective_operator_gate,
+)
 
 # --- effective_operator_gate: shorthand -> effective / verbatim / None -----------
 
 
 def test_shorthand_for_declared_server_maps_to_effective_name() -> None:
     assert (
-        effective_operator_gate("b", {"github"}, "mcp__github__update_issue")
+        effective_operator_gate(
+            "b", {"github"}, "mcp__github__update_issue", connector_servers=set()
+        )
         == "mcp__plugin_b_github__update_issue"
     )
 
@@ -32,20 +45,23 @@ def test_shorthand_for_declared_server_maps_to_effective_name() -> None:
 def test_builtin_name_passes_verbatim() -> None:
     # No mcp__ prefix -> a built-in, armed by raw name; never rewritten, even when
     # the bundle declares servers.
-    assert effective_operator_gate("b", {"github"}, "Bash") == "Bash"
+    assert effective_operator_gate("b", {"github"}, "Bash", connector_servers=set()) == "Bash"
 
 
 def test_already_effective_name_passes_verbatim() -> None:
     # Already mcp__plugin_-prefixed -> passed through unchanged (the suffix is
     # unknowable without running the server, mirroring validate.py).
     name = "mcp__plugin_b_github__update_issue"
-    assert effective_operator_gate("b", {"github"}, name) == name
+    assert effective_operator_gate("b", {"github"}, name, connector_servers=set()) == name
 
 
 def test_shorthand_for_undeclared_server_is_unresolvable() -> None:
     # mcp__-shaped, names a server the bundle does not declare, not already
     # mcp__plugin_-prefixed -> unresolvable; the caller fails closed.
-    assert effective_operator_gate("b", {"github"}, "mcp__slack__post") is None
+    assert (
+        effective_operator_gate("b", {"github"}, "mcp__slack__post", connector_servers=set())
+        is None
+    )
 
 
 def test_shorthand_for_server_name_containing_double_underscore() -> None:
@@ -55,7 +71,7 @@ def test_shorthand_for_server_name_containing_double_underscore() -> None:
     # mcp__foo__bar__do splits to server "foo" (undeclared) and fails a valid
     # bundle closed. The server is foo__bar, the tool is do.
     assert (
-        effective_operator_gate("b", {"foo__bar"}, "mcp__foo__bar__do")
+        effective_operator_gate("b", {"foo__bar"}, "mcp__foo__bar__do", connector_servers=set())
         == "mcp__plugin_b_foo__bar__do"
     )
 
@@ -66,7 +82,9 @@ def test_shorthand_prefers_longest_matching_server_name() -> None:
     # mcp__foo__bar__do resolves to server foo__bar (tool do), not foo (tool
     # bar__do).
     assert (
-        effective_operator_gate("b", {"foo", "foo__bar"}, "mcp__foo__bar__do")
+        effective_operator_gate(
+            "b", {"foo", "foo__bar"}, "mcp__foo__bar__do", connector_servers=set()
+        )
         == "mcp__plugin_b_foo__bar__do"
     )
 
@@ -78,18 +96,26 @@ def test_already_prefixed_name_for_undeclared_prefix_fails_closed() -> None:
     # expected_prefixes check. A typo'd wrongbundle/wrongserver name arms a literal
     # the runtime never matches -> fail OPEN; this must fail CLOSED (None).
     assert (
-        effective_operator_gate("b", {"github"}, "mcp__plugin_wrongbundle_wrongserver__tool")
+        effective_operator_gate(
+            "b", {"github"}, "mcp__plugin_wrongbundle_wrongserver__tool", connector_servers=set()
+        )
         is None
     )
 
 
 def test_already_prefixed_name_with_empty_tool_suffix_fails_closed() -> None:
     # The bare expected prefix with no tool suffix arms nothing -> fail closed.
-    assert effective_operator_gate("b", {"github"}, "mcp__plugin_b_github__") is None
+    assert (
+        effective_operator_gate("b", {"github"}, "mcp__plugin_b_github__", connector_servers=set())
+        is None
+    )
 
 
 def test_shorthand_with_no_declared_servers_is_unresolvable() -> None:
-    assert effective_operator_gate("b", set(), "mcp__github__update_issue") is None
+    assert (
+        effective_operator_gate("b", set(), "mcp__github__update_issue", connector_servers=set())
+        is None
+    )
 
 
 def test_poisoned_servers_fail_mcp_names_closed_but_pass_builtins_verbatim() -> None:
@@ -99,17 +125,35 @@ def test_poisoned_servers_fail_mcp_names_closed_but_pass_builtins_verbatim() -> 
     # cross-check is the sole defense for the never-deploy-validated operator
     # override, so "cannot verify" must fail closed, not pass through. Only a
     # built-in (no mcp__ prefix, no server lookup) still passes verbatim.
-    assert effective_operator_gate("b", None, "mcp__github__update_issue") is None
-    assert effective_operator_gate("b", None, "mcp__plugin_b_github__update_issue") is None
-    assert effective_operator_gate("b", None, "Bash") == "Bash"
+    assert (
+        effective_operator_gate("b", None, "mcp__github__update_issue", connector_servers=set())
+        is None
+    )
+    assert (
+        effective_operator_gate(
+            "b", None, "mcp__plugin_b_github__update_issue", connector_servers=set()
+        )
+        is None
+    )
+    assert effective_operator_gate("b", None, "Bash", connector_servers=set()) == "Bash"
 
 
 def test_falsy_bundle_name_fails_mcp_names_closed() -> None:
     # No bundle name means the effective prefix cannot be constructed to verify an
     # mcp__ name -> fail closed. Built-ins still pass verbatim.
-    assert effective_operator_gate("", {"github"}, "mcp__github__update_issue") is None
-    assert effective_operator_gate("", {"github"}, "mcp__plugin_b_github__update_issue") is None
-    assert effective_operator_gate("", {"github"}, "Bash") == "Bash"
+    assert (
+        effective_operator_gate(
+            "", {"github"}, "mcp__github__update_issue", connector_servers=set()
+        )
+        is None
+    )
+    assert (
+        effective_operator_gate(
+            "", {"github"}, "mcp__plugin_b_github__update_issue", connector_servers=set()
+        )
+        is None
+    )
+    assert effective_operator_gate("", {"github"}, "Bash", connector_servers=set()) == "Bash"
 
 
 # --- declared_mcp_server_names: inline manifest + root .mcp.json, poison -> None --
@@ -162,3 +206,114 @@ def test_declared_names_poison_to_none_on_non_utf8_manifest(tmp_path) -> None:
     (tmp_path / ".claude-plugin").mkdir()
     (tmp_path / ".claude-plugin" / "plugin.json").write_bytes(b"\xff\xfe\x00")
     assert declared_mcp_server_names(tmp_path) is None
+
+
+# --- connectors.yaml servers: the OTHER namespacing rule (#1495) -----------------
+#
+# A connector is mounted straight onto ClaudeAgentOptions.mcp_servers, so its live
+# tool name is the bare mcp__<connector>__<tool> -- the same shape Curie's own
+# `curie` approval server gets, and NOT the mcp__plugin_<bundle>_<server>__<tool>
+# a plugin-loaded server gets. Rewriting a connector gate to the plugin form would
+# arm a literal the runtime never produces: green at deploy, silently never fires.
+
+
+def test_connector_shorthand_passes_verbatim_not_plugin_prefixed() -> None:
+    # The load-bearing case: already the live name, so it is returned UNCHANGED.
+    name = "mcp__kubernetes-admin__resources_create_or_update"
+    assert effective_operator_gate("b", set(), name, connector_servers={"kubernetes-admin"}) == name
+
+
+def test_connector_gate_is_not_rewritten_even_when_bundle_declares_mcp_servers() -> None:
+    # A bundle with both surfaces must namespace each by its own rule: the plugin
+    # server is rewritten, the connector is not.
+    assert (
+        effective_operator_gate(
+            "b", {"github"}, "mcp__github__update_issue", connector_servers={"grafana"}
+        )
+        == "mcp__plugin_b_github__update_issue"
+    )
+    assert (
+        effective_operator_gate(
+            "b", {"github"}, "mcp__grafana__query", connector_servers={"grafana"}
+        )
+        == "mcp__grafana__query"
+    )
+
+
+def test_undeclared_connector_still_fails_closed() -> None:
+    assert (
+        effective_operator_gate("b", set(), "mcp__ghost__x", connector_servers={"grafana"}) is None
+    )
+
+
+def test_connector_shorthand_with_empty_tool_remainder_fails_closed() -> None:
+    # The bare prefix arms nothing, exactly as for the plugin form.
+    assert (
+        effective_operator_gate("b", set(), "mcp__grafana__", connector_servers={"grafana"}) is None
+    )
+
+
+def test_poisoned_connector_set_fails_mcp_names_closed() -> None:
+    # connector_servers=None is the unreadable-connectors.yaml poison: an mcp__
+    # name cannot be verified against the full accepted set, so it fails CLOSED
+    # even when it would have matched a declared plugin server. Built-ins still
+    # pass verbatim.
+    assert (
+        effective_operator_gate(
+            "b", {"github"}, "mcp__github__update_issue", connector_servers=None
+        )
+        is None
+    )
+    assert effective_operator_gate("b", {"github"}, "Bash", connector_servers=None) == "Bash"
+
+
+def test_connector_named_plugin_is_matched_before_the_plugin_branch() -> None:
+    # `plugin` is a legal RFC 1123 connector name, so mcp__plugin__<tool> is a
+    # legitimate connector tool name. It must not fall into the mcp__plugin_
+    # branch and be rejected.
+    assert (
+        effective_operator_gate("b", set(), "mcp__plugin__do", connector_servers={"plugin"})
+        == "mcp__plugin__do"
+    )
+
+
+# --- connector_server_names: read connectors.yaml, poison to None ----------------
+
+
+def _connectors(tmp_path, text: str):
+    (tmp_path / ".claude-plugin").mkdir()
+    (tmp_path / ".claude-plugin" / "plugin.json").write_text(
+        json.dumps({"name": "b"}), encoding="utf-8"
+    )
+    (tmp_path / "connectors.yaml").write_text(text, encoding="utf-8")
+    return tmp_path
+
+
+def test_connector_names_read_from_connectors_yaml(tmp_path) -> None:
+    root = _connectors(
+        tmp_path,
+        "connectors:\n"
+        "  kubernetes-admin:\n"
+        "    image: ghcr.io/example/k8s-mcp:1.0.0\n"
+        "  grafana:\n"
+        "    url: https://mcp.internal/mcp\n",
+    )
+    assert connector_server_names(root) == {"kubernetes-admin", "grafana"}
+
+
+def test_connector_names_empty_when_no_connectors_yaml(tmp_path) -> None:
+    # The distinct fact "read and named nothing", not the unknowable poison: a
+    # bundle with no connectors must still have its plugin-server gates checked.
+    assert connector_server_names(tmp_path) == set()
+
+
+def test_connector_names_poison_to_none_on_unparseable_yaml(tmp_path) -> None:
+    root = _connectors(tmp_path, "connectors: [oops\n")
+    assert connector_server_names(root) is None
+
+
+def test_connector_names_poison_to_none_on_invalid_connectors(tmp_path) -> None:
+    # A connector that does not validate is never mounted, so its name is not a
+    # tool surface a gate may be namespaced to: unknowable, not empty.
+    root = _connectors(tmp_path, "connectors:\n  Bad_Name:\n    url: https://x/mcp\n")
+    assert connector_server_names(root) is None

--- a/packages/plugin-format/tests/test_validate.py
+++ b/packages/plugin-format/tests/test_validate.py
@@ -735,3 +735,107 @@ def test_confusable_key_alongside_allowed_tools_validates_clean(tmp_path: Path, 
 
     result = validate_bundle(bundle)
     assert result.valid, result.errors
+
+
+# --- a gate may name a connectors.yaml connector's tool (#1495) -----------------
+#
+# A bundle that declares its tool surface through connectors.yaml has no
+# mcpServers and no .mcp.json, so before #1495 the accepted-name set was empty and
+# EVERY gate it could write was rejected as not-namespaced: a connector tool could
+# not be gated at all. The connector's live name is the bare
+# mcp__<connector>__<tool> (it rides ClaudeAgentOptions.mcp_servers, not the plugin
+# loader), so that -- and NOT the plugin form -- is what validates.
+
+
+def _write_connectors(bundle: Path, text: str) -> Path:
+    path = bundle / "connectors.yaml"
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def test_gate_naming_a_connectors_yaml_server_passes(tmp_path: Path) -> None:
+    bundle = _bundle(
+        tmp_path,
+        '{"name": "demo", "approvalPolicy": {"gates": ['
+        '{"gate": "mcp__kubernetes-admin__resources_create_or_update", '
+        '"route": "sre-oncall"}]}}',
+    )
+    _write_connectors(
+        bundle,
+        "connectors:\n  kubernetes-admin:\n    image: ghcr.io/example/k8s-mcp:1.0.0\n",
+    )
+
+    result = validate_bundle(bundle)
+    assert result.valid, result.errors
+
+
+def test_connector_gate_in_the_plugin_form_is_rejected(tmp_path: Path) -> None:
+    # The inverse of the case above, and the reason the two sources cannot share
+    # one prefix: a connector is NOT plugin-namespaced at runtime, so the plugin
+    # form arms a literal the SDK never produces -- green deploy, silent no-op.
+    bundle = _bundle(
+        tmp_path,
+        '{"name": "demo", "approvalPolicy": {"gates": ['
+        '{"gate": "mcp__plugin_demo_kubernetes-admin__resources_create_or_update", '
+        '"route": "sre-oncall"}]}}',
+    )
+    _write_connectors(
+        bundle,
+        "connectors:\n  kubernetes-admin:\n    image: ghcr.io/example/k8s-mcp:1.0.0\n",
+    )
+
+    assert _GATE_CODE in _codes(bundle)
+
+
+def test_gate_naming_an_undeclared_connector_is_still_rejected(tmp_path: Path) -> None:
+    # The new source widens the accepted set, it does not open it: a server named
+    # by neither connectors.yaml nor the MCP config is still not namespaced.
+    bundle = _bundle(
+        tmp_path,
+        '{"name": "demo", "approvalPolicy": {"gates": ['
+        '{"gate": "mcp__ghost__resources_create_or_update", "route": "sre-oncall"}]}}',
+    )
+    _write_connectors(
+        bundle,
+        "connectors:\n  kubernetes-admin:\n    image: ghcr.io/example/k8s-mcp:1.0.0\n",
+    )
+
+    result = validate_bundle(bundle)
+    assert not result.valid
+    messages = _gate_errors(bundle)
+    assert len(messages) == 1, result.errors
+    # Actionable: it names the connector form the author should have used.
+    assert "mcp__kubernetes-admin__<tool>" in messages[0]
+
+
+def test_both_surfaces_each_validate_under_their_own_prefix(tmp_path: Path) -> None:
+    # A bundle with an MCP server AND a connector: each gate must use ITS source's
+    # namespacing rule, and crossing them fails.
+    bundle = _bundle(
+        tmp_path,
+        '{"name": "demo", "mcpServers": {"crm": {"command": "crm-server"}}, '
+        '"approvalPolicy": {"gates": ['
+        '{"gate": "mcp__plugin_demo_crm__send_contract", "route": "legal"}, '
+        '{"gate": "mcp__grafana__query", "route": "sre-oncall"}]}}',
+    )
+    _write_connectors(bundle, "connectors:\n  grafana:\n    url: https://mcp.internal/mcp\n")
+
+    result = validate_bundle(bundle)
+    assert result.valid, result.errors
+
+
+def test_gate_check_stays_silent_when_connectors_yaml_is_unreadable(tmp_path: Path) -> None:
+    # An unparseable connectors.yaml makes the accepted set unknowable. The file
+    # error already fires; the gate check must not stack a second, misleading error
+    # telling the author their correct gate names an undeclared server.
+    bundle = _bundle(
+        tmp_path,
+        '{"name": "demo", "approvalPolicy": {"gates": ['
+        '{"gate": "mcp__kubernetes-admin__resources_create_or_update", '
+        '"route": "sre-oncall"}]}}',
+    )
+    _write_connectors(bundle, "connectors: [oops\n")
+
+    codes = _codes(bundle)
+    assert "connectors.unreadable" in codes
+    assert _GATE_CODE not in codes

--- a/runner/src/curie_runner/__main__.py
+++ b/runner/src/curie_runner/__main__.py
@@ -164,9 +164,14 @@ def build_runner(
             grant_tool=config.approval_grant_tool,
             grantable_by_route=resolution.grantable_by_route,
             # Bundle identity so an operator mcp__<server>__<tool> shorthand
-            # normalizes to its effective plugin-prefixed runtime name (#703).
+            # normalizes to its effective plugin-prefixed runtime name (#703),
+            # and the connectors.yaml servers so a gate on a connector tool --
+            # whose live name is the bare mcp__<connector>__<tool> the SDK gives
+            # a directly-mounted server -- verifies instead of failing closed
+            # (#1495).
             bundle_name=resolution.bundle_name,
             mcp_servers=resolution.mcp_servers,
+            connector_servers=resolution.connector_servers,
         )
     except ApprovalPolicyError as exc:
         # Log then re-raise, matching the module's other two fatal boot paths

--- a/runner/src/curie_runner/approval.py
+++ b/runner/src/curie_runner/approval.py
@@ -48,6 +48,7 @@ from claude_agent_sdk.types import (
 from plugin_format import (
     ApprovalPolicy,
     PluginManifest,
+    connector_server_names,
     declared_mcp_server_names,
     effective_operator_gate,
     grantable_routes,
@@ -613,12 +614,19 @@ class ApprovalPolicyResolution:
     ``mcp_servers`` is ``None`` when the declared-server set is unknowable (the
     ``declared_mcp_server_names`` poison), which fails an ``mcp__`` shorthand
     closed. Both are ``None`` when there is no bundle/manifest to read.
+
+    ``connector_servers`` is the ``connectors.yaml`` half of the same tool surface
+    (#1495), carried separately because a connector's live tool name is
+    ``mcp__<connector>__<tool>`` -- the bare form, since the runner mounts it on
+    ``ClaudeAgentOptions.mcp_servers`` rather than loading it as a plugin. Same
+    ``None`` poison meaning.
     """
 
     route_by_tool: dict[str, str]
     grantable_by_route: dict[str, str]
     bundle_name: str | None = None
     mcp_servers: set[str] | None = None
+    connector_servers: set[str] | None = None
 
 
 def resolve_approval_policy(plugin_dir: str | None) -> ApprovalPolicyResolution:
@@ -676,9 +684,14 @@ def resolve_approval_policy(plugin_dir: str | None) -> ApprovalPolicyResolution:
     name = raw.get("name") if isinstance(raw, dict) else None
     bundle_name = name if isinstance(name, str) else None
     mcp_servers = declared_mcp_server_names(root)
+    connectors = connector_server_names(root)
     if not isinstance(raw, dict) or raw.get("approvalPolicy") is None:
         return ApprovalPolicyResolution(
-            {}, {}, bundle_name=bundle_name, mcp_servers=mcp_servers
+            {},
+            {},
+            bundle_name=bundle_name,
+            mcp_servers=mcp_servers,
+            connector_servers=connectors,
         )
     # An approvalPolicy IS declared. From here every failure is fail-closed:
     # the intent is established and a parse error cannot revoke it.
@@ -713,7 +726,11 @@ def resolve_approval_policy(plugin_dir: str | None) -> ApprovalPolicyResolution:
     # it, so this is belt-and-braces, not the enforcement point.
     grantable_by_route, _ambiguous = grantable_routes(policy.gates)
     return ApprovalPolicyResolution(
-        routes, grantable_by_route, bundle_name=bundle_name, mcp_servers=mcp_servers
+        routes,
+        grantable_by_route,
+        bundle_name=bundle_name,
+        mcp_servers=mcp_servers,
+        connector_servers=connectors,
     )
 
 
@@ -737,6 +754,7 @@ def build_approval_gate(
     grantable_by_route: dict[str, str] | None = None,
     bundle_name: str | None = None,
     mcp_servers: set[str] | None = None,
+    connector_servers: set[str] | None = None,
 ) -> ApprovalGate | None:
     """Merge the operator's gated tools with the bundle's declared gates.
 
@@ -784,14 +802,18 @@ def build_approval_gate(
         name = raw_name.strip()
         if not name:
             continue
-        effective = effective_operator_gate(bundle_name, mcp_servers, name)
+        effective = effective_operator_gate(
+            bundle_name, mcp_servers, name, connector_servers=connector_servers
+        )
         if effective is None:
             raise ApprovalPolicyError(
                 f"operator approval gate {name!r} names an MCP tool that cannot be"
                 " resolved to a declared bundle server; refusing to boot with a"
                 " gate that would arm nothing. Namespace it to its live"
-                " mcp__plugin_<bundle>_<server>__<tool> name, or check the bundle"
-                f" declares that server (declared servers: {mcp_servers})"
+                " mcp__plugin_<bundle>_<server>__<tool> name (or, for a"
+                " connectors.yaml connector, mcp__<connector>__<tool>), or check the"
+                f" bundle declares that server (declared MCP servers: {mcp_servers},"
+                f" declared connectors: {connector_servers})"
             )
         # A bare (non-mcp__) name is armed VERBATIM as a built-in tool name,
         # never rewritten or checked (#712): `effective_operator_gate` has no

--- a/runner/tests/test_approval.py
+++ b/runner/tests/test_approval.py
@@ -2010,6 +2010,7 @@ def test_operator_shorthand_gate_denies_the_effective_runtime_name() -> None:
             policy_routes={},
             bundle_name="b",
             mcp_servers={"github"},
+            connector_servers=set(),
         )
         assert gate is not None
         callback = build_can_use_tool(gate)
@@ -2062,6 +2063,7 @@ def test_builtin_and_already_effective_operator_gates_pass_verbatim() -> None:
             policy_routes={},
             bundle_name="b",
             mcp_servers={"github"},
+            connector_servers=set(),
         )
         assert builtin is not None
         assert isinstance(
@@ -2077,6 +2079,7 @@ def test_builtin_and_already_effective_operator_gates_pass_verbatim() -> None:
             policy_routes={},
             bundle_name="b",
             mcp_servers={"github"},
+            connector_servers=set(),
         )
         assert effective is not None
         assert isinstance(
@@ -2274,4 +2277,112 @@ def test_already_prefixed_operator_gate_naming_wrong_bundle_fails_closed() -> No
             policy_routes={},
             bundle_name="b",
             mcp_servers={"github"},
+        )
+
+
+# --- connectors.yaml tools are gateable end to end (#1495) ----------------------
+#
+# A connector rides ClaudeAgentOptions.mcp_servers (curie_runner.connectors), so
+# the SDK hands can_use_tool the bare mcp__<connector>__<tool>. The gate must arm
+# that exact literal: rewriting it to the plugin form would arm a name the SDK
+# never produces and the call would run unapproved.
+
+_K8S_TOOL = "mcp__kubernetes-admin__resources_create_or_update"
+
+
+def _connector_bundle(tmp_path, manifest: str, connectors: str) -> str:
+    plugin = tmp_path / ".claude-plugin"
+    plugin.mkdir(exist_ok=True)
+    (plugin / "plugin.json").write_text(manifest, encoding="utf-8")
+    (tmp_path / "connectors.yaml").write_text(connectors, encoding="utf-8")
+    return str(tmp_path)
+
+
+_K8S_CONNECTORS = "connectors:\n  kubernetes-admin:\n    image: ghcr.io/example/k8s-mcp:1.0.0\n"
+
+
+def test_resolution_carries_connector_server_names(tmp_path) -> None:
+    root = _connector_bundle(tmp_path, json.dumps({"name": "sre-bot"}), _K8S_CONNECTORS)
+    resolution = resolve_approval_policy(root)
+    assert resolution.connector_servers == {"kubernetes-admin"}
+
+
+def test_manifest_gate_on_a_connector_tool_denies_the_live_call(tmp_path) -> None:
+    """The end-to-end property: a manifest gate naming a connector tool blocks it.
+
+    Driven through the public can_use_tool callback with the exact name the SDK
+    emits for a directly-mounted server, not a set-membership peek.
+    """
+
+    root = _connector_bundle(
+        tmp_path,
+        json.dumps(
+            {
+                "name": "sre-bot",
+                "approvalPolicy": {"gates": [{"gate": _K8S_TOOL, "route": "sre-oncall"}]},
+            }
+        ),
+        _K8S_CONNECTORS,
+    )
+
+    async def go() -> None:
+        resolution = resolve_approval_policy(root)
+        gate = build_approval_gate(
+            operator_tools=None,
+            policy_routes=resolution.route_by_tool,
+            bundle_name=resolution.bundle_name,
+            mcp_servers=resolution.mcp_servers,
+            connector_servers=resolution.connector_servers,
+        )
+        assert gate is not None
+        result = await build_can_use_tool(gate)(
+            _K8S_TOOL, {"manifest": "..."}, ToolPermissionContext()
+        )
+        assert isinstance(result, PermissionResultDeny)
+        # And the blocked call carries the manifest route to the approving audience.
+        assert gate.route_by_tool[_K8S_TOOL] == "sre-oncall"
+
+    anyio.run(go)
+
+
+def test_operator_gate_on_a_connector_tool_arms_the_bare_name(tmp_path) -> None:
+    """The operator env-knob half: armed VERBATIM, never plugin-prefixed.
+
+    Before #1495 this raised ApprovalPolicyError (the connector is not a declared
+    MCP server), so an operator could not gate a connector tool at all. Rewriting
+    it to mcp__plugin_<bundle>_<connector>__<tool> would be worse: the gate would
+    arm green and the live call would sail through.
+    """
+
+    root = _connector_bundle(tmp_path, json.dumps({"name": "sre-bot"}), _K8S_CONNECTORS)
+
+    async def go() -> None:
+        resolution = resolve_approval_policy(root)
+        gate = build_approval_gate(
+            operator_tools=[_K8S_TOOL],
+            policy_routes={},
+            bundle_name=resolution.bundle_name,
+            mcp_servers=resolution.mcp_servers,
+            connector_servers=resolution.connector_servers,
+        )
+        assert gate is not None
+        assert gate.required == frozenset({_K8S_TOOL})
+        result = await build_can_use_tool(gate)(
+            _K8S_TOOL, {"manifest": "..."}, ToolPermissionContext()
+        )
+        assert isinstance(result, PermissionResultDeny)
+
+    anyio.run(go)
+
+
+def test_operator_gate_naming_an_undeclared_connector_still_fails_closed(tmp_path) -> None:
+    root = _connector_bundle(tmp_path, json.dumps({"name": "sre-bot"}), _K8S_CONNECTORS)
+    resolution = resolve_approval_policy(root)
+    with pytest.raises(ApprovalPolicyError):
+        build_approval_gate(
+            operator_tools=["mcp__ghost__do_it"],
+            policy_routes={},
+            bundle_name=resolution.bundle_name,
+            mcp_servers=resolution.mcp_servers,
+            connector_servers=resolution.connector_servers,
         )


### PR DESCRIPTION
`declared_mcp_server_names` sourced a bundle's MCP servers from only
`manifest.mcpServers` and `<root>/.mcp.json`. A bundle that declares its tool
surface in `connectors.yaml`, the cluster tier connector mechanism, has neither,
so the declared server set was empty for the entire approval gate name
machinery, and an approval gate could not be armed on a connector tool by any
path.

## Why the namespacing differs

A connector is not a plugin loaded MCP server. The runner mounts it directly on
`ClaudeAgentOptions.mcp_servers` (ADR-0086), on the same channel as Curie's own
platform servers, so the SDK names its tools `mcp__<connector>__<tool>` with
**no** `plugin_<bundle>_` infix. Every copy of the namespacing rule that assumes
the plugin form is therefore wrong for a connector.

Three call sites held that assumption, and they failed in different directions.

**Manifest deploy validation, fail closed.** `_validate_approval_policy` built
`expected_prefixes` from an empty server set, so the `any(...)` match could never
succeed and *every* `mcp__` gate a connectors only bundle could write was
rejected with `approval_policy.gate_not_namespaced`. Not silent, but it meant no
connector tool could be gated at all.

**The operator env knob, fail closed and fatal.** `CURIE_APPROVAL_REQUIRED_TOOLS`
naming a connector tool could not resolve against the empty declared set, so the
runner raised at boot and crash looped the pod. On an idle node the surfaced
error was a `ClaimTimeoutError`, whose text points at CPU saturation, which is
what made this expensive to diagnose.

**`cli/src/spec.rs`, fail open.** `validate_gate_namespacing` builds
`mcp__plugin_{bundle}_{server}__` **from the declared connectors**, so it accepts
a literal the runtime never produces: the gate validates green and then never
fires, and the tool runs unapproved. This is the #453 shape, and it is the fail
open that was confirmed empirically against an unpatched cluster tier build.
**This PR does not fix it** (see below).

## The fix

Union the connector server names from `connectors.yaml` into the server set that
deploy validation and the runtime gate check names against, as a **separate**
set rather than a merged one, because each source builds a different prefix:

* `connector_tool_prefix(server)` gives the bare `mcp__<server>__` the SDK
  produces for a directly mounted server, alongside the existing
  `effective_tool_prefix` for a plugin loaded one.
* `connector_server_names(root)` parses `connectors.yaml` through the same
  `validate_connectors` parser the deploy validator and the runner's connector
  mount already use, so the names a gate may be namespaced to are exactly the
  names Curie will mount.
* `effective_operator_gate` checks the connector branch **before** the plugin
  branch, so a connector legally named `plugin` is not swallowed by the plugin
  form. The reverse collision cannot happen: a connector name is an RFC 1123
  label, so it never contains the `_` that `mcp__plugin_<bundle>_<server>__`
  requires.
* The `None` poison stays distinct from the empty set in both sources. An
  unreadable or rejected declaration makes the accepted set unknowable, so the
  check fails closed rather than asserting against half a set. An empty set is
  the distinct fact that the bundle declares no connectors.
* The `gate_not_namespaced` deploy message and the runner boot error now name
  both live forms, so an operator can see which one they need.
* `CONNECTORS_FILE` moves next to its parser in `connectors.py`, so the
  validator, the approval policy, and the API bundle reader share one constant
  instead of each holding a copy. This also lets `approval_policy.py` name the
  file without importing `validate.py`.

## Known gap this leaves open

`cli/src/spec.rs` still holds the third copy of the rule and is **not** changed
here. That leaves the two validators demanding opposite forms for the same
connector gate: `spec.rs` accepts only `mcp__plugin_<bundle>_<connector>__<tool>`
and now `plugin_format` accepts only `mcp__<connector>__<tool>`, so there is no
spelling that satisfies both, and the spec path still validates green on a gate
that never fires. It is kept out of this diff to hold the change to the Python
namespacing rule, and it needs its own issue: closing #1495 on this merge does
not mean the `spec.rs` fail open is resolved. If it is preferable to keep #1495
open until `spec.rs` lands, drop the closing keyword below before merging.

## Validation

Validated end to end on a single node k3s cluster tier install with a real
model: deploy validation accepts an `mcp__<connector>__<tool>` gate, the runtime
gate fires on the live tool call, a durable approval is created, and the one shot
grant executes exactly once. The full write loop ran twice, including a
deployment restart behind a human approval, verified by reads afterwards.

Locally, `packages/plugin-format/tests runner/tests apps/api/tests
apps/worker/tests` is 2179 passed, 12 skipped, with `ruff check` and `mypy`
clean.

Closes #1495
