### PR TITLE
Resolve key-free object store credentials through the AWS provider chain

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,24 @@ VALKEY_PASSWORD=valkeypass
 # stops the API from booting.
 # SLACK_USERGROUP_CACHE_TTL_S=60
 
+# --- RustFS / S3 (dev stack) ---
+# The compose stack's RustFS wants a static key pair, but the code default is
+# now EMPTY, because an empty credential is what selects the AWS provider chain
+# (the key-free BYO object store path: IRSA, an instance role, an ambient
+# profile). So the dev key pair lives here rather than baked into the settings
+# classes.
+# Nothing loads this template. These two lines only take effect once it has been
+# copied to `.env`, which `curie install` does when it seeds the file. An `.env`
+# seeded before this change will not carry them, so a bare local API run needs
+# them added to that `.env`, or the two variables exported.
+# Only the API is affected either way: apps/api reads `.env` (its Settings
+# declares env_file=".env"), while a bare worker run reads no .env at all
+# (WorkerConfig declares no env file and run.py constructs it directly).
+# Under compose neither line matters, because compose.dev.yaml sets
+# S3_ACCESS_KEY / S3_SECRET_KEY explicitly for both curie-api and curie-worker.
+S3_ACCESS_KEY=rustfs
+S3_SECRET_KEY=rustfssecret
+
 # --- BEGIN generated boot env (aci_protocol.env_example_export) ---
 # The worker-to-runner boot contract (#488, ADR-0049). GENERATED from
 # aci_protocol.session.BootEnv -- do not hand-edit; regenerate with

--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -14,6 +14,19 @@ on:
     paths:
       - "charts/curie/**"
       - ".github/workflows/helm-ci.yaml"
+      # The object-store web-identity gate below EXECUTES these repository
+      # files, so a change to one of them can break the gate without touching
+      # any charts/ path. Without them in this filter, a PR that reverts the
+      # credential fix matches nothing here, the whole helm job is skipped, and
+      # the gate that exists to catch exactly that revert never runs. That is
+      # the difference between a gate and a gate-shaped thing.
+      - "packages/aci-protocol/src/aci_protocol/s3.py"
+      - "apps/api/src/curie_api/config.py"
+      - "apps/api/src/curie_api/storage.py"
+      - "apps/worker/src/curie_worker/config.py"
+      - "apps/worker/src/curie_worker/bundle_store.py"
+      - "uv.lock"
+      - "pyproject.toml"
 
 permissions:
   contents: read
@@ -258,6 +271,19 @@ jobs:
         run: |
           set -euo pipefail
           bash charts/curie/ci/worker-object-store-assertions.sh
+
+      # This otherwise Python-free chart job needs the workspace because the
+      # web-identity gate below does not stop at the rendered YAML: it builds
+      # the real API and worker BundleStore objects under each rendered
+      # workload's env and asks the constructed boto3 client which credential
+      # provider won. Reading the manifests alone cannot tell an omitted
+      # credential apart from one the SDK signs as an empty identity.
+      - name: Install uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        with:
+          python-version: "3.13"
+      - name: Sync workspace
+        run: uv sync
 
       # Prove the key-free object store path (#1325). Pointing the bundle store
       # at a real cloud object store used to REQUIRE static access keys: all

--- a/apps/api/src/curie_api/config.py
+++ b/apps/api/src/curie_api/config.py
@@ -1,8 +1,13 @@
 """Runtime configuration for the Curie API server.
 
 All values default to the compose dev stack (see compose.dev.yaml and
-.env.example) so a local run needs no .env. Override any field via the matching
-environment variable for shared or production deployments.
+.env.example) so a local run needs no .env, with one exception: the two S3
+credentials default to empty, because an empty credential is the signal that
+selects the AWS provider chain for the key-free BYO object store path (#1559).
+A local run against the compose RustFS therefore has to supply them, from .env
+or the environment; the dev values live in .env.example and compose.dev.yaml.
+Override any field via the matching environment variable for shared or
+production deployments.
 """
 
 from functools import lru_cache
@@ -54,9 +59,18 @@ class Settings(BaseSettings):
     langfuse_secret_key: str = "sk-lf-curie-dev"
 
     # RustFS / S3 for immutable plugin bundles (compose stack RustFS on 29000).
+    # The credentials default to EMPTY on purpose (#1559): an empty credential
+    # selects the AWS provider chain, which is the key-free BYO path the chart
+    # README documents under "Key-free object store auth" (IRSA, an instance
+    # role, an ambient profile). The dev static credential now lives in
+    # `.env.example` and `compose.dev.yaml`, which set S3_ACCESS_KEY /
+    # S3_SECRET_KEY explicitly for the compose stack's RustFS. Never reintroduce
+    # a non-empty value as a default here: a baked-in key is precisely what made
+    # the key-free path inert, because it is handed to boto3 as an explicit
+    # credential and the provider chain is never consulted.
     s3_endpoint_url: str = "http://localhost:29000"
-    s3_access_key: str = "rustfs"
-    s3_secret_key: str = "rustfssecret"
+    s3_access_key: str = ""
+    s3_secret_key: str = ""
     s3_region: str = "us-east-1"
     bundle_bucket: str = "curie-bundles"
     # Bundle ingestion bounds (ADR-0059 decision 3). Three independent caps:

--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -28,6 +28,17 @@ from sqlalchemy.engine import URL
 from sqlalchemy.ext.asyncio import create_async_engine
 from sqlalchemy.sql import text
 
+# The object-store credential the suite talks to compose's RustFS with. The code
+# default in `curie_api.config` is deliberately empty so that omitting these
+# variables selects the AWS provider chain instead (the key-free BYO object-store
+# path, #1559), which means the test environment has to name the dev credential
+# itself rather than leaning on a production default. Declaring it here also makes
+# the suite independent of whatever ambient AWS credentials the developer's machine
+# happens to carry, which previously decided the result. `setdefault`, so a
+# contributor pointing the suite at another store by exporting their own value wins.
+os.environ.setdefault("S3_ACCESS_KEY", "rustfs")
+os.environ.setdefault("S3_SECRET_KEY", "rustfssecret")
+
 API_DIR = Path(__file__).resolve().parents[1]
 ALEMBIC_DIR = API_DIR / "alembic"
 DB_PREFIX = "curie_test_"

--- a/apps/api/tests/test_credential_resolution.py
+++ b/apps/api/tests/test_credential_resolution.py
@@ -1,0 +1,65 @@
+"""The API's key-free BYO object-store path (#1559), end to end from env to signer.
+
+Documented behavior: leave ``S3_ACCESS_KEY``/``S3_SECRET_KEY`` unset and the API
+picks up ambient cloud credentials (IRSA, an instance role, an ambient profile).
+That only works if the config default is empty AND the empty value reaches boto3
+as ``None``, so this asserts the resolved signer rather than the config string:
+a config default of "" alone leaves the path just as inert.
+
+Asserted through the real ``BundleStore`` because that is what production
+constructs; a ``BundleStore`` that later grew its own credential handling would
+slip past a test of the bare builder. ``BundleStore.__init__`` only constructs a
+boto3 client and does no network I/O, and botocore's web-identity provider
+returns deferred credentials without calling STS, so this is fully offline.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+from curie_api.config import Settings
+from curie_api.storage import BundleStore
+
+
+@pytest.fixture
+def web_identity_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Only an IRSA-style web identity is available to the provider chain.
+
+    Every ``AWS_*``/``S3_*`` var is scrubbed first so an ambient developer
+    profile or a CI runner's own credentials cannot decide the result. The token
+    file's contents are never read (the provider defers the STS exchange), so a
+    placeholder is enough.
+    """
+    for name in list(os.environ):
+        if name.startswith(("AWS_", "S3_")):
+            monkeypatch.delenv(name, raising=False)
+    token_file = tmp_path / "token"
+    token_file.write_text("placeholder-web-identity-token")
+    monkeypatch.setenv("AWS_ROLE_ARN", "arn:aws:iam::000000000000:role/curie-bundles")
+    monkeypatch.setenv("AWS_WEB_IDENTITY_TOKEN_FILE", str(token_file))
+    monkeypatch.setenv("AWS_REGION", "us-east-1")
+    monkeypatch.setenv("S3_ENDPOINT_URL", "https://s3.example.com:443")
+
+
+def test_omitted_credential_env_reaches_web_identity(web_identity_env: None) -> None:
+    # _env_file=None is mandatory: Settings declares env_file=".env", so without
+    # it a stray developer .env in the checkout silently decides the result.
+    settings = Settings(_env_file=None)
+    store = BundleStore(settings)
+    credentials = store._client._request_signer._credentials
+    assert credentials.method == "assume-role-with-web-identity"
+
+
+def test_configured_credential_env_signs_explicitly(
+    web_identity_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The guard against "fixing" the chain by ignoring configured credentials: a
+    # RustFS/MinIO deployment supplies a static key pair via env and it must be
+    # the one that signs, even with an ambient web identity right next to it.
+    monkeypatch.setenv("S3_ACCESS_KEY", "static-ak")
+    monkeypatch.setenv("S3_SECRET_KEY", "static-sk")
+    settings = Settings(_env_file=None)
+    store = BundleStore(settings)
+    credentials = store._client._request_signer._credentials
+    assert credentials.method == "explicit"
+    assert credentials.access_key == "static-ak"

--- a/apps/worker/src/curie_worker/config.py
+++ b/apps/worker/src/curie_worker/config.py
@@ -408,9 +408,19 @@ class WorkerConfig(BaseSettings):
     )
     # RustFS / S3 for plugin bundles (mirrors the API's env names). The consumer
     # fetches a version's bundle by bundle_ref and loads its evals/ suite.
+    # The credentials default to EMPTY on purpose (#1559): an empty credential
+    # selects the AWS provider chain, which is the key-free BYO path the chart
+    # README documents under "Key-free object store auth" (IRSA, an instance
+    # role, an ambient profile). The dev static credential now lives in
+    # `.env.example` and `compose.dev.yaml`, which set S3_ACCESS_KEY /
+    # S3_SECRET_KEY explicitly for the compose stack's RustFS. Never reintroduce
+    # a non-empty value as a default here: a baked-in key is precisely what made
+    # the key-free path inert, because it is handed to boto3 as an explicit
+    # credential and the provider chain is never consulted. This block is a
+    # parity seam with the API's `Settings`, so the two must stay identical.
     s3_endpoint_url: str = "http://localhost:29000"
-    s3_access_key: str = "rustfs"
-    s3_secret_key: str = "rustfssecret"
+    s3_access_key: str = ""
+    s3_secret_key: str = ""
     s3_region: str = "us-east-1"
     bundle_bucket: str = "curie-bundles"
     # Bundle extraction bounds (ADR-0059 decision 3), applied by the Docker

--- a/apps/worker/tests/test_config.py
+++ b/apps/worker/tests/test_config.py
@@ -240,8 +240,13 @@ def test_defaults_parity_with_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
     assert config.eval_consumer_group == "curie-eval-workers"
     # RustFS / S3
     assert config.s3_endpoint_url == "http://localhost:29000"
-    assert config.s3_access_key == "rustfs"
-    assert config.s3_secret_key == "rustfssecret"
+    # Empty by default (#1559): a baked-in dev key is still an explicit credential
+    # to boto3, so it shadows the ambient cloud identity (IRSA, instance role) the
+    # key-free BYO object-store path relies on. Do not restore the RustFS dev pair
+    # here; compose supplies it via env, and the S3_ACCESS_KEY/S3_SECRET_KEY
+    # override entries above stay the guard that an operator value still wins.
+    assert config.s3_access_key == ""
+    assert config.s3_secret_key == ""
     assert config.s3_region == "us-east-1"
     assert config.bundle_bucket == "curie-bundles"
     # Platform API

--- a/apps/worker/tests/test_credential_resolution.py
+++ b/apps/worker/tests/test_credential_resolution.py
@@ -1,0 +1,64 @@
+"""The worker's key-free BYO object-store path (#1559), end to end from env to signer.
+
+The worker is a separate lane with its own settings class and its own defaults,
+and its config comment declares the S3 block a parity seam with the API
+("mirrors the API's env names"). A test covering only the API would leave the
+worker's default free to drift back to a baked-in dev key, so the worker's read
+path gets the same assertion as the API's write path.
+
+Asserted through the real ``BundleStore`` because that is what production
+constructs. ``BundleStore.__init__`` only builds a boto3 client and does no
+network I/O, and botocore's web-identity provider returns deferred credentials
+without calling STS, so this is fully offline.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+from curie_worker.bundle_store import BundleStore
+from curie_worker.config import WorkerConfig
+
+
+@pytest.fixture
+def web_identity_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Only an IRSA-style web identity is available to the provider chain.
+
+    Every ``AWS_*``/``S3_*`` var is scrubbed first so an ambient developer
+    profile or a CI runner's own credentials cannot decide the result. The token
+    file's contents are never read (the provider defers the STS exchange), so a
+    placeholder is enough.
+    """
+    for name in list(os.environ):
+        if name.startswith(("AWS_", "S3_")):
+            monkeypatch.delenv(name, raising=False)
+    token_file = tmp_path / "token"
+    token_file.write_text("placeholder-web-identity-token")
+    monkeypatch.setenv("AWS_ROLE_ARN", "arn:aws:iam::000000000000:role/curie-bundles")
+    monkeypatch.setenv("AWS_WEB_IDENTITY_TOKEN_FILE", str(token_file))
+    monkeypatch.setenv("AWS_REGION", "us-east-1")
+    monkeypatch.setenv("S3_ENDPOINT_URL", "https://s3.example.com:443")
+
+
+def test_omitted_credential_env_reaches_web_identity(web_identity_env: None) -> None:
+    config = WorkerConfig()
+    store = BundleStore(config)
+    credentials = store._client._request_signer._credentials
+    assert credentials.method == "assume-role-with-web-identity"
+
+
+def test_configured_credential_env_signs_explicitly(
+    web_identity_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The guard against "fixing" the chain by ignoring configured credentials: a
+    # RustFS/MinIO deployment supplies a static key pair via env and it must be
+    # the one that signs, even with an ambient web identity right next to it.
+    monkeypatch.setenv("S3_ACCESS_KEY", "static-ak")
+    monkeypatch.setenv("S3_SECRET_KEY", "static-sk")
+    config = WorkerConfig()
+    store = BundleStore(config)
+    credentials = store._client._request_signer._credentials
+    assert credentials.method == "explicit"
+    assert credentials.access_key == "static-ak"

--- a/charts/curie/ci/object-store-web-identity-assertions.sh
+++ b/charts/curie/ci/object-store-web-identity-assertions.sh
@@ -31,10 +31,29 @@
 set -euo pipefail
 
 CHART=${CHART:-charts/curie}
+
+# The cleanup trap is installed BEFORE the first mktemp, not after the last one.
+# Every command between the first temp file and the trap runs unprotected, and
+# under `set -e` any of them can end the script -- a failed `helm template`, a
+# full disk, an interrupted CI step -- leaking whatever had already been
+# created. Declaring the names empty first keeps `set -u` happy, and the
+# `${VAR:-}` expansions mean a trap that fires before a given mktemp ran passes
+# `rm -f` an empty argument it ignores rather than an unbound variable.
+STATIC_RENDERED=""
+WEB_IDENTITY_RENDERED=""
+WEB_IDENTITY_VALUES=""
+WEB_IDENTITY_TOKEN=""
+trap 'rm -f "${STATIC_RENDERED:-}" "${WEB_IDENTITY_RENDERED:-}" "${WEB_IDENTITY_VALUES:-}" "${WEB_IDENTITY_TOKEN:-}"' EXIT
+
 STATIC_RENDERED=$(mktemp)
 WEB_IDENTITY_RENDERED=$(mktemp)
 WEB_IDENTITY_VALUES=$(mktemp)
-trap 'rm -f "$STATIC_RENDERED" "$WEB_IDENTITY_RENDERED" "$WEB_IDENTITY_VALUES"' EXIT
+# Stands in for the projected ServiceAccount token the EKS pod-identity webhook
+# mounts. Its CONTENT is never read here: the web-identity provider hands back
+# deferred credentials and only exchanges the token at the first signed call, so
+# a placeholder is enough to observe which provider won and this stays offline.
+WEB_IDENTITY_TOKEN=$(mktemp)
+printf 'placeholder-projected-service-account-token' > "$WEB_IDENTITY_TOKEN"
 
 cat > "$WEB_IDENTITY_VALUES" <<'EOF'
 rustfs:
@@ -227,5 +246,288 @@ assert_static(sys.argv[1])
 assert_web_identity(sys.argv[2])
 PY
 
+# Everything above reads the rendered YAML. That is necessary and not
+# sufficient: an absent env var only means the chart stopped SUPPLYING a
+# credential, and the thing that actually has to happen is that the SDK then
+# RESOLVES one from the web-identity provider. Those are different claims, and
+# the gap between them is exactly where this feature was inert -- the manifests
+# were already clean while the api crashlooped at boot, because the settings
+# objects carry non-empty `rustfs`/`rustfssecret` DEFAULTS and the client
+# builder passes them unconditionally. Omitting the env var just falls back to
+# the default, and botocore reads that default as an explicit credential.
+#
+# So this second block stops asserting about fields and starts asserting about
+# an outcome: build the real production objects under the env each rendered
+# workload would actually get, and ask the constructed boto3 client which
+# provider won. `.method` is that answer, and it is the only check here that
+# cannot be satisfied by a rename or a moved field:
+#
+#   * "assume-role-with-web-identity" -- the chain was walked and the projected
+#     token provider supplied the identity. This is the feature working.
+#   * "explicit" -- a credential was handed to the client constructor, so
+#     botocore short-circuited at the first resolver and never reached the
+#     provider chain at all. An empty string counts: botocore treats
+#     `aws_access_key_id=""` as a supplied credential, not an absent one, so
+#     "we blanked the credential" is NOT the same fix as "we passed None".
+#
+# It goes through `BundleStore` rather than the shared `build_s3_client` helper
+# on purpose. `BundleStore` is what production constructs; testing the helper
+# alone would stay green if a store grew its own credential handling on top.
+#
+# Offline by construction: the web-identity provider returns deferred
+# credentials and defers the STS exchange to the first signed request, which
+# never happens here. No network, no cluster, no bucket.
+uv run --python 3.13 python - "$STATIC_RENDERED" "$WEB_IDENTITY_RENDERED" "$WEB_IDENTITY_TOKEN" <<'PY'
+import base64, os, sys, boto3, yaml
+
+ROLE_ANNOTATION = "eks.amazonaws.com/role-arn"
+
+
+def load_manifest(path):
+    """Index the workloads, Secrets, and ServiceAccounts of one rendered chart."""
+    deployments, secrets, service_accounts = {}, {}, {}
+    with open(path) as fh:
+        for doc in yaml.safe_load_all(fh):
+            if not doc:
+                continue
+            kind = doc.get("kind")
+            name = doc.get("metadata", {}).get("name", "")
+            if kind == "Deployment":
+                deployments[name] = doc
+            elif kind == "Secret":
+                values = {
+                    key: base64.b64decode(encoded).decode()
+                    for key, encoded in (doc.get("data") or {}).items()
+                }
+                values.update(doc.get("stringData") or {})
+                secrets[name] = values
+            elif kind == "ServiceAccount":
+                service_accounts[name] = doc["metadata"].get("annotations") or {}
+    return deployments, secrets, service_accounts
+
+
+def deployment_for(deployments, name):
+    """The Deployment by its exact rendered name.
+
+    Named exactly rather than by suffix because the chart also renders
+    `curie-langfuse-worker`, so a `-worker` suffix match picks up two workloads
+    and whichever one document order happens to leave last.
+    """
+    assert name in deployments, (
+        f"Deployment {name} was not rendered (rendered {sorted(deployments)})"
+    )
+    return deployments[name]
+
+
+def container_named(label, deployment, container_name):
+    """The container this workload actually runs, chosen by name, never by index.
+
+    Indexing `containers[0]` reads whichever container the pod spec happens to
+    list first, and that is not the same claim as "the application container".
+    A sidecar prepended to the spec -- a proxy, a log shipper, a mesh injector
+    -- would carry no S3 credential env at all, so both lanes would read a clean
+    environment and pass while the real api or worker container kept its
+    explicit keys. The gate would then assert about a container nobody stores a
+    bundle from.
+
+    Missing is a hard failure rather than a fallback to index 0 for the same
+    reason: a silent fallback restores exactly the positional read this exists
+    to remove, and a container rename is a real change to what the gate covers.
+    """
+    containers = deployment["spec"]["template"]["spec"].get("containers", []) or []
+    matches = [c for c in containers if c.get("name") == container_name]
+    assert len(matches) == 1, (
+        f"{label}: Deployment {deployment['metadata']['name']} must run exactly one "
+        f"container named {container_name!r}, but it renders "
+        f"{[c.get('name') for c in containers]}. This gate asserts about the "
+        "application container specifically, so it will not guess which one that is."
+    )
+    return matches[0]
+
+
+def resolve_env(label, deployment, container_name, secrets):
+    """The env the kubelet would hand this container, secretKeyRefs included.
+
+    Reading only inline `value` entries is the trap here. On the static path the
+    api and the worker carry `S3_ACCESS_KEY` inline but source `S3_SECRET_KEY`
+    from a secretKeyRef, so a value-only reader produces an access key with no
+    secret -- which botocore rejects with PartialCredentialsError, a failure
+    that looks like a broken gate rather than the passing static lane it is.
+    """
+    container = container_named(label, deployment, container_name)
+    resolved = {}
+    for entry in container.get("env", []) or []:
+        name = entry["name"]
+        if "value" in entry:
+            resolved[name] = str(entry["value"])
+            continue
+        source = (entry.get("valueFrom") or {}).get("secretKeyRef")
+        if source is None:
+            # fieldRef, resourceFieldRef and friends are pod metadata, never a
+            # credential, so they cannot steer provider resolution.
+            continue
+        secret = secrets.get(source["name"])
+        assert secret is not None, (
+            f"{label} env {name} references Secret {source['name']}, which the chart "
+            "did not render"
+        )
+        assert source["key"] in secret, (
+            f"{label} env {name} references key {source['key']} of Secret "
+            f"{source['name']}, which holds {sorted(secret)}"
+        )
+        resolved[name] = secret[source["key"]]
+    return resolved
+
+
+def resolve_role_arn(label, deployment, service_accounts):
+    """The role ARN bound to THIS workload, via the ServiceAccount it names.
+
+    Follows serviceAccountName rather than suffix-matching an account, because
+    the api and the worker bind different roles and picking the wrong one would
+    silently assert against an identity the workload never gets.
+    """
+    account = deployment["spec"]["template"]["spec"].get("serviceAccountName")
+    assert account, f"{label} Deployment names no serviceAccountName"
+    assert account in service_accounts, (
+        f"{label} binds ServiceAccount {account}, which the chart did not render "
+        f"(rendered {sorted(service_accounts)})"
+    )
+    arn = service_accounts[account].get(ROLE_ANNOTATION)
+    assert arn, (
+        f"ServiceAccount {account} carries no {ROLE_ANNOTATION} annotation, so {label} "
+        "has no identity to assume"
+    )
+    return arn
+
+
+def apply_env(manifest_env, overrides):
+    """Scrub every ambient AWS_/S3_ key, then apply only manifest-derived values.
+
+    Load-bearing, not hygiene. A developer box or a CI runner with an ambient
+    AWS_PROFILE, an instance role, or a leftover AWS_ACCESS_KEY_ID would decide
+    the provider chain instead of the chart, and the key-free assertion would
+    then pass or fail for a reason that has nothing to do with this chart.
+    """
+    for key in [key for key in os.environ if key.startswith(("AWS_", "S3_"))]:
+        del os.environ[key]
+    for key, value in manifest_env.items():
+        if key.startswith(("AWS_", "S3_")):
+            os.environ[key] = value
+    os.environ.update(overrides)
+
+
+def api_client():
+    from curie_api.config import Settings
+    from curie_api.storage import BundleStore
+
+    # `_env_file=None` is mandatory: Settings declares `env_file=".env"`, so a
+    # stray dotenv in the checkout would otherwise supply credentials and quietly
+    # decide the result of this gate.
+    return BundleStore(Settings(_env_file=None))._client
+
+
+def worker_client():
+    from curie_worker.bundle_store import BundleStore
+    from curie_worker.config import WorkerConfig
+
+    # WorkerConfig declares no env file, so there is nothing to suppress.
+    return BundleStore(WorkerConfig())._client
+
+
+def credentials_of(label, client):
+    credentials = client._request_signer._credentials
+    assert credentials is not None, (
+        f"{label} resolved no credentials at all; the provider chain was walked and "
+        "came back empty"
+    )
+    return credentials
+
+
+static_deployments, static_secrets, static_accounts = load_manifest(sys.argv[1])
+free_deployments, free_secrets, free_accounts = load_manifest(sys.argv[2])
+token_file = sys.argv[3]
+
+# Release name is fixed at `curie` by the two `helm template` calls above, and
+# the container name is spelled out beside the Deployment name rather than
+# derived from the label, so a chart-side rename of either one fails loudly here
+# instead of quietly re-pointing the gate at a different container.
+WORKLOADS = (
+    ("api", "curie-api", "api", api_client),
+    ("worker", "curie-worker", "worker", worker_client),
+)
+
+# `boto3.DEFAULT_SESSION = None` before every client build is load-bearing, not
+# defensive tidiness, and it is the half of the isolation `apply_env` cannot do.
+# `build_s3_client` calls `boto3.client(...)`, which is a method on boto3's
+# GLOBAL default session, and a session caches the credentials it resolves for
+# the life of the process. All four clients below are built in ONE interpreter,
+# so without this reset the first resolution wins and every later iteration is
+# handed the cached credential object rather than resolving under the
+# environment that iteration just applied. The whole point of scrubbing and
+# reapplying the env per workload is that each lane resolves from scratch; a
+# reused session silently turns the second, third, and fourth assertions into
+# restatements of the first, and they would keep passing while asserting
+# nothing. Dropping the reference forces boto3 to build a new session, and a new
+# session starts with an empty credential cache. Verified by the objects: with
+# the reset the api and worker resolve to distinct credential instances, without
+# it they are the same object.
+
+# Static lane. Same web-identity env present, so this also proves the key-free
+# path is selected by the ABSENCE of configured keys and not by the ambient
+# environment: a default install must keep signing with its own credentials even
+# on a cluster where a role happens to be bound.
+for label, workload, container_name, build_client in WORKLOADS:
+    deployment = deployment_for(static_deployments, workload)
+    manifest_env = resolve_env(label, deployment, container_name, static_secrets)
+    expected_key = manifest_env["S3_ACCESS_KEY"]
+    apply_env(
+        manifest_env,
+        {
+            "AWS_ROLE_ARN": "arn:aws:iam::000000000000:role/curie-unused",
+            "AWS_WEB_IDENTITY_TOKEN_FILE": token_file,
+            "AWS_REGION": "us-east-1",
+        },
+    )
+    boto3.DEFAULT_SESSION = None
+    credentials = credentials_of(label, build_client())
+    assert credentials.method == "explicit", (
+        f"static: {label} resolved credentials via {credentials.method!r}; the default "
+        "install signs with the in-chart RustFS keys, which no provider chain can supply"
+    )
+    # The method alone would still pass if the store signed with the wrong key,
+    # so pin the value the manifest actually carries.
+    assert credentials.access_key == expected_key, (
+        f"static: {label} signs with access key {credentials.access_key!r}, but the "
+        f"rendered manifest carries {expected_key!r}"
+    )
+    print(f"ok: static: {label} signs explicitly with the rendered access key")
+
+# Key-free lane. AWS_ROLE_ARN and AWS_WEB_IDENTITY_TOKEN_FILE are the two vars
+# the EKS pod-identity webhook injects; together they are the entire input to
+# the provider this path depends on.
+for label, workload, container_name, build_client in WORKLOADS:
+    deployment = deployment_for(free_deployments, workload)
+    apply_env(
+        resolve_env(label, deployment, container_name, free_secrets),
+        {
+            "AWS_ROLE_ARN": resolve_role_arn(label, deployment, free_accounts),
+            "AWS_WEB_IDENTITY_TOKEN_FILE": token_file,
+            "AWS_REGION": "us-east-1",
+        },
+    )
+    boto3.DEFAULT_SESSION = None
+    method = credentials_of(label, build_client()).method
+    assert method == "assume-role-with-web-identity", (
+        f"key-free: {label} built a client whose credentials resolved via {method!r}, "
+        "not 'assume-role-with-web-identity'. 'explicit' means a credential was passed "
+        "to the client constructor, so botocore stopped at the first resolver and the "
+        "web-identity provider was never reached -- the key-free path is inert no "
+        "matter how clean the rendered manifest looks. Note that an empty-string "
+        "credential is still explicit to botocore; the constructor has to receive no "
+        "credential at all."
+    )
+    print(f"ok: key-free: {label} resolves credentials via {method}")
+PY
+
 echo
-echo "PASS: the default install keeps static object-store credentials; clearing rustfs.auth.accessKey omits every credential env and shell export across api, worker, and bundle-fetch, binds identity through ServiceAccount annotations, is refused against the in-chart RustFS, and leaves Rail 1's IMDS denial intact."
+echo "PASS: the default install keeps static object-store credentials and still signs with the access key its manifest carries; clearing rustfs.auth.accessKey omits every credential env and shell export across api, worker, and bundle-fetch, binds identity through ServiceAccount annotations, is refused against the in-chart RustFS, leaves Rail 1's IMDS denial intact, and makes the api and worker BundleStore objects resolve real credentials through the web-identity provider rather than an explicit key."

--- a/cli/tests/chart_check.rs
+++ b/cli/tests/chart_check.rs
@@ -230,15 +230,28 @@ fn helm_ci_and_the_chart_ci_directory_cannot_diverge() {
 
 /// AC4: the verb passes on the unmodified chart.
 ///
-/// This runs the real assertion suite, so it needs `helm` on PATH and takes
-/// single-digit seconds. It skips rather than fails where helm is absent, the
-/// same posture as the Valkey-backed tests: a missing local tool is not a
-/// regression in the chart. helm-ci itself is the environment where the suite is
-/// guaranteed to run.
+/// This runs the real assertion suite, so it needs BOTH `helm` and `uv` on PATH
+/// and takes single-digit seconds. `uv` joined `helm` with #1559: the object
+/// store assertions no longer only read the rendered manifest, they drive the
+/// real Python API and worker `BundleStore` clients through `uv run` to prove
+/// which botocore credential provider actually resolves, which reading YAML
+/// cannot show.
+///
+/// It skips rather than fails where either tool is absent, the same posture as
+/// the Valkey-backed tests: a missing local tool is not a regression in the
+/// chart. helm-ci itself is the environment where the suite is guaranteed to
+/// run, and `.github/workflows/helm-ci.yaml` installs uv and runs `uv sync`
+/// before that step, so the executing assertion runs for real on every chart
+/// change and on every push to main and next. Skipping here narrows where the
+/// suite runs locally, never where it gates.
 #[tokio::test]
 async fn chart_check_passes_on_the_unmodified_chart() {
     if Command::new("helm").arg("version").output().is_err() {
         eprintln!("skipping: helm is not on PATH");
+        return;
+    }
+    if Command::new("uv").arg("--version").output().is_err() {
+        eprintln!("skipping: uv is not on PATH");
         return;
     }
 

--- a/packages/aci-protocol/src/aci_protocol/s3.py
+++ b/packages/aci-protocol/src/aci_protocol/s3.py
@@ -12,6 +12,12 @@ It takes primitives, not either app's config object, so it couples to neither
 `curie_api.Settings` nor `curie_worker.WorkerConfig`. `boto3` is imported
 lazily inside the function so importing this module (and the rest of
 ``aci_protocol``) never requires boto3 for consumers that do not touch S3.
+
+Empty credentials mean "resolve through the AWS provider chain" (#1559). A
+caller that leaves `access_key`/`secret_key` empty is running the key-free BYO
+object-store path, where the identity comes from IRSA, an instance role, or an
+ambient profile instead of a static key pair; the builder is what turns that
+emptiness into the signal boto3 recognizes.
 """
 
 from __future__ import annotations
@@ -33,6 +39,17 @@ def build_s3_client(
 
     Path-style addressing is required for RustFS and works with AWS S3, so it is
     fixed here. Callers pass their resolved config values as keyword primitives.
+
+    An empty credential becomes `None`, because `None` is boto3's documented
+    "resolve through the provider chain" signal and an empty string is NOT
+    equivalent to it. Botocore treats an empty-string credential as an explicit
+    credential: it stops at the first resolver, never reaches the web-identity
+    provider, and signs with an empty identity, so the key-free path fails
+    silently rather than falling back. Passing the empty value straight through
+    is what made that path inert (#1559). A static key pair is unaffected, and
+    half a pair (one value set, the other empty) still raises
+    `PartialCredentialsError` at construction rather than quietly resolving an
+    ambient identity, which would mask a typo'd key as a working deployment.
     """
     import boto3
     from botocore.client import Config as BotoConfig
@@ -40,8 +57,8 @@ def build_s3_client(
     return boto3.client(
         "s3",
         endpoint_url=endpoint_url,
-        aws_access_key_id=access_key,
-        aws_secret_access_key=secret_key,
+        aws_access_key_id=access_key or None,
+        aws_secret_access_key=secret_key or None,
         region_name=region,
         config=BotoConfig(s3={"addressing_style": "path"}),
     )

--- a/packages/aci-protocol/tests/test_s3.py
+++ b/packages/aci-protocol/tests/test_s3.py
@@ -1,6 +1,38 @@
-"""The shared S3 client builder (#501): path-style addressing, offline."""
+"""The shared S3 client builder (#501): path-style addressing, offline.
 
+The credential tests below (#1559) pin the key-free BYO object-store path: an
+omitted credential must reach botocore's provider chain (IRSA / instance role /
+ambient profile), not be signed as an explicit empty-string identity. Botocore's
+web-identity provider returns DEFERRED credentials, so it resolves the provider
+without ever calling STS. Everything here stays offline and needs no mocks.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
 from aci_protocol.s3 import build_s3_client
+from botocore.exceptions import PartialCredentialsError
+
+
+@pytest.fixture
+def web_identity_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Only an IRSA-style web identity is available to the provider chain.
+
+    Every ``AWS_*``/``S3_*`` var is scrubbed first so an ambient developer
+    profile or a CI runner's own credentials cannot decide the result; what is
+    left is the exact env a pod running under IRSA sees. The token file's
+    contents are never read here (the provider defers the STS exchange), so a
+    placeholder is enough.
+    """
+    for name in list(os.environ):
+        if name.startswith(("AWS_", "S3_")):
+            monkeypatch.delenv(name, raising=False)
+    token_file = tmp_path / "token"
+    token_file.write_text("placeholder-web-identity-token")
+    monkeypatch.setenv("AWS_ROLE_ARN", "arn:aws:iam::000000000000:role/curie-bundles")
+    monkeypatch.setenv("AWS_WEB_IDENTITY_TOKEN_FILE", str(token_file))
+    monkeypatch.setenv("AWS_REGION", "us-east-1")
 
 
 def test_build_s3_client_is_path_style() -> None:
@@ -16,3 +48,52 @@ def test_build_s3_client_is_path_style() -> None:
     assert client.meta.config.s3["addressing_style"] == "path"
     assert client.meta.endpoint_url == "http://rustfs.test:9000"
     assert client.meta.region_name == "us-east-1"
+
+
+def test_empty_credentials_resolve_through_the_provider_chain(
+    web_identity_env: None,
+) -> None:
+    # An empty string is STILL an explicit credential to botocore; only None means
+    # "use the provider chain". So the builder must translate omitted-in-config to
+    # None, and the proof is which provider actually resolved: assert on the
+    # signer's resolved method rather than on the config string, because a config
+    # default of "" alone leaves the key-free path just as inert.
+    client = build_s3_client(
+        endpoint_url="https://s3.example.com:443",
+        access_key="",
+        secret_key="",
+        region="us-east-1",
+    )
+    credentials = client._request_signer._credentials
+    assert credentials.method == "assume-role-with-web-identity"
+
+
+def test_explicit_credentials_still_win_over_the_chain(web_identity_env: None) -> None:
+    # The guard against "fixing" the chain by ignoring configured credentials: a
+    # RustFS/MinIO deployment supplies a static key pair and it must be the one
+    # that signs, even with an ambient web identity sitting right next to it.
+    client = build_s3_client(
+        endpoint_url="https://s3.example.com:443",
+        access_key="ak",
+        secret_key="sk",
+        region="us-east-1",
+    )
+    credentials = client._request_signer._credentials
+    assert credentials.method == "explicit"
+    assert credentials.access_key == "ak"
+
+
+def test_half_a_credential_is_refused_not_silently_downgraded(
+    web_identity_env: None,
+) -> None:
+    # Half a credential is an operator mistake, and it must fail loudly at
+    # construction rather than sign with a partial identity or quietly fall back
+    # to the ambient web identity (which would mask a typo'd secret key as a
+    # working deployment until the wrong role's permissions bit).
+    with pytest.raises(PartialCredentialsError):
+        build_s3_client(
+            endpoint_url="https://s3.example.com:443",
+            access_key="ak",
+            secret_key="",
+            region="us-east-1",
+        )

--- a/release/tests/test_authorize.py
+++ b/release/tests/test_authorize.py
@@ -1014,9 +1014,20 @@ class TestHelmCiWorkflowTriggers:
         assert "paths" not in triggers["push"]
         assert "paths-ignore" not in triggers["push"]
         assert triggers["pull_request"]["branches"] == ["main", "next"]
+        # The Python paths are not strays to tidy up: the object-store
+        # web-identity gate executes those repository files against each
+        # rendered workload, so a PR touching only them (a revert of the
+        # credential fix) must still match this filter or the gate never runs.
         assert triggers["pull_request"]["paths"] == [
             "charts/curie/**",
             ".github/workflows/helm-ci.yaml",
+            "packages/aci-protocol/src/aci_protocol/s3.py",
+            "apps/api/src/curie_api/config.py",
+            "apps/api/src/curie_api/storage.py",
+            "apps/worker/src/curie_worker/config.py",
+            "apps/worker/src/curie_worker/bundle_store.py",
+            "uv.lock",
+            "pyproject.toml",
         ]
 
 


### PR DESCRIPTION
The key-free BYO object store path documented in the chart README never reached the AWS provider chain. The API crashlooped at boot and the worker failed every bundle and eval read. Only the sandbox bundle-fetch init container worked, because it is the AWS CLI with its own chain.

The chart half was already correct. The defect was code side, and it took two halves to close, because an empty string is still an explicit credential to botocore:

| passed to boto3 | resolved method |
| --- | --- |
| `"rustfs"` | `explicit` |
| `""` | `explicit` |
| `None` | `assume-role-with-web-identity` |

1. `build_s3_client` now maps an empty credential to `None`, which is boto3's documented "resolve through the provider chain" signal.
2. The API and worker `s3_access_key` / `s3_secret_key` defaults are now empty, so omitting the env var produces an empty value rather than the dev default.

Either half alone leaves the path inert.

## The gate now rejects by execution

The existing gate passed throughout, because it asserted the credential env vars were ABSENT from the rendered manifest and never that an identity ARRIVED. It now renders the chart, reconstructs each workload's real environment (resolving `secretKeyRef` against the rendered Secrets, since `S3_SECRET_KEY` is a secret ref while `S3_ACCESS_KEY` is inline), resolves each workload's own `serviceAccountName` to pick its role ARN, builds the real API and worker `BundleStore` objects, and asserts which credential provider botocore selected. It stays offline; the web identity provider returns deferred credentials without an STS call.

Negative control, run on this branch:

| state | result |
| --- | --- |
| full fix | `rc=0`, nine `ok:` lines |
| revert the builder half only | `rc=1`, `resolved via 'explicit'` |
| revert the settings defaults only | `rc=1`, `resolved via 'explicit'` |

`helm-ci` gains the workspace it now needs and a widened path filter, so the gate runs on the pull requests that can break it rather than only on chart changes.

## Local loop

`compose.dev.yaml` already sets both credentials for `curie-api` and `curie-worker` and is untouched. Verified by a real round trip against a live RustFS: the production `Settings` and `BundleStore` wrote 54 bytes and the real worker `BundleStore` read them back, both signing `explicit`.

The dev static credential moves to `.env.example`, and the API test suite now names it explicitly instead of inheriting it from a production default. That second part is load bearing: without it the suite went to 34 failed and 227 errors on a CI shaped environment, because the old non-empty default had been silently doubling as test configuration. It also makes the suite independent of whatever ambient AWS credentials a developer's machine carries, which previously could decide the result.

Note for existing developers: an `.env` seeded before this change will not carry the new lines, so a bare non-compose local API run needs them added or the two variables exported. Under compose nothing changes.

## Known risk, please rule on this

Making the key-free path work means the API and worker now consult the AWS provider chain. No egress NetworkPolicy selects the api or worker pods (every one of them selects `component: runner-sandbox`), so on a key-free install whose role annotation is missing or whose projected token fails, those two can fall through to the EC2 instance metadata endpoint and assume the node role instead of failing closed. The chart README states the instance role is deliberately unavailable, so this contradicts the documented intent of the key-free feature.

This regresses no working install, since a key-free install crashlooped before this fix, so the path is only now reachable at all. It is left out of this PR because the fix is a chart change with a real design choice in it: disable EC2 metadata for those two workloads, add an egress policy covering them, or refuse the render when a key-free config carries no role annotation. That is a maintainer call rather than something to decide inside a code side fix.

## Other follow-ups, not fixed here

- Langfuse receives `LANGFUSE_S3_EVENT_UPLOAD_ACCESS_KEY_ID` from `rustfs.auth.accessKey` with no `curie.rustfs.staticCredentials` guard, so clearing the key hands Langfuse an empty access key. A separate chart gap that needs its own decision about whether the Langfuse uploader supports web identity at all.
- The gate's original python block matches deployments by name suffix, and `curie-langfuse-worker` also matches `-worker`. Latent today only because `curie-worker` renders last. Pre-existing and left alone to keep this diff scoped.

## Validation

`pytest packages/aci-protocol apps/api` 803 passed. `pytest apps/worker` shows only the 28 pre-existing `tests/binding/` failures from the local Postgres migration issue, which are present on the base branch. `ruff`, `mypy`, `lint-imports`, `check-docs`, `check-contracts` (no drift, so no `PROTOCOL_VERSION` bump), `helm lint`, and the `ci-retry-gate` and `ci-workflow-paths` suites all pass.

Closes #1559
