### PR TITLE
Wire worker approval API credential

### DIFF
--- a/charts/curie/ci/connector-reconciler-rbac-assertions.sh
+++ b/charts/curie/ci/connector-reconciler-rbac-assertions.sh
@@ -28,11 +28,9 @@
 #       module's docstring claims this file enforces that; this is the claim.
 #   (f) Nothing the reconciler grants is cluster-scoped, and it never mentions
 #       pods.
-#   (g) The reconciler's RBAC and API key are switched by the same flag. A
-#       grant without matching reconciler env is unused authority, and a
-#       credential without matching grant loops on authorization failure. The
-#       worker API URL is intentionally present in both states because worker
-#       API calls do not depend on reconciliation.
+#   (g) The reconciler's RBAC and connector env are switched by the same flag.
+#       The worker API URL and key are intentionally present in both states
+#       because approval API calls do not depend on reconciliation.
 #   (h) The reconciler is pointed at the namespace and release the worker
 #       already tells the runner about, so the Service it creates is the one the
 #       agent dials.
@@ -169,17 +167,18 @@ if grep -q "pods" <<<"$ENABLED_RULES"; then
   fail f "the connector Role mentions pods; it manages objects, never pods directly"
 fi
 
-# (g) The connector gate keeps the extra authority and API credential together.
-# A grant without matching reconciler env is unused authority, and a credential
-# without matching grant loops on authorization failure. The API URL is always
-# present because worker API calls do not depend on reconciliation.
-for required in CURIE_CONNECTOR_RECONCILE CURIE_CONNECTOR_APP_NAME CURIE_API_KEY; do
+# (g) The connector gate keeps extra authority and connector env together.
+# The worker API URL and key are always present because worker API calls do not
+# depend on reconciliation.
+for required in CURIE_CONNECTOR_RECONCILE CURIE_CONNECTOR_APP_NAME; do
   grep -q "$required" <<<"$ENABLED" || fail g "enabling the reconciler did not render $required"
   grep -q "$required" <<<"$DISABLED" &&
     fail g "$required renders with the reconciler disabled; the env gate is not working"
 done
-grep -q "CURIE_API_URL" <<<"$ENABLED" || fail g "enabled render is missing CURIE_API_URL"
-grep -q "CURIE_API_URL" <<<"$DISABLED" || fail g "disabled render is missing CURIE_API_URL"
+for required in CURIE_API_URL CURIE_API_KEY; do
+  grep -q "$required" <<<"$ENABLED" || fail g "enabled render is missing $required"
+  grep -q "$required" <<<"$DISABLED" || fail g "disabled render is missing $required"
+done
 
 # (h) The worker reconciles the namespace and release it already tells the
 #     runner about. Two settings could disagree, and the symptom would be a

--- a/charts/curie/ci/render-assertions.sh
+++ b/charts/curie/ci/render-assertions.sh
@@ -759,15 +759,20 @@ if check_github_token_empty "$GHT_MUTANT_RENDER" "mutant (githubToken via curie.
 fi
 echo "  ok: a generated githubToken is rejected (the assert can fail)"
 
-echo "=== Assertion 12c: worker API URL wiring (#1529) ==="
-WORKER_API_CHECK="$TMP/check_worker_api_url.py"
+echo "=== Assertion 12c: worker API URL and key wiring (#1529, #1578) ==="
+WORKER_API_CHECK="$TMP/check_worker_api.py"
 cat > "$WORKER_API_CHECK" <<'PYEOF'
 import sys
 
 import yaml
 
-manifest, expected = sys.argv[1:]
-docs = [doc for doc in yaml.safe_load_all(open(manifest)) if doc]
+manifest, secret_manifest, expected_url, key_source, *key_ref = sys.argv[1:]
+docs = [
+    doc
+    for path in (manifest, secret_manifest)
+    for doc in yaml.safe_load_all(open(path))
+    if doc
+]
 workers = [
     doc
     for doc in docs
@@ -781,36 +786,83 @@ containers = workers[0]["spec"]["template"]["spec"].get("containers", [])
 if len(containers) != 1 or containers[0].get("name") != "worker":
     raise SystemExit("expected one worker container")
 
-entries = [
-    entry
-    for entry in containers[0].get("env", [])
-    if entry.get("name") == "CURIE_API_URL"
-]
-if len(entries) != 1:
-    raise SystemExit(f"CURIE_API_URL appears {len(entries)} times")
-if entries[0].get("value") != expected:
+def only_entry(name):
+    entries = [entry for entry in containers[0].get("env", []) if entry.get("name") == name]
+    if len(entries) != 1:
+        raise SystemExit(f"{name} appears {len(entries)} times")
+    return entries[0]
+
+url_entry = only_entry("CURIE_API_URL")
+if url_entry.get("value") != expected_url:
     raise SystemExit(
-        f"CURIE_API_URL is {entries[0].get('value')!r}, expected {expected!r}"
+        f"CURIE_API_URL is {url_entry.get('value')!r}, expected {expected_url!r}"
+    )
+
+key_entry = only_entry("CURIE_API_KEY")
+
+if key_source == "chart":
+    chart_secrets = [
+        doc
+        for doc in docs
+        if doc.get("kind") == "Secret"
+        and "apiKey" in (doc.get("stringData") or {})
+    ]
+    if len(chart_secrets) != 1:
+        raise SystemExit(
+            f"expected one chart Secret containing apiKey, found {len(chart_secrets)}"
+        )
+    expected_key_entry = {
+        "name": "CURIE_API_KEY",
+        "valueFrom": {
+            "secretKeyRef": {
+                "name": chart_secrets[0].get("metadata", {}).get("name"),
+                "key": "apiKey",
+            }
+        },
+    }
+elif key_source == "operator":
+    if len(key_ref) != 2:
+        raise SystemExit("operator key assertion requires a Secret name and key")
+    expected_key_entry = {
+        "name": "CURIE_API_KEY",
+        "valueFrom": {
+            "secretKeyRef": {"name": key_ref[0], "key": key_ref[1]}
+        },
+    }
+else:
+    raise SystemExit(f"unknown key source {key_source!r}")
+
+if key_entry != expected_key_entry:
+    raise SystemExit(
+        "CURIE_API_KEY does not match its expected Secret reference"
     )
 PYEOF
 
-assert_worker_api_url() {
-  local name="$1" release="$2" expected="$3"
-  shift 3
+assert_worker_api() {
+  local name="$1" release="$2" expected_url="$3" key_source="$4"
+  shift 4
+  local key_args=()
+  if [[ "$key_source" == "operator" ]]; then
+    key_args=("$1" "$2")
+    shift 2
+  fi
   local out="$TMP/worker_api_url_$name"
   mkdir -p "$out"
   helm template "$release" "$CHART" --output-dir "$out" "$@" >/dev/null
   local manifest="$out/curie/templates/worker.yaml"
+  local secret_manifest="$out/curie/templates/secrets.yaml"
   [[ -f "$manifest" ]] || fail "$name: worker.yaml did not render"
+  [[ -f "$secret_manifest" ]] || fail "$name: secrets.yaml did not render"
   local error
-  if ! error="$(python3 "$WORKER_API_CHECK" "$manifest" "$expected" 2>&1)"; then
+  if ! error="$(python3 "$WORKER_API_CHECK" "$manifest" "$secret_manifest" "$expected_url" "$key_source" "${key_args[@]}" 2>&1)"; then
     fail "$name: $error"
   fi
 }
 
-assert_worker_api_url default curie http://curie-api:8000
-assert_worker_api_url release other http://other-curie-api:8000
-assert_worker_api_url port curie http://curie-api:9999 --set api.service.port=9999
+assert_worker_api default curie http://curie-api:8000 chart
+assert_worker_api enabled curie http://curie-api:8000 chart --set worker.connectorReconciler.enabled=true
+assert_worker_api release other http://other-curie-api:8000 chart
+assert_worker_api port curie http://curie-api:9999 chart --set api.service.port=9999
 
 WORKER_API_BYO="$TMP/worker_api_byo.yaml"
 cat > "$WORKER_API_BYO" <<'EOF'
@@ -819,7 +871,7 @@ api:
 dispatcher:
   apiBaseUrl: https://byo-api.example
 EOF
-assert_worker_api_url byo curie https://byo-api.example -f "$WORKER_API_BYO"
+assert_worker_api byo curie https://byo-api.example chart -f "$WORKER_API_BYO"
 
 WORKER_API_OVERRIDE="$TMP/worker_api_override.yaml"
 cat > "$WORKER_API_OVERRIDE" <<'EOF'
@@ -832,8 +884,20 @@ worker:
     - name: CURIE_API_URL
       value: http://operator.example:9000
 EOF
-assert_worker_api_url override curie http://operator.example:9000 -f "$WORKER_API_OVERRIDE"
-echo "  ok: default, release name, configured port, BYO API, and operator override render one worker API URL"
+assert_worker_api override curie http://operator.example:9000 chart -f "$WORKER_API_OVERRIDE"
+
+WORKER_API_KEY_OVERRIDE="$TMP/worker_api_key_override.yaml"
+cat > "$WORKER_API_KEY_OVERRIDE" <<'EOF'
+worker:
+  extraEnv:
+    - name: CURIE_API_KEY
+      valueFrom:
+        secretKeyRef:
+          name: operatorapisecret
+          key: apiKey
+EOF
+assert_worker_api key_override curie http://curie-api:8000 operator operatorapisecret apiKey -f "$WORKER_API_KEY_OVERRIDE"
+echo "  ok: default and connector enabled renders use one chart API key reference; operator key override renders once without a chart duplicate"
 
 echo
-echo "PASS: sealed render generates strong values for all 11 keys (encryptionKey 64-hex and Langfuse init credentials 32 alphanumeric); dev overlay keeps published defaults; explicit credential and OTel overrides win on the sealed path; default OTel Basic auth uses the resolved Langfuse project secret; every runner boot-env name is a declared contract key (proven by a failing negative control); every control-plane pod, the agent-sandbox controller, and the sandbox render with the expected priorityClassName, including under operator override; the runner SandboxTemplate opts the controller out of its own permissive NetworkPolicy whenever Rail 1 is on, and leaves it to the controller's default when Rail 1 is off; api.githubToken stays a plain pass-through (empty renders empty, an explicit value renders verbatim, and it is never generated), proven by a failing negative control; and the worker renders exactly one API URL in the default, release name, configured port, BYO API, and operator override cases."
+echo "PASS: sealed render generates strong values for all 11 keys (encryptionKey 64-hex and Langfuse init credentials 32 alphanumeric); dev overlay keeps published defaults; explicit credential and OTel overrides win on the sealed path; default OTel Basic auth uses the resolved Langfuse project secret; every runner boot-env name is a declared contract key (proven by a failing negative control); every control-plane pod, the agent-sandbox controller, and the sandbox render with the expected priorityClassName, including under operator override; the runner SandboxTemplate opts the controller out of its own permissive NetworkPolicy whenever Rail 1 is on, and leaves it to the controller's default when Rail 1 is off; api.githubToken stays a plain pass-through (empty renders empty, an explicit value renders verbatim, and it is never generated), proven by a failing negative control; and the worker renders exactly one API URL plus exactly one correctly sourced API key in default, connector enabled, release name, configured port, BYO API, and operator override cases."

--- a/charts/curie/templates/worker.yaml
+++ b/charts/curie/templates/worker.yaml
@@ -116,9 +116,13 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- $hasWorkerApiUrl := false }}
+      {{- $hasWorkerApiKey := false }}
       {{- range .Values.worker.extraEnv }}
       {{- if eq .name "CURIE_API_URL" }}
       {{- $hasWorkerApiUrl = true }}
+      {{- end }}
+      {{- if eq .name "CURIE_API_KEY" }}
+      {{- $hasWorkerApiKey = true }}
       {{- end }}
       {{- end }}
       containers:
@@ -133,6 +137,9 @@ spec:
             {{- include "curie.env.valkey" . | nindent 12 }}
             {{- if not $hasWorkerApiUrl }}
             {{- include "curie.env.apiUrl" . | nindent 12 }}
+            {{- end }}
+            {{- if not $hasWorkerApiKey }}
+            {{- include "curie.env.apiKey" . | nindent 12 }}
             {{- end }}
             - name: SLACK_BOT_TOKEN
               valueFrom:
@@ -179,11 +186,6 @@ spec:
               value: {{ include "curie.name" . | quote }}
             - name: CURIE_CONNECTOR_RECONCILE_INTERVAL_S
               value: {{ .Values.worker.connectorReconciler.intervalSeconds | quote }}
-            # The reconciler fetches rendered objects from the API rather than
-            # deriving them again (ADR-0090), so it needs the API key. The general
-            # worker API URL is rendered separately without making this key
-            # unconditional.
-            {{- include "curie.env.apiKey" . | nindent 12 }}
 {{- end }}
             - name: CURIE_WARM_POOL
               value: {{ $warmPool | quote }}


### PR DESCRIPTION
## Summary

Gives every chart worker the same Secret backed API key consumed by the platform API, so default installs can create approval records.

Preserves operator key overrides and keeps connector permissions behind their existing flag.

Closes #1578

## Done check

* [x] Tests were committed before implementation and failed on the missing default key.
* [x] Default, connector enabled, release name, port, external API, URL override, and key override renders are covered.
* [x] Code, scope, security, and consolidation reviews approved.
* [x] All chart assertion scripts passed and all three Helm lint overlays passed.
* [x] A disposable default install created an approval with HTTP 201, resolved it as a different actor, resumed the waiting turn, and returned an empty pending list.
* [x] The release, namespace, port forward, and disposable cluster were removed.