### PR TITLE
Derive runner pins from uv.lock

### DIFF
--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -10,8 +10,8 @@
 # @anthropic-ai/claude-code CLI alongside the Python runner. With
 # CURIE_FAKE_MODEL=1 the container answers synthetic events offline (no CLI/model
 # call), which is how the container smoke round-trips without a credential.
-# Python 3.13 is required by the frozen workspace packages; Node 22 is required
-# by the Claude Code CLI the SDK spawns. Base on python:3.13 and add Node.
+# The frozen workspace packages require the Python base below; Node 22 is
+# required by the Claude Code CLI the SDK spawns. Add Node to the Python base.
 # Node comes from the official image rather than NodeSource's apt repo. That
 # repo's setup script (`deb.nodesource.com/setup_22.x`) started returning 403 to
 # everyone on 2026-07-27, which broke every runner-image build repo-wide: curl
@@ -51,27 +51,22 @@ WORKDIR /app
 # The three source trees the runner needs: the two frozen workspace packages and
 # the runner itself. Copied by path so the image is reproducible from the lockfile
 # above them (root pyproject/uv.lock are the workspace source of truth).
+COPY uv.lock ./uv.lock
 COPY packages/aci-protocol ./packages/aci-protocol
 COPY packages/plugin-format ./packages/plugin-format
 COPY runner ./runner
 
 # One venv. Install the local packages first, then the runner without redeps,
-# then its third-party deps. The versions are pinned == to the tested workspace
-# uv.lock (source of truth: root uv.lock) so a rebuild ships exactly what CI
-# exercised rather than resolving a newer SDK/aiohttp/OTel at build time. Keep
-# these pins in lockstep with uv.lock when the runner's deps move. The local
-# packages are installed by path first so the "aci-protocol"/"plugin-format"
-# requirements resolve to the copied trees, not a same-named PyPI distribution.
+# then its direct registry dependencies exported from the tested workspace
+# uv.lock. The local packages are installed by path first so the
+# "aci-protocol"/"plugin-format" requirements resolve to the copied trees, not
+# a same-named PyPI distribution.
 RUN python3 -m venv /app/.venv \
     && /app/.venv/bin/pip install --no-cache-dir --upgrade pip \
     && /app/.venv/bin/pip install --no-cache-dir ./packages/aci-protocol ./packages/plugin-format \
     && /app/.venv/bin/pip install --no-cache-dir --no-deps ./runner \
-    && /app/.venv/bin/pip install --no-cache-dir \
-        "claude-agent-sdk==0.2.135" \
-        "aiohttp==3.14.3" \
-        "opentelemetry-sdk==1.44.0" \
-        "opentelemetry-exporter-otlp-proto-http==1.44.0" \
-        "anyio==4.14.1"
+    && python3 runner/export_dependency_pins.py < uv.lock > /tmp/runner-dependency-pins.txt \
+    && /app/.venv/bin/pip install --no-cache-dir -r /tmp/runner-dependency-pins.txt
 
 # Run as a non-root user. The claude-agent-sdk spawns
 # `claude --dangerously-skip-permissions` (permission_mode=bypassPermissions),

--- a/runner/export_dependency_pins.py
+++ b/runner/export_dependency_pins.py
@@ -1,0 +1,94 @@
+"""Export the runner's direct registry dependencies from a uv lockfile."""
+
+from __future__ import annotations
+
+import re
+import sys
+import tomllib
+from typing import Any
+
+
+class InvalidLock(ValueError):
+    """Raised when the runner dependency records cannot be trusted."""
+
+
+def _normalize_name(name: str) -> str:
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def _require_package_records(lock: dict[str, Any]) -> list[dict[str, Any]]:
+    packages = lock.get("package")
+    if not isinstance(packages, list) or not all(
+        isinstance(package, dict) for package in packages
+    ):
+        raise InvalidLock("uv.lock must contain package records")
+    return packages
+
+
+def _package_name(package: dict[str, Any], context: str) -> str:
+    name = package.get("name")
+    if not isinstance(name, str) or not (normalized := _normalize_name(name)):
+        raise InvalidLock(f"{context} must declare a package name")
+    return normalized
+
+
+def _runner_dependency_pins(lock: dict[str, Any]) -> list[str]:
+    packages = _require_package_records(lock)
+    runners = [
+        package
+        for package in packages
+        if _package_name(package, "uv.lock package record") == "curie-runner"
+    ]
+    if len(runners) != 1:
+        raise InvalidLock("uv.lock must contain exactly one curie-runner record")
+
+    dependencies = runners[0].get("dependencies")
+    if not isinstance(dependencies, list):
+        raise InvalidLock("curie-runner must declare dependency records")
+
+    package_by_name: dict[str, dict[str, Any]] = {}
+    for package in packages:
+        name = _package_name(package, "uv.lock package record")
+        if name in package_by_name:
+            raise InvalidLock(f"uv.lock resolves {name} more than once")
+        package_by_name[name] = package
+
+    dependency_names: set[str] = set()
+    pins: dict[str, str] = {}
+    for dependency in dependencies:
+        if not isinstance(dependency, dict):
+            raise InvalidLock("each curie-runner dependency must be a package record")
+        name = _package_name(dependency, "each curie-runner dependency")
+        if name in dependency_names:
+            raise InvalidLock(f"curie-runner dependency {name} is duplicated")
+        dependency_names.add(name)
+
+        resolved = package_by_name.get(name)
+        if resolved is None:
+            raise InvalidLock(f"uv.lock does not resolve curie-runner dependency {name}")
+        source = resolved.get("source")
+        if not isinstance(source, dict):
+            raise InvalidLock(f"uv.lock package {name} must declare its source")
+        if "registry" not in source:
+            continue
+
+        version = resolved.get("version")
+        if not isinstance(version, str) or not version:
+            raise InvalidLock(f"uv.lock registry package {name} must declare a version")
+        pins[name] = version
+
+    return [f"{name}=={version}" for name, version in sorted(pins.items())]
+
+
+def main() -> int:
+    try:
+        lock = tomllib.loads(sys.stdin.read())
+        print("\n".join(_runner_dependency_pins(lock)))
+    except (InvalidLock, tomllib.TOMLDecodeError) as error:
+        print(f"invalid uv.lock: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/runner/tests/test_dockerfile_dependency_pins.py
+++ b/runner/tests/test_dockerfile_dependency_pins.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import re
 import shlex
+import subprocess
+import sys
 import tomllib
 from dataclasses import dataclass
 from pathlib import Path
@@ -10,7 +12,9 @@ import pytest
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _DOCKERFILE = _REPO_ROOT / "runner" / "Dockerfile"
+_EXPORTER = _REPO_ROOT / "runner" / "export_dependency_pins.py"
 _UV_LOCK = _REPO_ROOT / "uv.lock"
+_REQUIREMENTS_PATH = "/tmp/runner-dependency-pins.txt"
 _EXACT_NPM_VERSION = re.compile(
     r"\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?"
 )
@@ -117,30 +121,6 @@ def _dockerfile_python_pins(instructions: list[str]) -> dict[str, list[str]]:
     return pins
 
 
-def _dockerfile_python_operands(dockerfile_text: str) -> dict[str, str]:
-    operands: dict[str, str] = {}
-    controls = {"&&", "||", ";"}
-    for instruction in _logical_instructions(dockerfile_text):
-        tokens = _shell_tokens(instruction)
-        if not tokens or tokens[0].upper() != "RUN":
-            continue
-        for index, token in enumerate(tokens[:-1]):
-            if not _PIP_EXECUTABLE.fullmatch(token.rsplit("/", 1)[-1]) or (
-                tokens[index + 1] != "install"
-            ):
-                continue
-            for operand in tokens[index + 2 :]:
-                if operand in controls:
-                    break
-                if operand.startswith("-") or "==" not in operand:
-                    continue
-                name, _ = operand.split("==", 1)
-                package = _normalize_python_name(name)
-                assert package not in operands, f"Dockerfile must pin {package} exactly once"
-                operands[package] = operand
-    return operands
-
-
 def _split_npm_operand(operand: str) -> tuple[str, str | None]:
     version_at = operand.rfind("@")
     if version_at <= 0:
@@ -243,12 +223,102 @@ def _find_violations(lock_text: str, dockerfile_text: str) -> list[Violation]:
     return sorted(violations, key=lambda violation: (violation.package, violation.message))
 
 
-def test_actual_runner_dockerfile_matches_locked_dependencies() -> None:
-    violations = _find_violations(
-        _UV_LOCK.read_text(encoding="utf-8"),
-        _DOCKERFILE.read_text(encoding="utf-8"),
+def _run_dependency_exporter(lock_text: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(_EXPORTER)],
+        input=lock_text,
+        capture_output=True,
+        check=False,
+        text=True,
     )
-    assert violations == []
+
+
+def _export_runner_dependencies(lock_text: str) -> list[str]:
+    result = _run_dependency_exporter(lock_text)
+    assert result.returncode == 0, result.stderr
+    return result.stdout.splitlines()
+
+
+def _effective_runner_python_operands(lock_text: str) -> dict[str, str]:
+    dockerfile = _DOCKERFILE.read_text(encoding="utf-8")
+    instructions = _logical_instructions(dockerfile)
+    assert any(
+        "python3 runner/export_dependency_pins.py < uv.lock "
+        f"> {_REQUIREMENTS_PATH}" in instruction
+        and f"pip install --no-cache-dir -r {_REQUIREMENTS_PATH}" in instruction
+        for instruction in instructions
+    )
+    operands: dict[str, str] = {}
+    for operand in _export_runner_dependencies(lock_text):
+        package, _ = operand.split("==", 1)
+        normalized = _normalize_python_name(package)
+        assert normalized not in operands, f"runner requirements must pin {normalized} once"
+        operands[normalized] = operand
+    return operands
+
+
+def _replace_locked_package_version(
+    lock_text: str, package: str, replacement: str
+) -> str:
+    pattern = re.compile(
+        rf'(?m)(^\[\[package\]\]\nname = "{re.escape(package)}"\nversion = ")[^"]+("$)'
+    )
+    updated, count = pattern.subn(
+        lambda match: f"{match.group(1)}{replacement}{match.group(2)}",
+        lock_text,
+    )
+    assert count == 1, f"uv.lock must contain exactly one {package} record"
+    return updated
+
+
+def _dockerfile_with_python_pins(pins: dict[str, str]) -> str:
+    operands = " \\\n    ".join(f'"{package}=={version}"' for package, version in pins.items())
+    return f"RUN pip install --no-cache-dir \\\n    {operands}\n"
+
+
+def test_dependency_exporter_emits_sorted_direct_registry_pins() -> None:
+    lock_text = _UV_LOCK.read_text(encoding="utf-8")
+    expected = _locked_runner_dependencies(lock_text)
+
+    assert _export_runner_dependencies(lock_text) == [
+        f"{package}=={version}" for package, version in sorted(expected.items())
+    ]
+
+
+def test_dependency_exporter_reflects_a_lock_version_bump() -> None:
+    lock_text = _UV_LOCK.read_text(encoding="utf-8")
+    expected = _locked_runner_dependencies(lock_text)
+    replacement = f"{expected['claude-agent-sdk']}.post1"
+    bumped_lock = _replace_locked_package_version(
+        lock_text, "claude-agent-sdk", replacement
+    )
+
+    pins = _export_runner_dependencies(bumped_lock)
+
+    assert "claude-agent-sdk==" + replacement in pins
+    assert f"claude-agent-sdk=={expected['claude-agent-sdk']}" not in pins
+
+
+def test_dependency_exporter_rejects_malformed_lock_input() -> None:
+    result = _run_dependency_exporter("[[package]\nname = ")
+
+    assert result.returncode != 0
+    assert result.stdout == ""
+    assert "invalid uv.lock" in result.stderr
+
+
+def test_dockerfile_generates_python_requirements_from_the_lock_exporter() -> None:
+    dockerfile = _DOCKERFILE.read_text(encoding="utf-8")
+    instructions = _logical_instructions(dockerfile)
+
+    assert "COPY uv.lock ./uv.lock" in instructions
+    assert any(
+        "python3 runner/export_dependency_pins.py < uv.lock "
+        f"> {_REQUIREMENTS_PATH}" in instruction
+        and f"pip install --no-cache-dir -r {_REQUIREMENTS_PATH}" in instruction
+        for instruction in instructions
+    )
+    assert _dockerfile_python_pins(instructions) == {}
 
 
 def test_prechange_drift_reports_all_four_violations() -> None:
@@ -290,11 +360,9 @@ RUN /app/.venv/bin/pip install \\
 def test_python_pin_revert_is_rejected() -> None:
     lock_text = _UV_LOCK.read_text(encoding="utf-8")
     expected = _locked_runner_dependencies(lock_text)
-    dockerfile = _DOCKERFILE.read_text(encoding="utf-8")
-    current = _dockerfile_python_operands(dockerfile)["claude-agent-sdk"]
-    assert dockerfile.count(current) == 1
     stale_version = f"{expected['claude-agent-sdk']}.stale"
-    mutated = dockerfile.replace(current, f"claude-agent-sdk=={stale_version}")
+    pins = expected | {"claude-agent-sdk": stale_version}
+    mutated = _dockerfile_with_python_pins(pins)
 
     violations = _find_violations(lock_text, mutated)
     assert Violation(
@@ -334,8 +402,7 @@ def test_npm_global_install_aliases_require_exact_versions(command: str) -> None
 @pytest.mark.parametrize("executable", ["pip", "pip3"])
 def test_pip_executable_forms_are_compared_with_the_lock(executable: str) -> None:
     lock_text = _UV_LOCK.read_text(encoding="utf-8")
-    dockerfile = _DOCKERFILE.read_text(encoding="utf-8")
-    operands = _dockerfile_python_operands(dockerfile)
+    operands = _effective_runner_python_operands(lock_text)
     synthetic = "RUN " + executable + " install " + " ".join(
         f'"{operand}"' for operand in operands.values()
     )
@@ -345,9 +412,8 @@ def test_pip_executable_forms_are_compared_with_the_lock(executable: str) -> Non
 
 def test_python_pin_set_must_match_all_direct_registry_dependencies() -> None:
     lock_text = _UV_LOCK.read_text(encoding="utf-8")
-    dockerfile = _DOCKERFILE.read_text(encoding="utf-8")
     expected = _locked_runner_dependencies(lock_text)
-    operands = _dockerfile_python_operands(dockerfile)
+    operands = _effective_runner_python_operands(lock_text)
     assert operands.keys() == expected.keys()
     baseline = "RUN pip install " + " ".join(
         f'"{operand}"' for operand in operands.values()


### PR DESCRIPTION
Closes #1593

Runner image dependency pins now derive from uv.lock during the Docker build. The pin invariant test retains deliberate mismatch coverage.