### PR TITLE
Share span attribute keys with observability reader

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "redis>=5.0",
     "plugin-format",
     "aci-protocol",
+    "curie-telemetry-schema",
 ]
 
 [build-system]

--- a/apps/api/src/curie_api/langfuse.py
+++ b/apps/api/src/curie_api/langfuse.py
@@ -11,6 +11,7 @@ import json
 from typing import Any
 
 import httpx
+from curie_telemetry_schema import SpanAttributeKey
 
 from .config import Settings
 from .schemas import ObservationNode
@@ -44,11 +45,11 @@ def matching_traces(
 
 # The OTel resource attribute the runner stamps (runner/otel.py) so a trace is
 # attributable to the concrete sandbox that served it.
-_SANDBOX_ATTR = "curie.sandbox_id"
+_SANDBOX_ATTR = SpanAttributeKey.CURIE_SANDBOX_ID.value
 
 # The OTel span attribute the runner stamps on the root agent.run span (ADR-0076
 # Stone 3, #889) when a turn resumes a resolved approval.
-_APPROVAL_DECISION_ATTR = "gen_ai.approval.decision"
+_APPROVAL_DECISION_ATTR = SpanAttributeKey.APPROVAL_DECISION.value
 
 
 def _probe_attr(bag: Any, key: str, *, bare_key: str | None = None) -> str | None:

--- a/apps/api/tests/test_langfuse_import_boundary.py
+++ b/apps/api/tests/test_langfuse_import_boundary.py
@@ -1,0 +1,36 @@
+"""Import boundary for the Langfuse observability reader."""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_importing_langfuse_does_not_load_the_runner_or_harness_sdk() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import json, sys; import curie_api.langfuse; print(json.dumps(sorted(sys.modules)))",
+        ],
+        check=True,
+        capture_output=True,
+        cwd=Path(__file__).resolve().parents[3],
+        text=True,
+    )
+
+    imported_modules = json.loads(result.stdout)
+    forbidden_prefixes = ("claude_agent_sdk", "curie_runner")
+    leaked_modules = [
+        module
+        for module in imported_modules
+        if module == forbidden_prefixes[0]
+        or module.startswith(f"{forbidden_prefixes[0]}.")
+        or module == forbidden_prefixes[1]
+        or module.startswith(f"{forbidden_prefixes[1]}.")
+    ]
+
+    assert not leaked_modules, (
+        "curie_api.langfuse must not load runner or harness modules: "
+        f"{leaked_modules}"
+    )

--- a/docs/interfaces/telemetry-otel/INTERFACE.md
+++ b/docs/interfaces/telemetry-otel/INTERFACE.md
@@ -34,7 +34,7 @@ A second backend must ingest the OTLP-HTTP export produced in
 attribute schema, not an open bag of `gen_ai.*` keys:
 
 - **The vocabulary is closed and committed.** `SpanAttributeKey`
-  (`runner/src/curie_runner/otel.py::SpanAttributeKey`) is the only key set the runner
+  (`packages/telemetry-schema/src/curie_telemetry_schema/__init__.py::SpanAttributeKey`) is the only key set the runner
   may attach: `langfuse.trace.name`, `langfuse.session.id`, `langfuse.user.id`,
   `gen_ai.approval.decision`, `gen_ai.request.model`, a bare `model`,
   `gen_ai.usage.input_tokens` / `output_tokens` / `cache_read_input_tokens` /

--- a/packages/telemetry-schema/pyproject.toml
+++ b/packages/telemetry-schema/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "curie-telemetry-schema"
+version = "0.0.0"
+description = "Shared Curie telemetry attribute key schema"
+requires-python = ">=3.13"
+dependencies = []
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/curie_telemetry_schema"]

--- a/packages/telemetry-schema/src/curie_telemetry_schema/__init__.py
+++ b/packages/telemetry-schema/src/curie_telemetry_schema/__init__.py
@@ -1,0 +1,38 @@
+"""Shared telemetry attribute key schema."""
+
+from enum import StrEnum
+
+
+class SpanAttributeKey(StrEnum):
+    """The closed set of keys the runner may attach to a span or resource.
+
+    ADR-0076 decision 1. Str-mixin so a member is usable anywhere a plain
+    attribute-value string is expected (e.g. dict keys, f-strings), but every
+    ``set_attribute``/``Resource.create`` call site should pass a member here
+    rather than a literal, so an unlisted key is a construction-time error.
+    """
+
+    TRACE_NAME = "langfuse.trace.name"
+    SESSION_ID = "langfuse.session.id"
+    USER_ID = "langfuse.user.id"
+    # ADR-0076 Stone 3 (#889, epic #512): the resolved terminal decision
+    # (approved/rejected/expired) of the approval a resume turn is resuming
+    # from, threaded in from the worker's authority-free CURIE_APPROVAL_DECISION
+    # boot-env fact. Closes the "did an approval get requested" gap ADR-0038
+    # named open, on the existing span stream.
+    APPROVAL_DECISION = "gen_ai.approval.decision"
+    REQUEST_MODEL = "gen_ai.request.model"
+    MODEL = "model"
+    USAGE_INPUT_TOKENS = "gen_ai.usage.input_tokens"
+    USAGE_OUTPUT_TOKENS = "gen_ai.usage.output_tokens"
+    USAGE_CACHE_READ_INPUT_TOKENS = "gen_ai.usage.cache_read_input_tokens"
+    USAGE_CACHE_CREATION_INPUT_TOKENS = "gen_ai.usage.cache_creation_input_tokens"
+    TOOL_NAME = "gen_ai.tool.name"
+    OPERATION_NAME = "gen_ai.operation.name"
+    SERVICE_NAME = "service.name"
+    CURIE_SESSION_ID = "curie.session_id"
+    CURIE_SANDBOX_ID = "curie.sandbox_id"
+    SCHEMA_VERSION_KEY = "schema.version"
+
+
+__all__ = ["SpanAttributeKey"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ requires-python = ">=3.13"
 dependencies = [
     "aci-protocol",
     "curie-channel-protocol",
+    "curie-telemetry-schema",
     "plugin-format",
     "curie-api",
     "curie-dispatcher",
@@ -21,6 +22,7 @@ members = [
     "packages/aci-protocol",
     "packages/channel-protocol",
     "packages/plugin-format",
+    "packages/telemetry-schema",
     "packages/test-support",
     "apps/api",
     "apps/dispatcher",
@@ -33,6 +35,7 @@ members = [
 [tool.uv.sources]
 aci-protocol = { workspace = true }
 curie-channel-protocol = { workspace = true }
+curie-telemetry-schema = { workspace = true }
 plugin-format = { workspace = true }
 curie-test-support = { workspace = true }
 curie-api = { workspace = true }
@@ -70,6 +73,7 @@ root_packages = [
     "curie_worker",
     "curie_dispatcher",
     "curie_runner",
+    "curie_telemetry_schema",
     # The frozen contract packages (#961). Outside the graph, no contract could
     # ever fire on them, which left the worst possible place for an SDK import
     # ungated. Clean today; the contract below keeps them that way.
@@ -80,6 +84,24 @@ root_packages = [
 # Required for the contracts below: `claude_agent_sdk` is an EXTERNAL package, and
 # import-linter only tracks imports that leave the root packages when told to.
 include_external_packages = true
+
+[[tool.importlinter.contracts]]
+# Telemetry attribute names are shared schema, not an application or harness
+# integration surface. Keeping this package independent lets every producer and
+# consumer use the exact same enum without reversing a runtime dependency.
+name = "The telemetry schema package stays independent"
+type = "forbidden"
+source_modules = ["curie_telemetry_schema"]
+forbidden_modules = [
+    "curie_api",
+    "curie_worker",
+    "curie_dispatcher",
+    "curie_runner",
+    "aci_protocol",
+    "channel_protocol",
+    "plugin_format",
+    "claude_agent_sdk",
+]
 
 [[tool.importlinter.contracts]]
 # The SDK is a runner-side concern. If the platform ever imports it directly, the
@@ -168,6 +190,7 @@ mypy_path = [
     "packages/aci-protocol/src",
     "packages/channel-protocol/src",
     "packages/plugin-format/src",
+    "packages/telemetry-schema/src",
     "packages/test-support/src",
     "apps/api/src",
     "apps/dispatcher/src",
@@ -180,6 +203,7 @@ files = [
     "packages/aci-protocol/src",
     "packages/channel-protocol/src",
     "packages/plugin-format/src",
+    "packages/telemetry-schema/src",
     "packages/test-support/src",
     "apps/api/src",
     "apps/dispatcher/src",

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -2,7 +2,8 @@
 # full ACI v0.1 runner.
 #
 # BUILD FROM THE REPO ROOT, not from runner/, because the runner compiles against
-# the frozen workspace packages (packages/aci-protocol, packages/plugin-format):
+# the frozen workspace packages (packages/aci-protocol, packages/plugin-format)
+# and shared telemetry schema (packages/telemetry-schema):
 #
 #   docker build -f runner/Dockerfile -t curie-runner .
 #
@@ -44,22 +45,27 @@ RUN npm install -g @modelcontextprotocol/server-github@2025.4.8
 
 WORKDIR /app
 
-# The three source trees the runner needs: the two frozen workspace packages and
-# the runner itself. Copied by path so the image is reproducible from the lockfile
-# above them (root pyproject/uv.lock are the workspace source of truth).
+# The four source trees the runner needs: the two frozen workspace packages, the
+# shared telemetry schema, and the runner itself. Copied by path so the image is
+# reproducible from the lockfile above them (root pyproject/uv.lock are the
+# workspace source of truth).
 COPY uv.lock ./uv.lock
 COPY packages/aci-protocol ./packages/aci-protocol
 COPY packages/plugin-format ./packages/plugin-format
+COPY packages/telemetry-schema ./packages/telemetry-schema
 COPY runner ./runner
 
 # One venv. Install every local project without dependencies, then install the
 # full registry dependency closure exported from the tested workspace uv.lock.
 # The local packages are installed by path first so the
-# "aci-protocol"/"plugin-format" requirements resolve to the copied trees, not
-# a same-named PyPI distribution.
+# workspace requirements resolve to the copied trees, not same-named PyPI
+# distributions.
 RUN python3 -m venv /app/.venv \
     && /app/.venv/bin/pip install --no-cache-dir --upgrade pip \
-    && /app/.venv/bin/pip install --no-cache-dir --no-deps ./packages/aci-protocol ./packages/plugin-format \
+    && /app/.venv/bin/pip install --no-cache-dir --no-deps \
+        ./packages/aci-protocol \
+        ./packages/plugin-format \
+        ./packages/telemetry-schema \
     && /app/.venv/bin/pip install --no-cache-dir --no-deps ./runner \
     && python3 runner/export_dependency_pins.py < uv.lock > /tmp/runner-dependency-pins.txt \
     && /app/.venv/bin/pip install --no-cache-dir --no-deps -r /tmp/runner-dependency-pins.txt

--- a/runner/pyproject.toml
+++ b/runner/pyproject.toml
@@ -5,6 +5,7 @@ description = "Curie runner: claude-agent-sdk streaming session server implement
 requires-python = ">=3.13"
 dependencies = [
     "aci-protocol",
+    "curie-telemetry-schema",
     "plugin-format",
     "claude-agent-sdk>=0.2.135",
     "aiohttp>=3.14.3",

--- a/runner/src/curie_runner/otel.py
+++ b/runner/src/curie_runner/otel.py
@@ -15,8 +15,8 @@ opentelemetry SDK's own env parsing applies (it appends ``/v1/traces`` to a base
 ``OTEL_EXPORTER_OTLP_ENDPOINT``). When no endpoint is configured the tracer is a
 no-op, so unit tests and offline runs neither export nor fail.
 
-Per ADR-0076, every attribute this module attaches comes from the closed
-``SpanAttributeKey`` enum below rather than a bare string, so a future call site
+Per ADR-0076, every attribute this module attaches comes from the shared closed
+``SpanAttributeKey`` enum rather than a bare string, so a future call site
 with an unlisted key is a construction-time error, not a silent addition to the
 wire shape. ``SCHEMA_VERSION`` is bumped only when a key is removed, renamed, or
 changes value type; a new optional key is additive and does not bump it.
@@ -28,10 +28,10 @@ from __future__ import annotations
 
 from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
-from enum import StrEnum
 from typing import Any, cast
 
 from aci_protocol import OtelConfig
+from curie_telemetry_schema import SpanAttributeKey as SpanAttributeKey
 from opentelemetry import trace
 from opentelemetry.attributes import BoundedAttributes
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
@@ -49,42 +49,10 @@ _SERVICE_NAME = "curie-runner"
 SCHEMA_VERSION = "v1"
 
 
-class SpanAttributeKey(StrEnum):
-    """The closed set of keys the runner may attach to a span or resource.
-
-    ADR-0076 decision 1. Str-mixin so a member is usable anywhere a plain
-    attribute-value string is expected (e.g. dict keys, f-strings), but every
-    ``set_attribute``/``Resource.create`` call site should pass a member here
-    rather than a literal, so an unlisted key is a construction-time error.
-    """
-
-    TRACE_NAME = "langfuse.trace.name"
-    SESSION_ID = "langfuse.session.id"
-    USER_ID = "langfuse.user.id"
-    # ADR-0076 Stone 3 (#889, epic #512): the resolved terminal decision
-    # (approved/rejected/expired) of the approval a resume turn is resuming
-    # from, threaded in from the worker's authority-free CURIE_APPROVAL_DECISION
-    # boot-env fact. Closes the "did an approval get requested" gap ADR-0038
-    # named open, on the existing span stream.
-    APPROVAL_DECISION = "gen_ai.approval.decision"
-    REQUEST_MODEL = "gen_ai.request.model"
-    MODEL = "model"
-    USAGE_INPUT_TOKENS = "gen_ai.usage.input_tokens"
-    USAGE_OUTPUT_TOKENS = "gen_ai.usage.output_tokens"
-    USAGE_CACHE_READ_INPUT_TOKENS = "gen_ai.usage.cache_read_input_tokens"
-    USAGE_CACHE_CREATION_INPUT_TOKENS = "gen_ai.usage.cache_creation_input_tokens"
-    TOOL_NAME = "gen_ai.tool.name"
-    OPERATION_NAME = "gen_ai.operation.name"
-    SERVICE_NAME = "service.name"
-    CURIE_SESSION_ID = "curie.session_id"
-    CURIE_SANDBOX_ID = "curie.sandbox_id"
-    SCHEMA_VERSION_KEY = "schema.version"
-
-
 # ADR-0076 decision 2: a value-type change to an existing key is a breaking,
 # version-bump-worthy change exactly like a remove or rename, so it needs its
 # own source of truth to diff against -- the type half of the closed schema,
-# parallel to ``SpanAttributeKey`` being the key half. Every member above must
+# parallel to ``SpanAttributeKey`` being the key half. Every member must
 # appear here exactly once, mapped to its value-type name ("str" or "int");
 # the ``gen_ai.usage.*`` token counts are the only "int" members (see
 # ``record_usage`` below and ``redact.py``'s "only str and int attributes are

--- a/runner/tests/test_otel_schema_drift.py
+++ b/runner/tests/test_otel_schema_drift.py
@@ -2,7 +2,7 @@
 
 Mirrors ADR-0074's committed-artifact-plus-CI-gate discipline for the CLI's
 ``--json`` schemas, adapted for this Python-only surface: ``SpanAttributeKey``
-(``otel.py``) is the single source of truth in code, this file's committed
+(``curie_telemetry_schema``) is the single source of truth in code, this file's committed
 mirror (``runner/schema/otel-attributes.schema.json``) is the reviewed
 artifact, and the tests below fail loudly if the two diverge -- catching a
 new attribute key, a bumped ``SCHEMA_VERSION``, or a value-TYPE change to an
@@ -22,20 +22,116 @@ key=lambda m: m.value)}}`` as indented JSON to
 stable diff).
 """
 
+import ast
 import json
 from pathlib import Path
 
 import anyio
 from aci_protocol import Event, OtelConfig
-from curie_runner import RunTracer, SideEffectClassifier, build_tracer_provider
+from curie_runner import (
+    RunTracer,
+    SideEffectClassifier,
+    build_tracer_provider,
+)
+from curie_runner import (
+    SpanAttributeKey as RunnerSpanAttributeKey,
+)
 from curie_runner.fake import FakeModelSession
-from curie_runner.otel import SCHEMA_VERSION, SPAN_ATTRIBUTE_VALUE_TYPES, SpanAttributeKey
+from curie_runner.otel import SCHEMA_VERSION, SPAN_ATTRIBUTE_VALUE_TYPES
 from curie_runner.session import SessionRunner
+from curie_telemetry_schema import SpanAttributeKey
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
 _SCHEMA_PATH = Path(__file__).parent.parent / "schema" / "otel-attributes.schema.json"
+_REPO_ROOT = Path(__file__).parents[2]
+_ENUM_SOURCE = (
+    _REPO_ROOT
+    / "packages"
+    / "telemetry-schema"
+    / "src"
+    / "curie_telemetry_schema"
+    / "__init__.py"
+)
+
+
+def _production_python_modules() -> list[Path]:
+    source_dirs = (
+        _REPO_ROOT / "runner" / "src",
+        *sorted(_REPO_ROOT.glob("apps/*/src")),
+        *sorted(_REPO_ROOT.glob("packages/*/src")),
+    )
+    return sorted(
+        module
+        for source_dir in source_dirs
+        for module in source_dir.rglob("*.py")
+        if module != _ENUM_SOURCE
+    )
+
+
+def _display_module_path(module: Path) -> Path:
+    try:
+        return module.relative_to(_REPO_ROOT)
+    except ValueError:
+        return module
+
+
+def _open_coded_span_attribute_values(
+    modules: list[Path] | None = None,
+) -> list[tuple[Path, int, str, str]]:
+    # The bare "model" value is a common domain field, not a distinct OTel
+    # namespace, so it cannot identify a consumer drift.
+    members_by_value = {
+        member.value: member
+        for member in SpanAttributeKey
+        if member is not SpanAttributeKey.MODEL
+    }
+    violations: list[tuple[Path, int, str, str]] = []
+    modules_to_scan = _production_python_modules() if modules is None else modules
+
+    assert modules_to_scan, "The OTel literal scan must inspect at least one production module."
+
+    for module in modules_to_scan:
+        tree = ast.parse(module.read_text(), filename=str(module))
+        docstring_nodes = {
+            id(owner.body[0].value)
+            for owner in ast.walk(tree)
+            if isinstance(
+                owner,
+                (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef),
+            )
+            and owner.body
+            and isinstance(owner.body[0], ast.Expr)
+            and isinstance(owner.body[0].value, ast.Constant)
+            and isinstance(owner.body[0].value.value, str)
+        }
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Constant) or not isinstance(node.value, str):
+                continue
+            if id(node) in docstring_nodes:
+                continue
+            member = members_by_value.get(node.value)
+            if member is not None:
+                violations.append(
+                    (
+                        _display_module_path(module),
+                        node.lineno,
+                        node.value,
+                        member.name,
+                    )
+                )
+
+    return sorted(violations)
+
+
+def test_literal_scan_reports_the_exact_enum_key_in_an_injected_module(tmp_path: Path) -> None:
+    module = tmp_path / "consumer.py"
+    module.write_text('attribute = "curie.sandbox_id"\n')
+
+    assert _open_coded_span_attribute_values([module]) == [
+        (module, 1, "curie.sandbox_id", "CURIE_SANDBOX_ID")
+    ]
 
 
 def _committed_schema() -> dict:
@@ -63,12 +159,30 @@ def test_committed_schema_matches_the_enum() -> None:
     committed_keys = _committed_schema()["keys"]
     code_keys = {member.value: SPAN_ATTRIBUTE_VALUE_TYPES[member] for member in SpanAttributeKey}
     assert code_keys == committed_keys, (
-        "SpanAttributeKey (otel.py) and the committed schema "
+        "SpanAttributeKey (curie_telemetry_schema) and the committed schema "
         f"({_SCHEMA_PATH}) have diverged -- a key was added, removed, or "
         "RETYPED on one side but not the other (a retyped value, e.g. an "
         "attribute switching from str to int, trips this gate too). "
         "Regenerate the committed file (see this module's docstring) and "
         "commit it alongside the code change."
+    )
+
+
+def test_runner_reexports_the_shared_span_attribute_key_enum() -> None:
+    assert RunnerSpanAttributeKey is SpanAttributeKey
+
+
+def test_production_consumers_resolve_span_attribute_keys_through_the_enum() -> None:
+    violations = _open_coded_span_attribute_values()
+
+    assert not violations, (
+        "Production consumers must resolve OTel span attribute keys through "
+        "SpanAttributeKey instead of restating its values:\n"
+        + "\n".join(
+            f"{path}:{line}: {literal!r} must use "
+            f"SpanAttributeKey.{member}.value"
+            for path, line, literal, member in violations
+        )
     )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -17,6 +17,7 @@ members = [
     "curie-dispatcher",
     "curie-doclint",
     "curie-runner",
+    "curie-telemetry-schema",
     "curie-test-support",
     "curie-wire-tolerance-gate",
     "curie-worker",
@@ -535,6 +536,7 @@ dependencies = [
     { name = "asyncpg" },
     { name = "boto3" },
     { name = "boto3-stubs", extra = ["s3"] },
+    { name = "curie-telemetry-schema" },
     { name = "fastapi" },
     { name = "httpx" },
     { name = "kubernetes" },
@@ -555,6 +557,7 @@ requires-dist = [
     { name = "asyncpg", specifier = ">=0.30" },
     { name = "boto3", specifier = ">=1.43.55" },
     { name = "boto3-stubs", extras = ["s3"], specifier = ">=1.43.57" },
+    { name = "curie-telemetry-schema", editable = "packages/telemetry-schema" },
     { name = "fastapi", specifier = ">=0.139.2" },
     { name = "httpx", specifier = ">=0.28" },
     { name = "kubernetes", specifier = ">=36.0.3" },
@@ -626,6 +629,7 @@ dependencies = [
     { name = "aiohttp" },
     { name = "anyio" },
     { name = "claude-agent-sdk" },
+    { name = "curie-telemetry-schema" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-sdk" },
     { name = "plugin-format" },
@@ -637,10 +641,16 @@ requires-dist = [
     { name = "aiohttp", specifier = ">=3.14.3" },
     { name = "anyio", specifier = ">=4.6" },
     { name = "claude-agent-sdk", specifier = ">=0.2.135" },
+    { name = "curie-telemetry-schema", editable = "packages/telemetry-schema" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.30" },
     { name = "opentelemetry-sdk", specifier = ">=1.44.0" },
     { name = "plugin-format", editable = "packages/plugin-format" },
 ]
+
+[[package]]
+name = "curie-telemetry-schema"
+version = "0.0.0"
+source = { editable = "packages/telemetry-schema" }
 
 [[package]]
 name = "curie-test-support"
@@ -711,6 +721,7 @@ dependencies = [
     { name = "curie-channel-protocol" },
     { name = "curie-dispatcher" },
     { name = "curie-runner" },
+    { name = "curie-telemetry-schema" },
     { name = "curie-worker" },
     { name = "plugin-format" },
 ]
@@ -737,6 +748,7 @@ requires-dist = [
     { name = "curie-channel-protocol", editable = "packages/channel-protocol" },
     { name = "curie-dispatcher", editable = "apps/dispatcher" },
     { name = "curie-runner", editable = "runner" },
+    { name = "curie-telemetry-schema", editable = "packages/telemetry-schema" },
     { name = "curie-worker", editable = "apps/worker" },
     { name = "plugin-format", editable = "packages/plugin-format" },
 ]


### PR DESCRIPTION
## Summary

Moves `SpanAttributeKey` into the independent `curie-telemetry-schema` package so the runner and API observability reader share one definition without loading runner dependencies into the API. Extends the drift gate across production Python consumers.

## Related issue

Closes #1589

## End to end verification

Candidate commit: `20c75fc8`

* skill: required because runner schema packaging changed. Fake mode. `CARGO_TARGET_DIR="$PWD/cli/target" CURIE_E2E_TIERS=skill,local curie dev e2e-ladder` completed with `LADDER PASS (tiers: skill,local)`.
* local: required because API runtime wiring changed. The same command deployed the bundle, finalized a local turn, verified bundle identity, and removed all runner containers.
* local-release: not applicable because released image identity, installation, version pins, and release compose are unchanged.
* cluster: not applicable because charts, RBAC, sandbox claims, and cluster templates are unchanged.
* live provider: not applicable because model routing, credentials, authentication, and accounting are unchanged.
* external integration: not applicable because no third party API shape or authentication changed.

Positive proof: `uv run pytest apps/api/tests runner/tests -q` completed with 1438 passed and 8 skipped. The reader uses the shared enum and API import isolation passes.

Negative proof: changing `CURIE_SANDBOX_ID` to `curie.sandbox_ref` made `runner/tests/test_otel_schema_drift.py` fail in three tests. Replacing the API enum reference with `"curie.sandbox_id"` made the consumer gate fail with the exact file, line, and required enum member.

## Checklist

* [x] Every required tier names the exact command, candidate commit, mode, and observed outcome.
* [x] Each acceptance criterion has positive proof and a falsifiable negative.
* [x] Tests, type checks, lint, import contracts, lock verification, docs lint, and commit message checks pass.
* [x] The seam catalog points to the shared enum definition.
* [x] No ADR is needed because this applies the existing ADR 0076 contract.
