### PR TITLE
Fix correctness and accuracy papercuts

### DIFF
--- a/apps/worker/src/curie_worker/config.py
+++ b/apps/worker/src/curie_worker/config.py
@@ -456,11 +456,7 @@ class WorkerConfig(BaseSettings):
     # worker's localhost self-dial (#678). Empty means "not split out": the ref
     # falls back to api_base_url, byte-identical to the pre-#678 behavior. That
     # fallback is correct wherever the worker's own api_base_url is already
-    # runner-reachable; it does NOT by itself make an unreachable api_base_url
-    # reachable. The k8s substrate is a separate case -- a default chart install
-    # wires neither CURIE_API_URL nor this on the worker, so its runner state
-    # refs are the same localhost gap in the opposite substrate, out of #678's
-    # docker scope -- see runner_facing_api_base_url.
+    # runner-reachable.
     runner_api_base_url: str = Field(default="", validation_alias="CURIE_RUNNER_API_URL")
     api_key: str = Field(default="curie-dev-key", validation_alias=API_KEY_ENV)
     # ---------------------------------------------------------------------
@@ -511,9 +507,8 @@ class WorkerConfig(BaseSettings):
         network than the worker (the docker substrate: host-net worker, bridge-net
         runner). When it is unset this falls back to api_base_url, byte-identical
         to the pre-#678 behavior -- correct wherever the worker's own api_base_url
-        is already runner-reachable, but not itself a fix for a substrate where it
-        is not (see the field comment on the k8s gap). Callers minting
-        runner-facing refs (CURIE_MEMORY_REF / CURIE_HISTORY_REF) read this,
+        is already runner-reachable. Callers minting runner-facing refs
+        (CURIE_MEMORY_REF / CURIE_HISTORY_REF) read this,
         never api_base_url directly (#678).
         """
         return self.runner_api_base_url or self.api_base_url

--- a/charts/curie/ci/render-assertions.sh
+++ b/charts/curie/ci/render-assertions.sh
@@ -899,5 +899,55 @@ EOF
 assert_worker_api key_override curie http://curie-api:8000 operator operatorapisecret apiKey -f "$WORKER_API_KEY_OVERRIDE"
 echo "  ok: default and connector enabled renders use one chart API key reference; operator key override renders once without a chart duplicate"
 
+echo "=== Assertion 13: security probe uses the configured RustFS port (#1507) ==="
+SECURITY_PROBE_PORT="$TMP/security_probe_port.yaml"
+helm template curie "$CHART" \
+  --set rustfs.port=9100 \
+  --show-only templates/security-probe.yaml > "$SECURITY_PROBE_PORT"
+python3 - "$SECURITY_PROBE_PORT" <<'PYEOF'
+import sys
+
+import yaml
+
+manifest = sys.argv[1]
+docs = [doc for doc in yaml.safe_load_all(open(manifest)) if doc]
+probes = []
+for doc in docs:
+    if doc.get("kind") != "Job":
+        continue
+    containers = doc.get("spec", {}).get("template", {}).get("spec", {}).get("containers", [])
+    probe_containers = [container for container in containers if container.get("name") == "probe"]
+    if probe_containers:
+        probes.extend(probe_containers)
+
+if len(probes) != 1:
+    raise SystemExit(f"expected exactly one security probe container, found {len(probes)}")
+
+entries = [
+    entry
+    for entry in probes[0].get("env", [])
+    if entry.get("name") == "DATATIER_TARGETS"
+]
+if len(entries) != 1:
+    raise SystemExit(f"DATATIER_TARGETS appears {len(entries)} times in the security probe")
+
+targets = entries[0].get("value", "").split()
+expected = "curie-rustfs:9100"
+forbidden = "curie-rustfs:9000"
+failures = []
+if expected not in targets:
+    failures.append(
+        f"must include the configured RustFS target {expected!r}"
+    )
+if forbidden in targets:
+    failures.append(
+        f"must exclude the default RustFS target {forbidden!r} after rustfs.port=9100"
+    )
+if failures:
+    raise SystemExit(f"DATATIER_TARGETS {' and '.join(failures)}; got {targets!r}")
+
+print(f"  ok: DATATIER_TARGETS includes {expected!r} and excludes {forbidden!r}")
+PYEOF
+
 echo
-echo "PASS: sealed render generates strong values for all 11 keys (encryptionKey 64-hex and Langfuse init credentials 32 alphanumeric); dev overlay keeps published defaults; explicit credential and OTel overrides win on the sealed path; default OTel Basic auth uses the resolved Langfuse project secret; every runner boot-env name is a declared contract key (proven by a failing negative control); every control-plane pod, the agent-sandbox controller, and the sandbox render with the expected priorityClassName, including under operator override; the runner SandboxTemplate opts the controller out of its own permissive NetworkPolicy whenever Rail 1 is on, and leaves it to the controller's default when Rail 1 is off; api.githubToken stays a plain pass-through (empty renders empty, an explicit value renders verbatim, and it is never generated), proven by a failing negative control; and the worker renders exactly one API URL plus exactly one correctly sourced API key in default, connector enabled, release name, configured port, BYO API, and operator override cases."
+echo "PASS: sealed render generates strong values for all 11 keys (encryptionKey 64-hex and Langfuse init credentials 32 alphanumeric); dev overlay keeps published defaults; explicit credential and OTel overrides win on the sealed path; default OTel Basic auth uses the resolved Langfuse project secret; every runner boot-env name is a declared contract key (proven by a failing negative control); every control-plane pod, the agent-sandbox controller, and the sandbox render with the expected priorityClassName, including under operator override; the runner SandboxTemplate opts the controller out of its own permissive NetworkPolicy whenever Rail 1 is on, and leaves it to the controller's default when Rail 1 is off; api.githubToken stays a plain pass-through (empty renders empty, an explicit value renders verbatim, and it is never generated), proven by a failing negative control; the worker renders exactly one API URL plus exactly one correctly sourced API key in default, connector enabled, release name, configured port, BYO API, and operator override cases; and the security probe uses the configured RustFS port in DATATIER_TARGETS."

--- a/charts/curie/ci/worker-object-store-assertions.sh
+++ b/charts/curie/ci/worker-object-store-assertions.sh
@@ -60,6 +60,38 @@ def render(*values):
     return [doc for doc in yaml.safe_load_all(rendered.stdout) if doc]
 
 
+def assert_external_store_requires_hostname():
+    command = [
+        "helm",
+        "template",
+        "curie",
+        CHART,
+        "--namespace",
+        "dev",
+        "--set",
+        "rustfs.deploy=false",
+    ]
+    rendered = subprocess.run(command, capture_output=True, text=True)
+    if rendered.returncode == 0:
+        print(
+            "FAIL: rustfs.deploy=false without rustfs.host must fail Helm rendering",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+
+    diagnostic = rendered.stderr + rendered.stdout
+    if "hostname" not in diagnostic.lower():
+        print(
+            "FAIL: the missing rustfs.host error must say that a hostname is required",
+            file=sys.stderr,
+        )
+        if diagnostic:
+            print(diagnostic, file=sys.stderr, end="")
+        raise SystemExit(1)
+
+    print("ok: an external object store without rustfs.host is rejected as missing a hostname")
+
+
 def value_source(entry):
     return {key: entry[key] for key in ("value", "valueFrom") if key in entry}
 
@@ -279,6 +311,7 @@ def expect_failure(docs, messages):
         assert unsupported not in output, f"unsupported diagnostic {unsupported!r} in:\n{output}"
 
 
+assert_external_store_requires_hostname()
 default_docs = render()
 assert_contract(default_docs, "default", "http://curie-rustfs:9000")
 

--- a/charts/curie/templates/_helpers.tpl
+++ b/charts/curie/templates/_helpers.tpl
@@ -146,7 +146,7 @@ ANTHROPIC_BASE_URL ANTHROPIC_API_KEY CLAUDE_CODE_OAUTH_TOKEN ANTHROPIC_AUTH_TOKE
 {{- if .Values.rustfs.deploy -}}
 {{- printf "%s-rustfs" (include "curie.fullname" .) -}}
 {{- else -}}
-{{- required "rustfs.deploy is false: set rustfs.host to your external S3-compatible endpoint" .Values.rustfs.host -}}
+{{- required "rustfs.deploy is false: set rustfs.host to your external S3-compatible hostname" .Values.rustfs.host -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/curie/templates/security-probe.yaml
+++ b/charts/curie/templates/security-probe.yaml
@@ -161,7 +161,7 @@ spec:
 {{- $dt := list -}}
 {{- if .Values.security.dataTierNetworkPolicy.enabled -}}
 {{- if .Values.postgres.deploy }}{{- $dt = append $dt (printf "%s:5432" (include "curie.postgres.host" .)) -}}{{- end }}
-{{- if .Values.rustfs.deploy }}{{- $dt = append $dt (printf "%s:9000" (include "curie.rustfs.host" .)) -}}{{- end }}
+{{- if .Values.rustfs.deploy }}{{- $dt = append $dt (printf "%s:%v" (include "curie.rustfs.host" .) .Values.rustfs.port) -}}{{- end }}
 {{- if .Values.clickhouse.deploy }}{{- $dt = append $dt (printf "%s:8123" (include "curie.clickhouse.host" .)) -}}{{- end }}
 {{- if .Values.valkey.deploy }}{{- $dt = append $dt (printf "%s:6379" (include "curie.valkey.host" .)) -}}{{- end }}
 {{- end -}}

--- a/cli/src/seal.rs
+++ b/cli/src/seal.rs
@@ -59,8 +59,9 @@ impl crate::ui::CliOutput for SealOutput {
         ui.payload_plain(&snippet(&self.env_name, &self.sealed));
         ui.note(&format!(
             "sealed to public key {}. Only a cluster holding the matching private \
-             key can read it, so this is safe to commit. Merge the block above under \
-             connectors.{} in connectors.yaml.",
+             key can read it, so this is safe to commit. The block above belongs under \
+             connectors.{} in connectors.yaml, but connector validation rejects \
+             sealed_secrets until #1434 lands, so it cannot be used yet.",
             self.public_key, self.connector
         ));
     }

--- a/cli/tests/chart_check.rs
+++ b/cli/tests/chart_check.rs
@@ -93,6 +93,61 @@ fn chart_check_json_keeps_child_chatter_off_stdout() {
     );
 }
 
+#[cfg(unix)]
+fn shell_scripts_without_execute_permission(dir: &Path) -> Vec<PathBuf> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let entries = std::fs::read_dir(dir)
+        .unwrap_or_else(|error| panic!("read shell script directory {}: {error}", dir.display()));
+    let mut found = Vec::new();
+    for entry in entries {
+        let path = entry.expect("read shell script directory entry").path();
+        if path.is_file() && path.extension().is_some_and(|extension| extension == "sh") {
+            let mode = std::fs::metadata(&path)
+                .expect("read shell script metadata")
+                .permissions()
+                .mode();
+            if mode & 0o111 == 0 {
+                found.push(path.strip_prefix(dir).unwrap_or(&path).to_path_buf());
+            }
+        }
+    }
+
+    found.sort();
+    found
+}
+
+/// Every direct shell assertion entry must be executable even though production
+/// discovery intentionally skips files without an execute bit. This inventory
+/// is independent of discovery, so a lost mode cannot become invisible to both
+/// the local verb and its parity check.
+#[cfg(unix)]
+#[test]
+fn every_chart_ci_shell_script_is_executable() {
+    let ci_dir = repo_root().join(CHART_CI_DIR);
+    let missing = shell_scripts_without_execute_permission(&ci_dir);
+    assert!(
+        missing.is_empty(),
+        "every direct *.sh file in {CHART_CI_DIR} must be executable; missing execute permission: {missing:?}"
+    );
+
+    let scratch = tempfile::tempdir().expect("scratch dir");
+    let mutant = write_script(
+        scratch.path(),
+        "mode-regression.sh",
+        "#!/bin/bash\nexit 0\n",
+    );
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(&mutant, std::fs::Permissions::from_mode(0o644))
+        .expect("remove execute permission from scratch script");
+
+    assert_eq!(
+        shell_scripts_without_execute_permission(scratch.path()),
+        vec![PathBuf::from("mode-regression.sh")],
+        "the independent inventory must reject a direct shell script with mode 0644"
+    );
+}
+
 /// AC3: a script added to `charts/curie/ci/` is picked up with no edit to `cli/`.
 ///
 /// The scratch copy stands in for the real directory so the assertion is about

--- a/cli/tests/exit_codes.rs
+++ b/cli/tests/exit_codes.rs
@@ -8,12 +8,15 @@ use std::process::{Command, Output};
 
 const SEAL_VALUE: &str = "placeholder-seal-value";
 
-fn run_seal(connector: &str) -> Output {
+fn run_seal(connector: &str, json: bool) -> Output {
     let keypair = curie::sealing::generate_keypair();
     let connector_arg = format!("--connector={connector}");
-    Command::new(env!("CARGO_BIN_EXE_curie"))
+    let mut command = Command::new(env!("CARGO_BIN_EXE_curie"));
+    if json {
+        command.arg("--json");
+    }
+    command
         .args([
-            "--json",
             "seal",
             &connector_arg,
             "GRAFANA_TOKEN",
@@ -97,7 +100,7 @@ fn seal_rejects_invalid_connector_names_as_usage_with_a_fix() {
     ];
 
     for connector in invalid {
-        let output = run_seal(&connector);
+        let output = run_seal(&connector, true);
         let stdout = String::from_utf8_lossy(&output.stdout);
         let stderr = String::from_utf8_lossy(&output.stderr);
         assert_eq!(
@@ -121,7 +124,7 @@ fn seal_rejects_invalid_connector_names_as_usage_with_a_fix() {
 #[test]
 fn seal_accepts_the_connector_name_length_boundary_and_interior_dash() {
     for connector in ["a".repeat(40), "grafana-cloud".to_string()] {
-        let output = run_seal(&connector);
+        let output = run_seal(&connector, true);
         let stdout = String::from_utf8_lossy(&output.stdout);
         let stderr = String::from_utf8_lossy(&output.stderr);
         assert_eq!(
@@ -137,4 +140,59 @@ fn seal_accepts_the_connector_name_length_boundary_and_interior_dash() {
             "a sealed value must not expose its plaintext"
         );
     }
+}
+
+#[test]
+fn seal_human_output_warns_before_pasting_rejected_sealed_secrets() {
+    let human = run_seal("grafana", false);
+    let human_stdout = String::from_utf8_lossy(&human.stdout);
+    let human_stderr = String::from_utf8_lossy(&human.stderr);
+    let human_output = format!("{human_stdout}{human_stderr}");
+    assert_eq!(
+        human.status.code(),
+        Some(ExitClass::Success.code()),
+        "human seal must succeed\nstdout: {human_stdout}\nstderr: {human_stderr}"
+    );
+    assert!(
+        human_stdout.contains("sealed_secrets"),
+        "human seal must retain the paste block:\n{human_stdout}"
+    );
+    assert!(
+        human_output.contains("connector validation")
+            && human_output.contains("sealed_secrets")
+            && human_output.contains("#1434")
+            && human_output.contains("until"),
+        "human seal must warn that connector validation rejects sealed_secrets until #1434 lands:\n{human_output}"
+    );
+    let human_output_lower = human_output.to_ascii_lowercase();
+    assert!(
+        !human_output_lower.contains("merge") && !human_output_lower.contains("paste"),
+        "human seal must locate the block without telling the user to merge or paste it:\n{human_output}"
+    );
+
+    let json = run_seal("grafana", true);
+    let json_stdout = String::from_utf8_lossy(&json.stdout);
+    let json_stderr = String::from_utf8_lossy(&json.stderr);
+    assert_eq!(
+        json.status.code(),
+        Some(ExitClass::Success.code()),
+        "JSON seal must succeed\nstdout: {json_stdout}\nstderr: {json_stderr}"
+    );
+    let payload: serde_json::Value = serde_json::from_slice(&json.stdout)
+        .unwrap_or_else(|err| panic!("JSON seal must emit only JSON: {err}; {json_stdout}"));
+    let fields = payload.as_object().expect("JSON seal must emit an object");
+    assert_eq!(
+        fields
+            .keys()
+            .map(String::as_str)
+            .collect::<std::collections::BTreeSet<_>>(),
+        ["connector", "env_name", "sealed", "public_key", "yaml"]
+            .into_iter()
+            .collect(),
+        "JSON seal must retain its exact machine readable shape"
+    );
+    assert!(
+        !json_stdout.contains("#1434") && !json_stderr.contains("#1434"),
+        "the human warning must not appear in JSON mode:\nstdout: {json_stdout}\nstderr: {json_stderr}"
+    );
 }

--- a/docs/interfaces/sealed-credential/INTERFACE.md
+++ b/docs/interfaces/sealed-credential/INTERFACE.md
@@ -128,9 +128,9 @@ file would be misleading without saying so:
   `sealed_secrets` is present, on the grounds that refusing beats deploying a
   connector without the credential it needs. Nothing in the reconciler imports
   the sealing module. So `curie seal` hands an author a snippet that today makes
-  their bundle fail validation, and the CLI does not warn. The refusal was
-  briefly lifted and then deliberately restored, so this is a live gate rather
-  than an oversight.
+  their bundle fail validation. Human output warns that connector validation
+  rejects the snippet until #1434 lands. The refusal was briefly lifted and
+  then deliberately restored, so this is a live gate rather than an oversight.
 - **No version marker, so a format change is indistinguishable from
   corruption.** The envelope is bare base64 with nothing to negotiate on. Any
   future change — a different construction, a compressed payload, additional

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -6,12 +6,11 @@
 #
 #   docker build -f runner/Dockerfile -t curie-runner .
 #
-# The claude-agent-sdk drives the `claude` CLI, so the image carries Node plus the
-# @anthropic-ai/claude-code CLI alongside the Python runner. With
-# CURIE_FAKE_MODEL=1 the container answers synthetic events offline (no CLI/model
-# call), which is how the container smoke round-trips without a credential.
-# The frozen workspace packages require the Python base below; Node 22 is
-# required by the Claude Code CLI the SDK spawns. Add Node to the Python base.
+# The claude-agent-sdk supplies and drives its bundled platform `claude`
+# executable. The image carries Node and npm only for pinned MCP packages. With
+# CURIE_FAKE_MODEL=1 the container answers synthetic events offline (no CLI or
+# model call), which is how the container smoke round trips without a credential.
+# The frozen workspace packages require the Python base below.
 # Node comes from the official image rather than NodeSource's apt repo. That
 # repo's setup script (`deb.nodesource.com/setup_22.x`) started returning 403 to
 # everyone on 2026-07-27, which broke every runner-image build repo-wide: curl
@@ -35,9 +34,6 @@ RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
     && apt-get install -y --no-install-recommends curl ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-# The Claude Code CLI the SDK spawns for a real (non-fake) session.
-RUN npm install -g @anthropic-ai/claude-code@2.1.231
-
 # Off-the-shelf MCP servers pre-installed at build time so a bundle that
 # declares one starts it from the on-disk binary with NO runtime network fetch
 # (the runner rootfs is read-only at runtime, so an `npx`-style fetch would fail
@@ -56,27 +52,27 @@ COPY packages/aci-protocol ./packages/aci-protocol
 COPY packages/plugin-format ./packages/plugin-format
 COPY runner ./runner
 
-# One venv. Install the local packages first, then the runner without redeps,
-# then its direct registry dependencies exported from the tested workspace
-# uv.lock. The local packages are installed by path first so the
+# One venv. Install every local project without dependencies, then install the
+# full registry dependency closure exported from the tested workspace uv.lock.
+# The local packages are installed by path first so the
 # "aci-protocol"/"plugin-format" requirements resolve to the copied trees, not
 # a same-named PyPI distribution.
 RUN python3 -m venv /app/.venv \
     && /app/.venv/bin/pip install --no-cache-dir --upgrade pip \
-    && /app/.venv/bin/pip install --no-cache-dir ./packages/aci-protocol ./packages/plugin-format \
+    && /app/.venv/bin/pip install --no-cache-dir --no-deps ./packages/aci-protocol ./packages/plugin-format \
     && /app/.venv/bin/pip install --no-cache-dir --no-deps ./runner \
     && python3 runner/export_dependency_pins.py < uv.lock > /tmp/runner-dependency-pins.txt \
-    && /app/.venv/bin/pip install --no-cache-dir -r /tmp/runner-dependency-pins.txt
+    && /app/.venv/bin/pip install --no-cache-dir --no-deps -r /tmp/runner-dependency-pins.txt
 
 # Run as a non-root user. The claude-agent-sdk spawns
 # `claude --dangerously-skip-permissions` (permission_mode=bypassPermissions),
 # and Claude Code refuses that flag under uid 0 ("cannot be used with root/sudo
 # privileges"), so a root image fails every real-model boot. uid:gid 1000:1000
 # matches the A2 chart hardening (runAsUser/runAsGroup/fsGroup 1000) and HOME is
-# /home/runner (one of the chart's writablePaths). The venv and the global npm
-# `claude` CLI live in root-owned, world-readable paths, so uid 1000 imports the
-# deps and executes the CLI without owning them. HOME is the only writable path
-# the runtime needs; under the A2 read-only rootfs the chart mounts writable
+# /home/runner (one of the chart's writablePaths). The venv contains the SDK and
+# its bundled runtime in root owned, world readable paths, so uid 1000 imports
+# the dependencies and executes the CLI without owning them. HOME is the only
+# writable path the runtime needs; under the A2 read-only rootfs the chart mounts
 # emptyDirs at /tmp and /home/runner, and nothing here writes elsewhere.
 RUN groupadd --gid 1000 runner \
     && useradd --uid 1000 --gid 1000 --home-dir /home/runner --create-home --shell /usr/sbin/nologin runner \

--- a/runner/export_dependency_pins.py
+++ b/runner/export_dependency_pins.py
@@ -1,4 +1,4 @@
-"""Export the runner's direct registry dependencies from a uv lockfile."""
+"""Export the runner's recursive registry dependency closure from uv.lock."""
 
 from __future__ import annotations
 
@@ -34,18 +34,6 @@ def _package_name(package: dict[str, Any], context: str) -> str:
 
 def _runner_dependency_pins(lock: dict[str, Any]) -> list[str]:
     packages = _require_package_records(lock)
-    runners = [
-        package
-        for package in packages
-        if _package_name(package, "uv.lock package record") == "curie-runner"
-    ]
-    if len(runners) != 1:
-        raise InvalidLock("uv.lock must contain exactly one curie-runner record")
-
-    dependencies = runners[0].get("dependencies")
-    if not isinstance(dependencies, list):
-        raise InvalidLock("curie-runner must declare dependency records")
-
     package_by_name: dict[str, dict[str, Any]] = {}
     for package in packages:
         name = _package_name(package, "uv.lock package record")
@@ -53,31 +41,159 @@ def _runner_dependency_pins(lock: dict[str, Any]) -> list[str]:
             raise InvalidLock(f"uv.lock resolves {name} more than once")
         package_by_name[name] = package
 
-    dependency_names: set[str] = set()
-    pins: dict[str, str] = {}
-    for dependency in dependencies:
-        if not isinstance(dependency, dict):
-            raise InvalidLock("each curie-runner dependency must be a package record")
-        name = _package_name(dependency, "each curie-runner dependency")
-        if name in dependency_names:
-            raise InvalidLock(f"curie-runner dependency {name} is duplicated")
-        dependency_names.add(name)
+    runner = package_by_name.get("curie-runner")
+    if runner is None:
+        raise InvalidLock("uv.lock must contain exactly one curie-runner record")
 
-        resolved = package_by_name.get(name)
-        if resolved is None:
-            raise InvalidLock(f"uv.lock does not resolve curie-runner dependency {name}")
-        source = resolved.get("source")
+    pins: dict[str, str] = {}
+    reachable_conditions: dict[str, set[frozenset[str]]] = {}
+    traversed_states: dict[
+        str, set[tuple[frozenset[str], frozenset[str]]]
+    ] = {}
+
+    def visit(
+        package: dict[str, Any],
+        path_conditions: frozenset[str],
+        requested_extras: frozenset[str],
+    ) -> None:
+        name = _package_name(package, "reachable uv.lock package record")
+        known_conditions = reachable_conditions.setdefault(name, set())
+        if not any(known <= path_conditions for known in known_conditions):
+            known_conditions.difference_update(
+                known for known in known_conditions if path_conditions <= known
+            )
+            known_conditions.add(path_conditions)
+
+        known_states = traversed_states.setdefault(name, set())
+        if any(
+            known_conditions <= path_conditions and known_extras >= requested_extras
+            for known_conditions, known_extras in known_states
+        ):
+            return
+        known_states.difference_update(
+            (known_conditions, known_extras)
+            for known_conditions, known_extras in known_states
+            if path_conditions <= known_conditions
+            and requested_extras >= known_extras
+        )
+        known_states.add((path_conditions, requested_extras))
+
+        source = package.get("source")
         if not isinstance(source, dict):
             raise InvalidLock(f"uv.lock package {name} must declare its source")
-        if "registry" not in source:
+
+        if "registry" in source:
+            version = package.get("version")
+            if not isinstance(version, str) or not version:
+                raise InvalidLock(
+                    f"uv.lock registry package {name} must declare a version"
+                )
+            pins[name] = version
+
+        def visit_dependencies(
+            dependencies: Any, dependency_context: str
+        ) -> None:
+            if not isinstance(dependencies, list):
+                raise InvalidLock(f"{dependency_context} must contain records")
+
+            dependency_names: set[str] = set()
+            for dependency in dependencies:
+                if not isinstance(dependency, dict):
+                    raise InvalidLock(
+                        f"each {dependency_context} entry must be a record"
+                    )
+                dependency_name = _package_name(
+                    dependency, f"each {dependency_context} entry"
+                )
+                if dependency_name in dependency_names:
+                    raise InvalidLock(
+                        f"{dependency_context} dependency {dependency_name} "
+                        "is duplicated"
+                    )
+                dependency_names.add(dependency_name)
+
+                marker = dependency.get("marker")
+                if marker is not None and (
+                    not isinstance(marker, str)
+                    or not marker.strip()
+                    or any(character in marker for character in "\r\n;")
+                ):
+                    raise InvalidLock(
+                        f"{dependency_context} dependency {dependency_name} "
+                        "must declare a valid marker"
+                    )
+
+                extras = dependency.get("extra", [])
+                if not isinstance(extras, list) or not all(
+                    isinstance(extra, str) and extra for extra in extras
+                ):
+                    raise InvalidLock(
+                        f"{dependency_context} dependency {dependency_name} "
+                        "extras must be names"
+                    )
+
+                resolved = package_by_name.get(dependency_name)
+                if resolved is None:
+                    raise InvalidLock(
+                        f"uv.lock does not resolve {name} dependency "
+                        f"{dependency_name}"
+                    )
+                dependency_conditions = path_conditions
+                if marker is not None:
+                    dependency_conditions = path_conditions | {marker}
+                visit(resolved, dependency_conditions, frozenset(extras))
+
+        visit_dependencies(
+            package.get("dependencies", []), f"uv.lock package {name} dependencies"
+        )
+
+        if requested_extras:
+            optional_dependencies = package.get("optional-dependencies", {})
+            if not isinstance(optional_dependencies, dict):
+                raise InvalidLock(
+                    f"uv.lock package {name} optional dependencies must be tables"
+                )
+            for extra in sorted(requested_extras):
+                extra_dependencies = optional_dependencies.get(extra)
+                if extra_dependencies is None:
+                    raise InvalidLock(
+                        f"uv.lock package {name} does not declare selected extra {extra}"
+                    )
+                visit_dependencies(
+                    extra_dependencies,
+                    f"uv.lock package {name} extra {extra} dependencies",
+                )
+
+    runner_dependencies = runner.get("dependencies")
+    if not isinstance(runner_dependencies, list):
+        raise InvalidLock("curie-runner must declare dependency records")
+    visit(runner, frozenset(), frozenset())
+    pins.pop("curie-runner", None)
+
+    requirements: list[str] = []
+    for name, version in sorted(pins.items()):
+        conditions = reachable_conditions[name]
+        if frozenset() in conditions:
+            requirements.append(f"{name}=={version}")
             continue
 
-        version = resolved.get("version")
-        if not isinstance(version, str) or not version:
-            raise InvalidLock(f"uv.lock registry package {name} must declare a version")
-        pins[name] = version
+        path_markers: list[str] = []
+        for condition in sorted(conditions, key=lambda item: tuple(sorted(item))):
+            markers = sorted(condition)
+            if len(markers) == 1:
+                path_markers.append(markers[0])
+            else:
+                path_markers.append(
+                    " and ".join(f"({marker})" for marker in markers)
+                )
+        combined_marker = path_markers[0]
+        if len(path_markers) > 1:
+            combined_marker = " or ".join(
+                f"({path_marker})" for path_marker in path_markers
+            )
+        requirements.append(f"{name}=={version} ; {combined_marker}")
 
-    return [f"{name}=={version}" for name, version in sorted(pins.items())]
+    return requirements
 
 
 def main() -> int:

--- a/runner/export_dependency_pins.py
+++ b/runner/export_dependency_pins.py
@@ -60,7 +60,7 @@ def _runner_dependency_pins(lock: dict[str, Any]) -> list[str]:
         known_conditions = reachable_conditions.setdefault(name, set())
         if not any(known <= path_conditions for known in known_conditions):
             known_conditions.difference_update(
-                known for known in known_conditions if path_conditions <= known
+                {known for known in known_conditions if path_conditions <= known}
             )
             known_conditions.add(path_conditions)
 
@@ -71,10 +71,11 @@ def _runner_dependency_pins(lock: dict[str, Any]) -> list[str]:
         ):
             return
         known_states.difference_update(
-            (known_conditions, known_extras)
-            for known_conditions, known_extras in known_states
-            if path_conditions <= known_conditions
-            and requested_extras >= known_extras
+            {
+                (known_path, known_extras)
+                for known_path, known_extras in known_states
+                if path_conditions <= known_path and requested_extras >= known_extras
+            }
         )
         known_states.add((path_conditions, requested_extras))
 

--- a/runner/src/curie_runner/harness/claude.py
+++ b/runner/src/curie_runner/harness/claude.py
@@ -27,8 +27,11 @@ CLAUDE_CONTRIBUTION = HarnessContribution(
     aliases=frozenset({"claude-sdk", "claude-code"}),
     image="curie-runner",
     install=InstallSpec(
-        packages=("@anthropic-ai/claude-code",),
-        notes="runs as a non-root user; see runner/Dockerfile",
+        packages=("claude-agent-sdk",),
+        notes=(
+            "includes its bundled runtime and runs as a non-root user; "
+            "see runner/Dockerfile"
+        ),
     ),
     auth=AuthSpec(
         credential_env_keys=sdk_auth.DEFAULT_CREDENTIAL_ENV_KEYS,

--- a/runner/tests/test_dockerfile_dependency_pins.py
+++ b/runner/tests/test_dockerfile_dependency_pins.py
@@ -445,6 +445,57 @@ source = { registry = "https://pypi.org/simple" }
     ]
 
 
+def test_dependency_exporter_pins_a_shared_transitive_reached_both_ways() -> None:
+    """A package reached under a marker and again unconditionally pins unconditionally.
+
+    The unconditional path has to widen the recorded reachability of a package
+    already recorded as conditional. The exporter runs inside the runner image
+    build, so failing that widening takes the whole image build down rather than
+    emitting a wrong pin.
+    """
+    lock_text = """\
+version = 1
+revision = 3
+requires-python = ">=3.13"
+
+[[package]]
+name = "curie-runner"
+version = "0.0.0"
+source = { editable = "runner" }
+dependencies = [
+    { name = "windows-only", marker = "sys_platform == 'win32'" },
+    { name = "everywhere" },
+]
+
+[[package]]
+name = "windows-only"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "shared" },
+]
+
+[[package]]
+name = "everywhere"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "shared" },
+]
+
+[[package]]
+name = "shared"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+"""
+
+    assert _export_runner_dependencies(lock_text) == [
+        "everywhere==1.0.0",
+        "shared==2.0.0",
+        "windows-only==1.0.0 ; sys_platform == 'win32'",
+    ]
+
+
 @pytest.mark.parametrize(
     "marker_literal",
     [

--- a/runner/tests/test_dockerfile_dependency_pins.py
+++ b/runner/tests/test_dockerfile_dependency_pins.py
@@ -21,6 +21,52 @@ _EXACT_NPM_VERSION = re.compile(
 _NPM_PACKAGE = re.compile(r"(?:@[0-9A-Za-z._-]+/)?[0-9A-Za-z._-]+")
 _PIP_EXECUTABLE = re.compile(r"pip(?:\d+(?:\.\d+)?)?$")
 _NPM_INSTALL_ALIASES = {"install", "i", "add"}
+_SYNTHETIC_RECURSIVE_LOCK = """\
+version = 1
+revision = 3
+requires-python = ">=3.13"
+
+[[package]]
+name = "registry-second-level"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "registry-root" },
+]
+
+[[package]]
+name = "curie-runner"
+version = "0.0.0"
+source = { editable = "runner" }
+dependencies = [
+    { name = "local-bridge" },
+    { name = "registry-root" },
+]
+
+[[package]]
+name = "registry-middle"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "registry-second-level" },
+]
+
+[[package]]
+name = "local-bridge"
+version = "0.0.0"
+source = { editable = "packages/local-bridge" }
+dependencies = [
+    { name = "registry-middle" },
+]
+
+[[package]]
+name = "registry-root"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "registry-middle" },
+]
+"""
 
 
 @dataclass(frozen=True)
@@ -181,6 +227,35 @@ def _installs_generated_runner_requirements(instructions: list[str]) -> bool:
     return False
 
 
+def _generated_runner_requirements_install_command(
+    instructions: list[str],
+) -> list[str]:
+    controls = {"&&", "||", ";"}
+    matches: list[list[str]] = []
+    for instruction in instructions:
+        tokens = _shell_tokens(instruction)
+        if not tokens or tokens[0].upper() != "RUN":
+            continue
+        for index, token in enumerate(tokens[:-1]):
+            if not _PIP_EXECUTABLE.fullmatch(token.rsplit("/", 1)[-1]) or (
+                tokens[index + 1] != "install"
+            ):
+                continue
+            command: list[str] = []
+            for operand in tokens[index + 2 :]:
+                if operand in controls:
+                    break
+                command.append(operand)
+            if any(
+                option in {"-r", "--requirement"}
+                and requirement == _REQUIREMENTS_PATH
+                for option, requirement in zip(command, command[1:], strict=False)
+            ):
+                matches.append(command)
+    assert len(matches) == 1, "Dockerfile must install runner requirements once"
+    return matches[0]
+
+
 def _split_npm_operand(operand: str) -> tuple[str, str | None]:
     version_at = operand.rfind("@")
     if version_at <= 0:
@@ -302,24 +377,6 @@ def _export_runner_dependencies(lock_text: str) -> list[str]:
     return result.stdout.splitlines()
 
 
-def _effective_runner_python_operands(lock_text: str) -> dict[str, str]:
-    dockerfile = _DOCKERFILE.read_text(encoding="utf-8")
-    instructions = _logical_instructions(dockerfile)
-    assert any(
-        "python3 runner/export_dependency_pins.py < uv.lock "
-        f"> {_REQUIREMENTS_PATH}" in instruction
-        and f"pip install --no-cache-dir -r {_REQUIREMENTS_PATH}" in instruction
-        for instruction in instructions
-    )
-    operands: dict[str, str] = {}
-    for operand in _export_runner_dependencies(lock_text):
-        package, _ = operand.split("==", 1)
-        normalized = _normalize_python_name(package)
-        assert normalized not in operands, f"runner requirements must pin {normalized} once"
-        operands[normalized] = operand
-    return operands
-
-
 def _replace_locked_package_version(
     lock_text: str, package: str, replacement: str
 ) -> str:
@@ -339,13 +396,158 @@ def _dockerfile_with_python_pins(pins: dict[str, str]) -> str:
     return f"RUN pip install --no-cache-dir \\\n    {operands}\n"
 
 
-def test_dependency_exporter_emits_sorted_direct_registry_pins() -> None:
-    lock_text = _UV_LOCK.read_text(encoding="utf-8")
-    expected = _locked_runner_dependencies(lock_text)
+def test_dependency_exporter_emits_sorted_complete_registry_closure() -> None:
+    assert _export_runner_dependencies(_SYNTHETIC_RECURSIVE_LOCK) == [
+        "registry-middle==2.0.0",
+        "registry-root==1.0.0",
+        "registry-second-level==3.0.0",
+    ]
+
+
+def test_dependency_exporter_propagates_markers_through_transitives() -> None:
+    lock_text = """\
+version = 1
+revision = 3
+requires-python = ">=3.13"
+
+[[package]]
+name = "curie-runner"
+version = "0.0.0"
+source = { editable = "runner" }
+dependencies = [
+    { name = "always" },
+    { name = "windows-only", marker = "sys_platform == 'win32'" },
+]
+
+[[package]]
+name = "always"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+
+[[package]]
+name = "windows-only"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "windows-child" },
+]
+
+[[package]]
+name = "windows-child"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+"""
 
     assert _export_runner_dependencies(lock_text) == [
-        f"{package}=={version}" for package, version in sorted(expected.items())
+        "always==1.0.0",
+        "windows-child==3.0.0 ; sys_platform == 'win32'",
+        "windows-only==2.0.0 ; sys_platform == 'win32'",
     ]
+
+
+@pytest.mark.parametrize(
+    "marker_literal",
+    [
+        '""',
+        r'"\r"',
+        r'"\n"',
+        '"sys_platform == \'win32\'; python_version > \'3.13\'"',
+    ],
+)
+def test_dependency_exporter_rejects_malformed_markers(
+    marker_literal: str,
+) -> None:
+    lock_text = f"""\
+version = 1
+revision = 3
+requires-python = ">=3.13"
+
+[[package]]
+name = "curie-runner"
+version = "0.0.0"
+source = {{ editable = "runner" }}
+dependencies = [
+    {{ name = "conditional", marker = {marker_literal} }},
+]
+
+[[package]]
+name = "conditional"
+version = "1.0.0"
+source = {{ registry = "https://pypi.org/simple" }}
+"""
+
+    result = _run_dependency_exporter(lock_text)
+
+    assert result.returncode != 0
+    assert result.stdout == ""
+    assert "invalid uv.lock" in result.stderr
+
+
+def test_dependency_exporter_follows_selected_extra_dependency_closure() -> None:
+    lock_text = """\
+version = 1
+revision = 3
+requires-python = ">=3.13"
+
+[[package]]
+name = "curie-runner"
+version = "0.0.0"
+source = { editable = "runner" }
+dependencies = [
+    { name = "provider", extra = ["crypto", "crypto"] },
+]
+
+[[package]]
+name = "provider"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+
+[package.optional-dependencies]
+crypto = [
+    { name = "extra-child" },
+]
+
+[[package]]
+name = "extra-child"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "extra-leaf" },
+]
+
+[[package]]
+name = "extra-leaf"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+optional-dependencies = "unused malformed table"
+"""
+
+    assert _export_runner_dependencies(lock_text) == [
+        "extra-child==2.0.0",
+        "extra-leaf==3.0.0",
+        "provider==1.0.0",
+    ]
+
+
+def test_dependency_exporter_rejects_a_missing_referenced_transitive() -> None:
+    second_level_record = """\
+[[package]]
+name = "registry-second-level"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "registry-root" },
+]
+
+"""
+    assert second_level_record in _SYNTHETIC_RECURSIVE_LOCK
+    incomplete_lock = _SYNTHETIC_RECURSIVE_LOCK.replace(second_level_record, "")
+
+    result = _run_dependency_exporter(incomplete_lock)
+
+    assert result.returncode != 0
+    assert result.stdout == ""
+    assert "invalid uv.lock" in result.stderr
 
 
 def test_dependency_exporter_reflects_a_lock_version_bump() -> None:
@@ -378,9 +580,9 @@ def test_dockerfile_generates_python_requirements_from_the_lock_exporter() -> No
     assert any(
         "python3 runner/export_dependency_pins.py < uv.lock "
         f"> {_REQUIREMENTS_PATH}" in instruction
-        and f"pip install --no-cache-dir -r {_REQUIREMENTS_PATH}" in instruction
         for instruction in instructions
     )
+    assert "--no-deps" in _generated_runner_requirements_install_command(instructions)
     assert _dockerfile_python_pins(instructions) == {}
 
 
@@ -455,20 +657,31 @@ def test_python_pin_revert_is_rejected() -> None:
     ) in violations
 
 
-def test_npm_version_removal_is_rejected() -> None:
+def test_runner_image_uses_bundled_claude_cli_and_keeps_pinned_github_mcp() -> None:
     dockerfile = _DOCKERFILE.read_text(encoding="utf-8")
     npm_operands = _dockerfile_global_npm_operands(dockerfile)
-    assert len(npm_operands) >= 2
-    for current in npm_operands:
-        package, version = _split_npm_operand(current)
-        assert version and _EXACT_NPM_VERSION.fullmatch(version)
-        assert dockerfile.count(current) == 1
-        mutated = dockerfile.replace(current, package)
+    assert all(
+        _split_npm_operand(operand)[0] != "@anthropic-ai/claude-code"
+        for operand in npm_operands
+    )
+    github_operands = [
+        operand
+        for operand in npm_operands
+        if _split_npm_operand(operand)[0]
+        == "@modelcontextprotocol/server-github"
+    ]
+    assert len(github_operands) == 1
+    current = github_operands[0]
+    package, version = _split_npm_operand(current)
+    assert package == "@modelcontextprotocol/server-github"
+    assert version and _EXACT_NPM_VERSION.fullmatch(version)
+    assert dockerfile.count(current) == 1
+    mutated = dockerfile.replace(current, package)
 
-        violations = _find_violations(_UV_LOCK.read_text(encoding="utf-8"), mutated)
-        assert Violation(
-            package, "global npm install is missing an exact version"
-        ) in violations
+    violations = _find_violations(_UV_LOCK.read_text(encoding="utf-8"), mutated)
+    assert Violation(
+        package, "global npm install is missing an exact version"
+    ) in violations
 
 
 @pytest.mark.parametrize("command", sorted(_NPM_INSTALL_ALIASES))
@@ -485,7 +698,10 @@ def test_npm_global_install_aliases_require_exact_versions(command: str) -> None
 @pytest.mark.parametrize("executable", ["pip", "pip3"])
 def test_pip_executable_forms_are_compared_with_the_lock(executable: str) -> None:
     lock_text = _UV_LOCK.read_text(encoding="utf-8")
-    operands = _effective_runner_python_operands(lock_text)
+    operands = {
+        package: f"{package}=={version}"
+        for package, version in _locked_runner_dependencies(lock_text).items()
+    }
     synthetic = "RUN " + executable + " install " + " ".join(
         f'"{operand}"' for operand in operands.values()
     )
@@ -496,8 +712,9 @@ def test_pip_executable_forms_are_compared_with_the_lock(executable: str) -> Non
 def test_python_pin_set_must_match_all_direct_registry_dependencies() -> None:
     lock_text = _UV_LOCK.read_text(encoding="utf-8")
     expected = _locked_runner_dependencies(lock_text)
-    operands = _effective_runner_python_operands(lock_text)
-    assert operands.keys() == expected.keys()
+    operands = {
+        package: f"{package}=={version}" for package, version in expected.items()
+    }
     baseline = "RUN pip install " + " ".join(
         f'"{operand}"' for operand in operands.values()
     )

--- a/runner/tests/test_harness_contribution.py
+++ b/runner/tests/test_harness_contribution.py
@@ -30,6 +30,10 @@ def test_claude_contribution_image_identity() -> None:
     assert get_contribution().image == "curie-runner"
 
 
+def test_claude_contribution_install_uses_the_bundled_sdk_runtime() -> None:
+    assert get_contribution().install.packages == ("claude-agent-sdk",)
+
+
 def test_claude_contribution_model_override_env_keys() -> None:
     assert get_contribution().model_override_env_keys == (
         MODEL_BASE_URL_ENV,


### PR DESCRIPTION
Closes #1507

Fixes the seven applicable correctness items across worker guidance, chart validation and probes, CLI seal output, and runner image reproducibility. Items 4, 6, and 8 are closed on the issue with repository based reasons.