### PR TITLE
Report unlabelled trajectory eval results

### DIFF
--- a/cli/src/message.rs
+++ b/cli/src/message.rs
@@ -2780,17 +2780,6 @@ fn trajectory_matrix_report(
                 matrix_row.case_id
             );
         }
-        if cell
-            .model
-            .as_deref()
-            .map(str::trim)
-            .is_none_or(str::is_empty)
-        {
-            bail!(
-                "stream filtered trajectory result for case {:?} has no resolved model",
-                matrix_row.case_id
-            );
-        }
         let case_count = cell.case_count.context(format!(
             "stream filtered trajectory result for case {:?} has no case count",
             matrix_row.case_id

--- a/cli/tests/trajectory_platform_eval.rs
+++ b/cli/tests/trajectory_platform_eval.rs
@@ -101,6 +101,13 @@ fn incomplete_matrix_body() -> String {
     body.to_string()
 }
 
+fn unlabelled_model_matrix_body() -> String {
+    let mut body: serde_json::Value =
+        serde_json::from_str(&matrix_body()).expect("valid matrix fixture");
+    body["rows"][0]["cells"][0]["model"] = serde_json::Value::Null;
+    body.to_string()
+}
+
 fn platform_server_with_matrix(
     matrix: impl Fn() -> String + Send + Sync + 'static,
 ) -> support::MockServer {
@@ -447,6 +454,25 @@ fn local_and_cluster_use_the_same_structured_trajectory_verdicts() {
             .is_some_and(|detail| detail.contains("no trajectory spec")),
         "the missing spec verdict must remain explanatory: {local}"
     );
+    assert_platform_flow(&local_requests);
+    assert_platform_flow(&cluster_requests);
+}
+
+#[test]
+fn local_and_cluster_report_trajectory_results_without_a_resolved_model() {
+    let (local_output, local_requests) = run_platform_eval_against(
+        "local",
+        platform_server_with_matrix(unlabelled_model_matrix_body),
+    );
+    let (cluster_output, cluster_requests) = run_platform_eval_against(
+        "cluster",
+        platform_server_with_matrix(unlabelled_model_matrix_body),
+    );
+
+    let local = parsed_output(&local_output);
+    let cluster = parsed_output(&cluster_output);
+    assert_eq!(verdict_projection(&local), verdict_projection(&cluster));
+    assert_eq!(case_result(&local, "ordered")["passed"], true, "{local}");
     assert_platform_flow(&local_requests);
     assert_platform_flow(&cluster_requests);
 }


### PR DESCRIPTION
Closes #1709

Allows trajectory eval results without a resolved model label to reach the normal report path, matching the API contract.

Adds local and cluster CLI regression coverage for a null model cell.

Validation:

* [x] Focused test proved red before the fix and green after it.
* [x] Full CLI formatting, lint, and 1,326 tests passed.
* [x] The fix pin gate reported PINNED.
* [x] The local parity ladder passed in sealed fake mode.
* [x] Independent code and scope reviews approved.
* [x] Local and cluster sibling paths are covered.
* [x] No new guard was introduced.