### PR TITLE
Accept ADR-0087, ADR-0093, and ADR-0062

### DIFF
--- a/docs/adr/0062-harness-conformance-has-teeth.md
+++ b/docs/adr/0062-harness-conformance-has-teeth.md
@@ -2,7 +2,19 @@
 
 Date: 2026-07-21
 
-Status: Draft
+Status: Accepted
+
+Realized by the import-linter contracts in `pyproject.toml`, run as
+`uv run lint-imports` in `.github/workflows/ci.yaml`, so a forbidden import fails
+the build rather than being caught in review.
+
+Two of the three contracts this ADR asks for are live. The third, decision 1's
+full ban on importing `claude_agent_sdk` anywhere outside the Claude harness
+package, cannot pass yet: nine `curie_runner` modules still import it directly,
+and confining them is the refactor that decision 2 depends on. The two contracts
+that are live gate the boundaries already clean, so they cannot rot back before
+that lands. Acceptance records the decision; the third contract is added when the
+refactor does.
 
 Follows [ADR-0060](0060-the-harness-is-a-declared-package.md) (a harness is a
 declared package) and [ADR-0061](0061-out-of-process-harness-boundary.md) (the

--- a/docs/adr/0087-the-api-renders-connector-objects-the-cli-applies-them.md
+++ b/docs/adr/0087-the-api-renders-connector-objects-the-cli-applies-them.md
@@ -1,7 +1,12 @@
 # 87. The API renders connector objects; the CLI applies them
 
 Date: 2026-07-30
-Status: Draft
+Status: Accepted
+
+Realized by `read_version_connectors` in `apps/api/src/curie_api/routers/agents.py`,
+which renders the objects and applies none of them, and by `version_connectors` in
+`cli/src/api.rs` with the apply and prune in `cli/src/connectors.rs`, which are
+what reach the cluster.
 
 ## Context
 

--- a/docs/adr/0093-local-model-assets-are-pre-provisioned-never-implicitly-downloaded.md
+++ b/docs/adr/0093-local-model-assets-are-pre-provisioned-never-implicitly-downloaded.md
@@ -2,7 +2,11 @@
 
 Date: 2026-08-03
 
-Status: Draft
+Status: Accepted
+
+Realized by `preflight_local_model` in `cli/src/docker.rs`, which both tiers call
+from `cli/src/local.rs` before anything is brought up, and by the opt-in fetch
+flag that keeps the old behaviour available for anyone who wants it.
 
 ## Context
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -91,7 +91,7 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0059 | [The sandbox is a bounded resource envelope; capacity is a tenant boundary](0059-sandbox-is-a-bounded-resource-envelope.md) | Accepted |
 | 0060 | [The harness is a declared package, not a class](0060-the-harness-is-a-declared-package.md) | Accepted |
 | 0061 | [The harness boundary is an out-of-process adapter, wire-compatible with Omnigent](0061-out-of-process-harness-boundary.md) | Draft |
-| 0062 | [Harness conformance has teeth](0062-harness-conformance-has-teeth.md) | Draft |
+| 0062 | [Harness conformance has teeth](0062-harness-conformance-has-teeth.md) | Accepted |
 | 0063 | [Message-driven approval reply surface](0063-message-driven-approval-reply-surface.md) | Accepted |
 | 0064 | [Fail-forward cluster teardown](0064-fail-forward-cluster-teardown.md) | Accepted |
 | 0065 | [Tag protection, not the workflow gate, binds a write actor](0065-tag-protection-not-the-workflow-gate-binds-a-write-actor.md) | Accepted |
@@ -116,13 +116,13 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0084 | [Publish a verification contract for agents driving Curie](0084-publish-a-verification-contract-for-agents-driving-curie.md) | Accepted |
 | 0085 | [Acceptance, not implementation, authorizes an ADR](0085-acceptance-not-implementation-authorizes-an-adr.md) | Accepted |
 | 0086 | [Bundles declare connectors; the platform hosts them](0086-bundles-declare-connectors-the-platform-hosts-them.md) | Accepted |
-| 0087 | [The API renders connector objects; the CLI applies them](0087-the-api-renders-connector-objects-the-cli-applies-them.md) | Draft |
+| 0087 | [The API renders connector objects; the CLI applies them](0087-the-api-renders-connector-objects-the-cli-applies-them.md) | Accepted |
 | 0088 | [Per user delegated OAuth for MCP](0088-per-user-delegated-oauth-for-mcp.md) | Accepted |
 | 0089 | [Bundles declare their deploy targets](0089-bundles-declare-their-deploy-targets.md) | Accepted |
 | 0090 | [A reconciler applies connectors, so agent repos need no CLI](0090-a-reconciler-applies-connectors-so-agent-repos-need-no-cli.md) | Accepted |
 | 0091 | [Git-flow resolves deploy targets, so one repo serves many agents](0091-git-flow-resolves-deploy-targets-so-one-repo-serves-many-agents.md) | Accepted |
 | 0092 | [A GitHub App gives the platform its own repository identity](0092-a-github-app-gives-the-platform-its-own-repository-identity.md) | Accepted |
-| 0093 | [Local-model assets are pre-provisioned, never implicitly downloaded](0093-local-model-assets-are-pre-provisioned-never-implicitly-downloaded.md) | Draft |
+| 0093 | [Local-model assets are pre-provisioned, never implicitly downloaded](0093-local-model-assets-are-pre-provisioned-never-implicitly-downloaded.md) | Accepted |
 | 0094 | [A bundle carries its own sealed connector keys](0094-a-bundle-carries-its-own-sealed-connector-keys.md) | Accepted |
 | 0095 | [One tiered memory lifecycle for agent and channel memory](0095-tiered-memory-lifecycle.md) | Draft |
 | 0096 | [A third-party port adapter is a deployed service, not a loaded plugin](0096-port-adapters-are-deployed-services.md) | Accepted |


### PR DESCRIPTION
All three are already built and running in CI, so this is ADR-0102's
accept-alongside-implementation path rather than a plain acceptance. Maintainer
approval is recorded on this PR.

ADR-0102 asks for two things, and having the code is only one of them. The other
is that the document names the code that carries it out, which none of the three
did. That line is added here.

| ADR | What it names |
|---|---|
| 0087 | the rendering endpoint in the API, and the apply and prune in the CLI |
| 0093 | the preflight both tiers call before bringing anything up |
| 0062 | the import-linter contracts and the CI step that runs them |

Accepting 0087 also closes a gap. ADR-0090 is Accepted and builds on it, so until
now an accepted decision rested on a draft one.

## One caveat, written into 0062 rather than left implicit

Only two of that ADR's three contracts are switched on. The third, decision 1's
full ban on importing `claude_agent_sdk` outside the Claude harness package,
cannot pass yet, because nine `curie_runner` modules still import it directly and
confining them is a refactor that has not happened.

The two that are live gate the boundaries that are already clean, so they cannot
rot back before that refactor lands. The ADR now says this in its own header, so
that Accepted is not read as meaning the whole gate is armed.

Index regenerated, `scripts/check-docs.sh` passes.