### PR TITLE
Wire trajectory scoring across eval tiers

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -744,8 +744,8 @@ jobs:
   # it, taking the release round trip off the ladder's critical path
   # (~30-50s wall-clock). A fresh runner shares no Docker daemon with e2e-ladder
   # so it must rebuild the images; the shared GHA layer cache defuses that --
-  # these builds hit the same ladder-{runner,api,worker} scopes e2e-ladder
-  # populates, so on a warm cache they cost the --load export, not a full
+  # these builds reuse the same cache scopes as the other ladder jobs, so on a
+  # warm cache they cost the --load export, not a full
   # rebuild. Uses the same use:false / build-push-action mechanism.
   e2e-ladder-release:
     name: E2E parity ladder (local-release, fake model)
@@ -807,6 +807,17 @@ jobs:
           load: true
           cache-from: type=gha,scope=ladder-worker
           cache-to: type=gha,mode=max,scope=ladder-worker
+      - name: Build the ui image locally (satisfies the generated release compose, no registry auth)
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: apps/ui/Dockerfile
+          builder: ${{ steps.releasecache.outputs.name }}
+          tags: ghcr.io/curie-eng/curie-ui:latest
+          push: false
+          load: true
+          cache-from: type=gha,scope=ladder-ui
+          cache-to: type=gha,mode=max,scope=ladder-ui
       - name: Tag the api image for the generated release compose (ghcr.io/curie-eng/curie-api:latest, no registry auth)
         run: docker tag ghcr.io/curie-eng/curie-api:ci-local ghcr.io/curie-eng/curie-api:latest
       - name: Build the worker-local overlay for the generated release compose (ghcr.io/curie-eng/curie-worker-local:latest, no registry auth)

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -1360,8 +1360,30 @@
         "type": "object"
       },
       "EvalCell": {
-        "description": "One cell of the eval matrix: a case's result on a version.\n\n``model`` is the model the result was produced under (the matrix's model\ndimension), or ``None`` when the recording run carried no model tag.\n\n``plumbing_ok`` means the case ran to completion but no grader judged it (the\nfake-model tier, ADR-0055). It is a distinct status rather than a pass or a\nfail because it is neither: the fake answers from a canned script, so its cell\ncarries no comparative information and must never read as a green promotion\ngate.",
+        "description": "One cell of the eval matrix: a case's result on a version.\n\n``model`` is the model the result was produced under (the matrix's model\ndimension), or ``None`` when the recording run carried no model tag.\n\n``detail`` is the scorer's optional explanation for the verdict. It is\ndistinct from a trace's ``error``, which identifies a turn that did not\ncomplete.\n\n``plumbing_ok`` means the case ran to completion but no grader judged it (the\nfake-model tier, ADR-0055). It is a distinct status rather than a pass or a\nfail because it is neither: the fake answers from a canned script, so its cell\ncarries no comparative information and must never read as a green promotion\ngate.",
         "properties": {
+          "case_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Case Count"
+          },
+          "detail": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Detail"
+          },
           "model": {
             "anyOf": [
               {
@@ -1373,6 +1395,21 @@
             ],
             "title": "Model"
           },
+          "scorer": {
+            "anyOf": [
+              {
+                "enum": [
+                  "grader",
+                  "trajectory"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Scorer"
+          },
           "status": {
             "enum": [
               "pass",
@@ -1382,6 +1419,17 @@
             ],
             "title": "Status",
             "type": "string"
+          },
+          "stream_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stream Id"
           },
           "version": {
             "title": "Version",
@@ -5970,6 +6018,22 @@
               "default": 5,
               "title": "Versions",
               "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "stream_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Stream Id"
             }
           },
           {

--- a/apps/api/src/curie_api/evals.py
+++ b/apps/api/src/curie_api/evals.py
@@ -115,6 +115,48 @@ def _cost_of(trace: dict[str, Any]) -> float | None:
     return None
 
 
+def _detail_of(trace: dict[str, Any] | None) -> str | None:
+    """The scorer explanation on an eval trace, when the recorder supplied one.
+
+    ``error`` remains reserved for a turn that did not complete. ``detail`` is
+    the grader's explanation of a completed verdict, such as a trajectory
+    mismatch, and is intentionally not inferred from ``error``.
+    """
+    if trace is None:
+        return None
+    detail = (trace.get("metadata") or {}).get("detail")
+    return detail if isinstance(detail, str) else None
+
+
+def _stream_id_of(trace: dict[str, Any] | None) -> str | None:
+    if trace is None:
+        return None
+    stream_id = (trace.get("metadata") or {}).get("stream_id")
+    return stream_id if isinstance(stream_id, str) and stream_id else None
+
+
+def _scorer_of(
+    trace: dict[str, Any] | None,
+) -> Literal["grader", "trajectory"] | None:
+    if trace is None:
+        return None
+    scorer = (trace.get("metadata") or {}).get("scorer")
+    if scorer == "grader":
+        return "grader"
+    if scorer == "trajectory":
+        return "trajectory"
+    return None
+
+
+def _case_count_of(trace: dict[str, Any] | None) -> int | None:
+    if trace is None:
+        return None
+    case_count = (trace.get("metadata") or {}).get("case_count")
+    if isinstance(case_count, int) and not isinstance(case_count, bool):
+        return case_count
+    return None
+
+
 def _supersedes(
     trace: dict[str, Any], current: dict[str, Any] | None, ts: str
 ) -> bool:
@@ -187,6 +229,10 @@ def build_matrix(
                     version=version,
                     status=_status(version, case),
                     model=_model_of(latest.get((version, case))),
+                    detail=_detail_of(latest.get((version, case))),
+                    stream_id=_stream_id_of(latest.get((version, case))),
+                    scorer=_scorer_of(latest.get((version, case))),
+                    case_count=_case_count_of(latest.get((version, case))),
                 )
                 for version in versions
             ],

--- a/apps/api/src/curie_api/routers/evals.py
+++ b/apps/api/src/curie_api/routers/evals.py
@@ -42,7 +42,7 @@ async def trigger_eval(
             raise HTTPException(
                 status.HTTP_404_NOT_FOUND, "version not found for this agent"
             )
-        sha = version.commit_sha
+        sha = version.commit_sha or version.bundle_sha256
     else:
         deployment = await crud.get_active_deployment(
             session, agent.id, Environment.dev
@@ -57,15 +57,14 @@ async def trigger_eval(
             raise HTTPException(
                 status.HTTP_404_NOT_FOUND, "deployed version not found"
             )
-        sha = version.commit_sha or deployment.commit_sha
+        sha = version.commit_sha or deployment.commit_sha or version.bundle_sha256
 
     if sha is None:
-        # A version with no commit sha cannot be keyed in eval traces; this is a
-        # caller/data problem, surfaced as a clean 4xx rather than a 500 on the
-        # required-string EvalJob.sha field.
+        # Git versions use their commit sha. A local deployment has no commit,
+        # so its immutable bundle digest keys the same eval trace dimension.
         raise HTTPException(
             status.HTTP_400_BAD_REQUEST,
-            "resolved version has no commit sha; cannot run eval",
+            "resolved version has neither a commit sha nor a bundle digest; cannot run eval",
         )
 
     if version.bundle_ref is None:
@@ -103,12 +102,21 @@ async def trigger_eval(
 
 @router.get("/matrix", response_model=EvalMatrix)
 async def eval_matrix(
-    lf: LangfuseDep, suite: str, versions: int = 5
+    lf: LangfuseDep,
+    suite: str,
+    versions: int = 5,
+    stream_id: str | None = None,
 ) -> EvalMatrix:
     # Filtered by SUITE, the real dimension on eval traces. There is
     # deliberately no agent filter: eval traces are tagged by suite + version,
     # not agent, so an agent param would be dead. Do not re-add one.
     traces = await lf.list_traces_by_tags(["eval", f"suite:{suite}"])
+    if stream_id is not None:
+        traces = [
+            trace
+            for trace in traces
+            if (trace.get("metadata") or {}).get("stream_id") == stream_id
+        ]
     return build_matrix(traces, suite, versions)
 
 

--- a/apps/api/src/curie_api/schemas.py
+++ b/apps/api/src/curie_api/schemas.py
@@ -1176,6 +1176,10 @@ class EvalCell(BaseModel):
     ``model`` is the model the result was produced under (the matrix's model
     dimension), or ``None`` when the recording run carried no model tag.
 
+    ``detail`` is the scorer's optional explanation for the verdict. It is
+    distinct from a trace's ``error``, which identifies a turn that did not
+    complete.
+
     ``plumbing_ok`` means the case ran to completion but no grader judged it (the
     fake-model tier, ADR-0055). It is a distinct status rather than a pass or a
     fail because it is neither: the fake answers from a canned script, so its cell
@@ -1186,6 +1190,10 @@ class EvalCell(BaseModel):
     version: str
     status: Literal["pass", "fail", "plumbing_ok", "missing"]
     model: str | None = None
+    detail: str | None = None
+    stream_id: str | None = None
+    scorer: Literal["grader", "trajectory"] | None = None
+    case_count: int | None = None
 
 
 class EvalMatrixRow(BaseModel):
@@ -1495,4 +1503,3 @@ class ConsoleSessionOut(BaseModel):
     """
 
     expires_at: datetime
-

--- a/apps/api/tests/test_evals_integration.py
+++ b/apps/api/tests/test_evals_integration.py
@@ -14,7 +14,12 @@ from typing import Any
 import httpx
 import pytest
 from curie_api.config import get_settings
-from curie_worker.eval.models import EvalCaseResult, EvalOutcome, EvalRunResult
+from curie_worker.eval.models import (
+    EvalCaseResult,
+    EvalOutcome,
+    EvalRunResult,
+    EvalScorer,
+)
 from curie_worker.eval.recorder import LangfuseEvalRecorder
 
 
@@ -59,6 +64,50 @@ async def _seed(suite: str, sha_a: str, sha_b: str) -> None:
         await recorder.record(_result(sha_b, suite, c1=True, c2=True))
 
 
+async def _seed_same_sha_runs(suite: str, sha: str) -> None:
+    settings = get_settings()
+    async with httpx.AsyncClient(timeout=30.0) as http:
+        recorder = LangfuseEvalRecorder(
+            base_url=settings.langfuse_host,
+            public_key=settings.langfuse_public_key,
+            secret_key=settings.langfuse_secret_key,
+            client=http,
+        )
+        await recorder.record(
+            EvalRunResult(
+                version=sha,
+                suite=suite,
+                stream_id="1000-0",
+                scorer=EvalScorer.GRADER,
+                results=[
+                    EvalCaseResult(
+                        case_id="ordered",
+                        outcome=EvalOutcome.PASS,
+                        output="old run",
+                        latency_ms=1.0,
+                    )
+                ],
+            )
+        )
+        await recorder.record(
+            EvalRunResult(
+                version=sha,
+                suite=suite,
+                stream_id="2000-0",
+                scorer=EvalScorer.TRAJECTORY,
+                results=[
+                    EvalCaseResult(
+                        case_id="ordered",
+                        outcome=EvalOutcome.FAIL,
+                        output="new run",
+                        latency_ms=1.0,
+                        detail="mode=in_order expected=['Read', 'Bash'] observed=['Bash']",
+                    )
+                ],
+            )
+        )
+
+
 def test_matrix_reflects_seeded_multi_version_scores(
     client: Any, auth_headers: dict[str, str]
 ) -> None:
@@ -90,6 +139,57 @@ def test_matrix_reflects_seeded_multi_version_scores(
     assert cells.get(("c2", sha_a)) == "fail"
     assert cells.get(("c1", sha_b)) == "pass"
     assert cells.get(("c2", sha_b)) == "pass"
+
+
+def test_matrix_stream_id_filters_to_one_authoritative_run(
+    client: Any, auth_headers: dict[str, str]
+) -> None:
+    suite = f"stream-matrix-{secrets.token_hex(4)}"
+    sha = "sha" + secrets.token_hex(3)
+    asyncio.run(_seed_same_sha_runs(suite, sha))
+
+    deadline = time.time() + 60
+    unfiltered: dict[str, Any] = {}
+    filtered: dict[str, Any] = {}
+    while time.time() < deadline:
+        unfiltered_response = client.get(
+            "/evals/matrix", params={"suite": suite}, headers=auth_headers
+        )
+        filtered_response = client.get(
+            "/evals/matrix",
+            params={"suite": suite, "stream_id": "1000-0"},
+            headers=auth_headers,
+        )
+        assert unfiltered_response.status_code == 200, unfiltered_response.text
+        assert filtered_response.status_code == 200, filtered_response.text
+        unfiltered = unfiltered_response.json()
+        filtered = filtered_response.json()
+        if unfiltered["rows"] and filtered["rows"]:
+            unfiltered_streams = {
+                cell["stream_id"]
+                for row in unfiltered["rows"]
+                for cell in row["cells"]
+            }
+            filtered_streams = {
+                cell["stream_id"]
+                for row in filtered["rows"]
+                for cell in row["cells"]
+            }
+            if unfiltered_streams == {"2000-0"} and filtered_streams == {"1000-0"}:
+                break
+        time.sleep(2)
+
+    unfiltered_cells = unfiltered["rows"][0]["cells"]
+    assert len(unfiltered_cells) == 1
+    assert unfiltered_cells[0]["stream_id"] == "2000-0"
+    assert unfiltered_cells[0]["status"] == "fail"
+    assert unfiltered_cells[0]["case_count"] == 1
+
+    filtered_cells = filtered["rows"][0]["cells"]
+    assert len(filtered_cells) == 1
+    assert filtered_cells[0]["stream_id"] == "1000-0"
+    assert filtered_cells[0]["status"] == "pass"
+    assert filtered_cells[0]["case_count"] == 1
 
 
 def test_matrix_requires_api_key(client: Any) -> None:

--- a/apps/api/tests/test_evals_trigger_integration.py
+++ b/apps/api/tests/test_evals_trigger_integration.py
@@ -41,6 +41,7 @@ async def _seed_version_and_dev_deployment(
     version_label: str,
     commit_sha: str | None,
     bundle_ref: str | None,
+    bundle_sha256: str | None,
     deploy: bool = True,
 ) -> dict[str, str | None]:
     """Insert a version (with commit_sha/bundle_ref) and, optionally, an active
@@ -59,6 +60,14 @@ async def _seed_version_and_dev_deployment(
                 commit_sha=commit_sha,
                 bundle_ref=bundle_ref,
             )
+            if bundle_sha256 is not None:
+                assert bundle_ref is not None
+                version = await crud.attach_bundle(
+                    session,
+                    version,
+                    bundle_ref,
+                    bundle_sha256,
+                )
             version_id = str(version.id)
             if deploy:
                 await crud.create_deployment_row(
@@ -70,7 +79,12 @@ async def _seed_version_and_dev_deployment(
                 )
     finally:
         await engine.dispose()
-    return {"version_id": version_id, "sha": commit_sha, "bundle_ref": bundle_ref}
+    return {
+        "version_id": version_id,
+        "sha": commit_sha,
+        "bundle_ref": bundle_ref,
+        "bundle_sha256": bundle_sha256,
+    }
 
 
 def _seed(
@@ -79,6 +93,7 @@ def _seed(
     version_label: str = "v1",
     commit_sha: str | None = "cafef00d",
     bundle_ref: str | None = "bundles/x/y.tar.gz",
+    bundle_sha256: str | None = None,
     deploy: bool = True,
 ) -> dict[str, str | None]:
     return asyncio.run(
@@ -87,6 +102,7 @@ def _seed(
             version_label=version_label,
             commit_sha=commit_sha,
             bundle_ref=bundle_ref,
+            bundle_sha256=bundle_sha256,
             deploy=deploy,
         )
     )
@@ -146,6 +162,52 @@ def test_trigger_enqueues_for_active_dev_deployment(
     assert req.bundle_ref == seeded["bundle_ref"]
     assert req.target_url is None
     assert req.model is None  # no model requested -> worker default
+
+
+def test_trigger_uses_bundle_sha_for_a_local_version_without_a_commit(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    agent = _create_agent(client, auth_headers, "trigger-local-bundle-sha")
+    bundle_sha = "b" * 64
+    seeded = _seed(
+        agent["id"],
+        commit_sha=None,
+        bundle_ref="bundles/local/version.tar.gz",
+        bundle_sha256=bundle_sha,
+    )
+
+    resp = client.post(
+        "/evals/trigger", json={"agent_id": agent["id"]}, headers=auth_headers
+    )
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["version_id"] == seeded["version_id"]
+    assert body["sha"] == bundle_sha
+    payload = _payload_for_stream_id(body["stream_id"])
+    assert payload is not None
+    job = EvalJob.model_validate(payload)
+    assert job.sha == bundle_sha
+    assert job.bundle_ref == seeded["bundle_ref"]
+
+
+def test_trigger_rejects_a_version_with_no_commit_or_bundle_sha(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    agent = _create_agent(client, auth_headers, "trigger-no-version-identity")
+    _seed(
+        agent["id"],
+        commit_sha=None,
+        bundle_ref="bundles/local/version.tar.gz",
+        bundle_sha256=None,
+    )
+
+    resp = client.post(
+        "/evals/trigger", json={"agent_id": agent["id"]}, headers=auth_headers
+    )
+
+    assert resp.status_code == 400, resp.text
+    assert _count_eval_entries_for_agent(agent["id"]) == 0
 
 
 def test_trigger_threads_requested_model_onto_the_job(

--- a/apps/api/tests/test_evals_unit.py
+++ b/apps/api/tests/test_evals_unit.py
@@ -447,3 +447,75 @@ def test_per_version_summaries_surface_a_plumbing_only_row() -> None:
     assert fake.total == 0
     assert fake.plumbing == 2
     assert fake.completed == 0
+
+
+def test_same_sha_cross_agent_runs_keep_one_newest_cell_and_filter_exact_run() -> None:
+    def run_trace(
+        trace_id: str,
+        stream_id: str,
+        agent_id: str,
+        timestamp: str,
+        status: str,
+        scorer: str,
+        model: str | None,
+    ) -> dict[str, Any]:
+        return {
+            "id": trace_id,
+            "timestamp": timestamp,
+            "tags": ["eval", "version:same_sha", "suite:s"],
+            "metadata": {
+                "version": "same_sha",
+                "case_id": "ordered",
+                "outcome": status,
+                "passed": status == "pass",
+                "stream_id": stream_id,
+                "agent_id": agent_id,
+                "scorer": scorer,
+                "model": model,
+                "case_count": 1,
+            },
+        }
+
+    traces = [
+        run_trace(
+            "foreign",
+            "1000-0",
+            "other_agent",
+            "2026-08-19T00:00:00Z",
+            "pass",
+            "grader",
+            None,
+        ),
+        run_trace(
+            "triggered",
+            "2000-0",
+            "requested_agent",
+            "2026-08-19T00:01:00Z",
+            "fail",
+            "trajectory",
+            "resolved_model",
+        ),
+    ]
+
+    unfiltered = build_matrix(traces, "s", 5).model_dump()
+    row = next(row for row in unfiltered["rows"] if row["case_id"] == "ordered")
+    assert len(row["cells"]) == 1
+    newest = row["cells"][0]
+    assert newest["stream_id"] == "2000-0"
+    assert newest["status"] == "fail"
+    assert newest["scorer"] == "trajectory"
+    assert newest["model"] == "resolved_model"
+    assert newest["case_count"] == 1
+
+    requested_traces = [
+        trace
+        for trace in traces
+        if trace["metadata"]["stream_id"] == "1000-0"
+    ]
+    filtered = build_matrix(requested_traces, "s", 5).model_dump()
+    row = next(row for row in filtered["rows"] if row["case_id"] == "ordered")
+    assert len(row["cells"]) == 1
+    exact = row["cells"][0]
+    assert exact["stream_id"] == "1000-0"
+    assert exact["status"] == "pass"
+    assert exact["scorer"] == "grader"

--- a/apps/worker/schema/trajectory.schema.json
+++ b/apps/worker/schema/trajectory.schema.json
@@ -1,0 +1,66 @@
+{
+  "$defs": {
+    "TrajectoryCaseSpec": {
+      "description": "One case id and its deterministic trajectory expectation.",
+      "properties": {
+        "case_id": {
+          "title": "Case Id",
+          "type": "string"
+        },
+        "expected": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Expected",
+          "type": "array"
+        },
+        "mode": {
+          "$ref": "#/$defs/TrajectoryMode"
+        },
+        "threshold": {
+          "default": 1.0,
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Threshold",
+          "type": "number"
+        }
+      },
+      "required": [
+        "case_id",
+        "expected",
+        "mode"
+      ],
+      "title": "TrajectoryCaseSpec",
+      "type": "object"
+    },
+    "TrajectoryMode": {
+      "description": "How an observed tool-call sequence is compared against the expected one.",
+      "enum": [
+        "exact",
+        "in_order",
+        "any_order",
+        "precision",
+        "recall"
+      ],
+      "title": "TrajectoryMode",
+      "type": "string"
+    }
+  },
+  "$id": "https://curietech.ai/schemas/trajectory.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Trajectory specs supplied by the run layer above the frozen case port.",
+  "properties": {
+    "specs": {
+      "items": {
+        "$ref": "#/$defs/TrajectoryCaseSpec"
+      },
+      "title": "Specs",
+      "type": "array"
+    }
+  },
+  "required": [
+    "specs"
+  ],
+  "title": "Curie Trajectory Sidecar",
+  "type": "object"
+}

--- a/apps/worker/src/curie_worker/eval/models.py
+++ b/apps/worker/src/curie_worker/eval/models.py
@@ -193,6 +193,13 @@ class EvalOutcome(StrEnum):
     PLUMBING_OK = "plumbing_ok"
 
 
+class EvalScorer(StrEnum):
+    """The scorer selected by the run layer for an eval run."""
+
+    GRADER = "grader"
+    TRAJECTORY = "trajectory"
+
+
 class EvalCaseResult(BaseModel):
     """The outcome of running one case: its verdict, the output, and any error.
 
@@ -202,6 +209,10 @@ class EvalCaseResult(BaseModel):
     inconsistently, and ``None`` keeps an unmigrated reader fail-safe: it is falsy,
     so a truthiness check under-reports rather than ever going false-green, and
     nothing ever claims a row failed that no grader judged.
+
+    ``detail`` explains a scorer verdict without claiming that the runner or
+    turn failed. Runtime and transport failures remain in ``error``. This keeps
+    a deterministic trajectory mismatch distinct from a broken execution.
 
     ``cost_usd`` is the dollar cost the runner attributed to this case's turn
     when the harness reported usage/pricing; it is ``None`` when cost is not
@@ -216,6 +227,7 @@ class EvalCaseResult(BaseModel):
     output: str
     latency_ms: float
     error: str | None = None
+    detail: str | None = None
     cost_usd: float | None = None
 
     @computed_field  # type: ignore[prop-decorator]
@@ -241,6 +253,8 @@ class EvalRunResult(BaseModel):
     suite: str
     results: list[EvalCaseResult]
     model: str | None = None
+    stream_id: str | None = None
+    scorer: EvalScorer = EvalScorer.GRADER
 
     @property
     def total(self) -> int:

--- a/apps/worker/src/curie_worker/eval/recorder.py
+++ b/apps/worker/src/curie_worker/eval/recorder.py
@@ -110,6 +110,9 @@ class LangfuseEvalRecorder:
                     "version": run.version,
                     "suite": run.suite,
                     "model": run.model,
+                    "stream_id": run.stream_id,
+                    "scorer": run.scorer.value,
+                    "case_count": run.total,
                     "case_id": result.case_id,
                     "outcome": result.outcome.value,
                     # Kept alongside `outcome` so an unmigrated reader stays
@@ -118,6 +121,7 @@ class LangfuseEvalRecorder:
                     "passed": result.passed,
                     "latency_ms": result.latency_ms,
                     "cost_usd": result.cost_usd,
+                    "detail": result.detail,
                     "error": result.error,
                 },
             },

--- a/apps/worker/src/curie_worker/eval/run.py
+++ b/apps/worker/src/curie_worker/eval/run.py
@@ -25,10 +25,11 @@ from pathlib import Path
 import httpx
 
 from ..runner_client import RunnerClient
-from .models import EvalRunResult, EvalSuite
+from .models import EvalRunResult, EvalScorer, EvalSuite
 from .recorder import LangfuseEvalRecorder
 from .runner import EvalRunner
 from .sampling import AggregationPolicy, SampleConfig
+from .scorer import Scorer
 
 
 def load_suite(path: str | Path) -> EvalSuite:
@@ -45,6 +46,8 @@ async def run_eval_suite(
     model: str | None = None,
     fake: bool = False,
     samples: SampleConfig | None = None,
+    scorer: Scorer | None = None,
+    stream_id: str | None,
 ) -> EvalRunResult:
     """Run a suite against a runner endpoint and, if configured, record it.
 
@@ -53,10 +56,12 @@ async def run_eval_suite(
     eval matrix can slice pass-rate/cost by model. ``fake`` says that runner is
     the fake model, whose turns are never graded (ADR-0055). ``samples`` is the
     multi-sample / variance-aware-grading policy (#332); the default (``None`` ->
-    ``n=1``) runs each case once, unchanged.
+    ``n=1``) runs each case once, unchanged. ``scorer`` is selected by the run
+    layer when an optional trajectory sidecar is present; otherwise the runner
+    keeps its ordinary frozen grader scorer.
     """
     async with RunnerClient() as runner:
-        result = await EvalRunner(runner, samples=samples).run(
+        result = await EvalRunner(runner, scorer=scorer, samples=samples).run(
             suite,
             base_url=base_url,
             version=version,
@@ -64,6 +69,8 @@ async def run_eval_suite(
             model=model,
             fake=fake,
         )
+    scorer_name = EvalScorer.TRAJECTORY if scorer is not None else EvalScorer.GRADER
+    result = result.model_copy(update={"stream_id": stream_id, "scorer": scorer_name})
     if recorder is not None:
         await recorder.record(result)
     return result
@@ -103,12 +110,22 @@ async def _main_async(env: Mapping[str, str]) -> int:
                 client=client,
             )
             result = await run_eval_suite(
-                suite, base_url=base_url, version=version, recorder=recorder,
-                model=model, samples=samples,
+                suite,
+                base_url=base_url,
+                version=version,
+                recorder=recorder,
+                model=model,
+                samples=samples,
+                stream_id=None,
             )
     else:
         result = await run_eval_suite(
-            suite, base_url=base_url, version=version, model=model, samples=samples
+            suite,
+            base_url=base_url,
+            version=version,
+            model=model,
+            samples=samples,
+            stream_id=None,
         )
 
     print(result.model_dump_json())

--- a/apps/worker/src/curie_worker/eval/runner.py
+++ b/apps/worker/src/curie_worker/eval/runner.py
@@ -250,6 +250,7 @@ class EvalRunner:
             outcome=EvalOutcome.PASS if verdict.passed else EvalOutcome.FAIL,
             output=output,
             latency_ms=_elapsed_ms(start),
+            detail=verdict.detail,
             # Real token usage x model pricing (#390). None when the model is
             # unpriced or the runner reported no usage, so the matrix omits this
             # case from the model's cost rollup rather than counting it as free.

--- a/apps/worker/src/curie_worker/eval/sampling.py
+++ b/apps/worker/src/curie_worker/eval/sampling.py
@@ -113,6 +113,7 @@ def aggregate(
             outcome=EvalOutcome.PLUMBING_OK,
             output=rep.output,
             latency_ms=total_latency,
+            detail=rep.detail,
             cost_usd=cost,
         )
 
@@ -129,14 +130,16 @@ def aggregate(
 
     outcome = EvalOutcome.PASS if green else EvalOutcome.FAIL
     variance = f"{passes}/{graded_count} samples passed ({bar})"
+    representative = _representative(samples, outcome)
     # Variance rides `error` only on a RED aggregate, matching the runner's
     # convention that `error` explains why a case is not green; a flaky-but-green
     # case (e.g. 2/3 under majority) reports GREEN and leaves `error` clear.
     return EvalCaseResult(
         case_id=case_id,
         outcome=outcome,
-        output=_representative(samples, outcome).output,
+        output=representative.output,
         latency_ms=total_latency,
         error=None if green else f"variance-aware grading failed: {variance}",
+        detail=representative.detail,
         cost_usd=cost,
     )

--- a/apps/worker/src/curie_worker/eval/schema_export.py
+++ b/apps/worker/src/curie_worker/eval/schema_export.py
@@ -1,7 +1,7 @@
-"""Export the eval-case models to a canonical JSON Schema document.
+"""Export eval case and trajectory sidecar models to canonical schemas.
 
-Committed and drift-checked exactly like the plugin-format schema. Run as
-``python -m curie_worker.eval.schema_export`` to rewrite the committed schema.
+Committed and drift checked exactly like the plugin format schema. Run as
+``python -m curie_worker.eval.schema_export`` to rewrite both artifacts.
 """
 
 import json
@@ -11,10 +11,12 @@ from typing import Any
 from pydantic.json_schema import models_json_schema
 
 from .models import EvalCase, EvalSuite, Grader
+from .trajectory import TrajectorySidecar
 
 _MODELS = (EvalSuite, EvalCase, Grader)
 
 SCHEMA_ID = "https://curietech.ai/schemas/eval-cases.schema.json"
+TRAJECTORY_SCHEMA_ID = "https://curietech.ai/schemas/trajectory.schema.json"
 
 
 def schema_path() -> Path:
@@ -54,6 +56,37 @@ def write_schema() -> Path:
     return path
 
 
+def trajectory_schema_path() -> Path:
+    """The committed trajectory sidecar schema location."""
+
+    return Path(__file__).resolve().parents[3] / "schema" / "trajectory.schema.json"
+
+
+def build_trajectory_schema() -> dict[str, Any]:
+    """Build the JSON Schema document for the trajectory sidecar."""
+
+    generated = TrajectorySidecar.model_json_schema(ref_template="#/$defs/{model}")
+    generated["$schema"] = "https://json-schema.org/draft/2020-12/schema"
+    generated["$id"] = TRAJECTORY_SCHEMA_ID
+    generated["title"] = "Curie Trajectory Sidecar"
+    return generated
+
+
+def render_trajectory_schema() -> str:
+    """Render the canonical trajectory sidecar schema."""
+
+    return json.dumps(build_trajectory_schema(), indent=2, sort_keys=True) + "\n"
+
+
+def write_trajectory_schema() -> Path:
+    """Write the trajectory schema and return its path."""
+
+    path = trajectory_schema_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(render_trajectory_schema(), encoding="utf-8")
+    return path
+
+
 if __name__ == "__main__":
-    written = write_schema()
-    print(f"wrote {written}")
+    for written in (write_schema(), write_trajectory_schema()):
+        print(f"wrote {written}")

--- a/apps/worker/src/curie_worker/eval/stream.py
+++ b/apps/worker/src/curie_worker/eval/stream.py
@@ -7,7 +7,9 @@ For each entry it:
 
   1. fetches the version's immutable bundle from RustFS by ``bundle_ref`` and loads
      the suite from the bundle's own ``evals/cases.json`` (the same shape the CLI's
-     ``curie skill eval`` reads); the ``suite`` field names it and tags Langfuse;
+     ``curie skill eval`` reads); an optional ``evals/trajectory.json`` selects
+     deterministic trajectory scoring above that frozen format; the ``suite``
+     field names it and tags Langfuse;
   2. runs the suite against the runner: ``target_url`` if given (the dev/test
      shortcut), otherwise provisions a sandbox for the version via the G1
      substrate (the same boot env F2 uses) and tears it down in a finally;
@@ -30,6 +32,7 @@ import logging
 import secrets
 import tempfile
 import uuid
+from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
@@ -64,9 +67,11 @@ from ..config import WorkerConfig
 from ..sandbox import SandboxSubstrate
 from ..sandbox.types import SandboxError
 from ..stream_consumer import DeliverySpec, ReadLoopSpec, StreamConsumer
-from .models import EvalRunResult, EvalSuite
+from .models import EvalCaseResult, EvalOutcome, EvalRunResult, EvalScorer, EvalSuite
 from .recorder import LangfuseEvalRecorder
 from .run import run_eval_suite
+from .scorer import TrajectoryScorer
+from .trajectory import TrajectorySidecar
 
 logger = logging.getLogger(__name__)
 
@@ -86,6 +91,23 @@ _EVAL_READ_ERROR_BACKOFF_S = 0.5
 # Page size for the PEL scan in the delivery-cap check (#535); mirrors the runs
 # lane's _CAP_SCAN_PAGE so the whole pending list is cap-checked, not just its head.
 _EVAL_CAP_SCAN_PAGE = 1000
+
+
+@dataclass(frozen=True)
+class _ExtractedEvalFiles:
+    """Validated cases plus the optional run layer sidecar."""
+
+    suite: EvalSuite
+    trajectory_bytes: bytes | None
+
+
+@dataclass(frozen=True)
+class _LoadedEvalSuite:
+    """One suite and the scorer selection resolved above the frozen port."""
+
+    suite: EvalSuite
+    scorer: TrajectoryScorer | None = None
+    trajectory_error: str | None = None
 
 
 class EvalReporter:
@@ -143,6 +165,26 @@ def load_suite_from_bundle(
     decision 3), or a missing/invalid suite file. The size/ratio caps default
     to ``plugin_format``'s generous fallbacks; ``_load_suite`` passes the
     operator-configured ``WorkerConfig`` values instead."""
+    files = _extract_eval_files(
+        data,
+        suite_name,
+        max_uncompressed_bytes=max_uncompressed_bytes,
+        max_compression_ratio=max_compression_ratio,
+        max_members=max_members,
+    )
+    return None if files is None else files.suite
+
+
+def _extract_eval_files(
+    data: bytes,
+    suite_name: str,
+    *,
+    max_uncompressed_bytes: int,
+    max_compression_ratio: float,
+    max_members: int,
+) -> _ExtractedEvalFiles | None:
+    """Extract the eval files used by the run layer."""
+
     try:
         with tempfile.TemporaryDirectory() as tmp:
             dest = Path(tmp)
@@ -153,14 +195,50 @@ def load_suite_from_bundle(
                 max_compression_ratio=max_compression_ratio,
                 max_members=max_members,
             )
-            cases = next((p for p in dest.rglob("cases.json") if p.parent.name == "evals"), None)
+            cases = next(
+                (path for path in dest.rglob("cases.json") if path.parent.name == "evals"),
+                None,
+            )
             if cases is None:
                 return None
-            loaded = EvalSuite.model_validate_json(cases.read_text())
+            parsed = EvalSuite.model_validate_json(cases.read_bytes())
+            trajectory = cases.parent / "trajectory.json"
+            trajectory_bytes = trajectory.read_bytes() if trajectory.is_file() else None
     except Exception:
         logger.exception("could not load eval suite from bundle")
         return None
-    return EvalSuite(name=suite_name, cases=loaded.cases)
+
+    return _ExtractedEvalFiles(
+        suite=EvalSuite(name=suite_name, cases=parsed.cases),
+        trajectory_bytes=trajectory_bytes,
+    )
+
+
+def _select_scorer(files: _ExtractedEvalFiles) -> _LoadedEvalSuite:
+    """Validate an optional sidecar and select trajectory scoring when present."""
+
+    if files.trajectory_bytes is None:
+        return _LoadedEvalSuite(suite=files.suite)
+
+    try:
+        sidecar = TrajectorySidecar.model_validate_json(files.trajectory_bytes)
+    except Exception as exc:
+        return _LoadedEvalSuite(
+            suite=files.suite,
+            trajectory_error=f"invalid trajectory sidecar: {exc}",
+        )
+
+    case_ids = [case.id for case in files.suite.cases]
+    if len(case_ids) != len(set(case_ids)):
+        return _LoadedEvalSuite(
+            suite=files.suite,
+            trajectory_error="trajectory scoring rejects duplicate suite case ids",
+        )
+
+    return _LoadedEvalSuite(
+        suite=files.suite,
+        scorer=TrajectoryScorer(specs=sidecar.to_spec_map()),
+    )
 
 
 class EvalStreamConsumer(StreamConsumer):
@@ -291,7 +369,7 @@ class EvalStreamConsumer(StreamConsumer):
                 await self._dead_letter(entry_id, fields, reason="unparseable", delivery_count=1)
                 return
             try:
-                result = await self._run_and_report(item)
+                result = await self._run_and_report(item, entry_id)
                 logger.info("eval %s @ %s: %s", item.suite, item.sha, result.summary())
             except Exception:
                 # An unexpected error before the report attempt: leave pending so
@@ -302,25 +380,64 @@ class EvalStreamConsumer(StreamConsumer):
         finally:
             self._inflight_ids.discard(entry_id)
 
-    async def _run_and_report(self, item: EvalJob) -> EvalRunResult:
+    async def _run_and_report(self, item: EvalJob, stream_id: str) -> EvalRunResult:
         repo = await self._repo_lookup.repo_full_name(item.agent_id)
-        suite = await self._load_suite(item)
-        if suite is None:
+        loaded = await self._load_suite(item)
+        if loaded is None:
             return await self._report_failed(item, repo, "unresolvable suite/bundle")
+
+        suite = loaded.suite
+        model = self._eval_model(item)
+        if loaded.trajectory_error is not None:
+            result = EvalRunResult(
+                version=item.sha,
+                suite=suite.name,
+                model=model,
+                stream_id=stream_id,
+                scorer=EvalScorer.TRAJECTORY,
+                results=[
+                    EvalCaseResult(
+                        case_id=case.id,
+                        outcome=EvalOutcome.FAIL,
+                        output="",
+                        latency_ms=0.0,
+                        detail=loaded.trajectory_error,
+                    )
+                    for case in suite.cases
+                ],
+            )
+            if self._recorder is not None:
+                await self._recorder.record(result)
+            await self._report(item, repo, result)
+            return result
 
         base_url, release_key, token = await self._acquire_target(item)
         if base_url is None:
             return await self._report_failed(item, repo, "runner provisioning failed")
         try:
-            result = await run_eval_suite(
-                suite,
-                base_url=base_url,
-                version=item.sha,
-                recorder=self._recorder,
-                token=token,
-                model=self._eval_model(item),
-                fake=self._config.fake_model,
-            )
+            if loaded.scorer is None:
+                result = await run_eval_suite(
+                    suite,
+                    base_url=base_url,
+                    version=item.sha,
+                    recorder=self._recorder,
+                    token=token,
+                    model=model,
+                    fake=self._config.fake_model,
+                    stream_id=stream_id,
+                )
+            else:
+                result = await run_eval_suite(
+                    suite,
+                    base_url=base_url,
+                    version=item.sha,
+                    recorder=self._recorder,
+                    token=token,
+                    model=model,
+                    fake=self._config.fake_model,
+                    scorer=loaded.scorer,
+                    stream_id=stream_id,
+                )
         finally:
             if release_key is not None:
                 await asyncio.to_thread(self._substrate.release, release_key)
@@ -328,7 +445,7 @@ class EvalStreamConsumer(StreamConsumer):
         await self._report(item, repo, result)
         return result
 
-    async def _load_suite(self, item: EvalJob) -> EvalSuite | None:
+    async def _load_suite(self, item: EvalJob) -> _LoadedEvalSuite | None:
         if item.bundle_ref is None:
             return None
         try:
@@ -336,13 +453,14 @@ class EvalStreamConsumer(StreamConsumer):
         except Exception:
             logger.exception("could not fetch bundle %s", item.bundle_ref)
             return None
-        return load_suite_from_bundle(
+        files = _extract_eval_files(
             data,
             item.suite,
             max_uncompressed_bytes=self._config.bundle_max_uncompressed_bytes,
             max_compression_ratio=self._config.bundle_max_compression_ratio,
             max_members=self._config.bundle_max_members,
         )
+        return None if files is None else _select_scorer(files)
 
     async def _acquire_target(self, item: EvalJob) -> tuple[str | None, str | None, str | None]:
         if item.target_url is not None:
@@ -360,9 +478,7 @@ class EvalStreamConsumer(StreamConsumer):
             # claim may begin. The secrets/env prep above is cheap and does not
             # touch the cluster, so it stays outside the slot.
             async with self._claim_slots:
-                handle = await asyncio.to_thread(
-                    self._substrate.claim, release_key, env=env
-                )
+                handle = await asyncio.to_thread(self._substrate.claim, release_key, env=env)
         except SandboxError:
             logger.exception("could not provision a runner for eval %s", item.sha)
             return None, None, None

--- a/apps/worker/src/curie_worker/eval/trajectory.py
+++ b/apps/worker/src/curie_worker/eval/trajectory.py
@@ -1,0 +1,56 @@
+"""Validated trajectory sidecar models for deterministic eval scoring.
+
+The sidecar lives beside ``evals/cases.json`` and is owned by the run layer.
+It deliberately does not extend the frozen eval case format.
+"""
+
+from __future__ import annotations
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    model_validator,
+)
+
+from .scorer import TrajectoryMode, TrajectorySpec
+
+
+class TrajectoryCaseSpec(BaseModel):
+    """One case id and its deterministic trajectory expectation."""
+
+    model_config = ConfigDict(extra="ignore", frozen=True)
+
+    case_id: str
+    expected: list[str]
+    mode: TrajectoryMode
+    threshold: float = Field(default=1.0, strict=True, ge=0.0, le=1.0)
+
+    def to_domain(self) -> TrajectorySpec:
+        """Convert the transport model to the scorer domain model."""
+
+        return TrajectorySpec(
+            expected=tuple(self.expected),
+            mode=self.mode,
+            threshold=self.threshold,
+        )
+
+
+class TrajectorySidecar(BaseModel):
+    """Trajectory specs supplied by the run layer above the frozen case port."""
+
+    model_config = ConfigDict(extra="ignore", frozen=True)
+
+    specs: list[TrajectoryCaseSpec]
+
+    @model_validator(mode="after")
+    def _case_ids_are_unique(self) -> TrajectorySidecar:
+        case_ids = [spec.case_id for spec in self.specs]
+        if len(case_ids) != len(set(case_ids)):
+            raise ValueError("trajectory spec case ids must be unique")
+        return self
+
+    def to_spec_map(self) -> dict[str, TrajectorySpec]:
+        """Return the case id map consumed by :class:`TrajectoryScorer`."""
+
+        return {spec.case_id: spec.to_domain() for spec in self.specs}

--- a/apps/worker/tests/eval/test_recorder.py
+++ b/apps/worker/tests/eval/test_recorder.py
@@ -322,6 +322,61 @@ def test_a_graded_run_scores_every_case_and_is_not_tagged_plumbing() -> None:
     asyncio.run(go())
 
 
+def test_scorer_detail_is_recorded_separately_from_runtime_error() -> None:
+    async def go() -> None:
+        run = EvalRunResult(
+            version="v1",
+            suite="trajectory",
+            results=[
+                EvalCaseResult(
+                    case_id="missing",
+                    outcome=EvalOutcome.FAIL,
+                    output="all done",
+                    latency_ms=1.0,
+                    detail="no trajectory spec for case 'missing'",
+                )
+            ],
+        )
+
+        batch = await _capture_batch(run)
+        metadata = _trace_by_case(batch, "missing")["metadata"]
+        assert metadata["detail"] == "no trajectory spec for case 'missing'"
+        assert metadata["error"] is None
+
+    asyncio.run(go())
+
+
+def test_every_trace_records_the_authoritative_run_case_count() -> None:
+    async def go() -> None:
+        run = EvalRunResult(
+            version="v1",
+            suite="trajectory",
+            stream_id="2000-0",
+            results=[
+                EvalCaseResult(
+                    case_id="ordered",
+                    outcome=EvalOutcome.PASS,
+                    output="all done",
+                    latency_ms=1.0,
+                ),
+                EvalCaseResult(
+                    case_id="missing",
+                    outcome=EvalOutcome.FAIL,
+                    output="all done",
+                    latency_ms=1.0,
+                    detail="no trajectory spec for case 'missing'",
+                ),
+            ],
+        )
+
+        batch = await _capture_batch(run)
+        traces = [event["body"] for event in batch if event["type"] == "trace-create"]
+        assert len(traces) == 2
+        assert {trace["metadata"]["case_count"] for trace in traces} == {2}
+
+    asyncio.run(go())
+
+
 def test_records_per_case_results_and_reads_them_back() -> None:
     async def go() -> None:
         async with httpx.AsyncClient(timeout=30.0) as client:

--- a/apps/worker/tests/eval/test_runner.py
+++ b/apps/worker/tests/eval/test_runner.py
@@ -17,6 +17,7 @@ from curie_worker.eval import (
     GraderKind,
     SampleConfig,
     ScoreResult,
+    TrajectoryScorer,
 )
 
 CONTAINS = GraderKind.CONTAINS
@@ -420,6 +421,26 @@ def _one_case_suite() -> EvalSuite:
         name="s",
         cases=[EvalCase(id="c", input="q", grader=Grader(kind=CONTAINS, expected="deal-desk"))],
     )
+
+
+def test_scorer_failure_detail_is_preserved_separately_from_runtime_error(
+    make_eval_harness,
+) -> None:
+    """A scorer rejection explains the verdict without claiming the turn broke."""
+
+    async def go() -> None:
+        async with make_eval_harness() as (base_url, fake, client):
+            fake.responses = {"q": "all done"}
+            result = await EvalRunner(client, scorer=TrajectoryScorer()).run(
+                _one_case_suite(), base_url=base_url, version="v1"
+            )
+
+            case = result.results[0]
+            assert case.outcome is EvalOutcome.FAIL
+            assert case.detail == "no trajectory spec for case 'c'"
+            assert case.error is None
+
+    asyncio.run(go())
 
 
 def test_a_fake_turn_is_never_graded_and_is_neither_pass_nor_fail(make_eval_harness) -> None:

--- a/apps/worker/tests/eval/test_stream.py
+++ b/apps/worker/tests/eval/test_stream.py
@@ -847,17 +847,33 @@ def test_pending_entry_from_a_dead_consumer_is_reclaimed(make_eval_harness, bund
 RUNNER_TOKEN_ENV = "CURIE_RUNNER_TOKEN"
 
 
-def _suite_bundle(suite: EvalSuite) -> bytes:
+def _suite_bundle(
+    suite: EvalSuite,
+    *,
+    trajectory: dict[str, object] | str | None = None,
+    cases_payload: bytes | None = None,
+) -> bytes:
     """A minimal tar.gz carrying evals/cases.json, so the real
     load_suite_from_bundle returns a real suite (the RustFS fetch is the only
     faked boundary)."""
-    payload = suite.model_dump_json().encode("utf-8")
+    payload = cases_payload or suite.model_dump_json().encode("utf-8")
     buf = io.BytesIO()
     with tarfile.open(fileobj=buf, mode="w:gz") as tf:
         info = tarfile.TarInfo("evals/cases.json")
         info.size = len(payload)
         tf.addfile(info, io.BytesIO(payload))
+        if trajectory is not None:
+            trajectory_payload = (
+                trajectory if isinstance(trajectory, str) else json.dumps(trajectory)
+            ).encode("utf-8")
+            trajectory_info = tarfile.TarInfo("evals/trajectory.json")
+            trajectory_info.size = len(trajectory_payload)
+            tf.addfile(trajectory_info, io.BytesIO(trajectory_payload))
     return buf.getvalue()
+
+
+def _trajectory_sidecar(specs: list[dict[str, object]]) -> dict[str, object]:
+    return {"specs": specs}
 
 
 class _FakeBundleStore:
@@ -1174,7 +1190,7 @@ def test_a_fake_run_carrying_a_failure_still_posts_its_report(monkeypatch) -> No
     item = _item(suite="s", sha="deadbeef", bundle_ref="bundles/x.tgz", target_url=None)
 
     async def go() -> None:
-        await consumer._run_and_report(item)
+        await consumer._run_and_report(item, "test-stream-id")
 
     asyncio.run(go())
 
@@ -1206,7 +1222,7 @@ def test_a_real_run_still_posts_its_report(monkeypatch) -> None:
     item = _item(suite="s", sha="deadbeef", bundle_ref="bundles/x.tgz", target_url=None)
 
     async def go() -> None:
-        await consumer._run_and_report(item)
+        await consumer._run_and_report(item, "test-stream-id")
 
     asyncio.run(go())
 
@@ -1268,11 +1284,15 @@ def test_eval_threads_claim_token_into_run_eval_suite(monkeypatch) -> None:
         token: Any = None,
         model: Any = None,
         fake: Any = None,
+        stream_id: str | None,
+        scorer: Any = None,
     ) -> EvalRunResult:
         captured["base_url"] = base_url
         captured["token"] = token
         captured["model"] = model
         captured["fake"] = fake
+        captured["stream_id"] = stream_id
+        captured["scorer"] = scorer
         return EvalRunResult(version=version, suite=suite.name, results=[])
 
     monkeypatch.setattr(stream_module, "run_eval_suite", _capture_run)
@@ -1293,12 +1313,14 @@ def test_eval_threads_claim_token_into_run_eval_suite(monkeypatch) -> None:
     item = _item(suite="s", sha="deadbeef", bundle_ref="bundles/x.tgz", target_url=None)
 
     async def go() -> None:
-        await consumer._run_and_report(item)
+        await consumer._run_and_report(item, "test-stream-id")
 
     asyncio.run(go())
 
     assert captured["base_url"] == "http://sandbox.local:8080"
     assert captured["token"] == "tok-eval-xyz"
+    assert captured["stream_id"] == "test-stream-id"
+    assert captured["scorer"] is None
 
 
 @pytest.mark.parametrize("fake_model", [True, False])
@@ -1336,7 +1358,7 @@ def test_eval_threads_the_workers_fake_state_into_run_eval_suite(
     item = _item(suite="s", sha="deadbeef", bundle_ref="bundles/x.tgz", target_url=None)
 
     async def go() -> None:
-        await consumer._run_and_report(item)
+        await consumer._run_and_report(item, "test-stream-id")
 
     asyncio.run(go())
 
@@ -1429,3 +1451,535 @@ def test_committed_fixture_loads_from_bundle_with_name_override(
     assert len(suite.cases) == 1
     assert suite.cases[0].grader.grade("I am the example agent.") is True
     assert suite.cases[0].grader.grade("literally anything") is False
+
+
+def test_bundle_trajectory_sidecar_scores_observed_calls_instead_of_text(
+    make_eval_harness,
+    bundles,
+) -> None:
+    store, upload = bundles
+
+    async def go() -> None:
+        async with make_eval_harness() as (base_url, fake, _client):
+            suite = EvalSuite(
+                name="trajectory",
+                cases=[
+                    EvalCase(
+                        id="right_order",
+                        input="right",
+                        grader=Grader(kind=CONTAINS, expected="text grader pass"),
+                    ),
+                    EvalCase(
+                        id="wrong_order",
+                        input="wrong",
+                        grader=Grader(kind=CONTAINS, expected="text grader pass"),
+                    ),
+                ],
+            )
+            fake.responses = {
+                "right": "text grader miss",
+                "wrong": "text grader pass",
+            }
+            fake.tool_calls = {
+                "right": ["search", "fetch"],
+                "wrong": ["fetch", "search"],
+            }
+            cases_payload = (
+                json.dumps(suite.model_dump(mode="json"), indent=2, sort_keys=True)
+                + "\n"
+            ).encode("utf-8")
+            sidecar = _trajectory_sidecar(
+                [
+                    {
+                        "case_id": case_id,
+                        "expected": ["search", "fetch"],
+                        "mode": "exact",
+                        "threshold": 1.0,
+                    }
+                    for case_id in ("right_order", "wrong_order")
+                ],
+            )
+            reporter = _FakeReporter()
+            bundle_ref = upload(
+                _suite_bundle(
+                    suite,
+                    trajectory=sidecar,
+                    cases_payload=cases_payload,
+                )
+            )
+            consumer = _consumer(
+                WorkerConfig(fake_model=False),
+                bundle_store=store,
+                substrate=_UnusedSubstrate(),
+                reporter=reporter,
+                recorder=None,
+                repo_lookup=_StubRepo(),
+            )
+            item = _item(
+                suite="trajectory",
+                sha="trajectory_sha",
+                bundle_ref=bundle_ref,
+                target_url=base_url,
+            )
+
+            result = await consumer._run_and_report(item, "test-stream-id")
+
+            by_id = {row.case_id: row for row in result.results}
+            assert by_id["right_order"].outcome is EvalOutcome.PASS
+            assert by_id["right_order"].detail is None
+            assert by_id["wrong_order"].outcome is EvalOutcome.FAIL
+            assert by_id["wrong_order"].detail == (
+                "mode=exact expected=['search', 'fetch'] "
+                "observed=['fetch', 'search']"
+            )
+            assert by_id["wrong_order"].error is None
+            assert reporter.reports[0].passed_count == 1
+            assert reporter.reports[0].total == 2
+
+    asyncio.run(go())
+
+
+def test_bundle_trajectory_sidecar_fails_closed_for_a_missing_spec(
+    make_eval_harness,
+    bundles,
+) -> None:
+    store, upload = bundles
+
+    async def go() -> None:
+        async with make_eval_harness() as (base_url, fake, _client):
+            suite = EvalSuite(
+                name="trajectory",
+                cases=[
+                    EvalCase(
+                        id="missing",
+                        input="run",
+                        grader=Grader(kind=CONTAINS, expected="text grader pass"),
+                    )
+                ],
+            )
+            fake.responses = {"run": "text grader pass"}
+            fake.tool_calls = {"run": ["search", "fetch"]}
+            cases_payload = suite.model_dump_json().encode("utf-8")
+            sidecar = _trajectory_sidecar([])
+            bundle_ref = upload(
+                _suite_bundle(
+                    suite,
+                    trajectory=sidecar,
+                    cases_payload=cases_payload,
+                )
+            )
+            consumer = _consumer(
+                WorkerConfig(fake_model=False),
+                bundle_store=store,
+                substrate=_UnusedSubstrate(),
+                reporter=_FakeReporter(),
+                recorder=None,
+                repo_lookup=_StubRepo(),
+            )
+            item = _item(
+                suite="trajectory",
+                sha="missing_spec_sha",
+                bundle_ref=bundle_ref,
+                target_url=base_url,
+            )
+
+            result = await consumer._run_and_report(item, "test-stream-id")
+
+            case = result.results[0]
+            assert case.outcome is EvalOutcome.FAIL
+            assert case.detail == "no trajectory spec for case 'missing'"
+            assert case.error is None
+            assert len(fake.seen) == 1
+
+    asyncio.run(go())
+
+
+def test_bundle_without_trajectory_sidecar_keeps_ordinary_grading(
+    make_eval_harness,
+    bundles,
+) -> None:
+    store, upload = bundles
+
+    async def go() -> None:
+        async with make_eval_harness() as (base_url, fake, _client):
+            suite = EvalSuite(
+                name="ordinary",
+                cases=[
+                    EvalCase(
+                        id="ordinary",
+                        input="run",
+                        grader=Grader(kind=CONTAINS, expected="text grader pass"),
+                    )
+                ],
+            )
+            fake.responses = {"run": "text grader pass"}
+            fake.tool_calls = {"run": ["fetch", "search"]}
+            bundle_ref = upload(_suite_bundle(suite))
+            consumer = _consumer(
+                WorkerConfig(fake_model=False),
+                bundle_store=store,
+                substrate=_UnusedSubstrate(),
+                reporter=_FakeReporter(),
+                recorder=None,
+                repo_lookup=_StubRepo(),
+            )
+            item = _item(
+                suite="ordinary",
+                sha="ordinary_sha",
+                bundle_ref=bundle_ref,
+                target_url=base_url,
+            )
+
+            result = await consumer._run_and_report(item, "test-stream-id")
+
+            case = result.results[0]
+            assert case.outcome is EvalOutcome.PASS
+            assert case.detail is None
+            assert len(fake.seen) == 1
+
+    asyncio.run(go())
+
+
+def test_invalid_bundle_trajectory_sidecar_fails_before_running_cases(
+    make_eval_harness,
+    bundles,
+) -> None:
+    store, upload = bundles
+
+    async def go() -> None:
+        async with make_eval_harness() as (base_url, fake, _client):
+            suite = EvalSuite(
+                name="trajectory",
+                cases=[
+                    EvalCase(
+                        id="known",
+                        input="run",
+                        grader=Grader(kind=CONTAINS, expected="text grader pass"),
+                    )
+                ],
+            )
+            fake.responses = {"run": "text grader pass"}
+            cases_payload = suite.model_dump_json().encode("utf-8")
+            bundle_ref = upload(
+                _suite_bundle(
+                    suite,
+                    trajectory="{",
+                    cases_payload=cases_payload,
+                )
+            )
+            consumer = _consumer(
+                WorkerConfig(fake_model=False),
+                bundle_store=store,
+                substrate=_UnusedSubstrate(),
+                reporter=_FakeReporter(),
+                recorder=None,
+                repo_lookup=_StubRepo(),
+            )
+            item = _item(
+                suite="trajectory",
+                sha="invalid_sidecar_sha",
+                bundle_ref=bundle_ref,
+                target_url=base_url,
+            )
+
+            result = await consumer._run_and_report(item, "test-stream-id")
+
+            assert len(result.results) == 1
+            case = result.results[0]
+            assert case.outcome is EvalOutcome.FAIL
+            assert case.detail is not None
+            detail = case.detail.lower()
+            assert "trajectory" in detail
+            assert "invalid" in detail
+            assert case.error is None
+            assert fake.seen == []
+
+    asyncio.run(go())
+
+
+def test_trajectory_sidecar_ignores_specs_for_unknown_suite_cases(
+    make_eval_harness,
+    bundles,
+) -> None:
+    store, upload = bundles
+
+    async def go() -> None:
+        async with make_eval_harness() as (base_url, fake, _client):
+            suite = EvalSuite(
+                name="trajectory",
+                cases=[
+                    EvalCase(
+                        id="known",
+                        input="run",
+                        grader=Grader(kind=CONTAINS, expected="text must miss"),
+                    )
+                ],
+            )
+            fake.responses = {"run": "unrelated"}
+            fake.tool_calls = {"run": ["search"]}
+            sidecar = _trajectory_sidecar(
+                [
+                    {
+                        "case_id": "known",
+                        "expected": ["search"],
+                        "mode": "exact",
+                        "threshold": 1.0,
+                    },
+                    {
+                        "case_id": "not_in_suite",
+                        "expected": ["unused"],
+                        "mode": "exact",
+                        "threshold": 1.0,
+                    },
+                ]
+            )
+            bundle_ref = upload(_suite_bundle(suite, trajectory=sidecar))
+            consumer = _consumer(
+                WorkerConfig(fake_model=False),
+                bundle_store=store,
+                substrate=_UnusedSubstrate(),
+                reporter=_FakeReporter(),
+                recorder=None,
+                repo_lookup=_StubRepo(),
+            )
+            item = _item(
+                suite="trajectory",
+                sha="unknown_spec_sha",
+                bundle_ref=bundle_ref,
+                target_url=base_url,
+            )
+
+            result = await consumer._run_and_report(item, "test-stream-id")
+
+            assert len(result.results) == 1
+            assert result.results[0].outcome is EvalOutcome.PASS
+            assert result.results[0].detail is None
+            assert len(fake.seen) == 1
+
+    asyncio.run(go())
+
+
+def test_trajectory_sidecar_rejects_duplicate_suite_case_ids(
+    make_eval_harness,
+    bundles,
+) -> None:
+    store, upload = bundles
+
+    async def go() -> None:
+        async with make_eval_harness() as (base_url, fake, _client):
+            suite = EvalSuite(
+                name="trajectory",
+                cases=[
+                    EvalCase(
+                        id="duplicate",
+                        input="first",
+                        grader=Grader(kind=CONTAINS, expected="text pass"),
+                    ),
+                    EvalCase(
+                        id="duplicate",
+                        input="second",
+                        grader=Grader(kind=CONTAINS, expected="text pass"),
+                    ),
+                ],
+            )
+            fake.responses = {"first": "text pass", "second": "text pass"}
+            fake.tool_calls = {"first": ["Read"], "second": ["Read"]}
+            cases_payload = suite.model_dump_json().encode("utf-8")
+            sidecar = _trajectory_sidecar(
+                [
+                    {
+                        "case_id": "duplicate",
+                        "expected": ["Read"],
+                        "mode": "exact",
+                        "threshold": 1.0,
+                    }
+                ],
+            )
+            bundle_ref = upload(
+                _suite_bundle(
+                    suite,
+                    trajectory=sidecar,
+                    cases_payload=cases_payload,
+                )
+            )
+            consumer = _consumer(
+                WorkerConfig(fake_model=False),
+                bundle_store=store,
+                substrate=_UnusedSubstrate(),
+                reporter=_FakeReporter(),
+                recorder=None,
+                repo_lookup=_StubRepo(),
+            )
+            item = _item(
+                suite="trajectory",
+                sha="duplicate_case_sha",
+                bundle_ref=bundle_ref,
+                target_url=base_url,
+            )
+
+            result = await consumer._run_and_report(item, "test-stream-id")
+
+            assert len(result.results) == 2
+            assert all(row.outcome is EvalOutcome.FAIL for row in result.results)
+            assert all(
+                row.detail is not None
+                and "duplicate" in row.detail.lower()
+                and "case" in row.detail.lower()
+                for row in result.results
+            )
+            assert fake.seen == []
+
+    asyncio.run(go())
+
+
+def test_ordinary_suite_keeps_duplicate_case_ids_when_no_sidecar_selects_trajectory(
+    make_eval_harness,
+    bundles,
+) -> None:
+    store, upload = bundles
+
+    async def go() -> None:
+        async with make_eval_harness() as (base_url, fake, _client):
+            suite = EvalSuite(
+                name="ordinary",
+                cases=[
+                    EvalCase(
+                        id="duplicate",
+                        input="first",
+                        grader=Grader(kind=CONTAINS, expected="text pass"),
+                    ),
+                    EvalCase(
+                        id="duplicate",
+                        input="second",
+                        grader=Grader(kind=CONTAINS, expected="text pass"),
+                    ),
+                ],
+            )
+            fake.responses = {"first": "text pass", "second": "text pass"}
+            bundle_ref = upload(_suite_bundle(suite))
+            consumer = _consumer(
+                WorkerConfig(fake_model=False),
+                bundle_store=store,
+                substrate=_UnusedSubstrate(),
+                reporter=_FakeReporter(),
+                recorder=None,
+                repo_lookup=_StubRepo(),
+            )
+            item = _item(
+                suite="ordinary",
+                sha="ordinary_duplicate_sha",
+                bundle_ref=bundle_ref,
+                target_url=base_url,
+            )
+
+            result = await consumer._run_and_report(item, "test-stream-id")
+
+            assert [row.outcome for row in result.results] == [
+                EvalOutcome.PASS,
+                EvalOutcome.PASS,
+            ]
+            assert len(fake.seen) == 2
+
+    asyncio.run(go())
+
+
+def test_stream_records_the_trigger_identity_and_selected_trajectory_scorer(
+    make_eval_harness,
+    bundles,
+) -> None:
+    store, upload = bundles
+
+    async def go() -> None:
+        async with make_eval_harness() as (base_url, fake, _client):
+            suite = EvalSuite(
+                name="trajectory",
+                cases=[
+                    EvalCase(
+                        id="ordered",
+                        input="run",
+                        grader=Grader(kind=CONTAINS, expected="text must miss"),
+                    )
+                ],
+            )
+            fake.responses = {"run": "unrelated"}
+            fake.tool_calls = {"run": ["Read", "Bash"]}
+            cases_payload = suite.model_dump_json().encode("utf-8")
+            bundle_ref = upload(
+                _suite_bundle(
+                    suite,
+                    trajectory=_trajectory_sidecar(
+                        [
+                            {
+                                "case_id": "ordered",
+                                "expected": ["Read", "Bash"],
+                                "mode": "exact",
+                                "threshold": 1.0,
+                            }
+                        ],
+                    ),
+                    cases_payload=cases_payload,
+                )
+            )
+            token = uuid.uuid4().hex[:8]
+            cfg = _cfg(f"test:evals:{token}", f"g:{token}")
+            client = AsyncRedis(
+                host=_VH,
+                port=_VP,
+                password=_VPW,
+                decode_responses=True,
+            )
+            reports: list[dict[str, Any]] = []
+            async with httpx.AsyncClient(timeout=30.0) as lf_client:
+                consumer = _build_consumer(
+                    redis_client=client,
+                    cfg=cfg,
+                    bundle_store=store,
+                    substrate=_UnusedSubstrate(),
+                    reports=reports,
+                    lf_client=lf_client,
+                )
+                await consumer.ensure_group()
+                sha = f"trajectory_identity_{token}"
+                item = _item(
+                    suite="trajectory",
+                    sha=sha,
+                    bundle_ref=bundle_ref,
+                    target_url=base_url,
+                    model="resolved_model",
+                )
+                stream_id = await client.xadd(
+                    cfg.eval_stream,
+                    {STREAM_PAYLOAD_FIELD: item.model_dump_json()},
+                )
+
+                await _drain_one(consumer, reports)
+
+                trace: dict[str, Any] | None = None
+                for _ in range(40):
+                    response = await lf_client.get(
+                        f"{cfg.langfuse_host}/api/public/traces",
+                        params={"tags": f"version:{sha}"},
+                        auth=(cfg.langfuse_public_key, cfg.langfuse_secret_key),
+                    )
+                    traces = (
+                        response.json().get("data", [])
+                        if response.status_code == 200
+                        else []
+                    )
+                    if traces:
+                        trace = traces[0]
+                        break
+                    await asyncio.sleep(1)
+
+                assert trace is not None
+                metadata = trace["metadata"]
+                assert metadata["stream_id"] == stream_id
+                assert metadata["scorer"] == "trajectory"
+                assert metadata["model"] == "resolved_model"
+                assert metadata["outcome"] == "pass"
+                assert metadata["case_count"] == 1
+
+            await client.delete(cfg.eval_stream)
+            await client.aclose()
+
+    asyncio.run(go())

--- a/apps/worker/tests/eval/test_trajectory.py
+++ b/apps/worker/tests/eval/test_trajectory.py
@@ -1,0 +1,186 @@
+"""Trajectory sidecar and cross language matcher contracts."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from curie_worker.eval.schema_export import (
+    render_trajectory_schema,
+    trajectory_schema_path,
+)
+from curie_worker.eval.scorer import (
+    TrajectoryMode,
+    TrajectorySpec,
+    match_trajectory,
+)
+from curie_worker.eval.trajectory import TrajectorySidecar
+from pydantic import ValidationError
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+_VECTOR_PATH = _REPO_ROOT / "tests" / "vectors" / "trajectory-match.json"
+
+
+def _sidecar(**overrides: object) -> dict[str, object]:
+    value: dict[str, object] = {
+        "specs": [
+            {
+                "case_id": "weather",
+                "expected": ["WebSearch", "WebFetch"],
+                "mode": "in_order",
+                "threshold": 1.0,
+            }
+        ],
+    }
+    value.update(overrides)
+    return value
+
+
+def test_sidecar_json_converts_case_ids_to_domain_specs() -> None:
+    sidecar = TrajectorySidecar.model_validate_json(json.dumps(_sidecar()))
+
+    assert sidecar.to_spec_map() == {
+        "weather": TrajectorySpec(
+            expected=("WebSearch", "WebFetch"),
+            mode=TrajectoryMode.IN_ORDER,
+            threshold=1.0,
+        )
+    }
+
+
+@pytest.mark.parametrize(
+    "mode",
+    ["exact", "in_order", "any_order", "precision", "recall"],
+)
+def test_sidecar_accepts_every_trajectory_mode(mode: str) -> None:
+    spec = {
+        "case_id": "weather",
+        "expected": ["WebSearch"],
+        "mode": mode,
+        "threshold": 1.0,
+    }
+
+    sidecar = TrajectorySidecar.model_validate(_sidecar(specs=[spec]))
+
+    assert sidecar.to_spec_map()["weather"].mode is TrajectoryMode(mode)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("mode", "sideways"),
+        ("mode", 1),
+        ("threshold", -0.001),
+        ("threshold", 1.001),
+        ("threshold", "1.0"),
+    ],
+)
+def test_sidecar_rejects_invalid_spec_values(field: str, value: object) -> None:
+    spec = {
+        "case_id": "weather",
+        "expected": ["WebSearch"],
+        "mode": "exact",
+        "threshold": 1.0,
+        field: value,
+    }
+
+    with pytest.raises(ValidationError):
+        TrajectorySidecar.model_validate(_sidecar(specs=[spec]))
+
+
+def test_sidecar_rejects_duplicate_case_ids() -> None:
+    spec = {
+        "case_id": "weather",
+        "expected": ["WebSearch"],
+        "mode": "exact",
+        "threshold": 1.0,
+    }
+
+    with pytest.raises(ValidationError, match="unique"):
+        TrajectorySidecar.model_validate(_sidecar(specs=[spec, spec]))
+
+
+def test_sidecar_ignores_unknown_fields() -> None:
+    payload = _sidecar(
+        unexpected=True,
+        specs=[
+            {
+                "case_id": "weather",
+                "expected": ["WebSearch"],
+                "mode": "exact",
+                "threshold": 1.0,
+                "unexpected": True,
+            }
+        ],
+    )
+
+    sidecar = TrajectorySidecar.model_validate(payload)
+
+    assert sidecar.to_spec_map() == {
+        "weather": TrajectorySpec(
+            expected=("WebSearch",),
+            mode=TrajectoryMode.EXACT,
+            threshold=1.0,
+        )
+    }
+
+
+def test_sidecar_rejects_malformed_json() -> None:
+    with pytest.raises(ValidationError):
+        TrajectorySidecar.model_validate_json("{")
+
+
+def test_empty_expected_sequence_is_valid_for_ratio_edges() -> None:
+    sidecar = TrajectorySidecar.model_validate(
+        _sidecar(
+            specs=[
+                {
+                    "case_id": "nothing_required",
+                    "expected": [],
+                    "mode": "recall",
+                    "threshold": 1.0,
+                }
+            ]
+        )
+    )
+
+    assert sidecar.to_spec_map()["nothing_required"].expected == ()
+
+
+def test_committed_trajectory_schema_is_current() -> None:
+    assert render_trajectory_schema() == trajectory_schema_path().read_text(
+        encoding="utf-8"
+    ), "trajectory schema is stale; regenerate and commit it"
+
+
+def test_python_matcher_owns_the_shared_cross_language_vectors() -> None:
+    document: dict[str, Any] = json.loads(_VECTOR_PATH.read_text(encoding="utf-8"))
+    assert set(document) == {"comment", "vectors"}
+
+    for vector in document["vectors"]:
+        assert set(vector) == {
+            "name",
+            "mode",
+            "expected",
+            "observed",
+            "threshold",
+            "passed",
+            "detail",
+        }
+        result = match_trajectory(
+            TrajectorySpec(
+                expected=tuple(vector["expected"]),
+                mode=TrajectoryMode(vector["mode"]),
+                threshold=vector["threshold"],
+            ),
+            vector["observed"],
+        )
+        assert {
+            "passed": result.passed,
+            "detail": result.detail,
+        } == {
+            "passed": vector["passed"],
+            "detail": vector["detail"],
+        }, vector["name"]

--- a/cli/README.md
+++ b/cli/README.md
@@ -241,13 +241,50 @@ disk and targets no environment.
 | `cluster` | The platform on Kubernetes (a Helm release). | optional | yes | `up` `down` `status` `comms` `message` `eval` `deploy` `kill` `resume` `budget` `overrides` `reset-thread` `delete` | Operate and drive a deployed cluster release, and control its agents' lifecycle. |
 
 `eval` is on all three, running the SAME `evals/cases.json` with the SAME
-grader at each tier: a text-matcher case (`exact`/`contains`/`regex`) that
-passes at `skill` re-asserts the same way at `local` and `cluster`.
-`tool_called` cases are the one exception -- `local` and `cluster` can only
-grade the reply text, not the tool-call trajectory, so a `tool_called` case
-only ever passes at `skill eval` (a known gap;
-[ADR-0022](../docs/adr/0022-eval-completeness-tier-parity-and-trace-promotion.md)
-tracks closing it by moving grading server-side).
+grader at each tier. A text matcher case (`exact`, `contains`, or `regex`)
+that passes at `skill` is checked the same way at `local` and `cluster`.
+At `skill`, a `tool_called` grader reads runner tool frames directly. The
+legacy local and cluster reply path cannot observe those frames. Cross tier
+tool observation uses the trajectory sidecar and platform path below.
+
+For sequence scoring, add `evals/trajectory.json` beside `cases.json`. The
+sidecar is owned by the run layer, so it does not change the frozen eval case
+schema. Author the file in this shape:
+
+```json
+{
+  "specs": [
+    {
+      "case_id": "reports-a-temperature",
+      "expected": ["WebSearch", "WebFetch"],
+      "mode": "in_order",
+      "threshold": 1.0
+    }
+  ]
+}
+```
+
+`mode` accepts `exact`, `in_order`, `any_order`, `precision`, or `recall`.
+When the sidecar exists, every case is trajectory scored. A case without a
+matching spec fails closed and prints `no trajectory spec for case ...`.
+The case file and sidecar are packaged in the same immutable deployed bundle.
+The deploy receipt's `bundle_sha256` identifies the exact bundle used for
+local and cluster parity.
+
+Run the same authored suite at each tier:
+
+```bash
+curie skill eval --json
+curie local eval --json
+curie cluster eval --json
+```
+
+The skill tier scores the runner tool frames directly. The local and cluster
+tiers trigger the deployed bundle through the platform eval plane, then poll
+the matrix for the exact triggered stream and scorer. Deploy the changed
+bundle before those platform runs. An explicit `--cases` is refused for a
+local or cluster trajectory run because it cannot replace files inside the
+deployed bundle.
 
 The distinction that matters: `skill` is the **runner-only** loop, talking
 straight to a runner container's ACI (Agent Container Interface) HTTP
@@ -268,7 +305,7 @@ HTTP surface directly. No platform, no queue, no API, no Slack, no cluster.
 | `curie skill versions` | Not available at this tier (exit 4): `skill up` runs a local snapshot of the bundle on disk (its digest is on `skill status`), and nothing is deployed, so no version is assigned. Use `curie local versions <agent>` or `curie cluster versions <agent>`. |
 | `curie skill memory` | Not available at this tier (exit 4): this tier configures no memory namespace. Use `curie local memory <agent>` or `curie cluster memory <agent>`. |
 | `curie skill message "..."` | Send a synthetic Slack event: POST an ACI `event` frame to the local runner and stream the NDJSON reply (text deltas, tool notes, side effect flags, final). Abort a live turn with Ctrl-C. |
-| `curie skill eval` | Run `evals/cases.json` through the runner as `eval_case` events; prints a per case result table plus a pass or fail rollup; nonzero exit on failure. |
+| `curie skill eval` | Run `evals/cases.json` through the runner as `eval_case` events. When `evals/trajectory.json` exists, score the observed tool frames against its case keyed specs. Prints a per case result table plus a pass or fail rollup, with nonzero exit on failure. |
 | `curie skill status` | Show the local runner's session status. |
 | `curie skill down` | Stop and remove the local runner container. With no `.curie/runner.json` it falls back to container identity, so an orphaned runner is still clearable; `--name <NAME>` targets a container other than `curie-runner-local`. |
 
@@ -283,9 +320,10 @@ in Langfuse traces.
 the local and cluster tiers do with a deployed bundle. So editing a bundle file
 on the host does not reach the running runner: re-run `curie skill up
 --replace` and confirm the new `bundle_digest` in `curie skill status --json`.
-`evals/cases.json` is the exception -- `skill eval` reads it live from source,
-so a contract edit needs no restart. `skill down` (and `--replace`) release the
-snapshot along with the container.
+`evals/cases.json` and its optional `evals/trajectory.json` sidecar are the
+exceptions. `skill eval` reads them live from source, so an eval edit needs no
+restart. `skill down` and `--replace` release the snapshot along with the
+container.
 
 #### `local` target
 
@@ -304,7 +342,7 @@ the optional Slack dispatcher.
 | `curie local observability` | Print the local platform's observability surfaces: Curie Console, Langfuse UI (traces / cost / evals), and the Curie API base. URLs are printed only; pass `--open` to also open the browsable ones (Console, Langfuse) in a browser. `--json` never opens a browser. |
 | `curie local comms --slack` | Connect or disconnect a real Slack workspace for the compose stack.<br>• Resolves `SLACK_APP_TOKEN` and `SLACK_BOT_TOKEN` with precedence `--app-token`/`--bot-token` flag > env var > a value persisted with `curie secrets set` (so tokens saved once need no per-session re-export, #749).<br>• Masks them in dry run output.<br>• Starts or stops the dispatcher, and switches the worker between real Slack and the local stub. |
 | `curie local message "..."` | Drive the local compose stack end to end with zero Slack. Enqueues straight to the compose Valkey and lets the containerized worker answer. |
-| `curie local eval` | Run the bundle's `evals/cases.json` through the compose stack's enqueue -> worker -> sandbox -> reply path (one synthetic turn per case) and grade each captured reply with the SAME grader `skill eval` uses. Prints the identical per-case table + rollup; nonzero exit on failure.<br>• `--cases` overrides the file.<br>• `--dry-run` prints the plan.<br>• `--concurrency` defaults to 1 (sequential); values above 1 are refused for now (#709).<br>• Only the reply text is observed here, so a `tool_called` case always fails -- see "Using different tiers" above. |
+| `curie local eval` | Run the deployed bundle's eval suite through the compose platform. Without a trajectory sidecar, it uses the enqueue, worker, sandbox, and reply path with the shared grader. With `evals/trajectory.json`, it triggers the worker eval plane and reads each structured trajectory verdict from the exact matrix stream. Prints the same per case table and rollup, with nonzero exit on failure.<br>• `--cases` overrides the file only for a text graded run. It is refused for a trajectory run because the platform grades the deployed bundle.<br>• `--dry-run` prints the plan.<br>• `--concurrency` defaults to 1. Values above 1 are refused for now (#709). |
 | `curie local deploy` | Package the bundle as tar.gz and push it to the compose platform API (`--api-url`, default `http://localhost:28000`). Auth via `--api-key` or `CURIE_API_KEY`. |
 | `curie local overrides <agent> [--model V\|--clear-model] [--thinking V\|--clear-thinking]` | Read or change the agent's two nullable operator overrides via the compose platform API (`PATCH /agents/{id}`).<br>• With no change flags it INSPECTS and writes nothing.<br>• `--clear-<field>` sends explicit JSON null, restoring the platform default; an omitted field is left alone, which is a different request the API tells apart with `model_fields_set`.<br>• A blank value is refused rather than forwarded: an empty override skips the platform default instead of restoring it. |
 | `curie local reset-thread <agent> --thread-key <key> --yes` | Force a stuck thread's sandbox to be released via the compose platform API (`POST /agents/{id}/threads/{thread_key}/reset`, #737).<br>• The worker's next maintenance tick releases the thread's claim and route, so its next message cold-creates a fresh sandbox; conversation history is not deleted.<br>• Interrupts a live turn on the thread first, so it refuses without `--yes`. |
@@ -361,7 +399,7 @@ Wraps the umbrella Helm chart and the deployed release, the way `linkerd` or
 | `curie cluster observability` | Report the release's observability surfaces (Curie Console, Langfuse UI, Curie API base), using the same NodePort discovery as `cluster status`.<br>• Degrades a missing, ClusterIP, or unresolvable surface to a note instead of failing.<br>• URLs are printed only; pass `--open` to also open the browsable ones (Console, Langfuse) in a browser. `--json` never opens a browser.<br>• `--dry-run` prints the read-only discovery commands. |
 | `curie cluster comms --slack` | Connect or disconnect a real Slack workspace with a thin `helm upgrade --reuse-values`; env-backed tokens are masked in dry-run output. |
 | `curie cluster message "..."` | Drive the deployed release end to end. With a connected dispatcher, it posts a placeholder and routes the reply to the agent's bound Slack channel. Without a dispatcher, it uses the terminal reply stub and waits for the reply.<br>• Auto-discovers the release-generated API key and Valkey password from `<release>-secrets` when `--api-key` / `--valkey-password` (or their env vars) are omitted, so a default strong-secrets install needs no hand-exported credentials (#786). |
-| `curie cluster eval` | Run the bundle's `evals/cases.json` through the deployed release (self-plumbed port-forwards + per-turn reply stub, one synthetic turn per case) and grade each captured reply with the SAME grader `skill eval` uses. Prints the identical per-case table + rollup; nonzero exit on failure.<br>• `--cases` overrides the file.<br>• `--dry-run` prints the plan.<br>• `--concurrency` defaults to 1 (sequential); values above 1 are refused for now (#709).<br>• Only the reply text is observed here, so a `tool_called` case always fails -- see "Using different tiers" above.<br>• Auto-discovers the release-generated API key and Valkey password from `<release>-secrets` when `--api-key` / `--valkey-password` (or their env vars) are omitted, so a default strong-secrets install needs no hand-exported credentials (#790). |
+| `curie cluster eval` | Run the deployed bundle's eval suite through the Kubernetes platform. Without a trajectory sidecar, it uses the reply stub path with the shared grader. With `evals/trajectory.json`, it triggers the worker eval plane and reads each structured trajectory verdict from the exact matrix stream. Prints the same per case table and rollup, with nonzero exit on failure.<br>• `--cases` overrides the file only for a text graded run. It is refused for a trajectory run because the platform grades the deployed bundle.<br>• `--dry-run` prints the plan.<br>• `--concurrency` defaults to 1. Values above 1 are refused for now (#709).<br>• Auto discovers the release generated API key and Valkey password from `<release>-secrets` when `--api-key` or `--valkey-password`, and their environment variables, are omitted. A default strong secrets install needs no hand exported credentials (#790). |
 | `curie cluster deploy` | Package the bundle as tar.gz and push it to the platform API.<br>• When `--api-url` is omitted, self-plumbs a `kubectl port-forward` (loopback tunnel) to the release API service and auto-discovers the release-generated key from `<release>-secrets`, so the strong key never crosses the cleartext UI proxy (ADR-0057).<br>• Pass `--api-url` / `CURIE_API_URL` to direct-dial a URL instead (no tunnel); an explicit `--api-key` / `CURIE_API_KEY` still wins over discovery. |
 | `curie cluster kill <agent> --yes` | Kill an agent (stop its runs) via the platform API (`POST /agents/{id}/kill`). Destructive: refuses without `--yes`. |
 | `curie cluster resume <agent>` | Resume a killed agent via the platform API (`POST /agents/{id}/resume`). |

--- a/cli/api-mirrors.json
+++ b/cli/api-mirrors.json
@@ -172,16 +172,22 @@
       "omissions": []
     },
     {
+      "struct": "EvalCell",
+      "schema": "EvalCell",
+      "omissions": []
+    },
+    {
+      "struct": "EvalMatrixRow",
+      "schema": "EvalMatrixRow",
+      "omissions": []
+    },
+    {
       "struct": "EvalMatrix",
       "schema": "EvalMatrix",
       "omissions": [
         {
           "field": "cases",
           "why": "The sweep reads the per-(version, model) rollup (model_version_summaries) and the version columns (versions); the per-case identifiers (cases) that label the grid are not read by the CLI."
-        },
-        {
-          "field": "rows",
-          "why": "The per-case pass/fail grid (rows) is carried by the endpoint but unused by the sweep, which needs only the per-model rollup; the existing doc comment on EvalMatrix already states this."
         },
         {
           "field": "models",

--- a/cli/schema/baseline/eval.schema.json
+++ b/cli/schema/baseline/eval.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://schemas.curietech.ai/cli/eval/v1.1.json",
+  "$id": "https://schemas.curietech.ai/cli/eval/v1.2.json",
   "title": "curie skill eval --json",
   "description": "The agent-facing payload of `curie skill eval --json`: the outcome roll-up plus one row per eval case.",
   "type": "object",
@@ -72,6 +72,13 @@
           "output": {
             "type": "string",
             "description": "The graded answer text (the reply judged). Empty when the turn produced no gradeable text. Carried so a failing case is diagnosable without a re-run (#548)."
+          },
+          "detail": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Optional scorer explanation for this verdict. Present for a trajectory failure and omitted when the selected scorer has no additional evidence."
           }
         }
       }

--- a/cli/schema/eval.schema.json
+++ b/cli/schema/eval.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://schemas.curietech.ai/cli/eval/v1.1.json",
+  "$id": "https://schemas.curietech.ai/cli/eval/v1.2.json",
   "title": "curie skill eval --json",
   "description": "The agent-facing payload of `curie skill eval --json`: the outcome roll-up plus one row per eval case.",
   "type": "object",

--- a/cli/schema/eval.schema.json
+++ b/cli/schema/eval.schema.json
@@ -72,6 +72,13 @@
           "output": {
             "type": "string",
             "description": "The graded answer text (the reply judged). Empty when the turn produced no gradeable text. Carried so a failing case is diagnosable without a re-run (#548)."
+          },
+          "detail": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Optional scorer explanation for this verdict. Present for a trajectory failure and omitted when the selected scorer has no additional evidence."
           }
         }
       }

--- a/cli/schema/index.json
+++ b/cli/schema/index.json
@@ -97,7 +97,7 @@
       "result": "EvalOutput",
       "kind": "CliOutput",
       "schema": "eval.schema.json",
-      "version": "1.1"
+      "version": "1.2"
     },
     {
       "result": "GithubAppOutput",
@@ -253,7 +253,7 @@
       "result": "eval_json",
       "kind": "builder",
       "schema": "eval.schema.json",
-      "version": "1.1"
+      "version": "1.2"
     },
     {
       "result": "message_awaiting_approval_json",

--- a/cli/scripts/e2e-ladder.sh
+++ b/cli/scripts/e2e-ladder.sh
@@ -21,7 +21,7 @@
 # Rung 1 (skill) is the existing `cli/scripts/e2e.sh`, invoked as is
 # so the skill leg has exactly one implementation, and handed THIS run's bundle
 # copy through CURIE_E2E_BUNDLE. Rung 2 (local) is
-# `local up --minimal` -> `local deploy` -> `local message` -> `local down`,
+# `local up` -> `local deploy` -> `local message` -> `local down`,
 # against `compose.dev.yaml`. The `local-release` mode is the same round trip
 # against `compose.release.yaml` instead -- the generated, checkout-free
 # artifact `curie local up` runs on a release binary (issue #695), one half
@@ -734,9 +734,13 @@ rung_local() {
         echo "note: the reused stack's model mode was fixed by whoever ran \`local up\`; it is verified below against this run's mode, and a mismatch fails this rung."
     else
         echo
-        echo "=== curie local up --minimal ==="
-        # --minimal selects the core profile and blanks the OTel endpoint itself
-        # (core has no collector), so the ladder passes no profiles and no OTel env.
+        local up_args=(local up)
+        if [[ ! -f "$WORKDIR/bundle/evals/trajectory.json" ]]; then
+            up_args+=(--minimal)
+        fi
+        echo "=== curie ${up_args[*]} ==="
+        # Ordinary bundles use the core profile. A trajectory sidecar selects the
+        # full profile because its matrix read requires Langfuse.
         #
         # Claim ownership BEFORE starting, never after: `local up` blocks for
         # seconds while it waits for health, and containers exist for that whole
@@ -745,7 +749,7 @@ rung_local() {
         # it. Claiming a stack that then fails to boot is harmless, because
         # `local down` is safe against a partial or already-stopped stack.
         LOCAL_STACK_OWNED=1
-        "$BIN" local up --minimal
+        "$BIN" "${up_args[@]}"
     fi
 
     echo
@@ -792,12 +796,16 @@ rung_local() {
 
     echo
     echo "=== curie local eval --dry-run (suite parity) ==="
-    assert_suite "local" "$("$BIN" --json local eval --cases "$WORKDIR/bundle/evals/cases.json" --dry-run)"
+    local eval_args=(local eval)
+    if [[ ! -f "$WORKDIR/bundle/evals/trajectory.json" ]]; then
+        eval_args+=(--cases "$WORKDIR/bundle/evals/cases.json")
+    fi
+    assert_suite "local" "$(cd "$WORKDIR/bundle" && "$BIN" --json "${eval_args[@]}" --dry-run)"
 
     if [[ "$LIVE" == "1" ]]; then
         echo
         echo "=== curie local eval ==="
-        "$BIN" local eval --cases "$WORKDIR/bundle/evals/cases.json"
+        (cd "$WORKDIR/bundle" && "$BIN" "${eval_args[@]}")
     fi
 
     if (( LOCAL_STACK_OWNED )); then
@@ -870,17 +878,21 @@ rung_local_release() {
     # were already a pull, never a build) -- every curie-owned image it needs
     # must already exist locally under the tag the generator pinned, or `local
     # up` will try to pull a private GHCR image with no credentials. Check only
-    # the core profile's images (--minimal is what this rung brings up) and
+    # the selected profile's images and
     # only the curie-owned ones: postgres/valkey/rustfs are public and pulled
     # on demand same as rung_local already assumes.
+    local compose_profile="core"
+    if [[ -f "$WORKDIR/bundle-release/evals/trajectory.json" ]]; then
+        compose_profile="full"
+    fi
     local missing=0 image
     while IFS= read -r image; do
         [[ "$image" == ghcr.io/curie-eng/curie-* ]] || continue
         if ! docker image inspect "$image" >/dev/null 2>&1; then
-            echo "error: image '$image' is required by compose.release.yaml's core profile and is not present locally." >&2
+            echo "error: image '$image' is required by compose.release.yaml's $compose_profile profile and is not present locally." >&2
             missing=1
         fi
-    done < <(docker compose -f "$release_compose" --profile core config --images)
+    done < <(docker compose -f "$release_compose" --profile "$compose_profile" config --images)
     if (( missing )); then
         echo "fix: build and tag the missing image(s) locally under the tag compose.release.yaml pins (see .github/workflows/ci.yaml's e2e-ladder job for the exact build+tag steps CI uses), then re-run." >&2
         return 1
@@ -910,9 +922,13 @@ rung_local_release() {
         "$BIN" local down --wipe --yes -f "$release_compose" >/dev/null 2>&1 || true
 
         echo
-        echo "=== curie local up --minimal -f compose.release.yaml ==="
+        local up_args=(local up -f "$release_compose")
+        if [[ "$compose_profile" == "core" ]]; then
+            up_args+=(--minimal)
+        fi
+        echo "=== curie ${up_args[*]} ==="
         LOCAL_STACK_OWNED=1
-        "$BIN" local up --minimal -f "$release_compose"
+        "$BIN" "${up_args[@]}"
     fi
 
     echo
@@ -954,12 +970,16 @@ rung_local_release() {
 
     echo
     echo "=== curie local eval --dry-run (suite parity, release compose stack) ==="
-    assert_suite "local-release" "$("$BIN" --json local eval --cases "$WORKDIR/bundle-release/evals/cases.json" --dry-run)"
+    local eval_args=(local eval)
+    if [[ ! -f "$WORKDIR/bundle-release/evals/trajectory.json" ]]; then
+        eval_args+=(--cases "$WORKDIR/bundle-release/evals/cases.json")
+    fi
+    assert_suite "local-release" "$(cd "$WORKDIR/bundle-release" && "$BIN" --json "${eval_args[@]}" --dry-run)"
 
     if [[ "$LIVE" == "1" ]]; then
         echo
         echo "=== curie local eval (release compose stack) ==="
-        "$BIN" local eval --cases "$WORKDIR/bundle-release/evals/cases.json"
+        (cd "$WORKDIR/bundle-release" && "$BIN" "${eval_args[@]}")
     fi
 
     if (( LOCAL_STACK_OWNED )); then
@@ -1118,11 +1138,14 @@ print("yes" if isinstance(d, dict) and d.get("release_found") is True else "no")
     # for DIFFERENT reasons -- a machine-readable `--dry-run` plan here, an
     # auditable green on the live grade below -- and passing it once per call site
     # is what keeps it from being passed twice at either.
-    local eval_args=(cluster eval --cases "$WORKDIR/bundle/evals/cases.json")
+    local eval_args=(cluster eval)
+    if [[ ! -f "$WORKDIR/bundle/evals/trajectory.json" ]]; then
+        eval_args+=(--cases "$WORKDIR/bundle/evals/cases.json")
+    fi
     if [[ -n "${CURIE_E2E_LISTEN_HOST:-}" ]]; then
         eval_args+=(--listen-host "$CURIE_E2E_LISTEN_HOST")
     fi
-    assert_suite "cluster" "$("$BIN" --json "${eval_args[@]}" --dry-run)"
+    assert_suite "cluster" "$(cd "$WORKDIR/bundle" && "$BIN" --json "${eval_args[@]}" --dry-run)"
 
     if [[ "$LIVE" == "1" ]]; then
         echo
@@ -1147,7 +1170,7 @@ print("yes" if isinstance(d, dict) and d.get("release_found") is True else "no")
         # turn finalizes with a reply, and under live mode that reply is not the
         # fake sentinel) still fail it, and they are what caught the sandbox
         # reaper race in #1601.
-        if ! "$BIN" --json "${eval_args[@]}"; then
+        if ! (cd "$WORKDIR/bundle" && "$BIN" --json "${eval_args[@]}"); then
             echo "cluster: eval reported a failing case. Not failing the rung: this rung's grade is report only (#1603)." >&2
         fi
     fi

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -377,6 +377,30 @@ pub struct EvalModelVersionSummary {
     pub plumbing: u64,
 }
 
+/// One case and version verdict in the platform eval matrix.
+#[derive(Debug, Clone, Deserialize)]
+pub struct EvalCell {
+    pub version: String,
+    pub status: String,
+    #[serde(default)]
+    pub model: Option<String>,
+    #[serde(default)]
+    pub detail: Option<String>,
+    #[serde(default)]
+    pub stream_id: Option<String>,
+    #[serde(default)]
+    pub scorer: Option<String>,
+    #[serde(default)]
+    pub case_count: Option<u64>,
+}
+
+/// One case row across the versions returned by the eval matrix.
+#[derive(Debug, Clone, Deserialize)]
+pub struct EvalMatrixRow {
+    pub case_id: String,
+    pub cells: Vec<EvalCell>,
+}
+
 /// The eval matrix grid (`EvalMatrix` in openapi.json): `GET /evals/matrix`. The
 /// sweep reads `model_version_summaries` (the per-`(version, model)` dimension)
 /// plus `versions` (the shown version columns, newest first): a `--model` sweep
@@ -384,8 +408,9 @@ pub struct EvalModelVersionSummary {
 /// run's rows cannot satisfy the exit condition on the first poll (issue #608),
 /// and reads the per-version rollup scoped to the triggered sha so a prior sha's
 /// completions cannot mask the triggered sha's zero-completed outcome (#814). The
-/// window-blended `model_summaries` and the per-case `rows`/`cases`/`models` grid
-/// are carried by the endpoint but unused here.
+/// window-blended `model_summaries` and the `cases`/`models` labels are carried
+/// by the endpoint but unused here. The sidecar selected eval path reads `rows`
+/// so it can report the worker scorer's exact verdict and detail.
 #[derive(Debug, Clone, Deserialize)]
 pub struct EvalMatrix {
     pub suite: String,
@@ -395,6 +420,8 @@ pub struct EvalMatrix {
     pub versions: Vec<String>,
     #[serde(default)]
     pub model_version_summaries: Vec<EvalModelVersionSummary>,
+    #[serde(default)]
+    pub rows: Vec<EvalMatrixRow>,
 }
 
 /// The per-agent budget (`BudgetConfig` in openapi.json): the request and
@@ -1264,13 +1291,24 @@ impl ApiClient {
             .context("decoding eval trigger result")
     }
 
-    /// Read the eval matrix for a suite: `GET /evals/matrix?suite=..&versions=..`.
-    /// The sweep polls this for the per-model pass-rate rollup the recorder writes.
-    pub async fn eval_matrix(&self, suite: &str, versions: u32) -> Result<EvalMatrix> {
+    /// Read the eval matrix for a suite, optionally scoped to one triggered run.
+    pub async fn eval_matrix(
+        &self,
+        suite: &str,
+        versions: u32,
+        stream_id: Option<&str>,
+    ) -> Result<EvalMatrix> {
+        let mut query = vec![
+            ("suite", suite.to_string()),
+            ("versions", versions.to_string()),
+        ];
+        if let Some(stream_id) = stream_id {
+            query.push(("stream_id", stream_id.to_string()));
+        }
         let resp = self
             .http
             .get(format!("{}/evals/matrix", self.base_url))
-            .query(&[("suite", suite), ("versions", &versions.to_string())])
+            .query(&query)
             .header("X-API-Key", &self.api_key)
             .send()
             .await

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -17,8 +17,8 @@ use crate::api::{ApiClient, BudgetConfig, ChannelOutcome};
 use crate::bundle::pack_tar_gz;
 use crate::docker::{self, CheckSpec, StartSpec};
 use crate::evals::{
-    graded_answer, load_suite, outcome_label, rollup_line, turn_completed, turn_outcome,
-    CaseOutcome, EvalSuite,
+    graded_answer, load_eval, outcome_label, rollup_line, score_turn, turn_completed, CaseOutcome,
+    EvalSuite, TrajectoryScorer,
 };
 use crate::render::{boxed_summary, status_str, TurnPart, TurnPrinter};
 use crate::runner::RunnerClient;
@@ -2123,6 +2123,21 @@ pub fn status_json<T: serde::Serialize>(
 /// report the same shape through `report_eval`/`eval_json`.
 pub type EvalRow = (String, CaseOutcome, f64, String);
 
+/// Eval rows plus optional scorer explanations keyed by case id.
+pub struct EvalReport {
+    pub rows: Vec<EvalRow>,
+    pub details: BTreeMap<String, String>,
+}
+
+impl EvalReport {
+    pub fn from_rows(rows: Vec<EvalRow>) -> Self {
+        Self {
+            rows,
+            details: BTreeMap::new(),
+        }
+    }
+}
+
 /// The three counts every eval surface reports. Split out so the `--json`
 /// payload, the human roll-up, and the exit code all read the SAME tally rather
 /// than each re-deriving it -- `failed` in particular must be counted, never
@@ -2149,6 +2164,14 @@ fn eval_counts(results: &[EvalRow]) -> (usize, usize, usize) {
 /// snapshotted bundle, and on a skill run against a runner this checkout never
 /// recorded.
 pub fn eval_json(results: &[EvalRow], bundle_digest: Option<&str>) -> serde_json::Value {
+    eval_json_with_details(results, &BTreeMap::new(), bundle_digest)
+}
+
+fn eval_json_with_details(
+    results: &[EvalRow],
+    details: &BTreeMap<String, String>,
+    bundle_digest: Option<&str>,
+) -> serde_json::Value {
     // Derive every count from `results` in one pass so the rollup can never
     // disagree with the per-case rows (no caller-supplied passed/total to drift).
     let total = results.len();
@@ -2156,7 +2179,7 @@ pub fn eval_json(results: &[EvalRow], bundle_digest: Option<&str>) -> serde_json
     let cases: Vec<serde_json::Value> = results
         .iter()
         .map(|(id, outcome, seconds, output)| {
-            serde_json::json!({
+            let mut row = serde_json::json!({
                 "id": id,
                 "outcome": outcome,
                 // Tri-state (ADR-0055): a non-graded row claims neither verdict.
@@ -2166,7 +2189,11 @@ pub fn eval_json(results: &[EvalRow], bundle_digest: Option<&str>) -> serde_json
                 "passed": outcome.passed(),
                 "seconds": seconds,
                 "output": output,
-            })
+            });
+            if let Some(detail) = details.get(id) {
+                row["detail"] = serde_json::json!(detail);
+            }
+            row
         })
         .collect();
     serde_json::json!({
@@ -2400,7 +2427,7 @@ pub async fn eval(
     let saved = state::load(Path::new("."))?;
     let state_plugin_dir = saved.as_ref().map(|s| PathBuf::from(s.plugin_dir.clone()));
     let cases_path = resolve_cases_path(cases_path, Path::new("."), state_plugin_dir.as_deref())?;
-    let suite = load_suite(&cases_path)?;
+    let loaded = load_eval(&cases_path)?;
 
     // Model selection (#526): with `--model`, boot a transient runner per model,
     // run the suite against each, and report pass-rate per model -- the one
@@ -2409,7 +2436,8 @@ pub async fn eval(
     // default path drives the already-running runner (whatever model it booted).
     if !models.is_empty() {
         return eval_sweep(
-            &suite,
+            &loaded.suite,
+            loaded.trajectory.as_ref(),
             &models,
             &secrets,
             &image,
@@ -2429,11 +2457,18 @@ pub async fn eval(
     let bundle_digest = recorded_bundle_digest(saved.as_ref(), &url);
     let client = RunnerClient::new(&url)?;
     let ui = crate::ui::ui();
-    let bar = ui.progress_bar(suite.cases.len() as u64, "running evals");
+    let bar = ui.progress_bar(loaded.suite.cases.len() as u64, "running evals");
     // `run_suite_cases` also tallies completion for the `--model` sweep path;
     // the single-runner report doesn't need the count (it already reports the
     // per-case `Fail` either way and exits on any of them), so it is discarded.
-    let (results, _completed) = run_suite_cases(&client, &suite, fake, |_| bar.inc(1)).await?;
+    let (results, _completed) = run_suite_cases(
+        &client,
+        &loaded.suite,
+        fake,
+        loaded.trajectory.as_ref(),
+        |_| bar.inc(1),
+    )
+    .await?;
     bar.finish();
 
     report_eval(&results, bundle_digest.as_deref())
@@ -2467,9 +2502,11 @@ async fn run_suite_cases(
     client: &RunnerClient,
     suite: &EvalSuite,
     fake: bool,
+    trajectory_scorer: Option<&TrajectoryScorer>,
     mut on_case: impl FnMut(usize),
-) -> Result<(Vec<EvalRow>, usize)> {
+) -> Result<(EvalReport, usize)> {
     let mut results = Vec::with_capacity(suite.cases.len());
+    let mut details = BTreeMap::new();
     let mut completed = 0usize;
     for (i, case) in suite.cases.iter().enumerate() {
         // Fresh conversation by default (#550): reset the runner before a case so
@@ -2495,15 +2532,25 @@ async fn run_suite_cases(
         // Capture the graded answer -- the exact text `turn_outcome` judged -- so
         // a red case can be diagnosed from `--json` without a manual re-run
         // (#548). A fake row carries its canned reply for the same reason.
+        let scored = score_turn(case, &events, fake, trajectory_scorer);
+        if let Some(detail) = scored.detail {
+            details.insert(case.id.clone(), detail);
+        }
         results.push((
             case.id.clone(),
-            turn_outcome(case, &events, fake),
+            scored.outcome,
             elapsed,
             graded_answer(&events),
         ));
         on_case(i);
     }
-    Ok((results, completed))
+    Ok((
+        EvalReport {
+            rows: results,
+            details,
+        },
+        completed,
+    ))
 }
 
 /// The `docker run` spec one eval-sweep runner boots with. Split out of
@@ -2804,6 +2851,7 @@ mod eval_bundle {
 /// Run the suite once per model in a fresh runner and report pass-rate per model.
 async fn eval_sweep(
     suite: &EvalSuite,
+    trajectory_scorer: Option<&TrajectoryScorer>,
     models: &[String],
     secrets: &[String],
     image: &str,
@@ -2847,10 +2895,11 @@ async fn eval_sweep(
             // `boot_eval_runner` pins `fake_model: false`, so every sweep runner is a
             // REAL model whatever the standing dev runner is -- the sweep grades,
             // so this in-CLI path never produces a plumbing-only row.
-            let run = run_suite_cases(&client, suite, false, |_| {}).await;
+            let run = run_suite_cases(&client, suite, false, trajectory_scorer, |_| {}).await;
             let _ = docker::remove_container(&name).await;
             let (results, completed) = run?;
             let passed = results
+                .rows
                 .iter()
                 .filter(|(_, o, _, _)| *o == CaseOutcome::Pass)
                 .count();
@@ -3040,14 +3089,14 @@ pub fn report_sweep(rows: &[SweepRow], bundle_digest: Option<&str>) -> Result<()
 /// graded is confirmable from the machine surface. Callers pass `None` when no
 /// locally snapshotted bundle applies (the local/cluster tiers grade a deployed
 /// version), never a digest they did not observe.
-pub fn report_eval(results: &[EvalRow], bundle_digest: Option<&str>) -> Result<()> {
-    let (_passed, failed, _plumbing_ok) = eval_counts(results);
+pub fn report_eval(report: &EvalReport, bundle_digest: Option<&str>) -> Result<()> {
+    let (_passed, failed, _plumbing_ok) = eval_counts(&report.rows);
     // Emit through the one success point (#474), then apply the exit-code side
     // effect for BOTH paths -- the json path had it inline, the human path after.
     // Only a genuine `Fail` (failed > 0) exits non-zero: a plumbing-only run
     // graded nothing but is operationally successful, so it exits 0 (#606/#612).
     crate::ui::ui().emit(&EvalOutput {
-        results,
+        report,
         bundle_digest,
     });
     if failed > 0 {
@@ -3061,7 +3110,7 @@ pub fn report_eval(results: &[EvalRow], bundle_digest: Option<&str>) -> Result<(
 /// `json_contract.rs` stay green); `render` reproduces the per-case table and the
 /// roll-up verdict + per-red-case reply notes.
 struct EvalOutput<'a> {
-    results: &'a [EvalRow],
+    report: &'a EvalReport,
     /// The snapshot digest the evaluated runner mounted (#1087), or `None` when
     /// none applies to this run.
     bundle_digest: Option<&'a str>,
@@ -3069,11 +3118,11 @@ struct EvalOutput<'a> {
 
 impl crate::ui::CliOutput for EvalOutput<'_> {
     fn to_json(&self) -> serde_json::Value {
-        eval_json(self.results, self.bundle_digest)
+        eval_json_with_details(&self.report.rows, &self.report.details, self.bundle_digest)
     }
 
     fn render(&self, ui: &crate::ui::Ui) {
-        let results = self.results;
+        let results = &self.report.rows;
         let (passed, failed, plumbing_ok) = eval_counts(results);
         let rows: Vec<Vec<String>> = results
             .iter()
@@ -3103,12 +3152,16 @@ impl crate::ui::CliOutput for EvalOutput<'_> {
                 .iter()
                 .filter(|(_, o, _, _)| *o == CaseOutcome::Fail)
             {
-                let shown = if output.is_empty() {
-                    "<no reply text>".to_string()
+                if let Some(detail) = self.report.details.get(name) {
+                    ui.note(&format!("{name}: {detail}"));
                 } else {
-                    output.clone()
-                };
-                ui.note(&format!("{name} replied: {shown}"));
+                    let shown = if output.is_empty() {
+                        "<no reply text>".to_string()
+                    } else {
+                        output.clone()
+                    };
+                    ui.note(&format!("{name} replied: {shown}"));
+                }
             }
             ui.warn(&format!(
                 "{}; {failed} failed",

--- a/cli/src/evals.rs
+++ b/cli/src/evals.rs
@@ -12,6 +12,7 @@
 //! Python models. Grading semantics mirror the platform's `Grader.grade`. This is
 //! the CLI-local seed of the K1 eval machinery, not a replacement for it.
 
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 
 use anyhow::{anyhow, bail, Context, Result};
@@ -149,6 +150,190 @@ pub struct EvalSuite {
     pub cases: Vec<EvalCase>,
 }
 
+/// One supported comparison for an observed tool sequence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TrajectoryMode {
+    Exact,
+    InOrder,
+    AnyOrder,
+    Precision,
+    Recall,
+}
+
+impl TrajectoryMode {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Exact => "exact",
+            Self::InOrder => "in_order",
+            Self::AnyOrder => "any_order",
+            Self::Precision => "precision",
+            Self::Recall => "recall",
+        }
+    }
+}
+
+fn default_trajectory_threshold() -> f64 {
+    1.0
+}
+
+/// The trajectory expectation supplied above the frozen eval case port.
+#[derive(Debug, Clone, Deserialize)]
+pub struct TrajectorySpec {
+    pub case_id: String,
+    pub expected: Vec<String>,
+    pub mode: TrajectoryMode,
+    #[serde(default = "default_trajectory_threshold")]
+    pub threshold: f64,
+}
+
+/// The optional sibling configuration for trajectory scoring.
+#[derive(Debug, Clone, Deserialize)]
+struct TrajectorySidecar {
+    specs: Vec<TrajectorySpec>,
+}
+
+/// A trajectory verdict and its explanation when red.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TrajectoryScore {
+    pub passed: bool,
+    pub detail: Option<String>,
+}
+
+/// The case keyed scorer assembled from a validated trajectory sidecar.
+#[derive(Debug, Clone)]
+pub struct TrajectoryScorer {
+    specs: BTreeMap<String, TrajectorySpec>,
+}
+
+impl TrajectoryScorer {
+    pub fn score(&self, case_id: &str, observed: &[&str]) -> TrajectoryScore {
+        let Some(spec) = self.specs.get(case_id) else {
+            return TrajectoryScore {
+                passed: false,
+                detail: Some(format!(
+                    "no trajectory spec for case {}",
+                    python_string(case_id)
+                )),
+            };
+        };
+        match_trajectory(spec, observed)
+    }
+}
+
+/// The immutable cases payload plus its optional run layer scorer.
+#[derive(Debug, Clone)]
+pub struct LoadedEval {
+    pub suite: EvalSuite,
+    pub trajectory: Option<TrajectoryScorer>,
+}
+
+fn python_string(value: &str) -> String {
+    let escaped = value
+        .replace('\\', "\\\\")
+        .replace('\'', "\\'")
+        .replace('\n', "\\n")
+        .replace('\r', "\\r")
+        .replace('\t', "\\t");
+    format!("'{escaped}'")
+}
+
+fn python_list(values: &[impl AsRef<str>]) -> String {
+    let items = values
+        .iter()
+        .map(|value| python_string(value.as_ref()))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("[{items}]")
+}
+
+fn python_float(value: f64) -> String {
+    if value.fract() == 0.0 {
+        format!("{value:.1}")
+    } else {
+        value.to_string()
+    }
+}
+
+/// Rust mirror of the worker's authoritative deterministic matcher.
+pub fn match_trajectory(spec: &TrajectorySpec, observed: &[&str]) -> TrajectoryScore {
+    let expected = spec.expected.iter().map(String::as_str).collect::<Vec<_>>();
+    let mut detail = format!(
+        "mode={} expected={} observed={}",
+        spec.mode.as_str(),
+        python_list(&expected),
+        python_list(observed),
+    );
+
+    let passed = match spec.mode {
+        TrajectoryMode::Exact => observed == expected,
+        TrajectoryMode::InOrder => {
+            let mut expected_index = 0usize;
+            for tool in observed {
+                if expected
+                    .get(expected_index)
+                    .is_some_and(|want| want == tool)
+                {
+                    expected_index += 1;
+                }
+            }
+            expected_index == expected.len()
+        }
+        TrajectoryMode::AnyOrder => {
+            let mut remaining = BTreeMap::<&str, usize>::new();
+            for tool in &expected {
+                *remaining.entry(tool).or_default() += 1;
+            }
+            for tool in observed {
+                if let Some(count) = remaining.get_mut(tool) {
+                    *count = count.saturating_sub(1);
+                }
+            }
+            remaining.values().all(|count| *count == 0)
+        }
+        TrajectoryMode::Precision => {
+            let expected_tools = expected.iter().copied().collect::<BTreeSet<_>>();
+            let ratio = if observed.is_empty() {
+                1.0
+            } else {
+                observed
+                    .iter()
+                    .filter(|tool| expected_tools.contains(**tool))
+                    .count() as f64
+                    / observed.len() as f64
+            };
+            detail.push_str(&format!(
+                " precision={ratio:.3} threshold={}",
+                python_float(spec.threshold)
+            ));
+            ratio >= spec.threshold
+        }
+        TrajectoryMode::Recall => {
+            let expected_tools = expected.iter().copied().collect::<BTreeSet<_>>();
+            let observed_tools = observed.iter().copied().collect::<BTreeSet<_>>();
+            let ratio = if expected_tools.is_empty() {
+                1.0
+            } else {
+                expected_tools
+                    .iter()
+                    .filter(|tool| observed_tools.contains(**tool))
+                    .count() as f64
+                    / expected_tools.len() as f64
+            };
+            detail.push_str(&format!(
+                " recall={ratio:.3} threshold={}",
+                python_float(spec.threshold)
+            ));
+            ratio >= spec.threshold
+        }
+    };
+
+    TrajectoryScore {
+        passed,
+        detail: (!passed).then_some(detail),
+    }
+}
+
 /// Validate an assembled suite: reject an empty case list and eagerly compile
 /// every regex grader so a bad pattern fails now, not mid-run. Factored out of
 /// `load_suite` so the spec scaffold path (`spec.rs`) enforces the identical
@@ -185,13 +370,8 @@ pub fn validate_suite(name: &str, cases: &[EvalCase]) -> Result<()> {
     Ok(())
 }
 
-/// Parse the suite object at `path`. Rejects an empty `cases` list, eagerly
-/// compiles every regex grader (so a bad pattern fails at load, not mid-run),
-/// and turns the retired top-level-array format into a targeted migration hint.
-pub fn load_suite(path: &Path) -> Result<EvalSuite> {
-    let body =
-        std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
-    let value: serde_json::Value = serde_json::from_str(&body)
+fn parse_suite(path: &Path, body: &[u8]) -> Result<EvalSuite> {
+    let value: serde_json::Value = serde_json::from_slice(body)
         .with_context(|| format!("{} is not valid JSON", path.display()))?;
     if value.is_array() {
         bail!(
@@ -207,6 +387,75 @@ pub fn load_suite(path: &Path) -> Result<EvalSuite> {
         .with_context(|| format!("{} is not a valid eval suite", path.display()))?;
     validate_suite(&suite.name, &suite.cases)?;
     Ok(suite)
+}
+
+/// Parse the suite object at `path`. Rejects an empty `cases` list, eagerly
+/// compiles every regex grader (so a bad pattern fails at load, not mid-run),
+/// and turns the retired top-level-array format into a targeted migration hint.
+pub fn load_suite(path: &Path) -> Result<EvalSuite> {
+    let body = std::fs::read(path).with_context(|| format!("reading {}", path.display()))?;
+    parse_suite(path, &body)
+}
+
+/// Load the immutable cases bytes and validate an optional trajectory sidecar.
+///
+/// Specs may omit a case on purpose; the scorer then fails that case closed.
+pub fn load_eval(path: &Path) -> Result<LoadedEval> {
+    let body = std::fs::read(path).with_context(|| format!("reading {}", path.display()))?;
+    let suite = parse_suite(path, &body)?;
+    let sidecar_path = path
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .join("trajectory.json");
+    if !sidecar_path.is_file() {
+        return Ok(LoadedEval {
+            suite,
+            trajectory: None,
+        });
+    }
+
+    let sidecar_body = std::fs::read(&sidecar_path)
+        .with_context(|| format!("reading {}", sidecar_path.display()))?;
+    let sidecar: TrajectorySidecar = serde_json::from_slice(&sidecar_body).with_context(|| {
+        format!(
+            "{} is not a valid trajectory sidecar",
+            sidecar_path.display()
+        )
+    })?;
+
+    let mut case_ids = BTreeSet::new();
+    for case in &suite.cases {
+        if !case_ids.insert(case.id.as_str()) {
+            bail!(
+                "suite {:?} contains duplicate case id {:?}; trajectory specs require unique case ids",
+                suite.name,
+                case.id,
+            );
+        }
+    }
+    let mut specs = BTreeMap::new();
+    for spec in sidecar.specs {
+        if !(0.0..=1.0).contains(&spec.threshold) {
+            bail!(
+                "{} gives case {:?} threshold {}; expected a value from 0 through 1",
+                sidecar_path.display(),
+                spec.case_id,
+                spec.threshold,
+            );
+        }
+        let case_id = spec.case_id.clone();
+        if specs.insert(case_id.clone(), spec).is_some() {
+            bail!(
+                "{} contains duplicate trajectory spec for case {:?}",
+                sidecar_path.display(),
+                case_id,
+            );
+        }
+    }
+    Ok(LoadedEval {
+        suite,
+        trajectory: Some(TrajectoryScorer { specs }),
+    })
 }
 
 /// The graded answer for a turn: the `final` frame's text when a final arrived,
@@ -322,6 +571,54 @@ pub fn turn_outcome(case: &EvalCase, events: &[OutboundEvent], fake: bool) -> Ca
         CaseOutcome::Pass
     } else {
         CaseOutcome::Fail
+    }
+}
+
+/// One run layer verdict with optional scorer evidence.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScoredCaseOutcome {
+    pub outcome: CaseOutcome,
+    pub detail: Option<String>,
+}
+
+/// Grade a turn through the selected run layer scorer.
+///
+/// Completion and fake model truthfulness remain ahead of scoring. This means a
+/// fake turn is plumbing only even when a trajectory sidecar exists, while an
+/// incomplete turn remains a real failure without pretending a matcher ran.
+pub fn score_turn(
+    case: &EvalCase,
+    events: &[OutboundEvent],
+    fake: bool,
+    trajectory_scorer: Option<&TrajectoryScorer>,
+) -> ScoredCaseOutcome {
+    if !turn_completed(case, events) {
+        return ScoredCaseOutcome {
+            outcome: CaseOutcome::Fail,
+            detail: None,
+        };
+    }
+    if fake {
+        return ScoredCaseOutcome {
+            outcome: CaseOutcome::PlumbingOk,
+            detail: None,
+        };
+    }
+    if let Some(scorer) = trajectory_scorer {
+        let observed = trajectory(events);
+        let score = scorer.score(&case.id, &observed);
+        return ScoredCaseOutcome {
+            outcome: if score.passed {
+                CaseOutcome::Pass
+            } else {
+                CaseOutcome::Fail
+            },
+            detail: score.detail,
+        };
+    }
+    ScoredCaseOutcome {
+        outcome: turn_outcome(case, events, false),
+        detail: None,
     }
 }
 

--- a/cli/src/message.rs
+++ b/cli/src/message.rs
@@ -36,7 +36,7 @@ use crate::chat::{
     await_reply, await_resume, continue_hint_line, continue_hint_long_line, parse_approval_id,
     resolve_targets, Outcome, SlackStub,
 };
-use crate::evals::{EvalCase, EvalSuite, ExpectedStatus};
+use crate::evals::{EvalCase, EvalSuite, ExpectedStatus, LoadedEval};
 use crate::ops::{plain, require_on_path, run_capture, OpsCommand};
 use crate::queue::{self, connect, diagnostics, synthetic_turn, xadd};
 use crate::state::{save_turn, TurnContext, TurnVerb};
@@ -2169,11 +2169,11 @@ pub fn eval_dry_run_lines(opts: &EvalOpts, suite_name: &str, case_count: usize) 
 
 /// Resolve the eval suite the way `skill eval` does: an explicit `--cases`
 /// wins, else `evals/cases.json` in the cwd, then the recorded bundle dir.
-fn resolve_suite(explicit: Option<PathBuf>) -> Result<EvalSuite> {
+fn resolve_eval(explicit: Option<PathBuf>) -> Result<LoadedEval> {
     let state_plugin_dir = crate::state::load(Path::new("."))?.map(|s| PathBuf::from(s.plugin_dir));
     let path =
         crate::commands::resolve_cases_path(explicit, Path::new("."), state_plugin_dir.as_deref())?;
-    crate::evals::load_suite(&path)
+    crate::evals::load_eval(&path)
 }
 
 /// The shared per-tier eval engine: enqueue one synthetic `QueuedTurn` per case
@@ -2187,7 +2187,7 @@ async fn run_eval_turns(
     suite: &EvalSuite,
     conn: &mut MultiplexedConnection,
     stub: &mut SlackStub,
-) -> Result<Vec<crate::commands::EvalRow>> {
+) -> Result<crate::commands::EvalReport> {
     let ui = crate::ui::ui();
     let total = suite.cases.len();
     let bar = ui.progress_bar(total as u64, "running evals");
@@ -2241,7 +2241,7 @@ async fn run_eval_turns(
         bar.inc(1);
     }
     bar.finish();
-    Ok(results)
+    Ok(crate::commands::EvalReport::from_rows(results))
 }
 
 /// The shared `eval` handler: run the bundle's `evals/cases.json` through the
@@ -2278,14 +2278,27 @@ pub async fn eval(opts: EvalOpts) -> Result<()> {
                 ),
             ));
         }
-        let suite = resolve_suite(opts.cases.clone())?;
-        return eval_sweep(opts, suite).await;
+        let loaded = resolve_eval(opts.cases.clone())?;
+        return eval_sweep(opts, loaded.suite).await;
     }
-    let suite = resolve_suite(opts.cases.clone())?;
+    let loaded = resolve_eval(opts.cases.clone())?;
+    if loaded.trajectory.is_some() {
+        if opts.cases.is_some() {
+            return Err(anyhow::Error::from(
+                crate::exit::CliError::unsupported(
+                    "--cases cannot select a local file for a trajectory eval because local and cluster trajectory scoring grades the deployed bundle",
+                )
+                .with_fix(
+                    "drop --cases to grade the deployed trajectory suite, or use skill eval to grade the local file",
+                ),
+            ));
+        }
+        return eval_trajectory_platform(opts, loaded.suite).await;
+    }
     if opts.local {
-        eval_local(opts, suite).await
+        eval_local(opts, loaded.suite).await
     } else {
-        eval_cluster(opts, suite).await
+        eval_cluster(opts, loaded.suite).await
     }
 }
 
@@ -2586,7 +2599,7 @@ async fn eval_sweep(opts: EvalOpts, suite: EvalSuite) -> Result<()> {
     ui.note("waiting for the eval jobs to land in the matrix (Ctrl-C to stop; jobs keep running)");
     loop {
         let matrix = api
-            .eval_matrix(&suite.name, 5)
+            .eval_matrix(&suite.name, 5, None)
             .await
             .context("reading the eval matrix")?;
         if let Some(rows) = sweep_ready_rows(&matrix, &triggered_sha, &want) {
@@ -2635,6 +2648,196 @@ async fn eval_sweep(opts: EvalOpts, suite: EvalSuite) -> Result<()> {
         }
         tokio::time::sleep(SWEEP_POLL_INTERVAL).await;
     }
+}
+
+/// Run a sidecar selected eval through the platform scorer and read its case
+/// verdicts from the matrix column created by this trigger.
+async fn eval_trajectory_platform(opts: EvalOpts, suite: EvalSuite) -> Result<()> {
+    let ui = crate::ui::ui();
+    let api_base = if opts.local {
+        local_api_base(opts.api_url.as_deref())
+    } else {
+        format!("http://localhost:{}", opts.api_local_port)
+    };
+    if opts.dry_run {
+        let tier = if opts.local { "local" } else { "cluster" };
+        ui.emit(&crate::ui::DryRunPlan {
+            lines: vec![
+                format!(
+                    "grade {} case(s) from suite {:?} against the {tier} tier",
+                    suite.cases.len(),
+                    suite.name
+                ),
+                format!(
+                    "trigger trajectory suite {:?} through the {tier} platform eval plane",
+                    suite.name
+                ),
+                format!(
+                    "POST {api_base}/evals/trigger with no model override, then poll {api_base}/evals/matrix?suite={}",
+                    suite.name
+                ),
+            ],
+        });
+        return Ok(());
+    }
+
+    let (api, _api_pf) = if opts.local {
+        (ApiClient::new(&api_base, &opts.api_key)?, None)
+    } else {
+        require_on_path("kubectl")?;
+        let pf = start_port_forward(
+            &port_forward_command(
+                &opts.namespace,
+                &opts.release,
+                "api",
+                opts.api_local_port,
+                API_REMOTE_PORT,
+            ),
+            opts.api_local_port,
+            "api",
+        )
+        .await?;
+        (ApiClient::new(&api_base, &opts.api_key)?, Some(pf))
+    };
+
+    let agents = api
+        .list_agents()
+        .await
+        .context("listing agents to resolve the trajectory eval target")?;
+    let agent_id = select_agent_id(&agents, opts.channel.as_deref())?;
+    let triggered = api
+        .trigger_eval(&agent_id, Some(&suite.name), None)
+        .await
+        .context("triggering trajectory eval")?;
+    if triggered.suite != suite.name {
+        bail!(
+            "trajectory trigger returned suite {:?}, expected {:?}",
+            triggered.suite,
+            suite.name
+        );
+    }
+
+    let deadline = Instant::now() + Duration::from_secs(opts.timeout_secs);
+    loop {
+        let matrix = api
+            .eval_matrix(&suite.name, 5, Some(&triggered.stream_id))
+            .await
+            .context("reading trajectory eval matrix")?;
+        if let Some(report) =
+            trajectory_matrix_report(&matrix, &triggered.sha, &triggered.stream_id)?
+        {
+            return crate::commands::report_eval(&report, None);
+        }
+        if Instant::now() >= deadline {
+            bail!(
+                "timed out after {}s waiting for trajectory eval results for suite {:?} at sha {}",
+                opts.timeout_secs,
+                suite.name,
+                triggered.sha,
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+}
+
+fn trajectory_matrix_report(
+    matrix: &crate::api::EvalMatrix,
+    triggered_sha: &str,
+    triggered_stream_id: &str,
+) -> Result<Option<crate::commands::EvalReport>> {
+    if !matrix
+        .versions
+        .iter()
+        .any(|version| version == triggered_sha)
+    {
+        return Ok(None);
+    }
+
+    if matrix.rows.is_empty() {
+        return Ok(None);
+    }
+
+    let mut rows = Vec::with_capacity(matrix.rows.len());
+    let mut details = std::collections::BTreeMap::new();
+    let mut expected_case_count: Option<usize> = None;
+    for matrix_row in &matrix.rows {
+        let Some(cell) = matrix_row
+            .cells
+            .iter()
+            .find(|cell| cell.version == triggered_sha)
+        else {
+            return Ok(None);
+        };
+        if cell.stream_id.as_deref() != Some(triggered_stream_id) {
+            bail!(
+                "stream filtered eval matrix returned case {:?} from a different run",
+                matrix_row.case_id
+            );
+        }
+        if cell.scorer.as_deref() != Some("trajectory") {
+            bail!(
+                "stream filtered eval matrix returned case {:?} without trajectory scoring",
+                matrix_row.case_id
+            );
+        }
+        if cell
+            .model
+            .as_deref()
+            .map(str::trim)
+            .is_none_or(str::is_empty)
+        {
+            bail!(
+                "stream filtered trajectory result for case {:?} has no resolved model",
+                matrix_row.case_id
+            );
+        }
+        let case_count = cell.case_count.context(format!(
+            "stream filtered trajectory result for case {:?} has no case count",
+            matrix_row.case_id
+        ))?;
+        let case_count = usize::try_from(case_count).context(
+            "stream filtered trajectory case count exceeds this platform's supported size",
+        )?;
+        if case_count == 0 {
+            bail!(
+                "stream filtered trajectory result for case {:?} has an invalid zero case count",
+                matrix_row.case_id
+            );
+        }
+        match expected_case_count {
+            Some(expected) if expected != case_count => bail!(
+                "stream filtered trajectory matrix disagrees on case count: {expected} and {case_count}"
+            ),
+            None => expected_case_count = Some(case_count),
+            _ => {}
+        }
+        let outcome = match cell.status.as_str() {
+            "pass" => crate::evals::CaseOutcome::Pass,
+            "fail" => crate::evals::CaseOutcome::Fail,
+            "plumbing_ok" => crate::evals::CaseOutcome::PlumbingOk,
+            "missing" => return Ok(None),
+            status => bail!(
+                "eval matrix returned unknown status {status:?} for case {:?} at sha {triggered_sha}",
+                matrix_row.case_id
+            ),
+        };
+        if let Some(detail) = &cell.detail {
+            details.insert(matrix_row.case_id.clone(), detail.clone());
+        }
+        rows.push((matrix_row.case_id.clone(), outcome, 0.0, String::new()));
+    }
+    let expected_case_count = expected_case_count
+        .context("stream filtered trajectory matrix contained no authoritative case count")?;
+    if rows.len() < expected_case_count {
+        return Ok(None);
+    }
+    if rows.len() > expected_case_count {
+        bail!(
+            "stream filtered trajectory matrix returned {} cases but declared {expected_case_count}",
+            rows.len()
+        );
+    }
+    Ok(Some(crate::commands::EvalReport { rows, details }))
 }
 
 /// The wanted models' rows in the matrix for the TRIGGERED sha, scoped to the
@@ -3848,6 +4051,7 @@ mod tests {
             suite: "smoke".into(),
             versions: versions.iter().map(|v| v.to_string()).collect(),
             model_version_summaries: summaries,
+            rows: Vec::new(),
         }
     }
 

--- a/cli/tests/json_emit_contract.rs
+++ b/cli/tests/json_emit_contract.rs
@@ -262,20 +262,14 @@ fn dry_run_json_masks_credentials() {
 /// args beyond placeholders, so `eval` fails cases-resolution and satisfies the
 /// "emits an object" assertion via the CENTRALIZED ERROR-JSON path -- it never
 /// reaches its dry-run PLAN branch, which is the branch that was actually broken.
-/// This drives `eval` with a real `--cases` file so the plan branch is exercised,
-/// and asserts the payload is the PLAN (no `error` key), so an error-path
-/// regression cannot green this test. `--dry-run` touches no network.
+/// This drives `eval` from the real weather bundle so its deployed trajectory
+/// suite resolves without an explicit cases override, and asserts the payload is
+/// the PLAN (no `error` key), so an error-path regression cannot green this test.
+/// `--dry-run` touches no network.
 fn assert_eval_dry_run_plan(tier: &str) {
     let output = Command::new(bin())
-        .args([
-            tier,
-            "eval",
-            "--cases",
-            "examples/weather/evals/cases.json",
-            "--dry-run",
-            "--json",
-        ])
-        .current_dir(concat!(env!("CARGO_MANIFEST_DIR"), "/.."))
+        .args([tier, "eval", "--dry-run", "--json"])
+        .current_dir(concat!(env!("CARGO_MANIFEST_DIR"), "/../examples/weather"))
         .output()
         .unwrap_or_else(|e| panic!("run curie {tier} eval --dry-run --json: {e}"));
     let stdout = String::from_utf8_lossy(&output.stdout);

--- a/cli/tests/nightly_graded_ladder.rs
+++ b/cli/tests/nightly_graded_ladder.rs
@@ -290,12 +290,16 @@ fn live_local_rung_grades_the_deployed_weather_cases() {
 
     echo
     echo "=== curie local eval --dry-run (suite parity) ==="
-    assert_suite "local" "$("$BIN" --json local eval --cases "$WORKDIR/bundle/evals/cases.json" --dry-run)"
+    local eval_args=(local eval)
+    if [[ ! -f "$WORKDIR/bundle/evals/trajectory.json" ]]; then
+        eval_args+=(--cases "$WORKDIR/bundle/evals/cases.json")
+    fi
+    assert_suite "local" "$(cd "$WORKDIR/bundle" && "$BIN" --json "${eval_args[@]}" --dry-run)"
 
     if [[ "$LIVE" == "1" ]]; then
         echo
         echo "=== curie local eval ==="
-        "$BIN" local eval --cases "$WORKDIR/bundle/evals/cases.json"
+        (cd "$WORKDIR/bundle" && "$BIN" "${eval_args[@]}")
     fi"#;
     assert!(
         text.contains(contract),
@@ -312,12 +316,16 @@ fn live_local_release_rung_grades_its_own_weather_cases_copy() {
 
     echo
     echo "=== curie local eval --dry-run (suite parity, release compose stack) ==="
-    assert_suite "local-release" "$("$BIN" --json local eval --cases "$WORKDIR/bundle-release/evals/cases.json" --dry-run)"
+    local eval_args=(local eval)
+    if [[ ! -f "$WORKDIR/bundle-release/evals/trajectory.json" ]]; then
+        eval_args+=(--cases "$WORKDIR/bundle-release/evals/cases.json")
+    fi
+    assert_suite "local-release" "$(cd "$WORKDIR/bundle-release" && "$BIN" --json "${eval_args[@]}" --dry-run)"
 
     if [[ "$LIVE" == "1" ]]; then
         echo
         echo "=== curie local eval (release compose stack) ==="
-        "$BIN" local eval --cases "$WORKDIR/bundle-release/evals/cases.json"
+        (cd "$WORKDIR/bundle-release" && "$BIN" "${eval_args[@]}")
     fi"#;
     assert!(
         text.contains(contract),
@@ -335,11 +343,14 @@ fn live_cluster_rung_runs_weather_cases_with_the_message_listen_host() {
     // array plus that one call rather than the whole block, because the block
     // carries the #1602/#1603 rationale comments and a reworded comment must not
     // red this contract.
-    let contract = r#"local eval_args=(cluster eval --cases "$WORKDIR/bundle/evals/cases.json")
+    let contract = r#"local eval_args=(cluster eval)
+    if [[ ! -f "$WORKDIR/bundle/evals/trajectory.json" ]]; then
+        eval_args+=(--cases "$WORKDIR/bundle/evals/cases.json")
+    fi
     if [[ -n "${CURIE_E2E_LISTEN_HOST:-}" ]]; then
         eval_args+=(--listen-host "$CURIE_E2E_LISTEN_HOST")
     fi
-    assert_suite "cluster" "$("$BIN" --json "${eval_args[@]}" --dry-run)""#;
+    assert_suite "cluster" "$(cd "$WORKDIR/bundle" && "$BIN" --json "${eval_args[@]}" --dry-run)""#;
     assert!(
         text.contains(r#"assert_finalized_reply "cluster" "$out""#),
         "the live cluster rung must keep its plumbing assertion; ladder \
@@ -352,7 +363,7 @@ fn live_cluster_rung_runs_weather_cases_with_the_message_listen_host() {
          suite-parity dry-run; ladder contents:\n{text}"
     );
     assert!(
-        text.contains(r#"if ! "$BIN" --json "${eval_args[@]}"; then"#),
+        text.contains(r#"if ! (cd "$WORKDIR/bundle" && "$BIN" --json "${eval_args[@]}"); then"#),
         "the live cluster rung must still RUN cluster eval against the deployed \
          weather bundle cases and forward the message listen host -- through the \
          SAME array as the dry-run, so neither call can lose it -- and report \
@@ -379,7 +390,7 @@ fn live_cluster_rung_runs_weather_cases_with_the_message_listen_host() {
 fn live_cluster_rung_emits_the_graded_reply_for_passing_cases() {
     let text = ladder();
     assert!(
-        text.contains(r#"if ! "$BIN" --json "${eval_args[@]}"; then"#),
+        text.contains(r#"if ! (cd "$WORKDIR/bundle" && "$BIN" --json "${eval_args[@]}"); then"#),
         "the live cluster rung must run its eval with `--json` so a PASSING \
          case's reply text lands in the job log; without it a dishonest green \
          (a fabricated temperature) is indistinguishable from an honest one; \
@@ -447,6 +458,10 @@ fn write_ladder_stubs(dir: &Path) {
         &dir.join("curie"),
         r#"#!/bin/sh
 set -u
+
+if [ -n "${STUB_INVOCATION_LOG:-}" ]; then
+    printf '%s\n' "$*" >> "$STUB_INVOCATION_LOG"
+fi
 
 # `--plugin-dir <dir>` is the last pair on every deploy the ladder makes, so the
 # final argument is the bundle directory that rung packed.
@@ -578,6 +593,9 @@ print(json.dumps({
     "local up --minimal")
         echo "stub: compose stack up"
         ;;
+    "local up")
+        echo "stub: full compose stack up"
+        ;;
     "--json local deploy --plugin-dir "*)
         printf '%s' "$bundle_dir" > "$STUB_STATE/last_plugin_dir"
         emit_deploy "${STUB_LOCAL_SHA256:-$(sha_of_bundle "$bundle_dir")}"
@@ -595,10 +613,16 @@ print(json.dumps({
     "--json local eval --cases "*--dry-run*)
         emit_plan local 1 weather
         ;;
+    "--json local eval --dry-run")
+        emit_plan local 1 weather
+        ;;
     "--json cluster eval --cases "*--dry-run*)
         # Only the cluster count is an override: it is the knob the suite
         # divergence control moves. Everything else is the constant the weather
         # bundle declares.
+        emit_plan cluster "${STUB_CLUSTER_PLAN_COUNT:-1}" weather
+        ;;
+    "--json cluster eval --dry-run")
         emit_plan cluster "${STUB_CLUSTER_PLAN_COUNT:-1}" weather
         ;;
     # The two LIVE grades, and they are deliberately asymmetric: the local rung
@@ -606,7 +630,7 @@ print(json.dumps({
     # case's reply is auditable in the job log (#1602). The dry-run arms above
     # must stay above this one, since `--json cluster eval --cases *` matches a
     # dry-run argv too and the first matching arm wins.
-    "local eval --cases "*|"--json cluster eval --cases "*)
+    "local eval --cases "*|"--json cluster eval --cases "*|"local eval"|"--json cluster eval")
         if [ -n "${STUB_EVAL_MARKER:-}" ]; then
             printf '%s\n' called > "$STUB_EVAL_MARKER"
         fi
@@ -772,6 +796,10 @@ fn require_local_stub_port_free() {
 ///   exported value turns the skill rung into an `exit 97`.
 fn run_ladder(harness: &Path, envs: &[(&str, &str)]) -> Output {
     let script = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("scripts/e2e-ladder.sh");
+    run_ladder_script(&script, harness, envs)
+}
+
+fn run_ladder_script(script: &Path, harness: &Path, envs: &[(&str, &str)]) -> Output {
     let path = format!(
         "{}:{}",
         harness.display(),
@@ -801,6 +829,50 @@ fn run_ladder(harness: &Path, envs: &[(&str, &str)]) -> Output {
         command.env(key, value);
     }
     command.output().expect("run the real ladder script")
+}
+
+fn run_eval_argument_control(trajectory: bool) -> (Output, String) {
+    require_local_stub_port_free();
+    let root = tempfile::tempdir().expect("create isolated ladder root");
+    let scripts = root.path().join("cli/scripts");
+    let evals = root.path().join("examples/weather/evals");
+    fs::create_dir_all(&scripts).expect("create script directory");
+    fs::create_dir_all(&evals).expect("create eval directory");
+    let source = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("scripts/e2e-ladder.sh");
+    let script = scripts.join("e2e-ladder.sh");
+    fs::copy(source, &script).expect("copy ladder script");
+    fs::write(
+        evals.join("cases.json"),
+        r#"{"name":"weather","cases":[{"id":"weather","input":"weather","grader":{"kind":"contains","expected":"sunny"}}]}"#,
+    )
+    .expect("write cases");
+    if trajectory {
+        fs::write(
+            evals.join("trajectory.json"),
+            r#"{"specs":[{"case_id":"weather","expected":["WebSearch"],"mode":"exact","threshold":1.0}]}"#,
+        )
+        .expect("write trajectory sidecar");
+    }
+
+    let harness = tempfile::tempdir().expect("create harness directory");
+    write_ladder_stubs(harness.path());
+    let api_url = spawn_deployments_stub(&one_active_deployment());
+    let invocation_log = harness.path().join("invocations.log");
+    let invocation_log_value = invocation_log.display().to_string();
+    let output = run_ladder_script(
+        &script,
+        harness.path(),
+        &[
+            ("CURIE_E2E_TIERS", "local,cluster"),
+            ("CURIE_E2E_LIVE", "1"),
+            ("CURIE_CREDENTIALS", "test-credential"),
+            ("CURIE_API_URL", &api_url),
+            ("STUB_FAKE_MODEL", ""),
+            ("STUB_INVOCATION_LOG", &invocation_log_value),
+        ],
+    );
+    let invocations = fs::read_to_string(invocation_log).unwrap_or_default();
+    (output, invocations)
 }
 
 /// Whether some ONE line of the transcript carries every one of `needles`.
@@ -851,6 +923,76 @@ fn weather_bundle_sha256() -> String {
         .output()
         .expect("hash the weather bundle tree");
     String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+#[test]
+fn ladder_selects_platform_trajectory_eval_without_overriding_deployed_cases() {
+    let (trajectory_output, trajectory_invocations) = run_eval_argument_control(true);
+    let trajectory_transcript = transcript(&trajectory_output);
+    assert_eq!(
+        trajectory_output.status.code(),
+        Some(0),
+        "trajectory ladder failed:\n{trajectory_transcript}"
+    );
+    let trajectory_evals = trajectory_invocations
+        .lines()
+        .filter(|line| line.contains("local eval") || line.contains("cluster eval"))
+        .collect::<Vec<_>>();
+    assert_eq!(trajectory_evals.len(), 4, "{trajectory_invocations}");
+    assert!(
+        trajectory_evals
+            .iter()
+            .all(|line| !line.contains("--cases")),
+        "trajectory eval must use the deployed bundle instead of an explicit cases override: \
+         {trajectory_invocations}"
+    );
+    let trajectory_starts = trajectory_invocations
+        .lines()
+        .filter(|line| line.starts_with("local up"))
+        .collect::<Vec<_>>();
+    assert_eq!(trajectory_starts, ["local up"], "{trajectory_invocations}");
+    assert!(
+        trajectory_starts
+            .iter()
+            .all(|line| !line.contains("--minimal")),
+        "trajectory scoring requires the full local profile: {trajectory_invocations}"
+    );
+    for tier in ["local", "cluster"] {
+        assert!(
+            has_line_with(
+                &trajectory_transcript,
+                &[tier, r#"grade 1 case(s) from suite "weather""#,],
+            ),
+            "trajectory dry run must expose the standard suite and case count for {tier}: \
+             {trajectory_transcript}"
+        );
+    }
+
+    let (ordinary_output, ordinary_invocations) = run_eval_argument_control(false);
+    let ordinary_transcript = transcript(&ordinary_output);
+    assert_eq!(
+        ordinary_output.status.code(),
+        Some(0),
+        "ordinary ladder failed:\n{ordinary_transcript}"
+    );
+    let ordinary_evals = ordinary_invocations
+        .lines()
+        .filter(|line| line.contains("local eval") || line.contains("cluster eval"))
+        .collect::<Vec<_>>();
+    assert_eq!(ordinary_evals.len(), 4, "{ordinary_invocations}");
+    assert!(
+        ordinary_evals.iter().all(|line| line.contains("--cases")),
+        "ordinary eval must retain its explicit cases path: {ordinary_invocations}"
+    );
+    let ordinary_starts = ordinary_invocations
+        .lines()
+        .filter(|line| line.starts_with("local up"))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        ordinary_starts,
+        ["local up --minimal"],
+        "ordinary grading must retain the minimal local profile: {ordinary_invocations}"
+    );
 }
 
 /// POSITIVE CONTROL. Every rung -- skill, local and cluster -- reports the same

--- a/cli/tests/trajectory_eval.rs
+++ b/cli/tests/trajectory_eval.rs
@@ -1,0 +1,363 @@
+//! Integration coverage for trajectory scoring on the skill eval surface.
+//!
+//! These tests drive the built CLI against a wire faithful runner server. The
+//! final answer is deliberately made irrelevant to each expected verdict. Only
+//! the ordered `tool_note` observations may determine the result.
+
+mod support;
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::sync::Arc;
+
+use serde::Deserialize;
+use support::{serve, Response};
+
+const STRING_GRADER_EXPECTED: &str = "the string grader says pass";
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_curie")
+}
+
+fn output_text(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stdout).into_owned() + &String::from_utf8_lossy(&output.stderr)
+}
+
+fn frame(value: serde_json::Value) -> String {
+    serde_json::to_string(&value).expect("serialize ACI frame")
+}
+
+fn turn(tools: &[String], final_text: &str) -> Vec<String> {
+    let mut frames = tools
+        .iter()
+        .map(|tool| {
+            frame(serde_json::json!({
+                "type": "tool_note",
+                "version": curie_aci_protocol::PROTOCOL_VERSION,
+                "text": format!("called {tool}"),
+                "tool": tool,
+            }))
+        })
+        .collect::<Vec<_>>();
+    frames.push(frame(serde_json::json!({
+        "type": "final",
+        "version": curie_aci_protocol::PROTOCOL_VERSION,
+        "text": final_text,
+        "status": "done",
+    })));
+    frames
+}
+
+fn runner(
+    observed: BTreeMap<String, Vec<String>>,
+    final_text: BTreeMap<String, String>,
+) -> support::MockServer {
+    let observed = Arc::new(observed);
+    let final_text = Arc::new(final_text);
+    serve(
+        move |request| match (request.method.as_str(), request.path.as_str()) {
+            ("POST", "/v1/reset") => Response::json(200, "{}"),
+            ("POST", "/v1/event") => {
+                let body: serde_json::Value =
+                    serde_json::from_slice(&request.body).expect("valid inbound event");
+                let input = body["text"].as_str().expect("event text");
+                let tools = observed.get(input).expect("known eval input");
+                let answer = final_text.get(input).expect("known final answer");
+                Response::ndjson(&turn(tools, answer))
+            }
+            other => panic!("unexpected runner request: {other:?}"),
+        },
+    )
+}
+
+fn cases_bytes(case_ids: &[String]) -> Vec<u8> {
+    let cases = case_ids
+        .iter()
+        .map(|id| {
+            serde_json::json!({
+                "id": id,
+                "input": id,
+                "grader": {
+                    "kind": "contains",
+                    "expected": STRING_GRADER_EXPECTED,
+                },
+            })
+        })
+        .collect::<Vec<_>>();
+    serde_json::to_vec_pretty(&serde_json::json!({
+        "name": "trajectory",
+        "cases": cases,
+    }))
+    .expect("serialize eval suite")
+}
+
+fn write_bundle(cases: &[u8], specs: serde_json::Value) -> (tempfile::TempDir, PathBuf) {
+    let bundle = tempfile::tempdir().expect("bundle temp directory");
+    let evals = bundle.path().join("evals");
+    std::fs::create_dir_all(&evals).expect("create eval directory");
+    let cases_path = evals.join("cases.json");
+    std::fs::write(&cases_path, cases).expect("write cases");
+    std::fs::write(
+        evals.join("trajectory.json"),
+        serde_json::to_vec_pretty(&serde_json::json!({
+            "specs": specs,
+        }))
+        .expect("serialize trajectory sidecar"),
+    )
+    .expect("write trajectory sidecar");
+    (bundle, cases_path)
+}
+
+fn skill_eval(bundle: &Path, server: &support::MockServer) -> Output {
+    Command::new(bin())
+        .args(["skill", "eval", "--url", &server.base_url, "--json"])
+        .current_dir(bundle)
+        .stdin(std::process::Stdio::null())
+        .output()
+        .expect("run skill eval")
+}
+
+fn parsed_output(output: &Output) -> serde_json::Value {
+    serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "skill eval must emit one JSON result: {error}\n{}",
+            output_text(output)
+        )
+    })
+}
+
+fn case_result<'a>(body: &'a serde_json::Value, id: &str) -> &'a serde_json::Value {
+    body["cases"]
+        .as_array()
+        .expect("cases array")
+        .iter()
+        .find(|case| case["id"] == id)
+        .unwrap_or_else(|| panic!("missing result for {id}: {body}"))
+}
+
+#[derive(Debug, Deserialize)]
+struct VectorFile {
+    vectors: Vec<TrajectoryVector>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TrajectoryVector {
+    name: String,
+    mode: String,
+    expected: Vec<String>,
+    observed: Vec<String>,
+    threshold: f64,
+    passed: bool,
+    detail: Option<String>,
+}
+
+fn vectors() -> VectorFile {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("../tests/vectors/trajectory-match.json");
+    let body = std::fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("read {}: {error}", path.display()));
+    serde_json::from_str(&body).unwrap_or_else(|error| panic!("parse {}: {error}", path.display()))
+}
+
+#[test]
+fn skill_eval_uses_tool_order_instead_of_the_final_answer() {
+    let ids = vec!["ordered".to_string(), "wrong_order".to_string()];
+    let cases = cases_bytes(&ids);
+    let specs = serde_json::json!([
+        {
+            "case_id": "ordered",
+            "expected": ["Read", "Bash"],
+            "mode": "in_order",
+            "threshold": 1.0,
+        },
+        {
+            "case_id": "wrong_order",
+            "expected": ["Read", "Bash"],
+            "mode": "in_order",
+            "threshold": 1.0,
+        }
+    ]);
+    let (bundle, _cases_path) = write_bundle(&cases, specs);
+    let observed = BTreeMap::from([
+        (
+            "ordered".to_string(),
+            vec!["Read".to_string(), "Bash".to_string()],
+        ),
+        (
+            "wrong_order".to_string(),
+            vec!["Bash".to_string(), "Read".to_string()],
+        ),
+    ]);
+    let final_text = BTreeMap::from([
+        (
+            "ordered".to_string(),
+            "the string grader must fail".to_string(),
+        ),
+        (
+            "wrong_order".to_string(),
+            STRING_GRADER_EXPECTED.to_string(),
+        ),
+    ]);
+    let server = runner(observed, final_text);
+
+    let output = skill_eval(bundle.path(), &server);
+    assert!(
+        !output.status.success(),
+        "the wrong order case must make the run fail\n{}",
+        output_text(&output)
+    );
+    let body = parsed_output(&output);
+    assert_eq!(case_result(&body, "ordered")["passed"], true, "{body}");
+    assert_eq!(case_result(&body, "wrong_order")["passed"], false, "{body}");
+    assert!(
+        case_result(&body, "wrong_order")["detail"]
+            .as_str()
+            .is_some_and(|detail| detail.contains("observed")),
+        "a wrong order failure must explain the observed trajectory: {body}"
+    );
+}
+
+#[test]
+fn skill_eval_replays_the_shared_five_mode_trajectory_vectors() {
+    let vectors = vectors().vectors;
+    let modes = vectors
+        .iter()
+        .map(|vector| vector.mode.as_str())
+        .collect::<BTreeSet<_>>();
+    assert_eq!(
+        modes,
+        BTreeSet::from(["exact", "in_order", "any_order", "precision", "recall"]),
+        "the shared vectors must exercise every trajectory mode"
+    );
+
+    let ids = vectors
+        .iter()
+        .map(|vector| vector.name.clone())
+        .collect::<Vec<_>>();
+    let cases = cases_bytes(&ids);
+    let specs = vectors
+        .iter()
+        .map(|vector| {
+            serde_json::json!({
+                "case_id": vector.name,
+                "expected": vector.expected,
+                "mode": vector.mode,
+                "threshold": vector.threshold,
+            })
+        })
+        .collect::<Vec<_>>();
+    let (bundle, _cases_path) = write_bundle(&cases, serde_json::json!(specs));
+
+    let observed = vectors
+        .iter()
+        .map(|vector| (vector.name.clone(), vector.observed.clone()))
+        .collect::<BTreeMap<_, _>>();
+    let final_text = vectors
+        .iter()
+        .map(|vector| {
+            let text = if vector.passed {
+                "the string grader must fail"
+            } else {
+                STRING_GRADER_EXPECTED
+            };
+            (vector.name.clone(), text.to_string())
+        })
+        .collect::<BTreeMap<_, _>>();
+    let server = runner(observed, final_text);
+
+    let output = skill_eval(bundle.path(), &server);
+    let body = parsed_output(&output);
+    for vector in &vectors {
+        let result = case_result(&body, &vector.name);
+        assert_eq!(
+            result["passed"], vector.passed,
+            "trajectory vector {} must determine the verdict: {body}",
+            vector.name
+        );
+        match &vector.detail {
+            Some(detail) => assert_eq!(
+                result["detail"],
+                detail.as_str(),
+                "Rust detail must conform to the Python vector for {}",
+                vector.name
+            ),
+            None => assert!(
+                result["detail"].is_null(),
+                "a passing vector has no failure detail: {result}"
+            ),
+        }
+    }
+
+    let expected_success = vectors.iter().all(|vector| vector.passed);
+    assert_eq!(
+        output.status.success(),
+        expected_success,
+        "the process status must reflect the vector verdicts\n{}",
+        output_text(&output)
+    );
+}
+
+#[test]
+fn skill_eval_fails_closed_when_a_case_has_no_trajectory_spec() {
+    let ids = vec!["configured".to_string(), "missing_spec".to_string()];
+    let cases = cases_bytes(&ids);
+    let specs = serde_json::json!([{
+        "case_id": "configured",
+        "expected": ["Read"],
+        "mode": "exact",
+        "threshold": 1.0,
+    }]);
+    let (bundle, _cases_path) = write_bundle(&cases, specs);
+    let observed = BTreeMap::from([
+        ("configured".to_string(), vec!["Read".to_string()]),
+        ("missing_spec".to_string(), vec!["Read".to_string()]),
+    ]);
+    let final_text = BTreeMap::from([
+        ("configured".to_string(), STRING_GRADER_EXPECTED.to_string()),
+        (
+            "missing_spec".to_string(),
+            STRING_GRADER_EXPECTED.to_string(),
+        ),
+    ]);
+    let server = runner(observed, final_text);
+
+    let output = skill_eval(bundle.path(), &server);
+    assert!(
+        !output.status.success(),
+        "a missing trajectory spec must make the eval fail\n{}",
+        output_text(&output)
+    );
+    let body = parsed_output(&output);
+    assert_eq!(case_result(&body, "configured")["passed"], true, "{body}");
+    let missing = case_result(&body, "missing_spec");
+    assert_eq!(missing["passed"], false, "{body}");
+    let detail = missing["detail"]
+        .as_str()
+        .expect("a missing spec failure has visible detail");
+    assert!(detail.contains("no trajectory spec"), "{detail}");
+    assert!(detail.contains("missing_spec"), "{detail}");
+}
+
+#[test]
+fn skill_trajectory_eval_rejects_duplicate_suite_case_ids() {
+    let ids = vec!["duplicate".to_string(), "duplicate".to_string()];
+    let cases = cases_bytes(&ids);
+    let specs = serde_json::json!([{
+        "case_id": "duplicate",
+        "expected": ["Read"],
+        "mode": "exact",
+        "threshold": 1.0,
+    }]);
+    let (bundle, _cases_path) = write_bundle(&cases, specs);
+    let server = runner(
+        BTreeMap::from([("duplicate".to_string(), vec!["Read".to_string()])]),
+        BTreeMap::from([("duplicate".to_string(), STRING_GRADER_EXPECTED.to_string())]),
+    );
+
+    let output = skill_eval(bundle.path(), &server);
+
+    assert!(!output.status.success(), "{}", output_text(&output));
+    let text = output_text(&output).to_lowercase();
+    assert!(text.contains("duplicate"), "{text}");
+    assert!(text.contains("case id"), "{text}");
+}

--- a/cli/tests/trajectory_platform_eval.rs
+++ b/cli/tests/trajectory_platform_eval.rs
@@ -1,0 +1,484 @@
+//! Integration coverage for trajectory scoring on the platform eval plane.
+//!
+//! Local and cluster must both trigger the worker eval job and read its
+//! structured matrix cells. Neither tier may infer a trajectory verdict from a
+//! Slack reply string.
+
+mod support;
+
+use std::collections::BTreeMap;
+use std::ffi::OsString;
+use std::net::TcpListener;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use curie::api::ApiClient;
+use support::{serve, Request, Response};
+
+const AGENT_ID: &str = "11111111-1111-1111-1111-111111111111";
+const VERSION_ID: &str = "22222222-2222-2222-2222-222222222222";
+const SHA: &str = "abc123trajectory";
+const CHANNEL: &str = "C0EXAMPLE1";
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_curie")
+}
+
+fn output_text(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stdout).into_owned() + &String::from_utf8_lossy(&output.stderr)
+}
+
+fn matrix_body() -> String {
+    serde_json::json!({
+        "suite": "trajectory",
+        "versions": [SHA],
+        "cases": ["ordered", "wrong_order", "missing_spec"],
+        "rows": [
+            {
+                "case_id": "ordered",
+                "cells": [
+                    {
+                        "version": SHA,
+                        "status": "pass",
+                        "model": "resolved-model",
+                        "detail": null,
+                        "stream_id": "1-0",
+                        "scorer": "trajectory",
+                        "case_count": 3,
+                    }
+                ],
+            },
+            {
+                "case_id": "wrong_order",
+                "cells": [
+                    {
+                        "version": SHA,
+                        "status": "fail",
+                        "model": "resolved-model",
+                        "detail": "mode=in_order expected=['Read', 'Bash'] observed=['Bash', 'Read']",
+                        "stream_id": "1-0",
+                        "scorer": "trajectory",
+                        "case_count": 3,
+                    }
+                ],
+            },
+            {
+                "case_id": "missing_spec",
+                "cells": [
+                    {
+                        "version": SHA,
+                        "status": "fail",
+                        "model": "resolved-model",
+                        "detail": "no trajectory spec for case 'missing_spec'",
+                        "stream_id": "1-0",
+                        "scorer": "trajectory",
+                        "case_count": 3,
+                    }
+                ],
+            }
+        ],
+        "models": [null, "resolved-model"],
+        "model_summaries": [],
+        "model_version_summaries": [],
+    })
+    .to_string()
+}
+
+fn incomplete_matrix_body() -> String {
+    let mut body: serde_json::Value =
+        serde_json::from_str(&matrix_body()).expect("valid matrix fixture");
+    body["cases"]
+        .as_array_mut()
+        .expect("matrix cases")
+        .truncate(2);
+    body["rows"]
+        .as_array_mut()
+        .expect("matrix rows")
+        .truncate(2);
+    body.to_string()
+}
+
+fn platform_server_with_matrix(
+    matrix: impl Fn() -> String + Send + Sync + 'static,
+) -> support::MockServer {
+    serve(
+        move |request| match (request.method.as_str(), request.path.as_str()) {
+            ("GET", "/agents") => Response::json(
+                200,
+                &serde_json::json!([{
+                    "id": AGENT_ID,
+                    "name": "acme-bot",
+                    "channel": {"kind": "slack", "address": CHANNEL},
+                    "created_at": "2026-08-19T00:00:00Z",
+                }])
+                .to_string(),
+            ),
+            ("POST", "/evals/trigger") => Response::json(
+                200,
+                &serde_json::json!({
+                    "stream_id": "1-0",
+                    "agent_id": AGENT_ID,
+                    "version_id": VERSION_ID,
+                    "sha": SHA,
+                    "suite": "trajectory",
+                    "bundle_ref": "s3://example.com/trajectory-bundle",
+                    "model": null,
+                })
+                .to_string(),
+            ),
+            ("GET", path) if path.starts_with("/evals/matrix?") => Response::json(200, &matrix()),
+            other => panic!("unexpected platform request: {other:?}"),
+        },
+    )
+}
+
+fn platform_server() -> support::MockServer {
+    platform_server_with_matrix(matrix_body)
+}
+
+fn write_bundle() -> tempfile::TempDir {
+    let bundle = tempfile::tempdir().expect("bundle temp directory");
+    let evals = bundle.path().join("evals");
+    std::fs::create_dir_all(&evals).expect("create eval directory");
+    let cases = serde_json::to_vec_pretty(&serde_json::json!({
+        "name": "trajectory",
+        "cases": [
+            {
+                "id": "ordered",
+                "input": "ordered",
+                "grader": {"kind": "contains", "expected": "string says no"},
+            },
+            {
+                "id": "wrong_order",
+                "input": "wrong order",
+                "grader": {"kind": "contains", "expected": "string says yes"},
+            }
+        ],
+    }))
+    .expect("serialize cases");
+    std::fs::write(evals.join("cases.json"), &cases).expect("write cases");
+    let sidecar = serde_json::json!({
+        "specs": [
+            {
+                "case_id": "ordered",
+                "expected": ["Read", "Bash"],
+                "mode": "in_order",
+                "threshold": 1.0,
+            },
+            {
+                "case_id": "wrong_order",
+                "expected": ["Read", "Bash"],
+                "mode": "in_order",
+                "threshold": 1.0,
+            }
+        ],
+    });
+    std::fs::write(
+        evals.join("trajectory.json"),
+        serde_json::to_vec_pretty(&sidecar).expect("serialize trajectory sidecar"),
+    )
+    .expect("write trajectory sidecar");
+    bundle
+}
+
+fn unused_port() -> u16 {
+    TcpListener::bind("127.0.0.1:0")
+        .expect("bind temporary port")
+        .local_addr()
+        .expect("temporary port address")
+        .port()
+}
+
+fn write_kubectl_proxy(dir: &Path) -> PathBuf {
+    let path = dir.join("kubectl");
+    std::fs::write(
+        &path,
+        r#"#!/usr/bin/env python3
+import os
+import select
+import socket
+import sys
+import ctypes
+import signal
+
+ctypes.CDLL(None).prctl(1, signal.SIGTERM)
+
+args = sys.argv[1:]
+if "port-forward" not in args:
+    sys.stderr.write("unexpected kubectl invocation: " + " ".join(args) + "\n")
+    sys.exit(64)
+
+mapping = next(arg for arg in reversed(args) if ":" in arg and arg.split(":", 1)[0].isdigit())
+local_port = int(mapping.split(":", 1)[0])
+backend_host, backend_port = os.environ["CURIE_TEST_API_BACKEND"].rsplit(":", 1)
+
+listener = socket.socket()
+listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+listener.bind(("127.0.0.1", local_port))
+listener.listen()
+
+while True:
+    client, _ = listener.accept()
+    upstream = socket.create_connection((backend_host, int(backend_port)))
+    peers = {client: upstream, upstream: client}
+    open_sockets = [client, upstream]
+    while open_sockets:
+        readable, _, _ = select.select(open_sockets, [], [])
+        for source in readable:
+            data = source.recv(65536)
+            if not data:
+                open_sockets = []
+                break
+            peers[source].sendall(data)
+    client.close()
+    upstream.close()
+"#,
+    )
+    .expect("write kubectl proxy");
+    let mut permissions = std::fs::metadata(&path)
+        .expect("read kubectl proxy metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&path, permissions).expect("make kubectl proxy executable");
+    path
+}
+
+fn stub_path(dir: &Path) -> OsString {
+    let mut paths = vec![dir.to_path_buf()];
+    paths.extend(std::env::split_paths(
+        &std::env::var_os("PATH").unwrap_or_default(),
+    ));
+    std::env::join_paths(paths).expect("join tool path")
+}
+
+fn run_platform_eval_against(tier: &str, server: support::MockServer) -> (Output, Vec<Request>) {
+    let bundle = write_bundle();
+    let mut command = Command::new(bin());
+    command
+        .arg(tier)
+        .arg("eval")
+        .args(["--channel", CHANNEL, "--api-key", "test-key"])
+        .args(["--timeout-secs", "2", "--json"])
+        .current_dir(bundle.path())
+        .stdin(std::process::Stdio::null());
+
+    let _tools = if tier == "local" {
+        command.args(["--api-url", &server.base_url]);
+        None
+    } else {
+        let local_port = unused_port().to_string();
+        let tools = tempfile::tempdir().expect("tool temp directory");
+        let _kubectl = write_kubectl_proxy(tools.path());
+        let backend = server
+            .base_url
+            .strip_prefix("http://")
+            .expect("test server URL");
+        command
+            .args(["--api-local-port", &local_port])
+            .args(["--valkey-password", "unused"])
+            .env("CURIE_TEST_API_BACKEND", backend)
+            .env("PATH", stub_path(tools.path()));
+        Some(tools)
+    };
+
+    let output = command.output().expect("run platform trajectory eval");
+    (output, server.recorded())
+}
+
+fn run_platform_eval(tier: &str) -> (Output, Vec<Request>) {
+    run_platform_eval_against(tier, platform_server())
+}
+
+fn parsed_output(output: &Output) -> serde_json::Value {
+    serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "platform eval must emit one JSON result: {error}\n{}",
+            output_text(output)
+        )
+    })
+}
+
+fn case_result<'a>(body: &'a serde_json::Value, id: &str) -> &'a serde_json::Value {
+    body["cases"]
+        .as_array()
+        .expect("cases array")
+        .iter()
+        .find(|case| case["id"] == id)
+        .unwrap_or_else(|| panic!("missing result for {id}: {body}"))
+}
+
+fn verdict_projection(body: &serde_json::Value) -> BTreeMap<String, (bool, Option<String>)> {
+    body["cases"]
+        .as_array()
+        .expect("cases array")
+        .iter()
+        .map(|case| {
+            (
+                case["id"].as_str().expect("case id").to_string(),
+                (
+                    case["passed"].as_bool().expect("graded verdict"),
+                    case["detail"].as_str().map(str::to_string),
+                ),
+            )
+        })
+        .collect()
+}
+
+fn assert_platform_flow(requests: &[Request]) {
+    assert!(
+        requests
+            .iter()
+            .any(|request| request.method == "POST" && request.path == "/evals/trigger"),
+        "trajectory eval must trigger the worker eval plane: {requests:?}"
+    );
+    assert!(
+        requests.iter().any(|request| {
+            request.method == "GET"
+                && request.path.starts_with("/evals/matrix?")
+                && request.path.contains("stream_id=1-0")
+        }),
+        "trajectory eval must read structured matrix results for its exact trigger: {requests:?}"
+    );
+    let trigger = requests
+        .iter()
+        .find(|request| request.method == "POST" && request.path == "/evals/trigger")
+        .expect("trigger request");
+    let body: serde_json::Value = serde_json::from_slice(&trigger.body).expect("trigger JSON body");
+    assert_eq!(body["agent_id"], AGENT_ID, "{body}");
+    assert_eq!(body["suite"], "trajectory", "{body}");
+    assert!(
+        body.get("model").is_none(),
+        "a normal trajectory eval must not invent a model override: {body}"
+    );
+}
+
+#[tokio::test]
+async fn eval_matrix_dto_preserves_case_status_and_failure_detail() {
+    let server = platform_server();
+    let matrix = ApiClient::new(&server.base_url, "test-key")
+        .expect("API client")
+        .eval_matrix("trajectory", 5, Some("1-0"))
+        .await
+        .expect("read eval matrix");
+
+    assert_eq!(matrix.versions, vec![SHA]);
+    assert_eq!(matrix.rows.len(), 3);
+    let missing = matrix
+        .rows
+        .iter()
+        .find(|row| row.case_id == "missing_spec")
+        .expect("missing spec row");
+    assert_eq!(missing.cells.len(), 1);
+    let cell = missing
+        .cells
+        .iter()
+        .find(|cell| {
+            cell.stream_id.as_deref() == Some("1-0") && cell.scorer.as_deref() == Some("trajectory")
+        })
+        .expect("triggered trajectory cell");
+    assert_eq!(cell.version, SHA);
+    assert_eq!(cell.status, "fail");
+    assert_eq!(cell.model.as_deref(), Some("resolved-model"));
+    assert_eq!(cell.case_count, Some(3));
+    assert_eq!(
+        cell.detail.as_deref(),
+        Some("no trajectory spec for case 'missing_spec'")
+    );
+}
+
+#[test]
+fn local_trajectory_eval_refuses_an_explicit_cases_override() {
+    let server = platform_server();
+    let bundle = write_bundle();
+    let cases = bundle.path().join("evals/cases.json");
+    let output = Command::new(bin())
+        .args(["local", "eval", "--channel", CHANNEL])
+        .args(["--api-key", "test-key", "--api-url", &server.base_url])
+        .args(["--timeout-secs", "1", "--json"])
+        .arg("--cases")
+        .arg(&cases)
+        .current_dir(bundle.path())
+        .stdin(std::process::Stdio::null())
+        .output()
+        .expect("run local trajectory eval with explicit cases");
+
+    assert_eq!(output.status.code(), Some(4), "{}", output_text(&output));
+    let text = output_text(&output).to_lowercase();
+    assert!(text.contains("--cases"), "{text}");
+    assert!(text.contains("deployed"), "{text}");
+}
+
+#[test]
+fn local_and_cluster_use_the_same_structured_trajectory_verdicts() {
+    let (local_output, local_requests) = run_platform_eval("local");
+    let (cluster_output, cluster_requests) = run_platform_eval("cluster");
+
+    assert!(
+        !local_output.status.success(),
+        "the structured local result contains failures\n{}",
+        output_text(&local_output)
+    );
+    assert!(
+        !cluster_output.status.success(),
+        "the structured cluster result contains failures\n{}",
+        output_text(&cluster_output)
+    );
+    let local = parsed_output(&local_output);
+    let cluster = parsed_output(&cluster_output);
+    assert_eq!(verdict_projection(&local), verdict_projection(&cluster));
+    assert_eq!(case_result(&local, "ordered")["passed"], true, "{local}");
+    assert_eq!(
+        case_result(&local, "wrong_order")["passed"],
+        false,
+        "{local}"
+    );
+    assert!(
+        case_result(&local, "wrong_order")["detail"]
+            .as_str()
+            .is_some_and(|detail| detail.contains("observed")),
+        "the wrong order verdict must carry worker scoring detail: {local}"
+    );
+    assert!(
+        case_result(&local, "missing_spec")["detail"]
+            .as_str()
+            .is_some_and(|detail| detail.contains("no trajectory spec")),
+        "the missing spec verdict must remain explanatory: {local}"
+    );
+    assert_platform_flow(&local_requests);
+    assert_platform_flow(&cluster_requests);
+}
+
+#[test]
+fn platform_eval_waits_for_the_deployed_case_count_before_reporting() {
+    let matrix_polls = Arc::new(AtomicUsize::new(0));
+    let handler_polls = Arc::clone(&matrix_polls);
+    let server = platform_server_with_matrix(move || {
+        if handler_polls.fetch_add(1, Ordering::SeqCst) == 0 {
+            incomplete_matrix_body()
+        } else {
+            matrix_body()
+        }
+    });
+
+    let (output, requests) = run_platform_eval_against("local", server);
+    assert!(
+        !output.status.success(),
+        "the deployed missing spec row must make the eval fail\n{}",
+        output_text(&output)
+    );
+    assert!(
+        matrix_polls.load(Ordering::SeqCst) >= 2,
+        "the first response had both locally authored cases but only two of the deployed run's three rows: {requests:?}"
+    );
+    let body = parsed_output(&output);
+    assert_eq!(body["cases"].as_array().map(Vec::len), Some(3), "{body}");
+    assert!(
+        case_result(&body, "missing_spec")["detail"]
+            .as_str()
+            .is_some_and(|detail| detail.contains("no trajectory spec")),
+        "the matrix only deployed case must be reported: {body}"
+    );
+}

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,8 +1,10 @@
 # agents.md: the verification contract for driving Curie
 
 Curie is a harness that runs the same immutable bundle and the same eval suite
-(the bundle's own evals/cases.json) across three tiers, skill, local, and
-cluster, so an agent that worked locally does not silently break once deployed.
+<!-- doclint:ignore-line -->
+(the bundle's own `evals/cases.json` and optional `evals/trajectory.json`)
+across three tiers, skill, local, and cluster, so an agent that worked locally
+does not silently break once deployed.
 Its CLI's primary user is a coding agent driven by a developer, and this file is
 the contract that agent works to.
 
@@ -68,8 +70,23 @@ banned in this contract, so all three tiers are written out in full:
 - cluster tier: `curie cluster status --json` then `curie cluster eval --json`
 
 At the skill tier the bundle is the session, so there is no separate deploy
-step. `eval` runs the bundle's OWN evals/cases.json, the same file at every
-tier.
+<!-- doclint:ignore-line -->
+step. `eval` runs the bundle's OWN `evals/cases.json` at every tier. When the
+<!-- doclint:ignore-line -->
+bundle also carries `evals/trajectory.json`, every case is scored from the
+observed tool sequence. Skill reads runner tool frames directly. Local and
+cluster trigger the deployed bundle through the platform eval plane and read
+the exact triggered matrix stream. Deploy the changed bundle before running
+`curie local eval --json` or `curie cluster eval --json`. Those two trajectory
+runs refuse `--cases` because a local override cannot alter the deployed
+bundle.
+
+The trajectory sidecar maps each `case_id` to an `expected` tool sequence, a
+`mode` of `exact`, `in_order`, `any_order`, `precision`, or `recall`, and a
+`threshold`. The case file and sidecar are packaged in the same immutable
+deployed bundle. The deploy receipt's `bundle_sha256` is the parity identity
+for local and cluster. A case with no matching spec fails closed with an
+explanatory `detail`; it never passes by omission.
 
 **Success on an eval is `failed` equal to 0 AND `plumbing_ok` equal to 0.**
 `plumbing_ok` counts cases that completed on the fake model and were therefore

--- a/examples/weather/evals/trajectory.json
+++ b/examples/weather/evals/trajectory.json
@@ -1,0 +1,13 @@
+{
+  "specs": [
+    {
+      "case_id": "reports-a-temperature",
+      "expected": [
+        "WebSearch",
+        "WebFetch"
+      ],
+      "mode": "in_order",
+      "threshold": 1.0
+    }
+  ]
+}

--- a/tests/vectors/trajectory-match.json
+++ b/tests/vectors/trajectory-match.json
@@ -1,0 +1,113 @@
+{
+  "comment": "Python match_trajectory owns these verdicts. The Rust skill evaluator replays the same vectors so every eval tier uses identical trajectory semantics.",
+  "vectors": [
+    {
+      "name": "exact match",
+      "mode": "exact",
+      "expected": ["search", "fetch"],
+      "observed": ["search", "fetch"],
+      "threshold": 1.0,
+      "passed": true,
+      "detail": null
+    },
+    {
+      "name": "exact wrong order",
+      "mode": "exact",
+      "expected": ["search", "fetch"],
+      "observed": ["fetch", "search"],
+      "threshold": 1.0,
+      "passed": false,
+      "detail": "mode=exact expected=['search', 'fetch'] observed=['fetch', 'search']"
+    },
+    {
+      "name": "in order allows a gap",
+      "mode": "in_order",
+      "expected": ["search", "summarize"],
+      "observed": ["search", "fetch", "summarize"],
+      "threshold": 1.0,
+      "passed": true,
+      "detail": null
+    },
+    {
+      "name": "in order rejects reversed calls",
+      "mode": "in_order",
+      "expected": ["search", "summarize"],
+      "observed": ["summarize", "search"],
+      "threshold": 1.0,
+      "passed": false,
+      "detail": "mode=in_order expected=['search', 'summarize'] observed=['summarize', 'search']"
+    },
+    {
+      "name": "any order preserves multiplicity",
+      "mode": "any_order",
+      "expected": ["search", "search", "fetch"],
+      "observed": ["fetch", "search", "extra", "search"],
+      "threshold": 1.0,
+      "passed": true,
+      "detail": null
+    },
+    {
+      "name": "any order rejects a missing duplicate",
+      "mode": "any_order",
+      "expected": ["search", "search"],
+      "observed": ["search", "fetch"],
+      "threshold": 1.0,
+      "passed": false,
+      "detail": "mode=any_order expected=['search', 'search'] observed=['search', 'fetch']"
+    },
+    {
+      "name": "precision is one for no observed calls",
+      "mode": "precision",
+      "expected": ["search"],
+      "observed": [],
+      "threshold": 1.0,
+      "passed": true,
+      "detail": null
+    },
+    {
+      "name": "precision passes at the exact two thirds boundary",
+      "mode": "precision",
+      "expected": ["search", "fetch"],
+      "observed": ["search", "fetch", "write"],
+      "threshold": 0.6666666666666666,
+      "passed": true,
+      "detail": null
+    },
+    {
+      "name": "precision fails above the two thirds boundary",
+      "mode": "precision",
+      "expected": ["search", "fetch"],
+      "observed": ["search", "fetch", "write"],
+      "threshold": 0.667,
+      "passed": false,
+      "detail": "mode=precision expected=['search', 'fetch'] observed=['search', 'fetch', 'write'] precision=0.667 threshold=0.667"
+    },
+    {
+      "name": "recall is one for no expected calls",
+      "mode": "recall",
+      "expected": [],
+      "observed": ["extra"],
+      "threshold": 1.0,
+      "passed": true,
+      "detail": null
+    },
+    {
+      "name": "recall passes at the exact two thirds boundary",
+      "mode": "recall",
+      "expected": ["search", "fetch", "write"],
+      "observed": ["search", "fetch"],
+      "threshold": 0.6666666666666666,
+      "passed": true,
+      "detail": null
+    },
+    {
+      "name": "recall fails above the two thirds boundary",
+      "mode": "recall",
+      "expected": ["search", "fetch", "write"],
+      "observed": ["search", "fetch"],
+      "threshold": 0.667,
+      "passed": false,
+      "detail": "mode=recall expected=['search', 'fetch', 'write'] observed=['search', 'fetch'] recall=0.667 threshold=0.667"
+    }
+  ]
+}


### PR DESCRIPTION
Wires the deterministic trajectory scorer into skill, local, and cluster evals through an optional deployed sidecar. Preserves fail closed missing specs and exposes scorer detail through exact stream scoped results.

Keeps the frozen eval case schema unchanged and updates the parity ladder to exercise trajectory bundles.

Closes #389