### PR TITLE
Fix correctness and accuracy papercuts

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,14 +8,6 @@
 
 Closes #
 
-## Release train
-
-<!-- Use main for general bugs, security fixes, and shared changes. Use next only
-     for v0.7 features or bugs unique to unreleased v0.7 work. -->
-
-- [ ] This PR targets `main`.
-- [ ] This PR targets `next`.
-
 ## End-to-end verification
 
 <!-- Behavior-bearing changes only. Classify every tier required or n/a with a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,7 @@ the same commands.
 **Python (all packages, from root):**
 Run this local Python CI baseline. Do not use `--profile full` for startup
 because it can start stale application images.
+Set `base=next` when your worktree targets `next`.
 
 ```bash
 (

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,7 @@ because it can start stale application images.
 ```bash
 (
   set -e
+  base=${base:-main}
   export COMPOSE_PROJECT_NAME=curie-implement-baseline
   exec 9>/tmp/curie-implement-baseline.lock
   if ! flock -n 9; then
@@ -86,8 +87,8 @@ because it can start stale application images.
   done
   curl -fsS http://localhost:23000/api/public/health >/dev/null
   (cd apps/api && uv run alembic upgrade head)
-  git fetch --no-tags --depth=1 origin main || true
-  git show origin/main:packages/aci-protocol/schema/wire.lock > "$wire_lock" 2>/dev/null || true
+  git fetch --no-tags --depth=1 origin "$base" || true
+  git show "origin/$base:packages/aci-protocol/schema/wire.lock" > "$wire_lock" 2>/dev/null || true
   uv run python -m aci_protocol.wire_lock --check-base "$wire_lock"
   uv run pytest -q
 )
@@ -586,10 +587,13 @@ runtime verification, commits, and pull requests.
 Two different tools; do not conflate them.
 
 Draft ADRs may merge for discussion, but they cannot authorize implementation.
-Implementation may start only after the ADR is published as `Accepted` with
-explicit maintainer approval, and it is tracked in a linked GitHub issue and
-pull request. Follow [`docs/adr/AGENTS.md`](docs/adr/AGENTS.md) for the complete
-procedure.
+Acceptance is the authority for implementation. Normally, publish the ADR as
+`Accepted` with explicit maintainer approval before beginning implementation.
+As the coordinated exception, an ADR may land `Accepted` alongside
+implementation only with recorded explicit maintainer approval and a named
+realizing code path. Without both, acceptance must precede implementation. Track
+the work in a linked GitHub issue and pull request. Follow
+[`docs/adr/AGENTS.md`](docs/adr/AGENTS.md) for the complete procedure.
 
 - Write an **ADR** (`docs/adr/`, see ADR-0001) only for a **cross-cutting
   architectural decision that closes the door on alternatives.** It is a choice

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,10 @@ Workflow for non-trivial work:
   `docs/adr/`. A Draft may merge for discussion but cannot authorize
   implementation.
 - **Obtain explicit maintainer acceptance before implementation.** Acceptance
-  means the ADR is published with `Status: Accepted`.
+  means the ADR is published with `Status: Accepted`. Normally, acceptance must
+  precede implementation. As the coordinated exception, an ADR may land
+  `Accepted` alongside implementation only with recorded explicit maintainer
+  approval and a named realizing code path.
 - **Issues reference their Accepted ADR(s).** A GitHub issue that implements a
   decision links the ADR, so an agent picking up the issue reads the decision's
   intent first and builds to it.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -158,7 +158,7 @@ maintained by repository admins:
   alert set is triaged (fixed, or dismissed with a recorded reason).
 - **A single repository ruleset (`Default`) covers `main` and `next`, so both
   receive identical protection.** It requires all required status checks to
-  pass and all **review conversations resolved**. The `gitleaks full history`
+  pass and all **review conversations resolved**. The `gitleaks (full history)`
   status check is required, and CodeQL is enforced through the code scanning
   rule.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -156,19 +156,19 @@ maintained by repository admins:
   detected after it lands.
 - **Dependabot alerts** and **Dependabot security updates** enabled; the open
   alert set is triaged (fixed, or dismissed with a recorded reason).
-- **The `main` and `next` branch rulesets provide equal protection.** Each
-  requires all required status checks to pass, each pull request to be **up to
-  date with its target branch** before merge (no stale-green merges), and all
-  **review conversations resolved**. The audit, secret-scan, and CodeQL checks
-  are among the required set.
+- **A single repository ruleset (`Default`) covers `main` and `next`, so both
+  receive identical protection.** It requires all required status checks to
+  pass and all **review conversations resolved**. The `gitleaks full history`
+  status check is required, and CodeQL is enforced through the code scanning
+  rule.
 
 ### Bypass path and auditability
 
-The `main` and `next` rulesets apply to everyone, including admins, save explicit
-bypass-actor lists. Only repository or organization admins may bypass them, and
+The `Default` ruleset applies to everyone, including admins, save its explicit
+bypass actor. Only repository or organization admins may bypass it, and
 only to recover from a stuck state — e.g. a required check wedged by
 infrastructure rather than by the change under review. Every bypass is recorded
 in the organization audit log (ruleset-bypass events), and every merge's check
 state is visible on its PR, so a bypass is observable after the fact and is
-expected to be justified in the PR. Routine merges never bypass; the rulesets
-are the default and only paths.
+expected to be justified in the PR. Routine merges never bypass; the ruleset is
+the default and only path.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -131,7 +131,8 @@ admins maintain (issue #632).
 
 ### Enforced in the tree (CI)
 
-- **Secret scanning on pushes to main and pull requests targeting main, plus a weekly full-history sweep.** The
+- **Secret scanning on pushes to and pull requests targeting both `main` and
+  `next`, plus a weekly full-history sweep.** The
   `Secret Scan` workflow scans pull request commits from base to head, and full
   history on pushes, scheduled runs, and manual runs. Its scanner image is pinned
   to an immutable digest so this sensitive path cannot change under us.
@@ -155,18 +156,19 @@ maintained by repository admins:
   detected after it lands.
 - **Dependabot alerts** and **Dependabot security updates** enabled; the open
   alert set is triaged (fixed, or dismissed with a recorded reason).
-- **The `main` branch ruleset** requires all required status checks to pass and
-  to be **up to date with `main`** before merge (no stale-green merges), and all
-  **review conversations resolved**. The audit, secret-scan, and CodeQL checks are
-  among the required set.
+- **The `main` and `next` branch rulesets provide equal protection.** Each
+  requires all required status checks to pass, each pull request to be **up to
+  date with its target branch** before merge (no stale-green merges), and all
+  **review conversations resolved**. The audit, secret-scan, and CodeQL checks
+  are among the required set.
 
 ### Bypass path and auditability
 
-The `main` ruleset applies to everyone, including admins, save an explicit
-bypass-actor list. Only repository or organization admins may bypass it, and only
-to recover from a stuck state — e.g. a required check wedged by infrastructure
-rather than by the change under review. Every bypass is recorded in the
-organization audit log (ruleset-bypass events), and every merge's check state is
-visible on its PR, so a bypass is observable after the fact and is expected to be
-justified in the PR. Routine merges never bypass; the ruleset is the default and
-only path.
+The `main` and `next` rulesets apply to everyone, including admins, save explicit
+bypass-actor lists. Only repository or organization admins may bypass them, and
+only to recover from a stuck state — e.g. a required check wedged by
+infrastructure rather than by the change under review. Every bypass is recorded
+in the organization audit log (ruleset-bypass events), and every merge's check
+state is visible on its PR, so a bypass is observable after the fact and is
+expected to be justified in the PR. Routine merges never bypass; the rulesets
+are the default and only paths.

--- a/charts/curie/ci/worker-object-store-assertions.sh
+++ b/charts/curie/ci/worker-object-store-assertions.sh
@@ -6,13 +6,9 @@
 #
 # This was a real outage. worker.yaml set none of the four variables, so the
 # worker fell back to its compose default (http://localhost:29000) and every
-# bundle fetch got ECONNREFUSED. Both symptoms pointed elsewhere:
-#
-#   * every Slack turn died as ClaimTimeoutError after 90s, and that message
-#     names a CPU-saturated node first -- on an install idling at 11% CPU
-#   * the post-deploy eval silently stopped running with "unresolvable
-#     suite/bundle", which alerts nothing, because a suite that cannot resolve
-#     looks exactly like a suite nobody asked for
+# bundle fetch got ECONNREFUSED. The post-deploy eval silently stopped running
+# with "unresolvable suite/bundle", which alerts nothing, because a suite that
+# cannot resolve looks exactly like a suite nobody asked for.
 #
 # So this asserts AGREEMENT, not presence. Presence alone would still pass the
 # day someone points the worker at a different-but-populated endpoint.
@@ -139,8 +135,7 @@ def assert_contract(docs, label, expected_endpoint):
     for k in sorted(keys - worker_keys):
         failures.append(
             f"worker is missing {k}. Its config defaults these to the compose stack "
-            "(http://localhost:29000), so every bundle fetch fails with ECONNREFUSED -- and "
-            "the symptom is a ClaimTimeoutError that blames the node's CPU."
+            "(http://localhost:29000), so every bundle fetch fails with ECONNREFUSED."
         )
     for k in sorted(worker_keys - keys):
         failures.append(f"worker has {k}, but api does not")

--- a/charts/curie/ci/worker-object-store-assertions.sh
+++ b/charts/curie/ci/worker-object-store-assertions.sh
@@ -38,8 +38,11 @@ EOF
 # Capture Helm output in Python so a large manifest cannot be truncated by a
 # shell command substitution or redirected into the script's stdin.
 python3 - "$CHART" "$EXTERNAL_VALUES" <<'PY'
+import copy
+import io
 import subprocess
 import sys
+from contextlib import redirect_stdout
 
 import yaml
 
@@ -258,6 +261,92 @@ def assert_contract(docs, label, expected_endpoint):
     print(f"ok: {label}: S3_SECRET_KEY is a ref -> {ref['name']}/{ref['key']}")
 
 
-assert_contract(render(), "default", "http://curie-rustfs:9000")
+def probe_env(docs, kind, component, container_name, init=False):
+    for d in docs:
+        if d.get("kind") != kind:
+            continue
+        if d["metadata"].get("labels", {}).get("app.kubernetes.io/component") != component:
+            continue
+        pod_template = "template" if kind == "Deployment" else "podTemplate"
+        pod_spec = d["spec"][pod_template]["spec"]
+        containers = pod_spec.get("initContainers" if init else "containers", [])
+        matches = [c for c in containers if c.get("name") == container_name]
+        assert len(matches) == 1
+        return matches[0].get("env", [])
+    raise AssertionError(f"{kind} {component} was not rendered")
+
+
+def expect_failure(docs, messages):
+    captured = io.StringIO()
+    try:
+        with redirect_stdout(captured):
+            assert_contract(docs, "default probe", "http://curie-rustfs:9000")
+    except SystemExit as error:
+        assert error.code == 1
+    else:
+        raise AssertionError("object store contract probe unexpectedly passed")
+
+    output = captured.getvalue()
+    for message in messages:
+        assert message in output, f"missing diagnostic {message!r} in:\n{output}"
+    for unsupported in ("Traceback", "ClaimTimeoutError", "Slack turn", "CPU"):
+        assert unsupported not in output, f"unsupported diagnostic {unsupported!r} in:\n{output}"
+
+
+default_docs = render()
+assert_contract(default_docs, "default", "http://curie-rustfs:9000")
+
+missing_api_key = copy.deepcopy(default_docs)
+api_env = probe_env(missing_api_key, "Deployment", "api", "api")
+api_env[:] = [entry for entry in api_env if entry.get("name") != "S3_ACCESS_KEY"]
+expect_failure(
+    missing_api_key,
+    (
+        "api is missing object-store key S3_ACCESS_KEY",
+        "worker has S3_ACCESS_KEY, but api does not",
+    ),
+)
+
+three_divergences = copy.deepcopy(default_docs)
+api_env = probe_env(three_divergences, "Deployment", "api", "api")
+worker_env = probe_env(three_divergences, "Deployment", "worker", "worker")
+bundle_env = probe_env(
+    three_divergences,
+    "SandboxTemplate",
+    "agent-sandbox",
+    "bundle-fetch",
+    init=True,
+)
+api_env[:] = [entry for entry in api_env if entry.get("name") != "S3_ACCESS_KEY"]
+worker_endpoint = next(
+    entry for entry in worker_env if entry.get("name") == "S3_ENDPOINT_URL"
+)
+worker_endpoint.pop("valueFrom", None)
+worker_endpoint["value"] = "http://other-object-store:9000"
+bundle_bucket = next(
+    entry for entry in bundle_env if entry.get("name") == "BUNDLE_BUCKET"
+)
+bundle_bucket.pop("valueFrom", None)
+bundle_bucket["value"] = "other-bucket"
+expect_failure(
+    three_divergences,
+    (
+        "api is missing object-store key S3_ACCESS_KEY",
+        "worker has S3_ACCESS_KEY, but api does not",
+        "api and worker disagree on S3_ENDPOINT_URL",
+        "bundle fetch BUNDLE_BUCKET disagrees with api BUNDLE_BUCKET",
+    ),
+)
+
+unsupported_diagnostic = copy.deepcopy(default_docs)
+worker_env = probe_env(unsupported_diagnostic, "Deployment", "worker", "worker")
+worker_env[:] = [
+    entry for entry in worker_env if entry.get("name") != "S3_ACCESS_KEY"
+]
+expect_failure(
+    unsupported_diagnostic,
+    ("worker is missing S3_ACCESS_KEY",),
+)
+
 assert_contract(render(EXTERNAL_VALUES), "external", "https://s3.example.com:443")
 PY

--- a/charts/curie/ci/worker-object-store-assertions.sh
+++ b/charts/curie/ci/worker-object-store-assertions.sh
@@ -67,7 +67,7 @@ def has_usable_source(entry):
     return bool(entry.get("value")) or bool(entry.get("valueFrom"))
 
 
-def env_of(docs, kind, component, container_name, init=False):
+def container_env(docs, kind, component, container_name, init=False):
     """Select by the component LABEL and the container NAME.
 
     `endswith("-worker")` also matches `<release>-curie-langfuse-worker`, which
@@ -91,8 +91,13 @@ def env_of(docs, kind, component, container_name, init=False):
             f"{kind} {component} must render exactly one container named "
             f"{container_name}, got {len(matches)}"
         )
-        return {e["name"]: e for e in matches[0].get("env", [])}
+        return matches[0].get("env", [])
     return None
+
+
+def env_of(docs, kind, component, container_name, init=False):
+    env = container_env(docs, kind, component, container_name, init)
+    return None if env is None else {entry["name"]: entry for entry in env}
 
 
 def object_store_keys(env):
@@ -256,21 +261,6 @@ def assert_contract(docs, label, expected_endpoint):
     print(f"ok: {label}: S3_SECRET_KEY is a ref -> {ref['name']}/{ref['key']}")
 
 
-def probe_env(docs, kind, component, container_name, init=False):
-    for d in docs:
-        if d.get("kind") != kind:
-            continue
-        if d["metadata"].get("labels", {}).get("app.kubernetes.io/component") != component:
-            continue
-        pod_template = "template" if kind == "Deployment" else "podTemplate"
-        pod_spec = d["spec"][pod_template]["spec"]
-        containers = pod_spec.get("initContainers" if init else "containers", [])
-        matches = [c for c in containers if c.get("name") == container_name]
-        assert len(matches) == 1
-        return matches[0].get("env", [])
-    raise AssertionError(f"{kind} {component} was not rendered")
-
-
 def expect_failure(docs, messages):
     captured = io.StringIO()
     try:
@@ -292,7 +282,8 @@ default_docs = render()
 assert_contract(default_docs, "default", "http://curie-rustfs:9000")
 
 missing_api_key = copy.deepcopy(default_docs)
-api_env = probe_env(missing_api_key, "Deployment", "api", "api")
+api_env = container_env(missing_api_key, "Deployment", "api", "api")
+assert api_env is not None, "api Deployment was not rendered"
 api_env[:] = [entry for entry in api_env if entry.get("name") != "S3_ACCESS_KEY"]
 expect_failure(
     missing_api_key,
@@ -303,15 +294,18 @@ expect_failure(
 )
 
 three_divergences = copy.deepcopy(default_docs)
-api_env = probe_env(three_divergences, "Deployment", "api", "api")
-worker_env = probe_env(three_divergences, "Deployment", "worker", "worker")
-bundle_env = probe_env(
+api_env = container_env(three_divergences, "Deployment", "api", "api")
+assert api_env is not None, "api Deployment was not rendered"
+worker_env = container_env(three_divergences, "Deployment", "worker", "worker")
+assert worker_env is not None, "worker Deployment was not rendered"
+bundle_env = container_env(
     three_divergences,
     "SandboxTemplate",
     "agent-sandbox",
     "bundle-fetch",
     init=True,
 )
+assert bundle_env is not None, "SandboxTemplate bundle-fetch was not rendered"
 api_env[:] = [entry for entry in api_env if entry.get("name") != "S3_ACCESS_KEY"]
 worker_endpoint = next(
     entry for entry in worker_env if entry.get("name") == "S3_ENDPOINT_URL"
@@ -334,7 +328,8 @@ expect_failure(
 )
 
 unsupported_diagnostic = copy.deepcopy(default_docs)
-worker_env = probe_env(unsupported_diagnostic, "Deployment", "worker", "worker")
+worker_env = container_env(unsupported_diagnostic, "Deployment", "worker", "worker")
+assert worker_env is not None, "worker Deployment was not rendered"
 worker_env[:] = [
     entry for entry in worker_env if entry.get("name") != "S3_ACCESS_KEY"
 ]

--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -1951,6 +1951,7 @@ data:
         assert!(removed_stateful_components(&live, &rendered).is_empty());
     }
 
+    /// Source: https://github.com/helm/helm/blob/v3.16.4/pkg/kube/client.go#L452-L455
     /// Helm upgrade honors only the exact lowercase `keep` value.
     #[test]
     fn helm_upgrade_exact_keep_annotation_is_not_at_risk() {

--- a/docs/adr/AGENTS.md
+++ b/docs/adr/AGENTS.md
@@ -27,8 +27,12 @@ unless they also make such an architectural decision.
 3. Obtain explicit maintainer approval, then publish the status as `Accepted`.
    Existing code and implementation evidence cannot retroactively accept a
    Draft.
-4. Begin implementation only after acceptance. Track the work in a linked
-   GitHub issue and pull request.
+4. Acceptance is the authority for implementation. Normally, publish the ADR as
+   `Accepted` before beginning implementation. As the coordinated exception, an
+   ADR may land `Accepted` alongside implementation only with recorded explicit
+   maintainer approval and a named realizing code path. Without both, acceptance
+   must precede implementation. Track the work in a linked GitHub issue and pull
+   request.
 5. Revise a Draft through review. Once Accepted, preserve its body. Apply only
    the status, back link, pointer repair, and supersession rules in ADR 0045.
 6. Run `bash scripts/check-docs.sh` after any ADR change. Commit the regenerated

--- a/docs/adr/AGENTS.md
+++ b/docs/adr/AGENTS.md
@@ -1,7 +1,8 @@
 # ADR contributor procedure
 
-[ADR 0085](0085-acceptance-not-implementation-authorizes-an-adr.md) defines
-when an ADR authorizes implementation. [ADR 0045](0045-the-status-line-is-the-mutable-part-of-an-immutable-adr.md)
+[ADR 0085](0085-acceptance-not-implementation-authorizes-an-adr.md), as
+amended by [ADR 0102](0102-accepted-alongside-implementation-with-explicit-approval.md),
+defines when an ADR authorizes implementation. [ADR 0045](0045-the-status-line-is-the-mutable-part-of-an-immutable-adr.md)
 defines how Accepted ADR history is preserved.
 
 The ADR requirement applies only to product and platform architecture decisions

--- a/release/tests/test_authorize.py
+++ b/release/tests/test_authorize.py
@@ -889,6 +889,29 @@ def helm_ci_job_check_run_names() -> set[str]:
     return {job["name"] for job in doc["jobs"].values() if job.get("name")}
 
 
+class TestHelmCiCheckRunNames:
+    def test_expands_matrix_include_rows(self, tmp_path, monkeypatch):
+        workflow = tmp_path / "helm-ci.yaml"
+        workflow.write_text(
+            """\
+jobs:
+  chart:
+    name: Chart (${{ matrix.helm }})
+    strategy:
+      matrix:
+        include:
+          - helm: 3.16.4
+          - helm: 3.17.0
+"""
+        )
+        monkeypatch.setitem(globals(), "HELM_CI_YAML", workflow)
+
+        assert helm_ci_job_check_run_names() == {
+            "Chart (3.16.4)",
+            "Chart (3.17.0)",
+        }
+
+
 class TestReleaseWorkflowContract:
     def test_release_branch_sources_are_anchored_and_wired_to_authorization(self):
         source = RELEASE_YAML.read_text()

--- a/release/tests/test_authorize.py
+++ b/release/tests/test_authorize.py
@@ -855,8 +855,8 @@ RELEASE_YAML = REPO_ROOT / ".github" / "workflows" / "release.yaml"
 _MATRIX_REF = re.compile(r"\$\{\{\s*matrix\.([A-Za-z0-9_]+)\s*\}\}")
 
 
-def ci_job_check_run_names() -> set[str]:
-    """The concrete check-run names ci.yaml's jobs produce (issue #811).
+def workflow_job_check_run_names(path: Path) -> set[str]:
+    """The concrete check-run names a workflow's jobs produce (issue #811).
 
     Parses the real workflow rather than any list derived from
     `REQUIRED_CHECK_NAMES` -- deriving the expected set from the constant
@@ -868,7 +868,7 @@ def ci_job_check_run_names() -> set[str]:
     literal `matrix.name`), so a future job that matrixes on a different key
     is handled without editing this helper. A job with no `name:` is skipped.
     """
-    doc = yaml.safe_load(CI_YAML.read_text())
+    doc = yaml.safe_load(path.read_text())
     names: set[str] = set()
     for job in doc["jobs"].values():
         name = job.get("name")
@@ -884,9 +884,12 @@ def ci_job_check_run_names() -> set[str]:
     return names
 
 
+def ci_job_check_run_names() -> set[str]:
+    return workflow_job_check_run_names(CI_YAML)
+
+
 def helm_ci_job_check_run_names() -> set[str]:
-    doc = yaml.safe_load(HELM_CI_YAML.read_text())
-    return {job["name"] for job in doc["jobs"].values() if job.get("name")}
+    return workflow_job_check_run_names(HELM_CI_YAML)
 
 
 class TestHelmCiCheckRunNames:


### PR DESCRIPTION
## Summary

Fixes the eleven numbered correctness and accuracy papercuts in issue 1473. The issue introduction says ten, but its title and numbered list say eleven, so the numbered list is authoritative.

## Coverage

1. The duplicate Helm CI invocation was already removed on main, and the existing exact one to one regression test remains green.
2. Missing API object store keys now have a reverting probe that requires the named diagnostic and kills unchecked indexing.
3. Three simultaneous object store divergences now have a reverting probe that requires every diagnostic from one invocation.
4. The copied unsupported Slack turn, ClaimTimeoutError, and CPU narrative is removed from the script header and operator diagnostic. The original Helm CI and worker template comments remain owned by open issue 1453.
5. Secret scanning documentation now names both main and next.
6. Security documentation now accurately describes the single Default ruleset, its exact gitleaks context, CodeQL enforcement, and singular bypass actor. The false strict freshness and dependency audit claims were intentionally corrected from live ruleset 18711121.
7. The local wire lock recipe defaults to main and documents base=next for next worktrees.
8. Both named ADR procedures and the third agent instruction site now encode ADR 0102 coordinated acceptance consistently.
9. The redundant release train checkboxes are removed from the PR template.
10. The exact lowercase Helm keep assertion cites the pinned Helm v3.16.4 source.
11. CI and Helm CI check names now share matrix expansion, with a two row reverting fixture.

Closes #1473

## Verification

1. `curie dev chart-check` passed all 20 chart assertion scripts on 7baa1378.
2. `cd cli && cargo fmt --check && cargo clippy -- -D warnings && cargo test` passed the complete CLI suite.
3. `uv run ruff check release/tests/test_authorize.py`, `uv run mypy`, and `uv run pytest -q release/tests/test_authorize.py` passed with 63 tests.
4. `bash scripts/check-docs.sh` passed with a drift free interface catalog and resolving citations.
5. `CURIE_BIN=/home/theconnman/.cargo/shared-targets/agentos/debug/curie CURIE_E2E_TIERS=local curie dev e2e-ladder` passed on 7baa1378 in fake mode. It deployed one weather version, verified the running worker mode, finalized a real local turn with reply `all done`, checked suite parity, stopped the stack, and left no Curie containers.
6. Five mutations were executed and reverted. Duplicate workflow invocation, unchecked API indexing, first failure only reporting, restored unsupported diagnostic text, and raw Helm matrix names each failed its named regression test.

## Tier decision

1. Skill is not applicable because plugin packaging, the runner loop, ACI events, and skill verbs are untouched.
2. Local is required and passed because the changed diagnostic is surfaced through `curie dev chart-check`.
3. Local release is not applicable because binary identity, images, install paths, version pins, and release Compose are untouched.
4. Cluster is not applicable because no chart template, RBAC, security context, network policy, sandbox claim, or init container behavior changed.
5. Live provider is not applicable because model routing, credentials, tokens, and cost accounting are untouched.
6. External integration is not applicable because Slack, webhooks, OAuth, and third party API behavior are untouched.

## Done check

[x] Failing tests were committed before implementation in b0f423eb.

[x] All source, test, and documentation edits were performed by delegated native workers.

[N/A] No public return type was broadened.

[x] Cross engine code review approved with no blocking findings.

[x] Cross engine scope review approved every hunk and the issue 1453 boundary.

[x] Sibling parity is pinned for Helm CI versus chart check, branch aware wire lock guidance, and CI versus Helm CI matrix expansion.

[x] Guard behavior was demonstrated with five executed mutations and restored clean passes.

[x] Consolidation shared the chart container selector, passed all chart assertions, and received cross engine approval.

[N/A] Security review was not triggered because no authorization, secret handling, or data boundary changed.

[x] Observable chart diagnostic behavior passed through the real chart check surface.

[x] The required local end to end rung passed on the final branch.

[x] Full affected tests, lint, type checking, docs lint, commit message checks, and shell syntax checks are clean.
