### PR TITLE
Repair E2E required negative control

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1164,19 +1164,6 @@ jobs:
           set -euo pipefail
 
           validate_selected_outcomes() {
-            local skill_local_expected="skipped"
-            if [[ "$SKILL_SELECTED" == "true" || "$LOCAL_SELECTED" == "true" ]]; then
-              skill_local_expected="success"
-            fi
-            local local_release_expected="skipped"
-            if [[ "$LOCAL_RELEASE_SELECTED" == "true" ]]; then
-              local_release_expected="success"
-            fi
-            local cluster_expected="skipped"
-            if [[ "$CLUSTER_SELECTED" == "true" ]]; then
-              cluster_expected="success"
-            fi
-
             if [[ "$SKILL_LOCAL_RESULT" != "$skill_local_expected" ||
                   "$LOCAL_RELEASE_RESULT" != "$local_release_expected" ||
                   "$CLUSTER_RESULT" != "$cluster_expected" ]]; then
@@ -1194,27 +1181,34 @@ jobs:
             exit 1
           fi
 
+          skill_local_expected="skipped"
+          if [[ "$SKILL_SELECTED" == "true" || "$LOCAL_SELECTED" == "true" ]]; then
+            skill_local_expected="success"
+          fi
+          local_release_expected="skipped"
+          if [[ "$LOCAL_RELEASE_SELECTED" == "true" ]]; then
+            local_release_expected="success"
+          fi
+          cluster_expected="skipped"
+          if [[ "$CLUSTER_SELECTED" == "true" ]]; then
+            cluster_expected="success"
+          fi
+
           if ! validate_selected_outcomes; then
             echo "E2E required failed" >&2
             exit 1
           fi
 
-          negative_skill_local_result="$SKILL_LOCAL_RESULT"
-          negative_local_release_result="$LOCAL_RELEASE_RESULT"
-          negative_cluster_result="$CLUSTER_RESULT"
-          if [[ "$SKILL_SELECTED" == "true" || "$LOCAL_SELECTED" == "true" ]]; then
+          negative_skill_local_result="$skill_local_expected"
+          negative_local_release_result="$local_release_expected"
+          negative_cluster_result="$cluster_expected"
+          if [[ "$skill_local_expected" == "success" ]]; then
             negative_skill_local_result="skipped"
-          fi
-          if [[ "$LOCAL_RELEASE_SELECTED" == "true" ]]; then
+          elif [[ "$local_release_expected" == "success" ]]; then
             negative_local_release_result="skipped"
-          fi
-          if [[ "$CLUSTER_SELECTED" == "true" ]]; then
+          elif [[ "$cluster_expected" == "success" ]]; then
             negative_cluster_result="skipped"
-          fi
-          if [[ "$SKILL_SELECTED" != "true" &&
-                "$LOCAL_SELECTED" != "true" &&
-                "$LOCAL_RELEASE_SELECTED" != "true" &&
-                "$CLUSTER_SELECTED" != "true" ]]; then
+          else
             negative_skill_local_result="success"
           fi
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1163,6 +1163,28 @@ jobs:
         run: |
           set -euo pipefail
 
+          validate_selected_outcomes() {
+            local skill_local_expected="skipped"
+            if [[ "$SKILL_SELECTED" == "true" || "$LOCAL_SELECTED" == "true" ]]; then
+              skill_local_expected="success"
+            fi
+            local local_release_expected="skipped"
+            if [[ "$LOCAL_RELEASE_SELECTED" == "true" ]]; then
+              local_release_expected="success"
+            fi
+            local cluster_expected="skipped"
+            if [[ "$CLUSTER_SELECTED" == "true" ]]; then
+              cluster_expected="success"
+            fi
+
+            if [[ "$SKILL_LOCAL_RESULT" != "$skill_local_expected" ||
+                  "$LOCAL_RELEASE_RESULT" != "$local_release_expected" ||
+                  "$CLUSTER_RESULT" != "$cluster_expected" ]]; then
+              return 1
+            fi
+            return 0
+          }
+
           if [[ "$CHANGES_RESULT" != "success" ||
                 ( "$SKILL_SELECTED" != "true" && "$SKILL_SELECTED" != "false" ) ||
                 ( "$LOCAL_SELECTED" != "true" && "$LOCAL_SELECTED" != "false" ) ||
@@ -1172,39 +1194,37 @@ jobs:
             exit 1
           fi
 
-          skill_local_expected="skipped"
-          if [[ "$SKILL_SELECTED" == "true" || "$LOCAL_SELECTED" == "true" ]]; then
-            skill_local_expected="success"
-          fi
-          local_release_expected="skipped"
-          if [[ "$LOCAL_RELEASE_SELECTED" == "true" ]]; then
-            local_release_expected="success"
-          fi
-          cluster_expected="skipped"
-          if [[ "$CLUSTER_SELECTED" == "true" ]]; then
-            cluster_expected="success"
-          fi
-
-          if [[ "$SKILL_LOCAL_RESULT" != "$skill_local_expected" ||
-                "$LOCAL_RELEASE_RESULT" != "$local_release_expected" ||
-                "$CLUSTER_RESULT" != "$cluster_expected" ]]; then
+          if ! validate_selected_outcomes; then
             echo "E2E required failed" >&2
             exit 1
           fi
 
-          negative_skill_local_expected="skipped"
-          if [[ "true" == "true" || "false" == "true" ]]; then
-            negative_skill_local_expected="success"
+          negative_skill_local_result="$SKILL_LOCAL_RESULT"
+          negative_local_release_result="$LOCAL_RELEASE_RESULT"
+          negative_cluster_result="$CLUSTER_RESULT"
+          if [[ "$SKILL_SELECTED" == "true" || "$LOCAL_SELECTED" == "true" ]]; then
+            negative_skill_local_result="skipped"
           fi
-          negative_local_release_expected="skipped"
-          negative_cluster_expected="skipped"
-          if [[ "success" != "success" ||
-                "skipped" == "$negative_skill_local_expected" ||
-                "skipped" == "$negative_local_release_expected" ||
-                "skipped" == "$negative_cluster_expected" ]]; then
-            echo "Selected and skipped negative control passed"
-          else
+          if [[ "$LOCAL_RELEASE_SELECTED" == "true" ]]; then
+            negative_local_release_result="skipped"
+          fi
+          if [[ "$CLUSTER_SELECTED" == "true" ]]; then
+            negative_cluster_result="skipped"
+          fi
+          if [[ "$SKILL_SELECTED" != "true" &&
+                "$LOCAL_SELECTED" != "true" &&
+                "$LOCAL_RELEASE_SELECTED" != "true" &&
+                "$CLUSTER_SELECTED" != "true" ]]; then
+            negative_skill_local_result="success"
+          fi
+
+          if SKILL_LOCAL_RESULT="$negative_skill_local_result" \
+            LOCAL_RELEASE_RESULT="$negative_local_release_result" \
+            CLUSTER_RESULT="$negative_cluster_result" \
+            validate_selected_outcomes; then
             echo "Selected and skipped negative control failed" >&2
             exit 1
           fi
+          echo "Selected and skipped negative control passed"
+
           echo "E2E required passed"

--- a/tools/e2e-ci-selection/tests/test_e2e_ci_selection.py
+++ b/tools/e2e-ci-selection/tests/test_e2e_ci_selection.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
+from collections.abc import Callable
 from pathlib import Path
 
 import pytest
@@ -355,8 +356,14 @@ def _aggregate_contract() -> tuple[str, dict[str, str]]:
     return step["run"], bindings
 
 
-def _run_aggregate(**overrides: str) -> subprocess.CompletedProcess[str]:
+def _run_aggregate(
+    *,
+    script_transform: Callable[[str], str] | None = None,
+    **overrides: str,
+) -> subprocess.CompletedProcess[str]:
     script, bindings = _aggregate_contract()
+    if script_transform is not None:
+        script = script_transform(script)
     state = {
         "changes_result": "success",
         "skill_selected": "false",
@@ -429,3 +436,26 @@ def test_aggregate_negative_control_runs_before_real_results() -> None:
     assert negative_control in output
     assert real_result in output
     assert output.index(negative_control) < output.index(real_result)
+
+
+def test_negative_control_rejects_selected_skipped_outcome_when_validator_mutates() -> None:
+    unmutated = _run_aggregate(
+        skill_selected="true",
+        skill_local_result="success",
+    )
+    assert unmutated.returncode == 0, unmutated.stdout + unmutated.stderr
+
+    skill_result_check = '"$SKILL_LOCAL_RESULT" != "$skill_local_expected" ||'
+
+    def accept_selected_skipped(script: str) -> str:
+        assert script.count(skill_result_check) == 1
+        return script.replace(skill_result_check, "", 1)
+
+    completed = _run_aggregate(
+        script_transform=accept_selected_skipped,
+        skill_selected="true",
+        skill_local_result="skipped",
+    )
+    output = completed.stdout + completed.stderr
+    assert completed.returncode != 0, output
+    assert "Selected and skipped negative control failed" in output


### PR DESCRIPTION
Closes #1637

* Shares selected outcome validation between the real aggregate and its negative control.
* Derives the deliberately inconsistent case from actual rung selections and results.
* Adds mutation coverage proving selected plus skipped acceptance exits nonzero.