### PR TITLE
Accept ADR-0104, ADR-0088, and ADR-0044

### DIFF
--- a/docs/adr/0044-workflow-controlled-agents-callable-substrate.md
+++ b/docs/adr/0044-workflow-controlled-agents-callable-substrate.md
@@ -2,11 +2,22 @@
 
 Date: 2026-07-16
 
-Status: Draft
+Status: Accepted
 
 This is a **decision, not code**: it settles whether, and how deeply, Curie
 supports *workflow-controlled* agents — developer-authored orchestration
 frameworks such as LangGraph and CrewAI — and what we would build to do it.
+
+**Read every ADR-0031 reference below as ADR-0060 plus ADR-0061.** This ADR was
+drafted while [ADR-0031](0031-harness-neutral-runner-seams.md) was Proposed; it
+is now Superseded by [ADR-0060](0060-the-harness-is-a-declared-package.md) (a
+harness is a declared package) and
+[ADR-0061](0061-out-of-process-harness-boundary.md) (the boundary is a process,
+not a Protocol). The decision here is unaffected, because it never depended on
+which shape the harness seam took — only on that seam existing before B is
+built. So phase 2's first gate condition now reads "0060 and 0061 have landed"
+rather than "ADR-0031 has landed", and it is if anything further out: 0061 is
+itself still a Draft gated on a spike.
 
 ## Context
 
@@ -83,7 +94,7 @@ Prior decisions frame this:
 - **ADR-0028** (substrate is resilience, not a product swap axis): the same
   discipline applied to the sandbox seam — keep a clean port, but do not market it
   as a bring-your-own axis ahead of funded demand.
-- **ADR-0031** (harness-neutral runner seams, *Proposed*): the runner is still
+- **ADR-0031** (harness-neutral runner seams, *Superseded by 0060/0061*): the runner is still
   Claude-shaped at four seams (`translate.py` isinstance-matches SDK types, the
   side-effect allowlist hardcodes Claude tool names, plugin ingestion hands the
   bundle to the SDK). B depends on this refactor landing first.
@@ -146,7 +157,8 @@ ADR-0031 and demand.
 B is not "write an adapter" — it is a second runtime path through the runner:
 
 1. **ADR-0031 lands first** (the `TurnEvent` union + `BundleInstaller` port +
-   harness-declared tool identity). Biggest hidden cost; currently *Proposed*.
+   harness-declared tool identity). Biggest hidden cost; superseded by 0060 and
+   0061, of which 0061 is a Draft gated on a spike.
 2. **A non-turn-based runner seam** distinct from `ModelSession` — "run this whole
    program, stream ACI events" — since a flow is not a turn.
 3. **Per-framework in-pod translators**: `stream_events(v3)` → ACI for LangGraph,

--- a/docs/adr/0088-per-user-delegated-oauth-for-mcp.md
+++ b/docs/adr/0088-per-user-delegated-oauth-for-mcp.md
@@ -1,7 +1,7 @@
 # 88. Per user delegated OAuth for MCP
 
 Date: 2026-07-30
-Status: Draft
+Status: Accepted
 
 Extends: [ADR 0009](0009-per-agent-connector-auth.md) by adding a user owned
 credential mode alongside per agent credentials.

--- a/docs/adr/0104-a-named-security-posture-is-computed-not-configured.md
+++ b/docs/adr/0104-a-named-security-posture-is-computed-not-configured.md
@@ -2,7 +2,7 @@
 
 Date: 2026-08-10
 
-Status: Draft
+Status: Accepted
 
 Implements [#1226](https://github.com/curie-eng/curie/issues/1226).
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -73,7 +73,7 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0041 | [Every verb is answered at every tier](0041-every-verb-is-answered-at-every-tier.md) | Accepted |
 | 0042 | [Adopt LLM-as-a-Verifier: a continuous-score semantic grader and a live progress signal](0042-llm-as-a-verifier-grader-and-progress-signal.md) | Accepted |
 | 0043 | [The interface catalog is generated from declared front-matter and gated in CI](0043-generated-interface-catalog-and-doc-lint-gate.md) | Accepted |
-| 0044 | [Workflow-controlled agents run on Curie as a callable substrate first, a unified plane only on demand](0044-workflow-controlled-agents-callable-substrate.md) | Draft |
+| 0044 | [Workflow-controlled agents run on Curie as a callable substrate first, a unified plane only on demand](0044-workflow-controlled-agents-callable-substrate.md) | Accepted |
 | 0045 | [The status line is the mutable part of an immutable ADR](0045-the-status-line-is-the-mutable-part-of-an-immutable-adr.md) | Accepted |
 | 0046 | [Converged approval gates: durable provenance, loud route resolution, and observe-only resume reconciliation](0046-converged-approval-gates-and-durable-provenance.md) | Accepted |
 | 0047 | [ADR-0047: Canonical env-var names for the API base URL and model credential](0047-canonical-env-var-names.md) | Accepted |
@@ -117,7 +117,7 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0085 | [Acceptance, not implementation, authorizes an ADR](0085-acceptance-not-implementation-authorizes-an-adr.md) | Accepted |
 | 0086 | [Bundles declare connectors; the platform hosts them](0086-bundles-declare-connectors-the-platform-hosts-them.md) | Accepted |
 | 0087 | [The API renders connector objects; the CLI applies them](0087-the-api-renders-connector-objects-the-cli-applies-them.md) | Draft |
-| 0088 | [Per user delegated OAuth for MCP](0088-per-user-delegated-oauth-for-mcp.md) | Draft |
+| 0088 | [Per user delegated OAuth for MCP](0088-per-user-delegated-oauth-for-mcp.md) | Accepted |
 | 0089 | [Bundles declare their deploy targets](0089-bundles-declare-their-deploy-targets.md) | Accepted |
 | 0090 | [A reconciler applies connectors, so agent repos need no CLI](0090-a-reconciler-applies-connectors-so-agent-repos-need-no-cli.md) | Accepted |
 | 0091 | [Git-flow resolves deploy targets, so one repo serves many agents](0091-git-flow-resolves-deploy-targets-so-one-repo-serves-many-agents.md) | Accepted |
@@ -132,5 +132,5 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0101 | [Closed schemas version on every change: minor for optional, major for required](0101-schema-compatibility-for-closed-schemas.md) | Accepted |
 | 0102 | [Accepted alongside implementation with explicit approval](0102-accepted-alongside-implementation-with-explicit-approval.md) | Accepted |
 | 0103 | [Previous schema shape gate](0103-previous-schema-shape-gate.md) | Accepted |
-| 0104 | [A named security posture is computed from the layers that exist, never configured](0104-a-named-security-posture-is-computed-not-configured.md) | Draft |
+| 0104 | [A named security posture is computed from the layers that exist, never configured](0104-a-named-security-posture-is-computed-not-configured.md) | Accepted |
 <!-- END GENERATED: adr-index -->


### PR DESCRIPTION
Records explicit maintainer approval for three Draft ADRs, per
[ADR-0085](../blob/main/docs/adr/0085-acceptance-not-implementation-authorizes-an-adr.md)
as amended by
[ADR-0102](../blob/main/docs/adr/0102-accepted-alongside-implementation-with-explicit-approval.md).

None of the three has an implementation in the tree, so this is a plain
acceptance rather than ADR-0102's accepted-alongside-implementation path. No
realizing code path is named, and none is owed.

| ADR | Why it was ready |
|---|---|
| [0104](../blob/main/docs/adr/0104-a-named-security-posture-is-computed-not-configured.md) | Reporting-only, scoped to the deployment/agent/bundle layers that exist. Deliberately independent of #158 and #515, which is the direction asked for in discussion #1409. |
| [0088](../blob/main/docs/adr/0088-per-user-delegated-oauth-for-mcp.md) | Its own text asked to stay Draft "until maintainers approve the identity modes, immutable run principal, control plane grant ownership, and gateway boundary". That approval is what this records. |
| [0044](../blob/main/docs/adr/0044-workflow-controlled-agents-callable-substrate.md) | A positioning decision that authorizes no code. |

## On ADR-0088's acceptance conditions

Worth stating explicitly, since it reads like a blocked gate on a first pass:
conditions 1 to 8 sit under "Implementation work begins only after acceptance
and must demonstrate", so they are obligations on the implementation that
follows, not evidence owed before acceptance. Its four open decisions remain
named follow-ups.

## The one substantive edit

ADR-0044 carried a stale premise, corrected here **before** acceptance rather
than frozen into an Accepted body. It was drafted while ADR-0031 was *Proposed*;
ADR-0031 is now Superseded by ADR-0060 and ADR-0061.

The decision itself is unaffected: it never depended on which shape the harness
seam took, only on that seam existing before phase 2 is built. So the edit is
confined to the premise, not the argument:

- a note at the head stating that every ADR-0031 reference below reads as
  ADR-0060 plus ADR-0061;
- the two inline "currently *Proposed*" claims corrected.

Phase 2's gate now reads "0060 and 0061 have landed" rather than "ADR-0031 has
landed", which is if anything **further out**, since ADR-0061 is itself a Draft
gated on a spike. The gate did not loosen.

## Not in this PR

- **0087, 0093, 0062** (ratify-alongside-shipped-code). Under ADR-0102 these are
  the sanctioned path rather than an ADR-0085 exception, but 0102 also requires
  the ADR to name its realizing code path, and none of the three does yet: 0093
  names no code at all, 0087 names only `connectors.yaml` and `.mcp.json`, and
  0062 says "an import linter contract in CI" in prose without naming
  `pyproject.toml`'s `[tool.importlinter]` contracts or `.github/workflows/ci.yaml`.
  Each needs one added sentence first.
- **0030, 0061, 0075, 0095** — held on gates written into the ADRs themselves.
- **0040** — its central premise no longer holds and it needs a rewrite against
  0060/0061, not a status flip.
- Two broken relative links in 0030 and 0093, unrelated to the ADRs accepted here.

The regenerated `docs/adr/README.md` is committed alongside, and
`scripts/check-docs.sh` passes.