### PR TITLE
Add the ADR-0079 inbound hook ingress

### DIFF
--- a/apps/api/alembic/versions/0027_agents_hook_generation.py
+++ b/apps/api/alembic/versions/0027_agents_hook_generation.py
@@ -1,0 +1,54 @@
+"""agents.hook_generation: the rotation counter behind derived hook secrets (#269)
+
+ADR-0079's inbound hook ingress needs a per-agent shared secret an upstream signs
+its deliveries with. That secret is DERIVED (``hook_secret.derive``) from the
+platform key, the agent id and this counter rather than stored, so no
+third-party credential sits in plaintext in the control plane and the existing
+production guard on ``API_KEY`` covers it for free.
+
+What this column adds is the ability to revoke ONE agent's hook secret. Without
+it the only way to invalidate a leaked secret would be rotating the platform key,
+which invalidates every credential the platform has ever minted. The column
+holds an ordinary integer and reading it grants nothing.
+
+Defaults to 0 for existing rows, which is the same value a newly created agent
+gets, so no agent has a "no secret yet" state to special-case.
+
+Revision ID: 0027
+Revises: 0026
+Create Date: 2026-08-17
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0027"
+down_revision: str | None = "0026"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+SCHEMA = "curie"
+
+
+def upgrade() -> None:
+    # NOT NULL with a server default, so the backfill and the constraint land in
+    # one statement and no window exists where an existing agent reads as NULL.
+    op.add_column(
+        "agents",
+        sa.Column(
+            "hook_generation",
+            sa.Integer(),
+            server_default="0",
+            nullable=False,
+        ),
+        schema=SCHEMA,
+    )
+
+
+def downgrade() -> None:
+    # Dropping the counter resets every agent to generation 0 on a later upgrade,
+    # which REVIVES any hook secret that was rotated away. A downgrade here is
+    # therefore a credential event, not just a schema change.
+    op.drop_column("agents", "hook_generation", schema=SCHEMA)

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -1862,6 +1862,37 @@
         "title": "HelpPackConfig",
         "type": "object"
       },
+      "HookAccepted": {
+        "description": "The hook receipt. ``duplicate`` says whether THIS request enqueued.\n\n``stream_id`` is None only while another request holds the claim and has not\nenqueued yet (the 202 case).",
+        "properties": {
+          "duplicate": {
+            "title": "Duplicate",
+            "type": "boolean"
+          },
+          "event_id": {
+            "title": "Event Id",
+            "type": "string"
+          },
+          "stream_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stream Id"
+          }
+        },
+        "required": [
+          "event_id",
+          "stream_id",
+          "duplicate"
+        ],
+        "title": "HookAccepted",
+        "type": "object"
+      },
       "KillState": {
         "description": "Whether an agent is currently killed (kill switch, L1).",
         "properties": {
@@ -6185,6 +6216,91 @@
         "summary": "Health",
         "tags": [
           "health"
+        ]
+      }
+    },
+    "/hooks/{agent_id}/{hook}": {
+      "post": {
+        "description": "Verify one hook delivery and enqueue it as a turn.\n\nOrder, and why each step sits where it does:\n\n1. the hook NAME, validated before anything else, because it is about to be\n   used to build key names;\n2. the size bound, before the signature is computed, so an oversized body is\n   refused without the server ever HMAC-ing it;\n3. the agent row, which unavoidably precedes authentication here (see the\n   module docstring);\n4. the SIGNATURE over the raw body;\n5. the delivery id, checked after authentication so an unsigned caller learns\n   nothing about what this route wants;\n6. routability, then the claim, quota and enqueue.",
+        "operationId": "ingest_hook_hooks__agent_id___hook__post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Agent Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "hook",
+            "required": true,
+            "schema": {
+              "title": "Hook",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-curie-signature-256",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Curie-Signature-256"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-curie-delivery-id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Curie-Delivery-Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HookAccepted"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Ingest Hook",
+        "tags": [
+          "hooks"
         ]
       }
     },

--- a/apps/api/src/curie_api/config.py
+++ b/apps/api/src/curie_api/config.py
@@ -321,6 +321,16 @@ class Settings(BaseSettings):
     # exceeded requests are refused 429 rather than queued. It bounds the rate of
     # NEW work, not the depth of unconsumed work: the API cannot observe what the
     # worker has consumed without infrastructure phase 2 does not build.
+    # Inbound hook ingress (ADR-0079, #269). Body bound sized like the GitHub
+    # webhook's rather than the channel turn's: a hook payload is a machine
+    # document, not a person's message, and the whole document becomes the turn
+    # text today.
+    hook_max_body_bytes: int = 1024 * 1024
+    # Metered per AGENT: the thing worth bounding is how much work one agent's
+    # upstreams can create, and a per-hook counter would let a source multiply
+    # its own allowance by inventing hook names.
+    hook_backlog_limit: int = 64
+    hook_backlog_window_s: int = 60
     channel_binding_backlog_limit: int = 64
     channel_binding_backlog_window_s: int = 60
 

--- a/apps/api/src/curie_api/delivery.py
+++ b/apps/api/src/curie_api/delivery.py
@@ -1,0 +1,232 @@
+"""The at-least-once delivery machinery every inbound ingress route shares.
+
+Extracted from ``routers/channels.py`` when ADR-0079's hook ingress became the
+SECOND route needing it (issue #269). Until then it was one implementation and
+belonged where it was used; the abstraction is written now because there are two
+callers, not in anticipation of them.
+
+Copying it instead would have put two versions of the same idempotency argument
+in the tree, and the parts most worth not duplicating are the ones a reader
+cannot check by eye: the three-armed enqueue script, the reason a receipt has no
+expiry, and the reason the quota is counted only after a claim is won. Two copies
+of that drift silently, and the symptom is a correspondent answered twice.
+
+**Callers own their key names.** Every function here takes a fully-built key,
+because the namespace is the caller's decision and the two routes deliberately do
+not share one: a channel delivery is identified by ``(binding row, delivery id)``
+and a hook delivery by ``(agent, hook, delivery id)``. Handing both a shared
+prefix would let two different id spaces collide on one key and swallow each
+other's turns.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import time
+from typing import Any
+
+import redis.asyncio as redis
+from fastapi import Response
+
+# The API's Valkey client is built without `decode_responses`, so values come
+# back as bytes; `_text` is the package's named, documented decode for exactly
+# that.
+from .graveyardwatcher import _text
+
+logger = logging.getLogger(__name__)
+
+# The owner-checked enqueue, as ONE script so the ownership check and the XADD
+# are a single atomic step (Valkey runs a script single-threaded, which is
+# exactly the guarantee needed here). Three exhaustive outcomes:
+#
+#   (a) we still own the lease        -> XADD, and the claim becomes the receipt
+#   (b) the lease lapsed, NO successor -> re-claim and XADD in-script
+#   (c) a foreign token or a stream id -> no XADD; name the current owner
+#
+# (b) is not a nicety: without it a winner that resumed after its lease expired
+# but BEFORE any successor claimed would find an empty key, take the lease-lost
+# arm, and report a duplicate for a delivery that was NEVER enqueued -- and the
+# caller retries only transport failures, so that delivery is silently dropped.
+# (c)'s TOKEN comparison is what makes the lease OWNED: a merely SLOW winner
+# whose lease was re-claimed must not XADD on top of the retry's entry.
+#
+# The claim key has TWO phases with OPPOSITE expiry contracts, and BOTH enqueue
+# arms below write the second one: `pending:<token>` carries the lease TTL (what
+# makes a dead winner's delivery recoverable), while the stream id that replaces
+# it is a RECEIPT and is written with NO expiry at all. An expiry there lets the
+# same `delivery_id` win a fresh `SET NX` once it lapses, enqueue a second time,
+# and answer the correspondent twice -- silently, and only for the deliveries a
+# caller happens to retry after the window.
+_ENQUEUE_SCRIPT = """
+local cur = redis.call('GET', KEYS[1])
+if cur == ARGV[1] then
+  local id = redis.call('XADD', KEYS[2], '*', ARGV[3], ARGV[2])
+  redis.call('SET', KEYS[1], id)
+  return {1, id}
+elseif not cur then
+  redis.call('SET', KEYS[1], ARGV[1], 'EX', ARGV[4])
+  local id = redis.call('XADD', KEYS[2], '*', ARGV[3], ARGV[2])
+  redis.call('SET', KEYS[1], id)
+  return {1, id}
+else
+  return {0, cur}
+end
+"""
+
+# One caller's slot counter for the current window, taken atomically: INCR and
+# the window's EXPIRE cannot be two round trips, or a process that dies between
+# them leaves a counter that never expires and 429s that caller forever.
+_QUOTA_SCRIPT = """
+local n = redis.call('INCR', KEYS[1])
+if n == 1 then
+  redis.call('EXPIRE', KEYS[1], ARGV[1])
+end
+return n
+"""
+
+# Give a claim back, and ONLY our own: used when the quota refuses a delivery we
+# have already claimed, so the refusal does not leave the `delivery_id` locked
+# for a lease's duration. The compare is what keeps a slow caller from deleting
+# a successor's claim.
+_RELEASE_SCRIPT = """
+if redis.call('GET', KEYS[1]) == ARGV[1] then
+  redis.call('DEL', KEYS[1])
+end
+return 1
+"""
+
+
+def sha16(delivery_id: str) -> str:
+    """The short digest both of a delivery's derived names are built from.
+
+    Args:
+        delivery_id: The upstream's id for this delivery.
+
+    Returns:
+        The first 16 hex characters of its SHA-256.
+    """
+
+    return hashlib.sha256(delivery_id.encode()).hexdigest()[:16]
+
+
+async def claim_delivery(client: redis.Redis, key: str, owner: str, lease_s: int) -> bool:
+    """Claim one delivery for THIS request: ``SET NX EX``, first writer wins.
+
+    The structural sibling of the dispatcher's ``already_enqueued`` guard, with
+    two deliberate differences: the dispatcher DROPS a retry silently while
+    ingress ANSWERS it (an HTTP caller needs a response), and the value here is
+    an owner TOKEN that later becomes the stream id rather than a bare ``1``,
+    which is what makes that answer possible.
+
+    ``SET NX`` is the only atomic step available: a read-then-write guard (the
+    kernel's ``is_done`` check, read long before ``mark_done`` is written) admits
+    two winners, which is why idempotency is settled here, at ingress.
+
+    Args:
+        client: The Valkey client.
+        key: This delivery's claim key, in the caller's namespace.
+        owner: This request's opaque owner token.
+        lease_s: How long an unfinished claim survives.
+
+    Returns:
+        True when this request took the claim.
+    """
+
+    return bool(await client.set(key, owner, nx=True, ex=lease_s))
+
+
+async def enqueue_owned(
+    client: redis.Redis,
+    *,
+    key: str,
+    stream: str,
+    owner: str,
+    payload: str,
+    payload_field: str,
+    lease_s: int,
+) -> tuple[bool, str]:
+    """Enqueue the payload if this request still owns the claim.
+
+    Args:
+        client: The Valkey client.
+        key: This delivery's claim key.
+        stream: The runs stream to append to.
+        owner: This request's owner token.
+        payload: The serialized ``QueuedTurn``.
+        payload_field: The stream field the payload rides in.
+        lease_s: The lease used by the re-claim arm.
+
+    Returns:
+        ``(True, stream_id)`` when THIS request enqueued; ``(False, owner_value)``
+        naming the current owner when it did not.
+    """
+
+    result: Any = await client.eval(
+        _ENQUEUE_SCRIPT, 2, key, stream, owner, payload, payload_field, str(lease_s)
+    )
+    enqueued, current = result
+    return bool(enqueued), _text(current)
+
+
+async def take_backlog_slot(
+    client: redis.Redis, *, key_prefix: str, limit: int, window_s: int
+) -> bool:
+    """Count ONE new delivery against this caller's window, atomically.
+
+    Called only once a claim is won, so a duplicate the upstream is retrying
+    costs nothing -- the cap is on NEW work, which is the thing a compromised or
+    runaway source can make unbounded.
+
+    Args:
+        client: The Valkey client.
+        key_prefix: The counter's namespace, without the window suffix.
+        limit: The most new deliveries allowed per window.
+        window_s: The window length in seconds.
+
+    Returns:
+        True when this delivery fits inside the window's allowance.
+    """
+
+    window = int(time.time()) // window_s
+    key = f"{key_prefix}:{window}"
+    count: Any = await client.eval(_QUOTA_SCRIPT, 1, key, str(window_s))
+    return int(count) <= limit
+
+
+async def release_claim(client: redis.Redis, key: str, owner: str) -> None:
+    """Give back a claim this request took but will not enqueue.
+
+    Args:
+        client: The Valkey client.
+        key: This delivery's claim key.
+        owner: This request's owner token, compared before the delete.
+    """
+
+    await client.eval(_RELEASE_SCRIPT, 1, key, owner)
+
+
+def duplicate_stream_id(current: str, response: Response) -> str | None:
+    """Read a claim someone else owns, and set the status that describes it.
+
+    A ``pending:`` value means another request is mid-flight and there is no
+    stream id yet, so the answer is 202 ("come back"); anything else IS the
+    stream id of the entry that request enqueued, so the answer stays 200 with
+    that id. Either way the calling request issues no XADD.
+
+    Returns the id rather than a response model because the two routes answer
+    with different receipt shapes; the status code and the None-vs-id decision
+    are the parts that must not diverge, and those are made here.
+
+    Args:
+        current: The claim key's current value.
+        response: The FastAPI response, whose status this may set to 202.
+
+    Returns:
+        The stream id, or None while another request still holds the claim.
+    """
+
+    if current.startswith("pending:"):
+        response.status_code = 202
+        return None
+    return current

--- a/apps/api/src/curie_api/hook_signing.py
+++ b/apps/api/src/curie_api/hook_signing.py
@@ -1,0 +1,86 @@
+"""Signing and verification for inbound hook deliveries (#269).
+
+ADR-0079 decision 1 calls for a "per-agent hook secret" verified with the same
+HMAC pattern the GitHub webhook already uses. This module answers where that
+secret comes from, and the answer is that it is DERIVED rather than stored --
+which is also why the module is not named for a secret it never holds.
+
+**Why derived.** The obvious shape -- a secret column on ``agents`` -- puts a
+credential that a third party also holds in plaintext in the control-plane
+database, and this API has no encryption at rest (``agents.secrets`` is plain
+JSONB). Deriving it with HMAC keyed by the platform ``api_key`` keeps nothing
+secret in a row, inherits the production guard that already refuses to boot with
+a default ``api_key``, and is reproducible, so an operator can be shown the
+current value whenever they need to paste it into the upstream system.
+
+**Why a rotation counter is still stored.** Derivation alone would make the only
+way to revoke one compromised hook a rotation of the platform key, which revokes
+every credential the platform has minted. ``agents.hook_generation`` is an
+ordinary integer, not a secret: bumping it changes that one agent's derived
+secret and nothing else. Storing the counter rather than the secret is the whole
+trick.
+
+This is HMAC used as a key-derivation step, which is what ``sandbox_token`` and
+``channel_token`` already do with the same key; the primitives are imported from
+the first of them rather than copied.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+
+from .sandbox_token import _signature
+
+# The header an upstream presents its signature in. Named for this platform
+# rather than borrowing GitHub's ``X-Hub-Signature-256``: a hook source is any
+# system, and reusing GitHub's spelling would suggest a GitHub payload shape.
+SIGNATURE_HEADER = "X-Curie-Signature-256"
+
+# The label that separates this derivation from every other use of ``api_key``.
+# Without it a hook secret and some future token derived from the same key over
+# the same inputs would be the same bytes, and holding one would grant the other.
+_LABEL = "curie.hook.v1"
+
+
+def derive(api_key: str, *, agent_id: str, generation: int) -> str:
+    """The shared secret for one agent's hooks at one rotation generation.
+
+    Args:
+        api_key: The platform's shared signing key.
+        agent_id: The agent's id, as a string.
+        generation: The agent's ``hook_generation``; bumping it rotates.
+
+    Returns:
+        The secret, base64url-encoded, safe to hand to an operator verbatim.
+    """
+
+    return _signature(api_key, f"{_LABEL}:{agent_id}:{generation}")
+
+
+def verify(secret: str, body: bytes, header: str | None) -> bool:
+    """Constant-time check of the upstream's signature over the RAW body.
+
+    The raw bytes are signed, never a re-serialization: any parse-then-dump round
+    trip can change whitespace or key order, and a signature checked against
+    re-serialized bytes either rejects honest deliveries or, worse, is quietly
+    dropped as unworkable.
+
+    Mirrors ``gitflow.verify_signature`` deliberately, including the ``sha256=``
+    prefix, because an operator configuring a hook has almost certainly
+    configured a GitHub webhook before and the two should not differ in shape for
+    no reason.
+
+    Args:
+        secret: The derived per-agent secret.
+        body: The exact request body bytes.
+        header: The presented signature header, or None when absent.
+
+    Returns:
+        True only for a well-formed header that matches.
+    """
+
+    if not header or not header.startswith("sha256="):
+        return False
+    expected = "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+    return hmac.compare_digest(expected, header)

--- a/apps/api/src/curie_api/main.py
+++ b/apps/api/src/curie_api/main.py
@@ -38,6 +38,7 @@ from .routers import (
     deployments,
     evals,
     github,
+    hooks,
     memory,
     observability,
     runs,
@@ -273,6 +274,7 @@ def create_app() -> FastAPI:
     app.include_router(memory.router)
     app.include_router(approvals.router)
     app.include_router(channels.router)
+    app.include_router(hooks.router)
     return app
 
 

--- a/apps/api/src/curie_api/models.py
+++ b/apps/api/src/curie_api/models.py
@@ -98,6 +98,16 @@ class Agent(Base):
     # consumes them. NULL means no connector secrets. (The cluster tier delivers
     # values via a per-agent K8s Secret instead; only the names live here there.)
     secrets: Mapped[dict[str, Any] | None] = mapped_column(JSONB, default=None)
+    # Rotation counter for this agent's inbound hook secret (ADR-0079, #269).
+    #
+    # NOT a secret, which is the point. The secret an upstream signs with is
+    # DERIVED from the platform key, this agent's id and this number
+    # (`hook_secret.derive`), so nothing a reader of this table finds lets them
+    # forge a delivery. Bumping the counter rotates exactly one agent's hook
+    # secret; storing the secret itself would have meant a third-party credential
+    # sitting in plaintext in the control plane, and rotating it any other way
+    # means rotating the platform key for every agent at once.
+    hook_generation: Mapped[int] = mapped_column(default=0, server_default="0")
     created_at: Mapped[datetime] = mapped_column(server_default=func.now())
 
     versions: Mapped[list["AgentVersion"]] = relationship(

--- a/apps/api/src/curie_api/routers/channels.py
+++ b/apps/api/src/curie_api/routers/channels.py
@@ -27,7 +27,6 @@ URL, which is credential capture rather than merely SSRF.
 
 from __future__ import annotations
 
-import hashlib
 import logging
 import secrets
 import time
@@ -54,6 +53,14 @@ from .. import channel_token
 from ..auth import require_api_key, verify_platform_key
 from ..channel_token import CHANNEL_ENQUEUE_SCOPE
 from ..config import get_settings
+from ..delivery import (
+    claim_delivery,
+    duplicate_stream_id,
+    enqueue_owned,
+    release_claim,
+    sha16,
+    take_backlog_slot,
+)
 from ..deps import SessionDep
 
 # The API's Valkey client is built without `decode_responses`, so values come
@@ -85,66 +92,6 @@ _AUTH_DETAIL = "missing or invalid credential"
 # sharing an upstream id space -- two AgentMail inboxes, two webhook sources --
 # cannot swallow each other's turns (E16).
 _CLAIM_PREFIX = "curie:channel"
-
-# The owner-checked enqueue, as ONE script so the ownership check and the XADD
-# are a single atomic step (Valkey runs a script single-threaded, which is
-# exactly the guarantee needed here). Three exhaustive outcomes:
-#
-#   (a) we still own the lease        -> XADD, and the claim becomes the receipt
-#   (b) the lease lapsed, NO successor -> re-claim and XADD in-script
-#   (c) a foreign token or a stream id -> no XADD; name the current owner
-#
-# (b) is not a nicety: without it a winner that resumed after its lease expired
-# but BEFORE any successor claimed would find an empty key, take the lease-lost
-# arm, and report a duplicate for a delivery that was NEVER enqueued -- and the
-# adapter retries only transport failures, so that delivery is silently dropped.
-# (c)'s TOKEN comparison is what makes the lease OWNED: a merely SLOW winner
-# whose lease was re-claimed must not XADD on top of the retry's entry.
-#
-# The claim key has TWO phases with OPPOSITE expiry contracts, and BOTH enqueue
-# arms below write the second one: `pending:<token>` carries the lease TTL (what
-# makes a dead winner's delivery recoverable), while the stream id that replaces
-# it is a RECEIPT and is written with NO expiry at all. An expiry there lets the
-# same `delivery_id` win a fresh `SET NX` once it lapses, enqueue a second time,
-# and answer the correspondent twice -- silently, and only for the deliveries an
-# adapter happens to retry after the window.
-_ENQUEUE_SCRIPT = """
-local cur = redis.call('GET', KEYS[1])
-if cur == ARGV[1] then
-  local id = redis.call('XADD', KEYS[2], '*', ARGV[3], ARGV[2])
-  redis.call('SET', KEYS[1], id)
-  return {1, id}
-elseif not cur then
-  redis.call('SET', KEYS[1], ARGV[1], 'EX', ARGV[4])
-  local id = redis.call('XADD', KEYS[2], '*', ARGV[3], ARGV[2])
-  redis.call('SET', KEYS[1], id)
-  return {1, id}
-else
-  return {0, cur}
-end
-"""
-
-# One binding's slot counter for the current window, taken atomically: INCR and
-# the window's EXPIRE cannot be two round trips, or a process that dies between
-# them leaves a counter that never expires and 429s that binding forever.
-_QUOTA_SCRIPT = """
-local n = redis.call('INCR', KEYS[1])
-if n == 1 then
-  redis.call('EXPIRE', KEYS[1], ARGV[1])
-end
-return n
-"""
-
-# Give a claim back, and ONLY our own: used when the quota refuses a delivery we
-# have already claimed, so the refusal does not leave the `delivery_id` locked
-# for a lease's duration. The compare is what keeps a slow caller from deleting
-# a successor's claim.
-_RELEASE_SCRIPT = """
-if redis.call('GET', KEYS[1]) == ARGV[1] then
-  redis.call('DEL', KEYS[1])
-end
-return 1
-"""
 
 
 # --- request/response models --------------------------------------------------
@@ -329,10 +276,6 @@ async def mint_channel_token(
 # --- POST /channels/turns -----------------------------------------------------
 
 
-def _sha16(delivery_id: str) -> str:
-    return hashlib.sha256(delivery_id.encode()).hexdigest()[:16]
-
-
 # Both names below are built from the SAME digest of the same `delivery_id`, so
 # the handler hashes once and hands the digest to each: they name one delivery,
 # and re-deriving it per name is work paid on every ingress request.
@@ -430,92 +373,16 @@ def _mint_turn(row: AgentChannel, body: TurnIn, event_id: str) -> QueuedTurn:
     )
 
 
-async def _claim_delivery(
-    client: redis.Redis, key: str, owner: str, lease_s: int
-) -> bool:
-    """Claim one delivery for THIS request: `SET NX EX`, first writer wins.
-
-    The structural sibling of the dispatcher's `already_enqueued` guard
-    (`apps/dispatcher/src/curie_dispatcher/queue.py`'s `claim_event`), with two
-    deliberate differences: the dispatcher DROPS a retry silently while ingress
-    ANSWERS it (an HTTP caller needs a response), and the value here is an owner
-    TOKEN that later becomes the stream id rather than a bare `1`, which is what
-    makes that answer possible.
-
-    `SET NX` is the only atomic step available: a read-then-write guard (the
-    kernel's `is_done` check, read long before `mark_done` is written) admits two
-    winners, which is why idempotency is settled here, at ingress.
-    """
-
-    return bool(await client.set(key, owner, nx=True, ex=lease_s))
-
-
-async def _enqueue_owned(
-    client: redis.Redis,
-    *,
-    key: str,
-    stream: str,
-    owner: str,
-    payload: str,
-    lease_s: int,
-) -> tuple[bool, str]:
-    """Run the owner-checked enqueue script; True with the stream id when THIS
-    request enqueued, False with the current owner's value when it did not.
-
-    No receipt TTL is passed because the receipt has none: the claim key survives
-    as the stream id for good (see `_ENQUEUE_SCRIPT`)."""
-
-    result: Any = await client.eval(
-        _ENQUEUE_SCRIPT,
-        2,
-        key,
-        stream,
-        owner,
-        payload,
-        STREAM_PAYLOAD_FIELD,
-        str(lease_s),
-    )
-    enqueued, current = result
-    return bool(enqueued), _text(current)
-
-
-async def _take_backlog_slot(
-    client: redis.Redis, *, channel_id: uuid.UUID, limit: int, window_s: int
-) -> bool:
-    """Count ONE new delivery against this binding's window, atomically.
-
-    Called only once a claim is won, so a duplicate an adapter is retrying costs
-    nothing -- the cap is on NEW work per binding, which is the thing a
-    compromised adapter can make unbounded.
-    """
-
-    window = int(time.time()) // window_s
-    key = f"{_CLAIM_PREFIX}:backlog:{channel_id}:{window}"
-    count: Any = await client.eval(_QUOTA_SCRIPT, 1, key, str(window_s))
-    return int(count) <= limit
-
-
-async def _release_claim(client: redis.Redis, key: str, owner: str) -> None:
-    """Give back a claim this request took but will not enqueue."""
-
-    await client.eval(_RELEASE_SCRIPT, 1, key, owner)
-
-
-def _duplicate(
-    event_id: str, current: str, response: Response
-) -> TurnAccepted:
+def _duplicate(event_id: str, current: str, response: Response) -> TurnAccepted:
     """Answer a delivery someone else owns, from what the claim key holds.
 
-    A `pending:` value means another request is mid-flight and there is no stream
-    id yet, so the answer is 202 ("come back"); anything else IS the stream id of
-    the entry that request enqueued, so the answer is 200 with that id. Either
-    way this request issues no XADD.
+    The status and the None-vs-id decision live in `delivery.duplicate_stream_id`
+    so the hook ingress cannot drift from them; only this route's receipt SHAPE
+    is built here.
     """
 
-    if current.startswith("pending:"):
-        response.status_code = status.HTTP_202_ACCEPTED
-        return TurnAccepted(event_id=event_id, stream_id=None, duplicate=True)
-    return TurnAccepted(event_id=event_id, stream_id=current, duplicate=True)
+    stream_id = duplicate_stream_id(current, response)
+    return TurnAccepted(event_id=event_id, stream_id=stream_id, duplicate=True)
 
 
 @router.post("/turns", response_model=TurnAccepted)
@@ -566,7 +433,7 @@ async def ingest_turn(
         raise _unroutable(body.kind, body.address)
 
     # One hash of the `delivery_id`, shared by the two names derived from it.
-    digest = _sha16(body.delivery_id)
+    digest = sha16(body.delivery_id)
     event_id = _event_id(row.id, digest)
     client: redis.Redis = request.app.state.valkey
     key = _claim_key(row.id, digest)
@@ -592,12 +459,12 @@ async def ingest_turn(
     # have named its owner. If that repeats, the honest answer is "someone is
     # mid-flight" -- never a second XADD.
     for _attempt in range(2):
-        if await _claim_delivery(
+        if await claim_delivery(
             client, key, owner, settings.channel_delivery_lease_s
         ):
-            if not await _take_backlog_slot(
+            if not await take_backlog_slot(
                 client,
-                channel_id=row.id,
+                key_prefix=f"{_CLAIM_PREFIX}:backlog:{row.id}",
                 limit=settings.channel_binding_backlog_limit,
                 window_s=settings.channel_binding_backlog_window_s,
             ):
@@ -605,7 +472,7 @@ async def ingest_turn(
                 # is not locked out for a lease, and tell the adapter to retry.
                 # Metered per binding, so one compromised or runaway adapter
                 # cannot fill the shared stream for every other tenant.
-                await _release_claim(client, key, owner)
+                await release_claim(client, key, owner)
                 logger.warning(
                     "channel ingress refused event_id=%s kind=%s: binding backlog "
                     "quota of %d per %ds exceeded",
@@ -627,12 +494,13 @@ async def ingest_turn(
             # those requests answers from `event_id` alone and would have thrown
             # the payload away.
             turn = _mint_turn(row, body, event_id)
-            enqueued, current = await _enqueue_owned(
+            enqueued, current = await enqueue_owned(
                 client,
                 key=key,
                 stream=settings.runs_stream,
                 owner=owner,
                 payload=turn.model_dump_json(),
+                payload_field=STREAM_PAYLOAD_FIELD,
                 lease_s=settings.channel_delivery_lease_s,
             )
             if enqueued:

--- a/apps/api/src/curie_api/routers/hooks.py
+++ b/apps/api/src/curie_api/routers/hooks.py
@@ -1,0 +1,334 @@
+"""Generic HMAC-verified inbound hooks (ADR-0079 decision 1, issue #269).
+
+``POST /hooks/{agent_id}/{hook}`` turns an external event into a queued turn on
+the same stream a Slack mention feeds. No new execution machinery: the turn walks
+the identical consumer -> kernel -> claim path, and the only thing that marks it
+out is ``source=WEBHOOK``, which is what stops it steering a live conversation.
+
+**Why the API and not the dispatcher.** Settled by ADR-0079: the dispatcher is
+Socket-Mode only with no inbound HTTP server, while this service already owns
+HTTP ingress, already verifies an HMAC webhook and already produces to a Valkey
+stream.
+
+**Authentication is the signature, not the platform key**, exactly as the GitHub
+webhook does, so this router sits outside the ``X-API-Key`` dependency. The
+secret is per agent and derived rather than stored (see ``hook_secret``).
+
+**One ordering difference from ``/channels/turns``, stated because it is a real
+cost.** That route verifies its credential statelessly, before any query, so an
+attacker with no credential cannot make it touch the database. This route cannot:
+the secret is per agent, so the agent row must be read before the signature can
+be checked at all. The read is a single primary-key lookup behind an already
+enforced body bound, and it is the same exposure ``/github/webhook`` carries, but
+it is not the stronger property its sibling has.
+
+**A delivery id is required, not optional.** An at-least-once ingress without a
+stable upstream id cannot deduplicate, and both alternatives are worse than
+refusing: a per-request id disables idempotency silently, and a content digest
+makes an identical payload undeliverable forever, because a delivery receipt
+deliberately never expires. Refusing names the header and is fixed in the
+upstream's configuration.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import secrets as pysecrets
+import uuid
+from datetime import UTC, datetime
+from typing import Annotated
+
+import redis.asyncio as redis
+from aci_protocol import STREAM_PAYLOAD_FIELD, QueuedTurn, ReplyHandle, TurnSource
+from fastapi import APIRouter, Header, HTTPException, Request, Response, status
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.orm import selectinload
+
+from .. import hook_signing
+from ..config import get_settings
+from ..delivery import (
+    claim_delivery,
+    duplicate_stream_id,
+    enqueue_owned,
+    release_claim,
+    sha16,
+    take_backlog_slot,
+)
+from ..deps import SessionDep
+from ..graveyardwatcher import _text
+from ..models import Agent
+from ..wirebody import read_bounded_body
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/hooks", tags=["hooks"])
+
+# The claim namespace for hook deliveries. Deliberately NOT the channel ingress
+# prefix: that one is keyed by binding row id and this one by agent id, and two
+# different id spaces under one prefix could collide and swallow each other's
+# turns.
+_CLAIM_PREFIX = "curie:hook"
+
+# The one detail string every hook auth failure returns. Identical for "no
+# signature", "bad signature" and "no such agent", so a caller cannot use the
+# route to discover which agent ids exist.
+_AUTH_DETAIL = "missing or invalid signature"
+
+# A hook name is an operator-chosen label that ends up inside Valkey key names
+# and inside the conversation id, so it is constrained rather than trusted: no
+# separators, no unbounded length, nothing that could make two distinct hooks
+# build one key.
+_HOOK_NAME = re.compile(r"^[a-z0-9][a-z0-9._-]{0,62}$")
+
+# The header an upstream names its delivery with.
+_DELIVERY_HEADER = "X-Curie-Delivery-Id"
+
+
+class HookAccepted(BaseModel):
+    """The hook receipt. ``duplicate`` says whether THIS request enqueued.
+
+    ``stream_id`` is None only while another request holds the claim and has not
+    enqueued yet (the 202 case).
+    """
+
+    event_id: str
+    stream_id: str | None
+    duplicate: bool
+
+
+def _conversation_id(agent_id: uuid.UUID, hook: str) -> str:
+    """The thread every firing of one hook shares.
+
+    Per HOOK rather than per delivery, and the choice is load-bearing in two
+    directions. Per delivery would claim a fresh sandbox for every event, and two
+    rapid firings would run concurrently with no ordering at all. Sharing one
+    thread instead means a hook reuses its session and a second firing arriving
+    mid-run defers until the first finishes, which is exactly ADR-0079's "jobs
+    are outputs, not steering inputs" applied to a hook competing with itself.
+
+    It is also disjoint from the agent's Slack thread ids, so a hook can never
+    land in the middle of a human conversation.
+
+    Args:
+        agent_id: The agent this hook belongs to.
+        hook: The validated hook name.
+
+    Returns:
+        The conversation key.
+    """
+
+    return f"hook:{agent_id}:{hook}"
+
+
+def _hook_text(hook: str, body: bytes) -> str:
+    """The turn text a hook delivery becomes.
+
+    An INTERIM shape, and named as one. ADR-0079 deliberately left the payload
+    mapping open and Draft ADR-0099's trigger declarations are where a bundle
+    gets to say how its own hook renders; until that lands, handing the model the
+    raw document under a line naming the hook is the honest minimum. It invents
+    no format for a bundle to depend on, so replacing it later breaks nothing.
+
+    Args:
+        hook: The validated hook name.
+        body: The raw request body.
+
+    Returns:
+        The turn's text.
+    """
+
+    payload = body.decode("utf-8", errors="replace")
+    return f"Inbound hook `{hook}` fired with this payload:\n\n{payload}"
+
+
+async def _load_agent(session: SessionDep, agent_id: uuid.UUID) -> Agent | None:
+    """Load the agent and its single channel binding, or None."""
+
+    # Annotated rather than returned bare: `session.scalar` is typed Any, and the
+    # local annotation is how the rest of this package pins it (see `crud.py` and
+    # `channels._resolve_binding`).
+    agent: Agent | None = await session.scalar(
+        select(Agent).where(Agent.id == agent_id).options(selectinload(Agent.channel))
+    )
+    return agent
+
+
+def _mint_turn(agent: Agent, hook: str, event_id: str, body: bytes) -> QueuedTurn:
+    """Build the ``QueuedTurn`` a verified hook delivery becomes.
+
+    The reply route comes wholly from the agent's binding row, never from the
+    request: an upstream that could name its own endpoint would be pointing the
+    platform's authenticated egress wherever it liked.
+
+    ``placeholder`` is None because nothing was preposted -- this is precisely the
+    placeholder-less turn ADR-0079's kernel path exists for, so the first reply
+    delivery creates its own message.
+
+    Args:
+        agent: The agent, with its channel binding loaded.
+        hook: The validated hook name.
+        event_id: This delivery's deterministic event id.
+        body: The raw request body.
+
+    Returns:
+        The queued turn.
+    """
+
+    binding = agent.channel
+    return QueuedTurn(
+        event_id=event_id,
+        conversation_id=_conversation_id(agent.id, hook),
+        # The author is the platform, not a person: no human sent this, and
+        # putting an upstream-supplied identity here would let a hook impersonate
+        # one to anything downstream that reads the field.
+        author=f"hook:{hook}",
+        text=_hook_text(hook, body),
+        source=TurnSource.WEBHOOK,
+        reply_handle=ReplyHandle(
+            kind=binding.kind,
+            channel=binding.address,
+            placeholder=None,
+            endpoint=binding.endpoint,
+            adapter=binding.adapter,
+        ),
+        received_at=datetime.now(UTC).isoformat(),
+    )
+
+
+@router.post("/{agent_id}/{hook}", response_model=HookAccepted)
+async def ingest_hook(
+    request: Request,
+    response: Response,
+    session: SessionDep,
+    agent_id: uuid.UUID,
+    hook: str,
+    x_curie_signature_256: Annotated[str | None, Header()] = None,
+    x_curie_delivery_id: Annotated[str | None, Header()] = None,
+) -> HookAccepted:
+    """Verify one hook delivery and enqueue it as a turn.
+
+    Order, and why each step sits where it does:
+
+    1. the hook NAME, validated before anything else, because it is about to be
+       used to build key names;
+    2. the size bound, before the signature is computed, so an oversized body is
+       refused without the server ever HMAC-ing it;
+    3. the agent row, which unavoidably precedes authentication here (see the
+       module docstring);
+    4. the SIGNATURE over the raw body;
+    5. the delivery id, checked after authentication so an unsigned caller learns
+       nothing about what this route wants;
+    6. routability, then the claim, quota and enqueue.
+    """
+
+    if not _HOOK_NAME.match(hook):
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            "hook name must be 1-63 characters of lowercase letters, digits, dot, "
+            "dash or underscore",
+        )
+
+    settings = get_settings()
+    raw = await read_bounded_body(
+        request, settings.hook_max_body_bytes, subject="hook body"
+    )
+
+    agent = await _load_agent(session, agent_id)
+    # One refusal for "no such agent" and for "bad signature": a caller that can
+    # tell them apart can enumerate agent ids through a route that answers 401.
+    if agent is None:
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail=_AUTH_DETAIL)
+    secret = hook_signing.derive(
+        settings.api_key, agent_id=str(agent.id), generation=agent.hook_generation
+    )
+    if not hook_signing.verify(secret, raw, x_curie_signature_256):
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail=_AUTH_DETAIL)
+
+    if not x_curie_delivery_id:
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            f"{_DELIVERY_HEADER} is required: this ingress is at-least-once, so a "
+            "stable upstream id is what keeps a retried delivery from running the "
+            "agent twice",
+        )
+
+    # No unbound-agent branch, deliberately. `AgentCreate.channel` is required and
+    # `crud.update_agent_binding` mutates the row in place rather than clearing
+    # it, so an agent with no binding is not a reachable state and a branch for it
+    # would be speculative code guarding nothing. `test_hooks.py` pins that
+    # invariant, so if a future unbind path makes it reachable, that test fails
+    # here rather than this route silently minting a turn with no reply route.
+    digest = sha16(x_curie_delivery_id)
+    # Namespaced by agent AND hook, so two hooks on one agent cannot swallow each
+    # other's deliveries when an upstream reuses its id space across them.
+    event_id = f"hook-{agent.id}-{hook}-{digest}"
+    key = f"{_CLAIM_PREFIX}:delivery:{agent.id}:{hook}:{digest}"
+    owner = f"pending:{pysecrets.token_hex(16)}"
+    client: redis.Redis = request.app.state.valkey
+
+    # Two attempts, not a loop: the second exists only for the narrow case where
+    # the claim key expired between our failed `SET NX` and the `GET` that would
+    # have named its owner.
+    for _attempt in range(2):
+        if await claim_delivery(client, key, owner, settings.channel_delivery_lease_s):
+            if not await take_backlog_slot(
+                client,
+                key_prefix=f"{_CLAIM_PREFIX}:backlog:{agent.id}",
+                limit=settings.hook_backlog_limit,
+                window_s=settings.hook_backlog_window_s,
+            ):
+                # Metered per AGENT, not per hook: the thing worth bounding is how
+                # much work one agent's upstreams can create, and per-hook quotas
+                # would let a source multiply its allowance by inventing names.
+                await release_claim(client, key, owner)
+                logger.warning(
+                    "hook ingress refused event_id=%s: agent backlog quota of %d "
+                    "per %ds exceeded",
+                    event_id,
+                    settings.hook_backlog_limit,
+                    settings.hook_backlog_window_s,
+                )
+                raise HTTPException(
+                    status.HTTP_429_TOO_MANY_REQUESTS,
+                    "too many new hook deliveries for this agent; retry later",
+                    headers={"Retry-After": str(settings.hook_backlog_window_s)},
+                )
+            turn = _mint_turn(agent, hook, event_id, raw)
+            enqueued, current = await enqueue_owned(
+                client,
+                key=key,
+                stream=settings.runs_stream,
+                owner=owner,
+                payload=turn.model_dump_json(),
+                payload_field=STREAM_PAYLOAD_FIELD,
+                lease_s=settings.channel_delivery_lease_s,
+            )
+            if enqueued:
+                logger.info(
+                    "hook ingress enqueued event_id=%s stream_id=%s hook=%s",
+                    event_id,
+                    current,
+                    hook,
+                )
+                return HookAccepted(
+                    event_id=event_id, stream_id=current, duplicate=False
+                )
+            return HookAccepted(
+                event_id=event_id,
+                stream_id=duplicate_stream_id(current, response),
+                duplicate=True,
+            )
+        held = await client.get(key)
+        if held is not None:
+            return HookAccepted(
+                event_id=event_id,
+                stream_id=duplicate_stream_id(_text(held), response),
+                duplicate=True,
+            )
+
+    # Both attempts found the key absent after failing to claim it. Someone is
+    # mid-flight; answering "come back" is honest and never a second XADD.
+    response.status_code = status.HTTP_202_ACCEPTED
+    return HookAccepted(event_id=event_id, stream_id=None, duplicate=True)

--- a/apps/api/tests/test_channel_ingress_idempotency.py
+++ b/apps/api/tests/test_channel_ingress_idempotency.py
@@ -55,9 +55,10 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 DISPATCHER_QUEUE = (
     REPO_ROOT / "apps/dispatcher/src/curie_dispatcher/queue.py"
 )
-CHANNELS_ROUTER = (
-    REPO_ROOT / "apps/api/src/curie_api/routers/channels.py"
-)
+# The claim primitive moved to `curie_api.delivery` when the hook ingress became
+# its second caller (#269); this scan follows it, because what it corroborates is
+# where the primitive LIVES, not which router happens to call it.
+CHANNELS_ROUTER = REPO_ROOT / "apps/api/src/curie_api/delivery.py"
 
 
 # --- fixtures -----------------------------------------------------------------
@@ -259,7 +260,7 @@ def test_a_rival_arriving_mid_claim_never_enqueues_a_second_entry(
     """
 
     body = _turn(binding, f"msg-{uuid.uuid4().hex}")
-    real_claim = channels_router._claim_delivery
+    real_claim = channels_router.claim_delivery
     rival: dict[str, Any] = {}
     fired = False
 
@@ -273,7 +274,7 @@ def test_a_rival_arriving_mid_claim_never_enqueues_a_second_entry(
             )
         return result
 
-    monkeypatch.setattr(channels_router, "_claim_delivery", claim_then_let_the_rival_run)
+    monkeypatch.setattr(channels_router, "claim_delivery", claim_then_let_the_rival_run)
 
     winner = _post(channels_client, binding, body)
     loser = rival["response"]
@@ -433,7 +434,7 @@ def test_the_pending_lease_expires_but_the_receipt_never_does(
     """
 
     body = _turn(binding, f"msg-{uuid.uuid4().hex}")
-    real_claim = channels_router._claim_delivery
+    real_claim = channels_router.claim_delivery
     pending: dict[str, Any] = {}
 
     async def claim_then_inspect(*args: Any, **kwargs: Any) -> Any:
@@ -443,7 +444,7 @@ def test_the_pending_lease_expires_but_the_receipt_never_does(
         pending["ttl"] = valkey.ttl(key)
         return result
 
-    monkeypatch.setattr(channels_router, "_claim_delivery", claim_then_inspect)
+    monkeypatch.setattr(channels_router, "claim_delivery", claim_then_inspect)
 
     first = _post(channels_client, binding, body)
     assert first.status_code == 200, first.text
@@ -495,7 +496,7 @@ def test_a_resumed_owner_with_an_expired_uncontested_lease_still_enqueues(
     """
 
     body = _turn(binding, f"msg-{uuid.uuid4().hex}")
-    real_claim = channels_router._claim_delivery
+    real_claim = channels_router.claim_delivery
     expired: dict[str, str] = {}
 
     async def claim_then_expire_the_lease(*args: Any, **kwargs: Any) -> Any:
@@ -507,7 +508,7 @@ def test_a_resumed_owner_with_an_expired_uncontested_lease_still_enqueues(
         valkey.delete(key)
         return result
 
-    monkeypatch.setattr(channels_router, "_claim_delivery", claim_then_expire_the_lease)
+    monkeypatch.setattr(channels_router, "claim_delivery", claim_then_expire_the_lease)
 
     resumed = _post(channels_client, binding, body)
     assert resumed.status_code == 200, resumed.text
@@ -554,7 +555,7 @@ def test_a_slow_winner_whose_lease_was_re_claimed_does_not_enqueue(
     """
 
     body = _turn(binding, f"msg-{uuid.uuid4().hex}")
-    real_claim = channels_router._claim_delivery
+    real_claim = channels_router.claim_delivery
     rival: dict[str, Any] = {}
     fired = False
 
@@ -571,7 +572,7 @@ def test_a_slow_winner_whose_lease_was_re_claimed_does_not_enqueue(
             )
         return result
 
-    monkeypatch.setattr(channels_router, "_claim_delivery", claim_then_lose_the_lease)
+    monkeypatch.setattr(channels_router, "claim_delivery", claim_then_lose_the_lease)
 
     slow = _post(channels_client, binding, body)
     retry = rival["response"]
@@ -603,7 +604,7 @@ def test_a_slow_winner_whose_lease_was_re_claimed_by_an_in_flight_retry_is_202(
     """
 
     body = _turn(binding, f"msg-{uuid.uuid4().hex}")
-    real_claim = channels_router._claim_delivery
+    real_claim = channels_router.claim_delivery
     fired = False
 
     async def claim_then_hand_the_lease_over(*args: Any, **kwargs: Any) -> Any:
@@ -615,7 +616,7 @@ def test_a_slow_winner_whose_lease_was_re_claimed_by_an_in_flight_retry_is_202(
             valkey.set(key, f"pending:{uuid.uuid4().hex}", ex=300)
         return result
 
-    monkeypatch.setattr(channels_router, "_claim_delivery", claim_then_hand_the_lease_over)
+    monkeypatch.setattr(channels_router, "claim_delivery", claim_then_hand_the_lease_over)
 
     slow = _post(channels_client, binding, body)
     assert slow.status_code == 202, slow.text
@@ -718,7 +719,7 @@ def test_the_ingress_claim_matches_the_dispatchers_set_nx_ex_primitive(
     """
 
     body = _turn(binding, f"msg-{uuid.uuid4().hex}")
-    real_claim = channels_router._claim_delivery
+    real_claim = channels_router.claim_delivery
     pending: dict[str, Any] = {}
 
     async def claim_then_inspect(*args: Any, **kwargs: Any) -> Any:
@@ -733,7 +734,7 @@ def test_the_ingress_claim_matches_the_dispatchers_set_nx_ex_primitive(
         )
         return result
 
-    monkeypatch.setattr(channels_router, "_claim_delivery", claim_then_inspect)
+    monkeypatch.setattr(channels_router, "claim_delivery", claim_then_inspect)
 
     assert _post(channels_client, binding, body).status_code == 200
     # The LEASE is what carries the expiry; the receipt it becomes does not

--- a/apps/api/tests/test_hooks.py
+++ b/apps/api/tests/test_hooks.py
@@ -1,0 +1,492 @@
+"""The inbound hook ingress (ADR-0079 decision 1, issue #269).
+
+Most of these assert a REFUSAL, which is the half that matters: this route is a
+way for an outside system to make an agent act, so every test that proves it
+runs is worth less than one proving it does not run for the wrong caller.
+
+The claim/quota/enqueue machinery underneath is `curie_api.delivery`, already
+covered end to end by `test_channel_ingress_idempotency.py`; what is asserted
+here is the part this route owns -- who is allowed in, what the turn it mints
+says, and that a retry cannot run the agent twice.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import hmac
+import os
+import uuid
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+import redis
+from aci_protocol import QueuedTurn, TurnSource
+from curie_api.config import get_settings
+from curie_api.hook_signing import derive
+from curie_api.main import create_app
+from curie_test_support.valkey import connect_or_skip
+from fastapi.testclient import TestClient
+from sqlalchemy import text as sql_text
+from sqlalchemy.ext.asyncio import create_async_engine
+
+EMAIL_ENDPOINT = "http://curie-mail-adapter:8080/"
+EMAIL_ADAPTER = "agentmail-sandbox"
+
+
+# --- fixtures -----------------------------------------------------------------
+
+
+@pytest.fixture
+def runs_stream() -> Iterator[str]:
+    name = f"test:curie:runs:{uuid.uuid4().hex}"
+    os.environ["RUNS_STREAM"] = name
+    get_settings.cache_clear()
+    yield name
+    os.environ.pop("RUNS_STREAM", None)
+    get_settings.cache_clear()
+
+
+@pytest.fixture
+def valkey(runs_stream: str) -> Iterator[redis.Redis]:
+    client = connect_or_skip(decode_responses=True)
+    yield client
+    client.delete(runs_stream)
+    client.close()
+
+
+@pytest.fixture
+def hooks_client(_disposable_db: Any, runs_stream: str) -> Iterator[TestClient]:
+    with TestClient(create_app()) as test_client:
+        yield test_client
+
+
+@pytest.fixture
+def auth_headers() -> dict[str, str]:
+    return {"X-API-Key": get_settings().api_key}
+
+
+# --- helpers ------------------------------------------------------------------
+
+
+def _bind(client: TestClient, headers: dict[str, str], *, name: str) -> str:
+    """Create an agent bound to an email channel and return its id."""
+
+    created = client.post(
+        "/agents",
+        json={
+            "name": name,
+            "channel": {
+                "kind": "email",
+                "address": f"{name}@example.test",
+                "endpoint": EMAIL_ENDPOINT,
+                "adapter": EMAIL_ADAPTER,
+            },
+        },
+        headers=headers,
+    )
+    assert created.status_code == 201, created.text
+    return str(created.json()["id"])
+
+
+def _sign(secret: str, body: bytes) -> str:
+    return "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+
+
+def _secret_for(agent_id: str, generation: int = 0) -> str:
+    return derive(get_settings().api_key, agent_id=agent_id, generation=generation)
+
+
+def _post(
+    client: TestClient,
+    agent_id: str,
+    hook: str,
+    body: bytes,
+    *,
+    secret: str | None = None,
+    signature: str | None = None,
+    delivery_id: str | None = "dlv-1",
+) -> Any:
+    """POST one delivery, signing with `secret` unless a signature is forced."""
+
+    headers = {"Content-Type": "application/json"}
+    if signature is not None:
+        headers["X-Curie-Signature-256"] = signature
+    elif secret is not None:
+        headers["X-Curie-Signature-256"] = _sign(secret, body)
+    if delivery_id is not None:
+        headers["X-Curie-Delivery-Id"] = delivery_id
+    return client.post(f"/hooks/{agent_id}/{hook}", content=body, headers=headers)
+
+
+def _bump_generation(agent_id: str) -> None:
+    """Rotate this agent's hook secret, straight against Postgres.
+
+    There is no operator surface for rotation yet (that is the follow-up named in
+    the PR), so the test drives the column the route reads. Follows
+    `test_channels.py`'s fresh-engine-per-query pattern, which keeps the write off
+    the TestClient's portal loop.
+    """
+
+    async def run() -> None:
+        engine = create_async_engine(get_settings().database_url)
+        try:
+            async with engine.begin() as conn:
+                await conn.execute(
+                    sql_text(
+                        "UPDATE curie.agents SET hook_generation = hook_generation + 1 "
+                        "WHERE id = :aid"
+                    ),
+                    {"aid": uuid.UUID(agent_id)},
+                )
+        finally:
+            await engine.dispose()
+
+    asyncio.run(run())
+
+
+def _queued(valkey: redis.Redis, stream: str) -> list[QueuedTurn]:
+    entries = valkey.xrange(stream)
+    return [QueuedTurn.model_validate_json(fields["payload"]) for _, fields in entries]
+
+
+# --- the turn a verified delivery becomes -------------------------------------
+
+
+def test_a_signed_delivery_enqueues_a_webhook_turn_with_no_placeholder(
+    hooks_client: TestClient,
+    auth_headers: dict[str, str],
+    valkey: redis.Redis,
+    runs_stream: str,
+    clean_db: None,
+) -> None:
+    """The happy path, and the three fields that make it a JOB rather than a message.
+
+    `source=webhook` is what stops the kernel steering a live session with it,
+    and `placeholder=None` is the ADR-0079 shape whose whole point is that no
+    ingress preposted anything to edit.
+    """
+
+    agent_id = _bind(hooks_client, auth_headers, name="hookagent")
+    body = b'{"issue": 42}'
+
+    answer = _post(hooks_client, agent_id, "issues", body, secret=_secret_for(agent_id))
+
+    assert answer.status_code == 200, answer.text
+    assert answer.json()["duplicate"] is False
+    (turn,) = _queued(valkey, runs_stream)
+    assert turn.source is TurnSource.WEBHOOK
+    assert turn.source.is_job is True
+    assert turn.reply_handle.placeholder is None
+    # The reply route comes wholly from the binding row.
+    assert turn.reply_handle.kind == "email"
+    assert turn.reply_handle.endpoint == EMAIL_ENDPOINT
+    assert turn.reply_handle.adapter == EMAIL_ADAPTER
+    # The payload reaches the agent, and the author is the platform, not a person.
+    assert '{"issue": 42}' in turn.text
+    assert turn.author == "hook:issues"
+
+
+def test_every_firing_of_one_hook_shares_a_thread(
+    hooks_client: TestClient,
+    auth_headers: dict[str, str],
+    valkey: redis.Redis,
+    runs_stream: str,
+    clean_db: None,
+) -> None:
+    """Per hook, not per delivery.
+
+    A fresh thread per delivery would claim a sandbox per event and let two
+    firings run concurrently with no ordering; sharing one means the second
+    defers behind the first. Two hooks on one agent stay separate.
+    """
+
+    agent_id = _bind(hooks_client, auth_headers, name="threadagent")
+    s = _secret_for(agent_id)
+
+    _post(hooks_client, agent_id, "issues", b"{}", secret=s, delivery_id="d1")
+    _post(hooks_client, agent_id, "issues", b"{}", secret=s, delivery_id="d2")
+    _post(hooks_client, agent_id, "deploys", b"{}", secret=s, delivery_id="d3")
+
+    threads = [t.conversation_id for t in _queued(valkey, runs_stream)]
+    assert threads[0] == threads[1], threads
+    assert threads[2] != threads[0], threads
+
+
+# --- refusals -----------------------------------------------------------------
+
+
+def test_an_unsigned_delivery_is_refused_and_enqueues_nothing(
+    hooks_client: TestClient,
+    auth_headers: dict[str, str],
+    valkey: redis.Redis,
+    runs_stream: str,
+    clean_db: None,
+) -> None:
+    """No signature, no turn. The counterfactual is the point: the identical body
+    WITH a signature enqueues, so the refusal is the signature check and not some
+    unrelated rejection."""
+
+    agent_id = _bind(hooks_client, auth_headers, name="unsignedagent")
+    body = b'{"do": "something"}'
+
+    refused = _post(hooks_client, agent_id, "issues", body, signature=None)
+
+    assert refused.status_code == 401
+    assert _queued(valkey, runs_stream) == []
+
+    accepted = _post(hooks_client, agent_id, "issues", body, secret=_secret_for(agent_id))
+    assert accepted.status_code == 200
+    assert len(_queued(valkey, runs_stream)) == 1
+
+
+def test_a_forged_signature_is_refused(
+    hooks_client: TestClient,
+    auth_headers: dict[str, str],
+    valkey: redis.Redis,
+    runs_stream: str,
+    clean_db: None,
+) -> None:
+    """A well-formed signature computed with the wrong key buys nothing."""
+
+    agent_id = _bind(hooks_client, auth_headers, name="forgedagent")
+    body = b"{}"
+
+    refused = _post(
+        hooks_client, agent_id, "issues", body, signature=_sign("not-the-secret", body)
+    )
+
+    assert refused.status_code == 401
+    assert _queued(valkey, runs_stream) == []
+
+
+def test_a_signature_over_different_bytes_is_refused(
+    hooks_client: TestClient,
+    auth_headers: dict[str, str],
+    valkey: redis.Redis,
+    runs_stream: str,
+    clean_db: None,
+) -> None:
+    """The signature covers THIS body. A valid signature lifted from another
+    delivery cannot be replayed onto new content."""
+
+    agent_id = _bind(hooks_client, auth_headers, name="swapagent")
+    secret = _secret_for(agent_id)
+    stolen = _sign(secret, b'{"amount": 1}')
+
+    refused = _post(
+        hooks_client, agent_id, "issues", b'{"amount": 1000000}', signature=stolen
+    )
+
+    assert refused.status_code == 401
+    assert _queued(valkey, runs_stream) == []
+
+
+def test_another_agents_secret_cannot_sign_for_this_one(
+    hooks_client: TestClient,
+    auth_headers: dict[str, str],
+    valkey: redis.Redis,
+    runs_stream: str,
+    clean_db: None,
+) -> None:
+    """The secret is per agent, so holding one hook credential is not holding
+    every hook credential. This is the property the derivation exists to give."""
+
+    victim = _bind(hooks_client, auth_headers, name="victimagent")
+    attacker = _bind(hooks_client, auth_headers, name="attackeragent")
+    body = b"{}"
+
+    refused = _post(
+        hooks_client, victim, "issues", body, signature=_sign(_secret_for(attacker), body)
+    )
+
+    assert refused.status_code == 401
+    assert _queued(valkey, runs_stream) == []
+
+
+def test_rotating_the_generation_invalidates_the_old_secret(
+    hooks_client: TestClient,
+    auth_headers: dict[str, str],
+    valkey: redis.Redis,
+    runs_stream: str,
+    clean_db: None,
+) -> None:
+    """Rotation is the whole reason the counter is stored at all.
+
+    A secret derived at generation 0 must stop working once the agent moves on,
+    or the column buys nothing over deriving from the agent id alone.
+    """
+
+    agent_id = _bind(hooks_client, auth_headers, name="rotateagent")
+    old = _secret_for(agent_id, generation=0)
+    new = _secret_for(agent_id, generation=1)
+    assert old != new
+
+    _bump_generation(agent_id)
+    body = b"{}"
+
+    refused = _post(hooks_client, agent_id, "issues", body, signature=_sign(old, body))
+    assert refused.status_code == 401
+    assert _queued(valkey, runs_stream) == []
+
+    accepted = _post(hooks_client, agent_id, "issues", body, signature=_sign(new, body))
+    assert accepted.status_code == 200
+
+
+def test_an_unknown_agent_answers_the_same_401_as_a_bad_signature(
+    hooks_client: TestClient, clean_db: None
+) -> None:
+    """A caller must not be able to use this route to discover which agent ids
+    exist: "no such agent" and "wrong signature" are one answer."""
+
+    unknown = str(uuid.uuid4())
+
+    refused = _post(hooks_client, unknown, "issues", b"{}", secret="anything")
+
+    assert refused.status_code == 401
+    assert refused.json()["detail"] == "missing or invalid signature"
+
+
+def test_a_delivery_with_no_id_is_refused_after_authentication(
+    hooks_client: TestClient,
+    auth_headers: dict[str, str],
+    valkey: redis.Redis,
+    runs_stream: str,
+    clean_db: None,
+) -> None:
+    """Dedupe is not optional for an at-least-once ingress, so a missing delivery
+    id is a refusal rather than a silently un-deduplicated turn. It is checked
+    AFTER the signature, so an unsigned caller learns nothing about the shape the
+    route wants."""
+
+    agent_id = _bind(hooks_client, auth_headers, name="nodeliveryagent")
+    body = b"{}"
+
+    refused = _post(
+        hooks_client, agent_id, "issues", body, secret=_secret_for(agent_id),
+        delivery_id=None,
+    )
+
+    assert refused.status_code == 400
+    assert "X-Curie-Delivery-Id" in refused.json()["detail"]
+    assert _queued(valkey, runs_stream) == []
+
+    unsigned = _post(hooks_client, agent_id, "issues", body, signature=None, delivery_id=None)
+    assert unsigned.status_code == 401, "the id check leaked ahead of authentication"
+
+
+@pytest.mark.parametrize(
+    "hook",
+    ["", "UPPER", "has space", "has/slash", "has:colon", "x" * 64, ".leading"],
+)
+def test_a_hook_name_outside_the_allowed_shape_is_refused(
+    hooks_client: TestClient, auth_headers: dict[str, str], hook: str, clean_db: None
+) -> None:
+    """The name lands inside Valkey key names and the conversation id, so it is
+    constrained rather than trusted -- two distinct hooks must not be able to
+    build one key."""
+
+    agent_id = _bind(hooks_client, auth_headers, name=f"nameagent{abs(hash(hook)) % 997}")
+
+    answer = _post(hooks_client, agent_id, hook, b"{}", secret=_secret_for(agent_id))
+
+    assert answer.status_code in (400, 404, 405), f"{hook!r} -> {answer.status_code}"
+
+
+def test_an_agent_cannot_exist_without_a_binding(
+    hooks_client: TestClient, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    """The invariant this route relies on instead of a branch.
+
+    `hooks.ingest_hook` reads the binding without checking it for None, because
+    `AgentCreate.channel` is required and `crud.update_agent_binding` mutates in
+    place rather than clearing. A branch for an unreachable state would be
+    speculative; this test is what makes the assumption checkable, so a future
+    unbind path fails HERE rather than letting the route mint a turn with no
+    reply route.
+    """
+
+    refused = hooks_client.post(
+        "/agents", json={"name": "unboundagent"}, headers=auth_headers
+    )
+
+    assert refused.status_code == 422, refused.text
+    assert any(
+        err["loc"][-1] == "channel" for err in refused.json()["detail"]
+    ), refused.text
+
+
+# --- idempotency --------------------------------------------------------------
+
+
+def test_a_retried_delivery_never_runs_the_agent_twice(
+    hooks_client: TestClient,
+    auth_headers: dict[str, str],
+    valkey: redis.Redis,
+    runs_stream: str,
+    clean_db: None,
+) -> None:
+    """The property an at-least-once upstream depends on. The retry is answered,
+    not dropped, and it carries the SAME receipt."""
+
+    agent_id = _bind(hooks_client, auth_headers, name="retryagent")
+    secret = _secret_for(agent_id)
+
+    first = _post(hooks_client, agent_id, "issues", b"{}", secret=secret, delivery_id="dup-1")
+    second = _post(hooks_client, agent_id, "issues", b"{}", secret=secret, delivery_id="dup-1")
+
+    assert first.status_code == 200 and first.json()["duplicate"] is False
+    assert second.status_code == 200 and second.json()["duplicate"] is True
+    assert second.json()["event_id"] == first.json()["event_id"]
+    assert second.json()["stream_id"] == first.json()["stream_id"]
+    assert len(_queued(valkey, runs_stream)) == 1
+
+
+def test_two_hooks_on_one_agent_do_not_swallow_each_others_deliveries(
+    hooks_client: TestClient,
+    auth_headers: dict[str, str],
+    valkey: redis.Redis,
+    runs_stream: str,
+    clean_db: None,
+) -> None:
+    """An upstream that reuses one id space across two hooks must still get two
+    turns: the claim is namespaced by hook, not by agent alone."""
+
+    agent_id = _bind(hooks_client, auth_headers, name="twohookagent")
+    secret = _secret_for(agent_id)
+
+    a = _post(hooks_client, agent_id, "issues", b"{}", secret=secret, delivery_id="same")
+    b = _post(hooks_client, agent_id, "deploys", b"{}", secret=secret, delivery_id="same")
+
+    assert a.json()["duplicate"] is False
+    assert b.json()["duplicate"] is False
+    assert a.json()["event_id"] != b.json()["event_id"]
+    assert len(_queued(valkey, runs_stream)) == 2
+
+
+def test_two_agents_do_not_swallow_each_others_deliveries(
+    hooks_client: TestClient,
+    auth_headers: dict[str, str],
+    valkey: redis.Redis,
+    runs_stream: str,
+    clean_db: None,
+) -> None:
+    """Same id from two different agents' upstreams: two turns, not one."""
+
+    one = _bind(hooks_client, auth_headers, name="agentone")
+    two = _bind(hooks_client, auth_headers, name="agenttwo")
+
+    a = _post(hooks_client, one, "issues", b"{}", secret=_secret_for(one), delivery_id="same")
+    b = _post(hooks_client, two, "issues", b"{}", secret=_secret_for(two), delivery_id="same")
+
+    assert a.json()["duplicate"] is False
+    assert b.json()["duplicate"] is False
+    assert len(_queued(valkey, runs_stream)) == 2
+    # The event ids must differ too, and this is NOT implied by both turns being
+    # enqueued. The claim key is the INGRESS guard; `event_id` is what the WORKER
+    # dedupes on with its done marker, so two agents sharing one would enqueue
+    # both turns here and have the second silently skipped as already-handled.
+    # A mutation dropping the agent from `event_id` left this test green until
+    # this assertion existed.
+    assert a.json()["event_id"] != b.json()["event_id"]


### PR DESCRIPTION
Closes #269. Implements the API-lane half of [ADR-0079](https://github.com/curie-eng/curie/blob/next/docs/adr/0079-inbound-triggers-as-a-new-event-kind.md) decision 1, on top of the kernel and contract half that landed in #1631.

Targets `next`: it builds directly on `TurnSource` and the placeholder-less reply path, which exist only there.

`POST /hooks/{agent_id}/{hook}` turns an external event into a queued turn on the same stream a Slack mention feeds. No new execution machinery, exactly as #29 asked: the turn walks the identical consumer, kernel and claim path, and the only thing marking it out is `source=webhook`, which is what stops it steering a live conversation. It carries no placeholder, which is the shape #1631's kernel path exists for.

## Where the secret comes from

ADR-0079 says "per-agent hook secret" and leaves storage open. It is **derived**, not stored: `HMAC(api_key, "curie.hook.v1:<agent id>:<generation>")`.

The obvious alternative is a secret column on `agents`. This API has no encryption at rest, so that puts a credential a third party also holds in plaintext next to `agents.secrets`. Deriving it keeps nothing secret in a row and inherits the production guard that already refuses to boot on a default `api_key`, which a stored secret would have needed its own copy of. It is the same HMAC-from-`api_key` idiom `sandbox_token` and `channel_token` already use.

What **is** stored is `agents.hook_generation`, an ordinary integer. Without it the only way to revoke one leaked hook secret would be rotating the platform key, which revokes every credential the platform has ever minted. Bumping the counter changes exactly one agent's secret, and reading the column grants nothing.

## The shared machinery

The claim, quota and enqueue steps moved to `curie_api.delivery`. This is the second caller, which is the first point at which the abstraction is warranted rather than speculative. Copying would have put two versions of the same idempotency argument in the tree, and the parts worth not duplicating are the ones a reader cannot check by eye: the three-armed enqueue script, why a receipt has no expiry, and why the quota is counted only after a claim is won.

No behavior change to `/channels/turns`. Its 174 tests pass unchanged; the idempotency suite's monkeypatch seam still reaches through the router module, and its corroborating source scan follows the primitive to its new file.

## Decisions worth a reviewer's eye

- **One thread per hook, not per delivery.** Per delivery would claim a sandbox for every event and let two firings run concurrently with no ordering. Sharing one means a second firing defers behind the first, which is ADR-0079's "jobs are outputs" applied to a hook competing with itself. The id is also disjoint from the agent's Slack threads, so a hook cannot land mid-conversation.
- **A delivery id is required, not optional.** An at-least-once ingress without a stable upstream id cannot deduplicate, and both alternatives are worse than refusing: a per-request id disables idempotency silently, and a content digest makes an identical payload undeliverable forever, since a receipt deliberately never expires. Refusing names the header and is fixed in the upstream's configuration. Flagging it because it does mean an upstream that cannot add a header cannot use this route.
- **The turn text is an interim shape and says so.** ADR-0079 left the payload mapping open and Draft ADR-0099's trigger declarations are where a bundle says how its hook renders, so this hands the model the raw document under a line naming the hook and invents no format to depend on.
- **One ordering difference from `/channels/turns`, stated rather than glossed.** That route verifies its credential before any query. This one cannot: the secret is per agent, so the agent row is read first. Same exposure `/github/webhook` carries, behind an already enforced body bound, but not the stronger property its sibling has.
- **No unbound-agent branch.** `AgentCreate.channel` is required and `update_agent_binding` mutates in place, so that state is unreachable and a branch for it would guard nothing. A test pins the invariant instead, so a future unbind path fails there rather than letting this route mint a turn with no reply route.

## Not built, deliberately

There is **no operator surface for reading or rotating the secret yet** — no CLI command, no API endpoint. An operator cannot configure an upstream from this PR alone. That is a deliberate cut to keep the ingress reviewable on its own; the surface is a small follow-up (`curie agent hook-secret [--rotate]`) and I will open it as a separate issue unless you would rather it land here.

## Verification

- `840 passed, 9 skipped` across `apps/api`. The one failure is `test_cost_composes_metrics_for_the_agent`, which fails identically on a pristine `next` checkout because it needs a running Langfuse; it is not touched by this change.
- `ruff` clean, `mypy` clean across 186 files. `openapi.json` regenerated.
- Migration 0027 verified by hand through upgrade, downgrade and upgrade again: the column comes back as `integer NOT NULL DEFAULT 0`.
- **Ten mutations were run against the new protections and every one turned the suite red**: skipping verification entirely, dropping the agent or the generation from the derivation, accepting an absent signature header, dropping the delivery-id requirement, dropping the hook-name check, dropping the hook or the agent from the claim key and from the event id, and marking the turn as a person's message. The event-id one survived the first pass, because both turns still enqueued either way — the claim key is the ingress guard while the event id is what the *worker* dedupes on with its done marker, so two agents sharing one would have had the second turn silently skipped. The assertion that they differ exists because of that.

Refs #29.
