### PR TITLE
Release 0.6.1

### DIFF
--- a/charts/curie/Chart.yaml
+++ b/charts/curie/Chart.yaml
@@ -8,8 +8,8 @@ description: >-
   and two install-time preflights ship baked in: a CPU-AVX / ClickHouse-pin
   check and a NetworkPolicy-enforcement probe.
 type: application
-version: 0.6.1-rc.1
-appVersion: "0.6.1-rc.1"
+version: 0.6.1
+appVersion: "0.6.1"
 kubeVersion: ">=1.25.0-0"
 maintainers:
   - name: Curie

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -749,7 +749,7 @@ dependencies = [
 
 [[package]]
 name = "curie"
-version = "0.6.1-rc.1"
+version = "0.6.1"
 dependencies = [
  "anstream",
  "anstyle",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "curie"
-version = "0.6.1-rc.1"
+version = "0.6.1"
 edition = "2021"
 description = "Curie CLI: init/start/send/eval a plugin against a local runner (task I1)"
 


### PR DESCRIPTION
Sets `main`'s in-tree release version to the final `0.6.1`, so a `v0.6.1` tag publishes assets that self-report the version they are.

`main` currently reads `0.6.1-rc.1`. The prerelease `v0.6.1-rc.1` was tagged and published on 2026-08-16, and everything gating the final release is now done, so this is the last change before the tag. Tagging `v0.6.1` without this bump would ship a CLI whose `--version` reads `0.6.1-rc.1` and a chart that pins its images by `appVersion` to the RC.

Same three files and one string as every prior release commit (`ae1a91de`, `492d127b`, `21b14d56`, `50439d49`):

- `charts/curie/Chart.yaml` (`version` and `appVersion`)
- `cli/Cargo.toml`
- `cli/Cargo.lock`, matched on the `[[package]]` block whose `name = "curie"` rather than by string replacement

`scripts/check-version-consistency.sh` exits 0 and `git grep '0\.6\.1-rc\.1'` returns nothing after this change.