### PR TITLE
Randomize Langfuse init credentials

### DIFF
--- a/charts/curie/README.md
+++ b/charts/curie/README.md
@@ -222,11 +222,12 @@ Flipping any to `false` removes its resources from the render; consumers
 
 Secrets: all credentials are written to one `<release>-secrets` Secret. A sealed
 `helm install` (the default) AUTO-GENERATES a strong random per release for the
-nine chart-owned credentials (the backing-store passwords, the Langfuse
-salt/encryptionKey/nextauthSecret, and the api/webhook keys) rather than shipping
-the published dev defaults. The generated values are persisted via a `lookup` of
-the release Secret, so `helm upgrade` re-uses them and never rotates a live store
-credential (the Bitnami lookup-persist convention). Set
+eleven chart-owned credentials (the backing-store passwords, the Langfuse
+salt/encryptionKey/nextauthSecret and init project secret key/user password, and
+the api/webhook keys) rather than shipping the published dev defaults. The
+generated values are persisted via a `lookup` of the release Secret, so
+`helm upgrade` re-uses them and never rotates a live store credential (the
+Bitnami lookup-persist convention). Set
 `security.allowDevDefaults: true` (values-dev.yaml, i.e. `curie cluster up
 --dev`) to keep the deterministic published defaults for dev/CI. A per-store
 `existingSecret` and explicit `--set` overrides still win in every mode -- an
@@ -235,6 +236,9 @@ install AND upgrade (matching Bitnami's provided-value-first precedence), so
 rotation/recovery works; point `langfuse.existingSecret` (and each store's
 `existingSecret`) at your own Secrets to bring your own. `langfuse.encryptionKey`
 must be 64 hex chars (`openssl rand -hex 32`).
+
+When no OTel auth header override is supplied, the collector derives its header
+from the resolved Langfuse project secret key.
 
 Caveat: generation relies on Helm `lookup`, which is empty under client-side
 rendering. Driving this chart via `helm template | kubectl apply` or ArgoCD's

--- a/charts/curie/README.md
+++ b/charts/curie/README.md
@@ -115,12 +115,19 @@ helm install curie-dev charts/curie -n curie-dev --create-namespace \
 kubectl get pods -n curie-dev -w
 ```
 
-Reach the Langfuse UI:
+Reach the Langfuse UI after a stock install:
 
 ```bash
 kubectl port-forward -n curie svc/curie-langfuse-web 3000:3000
-# http://localhost:3000  -- dev keys: pk-lf-curie-dev / sk-lf-curie-dev
+# http://localhost:3000
+kubectl get secret curie-secrets -n curie -o jsonpath='{.data.langfuseInitProjectSecretKey}' | base64 -d; echo
+kubectl get secret curie-secrets -n curie -o jsonpath='{.data.langfuseInitUserPassword}' | base64 -d; echo
 ```
+
+Log in as `dev@curie.local` with the retrieved admin password. The first
+command retrieves the project secret key for API and OTel authentication.
+The development overlay retains the published development keys
+`pk-lf-curie-dev` and `sk-lf-curie-dev`.
 
 App services emit OTLP (OpenTelemetry Protocol) to the **collector**, never
 straight to Langfuse (Langfuse OTLP ingest is HTTP-only): `curie-otel-collector:4317` (gRPC) /
@@ -221,24 +228,28 @@ Flipping any to `false` removes its resources from the render; consumers
 (Langfuse env, the collector config) repoint at the BYO host automatically.
 
 Secrets: all credentials are written to one `<release>-secrets` Secret. A sealed
-`helm install` (the default) AUTO-GENERATES a strong random per release for the
-eleven chart-owned credentials (the backing-store passwords, the Langfuse
-salt/encryptionKey/nextauthSecret and init project secret key/user password, and
-the api/webhook keys) rather than shipping the published dev defaults. The
-generated values are persisted via a `lookup` of the release Secret, so
-`helm upgrade` re-uses them and never rotates a live store credential (the
-Bitnami lookup-persist convention). Set
-`security.allowDevDefaults: true` (values-dev.yaml, i.e. `curie cluster up
---dev`) to keep the deterministic published defaults for dev/CI. A per-store
-`existingSecret` and explicit `--set` overrides still win in every mode -- an
-override that differs from the published default beats the persisted value on
-install AND upgrade (matching Bitnami's provided-value-first precedence), so
-rotation/recovery works; point `langfuse.existingSecret` (and each store's
-`existingSecret`) at your own Secrets to bring your own. `langfuse.encryptionKey`
-must be 64 hex chars (`openssl rand -hex 32`).
+`helm install` (the default) generates strong random values for all eleven
+chart owned credentials: the backing store passwords, Langfuse
+salt/encryptionKey/nextauthSecret, the two Langfuse init credentials, and the
+api/webhook keys. Set `security.allowDevDefaults: true` (values-dev.yaml, i.e.
+`curie cluster up --dev`) to keep the deterministic published defaults for
+dev/CI.
 
-When no OTel auth header override is supplied, the collector derives its header
-from the resolved Langfuse project secret key.
+The nine non init credentials persist through `lookup`, so `helm upgrade`
+re-uses them. Their explicit `--set` overrides and per store `existingSecret`
+values take precedence for rotation or recovery. The Langfuse init project
+secret and user password are first boot inputs. A fresh install generates them,
+but changing them during an upgrade does not rotate records already initialized
+in Langfuse. Existing releases need Langfuse side rotation and coordinated
+consumer Secret updates. This chart does not perform that migration. Point
+`langfuse.existingSecret` (and each store's `existingSecret`) at your own
+Secrets to bring your own. `langfuse.encryptionKey` must be 64 hex chars
+(`openssl rand -hex 32`).
+
+With chart-managed init credentials and no OTel header override, the collector
+derives its header from the resolved Langfuse project secret key. With
+`langfuse.existingSecret`, provide a matching explicit
+`otelCollector.otlpAuthHeader`.
 
 Caveat: generation relies on Helm `lookup`, which is empty under client-side
 rendering. Driving this chart via `helm template | kubectl apply` or ArgoCD's
@@ -246,13 +257,12 @@ client-side Helm (no live API lookup) regenerates these values on every sync and
 would rotate live store credentials -- pin them via `--set`/`existingSecret` (or
 use the `helm install/upgrade` path / `curie cluster up`) in that case.
 
-Guard against shipping those dev defaults to a shared/production cluster with
-`--set security.checkDefaultCredentials=true`: the chart then refuses to render
-while `langfuse.init.projectSecretKey` or `langfuse.init.userPassword` still
-carries its published dev default (a Langfuse admin-takeover risk on a reachable
-UI; the project key also feeds the OTel Collector auth header). Override those
-values or supply `langfuse.existingSecret` to clear the gate. It is off by
-default so the zero-secret bare install stays green.
+Guard against supplied development values on a shared/production cluster with
+`--set security.checkDefaultCredentials=true`. This check compares the chart
+inputs before fresh install credential generation, so it does not inspect the
+generated Secret. It is off by default so the zero-secret bare install stays
+green. Supply explicit init values or `langfuse.existingSecret` when enabling
+the check.
 
 ### Key-free object store auth
 

--- a/charts/curie/ci/render-assertions.sh
+++ b/charts/curie/ci/render-assertions.sh
@@ -7,12 +7,18 @@
 #
 #   1. A SEALED render (security.allowDevDefaults defaults false, `lookup` empty
 #      offline under `helm template`) GENERATES a strong random value for each of
-#      the nine chart-owned secret keys instead of shipping the published dev
-#      default. The generated langfuseEncryptionKey is 64 lowercase-hex chars.
+#      the eleven chart-owned secret keys instead of shipping the published dev
+#      default. The generated langfuseEncryptionKey is 64 lowercase-hex chars,
+#      and the two Langfuse init credentials are 32 alphanumeric chars.
 #   2. The DEV overlay (values-dev.yaml sets allowDevDefaults=true) keeps the
 #      deterministic published defaults, so the dev/e2e path renders unchanged.
 #   3. An explicit `--set` override that differs from the published default is
 #      honored on the sealed path (override wins over generation).
+#   4. The OTel Basic auth header uses the resolved Langfuse project secret
+#      unless the operator supplies an explicit header override.
+#
+# Issue #1569 extends this contract to the two Langfuse init credentials and
+# adds an executed negative control for their published values.
 #
 # Issue #488 (freeze the boot env in the contract), Assertions 6-7. The Helm
 # template cannot import the frozen contract crate, so its hand-typed boot-env
@@ -36,7 +42,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CHART="$(cd "$SCRIPT_DIR/.." && pwd)"
 REPO_ROOT="$(cd "$CHART/../.." && pwd)"
 
-# The nine chart-owned secret keys, each with its published dev default.
+# The eleven chart-owned secret keys, each with its published dev default.
 KEYS=(
   postgresPassword
   valkeyPassword
@@ -45,6 +51,8 @@ KEYS=(
   langfuseSalt
   langfuseEncryptionKey
   langfuseNextauthSecret
+  langfuseInitProjectSecretKey
+  langfuseInitUserPassword
   apiKey
   githubWebhookSecret
 )
@@ -56,6 +64,8 @@ declare -A DEFAULTS=(
   [langfuseSalt]="dev-salt-change-me"
   [langfuseEncryptionKey]="0000000000000000000000000000000000000000000000000000000000000000"
   [langfuseNextauthSecret]="dev-nextauth-secret-change-me"
+  [langfuseInitProjectSecretKey]="sk-lf-curie-dev"
+  [langfuseInitUserPassword]="curie-dev-password"
   [apiKey]="curie-dev-key"
   [githubWebhookSecret]="dev-webhook-secret"
 )
@@ -92,14 +102,43 @@ fail() {
   exit 1
 }
 
-echo "=== Assertion 1: sealed render GENERATES (no published default) ==="
-for key in "${KEYS[@]}"; do
-  val="$(read_key "$SEALED" "$key")"
+check_generated_key() {
+  # $1 = rendered Secret, $2 = key, $3 = render label
+  local out="$1" key="$2" label="$3" val def
+  val="$(read_key "$out" "$key")"
   def="${DEFAULTS[$key]}"
   if [[ "$val" == "$def" ]]; then
-    fail "sealed render still emits the published dev default for '$key' (value == '$def'); expected a generated value."
+    echo "$label still emits the published dev default for '$key' (value == '$def'); expected a generated value." >&2
+    return 1
   fi
   echo "  ok: $key was generated (not the published default)"
+}
+
+echo "=== Assertion 1: sealed render GENERATES (no published default) ==="
+for key in "${KEYS[@]}"; do
+  check_generated_key "$SEALED" "$key" "sealed render" \
+    || fail "sealed render did not generate '$key'; see the message above."
+done
+
+echo "=== Assertion 1 negative control: published Langfuse init values FAIL the sealed detector ==="
+for key in langfuseInitProjectSecretKey langfuseInitUserPassword; do
+  negative_output=""
+  if negative_output="$(check_generated_key "$DEV" "$key" "development negative control" 2>&1)"; then
+    fail "negative control did not fire: published '$key' passed the sealed generation detector."
+  fi
+  if [[ "$negative_output" != *"published dev default for '$key'"* ]]; then
+    fail "negative control for '$key' failed for an unexpected reason: $negative_output"
+  fi
+  echo "  ok: published $key is rejected (the detector can fail)"
+done
+
+echo "=== Assertion 1: sealed Langfuse init credentials are 32 alphanumeric chars ==="
+for key in langfuseInitProjectSecretKey langfuseInitUserPassword; do
+  val="$(read_key "$SEALED" "$key")"
+  if [[ ! "$val" =~ ^[[:alnum:]]{32}$ ]]; then
+    fail "sealed $key must match ^[[:alnum:]]{32}$; got '${val}' (length ${#val})."
+  fi
+  echo "  ok: $key is 32 alphanumeric chars"
 done
 
 echo "=== Assertion 2: sealed langfuseEncryptionKey is 64 lowercase-hex chars ==="
@@ -124,13 +163,52 @@ echo "=== Assertion 4: explicit override wins on the sealed path ==="
 # `--set` that differs from the published default must be honored verbatim rather
 # than generated -- this proves the override branch sits ahead of generation.
 OVERRIDE="$TMP/override.yaml"
-helm template "$CHART" --set api.apiKey=override-sentinel-xyz \
+helm template "$CHART" \
+  --set api.apiKey=override-sentinel-xyz \
+  --set langfuse.init.projectSecretKey=override-project-secret-1569 \
+  --set langfuse.init.userPassword=override-user-password-1569 \
   --show-only templates/secrets.yaml > "$OVERRIDE"
 got="$(read_key "$OVERRIDE" apiKey)"
 if [[ "$got" != "override-sentinel-xyz" ]]; then
   fail "explicit --set api.apiKey override must be honored on the sealed path; expected 'override-sentinel-xyz', got '$got'."
 fi
 echo "  ok: explicit apiKey override honored (override wins over generation)"
+got="$(read_key "$OVERRIDE" langfuseInitProjectSecretKey)"
+if [[ "$got" != "override-project-secret-1569" ]]; then
+  fail "explicit --set langfuse.init.projectSecretKey override must be honored on the sealed path; expected 'override-project-secret-1569', got '$got'."
+fi
+echo "  ok: explicit Langfuse init project secret override honored"
+got="$(read_key "$OVERRIDE" langfuseInitUserPassword)"
+if [[ "$got" != "override-user-password-1569" ]]; then
+  fail "explicit --set langfuse.init.userPassword override must be honored on the sealed path; expected 'override-user-password-1569', got '$got'."
+fi
+echo "  ok: explicit Langfuse init user password override honored"
+
+assert_otlp_auth_agrees() {
+  # $1 = rendered Secret, $2 = expected public key, $3 = render label
+  local out="$1" public_key="$2" label="$3" project_secret got expected
+  project_secret="$(read_key "$out" langfuseInitProjectSecretKey)"
+  got="$(read_key "$out" otlpAuthHeader)"
+  expected="Basic $(printf '%s' "$public_key:$project_secret" | base64 | tr -d '\n')"
+  if [[ "$got" != "$expected" ]]; then
+    fail "$label OTel Basic auth must use the rendered langfuseInitProjectSecretKey; expected '$expected', got '$got'."
+  fi
+  echo "  ok: $label OTel Basic auth agrees with the rendered project secret"
+}
+
+echo "=== Assertion 4: default OTel auth uses the resolved Langfuse project secret ==="
+assert_otlp_auth_agrees "$SEALED" "pk-lf-curie-dev" "sealed render"
+assert_otlp_auth_agrees "$OVERRIDE" "pk-lf-curie-dev" "credential override render"
+
+OTLP_OVERRIDE="$TMP/otlp-override.yaml"
+helm template "$CHART" \
+  --set-string 'otelCollector.otlpAuthHeader=Basic explicit-otel-sentinel-1569' \
+  --show-only templates/secrets.yaml > "$OTLP_OVERRIDE"
+got="$(read_key "$OTLP_OVERRIDE" otlpAuthHeader)"
+if [[ "$got" != "Basic explicit-otel-sentinel-1569" ]]; then
+  fail "explicit --set otelCollector.otlpAuthHeader must be honored; expected 'Basic explicit-otel-sentinel-1569', got '$got'."
+fi
+echo "  ok: explicit OTel auth override honored"
 
 echo "=== Assertion 5: quoted \"false\" does NOT disable generation (fail closed) ==="
 # Go templates treat any non-empty string as truthy, so a quoted
@@ -753,4 +831,4 @@ assert_worker_api_url override curie http://operator.example:9000 -f "$WORKER_AP
 echo "  ok: default, release name, configured port, BYO API, and operator override render one worker API URL"
 
 echo
-echo "PASS: sealed render generates strong values for all 9 keys (encryptionKey 64-hex); dev overlay keeps published defaults; explicit override wins on the sealed path; every runner boot-env name is a declared contract key (proven by a failing negative control); every control-plane pod, the agent-sandbox controller, and the sandbox render with the expected priorityClassName, including under operator override; the runner SandboxTemplate opts the controller out of its own permissive NetworkPolicy whenever Rail 1 is on, and leaves it to the controller's default when Rail 1 is off; api.githubToken stays a plain pass-through (empty renders empty, an explicit value renders verbatim, and it is never generated), proven by a failing negative control; and the worker renders exactly one API URL in the default, release name, configured port, BYO API, and operator override cases."
+echo "PASS: sealed render generates strong values for all 11 keys (encryptionKey 64-hex and Langfuse init credentials 32 alphanumeric); dev overlay keeps published defaults; explicit credential and OTel overrides win on the sealed path; default OTel Basic auth uses the resolved Langfuse project secret; every runner boot-env name is a declared contract key (proven by a failing negative control); every control-plane pod, the agent-sandbox controller, and the sandbox render with the expected priorityClassName, including under operator override; the runner SandboxTemplate opts the controller out of its own permissive NetworkPolicy whenever Rail 1 is on, and leaves it to the controller's default when Rail 1 is off; api.githubToken stays a plain pass-through (empty renders empty, an explicit value renders verbatim, and it is never generated), proven by a failing negative control; and the worker renders exactly one API URL in the default, release name, configured port, BYO API, and operator override cases."

--- a/charts/curie/ci/render-assertions.sh
+++ b/charts/curie/ci/render-assertions.sh
@@ -114,13 +114,13 @@ check_generated_key() {
   echo "  ok: $key was generated (not the published default)"
 }
 
-echo "=== Assertion 1: sealed render GENERATES (no published default) ==="
+echo "=== Assertion 1a: sealed render GENERATES (no published default) ==="
 for key in "${KEYS[@]}"; do
   check_generated_key "$SEALED" "$key" "sealed render" \
     || fail "sealed render did not generate '$key'; see the message above."
 done
 
-echo "=== Assertion 1 negative control: published Langfuse init values FAIL the sealed detector ==="
+echo "=== Assertion 1b negative control: published Langfuse init values FAIL the sealed detector ==="
 for key in langfuseInitProjectSecretKey langfuseInitUserPassword; do
   negative_output=""
   if negative_output="$(check_generated_key "$DEV" "$key" "development negative control" 2>&1)"; then
@@ -132,7 +132,12 @@ for key in langfuseInitProjectSecretKey langfuseInitUserPassword; do
   echo "  ok: published $key is rejected (the detector can fail)"
 done
 
-echo "=== Assertion 1: sealed Langfuse init credentials are 32 alphanumeric chars ==="
+# Langfuse accepts this generated shape: its env schema defines
+# LANGFUSE_INIT_PROJECT_SECRET_KEY as an optional string, without an `sk`
+# prefix constraint, and initialization passes it through as the predefined
+# project secret key. See https://github.com/langfuse/langfuse/blob/bf78bcefd23f43bbd8d04c263f31b70ca2f1ec29/web/src/env.mjs and
+# https://github.com/langfuse/langfuse/blob/bf78bcefd23f43bbd8d04c263f31b70ca2f1ec29/web/src/initialize.ts.
+echo "=== Assertion 1c: sealed Langfuse init credentials are 32 alphanumeric chars ==="
 for key in langfuseInitProjectSecretKey langfuseInitUserPassword; do
   val="$(read_key "$SEALED" "$key")"
   if [[ ! "$val" =~ ^[[:alnum:]]{32}$ ]]; then
@@ -158,7 +163,7 @@ for key in "${KEYS[@]}"; do
   echo "  ok: $key == published default (deterministic dev path)"
 done
 
-echo "=== Assertion 4: explicit override wins on the sealed path ==="
+echo "=== Assertion 4a: explicit override wins on the sealed path ==="
 # On the sealed path (no allowDevDefaults, empty offline `lookup`), an operator
 # `--set` that differs from the published default must be honored verbatim rather
 # than generated -- this proves the override branch sits ahead of generation.
@@ -196,7 +201,7 @@ assert_otlp_auth_agrees() {
   echo "  ok: $label OTel Basic auth agrees with the rendered project secret"
 }
 
-echo "=== Assertion 4: default OTel auth uses the resolved Langfuse project secret ==="
+echo "=== Assertion 4b: default OTel auth uses the resolved Langfuse project secret ==="
 assert_otlp_auth_agrees "$SEALED" "pk-lf-curie-dev" "sealed render"
 assert_otlp_auth_agrees "$OVERRIDE" "pk-lf-curie-dev" "credential override render"
 
@@ -682,7 +687,7 @@ helm template runner-api-render "$CHART" --namespace runner-api-namespace \
 python3 "$RUNNER_API_CHECK" "$RUNNER_API_OFF_OUT" absent \
   || fail "api.deploy=false did not remove the runner sandbox API egress allowance."
 
-echo "=== Assertion 12: api.githubToken is passed through, never generated (#1109, #1124) ==="
+echo "=== Assertion 12a: api.githubToken is passed through, never generated (#1109, #1124) ==="
 # The one OPTIONAL credential in this Secret. curie.managedSecret GENERATES when
 # the value equals its default, which for an optional token means 32 characters
 # of noise sent to GitHub as a bearer token, failing auth in a way that reads
@@ -728,7 +733,7 @@ for key in "${KEYS[@]}"; do
 done
 echo "  ok: githubToken is not in the generated-key list"
 
-echo "=== Assertion 12 negative control: routing githubToken through curie.managedSecret FAILS ==="
+echo "=== Assertion 12b negative control: routing githubToken through curie.managedSecret FAILS ==="
 # Mandatory, per Assertion 7's convention: an assert that has never been shown
 # failing is not a pin, and the three checks above all pass at base. Mutate a
 # TEMP COPY of the chart (never the real template) into exactly the #1109
@@ -754,7 +759,7 @@ if check_github_token_empty "$GHT_MUTANT_RENDER" "mutant (githubToken via curie.
 fi
 echo "  ok: a generated githubToken is rejected (the assert can fail)"
 
-echo "=== Assertion 12: worker API URL wiring (#1529) ==="
+echo "=== Assertion 12c: worker API URL wiring (#1529) ==="
 WORKER_API_CHECK="$TMP/check_worker_api_url.py"
 cat > "$WORKER_API_CHECK" <<'PYEOF'
 import sys

--- a/charts/curie/templates/NOTES.txt
+++ b/charts/curie/templates/NOTES.txt
@@ -152,7 +152,10 @@ When exposed as NodePort (`curie up` does this by default), Langfuse is reachabl
 The nodePort is pinned in values (langfuse.web.service.nodePort) so it survives a down/up cycle.
 {{- end }}
   # Dev project public key (headless-bootstrapped): {{ .Values.langfuse.init.projectPublicKey }}
-  # The project secret key is stored in the {{ include "curie.secretName" . }} Secret (key langfuseInitProjectSecretKey), not printed here.
+  # Retrieve the project secret key:
+  kubectl get secret {{ include "curie.secretName" . }} -n {{ .Release.Namespace }} -o jsonpath='{.data.langfuseInitProjectSecretKey}' | base64 -d; echo
+  # Retrieve the Langfuse admin password:
+  kubectl get secret {{ include "curie.secretName" . }} -n {{ .Release.Namespace }} -o jsonpath='{.data.langfuseInitUserPassword}' | base64 -d; echo
 
 App services send OTLP traces to the collector, NOT directly to Langfuse:
   {{ include "curie.fullname" . }}-otel-collector:{{ .Values.otelCollector.service.grpcPort }} (gRPC) / :{{ .Values.otelCollector.service.httpPort }} (HTTP)

--- a/charts/curie/templates/_helpers.tpl
+++ b/charts/curie/templates/_helpers.tpl
@@ -194,9 +194,8 @@ true
 {{- printf "%s-langfuse-web" (include "curie.fullname" .) -}}
 {{- end -}}
 
-{{/* base64("<publicKey>:<secretKey>") for the OTel Collector's Authorization
-     header. Uses the operator override when set, otherwise derives it from the
-     Langfuse init keys so the trace path authenticates with no manual step. */}}
+{{/* base64("<publicKey>:<secretKey>") for the OTel Collector config checksum.
+     The emitted Secret header is resolved in secrets.yaml. */}}
 {{- define "curie.otlpAuthHeader" -}}
 {{- if .Values.otelCollector.otlpAuthHeader -}}
 {{- .Values.otelCollector.otlpAuthHeader -}}
@@ -243,10 +242,9 @@ service:
 
 {{/* ---- Default-credential gate (issue #198) ----
      When security.checkDefaultCredentials is on, refuse to render if a Langfuse
-     bootstrap identity still carries the published dev default from values.yaml.
-     These init identities are included in the eleven managed chart credentials,
-     but this gate intentionally evaluates their raw values before managed secret
-     resolution. They seed the org/project on first boot (a different lifecycle).
+     chart input for a bootstrap identity still carries the published dev default
+     from values.yaml. This helper compares inputs before managed secret
+     resolution. These init identities seed the org/project on first boot.
      The published admin password is a Langfuse admin-takeover risk on a reachable
      UI, and the project secret key also feeds the OTel Collector auth header. The operator
      clears the gate by overriding the value or supplying langfuse.existingSecret
@@ -291,12 +289,12 @@ service:
           quoted `--set security.allowDevDefaults="false"` would otherwise read as
           truthy and ship the published default -- a fail-OPEN regression.
        2. Explicit override: if the operator/CLI supplied a value that differs from
-          the published default (`ne value default`), it WINS -- even on `helm
-          upgrade`. This is operator intent (a rotation, a recovery, a `--set`, or
-          an `existingSecret`-equivalent value), so it must beat the persisted
-          value; matches Bitnami's `providedPasswordValue`-first precedence. It
-          MUST sit ahead of the persist branch or an explicit rotation on
-          upgrade would be silently ignored.
+          the published default (`ne value default`), it wins even on `helm
+          upgrade`. For the nine non init credentials, this supports rotation or
+          recovery. The Langfuse init credentials are first boot inputs, so an
+          upgrade only changes the Secret; it does not rotate Langfuse records.
+          The override must sit ahead of the persist branch or an explicit value
+          on upgrade would be silently ignored.
        3. Persist existing: no override, so if a prior install already GENERATED
           this key, re-use it. `helm upgrade` must NEVER rotate a live store
           credential (Postgres would reject the new password against its persisted

--- a/charts/curie/templates/_helpers.tpl
+++ b/charts/curie/templates/_helpers.tpl
@@ -244,11 +244,11 @@ service:
 {{/* ---- Default-credential gate (issue #198) ----
      When security.checkDefaultCredentials is on, refuse to render if a Langfuse
      bootstrap identity still carries the published dev default from values.yaml.
-     Unlike the nine store/control-plane secrets, these init identities seed the
-     org/project on first boot (a different lifecycle), so #57 deliberately
-     excludes them from its render-time gate; this closes that gap. The published
-     admin password is a Langfuse admin-takeover risk on a reachable UI, and the
-     project secret key also feeds the OTel Collector auth header. The operator
+     These init identities are included in the eleven managed chart credentials,
+     but this gate intentionally evaluates their raw values before managed secret
+     resolution. They seed the org/project on first boot (a different lifecycle).
+     The published admin password is a Langfuse admin-takeover risk on a reachable
+     UI, and the project secret key also feeds the OTel Collector auth header. The operator
      clears the gate by overriding the value or supplying langfuse.existingSecret
      (the #169 secretKeyRef escape carries both keys).
 

--- a/charts/curie/templates/secrets.yaml
+++ b/charts/curie/templates/secrets.yaml
@@ -11,15 +11,15 @@ those (or supply an `existingSecret` per store) in any shared deployment.
 
 The eleven chart owned credentials (the four backing store passwords, the three
 Langfuse app secrets, both init credentials, and the api and webhook keys) are
-resolved through
-`curie.managedSecret` (issue #195): a sealed install GENERATES a strong random
-per release and `helm upgrade` re-uses the persisted value (never rotates a live
-store credential). An explicit override (a `--set`/values value that differs from
-the published default) WINS in every mode, install and upgrade, so rotation and
-recovery work; `security.allowDevDefaults=true` (values-dev.yaml) instead keeps
-the deterministic published value. The remaining keys below
-carry the published dev defaults documented in values.yaml; they are NOT
-production material. `stringData` lets Kubernetes base64-encode them.
+resolved through `curie.managedSecret` (issue #195). A sealed fresh install
+generates a strong random per release; `security.allowDevDefaults=true`
+(values-dev.yaml) instead keeps deterministic published values. The nine
+non init credentials re-use persisted values on upgrade, and an explicit
+override supports their rotation and recovery. The Langfuse init credentials
+are first boot inputs: changing them during an upgrade does not rotate records
+already initialized in Langfuse. The remaining keys below carry the published
+dev defaults documented in values.yaml; they are not production material.
+`stringData` lets Kubernetes base64 encode them.
 
 Render-time gate: refuse to emit the published Langfuse bootstrap defaults when
 security.checkDefaultCredentials is on (issue #198). This Secret always renders,
@@ -52,8 +52,8 @@ stringData:
   # Langfuse admin (init user) password, referenced by the Langfuse web
   # deployment via secretKeyRef instead of a plaintext env value.
   langfuseInitUserPassword: {{ $langfuseInitUserPassword | quote }}
-  # Full `Authorization` header value the OTel Collector sends to Langfuse
-  # (derived from the Langfuse init keys unless otelCollector.otlpAuthHeader set).
+  # Full `Authorization` header value the OTel Collector sends to Langfuse.
+  # With langfuse.existingSecret, set a matching otelCollector.otlpAuthHeader.
   otlpAuthHeader: {{ .Values.otelCollector.otlpAuthHeader | default (printf "Basic %s" (printf "%s:%s" .Values.langfuse.init.projectPublicKey $langfuseInitProjectSecretKey | b64enc)) | quote }}
   # Opaque model credential the worker forwards into runner claims (empty unless
   # a real-model deploy sets agentSandbox.runner.credentials).

--- a/charts/curie/templates/secrets.yaml
+++ b/charts/curie/templates/secrets.yaml
@@ -9,8 +9,9 @@ Secret unconditionally (they have no per-component existingSecret escape). So
 this object always renders, synthesized from the values defaults -- override
 those (or supply an `existingSecret` per store) in any shared deployment.
 
-The nine chart-owned credentials (the backing-store passwords, the Langfuse
-salt/encryptionKey/nextauthSecret, and the api/webhook keys) are resolved through
+The eleven chart owned credentials (the four backing store passwords, the three
+Langfuse app secrets, both init credentials, and the api and webhook keys) are
+resolved through
 `curie.managedSecret` (issue #195): a sealed install GENERATES a strong random
 per release and `helm upgrade` re-uses the persisted value (never rotates a live
 store credential). An explicit override (a `--set`/values value that differs from
@@ -26,6 +27,8 @@ so the guard runs on every install/upgrade/template.
 */}}
 {{- include "curie.checkDefaultCredentials" . }}
 {{- $existingSecret := (lookup "v1" "Secret" .Release.Namespace (include "curie.secretName" .)).data | default dict -}}
+{{- $langfuseInitProjectSecretKey := include "curie.managedSecret" (dict "root" . "key" "langfuseInitProjectSecretKey" "value" .Values.langfuse.init.projectSecretKey "default" "sk-lf-curie-dev" "hex" false "existingData" $existingSecret) -}}
+{{- $langfuseInitUserPassword := include "curie.managedSecret" (dict "root" . "key" "langfuseInitUserPassword" "value" .Values.langfuse.init.userPassword "default" "curie-dev-password" "hex" false "existingData" $existingSecret) -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -45,13 +48,13 @@ stringData:
   langfuseNextauthSecret: {{ include "curie.managedSecret" (dict "root" . "key" "langfuseNextauthSecret" "value" .Values.langfuse.nextauthSecret "default" "dev-nextauth-secret-change-me" "hex" false "existingData" $existingSecret) | quote }}
   # Init project secret key, read by the model-pricing seed Job as basic-auth
   # password against the Langfuse public API.
-  langfuseInitProjectSecretKey: {{ .Values.langfuse.init.projectSecretKey | quote }}
+  langfuseInitProjectSecretKey: {{ $langfuseInitProjectSecretKey | quote }}
   # Langfuse admin (init user) password, referenced by the Langfuse web
   # deployment via secretKeyRef instead of a plaintext env value.
-  langfuseInitUserPassword: {{ .Values.langfuse.init.userPassword | quote }}
+  langfuseInitUserPassword: {{ $langfuseInitUserPassword | quote }}
   # Full `Authorization` header value the OTel Collector sends to Langfuse
   # (derived from the Langfuse init keys unless otelCollector.otlpAuthHeader set).
-  otlpAuthHeader: {{ include "curie.otlpAuthHeader" . | quote }}
+  otlpAuthHeader: {{ .Values.otelCollector.otlpAuthHeader | default (printf "Basic %s" (printf "%s:%s" .Values.langfuse.init.projectPublicKey $langfuseInitProjectSecretKey | b64enc)) | quote }}
   # Opaque model credential the worker forwards into runner claims (empty unless
   # a real-model deploy sets agentSandbox.runner.credentials).
   agentCredentials: {{ .Values.agentSandbox.runner.credentials | quote }}

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -78,7 +78,8 @@ langfuse:
   nextauthSecret: dev-nextauth-secret-change-me
   existingSecret: ""
   # Headless bootstrap: seeds a fixed org/project + keys on first boot so the
-  # OTel trace path authenticates with no manual key-minting. Dev values.
+  # OTel trace path authenticates with no manual key-minting. The default OTel
+  # header derives from the resolved project secret key. Dev values.
   init:
     orgId: curie
     orgName: Curie
@@ -1377,14 +1378,16 @@ security:
   # langfuse.existingSecret (the secretKeyRef escape, keys langfuseInitProjectSecretKey
   # + langfuseInitUserPassword). Off by default so the flagship zero-secret bare
   # install stays green and the dev/e2e overlays render unchanged; flip it on for a
-  # shared/production cluster. (#57 will extend this same gate to the nine
-  # store/control-plane secrets once its design pass lands.)
+  # shared/production cluster. (#57 will extend this same gate to the remaining
+  # chart credentials once its design pass lands. This gate evaluates
+  # the raw values above, before managed secret resolution.)
   checkDefaultCredentials: false
   # Auto-generate per-release chart credentials (issue #195). Default false: a
-  # no-override `helm install` GENERATES a strong random per release for the nine
-  # chart-owned credentials (postgres, valkey, clickhouse, and RustFS secrets, the
-  # Langfuse salt/encryptionKey/nextauthSecret, and the api/webhook keys) instead
-  # of shipping the published dev defaults. Generated values are persisted via a
+  # no-override `helm install` GENERATES a strong random per release for the eleven
+  # chart-owned credentials (the backing-store passwords, the Langfuse
+  # salt/encryptionKey/nextauthSecret and init project secret key/user password,
+  # and the api/webhook keys) instead of shipping the published dev defaults.
+  # Generated values are persisted via a
   # `lookup` of the release Secret, so `helm upgrade` re-uses them and never
   # rotates a live store credential. Set true (values-dev.yaml does) for a
   # deterministic dev/CI render that keeps the published defaults byte-for-byte.

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -77,9 +77,10 @@ langfuse:
   salt: dev-salt-change-me
   nextauthSecret: dev-nextauth-secret-change-me
   existingSecret: ""
-  # Headless bootstrap: seeds a fixed org/project + keys on first boot so the
-  # OTel trace path authenticates with no manual key-minting. The default OTel
-  # header derives from the resolved project secret key. Dev values.
+  # Headless bootstrap seeds a fixed org/project on first boot. The project
+  # secret key and user password are first boot inputs. Fresh chart installs
+  # generate them unless development defaults are enabled; changing them during
+  # an upgrade does not rotate Langfuse records already initialized. Dev values.
   init:
     orgId: curie
     orgName: Curie
@@ -475,8 +476,9 @@ inference:
 otelCollector:
   deploy: true
   image: otel/opentelemetry-collector-contrib:0.119.0
-  # base64("<publicKey>:<secretKey>"). Left empty, it is derived from
-  # langfuse.init keys at render time.
+  # base64("<publicKey>:<secretKey>"). With chart managed init credentials,
+  # an empty value is derived from the resolved project key at render time. With
+  # langfuse.existingSecret, provide a matching explicit value.
   otlpAuthHeader: ""
   service:
     grpcPort: 4317
@@ -1374,26 +1376,24 @@ security:
   # langfuse.init.userPassword) still carries the published dev default from this
   # file -- the published admin password is a Langfuse admin-takeover risk on a
   # reachable UI, and the project secret key also feeds the OTel Collector auth
-  # header. Clear the gate by overriding those values or supplying
+  # header. The check compares chart inputs before managed secret resolution.
+  # Clear the gate by overriding those values or supplying
   # langfuse.existingSecret (the secretKeyRef escape, keys langfuseInitProjectSecretKey
   # + langfuseInitUserPassword). Off by default so the flagship zero-secret bare
   # install stays green and the dev/e2e overlays render unchanged; flip it on for a
   # shared/production cluster. (#57 will extend this same gate to the remaining
-  # chart credentials once its design pass lands. This gate evaluates
-  # the raw values above, before managed secret resolution.)
+  # chart credentials once its design pass lands.)
   checkDefaultCredentials: false
   # Auto-generate per-release chart credentials (issue #195). Default false: a
-  # no-override `helm install` GENERATES a strong random per release for the eleven
-  # chart-owned credentials (the backing-store passwords, the Langfuse
-  # salt/encryptionKey/nextauthSecret and init project secret key/user password,
-  # and the api/webhook keys) instead of shipping the published dev defaults.
-  # Generated values are persisted via a
-  # `lookup` of the release Secret, so `helm upgrade` re-uses them and never
-  # rotates a live store credential. Set true (values-dev.yaml does) for a
-  # deterministic dev/CI render that keeps the published defaults byte-for-byte.
-  # A per-store `existingSecret` and explicit `--set` overrides still win in every
-  # mode -- an override that differs from the published default beats the persisted
-  # value on install AND upgrade, so rotation/recovery works.
+  # no-override `helm install` generates strong random values for the eleven
+  # chart owned credentials: the backing store passwords, Langfuse
+  # salt/encryptionKey/nextauthSecret, the two init credentials, and the
+  # api/webhook keys. Set true (values-dev.yaml does) for a deterministic dev/CI
+  # render that keeps the published defaults byte-for-byte. The nine non init
+  # credentials persist via `lookup`, so `helm upgrade` re-uses them. Their
+  # explicit `--set` overrides and per store `existingSecret` values support
+  # rotation and recovery. The two Langfuse init credentials are first boot
+  # inputs: changing them during an upgrade does not rotate initialized records.
   # Caveat: generation relies on Helm `lookup`, which is empty under client-side
   # rendering. Driving this chart via `helm template | kubectl apply` or ArgoCD's
   # client-side Helm (no live API lookup) regenerates these values on every sync


### PR DESCRIPTION
Closes #1569

Randomizes the Langfuse init project secret and admin password through the existing managed Secret flow. Fresh installs keep OTel authentication aligned with the resolved project key, preserve generated values on upgrade, and retain deterministic development defaults.

Existing initialized releases still require Langfuse side rotation because changing first boot init values does not migrate stored credentials.