### PR TITLE
Preserve App ID digits from values files

### DIFF
--- a/charts/curie/ci/github-app-credential-assertions.sh
+++ b/charts/curie/ci/github-app-credential-assertions.sh
@@ -14,11 +14,13 @@
 #       Without it the key is copied into every retained release revision (10 by
 #       default) and `helm get values` can print it.
 #
-# Five assertions.
+# Six assertions.
 set -euo pipefail
 
 CHART="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 fail() { echo "FAIL [$1] $2" >&2; exit 1; }
+VALUES_FILE="$(mktemp)"
+trap 'rm -f "$VALUES_FILE"' EXIT
 
 render() { helm template curie "$CHART" "$@" -s templates/api.yaml; }
 
@@ -46,24 +48,51 @@ if value != "1234567":
     sys.exit(1)
 PY
 
-# (b) Absent config renders empty, not a broken reference.
-OUT="$(render)"
-grep -q 'name: GITHUB_APP_ID' <<<"$OUT" || fail b "GITHUB_APP_ID should always render (empty is valid)"
+# (b) An unquoted values file App ID renders as the exact decimal string.
+cat >"$VALUES_FILE" <<'EOF'
+api:
+  githubAppId: 4475970
+EOF
+OUT="$(render -f "$VALUES_FILE")"
+python3 - "$OUT" <<'PY' || exit 1
+import sys, yaml
+doc = [d for d in yaml.safe_load_all(sys.argv[1]) if d and d.get("kind") == "Deployment"][0]
+env = {e["name"]: e for e in doc["spec"]["template"]["spec"]["containers"][0]["env"]}
+value = env["GITHUB_APP_ID"].get("value")
+if value != "4475970":
+    print(f"FAIL [b] GITHUB_APP_ID rendered as {value!r}, expected '4475970'. "
+          "An unquoted values file must preserve its decimal digits.",
+          file=sys.stderr)
+    sys.exit(1)
+PY
 
-# (c) Default path reads from the chart's own Secret.
+# (c) Absent config renders the exact empty string, not a broken reference.
+OUT="$(render)"
+python3 - "$OUT" <<'PY' || exit 1
+import sys, yaml
+doc = [d for d in yaml.safe_load_all(sys.argv[1]) if d and d.get("kind") == "Deployment"][0]
+env = {e["name"]: e for e in doc["spec"]["template"]["spec"]["containers"][0]["env"]}
+value = env["GITHUB_APP_ID"].get("value")
+if value != "":
+    print(f"FAIL [c] GITHUB_APP_ID rendered as {value!r}, expected empty string.",
+          file=sys.stderr)
+    sys.exit(1)
+PY
+
+# (d) Default path reads from the chart's own Secret.
 OUT="$(render --set api.githubAppPrivateKey=X)"
 env_block "$OUT" | grep -A 4 'GITHUB_APP_PRIVATE_KEY' | grep -q 'githubAppPrivateKey' \
-  || fail c "default path must read key githubAppPrivateKey from the chart Secret"
+  || fail d "default path must read key githubAppPrivateKey from the chart Secret"
 
-# (d) BYO path references the named Secret instead.
+# (e) BYO path references the named Secret instead.
 OUT="$(render --set api.githubAppExistingSecret=my-gh-app)"
-env_block "$OUT" | grep -q 'my-gh-app' || fail d "githubAppExistingSecret was not referenced"
-env_block "$OUT" | grep -q 'privateKey' || fail d "the default BYO key name was not used"
+env_block "$OUT" | grep -q 'my-gh-app' || fail e "githubAppExistingSecret was not referenced"
+env_block "$OUT" | grep -q 'privateKey' || fail e "the default BYO key name was not used"
 
-# (e) BYO wins over an inline value, so a leftover inline key cannot silently
+# (f) BYO wins over an inline value, so a leftover inline key cannot silently
 #     shadow the Secret an operator deliberately pointed at.
 OUT="$(render --set api.githubAppExistingSecret=my-gh-app --set api.githubAppPrivateKey=STALE)"
 env_block "$OUT" | grep -q 'my-gh-app' \
-  || fail e "githubAppExistingSecret must win over an inline githubAppPrivateKey"
+  || fail f "githubAppExistingSecret must win over an inline githubAppPrivateKey"
 
-echo "github-app-credential-assertions: all five assertions passed"
+echo "github-app-credential-assertions: all six assertions passed"

--- a/charts/curie/templates/api.yaml
+++ b/charts/curie/templates/api.yaml
@@ -91,7 +91,7 @@ spec:
             # cloning, instead of using GITHUB_TOKEN above. Both empty is fine:
             # public repositories clone with no credential.
             - name: GITHUB_APP_ID
-              value: {{ .Values.api.githubAppId | quote }}
+              value: {{ if .Values.api.githubAppId }}{{ .Values.api.githubAppId | int64 | quote }}{{ else }}""{{ end }}
             - name: GITHUB_APP_PRIVATE_KEY
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
Closes #1253

Normalizes numeric GitHub App IDs loaded from values files before quoting while preserving the empty default.

Adds a chart assertion for unquoted numeric YAML and exact empty output. Restoring the old quote expression fails the new assertion with scientific notation. A disposable kind install returned `4475970` from the running API container.