### PR TITLE
Recognize supported model providers consistently

### DIFF
--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -1867,7 +1867,7 @@ export const commandManifest = {
       "name": "cluster",
       "subcommands": [
         {
-          "about": "Install or upgrade the Curie release via Helm (helm upgrade --install). By default it puts the UI and Langfuse on node ports for tailnet/LAN access; pass --no-expose to keep them ClusterIP-only. Set CURIE_CREDENTIALS (an Anthropic API key; CURIE_MODEL_CREDENTIALS is a deprecated alias) to install with the real model; without it the install is sealed (fake model, canned replies). A real model is still unreachable behind the fail-closed sandbox until you open its egress with --allow-egress-host <provider> (or --allow-web-egress <CIDR> for a raw range)",
+          "about": "Install or upgrade the Curie release via Helm (helm upgrade --install). By default it puts the UI and Langfuse on node ports for tailnet/LAN access; pass --no-expose to keep them ClusterIP-only. Set CURIE_CREDENTIALS to a supported model provider credential (CURIE_MODEL_CREDENTIALS is a deprecated alias) to install with the real model; without it the install is sealed (fake model, canned replies). A real model is still unreachable behind the fail-closed sandbox until you open its egress with --allow-egress-host <provider> (or --allow-web-egress <CIDR> for a raw range). Zhipu, Moonshot, and DeepSeek also require their matching base URL in worker runtime configuration, in addition to a credential and named egress",
           "args": [
             {
               "default_values": [
@@ -1937,7 +1937,7 @@ export const commandManifest = {
             },
             {
               "global": false,
-              "help": "Open runner egress to a named model provider's API host(s), resolved to narrow host routes at install time (repeatable). One of: anthropic, openrouter. For a raw CIDR, use --allow-web-egress",
+              "help": "Open runner egress to a named model provider's API host(s), resolved to narrow host routes at install time (repeatable). One of: anthropic, openrouter, zhipu, moonshot, deepseek. Provider native Zhipu, Moonshot, and DeepSeek also need their matching worker runtime base URL; a credential plus egress alone does not reach them. For a raw CIDR, use --allow-web-egress",
               "id": "allow_egress_host",
               "long": "allow-egress-host",
               "positional": false,

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -1864,7 +1864,7 @@
       "name": "cluster",
       "subcommands": [
         {
-          "about": "Install or upgrade the Curie release via Helm (helm upgrade --install). By default it puts the UI and Langfuse on node ports for tailnet/LAN access; pass --no-expose to keep them ClusterIP-only. Set CURIE_CREDENTIALS (an Anthropic API key; CURIE_MODEL_CREDENTIALS is a deprecated alias) to install with the real model; without it the install is sealed (fake model, canned replies). A real model is still unreachable behind the fail-closed sandbox until you open its egress with --allow-egress-host <provider> (or --allow-web-egress <CIDR> for a raw range)",
+          "about": "Install or upgrade the Curie release via Helm (helm upgrade --install). By default it puts the UI and Langfuse on node ports for tailnet/LAN access; pass --no-expose to keep them ClusterIP-only. Set CURIE_CREDENTIALS to a supported model provider credential (CURIE_MODEL_CREDENTIALS is a deprecated alias) to install with the real model; without it the install is sealed (fake model, canned replies). A real model is still unreachable behind the fail-closed sandbox until you open its egress with --allow-egress-host <provider> (or --allow-web-egress <CIDR> for a raw range). Zhipu, Moonshot, and DeepSeek also require their matching base URL in worker runtime configuration, in addition to a credential and named egress",
           "args": [
             {
               "default_values": [
@@ -1934,7 +1934,7 @@
             },
             {
               "global": false,
-              "help": "Open runner egress to a named model provider's API host(s), resolved to narrow host routes at install time (repeatable). One of: anthropic, openrouter. For a raw CIDR, use --allow-web-egress",
+              "help": "Open runner egress to a named model provider's API host(s), resolved to narrow host routes at install time (repeatable). One of: anthropic, openrouter, zhipu, moonshot, deepseek. Provider native Zhipu, Moonshot, and DeepSeek also need their matching worker runtime base URL; a credential plus egress alone does not reach them. For a raw CIDR, use --allow-web-egress",
               "id": "allow_egress_host",
               "long": "allow-egress-host",
               "positional": false,

--- a/cli/src/credcheck.rs
+++ b/cli/src/credcheck.rs
@@ -94,20 +94,34 @@ pub fn check_secret(name: &str, value: &str) -> CheckResult {
     }
 }
 
+/// Whether a value has the documented nonempty `id.secret` credential shape.
+fn looks_like_zhipu_credential(value: &str) -> bool {
+    let mut parts = value.split('.');
+    matches!(
+        (parts.next(), parts.next(), parts.next()),
+        (Some(id), Some(secret), None) if !id.is_empty() && !secret.is_empty()
+    )
+}
+
 /// A model credential, whichever of the accepted names it arrives under.
 pub fn check_model_credential(value: &str) -> CheckResult {
     check_paste_hygiene(value)?;
-    const OK: &[&str] = &["sk-ant-", "sk-or-"];
-    if OK.iter().any(|p| value.starts_with(p)) {
+    if value.starts_with("sk-") {
         return Ok(());
     }
     match describe(value) {
         Some(actual) => Err(format!(
-            "that looks like {actual}, not a model credential. An Anthropic key starts \
-             with `sk-ant-`"
+            "that looks like {actual}, not a model credential. Supported shapes are \
+             `sk-ant-` (Anthropic), `sk-or-` (OpenRouter), dotted `id.secret`, and \
+             bare `sk-`; bare `sk-` and dotted `id.secret` shapes alone do not \
+             identify the provider"
         )),
+        None if looks_like_zhipu_credential(value) => Ok(()),
         None => Err(
-            "a model credential starts with `sk-ant-` (Anthropic) or `sk-or-` (OpenRouter)"
+            "supported model credential shapes are `sk-ant-` (Anthropic), \
+             `sk-or-` (OpenRouter), dotted `id.secret`, and bare `sk-`; \
+             bare `sk-` and dotted `id.secret` shapes alone do not identify the \
+             provider"
                 .to_string(),
         ),
     }
@@ -204,17 +218,41 @@ mod tests {
     }
 
     #[test]
-    fn a_model_credential_accepts_both_providers() {
-        check_model_credential("sk-ant-api03-abc").expect("anthropic");
-        check_model_credential("sk-or-v1-abc").expect("openrouter");
-        check_model_credential("sk-ant-oat01-abc").expect("oauth token is sk-ant- too");
+    fn a_model_credential_accepts_every_supported_shape() {
+        for (provider, credential) in [
+            ("anthropic", "sk-ant-api03-abc"),
+            ("anthropic oauth", "sk-ant-oat01-abc"),
+            ("openrouter", "sk-or-v1-abc"),
+            ("zhipu", "zhipu-id.secret"),
+            ("moonshot", "sk-MOONSHOT-abc"),
+            ("deepseek", "sk-DEEPSEEK-abc"),
+        ] {
+            check_model_credential(credential)
+                .unwrap_or_else(|err| panic!("{provider} credential shape was rejected: {err}"));
+        }
+    }
+
+    #[test]
+    fn malformed_zhipu_credentials_are_rejected() {
+        for credential in [".secret", "id.", "id.secret.extra"] {
+            assert!(
+                check_model_credential(credential).is_err(),
+                "accepted malformed Zhipu credential {credential:?}"
+            );
+        }
     }
 
     #[test]
     fn a_slack_token_pasted_as_a_model_credential_is_named() {
         let err = check_model_credential("xoxb-EXAMPLE-not-a-real-token").expect_err("must reject");
         assert!(err.contains("Slack bot user token"), "{err}");
-        assert!(err.contains("sk-ant-"), "{err}");
+        for shape in ["sk-ant-", "sk-or-", "id.secret", "bare `sk-`"] {
+            assert!(err.contains(shape), "error should name {shape}: {err}");
+        }
+        assert!(
+            err.contains("shapes alone do not identify the provider"),
+            "{err}"
+        );
     }
 
     /// The mistake the runbook warns about twice: it binds to a channel that

--- a/cli/src/guide.rs
+++ b/cli/src/guide.rs
@@ -298,7 +298,7 @@ pub fn primer() -> Primer {
             },
             Landmine {
                 title: "A real model in-cluster needs its provider's egress opened",
-                detail: "The runner sandbox is default-deny egress, so `curie cluster up` with a credential is still sealed and the model unreachable until you pass --allow-egress-host <provider> (anthropic/openrouter); a web-fetching skill additionally needs --allow-web-egress <CIDR> for its hosts.",
+                detail: "The runner sandbox is default-deny egress, so `curie cluster up` with a credential is still sealed and the model unreachable until you pass --allow-egress-host <provider> (anthropic/openrouter/zhipu/moonshot/deepseek). Zhipu, Moonshot, and DeepSeek also need their matching base URL in worker runtime configuration; a web-fetching skill additionally needs --allow-web-egress <CIDR> for its hosts.",
             },
             Landmine {
                 title: "The skill runner executes an immutable snapshot taken at `skill up`",
@@ -328,7 +328,7 @@ pub fn primer() -> Primer {
             },
             Recovery {
                 symptom: "\"(no response)\" or an empty reply",
-                fix: "You are on the fake model (--fake-model, or a sealed install). Provide a credential to go live; on cluster, also open the provider egress with --allow-egress-host <provider> or the model stays unreachable.",
+                fix: "You are on the fake model (--fake-model, or a sealed install). Provide a credential to go live; on cluster, also open the provider egress with --allow-egress-host <provider>. Zhipu, Moonshot, and DeepSeek also need their matching base URL in worker runtime configuration or the model stays unreachable.",
             },
             Recovery {
                 symptom: "the agent answers but never calls your MCP tools",

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1265,12 +1265,14 @@ enum ClusterAction {
     /// Install or upgrade the Curie release via Helm (helm upgrade --install).
     /// By default it puts the UI and Langfuse on node ports for tailnet/LAN
     /// access; pass --no-expose to keep them ClusterIP-only. Set
-    /// CURIE_CREDENTIALS (an Anthropic API key; CURIE_MODEL_CREDENTIALS is a
-    /// deprecated alias) to install with the real
+    /// CURIE_CREDENTIALS to a supported model provider credential
+    /// (CURIE_MODEL_CREDENTIALS is a deprecated alias) to install with the real
     /// model; without it the install is sealed (fake model, canned replies). A
     /// real model is still unreachable behind the fail-closed sandbox until you
     /// open its egress with --allow-egress-host <provider> (or --allow-web-egress
-    /// <CIDR> for a raw range).
+    /// <CIDR> for a raw range). Zhipu, Moonshot, and DeepSeek also require their
+    /// matching base URL in worker runtime configuration, in addition to a
+    /// credential and named egress.
     Up {
         /// Kubernetes namespace.
         #[arg(long, default_value = "curie")]
@@ -1299,7 +1301,10 @@ enum ClusterAction {
         local_model: Option<String>,
         /// Open runner egress to a named model provider's API host(s), resolved to
         /// narrow host routes at install time (repeatable). One of: anthropic,
-        /// openrouter. For a raw CIDR, use --allow-web-egress.
+        /// openrouter, zhipu, moonshot, deepseek. Provider native Zhipu,
+        /// Moonshot, and DeepSeek also need their matching worker runtime base
+        /// URL; a credential plus egress alone does not reach them. For a raw
+        /// CIDR, use --allow-web-egress.
         #[arg(long = "allow-egress-host", value_name = "PROVIDER")]
         allow_egress_host: Vec<String>,
         /// Open runner egress to a declared destination for skill web access,

--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -530,16 +530,12 @@ pub fn default_route_egress_warning(cidrs: &[String]) -> Option<String> {
 /// The canonical model providers `--allow-egress-host` accepts, each paired with
 /// the API hostname(s) its runner must reach, in the order shown in help and
 /// error text. The single source of truth for both the accepted-provider set and
-/// their egress hosts, so adding a provider is a one-line edit here.
+/// their egress hosts.
 ///
 /// This set is deliberately limited to the providers the runner can drive
-/// end-to-end today (`anthropic` via `sk-ant-` keys, `openrouter` via `sk-or-`
-/// keys). Opening egress to a host the runner cannot actually talk to gives
-/// false confidence, so a provider is only listed once the runner has runtime
-/// support for it. When the runner gains that support for additional providers
-/// (e.g. the `PROVIDER_BASE_URLS` base-URL providers zhipu/moonshot/deepseek, or
-/// native OpenAI/Gemini), layer them in here at the same time so the egress
-/// convenience list never advertises a provider the harness cannot use.
+/// end to end today. Opening egress to a host the runner cannot actually talk to
+/// gives false confidence, so a provider is only listed once the runner has
+/// runtime support for it. Native OpenAI and Gemini remain unsupported here.
 ///
 /// HOSTNAMES, never CIDRs: provider IPs rotate, so they are resolved to narrow
 /// host routes at install time (see [`resolve_provider_egress_cidrs`]) instead of
@@ -548,6 +544,9 @@ pub fn default_route_egress_warning(cidrs: &[String]) -> Option<String> {
 const EGRESS_PROVIDERS: &[(&str, &[&str])] = &[
     ("anthropic", &["api.anthropic.com"]),
     ("openrouter", &["openrouter.ai"]),
+    ("zhipu", &["api.z.ai"]),
+    ("moonshot", &["api.moonshot.ai"]),
+    ("deepseek", &["api.deepseek.com"]),
 ];
 
 /// The API hostname(s) a named model provider's runner must reach, or `None`
@@ -779,7 +778,8 @@ pub fn sealed_credential_warning(
     if credentials_present && !any_egress_opened {
         Some(
             "a real model credential is set but the sandbox is sealed -- no egress opened, so the \
-             model is unreachable. Pass --allow-egress-host <anthropic|openrouter> \
+             model is unreachable. Pass --allow-egress-host \
+             <anthropic|openrouter|zhipu|moonshot|deepseek> \
              (or --allow-web-egress <CIDR>) and re-run."
                 .to_string(),
         )
@@ -837,7 +837,7 @@ pub fn model_egress_status_lines(
         ));
         lines.push((
             false,
-            "Replies will be canned. Set CURIE_CREDENTIALS (an Anthropic API key) and re-run `curie cluster up` to enable the real model.".into(),
+            "Replies will be canned. Set CURIE_CREDENTIALS to an Anthropic, OpenRouter, Zhipu, Moonshot, or DeepSeek credential and configure matching egress before re-running `curie cluster up` to enable the real model. Provider native Zhipu, Moonshot, and DeepSeek also need their matching worker runtime base URL.".into(),
         ));
     }
     lines
@@ -7070,15 +7070,19 @@ mod tests {
 
     #[test]
     fn provider_egress_hosts_maps_known_providers_and_rejects_unknown() {
-        // The two runner-drivable providers map to their canonical API host(s).
-        assert_eq!(
-            provider_egress_hosts("anthropic").unwrap().to_vec(),
-            vec!["api.anthropic.com"]
-        );
-        assert_eq!(
-            provider_egress_hosts("openrouter").unwrap().to_vec(),
-            vec!["openrouter.ai"]
-        );
+        for (provider, hosts) in [
+            ("anthropic", vec!["api.anthropic.com"]),
+            ("openrouter", vec!["openrouter.ai"]),
+            ("zhipu", vec!["api.z.ai"]),
+            ("moonshot", vec!["api.moonshot.ai"]),
+            ("deepseek", vec!["api.deepseek.com"]),
+        ] {
+            assert_eq!(
+                provider_egress_hosts(provider).unwrap(),
+                hosts,
+                "{provider}"
+            );
+        }
 
         // `openai` and `gemini` are not runner-drivable today, so they are NOT
         // known providers: they fall through to `None` rather than minting an
@@ -7101,7 +7105,7 @@ mod tests {
     #[test]
     fn parse_egress_provider_accepts_known_and_errs_usage_on_unknown() {
         // Each runner-drivable provider parses to its own canonical name.
-        for p in ["anthropic", "openrouter"] {
+        for p in ["anthropic", "openrouter", "zhipu", "moonshot", "deepseek"] {
             assert_eq!(parse_egress_provider(p).unwrap(), p);
         }
 
@@ -7125,7 +7129,7 @@ mod tests {
         );
         // The message enumerates the accepted providers so the operator can fix
         // the flag without reading source.
-        for p in ["anthropic", "openrouter"] {
+        for p in ["anthropic", "openrouter", "zhipu", "moonshot", "deepseek"] {
             assert!(
                 err.message.contains(p),
                 "message should list `{p}`: {}",
@@ -7164,9 +7168,9 @@ mod tests {
     fn resolve_provider_egress_cidrs_dedups_sorts_and_covers_all_hosts() {
         use std::net::IpAddr;
         // Injected resolver so the test never touches real DNS. Anthropic and
-        // OpenRouter share 1.1.1.1 to prove deduplication; Anthropic also
+        // OpenRouter share 1.1.1.1 to prove deduplication. Anthropic also
         // yields an IPv6 address to prove the v4/v6 mix. All addresses are
-        // globally routable so they survive the split-horizon guard.
+        // globally routable so they survive the split horizon guard.
         let resolve = |host: &str| -> std::io::Result<Vec<IpAddr>> {
             Ok(match host {
                 "api.anthropic.com" => {
@@ -7178,15 +7182,27 @@ mod tests {
                 "openrouter.ai" => {
                     vec!["1.1.1.1".parse().unwrap(), "1.0.0.1".parse().unwrap()]
                 }
+                "api.z.ai" => vec!["8.8.8.8".parse().unwrap()],
+                "api.moonshot.ai" => vec!["8.8.4.4".parse().unwrap()],
+                "api.deepseek.com" => vec!["9.9.9.9".parse().unwrap()],
                 other => panic!("unexpected host {other}"),
             })
         };
-        let providers = vec!["anthropic".to_string(), "openrouter".to_string()];
+        let providers = ["anthropic", "openrouter", "zhipu", "moonshot", "deepseek"]
+            .map(str::to_string)
+            .to_vec();
         let cidrs = resolve_provider_egress_cidrs(&providers, resolve).unwrap();
-        // Deduplicated (one 1.1.1.1/32) and sorted for a stable install argv.
+        // Deduplicated to one 1.1.1.1/32 and sorted for a stable install argv.
         assert_eq!(
             cidrs,
-            vec!["1.0.0.1/32", "1.1.1.1/32", "2606:4700::1111/128"]
+            vec![
+                "1.0.0.1/32",
+                "1.1.1.1/32",
+                "2606:4700::1111/128",
+                "8.8.4.4/32",
+                "8.8.8.8/32",
+                "9.9.9.9/32"
+            ]
         );
     }
 
@@ -7371,6 +7387,12 @@ mod tests {
         assert!(warn.contains("unreachable"), "{warn}");
         assert!(warn.contains("--allow-egress-host"), "{warn}");
         assert!(warn.contains("--allow-web-egress"), "{warn}");
+        for provider in ["anthropic", "openrouter", "zhipu", "moonshot", "deepseek"] {
+            assert!(
+                warn.contains(provider),
+                "warning should name {provider}: {warn}"
+            );
+        }
 
         // Every other combination stays silent.
         assert!(sealed_credential_warning(true, true).is_none());
@@ -7437,6 +7459,22 @@ mod tests {
             msgs.iter().any(|m| m.contains("Replies will be canned")),
             "{msgs:?}"
         );
+    }
+
+    #[test]
+    fn model_egress_status_lines_canned_guidance_requires_native_base_urls() {
+        let lines = model_egress_status_lines(false, false, false, &[], false, false);
+        let canned = lines
+            .iter()
+            .map(|(_, message)| message.as_str())
+            .find(|message| message.contains("Replies will be canned"))
+            .expect("canned reply guidance");
+
+        for provider in ["Zhipu", "Moonshot", "DeepSeek"] {
+            assert!(canned.contains(provider), "{canned}");
+        }
+        assert!(canned.contains("worker runtime base URL"), "{canned}");
+        assert!(canned.contains("matching egress"), "{canned}");
     }
 
     #[test]

--- a/cli/tests/model_provider_registry.rs
+++ b/cli/tests/model_provider_registry.rs
@@ -1,0 +1,144 @@
+use std::cell::Cell;
+use std::collections::BTreeSet;
+use std::net::IpAddr;
+
+use curie::credcheck::check_model_credential;
+use curie::exit::ExitClass;
+use curie::ops::{parse_egress_provider, provider_egress_hosts, resolve_provider_egress_cidrs};
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ProviderRow {
+    name: String,
+    base_url: Option<String>,
+    egress_hosts: Vec<String>,
+    credential_examples: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ProviderRegistry {
+    providers: Vec<ProviderRow>,
+    unknown_provider_names: Vec<String>,
+    rejected_credential_examples: Vec<String>,
+}
+
+fn registry_source() -> &'static str {
+    include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../tests/vectors/model-provider-registry.json"
+    ))
+}
+
+fn parse_registry(raw: &str) -> Result<ProviderRegistry, String> {
+    let registry: ProviderRegistry =
+        serde_json::from_str(raw).map_err(|error| error.to_string())?;
+    if registry.providers.is_empty() {
+        return Err("provider registry is empty".to_string());
+    }
+    Ok(registry)
+}
+
+fn load_registry() -> ProviderRegistry {
+    parse_registry(registry_source()).expect("parse model provider registry")
+}
+
+#[test]
+fn every_supported_provider_passes_credential_and_egress_checks() {
+    let registry = load_registry();
+    assert!(!registry.providers.is_empty(), "no providers parsed");
+
+    let names = registry
+        .providers
+        .iter()
+        .map(|provider| provider.name.as_str())
+        .collect::<BTreeSet<_>>();
+    assert_eq!(names.len(), registry.providers.len(), "duplicate provider");
+
+    let expected_names = registry
+        .providers
+        .iter()
+        .map(|provider| provider.name.as_str())
+        .collect::<Vec<_>>()
+        .join(", ");
+    let error = parse_egress_provider("registry-probe").expect_err("probe must be unknown");
+    assert_eq!(
+        error.message,
+        format!(
+            "`--allow-egress-host` value `registry-probe` is not a known provider (expected one of: {expected_names})"
+        )
+    );
+
+    for provider in &registry.providers {
+        let endpoint = provider.base_url.as_deref().unwrap_or("SDK default");
+        assert!(
+            !provider.credential_examples.is_empty(),
+            "{} at {endpoint} has no credential examples",
+            provider.name
+        );
+        for credential in &provider.credential_examples {
+            check_model_credential(credential).unwrap_or_else(|error| {
+                panic!(
+                    "{} credential for {endpoint} was rejected: {error}",
+                    provider.name
+                )
+            });
+        }
+
+        assert_eq!(
+            parse_egress_provider(&provider.name).expect("supported provider must parse"),
+            provider.name.as_str()
+        );
+        let actual_hosts = provider_egress_hosts(&provider.name)
+            .expect("supported provider must have egress hosts");
+        let expected_hosts = provider
+            .egress_hosts
+            .iter()
+            .map(String::as_str)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            actual_hosts, expected_hosts,
+            "{} egress hosts",
+            provider.name
+        );
+    }
+}
+
+#[test]
+fn unknown_providers_fail_before_dns_resolution() {
+    let registry = load_registry();
+    assert!(!registry.unknown_provider_names.is_empty());
+
+    for unknown in &registry.unknown_provider_names {
+        assert!(provider_egress_hosts(unknown).is_none(), "{unknown:?}");
+        assert_eq!(
+            parse_egress_provider(unknown)
+                .expect_err("unknown provider must fail")
+                .class,
+            ExitClass::Usage,
+            "{unknown:?}"
+        );
+
+        let resolver_called = Cell::new(false);
+        let input = vec![unknown.clone()];
+        let result = resolve_provider_egress_cidrs(&input, |_host| {
+            resolver_called.set(true);
+            Ok(vec!["1.1.1.1".parse::<IpAddr>().expect("public address")])
+        });
+        assert!(result.is_err(), "{unknown:?}");
+        assert!(!resolver_called.get(), "DNS called for {unknown:?}");
+    }
+}
+
+#[test]
+fn rejected_credential_examples_stay_rejected() {
+    let registry = load_registry();
+    assert!(!registry.rejected_credential_examples.is_empty());
+    for credential in &registry.rejected_credential_examples {
+        assert!(
+            check_model_credential(credential).is_err(),
+            "accepted rejected credential {credential:?}"
+        );
+    }
+}

--- a/docs/interfaces/model-provider/INTERFACE.md
+++ b/docs/interfaces/model-provider/INTERFACE.md
@@ -21,12 +21,13 @@ order: 6
 
 ## The black line
 
-The model provider is swapped through config, not code: a base-URL override plus a
-credential whose prefix routes it onto the right SDK auth env, targeting any
-Anthropic-compatible endpoint. There is no provider interface to implement — a
-config author fills in a base URL, a credential, and a model id, and the runner maps
-them onto the variables the bundled Claude CLI authenticates from. What stays core is
-the Anthropic wire format (kept even for OpenRouter, so prompt caching survives).
+The model provider is swapped through config, not code: a base URL override plus a
+credential routes onto the right SDK auth env. The runner can target an
+Anthropic compatible endpoint, but named cluster egress is limited to the documented
+providers below. There is no provider interface to implement: a config author fills
+in a base URL, a credential, and a model id, and the runner maps them onto the
+variables the bundled Claude CLI authenticates from. What stays core is the Anthropic
+wire format (kept even for OpenRouter, so prompt caching survives).
 
 ## Current contract
 
@@ -51,11 +52,18 @@ four things:
   (`runner/src/curie_runner/sdk_auth.py::MODEL_ENV_KEY_ENV`) — a bare name or a JSON
   array of them, walked in order, first set and non-empty key winning
   (`runner/src/curie_runner/sdk_auth.py::resolve_credential`); a present-but-empty key
-  is skipped. `resolve_model_credential` (`runner/src/curie_runner/sdk_auth.py::resolve_model_credential`) routes it by
-  prefix: `sk-ant-oat...` → `CLAUDE_CODE_OAUTH_TOKEN`; other `sk-ant-...`
-  → `ANTHROPIC_API_KEY`; `sk-or-...` (OpenRouter) → base-URL override; a bare `sk-...`
-  raises `UnsupportedCredentialError` (`runner/src/curie_runner/sdk_auth.py::UnsupportedCredentialError`). An SDK credential
-  already in the env wins.
+  is skipped. Without a base URL override, `resolve_model_credential`
+  (`runner/src/curie_runner/sdk_auth.py::resolve_model_credential`) routes it by
+  prefix: `sk-ant-oat...` to `CLAUDE_CODE_OAUTH_TOKEN`; other `sk-ant-...`
+  to `ANTHROPIC_API_KEY`; `sk-or-...` (OpenRouter) to its base URL override; a
+  bare `sk-...` raises `UnsupportedCredentialError`
+  (`runner/src/curie_runner/sdk_auth.py::UnsupportedCredentialError`). With a
+  base URL override, a non OAuth provider credential is forwarded as the endpoint's
+  `x-api-key`. An SDK credential already in the env wins. The interactive CLI
+  paste check accepts the documented credential shape classes for Anthropic,
+  OpenRouter, Zhipu, Moonshot, and DeepSeek. A bare `sk-...` or dotted
+  `id.secret` value is intentionally ambiguous, so the check cannot identify a
+  provider or prove a key is live.
 - **Base URL**, `ANTHROPIC_BASE_URL`, or its `CURIE_`-namespaced alias
   `CURIE_MODEL_BASE_URL` (the raw var wins when both are set).
   `resolve_base_url_override` (`runner/src/curie_runner/sdk_auth.py::resolve_base_url_override`) builds the override env when either is set, and
@@ -98,7 +106,7 @@ gateway. A minimal config: `CURIE_MODEL_BASE_URL=https://api.deepseek.com/anthro
 
 ## Known leakage
 
-The gotcha the seam encodes rather than a bleed-through: base-URL override mode must
+The gotcha the seam encodes rather than a bleed-through: base URL override mode must
 carry a **non-empty** placeholder key, `NO_OP_API_KEY = "not-needed"`
 (`runner/src/curie_runner/sdk_auth.py::NO_OP_API_KEY`). The bundled Claude CLI treats an empty `ANTHROPIC_API_KEY` as
 "not logged in" and refuses to dial the overridden endpoint (empirically verified
@@ -106,28 +114,17 @@ carry a **non-empty** placeholder key, `NO_OP_API_KEY = "not-needed"`
 non-`sk-` placeholder passes the auth gate without being mistakable for a credential.
 The credential value is never logged.
 
-The real bleed-through is above the seam: three separate copies of provider knowledge
-live outside the runner, and each can drift from it.
+The runner, credential check, and named egress allowlist have distinct duties. The
+committed shared vector in `tests/vectors/model-provider-registry.json` pins their
+contract by projecting runner base URLs into CLI credential shapes and exact egress
+hosts for Anthropic, OpenRouter, Zhipu, Moonshot, and DeepSeek.
 
-- **A second, lagging provider registry in the CLI.** `--allow-egress-host` accepts
-  only `anthropic` and `openrouter` (the `EGRESS_PROVIDERS` table behind
-  `parse_egress_provider` in `cli/src/ops.rs`), while the runner ships `zhipu`,
-  `moonshot`, `deepseek`, and `openrouter`
-  (`runner/src/curie_runner/sdk_auth.py::PROVIDER_BASE_URLS`). The three
-  provider-native endpoints in the table above therefore have no provider name to
-  pass, so a cluster agent on Zhipu, Moonshot, or DeepSeek has to open its sandbox
-  egress with a raw `--allow-web-egress` CIDR instead. The doc comment on that table
-  still describes those three as runtime support the runner has yet to gain, which it
-  has since shipped.
-- **The CLI paste gate knows only the two prefix-routed shapes.**
-  `check_model_credential` (`cli/src/credcheck.rs`) accepts a pasted value only when
-  it starts with `sk-ant-` or `sk-or-`, so the interactive "Save Model Credential"
-  prompt (`cli/src/interactive.rs`) refuses every provider-native key the table above
-  documents: Zhipu's non-`sk-` `id.secret`, and Moonshot's and DeepSeek's bare `sk-`
-  keys. The runner accepts all three under a base-URL override, so this is a
-  paste-time check disagreeing with the resolver, not a real restriction; supplying
-  the credential through the environment or a saved secret short-circuits the prompt
-  before the check runs.
+- **Credential validation is not egress authorization.** A recognized credential
+  shape can be saved without selecting a provider or opening a route. The sandbox
+  remains sealed until `--allow-egress-host` names one of the five lowercase exact
+  providers, or the operator explicitly supplies `--allow-web-egress`. Unknown,
+  mixed case, URL, and host literal provider names remain usage errors. Local Ollama
+  has no named remote egress entry.
 - **Two mirrors of the non-forwardable-credential rule.** The runner is the authority
   for the `sk-ant-oat` prefix
   (`runner/src/curie_runner/sdk_auth.py::OAUTH_TOKEN_PREFIX`), and it is already

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -86,29 +86,35 @@ curie cluster up
 | `-f <compose>` | Override a resolved local-dev artifact path. |
 | `--image <ref>` | Override a resolved image reference. |
 | `--no-expose` | Keep the UI and Langfuse ClusterIP-only instead of exposing them on node ports. |
-| `CURIE_CREDENTIALS` (alias `CURIE_MODEL_CREDENTIALS`) | A real model credential. Present -> installs live (forwarded through masked `--set` machinery, so `--dry-run` never prints it). Absent -> installs sealed (canned replies). |
+| `CURIE_CREDENTIALS` (alias `CURIE_MODEL_CREDENTIALS`) | A real model credential. The interactive check accepts Anthropic `sk-ant-`, OpenRouter `sk-or-`, Zhipu `id.secret`, and bare `sk-` shapes for Moonshot or DeepSeek. It checks only shape, not provider identity or liveness. Present -> installs live (forwarded through masked `--set` machinery, so `--dry-run` never prints it). Absent -> installs sealed (canned replies). |
 | `--fake-model` | Force a sealed install even when a credential is present (a dev/CI escape hatch). |
 | `--github-token <token>` (or `CURIE_GITHUB_TOKEN`) | The Curie API's own GitHub credential, for cloning a PRIVATE repo during a git-flow bundle deploy and for posting the eval commit status. Goes to helm through a private mode-0600 values file, never a command-line argument, so it never appears in the helm command, the printed plan, or that plan's JSON. Prefer the environment variable: a token typed after the flag still sits in `curie`'s own argv, so it still reaches your shell history and `ps`. Omitting both on a later `cluster up` preserves whatever the release already has. Errors if combined with `--set api.githubToken=`. |
 | `--clear-github-token` | Remove the stored GitHub credential. Not a revocation: the running API keeps the old token until its pod restarts (`cluster up` prints the restart command), and the token itself stays valid at GitHub until you revoke it there. |
-| `--allow-egress-host <provider>` (repeatable) | Open runner egress on TCP 443 to a named model provider (`anthropic` or `openrouter`). |
+| `--allow-egress-host <provider>` (repeatable) | Open runner egress on TCP 443 to one named model provider: `anthropic`, `openrouter`, `zhipu`, `moonshot`, or `deepseek`. Names are lowercase exact; any other provider name is rejected. |
 | `--allow-web-egress <CIDR>` (repeatable) | Open runner egress on TCP 443 to an arbitrary CIDR (Classless Inter-Domain Routing block) -- for skill/tool web access, or a provider not covered above. |
 
 A downloaded release binary needs no repo checkout; the chart resolves from
 the version-pinned release asset by default.
+
+**Provider-native runtime configuration.** Zhipu, Moonshot, and DeepSeek need
+their matching documented `CURIE_MODEL_BASE_URL` in worker runtime configuration,
+as well as a credential and their named egress entry. Their credential shapes do
+not identify the provider: the base URL selects it.
 
 **Egress is sealed by default.** A model credential alone opens no egress:
 the sandbox stays fail-closed until you open its provider egress with one of
 the two flags above. Neither flag bakes provider IPs into the binary --
 only hostnames are resolved (to narrow `/32`+`/128` host routes) at install
 time, because provider/CDN IPs rotate; re-run `up` to re-resolve if calls
-start failing. `--allow-web-egress` is for agents whose skills need to
-reach the open web -- a search tool, a weather lookup, anything beyond the
-named model providers above: `curie cluster up --allow-web-egress
-0.0.0.0/0` opens the open internet (still minus the `169.254.169.254`
-metadata endpoint), or narrow the CIDR to a specific destination for a
-tighter posture. A default-route value (`0.0.0.0/0`, `::/0`, any `/0`
-prefix) prints a distinct rail-removal warning, since it removes the
-default-deny rail for a prompt-injectable sandbox.
+start failing. Credential shape validation does not select a provider or open a
+route. The named provider allowlist admits only the five documented lowercase
+names above; unknown names stay denied. `--allow-web-egress` is for agents whose
+skills need open web access, such as search or weather lookup, beyond the named
+model providers. `curie cluster up --allow-web-egress 0.0.0.0/0` opens the
+internet except `169.254.169.254`; narrow the CIDR to a specific destination for
+a tighter posture. A default route value (`0.0.0.0/0`, `::/0`, or any `/0`
+prefix) prints a distinct rail removal warning, since it removes the default
+deny rail for a prompt injectable sandbox.
 
 You don't need to worry about ordering when using the CLI flags together --
 `cluster up` composes `--allow-egress-host` and `--allow-web-egress` into

--- a/runner/tests/test_sdk_auth.py
+++ b/runner/tests/test_sdk_auth.py
@@ -5,6 +5,11 @@ All values are fake placeholders; this never touches a real credential.
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
+from typing import TypedDict, cast
+from urllib.parse import urlparse
+
 import pytest
 from curie_runner.sdk_auth import (
     API_BACKEND_ENV,
@@ -39,6 +44,64 @@ from curie_runner.sdk_auth import (
 # *_TOKEN / *_KEY literals; these are variable names, never values.
 ALT_TOKEN_KEY = "ANTHROPIC_AUTH_TOKEN_ALT"
 MY_CRED_KEY = "MY_CRED"
+
+_PROVIDER_REGISTRY = (
+    Path(__file__).resolve().parents[2]
+    / "tests"
+    / "vectors"
+    / "model-provider-registry.json"
+)
+_PROVIDER_REGISTRY_KEYS = frozenset(
+    {"providers", "unknown_provider_names", "rejected_credential_examples"}
+)
+_PROVIDER_ROW_KEYS = frozenset(
+    {"name", "base_url", "egress_hosts", "credential_examples"}
+)
+
+
+class _ProviderRow(TypedDict):
+    name: str
+    base_url: str | None
+    egress_hosts: list[str]
+    credential_examples: list[str]
+
+
+class _ProviderRegistryDocument(TypedDict):
+    providers: list[_ProviderRow]
+    unknown_provider_names: list[str]
+    rejected_credential_examples: list[str]
+
+
+def _load_provider_registry(raw: str | None = None) -> _ProviderRegistryDocument:
+    registry: object = json.loads(
+        _PROVIDER_REGISTRY.read_text(encoding="utf-8") if raw is None else raw
+    )
+    assert isinstance(registry, dict)
+    assert set(registry) == _PROVIDER_REGISTRY_KEYS
+
+    providers = registry["providers"]
+    assert isinstance(providers, list)
+    assert providers
+    for provider in providers:
+        assert isinstance(provider, dict)
+        assert set(provider) == _PROVIDER_ROW_KEYS
+        assert isinstance(provider["name"], str)
+        assert provider["base_url"] is None or isinstance(provider["base_url"], str)
+        assert isinstance(provider["egress_hosts"], list)
+        assert provider["egress_hosts"]
+        assert all(isinstance(host, str) and host for host in provider["egress_hosts"])
+        assert isinstance(provider["credential_examples"], list)
+        assert provider["credential_examples"]
+        assert all(
+            isinstance(example, str) and example
+            for example in provider["credential_examples"]
+        )
+
+    for key in ("unknown_provider_names", "rejected_credential_examples"):
+        assert isinstance(registry[key], list)
+        assert registry[key]
+        assert all(isinstance(value, str) for value in registry[key])
+    return cast(_ProviderRegistryDocument, registry)
 
 
 def test_anthropic_api_key_maps_to_api_key_env() -> None:
@@ -197,6 +260,32 @@ def test_provider_base_urls_stay_on_anthropic_format() -> None:
     assert PROVIDER_BASE_URLS["moonshot"] == MOONSHOT_BASE_URL
     assert PROVIDER_BASE_URLS["deepseek"] == DEEPSEEK_BASE_URL
     assert PROVIDER_BASE_URLS["openrouter"] == OPENROUTER_BASE_URL
+
+
+def test_provider_registry_matches_runner_authority() -> None:
+    registry = _load_provider_registry()
+    providers = registry["providers"]
+    by_name = {provider["name"]: provider for provider in providers}
+
+    assert len(by_name) == len(providers)
+    assert set(by_name) == {"anthropic", *PROVIDER_BASE_URLS}
+    assert [row["name"] for row in providers if row["base_url"] is None] == [
+        "anthropic"
+    ]
+    assert {
+        name: row["base_url"]
+        for name, row in by_name.items()
+        if row["base_url"] is not None
+    } == PROVIDER_BASE_URLS
+
+    for provider in providers:
+        base_url = provider["base_url"]
+        if base_url is not None:
+            hostname = urlparse(base_url).hostname
+            assert hostname is not None
+            assert provider["egress_hosts"] == [hostname]
+
+    assert not set(registry["unknown_provider_names"]) & set(by_name)
 
 
 @pytest.mark.parametrize(

--- a/tests/vectors/model-provider-registry.json
+++ b/tests/vectors/model-provider-registry.json
@@ -1,0 +1,52 @@
+{
+  "providers": [
+    {
+      "name": "anthropic",
+      "base_url": null,
+      "egress_hosts": ["api.anthropic.com"],
+      "credential_examples": [
+        "sk-ant-api03-PLACEHOLDER",
+        "sk-ant-oat01-PLACEHOLDER"
+      ]
+    },
+    {
+      "name": "openrouter",
+      "base_url": "https://openrouter.ai/api",
+      "egress_hosts": ["openrouter.ai"],
+      "credential_examples": ["sk-or-v1-PLACEHOLDER"]
+    },
+    {
+      "name": "zhipu",
+      "base_url": "https://api.z.ai/api/anthropic",
+      "egress_hosts": ["api.z.ai"],
+      "credential_examples": ["zhipu-id.PLACEHOLDER"]
+    },
+    {
+      "name": "moonshot",
+      "base_url": "https://api.moonshot.ai/anthropic",
+      "egress_hosts": ["api.moonshot.ai"],
+      "credential_examples": ["sk-MOONSHOT-PLACEHOLDER"]
+    },
+    {
+      "name": "deepseek",
+      "base_url": "https://api.deepseek.com/anthropic",
+      "egress_hosts": ["api.deepseek.com"],
+      "credential_examples": ["sk-DEEPSEEK-PLACEHOLDER"]
+    }
+  ],
+  "unknown_provider_names": [
+    "openai",
+    "gemini",
+    "acme.com",
+    "api.anthropic.com",
+    "",
+    "Anthropic"
+  ],
+  "rejected_credential_examples": [
+    "xoxb-EXAMPLE-not-a-real-token",
+    "github_pat_PLACEHOLDER",
+    ".secret",
+    "id.",
+    "id.secret.extra"
+  ]
+}


### PR DESCRIPTION
Closes #1588

Recognizes Zhipu, Moonshot, and DeepSeek across credential shape validation and named cluster egress. A shared vector pins runner, credential, and egress provider knowledge together while unknown provider names remain denied before DNS.

Done check:

* [x] Supported credential shapes pass the interactive validation path
* [x] All five documented providers pass exact named egress validation
* [x] Unknown and mixed case providers remain usage errors before DNS
* [x] Runner and CLI registries are pinned bidirectionally
* [x] Full affected Rust, Python, UI, lint, typecheck, and docs validation passed
* [x] Real CLI dry runs confirmed each new provider and rejected acme.com with exit 2
* [x] Independent code, scope, and security reviews approved