### PR TITLE
Adapter builder tooling: binding profile, curie adapter verbs, and conformance kit

### DIFF
--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -4085,6 +4085,363 @@ export const commandManifest = {
       "name": "interactive"
     },
     {
+      "about": "Build, validate, bind and smoke-test a channel adapter against an install: `adapter <scaffold|validate|bind|token|smoke-test>`",
+      "hidden": false,
+      "long_about": "Build, validate, bind and smoke-test a channel adapter against an install: `adapter <scaffold|validate|bind|token|smoke-test>`.\n\nReads an `adapter.yaml` binding profile (kind, address shape, reply route, egress credential identity) validated against the committed `packages/channel-protocol` schema, so the CLI and the Python conformance kit agree on one contract instead of two mirrors.",
+      "name": "adapter",
+      "subcommands": [
+        {
+          "about": "Write one binding profile for a new adapter, plus the next steps",
+          "args": [
+            {
+              "global": false,
+              "help": "Adapter name. The profile is written to `<dir>/<name>/adapter.yaml`",
+              "id": "name",
+              "positional": true,
+              "required": true
+            },
+            {
+              "global": false,
+              "help": "Channel kind this adapter owns, as a lowercase slug (e.g. email)",
+              "id": "kind",
+              "long": "kind",
+              "positional": false,
+              "required": true
+            },
+            {
+              "global": false,
+              "help": "A concrete address of the shape this adapter owns",
+              "id": "address",
+              "long": "address",
+              "positional": false,
+              "required": true
+            },
+            {
+              "global": false,
+              "help": "The absolute http or https route the worker POSTs reply events to",
+              "id": "endpoint",
+              "long": "endpoint",
+              "positional": false,
+              "required": true
+            },
+            {
+              "global": false,
+              "help": "The egress credential identity this adapter suggests, as a lowercase slug. A suggestion only: `adapter bind` asks an operator to confirm it",
+              "id": "adapter",
+              "long": "adapter",
+              "positional": false,
+              "required": true
+            },
+            {
+              "global": false,
+              "help": "Parent directory for the scaffolded adapter. Defaults to the current directory",
+              "id": "dir",
+              "long": "dir",
+              "positional": false,
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "long_about": "Write one binding profile for a new adapter, plus the next steps.\n\nDeliberately minimal: one `adapter.yaml` and nothing else. The generated `address.pattern` matches exactly the address it was scaffolded for, so the profile validates on the very next command; widen it by hand to the real shape of your channel's addresses.",
+          "name": "scaffold"
+        },
+        {
+          "about": "Accept or refuse a binding profile, and report the values it parsed",
+          "args": [
+            {
+              "default_values": [
+                "adapter.yaml"
+              ],
+              "global": false,
+              "help": "Path to the binding profile",
+              "id": "file",
+              "long": "file",
+              "positional": false,
+              "required": false,
+              "short": "f"
+            },
+            {
+              "global": false,
+              "help": "Also check that this concrete address matches the profile's declared shape",
+              "id": "address",
+              "long": "address",
+              "positional": false,
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "long_about": "Accept or refuse a binding profile, and report the values it parsed.\n\nThe version is checked first, then the committed schema, then the one rule a schema cannot express: `address.pattern` has to compile with the Rust regex crate as well as Python `re`, so no lookaround and no backreferences.",
+          "name": "validate"
+        },
+        {
+          "about": "Write an agent's four field channel route: kind, address, endpoint and the egress credential slug",
+          "args": [
+            {
+              "default_values": [
+                "adapter.yaml"
+              ],
+              "global": false,
+              "help": "Path to the binding profile",
+              "id": "file",
+              "long": "file",
+              "positional": false,
+              "required": false,
+              "short": "f"
+            },
+            {
+              "global": false,
+              "help": "Agent id to bind",
+              "id": "agent",
+              "positional": true,
+              "required": true
+            },
+            {
+              "global": false,
+              "help": "The concrete address to bind, checked against the profile's shape",
+              "id": "address",
+              "long": "address",
+              "positional": false,
+              "required": true
+            },
+            {
+              "global": false,
+              "help": "The egress credential identity to write. Operator owned",
+              "id": "adapter_slug",
+              "long": "adapter-slug",
+              "positional": false,
+              "required": true
+            },
+            {
+              "global": false,
+              "help": "Reply route override, for a profile that declares no endpoint",
+              "id": "endpoint",
+              "long": "endpoint",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "http://localhost:28000"
+              ],
+              "env": "CURIE_API_URL",
+              "global": false,
+              "help": "Platform API base URL",
+              "id": "api_url",
+              "long": "api-url",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "curie-dev-key"
+              ],
+              "env": "CURIE_API_KEY",
+              "global": false,
+              "help": "Platform API key",
+              "id": "api_key",
+              "long": "api-key",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Confirm the destination and the credential identity, and write",
+              "id": "yes",
+              "long": "yes",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "long_about": "Write an agent's four field channel route: kind, address, endpoint and the egress credential slug.\n\n`--address` and `--adapter-slug` are operator inputs, never taken from the profile: `address.example` is authoring documentation, and the slug selects which stored secret the worker sends, so a profile chosen value could redirect another adapter's credential. A slug differing from the profile's suggestion is shown with both values before it is written.",
+          "name": "bind"
+        },
+        {
+          "about": "Mint a `chn` token for one concrete (kind, address) pair",
+          "args": [
+            {
+              "default_values": [
+                "adapter.yaml"
+              ],
+              "global": false,
+              "help": "Path to the binding profile",
+              "id": "file",
+              "long": "file",
+              "positional": false,
+              "required": false,
+              "short": "f"
+            },
+            {
+              "global": false,
+              "help": "The concrete address to mint for, checked against the profile's shape",
+              "id": "address",
+              "long": "address",
+              "positional": false,
+              "required": true
+            },
+            {
+              "default_values": [
+                "http://localhost:28000"
+              ],
+              "env": "CURIE_API_URL",
+              "global": false,
+              "help": "Platform API base URL",
+              "id": "api_url",
+              "long": "api-url",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "curie-dev-key"
+              ],
+              "env": "CURIE_API_KEY",
+              "global": false,
+              "help": "Platform API key",
+              "id": "api_key",
+              "long": "api-key",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "3600"
+              ],
+              "global": false,
+              "help": "Token lifetime in seconds. The API accepts 1 to 604800",
+              "id": "ttl_s",
+              "long": "ttl-s",
+              "positional": false,
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "long_about": "Mint a `chn` token for one concrete (kind, address) pair.\n\nThe only verb whose payload carries a credential value: it rides under `token` alongside `\"secret\": true`, on stdout and on no diagnostic stream.",
+          "name": "token"
+        },
+        {
+          "about": "Probe a deployed adapter from the outside: does this endpoint accept the egress secret you supply, does it refuse a wrong one, and are the route fields present for this pair",
+          "args": [
+            {
+              "default_values": [
+                "adapter.yaml"
+              ],
+              "global": false,
+              "help": "Path to the binding profile",
+              "id": "file",
+              "long": "file",
+              "positional": false,
+              "required": false,
+              "short": "f"
+            },
+            {
+              "global": false,
+              "help": "The concrete address to probe, checked against the profile's shape",
+              "id": "address",
+              "long": "address",
+              "positional": false,
+              "required": true
+            },
+            {
+              "global": false,
+              "help": "Reply route override, for a profile that declares no endpoint",
+              "id": "endpoint",
+              "long": "endpoint",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "http://localhost:28000"
+              ],
+              "env": "CURIE_API_URL",
+              "global": false,
+              "help": "Platform API base URL",
+              "id": "api_url",
+              "long": "api-url",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "curie-dev-key"
+              ],
+              "env": "CURIE_API_KEY",
+              "global": false,
+              "help": "Platform API key",
+              "id": "api_key",
+              "long": "api-key",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Read the egress secret from this file. One of the two accepted sources; the profile names the variable its own adapter reads and that name is never resolved here",
+              "id": "secret_file",
+              "long": "secret-file",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Read the egress secret from stdin instead",
+              "id": "secret_stdin",
+              "long": "secret-stdin",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Also post a real turn twice and assert the second is reported as a duplicate. This enqueues a REAL turn against the bound agent",
+              "id": "enqueue",
+              "long": "enqueue",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Probe a cleartext http endpoint anyway",
+              "id": "allow_insecure",
+              "long": "allow-insecure",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Confirm the destination and the credential identity, and probe",
+              "id": "yes",
+              "long": "yes",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "long_about": "Probe a deployed adapter from the outside: does this endpoint accept the egress secret you supply, does it refuse a wrong one, and are the route fields present for this pair.\n\nThose two narrow claims are all it makes. It does not prove the running worker holds that slug or that value, and it is not the conformance floor: `curie-adapter-conformance` is the stricter check.",
+          "name": "smoke-test"
+        }
+      ]
+    },
+    {
       "about": "Store and manage local secrets in Curie private storage",
       "hidden": false,
       "name": "secrets",

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -4082,6 +4082,363 @@
       "name": "interactive"
     },
     {
+      "about": "Build, validate, bind and smoke-test a channel adapter against an install: `adapter <scaffold|validate|bind|token|smoke-test>`",
+      "hidden": false,
+      "long_about": "Build, validate, bind and smoke-test a channel adapter against an install: `adapter <scaffold|validate|bind|token|smoke-test>`.\n\nReads an `adapter.yaml` binding profile (kind, address shape, reply route, egress credential identity) validated against the committed `packages/channel-protocol` schema, so the CLI and the Python conformance kit agree on one contract instead of two mirrors.",
+      "name": "adapter",
+      "subcommands": [
+        {
+          "about": "Write one binding profile for a new adapter, plus the next steps",
+          "args": [
+            {
+              "global": false,
+              "help": "Adapter name. The profile is written to `<dir>/<name>/adapter.yaml`",
+              "id": "name",
+              "positional": true,
+              "required": true
+            },
+            {
+              "global": false,
+              "help": "Channel kind this adapter owns, as a lowercase slug (e.g. email)",
+              "id": "kind",
+              "long": "kind",
+              "positional": false,
+              "required": true
+            },
+            {
+              "global": false,
+              "help": "A concrete address of the shape this adapter owns",
+              "id": "address",
+              "long": "address",
+              "positional": false,
+              "required": true
+            },
+            {
+              "global": false,
+              "help": "The absolute http or https route the worker POSTs reply events to",
+              "id": "endpoint",
+              "long": "endpoint",
+              "positional": false,
+              "required": true
+            },
+            {
+              "global": false,
+              "help": "The egress credential identity this adapter suggests, as a lowercase slug. A suggestion only: `adapter bind` asks an operator to confirm it",
+              "id": "adapter",
+              "long": "adapter",
+              "positional": false,
+              "required": true
+            },
+            {
+              "global": false,
+              "help": "Parent directory for the scaffolded adapter. Defaults to the current directory",
+              "id": "dir",
+              "long": "dir",
+              "positional": false,
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "long_about": "Write one binding profile for a new adapter, plus the next steps.\n\nDeliberately minimal: one `adapter.yaml` and nothing else. The generated `address.pattern` matches exactly the address it was scaffolded for, so the profile validates on the very next command; widen it by hand to the real shape of your channel's addresses.",
+          "name": "scaffold"
+        },
+        {
+          "about": "Accept or refuse a binding profile, and report the values it parsed",
+          "args": [
+            {
+              "default_values": [
+                "adapter.yaml"
+              ],
+              "global": false,
+              "help": "Path to the binding profile",
+              "id": "file",
+              "long": "file",
+              "positional": false,
+              "required": false,
+              "short": "f"
+            },
+            {
+              "global": false,
+              "help": "Also check that this concrete address matches the profile's declared shape",
+              "id": "address",
+              "long": "address",
+              "positional": false,
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "long_about": "Accept or refuse a binding profile, and report the values it parsed.\n\nThe version is checked first, then the committed schema, then the one rule a schema cannot express: `address.pattern` has to compile with the Rust regex crate as well as Python `re`, so no lookaround and no backreferences.",
+          "name": "validate"
+        },
+        {
+          "about": "Write an agent's four field channel route: kind, address, endpoint and the egress credential slug",
+          "args": [
+            {
+              "default_values": [
+                "adapter.yaml"
+              ],
+              "global": false,
+              "help": "Path to the binding profile",
+              "id": "file",
+              "long": "file",
+              "positional": false,
+              "required": false,
+              "short": "f"
+            },
+            {
+              "global": false,
+              "help": "Agent id to bind",
+              "id": "agent",
+              "positional": true,
+              "required": true
+            },
+            {
+              "global": false,
+              "help": "The concrete address to bind, checked against the profile's shape",
+              "id": "address",
+              "long": "address",
+              "positional": false,
+              "required": true
+            },
+            {
+              "global": false,
+              "help": "The egress credential identity to write. Operator owned",
+              "id": "adapter_slug",
+              "long": "adapter-slug",
+              "positional": false,
+              "required": true
+            },
+            {
+              "global": false,
+              "help": "Reply route override, for a profile that declares no endpoint",
+              "id": "endpoint",
+              "long": "endpoint",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "http://localhost:28000"
+              ],
+              "env": "CURIE_API_URL",
+              "global": false,
+              "help": "Platform API base URL",
+              "id": "api_url",
+              "long": "api-url",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "curie-dev-key"
+              ],
+              "env": "CURIE_API_KEY",
+              "global": false,
+              "help": "Platform API key",
+              "id": "api_key",
+              "long": "api-key",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Confirm the destination and the credential identity, and write",
+              "id": "yes",
+              "long": "yes",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "long_about": "Write an agent's four field channel route: kind, address, endpoint and the egress credential slug.\n\n`--address` and `--adapter-slug` are operator inputs, never taken from the profile: `address.example` is authoring documentation, and the slug selects which stored secret the worker sends, so a profile chosen value could redirect another adapter's credential. A slug differing from the profile's suggestion is shown with both values before it is written.",
+          "name": "bind"
+        },
+        {
+          "about": "Mint a `chn` token for one concrete (kind, address) pair",
+          "args": [
+            {
+              "default_values": [
+                "adapter.yaml"
+              ],
+              "global": false,
+              "help": "Path to the binding profile",
+              "id": "file",
+              "long": "file",
+              "positional": false,
+              "required": false,
+              "short": "f"
+            },
+            {
+              "global": false,
+              "help": "The concrete address to mint for, checked against the profile's shape",
+              "id": "address",
+              "long": "address",
+              "positional": false,
+              "required": true
+            },
+            {
+              "default_values": [
+                "http://localhost:28000"
+              ],
+              "env": "CURIE_API_URL",
+              "global": false,
+              "help": "Platform API base URL",
+              "id": "api_url",
+              "long": "api-url",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "curie-dev-key"
+              ],
+              "env": "CURIE_API_KEY",
+              "global": false,
+              "help": "Platform API key",
+              "id": "api_key",
+              "long": "api-key",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "3600"
+              ],
+              "global": false,
+              "help": "Token lifetime in seconds. The API accepts 1 to 604800",
+              "id": "ttl_s",
+              "long": "ttl-s",
+              "positional": false,
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "long_about": "Mint a `chn` token for one concrete (kind, address) pair.\n\nThe only verb whose payload carries a credential value: it rides under `token` alongside `\"secret\": true`, on stdout and on no diagnostic stream.",
+          "name": "token"
+        },
+        {
+          "about": "Probe a deployed adapter from the outside: does this endpoint accept the egress secret you supply, does it refuse a wrong one, and are the route fields present for this pair",
+          "args": [
+            {
+              "default_values": [
+                "adapter.yaml"
+              ],
+              "global": false,
+              "help": "Path to the binding profile",
+              "id": "file",
+              "long": "file",
+              "positional": false,
+              "required": false,
+              "short": "f"
+            },
+            {
+              "global": false,
+              "help": "The concrete address to probe, checked against the profile's shape",
+              "id": "address",
+              "long": "address",
+              "positional": false,
+              "required": true
+            },
+            {
+              "global": false,
+              "help": "Reply route override, for a profile that declares no endpoint",
+              "id": "endpoint",
+              "long": "endpoint",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "http://localhost:28000"
+              ],
+              "env": "CURIE_API_URL",
+              "global": false,
+              "help": "Platform API base URL",
+              "id": "api_url",
+              "long": "api-url",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "curie-dev-key"
+              ],
+              "env": "CURIE_API_KEY",
+              "global": false,
+              "help": "Platform API key",
+              "id": "api_key",
+              "long": "api-key",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Read the egress secret from this file. One of the two accepted sources; the profile names the variable its own adapter reads and that name is never resolved here",
+              "id": "secret_file",
+              "long": "secret-file",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Read the egress secret from stdin instead",
+              "id": "secret_stdin",
+              "long": "secret-stdin",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Also post a real turn twice and assert the second is reported as a duplicate. This enqueues a REAL turn against the bound agent",
+              "id": "enqueue",
+              "long": "enqueue",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Probe a cleartext http endpoint anyway",
+              "id": "allow_insecure",
+              "long": "allow-insecure",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Confirm the destination and the credential identity, and probe",
+              "id": "yes",
+              "long": "yes",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "long_about": "Probe a deployed adapter from the outside: does this endpoint accept the egress secret you supply, does it refuse a wrong one, and are the route fields present for this pair.\n\nThose two narrow claims are all it makes. It does not prove the running worker holds that slug or that value, and it is not the conformance floor: `curie-adapter-conformance` is the stricter check.",
+          "name": "smoke-test"
+        }
+      ]
+    },
+    {
       "about": "Store and manage local secrets in Curie private storage",
       "hidden": false,
       "name": "secrets",

--- a/cli/schema/adapter-bind.schema.json
+++ b/cli/schema/adapter-bind.schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.curietech.ai/cli/adapter-bind/v1.json",
+  "title": "curie adapter bind --json",
+  "description": "The agent-facing payload of `curie adapter bind`: the whole four field route that was written. The API refuses a non-slack binding whose reply route is half set, so all four fields are reported together. `adapter` is the operator supplied slug, never the profile's suggestion, because that slug selects which stored secret the worker sends.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "agent": {
+      "type": "string",
+      "description": "The agent whose route was written."
+    },
+    "kind": {
+      "type": "string",
+      "description": "The channel kind, from the profile."
+    },
+    "address": {
+      "type": "string",
+      "description": "The concrete address that was bound, from --address."
+    },
+    "endpoint": {
+      "type": "string",
+      "description": "The reply route that was written."
+    },
+    "adapter": {
+      "type": "string",
+      "description": "The egress credential identity that was written, from --adapter-slug."
+    }
+  },
+  "required": [
+    "agent",
+    "kind",
+    "address",
+    "endpoint",
+    "adapter"
+  ]
+}

--- a/cli/schema/adapter-bind.schema.json
+++ b/cli/schema/adapter-bind.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://schemas.curietech.ai/cli/adapter-bind/v1.json",
+  "$id": "https://schemas.curietech.ai/cli/adapter-bind/v1.1.json",
   "title": "curie adapter bind --json",
   "description": "The agent-facing payload of `curie adapter bind`: the whole four field route that was written. The API refuses a non-slack binding whose reply route is half set, so all four fields are reported together. `adapter` is the operator supplied slug, never the profile's suggestion, because that slug selects which stored secret the worker sends.",
   "type": "object",
@@ -20,7 +20,7 @@
     },
     "endpoint": {
       "type": "string",
-      "description": "The reply route that was written."
+      "description": "The reply route that was written, reduced to scheme, host and port. The route the API stores is the full value, but a route can carry a token in its path or query and this payload is the form most likely to reach a CI artifact or a log aggregator, so the path and query are never reported."
     },
     "adapter": {
       "type": "string",

--- a/cli/schema/adapter-bind.schema.json
+++ b/cli/schema/adapter-bind.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://schemas.curietech.ai/cli/adapter-bind/v1.1.json",
+  "$id": "https://schemas.curietech.ai/cli/adapter-bind/v1.json",
   "title": "curie adapter bind --json",
   "description": "The agent-facing payload of `curie adapter bind`: the whole four field route that was written. The API refuses a non-slack binding whose reply route is half set, so all four fields are reported together. `adapter` is the operator supplied slug, never the profile's suggestion, because that slug selects which stored secret the worker sends.",
   "type": "object",

--- a/cli/schema/adapter-scaffold.schema.json
+++ b/cli/schema/adapter-scaffold.schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.curietech.ai/cli/adapter-scaffold/v1.json",
+  "title": "curie adapter scaffold --json",
+  "description": "The agent-facing payload of `curie adapter scaffold`: the one binding profile it wrote, the values it wrote into it, and the commands to run next. Credential IDENTITIES only, never a credential value.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "file": {
+      "type": "string",
+      "description": "Path of the binding profile that was written."
+    },
+    "kind": {
+      "type": "string",
+      "description": "The channel kind the scaffolded adapter owns."
+    },
+    "address": {
+      "type": "string",
+      "description": "The concrete address the profile was scaffolded for, and the one its generated pattern matches."
+    },
+    "endpoint": {
+      "type": "string",
+      "description": "The reply route written into the profile."
+    },
+    "adapter": {
+      "type": "string",
+      "description": "The egress credential identity the profile suggests. A suggestion only: bind requires an operator supplied slug."
+    },
+    "next_steps": {
+      "type": "array",
+      "description": "The commands that take this profile from authored to bound.",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "required": [
+    "file",
+    "kind",
+    "address",
+    "endpoint",
+    "adapter",
+    "next_steps"
+  ]
+}

--- a/cli/schema/adapter-smoke-test.schema.json
+++ b/cli/schema/adapter-smoke-test.schema.json
@@ -1,0 +1,157 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.curietech.ai/cli/adapter-smoke-test/v1.json",
+  "title": "curie adapter smoke-test --json",
+  "description": "The agent-facing payload of `curie adapter smoke-test`, machine readable in the same shape as the conformance kit's report. Two narrow claims only: the egress checks say whether THIS endpoint accepts the secret the operator supplied and refuses a wrong one, and the binding check says whether the route FIELDS are present for the pair. Neither says the running worker holds that slug or that value, and neither is whole floor conformance, which is why nothing here is named conformant and why manual_review_required is always reported. Credential IDENTITIES only, never a credential value; the endpoint is reduced to scheme, host and port.",
+  "type": "object",
+  "additionalProperties": false,
+  "$defs": {
+    "check": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The check's stable identifier."
+        },
+        "ok": {
+          "type": "boolean",
+          "description": "Whether this check passed."
+        },
+        "status": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "The HTTP status observed, or null when nothing answered."
+        },
+        "detail": {
+          "type": "string",
+          "description": "What was observed, in the narrow terms this verb is allowed to claim."
+        }
+      },
+      "required": [
+        "name",
+        "ok",
+        "status",
+        "detail"
+      ]
+    }
+  },
+  "properties": {
+    "endpoint": {
+      "type": "string",
+      "description": "The probed reply route, reduced to scheme, host and port. An endpoint can carry a token in its path or query."
+    },
+    "kind": {
+      "type": "string",
+      "description": "The channel kind probed."
+    },
+    "address": {
+      "type": "string",
+      "description": "The concrete address probed, from --address."
+    },
+    "verdict": {
+      "enum": [
+        "pass",
+        "fail"
+      ],
+      "description": "pass only when every check that ran passed. It is not a conformance verdict."
+    },
+    "counts": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "How many checks passed, failed, and did not run. A check that did not run is counted, never dropped, so no evidence never reads as evidence.",
+      "properties": {
+        "pass": {
+          "type": "integer"
+        },
+        "fail": {
+          "type": "integer"
+        },
+        "not_run": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "pass",
+        "fail",
+        "not_run"
+      ]
+    },
+    "manual_review_required": {
+      "type": "array",
+      "description": "The floor clauses no wire probe can observe, which a human has to read the adapter's code for.",
+      "items": {
+        "type": "string"
+      }
+    },
+    "egress_positive": {
+      "$ref": "#/$defs/check",
+      "description": "The endpoint accepted the operator supplied secret and answered inside the ack rules."
+    },
+    "egress_negative": {
+      "$ref": "#/$defs/check",
+      "description": "The endpoint refused a deliberately wrong secret. A 2xx here is a hard failure: the adapter is not authenticating the platform."
+    },
+    "binding": {
+      "$ref": "#/$defs/check",
+      "description": "The route fields are present for this pair: a 404 means unbound, a 409 means the reply route is unset."
+    },
+    "round_trip": {
+      "description": "The --enqueue check, or null when it did not run. It posts a REAL turn twice and asserts the second is reported as a duplicate.",
+      "anyOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "ok": {
+              "type": "boolean"
+            },
+            "status": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "detail": {
+              "type": "string"
+            },
+            "duplicate": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "description": "What the platform reported for the second post of the same delivery_id."
+            }
+          },
+          "required": [
+            "name",
+            "ok",
+            "status",
+            "detail",
+            "duplicate"
+          ]
+        },
+        {
+          "type": "null"
+        }
+      ]
+    }
+  },
+  "required": [
+    "endpoint",
+    "kind",
+    "address",
+    "verdict",
+    "counts",
+    "manual_review_required",
+    "egress_positive",
+    "egress_negative",
+    "binding",
+    "round_trip"
+  ]
+}

--- a/cli/schema/adapter-token.schema.json
+++ b/cli/schema/adapter-token.schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.curietech.ai/cli/adapter-token/v1.json",
+  "title": "curie adapter token --json",
+  "description": "The agent-facing payload of `curie adapter token`, the ONE result that carries a credential value and the one that declares itself as such. The token goes to stdout and to no diagnostic stream, so a caller can pipe stdout while keeping stderr in a log.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "token": {
+      "type": "string",
+      "description": "The minted chn token, scoped to the pair below for ttl_s seconds."
+    },
+    "secret": {
+      "type": "boolean",
+      "const": true,
+      "description": "Pinned true so a consumer can branch on it: this payload carries a credential value."
+    },
+    "kind": {
+      "type": "string",
+      "description": "The channel kind the token is scoped to."
+    },
+    "address": {
+      "type": "string",
+      "description": "The concrete address the token is scoped to. The API resolves on the pair, never the address alone."
+    },
+    "ttl_s": {
+      "type": "integer",
+      "description": "The token lifetime in seconds, between 1 and 604800."
+    }
+  },
+  "required": [
+    "token",
+    "secret",
+    "kind",
+    "address",
+    "ttl_s"
+  ]
+}

--- a/cli/schema/adapter-validate.schema.json
+++ b/cli/schema/adapter-validate.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://schemas.curietech.ai/cli/adapter-validate/v1.json",
+  "$id": "https://schemas.curietech.ai/cli/adapter-validate/v1.1.json",
   "title": "curie adapter validate --json",
   "description": "The agent-facing payload of `curie adapter validate`: the profile it parsed, not just a verdict. The parsed values are what the cross language corpus compares against, so an implementation that returned a constant instead of carrying the parsed field through is caught. Credential IDENTITIES only, never a credential value.",
   "type": "object",
@@ -33,7 +33,7 @@
             "string",
             "null"
           ],
-          "description": "The reply route, or null. Optional in a profile and reported as an explicit null so a consumer can read it unconditionally."
+          "description": "The reply route reduced to scheme, host and port, or null. A profile's route can carry a token in its path or query, so the path and query are never reported. Optional in a profile and reported as an explicit null so a consumer can read it unconditionally."
         },
         "address": {
           "type": "object",

--- a/cli/schema/adapter-validate.schema.json
+++ b/cli/schema/adapter-validate.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://schemas.curietech.ai/cli/adapter-validate/v1.1.json",
+  "$id": "https://schemas.curietech.ai/cli/adapter-validate/v1.json",
   "title": "curie adapter validate --json",
   "description": "The agent-facing payload of `curie adapter validate`: the profile it parsed, not just a verdict. The parsed values are what the cross language corpus compares against, so an implementation that returned a constant instead of carrying the parsed field through is caught. Credential IDENTITIES only, never a credential value.",
   "type": "object",
@@ -87,14 +87,10 @@
             "wire_version": {
               "type": "string",
               "description": "The reply wire version this adapter speaks, independent of the profile version."
-            },
-            "mints_reply_ref": {
-              "type": "boolean"
             }
           },
           "required": [
-            "wire_version",
-            "mints_reply_ref"
+            "wire_version"
           ]
         }
       },

--- a/cli/schema/adapter-validate.schema.json
+++ b/cli/schema/adapter-validate.schema.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.curietech.ai/cli/adapter-validate/v1.json",
+  "title": "curie adapter validate --json",
+  "description": "The agent-facing payload of `curie adapter validate`: the profile it parsed, not just a verdict. The parsed values are what the cross language corpus compares against, so an implementation that returned a constant instead of carrying the parsed field through is caught. Credential IDENTITIES only, never a credential value.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true,
+      "description": "Always true: a refused profile is an exit 2 usage error, not a payload."
+    },
+    "file": {
+      "type": "string",
+      "description": "Path of the profile that was read."
+    },
+    "profile": {
+      "type": "object",
+      "description": "The parsed binding profile.",
+      "additionalProperties": false,
+      "properties": {
+        "version": {
+          "type": "string",
+          "description": "The profile format version this file is written against."
+        },
+        "kind": {
+          "type": "string",
+          "description": "The channel kind this adapter owns."
+        },
+        "endpoint": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "The reply route, or null. Optional in a profile and reported as an explicit null so a consumer can read it unconditionally."
+        },
+        "address": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "type": "string"
+            },
+            "pattern": {
+              "type": "string",
+              "description": "The regex an address must match. It compiles in both Python re and the Rust regex crate."
+            },
+            "example": {
+              "type": "string",
+              "description": "A concrete address of this shape, for operator docs. Authoring documentation, never live deployment state."
+            }
+          },
+          "required": [
+            "description",
+            "pattern",
+            "example"
+          ]
+        },
+        "credentials": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "egress": {
+              "type": "string",
+              "description": "The egress credential identity this adapter suggests. A suggestion only."
+            },
+            "egress_secret_env": {
+              "type": "string",
+              "description": "The environment variable the ADAPTER reads its egress secret from. Documentation only; Curie never resolves this name."
+            },
+            "ingress_token_env": {
+              "type": "string",
+              "description": "The environment variable the ADAPTER reads its ingress token from. Documentation only; Curie never resolves this name."
+            }
+          },
+          "required": [
+            "egress",
+            "egress_secret_env",
+            "ingress_token_env"
+          ]
+        },
+        "conformance": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "wire_version": {
+              "type": "string",
+              "description": "The reply wire version this adapter speaks, independent of the profile version."
+            },
+            "mints_reply_ref": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "wire_version",
+            "mints_reply_ref"
+          ]
+        }
+      },
+      "required": [
+        "version",
+        "kind",
+        "endpoint",
+        "address",
+        "credentials",
+        "conformance"
+      ]
+    }
+  },
+  "required": [
+    "ok",
+    "file",
+    "profile"
+  ]
+}

--- a/cli/schema/baseline/adapter-bind.schema.json
+++ b/cli/schema/baseline/adapter-bind.schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.curietech.ai/cli/adapter-bind/v1.json",
+  "title": "curie adapter bind --json",
+  "description": "The agent-facing payload of `curie adapter bind`: the whole four field route that was written. The API refuses a non-slack binding whose reply route is half set, so all four fields are reported together. `adapter` is the operator supplied slug, never the profile's suggestion, because that slug selects which stored secret the worker sends.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "agent": {
+      "type": "string",
+      "description": "The agent whose route was written."
+    },
+    "kind": {
+      "type": "string",
+      "description": "The channel kind, from the profile."
+    },
+    "address": {
+      "type": "string",
+      "description": "The concrete address that was bound, from --address."
+    },
+    "endpoint": {
+      "type": "string",
+      "description": "The reply route that was written."
+    },
+    "adapter": {
+      "type": "string",
+      "description": "The egress credential identity that was written, from --adapter-slug."
+    }
+  },
+  "required": [
+    "agent",
+    "kind",
+    "address",
+    "endpoint",
+    "adapter"
+  ]
+}

--- a/cli/schema/baseline/adapter-bind.schema.json
+++ b/cli/schema/baseline/adapter-bind.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://schemas.curietech.ai/cli/adapter-bind/v1.json",
+  "$id": "https://schemas.curietech.ai/cli/adapter-bind/v1.1.json",
   "title": "curie adapter bind --json",
   "description": "The agent-facing payload of `curie adapter bind`: the whole four field route that was written. The API refuses a non-slack binding whose reply route is half set, so all four fields are reported together. `adapter` is the operator supplied slug, never the profile's suggestion, because that slug selects which stored secret the worker sends.",
   "type": "object",
@@ -20,7 +20,7 @@
     },
     "endpoint": {
       "type": "string",
-      "description": "The reply route that was written."
+      "description": "The reply route that was written, reduced to scheme, host and port. The route the API stores is the full value, but a route can carry a token in its path or query and this payload is the form most likely to reach a CI artifact or a log aggregator, so the path and query are never reported."
     },
     "adapter": {
       "type": "string",

--- a/cli/schema/baseline/adapter-bind.schema.json
+++ b/cli/schema/baseline/adapter-bind.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://schemas.curietech.ai/cli/adapter-bind/v1.1.json",
+  "$id": "https://schemas.curietech.ai/cli/adapter-bind/v1.json",
   "title": "curie adapter bind --json",
   "description": "The agent-facing payload of `curie adapter bind`: the whole four field route that was written. The API refuses a non-slack binding whose reply route is half set, so all four fields are reported together. `adapter` is the operator supplied slug, never the profile's suggestion, because that slug selects which stored secret the worker sends.",
   "type": "object",

--- a/cli/schema/baseline/adapter-scaffold.schema.json
+++ b/cli/schema/baseline/adapter-scaffold.schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.curietech.ai/cli/adapter-scaffold/v1.json",
+  "title": "curie adapter scaffold --json",
+  "description": "The agent-facing payload of `curie adapter scaffold`: the one binding profile it wrote, the values it wrote into it, and the commands to run next. Credential IDENTITIES only, never a credential value.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "file": {
+      "type": "string",
+      "description": "Path of the binding profile that was written."
+    },
+    "kind": {
+      "type": "string",
+      "description": "The channel kind the scaffolded adapter owns."
+    },
+    "address": {
+      "type": "string",
+      "description": "The concrete address the profile was scaffolded for, and the one its generated pattern matches."
+    },
+    "endpoint": {
+      "type": "string",
+      "description": "The reply route written into the profile."
+    },
+    "adapter": {
+      "type": "string",
+      "description": "The egress credential identity the profile suggests. A suggestion only: bind requires an operator supplied slug."
+    },
+    "next_steps": {
+      "type": "array",
+      "description": "The commands that take this profile from authored to bound.",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "required": [
+    "file",
+    "kind",
+    "address",
+    "endpoint",
+    "adapter",
+    "next_steps"
+  ]
+}

--- a/cli/schema/baseline/adapter-smoke-test.schema.json
+++ b/cli/schema/baseline/adapter-smoke-test.schema.json
@@ -1,0 +1,157 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.curietech.ai/cli/adapter-smoke-test/v1.json",
+  "title": "curie adapter smoke-test --json",
+  "description": "The agent-facing payload of `curie adapter smoke-test`, machine readable in the same shape as the conformance kit's report. Two narrow claims only: the egress checks say whether THIS endpoint accepts the secret the operator supplied and refuses a wrong one, and the binding check says whether the route FIELDS are present for the pair. Neither says the running worker holds that slug or that value, and neither is whole floor conformance, which is why nothing here is named conformant and why manual_review_required is always reported. Credential IDENTITIES only, never a credential value; the endpoint is reduced to scheme, host and port.",
+  "type": "object",
+  "additionalProperties": false,
+  "$defs": {
+    "check": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The check's stable identifier."
+        },
+        "ok": {
+          "type": "boolean",
+          "description": "Whether this check passed."
+        },
+        "status": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "The HTTP status observed, or null when nothing answered."
+        },
+        "detail": {
+          "type": "string",
+          "description": "What was observed, in the narrow terms this verb is allowed to claim."
+        }
+      },
+      "required": [
+        "name",
+        "ok",
+        "status",
+        "detail"
+      ]
+    }
+  },
+  "properties": {
+    "endpoint": {
+      "type": "string",
+      "description": "The probed reply route, reduced to scheme, host and port. An endpoint can carry a token in its path or query."
+    },
+    "kind": {
+      "type": "string",
+      "description": "The channel kind probed."
+    },
+    "address": {
+      "type": "string",
+      "description": "The concrete address probed, from --address."
+    },
+    "verdict": {
+      "enum": [
+        "pass",
+        "fail"
+      ],
+      "description": "pass only when every check that ran passed. It is not a conformance verdict."
+    },
+    "counts": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "How many checks passed, failed, and did not run. A check that did not run is counted, never dropped, so no evidence never reads as evidence.",
+      "properties": {
+        "pass": {
+          "type": "integer"
+        },
+        "fail": {
+          "type": "integer"
+        },
+        "not_run": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "pass",
+        "fail",
+        "not_run"
+      ]
+    },
+    "manual_review_required": {
+      "type": "array",
+      "description": "The floor clauses no wire probe can observe, which a human has to read the adapter's code for.",
+      "items": {
+        "type": "string"
+      }
+    },
+    "egress_positive": {
+      "$ref": "#/$defs/check",
+      "description": "The endpoint accepted the operator supplied secret and answered inside the ack rules."
+    },
+    "egress_negative": {
+      "$ref": "#/$defs/check",
+      "description": "The endpoint refused a deliberately wrong secret. A 2xx here is a hard failure: the adapter is not authenticating the platform."
+    },
+    "binding": {
+      "$ref": "#/$defs/check",
+      "description": "The route fields are present for this pair: a 404 means unbound, a 409 means the reply route is unset."
+    },
+    "round_trip": {
+      "description": "The --enqueue check, or null when it did not run. It posts a REAL turn twice and asserts the second is reported as a duplicate.",
+      "anyOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "ok": {
+              "type": "boolean"
+            },
+            "status": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "detail": {
+              "type": "string"
+            },
+            "duplicate": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "description": "What the platform reported for the second post of the same delivery_id."
+            }
+          },
+          "required": [
+            "name",
+            "ok",
+            "status",
+            "detail",
+            "duplicate"
+          ]
+        },
+        {
+          "type": "null"
+        }
+      ]
+    }
+  },
+  "required": [
+    "endpoint",
+    "kind",
+    "address",
+    "verdict",
+    "counts",
+    "manual_review_required",
+    "egress_positive",
+    "egress_negative",
+    "binding",
+    "round_trip"
+  ]
+}

--- a/cli/schema/baseline/adapter-token.schema.json
+++ b/cli/schema/baseline/adapter-token.schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.curietech.ai/cli/adapter-token/v1.json",
+  "title": "curie adapter token --json",
+  "description": "The agent-facing payload of `curie adapter token`, the ONE result that carries a credential value and the one that declares itself as such. The token goes to stdout and to no diagnostic stream, so a caller can pipe stdout while keeping stderr in a log.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "token": {
+      "type": "string",
+      "description": "The minted chn token, scoped to the pair below for ttl_s seconds."
+    },
+    "secret": {
+      "type": "boolean",
+      "const": true,
+      "description": "Pinned true so a consumer can branch on it: this payload carries a credential value."
+    },
+    "kind": {
+      "type": "string",
+      "description": "The channel kind the token is scoped to."
+    },
+    "address": {
+      "type": "string",
+      "description": "The concrete address the token is scoped to. The API resolves on the pair, never the address alone."
+    },
+    "ttl_s": {
+      "type": "integer",
+      "description": "The token lifetime in seconds, between 1 and 604800."
+    }
+  },
+  "required": [
+    "token",
+    "secret",
+    "kind",
+    "address",
+    "ttl_s"
+  ]
+}

--- a/cli/schema/baseline/adapter-validate.schema.json
+++ b/cli/schema/baseline/adapter-validate.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://schemas.curietech.ai/cli/adapter-validate/v1.json",
+  "$id": "https://schemas.curietech.ai/cli/adapter-validate/v1.1.json",
   "title": "curie adapter validate --json",
   "description": "The agent-facing payload of `curie adapter validate`: the profile it parsed, not just a verdict. The parsed values are what the cross language corpus compares against, so an implementation that returned a constant instead of carrying the parsed field through is caught. Credential IDENTITIES only, never a credential value.",
   "type": "object",
@@ -33,7 +33,7 @@
             "string",
             "null"
           ],
-          "description": "The reply route, or null. Optional in a profile and reported as an explicit null so a consumer can read it unconditionally."
+          "description": "The reply route reduced to scheme, host and port, or null. A profile's route can carry a token in its path or query, so the path and query are never reported. Optional in a profile and reported as an explicit null so a consumer can read it unconditionally."
         },
         "address": {
           "type": "object",

--- a/cli/schema/baseline/adapter-validate.schema.json
+++ b/cli/schema/baseline/adapter-validate.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://schemas.curietech.ai/cli/adapter-validate/v1.1.json",
+  "$id": "https://schemas.curietech.ai/cli/adapter-validate/v1.json",
   "title": "curie adapter validate --json",
   "description": "The agent-facing payload of `curie adapter validate`: the profile it parsed, not just a verdict. The parsed values are what the cross language corpus compares against, so an implementation that returned a constant instead of carrying the parsed field through is caught. Credential IDENTITIES only, never a credential value.",
   "type": "object",
@@ -87,14 +87,10 @@
             "wire_version": {
               "type": "string",
               "description": "The reply wire version this adapter speaks, independent of the profile version."
-            },
-            "mints_reply_ref": {
-              "type": "boolean"
             }
           },
           "required": [
-            "wire_version",
-            "mints_reply_ref"
+            "wire_version"
           ]
         }
       },

--- a/cli/schema/baseline/adapter-validate.schema.json
+++ b/cli/schema/baseline/adapter-validate.schema.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.curietech.ai/cli/adapter-validate/v1.json",
+  "title": "curie adapter validate --json",
+  "description": "The agent-facing payload of `curie adapter validate`: the profile it parsed, not just a verdict. The parsed values are what the cross language corpus compares against, so an implementation that returned a constant instead of carrying the parsed field through is caught. Credential IDENTITIES only, never a credential value.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true,
+      "description": "Always true: a refused profile is an exit 2 usage error, not a payload."
+    },
+    "file": {
+      "type": "string",
+      "description": "Path of the profile that was read."
+    },
+    "profile": {
+      "type": "object",
+      "description": "The parsed binding profile.",
+      "additionalProperties": false,
+      "properties": {
+        "version": {
+          "type": "string",
+          "description": "The profile format version this file is written against."
+        },
+        "kind": {
+          "type": "string",
+          "description": "The channel kind this adapter owns."
+        },
+        "endpoint": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "The reply route, or null. Optional in a profile and reported as an explicit null so a consumer can read it unconditionally."
+        },
+        "address": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "type": "string"
+            },
+            "pattern": {
+              "type": "string",
+              "description": "The regex an address must match. It compiles in both Python re and the Rust regex crate."
+            },
+            "example": {
+              "type": "string",
+              "description": "A concrete address of this shape, for operator docs. Authoring documentation, never live deployment state."
+            }
+          },
+          "required": [
+            "description",
+            "pattern",
+            "example"
+          ]
+        },
+        "credentials": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "egress": {
+              "type": "string",
+              "description": "The egress credential identity this adapter suggests. A suggestion only."
+            },
+            "egress_secret_env": {
+              "type": "string",
+              "description": "The environment variable the ADAPTER reads its egress secret from. Documentation only; Curie never resolves this name."
+            },
+            "ingress_token_env": {
+              "type": "string",
+              "description": "The environment variable the ADAPTER reads its ingress token from. Documentation only; Curie never resolves this name."
+            }
+          },
+          "required": [
+            "egress",
+            "egress_secret_env",
+            "ingress_token_env"
+          ]
+        },
+        "conformance": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "wire_version": {
+              "type": "string",
+              "description": "The reply wire version this adapter speaks, independent of the profile version."
+            },
+            "mints_reply_ref": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "wire_version",
+            "mints_reply_ref"
+          ]
+        }
+      },
+      "required": [
+        "version",
+        "kind",
+        "endpoint",
+        "address",
+        "credentials",
+        "conformance"
+      ]
+    }
+  },
+  "required": [
+    "ok",
+    "file",
+    "profile"
+  ]
+}

--- a/cli/schema/index.json
+++ b/cli/schema/index.json
@@ -13,7 +13,7 @@
       "result": "AdapterBindOutput",
       "kind": "CliOutput",
       "schema": "adapter-bind.schema.json",
-      "version": "1.1"
+      "version": "1.0"
     },
     {
       "result": "AdapterScaffoldOutput",
@@ -37,7 +37,7 @@
       "result": "AdapterValidateOutput",
       "kind": "CliOutput",
       "schema": "adapter-validate.schema.json",
-      "version": "1.1"
+      "version": "1.0"
     },
     {
       "result": "ApplyOutput",

--- a/cli/schema/index.json
+++ b/cli/schema/index.json
@@ -13,7 +13,7 @@
       "result": "AdapterBindOutput",
       "kind": "CliOutput",
       "schema": "adapter-bind.schema.json",
-      "version": "1.0"
+      "version": "1.1"
     },
     {
       "result": "AdapterScaffoldOutput",
@@ -37,7 +37,7 @@
       "result": "AdapterValidateOutput",
       "kind": "CliOutput",
       "schema": "adapter-validate.schema.json",
-      "version": "1.0"
+      "version": "1.1"
     },
     {
       "result": "ApplyOutput",

--- a/cli/schema/index.json
+++ b/cli/schema/index.json
@@ -10,6 +10,36 @@
       "version": "1.1"
     },
     {
+      "result": "AdapterBindOutput",
+      "kind": "CliOutput",
+      "schema": "adapter-bind.schema.json",
+      "version": "1.0"
+    },
+    {
+      "result": "AdapterScaffoldOutput",
+      "kind": "CliOutput",
+      "schema": "adapter-scaffold.schema.json",
+      "version": "1.0"
+    },
+    {
+      "result": "AdapterSmokeTestOutput",
+      "kind": "CliOutput",
+      "schema": "adapter-smoke-test.schema.json",
+      "version": "1.0"
+    },
+    {
+      "result": "AdapterTokenOutput",
+      "kind": "CliOutput",
+      "schema": "adapter-token.schema.json",
+      "version": "1.0"
+    },
+    {
+      "result": "AdapterValidateOutput",
+      "kind": "CliOutput",
+      "schema": "adapter-validate.schema.json",
+      "version": "1.0"
+    },
+    {
       "result": "ApplyOutput",
       "kind": "CliOutput",
       "schema": "apply.schema.json",

--- a/cli/src/adapter.rs
+++ b/cli/src/adapter.rs
@@ -1,0 +1,1126 @@
+//! `curie adapter`: author, validate and wire up a channel adapter binding
+//! profile (issue #1516).
+//!
+//! A binding profile is one install's `adapter.yaml`: the channel kind, the
+//! address shape, the reply route, and the credential IDENTITIES the adapter
+//! expects. It is authored by a third party, so this module treats it as data
+//! and never as an instruction:
+//!
+//! - `address.example` is authoring documentation. Every verb that resolves
+//!   against a concrete pair takes an explicit `--address`, checked against the
+//!   profile's own `address.pattern` before any request leaves.
+//! - `credentials.egress` is a non binding SUGGESTION. The worker indexes its
+//!   GLOBAL credential map by the slug the route carries, so a profile chosen
+//!   slug reaching the write path would let one adapter's file select another
+//!   adapter's secret. `bind` therefore requires `--adapter-slug` and writes
+//!   that value and only that value.
+//! - `credentials.egress_secret_env` documents what the ADAPTER reads. Nothing
+//!   here resolves it: `smoke-test` takes its egress secret from a file or from
+//!   stdin, supplied at the invocation boundary, or it refuses.
+//!
+//! The profile shape itself is validated against the committed
+//! `packages/channel-protocol` schema, so the CLI and the Python conformance kit
+//! agree on one contract instead of two mirrors. One rule cannot export: JSON
+//! Schema has no way to say "the Rust regex crate can compile this string", so
+//! `address.pattern` is an admitted PAIRED validator, enforced here in code and
+//! in `channel_protocol.manifest` in Python, with
+//! `packages/channel-protocol/schema/adapter-profile.corpus.json` as the drift
+//! gate between them.
+
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+use crate::api::{ApiClient, ChannelBindingWrite};
+use crate::exit::usage;
+use crate::ui::{CliOutput, Ui};
+
+/// The committed adapter binding profile schema, embedded at compile time.
+/// `packages/channel-protocol` exports and drift checks it against its own
+/// Pydantic models, so this constant tracks the frozen contract with no manual
+/// upkeep on the Rust side.
+const ADAPTER_PROFILE_SCHEMA: &str =
+    include_str!("../../packages/channel-protocol/schema/adapter-profile.schema.json");
+
+/// The profile format version this build understands. Independent of the reply
+/// wire version a profile declares in `conformance.wire_version`: conflating the
+/// two would let a wire bump silently invalidate every profile.
+pub const PROFILE_VERSION: &str = "1.0";
+
+/// The header the worker authenticates its egress with.
+const ADAPTER_SECRET_HEADER: &str = "X-Curie-Adapter-Secret";
+
+/// The worker refuses an acknowledgement body OVER this many bytes, so exactly
+/// this many still passes.
+const MAX_ACK_BODY_BYTES: usize = 65536;
+
+/// `ChannelTokenRequest.ttl_s` is `gt=0, le=604800`; a value outside that is a
+/// usage error here rather than a 422 from the API.
+const MAX_TTL_S: u64 = 604_800;
+
+/// What no wire probe can observe, reported on every smoke-test so a passing
+/// verdict is never read as whole floor conformance.
+const MANUAL_REVIEW_SECRET_ORDER: &str =
+    "floor clause 3c: that the adapter verifies the egress secret BEFORE any side effect. \
+     A probe sees the answer, never the order, so a human reads the request handler.";
+
+// ─── The profile ─────────────────────────────────────────────────────────────
+
+/// One install's binding profile for one adapter.
+///
+/// `deny_unknown_fields` is belt and braces behind the schema (which is closed
+/// too): a field this struct forgot becomes a loud parse failure rather than a
+/// silent drop.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct AdapterProfile {
+    pub version: String,
+    pub kind: String,
+    /// OPTIONAL here, required by the verbs that build a request from it. An
+    /// author publishes the address shape and the credential identities long
+    /// before any one install has a route. Absent reads back as JSON null, never
+    /// a missing key, so a consumer can branch on it unconditionally.
+    #[serde(default)]
+    pub endpoint: Option<String>,
+    pub address: AddressShape,
+    pub credentials: AdapterCredentials,
+    pub conformance: AdapterConformance,
+}
+
+/// The address form this adapter owns, as a regex plus a legible example.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct AddressShape {
+    pub description: String,
+    pub pattern: String,
+    pub example: String,
+}
+
+/// Which credential identities this adapter expects, by NAME only.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct AdapterCredentials {
+    /// A SUGGESTION. `bind` requires an operator supplied slug and never takes
+    /// this value alone.
+    pub egress: String,
+    /// Documentation of what the ADAPTER reads. Never resolved here.
+    pub egress_secret_env: String,
+    /// Documentation of what the ADAPTER reads. Never resolved here.
+    pub ingress_token_env: String,
+}
+
+/// What this adapter claims about the reply wire it speaks.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct AdapterConformance {
+    pub wire_version: String,
+    pub mints_reply_ref: bool,
+}
+
+/// The committed profile schema compiled with its root pointed at
+/// `AdapterProfile`. Same document, same `$defs`, different entry point.
+fn profile_validator() -> &'static jsonschema::Validator {
+    static VALIDATOR: std::sync::OnceLock<jsonschema::Validator> = std::sync::OnceLock::new();
+    VALIDATOR.get_or_init(|| {
+        let mut doc: serde_json::Value = serde_json::from_str(ADAPTER_PROFILE_SCHEMA).expect(
+            "packages/channel-protocol/schema/adapter-profile.schema.json is committed and valid JSON",
+        );
+        doc["$ref"] = serde_json::Value::String("#/$defs/AdapterProfile".to_string());
+        jsonschema::validator_for(&doc)
+            .expect("adapter-profile.schema.json's AdapterProfile def compiles to a validator")
+    })
+}
+
+/// Every way the committed schema rejects this document, joined.
+fn schema_errors(raw: &serde_json::Value) -> Option<String> {
+    let errors: Vec<String> = profile_validator()
+        .iter_errors(raw)
+        .map(|e| format!("{e} (at instance path {})", e.instance_path()))
+        .collect();
+    (!errors.is_empty()).then(|| errors.join("; "))
+}
+
+/// Read and accept one binding profile, in the order the acceptance rules run.
+///
+/// 1. The VERSION check, first and on its own. A schema for a version this build
+///    does not speak has no authority over the file, so reporting a field level
+///    error from it would send the author to fix a shape that was never theirs.
+/// 2. The committed schema, which is the sole authority for everything it can
+///    express.
+/// 3. The paired tier: `address.pattern` has to compile with the Rust regex
+///    crate, which JSON Schema cannot say.
+pub fn load_profile(file: &Path) -> Result<AdapterProfile> {
+    let raw = std::fs::read_to_string(file).map_err(|err| {
+        usage(format!(
+            "cannot read the adapter profile {}: {err}",
+            file.display()
+        ))
+    })?;
+    let value: serde_json::Value = serde_norway::from_str(&raw)
+        .map_err(|err| usage(format!("{} is not valid YAML: {err}", file.display())))?;
+
+    if let Some(declared) = value.get("version").and_then(|v| v.as_str()) {
+        if declared != PROFILE_VERSION {
+            return Err(usage(format!(
+                "{} declares adapter profile version {declared}; this build understands \
+                 version {PROFILE_VERSION}. Rewrite the profile against {PROFILE_VERSION}, \
+                 or use a Curie build that speaks {declared}.",
+                file.display()
+            )));
+        }
+    }
+
+    if let Some(errors) = schema_errors(&value) {
+        return Err(usage(format!(
+            "{} is not a valid adapter profile: {errors}",
+            file.display()
+        )));
+    }
+
+    let profile: AdapterProfile = serde_json::from_value(value).map_err(|err| {
+        usage(format!(
+            "{} is not a valid adapter profile: {err}",
+            file.display()
+        ))
+    })?;
+
+    compile_pattern(&profile.address.pattern, file)?;
+    Ok(profile)
+}
+
+/// The paired half of the address rule: the Rust regex dialect is the floor, so
+/// a pattern Python `re` compiles and this crate refuses (lookaround, a
+/// backreference) is refused here too rather than validating in one language and
+/// failing in the other.
+fn compile_pattern(pattern: &str, file: &Path) -> Result<regex::Regex> {
+    regex::Regex::new(pattern).map_err(|err| {
+        usage(format!(
+            "{}: address.pattern does not compile with the Rust regex crate, which is the \
+             floor both validators hold to (no lookaround, no backreferences): {err}",
+            file.display()
+        ))
+    })
+}
+
+/// Check an operator supplied address against the profile's declared shape,
+/// before any request. Without this the operator meets the mismatch as a 404
+/// from a live ingress instead of a usage error naming both halves.
+fn check_address(profile: &AdapterProfile, file: &Path, address: &str) -> Result<()> {
+    let pattern = compile_pattern(&profile.address.pattern, file)?;
+    if pattern.is_match(address) {
+        return Ok(());
+    }
+    Err(usage(format!(
+        "the address {address:?} does not match the shape {} declares: {}",
+        file.display(),
+        profile.address.pattern
+    )))
+}
+
+/// The route to POST reply events to: the explicit override, else the profile's
+/// own, else a usage error naming the missing field and the flag that supplies
+/// it. Never an empty string turned into a confusing HTTP error.
+fn resolve_endpoint(
+    profile: &AdapterProfile,
+    file: &Path,
+    override_endpoint: Option<&str>,
+) -> Result<String> {
+    if let Some(endpoint) = override_endpoint {
+        return Ok(endpoint.to_string());
+    }
+    match profile.endpoint.as_deref() {
+        Some(endpoint) => Ok(endpoint.to_string()),
+        None => Err(usage(format!(
+            "{} declares no endpoint, and this verb needs a concrete route: set endpoint \
+             in the profile, or pass --endpoint <url>",
+            file.display()
+        ))),
+    }
+}
+
+/// An endpoint reduced to scheme, host and port, the same redaction the worker's
+/// reply sink uses. An endpoint can carry a token in its path or query, and
+/// these strings reach terminals and logs.
+fn redacted(endpoint: &str) -> String {
+    match reqwest::Url::parse(endpoint) {
+        Ok(url) => match url.host_str() {
+            Some(host) => match url.port() {
+                Some(port) => format!("{}://{host}:{port}", url.scheme()),
+                None => format!("{}://{host}", url.scheme()),
+            },
+            None => "an unparseable endpoint".to_string(),
+        },
+        Err(_) => "an unparseable endpoint".to_string(),
+    }
+}
+
+// ─── scaffold ────────────────────────────────────────────────────────────────
+
+/// Options for `curie adapter scaffold`.
+#[derive(Debug, Clone)]
+pub struct ScaffoldOpts {
+    pub name: String,
+    pub kind: String,
+    pub address: String,
+    pub endpoint: String,
+    pub adapter: String,
+    pub dir: Option<PathBuf>,
+}
+
+/// Write one binding profile and print the next steps. Deliberately minimal: no
+/// project tree and no README, because the first thing an author would otherwise
+/// do after scaffolding is fix the scaffold's own output.
+///
+/// The generated `address.pattern` matches the address it was scaffolded for
+/// exactly (the address, regex escaped), so the profile it writes is one the
+/// validator accepts for that address on the very next command. Widen it by hand
+/// to the real shape of the channel's addresses.
+pub fn scaffold(opts: ScaffoldOpts) -> Result<AdapterScaffoldOutput> {
+    let root = opts.dir.unwrap_or_else(|| PathBuf::from("."));
+    let dir = root.join(&opts.name);
+    let file = dir.join("adapter.yaml");
+
+    let profile = AdapterProfile {
+        version: PROFILE_VERSION.to_string(),
+        kind: opts.kind.clone(),
+        endpoint: Some(opts.endpoint.clone()),
+        address: AddressShape {
+            description: format!("The {} address this adapter owns.", opts.kind),
+            pattern: format!("^{}$", regex::escape(&opts.address)),
+            example: opts.address.clone(),
+        },
+        credentials: AdapterCredentials {
+            egress: opts.adapter.clone(),
+            egress_secret_env: "CURIE_EGRESS_SECRET".to_string(),
+            ingress_token_env: "CURIE_INGRESS_TOKEN".to_string(),
+        },
+        conformance: AdapterConformance {
+            wire_version: "1.0".to_string(),
+            mints_reply_ref: false,
+        },
+    };
+
+    let body = serde_json::to_value(&profile).context("serializing the scaffolded profile")?;
+    if let Some(errors) = schema_errors(&body) {
+        return Err(usage(format!(
+            "those values do not make a valid adapter profile: {errors}"
+        )));
+    }
+    compile_pattern(&profile.address.pattern, &file)?;
+
+    if file.exists() {
+        return Err(usage(format!(
+            "{} already exists; scaffold never overwrites a profile",
+            file.display()
+        )));
+    }
+    std::fs::create_dir_all(&dir).with_context(|| format!("creating {}", dir.display()))?;
+    let yaml = serde_norway::to_string(&profile).context("rendering the profile as YAML")?;
+    let contents = format!("{}{yaml}", scaffold_header(&opts.address));
+    std::fs::write(&file, contents).with_context(|| format!("writing {}", file.display()))?;
+
+    let display = file.display().to_string();
+    Ok(AdapterScaffoldOutput {
+        next_steps: vec![
+            format!(
+                "curie adapter validate -f {display} --address {}",
+                opts.address
+            ),
+            format!(
+                "curie adapter bind -f {display} <agent> --address {} --adapter-slug {} --yes",
+                opts.address, opts.adapter
+            ),
+            format!(
+                "curie adapter smoke-test -f {display} --address {} --secret-file <path> --yes",
+                opts.address
+            ),
+        ],
+        file: display,
+        kind: opts.kind,
+        address: opts.address,
+        endpoint: opts.endpoint,
+        adapter: opts.adapter,
+    })
+}
+
+/// The comment block the scaffolded profile opens with: what the file is, and
+/// the one field an author almost always has to widen.
+fn scaffold_header(address: &str) -> String {
+    format!(
+        "# One install's binding profile for one channel adapter.\n\
+         #\n\
+         # address.pattern below matches exactly {address}, the address this was\n\
+         # scaffolded for. Widen it to the real shape of your channel's addresses; it\n\
+         # must compile in both Python re and the Rust regex crate, so no lookaround\n\
+         # and no backreferences.\n\
+         #\n\
+         # credentials names IDENTITIES only. egress is a suggestion that `curie\n\
+         # adapter bind` asks an operator to confirm, and the two env entries\n\
+         # document what your adapter reads. Curie resolves neither.\n"
+    )
+}
+
+/// Output of `adapter scaffold`.
+#[derive(Debug)]
+pub struct AdapterScaffoldOutput {
+    pub file: String,
+    pub kind: String,
+    pub address: String,
+    pub endpoint: String,
+    pub adapter: String,
+    pub next_steps: Vec<String>,
+}
+
+impl CliOutput for AdapterScaffoldOutput {
+    fn to_json(&self) -> serde_json::Value {
+        serde_json::json!({
+            "file": self.file,
+            "kind": self.kind,
+            "address": self.address,
+            "endpoint": self.endpoint,
+            "adapter": self.adapter,
+            "next_steps": self.next_steps,
+        })
+    }
+
+    fn render(&self, ui: &Ui) {
+        ui.payload(&format!("wrote {}", self.file));
+        for step in &self.next_steps {
+            ui.payload_plain(step);
+        }
+    }
+}
+
+// ─── validate ────────────────────────────────────────────────────────────────
+
+/// Accept or refuse one profile, and report the values it parsed.
+///
+/// The payload carries the parsed profile rather than a bare verdict, because
+/// the parsed values are what the cross language corpus compares against.
+pub fn validate(file: &Path, address: Option<&str>) -> Result<AdapterValidateOutput> {
+    let profile = load_profile(file)?;
+    if let Some(address) = address {
+        check_address(&profile, file, address)?;
+    }
+    Ok(AdapterValidateOutput {
+        file: file.display().to_string(),
+        profile,
+    })
+}
+
+/// Output of `adapter validate`.
+#[derive(Debug)]
+pub struct AdapterValidateOutput {
+    pub file: String,
+    pub profile: AdapterProfile,
+}
+
+impl CliOutput for AdapterValidateOutput {
+    fn to_json(&self) -> serde_json::Value {
+        serde_json::json!({
+            "ok": true,
+            "file": self.file,
+            "profile": serde_json::to_value(&self.profile)
+                .expect("a parsed adapter profile serializes"),
+        })
+    }
+
+    fn render(&self, ui: &Ui) {
+        ui.payload(&format!("{} is a valid adapter profile", self.file));
+        ui.kv("kind", &self.profile.kind);
+        ui.kv("address", &self.profile.address.pattern);
+        ui.kv(
+            "endpoint",
+            self.profile.endpoint.as_deref().unwrap_or("unset"),
+        );
+        ui.kv("egress", &self.profile.credentials.egress);
+    }
+}
+
+// ─── bind ────────────────────────────────────────────────────────────────────
+
+/// Options for `curie adapter bind`.
+#[derive(Debug, Clone)]
+pub struct BindOpts {
+    pub file: PathBuf,
+    pub agent: String,
+    pub address: String,
+    pub adapter_slug: String,
+    pub endpoint: Option<String>,
+    pub api_url: String,
+    pub api_key: String,
+    pub yes: bool,
+}
+
+/// Write the four field route for one agent.
+///
+/// The slug written is ALWAYS the operator's `--adapter-slug`. The profile's
+/// `credentials.egress` is read for one purpose only: to show the operator that
+/// the file suggested something else, which is a confirmation and never a
+/// selection. The worker indexes its global credential map by this slug, so a
+/// profile chosen value here would let one adapter's file redirect another
+/// adapter's secret to the endpoint that same file names.
+pub async fn bind(opts: BindOpts) -> Result<AdapterBindOutput> {
+    let profile = load_profile(&opts.file)?;
+    check_address(&profile, &opts.file, &opts.address)?;
+    let endpoint = resolve_endpoint(&profile, &opts.file, opts.endpoint.as_deref())?;
+
+    let suggested = profile.credentials.egress.as_str();
+    if !opts.yes {
+        let mut refusal = format!(
+            "binding {} would point the platform's authenticated egress at {}, under the \
+             egress credential {:?}. Re-run with --yes to confirm.",
+            opts.agent,
+            redacted(&endpoint),
+            opts.adapter_slug
+        );
+        if suggested != opts.adapter_slug {
+            refusal.push_str(&format!(
+                " The profile suggests a DIFFERENT slug: it names {suggested:?} and you passed \
+                 {:?}. The slug selects which stored secret the worker sends, so confirm the \
+                 one you meant.",
+                opts.adapter_slug
+            ));
+        }
+        return Err(usage(refusal));
+    }
+
+    let client = ApiClient::new(&opts.api_url, &opts.api_key)?;
+    let binding = ChannelBindingWrite {
+        kind: profile.kind.clone(),
+        address: opts.address.clone(),
+        endpoint: endpoint.clone(),
+        adapter: opts.adapter_slug.clone(),
+    };
+    client.set_agent_channel(&opts.agent, &binding).await?;
+
+    Ok(AdapterBindOutput {
+        agent: opts.agent,
+        kind: binding.kind,
+        address: binding.address,
+        endpoint: binding.endpoint,
+        adapter: binding.adapter,
+    })
+}
+
+/// Output of `adapter bind`: the whole route that was written, so the operator
+/// reads back the slug that will select the egress secret.
+#[derive(Debug)]
+pub struct AdapterBindOutput {
+    pub agent: String,
+    pub kind: String,
+    pub address: String,
+    pub endpoint: String,
+    pub adapter: String,
+}
+
+impl CliOutput for AdapterBindOutput {
+    fn to_json(&self) -> serde_json::Value {
+        serde_json::json!({
+            "agent": self.agent,
+            "kind": self.kind,
+            "address": self.address,
+            "endpoint": self.endpoint,
+            "adapter": self.adapter,
+        })
+    }
+
+    fn render(&self, ui: &Ui) {
+        ui.payload(&format!("bound {} to {}", self.agent, self.kind));
+        ui.kv("address", &self.address);
+        ui.kv("endpoint", &redacted(&self.endpoint));
+        ui.kv("adapter", &self.adapter);
+    }
+}
+
+// ─── token ───────────────────────────────────────────────────────────────────
+
+/// Options for `curie adapter token`.
+#[derive(Debug, Clone)]
+pub struct TokenOpts {
+    pub file: PathBuf,
+    pub address: String,
+    pub api_url: String,
+    pub api_key: String,
+    pub ttl_s: u64,
+}
+
+/// Mint a `chn` token for the concrete `(kind, address)` pair.
+///
+/// This is the one verb whose payload carries a secret VALUE, and it says so:
+/// the token rides under `token` alongside `"secret": true`, goes to stdout and
+/// to no diagnostic stream, so a caller can pipe stdout while keeping stderr in
+/// a log.
+pub async fn token(opts: TokenOpts) -> Result<AdapterTokenOutput> {
+    let profile = load_profile(&opts.file)?;
+    check_address(&profile, &opts.file, &opts.address)?;
+    if opts.ttl_s == 0 || opts.ttl_s > MAX_TTL_S {
+        return Err(usage(format!(
+            "--ttl-s {} is outside what the API accepts (1 to {MAX_TTL_S} seconds)",
+            opts.ttl_s
+        )));
+    }
+
+    let client = http_client()?;
+    let (status, body) = post_channel_token(
+        &client,
+        &opts.api_url,
+        &opts.api_key,
+        &profile.kind,
+        &opts.address,
+        opts.ttl_s,
+    )
+    .await?;
+    if !status.is_success() {
+        return Err(anyhow::anyhow!(
+            "minting a channel token failed with {status}: {}",
+            body.trim()
+        ));
+    }
+
+    let minted: MintedToken = serde_json::from_str(&body).context("decoding the minted token")?;
+    Ok(AdapterTokenOutput {
+        token: minted.token,
+        kind: profile.kind,
+        address: opts.address,
+        ttl_s: opts.ttl_s,
+    })
+}
+
+/// `ChannelTokenOut`, the mint response.
+#[derive(Debug, Deserialize)]
+struct MintedToken {
+    token: String,
+}
+
+/// Output of `adapter token`.
+#[derive(Debug)]
+pub struct AdapterTokenOutput {
+    pub token: String,
+    pub kind: String,
+    pub address: String,
+    pub ttl_s: u64,
+}
+
+impl CliOutput for AdapterTokenOutput {
+    fn to_json(&self) -> serde_json::Value {
+        serde_json::json!({
+            "token": self.token,
+            "secret": true,
+            "kind": self.kind,
+            "address": self.address,
+            "ttl_s": self.ttl_s,
+        })
+    }
+
+    fn render(&self, ui: &Ui) {
+        // The token alone, with no surrounding line: the human path is also the
+        // one a shell pipes into a variable.
+        ui.payload_plain(&self.token);
+    }
+}
+
+// ─── smoke-test ──────────────────────────────────────────────────────────────
+
+/// Options for `curie adapter smoke-test`.
+#[derive(Debug, Clone)]
+pub struct SmokeTestOpts {
+    pub file: PathBuf,
+    pub address: String,
+    pub endpoint: Option<String>,
+    pub api_url: String,
+    pub api_key: String,
+    pub secret_file: Option<PathBuf>,
+    pub secret_stdin: bool,
+    pub enqueue: bool,
+    pub allow_insecure: bool,
+    pub yes: bool,
+}
+
+/// Probe a deployed adapter from the outside.
+///
+/// What the checks are allowed to claim is narrow on purpose. The egress checks
+/// prove that THIS endpoint accepts the secret the operator supplied and refuses
+/// a wrong one; the binding check proves the route FIELDS are present. Neither
+/// proves the running worker holds that slug or that value, because the worker's
+/// lookup happens on its own side and the secret only travels during a real
+/// emit.
+pub async fn smoke_test(opts: SmokeTestOpts) -> Result<()> {
+    let profile = load_profile(&opts.file)?;
+    check_address(&profile, &opts.file, &opts.address)?;
+    let endpoint = resolve_endpoint(&profile, &opts.file, opts.endpoint.as_deref())?;
+
+    let (secret, source) = read_egress_secret(opts.secret_file.as_deref(), opts.secret_stdin)?;
+
+    if !endpoint.starts_with("https://") && !opts.allow_insecure {
+        return Err(usage(format!(
+            "{} is not an https route, so the egress secret would travel in cleartext. \
+             Pass --allow-insecure to probe it anyway.",
+            redacted(&endpoint)
+        )));
+    }
+
+    if !opts.yes {
+        return Err(usage(format!(
+            "this would send the secret from {source} to {}, as the egress identity the \
+             profile names ({:?}). Re-run with --yes to confirm both halves.",
+            redacted(&endpoint),
+            profile.credentials.egress
+        )));
+    }
+
+    let client = http_client()?;
+    let conversation = format!("curie-smoke-{}", uuid::Uuid::new_v4());
+    let event = status_event(&profile.kind, &opts.address, &conversation);
+
+    let positive = probe_egress(&client, &endpoint, &secret, &event, "egress_positive").await;
+    let wrong = format!("{secret}-not-the-secret");
+    let negative = refusal_of_a_wrong_secret(
+        probe_egress(&client, &endpoint, &wrong, &event, "egress_negative").await,
+    );
+
+    let (binding, minted) = probe_binding(&client, &opts, &profile).await;
+    let round_trip = if opts.enqueue {
+        Some(probe_round_trip(&client, &opts, &profile, minted.as_deref()).await)
+    } else {
+        None
+    };
+
+    let out = AdapterSmokeTestOutput {
+        endpoint: redacted(&endpoint),
+        kind: profile.kind,
+        address: opts.address,
+        egress_positive: positive,
+        egress_negative: negative,
+        binding,
+        round_trip,
+    };
+    let failed = out.counts().1;
+    crate::ui::ui().emit(&out);
+    if failed > 0 {
+        std::process::exit(crate::exit::ExitClass::Failure.code());
+    }
+    Ok(())
+}
+
+/// The egress secret, from a file or from stdin, and never from anywhere else.
+///
+/// `credentials.egress_secret_env` names a variable the ADAPTER reads; resolving
+/// it here would let a third party file choose which of an operator's secrets
+/// gets read and, in the same breath, where it is sent. There is deliberately no
+/// flag that names a variable either.
+fn read_egress_secret(file: Option<&Path>, stdin: bool) -> Result<(String, String)> {
+    match (file, stdin) {
+        (Some(path), false) => {
+            let raw = std::fs::read_to_string(path).map_err(|err| {
+                usage(format!(
+                    "cannot read the egress secret {}: {err}",
+                    path.display()
+                ))
+            })?;
+            let value = raw.trim().to_string();
+            if value.is_empty() {
+                return Err(usage(format!("{} is empty", path.display())));
+            }
+            Ok((value, path.display().to_string()))
+        }
+        (None, true) => {
+            let mut raw = String::new();
+            std::io::stdin()
+                .read_to_string(&mut raw)
+                .context("reading the egress secret from stdin")?;
+            let value = raw.trim().to_string();
+            if value.is_empty() {
+                return Err(usage("stdin carried no egress secret"));
+            }
+            Ok((value, "stdin".to_string()))
+        }
+        (Some(_), true) => Err(usage(
+            "pass the egress secret through --secret-file OR --secret-stdin, not both",
+        )),
+        (None, false) => Err(usage(
+            "an explicit egress secret source is required: pass --secret-file <path> or \
+             --secret-stdin. A profile names the variable its own adapter reads and that name \
+             is never resolved here, so nothing is read from your environment.",
+        )),
+    }
+}
+
+/// The best effort, side effect free probe event. `turn.status` is explicitly
+/// best effort at the adapter, so steps that send it cause no agent run and no
+/// outbound message.
+fn status_event(kind: &str, address: &str, conversation: &str) -> serde_json::Value {
+    serde_json::json!({
+        "version": "1.0",
+        "event": "turn.status",
+        "target": {
+            "kind": kind,
+            "address": address,
+            "conversation_id": conversation,
+            "reply_ref": serde_json::Value::Null,
+        },
+        "status": "curie adapter smoke test",
+    })
+}
+
+/// One check's verdict.
+#[derive(Debug, Clone)]
+pub struct CheckResult {
+    pub name: String,
+    pub ok: bool,
+    pub status: Option<u16>,
+    pub detail: String,
+}
+
+impl CheckResult {
+    fn to_json(&self) -> serde_json::Value {
+        serde_json::json!({
+            "name": self.name,
+            "ok": self.ok,
+            "status": self.status,
+            "detail": self.detail,
+        })
+    }
+}
+
+/// POST the probe event under one secret and judge the answer against the wire
+/// floor: 2xx, a JSON body, at or under the ack cap, and never a redirect.
+async fn probe_egress(
+    client: &reqwest::Client,
+    endpoint: &str,
+    secret: &str,
+    event: &serde_json::Value,
+    name: &str,
+) -> CheckResult {
+    let sent = client
+        .post(endpoint)
+        .header("Content-Type", "application/json")
+        .header(ADAPTER_SECRET_HEADER, secret)
+        .json(event)
+        .send()
+        .await;
+    let response = match sent {
+        Ok(response) => response,
+        Err(err) => {
+            return CheckResult {
+                name: name.to_string(),
+                ok: false,
+                status: None,
+                detail: format!("the endpoint did not answer: {err}"),
+            }
+        }
+    };
+    let status = response.status().as_u16();
+    let body = response.bytes().await.unwrap_or_default();
+    let mut detail = format!("the endpoint answered {status}");
+    let mut ok = (200..300).contains(&status);
+    if (300..400).contains(&status) {
+        ok = false;
+        detail = format!(
+            "the endpoint answered {status} (a redirect), which the worker refuses rather \
+             than replaying the egress credential at the redirect target"
+        );
+    } else if ok && body.len() > MAX_ACK_BODY_BYTES {
+        ok = false;
+        detail = format!(
+            "the acknowledgement body is {} bytes, over the {MAX_ACK_BODY_BYTES} byte cap",
+            body.len()
+        );
+    } else if ok && serde_json::from_slice::<serde_json::Value>(&body).is_err() {
+        ok = false;
+        detail = format!("the endpoint answered {status} with a body that is not JSON");
+    }
+    CheckResult {
+        name: name.to_string(),
+        ok,
+        status: Some(status),
+        detail,
+    }
+}
+
+/// The negative probe's verdict is INVERTED: the adapter must refuse a
+/// deliberately wrong secret, so a 2xx here is a hard failure, meaning it is not
+/// authenticating the platform at all.
+fn refusal_of_a_wrong_secret(outcome: CheckResult) -> CheckResult {
+    let accepted = |status: u16| (200..300).contains(&status);
+    CheckResult {
+        name: outcome.name,
+        ok: outcome.status.is_some_and(|status| !accepted(status)),
+        status: outcome.status,
+        detail: match outcome.status {
+            Some(status) if accepted(status) => {
+                "the endpoint accepted a WRONG secret; it is not authenticating the platform"
+                    .to_string()
+            }
+            Some(status) => format!("the endpoint refused a wrong secret with {status}"),
+            None => outcome.detail,
+        },
+    }
+}
+
+/// Mint a token for the pair, which is what proves the route FIELDS are present:
+/// a 404 means the pair is unbound and a 409 means the reply route is unset.
+async fn probe_binding(
+    client: &reqwest::Client,
+    opts: &SmokeTestOpts,
+    profile: &AdapterProfile,
+) -> (CheckResult, Option<String>) {
+    let sent = post_channel_token(
+        client,
+        &opts.api_url,
+        &opts.api_key,
+        &profile.kind,
+        &opts.address,
+        3600,
+    )
+    .await;
+    let (status, body) = match sent {
+        Ok(pair) => pair,
+        Err(err) => {
+            return (
+                CheckResult {
+                    name: "binding".to_string(),
+                    ok: false,
+                    status: None,
+                    detail: format!("the platform API did not answer: {err:#}"),
+                },
+                None,
+            )
+        }
+    };
+    let code = status.as_u16();
+    let detail = match code {
+        404 => "no agent is bound to this pair; bind one first".to_string(),
+        409 => "the binding carries no reply route; bind its endpoint and adapter slug".to_string(),
+        _ if status.is_success() => {
+            "the route fields are present for this pair. This says nothing about whether the \
+             worker holds a credential under that slug."
+                .to_string()
+        }
+        _ => format!("the platform API answered {code}: {}", body.trim()),
+    };
+    let minted = status
+        .is_success()
+        .then(|| {
+            serde_json::from_str::<MintedToken>(&body)
+                .ok()
+                .map(|m| m.token)
+        })
+        .flatten();
+    (
+        CheckResult {
+            name: "binding".to_string(),
+            ok: status.is_success(),
+            status: Some(code),
+            detail,
+        },
+        minted,
+    )
+}
+
+/// Post the same delivery twice and assert the second answer is the platform's
+/// duplicate. Opt in behind `--enqueue` because it enqueues a REAL turn.
+async fn probe_round_trip(
+    client: &reqwest::Client,
+    opts: &SmokeTestOpts,
+    profile: &AdapterProfile,
+    token: Option<&str>,
+) -> RoundTrip {
+    let Some(token) = token else {
+        return RoundTrip {
+            check: CheckResult {
+                name: "round_trip".to_string(),
+                ok: false,
+                status: None,
+                detail: "no channel token was minted, so no turn could be posted".to_string(),
+            },
+            duplicate: None,
+        };
+    };
+    let delivery = format!("curie-smoke-{}", uuid::Uuid::new_v4());
+    let body = serde_json::json!({
+        "kind": profile.kind,
+        "address": opts.address,
+        "delivery_id": delivery,
+        "conversation_id": delivery,
+        "author": "curie-adapter-smoke-test",
+        "text": "curie adapter smoke test",
+    });
+    let url = format!("{}/channels/turns", opts.api_url.trim_end_matches('/'));
+
+    let mut last: Option<(u16, serde_json::Value)> = None;
+    for _ in 0..2 {
+        let sent = client
+            .post(&url)
+            .header("X-API-Key", token)
+            .json(&body)
+            .send()
+            .await;
+        let response = match sent {
+            Ok(response) => response,
+            Err(err) => {
+                return RoundTrip {
+                    check: CheckResult {
+                        name: "round_trip".to_string(),
+                        ok: false,
+                        status: None,
+                        detail: format!("the platform API did not answer: {err}"),
+                    },
+                    duplicate: None,
+                }
+            }
+        };
+        let status = response.status().as_u16();
+        let payload = response
+            .json::<serde_json::Value>()
+            .await
+            .unwrap_or(serde_json::Value::Null);
+        last = Some((status, payload));
+    }
+
+    let (status, payload) = last.expect("two attempts were made");
+    let duplicate = payload
+        .get("duplicate")
+        .and_then(serde_json::Value::as_bool);
+    RoundTrip {
+        check: CheckResult {
+            name: "round_trip".to_string(),
+            ok: duplicate == Some(true),
+            status: Some(status),
+            detail: match duplicate {
+                Some(true) => "the re-posted delivery converged on the first answer".to_string(),
+                _ => "the re-posted delivery was not reported as a duplicate".to_string(),
+            },
+        },
+        duplicate,
+    }
+}
+
+/// The round trip check plus the platform's duplicate verdict.
+#[derive(Debug, Clone)]
+pub struct RoundTrip {
+    pub check: CheckResult,
+    pub duplicate: Option<bool>,
+}
+
+/// Output of `adapter smoke-test`.
+#[derive(Debug)]
+pub struct AdapterSmokeTestOutput {
+    pub endpoint: String,
+    pub kind: String,
+    pub address: String,
+    pub egress_positive: CheckResult,
+    pub egress_negative: CheckResult,
+    pub binding: CheckResult,
+    pub round_trip: Option<RoundTrip>,
+}
+
+impl AdapterSmokeTestOutput {
+    fn checks(&self) -> Vec<&CheckResult> {
+        let mut checks = vec![&self.egress_positive, &self.egress_negative, &self.binding];
+        if let Some(round_trip) = &self.round_trip {
+            checks.push(&round_trip.check);
+        }
+        checks
+    }
+
+    /// `(pass, fail, not_run)`. A check that did not run is counted, never
+    /// dropped, so no evidence never reads as evidence.
+    fn counts(&self) -> (u64, u64, u64) {
+        let mut pass = 0;
+        let mut fail = 0;
+        for check in self.checks() {
+            if check.ok {
+                pass += 1;
+            } else {
+                fail += 1;
+            }
+        }
+        let not_run = u64::from(self.round_trip.is_none());
+        (pass, fail, not_run)
+    }
+}
+
+impl CliOutput for AdapterSmokeTestOutput {
+    fn to_json(&self) -> serde_json::Value {
+        let (pass, fail, not_run) = self.counts();
+        serde_json::json!({
+            "endpoint": self.endpoint,
+            "kind": self.kind,
+            "address": self.address,
+            "verdict": if fail == 0 { "pass" } else { "fail" },
+            "counts": {"pass": pass, "fail": fail, "not_run": not_run},
+            "manual_review_required": [MANUAL_REVIEW_SECRET_ORDER],
+            "egress_positive": self.egress_positive.to_json(),
+            "egress_negative": self.egress_negative.to_json(),
+            "binding": self.binding.to_json(),
+            "round_trip": match &self.round_trip {
+                Some(round_trip) => {
+                    let mut value = round_trip.check.to_json();
+                    value["duplicate"] = serde_json::json!(round_trip.duplicate);
+                    value
+                }
+                None => serde_json::Value::Null,
+            },
+        })
+    }
+
+    fn render(&self, ui: &Ui) {
+        let (pass, fail, not_run) = self.counts();
+        ui.payload(&format!("{} {}", self.kind, self.endpoint));
+        for check in self.checks() {
+            ui.payload_plain(&format!(
+                "{}  {}  {}",
+                if check.ok { "pass" } else { "fail" },
+                check.name,
+                check.detail
+            ));
+        }
+        ui.payload_plain(&format!("{pass} passed, {fail} failed, {not_run} not run"));
+        ui.payload_plain(MANUAL_REVIEW_SECRET_ORDER);
+    }
+}
+
+// ─── HTTP ────────────────────────────────────────────────────────────────────
+
+/// The one client these verbs use. Redirects are disabled: following one would
+/// replay the egress secret at whatever origin the redirect named, which is the
+/// same reason the worker refuses them.
+fn http_client() -> Result<reqwest::Client> {
+    reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .connect_timeout(std::time::Duration::from_secs(5))
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+        .context("building HTTP client")
+}
+
+/// `POST /channels/token` for one concrete pair, returning the raw answer so
+/// each caller judges the status itself (a mint failure is fatal to `token` and
+/// a reported check to `smoke-test`).
+async fn post_channel_token(
+    client: &reqwest::Client,
+    api_url: &str,
+    api_key: &str,
+    kind: &str,
+    address: &str,
+    ttl_s: u64,
+) -> Result<(reqwest::StatusCode, String)> {
+    let url = format!("{}/channels/token", api_url.trim_end_matches('/'));
+    let response = client
+        .post(&url)
+        .header("X-API-Key", api_key)
+        .json(&serde_json::json!({
+            "kind": kind,
+            "address": address,
+            "ttl_s": ttl_s,
+        }))
+        .send()
+        .await
+        .context("POST /channels/token")?;
+    let status = response.status();
+    let body = response.text().await.unwrap_or_default();
+    Ok((status, body))
+}

--- a/cli/src/adapter.rs
+++ b/cli/src/adapter.rs
@@ -1120,12 +1120,22 @@ async fn probe_round_trip(
             duplicate: None,
         };
     };
+    // One id, minted once and reused for every identity field in the body, which
+    // is what makes the SECOND post a re-post rather than a second delivery.
+    // `reply_ref` is opaque and adapter minted (a Slack `ts`, a mail
+    // `Message-Id`), so a probe with no real upstream message mints its own; the
+    // platform requires it and hands it back to the adapter to address the reply
+    // to. It has to be BYTE IDENTICAL across the two posts, and it is, because
+    // both posts send this one `body` value: a fresh handle on the second post
+    // would describe a different delivery and defeat the duplicate detection
+    // this probe exists to demonstrate.
     let delivery = format!("curie-smoke-{}", uuid::Uuid::new_v4());
     let body = serde_json::json!({
         "kind": profile.kind,
         "address": opts.address,
         "delivery_id": delivery,
         "conversation_id": delivery,
+        "reply_ref": delivery,
         "author": "curie-adapter-smoke-test",
         "text": "curie adapter smoke test",
     });

--- a/cli/src/adapter.rs
+++ b/cli/src/adapter.rs
@@ -124,11 +124,14 @@ pub struct AdapterCredentials {
 }
 
 /// What this adapter claims about the reply wire it speaks.
+///
+/// `wire_version` is the reply wire and is INDEPENDENT of the profile's own
+/// `version`: conflating the two would let a wire bump silently invalidate every
+/// profile.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct AdapterConformance {
     pub wire_version: String,
-    pub mints_reply_ref: bool,
 }
 
 /// The committed profile schema compiled with its root pointed at
@@ -146,10 +149,28 @@ fn profile_validator() -> &'static jsonschema::Validator {
 }
 
 /// Every way the committed schema rejects this document, joined.
+///
+/// A validation error renders the INSTANCE it rejected, and the one instance in
+/// this document that can carry a credential is `endpoint`: the very profile the
+/// schema refuses for embedding userinfo is the one whose error text would
+/// otherwise read `https://user:password@host/hook`. The endpoint is therefore
+/// reduced to scheme, host and port everywhere it appears in a diagnostic, the
+/// same reduction the payloads and the human renders use. Scrubbing the VALUE
+/// rather than one instance path is deliberate: an error raised at the document
+/// root would echo the endpoint too, and a path based rule would miss it.
 fn schema_errors(raw: &serde_json::Value) -> Option<String> {
+    let secret_bearing = raw.get("endpoint").and_then(|e| e.as_str());
     let errors: Vec<String> = profile_validator()
         .iter_errors(raw)
-        .map(|e| format!("{e} (at instance path {})", e.instance_path()))
+        .map(|e| {
+            let rendered = format!("{e} (at instance path {})", e.instance_path());
+            match secret_bearing {
+                Some(endpoint) if !endpoint.is_empty() => {
+                    rendered.replace(endpoint, &redacted(endpoint))
+                }
+                _ => rendered,
+            }
+        })
         .collect();
     (!errors.is_empty()).then(|| errors.join("; "))
 }
@@ -173,16 +194,7 @@ pub fn load_profile(file: &Path) -> Result<AdapterProfile> {
     let value: serde_json::Value = serde_norway::from_str(&raw)
         .map_err(|err| usage(format!("{} is not valid YAML: {err}", file.display())))?;
 
-    if let Some(declared) = value.get("version").and_then(|v| v.as_str()) {
-        if declared != PROFILE_VERSION {
-            return Err(usage(format!(
-                "{} declares adapter profile version {declared}; this build understands \
-                 version {PROFILE_VERSION}. Rewrite the profile against {PROFILE_VERSION}, \
-                 or use a Curie build that speaks {declared}.",
-                file.display()
-            )));
-        }
-    }
+    check_declared_version(&value, file)?;
 
     if let Some(errors) = schema_errors(&value) {
         return Err(usage(format!(
@@ -200,6 +212,79 @@ pub fn load_profile(file: &Path) -> Result<AdapterProfile> {
 
     compile_pattern(&profile.address.pattern, file)?;
     Ok(profile)
+}
+
+/// The acceptance check that runs before the schema ever sees the document, in
+/// the same three branches `channel_protocol.manifest.read_profile_version`
+/// uses. Collapsing any two of them is what makes the diagnostic wrong.
+///
+/// - **Absent.** No key at all. Reporting this as a schema error would bury it
+///   under whatever else the closed schema found.
+/// - **Present but not a string.** Unquoted `version: 1.1` is a YAML float, so
+///   a check that asked only for a string view would skip the version branch
+///   entirely and report unrelated schema errors instead. Reporting it as a
+///   MISSING key is just as wrong: it sends the author hunting for a key that is
+///   sitting on line one of their file. The message therefore names the value it
+///   found, what type that value is, and the quoted form.
+/// - **Present, a string, and unacceptable.** Names both versions.
+fn check_declared_version(value: &serde_json::Value, file: &Path) -> Result<()> {
+    let quoted_form = format!("write version: \"{PROFILE_VERSION}\"");
+    let understood = format!("this build understands adapter profile version {PROFILE_VERSION}");
+    match value.get("version") {
+        None => Err(usage(format!(
+            "{} declares no version key; {understood}. A profile version is a quoted \
+             string, so {quoted_form}.",
+            file.display()
+        ))),
+        Some(serde_json::Value::String(declared)) if declared.is_empty() => Err(usage(format!(
+            "{} declares an empty version key; {understood}. A profile version is a quoted \
+             string, so {quoted_form}.",
+            file.display()
+        ))),
+        Some(serde_json::Value::String(declared)) => {
+            if declared == PROFILE_VERSION {
+                return Ok(());
+            }
+            Err(usage(format!(
+                "{} declares adapter profile version {declared}; this build understands \
+                 version {PROFILE_VERSION}. Rewrite the profile against {PROFILE_VERSION}, \
+                 or use a Curie build that speaks {declared}.",
+                file.display()
+            )))
+        }
+        Some(other) => Err(usage(format!(
+            "{} declares version {}, which is {} and not a string; {understood}. A profile \
+             version is a quoted string, so {quoted_form}.",
+            file.display(),
+            scalar_or_type(other),
+            json_type_name(other),
+        ))),
+    }
+}
+
+/// A scalar rendered as the author wrote it, or its type alone. A `version` key
+/// holding a whole mapping is a mistake worth naming, but echoing the mapping
+/// back would put an arbitrary slice of the file into an error string.
+fn scalar_or_type(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::Array(_) | serde_json::Value::Object(_) => {
+            json_type_name(value).to_string()
+        }
+        other => other.to_string(),
+    }
+}
+
+/// What a non string `version` value IS, in the terms an author reading YAML
+/// would recognise.
+fn json_type_name(value: &serde_json::Value) -> &'static str {
+    match value {
+        serde_json::Value::Null => "null",
+        serde_json::Value::Bool(_) => "a boolean",
+        serde_json::Value::Number(_) => "a number",
+        serde_json::Value::String(_) => "a string",
+        serde_json::Value::Array(_) => "a list",
+        serde_json::Value::Object(_) => "a mapping",
+    }
 }
 
 /// The paired half of the address rule: the Rust regex dialect is the floor, so
@@ -310,7 +395,6 @@ pub fn scaffold(opts: ScaffoldOpts) -> Result<AdapterScaffoldOutput> {
         },
         conformance: AdapterConformance {
             wire_version: "1.0".to_string(),
-            mints_reply_ref: false,
         },
     };
 
@@ -322,16 +406,31 @@ pub fn scaffold(opts: ScaffoldOpts) -> Result<AdapterScaffoldOutput> {
     }
     compile_pattern(&profile.address.pattern, &file)?;
 
-    if file.exists() {
-        return Err(usage(format!(
-            "{} already exists; scaffold never overwrites a profile",
-            file.display()
-        )));
-    }
     std::fs::create_dir_all(&dir).with_context(|| format!("creating {}", dir.display()))?;
     let yaml = serde_norway::to_string(&profile).context("rendering the profile as YAML")?;
     let contents = format!("{}{yaml}", scaffold_header(&opts.address));
-    std::fs::write(&file, contents).with_context(|| format!("writing {}", file.display()))?;
+
+    // The never overwrites rule is enforced by the CREATE itself, not by an
+    // `exists()` test followed by a write. Those are two operations, and the gap
+    // between them is a substitution window: `exists()` follows symlinks and
+    // answers false for a dangling one, and `fs::write` follows symlinks and
+    // truncates whatever it lands on, so a link planted in the gap (or already
+    // sitting there) redirects the write onto a victim path. `create_new` asks
+    // the kernel for exclusive creation, which refuses any existing entry
+    // INCLUDING a symlink, and there is no gap to race.
+    let mut handle = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&file)
+        .map_err(|err| match err.kind() {
+            std::io::ErrorKind::AlreadyExists => usage(format!(
+                "{} already exists; scaffold never overwrites a profile",
+                file.display()
+            )),
+            _ => anyhow::Error::new(err).context(format!("writing {}", file.display())),
+        })?;
+    std::io::Write::write_all(&mut handle, contents.as_bytes())
+        .with_context(|| format!("writing {}", file.display()))?;
 
     let display = file.display().to_string();
     Ok(AdapterScaffoldOutput {

--- a/cli/src/adapter.rs
+++ b/cli/src/adapter.rs
@@ -50,11 +50,23 @@ const ADAPTER_PROFILE_SCHEMA: &str =
 pub const PROFILE_VERSION: &str = "1.0";
 
 /// The header the worker authenticates its egress with.
-const ADAPTER_SECRET_HEADER: &str = "X-Curie-Adapter-Secret";
+pub const ADAPTER_SECRET_HEADER: &str = "X-Curie-Adapter-Secret";
 
 /// The worker refuses an acknowledgement body OVER this many bytes, so exactly
 /// this many still passes.
-const MAX_ACK_BODY_BYTES: usize = 65536;
+pub const MAX_ACK_BODY_BYTES: usize = 65536;
+
+/// The secret the negative probe sends, as a fixed constant that is never
+/// derived from the operator's real one.
+///
+/// A rejected authentication is one of the likeliest lines for an adapter to log
+/// verbatim, and the adapter is third party infrastructure whose logs the
+/// operator does not control, so a value built by suffixing the real secret
+/// would put the real secret on disk in plaintext at the other end. A fixed
+/// constant also proves the refusal STRICTLY better, because it cannot collide
+/// with a value some install actually configured. The Python conformance kit
+/// sends its own fixed constant for the identical probe.
+const WRONG_SECRET: &str = "curie-smoke-test-deliberately-wrong-secret";
 
 /// `ChannelTokenRequest.ttl_s` is `gt=0, le=604800`; a value outside that is a
 /// usage error here rather than a 422 from the API.
@@ -417,13 +429,35 @@ pub struct AdapterValidateOutput {
     pub profile: AdapterProfile,
 }
 
+impl AdapterValidateOutput {
+    /// The profile's endpoint reduced to scheme, host and port, or `None` when
+    /// the profile declares no route at all.
+    ///
+    /// A profile's `endpoint` can carry a token in its path or query, and every
+    /// form this payload takes is a form that reaches a terminal, a log
+    /// aggregator or a CI artifact, so neither the JSON nor the human render
+    /// ever carries the full route. Nothing downstream needs it: the operator
+    /// already holds the file it was read from, and `bind` sends the full value
+    /// to the API without going through this output at all.
+    fn redacted_endpoint(&self) -> Option<String> {
+        self.profile.endpoint.as_deref().map(redacted)
+    }
+}
+
 impl CliOutput for AdapterValidateOutput {
     fn to_json(&self) -> serde_json::Value {
+        let mut profile =
+            serde_json::to_value(&self.profile).expect("a parsed adapter profile serializes");
+        // Absent stays an explicit null, so a consumer can still read the key
+        // unconditionally.
+        profile["endpoint"] = match self.redacted_endpoint() {
+            Some(endpoint) => serde_json::Value::String(endpoint),
+            None => serde_json::Value::Null,
+        };
         serde_json::json!({
             "ok": true,
             "file": self.file,
-            "profile": serde_json::to_value(&self.profile)
-                .expect("a parsed adapter profile serializes"),
+            "profile": profile,
         })
     }
 
@@ -433,7 +467,7 @@ impl CliOutput for AdapterValidateOutput {
         ui.kv("address", &self.profile.address.pattern);
         ui.kv(
             "endpoint",
-            self.profile.endpoint.as_deref().unwrap_or("unset"),
+            &self.redacted_endpoint().unwrap_or("unset".to_string()),
         );
         ui.kv("egress", &self.profile.credentials.egress);
     }
@@ -500,7 +534,7 @@ pub async fn bind(opts: BindOpts) -> Result<AdapterBindOutput> {
         agent: opts.agent,
         kind: binding.kind,
         address: binding.address,
-        endpoint: binding.endpoint,
+        endpoint: redacted(&binding.endpoint),
         adapter: binding.adapter,
     })
 }
@@ -512,6 +546,11 @@ pub struct AdapterBindOutput {
     pub agent: String,
     pub kind: String,
     pub address: String,
+    /// ALREADY redacted to scheme, host and port, at construction rather than at
+    /// each emit. An endpoint can carry a token in its path or query, and
+    /// `--json` is the form most likely to be redirected into a CI artifact or a
+    /// log aggregator, so the full value never enters this struct and no later
+    /// emitter can leak what it does not hold.
     pub endpoint: String,
     pub adapter: String,
 }
@@ -530,7 +569,7 @@ impl CliOutput for AdapterBindOutput {
     fn render(&self, ui: &Ui) {
         ui.payload(&format!("bound {} to {}", self.agent, self.kind));
         ui.kv("address", &self.address);
-        ui.kv("endpoint", &redacted(&self.endpoint));
+        ui.kv("endpoint", &self.endpoint);
         ui.kv("adapter", &self.adapter);
     }
 }
@@ -676,9 +715,8 @@ pub async fn smoke_test(opts: SmokeTestOpts) -> Result<()> {
     let event = status_event(&profile.kind, &opts.address, &conversation);
 
     let positive = probe_egress(&client, &endpoint, &secret, &event, "egress_positive").await;
-    let wrong = format!("{secret}-not-the-secret");
     let negative = refusal_of_a_wrong_secret(
-        probe_egress(&client, &endpoint, &wrong, &event, "egress_negative").await,
+        probe_egress(&client, &endpoint, WRONG_SECRET, &event, "egress_negative").await,
     );
 
     let (binding, minted) = probe_binding(&client, &opts, &profile).await;
@@ -813,7 +851,6 @@ async fn probe_egress(
         }
     };
     let status = response.status().as_u16();
-    let body = response.bytes().await.unwrap_or_default();
     let mut detail = format!("the endpoint answered {status}");
     let mut ok = (200..300).contains(&status);
     if (300..400).contains(&status) {
@@ -822,21 +859,66 @@ async fn probe_egress(
             "the endpoint answered {status} (a redirect), which the worker refuses rather \
              than replaying the egress credential at the redirect target"
         );
-    } else if ok && body.len() > MAX_ACK_BODY_BYTES {
-        ok = false;
-        detail = format!(
-            "the acknowledgement body is {} bytes, over the {MAX_ACK_BODY_BYTES} byte cap",
-            body.len()
-        );
-    } else if ok && serde_json::from_slice::<serde_json::Value>(&body).is_err() {
-        ok = false;
-        detail = format!("the endpoint answered {status} with a body that is not JSON");
+    } else {
+        match read_capped(response).await {
+            Err(CappedRead::Oversize) => {
+                ok = false;
+                detail = format!(
+                    "the endpoint answered {status} with an acknowledgement body over the \
+                     {MAX_ACK_BODY_BYTES} byte cap, which is refused rather than truncated"
+                );
+            }
+            Err(CappedRead::Transport(err)) => {
+                ok = false;
+                detail = format!("the endpoint answered {status} and then broke off: {err}");
+            }
+            Ok(body) => {
+                if ok && serde_json::from_slice::<serde_json::Value>(&body).is_err() {
+                    ok = false;
+                    detail = format!("the endpoint answered {status} with a body that is not JSON");
+                }
+            }
+        }
     }
     CheckResult {
         name: name.to_string(),
         ok,
         status: Some(status),
         detail,
+    }
+}
+
+/// Why a capped read gave up.
+#[derive(Debug)]
+enum CappedRead {
+    /// The peer sent MORE than the cap. A refusal, never a truncation: judging
+    /// the first N bytes of a body that was never sent whole would hand the
+    /// parser a value nobody produced.
+    Oversize,
+    /// The peer broke off mid body.
+    Transport(String),
+}
+
+/// Read a response body with a RUNNING total, refusing once it passes the cap.
+///
+/// `reqwest::Response::bytes()` buffers the whole body first and would let the
+/// cap be enforced only after the memory was already allocated, which is no cap
+/// at all against a peer that answers with a multi gigabyte chunked body. The
+/// worker's reply sink and the Python conformance kit both stream for exactly
+/// this reason; this is the third reader of the same untrusted surface.
+async fn read_capped(mut response: reqwest::Response) -> Result<Vec<u8>, CappedRead> {
+    let mut body: Vec<u8> = Vec::new();
+    loop {
+        match response.chunk().await {
+            Ok(Some(chunk)) => {
+                if body.len() + chunk.len() > MAX_ACK_BODY_BYTES {
+                    return Err(CappedRead::Oversize);
+                }
+                body.extend_from_slice(&chunk);
+            }
+            Ok(None) => return Ok(body),
+            Err(err) => return Err(CappedRead::Transport(err.to_string())),
+        }
     }
 }
 
@@ -1121,6 +1203,15 @@ async fn post_channel_token(
         .await
         .context("POST /channels/token")?;
     let status = response.status();
-    let body = response.text().await.unwrap_or_default();
+    let body = match read_capped(response).await {
+        Ok(body) => String::from_utf8_lossy(&body).into_owned(),
+        Err(CappedRead::Oversize) => {
+            return Err(anyhow::anyhow!(
+                "POST /channels/token answered with a body over the {MAX_ACK_BODY_BYTES} \
+                 byte cap, which is refused rather than buffered"
+            ))
+        }
+        Err(CappedRead::Transport(_)) => String::new(),
+    };
     Ok((status, body))
 }

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -75,6 +75,23 @@ pub struct ChannelBinding {
     pub address: String,
 }
 
+/// The four-field channel route `curie adapter bind` WRITES (#1516).
+///
+/// A separate write-side struct rather than `Option` fields on [`ChannelBinding`]:
+/// the route is write-only (an agent read returns exactly `{kind, address}`), so
+/// widening the read model would make it claim a shape the API never returns.
+/// All four fields travel together because the API refuses a non-`slack` binding
+/// whose reply route is half set, and the `adapter` slug is always the operator's
+/// `--adapter-slug` -- it selects which stored secret the worker sends, so a
+/// profile-supplied value never reaches this struct on its own.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ChannelBindingWrite {
+    pub kind: String,
+    pub address: String,
+    pub endpoint: String,
+    pub adapter: String,
+}
+
 #[derive(Debug, Clone, Deserialize)]
 pub struct Agent {
     pub id: String,
@@ -663,6 +680,18 @@ impl ApiClient {
             .json()
             .await
             .context("decoding updated agent")
+    }
+
+    /// Write one agent's four-field channel route (#1516): `PATCH /agents/{id}`
+    /// with the whole [`ChannelBindingWrite`], since the API refuses a
+    /// non-`slack` binding whose reply route is half set.
+    pub async fn set_agent_channel(
+        &self,
+        agent_id: &str,
+        binding: &ChannelBindingWrite,
+    ) -> Result<Agent> {
+        self.update_agent(agent_id, &json!({ "channel": binding }))
+            .await
     }
 
     /// Bind the per-agent connector secrets (ADR-0009, #429). The values travel

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -4,6 +4,7 @@
 //! local runner container (via the generated `curie-aci-protocol` crate) and
 //! the platform API's committed OpenAPI surface. Task I1.
 
+pub mod adapter;
 pub mod api;
 pub mod artifacts;
 pub mod bundle;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -9,6 +9,7 @@ use std::path::PathBuf;
 
 use anyhow::{bail, Result};
 use clap::{Args, Parser, Subcommand};
+use curie::adapter;
 use curie::api;
 use curie::artifacts;
 use curie::commands::{
@@ -342,6 +343,17 @@ enum Command {
     /// memorizing the full command surface.
     #[command(alias = "ui", alias = "tui")]
     Interactive,
+    /// Build, validate, bind and smoke-test a channel adapter against an
+    /// install: `adapter <scaffold|validate|bind|token|smoke-test>`.
+    ///
+    /// Reads an `adapter.yaml` binding profile (kind, address shape, reply
+    /// route, egress credential identity) validated against the committed
+    /// `packages/channel-protocol` schema, so the CLI and the Python conformance
+    /// kit agree on one contract instead of two mirrors.
+    Adapter {
+        #[command(subcommand)]
+        action: AdapterAction,
+    },
     /// Store and manage local secrets in Curie private storage.
     Secrets {
         #[command(subcommand)]
@@ -600,6 +612,162 @@ enum SecretsAction {
     Unset {
         /// Environment-variable-style secret name.
         name: String,
+    },
+}
+
+#[derive(Subcommand)]
+enum AdapterAction {
+    /// Write one binding profile for a new adapter, plus the next steps.
+    ///
+    /// Deliberately minimal: one `adapter.yaml` and nothing else. The generated
+    /// `address.pattern` matches exactly the address it was scaffolded for, so
+    /// the profile validates on the very next command; widen it by hand to the
+    /// real shape of your channel's addresses.
+    Scaffold {
+        /// Adapter name. The profile is written to `<dir>/<name>/adapter.yaml`.
+        name: String,
+        /// Channel kind this adapter owns, as a lowercase slug (e.g. email).
+        #[arg(long)]
+        kind: String,
+        /// A concrete address of the shape this adapter owns.
+        #[arg(long)]
+        address: String,
+        /// The absolute http or https route the worker POSTs reply events to.
+        #[arg(long)]
+        endpoint: String,
+        /// The egress credential identity this adapter suggests, as a lowercase
+        /// slug. A suggestion only: `adapter bind` asks an operator to confirm it.
+        #[arg(long)]
+        adapter: String,
+        /// Parent directory for the scaffolded adapter. Defaults to the current
+        /// directory.
+        #[arg(long)]
+        dir: Option<PathBuf>,
+    },
+    /// Accept or refuse a binding profile, and report the values it parsed.
+    ///
+    /// The version is checked first, then the committed schema, then the one
+    /// rule a schema cannot express: `address.pattern` has to compile with the
+    /// Rust regex crate as well as Python `re`, so no lookaround and no
+    /// backreferences.
+    Validate {
+        /// Path to the binding profile.
+        #[arg(short = 'f', long = "file", default_value = "adapter.yaml")]
+        file: PathBuf,
+        /// Also check that this concrete address matches the profile's declared
+        /// shape.
+        #[arg(long)]
+        address: Option<String>,
+    },
+    /// Write an agent's four field channel route: kind, address, endpoint and
+    /// the egress credential slug.
+    ///
+    /// `--address` and `--adapter-slug` are operator inputs, never taken from
+    /// the profile: `address.example` is authoring documentation, and the slug
+    /// selects which stored secret the worker sends, so a profile chosen value
+    /// could redirect another adapter's credential. A slug differing from the
+    /// profile's suggestion is shown with both values before it is written.
+    Bind {
+        /// Path to the binding profile.
+        #[arg(short = 'f', long = "file", default_value = "adapter.yaml")]
+        file: PathBuf,
+        /// Agent id to bind.
+        agent: String,
+        /// The concrete address to bind, checked against the profile's shape.
+        #[arg(long)]
+        address: String,
+        /// The egress credential identity to write. Operator owned.
+        #[arg(long)]
+        adapter_slug: String,
+        /// Reply route override, for a profile that declares no endpoint.
+        #[arg(long)]
+        endpoint: Option<String>,
+        /// Platform API base URL.
+        #[arg(
+            long,
+            default_value = message::DEFAULT_LOCAL_API_URL,
+            env = "CURIE_API_URL"
+        )]
+        api_url: String,
+        /// Platform API key.
+        #[arg(long, default_value = "curie-dev-key", env = "CURIE_API_KEY", value_parser = message::api_key_or_default)]
+        api_key: String,
+        /// Confirm the destination and the credential identity, and write.
+        #[arg(long)]
+        yes: bool,
+    },
+    /// Mint a `chn` token for one concrete (kind, address) pair.
+    ///
+    /// The only verb whose payload carries a credential value: it rides under
+    /// `token` alongside `"secret": true`, on stdout and on no diagnostic
+    /// stream.
+    Token {
+        /// Path to the binding profile.
+        #[arg(short = 'f', long = "file", default_value = "adapter.yaml")]
+        file: PathBuf,
+        /// The concrete address to mint for, checked against the profile's shape.
+        #[arg(long)]
+        address: String,
+        /// Platform API base URL.
+        #[arg(
+            long,
+            default_value = message::DEFAULT_LOCAL_API_URL,
+            env = "CURIE_API_URL"
+        )]
+        api_url: String,
+        /// Platform API key.
+        #[arg(long, default_value = "curie-dev-key", env = "CURIE_API_KEY", value_parser = message::api_key_or_default)]
+        api_key: String,
+        /// Token lifetime in seconds. The API accepts 1 to 604800.
+        #[arg(long, default_value_t = 3600)]
+        ttl_s: u64,
+    },
+    /// Probe a deployed adapter from the outside: does this endpoint accept the
+    /// egress secret you supply, does it refuse a wrong one, and are the route
+    /// fields present for this pair.
+    ///
+    /// Those two narrow claims are all it makes. It does not prove the running
+    /// worker holds that slug or that value, and it is not the conformance
+    /// floor: `curie-adapter-conformance` is the stricter check.
+    #[command(name = "smoke-test")]
+    SmokeTest {
+        /// Path to the binding profile.
+        #[arg(short = 'f', long = "file", default_value = "adapter.yaml")]
+        file: PathBuf,
+        /// The concrete address to probe, checked against the profile's shape.
+        #[arg(long)]
+        address: String,
+        /// Reply route override, for a profile that declares no endpoint.
+        #[arg(long)]
+        endpoint: Option<String>,
+        /// Platform API base URL.
+        #[arg(
+            long,
+            default_value = message::DEFAULT_LOCAL_API_URL,
+            env = "CURIE_API_URL"
+        )]
+        api_url: String,
+        /// Platform API key.
+        #[arg(long, default_value = "curie-dev-key", env = "CURIE_API_KEY", value_parser = message::api_key_or_default)]
+        api_key: String,
+        /// Read the egress secret from this file. One of the two accepted
+        /// sources; the profile names the variable its own adapter reads and
+        /// that name is never resolved here.
+        #[arg(long)]
+        secret_file: Option<PathBuf>,
+        /// Read the egress secret from stdin instead.
+        #[arg(long)]
+        secret_stdin: bool,
+        /// Also post a real turn twice and assert the second is reported as a
+        /// duplicate. This enqueues a REAL turn against the bound agent.
+        #[arg(long)]
+        enqueue: bool,
+        /// Probe a cleartext http endpoint anyway.
+        #[arg(long)]
+        allow_insecure: bool,
+        /// Confirm the destination and the credential identity, and probe.
+        #[arg(long)]
+        yes: bool,
     },
 }
 
@@ -2085,6 +2253,93 @@ async fn run(command: Option<Command>) -> Result<()> {
         Some(Command::Install { update }) => commands::install(update).await,
         Some(Command::Update { image }) => commands::update(image).await,
         Some(Command::Interactive) => curie::interactive::run().await,
+        Some(Command::Adapter { action }) => match action {
+            AdapterAction::Scaffold {
+                name,
+                kind,
+                address,
+                endpoint,
+                adapter: slug,
+                dir,
+            } => emit(adapter::scaffold(adapter::ScaffoldOpts {
+                name,
+                kind,
+                address,
+                endpoint,
+                adapter: slug,
+                dir,
+            })?),
+            AdapterAction::Validate { file, address } => {
+                emit(adapter::validate(&file, address.as_deref())?)
+            }
+            AdapterAction::Bind {
+                file,
+                agent,
+                address,
+                adapter_slug,
+                endpoint,
+                api_url,
+                api_key,
+                yes,
+            } => emit(
+                adapter::bind(adapter::BindOpts {
+                    file,
+                    agent,
+                    address,
+                    adapter_slug,
+                    endpoint,
+                    api_url,
+                    api_key,
+                    yes,
+                })
+                .await?,
+            ),
+            AdapterAction::Token {
+                file,
+                address,
+                api_url,
+                api_key,
+                ttl_s,
+            } => emit(
+                adapter::token(adapter::TokenOpts {
+                    file,
+                    address,
+                    api_url,
+                    api_key,
+                    ttl_s,
+                })
+                .await?,
+            ),
+            // `smoke-test` emits its own report and then applies the exit-code
+            // side effect, the same shape `report_eval` uses: a failing verdict
+            // must still hand back the per-check detail before exiting non-zero.
+            AdapterAction::SmokeTest {
+                file,
+                address,
+                endpoint,
+                api_url,
+                api_key,
+                secret_file,
+                secret_stdin,
+                enqueue,
+                allow_insecure,
+                yes,
+            } => {
+                adapter::smoke_test(adapter::SmokeTestOpts {
+                    file,
+                    address,
+                    endpoint,
+                    api_url,
+                    api_key,
+                    secret_file,
+                    secret_stdin,
+                    enqueue,
+                    allow_insecure,
+                    yes,
+                })
+                .await
+            }
+        },
         Some(Command::Secrets { action }) => match action {
             SecretsAction::Set { name, from_env } => {
                 secrets::set(secrets::SetSecretOpts { name, from_env })

--- a/cli/tests/adapter_manifest.rs
+++ b/cli/tests/adapter_manifest.rs
@@ -1841,31 +1841,13 @@ const CHANNELS_ROUTER: &str = include_str!("../../apps/api/src/curie_api/routers
 /// `TurnIn` inherits and that FastAPI DOES publish.
 const API_OPENAPI: &str = include_str!("../../apps/api/openapi.json");
 
-/// The fields this gate is known to depend on, as a LIVENESS FLOOR on the parse.
+/// `(base class name, own required fields)` for a Pydantic model, read out of
+/// the router source.
 ///
-/// This is deliberately not the contract: the parsed set is, and a field added
-/// to `TurnIn` tomorrow tightens the pin with no edit here. What this catches is
-/// the parse going quiet. A source scan that stops matching returns a smaller
-/// set and every assertion built on it turns vacuous, which is worse than no pin
-/// at all, because it still reads as coverage. If `TurnIn` legitimately drops
-/// one of these, this list is supposed to red so a human looks at a contract
-/// change rather than a silently narrowed gate.
-const TURN_IN_FLOOR: [&str; 7] = [
-    "address",
-    "author",
-    "conversation_id",
-    "delivery_id",
-    "kind",
-    "reply_ref",
-    "text",
-];
-
-/// One Pydantic class's body, as `(base class, lines with the docstring cut)`.
-///
-/// Panics rather than returning empty at every step: a missing class, a missing
-/// header or an unterminated docstring are all "the source moved and this parse
-/// no longer knows what it is reading", and each has to be a loud failure.
-fn class_body<'a>(source: &'a str, name: &str) -> (String, Vec<&'a str>) {
+/// A required field is an annotated attribute with no `=`: a default of any kind
+/// makes it optional, and `model_config` is an assignment rather than an
+/// annotation, so neither reaches the set.
+fn pydantic_model(source: &str, name: &str) -> (String, std::collections::BTreeSet<String>) {
     let header = format!("\nclass {name}(");
     let start = source
         .find(&header)
@@ -1878,62 +1860,16 @@ fn class_body<'a>(source: &'a str, name: &str) -> (String, Vec<&'a str>) {
         .expect("a base list names a class")
         .trim()
         .to_string();
-
     let body_start = rest.find('\n').expect("a class header ends") + 1;
     let body = &rest[body_start..];
     let end = body.find("\nclass ").unwrap_or(body.len());
-    let mut lines: Vec<&str> = body[..end].lines().collect();
 
-    // Cut a leading docstring, so its prose cannot be read as a field. Every
-    // model in this router carries one, so its ABSENCE means the block being
-    // read is not the block this parse was written for.
-    let opener = lines
-        .iter()
-        .position(|line| !line.trim().is_empty())
-        .unwrap_or_else(|| panic!("{name} has a body"));
-    assert!(
-        lines[opener].trim_start().starts_with("\"\"\""),
-        "{name}'s body no longer opens with a docstring, so this parse is reading \
-         something other than the model it was written for: {:?}",
-        lines[opener]
-    );
-    let single_line = lines[opener].trim().len() > 6 && lines[opener].trim().ends_with("\"\"\"");
-    let close = if single_line {
-        opener
-    } else {
-        opener
-            + 1
-            + lines[opener + 1..]
-                .iter()
-                .position(|line| line.trim_end().ends_with("\"\"\""))
-                .unwrap_or_else(|| panic!("{name}'s docstring is unterminated"))
-    };
-    lines.drain(..=close);
-    (base, lines)
-}
-
-/// Annotated attributes in a class body, at EXACTLY four spaces of indentation
-/// when `strict`, at any indentation otherwise.
-///
-/// A required field is an annotated attribute with no `=`: a default of any kind
-/// makes it optional, and `model_config` is an assignment rather than an
-/// annotation, so neither reaches the set.
-fn annotated_fields(lines: &[&str], strict: bool) -> std::collections::BTreeSet<String> {
-    let mut found = std::collections::BTreeSet::new();
-    for line in lines {
-        let declaration = if strict {
-            match line.strip_prefix("    ") {
-                Some(rest) if !rest.starts_with(' ') => rest,
-                _ => continue,
-            }
-        } else {
-            let trimmed = line.trim_start();
-            if trimmed.len() == line.len() {
-                continue; // a top level statement is not a class attribute
-            }
-            trimmed
+    let mut required = std::collections::BTreeSet::new();
+    for line in body[..end].lines() {
+        let Some(declaration) = line.strip_prefix("    ") else {
+            continue;
         };
-        if declaration.starts_with('#') {
+        if declaration.starts_with(' ') || declaration.starts_with('#') {
             continue;
         }
         let Some((field, annotation)) = declaration.split_once(": ") else {
@@ -1942,49 +1878,19 @@ fn annotated_fields(lines: &[&str], strict: bool) -> std::collections::BTreeSet<
         if annotation.contains('=') || !field.chars().all(|c| c.is_ascii_lowercase() || c == '_') {
             continue;
         }
-        found.insert(field.to_string());
+        required.insert(field.to_string());
     }
-    found
-}
-
-/// `(base class name, own required fields)` for a Pydantic model, read out of
-/// the router source and CROSS CHECKED against itself.
-///
-/// The cross check is the whole point. A scan keyed on `    ` degrades silently
-/// the moment the file is reformatted, reindented or wrapped differently: it
-/// matches nothing, returns an empty set, and every assertion downstream passes
-/// while pinning nothing. So the same body is scanned twice, once keyed on that
-/// exact indentation and once indentation blind, and the two must agree. A
-/// reindent moves one and not the other, and the disagreement is the failure.
-fn pydantic_model(source: &str, name: &str) -> (String, std::collections::BTreeSet<String>) {
-    let (base, lines) = class_body(source, name);
-    let strict = annotated_fields(&lines, true);
-    let permissive = annotated_fields(&lines, false);
-
-    assert_eq!(
-        strict, permissive,
-        "the strict and permissive scans disagree on {name}'s fields, which means \
-         the source was reindented or rewrapped under this parse. Fix the parse; \
-         do NOT let it return the smaller set, because a pin that matches nothing \
-         still reads as coverage"
-    );
     assert!(
-        !strict.is_empty(),
+        !required.is_empty(),
         "{name} parsed to no required fields, so this gate would pass on an empty body"
     );
-    (base, strict)
+    (base, required)
 }
 
 /// Every field `TurnIn` requires: its own, read from the model source, plus the
 /// ones it inherits, read from the committed OpenAPI export.
 fn turn_in_required_fields() -> std::collections::BTreeSet<String> {
-    turn_in_required_fields_from(CHANNELS_ROUTER)
-}
-
-/// The same read, against a caller supplied copy of the router source, so the
-/// drift tests can feed it a reformatted one without touching `apps/`.
-fn turn_in_required_fields_from(source: &str) -> std::collections::BTreeSet<String> {
-    let (base, mut required) = pydantic_model(source, "TurnIn");
+    let (base, mut required) = pydantic_model(CHANNELS_ROUTER, "TurnIn");
     let openapi: serde_json::Value =
         serde_json::from_str(API_OPENAPI).expect("apps/api/openapi.json is valid JSON");
     let inherited = openapi["components"]["schemas"][&base]["required"]
@@ -1998,88 +1904,18 @@ fn turn_in_required_fields_from(source: &str) -> std::collections::BTreeSet<Stri
             .filter_map(|v| v.as_str().map(str::to_string)),
     );
 
-    for field in TURN_IN_FLOOR {
+    // Liveness, so a parse that stops seeing the model reds here rather than
+    // pinning nothing and still reading as coverage. `reply_ref` is the field
+    // the live 422 named; `kind` can only have come from the OpenAPI half, so
+    // both seams are known to have contributed.
+    for field in ["reply_ref", "conversation_id", "kind"] {
         assert!(
             required.contains(field),
-            "the parse lost {field:?}. Either the authority genuinely dropped it, \
-             which is a contract change to look at, or this parse stopped seeing \
-             the model. Parsed {required:?}"
+            "the parse lost {field:?}, so this gate no longer reads the authority. \
+             Parsed {required:?}"
         );
     }
     required
-}
-
-// ─── The pin fails loudly when the source it reads moves ────────────────────
-
-/// The positive control for the three drift tests below: against the real
-/// source, the parse yields a plausible set and finds the field the whole gate
-/// turns on. Without this, a `should_panic` test proves only that SOMETHING
-/// panicked.
-#[test]
-fn the_turn_in_parse_reads_a_plausible_field_set_from_the_real_source() {
-    let required = turn_in_required_fields();
-    assert!(
-        required.contains("reply_ref"),
-        "the parse must see the field the live 422 named; parsed {required:?}"
-    );
-    assert!(
-        required.len() >= TURN_IN_FLOOR.len(),
-        "the parse must see at least the floor; parsed {required:?}"
-    );
-    // The base half comes from the committed OpenAPI export, the own half from
-    // the model source. Both must have contributed, or one seam is dead.
-    let (_, own) = pydantic_model(CHANNELS_ROUTER, "TurnIn");
-    assert!(
-        !own.contains("kind") && required.contains("kind"),
-        "`kind` is inherited, so it can only have come from the OpenAPI export; \
-         own {own:?}, combined {required:?}"
-    );
-}
-
-/// Reindenting the model body must be a LOUD failure, not a quiet empty parse.
-/// This is the exact degradation a `strip_prefix("    ")` scan hides: after a
-/// reformat it matches nothing and every assertion built on it turns vacuous.
-///
-/// Simulated against an in memory copy of the real source, because `apps/` is
-/// not this crate's to edit.
-#[test]
-#[should_panic(expected = "the strict and permissive scans disagree")]
-fn a_reindented_model_body_fails_the_parse_instead_of_emptying_it() {
-    let reindented = CHANNELS_ROUTER.replace("\n    ", "\n      ");
-    let _ = turn_in_required_fields_from(&reindented);
-}
-
-/// The same, for a tab reindent, which `strip_prefix("    ")` also misses.
-#[test]
-#[should_panic(expected = "the strict and permissive scans disagree")]
-fn a_tab_indented_model_body_fails_the_parse_instead_of_emptying_it() {
-    let tabbed = CHANNELS_ROUTER.replace("\n    ", "\n\t");
-    let _ = turn_in_required_fields_from(&tabbed);
-}
-
-/// The discriminating case, and the one a non empty check cannot reach: ONE
-/// field rewrapped deeper. The strict scan then returns four of the five fields,
-/// which is non empty and looks entirely healthy, while `reply_ref` (the field
-/// this whole gate exists for) has quietly fallen out of the pin. Only the
-/// cross check sees it.
-#[test]
-#[should_panic(expected = "the strict and permissive scans disagree")]
-fn a_single_rewrapped_field_fails_the_parse_rather_than_dropping_out_of_it() {
-    let rewrapped = CHANNELS_ROUTER.replace("\n    reply_ref: str", "\n        reply_ref: str");
-    assert_ne!(
-        rewrapped, CHANNELS_ROUTER,
-        "the drift simulation must actually change the source, or this proves nothing"
-    );
-    let _ = turn_in_required_fields_from(&rewrapped);
-}
-
-/// A renamed or moved model must be a loud failure too, rather than a parse that
-/// silently reads whatever class happens to sit at that offset.
-#[test]
-#[should_panic(expected = "TurnIn is defined in the router source")]
-fn a_renamed_model_fails_the_parse() {
-    let renamed = CHANNELS_ROUTER.replace("\nclass TurnIn(", "\nclass TurnInV2(");
-    let _ = turn_in_required_fields_from(&renamed);
 }
 
 /// A platform API stand-in that also answers the turn ingress, reporting the

--- a/cli/tests/adapter_manifest.rs
+++ b/cli/tests/adapter_manifest.rs
@@ -297,6 +297,40 @@ fn smoke_test_payload(api: &MockServer, endpoint: &MockServer, secret: &str) -> 
     stdout_json(&output)
 }
 
+/// The same drive as [`smoke_test_payload`], with `--enqueue`, which is the only
+/// flag that makes the verb post a turn at all.
+fn smoke_test_payload_enqueuing(
+    api: &MockServer,
+    endpoint: &MockServer,
+    secret: &str,
+) -> serde_json::Value {
+    let dir = tempdir();
+    let mut profile = routed_valid_case();
+    profile["endpoint"] = serde_json::json!(endpoint.base_url.clone());
+    let path = write_profile(dir.path(), &profile);
+    let address = profile["address"]["example"].as_str().unwrap().to_string();
+    let secret_file = dir.path().join("egress.secret");
+    std::fs::write(&secret_file, secret).expect("write the egress secret");
+
+    let output = run(&[
+        "adapter",
+        "smoke-test",
+        "-f",
+        path.to_str().unwrap(),
+        "--address",
+        &address,
+        "--secret-file",
+        secret_file.to_str().unwrap(),
+        "--allow-insecure",
+        "--enqueue",
+        "--yes",
+        "--api-url",
+        &api.base_url,
+        "--json",
+    ]);
+    stdout_json(&output)
+}
+
 /// Every value that reached the endpoint under the egress secret header, in
 /// order. This is the wire, not a log line, so a derived probe cannot hide.
 fn secrets_sent(server: &MockServer) -> Vec<String> {
@@ -1781,6 +1815,349 @@ fn an_acknowledgement_body_exactly_at_the_cap_still_passes() {
         payload["egress_positive"]["ok"],
         serde_json::json!(true),
         "the worker refuses a body OVER the cap, so exactly the cap passes: {payload}"
+    );
+}
+
+// ─── The enqueued turn body is pinned to the API's own model ─────────────────
+
+/// The API router that DEFINES `TurnIn`, read as the authority it is.
+///
+/// There is no committed artifact describing `TurnIn`, and that is not an
+/// oversight to route around quietly. `POST /channels/turns` takes a bare
+/// `Request` so it can enforce its size bound BEFORE authentication and before
+/// JSON parsing, then parses `TurnIn` by hand; FastAPI therefore never sees a
+/// body model, emits no `requestBody`, and `TurnIn` is absent from the committed
+/// `apps/api/openapi.json` (which is generated and drift gated, and does carry
+/// `ChannelBinding`, `ChannelTokenRequest` and `TurnAccepted`).
+///
+/// So this reads the model's own source rather than restating its fields here.
+/// A hand written list of required fields is the drift that produced the bug
+/// this test exists for: the payload was written once against a model that later
+/// grew `reply_ref`, and nothing failed until a live install answered 422.
+/// Reading the authority cannot go stale; a second copy of it always can.
+const CHANNELS_ROUTER: &str = include_str!("../../apps/api/src/curie_api/routers/channels.py");
+
+/// The committed, drift gated OpenAPI export, for the half of the body that
+/// `TurnIn` inherits and that FastAPI DOES publish.
+const API_OPENAPI: &str = include_str!("../../apps/api/openapi.json");
+
+/// `(base class name, own required fields)` for a Pydantic model, read out of
+/// the router source.
+///
+/// A required field is an annotated attribute with no `=`: a default of any kind
+/// makes it optional, and `model_config` is an assignment rather than an
+/// annotation, so neither reaches the set.
+fn pydantic_model(source: &str, name: &str) -> (String, std::collections::BTreeSet<String>) {
+    let header = format!("\nclass {name}(");
+    let start = source
+        .find(&header)
+        .unwrap_or_else(|| panic!("{name} is defined in the router source"))
+        + 1;
+    let rest = &source[start..];
+    let base = rest[rest.find('(').expect("a class header has a base list") + 1..]
+        .split([')', ','])
+        .next()
+        .expect("a base list names a class")
+        .trim()
+        .to_string();
+    let body_start = rest.find('\n').expect("a class header ends") + 1;
+    let body = &rest[body_start..];
+    let end = body.find("\nclass ").unwrap_or(body.len());
+
+    let mut required = std::collections::BTreeSet::new();
+    for line in body[..end].lines() {
+        let Some(declaration) = line.strip_prefix("    ") else {
+            continue;
+        };
+        if declaration.starts_with(' ') || declaration.starts_with('#') {
+            continue;
+        }
+        let Some((field, annotation)) = declaration.split_once(": ") else {
+            continue;
+        };
+        if annotation.contains('=') || !field.chars().all(|c| c.is_ascii_lowercase() || c == '_') {
+            continue;
+        }
+        required.insert(field.to_string());
+    }
+    assert!(
+        !required.is_empty(),
+        "{name} parsed to no required fields, so this gate would pass on an empty body"
+    );
+    (base, required)
+}
+
+/// Every field `TurnIn` requires: its own, read from the model source, plus the
+/// ones it inherits, read from the committed OpenAPI export.
+fn turn_in_required_fields() -> std::collections::BTreeSet<String> {
+    let (base, mut required) = pydantic_model(CHANNELS_ROUTER, "TurnIn");
+    let openapi: serde_json::Value =
+        serde_json::from_str(API_OPENAPI).expect("apps/api/openapi.json is valid JSON");
+    let inherited = openapi["components"]["schemas"][&base]["required"]
+        .as_array()
+        .unwrap_or_else(|| {
+            panic!("the committed OpenAPI export declares {base}, which TurnIn inherits")
+        });
+    required.extend(
+        inherited
+            .iter()
+            .filter_map(|v| v.as_str().map(str::to_string)),
+    );
+    required
+}
+
+/// A platform API stand-in that also answers the turn ingress, reporting the
+/// duplicate verdict the round trip probe reads.
+fn api_recorder_with_turns() -> MockServer {
+    let seen = std::sync::Mutex::new(std::collections::BTreeSet::<String>::new());
+    serve(move |req: &Request| {
+        if req.path.starts_with("/channels/token") {
+            return Response::json(200, r#"{"token":"chn_test_token_value"}"#);
+        }
+        if req.path.starts_with("/channels/turns") {
+            let body: serde_json::Value =
+                serde_json::from_slice(&req.body).unwrap_or(serde_json::Value::Null);
+            // Stand in for the platform's real refusal: a body missing anything
+            // TurnIn requires is a 422, exactly as the live API answered.
+            let missing: Vec<String> = turn_in_required_fields()
+                .into_iter()
+                .filter(|field| body.get(field).is_none_or(serde_json::Value::is_null))
+                .collect();
+            if !missing.is_empty() {
+                return Response::json(
+                    422,
+                    &format!(r#"{{"detail":[{{"type":"missing","loc":{missing:?}}}]}}"#),
+                );
+            }
+            let delivery = body["delivery_id"].as_str().unwrap_or_default().to_string();
+            let duplicate = !seen.lock().expect("the recorder lock").insert(delivery);
+            return Response::json(
+                200,
+                &format!(r#"{{"event_id":"chn-x","stream_id":"1-0","duplicate":{duplicate}}}"#),
+            );
+        }
+        Response::json(
+            200,
+            r#"{"id":"demo","name":"demo","channel":{"kind":"email","address":"agent@example.test"}}"#,
+        )
+    })
+}
+
+/// The body `--enqueue` actually puts on the wire must satisfy every field the
+/// platform's own `TurnIn` requires.
+///
+/// This is the regression gate for a bug only a live install surfaced: the
+/// payload omitted `reply_ref`, the API answered 422 with
+/// `{"type":"missing","loc":["body","reply_ref"]}`, and the verb reported the
+/// round trip as failed. Nothing in the suite could see it, because nothing
+/// compared the request body against the model that judges it.
+///
+/// Mutation to run against the implementation: drop `reply_ref` from the body.
+/// This reds.
+#[test]
+fn the_enqueued_turn_body_carries_every_field_the_platform_requires() {
+    assert_verb_routes("smoke-test");
+    let api = api_recorder_with_turns();
+    let endpoint = endpoint_recorder();
+
+    let payload = smoke_test_payload_enqueuing(&api, &endpoint, REAL_EGRESS_SECRET);
+
+    let turns: Vec<serde_json::Value> = api
+        .recorded()
+        .iter()
+        .filter(|req| req.method == "POST" && req.path.starts_with("/channels/turns"))
+        .map(|req| serde_json::from_slice(&req.body).expect("the turn body is JSON"))
+        .collect();
+    assert_eq!(
+        turns.len(),
+        2,
+        "the round trip posts the same delivery twice; saw {turns:?}"
+    );
+
+    let required = turn_in_required_fields();
+    assert!(
+        required.contains("reply_ref"),
+        "the authority must still require reply_ref, or this gate proves nothing \
+         about the field the live 422 named; required {required:?}"
+    );
+    for (nth, body) in turns.iter().enumerate() {
+        for field in &required {
+            assert!(
+                body.get(field).is_some_and(|v| !v.is_null()),
+                "post {} omits {field:?}, which TurnIn requires; the platform answers \
+                 422 for exactly this. body: {body}",
+                nth + 1
+            );
+        }
+    }
+
+    // Byte identical across both posts, or the second describes a DIFFERENT
+    // delivery and the duplicate verdict below is meaningless.
+    assert_eq!(
+        turns[0], turns[1],
+        "both posts must send the identical body, or the platform is being asked \
+         to deduplicate two different deliveries"
+    );
+
+    assert_eq!(
+        payload["round_trip"]["duplicate"],
+        serde_json::json!(true),
+        "the re-post must be reported as the duplicate: {payload}"
+    );
+    assert_eq!(
+        payload["round_trip"]["ok"],
+        serde_json::json!(true),
+        "a body the platform accepts must produce a passing round trip: {payload}"
+    );
+}
+
+/// The control that keeps the test above honest: the recorder really does refuse
+/// a body missing a required field, so a green round trip is evidence and not an
+/// artifact of a permissive stand-in.
+#[test]
+fn the_turn_recorder_refuses_a_body_missing_a_required_field() {
+    let api = api_recorder_with_turns();
+    let required = turn_in_required_fields();
+
+    let mut complete = serde_json::json!({});
+    for field in &required {
+        complete[field] = serde_json::json!("x");
+    }
+
+    assert_eq!(
+        post_turn(&api, &complete),
+        200,
+        "a complete body must be accepted, or every refusal below is vacuous"
+    );
+
+    for field in &required {
+        let mut missing = complete.clone();
+        missing.as_object_mut().expect("an object").remove(field);
+        assert_eq!(
+            post_turn(&api, &missing),
+            422,
+            "a body missing {field:?} must be refused, or the gate above cannot see \
+             an omission"
+        );
+    }
+}
+
+/// POST one turn body to the recorder, returning its status.
+///
+/// Reads the STATUS LINE only and then drops the connection. The recorder keeps
+/// a connection open for pipelined requests, so reading to EOF would block until
+/// a close that never comes.
+fn post_turn(api: &MockServer, body: &serde_json::Value) -> u16 {
+    let encoded = serde_json::to_vec(body).expect("the body serializes");
+    let address: std::net::SocketAddr = api
+        .base_url
+        .trim_start_matches("http://")
+        .parse()
+        .expect("the recorder base url is an address");
+    let mut stream = std::net::TcpStream::connect(address).expect("connect to the recorder");
+    stream
+        .set_read_timeout(Some(std::time::Duration::from_secs(10)))
+        .expect("a read timeout, so a stuck recorder fails the test instead of hanging it");
+
+    use std::io::{BufRead, Write};
+    let request = format!(
+        "POST /channels/turns HTTP/1.1\r\nHost: local\r\nContent-Type: application/json\r\n\
+         Content-Length: {}\r\n\r\n",
+        encoded.len()
+    );
+    stream.write_all(request.as_bytes()).expect("write headers");
+    stream.write_all(&encoded).expect("write body");
+    stream.flush().expect("flush the request");
+
+    let mut status_line = String::new();
+    std::io::BufReader::new(&stream)
+        .read_line(&mut status_line)
+        .expect("read the status line");
+    status_line
+        .split_whitespace()
+        .nth(1)
+        .and_then(|code| code.parse::<u16>().ok())
+        .unwrap_or_else(|| panic!("the recorder answered a status line: {status_line:?}"))
+}
+
+// ─── A probe failure never escapes the report ────────────────────────────────
+
+/// Every dependency broken at once still produces a COMPLETE verdict, not an
+/// error path.
+///
+/// The Python kit's equivalent hazard (finding 12) is that probe discovery
+/// converts a failure to missing evidence while a LATER call of the same probe
+/// raises uncaught. The Rust verb has no discovery-then-reuse seam, and every
+/// probe converts its own transport error, non 2xx status and unreadable body
+/// into a `CheckResult` at the call site, so there is no `?` between the first
+/// probe and the emit. This pins that property behaviorally rather than by
+/// reading the code: with a dead endpoint AND an API answering 500, the verb
+/// must still emit every check, a `fail` verdict and the failure exit code.
+#[test]
+fn every_probe_failure_becomes_a_reported_check_rather_than_an_error_exit() {
+    let api = serve(|_req: &Request| Response::json(500, r#"{"detail":"boom"}"#));
+    // Bound then dropped, so the port answers nothing at all: a connection
+    // refused is the transport failure no status code can stand in for.
+    let dead = {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        drop(listener);
+        format!("http://{addr}")
+    };
+
+    let dir = tempdir();
+    let mut profile = routed_valid_case();
+    profile["endpoint"] = serde_json::json!(dead);
+    let path = write_profile(dir.path(), &profile);
+    let address = profile["address"]["example"].as_str().unwrap().to_string();
+    let secret_file = dir.path().join("egress.secret");
+    std::fs::write(&secret_file, REAL_EGRESS_SECRET).expect("write the secret");
+
+    let output = run(&[
+        "adapter",
+        "smoke-test",
+        "-f",
+        path.to_str().unwrap(),
+        "--address",
+        &address,
+        "--secret-file",
+        secret_file.to_str().unwrap(),
+        "--allow-insecure",
+        "--enqueue",
+        "--yes",
+        "--api-url",
+        &api.base_url,
+        "--json",
+    ]);
+
+    assert_eq!(
+        code(&output),
+        1,
+        "a failing probe is a FAILURE exit, never an error path that drops the \
+         report\n{}",
+        text(&output)
+    );
+    let payload = stdout_json(&output);
+    for check in [
+        "egress_positive",
+        "egress_negative",
+        "binding",
+        "round_trip",
+    ] {
+        assert!(
+            payload[check].is_object(),
+            "{check} must still be reported when everything is broken: {payload}"
+        );
+        assert_eq!(
+            payload[check]["ok"],
+            serde_json::json!(false),
+            "{check} must be reported as failed: {payload}"
+        );
+    }
+    assert_eq!(
+        payload["verdict"],
+        serde_json::json!("fail"),
+        "payload: {payload}"
     );
 }
 

--- a/cli/tests/adapter_manifest.rs
+++ b/cli/tests/adapter_manifest.rs
@@ -10,9 +10,9 @@
 //! byte identical corpus. Every valid case must parse AND carry its parsed values
 //! back out through `curie adapter validate --json`, and the valid cases
 //! deliberately differ in `kind`, `endpoint` presence, `address.pattern`,
-//! `credentials.egress` and `conformance.mints_reply_ref`, so an implementation
-//! that returns a constant instead of the parsed value dies on the comparison
-//! rather than tracking a self updating expectation.
+//! `credentials.egress` and `credentials.egress_secret_env`, so an
+//! implementation that returns a constant instead of the parsed value dies on
+//! the comparison rather than tracking a self updating expectation.
 //!
 //! The corpus tags each invalid case with the mechanism that enforces it:
 //!
@@ -389,9 +389,9 @@ fn rust_accepts_every_valid_corpus_profile() {
                 .unwrap_or_default()
                 .to_string(),
         );
-        seen.entry("mints_reply_ref")
+        seen.entry("egress_secret_env")
             .or_default()
-            .insert(case["conformance"]["mints_reply_ref"].to_string());
+            .insert(case["credentials"]["egress_secret_env"].to_string());
     }
     for (field, values) in &seen {
         assert!(
@@ -441,8 +441,12 @@ fn rust_accepts_every_valid_corpus_profile() {
             "payload: {payload}"
         );
         assert_eq!(
-            parsed["conformance"]["mints_reply_ref"], case["conformance"]["mints_reply_ref"],
+            parsed["conformance"]["wire_version"], case["conformance"]["wire_version"],
             "payload: {payload}"
+        );
+        assert!(
+            parsed["conformance"].get("mints_reply_ref").is_none(),
+            "mints_reply_ref left the contract; no payload may still report it: {payload}"
         );
         // The endpoint is the one parsed field the payload REDUCES rather than
         // carries: a profile route can hold a token in its path or query, and
@@ -628,6 +632,329 @@ fn version_is_checked_before_schema_validation() {
         !message.contains("retries"),
         "the unknown key must NOT be reported: a schema for a version we do not \
          speak has no authority over this file\n{message}"
+    );
+}
+
+/// The corpus case whose `why` carries this fragment, so a test names the rule
+/// it is exercising rather than an array index that renumbers on the next edit.
+fn invalid_case_saying(fragment: &str) -> serde_json::Value {
+    invalid_cases()
+        .into_iter()
+        .find(|(why, _, _)| why.contains(fragment))
+        .unwrap_or_else(|| panic!("the corpus carries an invalid case whose why says {fragment:?}"))
+        .2
+}
+
+/// Unquoted `version: 1.1` is a YAML float, so a version check that asked only
+/// for a string view finds nothing, skips its own branch, and reports whatever
+/// the closed schema found instead. A check that treats it as a MISSING key is
+/// just as wrong: it sends the author hunting for a key sitting on line one.
+///
+/// The corpus case carries an unknown `future_field` alongside it precisely so
+/// the two failures compete, and the version has to win.
+///
+/// Mutation to run against the implementation: read the version with
+/// `value.get("version").and_then(|v| v.as_str())`. The unknown property leaks
+/// into the message and this reds.
+#[test]
+fn a_numeric_version_is_a_version_error_that_names_the_value_and_the_quoted_form() {
+    assert_verb_routes("validate");
+    let profile = invalid_case_saying("version is the NUMBER 1.1");
+    let dir = tempdir();
+    let path = write_profile(dir.path(), &profile);
+
+    let output = run(&["adapter", "validate", "-f", path.to_str().unwrap()]);
+    assert_eq!(code(&output), 2, "{}", text(&output));
+    let message = text(&output);
+
+    assert!(
+        message.contains("1.1"),
+        "the message must name the value it found\n{message}"
+    );
+    assert!(
+        message.contains("not a string") && message.contains("number"),
+        "the message must say the value is present and of the wrong type\n{message}"
+    );
+    assert!(
+        message.contains(&format!("version: \"{}\"", "1.0")),
+        "the message must name the quoted form the author has to write\n{message}"
+    );
+    assert!(
+        !message.contains("future_field"),
+        "the version refusal must WIN: a schema for a version we do not speak has \
+         no authority over this file\n{message}"
+    );
+    assert!(
+        !message.contains("no version key"),
+        "a present value of the wrong type is not a missing key, and reporting it \
+         as one sends the author looking for a key that is already there\n{message}"
+    );
+}
+
+/// The other two branches of the same check, kept distinct for the same reason.
+/// A missing key is refused BEFORE the schema, so the operator reads the version
+/// rule rather than `version is a required property` buried in a list.
+#[test]
+fn an_absent_and_an_empty_version_are_each_their_own_refusal() {
+    assert_verb_routes("validate");
+    let base = routed_valid_case();
+
+    let mut absent = base.clone();
+    absent.as_object_mut().unwrap().remove("version");
+    let mut empty = base.clone();
+    empty["version"] = serde_json::json!("");
+
+    for (profile, expected) in [(absent, "no version key"), (empty, "empty version key")] {
+        let dir = tempdir();
+        let path = write_profile(dir.path(), &profile);
+        let output = run(&["adapter", "validate", "-f", path.to_str().unwrap()]);
+        assert_eq!(code(&output), 2, "{}", text(&output));
+        let message = text(&output);
+        assert!(
+            message.contains(expected),
+            "the refusal must say {expected:?}\n{message}"
+        );
+        assert!(
+            message.contains(&format!("version: \"{}\"", "1.0")),
+            "every version refusal names the quoted form\n{message}"
+        );
+    }
+}
+
+// ─── The Rust regex dialect IS the tier 3 floor ──────────────────────────────
+
+/// Every construct `channel_protocol.manifest._RUST_UNSUPPORTED_GROUPS` and
+/// `_RUST_UNSUPPORTED_ESCAPES` name must actually be refused by the crate this
+/// CLI matches addresses with. The Python table is a hand written mirror of a
+/// crate's behaviour, so it can only be trusted against the crate itself: a
+/// construct listed there that `regex` in fact ACCEPTS would mean Python is
+/// refusing profiles `curie adapter validate` would take, which is drift in the
+/// direction no corpus case can catch.
+#[test]
+fn the_regex_crate_refuses_every_construct_python_lists_as_unsupported() {
+    let unsupported = [
+        ("lookahead", "^(?=.*@)[a-z0-9@.]+$"),
+        ("negative lookahead", "^(?!admin)[a-z]+$"),
+        ("lookbehind", "(?<=@)[a-z0-9.]+$"),
+        ("negative lookbehind", "(?<!@)[a-z0-9.]+$"),
+        ("backreference", r"^([a-z0-9]+)@\1\.example\.test$"),
+        ("named backreference", "^(?P<a>[a-z]+)(?P=a)$"),
+        ("atomic group", "^(?>a)$"),
+        (
+            "conditional group",
+            r"^([a-z]+)?(?(1)@example\.test|admin)$",
+        ),
+        (
+            "inline comment group",
+            r"^[a-z0-9]+(?#the local part)@example\.test$",
+        ),
+        ("ASCII flag", r"(?a)^[a-z0-9]+@example\.test$"),
+        ("end of string anchor", r"^[a-z0-9]+@example\.test\Z"),
+        (
+            "named character escape",
+            r"^[a-z0-9]+\N{COMMERCIAL AT}example\.test$",
+        ),
+    ];
+    for (name, pattern) in unsupported {
+        assert!(
+            regex::Regex::new(pattern).is_err(),
+            "the regex crate ACCEPTS {name} ({pattern:?}), so listing it as unsupported \
+             makes the Python validator refuse a profile this CLI would take"
+        );
+    }
+}
+
+/// The false positive control, and the reason the Python table's non entries are
+/// non entries. These four are accepted by the crate, so listing any of them
+/// would refuse a profile that is fine on both sides.
+#[test]
+fn the_regex_crate_accepts_the_constructs_python_deliberately_does_not_list() {
+    let supported = [
+        ("non capturing group", "^[a-z0-9]+(?:-[a-z0-9]+)*$"),
+        ("named group", "^(?P<local>[a-z]+)@example$"),
+        ("inline case insensitive flag", "(?i)^[a-z]+$"),
+        ("possessive quantifier", "^[a-z]++$"),
+    ];
+    for (name, pattern) in supported {
+        assert!(
+            regex::Regex::new(pattern).is_ok(),
+            "the regex crate refuses {name} ({pattern:?}); Python leaves it off the \
+             unsupported table, so the two validators now disagree"
+        );
+    }
+}
+
+/// The end to end half of the control: a valid corpus profile whose pattern uses
+/// an accepted construct still validates through the real binary, so the tier 3
+/// scan cannot be greened by refusing everything with a `(?` in it.
+#[test]
+fn a_profile_using_an_accepted_group_construct_still_validates() {
+    let profile = valid_cases()
+        .into_iter()
+        .find(|case| {
+            case["address"]["pattern"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("(?")
+        })
+        .expect("the corpus carries a valid pattern using a group construct");
+
+    let dir = tempdir();
+    let path = write_profile(dir.path(), &profile);
+    let output = run(&[
+        "adapter",
+        "validate",
+        "-f",
+        path.to_str().unwrap(),
+        "--json",
+    ]);
+    assert_eq!(
+        code(&output),
+        0,
+        "an accepted construct must not be refused\n{}",
+        text(&output)
+    );
+    assert_eq!(stdout_json(&output)["ok"], serde_json::json!(true));
+}
+
+// ─── A schema diagnostic never echoes the endpoint ───────────────────────────
+
+/// The profile the schema refuses for embedding userinfo is exactly the one
+/// whose rejected instance value IS a credential. A validation error renders the
+/// instance it rejected, so the diagnostic has to carry the same reduction the
+/// payloads and the human renders carry.
+///
+/// Mutation to run against the implementation: format the errors as `{e}` with
+/// no scrub. This reds.
+#[test]
+fn a_schema_diagnostic_never_echoes_the_endpoints_credentials() {
+    assert_verb_routes("validate");
+    for (endpoint, secret) in [
+        (
+            "https://user:passw0rd@adapter.example.test/hook",
+            "passw0rd",
+        ),
+        (
+            "https://adapter.example.test/hook?ingress_token=qu3rys3cret",
+            "qu3rys3cret",
+        ),
+    ] {
+        let mut profile = routed_valid_case();
+        profile["endpoint"] = serde_json::json!(endpoint);
+        // Force a schema refusal that is NOT about the endpoint too, so the
+        // scrub is proven on a diagnostic the endpoint merely rides along in.
+        profile["kind"] = serde_json::json!("NotASlug");
+
+        let dir = tempdir();
+        let path = write_profile(dir.path(), &profile);
+        let output = run(&["adapter", "validate", "-f", path.to_str().unwrap()]);
+        assert_eq!(code(&output), 2, "{}", text(&output));
+
+        let message = text(&output);
+        assert!(
+            !message.contains(secret),
+            "a schema diagnostic must not echo the endpoint's credential {secret:?}\n{message}"
+        );
+        assert!(!message.contains("/hook"), "nor its path\n{message}");
+    }
+}
+
+// ─── `scaffold` creates exclusively, it does not check then write ────────────
+
+/// The no overwrite guarantee has to be the CREATE, not an `exists()` test
+/// followed by a write. Those are two operations, and a symlink slips between
+/// them: `Path::exists` FOLLOWS the link, so a DANGLING one answers false, and
+/// `fs::write` follows it too and creates the victim at the other end. The
+/// check passes, the write lands somewhere else, and the guarantee is gone
+/// without any race being needed.
+///
+/// A link to an existing file does not discriminate, because `exists()` happens
+/// to catch that one; the dangling case is the whole test.
+///
+/// Mutation to run against the implementation: restore the `file.exists()` check
+/// plus `std::fs::write`. The victim path gets created and this reds.
+#[test]
+#[cfg(unix)]
+fn scaffold_refuses_a_dangling_symlink_rather_than_writing_through_it() {
+    let dir = tempdir();
+    let victim = dir.path().join("victim.yaml");
+    assert!(!victim.exists(), "the victim must not exist yet");
+
+    let root = dir.path().join("root");
+    std::fs::create_dir_all(root.join("demo")).expect("create the scaffold dir");
+    let planted = root.join("demo/adapter.yaml");
+    std::os::unix::fs::symlink(&victim, &planted).expect("plant the dangling symlink");
+
+    let output = run(&[
+        "adapter",
+        "scaffold",
+        "demo",
+        "--kind",
+        "email",
+        "--address",
+        "agent@example.test",
+        "--endpoint",
+        "https://h.example.test/curie",
+        "--adapter",
+        "demo-egress",
+        "--dir",
+        root.to_str().unwrap(),
+    ]);
+
+    assert_eq!(
+        code(&output),
+        2,
+        "an entry already at the destination is a usage error, a dangling symlink \
+         included\n{}",
+        text(&output)
+    );
+    assert!(
+        !victim.exists(),
+        "scaffold wrote THROUGH the link and created {}; exclusive creation is what \
+         makes the no overwrite rule true",
+        victim.display()
+    );
+    assert!(
+        text(&output).contains("never overwrites"),
+        "the refusal must name the rule\n{}",
+        text(&output)
+    );
+}
+
+/// The plain half of the same rule, so the symlink test above is not the only
+/// thing holding it up.
+#[test]
+fn scaffold_refuses_an_existing_profile() {
+    let dir = tempdir();
+    std::fs::create_dir_all(dir.path().join("demo")).expect("create the scaffold dir");
+    let existing = dir.path().join("demo/adapter.yaml");
+    std::fs::write(&existing, "mine\n").expect("write the existing profile");
+
+    let output = run(&[
+        "adapter",
+        "scaffold",
+        "demo",
+        "--kind",
+        "email",
+        "--address",
+        "agent@example.test",
+        "--endpoint",
+        "https://h.example.test/curie",
+        "--adapter",
+        "demo-egress",
+        "--dir",
+        dir.path().to_str().unwrap(),
+    ]);
+
+    assert_eq!(code(&output), 2, "{}", text(&output));
+    assert!(
+        text(&output).contains("never overwrites"),
+        "the refusal must name the rule\n{}",
+        text(&output)
+    );
+    assert_eq!(
+        std::fs::read_to_string(&existing).expect("the profile survives"),
+        "mine\n"
     );
 }
 

--- a/cli/tests/adapter_manifest.rs
+++ b/cli/tests/adapter_manifest.rs
@@ -1,0 +1,1205 @@
+//! Contract gate for the `curie adapter` verb family (issue #1516, Stream B).
+//!
+//! Two things are proven here, and neither is provable by reading source.
+//!
+//! **The cross language contract.** `packages/channel-protocol` owns the adapter
+//! binding profile as Pydantic models, exports
+//! `schema/adapter-profile.schema.json`, and commits
+//! `schema/adapter-profile.corpus.json` as the shared fixture. Python asserts its
+//! half in `test_manifest_corpus.py`; this file asserts the Rust half over the
+//! byte identical corpus. Every valid case must parse AND carry its parsed values
+//! back out through `curie adapter validate --json`, and the valid cases
+//! deliberately differ in `kind`, `endpoint` presence, `address.pattern`,
+//! `credentials.egress` and `conformance.mints_reply_ref`, so an implementation
+//! that returns a constant instead of the parsed value dies on the comparison
+//! rather than tracking a self updating expectation.
+//!
+//! The corpus tags each invalid case with the mechanism that enforces it:
+//!
+//! - **tier 1 and 2** are enforced by the exported JSON Schema, so this file
+//!   asserts the committed schema itself rejects them.
+//! - **tier 3** is an admitted PAIRED validator (one in Python, one in Rust),
+//!   because JSON Schema cannot express "the Rust regex crate can compile this
+//!   string". The assertion is inverted: the schema must ACCEPT a tier 3 case and
+//!   the Rust verb must still reject it. That inversion is what stops a later
+//!   reader assuming the rule exports.
+//!
+//! **The credential selection boundary.** A binding profile is a third party
+//! file. The worker indexes its GLOBAL credential map by the slug the route
+//! carries (`apps/worker/src/curie_worker/reply_sink.py::HttpReplyAdapter::_secret_for`),
+//! so a profile controlled slug reaching the write path would let one adapter's
+//! file select another adapter's secret and have the platform POST it to the host
+//! that same file names. The profile's `credentials.egress` is therefore a non
+//! binding SUGGESTION, `--adapter-slug` is a required operator input on `bind`,
+//! and the same reasoning makes `--address` required on the three live verbs and
+//! the `smoke-test` egress secret operator supplied at the invocation boundary.
+//! The tests below drive the real binary against a loopback recorder and assert
+//! on the bytes that reach the wire, so a fallback to the profile's value is
+//! caught as a changed request body rather than a changed comment.
+//!
+//! Everything here is hermetic: no Curie install, no cluster, no network beyond
+//! loopback, and every port is ephemeral.
+
+mod support;
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+
+use support::{serve, MockServer, Request, Response};
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+/// The committed profile schema, the same bytes `cli/src/adapter.rs` embeds.
+const PROFILE_SCHEMA: &str =
+    include_str!("../../packages/channel-protocol/schema/adapter-profile.schema.json");
+
+/// The committed cross language corpus, the same bytes
+/// `packages/channel-protocol/tests/test_manifest_corpus.py` reads.
+const PROFILE_CORPUS: &str =
+    include_str!("../../packages/channel-protocol/schema/adapter-profile.corpus.json");
+
+fn corpus() -> serde_json::Value {
+    serde_json::from_str(PROFILE_CORPUS).expect("adapter-profile.corpus.json is valid JSON")
+}
+
+fn valid_cases() -> Vec<serde_json::Value> {
+    corpus()["valid"]
+        .as_array()
+        .expect("corpus carries a valid array")
+        .clone()
+}
+
+/// Every invalid case as `(why, tier, profile)`.
+fn invalid_cases() -> Vec<(String, u64, serde_json::Value)> {
+    corpus()["invalid"]
+        .as_array()
+        .expect("corpus carries an invalid array")
+        .iter()
+        .map(|case| {
+            (
+                case["why"].as_str().expect("case carries why").to_string(),
+                case["tier"].as_u64().expect("case carries a tier"),
+                case["profile"].clone(),
+            )
+        })
+        .collect()
+}
+
+/// The exported schema compiled with its root pointed at `AdapterProfile`, the
+/// same entry point `cli/src/adapter.rs` uses. This is the tier 1 and 2
+/// authority; it is deliberately NOT the tier 3 authority.
+fn profile_validator() -> jsonschema::Validator {
+    let mut doc: serde_json::Value =
+        serde_json::from_str(PROFILE_SCHEMA).expect("adapter-profile.schema.json is valid JSON");
+    doc["$ref"] = serde_json::Value::String("#/$defs/AdapterProfile".to_string());
+    jsonschema::validator_for(&doc).expect("the AdapterProfile def compiles to a validator")
+}
+
+/// The corpus case with no `endpoint` at all. `endpoint` is OPTIONAL in the
+/// schema and REQUIRED by the verbs that build a request from it, which is the
+/// asymmetry several tests below turn on.
+fn endpointless_valid_case() -> serde_json::Value {
+    valid_cases()
+        .into_iter()
+        .find(|case| case.get("endpoint").is_none() || case["endpoint"].is_null())
+        .expect("the corpus carries a valid case with no endpoint")
+}
+
+/// A valid case that DOES carry an endpoint, for the tests that need a route.
+fn routed_valid_case() -> serde_json::Value {
+    valid_cases()
+        .into_iter()
+        .find(|case| case.get("endpoint").is_some_and(|e| e.is_string()))
+        .expect("the corpus carries a valid case with an endpoint")
+}
+
+// ─── Process harness ─────────────────────────────────────────────────────────
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_curie")
+}
+
+/// A profile written where the verbs read it. JSON is a subset of YAML, so the
+/// corpus values land byte faithfully with no re-encoding step of our own to get
+/// wrong.
+fn write_profile(dir: &Path, profile: &serde_json::Value) -> PathBuf {
+    let path = dir.join("adapter.yaml");
+    std::fs::write(
+        &path,
+        serde_json::to_string_pretty(profile).expect("profile serializes"),
+    )
+    .expect("write adapter.yaml");
+    path
+}
+
+/// Run `curie <args>` with a closed stdin, so a command that reaches an
+/// interactive confirmation fails immediately instead of hanging the suite.
+fn run(args: &[&str]) -> Output {
+    run_with_env(args, &[])
+}
+
+fn run_with_env(args: &[&str], env: &[(&str, &str)]) -> Output {
+    let mut cmd = Command::new(bin());
+    cmd.args(args).stdin(Stdio::null());
+    for (key, value) in env {
+        cmd.env(key, value);
+    }
+    cmd.output().expect("run curie")
+}
+
+fn text(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stdout).into_owned() + &String::from_utf8_lossy(&output.stderr)
+}
+
+fn code(output: &Output) -> i32 {
+    output.status.code().expect("curie exited with a code")
+}
+
+fn stdout_json(output: &Output) -> serde_json::Value {
+    let raw = String::from_utf8_lossy(&output.stdout);
+    serde_json::from_str(raw.trim()).unwrap_or_else(|e| {
+        panic!(
+            "--json stdout must be one JSON object: {e}\nstdout: {raw}\nstderr: {}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    })
+}
+
+/// The `--help` long flags for one verb, so a refusal test cannot pass merely
+/// because clap rejected a flag the verb never declared.
+fn help_flags(args: &[&str]) -> std::collections::BTreeSet<String> {
+    let output = run(&[args, &["--help"]].concat());
+    assert_eq!(
+        code(&output),
+        0,
+        "expected `curie {} --help` to route\n{}",
+        args.join(" "),
+        text(&output)
+    );
+    text(&output)
+        .split_whitespace()
+        .filter(|token| token.starts_with("--") && token.len() > 2)
+        .map(|token| token.trim_end_matches([',', '=', '<']).to_string())
+        .collect()
+}
+
+/// Precondition for every refusal test below. Exit 2 is also what clap returns
+/// for a subcommand it has never heard of, so an exit-2 assertion proves nothing
+/// until the verb itself routes. Asserting that first is what stops a refusal
+/// test greening for the wrong reason, before the verb exists and after someone
+/// later deletes it.
+fn assert_verb_routes(verb: &str) {
+    let output = run(&["adapter", verb, "--help"]);
+    assert_eq!(
+        code(&output),
+        0,
+        "`curie adapter {verb}` must route before any of its refusals mean \
+         anything\n{}",
+        text(&output)
+    );
+}
+
+// ─── Loopback recorders ──────────────────────────────────────────────────────
+
+/// A platform API stand-in on an ephemeral port. It answers the two routes the
+/// live verbs touch and records every request, so the tests assert on the bytes
+/// the CLI actually put on the wire.
+fn api_recorder() -> MockServer {
+    serve(|req: &Request| {
+        if req.path.starts_with("/channels/token") {
+            Response::json(200, r#"{"token":"chn_test_token_value"}"#)
+        } else {
+            Response::json(
+                200,
+                r#"{"id":"demo","name":"demo","channel":{"kind":"email","address":"agent@example.test"}}"#,
+            )
+        }
+    })
+}
+
+/// An adapter egress endpoint stand-in on an ephemeral port.
+fn endpoint_recorder() -> MockServer {
+    serve(|_req: &Request| Response::json(200, r#"{"ok":true}"#))
+}
+
+fn bodies(server: &MockServer) -> Vec<String> {
+    server
+        .recorded()
+        .iter()
+        .map(|req| String::from_utf8_lossy(&req.body).into_owned())
+        .collect()
+}
+
+/// The JSON body of the first request whose method and path prefix match.
+fn recorded_body(server: &MockServer, method: &str, path_prefix: &str) -> serde_json::Value {
+    let recorded = server.recorded();
+    let req = recorded
+        .iter()
+        .find(|req| req.method == method && req.path.starts_with(path_prefix))
+        .unwrap_or_else(|| {
+            panic!(
+                "no {method} {path_prefix} request was recorded; saw {:?}",
+                recorded
+                    .iter()
+                    .map(|r| format!("{} {}", r.method, r.path))
+                    .collect::<Vec<_>>()
+            )
+        });
+    serde_json::from_slice(&req.body).unwrap_or_else(|e| {
+        panic!(
+            "{method} {path_prefix} body must be JSON: {e}\n{}",
+            String::from_utf8_lossy(&req.body)
+        )
+    })
+}
+
+fn tempdir() -> tempfile::TempDir {
+    tempfile::tempdir().expect("tempdir")
+}
+
+// ─── The corpus is the drift gate between the two validators ─────────────────
+
+/// Every valid corpus profile parses in Rust AND its parsed values come back out.
+///
+/// The comparison is against the corpus value, never against a value this test
+/// computed, so the only way to green it is to carry the parsed field through.
+/// The corpus cases differ from each other on all five compared fields, which is
+/// what kills an implementation that hardcodes or drops one: a constant cannot
+/// satisfy `email` and `ms_teams` and `webhook` at once.
+///
+/// Mutation to run against the implementation: replace the parsed
+/// `credentials.egress` with a literal, or drop `endpoint` from the payload.
+/// Both must red here.
+#[test]
+fn rust_accepts_every_valid_corpus_profile() {
+    let cases = valid_cases();
+    assert!(
+        cases.len() >= 2,
+        "value parity needs at least two differing valid cases"
+    );
+
+    // Prove the fixture itself can kill a constant before trusting it to.
+    let mut seen: BTreeMap<&str, std::collections::BTreeSet<String>> = BTreeMap::new();
+    for case in &cases {
+        seen.entry("kind")
+            .or_default()
+            .insert(case["kind"].to_string());
+        seen.entry("egress")
+            .or_default()
+            .insert(case["credentials"]["egress"].to_string());
+        seen.entry("pattern")
+            .or_default()
+            .insert(case["address"]["pattern"].to_string());
+        seen.entry("endpoint").or_default().insert(
+            case.get("endpoint")
+                .cloned()
+                .unwrap_or_default()
+                .to_string(),
+        );
+        seen.entry("mints_reply_ref")
+            .or_default()
+            .insert(case["conformance"]["mints_reply_ref"].to_string());
+    }
+    for (field, values) in &seen {
+        assert!(
+            values.len() >= 2,
+            "the corpus must carry at least two DIFFERENT {field} values, or a \
+             constant returning implementation survives; saw {values:?}"
+        );
+    }
+
+    for case in &cases {
+        let dir = tempdir();
+        let path = write_profile(dir.path(), case);
+        let output = run(&[
+            "adapter",
+            "validate",
+            "-f",
+            path.to_str().unwrap(),
+            "--json",
+        ]);
+        assert_eq!(
+            code(&output),
+            0,
+            "a valid corpus profile must validate: {case}\n{}",
+            text(&output)
+        );
+
+        let payload = stdout_json(&output);
+        assert_eq!(payload["ok"], serde_json::json!(true), "payload: {payload}");
+
+        let parsed = &payload["profile"];
+        assert_eq!(parsed["version"], case["version"], "payload: {payload}");
+        assert_eq!(parsed["kind"], case["kind"], "payload: {payload}");
+        assert_eq!(
+            parsed["address"]["pattern"], case["address"]["pattern"],
+            "payload: {payload}"
+        );
+        assert_eq!(
+            parsed["address"]["example"], case["address"]["example"],
+            "payload: {payload}"
+        );
+        assert_eq!(
+            parsed["credentials"]["egress"], case["credentials"]["egress"],
+            "payload: {payload}"
+        );
+        assert_eq!(
+            parsed["credentials"]["egress_secret_env"], case["credentials"]["egress_secret_env"],
+            "payload: {payload}"
+        );
+        assert_eq!(
+            parsed["conformance"]["mints_reply_ref"], case["conformance"]["mints_reply_ref"],
+            "payload: {payload}"
+        );
+        // Absent in the file must read back as JSON null, never a missing key,
+        // so a consumer can branch on it unconditionally.
+        let expected_endpoint = case
+            .get("endpoint")
+            .cloned()
+            .unwrap_or(serde_json::Value::Null);
+        assert_eq!(parsed["endpoint"], expected_endpoint, "payload: {payload}");
+    }
+}
+
+/// Every invalid corpus case is refused by the verb, whatever its tier. This is
+/// the union assertion; the two tier specific tests below prove WHICH mechanism
+/// caught each one.
+#[test]
+fn rust_rejects_every_invalid_corpus_profile() {
+    assert_verb_routes("validate");
+    for (why, tier, profile) in invalid_cases() {
+        let dir = tempdir();
+        let path = write_profile(dir.path(), &profile);
+        let output = run(&["adapter", "validate", "-f", path.to_str().unwrap()]);
+        assert_eq!(
+            code(&output),
+            2,
+            "tier {tier} case must exit 2 (usage): {why}\n{}",
+            text(&output)
+        );
+    }
+}
+
+/// Tiers 1 and 2 are the exported schema's job, so the committed schema must
+/// reject them on its own. If a case tagged tier 1 slips through the schema, the
+/// tag is a lie and the Python side is enforcing something Rust only happens to
+/// mirror.
+#[test]
+fn the_committed_schema_rejects_every_tier_1_and_2_invalid_case() {
+    let validator = profile_validator();
+    for (why, tier, profile) in invalid_cases() {
+        if tier > 2 {
+            continue;
+        }
+        assert!(
+            !validator.is_valid(&profile),
+            "tier {tier} claims the exported schema catches this, but it validated: {why}"
+        );
+    }
+}
+
+/// Tier 3 is the admitted paired validator, and this is the INVERTED assertion
+/// that keeps the admission honest: the schema must ACCEPT the case (JSON Schema
+/// cannot express "the Rust regex crate compiles this") while the Rust verb still
+/// refuses it. A tier 3 case the schema unexpectedly catches is as wrong as a
+/// tier 1 case it misses, because it would mean the pairing was never needed.
+///
+/// Mutation to run against the corpus: retag one tier 3 case as tier 1. The test
+/// above must then red.
+#[test]
+fn rust_rejects_every_tier_3_invalid_case_in_code() {
+    assert_verb_routes("validate");
+    let validator = profile_validator();
+    let mut tier_3 = 0;
+    for (why, tier, profile) in invalid_cases() {
+        if tier != 3 {
+            continue;
+        }
+        tier_3 += 1;
+        assert!(
+            validator.is_valid(&profile),
+            "a tier 3 case must be one the exported schema ACCEPTS, or it is not \
+             a paired validator at all: {why}"
+        );
+
+        let dir = tempdir();
+        let path = write_profile(dir.path(), &profile);
+        let output = run(&["adapter", "validate", "-f", path.to_str().unwrap()]);
+        assert_eq!(
+            code(&output),
+            2,
+            "the Rust side must carry its half of the paired validator: {why}\n{}",
+            text(&output)
+        );
+    }
+    assert!(
+        tier_3 >= 3,
+        "the corpus must carry a tier 3 case per Rust unsupported construct \
+         (lookahead, lookbehind, backreference); found {tier_3}"
+    );
+}
+
+/// The floor the tier 3 rule exists to guarantee: every pattern the corpus calls
+/// valid actually compiles with the crate `curie adapter` matches addresses with.
+#[test]
+fn rust_regex_compiles_every_valid_corpus_pattern() {
+    for case in valid_cases() {
+        let pattern = case["address"]["pattern"]
+            .as_str()
+            .expect("address.pattern is a string");
+        regex::Regex::new(pattern).unwrap_or_else(|e| {
+            panic!("valid corpus pattern must compile in Rust: {pattern}: {e}")
+        });
+    }
+}
+
+// ─── The version check runs first ────────────────────────────────────────────
+
+/// A profile written against a version this build does not understand is refused
+/// with BOTH versions named, so the operator learns what to do rather than
+/// reading a field level schema error about a shape that was never theirs.
+#[test]
+fn version_mismatch_is_a_usage_error_naming_both() {
+    assert_verb_routes("validate");
+    let mut profile = routed_valid_case();
+    profile["version"] = serde_json::json!("1.1");
+
+    let dir = tempdir();
+    let path = write_profile(dir.path(), &profile);
+    let output = run(&["adapter", "validate", "-f", path.to_str().unwrap()]);
+
+    assert_eq!(code(&output), 2, "{}", text(&output));
+    let message = text(&output);
+    assert!(
+        message.contains("1.1"),
+        "the message must name the file's version\n{message}"
+    );
+    assert!(
+        message.contains("1.0"),
+        "the message must name the version this build understands\n{message}"
+    );
+}
+
+/// The ordering assertion, which is the only thing the test above cannot prove:
+/// a file that is BOTH a wrong version and structurally invalid must report the
+/// version, because the schema for a version we do not speak has no authority
+/// over that file.
+///
+/// Mutation to run against the implementation: move the version check after
+/// schema validation. This must red while the test above stays green.
+#[test]
+fn version_is_checked_before_schema_validation() {
+    assert_verb_routes("validate");
+    let mut profile = routed_valid_case();
+    profile["version"] = serde_json::json!("1.1");
+    profile["retries"] = serde_json::json!(3);
+
+    let dir = tempdir();
+    let path = write_profile(dir.path(), &profile);
+    let output = run(&["adapter", "validate", "-f", path.to_str().unwrap()]);
+
+    assert_eq!(code(&output), 2, "{}", text(&output));
+    let message = text(&output);
+    assert!(
+        message.contains("1.1"),
+        "the version mismatch must be what is reported\n{message}"
+    );
+    assert!(
+        !message.contains("retries"),
+        "the unknown key must NOT be reported: a schema for a version we do not \
+         speak has no authority over this file\n{message}"
+    );
+}
+
+// ─── `--address` is an operator input, never `address.example` ───────────────
+
+/// `address.example` is authoring documentation. Every live verb must declare
+/// `--address` so no code path can reach for the profile's example instead, and
+/// the two flags that make a route operator owned must exist on `bind`.
+#[test]
+fn the_live_verbs_declare_the_operator_owned_flags() {
+    for verb in ["bind", "token", "smoke-test"] {
+        let flags = help_flags(&["adapter", verb]);
+        assert!(
+            flags.contains("--address"),
+            "`adapter {verb}` must declare --address; saw {flags:?}"
+        );
+    }
+
+    let bind = help_flags(&["adapter", "bind"]);
+    for flag in ["--adapter-slug", "--endpoint", "--yes"] {
+        assert!(
+            bind.contains(flag),
+            "`adapter bind` must declare {flag}; saw {bind:?}"
+        );
+    }
+}
+
+/// Omitting `--address` is a usage error on every verb that resolves against a
+/// concrete `(kind, address)` pair, and nothing reaches the API first.
+#[test]
+fn the_live_verbs_require_an_explicit_address() {
+    for verb in ["bind", "token", "smoke-test"] {
+        assert_verb_routes(verb);
+    }
+    let api = api_recorder();
+    let profile = routed_valid_case();
+    let dir = tempdir();
+    let path = write_profile(dir.path(), &profile);
+    let file = path.to_str().unwrap();
+
+    let invocations: Vec<Vec<String>> = vec![
+        vec![
+            "adapter".into(),
+            "bind".into(),
+            "-f".into(),
+            file.into(),
+            "demo".into(),
+            "--adapter-slug".into(),
+            "operator-owned".into(),
+            "--yes".into(),
+            "--api-url".into(),
+            api.base_url.clone(),
+        ],
+        vec![
+            "adapter".into(),
+            "token".into(),
+            "-f".into(),
+            file.into(),
+            "--api-url".into(),
+            api.base_url.clone(),
+        ],
+        vec![
+            "adapter".into(),
+            "smoke-test".into(),
+            "-f".into(),
+            file.into(),
+            "--yes".into(),
+            "--api-url".into(),
+            api.base_url.clone(),
+        ],
+    ];
+
+    for argv in invocations {
+        let borrowed: Vec<&str> = argv.iter().map(String::as_str).collect();
+        let output = run(&borrowed);
+        assert_eq!(
+            code(&output),
+            2,
+            "{:?} must be a usage error without --address\n{}",
+            argv,
+            text(&output)
+        );
+    }
+
+    assert!(
+        api.recorded().is_empty(),
+        "no request may leave before an address is supplied; saw {:?}",
+        bodies(&api)
+    );
+    let example = profile["address"]["example"].as_str().unwrap();
+    for body in bodies(&api) {
+        assert!(
+            !body.contains(example),
+            "the profile's address.example must never become live state: {body}"
+        );
+    }
+}
+
+/// A supplied address is checked against the profile's own pattern before any
+/// request, so the operator reads a usage error instead of discovering the
+/// mismatch as a 404 from a live ingress.
+#[test]
+fn address_mismatch_is_a_usage_error() {
+    assert_verb_routes("validate");
+    let profile = routed_valid_case();
+    let dir = tempdir();
+    let path = write_profile(dir.path(), &profile);
+
+    let output = run(&[
+        "adapter",
+        "validate",
+        "-f",
+        path.to_str().unwrap(),
+        "--address",
+        "definitely not this shape",
+    ]);
+    assert_eq!(code(&output), 2, "{}", text(&output));
+    let message = text(&output);
+    assert!(
+        message.contains("definitely not this shape"),
+        "the message must name the address\n{message}"
+    );
+    assert!(
+        message.contains(profile["address"]["pattern"].as_str().unwrap()),
+        "the message must name the pattern\n{message}"
+    );
+}
+
+/// The false positive control for the test above: an address of the declared
+/// shape passes, so the check is a real match and not a blanket refusal.
+#[test]
+fn an_address_matching_the_pattern_validates() {
+    let profile = routed_valid_case();
+    let dir = tempdir();
+    let path = write_profile(dir.path(), &profile);
+
+    let output = run(&[
+        "adapter",
+        "validate",
+        "-f",
+        path.to_str().unwrap(),
+        "--address",
+        profile["address"]["example"].as_str().unwrap(),
+        "--json",
+    ]);
+    assert_eq!(code(&output), 0, "{}", text(&output));
+    assert_eq!(stdout_json(&output)["ok"], serde_json::json!(true));
+}
+
+// ─── The credential selection boundary ───────────────────────────────────────
+
+/// A profile whose `credentials.egress` names ANOTHER adapter's slug must not be
+/// able to put that slug on the wire. The operator supplies `--adapter-slug` and
+/// that value, and only that value, becomes the route's `adapter` field, because
+/// the worker uses it to index a map holding every adapter's secret.
+///
+/// Mutation to run against the implementation: fall back to
+/// `profile.credentials.egress` when the flag is absent, or prefer the profile's
+/// value when the two differ. This must red.
+#[test]
+fn a_profile_slug_alone_never_reaches_the_write_payload() {
+    let api = api_recorder();
+    let mut profile = routed_valid_case();
+    profile["credentials"]["egress"] = serde_json::json!("victim-adapter");
+
+    let dir = tempdir();
+    let path = write_profile(dir.path(), &profile);
+    let address = profile["address"]["example"].as_str().unwrap().to_string();
+
+    let output = run(&[
+        "adapter",
+        "bind",
+        "-f",
+        path.to_str().unwrap(),
+        "demo",
+        "--address",
+        &address,
+        "--adapter-slug",
+        "operator-owned",
+        "--yes",
+        "--api-url",
+        &api.base_url,
+    ]);
+
+    let body = recorded_body(&api, "PATCH", "/agents/");
+    assert_eq!(
+        body["channel"]["adapter"],
+        serde_json::json!("operator-owned"),
+        "the written slug must be the operator's, exit {}\n{}",
+        code(&output),
+        text(&output)
+    );
+    for raw in bodies(&api) {
+        assert!(
+            !raw.contains("victim-adapter"),
+            "the profile's suggested slug must never reach the API: {raw}"
+        );
+    }
+}
+
+/// There is no invocation in which the profile's value is the only source, so
+/// the fallback the test above forbids has nowhere to hide.
+#[test]
+fn bind_requires_adapter_slug() {
+    assert_verb_routes("bind");
+    let api = api_recorder();
+    let profile = routed_valid_case();
+    let dir = tempdir();
+    let path = write_profile(dir.path(), &profile);
+    let address = profile["address"]["example"].as_str().unwrap().to_string();
+
+    let output = run(&[
+        "adapter",
+        "bind",
+        "-f",
+        path.to_str().unwrap(),
+        "demo",
+        "--address",
+        &address,
+        "--yes",
+        "--api-url",
+        &api.base_url,
+    ]);
+
+    assert_eq!(code(&output), 2, "{}", text(&output));
+    assert!(
+        api.recorded().is_empty(),
+        "nothing may be written without an operator supplied slug; saw {:?}",
+        bodies(&api)
+    );
+}
+
+/// When the operator's slug and the profile's suggestion differ, the operator
+/// sees both values and has to confirm. Confirming a value the profile chose is
+/// not operator owned credential mapping, so the confirmation is what makes the
+/// suggestion safe to keep in the file at all.
+#[test]
+fn mismatched_slug_requires_confirmation() {
+    assert_verb_routes("bind");
+    let api = api_recorder();
+    let mut profile = routed_valid_case();
+    profile["credentials"]["egress"] = serde_json::json!("victim-adapter");
+
+    let dir = tempdir();
+    let path = write_profile(dir.path(), &profile);
+    let address = profile["address"]["example"].as_str().unwrap().to_string();
+
+    let output = run(&[
+        "adapter",
+        "bind",
+        "-f",
+        path.to_str().unwrap(),
+        "demo",
+        "--address",
+        &address,
+        "--adapter-slug",
+        "operator-owned",
+        "--api-url",
+        &api.base_url,
+    ]);
+
+    assert_ne!(
+        code(&output),
+        0,
+        "a slug mismatch must not proceed unconfirmed\n{}",
+        text(&output)
+    );
+    let message = text(&output);
+    assert!(
+        message.contains("operator-owned") && message.contains("victim-adapter"),
+        "both values must be shown so the operator can tell them apart\n{message}"
+    );
+    assert!(
+        api.recorded().is_empty(),
+        "nothing may be written before the mismatch is confirmed; saw {:?}",
+        bodies(&api)
+    );
+}
+
+/// The API refuses a non `slack` binding whose reply route is half set, so `bind`
+/// writes all four fields or the operator gets a token mint 409 later instead.
+#[test]
+fn bind_writes_all_four_route_fields() {
+    let api = api_recorder();
+    let profile = routed_valid_case();
+    let dir = tempdir();
+    let path = write_profile(dir.path(), &profile);
+    let address = profile["address"]["example"].as_str().unwrap().to_string();
+
+    run(&[
+        "adapter",
+        "bind",
+        "-f",
+        path.to_str().unwrap(),
+        "demo",
+        "--address",
+        &address,
+        "--adapter-slug",
+        "operator-owned",
+        "--yes",
+        "--api-url",
+        &api.base_url,
+    ]);
+
+    let body = recorded_body(&api, "PATCH", "/agents/");
+    let channel = &body["channel"];
+    assert_eq!(channel["kind"], profile["kind"], "body: {body}");
+    assert_eq!(
+        channel["address"],
+        serde_json::json!(address),
+        "body: {body}"
+    );
+    assert_eq!(channel["endpoint"], profile["endpoint"], "body: {body}");
+    assert_eq!(
+        channel["adapter"],
+        serde_json::json!("operator-owned"),
+        "body: {body}"
+    );
+}
+
+// ─── `endpoint` is schema optional and verb required ─────────────────────────
+
+/// A profile with no `endpoint` is a legal profile: an author publishes the
+/// address shape and credential identities long before any one install has a
+/// route. Both the committed schema and the verb that only reads must accept it.
+#[test]
+fn an_endpointless_profile_is_schema_valid_and_validates() {
+    let profile = endpointless_valid_case();
+    assert!(
+        profile_validator().is_valid(&profile),
+        "endpoint must be OPTIONAL in the committed schema: {profile}"
+    );
+
+    let dir = tempdir();
+    let path = write_profile(dir.path(), &profile);
+    let output = run(&[
+        "adapter",
+        "validate",
+        "-f",
+        path.to_str().unwrap(),
+        "--json",
+    ]);
+    assert_eq!(code(&output), 0, "{}", text(&output));
+
+    let payload = stdout_json(&output);
+    assert_eq!(payload["ok"], serde_json::json!(true), "{payload}");
+    assert!(
+        payload["profile"]["endpoint"].is_null(),
+        "an absent endpoint reads back as null, never a missing key: {payload}"
+    );
+}
+
+/// The other half of that asymmetry: a verb that must build a request against a
+/// route fails as a usage error naming the missing field and the flag that
+/// supplies it, never as a confusing HTTP error against an empty string.
+#[test]
+fn missing_endpoint_is_a_usage_error_on_the_verbs_that_need_one() {
+    for verb in ["bind", "smoke-test"] {
+        assert_verb_routes(verb);
+    }
+    let api = api_recorder();
+    let profile = endpointless_valid_case();
+    let dir = tempdir();
+    let path = write_profile(dir.path(), &profile);
+    let file = path.to_str().unwrap().to_string();
+    let address = profile["address"]["example"].as_str().unwrap().to_string();
+
+    let invocations: Vec<Vec<String>> = vec![
+        vec![
+            "adapter".into(),
+            "bind".into(),
+            "-f".into(),
+            file.clone(),
+            "demo".into(),
+            "--address".into(),
+            address.clone(),
+            "--adapter-slug".into(),
+            "operator-owned".into(),
+            "--yes".into(),
+            "--api-url".into(),
+            api.base_url.clone(),
+        ],
+        vec![
+            "adapter".into(),
+            "smoke-test".into(),
+            "-f".into(),
+            file.clone(),
+            "--address".into(),
+            address.clone(),
+            "--yes".into(),
+            "--api-url".into(),
+            api.base_url.clone(),
+        ],
+    ];
+
+    for argv in invocations {
+        let borrowed: Vec<&str> = argv.iter().map(String::as_str).collect();
+        let output = run(&borrowed);
+        assert_eq!(
+            code(&output),
+            2,
+            "{:?} must be a usage error with no route\n{}",
+            argv,
+            text(&output)
+        );
+        let message = text(&output);
+        assert!(
+            message.contains("endpoint"),
+            "the message must name the missing field\n{message}"
+        );
+        assert!(
+            message.contains("--endpoint"),
+            "the message must name the flag that supplies it\n{message}"
+        );
+    }
+
+    assert!(
+        api.recorded().is_empty(),
+        "no request may be built against a route that does not exist; saw {:?}",
+        bodies(&api)
+    );
+}
+
+/// The false positive control: the named flag really does supply the route, so
+/// the refusal above is a missing input and not a rejection of the profile.
+#[test]
+fn an_explicit_endpoint_override_supplies_the_missing_route_on_bind() {
+    let api = api_recorder();
+    let profile = endpointless_valid_case();
+    let dir = tempdir();
+    let path = write_profile(dir.path(), &profile);
+    let address = profile["address"]["example"].as_str().unwrap().to_string();
+
+    run(&[
+        "adapter",
+        "bind",
+        "-f",
+        path.to_str().unwrap(),
+        "demo",
+        "--address",
+        &address,
+        "--adapter-slug",
+        "operator-owned",
+        "--endpoint",
+        "https://override.example.test/curie/reply",
+        "--yes",
+        "--api-url",
+        &api.base_url,
+    ]);
+
+    let body = recorded_body(&api, "PATCH", "/agents/");
+    assert_eq!(
+        body["channel"]["endpoint"],
+        serde_json::json!("https://override.example.test/curie/reply"),
+        "body: {body}"
+    );
+}
+
+// ─── The egress secret is operator supplied at the invocation boundary ───────
+
+/// `credentials.egress_secret_env` documents what the ADAPTER reads. It is never
+/// an instruction to this CLI, because a profile that could name a variable could
+/// name `AWS_SECRET_ACCESS_KEY` and have the platform POST it to the host that
+/// same file names. The only accepted sources are a file and stdin, and there is
+/// no flag through which a name could be passed either.
+#[test]
+fn smoke_test_takes_its_secret_only_from_an_operator_supplied_source() {
+    let flags = help_flags(&["adapter", "smoke-test"]);
+    for flag in ["--secret-file", "--secret-stdin", "--yes"] {
+        assert!(
+            flags.contains(flag),
+            "`adapter smoke-test` must declare {flag}; saw {flags:?}"
+        );
+    }
+    for forbidden in ["--secret-env", "--secret", "--secret-name"] {
+        assert!(
+            !flags.contains(forbidden),
+            "`adapter smoke-test` must expose no flag naming an environment \
+             variable or carrying a secret value: {forbidden}; saw {flags:?}"
+        );
+    }
+}
+
+/// The boundary itself, asserted behaviorally: with the variable the profile
+/// names exported and holding a sentinel, and no explicit source given, the
+/// command refuses and the sentinel reaches neither the endpoint, the API, nor
+/// the operator's terminal.
+#[test]
+fn smoke_test_never_reads_the_variable_the_profile_names() {
+    assert_verb_routes("smoke-test");
+    let api = api_recorder();
+    let endpoint = endpoint_recorder();
+    let sentinel = "SENTINEL-PROFILE-NAMED-VALUE-1516";
+
+    let mut profile = routed_valid_case();
+    profile["endpoint"] = serde_json::json!(endpoint.base_url);
+    let named_variable = profile["credentials"]["egress_secret_env"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let dir = tempdir();
+    let path = write_profile(dir.path(), &profile);
+    let address = profile["address"]["example"].as_str().unwrap().to_string();
+
+    let output = run_with_env(
+        &[
+            "adapter",
+            "smoke-test",
+            "-f",
+            path.to_str().unwrap(),
+            "--address",
+            &address,
+            "--allow-insecure",
+            "--yes",
+            "--api-url",
+            &api.base_url,
+        ],
+        &[(named_variable.as_str(), sentinel)],
+    );
+
+    assert_eq!(
+        code(&output),
+        2,
+        "an explicit secret source is required\n{}",
+        text(&output)
+    );
+    for raw in bodies(&endpoint).into_iter().chain(bodies(&api)) {
+        assert!(
+            !raw.contains(sentinel),
+            "a profile named variable must never be resolved and sent: {raw}"
+        );
+    }
+    assert!(
+        !text(&output).contains(sentinel),
+        "a profile named variable must never be read back to the operator"
+    );
+}
+
+// ─── `token` is the single deliberate secret carrying payload ────────────────
+
+/// `token` returns a bearer credential, so its payload carries the value under an
+/// explicit `token` field plus `"secret": true`. The value goes to stdout and
+/// nowhere else, so a caller can pipe stdout while keeping stderr in a log.
+#[test]
+fn token_writes_the_token_to_stdout_and_to_no_diagnostic_stream() {
+    let api = api_recorder();
+    let profile = routed_valid_case();
+    let dir = tempdir();
+    let path = write_profile(dir.path(), &profile);
+    let address = profile["address"]["example"].as_str().unwrap().to_string();
+
+    let output = run(&[
+        "adapter",
+        "token",
+        "-f",
+        path.to_str().unwrap(),
+        "--address",
+        &address,
+        "--api-url",
+        &api.base_url,
+        "--json",
+    ]);
+    assert_eq!(code(&output), 0, "{}", text(&output));
+
+    let payload = stdout_json(&output);
+    assert_eq!(
+        payload["token"],
+        serde_json::json!("chn_test_token_value"),
+        "payload: {payload}"
+    );
+    assert_eq!(
+        payload["secret"],
+        serde_json::json!(true),
+        "the one payload that carries a secret must say so: {payload}"
+    );
+    assert!(
+        !String::from_utf8_lossy(&output.stderr).contains("chn_test_token_value"),
+        "the token must not reach stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // The API resolves on the PAIR, never the address alone, so both halves go up.
+    let body = recorded_body(&api, "POST", "/channels/token");
+    assert_eq!(body["kind"], profile["kind"], "body: {body}");
+    assert_eq!(body["address"], serde_json::json!(address), "body: {body}");
+}
+
+/// `ChannelTokenRequest.ttl_s` is `gt=0, le=604800`. A value the API refuses is a
+/// usage error here, so the operator reads a fix hint rather than a 422.
+#[test]
+fn token_refuses_a_ttl_the_api_would_reject() {
+    assert_verb_routes("token");
+    let api = api_recorder();
+    let profile = routed_valid_case();
+    let dir = tempdir();
+    let path = write_profile(dir.path(), &profile);
+    let address = profile["address"]["example"].as_str().unwrap().to_string();
+
+    for ttl in ["0", "604801"] {
+        let output = run(&[
+            "adapter",
+            "token",
+            "-f",
+            path.to_str().unwrap(),
+            "--address",
+            &address,
+            "--ttl-s",
+            ttl,
+            "--api-url",
+            &api.base_url,
+        ]);
+        assert_eq!(
+            code(&output),
+            2,
+            "--ttl-s {ttl} is outside the API's bounds\n{}",
+            text(&output)
+        );
+    }
+    assert!(
+        api.recorded().is_empty(),
+        "an out of bounds ttl must never reach the API; saw {:?}",
+        bodies(&api)
+    );
+}
+
+// ─── `scaffold` stays minimal ────────────────────────────────────────────────
+
+/// `scaffold` writes one profile and prints next steps. No project tree, no
+/// README: the file it writes has to be one the validator accepts, and the
+/// address it was given has to match the pattern it generated, or the first
+/// thing an author does after scaffolding is fix the scaffold's own output.
+#[test]
+fn scaffold_writes_exactly_one_file_the_validator_accepts() {
+    let dir = tempdir();
+    let output = run(&[
+        "adapter",
+        "scaffold",
+        "demo",
+        "--kind",
+        "email",
+        "--address",
+        "agent@example.test",
+        "--endpoint",
+        "https://h.example.test/curie",
+        "--adapter",
+        "demo-egress",
+        "--dir",
+        dir.path().to_str().unwrap(),
+    ]);
+    assert_eq!(code(&output), 0, "{}", text(&output));
+
+    let mut written = Vec::new();
+    let mut stack = vec![dir.path().to_path_buf()];
+    while let Some(next) = stack.pop() {
+        for entry in std::fs::read_dir(&next).expect("read scaffold dir") {
+            let path = entry.expect("dir entry").path();
+            if path.is_dir() {
+                stack.push(path);
+            } else {
+                written.push(
+                    path.strip_prefix(dir.path())
+                        .expect("under the scaffold dir")
+                        .to_string_lossy()
+                        .into_owned(),
+                );
+            }
+        }
+    }
+    written.sort();
+    assert_eq!(
+        written,
+        vec!["demo/adapter.yaml".to_string()],
+        "scaffold writes the profile and nothing else"
+    );
+
+    let profile = dir.path().join("demo/adapter.yaml");
+    let validated = run(&[
+        "adapter",
+        "validate",
+        "-f",
+        profile.to_str().unwrap(),
+        "--address",
+        "agent@example.test",
+        "--json",
+    ]);
+    assert_eq!(
+        code(&validated),
+        0,
+        "the scaffolded profile must accept the address it was scaffolded for\n{}",
+        text(&validated)
+    );
+    assert_eq!(stdout_json(&validated)["ok"], serde_json::json!(true));
+}

--- a/cli/tests/adapter_manifest.rs
+++ b/cli/tests/adapter_manifest.rs
@@ -1841,13 +1841,31 @@ const CHANNELS_ROUTER: &str = include_str!("../../apps/api/src/curie_api/routers
 /// `TurnIn` inherits and that FastAPI DOES publish.
 const API_OPENAPI: &str = include_str!("../../apps/api/openapi.json");
 
-/// `(base class name, own required fields)` for a Pydantic model, read out of
-/// the router source.
+/// The fields this gate is known to depend on, as a LIVENESS FLOOR on the parse.
 ///
-/// A required field is an annotated attribute with no `=`: a default of any kind
-/// makes it optional, and `model_config` is an assignment rather than an
-/// annotation, so neither reaches the set.
-fn pydantic_model(source: &str, name: &str) -> (String, std::collections::BTreeSet<String>) {
+/// This is deliberately not the contract: the parsed set is, and a field added
+/// to `TurnIn` tomorrow tightens the pin with no edit here. What this catches is
+/// the parse going quiet. A source scan that stops matching returns a smaller
+/// set and every assertion built on it turns vacuous, which is worse than no pin
+/// at all, because it still reads as coverage. If `TurnIn` legitimately drops
+/// one of these, this list is supposed to red so a human looks at a contract
+/// change rather than a silently narrowed gate.
+const TURN_IN_FLOOR: [&str; 7] = [
+    "address",
+    "author",
+    "conversation_id",
+    "delivery_id",
+    "kind",
+    "reply_ref",
+    "text",
+];
+
+/// One Pydantic class's body, as `(base class, lines with the docstring cut)`.
+///
+/// Panics rather than returning empty at every step: a missing class, a missing
+/// header or an unterminated docstring are all "the source moved and this parse
+/// no longer knows what it is reading", and each has to be a loud failure.
+fn class_body<'a>(source: &'a str, name: &str) -> (String, Vec<&'a str>) {
     let header = format!("\nclass {name}(");
     let start = source
         .find(&header)
@@ -1860,16 +1878,62 @@ fn pydantic_model(source: &str, name: &str) -> (String, std::collections::BTreeS
         .expect("a base list names a class")
         .trim()
         .to_string();
+
     let body_start = rest.find('\n').expect("a class header ends") + 1;
     let body = &rest[body_start..];
     let end = body.find("\nclass ").unwrap_or(body.len());
+    let mut lines: Vec<&str> = body[..end].lines().collect();
 
-    let mut required = std::collections::BTreeSet::new();
-    for line in body[..end].lines() {
-        let Some(declaration) = line.strip_prefix("    ") else {
-            continue;
+    // Cut a leading docstring, so its prose cannot be read as a field. Every
+    // model in this router carries one, so its ABSENCE means the block being
+    // read is not the block this parse was written for.
+    let opener = lines
+        .iter()
+        .position(|line| !line.trim().is_empty())
+        .unwrap_or_else(|| panic!("{name} has a body"));
+    assert!(
+        lines[opener].trim_start().starts_with("\"\"\""),
+        "{name}'s body no longer opens with a docstring, so this parse is reading \
+         something other than the model it was written for: {:?}",
+        lines[opener]
+    );
+    let single_line = lines[opener].trim().len() > 6 && lines[opener].trim().ends_with("\"\"\"");
+    let close = if single_line {
+        opener
+    } else {
+        opener
+            + 1
+            + lines[opener + 1..]
+                .iter()
+                .position(|line| line.trim_end().ends_with("\"\"\""))
+                .unwrap_or_else(|| panic!("{name}'s docstring is unterminated"))
+    };
+    lines.drain(..=close);
+    (base, lines)
+}
+
+/// Annotated attributes in a class body, at EXACTLY four spaces of indentation
+/// when `strict`, at any indentation otherwise.
+///
+/// A required field is an annotated attribute with no `=`: a default of any kind
+/// makes it optional, and `model_config` is an assignment rather than an
+/// annotation, so neither reaches the set.
+fn annotated_fields(lines: &[&str], strict: bool) -> std::collections::BTreeSet<String> {
+    let mut found = std::collections::BTreeSet::new();
+    for line in lines {
+        let declaration = if strict {
+            match line.strip_prefix("    ") {
+                Some(rest) if !rest.starts_with(' ') => rest,
+                _ => continue,
+            }
+        } else {
+            let trimmed = line.trim_start();
+            if trimmed.len() == line.len() {
+                continue; // a top level statement is not a class attribute
+            }
+            trimmed
         };
-        if declaration.starts_with(' ') || declaration.starts_with('#') {
+        if declaration.starts_with('#') {
             continue;
         }
         let Some((field, annotation)) = declaration.split_once(": ") else {
@@ -1878,19 +1942,49 @@ fn pydantic_model(source: &str, name: &str) -> (String, std::collections::BTreeS
         if annotation.contains('=') || !field.chars().all(|c| c.is_ascii_lowercase() || c == '_') {
             continue;
         }
-        required.insert(field.to_string());
+        found.insert(field.to_string());
     }
+    found
+}
+
+/// `(base class name, own required fields)` for a Pydantic model, read out of
+/// the router source and CROSS CHECKED against itself.
+///
+/// The cross check is the whole point. A scan keyed on `    ` degrades silently
+/// the moment the file is reformatted, reindented or wrapped differently: it
+/// matches nothing, returns an empty set, and every assertion downstream passes
+/// while pinning nothing. So the same body is scanned twice, once keyed on that
+/// exact indentation and once indentation blind, and the two must agree. A
+/// reindent moves one and not the other, and the disagreement is the failure.
+fn pydantic_model(source: &str, name: &str) -> (String, std::collections::BTreeSet<String>) {
+    let (base, lines) = class_body(source, name);
+    let strict = annotated_fields(&lines, true);
+    let permissive = annotated_fields(&lines, false);
+
+    assert_eq!(
+        strict, permissive,
+        "the strict and permissive scans disagree on {name}'s fields, which means \
+         the source was reindented or rewrapped under this parse. Fix the parse; \
+         do NOT let it return the smaller set, because a pin that matches nothing \
+         still reads as coverage"
+    );
     assert!(
-        !required.is_empty(),
+        !strict.is_empty(),
         "{name} parsed to no required fields, so this gate would pass on an empty body"
     );
-    (base, required)
+    (base, strict)
 }
 
 /// Every field `TurnIn` requires: its own, read from the model source, plus the
 /// ones it inherits, read from the committed OpenAPI export.
 fn turn_in_required_fields() -> std::collections::BTreeSet<String> {
-    let (base, mut required) = pydantic_model(CHANNELS_ROUTER, "TurnIn");
+    turn_in_required_fields_from(CHANNELS_ROUTER)
+}
+
+/// The same read, against a caller supplied copy of the router source, so the
+/// drift tests can feed it a reformatted one without touching `apps/`.
+fn turn_in_required_fields_from(source: &str) -> std::collections::BTreeSet<String> {
+    let (base, mut required) = pydantic_model(source, "TurnIn");
     let openapi: serde_json::Value =
         serde_json::from_str(API_OPENAPI).expect("apps/api/openapi.json is valid JSON");
     let inherited = openapi["components"]["schemas"][&base]["required"]
@@ -1903,7 +1997,89 @@ fn turn_in_required_fields() -> std::collections::BTreeSet<String> {
             .iter()
             .filter_map(|v| v.as_str().map(str::to_string)),
     );
+
+    for field in TURN_IN_FLOOR {
+        assert!(
+            required.contains(field),
+            "the parse lost {field:?}. Either the authority genuinely dropped it, \
+             which is a contract change to look at, or this parse stopped seeing \
+             the model. Parsed {required:?}"
+        );
+    }
     required
+}
+
+// ─── The pin fails loudly when the source it reads moves ────────────────────
+
+/// The positive control for the three drift tests below: against the real
+/// source, the parse yields a plausible set and finds the field the whole gate
+/// turns on. Without this, a `should_panic` test proves only that SOMETHING
+/// panicked.
+#[test]
+fn the_turn_in_parse_reads_a_plausible_field_set_from_the_real_source() {
+    let required = turn_in_required_fields();
+    assert!(
+        required.contains("reply_ref"),
+        "the parse must see the field the live 422 named; parsed {required:?}"
+    );
+    assert!(
+        required.len() >= TURN_IN_FLOOR.len(),
+        "the parse must see at least the floor; parsed {required:?}"
+    );
+    // The base half comes from the committed OpenAPI export, the own half from
+    // the model source. Both must have contributed, or one seam is dead.
+    let (_, own) = pydantic_model(CHANNELS_ROUTER, "TurnIn");
+    assert!(
+        !own.contains("kind") && required.contains("kind"),
+        "`kind` is inherited, so it can only have come from the OpenAPI export; \
+         own {own:?}, combined {required:?}"
+    );
+}
+
+/// Reindenting the model body must be a LOUD failure, not a quiet empty parse.
+/// This is the exact degradation a `strip_prefix("    ")` scan hides: after a
+/// reformat it matches nothing and every assertion built on it turns vacuous.
+///
+/// Simulated against an in memory copy of the real source, because `apps/` is
+/// not this crate's to edit.
+#[test]
+#[should_panic(expected = "the strict and permissive scans disagree")]
+fn a_reindented_model_body_fails_the_parse_instead_of_emptying_it() {
+    let reindented = CHANNELS_ROUTER.replace("\n    ", "\n      ");
+    let _ = turn_in_required_fields_from(&reindented);
+}
+
+/// The same, for a tab reindent, which `strip_prefix("    ")` also misses.
+#[test]
+#[should_panic(expected = "the strict and permissive scans disagree")]
+fn a_tab_indented_model_body_fails_the_parse_instead_of_emptying_it() {
+    let tabbed = CHANNELS_ROUTER.replace("\n    ", "\n\t");
+    let _ = turn_in_required_fields_from(&tabbed);
+}
+
+/// The discriminating case, and the one a non empty check cannot reach: ONE
+/// field rewrapped deeper. The strict scan then returns four of the five fields,
+/// which is non empty and looks entirely healthy, while `reply_ref` (the field
+/// this whole gate exists for) has quietly fallen out of the pin. Only the
+/// cross check sees it.
+#[test]
+#[should_panic(expected = "the strict and permissive scans disagree")]
+fn a_single_rewrapped_field_fails_the_parse_rather_than_dropping_out_of_it() {
+    let rewrapped = CHANNELS_ROUTER.replace("\n    reply_ref: str", "\n        reply_ref: str");
+    assert_ne!(
+        rewrapped, CHANNELS_ROUTER,
+        "the drift simulation must actually change the source, or this proves nothing"
+    );
+    let _ = turn_in_required_fields_from(&rewrapped);
+}
+
+/// A renamed or moved model must be a loud failure too, rather than a parse that
+/// silently reads whatever class happens to sit at that offset.
+#[test]
+#[should_panic(expected = "TurnIn is defined in the router source")]
+fn a_renamed_model_fails_the_parse() {
+    let renamed = CHANNELS_ROUTER.replace("\nclass TurnIn(", "\nclass TurnInV2(");
+    let _ = turn_in_required_fields_from(&renamed);
 }
 
 /// A platform API stand-in that also answers the turn ingress, reporting the

--- a/cli/tests/adapter_manifest.rs
+++ b/cli/tests/adapter_manifest.rs
@@ -46,6 +46,7 @@ use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
 
+use curie::adapter::{ADAPTER_SECRET_HEADER, MAX_ACK_BODY_BYTES};
 use support::{serve, MockServer, Request, Response};
 
 // ─── Fixtures ────────────────────────────────────────────────────────────────
@@ -258,6 +259,91 @@ fn tempdir() -> tempfile::TempDir {
     tempfile::tempdir().expect("tempdir")
 }
 
+/// The egress secret the smoke-test probes are given. Distinctive enough that a
+/// negative probe DERIVED from it (the real value plus a suffix) is detectable
+/// by substring, which is the whole assertion.
+const REAL_EGRESS_SECRET: &str = "operator-real-egress-secret-1516";
+
+/// Drive `adapter smoke-test` against a loopback endpoint and API, and hand back
+/// its `--json` payload. The verb exits non-zero whenever a check fails, so the
+/// code is deliberately not asserted here: the payload is the evidence, and it
+/// is emitted before the exit code is applied.
+fn smoke_test_payload(api: &MockServer, endpoint: &MockServer, secret: &str) -> serde_json::Value {
+    let dir = tempdir();
+    let mut profile = routed_valid_case();
+    profile["endpoint"] = serde_json::json!(endpoint.base_url.clone());
+    let path = write_profile(dir.path(), &profile);
+    let address = profile["address"]["example"].as_str().unwrap().to_string();
+    let secret_file = dir.path().join("egress.secret");
+    std::fs::write(&secret_file, secret).expect("write the egress secret");
+
+    let output = run(&[
+        "adapter",
+        "smoke-test",
+        "-f",
+        path.to_str().unwrap(),
+        "--address",
+        &address,
+        "--secret-file",
+        secret_file.to_str().unwrap(),
+        // The recorders are loopback http, and refusing cleartext is a
+        // separate, already covered rule.
+        "--allow-insecure",
+        "--yes",
+        "--api-url",
+        &api.base_url,
+        "--json",
+    ]);
+    stdout_json(&output)
+}
+
+/// Every value that reached the endpoint under the egress secret header, in
+/// order. This is the wire, not a log line, so a derived probe cannot hide.
+fn secrets_sent(server: &MockServer) -> Vec<String> {
+    server
+        .recorded()
+        .iter()
+        .filter_map(|req| req.header(ADAPTER_SECRET_HEADER).map(str::to_string))
+        .collect()
+}
+
+/// A syntactically valid JSON acknowledgement of EXACTLY `total` bytes, so the
+/// cap tests turn on size alone and never on a parse failure.
+fn json_body_of(total: usize) -> Response {
+    const OPEN: &str = "{\"pad\":\"";
+    const CLOSE: &str = "\"}";
+    let body = format!(
+        "{OPEN}{}{CLOSE}",
+        "a".repeat(total - OPEN.len() - CLOSE.len())
+    );
+    assert_eq!(
+        body.len(),
+        total,
+        "the fixture must be exactly {total} bytes"
+    );
+    Response {
+        status: 200,
+        content_type: "application/json".into(),
+        body: body.into_bytes(),
+    }
+}
+
+/// The scheme, host and port of a URL, computed with plain string operations.
+///
+/// Deliberately NOT `reqwest::Url`, which is the crate the implementation
+/// redacts with: an expectation computed by the code under test is the code
+/// under test agreeing with itself.
+fn origin_of(url: &str) -> String {
+    let (scheme, rest) = url
+        .split_once("://")
+        .unwrap_or_else(|| panic!("an endpoint carries a scheme: {url}"));
+    let authority = rest
+        .split(['/', '?', '#'])
+        .next()
+        .expect("a URL carries an authority");
+    format!("{scheme}://{authority}")
+}
+
 // ─── The corpus is the drift gate between the two validators ─────────────────
 
 /// Every valid corpus profile parses in Rust AND its parsed values come back out.
@@ -268,12 +354,18 @@ fn tempdir() -> tempfile::TempDir {
 /// what kills an implementation that hardcodes or drops one: a constant cannot
 /// satisfy `email` and `ms_teams` and `webhook` at once.
 ///
+/// `endpoint` is the one field compared in REDUCED form, because a profile route
+/// can carry a token in its path or query and this payload reaches CI artifacts
+/// and log aggregators. Its scheme, host and port still come from the corpus, so
+/// a constant returning implementation dies here just the same.
+///
 /// Mutation to run against the implementation: replace the parsed
-/// `credentials.egress` with a literal, or drop `endpoint` from the payload.
-/// Both must red here.
+/// `credentials.egress` with a literal, drop `endpoint` from the payload, or
+/// emit the endpoint whole. All three must red here.
 #[test]
 fn rust_accepts_every_valid_corpus_profile() {
     let cases = valid_cases();
+    let mut redactions_proven = 0usize;
     assert!(
         cases.len() >= 2,
         "value parity needs at least two differing valid cases"
@@ -352,14 +444,41 @@ fn rust_accepts_every_valid_corpus_profile() {
             parsed["conformance"]["mints_reply_ref"], case["conformance"]["mints_reply_ref"],
             "payload: {payload}"
         );
-        // Absent in the file must read back as JSON null, never a missing key,
-        // so a consumer can branch on it unconditionally.
-        let expected_endpoint = case
-            .get("endpoint")
-            .cloned()
-            .unwrap_or(serde_json::Value::Null);
-        assert_eq!(parsed["endpoint"], expected_endpoint, "payload: {payload}");
+        // The endpoint is the one parsed field the payload REDUCES rather than
+        // carries: a profile route can hold a token in its path or query, and
+        // `--json` is the form that reaches CI artifacts and log aggregators.
+        // Absent in the file must still read back as JSON null, never a missing
+        // key, so a consumer can branch on it unconditionally.
+        match case.get("endpoint").and_then(|e| e.as_str()) {
+            Some(raw) => {
+                let origin = origin_of(raw);
+                assert_eq!(
+                    parsed["endpoint"],
+                    serde_json::json!(origin),
+                    "payload: {payload}"
+                );
+                let tail = &raw[origin.len()..];
+                if !tail.is_empty() {
+                    redactions_proven += 1;
+                    assert!(
+                        !payload.to_string().contains(tail),
+                        "no part of the endpoint's path or query may appear anywhere in \
+                         the payload; {tail:?} did: {payload}"
+                    );
+                }
+            }
+            None => assert!(
+                parsed["endpoint"].is_null(),
+                "an absent endpoint reads back as null: {payload}"
+            ),
+        }
     }
+
+    assert!(
+        redactions_proven > 0,
+        "the corpus must carry at least one endpoint with a path or query, or the \
+         redaction assertion above cannot tell a reduction from a passthrough"
+    );
 }
 
 /// Every invalid corpus case is refused by the verb, whatever its tier. This is
@@ -1132,6 +1251,209 @@ fn token_refuses_a_ttl_the_api_would_reject() {
         api.recorded().is_empty(),
         "an out of bounds ttl must never reach the API; saw {:?}",
         bodies(&api)
+    );
+}
+
+// ─── The reported endpoint is reduced, the written one is whole ──────────────
+
+/// `bind --json` is the form most likely to be redirected into a CI artifact, a
+/// ticket or a log aggregator, and an endpoint can carry a token in its path or
+/// query. The payload therefore reports scheme, host and port only, while the
+/// route WRITTEN to the API stays whole, because that is the route the worker
+/// has to POST to.
+///
+/// Mutation to run against the implementation: report `binding.endpoint`
+/// unreduced. The stdout half must red while the wire half stays green.
+#[test]
+fn bind_reports_a_reduced_endpoint_while_writing_the_whole_route() {
+    let api = api_recorder();
+    let mut profile = routed_valid_case();
+    let route = "https://adapter.example.test/curie/reply?ingress_token=s3cr3t-in-the-query";
+    profile["endpoint"] = serde_json::json!(route);
+
+    let dir = tempdir();
+    let path = write_profile(dir.path(), &profile);
+    let address = profile["address"]["example"].as_str().unwrap().to_string();
+
+    let output = run(&[
+        "adapter",
+        "bind",
+        "-f",
+        path.to_str().unwrap(),
+        "demo",
+        "--address",
+        &address,
+        "--adapter-slug",
+        "operator-owned",
+        "--yes",
+        "--api-url",
+        &api.base_url,
+        "--json",
+    ]);
+    assert_eq!(code(&output), 0, "{}", text(&output));
+
+    let payload = stdout_json(&output);
+    assert_eq!(
+        payload["endpoint"],
+        serde_json::json!(origin_of(route)),
+        "payload: {payload}"
+    );
+    let whole = text(&output);
+    for leaked in ["ingress_token", "s3cr3t-in-the-query", "/curie/reply"] {
+        assert!(
+            !whole.contains(leaked),
+            "no part of the endpoint's path or query may reach stdout or stderr; \
+             {leaked:?} did:\n{whole}"
+        );
+    }
+
+    // The false positive control: the reduction is a reporting decision, not a
+    // truncation of the route itself.
+    let body = recorded_body(&api, "PATCH", "/agents/");
+    assert_eq!(
+        body["channel"]["endpoint"],
+        serde_json::json!(route),
+        "the whole route must still be written: {body}"
+    );
+}
+
+// ─── The negative probe carries a constant, never the real secret ────────────
+
+/// An adapter's rejected-auth path is one of the likeliest places for a
+/// credential to be written to disk in plaintext ("rejected secret X"), and the
+/// adapter is third party infrastructure whose logs the operator does not
+/// control. The wrong secret the negative probe sends must therefore be a fixed
+/// constant, never the operator's real one with something appended.
+///
+/// Mutation to run against the implementation: build the wrong secret as
+/// `format!("{secret}-not-the-secret")`. The containment assertion must red
+/// while the refusal assertion stays green, which is the whole point: a derived
+/// value proves the same thing and leaks while doing it.
+#[test]
+fn the_negative_probe_sends_a_constant_that_does_not_carry_the_real_secret() {
+    assert_verb_routes("smoke-test");
+    let api = api_recorder();
+    let endpoint = serve(|req: &Request| {
+        if req.header(ADAPTER_SECRET_HEADER) == Some(REAL_EGRESS_SECRET) {
+            Response::json(200, r#"{"ok":true}"#)
+        } else {
+            Response::json(401, r#"{"detail":"rejected"}"#)
+        }
+    });
+
+    let payload = smoke_test_payload(&api, &endpoint, REAL_EGRESS_SECRET);
+
+    assert_eq!(
+        payload["egress_positive"]["ok"],
+        serde_json::json!(true),
+        "the endpoint accepts the real secret, so the positive probe must pass: {payload}"
+    );
+    assert_eq!(
+        payload["egress_negative"]["ok"],
+        serde_json::json!(true),
+        "a wrong secret must still be PROVEN refused: {payload}"
+    );
+    assert_eq!(
+        payload["egress_negative"]["status"],
+        serde_json::json!(401),
+        "the refusal must be the endpoint's, read off its answer: {payload}"
+    );
+
+    let sent = secrets_sent(&endpoint);
+    assert_eq!(
+        sent.len(),
+        2,
+        "the egress probes are one positive and one negative; saw {sent:?}"
+    );
+    assert_eq!(
+        sent.iter().filter(|s| *s == REAL_EGRESS_SECRET).count(),
+        1,
+        "exactly one probe may carry the real secret; saw {sent:?}"
+    );
+    for value in &sent {
+        assert!(
+            value == REAL_EGRESS_SECRET || !value.contains(REAL_EGRESS_SECRET),
+            "the wrong secret must not be derived from the real one, or a rejected \
+             auth log line at the adapter hands the real value back for the cost of \
+             stripping a suffix: {value:?}"
+        );
+    }
+}
+
+/// The false positive control for the test above: the negative check is a real
+/// check, so an endpoint that accepts ANY secret fails it. Without this, the
+/// refusal assertion would green against a probe that never happened.
+#[test]
+fn an_endpoint_that_accepts_any_secret_fails_the_negative_check() {
+    let api = api_recorder();
+    let endpoint = endpoint_recorder();
+
+    let payload = smoke_test_payload(&api, &endpoint, REAL_EGRESS_SECRET);
+
+    assert_eq!(
+        payload["egress_negative"]["ok"],
+        serde_json::json!(false),
+        "an endpoint answering 2xx to a wrong secret is not authenticating the \
+         platform at all: {payload}"
+    );
+    assert_eq!(
+        payload["verdict"],
+        serde_json::json!("fail"),
+        "a failed check must fail the verdict: {payload}"
+    );
+}
+
+// ─── The acknowledgement body is read under a cap ────────────────────────────
+
+/// The adapter under test is untrusted, so its answer is read with a running
+/// total and refused once it passes the cap. Reading it whole and measuring
+/// afterwards enforces nothing: the memory is already allocated by then, and a
+/// multi gigabyte chunked answer is an OOM of the operator's shell.
+///
+/// Oversize is a FAILURE and never a truncation, because judging the first N
+/// bytes of a body that was never sent whole hands the parser a value nobody
+/// produced. Asserted at the check verdict, which is the observable this test
+/// can hold; the streaming itself is pinned by the boundary control below.
+#[test]
+fn an_oversize_acknowledgement_body_fails_the_egress_check() {
+    let api = api_recorder();
+    let endpoint = serve(|_req: &Request| json_body_of(MAX_ACK_BODY_BYTES + 1024));
+
+    let payload = smoke_test_payload(&api, &endpoint, REAL_EGRESS_SECRET);
+
+    assert_eq!(
+        payload["egress_positive"]["status"],
+        serde_json::json!(200),
+        "the endpoint answered 2xx, so the failure below is about SIZE: {payload}"
+    );
+    assert_eq!(
+        payload["egress_positive"]["ok"],
+        serde_json::json!(false),
+        "an oversize acknowledgement must be refused: {payload}"
+    );
+    let detail = payload["egress_positive"]["detail"]
+        .as_str()
+        .unwrap_or_default();
+    assert!(
+        detail.contains(&MAX_ACK_BODY_BYTES.to_string()),
+        "the detail must name the cap that was exceeded: {detail}"
+    );
+}
+
+/// The boundary control: a body of EXACTLY the cap still passes, so the refusal
+/// above is a real ceiling and not a blanket refusal of any body large enough to
+/// arrive in more than one chunk.
+#[test]
+fn an_acknowledgement_body_exactly_at_the_cap_still_passes() {
+    let api = api_recorder();
+    let endpoint = serve(|_req: &Request| json_body_of(MAX_ACK_BODY_BYTES));
+
+    let payload = smoke_test_payload(&api, &endpoint, REAL_EGRESS_SECRET);
+
+    assert_eq!(
+        payload["egress_positive"]["ok"],
+        serde_json::json!(true),
+        "the worker refuses a body OVER the cap, so exactly the cap passes: {payload}"
     );
 }
 

--- a/cli/tests/command_surface.rs
+++ b/cli/tests/command_surface.rs
@@ -112,6 +112,11 @@ fn process_help_routes_positive_forms() {
         &["cluster", "eval"],
         &["cluster", "deploy"],
         &["try"],
+        &["adapter", "scaffold"],
+        &["adapter", "validate"],
+        &["adapter", "bind"],
+        &["adapter", "token"],
+        &["adapter", "smoke-test"],
         &["init"],
         &["interactive"],
         &["secrets", "set"],
@@ -179,6 +184,7 @@ fn process_help_top_level_lists_new_surface_and_hides_retired_verbs() {
     let text = output_text(&output);
 
     for needle in [
+        "adapter",
         "skill",
         "local",
         "cluster",

--- a/cli/tests/json_contract.rs
+++ b/cli/tests/json_contract.rs
@@ -1974,7 +1974,7 @@ fn the_validate_payload_carries_the_parsed_profile() {
                 "egress_secret_env": "CURIE_EGRESS_SECRET",
                 "ingress_token_env": "CURIE_INGRESS_TOKEN",
             },
-            "conformance": {"wire_version": "1.0", "mints_reply_ref": true},
+            "conformance": {"wire_version": "1.0"},
         },
     });
     assert!(
@@ -2006,6 +2006,23 @@ fn the_validate_payload_carries_the_parsed_profile() {
         "an empty profile object must be rejected, or the parity comparison has \
          nothing to compare"
     );
+}
+
+/// `mints_reply_ref` left the profile contract: it was a fifth field with no
+/// consumer anywhere, `required` in a closed schema, so it was removed while
+/// removal was still free. Asserted across the whole adapter output surface
+/// rather than on the one schema that carried it, because a closed schema that
+/// re-declares it would make every profile written against the current contract
+/// invalid.
+#[test]
+fn no_adapter_payload_declares_the_retired_mints_reply_ref_field() {
+    for name in ADAPTER_SCHEMAS {
+        let declared = declared_property_names(&load_schema(name));
+        assert!(
+            !declared.contains("mints_reply_ref"),
+            "{name} still declares `mints_reply_ref`; declared {declared:?}"
+        );
+    }
 }
 
 /// The API refuses a non `slack` binding whose reply route is half set, so the

--- a/cli/tests/json_contract.rs
+++ b/cli/tests/json_contract.rs
@@ -1814,3 +1814,250 @@ fn a_new_family_schema_gate_has_teeth() {
         "kill schema must reject a Done object missing the required `killed` key"
     );
 }
+
+// ─── `curie adapter` result schemas (#1516) ──────────────────────────────────
+//
+// The five verbs' `--json` payloads are the agent-facing contract, and under
+// ADR-0101 as amended by ADR-0103 a property added later at an unchanged `$id`
+// is a red build. These gates lock the shapes that carry a decision: which
+// payload is allowed to hold a secret value, that a validated profile comes back
+// with its parsed fields rather than a bare verdict, that a bind reports the
+// whole four field route it wrote, and that the smoke-test verdict is machine
+// readable and never claims more than it checked.
+
+/// Every property name the schema declares, at any depth.
+fn declared_property_names(schema: &serde_json::Value) -> BTreeSet<String> {
+    let mut found = BTreeSet::new();
+    let mut stack = vec![schema];
+    while let Some(node) = stack.pop() {
+        match node {
+            serde_json::Value::Object(map) => {
+                for (key, value) in map {
+                    if key == "properties" {
+                        if let Some(props) = value.as_object() {
+                            found.extend(props.keys().cloned());
+                        }
+                    }
+                    stack.push(value);
+                }
+            }
+            serde_json::Value::Array(items) => stack.extend(items.iter()),
+            _ => {}
+        }
+    }
+    found
+}
+
+fn required_names(schema: &serde_json::Value) -> BTreeSet<String> {
+    schema["required"]
+        .as_array()
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|v| v.as_str().map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+const ADAPTER_SCHEMAS: [&str; 5] = [
+    "adapter-scaffold.schema.json",
+    "adapter-validate.schema.json",
+    "adapter-bind.schema.json",
+    "adapter-token.schema.json",
+    "adapter-smoke-test.schema.json",
+];
+
+/// The five schemas are committed, compile, are closed, and discriminate. An
+/// empty object satisfying one of them would mean the gate is decorative.
+#[test]
+fn adapter_result_schemas_are_committed_closed_and_discriminating() {
+    for name in ADAPTER_SCHEMAS {
+        let schema = load_schema(name);
+        assert_eq!(
+            schema["additionalProperties"],
+            serde_json::json!(false),
+            "{name} must be closed"
+        );
+        assert!(
+            !required_names(&schema).is_empty(),
+            "{name} must require something"
+        );
+        let v = validator(&schema);
+        assert!(
+            !v.is_valid(&serde_json::json!({})),
+            "{name} must reject an empty object, or it gates nothing"
+        );
+    }
+}
+
+/// `adapter token` returns a bearer credential, so it is the single deliberate
+/// exception to the no-secrets-in-a-payload rule, and it declares itself as one.
+#[test]
+fn the_token_payload_is_the_one_that_declares_a_secret() {
+    let schema = load_schema("adapter-token.schema.json");
+    let required = required_names(&schema);
+    assert!(
+        required.contains("token") && required.contains("secret"),
+        "adapter-token must require both `token` and `secret`; required {required:?}"
+    );
+
+    let v = validator(&schema);
+    let payload = serde_json::json!({
+        "token": "chn_example",
+        "secret": true,
+        "kind": "email",
+        "address": "agent@example.test",
+        "ttl_s": 3600,
+    });
+    assert!(
+        v.is_valid(&payload),
+        "adapter-token must accept a token payload marked secret: {payload}"
+    );
+
+    let mut unmarked = payload.clone();
+    unmarked["secret"] = serde_json::json!(false);
+    assert!(
+        !v.is_valid(&unmarked),
+        "the secret marker must be pinned true, not merely present, or a consumer \
+         cannot branch on it"
+    );
+}
+
+/// The other four payloads carry credential IDENTITIES (`*_env` names and the
+/// adapter slug) and never a credential VALUE. Asserted as a shape rule on the
+/// committed contract rather than on one sampled payload, so a later property
+/// addition cannot open the hole.
+#[test]
+fn no_other_adapter_payload_declares_a_secret_value() {
+    for name in ADAPTER_SCHEMAS {
+        if name == "adapter-token.schema.json" {
+            continue;
+        }
+        let declared = declared_property_names(&load_schema(name));
+        for forbidden in ["token", "secret", "password", "credential", "api_key"] {
+            assert!(
+                !declared.contains(forbidden),
+                "{name} must declare no `{forbidden}` property; declared {declared:?}"
+            );
+        }
+    }
+}
+
+/// `validate` reports the profile it parsed, not just a verdict: the parsed
+/// values are what `cli/tests/adapter_manifest.rs` compares against the shared
+/// corpus, which is the only thing standing between a real parse and a constant.
+#[test]
+fn the_validate_payload_carries_the_parsed_profile() {
+    let schema = load_schema("adapter-validate.schema.json");
+    let required = required_names(&schema);
+    assert!(
+        required.contains("ok") && required.contains("profile"),
+        "adapter-validate must require `ok` and `profile`; required {required:?}"
+    );
+
+    let v = validator(&schema);
+    let mut payload = serde_json::json!({
+        "ok": true,
+        "file": "adapter.yaml",
+        "profile": {
+            "version": "1.0",
+            "kind": "email",
+            "endpoint": "https://mail.example.test/curie/reply",
+            "address": {
+                "description": "The mailbox this adapter owns.",
+                "pattern": "^[a-z]+@example\\.test$",
+                "example": "agent@example.test",
+            },
+            "credentials": {
+                "egress": "agentmail-sandbox",
+                "egress_secret_env": "CURIE_EGRESS_SECRET",
+                "ingress_token_env": "CURIE_INGRESS_TOKEN",
+            },
+            "conformance": {"wire_version": "1.0", "mints_reply_ref": true},
+        },
+    });
+    assert!(
+        v.is_valid(&payload),
+        "adapter-validate must accept a parsed profile: {payload}"
+    );
+
+    // `endpoint` is optional in the profile, so the payload reports it as an
+    // explicit null rather than dropping the key (#456: an agent consumer must
+    // be able to read it unconditionally).
+    payload["profile"]["endpoint"] = serde_json::Value::Null;
+    assert!(
+        v.is_valid(&payload),
+        "adapter-validate must accept a null endpoint: {payload}"
+    );
+
+    payload["profile"]
+        .as_object_mut()
+        .unwrap()
+        .remove("endpoint");
+    assert!(
+        !v.is_valid(&payload),
+        "a missing endpoint key must be rejected; absent is reported as null"
+    );
+
+    payload["profile"] = serde_json::json!({});
+    assert!(
+        !v.is_valid(&payload),
+        "an empty profile object must be rejected, or the parity comparison has \
+         nothing to compare"
+    );
+}
+
+/// The API refuses a non `slack` binding whose reply route is half set, so the
+/// payload reports the whole route that was written, `adapter` slug included.
+/// That slug is the operator's, never the profile's suggestion.
+#[test]
+fn the_bind_payload_reports_the_whole_route_it_wrote() {
+    let schema = load_schema("adapter-bind.schema.json");
+    let required = required_names(&schema);
+    for field in ["agent", "kind", "address", "endpoint", "adapter"] {
+        assert!(
+            required.contains(field),
+            "adapter-bind must require `{field}`; required {required:?}"
+        );
+    }
+
+    let v = validator(&schema);
+    let payload = serde_json::json!({
+        "agent": "demo",
+        "kind": "email",
+        "address": "agent@example.test",
+        "endpoint": "https://mail.example.test/curie/reply",
+        "adapter": "operator-owned",
+    });
+    assert!(v.is_valid(&payload), "adapter-bind must accept: {payload}");
+}
+
+/// The smoke-test verdict is machine readable in the same shape as the
+/// conformance kit's, and it never carries a field named `conformant`: the verb
+/// checks that this endpoint accepts the supplied secret and that the route
+/// fields are present, and neither of those is whole floor conformance.
+#[test]
+fn the_smoke_test_payload_is_machine_readable_and_never_claims_conformance() {
+    let name = "adapter-smoke-test.schema.json";
+    let required = required_names(&load_schema(name));
+    for field in ["verdict", "counts", "manual_review_required"] {
+        assert!(
+            required.contains(field),
+            "{name} must require `{field}`; required {required:?}"
+        );
+    }
+
+    let declared = declared_property_names(&load_schema(name));
+    assert!(
+        !declared.contains("conformant"),
+        "no field named `conformant` may exist anywhere in the output surface; \
+         declared {declared:?}"
+    );
+    for field in ["name", "ok", "status", "detail"] {
+        assert!(
+            declared.contains(field),
+            "{name} must report per check `{field}`; declared {declared:?}"
+        );
+    }
+}

--- a/docs/guides/building-a-channel-adapter.md
+++ b/docs/guides/building-a-channel-adapter.md
@@ -225,8 +225,160 @@ An adapter must:
 5. Handle all four events, and tolerate ones it does not use.
 6. Dedupe on `TurnCompleted.event_id`, at minimum in memory, and tolerate a
    completion arriving for a conversation it already considers finished.
-7. Re-mint its `chn` token rather than treating a 401 as fatal, since any
-   rebind invalidates it.
+7. Never treat a 401 as fatal: hold the delivery, stay alive, surface a loud
+   stale credential signal so the operator notices, and resume once the
+   operator supplies a replacement token. An adapter holds no platform key and
+   must never try to mint its own replacement (see section 3); the mint stays
+   platform key only.
+
+## 8. Building tooling: the binding profile, `curie adapter`, and the conformance kit
+
+Everything below reads or writes an `adapter.yaml` file. Scaffold one,
+validate it, bind it to an agent, mint a token against it, smoke test the
+deployed adapter, then run the full conformance kit before calling the
+adapter done.
+
+### The binding profile
+
+`adapter.yaml` is a **per install binding file**: the channel kind an adapter
+owns, the address shape it accepts, the endpoint this install's worker POSTs
+reply events to, and the names of the credentials involved. It is not the
+install agnostic composition manifest ADR-0096 decision 2 describes (image
+reference, config and secret schema, platform performed composition). That
+document is separate and later; nothing here pre-empts it.
+
+Fields:
+
+- `version`: the profile format version, checked before anything else (see
+  Compatibility below).
+- `kind`: the channel kind this adapter owns, a lowercase slug.
+- `endpoint`: the reply route. Optional here; `bind`, `token`, and
+  `smoke-test` need a concrete one and either read it off the profile or take
+  an override.
+- `address`: `description`, `pattern` (a regex that has to compile in both
+  Python `re` and the Rust `regex` crate, so no lookaround and no
+  backreferences), and `example`.
+- `credentials`: `egress` (a slug, a suggestion only, see below),
+  `egress_secret_env` and `ingress_token_env` (documentation of what the
+  adapter itself reads; Curie never resolves either name).
+- `conformance`: `wire_version` (the reply wire this adapter speaks) and
+  `mints_reply_ref`.
+
+The schema is closed (`additionalProperties: false`), so a typo'd key is
+refused rather than silently ignored.
+
+### Compatibility policy
+
+A third party commits an `adapter.yaml` you cannot force it to upgrade. Both
+`curie adapter validate` and the Python kit read the raw `version` key and
+check it before touching the schema. A version they do not accept is refused
+with a message naming both versions, for example: this curie understands
+adapter profile 1.0; the file declares 1.1. That check has to run first: a
+1.1 file checked against the closed schema trips `additionalProperties:
+false`, and the operator reads "additional property not allowed" instead of
+the version they actually have to act on. A missing `version` key gets the
+same refusal, never a default.
+
+Acceptance is same major, less or equal minor: a 1.0 build refuses 1.1 (it
+cannot know the new field is optional) and refuses 2.0 outright; a 1.1 build
+still accepts a 1.0 file.
+
+On a version you do not recognize: upgrade `curie`, or pin the older profile
+version. Never delete the `version` key to work around the refusal.
+
+The change class table, so an adapter author can predict the bump before a
+change lands:
+
+| Change | Bump | Why |
+|---|---|---|
+| Add an optional property | minor, 1.0 to 1.1 | The schema is closed, so a consumer on 1.0 rejects the new payload. |
+| Add a required property; remove or rename one; change a type; tighten a pattern; make an optional property required | major, 1.0 to 2.0 | Invalidates a file a conforming author previously wrote. |
+| Loosen a pattern, widen an enum, relax a bound | minor | Same closed schema reasoning as an added optional property. |
+| Edit a description, a title, or a comment | none | No shape change. |
+
+### `curie adapter` verbs
+
+All five read or write the profile at `--file` (default `adapter.yaml`).
+
+- **`scaffold <name>`** writes one `adapter.yaml` under `<dir>/<name>/`
+  (`--dir` defaults to the current directory) from `--kind`, `--address`,
+  `--endpoint`, and `--adapter`. The generated `address.pattern` matches
+  exactly the address it was scaffolded for; widen it by hand to the real
+  shape of the channel's addresses.
+- **`validate`** checks the version, then the schema, then the one rule the
+  schema cannot express: `address.pattern` has to compile with the Rust
+  `regex` crate as well as Python `re`. Pass `--address` to also check that a
+  concrete address matches the declared shape.
+- **`bind <agent>`** writes the agent's four field channel route. It takes an
+  explicit `--address` and an explicit `--adapter-slug`, both operator
+  supplied, never taken from the profile: `address.example` is authoring
+  documentation, not an operator confirmed value, and the profile's
+  `credentials.egress` is only a suggestion. Requires `--yes` to actually
+  write.
+- **`token`** mints a `chn` token for one concrete `(kind, address)` pair. It
+  also takes an explicit `--address`. `--ttl-s` defaults to 3600, and the API
+  accepts 1 to 604800.
+- **`smoke-test`** probes a deployed adapter from the outside: does it accept
+  the egress secret you supply, does it refuse a wrong one, are the route
+  fields present for this pair. It also takes an explicit `--address`, plus
+  `--secret-file` or `--secret-stdin` for the egress secret. It is a narrower
+  check than the conformance kit, not a replacement for it.
+
+`--address` and `--adapter-slug` are operator owned on all three verbs for the
+same reason: the worker's credential map is indexed by the route's adapter
+slug, so a profile that named the wrong slug, or a stale `address.example`,
+would point a real credential at the wrong destination. That is a security
+boundary, so the CLI asks a human to confirm it rather than trusting the
+file.
+
+`smoke-test` also never reads the egress secret from an environment variable
+the profile names. `credentials.egress_secret_env` documents what the adapter
+itself reads; Curie never resolves that name. The secret has to come from
+`--secret-file` or `--secret-stdin`, supplied at the command line, or the
+command refuses, because a hostile profile could otherwise name any
+environment variable on the operator's box and have its value read and sent.
+
+### The conformance kit
+
+`channel-protocol[conformance]` ships two front doors onto the same seven
+rule floor:
+
+- **The importable runner.** `from channel_protocol.conformance import
+  run_floor`. Call it with an `AdapterUnderTest`, an `IngressDriver`, and a
+  side effect probe, and assert `report.automated_floor == "pass"` in your own
+  test suite.
+- **The console script.** `curie-adapter-conformance --profile adapter.yaml
+  --endpoint <url> --secret-file <path>` (or `--secret-stdin`), the command a
+  vendor runs in its own repo and quotes in its own README. Add `--driver
+  module:attr` naming a zero argument factory for an `IngressDriver`, or rules
+  1, 2, and 7 and clause 3b report `not_run`. `--json` emits the report as
+  JSON; `--mode diagnostic` reports partial results while an adapter is still
+  being built and never reaches a passing verdict.
+
+The exit code follows `automated_floor`: nothing short of a full strict pass
+exits 0, so a README cannot claim conformance off a partial run.
+
+### Verdict semantics
+
+`automated_floor` is `pass` or `fail` over the automatable clauses only. Two
+clauses are outside that domain:
+
+- **3c**, that the egress secret is compared in constant time. No HTTP status
+  carries the answer, because two rejections that take different amounts of
+  wall time are indistinguishable from two rejections on a loaded box.
+- **7c**, that a stale ingress credential is signalled loudly. That signal is
+  for the adapter's own operator, in a log, a metric, or a page, so it never
+  crosses the wire the kit observes.
+
+Both are listed in `manual_review_required`, with why no check decides them
+and how to review them by hand. A `pass` does not assert either one: read the
+adapter's secret check yourself for 3c, and arm a 401 and confirm the signal
+for 7c.
+
+Missing evidence is never success. Any automatable clause that is not
+`pass`, including `not_run` from an unsupplied ingress driver or an adapter
+with no side effect probe, makes `automated_floor` fail. There is no
+`partial` status and no `skipped` status.
 
 ## Related
 

--- a/docs/guides/building-a-channel-adapter.md
+++ b/docs/guides/building-a-channel-adapter.md
@@ -391,6 +391,14 @@ your adapter with one credential swapped. You give the kit that access by
 implementing `IngressDriver` (`channel_protocol.conformance.driver`) and
 passing it in, or naming a zero argument factory for one on `--driver`.
 
+Every method on `IngressDriver` runs under a hard bound (five seconds by
+default). The kit calls each one on its own thread and walks away the moment
+the bound expires; it never waits on a callback that has already shown it
+does not answer. A callback that misses the bound does not hang the run and
+does not pass silently either: it turns into a named clause FAILURE that
+tells you the defect is in your driver, not in your adapter, so you are not
+left debugging the wrong code.
+
 The methods, and what each has to guarantee:
 
 - **`start(*, ingress_url, token)`** points your already running adapter at
@@ -411,12 +419,22 @@ The methods, and what each has to guarantee:
   202 for that one identity before the identity can reach it, and a single
   call that both declared and injected would leave a window where a
   different, unrelated delivery in flight consumes that response instead.
-- **`settled(identity) -> bool`** reports whether your adapter has retired
-  this delivery, having either delivered it or given up on it. Rule 2's
-  finality check waits on this rather than a fixed clock, because no timer
-  survives a retry schedule patient enough to outlast it. Answer `False` for
-  as long as your adapter might still retry; a driver that never reports
-  `True` leaves rule 2 with no finality evidence to judge.
+- **`settled(identity) -> bool`** answers whether every attempt at this
+  delivery has been retired: none in flight, and none still scheduled.
+  "Retired" is that precise claim, not a description of the active queue
+  being empty; a delivery you pulled off the queue but left a retry sitting
+  on a timer is not retired, and answering `True` for it is the naive
+  implementation this method exists to catch. The kit does not take your
+  `True` on faith. Rule 2's finality check waits on it rather than a fixed
+  clock, because no timer survives a retry schedule patient enough to outlast
+  it, but once you claim retired the kit keeps watching the wire for a
+  bounded grace period afterward, and any post carrying that delivery id in
+  that window is reported as a failure of your claim, named as such, not a
+  quiet pass. Implementing `settled` as a short sleep will fail here, and
+  that is deliberate: only your adapter's own retry state can answer this
+  honestly. Answer `False` for as long as your adapter might still retry; a
+  driver that never reports `True` leaves rule 2 with no finality evidence to
+  judge.
 - **`restart(*, egress_secret=..., token=...)`** restarts your adapter,
   optionally replacing one credential. Both arguments default to the
   unchanged sentinel, `Ellipsis`, because `None` is itself meaningful for

--- a/docs/guides/building-a-channel-adapter.md
+++ b/docs/guides/building-a-channel-adapter.md
@@ -261,11 +261,31 @@ Fields:
 - `credentials`: `egress` (a slug, a suggestion only, see below),
   `egress_secret_env` and `ingress_token_env` (documentation of what the
   adapter itself reads; Curie never resolves either name).
-- `conformance`: `wire_version` (the reply wire this adapter speaks) and
-  `mints_reply_ref`.
+- `conformance`: `wire_version`, the reply wire this adapter speaks.
 
 The schema is closed (`additionalProperties: false`), so a typo'd key is
 refused rather than silently ignored.
+
+### The address pattern's regex dialect
+
+`address.pattern` has to compile under two engines: Python `re`, used by the
+Python conformance kit, and the Rust `regex` crate, used by `curie adapter
+validate`. The Rust crate is the narrower of the two, so it is the one that
+decides what is portable. `curie adapter validate` refuses a pattern the
+crate cannot compile even when Python `re` accepts it, so an author never
+ends up with a pattern that behaves differently on the two paths.
+
+Refused constructs:
+
+- Lookahead and lookbehind, positive or negative: `(?=`, `(?!`, `(?<=`, `(?<!`
+- Named backreferences: `(?P=`
+- Atomic groups: `(?>`
+- Conditional groups: `(?(`
+- Inline comment groups: `(?#`
+- The Python only ASCII flag: `(?a`
+- The Python only `\Z` end of string anchor (the crate spells this `\z`)
+- The Python only `\N` named character escape, which the crate has no
+  equivalent for
 
 ### Compatibility policy
 
@@ -278,6 +298,10 @@ adapter profile 1.0; the file declares 1.1. That check has to run first: a
 false`, and the operator reads "additional property not allowed" instead of
 the version they actually have to act on. A missing `version` key gets the
 same refusal, never a default.
+
+`version` also has to be spelled canonically: plain digits, no leading zero.
+`01.0` or `1.00` are refused as malformed before the acceptance check even
+runs, rather than parsed as `1.0`.
 
 Acceptance is same major, less or equal minor: a 1.0 build refuses 1.1 (it
 cannot know the new field is optional) and refuses 2.0 outright; a 1.1 build

--- a/docs/guides/building-a-channel-adapter.md
+++ b/docs/guides/building-a-channel-adapter.md
@@ -358,6 +358,55 @@ rule floor:
 The exit code follows `automated_floor`: nothing short of a full strict pass
 exits 0, so a README cannot claim conformance off a partial run.
 
+### The ingress driver
+
+Rules 1, 2, and 7, plus clause 3b, need something only you can provide: a way
+to point your adapter at the kit's ingress, inject an upstream message under a
+known id, tell whether your adapter is done with that delivery, and restart
+your adapter with one credential swapped. You give the kit that access by
+implementing `IngressDriver` (`channel_protocol.conformance.driver`) and
+passing it in, or naming a zero argument factory for one on `--driver`.
+
+The methods, and what each has to guarantee:
+
+- **`start(*, ingress_url, token)`** points your already running adapter at
+  the kit's ingress. Configuration only: the kit refuses to check an adapter
+  that has to be edited to be checked, because that is not the adapter your
+  operator runs.
+- **`reserve() -> UpstreamIdentity`** declares the `delivery_id` the next
+  `release` will carry, before that message exists. This is the load bearing
+  method. The kit correlates an observed POST to a stimulus by matching the
+  wire's `delivery_id` against what `reserve` returned, because that is the
+  only correlation an adapter running in another process or another language
+  can satisfy; it never reads your private in process state. If your
+  `reserve` returns an id your adapter does not actually send, rules 1 and 2
+  fail naming the mismatch, the same as a genuinely nonconformant adapter
+  would.
+- **`release(identity)`** delivers the message `reserve` declared. Injection
+  is deliberately the second step: rule 2 has to arm the ingress to answer
+  202 for that one identity before the identity can reach it, and a single
+  call that both declared and injected would leave a window where a
+  different, unrelated delivery in flight consumes that response instead.
+- **`settled(identity) -> bool`** reports whether your adapter has retired
+  this delivery, having either delivered it or given up on it. Rule 2's
+  finality check waits on this rather than a fixed clock, because no timer
+  survives a retry schedule patient enough to outlast it. Answer `False` for
+  as long as your adapter might still retry; a driver that never reports
+  `True` leaves rule 2 with no finality evidence to judge.
+- **`restart(*, egress_secret=..., token=...)`** restarts your adapter,
+  optionally replacing one credential. Both arguments default to the
+  unchanged sentinel, `Ellipsis`, because `None` is itself meaningful for
+  each: clause 3b calls `restart(egress_secret=None)` to prove your adapter
+  refuses to serve with no egress secret of its own, and rule 7 calls
+  `restart(token=<fresh>)` to hand you an operator-issued replacement ingress
+  token without disturbing the egress secret.
+- **`stop()`** stops your adapter, called once at the end of a run.
+
+Without a driver, rules 1, 2, and 7 and clause 3b all report `not_run`, and
+`not_run` is nonconformant: the kit never reads missing evidence as a pass.
+Supply the driver to get a real verdict on your delivery_id stability, your
+handling of a final 202, and your stale credential recovery.
+
 ### Verdict semantics
 
 `automated_floor` is `pass` or `fail` over the automatable clauses only. Two

--- a/docs/interfaces/channel-ingress/INTERFACE.md
+++ b/docs/interfaces/channel-ingress/INTERFACE.md
@@ -100,6 +100,19 @@ protocol (not just the service) is the seam: the Rust CLI mints the exact
 (`cli/src/queue.rs`) and drives the whole deployed system with zero Slack contact
 via `curie local message` / `cluster message` (`cli/src/chat.rs`, `cli/src/message.rs`).
 
+A third party channel adapter sits outside this seam entirely, over the
+`POST /channels/turns` ingress and reply event egress described in
+`docs/guides/building-a-channel-adapter.md`. Two artifacts help an author
+build one: an `adapter.yaml` binding profile (a per install binding file
+naming the channel kind, address shape, reply endpoint, and credential
+identities; not the install agnostic composition manifest ADR-0096 decision 2
+describes, which is separate and later), read and written by the `curie
+adapter` verbs (`scaffold`, `validate`, `bind`, `token`, `smoke-test`); and
+the `channel-protocol[conformance]` kit, a black box HTTP checker against the
+seven rule wire floor, run either as an importable `run_floor` or as the
+`curie-adapter-conformance` console command. Both live in
+`packages/channel-protocol`.
+
 ## Known leakage
 
 Two ends and the binding surface were cleaned; what remains is egress semantics and a

--- a/docs/interfaces/cli-output/INTERFACE.md
+++ b/docs/interfaces/cli-output/INTERFACE.md
@@ -119,10 +119,10 @@ That set is not hand-maintained prose: `cli/schema/index.json` carries one
   syntactic call-site inventory, not a type-level proof that *every* verb returns
   a `CliOutput`.
 - **Committed JSON Schemas with a drift gate (since #841).** Each `to_json` is no
-  longer schema-free: there are 41 committed schemas under `cli/schema/` with an
+  longer schema-free: there are 56 committed schemas under `cli/schema/` with an
   index (`cli/schema/index.json`), a `syn`-based inventory gate over every `impl
-  CliOutput`, and per-family output validation — all 41 are validated against real
-  `to_json()` output across 66 tests in `cli/tests/json_contract.rs`. Those tests
+  CliOutput`, and per-family output validation — all 56 are validated against real
+  `to_json()` output across 73 tests in `cli/tests/json_contract.rs`. Those tests
   drive each output type's `to_json()` once per output variant rather than calling
   the pure builder functions behind it, so a variant whose `to_json()` arm drifts
   from the schema is caught even when the builder it delegates to still validates.

--- a/packages/channel-protocol/pyproject.toml
+++ b/packages/channel-protocol/pyproject.toml
@@ -1,9 +1,18 @@
 [project]
 name = "curie-channel-protocol"
-version = "0.1.0"
+version = "0.2.0"
 description = "Rendering-neutral Curie channel message contract"
 requires-python = ">=3.13"
+# Stays pydantic only: the worker and the API import channel_protocol and must
+# not acquire an HTTP client. Everything the conformance kit needs lives in the
+# optional extra below.
 dependencies = ["pydantic>=2.9"]
+
+[project.optional-dependencies]
+conformance = ["httpx>=0.27", "pyyaml>=6.0", "jsonschema>=4.23"]
+
+[project.scripts]
+curie-adapter-conformance = "channel_protocol.conformance.cli:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/packages/channel-protocol/schema/adapter-profile.baseline.json
+++ b/packages/channel-protocol/schema/adapter-profile.baseline.json
@@ -3,16 +3,12 @@
     "AdapterConformance": {
       "additionalProperties": false,
       "properties": {
-        "mints_reply_ref": {
-          "type": "boolean"
-        },
         "wire_version": {
           "const": "1.0",
           "type": "string"
         }
       },
       "required": [
-        "mints_reply_ref",
         "wire_version"
       ]
     },

--- a/packages/channel-protocol/schema/adapter-profile.baseline.json
+++ b/packages/channel-protocol/schema/adapter-profile.baseline.json
@@ -1,0 +1,103 @@
+{
+  "models": {
+    "AdapterConformance": {
+      "additionalProperties": false,
+      "properties": {
+        "mints_reply_ref": {
+          "type": "boolean"
+        },
+        "wire_version": {
+          "const": "1.0",
+          "type": "string"
+        }
+      },
+      "required": [
+        "mints_reply_ref",
+        "wire_version"
+      ]
+    },
+    "AdapterCredentials": {
+      "additionalProperties": false,
+      "properties": {
+        "egress": {
+          "pattern": "^[a-z0-9]+(?:[-_][a-z0-9]+)*$",
+          "type": "string"
+        },
+        "egress_secret_env": {
+          "pattern": "^[A-Z][A-Z0-9_]*$",
+          "type": "string"
+        },
+        "ingress_token_env": {
+          "pattern": "^[A-Z][A-Z0-9_]*$",
+          "type": "string"
+        }
+      },
+      "required": [
+        "egress",
+        "egress_secret_env",
+        "ingress_token_env"
+      ]
+    },
+    "AdapterProfile": {
+      "additionalProperties": false,
+      "properties": {
+        "address": {
+          "$ref": "#/$defs/AddressShape"
+        },
+        "conformance": {
+          "$ref": "#/$defs/AdapterConformance"
+        },
+        "credentials": {
+          "$ref": "#/$defs/AdapterCredentials"
+        },
+        "endpoint": {
+          "anyOf": [
+            {
+              "pattern": "^https?://[^\\s/?#@]+(?:[/?#][^\\s]*)?$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "kind": {
+          "pattern": "^[a-z0-9]+(?:[-_][a-z0-9]+)*$",
+          "type": "string"
+        },
+        "version": {
+          "const": "1.0",
+          "type": "string"
+        }
+      },
+      "required": [
+        "address",
+        "conformance",
+        "credentials",
+        "kind",
+        "version"
+      ]
+    },
+    "AddressShape": {
+      "additionalProperties": false,
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "example": {
+          "type": "string"
+        },
+        "pattern": {
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "description",
+        "example",
+        "pattern"
+      ]
+    }
+  },
+  "version": "1.0"
+}

--- a/packages/channel-protocol/schema/adapter-profile.corpus.json
+++ b/packages/channel-protocol/schema/adapter-profile.corpus.json
@@ -1,0 +1,432 @@
+{
+  "_comment": "Cross language fixture for the adapter binding profile (#1516, following #490 and #1079). Three consumers read this file: the Pydantic models in channel_protocol.manifest, the exported schema/adapter-profile.schema.json, and the Rust CLI in cli/src/adapter.rs. Every invalid case is rejected by the Pydantic model and by the Rust CLI. The exported schema rejects tier 1 and tier 2 only: tier 3 is an admitted PAIRED validator (one in Python, one in Rust), because JSON Schema cannot express 'the Rust regex crate can compile this string'. The tier field on each invalid case declares which mechanism enforces the rule, and test_manifest_corpus.py asserts the declaration is truthful in both directions, so a tier 3 case the schema unexpectedly catches is as red as a tier 1 case it misses. Valid case values deliberately VARY (different kind, egress, address pattern, endpoint presence and mints_reply_ref), so a consumer that returns a constant instead of carrying the parsed value through is killed by the comparison rather than tracking a self updating expectation.",
+  "valid": [
+    {
+      "version": "1.0",
+      "kind": "email",
+      "endpoint": "https://curie-mail-adapter.example.test/curie/reply",
+      "address": {
+        "description": "The mailbox this adapter owns.",
+        "pattern": "^[a-z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]{2,}$",
+        "example": "agent@example.test"
+      },
+      "credentials": {
+        "egress": "agentmail-sandbox",
+        "egress_secret_env": "CURIE_EGRESS_SECRET",
+        "ingress_token_env": "CURIE_INGRESS_TOKEN"
+      },
+      "conformance": {
+        "wire_version": "1.0",
+        "mints_reply_ref": true
+      }
+    },
+    {
+      "version": "1.0",
+      "kind": "ms_teams",
+      "endpoint": "http://ms-teams-adapter.internal.example.test:8080/reply",
+      "address": {
+        "description": "The Teams conversation this adapter owns.",
+        "pattern": "^19:[a-zA-Z0-9_-]+@thread\\.tacv2$",
+        "example": "19:abc_def@thread.tacv2"
+      },
+      "credentials": {
+        "egress": "ms_teams_egress",
+        "egress_secret_env": "MS_TEAMS_EGRESS_SECRET",
+        "ingress_token_env": "MS_TEAMS_INGRESS_TOKEN"
+      },
+      "conformance": {
+        "wire_version": "1.0",
+        "mints_reply_ref": false
+      }
+    },
+    {
+      "version": "1.0",
+      "kind": "webhook",
+      "address": {
+        "description": "The webhook route this adapter owns.",
+        "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*/[a-z0-9]+$",
+        "example": "team-alpha/inbox"
+      },
+      "credentials": {
+        "egress": "webhook-egress",
+        "egress_secret_env": "WEBHOOK_EGRESS_SECRET",
+        "ingress_token_env": "WEBHOOK_INGRESS_TOKEN"
+      },
+      "conformance": {
+        "wire_version": "1.0",
+        "mints_reply_ref": true
+      }
+    }
+  ],
+  "invalid": [
+    {
+      "why": "kind is uppercase, and a kind is a lowercase slug",
+      "tier": 1,
+      "profile": {
+        "version": "1.0",
+        "kind": "Email",
+        "endpoint": "https://curie-mail-adapter.example.test/curie/reply",
+        "address": {
+          "description": "The mailbox this adapter owns.",
+          "pattern": "^[a-z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]{2,}$",
+          "example": "agent@example.test"
+        },
+        "credentials": {
+          "egress": "agentmail-sandbox",
+          "egress_secret_env": "CURIE_EGRESS_SECRET",
+          "ingress_token_env": "CURIE_INGRESS_TOKEN"
+        },
+        "conformance": {
+          "wire_version": "1.0",
+          "mints_reply_ref": true
+        }
+      }
+    },
+    {
+      "why": "kind has a leading hyphen, so it is not a slug",
+      "tier": 1,
+      "profile": {
+        "version": "1.0",
+        "kind": "-email",
+        "endpoint": "https://curie-mail-adapter.example.test/curie/reply",
+        "address": {
+          "description": "The mailbox this adapter owns.",
+          "pattern": "^[a-z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]{2,}$",
+          "example": "agent@example.test"
+        },
+        "credentials": {
+          "egress": "agentmail-sandbox",
+          "egress_secret_env": "CURIE_EGRESS_SECRET",
+          "ingress_token_env": "CURIE_INGRESS_TOKEN"
+        },
+        "conformance": {
+          "wire_version": "1.0",
+          "mints_reply_ref": true
+        }
+      }
+    },
+    {
+      "why": "credentials.egress is uppercase, and an egress identity is the same slug shape as a kind",
+      "tier": 1,
+      "profile": {
+        "version": "1.0",
+        "kind": "email",
+        "endpoint": "https://curie-mail-adapter.example.test/curie/reply",
+        "address": {
+          "description": "The mailbox this adapter owns.",
+          "pattern": "^[a-z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]{2,}$",
+          "example": "agent@example.test"
+        },
+        "credentials": {
+          "egress": "AgentMail-Sandbox",
+          "egress_secret_env": "CURIE_EGRESS_SECRET",
+          "ingress_token_env": "CURIE_INGRESS_TOKEN"
+        },
+        "conformance": {
+          "wire_version": "1.0",
+          "mints_reply_ref": true
+        }
+      }
+    },
+    {
+      "why": "egress_secret_env is lowercase, and the field holds an environment variable NAME. The pattern is a legibility constraint and claims nothing about secrecy",
+      "tier": 1,
+      "profile": {
+        "version": "1.0",
+        "kind": "email",
+        "endpoint": "https://curie-mail-adapter.example.test/curie/reply",
+        "address": {
+          "description": "The mailbox this adapter owns.",
+          "pattern": "^[a-z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]{2,}$",
+          "example": "agent@example.test"
+        },
+        "credentials": {
+          "egress": "agentmail-sandbox",
+          "egress_secret_env": "curie_egress_secret",
+          "ingress_token_env": "CURIE_INGRESS_TOKEN"
+        },
+        "conformance": {
+          "wire_version": "1.0",
+          "mints_reply_ref": true
+        }
+      }
+    },
+    {
+      "why": "egress_secret_env carries hyphens, which no shell environment variable name may hold",
+      "tier": 1,
+      "profile": {
+        "version": "1.0",
+        "kind": "email",
+        "endpoint": "https://curie-mail-adapter.example.test/curie/reply",
+        "address": {
+          "description": "The mailbox this adapter owns.",
+          "pattern": "^[a-z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]{2,}$",
+          "example": "agent@example.test"
+        },
+        "credentials": {
+          "egress": "agentmail-sandbox",
+          "egress_secret_env": "CURIE-EGRESS-SECRET",
+          "ingress_token_env": "CURIE_INGRESS_TOKEN"
+        },
+        "conformance": {
+          "wire_version": "1.0",
+          "mints_reply_ref": true
+        }
+      }
+    },
+    {
+      "why": "ingress_token_env is empty, which names no variable at all",
+      "tier": 1,
+      "profile": {
+        "version": "1.0",
+        "kind": "email",
+        "endpoint": "https://curie-mail-adapter.example.test/curie/reply",
+        "address": {
+          "description": "The mailbox this adapter owns.",
+          "pattern": "^[a-z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]{2,}$",
+          "example": "agent@example.test"
+        },
+        "credentials": {
+          "egress": "agentmail-sandbox",
+          "egress_secret_env": "CURIE_EGRESS_SECRET",
+          "ingress_token_env": ""
+        },
+        "conformance": {
+          "wire_version": "1.0",
+          "mints_reply_ref": true
+        }
+      }
+    },
+    {
+      "why": "an unknown top level key, which a closed profile refuses so a typo is never silently ignored",
+      "tier": 1,
+      "profile": {
+        "version": "1.0",
+        "kind": "email",
+        "endpoint": "https://curie-mail-adapter.example.test/curie/reply",
+        "retries": 3,
+        "address": {
+          "description": "The mailbox this adapter owns.",
+          "pattern": "^[a-z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]{2,}$",
+          "example": "agent@example.test"
+        },
+        "credentials": {
+          "egress": "agentmail-sandbox",
+          "egress_secret_env": "CURIE_EGRESS_SECRET",
+          "ingress_token_env": "CURIE_INGRESS_TOKEN"
+        },
+        "conformance": {
+          "wire_version": "1.0",
+          "mints_reply_ref": true
+        }
+      }
+    },
+    {
+      "why": "a profile version this build does not understand, refused by the acceptance check before any schema validation runs",
+      "tier": 1,
+      "profile": {
+        "version": "1.1",
+        "kind": "email",
+        "endpoint": "https://curie-mail-adapter.example.test/curie/reply",
+        "address": {
+          "description": "The mailbox this adapter owns.",
+          "pattern": "^[a-z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]{2,}$",
+          "example": "agent@example.test"
+        },
+        "credentials": {
+          "egress": "agentmail-sandbox",
+          "egress_secret_env": "CURIE_EGRESS_SECRET",
+          "ingress_token_env": "CURIE_INGRESS_TOKEN"
+        },
+        "conformance": {
+          "wire_version": "1.0",
+          "mints_reply_ref": true
+        }
+      }
+    },
+    {
+      "why": "conformance.wire_version names a reply wire this build does not speak, and it is independent of the profile version",
+      "tier": 1,
+      "profile": {
+        "version": "1.0",
+        "kind": "email",
+        "endpoint": "https://curie-mail-adapter.example.test/curie/reply",
+        "address": {
+          "description": "The mailbox this adapter owns.",
+          "pattern": "^[a-z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]{2,}$",
+          "example": "agent@example.test"
+        },
+        "credentials": {
+          "egress": "agentmail-sandbox",
+          "egress_secret_env": "CURIE_EGRESS_SECRET",
+          "ingress_token_env": "CURIE_INGRESS_TOKEN"
+        },
+        "conformance": {
+          "wire_version": "2.0",
+          "mints_reply_ref": true
+        }
+      }
+    },
+    {
+      "why": "the endpoint embeds userinfo, which discloses a credential everywhere the route is read back",
+      "tier": 2,
+      "profile": {
+        "version": "1.0",
+        "kind": "email",
+        "endpoint": "https://user:pw@curie-mail-adapter.example.test/curie/reply",
+        "address": {
+          "description": "The mailbox this adapter owns.",
+          "pattern": "^[a-z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]{2,}$",
+          "example": "agent@example.test"
+        },
+        "credentials": {
+          "egress": "agentmail-sandbox",
+          "egress_secret_env": "CURIE_EGRESS_SECRET",
+          "ingress_token_env": "CURIE_INGRESS_TOKEN"
+        },
+        "conformance": {
+          "wire_version": "1.0",
+          "mints_reply_ref": true
+        }
+      }
+    },
+    {
+      "why": "the endpoint is relative, so the worker has no host to POST the reply to",
+      "tier": 2,
+      "profile": {
+        "version": "1.0",
+        "kind": "email",
+        "endpoint": "/curie/reply",
+        "address": {
+          "description": "The mailbox this adapter owns.",
+          "pattern": "^[a-z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]{2,}$",
+          "example": "agent@example.test"
+        },
+        "credentials": {
+          "egress": "agentmail-sandbox",
+          "egress_secret_env": "CURIE_EGRESS_SECRET",
+          "ingress_token_env": "CURIE_INGRESS_TOKEN"
+        },
+        "conformance": {
+          "wire_version": "1.0",
+          "mints_reply_ref": true
+        }
+      }
+    },
+    {
+      "why": "the endpoint scheme is not http or https, so it is not a route the worker can POST to",
+      "tier": 2,
+      "profile": {
+        "version": "1.0",
+        "kind": "email",
+        "endpoint": "mailto:agent@example.test",
+        "address": {
+          "description": "The mailbox this adapter owns.",
+          "pattern": "^[a-z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]{2,}$",
+          "example": "agent@example.test"
+        },
+        "credentials": {
+          "egress": "agentmail-sandbox",
+          "egress_secret_env": "CURIE_EGRESS_SECRET",
+          "ingress_token_env": "CURIE_INGRESS_TOKEN"
+        },
+        "conformance": {
+          "wire_version": "1.0",
+          "mints_reply_ref": true
+        }
+      }
+    },
+    {
+      "why": "address.pattern does not compile as a regex at all, in either dialect",
+      "tier": 3,
+      "profile": {
+        "version": "1.0",
+        "kind": "email",
+        "endpoint": "https://curie-mail-adapter.example.test/curie/reply",
+        "address": {
+          "description": "The mailbox this adapter owns.",
+          "pattern": "^[a-z",
+          "example": "agent@example.test"
+        },
+        "credentials": {
+          "egress": "agentmail-sandbox",
+          "egress_secret_env": "CURIE_EGRESS_SECRET",
+          "ingress_token_env": "CURIE_INGRESS_TOKEN"
+        },
+        "conformance": {
+          "wire_version": "1.0",
+          "mints_reply_ref": true
+        }
+      }
+    },
+    {
+      "why": "address.pattern uses LOOKAHEAD, which Python re compiles and the Rust regex crate refuses. The most likely silent cross language divergence in this contract",
+      "tier": 3,
+      "profile": {
+        "version": "1.0",
+        "kind": "email",
+        "endpoint": "https://curie-mail-adapter.example.test/curie/reply",
+        "address": {
+          "description": "The mailbox this adapter owns.",
+          "pattern": "^(?=.*@)[a-z0-9@.]+$",
+          "example": "agent@example.test"
+        },
+        "credentials": {
+          "egress": "agentmail-sandbox",
+          "egress_secret_env": "CURIE_EGRESS_SECRET",
+          "ingress_token_env": "CURIE_INGRESS_TOKEN"
+        },
+        "conformance": {
+          "wire_version": "1.0",
+          "mints_reply_ref": true
+        }
+      }
+    },
+    {
+      "why": "address.pattern uses LOOKBEHIND, which Python re compiles and the Rust regex crate refuses",
+      "tier": 3,
+      "profile": {
+        "version": "1.0",
+        "kind": "email",
+        "endpoint": "https://curie-mail-adapter.example.test/curie/reply",
+        "address": {
+          "description": "The mailbox this adapter owns.",
+          "pattern": "(?<=@)[a-z0-9.]+$",
+          "example": "agent@example.test"
+        },
+        "credentials": {
+          "egress": "agentmail-sandbox",
+          "egress_secret_env": "CURIE_EGRESS_SECRET",
+          "ingress_token_env": "CURIE_INGRESS_TOKEN"
+        },
+        "conformance": {
+          "wire_version": "1.0",
+          "mints_reply_ref": true
+        }
+      }
+    },
+    {
+      "why": "address.pattern uses a BACKREFERENCE, which Python re compiles and the Rust regex crate refuses",
+      "tier": 3,
+      "profile": {
+        "version": "1.0",
+        "kind": "email",
+        "endpoint": "https://curie-mail-adapter.example.test/curie/reply",
+        "address": {
+          "description": "The mailbox this adapter owns.",
+          "pattern": "^([a-z0-9]+)@\\1\\.example\\.test$",
+          "example": "agent@agent.example.test"
+        },
+        "credentials": {
+          "egress": "agentmail-sandbox",
+          "egress_secret_env": "CURIE_EGRESS_SECRET",
+          "ingress_token_env": "CURIE_INGRESS_TOKEN"
+        },
+        "conformance": {
+          "wire_version": "1.0",
+          "mints_reply_ref": true
+        }
+      }
+    }
+  ]
+}

--- a/packages/channel-protocol/schema/adapter-profile.corpus.json
+++ b/packages/channel-protocol/schema/adapter-profile.corpus.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Cross language fixture for the adapter binding profile (#1516, following #490 and #1079). Three consumers read this file: the Pydantic models in channel_protocol.manifest, the exported schema/adapter-profile.schema.json, and the Rust CLI in cli/src/adapter.rs. Every invalid case is rejected by the Pydantic model and by the Rust CLI. The exported schema rejects tier 1 and tier 2 only: tier 3 is an admitted PAIRED validator (one in Python, one in Rust), because JSON Schema cannot express 'the Rust regex crate can compile this string'. The tier field on each invalid case declares which mechanism enforces the rule, and test_manifest_corpus.py asserts the declaration is truthful in both directions, so a tier 3 case the schema unexpectedly catches is as red as a tier 1 case it misses. Valid case values deliberately VARY (different kind, egress, address pattern, endpoint presence and mints_reply_ref), so a consumer that returns a constant instead of carrying the parsed value through is killed by the comparison rather than tracking a self updating expectation.",
+  "_comment": "Cross language fixture for the adapter binding profile (#1516, following #490 and #1079). Three consumers read this file: the Pydantic models in channel_protocol.manifest, the exported schema/adapter-profile.schema.json, and the Rust CLI in cli/src/adapter.rs. Every invalid case is rejected by the Pydantic model and by the Rust CLI. The exported schema rejects tier 1 and tier 2 only: tier 3 is an admitted PAIRED validator (one in Python, one in Rust), because JSON Schema cannot express 'the Rust regex crate can compile this string'. The tier field on each invalid case declares which mechanism enforces the rule, and test_manifest_corpus.py asserts the declaration is truthful in both directions, so a tier 3 case the schema unexpectedly catches is as red as a tier 1 case it misses. Valid case values deliberately VARY (different kind, egress, address pattern and endpoint presence), so a consumer that returns a constant instead of carrying the parsed value through is killed by the comparison rather than tracking a self updating expectation.",
   "valid": [
     {
       "version": "1.0",
@@ -16,8 +16,7 @@
         "ingress_token_env": "CURIE_INGRESS_TOKEN"
       },
       "conformance": {
-        "wire_version": "1.0",
-        "mints_reply_ref": true
+        "wire_version": "1.0"
       }
     },
     {
@@ -35,8 +34,7 @@
         "ingress_token_env": "MS_TEAMS_INGRESS_TOKEN"
       },
       "conformance": {
-        "wire_version": "1.0",
-        "mints_reply_ref": false
+        "wire_version": "1.0"
       }
     },
     {
@@ -53,8 +51,7 @@
         "ingress_token_env": "WEBHOOK_INGRESS_TOKEN"
       },
       "conformance": {
-        "wire_version": "1.0",
-        "mints_reply_ref": true
+        "wire_version": "1.0"
       }
     }
   ],
@@ -77,8 +74,7 @@
           "ingress_token_env": "CURIE_INGRESS_TOKEN"
         },
         "conformance": {
-          "wire_version": "1.0",
-          "mints_reply_ref": true
+          "wire_version": "1.0"
         }
       }
     },
@@ -100,8 +96,7 @@
           "ingress_token_env": "CURIE_INGRESS_TOKEN"
         },
         "conformance": {
-          "wire_version": "1.0",
-          "mints_reply_ref": true
+          "wire_version": "1.0"
         }
       }
     },
@@ -123,8 +118,7 @@
           "ingress_token_env": "CURIE_INGRESS_TOKEN"
         },
         "conformance": {
-          "wire_version": "1.0",
-          "mints_reply_ref": true
+          "wire_version": "1.0"
         }
       }
     },
@@ -146,8 +140,7 @@
           "ingress_token_env": "CURIE_INGRESS_TOKEN"
         },
         "conformance": {
-          "wire_version": "1.0",
-          "mints_reply_ref": true
+          "wire_version": "1.0"
         }
       }
     },
@@ -169,8 +162,7 @@
           "ingress_token_env": "CURIE_INGRESS_TOKEN"
         },
         "conformance": {
-          "wire_version": "1.0",
-          "mints_reply_ref": true
+          "wire_version": "1.0"
         }
       }
     },
@@ -192,8 +184,7 @@
           "ingress_token_env": ""
         },
         "conformance": {
-          "wire_version": "1.0",
-          "mints_reply_ref": true
+          "wire_version": "1.0"
         }
       }
     },
@@ -216,8 +207,7 @@
           "ingress_token_env": "CURIE_INGRESS_TOKEN"
         },
         "conformance": {
-          "wire_version": "1.0",
-          "mints_reply_ref": true
+          "wire_version": "1.0"
         }
       }
     },
@@ -239,8 +229,7 @@
           "ingress_token_env": "CURIE_INGRESS_TOKEN"
         },
         "conformance": {
-          "wire_version": "1.0",
-          "mints_reply_ref": true
+          "wire_version": "1.0"
         }
       }
     },
@@ -262,8 +251,7 @@
           "ingress_token_env": "CURIE_INGRESS_TOKEN"
         },
         "conformance": {
-          "wire_version": "2.0",
-          "mints_reply_ref": true
+          "wire_version": "2.0"
         }
       }
     },
@@ -285,8 +273,7 @@
           "ingress_token_env": "CURIE_INGRESS_TOKEN"
         },
         "conformance": {
-          "wire_version": "1.0",
-          "mints_reply_ref": true
+          "wire_version": "1.0"
         }
       }
     },
@@ -308,8 +295,7 @@
           "ingress_token_env": "CURIE_INGRESS_TOKEN"
         },
         "conformance": {
-          "wire_version": "1.0",
-          "mints_reply_ref": true
+          "wire_version": "1.0"
         }
       }
     },
@@ -331,8 +317,7 @@
           "ingress_token_env": "CURIE_INGRESS_TOKEN"
         },
         "conformance": {
-          "wire_version": "1.0",
-          "mints_reply_ref": true
+          "wire_version": "1.0"
         }
       }
     },
@@ -354,8 +339,7 @@
           "ingress_token_env": "CURIE_INGRESS_TOKEN"
         },
         "conformance": {
-          "wire_version": "1.0",
-          "mints_reply_ref": true
+          "wire_version": "1.0"
         }
       }
     },
@@ -377,8 +361,7 @@
           "ingress_token_env": "CURIE_INGRESS_TOKEN"
         },
         "conformance": {
-          "wire_version": "1.0",
-          "mints_reply_ref": true
+          "wire_version": "1.0"
         }
       }
     },
@@ -400,8 +383,7 @@
           "ingress_token_env": "CURIE_INGRESS_TOKEN"
         },
         "conformance": {
-          "wire_version": "1.0",
-          "mints_reply_ref": true
+          "wire_version": "1.0"
         }
       }
     },
@@ -423,8 +405,206 @@
           "ingress_token_env": "CURIE_INGRESS_TOKEN"
         },
         "conformance": {
-          "wire_version": "1.0",
-          "mints_reply_ref": true
+          "wire_version": "1.0"
+        }
+      }
+    },
+    {
+      "why": "version is the NUMBER 1.1, which is what unquoted version: 1.1 parses to in YAML, and the profile also carries an unknown future_field. The version refusal has to win: it must name the value 1.1 and the quoted string form, and it must not report a missing version key or the unknown property",
+      "tier": 1,
+      "profile": {
+        "version": 1.1,
+        "kind": "email",
+        "endpoint": "https://curie-mail-adapter.example.test/curie/reply",
+        "future_field": true,
+        "address": {
+          "description": "The mailbox this adapter owns.",
+          "pattern": "^[a-z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]{2,}$",
+          "example": "agent@example.test"
+        },
+        "credentials": {
+          "egress": "agentmail-sandbox",
+          "egress_secret_env": "CURIE_EGRESS_SECRET",
+          "ingress_token_env": "CURIE_INGRESS_TOKEN"
+        },
+        "conformance": {
+          "wire_version": "1.0"
+        }
+      }
+    },
+    {
+      "why": "address.pattern uses an ATOMIC GROUP, which Python re compiles and the Rust regex crate refuses",
+      "tier": 3,
+      "profile": {
+        "version": "1.0",
+        "kind": "email",
+        "endpoint": "https://curie-mail-adapter.example.test/curie/reply",
+        "address": {
+          "description": "The address this adapter owns.",
+          "pattern": "^(?>a)$",
+          "example": "a"
+        },
+        "credentials": {
+          "egress": "agentmail-sandbox",
+          "egress_secret_env": "CURIE_EGRESS_SECRET",
+          "ingress_token_env": "CURIE_INGRESS_TOKEN"
+        },
+        "conformance": {
+          "wire_version": "1.0"
+        }
+      }
+    },
+    {
+      "why": "address.pattern uses a CONDITIONAL GROUP, which Python re compiles and the Rust regex crate refuses",
+      "tier": 3,
+      "profile": {
+        "version": "1.0",
+        "kind": "email",
+        "endpoint": "https://curie-mail-adapter.example.test/curie/reply",
+        "address": {
+          "description": "The mailbox this adapter owns.",
+          "pattern": "^([a-z]+)?(?(1)@example\\.test|admin)$",
+          "example": "agent@example.test"
+        },
+        "credentials": {
+          "egress": "agentmail-sandbox",
+          "egress_secret_env": "CURIE_EGRESS_SECRET",
+          "ingress_token_env": "CURIE_INGRESS_TOKEN"
+        },
+        "conformance": {
+          "wire_version": "1.0"
+        }
+      }
+    },
+    {
+      "why": "address.pattern uses an INLINE COMMENT GROUP, which Python re compiles and the Rust regex crate refuses",
+      "tier": 3,
+      "profile": {
+        "version": "1.0",
+        "kind": "email",
+        "endpoint": "https://curie-mail-adapter.example.test/curie/reply",
+        "address": {
+          "description": "The mailbox this adapter owns.",
+          "pattern": "^[a-z0-9]+(?#the local part)@example\\.test$",
+          "example": "agent@example.test"
+        },
+        "credentials": {
+          "egress": "agentmail-sandbox",
+          "egress_secret_env": "CURIE_EGRESS_SECRET",
+          "ingress_token_env": "CURIE_INGRESS_TOKEN"
+        },
+        "conformance": {
+          "wire_version": "1.0"
+        }
+      }
+    },
+    {
+      "why": "address.pattern opens with the Python only ASCII flag, which Python re compiles and the Rust regex crate refuses",
+      "tier": 3,
+      "profile": {
+        "version": "1.0",
+        "kind": "email",
+        "endpoint": "https://curie-mail-adapter.example.test/curie/reply",
+        "address": {
+          "description": "The mailbox this adapter owns.",
+          "pattern": "(?a)^[a-z0-9]+@example\\.test$",
+          "example": "agent@example.test"
+        },
+        "credentials": {
+          "egress": "agentmail-sandbox",
+          "egress_secret_env": "CURIE_EGRESS_SECRET",
+          "ingress_token_env": "CURIE_INGRESS_TOKEN"
+        },
+        "conformance": {
+          "wire_version": "1.0"
+        }
+      }
+    },
+    {
+      "why": "address.pattern anchors with Python's \\Z, which the Rust regex crate spells \\z and refuses as written",
+      "tier": 3,
+      "profile": {
+        "version": "1.0",
+        "kind": "email",
+        "endpoint": "https://curie-mail-adapter.example.test/curie/reply",
+        "address": {
+          "description": "The mailbox this adapter owns.",
+          "pattern": "^[a-z0-9]+@example\\.test\\Z",
+          "example": "agent@example.test"
+        },
+        "credentials": {
+          "egress": "agentmail-sandbox",
+          "egress_secret_env": "CURIE_EGRESS_SECRET",
+          "ingress_token_env": "CURIE_INGRESS_TOKEN"
+        },
+        "conformance": {
+          "wire_version": "1.0"
+        }
+      }
+    },
+    {
+      "why": "address.pattern uses Python's \\N named character escape, which the Rust regex crate has no equivalent for and refuses",
+      "tier": 3,
+      "profile": {
+        "version": "1.0",
+        "kind": "email",
+        "endpoint": "https://curie-mail-adapter.example.test/curie/reply",
+        "address": {
+          "description": "The mailbox this adapter owns.",
+          "pattern": "^[a-z0-9]+\\N{COMMERCIAL AT}example\\.test$",
+          "example": "agent@example.test"
+        },
+        "credentials": {
+          "egress": "agentmail-sandbox",
+          "egress_secret_env": "CURIE_EGRESS_SECRET",
+          "ingress_token_env": "CURIE_INGRESS_TOKEN"
+        },
+        "conformance": {
+          "wire_version": "1.0"
+        }
+      }
+    },
+    {
+      "why": "version carries a LEADING ZERO. The Rust CLI compares the declared string to 1.0 for equality and refuses this, so a Python side that parsed the numbers and accepted it would take a profile curie adapter validate rejects. The refusal has to name the spelling, not report a mismatch between two versions an operator reads as equal",
+      "tier": 1,
+      "profile": {
+        "version": "01.0",
+        "kind": "email",
+        "endpoint": "https://curie-mail-adapter.example.test/curie/reply",
+        "address": {
+          "description": "The mailbox this adapter owns.",
+          "pattern": "^[a-z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]{2,}$",
+          "example": "agent@example.test"
+        },
+        "credentials": {
+          "egress": "agentmail-sandbox",
+          "egress_secret_env": "CURIE_EGRESS_SECRET",
+          "ingress_token_env": "CURIE_INGRESS_TOKEN"
+        },
+        "conformance": {
+          "wire_version": "1.0"
+        }
+      }
+    },
+    {
+      "why": "the version MINOR carries a leading zero, the same non canonical spelling as 01.0 on the other side of the dot",
+      "tier": 1,
+      "profile": {
+        "version": "1.00",
+        "kind": "email",
+        "endpoint": "https://curie-mail-adapter.example.test/curie/reply",
+        "address": {
+          "description": "The mailbox this adapter owns.",
+          "pattern": "^[a-z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]{2,}$",
+          "example": "agent@example.test"
+        },
+        "credentials": {
+          "egress": "agentmail-sandbox",
+          "egress_secret_env": "CURIE_EGRESS_SECRET",
+          "ingress_token_env": "CURIE_INGRESS_TOKEN"
+        },
+        "conformance": {
+          "wire_version": "1.0"
         }
       }
     }

--- a/packages/channel-protocol/schema/adapter-profile.schema.json
+++ b/packages/channel-protocol/schema/adapter-profile.schema.json
@@ -1,0 +1,141 @@
+{
+  "$defs": {
+    "AdapterConformance": {
+      "additionalProperties": false,
+      "description": "What this adapter claims about the reply wire it speaks.\n\n``wire_version`` is the reply wire (ADR-0096), imported from ``reply.py``\nand never re typed here. It is INDEPENDENT of the profile's own ``version``:\nconflating the two would let a wire bump silently invalidate every profile.",
+      "properties": {
+        "mints_reply_ref": {
+          "description": "Whether the adapter mints an opaque reply_ref the platform can address a later edit to. False means every reply is a fresh post.",
+          "title": "Mints Reply Ref",
+          "type": "boolean"
+        },
+        "wire_version": {
+          "const": "1.0",
+          "description": "The reply wire version this adapter speaks, from channel_protocol.reply.",
+          "title": "Wire Version",
+          "type": "string"
+        }
+      },
+      "required": [
+        "wire_version",
+        "mints_reply_ref"
+      ],
+      "title": "AdapterConformance",
+      "type": "object"
+    },
+    "AdapterCredentials": {
+      "additionalProperties": false,
+      "description": "Which credential identities this adapter expects, by NAME only.\n\n``egress`` is a non binding SUGGESTION. It is authority for nothing: the\nworker's credential map is indexed by the slug the binding carries, so a\nprofile that named another adapter's slug would redirect that adapter's\nsecret. ``curie adapter bind`` therefore requires an operator supplied slug\nand the profile's value is only ever a default shown for confirmation.\n\n``egress_secret_env`` and ``ingress_token_env`` are DOCUMENTATION of what\nthe adapter itself reads. Nothing in Curie resolves them: the conformance\nkit and the CLI take a secret at the invocation boundary instead, so a\nprofile can never choose which of an operator's secrets gets read.",
+      "properties": {
+        "egress": {
+          "description": "The egress credential identity this adapter suggests. A SUGGESTION only: bind requires an operator supplied slug and never takes this value alone.",
+          "pattern": "^[a-z0-9]+(?:[-_][a-z0-9]+)*$",
+          "title": "Egress",
+          "type": "string"
+        },
+        "egress_secret_env": {
+          "description": "The environment variable the ADAPTER reads its egress secret from. Documentation only. Curie never resolves this name.",
+          "pattern": "^[A-Z][A-Z0-9_]*$",
+          "title": "Egress Secret Env",
+          "type": "string"
+        },
+        "ingress_token_env": {
+          "description": "The environment variable the ADAPTER reads its ingress token from. Documentation only. Curie never resolves this name.",
+          "pattern": "^[A-Z][A-Z0-9_]*$",
+          "title": "Ingress Token Env",
+          "type": "string"
+        }
+      },
+      "required": [
+        "egress",
+        "egress_secret_env",
+        "ingress_token_env"
+      ],
+      "title": "AdapterCredentials",
+      "type": "object"
+    },
+    "AdapterProfile": {
+      "additionalProperties": false,
+      "description": "One install's binding profile for one adapter.\n\nClosed by construction (``extra='forbid'``), so a typo'd key is refused\ninstead of silently ignored. Read it through ``load_profile``, never\nthrough ``model_validate`` directly: the version check has to run first.",
+      "properties": {
+        "address": {
+          "$ref": "#/$defs/AddressShape"
+        },
+        "conformance": {
+          "$ref": "#/$defs/AdapterConformance"
+        },
+        "credentials": {
+          "$ref": "#/$defs/AdapterCredentials"
+        },
+        "endpoint": {
+          "anyOf": [
+            {
+              "pattern": "^https?://[^\\s/?#@]+(?:[/?#][^\\s]*)?$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The absolute http or https route this install's worker POSTs reply events to. OPTIONAL here: the verbs that need a concrete route (bind, token, smoke-test) require it at the verb boundary or take an override.",
+          "title": "Endpoint"
+        },
+        "kind": {
+          "description": "The channel kind this adapter owns, as a lowercase slug.",
+          "pattern": "^[a-z0-9]+(?:[-_][a-z0-9]+)*$",
+          "title": "Kind",
+          "type": "string"
+        },
+        "version": {
+          "const": "1.0",
+          "description": "The adapter profile format version this file is written against.",
+          "title": "Version",
+          "type": "string"
+        }
+      },
+      "required": [
+        "version",
+        "kind",
+        "address",
+        "credentials",
+        "conformance"
+      ],
+      "title": "AdapterProfile",
+      "type": "object"
+    },
+    "AddressShape": {
+      "additionalProperties": false,
+      "description": "The address form this adapter owns, as a regex plus an operator legible example.\n\n``pattern`` is the tier 3 paired validator: the Rust ``regex`` dialect is\nthe floor, so a pattern Python ``re`` compiles and Rust refuses is rejected\nhere too. Without that, a profile would validate in the Python kit and fail\nin ``curie adapter validate`` with no shared rule to point at.",
+      "properties": {
+        "description": {
+          "description": "What this address identifies, in the channel's terms.",
+          "title": "Description",
+          "type": "string"
+        },
+        "example": {
+          "description": "A concrete address of this shape, for operator docs.",
+          "title": "Example",
+          "type": "string"
+        },
+        "pattern": {
+          "description": "A regex the address must match. It has to compile in BOTH Python re and the Rust regex crate, so lookaround and backreferences are refused.",
+          "minLength": 1,
+          "title": "Pattern",
+          "type": "string"
+        }
+      },
+      "required": [
+        "description",
+        "pattern",
+        "example"
+      ],
+      "title": "AddressShape",
+      "type": "object"
+    }
+  },
+  "$id": "https://curietech.ai/schemas/adapter-profile.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "manifestVersion": "1.0",
+  "title": "Curie Adapter Manifest v1.0"
+}

--- a/packages/channel-protocol/schema/adapter-profile.schema.json
+++ b/packages/channel-protocol/schema/adapter-profile.schema.json
@@ -4,11 +4,6 @@
       "additionalProperties": false,
       "description": "What this adapter claims about the reply wire it speaks.\n\n``wire_version`` is the reply wire (ADR-0096), imported from ``reply.py``\nand never re typed here. It is INDEPENDENT of the profile's own ``version``:\nconflating the two would let a wire bump silently invalidate every profile.",
       "properties": {
-        "mints_reply_ref": {
-          "description": "Whether the adapter mints an opaque reply_ref the platform can address a later edit to. False means every reply is a fresh post.",
-          "title": "Mints Reply Ref",
-          "type": "boolean"
-        },
         "wire_version": {
           "const": "1.0",
           "description": "The reply wire version this adapter speaks, from channel_protocol.reply.",
@@ -17,8 +12,7 @@
         }
       },
       "required": [
-        "wire_version",
-        "mints_reply_ref"
+        "wire_version"
       ],
       "title": "AdapterConformance",
       "type": "object"
@@ -119,7 +113,7 @@
           "type": "string"
         },
         "pattern": {
-          "description": "A regex the address must match. It has to compile in BOTH Python re and the Rust regex crate, so lookaround and backreferences are refused.",
+          "description": "A regex the address must match. It has to compile in BOTH Python re and the Rust regex crate, so lookaround, backreferences, atomic and conditional groups, inline comments and Python only escapes are refused.",
           "minLength": 1,
           "title": "Pattern",
           "type": "string"

--- a/packages/channel-protocol/src/channel_protocol/__init__.py
+++ b/packages/channel-protocol/src/channel_protocol/__init__.py
@@ -1,5 +1,12 @@
 """Rendering-neutral messages shared by Curie channel adapters."""
 
+from .manifest import (
+    PROFILE_VERSION,
+    AdapterConformance,
+    AdapterCredentials,
+    AdapterProfile,
+    AddressShape,
+)
 from .models import (
     MESSAGE_VERSION,
     Action,
@@ -27,8 +34,13 @@ from .reply import (
 
 __all__ = [
     "MESSAGE_VERSION",
+    "PROFILE_VERSION",
     "REPLY_WIRE_VERSION",
     "Action",
+    "AdapterConformance",
+    "AdapterCredentials",
+    "AdapterProfile",
+    "AddressShape",
     "ChannelCapability",
     "ChannelCapabilities",
     "ChoiceIntent",

--- a/packages/channel-protocol/src/channel_protocol/conformance/__init__.py
+++ b/packages/channel-protocol/src/channel_protocol/conformance/__init__.py
@@ -1,0 +1,63 @@
+"""The channel adapter conformance kit (#1516).
+
+A BLACK BOX HTTP driver a third party runs against its own adapter, in its own
+repo, to check it against the documented seven rule wire floor. It imports
+nothing from the adapter and knows nothing about its language, so the same kit
+works on a Go adapter and on the Python reference one with zero edits to either.
+
+Deliberately NOT imported by ``channel_protocol/__init__.py``: the worker and
+the API import this package for its wire models, and the kit brings an HTTP
+client with it. A contract package that dragged an HTTP client into every
+consumer would be paying for a tool none of them run.
+
+Install it as ``curie-channel-protocol[conformance]`` and use it either as a
+library::
+
+    from channel_protocol.conformance import run_floor
+
+    def test_my_adapter_meets_the_curie_floor() -> None:
+        report = run_floor(adapter, driver=MyDriver(), side_effect_probe=probe)
+        assert report.automated_floor == "pass", report.detail()
+
+or as the ``curie-adapter-conformance`` command.
+"""
+
+from .driver import IngressDriver, UpstreamIdentity
+from .floor import (
+    ClauseResult,
+    FloorMode,
+    FloorReport,
+    FloorResult,
+    FloorStatus,
+    ManualReviewItem,
+    run_floor,
+)
+from .ingress import FakeIngress, ObservedRequest
+from .transport import (
+    ADAPTER_SECRET_HEADER,
+    MAX_ACK_BODY_BYTES,
+    AdapterResponse,
+    AdapterUnderTest,
+    AdapterUnreachableError,
+    side_effect_probe,
+)
+
+__all__ = [
+    "ADAPTER_SECRET_HEADER",
+    "MAX_ACK_BODY_BYTES",
+    "AdapterResponse",
+    "AdapterUnderTest",
+    "AdapterUnreachableError",
+    "ClauseResult",
+    "FakeIngress",
+    "FloorMode",
+    "FloorReport",
+    "FloorResult",
+    "FloorStatus",
+    "IngressDriver",
+    "ManualReviewItem",
+    "ObservedRequest",
+    "UpstreamIdentity",
+    "run_floor",
+    "side_effect_probe",
+]

--- a/packages/channel-protocol/src/channel_protocol/conformance/__init__.py
+++ b/packages/channel-protocol/src/channel_protocol/conformance/__init__.py
@@ -32,7 +32,7 @@ from .floor import (
     ManualReviewItem,
     run_floor,
 )
-from .ingress import FakeIngress, ObservedRequest
+from .ingress import MAX_TURN_BODY_BYTES, FakeIngress, ObservedRequest
 from .transport import (
     ADAPTER_SECRET_HEADER,
     MAX_ACK_BODY_BYTES,
@@ -45,6 +45,7 @@ from .transport import (
 __all__ = [
     "ADAPTER_SECRET_HEADER",
     "MAX_ACK_BODY_BYTES",
+    "MAX_TURN_BODY_BYTES",
     "AdapterResponse",
     "AdapterUnderTest",
     "AdapterUnreachableError",

--- a/packages/channel-protocol/src/channel_protocol/conformance/cli.py
+++ b/packages/channel-protocol/src/channel_protocol/conformance/cli.py
@@ -1,0 +1,201 @@
+"""``curie-adapter-conformance``: the kit's console front door (#1516).
+
+The command a vendor runs in its own repo and quotes in its own README, so the
+two properties that matter most are structural here:
+
+* **The exit code follows ``automated_floor``**, and nothing short of a full
+  strict pass exits 0. An exit code that cannot tell a full run from a partial
+  one is exactly what lets a README claim conformance off an egress only
+  invocation.
+* **The JSON payload carries the verdict next to the list of what no machine
+  checked**, and the human render prints them together, so the verdict is never
+  quotable on its own.
+
+**The secret never comes from a profile named environment variable.** A third
+party authored file must never choose which of an operator's secrets gets read
+and where it is sent: a hostile profile naming another vault entry over a
+perfectly valid HTTPS endpoint defeats every shape check that could be written.
+The secret comes from ``--secret-file`` or ``--secret-stdin``, supplied at the
+invocation boundary, or the command refuses. There is no ``--secret-env`` flag
+to misuse, which is the point: ``credentials.egress_secret_env`` in the profile
+documents what the ADAPTER reads and is never resolved here.
+
+The kit posts deliberately wrong secrets, so run it against a test instance with
+a throwaway secret.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import json
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+from typing import cast
+
+import yaml
+from pydantic import ValidationError
+
+from ..manifest import ProfileVersionError, load_profile
+from .driver import IngressDriver
+from .floor import FloorMode, run_floor
+from .transport import AdapterUnderTest, redacted, side_effect_probe
+
+# Generous, because the adapter under test is a third party service the kit has
+# no other handle on: a slow honest answer must not read as a refusal.
+REQUEST_TIMEOUT_S = 30.0
+
+_USAGE_ERROR = 2
+_NONCONFORMANT = 1
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="curie-adapter-conformance",
+        description=(
+            "Check a running channel adapter against the Curie seven rule wire "
+            "floor. Exits 0 only when every machine checkable clause passed."
+        ),
+    )
+    parser.add_argument(
+        "--profile",
+        type=Path,
+        required=True,
+        help="Path to the adapter.yaml binding profile.",
+    )
+    parser.add_argument(
+        "--endpoint",
+        required=True,
+        help="The adapter's reply endpoint, the URL the worker POSTs events to.",
+    )
+    parser.add_argument(
+        "--secret-file",
+        type=Path,
+        help="Path to a file holding the egress secret. One of the two accepted sources.",
+    )
+    parser.add_argument(
+        "--secret-stdin",
+        action="store_true",
+        help="Read the egress secret from stdin, so it never touches disk.",
+    )
+    parser.add_argument(
+        "--driver",
+        help=(
+            "An ingress driver, as module:attr naming a zero argument factory. "
+            "Without it floor rules 1, 2 and 7 and clause 3b report not_run, and "
+            "not_run makes the verdict fail."
+        ),
+    )
+    parser.add_argument(
+        "--mode",
+        choices=("strict", "diagnostic"),
+        default="strict",
+        help=(
+            "strict is the only mode that can reach a passing verdict. diagnostic "
+            "reports partial results while building and never passes."
+        ),
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="as_json",
+        help="Emit the report as JSON instead of a human render.",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run one conformance check. ``None`` means read the process arguments.
+
+    The ``None`` default is the console script's calling convention: the
+    generated entry point invokes ``main()`` with no arguments. Every other
+    caller, this package's tests included, passes an explicit argument vector.
+    """
+
+    parser = build_parser()
+    args = parser.parse_args(None if argv is None else list(argv))
+
+    try:
+        raw = yaml.safe_load(args.profile.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError) as error:
+        print(f"the profile could not be read: {error}", file=sys.stderr)
+        return _USAGE_ERROR
+    if not isinstance(raw, dict):
+        print("the profile is not a YAML mapping", file=sys.stderr)
+        return _USAGE_ERROR
+    try:
+        profile = load_profile(raw)
+    except (ProfileVersionError, ValidationError) as error:
+        print(f"the profile is not usable: {error}", file=sys.stderr)
+        return _USAGE_ERROR
+
+    secret = _read_secret(args.secret_file, stdin=args.secret_stdin)
+    if secret is None:
+        return _USAGE_ERROR
+
+    driver: IngressDriver | None = None
+    if args.driver is not None:
+        try:
+            driver = _load_driver(args.driver)
+        except (ImportError, AttributeError, TypeError, ValueError) as error:
+            print(
+                f"the driver spec {args.driver!r} could not be resolved: {error}. "
+                "Without a driver rules 1, 2 and 7 would silently report not_run, "
+                "so a typo is refused rather than run around.",
+                file=sys.stderr,
+            )
+            return _USAGE_ERROR
+
+    adapter = AdapterUnderTest(
+        endpoint=args.endpoint,
+        secret=secret,
+        kind=profile.kind,
+        address=profile.address.example,
+        timeout_s=REQUEST_TIMEOUT_S,
+    )
+    report = run_floor(
+        adapter,
+        driver=driver,
+        side_effect_probe=side_effect_probe(adapter),
+        mode=cast(FloorMode, args.mode),
+    )
+    if args.as_json:
+        print(json.dumps(report.model_dump(mode="json"), indent=2))
+    else:
+        print(f"adapter endpoint: {redacted(adapter.endpoint)}")
+        print(report.detail())
+    return 0 if report.automated_floor == "pass" else _NONCONFORMANT
+
+
+def _read_secret(secret_file: Path | None, *, stdin: bool) -> str | None:
+    """The egress secret, from the invocation boundary or nowhere."""
+
+    if secret_file is not None and stdin:
+        print(
+            "pass exactly one of --secret-file and --secret-stdin", file=sys.stderr
+        )
+        return None
+    if secret_file is not None:
+        return secret_file.read_text(encoding="utf-8").strip()
+    if stdin:
+        return sys.stdin.read().strip()
+    print(
+        "the egress secret must be supplied at the invocation boundary: pass "
+        "--secret-file PATH or --secret-stdin. credentials.egress_secret_env in the "
+        "profile documents what the ADAPTER reads and is never resolved here, so a "
+        "profile can never choose which of your secrets gets read or where it is sent.",
+        file=sys.stderr,
+    )
+    return None
+
+
+def _load_driver(spec: str) -> IngressDriver:
+    """Resolve ``module:attr`` to a driver by calling the named factory."""
+
+    module_name, separator, attribute = spec.partition(":")
+    if not separator or not module_name or not attribute:
+        raise ValueError("a driver spec is module:attr naming a zero argument factory")
+    module = importlib.import_module(module_name)
+    factory = getattr(module, attribute)
+    return cast(IngressDriver, factory())

--- a/packages/channel-protocol/src/channel_protocol/conformance/driver.py
+++ b/packages/channel-protocol/src/channel_protocol/conformance/driver.py
@@ -1,0 +1,90 @@
+"""The vendor supplied ingress driver, and the correlation handshake (#1516).
+
+Floor rules 1, 2 and 7, and clause 3b, are about what an adapter does with its
+OWN upstream: a stable delivery id across a retry, a response treated as final,
+a stale ingress credential survived, an egress secret unset. Nothing the kit can
+reach over the adapter's egress endpoint provokes any of those, so the adapter's
+author implements this Protocol once, in their own repo, and the kit drives it.
+
+Without a driver those rules report ``not_run``, and ``not_run`` is
+nonconformant. There is no shape of run in which missing evidence reads as a
+pass.
+
+**The correlation rule is the load bearing half.** ``stimulate`` returns the
+``delivery_id`` the adapter will put on the wire for the message it just
+injected, and ``FakeIngress`` correlates an observed POST to that stimulus by
+matching the body's ``delivery_id`` against it. Correlation is therefore a
+property of the OBSERVED WIRE and never of private in process state, which is
+the only form an adapter in another process or another language can satisfy. A
+``stimulate`` that returns an id the adapter never sends is itself a finding:
+rules 1 and 2 fail naming the identity nothing matched, because reading a driver
+that does not implement the contract as conformant would certify every broken
+vendor driver along with it.
+"""
+
+from __future__ import annotations
+
+from types import EllipsisType
+from typing import Protocol
+
+from pydantic import BaseModel, ConfigDict
+
+
+class UpstreamIdentity(BaseModel):
+    """One injected upstream message, in the two terms the kit needs.
+
+    ``stimulus_id`` is the kit's own label, for reporting. ``delivery_id`` is
+    the contract: whatever the adapter will send for this message, this is it.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    stimulus_id: str
+    delivery_id: str
+
+
+class IngressDriver(Protocol):
+    """What an adapter author implements so the ingress rules can be decided.
+
+    ``restart`` uses Ellipsis as the UNCHANGED sentinel, because both credential
+    arguments need a three way choice and ``None`` already means "unset". Clause
+    3b calls ``restart(egress_secret=None)`` to prove the adapter refuses to
+    serve with no secret of its own; rule 7 calls ``restart(token=fresh)`` to
+    supply an operator issued replacement, and must not disturb the egress
+    secret while doing it. Not passing an argument leaves that credential alone.
+    """
+
+    def start(self, *, ingress_url: str, token: str) -> None:
+        """Point the running adapter at this ingress. CONFIGURATION ONLY.
+
+        No adapter modification: an adapter that has to be edited to be checked
+        is not the adapter the operator runs.
+        """
+        ...
+
+    def stimulate(self) -> UpstreamIdentity:
+        """Deliver one upstream message, and declare the id it will carry."""
+        ...
+
+    def set_transport(self, *, reachable: bool) -> None:
+        """Break, or restore, the adapter's path to ingress.
+
+        Rule 1 is about retrying a TRANSPORT failure with the same delivery id,
+        so the failure has to be provoked below the response layer. Breaking it
+        here rather than at the ingress is deliberate: a failure the ingress
+        answered is a response, and a response is final under rule 2.
+        """
+        ...
+
+    def restart(
+        self,
+        *,
+        egress_secret: str | None | EllipsisType = ...,
+        token: str | None | EllipsisType = ...,
+    ) -> None:
+        """Restart the adapter, optionally replacing one credential."""
+        ...
+
+    def stop(self) -> None:
+        """Stop the adapter. Called once, at the end of a run."""
+        ...

--- a/packages/channel-protocol/src/channel_protocol/conformance/driver.py
+++ b/packages/channel-protocol/src/channel_protocol/conformance/driver.py
@@ -97,6 +97,19 @@ class IngressDriver(Protocol):
         working: a verdict taken on a timer is a verdict any retry schedule
         evades by being slower than the timer. A driver that never reports an
         identity retired leaves the rule nonpassing rather than passing.
+
+        **"Retired" means no attempt remains scheduled, not that the active
+        queue is empty.** A delivery removed from the queue with a retry sitting
+        on a timer is NOT retired, and reporting it as such is the naive
+        implementation this kit exists to catch. The kit keeps watching after
+        the claim and fails the rule, naming the harness, if a post for the
+        identity arrives afterwards, so an over eager answer here produces a
+        loud failure rather than a quiet pass.
+
+        Like every method on this Protocol it is called under a hard timeout and
+        must RETURN. Blocking, here or anywhere else in this interface, is
+        reported as a harness defect: a callback that never answers would
+        otherwise turn a verdict into a hang, which tells its reader nothing.
         """
         ...
 

--- a/packages/channel-protocol/src/channel_protocol/conformance/driver.py
+++ b/packages/channel-protocol/src/channel_protocol/conformance/driver.py
@@ -10,16 +10,30 @@ Without a driver those rules report ``not_run``, and ``not_run`` is
 nonconformant. There is no shape of run in which missing evidence reads as a
 pass.
 
-**The correlation rule is the load bearing half.** ``stimulate`` returns the
-``delivery_id`` the adapter will put on the wire for the message it just
-injected, and ``FakeIngress`` correlates an observed POST to that stimulus by
-matching the body's ``delivery_id`` against it. Correlation is therefore a
+**The correlation rule is the load bearing half.** ``reserve`` returns the
+``delivery_id`` the adapter will put on the wire for a message that has not been
+injected yet, and ``FakeIngress`` correlates an observed POST to that stimulus
+by matching the body's ``delivery_id`` against it. Correlation is therefore a
 property of the OBSERVED WIRE and never of private in process state, which is
 the only form an adapter in another process or another language can satisfy. A
-``stimulate`` that returns an id the adapter never sends is itself a finding:
+``reserve`` that returns an id the adapter never sends is itself a finding:
 rules 1 and 2 fail naming the identity nothing matched, because reading a driver
 that does not implement the contract as conformant would certify every broken
 vendor driver along with it.
+
+**Injection is two phase, and that is not a convenience.** Rule 2 has to arm the
+ingress to answer 202 for ONE named identity before that identity can reach it.
+A single call that both injects and declares leaves a window in which the
+message is already in flight, so the kit would have to arm a global one shot
+instead, and any other delivery arriving first would consume it. The rule then
+passes without the declared delivery ever receiving the response whose finality
+it is about. So ``reserve`` declares and ``release`` injects, in that order.
+
+**Quiescence is declared, never assumed.** No finite observation establishes
+that an adapter has stopped retrying, so ``settled`` is what retires a stimulus,
+and a driver that cannot answer it leaves rule 2 with no finality evidence and
+therefore nonpassing. A fixed wall clock window in its place would be a check
+any retry schedule evades by outlasting it.
 """
 
 from __future__ import annotations
@@ -62,17 +76,27 @@ class IngressDriver(Protocol):
         """
         ...
 
-    def stimulate(self) -> UpstreamIdentity:
-        """Deliver one upstream message, and declare the id it will carry."""
+    def reserve(self) -> UpstreamIdentity:
+        """Declare the id the NEXT released message will carry. Injects nothing.
+
+        Called before ``release``, so the kit can arm its ingress for this exact
+        identity while the message is still nowhere near the wire.
+        """
         ...
 
-    def set_transport(self, *, reachable: bool) -> None:
-        """Break, or restore, the adapter's path to ingress.
+    def release(self, identity: UpstreamIdentity) -> None:
+        """Deliver the message ``reserve`` declared. Injects, declares nothing."""
+        ...
 
-        Rule 1 is about retrying a TRANSPORT failure with the same delivery id,
-        so the failure has to be provoked below the response layer. Breaking it
-        here rather than at the ingress is deliberate: a failure the ingress
-        answered is a response, and a response is final under rule 2.
+    def settled(self, identity: UpstreamIdentity) -> bool:
+        """Whether the adapter has retired this delivery and will not retry it.
+
+        True once the adapter is done with the identity, whether it delivered it
+        or gave up on it. Rule 2 asks whether a response was treated as final,
+        and that question is only answerable once the adapter has stopped
+        working: a verdict taken on a timer is a verdict any retry schedule
+        evades by being slower than the timer. A driver that never reports an
+        identity retired leaves the rule nonpassing rather than passing.
         """
         ...
 

--- a/packages/channel-protocol/src/channel_protocol/conformance/floor.py
+++ b/packages/channel-protocol/src/channel_protocol/conformance/floor.py
@@ -599,11 +599,25 @@ def _rule_6(adapter: AdapterUnderTest, probe: Callable[[], int] | None) -> Floor
 
 
 def _clause_6(adapter: AdapterUnderTest, probe: Callable[[], int] | None) -> ClauseResult:
-    """A duplicate completion is acked but answered ONCE.
+    """A duplicate completion is acked but answered ONCE, and a finished
+    conversation still accepts a further completion.
 
-    Wire indistinguishable, which is the whole reason this needs a probe: an
-    adapter that answers the correspondent twice returns 200 to both posts,
-    exactly like one that suppressed the duplicate.
+    The first half is wire indistinguishable, which is the whole reason this
+    needs a probe: an adapter that answers the correspondent twice returns 200
+    to both posts, exactly like one that suppressed the duplicate.
+
+    The second half is about the SAME conversation, and it has to be, or it is
+    not the rule. The kit drives one conversation to a completed state through
+    the ordinary path, then posts another completion for THAT conversation
+    under a NEW event_id. Sending a fresh conversation instead would probe
+    whether the adapter tolerates a completion it has never seen, which no floor
+    rule asks for and which every adapter that fails this one still passes.
+
+    A new event_id on a finished conversation is ordinary traffic rather than a
+    redelivery: a conversation with more than one turn produces exactly this,
+    and so does a sweeper draining a record after an outage. An adapter that
+    treats its own retirement of a conversation as final breaks the platform
+    here, and it answers the duplicate perfectly while doing it.
     """
 
     if probe is None:
@@ -613,17 +627,20 @@ def _clause_6(adapter: AdapterUnderTest, probe: Callable[[], int] | None) -> Cla
             "no side effect probe was supplied, and both acks are 2xx whether or not "
             "the duplicate was suppressed",
         )
+    conversation = new_conversation_id()
     completed = turn_completed(
-        adapter, conversation_id=new_conversation_id(), event_id=new_event_id()
+        adapter, conversation_id=conversation, event_id=new_event_id()
     )
     try:
         before = probe()
         first = adapter.post_event(completed, secret=adapter.secret)
         second = adapter.post_event(completed, secret=adapter.secret)
         after = probe()
+        # The same conversation, which the two posts above have now finished,
+        # receiving a further completion under an event_id it has never seen.
         finished = adapter.post_event(
             turn_completed(
-                adapter, conversation_id=new_conversation_id(), event_id=new_event_id()
+                adapter, conversation_id=conversation, event_id=new_event_id()
             ),
             secret=adapter.secret,
         )
@@ -641,13 +658,16 @@ def _clause_6(adapter: AdapterUnderTest, probe: Callable[[], int] | None) -> Cla
         )
     if not _is_2xx(finished.status):
         problems.append(
-            f"answered {finished.status} to a turn.completed for a conversation it "
-            "has never seen"
+            f"answered {finished.status} to a further turn.completed for a "
+            "conversation it had already finished, so a later turn on a retired "
+            "conversation, and a sweeper draining a record after an outage, both "
+            "break against this adapter"
         )
     return _verdict(
         "6",
         problems,
-        f"a duplicate event_id moved the side effect count by {after - before}",
+        f"a duplicate event_id moved the side effect count by {after - before}, and a "
+        "further completion for the conversation it had just finished was accepted",
     )
 
 

--- a/packages/channel-protocol/src/channel_protocol/conformance/floor.py
+++ b/packages/channel-protocol/src/channel_protocol/conformance/floor.py
@@ -35,13 +35,14 @@ instead, and neither ever reads as ``pass``.
 from __future__ import annotations
 
 import json
+import threading
 import time
 from collections.abc import Callable
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict
 
-from .driver import IngressDriver
+from .driver import IngressDriver, UpstreamIdentity
 from .ingress import NO_RESPONSE, TURNS_PATH, FakeIngress, ObservedRequest
 from .transport import (
     MAX_ACK_BODY_BYTES,
@@ -70,22 +71,24 @@ _ARRIVAL_TIMEOUT_S = 15.0
 # rule 2 nonpassing.
 _QUIESCENCE_TIMEOUT_S = 20.0
 
-# A confirmation window AFTER the driver reported the delivery retired, so a
-# driver that retires an identity its adapter is still attempting is caught.
-# Deliberately short, because it is a check on the driver's claim and not the
-# evidence the verdict rests on.
-_POST_QUIESCENCE_S = 0.5
+# The hard bound on ANY vendor supplied driver callback. A callback that does
+# not answer is a harness defect and is reported as one; it is never allowed to
+# become a hang, because a hang reads as a slow test rather than as a broken
+# adapter and therefore tells nobody anything.
+_DRIVER_CALLBACK_TIMEOUT_S = 5.0
 
-# How long a side effect count has to hold still before the kit reads it as
-# final. The refusal and the side effect an adapter performs anyway are two
-# different events, and an adapter that answers 401 first and acts afterwards
-# is exactly what clause 3a exists to catch, so an immediate read is a read of
-# the wrong moment.
-_SIDE_EFFECT_QUIET_S = 1.0
-
-# The ceiling on that settling. A count that never stops moving is its own
-# finding, and the clause says so rather than waiting forever.
-_SIDE_EFFECT_SETTLE_TIMEOUT_S = 10.0
+# The one observation window this kit uses for every negative assertion, and
+# the reason there is only one of it: three bespoke constants were three
+# separate things to outlast.
+#
+# It is a DETECTOR window, not an inference window, and the difference is the
+# whole fix. The old shape asked "has anything happened recently" and concluded
+# from a quiet interval that nothing further ever would, which is not something
+# a timer can establish. This one runs AFTER a barrier that claims the work is
+# finished, and treats anything it sees as a failure of that claim, named and
+# attributed. A pass therefore reports what was actually observed rather than
+# an inference from silence, and the clause details say exactly that.
+_GRACE_S = 1.8
 
 # How long the kit lets a 401 settle before asking whether the adapter is still
 # serving. An adapter that treats a stale credential as fatal takes a moment to
@@ -218,7 +221,9 @@ def run_floor(
         if driver is not None:
             ingress = FakeIngress(kind=adapter.kind, address=adapter.address)
             ingress.start()
-            driver.start(ingress_url=ingress.url, token=ingress.token)
+            _bounded_call(
+                "start", lambda: driver.start(ingress_url=ingress.url, token=ingress.token)
+            )
         results = [
             _rule_3(adapter, driver, side_effect_probe),
             _rule_4(adapter),
@@ -233,13 +238,26 @@ def run_floor(
             # identity the kit never declared) is provoked by an adapter's FIRST
             # successful delivery, so a rule that consumed that delivery first
             # would leave the control asserting nothing.
-            rule_2 = _rule_2(driver, ingress)
-            rule_1 = _rule_1(driver, ingress)
-            rule_7 = _rule_7(adapter, driver, ingress)
+            rule_2 = _guarded(
+                2, _RULE_2_TITLE, "2", lambda: _rule_2(driver, ingress)
+            )
+            rule_1 = _guarded(
+                1, _RULE_1_TITLE, "1", lambda: _rule_1(driver, ingress)
+            )
+            rule_7 = _guarded(
+                7, _RULE_7_TITLE, "7a", lambda: _rule_7(adapter, driver, ingress)
+            )
             results.extend([rule_1, rule_2, rule_7])
     finally:
         if driver is not None:
-            driver.stop()
+            # Bounded, and its fault swallowed: the report is already assembled,
+            # so there is no clause left to fail, and a driver that will not stop
+            # must not be able to hold the run open or to keep the ingress
+            # listener alive behind it.
+            try:
+                _bounded_call("the driver's stop()", driver.stop)
+            except _HarnessFault:
+                pass
         if ingress is not None:
             ingress.stop()
     results.sort(key=lambda result: result.rule)
@@ -301,38 +319,141 @@ def _is_2xx(status: int) -> bool:
     return 200 <= status < 300
 
 
-# --- rule 3: verify the egress secret before any side effect -----------------
+# --- the two mechanisms every negative assertion in this kit is built on ------
 
 
-def _settled_side_effects(probe: Callable[[], int]) -> int:
-    """The side effect count, read once it has stopped moving.
+class _HarnessFault(RuntimeError):
+    """A vendor callback that did not answer, or answered by raising.
 
-    A bare read is a read of the wrong moment. The response and the side effect
-    are two different events, and the break clause 3a exists to catch is exactly
-    an adapter that answers 401 first and performs the effect a moment later, so
-    a count sampled the instant the response lands agrees with a conformant
-    adapter's count. The barrier waits for the value to hold still, and the
-    quiet window RESTARTS every time it moves, so it is not a deadline an
-    adapter beats by being slower than a constant. A count that never settles is
-    reported as itself rather than waited on forever.
+    Covers both halves of the harness the vendor supplies: the ingress driver
+    and the side effect probe. Carried as an exception so no call site can
+    forget it, and reported as a clause FAILURE naming the harness. Both are
+    written by the same party as the adapter, so this is rarely malice: it is a
+    vendor implementing a callback naively, and the outcome that must never
+    happen is that they read a pass and ship.
 
-    A vendor probe is expected to be a barrier of its own, returning only once
-    work spawned by preceding requests has quiesced. This is what the kit can
-    enforce without taking the probe's word for it.
+    ``reason`` is the bare cause, so a caller closer to the failure can say
+    where it happened without quoting a whole sentence inside its own.
     """
 
-    deadline = time.monotonic() + _SIDE_EFFECT_SETTLE_TIMEOUT_S
-    count = probe()
-    quiet_until = time.monotonic() + _SIDE_EFFECT_QUIET_S
-    while time.monotonic() < deadline:
+    def __init__(self, message: str, *, reason: str) -> None:
+        super().__init__(message)
+        self.reason = reason
+
+
+def _bounded_call(what: str, call: Callable[[], Any]) -> Any:
+    """Run one vendor callback under a hard bound. Never inline.
+
+    The kit calls vendor callbacks inside timed rules, and a synchronous call to
+    one that blocks forever takes the whole run with it: the deadline the caller
+    thinks it has is never reached, because control never comes back to check
+    it. So every callback runs on a daemon thread that is joined with a timeout
+    and then ABANDONED. Abandoned deliberately: a blocked callback cannot be
+    made to return, and waiting for it during teardown would only move the hang
+    somewhere less visible. A daemon thread does not hold interpreter exit, so
+    the cost of abandoning it is bounded.
+
+    A callback that misses the bound is never retried. It has already shown it
+    does not answer, and polling it again would leak one blocked thread per
+    poll.
+
+    Raising is handled here too, and for the same reason: an exception out of
+    the middle of a clause aborts the whole report, so it becomes an
+    attributable clause failure instead.
+    """
+
+    outcome: dict[str, Any] = {}
+
+    def run() -> None:
+        try:
+            outcome["value"] = call()
+        except BaseException as error:  # noqa: BLE001
+            outcome["error"] = f"{type(error).__name__}: {error}"
+
+    worker = threading.Thread(target=run, daemon=True, name="conformance-callback")
+    worker.start()
+    worker.join(_DRIVER_CALLBACK_TIMEOUT_S)
+    if worker.is_alive():
+        reason = (
+            f"did not answer within {_DRIVER_CALLBACK_TIMEOUT_S} seconds, so it is "
+            "holding the kit rather than answering it"
+        )
+        raise _HarnessFault(
+            f"{what} {reason}. This is a defect in the harness rather than in the "
+            "adapter: every vendor callback has to return, and one that blocks turns "
+            "a verdict into a hang",
+            reason=reason,
+        )
+    if "error" in outcome:
+        reason = f"raised {outcome['error']}"
+        raise _HarnessFault(
+            f"{what} {reason}, so the kit could not reach a verdict. This is a defect "
+            "in the harness rather than in the adapter",
+            reason=reason,
+        )
+    return outcome.get("value")
+
+
+def _probe_reader(probe: Callable[[], int], clause_id: str) -> Callable[[], int]:
+    """The side effect probe, wrapped so a failure mid run is a clause failure.
+
+    Discovery only ever established that the probe answered ONCE. A probe that
+    starts failing partway through a run used to escape as an httpx error or a
+    KeyError out of the middle of a clause and abort the entire report, and the
+    observation windows read it many times per clause rather than twice, so
+    there are far more chances for it to happen. Same mechanism as the driver
+    callbacks, and the same reason: an unexpected condition becomes an
+    attributable failure, never an escaped exception and never a silent pass.
+    """
+
+    def read() -> int:
+        try:
+            return int(_bounded_call("the side effect probe", probe))
+        except _HarnessFault as fault:
+            raise _HarnessFault(
+                f"the side effect probe {fault.reason} while clause {clause_id} was "
+                "in flight, so the count this clause decides on is unreadable. This "
+                "is the probe endpoint rather than the adapter's reply handling: "
+                "discovery proved only that it answered once, and a clause reads it "
+                "many times",
+                reason=fault.reason,
+            ) from None
+
+    return read
+
+
+def _guarded(
+    rule: int, title: str, clause_id: str, run: Callable[[], FloorResult]
+) -> FloorResult:
+    """Run one ingress rule, turning a driver fault into a clause failure."""
+
+    try:
+        return run()
+    except _HarnessFault as fault:
+        return _result(rule, title, [_clause(clause_id, "fail", str(fault))])
+
+
+def _side_effects_after(
+    probe: Callable[[], int], baseline: int, *, allowed: int
+) -> tuple[int, bool]:
+    """Watch the side effect count for the grace window. Returns (worst, exceeded).
+
+    A DETECTOR, not an inference. The clause has already sent everything it is
+    going to send, so the question is not "has the count settled" but "does it
+    stay inside its allowance", and any excess is a failure the moment it
+    appears rather than a miss. Exits early on an excess, so the break costs
+    less than the control does.
+    """
+
+    deadline = time.monotonic() + _GRACE_S
+    worst = probe() - baseline
+    while worst <= allowed and time.monotonic() < deadline:
         time.sleep(_POLL_S)
-        current = probe()
-        if current != count:
-            count = current
-            quiet_until = time.monotonic() + _SIDE_EFFECT_QUIET_S
-        elif time.monotonic() >= quiet_until:
-            return count
-    return probe()
+        worst = max(worst, probe() - baseline)
+    return worst, worst > allowed
+
+
+# --- rule 3: verify the egress secret before any side effect -----------------
 
 
 def _rule_3(
@@ -378,42 +499,53 @@ def _clause_3a(adapter: AdapterUnderTest, probe: Callable[[], int] | None) -> Cl
             "effect and then returns 401 could not be told from one that refuses first",
         )
     conversation = new_conversation_id()
+    read = _probe_reader(probe, "3a")
     try:
-        accepted = adapter.post_event(
-            turn_status(adapter, conversation_id=conversation), secret=adapter.secret
-        )
-        if accepted.status in (401, 403):
-            return _clause(
-                "3a",
-                "fail",
-                f"the adapter answered {accepted.status} to its own configured secret, "
-                "so it refuses the platform rather than verifying it",
-            )
-        before = _settled_side_effects(probe)
+        # The refused requests go FIRST, before this clause has sent the adapter
+        # anything it would accept. That is what makes the baseline trustworthy
+        # without a drain: nothing the kit has sent can still be in flight, so
+        # any movement during the window below was caused by a refusal and by
+        # nothing else. Checking the adapter's own secret first would leave its
+        # legitimate effect racing the window and cost a false failure.
+        baseline = read()
         wrong = adapter.post_event(
             turn_status(adapter, conversation_id=conversation), secret=WRONG_SECRET
         )
         absent = adapter.post_event(
             turn_status(adapter, conversation_id=conversation), secret=None
         )
-        after = _settled_side_effects(probe)
+        leaked, exceeded = _side_effects_after(read, baseline, allowed=0)
+        accepted = adapter.post_event(
+            turn_status(adapter, conversation_id=conversation), secret=adapter.secret
+        )
     except AdapterUnreachableError as error:
         return _clause("3a", "fail", str(error))
+    except _HarnessFault as fault:
+        return _clause("3a", "fail", str(fault))
+    if accepted.status in (401, 403):
+        return _clause(
+            "3a",
+            "fail",
+            f"the adapter answered {accepted.status} to its own configured secret, "
+            "so it refuses the platform rather than verifying it",
+        )
     problems: list[str] = []
     if _is_2xx(wrong.status):
         problems.append(f"a wrong secret was accepted with {wrong.status}")
     if _is_2xx(absent.status):
         problems.append(f"an absent secret was accepted with {absent.status}")
-    if after != before:
+    if exceeded:
         problems.append(
-            f"the refused requests moved the side effect count from {before} to {after}, "
-            "so the side effect happened before the rejection"
+            f"the refused requests moved the side effect count by {leaked} within "
+            f"{_GRACE_S} seconds of the refusal, so the adapter answered the "
+            "correspondent and rejected the request afterwards"
         )
     return _verdict(
         "3a",
         problems,
         f"a wrong secret answered {wrong.status}, an absent one answered "
-        f"{absent.status}, and neither moved the side effect count",
+        f"{absent.status}, and the side effect count did not move in the "
+        f"{_GRACE_S} seconds after either",
     )
 
 
@@ -450,10 +582,11 @@ def _clause_3b(
             "unauthenticated request and then returns a refusal could not be told "
             "from one that refuses it outright",
         )
+    read = _probe_reader(probe, "3b")
     try:
-        driver.restart(egress_secret=None)
+        _bounded_call("the driver's restart()", lambda: driver.restart(egress_secret=None))
         try:
-            before = _settled_side_effects(probe)
+            baseline = read()
             with_secret = adapter.post_event(
                 turn_status(adapter, conversation_id=new_conversation_id()),
                 secret=adapter.secret,
@@ -461,7 +594,7 @@ def _clause_3b(
             without_secret = adapter.post_event(
                 turn_status(adapter, conversation_id=new_conversation_id()), secret=None
             )
-            after = _settled_side_effects(probe)
+            served, exceeded = _side_effects_after(read, baseline, allowed=0)
         except AdapterUnreachableError:
             return _clause(
                 "3b",
@@ -469,8 +602,19 @@ def _clause_3b(
                 "with its own egress secret unset the adapter stopped answering "
                 "entirely, which refuses every request",
             )
+    except _HarnessFault as fault:
+        return _clause("3b", "fail", str(fault))
     finally:
-        driver.restart(egress_secret=adapter.secret)
+        # Bounded too, and outside the fault handler above: a driver that cannot
+        # put the secret back leaves every later rule checking a deaf adapter,
+        # and it must not be able to hang the run while doing it.
+        try:
+            _bounded_call(
+                "the driver's restart()",
+                lambda: driver.restart(egress_secret=adapter.secret),
+            )
+        except _HarnessFault:
+            pass
     problems: list[str] = []
     if _is_2xx(with_secret.status):
         problems.append(
@@ -482,17 +626,18 @@ def _clause_3b(
             f"with its own secret unset the adapter accepted an unauthenticated "
             f"request with {without_secret.status}"
         )
-    if after != before:
+    if exceeded:
         problems.append(
             f"with its own secret unset the refused requests still moved the side "
-            f"effect count from {before} to {after}, so the adapter served them"
+            f"effect count by {served} within {_GRACE_S} seconds, so the adapter "
+            "served them and answered a refusal afterwards"
         )
     return _verdict(
         "3b",
         problems,
         f"with its own secret unset the adapter refused both requests "
-        f"({with_secret.status} and {without_secret.status}) and neither moved the "
-        "side effect count",
+        f"({with_secret.status} and {without_secret.status}) and the side effect "
+        f"count did not move in the {_GRACE_S} seconds after either",
     )
 
 
@@ -628,16 +773,22 @@ def _clause_6(adapter: AdapterUnderTest, probe: Callable[[], int] | None) -> Cla
             "the duplicate was suppressed",
         )
     conversation = new_conversation_id()
+    read = _probe_reader(probe, "6")
     completed = turn_completed(
         adapter, conversation_id=conversation, event_id=new_event_id()
     )
     try:
-        before = probe()
+        before = read()
         first = adapter.post_event(completed, secret=adapter.secret)
         second = adapter.post_event(completed, secret=adapter.secret)
-        after = probe()
+        # Watched, never sampled. An adapter that answers the redelivery 200 and
+        # hands the second correspondent effect to a queue looks identical to a
+        # deduping one at the instant the ack arrives, and the count it moves is
+        # the only evidence there is that it answered the correspondent twice.
+        moved, exceeded = _side_effects_after(read, before, allowed=1)
         # The same conversation, which the two posts above have now finished,
         # receiving a further completion under an event_id it has never seen.
+        # Sent after the window closes, so its own effect is never counted here.
         finished = adapter.post_event(
             turn_completed(
                 adapter, conversation_id=conversation, event_id=new_event_id()
@@ -646,15 +797,18 @@ def _clause_6(adapter: AdapterUnderTest, probe: Callable[[], int] | None) -> Cla
         )
     except AdapterUnreachableError as error:
         return _clause("6", "fail", str(error))
+    except _HarnessFault as fault:
+        return _clause("6", "fail", str(fault))
     problems: list[str] = []
     if not _is_2xx(first.status):
         problems.append(f"answered {first.status} to a turn.completed")
     if not _is_2xx(second.status):
         problems.append(f"answered {second.status} to a redelivered turn.completed")
-    if after - before > 1:
+    if exceeded:
         problems.append(
-            f"the duplicate event_id moved the side effect count by {after - before}, "
-            "so the correspondent was answered twice"
+            f"the duplicate event_id moved the side effect count by {moved} within "
+            f"{_GRACE_S} seconds of the redelivery, so the correspondent was "
+            "answered twice"
         )
     if not _is_2xx(finished.status):
         problems.append(
@@ -666,8 +820,9 @@ def _clause_6(adapter: AdapterUnderTest, probe: Callable[[], int] | None) -> Cla
     return _verdict(
         "6",
         problems,
-        f"a duplicate event_id moved the side effect count by {after - before}, and a "
-        "further completion for the conversation it had just finished was accepted",
+        f"a duplicate event_id moved the side effect count by {moved} over the "
+        f"{_GRACE_S} seconds after it, and a further completion for the conversation "
+        "it had just finished was accepted",
     )
 
 
@@ -738,6 +893,29 @@ def _framing_failure(
     )
 
 
+def _posts_after(
+    ingress: FakeIngress, since: int, delivery_id: str
+) -> list[ObservedRequest]:
+    """Any post of this identity that arrives during the grace window.
+
+    The counterpart of ``_side_effects_after`` on the ingress side, and the same
+    shape for the same reason: it looks for activity that should not exist
+    rather than concluding from quiet that none ever will. Exits early on the
+    first offender.
+    """
+
+    deadline = time.monotonic() + _GRACE_S
+    while True:
+        late = [
+            post
+            for post in _turn_posts(ingress, since)
+            if post.delivery_id == delivery_id
+        ]
+        if late or time.monotonic() >= deadline:
+            return late
+        time.sleep(_POLL_S)
+
+
 def _wait_for(predicate: Callable[[], bool], *, timeout_s: float) -> bool:
     deadline = time.monotonic() + timeout_s
     while time.monotonic() < deadline:
@@ -776,11 +954,11 @@ def _rule_1(driver: IngressDriver, ingress: FakeIngress) -> FloorResult:
     claim converges on the id and on nothing else.
     """
 
-    identity = driver.reserve()
+    identity: UpstreamIdentity = _bounded_call("the driver's reserve()", driver.reserve)
     ingress.arm_blackhole()
     mark = len(ingress.records())
     try:
-        driver.release(identity)
+        _bounded_call("the driver's release()", lambda: driver.release(identity))
         attempted = _wait_for(
             lambda: any(
                 post.status == NO_RESPONSE and post.delivery_id == identity.delivery_id
@@ -857,10 +1035,10 @@ def _rule_2(driver: IngressDriver, ingress: FakeIngress) -> FloorResult:
       with no finality evidence, and no evidence is never a pass.
     """
 
-    identity = driver.reserve()
+    identity: UpstreamIdentity = _bounded_call("the driver's reserve()", driver.reserve)
     ingress.arm_202(identity.delivery_id)
     mark = len(ingress.records())
-    driver.release(identity)
+    _bounded_call("the driver's release()", lambda: driver.release(identity))
     # Waited for on the DECLARED identity, never on "some post arrived": an
     # adapter with another delivery already in flight satisfies the weaker
     # predicate with the wrong message, and the rule would then decide the
@@ -881,7 +1059,8 @@ def _rule_2(driver: IngressDriver, ingress: FakeIngress) -> FloorResult:
         )
         return _result(2, _RULE_2_TITLE, [_clause("2", "fail", detail)])
     retired = _wait_for(
-        lambda: driver.settled(identity), timeout_s=_QUIESCENCE_TIMEOUT_S
+        lambda: bool(_bounded_call("the driver's settled()", lambda: driver.settled(identity))),
+        timeout_s=_QUIESCENCE_TIMEOUT_S,
     )
     if not retired:
         return _result(2, _RULE_2_TITLE, [
@@ -893,10 +1072,25 @@ def _rule_2(driver: IngressDriver, ingress: FakeIngress) -> FloorResult:
                 "has stopped attempting it and there is no finality to judge",
             )
         ])
-    # A short confirmation AFTER the driver's claim, never in place of it: this
-    # catches a driver that retires an identity its adapter is still retrying,
-    # rather than being the window the verdict rests on.
-    time.sleep(_POST_QUIESCENCE_S)
+    # The claim is on the record now, and everything after it is evidence ABOUT
+    # the claim rather than an inference from silence. A driver that reports an
+    # identity retired while its adapter still has an attempt scheduled is the
+    # naive implementation this kit exists to catch, and it used to buy a pass.
+    claim_mark = len(ingress.records())
+    late = _posts_after(ingress, claim_mark, identity.delivery_id)
+    if late:
+        return _result(2, _RULE_2_TITLE, [
+            _clause(
+                "2",
+                "fail",
+                f"the driver reported {identity.delivery_id} retired and the adapter "
+                f"posted it again {len(late)} time(s) within {_GRACE_S} seconds of "
+                "that claim. Both halves of the contract broke here: the adapter "
+                "treated a response as a retry signal, and the driver's settled() "
+                "declared quiescence while an attempt was still scheduled, so the "
+                "harness needs fixing as well as the adapter",
+            )
+        ])
     framing = _framing_failure(ingress, mark, "2")
     if framing is not None:
         # The rule's pass branch is a statement about a post the ingress did NOT
@@ -933,8 +1127,9 @@ def _rule_2(driver: IngressDriver, ingress: FakeIngress) -> FloorResult:
         _clause(
             "2",
             "pass",
-            f"ingress answered {matching[0].status} to {identity.delivery_id} and the "
-            "adapter retired it without posting it again",
+            f"ingress answered {matching[0].status} to {identity.delivery_id}, the "
+            f"driver reported it retired, and no further post for it arrived in the "
+            f"{_GRACE_S} seconds after that claim",
         )
     ])
 
@@ -958,9 +1153,9 @@ def _rule_7(
     """
 
     ingress.arm_401()
-    identity = driver.reserve()
+    identity: UpstreamIdentity = _bounded_call("the driver's reserve()", driver.reserve)
     mark = len(ingress.records())
-    driver.release(identity)
+    _bounded_call("the driver's release()", lambda: driver.release(identity))
     refused = _wait_for(
         lambda: any(
             post.status == 401 and post.delivery_id == identity.delivery_id
@@ -1017,7 +1212,7 @@ def _clause_7a(
             "treated a stale ingress credential as fatal",
         )
     resume_mark = len(ingress.records())
-    driver.restart(token=ingress.token)
+    _bounded_call("the driver's restart()", lambda: driver.restart(token=ingress.token))
     # The resumed post has to carry the DECLARED identity. Any later 2xx would
     # also be satisfied by an adapter that discarded the held delivery and then
     # posted something else entirely, and the clause would then report that the

--- a/packages/channel-protocol/src/channel_protocol/conformance/floor.py
+++ b/packages/channel-protocol/src/channel_protocol/conformance/floor.py
@@ -1,0 +1,850 @@
+"""The seven rule wire floor, as checks a third party can run on its adapter.
+
+``run_floor`` is the one entry point both front doors call. It returns a
+``FloorReport`` and never raises on a nonconformant adapter: a refusal is
+evidence, and the report is where evidence goes.
+
+**The verdict domain is the AUTOMATABLE clause set, and the field is named for
+exactly what it covers.** ``automated_floor`` answers one question, "did every
+machine checkable clause hold", and ``manual_review_required`` answers the
+other, "what did no machine check". Neither is allowed to swallow the other.
+There is no field named ``conformant`` at any depth of the output, because a
+boolean by that name is truthfully quotable as whole floor conformance while
+clause 3c was never asserted, and the name itself was the hole.
+
+**Missing evidence is never success.** Any automatable clause that is not
+``pass``, including ``not_run`` from an unsupplied driver or an adapter that
+exposes no side effect probe, makes ``automated_floor`` fail. There is no
+``partial`` and no ``skipped`` status: deleting them is what makes the rule
+structural rather than a label a later revision can relax.
+
+Two clauses are outside the domain and carry ``automatable=False``:
+
+* **3c, constant time comparison.** Two rejections that take different amounts
+  of wall time are indistinguishable from two rejections on a loaded box, and no
+  HTTP status carries the answer. An adapter that compares with ``==`` answers
+  every request exactly as one that uses ``hmac.compare_digest``.
+* **7c, the loud stale credential signal.** The adapter's operator has to LEARN
+  that its ingress token died. That signal is a log line, a metric or a page,
+  and none of them cross the wire the kit can see.
+
+Both are reported as ``not_run`` with the reason and what a human must read
+instead, and neither ever reads as ``pass``.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from collections.abc import Callable
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict
+
+from .driver import IngressDriver
+from .ingress import TURNS_PATH, FakeIngress, ObservedRequest
+from .transport import (
+    MAX_ACK_BODY_BYTES,
+    WRONG_SECRET,
+    AdapterUnderTest,
+    AdapterUnreachableError,
+    body_with_extra_key,
+    new_conversation_id,
+    new_event_id,
+    reply_post,
+    reply_update,
+    turn_completed,
+    turn_status,
+)
+
+FloorStatus = Literal["pass", "fail", "not_run"]
+FloorMode = Literal["strict", "diagnostic"]
+
+_STRICT = ConfigDict(extra="forbid")
+
+# How long a controlled transport outage lasts before the kit heals it. Long
+# enough that the adapter's first attempt has certainly failed, short enough
+# that a run does not become a sleep.
+_OUTAGE_S = 0.2
+
+# How long the kit waits for an adapter to reach the ingress at all.
+_ARRIVAL_TIMEOUT_S = 15.0
+
+# How long rule 2 watches for a SECOND post after ingress answered the first.
+# A response is final, so any further attempt for that delivery is the defect.
+_FINALITY_SETTLE_S = 0.5
+
+# How long the kit lets a 401 settle before asking whether the adapter is still
+# serving. An adapter that treats a stale credential as fatal takes a moment to
+# finish dying, and probing into that window would read a corpse as alive.
+_LIVENESS_SETTLE_S = 1.2
+
+# How long the kit waits for a held delivery to resume after an operator
+# supplied replacement token.
+_RESUME_TIMEOUT_S = 8.0
+
+_POLL_S = 0.02
+
+_EXTRA_KEY = "conformance_probe_unmodelled_key"
+
+
+class ClauseResult(BaseModel):
+    """One floor clause, and whether a machine could decide it at all."""
+
+    model_config = _STRICT
+
+    clause: str
+    status: FloorStatus
+    automatable: bool
+    detail: str
+
+
+class FloorResult(BaseModel):
+    """One floor rule, whose status is derived from its automatable clauses."""
+
+    model_config = _STRICT
+
+    rule: int
+    title: str
+    status: FloorStatus
+    clauses: list[ClauseResult]
+    detail: str
+
+
+class ManualReviewItem(BaseModel):
+    """A clause no black box check can decide, and what a human must read."""
+
+    model_config = _STRICT
+
+    clause: str
+    title: str
+    reason: str
+    how_to_review: str
+
+
+class FloorReport(BaseModel):
+    """The whole verdict, and everything the verdict does not cover."""
+
+    model_config = _STRICT
+
+    automated_floor: Literal["pass", "fail"]
+    manual_review_required: list[ManualReviewItem]
+    mode: FloorMode
+    counts: dict[str, int]
+    results: list[FloorResult]
+
+    def detail(self) -> str:
+        """The verdict and the manual review list, rendered together.
+
+        Together, always: a verdict printed on its own reads as more than it
+        covers, which is the failure this report's whole shape exists to stop.
+        """
+
+        counts = ", ".join(f"{name}: {value}" for name, value in sorted(self.counts.items()))
+        lines = [
+            f"automated_floor: {self.automated_floor} (mode: {self.mode})",
+            f"clause counts: {counts}",
+            "manual review required, decided by no machine:",
+        ]
+        for item in self.manual_review_required:
+            lines.append(f"  {item.clause} {item.title}")
+            lines.append(f"    why no check decides it: {item.reason}")
+            lines.append(f"    how to review it: {item.how_to_review}")
+        lines.append("rules:")
+        for result in self.results:
+            lines.append(f"  rule {result.rule} [{result.status}] {result.title}")
+            for clause in result.clauses:
+                lines.append(f"    {clause.clause} [{clause.status}] {clause.detail}")
+        return "\n".join(lines)
+
+
+MANUAL_REVIEW: tuple[ManualReviewItem, ...] = (
+    ManualReviewItem(
+        clause="3c",
+        title="the egress secret is compared in constant time",
+        reason=(
+            "a comparison that returns early and one that does not answer every "
+            "request identically, and wall time over a network is dominated by "
+            "scheduling noise, so no response the adapter can send carries the answer"
+        ),
+        how_to_review=(
+            "read the adapter's secret check and confirm it uses a constant time "
+            "primitive such as hmac.compare_digest, never == on the two strings"
+        ),
+    ),
+    ManualReviewItem(
+        clause="7c",
+        title="a stale ingress credential is signalled loudly",
+        reason=(
+            "the signal is for the adapter's own operator and lands in a log, a "
+            "metric or a page, so it never crosses the wire this kit observes"
+        ),
+        how_to_review=(
+            "arm a 401 from ingress and confirm the adapter emits a distinguishable "
+            "stale credential signal an operator would actually see, not a line "
+            "buried among ordinary delivery errors"
+        ),
+    ),
+)
+
+
+def run_floor(
+    adapter: AdapterUnderTest,
+    *,
+    driver: IngressDriver | None = None,
+    side_effect_probe: Callable[[], int] | None = None,
+    mode: FloorMode = "strict",
+) -> FloorReport:
+    """Check one running adapter against the seven rule floor.
+
+    ``driver`` is what makes rules 1, 2, 7 and clause 3b decidable, and
+    ``side_effect_probe`` is what makes clause 3a and rule 6 decidable. Omit
+    either and the clauses it covers report ``not_run``, which is nonconformant.
+    """
+
+    ingress: FakeIngress | None = None
+    try:
+        if driver is not None:
+            ingress = FakeIngress(kind=adapter.kind, address=adapter.address)
+            ingress.start()
+            driver.start(ingress_url=ingress.url, token=ingress.token)
+        results = [
+            _rule_3(adapter, driver, side_effect_probe),
+            _rule_4(adapter),
+            _rule_5(adapter),
+            _rule_6(adapter, side_effect_probe),
+        ]
+        if driver is None or ingress is None:
+            results.extend(_ingress_rules_not_run())
+        else:
+            # Rule 2 runs before rule 1 deliberately: it is the only rule whose
+            # false positive control (a legitimate upstream redelivery under an
+            # identity the kit never declared) is provoked by an adapter's FIRST
+            # successful delivery, so a rule that consumed that delivery first
+            # would leave the control asserting nothing.
+            rule_2 = _rule_2(driver, ingress)
+            rule_1 = _rule_1(driver, ingress)
+            rule_7 = _rule_7(adapter, driver, ingress)
+            results.extend([rule_1, rule_2, rule_7])
+    finally:
+        if driver is not None:
+            driver.stop()
+        if ingress is not None:
+            ingress.stop()
+    results.sort(key=lambda result: result.rule)
+    return _report(results, mode=mode)
+
+
+def _report(results: list[FloorResult], *, mode: FloorMode) -> FloorReport:
+    clauses = [clause for result in results for clause in result.clauses]
+    counts = {
+        status: sum(1 for clause in clauses if clause.status == status)
+        for status in ("pass", "fail", "not_run")
+    }
+    decided = all(
+        clause.status == "pass" for clause in clauses if clause.automatable
+    )
+    return FloorReport(
+        automated_floor="pass" if mode == "strict" and decided else "fail",
+        manual_review_required=list(MANUAL_REVIEW),
+        mode=mode,
+        counts=counts,
+        results=results,
+    )
+
+
+def _result(rule: int, title: str, clauses: list[ClauseResult]) -> FloorResult:
+    """Roll clauses up into a rule status over the AUTOMATABLE clauses only.
+
+    A rule carrying an unobservable clause would otherwise be permanently short
+    of pass, which is a verdict no correct adapter can reach and therefore a
+    verdict that carries no information.
+    """
+
+    automatable = [clause for clause in clauses if clause.automatable]
+    if any(clause.status == "fail" for clause in automatable):
+        status: FloorStatus = "fail"
+    elif any(clause.status == "not_run" for clause in automatable):
+        status = "not_run"
+    else:
+        status = "pass"
+    detail = "; ".join(f"{clause.clause} [{clause.status}] {clause.detail}" for clause in clauses)
+    return FloorResult(rule=rule, title=title, status=status, clauses=clauses, detail=detail)
+
+
+def _clause(clause: str, status: FloorStatus, detail: str) -> ClauseResult:
+    return ClauseResult(clause=clause, status=status, automatable=True, detail=detail)
+
+
+def _manual_clause(clause: str, detail: str) -> ClauseResult:
+    return ClauseResult(clause=clause, status="not_run", automatable=False, detail=detail)
+
+
+def _verdict(clause: str, problems: list[str], passed: str) -> ClauseResult:
+    if problems:
+        return _clause(clause, "fail", "; ".join(problems))
+    return _clause(clause, "pass", passed)
+
+
+def _is_2xx(status: int) -> bool:
+    return 200 <= status < 300
+
+
+# --- rule 3: verify the egress secret before any side effect -----------------
+
+
+def _rule_3(
+    adapter: AdapterUnderTest,
+    driver: IngressDriver | None,
+    probe: Callable[[], int] | None,
+) -> FloorResult:
+    return _result(
+        3,
+        "verify the egress secret on every request, before any side effect",
+        [
+            _clause_3a(adapter, probe),
+            _clause_3b(adapter, driver),
+            _manual_clause(
+                "3c",
+                "constant time comparison is not observable over HTTP; see "
+                "manual_review_required",
+            ),
+        ],
+    )
+
+
+def _clause_3a(adapter: AdapterUnderTest, probe: Callable[[], int] | None) -> ClauseResult:
+    """A wrong or absent secret is refused, AND causes no side effect.
+
+    The status alone is not enough and this is the exact hole it leaves: an
+    adapter that performs the side effect and then returns 401 answers
+    identically to a correct one. Only a side effect count separates them, so
+    without a probe this clause is ``not_run``.
+    """
+
+    if probe is None:
+        return _clause(
+            "3a",
+            "not_run",
+            "no side effect probe was supplied, so an adapter that performs the side "
+            "effect and then returns 401 could not be told from one that refuses first",
+        )
+    conversation = new_conversation_id()
+    try:
+        accepted = adapter.post_event(
+            turn_status(adapter, conversation_id=conversation), secret=adapter.secret
+        )
+        if accepted.status in (401, 403):
+            return _clause(
+                "3a",
+                "fail",
+                f"the adapter answered {accepted.status} to its own configured secret, "
+                "so it refuses the platform rather than verifying it",
+            )
+        before = probe()
+        wrong = adapter.post_event(
+            turn_status(adapter, conversation_id=conversation), secret=WRONG_SECRET
+        )
+        absent = adapter.post_event(
+            turn_status(adapter, conversation_id=conversation), secret=None
+        )
+        after = probe()
+    except AdapterUnreachableError as error:
+        return _clause("3a", "fail", str(error))
+    problems: list[str] = []
+    if _is_2xx(wrong.status):
+        problems.append(f"a wrong secret was accepted with {wrong.status}")
+    if _is_2xx(absent.status):
+        problems.append(f"an absent secret was accepted with {absent.status}")
+    if after != before:
+        problems.append(
+            f"the refused requests moved the side effect count from {before} to {after}, "
+            "so the side effect happened before the rejection"
+        )
+    return _verdict(
+        "3a",
+        problems,
+        f"a wrong secret answered {wrong.status}, an absent one answered "
+        f"{absent.status}, and neither moved the side effect count",
+    )
+
+
+def _clause_3b(adapter: AdapterUnderTest, driver: IngressDriver | None) -> ClauseResult:
+    """An adapter whose OWN egress secret is unset refuses everything.
+
+    Serving unauthenticated is worse than not serving: anyone who can reach the
+    endpoint could forge a completion. Restoring the real secret afterwards is
+    part of the clause, or every rule that runs later is checking a deaf adapter.
+    """
+
+    if driver is None:
+        return _clause(
+            "3b",
+            "not_run",
+            "no ingress driver was supplied, so the adapter could not be restarted "
+            "with its own egress secret unset",
+        )
+    try:
+        driver.restart(egress_secret=None)
+        try:
+            with_secret = adapter.post_event(
+                turn_status(adapter, conversation_id=new_conversation_id()),
+                secret=adapter.secret,
+            )
+            without_secret = adapter.post_event(
+                turn_status(adapter, conversation_id=new_conversation_id()), secret=None
+            )
+        except AdapterUnreachableError:
+            return _clause(
+                "3b",
+                "pass",
+                "with its own egress secret unset the adapter stopped answering "
+                "entirely, which refuses every request",
+            )
+    finally:
+        driver.restart(egress_secret=adapter.secret)
+    problems: list[str] = []
+    if _is_2xx(with_secret.status):
+        problems.append(
+            f"with its own secret unset the adapter still accepted a request with "
+            f"{with_secret.status}"
+        )
+    if _is_2xx(without_secret.status):
+        problems.append(
+            f"with its own secret unset the adapter accepted an unauthenticated "
+            f"request with {without_secret.status}"
+        )
+    return _verdict(
+        "3b",
+        problems,
+        f"with its own secret unset the adapter refused both requests "
+        f"({with_secret.status} and {without_secret.status})",
+    )
+
+
+# --- rule 4: the acknowledgement shape ---------------------------------------
+
+
+def _rule_4(adapter: AdapterUnderTest) -> FloorResult:
+    return _result(4, "answer 2xx with a JSON body under the ack cap, and never redirect", [
+        _clause_4(adapter),
+    ])
+
+
+def _clause_4(adapter: AdapterUnderTest) -> ClauseResult:
+    try:
+        response = adapter.post_event(
+            turn_status(adapter, conversation_id=new_conversation_id()), secret=adapter.secret
+        )
+    except AdapterUnreachableError as error:
+        return _clause("4", "fail", str(error))
+    problems: list[str] = []
+    if 300 <= response.status < 400:
+        problems.append(
+            f"answered {response.status}, a redirect, which the platform refuses to "
+            "follow rather than replaying the egress credential at the named origin"
+        )
+    elif not _is_2xx(response.status):
+        problems.append(f"answered {response.status}, which is a delivery failure")
+    if response.oversize:
+        problems.append(
+            f"answered with more than {MAX_ACK_BODY_BYTES} bytes, which the worker "
+            "refuses to buffer and treats as a failed delivery"
+        )
+    else:
+        try:
+            decoded = json.loads(response.body)
+        except ValueError:
+            problems.append(
+                f"the acknowledgement body is not JSON ({len(response.body)} bytes)"
+            )
+        else:
+            if not isinstance(decoded, dict):
+                problems.append("the acknowledgement body is not a JSON object")
+    return _verdict(
+        "4",
+        problems,
+        f"answered {response.status} with a JSON object of {len(response.body)} bytes",
+    )
+
+
+# --- rule 5: handle all four events, tolerate the unused ones -----------------
+
+
+def _rule_5(adapter: AdapterUnderTest) -> FloorResult:
+    return _result(5, "handle all four reply events, including the ones it does not use", [
+        _clause_5(adapter),
+    ])
+
+
+def _clause_5(adapter: AdapterUnderTest) -> ClauseResult:
+    """Every member of the four member union, plus one unmodelled extra key.
+
+    Only the four. The reply wire is a STRICT four member union, so a kit that
+    also sent an unknown discriminator would be asserting a requirement the
+    platform never made, and would teach authors to accept a shape the worker
+    cannot send. Forward event tolerance is a separate compatibility rule, not
+    something smuggled into the floor.
+    """
+
+    conversation = new_conversation_id()
+    events = (
+        turn_status(adapter, conversation_id=conversation),
+        reply_update(adapter, conversation_id=conversation),
+        reply_post(adapter, conversation_id=conversation),
+        turn_completed(
+            adapter, conversation_id=conversation, event_id=new_event_id()
+        ),
+    )
+    problems: list[str] = []
+    try:
+        for event in events:
+            response = adapter.post_event(event, secret=adapter.secret)
+            if not _is_2xx(response.status):
+                problems.append(f"answered {response.status} to {event.event}")
+        tolerant = adapter.post_body(
+            body_with_extra_key(
+                reply_update(adapter, conversation_id=conversation),
+                key=_EXTRA_KEY,
+                value="a key a later wire revision could add",
+            ),
+            secret=adapter.secret,
+        )
+    except AdapterUnreachableError as error:
+        return _clause("5", "fail", str(error))
+    if not _is_2xx(tolerant.status):
+        problems.append(
+            f"answered {tolerant.status} to a reply.update carrying one unmodelled "
+            "key, so a later optional field would break it"
+        )
+    return _verdict(
+        "5",
+        problems,
+        "all four events and an unmodelled extra key were accepted",
+    )
+
+
+# --- rule 6: dedupe on event_id ----------------------------------------------
+
+
+def _rule_6(adapter: AdapterUnderTest, probe: Callable[[], int] | None) -> FloorResult:
+    return _result(6, "dedupe on turn.completed event_id, and tolerate a finished "
+                      "conversation", [_clause_6(adapter, probe)])
+
+
+def _clause_6(adapter: AdapterUnderTest, probe: Callable[[], int] | None) -> ClauseResult:
+    """A duplicate completion is acked but answered ONCE.
+
+    Wire indistinguishable, which is the whole reason this needs a probe: an
+    adapter that answers the correspondent twice returns 200 to both posts,
+    exactly like one that suppressed the duplicate.
+    """
+
+    if probe is None:
+        return _clause(
+            "6",
+            "not_run",
+            "no side effect probe was supplied, and both acks are 2xx whether or not "
+            "the duplicate was suppressed",
+        )
+    completed = turn_completed(
+        adapter, conversation_id=new_conversation_id(), event_id=new_event_id()
+    )
+    try:
+        before = probe()
+        first = adapter.post_event(completed, secret=adapter.secret)
+        second = adapter.post_event(completed, secret=adapter.secret)
+        after = probe()
+        finished = adapter.post_event(
+            turn_completed(
+                adapter, conversation_id=new_conversation_id(), event_id=new_event_id()
+            ),
+            secret=adapter.secret,
+        )
+    except AdapterUnreachableError as error:
+        return _clause("6", "fail", str(error))
+    problems: list[str] = []
+    if not _is_2xx(first.status):
+        problems.append(f"answered {first.status} to a turn.completed")
+    if not _is_2xx(second.status):
+        problems.append(f"answered {second.status} to a redelivered turn.completed")
+    if after - before > 1:
+        problems.append(
+            f"the duplicate event_id moved the side effect count by {after - before}, "
+            "so the correspondent was answered twice"
+        )
+    if not _is_2xx(finished.status):
+        problems.append(
+            f"answered {finished.status} to a turn.completed for a conversation it "
+            "has never seen"
+        )
+    return _verdict(
+        "6",
+        problems,
+        f"a duplicate event_id moved the side effect count by {after - before}",
+    )
+
+
+# --- rules 1, 2 and 7: the ingress half --------------------------------------
+
+
+def _ingress_rules_not_run() -> list[FloorResult]:
+    """No driver means no evidence, and no evidence is never a pass."""
+
+    reason = (
+        "no ingress driver was supplied, so nothing could point the adapter at a "
+        "recording ingress or inject an upstream message"
+    )
+    return [
+        _result(1, _RULE_1_TITLE, [_clause("1", "not_run", reason)]),
+        _result(2, _RULE_2_TITLE, [_clause("2", "not_run", reason)]),
+        _result(
+            7,
+            _RULE_7_TITLE,
+            [
+                _clause("7a", "not_run", reason),
+                _clause("7b", "not_run", reason),
+                _manual_clause("7c", _MANUAL_7C_DETAIL),
+            ],
+        ),
+    ]
+
+
+_RULE_1_TITLE = "send a delivery_id that is stable across a retried transport failure"
+_RULE_2_TITLE = "treat any response from ingress as final, including 202"
+_RULE_7_TITLE = "survive a stale ingress credential and resume on a replacement"
+_MANUAL_7C_DETAIL = (
+    "a loud stale credential signal is not observable over the wire; see "
+    "manual_review_required"
+)
+
+
+def _turn_posts(ingress: FakeIngress, since: int) -> list[ObservedRequest]:
+    return [record for record in ingress.records()[since:] if record.path == TURNS_PATH]
+
+
+def _wait_for(predicate: Callable[[], bool], *, timeout_s: float) -> bool:
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(_POLL_S)
+    return False
+
+
+def _unmatched(declared: str, posts: list[ObservedRequest]) -> str:
+    observed = sorted({post.delivery_id or "<absent>" for post in posts})
+    return (
+        f"no observed delivery matched the declared upstream identity {declared}; "
+        f"the wire carried {observed}. Either the adapter derives its delivery_id "
+        "differently or the driver's stimulate does not return the id the adapter "
+        "will send, and both are findings"
+    )
+
+
+def _rule_1(driver: IngressDriver, ingress: FakeIngress) -> FloorResult:
+    """After a transport failure, the SAME delivery_id arrives.
+
+    The kit takes the transport down itself, so it knows a first attempt failed
+    without needing to observe it: the failure happened below the ingress and
+    was never answered, which is the only kind of failure rule 1 licenses a
+    retry for. What has to be observed is the id the retry carried, and it has
+    to be byte identical to the one the driver declared. A delivery_id minted
+    per attempt answers the correspondent once per retry, because the platform's
+    claim converges on the id and on nothing else.
+    """
+
+    driver.set_transport(reachable=False)
+    mark = len(ingress.records())
+    identity = driver.stimulate()
+    time.sleep(_OUTAGE_S)
+    driver.set_transport(reachable=True)
+    arrived = _wait_for(
+        lambda: any(_is_2xx(post.status) for post in _turn_posts(ingress, mark)),
+        timeout_s=_ARRIVAL_TIMEOUT_S,
+    )
+    posts = _turn_posts(ingress, mark)
+    if not arrived:
+        return _result(1, _RULE_1_TITLE, [
+            _clause(
+                "1",
+                "fail",
+                f"no delivery arrived after the transport was restored, so the "
+                f"adapter did not retry a transport failure; the declared identity "
+                f"was {identity.delivery_id}",
+            )
+        ])
+    if not any(post.delivery_id == identity.delivery_id for post in posts):
+        return _result(
+            1, _RULE_1_TITLE, [_clause("1", "fail", _unmatched(identity.delivery_id, posts))]
+        )
+    return _result(1, _RULE_1_TITLE, [
+        _clause(
+            "1",
+            "pass",
+            f"after a transport failure the adapter delivered {identity.delivery_id}, "
+            "byte identical to the identity it declared",
+        )
+    ])
+
+
+def _rule_2(driver: IngressDriver, ingress: FakeIngress) -> FloorResult:
+    """A 202 is a response, so it is final.
+
+    202 reads like an invitation to come back and it is not: another request
+    holds the claim, and the answer is already decided. The false positive
+    control is what makes the rule usable, because an upstream redelivery under
+    an identity the kit never declared is legitimate at least once behavior, so
+    the assertion is about THIS delivery id and not about post counts.
+    """
+
+    ingress.arm_202()
+    mark = len(ingress.records())
+    identity = driver.stimulate()
+    arrived = _wait_for(
+        lambda: bool(_turn_posts(ingress, mark)), timeout_s=_ARRIVAL_TIMEOUT_S
+    )
+    if not arrived:
+        return _result(2, _RULE_2_TITLE, [
+            _clause(
+                "2",
+                "fail",
+                f"no delivery arrived for the declared identity {identity.delivery_id}",
+            )
+        ])
+    if not any(
+        post.delivery_id == identity.delivery_id for post in _turn_posts(ingress, mark)
+    ):
+        return _result(2, _RULE_2_TITLE, [
+            _clause("2", "fail", _unmatched(identity.delivery_id, _turn_posts(ingress, mark)))
+        ])
+    time.sleep(_FINALITY_SETTLE_S)
+    matching = [
+        post
+        for post in _turn_posts(ingress, mark)
+        if post.delivery_id == identity.delivery_id
+    ]
+    if len(matching) > 1:
+        return _result(2, _RULE_2_TITLE, [
+            _clause(
+                "2",
+                "fail",
+                f"ingress answered {matching[0].status} and the adapter posted "
+                f"{identity.delivery_id} {len(matching)} times, so it treated a "
+                "response as a retry signal",
+            )
+        ])
+    return _result(2, _RULE_2_TITLE, [
+        _clause(
+            "2",
+            "pass",
+            f"ingress answered {matching[0].status} and the adapter did not post "
+            f"{identity.delivery_id} again",
+        )
+    ])
+
+
+def _rule_7(
+    adapter: AdapterUnderTest, driver: IngressDriver, ingress: FakeIngress
+) -> FloorResult:
+    """A 401 from ingress is not fatal, and the adapter never mints.
+
+    The adapter holds no platform key, so re minting is the trust boundary
+    breach and not the fix: an adapter that could mint would defeat both the
+    token TTL and the binding generation, which are the only two things standing
+    in for a revocation list. Conformant behavior is to hold the delivery, stay
+    alive, and deliver it once an operator supplies a replacement token.
+
+    That the resumed delivery carries a BYTE IDENTICAL delivery id is rule 1's
+    clause, not this one. An adapter that renames a delivery between attempts is
+    a rule 1 defect, and deciding it a second time here would report one break
+    twice while leaving this rule undecidable for every adapter whose restart
+    path attempts once before its ingress url is configured.
+    """
+
+    ingress.arm_401()
+    mark = len(ingress.records())
+    identity = driver.stimulate()
+    refused = _wait_for(
+        lambda: any(post.status == 401 for post in _turn_posts(ingress, mark)),
+        timeout_s=_ARRIVAL_TIMEOUT_S,
+    )
+    clause_7a = _clause_7a(adapter, driver, ingress, identity.delivery_id, mark, refused)
+    minted = ingress.mint_attempts()
+    mint_problems: list[str] = []
+    if minted:
+        mint_problems.append(
+            f"the adapter tried {minted} time(s) to mint its own replacement token, "
+            "which the platform refuses and which would defeat both the token TTL "
+            "and the binding generation"
+        )
+    clause_7b = _verdict(
+        "7b", mint_problems, "the adapter never tried to mint its own replacement token"
+    )
+    return _result(
+        7, _RULE_7_TITLE, [clause_7a, clause_7b, _manual_clause("7c", _MANUAL_7C_DETAIL)]
+    )
+
+
+def _clause_7a(
+    adapter: AdapterUnderTest,
+    driver: IngressDriver,
+    ingress: FakeIngress,
+    declared: str,
+    mark: int,
+    refused: bool,
+) -> ClauseResult:
+    if not refused:
+        return _clause(
+            "7a",
+            "fail",
+            f"no delivery reached the ingress to be refused; the declared identity "
+            f"was {declared}",
+        )
+    if not any(post.delivery_id == declared for post in _turn_posts(ingress, mark)):
+        return _clause("7a", "fail", _unmatched(declared, _turn_posts(ingress, mark)))
+    time.sleep(_LIVENESS_SETTLE_S)
+    if not _endpoint_answers(adapter):
+        return _clause(
+            "7a",
+            "fail",
+            "the egress endpoint stopped answering after the 401, so the adapter "
+            "treated a stale ingress credential as fatal",
+        )
+    resume_mark = len(ingress.records())
+    driver.restart(token=ingress.token)
+    resumed = _wait_for(
+        lambda: any(_is_2xx(post.status) for post in _turn_posts(ingress, resume_mark)),
+        timeout_s=_RESUME_TIMEOUT_S,
+    )
+    if not resumed:
+        return _clause(
+            "7a",
+            "fail",
+            f"the adapter survived the 401 but never delivered {declared} again after "
+            "an operator supplied a replacement token, so the in flight delivery was "
+            "discarded",
+        )
+    return _clause(
+        "7a",
+        "pass",
+        f"the adapter held {declared} through the 401, stayed alive, and delivered it "
+        "once a replacement token was supplied",
+    )
+
+
+def _endpoint_answers(adapter: AdapterUnderTest) -> bool:
+    """Whether the egress endpoint is still serving. Any status counts.
+
+    A refusal is still an answer: the question here is whether the process
+    survived, not whether it liked the request.
+    """
+
+    try:
+        adapter.post_event(
+            turn_status(adapter, conversation_id=new_conversation_id()),
+            secret=adapter.secret,
+        )
+    except AdapterUnreachableError:
+        return False
+    return True

--- a/packages/channel-protocol/src/channel_protocol/conformance/floor.py
+++ b/packages/channel-protocol/src/channel_protocol/conformance/floor.py
@@ -42,13 +42,12 @@ from typing import Literal
 from pydantic import BaseModel, ConfigDict
 
 from .driver import IngressDriver
-from .ingress import TURNS_PATH, FakeIngress, ObservedRequest
+from .ingress import NO_RESPONSE, TURNS_PATH, FakeIngress, ObservedRequest
 from .transport import (
     MAX_ACK_BODY_BYTES,
     WRONG_SECRET,
     AdapterUnderTest,
     AdapterUnreachableError,
-    body_with_extra_key,
     new_conversation_id,
     new_event_id,
     reply_post,
@@ -62,17 +61,31 @@ FloorMode = Literal["strict", "diagnostic"]
 
 _STRICT = ConfigDict(extra="forbid")
 
-# How long a controlled transport outage lasts before the kit heals it. Long
-# enough that the adapter's first attempt has certainly failed, short enough
-# that a run does not become a sleep.
-_OUTAGE_S = 0.2
-
 # How long the kit waits for an adapter to reach the ingress at all.
 _ARRIVAL_TIMEOUT_S = 15.0
 
-# How long rule 2 watches for a SECOND post after ingress answered the first.
-# A response is final, so any further attempt for that delivery is the defect.
-_FINALITY_SETTLE_S = 0.5
+# How long the kit waits for the driver to report a delivery RETIRED. This is
+# the finality barrier, and it is a bound on the driver's answer rather than a
+# window the verdict is taken at the end of: a driver that never answers leaves
+# rule 2 nonpassing.
+_QUIESCENCE_TIMEOUT_S = 20.0
+
+# A confirmation window AFTER the driver reported the delivery retired, so a
+# driver that retires an identity its adapter is still attempting is caught.
+# Deliberately short, because it is a check on the driver's claim and not the
+# evidence the verdict rests on.
+_POST_QUIESCENCE_S = 0.5
+
+# How long a side effect count has to hold still before the kit reads it as
+# final. The refusal and the side effect an adapter performs anyway are two
+# different events, and an adapter that answers 401 first and acts afterwards
+# is exactly what clause 3a exists to catch, so an immediate read is a read of
+# the wrong moment.
+_SIDE_EFFECT_QUIET_S = 1.0
+
+# The ceiling on that settling. A count that never stops moving is its own
+# finding, and the clause says so rather than waiting forever.
+_SIDE_EFFECT_SETTLE_TIMEOUT_S = 10.0
 
 # How long the kit lets a 401 settle before asking whether the adapter is still
 # serving. An adapter that treats a stale credential as fatal takes a moment to
@@ -84,8 +97,6 @@ _LIVENESS_SETTLE_S = 1.2
 _RESUME_TIMEOUT_S = 8.0
 
 _POLL_S = 0.02
-
-_EXTRA_KEY = "conformance_probe_unmodelled_key"
 
 
 class ClauseResult(BaseModel):
@@ -293,6 +304,37 @@ def _is_2xx(status: int) -> bool:
 # --- rule 3: verify the egress secret before any side effect -----------------
 
 
+def _settled_side_effects(probe: Callable[[], int]) -> int:
+    """The side effect count, read once it has stopped moving.
+
+    A bare read is a read of the wrong moment. The response and the side effect
+    are two different events, and the break clause 3a exists to catch is exactly
+    an adapter that answers 401 first and performs the effect a moment later, so
+    a count sampled the instant the response lands agrees with a conformant
+    adapter's count. The barrier waits for the value to hold still, and the
+    quiet window RESTARTS every time it moves, so it is not a deadline an
+    adapter beats by being slower than a constant. A count that never settles is
+    reported as itself rather than waited on forever.
+
+    A vendor probe is expected to be a barrier of its own, returning only once
+    work spawned by preceding requests has quiesced. This is what the kit can
+    enforce without taking the probe's word for it.
+    """
+
+    deadline = time.monotonic() + _SIDE_EFFECT_SETTLE_TIMEOUT_S
+    count = probe()
+    quiet_until = time.monotonic() + _SIDE_EFFECT_QUIET_S
+    while time.monotonic() < deadline:
+        time.sleep(_POLL_S)
+        current = probe()
+        if current != count:
+            count = current
+            quiet_until = time.monotonic() + _SIDE_EFFECT_QUIET_S
+        elif time.monotonic() >= quiet_until:
+            return count
+    return probe()
+
+
 def _rule_3(
     adapter: AdapterUnderTest,
     driver: IngressDriver | None,
@@ -303,7 +345,7 @@ def _rule_3(
         "verify the egress secret on every request, before any side effect",
         [
             _clause_3a(adapter, probe),
-            _clause_3b(adapter, driver),
+            _clause_3b(adapter, driver, probe),
             _manual_clause(
                 "3c",
                 "constant time comparison is not observable over HTTP; see "
@@ -320,6 +362,12 @@ def _clause_3a(adapter: AdapterUnderTest, probe: Callable[[], int] | None) -> Cl
     adapter that performs the side effect and then returns 401 answers
     identically to a correct one. Only a side effect count separates them, so
     without a probe this clause is ``not_run``.
+
+    Both counts are taken through the settling barrier rather than read off the
+    probe directly. The refusal and the effect are separate events, so an
+    adapter that answers 401 and acts a moment afterwards is indistinguishable
+    from a conformant one at the instant the response arrives, and reading the
+    count there is reading the wrong moment.
     """
 
     if probe is None:
@@ -341,14 +389,14 @@ def _clause_3a(adapter: AdapterUnderTest, probe: Callable[[], int] | None) -> Cl
                 f"the adapter answered {accepted.status} to its own configured secret, "
                 "so it refuses the platform rather than verifying it",
             )
-        before = probe()
+        before = _settled_side_effects(probe)
         wrong = adapter.post_event(
             turn_status(adapter, conversation_id=conversation), secret=WRONG_SECRET
         )
         absent = adapter.post_event(
             turn_status(adapter, conversation_id=conversation), secret=None
         )
-        after = probe()
+        after = _settled_side_effects(probe)
     except AdapterUnreachableError as error:
         return _clause("3a", "fail", str(error))
     problems: list[str] = []
@@ -369,12 +417,22 @@ def _clause_3a(adapter: AdapterUnderTest, probe: Callable[[], int] | None) -> Cl
     )
 
 
-def _clause_3b(adapter: AdapterUnderTest, driver: IngressDriver | None) -> ClauseResult:
+def _clause_3b(
+    adapter: AdapterUnderTest,
+    driver: IngressDriver | None,
+    probe: Callable[[], int] | None,
+) -> ClauseResult:
     """An adapter whose OWN egress secret is unset refuses everything.
 
     Serving unauthenticated is worse than not serving: anyone who can reach the
     endpoint could forge a completion. Restoring the real secret afterwards is
     part of the clause, or every rule that runs later is checking a deaf adapter.
+
+    "Refuses" is about the SIDE EFFECT and not only the status, exactly as in
+    clause 3a. An adapter that answers the correspondent and then returns 401
+    has served an unauthenticated request; its response says otherwise, and the
+    count is the only thing that separates the two. So this clause needs the
+    probe as much as 3a does, and without one it is ``not_run``.
     """
 
     if driver is None:
@@ -384,9 +442,18 @@ def _clause_3b(adapter: AdapterUnderTest, driver: IngressDriver | None) -> Claus
             "no ingress driver was supplied, so the adapter could not be restarted "
             "with its own egress secret unset",
         )
+    if probe is None:
+        return _clause(
+            "3b",
+            "not_run",
+            "no side effect probe was supplied, so an adapter that acts on an "
+            "unauthenticated request and then returns a refusal could not be told "
+            "from one that refuses it outright",
+        )
     try:
         driver.restart(egress_secret=None)
         try:
+            before = _settled_side_effects(probe)
             with_secret = adapter.post_event(
                 turn_status(adapter, conversation_id=new_conversation_id()),
                 secret=adapter.secret,
@@ -394,6 +461,7 @@ def _clause_3b(adapter: AdapterUnderTest, driver: IngressDriver | None) -> Claus
             without_secret = adapter.post_event(
                 turn_status(adapter, conversation_id=new_conversation_id()), secret=None
             )
+            after = _settled_side_effects(probe)
         except AdapterUnreachableError:
             return _clause(
                 "3b",
@@ -414,11 +482,17 @@ def _clause_3b(adapter: AdapterUnderTest, driver: IngressDriver | None) -> Claus
             f"with its own secret unset the adapter accepted an unauthenticated "
             f"request with {without_secret.status}"
         )
+    if after != before:
+        problems.append(
+            f"with its own secret unset the refused requests still moved the side "
+            f"effect count from {before} to {after}, so the adapter served them"
+        )
     return _verdict(
         "3b",
         problems,
         f"with its own secret unset the adapter refused both requests "
-        f"({with_secret.status} and {without_secret.status})",
+        f"({with_secret.status} and {without_secret.status}) and neither moved the "
+        "side effect count",
     )
 
 
@@ -478,12 +552,16 @@ def _rule_5(adapter: AdapterUnderTest) -> FloorResult:
 
 
 def _clause_5(adapter: AdapterUnderTest) -> ClauseResult:
-    """Every member of the four member union, plus one unmodelled extra key.
+    """Every member of the four member union, and only the four.
 
-    Only the four. The reply wire is a STRICT four member union, so a kit that
-    also sent an unknown discriminator would be asserting a requirement the
-    platform never made, and would teach authors to accept a shape the worker
-    cannot send. Forward event tolerance is a separate compatibility rule, not
+    The reply wire is a STRICT four member union, so a kit that also sent an
+    unknown discriminator would be asserting a requirement the platform never
+    made, and would teach authors to accept a shape the worker cannot send.
+
+    Rule 5 is about EVENTS: handle all four, and tolerate the ones this adapter
+    has no use for. It says nothing about unmodelled keys, and the kit does not
+    get to add to it. Forward tolerance, at the event level or the field level,
+    is a separate versioned compatibility rule with its own assertion, not
     something smuggled into the floor.
     """
 
@@ -502,25 +580,13 @@ def _clause_5(adapter: AdapterUnderTest) -> ClauseResult:
             response = adapter.post_event(event, secret=adapter.secret)
             if not _is_2xx(response.status):
                 problems.append(f"answered {response.status} to {event.event}")
-        tolerant = adapter.post_body(
-            body_with_extra_key(
-                reply_update(adapter, conversation_id=conversation),
-                key=_EXTRA_KEY,
-                value="a key a later wire revision could add",
-            ),
-            secret=adapter.secret,
-        )
     except AdapterUnreachableError as error:
         return _clause("5", "fail", str(error))
-    if not _is_2xx(tolerant.status):
-        problems.append(
-            f"answered {tolerant.status} to a reply.update carrying one unmodelled "
-            "key, so a later optional field would break it"
-        )
     return _verdict(
         "5",
         problems,
-        "all four events and an unmodelled extra key were accepted",
+        "all four reply events were accepted, including the ones this adapter "
+        "has no use for",
     )
 
 
@@ -623,6 +689,35 @@ def _turn_posts(ingress: FakeIngress, since: int) -> list[ObservedRequest]:
     return [record for record in ingress.records()[since:] if record.path == TURNS_PATH]
 
 
+def _framing_failure(
+    ingress: FakeIngress, since: int, clause_id: str
+) -> ClauseResult | None:
+    """A failure for any request in this window the ingress could not read.
+
+    Every ingress rule decides on which ``ObservedRequest`` values landed in its
+    window, and rule 2 and clause 7b decide on which ones did NOT. The adapter
+    under test writes its own request headers, so a request the ingress cannot
+    frame is a request the kit cannot attribute, and reading an unattributable
+    request as an absent one hands the adapter a switch over its own verdict.
+    Incomplete evidence is a failure of the rule whose window it landed in, the
+    same way missing evidence is never a pass anywhere else in this kit.
+    """
+
+    broken = [
+        record for record in ingress.records()[since:] if record.framing_error is not None
+    ]
+    if not broken:
+        return None
+    reasons = sorted({str(record.framing_error) for record in broken})
+    return _clause(
+        clause_id,
+        "fail",
+        f"the adapter sent {len(broken)} request(s) the ingress could not read "
+        f"({'; '.join(reasons)}), so those posts could not be attributed and this "
+        "rule would be deciding on evidence the adapter chose",
+    )
+
+
 def _wait_for(predicate: Callable[[], bool], *, timeout_s: float) -> bool:
     deadline = time.monotonic() + timeout_s
     while time.monotonic() < deadline:
@@ -637,7 +732,7 @@ def _unmatched(declared: str, posts: list[ObservedRequest]) -> str:
     return (
         f"no observed delivery matched the declared upstream identity {declared}; "
         f"the wire carried {observed}. Either the adapter derives its delivery_id "
-        "differently or the driver's stimulate does not return the id the adapter "
+        "differently or the driver's reserve does not return the id the adapter "
         "will send, and both are findings"
     )
 
@@ -645,33 +740,65 @@ def _unmatched(declared: str, posts: list[ObservedRequest]) -> str:
 def _rule_1(driver: IngressDriver, ingress: FakeIngress) -> FloorResult:
     """After a transport failure, the SAME delivery_id arrives.
 
-    The kit takes the transport down itself, so it knows a first attempt failed
-    without needing to observe it: the failure happened below the ingress and
-    was never answered, which is the only kind of failure rule 1 licenses a
-    retry for. What has to be observed is the id the retry carried, and it has
-    to be byte identical to the one the driver declared. A delivery_id minted
+    The failure is provoked at the KIT'S OWN ingress, which reads the request,
+    records it with the delivery id that was on it, and closes the connection
+    with nothing on it. That is a transport failure rather than a response, so
+    it is the only kind of failure rule 1 licenses a retry for, and it is the
+    only arrangement under which the kit can say the DECLARED delivery is the
+    one that met the outage. An outage arranged privately by the driver leaves
+    the kit sleeping for a fixed window instead, and an adapter whose first
+    attempt lands after that window is certified for a retry that never
+    happened, off a single successful post.
+
+    So the kit waits for the failed attempt rather than timing it, then heals
+    the transport and requires the SAME id to come back. A delivery_id minted
     per attempt answers the correspondent once per retry, because the platform's
     claim converges on the id and on nothing else.
     """
 
-    driver.set_transport(reachable=False)
+    identity = driver.reserve()
+    ingress.arm_blackhole()
     mark = len(ingress.records())
-    identity = driver.stimulate()
-    time.sleep(_OUTAGE_S)
-    driver.set_transport(reachable=True)
+    try:
+        driver.release(identity)
+        attempted = _wait_for(
+            lambda: any(
+                post.status == NO_RESPONSE and post.delivery_id == identity.delivery_id
+                for post in _turn_posts(ingress, mark)
+            ),
+            timeout_s=_ARRIVAL_TIMEOUT_S,
+        )
+    finally:
+        ingress.disarm_blackhole()
+    if not attempted:
+        seen = sorted(
+            {post.delivery_id or "<absent>" for post in _turn_posts(ingress, mark)}
+        )
+        return _result(1, _RULE_1_TITLE, [
+            _clause(
+                "1",
+                "fail",
+                f"the declared delivery {identity.delivery_id} never reached the "
+                "unavailable transport, so no failure occurred and there is no retry "
+                f"to judge; the wire carried {seen}",
+            )
+        ])
     arrived = _wait_for(
         lambda: any(_is_2xx(post.status) for post in _turn_posts(ingress, mark)),
         timeout_s=_ARRIVAL_TIMEOUT_S,
     )
-    posts = _turn_posts(ingress, mark)
+    posts = [post for post in _turn_posts(ingress, mark) if post.status != NO_RESPONSE]
+    framing = _framing_failure(ingress, mark, "1")
+    if framing is not None:
+        return _result(1, _RULE_1_TITLE, [framing])
     if not arrived:
         return _result(1, _RULE_1_TITLE, [
             _clause(
                 "1",
                 "fail",
-                f"no delivery arrived after the transport was restored, so the "
-                f"adapter did not retry a transport failure; the declared identity "
-                f"was {identity.delivery_id}",
+                f"the declared delivery {identity.delivery_id} met the unavailable "
+                "transport and nothing arrived once it was restored, so the adapter "
+                "did not retry a transport failure",
             )
         ])
     if not any(post.delivery_id == identity.delivery_id for post in posts):
@@ -696,34 +823,82 @@ def _rule_2(driver: IngressDriver, ingress: FakeIngress) -> FloorResult:
     control is what makes the rule usable, because an upstream redelivery under
     an identity the kit never declared is legitimate at least once behavior, so
     the assertion is about THIS delivery id and not about post counts.
+
+    Two properties carry the rule, and neither is a timer.
+
+    * The 202 is armed for the DECLARED identity and no other, which is why
+      injection is two phase. A global one shot is consumed by whichever
+      delivery reaches the ingress first, and the rule then passes on a declared
+      delivery that only ever saw a 200, having tested finality against nothing.
+    * The verdict is taken once the driver reports the delivery RETIRED, never
+      after a fixed settle. A fixed window is a check an adapter evades by
+      retrying more slowly than the window is wide, and no adapter has to be
+      hostile to do it. A driver that never retires the identity leaves the rule
+      with no finality evidence, and no evidence is never a pass.
     """
 
-    ingress.arm_202()
+    identity = driver.reserve()
+    ingress.arm_202(identity.delivery_id)
     mark = len(ingress.records())
-    identity = driver.stimulate()
+    driver.release(identity)
+    # Waited for on the DECLARED identity, never on "some post arrived": an
+    # adapter with another delivery already in flight satisfies the weaker
+    # predicate with the wrong message, and the rule would then decide the
+    # declared one absent before it had a chance to be sent.
     arrived = _wait_for(
-        lambda: bool(_turn_posts(ingress, mark)), timeout_s=_ARRIVAL_TIMEOUT_S
+        lambda: any(
+            post.delivery_id == identity.delivery_id
+            for post in _turn_posts(ingress, mark)
+        ),
+        timeout_s=_ARRIVAL_TIMEOUT_S,
     )
     if not arrived:
+        posts = _turn_posts(ingress, mark)
+        detail = (
+            f"no delivery arrived for the declared identity {identity.delivery_id}"
+            if not posts
+            else _unmatched(identity.delivery_id, posts)
+        )
+        return _result(2, _RULE_2_TITLE, [_clause("2", "fail", detail)])
+    retired = _wait_for(
+        lambda: driver.settled(identity), timeout_s=_QUIESCENCE_TIMEOUT_S
+    )
+    if not retired:
         return _result(2, _RULE_2_TITLE, [
             _clause(
                 "2",
                 "fail",
-                f"no delivery arrived for the declared identity {identity.delivery_id}",
+                f"the driver never reported {identity.delivery_id} retired within "
+                f"{_QUIESCENCE_TIMEOUT_S} seconds, so the kit cannot say the adapter "
+                "has stopped attempting it and there is no finality to judge",
             )
         ])
-    if not any(
-        post.delivery_id == identity.delivery_id for post in _turn_posts(ingress, mark)
-    ):
-        return _result(2, _RULE_2_TITLE, [
-            _clause("2", "fail", _unmatched(identity.delivery_id, _turn_posts(ingress, mark)))
-        ])
-    time.sleep(_FINALITY_SETTLE_S)
+    # A short confirmation AFTER the driver's claim, never in place of it: this
+    # catches a driver that retires an identity its adapter is still retrying,
+    # rather than being the window the verdict rests on.
+    time.sleep(_POST_QUIESCENCE_S)
+    framing = _framing_failure(ingress, mark, "2")
+    if framing is not None:
+        # The rule's pass branch is a statement about a post the ingress did NOT
+        # see, so an unreadable post inside the window is exactly what would
+        # make that statement false while leaving it true on the records.
+        return _result(2, _RULE_2_TITLE, [framing])
     matching = [
         post
         for post in _turn_posts(ingress, mark)
         if post.delivery_id == identity.delivery_id
     ]
+    still_armed = ingress.armed_202()
+    if still_armed is not None:
+        return _result(2, _RULE_2_TITLE, [
+            _clause(
+                "2",
+                "fail",
+                f"the ingress was armed to answer 202 for {still_armed} and that "
+                "delivery never arrived to receive it, so the adapter's handling of "
+                "an in flight claim was never exercised",
+            )
+        ])
     if len(matching) > 1:
         return _result(2, _RULE_2_TITLE, [
             _clause(
@@ -738,8 +913,8 @@ def _rule_2(driver: IngressDriver, ingress: FakeIngress) -> FloorResult:
         _clause(
             "2",
             "pass",
-            f"ingress answered {matching[0].status} and the adapter did not post "
-            f"{identity.delivery_id} again",
+            f"ingress answered {matching[0].status} to {identity.delivery_id} and the "
+            "adapter retired it without posting it again",
         )
     ])
 
@@ -763,13 +938,23 @@ def _rule_7(
     """
 
     ingress.arm_401()
+    identity = driver.reserve()
     mark = len(ingress.records())
-    identity = driver.stimulate()
+    driver.release(identity)
     refused = _wait_for(
-        lambda: any(post.status == 401 for post in _turn_posts(ingress, mark)),
+        lambda: any(
+            post.status == 401 and post.delivery_id == identity.delivery_id
+            for post in _turn_posts(ingress, mark)
+        ),
         timeout_s=_ARRIVAL_TIMEOUT_S,
     )
     clause_7a = _clause_7a(adapter, driver, ingress, identity.delivery_id, mark, refused)
+    # Computed after 7a, because the whole 401 window is what 7a spans, and the
+    # unreadable request is the more fundamental finding than whatever 7a
+    # concluded on the records it could read.
+    framing = _framing_failure(ingress, mark, "7a")
+    if framing is not None:
+        clause_7a = framing
     minted = ingress.mint_attempts()
     mint_problems: list[str] = []
     if minted:
@@ -813,17 +998,30 @@ def _clause_7a(
         )
     resume_mark = len(ingress.records())
     driver.restart(token=ingress.token)
+    # The resumed post has to carry the DECLARED identity. Any later 2xx would
+    # also be satisfied by an adapter that discarded the held delivery and then
+    # posted something else entirely, and the clause would then report that the
+    # held delivery resumed when it did not.
     resumed = _wait_for(
-        lambda: any(_is_2xx(post.status) for post in _turn_posts(ingress, resume_mark)),
+        lambda: any(
+            _is_2xx(post.status) and post.delivery_id == declared
+            for post in _turn_posts(ingress, resume_mark)
+        ),
         timeout_s=_RESUME_TIMEOUT_S,
     )
     if not resumed:
+        after_restart = sorted(
+            {
+                f"{post.delivery_id or '<absent>'}:{post.status}"
+                for post in _turn_posts(ingress, resume_mark)
+            }
+        )
         return _clause(
             "7a",
             "fail",
             f"the adapter survived the 401 but never delivered {declared} again after "
             "an operator supplied a replacement token, so the in flight delivery was "
-            "discarded",
+            f"discarded; after the restart the wire carried {after_restart}",
         )
     return _clause(
         "7a",

--- a/packages/channel-protocol/src/channel_protocol/conformance/ingress.py
+++ b/packages/channel-protocol/src/channel_protocol/conformance/ingress.py
@@ -1,0 +1,274 @@
+"""A stand in for the platform's ingress, with the platform's real semantics.
+
+This is PART OF THE KIT, not a mock of it. The ingress floor rules are decided
+against what this server answers, so anything it answers differently from
+``apps/api/src/curie_api/routers/channels.py`` is a rule decided against a
+fiction. The three semantics that matter, and why each one is here:
+
+* **The claim is keyed on the binding plus the delivery id, never the delivery
+  id alone.** The real API derives an ``event_id`` from the pair, so two inboxes
+  sharing an upstream id space cannot swallow each other's turns. Key on the id
+  alone and an author testing two addresses reads a false duplicate.
+* **An in flight claim answers 202 with a null ``stream_id``**, never the
+  ``pending:`` sentinel the API keeps internally. Answering the sentinel would
+  teach an author to parse a value production never sends.
+* **Minting is platform key only.** The adapter holds no platform key, so a mint
+  it attempts must be refused, exactly as production refuses it. A kit whose
+  fake handed out a token on request would certify the trust boundary breach it
+  exists to prevent: an adapter that can mint defeats both the token TTL and the
+  binding generation.
+
+Every request is recorded with the ``delivery_id`` that was ON THE WIRE. That
+is the whole correlation mechanism: a post is attributed to a stimulus by
+matching the declared ``UpstreamIdentity``, never by in process coordination, so
+an adapter in another process or another language is decidable on the same
+evidence.
+
+The server binds 127.0.0.1 on an ephemeral port and is torn down by ``stop``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import threading
+import time
+import uuid
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any, cast
+
+from pydantic import BaseModel, ConfigDict
+
+TURNS_PATH = "/channels/turns"
+TOKEN_PATH = "/channels/token"
+
+_API_KEY_HEADER = "X-API-Key"
+
+
+class ObservedRequest(BaseModel):
+    """One request this ingress answered, in the terms the floor reasons in.
+
+    Deliberately NOT the headers or the body: a recording is quoted into
+    reports and issues, and both carry credentials. The ``delivery_id`` is the
+    only body field any rule correlates on.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    path: str
+    delivery_id: str | None
+    status: int
+    at: float
+
+
+class _IngressServer(ThreadingHTTPServer):
+    daemon_threads = True
+    ingress: FakeIngress
+
+
+class _IngressHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+    server_version = "curie-conformance-ingress/1"
+
+    def log_message(self, fmt: str, *args: Any) -> None:
+        return
+
+    def do_POST(self) -> None:
+        ingress = cast(_IngressServer, self.server).ingress
+        length = int(self.headers.get("Content-Length") or 0)
+        body = self.rfile.read(length) if length else b""
+        route = self.path.split("?", 1)[0]
+        api_key = self.headers.get(_API_KEY_HEADER)
+        if route == TURNS_PATH:
+            status, payload = ingress.answer_turn(api_key, body)
+        elif route == TOKEN_PATH:
+            status, payload = ingress.answer_mint(api_key)
+        else:
+            status, payload = 404, {"detail": "no such route"}
+        encoded = json.dumps(payload).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(encoded)))
+        self.end_headers()
+        self.wfile.write(encoded)
+
+
+class FakeIngress:
+    """The platform's ingress, reduced to what the floor rules can observe.
+
+    ``kind`` and ``address`` name the binding this stands in for. They are
+    recorded and they form half the claim key; they are deliberately NOT
+    enforced, because no floor rule turns on the API's 404 for an unbound pair
+    and enforcing it would only add a way for a run to die early.
+    """
+
+    def __init__(self, *, kind: str, address: str) -> None:
+        self.kind = kind
+        self.address = address
+        self.platform_key = f"platform_key_{uuid.uuid4().hex}"
+        self.token = _new_token()
+        self._valid_tokens = {self.token}
+        self._claims: dict[tuple[str, str, str], str] = {}
+        self._records: list[ObservedRequest] = []
+        self._pending_202 = False
+        self._lock = threading.Lock()
+        self._server: _IngressServer | None = None
+        self._thread: threading.Thread | None = None
+        self._port = 0
+
+    # -- lifecycle ---------------------------------------------------------
+
+    @property
+    def url(self) -> str:
+        return f"http://127.0.0.1:{self._port}"
+
+    def start(self) -> None:
+        server = _IngressServer(("127.0.0.1", 0), _IngressHandler)
+        server.ingress = self
+        self._port = int(server.server_address[1])
+        self._server = server
+        self._thread = threading.Thread(target=server.serve_forever, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        server, self._server = self._server, None
+        thread, self._thread = self._thread, None
+        if server is not None:
+            server.shutdown()
+            server.server_close()
+        if thread is not None:
+            thread.join(timeout=5)
+
+    # -- arming ------------------------------------------------------------
+
+    def arm_401(self) -> None:
+        """Invalidate every outstanding token and issue a replacement.
+
+        This is what a rebind does in production: every binding write bumps the
+        generation unconditionally, so an adapter holding the old token starts
+        getting 401 and an operator has to hand it a new one. Rule 7 is about
+        what the adapter does in that window, so the fake reproduces the cause
+        rather than a global "answer 401 to everything" switch.
+        """
+
+        with self._lock:
+            self._valid_tokens.clear()
+            self.token = _new_token()
+            self._valid_tokens.add(self.token)
+
+    def arm_202(self) -> None:
+        """Answer the NEXT turn post as an in flight claim.
+
+        One shot, and provoked rather than raced: rule 2 needs a 202 to exist,
+        and waiting for a real concurrent claim race would make the rule flaky
+        without making it stronger.
+        """
+
+        with self._lock:
+            self._pending_202 = True
+
+    # -- observation -------------------------------------------------------
+
+    def records(self) -> tuple[ObservedRequest, ...]:
+        with self._lock:
+            return tuple(self._records)
+
+    def mint_attempts(self) -> int:
+        """How many times the adapter tried to mint its own token. Must be zero."""
+
+        with self._lock:
+            return sum(1 for record in self._records if record.path == TOKEN_PATH)
+
+    # -- the two routes ----------------------------------------------------
+
+    def answer_turn(self, api_key: str | None, body: bytes) -> tuple[int, dict[str, Any]]:
+        delivery_id, kind, address = _delivery_fields(body)
+        if api_key is None or api_key not in self._valid_tokens:
+            self._record(TURNS_PATH, delivery_id, 401)
+            return 401, {"detail": "missing, malformed, expired or stale credential"}
+        event_id = _event_id(kind, address, delivery_id)
+        with self._lock:
+            if self._pending_202:
+                self._pending_202 = False
+                status: int = 202
+                payload: dict[str, Any] = {
+                    "event_id": event_id,
+                    "stream_id": None,
+                    "duplicate": True,
+                }
+            else:
+                key = (kind, address, delivery_id or "")
+                claimed = self._claims.get(key)
+                if claimed is None:
+                    claimed = f"{int(time.time() * 1000)}-{len(self._claims)}"
+                    self._claims[key] = claimed
+                    status, payload = 200, {
+                        "event_id": event_id,
+                        "stream_id": claimed,
+                        "duplicate": False,
+                    }
+                else:
+                    status, payload = 200, {
+                        "event_id": event_id,
+                        "stream_id": claimed,
+                        "duplicate": True,
+                    }
+            self._records.append(
+                ObservedRequest(
+                    path=TURNS_PATH,
+                    delivery_id=delivery_id,
+                    status=status,
+                    at=time.monotonic(),
+                )
+            )
+        return status, payload
+
+    def answer_mint(self, api_key: str | None) -> tuple[int, dict[str, Any]]:
+        if api_key != self.platform_key:
+            self._record(TOKEN_PATH, None, 401)
+            return 401, {"detail": "minting a channel token requires the platform key"}
+        token = _new_token()
+        with self._lock:
+            self._valid_tokens.add(token)
+        self._record(TOKEN_PATH, None, 200)
+        return 200, {"token": token}
+
+    def _record(self, path: str, delivery_id: str | None, status: int) -> None:
+        with self._lock:
+            self._records.append(
+                ObservedRequest(
+                    path=path,
+                    delivery_id=delivery_id,
+                    status=status,
+                    at=time.monotonic(),
+                )
+            )
+
+
+def _new_token() -> str:
+    return f"chn_{uuid.uuid4().hex}"
+
+
+def _event_id(kind: str, address: str, delivery_id: str | None) -> str:
+    """The claim identity, over the BINDING plus the delivery id.
+
+    Never the delivery id alone: two adapters sharing an upstream id space would
+    otherwise swallow each other's turns.
+    """
+
+    digest = hashlib.sha256(
+        "\x00".join((kind, address, delivery_id or "")).encode()
+    ).hexdigest()
+    return f"evt_{digest[:32]}"
+
+
+def _delivery_fields(body: bytes) -> tuple[str | None, str, str]:
+    try:
+        decoded = json.loads(body) if body else None
+    except ValueError:
+        decoded = None
+    if not isinstance(decoded, dict):
+        return None, "", ""
+    raw = decoded.get("delivery_id")
+    delivery_id = str(raw) if isinstance(raw, str) and raw else None
+    return delivery_id, str(decoded.get("kind", "")), str(decoded.get("address", ""))

--- a/packages/channel-protocol/src/channel_protocol/conformance/ingress.py
+++ b/packages/channel-protocol/src/channel_protocol/conformance/ingress.py
@@ -24,6 +24,15 @@ matching the declared ``UpstreamIdentity``, never by in process coordination, so
 an adapter in another process or another language is decidable on the same
 evidence.
 
+**Every request is recorded, including the ones this server refuses to read.**
+The adapter under test writes its own request headers, and two floor clauses
+(rule 2's finality check and clause 7b's mint check) read the ABSENCE of a
+record as conformance. So a request whose framing this server rejects is
+recorded as unreadable rather than dropped: dropping it would let a hostile or
+merely broken adapter suppress its own duplicate post, or its own attempt to
+mint a platform credential, and certify clean on the trust boundary this kit
+exists to enforce.
+
 The server binds 127.0.0.1 on an ephemeral port and is torn down by ``stop``.
 """
 
@@ -35,12 +44,33 @@ import threading
 import time
 import uuid
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
-from typing import Any, cast
+from typing import Any, NamedTuple, cast
 
 from pydantic import BaseModel, ConfigDict
 
 TURNS_PATH = "/channels/turns"
 TOKEN_PATH = "/channels/token"
+
+# The most turn body this ingress will read, and the bound the real API puts on
+# the same route. RE DECLARED here, never imported: ``channel_protocol`` is a
+# contract package and ``curie_api`` imports IT, so importing back would invert
+# the dependency. The copy is kept honest by
+# ``tests/test_conformance_egress.py::test_platform_constants_match``, which
+# reads the value back out of the API's settings and fails on any drift.
+# Authoritative site: apps/api/src/curie_api/config.py, channel_turn_max_body_bytes.
+MAX_TURN_BODY_BYTES = 256 * 1024
+
+# How long one connection may hold a handler thread without making progress.
+# The adapter under test is untrusted by construction, so a connection that
+# declares a body and then goes quiet must not pin a thread for the whole run.
+_HANDLER_TIMEOUT_S = 10.0
+
+# The recorded status of a request this ingress deliberately did not answer.
+# Not an HTTP status at all, because none of them mean "no response was sent":
+# a transport failure is precisely the absence of one, and rule 1 turns on the
+# difference between a failure the adapter must retry and a response it must
+# treat as final.
+NO_RESPONSE = 0
 
 _API_KEY_HEADER = "X-API-Key"
 
@@ -51,6 +81,11 @@ class ObservedRequest(BaseModel):
     Deliberately NOT the headers or the body: a recording is quoted into
     reports and issues, and both carry credentials. The ``delivery_id`` is the
     only body field any rule correlates on.
+
+    ``framing_error`` names why a request could not be read at all. It is the
+    difference between "the adapter did not post" and "the adapter posted
+    something this server could not attribute", and no floor rule is allowed to
+    confuse the two.
     """
 
     model_config = ConfigDict(frozen=True, extra="forbid")
@@ -59,6 +94,15 @@ class ObservedRequest(BaseModel):
     delivery_id: str | None
     status: int
     at: float
+    framing_error: str | None
+
+
+class _Framing(NamedTuple):
+    """A request body, or the reason it could not be framed and the refusal."""
+
+    body: bytes
+    error: str | None
+    status: int
 
 
 class _IngressServer(ThreadingHTTPServer):
@@ -69,22 +113,99 @@ class _IngressServer(ThreadingHTTPServer):
 class _IngressHandler(BaseHTTPRequestHandler):
     protocol_version = "HTTP/1.1"
     server_version = "curie-conformance-ingress/1"
+    # ``socketserver`` applies this to the accepted connection, so a peer that
+    # declares a body and never sends it cannot hold a handler thread for the
+    # life of the run.
+    timeout = _HANDLER_TIMEOUT_S
 
     def log_message(self, fmt: str, *args: Any) -> None:
         return
 
     def do_POST(self) -> None:
         ingress = cast(_IngressServer, self.server).ingress
-        length = int(self.headers.get("Content-Length") or 0)
-        body = self.rfile.read(length) if length else b""
         route = self.path.split("?", 1)[0]
+        try:
+            self._serve_post(ingress, route)
+        except Exception as error:  # noqa: BLE001
+            # Nothing this handler can raise is allowed to cost the kit an
+            # observation. Every ingress rule decides on the presence or absence
+            # of a record, and the adapter under test controls the request, so a
+            # handler that raised its way out without recording would hand the
+            # adapter a switch for what the kit is able to see.
+            ingress.record_unframeable(
+                route, f"the ingress handler failed ({type(error).__name__})", status=500
+            )
+            self.close_connection = True
+            self._answer(500, {"detail": "the ingress could not read that request"})
+
+    def _serve_post(self, ingress: FakeIngress, route: str) -> None:
+        framing = self._frame_body()
+        if framing.error is not None:
+            ingress.record_unframeable(route, framing.error, status=framing.status)
+            # The stream is out of sync with the declared framing, so anything
+            # still on it would be read as the next request.
+            self.close_connection = True
+            self._answer(framing.status, {"detail": framing.error})
+            return
         api_key = self.headers.get(_API_KEY_HEADER)
         if route == TURNS_PATH:
-            status, payload = ingress.answer_turn(api_key, body)
+            status, payload = ingress.answer_turn(api_key, framing.body)
         elif route == TOKEN_PATH:
             status, payload = ingress.answer_mint(api_key)
         else:
             status, payload = 404, {"detail": "no such route"}
+        if status == NO_RESPONSE:
+            # The blackhole: the request was read and recorded, and the
+            # connection closes with nothing on it. That is a transport failure
+            # from the adapter's side, not a response, which is the only kind of
+            # failure rule 1 licenses a retry for.
+            self.close_connection = True
+            return
+        self._answer(status, payload)
+
+    def _frame_body(self) -> _Framing:
+        """The request body, read under the turn body cap.
+
+        An exact ``Content-Length`` inside the cap is the only framing this
+        server accepts. It cannot decode a chunked body, so tolerating one (or a
+        missing, unparseable, negative or oversized length) would mean answering
+        on a body it never read, which is the same evidence loss as dropping the
+        request. Everything else is refused, recorded, and named.
+        """
+
+        if self.headers.get("Transfer-Encoding"):
+            return _Framing(
+                b"",
+                "the request declared a Transfer-Encoding, and this ingress reads "
+                "only an exact Content-Length",
+                400,
+            )
+        declared = self.headers.get("Content-Length")
+        if declared is None:
+            return _Framing(b"", "the request declared no Content-Length", 400)
+        try:
+            length = int(declared)
+        except ValueError:
+            return _Framing(b"", "the request declared an unparseable Content-Length", 400)
+        if length < 0:
+            return _Framing(b"", "the request declared a negative Content-Length", 400)
+        if length > MAX_TURN_BODY_BYTES:
+            # 413 rather than 400, because this is the one framing refusal the
+            # real API also makes, and it makes it with this status.
+            return _Framing(
+                b"",
+                f"the request declared a Content-Length over the "
+                f"{MAX_TURN_BODY_BYTES} byte turn body cap",
+                413,
+            )
+        body = self.rfile.read(length) if length else b""
+        if len(body) != length:
+            return _Framing(
+                b"", "the request sent fewer bytes than its Content-Length declared", 400
+            )
+        return _Framing(body, None, 0)
+
+    def _answer(self, status: int, payload: dict[str, Any]) -> None:
         encoded = json.dumps(payload).encode()
         self.send_response(status)
         self.send_header("Content-Type", "application/json")
@@ -110,7 +231,8 @@ class FakeIngress:
         self._valid_tokens = {self.token}
         self._claims: dict[tuple[str, str, str], str] = {}
         self._records: list[ObservedRequest] = []
-        self._pending_202 = False
+        self._pending_202: str | None = None
+        self._blackholed = False
         self._lock = threading.Lock()
         self._server: _IngressServer | None = None
         self._thread: threading.Thread | None = None
@@ -156,16 +278,45 @@ class FakeIngress:
             self.token = _new_token()
             self._valid_tokens.add(self.token)
 
-    def arm_202(self) -> None:
-        """Answer the NEXT turn post as an in flight claim.
+    def arm_202(self, delivery_id: str) -> None:
+        """Answer the next post of THIS delivery id as an in flight claim.
 
-        One shot, and provoked rather than raced: rule 2 needs a 202 to exist,
-        and waiting for a real concurrent claim race would make the rule flaky
-        without making it stronger.
+        Scoped to one identity, never to "the next post that arrives": rule 2
+        asks whether the adapter treated the response to ITS declared delivery
+        as final, so a one shot any other delivery could consume would let the
+        rule pass with the declared delivery never having seen a 202 at all.
+        Provoked rather than raced, because waiting for a real concurrent claim
+        race would make the rule flaky without making it stronger.
         """
 
         with self._lock:
-            self._pending_202 = True
+            self._pending_202 = delivery_id
+
+    def armed_202(self) -> str | None:
+        """The delivery id still waiting for its 202, if it never arrived."""
+
+        with self._lock:
+            return self._pending_202
+
+    def arm_blackhole(self) -> None:
+        """Read and record every turn post, and answer none of them.
+
+        This is how the kit takes the transport down ITSELF, rather than asking
+        the driver to take it down somewhere the kit cannot see. Rule 1 has to
+        establish that the declared delivery actually met an unavailable
+        transport before a retry can mean anything, and an outage the driver
+        arranges privately leaves the kit sleeping for a fixed window and
+        calling whatever arrives afterwards a retry. Here the failed attempt is
+        on the wire, with its delivery id, like every other piece of evidence
+        this kit decides on.
+        """
+
+        with self._lock:
+            self._blackholed = True
+
+    def disarm_blackhole(self) -> None:
+        with self._lock:
+            self._blackholed = False
 
     # -- observation -------------------------------------------------------
 
@@ -174,22 +325,48 @@ class FakeIngress:
             return tuple(self._records)
 
     def mint_attempts(self) -> int:
-        """How many times the adapter tried to mint its own token. Must be zero."""
+        """How many times the adapter tried to mint its own token. Must be zero.
+
+        Counted over EVERY record on the mint route, including requests this
+        server refused to read. A mint attempt the ingress could not frame is
+        still a mint attempt, and clause 7b is the trust boundary clause: an
+        attempt that went uncounted would certify an adapter that mints its own
+        platform credential.
+        """
 
         with self._lock:
             return sum(1 for record in self._records if record.path == TOKEN_PATH)
+
+    def record_unframeable(self, path: str, reason: str, *, status: int) -> None:
+        """Record a request this server could not read, and why.
+
+        Recorded rather than dropped, and that is the entire point: the floor
+        reads the absence of a record as conformance in two places, and the
+        adapter under test writes its own request headers. An unreadable request
+        is not an absent one.
+        """
+
+        self._record(path, None, status, framing_error=reason)
 
     # -- the two routes ----------------------------------------------------
 
     def answer_turn(self, api_key: str | None, body: bytes) -> tuple[int, dict[str, Any]]:
         delivery_id, kind, address = _delivery_fields(body)
+        with self._lock:
+            blackholed = self._blackholed
+        if blackholed:
+            # Ahead of the credential check, because a transport that is down is
+            # down for an authorized request too, and an adapter that saw a 401
+            # here would be exercising rule 7 rather than rule 1.
+            self._record(TURNS_PATH, delivery_id, NO_RESPONSE, framing_error=None)
+            return NO_RESPONSE, {}
         if api_key is None or api_key not in self._valid_tokens:
-            self._record(TURNS_PATH, delivery_id, 401)
+            self._record(TURNS_PATH, delivery_id, 401, framing_error=None)
             return 401, {"detail": "missing, malformed, expired or stale credential"}
         event_id = _event_id(kind, address, delivery_id)
         with self._lock:
-            if self._pending_202:
-                self._pending_202 = False
+            if delivery_id is not None and self._pending_202 == delivery_id:
+                self._pending_202 = None
                 status: int = 202
                 payload: dict[str, Any] = {
                     "event_id": event_id,
@@ -219,21 +396,29 @@ class FakeIngress:
                     delivery_id=delivery_id,
                     status=status,
                     at=time.monotonic(),
+                    framing_error=None,
                 )
             )
         return status, payload
 
     def answer_mint(self, api_key: str | None) -> tuple[int, dict[str, Any]]:
         if api_key != self.platform_key:
-            self._record(TOKEN_PATH, None, 401)
+            self._record(TOKEN_PATH, None, 401, framing_error=None)
             return 401, {"detail": "minting a channel token requires the platform key"}
         token = _new_token()
         with self._lock:
             self._valid_tokens.add(token)
-        self._record(TOKEN_PATH, None, 200)
+        self._record(TOKEN_PATH, None, 200, framing_error=None)
         return 200, {"token": token}
 
-    def _record(self, path: str, delivery_id: str | None, status: int) -> None:
+    def _record(
+        self,
+        path: str,
+        delivery_id: str | None,
+        status: int,
+        *,
+        framing_error: str | None,
+    ) -> None:
         with self._lock:
             self._records.append(
                 ObservedRequest(
@@ -241,6 +426,7 @@ class FakeIngress:
                     delivery_id=delivery_id,
                     status=status,
                     at=time.monotonic(),
+                    framing_error=framing_error,
                 )
             )
 

--- a/packages/channel-protocol/src/channel_protocol/conformance/transport.py
+++ b/packages/channel-protocol/src/channel_protocol/conformance/transport.py
@@ -1,0 +1,274 @@
+"""The kit's egress half: how it talks to the adapter under test (#1516).
+
+Everything here is BLACK BOX. The kit holds an endpoint, a secret and the two
+address fields, and it learns what the adapter does purely from what comes back
+over HTTP. It never imports the adapter, so the same kit works on an adapter
+written in Go.
+
+Every event the kit sends is built from a real ``channel_protocol.reply`` model
+and serialized with ``model_dump_json``, so the kit can never send a shape the
+worker could not send. The one deliberate exception is the unmodelled extra key
+probe, which takes a real event, dumps it, and adds one key: floor rule 5 asks
+whether an adapter tolerates a later wire revision, and a strict model cannot
+express that by construction.
+
+``ADAPTER_SECRET_HEADER`` and ``MAX_ACK_BODY_BYTES`` are RE DECLARED here, never
+imported. ``apps/worker/src/curie_worker/reply_sink.py`` is the authoritative
+site for both, and importing it would invert the dependency: this package is a
+contract package and the worker imports IT. The copy is kept honest by
+``tests/test_conformance_egress.py::test_worker_constants_match``, which reads
+both values back out of the worker source and fails on any drift.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from collections.abc import Callable
+from typing import Any
+from urllib.parse import urlsplit
+
+import httpx
+from pydantic import BaseModel, ConfigDict
+
+from ..models import MESSAGE_VERSION, OutboundMessage
+from ..reply import (
+    REPLY_WIRE_VERSION,
+    ReplyEvent,
+    ReplyPost,
+    ReplyTarget,
+    ReplyUpdate,
+    TurnCompleted,
+    TurnStatus,
+)
+
+# The per adapter egress credential travels in this header, and only this one.
+# Authoritative site: apps/worker/src/curie_worker/reply_sink.py.
+ADAPTER_SECRET_HEADER = "X-Curie-Adapter-Secret"
+
+# The most acknowledgement body the worker will read off an adapter. Oversize is
+# a DELIVERY FAILURE there, not a truncation, so the kit's boundary is the same
+# one: at the cap passes, one byte over fails.
+# Authoritative site: apps/worker/src/curie_worker/reply_sink.py.
+MAX_ACK_BODY_BYTES = 64 * 1024
+
+# Where the kit reads the adapter's side effect count from. A count, not a log:
+# the two clauses that need it (3a and rule 6) both ask "did the number move",
+# and an integer over HTTP is the smallest thing an adapter in any language can
+# expose. Without it those clauses are not_run, and not_run is nonconformant.
+SIDE_EFFECT_PROBE_PATH = "/_probe"
+SIDE_EFFECT_PROBE_FIELD = "side_effects"
+
+# A secret the adapter cannot have been configured with. Clause 3a posts under
+# it and the request must be refused.
+WRONG_SECRET = "conformance_kit_deliberately_wrong_secret"
+
+_STRICT = ConfigDict(frozen=True, extra="forbid")
+
+
+class AdapterUnreachableError(RuntimeError):
+    """The adapter endpoint did not answer at all.
+
+    Distinct from a refusal: a response that arrived and said no is evidence,
+    and an endpoint that never answered is the absence of it. The message names
+    only the REDACTED endpoint and the exception class, because these strings
+    reach a report a vendor pastes into a public issue and an endpoint's path or
+    query can itself be a credential.
+    """
+
+
+def redacted(endpoint: str) -> str:
+    """An endpoint reduced to scheme and host, for a string a human will read.
+
+    Same shape, and the same reason, as the worker's own helper: an endpoint can
+    carry a token in its path or its query, and every string this module puts in
+    a report is quotable.
+    """
+
+    parsed = urlsplit(endpoint)
+    if not parsed.scheme or not parsed.hostname:
+        return "an unparseable endpoint"
+    port = f":{parsed.port}" if parsed.port else ""
+    return f"{parsed.scheme}://{parsed.hostname}{port}"
+
+
+class AdapterResponse(BaseModel):
+    """One answer from the adapter, read under the ack cap.
+
+    ``oversize`` is a first class outcome rather than a truncated ``body``: the
+    floor treats a body over the cap as a failure, and a caller handed a
+    silently shortened body could not tell the two apart.
+    """
+
+    model_config = _STRICT
+
+    status: int
+    body: bytes
+    oversize: bool
+
+
+class AdapterUnderTest(BaseModel):
+    """The adapter the kit is pointed at, and the only handle it has on it."""
+
+    model_config = _STRICT
+
+    endpoint: str
+    secret: str
+    kind: str
+    address: str
+    timeout_s: float
+
+    @property
+    def redacted_endpoint(self) -> str:
+        return redacted(self.endpoint)
+
+    @property
+    def origin(self) -> str:
+        """The endpoint's scheme and authority, with no path, query or fragment."""
+
+        parsed = urlsplit(self.endpoint)
+        return f"{parsed.scheme}://{parsed.netloc}"
+
+    def post_body(self, body: bytes, *, secret: str | None) -> AdapterResponse:
+        """POST one raw event body. ``secret=None`` sends no credential header.
+
+        Redirects are never followed. Following one would replay the platform's
+        egress credential at whatever origin the adapter named, which is exactly
+        why the worker refuses them, so a kit that followed them would certify a
+        credential exfiltration primitive.
+
+        The body is read in a LOOP with a running total, never one sized read: a
+        chunked response answers a short first buffer, so a single read lets a
+        body of any size through behind it.
+        """
+
+        headers = {"Content-Type": "application/json"}
+        if secret is not None:
+            headers[ADAPTER_SECRET_HEADER] = secret
+        try:
+            with httpx.Client(timeout=self.timeout_s, follow_redirects=False) as client:
+                with client.stream(
+                    "POST", self.endpoint, content=body, headers=headers
+                ) as response:
+                    chunks: list[bytes] = []
+                    total = 0
+                    oversize = False
+                    for chunk in response.iter_bytes():
+                        total += len(chunk)
+                        if total > MAX_ACK_BODY_BYTES:
+                            oversize = True
+                            break
+                        chunks.append(chunk)
+                    return AdapterResponse(
+                        status=response.status_code,
+                        body=b"".join(chunks),
+                        oversize=oversize,
+                    )
+        except httpx.HTTPError as error:
+            raise AdapterUnreachableError(
+                f"the adapter endpoint {self.redacted_endpoint} did not answer "
+                f"({type(error).__name__})"
+            ) from None
+
+    def post_event(self, event: ReplyEvent, *, secret: str | None) -> AdapterResponse:
+        """POST one real reply event, serialized the way the worker serializes it."""
+
+        return self.post_body(event.model_dump_json().encode(), secret=secret)
+
+
+def new_conversation_id() -> str:
+    """A conversation the adapter has never seen, so a probe cannot collide."""
+
+    return f"conf-conv-{uuid.uuid4().hex}"
+
+
+def new_event_id() -> str:
+    return f"conf-event-{uuid.uuid4().hex}"
+
+
+def reply_target(adapter: AdapterUnderTest, *, conversation_id: str) -> ReplyTarget:
+    return ReplyTarget(
+        kind=adapter.kind,
+        address=adapter.address,
+        conversation_id=conversation_id,
+        reply_ref=f"conf-ref-{conversation_id}",
+    )
+
+
+def turn_status(adapter: AdapterUnderTest, *, conversation_id: str) -> TurnStatus:
+    return TurnStatus(
+        version=REPLY_WIRE_VERSION,
+        target=reply_target(adapter, conversation_id=conversation_id),
+        event="turn.status",
+        status="the conformance kit is checking this adapter",
+    )
+
+
+def reply_update(adapter: AdapterUnderTest, *, conversation_id: str) -> ReplyUpdate:
+    return ReplyUpdate(
+        version=REPLY_WIRE_VERSION,
+        target=reply_target(adapter, conversation_id=conversation_id),
+        event="reply.update",
+        text="a conformance kit reply",
+    )
+
+
+def reply_post(adapter: AdapterUnderTest, *, conversation_id: str) -> ReplyPost:
+    return ReplyPost(
+        version=REPLY_WIRE_VERSION,
+        target=reply_target(adapter, conversation_id=conversation_id),
+        event="reply.post",
+        message=OutboundMessage(version=MESSAGE_VERSION, text="a conformance kit card"),
+        requested_by="conformance_kit",
+    )
+
+
+def turn_completed(
+    adapter: AdapterUnderTest, *, conversation_id: str, event_id: str
+) -> TurnCompleted:
+    return TurnCompleted(
+        version=REPLY_WIRE_VERSION,
+        target=reply_target(adapter, conversation_id=conversation_id),
+        event="turn.completed",
+        event_id=event_id,
+        outcome="delivered",
+    )
+
+
+def body_with_extra_key(event: ReplyEvent, *, key: str, value: str) -> bytes:
+    """A real event carrying one key the current models do not define.
+
+    Floor rule 5 asks an adapter to tolerate a later wire revision adding an
+    optional key. The models are strict producers, so the only way to build the
+    probe is to dump a real event and add the key to the dumped payload.
+    """
+
+    payload: dict[str, Any] = json.loads(event.model_dump_json())
+    payload[key] = value
+    return json.dumps(payload).encode()
+
+
+def side_effect_probe(adapter: AdapterUnderTest) -> Callable[[], int] | None:
+    """The adapter's side effect count, if it exposes one, else None.
+
+    Discovery is one real GET rather than a promise: an adapter that does not
+    answer ``/_probe`` leaves clause 3a and rule 6 with no evidence, and the
+    honest report for that is ``not_run``, which is nonconformant. Returning a
+    callable that would fail later would turn a missing probe into a crash
+    halfway through a run instead.
+    """
+
+    url = f"{adapter.origin}{SIDE_EFFECT_PROBE_PATH}"
+
+    def read() -> int:
+        with httpx.Client(timeout=adapter.timeout_s) as client:
+            response = client.get(url)
+            response.raise_for_status()
+            payload = response.json()
+        return int(payload[SIDE_EFFECT_PROBE_FIELD])
+
+    try:
+        read()
+    except (httpx.HTTPError, KeyError, TypeError, ValueError):
+        return None
+    return read

--- a/packages/channel-protocol/src/channel_protocol/conformance/transport.py
+++ b/packages/channel-protocol/src/channel_protocol/conformance/transport.py
@@ -6,17 +6,20 @@ over HTTP. It never imports the adapter, so the same kit works on an adapter
 written in Go.
 
 Every event the kit sends is built from a real ``channel_protocol.reply`` model
-and serialized with ``model_dump_json``, so the kit can never send a shape the
-worker could not send. The one deliberate exception is the unmodelled extra key
-probe, which takes a real event, dumps it, and adds one key: floor rule 5 asks
-whether an adapter tolerates a later wire revision, and a strict model cannot
-express that by construction.
+and serialized with ``model_dump_json``, with no exceptions, so the kit can
+never send a shape the worker could not send. A kit that hand built a payload
+would be free to assert a requirement the published floor never states.
+
+Every response the kit reads off the adapter is read in a LOOP with a running
+total and refused past the cap, the acknowledgement and the side effect probe
+alike. The adapter is untrusted by construction and both reads land on the
+kit's own heap.
 
 ``ADAPTER_SECRET_HEADER`` and ``MAX_ACK_BODY_BYTES`` are RE DECLARED here, never
 imported. ``apps/worker/src/curie_worker/reply_sink.py`` is the authoritative
 site for both, and importing it would invert the dependency: this package is a
 contract package and the worker imports IT. The copy is kept honest by
-``tests/test_conformance_egress.py::test_worker_constants_match``, which reads
+``tests/test_conformance_egress.py::test_platform_constants_match``, which reads
 both values back out of the worker source and fails on any drift.
 """
 
@@ -235,19 +238,6 @@ def turn_completed(
     )
 
 
-def body_with_extra_key(event: ReplyEvent, *, key: str, value: str) -> bytes:
-    """A real event carrying one key the current models do not define.
-
-    Floor rule 5 asks an adapter to tolerate a later wire revision adding an
-    optional key. The models are strict producers, so the only way to build the
-    probe is to dump a real event and add the key to the dumped payload.
-    """
-
-    payload: dict[str, Any] = json.loads(event.model_dump_json())
-    payload[key] = value
-    return json.dumps(payload).encode()
-
-
 def side_effect_probe(adapter: AdapterUnderTest) -> Callable[[], int] | None:
     """The adapter's side effect count, if it exposes one, else None.
 
@@ -256,15 +246,33 @@ def side_effect_probe(adapter: AdapterUnderTest) -> Callable[[], int] | None:
     honest report for that is ``not_run``, which is nonconformant. Returning a
     callable that would fail later would turn a missing probe into a crash
     halfway through a run instead.
+
+    The probe body is read under the SAME cap as an acknowledgement, streamed
+    with a running total, and redirects are not followed. This GET lands on the
+    same untrusted origin the acknowledgement comes from, it is issued once per
+    probed clause rather than once per run, and a probe that answered an
+    unbounded chunked body would OOM whatever CI box the vendor runs the kit on.
+    The count itself is one integer, so a payload near the cap is already orders
+    of magnitude past anything honest.
     """
 
     url = f"{adapter.origin}{SIDE_EFFECT_PROBE_PATH}"
 
     def read() -> int:
-        with httpx.Client(timeout=adapter.timeout_s) as client:
-            response = client.get(url)
-            response.raise_for_status()
-            payload = response.json()
+        with httpx.Client(timeout=adapter.timeout_s, follow_redirects=False) as client:
+            with client.stream("GET", url) as response:
+                response.raise_for_status()
+                chunks: list[bytes] = []
+                total = 0
+                for chunk in response.iter_bytes():
+                    total += len(chunk)
+                    if total > MAX_ACK_BODY_BYTES:
+                        raise ValueError(
+                            "the side effect probe answered with more than "
+                            f"{MAX_ACK_BODY_BYTES} bytes, which the kit refuses to buffer"
+                        )
+                    chunks.append(chunk)
+        payload: dict[str, Any] = json.loads(b"".join(chunks))
         return int(payload[SIDE_EFFECT_PROBE_FIELD])
 
     try:

--- a/packages/channel-protocol/src/channel_protocol/manifest.py
+++ b/packages/channel-protocol/src/channel_protocol/manifest.py
@@ -13,7 +13,13 @@ the version this build understands and the version the file declares. Run it
 the other way round and a 1.1 file trips the closed schema first, so the
 operator reads "additional property not allowed" instead of the version they
 actually have to act on. A missing ``version`` key is the same refusal, never a
-default.
+default, and a key PRESENT with a non string value is a THIRD refusal that
+names the value it found: unquoted ``version: 1.1`` is a YAML float, and
+reporting that as a missing key sends the author looking for a key that is
+already there. A non canonical SPELLING such as ``01.0`` is a FOURTH refusal
+that says so in those terms: the Rust CLI compares the declared string to
+``1.0`` for equality, so accepting it here would take a profile
+``curie adapter validate`` refuses.
 
 **Three validation tiers, unequally enforced, and the asymmetry is deliberate.**
 
@@ -70,30 +76,57 @@ _ENV_NAME_PATTERN = r"^[A-Z][A-Z0-9_]*$"
 # `_validate_channel_endpoint` remains the authority on what may be stored.
 _ENDPOINT_PATTERN = r"^https?://[^\s/?#@]+(?:[/?#][^\s]*)?$"
 
-# Constructs the Rust `regex` crate cannot compile. `(?:` and `(?<name>` are
-# both fine there, so the lookbehind forms are matched on their `=` and `!`
-# rather than on `(?<` alone.
+# Group openers the Rust `regex` crate cannot compile while Python `re` can.
+# `(?:`, `(?P<name>` and the `i m s x u` flag letters are fine on both sides, so
+# the lookbehind forms are matched on their `=` and `!` rather than on `(?<`
+# alone, and only the Python only `a` flag letter is listed. Every entry here
+# was checked against regex 1.13.1 by compiling it: a construct that crate in
+# fact accepts must not be listed, or this validator refuses a profile
+# `curie adapter validate` would take.
 _RUST_UNSUPPORTED_GROUPS = (
     ("(?=", "lookahead"),
     ("(?!", "negative lookahead"),
     ("(?<=", "lookbehind"),
     ("(?<!", "negative lookbehind"),
     ("(?P=", "a named backreference"),
+    ("(?>", "an atomic group"),
+    ("(?(", "a conditional group"),
+    ("(?#", "an inline comment group"),
+    ("(?a", "the Python only ASCII flag"),
 )
+
+# Escapes in the same class, keyed by the single character after the backslash.
+# `\Z` is Python's end of string anchor and the crate spells that `\z`; `\N` is
+# Python's named character escape and the crate has no equivalent. Both are
+# refused inside a character class too, which is correct: the crate rejects them
+# there as well.
+_RUST_UNSUPPORTED_ESCAPES = {
+    "Z": "the Python only \\Z anchor",
+    "N": "the Python only \\N named character escape",
+}
 
 
 class ProfileVersionError(Exception):
     """A profile declares a format version this build does not understand."""
 
 
+# The ONLY spelling of a profile version: two plain decimal numbers, neither
+# carrying a leading zero. Parsing `major.minor` numerically instead would make
+# `01.0` and `1.00` acceptable here, and the Rust CLI compares the declared
+# string to `1.0` for equality and refuses both. Python is the side that moves,
+# because `01.0` is malformed under any honest reading of the contract and
+# tightening here costs the Rust half nothing.
+_CANONICAL_VERSION = re.compile(r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$")
+
+
 def _version_parts(value: str) -> tuple[int, int]:
-    major, separator, minor = value.partition(".")
-    if not separator or not major.isdigit() or not minor.isdigit():
-        raise ValueError(f"{value!r} is not a major.minor profile version")
-    return int(major), int(minor)
+    match = _CANONICAL_VERSION.fullmatch(value)
+    if match is None:
+        raise ValueError(f"{value!r} is not a canonical major.minor profile version")
+    return int(match.group(1)), int(match.group(2))
 
 
-def _is_acceptable(declared: str) -> bool:
+def _is_acceptable(declared: tuple[int, int]) -> bool:
     """Same major, less or equal minor.
 
     A 1.0 build refuses 1.1 because it cannot know the property 1.1 added is
@@ -102,35 +135,59 @@ def _is_acceptable(declared: str) -> bool:
     to upgrade.
     """
 
-    understood_major, understood_minor = _version_parts(PROFILE_VERSION)
-    try:
-        declared_major, declared_minor = _version_parts(declared)
-    except ValueError:
-        return False
-    return declared_major == understood_major and declared_minor <= understood_minor
+    understood = _version_parts(PROFILE_VERSION)
+    return declared[0] == understood[0] and declared[1] <= understood[1]
 
 
 def read_profile_version(raw: Mapping[str, Any]) -> str:
-    """Read the raw ``version`` key, before anything else looks at the payload."""
+    """Read the raw ``version`` key, before anything else looks at the payload.
 
-    declared = raw.get("version")
-    if not isinstance(declared, str) or not declared:
+    A missing key and a key holding something other than a non empty string are
+    DIFFERENT refusals. Collapsing them reports ``version: 1.1`` (a YAML float,
+    because it was written unquoted) as "declares no version key", which sends
+    the author hunting for a key that is sitting on line one of their file.
+    """
+
+    understood = f"this curie understands adapter profile {PROFILE_VERSION}; "
+    if "version" not in raw:
+        raise ProfileVersionError(understood + "the profile declares no version key")
+    declared = raw["version"]
+    if not isinstance(declared, str):
         raise ProfileVersionError(
-            f"this curie understands adapter profile {PROFILE_VERSION}; "
-            "the profile declares no version key"
+            understood + f"the profile declares version {declared!r}, which is a "
+            f"{type(declared).__name__} and not a string. A profile version is a quoted "
+            f'string, so write version: "{PROFILE_VERSION}"'
+        )
+    if not declared:
+        raise ProfileVersionError(
+            understood + "the profile declares an empty version key. A profile version is "
+            f'a quoted string, so write version: "{PROFILE_VERSION}"'
         )
     return declared
 
 
 def check_version(declared: str) -> None:
-    """Refuse a version this build cannot read, naming BOTH versions."""
+    """Refuse a version this build cannot read, naming BOTH versions.
 
-    if _is_acceptable(declared):
+    A non canonical SPELLING is its own refusal, separate from a version this
+    build does not speak. An operator who typed ``01.0`` needs to be told the
+    spelling is wrong: told only "the profile declares 01.0" against an
+    understood 1.0, they read a version mismatch between two versions that look
+    equal and have nowhere to go.
+    """
+
+    understood = f"this curie understands adapter profile {PROFILE_VERSION}; "
+    try:
+        parts = _version_parts(declared)
+    except ValueError:
+        raise ProfileVersionError(
+            understood + f"the profile declares version {declared!r}, which is not a "
+            "canonical major.minor version. Both numbers are plain digits with no "
+            f'leading zeros, so write version: "{PROFILE_VERSION}"'
+        ) from None
+    if _is_acceptable(parts):
         return
-    raise ProfileVersionError(
-        f"this curie understands adapter profile {PROFILE_VERSION}; "
-        f"the profile declares {declared}"
-    )
+    raise ProfileVersionError(understood + f"the profile declares {declared}")
 
 
 def _rust_unsupported_construct(pattern: str) -> str | None:
@@ -150,6 +207,9 @@ def _rust_unsupported_construct(pattern: str) -> str | None:
                 return f"the backreference \\{following}"
             if following == "g":
                 return "a backreference"
+            unsupported = _RUST_UNSUPPORTED_ESCAPES.get(following)
+            if unsupported is not None:
+                return unsupported
             index += 2
             continue
         if in_class:
@@ -183,7 +243,8 @@ class AddressShape(BaseModel):
         min_length=1,
         description=(
             "A regex the address must match. It has to compile in BOTH Python re "
-            "and the Rust regex crate, so lookaround and backreferences are refused."
+            "and the Rust regex crate, so lookaround, backreferences, atomic and "
+            "conditional groups, inline comments and Python only escapes are refused."
         ),
     )
     example: str = Field(description="A concrete address of this shape, for operator docs.")
@@ -256,12 +317,6 @@ class AdapterConformance(BaseModel):
 
     wire_version: ReplyWireVersion = Field(
         description="The reply wire version this adapter speaks, from channel_protocol.reply."
-    )
-    mints_reply_ref: bool = Field(
-        description=(
-            "Whether the adapter mints an opaque reply_ref the platform can address "
-            "a later edit to. False means every reply is a fresh post."
-        )
     )
 
 

--- a/packages/channel-protocol/src/channel_protocol/manifest.py
+++ b/packages/channel-protocol/src/channel_protocol/manifest.py
@@ -1,0 +1,308 @@
+"""The adapter binding profile (``adapter.yaml``) one install commits (#1516).
+
+This is NOT ADR-0096 decision 2's install agnostic composition manifest (image
+reference, config and secret schema, platform performed composition). That
+document is separate and later, and nothing in this module pre empts it. What
+is modelled here is the PER INSTALL binding profile: the channel kind an
+adapter owns, the address shape it accepts, the endpoint this install's worker
+POSTs reply events to, and the names of the credentials involved.
+
+**The version check runs FIRST.** ``load_profile`` reads the raw ``version``
+key and refuses an unacceptable one before any schema validation, naming both
+the version this build understands and the version the file declares. Run it
+the other way round and a 1.1 file trips the closed schema first, so the
+operator reads "additional property not allowed" instead of the version they
+actually have to act on. A missing ``version`` key is the same refusal, never a
+default.
+
+**Three validation tiers, unequally enforced, and the asymmetry is deliberate.**
+
+* Tier 1 and tier 2 (the slugs, the environment variable names, the two
+  ``Literal`` versions, the endpoint shape) are ``Field`` constraints, so they
+  export into ``schema/adapter-profile.schema.json`` and the Rust CLI gets them
+  for free. For these the exported schema genuinely is the single source.
+* Tier 3 is ``address.pattern``'s compilability under the Rust ``regex``
+  crate. JSON Schema has no keyword for "the Rust regex crate can compile this
+  string" and no extension both a Python and a Rust validator would honour, so
+  this rule is an ADMITTED PAIRED VALIDATOR: one implementation here, one in
+  the Rust CLI, with ``schema/adapter-profile.corpus.json`` as the drift gate
+  between them. The exported schema ACCEPTS every tier 3 case and
+  ``tests/test_manifest_corpus.py`` asserts that it does, so nobody later reads
+  the exported schema as the sole authority and drops the Rust half.
+
+Every regex this module puts into the schema is lookaround free, because the
+Rust ``regex`` crate refuses lookaround and would fail to compile the exported
+constraint it is handed.
+"""
+
+import re
+from collections.abc import Mapping
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from .reply import ReplyWireVersion
+
+ProfileVersion = Literal["1.0"]
+PROFILE_VERSION: ProfileVersion = "1.0"
+
+_STRICT = ConfigDict(extra="forbid")
+
+# Copied VERBATIM from apps/api/src/curie_api/schemas.py::_CHANNEL_KIND. The API
+# owns the slug rule and this is a copy of it, so a tightening on either side
+# without the other would let the CLI accept a value the API refuses.
+# tests/test_manifest.py asserts the two strings are byte identical. Underscores
+# are legal: `ms_teams` is a kind the API accepts.
+_SLUG_PATTERN = r"^[a-z0-9]+(?:[-_][a-z0-9]+)*$"
+
+# A shell environment variable NAME. This is a LEGIBILITY constraint and it
+# claims nothing whatsoever about secrecy: `DEADBEEF` and `ABC123` both match
+# it. Preventing a committed secret VALUE is the repo's gitleaks gate, the only
+# mechanism that inspects values. What the pattern buys is that a field meant to
+# hold `CURIE_EGRESS_SECRET` cannot hold a sentence or a URL.
+_ENV_NAME_PATTERN = r"^[A-Z][A-Z0-9_]*$"
+
+# An absolute http or https URL with a host and no userinfo. Lookaround free so
+# the Rust `regex` crate compiles the exported constraint. Userinfo is excluded
+# by forbidding `@` in the authority, which makes
+# `https://user:pw@host/x` fail rather than parse as a host of `user:pw@host`.
+# This is FAIL FAST FEEDBACK, not a security control: the API's
+# `_validate_channel_endpoint` remains the authority on what may be stored.
+_ENDPOINT_PATTERN = r"^https?://[^\s/?#@]+(?:[/?#][^\s]*)?$"
+
+# Constructs the Rust `regex` crate cannot compile. `(?:` and `(?<name>` are
+# both fine there, so the lookbehind forms are matched on their `=` and `!`
+# rather than on `(?<` alone.
+_RUST_UNSUPPORTED_GROUPS = (
+    ("(?=", "lookahead"),
+    ("(?!", "negative lookahead"),
+    ("(?<=", "lookbehind"),
+    ("(?<!", "negative lookbehind"),
+    ("(?P=", "a named backreference"),
+)
+
+
+class ProfileVersionError(Exception):
+    """A profile declares a format version this build does not understand."""
+
+
+def _version_parts(value: str) -> tuple[int, int]:
+    major, separator, minor = value.partition(".")
+    if not separator or not major.isdigit() or not minor.isdigit():
+        raise ValueError(f"{value!r} is not a major.minor profile version")
+    return int(major), int(minor)
+
+
+def _is_acceptable(declared: str) -> bool:
+    """Same major, less or equal minor.
+
+    A 1.0 build refuses 1.1 because it cannot know the property 1.1 added is
+    optional, and refuses 2.0 outright. A later 1.1 build still accepts a 1.0
+    file, which is what lets a third party commit a profile we cannot force it
+    to upgrade.
+    """
+
+    understood_major, understood_minor = _version_parts(PROFILE_VERSION)
+    try:
+        declared_major, declared_minor = _version_parts(declared)
+    except ValueError:
+        return False
+    return declared_major == understood_major and declared_minor <= understood_minor
+
+
+def read_profile_version(raw: Mapping[str, Any]) -> str:
+    """Read the raw ``version`` key, before anything else looks at the payload."""
+
+    declared = raw.get("version")
+    if not isinstance(declared, str) or not declared:
+        raise ProfileVersionError(
+            f"this curie understands adapter profile {PROFILE_VERSION}; "
+            "the profile declares no version key"
+        )
+    return declared
+
+
+def check_version(declared: str) -> None:
+    """Refuse a version this build cannot read, naming BOTH versions."""
+
+    if _is_acceptable(declared):
+        return
+    raise ProfileVersionError(
+        f"this curie understands adapter profile {PROFILE_VERSION}; "
+        f"the profile declares {declared}"
+    )
+
+
+def _rust_unsupported_construct(pattern: str) -> str | None:
+    """Name the first construct the Rust ``regex`` crate would refuse, or None.
+
+    Character classes are skipped, because `(` and `\\` mean something else
+    inside them and a naive scan would refuse a pattern both dialects accept.
+    """
+
+    index = 0
+    in_class = False
+    while index < len(pattern):
+        char = pattern[index]
+        if char == "\\":
+            following = pattern[index + 1 : index + 2]
+            if following.isdigit() and following != "0":
+                return f"the backreference \\{following}"
+            if following == "g":
+                return "a backreference"
+            index += 2
+            continue
+        if in_class:
+            in_class = char != "]"
+            index += 1
+            continue
+        if char == "[":
+            in_class = True
+            index += 1
+            continue
+        for prefix, name in _RUST_UNSUPPORTED_GROUPS:
+            if pattern.startswith(prefix, index):
+                return name
+        index += 1
+    return None
+
+
+class AddressShape(BaseModel):
+    """The address form this adapter owns, as a regex plus an operator legible example.
+
+    ``pattern`` is the tier 3 paired validator: the Rust ``regex`` dialect is
+    the floor, so a pattern Python ``re`` compiles and Rust refuses is rejected
+    here too. Without that, a profile would validate in the Python kit and fail
+    in ``curie adapter validate`` with no shared rule to point at.
+    """
+
+    model_config = _STRICT
+
+    description: str = Field(description="What this address identifies, in the channel's terms.")
+    pattern: str = Field(
+        min_length=1,
+        description=(
+            "A regex the address must match. It has to compile in BOTH Python re "
+            "and the Rust regex crate, so lookaround and backreferences are refused."
+        ),
+    )
+    example: str = Field(description="A concrete address of this shape, for operator docs.")
+
+    @field_validator("pattern")
+    @classmethod
+    def _compiles_in_both_dialects(cls, value: str) -> str:
+        try:
+            re.compile(value)
+        except re.error as error:
+            raise ValueError(f"address.pattern is not a valid regex: {error}") from error
+        construct = _rust_unsupported_construct(value)
+        if construct is not None:
+            raise ValueError(
+                f"address.pattern uses {construct}, which the Rust regex crate cannot "
+                "compile, so curie adapter validate would refuse the same profile"
+            )
+        return value
+
+
+class AdapterCredentials(BaseModel):
+    """Which credential identities this adapter expects, by NAME only.
+
+    ``egress`` is a non binding SUGGESTION. It is authority for nothing: the
+    worker's credential map is indexed by the slug the binding carries, so a
+    profile that named another adapter's slug would redirect that adapter's
+    secret. ``curie adapter bind`` therefore requires an operator supplied slug
+    and the profile's value is only ever a default shown for confirmation.
+
+    ``egress_secret_env`` and ``ingress_token_env`` are DOCUMENTATION of what
+    the adapter itself reads. Nothing in Curie resolves them: the conformance
+    kit and the CLI take a secret at the invocation boundary instead, so a
+    profile can never choose which of an operator's secrets gets read.
+    """
+
+    model_config = _STRICT
+
+    egress: str = Field(
+        pattern=_SLUG_PATTERN,
+        description=(
+            "The egress credential identity this adapter suggests. A SUGGESTION only: "
+            "bind requires an operator supplied slug and never takes this value alone."
+        ),
+    )
+    egress_secret_env: str = Field(
+        pattern=_ENV_NAME_PATTERN,
+        description=(
+            "The environment variable the ADAPTER reads its egress secret from. "
+            "Documentation only. Curie never resolves this name."
+        ),
+    )
+    ingress_token_env: str = Field(
+        pattern=_ENV_NAME_PATTERN,
+        description=(
+            "The environment variable the ADAPTER reads its ingress token from. "
+            "Documentation only. Curie never resolves this name."
+        ),
+    )
+
+
+class AdapterConformance(BaseModel):
+    """What this adapter claims about the reply wire it speaks.
+
+    ``wire_version`` is the reply wire (ADR-0096), imported from ``reply.py``
+    and never re typed here. It is INDEPENDENT of the profile's own ``version``:
+    conflating the two would let a wire bump silently invalidate every profile.
+    """
+
+    model_config = _STRICT
+
+    wire_version: ReplyWireVersion = Field(
+        description="The reply wire version this adapter speaks, from channel_protocol.reply."
+    )
+    mints_reply_ref: bool = Field(
+        description=(
+            "Whether the adapter mints an opaque reply_ref the platform can address "
+            "a later edit to. False means every reply is a fresh post."
+        )
+    )
+
+
+class AdapterProfile(BaseModel):
+    """One install's binding profile for one adapter.
+
+    Closed by construction (``extra='forbid'``), so a typo'd key is refused
+    instead of silently ignored. Read it through ``load_profile``, never
+    through ``model_validate`` directly: the version check has to run first.
+    """
+
+    model_config = _STRICT
+
+    version: ProfileVersion = Field(
+        description="The adapter profile format version this file is written against."
+    )
+    kind: str = Field(
+        pattern=_SLUG_PATTERN,
+        description="The channel kind this adapter owns, as a lowercase slug.",
+    )
+    endpoint: str | None = Field(
+        default=None,
+        pattern=_ENDPOINT_PATTERN,
+        description=(
+            "The absolute http or https route this install's worker POSTs reply events "
+            "to. OPTIONAL here: the verbs that need a concrete route (bind, token, "
+            "smoke-test) require it at the verb boundary or take an override."
+        ),
+    )
+    address: AddressShape
+    credentials: AdapterCredentials
+    conformance: AdapterConformance
+
+
+def load_profile(raw: Mapping[str, Any]) -> AdapterProfile:
+    """Parse a profile payload, version check FIRST.
+
+    This is the entry point every consumer uses. ``AdapterProfile.model_validate``
+    on its own skips the acceptance rule and reports a closed schema violation
+    where the operator needed to read a version.
+    """
+
+    check_version(read_profile_version(raw))
+    return AdapterProfile.model_validate(raw)

--- a/packages/channel-protocol/src/channel_protocol/manifest_schema.py
+++ b/packages/channel-protocol/src/channel_protocol/manifest_schema.py
@@ -1,0 +1,188 @@
+"""Export the committed adapter binding profile JSON Schema and its shape baseline.
+
+Two committed artifacts, two different jobs, and confusing them is how a
+breaking profile change lands quietly:
+
+* ``schema/adapter-profile.schema.json`` is the DRIFT gate. It proves the
+  committed schema still matches the models. It says nothing about whether a
+  change was compatible or whether it earned a version bump.
+* ``schema/adapter-profile.baseline.json`` is the BUMP gate. It records the
+  canonical validation shape at the current ``PROFILE_VERSION``, so a change
+  that must bump cannot land at an unchanged version. Refreshing it is legal
+  only in the commit that also bumps ``PROFILE_VERSION``, and
+  ``tests/test_manifest_previous_shape.py`` asserts that pairing.
+
+The change class table, which decides the bump:
+
+* Add an OPTIONAL property: minor (1.0 to 1.1). The schema is closed, so a
+  consumer on 1.0 rejects the new payload.
+* Add a REQUIRED property, remove or rename one, change a type, tighten a
+  ``pattern``, or make an optional property required: major (1.0 to 2.0). Each
+  invalidates a file a conforming author had already written.
+* Loosen a ``pattern``, widen an ``enum``, relax a bound: minor. Same closed
+  schema reasoning as an added optional property.
+* Edit a ``description``, a ``title`` or a ``$comment``: no bump. No shape
+  change, which is why the baseline excludes both prose keywords.
+
+Consumer acceptance is same major, less or equal minor
+(``channel_protocol.manifest.check_version``).
+
+``schema_export.py`` is deliberately NOT edited to carry this. The profile is a
+build time declaration, not a wire message; a separate ``$id`` lets the two
+version independently, and then each drift test names which contract broke.
+"""
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from pydantic.json_schema import models_json_schema
+
+from .manifest import (
+    PROFILE_VERSION,
+    AdapterConformance,
+    AdapterCredentials,
+    AdapterProfile,
+    AddressShape,
+)
+
+SCHEMA_ID = "https://curietech.ai/schemas/adapter-profile.schema.json"
+
+# Every model the drift gate (tests/test_manifest_schema_compat.py) can see. A
+# model that is never listed here is invisible to it, so the committed schema
+# would stay "current" while the profile it documents lost half its surface.
+_MODELS = (
+    AdapterProfile,
+    AddressShape,
+    AdapterCredentials,
+    AdapterConformance,
+)
+
+# The keywords the bump gate records, per Section 2.1 of the profile's
+# compatibility policy. `description` and `title` are excluded on purpose: a
+# gate that reds on prose becomes noise, and noise gets refreshed reflexively,
+# which is exactly how a real shape change gets waved through. The composition
+# keywords are included so a property that changes which model it resolves to
+# is recorded as the shape change it is.
+_CANONICAL_KEYWORDS = frozenset(
+    {
+        "$ref",
+        "additionalProperties",
+        "allOf",
+        "anyOf",
+        "const",
+        "enum",
+        "exclusiveMaximum",
+        "exclusiveMinimum",
+        "format",
+        "items",
+        "maxItems",
+        "maxLength",
+        "maximum",
+        "minItems",
+        "minLength",
+        "minimum",
+        "oneOf",
+        "pattern",
+        "prefixItems",
+        "required",
+        "type",
+    }
+)
+
+
+def schema_path() -> Path:
+    return Path(__file__).resolve().parents[2] / "schema" / "adapter-profile.schema.json"
+
+
+def baseline_path() -> Path:
+    return Path(__file__).resolve().parents[2] / "schema" / "adapter-profile.baseline.json"
+
+
+def build_schema() -> dict[str, Any]:
+    _, top = models_json_schema(
+        [(model, "validation") for model in _MODELS],
+        ref_template="#/$defs/{model}",
+    )
+    return {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": SCHEMA_ID,
+        "title": "Curie Adapter Manifest v1.0",
+        "manifestVersion": PROFILE_VERSION,
+        **top,
+    }
+
+
+def render_schema() -> str:
+    return json.dumps(build_schema(), indent=2, sort_keys=True) + "\n"
+
+
+def write_schema() -> Path:
+    path = schema_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(render_schema(), encoding="utf-8")
+    return path
+
+
+def _canonical_constraint(node: Any) -> Any:
+    """Keep only the keywords that decide whether a payload validates."""
+
+    if isinstance(node, list):
+        return [_canonical_constraint(member) for member in node]
+    if not isinstance(node, dict):
+        return node
+    reduced: dict[str, Any] = {}
+    for keyword in sorted(node):
+        if keyword not in _CANONICAL_KEYWORDS:
+            continue
+        value = node[keyword]
+        if keyword == "enum" and isinstance(value, list):
+            reduced[keyword] = sorted(value, key=repr)
+        else:
+            reduced[keyword] = _canonical_constraint(value)
+    return reduced
+
+
+def canonical_shape(schema: dict[str, Any]) -> dict[str, Any]:
+    """The validation shape of every exported model, prose stripped out.
+
+    Deeper than a names and required list on purpose: a names only baseline
+    stays green on exactly the changes the change class table says must bump,
+    namely a tightened pattern, a changed type, a narrowed enum, a changed
+    format or a moved bound.
+    """
+
+    return {
+        name: {
+            "required": sorted(definition.get("required", [])),
+            "additionalProperties": definition.get("additionalProperties", True),
+            "properties": {
+                prop: _canonical_constraint(subschema)
+                for prop, subschema in sorted(definition.get("properties", {}).items())
+            },
+        }
+        for name, definition in sorted(schema.get("$defs", {}).items())
+    }
+
+
+def build_baseline() -> dict[str, Any]:
+    return {"version": PROFILE_VERSION, "models": canonical_shape(build_schema())}
+
+
+def render_baseline() -> str:
+    return json.dumps(build_baseline(), indent=2, sort_keys=True) + "\n"
+
+
+def write_baseline() -> Path:
+    path = baseline_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(render_baseline(), encoding="utf-8")
+    return path
+
+
+if __name__ == "__main__":
+    if "--write-baseline" in sys.argv[1:]:
+        print(f"wrote {write_baseline()}")
+    else:
+        print(f"wrote {write_schema()}")

--- a/packages/channel-protocol/tests/conformance_stubs.py
+++ b/packages/channel-protocol/tests/conformance_stubs.py
@@ -1,0 +1,945 @@
+"""Real HTTP adapter stubs, and the ingress drivers over them (#1516).
+
+These are TEST FIXTURES. They are never packaged, they are not adapters anyone
+deploys, and they do not collide with the first party adapter directory #1515
+owns. They exist to be the conformance kit's NEGATIVE CONTROL: for every
+automatable floor clause there is a stub that breaks exactly that clause and
+nothing else, so a kit that quietly asserts nothing goes green on the conformant
+stub and stays green on the break, which reds the suite.
+
+Everything here is a real HTTP server on 127.0.0.1 on an EPHEMERAL port, driven
+over real loopback HTTP. Nothing internal is faked: an in process shortcut would
+defeat the only thing a black box kit is for.
+
+The stub deliberately re declares ``X-Curie-Adapter-Secret`` rather than
+importing the kit's constant. A stub that read the header name out of the thing
+under test could not witness a drift in it.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import hmac
+import http.client
+import json
+import os
+import socket
+import subprocess
+import sys
+import threading
+import time
+import urllib.error
+import urllib.request
+import uuid
+from collections.abc import Callable, Iterator
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from types import EllipsisType
+from typing import Any
+
+from channel_protocol.conformance import ClauseResult, FloorReport, FloorResult, UpstreamIdentity
+
+# The egress secret header, as an adapter author reads it out of the guide. Not
+# imported from the kit on purpose: see the module docstring.
+SECRET_HEADER = "X-Curie-Adapter-Secret"
+
+# The stub retries a TRANSPORT failure for about ten seconds, which is long
+# enough for the kit to restore a path it took down and short enough that a
+# hung run still ends.
+_MAX_ATTEMPTS = 200
+_RETRY_DELAY = 0.05
+
+# The keys each reply event models, so the stub can report an UNMODELLED extra
+# key back to the test that asked whether the kit probes tolerance for one.
+_MODELLED_KEYS: dict[str, frozenset[str]] = {
+    "turn.status": frozenset({"version", "target", "event", "status"}),
+    "reply.update": frozenset(
+        {"version", "target", "event", "text", "message", "settled", "nav"}
+    ),
+    "reply.post": frozenset({"version", "target", "event", "message", "requested_by"}),
+    "turn.completed": frozenset({"version", "target", "event", "event_id", "outcome"}),
+}
+
+STUB_MAIN = Path(__file__).with_name("stub_adapter_main.py")
+
+
+@dataclasses.dataclass(frozen=True)
+class StubBehavior:
+    """One adapter's behavior. Every default is the CONFORMANT choice."""
+
+    # Rule 3 (egress secret verification).
+    skips_secret_check: bool = False
+    side_effect_then_401: bool = False
+    accepts_when_secret_unset: bool = False
+    # Rule 4 (ack shape).
+    redirects: bool = False
+    empty_ack_body: bool = False
+    ack_body_bytes: int | None = None
+    ack_chunked_bytes: int | None = None
+    # Rule 5 (handles all four events).
+    rejects_turn_status: bool = False
+    # Rule 6 (dedupe on event_id).
+    double_sends_duplicate: bool = False
+    # Rule 1 (stable delivery_id).
+    fresh_delivery_id_per_retry: bool = False
+    # Rule 2 (an ingress response is final).
+    retries_after_202: bool = False
+    posts_an_unrelated_delivery: bool = False
+    # Rule 7 (stale credential handling).
+    exits_on_401: bool = False
+    drops_on_401: bool = False
+    self_mints_on_401: bool = False
+
+
+CONFORMANT = StubBehavior()
+
+# One named break per automatable clause, which is what makes the kit
+# falsifiable. Adding a clause to the kit without adding a break here leaves
+# that clause unproven.
+BREAKS: dict[str, StubBehavior] = {
+    "skips_secret_check": StubBehavior(skips_secret_check=True),
+    "side_effect_then_401": StubBehavior(side_effect_then_401=True),
+    "accepts_when_secret_unset": StubBehavior(accepts_when_secret_unset=True),
+    "redirects": StubBehavior(redirects=True),
+    "empty_ack_body": StubBehavior(empty_ack_body=True),
+    "rejects_turn_status": StubBehavior(rejects_turn_status=True),
+    "double_sends_duplicate": StubBehavior(double_sends_duplicate=True),
+    "fresh_delivery_id_per_retry": StubBehavior(fresh_delivery_id_per_retry=True),
+    "retries_after_202": StubBehavior(retries_after_202=True),
+    "posts_an_unrelated_delivery": StubBehavior(posts_an_unrelated_delivery=True),
+    "exits_on_401": StubBehavior(exits_on_401=True),
+    "drops_on_401": StubBehavior(drops_on_401=True),
+    "self_mints_on_401": StubBehavior(self_mints_on_401=True),
+}
+
+
+def free_port() -> int:
+    """An ephemeral port nothing holds. Never a hardcoded one: this box runs
+    parallel jobs and a fixed port collides."""
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def padded_ack(size: int) -> bytes:
+    """A valid JSON ack of EXACTLY ``size`` bytes."""
+
+    skeleton = b'{"ref": "stub-ref", "pad": ""}'
+    padding = size - len(skeleton)
+    if padding < 0:
+        raise ValueError(f"an ack cannot be shorter than {len(skeleton)} bytes")
+    return b'{"ref": "stub-ref", "pad": "' + b"a" * padding + b'"}'
+
+
+class _Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+    server_version = "curie-conformance-stub/1"
+
+    @property
+    def stub(self) -> StubAdapter:
+        return self.server.stub  # type: ignore[attr-defined]
+
+    def log_message(self, fmt: str, *args: Any) -> None:
+        return
+
+    def _json(self, status: int, payload: dict[str, Any]) -> None:
+        body = json.dumps(payload).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    @property
+    def route(self) -> str:
+        """The path with any query stripped.
+
+        An endpoint may legitimately carry a query (it can even BE part of the
+        credential), so routing on the raw path would 404 a real adapter URL.
+        """
+
+        return self.path.split("?", 1)[0]
+
+    def do_GET(self) -> None:
+        if self.route == "/_probe":
+            self._json(200, self.stub.probe())
+            return
+        self._json(404, {"error": "not found"})
+
+    def do_POST(self) -> None:
+        length = int(self.headers.get("Content-Length") or 0)
+        body = self.rfile.read(length) if length else b""
+        if self.route.startswith("/_control/"):
+            self._control(self.route, body)
+            return
+        if self.route == "/curie":
+            self._egress(body)
+            return
+        self._json(404, {"error": "not found"})
+
+    def _control(self, path: str, body: bytes) -> None:
+        stub = self.stub
+        payload: dict[str, Any] = json.loads(body) if body else {}
+        if path == "/_control/configure":
+            stub.configure(ingress_url=payload["ingress_url"], token=payload["token"])
+            self._json(200, {"ok": True})
+            return
+        if path == "/_control/stimulate":
+            delivery_id = stub.inject(str(payload["upstream_id"]))
+            self._json(200, {"delivery_id": delivery_id})
+            return
+        if path == "/_control/transport":
+            stub.set_reachable(bool(payload["reachable"]))
+            self._json(200, {"ok": True})
+            return
+        self._json(404, {"error": "not found"})
+
+    def _egress(self, body: bytes) -> None:
+        stub = self.stub
+        behavior = stub.behavior
+        secret = stub.secret
+        supplied = self.headers.get(SECRET_HEADER)
+
+        if secret is None and not behavior.accepts_when_secret_unset:
+            # Floor clause 3b: an adapter whose OWN secret is unset refuses
+            # everything rather than serving unauthenticated.
+            self._json(503, {"error": "egress secret is unset"})
+            return
+
+        authorized = behavior.skips_secret_check or (
+            secret is not None
+            and supplied is not None
+            and hmac.compare_digest(supplied, secret)
+        )
+        if secret is None and behavior.accepts_when_secret_unset:
+            authorized = True
+        if not authorized:
+            if behavior.side_effect_then_401:
+                # The break codex-7 named, and the reason clause 3a needs a
+                # probe: the side effect happens, THEN the rejection. The
+                # status is identical to the conformant one.
+                stub.handle_event(body)
+            self._json(401, {"error": "unauthorized"})
+            return
+
+        if stub.handle_event(body) == "reject":
+            self._json(500, {"error": "this adapter refuses that event"})
+            return
+        self._ack()
+
+    def _ack(self) -> None:
+        behavior = self.stub.behavior
+        if behavior.redirects:
+            self.send_response(302)
+            self.send_header("Location", "http://127.0.0.1:1/somewhere-else")
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+            return
+        if behavior.ack_chunked_bytes is not None:
+            self._chunked_ack(behavior.ack_chunked_bytes)
+            return
+        if behavior.empty_ack_body:
+            body = b""
+        elif behavior.ack_body_bytes is not None:
+            body = padded_ack(behavior.ack_body_bytes)
+        else:
+            body = b'{"ref": "stub-ref"}'
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        if body:
+            self.wfile.write(body)
+
+    def _chunked_ack(self, size: int) -> None:
+        """An oversize ack with NO content length, sent as small chunks.
+
+        A kit that trusts ``Content-Length``, or that does one sized read,
+        passes this. The worker's ``_read_capped`` is a loop for exactly this
+        reason, so the kit has to be one too.
+        """
+
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Transfer-Encoding", "chunked")
+        self.end_headers()
+        first = b'{"ref": "x", "pad": "'
+        self.wfile.write(f"{len(first):x}\r\n".encode() + first + b"\r\n")
+        remaining = size - len(first) - 2
+        block = b"a" * 8192
+        while remaining > 0:
+            piece = block[: min(len(block), remaining)]
+            self.wfile.write(f"{len(piece):x}\r\n".encode() + piece + b"\r\n")
+            remaining -= len(piece)
+        tail = b'"}'
+        self.wfile.write(f"{len(tail):x}\r\n".encode() + tail + b"\r\n")
+        self.wfile.write(b"0\r\n\r\n")
+
+
+class StubAdapter:
+    """One stub adapter: an egress endpoint plus an ingress sender.
+
+    ``state_path`` is what a restart survives on. A real adapter re reads its
+    upstream inbox after a restart; the stub writes the equivalent to a file, so
+    "resume the same delivery after an operator supplies a replacement token" is
+    a property of the stub rather than an artifact of shared memory.
+    """
+
+    def __init__(
+        self,
+        behavior: StubBehavior = CONFORMANT,
+        *,
+        secret: str | None,
+        state_path: Path,
+        port: int | None = None,
+        standalone: bool = False,
+    ) -> None:
+        self.behavior = behavior
+        self.secret = secret
+        self.state_path = state_path
+        self.port = port if port is not None else free_port()
+        self._standalone = standalone
+        self._lock = threading.Lock()
+        self._httpd: ThreadingHTTPServer | None = None
+        self._serve_thread: threading.Thread | None = None
+        self._sender_thread: threading.Thread | None = None
+        self._stopping = threading.Event()
+        self._pending: list[dict[str, str]] = []
+        self._dead_url = f"http://127.0.0.1:{free_port()}"
+        self.ingress_url: str | None = None
+        self.token: str | None = None
+        self.reachable = True
+        self.side_effects = 0
+        self.dropped = 0
+        self.stale_credential = False
+        self.held: list[dict[str, str]] = []
+        self.delivered: list[str] = []
+        self.seen_event_ids: list[str] = []
+        self.events: list[dict[str, Any]] = []
+        self._posted_unrelated = False
+
+    # -- lifecycle ---------------------------------------------------------
+
+    @property
+    def endpoint(self) -> str:
+        return f"http://127.0.0.1:{self.port}/curie"
+
+    @property
+    def base_url(self) -> str:
+        return f"http://127.0.0.1:{self.port}"
+
+    def start(self) -> None:
+        self._load_state()
+        self._stopping = threading.Event()
+        httpd = ThreadingHTTPServer(("127.0.0.1", self.port), _Handler)
+        httpd.daemon_threads = True
+        httpd.stub = self  # type: ignore[attr-defined]
+        self.port = int(httpd.server_address[1])
+        self._httpd = httpd
+        self._serve_thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+        self._serve_thread.start()
+        self._sender_thread = threading.Thread(target=self._send_loop, daemon=True)
+        self._sender_thread.start()
+
+    def stop(self) -> None:
+        self._stopping.set()
+        httpd, self._httpd = self._httpd, None
+        if httpd is not None:
+            httpd.shutdown()
+            httpd.server_close()
+        current = threading.current_thread()
+        for thread in (self._serve_thread, self._sender_thread):
+            # A thread never joins itself: the sender thread is what calls stop
+            # when the adapter simulates dying on a 401.
+            if thread is not None and thread is not current:
+                thread.join(timeout=5)
+        self._serve_thread = None
+        self._sender_thread = None
+
+    def restart(
+        self,
+        *,
+        secret: str | None | EllipsisType = ...,
+        token: str | None | EllipsisType = ...,
+    ) -> None:
+        """Restart on the SAME port, reloading only what was persisted."""
+
+        ingress_url = self.ingress_url
+        self.stop()
+        if not isinstance(secret, EllipsisType):
+            self.secret = secret
+        if not isinstance(token, EllipsisType):
+            self.token = token
+        self._pending = []
+        self.start()
+        self.ingress_url = ingress_url
+
+    def configure(self, *, ingress_url: str, token: str) -> None:
+        self.ingress_url = ingress_url
+        self.token = token
+        self.reachable = True
+
+    def set_reachable(self, reachable: bool) -> None:
+        self.reachable = reachable
+
+    # -- egress ------------------------------------------------------------
+
+    def handle_event(self, body: bytes) -> str:
+        """Record one reply event and perform its side effect. ``ok`` or ``reject``."""
+
+        try:
+            decoded = json.loads(body)
+        except ValueError:
+            decoded = None
+        with self._lock:
+            if not isinstance(decoded, dict):
+                self.events.append({"event": "<unparseable>", "extra_keys": []})
+                return "ok"
+            name = str(decoded.get("event"))
+            modelled = _MODELLED_KEYS.get(name, frozenset())
+            self.events.append(
+                {"event": name, "extra_keys": sorted(set(decoded) - modelled)}
+            )
+            if name == "turn.status" and self.behavior.rejects_turn_status:
+                return "reject"
+            if name == "turn.completed":
+                event_id = str(decoded.get("event_id"))
+                duplicate = event_id in self.seen_event_ids
+                if not duplicate:
+                    self.seen_event_ids.append(event_id)
+                if not duplicate or self.behavior.double_sends_duplicate:
+                    self.side_effects += 1
+                self._persist_locked()
+                return "ok"
+            self.side_effects += 1
+            self._persist_locked()
+            return "ok"
+
+    def probe(self) -> dict[str, Any]:
+        with self._lock:
+            return {
+                "side_effects": self.side_effects,
+                "dropped": self.dropped,
+                "stale_credential": self.stale_credential,
+                "held": len(self.held),
+                "delivered": list(self.delivered),
+                "seen_event_ids": list(self.seen_event_ids),
+                "events": list(self.events),
+            }
+
+    # -- ingress -----------------------------------------------------------
+
+    def inject(self, upstream_id: str) -> str:
+        """Deliver one upstream message. Returns the delivery_id it will send.
+
+        The derivation is documented and deterministic, which is what lets a
+        driver DECLARE the identity without reading anything back.
+        """
+
+        delivery_id = f"dlv-{upstream_id}"
+        with self._lock:
+            self._pending.append(
+                {
+                    "delivery_id": delivery_id,
+                    "conversation_id": f"conv-{upstream_id}",
+                    "author": "someone@example.test",
+                    "text": "hello",
+                }
+            )
+        return delivery_id
+
+    def _send_loop(self) -> None:
+        while not self._stopping.is_set():
+            with self._lock:
+                item = self._pending.pop(0) if self._pending else None
+            if item is None:
+                time.sleep(0.01)
+                continue
+            self._deliver(item)
+
+    def _deliver(self, item: dict[str, str]) -> None:
+        base = item["delivery_id"]
+        attempt = 0
+        while attempt < _MAX_ATTEMPTS and not self._stopping.is_set():
+            attempt += 1
+            if attempt == 1 or not self.behavior.fresh_delivery_id_per_retry:
+                delivery_id = base
+            else:
+                delivery_id = f"{base}-r{attempt}"
+            status = self._post_turn(delivery_id, item)
+            if status is None:
+                time.sleep(_RETRY_DELAY)
+                continue
+            self._on_status(status, delivery_id, item)
+            return
+        with self._lock:
+            self.dropped += 1
+            self._persist_locked()
+
+    def _on_status(self, status: int, delivery_id: str, item: dict[str, str]) -> None:
+        if status == 401:
+            self._on_stale_credential(item)
+            return
+        if 200 <= status < 300:
+            with self._lock:
+                self.delivered.append(delivery_id)
+                self._persist_locked()
+            if status == 202 and self.behavior.retries_after_202:
+                # Rule 2's break: a 202 is a RESPONSE, so it is final. Posting
+                # again after one is the defect.
+                time.sleep(_RETRY_DELAY)
+                self._post_turn(delivery_id, item)
+            if self.behavior.posts_an_unrelated_delivery and not self._posted_unrelated:
+                # A legitimate upstream redelivery under an identity the kit
+                # never declared. It must not red rule 2.
+                self._posted_unrelated = True
+                unrelated = f"dlv-unrelated-{uuid.uuid4().hex[:8]}"
+                self._post_turn(unrelated, dict(item, conversation_id="conv-unrelated"))
+            return
+        with self._lock:
+            self.dropped += 1
+            self._persist_locked()
+
+    def _on_stale_credential(self, item: dict[str, str]) -> None:
+        if self.behavior.exits_on_401:
+            self._die()
+            return
+        if self.behavior.drops_on_401:
+            with self._lock:
+                self.dropped += 1
+                self._persist_locked()
+            return
+        if self.behavior.self_mints_on_401:
+            # The trust boundary breach RULING 2 forbids: the adapter holds no
+            # platform key, so it must never try to mint its own replacement.
+            self._attempt_mint()
+        with self._lock:
+            self.stale_credential = True
+            self.held.append(item)
+            self._persist_locked()
+
+    def _die(self) -> None:
+        if self._standalone:
+            os._exit(3)
+        # In process, the equivalent observable is the endpoint going away with
+        # the in flight delivery unpersisted.
+        self.stop()
+
+    def _target(self) -> str | None:
+        if self.ingress_url is None:
+            return None
+        return self.ingress_url if self.reachable else self._dead_url
+
+    def _post_turn(self, delivery_id: str, item: dict[str, str]) -> int | None:
+        target = self._target()
+        if target is None:
+            return None
+        body = json.dumps(
+            {
+                "kind": os.environ.get("STUB_KIND", "email"),
+                "address": os.environ.get("STUB_ADDRESS", "agent@example.test"),
+                "delivery_id": delivery_id,
+                "conversation_id": item["conversation_id"],
+                "author": item["author"],
+                "text": item["text"],
+                "reply_ref": delivery_id,
+            }
+        ).encode()
+        request = urllib.request.Request(
+            f"{target}/channels/turns",
+            data=body,
+            headers={"Content-Type": "application/json", "X-API-Key": self.token or ""},
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=5) as response:
+                return int(response.status)
+        except urllib.error.HTTPError as error:
+            return int(error.code)
+        except (urllib.error.URLError, OSError, http.client.HTTPException):
+            return None
+
+    def _attempt_mint(self) -> None:
+        target = self._target()
+        if target is None:
+            return
+        request = urllib.request.Request(
+            f"{target}/channels/token",
+            data=json.dumps({"kind": "email", "address": "agent@example.test"}).encode(),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=5):
+                return
+        except (urllib.error.URLError, OSError, http.client.HTTPException):
+            return
+
+    # -- persistence -------------------------------------------------------
+
+    def _persist_locked(self) -> None:
+        self.state_path.write_text(
+            json.dumps(
+                {
+                    "side_effects": self.side_effects,
+                    "dropped": self.dropped,
+                    "stale_credential": self.stale_credential,
+                    "held": self.held,
+                    "delivered": self.delivered,
+                    "seen_event_ids": self.seen_event_ids,
+                    "events": self.events,
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    def _load_state(self) -> None:
+        if not self.state_path.exists():
+            return
+        state = json.loads(self.state_path.read_text(encoding="utf-8"))
+        self.side_effects = int(state.get("side_effects", 0))
+        self.dropped = int(state.get("dropped", 0))
+        self.stale_credential = bool(state.get("stale_credential", False))
+        self.delivered = list(state.get("delivered", []))
+        self.seen_event_ids = list(state.get("seen_event_ids", []))
+        self.events = list(state.get("events", []))
+        # A held delivery is what "did not silently drop it" means: it comes
+        # back out of the queue as soon as the adapter is running again.
+        self._pending = list(state.get("held", []))
+        self.held = []
+        self._persist_locked()
+
+
+def conformant_stub(
+    *,
+    secret: str | None,
+    state_path: Path,
+    port: int | None = None,
+    ack_body_bytes: int | None = None,
+    ack_chunked_bytes: int | None = None,
+) -> StubAdapter:
+    """A stub that satisfies every floor rule the kit can assert."""
+
+    behavior = dataclasses.replace(
+        CONFORMANT, ack_body_bytes=ack_body_bytes, ack_chunked_bytes=ack_chunked_bytes
+    )
+    return StubAdapter(behavior, secret=secret, state_path=state_path, port=port)
+
+
+def non_conformant_stub(
+    break_name: str,
+    *,
+    secret: str | None,
+    state_path: Path,
+    port: int | None = None,
+) -> StubAdapter:
+    """A stub that breaks exactly one floor clause."""
+
+    return StubAdapter(BREAKS[break_name], secret=secret, state_path=state_path, port=port)
+
+
+def serve_from_env() -> None:
+    """Run one stub as a standalone process, configured purely by environment."""
+
+    secret = os.environ.get("STUB_SECRET")
+    behavior_name = os.environ.get("STUB_BEHAVIOR", "conformant")
+    behavior = CONFORMANT if behavior_name == "conformant" else BREAKS[behavior_name]
+    stub = StubAdapter(
+        behavior,
+        secret=secret or None,
+        state_path=Path(os.environ["STUB_STATE"]),
+        port=int(os.environ["STUB_PORT"]),
+        standalone=True,
+    )
+    stub.start()
+    sys.stdout.write("ready\n")
+    sys.stdout.flush()
+    threading.Event().wait()
+
+
+# --- ingress drivers ---------------------------------------------------------
+
+
+class StubIngressDriver:
+    """The IN PROCESS driver: it holds the stub OBJECT.
+
+    That reference is the temptation FIX A exists to rule out. Anything the kit
+    correlates through this object rather than through the wire passes here and
+    fails under ``SubprocessIngressDriver``, which is the whole point of running
+    every ingress assertion under both.
+    """
+
+    def __init__(self, stub: StubAdapter) -> None:
+        self.stub = stub
+        self._stimuli = 0
+
+    def start(self, *, ingress_url: str, token: str) -> None:
+        self.stub.configure(ingress_url=ingress_url, token=token)
+
+    def stimulate(self) -> UpstreamIdentity:
+        self._stimuli += 1
+        upstream_id = uuid.uuid4().hex[:10]
+        delivery_id = self.stub.inject(upstream_id)
+        return UpstreamIdentity(
+            stimulus_id=f"in-process-{self._stimuli}", delivery_id=delivery_id
+        )
+
+    def set_transport(self, *, reachable: bool) -> None:
+        self.stub.set_reachable(reachable)
+
+    def restart(
+        self,
+        *,
+        egress_secret: str | None | EllipsisType = ...,
+        token: str | None | EllipsisType = ...,
+    ) -> None:
+        self.stub.restart(secret=egress_secret, token=token)
+
+    def stop(self) -> None:
+        self.stub.stop()
+
+
+class SubprocessIngressDriver:
+    """The OUT OF PROCESS driver: a ``subprocess.Popen`` and an HTTP surface.
+
+    It shares no memory with the kit or with the stub, so the only thing that
+    can correlate an observed post to a stimulus is the ``delivery_id`` this
+    driver declares and the adapter puts on the wire.
+    """
+
+    def __init__(
+        self,
+        *,
+        port: int,
+        secret: str | None,
+        state_path: Path,
+        behavior_name: str = "conformant",
+    ) -> None:
+        self.port = port
+        self.secret = secret
+        self.state_path = state_path
+        self.behavior_name = behavior_name
+        self._process: Any = None
+        self._token: str | None = None
+        self._ingress_url: str | None = None
+        self._stimuli = 0
+
+    @property
+    def endpoint(self) -> str:
+        return f"http://127.0.0.1:{self.port}/curie"
+
+    @property
+    def base_url(self) -> str:
+        return f"http://127.0.0.1:{self.port}"
+
+    def boot(self) -> None:
+        """Start the adapter process without pointing it at an ingress yet.
+
+        The egress rules run against a live endpoint before any ingress rule
+        does, so the fixture boots the adapter and ``start`` only configures it.
+        """
+
+        if self._process is None:
+            self._spawn()
+
+    def _spawn(self) -> None:
+        env = dict(os.environ)
+        env.update(
+            {
+                "STUB_PORT": str(self.port),
+                "STUB_BEHAVIOR": self.behavior_name,
+                "STUB_STATE": str(self.state_path),
+            }
+        )
+        if self.secret is None:
+            env.pop("STUB_SECRET", None)
+        else:
+            env["STUB_SECRET"] = self.secret
+        self._process = subprocess.Popen(
+            [sys.executable, str(STUB_MAIN)],
+            env=env,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        wait_until_ready(self.base_url)
+
+    def _kill(self) -> None:
+        process, self._process = self._process, None
+        if process is None:
+            return
+        process.terminate()
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=5)
+
+    def start(self, *, ingress_url: str, token: str) -> None:
+        self._ingress_url = ingress_url
+        self._token = token
+        if self._process is None:
+            self._spawn()
+        control(self.base_url, "configure", {"ingress_url": ingress_url, "token": token})
+
+    def stimulate(self) -> UpstreamIdentity:
+        self._stimuli += 1
+        upstream_id = uuid.uuid4().hex[:10]
+        control(self.base_url, "stimulate", {"upstream_id": upstream_id})
+        # DECLARED, not read back: the derivation is the documented contract.
+        return UpstreamIdentity(
+            stimulus_id=f"subprocess-{self._stimuli}", delivery_id=f"dlv-{upstream_id}"
+        )
+
+    def set_transport(self, *, reachable: bool) -> None:
+        control(self.base_url, "transport", {"reachable": reachable})
+
+    def restart(
+        self,
+        *,
+        egress_secret: str | None | EllipsisType = ...,
+        token: str | None | EllipsisType = ...,
+    ) -> None:
+        if not isinstance(egress_secret, EllipsisType):
+            self.secret = egress_secret
+        if not isinstance(token, EllipsisType):
+            self._token = token
+        self._kill()
+        self._spawn()
+        if self._ingress_url is not None:
+            control(
+                self.base_url,
+                "configure",
+                {"ingress_url": self._ingress_url, "token": self._token or ""},
+            )
+
+    def stop(self) -> None:
+        self._kill()
+
+
+class LyingIngressDriver:
+    """A driver that declares a delivery_id its adapter will never send.
+
+    The honest verdict for it is a rule 1 FAILURE naming the mismatch. A kit
+    that reads it as conformant would certify every broken vendor driver.
+    """
+
+    def __init__(self, inner: StubIngressDriver | SubprocessIngressDriver) -> None:
+        self.inner = inner
+
+    def start(self, *, ingress_url: str, token: str) -> None:
+        self.inner.start(ingress_url=ingress_url, token=token)
+
+    def stimulate(self) -> UpstreamIdentity:
+        declared = self.inner.stimulate()
+        return UpstreamIdentity(
+            stimulus_id=declared.stimulus_id,
+            delivery_id=f"never-sent-{uuid.uuid4().hex[:8]}",
+        )
+
+    def set_transport(self, *, reachable: bool) -> None:
+        self.inner.set_transport(reachable=reachable)
+
+    def restart(
+        self,
+        *,
+        egress_secret: str | None | EllipsisType = ...,
+        token: str | None | EllipsisType = ...,
+    ) -> None:
+        self.inner.restart(egress_secret=egress_secret, token=token)
+
+    def stop(self) -> None:
+        self.inner.stop()
+
+
+def subprocess_driver_from_env() -> SubprocessIngressDriver:
+    """A ``--driver module:attr`` target, so the CLI's driver loading is exercised."""
+
+    driver = SubprocessIngressDriver(
+        port=int(os.environ["STUB_PORT"]),
+        secret=os.environ.get("STUB_SECRET"),
+        state_path=Path(os.environ["STUB_STATE"]),
+        behavior_name=os.environ.get("STUB_BEHAVIOR", "conformant"),
+    )
+    # Booted here rather than in ``start``, so the egress rules find a live
+    # endpoint whichever order the kit runs its rules in.
+    driver.boot()
+    return driver
+
+
+# --- helpers shared by the test modules --------------------------------------
+
+
+def control(base_url: str, verb: str, payload: dict[str, Any]) -> dict[str, Any]:
+    """Drive a stub's control surface over HTTP, the way a vendor driver would."""
+
+    request = urllib.request.Request(
+        f"{base_url}/_control/{verb}",
+        data=json.dumps(payload).encode(),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=10) as response:
+        decoded: dict[str, Any] = json.loads(response.read())
+        return decoded
+
+
+def wait_until_ready(base_url: str, *, timeout_s: float = 20.0) -> None:
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        try:
+            with urllib.request.urlopen(f"{base_url}/_probe", timeout=1):
+                return
+        except (urllib.error.URLError, OSError, http.client.HTTPException):
+            time.sleep(0.02)
+    raise AssertionError(f"{base_url} never became ready")
+
+
+def read_probe(base_url: str) -> dict[str, Any]:
+    with urllib.request.urlopen(f"{base_url}/_probe", timeout=10) as response:
+        decoded: dict[str, Any] = json.loads(response.read())
+        return decoded
+
+
+def side_effect_probe_for(base_url: str) -> Callable[[], int]:
+    """The kit's side effect probe: an integer count, read over HTTP.
+
+    Over HTTP rather than off an object, so the same probe works against a
+    subprocess stub and against a vendor adapter in another language.
+    """
+
+    def probe() -> int:
+        return int(read_probe(base_url)["side_effects"])
+
+    return probe
+
+
+def rule(report: FloorReport, number: int) -> FloorResult:
+    for result in report.results:
+        if result.rule == number:
+            return result
+    raise AssertionError(f"the report carries no rule {number}: {report.detail()}")
+
+
+def rule_status(report: FloorReport, number: int) -> str:
+    return rule(report, number).status
+
+
+def clauses(report: FloorReport) -> Iterator[ClauseResult]:
+    for result in report.results:
+        yield from result.clauses
+
+
+def clause(report: FloorReport, clause_id: str) -> ClauseResult:
+    for candidate in clauses(report):
+        if candidate.clause == clause_id:
+            return candidate
+    raise AssertionError(f"the report carries no clause {clause_id}: {report.detail()}")
+
+
+def clause_status(report: FloorReport, clause_id: str) -> str:
+    return clause(report, clause_id).status
+
+
+def random_secret() -> str:
+    return f"stub-secret-{uuid.uuid4().hex}"

--- a/packages/channel-protocol/tests/conformance_stubs.py
+++ b/packages/channel-protocol/tests/conformance_stubs.py
@@ -80,6 +80,10 @@ class StubBehavior:
     rejects_turn_status: bool = False
     # Rule 6 (dedupe on event_id, and tolerate a finished conversation).
     double_sends_duplicate: bool = False
+    # How long after the redelivery the second correspondent effect lands. The
+    # ack is an immediate 200 either way, so a count sampled when it arrives
+    # reads a delta of one and the adapter answered the correspondent twice.
+    duplicate_side_effect_delay_s: float = 0.0
     # Treats its own retirement of a conversation as final: the exact duplicate
     # is tolerated, and a NEW event_id for that conversation is refused. A
     # multi turn conversation and an outage sweeper both produce that traffic.
@@ -150,6 +154,18 @@ BREAKS: dict[str, StubBehavior] = {
         side_effect_then_401=True, side_effect_delay_s=0.1
     ),
     "side_effect_when_secret_unset": StubBehavior(side_effect_when_secret_unset=True),
+    # The same three breaks, each delayed past any quiet window a kit could
+    # infer finality from. None of them is adversarial: an adapter that hands
+    # its work to a queue looks exactly like this.
+    "slowly_delayed_side_effect_then_401": StubBehavior(
+        side_effect_then_401=True, side_effect_delay_s=1.2
+    ),
+    "slowly_serves_when_secret_unset": StubBehavior(
+        side_effect_when_secret_unset=True, side_effect_delay_s=1.2
+    ),
+    "delayed_duplicate_side_effect": StubBehavior(
+        double_sends_duplicate=True, duplicate_side_effect_delay_s=0.2
+    ),
     "drops_on_401_and_posts_unrelated_after_restart": StubBehavior(
         drops_on_401=True, posts_unrelated_after_restart=True
     ),
@@ -529,13 +545,32 @@ class StubAdapter:
                     self.finished_conversations.append(conversation)
                 if not duplicate:
                     self.seen_event_ids.append(event_id)
-                if not duplicate or self.behavior.double_sends_duplicate:
+                if duplicate and self.behavior.duplicate_side_effect_delay_s:
+                    # Answered twice, with the second answer on a timer. The ack
+                    # for the redelivery is still an immediate 200.
+                    self._schedule_increment_locked(
+                        self.behavior.duplicate_side_effect_delay_s
+                    )
+                elif not duplicate or self.behavior.double_sends_duplicate:
                     self.side_effects += 1
                 self._persist_locked()
                 return "ok"
             self.side_effects += 1
             self._persist_locked()
             return "ok"
+
+    def _schedule_increment_locked(self, delay: float) -> None:
+        """Move the side effect count later. Caller already holds ``_lock``."""
+
+        def bump() -> None:
+            with self._lock:
+                self.side_effects += 1
+                self._persist_locked()
+
+        timer = threading.Timer(delay, bump)
+        timer.daemon = True
+        self._timers.append(timer)
+        timer.start()
 
     def perform_side_effect(self, body: bytes) -> None:
         """Answer the correspondent, possibly AFTER the response has gone out.
@@ -1098,6 +1133,86 @@ class RacingIngressDriver:
 
     def settled(self, identity: UpstreamIdentity) -> bool:
         return self.inner.settled(identity)
+
+    def restart(
+        self,
+        *,
+        egress_secret: str | None | EllipsisType = ...,
+        token: str | None | EllipsisType = ...,
+    ) -> None:
+        self.inner.restart(egress_secret=egress_secret, token=token)
+
+    def stop(self) -> None:
+        self.inner.stop()
+
+
+class EagerlySettledDriver:
+    """A driver that reports every delivery retired the moment it is asked.
+
+    The naive implementation, and the one a vendor writes first: it answers
+    from an empty active queue and does not know about the retry its adapter has
+    sitting on a timer. Not hostile, which is the point. The kit has to catch it
+    and say which half of the contract broke, because the vendor who wrote it is
+    the same person who wrote the adapter and will otherwise ship believing the
+    kit checked something.
+    """
+
+    def __init__(self, inner: StubIngressDriver | SubprocessIngressDriver) -> None:
+        self.inner = inner
+
+    def start(self, *, ingress_url: str, token: str) -> None:
+        self.inner.start(ingress_url=ingress_url, token=token)
+
+    def reserve(self) -> UpstreamIdentity:
+        return self.inner.reserve()
+
+    def release(self, identity: UpstreamIdentity) -> None:
+        self.inner.release(identity)
+
+    def settled(self, identity: UpstreamIdentity) -> bool:
+        return True
+
+    def restart(
+        self,
+        *,
+        egress_secret: str | None | EllipsisType = ...,
+        token: str | None | EllipsisType = ...,
+    ) -> None:
+        self.inner.restart(egress_secret=egress_secret, token=token)
+
+    def stop(self) -> None:
+        self.inner.stop()
+
+
+class BlockingSettledDriver:
+    """A driver whose ``settled`` waits for an event that never fires.
+
+    The shape a vendor reaches for when quiescence is signalled internally: wait
+    on the completion the adapter is supposed to publish. When the adapter never
+    publishes it, a kit that calls the callback inline never returns to its own
+    deadline, and the promised failure becomes a hang. The event is exposed so a
+    test can release the blocked thread during teardown instead of leaving it
+    sleeping.
+    """
+
+    def __init__(self, inner: StubIngressDriver | SubprocessIngressDriver) -> None:
+        self.inner = inner
+        self.released = threading.Event()
+        self.calls = 0
+
+    def start(self, *, ingress_url: str, token: str) -> None:
+        self.inner.start(ingress_url=ingress_url, token=token)
+
+    def reserve(self) -> UpstreamIdentity:
+        return self.inner.reserve()
+
+    def release(self, identity: UpstreamIdentity) -> None:
+        self.inner.release(identity)
+
+    def settled(self, identity: UpstreamIdentity) -> bool:
+        self.calls += 1
+        self.released.wait()
+        return True
 
     def restart(
         self,

--- a/packages/channel-protocol/tests/conformance_stubs.py
+++ b/packages/channel-protocol/tests/conformance_stubs.py
@@ -36,6 +36,7 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from types import EllipsisType
 from typing import Any
+from urllib.parse import urlsplit
 
 from channel_protocol.conformance import ClauseResult, FloorReport, FloorResult, UpstreamIdentity
 
@@ -49,17 +50,6 @@ SECRET_HEADER = "X-Curie-Adapter-Secret"
 _MAX_ATTEMPTS = 200
 _RETRY_DELAY = 0.05
 
-# The keys each reply event models, so the stub can report an UNMODELLED extra
-# key back to the test that asked whether the kit probes tolerance for one.
-_MODELLED_KEYS: dict[str, frozenset[str]] = {
-    "turn.status": frozenset({"version", "target", "event", "status"}),
-    "reply.update": frozenset(
-        {"version", "target", "event", "text", "message", "settled", "nav"}
-    ),
-    "reply.post": frozenset({"version", "target", "event", "message", "requested_by"}),
-    "turn.completed": frozenset({"version", "target", "event", "event_id", "outcome"}),
-}
-
 STUB_MAIN = Path(__file__).with_name("stub_adapter_main.py")
 
 
@@ -71,24 +61,48 @@ class StubBehavior:
     skips_secret_check: bool = False
     side_effect_then_401: bool = False
     accepts_when_secret_unset: bool = False
+    # The side effect a refused request performs ANYWAY, scheduled after the
+    # refusal has already been answered. The status is a conformant 401 and the
+    # correspondent was answered, so only a count taken after the work settles
+    # separates this from a correct adapter.
+    side_effect_delay_s: float = 0.0
+    # Clause 3b: with its OWN secret unset, refuse the request and serve it.
+    side_effect_when_secret_unset: bool = False
     # Rule 4 (ack shape).
     redirects: bool = False
     empty_ack_body: bool = False
     ack_body_bytes: int | None = None
     ack_chunked_bytes: int | None = None
+    # A valid probe payload padded past the ack cap, sent as small chunks. A kit
+    # that reads the probe with one unbounded call buffers the whole thing.
+    probe_chunked_bytes: int | None = None
     # Rule 5 (handles all four events).
     rejects_turn_status: bool = False
     # Rule 6 (dedupe on event_id).
     double_sends_duplicate: bool = False
     # Rule 1 (stable delivery_id).
     fresh_delivery_id_per_retry: bool = False
+    # How long the adapter waits before its FIRST attempt. Long enough and a
+    # fixed outage window is over before the adapter ever meets it.
+    slow_start_s: float = 0.0
+    drops_on_transport_failure: bool = False
     # Rule 2 (an ingress response is final).
     retries_after_202: bool = False
+    # How long after the 202 the retry goes out. Longer than any fixed finality
+    # window and the defect happens after the verdict was taken.
+    retry_after_202_delay_s: float = _RETRY_DELAY
     posts_an_unrelated_delivery: bool = False
+    # Rule 7: on restart, post something the kit never declared.
+    posts_unrelated_after_restart: bool = False
     # Rule 7 (stale credential handling).
     exits_on_401: bool = False
     drops_on_401: bool = False
     self_mints_on_401: bool = False
+    # Evidence suppression: the offending ingress post goes out under a
+    # Content-Length the ingress cannot use. The adapter under test writes its
+    # own request headers, so a kit that lets a header parse failure destroy the
+    # observation lets the adapter choose what the kit is able to see.
+    evades_with_bad_content_length: bool = False
 
 
 CONFORMANT = StubBehavior()
@@ -110,6 +124,30 @@ BREAKS: dict[str, StubBehavior] = {
     "exits_on_401": StubBehavior(exits_on_401=True),
     "drops_on_401": StubBehavior(drops_on_401=True),
     "self_mints_on_401": StubBehavior(self_mints_on_401=True),
+    # The two evasions: the same break, with the offending post hidden behind a
+    # Content-Length the ingress cannot parse. Each must reach the SAME verdict
+    # as the honest break above it.
+    "retries_after_202_evasively": StubBehavior(
+        retries_after_202=True, evades_with_bad_content_length=True
+    ),
+    "self_mints_on_401_evasively": StubBehavior(
+        self_mints_on_401=True, evades_with_bad_content_length=True
+    ),
+    # The timing evasions: the same defects, arranged so a kit deciding on a
+    # fixed wall clock window records the conformant half and stops watching.
+    "slow_start_and_drops_on_transport_failure": StubBehavior(
+        slow_start_s=0.25, drops_on_transport_failure=True
+    ),
+    "retries_late_after_202": StubBehavior(
+        retries_after_202=True, retry_after_202_delay_s=0.65
+    ),
+    "delayed_side_effect_then_401": StubBehavior(
+        side_effect_then_401=True, side_effect_delay_s=0.1
+    ),
+    "side_effect_when_secret_unset": StubBehavior(side_effect_when_secret_unset=True),
+    "drops_on_401_and_posts_unrelated_after_restart": StubBehavior(
+        drops_on_401=True, posts_unrelated_after_restart=True
+    ),
 }
 
 
@@ -120,6 +158,46 @@ def free_port() -> int:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         sock.bind(("127.0.0.1", 0))
         return int(sock.getsockname()[1])
+
+
+def post_with_declared_length(
+    url: str, body: bytes, headers: dict[str, str], *, declared_length: str
+) -> int:
+    """POST with a Content-Length the CALLER chooses, honest or not.
+
+    ``urllib`` computes that header itself, so a raw connection is the only way
+    to send the framing a hostile or broken adapter would send. Returns the
+    status, and raises on a transport failure so a caller that expected an
+    answer cannot mistake a dead connection for one.
+    """
+
+    parsed = urlsplit(url)
+    connection = http.client.HTTPConnection(
+        parsed.hostname or "127.0.0.1", parsed.port, timeout=10
+    )
+    try:
+        connection.putrequest("POST", parsed.path)
+        for name, value in headers.items():
+            connection.putheader(name, value)
+        connection.putheader("Content-Length", declared_length)
+        connection.endheaders()
+        connection.send(body)
+        return int(connection.getresponse().status)
+    finally:
+        connection.close()
+
+
+def _post_unparseable_length(
+    url: str, body: bytes, headers: dict[str, str]
+) -> int | None:
+    """The evasion: a Content-Length no server can turn into a number."""
+
+    try:
+        return post_with_declared_length(
+            url, body, headers, declared_length=f"{len(body)}x"
+        )
+    except (OSError, http.client.HTTPException):
+        return None
 
 
 def padded_ack(size: int) -> bytes:
@@ -163,6 +241,13 @@ class _Handler(BaseHTTPRequestHandler):
 
     def do_GET(self) -> None:
         if self.route == "/_probe":
+            oversize = self.stub.behavior.probe_chunked_bytes
+            if oversize is not None:
+                # A VALID probe payload, just far too large. A kit that reads it
+                # unbounded returns the count and buffers the padding, so this
+                # break is only caught by a cap and never by a parse error.
+                self._chunked_json(b'{"side_effects": 0, "pad": "', oversize)
+                return
             self._json(200, self.stub.probe())
             return
         self._json(404, {"error": "not found"})
@@ -189,9 +274,8 @@ class _Handler(BaseHTTPRequestHandler):
             delivery_id = stub.inject(str(payload["upstream_id"]))
             self._json(200, {"delivery_id": delivery_id})
             return
-        if path == "/_control/transport":
-            stub.set_reachable(bool(payload["reachable"]))
-            self._json(200, {"ok": True})
+        if path == "/_control/retired":
+            self._json(200, {"retired": stub.is_retired(str(payload["delivery_id"]))})
             return
         self._json(404, {"error": "not found"})
 
@@ -204,6 +288,10 @@ class _Handler(BaseHTTPRequestHandler):
         if secret is None and not behavior.accepts_when_secret_unset:
             # Floor clause 3b: an adapter whose OWN secret is unset refuses
             # everything rather than serving unauthenticated.
+            if behavior.side_effect_when_secret_unset:
+                # The 3b break the status cannot show: the correspondent is
+                # answered and the response is a clean refusal.
+                stub.perform_side_effect(body)
             self._json(503, {"error": "egress secret is unset"})
             return
 
@@ -218,8 +306,9 @@ class _Handler(BaseHTTPRequestHandler):
             if behavior.side_effect_then_401:
                 # The break codex-7 named, and the reason clause 3a needs a
                 # probe: the side effect happens, THEN the rejection. The
-                # status is identical to the conformant one.
-                stub.handle_event(body)
+                # status is identical to the conformant one, and with a delay
+                # the count is identical too at the instant of the response.
+                stub.perform_side_effect(body)
             self._json(401, {"error": "unauthorized"})
             return
 
@@ -237,7 +326,7 @@ class _Handler(BaseHTTPRequestHandler):
             self.end_headers()
             return
         if behavior.ack_chunked_bytes is not None:
-            self._chunked_ack(behavior.ack_chunked_bytes)
+            self._chunked_json(b'{"ref": "x", "pad": "', behavior.ack_chunked_bytes)
             return
         if behavior.empty_ack_body:
             body = b""
@@ -252,19 +341,21 @@ class _Handler(BaseHTTPRequestHandler):
         if body:
             self.wfile.write(body)
 
-    def _chunked_ack(self, size: int) -> None:
-        """An oversize ack with NO content length, sent as small chunks.
+    def _chunked_json(self, head: bytes, size: int) -> None:
+        """An oversize JSON body with NO content length, sent as small chunks.
 
         A kit that trusts ``Content-Length``, or that does one sized read,
         passes this. The worker's ``_read_capped`` is a loop for exactly this
-        reason, so the kit has to be one too.
+        reason, so every read the kit makes has to be one too. ``head`` opens
+        the object, so the same writer serves an acknowledgement and a side
+        effect probe response.
         """
 
         self.send_response(200)
         self.send_header("Content-Type", "application/json")
         self.send_header("Transfer-Encoding", "chunked")
         self.end_headers()
-        first = b'{"ref": "x", "pad": "'
+        first = head
         self.wfile.write(f"{len(first):x}\r\n".encode() + first + b"\r\n")
         remaining = size - len(first) - 2
         block = b"a" * 8192
@@ -306,10 +397,11 @@ class StubAdapter:
         self._sender_thread: threading.Thread | None = None
         self._stopping = threading.Event()
         self._pending: list[dict[str, str]] = []
-        self._dead_url = f"http://127.0.0.1:{free_port()}"
+        self._retired: set[str] = set()
+        self._timers: list[threading.Timer] = []
+        self._starts = 0
         self.ingress_url: str | None = None
         self.token: str | None = None
-        self.reachable = True
         self.side_effects = 0
         self.dropped = 0
         self.stale_credential = False
@@ -332,6 +424,7 @@ class StubAdapter:
     def start(self) -> None:
         self._load_state()
         self._stopping = threading.Event()
+        self._starts += 1
         httpd = ThreadingHTTPServer(("127.0.0.1", self.port), _Handler)
         httpd.daemon_threads = True
         httpd.stub = self  # type: ignore[attr-defined]
@@ -341,9 +434,18 @@ class StubAdapter:
         self._serve_thread.start()
         self._sender_thread = threading.Thread(target=self._send_loop, daemon=True)
         self._sender_thread.start()
+        if self.behavior.posts_unrelated_after_restart and self._starts > 1:
+            # Rule 7's break that a bare "some 2xx arrived" predicate reads as a
+            # resume: the held delivery is gone and something else takes its
+            # place on the wire.
+            self.inject(f"unrelated-after-restart-{uuid.uuid4().hex[:8]}")
 
     def stop(self) -> None:
         self._stopping.set()
+        with self._lock:
+            timers, self._timers = self._timers, []
+        for timer in timers:
+            timer.cancel()
         httpd, self._httpd = self._httpd, None
         if httpd is not None:
             httpd.shutdown()
@@ -372,16 +474,14 @@ class StubAdapter:
         if not isinstance(token, EllipsisType):
             self.token = token
         self._pending = []
-        self.start()
+        # Restored BEFORE the send loop exists, so a resumed delivery never
+        # races the configuration it needs.
         self.ingress_url = ingress_url
+        self.start()
 
     def configure(self, *, ingress_url: str, token: str) -> None:
         self.ingress_url = ingress_url
         self.token = token
-        self.reachable = True
-
-    def set_reachable(self, reachable: bool) -> None:
-        self.reachable = reachable
 
     # -- egress ------------------------------------------------------------
 
@@ -394,13 +494,10 @@ class StubAdapter:
             decoded = None
         with self._lock:
             if not isinstance(decoded, dict):
-                self.events.append({"event": "<unparseable>", "extra_keys": []})
+                self.events.append({"event": "<unparseable>"})
                 return "ok"
             name = str(decoded.get("event"))
-            modelled = _MODELLED_KEYS.get(name, frozenset())
-            self.events.append(
-                {"event": name, "extra_keys": sorted(set(decoded) - modelled)}
-            )
+            self.events.append({"event": name})
             if name == "turn.status" and self.behavior.rejects_turn_status:
                 return "reject"
             if name == "turn.completed":
@@ -416,6 +513,24 @@ class StubAdapter:
             self._persist_locked()
             return "ok"
 
+    def perform_side_effect(self, body: bytes) -> None:
+        """Answer the correspondent, possibly AFTER the response has gone out.
+
+        A real adapter that hands the work to a queue does exactly this, so a
+        delay here is a plausible adapter and not a contrived one. It is also
+        invisible to any check that reads a count the moment a response lands.
+        """
+
+        delay = self.behavior.side_effect_delay_s
+        if not delay:
+            self.handle_event(body)
+            return
+        timer = threading.Timer(delay, self.handle_event, args=(body,))
+        timer.daemon = True
+        with self._lock:
+            self._timers.append(timer)
+        timer.start()
+
     def probe(self) -> dict[str, Any]:
         with self._lock:
             return {
@@ -426,6 +541,7 @@ class StubAdapter:
                 "delivered": list(self.delivered),
                 "seen_event_ids": list(self.seen_event_ids),
                 "events": list(self.events),
+                "retired": sorted(self._retired),
             }
 
     # -- ingress -----------------------------------------------------------
@@ -434,11 +550,12 @@ class StubAdapter:
         """Deliver one upstream message. Returns the delivery_id it will send.
 
         The derivation is documented and deterministic, which is what lets a
-        driver DECLARE the identity without reading anything back.
+        driver DECLARE the identity before this is ever called.
         """
 
         delivery_id = f"dlv-{upstream_id}"
         with self._lock:
+            self._retired.discard(delivery_id)
             self._pending.append(
                 {
                     "delivery_id": delivery_id,
@@ -449,6 +566,17 @@ class StubAdapter:
             )
         return delivery_id
 
+    def is_retired(self, delivery_id: str) -> bool:
+        """Whether this delivery is done: acknowledged, or given up on.
+
+        The stub's answer to the driver contract's quiescence barrier. It is set
+        only once ``_deliver`` has returned for that identity, so an adapter
+        still inside a retry (however slow) is never reported retired.
+        """
+
+        with self._lock:
+            return delivery_id in self._retired
+
     def _send_loop(self) -> None:
         while not self._stopping.is_set():
             with self._lock:
@@ -456,19 +584,43 @@ class StubAdapter:
             if item is None:
                 time.sleep(0.01)
                 continue
-            self._deliver(item)
+            try:
+                self._deliver(item)
+            finally:
+                # Retired means "this adapter is done with the identity", pass
+                # or fail. Set here rather than on the success path, so a
+                # delivery that was dropped still stops the kit waiting on it.
+                with self._lock:
+                    self._retired.add(item["delivery_id"])
+                    self._persist_locked()
 
     def _deliver(self, item: dict[str, str]) -> None:
         base = item["delivery_id"]
+        if self.behavior.slow_start_s:
+            # A first attempt late enough that a fixed outage window would be
+            # over before it happens.
+            time.sleep(self.behavior.slow_start_s)
         attempt = 0
         while attempt < _MAX_ATTEMPTS and not self._stopping.is_set():
+            if self._target() is None:
+                # Not yet pointed at an ingress. Waiting to be configured is not
+                # a delivery attempt, and counting it as one would make a
+                # restart consume an attempt and rename the delivery under
+                # `fresh_delivery_id_per_retry` before it ever touched the wire.
+                time.sleep(_RETRY_DELAY)
+                continue
             attempt += 1
             if attempt == 1 or not self.behavior.fresh_delivery_id_per_retry:
                 delivery_id = base
             else:
                 delivery_id = f"{base}-r{attempt}"
-            status = self._post_turn(delivery_id, item)
+            status = self._post_turn(delivery_id, item, evasive=False)
             if status is None:
+                if self.behavior.drops_on_transport_failure:
+                    with self._lock:
+                        self.dropped += 1
+                        self._persist_locked()
+                    return
                 time.sleep(_RETRY_DELAY)
                 continue
             self._on_status(status, delivery_id, item)
@@ -488,14 +640,20 @@ class StubAdapter:
             if status == 202 and self.behavior.retries_after_202:
                 # Rule 2's break: a 202 is a RESPONSE, so it is final. Posting
                 # again after one is the defect.
-                time.sleep(_RETRY_DELAY)
-                self._post_turn(delivery_id, item)
+                time.sleep(self.behavior.retry_after_202_delay_s)
+                self._post_turn(
+                    delivery_id,
+                    item,
+                    evasive=self.behavior.evades_with_bad_content_length,
+                )
             if self.behavior.posts_an_unrelated_delivery and not self._posted_unrelated:
                 # A legitimate upstream redelivery under an identity the kit
                 # never declared. It must not red rule 2.
                 self._posted_unrelated = True
                 unrelated = f"dlv-unrelated-{uuid.uuid4().hex[:8]}"
-                self._post_turn(unrelated, dict(item, conversation_id="conv-unrelated"))
+                self._post_turn(
+                    unrelated, dict(item, conversation_id="conv-unrelated"), evasive=False
+                )
             return
         with self._lock:
             self.dropped += 1
@@ -527,11 +685,11 @@ class StubAdapter:
         self.stop()
 
     def _target(self) -> str | None:
-        if self.ingress_url is None:
-            return None
-        return self.ingress_url if self.reachable else self._dead_url
+        return self.ingress_url
 
-    def _post_turn(self, delivery_id: str, item: dict[str, str]) -> int | None:
+    def _post_turn(
+        self, delivery_id: str, item: dict[str, str], *, evasive: bool
+    ) -> int | None:
         target = self._target()
         if target is None:
             return None
@@ -546,11 +704,11 @@ class StubAdapter:
                 "reply_ref": delivery_id,
             }
         ).encode()
+        headers = {"Content-Type": "application/json", "X-API-Key": self.token or ""}
+        if evasive:
+            return _post_unparseable_length(f"{target}/channels/turns", body, headers)
         request = urllib.request.Request(
-            f"{target}/channels/turns",
-            data=body,
-            headers={"Content-Type": "application/json", "X-API-Key": self.token or ""},
-            method="POST",
+            f"{target}/channels/turns", data=body, headers=headers, method="POST"
         )
         try:
             with urllib.request.urlopen(request, timeout=5) as response:
@@ -564,11 +722,13 @@ class StubAdapter:
         target = self._target()
         if target is None:
             return
+        body = json.dumps({"kind": "email", "address": "agent@example.test"}).encode()
+        headers = {"Content-Type": "application/json"}
+        if self.behavior.evades_with_bad_content_length:
+            _post_unparseable_length(f"{target}/channels/token", body, headers)
+            return
         request = urllib.request.Request(
-            f"{target}/channels/token",
-            data=json.dumps({"kind": "email", "address": "agent@example.test"}).encode(),
-            headers={"Content-Type": "application/json"},
-            method="POST",
+            f"{target}/channels/token", data=body, headers=headers, method="POST"
         )
         try:
             with urllib.request.urlopen(request, timeout=5):
@@ -589,6 +749,7 @@ class StubAdapter:
                     "delivered": self.delivered,
                     "seen_event_ids": self.seen_event_ids,
                     "events": self.events,
+                    "retired": sorted(self._retired),
                 }
             ),
             encoding="utf-8",
@@ -604,6 +765,7 @@ class StubAdapter:
         self.delivered = list(state.get("delivered", []))
         self.seen_event_ids = list(state.get("seen_event_ids", []))
         self.events = list(state.get("events", []))
+        self._retired = set(state.get("retired", []))
         # A held delivery is what "did not silently drop it" means: it comes
         # back out of the queue as soon as the adapter is running again.
         self._pending = list(state.get("held", []))
@@ -618,11 +780,15 @@ def conformant_stub(
     port: int | None = None,
     ack_body_bytes: int | None = None,
     ack_chunked_bytes: int | None = None,
+    probe_chunked_bytes: int | None = None,
 ) -> StubAdapter:
     """A stub that satisfies every floor rule the kit can assert."""
 
     behavior = dataclasses.replace(
-        CONFORMANT, ack_body_bytes=ack_body_bytes, ack_chunked_bytes=ack_chunked_bytes
+        CONFORMANT,
+        ack_body_bytes=ack_body_bytes,
+        ack_chunked_bytes=ack_chunked_bytes,
+        probe_chunked_bytes=probe_chunked_bytes,
     )
     return StubAdapter(behavior, secret=secret, state_path=state_path, port=port)
 
@@ -677,16 +843,20 @@ class StubIngressDriver:
     def start(self, *, ingress_url: str, token: str) -> None:
         self.stub.configure(ingress_url=ingress_url, token=token)
 
-    def stimulate(self) -> UpstreamIdentity:
+    def reserve(self) -> UpstreamIdentity:
         self._stimuli += 1
         upstream_id = uuid.uuid4().hex[:10]
-        delivery_id = self.stub.inject(upstream_id)
+        # DECLARED from the documented derivation, and nothing is injected: the
+        # kit arms its ingress for this identity before the message exists.
         return UpstreamIdentity(
-            stimulus_id=f"in-process-{self._stimuli}", delivery_id=delivery_id
+            stimulus_id=f"in-process-{self._stimuli}", delivery_id=f"dlv-{upstream_id}"
         )
 
-    def set_transport(self, *, reachable: bool) -> None:
-        self.stub.set_reachable(reachable)
+    def release(self, identity: UpstreamIdentity) -> None:
+        self.stub.inject(identity.delivery_id.removeprefix("dlv-"))
+
+    def settled(self, identity: UpstreamIdentity) -> bool:
+        return self.stub.is_retired(identity.delivery_id)
 
     def restart(
         self,
@@ -782,17 +952,26 @@ class SubprocessIngressDriver:
             self._spawn()
         control(self.base_url, "configure", {"ingress_url": ingress_url, "token": token})
 
-    def stimulate(self) -> UpstreamIdentity:
+    def reserve(self) -> UpstreamIdentity:
         self._stimuli += 1
         upstream_id = uuid.uuid4().hex[:10]
-        control(self.base_url, "stimulate", {"upstream_id": upstream_id})
         # DECLARED, not read back: the derivation is the documented contract.
         return UpstreamIdentity(
             stimulus_id=f"subprocess-{self._stimuli}", delivery_id=f"dlv-{upstream_id}"
         )
 
-    def set_transport(self, *, reachable: bool) -> None:
-        control(self.base_url, "transport", {"reachable": reachable})
+    def release(self, identity: UpstreamIdentity) -> None:
+        control(
+            self.base_url,
+            "stimulate",
+            {"upstream_id": identity.delivery_id.removeprefix("dlv-")},
+        )
+
+    def settled(self, identity: UpstreamIdentity) -> bool:
+        answer = control(
+            self.base_url, "retired", {"delivery_id": identity.delivery_id}
+        )
+        return bool(answer["retired"])
 
     def restart(
         self,
@@ -826,19 +1005,72 @@ class LyingIngressDriver:
 
     def __init__(self, inner: StubIngressDriver | SubprocessIngressDriver) -> None:
         self.inner = inner
+        # The lie is only in what it DECLARES. The message it injects is the
+        # honest one, so the adapter is exonerated and the driver is the finding.
+        self._honest: dict[str, UpstreamIdentity] = {}
 
     def start(self, *, ingress_url: str, token: str) -> None:
         self.inner.start(ingress_url=ingress_url, token=token)
 
-    def stimulate(self) -> UpstreamIdentity:
-        declared = self.inner.stimulate()
+    def reserve(self) -> UpstreamIdentity:
+        honest = self.inner.reserve()
+        self._honest[f"never-sent-{uuid.uuid4().hex[:8]}"] = honest
+        declared = list(self._honest)[-1]
         return UpstreamIdentity(
-            stimulus_id=declared.stimulus_id,
-            delivery_id=f"never-sent-{uuid.uuid4().hex[:8]}",
+            stimulus_id=honest.stimulus_id, delivery_id=declared
         )
 
-    def set_transport(self, *, reachable: bool) -> None:
-        self.inner.set_transport(reachable=reachable)
+    def release(self, identity: UpstreamIdentity) -> None:
+        self.inner.release(self._honest[identity.delivery_id])
+
+    def settled(self, identity: UpstreamIdentity) -> bool:
+        return self.inner.settled(self._honest[identity.delivery_id])
+
+    def restart(
+        self,
+        *,
+        egress_secret: str | None | EllipsisType = ...,
+        token: str | None | EllipsisType = ...,
+    ) -> None:
+        self.inner.restart(egress_secret=egress_secret, token=token)
+
+    def stop(self) -> None:
+        self.inner.stop()
+
+
+class RacingIngressDriver:
+    """A driver whose adapter already has ANOTHER delivery in flight.
+
+    Not a hostile driver: an upstream queue holding more than one message is the
+    ordinary case, and this is what it looks like from the ingress. It is also
+    the exact shape that drains a globally armed one shot 202 before the
+    declared delivery can reach it, which is why rule 2 arms for one identity.
+    The decoy is released once, on the first stimulus, so the later rules run
+    against an adapter with nothing extra in flight.
+    """
+
+    def __init__(self, inner: StubIngressDriver | SubprocessIngressDriver) -> None:
+        self.inner = inner
+        self._raced = False
+
+    def start(self, *, ingress_url: str, token: str) -> None:
+        self.inner.start(ingress_url=ingress_url, token=token)
+
+    def reserve(self) -> UpstreamIdentity:
+        return self.inner.reserve()
+
+    def release(self, identity: UpstreamIdentity) -> None:
+        if not self._raced:
+            self._raced = True
+            decoy = self.inner.reserve()
+            self.inner.release(decoy)
+            deadline = time.monotonic() + 10.0
+            while time.monotonic() < deadline and not self.inner.settled(decoy):
+                time.sleep(0.02)
+        self.inner.release(identity)
+
+    def settled(self, identity: UpstreamIdentity) -> bool:
+        return self.inner.settled(identity)
 
     def restart(
         self,

--- a/packages/channel-protocol/tests/conformance_stubs.py
+++ b/packages/channel-protocol/tests/conformance_stubs.py
@@ -78,8 +78,12 @@ class StubBehavior:
     probe_chunked_bytes: int | None = None
     # Rule 5 (handles all four events).
     rejects_turn_status: bool = False
-    # Rule 6 (dedupe on event_id).
+    # Rule 6 (dedupe on event_id, and tolerate a finished conversation).
     double_sends_duplicate: bool = False
+    # Treats its own retirement of a conversation as final: the exact duplicate
+    # is tolerated, and a NEW event_id for that conversation is refused. A
+    # multi turn conversation and an outage sweeper both produce that traffic.
+    rejects_finished_conversation: bool = False
     # Rule 1 (stable delivery_id).
     fresh_delivery_id_per_retry: bool = False
     # How long the adapter waits before its FIRST attempt. Long enough and a
@@ -118,6 +122,7 @@ BREAKS: dict[str, StubBehavior] = {
     "empty_ack_body": StubBehavior(empty_ack_body=True),
     "rejects_turn_status": StubBehavior(rejects_turn_status=True),
     "double_sends_duplicate": StubBehavior(double_sends_duplicate=True),
+    "rejects_finished_conversation": StubBehavior(rejects_finished_conversation=True),
     "fresh_delivery_id_per_retry": StubBehavior(fresh_delivery_id_per_retry=True),
     "retries_after_202": StubBehavior(retries_after_202=True),
     "posts_an_unrelated_delivery": StubBehavior(posts_an_unrelated_delivery=True),
@@ -408,6 +413,7 @@ class StubAdapter:
         self.held: list[dict[str, str]] = []
         self.delivered: list[str] = []
         self.seen_event_ids: list[str] = []
+        self.finished_conversations: list[str] = []
         self.events: list[dict[str, Any]] = []
         self._posted_unrelated = False
 
@@ -503,6 +509,24 @@ class StubAdapter:
             if name == "turn.completed":
                 event_id = str(decoded.get("event_id"))
                 duplicate = event_id in self.seen_event_ids
+                target = decoded.get("target")
+                conversation = (
+                    str(target.get("conversation_id"))
+                    if isinstance(target, dict)
+                    else ""
+                )
+                if (
+                    self.behavior.rejects_finished_conversation
+                    and not duplicate
+                    and conversation in self.finished_conversations
+                ):
+                    # Rule 6's second half, and it is invisible to the first: the
+                    # exact duplicate is still tolerated, so the dedupe probe
+                    # reads this adapter as conformant. Only a completion for a
+                    # conversation it has already retired is refused.
+                    return "reject"
+                if conversation and conversation not in self.finished_conversations:
+                    self.finished_conversations.append(conversation)
                 if not duplicate:
                     self.seen_event_ids.append(event_id)
                 if not duplicate or self.behavior.double_sends_duplicate:
@@ -540,6 +564,7 @@ class StubAdapter:
                 "held": len(self.held),
                 "delivered": list(self.delivered),
                 "seen_event_ids": list(self.seen_event_ids),
+                "finished_conversations": list(self.finished_conversations),
                 "events": list(self.events),
                 "retired": sorted(self._retired),
             }
@@ -748,6 +773,7 @@ class StubAdapter:
                     "held": self.held,
                     "delivered": self.delivered,
                     "seen_event_ids": self.seen_event_ids,
+                    "finished_conversations": self.finished_conversations,
                     "events": self.events,
                     "retired": sorted(self._retired),
                 }
@@ -764,6 +790,7 @@ class StubAdapter:
         self.stale_credential = bool(state.get("stale_credential", False))
         self.delivered = list(state.get("delivered", []))
         self.seen_event_ids = list(state.get("seen_event_ids", []))
+        self.finished_conversations = list(state.get("finished_conversations", []))
         self.events = list(state.get("events", []))
         self._retired = set(state.get("retired", []))
         # A held delivery is what "did not silently drop it" means: it comes

--- a/packages/channel-protocol/tests/conftest.py
+++ b/packages/channel-protocol/tests/conftest.py
@@ -1,0 +1,11 @@
+"""Make the sibling conformance stub modules importable by name.
+
+pytest's importlib import mode does not put the test directory on ``sys.path``,
+so ``import conformance_stubs`` from a test module fails without this. Same
+idiom, and the same reason, as ``tests/soak/conftest.py``.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))

--- a/packages/channel-protocol/tests/stub_adapter_main.py
+++ b/packages/channel-protocol/tests/stub_adapter_main.py
@@ -1,0 +1,20 @@
+"""Run one conformance stub adapter as a standalone process.
+
+This is FIX A's out of process proof. Started with ``subprocess.Popen`` and
+configured purely through environment variables and its own HTTP surface, it
+shares no memory with the conformance kit, so nothing can correlate an observed
+ingress post to a stimulus except the ``delivery_id`` travelling on the wire.
+
+Environment: ``STUB_PORT``, ``STUB_STATE``, ``STUB_BEHAVIOR`` and the optional
+``STUB_SECRET`` (absent means the adapter's own egress secret is unset).
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from conformance_stubs import serve_from_env  # noqa: E402
+
+if __name__ == "__main__":
+    serve_from_env()

--- a/packages/channel-protocol/tests/test_conformance_cli.py
+++ b/packages/channel-protocol/tests/test_conformance_cli.py
@@ -64,7 +64,7 @@ def _write_profile(tmp_path: Path) -> Path:
             "egress_secret_env": "CURIE_EGRESS_SECRET",
             "ingress_token_env": "CURIE_INGRESS_TOKEN",
         },
-        "conformance": {"wire_version": "1.0", "mints_reply_ref": True},
+        "conformance": {"wire_version": "1.0"},
     }
     path = tmp_path / "adapter.yaml"
     path.write_text(yaml.safe_dump(profile), encoding="utf-8")

--- a/packages/channel-protocol/tests/test_conformance_cli.py
+++ b/packages/channel-protocol/tests/test_conformance_cli.py
@@ -1,0 +1,397 @@
+"""The conformance kit's console front door (#1516).
+
+The CLI is the surface a vendor quotes in a README, so the two properties that
+matter most are here: the exit code follows ``automated_floor`` and nothing
+short of a full strict pass exits 0, and the JSON payload carries the verdict
+next to the list of what no machine checked.
+
+The kit is also handed a real egress secret, so it must never write one into a
+report. That is asserted rather than promised.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import subprocess
+import sys
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+from channel_protocol.conformance.cli import main
+from conformance_stubs import (
+    StubAdapter,
+    conformant_stub,
+    free_port,
+    non_conformant_stub,
+    random_secret,
+)
+
+_KIND = "email"
+_ADDRESS = "agent@example.test"
+_QUERY_TOKEN = "querysecretvalue"
+
+
+@pytest.fixture
+def secret() -> str:
+    return random_secret()
+
+
+@contextmanager
+def _running(stub: StubAdapter) -> Iterator[StubAdapter]:
+    stub.start()
+    try:
+        yield stub
+    finally:
+        stub.stop()
+
+
+def _write_profile(tmp_path: Path) -> Path:
+    profile = {
+        "version": "1.0",
+        "kind": _KIND,
+        "address": {
+            "description": "The mailbox this adapter owns.",
+            "pattern": r"^[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}$",
+            "example": _ADDRESS,
+        },
+        "credentials": {
+            "egress": "conformance-stub",
+            "egress_secret_env": "CURIE_EGRESS_SECRET",
+            "ingress_token_env": "CURIE_INGRESS_TOKEN",
+        },
+        "conformance": {"wire_version": "1.0", "mints_reply_ref": True},
+    }
+    path = tmp_path / "adapter.yaml"
+    path.write_text(yaml.safe_dump(profile), encoding="utf-8")
+    return path
+
+
+def _write_secret(tmp_path: Path, secret: str) -> Path:
+    path = tmp_path / "egress-secret"
+    path.write_text(secret, encoding="utf-8")
+    return path
+
+
+def _argv(
+    tmp_path: Path, stub: StubAdapter, secret: str, *extra: str, query: bool = False
+) -> list[str]:
+    endpoint = stub.endpoint + (f"?trace={_QUERY_TOKEN}" if query else "")
+    return [
+        "--profile",
+        str(_write_profile(tmp_path)),
+        "--endpoint",
+        endpoint,
+        "--secret-file",
+        str(_write_secret(tmp_path, secret)),
+        *extra,
+    ]
+
+
+def _payload(captured: str) -> dict[str, Any]:
+    decoded: dict[str, Any] = json.loads(captured)
+    return decoded
+
+
+def test_cli_exits_non_zero_on_any_fail(
+    tmp_path: Path, secret: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    with _running(
+        non_conformant_stub("redirects", secret=secret, state_path=tmp_path / "state.json")
+    ) as stub:
+        code = main(_argv(tmp_path, stub, secret, "--json"))
+
+    assert code != 0
+    assert _payload(capsys.readouterr().out)["automated_floor"] == "fail"
+
+
+def test_cli_exits_non_zero_on_any_not_run_in_strict_mode(
+    tmp_path: Path, secret: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A partial run is not a pass, and the exit code has to say so.
+
+    This is the second front door of RULING 3. An exit code that cannot tell a
+    full run from a partial one is exactly what lets a README claim conformance
+    off an egress only invocation.
+    """
+
+    with _running(
+        conformant_stub(secret=secret, state_path=tmp_path / "state.json")
+    ) as stub:
+        code = main(_argv(tmp_path, stub, secret, "--json"))
+        payload = _payload(capsys.readouterr().out)
+
+    assert code != 0
+    assert payload["automated_floor"] == "fail"
+    statuses = {result["rule"]: result["status"] for result in payload["results"]}
+    assert statuses[4] == "pass"
+    assert statuses[5] == "pass"
+    assert {statuses[1], statuses[2], statuses[7]} == {"not_run"}
+
+
+def test_cli_process_exit_code_follows_the_verdict(tmp_path: Path, secret: str) -> None:
+    """Asserted against a real PROCESS, because CI reads the exit status and
+    not a return value."""
+
+    with _running(
+        conformant_stub(secret=secret, state_path=tmp_path / "state.json")
+    ) as stub:
+        completed = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "import sys;"
+                "from channel_protocol.conformance.cli import main;"
+                "sys.exit(main(sys.argv[1:]))",
+                *_argv(tmp_path, stub, secret, "--json"),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=300,
+        )
+
+    assert completed.returncode != 0, completed.stdout + completed.stderr
+    assert _payload(completed.stdout)["automated_floor"] == "fail"
+
+
+def test_diagnostic_mode_never_reports_conformant_and_stamps_its_mode(
+    tmp_path: Path, secret: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Diagnostic mode exists so an author can see partial results while
+    building, and it must never be mistakable for a strict run."""
+
+    with _running(
+        conformant_stub(secret=secret, state_path=tmp_path / "state.json")
+    ) as stub:
+        main(_argv(tmp_path, stub, secret, "--json", "--mode", "diagnostic"))
+        payload = _payload(capsys.readouterr().out)
+
+    assert payload["mode"] == "diagnostic"
+    assert payload["automated_floor"] == "fail"
+
+
+def test_json_payload_carries_verdict_and_counts(
+    tmp_path: Path, secret: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """All four top level fields ship in v1. Under ADR-0101 they cannot be
+    added later without a version bump, so they are here now."""
+
+    with _running(
+        conformant_stub(secret=secret, state_path=tmp_path / "state.json")
+    ) as stub:
+        main(_argv(tmp_path, stub, secret, "--json"))
+        payload = _payload(capsys.readouterr().out)
+
+    assert set(payload) >= {
+        "automated_floor",
+        "manual_review_required",
+        "mode",
+        "counts",
+        "results",
+    }
+    assert set(payload["counts"]) == {"pass", "fail", "not_run"}
+    assert any(item["clause"] == "3c" for item in payload["manual_review_required"])
+
+
+def test_no_conformant_field_in_the_payload(
+    tmp_path: Path, secret: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A field literally named ``conformant`` is quotable as whole floor
+    conformance while clause 3c was never asserted. The name was the hole, so
+    the name is gone, at every depth of the payload."""
+
+    with _running(
+        conformant_stub(secret=secret, state_path=tmp_path / "state.json")
+    ) as stub:
+        main(_argv(tmp_path, stub, secret, "--json"))
+        payload = _payload(capsys.readouterr().out)
+
+    assert "conformant" not in _all_keys(payload)
+
+
+def _all_keys(payload: Any) -> set[str]:
+    found: set[str] = set()
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            found.add(str(key))
+            found |= _all_keys(value)
+    elif isinstance(payload, list):
+        for item in payload:
+            found |= _all_keys(item)
+    return found
+
+
+def test_the_human_render_prints_the_manual_review_beside_the_verdict(
+    tmp_path: Path, secret: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A passing run still has to show what was not checked, or the verdict
+    reads as more than it covers."""
+
+    with _running(
+        conformant_stub(secret=secret, state_path=tmp_path / "state.json")
+    ) as stub:
+        main(_argv(tmp_path, stub, secret))
+        rendered = capsys.readouterr().out
+
+    assert "automated_floor" in rendered
+    assert "3c" in rendered
+
+
+def test_cli_report_never_contains_the_secret_or_the_endpoint_query(
+    tmp_path: Path, secret: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The kit is pointed at a live adapter with a real egress secret and an
+    endpoint whose query may itself be a credential. Neither may reach a report
+    a vendor pastes into an issue."""
+
+    with _running(
+        conformant_stub(secret=secret, state_path=tmp_path / "state.json")
+    ) as stub:
+        main(_argv(tmp_path, stub, secret, "--json", query=True))
+        json_output = capsys.readouterr()
+        main(_argv(tmp_path, stub, secret, query=True))
+        human_output = capsys.readouterr()
+
+    for stream in (
+        json_output.out,
+        json_output.err,
+        human_output.out,
+        human_output.err,
+    ):
+        assert secret not in stream
+        assert _QUERY_TOKEN not in stream
+
+
+def test_cli_refuses_a_profile_named_env_var_as_a_secret_source(
+    tmp_path: Path,
+    secret: str,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A third party authored file must never choose which of an operator's
+    secrets gets read and where it is sent.
+
+    ``credentials.egress_secret_env`` documents what the ADAPTER reads. The
+    profile's value is exported here and the run must still refuse, rather than
+    quietly resolving it and posting the result at the profile's endpoint.
+    """
+
+    monkeypatch.setenv("CURIE_EGRESS_SECRET", secret)
+    with _running(
+        conformant_stub(secret=secret, state_path=tmp_path / "state.json")
+    ) as stub:
+        code = main(
+            [
+                "--profile",
+                str(_write_profile(tmp_path)),
+                "--endpoint",
+                stub.endpoint,
+                "--json",
+            ]
+        )
+        captured = capsys.readouterr()
+
+    assert code != 0
+    assert '"automated_floor": "pass"' not in captured.out
+    assert "--secret-file" in captured.out + captured.err
+
+
+def test_cli_has_no_secret_env_flag_at_all(capsys: pytest.CaptureFixture[str]) -> None:
+    """RULING 4 is structural: the flag does not exist, so it cannot be used."""
+
+    with pytest.raises(SystemExit):
+        main(["--help"])
+    assert "--secret-env" not in capsys.readouterr().out
+
+
+def test_cli_accepts_the_secret_on_stdin(
+    tmp_path: Path,
+    secret: str,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The second operator supplied source, so a secret never has to touch disk."""
+
+    monkeypatch.setattr(sys, "stdin", io.StringIO(secret + "\n"))
+    with _running(
+        conformant_stub(secret=secret, state_path=tmp_path / "state.json")
+    ) as stub:
+        main(
+            [
+                "--profile",
+                str(_write_profile(tmp_path)),
+                "--endpoint",
+                stub.endpoint,
+                "--secret-stdin",
+                "--json",
+            ]
+        )
+        payload = _payload(capsys.readouterr().out)
+
+    statuses = {result["rule"]: result["status"] for result in payload["results"]}
+    assert statuses[4] == "pass", payload
+    assert statuses[5] == "pass", payload
+
+
+def test_cli_loads_a_driver_from_a_module_attr_spec(
+    tmp_path: Path,
+    secret: str,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The vendor's front door: with a driver supplied, a correct adapter
+    reaches a strict pass and the command exits 0."""
+
+    state_path = tmp_path / "stub-state.json"
+    port = free_port()
+    monkeypatch.setenv("STUB_PORT", str(port))
+    monkeypatch.setenv("STUB_SECRET", secret)
+    monkeypatch.setenv("STUB_STATE", str(state_path))
+    monkeypatch.setenv("STUB_BEHAVIOR", "conformant")
+
+    code = main(
+        [
+            "--profile",
+            str(_write_profile(tmp_path)),
+            "--endpoint",
+            f"http://127.0.0.1:{port}/curie",
+            "--secret-file",
+            str(_write_secret(tmp_path, secret)),
+            "--driver",
+            "conformance_stubs:subprocess_driver_from_env",
+            "--json",
+        ]
+    )
+    payload = _payload(capsys.readouterr().out)
+
+    assert code == 0, payload
+    assert payload["automated_floor"] == "pass"
+
+
+def test_cli_refuses_a_driver_spec_it_cannot_resolve(
+    tmp_path: Path, secret: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A typo'd driver spec must be a loud usage error, never a silent run with
+    rules 1, 2 and 7 quietly ``not_run``."""
+
+    with _running(
+        conformant_stub(secret=secret, state_path=tmp_path / "state.json")
+    ) as stub:
+        code = main(
+            _argv(
+                tmp_path,
+                stub,
+                secret,
+                "--driver",
+                "conformance_stubs:no_such_driver_factory",
+                "--json",
+            )
+        )
+        captured = capsys.readouterr()
+
+    assert code != 0
+    assert "no_such_driver_factory" in captured.out + captured.err

--- a/packages/channel-protocol/tests/test_conformance_egress.py
+++ b/packages/channel-protocol/tests/test_conformance_egress.py
@@ -21,9 +21,11 @@ import pytest
 from channel_protocol.conformance import (
     ADAPTER_SECRET_HEADER,
     MAX_ACK_BODY_BYTES,
+    MAX_TURN_BODY_BYTES,
     AdapterUnderTest,
     FloorReport,
     run_floor,
+    side_effect_probe,
 )
 from conformance_stubs import (
     SECRET_HEADER,
@@ -42,6 +44,7 @@ from conformance_stubs import (
 
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 _REPLY_SINK = _REPO_ROOT / "apps" / "worker" / "src" / "curie_worker" / "reply_sink.py"
+_API_CONFIG = _REPO_ROOT / "apps" / "api" / "src" / "curie_api" / "config.py"
 
 _FOUR_EVENTS = {"turn.status", "reply.update", "reply.post", "turn.completed"}
 
@@ -108,33 +111,46 @@ def _literal(node: ast.expr) -> Any:
     raise AssertionError(f"{ast.unparse(node)} is not a constant expression")
 
 
-def _worker_constant(name: str) -> Any:
-    """One module level constant, read out of the worker's source.
+def _source_constant(path: Path, name: str) -> Any:
+    """One constant, read out of a first party module's source.
 
     Read rather than imported: ``channel_protocol`` must never depend on
-    ``curie_worker``, so the kit re declares these values and this is the gate
-    that keeps the copy honest.
+    ``curie_worker`` or ``curie_api``, so the kit re declares these values and
+    this is the gate that keeps the copies honest. Both a bare assignment and an
+    annotated settings field are accepted, because the two authoritative sites
+    write theirs differently.
     """
 
-    tree = ast.parse(_REPLY_SINK.read_text(encoding="utf-8"))
+    tree = ast.parse(path.read_text(encoding="utf-8"))
     for node in ast.walk(tree):
         if isinstance(node, ast.Assign) and any(
             isinstance(target, ast.Name) and target.id == name for target in node.targets
         ):
             return _literal(node.value)
-    raise AssertionError(f"{name} is not assigned in {_REPLY_SINK}")
+        if (
+            isinstance(node, ast.AnnAssign)
+            and isinstance(node.target, ast.Name)
+            and node.target.id == name
+            and node.value is not None
+        ):
+            return _literal(node.value)
+    raise AssertionError(f"{name} is not assigned in {path}")
 
 
-def test_worker_constants_match() -> None:
-    """The kit's copies of the worker's egress constants cannot drift.
+def test_platform_constants_match() -> None:
+    """The kit's copies of the platform's wire constants cannot drift.
 
-    Change either one in the worker and this reds, which is the only thing
-    standing between a re declared constant and a kit that asserts the wrong
-    cap or sends the wrong header.
+    Change any of them at its authoritative site and this reds, which is the
+    only thing standing between a re declared constant and a kit that sends the
+    wrong header, asserts the wrong ack cap, or stands in for the ingress with a
+    body bound the real route does not have.
     """
 
-    assert ADAPTER_SECRET_HEADER == _worker_constant("ADAPTER_SECRET_HEADER")
-    assert MAX_ACK_BODY_BYTES == _worker_constant("MAX_ACK_BODY_BYTES")
+    assert ADAPTER_SECRET_HEADER == _source_constant(_REPLY_SINK, "ADAPTER_SECRET_HEADER")
+    assert MAX_ACK_BODY_BYTES == _source_constant(_REPLY_SINK, "MAX_ACK_BODY_BYTES")
+    assert MAX_TURN_BODY_BYTES == _source_constant(
+        _API_CONFIG, "channel_turn_max_body_bytes"
+    )
     # The stub reads the header name from the guide, independently of both.
     assert ADAPTER_SECRET_HEADER == SECRET_HEADER
 
@@ -250,6 +266,68 @@ def test_non_conformant_stub_fails_rule_3_clause_3a_when_it_performs_the_side_ef
         assert clause_status(report, "3a") == "fail", report.detail()
         # The probe is what saw it: the rejected requests moved the counter.
         assert read_probe(stub.base_url)["side_effects"] > 0
+
+
+def test_non_conformant_stub_fails_clause_3a_when_the_side_effect_lands_after_the_401(
+    tmp_path: Path, secret: str
+) -> None:
+    """The refusal and the side effect are two different events.
+
+    This adapter answers a conformant 401 and hands the work to a timer that
+    fires 100 ms later, which is what an adapter that queues its work actually
+    looks like. A count read the instant the refusal arrives is identical to a
+    correct adapter's, so the clause has to read the count once it has stopped
+    moving rather than the moment the response lands.
+    """
+
+    with _running(
+        non_conformant_stub(
+            "delayed_side_effect_then_401",
+            secret=secret,
+            state_path=tmp_path / "state.json",
+        )
+    ) as stub:
+        report = _report_for(stub, secret)
+
+        assert clause_status(report, "3a") == "fail", report.detail()
+        assert report.automated_floor == "fail", report.detail()
+        assert read_probe(stub.base_url)["side_effects"] > 0
+
+
+def test_non_conformant_stub_fails_clause_3b_when_it_serves_with_its_secret_unset(
+    tmp_path: Path, secret: str
+) -> None:
+    """With its own secret unset, refusing is about the SIDE EFFECT too.
+
+    This adapter answers a clean 503 to every request and answers the
+    correspondent anyway. Its statuses are indistinguishable from a conformant
+    adapter's, so a clause that inspects only the response certifies an adapter
+    that serves unauthenticated requests, which is the exact thing 3b exists to
+    forbid.
+    """
+
+    with _running(
+        non_conformant_stub(
+            "side_effect_when_secret_unset",
+            secret=secret,
+            state_path=tmp_path / "state.json",
+        )
+    ) as stub:
+        report = _report_for(stub, secret, with_driver=True)
+
+        assert clause_status(report, "3b") == "fail", report.detail()
+        assert report.automated_floor == "fail", report.detail()
+
+
+def test_clause_3b_is_not_run_without_a_side_effect_probe(
+    conformant: StubAdapter, secret: str
+) -> None:
+    """3b needs the probe as much as 3a does, and says so rather than passing."""
+
+    report = _report_for(conformant, secret, with_probe=False, with_driver=True)
+
+    assert clause_status(report, "3b") == "not_run", report.detail()
+    assert report.automated_floor == "fail", report.detail()
 
 
 def test_non_conformant_stub_fails_rule_3_clause_3b_when_it_accepts_with_its_secret_unset(
@@ -390,18 +468,34 @@ def test_rule_5_sends_only_the_four_union_members(
     assert observed == _FOUR_EVENTS, f"the kit sent {sorted(observed)}"
 
 
-def test_rule_5_probes_that_an_adapter_tolerates_an_unmodeled_extra_key(
-    conformant: StubAdapter, secret: str
+def test_a_hostile_side_effect_probe_response_is_refused_rather_than_buffered(
+    tmp_path: Path, secret: str
 ) -> None:
-    """A later wire revision adds optional keys, so the floor probe includes one
-    known event carrying a key the current models do not define."""
+    """The probe GET lands on the same untrusted origin the ack comes from.
 
-    _report_for(conformant, secret)
+    The payload here is VALID and merely enormous, so an unbounded read returns
+    the count and quietly buffers the padding. Only a cap catches it, and the
+    honest outcome of a refused probe is ``not_run`` on the two clauses that
+    need one, which is nonconformant.
+    """
 
-    events = read_probe(conformant.base_url)["events"]
-    assert any(entry["extra_keys"] for entry in events), (
-        "no request carried an unmodeled key, so tolerance was never probed"
-    )
+    with _running(
+        conformant_stub(
+            secret=secret,
+            state_path=tmp_path / "state.json",
+            probe_chunked_bytes=MAX_ACK_BODY_BYTES * 3,
+        )
+    ) as stub:
+        adapter = _adapter_for(stub, secret)
+
+        assert side_effect_probe(adapter) is None, (
+            "an oversize probe response was accepted, so the kit buffered it"
+        )
+
+        report = run_floor(adapter, driver=None, side_effect_probe=side_effect_probe(adapter))
+        assert clause_status(report, "3a") == "not_run", report.detail()
+        assert rule_status(report, 6) == "not_run", report.detail()
+        assert report.automated_floor == "fail", report.detail()
 
 
 def test_clause_3a_and_rule_6_report_not_run_without_a_side_effect_probe(

--- a/packages/channel-protocol/tests/test_conformance_egress.py
+++ b/packages/channel-protocol/tests/test_conformance_egress.py
@@ -407,6 +407,37 @@ def test_non_conformant_stub_fails_rule_6_when_it_double_sends_a_duplicate(
         assert rule_status(report, 6) == "fail", report.detail()
 
 
+def test_non_conformant_stub_fails_rule_6_when_it_rejects_a_finished_conversation(
+    tmp_path: Path, secret: str
+) -> None:
+    """Rule 6's second half, against an adapter that passes its first half.
+
+    This adapter dedupes perfectly: the exact duplicate event_id is tolerated
+    and answered once, so the whole probe the clause is named for reads clean.
+    What it refuses is a further completion for a conversation it has already
+    retired, which is what a second turn on that conversation looks like, and
+    what a sweeper draining a record after an outage looks like. A clause that
+    probes a FRESH conversation there reads this adapter as conformant, because
+    a conversation it has never seen is not one it has finished.
+    """
+
+    with _running(
+        non_conformant_stub(
+            "rejects_finished_conversation",
+            secret=secret,
+            state_path=tmp_path / "state.json",
+        )
+    ) as stub:
+        report = _report_for(stub, secret)
+
+        assert rule_status(report, 6) == "fail", report.detail()
+        assert report.automated_floor == "fail", report.detail()
+        # The dedupe half genuinely held, so the failure is attributable to the
+        # tolerance half and not to a break bleeding across the clause.
+        assert "already finished" in clause(report, "6").detail, report.detail()
+        assert "redelivered" not in clause(report, "6").detail, report.detail()
+
+
 def test_ack_of_exactly_the_cap_passes_and_one_byte_over_fails(
     tmp_path: Path, secret: str
 ) -> None:

--- a/packages/channel-protocol/tests/test_conformance_egress.py
+++ b/packages/channel-protocol/tests/test_conformance_egress.py
@@ -12,11 +12,13 @@ kit's assertion for that clause turns its case green and reds the suite.
 from __future__ import annotations
 
 import ast
+import itertools
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 
+import httpx
 import pytest
 from channel_protocol.conformance import (
     ADAPTER_SECRET_HEADER,
@@ -319,6 +321,79 @@ def test_non_conformant_stub_fails_clause_3b_when_it_serves_with_its_secret_unse
         assert report.automated_floor == "fail", report.detail()
 
 
+def test_clauses_3a_and_3b_catch_a_side_effect_delayed_past_any_quiet_window(
+    tmp_path: Path, secret: str
+) -> None:
+    """A quiet window is not evidence, and 1.2 seconds is not adversarial.
+
+    Both breaks answer a clean refusal and hand the correspondent to a timer
+    that fires well after any interval a kit could call quiet. Inferring
+    finality from silence passes both of them; observing for a named window and
+    failing on ANY movement catches both, and the two clauses share the one
+    mechanism rather than each carrying its own constant to outlast.
+    """
+
+    with _running(
+        non_conformant_stub(
+            "slowly_delayed_side_effect_then_401",
+            secret=secret,
+            state_path=tmp_path / "3a.json",
+        )
+    ) as stub:
+        report = _report_for(stub, secret)
+        assert clause_status(report, "3a") == "fail", report.detail()
+        assert report.automated_floor == "fail", report.detail()
+
+    with _running(
+        non_conformant_stub(
+            "slowly_serves_when_secret_unset",
+            secret=secret,
+            state_path=tmp_path / "3b.json",
+        )
+    ) as stub:
+        report = _report_for(stub, secret, with_driver=True)
+        assert clause_status(report, "3b") == "fail", report.detail()
+        assert report.automated_floor == "fail", report.detail()
+
+
+def test_a_probe_that_stops_answering_fails_the_clause_instead_of_aborting_the_run(
+    conformant: StubAdapter, secret: str
+) -> None:
+    """Discovery proved the probe answered ONCE, and nothing more than that.
+
+    A probe that starts failing partway through used to escape as an httpx error
+    out of the middle of a clause and take the whole report with it, and the
+    observation windows read it many times per clause rather than twice, so
+    there are far more chances for it now. The honest outcome is a clause
+    failure that names the probe endpoint, so the vendor knows to look at their
+    probe rather than at their reply handling, and every other rule still
+    reaches a verdict.
+    """
+
+    honest = side_effect_probe_for(conformant.base_url)
+    reads = itertools.count()
+
+    def stops_answering() -> int:
+        if next(reads) < 1:
+            return honest()
+        raise httpx.ConnectError("the probe endpoint refused the connection")
+
+    report = run_floor(
+        _adapter_for(conformant, secret), driver=None, side_effect_probe=stops_answering
+    )
+
+    assert clause_status(report, "3a") == "fail", report.detail()
+    assert rule_status(report, 6) == "fail", report.detail()
+    assert report.automated_floor == "fail", report.detail()
+    detail = clause(report, "3a").detail
+    assert "side effect probe" in detail, detail
+    assert "clause 3a" in detail, detail
+    # The run still produced a report, and the rules that never touch the probe
+    # still reached their own verdicts rather than being lost with it.
+    assert rule_status(report, 4) == "pass", report.detail()
+    assert rule_status(report, 5) == "pass", report.detail()
+
+
 def test_clause_3b_is_not_run_without_a_side_effect_probe(
     conformant: StubAdapter, secret: str
 ) -> None:
@@ -405,6 +480,31 @@ def test_non_conformant_stub_fails_rule_6_when_it_double_sends_a_duplicate(
     ) as stub:
         report = _report_for(stub, secret)
         assert rule_status(report, 6) == "fail", report.detail()
+
+
+def test_non_conformant_stub_fails_rule_6_when_the_duplicate_effect_is_delayed(
+    tmp_path: Path, secret: str
+) -> None:
+    """The redelivery is acked 200 immediately and answered 200 ms later.
+
+    Both acks look identical to a deduping adapter's, and the count read the
+    instant the second ack lands shows a delta of one, so the whole rule passes
+    on an adapter that answered the correspondent twice. The count has to be
+    WATCHED across the window rather than sampled at the end of the exchange.
+    """
+
+    with _running(
+        non_conformant_stub(
+            "delayed_duplicate_side_effect",
+            secret=secret,
+            state_path=tmp_path / "state.json",
+        )
+    ) as stub:
+        report = _report_for(stub, secret)
+
+        assert rule_status(report, 6) == "fail", report.detail()
+        assert report.automated_floor == "fail", report.detail()
+        assert "answered twice" in clause(report, "6").detail, report.detail()
 
 
 def test_non_conformant_stub_fails_rule_6_when_it_rejects_a_finished_conversation(

--- a/packages/channel-protocol/tests/test_conformance_egress.py
+++ b/packages/channel-protocol/tests/test_conformance_egress.py
@@ -1,0 +1,420 @@
+"""The conformance kit's egress half, driven over real loopback HTTP (#1516).
+
+Every test here stands up a REAL stub adapter and points the REAL kit at it.
+Nothing internal is mocked, because a black box kit that is exercised through an
+in process shortcut proves nothing about the black box.
+
+The falsifiability controls are the point of the file: for every automatable
+clause there is a ``test_non_conformant_stub_fails_...`` case, so deleting the
+kit's assertion for that clause turns its case green and reds the suite.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+import pytest
+from channel_protocol.conformance import (
+    ADAPTER_SECRET_HEADER,
+    MAX_ACK_BODY_BYTES,
+    AdapterUnderTest,
+    FloorReport,
+    run_floor,
+)
+from conformance_stubs import (
+    SECRET_HEADER,
+    StubAdapter,
+    StubIngressDriver,
+    clause,
+    clause_status,
+    clauses,
+    conformant_stub,
+    non_conformant_stub,
+    random_secret,
+    read_probe,
+    rule_status,
+    side_effect_probe_for,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_REPLY_SINK = _REPO_ROOT / "apps" / "worker" / "src" / "curie_worker" / "reply_sink.py"
+
+_FOUR_EVENTS = {"turn.status", "reply.update", "reply.post", "turn.completed"}
+
+
+@contextmanager
+def _running(stub: StubAdapter) -> Iterator[StubAdapter]:
+    """Start a stub and tear it down, pass or fail.
+
+    A leaked listener survives the test that made it and breaks the next run,
+    so every server this file starts is closed here.
+    """
+
+    stub.start()
+    try:
+        yield stub
+    finally:
+        stub.stop()
+
+
+def _adapter_for(stub: StubAdapter, secret: str) -> AdapterUnderTest:
+    return AdapterUnderTest(
+        endpoint=stub.endpoint,
+        secret=secret,
+        kind="email",
+        address="agent@example.test",
+        timeout_s=15.0,
+    )
+
+
+@pytest.fixture
+def secret() -> str:
+    return random_secret()
+
+
+@pytest.fixture
+def conformant(tmp_path: Path, secret: str) -> Iterator[StubAdapter]:
+    with _running(
+        conformant_stub(secret=secret, state_path=tmp_path / "state.json")
+    ) as stub:
+        yield stub
+
+
+def _report_for(
+    stub: StubAdapter,
+    secret: str,
+    *,
+    with_probe: bool = True,
+    with_driver: bool = False,
+) -> FloorReport:
+    return run_floor(
+        _adapter_for(stub, secret),
+        driver=StubIngressDriver(stub) if with_driver else None,
+        side_effect_probe=side_effect_probe_for(stub.base_url) if with_probe else None,
+    )
+
+
+def _literal(node: ast.expr) -> Any:
+    """Evaluate the constant expressions the worker's constants are written as."""
+
+    if isinstance(node, ast.Constant):
+        return node.value
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Mult):
+        return _literal(node.left) * _literal(node.right)
+    raise AssertionError(f"{ast.unparse(node)} is not a constant expression")
+
+
+def _worker_constant(name: str) -> Any:
+    """One module level constant, read out of the worker's source.
+
+    Read rather than imported: ``channel_protocol`` must never depend on
+    ``curie_worker``, so the kit re declares these values and this is the gate
+    that keeps the copy honest.
+    """
+
+    tree = ast.parse(_REPLY_SINK.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and any(
+            isinstance(target, ast.Name) and target.id == name for target in node.targets
+        ):
+            return _literal(node.value)
+    raise AssertionError(f"{name} is not assigned in {_REPLY_SINK}")
+
+
+def test_worker_constants_match() -> None:
+    """The kit's copies of the worker's egress constants cannot drift.
+
+    Change either one in the worker and this reds, which is the only thing
+    standing between a re declared constant and a kit that asserts the wrong
+    cap or sends the wrong header.
+    """
+
+    assert ADAPTER_SECRET_HEADER == _worker_constant("ADAPTER_SECRET_HEADER")
+    assert MAX_ACK_BODY_BYTES == _worker_constant("MAX_ACK_BODY_BYTES")
+    # The stub reads the header name from the guide, independently of both.
+    assert ADAPTER_SECRET_HEADER == SECRET_HEADER
+
+
+def test_conformant_stub_passes_and_still_lists_manual_review(
+    conformant: StubAdapter, secret: str
+) -> None:
+    """A correct adapter CAN pass, and the pass is never quotable on its own.
+
+    Both halves are asserted together because the pair IS the contract: a
+    verdict printed without the manual review list is the failure mode this
+    test exists to prevent.
+    """
+
+    report = _report_for(conformant, secret, with_driver=True)
+
+    assert report.automated_floor == "pass", report.detail()
+    assert report.mode == "strict"
+    for rule_number in (1, 2, 4, 5, 6, 7):
+        assert rule_status(report, rule_number) == "pass", report.detail()
+    assert clause_status(report, "3a") == "pass", report.detail()
+    assert clause_status(report, "3b") == "pass", report.detail()
+
+    reviewed = {item.clause for item in report.manual_review_required}
+    assert "3c" in reviewed, report.detail()
+    item = next(i for i in report.manual_review_required if i.clause == "3c")
+    assert item.reason.strip(), "a manual review item with no reason is a footnote"
+    assert item.how_to_review.strip(), "a human needs to be told what to read"
+
+
+def test_clause_3c_is_never_automatable_and_never_reads_as_pass(
+    conformant: StubAdapter, secret: str
+) -> None:
+    """Constant time comparison is not black box observable, so it is outside
+    the verdict domain and an HTTP status is never allowed to imply it."""
+
+    report = _report_for(conformant, secret, with_driver=True)
+
+    constant_time = clause(report, "3c")
+    assert constant_time.automatable is False
+    assert constant_time.status != "pass"
+    assert not any(
+        candidate.automatable and candidate.clause == "3c" for candidate in clauses(report)
+    )
+
+
+def test_the_report_carries_no_field_named_conformant(
+    conformant: StubAdapter, secret: str
+) -> None:
+    """A boolean literally named ``conformant`` is quotable as whole floor
+    conformance while clause 3c was never asserted. The name was the hole."""
+
+    report = _report_for(conformant, secret, with_driver=True)
+
+    assert "conformant" not in FloorReport.model_fields
+    assert _keys_of(report.model_dump(mode="json")).isdisjoint({"conformant"})
+
+
+def _keys_of(payload: Any) -> set[str]:
+    found: set[str] = set()
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            found.add(str(key))
+            found |= _keys_of(value)
+    elif isinstance(payload, list):
+        for item in payload:
+            found |= _keys_of(item)
+    return found
+
+
+def test_counts_cover_every_clause(conformant: StubAdapter, secret: str) -> None:
+    """``counts`` is the verdict's arithmetic, so it has to be over the same
+    population the verdict is computed on."""
+
+    report = _report_for(conformant, secret, with_driver=True)
+
+    assert set(report.counts) == {"pass", "fail", "not_run"}
+    assert sum(report.counts.values()) == len(list(clauses(report)))
+    for status in ("pass", "fail", "not_run"):
+        assert report.counts[status] == sum(
+            1 for candidate in clauses(report) if candidate.status == status
+        )
+
+
+def test_non_conformant_stub_fails_rule_3_clause_3a_when_it_skips_the_secret_check(
+    tmp_path: Path, secret: str
+) -> None:
+    with _running(
+        non_conformant_stub(
+            "skips_secret_check", secret=secret, state_path=tmp_path / "state.json"
+        )
+    ) as stub:
+        report = _report_for(stub, secret)
+        assert clause_status(report, "3a") == "fail", report.detail()
+        assert report.automated_floor == "fail"
+
+
+def test_non_conformant_stub_fails_rule_3_clause_3a_when_it_performs_the_side_effect_first(
+    tmp_path: Path, secret: str
+) -> None:
+    """The status is a conformant 401 and the adapter is still broken.
+
+    This is the exact hole a status only check leaves open, which is why clause
+    3a needs a side effect probe rather than a response code.
+    """
+
+    with _running(
+        non_conformant_stub(
+            "side_effect_then_401", secret=secret, state_path=tmp_path / "state.json"
+        )
+    ) as stub:
+        report = _report_for(stub, secret)
+        assert clause_status(report, "3a") == "fail", report.detail()
+        # The probe is what saw it: the rejected requests moved the counter.
+        assert read_probe(stub.base_url)["side_effects"] > 0
+
+
+def test_non_conformant_stub_fails_rule_3_clause_3b_when_it_accepts_with_its_secret_unset(
+    tmp_path: Path, secret: str
+) -> None:
+    """An adapter started with no egress secret of its own must refuse
+    everything, not serve unauthenticated."""
+
+    with _running(
+        non_conformant_stub(
+            "accepts_when_secret_unset", secret=secret, state_path=tmp_path / "state.json"
+        )
+    ) as stub:
+        report = _report_for(stub, secret, with_driver=True)
+        assert clause_status(report, "3b") == "fail", report.detail()
+        assert report.automated_floor == "fail"
+
+
+def test_non_conformant_stub_fails_rule_4_when_it_redirects(
+    tmp_path: Path, secret: str
+) -> None:
+    """A 3xx would bounce the platform's egress credential at whatever origin
+    the adapter named, so the kit must post with redirects disabled."""
+
+    with _running(
+        non_conformant_stub("redirects", secret=secret, state_path=tmp_path / "state.json")
+    ) as stub:
+        report = _report_for(stub, secret)
+        assert rule_status(report, 4) == "fail", report.detail()
+
+
+def test_non_conformant_stub_fails_rule_4_when_its_ack_is_not_json(
+    tmp_path: Path, secret: str
+) -> None:
+    """The worker tolerates an empty body, the floor does not. The two must not
+    disagree silently, so the kit is the stricter one and says so."""
+
+    with _running(
+        non_conformant_stub(
+            "empty_ack_body", secret=secret, state_path=tmp_path / "state.json"
+        )
+    ) as stub:
+        report = _report_for(stub, secret)
+        assert rule_status(report, 4) == "fail", report.detail()
+
+
+def test_non_conformant_stub_fails_rule_5_when_it_rejects_turn_status(
+    tmp_path: Path, secret: str
+) -> None:
+    """``turn.status`` is the event an email adapter has no use for, which is
+    exactly the one "tolerate ones it does not use" is about."""
+
+    with _running(
+        non_conformant_stub(
+            "rejects_turn_status", secret=secret, state_path=tmp_path / "state.json"
+        )
+    ) as stub:
+        report = _report_for(stub, secret)
+        assert rule_status(report, 5) == "fail", report.detail()
+
+
+def test_non_conformant_stub_fails_rule_6_when_it_double_sends_a_duplicate(
+    tmp_path: Path, secret: str
+) -> None:
+    """Both acks are 200 and the adapter answered the correspondent twice.
+
+    Wire indistinguishable, which is why rule 6 is ``not_run`` without a probe
+    rather than a quiet pass.
+    """
+
+    with _running(
+        non_conformant_stub(
+            "double_sends_duplicate", secret=secret, state_path=tmp_path / "state.json"
+        )
+    ) as stub:
+        report = _report_for(stub, secret)
+        assert rule_status(report, 6) == "fail", report.detail()
+
+
+def test_ack_of_exactly_the_cap_passes_and_one_byte_over_fails(
+    tmp_path: Path, secret: str
+) -> None:
+    """The worker refuses OVER the cap, so the boundary assertion is ``<=``.
+
+    An off by one in either direction is caught: 65536 is a pass and 65537 is a
+    failure, in one test so neither half can be relaxed alone.
+    """
+
+    with _running(
+        conformant_stub(
+            secret=secret,
+            state_path=tmp_path / "at-cap.json",
+            ack_body_bytes=MAX_ACK_BODY_BYTES,
+        )
+    ) as at_cap:
+        at_cap_report = _report_for(at_cap, secret)
+        assert rule_status(at_cap_report, 4) == "pass", at_cap_report.detail()
+
+    with _running(
+        conformant_stub(
+            secret=secret,
+            state_path=tmp_path / "over.json",
+            ack_body_bytes=MAX_ACK_BODY_BYTES + 1,
+        )
+    ) as over:
+        over_report = _report_for(over, secret)
+        assert rule_status(over_report, 4) == "fail", over_report.detail()
+
+
+def test_chunked_oversize_body_is_caught(tmp_path: Path, secret: str) -> None:
+    """A chunked body carries no ``Content-Length`` and answers a short first
+    read, so a kit that checks the header, or does one sized read, passes it."""
+
+    with _running(
+        conformant_stub(
+            secret=secret,
+            state_path=tmp_path / "state.json",
+            ack_chunked_bytes=MAX_ACK_BODY_BYTES * 3,
+        )
+    ) as stub:
+        report = _report_for(stub, secret)
+        assert rule_status(report, 4) == "fail", report.detail()
+
+
+def test_rule_5_sends_only_the_four_union_members(
+    conformant: StubAdapter, secret: str
+) -> None:
+    """The reply wire is a STRICT four member union.
+
+    Forward event tolerance is not part of floor rule 5, so a kit that sends an
+    unknown discriminator is asserting a requirement the platform never made and
+    would teach adapters to accept a shape the worker cannot send.
+    """
+
+    _report_for(conformant, secret)
+
+    observed = {entry["event"] for entry in read_probe(conformant.base_url)["events"]}
+    assert observed == _FOUR_EVENTS, f"the kit sent {sorted(observed)}"
+
+
+def test_rule_5_probes_that_an_adapter_tolerates_an_unmodeled_extra_key(
+    conformant: StubAdapter, secret: str
+) -> None:
+    """A later wire revision adds optional keys, so the floor probe includes one
+    known event carrying a key the current models do not define."""
+
+    _report_for(conformant, secret)
+
+    events = read_probe(conformant.base_url)["events"]
+    assert any(entry["extra_keys"] for entry in events), (
+        "no request carried an unmodeled key, so tolerance was never probed"
+    )
+
+
+def test_clause_3a_and_rule_6_report_not_run_without_a_side_effect_probe(
+    conformant: StubAdapter, secret: str
+) -> None:
+    """Missing evidence is never a pass, and it is never a silent skip either.
+
+    Both clauses need a side effect probe to be decidable, so without one they
+    are ``not_run``, and ``not_run`` is nonconformant.
+    """
+
+    report = _report_for(conformant, secret, with_probe=False, with_driver=True)
+
+    assert clause_status(report, "3a") == "not_run", report.detail()
+    assert rule_status(report, 6) == "not_run", report.detail()
+    assert report.automated_floor == "fail", report.detail()

--- a/packages/channel-protocol/tests/test_conformance_ingress.py
+++ b/packages/channel-protocol/tests/test_conformance_ingress.py
@@ -1,0 +1,437 @@
+"""The conformance kit's ingress half: floor rules 1, 2 and 7 (#1516).
+
+**Every rule level test here is parametrized over BOTH drivers.** The in process
+``StubIngressDriver`` holds the stub object; the ``SubprocessIngressDriver``
+holds a ``subprocess.Popen`` and an HTTP surface and shares no memory with
+anything. If the kit ever correlated an observed ingress post to a stimulus
+through private in process state instead of through the ``delivery_id`` on the
+wire, the in process run would still pass and the out of process run would fail.
+That asymmetry is the entire reason the parametrization exists.
+
+The kit is black box: nothing here imports the adapter, and nothing internal is
+faked. ``FakeIngress`` is a real HTTP server reproducing the platform's real
+claim semantics, and it is part of the kit rather than a mock of it.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+from channel_protocol.conformance import AdapterUnderTest, FakeIngress, FloorReport, run_floor
+from conformance_stubs import (
+    LyingIngressDriver,
+    StubAdapter,
+    StubIngressDriver,
+    SubprocessIngressDriver,
+    conformant_stub,
+    free_port,
+    non_conformant_stub,
+    random_secret,
+    rule,
+    rule_status,
+    side_effect_probe_for,
+)
+
+DRIVER_KINDS = ("in-process", "subprocess")
+
+_KIND = "email"
+_ADDRESS = "agent@example.test"
+
+
+@dataclass
+class Harness:
+    """One running adapter plus the driver that steers it."""
+
+    adapter: AdapterUnderTest
+    driver: Any
+    base_url: str
+
+
+@pytest.fixture
+def secret() -> str:
+    return random_secret()
+
+
+@contextmanager
+def _harness(
+    driver_kind: str,
+    *,
+    tmp_path: Path,
+    secret: str,
+    behavior_name: str = "conformant",
+) -> Iterator[Harness]:
+    """Start an adapter and its driver, and tear both down whatever happens.
+
+    A leaked listener or an orphaned subprocess outlives the test that made it
+    and breaks the next run, so teardown is unconditional.
+    """
+
+    state_path = tmp_path / "stub-state.json"
+    if driver_kind == "in-process":
+        stub: StubAdapter = (
+            conformant_stub(secret=secret, state_path=state_path)
+            if behavior_name == "conformant"
+            else non_conformant_stub(behavior_name, secret=secret, state_path=state_path)
+        )
+        stub.start()
+        driver: Any = StubIngressDriver(stub)
+        harness = Harness(
+            adapter=_adapter_for(stub.endpoint, secret),
+            driver=driver,
+            base_url=stub.base_url,
+        )
+        try:
+            yield harness
+        finally:
+            stub.stop()
+        return
+
+    subprocess_driver = SubprocessIngressDriver(
+        port=free_port(),
+        secret=secret,
+        state_path=state_path,
+        behavior_name=behavior_name,
+    )
+    subprocess_driver.boot()
+    try:
+        yield Harness(
+            adapter=_adapter_for(subprocess_driver.endpoint, secret),
+            driver=subprocess_driver,
+            base_url=subprocess_driver.base_url,
+        )
+    finally:
+        subprocess_driver.stop()
+
+
+def _adapter_for(endpoint: str, secret: str) -> AdapterUnderTest:
+    return AdapterUnderTest(
+        endpoint=endpoint,
+        secret=secret,
+        kind=_KIND,
+        address=_ADDRESS,
+        timeout_s=15.0,
+    )
+
+
+def _run(harness: Harness, *, driver: Any = None) -> FloorReport:
+    return run_floor(
+        harness.adapter,
+        driver=harness.driver if driver is None else driver,
+        side_effect_probe=side_effect_probe_for(harness.base_url),
+    )
+
+
+def _post(url: str, payload: dict[str, Any], *, api_key: str | None) -> tuple[int, Any]:
+    headers = {"Content-Type": "application/json"}
+    if api_key is not None:
+        headers["X-API-Key"] = api_key
+    request = urllib.request.Request(
+        url, data=json.dumps(payload).encode(), headers=headers, method="POST"
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=10) as response:
+            return int(response.status), json.loads(response.read() or b"null")
+    except urllib.error.HTTPError as error:
+        return int(error.code), json.loads(error.read() or b"null")
+
+
+@contextmanager
+def _fake_ingress() -> Iterator[FakeIngress]:
+    ingress = FakeIngress(kind=_KIND, address=_ADDRESS)
+    ingress.start()
+    try:
+        yield ingress
+    finally:
+        ingress.stop()
+
+
+# --- FakeIngress itself, which the ingress rules are decided against ----------
+
+
+def test_fake_ingress_reproduces_the_duplicate_matrix() -> None:
+    """The fake has to answer what the real ingress answers, or every rule
+    decided against it is decided against a fiction.
+
+    Includes the claim key: the platform derives ``event_id`` from the binding
+    plus ``delivery_id`` and never ``delivery_id`` alone, so two inboxes sharing
+    an upstream id space must not swallow each other's turns.
+    """
+
+    with _fake_ingress() as ingress:
+        turns = f"{ingress.url}/channels/turns"
+        body = {
+            "kind": _KIND,
+            "address": _ADDRESS,
+            "delivery_id": "dlv-1",
+            "conversation_id": "conv-1",
+            "author": "someone@example.test",
+            "text": "hello",
+        }
+
+        first_status, first = _post(turns, body, api_key=ingress.token)
+        assert first_status == 200
+        assert first["duplicate"] is False
+        assert first["stream_id"]
+
+        retry_status, retry = _post(turns, body, api_key=ingress.token)
+        assert retry_status == 200
+        assert retry["duplicate"] is True
+        assert retry["event_id"] == first["event_id"]
+        assert retry["stream_id"] == first["stream_id"]
+
+        other_inbox = dict(body, address="other@example.test")
+        other_status, other = _post(turns, other_inbox, api_key=ingress.token)
+        assert other_status == 200
+        assert other["duplicate"] is False
+        assert other["event_id"] != first["event_id"]
+
+        ingress.arm_202()
+        in_flight_status, in_flight = _post(
+            turns, dict(body, delivery_id="dlv-2"), api_key=ingress.token
+        )
+        assert in_flight_status == 202
+        assert in_flight["duplicate"] is True
+        # Never the `pending:` sentinel: the real API answers null here, and
+        # returning the sentinel would teach an author to parse a value
+        # production never sends.
+        assert in_flight["stream_id"] is None
+
+
+def test_fake_ingress_refuses_a_keyless_mint() -> None:
+    """The adapter holds no platform key, so a mint it attempts must fail.
+
+    Without this the kit would certify the trust boundary breach outright: a
+    self minting adapter defeats both the token TTL and the binding generation.
+    """
+
+    with _fake_ingress() as ingress:
+        mint = f"{ingress.url}/channels/token"
+
+        keyless_status, _ = _post(mint, {"kind": _KIND, "address": _ADDRESS}, api_key=None)
+        assert keyless_status == 401
+
+        wrong_status, _ = _post(
+            mint, {"kind": _KIND, "address": _ADDRESS}, api_key="not-the-platform-key"
+        )
+        assert wrong_status == 401
+
+        operator_status, minted = _post(
+            mint, {"kind": _KIND, "address": _ADDRESS}, api_key=ingress.platform_key
+        )
+        assert operator_status == 200
+        assert minted["token"]
+
+
+# --- the ingress floor rules, under both drivers ------------------------------
+
+
+@pytest.mark.parametrize("driver_kind", DRIVER_KINDS)
+def test_conformant_stub_passes_every_ingress_rule(
+    driver_kind: str, tmp_path: Path, secret: str
+) -> None:
+    with _harness(driver_kind, tmp_path=tmp_path, secret=secret) as harness:
+        report = _run(harness)
+
+    assert rule_status(report, 1) == "pass", report.detail()
+    assert rule_status(report, 2) == "pass", report.detail()
+    assert rule_status(report, 7) == "pass", report.detail()
+    assert report.automated_floor == "pass", report.detail()
+
+
+@pytest.mark.parametrize("driver_kind", DRIVER_KINDS)
+def test_rule_1_catches_a_fresh_delivery_id_per_retry(
+    driver_kind: str, tmp_path: Path, secret: str
+) -> None:
+    """A delivery_id minted per attempt answers the correspondent once per
+    retry, because the platform's claim converges on the id and nothing else."""
+
+    with _harness(
+        driver_kind,
+        tmp_path=tmp_path,
+        secret=secret,
+        behavior_name="fresh_delivery_id_per_retry",
+    ) as harness:
+        report = _run(harness)
+
+    assert rule_status(report, 1) == "fail", report.detail()
+    assert report.automated_floor == "fail"
+
+
+@pytest.mark.parametrize("driver_kind", DRIVER_KINDS)
+def test_rule_1_fails_when_the_driver_declares_an_identity_the_adapter_never_sends(
+    driver_kind: str, tmp_path: Path, secret: str
+) -> None:
+    """A driver that does not implement the correlation contract is a finding.
+
+    Reading a lying driver as conformant is the failure that would let every
+    broken vendor driver certify its adapter, so the honest verdict is a rule 1
+    failure naming the identity nothing on the wire matched.
+    """
+
+    with _harness(driver_kind, tmp_path=tmp_path, secret=secret) as harness:
+        report = _run(harness, driver=LyingIngressDriver(harness.driver))
+
+    assert rule_status(report, 1) == "fail", report.detail()
+    assert "never-sent-" in rule(report, 1).detail, rule(report, 1).detail
+
+
+def test_correlation_uses_only_the_declared_identity(tmp_path: Path) -> None:
+    """The in process and out of process runs must reach the SAME verdict.
+
+    Correlate by arrival order instead of by the declared ``delivery_id`` and
+    the out of process run diverges, because nothing out there can tell the kit
+    which stimulus a post belongs to except the value on the wire.
+    """
+
+    verdicts: dict[str, dict[str, dict[int, str]]] = {}
+    for behavior_name in ("conformant", "fresh_delivery_id_per_retry"):
+        verdicts[behavior_name] = {}
+        for driver_kind in DRIVER_KINDS:
+            secret = random_secret()
+            root = tmp_path / f"{behavior_name}-{driver_kind}"
+            root.mkdir()
+            with _harness(
+                driver_kind, tmp_path=root, secret=secret, behavior_name=behavior_name
+            ) as harness:
+                report = _run(harness)
+            verdicts[behavior_name][driver_kind] = {
+                number: rule_status(report, number) for number in (1, 2, 7)
+            }
+
+    for behavior_name, by_driver in verdicts.items():
+        assert by_driver["in-process"] == by_driver["subprocess"], (
+            f"{behavior_name} was judged differently out of process: {by_driver}"
+        )
+    assert verdicts["conformant"]["subprocess"][1] == "pass"
+    assert verdicts["fresh_delivery_id_per_retry"]["subprocess"][1] == "fail"
+
+
+@pytest.mark.parametrize("driver_kind", DRIVER_KINDS)
+def test_rule_2_catches_a_retry_after_a_202(
+    driver_kind: str, tmp_path: Path, secret: str
+) -> None:
+    """A 202 is a RESPONSE, so it is final. Posting again after one is the
+    defect, even though 202 reads like an invitation to come back."""
+
+    with _harness(
+        driver_kind, tmp_path=tmp_path, secret=secret, behavior_name="retries_after_202"
+    ) as harness:
+        report = _run(harness)
+
+    assert rule_status(report, 2) == "fail", report.detail()
+
+
+@pytest.mark.parametrize("driver_kind", DRIVER_KINDS)
+def test_rule_2_tolerates_a_redelivery_under_a_new_stimulus(
+    driver_kind: str, tmp_path: Path, secret: str
+) -> None:
+    """The false positive control, and the reason a stimulus label exists.
+
+    An upstream redelivery under an identity the kit never declared is
+    legitimate at least once behavior. A kit that simply counted posts after the
+    202 would red this, and would then reject correct adapters.
+    """
+
+    with _harness(
+        driver_kind,
+        tmp_path=tmp_path,
+        secret=secret,
+        behavior_name="posts_an_unrelated_delivery",
+    ) as harness:
+        report = _run(harness)
+
+    assert rule_status(report, 2) == "pass", report.detail()
+
+
+@pytest.mark.parametrize("driver_kind", DRIVER_KINDS)
+def test_rule_7_passes_when_a_replacement_token_resumes_the_same_delivery_id(
+    driver_kind: str, tmp_path: Path, secret: str
+) -> None:
+    """The corrected rule 7: hold the delivery, do not die, resume on a fresh
+    operator supplied token, and do not mint anything."""
+
+    with _harness(driver_kind, tmp_path=tmp_path, secret=secret) as harness:
+        report = _run(harness)
+
+    assert rule_status(report, 7) == "pass", report.detail()
+
+
+@pytest.mark.parametrize("driver_kind", DRIVER_KINDS)
+def test_rule_7_fails_when_a_401_is_fatal(
+    driver_kind: str, tmp_path: Path, secret: str
+) -> None:
+    with _harness(
+        driver_kind, tmp_path=tmp_path, secret=secret, behavior_name="exits_on_401"
+    ) as harness:
+        report = _run(harness)
+
+    assert rule_status(report, 7) == "fail", report.detail()
+
+
+@pytest.mark.parametrize("driver_kind", DRIVER_KINDS)
+def test_rule_7_fails_when_the_delivery_is_silently_dropped(
+    driver_kind: str, tmp_path: Path, secret: str
+) -> None:
+    """Surviving the 401 is not enough: a delivery discarded on the way is a
+    turn the correspondent never gets an answer to."""
+
+    with _harness(
+        driver_kind, tmp_path=tmp_path, secret=secret, behavior_name="drops_on_401"
+    ) as harness:
+        report = _run(harness)
+
+    assert rule_status(report, 7) == "fail", report.detail()
+
+
+@pytest.mark.parametrize("driver_kind", DRIVER_KINDS)
+def test_rule_7_fails_an_adapter_that_tries_to_self_mint(
+    driver_kind: str, tmp_path: Path, secret: str
+) -> None:
+    """An adapter that re mints its own token is the breach RULING 2 exists to
+    stop, so it must FAIL rather than pass the rule it used to define."""
+
+    with _harness(
+        driver_kind, tmp_path=tmp_path, secret=secret, behavior_name="self_mints_on_401"
+    ) as harness:
+        report = _run(harness)
+
+    assert rule_status(report, 7) == "fail", report.detail()
+
+
+def test_rules_1_2_7_report_not_run_without_a_driver_and_the_report_is_nonconformant(
+    tmp_path: Path, secret: str
+) -> None:
+    """The most important assertion in the kit: NO EVIDENCE IS NOT A PASS.
+
+    An unsupplied ingress driver leaves rules 1, 2 and 7 and clause 3b with
+    nothing to exercise them. They report ``not_run``, and because ``not_run``
+    is an automatable clause short of pass, the whole verdict is ``fail``. The
+    day this stops holding, a vendor can claim conformance off a partial run.
+    """
+
+    stub = conformant_stub(secret=secret, state_path=tmp_path / "stub-state.json")
+    stub.start()
+    try:
+        report = run_floor(
+            _adapter_for(stub.endpoint, secret),
+            driver=None,
+            side_effect_probe=side_effect_probe_for(stub.base_url),
+        )
+    finally:
+        stub.stop()
+
+    for number in (1, 2, 7):
+        assert rule_status(report, number) == "not_run", report.detail()
+    assert report.automated_floor == "fail", report.detail()
+    # Rules 4, 5 and 6 were genuinely exercised, so this is a partial run
+    # reported honestly rather than a run that failed to start.
+    for number in (4, 5, 6):
+        assert rule_status(report, number) == "pass", report.detail()

--- a/packages/channel-protocol/tests/test_conformance_ingress.py
+++ b/packages/channel-protocol/tests/test_conformance_ingress.py
@@ -25,15 +25,24 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-from channel_protocol.conformance import AdapterUnderTest, FakeIngress, FloorReport, run_floor
+from channel_protocol.conformance import (
+    MAX_TURN_BODY_BYTES,
+    AdapterUnderTest,
+    FakeIngress,
+    FloorReport,
+    run_floor,
+)
 from conformance_stubs import (
     LyingIngressDriver,
+    RacingIngressDriver,
     StubAdapter,
     StubIngressDriver,
     SubprocessIngressDriver,
+    clause_status,
     conformant_stub,
     free_port,
     non_conformant_stub,
+    post_with_declared_length,
     random_secret,
     rule,
     rule_status,
@@ -193,16 +202,84 @@ def test_fake_ingress_reproduces_the_duplicate_matrix() -> None:
         assert other["duplicate"] is False
         assert other["event_id"] != first["event_id"]
 
-        ingress.arm_202()
+        # Armed for ONE identity. A different delivery arriving first must not
+        # be able to consume it, or rule 2 passes on a declared delivery that
+        # never saw the in flight claim its finality is about.
+        ingress.arm_202("dlv-2")
+        unrelated_status, _ = _post(
+            turns, dict(body, delivery_id="dlv-other"), api_key=ingress.token
+        )
+        assert unrelated_status == 200
+        assert ingress.armed_202() == "dlv-2"
+
         in_flight_status, in_flight = _post(
             turns, dict(body, delivery_id="dlv-2"), api_key=ingress.token
         )
         assert in_flight_status == 202
         assert in_flight["duplicate"] is True
+        assert ingress.armed_202() is None
         # Never the `pending:` sentinel: the real API answers null here, and
         # returning the sentinel would teach an author to parse a value
         # production never sends.
         assert in_flight["stream_id"] is None
+
+
+def test_a_request_the_ingress_cannot_frame_is_still_recorded() -> None:
+    """The adapter under test writes its own request headers.
+
+    Every ingress rule decides on which records landed in its window, and two of
+    them read absence as conformance, so a header the ingress cannot parse must
+    never be able to delete the observation. It is refused, and it is COUNTED.
+    """
+
+    with _fake_ingress() as ingress:
+        turn = post_with_declared_length(
+            f"{ingress.url}/channels/turns",
+            json.dumps({"kind": _KIND, "address": _ADDRESS, "delivery_id": "dlv-1"}).encode(),
+            {"Content-Type": "application/json", "X-API-Key": ingress.token},
+            declared_length="51x",
+        )
+        assert turn == 400
+
+        mint = post_with_declared_length(
+            f"{ingress.url}/channels/token",
+            json.dumps({"kind": _KIND, "address": _ADDRESS}).encode(),
+            {"Content-Type": "application/json"},
+            declared_length="0abc",
+        )
+        assert mint == 400
+
+        records = ingress.records()
+        assert [record.path for record in records] == [
+            "/channels/turns",
+            "/channels/token",
+        ], records
+        assert all(record.framing_error for record in records), records
+        # The trust boundary clause counts records on the mint route, so an
+        # unreadable mint attempt is still a mint attempt.
+        assert ingress.mint_attempts() == 1
+
+
+def test_an_oversize_declared_turn_body_is_refused_and_recorded() -> None:
+    """The bound is enforced on the DECLARED length, before a byte is read.
+
+    Same posture, and the same status, as the real API's ``_read_bounded_body``:
+    the ingress the kit points an untrusted adapter at must not be persuadable
+    into holding an arbitrary body on the kit's own heap.
+    """
+
+    with _fake_ingress() as ingress:
+        status = post_with_declared_length(
+            f"{ingress.url}/channels/turns",
+            b'{"delivery_id": "dlv-1"}',
+            {"Content-Type": "application/json", "X-API-Key": ingress.token},
+            declared_length=str(MAX_TURN_BODY_BYTES + 1),
+        )
+
+        assert status == 413
+        records = ingress.records()
+        assert len(records) == 1, records
+        assert records[0].framing_error, records[0]
 
 
 def test_fake_ingress_refuses_a_keyless_mint() -> None:
@@ -263,6 +340,31 @@ def test_rule_1_catches_a_fresh_delivery_id_per_retry(
 
     assert rule_status(report, 1) == "fail", report.detail()
     assert report.automated_floor == "fail"
+
+
+@pytest.mark.parametrize("driver_kind", DRIVER_KINDS)
+def test_rule_1_fails_an_adapter_that_never_met_the_outage_and_never_retried(
+    driver_kind: str, tmp_path: Path, secret: str
+) -> None:
+    """Rule 1 needs the FAILURE on the wire, not a window it was assumed in.
+
+    This adapter starts slowly and abandons a delivery the moment the transport
+    fails. A kit that takes the transport down for a fixed 200 ms and restores
+    it on a timer never overlaps with the adapter's first attempt at all: the
+    post lands afterwards, gets a 200, and rule 1 certifies a retry that never
+    happened off one successful delivery.
+    """
+
+    with _harness(
+        driver_kind,
+        tmp_path=tmp_path,
+        secret=secret,
+        behavior_name="slow_start_and_drops_on_transport_failure",
+    ) as harness:
+        report = _run(harness)
+
+    assert rule_status(report, 1) == "fail", report.detail()
+    assert report.automated_floor == "fail", report.detail()
 
 
 @pytest.mark.parametrize("driver_kind", DRIVER_KINDS)
@@ -327,6 +429,77 @@ def test_rule_2_catches_a_retry_after_a_202(
         report = _run(harness)
 
     assert rule_status(report, 2) == "fail", report.detail()
+
+
+@pytest.mark.parametrize("driver_kind", DRIVER_KINDS)
+def test_rule_2_catches_a_retry_after_a_202_hidden_behind_a_bad_content_length(
+    driver_kind: str, tmp_path: Path, secret: str
+) -> None:
+    """The same break as above, with the duplicate post made unreadable.
+
+    This adapter posts honestly, then re posts under a Content-Length no server
+    can parse. If a parse failure can cost the ingress an observation, the kit
+    sees one post, reports ``2 [pass] the adapter did not post it again``, and
+    certifies an adapter that treats a response as a retry signal.
+    """
+
+    with _harness(
+        driver_kind,
+        tmp_path=tmp_path,
+        secret=secret,
+        behavior_name="retries_after_202_evasively",
+    ) as harness:
+        report = _run(harness)
+
+    assert rule_status(report, 2) == "fail", report.detail()
+    assert report.automated_floor == "fail", report.detail()
+
+
+@pytest.mark.parametrize("driver_kind", DRIVER_KINDS)
+def test_rule_2_catches_a_retry_that_arrives_after_any_fixed_settle_window(
+    driver_kind: str, tmp_path: Path, secret: str
+) -> None:
+    """The same break, retried late enough to outlast a fixed window.
+
+    650 ms is not adversarial engineering, it is an ordinary backoff. A kit that
+    sleeps 500 ms and then decides records the conformant half of this adapter's
+    behavior and stops watching before the defect happens, so the verdict is
+    about the kit's timer rather than about the adapter.
+    """
+
+    with _harness(
+        driver_kind,
+        tmp_path=tmp_path,
+        secret=secret,
+        behavior_name="retries_late_after_202",
+    ) as harness:
+        report = _run(harness)
+
+    assert rule_status(report, 2) == "fail", report.detail()
+    assert report.automated_floor == "fail", report.detail()
+
+
+@pytest.mark.parametrize("driver_kind", DRIVER_KINDS)
+def test_rule_2_gives_the_202_to_the_declared_delivery_and_no_other(
+    driver_kind: str, tmp_path: Path, secret: str
+) -> None:
+    """The in flight claim has to reach the DECLARED delivery, or nothing was
+    tested.
+
+    ``RacingIngressDriver`` puts another, entirely legitimate delivery on the
+    wire first, which is what an upstream queue holding more than one message
+    looks like. Against a globally armed one shot that decoy consumes the 202
+    and the declared delivery only ever sees a 200, so the rule reports pass
+    having exercised finality against a response it never provoked. The verdict
+    stays pass here and the reason is what changed: the 202 went to the
+    identity the rule is about.
+    """
+
+    with _harness(driver_kind, tmp_path=tmp_path, secret=secret) as harness:
+        report = _run(harness, driver=RacingIngressDriver(harness.driver))
+
+    assert rule_status(report, 2) == "pass", report.detail()
+    assert "answered 202" in rule(report, 2).detail, rule(report, 2).detail
 
 
 @pytest.mark.parametrize("driver_kind", DRIVER_KINDS)
@@ -404,6 +577,55 @@ def test_rule_7_fails_an_adapter_that_tries_to_self_mint(
         report = _run(harness)
 
     assert rule_status(report, 7) == "fail", report.detail()
+
+
+@pytest.mark.parametrize("driver_kind", DRIVER_KINDS)
+def test_rule_7_fails_when_the_resumed_post_is_not_the_held_delivery(
+    driver_kind: str, tmp_path: Path, secret: str
+) -> None:
+    """"Something arrived after the restart" is not "the held delivery resumed".
+
+    This adapter discards the held delivery on the 401 and then posts an
+    entirely different one once it is back. A resume predicate that accepts any
+    later 2xx reports that the held delivery resumed, and the detail it prints
+    says so, about a turn the correspondent will never get an answer to.
+    """
+
+    with _harness(
+        driver_kind,
+        tmp_path=tmp_path,
+        secret=secret,
+        behavior_name="drops_on_401_and_posts_unrelated_after_restart",
+    ) as harness:
+        report = _run(harness)
+
+    assert clause_status(report, "7a") == "fail", report.detail()
+    assert report.automated_floor == "fail", report.detail()
+
+
+@pytest.mark.parametrize("driver_kind", DRIVER_KINDS)
+def test_rule_7_fails_a_self_mint_hidden_behind_a_bad_content_length(
+    driver_kind: str, tmp_path: Path, secret: str
+) -> None:
+    """The trust boundary clause, against an adapter that hides its mint.
+
+    Clause 7b decides on ``mint_attempts()``, which counts records, so an
+    unreadable mint POST that went unrecorded would report ``7b [pass] the
+    adapter never tried to mint its own replacement token`` about an adapter
+    that just did. This is the one verdict a vendor quotes.
+    """
+
+    with _harness(
+        driver_kind,
+        tmp_path=tmp_path,
+        secret=secret,
+        behavior_name="self_mints_on_401_evasively",
+    ) as harness:
+        report = _run(harness)
+
+    assert clause_status(report, "7b") == "fail", report.detail()
+    assert rule_status(report, 7) == "fail", report.detail()
+    assert report.automated_floor == "fail", report.detail()
 
 
 def test_rules_1_2_7_report_not_run_without_a_driver_and_the_report_is_nonconformant(

--- a/packages/channel-protocol/tests/test_conformance_ingress.py
+++ b/packages/channel-protocol/tests/test_conformance_ingress.py
@@ -16,6 +16,7 @@ claim semantics, and it is part of the kit rather than a mock of it.
 from __future__ import annotations
 
 import json
+import time
 import urllib.error
 import urllib.request
 from collections.abc import Iterator
@@ -33,6 +34,8 @@ from channel_protocol.conformance import (
     run_floor,
 )
 from conformance_stubs import (
+    BlockingSettledDriver,
+    EagerlySettledDriver,
     LyingIngressDriver,
     RacingIngressDriver,
     StubAdapter,
@@ -477,6 +480,73 @@ def test_rule_2_catches_a_retry_that_arrives_after_any_fixed_settle_window(
 
     assert rule_status(report, 2) == "fail", report.detail()
     assert report.automated_floor == "fail", report.detail()
+
+
+@pytest.mark.parametrize("driver_kind", DRIVER_KINDS)
+def test_rule_2_fails_a_driver_that_reports_retired_with_a_retry_still_scheduled(
+    driver_kind: str, tmp_path: Path, secret: str
+) -> None:
+    """A driver claim is evidence about the driver, not a verdict about the adapter.
+
+    ``EagerlySettledDriver`` answers from an empty active queue while its
+    adapter still has a 650 ms retry on a timer, which is what a vendor writes
+    first. Taking the claim as authoritative and watching for another fixed
+    window is the original late retry evasion in new clothes: the retry lands
+    after the window and the adapter is certified. The kit has to keep watching
+    and name BOTH halves, because the vendor has an adapter bug and a harness
+    bug and needs to know about each.
+    """
+
+    with _harness(
+        driver_kind,
+        tmp_path=tmp_path,
+        secret=secret,
+        behavior_name="retries_late_after_202",
+    ) as harness:
+        report = _run(harness, driver=EagerlySettledDriver(harness.driver))
+
+    assert rule_status(report, 2) == "fail", report.detail()
+    assert report.automated_floor == "fail", report.detail()
+    detail = rule(report, 2).detail
+    assert "settled()" in detail, detail
+    assert "harness" in detail, detail
+
+
+def test_a_driver_callback_that_blocks_fails_the_rule_instead_of_hanging_the_kit(
+    tmp_path: Path, secret: str
+) -> None:
+    """The worst outcome available is a hang, and this is the test that forbids it.
+
+    ``_wait_for`` used to call the predicate inline, so a ``settled`` that never
+    returned never gave control back to the deadline that was supposed to bound
+    it. The promised failure was a hang, and a hang reads as a slow suite rather
+    than as a broken harness, so nobody is ever told anything.
+
+    The test itself must not be able to hang either, which is why it asserts on
+    elapsed time and releases the blocked callback in a finalizer. If the bound
+    ever regresses, this fails on the clock rather than stalling the run.
+    """
+
+    with _harness("in-process", tmp_path=tmp_path, secret=secret) as harness:
+        driver = BlockingSettledDriver(harness.driver)
+        # Released whatever happens, so the abandoned callback thread does not
+        # outlive the test still waiting.
+        try:
+            started = time.monotonic()
+            report = _run(harness, driver=driver)
+            elapsed = time.monotonic() - started
+        finally:
+            driver.released.set()
+
+    assert elapsed < 60.0, f"the kit took {elapsed:.1f}s, so the bound did not hold"
+    assert rule_status(report, 2) == "fail", report.detail()
+    assert report.automated_floor == "fail", report.detail()
+    detail = rule(report, 2).detail
+    assert "did not answer" in detail, detail
+    assert "harness" in detail, detail
+    # Asked once and not once per poll: a callback that has shown it does not
+    # answer must not be retried, or every poll leaks another blocked thread.
+    assert driver.calls == 1, driver.calls
 
 
 @pytest.mark.parametrize("driver_kind", DRIVER_KINDS)

--- a/packages/channel-protocol/tests/test_manifest.py
+++ b/packages/channel-protocol/tests/test_manifest.py
@@ -11,6 +11,7 @@ compares a value that survived parsing. None of them inspects an internal name.
 """
 
 import ast
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -18,10 +19,12 @@ from typing import Any
 
 import pytest
 from channel_protocol.manifest import (
+    PROFILE_VERSION,
     AdapterConformance,
     AdapterProfile,
     AddressShape,
     ProfileVersionError,
+    check_version,
     load_profile,
 )
 from channel_protocol.reply import REPLY_WIRE_VERSION
@@ -48,7 +51,7 @@ def _profile(**overrides: Any) -> dict[str, Any]:
             "egress_secret_env": "CURIE_EGRESS_SECRET",
             "ingress_token_env": "CURIE_INGRESS_TOKEN",
         },
-        "conformance": {"wire_version": "1.0", "mints_reply_ref": True},
+        "conformance": {"wire_version": "1.0"},
     }
     base.update(overrides)
     return base
@@ -82,7 +85,6 @@ def test_profile_round_trips() -> None:
     assert decoded.endpoint == "https://curie-mail-adapter.example.test/curie/reply"
     assert decoded.address.example == "agent@example.test"
     assert decoded.credentials.egress == "agentmail-sandbox"
-    assert decoded.conformance.mints_reply_ref is True
 
 
 def test_rejects_an_unknown_top_level_key() -> None:
@@ -155,31 +157,63 @@ def test_endpoint_is_optional() -> None:
 def test_rejects_a_pattern_rust_regex_cannot_compile() -> None:
     """The Rust regex dialect is the floor for ``address.pattern``.
 
-    Python ``re`` compiles lookaround and backreferences and the Rust ``regex``
-    crate refuses them, so a pattern that only Python accepts would be a silent
-    cross language divergence. This is the admitted paired validator: JSON
-    Schema cannot express the rule, so it lives in two implementations kept in
-    step by the shared corpus.
+    Python ``re`` compiles lookaround, backreferences, atomic and conditional
+    groups, inline comments, the ASCII flag, ``\\Z`` and ``\\N{...}``, and the
+    Rust ``regex`` crate refuses every one of them, so a pattern that only
+    Python accepts would be a silent cross language divergence. Each pattern
+    below was compiled against regex 1.13.1 to confirm it really is refused
+    there. This is the admitted paired validator: JSON Schema cannot express the
+    rule, so it lives in two implementations kept in step by the shared corpus.
     """
 
     address = _profile()["address"]
+
+    with pytest.raises(ValidationError):
+        AddressShape.model_validate(dict(address, pattern="^[a-z"))
+
     for pattern in (
-        "^[a-z",
         "^(?=.*@)[a-z0-9@.]+$",
+        "(?!x)[a-z0-9.]+$",
         "(?<=@)[a-z0-9.]+$",
+        "(?<!x)[a-z0-9.]+$",
         r"^([a-z0-9]+)@\1\.example\.test$",
+        r"^(?P<host>[a-z]+)@(?P=host)$",
+        "^(?>a)$",
+        r"^([a-z]+)?(?(1)@example\.test|admin)$",
+        r"^[a-z0-9]+(?#the local part)@example\.test$",
+        r"(?a)^[a-z0-9]+@example\.test$",
+        r"^[a-z0-9]+@example\.test\Z",
+        r"^[a-z0-9]+\N{COMMERCIAL AT}example\.test$",
     ):
+        re.compile(pattern)  # a divergence, not a plain syntax error Python also refuses
         with pytest.raises(ValidationError):
             AddressShape.model_validate(dict(address, pattern=pattern))
 
 
+def test_accepts_a_pattern_both_dialects_compile() -> None:
+    """The false positive control on the paired regex validator.
+
+    A scanner that refuses every ``(?`` would pass the rejection test above
+    while making non capturing groups and named groups, which the Rust ``regex``
+    crate compiles happily, unusable in a profile.
+    """
+
+    address = _profile()["address"]
+    for pattern in (
+        r"^(?:[a-z0-9]+)@example\.test$",
+        r"^(?P<local>[a-z0-9]+)@example\.test$",
+        r"(?i)^[A-Z0-9]+@example\.test$",
+        r"^[a-z0-9(?=)\\]+@example\.test$",
+        "^a*+$",
+    ):
+        assert AddressShape.model_validate(dict(address, pattern=pattern)).pattern == pattern
+
+
 def test_wire_version_is_the_reply_module_literal() -> None:
-    accepted = AdapterConformance.model_validate(
-        {"wire_version": REPLY_WIRE_VERSION, "mints_reply_ref": True}
-    )
+    accepted = AdapterConformance.model_validate({"wire_version": REPLY_WIRE_VERSION})
     assert accepted.wire_version == REPLY_WIRE_VERSION
     with pytest.raises(ValidationError):
-        AdapterConformance.model_validate({"wire_version": "2.0", "mints_reply_ref": True})
+        AdapterConformance.model_validate({"wire_version": "2.0"})
 
 
 def test_version_mismatch_is_refused_before_schema_validation() -> None:
@@ -202,8 +236,85 @@ def test_version_mismatch_is_refused_before_schema_validation() -> None:
 
     missing = _profile()
     del missing["version"]
-    with pytest.raises(ProfileVersionError):
+    with pytest.raises(ProfileVersionError) as absent:
         load_profile(missing)
+    assert "no version key" in str(absent.value)
+
+
+def test_a_non_string_version_names_the_value_it_found() -> None:
+    """A present key of the wrong type is not a missing key.
+
+    ``version: 1.1`` written unquoted is a YAML FLOAT, so the key is sitting on
+    line one of the file. Reporting that as "declares no version key" sends the
+    author looking for something already there, and reporting the unknown
+    property instead loses the version entirely.
+    """
+
+    with pytest.raises(ProfileVersionError) as numeric:
+        load_profile(_profile(version=1.1, future_field=True))
+    message = str(numeric.value)
+    assert "1.1" in message
+    assert "no version key" not in message
+    assert "future_field" not in message
+    assert '"1.0"' in message, "the message never states the quoted string form required"
+
+    with pytest.raises(ProfileVersionError) as boolean:
+        load_profile(_profile(version=True))
+    assert "no version key" not in str(boolean.value)
+
+    with pytest.raises(ProfileVersionError) as empty:
+        load_profile(_profile(version=""))
+    assert "no version key" not in str(empty.value)
+
+
+def test_a_non_canonical_version_spelling_is_refused_as_a_spelling() -> None:
+    """``01.0`` and ``1.00`` are refused, and the refusal says why.
+
+    The Rust CLI compares the declared string to ``1.0`` for equality, so a
+    Python side that parsed the two numbers and accepted these would take a
+    profile ``curie adapter validate`` refuses. Reporting them as a plain
+    mismatch leaves the operator staring at "understands 1.0, declares 01.0",
+    two versions that read as equal, with nothing to act on.
+    """
+
+    for spelling in ("01.0", "1.00", "1.0.0", "1", "v1.0", " 1.0"):
+        with pytest.raises(ProfileVersionError) as refused:
+            load_profile(_profile(version=spelling))
+        message = str(refused.value)
+        assert "canonical" in message, f"{spelling} was not refused as a spelling: {message}"
+        assert "leading zeros" in message
+
+    understood = load_profile(_profile(version=PROFILE_VERSION))
+    assert understood.version == PROFILE_VERSION
+
+    with pytest.raises(ProfileVersionError) as newer:
+        load_profile(_profile(version="1.1"))
+    assert "canonical" not in str(newer.value), (
+        "a version this build simply does not speak is being reported as a misspelling"
+    )
+
+
+def test_a_later_build_still_accepts_an_earlier_minor(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The canonical spelling rule does not cost the compatible minor policy.
+
+    Same major and less or equal minor is what lets a third party keep a 1.0
+    profile we cannot force it to upgrade. Asserted by standing ``check_version``
+    up as a 1.1 build, because that policy is otherwise unobservable until the
+    day someone bumps ``PROFILE_VERSION``.
+    """
+
+    monkeypatch.setattr("channel_protocol.manifest.PROFILE_VERSION", "1.1")
+    check_version("1.0")
+    check_version("1.1")
+    with pytest.raises(ProfileVersionError) as older_build:
+        check_version("1.2")
+    assert "canonical" not in str(older_build.value)
+    with pytest.raises(ProfileVersionError):
+        check_version("2.0")
+    for spelling in ("01.1", "1.10.0", "1.01"):
+        with pytest.raises(ProfileVersionError) as misspelled:
+            check_version(spelling)
+        assert "canonical" in str(misspelled.value)
 
 
 def test_bare_import_pulls_no_http_client() -> None:

--- a/packages/channel-protocol/tests/test_manifest.py
+++ b/packages/channel-protocol/tests/test_manifest.py
@@ -1,0 +1,220 @@
+"""The adapter binding profile models (#1516).
+
+``adapter.yaml`` is a PER INSTALL binding profile: the channel kind an adapter
+owns, the address shape it accepts, the endpoint this install's worker POSTs
+reply events to, and the name of the egress credential identity. It is not
+ADR-0096 decision 2's install agnostic composition manifest, and nothing here
+should be read as pre-empting that document.
+
+Every assertion below is behavioral: it validates or refuses a real payload, or
+compares a value that survived parsing. None of them inspects an internal name.
+"""
+
+import ast
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+from channel_protocol.manifest import (
+    AdapterConformance,
+    AdapterProfile,
+    AddressShape,
+    ProfileVersionError,
+    load_profile,
+)
+from channel_protocol.reply import REPLY_WIRE_VERSION
+from pydantic import ValidationError
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_API_SCHEMAS = _REPO_ROOT / "apps" / "api" / "src" / "curie_api" / "schemas.py"
+
+
+def _profile(**overrides: Any) -> dict[str, Any]:
+    """A profile every consumer accepts, with the caller's keys replaced."""
+
+    base: dict[str, Any] = {
+        "version": "1.0",
+        "kind": "email",
+        "endpoint": "https://curie-mail-adapter.example.test/curie/reply",
+        "address": {
+            "description": "The mailbox this adapter owns.",
+            "pattern": r"^[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}$",
+            "example": "agent@example.test",
+        },
+        "credentials": {
+            "egress": "agentmail-sandbox",
+            "egress_secret_env": "CURIE_EGRESS_SECRET",
+            "ingress_token_env": "CURIE_INGRESS_TOKEN",
+        },
+        "conformance": {"wire_version": "1.0", "mints_reply_ref": True},
+    }
+    base.update(overrides)
+    return base
+
+
+def _api_channel_kind_pattern() -> str:
+    """The slug pattern source the API validates channel kinds and adapters with.
+
+    Read out of the source rather than imported, so this gate does not drag the
+    API's runtime dependencies into a contract package's test run.
+    """
+
+    tree = ast.parse(_API_SCHEMAS.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(t, ast.Name) and t.id == "_CHANNEL_KIND" for t in node.targets):
+            continue
+        call = node.value
+        assert isinstance(call, ast.Call), "_CHANNEL_KIND is no longer a re.compile call"
+        literal = call.args[0]
+        assert isinstance(literal, ast.Constant) and isinstance(literal.value, str)
+        return literal.value
+    raise AssertionError(f"{_API_SCHEMAS} no longer defines _CHANNEL_KIND")
+
+
+def test_profile_round_trips() -> None:
+    profile = load_profile(_profile())
+    decoded = AdapterProfile.model_validate_json(profile.model_dump_json())
+    assert decoded.kind == "email"
+    assert decoded.endpoint == "https://curie-mail-adapter.example.test/curie/reply"
+    assert decoded.address.example == "agent@example.test"
+    assert decoded.credentials.egress == "agentmail-sandbox"
+    assert decoded.conformance.mints_reply_ref is True
+
+
+def test_rejects_an_unknown_top_level_key() -> None:
+    with pytest.raises(ValidationError):
+        AdapterProfile.model_validate(_profile(retries=3))
+
+
+def test_env_name_pattern_rejects_a_lowercase_name() -> None:
+    """The pattern is a legibility constraint on a variable NAME.
+
+    It claims nothing about secrecy: ``DEADBEEF`` matches it. Committed values
+    are the repo's gitleaks gate, and which credential gets read is decided at
+    the invocation boundary, never by this field.
+    """
+
+    credentials = dict(_profile()["credentials"], egress_secret_env="curie_egress_secret")
+    with pytest.raises(ValidationError):
+        AdapterProfile.model_validate(_profile(credentials=credentials))
+
+    hyphenated = dict(_profile()["credentials"], ingress_token_env="CURIE-INGRESS-TOKEN")
+    with pytest.raises(ValidationError):
+        AdapterProfile.model_validate(_profile(credentials=hyphenated))
+
+
+def test_slug_pattern_is_byte_identical_to_the_api() -> None:
+    """The API owns the slug rule; the profile copies it verbatim.
+
+    A tightening on either side without the other would let the CLI accept a
+    value the API refuses, or refuse one it accepts.
+    """
+
+    api_pattern = _api_channel_kind_pattern()
+    schema = AdapterProfile.model_json_schema()
+    assert schema["properties"]["kind"]["pattern"] == api_pattern
+    credentials = schema["$defs"]["AdapterCredentials"]["properties"]
+    assert credentials["egress"]["pattern"] == api_pattern
+
+
+def test_accepts_an_underscore_slug() -> None:
+    credentials = dict(_profile()["credentials"], egress="ms_teams_egress")
+    profile = load_profile(_profile(kind="ms_teams", credentials=credentials))
+    assert profile.kind == "ms_teams"
+    assert profile.credentials.egress == "ms_teams_egress"
+
+
+def test_rejects_an_endpoint_with_userinfo() -> None:
+    with pytest.raises(ValidationError):
+        AdapterProfile.model_validate(
+            _profile(endpoint="https://user:pw@curie-mail-adapter.example.test/curie/reply")
+        )
+    with pytest.raises(ValidationError):
+        AdapterProfile.model_validate(_profile(endpoint="/curie/reply"))
+
+
+def test_endpoint_is_optional() -> None:
+    """A live verb requires a concrete endpoint; the model does not.
+
+    The verbs that POST somewhere (bind, token, smoke-test) demand it at the
+    verb boundary, so keeping it optional here costs nothing and leaves the
+    schema line open to a profile that names no install specific route.
+    """
+
+    raw = _profile()
+    del raw["endpoint"]
+    profile = load_profile(raw)
+    assert profile.endpoint is None
+    assert AdapterProfile.model_validate_json(profile.model_dump_json()).endpoint is None
+
+
+def test_rejects_a_pattern_rust_regex_cannot_compile() -> None:
+    """The Rust regex dialect is the floor for ``address.pattern``.
+
+    Python ``re`` compiles lookaround and backreferences and the Rust ``regex``
+    crate refuses them, so a pattern that only Python accepts would be a silent
+    cross language divergence. This is the admitted paired validator: JSON
+    Schema cannot express the rule, so it lives in two implementations kept in
+    step by the shared corpus.
+    """
+
+    address = _profile()["address"]
+    for pattern in (
+        "^[a-z",
+        "^(?=.*@)[a-z0-9@.]+$",
+        "(?<=@)[a-z0-9.]+$",
+        r"^([a-z0-9]+)@\1\.example\.test$",
+    ):
+        with pytest.raises(ValidationError):
+            AddressShape.model_validate(dict(address, pattern=pattern))
+
+
+def test_wire_version_is_the_reply_module_literal() -> None:
+    accepted = AdapterConformance.model_validate(
+        {"wire_version": REPLY_WIRE_VERSION, "mints_reply_ref": True}
+    )
+    assert accepted.wire_version == REPLY_WIRE_VERSION
+    with pytest.raises(ValidationError):
+        AdapterConformance.model_validate({"wire_version": "2.0", "mints_reply_ref": True})
+
+
+def test_version_mismatch_is_refused_before_schema_validation() -> None:
+    """The acceptance rule runs first, and it names both versions.
+
+    Run it after schema validation instead and a 1.1 file trips the closed
+    schema first, so the operator reads "additional property not allowed"
+    rather than the version they actually need to act on.
+    """
+
+    with pytest.raises(ProfileVersionError) as newer:
+        load_profile(_profile(version="1.1"))
+    assert "1.0" in str(newer.value)
+    assert "1.1" in str(newer.value)
+
+    with pytest.raises(ProfileVersionError) as newer_with_unknown_key:
+        load_profile(_profile(version="1.1", retries=3))
+    assert "1.1" in str(newer_with_unknown_key.value)
+    assert "retries" not in str(newer_with_unknown_key.value)
+
+    missing = _profile()
+    del missing["version"]
+    with pytest.raises(ProfileVersionError):
+        load_profile(missing)
+
+
+def test_bare_import_pulls_no_http_client() -> None:
+    """The worker and the API import this package and must not acquire httpx.
+
+    Asserted in a fresh interpreter, because any other test in this session
+    could have imported httpx into this one.
+    """
+
+    probe = "import channel_protocol, sys; raise SystemExit(1 if 'httpx' in sys.modules else 0)"
+    completed = subprocess.run([sys.executable, "-c", probe], capture_output=True, text=True)
+    assert completed.returncode == 0, (
+        f"import channel_protocol pulled in httpx: {completed.stdout}{completed.stderr}"
+    )

--- a/packages/channel-protocol/tests/test_manifest_corpus.py
+++ b/packages/channel-protocol/tests/test_manifest_corpus.py
@@ -1,0 +1,142 @@
+"""The three consumer corpus for the adapter binding profile (#1516).
+
+The same committed file is read by the Pydantic models here, by the exported
+JSON Schema, and by the Rust CLI (``cli/tests/adapter_manifest.rs``). Every
+invalid case is rejected by the Pydantic model. The exported schema rejects
+tier 1 and tier 2 only.
+
+Tier 3 is an ADMITTED PAIRED VALIDATOR: JSON Schema has no keyword for "the
+Rust regex crate can compile this string" and no extension both validators
+would honor, so the rule lives in a Python validator and a Rust one, with this
+corpus as the drift gate between them. The tier 3 branch below therefore
+asserts the INVERSE, that the schema accepts the case. Without that inverted
+assertion a future reader would assume the rule exports, and the Rust half
+could quietly disappear.
+"""
+
+import json
+from pathlib import Path
+from typing import Any
+
+import jsonschema
+import pytest
+from channel_protocol.manifest import ProfileVersionError, load_profile
+from channel_protocol.manifest_schema import build_schema
+from pydantic import ValidationError
+
+_CORPUS: dict[str, Any] = json.loads(
+    (Path(__file__).parents[1] / "schema" / "adapter-profile.corpus.json").read_text(
+        encoding="utf-8"
+    )
+)
+_ROOT_MODEL = "AdapterProfile"
+
+
+def _schema_validator() -> jsonschema.protocols.Validator:
+    schema = build_schema()
+    root = {
+        "$schema": schema["$schema"],
+        "$ref": f"#/$defs/{_ROOT_MODEL}",
+        "$defs": schema["$defs"],
+    }
+    return jsonschema.Draft202012Validator(root)
+
+
+def _referenced_models(property_schema: dict[str, Any]) -> list[str]:
+    """Model names a property's schema can resolve to, direct or through a union."""
+
+    names = []
+    ref = property_schema.get("$ref")
+    if isinstance(ref, str):
+        names.append(ref.rsplit("/", 1)[-1])
+    for member in list(property_schema.get("anyOf", [])) + list(property_schema.get("oneOf", [])):
+        names.extend(_referenced_models(member))
+    items = property_schema.get("items")
+    if isinstance(items, dict):
+        names.extend(_referenced_models(items))
+    return names
+
+
+def _mark_exercised(
+    defs: dict[str, Any], model: str, value: dict[str, Any], seen: set[str]
+) -> None:
+    properties = defs[model].get("properties", {})
+    for name, raw in value.items():
+        if name not in properties:
+            continue
+        seen.add(f"{model}.{name}")
+        if not isinstance(raw, dict):
+            continue
+        for child in _referenced_models(properties[name]):
+            if child in defs:
+                _mark_exercised(defs, child, raw, seen)
+
+
+def test_every_invalid_case_is_rejected_at_its_declared_tier() -> None:
+    validator = _schema_validator()
+    for case in _CORPUS["invalid"]:
+        tier = case["tier"]
+        assert tier in (1, 2, 3), f"unknown tier {tier}: {case['why']}"
+        with pytest.raises((ValidationError, ProfileVersionError)):
+            load_profile(case["profile"])
+        caught_by_schema = not validator.is_valid(case["profile"])
+        if tier == 3:
+            assert not caught_by_schema, (
+                "a tier 3 case is caught by the exported schema, so its tier tag is "
+                f"wrong and the rule does not need a paired validator: {case['why']}"
+            )
+        else:
+            assert caught_by_schema, (
+                f"a tier {tier} case is not caught by the exported schema, so the Rust "
+                f"CLI does not get the rule for free: {case['why']}"
+            )
+
+
+def test_corpus_covers_every_schema_property() -> None:
+    """A property no valid case carries is a property the Rust mirror can omit.
+
+    The Rust struct uses ``deny_unknown_fields``, so a field the corpus never
+    sends can be missing on that side and every cross language test stays green.
+    """
+
+    defs = build_schema()["$defs"]
+    seen: set[str] = set()
+    for profile in _CORPUS["valid"]:
+        _mark_exercised(defs, _ROOT_MODEL, profile, seen)
+
+    declared = {
+        f"{model}.{name}"
+        for model, definition in defs.items()
+        for name in definition.get("properties", {})
+    }
+    missing = sorted(declared - seen)
+    assert not missing, f"no valid corpus case exercises: {', '.join(missing)}"
+
+
+def test_valid_profiles_round_trip_compared_values() -> None:
+    """Values are COMPARED, not merely parsed.
+
+    A consumer that returns a constant instead of carrying the parsed value
+    through passes a parse only check on every case. The corpus therefore
+    varies the values across cases, and this asserts the variation survived.
+    """
+
+    egress_values = set()
+    patterns = set()
+    for profile in _CORPUS["valid"]:
+        parsed = load_profile(profile)
+        assert parsed.credentials.egress == profile["credentials"]["egress"]
+        assert parsed.address.pattern == profile["address"]["pattern"]
+        assert parsed.endpoint == profile.get("endpoint")
+        assert parsed.conformance.mints_reply_ref == profile["conformance"]["mints_reply_ref"]
+        egress_values.add(profile["credentials"]["egress"])
+        patterns.add(profile["address"]["pattern"])
+
+    assert len(egress_values) >= 2, "every valid case carries the same egress identity"
+    assert len(patterns) >= 2, "every valid case carries the same address pattern"
+    assert any("endpoint" not in profile for profile in _CORPUS["valid"]), (
+        "no valid case omits endpoint, so its optionality is never exercised"
+    )
+    assert any("_" in profile["kind"] for profile in _CORPUS["valid"]), (
+        "no valid case carries an underscore slug, which the API accepts"
+    )

--- a/packages/channel-protocol/tests/test_manifest_corpus.py
+++ b/packages/channel-protocol/tests/test_manifest_corpus.py
@@ -128,7 +128,6 @@ def test_valid_profiles_round_trip_compared_values() -> None:
         assert parsed.credentials.egress == profile["credentials"]["egress"]
         assert parsed.address.pattern == profile["address"]["pattern"]
         assert parsed.endpoint == profile.get("endpoint")
-        assert parsed.conformance.mints_reply_ref == profile["conformance"]["mints_reply_ref"]
         egress_values.add(profile["credentials"]["egress"])
         patterns.add(profile["address"]["pattern"])
 

--- a/packages/channel-protocol/tests/test_manifest_previous_shape.py
+++ b/packages/channel-protocol/tests/test_manifest_previous_shape.py
@@ -1,0 +1,90 @@
+"""The bump gate: a shape change cannot land at an unchanged profile version.
+
+A third party commits an ``adapter.yaml`` we cannot force it to upgrade, so the
+profile carries a compatibility policy: adding an optional property is a minor
+bump, and adding a required one, removing or renaming one, changing a type or
+tightening a pattern is a major bump. The drift gate in
+``test_manifest_schema_compat.py`` proves the committed schema matches the
+models; it says nothing about whether a change earned a bump.
+
+The committed baseline is deliberately DEEPER than a names and required list.
+A names only baseline stays green on exactly the changes the policy says must
+bump: a tightened pattern, a changed type, a narrowed enum, a moved bound. So
+the baseline records the canonical validation keywords per property, and
+``description`` and ``title`` are excluded so a prose edit is correctly not a
+shape change.
+
+Refreshing the baseline is legal only in the commit that also bumps
+``PROFILE_VERSION``, and the first test asserts that pairing.
+"""
+
+import copy
+import json
+from typing import Any
+
+from channel_protocol.manifest import PROFILE_VERSION
+from channel_protocol.manifest_schema import (
+    baseline_path,
+    build_baseline,
+    build_schema,
+    canonical_shape,
+)
+
+
+def _committed_baseline() -> dict[str, Any]:
+    loaded: dict[str, Any] = json.loads(baseline_path().read_text(encoding="utf-8"))
+    return loaded
+
+
+def test_shape_matches_the_baseline_at_an_unchanged_version() -> None:
+    committed = _committed_baseline()
+    assert committed["version"] == PROFILE_VERSION, (
+        "the committed baseline records a different profile version than the models; "
+        "the baseline may only be refreshed in the commit that bumps PROFILE_VERSION"
+    )
+    assert build_baseline() == committed, (
+        "the adapter profile shape changed at an unchanged version. Pick the bump from "
+        "the change class table, bump PROFILE_VERSION, then regenerate the baseline with "
+        "python -m channel_protocol.manifest_schema --write-baseline"
+    )
+
+    live = canonical_shape(build_schema())
+    assert live == committed["models"]
+
+    added_optional = copy.deepcopy(build_schema())
+    added_optional["$defs"]["AdapterProfile"]["properties"]["retries"] = {"type": "integer"}
+    assert canonical_shape(added_optional) != committed["models"], (
+        "an added optional property is not recorded, so a minor bump could land unnoticed"
+    )
+
+    tightened = copy.deepcopy(build_schema())
+    kind = tightened["$defs"]["AdapterProfile"]["properties"]["kind"]
+    assert "pattern" in kind, "kind no longer carries an exported pattern"
+    kind["pattern"] = r"^[a-z0-9]+(?:-[a-z0-9]+)*$"
+    assert canonical_shape(tightened) != committed["models"], (
+        "a tightened pattern is not recorded, so a file a conforming author already "
+        "wrote could be invalidated at an unchanged version"
+    )
+
+    retyped = copy.deepcopy(build_schema())
+    retyped["$defs"]["AdapterProfile"]["properties"]["kind"]["type"] = "integer"
+    assert canonical_shape(retyped) != committed["models"], (
+        "a changed property type is not recorded, which is the hole a names only "
+        "baseline leaves open"
+    )
+
+
+def test_a_description_edit_is_not_a_shape_change() -> None:
+    """The false positive control.
+
+    A gate that reds on prose becomes noise, and noise gets refreshed
+    reflexively, which is how the real shape changes get waved through.
+    """
+
+    edited = copy.deepcopy(build_schema())
+    profile = edited["$defs"]["AdapterProfile"]
+    profile["title"] = "Renamed in the docs only"
+    profile["description"] = "A per install binding profile. Prose edited."
+    profile["properties"]["kind"]["description"] = "The channel kind this adapter owns."
+
+    assert canonical_shape(edited) == canonical_shape(build_schema())

--- a/packages/channel-protocol/tests/test_manifest_schema_compat.py
+++ b/packages/channel-protocol/tests/test_manifest_schema_compat.py
@@ -1,0 +1,7 @@
+from channel_protocol.manifest_schema import render_schema, schema_path
+
+
+def test_committed_manifest_schema_is_current() -> None:
+    assert schema_path().read_text(encoding="utf-8") == render_schema(), (
+        "adapter profile schema is stale; run python -m channel_protocol.manifest_schema"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -570,14 +570,27 @@ requires-dist = [
 
 [[package]]
 name = "curie-channel-protocol"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "packages/channel-protocol" }
 dependencies = [
     { name = "pydantic" },
 ]
 
+[package.optional-dependencies]
+conformance = [
+    { name = "httpx" },
+    { name = "jsonschema" },
+    { name = "pyyaml" },
+]
+
 [package.metadata]
-requires-dist = [{ name = "pydantic", specifier = ">=2.9" }]
+requires-dist = [
+    { name = "httpx", marker = "extra == 'conformance'", specifier = ">=0.27" },
+    { name = "jsonschema", marker = "extra == 'conformance'", specifier = ">=4.23" },
+    { name = "pydantic", specifier = ">=2.9" },
+    { name = "pyyaml", marker = "extra == 'conformance'", specifier = ">=6.0" },
+]
+provides-extras = ["conformance"]
 
 [[package]]
 name = "curie-dispatcher"


### PR DESCRIPTION
Adapter builder tooling for the neutral channel port: a binding profile, a `curie adapter` verb family, and a conformance kit a third party can run against its own adapter.

**Stacked on #1514** (`task/1459-channel-neutral-binding`), which carries the neutral channel interface and the builder guide this tooling serves. Review that one first; this branch is cut from it and targets `next`.

## What ships

**A binding profile (`adapter.yaml`).** Declares the channel kind, the address shape, the endpoint and the egress credential slug. Single sourced from Pydantic in `channel-protocol`, exported to a committed JSON Schema the Rust CLI embeds, so there is no hand mirrored second model. Deliberately scoped as a **per install binding file, not** the install agnostic composition manifest ADR-0096 decision 2 describes; that stays a later document, and the guide says so.

**A `curie adapter` verb family.** `scaffold`, `validate`, `bind`, `token`, `smoke-test`. Three flags are operator owned rather than profile supplied, and that is a security boundary rather than ergonomics: the worker indexes its global credential map by the route's adapter slug, so a profile that could choose both the slug and the endpoint would be a credential exfiltration primitive against every other adapter on the install. `bind` therefore requires an explicit `--adapter-slug`, the live verbs require an explicit `--address`, and `smoke-test` takes its secret from an operator supplied file or stdin.

**A conformance kit.** Black box over HTTP, so it never imports the adapter and works in any language. Two front doors, an importable runner and a `curie-adapter-conformance` console script. It reports `automated_floor` pass or fail over the automatable clauses, alongside a mandatory `manual_review_required` list naming the clauses no black box run can observe. There is no field named `conformant`, because one could be truthfully quoted while an unobservable clause went unasserted.

## Floor rule 7 is corrected

The published rule told adapters to re mint their own `chn` token. The mint is platform key only and an adapter holds no platform key, so the guide was asking for something the API refuses. It now says hold the delivery, stay alive, surface a loud stale credential signal, and resume on an operator supplied replacement. Rules 1 through 6 are byte identical.

## Review found real defects, and they are fixed

The kit's entire value is that it can fail a bad adapter, so it was attacked rather than read. Adversarial review across several rounds found, with reproductions, that a non conformant adapter could pass by: sending a malformed `Content-Length` to delete the evidence against itself; starting late so rule 1 saw no retry; letting an unrelated delivery consume a globally armed 202; scheduling a retry past a fixed settle window; performing a side effect and then answering 401; or dropping a held delivery and posting something unrelated after restart. Floor rule 6's tolerance half was asserting against a conversation the adapter had never seen, which tested the wrong property entirely.

The deeper fix is a principle rather than a longer timeout: negative assertions are never decided by waiting. Driver callbacks run under a hard bound, a blocked one becomes a clause failure naming the harness rather than a hang, and the grace window is a detector, so a driver that claims completion early produces an attributable failure instead of a false pass.

## Live verification found a bug only a real install could

`smoke-test --enqueue` omitted `reply_ref`, which `TurnIn` requires, so the API answered 422 and the verb could never demonstrate the idempotency it exists to show. Fixed, re verified live, and pinned by a self checking test so a reformat reds it rather than silently pinning nothing. Both the failing first run and the passing re run are recorded.

## Verification

`packages/channel-protocol` 129 passed. `cli` 1272 passed across 40 suites. `ruff`, `mypy`, `lint-imports`, `uv lock --check`, `cargo fmt`, `cargo clippy -D warnings`, the schema baseline check and `curie dev docs-lint` all green. Live: bind, token, and smoke-test exercised against a running install, including the mutation checks that the wrong egress secret fails and that the second enqueued post reports `duplicate: true`.

No changes under `apps/` or `charts/`, no first party adapter directory (that is #1515's), and the reference adapter was driven read only and is unmodified.

Closes #1516
