### PR TITLE
Fix correctness and accuracy papercuts

### DIFF
--- a/charts/curie/README.md
+++ b/charts/curie/README.md
@@ -324,8 +324,9 @@ agentSandbox:
 
 The bundle fetch uses path style addressing, so it appends
 `agentSandbox.runner.bundleFetch.bucket` to this endpoint. For another AWS
-region, change both the region in `rustfs.host` and `rustfs.region` so the
-endpoint and SigV4 signing region agree.
+region, change the region in `rustfs.host` and set `rustfs.region` to control
+the SigV4 signing region used by the bundle fetch init container. This setting
+does not configure the API or worker S3 clients.
 
 Scope the runner's role to the bundle bucket, **read-only**. NetworkPolicy
 selects pods rather than containers, so any identity the bundle-fetch init

--- a/charts/curie/README.md
+++ b/charts/curie/README.md
@@ -302,8 +302,9 @@ both env vars:
 ```yaml
 rustfs:
   deploy: false
-  host: my-bucket.s3.us-east-1.amazonaws.com
+  host: s3.us-east-1.amazonaws.com
   port: 443
+  region: us-east-1
   auth:
     accessKey: ""            # selects the key-free path
 api:
@@ -320,6 +321,11 @@ agentSandbox:
       annotations:
         eks.amazonaws.com/role-arn: arn:aws:iam::000000000000:role/curie-runner
 ```
+
+The bundle fetch uses path style addressing, so it appends
+`agentSandbox.runner.bundleFetch.bucket` to this endpoint. For another AWS
+region, change both the region in `rustfs.host` and `rustfs.region` so the
+endpoint and SigV4 signing region agree.
 
 Scope the runner's role to the bundle bucket, **read-only**. NetworkPolicy
 selects pods rather than containers, so any identity the bundle-fetch init

--- a/charts/curie/ci/object-store-web-identity-assertions.sh
+++ b/charts/curie/ci/object-store-web-identity-assertions.sh
@@ -41,12 +41,14 @@ CHART=${CHART:-charts/curie}
 # `rm -f` an empty argument it ignores rather than an unbound variable.
 STATIC_RENDERED=""
 WEB_IDENTITY_RENDERED=""
+REGION_OVERRIDE_RENDERED=""
 WEB_IDENTITY_VALUES=""
 WEB_IDENTITY_TOKEN=""
-trap 'rm -f "${STATIC_RENDERED:-}" "${WEB_IDENTITY_RENDERED:-}" "${WEB_IDENTITY_VALUES:-}" "${WEB_IDENTITY_TOKEN:-}"' EXIT
+trap 'rm -f "${STATIC_RENDERED:-}" "${WEB_IDENTITY_RENDERED:-}" "${REGION_OVERRIDE_RENDERED:-}" "${WEB_IDENTITY_VALUES:-}" "${WEB_IDENTITY_TOKEN:-}"' EXIT
 
 STATIC_RENDERED=$(mktemp)
 WEB_IDENTITY_RENDERED=$(mktemp)
+REGION_OVERRIDE_RENDERED=$(mktemp)
 WEB_IDENTITY_VALUES=$(mktemp)
 # Stands in for the projected ServiceAccount token the EKS pod-identity webhook
 # mounts. Its CONTENT is never read here: the web-identity provider hands back
@@ -92,6 +94,8 @@ EOF
 helm template curie "$CHART" --namespace dev > "$STATIC_RENDERED"
 helm template curie "$CHART" --namespace dev \
   --values "$WEB_IDENTITY_VALUES" > "$WEB_IDENTITY_RENDERED"
+helm template curie "$CHART" --namespace dev \
+  --set rustfs.region=eu-west-1 > "$REGION_OVERRIDE_RENDERED"
 
 # Assertion 1: clearing the access key while the in-chart RustFS is deployed is
 # refused at render. That store is configured with those very credentials and
@@ -106,7 +110,25 @@ if helm template curie "$CHART" --namespace dev \
 fi
 echo "ok: an empty access key with the in-chart RustFS is refused at render"
 
-python3 - "$STATIC_RENDERED" "$WEB_IDENTITY_RENDERED" <<'PY'
+# Assertion 2: the in-chart RustFS also requires its secret material. Empty
+# secretKey must fail before installation, while an explicitly named external
+# Secret is a legitimate source for that value and must still render.
+if helm template curie "$CHART" --namespace dev \
+  --set rustfs.auth.secretKey="" > /dev/null 2>&1; then
+  echo "FAIL: clearing rustfs.auth.secretKey with rustfs.deploy=true and no existingSecret must be refused" >&2
+  exit 1
+fi
+echo "ok: an empty secret key with the in-chart RustFS is refused at render"
+
+if ! helm template curie "$CHART" --namespace dev \
+  --set rustfs.auth.secretKey="" \
+  --set rustfs.existingSecret=externally-managed-rustfs > /dev/null; then
+  echo "FAIL: an existing RustFS Secret with an empty rustfs.auth.secretKey must render" >&2
+  exit 1
+fi
+echo "ok: an existing RustFS Secret with an empty rustfs.auth.secretKey renders"
+
+python3 - "$STATIC_RENDERED" "$WEB_IDENTITY_RENDERED" "$REGION_OVERRIDE_RENDERED" <<'PY'
 import ipaddress, sys, yaml
 
 CREDENTIAL_KEYS = ("S3_ACCESS_KEY", "S3_SECRET_KEY")
@@ -242,8 +264,20 @@ def assert_web_identity(path):
     print("ok: web-identity: no S3 credential env or shell export reaches any consumer")
 
 
+def assert_bundle_fetch_region(path, expected_region):
+    _, _, bundle_fetch, _, _, _ = read(path)
+    rendered = bundle_fetch.get("AWS_DEFAULT_REGION", {}).get("value")
+    assert rendered == expected_region, (
+        f"bundle-fetch AWS_DEFAULT_REGION rendered as {rendered!r}; expected "
+        f"{expected_region!r} from rustfs.region"
+    )
+    print(f"ok: bundle-fetch AWS_DEFAULT_REGION renders {expected_region}")
+
+
 assert_static(sys.argv[1])
 assert_web_identity(sys.argv[2])
+assert_bundle_fetch_region(sys.argv[1], "us-east-1")
+assert_bundle_fetch_region(sys.argv[3], "eu-west-1")
 PY
 
 # Everything above reads the rendered YAML. That is necessary and not

--- a/charts/curie/templates/_helpers.tpl
+++ b/charts/curie/templates/_helpers.tpl
@@ -184,6 +184,9 @@ http
      no metadata access and leaves Rail 1 intact. */}}
 {{- define "curie.rustfs.staticCredentials" -}}
 {{- if .Values.rustfs.auth.accessKey -}}
+{{- if and .Values.rustfs.deploy (not .Values.rustfs.existingSecret) (not .Values.rustfs.auth.secretKey) -}}
+{{- fail "rustfs.auth.secretKey is empty but rustfs.deploy is true and rustfs.existingSecret is empty. The in-chart RustFS requires secret material for static credentials. Either set rustfs.auth.secretKey, or set rustfs.existingSecret to a Secret containing rustfsSecretKey." -}}
+{{- end -}}
 true
 {{- else if .Values.rustfs.deploy -}}
 {{- fail "rustfs.auth.accessKey is empty but rustfs.deploy is true. The in-chart RustFS is configured with those static credentials and has no web-identity path, so clearing the key would leave every bundle read and write unauthenticated against it. Either set rustfs.auth.accessKey, or set rustfs.deploy=false and point rustfs.host at an external store that accepts the ServiceAccount's projected token (see the chart README, 'Key-free object store auth')." -}}

--- a/charts/curie/templates/agent-sandbox.yaml
+++ b/charts/curie/templates/agent-sandbox.yaml
@@ -321,7 +321,7 @@ spec:
             - name: BUNDLE_BUCKET
               value: {{ $bf.bucket | quote }}
             - name: AWS_DEFAULT_REGION
-              value: us-east-1
+              value: {{ .Values.rustfs.region | quote }}
             - name: AWS_CONFIG_FILE
               value: /aws-config/config
             - name: AWS_SHARED_CREDENTIALS_FILE

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -402,6 +402,8 @@ rustfs:
   # For the API, worker, and sandbox bundle fetch endpoints, an external RustFS on port 443 uses HTTPS. All other configurations use HTTP.
   host: ""
   port: 9000
+  # Signing region for sandbox bundle fetches. Keep it aligned with the regional S3 endpoint.
+  region: us-east-1
   consolePort: 9001
   bucket: langfuse
   # Static credentials, and the only mode the in-chart RustFS supports.

--- a/cli/schema/baseline/chart-check.schema.json
+++ b/cli/schema/baseline/chart-check.schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.curietech.ai/cli/chart-check/v1.json",
+  "title": "curie dev chart-check --json",
+  "description": "The agent-facing result of `curie dev chart-check`: the number of passing scripts, the total discovered scripts, and the ordered result of every assertion script.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "passed": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "total": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "scripts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "passed": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "name",
+          "passed"
+        ]
+      }
+    }
+  },
+  "required": [
+    "passed",
+    "total",
+    "scripts"
+  ]
+}

--- a/cli/schema/chart-check.schema.json
+++ b/cli/schema/chart-check.schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.curietech.ai/cli/chart-check/v1.json",
+  "title": "curie dev chart-check --json",
+  "description": "The agent-facing result of `curie dev chart-check`: the number of passing scripts, the total discovered scripts, and the ordered result of every assertion script.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "passed": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "total": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "scripts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "passed": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "name",
+          "passed"
+        ]
+      }
+    }
+  },
+  "required": [
+    "passed",
+    "total",
+    "scripts"
+  ]
+}

--- a/cli/schema/index.json
+++ b/cli/schema/index.json
@@ -34,6 +34,12 @@
       "version": "1.0"
     },
     {
+      "result": "ChartCheckOutput",
+      "kind": "CliOutput",
+      "schema": "chart-check.schema.json",
+      "version": "1.0"
+    },
+    {
       "result": "CheckOutput",
       "kind": "CliOutput",
       "schema": "check.schema.json",

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -5,7 +5,6 @@
 //! scaffold, state, evals, render).
 
 use std::collections::BTreeMap;
-use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
@@ -685,8 +684,8 @@ fn is_executable(_path: &Path) -> bool {
     true
 }
 
-/// Run every discovered script from `root`, streaming its output, and report how
-/// each one fared.
+/// Run every discovered script from `root`, streaming its stdout and stderr to
+/// this process's stderr, and report how each one fared.
 ///
 /// A failure does not stop the run: the point of the verb is that one invocation
 /// surfaces every problem, rather than making a contributor fix, re-run, and
@@ -710,20 +709,17 @@ pub async fn run_chart_check_scripts(
             scripts.len(),
             rel.display()
         ));
-        let output = tokio::process::Command::new("bash")
+        let status = tokio::process::Command::new("bash")
             .arg(script)
             .current_dir(root)
-            .output()
+            .stdout(std::io::stderr())
+            .stderr(std::process::Stdio::inherit())
+            .status()
             .await
             .with_context(|| format!("failed to invoke bash for {name}"))?;
-        {
-            let mut stderr = std::io::stderr().lock();
-            let _ = stderr.write_all(&output.stdout);
-            let _ = stderr.write_all(&output.stderr);
-        }
         outcomes.push(ChartCheckOutcome {
             name,
-            passed: output.status.success(),
+            passed: status.success(),
         });
     }
     Ok(outcomes)

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -5,6 +5,7 @@
 //! scaffold, state, evals, render).
 
 use std::collections::BTreeMap;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
@@ -621,10 +622,32 @@ pub async fn dev_script(rel_path: &str) -> Result<()> {
 pub const CHART_CI_DIR: &str = "charts/curie/ci";
 
 /// One chart assertion script and how it fared.
+#[derive(Serialize)]
 pub struct ChartCheckOutcome {
     /// The script's file name, e.g. `render-assertions.sh`.
     pub name: String,
     pub passed: bool,
+}
+
+/// The result of a successful `curie dev chart-check` run.
+#[derive(Serialize)]
+pub struct ChartCheckOutput {
+    pub passed: usize,
+    pub total: usize,
+    pub scripts: Vec<ChartCheckOutcome>,
+}
+
+impl crate::ui::CliOutput for ChartCheckOutput {
+    fn to_json(&self) -> serde_json::Value {
+        serde_json::to_value(self).unwrap_or_else(|_| serde_json::json!({}))
+    }
+
+    fn render(&self, ui: &crate::ui::Ui) {
+        ui.success(&format!(
+            "all {} chart assertion scripts passed",
+            self.total
+        ));
+    }
 }
 
 /// Discover the assertion scripts `curie dev chart-check` runs: every executable
@@ -687,15 +710,20 @@ pub async fn run_chart_check_scripts(
             scripts.len(),
             rel.display()
         ));
-        let status = tokio::process::Command::new("bash")
+        let output = tokio::process::Command::new("bash")
             .arg(script)
             .current_dir(root)
-            .status()
+            .output()
             .await
             .with_context(|| format!("failed to invoke bash for {name}"))?;
+        {
+            let mut stderr = std::io::stderr().lock();
+            let _ = stderr.write_all(&output.stdout);
+            let _ = stderr.write_all(&output.stderr);
+        }
         outcomes.push(ChartCheckOutcome {
             name,
-            passed: status.success(),
+            passed: output.status.success(),
         });
     }
     Ok(outcomes)
@@ -749,10 +777,13 @@ pub async fn dev_chart_check() -> Result<()> {
             failed.join(", ")
         );
     }
-    ui.success(&format!(
-        "all {} chart assertion scripts passed",
-        outcomes.len()
-    ));
+    let passed = outcomes.iter().filter(|outcome| outcome.passed).count();
+    let total = outcomes.len();
+    ui.emit(&ChartCheckOutput {
+        passed,
+        total,
+        scripts: outcomes,
+    });
     Ok(())
 }
 

--- a/cli/tests/chart_check.rs
+++ b/cli/tests/chart_check.rs
@@ -68,7 +68,10 @@ fn chart_check_json_keeps_child_chatter_off_stdout() {
              {error}; stdout: {stdout:?}"
         )
     });
-    assert!(payload.is_object(), "--json result must be an object: {payload}");
+    assert!(
+        payload.is_object(),
+        "--json result must be an object: {payload}"
+    );
     assert_eq!(payload["passed"], 1, "{payload}");
     assert_eq!(payload["total"], 1, "{payload}");
     assert_eq!(

--- a/cli/tests/chart_check.rs
+++ b/cli/tests/chart_check.rs
@@ -34,6 +34,62 @@ fn write_script(dir: &Path, name: &str, body: &str) -> PathBuf {
     path
 }
 
+/// Under `--json`, child process chatter belongs on stderr and stdout is one
+/// machine readable result object. The script intentionally writes each stream
+/// without a newline so inherited stdout cannot be mistaken for a JSON line.
+#[test]
+fn chart_check_json_keeps_child_chatter_off_stdout() {
+    let scratch = tempfile::tempdir().expect("scratch repo");
+    let ci_dir = scratch.path().join(CHART_CI_DIR);
+    std::fs::create_dir_all(&ci_dir).expect("create chart assertion directory");
+    std::fs::create_dir_all(scratch.path().join("runner")).expect("create repo sentinel dir");
+    std::fs::write(scratch.path().join("runner/Dockerfile"), "").expect("write repo sentinel");
+    write_script(
+        &ci_dir,
+        "chatty-assertion.sh",
+        "#!/bin/bash\nprintf 'child stdout without newline'\nprintf 'child stderr without newline' >&2\n",
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_curie"))
+        .args(["--json", "dev", "chart-check"])
+        .current_dir(scratch.path())
+        .output()
+        .expect("run chart-check against scratch repository");
+    let stdout = String::from_utf8(output.stdout).expect("stdout is UTF-8");
+    let stderr = String::from_utf8(output.stderr).expect("stderr is UTF-8");
+
+    assert!(
+        output.status.success(),
+        "the passing assertion script must leave chart-check successful; stderr: {stderr}"
+    );
+    let payload: serde_json::Value = serde_json::from_str(&stdout).unwrap_or_else(|error| {
+        panic!(
+            "--json stdout must be exactly one parseable result object, not child chatter: \
+             {error}; stdout: {stdout:?}"
+        )
+    });
+    assert!(payload.is_object(), "--json result must be an object: {payload}");
+    assert_eq!(payload["passed"], 1, "{payload}");
+    assert_eq!(payload["total"], 1, "{payload}");
+    assert_eq!(
+        payload["scripts"],
+        serde_json::json!([{ "name": "chatty-assertion.sh", "passed": true }]),
+        "{payload}"
+    );
+    assert!(
+        !stdout.contains("child stdout without newline"),
+        "child stdout must not contaminate the result object: {stdout:?}"
+    );
+    assert!(
+        stderr.contains("child stdout without newline"),
+        "captured child stdout must be replayed to stderr: {stderr:?}"
+    );
+    assert!(
+        stderr.contains("child stderr without newline"),
+        "captured child stderr must remain on stderr: {stderr:?}"
+    );
+}
+
 /// AC3: a script added to `charts/curie/ci/` is picked up with no edit to `cli/`.
 ///
 /// The scratch copy stands in for the real directory so the assertion is about

--- a/cli/tests/json_contract.rs
+++ b/cli/tests/json_contract.rs
@@ -839,10 +839,10 @@ fn eval_schema_gate_has_teeth() {
 
 use curie::api::{ApprovalRecord, MemoryEntry, Version};
 use curie::commands::{
-    ApprovalsOutput, BudgetOutput, BumpVersionOutput, CheckMatch, CheckReport, DeclaredServer,
-    DeleteOutput, DeployOutput, KillOutput, ListAgentsOutput, LocalAgentSummary, MemoryOutput,
-    ResetThreadOutput, ResumeOutput, SkillApprovalsOutput, SkillMessageOutput, SweepRow,
-    VersionsOutput,
+    ApprovalsOutput, BudgetOutput, BumpVersionOutput, ChartCheckOutcome, ChartCheckOutput,
+    CheckMatch, CheckReport, DeclaredServer, DeleteOutput, DeployOutput, KillOutput,
+    ListAgentsOutput, LocalAgentSummary, MemoryOutput, ResetThreadOutput, ResumeOutput,
+    SkillApprovalsOutput, SkillMessageOutput, SweepRow, VersionsOutput,
 };
 use curie::comms::CommsOutput;
 use curie::local::{
@@ -871,6 +871,25 @@ fn dry_run_plan_validates() {
         ],
     };
     assert_valid("dry-run.schema.json", &plan.to_json());
+}
+
+#[test]
+fn chart_check_output_validates() {
+    let output = ChartCheckOutput {
+        passed: 2,
+        total: 2,
+        scripts: vec![
+            ChartCheckOutcome {
+                name: "first-assertion.sh".to_string(),
+                passed: true,
+            },
+            ChartCheckOutcome {
+                name: "second-assertion.sh".to_string(),
+                passed: true,
+            },
+        ],
+    };
+    assert_valid("chart-check.schema.json", &output.to_json());
 }
 
 #[test]

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -29,7 +29,7 @@ is documentation of where the code already draws the line, not a new abstraction
 | Memory | CLEAN | 1 loader (StateApiMemoryStore) | not separately graded | #28 | [Memory](interfaces/memory/INTERFACE.md) |
 | Conversation history | CLEAN | 1 loader (StateApiTranscriptStore) | not separately graded | #20 | [Conversation history](interfaces/conversation-history/INTERFACE.md) |
 | Triggers | SOFT | 3 hardcoded (Slack, GH push, commit poll) | not separately graded | #29 | [Triggers](interfaces/triggers/INTERFACE.md) |
-| CLI output (agent-facing `--json`) | CLEAN | 39 outputs behind one trait | not separately graded | #456 | [CLI output (agent-facing `--json`)](interfaces/cli-output/INTERFACE.md) |
+| CLI output (agent-facing `--json`) | CLEAN | 40 outputs behind one trait | not separately graded | #456 | [CLI output (agent-facing `--json`)](interfaces/cli-output/INTERFACE.md) |
 | Harness package (declared contribution) | CLEAN | 1 (built-in Claude) behind the entry-point registry | not separately graded | #844 | [Harness package (declared contribution)](interfaces/harness-package/INTERFACE.md) |
 | Connector host (bundle-declared MCP servers) | CLEAN | 1 (Kubernetes) + in-memory fake | not separately graded | #1063, #1184 | [Connector host (bundle-declared MCP servers)](interfaces/connector-host/INTERFACE.md) |
 | Sealed credential (cluster-sealed connector secrets) | SOFT | 2 halves (Rust sealer, Python opener) over one frozen wire | not separately graded | #1240 | [Sealed credential (cluster-sealed connector secrets)](interfaces/sealed-credential/INTERFACE.md) |

--- a/docs/interfaces/cli-output/INTERFACE.md
+++ b/docs/interfaces/cli-output/INTERFACE.md
@@ -1,7 +1,7 @@
 ---
 seam: CLI output (agent-facing `--json`)
 kind: CLEAN
-impls: 39 outputs behind one trait
+impls: 40 outputs behind one trait
 grade: not separately graded
 epics:
   - "#456"
@@ -13,7 +13,7 @@ order: 18
 > Part of the Curie swappable-seam catalog — see the [seam index](../../interfaces.md).
 
 <!-- BEGIN GENERATED: header (curie dev docs-lint) -->
-> **Kind:** CLEAN &nbsp;·&nbsp; **Implementations today:** 39 outputs behind one trait &nbsp;·&nbsp; **Swap-readiness grade:** not separately graded
+> **Kind:** CLEAN &nbsp;·&nbsp; **Implementations today:** 40 outputs behind one trait &nbsp;·&nbsp; **Swap-readiness grade:** not separately graded
 <!-- END GENERATED: header -->
 
 **Kind legend:** CLEAN = a real `Protocol`/typed port class · SOFT = swap via env/URL/prefix/wire, no code interface · NONE = not built yet.
@@ -65,7 +65,7 @@ This is the catalog's first **Rust** seam. It is listed here because the agent-f
 
 ## Implementations today
 
-39 `CliOutput` implementations, all in the CLI crate, grouped by owning module:
+40 `CliOutput` implementations, all in the CLI crate, grouped by owning module:
 
 - **`DryRunPlan`** (`cli/src/ui.rs`) — the generic `--dry-run` plan; JSON is
   `{"dry_run":true,"plan":[lines]}` and the human render is the same lines verbatim,
@@ -114,10 +114,10 @@ That set is not hand-maintained prose: `cli/schema/index.json` carries one
   syntactic call-site inventory, not a type-level proof that *every* verb returns
   a `CliOutput`.
 - **Committed JSON Schemas with a drift gate (since #841).** Each `to_json` is no
-  longer schema-free: there are 39 committed schemas under `cli/schema/` with an
+  longer schema-free: there are 40 committed schemas under `cli/schema/` with an
   index (`cli/schema/index.json`), a `syn`-based inventory gate over every `impl
-  CliOutput`, and per-family output validation — all 39 are validated against real
-  `to_json()` output across 64 tests in `cli/tests/json_contract.rs`. Those tests
+  CliOutput`, and per-family output validation — all 40 are validated against real
+  `to_json()` output across 65 tests in `cli/tests/json_contract.rs`. Those tests
   drive each output type's `to_json()` once per output variant rather than calling
   the pure builder functions behind it, so a variant whose `to_json()` arm drifts
   from the schema is caught even when the builder it delegates to still validates.

--- a/docs/interfaces/cli-output/INTERFACE.md
+++ b/docs/interfaces/cli-output/INTERFACE.md
@@ -75,9 +75,10 @@ This is the catalog's first **Rust** seam. It is listed here because the agent-f
   duplicated: the outputs whose verbs take `--dry-run` are enums carrying a `DryRun`
   variant that delegates to it instead of re-rendering the plan.
 - **`cli/src/commands.rs`**, the largest group, covering the skill and agent verbs
-  and the shared lifecycle results: `InitOutput`, `CheckOutput`, `ListAgentsOutput`,
-  `BumpVersionOutput`, `StatusOutput`, `SkillMessageOutput`, `EvalOutput`,
-  `DeployOutput`, `KillOutput`, `ResumeOutput`, `BudgetOutput`, `ResetThreadOutput`,
+  and the shared lifecycle results: `InitOutput`, `CheckOutput`, `ChartCheckOutput`,
+  `ListAgentsOutput`, `BumpVersionOutput`, `StatusOutput`, `SkillMessageOutput`,
+  `EvalOutput`, `DeployOutput`, `AllTargetsDeployOutput`, `KillOutput`, `ResumeOutput`,
+  `BudgetOutput`, `ResetThreadOutput`,
   `DeleteOutput`, `VersionsOutput`, `MemoryOutput`, `ApprovalsOutput`,
   `SkillApprovalsOutput`, `OverridesOutput`.
 - **`cli/src/local.rs`** and **`cli/src/ops.rs`**, the operator verbs, one output per

--- a/packages/plugin-format/tests/test_connector_render.py
+++ b/packages/plugin-format/tests/test_connector_render.py
@@ -819,7 +819,7 @@ def test_a_remote_connector_renders_no_policies() -> None:
 
 
 # --------------------------------------------------------------------------- #
-# `spec.port` is read in five places, and every one of them has to read the
+# `spec.port` is read in six places, and every one of them has to read the
 # DECLARED port. The default is 8000, so a reader that hardcodes it keeps
 # working for every connector that never sets `port:` and breaks only for the
 # ones that do -- silently, and with a different symptom per reader. These
@@ -861,3 +861,30 @@ def test_a_wrong_url_port_makes_the_sandbox_dial_a_port_nothing_serves(port: int
     spec = ConnectorSpec(image="grafana/mcp-grafana:0.17.2", port=port)
     url = r.mcp_entry("acme-rel", "acme-bot", "acme-ns", "grafana", spec)["url"]
     assert url == f"http://acme-rel-acme-bot-mcp-grafana.acme-ns.svc.cluster.local:{port}/mcp"
+
+
+@pytest.mark.parametrize("port", [9876, 9999])
+def test_connector_env_port_placeholders_use_the_declared_port(port: int) -> None:
+    spec = ConnectorSpec(
+        image="grafana/mcp-grafana:0.17.2",
+        port=port,
+        env={
+            "ALLOWED_HOSTS": "${CURIE_ALLOWED_HOSTS}",
+            "CONNECTOR_PORT": "${CURIE_CONNECTOR_PORT}",
+            "CONNECTOR_URL": "${CURIE_CONNECTOR_URL}",
+        },
+    )
+    env = next(o for o in _objs(spec=spec) if o["kind"] == "Deployment")["spec"]["template"][
+        "spec"
+    ]["containers"][0]["env"]
+    assert {entry["name"]: entry["value"] for entry in env} == {
+        "ALLOWED_HOSTS": (
+            f"acme-bot-acme-bot-mcp-grafana:{port},"
+            f"acme-bot-acme-bot-mcp-grafana.acme-bot:{port},"
+            f"acme-bot-acme-bot-mcp-grafana.acme-bot.svc.cluster.local:{port}"
+        ),
+        "CONNECTOR_PORT": str(port),
+        "CONNECTOR_URL": (
+            f"http://acme-bot-acme-bot-mcp-grafana.acme-bot.svc.cluster.local:{port}"
+        ),
+    }

--- a/runner/src/curie_runner/connectors.py
+++ b/runner/src/curie_runner/connectors.py
@@ -41,12 +41,10 @@ from typing import Any
 
 import yaml
 from plugin_format.connector_render import mcp_entry, unhosted_mcp_entry
-from plugin_format.connectors import ConnectorsFile, validate_connectors
+from plugin_format.connectors import CONNECTORS_FILE, ConnectorsFile, validate_connectors
 from plugin_format.yaml_loader import safe_load_unique
 
 logger = logging.getLogger(__name__)
-
-CONNECTORS_FILE = "connectors.yaml"
 
 
 def _read(plugin_dir: str | Path) -> ConnectorsFile | None:
@@ -55,7 +53,7 @@ def _read(plugin_dir: str | Path) -> ConnectorsFile | None:
         return None
     try:
         data = safe_load_unique(path.read_text(encoding="utf-8"))
-    except (OSError, yaml.YAMLError) as exc:
+    except (OSError, UnicodeDecodeError, yaml.YAMLError) as exc:
         # Deploy already validated this file, so reaching here means the bundle
         # changed underneath us. Log and mount nothing rather than fail the
         # turn: the agent loses the connector's tools, which is visible, where a

--- a/runner/tests/test_connectors.py
+++ b/runner/tests/test_connectors.py
@@ -96,6 +96,12 @@ def test_unreadable_connectors_file_mounts_nothing_rather_than_crashing(tmp_path
     assert servers == {}
 
 
+def test_non_utf8_connectors_file_mounts_nothing_rather_than_crashing(tmp_path: Path) -> None:
+    root = _bundle(tmp_path)
+    (root / "connectors.yaml").write_bytes(b"\x80")
+    assert derive_mcp_servers(root, **SCOPE) == {}
+
+
 def test_explicit_mapping_tag_on_a_scalar_mounts_nothing(tmp_path: Path) -> None:
     servers = derive_mcp_servers(
         _bundle(tmp_path, "connectors: !!map foo\n"), **SCOPE


### PR DESCRIPTION
## Summary\n\n* Fixes items 1, 2, 3, 4, 5, and 10 with reverting regression coverage.\n* Keeps chart check JSON machine readable while preserving live operator feedback.\n* Hardens RustFS credential and region behavior, corrects S3 documentation, and handles malformed connector files safely.\n\n## Disposition\n\n* Item 6 is closed without change because the stopword grouping is intentional and has no consuming behavior.\n* Item 7 is already fixed on the next release train.\n* Item 8 applies only to next and is outside this stable batch.\n* Item 9 is already correct because the assertions are uniquely labeled 12a, 12b, and 12c.\n* Item 11 applies only to next and is tied to frozen interface work.\n\nAll affected Python, Rust, Helm, documentation, skill, local, and cluster checks passed.\n\nCloses #1565