### PR TITLE
Keep declared Helm values as strings

### DIFF
--- a/cli/src/installation.rs
+++ b/cli/src/installation.rs
@@ -35,10 +35,11 @@ pub struct Installation {
     pub credentials: Credentials,
     #[serde(default)]
     pub comms: Comms,
-    /// Verbatim `helm --set key=value` escape hatch, for anything this schema
-    /// does not model yet. Present deliberately: without it, adopting the file
-    /// would mean giving up settings that flags can express, and nobody would
-    /// adopt it.
+    /// Verbatim values emitted as `helm --set-string key=value` for chart settings
+    /// this schema does not model yet. Every accepted value remains a string.
+    /// Values shaped like booleans or null after trimmed ASCII case normalization
+    /// are refused because Helm treats every nonempty string as true in template
+    /// conditions. Use a modeled `curie.yaml` field when typed behavior is required.
     #[serde(default)]
     pub set: BTreeMap<String, String>,
 }
@@ -148,6 +149,19 @@ impl Installation {
                 bail!("platform.egress[].host must not be empty");
             }
         }
+        for (key, value) in &self.set {
+            let trimmed = value.trim();
+            if ["true", "false", "null"]
+                .iter()
+                .any(|reserved| trimmed.eq_ignore_ascii_case(reserved))
+            {
+                bail!(
+                    "set.{key} cannot use `{value}` because set values are always strings and \
+                     Helm treats every nonempty string as true in template conditions. \
+                     Use a modeled curie.yaml field for typed boolean or null behavior."
+                );
+            }
+        }
         // Refuse rather than ignore. A declared-but-unapplied credential is the
         // failure this whole ADR exists to prevent: the file would say the App
         // is configured while the cluster disagreed, which is exactly the
@@ -221,12 +235,8 @@ impl Installation {
         Ok(())
     }
 
-    /// The `--set key=value` tokens this file implies, in a stable order so a
-    /// plan diff is readable and a test can pin it.
-    ///
-    /// Platform toggles render before the `set:` escape hatch so an explicit
-    /// `set:` entry wins on a later-key-wins reading, matching how a trailing
-    /// `--set` beats an earlier one on the helm command line.
+    /// The modeled `--set key=value` tokens this file implies, in a stable
+    /// order so a plan diff is readable and a test can pin it.
     pub fn helm_sets(&self) -> Vec<String> {
         let mut out = Vec::new();
         if let Some(ui) = self.platform.ui {
@@ -235,10 +245,15 @@ impl Installation {
         if let Some(inference) = self.platform.inference {
             out.push(format!("inference.deploy={inference}"));
         }
-        for (key, value) in &self.set {
-            out.push(format!("{key}={value}"));
-        }
         out
+    }
+
+    /// The declared string tokens this file implies, in stable key order.
+    pub fn helm_set_strings(&self) -> Vec<String> {
+        self.set
+            .iter()
+            .map(|(key, value)| format!("{key}={value}"))
+            .collect()
     }
 
     /// Provider names for `--allow-egress-host`, validated downstream by
@@ -288,6 +303,10 @@ mod tests {
         assert_eq!(cfg.install.namespace, "acme");
         assert_eq!(cfg.install.release, "acme");
         assert!(cfg.helm_sets().is_empty(), "no platform toggles declared");
+        assert!(
+            cfg.helm_set_strings().is_empty(),
+            "no declared string values"
+        );
         assert!(cfg.credential_names().is_empty());
     }
 
@@ -401,17 +420,50 @@ mod tests {
     }
 
     #[test]
-    fn explicit_set_entries_render_after_platform_toggles() {
+    fn declared_set_entries_remain_verbatim_after_platform_toggles() {
         let raw = format!(
-            "{}platform:\n  ui: false\nset:\n  security.gvisor.mode: \"off\"\n",
+            "{}platform:\n  ui: false\nset:\n  api.githubAppId: \"4475970\"\n  \
+             example.label: plain\n  example.leadingZero: \"00123\"\n  worker.replicas: \"3\"\n",
             minimal()
         );
         let cfg = Installation::parse(&raw).unwrap();
         assert_eq!(
             cfg.helm_sets(),
-            vec!["ui.deploy=false", "security.gvisor.mode=off"],
-            "a later --set wins on the helm command line, so escape-hatch keys go last"
+            vec!["ui.deploy=false"],
+            "modeled settings must remain in the Helm typed lane"
         );
+        assert_eq!(
+            cfg.helm_set_strings(),
+            vec![
+                "api.githubAppId=4475970",
+                "example.label=plain",
+                "example.leadingZero=00123",
+                "worker.replicas=3",
+            ],
+            "declared strings must retain their exact value in the Helm string lane"
+        );
+    }
+
+    #[test]
+    fn boolean_and_null_shaped_declared_set_values_are_rejected() {
+        for value in ["\"true\"", "\" FALSE \"", "\"Null\""] {
+            let raw = format!("{}set:\n  example.value: {value}\n", minimal());
+            let err =
+                Installation::parse(&raw).expect_err(&format!("quoted {value} must be rejected"));
+            let message = format!("{err:#}");
+            assert!(
+                message.contains("set.example.value"),
+                "error must name the rejected key: {message}"
+            );
+            assert!(
+                message.contains("set values are always strings"),
+                "error must explain the string contract: {message}"
+            );
+            assert!(
+                message.contains("Use a modeled curie.yaml field"),
+                "error must give the operator a safe next action: {message}"
+            );
+        }
     }
 
     #[test]
@@ -671,6 +723,7 @@ fn plan_installation_inner(
         chart: String::new(),
         no_expose: false,
         set: cfg.helm_sets(),
+        set_string: cfg.helm_set_strings(),
         allow_egress_host: cfg.egress_hosts(),
         resolved_egress_cidrs: vec![],
         allow_web_egress: vec![],
@@ -796,7 +849,10 @@ enum GuardVerdict {
 /// Runs even under `--dry-run`: the plan a dry run prints is exactly the plan
 /// that would destroy the store, so an operator reading it deserves the same
 /// warning the real run would give.
-async fn guard_stateful_removal(up: &crate::ops::UpOpts) -> Result<GuardVerdict> {
+async fn guard_stateful_removal(
+    up: &crate::ops::UpOpts,
+    value_plan: &crate::ops::UpValuePlan,
+) -> Result<GuardVerdict> {
     let live = crate::ops::live_stateful_components(&up.common)
         .await
         .context("could not check whether this apply would remove stateful components")?;
@@ -807,14 +863,7 @@ async fn guard_stateful_removal(up: &crate::ops::UpOpts) -> Result<GuardVerdict>
         // rather than a silent empty answer (#1351).
         return Ok(GuardVerdict::Clear);
     }
-    // The same effective values the upgrade would send, so the render reflects
-    // what this apply would actually create rather than the chart's defaults.
-    let sets: Vec<String> = crate::ops::up_value_plan(up)
-        .effective_values()
-        .into_iter()
-        .map(|(k, v)| format!("{k}={v}"))
-        .collect();
-    let rendered = crate::ops::chart_stateful_components(&up.chart, &up.common, &sets).await?;
+    let rendered = crate::ops::chart_stateful_components(&up.chart, &up.common, value_plan).await?;
     let removed = crate::ops::removed_stateful_components(&live, &rendered);
     if removed.is_empty() {
         return Ok(GuardVerdict::Clear);
@@ -964,7 +1013,9 @@ pub async fn apply(opts: ApplyOpts) -> Result<ApplyOutput> {
     let migrating = if allow_stateful_removal {
         false
     } else {
-        match guard_stateful_removal(&up).await? {
+        // Guard the exact upgrade plan, including preserved values carried through
+        // the private values file.
+        match guard_stateful_removal(&up, &up_values).await? {
             GuardVerdict::Clear => false,
             GuardVerdict::WouldRemove(removed)
                 if migrate_store

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -2571,6 +2571,7 @@ async fn run(command: Option<Command>) -> Result<()> {
                             chart,
                             no_expose,
                             set,
+                            set_string: vec![],
                             allow_egress_host,
                             // Populated by ops::up (resolve named providers to host
                             // routes on a live run); empty here so the pure builder and

--- a/cli/src/migrate_store.rs
+++ b/cli/src/migrate_store.rs
@@ -695,11 +695,12 @@ pub async fn run_export(o: &CommonOpts, chart: &str, bucket: &str) -> Result<Mig
         .collect();
     // migrate_store reasons about COMPONENTS only (which store is which); the
     // resource names the guard also needs are irrelevant here.
-    let rendered: Vec<String> = crate::ops::chart_stateful_components(chart, o, &[])
-        .await?
-        .into_iter()
-        .map(|(component, _)| component)
-        .collect();
+    let rendered: Vec<String> =
+        crate::ops::chart_stateful_components(chart, o, &crate::ops::UpValuePlan::default())
+            .await?
+            .into_iter()
+            .map(|(component, _)| component)
+            .collect();
     let (from, to) = ensure_migratable(&plan(&live, &rendered)?)?;
 
     let image = "amazon/aws-cli:2.32.6";
@@ -956,11 +957,12 @@ pub async fn run_auto(o: &CommonOpts, chart: &str, bucket: &str) -> Result<Migra
         .collect();
     // migrate_store reasons about COMPONENTS only (which store is which); the
     // resource names the guard also needs are irrelevant here.
-    let rendered: Vec<String> = crate::ops::chart_stateful_components(chart, o, &[])
-        .await?
-        .into_iter()
-        .map(|(component, _)| component)
-        .collect();
+    let rendered: Vec<String> =
+        crate::ops::chart_stateful_components(chart, o, &crate::ops::UpValuePlan::default())
+            .await?
+            .into_iter()
+            .map(|(component, _)| component)
+            .collect();
     let (from, to) = ensure_migratable(&plan(&live, &rendered)?)?;
 
     let image = "amazon/aws-cli:2.32.6";

--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -301,6 +301,7 @@ pub struct UpOpts {
     pub chart: String,
     pub no_expose: bool,
     pub set: Vec<String>,
+    pub set_string: Vec<String>,
     /// Named model providers (validated against [`parse_egress_provider`]) whose
     /// API host(s) runner egress is opened to. Resolved to narrow host-route
     /// CIDRs at install time into [`resolved_egress_cidrs`]; empty means no
@@ -347,6 +348,12 @@ pub struct UpOpts {
     /// generating strong per-release randoms (the first-class dev escape hatch
     /// that replaces hand-passing `--set` for every secret).
     pub dev: bool,
+}
+
+impl UpOpts {
+    fn operator_sets(&self) -> Vec<String> {
+        self.set.iter().chain(&self.set_string).cloned().collect()
+    }
 }
 
 pub struct DownOpts {
@@ -460,8 +467,9 @@ pub(crate) fn validate_up_inputs(
 ) -> Result<()> {
     validate_web_egress_cidrs(&opts.allow_web_egress)
         .context("invalid --allow-web-egress value")?;
-    check_runner_model_conflict(opts.model.as_deref(), &opts.set)?;
-    check_github_token_conflict(github_token, clear_github_token, &opts.set)?;
+    let operator_sets = opts.operator_sets();
+    check_runner_model_conflict(opts.model.as_deref(), &operator_sets)?;
+    check_github_token_conflict(github_token, clear_github_token, &operator_sets)?;
     for host in &opts.allow_egress_host {
         parse_egress_provider(host)?;
     }
@@ -1434,10 +1442,10 @@ pub fn stateful_components_from_list(list: &serde_json::Value) -> Vec<(String, S
 /// `helm template` rather than a dry-run upgrade: it needs no cluster and
 /// cannot mutate, so the guard is safe to run before deciding whether to
 /// proceed.
-pub async fn chart_stateful_components(
+pub(crate) async fn chart_stateful_components(
     chart: &str,
     o: &CommonOpts,
-    value_sets: &[String],
+    value_plan: &UpValuePlan,
 ) -> Result<Vec<(String, String)>> {
     let mut args = vec![
         plain("template"),
@@ -1446,10 +1454,7 @@ pub async fn chart_stateful_components(
         plain("-n"),
         plain(&o.namespace),
     ];
-    for entry in value_sets {
-        args.push(plain("--set"));
-        args.push(plain(entry));
-    }
+    value_plan.append_command_args(&mut args);
     let (ok, out, err) = run_capture(&OpsCommand::new("helm", args)).await?;
     if !ok {
         bail!("could not render the target chart to check for removed stateful components: {err}");
@@ -2015,15 +2020,17 @@ pub(crate) fn complete_up_opts(
     clear_github_token: bool,
     resolve_provider_egress: bool,
 ) -> Result<UpOpts> {
+    let operator_sets = opts.operator_sets();
     if !opts.dev {
-        opts.secrets = resolve_generated_secrets(existing, &opts.set)?;
+        opts.secrets = resolve_generated_secrets(existing, &operator_sets)?;
         opts.secrets.extend(resolve_managed_values_for_up(
             existing,
-            &opts.set,
+            &operator_sets,
             opts.common.dry_run,
         ));
     }
-    opts.github_token = resolve_github_token(existing, &opts.set, github_token, clear_github_token);
+    opts.github_token =
+        resolve_github_token(existing, &operator_sets, github_token, clear_github_token);
     if resolve_provider_egress
         && !opts.allow_egress_host.is_empty()
         && opts.resolved_egress_cidrs.is_empty()
@@ -2174,6 +2181,7 @@ enum DiffParticipation {
 #[derive(Clone, PartialEq, Eq)]
 enum PlannedHelmValues {
     Set {
+        flag: HelmSetFlag,
         expression: String,
         effective: Vec<(String, String)>,
     },
@@ -2181,6 +2189,12 @@ enum PlannedHelmValues {
         values: Vec<(String, String)>,
         diff: DiffParticipation,
     },
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum HelmSetFlag {
+    Set,
+    SetString,
 }
 
 #[derive(Clone, Default, PartialEq, Eq)]
@@ -2193,6 +2207,7 @@ impl UpValuePlan {
         let key = key.into();
         let value = value.into();
         self.entries.push(PlannedHelmValues::Set {
+            flag: HelmSetFlag::Set,
             expression: format!("{key}={value}"),
             effective: vec![(key, value)],
         });
@@ -2204,6 +2219,19 @@ impl UpValuePlan {
             .map(|(key, value)| (key.trim().to_string(), value.to_string()))
             .collect();
         self.entries.push(PlannedHelmValues::Set {
+            flag: HelmSetFlag::Set,
+            expression,
+            effective,
+        });
+    }
+
+    fn set_string_expression(&mut self, expression: String) {
+        let effective = operator_set_entries(std::slice::from_ref(&expression))
+            .into_iter()
+            .map(|(key, value)| (key.trim().to_string(), value.to_string()))
+            .collect();
+        self.entries.push(PlannedHelmValues::Set {
+            flag: HelmSetFlag::SetString,
             expression,
             effective,
         });
@@ -2219,8 +2247,13 @@ impl UpValuePlan {
     fn append_command_args(&self, args: &mut Vec<CmdArg>) {
         for entry in &self.entries {
             match entry {
-                PlannedHelmValues::Set { expression, .. } => {
-                    args.push(plain("--set"));
+                PlannedHelmValues::Set {
+                    flag, expression, ..
+                } => {
+                    args.push(plain(match flag {
+                        HelmSetFlag::Set => "--set",
+                        HelmSetFlag::SetString => "--set-string",
+                    }));
                     args.push(plain(expression));
                 }
                 PlannedHelmValues::SecretFile { values, .. } => {
@@ -2309,12 +2342,18 @@ pub(crate) fn up_value_plan(o: &UpOpts) -> UpValuePlan {
     }
     plan.secret_file(o.secrets.clone(), DiffParticipation::Preserve);
     if let Some(model) = &o.model {
-        if explicit_runner_model(&o.set).is_none() {
+        if explicit_runner_model(&o.operator_sets()).is_none() {
             plan.set(RUNNER_MODEL_KEY, model);
         }
     }
     for expression in &o.set {
         plan.set_expression(expression.clone());
+    }
+    // Helm merges `--set-string` after `--set`, while `effective_values` uses
+    // insertion order. Keep the declared lane after the typed lane so duplicate
+    // keys resolve identically.
+    for expression in &o.set_string {
+        plan.set_string_expression(expression.clone());
     }
     plan
 }
@@ -3261,7 +3300,8 @@ async fn run_prepared_up(
 ) -> Result<ClusterUpOutput> {
     let ui = crate::ui::ui();
     if !opts.dev {
-        let preserved = resolve_preserved_values(existing.as_ref(), &opts.set);
+        let operator_sets = opts.operator_sets();
+        let preserved = resolve_preserved_values(existing.as_ref(), &operator_sets);
         if !preserved.is_empty() {
             let sealing_values = preserved
                 .iter()
@@ -3286,7 +3326,11 @@ async fn run_prepared_up(
             };
             ui.note(&message);
         }
-        match sealing_private_key_disposition(existing.as_ref(), &opts.set, opts.common.dry_run) {
+        match sealing_private_key_disposition(
+            existing.as_ref(),
+            &operator_sets,
+            opts.common.dry_run,
+        ) {
             SealingPrivateKeyDisposition::Generated => {
                 ui.note("generated a sealing private key for this release; later cluster up runs preserve it");
             }
@@ -3380,7 +3424,7 @@ async fn run_prepared_up(
             }
         }
     }
-    if set_passthrough_leaks_github_token(&opts.set) {
+    if set_passthrough_leaks_github_token(&opts.operator_sets()) {
         ui.warn("a GitHub credential passed with --set lands in the process table, shell history and the printed plan; use --github-token, or CURIE_GITHUB_TOKEN to keep it out of shell history too");
     }
 
@@ -4715,6 +4759,7 @@ mod tests {
             dev: false,
             no_expose: false,
             set: vec![],
+            set_string: vec![],
             allow_web_egress: vec![],
             fake_model: false,
             credentials: None,
@@ -4735,6 +4780,7 @@ mod tests {
         let cmds = up_commands(&UpOpts {
             common: common(),
             github_token: GithubTokenPlan::Untouched,
+            set_string: vec![],
             allow_egress_host: vec![],
             resolved_egress_cidrs: vec![],
             chart: "charts/curie".into(),
@@ -4765,6 +4811,7 @@ mod tests {
             dev: false,
             no_expose: true,
             set: vec!["worker.replicas=2".into(), "dispatcher.deploy=false".into()],
+            set_string: vec![],
             allow_web_egress: vec![],
             fake_model: false,
             credentials: None,
@@ -4785,6 +4832,7 @@ mod tests {
         let cmds = up_commands(&UpOpts {
             common: common(),
             github_token: GithubTokenPlan::Untouched,
+            set_string: vec![],
             allow_egress_host: vec![],
             resolved_egress_cidrs: vec![],
             chart: "charts/curie".into(),
@@ -4818,6 +4866,7 @@ mod tests {
             dev: false,
             no_expose: false,
             set: vec![],
+            set_string: vec![],
             allow_web_egress: vec![],
             fake_model: true,
             credentials: None,
@@ -4834,6 +4883,7 @@ mod tests {
         let cmds = up_commands(&UpOpts {
             common: common(),
             github_token: GithubTokenPlan::Untouched,
+            set_string: vec![],
             allow_egress_host: vec!["anthropic".into()],
             resolved_egress_cidrs: vec!["192.0.2.10/32".into()],
             chart: "charts/curie".into(),
@@ -4975,6 +5025,7 @@ mod tests {
             dev: false,
             no_expose: true,
             set: vec![],
+            set_string: vec![],
             allow_web_egress: vec![],
             fake_model: false,
             credentials: None,
@@ -4991,6 +5042,7 @@ mod tests {
         let cmds = up_commands(&UpOpts {
             common: common(),
             github_token: GithubTokenPlan::Untouched,
+            set_string: vec![],
             allow_egress_host: vec![],
             resolved_egress_cidrs: vec![],
             chart: "charts/curie".into(),
@@ -5022,6 +5074,7 @@ mod tests {
             dev: false,
             no_expose: true,
             set: vec![],
+            set_string: vec![],
             allow_web_egress: vec![],
             fake_model: false,
             credentials: None,
@@ -5041,6 +5094,7 @@ mod tests {
         let cmds = up_commands(&UpOpts {
             common: common(),
             github_token: GithubTokenPlan::Untouched,
+            set_string: vec![],
             allow_egress_host: vec![],
             resolved_egress_cidrs: vec![],
             chart: "charts/curie".into(),
@@ -5072,6 +5126,7 @@ mod tests {
             dev: false,
             no_expose: true,
             set: vec!["agentSandbox.runner.model=z-ai/glm-5.2".into()],
+            set_string: vec![],
             allow_web_egress: vec![],
             fake_model: false,
             credentials: None,
@@ -5095,6 +5150,7 @@ mod tests {
         let cmds = up_commands(&UpOpts {
             common: common(),
             github_token: GithubTokenPlan::Untouched,
+            set_string: vec![],
             allow_egress_host: vec![],
             resolved_egress_cidrs: vec![],
             chart: "charts/curie".into(),
@@ -5176,6 +5232,7 @@ mod tests {
             dev: false,
             no_expose: false,
             set: vec![],
+            set_string: vec![],
             allow_web_egress: vec!["203.0.113.0/24".into()],
             fake_model: false,
             credentials: Some("sk-ant-secretsecret".into()),
@@ -5206,6 +5263,7 @@ mod tests {
         let cmds = up_commands(&UpOpts {
             common: common(),
             github_token: GithubTokenPlan::Untouched,
+            set_string: vec![],
             allow_egress_host: vec![],
             resolved_egress_cidrs: vec![],
             chart: "charts/curie".into(),
@@ -5247,6 +5305,7 @@ mod tests {
             dev: false,
             no_expose: false,
             set: vec![],
+            set_string: vec![],
             allow_web_egress: vec!["203.0.113.0/24".into(), "198.51.100.0/24".into()],
             fake_model: false,
             credentials: Some("sk-ant-secretsecret".into()),
@@ -5273,6 +5332,7 @@ mod tests {
         let sealed_cmds = up_commands(&UpOpts {
             common: common(),
             github_token: GithubTokenPlan::Untouched,
+            set_string: vec![],
             allow_egress_host: vec![],
             resolved_egress_cidrs: vec![],
             chart: "charts/curie".into(),
@@ -5299,6 +5359,7 @@ mod tests {
             dev: false,
             no_expose: false,
             set: vec![],
+            set_string: vec![],
             allow_web_egress: vec![],
             fake_model: false,
             credentials: Some("sk-ant-secretsecret".into()),
@@ -6440,6 +6501,7 @@ mod tests {
         let cmds = up_commands(&UpOpts {
             common: common(),
             github_token: GithubTokenPlan::Untouched,
+            set_string: vec![],
             allow_egress_host: vec![],
             resolved_egress_cidrs: vec![],
             chart: "charts/curie".into(),
@@ -6630,6 +6692,7 @@ mod tests {
             dev: false,
             no_expose: true,
             set: vec![],
+            set_string: vec![],
             allow_web_egress: vec![],
             fake_model: false,
             credentials: None,
@@ -6672,6 +6735,7 @@ mod tests {
         let cmds = up_commands(&UpOpts {
             common: common(),
             github_token: GithubTokenPlan::Untouched,
+            set_string: vec![],
             allow_egress_host: vec![],
             resolved_egress_cidrs: vec![],
             chart: "charts/curie".into(),
@@ -6704,6 +6768,7 @@ mod tests {
             dev: true,
             no_expose: true,
             set: vec![],
+            set_string: vec![],
             allow_web_egress: vec![],
             fake_model: false,
             credentials: None,
@@ -6724,6 +6789,7 @@ mod tests {
         let cmds = up_commands(&UpOpts {
             common: common(),
             github_token: GithubTokenPlan::Untouched,
+            set_string: vec![],
             allow_egress_host: vec![],
             resolved_egress_cidrs: vec![],
             chart: "charts/curie".into(),
@@ -7606,6 +7672,7 @@ mod tests {
             dev: false,
             no_expose: true,
             set: vec![],
+            set_string: vec![],
             allow_web_egress: vec!["203.0.113.0/24".into()],
             fake_model: false,
             credentials: Some("sk-ant-secretsecret".into()),
@@ -7648,6 +7715,7 @@ mod tests {
             common: common(),
             github_token: GithubTokenPlan::Untouched,
             model: None,
+            set_string: vec![],
             allow_egress_host: vec![],
             resolved_egress_cidrs: vec![],
             chart: "charts/curie".into(),
@@ -7687,6 +7755,7 @@ mod tests {
             dev: false,
             no_expose: true,
             set: vec![],
+            set_string: vec![],
             allow_web_egress: vec!["203.0.113.0/24".into()],
             fake_model: true,
             credentials: None,
@@ -7725,6 +7794,7 @@ mod tests {
         up_commands(&UpOpts {
             common: common(),
             github_token: plan,
+            set_string: vec![],
             allow_egress_host: vec![],
             resolved_egress_cidrs: vec![],
             chart: "charts/curie".into(),
@@ -8109,6 +8179,7 @@ mod tests {
             dev: true,
             no_expose: true,
             set: vec![],
+            set_string: vec![],
             allow_web_egress: vec![],
             fake_model: false,
             credentials: None,
@@ -8149,6 +8220,7 @@ mod tests {
         let cmds = up_commands(&UpOpts {
             common: common(),
             github_token: GithubTokenPlan::Set(GH_SENTINEL.into()),
+            set_string: vec![],
             allow_egress_host: vec![],
             resolved_egress_cidrs: vec![],
             chart: "charts/curie".into(),

--- a/cli/tests/installation_plan_parity.rs
+++ b/cli/tests/installation_plan_parity.rs
@@ -671,7 +671,7 @@ fn live_mixed_store_statefulsets() -> String {
 }
 
 fn installation_with_effective_values() -> &'static str {
-    "version: 1\ninstall:\n  namespace: parity\n  release: parity\ncredentials:\n  model: CURIE_APPLY_TEST_MODEL_KEY\n  github_token: CURIE_APPLY_TEST_GITHUB_TOKEN\nplatform:\n  ui: false\n  inference: true\nset:\n  dispatcher.deploy: \"false\"\n  worker.replicas: \"3\"\n"
+    "version: 1\ninstall:\n  namespace: parity\n  release: parity\ncredentials:\n  model: CURIE_APPLY_TEST_MODEL_KEY\n  github_token: CURIE_APPLY_TEST_GITHUB_TOKEN\nplatform:\n  ui: false\n  inference: true\nset:\n  example.mode: disabled\n  worker.replicas: \"3\"\n"
 }
 
 #[derive(Clone, Copy)]
@@ -1171,6 +1171,95 @@ fn absent_release_diff_matches_apply_dry_run_for_effective_installation_values()
         .map(String::as_str)
         .collect::<BTreeSet<_>>();
     assert_eq!(diff_keys, apply_keys, "apply plan: {apply}; diff: {diff}");
+}
+
+#[test]
+fn numeric_looking_declared_set_values_use_helm_string_semantics() {
+    let fixture = HelmFixture::new(
+        "version: 1\ninstall:\n  namespace: parity\n  release: parity\nplatform:\n  ui: false\nset:\n  api.githubAppId: \"4475970\"\n  example.label: plain\n  example.leadingZero: \"00123\"\n  ui.deploy: disabled\n  worker.replicas: \"3\"\n",
+        HelmValuesResponse::Absent,
+    );
+    let live_statefulset = json!({
+        "apiVersion": "v1",
+        "kind": "List",
+        "items": [{
+            "metadata": {"name": "parity-rustfs"},
+            "spec": {"selector": {"matchLabels": {"app.kubernetes.io/component": "rustfs"}}}
+        }]
+    })
+    .to_string();
+
+    let output = fixture.apply(
+        &[],
+        &[("CURIE_TEST_KUBECTL_STS", live_statefulset.as_str())],
+    );
+    let calls = fixture.calls();
+    assert!(
+        output.status.success(),
+        "apply failed with stdout:\n{}\nstderr:\n{}\ncalls:\n{calls}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let template = calls
+        .lines()
+        .find(|line| line.starts_with("HELM_CALL: template "))
+        .unwrap_or_else(|| panic!("stateful guard did not render the chart:\n{calls}"));
+    let upgrade = calls
+        .lines()
+        .find(|line| line.starts_with("HELM_CALL: upgrade "))
+        .unwrap_or_else(|| panic!("apply did not upgrade the release:\n{calls}"));
+
+    for command in [template, upgrade] {
+        let tokens = command.split_whitespace().collect::<Vec<_>>();
+        assert!(
+            tokens
+                .windows(2)
+                .any(|pair| pair == ["--set", "ui.deploy=false"]),
+            "modeled values must retain Helm typed semantics: {command}"
+        );
+        let modeled_index = tokens
+            .windows(2)
+            .position(|pair| pair == ["--set", "ui.deploy=false"])
+            .expect("modeled ui value");
+        let declared_index = tokens
+            .windows(2)
+            .position(|pair| pair == ["--set-string", "ui.deploy=disabled"])
+            .unwrap_or_else(|| panic!("declared ui override missing: {command}"));
+        assert!(
+            modeled_index < declared_index,
+            "declared string override must follow the modeled value: {command}"
+        );
+        for setting in [
+            "api.githubAppId=4475970",
+            "example.label=plain",
+            "example.leadingZero=00123",
+            "ui.deploy=disabled",
+            "worker.replicas=3",
+        ] {
+            assert!(
+                tokens
+                    .windows(2)
+                    .any(|pair| pair == ["--set-string", setting]),
+                "declared value must use Helm string semantics: {command}"
+            );
+            assert!(
+                !tokens.windows(2).any(|pair| pair == ["--set", setting]),
+                "declared value reached Helm through the typed lane: {command}"
+            );
+        }
+    }
+
+    let diff = json_output(fixture.diff(&[]), "diff");
+    for (key, value) in [
+        ("ui.deploy", "disabled"),
+        ("api.githubAppId", "<secret>"),
+        ("example.label", "plain"),
+        ("example.leadingZero", "00123"),
+        ("worker.replicas", "3"),
+    ] {
+        assert_added(&diff, key, value);
+    }
 }
 
 #[test]


### PR DESCRIPTION
Closes #1375

Routes every accepted `curie.yaml` `set:` entry through Helm string semantics while keeping modeled and command line values typed.

Rejects boolean and null shaped declared strings because Helm template conditions treat nonempty strings as true. The stateful safety render consumes the same upgrade plan, including preserved values through its private temporary values file.

A live apply stored `api.githubAppId` as the JSON string `"4475970"`, and the running pod received the same digits.