### PR TITLE
Fix correctness and accuracy papercuts

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -114,7 +114,9 @@ description = "Placeholder values this repo uses deliberately, plus generated ar
 # here is a value a reader is meant to copy and replace.
 regexTarget = "match"
 regexes = [
-  '''\bC0EXAMPLE[0-9]\b''',
+  # All three conversation prefixes: the CLI validates D (DM) and G (legacy
+  # private group) ids alongside C, so their examples need the same cover.
+  '''\b[CGD]0EXAMPLE[0-9]\b''',
   '''\bi-0123456789abcdef0\b''',
   '''\b000000000000\b''',
   '''\bexample\.com\b''',

--- a/apps/worker/src/curie_worker/config.py
+++ b/apps/worker/src/curie_worker/config.py
@@ -51,8 +51,7 @@ def _parse_bool(value: object) -> bool:
 
     A real bool passes through (so kwarg construction in tests is unchanged); any
     other string is truthy only when it is one of the accepted tokens, matching
-    the previous hand-rolled ``_b`` (note: the worker does not treat "on" as
-    truthy, unlike the dispatcher).
+    the previous hand rolled ``_b``.
     """
     if isinstance(value, bool):
         return value

--- a/apps/worker/tests/binding/test_no_unrun_async_test_bodies.py
+++ b/apps/worker/tests/binding/test_no_unrun_async_test_bodies.py
@@ -86,8 +86,14 @@ def _unrun_coroutines(tree: ast.AST) -> list[tuple[str, str, int]]:
 
 
 def test_no_test_defines_a_coroutine_it_never_runs() -> None:
+    test_files = _test_files()
+    assert len(test_files) > 150, (
+        f"Async test body scan found {len(test_files)} files under root "
+        f"{REPO_ROOT.resolve()}; expected more than 150"
+    )
+
     problems: list[str] = []
-    for path in _test_files():
+    for path in test_files:
         try:
             tree = ast.parse(path.read_text(encoding="utf-8"))
         except SyntaxError:  # pragma: no cover - a broken file is another gate's job

--- a/apps/worker/tests/eval/test_recorder.py
+++ b/apps/worker/tests/eval/test_recorder.py
@@ -328,7 +328,7 @@ def test_records_per_case_results_and_reads_them_back() -> None:
             try:
                 (await client.get(f"{_LF_HOST}/api/public/health")).raise_for_status()
             except httpx.HTTPError as exc:
-                pytest.skip(f"Langfuse not reachable at {_LF_HOST}: {exc}")
+                pytest.fail(f"Langfuse not reachable at {_LF_HOST}: {exc}")
 
             recorder = LangfuseEvalRecorder(
                 base_url=_LF_HOST, public_key=_LF_PK, secret_key=_LF_SK, client=client

--- a/apps/worker/tests/test_config.py
+++ b/apps/worker/tests/test_config.py
@@ -571,7 +571,7 @@ def test_async_test_body_gate_rejects_a_shallow_corpus(
         repo_root / "apps/worker/tests/binding/test_no_unrun_async_test_bodies.py",
     )
     monkeypatch.setattr(module, "REPO_ROOT", tmp_path)
-    gate = getattr(module, "test_no_test_defines_a_coroutine_it_never_runs")
+    gate = module.test_no_test_defines_a_coroutine_it_never_runs
     assert callable(gate)
 
     with pytest.raises(AssertionError) as exc_info:
@@ -592,7 +592,7 @@ def test_recorder_health_precondition_fails_when_service_is_unavailable(
     )
     unavailable_host = "http://127.0.0.1:1"
     monkeypatch.setattr(module, "_LF_HOST", unavailable_host)
-    recorder_test = getattr(module, "test_records_per_case_results_and_reads_them_back")
+    recorder_test = module.test_records_per_case_results_and_reads_them_back
     assert callable(recorder_test)
 
     try:

--- a/apps/worker/tests/test_config.py
+++ b/apps/worker/tests/test_config.py
@@ -439,17 +439,17 @@ def test_curie_dead_letter_stream_reaches_the_dead_letter_field(
     assert config.dead_letter_stream_name() == "operations:dead"
 
 
-# --- Per-service bool divergence (review #178) -------------------------------
+# Worker boolean behavior (review #178)
 #
-# The old worker ``_b`` accepted only ("1", "true", "yes") as truthy -- notably
-# NOT "on", unlike the dispatcher's ``_set_bool``. These lock that divergence.
+# The old worker ``_b`` accepted only ("1", "true", "yes") as truthy. These
+# tests preserve that exact token set.
 
 
 @pytest.mark.parametrize("token", ["1", "true", "yes", "TRUE", "Yes", " yes "])
 def test_bool_shared_truthy_tokens(
     monkeypatch: pytest.MonkeyPatch, token: str
 ) -> None:
-    """The truthy set shared with the dispatcher parses to True (case/space-insensitive)."""
+    """The worker truthy tokens parse to True regardless of case or surrounding space."""
     _clear_all_config_env(monkeypatch)
     monkeypatch.setenv("CURIE_SHIMMER", token)
     monkeypatch.setenv("CURIE_FAKE_MODEL", token)
@@ -464,7 +464,7 @@ def test_bool_shared_truthy_tokens(
 def test_bool_worker_rejects_on_and_falsy_tokens(
     monkeypatch: pytest.MonkeyPatch, token: str
 ) -> None:
-    """The worker does NOT treat "on" as truthy (the dispatcher does); falsy tokens are False."""
+    """The worker parses "on" and the other rejected tokens as False."""
     _clear_all_config_env(monkeypatch)
     monkeypatch.setenv("CURIE_SHIMMER", token)
     monkeypatch.setenv("CURIE_FAKE_MODEL", token)
@@ -547,7 +547,7 @@ def test_worker_boolean_explanations_do_not_cite_removed_parser() -> None:
     config_region = config_text[config_start:config_end]
 
     test_text = Path(__file__).read_text(encoding="utf-8")
-    test_start = test_text.index("# --- Per-service bool divergence")
+    test_start = test_text.index("# Worker boolean behavior")
     test_end = test_text.index("# --- Eval claim-creation concurrency", test_start)
     test_region = test_text[test_start:test_end]
 

--- a/apps/worker/tests/test_config.py
+++ b/apps/worker/tests/test_config.py
@@ -10,8 +10,11 @@ BaseSettings refactor.
 
 from __future__ import annotations
 
+import importlib.util
 import os
 import socket
+from pathlib import Path
+from types import ModuleType
 
 import pytest
 from curie_worker.config import WorkerConfig
@@ -524,3 +527,81 @@ def test_eval_max_concurrent_claims_rejects_zero(
 
     with pytest.raises(ValueError):
         WorkerConfig()
+
+
+def _load_test_module(module_name: str, path: Path) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_worker_boolean_explanations_do_not_cite_removed_parser() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    config_text = (
+        repo_root / "apps/worker/src/curie_worker/config.py"
+    ).read_text(encoding="utf-8")
+    config_start = config_text.index("def _parse_bool")
+    config_end = config_text.index("\n\nBool =", config_start)
+    config_region = config_text[config_start:config_end]
+
+    test_text = Path(__file__).read_text(encoding="utf-8")
+    test_start = test_text.index("# --- Per-service bool divergence")
+    test_end = test_text.index("# --- Eval claim-creation concurrency", test_start)
+    test_region = test_text[test_start:test_end]
+
+    removed_helper = "_" + "set" + "_bool"
+    retired_service = "dis" + "patcher"
+
+    for region in (config_region, test_region):
+        assert removed_helper not in region, f"boolean notes still cite {removed_helper}"
+        assert retired_service not in region, (
+            f"boolean notes still compare this parser to {retired_service}"
+        )
+
+
+def test_async_test_body_gate_rejects_a_shallow_corpus(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    module = _load_test_module(
+        "issue_1431_async_body_gate",
+        repo_root / "apps/worker/tests/binding/test_no_unrun_async_test_bodies.py",
+    )
+    monkeypatch.setattr(module, "REPO_ROOT", tmp_path)
+    gate = getattr(module, "test_no_test_defines_a_coroutine_it_never_runs")
+    assert callable(gate)
+
+    with pytest.raises(AssertionError) as exc_info:
+        gate()
+
+    message = str(exc_info.value)
+    assert str(tmp_path.resolve()) in message
+    assert "0" in message
+
+
+def test_recorder_health_precondition_fails_when_service_is_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    module = _load_test_module(
+        "issue_1431_recorder",
+        repo_root / "apps/worker/tests/eval/test_recorder.py",
+    )
+    unavailable_host = "http://127.0.0.1:1"
+    monkeypatch.setattr(module, "_LF_HOST", unavailable_host)
+    recorder_test = getattr(module, "test_records_per_case_results_and_reads_them_back")
+    assert callable(recorder_test)
+
+    try:
+        recorder_test()
+    except pytest.skip.Exception as exc:
+        pytest.fail(f"health precondition skipped at {unavailable_host}: {exc}")
+    except pytest.fail.Exception as exc:
+        message = str(exc)
+        assert "Langfuse not reachable at" in message
+        assert unavailable_host in message
+    else:
+        pytest.fail("health precondition returned successfully while its service was absent")

--- a/cli/schema/approvals.schema.json
+++ b/cli/schema/approvals.schema.json
@@ -73,7 +73,7 @@
           ]
         },
         "card_channel": {
-          "description": "The channel the approval card was posted to, or null when the record names no route (the requesting channel is then the approver set). This is what `--resolve` needs as `--actor-channel`: with no `approvers` block the channel's MEMBERS are the approver set, and the server-side authorizer compares against it, so the value is not derivable by guessing (#1078).\n\nOPTIONAL, and the only optional property in this record, which is deliberate rather than an oversight. Every sibling was required at birth, when no compatibility question existed. ADR-0101 prefers optional for a property added later: a consumer can tolerate its absence in a payload from an older CLI, which keeps this a MINOR bump. Making it required would reject those older payloads and cost a major version for no gain.",
+          "description": "The channel the approval card was posted to, or null on an older row or a direct API write that omitted the field. This is what `--resolve` needs as `--actor-channel`: with no `approvers` block the channel's MEMBERS are the approver set, and the server-side authorizer compares against it, so the value is not derivable by guessing (#1078).\n\nOPTIONAL, and the only optional property in this record, which is deliberate rather than an oversight. Every sibling was required at birth, when no compatibility question existed. ADR-0101 prefers optional for a property added later: a consumer can tolerate its absence in a payload from an older CLI, which keeps this a MINOR bump. Making it required would reject those older payloads and cost a major version for no gain.",
           "type": [
             "string",
             "null"

--- a/cli/schema/baseline/approvals.schema.json
+++ b/cli/schema/baseline/approvals.schema.json
@@ -73,7 +73,7 @@
           ]
         },
         "card_channel": {
-          "description": "The channel the approval card was posted to, or null when the record names no route (the requesting channel is then the approver set). This is what `--resolve` needs as `--actor-channel`: with no `approvers` block the channel's MEMBERS are the approver set, and the server-side authorizer compares against it, so the value is not derivable by guessing (#1078).\n\nOPTIONAL, and the only optional property in this record, which is deliberate rather than an oversight. Every sibling was required at birth, when no compatibility question existed. ADR-0101 prefers optional for a property added later: a consumer can tolerate its absence in a payload from an older CLI, which keeps this a MINOR bump. Making it required would reject those older payloads and cost a major version for no gain.",
+          "description": "The channel the approval card was posted to, or null on an older row or a direct API write that omitted the field. This is what `--resolve` needs as `--actor-channel`: with no `approvers` block the channel's MEMBERS are the approver set, and the server-side authorizer compares against it, so the value is not derivable by guessing (#1078).\n\nOPTIONAL, and the only optional property in this record, which is deliberate rather than an oversight. Every sibling was required at birth, when no compatibility question existed. ADR-0101 prefers optional for a property added later: a consumer can tolerate its absence in a payload from an older CLI, which keeps this a MINOR bump. Making it required would reject those older payloads and cost a major version for no gain.",
           "type": [
             "string",
             "null"

--- a/cli/scripts/refresh-schema-baseline.sh
+++ b/cli/scripts/refresh-schema-baseline.sh
@@ -10,6 +10,14 @@
 # script refuses when the gate would go from red to green purely because the
 # baseline moved.
 #
+# The refusal reads SHAPE -- the properties-and-required reading
+# `cli/tests/schema_inventory.rs` uses -- not a byte diff. ADR-0101 versions on a
+# shape change, and that gate already skips `description`, `title` and
+# `$comment` as prose. A byte diff here refused a corrected description outright
+# and demanded a bump that would tell every consumer to refetch a schema whose
+# shape did not move, which is neither what the ADR says nor what
+# `cli/schema/baseline/README.md` says this script does.
+#
 # It also refuses when the gate is currently GREEN and nothing needs refreshing.
 # Running it speculatively is how the baseline stops being a record of the last
 # published revision and becomes a copy of whatever is checked out, which costs
@@ -41,14 +49,60 @@ esac
 shopt -s nullglob
 live_schemas=("$schema_dir"/*.schema.json)
 
+# One schema's `$id` on the first line, then the JSON Pointer of every
+# `properties` key and every `required` entry anywhere in the document,
+# `$defs` included, sorted so the output is a stable fingerprint of the shape.
+# Mirrors `shape`/`walk` in cli/tests/schema_inventory.rs, prose skip included;
+# the two must agree, since that gate is what fails CI and this is what decides
+# whether the baseline may be refreshed for it.
+schema_shape() {
+  python3 - "$1" <<'SHAPE'
+import json, sys
+
+# Prose, not shape: skipping these keeps a reworded description from reading as
+# a compatibility event. Same list as the Rust gate.
+PROSE_KEYS = ("description", "title", "$comment")
+
+
+def walk(node, path, props, required):
+    if isinstance(node, dict):
+        declared = node.get("properties")
+        if isinstance(declared, dict):
+            props.update(f"{path}/properties/{key}" for key in declared)
+        names = node.get("required")
+        if isinstance(names, list):
+            required.update(
+                f"{path}/required/{name}" for name in names if isinstance(name, str)
+            )
+        for key, value in node.items():
+            if key in PROSE_KEYS:
+                continue
+            walk(value, f"{path}/{key}", props, required)
+    elif isinstance(node, list):
+        for index, value in enumerate(node):
+            walk(value, f"{path}/{index}", props, required)
+
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    schema = json.load(handle)
+props, required = set(), set()
+walk(schema, "", props, required)
+print(schema.get("$id", "") if isinstance(schema, dict) else "")
+for entry in sorted(props | required):
+    print(entry)
+SHAPE
+}
+
 mismatched=()
 for f in "${live_schemas[@]}"; do
   name="$(basename "$f")"
   base="$baseline_dir/$name"
   [[ -f "$base" ]] || continue
-  cur_id="$(python3 -c 'import json,sys;print(json.load(open(sys.argv[1]))["$id"])' "$f")"
-  base_id="$(python3 -c 'import json,sys;print(json.load(open(sys.argv[1]))["$id"])' "$base")"
-  if [[ "$cur_id" == "$base_id" ]] && ! diff -q "$f" "$base" >/dev/null; then
+  cur_shape="$(schema_shape "$f")"
+  base_shape="$(schema_shape "$base")"
+  cur_id="$(head -n1 <<<"$cur_shape")"
+  base_id="$(head -n1 <<<"$base_shape")"
+  if [[ "$cur_id" == "$base_id" && "$cur_shape" != "$base_shape" ]]; then
     mismatched+=("$name ($cur_id)")
   fi
 done
@@ -93,7 +147,7 @@ if (( ${#changed[@]} == 0 && ${#baseline_only[@]} == 0 )); then
 fi
 
 if (( ${#mismatched[@]} > 0 )); then
-  echo "refusing to refresh: these schemas changed while keeping their \$id (ADR-0101)." >&2
+  echo "refusing to refresh: these schemas changed SHAPE while keeping their \$id (ADR-0101)." >&2
   printf '  %s\n' "${mismatched[@]}" >&2
   echo >&2
   echo "Bump the version first -- minor for an added optional property, major for" >&2

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -4265,8 +4265,6 @@ pub struct ApprovalCmd {
 /// re-checks all of these; these exist only so a typo is answered locally with a
 /// fix hint instead of a round trip (the same split the API's own
 /// `_validate_slack_channel_id` docstring describes).
-static SLACK_CHANNEL_ID: std::sync::LazyLock<regex::Regex> =
-    std::sync::LazyLock::new(|| regex::Regex::new(r"^[CDG][A-Z0-9]{7,}$").expect("channel id re"));
 static SLACK_USERGROUP_ID: std::sync::LazyLock<regex::Regex> =
     std::sync::LazyLock::new(|| regex::Regex::new(r"^S[A-Z0-9]{7,}$").expect("usergroup id re"));
 static SLACK_USER_ID: std::sync::LazyLock<regex::Regex> =
@@ -4467,7 +4465,7 @@ fn build_route_bindings(
 
 /// Channel-shape check for one route binding, with the route named in the error.
 fn validate_route_channel(route: &str, channel: &str) -> Result<()> {
-    if !SLACK_CHANNEL_ID.is_match(channel) {
+    if !crate::credcheck::looks_like_slack_channel_id(channel) {
         return Err(crate::exit::CliError::usage(format!(
             "route {route:?}: {channel:?} is not a Slack channel ID. Real Slack events \
              carry the ID and the worker routes on it, so a #name binding never \
@@ -4568,9 +4566,8 @@ fn approval_record_json(r: &crate::api::ApprovalRecord) -> serde_json::Value {
         "summary": r.summary,
         "expires_at": r.expires_at,
         "resolved_by": r.resolved_by,
-        // #1078: the one field --resolve cannot be driven without. Null when
-        // the record names no route, which means the requesting channel is the
-        // approver set rather than a bound one.
+        // #1078: the one field --resolve cannot be driven without. Null only
+        // for an older row or a direct API write that omitted this field.
         "card_channel": r.card_channel,
     })
 }

--- a/cli/src/credcheck.rs
+++ b/cli/src/credcheck.rs
@@ -20,6 +20,9 @@
 /// What went wrong with a pasted value, phrased for the person who pasted it.
 pub type CheckResult = Result<(), String>;
 
+static SLACK_CHANNEL_ID: std::sync::LazyLock<regex::Regex> =
+    std::sync::LazyLock::new(|| regex::Regex::new(r"^[CDG][A-Z0-9]{7,}$").expect("channel id re"));
+
 /// Credentials whose prefix identifies them, and what to call them.
 const KNOWN_PREFIXES: &[(&str, &str, &str)] = &[
     ("SLACK_APP_TOKEN", "xapp-", "app-level token"),
@@ -114,17 +117,26 @@ pub fn check_model_credential(value: &str) -> CheckResult {
             "that looks like {actual}, not a model credential. Supported shapes are \
              `sk-ant-` (Anthropic), `sk-or-` (OpenRouter), dotted `id.secret`, and \
              bare `sk-`; bare `sk-` and dotted `id.secret` shapes alone do not \
-             identify the provider"
+             identify the provider. Set `CURIE_MODEL_BASE_URL` to choose the provider \
+             endpoint, then provide the value with `curie secrets set <NAME>` or \
+             `export <NAME>=...`"
         )),
         None if looks_like_zhipu_credential(value) => Ok(()),
         None => Err(
             "supported model credential shapes are `sk-ant-` (Anthropic), \
              `sk-or-` (OpenRouter), dotted `id.secret`, and bare `sk-`; \
              bare `sk-` and dotted `id.secret` shapes alone do not identify the \
-             provider"
+             provider. Set `CURIE_MODEL_BASE_URL` to choose the provider endpoint, \
+             then provide the value with `curie secrets set <NAME>` or \
+             `export <NAME>=...`"
                 .to_string(),
         ),
     }
+}
+
+/// Whether a value has the Slack channel shape accepted by the API.
+pub fn looks_like_slack_channel_id(value: &str) -> bool {
+    SLACK_CHANNEL_ID.is_match(value)
 }
 
 /// A Slack channel ID, not a channel name.
@@ -137,18 +149,13 @@ pub fn check_channel_id(value: &str) -> CheckResult {
     if let Some(name) = value.strip_prefix('#') {
         return Err(format!(
             "that is a channel NAME. Curie binds by id: right-click #{name} -> View channel \
-             details, and copy the id at the bottom (it starts with C)"
+             details, and copy the id at the bottom (it starts with C, D, or G)"
         ));
     }
-    let looks_like_id = value.starts_with('C')
-        && value.len() >= 9
-        && value[1..]
-            .chars()
-            .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit());
-    if !looks_like_id {
+    if !looks_like_slack_channel_id(value) {
         return Err(
-            "a Slack channel id starts with C and is upper case letters and digits, \
-             e.g. C0EXAMPLE1"
+            "a Slack channel id starts with C, D, or G and continues with upper case \
+             letters and digits, e.g. C0EXAMPLE1, D0EXAMPLE1, or G0EXAMPLE1"
                 .to_string(),
         );
     }

--- a/cli/src/guide.rs
+++ b/cli/src/guide.rs
@@ -285,8 +285,8 @@ pub fn primer() -> Primer {
                 detail: "The platform blocks the author of the turn that raised a request from resolving it, under every approver set. Testing an approval flow therefore needs a second actor: pass `--as <other-user>` on the resolve.",
             },
             Landmine {
-                title: "A group-bound route with no bot token on the API refuses every click",
-                detail: "`--route-approvers <name>=group:<S...>` makes the API resolve Slack user-group membership, which needs SLACK_BOT_TOKEN with the `usergroups:read` scope on the API process. Without it the lookup is undetermined and the authorizer fails CLOSED, so every resolution is refused as not-an-approver with nothing naming the token as the cause. Bind `users:` instead, or set the token (the scope needs the Slack app reinstalled).",
+                title: "A group route with no bot token on the API refuses every click",
+                detail: "`--route-approvers <name>=group:<S...>` makes the API resolve Slack user-group membership, which needs SLACK_BOT_TOKEN with the `usergroups:read` scope on the API process. Without it the lookup is undetermined and the authorizer fails CLOSED: every resolution reports `could not verify approver group membership`. Bind `users:` instead, or set the token (the scope needs the Slack app reinstalled).",
             },
             Landmine {
                 title: "Silence after a request usually means an unbound route",
@@ -348,7 +348,7 @@ pub fn primer() -> Primer {
             },
             Recovery {
                 symptom: "a resolve is refused with \"you are not an approver\"",
-                fix: "The route's approver set does not admit that actor from that channel. With no approvers block the card channel's members are the set, so pass `--actor-channel` with the channel that route is bound to (or the requesting channel when the record names no route).",
+                fix: "The route's approver set does not admit that actor from that channel. With no approvers block the card channel's members are the set, so pass `--actor-channel` with the channel that route is bound to. A null `card_channel` is from an older row or a direct API write that omitted the field, so use the requesting channel.",
             },
             Recovery {
                 symptom: "a command \"does not exist\"",

--- a/cli/src/guide.rs
+++ b/cli/src/guide.rs
@@ -286,7 +286,7 @@ pub fn primer() -> Primer {
             },
             Landmine {
                 title: "A group route with no bot token on the API refuses every click",
-                detail: "`--route-approvers <name>=group:<S...>` makes the API resolve Slack user-group membership, which needs SLACK_BOT_TOKEN with the `usergroups:read` scope on the API process. Without it the lookup is undetermined and the authorizer fails CLOSED: every resolution reports `could not verify approver group membership`. Bind `users:` instead, or set the token (the scope needs the Slack app reinstalled).",
+                detail: "`--route-approvers <name>=group:<S...>` makes the API resolve Slack user-group membership, which needs SLACK_BOT_TOKEN with the `usergroups:read` scope on the API process. Without it the lookup is undetermined and the authorizer fails CLOSED: every resolution reports `could not verify approver group membership`; the refusal does not name the missing token. Bind `users:` instead, or set the token (the scope needs the Slack app reinstalled).",
             },
             Landmine {
                 title: "Silence after a request usually means an unbound route",
@@ -349,6 +349,14 @@ pub fn primer() -> Primer {
             Recovery {
                 symptom: "a resolve is refused with \"you are not an approver\"",
                 fix: "The route's approver set does not admit that actor from that channel. With no approvers block the card channel's members are the set, so pass `--actor-channel` with the channel that route is bound to. A null `card_channel` is from an older row or a direct API write that omitted the field, so use the requesting channel.",
+            },
+            Recovery {
+                symptom: "a resolve is refused with \"could not verify approvers\"",
+                fix: "The declared approvers block is malformed, so the platform cannot determine who may resolve. Correct its `users` or `group` value, then replace the complete route map.",
+            },
+            Recovery {
+                symptom: "a resolve is refused with \"could not verify approver group membership\"",
+                fix: "Slack group membership could not be verified, so the platform fails CLOSED. The refusal does not name the missing token. Check the API's SLACK_BOT_TOKEN, its `usergroups:read` scope and reinstallation, and Slack availability.",
             },
             Recovery {
                 symptom: "a command \"does not exist\"",

--- a/cli/src/interactive.rs
+++ b/cli/src/interactive.rs
@@ -1324,9 +1324,9 @@ fn ensure_model_credential_available(
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
     app: &App,
 ) -> Result<()> {
-    const RECOVERY: &str = "A supported model credential is required. Set \
-        `CURIE_MODEL_BASE_URL` to choose the provider endpoint, then save the value with \
-        `curie secrets set <NAME>` or `export <NAME>=...` and retry";
+    const RECOVERY: &str =
+        "A model credential is required. `CURIE_MODEL_BASE_URL` selects the endpoint. Use \
+        `curie secrets set <NAME>` or `export <NAME>=...`, then retry";
     const NAMES: &[&str] = &[
         "CURIE_CREDENTIALS",
         "ANTHROPIC_API_KEY",

--- a/cli/src/interactive.rs
+++ b/cli/src/interactive.rs
@@ -1314,15 +1314,9 @@ fn ensure_secret_available(
     if !save {
         anyhow::bail!("{recovery}");
     }
-    let value = prompt_checked(
-        terminal,
-        app,
-        "Save Secret",
-        name,
-        &recovery,
-        true,
-        |v| crate::credcheck::check_secret(name, v),
-    )?;
+    let value = prompt_checked(terminal, app, "Save Secret", name, &recovery, true, |v| {
+        crate::credcheck::check_secret(name, v)
+    })?;
     crate::secrets::save_value(name, &value)
 }
 

--- a/cli/src/interactive.rs
+++ b/cli/src/interactive.rs
@@ -804,17 +804,15 @@ fn deploy_to_slack(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, app: &
     let repo_root = find_repo_root(cwd.clone())
         .context("could not find Curie repo root; run this workflow from the source checkout")?;
 
-    let Some(channel) = prompt_checked(
+    let channel = prompt_checked(
         terminal,
         app,
         "Deploy to Slack",
-        "Slack channel ID (C0...)",
+        "Slack channel ID (C0..., D0..., or G0...)",
+        "A Slack channel ID is required to deploy to Slack",
         false,
         crate::credcheck::check_channel_id,
-    )?
-    else {
-        return Ok(());
-    };
+    )?;
     let plugin_dir = prompt_bundle_dir(terminal, app, "Deploy to Slack", &repo_root)?
         .filter(|dir| !dir.trim().is_empty())
         .unwrap_or_else(|| ".".to_string());
@@ -1153,16 +1151,17 @@ fn prompt_checked(
     app: &App,
     title: &str,
     label: &str,
+    cancel_recovery: &str,
     secret: bool,
     check: impl Fn(&str) -> crate::credcheck::CheckResult,
-) -> Result<Option<String>> {
+) -> Result<String> {
     let mut shown = label.to_string();
     loop {
         let Some(value) = prompt_text(terminal, app, title, &shown, None, secret, false)? else {
-            return Ok(None);
+            anyhow::bail!("{cancel_recovery}");
         };
         match check(&value) {
-            Ok(()) => return Ok(Some(value)),
+            Ok(()) => return Ok(value),
             Err(reason) => shown = format!("{label} -- {reason}"),
         }
     }
@@ -1278,6 +1277,10 @@ fn ensure_secret_available(
     app: &App,
     name: &str,
 ) -> Result<()> {
+    let recovery = format!(
+        "{name} is required for this workflow. Save it with `curie secrets set {name}` \
+         or `export {name}=...`, then retry"
+    );
     if std::env::var_os(name).is_some() {
         return Ok(());
     }
@@ -1306,17 +1309,20 @@ fn ensure_secret_available(
         ],
     )?
     else {
-        anyhow::bail!("{name} is required for this workflow");
+        anyhow::bail!("{recovery}");
     };
     if !save {
-        anyhow::bail!("{name} is required for this workflow");
+        anyhow::bail!("{recovery}");
     }
-    let Some(value) = prompt_checked(terminal, app, "Save Secret", name, true, |v| {
-        crate::credcheck::check_secret(name, v)
-    })?
-    else {
-        anyhow::bail!("{name} is required for this workflow");
-    };
+    let value = prompt_checked(
+        terminal,
+        app,
+        "Save Secret",
+        name,
+        &recovery,
+        true,
+        |v| crate::credcheck::check_secret(name, v),
+    )?;
     crate::secrets::save_value(name, &value)
 }
 
@@ -1324,6 +1330,9 @@ fn ensure_model_credential_available(
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
     app: &App,
 ) -> Result<()> {
+    const RECOVERY: &str = "A supported model credential is required. Set \
+        `CURIE_MODEL_BASE_URL` to choose the provider endpoint, then save the value with \
+        `curie secrets set <NAME>` or `export <NAME>=...` and retry";
     const NAMES: &[&str] = &[
         "CURIE_CREDENTIALS",
         "ANTHROPIC_API_KEY",
@@ -1370,14 +1379,17 @@ fn ensure_model_credential_available(
         choices,
     )?
     else {
-        anyhow::bail!("a supported model credential is required");
+        anyhow::bail!(RECOVERY);
     };
-    let Some(value) = prompt_checked(terminal, app, "Save Model Credential", &name, true, |v| {
-        crate::credcheck::check_model_credential(v)
-    })?
-    else {
-        anyhow::bail!("a supported model credential is required");
-    };
+    let value = prompt_checked(
+        terminal,
+        app,
+        "Save Model Credential",
+        &name,
+        RECOVERY,
+        true,
+        crate::credcheck::check_model_credential,
+    )?;
     crate::secrets::save_value(&name, &value)
 }
 

--- a/cli/src/recipes.rs
+++ b/cli/src/recipes.rs
@@ -276,7 +276,7 @@ pub(crate) fn recipes() -> Vec<Recipe> {
             }],
             notes: &[
                 "Each record reports its id and `card_channel`, the channel its route bound the card to; pass that as `--actor-channel` when resolving: `--resolve <id> --as <user> --actor-channel <card_channel>`.",
-                "A null `card_channel` means the record names no route, so the REQUESTING channel is the approver set; pass that one instead.",
+                "A null `card_channel` is from an older row or a direct API write that omitted the field; pass the requesting channel instead.",
                 "The server blocks self-approval, so the resolving actor must not be the person whose turn raised the request.",
             ],
         },

--- a/cli/src/scaffold.rs
+++ b/cli/src/scaffold.rs
@@ -165,6 +165,8 @@ const CONNECTORS_YAML: &str = r#"# What this agent needs running. Curie derives 
 #     # `curie secrets set <NAME>`; they never belong in this file.
 #     secrets:
 #       - GRAFANA_SERVICE_ACCOUNT_TOKEN
+#     secret_files:
+#       GRAFANA_CLIENT_CERT: /etc/grafana/client.pem
 #
 #     # Where to reach it on a tier that cannot host it -- `skill` hosts
 #     # nothing, so this is how local development reaches your own copy.

--- a/cli/tests/approval_route_bindings.rs
+++ b/cli/tests/approval_route_bindings.rs
@@ -21,6 +21,7 @@
 mod support;
 
 use curie::commands::{approvals, AgentActionOpts, ApprovalCmd, ApprovalsOutput};
+use curie::credcheck::check_channel_id;
 use std::sync::{Arc, Mutex};
 use support::{serve, MockServer, Response};
 
@@ -214,6 +215,37 @@ async fn route_flag_writes_the_channel_binding() {
             assert!(routes["deal_desk"].approvers.is_none());
         }
         _ => panic!("expected the Routes output"),
+    }
+}
+
+#[test]
+fn guided_channel_validation_accepts_slack_channel_kinds() {
+    for channel in ["C0EXAMPLE1", "D0EXAMPLE1", "G0EXAMPLE1"] {
+        check_channel_id(channel)
+            .unwrap_or_else(|error| panic!("guided validation rejected {channel}: {error}"));
+    }
+}
+
+#[tokio::test]
+async fn direct_and_group_channels_reach_the_route_request() {
+    for (channel, bound) in [
+        ("C0EXAMPLE1", r#"{"team":{"channel":"C0EXAMPLE1"}}"#),
+        ("D0EXAMPLE1", r#"{"team":{"channel":"D0EXAMPLE1"}}"#),
+        ("G0EXAMPLE1", r#"{"team":{"channel":"G0EXAMPLE1"}}"#),
+    ] {
+        let server = stub("null", bound);
+        run(
+            &server,
+            ApprovalCmd {
+                route: vec![format!("team={channel}")],
+                ..ApprovalCmd::default()
+            },
+        )
+        .await
+        .unwrap_or_else(|error| panic!("route validation rejected {channel}: {error}"));
+
+        let body = patch_body(&server);
+        assert_eq!(body["approval_routes"]["team"]["channel"], channel);
     }
 }
 

--- a/cli/tests/guide.rs
+++ b/cli/tests/guide.rs
@@ -223,11 +223,11 @@ fn guide_documents_the_approval_plane() {
             // tree, and each was reachable only from docs/approvals.md, which
             // the primer's own premise says the agent does not read.
             //
-            // The token: a group-bound route with no SLACK_BOT_TOKEN on the API
-            // refuses EVERY click, and the refusal names the approver set
-            // rather than the missing token, so the cause is invisible.
+            // A missing token leaves group membership unverified. The public
+            // refusal must say so while preserving the setup facts below.
             "SLACK_BOT_TOKEN",
             "usergroups:read",
+            "could not verify approver group membership",
             // The two refusals a second approver actually meets. Everything the
             // primer covered before was a first-approver problem.
             "409",
@@ -238,12 +238,53 @@ fn guide_documents_the_approval_plane() {
                 "{label} primer missing the approval fact `{needle}`\n{text}"
             );
         }
+        assert!(
+            !text.contains(
+                "every resolution is refused as not-an-approver with nothing naming the token as the cause"
+            ),
+            "{label} primer preserves the obsolete group lookup refusal\n{text}"
+        );
     }
+    let approvals_document = include_str!("../../docs/approvals.md");
+    assert!(
+        approvals_document.contains("could not verify approver group membership"),
+        "approval documentation omits the literal failed group lookup refusal"
+    );
+    assert!(
+        !approvals_document.contains(
+            "every resolution is refused as not-an-approver with nothing naming the token as the cause"
+        ),
+        "approval documentation preserves the obsolete group lookup refusal"
+    );
     // The section is structural in the markdown, not a stray landmine mention.
     assert!(
         md.contains("## Approvals"),
         "markdown primer has no Approvals section\n{md}"
     );
+}
+
+#[test]
+fn approval_card_channel_null_explanations_preserve_compatibility_meaning() {
+    // #1431: `card_channel` is absent only for an older row or a direct API
+    // write that omitted the field. It does not describe a routeless request.
+    // These are four independent public consumers of that fact.
+    for (surface, text) in [
+        ("approval schema", include_str!("../schema/approvals.schema.json")),
+        ("approval recipe", include_str!("../src/recipes.rs")),
+        ("approval JSON projection", include_str!("../src/commands.rs")),
+        ("approval documentation", include_str!("../../docs/approvals.md")),
+    ] {
+        for fact in ["older row", "direct API write", "omitted"] {
+            assert!(
+                text.contains(fact),
+                "{surface} does not explain null `card_channel` with `{fact}`"
+            );
+        }
+        assert!(
+            !text.contains("names no route"),
+            "{surface} still claims null `card_channel` means the record names no route"
+        );
+    }
 }
 
 #[test]

--- a/cli/tests/guide.rs
+++ b/cli/tests/guide.rs
@@ -227,7 +227,12 @@ fn guide_documents_the_approval_plane() {
             // refusal must say so while preserving the setup facts below.
             "SLACK_BOT_TOKEN",
             "usergroups:read",
+            // #1431. InvalidApprovers and failed group lookup are independent
+            // refusals. An operator cannot safely infer the missing credential
+            // from the group lookup response itself.
+            "could not verify approvers",
             "could not verify approver group membership",
+            "the refusal does not name the missing token",
             // The two refusals a second approver actually meets. Everything the
             // primer covered before was a first-approver problem.
             "409",
@@ -246,15 +251,20 @@ fn guide_documents_the_approval_plane() {
         );
     }
     let approvals_document = include_str!("../../docs/approvals.md");
-    assert!(
-        approvals_document.contains("could not verify approver group membership"),
-        "approval documentation omits the literal failed group lookup refusal"
-    );
-    assert!(
-        !approvals_document.contains(
-            "every resolution is refused as not-an-approver with nothing naming the token as the cause"
-        ),
-        "approval documentation preserves the obsolete group lookup refusal"
+    let invalid_approvers_row = approvals_document
+        .lines()
+        .find(|line| line.starts_with("| `403 ") && line.contains("could not verify approvers"))
+        .expect("approval troubleshooting has an InvalidApprovers row");
+    let group_lookup_row = approvals_document
+        .lines()
+        .find(|line| {
+            line.starts_with("| `403 ")
+                && line.contains("could not verify approver group membership")
+        })
+        .expect("approval troubleshooting has a failed group lookup row");
+    assert_ne!(
+        invalid_approvers_row, group_lookup_row,
+        "InvalidApprovers and failed group lookup must remain separate troubleshooting rows"
     );
     // The section is structural in the markdown, not a stray landmine mention.
     assert!(

--- a/cli/tests/guide.rs
+++ b/cli/tests/guide.rs
@@ -269,10 +269,19 @@ fn approval_card_channel_null_explanations_preserve_compatibility_meaning() {
     // write that omitted the field. It does not describe a routeless request.
     // These are four independent public consumers of that fact.
     for (surface, text) in [
-        ("approval schema", include_str!("../schema/approvals.schema.json")),
+        (
+            "approval schema",
+            include_str!("../schema/approvals.schema.json"),
+        ),
         ("approval recipe", include_str!("../src/recipes.rs")),
-        ("approval JSON projection", include_str!("../src/commands.rs")),
-        ("approval documentation", include_str!("../../docs/approvals.md")),
+        (
+            "approval JSON projection",
+            include_str!("../src/commands.rs"),
+        ),
+        (
+            "approval documentation",
+            include_str!("../../docs/approvals.md"),
+        ),
     ] {
         for fact in ["older row", "direct API write", "omitted"] {
             assert!(

--- a/cli/tests/model_provider_registry.rs
+++ b/cli/tests/model_provider_registry.rs
@@ -136,9 +136,19 @@ fn rejected_credential_examples_stay_rejected() {
     let registry = load_registry();
     assert!(!registry.rejected_credential_examples.is_empty());
     for credential in &registry.rejected_credential_examples {
-        assert!(
-            check_model_credential(credential).is_err(),
-            "accepted rejected credential {credential:?}"
-        );
+        let error = match check_model_credential(credential) {
+            Ok(()) => panic!("accepted rejected credential {credential:?}"),
+            Err(error) => error,
+        };
+        for recovery in [
+            "CURIE_MODEL_BASE_URL",
+            "curie secrets set <NAME>",
+            "export <NAME>=",
+        ] {
+            assert!(
+                error.contains(recovery),
+                "credential error must name recovery {recovery:?}: {error}"
+            );
+        }
     }
 }

--- a/cli/tests/spec_scaffold.rs
+++ b/cli/tests/spec_scaffold.rs
@@ -21,7 +21,7 @@ use std::path::Path;
 use std::process::Command;
 
 use curie::evals::{load_suite, GraderKind};
-use curie::scaffold::{read_manifest, scaffold_from_spec};
+use curie::scaffold::{read_manifest, scaffold, scaffold_from_spec};
 use curie::spec::parse;
 
 fn bin() -> &'static str {
@@ -102,6 +102,34 @@ fn scaffolds_the_full_bundle_from_a_valid_spec() {
     // 5. .gitignore ignores local workstation state.
     let gitignore = std::fs::read_to_string(out.join(".gitignore")).unwrap();
     assert!(gitignore.contains(".curie/"), "{gitignore}");
+}
+
+#[test]
+fn default_scaffold_documents_a_file_backed_secret() {
+    let dir = tempfile::tempdir().unwrap();
+    scaffold(dir.path(), "acme").expect("default scaffold succeeds");
+
+    let connectors = std::fs::read_to_string(dir.path().join("connectors.yaml")).unwrap();
+    let mut lines = connectors.lines();
+    let secret_files = lines
+        .find(|line| line.trim() == "#     secret_files:")
+        .expect("connectors.yaml must show the commented secret_files mapping");
+    assert_eq!(secret_files, "#     secret_files:");
+
+    let projection = lines
+        .next()
+        .expect("secret_files must include a secret name and file path");
+    let mapping = projection
+        .strip_prefix("#       ")
+        .expect("the file projection must remain commented");
+    let (name, path) = mapping
+        .split_once(':')
+        .expect("the file projection must be a YAML mapping");
+    assert!(!name.trim().is_empty(), "the secret name must be nonempty");
+    assert!(
+        path.trim().starts_with('/'),
+        "the projection must show an absolute file path: {projection}"
+    );
 }
 
 /// A spec declaring `secrets` and `approvalPolicy` scaffolds a gated, authed

--- a/cli/tests/tui_parity.rs
+++ b/cli/tests/tui_parity.rs
@@ -194,7 +194,11 @@ fn a_bogus_verb_fails_the_gate() {
 }
 
 #[cfg(target_os = "linux")]
-fn cancel_next_local_deploy_prompt(environment: &[(&str, &str)], cancellation: &str) -> String {
+fn cancel_next_local_deploy_prompt(
+    environment: &[(&str, &str)],
+    after_intro: &[&[u8]],
+    cancellation: &str,
+) -> String {
     let config = tempfile::tempdir().expect("create isolated config directory");
     let shell_command = format!(
         "stty rows {CAPTURE_ROWS} cols {CAPTURE_COLUMNS}; exec {} interactive",
@@ -233,7 +237,12 @@ fn cancel_next_local_deploy_prompt(environment: &[(&str, &str)], cancellation: &
 
     let mut input = child.stdin.take().expect("terminal input");
     thread::sleep(Duration::from_millis(200));
-    for keys in [b"\t\t\t\t".as_slice(), b"\r", b"\r", b"\r", b"\x1b"] {
+    for keys in [b"\t\t\t\t".as_slice(), b"\r", b"\r", b"\r"] {
+        input.write_all(keys).expect("send terminal input");
+        input.flush().expect("flush terminal input");
+        thread::sleep(Duration::from_millis(150));
+    }
+    for keys in after_intro {
         input.write_all(keys).expect("send terminal input");
         input.flush().expect("flush terminal input");
         thread::sleep(Duration::from_millis(150));
@@ -275,6 +284,7 @@ fn guided_prompt_cancellation_names_visible_recovery() {
             ("SLACK_APP_TOKEN", "xapp-EXAMPLE-app-token"),
             ("SLACK_BOT_TOKEN", "xoxb-EXAMPLE-bot-token"),
         ],
+        &[b"\x1b"],
         "channel",
     );
     assert!(
@@ -291,6 +301,7 @@ fn model_credential_cancellation_names_every_recovery_path() {
             ("SLACK_APP_TOKEN", "xapp-EXAMPLE-app-token"),
             ("SLACK_BOT_TOKEN", "xoxb-EXAMPLE-bot-token"),
         ],
+        &[b"\x1b"],
         "model credential",
     );
     for recovery in [
@@ -313,6 +324,7 @@ fn slack_app_token_cancellation_names_every_recovery_path() {
             ("CURIE_CREDENTIALS", "sk-EXAMPLE-model-credential"),
             ("SLACK_BOT_TOKEN", "xoxb-EXAMPLE-bot-token"),
         ],
+        &[b"\x1b"],
         "Slack app token",
     );
     for recovery in [
@@ -322,6 +334,73 @@ fn slack_app_token_cancellation_names_every_recovery_path() {
         assert!(
             text.contains(recovery),
             "Slack app token cancellation must show {recovery:?}:\n{text}"
+        );
+    }
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn slack_app_token_cancel_choice_names_every_recovery_path() {
+    let text = cancel_next_local_deploy_prompt(
+        &[
+            ("CURIE_CREDENTIALS", "sk-EXAMPLE-model-credential"),
+            ("SLACK_BOT_TOKEN", "xoxb-EXAMPLE-bot-token"),
+        ],
+        &[b"\x1b[B", b"\r"],
+        "Slack app token cancel choice",
+    );
+    for recovery in [
+        "curie secrets set SLACK_APP_TOKEN",
+        "export SLACK_APP_TOKEN=",
+    ] {
+        assert!(
+            text.contains(recovery),
+            "Slack app token cancel choice must show {recovery:?}:\n{text}"
+        );
+    }
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn slack_app_token_value_cancellation_names_every_recovery_path() {
+    let text = cancel_next_local_deploy_prompt(
+        &[
+            ("CURIE_CREDENTIALS", "sk-EXAMPLE-model-credential"),
+            ("SLACK_BOT_TOKEN", "xoxb-EXAMPLE-bot-token"),
+        ],
+        &[b"\r", b"\x1b"],
+        "Slack app token value",
+    );
+    for recovery in [
+        "curie secrets set SLACK_APP_TOKEN",
+        "export SLACK_APP_TOKEN=",
+    ] {
+        assert!(
+            text.contains(recovery),
+            "Slack app token value cancellation must show {recovery:?}:\n{text}"
+        );
+    }
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn model_credential_value_cancellation_names_every_recovery_path() {
+    let text = cancel_next_local_deploy_prompt(
+        &[
+            ("SLACK_APP_TOKEN", "xapp-EXAMPLE-app-token"),
+            ("SLACK_BOT_TOKEN", "xoxb-EXAMPLE-bot-token"),
+        ],
+        &[b"\r", b"\x1b"],
+        "model credential value",
+    );
+    for recovery in [
+        "CURIE_MODEL_BASE_URL",
+        "curie secrets set <NAME>",
+        "export <NAME>=",
+    ] {
+        assert!(
+            text.contains(recovery),
+            "model credential value cancellation must show {recovery:?}:\n{text}"
         );
     }
 }

--- a/cli/tests/tui_parity.rs
+++ b/cli/tests/tui_parity.rs
@@ -113,3 +113,64 @@ fn a_bogus_verb_fails_the_gate() {
         output_text(&output)
     );
 }
+
+fn source_between<'a>(source: &'a str, start: &str, end: &str) -> &'a str {
+    let rest = source
+        .split_once(start)
+        .unwrap_or_else(|| panic!("missing source anchor {start:?}"))
+        .1;
+    rest.split_once(end)
+        .unwrap_or_else(|| panic!("missing source anchor {end:?}"))
+        .0
+}
+
+#[test]
+fn guided_prompt_cancellation_names_visible_recovery() {
+    // The concrete terminal prompt has no injectable input seam. This source
+    // gate therefore pins guidance inside each production call site rather than
+    // accepting the same words from unrelated documentation.
+    let source = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/interactive.rs"));
+
+    let deploy = source_between(source, "fn deploy_to_slack(", "fn env_credential_present(");
+    let channel_cancel = source_between(
+        deploy,
+        "prompt_checked(",
+        "let plugin_dir = prompt_bundle_dir(",
+    );
+    assert!(
+        channel_cancel.contains("Slack channel ID") && channel_cancel.contains("required"),
+        "channel cancellation must return a visible channel requirement: {channel_cancel}"
+    );
+    assert!(
+        !channel_cancel.contains("return Ok(());"),
+        "channel cancellation must not silently succeed: {channel_cancel}"
+    );
+
+    let secret = source_between(
+        source,
+        "fn ensure_secret_available(",
+        "fn ensure_model_credential_available(",
+    );
+    for recovery in ["curie secrets set {name}", "export {name}="] {
+        assert!(
+            secret.contains(recovery),
+            "secret cancellation must name {recovery:?} at its call site"
+        );
+    }
+
+    let model = source_between(
+        source,
+        "fn ensure_model_credential_available(",
+        "fn model_credential_status(",
+    );
+    for recovery in [
+        "CURIE_MODEL_BASE_URL",
+        "curie secrets set <NAME>",
+        "export <NAME>=",
+    ] {
+        assert!(
+            model.contains(recovery),
+            "model cancellation must name {recovery:?} at its call site"
+        );
+    }
+}

--- a/cli/tests/tui_parity.rs
+++ b/cli/tests/tui_parity.rs
@@ -20,14 +20,21 @@
 //! The guided prompt check also drives cancellation through a real terminal
 //! and requires the recovery message before the action list accepts input.
 
+#[cfg(target_os = "linux")]
 use std::io::Write;
-use std::process::{Command, Stdio};
+use std::process::Command;
+#[cfg(target_os = "linux")]
+use std::process::Stdio;
+#[cfg(target_os = "linux")]
 use std::thread;
+#[cfg(target_os = "linux")]
 use std::time::{Duration, Instant};
 
 use curie::recipes::command_recipe_argvs;
 
+#[cfg(target_os = "linux")]
 const CAPTURE_ROWS: usize = 40;
+#[cfg(target_os = "linux")]
 const CAPTURE_COLUMNS: usize = 240;
 
 fn bin() -> &'static str {
@@ -46,6 +53,7 @@ fn output_text(output: &std::process::Output) -> String {
     String::from_utf8_lossy(&output.stdout).into_owned() + &String::from_utf8_lossy(&output.stderr)
 }
 
+#[cfg(target_os = "linux")]
 fn replay_terminal(text: &str) -> String {
     let mut screen = vec![vec![' '; CAPTURE_COLUMNS]; CAPTURE_ROWS];
     let mut row = 0usize;
@@ -186,22 +194,37 @@ fn a_bogus_verb_fails_the_gate() {
 }
 
 #[cfg(target_os = "linux")]
-#[test]
-fn guided_prompt_cancellation_names_visible_recovery() {
+fn cancel_next_local_deploy_prompt(environment: &[(&str, &str)], cancellation: &str) -> String {
     let config = tempfile::tempdir().expect("create isolated config directory");
-    let command = format!(
+    let shell_command = format!(
         "stty rows {CAPTURE_ROWS} cols {CAPTURE_COLUMNS}; exec {} interactive",
         bin()
     );
-    let mut child = Command::new("script")
-        .args(["--quiet", "--return", "--command", &command, "/dev/null"])
+    let mut process = Command::new("script");
+    process
+        .args([
+            "--quiet",
+            "--return",
+            "--command",
+            &shell_command,
+            "/dev/null",
+        ])
         .current_dir(env!("CARGO_MANIFEST_DIR"))
         .env("TERM", "xterm-256color")
         .env("NO_COLOR", "1")
-        .env("CURIE_CONFIG_DIR", config.path())
-        .env("CURIE_CREDENTIALS", "sk-EXAMPLE-model-credential")
-        .env("SLACK_APP_TOKEN", "xapp-EXAMPLE-app-token")
-        .env("SLACK_BOT_TOKEN", "xoxb-EXAMPLE-bot-token")
+        .env("CURIE_CONFIG_DIR", config.path());
+    for name in [
+        "CURIE_CREDENTIALS",
+        "ANTHROPIC_API_KEY",
+        "CLAUDE_CODE_OAUTH_TOKEN",
+        "CURIE_MODEL_BASE_URL",
+        "SLACK_APP_TOKEN",
+        "SLACK_BOT_TOKEN",
+    ] {
+        process.env_remove(name);
+    }
+    process.envs(environment.iter().copied());
+    let mut child = process
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -229,7 +252,7 @@ fn guided_prompt_cancellation_names_visible_recovery() {
             child.kill().expect("stop stuck interactive CLI");
             let output = child.wait_with_output().expect("collect terminal output");
             panic!(
-                "channel cancellation did not return to the action list:\n{}",
+                "{cancellation} cancellation did not return to the action list:\n{}",
                 output_text(&output)
             );
         }
@@ -240,8 +263,65 @@ fn guided_prompt_cancellation_names_visible_recovery() {
     let output = child.wait_with_output().expect("collect terminal output");
     let text = replay_terminal(&output_text(&output));
     assert!(output.status.success(), "interactive CLI failed:\n{text}");
+    text
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn guided_prompt_cancellation_names_visible_recovery() {
+    let text = cancel_next_local_deploy_prompt(
+        &[
+            ("CURIE_CREDENTIALS", "sk-EXAMPLE-model-credential"),
+            ("SLACK_APP_TOKEN", "xapp-EXAMPLE-app-token"),
+            ("SLACK_BOT_TOKEN", "xoxb-EXAMPLE-bot-token"),
+        ],
+        "channel",
+    );
     assert!(
         text.contains("Action failed: A Slack channel ID is required to deploy to Slack"),
         "channel cancellation must show the recovery requirement:\n{text}"
     );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn model_credential_cancellation_names_every_recovery_path() {
+    let text = cancel_next_local_deploy_prompt(
+        &[
+            ("SLACK_APP_TOKEN", "xapp-EXAMPLE-app-token"),
+            ("SLACK_BOT_TOKEN", "xoxb-EXAMPLE-bot-token"),
+        ],
+        "model credential",
+    );
+    for recovery in [
+        "CURIE_MODEL_BASE_URL",
+        "curie secrets set <NAME>",
+        "export <NAME>=",
+    ] {
+        assert!(
+            text.contains(recovery),
+            "model credential cancellation must show {recovery:?}:\n{text}"
+        );
+    }
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn slack_app_token_cancellation_names_every_recovery_path() {
+    let text = cancel_next_local_deploy_prompt(
+        &[
+            ("CURIE_CREDENTIALS", "sk-EXAMPLE-model-credential"),
+            ("SLACK_BOT_TOKEN", "xoxb-EXAMPLE-bot-token"),
+        ],
+        "Slack app token",
+    );
+    for recovery in [
+        "curie secrets set SLACK_APP_TOKEN",
+        "export SLACK_APP_TOKEN=",
+    ] {
+        assert!(
+            text.contains(recovery),
+            "Slack app token cancellation must show {recovery:?}:\n{text}"
+        );
+    }
 }

--- a/cli/tests/tui_parity.rs
+++ b/cli/tests/tui_parity.rs
@@ -16,10 +16,19 @@
 //! the `Cli` grammar is defined in the binary crate (`main.rs`), not the
 //! library. Relocating the grammar into the library to enable in-process
 //! parsing is a separate, larger change.
+//!
+//! The guided prompt check also drives cancellation through a real terminal
+//! and requires the recovery message before the action list accepts input.
 
-use std::process::Command;
+use std::io::Write;
+use std::process::{Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
 
 use curie::recipes::command_recipe_argvs;
+
+const CAPTURE_ROWS: usize = 40;
+const CAPTURE_COLUMNS: usize = 240;
 
 fn bin() -> &'static str {
     env!("CARGO_BIN_EXE_curie")
@@ -35,6 +44,68 @@ fn run_help(argv: &[String]) -> std::process::Output {
 
 fn output_text(output: &std::process::Output) -> String {
     String::from_utf8_lossy(&output.stdout).into_owned() + &String::from_utf8_lossy(&output.stderr)
+}
+
+fn replay_terminal(text: &str) -> String {
+    let mut screen = vec![vec![' '; CAPTURE_COLUMNS]; CAPTURE_ROWS];
+    let mut row = 0usize;
+    let mut column = 0usize;
+    let mut chars = text.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        if ch == '\x1b' && chars.peek() == Some(&'[') {
+            chars.next();
+            let mut parameters = String::new();
+            let mut final_byte = None;
+            for next in chars.by_ref() {
+                if next.is_ascii() && ('@'..='~').contains(&next) {
+                    final_byte = Some(next);
+                    break;
+                }
+                parameters.push(next);
+            }
+            if matches!(final_byte, Some('H' | 'f')) {
+                let mut position = parameters.split(';');
+                row = position
+                    .next()
+                    .filter(|value| !value.is_empty())
+                    .and_then(|value| value.parse::<usize>().ok())
+                    .unwrap_or(1)
+                    .saturating_sub(1)
+                    .min(CAPTURE_ROWS - 1);
+                column = position
+                    .next()
+                    .filter(|value| !value.is_empty())
+                    .and_then(|value| value.parse::<usize>().ok())
+                    .unwrap_or(1)
+                    .saturating_sub(1)
+                    .min(CAPTURE_COLUMNS - 1);
+            }
+            continue;
+        }
+
+        match ch {
+            '\r' => column = 0,
+            '\n' => {
+                row = (row + 1).min(CAPTURE_ROWS - 1);
+            }
+            printable if !printable.is_control() => {
+                if column >= CAPTURE_COLUMNS {
+                    column = 0;
+                    row = (row + 1).min(CAPTURE_ROWS - 1);
+                }
+                screen[row][column] = printable;
+                column += 1;
+            }
+            _ => {}
+        }
+    }
+
+    screen
+        .into_iter()
+        .map(|line| line.into_iter().collect::<String>().trim_end().to_string())
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 /// Every Command recipe in the TUI catalog must resolve to a real verb with
@@ -114,63 +185,63 @@ fn a_bogus_verb_fails_the_gate() {
     );
 }
 
-fn source_between<'a>(source: &'a str, start: &str, end: &str) -> &'a str {
-    let rest = source
-        .split_once(start)
-        .unwrap_or_else(|| panic!("missing source anchor {start:?}"))
-        .1;
-    rest.split_once(end)
-        .unwrap_or_else(|| panic!("missing source anchor {end:?}"))
-        .0
-}
-
+#[cfg(target_os = "linux")]
 #[test]
 fn guided_prompt_cancellation_names_visible_recovery() {
-    // The concrete terminal prompt has no injectable input seam. This source
-    // gate therefore pins guidance inside each production call site rather than
-    // accepting the same words from unrelated documentation.
-    let source = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/interactive.rs"));
+    let config = tempfile::tempdir().expect("create isolated config directory");
+    let command = format!(
+        "stty rows {CAPTURE_ROWS} cols {CAPTURE_COLUMNS}; exec {} interactive",
+        bin()
+    );
+    let mut child = Command::new("script")
+        .args(["--quiet", "--return", "--command", &command, "/dev/null"])
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .env("TERM", "xterm-256color")
+        .env("NO_COLOR", "1")
+        .env("CURIE_CONFIG_DIR", config.path())
+        .env("CURIE_CREDENTIALS", "sk-EXAMPLE-model-credential")
+        .env("SLACK_APP_TOKEN", "xapp-EXAMPLE-app-token")
+        .env("SLACK_BOT_TOKEN", "xoxb-EXAMPLE-bot-token")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("start interactive CLI in a terminal");
 
-    let deploy = source_between(source, "fn deploy_to_slack(", "fn env_credential_present(");
-    let channel_cancel = source_between(
-        deploy,
-        "prompt_checked(",
-        "let plugin_dir = prompt_bundle_dir(",
-    );
-    assert!(
-        channel_cancel.contains("Slack channel ID") && channel_cancel.contains("required"),
-        "channel cancellation must return a visible channel requirement: {channel_cancel}"
-    );
-    assert!(
-        !channel_cancel.contains("return Ok(());"),
-        "channel cancellation must not silently succeed: {channel_cancel}"
-    );
-
-    let secret = source_between(
-        source,
-        "fn ensure_secret_available(",
-        "fn ensure_model_credential_available(",
-    );
-    for recovery in ["curie secrets set {name}", "export {name}="] {
-        assert!(
-            secret.contains(recovery),
-            "secret cancellation must name {recovery:?} at its call site"
-        );
+    let mut input = child.stdin.take().expect("terminal input");
+    thread::sleep(Duration::from_millis(200));
+    for keys in [b"\t\t\t\t".as_slice(), b"\r", b"\r", b"\r", b"\x1b"] {
+        input.write_all(keys).expect("send terminal input");
+        input.flush().expect("flush terminal input");
+        thread::sleep(Duration::from_millis(150));
     }
+    thread::sleep(Duration::from_millis(350));
+    input.write_all(b"q").expect("leave interactive CLI");
+    input.flush().expect("flush exit input");
 
-    let model = source_between(
-        source,
-        "fn ensure_model_credential_available(",
-        "fn model_credential_status(",
-    );
-    for recovery in [
-        "CURIE_MODEL_BASE_URL",
-        "curie secrets set <NAME>",
-        "export <NAME>=",
-    ] {
-        assert!(
-            model.contains(recovery),
-            "model cancellation must name {recovery:?} at its call site"
-        );
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        if child.try_wait().expect("poll interactive CLI").is_some() {
+            break;
+        }
+        if Instant::now() >= deadline {
+            drop(input);
+            child.kill().expect("stop stuck interactive CLI");
+            let output = child.wait_with_output().expect("collect terminal output");
+            panic!(
+                "channel cancellation did not return to the action list:\n{}",
+                output_text(&output)
+            );
+        }
+        thread::sleep(Duration::from_millis(25));
     }
+    drop(input);
+
+    let output = child.wait_with_output().expect("collect terminal output");
+    let text = replay_terminal(&output_text(&output));
+    assert!(output.status.success(), "interactive CLI failed:\n{text}");
+    assert!(
+        text.contains("Action failed: A Slack channel ID is required to deploy to Slack"),
+        "channel cancellation must show the recovery requirement:\n{text}"
+    );
 }

--- a/docs/approvals.md
+++ b/docs/approvals.md
@@ -157,8 +157,8 @@ Three properties worth knowing before you design around this:
 - **The buttons are visible to everyone in the channel.** Slack cannot hide a button per
   user, so authorization is enforced when the click arrives, not by hiding the control.
   A refused click gets a private, reasoned refusal.
-- **A lookup that fails denies.** A group-bound route with no bot token, or a Slack
-  outage, reports "could not verify" and refuses. It never falls back to channel
+- **A lookup that fails denies.** A group route with no bot token, or a Slack
+  outage, reports "could not verify approver group membership" and refuses. It never falls back to channel
   membership, because that would silently widen the set an operator narrowed.
 
 Resolving a group-bound route needs `SLACK_BOT_TOKEN` on the API with the
@@ -167,8 +167,8 @@ Resolving a group-bound route needs `SLACK_BOT_TOKEN` on the API with the
 `.env.example`; `apps/api/src/curie_api/slack_usergroups.py` is the lookup that
 consumes them and names neither, so it is the wrong place to send a reader
 checking the claim. The scope needs the Slack app reinstalled. Without the
-token, such a route fails closed: every resolution on it is refused as
-not-an-approver, with nothing naming the missing token as the cause.
+token, such a route fails closed: every resolution reports `could not verify approver
+group membership`.
 
 ## What your skill must handle on resume
 
@@ -244,8 +244,8 @@ or `approvers.group` ignores the channel entirely, so passing it there is harmle
 | Symptom | Cause and fix |
 |---|---|
 | `403 self-approval is blocked` | You are the author of the turn that raised it. Resolve as a different actor. |
-| `403 you are not an approver` | The route's set does not admit that actor from that channel. Pass the record's `card_channel` as `--actor-channel` (`--list --json` reports it since #1078), or check the `approvers` block. A null `card_channel` means the record names no route, so the requesting channel is the set. |
-| `403 could not verify approvers` | A group lookup failed or the approvers block does not parse. Check `SLACK_BOT_TOKEN` and the `usergroups:read` scope; this never falls back to channel membership. |
+| `403 you are not an approver` | The route's set does not admit that actor from that channel. Pass the record's `card_channel` as `--actor-channel` (`--list --json` reports it since #1078), or check the `approvers` block. A null `card_channel` is from an older row or a direct API write that omitted the field, so use the requesting channel. |
+| `403 could not verify approver group membership` | A group lookup failed or the approvers block does not parse. Check `SLACK_BOT_TOKEN` and the `usergroups:read` scope; this never falls back to channel membership. |
 | `409 already resolved by ...` | Someone else won the claim. The decision stands. |
 | `410 expired` | The record passed its deadline. The session was already woken down its timeout branch. |
 | Agent says a request is pending, no card anywhere | The named route is not bound for this agent, so the turn escalated instead of posting. Add the binding. |

--- a/docs/approvals.md
+++ b/docs/approvals.md
@@ -245,7 +245,8 @@ or `approvers.group` ignores the channel entirely, so passing it there is harmle
 |---|---|
 | `403 self-approval is blocked` | You are the author of the turn that raised it. Resolve as a different actor. |
 | `403 you are not an approver` | The route's set does not admit that actor from that channel. Pass the record's `card_channel` as `--actor-channel` (`--list --json` reports it since #1078), or check the `approvers` block. A null `card_channel` is from an older row or a direct API write that omitted the field, so use the requesting channel. |
-| `403 could not verify approver group membership` | A group lookup failed or the approvers block does not parse. Check `SLACK_BOT_TOKEN` and the `usergroups:read` scope; this never falls back to channel membership. |
+| `403 could not verify approvers` | The declared `approvers` block is malformed and cannot be evaluated. Correct its `users` or `group` value, then replace the complete route map. |
+| `403 could not verify approver group membership` | Slack group membership could not be verified. This fails closed and does not name its cause. Check the API `SLACK_BOT_TOKEN`, its `usergroups:read` scope and reinstallation, and Slack availability. It never falls back to channel membership. |
 | `409 already resolved by ...` | Someone else won the claim. The decision stands. |
 | `410 expired` | The record passed its deadline. The session was already woken down its timeout branch. |
 | Agent says a request is pending, no card anywhere | The named route is not bound for this agent, so the turn escalated instead of posting. Add the binding. |

--- a/tools/ci-retry-gate/tests/test_gitleaks_scope.py
+++ b/tools/ci-retry-gate/tests/test_gitleaks_scope.py
@@ -348,7 +348,26 @@ def test_gitleaks_config_keeps_the_slack_identifier_guards() -> None:
     slack_rule = next(rule for rule in config["rules"] if rule["id"] == "slack-conversation-id")
     assert slack_rule["regex"] == r"\b[CGD][0-9][A-Z0-9]{7,9}\b"
 
-    assert r"\bC0EXAMPLE[0-9]\b" in config["allowlist"]["regexes"]
+    # Read the allowlist for what it COVERS, not for one literal spelling. The
+    # CLI validates all three conversation prefixes, so a test needing a fake
+    # DM or private group id has to be able to write one without reddening the
+    # scan, and nothing that merely looks like an id may ride along.
+    rule = re.compile(str(slack_rule["regex"]))
+    allowed = [re.compile(str(pattern)) for pattern in config["allowlist"]["regexes"]]
+
+    for example in ("C0EXAMPLE1", "D0EXAMPLE1", "G0EXAMPLE1"):
+        assert rule.search(example), f"{example} is not the shape the rule catches"
+        assert any(pattern.search(example) for pattern in allowed), (
+            f"{example} is not allowlisted, so any test using it reddens the scan"
+        )
+
+    # Split so no literal here reaches the rule's shape; rejoining is the defect
+    # this file's sibling test already had to fix once.
+    not_an_example = "C0" + "NOTLISTED"
+    assert rule.search(not_an_example), "the negative control must be a real match first"
+    assert not any(pattern.search(not_an_example) for pattern in allowed), (
+        "the EXAMPLE allowlist must not wave through an ordinary looking id"
+    )
 
     assert (
         "Requiring the digit is what separates them from ordinary"


### PR DESCRIPTION
## Summary

1. Declines the plugin example change because it would edit the frozen plugin format contract. The reason is recorded on the issue.
2. Adds the missing `secret_files` scaffold example. Existing documentation already covers the field, so the scaffold is the reasonable default scope.
3. Shares Slack channel identifier validation across credential checks and route bindings, including C, D, and G prefixes.
4. Makes credential and channel cancellation recovery visible and actionable.
5. Corrects all four null `card_channel` explanations.
6. Separates approver validation wording from group membership lookup wording while preserving the missing token diagnostic.
7. Removes stale fabricated documentation references.
8. Adds a corpus floor above 150 async test bodies.
9. Makes recorder health failure fail the suite instead of skipping it.

## Done check

* [x] Behavior changes have regression tests that fail when reverted.
* [x] Code review and scope review approved the complete diff.
* [x] Shared seam behavior routes through common predicates or constants.
* [x] Guard failures are exercised through real consumer paths.
* [x] Consolidation found no warranted simplification.
* [x] Python lint, type checking, documentation checks, focused worker tests, the real recorder suite, the full Rust suite, and the skill plus local ladders pass.
* [x] The scaffold and cancellation paths were exercised through the released CLI binary.

Closes #1431
