### PR TITLE
Keep cancelled E2E runs neutral

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1148,7 +1148,10 @@ jobs:
     name: E2E required
     runs-on: ubuntu-latest
     needs: [changes, e2e-ladder, e2e-ladder-release, e2e-ladder-cluster]
-    if: ${{ always() }}
+    # A cancelled run leaves no evidence and must rerun. In a completed run,
+    # every dependency outcome reaches the strict matcher below, which rejects
+    # selected results other than success.
+    if: ${{ !cancelled() }}
     steps:
       - name: Require exact selected outcomes
         env:

--- a/tools/e2e-ci-selection/tests/test_e2e_ci_selection.py
+++ b/tools/e2e-ci-selection/tests/test_e2e_ci_selection.py
@@ -333,7 +333,7 @@ def _aggregate_contract() -> tuple[str, dict[str, str]]:
         "e2e-ladder-release",
         "e2e-ladder-cluster",
     }
-    assert job["if"] == "${{ always() }}"
+    assert job["if"] == "${{ !cancelled() }}"
 
     candidates = [
         step
@@ -410,6 +410,7 @@ def test_aggregate_accepts_exact_selected_outcomes(state: dict[str, str]) -> Non
         {"local_selected": "true", "skill_local_result": "cancelled"},
         {"local_release_selected": "true", "local_release_result": "failure"},
         {"cluster_selected": "true", "cluster_result": "skipped"},
+        {"cluster_selected": "true", "cluster_result": "cancelled"},
         {"skill_local_result": "success"},
         {"local_release_result": "success"},
         {"cluster_result": "success"},


### PR DESCRIPTION
Closes #1623

Cancelled workflow runs now leave E2E required with no result instead of manufacturing a test failure. Completed runs still require exact selected outcomes, including rejection of cancelled cluster evidence.

Checks

* 104 focused tests passed
* Ruff passed
* Code review approved
* Scope review passed
* Live cancellation made the cluster rung and E2E required conclude cancelled
* Rerunning the same commit made the cluster rung and E2E required conclude success