### PR TITLE
Reconcile a v0.6.x database onto the v0.7.0 migration chain

### DIFF
--- a/apps/api/alembic/versions/0021a_agent_channels_reconcile.py
+++ b/apps/api/alembic/versions/0021a_agent_channels_reconcile.py
@@ -1,0 +1,85 @@
+"""reconcile a v0.6.x database that never ran 0021_agent_channels (#1705)
+
+Revision id `0021` means two different things across the release train. On the
+v0.6.x line it is `0021_console_sessions`; on this line it is
+`0021_agent_channels`, and console_sessions was renumbered to `0026`. Both sides
+declare `down_revision = "0020"`, so a v0.6.x database is already stamped `0021`
+meaning "console_sessions applied". This chain reads that stamp, concludes
+`0021_agent_channels` has run, skips it, and starts at `0022`, which joins a
+`curie.agent_channels` that was never created.
+
+Renumbering is not available as a fix. v0.6.2 is published and operator
+databases carry `0021` meaning console_sessions, so every revision id that has
+shipped has to keep the meaning it shipped with. This revision sits between
+`0021` and `0022` instead and reconciles whichever of the two meanings the
+database in front of it actually carries: on a fresh install `agent_channels` is
+already there and there is nothing to do, and on a v0.6.x database the binding
+table, its constraints and its backfill all still have to land before `0022` can
+read them.
+
+It executes `0021_agent_channels.upgrade()` rather than restating that
+migration's statements. The two paths have to converge on the same schema, and
+executing the same statements is the only way to guarantee they do: a second
+copy of the CREATE TABLE, the two named unique constraints and the
+`INSERT ... SELECT` would be free to diverge from the original.
+
+That matters most for the half that is not DDL. 0021's own docstring records
+that the BACKFILL is the migration, and that creating the table without the
+`INSERT ... SELECT` produces a perfectly valid empty table and silently unbinds
+every agent in the install: deployed, healthy looking, answering nothing. A
+reconciliation that created an empty table would be worse than the crash it
+replaces, because a crash stops the rollout and an empty table does not.
+
+`downgrade` is deliberately a no-op. 0021 still sits below this revision and
+still owns the inverse of its own upgrade, so undoing the work here as well
+would leave that downgrade with nothing to drop. Walking down through this
+revision therefore lands on the v0.7 shape of `0020`, which is where the chain
+below it expects to be.
+
+Revision ID: 0021a
+Revises: 0021
+Create Date: 2026-08-19
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0021a"
+down_revision: str | None = "0021"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+SCHEMA = "curie"
+TABLE = "agent_channels"
+
+# The revision whose effect this one replays. Named rather than resolved
+# relative to this revision: a later insertion above 0021 would silently
+# re-point a relative reference at the wrong migration.
+AGENT_CHANNELS_REVISION = "0021"
+
+
+def upgrade() -> None:
+    already_applied = (
+        op.get_bind().execute(sa.text(f"SELECT to_regclass('{SCHEMA}.{TABLE}')")).scalar()
+        is not None
+    )
+    if already_applied:
+        return
+
+    script = op.get_context().script
+    if script is None:
+        raise RuntimeError(
+            "cannot reconcile a v0.6.x database (#1705): this revision replays "
+            f"{AGENT_CHANNELS_REVISION} and needs the alembic script directory to reach "
+            "it, but the migration context was configured without one. Run the upgrade "
+            "through the alembic command API (`alembic upgrade head`) rather than a "
+            "bare MigrationContext."
+        )
+
+    script.get_revision(AGENT_CHANNELS_REVISION).module.upgrade()
+
+
+def downgrade() -> None:
+    """No-op: 0021 below still owns the inverse of the work replayed here."""

--- a/apps/api/alembic/versions/0022_approvals_reply_kind.py
+++ b/apps/api/alembic/versions/0022_approvals_reply_kind.py
@@ -65,7 +65,7 @@ old API pod inserting during the window must fail loudly rather than fabricate a
 kind.
 
 Revision ID: 0022
-Revises: 0021
+Revises: 0021a
 Create Date: 2026-08-13
 """
 
@@ -76,7 +76,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision: str = "0022"
-down_revision: str | None = "0021"
+down_revision: str | None = "0021a"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/apps/api/alembic/versions/0026_console_sessions.py
+++ b/apps/api/alembic/versions/0026_console_sessions.py
@@ -11,6 +11,14 @@ Nothing reads this table yet. Slice 1 lands the store and the two exchange
 endpoints wired to nothing; ``require_api_key`` starts accepting a session in
 slice 2 (#1045).
 
+This same DDL shipped on the v0.6.x line as revision ``0021``, which is the id
+this line spends on ``0021_agent_channels`` (#1705). So a database upgrading
+from v0.6.x already holds ``console_sessions``, created by byte identical
+statements, and reaches this revision with the work already done. ``upgrade``
+therefore checks before it creates: without that check the upgrade path dies on
+a DuplicateTableError, one revision after the reconciliation that carried the
+binding table across.
+
 Revision ID: 0026
 Revises: 0025
 Create Date: 2026-07-28
@@ -30,6 +38,15 @@ SCHEMA = "curie"
 
 
 def upgrade() -> None:
+    already_created = (
+        op.get_bind()
+        .execute(sa.text(f"SELECT to_regclass('{SCHEMA}.console_sessions')"))
+        .scalar()
+        is not None
+    )
+    if already_created:
+        return
+
     op.create_table(
         "console_sessions",
         sa.Column(

--- a/apps/api/tests/test_migration_0021a_v0_6_x_reconcile.py
+++ b/apps/api/tests/test_migration_0021a_v0_6_x_reconcile.py
@@ -1,0 +1,173 @@
+"""A v0.6.x database must be able to reach head (#1705).
+
+Revision id `0021` means `console_sessions` on the v0.6.x line and
+`agent_channels` on this one, and both sides declare `down_revision = "0020"`.
+So a v0.6.x database arrives already stamped `0021`, this chain concludes
+`0021_agent_channels` has run, skips it, and `0022` joins a `curie.agent_channels`
+that was never created. `0021a_agent_channels_reconcile` closes that, and `0026`
+then has to skip a `console_sessions` table the database already holds.
+
+No gate in this repo saw it, because every tier builds its database from zero.
+This test builds one that does not: this tree's own `0001`..`0020` (byte
+identical on both release lines), plus the `console_sessions` DDL that shipped
+as v0.6.2's `0021`, stamped `0021`. That DDL is written out here rather than
+borrowed from `0026`: it is frozen released history, and a fixture that read the
+current tree for it would stop describing what operators actually hold the
+moment that revision is touched.
+
+Two separate failures are asserted, because the first one hides the second, and
+because reaching head is not on its own the property that matters. 0021's own
+docstring is explicit that creating `agent_channels` without the
+`INSERT ... SELECT` produces a perfectly valid empty table and silently unbinds
+every agent in the install, so a reconciliation that skipped the backfill would
+satisfy a "reaches head" assertion while being worse than the crash it replaced.
+
+Follows `test_migration_0021_agent_channels.py`: a throwaway database all to
+itself via `isolated_migration_db`, real Postgres, no mocking.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from pathlib import Path
+from typing import Any
+
+from alembic import command
+from alembic.config import Config
+from curie_api.config import get_settings
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlalchemy.sql import text
+
+ALEMBIC_DIR = Path(__file__).resolve().parents[1] / "alembic"
+
+# The last revision the two release lines agree on. Above it, `0021` forks.
+SHARED = "0020"
+
+# The stamp a v0.6.x database carries: its own `0021_console_sessions`.
+V062_HEAD = "0021"
+
+# The DDL v0.6.2's `0021_console_sessions` left behind, transcribed. Renumbered
+# to `0026` on this line with its statements unchanged, which is why the upgrade
+# path finds the table already there.
+V062_CONSOLE_SESSIONS_DDL = """
+    CREATE TABLE curie.console_sessions (
+        id UUID NOT NULL,
+        login_code_hash VARCHAR NOT NULL,
+        login_code_expires_at TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+        session_token_hash VARCHAR,
+        session_expires_at TIMESTAMP WITHOUT TIME ZONE,
+        consumed_at TIMESTAMP WITHOUT TIME ZONE,
+        revoked_at TIMESTAMP WITHOUT TIME ZONE,
+        created_at TIMESTAMP WITHOUT TIME ZONE DEFAULT now() NOT NULL,
+        PRIMARY KEY (id)
+    )
+"""
+V062_CONSOLE_SESSIONS_INDEXES = (
+    "CREATE UNIQUE INDEX ix_console_sessions_login_code_hash "
+    "ON curie.console_sessions (login_code_hash)",
+    "CREATE UNIQUE INDEX ix_console_sessions_session_token_hash "
+    "ON curie.console_sessions (session_token_hash)",
+)
+
+BINDINGS = (("acme-bot", "C0EXAMPLE1"), ("acme-ops", "C0EXAMPLE2"))
+
+
+def _sql(statement: str, params: dict[str, Any] | None = None) -> list[Any]:
+    """Run one statement against the isolated migration database."""
+
+    async def _go() -> list[Any]:
+        engine = create_async_engine(get_settings().database_url)
+        try:
+            async with engine.begin() as conn:
+                result = await conn.execute(text(statement), params or {})
+                return list(result.all()) if result.returns_rows else []
+        finally:
+            await engine.dispose()
+
+    return asyncio.run(_go())
+
+
+def _alembic_config() -> Config:
+    cfg = Config()
+    cfg.set_main_option("script_location", str(ALEMBIC_DIR))
+    return cfg
+
+
+def _seed_v062_database() -> None:
+    """Build a database in exactly the shape v0.6.2 leaves behind."""
+
+    command.upgrade(_alembic_config(), SHARED)
+    for name, channel in BINDINGS:
+        _sql(
+            "INSERT INTO curie.agents (id, name, slack_channel) VALUES (:id, :name, :ch)",
+            {"id": uuid.uuid4(), "name": name, "ch": channel},
+        )
+    _sql(V062_CONSOLE_SESSIONS_DDL)
+    for statement in V062_CONSOLE_SESSIONS_INDEXES:
+        _sql(statement)
+    _sql(
+        "UPDATE curie.alembic_version SET version_num = :rev",
+        {"rev": V062_HEAD},
+    )
+
+
+def _stamped_revision() -> str:
+    rows = _sql("SELECT version_num FROM curie.alembic_version")
+    assert len(rows) == 1, rows
+    revision: str = rows[0][0]
+    return revision
+
+
+def test_v0_6_x_database_reaches_head_with_its_bindings_carried_over(
+    isolated_migration_db: None,
+) -> None:
+    _seed_v062_database()
+    assert _stamped_revision() == V062_HEAD
+
+    command.upgrade(_alembic_config(), "head")
+
+    assert _stamped_revision() == "0027"
+
+    # The backfill IS the migration: an empty table here is every agent
+    # deployed, healthy looking and unroutable.
+    bindings = _sql(
+        "SELECT a.name, c.kind, c.address FROM curie.agent_channels c "
+        "JOIN curie.agents a ON a.id = c.agent_id ORDER BY a.name"
+    )
+    assert [tuple(row) for row in bindings] == [
+        (name, "slack", channel) for name, channel in BINDINGS
+    ]
+
+    # The legacy column and its named constraint went with it, exactly as they
+    # do on a fresh install.
+    assert (
+        _sql(
+            "SELECT 1 FROM information_schema.columns WHERE table_schema = 'curie' "
+            "AND table_name = 'agents' AND column_name = 'slack_channel'"
+        )
+        == []
+    )
+
+    # Re-running the upgrade against the already-upgraded database is a no-op.
+    command.upgrade(_alembic_config(), "head")
+    assert _stamped_revision() == "0027"
+    assert len(_sql("SELECT 1 FROM curie.agent_channels")) == len(BINDINGS)
+
+
+def test_v0_6_x_console_sessions_survives_the_upgrade(
+    isolated_migration_db: None,
+) -> None:
+    _seed_v062_database()
+
+    command.upgrade(_alembic_config(), "head")
+
+    indexes = _sql(
+        "SELECT indexname FROM pg_indexes WHERE schemaname = 'curie' "
+        "AND tablename = 'console_sessions' ORDER BY indexname"
+    )
+    assert [row[0] for row in indexes] == [
+        "console_sessions_pkey",
+        "ix_console_sessions_login_code_hash",
+        "ix_console_sessions_session_token_hash",
+    ]


### PR DESCRIPTION
## What breaks

A v0.6.x cluster cannot be upgraded to v0.7.0. The chart runs `alembic upgrade head` as the API deployment's `migrate` init container, so on `helm upgrade` from v0.6.x that container dies and the API pod never starts:

```
sqlalchemy.exc.ProgrammingError: asyncpg.exceptions.UndefinedTableError:
relation "curie.agent_channels" does not exist
```

## Root cause

Revision id `0021` means two different things across the release train, and both sides declare `down_revision = "0020"`:

| Revision | `main` / v0.6.2 | `next` / v0.7.0-rc.1 |
|---|---|---|
| `0021` | `0021_console_sessions` | `0021_agent_channels` |
| `0026` | does not exist | `0026_console_sessions` |

So a v0.6.x database arrives stamped `0021` meaning "console_sessions applied". This chain reads that stamp, concludes `0021_agent_channels` already ran, skips it, and starts at `0022`, which joins a `curie.agent_channels` that was never created.

There is a second failure behind the first: `0026_console_sessions` creates a table the v0.6.x database already holds, so once `0022` is past it dies on a `DuplicateTableError`.

## The design

Renumbering is not available. v0.6.2 is published and operator databases carry `0021` meaning console_sessions, so every revision id that has shipped has to keep the meaning it shipped with. Instead:

1. **New revision `0021a`, between `0021` and `0022`.** It checks whether `curie.agent_channels` exists. On a fresh install it does, `0021` ran, and this is a no-op. On a v0.6.x database it does not, and the reconciliation lands the binding table before `0022` reads it. `0022` is repointed at `0021a`.
2. **`0021a` executes `0021_agent_channels.upgrade()` rather than restating it.** The two paths have to converge on the same schema, and running the same statements is the only way to guarantee they do. It matters most for the half that is not DDL: 0021's own docstring records that the BACKFILL is the migration, and that creating `agent_channels` without the `INSERT ... SELECT` produces a valid empty table and silently unbinds every agent in the install, deployed, healthy looking and answering nothing. A reconciliation that created an empty table would pass a "reaches head" check while being worse than the crash it replaced.
3. **`0026` checks before it creates.** The v0.6.x line shipped byte identical DDL as its own `0021`, so on the upgrade path the work is already done.
4. `0021a`'s `downgrade` is a no-op: `0021` still sits below it and still owns the inverse of its own upgrade.

`0023`, `0024`, `0025` and `0027` were checked for the same class of assumption and need no change: `0001`..`0020` are byte identical on both lines, so `console_sessions` is the only thing a v0.6.x database holds that this line's `0020` does not.

## Verification

A genuinely v0.6.2-initialized Postgres (built from a `v0.6.2` checkout, seeded with two agents on distinct `slack_channel` values and one pending approval), then upgraded with this branch:

```
Running upgrade 0021 -> 0021a, reconcile a v0.6.x database that never ran 0021_agent_channels (#1705)
Running upgrade 0021a -> 0022, approvals carry their own routing half: reply_kind + reply_adapter (#1459)
Running upgrade 0022 -> 0023, binding uniqueness widens from address to (kind, address) (#1459)
Running upgrade 0023 -> 0024, a binding gets its server-controlled route and its rebind generation (#1459)
Running upgrade 0024 -> 0025, allow approvals without a reply placeholder (#1528)
Running upgrade 0025 -> 0026, console_sessions: the store behind revocable console sessions (#1044)
Running upgrade 0026 -> 0027, agents.hook_generation: the rotation counter behind derived hook secrets (#269)
```

The bindings survived, and the approval took its kind from its own binding:

```
 kind  |  address   |   name
-------+------------+----------
 slack | C0EXAMPLE1 | acme-bot
 slack | C0EXAMPLE2 | acme-ops
```

A 126 line schema inventory (tables, columns with types, nullability and defaults, every index definition, every constraint name and definition) dumped from the upgraded database and from a fresh install of this branch diffs empty. Re-running `alembic upgrade head` against the upgraded database is a clean no-op and leaves the inventory unchanged.

The new test was watched failing against the unfixed tree with `UndefinedTableError`, and failing again with only the `0026` guard removed with `DuplicateTableError`, before passing with the full change.

Gates: `ruff check .`, `mypy` (188 files), the alembic revision gate (`head 0027`), import boundaries, the docs gate and the wire tolerance gate all pass. `pytest apps/api -q` reports 786 passed, 95 skipped, 4 failed; all 4 fail identically on unmodified `next` in the same environment and are artifacts of running against private Postgres/Valkey/RustFS ports instead of the compose dev stack, which was deliberately not started on this box.

The gate hole itself (no CI job migrates a database stamped by the other release line) is left to its own issue, as #1705 suggests.

Closes #1705
