### PR TITLE
Make store migration verification fail closed

### DIFF
--- a/cli/src/installation.rs
+++ b/cli/src/installation.rs
@@ -1057,27 +1057,37 @@ pub async fn apply(opts: ApplyOpts) -> Result<ApplyOutput> {
         return Ok(ApplyOutput::DryRun(crate::ui::DryRunPlan { lines }));
     }
 
-    // Load the staged objects into whatever the upgrade created, and verify per
-    // object. `run_import` retains the staging pod when anything is missing, so
-    // a partial load stays recoverable.
+    // Load the staged objects into the planned target. Import returns only once
+    // the persisted source inventory is present there at the same sizes.
     if migrating {
         let common = crate::ops::CommonOpts {
             namespace: cfg.install.namespace.clone(),
             release: cfg.install.release.clone(),
             dry_run: false,
         };
-        let imported = crate::migrate_store::run_import(&common, BUNDLE_BUCKET, false).await?;
-        if let crate::migrate_store::MigrateStoreOutput::Imported { missing, .. } = &imported {
-            if !missing.is_empty() {
-                bail!(
-                    "the upgrade applied, but {} staged object(s) did not reach the new \
-                     store. The staging pod has been kept -- it holds the only other \
-                     copy. Re-run `curie cluster migrate-store --phase import` before \
-                     deleting it.",
-                    missing.len()
-                );
-            }
-        }
+        let recovery_command = format!(
+            "`curie cluster migrate-store --phase import --namespace {} --release {}`",
+            common.namespace, common.release
+        );
+        let target = crate::migrate_store::read_planned_target(&common)
+            .await
+            .with_context(|| {
+                format!(
+                    "the upgrade applied, but the planned migration target could not be verified; the staging pod remains available. Retry with {recovery_command}"
+                )
+            })?;
+        crate::migrate_store::run_import_to_planned_target(
+            &common,
+            target,
+            BUNDLE_BUCKET,
+            false,
+        )
+            .await
+            .with_context(|| {
+                format!(
+                    "the upgrade applied, but store import verification did not complete; the staging pod remains available. Retry with {recovery_command}"
+                )
+            })?;
     }
 
     Ok(ApplyOutput::Applied {

--- a/cli/src/migrate_store.rs
+++ b/cli/src/migrate_store.rs
@@ -58,6 +58,14 @@ impl StoreKind {
             StoreKind::Rustfs => "rustfsSecretKey",
         }
     }
+
+    fn from_suffix(value: &str) -> Option<Self> {
+        match value {
+            "minio" => Some(StoreKind::Minio),
+            "rustfs" => Some(StoreKind::Rustfs),
+            _ => None,
+        }
+    }
 }
 
 /// Identify the store among a release's StatefulSet COMPONENTS.
@@ -134,11 +142,13 @@ pub fn create_staging_pod_cmd(o: &CommonOpts, image: &str, secret_name: &str) ->
                 "command": ["sleep", "86400"],
                 "volumeMounts": [
                     {"name": "stage", "mountPath": "/stage"},
+                    {"name": "migration", "mountPath": "/migration"},
                     {"name": "release-secret", "mountPath": "/secret", "readOnly": true}
                 ]
             }],
             "volumes": [
                 {"name": "stage", "emptyDir": {}},
+                {"name": "migration", "emptyDir": {}},
                 {"name": "release-secret", "secret": {"secretName": secret_name}}
             ]
         }
@@ -212,6 +222,10 @@ fn sync_script(store: StoreKind, endpoint: &str, from: &str, to: &str) -> String
 /// verb failed: `array index out of bounds: index 0, length 0`. Filtering on
 /// `spec.selector` is what actually finds it.
 pub fn store_service_cmd(o: &CommonOpts, store: StoreKind) -> OpsCommand {
+    store_service_for_component_cmd(o, store.suffix())
+}
+
+fn store_service_for_component_cmd(o: &CommonOpts, component: &str) -> OpsCommand {
     OpsCommand::new(
         "kubectl",
         vec![
@@ -222,7 +236,7 @@ pub fn store_service_cmd(o: &CommonOpts, store: StoreKind) -> OpsCommand {
             plain("-o"),
             plain(format!(
                 r#"jsonpath={{.items[?(@.spec.selector.app\.kubernetes\.io/component=="{}")].metadata.name}}"#,
-                store.suffix()
+                component
             )),
         ],
     )
@@ -246,6 +260,16 @@ pub fn export_cmd(o: &CommonOpts, from: StoreKind, bucket: &str, endpoint: &str)
 /// `mb` on an existing bucket is a no-op error, so it is tolerated: a re-run
 /// after a partial import must not fail on the bucket already being there.
 pub fn import_cmd(o: &CommonOpts, to: StoreKind, bucket: &str, endpoint: &str) -> OpsCommand {
+    import_for_store_cmd(o, to.access_key(), to.secret_key(), bucket, endpoint)
+}
+
+fn import_for_store_cmd(
+    o: &CommonOpts,
+    access_key: &str,
+    secret_key: &str,
+    bucket: &str,
+    endpoint: &str,
+) -> OpsCommand {
     let script = format!(
         "set -e; {wait}\
          export AWS_DEFAULT_REGION=us-east-1; \
@@ -255,16 +279,11 @@ pub fn import_cmd(o: &CommonOpts, to: StoreKind, bucket: &str, endpoint: &str) -
          aws s3 mb s3://{bucket} --endpoint-url {endpoint} || true; \
          aws s3 sync /stage s3://{bucket} --endpoint-url {endpoint} --only-show-errors; \
          echo synced",
-        wait = await_secret_key(to.secret_key()),
-        access = to.access_key(),
-        secret = to.secret_key(),
+        wait = await_secret_key(secret_key),
+        access = access_key,
+        secret = secret_key,
     );
     exec_cmd(o, &script)
-}
-
-/// Count staged objects, for the before/after comparison.
-pub fn staged_count_cmd(o: &CommonOpts) -> OpsCommand {
-    exec_cmd(o, "find /stage -type f | wc -l")
 }
 
 /// List `<size> <key>` for every object in a store, for a per-object diff.
@@ -278,16 +297,29 @@ pub fn store_listing_cmd(
     bucket: &str,
     endpoint: &str,
 ) -> OpsCommand {
+    store_listing_for_store_cmd(o, store.access_key(), store.secret_key(), bucket, endpoint)
+}
+
+fn store_listing_for_store_cmd(
+    o: &CommonOpts,
+    access_key: &str,
+    secret_key: &str,
+    bucket: &str,
+    endpoint: &str,
+) -> OpsCommand {
     let script = format!(
-        "{wait}export AWS_DEFAULT_REGION=us-east-1; \
+        "set -e; {wait}export AWS_DEFAULT_REGION=us-east-1; \
          aws configure set default.s3.addressing_style path; \
          export AWS_ACCESS_KEY_ID={access}; \
          export AWS_SECRET_ACCESS_KEY=$(cat /secret/{secret}); \
+         listing_raw=$(mktemp /tmp/curie-store-listing.XXXXXX); \
+         trap 'rm -f \"$listing_raw\"' EXIT; \
          aws s3 ls s3://{bucket} --recursive --endpoint-url {endpoint} \
-         | awk '{{print $3, $4}}' | sort",
-        wait = await_secret_key(store.secret_key()),
-        access = store.access_key(),
-        secret = store.secret_key(),
+         > \"$listing_raw\"; \
+         awk '{{print $3, $4}}' \"$listing_raw\" | sort",
+        wait = await_secret_key(secret_key),
+        access = access_key,
+        secret = secret_key,
     );
     exec_cmd(o, &script)
 }
@@ -295,6 +327,49 @@ pub fn store_listing_cmd(
 /// The staged files as `<size> <key>`, comparable with a store listing.
 pub fn staged_listing_cmd(o: &CommonOpts) -> OpsCommand {
     exec_cmd(o, "cd /stage && find . -type f -printf '%s %P\\n' | sort")
+}
+
+/// Capture the final source inventory and the target selected before upgrade.
+pub fn persist_migration_evidence_cmd(
+    o: &CommonOpts,
+    from: StoreKind,
+    to: StoreKind,
+    bucket: &str,
+    endpoint: &str,
+) -> OpsCommand {
+    let script = format!(
+        "set -e; {wait}export AWS_DEFAULT_REGION=us-east-1; \
+         aws configure set default.s3.addressing_style path; \
+         export AWS_ACCESS_KEY_ID={access}; \
+         export AWS_SECRET_ACCESS_KEY=$(cat /secret/{secret}); \
+         source_raw=/migration/source.raw.$$; \
+         source_tmp=/migration/source.list.tmp.$$; \
+         target_tmp=/migration/target.tmp.$$; \
+         trap 'rm -f \"$source_raw\" \"$source_tmp\" \"$target_tmp\"' EXIT; \
+         aws s3 ls s3://{bucket} --recursive --endpoint-url {endpoint} \
+         > \"$source_raw\"; \
+         awk '{{print $3, $4}}' \"$source_raw\" | sort > \"$source_tmp\"; \
+         [ -s \"$source_tmp\" ] || {{ echo 'the final source inventory is empty' >&2; exit 1; }}; \
+         printf '%s\\n' '{target}' > \"$target_tmp\"; \
+         mv \"$target_tmp\" /migration/target; \
+         mv \"$source_tmp\" /migration/source.list; \
+         cat /migration/source.list",
+        wait = await_secret_key(from.secret_key()),
+        access = from.access_key(),
+        secret = from.secret_key(),
+        target = to.suffix(),
+    );
+    exec_cmd(o, &script)
+}
+
+/// Read the target persisted by the export phase.
+pub fn planned_target_cmd(o: &CommonOpts) -> OpsCommand {
+    exec_cmd(o, "set -e; cat /migration/target")
+}
+
+/// Read the final source inventory persisted by the export phase.
+pub fn persisted_source_listing_cmd(o: &CommonOpts) -> OpsCommand {
+    exec_cmd(o, "set -e; cat /migration/source.list")
 }
 
 pub fn delete_staging_pod_cmd(o: &CommonOpts) -> OpsCommand {
@@ -468,11 +543,25 @@ mod tests {
             export_cmd(&o, StoreKind::Minio, "curie-bundles", "http://s:9000"),
             import_cmd(&o, StoreKind::Rustfs, "curie-bundles", "http://s:9000"),
             store_listing_cmd(&o, StoreKind::Minio, "curie-bundles", "http://s:9000"),
+            persist_migration_evidence_cmd(
+                &o,
+                StoreKind::Minio,
+                StoreKind::Rustfs,
+                "curie-bundles",
+                "http://s:9000",
+            ),
         ] {
             let joined = format!("{:?}", cmd.args);
             assert!(
                 joined.contains("/secret/"),
                 "the password must be read from the mounted Secret: {joined}"
+            );
+            assert!(
+                joined
+                    .split("AWS_SECRET_ACCESS_KEY=")
+                    .skip(1)
+                    .all(|assignment| assignment.starts_with("$(cat /secret/")),
+                "every password assignment must read from the mounted Secret: {joined}"
             );
             for leaked in [
                 "minioRootPassword=",
@@ -671,7 +760,7 @@ impl crate::ui::CliOutput for MigrateStoreOutput {
                     ));
                 }
                 if missing.is_empty() {
-                    ui.payload_plain("verified: every staged object is present at the same size");
+                    ui.payload_plain("verified: every source object is present at the same size");
                 } else {
                     ui.payload_plain(&format!("MISSING {} object(s):", missing.len()));
                     for k in missing {
@@ -684,6 +773,117 @@ impl crate::ui::CliOutput for MigrateStoreOutput {
             }
         }
     }
+}
+
+/// Load and validate the destination selected before the destructive upgrade.
+pub async fn read_planned_target(o: &CommonOpts) -> Result<StoreKind> {
+    let (ok, target, err) = crate::ops::run_capture(&planned_target_cmd(o)).await?;
+    if !ok {
+        bail!("could not read the planned migration target from the staging pod: {err}");
+    }
+    let target = target.trim();
+    StoreKind::from_suffix(target).ok_or_else(|| {
+        anyhow::anyhow!(
+            "the planned migration target in the staging pod is {}. Expected `minio` or `rustfs`; staging has been kept.",
+            if target.is_empty() {
+                "empty".to_string()
+            } else {
+                format!("unknown: `{target}`")
+            }
+        )
+    })
+}
+
+async fn read_persisted_source_listing(o: &CommonOpts) -> Result<String> {
+    let (ok, source, err) = crate::ops::run_capture(&persisted_source_listing_cmd(o)).await?;
+    if !ok {
+        bail!(
+            "could not read the final source inventory from the staging pod; staging has been kept: {err}"
+        );
+    }
+    if source.trim().is_empty() {
+        bail!(
+            "the final source inventory in the staging pod is empty; migration safety cannot be verified, so staging has been kept"
+        );
+    }
+    Ok(source)
+}
+
+fn observed_live_store(components: &[String]) -> Result<StoreKind> {
+    let stores: Vec<StoreKind> = [StoreKind::Minio, StoreKind::Rustfs]
+        .into_iter()
+        .filter(|kind| {
+            components
+                .iter()
+                .any(|component| component == kind.suffix())
+        })
+        .collect();
+    match stores.as_slice() {
+        [store] => Ok(*store),
+        [] => bail!(
+            "no object store StatefulSet in the release. Run the upgrade before `--phase import`; staging has been kept."
+        ),
+        _ => bail!(
+            "the live release reports both minio and rustfs object stores, so the migration target is ambiguous; staging has been kept"
+        ),
+    }
+}
+
+fn live_statefulsets_cmd(o: &CommonOpts) -> OpsCommand {
+    OpsCommand::new(
+        "kubectl",
+        vec![
+            plain("get"),
+            plain("statefulset"),
+            plain("-n"),
+            plain(&o.namespace),
+            plain("-o"),
+            plain("json"),
+        ],
+    )
+}
+
+fn standalone_import_dry_run_plan(
+    o: &CommonOpts,
+    bucket: &str,
+    keep_staging: bool,
+) -> MigrateStoreOutput {
+    let endpoint = endpoint_for("<planned-store-service>", &o.namespace);
+    let mut lines = vec![
+        planned_target_cmd(o).display(),
+        live_statefulsets_cmd(o).display(),
+        "verify the live release has exactly one object store and it matches the persisted planned target".to_string(),
+        persisted_source_listing_cmd(o).display(),
+        staged_listing_cmd(o).display(),
+        "verify every persisted source object is present in staging at the same size".to_string(),
+        store_service_for_component_cmd(o, "<planned-target>").display(),
+        import_for_store_cmd(
+            o,
+            "<planned-target-access-key>",
+            "<planned-target-secret-key>",
+            bucket,
+            &endpoint,
+        )
+        .display(),
+        store_listing_for_store_cmd(
+            o,
+            "<planned-target-access-key>",
+            "<planned-target-secret-key>",
+            bucket,
+            &endpoint,
+        )
+        .display(),
+        "verify every persisted source object is present in the planned target at the same size"
+            .to_string(),
+    ];
+    if !keep_staging {
+        lines.push(
+            "delete staging only after source versus planned target verification succeeds"
+                .to_string(),
+        );
+        lines.push(delete_staging_pod_cmd(o).display());
+    }
+    MigrateStoreOutput::DryRun(crate::ui::DryRunPlan { lines })
 }
 
 /// Phase one: stage every object while the old store is still up.
@@ -703,6 +903,15 @@ pub async fn run_export(o: &CommonOpts, chart: &str, bucket: &str) -> Result<Mig
             .collect();
     let (from, to) = ensure_migratable(&plan(&live, &rendered)?)?;
 
+    run_export_with_plan(o, from, to, bucket).await
+}
+
+async fn run_export_with_plan(
+    o: &CommonOpts,
+    from: StoreKind,
+    to: StoreKind,
+    bucket: &str,
+) -> Result<MigrateStoreOutput> {
     let image = "amazon/aws-cli:2.32.6";
     // Discovered, not computed. `<release>-secrets` is only the chart Secret's
     // name when the release name contains the chart name; a default install
@@ -717,7 +926,8 @@ pub async fn run_export(o: &CommonOpts, chart: &str, bucket: &str) -> Result<Mig
             delete_staging_pod_cmd(o),
             create_staging_pod_cmd(o, image, &secret),
             export_cmd(o, from, bucket, &endpoint),
-            staged_count_cmd(o),
+            staged_listing_cmd(o),
+            persist_migration_evidence_cmd(o, from, to, bucket, &endpoint),
         ];
         return Ok(MigrateStoreOutput::DryRun(crate::ui::DryRunPlan {
             lines: cmds.iter().map(|c| c.display()).collect(),
@@ -749,9 +959,13 @@ pub async fn run_export(o: &CommonOpts, chart: &str, bucket: &str) -> Result<Mig
     if !ok {
         bail!("the export copy failed; the old store is untouched: {err}");
     }
-    let (_, count, _) = crate::ops::run_capture(&staged_count_cmd(o)).await?;
-    let objects: usize = count.trim().parse().unwrap_or(0);
-    if objects == 0 {
+    let (ok, staged, err) = crate::ops::run_capture(&staged_listing_cmd(o)).await?;
+    if !ok {
+        bail!(
+            "could not inventory the staged copy; the old store and staging pod remain available: {err}"
+        );
+    }
+    if staged.trim().is_empty() {
         bail!(
             "staged 0 objects from {}. Refusing to call that a successful export -- \
              upgrading now would leave the new store empty. Check --bucket (currently \
@@ -759,6 +973,31 @@ pub async fn run_export(o: &CommonOpts, chart: &str, bucket: &str) -> Result<Mig
             from.suffix()
         );
     }
+    let (ok, source, err) = crate::ops::run_capture(&persist_migration_evidence_cmd(
+        o, from, to, bucket, &endpoint,
+    ))
+    .await?;
+    if !ok {
+        bail!(
+            "could not capture the final source inventory; the old store and staging pod remain available: {err}"
+        );
+    }
+    if source.trim().is_empty() {
+        bail!(
+            "the final source inventory is empty; refusing to upgrade because migration safety cannot be verified"
+        );
+    }
+    let unstaged = missing_after(&source, &staged);
+    if !unstaged.is_empty() {
+        bail!(
+            "the source changed after the export and these objects are absent or resized in staging: {}. Refusing to upgrade; the source and staging pod remain available for a safe retry.",
+            unstaged.join(", ")
+        );
+    }
+    let objects = staged
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .count();
     Ok(MigrateStoreOutput::Exported {
         from: from.suffix().to_string(),
         to: to.suffix().to_string(),
@@ -781,9 +1020,24 @@ pub fn wait_ready_cmd(o: &CommonOpts) -> OpsCommand {
     )
 }
 
-/// Phase two: load the staged objects into the new store and verify per object.
+/// Standalone phase two: read the persisted target, load staging, and verify it.
 pub async fn run_import(
     o: &CommonOpts,
+    bucket: &str,
+    keep_staging: bool,
+) -> Result<MigrateStoreOutput> {
+    if o.dry_run {
+        return Ok(standalone_import_dry_run_plan(o, bucket, keep_staging));
+    }
+
+    let to = read_planned_target(o).await?;
+    run_import_to_planned_target(o, to, bucket, keep_staging).await
+}
+
+/// Load staging into the exact target selected before the destructive upgrade.
+pub async fn run_import_to_planned_target(
+    o: &CommonOpts,
+    to: StoreKind,
     bucket: &str,
     keep_staging: bool,
 ) -> Result<MigrateStoreOutput> {
@@ -792,26 +1046,16 @@ pub async fn run_import(
         .into_iter()
         .map(|(component, _)| component)
         .collect();
-    let to = detect_store(&live).ok_or_else(|| {
-        anyhow::anyhow!(
-            "no object store StatefulSet in the release. Run the upgrade before \
-             `--phase import`."
-        )
-    })?;
-
-    if o.dry_run {
-        let endpoint = endpoint_for("<store-service>", &o.namespace);
-        let cmds = [
-            store_service_cmd(o, to),
-            staged_listing_cmd(o),
-            import_cmd(o, to, bucket, &endpoint),
-            store_listing_cmd(o, to, bucket, &endpoint),
-            delete_staging_pod_cmd(o),
-        ];
-        return Ok(MigrateStoreOutput::DryRun(crate::ui::DryRunPlan {
-            lines: cmds.iter().map(|c| c.display()).collect(),
-        }));
+    let observed = observed_live_store(&live)?;
+    if observed != to {
+        bail!(
+            "the live release runs {}, but the migration planned {}. Refusing to import into a different store; staging has been kept.",
+            observed.suffix(),
+            to.suffix()
+        );
     }
+
+    let source = read_persisted_source_listing(o).await?;
 
     let (ok, service, err) = crate::ops::run_capture(&store_service_cmd(o, to)).await?;
     let service = service.trim().to_string();
@@ -833,22 +1077,39 @@ pub async fn run_import(
     if staged.trim().is_empty() {
         bail!("the staging pod holds no objects; nothing to import");
     }
+    let unstaged = missing_after(&source, &staged);
+    if !unstaged.is_empty() {
+        bail!(
+            "the staged copy is missing or has resized source objects: {}. Refusing to import; staging has been kept.",
+            unstaged.join(", ")
+        );
+    }
     let (ok, _, err) = crate::ops::run_capture(&import_cmd(o, to, bucket, &endpoint)).await?;
     if !ok {
         bail!("the import copy failed; the staged copy is intact, so retry is safe: {err}");
     }
-    let (_, listing, _) =
+    let (ok, listing, err) =
         crate::ops::run_capture(&store_listing_cmd(o, to, bucket, &endpoint)).await?;
+    if !ok {
+        bail!(
+            "could not list the planned {} target after import; staging has been kept: {err}",
+            to.suffix()
+        );
+    }
 
-    let missing = missing_after(&staged, &listing);
-    let added = added_after(&staged, &listing);
+    let missing = missing_after(&source, &listing);
+    let added = added_after(&source, &listing);
     let objects = listing.lines().filter(|l| !l.trim().is_empty()).count();
 
-    // Keep the staging pod whenever anything is missing: it holds the only
-    // remaining copy, and deleting it would turn a recoverable partial import
-    // into permanent loss.
-    let kept = keep_staging || !missing.is_empty();
-    if !kept {
+    if !missing.is_empty() {
+        bail!(
+            "the planned {} target is missing or has resized source objects: {}. Migration is unverified and staging has been kept.",
+            to.suffix(),
+            missing.join(", ")
+        );
+    }
+
+    if !keep_staging {
         crate::ops::run_capture(&delete_staging_pod_cmd(o))
             .await
             .ok();
@@ -856,9 +1117,9 @@ pub async fn run_import(
     Ok(MigrateStoreOutput::Imported {
         store: to.suffix().to_string(),
         objects,
-        missing,
+        missing: vec![],
         added,
-        staging_kept: kept,
+        staging_kept: keep_staging,
     })
 }
 
@@ -973,9 +1234,12 @@ pub async fn run_auto(o: &CommonOpts, chart: &str, bucket: &str) -> Result<Migra
             store_service_cmd(o, from),
             create_staging_pod_cmd(o, image, &secret),
             export_cmd(o, from, bucket, &ep),
+            staged_listing_cmd(o),
+            persist_migration_evidence_cmd(o, from, to, bucket, &ep),
             get_values_cmd(o),
             upgrade_cmd(o, chart, "<captured values>"),
             store_service_cmd(o, to),
+            persisted_source_listing_cmd(o),
             import_cmd(o, to, bucket, &ep),
             store_listing_cmd(o, to, bucket, &ep),
             delete_staging_pod_cmd(o),
@@ -988,7 +1252,7 @@ pub async fn run_auto(o: &CommonOpts, chart: &str, bucket: &str) -> Result<Migra
     let ui = crate::ui::ui();
 
     // 1. Stage, before anything is destroyed.
-    let exported = run_export(o, chart, bucket).await?;
+    let exported = run_export_with_plan(o, from, to, bucket).await?;
     let staged = match &exported {
         MigrateStoreOutput::Exported { objects, .. } => *objects,
         _ => 0,
@@ -1020,7 +1284,7 @@ pub async fn run_auto(o: &CommonOpts, chart: &str, bucket: &str) -> Result<Migra
 
     // 3. Load the staged objects into whatever the upgrade created, and verify.
     ui.note(&format!("importing into {}", to.suffix()));
-    run_import(o, bucket, false).await
+    run_import_to_planned_target(o, to, bucket, false).await
 }
 
 #[cfg(test)]

--- a/cli/tests/installation_plan_parity.rs
+++ b/cli/tests/installation_plan_parity.rs
@@ -2263,6 +2263,95 @@ fn apply_import_failure_names_the_standalone_recovery_command() {
 }
 
 #[test]
+fn migrate_store_source_listing_shell_preserves_a_failed_aws_status() {
+    let fixture = HelmFixture::new(
+        installation_for_the_stateful_guard(),
+        HelmValuesResponse::Absent,
+    );
+    let live = live_minio_statefulset();
+
+    let _ = fixture.apply(
+        &["--migrate-store"],
+        &[
+            ("CURIE_TEST_KUBECTL_STS", live.as_str()),
+            ("CURIE_TEST_SOURCE_LIST_FAIL", "1"),
+        ],
+    );
+
+    let script = fixture.last_exec_script();
+    assert!(
+        script.contains("aws s3 ls")
+            && script.contains("parity-minio.parity.svc.cluster.local")
+            && script.contains("/migration/source.list"),
+        "the public CLI must expose the source evidence shell to the kubectl surface: {script}"
+    );
+
+    let shell_bin = fixture.temp.path().join("source-listing-shell-bin");
+    fs::create_dir(&shell_bin).expect("create source listing shell bin directory");
+    let aws_log = fixture.temp.path().join("source-aws-calls.log");
+    write_exec(
+        &shell_bin,
+        "aws",
+        r#"#!/bin/sh
+printf '%s\n' "$*" >> "$CURIE_TEST_AWS_LOG"
+if [ "$1" = configure ]; then
+    exit 0
+fi
+if [ "$1" = s3 ] && [ "$2" = ls ]; then
+    printf '%s\n' 'forced aws source listing failure' >&2
+    exit 42
+fi
+printf 'unexpected aws invocation: %s\n' "$*" >&2
+exit 64
+"#,
+    );
+    write_exec(
+        &shell_bin,
+        "cat",
+        "#!/bin/sh\nprintf '%s\\n' 'fixture-secret'\n",
+    );
+    write_exec(&shell_bin, "[", "#!/bin/sh\nexit 0\n");
+    let source_raw = fixture.temp.path().join("source.raw");
+    let source_tmp = fixture.temp.path().join("source.list.tmp");
+    let target_tmp = fixture.temp.path().join("target.tmp");
+    let bash_env = fixture.temp.path().join("source-listing-bash-env");
+    fs::write(
+        &bash_env,
+        "enable -n [\ntrap 'source_raw=\"$CURIE_TEST_SOURCE_RAW\"; source_tmp=\"$CURIE_TEST_SOURCE_TMP\"; target_tmp=\"$CURIE_TEST_TARGET_TMP\"' DEBUG\n",
+    )
+    .expect("write source listing bash environment");
+    let mut paths = vec![shell_bin];
+    if let Some(current) = std::env::var_os("PATH") {
+        paths.extend(std::env::split_paths(&current));
+    }
+    let path = std::env::join_paths(paths).expect("join source listing shell PATH");
+
+    let shell_output = Command::new("bash")
+        .arg("-c")
+        .arg(&script)
+        .env("BASH_ENV", &bash_env)
+        .env("PATH", path)
+        .env("CURIE_TEST_AWS_LOG", &aws_log)
+        .env("CURIE_TEST_SOURCE_RAW", &source_raw)
+        .env("CURIE_TEST_SOURCE_TMP", &source_tmp)
+        .env("CURIE_TEST_TARGET_TMP", &target_tmp)
+        .output()
+        .expect("execute the generated source listing shell");
+    let aws_calls = fs::read_to_string(&aws_log).expect("read fake source aws calls");
+    assert!(
+        aws_calls.lines().any(|line| line.starts_with("s3 ls ")),
+        "the generated source shell must reach the failing aws listing:\n{aws_calls}"
+    );
+    assert_eq!(
+        shell_output.status.code(),
+        Some(42),
+        "the exact generated source shell must preserve aws exit 42; stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&shell_output.stdout),
+        String::from_utf8_lossy(&shell_output.stderr)
+    );
+}
+
+#[test]
 fn migrate_store_listing_shell_preserves_a_failed_aws_status() {
     let fixture = HelmFixture::new(
         installation_for_the_stateful_guard(),

--- a/cli/tests/installation_plan_parity.rs
+++ b/cli/tests/installation_plan_parity.rs
@@ -95,6 +95,8 @@ struct HelmFixture {
     file: PathBuf,
     values_response: HelmValuesResponse,
     log: PathBuf,
+    migration_state: PathBuf,
+    last_exec_script: PathBuf,
 }
 
 impl HelmFixture {
@@ -250,6 +252,14 @@ if [ -n "${{CURIE_TEST_CALL_LOG:-}}" ]; then
     printf 'KUBECTL_CALL: %s\n' "$*" >> "$CURIE_TEST_CALL_LOG"
 fi
 all="$*"
+script=""
+previous=""
+for argument in "$@"; do
+    if [ "$previous" = '-c' ]; then
+        script="$argument"
+    fi
+    previous="$argument"
+done
 verb=""
 object=""
 while [ $# -gt 0 ]; do
@@ -271,6 +281,27 @@ unexpected() {{
     printf 'unexpected kubectl invocation: %s\n' "$all" >&2
     exit 64
 }}
+migration_target="$CURIE_TEST_MIGRATION_STATE/target"
+migration_source="$CURIE_TEST_MIGRATION_STATE/source.list"
+persist_target() {{
+    target=$(printf '%s\n' "$script" | sed -n "s/.*printf '%s\\\\n' '\\(minio\\|rustfs\\)' > .*/\\1/p")
+    case "$target" in
+        minio|rustfs) printf '%s\n' "$target" > "$migration_target" ;;
+        *) unexpected ;;
+    esac
+}}
+persist_source() {{
+    if [ "${{CURIE_TEST_SOURCE_LIST_FAIL:-}}" = 1 ]; then
+        printf '%s\n' 'source listing failed' >&2
+        exit 1
+    fi
+    if [ -n "${{CURIE_TEST_SOURCE_LIST+x}}" ]; then
+        printf '%s\n' "$CURIE_TEST_SOURCE_LIST" > "$migration_source"
+    else
+        printf '%s\n' '{STAGED_OBJECT}' > "$migration_source"
+    fi
+    cat "$migration_source"
+}}
 case "$verb $object" in
 'get priorityclass')
     # Empty stdout with exit 0 is kubectl --ignore-not-found for an absent class.
@@ -288,7 +319,10 @@ case "$verb $object" in
         printf '%s\n' '{KUBECTL_FORBIDDEN}' >&2
         exit 1
     fi
-    if [ -n "${{CURIE_TEST_KUBECTL_STS:-}}" ]; then
+    if [ -n "${{CURIE_TEST_KUBECTL_STS_AFTER_UPGRADE:-}}" ] &&
+       grep -q '^HELM_CALL: upgrade ' "$CURIE_TEST_CALL_LOG"; then
+        printf '%s\n' "$CURIE_TEST_KUBECTL_STS_AFTER_UPGRADE"
+    elif [ -n "${{CURIE_TEST_KUBECTL_STS:-}}" ]; then
         printf '%s\n' "$CURIE_TEST_KUBECTL_STS"
     else
         printf '%s\n' '{KUBECTL_EMPTY_LIST}'
@@ -306,18 +340,83 @@ case "$verb $object" in
 'get secret')
     printf '%s\n' "${{CURIE_TEST_RELEASE_SECRET:-parity-secrets}}"
     ;;
-'run '*|'wait '*|'delete pod')
-    # Staging-pod lifecycle: nothing to say, just succeed.
-    : ;;
+'run '*)
+    mkdir -p "$CURIE_TEST_MIGRATION_STATE"
+    ;;
+'wait '*)
+    :
+    ;;
+'delete pod')
+    case "$all" in
+        *store-migration*) rm -f "$migration_target" "$migration_source" ;;
+    esac
+    ;;
 'exec '*)
+    printf '%s' "$script" > "$CURIE_TEST_LAST_EXEC_SCRIPT"
     # One answer per in-pod script the migration runs, keyed on the script
     # itself: a single canned answer here would let the export and the verify
     # read each other's output.
-    case "$all" in
+    case "$script" in
+        *'aws s3 ls'*'/migration/source.list'*|*'/migration/source.list'*'aws s3 ls'*)
+            persist_source
+            case "$script" in
+                *'/migration/target'*) persist_target ;;
+            esac
+            ;;
+        *'printf'*'/migration/target'*|*'echo '*'/migration/target'*)
+            persist_target
+            ;;
+        *'cat /migration/target'*)
+            if [ ! -s "$migration_target" ]; then
+                printf '%s\n' 'planned migration target is missing' >&2
+                exit 1
+            fi
+            cat "$migration_target"
+            ;;
+        *'cat /migration/source.list'*)
+            if [ ! -s "$migration_source" ]; then
+                printf '%s\n' 'persisted source inventory is missing' >&2
+                exit 1
+            fi
+            cat "$migration_source"
+            ;;
         *'wc -l'*) printf '%s\n' '1' ;;
-        *'-printf'*) printf '%s\n' '{STAGED_OBJECT}' ;;
-        *'aws s3 ls'*) printf '%s\n' '{STAGED_OBJECT}' ;;
+        *'-printf'*)
+            if [ -n "${{CURIE_TEST_STAGED_LIST+x}}" ]; then
+                printf '%s\n' "$CURIE_TEST_STAGED_LIST"
+            else
+                printf '%s\n' '{STAGED_OBJECT}'
+            fi
+            ;;
+        *'aws s3 ls'*)
+            case "$script" in
+                *'parity-minio.parity.svc.cluster.local'*)
+                    if [ "${{CURIE_TEST_SOURCE_LIST_FAIL:-}}" = 1 ]; then
+                        printf '%s\n' 'source listing failed' >&2
+                        exit 1
+                    fi
+                    if [ -n "${{CURIE_TEST_SOURCE_LIST+x}}" ]; then
+                        printf '%s\n' "$CURIE_TEST_SOURCE_LIST"
+                    else
+                        printf '%s\n' '{STAGED_OBJECT}'
+                    fi
+                    ;;
+                *'parity-rustfs.parity.svc.cluster.local'*)
+                    if [ "${{CURIE_TEST_TARGET_LIST_FAIL:-}}" = 1 ]; then
+                        printf '%s\n' 'target listing failed' >&2
+                        exit 1
+                    fi
+                    if [ -n "${{CURIE_TEST_TARGET_LIST+x}}" ]; then
+                        printf '%s\n' "$CURIE_TEST_TARGET_LIST"
+                    else
+                        printf '%s\n' '{STAGED_OBJECT}'
+                    fi
+                    ;;
+                *) unexpected ;;
+            esac
+            ;;
         *'aws s3 sync'*) printf '%s\n' 'synced' ;;
+        *'/migration/'*) unexpected ;;
         *) unexpected ;;
     esac
     ;;
@@ -331,11 +430,16 @@ exit 0
         );
 
         let log = temp.path().join("calls.log");
+        let migration_state = temp.path().join("migration");
+        fs::create_dir(&migration_state).expect("create migration state directory");
+        let last_exec_script = temp.path().join("last-exec-script");
         Self {
             temp,
             file,
             values_response,
             log,
+            migration_state,
+            last_exec_script,
         }
     }
 
@@ -345,6 +449,28 @@ exit 0
     /// than panicking.
     fn calls(&self) -> String {
         fs::read_to_string(&self.log).unwrap_or_default()
+    }
+
+    fn seed_migration_evidence(&self, target: &str, source: &str) {
+        fs::write(self.migration_state.join("target"), format!("{target}\n"))
+            .expect("write planned migration target");
+        fs::write(
+            self.migration_state.join("source.list"),
+            format!("{source}\n"),
+        )
+        .expect("write persisted source inventory");
+    }
+
+    fn migration_target(&self) -> Option<String> {
+        fs::read_to_string(self.migration_state.join("target")).ok()
+    }
+
+    fn migration_source(&self) -> Option<String> {
+        fs::read_to_string(self.migration_state.join("source.list")).ok()
+    }
+
+    fn last_exec_script(&self) -> String {
+        fs::read_to_string(&self.last_exec_script).expect("captured in pod shell")
     }
 
     fn run(&self, args: &[&str], env: &[(&str, &str)]) -> Output {
@@ -361,11 +487,19 @@ exit 0
             .args(args)
             .env("PATH", path)
             .env("CURIE_TEST_CALL_LOG", &self.log)
+            .env("CURIE_TEST_MIGRATION_STATE", &self.migration_state)
+            .env("CURIE_TEST_LAST_EXEC_SCRIPT", &self.last_exec_script)
             .env_remove("CURIE_TEST_KUBECTL_STS")
+            .env_remove("CURIE_TEST_KUBECTL_STS_AFTER_UPGRADE")
             .env_remove("CURIE_TEST_KUBECTL_FAIL")
             .env_remove("CURIE_TEST_KUBECTL_FORBIDDEN")
             .env_remove("CURIE_TEST_HELM_MIXED_STATEFULSETS")
             .env_remove("CURIE_TEST_RELEASE_SECRET")
+            .env_remove("CURIE_TEST_SOURCE_LIST_FAIL")
+            .env_remove("CURIE_TEST_SOURCE_LIST")
+            .env_remove("CURIE_TEST_STAGED_LIST")
+            .env_remove("CURIE_TEST_TARGET_LIST_FAIL")
+            .env_remove("CURIE_TEST_TARGET_LIST")
             .env_remove("CURIE_CREDENTIALS")
             .env_remove("CURIE_MODEL_CREDENTIALS")
             .env_remove("CURIE_GITHUB_TOKEN")
@@ -664,6 +798,36 @@ fn live_mixed_store_statefulsets() -> String {
             {
                 "metadata": {"name": "parity-clickhouse"},
                 "spec": {"selector": {"matchLabels": {"app.kubernetes.io/component": "clickhouse"}}}
+            }
+        ]
+    })
+    .to_string()
+}
+
+fn live_rustfs_statefulset() -> String {
+    json!({
+        "apiVersion": "v1",
+        "kind": "List",
+        "items": [{
+            "metadata": {"name": "parity-rustfs"},
+            "spec": {"selector": {"matchLabels": {"app.kubernetes.io/component": "rustfs"}}}
+        }]
+    })
+    .to_string()
+}
+
+fn live_both_store_statefulsets() -> String {
+    json!({
+        "apiVersion": "v1",
+        "kind": "List",
+        "items": [
+            {
+                "metadata": {"name": "parity-minio"},
+                "spec": {"selector": {"matchLabels": {"app.kubernetes.io/component": "minio"}}}
+            },
+            {
+                "metadata": {"name": "parity-rustfs"},
+                "spec": {"selector": {"matchLabels": {"app.kubernetes.io/component": "rustfs"}}}
             }
         ]
     })
@@ -1409,10 +1573,15 @@ fn migrate_store_alone_still_migrates() {
         installation_for_the_stateful_guard(),
         HelmValuesResponse::Absent,
     );
+    let live_before = live_minio_statefulset();
+    let live_after = live_rustfs_statefulset();
 
     let output = fixture.apply(
         &["--migrate-store"],
-        &[("CURIE_TEST_KUBECTL_STS", &live_minio_statefulset())],
+        &[
+            ("CURIE_TEST_KUBECTL_STS", live_before.as_str()),
+            ("CURIE_TEST_KUBECTL_STS_AFTER_UPGRADE", live_after.as_str()),
+        ],
     );
 
     let calls = fixture.calls();
@@ -1441,19 +1610,741 @@ fn migrate_store_alone_still_migrates() {
     // The export must be COMPLETE before the upgrade deletes the old store, and
     // the import must run after it. Staging alone, then upgrading, is the
     // failure mode that empties the store.
+    let exported = calls
+        .find("aws s3 sync s3://curie-bundles /stage")
+        .unwrap_or_else(|| panic!("the export must copy the source into staging:\n{calls}"));
     let staged = calls
-        .find("find /stage -type f | wc -l")
-        .unwrap_or_else(|| panic!("the export must count what it staged:\n{calls}"));
+        .find("find . -type f -printf")
+        .unwrap_or_else(|| panic!("the export must inventory what it staged:\n{calls}"));
+    let source_capture = calls
+        .find("aws s3 ls s3://curie-bundles --recursive --endpoint-url http://parity-minio.parity.svc.cluster.local:9000")
+        .unwrap_or_else(|| panic!("the export must capture the final source inventory:\n{calls}"));
     let imported = calls
         .find("aws s3 sync /stage")
         .unwrap_or_else(|| panic!("the import must load the staged objects back:\n{calls}"));
     assert!(
-        staged < upgrade && upgrade < imported,
+        exported < staged && staged < upgrade && upgrade < imported,
         "the export completes before the upgrade and the import runs after it:\n{calls}"
     );
+    let source_read = upgrade
+        + calls[upgrade..]
+            .find("/migration/source.list")
+            .unwrap_or_else(|| {
+                panic!("the import must read the persisted source inventory:\n{calls}")
+            });
+    let target_listing = calls
+        .find("aws s3 ls s3://curie-bundles --recursive --endpoint-url http://parity-rustfs.parity.svc.cluster.local:9000")
+        .unwrap_or_else(|| panic!("the migration must verify the planned target:\n{calls}"));
+    let released = calls
+        .rfind("KUBECTL_CALL: delete pod")
+        .unwrap_or_else(|| panic!("a verified migration must release staging:\n{calls}"));
     assert!(
-        calls.contains("KUBECTL_CALL: delete pod"),
+        target_listing < released,
         "a verified migration releases the staging pod:\n{calls}"
+    );
+    assert!(
+        exported < source_capture
+            && source_capture < upgrade
+            && upgrade < source_read
+            && source_read < target_listing
+            && target_listing < released,
+        "the safe path must export, capture source evidence, upgrade, read that evidence, verify the target, then release staging:\n{calls}"
+    );
+}
+
+#[test]
+fn migrate_store_refuses_a_live_store_that_disagrees_with_the_planned_target() {
+    let fixture = HelmFixture::new(
+        installation_for_the_stateful_guard(),
+        HelmValuesResponse::Absent,
+    );
+    let live_before = live_minio_statefulset();
+    let live_after = live_minio_statefulset();
+
+    let output = fixture.apply(
+        &["--migrate-store"],
+        &[
+            ("CURIE_TEST_KUBECTL_STS", live_before.as_str()),
+            ("CURIE_TEST_KUBECTL_STS_AFTER_UPGRADE", live_after.as_str()),
+        ],
+    );
+
+    let calls = fixture.calls();
+    let upgrade = calls
+        .find("HELM_CALL: upgrade")
+        .unwrap_or_else(|| panic!("the migration must reach the planned upgrade:\n{calls}"));
+    assert!(
+        !output.status.success(),
+        "a live minio store cannot satisfy the planned rustfs target; stdout:\n{}\nstderr:\n{}\ncalls:\n{calls}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !calls[upgrade..].contains("aws s3 sync /stage"),
+        "the migration must not import into the detected old store:\n{calls}"
+    );
+    assert!(
+        !calls[upgrade..].contains("KUBECTL_CALL: delete pod"),
+        "a target disagreement must retain the staged copy:\n{calls}"
+    );
+}
+
+#[test]
+fn migrate_store_standalone_import_dry_run_reads_no_live_state() {
+    let fixture = HelmFixture::new(
+        installation_for_the_stateful_guard(),
+        HelmValuesResponse::Absent,
+    );
+
+    let output = fixture.run(
+        &[
+            "cluster",
+            "migrate-store",
+            "--phase",
+            "import",
+            "--namespace",
+            "parity",
+            "--release",
+            "parity",
+            "--dry-run",
+        ],
+        &[],
+    );
+
+    let calls = fixture.calls();
+    assert!(
+        calls.is_empty(),
+        "standalone import dry run must not read the cluster or persisted state:\n{calls}"
+    );
+    let json = json_output(output, "cluster migrate-store --phase import --dry-run");
+    let plan = json["plan"]
+        .as_array()
+        .expect("standalone import dry run plan array");
+    assert!(
+        plan.iter()
+            .filter_map(Value::as_str)
+            .any(|line| line.contains("cat /migration/target")),
+        "the plan must show the persisted target read: {json}"
+    );
+    assert!(
+        plan.iter()
+            .filter_map(Value::as_str)
+            .any(|line| line.contains("cat /migration/source.list")),
+        "the plan must show the persisted source proof read: {json}"
+    );
+}
+
+#[test]
+fn migrate_store_split_export_then_import_uses_persisted_evidence() {
+    let fixture = HelmFixture::new(
+        installation_for_the_stateful_guard(),
+        HelmValuesResponse::Absent,
+    );
+    let chart = repo_root().join("charts/curie");
+    let live_before = live_minio_statefulset();
+    let inventory = "100 bundle.tar\n200 second_bundle.tar";
+
+    let exported = fixture.run(
+        &[
+            "cluster",
+            "migrate-store",
+            "--phase",
+            "export",
+            "--namespace",
+            "parity",
+            "--release",
+            "parity",
+            "--chart",
+            chart.to_str().expect("UTF 8 chart path"),
+        ],
+        &[
+            ("CURIE_TEST_KUBECTL_STS", live_before.as_str()),
+            ("CURIE_TEST_SOURCE_LIST", inventory),
+            ("CURIE_TEST_STAGED_LIST", inventory),
+        ],
+    );
+
+    let export_json = json_output(exported, "cluster migrate-store --phase export");
+    assert_eq!(export_json["phase"], "export", "{export_json}");
+    assert_eq!(export_json["to"], "rustfs", "{export_json}");
+    assert_eq!(export_json["objects"], 2, "{export_json}");
+    assert_eq!(
+        fixture.migration_target().as_deref(),
+        Some("rustfs\n"),
+        "export must persist its planned target for a later process"
+    );
+    assert_eq!(
+        fixture.migration_source().as_deref(),
+        Some("100 bundle.tar\n200 second_bundle.tar\n"),
+        "export must persist its final source inventory for a later process"
+    );
+
+    let before_import = fixture.calls().len();
+    let live_after = live_rustfs_statefulset();
+    let imported = fixture.run(
+        &[
+            "cluster",
+            "migrate-store",
+            "--phase",
+            "import",
+            "--namespace",
+            "parity",
+            "--release",
+            "parity",
+        ],
+        &[
+            ("CURIE_TEST_KUBECTL_STS", live_after.as_str()),
+            ("CURIE_TEST_STAGED_LIST", inventory),
+            ("CURIE_TEST_TARGET_LIST", inventory),
+        ],
+    );
+
+    let import_json = json_output(imported, "cluster migrate-store --phase import");
+    assert_eq!(import_json["phase"], "import", "{import_json}");
+    assert_eq!(import_json["store"], "rustfs", "{import_json}");
+    assert_eq!(import_json["objects"], 2, "{import_json}");
+    assert_eq!(import_json["verified"], true, "{import_json}");
+    assert_eq!(import_json["staging_kept"], false, "{import_json}");
+    let calls = fixture.calls();
+    let import_calls = &calls[before_import..];
+    assert!(
+        import_calls.contains("/migration/target"),
+        "the second process must read the target exported by the first:\n{import_calls}"
+    );
+    assert!(
+        import_calls.contains("/migration/source.list"),
+        "the second process must read the source inventory exported by the first:\n{import_calls}"
+    );
+    assert!(
+        import_calls.contains("http://parity-rustfs.parity.svc.cluster.local:9000"),
+        "the second process must import into the persisted rustfs target:\n{import_calls}"
+    );
+    assert!(
+        fixture.migration_target().is_none() && fixture.migration_source().is_none(),
+        "verified import may release the staging pod and its evidence"
+    );
+}
+
+#[test]
+fn migrate_store_standalone_import_refuses_a_detected_store_that_disagrees_with_the_plan() {
+    let fixture = HelmFixture::new(
+        installation_for_the_stateful_guard(),
+        HelmValuesResponse::Absent,
+    );
+    fixture.seed_migration_evidence("rustfs", STAGED_OBJECT);
+    let live = live_minio_statefulset();
+
+    let output = fixture.run(
+        &[
+            "cluster",
+            "migrate-store",
+            "--phase",
+            "import",
+            "--namespace",
+            "parity",
+            "--release",
+            "parity",
+        ],
+        &[("CURIE_TEST_KUBECTL_STS", live.as_str())],
+    );
+
+    let calls = fixture.calls();
+    let error = json_error(output, "cluster migrate-store --phase import");
+    let message = error["error"].as_str().expect("error message string");
+    assert!(
+        message.contains("rustfs") && message.contains("minio"),
+        "the refusal must name the planned and detected stores: {error}"
+    );
+    assert!(
+        calls.contains("/migration/target"),
+        "standalone import must read the persisted plan:\n{calls}"
+    );
+    assert!(
+        !calls.contains("KUBECTL_CALL: get svc")
+            && !calls.contains("aws s3 sync /stage")
+            && !calls.contains("KUBECTL_CALL: delete pod"),
+        "a plan disagreement must stop before target lookup, import, or staging deletion:\n{calls}"
+    );
+    assert_eq!(
+        fixture.migration_target().as_deref(),
+        Some("rustfs\n"),
+        "a target disagreement must retain the persisted plan"
+    );
+    assert_eq!(
+        fixture.migration_source().as_deref(),
+        Some("100 bundle.tar\n"),
+        "a target disagreement must retain the persisted source proof"
+    );
+}
+
+#[test]
+fn migrate_store_standalone_import_refuses_an_unknown_persisted_target() {
+    let fixture = HelmFixture::new(
+        installation_for_the_stateful_guard(),
+        HelmValuesResponse::Absent,
+    );
+    fixture.seed_migration_evidence("seaweedfs", STAGED_OBJECT);
+    let live = live_rustfs_statefulset();
+
+    let output = fixture.run(
+        &[
+            "cluster",
+            "migrate-store",
+            "--phase",
+            "import",
+            "--namespace",
+            "parity",
+            "--release",
+            "parity",
+        ],
+        &[("CURIE_TEST_KUBECTL_STS", live.as_str())],
+    );
+
+    let calls = fixture.calls();
+    let error = json_error(output, "cluster migrate-store --phase import");
+    let message = error["error"].as_str().expect("error message string");
+    assert!(
+        message.contains("unknown") && message.contains("seaweedfs"),
+        "the refusal must name the malformed persisted target: {error}"
+    );
+    assert!(
+        !calls.contains("aws s3 sync /stage") && !calls.contains("KUBECTL_CALL: delete pod"),
+        "an unknown target must stop before import or staging deletion:\n{calls}"
+    );
+    assert_eq!(
+        fixture.migration_target().as_deref(),
+        Some("seaweedfs\n"),
+        "an unknown target must retain the persisted evidence"
+    );
+    assert_eq!(
+        fixture.migration_source().as_deref(),
+        Some("100 bundle.tar\n"),
+        "an unknown target must retain the source proof"
+    );
+}
+
+#[test]
+fn migrate_store_standalone_import_refuses_both_live_stores() {
+    let fixture = HelmFixture::new(
+        installation_for_the_stateful_guard(),
+        HelmValuesResponse::Absent,
+    );
+    fixture.seed_migration_evidence("rustfs", STAGED_OBJECT);
+    let live = live_both_store_statefulsets();
+
+    let output = fixture.run(
+        &[
+            "cluster",
+            "migrate-store",
+            "--phase",
+            "import",
+            "--namespace",
+            "parity",
+            "--release",
+            "parity",
+        ],
+        &[("CURIE_TEST_KUBECTL_STS", live.as_str())],
+    );
+
+    let calls = fixture.calls();
+    let error = json_error(output, "cluster migrate-store --phase import");
+    let message = error["error"].as_str().expect("error message string");
+    assert!(
+        message.contains("both minio and rustfs"),
+        "the refusal must name the ambiguous live stores: {error}"
+    );
+    assert!(
+        !calls.contains("KUBECTL_CALL: get svc")
+            && !calls.contains("aws s3 sync /stage")
+            && !calls.contains("KUBECTL_CALL: delete pod"),
+        "ambiguous live stores must stop before target lookup, import, or staging deletion:\n{calls}"
+    );
+    assert_eq!(
+        fixture.migration_target().as_deref(),
+        Some("rustfs\n"),
+        "ambiguous live stores must retain the persisted plan"
+    );
+    assert_eq!(
+        fixture.migration_source().as_deref(),
+        Some("100 bundle.tar\n"),
+        "ambiguous live stores must retain the source proof"
+    );
+}
+
+#[test]
+fn migrate_store_requires_a_successful_source_listing_before_deleting_staging() {
+    let fixture = HelmFixture::new(
+        installation_for_the_stateful_guard(),
+        HelmValuesResponse::Absent,
+    );
+    let live_before = live_minio_statefulset();
+    let live_after = live_rustfs_statefulset();
+
+    let output = fixture.apply(
+        &["--migrate-store"],
+        &[
+            ("CURIE_TEST_KUBECTL_STS", live_before.as_str()),
+            ("CURIE_TEST_KUBECTL_STS_AFTER_UPGRADE", live_after.as_str()),
+            ("CURIE_TEST_SOURCE_LIST_FAIL", "1"),
+        ],
+    );
+
+    let calls = fixture.calls();
+    let source_listing = calls
+        .find("aws s3 ls s3://curie-bundles --recursive --endpoint-url http://parity-minio.parity.svc.cluster.local:9000")
+        .unwrap_or_else(|| panic!("verification must list the planned source store:\n{calls}"));
+    assert!(
+        !output.status.success(),
+        "a failed source listing leaves the migration unverified; stdout:\n{}\nstderr:\n{}\ncalls:\n{calls}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let reported = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        reported.contains("source listing failed"),
+        "the source listing failure must remain diagnosable:\n{reported}"
+    );
+    assert!(
+        !calls.contains("HELM_CALL: upgrade"),
+        "a failed final source inventory must stop before the destructive upgrade:\n{calls}"
+    );
+    assert!(
+        !calls[source_listing..].contains("KUBECTL_CALL: delete pod"),
+        "a failed source listing must retain the staged copy:\n{calls}"
+    );
+}
+
+#[test]
+fn migrate_store_refuses_a_late_source_object_before_the_upgrade() {
+    let fixture = HelmFixture::new(
+        installation_for_the_stateful_guard(),
+        HelmValuesResponse::Absent,
+    );
+    let live_before = live_minio_statefulset();
+    let live_after = live_rustfs_statefulset();
+
+    let output = fixture.apply(
+        &["--migrate-store"],
+        &[
+            ("CURIE_TEST_KUBECTL_STS", live_before.as_str()),
+            ("CURIE_TEST_KUBECTL_STS_AFTER_UPGRADE", live_after.as_str()),
+            (
+                "CURIE_TEST_SOURCE_LIST",
+                "100 bundle.tar\n200 late_bundle.tar",
+            ),
+            ("CURIE_TEST_STAGED_LIST", STAGED_OBJECT),
+        ],
+    );
+
+    let calls = fixture.calls();
+    let source_listing = calls
+        .find("aws s3 ls s3://curie-bundles --recursive --endpoint-url http://parity-minio.parity.svc.cluster.local:9000")
+        .unwrap_or_else(|| panic!("the export must capture the final source inventory:\n{calls}"));
+    assert!(
+        calls[..source_listing].contains("aws s3 sync s3://curie-bundles /stage"),
+        "the late write check must follow the export copy:\n{calls}"
+    );
+    assert!(
+        !output.status.success(),
+        "a source object absent from staging must refuse the migration; stdout:\n{}\nstderr:\n{}\ncalls:\n{calls}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let reported = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        reported.contains("late_bundle.tar"),
+        "the late source object must be named in the refusal:\n{reported}"
+    );
+    assert!(
+        !calls.contains("HELM_CALL: upgrade") && !calls.contains("aws s3 sync /stage"),
+        "a source versus staging mismatch must stop before upgrade and import:\n{calls}"
+    );
+    assert_eq!(
+        fixture.migration_source().as_deref(),
+        Some("100 bundle.tar\n200 late_bundle.tar\n"),
+        "the failed preupgrade check must retain its final source evidence"
+    );
+}
+
+#[test]
+fn migrate_store_keeps_staging_when_the_target_omits_a_source_object() {
+    let fixture = HelmFixture::new(
+        installation_for_the_stateful_guard(),
+        HelmValuesResponse::Absent,
+    );
+    let live_before = live_minio_statefulset();
+    let live_after = live_rustfs_statefulset();
+
+    let output = fixture.apply(
+        &["--migrate-store"],
+        &[
+            ("CURIE_TEST_KUBECTL_STS", live_before.as_str()),
+            ("CURIE_TEST_KUBECTL_STS_AFTER_UPGRADE", live_after.as_str()),
+            (
+                "CURIE_TEST_SOURCE_LIST",
+                "100 bundle.tar\n200 late_bundle.tar",
+            ),
+            (
+                "CURIE_TEST_STAGED_LIST",
+                "100 bundle.tar\n200 late_bundle.tar",
+            ),
+            ("CURIE_TEST_TARGET_LIST", STAGED_OBJECT),
+        ],
+    );
+
+    let calls = fixture.calls();
+    let source_listing = calls
+        .find("aws s3 ls s3://curie-bundles --recursive --endpoint-url http://parity-minio.parity.svc.cluster.local:9000")
+        .unwrap_or_else(|| panic!("verification must list the planned source store:\n{calls}"));
+    let target_listing = calls
+        .find("aws s3 ls s3://curie-bundles --recursive --endpoint-url http://parity-rustfs.parity.svc.cluster.local:9000")
+        .unwrap_or_else(|| panic!("verification must list the planned target store:\n{calls}"));
+    assert!(
+        source_listing < target_listing,
+        "verification must compare the source snapshot with the target result:\n{calls}"
+    );
+    let upgrade = calls.find("HELM_CALL: upgrade").unwrap_or_else(|| {
+        panic!("equal source and staging inventories must reach the upgrade:\n{calls}")
+    });
+    assert!(
+        upgrade < target_listing,
+        "the target mismatch must be detected after the safe preupgrade check:\n{calls}"
+    );
+    assert!(
+        !output.status.success(),
+        "a target missing a source object must be unverified; stdout:\n{}\nstderr:\n{}\ncalls:\n{calls}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let reported = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        reported.contains("late_bundle.tar"),
+        "the unsafe target object must be named in the failure:\n{reported}"
+    );
+    assert!(
+        !calls[target_listing..].contains("KUBECTL_CALL: delete pod"),
+        "an incomplete target must retain the staged copy:\n{calls}"
+    );
+    assert_eq!(
+        fixture.migration_source().as_deref(),
+        Some("100 bundle.tar\n200 late_bundle.tar\n"),
+        "failed target verification must retain the persisted source proof"
+    );
+}
+
+#[test]
+fn migrate_store_import_exits_nonzero_when_the_target_listing_fails() {
+    let fixture = HelmFixture::new(
+        installation_for_the_stateful_guard(),
+        HelmValuesResponse::Absent,
+    );
+    fixture.seed_migration_evidence("rustfs", STAGED_OBJECT);
+    let live = live_rustfs_statefulset();
+
+    let output = fixture.run(
+        &[
+            "cluster",
+            "migrate-store",
+            "--phase",
+            "import",
+            "--namespace",
+            "parity",
+            "--release",
+            "parity",
+        ],
+        &[
+            ("CURIE_TEST_KUBECTL_STS", live.as_str()),
+            ("CURIE_TEST_TARGET_LIST_FAIL", "1"),
+        ],
+    );
+
+    let calls = fixture.calls();
+    assert!(
+        calls.contains("/migration/target") && calls.contains("/migration/source.list"),
+        "standalone import must use the persisted plan and source proof:\n{calls}"
+    );
+    assert!(
+        calls.contains("aws s3 ls s3://curie-bundles --recursive --endpoint-url http://parity-rustfs.parity.svc.cluster.local:9000"),
+        "the import must attempt target verification:\n{calls}"
+    );
+    assert!(
+        !output.status.success(),
+        "a failed target listing must not report a verified migration; stdout:\n{}\nstderr:\n{}\ncalls:\n{calls}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let reported = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        reported.contains("target listing failed"),
+        "the target listing failure must remain diagnosable:\n{reported}"
+    );
+    assert!(
+        !calls.contains("KUBECTL_CALL: delete pod"),
+        "failed target verification must retain the staged copy:\n{calls}"
+    );
+    assert_eq!(
+        fixture.migration_target().as_deref(),
+        Some("rustfs\n"),
+        "failed target verification must retain the planned target"
+    );
+    assert_eq!(
+        fixture.migration_source().as_deref(),
+        Some("100 bundle.tar\n"),
+        "failed target verification must retain the source proof"
+    );
+}
+
+#[test]
+fn apply_import_failure_names_the_standalone_recovery_command() {
+    let fixture = HelmFixture::new(
+        installation_for_the_stateful_guard(),
+        HelmValuesResponse::Absent,
+    );
+    let live_before = live_minio_statefulset();
+    let live_after = live_rustfs_statefulset();
+
+    let output = fixture.apply(
+        &["--migrate-store"],
+        &[
+            ("CURIE_TEST_KUBECTL_STS", live_before.as_str()),
+            ("CURIE_TEST_KUBECTL_STS_AFTER_UPGRADE", live_after.as_str()),
+            ("CURIE_TEST_TARGET_LIST_FAIL", "1"),
+        ],
+    );
+
+    let calls = fixture.calls();
+    assert!(
+        calls.contains("HELM_CALL: upgrade")
+            && calls.contains("aws s3 ls s3://curie-bundles --recursive --endpoint-url http://parity-rustfs.parity.svc.cluster.local:9000"),
+        "the fixture must fail during import verification after the upgrade:\n{calls}"
+    );
+    assert!(
+        !output.status.success(),
+        "apply import verification failure must exit nonzero; stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let error: Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|parse_error| {
+        panic!(
+            "apply import verification failure did not emit one JSON error object: {parse_error}; stdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    assert!(error.get("fix").is_some(), "apply error payload: {error}");
+    let message = error["error"].as_str().expect("error message string");
+    assert!(
+        message.contains("curie cluster migrate-store --phase import"),
+        "an applied upgrade with failed import must name the standalone recovery command: {error}"
+    );
+    let upgrade = calls
+        .find("HELM_CALL: upgrade")
+        .expect("the fixture reached the applied upgrade");
+    assert!(
+        !calls[upgrade..].contains("KUBECTL_CALL: delete pod"),
+        "failed apply import verification must retain staging after the upgrade:\n{calls}"
+    );
+}
+
+#[test]
+fn migrate_store_listing_shell_preserves_a_failed_aws_status() {
+    let fixture = HelmFixture::new(
+        installation_for_the_stateful_guard(),
+        HelmValuesResponse::Absent,
+    );
+    fixture.seed_migration_evidence("rustfs", STAGED_OBJECT);
+    let live = live_rustfs_statefulset();
+
+    let _ = fixture.run(
+        &[
+            "cluster",
+            "migrate-store",
+            "--phase",
+            "import",
+            "--namespace",
+            "parity",
+            "--release",
+            "parity",
+        ],
+        &[
+            ("CURIE_TEST_KUBECTL_STS", live.as_str()),
+            ("CURIE_TEST_TARGET_LIST_FAIL", "1"),
+        ],
+    );
+
+    let script = fixture.last_exec_script();
+    assert!(
+        script.contains("aws s3 ls") && script.contains("parity-rustfs.parity.svc.cluster.local"),
+        "the public CLI must expose the target listing shell to the kubectl surface: {script}"
+    );
+
+    let shell_bin = fixture.temp.path().join("listing-shell-bin");
+    fs::create_dir(&shell_bin).expect("create listing shell bin directory");
+    let aws_log = fixture.temp.path().join("aws-calls.log");
+    write_exec(
+        &shell_bin,
+        "aws",
+        r#"#!/bin/sh
+printf '%s\n' "$*" >> "$CURIE_TEST_AWS_LOG"
+if [ "$1" = configure ]; then
+    exit 0
+fi
+if [ "$1" = s3 ] && [ "$2" = ls ]; then
+    printf '%s\n' 'forced aws listing failure' >&2
+    exit 1
+fi
+printf 'unexpected aws invocation: %s\n' "$*" >&2
+exit 64
+"#,
+    );
+    write_exec(
+        &shell_bin,
+        "cat",
+        "#!/bin/sh\nprintf '%s\\n' 'fixture-secret'\n",
+    );
+    write_exec(&shell_bin, "[", "#!/bin/sh\nexit 0\n");
+    let bash_env = fixture.temp.path().join("listing-bash-env");
+    fs::write(&bash_env, "enable -n [\n").expect("write bash environment");
+    let mut paths = vec![shell_bin];
+    if let Some(current) = std::env::var_os("PATH") {
+        paths.extend(std::env::split_paths(&current));
+    }
+    let path = std::env::join_paths(paths).expect("join listing shell PATH");
+
+    let shell_output = Command::new("bash")
+        .arg("-c")
+        .arg(&script)
+        .env("BASH_ENV", &bash_env)
+        .env("PATH", path)
+        .env("CURIE_TEST_AWS_LOG", &aws_log)
+        .output()
+        .expect("execute the generated listing shell");
+    let aws_calls = fs::read_to_string(&aws_log).expect("read fake aws calls");
+    assert!(
+        aws_calls.lines().any(|line| line.starts_with("s3 ls ")),
+        "the generated shell must reach the failing aws listing:\n{aws_calls}"
+    );
+    assert!(
+        !shell_output.status.success(),
+        "the exact generated listing shell must preserve aws exit one; stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&shell_output.stdout),
+        String::from_utf8_lossy(&shell_output.stderr)
     );
 }
 


### PR DESCRIPTION
## Summary

* Persists the planned target and final source inventory with staged migration data
* Rejects detected target mismatches and listing failures before staging cleanup
* Makes unverified imports exit nonzero while retaining recovery guidance

## Done check

* Tests were committed before implementation
* Production edits were delegated
* No return type was broadened
* Code and scope reviews approved the final behavior
* All migration entry points use the planned target
* Unsafe target and listing guards were demonstrated through the actual CLI
* Consolidation and full CLI validation passed
* Security review was not applicable
* Runtime CLI verification passed

Closes #1353