### PR TITLE
Fix review window papercuts

### DIFF
--- a/apps/worker/src/curie_worker/connector_agent.py
+++ b/apps/worker/src/curie_worker/connector_agent.py
@@ -6,7 +6,7 @@ them can know on its own -- which objects are this agent's to manage, and when
 reconciling would do more harm than leaving it alone.
 
 **The credential hazard, which is the reason this module is not three lines.**
-The API's render emits a Service, a Deployment and a NetworkPolicy per
+The API's render emits a Service, a Deployment and two NetworkPolicies per
 connector. It never emits the Secret. For a connector using the owned form
 (`secrets: [NAME]`) that Secret is minted by `curie cluster deploy`, from values
 only the operator's environment holds -- the cluster deliberately does not have

--- a/charts/curie/ci/worker-object-store-assertions.sh
+++ b/charts/curie/ci/worker-object-store-assertions.sh
@@ -24,7 +24,8 @@
 # and leaves both pods in CreateContainerConfigError.
 set -euo pipefail
 
-CHART=${CHART:-charts/curie}
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART="${CHART:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 EXTERNAL_VALUES=$(mktemp)
 trap 'rm -f "$EXTERNAL_VALUES"' EXIT
 

--- a/cli/src/connectors.rs
+++ b/cli/src/connectors.rs
@@ -9,10 +9,10 @@
 //!
 //! Pruning is the reason this is not a bare `kubectl apply`. Every object
 //! carries a label naming the agent that declared it, so removing a connector
-//! from `connectors.yaml` removes its Deployment, Service, and NetworkPolicy on
-//! the next deploy. Without that, a deleted connector leaves a pod running with
-//! a credential mounted and nothing referencing it -- the kind of leak nobody
-//! notices because nothing breaks.
+//! from `connectors.yaml` removes its Deployment, Service, and NetworkPolicies
+//! on the next deploy. Without that, a deleted connector leaves a pod running
+//! with a credential mounted and nothing referencing it -- the kind of leak
+//! nobody notices because nothing breaks.
 
 use anyhow::{Context, Result};
 use serde_json::Value;
@@ -234,7 +234,7 @@ mod tests {
     #[test]
     fn prune_with_nothing_declared_removes_everything_owned() {
         // The connector was deleted from connectors.yaml: its Deployment,
-        // Service, and NetworkPolicy must go, or a pod keeps running with a
+        // Service, and two NetworkPolicies must go, or a pod keeps running with a
         // credential mounted and nothing referencing it.
         let args = prune_args("ns", "acme-bot", &[]);
         assert!(!args.iter().any(|a| a.starts_with("--field-selector")));

--- a/packages/plugin-format/src/plugin_format/connector_render.py
+++ b/packages/plugin-format/src/plugin_format/connector_render.py
@@ -341,7 +341,7 @@ def render_networkpolicy(
 def render_ingress_networkpolicy(
     release: str, agent: str, app_name: str, connector: str, spec: ConnectorSpec
 ) -> dict[str, Any]:
-    """Ingress to this connector: the sandbox, and nothing else.
+    """Ingress to this connector: any sandbox in this release, and nothing else.
 
     The egress policy above says where the sandbox may GO. It says nothing
     about who may ARRIVE, and those are not the same question. Without this,


### PR DESCRIPTION
Closes #1454

Corrects connector object and ingress descriptions, and makes the object store assertion script independent of the current directory.

Items 1 through 4 were already resolved on main by #1442 and #1674. Their disposition is recorded on the issue.

## Done check

[x] New behavior test is not applicable because this branch changes descriptions and static assertion path resolution only.
[x] All implementation edits were delegated.
[x] Return type review is not applicable.
[x] Code review approved.
[x] Scope review approved.
[x] Sibling path parity is not applicable.
[x] Guard demonstration is not applicable.
[x] Consolidation reviewed with no edits needed.
[x] Security review is not applicable.
[x] Product runtime E2E is not applicable.
[x] Full affected validation passed.