### PR TITLE
Give worker turns time to drain

### DIFF
--- a/charts/curie/ci/worker-ttl-bounds-assertions.sh
+++ b/charts/curie/ci/worker-ttl-bounds-assertions.sh
@@ -113,6 +113,26 @@ for pair in want:
 PY
 )"
 
+WORKER_TERMINATION_GRACE_PY="$(
+  cat <<'PY'
+import sys, yaml
+docs = [d for d in yaml.safe_load_all(open(sys.argv[1])) if d]
+deploys = [
+    d for d in docs
+    if d.get("kind") == "Deployment"
+    and (d["metadata"].get("labels") or {}).get("app.kubernetes.io/component") == "worker"
+]
+if len(deploys) != 1:
+    raise SystemExit(f"expected exactly one worker Deployment, rendered {len(deploys)}")
+got = deploys[0]["spec"]["template"]["spec"].get("terminationGracePeriodSeconds")
+if type(got) is not int or got != 1800:
+    raise SystemExit(
+        "worker terminationGracePeriodSeconds rendered "
+        f"{got!r}, expected integer 1800"
+    )
+PY
+)"
+
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
@@ -156,8 +176,13 @@ assert_refused() {
 #     ci/api-ingress-assertions.sh:31-34 documents having fallen into. The
 #     negatives below render the WHOLE chart (via `render()`, no `-s`), so the
 #     guard must cover that same render shape, not just the worker template.
-helm template curie "$CHART" >/dev/null 2>&1 \
-  || fail a "the full-chart default render FAILED; every negative below would pass for the wrong reason"
+DEFAULT_RENDER="$TMP/default.yaml"
+if ! helm template curie "$CHART" >"$DEFAULT_RENDER" 2>&1; then
+  fail a "the full-chart default render FAILED; every negative below would pass for the wrong reason"
+fi
+if ! msg="$(python3 -c "$WORKER_TERMINATION_GRACE_PY" "$DEFAULT_RENDER" 2>&1)"; then
+  fail a "$msg"
+fi
 assert_env a -- \
   CURIE_CLAIM_TIMEOUT_SECONDS=90 \
   CURIE_ROUTE_TTL_SECONDS=3600 \

--- a/charts/curie/templates/worker.yaml
+++ b/charts/curie/templates/worker.yaml
@@ -104,6 +104,7 @@ spec:
         {{- include "curie.labels" . | nindent 8 }}
         {{- include "curie.selectorLabels" (dict "root" . "component" "worker") | nindent 8 }}
     spec:
+      terminationGracePeriodSeconds: {{ .Values.worker.terminationGracePeriodSeconds }}
       {{- if .Values.worker.serviceAccount.create }}
       serviceAccountName: {{ include "curie.fullname" . }}-worker
       {{- end }}

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -760,6 +760,7 @@ dispatcher:
 worker:
   deploy: true
   replicas: 1
+  terminationGracePeriodSeconds: 1800
   image:
     repository: ghcr.io/curie-eng/curie-worker
     # Empty -> chart appVersion (immutable). Set to pin an explicit version tag.


### PR DESCRIPTION
Closes #1570

Sets the worker Pod termination grace to 1800 seconds, matching three 600 second runner attempts. Adds a structural assertion on the rendered Deployment.

Done check

1. [x] Failing render assertion was committed before implementation. Before squash, e10f854e preceded 8b45a9dc.
2. [x] Separate delegated contexts performed test and production edits.
3. [x] N/A. No function or return type changed.
4. [x] Independent code review found no blocking correctness, intent, or documentation defect.
5. [x] Independent scope review mapped every hunk to the acceptance criterion or test necessity and found no passenger change.
6. [x] N/A. No sibling path seam changed.
7. [x] The new assertion rejected the original chart with: worker terminationGracePeriodSeconds rendered None, expected integer 1800.
8. [x] Consolidation found no safe simplification. The affected suite remained green.
9. [x] N/A. No security surface changed.
10. [x] Live Kubernetes Deployment inspection returned integer 1800.
11. [x] The focused worker chart assertion passed, Helm lint passed, and development values rendered with integer 1800.
12. [x] Shell syntax and Helm lint were clean for every edited file.

Runtime note: the live Deployment query returned 1800. The broader chart runtime harness reached install on an isolated cluster, but its execution session detached before the terminal PASS marker. All temporary resources were removed. CI will rerun the chart gates.