### PR TITLE
Reject PriorityClasses without Helm ownership

### DIFF
--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -2447,10 +2447,16 @@ struct PriorityClassOwner {
 }
 
 #[derive(Debug, PartialEq, Eq)]
+enum PriorityClassOwnership {
+    Absent,
+    Existing(Option<PriorityClassOwner>),
+}
+
+#[derive(Debug, PartialEq, Eq)]
 struct PriorityClassConflict {
     role: PriorityClassRole,
     name: String,
-    owner: PriorityClassOwner,
+    owner: Option<PriorityClassOwner>,
 }
 
 fn priority_class_name_from_render(
@@ -2587,7 +2593,7 @@ fn priority_class_metadata_value<'a>(
     }
 }
 
-async fn priority_class_owner(name: &str) -> Result<Option<PriorityClassOwner>> {
+async fn priority_class_owner(name: &str) -> Result<PriorityClassOwnership> {
     let cmd = OpsCommand::new(
         "kubectl",
         vec![
@@ -2608,7 +2614,7 @@ async fn priority_class_owner(name: &str) -> Result<Option<PriorityClassOwner>> 
         ));
     }
     if out.trim().is_empty() {
-        return Ok(None);
+        return Ok(PriorityClassOwnership::Absent);
     }
     let value: serde_json::Value = serde_json::from_str(out.trim())
         .map_err(|_| priority_class_read_error(name, "kubectl returned invalid JSON", false))?;
@@ -2636,33 +2642,40 @@ async fn priority_class_owner(name: &str) -> Result<Option<PriorityClassOwner>> 
     let labels = priority_class_metadata_map(metadata, "labels", name)?;
     if priority_class_metadata_value(labels, "app.kubernetes.io/managed-by", name)? != Some("Helm")
     {
-        return Ok(None);
+        return Ok(PriorityClassOwnership::Existing(None));
     }
     let annotations = priority_class_metadata_map(metadata, "annotations", name)?;
     let Some(release) =
         priority_class_metadata_value(annotations, "meta.helm.sh/release-name", name)?
     else {
-        return Ok(None);
+        return Ok(PriorityClassOwnership::Existing(None));
     };
     let Some(namespace) =
         priority_class_metadata_value(annotations, "meta.helm.sh/release-namespace", name)?
     else {
-        return Ok(None);
+        return Ok(PriorityClassOwnership::Existing(None));
     };
-    Ok(Some(PriorityClassOwner {
+    Ok(PriorityClassOwnership::Existing(Some(PriorityClassOwner {
         release: release.to_string(),
         namespace: namespace.to_string(),
-    }))
+    })))
 }
 
 async fn preflight_priority_class_ownership(opts: &UpOpts, plan: &UpValuePlan) -> Result<()> {
     let rendered = rendered_priority_classes(&opts.chart, &opts.common, plan).await?;
     let mut conflicts = Vec::new();
     for (role, name) in rendered {
-        let Some(owner) = priority_class_owner(&name).await? else {
-            continue;
+        let owner = match priority_class_owner(&name).await? {
+            PriorityClassOwnership::Absent => continue,
+            PriorityClassOwnership::Existing(owner) => owner,
         };
-        if owner.release != opts.common.release || owner.namespace != opts.common.namespace {
+        let conflicts_with_target = match owner.as_ref() {
+            None => true,
+            Some(owner) => {
+                owner.release != opts.common.release || owner.namespace != opts.common.namespace
+            }
+        };
+        if conflicts_with_target {
             conflicts.push(PriorityClassConflict { role, name, owner });
         }
     }
@@ -2672,10 +2685,17 @@ async fn preflight_priority_class_ownership(opts: &UpOpts, plan: &UpValuePlan) -
 
     let mut message = String::from("PriorityClass ownership conflicts block installation:");
     for conflict in conflicts {
-        message.push_str(&format!(
-            "\nPriorityClass `{}` is owned by Helm release `{}` in namespace `{}`.",
-            conflict.name, conflict.owner.release, conflict.owner.namespace
-        ));
+        if let Some(owner) = conflict.owner {
+            message.push_str(&format!(
+                "\nPriorityClass `{}` is owned by Helm release `{}` in namespace `{}`.",
+                conflict.name, owner.release, owner.namespace
+            ));
+        } else {
+            message.push_str(&format!(
+                "\nPriorityClass `{}` exists without complete Helm ownership metadata.",
+                conflict.name
+            ));
+        }
         message.push_str(&format!(
             "\nReuse it with `--set priorityClasses.{}.create=false --set priorityClasses.{}.name={}`.",
             conflict.role.key(),

--- a/cli/tests/cluster_up_priorityclass_preflight.rs
+++ b/cli/tests/cluster_up_priorityclass_preflight.rs
@@ -158,6 +158,21 @@ case "$mode" in
     absent)
         exit 0
         ;;
+    unmanaged)
+        printf '{"apiVersion":"scheduling.k8s.io/v1","kind":"PriorityClass","metadata":{"name":"%s"}}\n' \
+            "$name"
+        exit 0
+        ;;
+    helm-without-annotations)
+        printf '{"apiVersion":"scheduling.k8s.io/v1","kind":"PriorityClass","metadata":{"name":"%s","labels":{"app.kubernetes.io/managed-by":"Helm"}}}\n' \
+            "$name"
+        exit 0
+        ;;
+    helm-without-release-namespace)
+        printf '{"apiVersion":"scheduling.k8s.io/v1","kind":"PriorityClass","metadata":{"name":"%s","labels":{"app.kubernetes.io/managed-by":"Helm"},"annotations":{"meta.helm.sh/release-name":"%s"}}}\n' \
+            "$name" "$foreign_release"
+        exit 0
+        ;;
     malformed)
         printf '%s\n' '{"metadata":'
         exit 0
@@ -354,6 +369,84 @@ fn foreign_owners_for_both_roles_block_with_exact_remediation() {
         ["shared-platform", "shared-sandbox"],
         "the preflight must aggregate both rendered conflicts before failing"
     );
+}
+
+#[test]
+fn unmanaged_platform_class_blocks_with_exact_remediation() {
+    let fixture = Fixture::new();
+    let output = fixture.run(
+        "shared-platform",
+        "unmanaged",
+        DEFAULT_SANDBOX,
+        "absent",
+        &["--set", "priorityClasses.platform.name=shared-platform"],
+    );
+    let shown = assert_failed_before_upgrade(&fixture, &output);
+
+    for expected in [
+        "shared-platform",
+        "exists without complete Helm ownership metadata",
+        "--set priorityClasses.platform.create=false --set priorityClasses.platform.name=shared-platform",
+        "--set priorityClasses.platform.name=<different-name>",
+    ] {
+        assert!(
+            shown.contains(expected),
+            "the unmanaged platform conflict must contain `{expected}`:\n{shown}"
+        );
+    }
+    assert_eq!(fixture.queries(), ["shared-platform", DEFAULT_SANDBOX]);
+}
+
+#[test]
+fn helm_labelled_sandbox_class_without_release_annotations_blocks_with_exact_remediation() {
+    let fixture = Fixture::new();
+    let output = fixture.run(
+        DEFAULT_PLATFORM,
+        "absent",
+        "shared-sandbox",
+        "helm-without-annotations",
+        &["--set", "priorityClasses.sandbox.name=shared-sandbox"],
+    );
+    let shown = assert_failed_before_upgrade(&fixture, &output);
+
+    for expected in [
+        "shared-sandbox",
+        "exists without complete Helm ownership metadata",
+        "--set priorityClasses.sandbox.create=false --set priorityClasses.sandbox.name=shared-sandbox",
+        "--set priorityClasses.sandbox.name=<different-name>",
+    ] {
+        assert!(
+            shown.contains(expected),
+            "the incomplete sandbox ownership conflict must contain `{expected}`:\n{shown}"
+        );
+    }
+    assert_eq!(fixture.queries(), [DEFAULT_PLATFORM, "shared-sandbox"]);
+}
+
+#[test]
+fn helm_labelled_platform_class_without_release_namespace_blocks_with_exact_remediation() {
+    let fixture = Fixture::new();
+    let output = fixture.run(
+        "shared-platform",
+        "helm-without-release-namespace",
+        DEFAULT_SANDBOX,
+        "absent",
+        &["--set", "priorityClasses.platform.name=shared-platform"],
+    );
+    let shown = assert_failed_before_upgrade(&fixture, &output);
+
+    for expected in [
+        "shared-platform",
+        "exists without complete Helm ownership metadata",
+        "--set priorityClasses.platform.create=false --set priorityClasses.platform.name=shared-platform",
+        "--set priorityClasses.platform.name=<different-name>",
+    ] {
+        assert!(
+            shown.contains(expected),
+            "the incomplete platform ownership conflict must contain `{expected}`:\n{shown}"
+        );
+    }
+    assert_eq!(fixture.queries(), ["shared-platform", DEFAULT_SANDBOX]);
 }
 
 #[test]


### PR DESCRIPTION
Closes #1636

Summary

* Treat an existing PriorityClass without complete target Helm ownership as a preflight conflict.
* Preserve the existing reuse and rename remediation before Helm mutation.
* Cover unlabeled, annotation free, and missing namespace ownership shapes.

Done check

* [x] Failing tests preceded implementation: red contract e88ab464 failed both new paths before the final squash.
* [x] All code and test edits were delegated to separate fresh contexts.
* [x] Return type audit: only a private helper changed and its sole caller was migrated.
* [x] Independent code review approved with no blocking findings.
* [x] Independent scope review approved every hunk.
* [x] Sibling paths covered: cluster up and apply share the preflight, and both PriorityClass roles use the same loop.
* [x] Guard demonstration passed against a disposable kind cluster before Helm apply.
* [x] Consolidation found no safe simplification.
* [x] Security review not applicable because no auth, secrets, permissions, or data boundary changed.
* [x] Observable refusal, exact ownership success, and convergent rerun were recorded.
* [x] Required local and cluster runtime tiers passed.
* [x] Formatting, Clippy, 187 affected unit tests, 11 integration tests, and all three fix pin mutations passed.