### PR TITLE
Release 0.6.1-rc.1

### DIFF
--- a/charts/curie/Chart.yaml
+++ b/charts/curie/Chart.yaml
@@ -8,8 +8,8 @@ description: >-
   and two install-time preflights ship baked in: a CPU-AVX / ClickHouse-pin
   check and a NetworkPolicy-enforcement probe.
 type: application
-version: 0.7.0-rc.4
-appVersion: "0.7.0-rc.4"
+version: 0.6.1-rc.1
+appVersion: "0.6.1-rc.1"
 kubeVersion: ">=1.25.0-0"
 maintainers:
   - name: Curie

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -749,7 +749,7 @@ dependencies = [
 
 [[package]]
 name = "curie"
-version = "0.7.0-rc.4"
+version = "0.6.1-rc.1"
 dependencies = [
  "anstream",
  "anstyle",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "curie"
-version = "0.7.0-rc.4"
+version = "0.6.1-rc.1"
 edition = "2021"
 description = "Curie CLI: init/start/send/eval a plugin against a local runner (task I1)"
 


### PR DESCRIPTION
Sets main's in-tree release version to `0.6.1-rc.1`, so a `v0.6.1-rc.1` tag publishes assets that self-report the version they are.

main's in-tree version was `0.7.0-rc.4`. Under the release train model in `AGENTS.md`, `main` is the stable v0.6.x line and `next` is the v0.7.0 integration branch, so that string was on the wrong branch. Tagging `v0.6.1-rc.1` without this bump would ship a CLI whose `--version` reads `0.7.0-rc.4` and a chart that pins its images by `appVersion` to a v0.7 RC that no longer exists.

This is an intentional downgrade of the version string, `0.7.0-rc.4` to `0.6.1-rc.1`. The four `v0.7.0-rc.*` tags and releases previously cut off `main` were deleted on 2026-08-16 as created in error, so nothing published depends on the v0.7 numbering here.

Same three files and one string as every prior RC (`492d127b`, `21b14d56`, `50439d49`):

- `charts/curie/Chart.yaml` (`version` and `appVersion`)
- `cli/Cargo.toml`
- `cli/Cargo.lock`, matched on the `[[package]]` block whose `name = "curie"` rather than by string replacement

`git grep '0\.7\.0-rc'` returns nothing after this change.

Context: #1476.
