### PR TITLE
Pin queued turn source key

### DIFF
--- a/cli/tests/chat_enqueue.rs
+++ b/cli/tests/chat_enqueue.rs
@@ -91,6 +91,7 @@ async fn xadd_lands_the_exact_seam_shape_on_real_valkey() {
             "event_id",
             "received_at",
             "reply_handle",
+            "source",
             "text",
         ]
     );


### PR DESCRIPTION
Closes #1702

Updates the live Valkey wire seam assertion to include `source`, which `QueuedTurn` always serializes as part of the frozen queue contract.

The focused command ran with the compose Valkey healthy on port 26379.

`cd cli && cargo test --locked xadd_lands_the_exact_seam_shape_on_real_valkey`

```text
running 1 test
test xadd_lands_the_exact_seam_shape_on_real_valkey ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 8 filtered out; finished in 0.00s
```

`cd cli && cargo test --locked`

```text
aggregate test result: 1325 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```