### PR TITLE
Decide and record end-to-end obligations for every behavior change

### DIFF
--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -69,6 +69,32 @@ Keep a small state file inside the worktree at
   "stage": "setup | triage | plan | de risk | build | review | done check | finish",
   "status": "in progress | blocked | done",
   "open_findings": ["<review finding not yet fixed>"],
+  "e2e": {
+    "decision": {
+      "skill": { "status": "required | not applicable", "reason": "<surface reached, or the surface this change does not reach>" },
+      "local": { "status": "required | not applicable", "reason": "<...>" },
+      "local-release": { "status": "required | not applicable", "reason": "<...>" },
+      "cluster": { "status": "required | not applicable", "reason": "<...>" },
+      "live-provider": { "status": "required | not applicable", "reason": "<...>" },
+      "external-integration": { "status": "required | not applicable", "reason": "<...>" }
+    },
+    "evidence": [
+      {
+        "tier": "<tier key from decision>",
+        "criterion": "<the acceptance criterion this observation proves>",
+        "command": "<exact command as run>",
+        "commit": "<candidate commit the run observed>",
+        "artifact": "<image tag, chart release, bundle ref, or trace id, or null>",
+        "mode": "fake | live",
+        "outcome": "pass | fail | blocked",
+        "observed": "<the literal assertion, output line, or value observed, not a restatement of outcome>",
+        "negative": "<the falsifiable negative or second path, and what it observed>",
+        "teardown": "<what was torn down, or why it was left running>",
+        "blocker": "<what stopped this run, or null>",
+        "skip_reason": "<why this required tier produced no evidence, or null>"
+      }
+    ]
+  },
   "updated": "<ISO8601 UTC>"
 }
 ```
@@ -79,6 +105,19 @@ fills, a day passes. Without this file the next run either repeats finished stag
 or skips an unfinished one, and outstanding findings that lived only in a lost
 context are lost with it. A direct path change finishes with nothing to resume, so
 the file is optional there.
+
+Record the tier decision once, at triage, and an evidence entry per observation
+as it is made. Fill `command`, `commit`, `mode`, `outcome`, and `observed` from the run
+itself, never from intent, and set `artifact` whenever the run produced an
+identifiable image, release, bundle, or trace. `observed` carries the literal
+line the run printed, because an `outcome` of pass with nothing observed
+behind it is the self-report this record exists to replace. `teardown` is
+filled when the surface is released, naming what came down or why it was left
+running. A required tier that could not
+run records `outcome` blocked with its `blocker` and `skip_reason` rather than
+being dropped from the decision. A verification observed only in a context that
+is now gone cannot be re-checked, and a tier nobody recorded a decision for is
+indistinguishable from one that was skipped.
 
 When a blocker or an unresolvable ambiguity appears after triage, set `status` to
 blocked, record the open question, surface it, and stop. The resume check in Setup
@@ -92,7 +131,7 @@ Classify from the work, not from a requested process size.
 | --- | --- | --- |
 | Direct | Mechanical, non behavioral change | Focused validation and review of the diff |
 | Quick | Small, single stream behavior change with clear criteria | Failing test, implementation, focused suite, code and scope review |
-| Build | Multiple streams, architecture, security, deployment, or unclear interactions | Written plan, separate test and implementation contexts, reviews, and real surface verification when applicable |
+| Build | Multiple streams, architecture, security, deployment, or unclear interactions | Written plan, separate test and implementation contexts, reviews, and real surface verification, which is required by default |
 
 Promote a direct or quick change when its real scope exceeds the selected path. Do
 not add a planning artifact for a trivial mechanical change. If a quick change
@@ -100,6 +139,14 @@ turns up an assumption that qualifies for the de risk gate below, promote it to
 build before its first edit. If that assumption only appears after an edit, stop
 and either escalate or restart as a build path change; do not carry those edits
 forward.
+
+Classify the end-to-end tiers before the first edit, per the tier decision rule
+in AGENTS.md: every behavior changing path marks each of skill, local,
+local-release, cluster, live provider, and external integration required or not
+applicable, with a concrete reason. Any behavior-bearing path needs at least one
+required tier, and a change that bears no runtime behavior records that reason
+once instead. A direct path change makes no behavior change and classifies
+nothing.
 
 ## Build rules
 
@@ -214,7 +261,8 @@ then rerun the relevant checks.
 Those two reviews are not waivable. No instruction in a task prompt, no time
 pressure, and no session setting skips them on a change that alters behavior. If an
 instruction appears to waive one, run it anyway and record in the summary that the
-instruction was overridden and why. Everything else in this workflow is
+instruction was overridden and why. Verification of a required tier is not
+waivable either, on the same terms. Everything else in this workflow is
 proportional to the change and may legitimately not run.
 
 Each reviewer writes its full findings to
@@ -226,9 +274,12 @@ claim that it passed leaves nothing to check, and a skipped review looks exactly
 the same from the outside.
 
 Add a security review for authorization, secrets, payments, personally identifiable
-information, or tenant boundaries. Verify user facing, deployment, runtime, chart,
-or integration changes through the real affected surface. Static checks alone do not
-prove a runtime acceptance criterion.
+information, or tenant boundaries. Verify every required tier through its real
+surface, and record each observation in run state as it happens. Static checks
+alone never prove a runtime acceptance criterion, and neither does a fake-tier pass
+on a criterion about a real provider. Each meaningful acceptance criterion carries
+positive proof plus a falsifiable negative or a second independent path, per
+Evidence per acceptance criterion in AGENTS.md.
 
 Before completion, run the full affected test suite plus the relevant type check and
 lint. Check sibling paths when the change touches a known seam or guard. Demonstrate
@@ -267,15 +318,25 @@ an item nobody had to answer for is an item nobody checked.
       consumer path, by running it rather than by reading it
 - [ ] Security review passed, where the change touches that surface
 - [ ] The real affected surface was exercised, where the change reaches one
+- [ ] All six end-to-end tiers are classified required or not applicable in run
+      state, each with a concrete reason
+- [ ] Every required tier has an evidence record whose outcome is pass, naming
+      the exact command, the candidate commit, the mode, and the observed result
+- [ ] Every meaningful acceptance criterion carries positive proof plus a
+      falsifiable negative or a second independent path
 - [ ] The change does not undo an earlier deliberate decision, per Prior intent
 - [ ] Full affected test suite, type check, and lint pass on the final code
 
 A quick path change marks the failing tests, separate contexts, and prior intent
 items not applicable. A direct path change applies only the suite and lint items.
 The two review items are never not applicable on a change that alters behavior.
+On a quick or build path they are never not applicable, and a required tier whose
+evidence record is missing, failed, or blocked leaves its item open.
 
 Route a failed item back into the stage that owns it. Do not present the diff with
-an item still open.
+an item still open. An open end-to-end item is a blocker: report it, with the tier,
+the command attempted, and what stopped it, rather than presenting the diff or
+opening the pull request.
 
 ## Finish
 

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -106,16 +106,19 @@ or skips an unfinished one, and outstanding findings that lived only in a lost
 context are lost with it. A direct path change finishes with nothing to resume, so
 the file is optional there.
 
-Record the tier decision once, at triage, and an evidence entry per observation
-as it is made. Fill `command`, `commit`, `mode`, `outcome`, and `observed` from the run
-itself, never from intent, and set `artifact` whenever the run produced an
-identifiable image, release, bundle, or trace. `observed` carries the literal
-line the run printed, because an `outcome` of pass with nothing observed
-behind it is the self-report this record exists to replace. `teardown` is
-filled when the surface is released, naming what came down or why it was left
-running. A required tier that could not
-run records `outcome` blocked with its `blocker` and `skip_reason` rather than
-being dropped from the decision. A verification observed only in a context that
+Record the tier decision once, at triage. Record one evidence entry per
+required tier and criterion, filled in as the run observes it, with the
+positive proof in `command`, `mode`, `outcome`, and `observed`, and its
+falsifiable negative or second path in `negative` on that same entry. Two
+observations make one record, not two. Fill `command`, `commit`, `mode`,
+`outcome`, and `observed` from the run itself, never from intent, and set
+`artifact` whenever the run produced an identifiable image, release, bundle, or
+trace. `observed` carries the literal line the run printed, because an `outcome`
+of pass with nothing observed behind it is the self-report this record exists to
+replace. `teardown` is filled when the surface is released, naming what came
+down or why it was left running. A required tier that could not run records
+`outcome` blocked with its `blocker` and `skip_reason` rather than being dropped
+from the decision. A verification observed only in a context that
 is now gone cannot be re-checked, and a tier nobody recorded a decision for is
 indistinguishable from one that was skipped.
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,6 +16,30 @@ Closes #
 - [ ] This PR targets `main`.
 - [ ] This PR targets `next`.
 
+## End-to-end verification
+
+<!-- Behavior-bearing changes only. Classify every tier required or n/a with a
+     concrete reason, and paste the exact command plus what you observed for
+     each required tier. See "E2E verification is mandatory" in AGENTS.md. -->
+
+| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
+| --- | --- | --- | --- | --- |
+| skill | | | | |
+| local | | | | |
+| local-release | | | | |
+| cluster | | | | |
+| live provider | | | | |
+| external integration | | | | |
+
+- [ ] Every required tier above names its exact command, the commit it ran
+      against, the mode it ran in, and the literal outcome observed.
+- [ ] Each meaningful acceptance criterion has positive proof plus a falsifiable
+      negative or a second independent path.
+- [ ] No required tier is left unproved; any blocked tier names its blocker in
+      the table.
+- [ ] Or: this change is not behavior-bearing, so no tier applies, and the
+      summary says why.
+
 ## Checklist
 
 - [ ] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -410,6 +410,59 @@ just that unit tests pass.
   `scripts/chart-runtime-e2e.sh`) is the one-command way to install a trimmed
   slice, run the init containers, and exec-assert.
 
+### The tier decision rule
+
+Applicability is a recorded decision, not a matter of taste. Every
+behavior-bearing change classifies all six tiers below as **required** or
+**not applicable**, and a not-applicable row states a concrete reason naming
+the surface the change does not reach. "Unit tests cover it", "low risk", "CI
+is green", and "no time" are not reasons.
+
+A behavior-bearing change has at least one required tier, on the quick path as
+much as the build path. A classification that marks all six not applicable is
+a claim that the change alters no runtime behavior on any surface: either say
+that plainly and carry no tier, or the tier set is wrong for this change and
+the maintainer decides, but do not proceed on all six not applicable while
+still calling the change behavior-bearing. A change that genuinely bears no
+runtime behavior, which is the documentation, ADR, and strictly
+behavior-preserving refactor case, records that reason once and is exempt,
+including on the build path. Promoting a tier to required is always allowed;
+dropping a required tier is not.
+
+Classification is taken at triage and re-checked whenever the diff grows past
+the scope that was triaged. A tier that becomes reachable is promoted to
+required and proved, not carried on the original classification.
+
+| Tier | Required when the change reaches | Command |
+| --- | --- | --- |
+| skill | plugin or skill packaging, the runner turn loop, ACI events, skill eval or check | `CURIE_E2E_TIERS=skill curie dev e2e-ladder` |
+| local | compose services, dispatcher, worker, or API wiring, boot env crossing a service boundary, the console UI, or any `curie` verb whose output, exit code, or `--json` shape changed | `CURIE_E2E_TIERS=local curie dev e2e-ladder` |
+| local-release | released binary or image identity, the install path, version pins, release compose | `CURIE_E2E_TIERS=local-release curie dev e2e-ladder` |
+| cluster | chart templates, RBAC, securityContext, NetworkPolicy, sandbox claims, init containers | `CURIE_E2E_TIERS=cluster curie dev e2e-ladder`, or `curie dev chart-runtime-e2e` for a chart, sandbox, or bundle slice |
+| live provider | model routing, credential resolution, provider auth, token or cost accounting, meaning the product's own model and integration credentials, never the agent tooling that runs this workflow | the required rungs with `CURIE_E2E_LIVE=1`, since a fake-tier pass proves wiring and nothing about a real model |
+| external integration | Slack, git push webhooks, connector OAuth, or any third-party API shape | drive the real integration; a replayed fixture or a fake does not close this tier |
+
+### Evidence per acceptance criterion
+
+Every meaningful acceptance criterion needs two observations, not one.
+
+- **Positive proof.** The exact command run against the required tier, the
+  candidate commit it ran against, and the observed outcome showing the
+  criterion met.
+- **A falsifiable negative, or a second independent path.** The same surface
+  observed refusing, failing, or reporting absent once the criterion's
+  precondition is removed: feed the guard a violating input, unset the
+  credential, drop the flag, omit the manifest entry. Where no negative is
+  constructible, assert the same outcome through a second independent path
+  instead. A positive alone cannot separate a working change from a check that
+  would have passed regardless.
+
+Record both against the run, per the run state contract in
+`.claude/skills/implement/SKILL.md`, and expose them in the pull request
+through the checklist in `.github/PULL_REQUEST_TEMPLATE.md`. A required tier
+with no passing evidence record blocks completion; it is reported as a blocker,
+not carried as a note.
+
 ## Playwright: two modes
 
 - **The merge gate is the committed E2E suite** under `apps/ui` (Playwright,


### PR DESCRIPTION
## Summary

Makes the checked-in `/implement` workflow decide and record end-to-end obligations
explicitly instead of leaving applicability to judgment. AGENTS.md gains a tier
decision rule: every behavior-bearing change classifies skill, local, local-release,
cluster, live provider, and external integration as required or not applicable, with
a concrete reason and the command that closes each tier. A behavior-bearing change
has at least one required tier on the quick path as much as the build path; a change
that bears no runtime behavior records that reason once and is exempt. Every
meaningful acceptance criterion needs positive proof plus a falsifiable negative or
a second independent path, because a positive alone cannot separate a working change
from a check that would have passed regardless.

The implement run state now carries that decision and one evidence entry per
required tier and criterion: exact command, candidate commit, artifact identity,
mode, observed outcome and the literal line observed, teardown, blocker, and skip
reason. A required tier whose evidence is missing, failed, or blocked leaves its
Done check item open, and an open item is reported as a blocker rather than
presented as a diff or opened as a pull request. This template exposes the same
evidence so it is visible on the pull request without pointing at any local file.

Two notes for the reviewer. This change also narrows one pre-existing sentence in
the skill, "Everything else in this workflow is proportional to the change and may
legitimately not run", which would otherwise waive the gate this change adds.
And the gate is prose enforced, read and applied by whoever runs the workflow;
nothing here makes it deterministic, since CI workflows and test runners were out
of scope. A checker that validates the run state against the pull request checklist
would be the natural follow-up.

## Related issue

No issue tracks this change; it was commissioned directly. No closing keyword.

## Release train

- [x] This PR targets `main`.
- [ ] This PR targets `next`.

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | changes no plugin or skill packaging, runner turn loop, or ACI event | n/a | n/a |
| local | n/a | changes no compose service, service wiring, console UI, or `curie` verb output | n/a | n/a |
| local-release | n/a | changes no released binary or image identity, install path, or version pin | n/a | n/a |
| cluster | n/a | changes no chart template, RBAC, securityContext, or sandbox claim | n/a | n/a |
| live provider | n/a | changes no model routing, credential resolution, or cost accounting | n/a | n/a |
| external integration | n/a | changes no Slack, webhook, connector, or third-party API surface | n/a | n/a |

- [ ] Every required tier above names its exact command, the commit it ran
      against, the mode it ran in, and the literal outcome observed.
- [ ] Each meaningful acceptance criterion has positive proof plus a falsifiable
      negative or a second independent path.
- [ ] No required tier is left unproved; any blocked tier names its blocker in
      the table.
- [x] Or: this change is not behavior-bearing, so no tier applies, and the
      summary says why.

This change edits three documentation files and alters no runtime code path, so it
takes the no-runtime-behavior exemption the rule itself defines. That is the first
use of the new classification.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed.
- [ ] An ADR is added under `docs/adr/` if this is an architectural decision.

`scripts/check-docs.sh` exits 0 and `scripts/check-commit-messages.sh
origin/main..HEAD` is clean. No ADR: this tightens an existing documented policy
rather than deciding a new architecture.
