### PR TITLE
Release 0.6.2

### DIFF
--- a/charts/curie/Chart.yaml
+++ b/charts/curie/Chart.yaml
@@ -8,8 +8,8 @@ description: >-
   and two install-time preflights ship baked in: a CPU-AVX / ClickHouse-pin
   check and a NetworkPolicy-enforcement probe.
 type: application
-version: 0.6.1
-appVersion: "0.6.1"
+version: 0.6.2
+appVersion: "0.6.2"
 kubeVersion: ">=1.25.0-0"
 maintainers:
   - name: Curie

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -749,7 +749,7 @@ dependencies = [
 
 [[package]]
 name = "curie"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anstream",
  "anstyle",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "curie"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 description = "Curie CLI: init/start/send/eval a plugin against a local runner (task I1)"
 


### PR DESCRIPTION
Sets main's in-tree version to 0.6.2 so a v0.6.2 tag publishes assets that self-report the version they are.

Touches the same three files as every prior release commit: `charts/curie/Chart.yaml` version and appVersion, `cli/Cargo.toml`, and the single `curie` entry in `cli/Cargo.lock`. Produced by `curie dev bump-version 0.6.2`, so the lock entry is matched on the `[[package]]` block rather than by string replacement.

`scripts/check-version-consistency.sh` reports all three fields agree at 0.6.2.

The annotated `v0.6.2` tag goes on the merge commit of this PR once its required checks are green.