### PR TITLE
Add deterministic E2E CI selection

### DIFF
--- a/.github/e2e-selection.yaml
+++ b/.github/e2e-selection.yaml
@@ -1,0 +1,22 @@
+version: 1
+fallback: [skill, local, local-release, cluster]
+rules:
+  exact:
+    compose.dev.yaml: [local]
+    pyproject.toml: [skill, local, local-release, cluster]
+    uv.lock: [skill, local, local-release, cluster]
+    .github/e2e-selection.yaml: [skill, local, local-release, cluster]
+    .github/workflows/ci.yaml: [skill, local, local-release, cluster]
+  prefixes:
+    charts: [cluster]
+    compose: [local-release]
+    apps/api: [local, local-release, cluster]
+    apps/worker: [local, local-release, cluster]
+    otel: [local, local-release]
+    runner: [skill, local, local-release, cluster]
+    cli: [skill, local, local-release, cluster]
+    packages: [skill, local, local-release, cluster]
+    examples: [skill, local, local-release, cluster]
+    tools/e2e-ci-selection: [skill, local, local-release, cluster]
+  ignored_prefixes:
+    docs: []

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -587,9 +587,8 @@ jobs:
   # Reuses the release binary the Rust job already built and uploaded. The
   # local rung needs a working Docker daemon for `docker compose`;
   # ubuntu-latest ships one, the same assumption the `compose` job above
-  # already relies on. `CURIE_E2E_TIERS` and `CURIE_E2E_LIVE` are left
-  # unset, so the script's own defaults apply: skill + local rungs, fake
-  # model, credential-free. Expect this to be the slowest job in the
+  # already relies on. `CURIE_E2E_TIERS` carries the selected skill and local
+  # subset. Expect this to be the slowest job in the
   # workflow -- three image builds (runner, api, worker base) plus one more
   # (the worker-local overlay) that compose triggers itself, on top of the
   # actual up/deploy/message/down round trip; `local up --wait` alone can run
@@ -651,7 +650,7 @@ jobs:
     # just stops paying the ~2min image-build + rung cost when nothing it
     # exercises changed. Always runs on push to either release train branch (the
     # changes job forces it).
-    if: needs.changes.outputs.ladder == 'true'
+    if: ${{ needs.changes.outputs.skill == 'true' || needs.changes.outputs.local == 'true' }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -737,6 +736,7 @@ jobs:
         env:
           CURIE_BIN: cli/target/release/curie
           CURIE_BASE_TAG: ci-local
+          CURIE_E2E_TIERS: ${{ needs.changes.outputs.skill_local_tiers }}
         run: bash cli/scripts/e2e-ladder.sh
 
   # LOCAL-RELEASE RUNG -- split into its own job (issue #695 follow-up) so it
@@ -746,13 +746,12 @@ jobs:
   # so it must rebuild the images; the shared GHA layer cache defuses that --
   # these builds hit the same ladder-{runner,api,worker} scopes e2e-ladder
   # populates, so on a warm cache they cost the --load export, not a full
-  # rebuild. Same use:false / build-push-action mechanism and the same path
-  # gate as e2e-ladder, so the two skip together on irrelevant PRs.
+  # rebuild. Uses the same use:false / build-push-action mechanism.
   e2e-ladder-release:
     name: E2E parity ladder (local-release, fake model)
     runs-on: ubuntu-latest
     needs: [rust-build, changes]
-    if: needs.changes.outputs.ladder == 'true'
+    if: ${{ needs.changes.outputs.local_release == 'true' }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -866,62 +865,45 @@ jobs:
   # treat the kind/reachability path as unverified rather than assuming the
   # theory above is right. Kept a SEPARATE job from `e2e-ladder` on purpose: the
   # skill/local signal must never be reddened by a kind or Helm flake.
-  # Gate the expensive e2e parity ladder rungs so they run ONLY when a change
-  # could affect the build/deploy/message path any rung exercises (charts / cli /
-  # app+runner images / the ACI wire / this workflow), and always on push to
-  # either release train branch. An unrelated PR (docs, UI-only, gtools, etc.) skips every ladder rung
-  # entirely -- the ladder's image builds + rungs are ~2min it need not pay when
-  # nothing it tests changed. Pure git-diff, no third-party action. (No ladder
-  # rung is a required check anyway -- the ruleset requires only
-  # Compose/Contracts/Python/Rust/UI -- so this only trims wasted runs, never
-  # blocks a merge.)
   changes:
-    name: Detect ladder-relevant changes
+    name: Select end to end tiers
     runs-on: ubuntu-latest
     outputs:
-      ladder: ${{ steps.filter.outputs.ladder }}
+      skill: ${{ steps.filter.outputs.skill }}
+      local: ${{ steps.filter.outputs.local }}
+      local_release: ${{ steps.filter.outputs.local_release }}
+      cluster: ${{ steps.filter.outputs.cluster }}
+      skill_local_tiers: ${{ steps.filter.outputs.skill_local_tiers }}
     steps:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
           fetch-depth: 0
+      - name: Install uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
       - id: filter
         run: |
           set -euo pipefail
           if [ "${{ github.event_name }}" = "push" ]; then
-            echo "ladder=true" >> "$GITHUB_OUTPUT"   # post-merge gate on a release train branch
-            exit 0
-          fi
-          base="${{ github.base_ref }}"
-          git fetch --quiet origin "$base"
-          # The ladder-relevant surface. #906 reused #843's cluster-rung filter
-          # verbatim when it gated all three rungs, but the local and
-          # local-release rungs BOOT COMPOSE, so their input surface is strictly
-          # larger: compose.dev.yaml (local), the generated release compose and
-          # the generator/overlay under compose/ (local-release), and otel/ (the
-          # collector every profile starts). Without those a compose-only PR
-          # skipped the very rungs that exist to test compose -- including the
-          # local-release rung whose stated purpose is closing that parity seam
-          # (#958). compose.release.yaml is generated, not tracked, and is listed
-          # so a future decision to commit it does not silently re-open the hole.
-          # #1032 widened the surface again: examples/ is the fixed bundle every
-          # rung deploys (cli/scripts/e2e-ladder.sh hardcodes BUNDLE_SRC to
-          # examples/weather and copies it into both the local and local-release
-          # workdirs), and the root pyproject.toml / uv.lock are what every
-          # ladder image builds and boots. A PR editing any of the three changed
-          # what the rungs exercise while skipping every rung.
-          if git diff --name-only "origin/$base...HEAD" \
-              | grep -qE '^(charts/|cli/|apps/|runner/|packages/|examples/|compose/|compose\.dev\.yaml|compose\.release\.yaml|otel/|pyproject\.toml|uv\.lock|\.github/workflows/ci\.yaml)'; then
-            echo "ladder=true" >> "$GITHUB_OUTPUT"
+            uv run --no-project --with pyyaml==6.0.3 python \
+              tools/e2e-ci-selection/select.py \
+              --registry .github/e2e-selection.yaml \
+              --push
           else
-            echo "ladder=false" >> "$GITHUB_OUTPUT"
+            base="${{ github.base_ref }}"
+            git fetch --quiet origin "$base"
+            uv run --no-project --with pyyaml==6.0.3 python \
+              tools/e2e-ci-selection/select.py \
+              --registry .github/e2e-selection.yaml \
+              --base "origin/$base" \
+              --head HEAD
           fi
 
   e2e-ladder-cluster:
     name: E2E parity ladder (cluster rung on kind, fake model)
     runs-on: ubuntu-latest
     needs: [rust-build, changes]
-    if: needs.changes.outputs.ladder == 'true'
+    if: ${{ needs.changes.outputs.cluster == 'true' }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -1163,3 +1145,71 @@ jobs:
           kubectl get events -n curie --sort-by=.lastTimestamp | tail -50 || true
           kubectl describe pods -n curie -l app.kubernetes.io/component=runner-sandbox || true
           kubectl logs -n curie -l app.kubernetes.io/component=worker --tail=100 || true
+
+  e2e-required:
+    name: E2E required
+    runs-on: ubuntu-latest
+    needs: [changes, e2e-ladder, e2e-ladder-release, e2e-ladder-cluster]
+    if: ${{ always() }}
+    steps:
+      - name: Require exact selected outcomes
+        env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          SKILL_SELECTED: ${{ needs.changes.outputs.skill }}
+          LOCAL_SELECTED: ${{ needs.changes.outputs.local }}
+          LOCAL_RELEASE_SELECTED: ${{ needs.changes.outputs.local_release }}
+          CLUSTER_SELECTED: ${{ needs.changes.outputs.cluster }}
+          SKILL_LOCAL_RESULT: ${{ needs.e2e-ladder.result }}
+          LOCAL_RELEASE_RESULT: ${{ needs.e2e-ladder-release.result }}
+          CLUSTER_RESULT: ${{ needs.e2e-ladder-cluster.result }}
+        run: |
+          set -euo pipefail
+
+          check_boolean() {
+            [[ "$1" == "true" || "$1" == "false" ]]
+          }
+
+          check_group() {
+            if [[ "$1" == "true" ]]; then
+              [[ "$2" == "success" ]]
+            else
+              [[ "$2" == "skipped" ]]
+            fi
+          }
+
+          check_results() {
+            [[ "$1" == "success" ]] || return 1
+            check_boolean "$2" || return 1
+            check_boolean "$3" || return 1
+            check_boolean "$4" || return 1
+            check_boolean "$5" || return 1
+
+            skill_local_selected="false"
+            if [[ "$2" == "true" || "$3" == "true" ]]; then
+              skill_local_selected="true"
+            fi
+
+            check_group "$skill_local_selected" "$6" || return 1
+            check_group "$4" "$7" || return 1
+            check_group "$5" "$8" || return 1
+          }
+
+          if check_results success true false false false skipped skipped skipped; then
+            echo "Selected and skipped negative control failed" >&2
+            exit 1
+          fi
+          echo "Selected and skipped negative control passed"
+
+          if ! check_results \
+            "$CHANGES_RESULT" \
+            "$SKILL_SELECTED" \
+            "$LOCAL_SELECTED" \
+            "$LOCAL_RELEASE_SELECTED" \
+            "$CLUSTER_SELECTED" \
+            "$SKILL_LOCAL_RESULT" \
+            "$LOCAL_RELEASE_RESULT" \
+            "$CLUSTER_RESULT"; then
+            echo "E2E required failed" >&2
+            exit 1
+          fi
+          echo "E2E required passed"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1165,51 +1165,48 @@ jobs:
         run: |
           set -euo pipefail
 
-          check_boolean() {
-            [[ "$1" == "true" || "$1" == "false" ]]
-          }
-
-          check_group() {
-            if [[ "$1" == "true" ]]; then
-              [[ "$2" == "success" ]]
-            else
-              [[ "$2" == "skipped" ]]
-            fi
-          }
-
-          check_results() {
-            [[ "$1" == "success" ]] || return 1
-            check_boolean "$2" || return 1
-            check_boolean "$3" || return 1
-            check_boolean "$4" || return 1
-            check_boolean "$5" || return 1
-
-            skill_local_selected="false"
-            if [[ "$2" == "true" || "$3" == "true" ]]; then
-              skill_local_selected="true"
-            fi
-
-            check_group "$skill_local_selected" "$6" || return 1
-            check_group "$4" "$7" || return 1
-            check_group "$5" "$8" || return 1
-          }
-
-          if check_results success true false false false skipped skipped skipped; then
-            echo "Selected and skipped negative control failed" >&2
+          if [[ "$CHANGES_RESULT" != "success" ||
+                ( "$SKILL_SELECTED" != "true" && "$SKILL_SELECTED" != "false" ) ||
+                ( "$LOCAL_SELECTED" != "true" && "$LOCAL_SELECTED" != "false" ) ||
+                ( "$LOCAL_RELEASE_SELECTED" != "true" && "$LOCAL_RELEASE_SELECTED" != "false" ) ||
+                ( "$CLUSTER_SELECTED" != "true" && "$CLUSTER_SELECTED" != "false" ) ]]; then
+            echo "E2E required failed" >&2
             exit 1
           fi
-          echo "Selected and skipped negative control passed"
 
-          if ! check_results \
-            "$CHANGES_RESULT" \
-            "$SKILL_SELECTED" \
-            "$LOCAL_SELECTED" \
-            "$LOCAL_RELEASE_SELECTED" \
-            "$CLUSTER_SELECTED" \
-            "$SKILL_LOCAL_RESULT" \
-            "$LOCAL_RELEASE_RESULT" \
-            "$CLUSTER_RESULT"; then
+          skill_local_expected="skipped"
+          if [[ "$SKILL_SELECTED" == "true" || "$LOCAL_SELECTED" == "true" ]]; then
+            skill_local_expected="success"
+          fi
+          local_release_expected="skipped"
+          if [[ "$LOCAL_RELEASE_SELECTED" == "true" ]]; then
+            local_release_expected="success"
+          fi
+          cluster_expected="skipped"
+          if [[ "$CLUSTER_SELECTED" == "true" ]]; then
+            cluster_expected="success"
+          fi
+
+          if [[ "$SKILL_LOCAL_RESULT" != "$skill_local_expected" ||
+                "$LOCAL_RELEASE_RESULT" != "$local_release_expected" ||
+                "$CLUSTER_RESULT" != "$cluster_expected" ]]; then
             echo "E2E required failed" >&2
+            exit 1
+          fi
+
+          negative_skill_local_expected="skipped"
+          if [[ "true" == "true" || "false" == "true" ]]; then
+            negative_skill_local_expected="success"
+          fi
+          negative_local_release_expected="skipped"
+          negative_cluster_expected="skipped"
+          if [[ "success" != "success" ||
+                "skipped" == "$negative_skill_local_expected" ||
+                "skipped" == "$negative_local_release_expected" ||
+                "skipped" == "$negative_cluster_expected" ]]; then
+            echo "Selected and skipped negative control passed"
+          else
+            echo "Selected and skipped negative control failed" >&2
             exit 1
           fi
           echo "E2E required passed"

--- a/release/tests/test_authorize.py
+++ b/release/tests/test_authorize.py
@@ -15,6 +15,7 @@ import inspect
 import json
 import os
 import re
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -1202,62 +1203,34 @@ class TestLegitimateSkips:
             required_names=TEST_REQUIRED_NAMES,
         )
 
-    def test_every_conditional_required_ci_job_gates_only_on_the_ladder_output(self):
-        """A required ci.yaml job may carry no `if:` but the ladder gate.
-
-        Exactly two required jobs are conditional today -- `e2e-ladder`
-        (`E2E parity ladder (skill + local, fake model)`) and
-        `e2e-ladder-release` (`E2E parity ladder (local-release, fake model)`)
-        -- and both gate solely on `needs.changes.outputs.ladder == 'true'`,
-        which the `changes` job forces true on push (pinned behaviorally by the
-        test below). Any other expression reopens the hole: adding a
-        `github.event_name == 'pull_request'` conjunct, for instance, would
-        conclude those required checks `skipped` on every push and block every
-        release, while the `changes` job still faithfully wrote `ladder=true`.
-
-        Filtered on `REQUIRED_CHECK_NAMES` rather than over all jobs because
-        `e2e-ladder-cluster` and `commit-messages` also declare an `if:` but
-        their names are not required, so a skip there cannot reach the gate;
-        they are out of this assertion by construction. Asserted over every
-        matching job rather than the two known ids, so a newly-added
-        conditional required job is covered without editing this test.
-        """
+    def test_required_ci_job_conditions_match_tier_outputs(self):
+        """Required conditional jobs must select exactly their owned tiers."""
         doc = yaml.safe_load(CI_YAML.read_text())
-        offenders = {
+        actual = {
             job_id: str(job["if"]).strip()
             for job_id, job in doc["jobs"].items()
             if job.get("name") in authorize_module.REQUIRED_CHECK_NAMES
             and "if" in job
-            and str(job["if"]).strip() != "needs.changes.outputs.ladder == 'true'"
+        }
+        expected = {
+            "e2e-ladder": (
+                "${{ needs.changes.outputs.skill == 'true' || "
+                "needs.changes.outputs.local == 'true' }}"
+            ),
+            "e2e-ladder-release": (
+                "${{ needs.changes.outputs.local_release == 'true' }}"
+            ),
         }
 
-        assert not offenders, (
-            "ci.yaml required job(s) carry a job-level `if:` other than the "
-            "ladder gate, so their required check-run can conclude `skipped` on "
-            f"a release train push and block every release: {sorted(offenders.items())}"
+        assert actual == expected, (
+            "required ci.yaml jobs no longer gate on their exact tier outputs: "
+            f"expected {expected!r}, got {actual!r}"
         )
 
-    def test_the_changes_filter_step_emits_ladder_true_when_executed_as_a_push(
+    def test_the_changes_filter_step_emits_every_tier_when_executed_as_a_push(
         self, tmp_path
     ):
-        """The push short-circuit is what makes the conditional jobs safe.
-
-        The `changes` job's filter step emits `ladder=true` unconditionally on
-        a push to a release train branch, before ever consulting the
-        changed-file filter, so the required ladder jobs gated on that output
-        always run and never report `skipped` on a releasable push. Remove the
-        short-circuit and a docs-only push skips both required checks, and this
-        gate refuses every release.
-
-        Executed rather than grepped: a harmless shell rewrite of the same
-        behavior would fail a text scan, and a scan that finds the literal
-        `ladder=true` in a branch that no longer runs would pass while the
-        safety was gone. Interpolations are substituted first --
-        `github.event_name` becomes `push`, every other expression becomes
-        empty -- so without the short-circuit the script falls through to
-        `git fetch --quiet origin ""` under `set -euo pipefail` and exits
-        non-zero. It runs in `tmp_path` so it cannot touch this repo.
-        """
+        """A push selects every tier through the real selector runtime."""
         doc = yaml.safe_load(CI_YAML.read_text())
         filter_step = next(
             step
@@ -1271,6 +1244,14 @@ class TestLegitimateSkips:
         )
         script_path = tmp_path / "filter.sh"
         script_path.write_text(script)
+        selector_path = tmp_path / "tools" / "e2e-ci-selection" / "select.py"
+        selector_path.parent.mkdir(parents=True)
+        shutil.copy2(
+            REPO_ROOT / "tools" / "e2e-ci-selection" / "select.py", selector_path
+        )
+        registry_path = tmp_path / ".github" / "e2e-selection.yaml"
+        registry_path.parent.mkdir()
+        shutil.copy2(REPO_ROOT / ".github" / "e2e-selection.yaml", registry_path)
         github_output = tmp_path / "github_output"
         github_output.touch()
 
@@ -1283,14 +1264,18 @@ class TestLegitimateSkips:
         )
 
         assert result.returncode == 0, (
-            "ci.yaml's `changes` filter step no longer short-circuits on push -- "
-            "it fell through to the changed-file filter and failed: "
+            "ci.yaml's `changes` filter step no longer selects tiers on push: "
             f"{result.stderr}"
         )
-        assert "ladder=true" in github_output.read_text(), (
-            "ci.yaml's `changes` job no longer forces ladder=true on push, so the "
-            "`if: needs.changes.outputs.ladder == 'true'` required jobs can report "
-            f"`skipped` on a release train push: {github_output.read_text()!r}"
+        assert github_output.read_text().splitlines() == [
+            "skill=true",
+            "local=true",
+            "local_release=true",
+            "cluster=true",
+            "skill_local_tiers=skill,local",
+        ], (
+            "ci.yaml's push selection no longer emits the complete tier contract: "
+            f"{github_output.read_text()!r}"
         )
 
 

--- a/tools/e2e-ci-selection/select.py
+++ b/tools/e2e-ci-selection/select.py
@@ -1,0 +1,217 @@
+"""Select end to end CI tiers from changed repository paths."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, cast
+
+import yaml
+
+TIERS = ("skill", "local", "local-release", "cluster")
+OUTPUT_KEYS = {
+    "skill": "skill",
+    "local": "local",
+    "local-release": "local_release",
+    "cluster": "cluster",
+}
+
+
+class RegistryError(ValueError):
+    """The selection registry is malformed or ambiguous."""
+
+
+class UniqueKeyLoader(yaml.SafeLoader):
+    """YAML loader that rejects duplicate mapping keys."""
+
+
+def _construct_unique_mapping(
+    loader: yaml.SafeLoader,
+    node: yaml.nodes.MappingNode,
+    deep: bool = False,
+) -> dict[Any, Any]:
+    loader.flatten_mapping(node)
+    result: dict[Any, Any] = {}
+    for key_node, value_node in node.value:
+        key = loader.construct_object(key_node, deep=deep)
+        try:
+            duplicate = key in result
+        except TypeError as exc:
+            raise RegistryError("registry contains an unhashable mapping key") from exc
+        if duplicate:
+            raise RegistryError(f"duplicate registry key: {key}")
+        result[key] = loader.construct_object(value_node, deep=deep)
+    return result
+
+
+UniqueKeyLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+    _construct_unique_mapping,
+)
+
+
+@dataclass(frozen=True)
+class Registry:
+    fallback: tuple[str, ...]
+    exact: dict[str, tuple[str, ...]]
+    prefixes: dict[str, tuple[str, ...]]
+    ignored_prefixes: tuple[str, ...]
+
+
+def _mapping(value: object, label: str) -> dict[str, object]:
+    if not isinstance(value, dict):
+        raise RegistryError(f"{label} must be a mapping")
+    if any(not isinstance(key, str) for key in value):
+        raise RegistryError(f"{label} keys must be strings")
+    return cast(dict[str, object], value)
+
+
+def _tiers(value: object, label: str) -> tuple[str, ...]:
+    if not isinstance(value, list) or any(not isinstance(item, str) for item in value):
+        raise RegistryError(f"{label} must be a tier list")
+    tiers = tuple(item for item in value if isinstance(item, str))
+    if len(set(tiers)) != len(tiers):
+        raise RegistryError(f"{label} contains a duplicate tier")
+    unknown = sorted(set(tiers).difference(TIERS))
+    if unknown:
+        raise RegistryError(f"{label} contains unknown tiers: {', '.join(unknown)}")
+    return tiers
+
+
+def _tier_rules(value: object, label: str) -> dict[str, tuple[str, ...]]:
+    rules = _mapping(value, label)
+    selected: dict[str, tuple[str, ...]] = {}
+    for path, tiers in rules.items():
+        if not path or path.startswith("/") or path.endswith("/"):
+            raise RegistryError(f"{label} contains an invalid path")
+        selected_tiers = _tiers(tiers, f"{label}.{path}")
+        if not selected_tiers:
+            raise RegistryError(f"{label}.{path} must select at least one tier")
+        selected[path] = selected_tiers
+    return selected
+
+
+def _matches_prefix(path: str, prefix: str) -> bool:
+    return path == prefix or path.startswith(f"{prefix}/")
+
+
+def _load_registry(path: Path) -> Registry:
+    with path.open(encoding="utf-8") as stream:
+        document = yaml.load(stream, Loader=UniqueKeyLoader)
+    root = _mapping(document, "registry")
+    if type(root.get("version")) is not int or root["version"] != 1:
+        raise RegistryError("registry version must be 1")
+
+    fallback = _tiers(root.get("fallback"), "fallback")
+    if fallback != TIERS:
+        raise RegistryError("fallback must contain every tier in canonical order")
+
+    rules = _mapping(root.get("rules"), "rules")
+    if set(rules) != {"exact", "prefixes", "ignored_prefixes"}:
+        raise RegistryError("rules must define exact, prefixes, and ignored_prefixes")
+    exact = _tier_rules(rules["exact"], "rules.exact")
+    prefixes = _tier_rules(rules["prefixes"], "rules.prefixes")
+    ignored_rules = _mapping(rules["ignored_prefixes"], "rules.ignored_prefixes")
+
+    ignored_prefixes: list[str] = []
+    for ignored, value in ignored_rules.items():
+        if not ignored or ignored.startswith("/") or ignored.endswith("/"):
+            raise RegistryError("rules.ignored_prefixes contains an invalid path")
+        if value != []:
+            raise RegistryError("ignored prefix values must be empty lists")
+        ignored_prefixes.append(ignored)
+
+    for ignored in ignored_prefixes:
+        if any(_matches_prefix(path, ignored) for path in exact):
+            raise RegistryError(f"ignored prefix overlaps a selected rule: {ignored}")
+        if any(
+            _matches_prefix(prefix, ignored) or _matches_prefix(ignored, prefix)
+            for prefix in prefixes
+        ):
+            raise RegistryError(f"ignored prefix overlaps a selected rule: {ignored}")
+
+    return Registry(fallback, exact, prefixes, tuple(ignored_prefixes))
+
+
+def _select_path(registry: Registry, path: str) -> set[str]:
+    if any(_matches_prefix(path, prefix) for prefix in registry.ignored_prefixes):
+        return set()
+
+    selected: set[str] = set()
+    matched = False
+    if path in registry.exact:
+        matched = True
+        selected.update(registry.exact[path])
+    for prefix, tiers in registry.prefixes.items():
+        if _matches_prefix(path, prefix):
+            matched = True
+            selected.update(tiers)
+    return selected if matched else set(registry.fallback)
+
+
+def _changed_paths(base: str, head: str) -> list[str]:
+    completed = subprocess.run(
+        ["git", "diff", "--no-renames", "--name-only", f"{base}...{head}"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return [line for line in completed.stdout.splitlines() if line]
+
+
+def _render(selected: set[str]) -> str:
+    lines = [
+        f"{OUTPUT_KEYS[tier]}={'true' if tier in selected else 'false'}"
+        for tier in TIERS
+    ]
+    skill_local = ",".join(tier for tier in TIERS[:2] if tier in selected)
+    lines.append(f"skill_local_tiers={skill_local}")
+    return "\n".join(lines) + "\n"
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--registry", required=True, type=Path)
+    parser.add_argument("--path", action="append", default=[])
+    parser.add_argument("--base")
+    parser.add_argument("--head")
+    parser.add_argument("--push", action="store_true")
+    return parser
+
+
+def _run() -> None:
+    args = _parser().parse_args()
+    registry = _load_registry(args.registry)
+
+    if args.push:
+        if args.path or args.base or args.head:
+            raise RegistryError("push cannot be combined with paths or revisions")
+        selected = set(TIERS)
+    else:
+        if args.path and (args.base or args.head):
+            raise RegistryError("paths cannot be combined with revisions")
+        if args.path:
+            paths = args.path
+        elif args.base and args.head:
+            paths = _changed_paths(args.base, args.head)
+        else:
+            raise RegistryError("provide paths, push, or both base and head revisions")
+        selected = set().union(*(_select_path(registry, path) for path in paths))
+
+    output_path = os.environ.get("GITHUB_OUTPUT")
+    if not output_path:
+        raise RegistryError("GITHUB_OUTPUT is required")
+    with Path(output_path).open("a", encoding="utf-8") as stream:
+        stream.write(_render(selected))
+
+
+def main() -> int:
+    _run()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/e2e-ci-selection/tests/test_e2e_ci_selection.py
+++ b/tools/e2e-ci-selection/tests/test_e2e_ci_selection.py
@@ -1,0 +1,431 @@
+"""Executable contract for deterministic end to end CI selection."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SELECTOR = REPO_ROOT / "tools" / "e2e-ci-selection" / "select.py"
+REGISTRY = REPO_ROOT / ".github" / "e2e-selection.yaml"
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yaml"
+
+TIERS = ("skill", "local", "local-release", "cluster")
+OUTPUT_KEYS = {
+    "skill": "skill",
+    "local": "local",
+    "local-release": "local_release",
+    "cluster": "cluster",
+}
+
+
+def _invoke_selector(
+    tmp_path: Path,
+    *paths: str,
+    registry: Path = REGISTRY,
+    push: bool = False,
+    base: str | None = None,
+    head: str | None = None,
+    cwd: Path | None = None,
+) -> tuple[subprocess.CompletedProcess[str], str]:
+    output_path = tmp_path / f"github-output-{len(list(tmp_path.glob('github-output-*')))}"
+    command = [sys.executable, str(SELECTOR), "--registry", str(registry)]
+    if push:
+        command.append("--push")
+    if base is not None:
+        command.extend(("--base", base))
+    if head is not None:
+        command.extend(("--head", head))
+    for path in paths:
+        command.extend(("--path", path))
+
+    environment = os.environ.copy()
+    environment["GITHUB_OUTPUT"] = str(output_path)
+    completed = subprocess.run(
+        command,
+        cwd=cwd or tmp_path,
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    output = output_path.read_text() if output_path.exists() else ""
+    return completed, output
+
+
+def _expected_output(*selected: str) -> str:
+    selected_tiers = set(selected)
+    lines = [
+        f"{OUTPUT_KEYS[tier]}={'true' if tier in selected_tiers else 'false'}"
+        for tier in TIERS
+    ]
+    skill_local = ",".join(tier for tier in TIERS[:2] if tier in selected_tiers)
+    lines.append(f"skill_local_tiers={skill_local}")
+    return "\n".join(lines) + "\n"
+
+
+def _assert_selection(
+    tmp_path: Path,
+    path: str,
+    selected: tuple[str, ...],
+) -> None:
+    completed, output = _invoke_selector(tmp_path, path)
+    assert completed.returncode == 0, completed.stderr
+    assert output == _expected_output(*selected)
+
+
+@pytest.mark.parametrize(
+    ("path", "selected"),
+    [
+        ("runner/example.py", TIERS),
+        ("compose.dev.yaml", ("local",)),
+        ("compose/generated.py", ("local-release",)),
+        ("charts/curie/values.yaml", ("cluster",)),
+        ("apps/api/example.py", ("local", "local-release", "cluster")),
+        ("apps/worker/example.py", ("local", "local-release", "cluster")),
+        ("otel/collector.yaml", ("local", "local-release")),
+        ("cli/example.rs", TIERS),
+        ("packages/example.py", TIERS),
+        ("pyproject.toml", TIERS),
+        ("uv.lock", TIERS),
+    ],
+)
+def test_registry_maps_each_known_surface(
+    tmp_path: Path,
+    path: str,
+    selected: tuple[str, ...],
+) -> None:
+    _assert_selection(tmp_path, path, selected)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "examples/weather/evals/cases.json",
+        ".github/e2e-selection.yaml",
+        ".github/workflows/ci.yaml",
+        "tools/e2e-ci-selection/select.py",
+    ],
+)
+def test_weather_and_enforcement_paths_select_every_tier(tmp_path: Path, path: str) -> None:
+    _assert_selection(tmp_path, path, TIERS)
+
+
+def test_ignored_unknown_and_union_selection_are_deterministic(tmp_path: Path) -> None:
+    ignored, ignored_output = _invoke_selector(tmp_path, "docs/example.md")
+    assert ignored.returncode == 0, ignored.stderr
+    assert ignored_output == _expected_output()
+
+    unknown, unknown_output = _invoke_selector(tmp_path, "new-surface/module.py")
+    assert unknown.returncode == 0, unknown.stderr
+    assert unknown_output == _expected_output(*TIERS)
+
+    forward, forward_output = _invoke_selector(
+        tmp_path,
+        "charts/curie/values.yaml",
+        "compose.dev.yaml",
+        "otel/collector.yaml",
+    )
+    reverse, reverse_output = _invoke_selector(
+        tmp_path,
+        "otel/collector.yaml",
+        "compose.dev.yaml",
+        "charts/curie/values.yaml",
+    )
+    assert forward.returncode == 0, forward.stderr
+    assert reverse.returncode == 0, reverse.stderr
+    assert forward_output == reverse_output == _expected_output(
+        "local",
+        "local-release",
+        "cluster",
+    )
+
+
+def test_push_selects_every_tier_without_a_repository(tmp_path: Path) -> None:
+    completed, output = _invoke_selector(tmp_path, push=True)
+    assert completed.returncode == 0, completed.stderr
+    assert output == _expected_output(*TIERS)
+
+
+def test_revisions_select_changed_paths_and_unknown_fallback(tmp_path: Path) -> None:
+    repository = tmp_path / "repository"
+    repository.mkdir()
+    subprocess.run(
+        ["git", "init", "--initial-branch", "main"],
+        cwd=repository,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        cwd=repository,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test User"],
+        cwd=repository,
+        check=True,
+    )
+
+    known_path = repository / "compose.dev.yaml"
+    known_path.write_text("version: one\n")
+    subprocess.run(["git", "add", "."], cwd=repository, check=True)
+    subprocess.run(["git", "commit", "-m", "base"], cwd=repository, check=True)
+    base = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repository,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+    known_path.write_text("version: two\n")
+    subprocess.run(["git", "commit", "-am", "known"], cwd=repository, check=True)
+    known_head = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repository,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    known, known_output = _invoke_selector(
+        tmp_path,
+        base=base,
+        head=known_head,
+        cwd=repository,
+    )
+    assert known.returncode == 0, known.stderr
+    assert known_output == _expected_output("local")
+
+    (repository / "new-surface.txt").write_text("new\n")
+    subprocess.run(["git", "add", "."], cwd=repository, check=True)
+    subprocess.run(["git", "commit", "-m", "unknown"], cwd=repository, check=True)
+    unknown_head = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repository,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    unknown, unknown_output = _invoke_selector(
+        tmp_path,
+        base=known_head,
+        head=unknown_head,
+        cwd=repository,
+    )
+    assert unknown.returncode == 0, unknown.stderr
+    assert unknown_output == _expected_output(*TIERS)
+
+
+VALID_REGISTRY = """
+version: 1
+fallback: [skill, local, local-release, cluster]
+rules:
+  exact:
+    compose.dev.yaml: [local]
+  prefixes:
+    charts: [cluster]
+  ignored_prefixes:
+    docs: []
+"""
+
+
+@pytest.mark.parametrize(
+    "registry_text",
+    [
+        VALID_REGISTRY.replace("charts: [cluster]", "charts: [unknown]"),
+        VALID_REGISTRY.replace("charts: [cluster]", "charts: [cluster, cluster]"),
+        VALID_REGISTRY.replace("compose.dev.yaml: [local]", "compose.dev.yaml: []"),
+        VALID_REGISTRY.replace("charts: [cluster]", "charts: []"),
+        VALID_REGISTRY.replace("version: 1", "version: true"),
+        VALID_REGISTRY.replace(
+            "    charts: [cluster]",
+            "    charts: [cluster]\n    charts: [local]",
+        ),
+        VALID_REGISTRY.replace("  exact:\n    compose.dev.yaml: [local]", "  exact: []"),
+        VALID_REGISTRY.replace(
+            "fallback: [skill, local, local-release, cluster]",
+            "fallback: [skill, local]",
+        ),
+        VALID_REGISTRY.replace("    docs: []", "    charts: []"),
+    ],
+    ids=(
+        "unknown_tier",
+        "duplicate_tier",
+        "empty_exact_tiers",
+        "empty_prefix_tiers",
+        "boolean_version",
+        "duplicate_rule",
+        "malformed_entry",
+        "invalid_fallback",
+        "ignored_overlap",
+    ),
+)
+def test_selector_rejects_invalid_registries(
+    tmp_path: Path,
+    registry_text: str,
+) -> None:
+    registry = tmp_path / "registry.yaml"
+    registry.write_text(registry_text)
+    completed, _output = _invoke_selector(tmp_path, "charts/example.yaml", registry=registry)
+    assert completed.returncode != 0
+
+
+AGGREGATE_EXPRESSIONS = {
+    "changes_result": "${{ needs.changes.result }}",
+    "skill_selected": "${{ needs.changes.outputs.skill }}",
+    "local_selected": "${{ needs.changes.outputs.local }}",
+    "local_release_selected": "${{ needs.changes.outputs.local_release }}",
+    "cluster_selected": "${{ needs.changes.outputs.cluster }}",
+    "skill_local_result": "${{ needs.e2e-ladder.result }}",
+    "local_release_result": "${{ needs.e2e-ladder-release.result }}",
+    "cluster_result": "${{ needs.e2e-ladder-cluster.result }}",
+}
+
+
+def test_workflow_consumes_each_selection_output_exactly() -> None:
+    workflow = yaml.safe_load(WORKFLOW.read_text())
+    jobs = workflow["jobs"]
+    assert jobs["changes"]["outputs"] == {
+        "skill": "${{ steps.filter.outputs.skill }}",
+        "local": "${{ steps.filter.outputs.local }}",
+        "local_release": "${{ steps.filter.outputs.local_release }}",
+        "cluster": "${{ steps.filter.outputs.cluster }}",
+        "skill_local_tiers": "${{ steps.filter.outputs.skill_local_tiers }}",
+    }
+
+    skill_local = jobs["e2e-ladder"]
+    assert skill_local["if"] == (
+        "${{ needs.changes.outputs.skill == 'true' || "
+        "needs.changes.outputs.local == 'true' }}"
+    )
+    ladder_steps = [
+        step
+        for step in skill_local["steps"]
+        if step.get("run") == "bash cli/scripts/e2e-ladder.sh"
+    ]
+    assert len(ladder_steps) == 1
+    assert ladder_steps[0]["env"]["CURIE_E2E_TIERS"] == (
+        "${{ needs.changes.outputs.skill_local_tiers }}"
+    )
+
+    assert jobs["e2e-ladder-release"]["if"] == (
+        "${{ needs.changes.outputs.local_release == 'true' }}"
+    )
+    assert jobs["e2e-ladder-cluster"]["if"] == (
+        "${{ needs.changes.outputs.cluster == 'true' }}"
+    )
+
+
+def _aggregate_contract() -> tuple[str, dict[str, str]]:
+    workflow = yaml.safe_load(WORKFLOW.read_text())
+    job = workflow["jobs"]["e2e-required"]
+    assert job["name"] == "E2E required"
+    assert set(job["needs"]) == {
+        "changes",
+        "e2e-ladder",
+        "e2e-ladder-release",
+        "e2e-ladder-cluster",
+    }
+    assert job["if"] == "${{ always() }}"
+
+    candidates = [
+        step
+        for step in job["steps"]
+        if isinstance(step, dict)
+        and isinstance(step.get("run"), str)
+        and isinstance(step.get("env"), dict)
+        and AGGREGATE_EXPRESSIONS["changes_result"] in step["env"].values()
+    ]
+    assert len(candidates) == 1
+    step = candidates[0]
+    bindings: dict[str, str] = {}
+    for semantic_name, expression in AGGREGATE_EXPRESSIONS.items():
+        environment_names = [
+            name for name, value in step["env"].items() if value == expression
+        ]
+        assert len(environment_names) == 1, expression
+        bindings[semantic_name] = environment_names[0]
+    return step["run"], bindings
+
+
+def _run_aggregate(**overrides: str) -> subprocess.CompletedProcess[str]:
+    script, bindings = _aggregate_contract()
+    state = {
+        "changes_result": "success",
+        "skill_selected": "false",
+        "local_selected": "false",
+        "local_release_selected": "false",
+        "cluster_selected": "false",
+        "skill_local_result": "skipped",
+        "local_release_result": "skipped",
+        "cluster_result": "skipped",
+    }
+    state.update(overrides)
+    environment = os.environ.copy()
+    environment.update({bindings[name]: value for name, value in state.items()})
+    return subprocess.run(
+        ["bash", "--noprofile", "--norc", "-e", "-o", "pipefail", "-c", script],
+        cwd=REPO_ROOT,
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+@pytest.mark.parametrize(
+    "state",
+    [
+        {},
+        {"skill_selected": "true", "skill_local_result": "success"},
+        {"local_selected": "true", "skill_local_result": "success"},
+        {
+            "skill_selected": "true",
+            "local_selected": "true",
+            "local_release_selected": "true",
+            "cluster_selected": "true",
+            "skill_local_result": "success",
+            "local_release_result": "success",
+            "cluster_result": "success",
+        },
+    ],
+)
+def test_aggregate_accepts_exact_selected_outcomes(state: dict[str, str]) -> None:
+    completed = _run_aggregate(**state)
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+
+
+@pytest.mark.parametrize(
+    "state",
+    [
+        {"changes_result": "failure"},
+        {"skill_selected": "true", "skill_local_result": "skipped"},
+        {"local_selected": "true", "skill_local_result": "cancelled"},
+        {"local_release_selected": "true", "local_release_result": "failure"},
+        {"cluster_selected": "true", "cluster_result": "skipped"},
+        {"skill_local_result": "success"},
+        {"local_release_result": "success"},
+        {"cluster_result": "success"},
+    ],
+)
+def test_aggregate_rejects_inconsistent_outcomes(state: dict[str, str]) -> None:
+    completed = _run_aggregate(**state)
+    assert completed.returncode != 0
+
+
+def test_aggregate_negative_control_runs_before_real_results() -> None:
+    completed = _run_aggregate()
+    output = completed.stdout + completed.stderr
+    assert completed.returncode == 0, output
+    negative_control = "Selected and skipped negative control passed"
+    real_result = "E2E required passed"
+    assert negative_control in output
+    assert real_result in output
+    assert output.index(negative_control) < output.index(real_result)


### PR DESCRIPTION
Replaces the hand maintained ladder path selector with a versioned registry and checked selector. Adds a single E2E required aggregate that accepts valid not applicable outcomes and fails closed when selected rung evidence is missing, skipped, cancelled, or failed.

Validation: uv run pytest -q tools/e2e-ci-selection/tests/test_e2e_ci_selection.py tools/ci-workflow-paths/tests/test_workflow_paths.py; uv run ruff check tools/e2e-ci-selection; uv run mypy tools/e2e-ci-selection/select.py.

Administrator action after merge: add the E2E required check name to branch protection. Repository settings were not modified.