### PR TITLE
Accept ADR-0040

### DIFF
--- a/docs/adr/0040-adopt-acp-as-an-edge-projection.md
+++ b/docs/adr/0040-adopt-acp-as-an-edge-projection.md
@@ -2,7 +2,7 @@
 
 Date: 2026-07-16
 
-Status: Draft
+Status: Accepted
 
 ## Context
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -69,7 +69,7 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0037 | [Opt-in binding hook and Pareto model routing](0037-opt-in-binding-hook-and-pareto-model-routing.md) | Accepted |
 | 0038 | [An observability CLI helper for the agent-dev loop](0038-observability-cli-helper-for-the-agent-dev-loop.md) | Accepted |
 | 0039 | [Bounded delivery: a delivery cap and a dead-letter graveyard](0039-bounded-delivery-and-a-dead-letter-graveyard.md) | Accepted |
-| 0040 | [Adopt the Agent Client Protocol as an edge projection](0040-adopt-acp-as-an-edge-projection.md) | Draft |
+| 0040 | [Adopt the Agent Client Protocol as an edge projection](0040-adopt-acp-as-an-edge-projection.md) | Accepted |
 | 0041 | [Every verb is answered at every tier](0041-every-verb-is-answered-at-every-tier.md) | Accepted |
 | 0042 | [Adopt LLM-as-a-Verifier: a continuous-score semantic grader and a live progress signal](0042-llm-as-a-verifier-grader-and-progress-signal.md) | Accepted |
 | 0043 | [The interface catalog is generated from declared front-matter and gated in CI](0043-generated-interface-catalog-and-doc-lint-gate.md) | Accepted |


### PR DESCRIPTION
Records maintainer approval for ADR-0040. Nothing implements it yet, so this is
a plain acceptance under ADR-0085.

## Why it was held, and why that is over

Decision 1 used to say ADR-0031's `TurnEvent` union stays the internal canonical
type. ADR-0031 is superseded, so that was false. #1551 removed the premise and
left the source type open until the harness boundary settles.

## Why accept it now

ADR-0096 is already Accepted and inherits decision 4 from this ADR: an adapter
carries and renders, it never decides who is authorized. Until now an accepted
decision rested on a draft one. This closes that.

ADR-0040 also sets no gate for itself. Unlike 0030, 0061, 0075 and 0095, it never
asked for a spike or evidence before acceptance.

## What this does not do

It does not start the ACP work. Decision 2's entry point needs the harness
boundary settled first, which waits on ADR-0061's spike, and the ADR says so in
its own consequences. This records the decision.

Index regenerated, `scripts/check-docs.sh` passes.