### PR TITLE
Pin queued turn source key

### DIFF
--- a/cli/tests/chat_enqueue.rs
+++ b/cli/tests/chat_enqueue.rs
@@ -91,6 +91,7 @@ async fn xadd_lands_the_exact_seam_shape_on_real_valkey() {
             "event_id",
             "received_at",
             "reply_handle",
+            "source",
             "text",
         ]
     );


### PR DESCRIPTION
Closes #1702

Adds `source` to the exact serialized `QueuedTurn` key expectation. The focused test passes against real Valkey on current `main`.