### PR TITLE
Reject deployment targets without agents

### DIFF
--- a/apps/api/src/curie_api/gitflow.py
+++ b/apps/api/src/curie_api/gitflow.py
@@ -561,7 +561,19 @@ def resolve_target_agent(
             "deploys to. Declare a target (ADR-0089).",
         )
 
-    matching = [t for t in targets.targets.values() if t.env == environment.value]
+    matching = [
+        (key, target)
+        for key, target in targets.targets.items()
+        if target.env == environment.value
+    ]
+    agent_names: list[str] = []
+    for key, target in matching:
+        if target.agent is None:
+            raise TargetUnresolved(
+                "deploy.missing_agent",
+                f"targets.{key}: agent is required for every declared target",
+            )
+        agent_names.append(target.agent)
     if not matching:
         # Not an error: a repository may deploy only prod from main and leave
         # dev to the CLI. Ignoring matches how an unmatched branch behaves.
@@ -570,11 +582,11 @@ def resolve_target_agent(
         raise TargetUnresolved(
             "deploy.ambiguous_env",
             f"deploy.yaml declares {len(matching)} targets with env "
-            f"{environment.value!r} ({', '.join(sorted(str(t.agent) for t in matching))}); "
+            f"{environment.value!r} ({', '.join(sorted(agent_names))}); "
             "one branch cannot deploy to two agents in one push.",
         )
 
-    wanted = matching[0].agent
+    wanted = agent_names[0]
     for agent in repo_agents:
         if agent.name == wanted:
             return agent
@@ -619,7 +631,7 @@ def _target_agent_name(targets: DeployTargetsFile | None, environment: Environme
     if targets is None:
         return None
     matching = [t for t in targets.targets.values() if t.env == environment.value]
-    return str(matching[0].agent) if len(matching) == 1 else None
+    return matching[0].agent if len(matching) == 1 else None
 
 
 async def _sibling_bundle(

--- a/apps/api/tests/test_gitflow_targets.py
+++ b/apps/api/tests/test_gitflow_targets.py
@@ -15,10 +15,10 @@ from __future__ import annotations
 import uuid
 
 import pytest
-from curie_api.gitflow import TargetUnresolved, resolve_target_agent
+from curie_api.gitflow import TargetUnresolved, _target_agent_name, resolve_target_agent
 from curie_api.models import Agent, Environment
 from curie_test_support.scaffold import scaffolded_deploy_yaml
-from plugin_format.deploy_targets import validate_deploy_targets
+from plugin_format.deploy_targets import DeployTarget, DeployTargetsFile, validate_deploy_targets
 
 REPO = "acme-corp/acme-bot"
 
@@ -119,6 +119,41 @@ def test_two_targets_for_one_environment_are_refused() -> None:
     with pytest.raises(TargetUnresolved) as caught:
         resolve_target_agent(ambiguous, Environment.prod, [agent("acme-bot")], None)
     assert caught.value.code == "deploy.ambiguous_env"
+
+
+def test_a_selected_target_missing_its_agent_is_refused() -> None:
+    invalid = DeployTargetsFile(targets={"prod_target": DeployTarget(env="prod")})
+
+    with pytest.raises(TargetUnresolved) as caught:
+        resolve_target_agent(invalid, Environment.prod, [agent("acme-bot")], None)
+
+    message = str(caught.value)
+    assert caught.value.code == "deploy.missing_agent"
+    assert "prod_target" in message
+    assert "None" not in message
+
+
+def test_a_missing_agent_is_reported_before_environment_ambiguity() -> None:
+    invalid = DeployTargetsFile(
+        targets={
+            "missing_target": DeployTarget(env="prod"),
+            "valid_target": DeployTarget(agent="acme-bot", env="prod"),
+        }
+    )
+
+    with pytest.raises(TargetUnresolved) as caught:
+        resolve_target_agent(invalid, Environment.prod, [agent("acme-bot")], None)
+
+    message = str(caught.value)
+    assert caught.value.code == "deploy.missing_agent"
+    assert "missing_target" in message
+    assert "None" not in message
+
+
+def test_the_early_target_lookup_preserves_a_missing_agent() -> None:
+    invalid = DeployTargetsFile(targets={"prod_target": DeployTarget(env="prod")})
+
+    assert _target_agent_name(invalid, Environment.prod) is None
 
 
 # --------------------------------------------------------------------------- #

--- a/apps/api/tests/test_resolve_deploy_target.py
+++ b/apps/api/tests/test_resolve_deploy_target.py
@@ -86,6 +86,31 @@ def test_a_validation_error_is_returned_not_swallowed(
     assert "deploy.bad_env" in r.json()["detail"]
 
 
+@pytest.mark.parametrize(
+    "content",
+    [
+        "targets:\n  p:\n    env: prod\n",
+        "targets:\n  p:\n    agent: null\n    env: prod\n",
+    ],
+    ids=["omitted", "explicit_null"],
+)
+def test_resolve_and_list_name_a_target_with_no_agent(
+    client: TestClient, auth_headers: dict, content: str
+) -> None:
+    resolved = _resolve(client, auth_headers, content, "p")
+    listed = client.post(
+        "/deploy-targets/list",
+        json={"content": content, "target": "p"},
+        headers=auth_headers,
+    )
+    assert resolved.status_code == listed.status_code == 400
+    assert resolved.json()["detail"] == listed.json()["detail"]
+    detail = resolved.json()["detail"]
+    assert "deploy.missing_agent" in detail
+    assert "targets.p" in detail
+    assert "None" not in detail
+
+
 def test_unparseable_yaml_is_a_400_naming_the_problem(
     client: TestClient, auth_headers: dict
 ) -> None:

--- a/docs/interfaces/bundle-format/INTERFACE.md
+++ b/docs/interfaces/bundle-format/INTERFACE.md
@@ -72,6 +72,7 @@ files**, both optional, both invisible to Claude Code:
   `{agent, env, slack_channel}` where `env` is `dev` or `prod`. Validated by
   `packages/plugin-format/src/plugin_format/validate.py::_validate_deploy_targets`, which emits
   `deploy.*` codes (`deploy.not_object`, `deploy.bad_target_name`, `deploy.bad_env`,
+  `deploy.missing_agent` (a declared target must name its agent; the error names the target key),
   `deploy.bad_agent_name`, `deploy.bad_slack_channel`).
 
 The two overlay files are not independent of the manifest, which is the part a second consumer is

--- a/packages/plugin-format/src/plugin_format/deploy_targets.py
+++ b/packages/plugin-format/src/plugin_format/deploy_targets.py
@@ -59,8 +59,8 @@ class DeployTarget(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    # Which agent this target binds. Defaults to the manifest name, so a
-    # single-agent bundle need not repeat itself.
+    # Which agent this target binds. Validation requires it on every declared
+    # target, while the nullable shape preserves the existing schema.
     agent: str | None = None
     env: str = "dev"
     slack_channel: str | None = None
@@ -117,7 +117,14 @@ def validate_deploy_targets(data: Any) -> tuple[DeployTargetsFile | None, list[t
                     "never be selected.",
                 )
             )
-        if target.agent is not None and not _is_valid_name(target.agent):
+        if target.agent is None:
+            errors.append(
+                (
+                    "deploy.missing_agent",
+                    f"{where}: agent is required for every declared target",
+                )
+            )
+        elif not _is_valid_name(target.agent):
             errors.append(
                 (
                     "deploy.bad_agent_name",

--- a/packages/plugin-format/tests/test_deploy_targets.py
+++ b/packages/plugin-format/tests/test_deploy_targets.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
 from plugin_format import validate_bundle
 from plugin_format.deploy_targets import validate_deploy_targets
 
@@ -91,10 +92,17 @@ def test_env_defaults_to_dev_so_a_target_must_opt_in_to_prod() -> None:
     assert parsed.targets["p"].env == "dev"
 
 
-def test_agent_may_be_omitted_to_mean_the_manifest_name() -> None:
-    parsed, _ = validate_deploy_targets({"targets": {"p": {"env": "prod"}}})
-    assert parsed is not None
-    assert parsed.targets["p"].agent is None
+@pytest.mark.parametrize(
+    "target",
+    [{"env": "prod"}, {"agent": None, "env": "prod"}],
+    ids=["omitted", "explicit_null"],
+)
+def test_missing_agent_names_the_target(target: dict[str, object]) -> None:
+    _, errors = validate_deploy_targets({"targets": {"p": target}})
+    messages = [message for code, message in errors if code == "deploy.missing_agent"]
+    assert len(messages) == 1
+    assert "targets.p" in messages[0]
+    assert "None" not in messages[0]
 
 
 def test_unknown_key_is_rejected_not_ignored() -> None:
@@ -113,6 +121,23 @@ def test_bundle_surfaces_a_target_error(tmp_path: Path) -> None:
     result = validate_bundle(str(root))
     assert not result.valid
     assert any(e.code == "deploy.bad_env" for e in result.errors)
+
+
+@pytest.mark.parametrize(
+    "target_yaml",
+    ["    env: prod\n", "    agent: null\n    env: prod\n"],
+    ids=["omitted", "explicit_null"],
+)
+def test_bundle_refuses_a_missing_agent_at_load_time(
+    tmp_path: Path, target_yaml: str
+) -> None:
+    root = _bundle(tmp_path, f"targets:\n  p:\n{target_yaml}")
+    result = validate_bundle(str(root))
+    issues = [error for error in result.errors if error.code == "deploy.missing_agent"]
+    assert not result.valid
+    assert len(issues) == 1
+    assert "targets.p" in issues[0].message
+    assert "None" not in issues[0].message
 
 
 def test_bundle_surfaces_unparseable_yaml(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #1213

Rejects any declared deploy target that omits its agent with `deploy.missing_agent`, names the offending target key, and prevents null agent values from reaching user facing strings. The nullable schema shape remains unchanged.

Coordinates with #1198 and #1679 because both changes touch deployment YAML validation tests. Whichever lands second should rebase and retain both rejection cases.

Done check

* [x] Test contract was committed before implementation during the build
* [x] Source edits came from separate delegated executors
* [x] No public return type was broadened
* [x] Code and scope reviews approved
* [x] API and git flow sibling paths are covered
* [x] The guard rejects omitted and explicit null agents
* [x] The documentation error registry is current
* [x] Runtime API verification passed for invalid and valid targets
* [x] Affected tests, Ruff, mypy, contract drift, and docs lint passed
* [x] Security review was not applicable
* [x] Consolidation made no edits because the named tool was unavailable