### PR TITLE
Resolve an operator approval gate into every live tool name it can denote

### DIFF
--- a/packages/plugin-format/src/plugin_format/__init__.py
+++ b/packages/plugin-format/src/plugin_format/__init__.py
@@ -10,7 +10,7 @@ from .approval_policy import (
     connector_server_names,
     connector_tool_prefix,
     declared_mcp_server_names,
-    effective_operator_gate,
+    effective_operator_gates,
     grantable_routes,
 )
 from .archive import (
@@ -60,7 +60,7 @@ __all__ = [
     "declared_mcp_server_names",
     "connector_server_names",
     "connector_tool_prefix",
-    "effective_operator_gate",
+    "effective_operator_gates",
     "validate_bundle",
     "ValidationResult",
     "ValidationIssue",

--- a/packages/plugin-format/src/plugin_format/approval_policy.py
+++ b/packages/plugin-format/src/plugin_format/approval_policy.py
@@ -80,7 +80,7 @@ def effective_tool_prefix(bundle_name: str, server: str) -> str:
     """The live tool-name prefix the SDK plugin-namespacing produces (#703).
 
     The SAME template ``validate.py`` builds ``expected_prefixes`` from and
-    ``effective_operator_gate`` matches against -- ONE definition shared by the
+    ``effective_operator_gates`` matches against -- ONE definition shared by the
     deploy-time validator and the runtime loader so the prefix format cannot
     drift between them (the #453/#544 lesson).
     """
@@ -238,61 +238,66 @@ def connector_server_names(root: str | Path) -> set[str] | None:
     return set(parsed.connectors)
 
 
-def effective_operator_gate(
+def effective_operator_gates(
     bundle_name: str | None,
     servers: set[str] | None,
     name: str,
     *,
     connector_servers: set[str] | None,
-) -> str | None:
-    """Map an operator gate name to its effective runtime tool name (#703).
+) -> frozenset[str] | None:
+    """Map an operator gate name to the effective runtime tool name(s) it arms (#703).
 
     The SDK plugin-prefixes a bundle MCP tool to
     ``mcp__plugin_<bundle>_<server>__<tool>``. An operator who writes the natural
     shorthand ``mcp__<server>__<tool>`` in ``CURIE_APPROVAL_REQUIRED_TOOLS`` must
     have it rewritten to that effective form, or the gate arms a literal that the
-    runtime name never matches (a silent fail-open). Returns:
+    runtime name never matches (a silent fail-open). Returns a NON-EMPTY
+    ``frozenset`` of the live names to arm, or ``None`` for "cannot verify":
 
-    - the rewritten effective name when ``name`` is ``mcp__<server>__<tool>`` and
-      ``<server>`` is a declared bundle server. ``<server>`` is resolved by
-      MATCHING the shorthand against the declared servers (a server name may itself
-      contain ``__``, so splitting at the first ``__`` would misparse
-      ``mcp__foo__bar__do`` as server ``foo``); the longest matching server name
-      wins when one is a prefix of another. The effective prefix is built exactly
-      as ``validate.py`` constructs ``expected_prefixes``;
-    - ``name`` verbatim for an ``mcp__<connector>__<tool>`` naming a connector the
-      bundle declares in ``connectors.yaml`` (#1495). A connector rides the SDK's
+    - ``{rewritten}`` when ``name`` is ``mcp__<server>__<tool>`` and ``<server>`` is
+      a declared bundle server. ``<server>`` is resolved by MATCHING the shorthand
+      against the declared servers (a server name may itself contain ``__``, so
+      splitting at the first ``__`` would misparse ``mcp__foo__bar__do`` as server
+      ``foo``); the longest matching server name wins when one is a prefix of
+      another. The effective prefix is built exactly as ``validate.py`` constructs
+      ``expected_prefixes``;
+    - ``{name}`` for an ``mcp__<connector>__<tool>`` naming a connector the bundle
+      declares in ``connectors.yaml`` (#1495). A connector rides the SDK's
       ``mcp_servers`` map directly, so that shorthand IS already the live runtime
       name: it is verified against the declared connectors and returned unchanged,
-      never rewritten to the plugin form the runtime never produces. Both the
-      connector rule and the plugin-shorthand rule test the SAME ``mcp__<server>__``
-      prefix shape, so ONE name can match both sets; the two candidates compete on
-      SPECIFICITY (the longest matched server name wins) rather than on which check
-      runs first (#1564);
-    - ``name`` verbatim only for a built-in with no ``mcp__`` prefix (armed by raw
-      name), OR for an already ``mcp__plugin_``-prefixed name that MATCHES an
-      expected prefix ``mcp__plugin_<bundle>_<server>__`` for a declared server
-      (with a non-empty tool remainder), mirroring ``validate.py``'s
-      ``expected_prefixes`` check -- an already-prefixed name is NOT trusted blindly
-      (a typo'd ``mcp__plugin_wrongbundle_wrongserver__tool`` would arm a literal the
-      runtime never matches, a fail-open);
+      never rewritten to the plugin form the runtime never produces;
+    - ``{name, rewritten}`` -- BOTH live forms -- when ``name`` matches a declared
+      connector AND a declared MCP server of a DIFFERENT name (#1564). The two rules
+      test the SAME ``mcp__<server>__`` prefix shape, so one gate name can match
+      both sets, and NOTHING in the inputs says which server actually hosts the
+      tool. Arming both is fail-CLOSED (at worst one extra approval card for a tool
+      nobody calls); arming one is a coin flip that fails OPEN half the time;
+    - ``{name}`` for a built-in with no ``mcp__`` prefix (armed by raw name), OR for
+      an already ``mcp__plugin_``-prefixed name that MATCHES an expected prefix
+      ``mcp__plugin_<bundle>_<server>__`` for a declared server (with a non-empty
+      tool remainder), mirroring ``validate.py``'s ``expected_prefixes`` check -- an
+      already-prefixed name is NOT trusted blindly (a typo'd
+      ``mcp__plugin_wrongbundle_wrongserver__tool`` would arm a literal the runtime
+      never matches, a fail-open);
     - ``None`` when ``name`` is ``mcp__``-shaped and cannot be verified against a
       declared server or connector: an undeclared server, no declared servers,
       ``servers`` or ``connector_servers`` being ``None`` (unknowable), a falsy
-      ``bundle_name`` (cannot construct the plugin prefix to verify), an empty tool
-      remainder, an already-prefixed name matching no expected
-      prefix, or an AMBIGUOUS name matching a connector and a declared MCP server at
-      EQUAL specificity (#1564) -- the two live forms differ and there is no
-      principled winner, so refuse rather than pick one silently. The operator
-      override is never deploy-validated, so this runtime
-      check is its sole defense -- "cannot verify" fails CLOSED, not through. The
-      caller fails closed on ``None``.
+      ``bundle_name`` (cannot construct the plugin prefix to verify or to build),
+      an empty tool remainder, an already-prefixed name matching no expected prefix,
+      or a name matching a connector and a declared MCP server of the SAME name
+      (#1564) -- that is an invalid CONFIGURATION, not an unknowable one, and it
+      must keep failing loudly. The operator override is never deploy-validated, so
+      this runtime check is its sole defense -- "cannot verify" fails CLOSED, not
+      through. The caller fails closed on ``None``.
+
+    An empty ``frozenset`` is never returned: it would read as "armed nothing",
+    which is the fail-open shape this helper exists to prevent. Refusal is ``None``.
     """
 
     # A built-in tool (Bash, Write, ...) carries no mcp__ prefix: armed by raw
     # name, never rewritten and never server-checked.
     if not name.startswith("mcp__"):
-        return name
+        return frozenset({name})
     # Every mcp__-shaped name is verified against the declared-server sets. Without
     # them (an unreadable MCP or connectors declaration) nothing can be verified, so
     # fail closed -- this runtime check is the operator override's only defense.
@@ -304,31 +309,46 @@ def effective_operator_gate(
     # mcp__plugin_<bundle>_<server>__<tool>. Both rules test the SAME
     # mcp__<server>__ prefix shape (connector_tool_prefix vs the shorthand template
     # below), so ONE name can match both sets -- with connector `git` and MCP server
-    # `git__hub` both declared, mcp__git__hub__create_pr matches each. Compute BOTH
-    # candidates and arbitrate on SPECIFICITY: the longest matched server name wins,
-    # exactly as _longest_matching_server arbitrates WITHIN one set. Deciding by
-    # which check runs first would let the connector shadow the plugin server and
-    # arm the un-rewritten literal, which the runtime never produces -- the #453
-    # fail-open, in reverse (#1564).
+    # `git__hub` both declared, mcp__git__hub__create_pr matches each.
     connector = _longest_matching_server(name, connector_servers, connector_tool_prefix)
     shorthand = _longest_matching_server(name, servers, lambda s: f"mcp__{s}__")
-    # Equal specificity means the connector and the MCP server carry the SAME name
-    # (equal-length prefixes of one name under one template are the same string),
-    # and their live forms differ. There is no principled winner, so refuse rather
-    # than pick one silently: the caller turns None into a loud boot error (#520).
-    # validate._reject_connector_name_collisions already rejects this at deploy, but
-    # the operator env knob is never deploy-validated, which is what this defends.
-    if connector is not None and shorthand is not None and len(connector) == len(shorthand):
-        return None
-    # The connector won on specificity (or is the only match): return the name
-    # unchanged (#1495). Resolved BEFORE the already-prefixed literal branch below,
-    # because a connector may legally be named `plugin` and its mcp__plugin__<tool>
-    # would otherwise fall into that branch and be rejected. The RFC 1123 argument
-    # ("a connector name never contains `_`") is why the literal branch cannot steal
-    # a connector name -- it says nothing about the shorthand branch, which shares
-    # the connector's exact prefix shape and needs the contest above.
-    if connector is not None and (shorthand is None or len(connector) > len(shorthand)):
-        return name
+    if connector is not None and shorthand is not None:
+        # Equal length means the connector and the MCP server carry the SAME name
+        # (equal-length prefixes of one name under one template are the same
+        # string), and their live forms differ. That is an invalid CONFIGURATION,
+        # so refuse: the caller turns None into a loud boot error (#520).
+        # validate._reject_connector_name_collisions already rejects this at
+        # deploy, but the operator env knob is never deploy-validated, which is
+        # what this defends.
+        if len(connector) == len(shorthand):
+            return None
+        # Two DIFFERENT servers each match this one gate name, and which one the
+        # operator meant is unknowable from the inputs. Do NOT arbitrate on the
+        # length of the matched server name: a name's length says nothing about
+        # which server actually hosts the tool. With connector `deploy` exposing a
+        # tool `prod__apply` and an MCP server `deploy__prod` declared,
+        # mcp__deploy__prod__apply is ALREADY live for the connector while the
+        # longer server name would rewrite it into a literal the SDK never emits.
+        # Picking either side by length just inverts which one gets shadowed, and
+        # build_can_use_tool matches by exact string equality, so the shadowed side
+        # gates nothing at all, silently. Arm BOTH live forms instead: gate.required
+        # is a frozenset, so over-arming costs at most one approval card for a tool
+        # nobody calls, while under-arming is a total fail-open (#1564).
+        if not bundle_name:
+            # The plugin half cannot be constructed, so arming both is impossible;
+            # arming only the connector half would re-create the shadow. Refuse.
+            return None
+        tool = name[len(f"mcp__{shorthand}__") :]
+        return frozenset({name, f"mcp__plugin_{bundle_name}_{shorthand}__{tool}"})
+    # The connector is the ONLY match: return the name unchanged (#1495). Resolved
+    # BEFORE the already-prefixed literal branch below, because a connector may
+    # legally be named `plugin` and its mcp__plugin__<tool> would otherwise fall
+    # into that branch and be rejected. The RFC 1123 argument ("a connector name
+    # never contains `_`") is why the literal branch cannot steal a connector name
+    # -- it says nothing about the shorthand branch, which shares the connector's
+    # exact prefix shape and is handled by the arm-both rule above.
+    if connector is not None:
+        return frozenset({name})
     # The plugin form needs the bundle name to construct the prefix to verify
     # against; without it nothing can be verified, so fail closed.
     if not bundle_name:
@@ -340,7 +360,7 @@ def effective_operator_gate(
         matched = _longest_matching_server(
             name, servers, lambda s: effective_tool_prefix(bundle_name, s)
         )
-        return name if matched is not None else None
+        return frozenset({name}) if matched is not None else None
     # An mcp__<server>__<tool> shorthand: <server> was resolved above by matching
     # against the declared servers rather than splitting at the first __ (a server
     # name may contain __), preferring the longest match; require a non-empty tool
@@ -348,4 +368,4 @@ def effective_operator_gate(
     if shorthand is None:
         return None
     tool = name[len(f"mcp__{shorthand}__") :]
-    return f"mcp__plugin_{bundle_name}_{shorthand}__{tool}"
+    return frozenset({f"mcp__plugin_{bundle_name}_{shorthand}__{tool}"})

--- a/packages/plugin-format/src/plugin_format/approval_policy.py
+++ b/packages/plugin-format/src/plugin_format/approval_policy.py
@@ -251,9 +251,29 @@ def effective_operator_gates(
     ``mcp__plugin_<bundle>_<server>__<tool>``. An operator who writes the natural
     shorthand ``mcp__<server>__<tool>`` in ``CURIE_APPROVAL_REQUIRED_TOOLS`` must
     have it rewritten to that effective form, or the gate arms a literal that the
-    runtime name never matches (a silent fail-open). Returns a NON-EMPTY
-    ``frozenset`` of the live names to arm, or ``None`` for "cannot verify":
+    runtime name never matches (a silent fail-open).
 
+    Every naming rule below CONTRIBUTES to one union; none of them returns on its own
+    match. That shape is the whole point of this function, and an early return is the
+    defect it keeps having: the rules all read the same ``mcp__<...>__<tool>`` shape,
+    so one gate name routinely satisfies several of them, and NOTHING in the inputs
+    says which server actually hosts the tool. Returning on the first rule that
+    matches therefore picks a reading by branch ORDERING, and ``build_can_use_tool``
+    matches by exact string equality, so every live name the ordering did not pick
+    gates nothing at all, silently (#1495, #1564). Arming an extra name costs at most
+    one approval card for a tool nobody calls; missing one is a total fail-open. Do
+    not reintroduce an early return here.
+
+    Returns the NON-EMPTY ``frozenset`` of live names to arm -- the union of:
+
+    - ``{name}`` for a built-in with no ``mcp__`` prefix, armed by raw name and never
+      server-checked. The one rule that short-circuits, because a name without the
+      ``mcp__`` prefix can satisfy no other rule;
+    - ``{name}`` when ``name`` is ``mcp__<connector>__<tool>`` naming a connector the
+      bundle declares in ``connectors.yaml`` (#1495). A connector rides the SDK's
+      ``mcp_servers`` map directly, so that shorthand IS already the live runtime
+      name: it is verified against the declared connectors and armed unchanged, never
+      rewritten to the plugin form the runtime never produces;
     - ``{rewritten}`` when ``name`` is ``mcp__<server>__<tool>`` and ``<server>`` is
       a declared bundle server. ``<server>`` is resolved by MATCHING the shorthand
       against the declared servers (a server name may itself contain ``__``, so
@@ -261,41 +281,44 @@ def effective_operator_gates(
       ``foo``); the longest matching server name wins when one is a prefix of
       another. The effective prefix is built exactly as ``validate.py`` constructs
       ``expected_prefixes``;
-    - ``{name}`` for an ``mcp__<connector>__<tool>`` naming a connector the bundle
-      declares in ``connectors.yaml`` (#1495). A connector rides the SDK's
-      ``mcp_servers`` map directly, so that shorthand IS already the live runtime
-      name: it is verified against the declared connectors and returned unchanged,
-      never rewritten to the plugin form the runtime never produces;
-    - ``{name, rewritten}`` -- BOTH live forms -- when ``name`` matches a declared
-      connector AND a declared MCP server of a DIFFERENT name (#1564). The two rules
-      test the SAME ``mcp__<server>__`` prefix shape, so one gate name can match
-      both sets, and NOTHING in the inputs says which server actually hosts the
-      tool. Arming both is fail-CLOSED (at worst one extra approval card for a tool
-      nobody calls); arming one is a coin flip that fails OPEN half the time;
-    - ``{name}`` for a built-in with no ``mcp__`` prefix (armed by raw name), OR for
-      an already ``mcp__plugin_``-prefixed name that MATCHES an expected prefix
-      ``mcp__plugin_<bundle>_<server>__`` for a declared server (with a non-empty
-      tool remainder), mirroring ``validate.py``'s ``expected_prefixes`` check -- an
-      already-prefixed name is NOT trusted blindly (a typo'd
+    - ``{name}`` when ``name`` is already ``mcp__plugin_``-prefixed AND matches an
+      expected prefix ``mcp__plugin_<bundle>_<server>__`` for a declared server (with
+      a non-empty tool remainder), mirroring ``validate.py``'s ``expected_prefixes``
+      check -- an already-prefixed name is NOT trusted blindly (a typo'd
       ``mcp__plugin_wrongbundle_wrongserver__tool`` would arm a literal the runtime
-      never matches, a fail-open);
-    - ``None`` when ``name`` is ``mcp__``-shaped and cannot be verified against a
-      declared server or connector: an undeclared server, no declared servers,
-      ``servers`` or ``connector_servers`` being ``None`` (unknowable), a falsy
-      ``bundle_name`` (cannot construct the plugin prefix to verify or to build),
-      an empty tool remainder, an already-prefixed name matching no expected prefix,
-      or a name matching a connector and a declared MCP server of the SAME name
-      (#1564) -- that is an invalid CONFIGURATION, not an unknowable one, and it
-      must keep failing loudly. The operator override is never deploy-validated, so
-      this runtime check is its sole defense -- "cannot verify" fails CLOSED, not
-      through. The caller fails closed on ``None``.
+      never matches, a fail-open).
+
+    The last two rules can BOTH read one name, which is why the prefixed rule joins
+    the union instead of returning: ``mcp__plugin_b_github__update_issue`` is the live
+    form for server ``github`` AND the shorthand for a server named
+    ``plugin_b_github`` (live form ``mcp__plugin_b_plugin_b_github__update_issue``),
+    so both are armed (#1564). Likewise the connector and shorthand rules, for a
+    connector and an MCP server of DIFFERENT names.
+
+    Returns ``None`` -- "cannot verify", which the caller turns into a loud
+    fail-closed boot error (#520) -- when the union comes out empty, or when the
+    inputs are refused outright:
+
+    - ``servers`` or ``connector_servers`` is ``None`` (an unreadable MCP or
+      connectors declaration), so no ``mcp__``-shaped name is verifiable;
+    - ``name`` matches a declared connector AND a declared MCP server of the SAME
+      name (#1564): an invalid CONFIGURATION, not an unknowable one, which must keep
+      failing loudly rather than arming a union;
+    - that same double match with a falsy ``bundle_name``: the plugin half cannot be
+      constructed, and arming the connector half alone would re-create the shadow;
+    - an ``mcp__``-shaped name no rule verifies: an undeclared server, no declared
+      servers, an empty tool remainder, a falsy ``bundle_name`` on a name only the
+      plugin rules could read, or an already-prefixed name matching no expected
+      prefix. The operator override is never deploy-validated, so this runtime check
+      is its sole defense -- "cannot verify" fails CLOSED, not through.
 
     An empty ``frozenset`` is never returned: it would read as "armed nothing",
     which is the fail-open shape this helper exists to prevent. Refusal is ``None``.
     """
 
     # A built-in tool (Bash, Write, ...) carries no mcp__ prefix: armed by raw
-    # name, never rewritten and never server-checked.
+    # name, never rewritten and never server-checked. No rule in the union below can
+    # read such a name, so there is nothing to union it with.
     if not name.startswith("mcp__"):
         return frozenset({name})
     # Every mcp__-shaped name is verified against the declared-server sets. Without
@@ -308,8 +331,8 @@ def effective_operator_gates(
     # plugin server's mcp__<server>__<tool> shorthand must be REWRITTEN to
     # mcp__plugin_<bundle>_<server>__<tool>. Both rules test the SAME
     # mcp__<server>__ prefix shape (connector_tool_prefix vs the shorthand template
-    # below), so ONE name can match both sets -- with connector `git` and MCP server
-    # `git__hub` both declared, mcp__git__hub__create_pr matches each.
+    # below), so ONE name can match both sets -- with connector `deploy` and MCP
+    # server `deploy__prod` both declared, mcp__deploy__prod__apply matches each.
     connector = _longest_matching_server(name, connector_servers, connector_tool_prefix)
     shorthand = _longest_matching_server(name, servers, lambda s: f"mcp__{s}__")
     if connector is not None and shorthand is not None:
@@ -322,50 +345,53 @@ def effective_operator_gates(
         # what this defends.
         if len(connector) == len(shorthand):
             return None
-        # Two DIFFERENT servers each match this one gate name, and which one the
-        # operator meant is unknowable from the inputs. Do NOT arbitrate on the
-        # length of the matched server name: a name's length says nothing about
-        # which server actually hosts the tool. With connector `deploy` exposing a
-        # tool `prod__apply` and an MCP server `deploy__prod` declared,
-        # mcp__deploy__prod__apply is ALREADY live for the connector while the
-        # longer server name would rewrite it into a literal the SDK never emits.
-        # Picking either side by length just inverts which one gets shadowed, and
-        # build_can_use_tool matches by exact string equality, so the shadowed side
-        # gates nothing at all, silently. Arm BOTH live forms instead: gate.required
-        # is a frozenset, so over-arming costs at most one approval card for a tool
-        # nobody calls, while under-arming is a total fail-open (#1564).
+        # Two DIFFERENT servers each match this one gate name. The plugin half of
+        # the pair cannot be constructed without a bundle name, and arming the
+        # connector half alone would re-create the very shadow the union closes, so
+        # refuse outright rather than arm a partial union.
         if not bundle_name:
-            # The plugin half cannot be constructed, so arming both is impossible;
-            # arming only the connector half would re-create the shadow. Refuse.
             return None
-        tool = name[len(f"mcp__{shorthand}__") :]
-        return frozenset({name, f"mcp__plugin_{bundle_name}_{shorthand}__{tool}"})
-    # The connector is the ONLY match: return the name unchanged (#1495). Resolved
-    # BEFORE the already-prefixed literal branch below, because a connector may
-    # legally be named `plugin` and its mcp__plugin__<tool> would otherwise fall
-    # into that branch and be rejected. The RFC 1123 argument ("a connector name
-    # never contains `_`") is why the literal branch cannot steal a connector name
-    # -- it says nothing about the shorthand branch, which shares the connector's
-    # exact prefix shape and is handled by the arm-both rule above.
+
+    # THE union. Every rule below ADDS the live name it would arm and none of them
+    # returns, because a single gate name can legitimately be read by several of
+    # them and nothing here says which server hosts the tool. Do NOT convert any of
+    # these into an early return: build_can_use_tool matches by exact string
+    # equality, so a live form the union omits gates nothing at all, silently, while
+    # an extra one costs at most one approval card for a tool nobody calls (#1564).
+    # A set dedupes when two readings land on the same literal, so the readings need
+    # no special-casing when they agree.
+    resolved: set[str] = set()
+    # A connectors.yaml server is mounted straight onto the SDK's mcp_servers map
+    # (ADR-0086), so its shorthand IS already the live name: armed unchanged, never
+    # rewritten (#1495). This rule needs no bundle name, which is why a
+    # connectors-only bundle without one still arms its gates.
     if connector is not None:
-        return frozenset({name})
-    # The plugin form needs the bundle name to construct the prefix to verify
-    # against; without it nothing can be verified, so fail closed.
-    if not bundle_name:
+        resolved.add(name)
+    if bundle_name:
+        # An mcp__<server>__<tool> shorthand for a declared plugin server: <server>
+        # was resolved above by matching against the declared servers rather than
+        # splitting at the first __ (a server name may contain __), preferring the
+        # longest match, with a non-empty tool remainder required.
+        if shorthand is not None:
+            tool = name[len(f"mcp__{shorthand}__") :]
+            resolved.add(f"mcp__plugin_{bundle_name}_{shorthand}__{tool}")
+        # Already the effective plugin-namespaced form: verify it matches an
+        # expected prefix mcp__plugin_<bundle>_<server>__ for a declared server
+        # (non-empty tool remainder), exactly as validate.py asserts. NOT trusted
+        # verbatim -- a typo'd mcp__plugin_wrongbundle_wrongserver__tool would arm a
+        # literal the runtime never emits. A connector may legally be named `plugin`
+        # (RFC 1123 forbids `_` in a connector name, so the reverse cannot happen),
+        # and its mcp__plugin__<tool> lands here too: it adds nothing when no
+        # expected prefix matches, and the connector rule above already armed it.
+        if name.startswith("mcp__plugin_"):
+            bundle = bundle_name
+            matched = _longest_matching_server(
+                name, servers, lambda s: effective_tool_prefix(bundle, s)
+            )
+            if matched is not None:
+                resolved.add(name)
+    # An empty union means no rule verified this name: fail CLOSED with None rather
+    # than return an empty frozenset, which would read as "armed nothing".
+    if not resolved:
         return None
-    # Already the effective plugin-namespaced form: verify it matches an expected
-    # prefix mcp__plugin_<bundle>_<server>__ for a declared server (with a non-empty
-    # tool remainder), exactly as validate.py asserts. Do NOT trust it verbatim.
-    if name.startswith("mcp__plugin_"):
-        matched = _longest_matching_server(
-            name, servers, lambda s: effective_tool_prefix(bundle_name, s)
-        )
-        return frozenset({name}) if matched is not None else None
-    # An mcp__<server>__<tool> shorthand: <server> was resolved above by matching
-    # against the declared servers rather than splitting at the first __ (a server
-    # name may contain __), preferring the longest match; require a non-empty tool
-    # remainder.
-    if shorthand is None:
-        return None
-    tool = name[len(f"mcp__{shorthand}__") :]
-    return frozenset({f"mcp__plugin_{bundle_name}_{shorthand}__{tool}"})
+    return frozenset(resolved)

--- a/packages/plugin-format/src/plugin_format/approval_policy.py
+++ b/packages/plugin-format/src/plugin_format/approval_policy.py
@@ -264,7 +264,11 @@ def effective_operator_gate(
       bundle declares in ``connectors.yaml`` (#1495). A connector rides the SDK's
       ``mcp_servers`` map directly, so that shorthand IS already the live runtime
       name: it is verified against the declared connectors and returned unchanged,
-      never rewritten to the plugin form the runtime never produces;
+      never rewritten to the plugin form the runtime never produces. Both the
+      connector rule and the plugin-shorthand rule test the SAME ``mcp__<server>__``
+      prefix shape, so ONE name can match both sets; the two candidates compete on
+      SPECIFICITY (the longest matched server name wins) rather than on which check
+      runs first (#1564);
     - ``name`` verbatim only for a built-in with no ``mcp__`` prefix (armed by raw
       name), OR for an already ``mcp__plugin_``-prefixed name that MATCHES an
       expected prefix ``mcp__plugin_<bundle>_<server>__`` for a declared server
@@ -276,8 +280,11 @@ def effective_operator_gate(
       declared server or connector: an undeclared server, no declared servers,
       ``servers`` or ``connector_servers`` being ``None`` (unknowable), a falsy
       ``bundle_name`` (cannot construct the plugin prefix to verify), an empty tool
-      remainder, or an already-prefixed name matching no expected
-      prefix. The operator override is never deploy-validated, so this runtime
+      remainder, an already-prefixed name matching no expected
+      prefix, or an AMBIGUOUS name matching a connector and a declared MCP server at
+      EQUAL specificity (#1564) -- the two live forms differ and there is no
+      principled winner, so refuse rather than pick one silently. The operator
+      override is never deploy-validated, so this runtime
       check is its sole defense -- "cannot verify" fails CLOSED, not through. The
       caller fails closed on ``None``.
     """
@@ -292,12 +299,35 @@ def effective_operator_gate(
     if servers is None or connector_servers is None:
         return None
     # A connectors.yaml server is mounted straight onto the SDK's mcp_servers map
-    # (ADR-0086), so mcp__<connector>__<tool> is ALREADY the live runtime name.
-    # Checked BEFORE the plugin branch: a connector may legally be named `plugin`,
-    # and its mcp__plugin__<tool> would otherwise fall into the plugin branch and be
-    # rejected. The reverse cannot happen -- a connector name is an RFC 1123 label,
-    # so it never contains the `_` that mcp__plugin_<bundle>_<server>__ requires.
-    if _longest_matching_server(name, connector_servers, connector_tool_prefix) is not None:
+    # (ADR-0086), so mcp__<connector>__<tool> is ALREADY the live runtime name; a
+    # plugin server's mcp__<server>__<tool> shorthand must be REWRITTEN to
+    # mcp__plugin_<bundle>_<server>__<tool>. Both rules test the SAME
+    # mcp__<server>__ prefix shape (connector_tool_prefix vs the shorthand template
+    # below), so ONE name can match both sets -- with connector `git` and MCP server
+    # `git__hub` both declared, mcp__git__hub__create_pr matches each. Compute BOTH
+    # candidates and arbitrate on SPECIFICITY: the longest matched server name wins,
+    # exactly as _longest_matching_server arbitrates WITHIN one set. Deciding by
+    # which check runs first would let the connector shadow the plugin server and
+    # arm the un-rewritten literal, which the runtime never produces -- the #453
+    # fail-open, in reverse (#1564).
+    connector = _longest_matching_server(name, connector_servers, connector_tool_prefix)
+    shorthand = _longest_matching_server(name, servers, lambda s: f"mcp__{s}__")
+    # Equal specificity means the connector and the MCP server carry the SAME name
+    # (equal-length prefixes of one name under one template are the same string),
+    # and their live forms differ. There is no principled winner, so refuse rather
+    # than pick one silently: the caller turns None into a loud boot error (#520).
+    # validate._reject_connector_name_collisions already rejects this at deploy, but
+    # the operator env knob is never deploy-validated, which is what this defends.
+    if connector is not None and shorthand is not None and len(connector) == len(shorthand):
+        return None
+    # The connector won on specificity (or is the only match): return the name
+    # unchanged (#1495). Resolved BEFORE the already-prefixed literal branch below,
+    # because a connector may legally be named `plugin` and its mcp__plugin__<tool>
+    # would otherwise fall into that branch and be rejected. The RFC 1123 argument
+    # ("a connector name never contains `_`") is why the literal branch cannot steal
+    # a connector name -- it says nothing about the shorthand branch, which shares
+    # the connector's exact prefix shape and needs the contest above.
+    if connector is not None and (shorthand is None or len(connector) > len(shorthand)):
         return name
     # The plugin form needs the bundle name to construct the prefix to verify
     # against; without it nothing can be verified, so fail closed.
@@ -311,12 +341,11 @@ def effective_operator_gate(
             name, servers, lambda s: effective_tool_prefix(bundle_name, s)
         )
         return name if matched is not None else None
-    # An mcp__<server>__<tool> shorthand: resolve <server> by matching against the
-    # declared servers rather than splitting at the first __ (a server name may
-    # contain __). Prefer the longest match to disambiguate when one server name is
-    # a prefix of another; require a non-empty tool remainder.
-    best_server = _longest_matching_server(name, servers, lambda s: f"mcp__{s}__")
-    if best_server is None:
+    # An mcp__<server>__<tool> shorthand: <server> was resolved above by matching
+    # against the declared servers rather than splitting at the first __ (a server
+    # name may contain __), preferring the longest match; require a non-empty tool
+    # remainder.
+    if shorthand is None:
         return None
-    tool = name[len(f"mcp__{best_server}__") :]
-    return f"mcp__plugin_{bundle_name}_{best_server}__{tool}"
+    tool = name[len(f"mcp__{shorthand}__") :]
+    return f"mcp__plugin_{bundle_name}_{shorthand}__{tool}"

--- a/packages/plugin-format/tests/test_effective_operator_gate.py
+++ b/packages/plugin-format/tests/test_effective_operator_gate.py
@@ -300,18 +300,6 @@ def test_connector_and_longer_plugin_server_both_armed() -> None:
     ) == frozenset({"mcp__git__hub__create_pr", "mcp__plugin_b_git__hub__create_pr"})
 
 
-def test_connector_and_shorter_plugin_server_both_armed() -> None:
-    # The mirror image, so the rule is proven symmetric rather than a hardcoded
-    # "plugins win" or "connectors win": connector `git__hub` and MCP server `git`
-    # both match, and both live forms are armed. Before #1564's follow-up this
-    # returned the connector's bare name alone, on the theory that the longer
-    # matched server name was the more specific match -- but a server name's length
-    # carries no information about which server hosts the tool.
-    assert effective_operator_gates(
-        "b", {"git"}, "mcp__git__hub__create_pr", connector_servers={"git__hub"}
-    ) == frozenset({"mcp__git__hub__create_pr", "mcp__plugin_b_git__hub__create_pr"})
-
-
 def test_connector_tool_containing_double_underscore_stays_armed() -> None:
     # The regression the length tiebreak produced: connector `deploy` exposes a tool
     # named `prod__apply`, so mcp__deploy__prod__apply is ALREADY the live name --
@@ -361,6 +349,55 @@ def test_ambiguous_match_refuses_even_when_bundle_name_is_falsy() -> None:
     # The tie must not be reachable-around by an empty bundle name: refusing has to
     # happen before the connector-verbatim path, not only after it.
     assert effective_operator_gates("", {"git"}, "mcp__git__x", connector_servers={"git"}) is None
+
+
+# --- the already-prefixed reading is a UNION member, not a winner (#1564) --------
+#
+# mcp__plugin_-prefixed names have TWO readings whenever a declared server name
+# itself starts with `plugin_`: the already-effective live form, and the
+# mcp__<server>__<tool> shorthand for that server. Returning on whichever branch
+# ran first picked one by ordering, exactly the defect the connector/shorthand pair
+# above exists to close.
+
+
+def test_already_prefixed_name_also_armed_as_shorthand_for_plugin_named_server() -> None:
+    # The fail-OPEN half. mcp__plugin_b_github__update_issue is the live form for
+    # server `github` AND the shorthand for a server literally named
+    # `plugin_b_github`, whose live form is mcp__plugin_b_plugin_b_github__update_issue.
+    # Arming only the first left the second ungated: build_can_use_tool compares by
+    # exact string equality, so if `plugin_b_github` is the server that hosts
+    # update_issue, the call ran with no approval at all.
+    assert effective_operator_gates(
+        "b",
+        {"github", "plugin_b_github"},
+        "mcp__plugin_b_github__update_issue",
+        connector_servers=set(),
+    ) == frozenset(
+        {"mcp__plugin_b_github__update_issue", "mcp__plugin_b_plugin_b_github__update_issue"}
+    )
+
+
+def test_already_prefixed_shape_resolves_as_shorthand_when_only_that_reading_verifies() -> None:
+    # The fail-CLOSED half of the same early return. mcp__plugin_x__do LOOKS already
+    # prefixed but verifies against no expected prefix; it IS a valid shorthand for
+    # declared server `plugin_x`. The early return refused the whole name, so a
+    # legitimate gate refused to boot. The union resolves it to the one live form.
+    assert effective_operator_gates(
+        "b", {"plugin_x"}, "mcp__plugin_x__do", connector_servers=set()
+    ) == frozenset({"mcp__plugin_b_plugin_x__do"})
+
+
+def test_already_prefixed_name_matching_no_reading_still_fails_closed() -> None:
+    # The union must not become arm-anything: a mcp__plugin_-prefixed name that
+    # verifies against NOTHING -- no expected prefix, no shorthand server, no
+    # connector -- keeps failing CLOSED, same input shape as
+    # test_already_prefixed_name_for_undeclared_prefix_fails_closed.
+    assert (
+        effective_operator_gates(
+            "b", {"github"}, "mcp__plugin_wrongbundle_wrongserver__tool", connector_servers=set()
+        )
+        is None
+    )
 
 
 # --- connector_server_names: read connectors.yaml, poison to None ----------------

--- a/packages/plugin-format/tests/test_effective_operator_gate.py
+++ b/packages/plugin-format/tests/test_effective_operator_gate.py
@@ -277,6 +277,67 @@ def test_connector_named_plugin_is_matched_before_the_plugin_branch() -> None:
     )
 
 
+# --- a connector and a plugin server can match the SAME name (#1564) -------------
+#
+# Both rules build the byte-identical prefix shape mcp__<server>__, so ONE gate
+# name can match a declared connector AND a declared MCP server. Deciding by which
+# check runs first lets the connector shadow the plugin server and arm the
+# un-rewritten literal the runtime never produces. The two candidates must compete
+# on SPECIFICITY, and an equal-specificity tie must refuse.
+
+
+def test_connector_does_not_shadow_a_longer_matching_plugin_server() -> None:
+    # The #1564 defect: connector `git` and MCP server `git__hub` both match
+    # mcp__git__hub__create_pr. The MCP server is the LONGER, more specific match,
+    # so the name must be rewritten to the live plugin form. Returning it verbatim
+    # arms a literal the SDK never emits -- a total fail-open on the gate.
+    assert (
+        effective_operator_gate(
+            "b", {"git__hub"}, "mcp__git__hub__create_pr", connector_servers={"git"}
+        )
+        == "mcp__plugin_b_git__hub__create_pr"
+    )
+
+
+def test_connector_wins_when_it_is_the_more_specific_match() -> None:
+    # The mirror image, so the contest is proven symmetric rather than a hardcoded
+    # "plugins win": connector `git__hub` is the longer match against MCP server
+    # `git`, so the connector's live bare name is returned verbatim (#1495).
+    assert (
+        effective_operator_gate(
+            "b", {"git"}, "mcp__git__hub__create_pr", connector_servers={"git__hub"}
+        )
+        == "mcp__git__hub__create_pr"
+    )
+
+
+def test_equal_length_connector_and_server_match_is_ambiguous_and_refuses() -> None:
+    # Equal specificity means the connector and the MCP server carry the SAME name,
+    # and their live forms differ (bare vs plugin-prefixed). There is no principled
+    # winner, so refuse rather than pick one silently -- the caller turns None into
+    # a loud boot error (#520 fail-closed).
+    assert (
+        effective_operator_gate("b", {"git"}, "mcp__git__create_pr", connector_servers={"git"})
+        is None
+    )
+
+
+def test_connector_still_wins_verbatim_when_bundle_name_is_falsy() -> None:
+    # Regression pin for #1495: a connectors-only bundle with no bundle name still
+    # arms the connector gate verbatim, so the connector match must keep resolving
+    # BEFORE the `if not bundle_name` guard. This ordering is load-bearing.
+    assert (
+        effective_operator_gate("", set(), "mcp__grafana__query", connector_servers={"grafana"})
+        == "mcp__grafana__query"
+    )
+
+
+def test_ambiguous_match_refuses_even_when_bundle_name_is_falsy() -> None:
+    # The tie must not be reachable-around by an empty bundle name: refusing has to
+    # happen before the connector-verbatim path, not only after it.
+    assert effective_operator_gate("", {"git"}, "mcp__git__x", connector_servers={"git"}) is None
+
+
 # --- connector_server_names: read connectors.yaml, poison to None ----------------
 
 

--- a/packages/plugin-format/tests/test_effective_operator_gate.py
+++ b/packages/plugin-format/tests/test_effective_operator_gate.py
@@ -1,14 +1,15 @@
 """Unit table for the shared operator-gate normalization helpers (#703).
 
-``effective_operator_gate(bundle_name, servers, name, connector_servers=...)`` maps
+``effective_operator_gates(bundle_name, servers, name, connector_servers=...)`` maps
 an operator-supplied
-``CURIE_APPROVAL_REQUIRED_TOOLS`` name to the effective runtime tool name the SDK
-plugin-prefixes a bundle MCP tool to, returning the rewritten effective name, the
-name verbatim when it needs no rewrite (a built-in, an already-effective name, or a
-``connectors.yaml`` connector tool), or ``None`` when it is an unresolvable
-``mcp__`` shorthand (the caller fails
-closed). ``declared_mcp_server_names(root)`` reads the bundle's declared MCP server
-names (inline manifest ``mcpServers`` + root ``.mcp.json``) with the same
+``CURIE_APPROVAL_REQUIRED_TOOLS`` name to the NON-EMPTY frozenset of live runtime
+tool names it arms: the rewritten effective name the SDK plugin-prefixes a bundle
+MCP tool to, the name verbatim when it needs no rewrite (a built-in, an
+already-effective name, or a ``connectors.yaml`` connector tool), BOTH live forms
+when a connector and a declared MCP server of different names each match it
+(#1564), or ``None`` when it is an unresolvable ``mcp__`` shorthand (the caller
+fails closed). ``declared_mcp_server_names(root)`` reads the bundle's declared MCP
+server names (inline manifest ``mcpServers`` + root ``.mcp.json``) with the same
 poison-to-``None`` semantics as ``validate._validate_mcp``;
 ``connector_server_names(root)`` reads the ``connectors.yaml`` half with the same
 semantics (#1495).
@@ -27,39 +28,40 @@ import json
 from plugin_format import (
     connector_server_names,
     declared_mcp_server_names,
-    effective_operator_gate,
+    effective_operator_gates,
 )
 
-# --- effective_operator_gate: shorthand -> effective / verbatim / None -----------
+# --- effective_operator_gates: shorthand -> effective / verbatim / None ----------
 
 
 def test_shorthand_for_declared_server_maps_to_effective_name() -> None:
-    assert (
-        effective_operator_gate(
-            "b", {"github"}, "mcp__github__update_issue", connector_servers=set()
-        )
-        == "mcp__plugin_b_github__update_issue"
-    )
+    assert effective_operator_gates(
+        "b", {"github"}, "mcp__github__update_issue", connector_servers=set()
+    ) == frozenset({"mcp__plugin_b_github__update_issue"})
 
 
 def test_builtin_name_passes_verbatim() -> None:
     # No mcp__ prefix -> a built-in, armed by raw name; never rewritten, even when
     # the bundle declares servers.
-    assert effective_operator_gate("b", {"github"}, "Bash", connector_servers=set()) == "Bash"
+    assert effective_operator_gates(
+        "b", {"github"}, "Bash", connector_servers=set()
+    ) == frozenset({"Bash"})
 
 
 def test_already_effective_name_passes_verbatim() -> None:
     # Already mcp__plugin_-prefixed -> passed through unchanged (the suffix is
     # unknowable without running the server, mirroring validate.py).
     name = "mcp__plugin_b_github__update_issue"
-    assert effective_operator_gate("b", {"github"}, name, connector_servers=set()) == name
+    assert effective_operator_gates(
+        "b", {"github"}, name, connector_servers=set()
+    ) == frozenset({name})
 
 
 def test_shorthand_for_undeclared_server_is_unresolvable() -> None:
     # mcp__-shaped, names a server the bundle does not declare, not already
     # mcp__plugin_-prefixed -> unresolvable; the caller fails closed.
     assert (
-        effective_operator_gate("b", {"github"}, "mcp__slack__post", connector_servers=set())
+        effective_operator_gates("b", {"github"}, "mcp__slack__post", connector_servers=set())
         is None
     )
 
@@ -70,10 +72,9 @@ def test_shorthand_for_server_name_containing_double_underscore() -> None:
     # declared server set, not by splitting at the FIRST "__" -- otherwise
     # mcp__foo__bar__do splits to server "foo" (undeclared) and fails a valid
     # bundle closed. The server is foo__bar, the tool is do.
-    assert (
-        effective_operator_gate("b", {"foo__bar"}, "mcp__foo__bar__do", connector_servers=set())
-        == "mcp__plugin_b_foo__bar__do"
-    )
+    assert effective_operator_gates(
+        "b", {"foo__bar"}, "mcp__foo__bar__do", connector_servers=set()
+    ) == frozenset({"mcp__plugin_b_foo__bar__do"})
 
 
 def test_shorthand_prefers_longest_matching_server_name() -> None:
@@ -81,12 +82,9 @@ def test_shorthand_prefers_longest_matching_server_name() -> None:
     # so the resolution is unambiguous: with both "foo" and "foo__bar" declared,
     # mcp__foo__bar__do resolves to server foo__bar (tool do), not foo (tool
     # bar__do).
-    assert (
-        effective_operator_gate(
-            "b", {"foo", "foo__bar"}, "mcp__foo__bar__do", connector_servers=set()
-        )
-        == "mcp__plugin_b_foo__bar__do"
-    )
+    assert effective_operator_gates(
+        "b", {"foo", "foo__bar"}, "mcp__foo__bar__do", connector_servers=set()
+    ) == frozenset({"mcp__plugin_b_foo__bar__do"})
 
 
 def test_already_prefixed_name_for_undeclared_prefix_fails_closed() -> None:
@@ -96,7 +94,7 @@ def test_already_prefixed_name_for_undeclared_prefix_fails_closed() -> None:
     # expected_prefixes check. A typo'd wrongbundle/wrongserver name arms a literal
     # the runtime never matches -> fail OPEN; this must fail CLOSED (None).
     assert (
-        effective_operator_gate(
+        effective_operator_gates(
             "b", {"github"}, "mcp__plugin_wrongbundle_wrongserver__tool", connector_servers=set()
         )
         is None
@@ -106,14 +104,16 @@ def test_already_prefixed_name_for_undeclared_prefix_fails_closed() -> None:
 def test_already_prefixed_name_with_empty_tool_suffix_fails_closed() -> None:
     # The bare expected prefix with no tool suffix arms nothing -> fail closed.
     assert (
-        effective_operator_gate("b", {"github"}, "mcp__plugin_b_github__", connector_servers=set())
+        effective_operator_gates(
+            "b", {"github"}, "mcp__plugin_b_github__", connector_servers=set()
+        )
         is None
     )
 
 
 def test_shorthand_with_no_declared_servers_is_unresolvable() -> None:
     assert (
-        effective_operator_gate("b", set(), "mcp__github__update_issue", connector_servers=set())
+        effective_operator_gates("b", set(), "mcp__github__update_issue", connector_servers=set())
         is None
     )
 
@@ -126,34 +126,38 @@ def test_poisoned_servers_fail_mcp_names_closed_but_pass_builtins_verbatim() -> 
     # override, so "cannot verify" must fail closed, not pass through. Only a
     # built-in (no mcp__ prefix, no server lookup) still passes verbatim.
     assert (
-        effective_operator_gate("b", None, "mcp__github__update_issue", connector_servers=set())
+        effective_operator_gates("b", None, "mcp__github__update_issue", connector_servers=set())
         is None
     )
     assert (
-        effective_operator_gate(
+        effective_operator_gates(
             "b", None, "mcp__plugin_b_github__update_issue", connector_servers=set()
         )
         is None
     )
-    assert effective_operator_gate("b", None, "Bash", connector_servers=set()) == "Bash"
+    assert effective_operator_gates("b", None, "Bash", connector_servers=set()) == frozenset(
+        {"Bash"}
+    )
 
 
 def test_falsy_bundle_name_fails_mcp_names_closed() -> None:
     # No bundle name means the effective prefix cannot be constructed to verify an
     # mcp__ name -> fail closed. Built-ins still pass verbatim.
     assert (
-        effective_operator_gate(
+        effective_operator_gates(
             "", {"github"}, "mcp__github__update_issue", connector_servers=set()
         )
         is None
     )
     assert (
-        effective_operator_gate(
+        effective_operator_gates(
             "", {"github"}, "mcp__plugin_b_github__update_issue", connector_servers=set()
         )
         is None
     )
-    assert effective_operator_gate("", {"github"}, "Bash", connector_servers=set()) == "Bash"
+    assert effective_operator_gates("", {"github"}, "Bash", connector_servers=set()) == frozenset(
+        {"Bash"}
+    )
 
 
 # --- declared_mcp_server_names: inline manifest + root .mcp.json, poison -> None --
@@ -220,36 +224,33 @@ def test_declared_names_poison_to_none_on_non_utf8_manifest(tmp_path) -> None:
 def test_connector_shorthand_passes_verbatim_not_plugin_prefixed() -> None:
     # The load-bearing case: already the live name, so it is returned UNCHANGED.
     name = "mcp__kubernetes-admin__resources_create_or_update"
-    assert effective_operator_gate("b", set(), name, connector_servers={"kubernetes-admin"}) == name
+    assert effective_operator_gates(
+        "b", set(), name, connector_servers={"kubernetes-admin"}
+    ) == frozenset({name})
 
 
 def test_connector_gate_is_not_rewritten_even_when_bundle_declares_mcp_servers() -> None:
     # A bundle with both surfaces must namespace each by its own rule: the plugin
     # server is rewritten, the connector is not.
-    assert (
-        effective_operator_gate(
-            "b", {"github"}, "mcp__github__update_issue", connector_servers={"grafana"}
-        )
-        == "mcp__plugin_b_github__update_issue"
-    )
-    assert (
-        effective_operator_gate(
-            "b", {"github"}, "mcp__grafana__query", connector_servers={"grafana"}
-        )
-        == "mcp__grafana__query"
-    )
+    assert effective_operator_gates(
+        "b", {"github"}, "mcp__github__update_issue", connector_servers={"grafana"}
+    ) == frozenset({"mcp__plugin_b_github__update_issue"})
+    assert effective_operator_gates(
+        "b", {"github"}, "mcp__grafana__query", connector_servers={"grafana"}
+    ) == frozenset({"mcp__grafana__query"})
 
 
 def test_undeclared_connector_still_fails_closed() -> None:
     assert (
-        effective_operator_gate("b", set(), "mcp__ghost__x", connector_servers={"grafana"}) is None
+        effective_operator_gates("b", set(), "mcp__ghost__x", connector_servers={"grafana"}) is None
     )
 
 
 def test_connector_shorthand_with_empty_tool_remainder_fails_closed() -> None:
     # The bare prefix arms nothing, exactly as for the plugin form.
     assert (
-        effective_operator_gate("b", set(), "mcp__grafana__", connector_servers={"grafana"}) is None
+        effective_operator_gates("b", set(), "mcp__grafana__", connector_servers={"grafana"})
+        is None
     )
 
 
@@ -259,65 +260,90 @@ def test_poisoned_connector_set_fails_mcp_names_closed() -> None:
     # even when it would have matched a declared plugin server. Built-ins still
     # pass verbatim.
     assert (
-        effective_operator_gate(
+        effective_operator_gates(
             "b", {"github"}, "mcp__github__update_issue", connector_servers=None
         )
         is None
     )
-    assert effective_operator_gate("b", {"github"}, "Bash", connector_servers=None) == "Bash"
+    assert effective_operator_gates("b", {"github"}, "Bash", connector_servers=None) == frozenset(
+        {"Bash"}
+    )
 
 
 def test_connector_named_plugin_is_matched_before_the_plugin_branch() -> None:
     # `plugin` is a legal RFC 1123 connector name, so mcp__plugin__<tool> is a
     # legitimate connector tool name. It must not fall into the mcp__plugin_
     # branch and be rejected.
-    assert (
-        effective_operator_gate("b", set(), "mcp__plugin__do", connector_servers={"plugin"})
-        == "mcp__plugin__do"
-    )
+    assert effective_operator_gates(
+        "b", set(), "mcp__plugin__do", connector_servers={"plugin"}
+    ) == frozenset({"mcp__plugin__do"})
 
 
 # --- a connector and a plugin server can match the SAME name (#1564) -------------
 #
 # Both rules build the byte-identical prefix shape mcp__<server>__, so ONE gate
-# name can match a declared connector AND a declared MCP server. Deciding by which
-# check runs first lets the connector shadow the plugin server and arm the
-# un-rewritten literal the runtime never produces. The two candidates must compete
-# on SPECIFICITY, and an equal-specificity tie must refuse.
+# name can match a declared connector AND a declared MCP server. Only one of the
+# two live tool names is real, and NOTHING in the inputs says which. Arming one of
+# them is a coin flip, and build_can_use_tool matches by exact string equality, so
+# losing the flip gates nothing at all, silently. Both live forms are armed; a
+# connector and an MCP server carrying the SAME name is a different thing -- an
+# invalid configuration -- and still refuses.
 
 
-def test_connector_does_not_shadow_a_longer_matching_plugin_server() -> None:
-    # The #1564 defect: connector `git` and MCP server `git__hub` both match
-    # mcp__git__hub__create_pr. The MCP server is the LONGER, more specific match,
-    # so the name must be rewritten to the live plugin form. Returning it verbatim
-    # arms a literal the SDK never emits -- a total fail-open on the gate.
+def test_connector_and_longer_plugin_server_both_armed() -> None:
+    # Connector `git` and MCP server `git__hub` both match mcp__git__hub__create_pr.
+    # Arming only the connector's bare form arms a literal the SDK never emits when
+    # the tool really lives on the plugin server -- a total fail-open on the gate.
+    # Both forms are armed, so whichever server hosts it, the live call is gated.
+    assert effective_operator_gates(
+        "b", {"git__hub"}, "mcp__git__hub__create_pr", connector_servers={"git"}
+    ) == frozenset({"mcp__git__hub__create_pr", "mcp__plugin_b_git__hub__create_pr"})
+
+
+def test_connector_and_shorter_plugin_server_both_armed() -> None:
+    # The mirror image, so the rule is proven symmetric rather than a hardcoded
+    # "plugins win" or "connectors win": connector `git__hub` and MCP server `git`
+    # both match, and both live forms are armed. Before #1564's follow-up this
+    # returned the connector's bare name alone, on the theory that the longer
+    # matched server name was the more specific match -- but a server name's length
+    # carries no information about which server hosts the tool.
+    assert effective_operator_gates(
+        "b", {"git"}, "mcp__git__hub__create_pr", connector_servers={"git__hub"}
+    ) == frozenset({"mcp__git__hub__create_pr", "mcp__plugin_b_git__hub__create_pr"})
+
+
+def test_connector_tool_containing_double_underscore_stays_armed() -> None:
+    # The regression the length tiebreak produced: connector `deploy` exposes a tool
+    # named `prod__apply`, so mcp__deploy__prod__apply is ALREADY the live name --
+    # and MCP server `deploy__prod` is merely the LONGER matched name. Picking the
+    # longer one rewrote this into mcp__plugin_acme-bot_deploy__prod__apply, a
+    # literal the SDK never emits, and the real connector call sailed through
+    # ungated. Length is not evidence of intent in either direction: it says which
+    # declared NAME is longer, never which server hosts the tool. Arm both.
+    assert effective_operator_gates(
+        "acme-bot", {"deploy__prod"}, "mcp__deploy__prod__apply", connector_servers={"deploy"}
+    ) == frozenset({"mcp__deploy__prod__apply", "mcp__plugin_acme-bot_deploy__prod__apply"})
+
+
+def test_double_match_with_falsy_bundle_name_refuses() -> None:
+    # Without a bundle name the plugin half of the pair cannot be constructed.
+    # Arming only the connector half would re-create the very shadow this rule
+    # exists to close, so refuse outright and let the caller fail closed.
     assert (
-        effective_operator_gate(
-            "b", {"git__hub"}, "mcp__git__hub__create_pr", connector_servers={"git"}
+        effective_operator_gates(
+            "", {"deploy__prod"}, "mcp__deploy__prod__apply", connector_servers={"deploy"}
         )
-        == "mcp__plugin_b_git__hub__create_pr"
-    )
-
-
-def test_connector_wins_when_it_is_the_more_specific_match() -> None:
-    # The mirror image, so the contest is proven symmetric rather than a hardcoded
-    # "plugins win": connector `git__hub` is the longer match against MCP server
-    # `git`, so the connector's live bare name is returned verbatim (#1495).
-    assert (
-        effective_operator_gate(
-            "b", {"git"}, "mcp__git__hub__create_pr", connector_servers={"git__hub"}
-        )
-        == "mcp__git__hub__create_pr"
+        is None
     )
 
 
 def test_equal_length_connector_and_server_match_is_ambiguous_and_refuses() -> None:
     # Equal specificity means the connector and the MCP server carry the SAME name,
-    # and their live forms differ (bare vs plugin-prefixed). There is no principled
-    # winner, so refuse rather than pick one silently -- the caller turns None into
-    # a loud boot error (#520 fail-closed).
+    # and their live forms differ (bare vs plugin-prefixed). That is an invalid
+    # CONFIGURATION, not an unknowable one -- refuse rather than paper over it: the
+    # caller turns None into a loud boot error (#520 fail-closed).
     assert (
-        effective_operator_gate("b", {"git"}, "mcp__git__create_pr", connector_servers={"git"})
+        effective_operator_gates("b", {"git"}, "mcp__git__create_pr", connector_servers={"git"})
         is None
     )
 
@@ -326,16 +352,15 @@ def test_connector_still_wins_verbatim_when_bundle_name_is_falsy() -> None:
     # Regression pin for #1495: a connectors-only bundle with no bundle name still
     # arms the connector gate verbatim, so the connector match must keep resolving
     # BEFORE the `if not bundle_name` guard. This ordering is load-bearing.
-    assert (
-        effective_operator_gate("", set(), "mcp__grafana__query", connector_servers={"grafana"})
-        == "mcp__grafana__query"
-    )
+    assert effective_operator_gates(
+        "", set(), "mcp__grafana__query", connector_servers={"grafana"}
+    ) == frozenset({"mcp__grafana__query"})
 
 
 def test_ambiguous_match_refuses_even_when_bundle_name_is_falsy() -> None:
     # The tie must not be reachable-around by an empty bundle name: refusing has to
     # happen before the connector-verbatim path, not only after it.
-    assert effective_operator_gate("", {"git"}, "mcp__git__x", connector_servers={"git"}) is None
+    assert effective_operator_gates("", {"git"}, "mcp__git__x", connector_servers={"git"}) is None
 
 
 # --- connector_server_names: read connectors.yaml, poison to None ----------------

--- a/runner/src/curie_runner/approval.py
+++ b/runner/src/curie_runner/approval.py
@@ -813,7 +813,10 @@ def build_approval_gate(
                 " mcp__plugin_<bundle>_<server>__<tool> name (or, for a"
                 " connectors.yaml connector, mcp__<connector>__<tool>), or check the"
                 f" bundle declares that server (declared MCP servers: {mcp_servers},"
-                f" declared connectors: {connector_servers})"
+                f" declared connectors: {connector_servers}). A gate is also refused"
+                " when it is ambiguous -- a declared connector name and a declared MCP"
+                " server name collide, so the gate resolves to two different live tool"
+                " names with no principled winner; rename one of them"
             )
         # A bare (non-mcp__) name is armed VERBATIM as a built-in tool name,
         # never rewritten or checked (#712): `effective_operator_gate` has no

--- a/runner/src/curie_runner/approval.py
+++ b/runner/src/curie_runner/approval.py
@@ -50,7 +50,7 @@ from plugin_format import (
     PluginManifest,
     connector_server_names,
     declared_mcp_server_names,
-    effective_operator_gate,
+    effective_operator_gates,
     grantable_routes,
     resolve_manifest,
 )
@@ -802,7 +802,7 @@ def build_approval_gate(
         name = raw_name.strip()
         if not name:
             continue
-        effective = effective_operator_gate(
+        effective = effective_operator_gates(
             bundle_name, mcp_servers, name, connector_servers=connector_servers
         )
         if effective is None:
@@ -819,7 +819,7 @@ def build_approval_gate(
                 " names with no principled winner; rename one of them"
             )
         # A bare (non-mcp__) name is armed VERBATIM as a built-in tool name,
-        # never rewritten or checked (#712): `effective_operator_gate` has no
+        # never rewritten or checked (#712): `effective_operator_gates` has no
         # way to tell a real built-in ("Bash") from an operator's mistaken bare
         # MCP tool name ("resolve_leak" meant as shorthand for an in-bundle MCP
         # tool). That second case silently arms a literal the SDK's
@@ -831,7 +831,7 @@ def build_approval_gate(
         # warn when the name isn't among the well-known Claude Code built-ins,
         # naming the mcp__<server>__<tool> form the operator likely meant.
         if (
-            effective == name
+            effective == frozenset({name})
             and not name.startswith("mcp__")
             and name not in _KNOWN_BUILTIN_TOOLS
         ):
@@ -845,7 +845,11 @@ def build_approval_gate(
                 mcp_servers,
                 name,
             )
-        normalized.append(effective)
+        # One gate name can resolve to MORE than one live tool name when a declared
+        # connector and a declared MCP server both match it and nothing says which
+        # hosts the tool (#1564). Arm every returned form: over-arming costs an
+        # extra approval card, under-arming is a silent fail-open.
+        normalized.extend(effective)
 
     operator = frozenset(normalized)
     redefined = sorted(operator & set(policy_routes))

--- a/runner/tests/test_approval.py
+++ b/runner/tests/test_approval.py
@@ -2403,9 +2403,10 @@ _GIT_CONNECTORS = "connectors:\n  git:\n    image: ghcr.io/example/git-mcp:1.0.0
 def test_connector_does_not_shadow_a_plugin_server_it_prefixes(tmp_path) -> None:
     """Connector `git` + plugin MCP server `git__hub`, gate mcp__git__hub__create_pr.
 
-    The MCP server is the more specific match, so the gate must arm the live
-    plugin-namespaced name and deny the real call. Arming the connector's bare
-    form instead arms a literal the SDK never emits.
+    Both declared servers match the one gate name and nothing says which hosts the
+    tool, so BOTH live forms are armed and either real call is denied. Arming only
+    the connector's bare form arms a literal the SDK never emits when the tool
+    lives on the plugin server.
     """
 
     root = _connector_bundle(tmp_path, json.dumps({"name": "acme-bot"}), _GIT_CONNECTORS)
@@ -2424,9 +2425,54 @@ def test_connector_does_not_shadow_a_plugin_server_it_prefixes(tmp_path) -> None
             connector_servers=resolution.connector_servers,
         )
         assert gate is not None
-        assert gate.required == frozenset({live})
+        assert gate.required == frozenset({live, "mcp__git__hub__create_pr"})
         result = await build_can_use_tool(gate)(live, {"title": "..."}, ToolPermissionContext())
         assert isinstance(result, PermissionResultDeny)
+
+    anyio.run(go)
+
+
+def test_connector_tool_with_double_underscore_is_denied_alongside_its_plugin_twin(
+    tmp_path,
+) -> None:
+    """The fail-open a length tiebreak leaves behind, driven end to end.
+
+    Connector `deploy` exposes a tool named `prod__apply`, so
+    mcp__deploy__prod__apply is ALREADY the live name -- and MCP server
+    `deploy__prod` is merely the LONGER matched name. Preferring the longer match
+    rewrote the gate into mcp__plugin_acme-bot_deploy__prod__apply, which the SDK
+    never emits for the connector, and build_can_use_tool's exact-string match let
+    the real connector call run unapproved with nothing logged. Neither name's
+    length says which server hosts the tool, so both live forms must be armed and
+    both calls must be denied.
+    """
+
+    root = _connector_bundle(
+        tmp_path,
+        json.dumps({"name": "acme-bot"}),
+        "connectors:\n  deploy:\n    image: ghcr.io/example/deploy-mcp:1.0.0\n",
+    )
+    (tmp_path / ".mcp.json").write_text(
+        json.dumps({"mcpServers": {"deploy__prod": {"command": "deploy-server"}}}),
+        encoding="utf-8",
+    )
+    connector_live = "mcp__deploy__prod__apply"
+    plugin_live = "mcp__plugin_acme-bot_deploy__prod__apply"
+
+    async def go() -> None:
+        resolution = resolve_approval_policy(root)
+        gate = build_approval_gate(
+            operator_tools=[connector_live],
+            policy_routes={},
+            bundle_name=resolution.bundle_name,
+            mcp_servers=resolution.mcp_servers,
+            connector_servers=resolution.connector_servers,
+        )
+        assert gate is not None
+        callback = build_can_use_tool(gate)
+        for live in (connector_live, plugin_live):
+            result = await callback(live, {"env": "prod"}, ToolPermissionContext())
+            assert isinstance(result, PermissionResultDeny), live
 
     anyio.run(go)
 

--- a/runner/tests/test_approval.py
+++ b/runner/tests/test_approval.py
@@ -2386,3 +2386,104 @@ def test_operator_gate_naming_an_undeclared_connector_still_fails_closed(tmp_pat
             mcp_servers=resolution.mcp_servers,
             connector_servers=resolution.connector_servers,
         )
+
+
+# --- a connector must not shadow a plugin server it prefixes (#1564) -------------
+#
+# A connectors.yaml connector and a plugin-loaded MCP server produce the SAME
+# mcp__<server>__ prefix shape, so one operator gate name can match both -- but
+# only one of the two live tool names is real. build_can_use_tool compares by
+# exact string equality, so arming the wrong one is a total fail-open: the SDK
+# hands over the live name, it is not in gate.required, and the call is ALLOWED
+# with no block recorded and nothing logged.
+
+_GIT_CONNECTORS = "connectors:\n  git:\n    image: ghcr.io/example/git-mcp:1.0.0\n"
+
+
+def test_connector_does_not_shadow_a_plugin_server_it_prefixes(tmp_path) -> None:
+    """Connector `git` + plugin MCP server `git__hub`, gate mcp__git__hub__create_pr.
+
+    The MCP server is the more specific match, so the gate must arm the live
+    plugin-namespaced name and deny the real call. Arming the connector's bare
+    form instead arms a literal the SDK never emits.
+    """
+
+    root = _connector_bundle(tmp_path, json.dumps({"name": "acme-bot"}), _GIT_CONNECTORS)
+    (tmp_path / ".mcp.json").write_text(
+        json.dumps({"mcpServers": {"git__hub": {"command": "gh-server"}}}), encoding="utf-8"
+    )
+    live = "mcp__plugin_acme-bot_git__hub__create_pr"
+
+    async def go() -> None:
+        resolution = resolve_approval_policy(root)
+        gate = build_approval_gate(
+            operator_tools=["mcp__git__hub__create_pr"],
+            policy_routes={},
+            bundle_name=resolution.bundle_name,
+            mcp_servers=resolution.mcp_servers,
+            connector_servers=resolution.connector_servers,
+        )
+        assert gate is not None
+        assert gate.required == frozenset({live})
+        result = await build_can_use_tool(gate)(live, {"title": "..."}, ToolPermissionContext())
+        assert isinstance(result, PermissionResultDeny)
+
+    anyio.run(go)
+
+
+def test_connector_gate_on_a_connector_tool_still_denies_alongside_a_prefixed_server(
+    tmp_path,
+) -> None:
+    """The #1495 property survives in the very bundle that triggers the contest.
+
+    Gate mcp__git__status names a genuine connector tool: no declared MCP server
+    matches it, so it stays the bare live name and the real call is denied.
+    """
+
+    root = _connector_bundle(tmp_path, json.dumps({"name": "acme-bot"}), _GIT_CONNECTORS)
+    (tmp_path / ".mcp.json").write_text(
+        json.dumps({"mcpServers": {"git__hub": {"command": "gh-server"}}}), encoding="utf-8"
+    )
+
+    async def go() -> None:
+        resolution = resolve_approval_policy(root)
+        gate = build_approval_gate(
+            operator_tools=["mcp__git__status"],
+            policy_routes={},
+            bundle_name=resolution.bundle_name,
+            mcp_servers=resolution.mcp_servers,
+            connector_servers=resolution.connector_servers,
+        )
+        assert gate is not None
+        assert gate.required == frozenset({"mcp__git__status"})
+        result = await build_can_use_tool(gate)(
+            "mcp__git__status", {"manifest": "..."}, ToolPermissionContext()
+        )
+        assert isinstance(result, PermissionResultDeny)
+
+    anyio.run(go)
+
+
+def test_ambiguous_connector_and_server_gate_refuses_to_boot(tmp_path) -> None:
+    """Connector `git` and MCP server `git` both match mcp__git__create_pr.
+
+    The two live forms differ and neither is more specific, so there is no
+    principled winner. validate_bundle rejects this bundle at deploy, but the
+    operator env knob is never deploy-validated -- the runtime must refuse on its
+    own, loudly and with a message that names the ambiguity rather than claiming
+    the gate resolved to nothing.
+    """
+
+    root = _connector_bundle(tmp_path, json.dumps({"name": "acme-bot"}), _GIT_CONNECTORS)
+    (tmp_path / ".mcp.json").write_text(
+        json.dumps({"mcpServers": {"git": {"command": "git-server"}}}), encoding="utf-8"
+    )
+    resolution = resolve_approval_policy(root)
+    with pytest.raises(ApprovalPolicyError, match="ambiguous"):
+        build_approval_gate(
+            operator_tools=["mcp__git__create_pr"],
+            policy_routes={},
+            bundle_name=resolution.bundle_name,
+            mcp_servers=resolution.mcp_servers,
+            connector_servers=resolution.connector_servers,
+        )


### PR DESCRIPTION
Closes #1564

## The fail-open

A `connectors.yaml` connector and a plugin-loaded MCP server produce live tool
names through different rules, but both rules test the byte-identical prefix
shape `mcp__<server>__`. `effective_operator_gate` checked the connector set
first and returned the operator's gate string verbatim on the first hit, so a
connector whose name is the leading `__`-delimited segment of an MCP server key
shadowed that server. With connector `git` and server `git__hub` declared, the
gate `mcp__git__hub__create_pr` armed a literal the SDK never emits.

`build_can_use_tool` matches by exact string equality, so the gate flipped from
`PermissionResultDeny` to `PermissionResultAllow` and the tool ran unapproved
with no block recorded and nothing logged. Introduced by #1547.

## The fix, and where it differs from the issue

The issue proposed picking the longer matching server name and refusing only on
an equal-length tie. Security review found that only inverts the shadow: a
name's length says nothing about which server hosts the tool. With connector
`deploy` exposing a tool named `prod__apply` and a server keyed `deploy__prod`,
the gate `mcp__deploy__prod__apply` was already the live connector name and the
tiebreak rewrote it into a plugin literal, allowing the real call. That case
resolved correctly on `main`, so the suggested fix would have regressed #1495
while fixing #1564.

Three naming rules can read one gate string: the connector's verbatim form, the
plugin shorthand rewrite, and an already-effective `mcp__plugin_` form. Nothing
in the inputs says which server hosts the tool, so the function now arms every
form that verifies instead of letting whichever rule sits earliest win.
`gate.required` is a frozenset and the union never subtracts, so over-arming
costs at most one approval card for a tool nobody calls, while under-arming
gates nothing at all.

`effective_operator_gate` becomes `effective_operator_gates`, returning
`frozenset[str] | None`. `None` keeps its exact meaning of "cannot verify", so
the caller still fails closed, and an empty set is never returned. It refuses
when nothing verifies, when a connector and an MCP server carry the identical
name (an invalid bundle the deploy validator already rejects, so it stays a loud
boot error rather than a silent double arm), and when a double match cannot
construct its plugin half for lack of a bundle name.

Cross-engine review then found the same defect surviving in the
already-`mcp__plugin_`-prefixed branch, which still returned on its own match:
`mcp__plugin_b_github__update_issue` with servers `{github, plugin_b_github}`
armed only the first reading, and `mcp__plugin_x__do` with server `plugin_x`
refused a legitimate gate outright. Both are folded into the same union.

The guard comment that justified the original ordering is corrected rather than
worked around. Its RFC 1123 argument holds for the already-prefixed branch and
never held for the shorthand branch, which is the one sharing the connector's
prefix shape.

## Deviation to be aware of when reviewing

AC1 asks that `effective_operator_gate` resolve to the plugin server's live
name. That name is now one member of a returned set rather than the sole return
value, and the singular helper no longer exists. The security outcome the AC
describes holds exactly: the plugin live name is armed and `can_use_tool` denies
it. Flagging the wording so the change is a deliberate decision on the record
rather than a surprise.

## Not fixed here

The deploy validator half. `_validate_approval_policy` accepts a manifest gate
matching either prefix form, and a manifest `approvalPolicy` gate is
deploy-validated and then never re-normalized at runtime, so the same shadow
applies to it. That path is worse than the one fixed here, since both halves are
under the bundle author's control and there is no runtime backstop. It is
outside this issue's acceptance criteria and changing the validator risks
rejecting bundles that validate today, so it wants its own issue.

## Verification

`uv run --python 3.13 pytest packages/plugin-format runner -q` passes, 847
passed and 4 skipped, against 834 passed and 4 skipped on `main`. Ruff, mypy,
`lint-imports`, and `scripts/check-docs.sh` are clean. Reverting the
implementation fails the new tests, checked by stashing the source and by
restoring the early return in isolation.

The load-bearing tests drive `resolve_approval_policy` to `build_approval_gate`
to `build_can_use_tool` against real bundle directories, not the naming
function, and assert `PermissionResultDeny` on the live tool names.