### PR TITLE
Catalog four undocumented swappable seams

### DIFF
--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -32,6 +32,7 @@ is documentation of where the code already draws the line, not a new abstraction
 | CLI output (agent-facing `--json`) | CLEAN | 39 outputs behind one trait | not separately graded | #456 | [CLI output (agent-facing `--json`)](interfaces/cli-output/INTERFACE.md) |
 | Harness package (declared contribution) | CLEAN | 1 (built-in Claude) behind the entry-point registry | not separately graded | #844 | [Harness package (declared contribution)](interfaces/harness-package/INTERFACE.md) |
 | Connector host (bundle-declared MCP servers) | CLEAN | 1 (Kubernetes) + in-memory fake | not separately graded | #1118, #1184 | [Connector host (bundle-declared MCP servers)](interfaces/connector-host/INTERFACE.md) |
+| Sealed credential (cluster-sealed connector secrets) | SOFT | 2 halves (Rust sealer, Python opener) over one frozen wire | not separately graded | #1240 | [Sealed credential (cluster-sealed connector secrets)](interfaces/sealed-credential/INTERFACE.md) |
 <!-- END GENERATED: seam-table -->
 
 ## Kind legend

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -31,7 +31,7 @@ is documentation of where the code already draws the line, not a new abstraction
 | Triggers | SOFT | 3 hardcoded (Slack, GH push, commit poll) | not separately graded | #29 | [Triggers](interfaces/triggers/INTERFACE.md) |
 | CLI output (agent-facing `--json`) | CLEAN | 39 outputs behind one trait | not separately graded | #456 | [CLI output (agent-facing `--json`)](interfaces/cli-output/INTERFACE.md) |
 | Harness package (declared contribution) | CLEAN | 1 (built-in Claude) behind the entry-point registry | not separately graded | #844 | [Harness package (declared contribution)](interfaces/harness-package/INTERFACE.md) |
-| Connector host (bundle-declared MCP servers) | CLEAN | 1 (Kubernetes) + in-memory fake | not separately graded | #1118, #1184 | [Connector host (bundle-declared MCP servers)](interfaces/connector-host/INTERFACE.md) |
+| Connector host (bundle-declared MCP servers) | CLEAN | 1 (Kubernetes) + in-memory fake | not separately graded | #1063, #1184 | [Connector host (bundle-declared MCP servers)](interfaces/connector-host/INTERFACE.md) |
 | Sealed credential (cluster-sealed connector secrets) | SOFT | 2 halves (Rust sealer, Python opener) over one frozen wire | not separately graded | #1240 | [Sealed credential (cluster-sealed connector secrets)](interfaces/sealed-credential/INTERFACE.md) |
 | Third-party port adapter (deployed service) | NONE | 0 (intended line recorded, nothing built) | not separately graded | #19, #158 | [Third-party port adapter (deployed service)](interfaces/port-adapter-service/INTERFACE.md) |
 <!-- END GENERATED: seam-table -->

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -31,6 +31,7 @@ is documentation of where the code already draws the line, not a new abstraction
 | Triggers | SOFT | 3 hardcoded (Slack, GH push, commit poll) | not separately graded | #29 | [Triggers](interfaces/triggers/INTERFACE.md) |
 | CLI output (agent-facing `--json`) | CLEAN | 39 outputs behind one trait | not separately graded | #456 | [CLI output (agent-facing `--json`)](interfaces/cli-output/INTERFACE.md) |
 | Harness package (declared contribution) | CLEAN | 1 (built-in Claude) behind the entry-point registry | not separately graded | #844 | [Harness package (declared contribution)](interfaces/harness-package/INTERFACE.md) |
+| Connector host (bundle-declared MCP servers) | CLEAN | 1 (Kubernetes) + in-memory fake | not separately graded | #1118, #1184 | [Connector host (bundle-declared MCP servers)](interfaces/connector-host/INTERFACE.md) |
 <!-- END GENERATED: seam-table -->
 
 ## Kind legend

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -33,6 +33,7 @@ is documentation of where the code already draws the line, not a new abstraction
 | Harness package (declared contribution) | CLEAN | 1 (built-in Claude) behind the entry-point registry | not separately graded | #844 | [Harness package (declared contribution)](interfaces/harness-package/INTERFACE.md) |
 | Connector host (bundle-declared MCP servers) | CLEAN | 1 (Kubernetes) + in-memory fake | not separately graded | #1118, #1184 | [Connector host (bundle-declared MCP servers)](interfaces/connector-host/INTERFACE.md) |
 | Sealed credential (cluster-sealed connector secrets) | SOFT | 2 halves (Rust sealer, Python opener) over one frozen wire | not separately graded | #1240 | [Sealed credential (cluster-sealed connector secrets)](interfaces/sealed-credential/INTERFACE.md) |
+| Third-party port adapter (deployed service) | NONE | 0 (intended line recorded, nothing built) | not separately graded | #19, #158 | [Third-party port adapter (deployed service)](interfaces/port-adapter-service/INTERFACE.md) |
 <!-- END GENERATED: seam-table -->
 
 ## Kind legend

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -30,6 +30,7 @@ is documentation of where the code already draws the line, not a new abstraction
 | Conversation history | CLEAN | 1 loader (StateApiTranscriptStore) | not separately graded | #20 | [Conversation history](interfaces/conversation-history/INTERFACE.md) |
 | Triggers | SOFT | 3 hardcoded (Slack, GH push, commit poll) | not separately graded | #29 | [Triggers](interfaces/triggers/INTERFACE.md) |
 | CLI output (agent-facing `--json`) | CLEAN | 39 outputs behind one trait | not separately graded | #456 | [CLI output (agent-facing `--json`)](interfaces/cli-output/INTERFACE.md) |
+| Harness package (declared contribution) | CLEAN | 1 (built-in Claude) behind the entry-point registry | not separately graded | #844 | [Harness package (declared contribution)](interfaces/harness-package/INTERFACE.md) |
 <!-- END GENERATED: seam-table -->
 
 ## Kind legend

--- a/docs/interfaces/connector-host/INTERFACE.md
+++ b/docs/interfaces/connector-host/INTERFACE.md
@@ -4,7 +4,7 @@ kind: CLEAN
 impls: 1 (Kubernetes) + in-memory fake
 grade: not separately graded
 epics:
-  - "#1118"
+  - "#1063"
   - "#1184"
 order: 20
 ---
@@ -179,6 +179,18 @@ The port is a real `Protocol`, and the values crossing it are Kubernetes:
   that prunes another agent's connectors. None of that is expressible in the three
   method signatures, so a host without those semantics satisfies the `Protocol`
   and still behaves differently.
+- **There are two appliers, only one of them behind the port, and they
+  disagree.** The CLI applies the same rendered objects on the `cluster deploy`
+  path (`cli/src/connectors.rs`) with a plain client-side `kubectl apply`, prunes
+  in one bulk labelled delete, mints and deletes the owned Secret, and stamps no
+  drift hash; the reconciler server-side applies, prunes one object at a time,
+  never touches that Secret, and stamps a hash on every apply — so a
+  CLI-created object reads as drift and is adopted on the reconciler's first
+  pass. The ownership label that decides what gets deleted is also two
+  hand-maintained copies of one string, `OWNER_LABEL`
+  (`apps/worker/src/curie_worker/connector_reconcile.py::OWNER_LABEL`) and a Rust
+  constant in `cli/src/connectors.rs`, with no codegen or drift gate tying them
+  together the way the ACI contract is tied.
 - **The port's own docstring miscounts itself.** `ConnectorClient` is introduced
   as "deliberately four verbs" while declaring three; the cluster module states
   the true shape, four object kinds and three verbs. A second implementer reading
@@ -189,6 +201,6 @@ The port is a real `Protocol`, and the values crossing it are Kubernetes:
 - **Related seam:** [substrate](../substrate/INTERFACE.md) — `SandboxClient` is the other Kubernetes-behind-a-Protocol seam, and it is the discipline this one copies; it covers the runner runtime, not connector workloads.
 - **Related seam:** [bundle-format](../bundle-format/INTERFACE.md) — `connectors.yaml` is an additive, platform-facing declaration in the bundle; declaring intent is a bundle's job, being the platform's implementation is not.
 - **Related seam:** [sealed-credential](../sealed-credential/INTERFACE.md) — the third credential holder shape a connector spec can declare.
-- **Epic(s):** #1118 — hosted connectors declared by a bundle; #1184 — the in-cluster connector reconciler and its RBAC
+- **Epic(s):** #1063 — bundles declare connectors and the platform derives the objects; #1184 — the in-cluster connector reconciler and its RBAC
 - **Vision doc:** [architecture-vision.md](../../architecture-vision.md) — connector hosting is not one of the six swap-readiness Jobs; not separately graded
 - **ADR(s):** [ADR-0086](../../adr/0086-bundles-declare-connectors-the-platform-hosts-them.md) — bundles declare connectors, the platform hosts them; [ADR-0087](../../adr/0087-the-api-renders-connector-objects-the-cli-applies-them.md) — the API renders connector objects and never applies them; [ADR-0090](../../adr/0090-a-reconciler-applies-connectors-so-agent-repos-need-no-cli.md) — a reconciler applies them, so agent repos need no CLI; [ADR-0009](../../adr/0009-per-agent-connector-auth.md) — per-agent secrets and connector credentials

--- a/docs/interfaces/connector-host/INTERFACE.md
+++ b/docs/interfaces/connector-host/INTERFACE.md
@@ -1,0 +1,194 @@
+---
+seam: Connector host (bundle-declared MCP servers)
+kind: CLEAN
+impls: 1 (Kubernetes) + in-memory fake
+grade: not separately graded
+epics:
+  - "#1118"
+  - "#1184"
+order: 20
+---
+# INTERFACE: Connector host (bundle-declared MCP servers)
+
+> Part of the Curie swappable-seam catalog — see the [seam index](../../interfaces.md).
+<!-- BEGIN GENERATED: header (curie dev docs-lint) -->
+> **Kind:** CLEAN &nbsp;·&nbsp; **Implementations today:** 1 (Kubernetes) + in-memory fake &nbsp;·&nbsp; **Swap-readiness grade:** not separately graded
+<!-- END GENERATED: header -->
+
+**Kind legend:** CLEAN = a real `Protocol`/typed port class · SOFT = swap via env/URL/prefix/wire, no code interface · NONE = not built yet.
+
+## The black line
+
+A bundle **declares** the MCP servers an agent needs; the platform **hosts**
+them (ADR-0086). The author writes intent in `connectors.yaml` and never writes
+a Deployment, a Service, a Secret reference, container hardening or a
+NetworkPolicy again. Under ADR-0087 the API renders those objects but never
+applies them, and under ADR-0090 an in-cluster reconciler applies them so an
+agent repository needs no CLI and no `kubectl`-capable operator standing next to
+the cluster.
+
+The swappable thing is the **workload host**: the half that mutates sits behind
+the `ConnectorClient` `Protocol`, and a second implementation substitutes Docker
+or compose for Kubernetes behind the same verbs. The decision half — what to
+create, what to prune, what has drifted — stays opinionated core and never
+imports the cluster module, which is exactly what lets the dangerous logic be
+tested against an in-memory fake. A second, narrower port sits beside it:
+`ManifestSource`, where the rendered objects come from, so the reconcile step is
+testable without an API.
+
+Two orderings and one refusal are load-bearing above the line and a second host
+inherits all three: apply before delete, so a part-way failure leaves inert
+extra objects rather than a missing Deployment; delete one at a time, continuing
+past failures, so one undeletable object cannot strand the rest as orphans; and
+refuse to act on any object not carrying this agent's owner label.
+
+## Current contract
+
+A second host implements `ConnectorClient`
+(`apps/worker/src/curie_worker/connector_apply.py::ConnectorClient`). It is
+deliberately narrow — a wider seam invites the reconciler to grow cluster access
+it does not need, and the RBAC behind it is scoped to exactly the object kinds a
+connector consists of. Three methods:
+
+- `list_owned(namespace, owner) -> list[dict[str, Any]]`
+  (`apps/worker/src/curie_worker/connector_apply.py::ConnectorClient.list_owned`)
+  — every connector object labelled for this owner. Each returned object **must**
+  carry `kind` and `metadata.name`, because ownership and every prune decision is
+  keyed on that pair by `identity`
+  (`apps/worker/src/curie_worker/connector_reconcile.py::identity`).
+- `apply(namespace, obj) -> None`
+  (`apps/worker/src/curie_worker/connector_apply.py::ConnectorClient.apply`) —
+  create or update one object.
+- `delete(namespace, kind, name) -> None`
+  (`apps/worker/src/curie_worker/connector_apply.py::ConnectorClient.delete`) —
+  remove one object; missing is success, not an error.
+
+The driver is `execute`
+(`apps/worker/src/curie_worker/connector_apply.py::execute`), which consumes a
+`ReconcilePlan`
+(`apps/worker/src/curie_worker/connector_reconcile.py::ReconcilePlan`) built by
+`plan` (`apps/worker/src/curie_worker/connector_reconcile.py::plan`) and returns
+an `ApplyReport`
+(`apps/worker/src/curie_worker/connector_apply.py::ApplyReport`). Ownership is
+the label `OWNER_LABEL`
+(`apps/worker/src/curie_worker/connector_reconcile.py::OWNER_LABEL`), and drift
+is detected against a hash stamped in `HASH_ANNOTATION`
+(`apps/worker/src/curie_worker/connector_reconcile.py::HASH_ANNOTATION`) by
+`stamp_hash`
+(`apps/worker/src/curie_worker/connector_reconcile.py::stamp_hash`), with
+`owner_of` (`apps/worker/src/curie_worker/connector_reconcile.py::owner_of`) the
+single ownership reader.
+
+Where the desired objects come from is the second port, `ManifestSource`
+(`apps/worker/src/curie_worker/connector_agent.py::ManifestSource`); one agent's
+pass is `reconcile_agent`
+(`apps/worker/src/curie_worker/connector_agent.py::reconcile_agent`), and the
+owner label is stamped by `own`
+(`apps/worker/src/curie_worker/connector_agent.py::own`).
+
+The declaration side is frozen in the bundle format: `CONNECTORS_FILE`
+(`packages/plugin-format/src/plugin_format/connectors.py::CONNECTORS_FILE`) is
+`connectors.yaml`, parsed into `ConnectorsFile`
+(`packages/plugin-format/src/plugin_format/connectors.py::ConnectorsFile`), a
+mapping of name to `ConnectorSpec`
+(`packages/plugin-format/src/plugin_format/connectors.py::ConnectorSpec`). A spec
+is one of two forms, hosted (`image`) or remote (`url`), and unlike the rest of
+that package it forbids unknown keys: `connectors.yaml` is Curie's own file with
+no external producer, so an unrecognised key is a typo rather than a Claude Code
+extension to tolerate. Credentials are declared by **name** in three holder
+shapes — resolved by Curie, referenced out of band via `SecretRef`
+(`packages/plugin-format/src/plugin_format/connectors.py::SecretRef`), or carried
+sealed by the bundle (see [sealed-credential](../sealed-credential/INTERFACE.md)).
+
+Rendering is a pure function outside the port entirely: `render`
+(`packages/plugin-format/src/plugin_format/connector_render.py::render`), driven
+by the API through `render_connector_manifests`
+(`apps/api/src/curie_api/bundles.py::render_connector_manifests`) and served at
+the version subresource `read_version_connectors`
+(`apps/api/src/curie_api/routers/agents.py::read_version_connectors`), with
+`read_connectors` (`apps/api/src/curie_api/bundles.py::read_connectors`) parsing
+the file and `connector_mcp_entries`
+(`apps/api/src/curie_api/bundles.py::connector_mcp_entries`) deriving the
+`.mcp.json` the sandbox dials.
+
+The reconciler is off by default. `WorkerConfig`
+(`apps/worker/src/curie_worker/config.py::WorkerConfig`) reads
+`CURIE_CONNECTOR_RECONCILE` (default false), `CURIE_CONNECTOR_RECONCILE_INTERVAL_S`
+(default 60 seconds) and `CURIE_CONNECTOR_APP_NAME`, and reuses `CURIE_RELEASE`
+and `CURIE_NAMESPACE`, which must agree with the values the runner's connector
+scope is built from — the runner dials a Service by the name they produce and
+the reconciler creates the Service by the same name. Enabling the flag is what
+makes the chart grant the worker create, patch and delete on the connector
+object kinds, so a worker that is not reconciling does not hold that grant.
+
+## Implementations today
+
+One production host plus a fake:
+
+- **Kubernetes:** `KubernetesConnectorClient`
+  (`apps/worker/src/curie_worker/connector_k8s.py::KubernetesConnectorClient`),
+  in-cluster or kubeconfig auth. Everything Kubernetes-shaped in the reconciler
+  stops in that module. Writes are **server-side applies** with `force=True`
+  under a stable field manager, `FIELD_MANAGER`
+  (`apps/worker/src/curie_worker/connector_k8s.py::FIELD_MANAGER`): not
+  create-then-replace, because a rendered Service declares no `clusterIP` and
+  replacing a live one without it is rejected outright, and because server-side
+  apply can remove a field we previously set and no longer declare, which a merge
+  patch cannot express. `force=True` is what makes a hand-edited field come back,
+  which is the drift correction ADR-0090 asks for. The object kinds are
+  `CONNECTOR_KINDS`
+  (`apps/worker/src/curie_worker/connector_k8s.py::CONNECTOR_KINDS`) — Deployment,
+  Service, Secret and NetworkPolicy — and anything else raises `UnsupportedKind`
+  (`apps/worker/src/curie_worker/connector_k8s.py::UnsupportedKind`).
+- **Fake:** an in-memory client in `apps/worker/tests/reconcile/test_connector_apply.py`,
+  which is what lets the half that can delete a live connector be tested without
+  a cluster. There is no second production host.
+
+The loop that drives it is `ConnectorReconcileLoop`
+(`apps/worker/src/curie_worker/connector_loop.py::ConnectorReconcileLoop`) over
+`HttpManifestSource`
+(`apps/worker/src/curie_worker/connector_loop.py::HttpManifestSource`), which is
+the `ManifestSource` implementation that fetches rendered objects from the API.
+
+## Known leakage
+
+The port is a real `Protocol`, and the values crossing it are Kubernetes:
+
+- **The exchanged type is raw cluster wire JSON.** Every verb trades
+  `dict[str, Any]` holding `kind`, `apiVersion` and `metadata`, and reads come
+  back as unparsed JSON on purpose — the rest of the reconciler compares against
+  what the API rendered, which is camelCase, and the generated typed models would
+  hand back snake_case attributes and quietly compare unequal on every field. A
+  Docker or compose host would have to synthesize Kubernetes-shaped dictionaries
+  to satisfy a port that never mentions Kubernetes in its own signatures.
+- **Rendering is Kubernetes-specific and sits outside the port.** `render`
+  (`packages/plugin-format/src/plugin_format/connector_render.py::render`) emits a
+  Deployment, a Service and two NetworkPolicies, and it runs in the API, not
+  behind `ConnectorClient`. Swapping the host therefore swaps only the applier;
+  the second host needs a second renderer too, and no port covers that half.
+- **There is no selector.** Unlike the substrate seam's `CURIE_SANDBOX_SUBSTRATE`,
+  nothing chooses a connector host at runtime: `_build_connector_loop`
+  (`apps/worker/src/curie_worker/run.py::_build_connector_loop`) imports and
+  constructs `KubernetesConnectorClient` directly. The flag that exists switches
+  the reconciler on and off, not which host it drives, so a second implementation
+  starts by editing the composition root.
+- **Server-side-apply semantics are assumed, not stated.** Drift correction
+  depends on field-manager ownership and on apply being able to remove an
+  undeclared field; prune depends on server-side label selection, applied by the
+  API server rather than client-side because a filter that can be forgotten is one
+  that prunes another agent's connectors. None of that is expressible in the three
+  method signatures, so a host without those semantics satisfies the `Protocol`
+  and still behaves differently.
+- **The port's own docstring miscounts itself.** `ConnectorClient` is introduced
+  as "deliberately four verbs" while declaring three; the cluster module states
+  the true shape, four object kinds and three verbs. A second implementer reading
+  the port first will look for a fourth method that was never there.
+
+## Cross-links
+
+- **Related seam:** [substrate](../substrate/INTERFACE.md) — `SandboxClient` is the other Kubernetes-behind-a-Protocol seam, and it is the discipline this one copies; it covers the runner runtime, not connector workloads.
+- **Related seam:** [bundle-format](../bundle-format/INTERFACE.md) — `connectors.yaml` is an additive, platform-facing declaration in the bundle; declaring intent is a bundle's job, being the platform's implementation is not.
+- **Related seam:** [sealed-credential](../sealed-credential/INTERFACE.md) — the third credential holder shape a connector spec can declare.
+- **Epic(s):** #1118 — hosted connectors declared by a bundle; #1184 — the in-cluster connector reconciler and its RBAC
+- **Vision doc:** [architecture-vision.md](../../architecture-vision.md) — connector hosting is not one of the six swap-readiness Jobs; not separately graded
+- **ADR(s):** [ADR-0086](../../adr/0086-bundles-declare-connectors-the-platform-hosts-them.md) — bundles declare connectors, the platform hosts them; [ADR-0087](../../adr/0087-the-api-renders-connector-objects-the-cli-applies-them.md) — the API renders connector objects and never applies them; [ADR-0090](../../adr/0090-a-reconciler-applies-connectors-so-agent-repos-need-no-cli.md) — a reconciler applies them, so agent repos need no CLI; [ADR-0009](../../adr/0009-per-agent-connector-auth.md) — per-agent secrets and connector credentials

--- a/docs/interfaces/harness-package/INTERFACE.md
+++ b/docs/interfaces/harness-package/INTERFACE.md
@@ -1,0 +1,187 @@
+---
+seam: Harness package (declared contribution)
+kind: CLEAN
+impls: 1 (built-in Claude) behind the entry-point registry
+grade: not separately graded
+epics:
+  - "#844"
+order: 19
+---
+# INTERFACE: Harness package (declared contribution)
+
+> Part of the Curie swappable-seam catalog — see the [seam index](../../interfaces.md).
+<!-- BEGIN GENERATED: header (curie dev docs-lint) -->
+> **Kind:** CLEAN &nbsp;·&nbsp; **Implementations today:** 1 (built-in Claude) behind the entry-point registry &nbsp;·&nbsp; **Swap-readiness grade:** not separately graded
+<!-- END GENERATED: header -->
+
+**Kind legend:** CLEAN = a real `Protocol`/typed port class · SOFT = swap via env/URL/prefix/wire, no code interface · NONE = not built yet.
+
+## The black line
+
+This is the layer **above** the in-process session port. Where
+[`harness-modelsession`](../harness-modelsession/INTERFACE.md) draws the line at
+one object the runner talks to during a turn, this seam draws it at the **unit
+of distribution**: under ADR-0060 a harness is an installable Python package
+that declares one contribution manifest, discovered through a setuptools entry
+point group and selected by name at runtime. Identity, aliases and labels, the
+install spec, the auth spec, the declared read-only tool set, the model-override
+env keys, the per-spawn environment builder and the bundle compile hook stop
+being nine files of implicit core knowledge and become fields somebody wrote
+down on purpose.
+
+The two lines are swapped independently, which is why they are two files: a
+harness package supplies the manifest, and the manifest's consumers may or may
+not go on to construct a `ModelSession`. What stays opinionated core is
+everything the manifest is fed into — the ACI wire the runner serves, the
+session runner, the side-effect classifier.
+
+Discovery is deliberately **fail-closed**. A malformed, colliding, or
+name-squatting registration raises rather than being skipped, because an
+ambiguous registry is worse than a missing harness and silently shadowing the
+built-in Claude harness is the single worst failure this registry could have.
+
+## Current contract
+
+A third party ships a package declaring an entry point in the group
+`ENTRY_POINT_GROUP` (`runner/src/curie_runner/harness/registry.py::ENTRY_POINT_GROUP`),
+whose value is `"curie.harness"`. The entry point resolves to a zero-argument
+callable returning a `HarnessContribution`
+(`runner/src/curie_runner/harness/contribution.py::HarnessContribution`), a
+frozen dataclass whose ten fields are, in declaration order: `name`, `image`,
+`install`, `auth`, `readonly_tools`, `model_override_env_keys`,
+`build_spawn_env`, `compile_bundle`, `aliases`, `labels`. It declares **no
+methods**; the two behavioral hooks are callable fields, which is the whole
+code surface a third party writes.
+
+Three supporting types travel with it, all frozen dataclasses in the same
+module: `InstallSpec`
+(`runner/src/curie_runner/harness/contribution.py::InstallSpec`) names what the
+image must install; `AuthSpec`
+(`runner/src/curie_runner/harness/contribution.py::AuthSpec`) names the
+credential env keys and OAuth token prefix the engine accepts; and
+`BundleCompileResult`
+(`runner/src/curie_runner/harness/contribution.py::BundleCompileResult`) is what
+`compile_bundle` returns, a mounted bundle translated into that harness's native
+session config.
+
+The registry exposes exactly two functions and no `register`, because
+registration is packaging metadata rather than a call:
+
+- `discover_contributions`
+  (`runner/src/curie_runner/harness/registry.py::discover_contributions`) reads
+  `importlib.metadata` entry points for the group and returns every contribution
+  keyed by its declared name **and** each of its aliases. Nothing is cached; the
+  scan repeats per call unless the caller passes a prepared mapping.
+- `resolve_harness`
+  (`runner/src/curie_runner/harness/registry.py::resolve_harness`) looks a name
+  up in that mapping and raises `UnknownHarnessError`
+  (`runner/src/curie_runner/harness/registry.py::UnknownHarnessError`) on a miss.
+
+Four guard rules are fail-closed, and the first two run against entry-point
+**metadata before the object is loaded** while the last two run against the keys
+the loaded contribution actually claims:
+
+- a flat, top-level package path is refused — `FlatHarnessPackageError`
+  (`runner/src/curie_runner/harness/registry.py::FlatHarnessPackageError`);
+- a built-in name claimed from any other path is refused —
+  `HarnessNameCollisionError`
+  (`runner/src/curie_runner/harness/registry.py::HarnessNameCollisionError`),
+  checked against `BUILTIN_HARNESS_CANONICAL_PATHS`
+  (`runner/src/curie_runner/harness/registry.py::BUILTIN_HARNESS_CANONICAL_PATHS`),
+  which reserves `claude`, `claude-sdk` and `claude-code` for one canonical path;
+- a non-`str` key is refused — `MalformedHarnessContributionError`
+  (`runner/src/curie_runner/harness/registry.py::MalformedHarnessContributionError`).
+  The check is an exact `type(key) is not str` rather than `isinstance`,
+  because a `str` subclass can override equality and hashing and so still steer
+  the dict lookups below it;
+- two contributions claiming one key collide, again `HarnessNameCollisionError`.
+
+Selection is a runner-local env read, not a boot-env contract key:
+`RunnerConfig.from_env`
+(`runner/src/curie_runner/config.py::RunnerConfig.from_env`) reads
+`CURIE_HARNESS`, and an empty or unset value selects `DEFAULT_HARNESS`
+(`runner/src/curie_runner/harness/registry.py::DEFAULT_HARNESS`), which is
+`"claude"`. The default name is declared once, in the registry rather than the
+config, so the runner config and the boot path share it. The resolved name is
+carried on `RunnerConfig`
+(`runner/src/curie_runner/config.py::RunnerConfig`).
+
+## Implementations today
+
+One, plus test-only synthetics. `runner/pyproject.toml` declares the single
+in-tree entry point, `claude`, pointing at `get_contribution`
+(`runner/src/curie_runner/harness/claude.py::get_contribution`), which returns
+`CLAUDE_CONTRIBUTION`
+(`runner/src/curie_runner/harness/claude.py::CLAUDE_CONTRIBUTION`). That module
+adds no behavior of its own by design: it names what already existed so a second
+harness has something to register alongside. No other `pyproject.toml` in the
+workspace declares the group, and there is no fake harness *package* — the
+`ModelSession`-level fake belongs to the sibling seam, and synthetic
+contributions exist only inside `runner/tests/test_harness_registry.py`.
+
+The manifest is consumed in exactly one module, the runner's boot path
+(`runner/src/curie_runner/__main__.py`). `_resolve_harness`
+(`runner/src/curie_runner/__main__.py::_resolve_harness`) turns a name into a
+contribution, `main` (`runner/src/curie_runner/__main__.py::main`) calls
+`build_spawn_env`, and `build_runner`
+(`runner/src/curie_runner/__main__.py::build_runner`) calls `compile_bundle` and
+feeds `readonly_tools` to `SideEffectClassifier`
+(`runner/src/curie_runner/side_effects.py::SideEffectClassifier`).
+
+The gate a registration must survive today is the import-linter contract set in
+the root `pyproject.toml`, run as `uv run lint-imports` in
+`.github/workflows/ci.yaml`. One of its three contracts guards this seam
+specifically, forbidding `claude_agent_sdk` inside
+`runner/src/curie_runner/harness/contribution.py` and
+`runner/src/curie_runner/harness/registry.py` while deliberately exempting
+`runner/src/curie_runner/harness/claude.py`, which is the Claude harness itself.
+The registry's own behavior is pinned by `runner/tests/test_harness_registry.py`,
+`runner/tests/test_harness_contribution.py` and
+`runner/tests/test_harness_boot_wiring.py`.
+
+## Known leakage
+
+The registry is CLEAN as a discovery mechanism, and it is a guarded indirection
+around one contribution rather than a working plugin distribution channel. Four
+concrete gaps:
+
+- **Most of the manifest has no reader.** `image`, `install`, `auth` and
+  `model_override_env_keys` are declared and consumed by nothing in production;
+  `labels` has no reader anywhere, tests included. Only `build_spawn_env`,
+  `compile_bundle` and `readonly_tools` are load-bearing, plus `name`/`aliases`
+  inside the registry. A second harness that fills the other fields correctly
+  changes no behavior.
+- **The facts the manifest declares are still hardcoded elsewhere, in two
+  languages.** The runner image name is a Rust constant (`cli/src/docker.rs`) and
+  a Python default inside `_sandbox_client`
+  (`apps/worker/src/curie_worker/run.py::_sandbox_client`), neither of which
+  reads `HarnessContribution.image`. The credential mirror that ADR-0060 cited as
+  its motivating duplication is still hand-copied in the Docker substrate
+  (`apps/worker/src/curie_worker/sandbox/docker.py`) rather than read off
+  `AuthSpec`.
+- **Nothing can set `CURIE_HARNESS`.** It is explicitly a runner-local knob and
+  not a boot-env key, and the boot-env gate's own allowlist records that
+  (`apps/worker/tests/binding/test_boot_env_single_declaration.py`). No chart
+  template, compose file, worker binding or CLI flag writes it, so selecting a
+  non-default harness today means hand-setting container env. ADR-0060 decision 3
+  asked for a declarative `harness:` field plus a CLI flag; neither exists.
+- **A built-in name never goes through discovery at all, and a third party
+  cannot install without rebuilding the image.** `_resolve_harness` short-circuits
+  any name in `BUILTIN_HARNESS_CANONICAL_PATHS` to a direct import so a broken
+  sibling entry point cannot take the Claude harness down (#865) — which also
+  means packaging metadata is never consulted on the default path. Meanwhile
+  `importlib.metadata` only sees distributions installed into the runner image's
+  sealed virtualenv (`runner/Dockerfile`), and that rootfs is read-only at
+  runtime, so a runtime install is not merely unwired but impossible. The
+  mechanism buys declaration, not deployment: the distribution story is a derived
+  image, and `InstallSpec.packages`, which exists to describe exactly that, is
+  read by nobody.
+
+## Cross-links
+
+- **Sibling seam:** [harness-modelsession](../harness-modelsession/INTERFACE.md) — the in-process `ModelSession` port this layer sits above; it covers the turn-time object, this file covers the package and its discovery.
+- **Sibling seam:** [aci-producer](../aci-producer/INTERFACE.md) — the frozen cross-process wire. The contribution manifest is deliberately **not** an `aci-protocol` frozen contract type; freezing it is a later choice once a second harness has exercised it.
+- **Related seam:** [port-adapter-service](../port-adapter-service/INTERFACE.md) — ADR-0096 generalizes this mechanism, and reserves in-process entry-point groups for the narrow ports that cannot cross a process boundary.
+- **Epic(s):** #844 — implement the package-shaped harness redesign (ADR-0060/0061/0062)
+- **Vision doc:** [architecture-vision.md](../../architecture-vision.md) — the declared-package layer sits above the session port; not one of the six swap-readiness Jobs, so not separately graded
+- **ADR(s):** [ADR-0060](../../adr/0060-the-harness-is-a-declared-package.md) — the unit of a harness is an installable package declaring a contribution manifest, registered by entry point with fail-closed guard rules; [ADR-0062](../../adr/0062-harness-conformance-has-teeth.md) — a registry proves an object loaded, a conformance kit proves it behaves; the import-linter contracts are the part realized so far

--- a/docs/interfaces/port-adapter-service/INTERFACE.md
+++ b/docs/interfaces/port-adapter-service/INTERFACE.md
@@ -1,0 +1,169 @@
+---
+seam: Third-party port adapter (deployed service)
+kind: NONE
+impls: 0 (intended line recorded, nothing built)
+grade: not separately graded
+epics:
+  - "#19"
+  - "#158"
+order: 22
+---
+# INTERFACE: Third-party port adapter (deployed service)
+
+> Part of the Curie swappable-seam catalog — see the [seam index](../../interfaces.md).
+<!-- BEGIN GENERATED: header (curie dev docs-lint) -->
+> **Kind:** NONE &nbsp;·&nbsp; **Implementations today:** 0 (intended line recorded, nothing built) &nbsp;·&nbsp; **Swap-readiness grade:** not separately graded
+<!-- END GENERATED: header -->
+
+**Kind legend:** CLEAN = a real `Protocol`/typed port class · SOFT = swap via env/URL/prefix/wire, no code interface · NONE = not built yet.
+
+## The black line
+
+Every other file in this catalog answers "where does the code already draw a
+line for *this* seam". This one answers the question that sits above all of
+them, and that ADR-0096 settles: **where does a third party put its code so the
+platform uses it instead of the default?**
+
+The answer is a **deployed service**, not a loaded plugin. A third-party
+platform adapter speaks the port's versioned wire contract and is selected by
+composition — chart values, compose, or endpoint config — rather than by runtime
+code loading. Four reasons, in the ADR's order of weight: it is language-neutral,
+so an internal-tools team writes its adapter in the stack its tool already lives
+in rather than being conscripted into Python; its blast radius is a process, so a
+crash or a hang in third-party code is a failed dependency rather than a wedged
+worker; it is independently upgradable behind a versioned wire; and it is what
+the system already does everywhere a second implementation exists, so it adds no
+new operational concept.
+
+The line this file records is therefore a **placement constraint**, and nothing
+implements it yet. That is what NONE is for.
+
+## Current contract
+
+There is no contract to conform to yet. What a first implementation must honor,
+taken from ADR-0096 rather than invented here:
+
+- **Two plugin kinds that do not merge.** An *agent bundle* extends one agent, is
+  the Claude plugin shape verbatim, runs inside the sandbox trust domain, and
+  versions with the agent. A *platform adapter* implements a platform port, runs
+  in the platform trust domain, holds platform-adjacent credentials, and versions
+  with the deployment. A request to plug in a new channel, store or harness is
+  never answered by the bundle format. The rule is narrow and sharp: a bundle's
+  files never execute as platform code, while declaring an implementation for the
+  platform to host is allowed and already shipped — see
+  [connector-host](../connector-host/INTERFACE.md), which is that same
+  declare-and-host split one scope down, agent-scoped instead of
+  deployment-scoped.
+- **The wire is HTTP or a queue payload.** A bespoke RPC plugin protocol was
+  rejected because the platform already composes over contracts that are
+  versioned, drift-gated and understood by every lane; revisit only if a port's
+  contract genuinely cannot be expressed that way, which none currently is.
+- **A four-rung promotion ladder before a port is pluggable.** An `INTERFACE.md`
+  documents where the code already draws the line; a contract package makes the
+  line a schema, as `packages/aci-protocol` and `packages/channel-protocol`
+  already do; a conformance suite is something a third party runs against its own
+  adapter before it ever talks to us; and the port owes an entry in an adapter
+  manifest schema naming the config, secrets and endpoints an implementation
+  declares. Without that fourth rung a third party can be conformant and still
+  not installable, which counts as an unfinished promotion rather than a finished
+  one. A registry proves an object was loaded; a conformance kit proves it
+  behaves.
+- **Credential rules, which are the trust boundary.** An adapter is a rendering
+  and transport contract, never a trust boundary: approvals resolve solely
+  through the API authorizer, and an adapter's report of who clicked is input
+  rather than authority. An adapter holds its own channel credentials and never
+  the platform's model credentials, and **a reply endpoint never receives any
+  credential other than its own**, so per-endpoint authentication is part of the
+  egress contract a promoted port publishes rather than something bolted on later.
+- **Ingress is the authenticated hook surface, never the broker.** A third-party
+  adapter enqueues nothing directly: raw produce access can mint a turn for any
+  agent and forge its author, bypassing the dedupe and authentication API ingress
+  exists to provide. Direct enqueue stays first-party only.
+- **In-process entry points are the narrow exception.** Reserved for ports that
+  are latency- or transaction-coupled to a turn and would be absurd behind HTTP —
+  the binding hook that runs at claim time before the sandbox boots
+  (`apps/worker/src/curie_worker/binding.py`), approver-set membership on the
+  approval path (`apps/api/src/curie_api/approvers.py::ApproverSet`), and eval
+  scorers inside a graded sweep. Those would use per-port `curie.<port>`
+  entry-point groups carrying the same fail-closed guard rules as the harness
+  registry, described in [harness-package](../harness-package/INTERFACE.md). The
+  cost is why it stays the exception: the contribution must be pip-installed into
+  a service image, which means a derived image per service, rebuilt on every
+  platform release.
+- **Ports are promoted one at a time, on demand, and the channel port is
+  first** — the only seam with named third-party askers and the only one graded
+  `C`. No generic plugin framework is built now, because most seams have one
+  implementation and no asking party, and a framework would encode guesses about
+  second implementations that do not exist. This is the standing restraint of
+  [architecture-vision.md](../../architecture-vision.md) applied to the plugin
+  question itself.
+
+## Implementations today
+
+None, and no partial one. The mechanism is unbuilt on this release train:
+
+- there is no `curie adapter` verb family in the CLI surface
+  (`cli/command-manifest.json`), and no adapter manifest schema anywhere;
+- the only entry-point group declared in the repo is the harness one,
+  `ENTRY_POINT_GROUP`
+  (`runner/src/curie_runner/harness/registry.py::ENTRY_POINT_GROUP`); no
+  `curie.<port>` sibling group exists;
+- there is no service-registration table, no adapter address or endpoint
+  configuration, and no channel-neutral egress port;
+- `packages/channel-protocol` holds the neutral reply DTOs — `OutboundMessage`
+  (`packages/channel-protocol/src/channel_protocol/models.py::OutboundMessage`)
+  and `ChannelCapabilities`
+  (`packages/channel-protocol/src/channel_protocol/models.py::ChannelCapabilities`)
+  — which are the second rung of the ladder above, but it carries no conformance
+  kit.
+
+The nearest existing thing is per-turn and pre-dates this decision:
+`ReplyHandle` (`packages/aci-protocol/src/aci_protocol/turn.py::ReplyHandle`)
+carries a per-turn reply endpoint, which is what lets the first-party CLI stub
+and a real Slack workspace coexist on one worker (#19). ADR-0096 promotes that
+stub in status: it is the existing second channel implementation and becomes the
+reference adapter the first conformance kit grows from.
+
+## Known leakage
+
+A NONE seam has no implementation to leak, so what belongs here is the distance
+between the recorded intent and the tree, and the things a first implementer
+would trip over:
+
+- **The credential rule the decision states is violated by today's egress.**
+  `AsyncSlackSink` (`apps/worker/src/curie_worker/slack_sink.py::AsyncSlackSink`)
+  delivers every per-turn reply through one client holding a single Slack bot
+  token, presented to whatever endpoint the turn names, and the
+  unreachable-endpoint fallback re-sends that reply's content to the default
+  transport. Both are correct for a one-workspace install and wrong the moment a
+  vendor endpoint coexists with real Slack: the vendor would be handed the
+  platform's token, and an outage would leak a vendor turn's reply into Slack.
+  ADR-0096 writes this down precisely because it is a prerequisite, not a
+  follow-up.
+- **The binding surface is still a literal Slack column.** `Agent`
+  (`apps/api/src/curie_api/models.py::Agent`) binds an agent by `slack_channel`,
+  and the API's validators reject ids that are not Slack-shaped, so a vendor
+  would today have to mint Slack-shaped channel ids exactly as the CLI stub does.
+  The rename is a migration plus a contract change, not a refactor.
+- **The interactivity return path has no scoped credential.** Approval resolution
+  sits behind the single platform-wide key, and the scoped token minted for the
+  sandbox is deliberately rejected everywhere but the state router. A scoped
+  adapter credential in that shape is a prerequisite of a second channel adapter
+  rather than a follow-up to one.
+- **The decision is Accepted while the mechanism is not built, and its own
+  acceptance header names realizing code paths that only partly exist here.** The
+  ADR's Consequences section is explicit that it authorizes no code and ships
+  without a reference third-party adapter, and the items listed under
+  "Implementations today" above are what a reader will and will not find in the
+  tree. Treat this file as the record of the intended line, not as evidence that
+  a plugin mechanism is available.
+
+## Cross-links
+
+- **Related seam:** [harness-package](../harness-package/INTERFACE.md) — the only entry-point plugin mechanism in the codebase, and the model ADR-0096 generalizes from while reserving it for the narrow in-process exception.
+- **Related seam:** [connector-host](../connector-host/INTERFACE.md) — the declare-and-host split one scope down, and the hosting substrate an operator-run adapter would reuse.
+- **Related seam:** [channel-ingress](../channel-ingress/INTERFACE.md) — the port promoted first, and the one whose grade this decision is trying to move.
+- **Related seam:** [channel-interaction](../channel-interaction/INTERFACE.md) — the neutral interaction primitives that are already the second rung of the promotion ladder.
+- **Epic(s):** #19 — per-turn reply endpoint routing, which the worked example builds on; #158 — multi-tenancy, deliberately out of scope until it settles what a tenant owns
+- **Vision doc:** [architecture-vision.md](../../architecture-vision.md) — the standing restraint that no speculative adapter layer is written ahead of a real second implementation; not one of the six swap-readiness Jobs, so not separately graded
+- **ADR(s):** [ADR-0096](../../adr/0096-port-adapters-are-deployed-services.md) — a third-party port adapter is a deployed service, not a loaded plugin; [ADR-0060](../../adr/0060-the-harness-is-a-declared-package.md) — the harness registry it generalizes; [ADR-0086](../../adr/0086-bundles-declare-connectors-the-platform-hosts-them.md) — the declare-and-host precedent moved up one scope; [ADR-0040](../../adr/0040-adopt-acp-as-an-edge-projection.md) — the trust rule inherited verbatim: an adapter is a rendering and transport contract, never a trust boundary

--- a/docs/interfaces/sealed-credential/INTERFACE.md
+++ b/docs/interfaces/sealed-credential/INTERFACE.md
@@ -1,0 +1,174 @@
+---
+seam: Sealed credential (cluster-sealed connector secrets)
+kind: SOFT
+impls: 2 halves (Rust sealer, Python opener) over one frozen wire
+grade: not separately graded
+epics:
+  - "#1240"
+order: 21
+---
+# INTERFACE: Sealed credential (cluster-sealed connector secrets)
+
+> Part of the Curie swappable-seam catalog — see the [seam index](../../interfaces.md).
+<!-- BEGIN GENERATED: header (curie dev docs-lint) -->
+> **Kind:** SOFT &nbsp;·&nbsp; **Implementations today:** 2 halves (Rust sealer, Python opener) over one frozen wire &nbsp;·&nbsp; **Swap-readiness grade:** not separately graded
+<!-- END GENERATED: header -->
+
+**Kind legend:** CLEAN = a real `Protocol`/typed port class · SOFT = swap via env/URL/prefix/wire, no code interface · NONE = not built yet.
+
+## The black line
+
+A bundle can carry its own connector credential, encrypted to the cluster that
+will run it (ADR-0094). The blob is useless without that cluster's private key,
+so it lives in the agent repository beside the connector that reads it and an
+agent repo becomes self-contained: clone it, point a cluster at it, tools work.
+
+The seam is **a crypto wire format, not a code interface**, and that is
+deliberate — which makes it SOFT in exactly the sense the catalog means. The
+Rust CLI seals (`cli/src/sealing.rs`) and the Python worker opens
+(`apps/worker/src/curie_worker/sealing.py`), and the two halves share no type,
+no package and no generated schema. The opener's module docstring names the
+constraint outright: **wire compatibility with the CLI is the load-bearing
+property**. It is held not by an assumption but by both sides naming the same
+primitive rather than assembling their own, because two "compatible" AEAD stacks
+that disagree about nonce derivation would fail only at deploy, on a credential
+nobody can read out of a log.
+
+A second implementation here is a second sealer (another language, an authoring
+tool) or a second opener (a KMS-backed one). Either must satisfy the format
+below verbatim; there is nothing else to implement against.
+
+## Current contract
+
+- **Primitive.** A libsodium sealed box, `crypto_box_seal`: X25519 plus
+  XSalsa20-Poly1305, anonymous sender. Chosen because "encrypt anonymously to a
+  recipient public key" is exactly one named primitive, so there is no nonce
+  discipline, key derivation or AEAD pairing for this repository to get wrong.
+  A sealed value authenticates nothing about who sealed it, and nothing
+  downstream may believe it does.
+- **Envelope.** Base64 of the raw sealed box, which is an ephemeral public key
+  followed by the ciphertext. Standard alphabet with padding on the Rust side;
+  the Python side decodes with validation on. There is **no prefix, no version
+  byte and no type tag**. Re-sealing the same value produces a different blob, so
+  a repository's history does not leak that two secrets are equal.
+- **Keys.** Base64 of exactly 32 raw bytes, both halves. The private key reaches
+  the opener as `CURRENT_KEY_ENV`
+  (`apps/worker/src/curie_worker/sealing.py::CURRENT_KEY_ENV`), which is
+  `CURIE_SEALING_PRIVATE_KEY`.
+- **Rotation is two keys, tried in order.** `active_private_keys`
+  (`apps/worker/src/curie_worker/sealing.py::active_private_keys`) returns the
+  current key first and then `PREVIOUS_KEY_ENV`
+  (`apps/worker/src/curie_worker/sealing.py::PREVIOUS_KEY_ENV`),
+  `CURIE_SEALING_PREVIOUS_PRIVATE_KEY`, skipping either when blank. ADR-0094
+  requires the overlap: without it, rotating the cluster keypair invalidates
+  every blob every agent repository has committed, all at once. An empty key set
+  is a legitimate state — an install using only operator-supplied credentials
+  never needs one.
+- **Opening.** `open_sealed`
+  (`apps/worker/src/curie_worker/sealing.py::open_sealed`) base64-decodes, then
+  tries each active key, skipping a malformed key rather than treating it as
+  fatal, and never logs the blob or the plaintext. `open_all`
+  (`apps/worker/src/curie_worker/sealing.py::open_all`) is all-or-nothing across
+  one connector's values: a connector brought up with three of its four
+  credentials is the same silently broken pod as one brought up with none.
+- **Failure is fatal by design.** `SealedSecretError`
+  (`apps/worker/src/curie_worker/sealing.py::SealedSecretError`) stops the agent
+  being reconciled, because the alternative — deploy the connector without the
+  credential — produces a pod that starts, passes its health check, and returns
+  401 on every call: healthy in `kubectl get pods` and broken for every user.
+- **Carrier.** `ConnectorSpec.sealed_secrets`
+  (`packages/plugin-format/src/plugin_format/connectors.py::ConnectorSpec`), a
+  mapping keyed by env var name so it reads like `env` and cannot express two
+  blobs for one variable. It is excluded from `ConnectorSpec.resolved_secrets`
+  (`packages/plugin-format/src/plugin_format/connectors.py::ConnectorSpec.resolved_secrets`)
+  and included in `ConnectorSpec.secret_names`
+  (`packages/plugin-format/src/plugin_format/connectors.py::ConnectorSpec.secret_names`):
+  the blob **is** the credential, so the deploy path has no value to resolve.
+
+Key custody is asymmetric on purpose. The CLI mints the keypair on
+`curie cluster up` and preserves it across upgrades (`cli/src/ops.rs`); the chart
+never generates one, because it has no lookup-persist and a chart-side random
+would mint a new key on every `helm upgrade`
+(`charts/curie/templates/secrets.yaml`, `charts/curie/values.yaml`). The previous
+key is only ever preserved, never generated, since it exists solely because an
+operator deliberately rotated. Only the worker receives the keys, because the
+connector reconciler runs there and nothing else in the release decrypts
+(`charts/curie/templates/worker.yaml`), asserted by
+`charts/curie/ci/sealing-key-assertions.sh`.
+
+## Implementations today
+
+Two halves, one each way, plus the chart that carries the key:
+
+- **Sealer:** `cli/src/sealing.rs` (the `crypto_box` crate, standard base64),
+  wrapped by the `curie seal` verb in `cli/src/seal.rs`, which prints a pasteable
+  `connectors.yaml` snippet and whose `--json` shape is pinned by
+  `cli/schema/seal.schema.json` and `cli/tests/json_contract.rs`. It also holds a
+  mirror opener used only by its own tests.
+- **Opener:** `apps/worker/src/curie_worker/sealing.py` (PyNaCl `SealedBox`).
+
+The one thing that pins the two together is a **single captured fixture**:
+`test_a_blob_sealed_by_the_cli_opens_here`
+(`apps/worker/tests/test_sealing.py::test_a_blob_sealed_by_the_cli_opens_here`)
+opens a blob produced by the Rust implementation, against a private key derived
+from a readable seed rather than pasted as base64 so the file carries no
+high-entropy literal a scanner must be told to ignore. It is the only test that
+can catch the two sides disagreeing: every other test in that file seals with
+PyNaCl and would pass happily while the CLI emitted something it cannot read.
+
+## Known leakage
+
+This seam is a wire contract whose production path is not yet connected, and the
+file would be misleading without saying so:
+
+- **The opener has no production caller, and the carrier field is refused.**
+  `validate_connectors`
+  (`packages/plugin-format/src/plugin_format/connectors.py::validate_connectors`)
+  emits `connectors.sealed_secrets_unsupported` and rejects the whole file when
+  `sealed_secrets` is present, on the grounds that refusing beats deploying a
+  connector without the credential it needs. Nothing in the reconciler imports
+  the sealing module. So `curie seal` hands an author a snippet that today makes
+  their bundle fail validation, and the CLI does not warn. The refusal was
+  briefly lifted and then deliberately restored, so this is a live gate rather
+  than an oversight.
+- **No version marker, so a format change is indistinguishable from
+  corruption.** The envelope is bare base64 with nothing to negotiate on. Any
+  future change — a different construction, a compressed payload, additional
+  authenticated data binding a blob to one agent — surfaces through
+  `open_sealed` as the same generic "does not decrypt with any of this cluster's
+  active sealing keys" that a wrong-cluster blob produces.
+- **The private key is a plain env var, not a KMS handle.** The chart mounts it
+  through a `secretKeyRef` and `active_private_keys` reads the process
+  environment, which forecloses envelope encryption, per-decrypt audit,
+  key-usage limits and non-exportable keys; anything that can exec into the
+  worker pod reads the raw key, and the CLI deliberately reads the private key
+  back out of the cluster to derive the public half. ADR-0094 points at the
+  chart's `existingSecret` idiom as the mitigation, and there is no
+  `sealing.existingSecret` value.
+- **The conformance pin runs one direction and cannot be regenerated by any
+  command in the repo.** Rust to Python is fixed by the captured fixture above;
+  Python to Rust is exercised only against blobs Rust itself sealed. The fixture's
+  own docstring says regeneration means writing a temporary test in the Rust
+  module, so there is no committed generator and no shared vector file under
+  `tests/vectors/` the way credential forwarding has one.
+- **The base64 alphabet and padding are agreed by coincidence, not assertion.**
+  Both sides happen to default to the standard alphabet; nothing seals with the
+  URL-safe variant and asserts rejection, and nothing round-trips a padded value.
+  The captured fixture happens to be a length that needs no padding, so it does
+  not cover the case either.
+- **Rotation has no attribution and no reseal command.** The failure text is
+  identical whether a blob was sealed to a rotated-out key or to another cluster
+  entirely, and the Rust mirror deliberately does not say which key failed.
+  ADR-0094 asked for `curie seal` to be able to reseal a repository in one
+  command; that half did not ship, so an operator mid-rotation has no way to
+  enumerate which repositories still carry stale blobs and no signal until each
+  agent's reconcile fails.
+
+## Cross-links
+
+- **Related seam:** [connector-host](../connector-host/INTERFACE.md) — the consumer this credential is for; sealed values are the third holder shape a connector spec can declare.
+- **Related seam:** [bundle-format](../bundle-format/INTERFACE.md) — the carrier. `sealed_secrets` is additive and optional, which is what let it land as a backward-compatible change.
+- **Related seam:** [model-provider](../model-provider/INTERFACE.md) — the other credential axis, and a separate one: the model credential is resolved by the platform rather than carried by the bundle.
+- **Epic(s):** #1240 — a bundle carries its own sealed connector keys, removing the last manual step in onboarding an agent
+- **Vision doc:** [architecture-vision.md](../../architecture-vision.md) — credential sealing is not one of the six swap-readiness Jobs; not separately graded
+- **ADR(s):** [ADR-0094](../../adr/0094-a-bundle-carries-its-own-sealed-connector-keys.md) — a bundle carries its own sealed connector keys, with two active keys so a rotation can overlap; [ADR-0009](../../adr/0009-per-agent-connector-auth.md) — per-agent secrets and connector credentials, the mechanism sealed values join rather than replace


### PR DESCRIPTION
Adds four `INTERFACE.md` entries for boundaries that had no catalog entry. All four postdate the catalog's creation, and each was re-verified against the code at this base rather than trusted from an earlier survey.

- **`harness-package`** (CLEAN) the entry point discovered harness contribution registry of ADR-0060. This is the layer above the in process `ModelSession` port, which the catalog documented while never covering discovery, selection, or the contribution manifest a third party actually implements.
- **`connector-host`** (CLEAN) hosted MCP connectors declared by a bundle and applied by a reconciler (ADR-0086, ADR-0087, ADR-0090). The catalog covered `SandboxClient` but nothing about the second workload boundary in the worker.
- **`sealed-credential`** (SOFT) the cluster sealed connector credentials of ADR-0094. The Rust CLI seals and the Python worker opens, sharing no type and no generated schema, so the wire format is the whole contract.
- **`port-adapter-service`** (NONE) ADR-0096's answer to where a third party puts its code so the platform uses it instead of the default. ADR-0096 is now Accepted, so the intended line is recorded rather than proposed, and the entry states plainly that nothing implements it yet.

Every `Known leakage` section names something specific and load bearing rather than reading as boilerplate: five of the ten harness manifest fields have no production reader and nothing in the platform can even set `CURIE_HARNESS`; the connector port trades raw Kubernetes wire dicts and has two appliers that disagree with each other; the sealed credential opener has no production caller because bundle validation still refuses the carrier field; and the port adapter entry records the single token egress client that ADR-0096 itself names as a prerequisite.

Re-verification changed three things relative to the survey that suggested these: ADR-0096 has moved from Draft to Accepted, so the NONE entry is written as a record of an accepted decision; ADR-0094 is likewise Accepted while its carrier field is still gated off; and a fifth candidate, the console session store from ADR-0083, was examined and dropped. It has no port, no runtime selection, no second implementation and no frozen contract, and its own router says nothing consumes a session yet, so it is a security posture rather than a substitution point.

`bash scripts/check-docs.sh` exits 0. No existing seam file is touched.

Note for whoever merges second: `docs/interfaces.md` is a fully generated artifact and a concurrent branch also regenerates it, so a conflict there is expected. Resolve it by re-running the generator, never by hand merging.