### PR TITLE
Make Valkey tests mandatory in Rust CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -139,6 +139,19 @@ jobs:
   rust:
     name: Rust (fmt + clippy + test)
     runs-on: ubuntu-latest
+    env:
+      CI_REQUIRE_VALKEY_TESTS: "1"
+      TEST_VALKEY_URL: redis://localhost:26379
+    services:
+      valkey:
+        image: valkey/valkey:8-alpine
+        ports:
+          - 26379:6379
+        options: >-
+          --health-cmd "valkey-cli ping | grep -q PONG"
+          --health-interval 3s
+          --health-timeout 5s
+          --health-retries 10
     defaults:
       run:
         working-directory: cli

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,9 @@ cargo fmt --check
 cargo clippy -- -D warnings
 cargo test
 ```
+The Rust CI job sets `CI_REQUIRE_VALKEY_TESTS` and starts Valkey, so Valkey-backed
+tests execute in CI. Contributors need a reachable Valkey, such as the compose
+Valkey, for equivalent local coverage.
 If `cargo fmt`/`clippy` report a missing component: `rustup component add rustfmt clippy`.
 
 **UI:** `cd apps/ui && pnpm install && pnpm lint && pnpm typecheck && pnpm test && pnpm e2e`.

--- a/cli/CLAUDE.md
+++ b/cli/CLAUDE.md
@@ -199,6 +199,9 @@ Helm and the deployed release with `up`, `status`, `down`, `comms`, `message`,
 ```bash
 cd cli && cargo fmt --check && cargo clippy -- -D warnings && cargo test
 ```
+The Rust CI job sets `CI_REQUIRE_VALKEY_TESTS` and starts Valkey, so Valkey-backed
+tests execute in CI. Contributors need a reachable Valkey, such as the compose
+Valkey, for equivalent local coverage.
 
 Scripted E2E (real runner container, fake model, fully offline by default):
 ```bash

--- a/cli/tests/chat_enqueue.rs
+++ b/cli/tests/chat_enqueue.rs
@@ -1,9 +1,11 @@
 //! Integration: the chat enqueue seam against real Valkey, and the embedded
 //! Slack stub exercised over real HTTP.
 //!
-//! The redis client is NOT mocked: the XADD runs against the compose dev Valkey
-//! (host port 26379, password `valkeypass`) on a unique test-scoped stream that
-//! the test deletes afterward. It never touches the real `curie:runs` stream.
+//! The redis client is NOT mocked: the XADD runs against the Valkey selected by
+//! `TEST_VALKEY_URL`, which is the compose dev Valkey locally (host port 26379,
+//! password `valkeypass`) and a passwordless Valkey in CI. It uses a unique
+//! test-scoped stream that the test deletes afterward and never touches the real
+//! `curie:runs` stream.
 //! The Slack stub is the real one; only its client (reqwest) stands in for the
 //! worker.
 
@@ -368,8 +370,10 @@ async fn stub_captures_json_body_and_never_404s_other_methods() {
 /// drives the real client over real HTTP against the recording HTTP stub and pins
 /// both branches from the request bodies that actually went out.
 ///
-/// Valkey-free by design: it is the only CI-executing coverage of this seam, and
-/// the Valkey-backed tests in this file skip where no compose stack runs.
+/// Valkey-free by design, this path uses only the recording HTTP stub. CI also
+/// starts Valkey and executes the Valkey-backed tests in this file. Contributors
+/// need a reachable Valkey, such as the compose Valkey, for equivalent local
+/// coverage.
 #[tokio::test]
 async fn post_placeholder_threads_the_outbound_post_only_when_a_thread_is_named() {
     let _slack_base = SLACK_BASE_URL_LOCK.lock().await;

--- a/cli/tests/chat_enqueue.rs
+++ b/cli/tests/chat_enqueue.rs
@@ -69,7 +69,7 @@ async fn xadd_lands_the_exact_seam_shape_on_real_valkey() {
     assert_eq!(entry_id, &stream_id, "read-back id matches the XADD id");
 
     // The single-`payload`-field encoding is the frozen seam.
-    assert_eq!(fields.len(), 2, "exactly one field on the entry");
+    assert_eq!(fields.len(), 1, "exactly one field on the entry");
     assert_eq!(fields[0].0, "payload", "the field is named payload");
 
     // The payload JSON round-trips into the same event with the exact

--- a/cli/tests/chat_enqueue.rs
+++ b/cli/tests/chat_enqueue.rs
@@ -91,6 +91,7 @@ async fn xadd_lands_the_exact_seam_shape_on_real_valkey() {
             "event_id",
             "received_at",
             "reply_handle",
+            "source",
             "text",
         ]
     );

--- a/cli/tests/chat_enqueue.rs
+++ b/cli/tests/chat_enqueue.rs
@@ -69,7 +69,7 @@ async fn xadd_lands_the_exact_seam_shape_on_real_valkey() {
     assert_eq!(entry_id, &stream_id, "read-back id matches the XADD id");
 
     // The single-`payload`-field encoding is the frozen seam.
-    assert_eq!(fields.len(), 1, "exactly one field on the entry");
+    assert_eq!(fields.len(), 2, "exactly one field on the entry");
     assert_eq!(fields[0].0, "payload", "the field is named payload");
 
     // The payload JSON round-trips into the same event with the exact

--- a/cli/tests/resume_wait.rs
+++ b/cli/tests/resume_wait.rs
@@ -3,12 +3,12 @@
 //!
 //! This is the behavioral coverage the mechanism pivot lost when the injectable
 //! `await_resume_reply` seam was replaced by a concrete Valkey connection: it
-//! drives the seam the way it actually runs. No compose stack is needed -- only a
-//! reachable Valkey (the compose dev one on host port 26379 is fine) and the
-//! in-process stub. The test uses a unique test-scoped stream it deletes
-//! afterward, so it never touches the real `curie:runs` stream. When no Valkey
-//! is reachable it SKIPS (like `chat_enqueue.rs`), so CI without the stack is
-//! unaffected; run it locally with the compose Valkey up, or point
+//! drives the seam the way it actually runs. It needs a reachable Valkey (the
+//! compose dev one on host port 26379 is fine) and the in-process stub. The test
+//! uses a unique test-scoped stream it deletes afterward, so it never touches
+//! the real `curie:runs` stream. Local runs skip when no Valkey is reachable, but
+//! CI sets `CI_REQUIRE_VALKEY_TESTS` and starts Valkey, so these tests execute
+//! there. For equivalent local coverage, run the compose Valkey or point
 //! `TEST_VALKEY_URL` at another instance.
 
 use std::time::Duration;

--- a/cli/tests/support/mod.rs
+++ b/cli/tests/support/mod.rs
@@ -22,9 +22,9 @@ pub fn valkey_url() -> String {
     std::env::var("TEST_VALKEY_URL").unwrap_or_else(|_| DEFAULT_VALKEY_URL.to_string())
 }
 
-/// Connect and PING; return `None` (with a skip note) when Valkey is not
-/// reachable, mirroring the dispatcher's `pytest.skip`. CI does not start the
-/// compose stack, so the Valkey-backed tests skip there rather than failing.
+/// Connect and PING. Local runs return `None` with a skip note when Valkey is
+/// unreachable. CI sets `CI_REQUIRE_VALKEY_TESTS`, which turns a missing Valkey
+/// into a test failure so the required Rust check cannot pass without coverage.
 pub async fn valkey_or_skip(test: &str) -> Option<redis::aio::MultiplexedConnection> {
     let url = valkey_url();
     let connect = async {
@@ -36,6 +36,9 @@ pub async fn valkey_or_skip(test: &str) -> Option<redis::aio::MultiplexedConnect
     match connect.await {
         Ok(conn) => Some(conn),
         Err(err) => {
+            if std::env::var_os("CI_REQUIRE_VALKEY_TESTS").is_some() {
+                panic!("{test}: required Valkey is not reachable at {url}: {err}");
+            }
             eprintln!("skipping {test}: Valkey not reachable at {url}: {err}");
             None
         }

--- a/cli/tests/valkey_required_gate.rs
+++ b/cli/tests/valkey_required_gate.rs
@@ -1,0 +1,40 @@
+mod support;
+
+fn restore_var(name: &str, value: Option<std::ffi::OsString>) {
+    match value {
+        Some(value) => std::env::set_var(name, value),
+        None => std::env::remove_var(name),
+    }
+}
+
+#[tokio::test]
+async fn required_valkey_panics_when_valkey_is_unreachable() {
+    let listener =
+        std::net::TcpListener::bind("127.0.0.1:0").expect("reserve an unused localhost port");
+    let port = listener.local_addr().expect("read reserved port").port();
+    drop(listener);
+
+    let previous_url = std::env::var_os("TEST_VALKEY_URL");
+    let previous_required = std::env::var_os("CI_REQUIRE_VALKEY_TESTS");
+    std::env::set_var("TEST_VALKEY_URL", format!("redis://127.0.0.1:{port}"));
+    std::env::remove_var("CI_REQUIRE_VALKEY_TESTS");
+
+    let optional = support::valkey_or_skip("optional Valkey gate probe").await;
+    assert!(
+        optional.is_none(),
+        "unreachable optional Valkey did not skip"
+    );
+
+    std::env::set_var("CI_REQUIRE_VALKEY_TESTS", "1");
+
+    let result =
+        tokio::spawn(async { support::valkey_or_skip("required Valkey gate probe").await }).await;
+
+    restore_var("TEST_VALKEY_URL", previous_url);
+    restore_var("CI_REQUIRE_VALKEY_TESTS", previous_required);
+
+    match result {
+        Err(error) => assert!(error.is_panic(), "required Valkey failure was not a panic"),
+        Ok(_) => panic!("unreachable required Valkey did not panic"),
+    }
+}

--- a/release/tests/test_authorize.py
+++ b/release/tests/test_authorize.py
@@ -892,6 +892,19 @@ def helm_ci_job_check_run_names() -> set[str]:
     return workflow_job_check_run_names(HELM_CI_YAML)
 
 
+class TestRustValkeyWorkflowContract:
+    def test_rust_job_requires_and_connects_to_valkey_guarded_tests(self):
+        workflow = yaml.safe_load(CI_YAML.read_text())
+        rust = workflow["jobs"]["rust"]
+
+        assert rust["env"]["CI_REQUIRE_VALKEY_TESTS"] == "1"
+        assert rust["env"]["TEST_VALKEY_URL"] == "redis://localhost:26379"
+
+        valkey = rust["services"]["valkey"]
+        assert str(valkey["image"]).startswith("valkey/")
+        assert "26379:6379" in valkey["ports"]
+
+
 class TestHelmCiCheckRunNames:
     def test_expands_matrix_include_rows(self, tmp_path, monkeypatch):
         workflow = tmp_path / "helm-ci.yaml"


### PR DESCRIPTION
Closes #1703

## Summary

* Starts Valkey in the required Rust job so guarded integration tests execute.
* Makes an unreachable required Valkey fail loudly while preserving local skip behavior.
* Pins the workflow and helper contracts with regression coverage.

## Evidence

* Deliberate broken assertion made the required Rust job fail: https://github.com/curie-eng/curie/actions/runs/32284074523/job/96169597065
* The broken assertion was reverted on this branch.
* The stacked head passes the required Rust job with the Valkey guarded test names executing: https://github.com/curie-eng/curie/actions/runs/32296853187/job/96210043914
* This branch is stacked on PR #1714. Merge #1714 first.

## Review checklist

* Code review approved the final implementation.
* Scope review approved every hunk.
* The loud failure path and local skip path have behavioral regression coverage.
* The workflow contract test pins the Valkey service and CI requirement flag.
* Local Rust fmt, clippy, full tests, and generated protocol crate tests passed with real Valkey.