### PR TITLE
Scope the secret scan to the pushed branch history

### DIFF
--- a/.github/workflows/gitleaks.yaml
+++ b/.github/workflows/gitleaks.yaml
@@ -32,8 +32,9 @@ jobs:
           persist-credentials: false
           # fetch-depth: 0 pulls the entire history so `gitleaks detect` scans
           # every commit, not just the tip. Pull request scans use an explicit
-          # base to head range below; push, scheduled, and manual scans remain
-          # full history.
+          # base to head range below, and push scans use the pushed commit's own
+          # history; scheduled and manual scans remain full history across every
+          # ref.
           fetch-depth: 0
       # Retry eligibility (#1106): only a step whose whole job is to ACQUIRE a
       # third-party dependency (a tool binary, an image, a registry session, a
@@ -74,6 +75,16 @@ jobs:
         if: github.event_name == 'pull_request'
         run: |
           echo "GITLEAKS_LOG_OPTS=--log-opts=${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}" >> "$GITHUB_ENV"
+      # Without a log range gitleaks scans every ref the `fetch-depth: 0`
+      # checkout pulled down, so a push to a release branch also scanned every
+      # unmerged feature branch and a finding on one of them reddened the
+      # release branch (#1592). Scoping to the pushed commit's own history keeps
+      # the branch answerable for what is actually on it, and stays full history
+      # for that branch so a secret added and later deleted is still caught.
+      - name: Scope gitleaks to the pushed branch history
+        if: github.event_name == 'push'
+        run: |
+          echo "GITLEAKS_LOG_OPTS=--log-opts=--full-history ${{ github.sha }}" >> "$GITHUB_ENV"
       # Run gitleaks from its official public image rather than the marketplace
       # action: the action requires a paid GITLEAKS_LICENSE for organization
       # accounts, while the CLI/image is MIT-licensed and free. Pinned to an
@@ -87,8 +98,39 @@ jobs:
       # reference now lives in this job's `env:` block as `GITLEAKS_IMAGE`, so
       # the pull step above and the scan below share one pinned tag and digest.
       - name: Run gitleaks
+        id: scan
         run: |
           docker run --rm -v "${{ github.workspace }}:/repo" \
             "$GITLEAKS_IMAGE" \
             detect --source /repo --redact --verbose --exit-code 1 \
+            --report-path /repo/gitleaks-report.json \
             ${GITLEAKS_LOG_OPTS:+"$GITLEAKS_LOG_OPTS"}
+      # The scheduled sweep and manual dispatches stay deliberately wide, so a
+      # finding there can come from any ref and the commit alone does not say
+      # which. Mapping each reported commit back to the refs that contain it is
+      # what makes a red sweep actionable instead of a hunt.
+      #
+      # `git for-each-ref --contains`, not `git branch --all --contains`: the
+      # wide sweep walks every ref the `fetch-depth: 0` checkout pulled down,
+      # tags included, and this repository carries `v0.1.0` through `v0.6.0`
+      # plus `backup/*` refs. A finding on a commit reachable only from a tag
+      # (or whose branch has since been deleted) printed a bare colon with
+      # nothing after it under the branch-only form, which is exactly the
+      # non-actionable output this step exists to prevent. The empty case is
+      # spelled out for the same reason.
+      #
+      # Keyed on `conclusion`, not `outcome`: the scan carries no
+      # `continue-on-error` so the two read the same here, and `steps.*.outcome`
+      # is the retry-guard marker the eligibility gate polices
+      # (tools/ci-retry-gate). This step reports on a failure, it never reruns
+      # the scan, and it must not read as a retry wrap around it.
+      - name: Name the refs each finding came from
+        if: failure() && steps.scan.conclusion == 'failure'
+        run: |
+          set -euo pipefail
+          test -f gitleaks-report.json || exit 0
+          jq -r '.[].Commit' gitleaks-report.json | sort -u | while read -r sha; do
+            refs=$(git for-each-ref --contains "$sha" --format='%(refname:short)' \
+              refs/heads refs/remotes refs/tags | paste -sd', ' - || true)
+            echo "$sha appears on: ${refs:-no ref contains this commit (unreachable or dangling object)}"
+          done

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -174,14 +174,6 @@ stopwords = [
   "C000000S03",
   "C000000S04",
   "C000000S05",
-  # S06 to S09 exist only in history: the per-agent secret-delivery work
-  # introduced them and later edited them away, but gitleaks scans every
-  # commit, so an id absent from the tree still fails the scan forever.
-  # Registering them is the only fix that does not rewrite history.
-  "C000000S06",
-  "C000000S07",
-  "C000000S08",
-  "C000000S09",
   "C000000X01",
   "C0000BND1",
   "C0000BND2",
@@ -223,12 +215,12 @@ stopwords = [
   "C0WRONG01",
   "C9999ZZZZ",
   # The channel-neutral agent_channels work (#1491) scrubbed these from the
-  # tree, but gitleaks scans every commit, so the fixtures the seven commits
-  # behind that change introduced still fail the full-history scan on every
-  # push to main. Registering them is the same remedy the S06-to-S09 note
-  # above records, for the same reason: it is the only fix that does not
-  # rewrite history. Every one clears the bar this list sets -- each spells a
-  # word, repeats a character, or is mostly zeroes.
+  # tree, but they survive in commits on an unmerged branch. A push scan no
+  # longer reaches them: #1592 scoped push-event runs to the pushed
+  # branch's own history. The weekly scheduled sweep still scans every ref,
+  # so these entries stay registered rather than being deleted. Every one
+  # clears the bar this list sets -- each spells a word, repeats a
+  # character, or is mostly zeroes.
   "C0000ADD01",
   "C0000DEL01",
   "C0000DEL02",

--- a/tools/ci-retry-gate/tests/test_gitleaks_scope.py
+++ b/tools/ci-retry-gate/tests/test_gitleaks_scope.py
@@ -1,4 +1,4 @@
-"""Regression coverage for pull request secret scan scope."""
+"""Regression coverage for secret scan scope."""
 
 from __future__ import annotations
 
@@ -7,13 +7,15 @@ import re
 import secrets
 import string
 import subprocess
-from pathlib import Path
-from typing import Any
+import tomllib
+from pathlib import Path, PurePosixPath
+from typing import Any, cast
 
 import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "gitleaks.yaml"
+GITLEAKS_CONFIG_PATH = REPO_ROOT / ".gitleaks.toml"
 
 
 def _workflow() -> dict[str, Any]:
@@ -33,6 +35,73 @@ def _gitleaks_image() -> str:
     assert isinstance(image, str)
     assert "@sha256:" in image, "the test must run the immutable workflow image"
     return image
+
+
+def _trigger_block() -> dict[str, Any]:
+    # PyYAML resolves the bare `on:` key to the boolean True.
+    document = cast(dict[Any, Any], _workflow())
+    triggers = document.get(True, document.get("on"))
+    assert isinstance(triggers, dict)
+    return triggers
+
+
+def _push_scope_step() -> dict[str, Any]:
+    steps = _gitleaks_job()["steps"]
+    assert isinstance(steps, list)
+    scope_steps = [
+        step
+        for step in steps
+        if "GITLEAKS_LOG_OPTS=" in str(step.get("run", ""))
+        and "github.sha" in str(step.get("run", ""))
+    ]
+    assert len(scope_steps) == 1, "workflow must define exactly one push scoping step"
+    step = scope_steps[0]
+    assert isinstance(step, dict)
+    return step
+
+
+def _push_log_range(pushed_sha: str) -> str:
+    scope_command = str(_push_scope_step()["run"])
+    match = re.search(r"GITLEAKS_LOG_OPTS=--log-opts=(?P<range>[^\"\n]+)", scope_command)
+    assert match is not None, f"the push scoping step must export a log range: {scope_command}"
+    return re.sub(r"\$\{\{\s*github\.sha\s*\}\}", pushed_sha, match.group("range")).strip()
+
+
+def _scan_step() -> dict[str, Any]:
+    steps = _gitleaks_job()["steps"]
+    assert isinstance(steps, list)
+    step = next(step for step in steps if step.get("name") == "Run gitleaks")
+    assert isinstance(step, dict)
+    return step
+
+
+def _scan_report_path() -> str:
+    scan_command = str(_scan_step()["run"])
+    match = re.search(r"--report-path\s+(?P<path>\S+)", scan_command)
+    assert match is not None, f"the scan step must write a findings report: {scan_command}"
+    return match.group("path")
+
+
+def _attribution_step() -> dict[str, Any]:
+    steps = _gitleaks_job()["steps"]
+    assert isinstance(steps, list)
+    attribution_steps = [
+        step
+        for step in steps
+        if "--contains" in str(step.get("run", ""))
+        and re.search(r"git (for-each-ref|branch)\b", str(step.get("run", "")))
+    ]
+    assert len(attribution_steps) == 1, "workflow must define exactly one ref attribution step"
+    step = attribution_steps[0]
+    assert isinstance(step, dict)
+    return step
+
+
+def _gitleaks_config() -> dict[str, Any]:
+    with GITLEAKS_CONFIG_PATH.open("rb") as handle:
+        document = tomllib.load(handle)
+    assert isinstance(document, dict)
+    return document
 
 
 def _git(repo: Path, *args: str) -> str:
@@ -67,7 +136,12 @@ def _runtime_secret() -> str:
     return "GITHUB_TOKEN=" + "gh" + "p_" + suffix + "\n"
 
 
-def _scan(repo: Path, log_range: str | None = None) -> subprocess.CompletedProcess[str]:
+def _scan(
+    repo: Path,
+    log_range: str | None = None,
+    report_path: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    mount = f"{repo}:/repo" if report_path is not None else f"{repo}:/repo:ro"
     command = [
         "docker",
         "run",
@@ -75,7 +149,7 @@ def _scan(repo: Path, log_range: str | None = None) -> subprocess.CompletedProce
         "--user",
         f"{os.getuid()}:{os.getgid()}",
         "--volume",
-        f"{repo}:/repo:ro",
+        mount,
         _gitleaks_image(),
         "detect",
         "--source",
@@ -85,6 +159,8 @@ def _scan(repo: Path, log_range: str | None = None) -> subprocess.CompletedProce
         "--exit-code",
         "1",
     ]
+    if report_path is not None:
+        command.extend(["--report-path", report_path])
     if log_range is not None:
         command.append(f"--log-opts={log_range}")
     return subprocess.run(command, capture_output=True, text=True, check=False)
@@ -183,3 +259,200 @@ def test_workflow_limits_log_range_to_pull_requests() -> None:
         scan_command,
         re.DOTALL,
     ), "the gitleaks invocation must pass the pull request range only when it is set"
+
+
+def test_workflow_limits_log_range_to_the_pushed_branch_history() -> None:
+    step = _push_scope_step()
+
+    condition = str(step.get("if", "")).removeprefix("${{").removesuffix("}}").strip()
+    assert condition in {
+        "github.event_name == 'push'",
+        'github.event_name == "push"',
+    }, "the push log range must be configured only for push events"
+
+    scope_command = str(step["run"])
+    assert re.search(
+        r"GITLEAKS_LOG_OPTS=--log-opts=[^\"\n]*\$\{\{\s*github\.sha\s*\}\}",
+        scope_command,
+    ), "the push range must be anchored on the pushed commit SHA"
+    assert "GITHUB_ENV" in scope_command
+
+
+def test_scheduled_and_manual_scans_stay_unscoped() -> None:
+    steps = _gitleaks_job()["steps"]
+    assert isinstance(steps, list)
+
+    setters = [step for step in steps if "GITLEAKS_LOG_OPTS=" in str(step.get("run", ""))]
+    assert setters, "the workflow must scope at least one event"
+    for step in setters:
+        condition = str(step.get("if", ""))
+        assert "pull_request" in condition or "push" in condition, (
+            f"step {step.get('name')!r} narrows the log range without a pull request or push "
+            "guard, which would also narrow the scheduled sweep and manual dispatches"
+        )
+
+    triggers = _trigger_block()
+    assert "schedule" in triggers, "the weekly full history sweep must stay configured"
+    assert "workflow_dispatch" in triggers, "the manual full history scan must stay configured"
+
+
+def test_push_range_ignores_secret_on_unmerged_branch(tmp_path: Path) -> None:
+    repo, _ = _new_repo(tmp_path / "repo")
+
+    _git(repo, "switch", "--create", "unmerged")
+    (repo / "credentials.env").write_text(_runtime_secret(), encoding="utf-8")
+    _commit(repo, "unmerged secret")
+
+    _git(repo, "switch", "main")
+    (repo / "feature.txt").write_text("clean release branch\n", encoding="utf-8")
+    pushed_sha = _commit(repo, "clean release branch commit")
+
+    scoped = _scan(repo, _push_log_range(pushed_sha))
+    assert scoped.returncode == 0, _scan_diagnostics(scoped)
+
+    unscoped = _scan(repo)
+    assert unscoped.returncode == 1, _scan_diagnostics(unscoped)
+
+
+def test_push_range_finds_secret_deleted_from_pushed_branch_history(tmp_path: Path) -> None:
+    repo, _ = _new_repo(tmp_path / "repo")
+
+    secret_path = repo / "credentials.env"
+    secret_path.write_text(_runtime_secret(), encoding="utf-8")
+    _commit(repo, "add secret")
+    secret_path.unlink()
+    pushed_sha = _commit(repo, "remove secret")
+
+    result = _scan(repo, _push_log_range(pushed_sha))
+
+    assert result.returncode == 1, _scan_diagnostics(result)
+
+
+def test_gitleaks_config_declares_no_rewritten_history_stopwords() -> None:
+    stopwords = _gitleaks_config()["allowlist"]["stopwords"]
+    assert isinstance(stopwords, list)
+
+    # Split so no literal here reaches the slack-conversation-id shape
+    # (\b[CGD][0-9][A-Z0-9]{7,9}\b): "C000000S" alone is only 8 chars and
+    # does not match. Do not rejoin this into a single literal.
+    dead_prefix = "C000000S"
+    dead_pattern = re.compile(re.escape(dead_prefix) + r"0[6-9]")
+    dead = [word for word in stopwords if dead_pattern.fullmatch(str(word))]
+
+    assert dead == [], f"these stopwords match nothing after the history rewrite: {dead}"
+
+
+def test_gitleaks_config_keeps_the_slack_identifier_guards() -> None:
+    config = _gitleaks_config()
+
+    slack_rule = next(rule for rule in config["rules"] if rule["id"] == "slack-conversation-id")
+    assert slack_rule["regex"] == r"\b[CGD][0-9][A-Z0-9]{7,9}\b"
+
+    assert r"\bC0EXAMPLE[0-9]\b" in config["allowlist"]["regexes"]
+
+    assert (
+        "Requiring the digit is what separates them from ordinary"
+        in GITLEAKS_CONFIG_PATH.read_text(encoding="utf-8")
+    )
+
+
+def test_scan_step_writes_the_report_the_attribution_step_reads() -> None:
+    scan_step = _scan_step()
+    assert scan_step.get("id"), "the scan step needs an id so a later step can key off its outcome"
+
+    report_path = _scan_report_path()
+    attribution_command = str(_attribution_step()["run"])
+
+    assert PurePosixPath(report_path).name in attribution_command, (
+        f"the attribution step must read the report the scan writes ({report_path})"
+    )
+
+
+def test_workflow_names_the_branch_each_finding_came_from() -> None:
+    scan_id = str(_scan_step().get("id", ""))
+    assert scan_id, "the scan step needs an id so a later step can key off its outcome"
+
+    step = _attribution_step()
+    condition = str(step.get("if", ""))
+    assert "failure()" in condition, "attribution must not fire on a green run"
+    assert re.search(
+        rf"steps\.{re.escape(scan_id)}\.(outcome|conclusion)\s*==\s*['\"]failure['\"]",
+        condition,
+    ), "attribution must be conditioned on the scan step failing"
+
+    attribution_command = str(step["run"])
+    assert PurePosixPath(_scan_report_path()).name in attribution_command
+    assert re.search(r"git for-each-ref[^\n]*--contains", attribution_command), (
+        "attribution must map each reported commit to the refs that contain it"
+    )
+    # `git branch --all --contains` lists branch refs only, so a finding on a
+    # commit reachable only from a tag printed a bare colon. The wide sweep
+    # reaches tags, so the attribution has to as well.
+    assert "refs/tags" in attribution_command, (
+        "attribution must cover tags, not only branches, because the scheduled "
+        "sweep scans every ref the checkout pulled down"
+    )
+    assert "refs/heads" in attribution_command and "refs/remotes" in attribution_command, (
+        "attribution must still cover local and remote-tracking branches"
+    )
+
+
+def test_attribution_command_names_the_branch_a_finding_came_from(tmp_path: Path) -> None:
+    repo, _ = _new_repo(tmp_path / "repo")
+
+    _git(repo, "switch", "--create", "feature/leaky")
+    (repo / "credentials.env").write_text(_runtime_secret(), encoding="utf-8")
+    leaky_sha = _commit(repo, "leaky commit")
+    _git(repo, "switch", "main")
+
+    scan = _scan(repo, report_path=_scan_report_path())
+    assert scan.returncode == 1, _scan_diagnostics(scan)
+
+    attribution = subprocess.run(
+        ["bash", "-c", str(_attribution_step()["run"])],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert attribution.returncode == 0, _scan_diagnostics(attribution)
+    assert leaky_sha in attribution.stdout, _scan_diagnostics(attribution)
+    assert "feature/leaky" in attribution.stdout, _scan_diagnostics(attribution)
+
+
+def test_attribution_command_names_the_tag_a_finding_came_from(tmp_path: Path) -> None:
+    """A finding reachable only from a tag must still be attributed to that tag.
+
+    The scheduled sweep walks every ref the full checkout pulled down, tags
+    included, and this repository carries release tags plus `backup/*` refs. A
+    branch-only attribution printed the SHA followed by an empty list once the
+    branch was deleted, which is the non-actionable output the step exists to
+    prevent.
+    """
+    repo, _ = _new_repo(tmp_path / "repo")
+
+    _git(repo, "switch", "--create", "doomed")
+    (repo / "credentials.env").write_text(_runtime_secret(), encoding="utf-8")
+    leaky_sha = _commit(repo, "leaky commit")
+    _git(repo, "tag", "v9.9.9-leaky", leaky_sha)
+    _git(repo, "switch", "main")
+    _git(repo, "branch", "--delete", "--force", "doomed")
+
+    scan = _scan(repo, report_path=_scan_report_path())
+    assert scan.returncode == 1, _scan_diagnostics(scan)
+
+    attribution = subprocess.run(
+        ["bash", "-c", str(_attribution_step()["run"])],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert attribution.returncode == 0, _scan_diagnostics(attribution)
+    assert leaky_sha in attribution.stdout, _scan_diagnostics(attribution)
+    assert "v9.9.9-leaky" in attribution.stdout, _scan_diagnostics(attribution)
+    assert not re.search(rf"{re.escape(leaky_sha)} appears on:\s*$", attribution.stdout, re.M), (
+        f"the finding was reported with no ref named: {attribution.stdout}"
+    )


### PR DESCRIPTION
Two problems in the secret scan that compound: a push to a release branch was scanning branches it does not own, and the allowlist had drifted to cover fixtures that no longer exist.

## Push scans reached every ref

`gitleaks detect` with no `--log-opts` scans `--full-history --all`. This workflow checks out with `fetch-depth: 0`, so a push to `main` or `next` scanned every fetched remote ref. Run 31879566558, a push to `next`, scanned 1138 commits and reported 17 findings, none of them on `next`: four on `task/440-per-agent-secret-delivery` and thirteen on `task/1459-channel-neutral-binding`. `next` has been red on Secret Scan since 2026-08-14 for exactly that reason.

Push events now scan the pushed commit's own history. The pull request path was already correctly scoped and is unchanged. The scheduled weekly sweep and `workflow_dispatch` stay deliberately wide across every ref.

Because the wide sweep is kept, a failing scan now names the refs that contain each reported commit, so a red sweep says where a finding lives instead of only which commit it sits on. That uses `git for-each-ref` rather than `git branch`: the sweep reaches tags too, and this repository carries `v0.1.0` through `v0.6.0` plus several `backup/*` refs, where the branch-only form printed a bare colon with nothing after it.

The attribution step keys on `steps.scan.conclusion` rather than `outcome` because `tools/ci-retry-gate` treats `steps.<id>.outcome` in an `if` as a retry marker. The job name stays exactly `gitleaks (full history)`, which `release/authorize.py` pins.

## Four stopwords that covered nothing

`C000000S06` through `C000000S09` are gone. The only commit in the repository carrying those values is the one that registered them in `.gitleaks.toml`, and the `paths` allowlist excludes that file from scanning, so they suppressed nothing. The `C0EXAMPLE[0-9]` allowlist regex and the comment explaining why the trailing digit matters are untouched. The comment on the retained `#1491` block was corrected, since it referenced the note removed here and asserted a push-scan behaviour this change ends.

## Verification

`tools/ci-retry-gate/tests/test_gitleaks_scope.py` gains ten tests, including docker-backed ones that derive the log range and the attribution shell from the workflow YAML rather than restating them, so a later edit that widens the scan or drops the attribution reds. Planting a secret on an unmerged branch: the workflow-derived push scan passes while an unscoped scan of the same repository fails. A secret introduced and later deleted in the pushed branch's own history still fails, and a finding reachable only from a tag is named by its tag.

A full-history all-refs scan of `main` with these stopwords removed reports no leaks over 1124 commits across 22 refs, confirming they were covering nothing. The same scan scoped to `next` tip `08ee4249` is clean over 1040 commits, so this change is what turns `next` green once it is forward merged.

`uv run pytest tools/ release/` is 265 passed; ruff, ruff format, and mypy are clean.

Closes #1592
Closes #1594
