### PR TITLE
Prove one artifact and one suite at every parity ladder rung

### DIFF
--- a/cli/CLAUDE.md
+++ b/cli/CLAUDE.md
@@ -215,10 +215,14 @@ the environment.
 Cold-start parity ladder (issue #690, `curie dev e2e-ladder` ->
 `cli/scripts/e2e-ladder.sh`) -- an E2E test, same as the scripted E2E above, not
 the falsifiability gate below it. It chains three rungs: rung 1 delegates to
-`e2e.sh` unchanged; rung 2 drives `local up --minimal` -> `local deploy` ->
-`local message` (reply asserted) -> `local down`, against `compose.dev.yaml`;
-rung 3 drives `cluster deploy` -> `cluster message` against a pre-installed
-release, a real round trip with no manual port-forward. A fourth,
+`e2e.sh`, passing it the common `examples/weather` bundle via
+`CURIE_E2E_BUNDLE` (a standalone `e2e.sh` run keeps its own `--from-spec`
+scaffold when the var is unset); rung 2 drives `local up --minimal` ->
+`local deploy` -> `local message` (reply asserted) -> `local down`, against
+`compose.dev.yaml`; rung 3 drives `cluster deploy` -> `cluster message`
+against a pre-installed release, a real round trip with no manual
+port-forward. The ladder asserts one bundle identity, one eval suite, and one
+model mode across every rung and fails on divergence. A fourth,
 separately-named `local-release` rung (issue #695) repeats rung 2's exact round
 trip against `compose.release.yaml` instead -- the file
 `compose/generate_release_compose.py` derives from `compose.dev.yaml` and the

--- a/cli/README.md
+++ b/cli/README.md
@@ -619,11 +619,13 @@ real model, failing fast if no model credential (`ANTHROPIC_API_KEY`,
 `CLAUDE_CODE_OAUTH_TOKEN`, or `CURIE_CREDENTIALS`) is present.
 
 The cold-start parity ladder (`curie dev e2e-ladder`, `cli/scripts/e2e-ladder.sh`)
-runs the same skill-tier script as rung 1, then adds a local rung (`local up
+runs rung 1 as the skill-tier script against the same bundle every other rung
+drives, then adds a local rung (`local up
 --minimal` -> `local deploy` -> `local message` with the reply asserted ->
 `local down`, against `compose.dev.yaml`) and a cluster rung (`cluster deploy`
 then `cluster message`, a real round trip with no manual port-forward) against
-a pre-installed release.
+a pre-installed release. It asserts one bundle identity, one eval suite, and
+one model mode across every rung and fails on divergence.
 
 A `local-release` rung repeats the local rung's exact round trip against the
 generated `compose.release.yaml` instead -- the artifact a release binary's
@@ -633,7 +635,7 @@ only coverage it gets. It needs the release-pinned
 `ghcr.io/curie-eng/curie-api` and `-worker-local` images already built and
 tagged locally (it preflights and fails with a fix hint otherwise).
 
-Two env knobs configure it:
+Three env knobs configure it:
 
 - `CURIE_E2E_TIERS` -- which rungs to run. Defaults to `skill,local`
   (credential-free, CI-safe); `all` runs `skill,local,cluster`. A tier named
@@ -653,6 +655,13 @@ Two env knobs configure it:
   host -- notably a kind/minikube cluster whose API server binds loopback, where
   the auto-detected `127.0.0.1` is unreachable from a pod. CI's kind cluster job
   sets it to the kind Docker network gateway.
+
+`CURIE_E2E_BUNDLE` is not a ladder knob: the ladder hardcodes `examples/weather`
+as its bundle source and sets the var itself when it invokes `cli/scripts/e2e.sh`
+for rung 1, so every rung drives the same bundle. It is a knob of `e2e.sh` --
+set it standalone to drive `e2e.sh` against a named bundle instead of
+scaffolding its own `deal-desk` one; leave it unset and `e2e.sh` keeps that
+scaffold. Exporting it before a ladder run has no effect on the ladder's rungs.
 
 The one-command pre-release gate:
 

--- a/cli/scripts/e2e-ladder.sh
+++ b/cli/scripts/e2e-ladder.sh
@@ -3,8 +3,24 @@
 #
 # This is an E2E test, not a gate: it drives the SAME bundle through each
 # deployment tier with the tier's own real verbs and asserts a turn actually
-# finalized. Rung 1 (skill) is the existing `cli/scripts/e2e.sh`, invoked as is
-# so the skill leg has exactly one implementation. Rung 2 (local) is
+# finalized.
+#
+# "The same bundle" is PROVEN, not asserted in prose. It cannot be proven by
+# packing once: no CLI surface accepts a pre-packed archive, so every tier packs
+# for itself -- skill packs and hashes client-side (cli/src/bundle.rs), while
+# local and cluster upload raw bytes the platform hashes server-side
+# (apps/api/src/curie_api/deploy.py). So the ladder packs ONCE PER RUNG from one
+# canonical source tree and asserts the independently computed sha256 values are
+# equal. That is a superset of pack-once: it additionally proves the skill
+# tier's client-side packer and the platform's server-side hasher agree on the
+# same source. The same reasoning applies to the case set -- the digest covers
+# `evals/cases.json`, so digest equality IS the case-id proof at the deployed
+# tiers, while each tier's own suite loader independently reports the suite name
+# and case count via `eval --dry-run`.
+#
+# Rung 1 (skill) is the existing `cli/scripts/e2e.sh`, invoked as is
+# so the skill leg has exactly one implementation, and handed THIS run's bundle
+# copy through CURIE_E2E_BUNDLE. Rung 2 (local) is
 # `local up --minimal` -> `local deploy` -> `local message` -> `local down`,
 # against `compose.dev.yaml`. The `local-release` mode is the same round trip
 # against `compose.release.yaml` instead -- the generated, checkout-free
@@ -31,9 +47,14 @@
 # every rung and requires a credential up front. Under fake, the local and
 # cluster rungs assert PLUMBING only -- that a turn finalized and a reply came
 # back -- never reply CONTENT (ADR-0055, #612): an assertion tuned to the
-# fake's canned reply manufactures a green. Rung 1 (skill) runs its own real
-# eval graders against whichever model it booted (cli/scripts/e2e.sh), fake or
-# live, since that leg is acceptance evidence for #325, not a plumbing probe.
+# fake's canned reply manufactures a green. Rung 1 (skill) invokes its own
+# tier's evaluator on whichever model it booted (cli/scripts/e2e.sh), but a FAKE
+# skill run is not a graded run: the skill evaluator refuses to consult a grader
+# on a fake turn (cli/src/evals.rs turn_outcome returns PlumbingOk), so every
+# case reports plumbing_ok and no grader ever reads a reply. A fake skill rung
+# therefore verifies PLUMBING and CASE IDENTITY only -- that the suite loaded,
+# that its cases are the ones the ladder packed, and that each turn completed.
+# GRADING, at every rung including skill, happens in LIVE mode only.
 #
 # Requirements: docker, a cargo toolchain (or $CURIE_BIN), and an
 # curie-runner image (`curie build`). Rung 3 additionally needs a reachable
@@ -81,6 +102,22 @@ FAKE_SENTINEL="all done"
 # brought a stack up owns tearing it down, so a stack that was already running
 # when the ladder started is reused and left alone.
 LOCAL_STACK_OWNED=0
+
+# Cross-rung artifact identity, pinned by the first rung to report a digest and
+# matched by every later one (see assert_bundle_identity). Empty until then.
+PARITY_DIGEST=""
+# What the run summary is allowed to claim: the rungs that ran, and the rungs
+# whose identity / suite / model mode were each actually asserted. Accumulated
+# by the assertions themselves, so the summary can never over-report.
+RAN_RUNGS=""
+PARITY_RUNGS=""
+SUITE_RUNGS=""
+MODE_RUNGS=""
+# Whether the cluster rung proved its turn could only bind to the deployment it
+# just created. Set only by the full active-set assertion, which is conditional
+# at that tier (see rung_cluster), so the summary reports upload identity and
+# runtime binding as the two separate claims they are.
+CLUSTER_BINDING_PROVEN=0
 
 # The label the sandbox substrate stamps on every runner container it spawns
 # (cli/src/docker.rs SANDBOX_LABEL, apps/worker sandbox/types.py). Container
@@ -182,7 +219,10 @@ apply_model_mode() {
         export CURIE_FAKE_MODEL=1
         echo "model mode: FAKE (sealed; CURIE_FAKE_MODEL=1 exported for the local rung)"
     fi
-    echo "note: the cluster rung's model is a property of the installed release (cluster up --fake-model), not of this run."
+    # Was a disclaimer that the cluster rung's mode is unverified. It is now
+    # verified: every deployed rung reads CURIE_FAKE_MODEL off the artifact that
+    # is actually running and fails on a contradiction (assert_model_mode).
+    echo "note: each deployed rung's effective mode is VERIFIED against this choice by reading CURIE_FAKE_MODEL off the running worker; a contradiction fails that rung."
 }
 
 # Accept ONLY the `reply` shape with finalized == true and a non-empty reply.
@@ -261,6 +301,299 @@ else:
     fi
 }
 
+# Cross-rung artifact identity. The digest identifies the ARCHIVE a tier
+# actually shipped, and the two sides compute it independently: skill hashes the
+# bytes it packed client-side (cli/src/bundle.rs), local and cluster get back the
+# platform's server-side hash of the bytes they uploaded
+# (apps/api/src/curie_api/deploy.py). The first rung to report pins the value;
+# every later rung must match it, so equality proves both hashers agree on one
+# source tree -- and, because `evals/cases.json` is inside that archive, that
+# every rung graded the same case ids.
+#
+# Deliberately called at the END of a rung rather than at its deploy step: the
+# rung's suite and mode evidence must reach the transcript BEFORE a cross-rung
+# divergence stops the run, because "the tier's own plan line matched and only
+# the digest moved" is exactly what distinguishes a case-ids-only divergence
+# from a suite divergence. Aborting at the deploy step would throw away the
+# evidence that makes the failure diagnosable.
+assert_bundle_identity() {
+    local label="$1" digest="$2"
+    if [[ -z "$digest" || "$digest" == "null" || "$digest" == "None" ]]; then
+        echo "$label: no bundle digest was reported, so this rung's artifact identity is unknown and cannot be compared." >&2
+        return 1
+    fi
+    if [[ -z "$PARITY_DIGEST" ]]; then
+        PARITY_DIGEST="$digest"
+        PARITY_RUNGS="$PARITY_RUNGS $label"
+        echo "$label: bundle identity pinned for this ladder run: $digest"
+        return 0
+    fi
+    if [[ "$digest" != "$PARITY_DIGEST" ]]; then
+        echo "$label: bundle identity DIVERGED -- this ladder pinned $PARITY_DIGEST, but the $label rung shipped $digest." >&2
+        echo "fix: the rungs are not running the same artifact. Check that nothing mutated the bundle copies between rungs, and that every copy's regular-file mtimes were normalized (pack_tar_gz embeds per-file mtime, so equal content is not enough)." >&2
+        return 1
+    fi
+    PARITY_RUNGS="$PARITY_RUNGS $label"
+    echo "$label: bundle identity matches the pinned digest: $digest"
+}
+
+# The suite the TIER's own frozen loader resolved, read off `eval --dry-run`.
+# Runs in fake mode as well as live: a dry run sends no turn, grades nothing and
+# needs no reachable stack (it returns before connecting), yet it still loads and
+# validates the cases file. The plan line carries a suite NAME and a case COUNT
+# and no ids at all, so this is a cross-check that the ladder handed the tier the
+# file it thinks it did -- never a case-id readback. The case-id claim at these
+# tiers rests on digest equality (assert_bundle_identity).
+assert_suite() {
+    local label="$1" payload="$2" line grade_line="" count="" suite=""
+    while IFS= read -r line; do
+        if [[ "$line" =~ ^grade\ ([0-9]+)\ case\(s\)\ from\ suite\ \"(.*)\"\ against\ the\ .+\ tier$ ]]; then
+            grade_line="$line"
+            count="${BASH_REMATCH[1]}"
+            suite="${BASH_REMATCH[2]}"
+        fi
+    done < <(printf '%s' "$payload" | python3 -c '
+import json, sys
+try:
+    plan = json.loads(sys.stdin.read()).get("plan") or []
+except Exception:
+    plan = []
+for entry in plan:
+    print(entry)
+' || true)
+    if [[ -z "$grade_line" ]]; then
+        # Print the raw payload, not just a verdict: a corrupt .curie in the
+        # invoking cwd can red this check for reasons that have nothing to do
+        # with parity, and the raw output is what tells the two apart.
+        echo "$label: the tier's \`eval --dry-run\` plan carried no \"grade N case(s) from suite ... tier\" line, so the suite it resolved cannot be read." >&2
+        printf '%s\n' "$payload" >&2
+        return 1
+    fi
+    # Re-match to repopulate BASH_REMATCH: the loop above may have run further
+    # iterations since the match that set grade_line.
+    [[ "$grade_line" =~ ^grade\ ([0-9]+)\ case\(s\)\ from\ suite\ \"(.*)\"\ against\ the\ .+\ tier$ ]]
+    local count="${BASH_REMATCH[1]}" suite="${BASH_REMATCH[2]}"
+    if [[ "$suite" != "$EXPECT_SUITE" || "$count" != "$EXPECT_CASE_COUNT" ]]; then
+        echo "$label: the tier resolved a different suite than the ladder packed. Expected suite \"$EXPECT_SUITE\" with $EXPECT_CASE_COUNT case(s); the tier's own loader reported: $grade_line" >&2
+        return 1
+    fi
+    SUITE_RUNGS="$SUITE_RUNGS $label"
+    echo "$label: suite parity asserted (name and count only, no ids) -- the tier's own loader reported: $grade_line"
+}
+
+# The effective model mode of the DEPLOYED artifact, compared against what this
+# run asked for. Truthiness rule mirrored from cli/src/local.rs
+# fake_model_is_truthy; an ABSENT value means live, because compose only
+# materializes a value through ${CURIE_FAKE_MODEL:-1} and the chart only sets it
+# on a sealed install.
+#
+# Bounded to FRESH claims, deliberately: mode reaches a run through the binding
+# (apps/worker/src/curie_worker/binding.py fake_model=...), read per claim, so
+# this describes the mode the NEXT turn gets. It says nothing about a sandbox
+# that was already running when the ladder started. Each rung deploys and then
+# messages, so that is exactly the turn it cares about -- but do not later read
+# this assertion as a claim about pre-existing sandboxes.
+assert_model_mode() {
+    local label="$1" observed="$2" truthy=0
+    case "${observed,,}" in
+        1|true|yes) truthy=1 ;;
+    esac
+    if [[ "$LIVE" == "1" ]]; then
+        if (( truthy )); then
+            echo "$label: this run asked for the LIVE model, but the deployed worker carries CURIE_FAKE_MODEL=$observed, so the rung would run sealed against the fake model and any grade it reported would be manufactured." >&2
+            echo "fix: for a compose rung run \`curie local down\` and re-run so the stack boots live; for the cluster rung reinstall the release without \`cluster up --fake-model\`." >&2
+            return 1
+        fi
+        MODE_RUNGS="$MODE_RUNGS $label"
+        echo "$label: deployed worker carries no truthy CURIE_FAKE_MODEL (observed: '$observed'), so the rung is live as asked"
+        return 0
+    fi
+    if (( ! truthy )); then
+        echo "$label: this run is sealed (fake model), but the deployed worker's CURIE_FAKE_MODEL is '$observed', which is not truthy, so the rung would call a real model." >&2
+        echo "fix: bring the deployment up sealed, or set CURIE_E2E_LIVE=1 to run the ladder live deliberately." >&2
+        return 1
+    fi
+    MODE_RUNGS="$MODE_RUNGS $label"
+    echo "$label: deployed worker carries CURIE_FAKE_MODEL=$observed (sealed, as asked)"
+}
+
+# A deploy receipt proves what was UPLOADED. It does NOT prove the following
+# `message` and `eval` turns ran that deployment: `deploy` defaults the
+# environment to dev (cli/src/commands.rs) while the worker's runtime binding
+# prefers prod over recency (apps/worker/src/curie_worker/binding.py's
+# `ORDER BY (d.environment = 'prod') DESC, d.deployed_at DESC`) over the ACTIVE
+# set only. So one stale active prod row for this agent serves the turn while the
+# ladder reports the digest of the dev bundle it just uploaded: a green ladder
+# proving the wrong artifact. Not hypothetical here -- `local down` is
+# deliberately non-destructive and the compose project name is pinned to
+# `curie`, so Postgres volumes and their deployment rows outlive every run and
+# are shared across worktrees.
+#
+# The invariant asserted, chosen over re-implementing that ORDER BY in shell:
+# exactly ONE active deployment exists for this agent, and it is this run's.
+# Why that is sufficient, each link checkable:
+#  1. A channel maps to exactly one agent, enforced in the database --
+#     apps/api/src/curie_api/models.py:44
+#     `slack_channel: Mapped[str] = mapped_column(unique=True)`, added by #38
+#     because without it the create succeeded and the second agent was silently
+#     shadowed by the worker's resolver at runtime.
+#  2. That agent has exactly one active deployment, which is what this
+#     assertion counts.
+#  3. The resolver selects over the ACTIVE set only --
+#     apps/worker/src/curie_worker/binding.py:172
+#     `JOIN {schema}.deployments d ON d.agent_id = a.id AND d.status = 'active'`,
+#     the same predicate counted here -- so no other status value can serve a
+#     row this assertion never saw.
+# Therefore the row the worker resolves for this channel can only be this run's,
+# whatever ordering it applies.
+#
+# Residual, named and deliberately not engineered around: the read happens before
+# the turn, so a deployment created in that window is not caught. That needs a
+# concurrent deployer against the same stack, which is why the ladder owns its
+# stack rather than fighting a foreign one.
+assert_sole_active_deployment() {
+    local label="$1" agent_id="$2" deployment_id="$3" api_base verdict listed
+    # The CLI's own public inputs, with the CLI's own defaults (cli/src/main.rs's
+    # --api-url/--api-key clap declarations, defaulting to the crate constants
+    # DEFAULT_LOCAL_API_URL and DEFAULT_API_KEY in cli/src/message.rs). Reading
+    # the same two variables means this queries whatever API the deploy above
+    # actually went to; it is not a ladder-local or test-only knob.
+    api_base="${CURIE_API_URL:-http://localhost:28000}"
+    # python3 + urllib, already a hard dependency of this script, so the read
+    # adds no new binary requirement.
+    verdict="$(python3 -c '
+import json, sys, urllib.request
+base, key, agent_id, deployment_id = sys.argv[1:5]
+url = base.rstrip("/") + "/deployments?agent_id=" + agent_id
+request = urllib.request.Request(url, headers={"X-API-Key": key})
+try:
+    with urllib.request.urlopen(request, timeout=30) as response:
+        rows = json.load(response)
+except Exception as exc:
+    print("unreachable")
+    print("%s: %s" % (type(exc).__name__, exc))
+    sys.exit(0)
+if not isinstance(rows, list):
+    print("unparseable")
+    print(repr(rows)[:400])
+    sys.exit(0)
+# Validate EVERY row before filtering, and fail on any that is not a
+# DeploymentOut (apps/api/src/curie_api/schemas.py). Skipping malformed rows
+# inside the filter instead would be fail-open on an unexpected shape: a
+# response carrying the expected active row PLUS a null or a truncated object
+# would be silently reduced to the one good row and pass as proof that exactly
+# one active deployment exists. An unexpected shape must surface as itself.
+required = ("id", "agent_id", "version_id", "environment", "status")
+malformed = [
+    r for r in rows
+    if not isinstance(r, dict) or any(field not in r for field in required)
+]
+if malformed:
+    print("malformed_row")
+    print(repr(malformed[:3])[:400])
+    sys.exit(0)
+active = [r for r in rows if r.get("status") == "active"]
+listed = ", ".join(
+    "%s (environment %s)" % (r.get("id"), r.get("environment")) for r in active
+) or "<none>"
+print("ok" if len(active) == 1 and active[0].get("id") == deployment_id else "shadowed")
+print(listed)
+' "$api_base" "${CURIE_API_KEY:-curie-dev-key}" "$agent_id" "$deployment_id" || echo "probe_failed")"
+    # Two-line protocol, split on the FIRST newline; `listed` first, because the
+    # second expansion overwrites the string both read.
+    listed="${verdict#*$'\n'}"
+    verdict="${verdict%%$'\n'*}"
+
+    case "$verdict" in
+        ok)
+            echo "$label: exactly one active deployment for this agent, and it is the one this rung just created ($deployment_id), so the turn below can only bind to it"
+            ;;
+        malformed_row)
+            echo "$label: the deployments read from $api_base/deployments?agent_id=$agent_id returned a row that is not a deployment object carrying id, agent_id, version_id, environment and status: $listed" >&2
+            echo "why: a malformed row is not filtered away here, deliberately. Discarding it would be fail-open -- the expected active row plus a null would then read as 'exactly one active deployment', certifying a binding this ladder never actually checked." >&2
+            echo "fix: this is an API or proxy problem, not a stale-state one; check what is answering GET /deployments at $api_base before trusting any rung's identity claim." >&2
+            return 1
+            ;;
+        shadowed)
+            echo "$label: the turn is NOT guaranteed to run the deployment this rung just created ($deployment_id). Active deployments for agent $agent_id: $listed" >&2
+            echo "why: the worker's runtime binding prefers an active prod deployment over recency, so a stale row can serve the turn while this rung reports the digest it just uploaded -- a green ladder proving the wrong artifact." >&2
+            echo "fix: curie local down --wipe --yes, then re-run the ladder." >&2
+            return 1
+            ;;
+        *)
+            echo "$label: could not read the active deployment set from $api_base/deployments?agent_id=$agent_id ($verdict): $listed" >&2
+            return 1
+            ;;
+    esac
+}
+
+# The two mode probes below are the SECOND deliberate use of this script's
+# documented raw-tool exception (see the header): no `curie` verb reports the
+# effective model mode of a deployed tier -- neither local-status.schema.json nor
+# cluster-status.schema.json carries a model field, and `local rebuild --json`'s
+# model_mode is a re-derivation from the invoking shell, not a read of the
+# running stack. So the ladder mirrors the CLI's own internal probe
+# (cli/src/message.rs probe_fake_model), which is deliberately a read of the
+# OUTPUT rather than a re-derivation of the input. A CLI verb that surfaced this
+# value is the named follow-up; adding one here is forbidden by scope.
+#
+# The project label on the `docker ps` below is deliberate EXTRA scoping, NOT a
+# mirror: the CLI selects on the service label alone, which is host-wide and
+# would match a concurrent worktree's worker. The compose project name is pinned
+# to `curie` by the CLI (cli/src/local.rs COMPOSE_PROJECT_NAME), so adding it
+# selects this ladder's stack and nothing else. Do not "fix" it back to an exact
+# mirror of the CLI's selector.
+probe_local_fake_model() {
+    local line value="" workers=()
+    while IFS= read -r line; do
+        if [[ -n "$line" ]]; then
+            workers+=("$line")
+        fi
+    done < <(docker ps --filter 'label=com.docker.compose.project=curie' --filter 'label=com.docker.compose.service=curie-worker' --format '{{.Names}}')
+    # Exactly one, never "inspect the first": two matches mean the scoping
+    # assumption broke and the probe's answer would be meaningless.
+    if (( ${#workers[@]} != 1 )); then
+        echo "local mode probe: expected exactly one running container matching label=com.docker.compose.project=curie plus label=com.docker.compose.service=curie-worker, found ${#workers[@]} (${workers[*]:-none})." >&2
+        return 1
+    fi
+    while IFS= read -r line; do
+        if [[ "$line" == CURIE_FAKE_MODEL=* ]]; then
+            value="${line#CURIE_FAKE_MODEL=}"
+        fi
+    done < <(docker inspect "${workers[0]}" --format '{{range .Config.Env}}{{println .}}{{end}}')
+    printf '%s' "$value"
+}
+
+probe_cluster_fake_model() {
+    # Release and namespace both default to `curie` (cli/src/main.rs), which is
+    # what this rung runs against; the deployment name is built the same way the
+    # CLI builds it, as `deployment/<release>-worker`.
+    kubectl -n curie get deployment/curie-worker \
+        -o 'jsonpath={.spec.template.spec.containers[*].env[?(@.name=="CURIE_FAKE_MODEL")].value}'
+}
+
+# One field out of a `deploy --json` receipt. deploy.schema.json is a oneOf over
+# deploy_result, aggregate_success, deploy_failure and connector_failure; the
+# ladder never passes --all-targets, so it gets deploy_result. The extractor
+# still fails with a named error and prints the payload rather than emitting an
+# empty string, so an unexpected shape surfaces as itself instead of pinning an
+# empty digest and making every later comparison vacuous.
+deploy_field() {
+    local label="$1" payload="$2" path="$3" value
+    value="$(printf '%s' "$payload" | python3 -c '
+import json, sys
+value = json.loads(sys.stdin.read())
+for key in sys.argv[1].split("."):
+    value = value[key]
+print(value)
+' "$path")" || {
+        echo "$label: the deploy --json receipt carried no $path; deploy.schema.json requires it on the deploy_result branch, so this is an unexpected payload shape." >&2
+        printf '%s\n' "$payload" >&2
+        return 1
+    }
+    printf '%s' "$value"
+}
+
 # The local reply stub binds a fixed port. A second ladder, or any process
 # holding it, would otherwise hang until the 300s message timeout and look like
 # a product failure.
@@ -321,13 +654,52 @@ case_leftover_runner_container() {
     echo "skill down --name cleared the leftover with no recorded state"
 }
 
-# Rung 1: the existing skill-tier round trip, invoked as is. Never copied. The
-# #747 recovery case rides here because it drives skill-tier verbs and shares
-# rung 1's runner-image requirement.
+# Rung 1: the existing skill-tier round trip. Still exactly one implementation
+# and never copied -- but no longer unparameterized: it is handed THIS run's
+# bundle copy through CURIE_E2E_BUNDLE, so rung 1 boots and grades the same
+# artifact and the same case set as every later rung. That deliberately
+# supersedes #690's "keep the current skill-tier leg as is"; the `--from-spec`
+# deal-desk leg it refers to (#325's acceptance evidence) is preserved as the
+# behavior of a bare `bash cli/scripts/e2e.sh`, which is where that evidence now
+# lives.
+#
+# The #747 recovery case rides here because it drives skill-tier verbs and shares
+# rung 1's runner-image requirement. It is unaffected by the shared bundle: it
+# expects exit 2 from `skill up`'s name-conflict preflight and never reaches a
+# pack, so it neither reads nor perturbs artifact identity.
 rung_skill() {
     echo
     echo "########## rung 1/3: skill ##########"
-    bash "$REPO_ROOT/cli/scripts/e2e.sh"
+    RAN_RUNGS="$RAN_RUNGS skill"
+
+    local log="$WORKDIR/rung-skill.log"
+    # `tee`, not a command substitution: rung 1 runs for minutes and its progress
+    # must keep streaming. `set -o pipefail` is already on (set -euo pipefail
+    # above), so a failing e2e.sh still fails this rung through the pipe rather
+    # than being masked by tee's exit status -- never add `|| true` here. The log
+    # lives inside $WORKDIR, so the existing `rm -rf` in the trap covers it and
+    # this adds no new cleanup path.
+    CURIE_E2E_BUNDLE="$WORKDIR/bundle" bash "$REPO_ROOT/cli/scripts/e2e.sh" | tee "$log"
+
+    # e2e.sh already prints its client-side digest on a stable line, and exits 1
+    # on a null or empty one BEFORE reaching that line, so a present line always
+    # carries a real value. Parsing it keeps the env contract at one variable:
+    # e2e.sh gains no output contract of its own.
+    local line digest=""
+    while IFS= read -r line; do
+        if [[ "$line" == "initial bundle digest: "* ]]; then
+            digest="${line#initial bundle digest: }"
+        fi
+    done < "$log"
+    if [[ -z "$digest" ]]; then
+        echo "skill: cli/scripts/e2e.sh printed no \"initial bundle digest:\" line, so rung 1's artifact identity cannot be read." >&2
+        return 1
+    fi
+    # Rung 1 is the one rung that reads its case ids back DIRECTLY, inside
+    # e2e.sh's --json skill eval assertion, in fake mode as well as live.
+    SUITE_RUNGS="$SUITE_RUNGS skill"
+    assert_bundle_identity "skill" "$digest"
+
     case_leftover_runner_container
 }
 
@@ -335,6 +707,7 @@ rung_skill() {
 rung_local() {
     echo
     echo "########## rung 2/3: local (compose) ##########"
+    RAN_RUNGS="$RAN_RUNGS local"
 
     assert_stub_port_free
 
@@ -342,13 +715,11 @@ rung_local() {
         # Reuse it and do NOT tear it down: the thread that brought a stack up
         # owns tearing it down, in both directions.
         echo "a compose stack is already running; reusing it and leaving teardown to whoever started it"
-        if [[ "$LIVE" == "1" ]]; then
-            # Model mode is fixed at `local up` time, so a reused stack may have
-            # been started sealed. Warn rather than refuse: the live-only fake
-            # sentinel control below catches it for real.
-            echo "warning: CURIE_E2E_LIVE=1, but the reused stack's model mode was fixed by whoever ran \`local up\` and is NOT verified here." >&2
-            echo "warning: if that stack was started with the fake model, this 'live' rung runs sealed; \`local down\` then re-run to be sure." >&2
-        fi
+        # Model mode is fixed at `local up` time, so a reused stack may have been
+        # started sealed. That used to be a warning; it is now VERIFIED by
+        # assert_model_mode below, off the reused stack's own running worker, and
+        # a contradiction is a hard failure with a fix line.
+        echo "note: the reused stack's model mode was fixed by whoever ran \`local up\`; it is verified below against this run's mode, and a mismatch fails this rung."
     else
         echo
         echo "=== curie local up --minimal ==="
@@ -366,11 +737,34 @@ rung_local() {
     fi
 
     echo
-    echo "=== curie local deploy ==="
+    echo "=== curie --json local deploy ==="
     # No --api-url: the default IS the cold-start path a real user hits, and
     # exercising the default is the point. First create binds C0LOCALDEV, so the
     # message below can resolve the sole deployed agent with no --channel.
-    "$BIN" local deploy --plugin-dir "$WORKDIR/bundle"
+    #
+    # --json for the receipt: `local status --json` carries no digest
+    # (cli/schema/local-status.schema.json is only `services`), so the deploy
+    # receipt's bundle.sha256 -- the platform's server-side hash of the bytes this
+    # rung uploaded -- is the ONLY surface that reports this tier's artifact
+    # identity. Read from stdout only; the human text is on stderr.
+    local deploy_json digest agent_id deployment_id
+    deploy_json="$("$BIN" --json local deploy --plugin-dir "$WORKDIR/bundle")"
+    printf '%s\n' "$deploy_json"
+    digest="$(deploy_field "local" "$deploy_json" bundle.sha256)"
+    agent_id="$(deploy_field "local" "$deploy_json" agent.id)"
+    deployment_id="$(deploy_field "local" "$deploy_json" deployment.id)"
+
+    echo
+    echo "=== assert the turn will bind to the deployment this rung created ==="
+    # BEFORE the turn, deliberately: a shadowed binding must stop the rung rather
+    # than produce a green turn against the wrong artifact.
+    assert_sole_active_deployment "local" "$agent_id" "$deployment_id"
+
+    echo
+    echo "=== assert the deployed worker's effective model mode ==="
+    local observed_mode
+    observed_mode="$(probe_local_fake_model)"
+    assert_model_mode "local" "$observed_mode"
 
     echo
     echo "=== curie local message --json ==="
@@ -383,6 +777,10 @@ rung_local() {
     out="$("$BIN" --json local message "$PROMPT" || true)"
     printf '%s\n' "$out"
     assert_finalized_reply "local" "$out"
+
+    echo
+    echo "=== curie local eval --dry-run (suite parity) ==="
+    assert_suite "local" "$("$BIN" --json local eval --cases "$WORKDIR/bundle/evals/cases.json" --dry-run)"
 
     if [[ "$LIVE" == "1" ]]; then
         echo
@@ -425,6 +823,11 @@ rung_local() {
         fi
         echo "no curie containers running"
     fi
+
+    # Last, not at the deploy step: see assert_bundle_identity's comment. The
+    # rung's suite and mode evidence is on the transcript by now, so a divergence
+    # here is diagnosable as an identity divergence specifically.
+    assert_bundle_identity "local" "$digest"
 }
 
 # local-release mode: the same local round trip as rung_local, but against the
@@ -437,6 +840,7 @@ rung_local() {
 rung_local_release() {
     echo
     echo "########## rung: local-release (compose, generated release artifact) ##########"
+    RAN_RUNGS="$RAN_RUNGS local-release"
 
     local release_compose="$WORKDIR/compose.release.yaml"
     echo
@@ -476,10 +880,10 @@ rung_local_release() {
         # Reuse it and do NOT tear it down, matching rung_local's rule: the
         # thread that brought a stack up owns tearing it down.
         echo "a compose stack is already running; reusing it and leaving teardown to whoever started it"
-        if [[ "$LIVE" == "1" ]]; then
-            echo "warning: CURIE_E2E_LIVE=1, but the reused stack's model mode was fixed by whoever ran \`local up\` and is NOT verified here." >&2
-            echo "warning: if that stack was started with the fake model, this 'live' rung runs sealed; \`local down\` then re-run to be sure." >&2
-        fi
+        # Same rule as rung_local, and changed together with it: the reused
+        # stack's mode is verified by assert_model_mode below rather than
+        # disclaimed in a warning.
+        echo "note: the reused stack's model mode was fixed by whoever ran \`local up\`; it is verified below against this run's mode, and a mismatch fails this rung."
     else
         echo
         echo "=== clear any stale volumes from a prior non-wiped teardown ==="
@@ -500,12 +904,33 @@ rung_local_release() {
     fi
 
     echo
-    echo "=== curie local deploy (release-compose stack) ==="
+    echo "=== curie --json local deploy (release-compose stack) ==="
     # A separate bundle copy from rung_local's, never the same directory: deploy
     # records state into the bundle dir, and reusing rung_local's copy here
     # would carry over its recorded agent/version ids instead of a fresh
-    # cold-start deploy.
-    "$BIN" local deploy --plugin-dir "$WORKDIR/bundle-release"
+    # cold-start deploy. The copies now pack to the same digest by construction
+    # (their regular-file mtimes are normalized where they are created), so a
+    # separate copy no longer means a separate identity.
+    local deploy_json digest agent_id deployment_id
+    deploy_json="$("$BIN" --json local deploy --plugin-dir "$WORKDIR/bundle-release")"
+    printf '%s\n' "$deploy_json"
+    digest="$(deploy_field "local-release" "$deploy_json" bundle.sha256)"
+    agent_id="$(deploy_field "local-release" "$deploy_json" agent.id)"
+    deployment_id="$(deploy_field "local-release" "$deploy_json" deployment.id)"
+
+    echo
+    echo "=== assert the turn will bind to the deployment this rung created ==="
+    # Normally trivially satisfied here, because this rung's pre-`up`
+    # `local down --wipe` above clears the deployment rows before it deploys. It
+    # is still asserted, because that wipe is skipped entirely when the rung
+    # reuses a running stack -- which is exactly the case where a shadow exists.
+    assert_sole_active_deployment "local-release" "$agent_id" "$deployment_id"
+
+    echo
+    echo "=== assert the deployed worker's effective model mode ==="
+    local observed_mode
+    observed_mode="$(probe_local_fake_model)"
+    assert_model_mode "local-release" "$observed_mode"
 
     echo
     echo "=== curie local message --json (release-compose stack) ==="
@@ -514,6 +939,10 @@ rung_local_release() {
     out="$("$BIN" --json local message "$PROMPT" || true)"
     printf '%s\n' "$out"
     assert_finalized_reply "local-release" "$out"
+
+    echo
+    echo "=== curie local eval --dry-run (suite parity, release compose stack) ==="
+    assert_suite "local-release" "$("$BIN" --json local eval --cases "$WORKDIR/bundle-release/evals/cases.json" --dry-run)"
 
     if [[ "$LIVE" == "1" ]]; then
         echo
@@ -544,6 +973,8 @@ rung_local_release() {
         fi
         echo "no curie containers running"
     fi
+
+    assert_bundle_identity "local-release" "$digest"
 }
 
 # Rung 3: the deployed release. Requires one to already exist; it is never
@@ -551,6 +982,7 @@ rung_local_release() {
 rung_cluster() {
     echo
     echo "########## rung 3/3: cluster ##########"
+    RAN_RUNGS="$RAN_RUNGS cluster"
 
     echo
     echo "=== curie cluster status (gate) ==="
@@ -578,10 +1010,62 @@ print("yes" if isinstance(d, dict) and d.get("release_found") is True else "no")
     fi
 
     echo
-    echo "=== curie cluster deploy ==="
+    echo "=== curie --json cluster deploy ==="
     # No --api-url: deploy auto-discovers the release's UI /api proxy over
     # NodePort. No --secret: it is declined at this tier by design (#440).
-    "$BIN" cluster deploy --plugin-dir "$WORKDIR/bundle"
+    # --json for the receipt: `cluster status --json` carries no digest, so the
+    # deploy receipt's bundle.sha256 is the only artifact-identity surface here
+    # too.
+    local deploy_json digest agent_id deployment_id deployment_status deployment_environment
+    deploy_json="$("$BIN" --json cluster deploy --plugin-dir "$WORKDIR/bundle")"
+    printf '%s\n' "$deploy_json"
+    digest="$(deploy_field "cluster" "$deploy_json" bundle.sha256)"
+    agent_id="$(deploy_field "cluster" "$deploy_json" agent.id)"
+    deployment_id="$(deploy_field "cluster" "$deploy_json" deployment.id)"
+    deployment_status="$(deploy_field "cluster" "$deploy_json" deployment.status)"
+    deployment_environment="$(deploy_field "cluster" "$deploy_json" deployment.environment)"
+
+    echo
+    echo "=== assert this rung's deployment is the terminal state a turn can bind to ==="
+    # The receipt's own terminal state first: it is readable at every tier, with
+    # no API credential at all.
+    if [[ "$deployment_status" != "active" ]]; then
+        echo "cluster: the deployment this rung created reports status '$deployment_status', not 'active', so no turn can bind to it." >&2
+        return 1
+    fi
+    if [[ "$deployment_environment" != "dev" ]]; then
+        echo "cluster: the deployment this rung created landed in environment '$deployment_environment'; this run asked for 'dev' (deploy's own default, and the ladder passes no --environment)." >&2
+        return 1
+    fi
+    echo "cluster: deploy receipt reports an active deployment in environment $deployment_environment"
+
+    # The full runtime-binding assertion is CONDITIONAL here, and only here,
+    # because the cluster API key has no default -- it is resolved from the
+    # installed release (cli/src/main.rs's --api-key value_parser) -- and CI's
+    # cluster ladder job supplies none, so requiring it would red a job this
+    # change cannot touch.
+    #
+    # So: when the operator's environment already carries CURIE_API_KEY, this
+    # rung performs exactly the same one-active-deployment assertion the local
+    # rungs perform, through the same helper, as a hard failure. When it does
+    # not, the rung does not fail and does not claim parity: the receipt above
+    # proves which artifact was UPLOADED, nothing proves the turn RAN it, and the
+    # summary reports the two as separate claims.
+    if [[ -n "${CURIE_API_KEY:-}" ]]; then
+        assert_sole_active_deployment "cluster" "$agent_id" "$deployment_id"
+        CLUSTER_BINDING_PROVEN=1
+    else
+        echo "cluster: runtime binding is NOT proven at this tier for this run. The deploy receipt proves which artifact was UPLOADED to the cluster; it does not prove the turn below ran that artifact, so a stale ACTIVE prod deployment shadowing the turn would go undetected here."
+        echo "cluster: to prove it, export CURIE_API_KEY (and CURIE_API_URL if the release's API is not on the default) and re-run; this rung then reads the active deployment set exactly as the local rungs do."
+    fi
+
+    echo
+    echo "=== assert the installed release's effective model mode ==="
+    # kubectl is only reached inside this rung, which already gated on a
+    # reachable release above, so a skill/local-only invocation never needs it.
+    local observed_mode
+    observed_mode="$(probe_cluster_fake_model)"
+    assert_model_mode "cluster" "$observed_mode"
 
     echo
     echo "=== curie cluster message --json ==="
@@ -614,17 +1098,29 @@ print("yes" if isinstance(d, dict) and d.get("release_found") is True else "no")
     printf '%s\n' "$out"
     assert_finalized_reply "cluster" "$out"
 
+    echo
+    echo "=== curie cluster eval --dry-run (suite parity) ==="
+    # ONE array feeding BOTH cluster eval calls (this dry-run plan and the live
+    # grade below), so `--listen-host` cannot reach one and be forgotten on the
+    # other. `--json` is deliberately NOT in the array: both call sites need it
+    # for DIFFERENT reasons -- a machine-readable `--dry-run` plan here, an
+    # auditable green on the live grade below -- and passing it once per call site
+    # is what keeps it from being passed twice at either.
+    local eval_args=(cluster eval --cases "$WORKDIR/bundle/evals/cases.json")
+    if [[ -n "${CURIE_E2E_LISTEN_HOST:-}" ]]; then
+        eval_args+=(--listen-host "$CURIE_E2E_LISTEN_HOST")
+    fi
+    assert_suite "cluster" "$("$BIN" --json "${eval_args[@]}" --dry-run)"
+
     if [[ "$LIVE" == "1" ]]; then
         echo
         echo "=== curie cluster eval (REPORT ONLY, does not fail this rung: #1603) ==="
-        # --json here and nowhere else: the human table prints a reply only for a
-        # RED case, so a green carried no evidence of HOW it was earned. The json
-        # payload carries `output` for every case, pass included, which is what
-        # makes the weather case's greens auditable from the job log (#1602).
-        local eval_args=(--json cluster eval --cases "$WORKDIR/bundle/evals/cases.json")
-        if [[ -n "${CURIE_E2E_LISTEN_HOST:-}" ]]; then
-            eval_args+=(--listen-host "$CURIE_E2E_LISTEN_HOST")
-        fi
+        # --json on this rung's live grade and no other rung's: the human table
+        # prints a reply only for a RED case, so a green carried no evidence of
+        # HOW it was earned. The json payload carries `output` for every case,
+        # pass included, which is what makes the weather case's greens auditable
+        # from the job log (#1602).
+        #
         # Report only on THIS rung alone (#1603). The graded weather case cannot
         # express what it is meant to assert here: it grades that a temperature
         # figure is PRESENT, and under the cluster rung's provider-only egress
@@ -639,10 +1135,12 @@ print("yes" if isinstance(d, dict) and d.get("release_found") is True else "no")
         # turn finalizes with a reply, and under live mode that reply is not the
         # fake sentinel) still fail it, and they are what caught the sandbox
         # reaper race in #1601.
-        if ! "$BIN" "${eval_args[@]}"; then
+        if ! "$BIN" --json "${eval_args[@]}"; then
             echo "cluster: eval reported a failing case. Not failing the rung: this rung's grade is report only (#1603)." >&2
         fi
     fi
+
+    assert_bundle_identity "cluster" "$digest"
 }
 
 echo
@@ -683,6 +1181,46 @@ fi
 cp -r "$BUNDLE_SRC" "$WORKDIR/bundle"
 cp -r "$BUNDLE_SRC" "$WORKDIR/bundle-release"
 
+# Normalize every regular file's mtime across both copies. This is load-bearing,
+# not hygiene: the digest every rung asserts on identifies an ARCHIVE, not a
+# source tree, because pack_tar_gz embeds per-file mtime (cli/src/bundle.rs), and
+# `cp -r` does NOT preserve mtimes. Two copies of identical content would
+# therefore pack to different bytes and different digests, and every multi-rung
+# run would be red by construction. Only regular files become tar entries (the
+# packer recurses directories and appends only files), and uid/gid are constant
+# inside one ladder process, so pinning file mtimes to a fixed epoch is exactly
+# sufficient to make both copies pack byte-identically.
+find "$WORKDIR/bundle" "$WORKDIR/bundle-release" -type f -exec touch -t 200001010000 {} +
+
+# The one place the expected suite is derived, from the file the ladder itself
+# packed, so no rung can be compared against an externally pinned value. The
+# case ids are recorded for the summary; they are PROVEN at the deployed tiers by
+# digest equality (evals/cases.json is inside the packed archive), and read back
+# directly only at the skill rung and, under CURIE_E2E_LIVE=1, at every rung.
+CASES_FILE="$WORKDIR/bundle/evals/cases.json"
+if [[ ! -f "$CASES_FILE" ]]; then
+    echo "error: the ladder's bundle carries no evals/cases.json at $CASES_FILE, so there is no common suite to assert." >&2
+    echo "fix: point BUNDLE_SRC at a bundle that ships an eval suite." >&2
+    exit 1
+fi
+{
+    read -r EXPECT_SUITE
+    read -r EXPECT_CASE_COUNT
+    read -r EXPECT_CASE_IDS
+} < <(python3 -c '
+import json, sys
+suite = json.load(open(sys.argv[1]))
+ids = sorted(case["id"] for case in suite["cases"])
+print(suite["name"])
+print(len(ids))
+print(",".join(ids))
+' "$CASES_FILE")
+echo
+echo "=== common bundle and suite ==="
+echo "bundle source: $BUNDLE_SRC"
+echo "suite: \"$EXPECT_SUITE\" with $EXPECT_CASE_COUNT case(s)"
+echo "case ids: $EXPECT_CASE_IDS"
+
 # Rungs run strictly in order and never in parallel: they share host ports, and
 # rung 1 must release its runner container before rung 2 starts.
 if (( RUN_SKILL )); then
@@ -711,6 +1249,33 @@ else
     echo
     echo "SKIPPING rung 3 (cluster): not named in CURIE_E2E_TIERS. It needs a live"
     echo "release and host-reachable pods, so it is opt-in: CURIE_E2E_TIERS=all."
+fi
+
+echo
+echo "=== parity summary (what this run actually proved) ==="
+echo "rungs run:$RAN_RUNGS"
+if [[ -z "$PARITY_DIGEST" ]]; then
+    echo "bundle identity: NOT reported by any rung that ran, so nothing about artifact identity was proven."
+else
+    echo "bundle identity: $PARITY_DIGEST, reported by rung(s):$PARITY_RUNGS"
+    if (( $(wc -w <<< "$PARITY_RUNGS") < 2 )); then
+        echo "note: only one rung reported a digest, so the CROSS-RUNG digest comparison was vacuous for this tier set -- only that rung's own identity was recorded. This is NOT a cross-rung parity claim."
+    fi
+fi
+echo "suite: \"$EXPECT_SUITE\" with $EXPECT_CASE_COUNT case(s), resolved by the tier's own loader at rung(s):$SUITE_RUNGS"
+echo "case ids: $EXPECT_CASE_IDS (proven at local/cluster by digest equality; read back directly at skill, and at every rung under CURIE_E2E_LIVE=1)"
+echo "model mode read off the deployed artifact at rung(s):${MODE_RUNGS:- none}"
+if [[ "$LIVE" == "1" ]]; then
+    echo "grading: GRADED rungs:$RAN_RUNGS -- each ran its tier's own evaluator against a real model."
+else
+    echo "grading: PLUMBING-ONLY rungs:$RAN_RUNGS -- sealed against the fake model, so no rung graded reply content and a green here must never be read as a graded pass (ADR-0055, #612)."
+fi
+if (( RUN_CLUSTER )); then
+    if (( CLUSTER_BINDING_PROVEN )); then
+        echo "cluster rung: upload identity AND runtime binding both proven -- exactly one active deployment existed for this agent before the turn, and it was the one this rung created, so the turn could only bind to the artifact whose digest is reported above."
+    else
+        echo "cluster rung: upload-identity-proven / runtime-binding-UNPROVEN. The digest above is the artifact this rung UPLOADED to the cluster; no read was performed to show the turn ran it, so a stale ACTIVE prod deployment shadowing the turn would have gone undetected. Read that digest as an upload record, never as a cluster parity claim, and see the cluster rung's own note above for how to prove it."
+    fi
 fi
 
 echo

--- a/cli/scripts/e2e.sh
+++ b/cli/scripts/e2e.sh
@@ -28,6 +28,15 @@
 #                         its own local and cluster rungs, so a single
 #                         CURIE_E2E_LIVE=1 now runs every rung live.
 #   CURIE_BIN           path to a prebuilt curie binary (skip cargo build)
+#   CURIE_E2E_BUNDLE    absolute path to an EXISTING bundle directory to drive
+#                         instead of scaffolding one. Unset by default, and
+#                         unset this script behaves exactly as it always has.
+#                         cli/scripts/e2e-ladder.sh sets it so rung 1 drives the
+#                         same artifact and the same case set as every later
+#                         rung, which is what makes the ladder's cross-rung
+#                         identity comparison mean anything. A value that is not
+#                         a directory is a hard error, never a silent fallback to
+#                         the scaffold.
 set -euo pipefail
 
 CLI_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -64,22 +73,88 @@ else
 fi
 
 WORKDIR="$(mktemp -d)"
+
+# Crash-safety state for the #1087 immutability proof further down, which
+# deliberately MUTATES a SKILL.md inside the bundle under test. Declared here,
+# BEFORE the trap is installed, because the trap reads them: under `set -u` a
+# trap that fires before these are assigned would itself die on an unbound
+# variable and skip the whole teardown it exists to perform.
+SKILL_MUTATION_PENDING=0
+SKILL_FILE_PATH=""
+SKILL_FILE_BACKUP=""
+
 cleanup() {
+    # Capture the real status first: everything below is best-effort, and a
+    # teardown command's own status must not become this script's exit code.
+    local rc=$?
+    # Restore BEFORE the `rm -rf` below, because the `cp -p` backup lives under
+    # $WORKDIR: deleting the workdir first would destroy the only copy that can
+    # put the caller's file back. The window this covers is every failure path
+    # between the append and the successful restore -- and with
+    # CURIE_E2E_BUNDLE set that file belongs to a directory this script does NOT
+    # own, so leaving the marker (and, worse, a shifted mtime, which
+    # `pack_tar_gz` folds into the bundle digest) would corrupt the caller's
+    # bundle and make a LATER ladder run fail as if the product were broken.
+    if [[ "$SKILL_MUTATION_PENDING" == "1" ]]; then
+        if [[ -f "$SKILL_FILE_BACKUP" ]]; then
+            cp -p "$SKILL_FILE_BACKUP" "$SKILL_FILE_PATH" || true
+            echo "cleanup: restored $SKILL_FILE_PATH from the pre-mutation backup (content and mtime)" >&2
+        else
+            echo "cleanup: WARNING -- $SKILL_FILE_PATH was mutated but its backup is gone; the file still carries the E2E marker." >&2
+        fi
+        SKILL_MUTATION_PENDING=0
+    fi
     docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
+    if [[ "$rc" -ne 0 && -n "${CURIE_E2E_BUNDLE:-}" ]]; then
+        # Failure path against a caller-supplied bundle only. `skill up` writes
+        # `.curie/runner.json` plus a materialized `.curie/snapshots/<digest>/`
+        # inside the bundle directory, and the success path's final `skill down`
+        # releases them (and asserts the snapshot root is empty). On a failure
+        # that never reaches it, this removes them directly rather than calling
+        # `skill down`: the container is already force-removed above, so the
+        # only thing left to release is these files, and the failure may well BE
+        # a broken `skill down`. Scoped to the caller-supplied case because the
+        # scaffolded bundle lives inside $WORKDIR, which the `rm -rf` below
+        # already takes, and to a non-zero exit so the success path is untouched.
+        rm -rf "${CURIE_E2E_BUNDLE}/.curie"
+    fi
     rm -rf "$WORKDIR"
 }
 trap cleanup EXIT
 
 echo
-echo "=== curie init --from-spec (non-interactive, agent-authored spec) ==="
-# AC #2: a coding agent writes a spec, the CLI scaffolds a runnable bundle from
-# it with zero prompts, and the spec-scaffolded evals/cases.json runs on the eval
-# path. The grader is falsifiable (it requires the agent to name itself), NOT
-# tuned to the fake model's canned "all done" reply: a grader written to match
-# the fake manufactures a green, and CI carrying one is exactly why #612 went
-# unnoticed. Under --fake-model the grader is never consulted at all -- the run
-# reports the non-graded plumbing_ok (ADR-0055).
-cat > "$WORKDIR/agent-spec.json" <<'EOF'
+echo "=== Resolve the bundle under test ==="
+if [[ -n "${CURIE_E2E_BUNDLE:-}" ]]; then
+    # Fail loudly rather than fall back: a typo silently re-scaffolding
+    # deal-desk would re-open the very skill-vs-local bundle divergence the
+    # ladder's identity comparison exists to close, and it would do so as a
+    # green run.
+    if [[ ! -d "$CURIE_E2E_BUNDLE" ]]; then
+        echo "error: CURIE_E2E_BUNDLE is set to '$CURIE_E2E_BUNDLE', which is not a directory." >&2
+        echo "fix: point it at an existing bundle directory, or unset it to scaffold deal-desk from the inline spec." >&2
+        exit 1
+    fi
+    BUNDLE_DIR="$CURIE_E2E_BUNDLE"
+    echo "bundle: supplied by the caller (CURIE_E2E_BUNDLE), scaffold skipped: $BUNDLE_DIR"
+else
+    BUNDLE_DIR="$WORKDIR/deal-desk"
+    echo "bundle: scaffolded here from the inline agent spec: $BUNDLE_DIR"
+
+    echo
+    echo "=== curie init --from-spec (non-interactive, agent-authored spec) ==="
+    # AC #2: a coding agent writes a spec, the CLI scaffolds a runnable bundle
+    # from it with zero prompts, and the spec-scaffolded evals/cases.json runs on
+    # the eval path. This leg is #325's acceptance evidence and is deliberately
+    # kept as the STANDALONE behavior of this script -- the ladder supplies its
+    # own common bundle instead, so the ladder run no longer carries #325's
+    # scaffold evidence and a bare `bash cli/scripts/e2e.sh` (plus CI's own
+    # --from-spec unit coverage) does.
+    # The grader is falsifiable (it requires the agent to name itself), NOT
+    # tuned to the fake model's canned "all done" reply: a grader written to match
+    # the fake manufactures a green, and CI carrying one is exactly why #612 went
+    # unnoticed. Under --fake-model the grader is never consulted at all -- the run
+    # reports the non-graded plumbing_ok (ADR-0055).
+    cat > "$WORKDIR/agent-spec.json" <<'EOF'
 {
   "name": "deal-desk",
   "description": "Prices and reviews deal desk requests.",
@@ -100,16 +175,23 @@ cat > "$WORKDIR/agent-spec.json" <<'EOF'
   ]
 }
 EOF
-"$BIN" init --from-spec "$WORKDIR/agent-spec.json" --dir "$WORKDIR/deal-desk"
+    "$BIN" init --from-spec "$WORKDIR/agent-spec.json" --dir "$BUNDLE_DIR"
+fi
 
-cd "$WORKDIR/deal-desk"
+cd "$BUNDLE_DIR"
 
-# A second suite for the explicit `--cases` leg. Its graders are real domain
-# graders, deliberately NOT matched to the fake-model script's canned "all done"
-# reply: this run is offline under --fake-model, so the graders are never
-# consulted and the suite reports plumbing_ok. Writing them to match the fake
-# would only re-create the bypass that let #612 ship green.
-cat > evals/e2e-cases.json <<'EOF'
+if [[ -z "${CURIE_E2E_BUNDLE:-}" ]]; then
+    # Standalone only. Writing a file under evals/ into a CALLER-SUPPLIED bundle
+    # would change the packed archive and therefore the bundle digest every
+    # ladder rung asserts on (`.curie` is excluded from the pack,
+    # cli/src/bundle.rs; `evals/` is not).
+    #
+    # A second suite for the explicit `--cases` leg. Its graders are real domain
+    # graders, deliberately NOT matched to the fake-model script's canned "all done"
+    # reply: this run is offline under --fake-model, so the graders are never
+    # consulted and the suite reports plumbing_ok. Writing them to match the fake
+    # would only re-create the bypass that let #612 ship green.
+    cat > evals/e2e-cases.json <<'EOF'
 {
   "name": "e2e",
   "cases": [
@@ -126,6 +208,7 @@ cat > evals/e2e-cases.json <<'EOF'
   ]
 }
 EOF
+fi
 
 echo
 if [[ "$LIVE" == "1" ]]; then
@@ -192,18 +275,46 @@ echo "initial bundle digest: $DIGEST_1"
 
 echo
 echo "=== #1087 AC1: edit the source after boot, confirm the running container keeps the ORIGINAL snapshot ==="
-SKILL_FILE_PATH="$WORKDIR/deal-desk/skills/deal-desk/SKILL.md"
-SKILL_FILE_ORIGINAL="$(cat "$SKILL_FILE_PATH")"
+# Derived from the bundle, not hardcoded to `deal-desk`: a caller-supplied
+# bundle names its skill directory whatever it likes. First match in sorted
+# order, so the choice is deterministic.
+SKILL_FILE_PATH=""
+while IFS= read -r CANDIDATE; do
+    if [[ -z "$SKILL_FILE_PATH" ]]; then
+        SKILL_FILE_PATH="$CANDIDATE"
+    fi
+done < <(find "$BUNDLE_DIR/skills" -mindepth 2 -maxdepth 2 -name SKILL.md | sort)
+if [[ -z "$SKILL_FILE_PATH" ]]; then
+    echo "error: no skills/*/SKILL.md exists under $BUNDLE_DIR, so the #1087 immutability proof has nothing to mutate." >&2
+    exit 1
+fi
+# The same file inside the runner's read-only /plugin mount, so the mount check
+# below follows the file this proof actually edited.
+SKILL_FILE_REL="${SKILL_FILE_PATH#"$BUNDLE_DIR"/}"
+# `cp -p` into $WORKDIR (outside the bundle, so it never enters the pack), never
+# `$(cat ...)` plus `printf '%s\n'`: that round trip strips trailing newlines and
+# adds exactly one back, which is byte-lossy for any file not ending in exactly
+# one newline, and it gives the restored file a NEW mtime. Both matter now --
+# `pack_tar_gz` embeds per-file mtime (cli/src/bundle.rs:181-184), so a lossy or
+# mtime-shifting restore silently changes the bundle digest the ladder's later
+# rungs assert against, and the failure would read as a product bug.
+SKILL_FILE_BACKUP="$WORKDIR/skill-md-original"
+cp -p "$SKILL_FILE_PATH" "$SKILL_FILE_BACKUP"
 MARKER="e2e-post-boot-source-edit-$$"
+# Claim the mutation BEFORE making it, never after: a failure (or a signal)
+# inside the append itself is exactly the case that has to be recoverable, and a
+# flag set afterwards would leave that window uncovered. The EXIT trap restores
+# from $SKILL_FILE_BACKUP whenever this is still 1.
+SKILL_MUTATION_PENDING=1
 echo "$MARKER" >> "$SKILL_FILE_PATH"
 
-MOUNTED_SKILL_MD="$(docker exec "$CONTAINER" cat /plugin/skills/deal-desk/SKILL.md)"
+MOUNTED_SKILL_MD="$(docker exec "$CONTAINER" cat "/plugin/$SKILL_FILE_REL")"
 if grep -qF "$MARKER" <<<"$MOUNTED_SKILL_MD"; then
-    echo "error: the running container's /plugin/skills/deal-desk/SKILL.md contains the marker '$MARKER', added to the HOST source after boot." >&2
+    echo "error: the running container's /plugin/$SKILL_FILE_REL contains the marker '$MARKER', added to the HOST source after boot." >&2
     echo "expected: the runner keeps executing the immutable snapshot it packed at \`skill up\` time, unaffected by a later host edit." >&2
     exit 1
 fi
-echo "confirmed: the running container's /plugin mount does not see the post-boot host edit"
+echo "confirmed: the running container's /plugin mount does not see the post-boot host edit ($SKILL_FILE_REL)"
 
 STATUS_JSON_1B="$("$BIN" skill status --json)"
 DIGEST_1B="$(printf '%s' "$STATUS_JSON_1B" | python3 -c 'import json,sys; print(json.load(sys.stdin)["bundle_digest"])')"
@@ -219,14 +330,71 @@ echo "=== curie skill message (synthetic event, streamed NDJSON reply) ==="
 "$BIN" skill message "@curie can we approve the Meridian deal at 18% discount?"
 
 echo
-echo "=== curie skill eval (spec-scaffolded evals/cases.json) ==="
-# No --cases: exercise the evals/cases.json the --from-spec scaffold wrote,
-# proving spec -> bundle -> skill eval passes end to end offline (AC #2).
-"$BIN" skill eval
+echo "=== curie skill eval --json (the bundle's own evals/cases.json) ==="
+# No --cases: exercise the bundle's own evals/cases.json. Standalone that is the
+# suite the --from-spec scaffold wrote, proving spec -> bundle -> skill eval
+# passes end to end offline (AC #2); under a caller-supplied bundle it is the
+# ladder's common suite, which is what makes the suite common across rungs with
+# no second env var. --json puts the payload on stdout and the human report on
+# stderr, so ONE run gives both the readable output and the machine-readable
+# rows the assertions below read.
+EVAL_JSON="$("$BIN" --json skill eval)"
+printf '%s\n' "$EVAL_JSON"
+# The skill tier is the one rung that reads its case ids back directly: its rows
+# carry `id` even on the fake model, because a fake turn is reported as the
+# non-graded third state `plumbing_ok` (ADR-0055) rather than being skipped. So
+# assert the ids ARE the bundle's ids, and assert the fake/live grading posture
+# positively: sealed means nothing was graded, live means everything was.
+if [[ "$LIVE" == "1" ]]; then
+    EXPECT_PLUMBING=0
+else
+    EXPECT_PLUMBING=all
+fi
+printf '%s' "$EVAL_JSON" | python3 -c '
+import json, sys
+payload = json.loads(sys.stdin.read())
+expect_plumbing = sys.argv[1]
+suite = json.load(open(sys.argv[2]))
+expected_ids = sorted(c["id"] for c in suite["cases"])
+reported_ids = sorted(c["id"] for c in payload["cases"])
+if reported_ids != expected_ids:
+    sys.exit(
+        "error: skill eval graded case ids %s; the bundle under test declares %s.\n"
+        "expected: the eval path runs the very suite that ships inside the bundle."
+        % (",".join(reported_ids), ",".join(expected_ids))
+    )
+total, passed, failed, plumbing = (
+    payload["total"], payload["passed"], payload["failed"], payload["plumbing_ok"]
+)
+if expect_plumbing == "all":
+    if not (plumbing == total and passed == 0 and failed == 0):
+        sys.exit(
+            "error: a sealed (fake-model) run must report every case as the non-graded "
+            "plumbing_ok and grade nothing; got total=%d passed=%d failed=%d plumbing_ok=%d.\n"
+            "expected: ADR-0055/#612 -- a fake turn returns one canned reply whatever the "
+            "input, so a graded verdict on it is manufactured."
+            % (total, passed, failed, plumbing)
+        )
+elif plumbing != 0:
+    sys.exit(
+        "error: a live run must grade every case, but %d of %d were reported as the "
+        "non-graded plumbing_ok, so the run was sealed against the fake model."
+        % (plumbing, total)
+    )
+print(
+    "confirmed: skill eval ran the case ids the bundle declares (%s) with total=%d passed=%d "
+    "failed=%d plumbing_ok=%d" % (",".join(reported_ids), total, passed, failed, plumbing)
+)
+' "$EXPECT_PLUMBING" "$BUNDLE_DIR/evals/cases.json"
 
-echo
-echo "=== curie skill eval (explicit cases file) ==="
-"$BIN" skill eval --cases evals/e2e-cases.json
+if [[ -z "${CURIE_E2E_BUNDLE:-}" ]]; then
+    echo
+    echo "=== curie skill eval (explicit cases file) ==="
+    # Standalone only, paired with the guard on the heredoc that writes this
+    # file: it does not exist in a caller-supplied bundle, and creating it there
+    # would move that bundle's packed digest.
+    "$BIN" skill eval --cases evals/e2e-cases.json
+fi
 
 echo
 echo "=== curie skill down ==="
@@ -251,12 +419,15 @@ echo "confirmed: re-up on changed source produced a new bundle digest ($DIGEST_1
 
 echo
 echo "=== restore the source and tear down the second runner ==="
-printf '%s\n' "$SKILL_FILE_ORIGINAL" > "$SKILL_FILE_PATH"
+cp -p "$SKILL_FILE_BACKUP" "$SKILL_FILE_PATH"
+# Released only once the restore actually succeeded, so the trap does not skip a
+# restore that never happened (and, on the success path, does not repeat one).
+SKILL_MUTATION_PENDING=0
 "$BIN" skill down
 
 echo
 echo "=== #1087: confirm teardown released the bundle snapshot ==="
-SNAPSHOT_ROOT="$WORKDIR/deal-desk/.curie/snapshots"
+SNAPSHOT_ROOT="$BUNDLE_DIR/.curie/snapshots"
 if [[ -d "$SNAPSHOT_ROOT" ]]; then
     REMAINING="$(find "$SNAPSHOT_ROOT" -mindepth 1 -maxdepth 1)"
     if [[ -n "$REMAINING" ]]; then

--- a/cli/tests/nightly_graded_ladder.rs
+++ b/cli/tests/nightly_graded_ladder.rs
@@ -28,9 +28,12 @@
 //! off, proving the two workflows are pinned to opposite sides of the seam.
 
 use std::fs;
+use std::io::{Read, Write};
+use std::net::TcpListener;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Output};
+use std::thread;
 
 /// Read a workflow file's raw text, or an empty string when it does not exist
 /// yet. Assertions on an empty string fail with their own readable messages
@@ -256,10 +259,38 @@ fn nightly_never_echoes_the_openrouter_secret_on_a_run_line() {
     }
 }
 
+// --- Assertion group 5: the eval-block TEXT contracts ----------------------
+//
+// The four tests below are exact-substring assertions on the ladder script's
+// source text, and they are therefore WEAK BY CONSTRUCTION: a substring match
+// proves no behavior at all, and a reformat that preserves behavior breaks
+// them. They are kept, not deleted, because they encode a real CI contract --
+// that the graded nightly path still fires the LIVE tier eval at every rung --
+// and deleting them would remove the only guard on it. The real coverage for
+// parity lives in the EXECUTING controls at the bottom of this file (assertion
+// group 6), which run the script rather than read it.
+//
+// Each region now also carries the `--dry-run` suite-parity check, which runs
+// in fake mode as well as live (no turn, no grading, no stack: the dry-run plan
+// line is resolved by the tier's own frozen suite loader). At the cluster rung
+// the dry-run and the live eval share one `eval_args` array so `--listen-host`
+// is forwarded to BOTH, which is why the two calls sit adjacent. `--json` is the
+// one flag NOT in that array: both calls pass it themselves, for different
+// reasons (#1602's auditable green, and a machine-readable dry-run plan).
+//
+// The cluster rung's grade is REPORT ONLY (#1603), so its text contract here
+// asserts the eval still RUNS and still runs under `--json`; the non-fatal half
+// is proved by the executing control at the bottom of this file, which runs the
+// ladder against a stub evaluator that exits 42.
+
 #[test]
 fn live_local_rung_grades_the_deployed_weather_cases() {
     let text = ladder();
     let contract = r#"assert_finalized_reply "local" "$out"
+
+    echo
+    echo "=== curie local eval --dry-run (suite parity) ==="
+    assert_suite "local" "$("$BIN" --json local eval --cases "$WORKDIR/bundle/evals/cases.json" --dry-run)"
 
     if [[ "$LIVE" == "1" ]]; then
         echo
@@ -269,7 +300,8 @@ fn live_local_rung_grades_the_deployed_weather_cases() {
     assert!(
         text.contains(contract),
         "the live local rung must run local eval after its plumbing assertion \
-         against the deployed weather bundle cases; ladder contents:\n{text}"
+         against the deployed weather bundle cases, with the suite-parity \
+         dry-run check in front of it; ladder contents:\n{text}"
     );
 }
 
@@ -277,6 +309,10 @@ fn live_local_rung_grades_the_deployed_weather_cases() {
 fn live_local_release_rung_grades_its_own_weather_cases_copy() {
     let text = ladder();
     let contract = r#"assert_finalized_reply "local-release" "$out"
+
+    echo
+    echo "=== curie local eval --dry-run (suite parity, release compose stack) ==="
+    assert_suite "local-release" "$("$BIN" --json local eval --cases "$WORKDIR/bundle-release/evals/cases.json" --dry-run)"
 
     if [[ "$LIVE" == "1" ]]; then
         echo
@@ -286,7 +322,8 @@ fn live_local_release_rung_grades_its_own_weather_cases_copy() {
     assert!(
         text.contains(contract),
         "the live local release rung must run local eval after its plumbing \
-         assertion against its own deployed weather bundle cases copy; \
+         assertion against its own deployed weather bundle cases copy, with \
+         the suite-parity dry-run check in front of it; \
          ladder contents:\n{text}"
     );
 }
@@ -294,10 +331,15 @@ fn live_local_release_rung_grades_its_own_weather_cases_copy() {
 #[test]
 fn live_cluster_rung_runs_weather_cases_with_the_message_listen_host() {
     let text = ladder();
-    let contract = r#"local eval_args=(--json cluster eval --cases "$WORKDIR/bundle/evals/cases.json")
-        if [[ -n "${CURIE_E2E_LISTEN_HOST:-}" ]]; then
-            eval_args+=(--listen-host "$CURIE_E2E_LISTEN_HOST")
-        fi"#;
+    // The shared `eval_args` array and the dry-run call it feeds. Scoped to the
+    // array plus that one call rather than the whole block, because the block
+    // carries the #1602/#1603 rationale comments and a reworded comment must not
+    // red this contract.
+    let contract = r#"local eval_args=(cluster eval --cases "$WORKDIR/bundle/evals/cases.json")
+    if [[ -n "${CURIE_E2E_LISTEN_HOST:-}" ]]; then
+        eval_args+=(--listen-host "$CURIE_E2E_LISTEN_HOST")
+    fi
+    assert_suite "cluster" "$("$BIN" --json "${eval_args[@]}" --dry-run)""#;
     assert!(
         text.contains(r#"assert_finalized_reply "cluster" "$out""#),
         "the live cluster rung must keep its plumbing assertion; ladder \
@@ -305,8 +347,15 @@ fn live_cluster_rung_runs_weather_cases_with_the_message_listen_host() {
     );
     assert!(
         text.contains(contract),
+        "the live cluster rung must resolve its suite through one shared \
+         eval_args array and forward the message listen host to the \
+         suite-parity dry-run; ladder contents:\n{text}"
+    );
+    assert!(
+        text.contains(r#"if ! "$BIN" --json "${eval_args[@]}"; then"#),
         "the live cluster rung must still RUN cluster eval against the deployed \
-         weather bundle cases and forward the message listen host -- report \
+         weather bundle cases and forward the message listen host -- through the \
+         SAME array as the dry-run, so neither call can lose it -- and report \
          only (#1603) means the grade is non-fatal, never that the step was \
          deleted; ladder contents:\n{text}"
     );
@@ -320,47 +369,251 @@ fn live_cluster_rung_runs_weather_cases_with_the_message_listen_host() {
 /// case, pass included, which is what keeps the report-only grade auditable in
 /// the job log. Asserted for the cluster rung alone, since the sibling
 /// assertions above pin the other rungs to the plain table.
+///
+/// The second half is the reconciliation of #1602 with the suite-parity dry-run
+/// that shares this rung's `eval_args`: BOTH calls need `--json` (auditability of
+/// a green here, a machine-readable plan there), so it is passed at each call
+/// site and must stay OUT of the shared array -- inside it, every invocation
+/// would carry `--json` twice.
 #[test]
 fn live_cluster_rung_emits_the_graded_reply_for_passing_cases() {
     let text = ladder();
     assert!(
-        text.contains(r#"local eval_args=(--json cluster eval --cases"#),
+        text.contains(r#"if ! "$BIN" --json "${eval_args[@]}"; then"#),
         "the live cluster rung must run its eval with `--json` so a PASSING \
          case's reply text lands in the job log; without it a dishonest green \
          (a fabricated temperature) is indistinguishable from an honest one; \
          ladder contents:\n{text}"
     );
+    assert!(
+        !text.contains(r#"local eval_args=(--json cluster eval"#),
+        "`--json` must be passed at each cluster eval call site, never stored in \
+         the shared eval_args array: in the array both the dry-run and the live \
+         grade would pass it twice, and neither invocation would be the one the \
+         executing controls below drive; ladder contents:\n{text}"
+    );
 }
 
-/// The inverse of the local/local-release assertions above, which pin those
-/// rungs to a bare `"$BIN" local eval ...` that `set -e` makes fatal. On the
-/// cluster rung the grade is REPORT ONLY (#1603): the eval still runs and still
-/// prints, but a red case must not fail the rung, because the weather case
-/// grades temperature PRESENCE and the cluster rung's provider-only egress makes
-/// presence a function of model phrasing rather than of a real fetch.
-#[test]
-fn live_cluster_rung_reports_but_does_not_propagate_evaluator_failure() {
-    let harness = tempfile::tempdir().expect("create harness directory");
-    let fake_curie = harness.path().join("curie");
-    let eval_marker = harness.path().join("eval_called");
+// --- Assertion group 6: the EXECUTING parity controls -----------------------
+//
+// Everything below runs the real `cli/scripts/e2e-ladder.sh` against a stub
+// `curie`, `docker` and `kubectl`, so it exercises the ladder's own parity
+// helpers rather than reading its source. No Docker daemon, no cluster, no
+// credential (the one live-mode control supplies a dummy CURIE_CREDENTIALS,
+// which apply_model_mode only checks for presence).
+//
+// The design that makes each negative control attributable: ONE stub body,
+// configured entirely through STUB_* env vars, so every negative control is the
+// positive control's configuration with exactly ONE knob moved. A non-zero exit
+// therefore cannot come from an unrelated breakage -- the positive control
+// proves the un-moved configuration is green -- and each control additionally
+// requires the operator-facing message to name the divergence it injected.
+//
+// All of these assert on exit codes and operator-facing message text, never on
+// the ladder's internal shell identifiers, so renaming `PARITY_DIGEST` or
+// `assert_bundle_identity` leaves them passing.
+
+/// The ids the stub deploy receipt reports. They are also what the stubbed
+/// `GET /deployments` read must agree with, which is the whole point of the
+/// sole-active-deployment control.
+const AGENT_ID: &str = "6f3d1c2a-0000-4000-8000-000000000001";
+const VERSION_ID: &str = "6f3d1c2a-0000-4000-8000-000000000002";
+const DEPLOYMENT_ID: &str = "6f3d1c2a-0000-4000-8000-000000000003";
+/// The stale `prod` row the second-active-deployment control injects. `prod`
+/// because the worker's runtime binding prefers it over recency, so this is the
+/// exact row that would silently serve the turn while the ladder reported the
+/// digest of the `dev` bundle it just uploaded.
+const STALE_PROD_DEPLOYMENT_ID: &str = "6f3d1c2a-0000-4000-8000-000000000099";
+
+/// A digest value pinned by the digest-divergence control at the local rung.
+const PINNED_DIGEST: &str = "a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1";
+/// The divergent digest the cluster rung reports in the digest-divergence
+/// control.
+const DIVERGENT_DIGEST: &str = "b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2";
+
+/// The stub `curie`, `docker` and `kubectl` the executing controls drive the
+/// ladder with. One body for all of them: behavior comes from STUB_* env vars
+/// so the tests differ by configuration, not by a second stub.
+///
+/// Every arm matches only the argv shape the scripts actually issue. An
+/// invocation variant nobody issues falls through to `exit 97`, deliberately: an
+/// arm that tolerates a shape the script does not use is a compatibility path,
+/// and it would keep a control green while hiding the regression that started
+/// issuing that shape (the `--json`-less deploy is the exact case -- the stub
+/// answers with JSON either way, so tolerating it would hide a deploy that
+/// stopped asking for a receipt).
+fn write_ladder_stubs(dir: &Path) {
     write_executable(
-        &fake_curie,
+        &dir.join("curie"),
         r#"#!/bin/sh
+set -u
+
+# `--plugin-dir <dir>` is the last pair on every deploy the ladder makes, so the
+# final argument is the bundle directory that rung packed.
+bundle_dir=""
+for arg in "$@"; do bundle_dir="$arg"; done
+
+# The `--name <name>` value, read off argv: the #747 leftover-runner case asserts
+# that `skill up`'s refusal names the exact container an operator must clear.
+name=""
+prev=""
+for arg in "$@"; do
+    if [ "$prev" = "--name" ]; then name="$arg"; fi
+    prev="$arg"
+done
+
+# A CONTENT-derived digest, not a canned one: the default makes two rungs that
+# packed the same tree agree by construction and two rungs that packed different
+# trees disagree by construction. That is what lets the case-ids-only control
+# prove the digest carries the case-id claim, and what lets the positive control
+# compare three independently derived digests instead of one canned constant.
+#
+# Hashes path plus bytes for every regular file, mtimes excluded (the ladder
+# normalizes those itself) and `.curie` excluded (the real packer excludes it,
+# cli/src/bundle.rs). The Rust side computes the same value for the pristine
+# weather bundle in weather_bundle_sha256(); the two must stay in step.
+sha_of_bundle() {
+    python3 -c 'import hashlib, os, sys
+root = sys.argv[1]
+digest = hashlib.sha256()
+for dirpath, dirnames, filenames in os.walk(root):
+    dirnames[:] = sorted(d for d in dirnames if d != ".curie")
+    for entry in sorted(filenames):
+        path = os.path.join(dirpath, entry)
+        digest.update(os.path.relpath(path, root).encode())
+        digest.update(open(path, "rb").read())
+print(digest.hexdigest())' "$1"
+}
+
+# The `deploy_result` branch of cli/schema/deploy.schema.json, with every field
+# the ladder reads: bundle.sha256, agent.id, version.id, and
+# deployment.{id,environment,status}.
+emit_deploy() {
+    printf '{"plugin":"weather","label":"e2e","environment":"dev","agent":{"name":"weather","id":"%s"},"version":{"label":"e2e","id":"%s"},"channel":"C0LOCALDEV","bundle":{"ref":"weather-e2e.tar.gz","sha256":"%s","size_bytes":2048},"deployment":{"id":"%s","environment":"dev","status":"active"}}\n' "$STUB_AGENT_ID" "$STUB_VERSION_ID" "$1" "$STUB_DEPLOYMENT_ID"
+}
+
+# The DryRunPlan shape (cli/src/ui.rs: {"dry_run":true,"plan":[lines]}) carrying
+# the one plan line the tier's suite loader emits.
+emit_plan() {
+    printf '{"dry_run":true,"plan":["grade %s case(s) from suite \\"%s\\" against the %s tier"]}\n' "$2" "$3" "$1"
+}
+
 case "$*" in
     "--version")
         echo "curie test harness"
         ;;
     "--json cluster status")
+        # The case-ids-only control's single injection point: after the local
+        # rung deployed and before the cluster rung does, rewrite ONLY the case
+        # ids in the bundle both rungs deploy. Suite name and case count are
+        # untouched, so every dry-run plan line still matches exactly and the
+        # digest is the only thing that moves.
+        if [ "${STUB_MUTATE_CASE_IDS:-0}" = "1" ] && [ -f "$STUB_STATE/last_plugin_dir" ]; then
+            python3 -c 'import json,sys
+p = sys.argv[1]
+d = json.load(open(p))
+for i, c in enumerate(d["cases"]):
+    c["id"] = "drifted-case-%d" % i
+json.dump(d, open(p, "w"))' "$(cat "$STUB_STATE/last_plugin_dir")/evals/cases.json"
+        fi
         printf '%s\n' '{"release_found":true}'
         ;;
-    "cluster deploy --plugin-dir "*)
+    "skill up --plugin-dir . --image curie-runner --port 7245 --name curie-e2e-runner --fake-model")
+        # The skill rung's identity surface. `skill up` packs an IMMUTABLE
+        # snapshot of the source as it stands now and the runner keeps it for its
+        # whole lifetime, so the digest is recorded here and replayed by
+        # `skill status --json` below. That is what makes e2e.sh's two #1087 legs
+        # resolve the way the real CLI resolves them: a host edit after boot is
+        # invisible to the running runner, and a re-up on the edited source packs
+        # a NEW digest.
+        printf '%s' "$(sha_of_bundle "$PWD")" > "$STUB_STATE/skill_digest"
+        echo "stub: runner up"
+        # e2e.sh asserts the boot panel NAMES the model path it resolved, and
+        # that it does not cry wolf about a missing credential. This arm is the
+        # sealed argv, so the sealed row is the honest answer to it.
+        echo "  Model    fake (offline, no credential)"
+        ;;
+    "skill up --fake-model --plugin-dir "*" --name "*)
+        # The #747 leftover-runner case: a taken container name must be a usage
+        # refusal (exit 2) carrying the operator's own remedy, never docker's raw
+        # "name is already in use" text.
+        echo "error: container name conflict: a container named '$name' already exists." >&2
+        echo "fix: curie skill down --name $name, then re-run." >&2
+        exit 2
+        ;;
+    "skill status")
+        echo "stub: runner running"
+        ;;
+    "skill status --json")
+        printf '{"bundle_digest":"%s"}\n' "$(cat "$STUB_STATE/skill_digest")"
+        ;;
+    "skill message "*)
+        echo "stub skill weather reply"
+        ;;
+    "--json skill eval")
+        # The bundle's OWN suite, read off the bundle e2e.sh cd'd into, because
+        # the skill rung is the one rung that reads its case ids back directly.
+        # Sealed shape only (ADR-0055: a fake turn is reported as the non-graded
+        # plumbing_ok and nothing is graded), which is what the one control that
+        # drives this rung runs as; a live skill run would fall on e2e.sh's own
+        # live-posture assertion rather than be silently accepted here.
+        python3 -c 'import json, sys
+suite = json.load(open(sys.argv[1]))
+ids = [case["id"] for case in suite["cases"]]
+print(json.dumps({
+    "suite": suite["name"],
+    "total": len(ids),
+    "passed": 0,
+    "failed": 0,
+    "plumbing_ok": len(ids),
+    "cases": [{"id": case_id, "status": "plumbing_ok"} for case_id in ids],
+}))' "$PWD/evals/cases.json"
+        ;;
+    "skill down")
+        echo "stub: runner down"
+        ;;
+    "skill down --name "*)
+        echo "stub: removed the leftover runner named '$name'"
+        ;;
+    "local up --minimal")
+        echo "stub: compose stack up"
+        ;;
+    "--json local deploy --plugin-dir "*)
+        printf '%s' "$bundle_dir" > "$STUB_STATE/last_plugin_dir"
+        emit_deploy "${STUB_LOCAL_SHA256:-$(sha_of_bundle "$bundle_dir")}"
+        ;;
+    "--json cluster deploy --plugin-dir "*)
+        printf '%s' "$bundle_dir" > "$STUB_STATE/last_plugin_dir"
+        emit_deploy "${STUB_CLUSTER_SHA256:-$(sha_of_bundle "$bundle_dir")}"
+        ;;
+    "--json local message "*)
+        printf '%s\n' '{"finalized":true,"reply":"stub local weather reply"}'
         ;;
     "--json cluster message "*)
-        printf '%s\n' '{"finalized":true,"reply":"live weather reply"}'
+        printf '%s\n' '{"finalized":true,"reply":"stub cluster weather reply"}'
         ;;
-    "--json cluster eval --cases "*)
-        printf '%s\n' called > "$EVAL_MARKER"
-        exit 42
+    "--json local eval --cases "*--dry-run*)
+        emit_plan local 1 weather
+        ;;
+    "--json cluster eval --cases "*--dry-run*)
+        # Only the cluster count is an override: it is the knob the suite
+        # divergence control moves. Everything else is the constant the weather
+        # bundle declares.
+        emit_plan cluster "${STUB_CLUSTER_PLAN_COUNT:-1}" weather
+        ;;
+    # The two LIVE grades, and they are deliberately asymmetric: the local rung
+    # runs the plain human table, the cluster rung runs `--json` so a passing
+    # case's reply is auditable in the job log (#1602). The dry-run arms above
+    # must stay above this one, since `--json cluster eval --cases *` matches a
+    # dry-run argv too and the first matching arm wins.
+    "local eval --cases "*|"--json cluster eval --cases "*)
+        if [ -n "${STUB_EVAL_MARKER:-}" ]; then
+            printf '%s\n' called > "$STUB_EVAL_MARKER"
+        fi
+        exit "${STUB_EVAL_EXIT:-0}"
+        ;;
+    "local down")
+        echo "stub: compose stack down"
         ;;
     *)
         echo "unexpected curie invocation: $*" >&2
@@ -370,18 +623,585 @@ esac
 "#,
     );
 
-    let script = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("scripts/e2e-ladder.sh");
-    let output = Command::new("bash")
-        .arg(script)
-        .env("CURIE_BIN", &fake_curie)
-        .env("CURIE_E2E_TIERS", "cluster")
-        .env("CURIE_E2E_LIVE", "1")
-        .env("CURIE_CREDENTIALS", "test-credential")
-        .env("EVAL_MARKER", &eval_marker)
-        .env_remove("CURIE_E2E_LISTEN_HOST")
-        .output()
-        .expect("run the real ladder script");
+    // The ladder's raw-docker uses are all either "is a stack already running"
+    // or "assert nothing survived", so an unrecognized invocation returning
+    // nothing is the honest default here; the two reads that carry a real
+    // answer (the compose-worker selection and its env inspect) get explicit
+    // arms above it.
+    write_executable(
+        &dir.join("docker"),
+        r#"#!/bin/sh
+set -u
+case "$*" in
+    "inspect "*)
+        if [ -n "${STUB_FAKE_MODEL:-}" ]; then
+            echo "CURIE_FAKE_MODEL=$STUB_FAKE_MODEL"
+        fi
+        echo "PATH=/usr/local/bin:/usr/bin:/bin"
+        ;;
+    *"com.docker.compose.service=curie-worker"*)
+        # Exactly one worker: the probe must refuse to guess when the scoping
+        # assumption breaks, so returning one id is the only shape that lets the
+        # mode assertion be reached at all.
+        echo "stub-curie-worker"
+        ;;
+    *)
+        ;;
+esac
+"#,
+    );
 
+    write_executable(
+        &dir.join("kubectl"),
+        r#"#!/bin/sh
+set -u
+case "$*" in
+    *"CURIE_FAKE_MODEL"*)
+        printf '%s' "${STUB_FAKE_MODEL:-}"
+        ;;
+    *)
+        ;;
+esac
+"#,
+    );
+}
+
+/// Serve one canned JSON body to every request on an ephemeral loopback port,
+/// and return its base URL for `CURIE_API_URL`.
+///
+/// `CURIE_API_URL` is not a test-only knob: it is the documented env fallback of
+/// every local verb's `--api-url` (`cli/src/main.rs:1193`), with the same
+/// default the CLI itself applies, so pointing the ladder's deployments read at
+/// a different API is production behavior that happens to also be the seam this
+/// control needs.
+fn spawn_deployments_stub(body: &str) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind the deployments stub");
+    let address = listener.local_addr().expect("read the stub address");
+    let response = format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        body.len()
+    );
+    thread::spawn(move || {
+        for stream in listener.incoming() {
+            let Ok(mut stream) = stream else { continue };
+            // The ladder only GETs, so the request is one small buffer and its
+            // content is irrelevant; it is drained only so the client sees a
+            // complete exchange before the response.
+            let mut request = [0u8; 2048];
+            let _ = stream.read(&mut request);
+            let _ = stream.write_all(response.as_bytes());
+            let _ = stream.flush();
+        }
+    });
+    format!("http://{address}")
+}
+
+/// The `DeploymentOut` list shape (`apps/api/src/curie_api/schemas.py:654-660`)
+/// for the healthy case: exactly one active row, and it is this run's.
+fn one_active_deployment() -> String {
+    format!(
+        "[{{\"id\":\"{DEPLOYMENT_ID}\",\"agent_id\":\"{AGENT_ID}\",\
+         \"version_id\":\"{VERSION_ID}\",\"environment\":\"dev\",\
+         \"commit_sha\":null,\"status\":\"active\",\
+         \"deployed_at\":\"2026-08-17T00:00:00Z\"}}]"
+    )
+}
+
+/// This run's `dev` row plus a stale active `prod` row for the same agent: the
+/// wrong-artifact-green shape.
+fn two_active_deployments() -> String {
+    format!(
+        "[{{\"id\":\"{DEPLOYMENT_ID}\",\"agent_id\":\"{AGENT_ID}\",\
+         \"version_id\":\"{VERSION_ID}\",\"environment\":\"dev\",\
+         \"commit_sha\":null,\"status\":\"active\",\
+         \"deployed_at\":\"2026-08-17T00:00:00Z\"}},\
+         {{\"id\":\"{STALE_PROD_DEPLOYMENT_ID}\",\"agent_id\":\"{AGENT_ID}\",\
+         \"version_id\":\"{VERSION_ID}\",\"environment\":\"prod\",\
+         \"commit_sha\":null,\"status\":\"active\",\
+         \"deployed_at\":\"2026-01-01T00:00:00Z\"}}]"
+    )
+}
+
+/// Refuse to run a control that drives the local rung while something holds the
+/// local reply stub's port.
+///
+/// `assert_stub_port_free` (`cli/scripts/e2e-ladder.sh`) is a real connect
+/// probe against a HOST-GLOBAL port that the ladder deliberately does not let a
+/// caller override, so no stub can satisfy it. On a box with several checkouts,
+/// a concurrent `local message` or `local eval` holds it and reds every
+/// local-rung control for a reason that has nothing to do with parity. Failing
+/// here, with the ladder's own fix line, keeps that red diagnosable instead of
+/// arriving as a confusing parity failure.
+fn require_local_stub_port_free() {
+    let address = "127.0.0.1:8155"
+        .parse()
+        .expect("parse the stub port address");
+    if std::net::TcpStream::connect_timeout(&address, std::time::Duration::from_millis(250)).is_ok()
+    {
+        panic!(
+            "port 8155 is already in use, so the ladder's local rung cannot \
+             start and this control cannot run. This is a host collision, not \
+             a parity failure. fix: stop the process holding it (another ladder \
+             run, or a stale local message/eval), then re-run."
+        );
+    }
+}
+
+/// Run the real ladder script against the stubs in `harness`, with `envs`
+/// carrying the tier selection and the STUB_* knobs this control moves.
+///
+/// Every variable the ladder or `e2e.sh` reads is REMOVED before `envs` is
+/// applied, so the child environment is fixed by the control rather than by
+/// whatever the developer happens to have exported. Two classes, both of which
+/// have already bitten:
+/// - `CURIE_API_KEY` / `CURIE_API_URL`: the cluster rung's runtime-binding read
+///   arms itself only when a key is present, so an exported key made a
+///   cluster-only control reach the default `localhost:28000` and fail
+///   unreachable -- green in CI, red on one box.
+/// - `CURIE_E2E_IMAGE` / `_PORT` / `_NETWORK` / `_OTEL`: these change the argv
+///   `e2e.sh` builds for `skill up`, which the stub matches exactly, so an
+///   exported value turns the skill rung into an `exit 97`.
+fn run_ladder(harness: &Path, envs: &[(&str, &str)]) -> Output {
+    let script = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("scripts/e2e-ladder.sh");
+    let path = format!(
+        "{}:{}",
+        harness.display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+    let mut command = Command::new("bash");
+    command
+        .arg(script)
+        .env("CURIE_BIN", harness.join("curie"))
+        .env("PATH", path)
+        .env("STUB_STATE", harness)
+        .env("STUB_AGENT_ID", AGENT_ID)
+        .env("STUB_VERSION_ID", VERSION_ID)
+        .env("STUB_DEPLOYMENT_ID", DEPLOYMENT_ID)
+        .env_remove("CURIE_E2E_TIERS")
+        .env_remove("CURIE_E2E_LIVE")
+        .env_remove("CURIE_E2E_LISTEN_HOST")
+        .env_remove("CURIE_E2E_BUNDLE")
+        .env_remove("CURIE_E2E_IMAGE")
+        .env_remove("CURIE_E2E_PORT")
+        .env_remove("CURIE_E2E_NETWORK")
+        .env_remove("CURIE_E2E_OTEL")
+        .env_remove("CURIE_FAKE_MODEL")
+        .env_remove("CURIE_API_KEY")
+        .env_remove("CURIE_API_URL");
+    for (key, value) in envs {
+        command.env(key, value);
+    }
+    command.output().expect("run the real ladder script")
+}
+
+/// Whether some ONE line of the transcript carries every one of `needles`.
+///
+/// Line-scoped rather than whole-transcript, and that is the load-bearing part:
+/// the stub's raw `deploy --json` receipt already echoes a digest into the
+/// transcript, so a whole-transcript `contains` check for that digest passes
+/// with no parity logic in the ladder at all. Requiring the digest to share a
+/// line with a rung label, or two digests to share a line with each other,
+/// demands an actual operator-facing report instead.
+fn has_line_with(transcript: &str, needles: &[&str]) -> bool {
+    transcript
+        .lines()
+        .any(|line| needles.iter().all(|needle| line.contains(needle)))
+}
+
+/// Both streams together, because a control asserts on the operator-facing
+/// message without caring which stream carried it.
+fn transcript(output: &Output) -> String {
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+/// The content digest of the weather bundle as it sits in the tree, which is the
+/// digest the content-derived stub reports for every rung before anything
+/// mutates the copy. Computed with the same path-plus-bytes walk the stub's
+/// `sha_of_bundle` runs, so the two agree by construction.
+fn weather_bundle_sha256() -> String {
+    let bundle = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../examples/weather");
+    let output = Command::new("python3")
+        .arg("-c")
+        .arg(
+            "import hashlib, os, sys\n\
+             root = sys.argv[1]\n\
+             digest = hashlib.sha256()\n\
+             for dirpath, dirnames, filenames in os.walk(root):\n\
+             \x20   dirnames[:] = sorted(d for d in dirnames if d != '.curie')\n\
+             \x20   for entry in sorted(filenames):\n\
+             \x20       path = os.path.join(dirpath, entry)\n\
+             \x20       digest.update(os.path.relpath(path, root).encode())\n\
+             \x20       digest.update(open(path, 'rb').read())\n\
+             print(digest.hexdigest())",
+        )
+        .arg(bundle)
+        .output()
+        .expect("hash the weather bundle tree");
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+/// POSITIVE CONTROL. Every rung -- skill, local and cluster -- reports the same
+/// bundle digest, a matching dry-run plan line, and a model mode consistent with
+/// the run, so the ladder must pass and must NAME that one digest against each of
+/// the three rungs.
+///
+/// Why it exists: without it, the five negative controls below are unanchored --
+/// a ladder that failed unconditionally would satisfy all of them. This is the
+/// test that makes "one knob moved" mean something, and it is also the only test
+/// that catches a parity assertion so strict it can never pass.
+///
+/// The skill rung is in the tier list deliberately, and it is the only executing
+/// coverage of that leg: it runs `cli/scripts/e2e.sh` as a child, so it is what
+/// fails if the `CURIE_E2E_BUNDLE` handoff breaks, if the `tee`d
+/// `initial bundle digest:` line stops being parsed, or if the skill rung stops
+/// comparing its identity with the deployed rungs. With local and cluster alone,
+/// every one of those regressions stayed green.
+///
+/// No digest is pinned through a STUB_* override here: all three rungs report the
+/// content-derived digest of the tree they actually packed, so their agreement is
+/// three independent derivations landing on one value rather than one canned
+/// constant echoed three times.
+#[test]
+fn parity_passes_when_every_rung_reports_the_same_identity() {
+    require_local_stub_port_free();
+    let harness = tempfile::tempdir().expect("create harness directory");
+    write_ladder_stubs(harness.path());
+    let api_url = spawn_deployments_stub(&one_active_deployment());
+    let digest = weather_bundle_sha256();
+
+    let output = run_ladder(
+        harness.path(),
+        &[
+            ("CURIE_E2E_TIERS", "skill,local,cluster"),
+            ("CURIE_API_URL", &api_url),
+            ("STUB_FAKE_MODEL", "1"),
+        ],
+    );
+
+    let transcript = transcript(&output);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "a ladder run whose rungs all report the same digest, the same suite \
+         and a mode matching the run must pass; transcript:\n{transcript}"
+    );
+    for rung in ["skill", "local", "cluster"] {
+        assert!(
+            has_line_with(&transcript, &[&digest, rung]),
+            "the ladder must report the common bundle digest against the {rung} \
+             rung by name, since the transcript IS the parity evidence an \
+             operator reads; transcript:\n{transcript}"
+        );
+    }
+    assert!(
+        transcript.contains("reports-a-temperature"),
+        "the ladder must name the common suite's case ids, so a reader can see \
+         WHICH case set every rung shared rather than taking `parity` on \
+         trust; transcript:\n{transcript}"
+    );
+}
+
+/// NEGATIVE CONTROL: bundle identity. The cluster rung's deploy receipt reports
+/// a different `bundle.sha256` than the local rung's.
+///
+/// Prevents shipping silently: two tiers running two different artifacts while
+/// the ladder reports a green "same bundle at every tier", which is the false
+/// claim in the script header this whole change repairs.
+#[test]
+fn parity_fails_when_a_rung_reports_a_different_bundle_digest() {
+    require_local_stub_port_free();
+    let harness = tempfile::tempdir().expect("create harness directory");
+    write_ladder_stubs(harness.path());
+    let api_url = spawn_deployments_stub(&one_active_deployment());
+
+    let output = run_ladder(
+        harness.path(),
+        &[
+            ("CURIE_E2E_TIERS", "local,cluster"),
+            ("CURIE_API_URL", &api_url),
+            ("STUB_LOCAL_SHA256", PINNED_DIGEST),
+            // The one knob moved off the positive control.
+            ("STUB_CLUSTER_SHA256", DIVERGENT_DIGEST),
+            ("STUB_FAKE_MODEL", "1"),
+        ],
+    );
+
+    let transcript = transcript(&output);
+    assert_ne!(
+        output.status.code(),
+        Some(0),
+        "a rung reporting a different bundle digest must fail the ladder; \
+         transcript:\n{transcript}"
+    );
+    assert!(
+        !transcript.contains("LADDER PASS"),
+        "the ladder must not announce a pass on a digest divergence; \
+         transcript:\n{transcript}"
+    );
+    assert!(
+        has_line_with(&transcript, &[PINNED_DIGEST, DIVERGENT_DIGEST]),
+        "the failure must put the pinned digest and the divergent one on one \
+         line, so an operator sees the mismatch itself rather than two \
+         unrelated receipts; transcript:\n{transcript}"
+    );
+    assert!(
+        has_line_with(&transcript, &[DIVERGENT_DIGEST, "cluster"]),
+        "the failure must name WHICH rung shipped the different artifact; \
+         transcript:\n{transcript}"
+    );
+}
+
+/// NEGATIVE CONTROL: suite and case count. The cluster tier's own suite loader
+/// reports two cases from the weather suite when the bundle the ladder packed
+/// carries one.
+///
+/// Prevents shipping silently: a tier grading a different suite than the one the
+/// ladder deployed -- the second half of the divergence this change repairs
+/// (skill graded `introduces-itself`, local and cluster graded
+/// `reports-a-temperature`, and nothing compared them).
+#[test]
+fn parity_fails_when_a_rung_resolves_a_different_case_set() {
+    require_local_stub_port_free();
+    let harness = tempfile::tempdir().expect("create harness directory");
+    write_ladder_stubs(harness.path());
+    let api_url = spawn_deployments_stub(&one_active_deployment());
+
+    let output = run_ladder(
+        harness.path(),
+        &[
+            ("CURIE_E2E_TIERS", "local,cluster"),
+            ("CURIE_API_URL", &api_url),
+            ("STUB_LOCAL_SHA256", PINNED_DIGEST),
+            ("STUB_CLUSTER_SHA256", PINNED_DIGEST),
+            ("STUB_FAKE_MODEL", "1"),
+            // The one knob moved off the positive control.
+            ("STUB_CLUSTER_PLAN_COUNT", "2"),
+        ],
+    );
+
+    let transcript = transcript(&output);
+    assert_ne!(
+        output.status.code(),
+        Some(0),
+        "a tier whose suite loader resolves a different case count must fail \
+         the ladder; transcript:\n{transcript}"
+    );
+    assert!(
+        !transcript.contains("LADDER PASS"),
+        "the ladder must not announce a pass on a suite divergence; \
+         transcript:\n{transcript}"
+    );
+    assert!(
+        transcript.contains("cluster")
+            && transcript
+                .contains(r#"grade 2 case(s) from suite "weather" against the cluster tier"#),
+        "the failure must name the rung and print the raw plan line the tier \
+         reported, so a harness red is distinguishable from a parity red; \
+         transcript:\n{transcript}"
+    );
+}
+
+/// NEGATIVE CONTROL: fake-versus-live mode. The run asks for live, and the
+/// deployed cluster worker reports `CURIE_FAKE_MODEL=1`.
+///
+/// Prevents shipping silently: a "graded" nightly rung actually running sealed
+/// against the fake model. The cluster rung is the target on purpose -- it is
+/// the rung whose mode the script used to DISCLAIM rather than verify.
+#[test]
+fn parity_fails_when_the_deployed_model_mode_contradicts_the_run() {
+    let harness = tempfile::tempdir().expect("create harness directory");
+    write_ladder_stubs(harness.path());
+
+    let output = run_ladder(
+        harness.path(),
+        &[
+            ("CURIE_E2E_TIERS", "cluster"),
+            ("CURIE_E2E_LIVE", "1"),
+            ("CURIE_CREDENTIALS", "test-credential"),
+            // The one knob moved: a live run against a sealed deployment.
+            ("STUB_FAKE_MODEL", "1"),
+        ],
+    );
+
+    let transcript = transcript(&output);
+    assert_ne!(
+        output.status.code(),
+        Some(0),
+        "a live run against a deployment whose worker reports the fake model \
+         must fail the ladder, not warn; transcript:\n{transcript}"
+    );
+    assert!(
+        !transcript.contains("LADDER PASS"),
+        "the ladder must not announce a pass on a mode contradiction; \
+         transcript:\n{transcript}"
+    );
+    assert!(
+        transcript.contains("cluster") && transcript.contains("CURIE_FAKE_MODEL"),
+        "the failure must name the rung and the observed CURIE_FAKE_MODEL value \
+         read off the running artifact; transcript:\n{transcript}"
+    );
+}
+
+/// NEGATIVE CONTROL: case ids only. Between the local rung's deploy and the
+/// cluster rung's, the bundle's suite file has every case id rewritten while its
+/// suite NAME and case COUNT stay identical. Both rungs' dry-run plan lines
+/// therefore match the expectation exactly, and the digest is the only signal
+/// that moved.
+///
+/// This is the control that proves the digest, not the dry-run plan line, is
+/// what carries the case-id claim: the plan line carries a name and a count and
+/// no ids at all, so if the ladder's case-set evidence rested on it, this run
+/// would go green while the two tiers graded different cases. Deleting this test
+/// makes that transitive argument unfalsifiable and lets a decorative case-id
+/// claim ship.
+#[test]
+fn parity_fails_when_only_the_case_ids_differ() {
+    require_local_stub_port_free();
+    let harness = tempfile::tempdir().expect("create harness directory");
+    write_ladder_stubs(harness.path());
+    let api_url = spawn_deployments_stub(&one_active_deployment());
+    let unmutated_digest = weather_bundle_sha256();
+
+    let output = run_ladder(
+        harness.path(),
+        &[
+            ("CURIE_E2E_TIERS", "local,cluster"),
+            ("CURIE_API_URL", &api_url),
+            ("STUB_FAKE_MODEL", "1"),
+            // The one knob moved off the positive control. No SHA overrides
+            // here: the stub reports a content-derived digest, so the
+            // divergence is CAUSED by the id rewrite rather than asserted.
+            ("STUB_MUTATE_CASE_IDS", "1"),
+        ],
+    );
+
+    let transcript = transcript(&output);
+    assert_ne!(
+        output.status.code(),
+        Some(0),
+        "a case-id-only divergence must still fail the ladder, through bundle \
+         identity; transcript:\n{transcript}"
+    );
+    assert!(
+        !transcript.contains("LADDER PASS"),
+        "the ladder must not announce a pass when two rungs graded different \
+         case ids; transcript:\n{transcript}"
+    );
+    assert!(
+        transcript.contains(r#"grade 1 case(s) from suite "weather" against the cluster tier"#),
+        "the cluster tier's plan line must still have matched the expected \
+         suite and count -- that is what makes this a case-ids-only \
+         divergence rather than a suite divergence; transcript:\n{transcript}"
+    );
+    assert!(
+        has_line_with(&transcript, &[&unmutated_digest, "cluster"]),
+        "the failure must be an identity failure naming the cluster rung and \
+         the pinned digest of the tree the ladder packed, not a suite failure; \
+         transcript:\n{transcript}"
+    );
+}
+
+/// NEGATIVE CONTROL: runtime binding. A stale active `prod` deployment exists
+/// for the same agent alongside the `dev` row this run just created.
+///
+/// Prevents shipping silently the worst failure in this area: a deploy receipt
+/// proves what was UPLOADED, not what the following turn RAN. The worker's
+/// binding prefers `prod` over recency over the active set, so a leftover active
+/// prod row serves the turn while the ladder reports the dev bundle's digest --
+/// a green ladder proving the wrong artifact. Deleting this test makes the
+/// sole-active-deployment assertion unfalsifiable.
+#[test]
+fn parity_fails_when_a_second_active_deployment_exists() {
+    require_local_stub_port_free();
+    let harness = tempfile::tempdir().expect("create harness directory");
+    write_ladder_stubs(harness.path());
+    // The one knob moved off the positive control: the deployments read.
+    let api_url = spawn_deployments_stub(&two_active_deployments());
+
+    let output = run_ladder(
+        harness.path(),
+        &[
+            ("CURIE_E2E_TIERS", "local,cluster"),
+            ("CURIE_API_URL", &api_url),
+            ("STUB_LOCAL_SHA256", PINNED_DIGEST),
+            ("STUB_CLUSTER_SHA256", PINNED_DIGEST),
+            ("STUB_FAKE_MODEL", "1"),
+        ],
+    );
+
+    let transcript = transcript(&output);
+    assert_ne!(
+        output.status.code(),
+        Some(0),
+        "a second active deployment for the same agent must stop the ladder \
+         before the turn, since the turn may bind to the wrong artifact; \
+         transcript:\n{transcript}"
+    );
+    assert!(
+        !transcript.contains("LADDER PASS"),
+        "the ladder must not announce a pass while a stale active deployment \
+         could have served the turn; transcript:\n{transcript}"
+    );
+    assert!(
+        transcript.contains(DEPLOYMENT_ID) && transcript.contains(STALE_PROD_DEPLOYMENT_ID),
+        "the failure must name every active deployment row, so the operator \
+         can see which one is the shadow; transcript:\n{transcript}"
+    );
+    assert!(
+        transcript.contains("local down --wipe --yes"),
+        "the failure must carry the actionable fix line, matching the ladder's \
+         other preflight-style hard failures; transcript:\n{transcript}"
+    );
+}
+
+/// The inverse of the local/local-release assertions above, which pin those
+/// rungs to a bare `"$BIN" local eval ...` that `set -e` makes fatal. On the
+/// cluster rung the grade is REPORT ONLY (#1603): the eval still runs and still
+/// prints, but a red case must not fail the rung, because the weather case
+/// grades temperature PRESENCE and the cluster rung's provider-only egress makes
+/// presence a function of model phrasing rather than of a real fetch.
+///
+/// This is the successor of the #872 coverage (commit 1d266a73's third bullet),
+/// which asserted the ladder EXITED 42 on a red deployed evaluator. #1603
+/// deliberately reversed that half for this one rung, so what survives from #872
+/// is the other half, and it is the half that mattered: the evaluator must
+/// actually have been REACHED. Report only means non-fatal, never skipped.
+///
+/// Driven through the shared stub so the cluster rung's deploy-receipt, suite and
+/// mode reads resolve deterministically instead of falling through to `exit 97`
+/// or reaching the host's real `kubectl`. `STUB_EVAL_EXIT=42` keeps the injected
+/// failure the same one #872 used, so the only thing that changed is what the
+/// ladder is allowed to do with it.
+#[test]
+fn live_cluster_rung_reports_but_does_not_propagate_evaluator_failure() {
+    let harness = tempfile::tempdir().expect("create harness directory");
+    write_ladder_stubs(harness.path());
+    let eval_marker = harness.path().join("eval_called");
+
+    let output = run_ladder(
+        harness.path(),
+        &[
+            ("CURIE_E2E_TIERS", "cluster"),
+            ("CURIE_E2E_LIVE", "1"),
+            ("CURIE_CREDENTIALS", "test-credential"),
+            // A live run needs the deployed worker to report NO fake model, or
+            // the mode assertion would red the run before the evaluator ran.
+            ("STUB_FAKE_MODEL", ""),
+            (
+                "STUB_EVAL_MARKER",
+                eval_marker.to_str().expect("marker path"),
+            ),
+            ("STUB_EVAL_EXIT", "42"),
+        ],
+    );
+
+    // Stream-scoped, not the merged transcript: the tolerated-grade notice is a
+    // stderr diagnostic while LADDER PASS is the stdout verdict, and a control
+    // that accepted either on either stream would pass with the two swapped.
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(


### PR DESCRIPTION
The ladder's header claimed it drives the SAME bundle through each deployment tier. It did not: rung 1 delegated to `cli/scripts/e2e.sh`, which scaffolded its own inline `deal-desk` bundle, while local, local-release and cluster drove `examples/weather`. Nothing compared artifact identity, case identifiers, or model mode, so a tier could drift from its siblings and the ladder still exited green.

Every rung now drives one common bundle and one suite, and divergence fails.

## What is asserted, and with what

- **Bundle identity.** The skill tier's client-side `bundle_digest` from `skill status --json` is compared against the platform's server-side `bundle.sha256` from `deploy --json`. Equality proves two independent hashers agree on one source tree, which is strictly stronger than packing once. No CLI surface accepts a pre-packed archive, so each tier packs for itself and the digests are compared instead.
- **Suite and case set.** Each tier's own loader resolves the suite via `eval --dry-run`, which sends no turn, so a sealed run never grades canned text. Case-id parity follows from the digest: byte-identical `evals/cases.json` implies identical ids.
- **Model mode.** Read off the running worker rather than re-derived from this run's environment. This closes the cluster rung's previously unverified mode and turns the reused-stack warning into a failure.
- **Deployment binding.** Exactly one active deployment must exist for the agent before the turn. A channel binds to one agent (unique constraint) and the resolver prefers an active `prod` row over a newer `dev` one, so a stale deployment could otherwise serve the very turn the ladder just certified.

`pack_tar_gz` embeds per-file mtime, so mtimes are normalized after each bundle copy and the mutated `SKILL.md` is restored with `cp -p`. Without that, two copies of identical content pack to different bytes and every multi-rung run reds in a way that reads like a product bug.

## Controls

One positive and five negative, executing the real script against stubs with no docker, cluster, or credential required: digest mismatch, case-set mismatch, mode contradiction, ids-only divergence (same suite name and count, different ids), and a second active deployment. The positive control pins no digest constant; three independently derived digests must agree.

## Standalone behavior

`cli/scripts/e2e.sh` gains exactly one input, `CURIE_E2E_BUNDLE`, which the ladder sets internally. With it unset the script is unchanged: it still scaffolds `deal-desk` from its inline spec and runs both eval legs, so its own acceptance evidence survives. A failure inside the `#1087` mutation window now restores a caller-supplied bundle to byte- and mtime-exact state instead of leaving it corrupted.

## Verified live

A `skill,local` invocation reported the same digest at both rungs (`55d9d608bf2764b331dd067c1ebc29d9554b57dbdcd56f1c36268cbfc3f74439`), from the skill tier's client-side pack and the platform's server-side hash, with the deployment-binding and mode assertions passing and `plumbing_ok=1 passed=0` confirming nothing was graded under the fake model.

## Limits, stated rather than papered over

- The cluster rung asserts the deployment binding only when `CURIE_API_KEY` is present, because that key has no default and CI's cluster job supplies none. Without it the rung prints that the receipt proves what was UPLOADED and that runtime binding is unproven, and the summary never reads as a cluster parity claim.
- The active-deployment read happens before the turn, so a deployment created inside that window would not be caught. That needs a concurrent deployer against the same stack.
- Agent, version, bundle and deployment rows created against a reused or cluster stack are not removed. No API surface can delete a deployment, which is pre-existing and not introduced here.
- CI runs the rungs in separate jobs. The default job covers skill and local, so its digest comparison is genuinely cross-rung; the `local-release` and `cluster` jobs are single-rung and print an explicit vacuity notice rather than a parity claim.
- Rung 1's graded coverage narrows from two cases to one, the direct cost of one common suite, and the ladder path no longer carries the `--from-spec` scaffold evidence that the standalone run still does.

Follow-ups worth filing: the local/cluster in-CLI eval path grades with no fake awareness; no verb reports a deployed tier's effective model mode; and there is no undeploy or stop endpoint.

Ref #690
