### PR TITLE
Cut dev profile debug info to line tables only

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -95,3 +95,16 @@ syn = { version = "3", features = ["full", "visit", "extra-traits"] }
 # parsed `syn::Block` (`ToTokens::to_token_stream`) to hand that walk its input.
 proc-macro2 = "1"
 quote = "1"
+
+# Dev builds carried full DWARF, which dominated the target dir. A section dump
+# of one 181MB integration test binary measured .text at 3.5MB against roughly
+# 175MB of .debug_* sections, so about 97% of every artifact was debug info.
+# With 41 integration test targets in cli/tests, each statically linking the
+# whole crate graph, a single target dir reached 175G.
+#
+# line-tables-only keeps file and line numbers in panics and backtraces, which
+# is what the test suite and local debugging actually read. It drops type and
+# variable DWARF, so a step debugger will not resolve locals. For that, build
+# the one target you are debugging with CARGO_PROFILE_DEV_DEBUG=2.
+[profile.dev]
+debug = "line-tables-only"


### PR DESCRIPTION
Dev builds emitted full DWARF, which dominated the Cargo target directory.

A section dump of one 181MB integration test binary measured `.text` at 3.5MB against roughly 175MB of `.debug_*` sections, so about 97% of each artifact was debug info. With 41 integration test targets in `cli/tests`, each statically linking the whole crate graph, a single shared target directory reached 175G in five days.

Setting `debug = "line-tables-only"` on the dev profile:

| | before | after |
|---|---|---|
| `curie` test binary | 181.4 MB | 56.5 MB |
| `.debug_info` | 69.8 MB | 9.0 MB |
| `.text` | 3.5 MB | 3.2 MB |
| average artifact | 139 MB | 34 MB |
| full test binary set, one hash variant | n/a | 2.22 G |

`.text` is unchanged, so the compiled code is identical; only debug info is dropped.

Panics and backtraces keep file and line numbers, which is what the test suite reads. Type and variable DWARF is dropped, so a step debugger will not resolve locals. For that, build the single target you are debugging with `CARGO_PROFILE_DEV_DEBUG=2`.

Verified with `cargo test --no-run` from a clean target directory, exit 0, all 41 integration test binaries plus the lib and bin tests built.