### PR TITLE
Fix main review papercuts

### DIFF
--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -3956,6 +3956,49 @@ export const commandManifest = {
           "name": "e2e-ladder"
         },
         {
+          "about": "Select the end to end tiers CI would run for paths or revisions",
+          "args": [
+            {
+              "global": false,
+              "help": "Changed path. Repeat for every path in the candidate change",
+              "id": "path",
+              "long": "path",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Base revision for a local branch comparison",
+              "id": "base",
+              "long": "base",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Head revision for a local branch comparison",
+              "id": "head",
+              "long": "head",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Select every tier, matching a push event",
+              "id": "push",
+              "long": "push",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "name": "e2e-ci-selection"
+        },
+        {
           "about": "Runtime E2E the Helm chart on a local cluster: install a trimmed slice, seed a bundle into RustFS, run the sandbox bundle-fetch init pair, and exec-assert the runner's view -- the one-command way to satisfy a chart/sandbox runtime acceptance criterion static checks cannot (#199, `bash scripts/chart-runtime-e2e.sh`)",
           "hidden": false,
           "name": "chart-runtime-e2e"

--- a/charts/curie/README.md
+++ b/charts/curie/README.md
@@ -118,16 +118,17 @@ kubectl get pods -n curie-dev -w
 Reach the Langfuse UI after a stock install:
 
 ```bash
-kubectl port-forward -n curie svc/curie-langfuse-web 3000:3000
-# http://localhost:3000
-kubectl get secret curie-secrets -n curie -o jsonpath='{.data.langfuseInitProjectSecretKey}' | base64 -d; echo
-kubectl get secret curie-secrets -n curie -o jsonpath='{.data.langfuseInitUserPassword}' | base64 -d; echo
+curie cluster observability
 ```
 
-Log in as `dev@curie.local` with the retrieved admin password. The first
-command retrieves the project secret key for API and OTel authentication.
-The development overlay retains the published development keys
-`pk-lf-curie-dev` and `sk-lf-curie-dev`.
+The command reports the Langfuse UI URL and a connection hint when the Service
+is not externally reachable. Pass `--open` to open a reachable Langfuse URL in
+your browser. It reports access surfaces only and does not read or rotate
+Langfuse credentials.
+
+For a sealed install, Helm's post install notes show how to retrieve the
+generated Langfuse admin password. Sign in as `dev@curie.local` unless
+`langfuse.init.userEmail` was overridden.
 
 App services emit OTLP (OpenTelemetry Protocol) to the **collector**, never
 straight to Langfuse (Langfuse OTLP ingest is HTTP-only): `curie-otel-collector:4317` (gRPC) /

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -3953,6 +3953,49 @@
           "name": "e2e-ladder"
         },
         {
+          "about": "Select the end to end tiers CI would run for paths or revisions",
+          "args": [
+            {
+              "global": false,
+              "help": "Changed path. Repeat for every path in the candidate change",
+              "id": "path",
+              "long": "path",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Base revision for a local branch comparison",
+              "id": "base",
+              "long": "base",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Head revision for a local branch comparison",
+              "id": "head",
+              "long": "head",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Select every tier, matching a push event",
+              "id": "push",
+              "long": "push",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "name": "e2e-ci-selection"
+        },
+        {
           "about": "Runtime E2E the Helm chart on a local cluster: install a trimmed slice, seed a bundle into RustFS, run the sandbox bundle-fetch init pair, and exec-assert the runner's view -- the one-command way to satisfy a chart/sandbox runtime acceptance criterion static checks cannot (#199, `bash scripts/chart-runtime-e2e.sh`)",
           "hidden": false,
           "name": "chart-runtime-e2e"

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -120,11 +120,10 @@ pub struct Agent {
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct ApprovalRouteBinding {
     // The deployed API can return a route binding with no `channel` after a
-    // live rebind, which previously hard-failed every verb that lists agents.
-    // Defaulting to empty is deliberate tolerance, not the fix: the
-    // underlying API/CLI schema mismatch (#1533) is still owed.
+    // live rebind. Preserve that absence so readers can distinguish it from an
+    // explicit empty string.
     #[serde(default)]
-    pub channel: String,
+    pub channel: Option<String>,
     /// Absent means the card channel's members are the approvers, the zero-setup
     /// default. Skipped on serialize so a channel-only write sends no `approvers`
     /// key at all: the API models the block with `extra="forbid"`, and an explicit
@@ -197,7 +196,7 @@ impl From<ApproversInput> for ApprovalApprovers {
 impl From<RouteBindingInput> for ApprovalRouteBinding {
     fn from(input: RouteBindingInput) -> Self {
         ApprovalRouteBinding {
-            channel: input.channel,
+            channel: Some(input.channel),
             approvers: input.approvers.map(Into::into),
         }
     }

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -617,6 +617,87 @@ pub async fn dev_script(rel_path: &str, args: &[&str]) -> Result<()> {
     Ok(())
 }
 
+pub async fn dev_e2e_ci_selection(
+    paths: &[PathBuf],
+    base: Option<&str>,
+    head: Option<&str>,
+    push: bool,
+) -> Result<()> {
+    let root = find_repo_root().context(
+        "runner/Dockerfile not found here or in any parent directory. Run `curie dev` \
+         from a curie source checkout.",
+    )?;
+    let selector = root.join("tools/e2e-ci-selection/select.py");
+    let registry = root.join(".github/e2e-selection.yaml");
+    if !selector.is_file() {
+        bail!("selector not found: {}", selector.display());
+    }
+    if !registry.is_file() {
+        bail!("selection registry not found: {}", registry.display());
+    }
+
+    let output_path = (0..100)
+        .find_map(|attempt| {
+            let path = std::env::temp_dir().join(format!(
+                "curie-e2e-ci-selection-{}-{attempt}",
+                std::process::id()
+            ));
+            std::fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&path)
+                .ok()
+                .map(|_| path)
+        })
+        .context("failed to create temporary selector output")?;
+
+    let selection = async {
+        let mut command = tokio::process::Command::new("uv");
+        command
+            .args([
+                "run",
+                "--no-project",
+                "--with",
+                "pyyaml==6.0.3",
+                "python",
+                "tools/e2e-ci-selection/select.py",
+                "--registry",
+                ".github/e2e-selection.yaml",
+            ])
+            .env("GITHUB_OUTPUT", &output_path)
+            .current_dir(&root);
+        for path in paths {
+            command.arg("--path").arg(path);
+        }
+        if let Some(base) = base {
+            command.arg("--base").arg(base);
+        }
+        if let Some(head) = head {
+            command.arg("--head").arg(head);
+        }
+        if push {
+            command.arg("--push");
+        }
+
+        let status = command
+            .status()
+            .await
+            .context("failed to invoke the end to end CI selector")?;
+        if !status.success() {
+            bail!("end to end CI selector failed ({status})");
+        }
+        std::fs::read_to_string(&output_path).context("failed to read selector output")
+    }
+    .await;
+
+    let cleanup = std::fs::remove_file(&output_path)
+        .with_context(|| format!("failed to remove {}", output_path.display()));
+    let selection = selection?;
+    cleanup?;
+    print!("{selection}");
+    Ok(())
+}
+
 /// The chart assertion scripts live here, and helm-ci runs every one of them on
 /// any `charts/curie/**` change.
 pub const CHART_CI_DIR: &str = "charts/curie/ci";
@@ -4471,8 +4552,8 @@ fn build_route_bindings(
                         ),
                     )
                 })?;
+            validate_route_channel(&name, &input.channel)?;
             let binding: crate::api::ApprovalRouteBinding = input.into();
-            validate_route_channel(&name, &binding.channel)?;
             if let Some(approvers) = &binding.approvers {
                 validate_parsed_approvers(&name, approvers)?;
             }
@@ -4485,9 +4566,9 @@ fn build_route_bindings(
         validate_route_channel(name, channel)?;
         bindings
             .entry(name.to_string())
-            .and_modify(|b| b.channel = channel.to_string())
+            .and_modify(|b| b.channel = Some(channel.to_string()))
             .or_insert_with(|| crate::api::ApprovalRouteBinding {
-                channel: channel.to_string(),
+                channel: Some(channel.to_string()),
                 approvers: None,
             });
     }
@@ -4734,7 +4815,13 @@ impl crate::ui::CliOutput for ApprovalsOutput {
                         // Print WHERE and WHO as separate labelled facts: ADR-0034
                         // unfused these two axes, and a single collapsed line would
                         // re-fuse them in the operator's head.
-                        ui.kv(name, &format!("channel {}", binding.channel));
+                        ui.kv(
+                            name,
+                            &format!(
+                                "channel {}",
+                                binding.channel.as_deref().unwrap_or("(missing)")
+                            ),
+                        );
                         ui.kv("", &format!("  approvers: {}", describe_approvers(binding)));
                     }
                 }
@@ -4746,10 +4833,12 @@ impl crate::ui::CliOutput for ApprovalsOutput {
 /// One line naming who may resolve a route's approvals, including the default.
 fn describe_approvers(binding: &crate::api::ApprovalRouteBinding) -> String {
     match &binding.approvers {
-        None => format!(
-            "members of {} (the default: no approvers block declared)",
-            binding.channel
-        ),
+        None => match binding.channel.as_deref() {
+            Some(channel) => {
+                format!("members of {channel} (the default: no approvers block declared)")
+            }
+            None => "unreadable: no channel or approvers block declared".to_string(),
+        },
         Some(a) => match (&a.users, &a.group) {
             // Mirror the API's precedence in the wording rather than hiding it:
             // `users` wins over `group`, so a binding carrying both must not read

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -512,6 +512,25 @@ enum DevAction {
     /// Run the cold-start parity ladder across the skill, local, and cluster
     /// tiers, fake model by default (#690, `bash cli/scripts/e2e-ladder.sh`).
     E2eLadder,
+    /// Select the end to end tiers CI would run for paths or revisions.
+    E2eCiSelection {
+        /// Changed path. Repeat for every path in the candidate change.
+        #[arg(
+            long,
+            required_unless_present_any = ["base", "push"],
+            conflicts_with_all = ["base", "head", "push"]
+        )]
+        path: Vec<PathBuf>,
+        /// Base revision for a local branch comparison.
+        #[arg(long, requires = "head", conflicts_with = "push")]
+        base: Option<String>,
+        /// Head revision for a local branch comparison.
+        #[arg(long, requires = "base", conflicts_with = "push")]
+        head: Option<String>,
+        /// Select every tier, matching a push event.
+        #[arg(long, conflicts_with_all = ["path", "base", "head"])]
+        push: bool,
+    },
     /// Runtime E2E the Helm chart on a local cluster: install a trimmed slice,
     /// seed a bundle into RustFS, run the sandbox bundle-fetch init pair, and
     /// exec-assert the runner's view -- the one-command way to satisfy a
@@ -2010,6 +2029,14 @@ async fn run(command: Option<Command>) -> Result<()> {
             }
             DevAction::E2e => commands::dev_script("cli/scripts/e2e.sh", &[]).await,
             DevAction::E2eLadder => commands::dev_script("cli/scripts/e2e-ladder.sh", &[]).await,
+            DevAction::E2eCiSelection {
+                path,
+                base,
+                head,
+                push,
+            } => {
+                commands::dev_e2e_ci_selection(&path, base.as_deref(), head.as_deref(), push).await
+            }
             DevAction::ChartRuntimeE2e => {
                 commands::dev_script("scripts/chart-runtime-e2e.sh", &[]).await
             }

--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -2545,9 +2545,7 @@ fn priority_class_read_error(
     detail: impl std::fmt::Display,
     transient: bool,
 ) -> anyhow::Error {
-    let fix = format!(
-        "check cluster reachability and permission with `kubectl get priorityclass {name} -o json`"
-    );
+    let fix = "run `curie cluster status`".to_string();
     let message = format!("could not inspect PriorityClass `{name}`: {detail}; {fix}");
     let error = if transient {
         crate::exit::CliError::transient(message)

--- a/cli/tests/approval_route_bindings.rs
+++ b/cli/tests/approval_route_bindings.rs
@@ -22,6 +22,7 @@ mod support;
 
 use curie::commands::{approvals, AgentActionOpts, ApprovalCmd, ApprovalsOutput};
 use curie::credcheck::check_channel_id;
+use curie::ui::CliOutput;
 use std::sync::{Arc, Mutex};
 use support::{serve, MockServer, Response};
 
@@ -211,7 +212,7 @@ async fn route_flag_writes_the_channel_binding() {
 
     match out {
         ApprovalsOutput::Routes { routes, .. } => {
-            assert_eq!(routes["deal_desk"].channel, "C0MANAGERS");
+            assert_eq!(routes["deal_desk"].channel.as_deref(), Some("C0MANAGERS"));
             assert!(routes["deal_desk"].approvers.is_none());
         }
         _ => panic!("expected the Routes output"),
@@ -284,7 +285,7 @@ async fn route_approvers_narrows_who_without_moving_where() {
     match out {
         ApprovalsOutput::Routes { routes, .. } => {
             let binding = &routes["finance"];
-            assert_eq!(binding.channel, "C0FINANCE0");
+            assert_eq!(binding.channel.as_deref(), Some("C0FINANCE0"));
             assert_eq!(
                 binding.approvers.as_ref().and_then(|a| a.group.as_deref()),
                 Some("S0FINGRP0")
@@ -340,10 +341,42 @@ async fn list_routes_reads_without_writing() {
     match out {
         ApprovalsOutput::Routes { agent, routes } => {
             assert_eq!(agent, "deal-desk");
-            assert_eq!(routes["deal_desk"].channel, "C0MANAGERS");
+            assert_eq!(routes["deal_desk"].channel.as_deref(), Some("C0MANAGERS"));
         }
         _ => panic!("expected the Routes output"),
     }
+}
+
+#[tokio::test]
+async fn list_routes_json_distinguishes_a_missing_channel_from_an_empty_channel() {
+    // Older API rows can omit `channel`; that absence means the CLI has no
+    // channel value to report, which differs from a stored explicit empty
+    // string. The read path stays tolerant of the former, but its JSON must
+    // preserve the distinction for an agent deciding whether to repair a row.
+    let routes = r#"{"legacy":{},"intentionally_empty":{"channel":""}}"#;
+    let server = stub(routes, routes);
+
+    let out = run(
+        &server,
+        ApprovalCmd {
+            list_routes: true,
+            ..ApprovalCmd::default()
+        },
+    )
+    .await
+    .expect("--list-routes should tolerate an older binding without a channel");
+
+    assert_no_write(&server);
+    let json = out.to_json();
+    assert_eq!(
+        json["routes"]["legacy"]["channel"],
+        serde_json::Value::Null,
+        "an omitted API channel must remain absent in list-routes JSON"
+    );
+    assert_eq!(
+        json["routes"]["intentionally_empty"]["channel"], "",
+        "an explicit empty API channel must remain an empty string in list-routes JSON"
+    );
 }
 
 #[tokio::test]
@@ -706,7 +739,7 @@ async fn an_api_response_tolerates_a_field_the_cli_does_not_model() {
 
     match out {
         ApprovalsOutput::Routes { routes, .. } => {
-            assert_eq!(routes["deal_desk"].channel, "C0MANAGERS");
+            assert_eq!(routes["deal_desk"].channel.as_deref(), Some("C0MANAGERS"));
         }
         _ => panic!("expected the Routes output"),
     }
@@ -738,6 +771,35 @@ async fn a_malformed_routes_file_writes_nothing() {
     assert!(
         err.to_string().contains("not a Slack channel ID"),
         "unexpected error: {err}"
+    );
+    assert_no_write(&server);
+}
+
+#[tokio::test]
+async fn a_routes_file_without_a_channel_writes_nothing() {
+    // API responses preserve a missing channel for diagnosis, but an operator
+    // supplied route must name where its approval card is posted.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("routes.json");
+    std::fs::write(&path, r#"{"legacy":{}}"#).expect("write");
+
+    let server = stub("null", "null");
+
+    let Err(err) = run(
+        &server,
+        ApprovalCmd {
+            routes_from: Some(path),
+            ..ApprovalCmd::default()
+        },
+    )
+    .await
+    else {
+        panic!("a route file binding without a channel must be refused");
+    };
+
+    assert!(
+        err.to_string().contains("channel"),
+        "the error must identify the required field: {err}"
     );
     assert_no_write(&server);
 }

--- a/cli/tests/cli_output_variants.rs
+++ b/cli/tests/cli_output_variants.rs
@@ -282,14 +282,14 @@ fn registry() -> BTreeMap<&'static str, Vec<VariantJson>> {
                     (
                         "deal_desk".to_string(),
                         curie::api::ApprovalRouteBinding {
-                            channel: "C0MANAGERS".to_string(),
+                            channel: Some("C0MANAGERS".to_string()),
                             approvers: None,
                         },
                     ),
                     (
                         "finance".to_string(),
                         curie::api::ApprovalRouteBinding {
-                            channel: "C0FINANCE0".to_string(),
+                            channel: Some("C0FINANCE0".to_string()),
                             approvers: Some(curie::api::ApprovalApprovers {
                                 group: Some("S0FINGRP0".to_string()),
                                 users: None,

--- a/cli/tests/cluster_up_priorityclass_preflight.rs
+++ b/cli/tests/cluster_up_priorityclass_preflight.rs
@@ -310,8 +310,8 @@ fn assert_read_recovery_hint(shown: &str, class_name: &str) {
         "the read error must name the PriorityClass: {shown}"
     );
     assert!(
-        lower.contains("check") && lower.contains("cluster") && lower.contains("permission"),
-        "the read error must tell the operator to check cluster reachability and permission: {shown}"
+        lower.contains("run `curie cluster status`"),
+        "the read error must tell the operator to run the Curie cluster status command: {shown}"
     );
 }
 
@@ -446,6 +446,44 @@ fn kubectl_failure_blocks_with_a_recovery_hint() {
         "kubectl detail was lost: {shown}"
     );
     assert_read_recovery_hint(&shown, DEFAULT_PLATFORM);
+}
+
+#[test]
+fn priorityclass_read_failure_json_fix_uses_cluster_status() {
+    let fixture = Fixture::new();
+    let output = fixture.run(
+        DEFAULT_PLATFORM,
+        "failure",
+        DEFAULT_SANDBOX,
+        "absent",
+        &["--json"],
+    );
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "a forbidden PriorityClass read remains a runtime failure\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        stderr(&output)
+    );
+    assert_eq!(
+        fixture.upgrade_count(),
+        0,
+        "helm upgrade --install must not run after a failed preflight"
+    );
+
+    let payload: serde_json::Value = serde_json::from_slice(&output.stdout)
+        .unwrap_or_else(|error| panic!("--json must emit the error payload: {error}"));
+    assert_eq!(
+        payload["fix"], "run `curie cluster status`",
+        "the machine readable recovery action must be the single Curie status command: {payload}"
+    );
+    assert!(
+        payload["error"]
+            .as_str()
+            .is_some_and(|error| error.contains(DEFAULT_PLATFORM)),
+        "the machine readable error must name the PriorityClass: {payload}"
+    );
 }
 
 #[test]

--- a/cli/tests/command_surface.rs
+++ b/cli/tests/command_surface.rs
@@ -1,3 +1,5 @@
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
 use std::process::Command;
 
 use curie::retired_hint;
@@ -193,6 +195,93 @@ fn process_dev_help_lists_verify_fix_pin() {
     assert!(
         leaf_text.contains("<CHANGE>") && leaf_text.contains("<SELECTOR>"),
         "verify-fix-pin help must require a change and selector\n{leaf_text}"
+    );
+}
+
+#[test]
+fn process_dev_e2e_ci_selection_delegates_path_selection() {
+    let repo_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("cli crate has a repository root");
+    let tools = tempfile::tempdir().expect("create fake tool directory");
+    let uv = tools.path().join("uv");
+    let marker = tools.path().join("uv-invoked");
+    fs::write(
+        &uv,
+        r#"#!/bin/sh
+set -eu
+
+if [ "$#" -ne 12 ] ||
+   [ "$1" != "run" ] ||
+   [ "$2" != "--no-project" ] ||
+   [ "$3" != "--with" ] ||
+   [ "$4" != "pyyaml==6.0.3" ] ||
+   [ "$5" != "python" ] ||
+   [ "$6" != "tools/e2e-ci-selection/select.py" ] ||
+   [ "$7" != "--registry" ] ||
+   [ "$8" != ".github/e2e-selection.yaml" ] ||
+   [ "$9" != "--path" ] ||
+   [ "${10}" != "compose.dev.yaml" ] ||
+   [ "${11}" != "--path" ] ||
+   [ "${12}" != "docs/example.md" ]; then
+    printf 'unexpected uv invocation: %s\n' "$*" >&2
+    exit 64
+fi
+
+printf 'invoked\n' > "${CURIE_TEST_UV_MARKER:?}"
+printf '%s\n' \
+    'skill=false' \
+    'local=true' \
+    'local_release=false' \
+    'cluster=false' \
+    'skill_local_tiers=local' > "${GITHUB_OUTPUT:?}"
+"#,
+    )
+    .expect("write fake uv executable");
+    let mut permissions = fs::metadata(&uv)
+        .expect("read fake uv metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&uv, permissions).expect("make fake uv executable");
+
+    let mut paths = vec![tools.path().to_path_buf()];
+    paths.extend(std::env::split_paths(
+        &std::env::var_os("PATH").unwrap_or_default(),
+    ));
+    let path = std::env::join_paths(paths).expect("join fake tool PATH");
+    let output = Command::new(bin())
+        .args([
+            "dev",
+            "e2e-ci-selection",
+            "--path",
+            "compose.dev.yaml",
+            "--path",
+            "docs/example.md",
+        ])
+        .current_dir(repo_root)
+        .env("PATH", path)
+        .env("CURIE_TEST_UV_MARKER", &marker)
+        .output()
+        .expect("run curie dev e2e-ci-selection");
+
+    assert!(
+        output.status.success(),
+        "expected e2e CI selection to succeed\n{}",
+        output_text(&output)
+    );
+    assert_eq!(
+        String::from_utf8(output.stdout).expect("selector output is utf-8"),
+        "skill=false\n\
+         local=true\n\
+         local_release=false\n\
+         cluster=false\n\
+         skill_local_tiers=local\n",
+        "the CLI wrapper must preserve the selector's union and ignored-path semantics"
+    );
+    assert_eq!(
+        fs::read_to_string(marker).expect("fake uv invocation marker"),
+        "invoked\n",
+        "the CLI wrapper must delegate selection through the pinned uv command"
     );
 }
 

--- a/tools/doclint/src/curie_doclint/counts.py
+++ b/tools/doclint/src/curie_doclint/counts.py
@@ -85,6 +85,14 @@ _SCHEMA_INDEX_NAME = "index.json"
 # different claim and use a different verb, so they cannot inflate this one.
 _ACI_POST_ROUTE_RE = re.compile(r"web\.post\(")
 
+# A direct aiohttp POST registration with a literal route path. Anchoring the
+# call at the start of a source line keeps examples and incidental mentions out
+# of the route inventory, while the captured path is the identity the seam docs
+# enumerate.
+_ACI_POST_ROUTE_NAME_RE = re.compile(
+    r'^\s*web\.post\(\s*"(?P<path>/[^"]+)"\s*,', re.MULTILINE
+)
+
 # A `CliOutput` implementation, anchored at column 0. Every one in the crate is
 # written at top level, so an anchored pattern cannot pick up a fixture impl
 # nested inside a test module or a doc example, and the crate spells the trait
@@ -95,6 +103,15 @@ _CLI_OUTPUT_IMPL_RE = re.compile(r"^impl (?:crate::ui::|ui::)?CliOutput for ", r
 # module's import line and would inflate a looser pattern, so the mapping call
 # is what is matched.
 _JSONB_COLUMN_RE = re.compile(r"mapped_column\(JSONB")
+
+# A direct ORM field declaration whose mapping starts with JSONB. The optional
+# annotation covers both the typed production models and the untyped miniature
+# trees used by the gate tests without admitting imports or prose mentions.
+_JSONB_COLUMN_NAME_RE = re.compile(
+    r"^\s*(?P<name>[A-Za-z_]\w*)\s*(?::[^=\n]+)?=\s*"
+    r"mapped_column\(\s*JSONB(?:\s*[,)]|\s*$)",
+    re.MULTILINE,
+)
 
 # FastAPI route decorators in a router module, anchored at column 0 so a
 # decorator quoted inside a docstring or a comment cannot inflate the count.
@@ -260,6 +277,25 @@ def _count_jsonb_columns(repo_root: Path) -> int:
     return len(_JSONB_COLUMN_RE.findall(path.read_text(encoding="utf-8")))
 
 
+def _jsonb_column_names(repo_root: Path) -> set[str]:
+    """List the ORM columns declared directly with the JSONB type.
+
+    Args:
+        repo_root: The repository root to resolve the models module against.
+
+    Returns:
+        The column names whose direct ``mapped_column`` declaration starts with
+        ``JSONB``, matching the identities enumerated in the seam doc.
+    """
+    path = repo_root / "apps" / "api" / "src" / "curie_api" / "models.py"
+    if not path.is_file():
+        return set()
+    return {
+        match.group("name")
+        for match in _JSONB_COLUMN_NAME_RE.finditer(path.read_text(encoding="utf-8"))
+    }
+
+
 def _count_aci_post_routes(repo_root: Path) -> int:
     """Count the POST routes the ACI server publishes.
 
@@ -279,6 +315,25 @@ def _count_aci_post_routes(repo_root: Path) -> int:
     if not path.is_file():
         return 0
     return len(_ACI_POST_ROUTE_RE.findall(path.read_text(encoding="utf-8")))
+
+
+def _aci_post_route_names(repo_root: Path) -> set[str]:
+    """List the literal paths in direct ACI POST route registrations.
+
+    Args:
+        repo_root: The repository root to resolve the server module against.
+
+    Returns:
+        The registered route paths, matching the identities enumerated in both
+        ACI seam docs.
+    """
+    path = repo_root / "runner" / "src" / "curie_runner" / "server.py"
+    if not path.is_file():
+        return set()
+    return {
+        match.group("path")
+        for match in _ACI_POST_ROUTE_NAME_RE.finditer(path.read_text(encoding="utf-8"))
+    }
 
 
 def _count_state_api_routes(repo_root: Path) -> int:
@@ -400,20 +455,25 @@ class NameSetClaim:
     likely one, because confining these imports is #844 Phase 2's refactor and
     moving imports between modules is precisely what it does (#1019).
 
-    ``pattern`` must capture the region holding the list in group 1; the names
-    are then read out of it as backticked tokens, so re-ordering or re-wrapping
-    the sentence does not matter but changing the membership does.
+    ``pattern`` must capture the region holding the list in group 1, and
+    ``item_pattern`` captures each identity within that region. Reordering or
+    rewrapping the sentence does not matter, but changing the membership does.
     """
 
     doc: str
     label: str
     pattern: re.Pattern[str]
+    item_pattern: re.Pattern[str]
     lister: Callable[[Path], set[str]]
     source: str
 
 
-# A backticked file name inside the enumerated region.
-_BACKTICKED_NAME_RE = re.compile(r"`([^`]+\.py)`")
+# Backticked identities inside each kind of enumerated region. Keeping these
+# claim specific prevents class names and explanatory inline code from being
+# mistaken for inventory members.
+_BACKTICKED_PY_NAME_RE = re.compile(r"`([^`]+\.py)`")
+_BACKTICKED_ACI_ROUTE_RE = re.compile(r"`(?:POST )?(/v1/[^`]+)`")
+_BACKTICKED_COLUMN_NAME_RE = re.compile(r"`([a-z][a-z0-9_]*)`")
 
 # Every enumeration claim the seam catalog makes.
 NAME_CLAIMS: tuple[NameSetClaim, ...] = (
@@ -423,8 +483,51 @@ NAME_CLAIMS: tuple[NameSetClaim, ...] = (
         # The parenthesised run after the claim sentence. DOTALL because the
         # list wraps across lines in the prose.
         pattern=re.compile(r"claude_agent_sdk`\s+today\s+\(([^)]*)\)", re.DOTALL),
+        item_pattern=_BACKTICKED_PY_NAME_RE,
         lister=_sdk_importing_runner_module_names,
         source="`from`/`import claude_agent_sdk` in runner/src/**/*.py",
+    ),
+    NameSetClaim(
+        doc="docs/interfaces/aci-producer/INTERFACE.md",
+        label="ACI POST endpoints, by route path",
+        pattern=re.compile(
+            r"POST\s+endpoints\s+\([^)]*\):\s*(.*?)(?=\s*Two GETs)",
+            re.DOTALL,
+        ),
+        item_pattern=_BACKTICKED_ACI_ROUTE_RE,
+        lister=_aci_post_route_names,
+        source=(
+            "direct web.post route registrations in "
+            "runner/src/curie_runner/server.py"
+        ),
+    ),
+    NameSetClaim(
+        doc="docs/interfaces/aci-producer/implementing-an-aci-server.md",
+        label="ACI POST routes in the implementer's guide, by path",
+        pattern=re.compile(
+            r"exposes\s+\S+\s+POST\s+routes.*?\n\n(.*?)(?=\n\nPlus two unauthenticated GETs)",
+            re.DOTALL,
+        ),
+        item_pattern=_BACKTICKED_ACI_ROUTE_RE,
+        lister=_aci_post_route_names,
+        source=(
+            "direct web.post route registrations in "
+            "runner/src/curie_runner/server.py"
+        ),
+    ),
+    NameSetClaim(
+        doc="docs/interfaces/relational-db/INTERFACE.md",
+        label="JSONB columns in the API models, by name",
+        pattern=re.compile(
+            r"used on \*\*\S+\*\* columns:\s*(.*?)(?:\. The last one|\.\s*$)",
+            re.DOTALL,
+        ),
+        item_pattern=_BACKTICKED_COLUMN_NAME_RE,
+        lister=_jsonb_column_names,
+        source=(
+            "direct mapped_column(JSONB declarations in "
+            "apps/api/src/curie_api/models.py"
+        ),
     ),
 )
 
@@ -482,7 +585,7 @@ def check_name_sets(
 
         expected = claim.lister(repo_root)
         for region in regions:
-            listed = set(_BACKTICKED_NAME_RE.findall(region))
+            listed = set(claim.item_pattern.findall(region))
             missing = sorted(expected - listed)
             extra = sorted(listed - expected)
             if not missing and not extra:

--- a/tools/doclint/tests/test_counts.py
+++ b/tools/doclint/tests/test_counts.py
@@ -116,6 +116,30 @@ def _relational_db_prose(count: str) -> str:
     return f"`JSONB` is imported from the dialect and used on **{count}** columns.\n"
 
 
+def _aci_names_prose() -> str:
+    """The ACI seam's route enumeration, in the house phrasing."""
+    return (
+        "A second implementation is an **ACI server**, an HTTP process serving\n"
+        "the four POST endpoints (`runner/src/curie_runner/server.py`): "
+        "`POST /v1/event` opens a\n"
+        "turn, `POST /v1/steer` injects into the live turn,\n"
+        "`POST /v1/interrupt` hard stops it, and `POST /v1/reset` discards "
+        "the conversation.\n"
+        "Two GETs sit alongside them.\n"
+    )
+
+
+def _relational_db_names_prose() -> str:
+    """The relational DB seam's JSONB enumeration, in the house phrasing."""
+    return (
+        "`JSONB` is imported from the dialect and used on **six** columns:\n"
+        "`behavior_packs`, `approval_required_tools`, `approval_routes` and "
+        "`secrets` on\n"
+        "`Agent`, `evidence` on `ApprovalAuditEntry`, and `value` on\n"
+        "`WorkflowStateEntry`.\n"
+    )
+
+
 # --- the count disagrees with the tree: the named drift class --------------
 
 
@@ -526,6 +550,54 @@ def test_renamed_module_is_reported_by_name(tmp_path: Path) -> None:
     assert len(findings) == 1, findings
     detail = findings[0].reason
     assert "runtime.py" in detail and "session.py" in detail, detail
+
+
+def test_renamed_aci_route_is_reported_when_the_count_is_unchanged(
+    tmp_path: Path,
+) -> None:
+    write(
+        tmp_path,
+        _ACI_SERVER,
+        'web.post("/v1/event", _event),\n'
+        'web.post("/v1/followup", _steer),\n'
+        'web.post("/v1/interrupt", _interrupt),\n'
+        'web.post("/v1/reset", _reset),\n',
+    )
+    write(tmp_path, _ACI_DOC, _aci_names_prose())
+
+    assert check_counts(tmp_path) == []
+
+    findings = check_name_sets(tmp_path)
+    assert len(findings) == 1, findings
+    detail = findings[0].reason
+    assert "/v1/followup" in detail and "/v1/steer" in detail, detail
+
+
+def test_renamed_jsonb_column_is_reported_when_the_count_is_unchanged(
+    tmp_path: Path,
+) -> None:
+    write(
+        tmp_path,
+        "apps/api/src/curie_api/models.py",
+        "behavior_settings = mapped_column(JSONB)\n"
+        "approval_required_tools = mapped_column(JSONB)\n"
+        "approval_routes = mapped_column(JSONB)\n"
+        "secrets = mapped_column(JSONB)\n"
+        "evidence = mapped_column(JSONB)\n"
+        "value = mapped_column(JSONB)\n",
+    )
+    write(tmp_path, _RELATIONAL_DB_DOC, _relational_db_names_prose())
+
+    assert check_counts(tmp_path) == []
+
+    findings = check_name_sets(tmp_path)
+    assert len(findings) == 1, findings
+    detail = findings[0].reason
+    assert "behavior_settings" in detail and "behavior_packs" in detail, detail
+
+
+def test_every_name_set_claim_matches_the_real_repository() -> None:
+    assert check_name_sets(REPO_ROOT) == []
 
 
 def test_swapped_import_is_caught_though_the_count_is_unchanged(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Preserves absent approval route channels in JSON, routes PriorityClass recovery through Curie, adds the local E2E selection command, pins catalog identities, and corrects stock Langfuse access guidance. Items 1, 2, and 4 remain isolated in #1716. Items 8, 10, and 11 are declined with reasons on #1644.

## Related issue

Closes #1644

## End to end verification

* Local is required because CLI output and command behavior changed. Fake mode passed on commit 88b1fc54 with `CURIE_E2E_TIERS=local CURIE_BIN=/tmp/curie-1644-target/debug/curie /tmp/curie-1644-target/debug/curie dev e2e-ladder`. The turn finalized with reply `all done`, the weather suite resolved one case, and teardown reported no Curie containers.
* Skill is not applicable because no plugin packaging, runner loop, ACI event, or skill command changed.
* Local release is not applicable because no released image, binary identity, install path, version pin, or release compose changed.
* Cluster is not applicable because no chart template, RBAC, policy, sandbox, or init container changed.
* Live provider is not applicable because no model route, provider credential, token, or cost behavior changed.
* External integration is not applicable because no Slack, webhook, OAuth, or third party API behavior changed.
* Positive proof also includes the full Rust suite, 178 Python checks, 147 UI tests, field parity, and docs lint.
* Falsifiable negatives returned `PINNED` for the approval channel, PriorityClass recovery, and E2E selection tests. Reversing the doclint product hunk made both identity mutation tests fail.

## Checklist

* [x] Every required tier names its command, commit, mode, and observed outcome.
* [x] Each meaningful behavior change has positive proof and a falsifiable negative.
* [x] No required tier is unproved.
* [x] Tests pass for every touched area.
* [x] Documentation reflects the changed behavior.
* [x] No ADR is needed because this is not an architectural decision.