### PR TITLE
Tolerate a missing channel on an approval route binding

### DIFF
--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -109,6 +109,11 @@ pub struct Agent {
 /// separates.
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct ApprovalRouteBinding {
+    // The deployed API can return a route binding with no `channel` after a
+    // live rebind, which previously hard-failed every verb that lists agents.
+    // Defaulting to empty is deliberate tolerance, not the fix: the
+    // underlying API/CLI schema mismatch (#1533) is still owed.
+    #[serde(default)]
     pub channel: String,
     /// Absent means the card channel's members are the approvers, the zero-setup
     /// default. Skipped on serialize so a channel-only write sends no `approvers`


### PR DESCRIPTION
Partially addresses part 3 of #1533.

After `cluster deploy --slack-channel` binds a real channel to an approval
route, the deployed API can return an `ApprovalRouteBinding` with no `channel`
field. Every CLI verb that lists agents then died decoding it with
`missing field 'channel'`.

`#[serde(default)]` on the field restores decoding, so the verbs stay usable.

This is deliberate tolerance, not the fix. The underlying API and CLI schema
mismatch that lets the field go missing is still owed, and #1533 stays open for
it along with its other two parts (the hardcoded `<release>-api` resource name
assumption, and the fixed 8123 tunnel with no bind check or endpoint
verification).

`cargo build --release` and `cargo fmt --check` pass under `cli/`.
