### PR TITLE
Reject duplicate deployment YAML keys

### DIFF
--- a/apps/api/src/curie_api/bundles.py
+++ b/apps/api/src/curie_api/bundles.py
@@ -13,7 +13,6 @@ import zipfile
 from pathlib import Path
 from typing import Any
 
-import yaml
 from plugin_format import (
     DEFAULT_MAX_COMPRESSION_RATIO,
     DEFAULT_MAX_MEMBERS,
@@ -29,6 +28,7 @@ from plugin_format import (
 from plugin_format.connectors import CONNECTORS_FILE, ConnectorsFile, validate_connectors
 from plugin_format.deploy_targets import DeployTargetsFile, validate_deploy_targets
 from plugin_format.validate import DEPLOY_FILE
+from plugin_format.yaml_loader import safe_load_unique
 
 # Re-exported so existing catchers (gitflow.py, routers/bundles.py, tests) keep
 # resolving ``bundles.UnsupportedArchive`` after the extraction logic moved to
@@ -108,7 +108,7 @@ def read_connectors(root: Path) -> ConnectorsFile:
     path = bundle_root(root) / CONNECTORS_FILE
     if not path.is_file():
         return ConnectorsFile()
-    parsed, errors = validate_connectors(yaml.safe_load(path.read_text(encoding="utf-8")))
+    parsed, errors = validate_connectors(safe_load_unique(path.read_text(encoding="utf-8")))
     if errors or parsed is None:  # pragma: no cover -- validate_bundle gates this
         return ConnectorsFile()
     return parsed
@@ -127,7 +127,9 @@ def read_deploy_targets(root: Path) -> DeployTargetsFile | None:
     path = bundle_root(root) / DEPLOY_FILE
     if not path.is_file():
         return None
-    parsed, errors = validate_deploy_targets(yaml.safe_load(path.read_text(encoding="utf-8")))
+    parsed, errors = validate_deploy_targets(
+        safe_load_unique(path.read_text(encoding="utf-8"))
+    )
     if errors or parsed is None:  # pragma: no cover -- validate_bundle gates this
         return None
     return parsed

--- a/apps/api/src/curie_api/routers/deploy_targets.py
+++ b/apps/api/src/curie_api/routers/deploy_targets.py
@@ -11,6 +11,7 @@ agent to create.
 import yaml
 from fastapi import APIRouter, Depends, HTTPException, status
 from plugin_format.deploy_targets import DeployTargetsFile, validate_deploy_targets
+from plugin_format.yaml_loader import DuplicateKeyError, safe_load_unique
 
 from ..auth import require_api_key
 from ..schemas import ListedTargets, NamedTarget, ResolvedTarget, ResolveTargetRequest
@@ -27,7 +28,12 @@ def _parse(content: str) -> DeployTargetsFile:
     """
 
     try:
-        data = yaml.safe_load(content)
+        data = safe_load_unique(content)
+    except DuplicateKeyError as exc:
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            f"deploy.duplicate_target: deploy.yaml contains duplicate key {exc.key!r}",
+        ) from exc
     except yaml.YAMLError as exc:
         raise HTTPException(
             status.HTTP_400_BAD_REQUEST, f"deploy.yaml is unparseable: {exc}"

--- a/apps/api/tests/test_resolve_deploy_target.py
+++ b/apps/api/tests/test_resolve_deploy_target.py
@@ -119,6 +119,34 @@ def test_unparseable_yaml_is_a_400_naming_the_problem(
     assert "unparseable" in r.json()["detail"]
 
 
+def test_explicit_mapping_tag_on_a_scalar_is_a_400(
+    client: TestClient, auth_headers: dict
+) -> None:
+    r = _resolve(client, auth_headers, "targets: !!map foo\n", "prod")
+    assert r.status_code == 400
+    assert "unparseable" in r.json()["detail"]
+
+
+def test_duplicate_target_name_is_a_400_naming_the_duplicate(
+    client: TestClient, auth_headers: dict
+) -> None:
+    content = (
+        "targets:\n"
+        "  prod:\n"
+        "    agent: first\n"
+        "    env: prod\n"
+        "    slack_channel: C0EXAMPLE1\n"
+        "  prod:\n"
+        "    agent: second\n"
+        "    env: prod\n"
+        "    slack_channel: C0EXAMPLE2\n"
+    )
+    r = _resolve(client, auth_headers, content, "prod")
+    assert r.status_code == 400, r.text
+    assert "deploy.duplicate_target" in r.json()["detail"]
+    assert "prod" in r.json()["detail"]
+
+
 # --------------------------------------------------------------------------- #
 # Listing every target (onboarding)
 # --------------------------------------------------------------------------- #

--- a/docs/interfaces/bundle-format/INTERFACE.md
+++ b/docs/interfaces/bundle-format/INTERFACE.md
@@ -65,15 +65,20 @@ files**, both optional, both invisible to Claude Code:
   names the credentials it needs (`secrets`, `secret_files`, `sealed_secrets`) by NAME only, never by
   value. Validated by `packages/plugin-format/src/plugin_format/validate.py::_validate_connectors`,
   which emits `connectors.*` codes (`connectors.not_object`, `connectors.ambiguous`,
-  `connectors.underspecified`, `connectors.reserved_name`, `connectors.duplicate_server`, and others).
+  `connectors.underspecified`, `connectors.reserved_name`, `connectors.duplicate_connector`,
+  `connectors.duplicate_server`, and others). Authored mapping keys are checked for
+  duplicates before validation, so a repeated connector name is rejected rather than
+  silently replaced by the last YAML value.
 - `deploy.yaml` (ADR-0089, `packages/plugin-format/src/plugin_format/deploy_targets.py::DeployTargetsFile`)
   declares named deploy targets under a `targets` map, each a
   `packages/plugin-format/src/plugin_format/deploy_targets.py::DeployTarget` of
   `{agent, env, slack_channel}` where `env` is `dev` or `prod`. Validated by
   `packages/plugin-format/src/plugin_format/validate.py::_validate_deploy_targets`, which emits
-  `deploy.*` codes (`deploy.not_object`, `deploy.bad_target_name`, `deploy.bad_env`,
-  `deploy.missing_agent` (a declared target must name its agent; the error names the target key),
-  `deploy.bad_agent_name`, `deploy.bad_slack_channel`).
+  `deploy.*` codes (`deploy.not_object`, `deploy.duplicate_target`, `deploy.bad_target_name`,
+  `deploy.bad_env`, `deploy.missing_agent` (a declared target must name its agent; the error names
+  the target key), `deploy.bad_agent_name`, `deploy.bad_slack_channel`). Authored mapping keys are
+  checked for duplicates before validation, so a repeated target name fails closed instead of
+  silently selecting the last YAML value.
 
 The two overlay files are not independent of the manifest, which is the part a second consumer is
 most likely to miss: `connectors.yaml` feeds manifest validation. The set of gate names

--- a/packages/plugin-format/src/plugin_format/approval_policy.py
+++ b/packages/plugin-format/src/plugin_format/approval_policy.py
@@ -23,6 +23,7 @@ from pydantic import ValidationError
 from .connectors import CONNECTORS_FILE, validate_connectors
 from .manifest import resolve_manifest
 from .models import ApprovalGate, McpConfig, PluginManifest
+from .yaml_loader import safe_load_unique
 
 
 def grantable_routes(
@@ -227,7 +228,7 @@ def connector_server_names(root: str | Path) -> set[str] | None:
     if not path.is_file():
         return set()
     try:
-        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        data = safe_load_unique(path.read_text(encoding="utf-8"))
     except (OSError, UnicodeDecodeError, yaml.YAMLError):
         return None
     parsed, errors = validate_connectors(data)

--- a/packages/plugin-format/src/plugin_format/validate.py
+++ b/packages/plugin-format/src/plugin_format/validate.py
@@ -33,6 +33,7 @@ from .models import (
     TriggerDeclaration,
 )
 from .reserved_env import is_reserved_boot_env_name
+from .yaml_loader import DuplicateKeyError, safe_load_unique
 
 # The hooks field is a mapping of event name -> list of matcher entries. Reused
 # to validate both the inline object and a declared hooks file.
@@ -112,7 +113,14 @@ def _validate_deploy_targets(root: Path, c: _Collector) -> None:
     if not path.is_file():
         return
     try:
-        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        data = safe_load_unique(path.read_text(encoding="utf-8"))
+    except DuplicateKeyError as exc:
+        c.error(
+            "deploy.duplicate_target",
+            f"{DEPLOY_FILE}: duplicate target key {exc.key!r}",
+            DEPLOY_FILE,
+        )
+        return
     except (OSError, yaml.YAMLError) as exc:
         c.error("deploy.unreadable", f"{DEPLOY_FILE}: {exc}", DEPLOY_FILE)
         return
@@ -132,7 +140,14 @@ def _validate_connectors(root: Path, c: _Collector) -> None:
     if not path.is_file():
         return
     try:
-        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        data = safe_load_unique(path.read_text(encoding="utf-8"))
+    except DuplicateKeyError as exc:
+        c.error(
+            "connectors.duplicate_connector",
+            f"{CONNECTORS_FILE}: duplicate connector key {exc.key!r}",
+            CONNECTORS_FILE,
+        )
+        return
     except (OSError, yaml.YAMLError) as exc:
         c.error("connectors.unreadable", f"{CONNECTORS_FILE}: {exc}", CONNECTORS_FILE)
         return

--- a/packages/plugin-format/src/plugin_format/yaml_loader.py
+++ b/packages/plugin-format/src/plugin_format/yaml_loader.py
@@ -1,0 +1,83 @@
+"""Load Curie owned YAML without silently replacing repeated keys."""
+
+from collections.abc import Hashable
+from typing import Any
+
+import yaml
+from yaml.constructor import ConstructorError
+from yaml.error import Mark
+from yaml.nodes import MappingNode, Node
+
+_MERGE_TAG = "tag:yaml.org,2002:merge"
+_VALUE_TAG = "tag:yaml.org,2002:value"
+_MERGE_KEY = object()
+
+
+class DuplicateKeyError(ConstructorError):
+    """A mapping repeats a key authored in the same mapping."""
+
+    def __init__(self, key: object, context_mark: Mark, problem_mark: Mark) -> None:
+        self.key = key
+        super().__init__(
+            "while constructing a mapping",
+            context_mark,
+            f"found duplicate key {key!r}",
+            problem_mark,
+        )
+
+
+class _UniqueKeyLoader(yaml.SafeLoader):
+    def __init__(self, stream: str) -> None:
+        super().__init__(stream)
+        self._checked_mapping_nodes: set[int] = set()
+
+    def _check_authored_keys(self, node: Node) -> None:
+        if not isinstance(node, MappingNode):
+            return
+
+        node_id = id(node)
+        if node_id in self._checked_mapping_nodes:
+            return
+        self._checked_mapping_nodes.add(node_id)
+
+        seen: set[Hashable] = set()
+        for key_node, _ in node.value:
+            if key_node.tag == _MERGE_TAG:
+                key: object = "<<"
+                comparable: Hashable = _MERGE_KEY
+            elif key_node.tag == _VALUE_TAG:
+                key = key_node.value
+                comparable = key
+            else:
+                key = self.construct_object(key_node, deep=False)
+                if not isinstance(key, Hashable):
+                    raise ConstructorError(
+                        "while constructing a mapping",
+                        node.start_mark,
+                        "found unhashable key",
+                        key_node.start_mark,
+                    )
+                comparable = key
+            if comparable in seen:
+                raise DuplicateKeyError(key, node.start_mark, key_node.start_mark)
+            seen.add(comparable)
+
+    def flatten_mapping(self, node: MappingNode) -> None:
+        self._check_authored_keys(node)
+        super().flatten_mapping(node)
+
+    def construct_mapping(
+        self, node: MappingNode, deep: bool = False
+    ) -> dict[Hashable, Any]:
+        self._check_authored_keys(node)
+        return super().construct_mapping(node, deep=deep)
+
+
+def safe_load_unique(text: str) -> Any:
+    """Safely load YAML and reject repeated authored mapping keys."""
+
+    loader = _UniqueKeyLoader(text)
+    try:
+        return loader.get_single_data()
+    finally:
+        loader.dispose()  # type: ignore[no-untyped-call]

--- a/packages/plugin-format/tests/test_connectors.py
+++ b/packages/plugin-format/tests/test_connectors.py
@@ -148,6 +148,21 @@ def test_bundle_surfaces_unparseable_yaml(tmp_path: Path) -> None:
     assert any(e.code == "connectors.unreadable" for e in result.errors)
 
 
+def test_bundle_rejects_a_duplicate_connector_name(tmp_path: Path) -> None:
+    root = _bundle(
+        tmp_path,
+        "connectors:\n"
+        "  grafana:\n"
+        "    url: https://first.example.com/mcp\n"
+        "  grafana:\n"
+        "    url: https://second.example.com/mcp\n",
+    )
+    result = validate_bundle(str(root))
+    assert not result.valid
+    issue = next(e for e in result.errors if e.code == "connectors.duplicate_connector")
+    assert "grafana" in issue.message
+
+
 def test_bundle_with_a_valid_connector_passes(tmp_path: Path) -> None:
     root = _bundle(
         tmp_path,

--- a/packages/plugin-format/tests/test_deploy_targets.py
+++ b/packages/plugin-format/tests/test_deploy_targets.py
@@ -147,5 +147,57 @@ def test_bundle_surfaces_unparseable_yaml(tmp_path: Path) -> None:
     assert any(e.code == "deploy.unreadable" for e in result.errors)
 
 
+def test_bundle_rejects_a_duplicate_target_name(tmp_path: Path) -> None:
+    root = _bundle(
+        tmp_path,
+        "targets:\n"
+        "  prod:\n"
+        "    agent: first\n"
+        "    env: prod\n"
+        "  prod:\n"
+        "    agent: second\n"
+        "    env: prod\n",
+    )
+    result = validate_bundle(str(root))
+    assert not result.valid
+    issue = next(e for e in result.errors if e.code == "deploy.duplicate_target")
+    assert "prod" in issue.message
+
+
+def test_bundle_allows_an_explicit_override_of_a_merged_target_field(tmp_path: Path) -> None:
+    root = _bundle(
+        tmp_path,
+        "targets:\n"
+        "  dev: &base\n"
+        "    agent: acme\n"
+        "    env: dev\n"
+        "    slack_channel: C0EXAMPLE1\n"
+        "  prod:\n"
+        "    <<: *base\n"
+        "    env: prod\n",
+    )
+    assert validate_bundle(str(root)).valid
+
+
+def test_bundle_allows_chained_merge_anchors(tmp_path: Path) -> None:
+    root = _bundle(
+        tmp_path,
+        "targets:\n"
+        "  dev: &dev\n"
+        "    agent: acmedev\n"
+        "    env: dev\n"
+        "    slack_channel: C0EXAMPLE1\n"
+        "  candidate: &candidate\n"
+        "    <<: *dev\n"
+        "    agent: acmecandidate\n"
+        "  prod:\n"
+        "    <<: *candidate\n"
+        "    agent: acmeprod\n"
+        "    env: prod\n"
+        "    slack_channel: C0EXAMPLE2\n",
+    )
+    assert validate_bundle(str(root)).valid
+
+
 def test_the_real_acme_bot_routing_validates(tmp_path: Path) -> None:
     assert validate_bundle(str(_bundle(tmp_path, REAL))).valid

--- a/packages/plugin-format/tests/test_effective_operator_gate.py
+++ b/packages/plugin-format/tests/test_effective_operator_gate.py
@@ -435,6 +435,20 @@ def test_connector_names_poison_to_none_on_unparseable_yaml(tmp_path) -> None:
     assert connector_server_names(root) is None
 
 
+def test_connector_names_poison_to_none_on_duplicate_name(tmp_path) -> None:
+    root = _connectors(
+        tmp_path,
+        "connectors:\n"
+        "  grafana:\n"
+        "    url: https://first.example.com/mcp\n"
+        "  grafana:\n"
+        "    url: https://second.example.com/mcp\n",
+    )
+    assert connector_server_names(root) is None, (
+        "duplicate grafana must poison connector names"
+    )
+
+
 def test_connector_names_poison_to_none_on_invalid_connectors(tmp_path) -> None:
     # A connector that does not validate is never mounted, so its name is not a
     # tool surface a gate may be namespaced to: unknowable, not empty.

--- a/runner/src/curie_runner/connectors.py
+++ b/runner/src/curie_runner/connectors.py
@@ -42,6 +42,7 @@ from typing import Any
 import yaml
 from plugin_format.connector_render import mcp_entry, unhosted_mcp_entry
 from plugin_format.connectors import ConnectorsFile, validate_connectors
+from plugin_format.yaml_loader import safe_load_unique
 
 logger = logging.getLogger(__name__)
 
@@ -53,7 +54,7 @@ def _read(plugin_dir: str | Path) -> ConnectorsFile | None:
     if not path.is_file():
         return None
     try:
-        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        data = safe_load_unique(path.read_text(encoding="utf-8"))
     except (OSError, yaml.YAMLError) as exc:
         # Deploy already validated this file, so reaching here means the bundle
         # changed underneath us. Log and mount nothing rather than fail the

--- a/runner/tests/test_connectors.py
+++ b/runner/tests/test_connectors.py
@@ -96,6 +96,28 @@ def test_unreadable_connectors_file_mounts_nothing_rather_than_crashing(tmp_path
     assert servers == {}
 
 
+def test_explicit_mapping_tag_on_a_scalar_mounts_nothing(tmp_path: Path) -> None:
+    servers = derive_mcp_servers(
+        _bundle(tmp_path, "connectors: !!map foo\n"), **SCOPE
+    )
+    assert servers == {}
+
+
+def test_duplicate_connector_name_mounts_nothing(tmp_path: Path) -> None:
+    servers = derive_mcp_servers(
+        _bundle(
+            tmp_path,
+            "connectors:\n"
+            "  grafana:\n"
+            "    url: https://first.example.com/mcp\n"
+            "  grafana:\n"
+            "    url: https://second.example.com/mcp\n",
+        ),
+        **SCOPE,
+    )
+    assert servers == {}, "duplicate grafana must mount nothing"
+
+
 def test_invalid_connectors_file_mounts_nothing(tmp_path: Path) -> None:
     servers = derive_mcp_servers(
         _bundle(tmp_path, "connectors:\n  Bad_Name:\n    image: x:1\n"), **SCOPE


### PR DESCRIPTION
Closes #1198

Rejects duplicate mapping keys in deploy.yaml and connectors.yaml before YAML parsing can select the final value. Preserves distinct targets and merge overrides across validation, API resolution, bundle reads, approval policy, and runner loading.

Validation passed with 378 affected tests, relevant lint, type checking, documentation checks, live HTTP parsing, and a negative mutation proof.