### PR TITLE
Reject Alembic revision collisions in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,6 +54,8 @@ jobs:
         run: uv lock --check
       - name: Sync workspace
         run: uv sync
+      - name: Alembic revision gate
+        run: uv run python scripts/check-alembic-revisions.py
       - name: Ruff
         run: uv run ruff check .
       - name: Mypy

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,7 @@ because it can start stale application images.
   trap 'docker compose --profile full -f compose.dev.yaml down -v; rm -f "$wire_lock"' EXIT
   uv lock --check
   uv sync
+  uv run python scripts/check-alembic-revisions.py
   uv run ruff check .
   uv run mypy
   uv run lint-imports

--- a/apps/api/tests/test_alembic_revision_gate.py
+++ b/apps/api/tests/test_alembic_revision_gate.py
@@ -1,0 +1,116 @@
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+from alembic.script import ScriptDirectory
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CHECKER = REPO_ROOT / "scripts" / "check-alembic-revisions.py"
+ALEMBIC_TREE = REPO_ROOT / "apps" / "api" / "alembic"
+CHECK_COMMAND = "uv run python scripts/check-alembic-revisions.py"
+
+
+def _write_revision(
+    script_location: Path,
+    filename: str,
+    revision: str,
+    down_revision: str | tuple[str, ...] | None,
+) -> None:
+    versions = script_location / "versions"
+    versions.mkdir(parents=True, exist_ok=True)
+    (versions / filename).write_text(
+        "\n".join(
+            [
+                f"revision = {revision!r}",
+                f"down_revision = {down_revision!r}",
+                "branch_labels = None",
+                "depends_on = None",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def _run_gate(script_location: Path | None = None) -> subprocess.CompletedProcess[str]:
+    command = [sys.executable, str(CHECKER)]
+    if script_location is not None:
+        command.extend(["--script-location", str(script_location)])
+    return subprocess.run(
+        command,
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_real_migration_tree_has_one_reported_head() -> None:
+    expected_head = ScriptDirectory(str(ALEMBIC_TREE)).get_current_head()
+
+    result = _run_gate()
+
+    assert expected_head is not None
+    assert result.returncode == 0, result.stderr
+    assert expected_head in result.stdout
+
+
+def test_duplicate_numeric_filename_prefix_fails_before_graph_validation(
+    tmp_path: Path,
+) -> None:
+    _write_revision(tmp_path, "0001_base.py", "base", None)
+    _write_revision(tmp_path, "0001_collision.py", "different_revision", "base")
+
+    result = _run_gate(tmp_path)
+
+    assert result.returncode == 1, result.stderr
+    assert "duplicate numeric revision" in result.stderr.lower()
+    assert "0001" in result.stderr
+    assert "0001_base.py" in result.stderr
+    assert "0001_collision.py" in result.stderr
+
+
+def test_unique_numbered_sibling_revisions_fail_with_both_heads(tmp_path: Path) -> None:
+    _write_revision(tmp_path, "0001_base.py", "base", None)
+    _write_revision(tmp_path, "0002_left.py", "left_branch", "base")
+    _write_revision(tmp_path, "0003_right.py", "right_branch", "base")
+
+    result = _run_gate(tmp_path)
+
+    assert result.returncode == 1, result.stderr
+    assert "expected exactly one alembic head" in result.stderr.lower()
+    assert "left_branch" in result.stderr
+    assert "right_branch" in result.stderr
+
+
+def test_merge_revision_restores_one_head(tmp_path: Path) -> None:
+    _write_revision(tmp_path, "0001_base.py", "base", None)
+    _write_revision(tmp_path, "0002_left.py", "left_branch", "base")
+    _write_revision(tmp_path, "0003_right.py", "right_branch", "base")
+    _write_revision(
+        tmp_path,
+        "0004_merge.py",
+        "merged_head",
+        ("left_branch", "right_branch"),
+    )
+
+    result = _run_gate(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    assert "merged_head" in result.stdout
+
+
+def test_python_ci_job_runs_exact_gate_before_dev_stack() -> None:
+    workflow = yaml.safe_load((REPO_ROOT / ".github/workflows/ci.yaml").read_text())
+    steps = workflow["jobs"]["python"]["steps"]
+
+    matching_steps = [step for step in steps if step.get("run") == CHECK_COMMAND]
+    assert len(matching_steps) == 1
+    assert matching_steps[0]["name"] == "Alembic revision gate"
+
+    gate_index = steps.index(matching_steps[0])
+    stack_index = next(
+        index for index, step in enumerate(steps) if step.get("name") == "Start dev stack"
+    )
+    assert gate_index < stack_index

--- a/scripts/check-alembic-revisions.py
+++ b/scripts/check-alembic-revisions.py
@@ -1,0 +1,116 @@
+import argparse
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+from alembic.script import ScriptDirectory
+
+FILENAME_PATTERN = re.compile(r"^(\d+)_.*\.py$")
+DEFAULT_SCRIPT_LOCATION = (
+    Path(__file__).resolve().parents[1] / "apps" / "api" / "alembic"
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate Alembic revision numbers and graph heads."
+    )
+    parser.add_argument(
+        "--script-location",
+        type=Path,
+        default=DEFAULT_SCRIPT_LOCATION,
+        help="Alembic script directory to validate.",
+    )
+    args = parser.parse_args()
+    script_location: Path = args.script_location
+    versions = script_location / "versions"
+
+    if not script_location.is_dir():
+        print(
+            f"Alembic revision gate failed: script location does not exist: "
+            f"{script_location}",
+            file=sys.stderr,
+        )
+        return 1
+
+    if not versions.is_dir():
+        print(
+            f"Alembic revision gate failed: versions directory does not exist: "
+            f"{versions}",
+            file=sys.stderr,
+        )
+        return 1
+
+    filenames_by_number: dict[str, list[str]] = defaultdict(list)
+    try:
+        for path in versions.iterdir():
+            if not path.is_file():
+                continue
+            match = FILENAME_PATTERN.fullmatch(path.name)
+            if match is not None:
+                filenames_by_number[match.group(1)].append(path.name)
+    except OSError as exc:
+        print(
+            f"Alembic revision gate failed: could not scan versions directory "
+            f"{versions}: {exc}",
+            file=sys.stderr,
+        )
+        return 1
+
+    duplicates = {
+        number: sorted(filenames)
+        for number, filenames in filenames_by_number.items()
+        if len(filenames) > 1
+    }
+    if duplicates:
+        print(
+            "Alembic revision gate failed: duplicate numeric revision "
+            "filename tokens found:",
+            file=sys.stderr,
+        )
+        for number in sorted(duplicates):
+            print(
+                f"  {number}: {', '.join(duplicates[number])}",
+                file=sys.stderr,
+            )
+        print(
+            "Rename migrations so every leading numeric token is unique.",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        heads = sorted(ScriptDirectory(str(script_location)).get_heads())
+    except Exception as exc:
+        print(
+            f"Alembic revision gate failed: could not load the revision graph "
+            f"from {script_location}: {exc}",
+            file=sys.stderr,
+        )
+        print(
+            "Fix malformed revision modules and graph references, then rerun "
+            "the checker.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if len(heads) != 1:
+        rendered_heads = ", ".join(heads) if heads else "none"
+        print(
+            f"Alembic revision gate failed: expected exactly one Alembic head, "
+            f"found {len(heads)}: {rendered_heads}",
+            file=sys.stderr,
+        )
+        print(
+            "Create a merge revision so the migration tree has one head.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"Alembic revision gate passed with head {heads[0]}.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #1627

Summary

* Reject duplicate numeric Alembic migration filenames before graph loading
* Require exactly one Alembic graph head in the shared Python CI job
* Cover both failures with database free subprocess tests