### PR TITLE
Document Curie behavior evidence

### DIFF
--- a/.agents/behaviors/git-flow-deploy/BEHAVIOR.md
+++ b/.agents/behaviors/git-flow-deploy/BEHAVIOR.md
@@ -1,0 +1,18 @@
+---
+name: git-flow-deploy
+description: Passing evidence for Curie's signed Git flow deployment and promotion path.
+---
+
+# Git flow deploy
+
+## Passing evidence
+
+A passing Git flow deploy run accepts a correctly signed push, resolves the target agent, selects the permitted deployment environment for the pushed ref, clones the trusted source, archives the produced artifact, and processes the push into the resolved agent's deployment. `apps/api/src/curie_api/routers/github.py:github_webhook` and `apps/api/src/curie_api/gitflow.py:verify_signature`, `environment_for_ref`, `clone_and_archive`, `process_push`, and `resolve_target_agent` define these steps. ADR-0091 defines the deployment intent.
+
+A passing run must demonstrate the supported dev deployment and main promotion paths, artifact reuse for the promotion, and isolation between different agents. It must also demonstrate rejection of an invalid signature, an ignored branch, an untrusted origin, and a foreign agent. `apps/api/tests/test_gitflow_integration.py` contains the named dev deploy, main promotion, signature rejection, ignored branch, trusted origin rejection, different agents, exact artifact reuse, and foreign agent rejection tests.
+
+## What a passing run does not prove
+
+A passing Git flow deploy run does not prove that every branch is deployable, that every GitHub webhook is trusted, or that every repository may deploy to every agent. The accepted environments and agent ownership are resolved from the incoming ref and target agent rather than inferred as universal permissions. `apps/api/src/curie_api/gitflow.py:environment_for_ref` and `resolve_target_agent`, plus the rejection tests in `apps/api/tests/test_gitflow_integration.py`, bound that claim.
+
+A passing run does not prove that a deployed artifact is correct for every future runtime request. It proves the signed push was processed through the Git flow path and that the tested deployment boundaries held for that run. ADR-0091 and `apps/api/tests/test_gitflow_integration.py` set this boundary.

--- a/.agents/behaviors/parity-ladder/BEHAVIOR.md
+++ b/.agents/behaviors/parity-ladder/BEHAVIOR.md
@@ -1,0 +1,20 @@
+---
+name: parity-ladder
+description: Passing evidence for Curie's parity ladder across skill, local, local-release, and cluster.
+---
+
+# Parity ladder
+
+## Passing evidence
+
+A passing parity ladder run uses the same weather bundle and the same case identity across every selected rung. `cli/scripts/e2e-ladder.sh` and ADR-0081 define this parity contract.
+
+The fake CI jobs `e2e-ladder`, `e2e-ladder-release`, and `e2e-ladder-cluster` prove selected rung plumbing, the weather bundle and case identity, and finalized nonempty replies where the rung produces a reply. They do not prove semantic correctness or use of a real model. `cli/scripts/e2e-ladder.sh` and `.github/workflows/ci.yaml` define this fake evidence.
+
+The live nightly jobs `ladder-skill-local`, `ladder-local-release`, and `ladder-cluster` add a content graded skill result and a non fake sentinel negative control on live reply rungs. `.github/workflows/nightly-graded-ladder.yaml` and ADR-0081 define this live evidence.
+
+## What a passing run does not prove
+
+The `local`, `local-release`, and `cluster` reply evidence does not grade reply semantics. A finalized nonempty reply is runtime evidence, not a claim that the reply is useful, correct, or equivalent in content to the content graded `skill` reply. `cli/scripts/e2e-ladder.sh` and ADR-0081 distinguish reply evidence from content grading.
+
+Issue #1622 reports that the `ladder-skill-local`, `ladder-local-release`, and `ladder-cluster` jobs in `.github/workflows/nightly-graded-ladder.yaml` recorded 10 passing runs out of 20 when the issue was filed. That is historical operating evidence only. It is not a passing threshold or a reliability guarantee for a future run.


### PR DESCRIPTION
Adopts the `.agents/behaviors/<name>/BEHAVIOR.md` discovery convention with specs for the parity ladder and Git flow deploy.

Each spec defines the evidence a passing run must show and the limits of that evidence. The parity spec preserves the fake versus live boundary and records the historical 10 of 20 rate at issue filing.

Validated with `bash scripts/check-docs.sh`, `uv run ruff check .`, structural frontmatter validation, unchanged frozen eval artifacts, and a manifest dependency grep.

Closes #1622