### PR TITLE
Derive the sandbox quota scope from the PriorityClass the pods carry

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -110,6 +110,19 @@ jobs:
           set -euo pipefail
           bash charts/curie/ci/clickhouse-logging-assertions.sh
 
+      # Prove the tenant capacity ceiling actually binds the pods it is meant to.
+      # The quota is PriorityClass-scoped, so if its scope is not the name the
+      # sandbox pods carry it matches nothing and enforces nothing -- silently,
+      # because the object exists and `used: 0` reads as "nothing consumed"
+      # rather than "matching nothing". Observed live: a sandbox holding
+      # `limits.cpu: 1` running while the quota reported used 0, with the scoped
+      # class absent from the cluster entirely (#1534). Compares the two rendered
+      # objects against each other, not a value against itself.
+      - name: helm render assertions (sandbox quota scope)
+        run: |
+          set -euo pipefail
+          bash charts/curie/ci/sandbox-quota-scope-assertions.sh
+
       # Prove the Langfuse web+worker containers carry a numeric runAsUser
       # alongside runAsNonRoot (issue #351) so the kubelet can verify non-root
       # and the pods actually start on an enforcing cluster.

--- a/charts/curie/ci/sandbox-quota-scope-assertions.sh
+++ b/charts/curie/ci/sandbox-quota-scope-assertions.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+#
+# Render-assertion test for the sandbox ResourceQuota's scope (#1534).
+#
+# The tenant capacity ceiling is a PriorityClass-scoped ResourceQuota, so it
+# bounds exactly the pods carrying one specific PriorityClass name. If that name
+# is not the name the sandbox pods actually carry, the quota matches nothing and
+# enforces nothing -- and it does so silently. The object exists, `kubectl get
+# resourcequota` prints it, and `used: 0` reads as "nothing consumed" rather than
+# "matching nothing". Kubernetes does not validate a scopeSelector's PriorityClass
+# name against an existing object, so there is no error anywhere.
+#
+# That is not hypothetical. On a live install that had renamed its sandbox
+# PriorityClass, a sandbox holding `limits.cpu: 1` was running while the quota
+# reported `used: {limits.cpu: "0", pods: "0"}`, and the scoped class was absent
+# from `kubectl get priorityclass` entirely. The whole ceiling was inert.
+#
+# The fix is to derive the scope from `priorityClasses.sandbox.name` -- the same
+# value agent-sandbox.yaml stamps on the sandbox pod template -- rather than from
+# an independent constant. These assertions pin that the two sides agree under
+# every way an operator can set them.
+#
+# Six assertions:
+#   (a) Default render: the quota's scope equals priorityClasses.sandbox.name.
+#   (b) The invariant that actually matters: the quota's scope equals the
+#       priorityClassName on the SandboxTemplate's pod spec. This is the one that
+#       would have caught the live failure, because it compares the two rendered
+#       objects rather than a value against itself.
+#   (c) Renaming priorityClasses.sandbox.name propagates to the quota. This is
+#       the regression: before the fix the scope stayed on the old default.
+#   (d) An explicit sandboxPriorityClassName still wins, for a PriorityClass
+#       managed outside this chart.
+#   (e) With both empty, helm FAILS rather than rendering a quota scoped to "".
+#       A quota scoped to an empty name matches no pods and enforces nothing --
+#       exactly the silent shape this file exists to prevent.
+#   (f) The quota is absent entirely when resourceQuota.enabled is false, so the
+#       gate did not become unconditional.
+set -euo pipefail
+
+CHART="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+QUOTA_TPL="templates/tenant-resourcequota.yaml"
+SANDBOX_TPL="templates/agent-sandbox.yaml"
+
+scope_of() {
+  # Print the single PriorityClass value the rendered quota scopes on.
+  python3 -c "
+import sys, yaml
+for doc in yaml.safe_load_all(open(sys.argv[1])):
+    if not doc or doc.get('kind') != 'ResourceQuota':
+        continue
+    for m in doc['spec']['scopeSelector']['matchExpressions']:
+        if m['scopeName'] == 'PriorityClass':
+            print(m['values'][0])
+            sys.exit(0)
+sys.exit('no PriorityClass scope found')
+" "$1"
+}
+
+echo "=== (a) default: quota scope == priorityClasses.sandbox.name ==="
+helm template rel "$CHART" --show-only "$QUOTA_TPL" > "$TMP/default-quota.yaml"
+DEFAULT_SCOPE="$(scope_of "$TMP/default-quota.yaml")"
+EXPECTED="$(python3 -c "
+import yaml; print(yaml.safe_load(open('$CHART/values.yaml'))['priorityClasses']['sandbox']['name'])
+")"
+[ "$DEFAULT_SCOPE" = "$EXPECTED" ] || {
+  echo "FAIL: quota scopes on '$DEFAULT_SCOPE', priorityClasses.sandbox.name is '$EXPECTED'" >&2
+  exit 1
+}
+echo "  ok: $DEFAULT_SCOPE"
+
+echo "=== (b) quota scope == the priorityClassName the sandbox pods carry ==="
+helm template rel "$CHART" --show-only "$SANDBOX_TPL" > "$TMP/default-sandbox.yaml"
+POD_PC="$(python3 -c "
+import sys, yaml
+for doc in yaml.safe_load_all(open('$TMP/default-sandbox.yaml')):
+    if not doc or doc.get('kind') != 'SandboxTemplate':
+        continue
+    print(doc['spec']['podTemplate']['spec'].get('priorityClassName', ''))
+    sys.exit(0)
+sys.exit('no SandboxTemplate rendered')
+")"
+[ "$DEFAULT_SCOPE" = "$POD_PC" ] || {
+  echo "FAIL: quota scopes on '$DEFAULT_SCOPE' but sandbox pods carry '$POD_PC'." >&2
+  echo "      The quota matches no sandbox and silently enforces nothing." >&2
+  exit 1
+}
+echo "  ok: both '$POD_PC'"
+
+echo "=== (c) renaming priorityClasses.sandbox.name propagates to the quota ==="
+helm template rel "$CHART" --show-only "$QUOTA_TPL" \
+  --set priorityClasses.sandbox.name=tenant-a-sandbox > "$TMP/renamed-quota.yaml"
+RENAMED_SCOPE="$(scope_of "$TMP/renamed-quota.yaml")"
+[ "$RENAMED_SCOPE" = "tenant-a-sandbox" ] || {
+  echo "FAIL: renamed to 'tenant-a-sandbox' but quota still scopes on '$RENAMED_SCOPE'." >&2
+  echo "      This is #1534: the rename leaves the ceiling inert." >&2
+  exit 1
+}
+helm template rel "$CHART" --show-only "$SANDBOX_TPL" \
+  --set priorityClasses.sandbox.name=tenant-a-sandbox > "$TMP/renamed-sandbox.yaml"
+grep -q "priorityClassName: tenant-a-sandbox" "$TMP/renamed-sandbox.yaml" || {
+  echo "FAIL: rename did not reach the sandbox pod template" >&2; exit 1
+}
+echo "  ok: both followed the rename"
+
+echo "=== (d) explicit sandboxPriorityClassName overrides the derivation ==="
+helm template rel "$CHART" --show-only "$QUOTA_TPL" \
+  --set priorityClasses.sandbox.name=ignored-here \
+  --set resourceQuota.sandboxPriorityClassName=externally-managed > "$TMP/override-quota.yaml"
+OVERRIDE_SCOPE="$(scope_of "$TMP/override-quota.yaml")"
+[ "$OVERRIDE_SCOPE" = "externally-managed" ] || {
+  echo "FAIL: explicit override ignored; scope is '$OVERRIDE_SCOPE'" >&2; exit 1
+}
+echo "  ok: $OVERRIDE_SCOPE"
+
+echo "=== (e) both empty -> helm fails rather than scoping on \"\" ==="
+if helm template rel "$CHART" --show-only "$QUOTA_TPL" \
+     --set priorityClasses.sandbox.name= \
+     --set resourceQuota.sandboxPriorityClassName= > "$TMP/empty.yaml" 2>"$TMP/empty.err"; then
+  echo "FAIL: rendered a quota with no resolvable PriorityClass name:" >&2
+  cat "$TMP/empty.yaml" >&2
+  exit 1
+fi
+grep -qi "matches no pods\|silently enforces nothing" "$TMP/empty.err" || {
+  echo "FAIL: helm failed, but not with the explanatory message:" >&2
+  cat "$TMP/empty.err" >&2
+  exit 1
+}
+echo "  ok: refused, with a reason"
+
+echo "=== (f) quota absent when resourceQuota.enabled=false ==="
+helm template rel "$CHART" --show-only "$QUOTA_TPL" \
+  --set resourceQuota.enabled=false > "$TMP/disabled.yaml" 2>/dev/null || true
+if grep -q "kind: ResourceQuota" "$TMP/disabled.yaml" 2>/dev/null; then
+  echo "FAIL: quota rendered despite resourceQuota.enabled=false" >&2; exit 1
+fi
+echo "  ok: absent"
+
+echo
+echo "All sandbox quota scope assertions passed."

--- a/charts/curie/templates/tenant-resourcequota.yaml
+++ b/charts/curie/templates/tenant-resourcequota.yaml
@@ -40,13 +40,38 @@ existing PriorityClass object at ResourceQuota-admission time. So this quota
 renders and behaves correctly whether #759 has landed yet or not:
   - #759 not yet merged / no pod sets this priorityClassName: the scope simply
     matches no pods yet (an inert-but-present quota), never an error.
-  - #759 merged with a DIFFERENT sandbox PriorityClass name than the default
-    guessed here (`resourceQuota.sandboxPriorityClassName`, default
-    "curie-sandbox"): override this value (or align the two names) so the
-    scope actually matches; see the PR notes for the coordination point.
+  - #759 merged with a DIFFERENT sandbox PriorityClass name: the scope now
+    DERIVES from `priorityClasses.sandbox.name`, the same value
+    agent-sandbox.yaml stamps on the sandbox pod template, so a rename
+    propagates to both sides at once and cannot desynchronize them.
+
+The derivation is the fix for a silent fail-open (#1534). The scope used to read
+`resourceQuota.sandboxPriorityClassName` independently of the name the pods
+actually carry, so renaming the PriorityClass -- without knowing to override a
+second, differently-named value -- left the quota scoped to a class nothing
+carried. Observed on a live install: a sandbox holding `limits.cpu: 1` running
+while the quota reported `used: {limits.cpu: "0", pods: "0"}`, with the scoped
+class absent from `kubectl get priorityclass` entirely. The whole tenant capacity
+ceiling was inert, and it presented as healthy -- the object exists, and `used: 0`
+reads as "nothing consumed" rather than "matching nothing".
+
+`sandboxPriorityClassName` remains as an EXPLICIT override for the one case
+deriving cannot serve: a PriorityClass managed outside this chart
+(`priorityClasses.sandbox.create: false`) whose name differs from
+`priorityClasses.sandbox.name`. Left unset -- the default -- it derives, which is
+what every in-chart install wants. Setting it is now a deliberate act rather than
+a silent prerequisite nobody knew about.
 */}}
 {{- if and .Values.agentSandbox.deploy .Values.resourceQuota.enabled }}
 {{- $rq := .Values.resourceQuota }}
+{{/*
+  Derive from the name the sandbox pods actually carry. An explicit
+  `sandboxPriorityClassName` still wins, for an externally-managed class.
+*/}}
+{{- $sandboxPriorityClass := $rq.sandboxPriorityClassName | default .Values.priorityClasses.sandbox.name }}
+{{- if not $sandboxPriorityClass }}
+{{- fail "resourceQuota.enabled is true but no sandbox PriorityClass name resolves: set priorityClasses.sandbox.name, or resourceQuota.sandboxPriorityClassName for an externally-managed class. A quota scoped to an empty name matches no pods and silently enforces nothing." }}
+{{- end }}
 apiVersion: v1
 kind: ResourceQuota
 metadata:
@@ -60,7 +85,7 @@ spec:
       - operator: In
         scopeName: PriorityClass
         values:
-          - {{ $rq.sandboxPriorityClassName | quote }}
+          - {{ $sandboxPriorityClass | quote }}
   # Only cpu/memory/pods: a PriorityClass-scoped quota cannot list
   # ephemeral-storage (see the header). Per-pod ephemeral limits x the pods cap
   # give the aggregate disk ceiling instead.

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -1399,15 +1399,24 @@ resourceQuota:
   # The PriorityClass name this quota's scopeSelector keys on, so the quota
   # binds only sandbox pods -- NOT the platform pods (api/worker/dispatcher)
   # or the data tier, which in the N=1 self-host topology share this same
-  # release namespace. This is the sandbox PriorityClass ADR-0059 decision 5 /
-  # issue #759 defines; #759 is being implemented in parallel and this is an
-  # assumed name pending that PR landing. If #759 ships a different name,
-  # override this value (or reconcile the two constant strings) so the
-  # scopeSelector actually matches. A name that matches no pod yet (#759 not
-  # merged) makes this quota inertly present rather than an error -- Kubernetes
+  # release namespace.
+  #
+  # EMPTY MEANS DERIVE, and empty is what you want. The quota's scope then takes
+  # `priorityClasses.sandbox.name` -- the same value agent-sandbox.yaml stamps on
+  # the sandbox pod template -- so the two sides cannot desynchronize and a
+  # rename propagates to both at once.
+  #
+  # This used to be an independent constant defaulting to "curie-sandbox", which
+  # made renaming the sandbox PriorityClass silently disable the entire tenant
+  # ceiling: the scope kept matching the old name, nothing carried it, and the
+  # quota reported `used: 0` while sandboxes ran unbounded (#1534). Kubernetes
   # does not validate a scopeSelector's PriorityClass name against an existing
-  # object.
-  sandboxPriorityClassName: curie-sandbox
+  # object, so nothing anywhere reported it.
+  #
+  # Set this ONLY for a PriorityClass managed outside this chart
+  # (`priorityClasses.sandbox.create: false`) whose name differs from
+  # `priorityClasses.sandbox.name`. Setting it overrides the derivation.
+  sandboxPriorityClassName: ""
   hard:
     requestsCpu: "4"
     requestsMemory: 8Gi


### PR DESCRIPTION
Ref #1534.

The tenant ResourceQuota is PriorityClass-scoped, and its scope came from `resourceQuota.sandboxPriorityClassName` — an independent constant defaulting to `curie-sandbox`. The sandbox pods take their class from `priorityClasses.sandbox.name`. **Renaming the latter without knowing to override the former leaves the quota scoped to a class nothing carries**, so it matches no pods and enforces nothing.

It fails silently and reads as healthy: the object exists, `kubectl get resourcequota` prints it, and `used: 0` looks like spare headroom rather than a scope matching nothing. Kubernetes does not validate a scopeSelector's PriorityClass name against an existing object.

**Observed on a cluster-tier install that had renamed its sandbox class:**

```
$ kubectl get priorityclass | grep sandbox
sre-bot-sandbox   100000          # curie-sandbox does not exist at all

$ kubectl get pods -l app.kubernetes.io/component=runner-sandbox \
    -o custom-columns=PC:.spec.priorityClassName,CPU:...limits.cpu
sre-bot-sandbox   1               # a sandbox is RUNNING

$ kubectl get resourcequota ...-sandbox-quota -o jsonpath='{.status.used}'
{"limits.cpu":"0","pods":"0", ...}  # and the quota counts zero
```

The whole tenant ceiling was inert. It also explains a divergence noted on #1534 — a default install dies at eight threads on the quota with the node idle, while a renamed one sails past and saturates the node instead. Only one of them has a working ceiling.

## The change

The scope now derives from `priorityClasses.sandbox.name`, the same value `agent-sandbox.yaml` stamps on the pod template, so a rename propagates to both sides at once. This follows the convention the chart already uses for the platform class (`agent-sandbox.yaml`: *"so an operator rename propagates"*).

`sandboxPriorityClassName` stays as an explicit override for a PriorityClass managed outside the chart, and defaults to empty. Setting it is now a deliberate act rather than a silent prerequisite. With neither resolvable, helm fails with a reason rather than rendering a quota scoped to `""`.

## The assertion

`charts/curie/ci/sandbox-quota-scope-assertions.sh`, six checks. The load-bearing one compares the two **rendered objects against each other** rather than a value against itself — that is what would have caught the live failure:

```
(b) quota scope == the priorityClassName the sandbox pods carry
```

**Fails when the fix is reverted** (per #1479): restoring the old template makes (c) fail with `renamed to 'tenant-a-sandbox' but quota still scopes on 'curie-sandbox'. This is #1534: the rename leaves the ceiling inert.`

Registered in `helm-ci.yaml`, so `chart_assertion_scripts_match_helm_ci_steps` stays green.

Targeting `next` per the #1534 milestone; happy to retarget `main` if this reads as a bug fix for the stable line instead.