### PR TITLE
Version reply handles for post once delivery

### DIFF
--- a/apps/api/alembic/versions/0025_reply_placeholder_nullable.py
+++ b/apps/api/alembic/versions/0025_reply_placeholder_nullable.py
@@ -1,0 +1,59 @@
+"""allow approvals without a reply placeholder (#1528)
+
+The worker may enqueue a final only reply target without a preposted message to
+edit. The explicit channel and endpoint still select where the reply goes, so
+the absent placeholder is durable approval state rather than a missing value.
+
+Existing placeholder strings keep their edit target unchanged. This revision
+only relaxes the column constraint and does not rewrite stored values.
+
+Revision ID: 0025
+Revises: 0024
+Create Date: 2026-08-14
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0025"
+down_revision: str | None = "0024"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+SCHEMA = "curie"
+TABLE = "approvals"
+COLUMN = "reply_placeholder"
+
+
+def upgrade() -> None:
+    op.alter_column(
+        TABLE,
+        COLUMN,
+        existing_type=sa.String(),
+        nullable=True,
+        schema=SCHEMA,
+    )
+
+
+def downgrade() -> None:
+    null_rows = op.get_bind().execute(
+        sa.text(
+            f"SELECT count(*) FROM {SCHEMA}.{TABLE} "  # noqa: S608
+            f"WHERE {COLUMN} IS NULL"  # noqa: S608
+        )
+    ).scalar_one()
+    if null_rows:
+        raise RuntimeError(
+            "cannot restore a required reply placeholder while "
+            f"{null_rows} approval rows have no placeholder"
+        )
+
+    op.alter_column(
+        TABLE,
+        COLUMN,
+        existing_type=sa.String(),
+        nullable=False,
+        schema=SCHEMA,
+    )

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -542,8 +542,15 @@
             "title": "Reply Endpoint"
           },
           "reply_placeholder": {
-            "title": "Reply Placeholder",
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reply Placeholder"
           },
           "resolution_note": {
             "anyOf": [
@@ -730,9 +737,16 @@
             "type": "string"
           },
           "reply_placeholder": {
-            "minLength": 1,
-            "title": "Reply Placeholder",
-            "type": "string"
+            "anyOf": [
+              {
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reply Placeholder"
           },
           "route": {
             "anyOf": [

--- a/apps/api/src/curie_api/models.py
+++ b/apps/api/src/curie_api/models.py
@@ -268,7 +268,7 @@ class Approval(Base):
     # because `slack` legitimately has none.
     reply_kind: Mapped[str]
     reply_channel: Mapped[str]
-    reply_placeholder: Mapped[str]
+    reply_placeholder: Mapped[str | None] = mapped_column(nullable=True)
     reply_endpoint: Mapped[str | None] = mapped_column(default=None)
     reply_adapter: Mapped[str | None] = mapped_column(default=None)
     # The approval route the request named (#247), and the channel the card

--- a/apps/api/src/curie_api/schemas.py
+++ b/apps/api/src/curie_api/schemas.py
@@ -1042,7 +1042,7 @@ class ApprovalOut(BaseModel):
     author: str
     summary: str
     reply_channel: str
-    reply_placeholder: str
+    reply_placeholder: str | None
     reply_endpoint: str | None
     dedupe_key: str
     route: str | None

--- a/apps/api/tests/test_approvals.py
+++ b/apps/api/tests/test_approvals.py
@@ -203,6 +203,23 @@ def _read_resumed_at(approval_id: str) -> datetime | None:
     return asyncio.run(_run())
 
 
+def _read_reply_placeholder(approval_id: str) -> str | None:
+    """Read the stored reply target without relying on the API response model."""
+
+    async def _run() -> str | None:
+        engine = create_async_engine(get_settings().database_url)
+        sessionmaker = async_sessionmaker(engine, expire_on_commit=False)
+        try:
+            async with sessionmaker() as session:
+                approval = await session.get(Approval, uuid.UUID(approval_id))
+                assert approval is not None
+                return approval.reply_placeholder
+        finally:
+            await engine.dispose()
+
+    return asyncio.run(_run())
+
+
 def test_resolve_endpoint_stays_200_when_enqueue_fails(
     approvals_client: TestClient,
     auth_headers: dict[str, str],
@@ -369,6 +386,7 @@ def test_create_get_list_round_trip(
         headers=auth_headers,
     )
     assert [a["id"] for a in listed.json()] == [body["id"]]
+    assert listed.json()[0]["reply_placeholder"] == payload["reply_placeholder"]
 
 
 def test_create_tolerates_unknown_field_from_a_newer_worker(
@@ -413,6 +431,47 @@ def test_create_is_idempotent_on_dedupe_key(
     replay = approvals_client.post("/approvals", json=payload, headers=auth_headers)
     assert replay.status_code == 200
     assert replay.json()["id"] == first.json()["id"]
+
+
+def test_create_round_trips_a_post_once_reply_target(
+    approvals_client: TestClient, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    """A reply without a placeholder keeps its explicit channel and endpoint."""
+
+    payload = _payload(
+        reply_channel="C_POST_ONCE",
+        reply_placeholder=None,
+        reply_endpoint="http://localhost:9999/api/",
+    )
+    created = approvals_client.post("/approvals", json=payload, headers=auth_headers)
+
+    assert created.status_code == 201, created.text
+    body = created.json()
+    assert body["reply_channel"] == payload["reply_channel"]
+    assert body["reply_placeholder"] is None
+    assert body["reply_endpoint"] == payload["reply_endpoint"]
+    assert _read_reply_placeholder(body["id"]) is None
+
+    fetched = approvals_client.get(f"/approvals/{body['id']}", headers=auth_headers)
+    assert fetched.status_code == 200, fetched.text
+    assert fetched.json()["reply_placeholder"] is None
+
+    listed = approvals_client.get(
+        "/approvals",
+        params={"status_filter": "pending", "conversation_id": payload["conversation_id"]},
+        headers=auth_headers,
+    )
+    assert [approval["id"] for approval in listed.json()] == [body["id"]]
+    assert listed.json()[0]["reply_placeholder"] is None
+
+    existing = approvals_client.post(
+        "/approvals",
+        json=_payload(reply_placeholder="p-existing"),
+        headers=auth_headers,
+    )
+    assert existing.status_code == 201, existing.text
+    assert existing.json()["reply_placeholder"] == "p-existing"
+    assert _read_reply_placeholder(existing.json()["id"]) == "p-existing"
 
 
 def test_resolve_once_and_enqueue_resume_turn(

--- a/apps/api/tests/test_migrations.py
+++ b/apps/api/tests/test_migrations.py
@@ -10,11 +10,18 @@ against the session's freshly-created, migrated disposable DB (conftest's
 """
 
 import asyncio
+import uuid
+from pathlib import Path
 
+import pytest
+from alembic import command
+from alembic.config import Config
 from curie_api.config import get_settings
 from curie_api.db import SCHEMA
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import create_async_engine
+
+ALEMBIC_DIR = Path(__file__).resolve().parents[1] / "alembic"
 
 
 def _column(sql: str) -> list[str]:
@@ -24,6 +31,73 @@ def _column(sql: str) -> list[str]:
             async with engine.connect() as conn:
                 result = await conn.execute(text(sql))
                 return [row[0] for row in result.fetchall()]
+        finally:
+            await engine.dispose()
+
+    return asyncio.run(run())
+
+
+def _insert_approval(approval_id: uuid.UUID, reply_placeholder: str | None) -> None:
+    async def run() -> None:
+        engine = create_async_engine(get_settings().database_url)
+        try:
+            async with engine.begin() as conn:
+                await conn.execute(
+                    text(
+                        "INSERT INTO curie.approvals (id, conversation_id, author, "
+                        "summary, reply_kind, reply_channel, reply_placeholder, "
+                        "dedupe_key, status) "
+                        "VALUES (:id, :conversation_id, :author, :summary, :reply_kind, "
+                        ":reply_channel, :reply_placeholder, :dedupe_key, 'pending')"
+                    ),
+                    {
+                        "id": approval_id,
+                        "conversation_id": f"th-{approval_id.hex[:8]}",
+                        "author": "U1",
+                        "summary": "Approve the change",
+                        "reply_kind": "slack",
+                        "reply_channel": "C1",
+                        "reply_placeholder": reply_placeholder,
+                        "dedupe_key": uuid.uuid4().hex,
+                    },
+                )
+        finally:
+            await engine.dispose()
+
+    asyncio.run(run())
+
+
+def _set_reply_placeholder(approval_id: uuid.UUID, placeholder: str) -> None:
+    async def run() -> None:
+        engine = create_async_engine(get_settings().database_url)
+        try:
+            async with engine.begin() as conn:
+                await conn.execute(
+                    text(
+                        "UPDATE curie.approvals SET reply_placeholder = :placeholder "
+                        "WHERE id = :id"
+                    ),
+                    {"id": approval_id, "placeholder": placeholder},
+                )
+        finally:
+            await engine.dispose()
+
+    asyncio.run(run())
+
+
+def _reply_placeholder(approval_id: uuid.UUID) -> str | None:
+    async def run() -> str | None:
+        engine = create_async_engine(get_settings().database_url)
+        try:
+            async with engine.connect() as conn:
+                result = await conn.execute(
+                    text(
+                        "SELECT reply_placeholder FROM curie.approvals WHERE id = :id"
+                    ),
+                    {"id": approval_id},
+                )
+                row = result.one()
+                return row[0]
         finally:
             await engine.dispose()
 
@@ -45,3 +119,58 @@ def test_public_schema_is_empty_after_migration(migrated: None) -> None:
         "SELECT tablename FROM pg_tables WHERE schemaname = 'public'"
     )
     assert public_tables == [], public_tables
+
+
+def test_reply_placeholder_becomes_nullable_without_rewriting_existing_strings(
+    isolated_migration_db: None,
+) -> None:
+    """The post once migration preserves old edit targets while allowing new ones."""
+
+    cfg = Config()
+    cfg.set_main_option("script_location", str(ALEMBIC_DIR))
+
+    # Target the revision immediately before this migration. A relative revision
+    # would silently stop testing this migration once a later one lands.
+    command.upgrade(cfg, "0024")
+    existing_id = uuid.uuid4()
+    _insert_approval(existing_id, "p-existing")
+
+    command.upgrade(cfg, "0025")
+
+    nullable = _column(
+        "SELECT is_nullable FROM information_schema.columns "
+        "WHERE table_schema = 'curie' AND table_name = 'approvals' "
+        "AND column_name = 'reply_placeholder'"
+    )
+    assert nullable == ["YES"], nullable
+    assert _reply_placeholder(existing_id) == "p-existing"
+
+    post_once_id = uuid.uuid4()
+    _insert_approval(post_once_id, None)
+    assert _reply_placeholder(post_once_id) is None
+
+
+def test_reply_placeholder_downgrade_refuses_null_rows(
+    isolated_migration_db: None,
+) -> None:
+    cfg = Config()
+    cfg.set_main_option("script_location", str(ALEMBIC_DIR))
+    command.upgrade(cfg, "0025")
+
+    approval_id = uuid.uuid4()
+    _insert_approval(approval_id, None)
+
+    with pytest.raises(RuntimeError, match="cannot restore a required reply placeholder"):
+        command.downgrade(cfg, "0024")
+
+    assert _reply_placeholder(approval_id) is None
+    _set_reply_placeholder(approval_id, "p-fixed")
+    command.downgrade(cfg, "0024")
+
+    nullable = _column(
+        "SELECT is_nullable FROM information_schema.columns "
+        "WHERE table_schema = 'curie' AND table_name = 'approvals' "
+        "AND column_name = 'reply_placeholder'"
+    )
+    assert nullable == ["NO"], nullable
+    assert _reply_placeholder(approval_id) == "p-fixed"

--- a/apps/api/tests/test_openapi_drift.py
+++ b/apps/api/tests/test_openapi_drift.py
@@ -1,5 +1,7 @@
 """The committed OpenAPI document must match the live app."""
 
+import json
+
 from curie_api.export_openapi import openapi_path, render_openapi
 
 
@@ -9,3 +11,14 @@ def test_committed_openapi_is_current() -> None:
         "apps/api/openapi.json is stale; run "
         "`uv run python -m curie_api.export_openapi` and commit"
     )
+
+
+def test_approval_reply_placeholder_schema_allows_null_and_string() -> None:
+    schemas = json.loads(render_openapi())["components"]["schemas"]
+
+    for name in ("ApprovalRequest", "ApprovalOut"):
+        property_schema = schemas[name]["properties"]["reply_placeholder"]
+        assert {option["type"] for option in property_schema["anyOf"]} == {
+            "null",
+            "string",
+        }

--- a/apps/api/tests/test_resume_reconciler.py
+++ b/apps/api/tests/test_resume_reconciler.py
@@ -114,6 +114,7 @@ def _detached_approval(
     resolved_by: str | None = "U9",
     reply_kind: str = "slack",
     reply_adapter: str | None = None,
+    reply_placeholder: str | None = "p-1",
 ) -> Approval:
     """An unpersisted ``Approval`` in a chosen status, for the pure-unit selector
     test: the turn builders read the record's fields only, so no DB round-trip is
@@ -135,7 +136,7 @@ def _detached_approval(
         # the right one.
         reply_kind=reply_kind,
         reply_channel="C1",
-        reply_placeholder="p-1",
+        reply_placeholder=reply_placeholder,
         reply_adapter=reply_adapter,
         dedupe_key=uuid.uuid4().hex,
         status=status,
@@ -154,6 +155,7 @@ async def _insert_approval(
     reply_kind: str = "slack",
     reply_channel: str | None = None,
     reply_adapter: str | None = None,
+    reply_placeholder: str | None = "p-1",
 ) -> uuid.UUID:
     """Insert an approval row in a chosen lifecycle state (bypassing the resolve
     endpoint), so a test can construct the exact stranded/settled/expired shapes
@@ -164,6 +166,7 @@ async def _insert_approval(
         resolved_by=resolved_by,
         reply_kind=reply_kind,
         reply_adapter=reply_adapter,
+        reply_placeholder=reply_placeholder,
     )
     approval.reply_endpoint = reply_endpoint
     if reply_channel is not None:
@@ -201,6 +204,7 @@ def test_reconciler_reenqueues_stranded_resolved_record(
             status=ApprovalStatus.approved,
             resolved_at=_naive(120),
             resumed_at=None,
+            reply_placeholder="reply placeholder",
         )
         reconciler = ResumeReconciler(
             sessionmaker,
@@ -219,7 +223,41 @@ def test_reconciler_reenqueues_stranded_resolved_record(
     assert len(entries) == 1
     turn = QueuedTurn.model_validate(json.loads(entries[0][1]["payload"]))
     assert turn.event_id == f"approval-{approval_id}-resolved"
+    assert turn.reply_handle.placeholder == "reply placeholder"
     assert resumed_at is not None
+
+
+def test_reconciler_preserves_a_post_once_reply_handle(
+    clean_db: None, valkey: redis.Redis, runs_stream: str
+) -> None:
+    """A stranded post once approval requeues without inventing a placeholder."""
+
+    async def steps(
+        sessionmaker: async_sessionmaker[AsyncSession], queue: ResumeQueue
+    ) -> tuple[uuid.UUID, int]:
+        approval_id = await _insert_approval(
+            sessionmaker,
+            status=ApprovalStatus.approved,
+            resolved_at=_naive(120),
+            resumed_at=None,
+            reply_endpoint="http://localhost:9999/api/",
+            reply_placeholder=None,
+        )
+        reconciler = ResumeReconciler(
+            sessionmaker, queue, interval_seconds=30, grace_seconds=0, batch_limit=100
+        )
+        return approval_id, await reconciler.reconcile_once()
+
+    approval_id, count = _run_async(steps, runs_stream)
+
+    assert count == 1
+    entries = valkey.xrange(runs_stream)
+    assert len(entries) == 1
+    turn = QueuedTurn.model_validate(json.loads(entries[0][1]["payload"]))
+    assert turn.event_id == f"approval-{approval_id}-resolved"
+    assert turn.reply_handle.channel == "C1"
+    assert turn.reply_handle.placeholder is None
+    assert turn.reply_handle.endpoint == "http://localhost:9999/api/"
 
 
 def test_reconciler_skips_already_resumed_record(

--- a/apps/api/tests/test_resume_turn_text.py
+++ b/apps/api/tests/test_resume_turn_text.py
@@ -30,6 +30,7 @@ def _resolved(
     resolved_by: str | None = "U_MANAGER",
     note: str | None = None,
     summary: str = "Give ACME a 20% discount",
+    reply_placeholder: str | None = "p-1",
 ) -> Approval:
     """A detached, resolved ``Approval``: only the fields the builder reads."""
 
@@ -43,7 +44,7 @@ def _resolved(
         # so every construction site has to state which channel raised the turn.
         reply_kind="slack",
         reply_channel="C1",
-        reply_placeholder="p-1",
+        reply_placeholder=reply_placeholder,
         reply_endpoint=None,
         reply_adapter=None,
         dedupe_key="ev-1",
@@ -67,6 +68,13 @@ def test_a_noted_resolution_carries_the_note_into_the_resume_turn() -> None:
     assert turn.text.startswith("[approval resolved]")
     assert '"Give ACME a 20% discount"' in turn.text
     assert "was approved by U_MANAGER" in turn.text
+
+
+def test_resume_turn_preserves_reply_placeholder_values() -> None:
+    for expected in (None, "reply placeholder"):
+        turn = build_resume_turn(_resolved(reply_placeholder=expected))
+
+        assert turn.reply_handle.placeholder == expected
 
 
 def test_a_bare_resolution_omits_the_note_clause_entirely() -> None:

--- a/apps/dispatcher/README.md
+++ b/apps/dispatcher/README.md
@@ -22,7 +22,7 @@ parenthetical is what the Slack adapter maps onto each one:
 | `conversation_id` | canonical thread/conversation key (the thread ts) |
 | `author` | who authored the message (the Slack user id) |
 | `text` | message text |
-| `reply_handle` | where the reply is delivered: a `ReplyHandle` of `channel`, `placeholder` (ts of the already-posted placeholder the worker edits in place), and an optional per-turn `endpoint` |
+| `reply_handle` | where the reply is delivered: a `ReplyHandle` of `channel`, required nullable `placeholder`, and an optional per-turn `endpoint`. The Slack adapter currently supplies the ts of its already posted placeholder. |
 | `received_at` | ISO-8601 UTC timestamp the adapter received it |
 
 The worker reconstructs it with `from_stream_fields(fields)`, a module-level

--- a/apps/ui/src/api/client.ts
+++ b/apps/ui/src/api/client.ts
@@ -715,7 +715,7 @@ export interface ApprovalOut {
   author: string;
   summary: string;
   reply_channel: string;
-  reply_placeholder: string;
+  reply_placeholder: string | null;
   reply_endpoint: string | null;
   dedupe_key: string;
   route: string | null;

--- a/apps/worker/src/curie_worker/kernel.py
+++ b/apps/worker/src/curie_worker/kernel.py
@@ -410,6 +410,8 @@ class Kernel:
         Returns normally once the event is terminally handled; the consumer then
         acks it. Raising leaves the entry pending for crash-recovery reclaim.
         """
+        self._required_placeholder(qevent)
+
         event_id = qevent.event_id
         thread = qevent.conversation_id
         target = _target_for(qevent)
@@ -1914,6 +1916,13 @@ class Kernel:
     def _backoff(self, attempt: int) -> float:
         raw: float = self._config.retry_backoff_base_s * (2 ** (attempt - 1))
         return min(self._config.retry_backoff_max_s, raw)
+
+    @staticmethod
+    def _required_placeholder(qevent: QueuedTurn) -> str:
+        placeholder = qevent.reply_handle.placeholder
+        if placeholder is None:
+            raise ValueError("reply_handle.placeholder must not be null")
+        return placeholder
 
     @staticmethod
     def _to_event(qevent: QueuedTurn) -> Event:

--- a/apps/worker/tests/kernel/test_approval_lifecycle.py
+++ b/apps/worker/tests/kernel/test_approval_lifecycle.py
@@ -34,9 +34,11 @@ class RecordingApprovals:
 
     def __init__(self, *, fail: bool = False) -> None:
         self.requests: list[ApprovalRequest] = []
+        self.create_calls = 0
         self.fail = fail
 
     async def create(self, request: ApprovalRequest) -> CreatedApproval:
+        self.create_calls += 1
         if self.fail:
             raise ApprovalBackendError("approval API unavailable")
         self.requests.append(request)
@@ -80,7 +82,7 @@ def _qevent(
     *,
     thread: str = "th-appr",
     event_id: str | None = None,
-    placeholder: str = "p-1",
+    placeholder: str | None = "p-1",
     endpoint: str | None = None,
     kind: str = "slack",
     adapter: str | None = None,
@@ -234,6 +236,31 @@ def test_a_slack_turns_record_carries_slack_and_no_adapter(make_harness) -> None
             req = approvals.requests[0]
             assert req.reply_kind == "slack"
             assert req.reply_adapter is None
+
+    asyncio.run(go())
+
+
+def test_null_placeholder_rejects_before_sink_runner_or_approval_persistence(
+    make_harness,
+) -> None:
+    async def go() -> None:
+        approvals = RecordingApprovals()
+        async with make_harness(approvals=approvals) as h:
+            h.runner.default_script = _awaiting_script("Give ACME a 20% discount")
+            event = _qevent(
+                "please discount",
+                placeholder=None,
+                endpoint="http://adapter.example.test/",
+                kind="email",
+                adapter="agentmail",
+            )
+
+            with pytest.raises(ValueError, match=r"reply_handle\.placeholder"):
+                await h.kernel.process_event(event)
+
+            assert h.runner.opened == []
+            assert h.sink.events == []
+            assert approvals.create_calls == 0
 
     asyncio.run(go())
 

--- a/apps/worker/tests/kernel/test_kernel.py
+++ b/apps/worker/tests/kernel/test_kernel.py
@@ -13,6 +13,7 @@ import time
 import uuid
 from collections.abc import Callable
 
+import pytest
 from aci_protocol import (
     ErrorEvent,
     Final,
@@ -38,7 +39,7 @@ def _qevent(
     *,
     thread: str = "th-1",
     event_id: str | None = None,
-    placeholder: str = "p-1",
+    placeholder: str | None = "p-1",
     endpoint: str | None = None,
 ) -> QueuedTurn:
     return QueuedTurn(
@@ -76,6 +77,22 @@ def test_new_turn_streams_to_slack_and_acks(make_harness) -> None:
             assert h.runner.opened == ["hi"]
             assert h.sink.last_text == "Hello world"
             assert await h.async_redis.exists(h.config.done_key(ev.event_id))
+
+    asyncio.run(go())
+
+
+def test_null_placeholder_is_rejected_before_any_sink_or_runner_call(
+    make_harness,
+) -> None:
+    async def go() -> None:
+        async with make_harness() as h:
+            event = _qevent("hi", placeholder=None)
+
+            with pytest.raises(ValueError, match=r"reply_handle\.placeholder"):
+                await h.kernel.process_event(event)
+
+            assert h.runner.opened == []
+            assert h.sink.events == []
 
     asyncio.run(go())
 

--- a/apps/worker/tests/kernel/test_mixed_version.py
+++ b/apps/worker/tests/kernel/test_mixed_version.py
@@ -1,4 +1,4 @@
-"""A 0.2.9 runner against a 0.3.0 worker fails LOUDLY.
+"""A 0.2.9 runner against a 0.4.0 worker fails LOUDLY.
 
 T-B14 (round-2 finding 4). The ACI bump is a breaking minor (D1), so a runner
 image left at ``0.2.9`` is not "mostly compatible" -- ``ndjson.py:61-68`` refuses
@@ -36,9 +36,9 @@ from curie_worker.consumer import Consumer
 
 DONE = SessionStatus.DONE
 
-# A frame stamped by a runner built at the PREVIOUS contract version, pinned as
-# a literal rather than generated, so this keeps testing the 0.2.9 -> 0.3.0 hop
-# after PROTOCOL_VERSION moves again.
+# A frame stamped by a historical runner, pinned as a literal rather than
+# generated, so this keeps testing the old contract hop after PROTOCOL_VERSION
+# moves again.
 FRAME_0_2_9 = (
     '{"version":"0.2.9","type":"final","text":"an answer from an old runner",'
     '"status":"done"}'
@@ -62,11 +62,13 @@ def _qevent(*, thread: str, event_id: str) -> QueuedTurn:
     )
 
 
-def test_the_worker_build_is_incompatible_with_the_previous_minor() -> None:
+def test_the_worker_build_rejects_historical_and_previous_deployed_minors() -> None:
     # The companion assertion (version.py:42-63). A breaking minor means the
-    # range genuinely excludes the old version -- if this ever reads True again,
-    # the bump was classed wrong and the cutover ordering rests on nothing.
-    assert PROTOCOL_VERSION == "0.3.0"
+    # range genuinely excludes both the previous deployed minor and the older
+    # historical version. If either reads True again, the bump was classed wrong
+    # and the cutover ordering rests on nothing.
+    assert PROTOCOL_VERSION == "0.4.0"
+    assert is_compatible("0.3.0", PROTOCOL_VERSION) is False
     assert is_compatible("0.2.9", PROTOCOL_VERSION) is False
 
 

--- a/cli/src/message.rs
+++ b/cli/src/message.rs
@@ -3383,7 +3383,8 @@ mod tests {
         let placeholder_ts = "1717171717.000900";
         let turn = connected_turn("C-real", &opts(Some("C-real")), None, placeholder_ts);
         assert_eq!(
-            turn.conversation_id, turn.reply_handle.placeholder,
+            turn.reply_handle.placeholder.as_deref(),
+            Some(turn.conversation_id.as_str()),
             "the connected turn must thread on the placeholder we actually posted"
         );
         assert_eq!(turn.conversation_id, placeholder_ts);
@@ -3407,7 +3408,10 @@ mod tests {
             placeholder_ts,
         );
         assert_eq!(turn.conversation_id, thread);
-        assert_eq!(turn.reply_handle.placeholder, placeholder_ts);
+        assert_eq!(
+            turn.reply_handle.placeholder.as_deref(),
+            Some(placeholder_ts)
+        );
         assert!(turn.reply_handle.endpoint.is_none());
     }
 

--- a/cli/src/queue.rs
+++ b/cli/src/queue.rs
@@ -60,7 +60,7 @@ pub fn synthetic_turn(
         reply_handle: ReplyHandle {
             kind: kind.into(),
             channel: channel.into(),
-            placeholder: placeholder.into(),
+            placeholder: Some(placeholder.into()),
             endpoint,
             // The CLI's stub keeps the Slack shape, so its route is the
             // configured `SLACK_API_BASE_URL` dev origin, not a named adapter.
@@ -458,7 +458,7 @@ mod tests {
         );
         assert!(turn.reply_handle.endpoint.is_none());
         // The placeholder is the real Slack ts we posted, not a stub-minted one.
-        assert_eq!(turn.reply_handle.placeholder, "1717.42");
+        assert_eq!(turn.reply_handle.placeholder, Some("1717.42".into()));
         let value: serde_json::Value = serde_json::from_str(&payload_json(&turn).unwrap()).unwrap();
         assert!(value["reply_handle"]["endpoint"].is_null());
         assert_eq!(value["reply_handle"]["placeholder"], "1717.42");
@@ -486,7 +486,7 @@ mod tests {
             reply_handle: ReplyHandle {
                 kind: "slack".into(),
                 channel: "C-SIM-x".into(),
-                placeholder: "1720000000.000200".into(),
+                placeholder: Some("1720000000.000200".into()),
                 endpoint: None,
                 adapter: None,
             },

--- a/cli/tests/chat_enqueue.rs
+++ b/cli/tests/chat_enqueue.rs
@@ -548,7 +548,8 @@ async fn connected_transport_enqueues_the_real_placeholder_as_the_conversation_i
          no message"
     );
     assert_eq!(
-        turn.conversation_id, turn.reply_handle.placeholder,
+        turn.reply_handle.placeholder.as_deref(),
+        Some(turn.conversation_id.as_str()),
         "the two coordinates on one turn must agree; #954 was exactly their disagreement"
     );
     assert_eq!(
@@ -595,7 +596,8 @@ async fn connected_transport_enqueues_the_real_placeholder_as_the_conversation_i
         "an explicit --thread is the conversation_id verbatim"
     );
     assert_eq!(
-        turn.reply_handle.placeholder, IN_THREAD_TS,
+        turn.reply_handle.placeholder.as_deref(),
+        Some(IN_THREAD_TS),
         "the reply handle still points at the real message Slack created inside \
          that thread, so the worker edits the right message"
     );

--- a/cli/tests/resume_wait.rs
+++ b/cli/tests/resume_wait.rs
@@ -34,7 +34,7 @@ fn resume_turn(resume_event_id: &str, endpoint: &str) -> QueuedTurn {
         reply_handle: ReplyHandle {
             kind: "slack".into(),
             channel: "C-SIM-x".into(),
-            placeholder: PLACEHOLDER_TS.into(),
+            placeholder: Some(PLACEHOLDER_TS.into()),
             endpoint: Some(endpoint.to_string()),
             adapter: None,
         },

--- a/docs/interfaces/channel-ingress/INTERFACE.md
+++ b/docs/interfaces/channel-ingress/INTERFACE.md
@@ -42,8 +42,9 @@ A second channel must produce the ingress payload and satisfy the egress Protoco
   (idempotency key), `conversation_id` (the conversation/thread key routing keeps one live
   session per), `author`, `text`, `received_at`, and `reply_handle` — a `ReplyHandle`
   (`packages/aci-protocol/src/aci_protocol/turn.py::ReplyHandle`) carrying `channel`,
-  `placeholder` (the pre-posted reply the worker edits in place), and an optional per-turn
-  `endpoint`. The dispatcher serializes it to a single Stream field via `to_stream_fields`
+  required nullable `placeholder`, and an optional per-turn `endpoint`. The Slack adapter
+  currently supplies the pre-posted reply ts that the worker edits in place. The
+  dispatcher serializes it to a single Stream field via `to_stream_fields`
   (`apps/dispatcher/src/curie_dispatcher/queue.py::to_stream_fields`), keyed by
   `STREAM_PAYLOAD_FIELD = "payload"` (`apps/dispatcher/src/curie_dispatcher/queue.py::STREAM_PAYLOAD_FIELD`).
   For the Slack adapter, `event_id` is the Slack event id, `conversation_id` is the thread

--- a/packages/aci-protocol/generated/rust/src/lib.rs
+++ b/packages/aci-protocol/generated/rust/src/lib.rs
@@ -6,7 +6,7 @@
 
 use serde::{Deserialize, Serialize};
 
-pub const PROTOCOL_VERSION: &str = "0.3.0";
+pub const PROTOCOL_VERSION: &str = "0.4.0";
 
 pub const RUNS_STREAM_DEFAULT: &str = "curie:runs";
 
@@ -59,6 +59,16 @@ where
         )));
     }
     Ok(value)
+}
+
+fn deserialize_required_nullable<'de, D, T>(
+    deserializer: D,
+) -> Result<Option<T>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    Option::<T>::deserialize(deserializer)
 }
 
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
@@ -223,7 +233,8 @@ pub mod env_keys {
 pub struct ReplyHandle {
     pub kind: String,
     pub channel: String,
-    pub placeholder: String,
+    #[serde(deserialize_with = "deserialize_required_nullable")]
+    pub placeholder: Option<String>,
     #[serde(default)]
     pub endpoint: Option<String>,
     #[serde(default)]
@@ -246,6 +257,7 @@ pub struct EvalJob {
     pub version_id: String,
     pub sha: String,
     pub suite: String,
+    #[serde(deserialize_with = "deserialize_required_nullable")]
     pub bundle_ref: Option<String>,
     #[serde(default)]
     pub target_url: Option<String>,
@@ -273,7 +285,8 @@ pub struct ApprovalRequest {
     pub summary: String,
     pub reply_kind: String,
     pub reply_channel: String,
-    pub reply_placeholder: String,
+    #[serde(deserialize_with = "deserialize_required_nullable")]
+    pub reply_placeholder: Option<String>,
     #[serde(default)]
     pub reply_endpoint: Option<String>,
     #[serde(default)]
@@ -417,6 +430,24 @@ mod tests {
     }
 
     #[test]
+    fn reply_handle_accepts_explicit_null_placeholder() {
+        let raw = r#"{"kind":"email","channel":"agent@example.test","placeholder":null,"endpoint":"https://adapter.example/hook","adapter":"agentmail_sandbox"}"#;
+        let decoded: ReplyHandle = serde_json::from_str(raw).unwrap();
+        assert_eq!(decoded.kind, "email");
+        assert_eq!(decoded.channel, "agent@example.test");
+        assert_eq!(decoded.placeholder, None);
+        assert_eq!(decoded.endpoint.as_deref(), Some("https://adapter.example/hook"));
+        assert_eq!(decoded.adapter.as_deref(), Some("agentmail_sandbox"));
+    }
+
+    #[test]
+    fn reply_handle_rejects_omitted_placeholder() {
+        let raw = r#"{"kind":"email","channel":"agent@example.test"}"#;
+        let error = serde_json::from_str::<ReplyHandle>(raw).unwrap_err();
+        assert!(error.to_string().contains("missing field `placeholder`"));
+    }
+
+    #[test]
     fn rejects_incompatible_version_event() {
         let raw = r#"{"type":"final","version":"9.9.9","text":"x","status":"done"}"#;
         assert!(serde_json::from_str::<OutboundEvent>(raw).is_err());
@@ -424,19 +455,19 @@ mod tests {
 
     #[test]
     fn rejects_incompatible_near_version() {
-        let raw = r#"{"type":"final","version":"0.4.0","text":"x","status":"done"}"#;
+        let raw = r#"{"type":"final","version":"0.5.0","text":"x","status":"done"}"#;
         assert!(serde_json::from_str::<OutboundEvent>(raw).is_err());
     }
 
     #[test]
     fn accepts_compatible_patch() {
-        let raw = r#"{"type":"final","version":"0.3.1","text":"x","status":"done"}"#;
+        let raw = r#"{"type":"final","version":"0.4.1","text":"x","status":"done"}"#;
         assert!(serde_json::from_str::<OutboundEvent>(raw).is_ok());
     }
 
     #[test]
     fn accepts_unknown_fields() {
-        let raw = r#"{"type":"final","version":"0.3.0","text":"x","status":"done","extra":1}"#;
+        let raw = r#"{"type":"final","version":"0.4.0","text":"x","status":"done","extra":1}"#;
         assert!(serde_json::from_str::<OutboundEvent>(raw).is_ok());
     }
 }

--- a/packages/aci-protocol/generated/ts/aci-protocol.ts
+++ b/packages/aci-protocol/generated/ts/aci-protocol.ts
@@ -20,7 +20,7 @@ export type ExpiresInSeconds = number | null;
  * authority-bearing per #544/ADR-0046, so the value domain is a named, exported
  * part of the contract rather than an inline annotation.
  *
- * This interface was referenced by `ACIProtocolV030`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV040`'s JSON-Schema
  * via the `definition` "GateKind".
  */
 export type GateKind = "permission" | "policy";
@@ -29,7 +29,7 @@ export type ReplyAdapter = string | null;
 export type ReplyChannel = string;
 export type ReplyEndpoint = string | null;
 export type ReplyKind = string;
-export type ReplyPlaceholder = string;
+export type ReplyPlaceholder = string | null;
 export type Route = string | null;
 export type Summary = string;
 export type ApiBackend = string | null;
@@ -107,14 +107,14 @@ export type Text1 = string;
 export type Type2 = "final";
 export type Version1 = string;
 /**
- * This interface was referenced by `ACIProtocolV030`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV040`'s JSON-Schema
  * via the `definition` "InboundMessage".
  */
 export type InboundMessage = Event | Interrupt;
 export type Kind1 = "interrupt";
 export type Reason = string;
 /**
- * This interface was referenced by `ACIProtocolV030`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV040`'s JSON-Schema
  * via the `definition` "OutboundEvent".
  */
 export type OutboundEvent = TextDelta | ToolNote | Final | ErrorEvent | SideEffectFlag;
@@ -137,7 +137,7 @@ export type Adapter = string | null;
 export type Channel = string;
 export type Endpoint1 = string | null;
 export type Kind2 = string;
-export type Placeholder = string;
+export type Placeholder = string | null;
 export type Text4 = string;
 /**
  * Terminal or awaiting status of a session, from the output contract.
@@ -145,12 +145,12 @@ export type Text4 = string;
  * Wire tokens follow the section 0 spelling; ``classified failure`` in prose
  * becomes the token ``classified-failure`` on the wire.
  *
- * This interface was referenced by `ACIProtocolV030`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV040`'s JSON-Schema
  * via the `definition` "SessionStatus".
  */
 export type SessionStatus1 = "done" | "idle-awaiting-input" | "classified-failure" | "awaiting-approval";
 
-export interface ACIProtocolV030 {
+export interface ACIProtocolV040 {
   [k: string]: unknown;
 }
 /**
@@ -174,7 +174,7 @@ export interface ACIProtocolV030 {
  * nullable because ``slack`` legitimately has no adapter -- its route is the
  * worker's configured Slack origin.
  *
- * This interface was referenced by `ACIProtocolV030`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV040`'s JSON-Schema
  * via the `definition` "ApprovalRequest".
  */
 export interface ApprovalRequest {
@@ -221,7 +221,7 @@ export interface ApprovalRequest {
  * baked template default, the worker's value is per-agent model routing. Do not
  * collapse either producer list to a single value.
  *
- * This interface was referenced by `ACIProtocolV030`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV040`'s JSON-Schema
  * via the `definition` "BootEnv".
  */
 export interface BootEnv {
@@ -260,7 +260,7 @@ export interface BootEnv {
  * section 0 describes these as per-tool secrets via K8s Secret refs, so the
  * contract carries the reference, not the secret material itself.
  *
- * This interface was referenced by `ACIProtocolV030`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV040`'s JSON-Schema
  * via the `definition` "SessionConfig".
  */
 export interface SessionConfig {
@@ -279,7 +279,7 @@ export interface SessionConfig {
  * ``task_budget_hint`` is the optional hint passed through to the model so it
  * self paces (section 6b); it is not a hard ceiling.
  *
- * This interface was referenced by `ACIProtocolV030`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV040`'s JSON-Schema
  * via the `definition` "Budget".
  */
 export interface Budget {
@@ -295,7 +295,7 @@ export interface Budget {
  * fields the prototype used (endpoint, headers, protocol); any others pass
  * through as raw env vars untouched and are out of scope for this typed view.
  *
- * This interface was referenced by `ACIProtocolV030`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV040`'s JSON-Schema
  * via the `definition` "OtelConfig".
  */
 export interface OtelConfig {
@@ -307,7 +307,7 @@ export interface OtelConfig {
 /**
  * A classified failure surfaced to the platform.
  *
- * This interface was referenced by `ACIProtocolV030`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV040`'s JSON-Schema
  * via the `definition` "ErrorEvent".
  */
 export interface ErrorEvent {
@@ -324,7 +324,7 @@ export interface ErrorEvent {
  * worker consumes off it (formerly the API's ``EvalJobRequest`` and the
  * worker's ``EvalWorkItem``, which had drifted on ``bundle_ref``).
  *
- * This interface was referenced by `ACIProtocolV030`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV040`'s JSON-Schema
  * via the `definition` "EvalJob".
  */
 export interface EvalJob {
@@ -344,7 +344,7 @@ export interface EvalJob {
  * Byte-identical across both lanes before this promotion, so it carries no
  * semantic decisions.
  *
- * This interface was referenced by `ACIProtocolV030`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV040`'s JSON-Schema
  * via the `definition` "EvalReport".
  */
 export interface EvalReport {
@@ -358,7 +358,7 @@ export interface EvalReport {
 /**
  * An inbound event delivered into a live session (initial or follow-up).
  *
- * This interface was referenced by `ACIProtocolV030`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV040`'s JSON-Schema
  * via the `definition` "Event".
  */
 export interface Event {
@@ -403,7 +403,7 @@ export interface Event {
  * scalars: a tolerant consumer decoding an older producer's ``final`` simply
  * sees them absent.
  *
- * This interface was referenced by `ACIProtocolV030`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV040`'s JSON-Schema
  * via the `definition` "Final".
  */
 export interface Final {
@@ -422,7 +422,7 @@ export interface Final {
 /**
  * A hard stop delivered on the control channel, distinct from a steer.
  *
- * This interface was referenced by `ACIProtocolV030`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV040`'s JSON-Schema
  * via the `definition` "Interrupt".
  */
 export interface Interrupt {
@@ -433,7 +433,7 @@ export interface Interrupt {
 /**
  * A streamed chunk of assistant text.
  *
- * This interface was referenced by `ACIProtocolV030`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV040`'s JSON-Schema
  * via the `definition` "TextDelta".
  */
 export interface TextDelta {
@@ -445,7 +445,7 @@ export interface TextDelta {
 /**
  * A human readable note about a tool call the harness is making.
  *
- * This interface was referenced by `ACIProtocolV030`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV040`'s JSON-Schema
  * via the `definition` "ToolNote".
  */
 export interface ToolNote {
@@ -461,7 +461,7 @@ export interface ToolNote {
  * Its presence gates the no-retry-after-side-effects rule (section 2b): a
  * failed run carrying this flag escalates to a human instead of retrying.
  *
- * This interface was referenced by `ACIProtocolV030`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV040`'s JSON-Schema
  * via the `definition` "SideEffectFlag".
  */
 export interface SideEffectFlag {
@@ -479,7 +479,7 @@ export interface SideEffectFlag {
  * stream-encoding helpers live with the producer (the dispatcher), not on this
  * frozen model, so the contract stays transport-agnostic.
  *
- * This interface was referenced by `ACIProtocolV030`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV040`'s JSON-Schema
  * via the `definition` "QueuedTurn".
  */
 export interface QueuedTurn {
@@ -502,12 +502,13 @@ export interface QueuedTurn {
  * address-only fallback or a ``"slack"`` guess -- the silent misroute this field
  * exists to close.
  *
- * The reply model is edit-in-place: the ingress adapter pre-posts a placeholder
- * message and the worker edits it as the answer streams. ``placeholder`` is an
- * **opaque, adapter-minted correlation handle** -- the worker never parses it and
- * only ever hands it back to the adapter that minted it. For the Slack adapter it
- * happens to be the ts of the pre-posted placeholder message; for another kind it
- * is whatever that adapter needs to find the same message again.
+ * The reply model supports editing an existing reply or carrying no existing
+ * reply reference. ``placeholder`` is a required, nullable, opaque correlation
+ * handle minted by the adapter. The worker never parses it and only ever hands
+ * it back to the adapter that minted it. For the Slack adapter it happens to be
+ * the ts of the preposted placeholder message. For another kind it is whatever
+ * that adapter needs to find the same message again. ``None`` means this turn
+ * has no existing reply to edit.
  *
  * ``endpoint`` is the per-turn reply target: the base URL of the channel API the
  * worker delivers this turn's reply through. It routes the reply back to the
@@ -526,7 +527,7 @@ export interface QueuedTurn {
  * third-party or pre-upgrade producer is not rejected outright, but every
  * first-party mint site sets it explicitly.
  *
- * This interface was referenced by `ACIProtocolV030`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV040`'s JSON-Schema
  * via the `definition` "ReplyHandle".
  */
 export interface ReplyHandle {

--- a/packages/aci-protocol/schema/aci-protocol.schema.json
+++ b/packages/aci-protocol/schema/aci-protocol.schema.json
@@ -114,9 +114,16 @@
           "type": "string"
         },
         "reply_placeholder": {
-          "minLength": 1,
-          "title": "Reply Placeholder",
-          "type": "string"
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Reply Placeholder"
         },
         "route": {
           "anyOf": [
@@ -1053,7 +1060,7 @@
       "type": "object"
     },
     "ReplyHandle": {
-      "description": "Channel-neutral coordinates for where a turn's reply is delivered.\n\n``kind`` and ``channel`` are the **routing pair** (ADR-0096): the channel kind\n(``slack``, ``email``, ...) plus the address within that kind. Both halves are\nneeded to resolve the binding, because one address can legitimately exist under\ntwo kinds. ``kind`` is REQUIRED and deliberately has no default: an optional\nkind forces the resolver to invent one, and every honest answer there is an\naddress-only fallback or a ``\"slack\"`` guess -- the silent misroute this field\nexists to close.\n\nThe reply model is edit-in-place: the ingress adapter pre-posts a placeholder\nmessage and the worker edits it as the answer streams. ``placeholder`` is an\n**opaque, adapter-minted correlation handle** -- the worker never parses it and\nonly ever hands it back to the adapter that minted it. For the Slack adapter it\nhappens to be the ts of the pre-posted placeholder message; for another kind it\nis whatever that adapter needs to find the same message again.\n\n``endpoint`` is the per-turn reply target: the base URL of the channel API the\nworker delivers this turn's reply through. It routes the reply back to the\ningress that enqueued the turn instead of a worker-global setting, so two\ningress paths (a real Slack workspace and a no-Slack CLI stub) can coexist on\none worker (issue #19). ``None`` means \"use the worker's configured default\"\n(its ``slack_api_base_url``, i.e. real Slack), so a producer that does not set\nit keeps the pre-#19 behavior.\n\n``adapter`` names the egress adapter identity whose credential authenticates\nthe reply, so a sink call made *before* binding resolution can still select the\nright credential. For non-Slack kinds ``endpoint`` and ``adapter`` are both\n**platform-set from the binding row** (never accepted from an ingress request\nbody); ``slack`` legitimately carries neither, because its route is the\nworker's configured Slack origin. ``adapter`` is optional at the schema so a\nthird-party or pre-upgrade producer is not rejected outright, but every\nfirst-party mint site sets it explicitly.",
+      "description": "Channel-neutral coordinates for where a turn's reply is delivered.\n\n``kind`` and ``channel`` are the **routing pair** (ADR-0096): the channel kind\n(``slack``, ``email``, ...) plus the address within that kind. Both halves are\nneeded to resolve the binding, because one address can legitimately exist under\ntwo kinds. ``kind`` is REQUIRED and deliberately has no default: an optional\nkind forces the resolver to invent one, and every honest answer there is an\naddress-only fallback or a ``\"slack\"`` guess -- the silent misroute this field\nexists to close.\n\nThe reply model supports editing an existing reply or carrying no existing\nreply reference. ``placeholder`` is a required, nullable, opaque correlation\nhandle minted by the adapter. The worker never parses it and only ever hands\nit back to the adapter that minted it. For the Slack adapter it happens to be\nthe ts of the preposted placeholder message. For another kind it is whatever\nthat adapter needs to find the same message again. ``None`` means this turn\nhas no existing reply to edit.\n\n``endpoint`` is the per-turn reply target: the base URL of the channel API the\nworker delivers this turn's reply through. It routes the reply back to the\ningress that enqueued the turn instead of a worker-global setting, so two\ningress paths (a real Slack workspace and a no-Slack CLI stub) can coexist on\none worker (issue #19). ``None`` means \"use the worker's configured default\"\n(its ``slack_api_base_url``, i.e. real Slack), so a producer that does not set\nit keeps the pre-#19 behavior.\n\n``adapter`` names the egress adapter identity whose credential authenticates\nthe reply, so a sink call made *before* binding resolution can still select the\nright credential. For non-Slack kinds ``endpoint`` and ``adapter`` are both\n**platform-set from the binding row** (never accepted from an ingress request\nbody); ``slack`` legitimately carries neither, because its route is the\nworker's configured Slack origin. ``adapter`` is optional at the schema so a\nthird-party or pre-upgrade producer is not rejected outright, but every\nfirst-party mint site sets it explicitly.",
       "properties": {
         "adapter": {
           "anyOf": [
@@ -1088,8 +1095,15 @@
           "type": "string"
         },
         "placeholder": {
-          "title": "Placeholder",
-          "type": "string"
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Placeholder"
         }
       },
       "required": [
@@ -1278,6 +1292,6 @@
   },
   "$id": "https://curietech.ai/schemas/aci-protocol.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "protocolVersion": "0.3.0",
-  "title": "ACI Protocol v0.3.0"
+  "protocolVersion": "0.4.0",
+  "title": "ACI Protocol v0.4.0"
 }

--- a/packages/aci-protocol/schema/wire.lock
+++ b/packages/aci-protocol/schema/wire.lock
@@ -1,4 +1,4 @@
 {
-  "protocol_version": "0.3.0",
-  "wire_sha256": "83beb192e8b1cc8950cfb6e11235bc7c1a706a1b140f496e8724014d413c0fbc"
+  "protocol_version": "0.4.0",
+  "wire_sha256": "7c109ae202284158bfc876a855b258c5896a4e7839550cb7fd095e7262fd2437"
 }

--- a/packages/aci-protocol/src/aci_protocol/rust_export.py
+++ b/packages/aci-protocol/src/aci_protocol/rust_export.py
@@ -162,12 +162,15 @@ def _struct_fields(model: type[BaseModel], skip: set[str], public: bool) -> list
         if field_name in skip:
             continue
         rust = _rust_type(field.annotation)
+        _, nullable = _split_optional(field.annotation)
         if field_name == WIRE_VERSION_FIELD:
             # The version field is mandatory and compatibility-checked on decode,
             # matching the NDJSON decoder. Detected by name (WIRE_VERSION_FIELD),
             # not by type, so dropping the old Literal does not silently remove
             # the guard and let #[serde(default)] make version optional.
             out.append('    #[serde(deserialize_with = "require_compatible_protocol_version")]')
+        elif field.is_required() and nullable:
+            out.append('    #[serde(deserialize_with = "deserialize_required_nullable")]')
         elif not field.is_required():
             # Any other field with a Pydantic default is omittable on the wire,
             # so Rust accepts it missing too.
@@ -271,6 +274,17 @@ where
 }"""
 
 
+_REQUIRED_NULLABLE_DESERIALIZER = """fn deserialize_required_nullable<'de, D, T>(
+    deserializer: D,
+) -> Result<Option<T>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    Option::<T>::deserialize(deserializer)
+}"""
+
+
 _TESTS = """#[cfg(test)]
 mod tests {
     use super::*;
@@ -322,6 +336,24 @@ mod tests {
         let encoded = serde_json::to_string(&message).unwrap();
         let decoded: InboundMessage = serde_json::from_str(&encoded).unwrap();
         assert_eq!(message, decoded);
+    }
+
+    #[test]
+    fn reply_handle_accepts_explicit_null_placeholder() {
+        let raw = r#"{"kind":"email","channel":"agent@example.test","placeholder":null,"endpoint":"https://adapter.example/hook","adapter":"agentmail_sandbox"}"#;
+        let decoded: ReplyHandle = serde_json::from_str(raw).unwrap();
+        assert_eq!(decoded.kind, "email");
+        assert_eq!(decoded.channel, "agent@example.test");
+        assert_eq!(decoded.placeholder, None);
+        assert_eq!(decoded.endpoint.as_deref(), Some("https://adapter.example/hook"));
+        assert_eq!(decoded.adapter.as_deref(), Some("agentmail_sandbox"));
+    }
+
+    #[test]
+    fn reply_handle_rejects_omitted_placeholder() {
+        let raw = r#"{"kind":"email","channel":"agent@example.test"}"#;
+        let error = serde_json::from_str::<ReplyHandle>(raw).unwrap_err();
+        assert!(error.to_string().contains("missing field `placeholder`"));
     }
 
 """
@@ -399,6 +431,7 @@ def render_rust() -> str:
         f'pub const EVAL_CONSUMER_GROUP_DEFAULT: &str = "{EVAL_CONSUMER_GROUP_DEFAULT}";',
         f'pub const STREAM_PAYLOAD_FIELD: &str = "{STREAM_PAYLOAD_FIELD}";',
         _VERSION_GUARD,
+        _REQUIRED_NULLABLE_DESERIALIZER,
         _string_enum(
             "SessionStatus",
             tuple(m.value for m in SessionStatus),

--- a/packages/aci-protocol/src/aci_protocol/turn.py
+++ b/packages/aci-protocol/src/aci_protocol/turn.py
@@ -40,12 +40,13 @@ class ReplyHandle(_AciModel):
     address-only fallback or a ``"slack"`` guess -- the silent misroute this field
     exists to close.
 
-    The reply model is edit-in-place: the ingress adapter pre-posts a placeholder
-    message and the worker edits it as the answer streams. ``placeholder`` is an
-    **opaque, adapter-minted correlation handle** -- the worker never parses it and
-    only ever hands it back to the adapter that minted it. For the Slack adapter it
-    happens to be the ts of the pre-posted placeholder message; for another kind it
-    is whatever that adapter needs to find the same message again.
+    The reply model supports editing an existing reply or carrying no existing
+    reply reference. ``placeholder`` is a required, nullable, opaque correlation
+    handle minted by the adapter. The worker never parses it and only ever hands
+    it back to the adapter that minted it. For the Slack adapter it happens to be
+    the ts of the preposted placeholder message. For another kind it is whatever
+    that adapter needs to find the same message again. ``None`` means this turn
+    has no existing reply to edit.
 
     ``endpoint`` is the per-turn reply target: the base URL of the channel API the
     worker delivers this turn's reply through. It routes the reply back to the
@@ -67,7 +68,7 @@ class ReplyHandle(_AciModel):
 
     kind: str
     channel: str
-    placeholder: str
+    placeholder: str | None
     endpoint: str | None = None
     adapter: str | None = None
 

--- a/packages/aci-protocol/src/aci_protocol/version.py
+++ b/packages/aci-protocol/src/aci_protocol/version.py
@@ -20,7 +20,7 @@ the guard.
 import re
 from typing import Final
 
-PROTOCOL_VERSION: Final = "0.3.0"
+PROTOCOL_VERSION: Final = "0.4.0"
 
 # The wire field carrying the protocol version on every outbound event. Both
 # exporters special-case this field by name; do not rename without updating them.

--- a/packages/aci-protocol/src/aci_protocol/wire.py
+++ b/packages/aci-protocol/src/aci_protocol/wire.py
@@ -36,12 +36,14 @@ would break that property.
 mirror had bare types, so it could construct a payload the API 422-rejects --
 the live bug stranding the durable-approval path. Resolved strict:
 
-- ``conversation_id``, ``author``, ``summary``, ``reply_channel``,
-  ``reply_placeholder``, ``dedupe_key``: ``min_length=1``. An empty string now
-  raises **at the worker**, at construction, instead of producing a 422 from the
-  API. Nothing that previously *succeeded* now fails -- those payloads were
-  already being rejected downstream. The failure just moves to the source with a
-  clear message.
+- ``conversation_id``, ``author``, ``summary``, ``reply_channel``, and
+  ``dedupe_key``: ``min_length=1``. An empty string now raises **at the worker**,
+  at construction, instead of producing a 422 from the API. Nothing that
+  previously *succeeded* now fails -- those payloads were already being rejected
+  downstream. The failure just moves to the source with a clear message.
+- ``reply_placeholder``: required ``str | None`` with ``min_length=1`` for a
+  nonnull value. ``None`` explicitly represents no placeholder to edit; omitting
+  the key remains invalid, and an empty nonnull string remains invalid.
 - ``gate_kind``: ``str | None`` -> ``GateKind | None``. A worker sending an
   unrecognized string now raises locally rather than 422ing. Per #544/ADR-0046
   this field is **authority-bearing** (it decides whether a gate may grant), so
@@ -139,7 +141,7 @@ class ApprovalRequest(_AciModel):
     summary: str = Field(min_length=1)
     reply_kind: str = Field(min_length=1)
     reply_channel: str = Field(min_length=1)
-    reply_placeholder: str = Field(min_length=1)
+    reply_placeholder: str | None = Field(min_length=1)
     reply_endpoint: str | None = None
     reply_adapter: str | None = None
     dedupe_key: str = Field(min_length=1)

--- a/packages/aci-protocol/tests/test_exporters.py
+++ b/packages/aci-protocol/tests/test_exporters.py
@@ -37,6 +37,22 @@ def test_generated_rust_guards_the_version() -> None:
         )
 
 
+def test_generated_rust_requires_nullable_reply_placeholder_key() -> None:
+    rust = render_rust()
+    reply_handle = re.search(r"pub struct ReplyHandle \{\n(.*?)\n\}", rust, re.DOTALL)
+    assert reply_handle, "no ReplyHandle struct in the generated Rust"
+    assert (
+        '#[serde(deserialize_with = "deserialize_required_nullable")]\n'
+        "    pub placeholder: Option<String>,"
+    ) in reply_handle.group(1)
+
+
+def test_generated_rust_carries_reply_handle_behavior_tests() -> None:
+    rust = render_rust()
+    assert "fn reply_handle_accepts_explicit_null_placeholder()" in rust
+    assert "fn reply_handle_rejects_omitted_placeholder()" in rust
+
+
 # ---------------------------------------------------------------------------
 # BootEnv export (#488). The env key (CURIE_RUNNER_TOKEN) is not the field
 # name (runner_token), so the mapping has to ride in the schema for codegen to

--- a/packages/aci-protocol/tests/test_ndjson.py
+++ b/packages/aci-protocol/tests/test_ndjson.py
@@ -115,8 +115,8 @@ def test_unknown_field_is_ignored_on_inbound_read() -> None:
 
 def test_compatible_patch_version_is_accepted() -> None:
     # AC: a same-major-minor patch difference is not an error. Build speaks
-    # 0.3.0; a 0.3.7 line decodes fine.
-    line = json.dumps({"type": "final", "version": "0.3.7", "text": "x", "status": "done"})
+    # 0.4.0; a 0.4.7 line decodes fine.
+    line = json.dumps({"type": "final", "version": "0.4.7", "text": "x", "status": "done"})
     decoded = parse_ndjson_line(line)
     assert isinstance(decoded, Final)
     assert decoded.text == "x"
@@ -125,11 +125,11 @@ def test_compatible_patch_version_is_accepted() -> None:
 def test_incompatible_minor_is_rejected_naming_both_versions() -> None:
     # AC: rejects an incompatible version with a message naming both versions.
     # The assertion is on the message content, not just the exception type.
-    line = json.dumps({"type": "final", "version": "0.4.0", "text": "x", "status": "done"})
+    line = json.dumps({"type": "final", "version": "0.3.0", "text": "x", "status": "done"})
     with pytest.raises(ProtocolVersionError) as excinfo:
         parse_ndjson_line(line)
     message = str(excinfo.value)
-    assert "0.4.0" in message
+    assert "0.3.0" in message
     assert PROTOCOL_VERSION in message
 
 

--- a/packages/aci-protocol/tests/test_schema_compat.py
+++ b/packages/aci-protocol/tests/test_schema_compat.py
@@ -14,7 +14,7 @@ pins, so a drifted schema is caught here before TypeScript can diverge.
 """
 
 from aci_protocol.rust_export import crate_dir, render_rust
-from aci_protocol.schema_export import render_schema, schema_path
+from aci_protocol.schema_export import build_schema, render_schema, schema_path
 
 
 def test_committed_json_schema_is_current() -> None:
@@ -29,3 +29,29 @@ def test_committed_rust_is_current() -> None:
     assert render_rust() == committed, (
         "generated Rust is stale; run scripts/check-contracts.sh and commit"
     )
+
+
+def test_reply_placeholders_are_required_nullable_strings() -> None:
+    definitions = build_schema()["$defs"]
+    reply_handle = definitions["ReplyHandle"]
+    approval_request = definitions["ApprovalRequest"]
+
+    assert "placeholder" in reply_handle["required"]
+    assert "reply_placeholder" in approval_request["required"]
+
+    handle_placeholder = reply_handle["properties"]["placeholder"]
+    approval_placeholder = approval_request["properties"]["reply_placeholder"]
+    assert "anyOf" in handle_placeholder
+    assert "anyOf" in approval_placeholder
+
+    handle_variants = handle_placeholder["anyOf"]
+    approval_variants = approval_placeholder["anyOf"]
+    assert {variant["type"] for variant in handle_variants} == {"null", "string"}
+    assert {variant["type"] for variant in approval_variants} == {"null", "string"}
+
+    handle_string = next(variant for variant in handle_variants if variant["type"] == "string")
+    approval_string = next(
+        variant for variant in approval_variants if variant["type"] == "string"
+    )
+    assert "minLength" not in handle_string
+    assert approval_string["minLength"] == 1

--- a/packages/aci-protocol/tests/test_turn.py
+++ b/packages/aci-protocol/tests/test_turn.py
@@ -164,3 +164,20 @@ def test_adapter_is_optional_and_round_trips_when_a_producer_sets_it() -> None:
     assert restored == routed
     assert restored.adapter == "agentmail-sandbox"
     assert restored.endpoint == "http://curie-mail-adapter:8080/"
+
+
+def test_reply_handle_without_placeholder_raises() -> None:
+    with pytest.raises(ValidationError):
+        ReplyHandle.model_validate({"kind": "slack", "channel": "C1"})
+
+
+def test_reply_handle_with_null_placeholder_succeeds() -> None:
+    handle = ReplyHandle.model_validate(
+        {"kind": "slack", "channel": "C1", "placeholder": None}
+    )
+    assert handle.placeholder is None
+
+
+def test_reply_handle_with_empty_placeholder_succeeds() -> None:
+    handle = ReplyHandle(kind="slack", channel="C1", placeholder="")
+    assert handle.placeholder == ""

--- a/packages/aci-protocol/tests/test_wire.py
+++ b/packages/aci-protocol/tests/test_wire.py
@@ -305,6 +305,27 @@ def test_approval_request_empty_conversation_id_raises() -> None:
         ApprovalRequest(**fields)  # type: ignore[arg-type]
 
 
+def test_approval_request_without_reply_placeholder_raises() -> None:
+    fields = _minimal_approval_request_fields()
+    del fields["reply_placeholder"]
+    with pytest.raises(ValidationError):
+        ApprovalRequest(**fields)  # type: ignore[arg-type]
+
+
+def test_approval_request_with_null_reply_placeholder_succeeds() -> None:
+    fields = _minimal_approval_request_fields()
+    fields["reply_placeholder"] = None
+    request = ApprovalRequest.model_validate(fields)
+    assert request.reply_placeholder is None
+
+
+def test_approval_request_with_empty_reply_placeholder_raises() -> None:
+    fields = _minimal_approval_request_fields()
+    fields["reply_placeholder"] = ""
+    with pytest.raises(ValidationError):
+        ApprovalRequest(**fields)  # type: ignore[arg-type]
+
+
 def test_approval_request_zero_expires_in_seconds_raises() -> None:
     with pytest.raises(ValidationError):
         ApprovalRequest(**_minimal_approval_request_fields(), expires_in_seconds=0)  # type: ignore[arg-type]


### PR DESCRIPTION
Closes #1528\n\nVersions ACI to 0.4.0 so reply placeholders are required nullable values while preserving channel kind and adapter. Adds migration 0025, nullable approval persistence, regenerated contract artifacts, and required nullable Rust decoding.\n\nCurrent producers continue sending strings. The worker rejects null before side effects until #1526 lands. Runner and worker versions 0.3 and 0.4 are incompatible and must deploy together after active sessions drain. A null delivered before #1526 is bounded by the transport delivery cap and moves to dead letter handling.