### PR TITLE
Harden git flow webhook inputs

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -62,6 +62,9 @@
           "repo_full_name": {
             "anyOf": [
               {
+                "maxLength": 140,
+                "minLength": 3,
+                "pattern": "^[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*/[A-Za-z0-9._-]+$",
                 "type": "string"
               },
               {
@@ -272,6 +275,9 @@
           "repo_full_name": {
             "anyOf": [
               {
+                "maxLength": 140,
+                "minLength": 3,
+                "pattern": "^[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*/[A-Za-z0-9._-]+$",
                 "type": "string"
               },
               {

--- a/apps/api/src/curie_api/commitpoller.py
+++ b/apps/api/src/curie_api/commitpoller.py
@@ -48,6 +48,7 @@ from typing import Any, Protocol
 import httpx
 
 from .config import Settings
+from .repo_full_name import InvalidRepoFullName, repo_url_path
 
 logger = logging.getLogger(__name__)
 
@@ -196,6 +197,7 @@ class GitHubBranchTip:
         return 60.0
 
     def sha_for(self, repo_full_name: str, branch: str) -> str | None:
+        repository_path = repo_url_path(repo_full_name)
         now = time.time()
         wait_until = self._retry_at.get(repo_full_name, 0.0)
         if now < wait_until:
@@ -210,7 +212,10 @@ class GitHubBranchTip:
         }
         if token:
             headers["Authorization"] = f"Bearer {token}"
-        url = f"{self._settings.github_api_url.rstrip('/')}/repos/{repo_full_name}/commits/{branch}"
+        url = (
+            f"{self._settings.github_api_url.rstrip('/')}"
+            f"/repos/{repository_path}/commits/{branch}"
+        )
         with httpx.Client(timeout=self._timeout) as client:
             response = client.get(url, headers=headers)
         if response.status_code in (403, 429):
@@ -367,14 +372,24 @@ class CommitPoller:
 
         binding_snapshots = {repo: tuple(names) for repo, names in bindings.items()}
 
-        targets = [
-            PollTarget(
-                repo_full_name=repo,
-                clone_url=gitflow.trusted_clone_url(repo, self._settings),
-                branches=tuple(branch_for_env.values()),
+        targets: list[PollTarget] = []
+        for repo in bindings:
+            try:
+                clone_url = gitflow.trusted_clone_url(repo, self._settings)
+            except InvalidRepoFullName as exc:
+                logger.warning(
+                    "commit poll skipping invalid repository binding repo=%r: %s",
+                    repo,
+                    exc,
+                )
+                continue
+            targets.append(
+                PollTarget(
+                    repo_full_name=repo,
+                    clone_url=clone_url,
+                    branches=tuple(branch_for_env.values()),
+                )
             )
-            for repo in bindings
-        ]
         # to_thread because the tip reader is sync httpx: a blocking call in
         # the event loop would stall every request the API is serving.
         moves: list[Move] = await asyncio.to_thread(moves_to_deploy, targets, self._tips, deployed)

--- a/apps/api/src/curie_api/gitflow.py
+++ b/apps/api/src/curie_api/gitflow.py
@@ -33,6 +33,7 @@ from .config import Settings
 from .evalqueue import EvalQueue, now_iso
 from .github_app import credentials_for
 from .models import Agent, AgentVersion, Environment
+from .repo_full_name import InvalidRepoFullName, repo_url_path
 from .schemas import WebhookResult
 from .storage import ObjectStore
 
@@ -57,6 +58,10 @@ class GitFlowError(Exception):
 
 class CloneOriginMismatch(GitFlowError):
     """The payload's clone URL is not the registered repository's origin."""
+
+
+class CommitNotOnBranch(GitFlowError):
+    """The pushed commit is not reachable from the payload's deploy branch."""
 
 
 def verify_signature(secret: str, body: bytes, header: str | None) -> bool:
@@ -96,7 +101,7 @@ def trusted_clone_url(repo_full_name: str, settings: Settings) -> str:
     only ever travel to the configured host (#1122).
     """
 
-    return f"{settings.github_clone_base.rstrip('/')}/{repo_full_name}.git"
+    return f"{settings.github_clone_base.rstrip('/')}/{repo_url_path(repo_full_name)}.git"
 
 
 def _origin_key(url: str) -> tuple[str, str, str, str, int | None, str, str, str]:
@@ -189,7 +194,9 @@ def _clone_credential_env(
     }
 
 
-def _git_failure_detail(exc: BaseException) -> str:
+def _git_failure_detail(
+    exc: BaseException | subprocess.CompletedProcess[bytes],
+) -> str:
     """git's stderr, which says *why* -- 'Repository not found' vs a timeout.
 
     The old message interpolated the exception, whose repr is the argv and an
@@ -213,6 +220,7 @@ def clone_and_archive(
     settings: Settings,
     *,
     repo_full_name: str,
+    ref: str,
     credentials: Any = None,
 ) -> bytes:
     """Mirror-clone the repo and return a tar of the tree at ``sha``.
@@ -256,6 +264,7 @@ def clone_and_archive(
     env = {
         **os.environ,
         "GIT_ALLOW_PROTOCOL": "file:https:http",
+        "GIT_NO_REPLACE_OBJECTS": "1",
         "GIT_TERMINAL_PROMPT": "0",
         **_clone_credential_env(
             trusted_url, settings, repo_full_name=repo_full_name, credentials=credentials
@@ -288,6 +297,22 @@ def clone_and_archive(
                 env=env,
                 timeout=120,
             )
+            ancestry = subprocess.run(
+                ["git", "-C", tmp, "merge-base", "--is-ancestor", sha, ref],
+                check=False,
+                capture_output=True,
+                env=env,
+                timeout=120,
+            )
+            if ancestry.returncode == 1:
+                raise CommitNotOnBranch(
+                    f"commit {sha[:12]} is not reachable from {ref}"
+                )
+            if ancestry.returncode != 0:
+                raise GitFlowError(
+                    f"could not verify commit {sha[:12]} against {ref}: "
+                    f"{_git_failure_detail(ancestry)}"
+                )
             archived = subprocess.run(
                 ["git", "-C", tmp, "archive", "--format=tar", "--", sha],
                 check=True,
@@ -353,7 +378,9 @@ async def process_push(
     ref = payload.get("ref")
     after = payload.get("after")
     repo = payload.get("repository")
-    environment = environment_for_ref(ref if isinstance(ref, str) else None, settings)
+    if not isinstance(ref, str):
+        return WebhookResult(status="ignored")
+    environment = environment_for_ref(ref, settings)
     if environment is None:
         return WebhookResult(status="ignored")
     if not isinstance(after, str) or after == _ZERO_SHA or not _is_valid_sha(after):
@@ -393,11 +420,21 @@ async def process_push(
             after,
             settings,
             repo_full_name=trusted_repo_full_name,
+            ref=ref,
         )
         extension, content_type = deploy.validate_archive(archive, settings)
+    except InvalidRepoFullName as exc:
+        return WebhookResult(
+            status="rejected", errors=[{"code": "git.invalid_repository", "message": str(exc)}]
+        )
     except CloneOriginMismatch as exc:
         return WebhookResult(
             status="rejected", errors=[{"code": "git.origin_mismatch", "message": str(exc)}]
+        )
+    except CommitNotOnBranch as exc:
+        return WebhookResult(
+            status="rejected",
+            errors=[{"code": "git.commit_not_on_branch", "message": str(exc)}],
         )
     except GitFlowError as exc:
         return WebhookResult(

--- a/apps/api/src/curie_api/github_app.py
+++ b/apps/api/src/curie_api/github_app.py
@@ -34,6 +34,11 @@ import httpx
 import jwt
 
 from .config import Settings
+from .repo_full_name import (
+    InvalidRepoFullName,
+    normalize_repo_full_name,
+    repo_url_path,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -170,6 +175,11 @@ class GitHubCredentials:
         token as "send no Authorization header".
         """
 
+        try:
+            repo_full_name = normalize_repo_full_name(repo_full_name)
+        except InvalidRepoFullName as exc:
+            raise GitHubAppError(str(exc)) from exc
+
         if not self.app_configured:
             return self.settings.github_token
 
@@ -206,7 +216,10 @@ class GitHubCredentials:
         if known is not None:
             return known
 
-        url = f"{self.settings.github_api_url.rstrip('/')}/repos/{repo_full_name}/installation"
+        url = (
+            f"{self.settings.github_api_url.rstrip('/')}"
+            f"/repos/{repo_url_path(repo_full_name)}/installation"
+        )
         data = self._get(url)
         installation_id = data.get("id")
         if not isinstance(installation_id, int):
@@ -223,7 +236,7 @@ class GitHubCredentials:
         # Scoped to this one repository even though the installation may cover
         # more. A credential that leaks is then useless against the others --
         # the narrowing ADR-0092 buys over an org-wide PAT.
-        owner, _, repo = repo_full_name.partition("/")
+        _, repo = repo_full_name.split("/", 1)
         data = self._post(url, {"repositories": [repo]} if repo else None)
 
         token = data.get("token")

--- a/apps/api/src/curie_api/github_checks.py
+++ b/apps/api/src/curie_api/github_checks.py
@@ -11,6 +11,8 @@ from typing import Literal
 
 import httpx
 
+from .repo_full_name import repo_url_path
+
 logger = logging.getLogger(__name__)
 
 State = Literal["success", "failure", "pending", "error"]
@@ -73,6 +75,7 @@ class GitHubStatusReporter:
                 description,
             )
             return state
+        repository_path = repo_url_path(repo_full_name)
         payload: dict[str, str] = {
             "state": state,
             "context": self._context,
@@ -81,7 +84,7 @@ class GitHubStatusReporter:
         if target_url:
             payload["target_url"] = target_url
         resp = await self._client.post(
-            f"{self._api_url}/repos/{repo_full_name}/statuses/{sha}",
+            f"{self._api_url}/repos/{repository_path}/statuses/{sha}",
             json=payload,
             headers={
                 "Accept": "application/vnd.github+json",

--- a/apps/api/src/curie_api/models.py
+++ b/apps/api/src/curie_api/models.py
@@ -12,9 +12,10 @@ from typing import Any
 
 from sqlalchemy import Enum, ForeignKey, UniqueConstraint, func
 from sqlalchemy.dialects.postgresql import JSONB, UUID
-from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.orm import Mapped, mapped_column, relationship, validates
 
 from .db import SCHEMA, Base
+from .repo_full_name import normalize_repo_full_name
 
 
 class Environment(enum.StrEnum):
@@ -50,6 +51,13 @@ class Agent(Base):
     # sharing a repository is intended, two sharing a channel is silent
     # shadowing.
     repo_full_name: Mapped[str | None] = mapped_column(default=None, index=True)
+
+    @validates("repo_full_name")
+    def _validate_repo_full_name(self, _key: str, value: str | None) -> str | None:
+        if value is None:
+            return None
+        return normalize_repo_full_name(value)
+
     # Per-agent budget (L1). Field names match the frozen ACI SessionConfig
     # CURIE_BUDGET so the worker passes them straight through at sandbox boot;
     # NULL means platform defaults apply.
@@ -418,4 +426,3 @@ class ConsoleSession(Base):
     consumed_at: Mapped[datetime | None] = mapped_column(default=None)
     revoked_at: Mapped[datetime | None] = mapped_column(default=None)
     created_at: Mapped[datetime] = mapped_column(server_default=func.now())
-

--- a/apps/api/src/curie_api/repo_full_name.py
+++ b/apps/api/src/curie_api/repo_full_name.py
@@ -1,0 +1,51 @@
+"""Strict GitHub repository binding validation and URL path construction."""
+
+import re
+from typing import Annotated
+from urllib.parse import quote
+
+from pydantic import AfterValidator, StringConstraints
+
+_OWNER_RE = re.compile(r"[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*")
+_REPOSITORY_RE = re.compile(r"[A-Za-z0-9._-]+")
+_SCHEMA_RE = r"^[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*/[A-Za-z0-9._-]+$"
+
+
+class InvalidRepoFullName(ValueError):
+    """A repository binding is not one valid GitHub ``owner/name`` pair."""
+
+
+def normalize_repo_full_name(value: str) -> str:
+    """Validate one repository binding and preserve its spelling exactly."""
+
+    if not isinstance(value, str) or value.count("/") != 1:
+        raise InvalidRepoFullName(
+            "repo_full_name must be exactly one GitHub owner/name pair"
+        )
+
+    owner, repository = value.split("/", 1)
+    if (
+        not 1 <= len(owner) <= 39
+        or _OWNER_RE.fullmatch(owner) is None
+        or not 1 <= len(repository) <= 100
+        or repository in {".", ".."}
+        or _REPOSITORY_RE.fullmatch(repository) is None
+    ):
+        raise InvalidRepoFullName(
+            "repo_full_name must be exactly one GitHub owner/name pair"
+        )
+    return value
+
+
+RepoFullName = Annotated[
+    str,
+    StringConstraints(min_length=3, max_length=140, pattern=_SCHEMA_RE),
+    AfterValidator(normalize_repo_full_name),
+]
+
+
+def repo_url_path(repo_full_name: str) -> str:
+    """Return an encoded two segment path for a validated repository binding."""
+
+    owner, repository = normalize_repo_full_name(repo_full_name).split("/", 1)
+    return f"{quote(owner, safe='')}/{quote(repository, safe='')}"

--- a/apps/api/src/curie_api/routers/evals.py
+++ b/apps/api/src/curie_api/routers/evals.py
@@ -11,6 +11,7 @@ from ..evalqueue import now_iso
 from ..evals import build_matrix
 from ..github_checks import GitHubReportError
 from ..models import Environment
+from ..repo_full_name import InvalidRepoFullName
 from ..schemas import (
     EvalMatrix,
     EvalReportResult,
@@ -135,6 +136,8 @@ async def report_eval(
             report.total,
             report.target_url,
         )
+    except InvalidRepoFullName as exc:
+        raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, str(exc)) from exc
     except GitHubReportError as exc:
         # A GitHub rejection is a caller/input problem (unknown repo or commit,
         # bad token), not an API server fault: surface it as a 4xx with the

--- a/apps/api/src/curie_api/schemas.py
+++ b/apps/api/src/curie_api/schemas.py
@@ -29,6 +29,7 @@ from pydantic import (
 
 from .config import get_settings
 from .models import Environment
+from .repo_full_name import RepoFullName
 
 # Slack channel IDs start with C (public/private channel), D (DM), or G (legacy
 # private group) followed by uppercase-alphanumeric chars. Allowlist-shaped on
@@ -729,7 +730,7 @@ class AgentCreate(BaseModel):
     # The WRITE model: a create may also configure the reply route (ADR-0096
     # phase 2). `AgentOut.channel` stays the read-only `{kind, address}` pair.
     channel: ChannelBindingWrite
-    repo_full_name: str | None = None
+    repo_full_name: RepoFullName | None = None
     behavior_packs: BehaviorPacksConfig | None = None
     # Per-agent model id, forwarded as CURIE_MODEL at boot (#254). None uses the
     # platform default model.
@@ -807,7 +808,7 @@ class AgentUpdate(BaseModel):
     # SECOND agent of a repo, which the unique index forbade from carrying it --
     # has no other way to be bound. Without this, git-flow cannot find that
     # agent and a target naming it is rejected as unknown.
-    repo_full_name: str | None = None
+    repo_full_name: RepoFullName | None = None
 
     _check_model = field_validator("model")(_validate_model_override)
     _check_thinking = field_validator("thinking")(_validate_thinking_override)

--- a/apps/api/tests/test_agents.py
+++ b/apps/api/tests/test_agents.py
@@ -26,6 +26,11 @@ from sqlalchemy.ext.asyncio import create_async_engine
 # The committed, exported contract -- the artifact every generated client and
 # every drift gate reads, not the in-process Pydantic model.
 OPENAPI = Path(__file__).resolve().parents[1] / "openapi.json"
+REPO_FULL_NAME_CORPUS = json.loads(
+    (Path(__file__).resolve().parents[3] / "tests/vectors/repo-full-name.json").read_text()
+)
+VALID_REPOSITORIES: list[dict[str, Any]] = REPO_FULL_NAME_CORPUS["valid"]
+INVALID_REPOSITORIES: list[dict[str, Any]] = REPO_FULL_NAME_CORPUS["invalid"]
 
 
 def _slack(address: str) -> dict[str, str]:
@@ -105,6 +110,72 @@ def test_two_agents_may_share_one_repository(
     )
     assert second.status_code == 201, second.text
     assert second.json()["repo_full_name"] == "octo/shared-repo"
+
+
+@pytest.mark.parametrize("case", INVALID_REPOSITORIES, ids=lambda case: case["name"])
+def test_repo_full_name_invalid_corpus_is_rejected_on_create_and_patch(
+    case: dict[str, str],
+    client: Any,
+    auth_headers: dict[str, str],
+    clean_db: None,
+) -> None:
+    seed = _create(
+        client,
+        auth_headers,
+        name="repo-patch-target",
+        channel=_slack("C0EXAMPLE1"),
+    )
+    assert seed.status_code == 201, seed.text
+
+    created = _create(
+        client,
+        auth_headers,
+        name="invalid-repo-create",
+        channel=_slack("C0EXAMPLE2"),
+        repo_full_name=case["value"],
+    )
+    patched = client.patch(
+        f"/agents/{seed.json()['id']}",
+        json={"repo_full_name": case["value"]},
+        headers=auth_headers,
+    )
+
+    assert (created.status_code, patched.status_code) == (422, 422), (
+        f"{case['name']} was accepted: create={created.text}, patch={patched.text}"
+    )
+
+
+@pytest.mark.parametrize("case", VALID_REPOSITORIES, ids=lambda case: case["name"])
+def test_repo_full_name_valid_corpus_round_trips_without_normalization(
+    case: dict[str, str],
+    client: Any,
+    auth_headers: dict[str, str],
+    clean_db: None,
+) -> None:
+    created = _create(
+        client,
+        auth_headers,
+        name="valid-repo-create",
+        channel=_slack("C0EXAMPLE1"),
+        repo_full_name=case["value"],
+    )
+    assert created.status_code == 201, created.text
+    assert created.json()["repo_full_name"] == case["value"]
+
+    patch_target = _create(
+        client,
+        auth_headers,
+        name="valid-repo-patch",
+        channel=_slack("C0EXAMPLE2"),
+    )
+    assert patch_target.status_code == 201, patch_target.text
+    patched = client.patch(
+        f"/agents/{patch_target.json()['id']}",
+        json={"repo_full_name": case["value"]},
+        headers=auth_headers,
+    )
+    assert patched.status_code == 200, patched.text
+    assert patched.json()["repo_full_name"] == case["value"]
 
 
 def test_two_agents_may_not_share_one_channel(

--- a/apps/api/tests/test_commitpoller.py
+++ b/apps/api/tests/test_commitpoller.py
@@ -198,7 +198,9 @@ def test_the_lifespan_wires_the_poller_to_the_bundle_store(clean_db: None) -> No
 # --------------------------------------------------------------------------- #
 # Rejections are reported, not called "deployed" (#1268)
 # --------------------------------------------------------------------------- #
-async def _capture_pushes(monkeypatch, *, deployed=None, tips=None) -> list[dict]:
+async def _capture_pushes(
+    monkeypatch, *, deployed=None, tips=None, bindings=None
+) -> list[dict]:
     """Run one real poll_once and return every payload it handed the deploy path.
 
     The point of driving the real method: every mutation the battery found
@@ -215,11 +217,26 @@ async def _capture_pushes(monkeypatch, *, deployed=None, tips=None) -> list[dict
         seen.append(payload)
         return WebhookResult(status="deployed")
 
-    await _run_poll_once(monkeypatch, None, on_push=capture, deployed=deployed, tips=tips)
+    await _run_poll_once(
+        monkeypatch,
+        None,
+        on_push=capture,
+        deployed=deployed,
+        tips=tips,
+        bindings=bindings,
+    )
     return seen
 
 
-async def _run_poll_once(monkeypatch, result, *, on_push=None, deployed=None, tips=None) -> None:
+async def _run_poll_once(
+    monkeypatch,
+    result,
+    *,
+    on_push=None,
+    deployed=None,
+    tips=None,
+    bindings=None,
+) -> None:
     """Drive the real poll_once with a stubbed deploy that returns `result`."""
     from contextlib import asynccontextmanager
 
@@ -236,7 +253,7 @@ async def _run_poll_once(monkeypatch, result, *, on_push=None, deployed=None, ti
             # First query lists bindings, second lists deployed state. Both
             # come from the real SQL in the module.
             if "FROM curie.agents" in str(stmt):
-                return Rows([(REPO, "agent")])
+                return Rows(bindings if bindings is not None else [(REPO, "agent")])
             return Rows(deployed or [])
 
     @asynccontextmanager
@@ -471,6 +488,32 @@ async def test_poll_once_deploys_when_the_recorded_sha_differs(monkeypatch) -> N
 
 
 @pytest.mark.anyio
+async def test_invalid_repo_full_name_is_skipped_without_blocking_valid_binding(
+    monkeypatch, caplog
+) -> None:
+    invalid = "octo/../escape?token=x"
+    valid = "Octo-Corp/repo.name_with-parts"
+    tips = Tips(
+        {
+            (invalid, "dev"): "bad123",
+            (valid, "dev"): "good456",
+            (invalid, "main"): None,
+            (valid, "main"): None,
+        }
+    )
+
+    with caplog.at_level(logging.WARNING, logger="curie_api.commitpoller"):
+        seen = await _capture_pushes(
+            monkeypatch,
+            tips=tips,
+            bindings=[(invalid, "bad-agent"), (valid, "good-agent")],
+        )
+
+    assert [payload["repository"]["full_name"] for payload in seen] == [valid]
+    assert invalid in " ".join(record.getMessage() for record in caplog.records)
+
+
+@pytest.mark.anyio
 async def test_run_forever_stops_when_cancelled() -> None:
     """Shutdown cancels this task and awaits it; it must actually end.
 
@@ -561,6 +604,33 @@ def test_a_404_is_still_a_missing_branch(monkeypatch) -> None:
     # by raising on everything.
     tip = _tip(monkeypatch, lambda r: httpx.Response(404, json={}))
     assert tip.sha_for(REPO, "nope") is None
+
+
+def test_a_valid_repository_is_preserved_in_the_commit_poll_url(monkeypatch) -> None:
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(200, json={"sha": "abc123"})
+
+    repo = "Octo-Corp/repo.name_with-parts"
+    assert _tip(monkeypatch, handler).sha_for(repo, "dev") == "abc123"
+    assert str(captured[0].url) == (
+        f"https://api.github.com/repos/{repo}/commits/dev"
+    )
+
+
+def test_invalid_repo_full_name_is_rejected_before_commit_poll_http(monkeypatch) -> None:
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(200, json={"sha": "abc123"})
+
+    with pytest.raises(ValueError):
+        _tip(monkeypatch, handler).sha_for("octo/../escape?token=x", "dev")
+
+    assert captured == []
 
 
 # Not re-cloning a commit that already settled (#1267)

--- a/apps/api/tests/test_evalqueue_integration.py
+++ b/apps/api/tests/test_evalqueue_integration.py
@@ -152,6 +152,7 @@ def _build_bare_repo(base_dir: Path, repo_full_name: str) -> tuple[str, str]:
     _git("add", "-A", cwd=work)
     _git("commit", "-q", "-m", "init", cwd=work)
     sha = _git("rev-parse", "HEAD", cwd=work)
+    _git("branch", "main", cwd=work)
     bare = base_dir / f"{repo_full_name}.git"
     bare.parent.mkdir(parents=True, exist_ok=True)
     _git("clone", "--quiet", "--bare", str(work), str(bare))

--- a/apps/api/tests/test_evals_report.py
+++ b/apps/api/tests/test_evals_report.py
@@ -1,5 +1,6 @@
 """POST /evals/report -> GitHub commit status (GitHub mocked via a fake reporter)."""
 
+import asyncio
 from typing import Any
 
 import httpx
@@ -120,6 +121,73 @@ def test_report_still_rejects_a_structurally_invalid_body(
     assert resp.status_code == 422, resp.text
     assert resp.json()["detail"][0]["loc"] == ["body", "passed_count"]
     assert reporter.calls == []
+
+
+def test_invalid_repo_full_name_returns_422_without_github_http(
+    auth_headers: dict[str, str],
+) -> None:
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(201, json={})
+
+    github_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    reporter = GitHubStatusReporter(
+        github_client,
+        api_url="https://api.github.com",
+        token="t",
+        context="curie/evals",
+    )
+    app = create_app()
+    app.dependency_overrides[get_github_reporter] = lambda: reporter
+    try:
+        with TestClient(app) as client:
+            resp = client.post(
+                "/evals/report",
+                json={
+                    "repo_full_name": "octo/../escape?token=x",
+                    "sha": "abc123",
+                    "passed_count": 1,
+                    "total": 1,
+                },
+                headers=auth_headers,
+            )
+    finally:
+        asyncio.run(github_client.aclose())
+
+    assert resp.status_code == 422, resp.text
+    assert captured == []
+
+
+def test_report_without_token_accepts_unbound_agent_sentinel() -> None:
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(201, json={})
+
+    github_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    reporter = GitHubStatusReporter(
+        github_client,
+        api_url="https://api.github.com",
+        token="",
+        context="curie/evals",
+    )
+    try:
+        state = asyncio.run(
+            reporter.report_eval(
+                "00000000-0000-0000-0000-000000000001",
+                "abc123",
+                1,
+                1,
+            )
+        )
+    finally:
+        asyncio.run(github_client.aclose())
+
+    assert state == "success"
+    assert captured == []
 
 
 def test_report_requires_api_key(client: Any) -> None:

--- a/apps/api/tests/test_gitflow_integration.py
+++ b/apps/api/tests/test_gitflow_integration.py
@@ -26,6 +26,7 @@ import pytest
 from curie_api import bundles, crud
 from curie_api.config import get_settings
 from curie_test_support.scaffold import scaffolded_deploy_yaml
+from sqlalchemy import text
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 SECRET = get_settings().github_webhook_secret
@@ -97,7 +98,32 @@ def _build_bare_repo(base_dir: Path, repo_full_name: str, files: dict[str, str])
     bare = base_dir / f"{repo_full_name}.git"
     bare.parent.mkdir(parents=True, exist_ok=True)
     _git("clone", "--quiet", "--bare", str(work), str(bare))
+    _git("update-ref", "refs/heads/main", sha, cwd=bare)
     return f"file://{bare}", sha
+
+
+def _build_bare_repo_with_pull_only_commit(
+    base_dir: Path, repo_full_name: str, files: dict[str, str]
+) -> tuple[str, str]:
+    """Add a valid commit only at ``refs/pull/1/head`` in the bare repo."""
+
+    clone_url, _dev_sha = _build_bare_repo(base_dir, repo_full_name, files)
+    work = base_dir / "_work" / repo_full_name
+    marker = work / "PULL_ONLY.txt"
+    marker.write_text("reachable only from the pull ref\n")
+    _git("add", marker.name, cwd=work)
+    _git("commit", "-q", "-m", "pull ref commit", cwd=work)
+    pull_sha = _git("rev-parse", "HEAD", cwd=work)
+
+    bare = base_dir / f"{repo_full_name}.git"
+    _git(
+        "push",
+        "--quiet",
+        str(bare),
+        f"{pull_sha}:refs/pull/1/head",
+        cwd=work,
+    )
+    return clone_url, pull_sha
 
 
 def _post(client: Any, event: str, payload: dict[str, Any], secret: str = SECRET) -> Any:
@@ -139,6 +165,22 @@ def _insert_partial_version(agent_id: str, sha: str) -> None:
                 version_label=sha[:12],
                 created_by="git-flow",
                 commit_sha=sha,
+            )
+        await engine.dispose()
+
+    asyncio.run(_run())
+
+
+def _set_legacy_repo_full_name(agent_id: str, repo_full_name: str) -> None:
+    async def _run() -> None:
+        engine = create_async_engine(get_settings().database_url)
+        async with engine.begin() as connection:
+            await connection.execute(
+                text(
+                    "UPDATE curie.agents SET repo_full_name = :repo_full_name "
+                    "WHERE id = :agent_id"
+                ),
+                {"repo_full_name": repo_full_name, "agent_id": uuid.UUID(agent_id)},
             )
         await engine.dispose()
 
@@ -188,6 +230,67 @@ def test_dev_push_deploys_dev_bot(
     ).json()
     assert len(deployments) == 1
     assert deployments[0]["environment"] == "dev"
+
+
+def test_signed_push_rejects_a_commit_unreachable_from_its_branch(
+    client: Any,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    trusted_clone_base: Path,
+) -> None:
+    agent_id = _register_agent(client, auth_headers)
+    clone_url, pull_sha = _build_bare_repo_with_pull_only_commit(
+        trusted_clone_base, REPO, VALID_FILES
+    )
+
+    response = _post(
+        client,
+        "push",
+        _push_payload("refs/heads/dev", pull_sha, clone_url),
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["status"] == "rejected", body
+    assert {error["code"] for error in body["errors"]} == {
+        "git.commit_not_on_branch"
+    }
+    assert client.get(f"/agents/{agent_id}/versions", headers=auth_headers).json() == []
+    assert (
+        client.get("/deployments", params={"agent_id": agent_id}, headers=auth_headers).json()
+        == []
+    )
+
+
+def test_signed_push_rejects_an_invalid_legacy_repository_binding(
+    client: Any,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    trusted_clone_base: Path,
+) -> None:
+    agent_id = _register_agent(client, auth_headers)
+    invalid_repo = "octo/.."
+    _set_legacy_repo_full_name(agent_id, invalid_repo)
+    payload = _push_payload(
+        "refs/heads/dev",
+        "a" * 40,
+        f"file://{trusted_clone_base}/{REPO}.git",
+    )
+    payload["repository"]["full_name"] = invalid_repo
+
+    response = _post(client, "push", payload)
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["status"] == "rejected", body
+    assert {error["code"] for error in body["errors"]} == {
+        "git.invalid_repository"
+    }
+    assert client.get(f"/agents/{agent_id}/versions", headers=auth_headers).json() == []
+    assert (
+        client.get("/deployments", params={"agent_id": agent_id}, headers=auth_headers).json()
+        == []
+    )
 
 
 def test_patched_repo_binding_routes_a_push(

--- a/apps/api/tests/test_gitflow_redirect.py
+++ b/apps/api/tests/test_gitflow_redirect.py
@@ -27,6 +27,7 @@ from curie_api.gitflow import GitFlowError, clone_and_archive
 
 _REPO = "octo/demo-agent"
 _VALID_SHA1 = "a" * 40
+_DEV_REF = "refs/heads/dev"
 
 
 @dataclass
@@ -153,7 +154,13 @@ def test_a_cross_host_redirect_receives_no_request_from_the_clone(
     payload_url = f"{base}/{_REPO}.git"
 
     with pytest.raises(GitFlowError):
-        clone_and_archive(payload_url, _VALID_SHA1, settings, repo_full_name=_REPO)
+        clone_and_archive(
+            payload_url,
+            _VALID_SHA1,
+            settings,
+            repo_full_name=_REPO,
+            ref=_DEV_REF,
+        )
 
     # Non-vacuity: git really did reach the origin and really was handed a 302.
     assert redirect_servers.origin_requests != [], "git never reached the origin"

--- a/apps/api/tests/test_gitflow_unit.py
+++ b/apps/api/tests/test_gitflow_unit.py
@@ -3,7 +3,10 @@
 import base64
 import hashlib
 import hmac
+import io
 import subprocess
+import tarfile
+from pathlib import Path
 from unittest import mock
 
 import pytest
@@ -25,6 +28,7 @@ _VALID_SHA256 = "a" * 64
 # because the trusted origin is derived from the stored binding plus config and
 # the payload's clone URL is only ever compared against it (#1122).
 _REPO = "octo/demo-agent"
+_DEV_REF = "refs/heads/dev"
 _LOCAL_BASE = "file:///tmp/gitflow-none"
 _ALLOWED_URL = f"{_LOCAL_BASE}/{_REPO}.git"
 _GITHUB_URL = f"https://github.com/{_REPO}.git"
@@ -78,7 +82,13 @@ def test_clone_and_archive_refuses_disallowed_scheme() -> None:
     # asserting the error is not a CloneOriginMismatch pins that ordering.
     settings = _local_settings()
     with pytest.raises(GitFlowError) as err:
-        clone_and_archive("ext::sh -c whoami", "0" * 40, settings, repo_full_name=_REPO)
+        clone_and_archive(
+            "ext::sh -c whoami",
+            "0" * 40,
+            settings,
+            repo_full_name=_REPO,
+            ref=_DEV_REF,
+        )
     assert not isinstance(err.value, CloneOriginMismatch)
     assert "scheme" in str(err.value)
 
@@ -112,12 +122,134 @@ def test_clone_and_archive_rejects_invalid_sha_before_any_subprocess(
     settings = _local_settings()
     with mock.patch("curie_api.gitflow.subprocess.run") as run:
         with pytest.raises(GitFlowError):
-            clone_and_archive(_ALLOWED_URL, bad_sha, settings, repo_full_name=_REPO)
+            clone_and_archive(
+                _ALLOWED_URL,
+                bad_sha,
+                settings,
+                repo_full_name=_REPO,
+                ref=_DEV_REF,
+            )
     run.assert_not_called()
 
 
-def _completed(stdout: bytes = b"") -> subprocess.CompletedProcess:
-    return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout)
+def _completed(
+    stdout: bytes = b"", *, returncode: int = 0, stderr: bytes = b""
+) -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(
+        args=[], returncode=returncode, stdout=stdout, stderr=stderr
+    )
+
+
+def _real_git(cwd: Path, *args: str) -> str:
+    completed = subprocess.run(
+        ["git", "-c", "user.name=t", "-c", "user.email=t", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return completed.stdout.strip()
+
+
+def test_clone_and_archive_ignores_replacement_objects(tmp_path: Path) -> None:
+    base = tmp_path / "remotes"
+    work = tmp_path / "work"
+    bare = base / f"{_REPO}.git"
+    work.mkdir()
+    bare.parent.mkdir(parents=True)
+
+    _real_git(work, "init", "-q", "-b", "dev")
+    marker = work / "marker.txt"
+    marker.write_text("approved tree\n")
+    _real_git(work, "add", marker.name)
+    _real_git(work, "commit", "-q", "-m", "approved")
+    approved_sha = _real_git(work, "rev-parse", "HEAD")
+
+    marker.write_text("replacement tree\n")
+    _real_git(work, "add", marker.name)
+    replacement_tree = _real_git(work, "write-tree")
+    replacement_sha = _real_git(work, "commit-tree", replacement_tree, "-m", "replacement")
+    _real_git(work, "replace", approved_sha, replacement_sha)
+    _real_git(tmp_path, "clone", "--quiet", "--mirror", str(work), str(bare))
+
+    archive = clone_and_archive(
+        f"file://{bare}",
+        approved_sha,
+        Settings(github_clone_base=f"file://{base}"),
+        repo_full_name=_REPO,
+        ref=_DEV_REF,
+    )
+
+    with tarfile.open(fileobj=io.BytesIO(archive), mode="r:") as contents:
+        archived_marker = contents.extractfile("marker.txt")
+        assert archived_marker is not None
+        assert archived_marker.read() == b"approved tree\n"
+
+
+def test_clone_and_archive_allows_a_commit_reachable_from_the_payload_ref() -> None:
+    settings = _local_settings()
+    with mock.patch("curie_api.gitflow.subprocess.run") as run:
+        run.side_effect = [
+            _completed(),
+            _completed(returncode=0),
+            _completed(b"tar-bytes"),
+        ]
+        result = clone_and_archive(
+            _ALLOWED_URL,
+            _VALID_SHA1,
+            settings,
+            repo_full_name=_REPO,
+            ref=_DEV_REF,
+        )
+
+    assert result == b"tar-bytes"
+    merge_base_argv = run.call_args_list[1].args[0]
+    assert merge_base_argv[-4:] == [
+        "merge-base",
+        "--is-ancestor",
+        _VALID_SHA1,
+        _DEV_REF,
+    ]
+
+
+def test_clone_and_archive_rejects_a_commit_unreachable_from_the_payload_ref() -> None:
+    from curie_api.gitflow import CommitNotOnBranch
+
+    settings = _local_settings()
+    with mock.patch("curie_api.gitflow.subprocess.run") as run:
+        run.side_effect = [_completed(), _completed(returncode=1)]
+        with pytest.raises(CommitNotOnBranch):
+            clone_and_archive(
+                _ALLOWED_URL,
+                _VALID_SHA1,
+                settings,
+                repo_full_name=_REPO,
+                ref=_DEV_REF,
+            )
+
+    assert len(run.call_args_list) == 2
+
+
+def test_clone_and_archive_treats_other_merge_base_failures_as_operational() -> None:
+    from curie_api.gitflow import CommitNotOnBranch
+
+    settings = _local_settings()
+    with mock.patch("curie_api.gitflow.subprocess.run") as run:
+        run.side_effect = [
+            _completed(),
+            _completed(returncode=2, stderr=b"fatal: invalid object"),
+        ]
+        with pytest.raises(GitFlowError) as err:
+            clone_and_archive(
+                _ALLOWED_URL,
+                _VALID_SHA1,
+                settings,
+                repo_full_name=_REPO,
+                ref=_DEV_REF,
+            )
+
+    assert not isinstance(err.value, CommitNotOnBranch)
+    assert len(run.call_args_list) == 2
 
 
 @pytest.mark.parametrize("good_sha", [_VALID_SHA1, _VALID_SHA256])
@@ -130,7 +262,13 @@ def test_clone_and_archive_accepts_valid_hex_and_inserts_dash_dash(
     settings = _local_settings()
     with mock.patch("curie_api.gitflow.subprocess.run") as run:
         run.return_value = _completed(b"tar-bytes")
-        result = clone_and_archive(_ALLOWED_URL, good_sha, settings, repo_full_name=_REPO)
+        result = clone_and_archive(
+            _ALLOWED_URL,
+            good_sha,
+            settings,
+            repo_full_name=_REPO,
+            ref=_DEV_REF,
+        )
 
     assert result == b"tar-bytes"
 
@@ -154,6 +292,7 @@ def test_clone_refuses_a_foreign_host_before_any_subprocess() -> None:
                 _VALID_SHA1,
                 settings,
                 repo_full_name=_REPO,
+                ref=_DEV_REF,
             )
     run.assert_not_called()
 
@@ -206,7 +345,13 @@ def test_clone_refuses_every_mismatch_dimension_before_any_subprocess(
     settings = Settings(github_token="ghs-secret-token")
     with mock.patch("curie_api.gitflow.subprocess.run") as run:
         with pytest.raises(CloneOriginMismatch):
-            clone_and_archive(payload_url, _VALID_SHA1, settings, repo_full_name=_REPO)
+            clone_and_archive(
+                payload_url,
+                _VALID_SHA1,
+                settings,
+                repo_full_name=_REPO,
+                ref=_DEV_REF,
+            )
     run.assert_not_called()
 
 
@@ -234,7 +379,13 @@ def test_clone_accepts_the_registered_origin_in_its_equivalent_forms(
     settings = Settings()
     with mock.patch("curie_api.gitflow.subprocess.run") as run:
         run.return_value = _completed(b"tar-bytes")
-        result = clone_and_archive(payload_url, _VALID_SHA1, settings, repo_full_name=_REPO)
+        result = clone_and_archive(
+            payload_url,
+            _VALID_SHA1,
+            settings,
+            repo_full_name=_REPO,
+            ref=_DEV_REF,
+        )
 
     assert result == b"tar-bytes"
     assert _GITHUB_URL in run.call_args_list[0].args[0]
@@ -259,6 +410,7 @@ def test_clone_refuses_a_mixed_case_scheme() -> None:
                 _VALID_SHA1,
                 settings,
                 repo_full_name=_REPO,
+                ref=_DEV_REF,
             )
     assert not isinstance(err.value, CloneOriginMismatch)
     run.assert_not_called()
@@ -290,7 +442,13 @@ def test_clone_refuses_a_configured_base_outside_the_scheme_allowlist(
     settings = Settings(github_token="ghs-secret-token", github_clone_base=clone_base)
     with mock.patch("curie_api.gitflow.subprocess.run") as run:
         with pytest.raises(GitFlowError) as err:
-            clone_and_archive(_GITHUB_URL, _VALID_SHA1, settings, repo_full_name=_REPO)
+            clone_and_archive(
+                _GITHUB_URL,
+                _VALID_SHA1,
+                settings,
+                repo_full_name=_REPO,
+                ref=_DEV_REF,
+            )
     assert not isinstance(err.value, CloneOriginMismatch)
     run.assert_not_called()
 
@@ -308,7 +466,13 @@ def test_clone_refuses_a_configured_base_git_would_read_as_an_option() -> None:
     )
     with mock.patch("curie_api.gitflow.subprocess.run") as run:
         with pytest.raises(GitFlowError) as err:
-            clone_and_archive(_GITHUB_URL, _VALID_SHA1, settings, repo_full_name=_REPO)
+            clone_and_archive(
+                _GITHUB_URL,
+                _VALID_SHA1,
+                settings,
+                repo_full_name=_REPO,
+                ref=_DEV_REF,
+            )
     assert not isinstance(err.value, CloneOriginMismatch)
     run.assert_not_called()
 
@@ -321,7 +485,13 @@ def test_clone_argv_inserts_dash_dash_before_the_url() -> None:
     settings = Settings()
     with mock.patch("curie_api.gitflow.subprocess.run") as run:
         run.return_value = _completed(b"tar-bytes")
-        clone_and_archive(_GITHUB_URL, _VALID_SHA1, settings, repo_full_name=_REPO)
+        clone_and_archive(
+            _GITHUB_URL,
+            _VALID_SHA1,
+            settings,
+            repo_full_name=_REPO,
+            ref=_DEV_REF,
+        )
 
     clone_argv = next(call.args[0] for call in run.call_args_list if "clone" in call.args[0])
     assert "--" in clone_argv, clone_argv
@@ -339,7 +509,13 @@ def test_clone_accepts_a_well_formed_https_base() -> None:
     settings = Settings(github_clone_base=base)
     with mock.patch("curie_api.gitflow.subprocess.run") as run:
         run.return_value = _completed(b"tar-bytes")
-        result = clone_and_archive(derived, _VALID_SHA1, settings, repo_full_name=_REPO)
+        result = clone_and_archive(
+            derived,
+            _VALID_SHA1,
+            settings,
+            repo_full_name=_REPO,
+            ref=_DEV_REF,
+        )
 
     assert result == b"tar-bytes"
     assert derived in run.call_args_list[0].args[0]
@@ -356,7 +532,13 @@ def test_clone_hands_git_the_derived_origin_not_the_payload_url() -> None:
     settings = Settings(github_token="ghs-secret-token")
     with mock.patch("curie_api.gitflow.subprocess.run") as run:
         run.return_value = _completed(b"tar-bytes")
-        clone_and_archive(payload_url, _VALID_SHA1, settings, repo_full_name=_REPO)
+        clone_and_archive(
+            payload_url,
+            _VALID_SHA1,
+            settings,
+            repo_full_name=_REPO,
+            ref=_DEV_REF,
+        )
 
     argv = run.call_args_list[0].args[0]
     assert _GITHUB_URL in argv
@@ -387,7 +569,13 @@ def test_clone_credential_is_keyed_to_the_derived_origin(
     settings = Settings(github_token="ghs-secret-token", github_clone_base=clone_base)
     with mock.patch("curie_api.gitflow.subprocess.run") as run:
         run.return_value = _completed(b"tar-bytes")
-        clone_and_archive(derived, _VALID_SHA1, settings, repo_full_name=repo)
+        clone_and_archive(
+            derived,
+            _VALID_SHA1,
+            settings,
+            repo_full_name=repo,
+            ref=_DEV_REF,
+        )
 
     clone_call = run.call_args_list[0]
     argv = clone_call.args[0]
@@ -416,7 +604,13 @@ def test_clone_pins_redirect_following_off() -> None:
     settings = _local_settings()
     with mock.patch("curie_api.gitflow.subprocess.run") as run:
         run.return_value = _completed(b"tar-bytes")
-        clone_and_archive(_ALLOWED_URL, _VALID_SHA1, settings, repo_full_name=_REPO)
+        clone_and_archive(
+            _ALLOWED_URL,
+            _VALID_SHA1,
+            settings,
+            repo_full_name=_REPO,
+            ref=_DEV_REF,
+        )
 
     argv = run.call_args_list[0].args[0]
     assert "-c" in argv, argv
@@ -434,6 +628,7 @@ def test_clone_sends_no_credential_when_none_is_configured() -> None:
             _VALID_SHA1,
             settings,
             repo_full_name="acme/public",
+            ref=_DEV_REF,
         )
     env = run.call_args_list[0].kwargs["env"]
     assert "GIT_CONFIG_COUNT" not in env
@@ -450,10 +645,11 @@ def test_clone_does_not_send_the_credential_over_plain_http() -> None:
     with mock.patch("curie_api.gitflow.subprocess.run") as run:
         run.return_value = _completed(b"tar-bytes")
         clone_and_archive(
-            "http://insecure.example/repo.git",
+            "http://insecure.example/acme/repo.git",
             _VALID_SHA1,
             settings,
-            repo_full_name="repo",
+            repo_full_name="acme/repo",
+            ref=_DEV_REF,
         )
     assert "GIT_CONFIG_COUNT" not in run.call_args_list[0].kwargs["env"]
 
@@ -468,7 +664,13 @@ def test_clone_failure_reports_git_stderr_not_the_exit_code() -> None:
     )
     with mock.patch("curie_api.gitflow.subprocess.run", side_effect=failure):
         with pytest.raises(GitFlowError) as err:
-            clone_and_archive(_ALLOWED_URL, _VALID_SHA1, settings, repo_full_name=_REPO)
+            clone_and_archive(
+                _ALLOWED_URL,
+                _VALID_SHA1,
+                settings,
+                repo_full_name=_REPO,
+                ref=_DEV_REF,
+            )
     assert "Repository not found" in str(err.value)
 
 

--- a/apps/api/tests/test_github_app.py
+++ b/apps/api/tests/test_github_app.py
@@ -150,6 +150,32 @@ def test_the_installation_is_discovered_not_configured(private_key: str, github:
     assert "github_app_installation_id" not in Settings.model_fields
 
 
+def test_a_valid_repository_is_preserved_in_app_lookup_and_token_scope(
+    private_key: str, github: Recorder
+) -> None:
+    repo = "Octo-Corp/repo.name_with-parts"
+
+    GitHubCredentials(settings=app_settings(private_key)).token_for(repo)
+
+    lookup = [call for call in github.calls if call[1].endswith("/installation")]
+    mint = [call for call in github.calls if call[1].endswith("/access_tokens")]
+    assert lookup[0][1] == f"https://api.github.com/repos/{repo}/installation"
+    assert mint[0][2] == {"repositories": ["repo.name_with-parts"]}
+
+
+def test_invalid_repo_full_name_never_reaches_github_app_http(
+    private_key: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    recorder = Recorder()
+    monkeypatch.setattr("curie_api.github_app.httpx.Client", serve(recorder.handle))
+    creds = GitHubCredentials(settings=app_settings(private_key))
+
+    with pytest.raises(GitHubAppError):
+        creds.token_for("octo/../escape?token=x")
+
+    assert recorder.calls == []
+
+
 # --------------------------------------------------------------------------- #
 # Caching
 # --------------------------------------------------------------------------- #

--- a/apps/api/tests/test_github_checks.py
+++ b/apps/api/tests/test_github_checks.py
@@ -19,7 +19,9 @@ def test_eval_state_maps_rollup_to_status() -> None:
     assert eval_state(0, 0) == ("failure", "0/0 passed")
 
 
-def _run_report(passed: int, total: int) -> tuple[httpx.Request, str]:
+def _run_report(
+    passed: int, total: int, repo_full_name: str = "octo/demo"
+) -> tuple[httpx.Request, str]:
     captured: list[httpx.Request] = []
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -36,7 +38,7 @@ def _run_report(passed: int, total: int) -> tuple[httpx.Request, str]:
                 context="curie/evals",
             )
             state = await reporter.report_eval(
-                "octo/demo", "abc123def", passed, total, target_url="https://x/run"
+                repo_full_name, "abc123def", passed, total, target_url="https://x/run"
             )
         return captured[0], state
 
@@ -64,6 +66,37 @@ def test_report_eval_posts_the_exact_commit_status() -> None:
 def test_report_eval_success_state() -> None:
     _, state = _run_report(36, 36)
     assert state == "success"
+
+
+def test_report_eval_preserves_a_valid_repository_in_the_status_url() -> None:
+    request, _ = _run_report(36, 36, "Octo-Corp/repo.name_with-parts")
+
+    assert str(request.url) == (
+        "https://api.github.com/repos/Octo-Corp/repo.name_with-parts/statuses/abc123def"
+    )
+
+
+def test_invalid_repo_full_name_is_rejected_before_status_http() -> None:
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(201, json={})
+
+    async def go() -> None:
+        transport = httpx.MockTransport(handler)
+        async with httpx.AsyncClient(transport=transport) as client:
+            reporter = GitHubStatusReporter(
+                client,
+                api_url="https://api.github.com",
+                token="tok-123",
+                context="curie/evals",
+            )
+            with pytest.raises(ValueError):
+                await reporter.report_eval("octo/../escape?token=x", "abc123", 1, 1)
+
+    asyncio.run(go())
+    assert captured == []
 
 
 def test_report_eval_skips_post_when_no_token() -> None:

--- a/apps/api/tests/test_repo_full_name.py
+++ b/apps/api/tests/test_repo_full_name.py
@@ -1,0 +1,55 @@
+"""Repository binding validation at persistence and clone URL boundaries."""
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from curie_api.config import Settings
+from curie_api.gitflow import trusted_clone_url
+from curie_api.models import Agent
+
+_CORPUS = json.loads(
+    (Path(__file__).resolve().parents[3] / "tests/vectors/repo-full-name.json").read_text()
+)
+VALID_REPOSITORIES: list[dict[str, Any]] = _CORPUS["valid"]
+INVALID_REPOSITORIES: list[dict[str, Any]] = _CORPUS["invalid"]
+
+
+@pytest.mark.parametrize("case", VALID_REPOSITORIES, ids=lambda case: case["name"])
+def test_repo_full_name_valid_corpus_preserves_orm_assignment(case: dict[str, str]) -> None:
+    agent = Agent(name=f"valid-{case['name']}")
+    agent.repo_full_name = case["value"]
+
+    assert agent.repo_full_name == case["value"]
+
+
+@pytest.mark.parametrize("case", INVALID_REPOSITORIES, ids=lambda case: case["name"])
+def test_repo_full_name_invalid_corpus_is_refused_on_orm_assignment(
+    case: dict[str, str],
+) -> None:
+    agent = Agent(name=f"invalid-{case['name']}")
+
+    with pytest.raises(ValueError):
+        agent.repo_full_name = case["value"]
+
+
+@pytest.mark.parametrize("case", VALID_REPOSITORIES, ids=lambda case: case["name"])
+def test_repo_full_name_valid_corpus_builds_the_expected_clone_url(
+    case: dict[str, str],
+) -> None:
+    settings = Settings(github_clone_base="https://github.example")
+
+    assert trusted_clone_url(case["value"], settings) == (
+        f"https://github.example/{case['url_path']}.git"
+    )
+
+
+@pytest.mark.parametrize("case", INVALID_REPOSITORIES, ids=lambda case: case["name"])
+def test_repo_full_name_invalid_corpus_never_reaches_a_clone_url(
+    case: dict[str, str],
+) -> None:
+    settings = Settings(github_clone_base="https://github.example")
+
+    with pytest.raises(ValueError):
+        trusted_clone_url(case["value"], settings)

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -495,6 +495,40 @@ fn warn_if_insecure(base_url: &str) {
     }
 }
 
+fn validate_repo_full_name(repo_full_name: &str) -> Result<()> {
+    let Some((owner, repository)) = repo_full_name.split_once('/') else {
+        bail!(
+            "invalid repo_full_name: expected one owner/name pair; the owner must use 1 to 39 \
+             ASCII letters or digits with single nonterminal hyphens, and the name must use 1 \
+             to 100 ASCII letters, digits, dots, underscores, or hyphens other than `.` or `..`"
+        );
+    };
+
+    let owner_valid = (1..=39).contains(&owner.len())
+        && owner
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+        && !owner.starts_with('-')
+        && !owner.ends_with('-')
+        && !owner.contains("--");
+    let repository_valid = (1..=100).contains(&repository.len())
+        && repository != "."
+        && repository != ".."
+        && repository
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-'));
+
+    if !owner_valid || !repository_valid {
+        bail!(
+            "invalid repo_full_name: expected one owner/name pair; the owner must use 1 to 39 \
+             ASCII letters or digits with single nonterminal hyphens, and the name must use 1 \
+             to 100 ASCII letters, digits, dots, underscores, or hyphens other than `.` or `..`"
+        );
+    }
+
+    Ok(())
+}
+
 /// The `POST /agents` body. Pure so the shape is testable without a live API.
 ///
 /// `repo_full_name` is sent only when asked, because a value the caller did not
@@ -743,6 +777,10 @@ impl ApiClient {
         slack_channel: Option<&str>,
         repo_full_name: Option<&str>,
     ) -> Result<(Agent, ChannelOutcome, Option<String>)> {
+        if let Some(repo_full_name) = repo_full_name {
+            validate_repo_full_name(repo_full_name)?;
+        }
+
         let existing = self
             .list_agents()
             .await?

--- a/cli/src/local.rs
+++ b/cli/src/local.rs
@@ -472,7 +472,11 @@ pub async fn with_deploy_unreachable_hint<T>(result: Result<T>, api_url: &str) -
     match result {
         Err(err) if crate::exit::is_transient_reqwest(&err) => {
             if !uses_default_local_api(api_url) {
-                return Err(err.context(deploy_unreachable_hint(api_url, None)));
+                return Err(crate::exit::operator_context(
+                    err,
+                    deploy_unreachable_hint(api_url, None),
+                    None,
+                ));
             }
 
             let cmd = OpsCommand::new(
@@ -485,7 +489,7 @@ pub async fn with_deploy_unreachable_hint<T>(result: Result<T>, api_url: &str) -
                     "the platform API at {api_url} is unreachable, and Curie could not read local compose state. Run `curie local status`, then re-run."
                 ),
             };
-            Err(err.context(hint))
+            Err(crate::exit::operator_context(err, hint, None))
         }
         result => result,
     }
@@ -1646,10 +1650,15 @@ mod tests {
             .await
             .expect_err("port 1 must refuse the test connection");
 
-        let result: anyhow::Result<()> = Err(transient.into());
+        let result: anyhow::Result<()> = Err(crate::exit::operator_context(
+            transient.into(),
+            "the API request failed",
+            None,
+        ));
         let error = with_deploy_unreachable_hint(result, crate::message::DEFAULT_LOCAL_API_URL)
             .await
             .expect_err("the original deploy failure must remain an error");
+        let (normal_message, _) = crate::exit::present_error(&error);
         let rendered = format!("{error:#}");
         let invocations = std::fs::read_to_string(&log).expect("read docker invocation log");
 
@@ -1657,6 +1666,14 @@ mod tests {
             invocations.trim(),
             "compose -p curie ps",
             "diagnosis must inspect the running Curie project by name"
+        );
+        assert!(
+            normal_message.contains("local stack is still starting"),
+            "normal output must select the state aware compose diagnosis: {normal_message}"
+        );
+        assert!(
+            !normal_message.contains("the API request failed"),
+            "normal output must not select the inner generic context: {normal_message}"
         );
         assert!(
             rendered.contains("local stack is still starting"),

--- a/cli/tests/api_deploy.rs
+++ b/cli/tests/api_deploy.rs
@@ -13,6 +13,42 @@ const AGENT_NAME: &str = "deal-desk";
 const VERSION_ID: &str = "22222222-2222-2222-2222-222222222222";
 const DEPLOYMENT_ID: &str = "33333333-3333-3333-3333-333333333333";
 
+#[derive(Debug, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RepoFullNameVectors {
+    comment: String,
+    valid: Vec<ValidRepoFullNameVector>,
+    invalid: Vec<InvalidRepoFullNameVector>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ValidRepoFullNameVector {
+    name: String,
+    value: String,
+    why: String,
+    url_path: String,
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct InvalidRepoFullNameVector {
+    name: String,
+    value: String,
+    why: String,
+}
+
+fn repo_full_name_vectors() -> RepoFullNameVectors {
+    let vectors: RepoFullNameVectors =
+        serde_json::from_str(include_str!("../../tests/vectors/repo-full-name.json"))
+            .expect("parse tests/vectors/repo-full-name.json");
+    assert!(
+        !vectors.comment.is_empty(),
+        "the shared repository name contract must explain its purpose"
+    );
+    vectors
+}
+
 fn route(method: &str, path: &str) -> Response {
     match (method, path) {
         ("GET", "/agents") => Response::json(200, "[]"),
@@ -223,6 +259,14 @@ async fn run_deploy(
     channel: Option<&str>,
     repo: Option<&str>,
 ) -> DeployOutcome {
+    run_deploy_result(client, channel, repo).await.unwrap()
+}
+
+async fn run_deploy_result(
+    client: &ApiClient,
+    channel: Option<&str>,
+    repo: Option<&str>,
+) -> anyhow::Result<DeployOutcome> {
     let dir = tempfile::tempdir().unwrap();
     scaffold(dir.path(), AGENT_NAME).unwrap();
     let archive = pack_tar_gz(dir.path()).unwrap();
@@ -238,7 +282,123 @@ async fn run_deploy(
             repo,
         )
         .await
-        .unwrap()
+}
+
+#[tokio::test]
+async fn invalid_repo_full_names_fail_before_any_http_request() {
+    let server = serve(|_req| Response::json(500, r#"{"detail":"request escaped preflight"}"#));
+    let client = ApiClient::new(&server.base_url, "k").unwrap();
+
+    for case in repo_full_name_vectors().invalid {
+        let err = match run_deploy_result(&client, None, Some(&case.value)).await {
+            Ok(_) => panic!("{} must be rejected: {}", case.name, case.why),
+            Err(err) => err,
+        };
+        let requests = server.recorded();
+        assert!(
+            requests.is_empty(),
+            "{} reached HTTP before validation with {:?}: {requests:?}",
+            case.name,
+            case.value
+        );
+
+        let message = format!("{err:#}");
+        assert!(
+            (message.contains("repo_full_name") || message.contains("--repo"))
+                && message.contains("owner/name"),
+            "{} returned an unactionable error for {:?}: {message}",
+            case.name,
+            case.value
+        );
+    }
+}
+
+#[tokio::test]
+async fn valid_repo_full_names_preserve_create_behavior() {
+    let server = serve(|req| match (req.method.as_str(), req.path.as_str()) {
+        ("GET", "/agents") => Response::json(200, "[]"),
+        ("POST", "/agents") => {
+            let body: serde_json::Value =
+                serde_json::from_slice(&req.body).expect("POST /agents body should be JSON");
+            let repo = body["repo_full_name"]
+                .as_str()
+                .expect("POST /agents should carry repo_full_name");
+            Response::json(201, &agent_json(AGENT_ID, AGENT_NAME, "#old", Some(repo)))
+        }
+        (method, path) => deploy_tail(method, path)
+            .unwrap_or_else(|| panic!("unexpected request: {method} {path}")),
+    });
+    let client = ApiClient::new(&server.base_url, "k").unwrap();
+    let vectors = repo_full_name_vectors();
+
+    for case in &vectors.valid {
+        let outcome = run_deploy(&client, None, Some(&case.value)).await;
+        assert_eq!(
+            outcome.agent.repo_full_name.as_deref(),
+            Some(case.value.as_str()),
+            "{} must preserve {:?}: {} (URL path {:?})",
+            case.name,
+            case.value,
+            case.why,
+            case.url_path
+        );
+    }
+
+    let creates: Vec<serde_json::Value> = server
+        .recorded()
+        .into_iter()
+        .filter(|request| request.method == "POST" && request.path == "/agents")
+        .map(|request| {
+            serde_json::from_slice(&request.body).expect("POST /agents body should be JSON")
+        })
+        .collect();
+    assert_eq!(creates.len(), vectors.valid.len());
+    for (body, case) in creates.iter().zip(&vectors.valid) {
+        assert_eq!(body["repo_full_name"].as_str(), Some(case.value.as_str()));
+    }
+}
+
+#[tokio::test]
+async fn valid_repo_full_names_preserve_bind_behavior() {
+    let server = serve(|req| match (req.method.as_str(), req.path.as_str()) {
+        ("GET", "/agents") => existing_agents(&agent_json(AGENT_ID, AGENT_NAME, "#old", None)),
+        ("PATCH", path) if *path == format!("/agents/{AGENT_ID}") => {
+            let body: serde_json::Value =
+                serde_json::from_slice(&req.body).expect("PATCH /agents/{id} body should be JSON");
+            let repo = body["repo_full_name"]
+                .as_str()
+                .expect("PATCH /agents/{id} should carry repo_full_name");
+            patched_agent("#old", Some(repo))
+        }
+        (method, path) => deploy_tail(method, path)
+            .unwrap_or_else(|| panic!("unexpected request: {method} {path}")),
+    });
+    let client = ApiClient::new(&server.base_url, "k").unwrap();
+    let vectors = repo_full_name_vectors();
+
+    for case in &vectors.valid {
+        let outcome = run_deploy(&client, None, Some(&case.value)).await;
+        assert_eq!(
+            outcome.agent.repo_full_name.as_deref(),
+            Some(case.value.as_str()),
+            "{} must preserve {:?}: {} (URL path {:?})",
+            case.name,
+            case.value,
+            case.why,
+            case.url_path
+        );
+    }
+
+    let patches = patch_bodies(&server);
+    assert_eq!(patches.len(), vectors.valid.len());
+    for (body, case) in patches.iter().zip(&vectors.valid) {
+        assert_eq!(body["repo_full_name"].as_str(), Some(case.value.as_str()));
+        assert!(
+            body.get("channel").is_none(),
+            "{} must bind without changing the channel: {body}",
+            case.name
+        );
+    }
 }
 
 #[tokio::test]

--- a/cli/tests/exit_codes.rs
+++ b/cli/tests/exit_codes.rs
@@ -254,8 +254,12 @@ fn local_deploy_keeps_connection_causes_out_of_the_human_error() {
     );
     let error_line = single_line_with_prefix(&human_stderr, "Error: ");
     assert!(
-        error_line.contains("Start the local stack first with `curie local up`"),
-        "the human error must retain the remedy: {human_stderr}"
+        error_line.contains("Check that --api-url points to a reachable API"),
+        "the human error must retain the custom API remedy: {human_stderr}"
+    );
+    assert!(
+        !error_line.contains("curie local up"),
+        "a custom API failure must not tell the user to start the local stack: {human_stderr}"
     );
     assert_eq!(
         error_line.matches(UNREACHABLE_API_URL).count(),

--- a/tests/vectors/repo-full-name.json
+++ b/tests/vectors/repo-full-name.json
@@ -1,0 +1,275 @@
+{
+  "comment": "Shared repository full name grammar for Python API writes and URL consumers plus Rust CLI deploy preflight. Both lanes preserve valid spelling exactly and reject every invalid value before persistence or network access.",
+  "valid": [
+    {
+      "name": "simple",
+      "value": "octo/demo",
+      "why": "The common owner and repository pair is accepted.",
+      "url_path": "octo/demo"
+    },
+    {
+      "name": "mixed_case_preserved",
+      "value": "OctoCorp/RelayCore",
+      "why": "Owner and repository casing is valid and must not be normalized.",
+      "url_path": "OctoCorp/RelayCore"
+    },
+    {
+      "name": "owner_hyphen",
+      "value": "octo-corp/demo",
+      "why": "A nonterminal single hyphen is legal in a GitHub owner login.",
+      "url_path": "octo-corp/demo"
+    },
+    {
+      "name": "repository_punctuation",
+      "value": "octo/repo.name_with-parts",
+      "why": "Repository dots, underscores, and hyphens are all legal.",
+      "url_path": "octo/repo.name_with-parts"
+    },
+    {
+      "name": "repository_leading_dot",
+      "value": "octo/.github",
+      "why": "A repository may begin with a dot when it is not exactly dot or dot dot.",
+      "url_path": "octo/.github"
+    },
+    {
+      "name": "single_character_segments",
+      "value": "a/r",
+      "why": "One character owner and repository names are valid.",
+      "url_path": "a/r"
+    },
+    {
+      "name": "maximum_owner_length",
+      "value": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/repo",
+      "why": "A GitHub owner login may contain 39 characters.",
+      "url_path": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/repo"
+    },
+    {
+      "name": "maximum_repository_length",
+      "value": "octo/rrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr",
+      "why": "A repository may contain 100 characters.",
+      "url_path": "octo/rrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr"
+    }
+  ],
+  "invalid": [
+    {
+      "name": "empty",
+      "value": "",
+      "why": "A repository binding needs both segments."
+    },
+    {
+      "name": "missing_separator",
+      "value": "octo",
+      "why": "The owner and repository must be separated by exactly one slash."
+    },
+    {
+      "name": "empty_owner",
+      "value": "/demo",
+      "why": "The owner segment cannot be empty."
+    },
+    {
+      "name": "empty_repository",
+      "value": "octo/",
+      "why": "The repository segment cannot be empty."
+    },
+    {
+      "name": "extra_path_segment",
+      "value": "octo/demo/extra",
+      "why": "Only one owner and repository pair is accepted."
+    },
+    {
+      "name": "double_separator",
+      "value": "octo//demo",
+      "why": "An empty segment cannot hide inside extra slashes."
+    },
+    {
+      "name": "dot_owner_traversal",
+      "value": "./demo",
+      "why": "A dot owner is a path traversal segment."
+    },
+    {
+      "name": "parent_owner_traversal",
+      "value": "../demo",
+      "why": "A dot dot owner is a path traversal segment."
+    },
+    {
+      "name": "dot_repository_traversal",
+      "value": "octo/.",
+      "why": "A dot repository is a path traversal segment."
+    },
+    {
+      "name": "parent_repository_traversal",
+      "value": "octo/..",
+      "why": "A dot dot repository is a path traversal segment."
+    },
+    {
+      "name": "encoded_traversal",
+      "value": "octo/%2e%2e",
+      "why": "Percent encoded traversal is not repository syntax."
+    },
+    {
+      "name": "https_url",
+      "value": "https://github.com/octo/demo",
+      "why": "A full URL is not a repository full name."
+    },
+    {
+      "name": "ssh_url",
+      "value": "git@github.com:octo/demo.git",
+      "why": "An SSH URL is not a repository full name."
+    },
+    {
+      "name": "scheme_character",
+      "value": "octo:corp/demo",
+      "why": "A colon cannot introduce URL scheme syntax."
+    },
+    {
+      "name": "userinfo_character",
+      "value": "octo@corp/demo",
+      "why": "An at sign cannot introduce URL user information."
+    },
+    {
+      "name": "carriage_return",
+      "value": "octo/demo\rheader",
+      "why": "A carriage return cannot enter a repository or HTTP path."
+    },
+    {
+      "name": "line_feed",
+      "value": "octo/demo\npath",
+      "why": "A line feed cannot enter a repository or HTTP path."
+    },
+    {
+      "name": "tab",
+      "value": "octo/demo\tpath",
+      "why": "A tab cannot enter a repository or HTTP path."
+    },
+    {
+      "name": "percent_syntax",
+      "value": "octo/demo%2Fother",
+      "why": "Percent syntax cannot smuggle a path delimiter."
+    },
+    {
+      "name": "query_syntax",
+      "value": "octo/demo?ref=main",
+      "why": "A question mark cannot escape into a URL query."
+    },
+    {
+      "name": "fragment_syntax",
+      "value": "octo/demo#fragment",
+      "why": "A hash cannot escape into a URL fragment."
+    },
+    {
+      "name": "backslash",
+      "value": "octo/demo\\other",
+      "why": "A backslash is not a repository character or structural separator."
+    },
+    {
+      "name": "leading_space",
+      "value": " octo/demo",
+      "why": "Whitespace is rejected instead of silently trimmed."
+    },
+    {
+      "name": "trailing_space",
+      "value": "octo/demo ",
+      "why": "Whitespace is rejected instead of silently trimmed."
+    },
+    {
+      "name": "embedded_space",
+      "value": "octo/demo repo",
+      "why": "Whitespace cannot appear inside either segment."
+    },
+    {
+      "name": "owner_leading_hyphen",
+      "value": "-octo/demo",
+      "why": "A GitHub owner login cannot begin with a hyphen."
+    },
+    {
+      "name": "owner_trailing_hyphen",
+      "value": "octo-/demo",
+      "why": "A GitHub owner login cannot end with a hyphen."
+    },
+    {
+      "name": "owner_consecutive_hyphens",
+      "value": "octo--corp/demo",
+      "why": "A GitHub owner login cannot contain consecutive hyphens."
+    },
+    {
+      "name": "owner_underscore",
+      "value": "octo_corp/demo",
+      "why": "A GitHub owner login does not accept repository punctuation."
+    },
+    {
+      "name": "owner_dot",
+      "value": "octo.corp/demo",
+      "why": "A GitHub owner login does not accept repository punctuation."
+    },
+    {
+      "name": "owner_too_long",
+      "value": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/repo",
+      "why": "A GitHub owner login cannot exceed 39 characters."
+    },
+    {
+      "name": "repository_too_long",
+      "value": "octo/rrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr",
+      "why": "A repository cannot exceed 100 characters."
+    },
+    {
+      "name": "unicode_repository",
+      "value": "octo/répo",
+      "why": "The repository grammar is ASCII only."
+    },
+    {
+      "name": "reserved_bang",
+      "value": "octo/demo!",
+      "why": "A reserved URL character is not repository syntax."
+    },
+    {
+      "name": "reserved_dollar",
+      "value": "octo/demo$",
+      "why": "A reserved URL character is not repository syntax."
+    },
+    {
+      "name": "reserved_ampersand",
+      "value": "octo/demo&other",
+      "why": "A reserved URL character is not repository syntax."
+    },
+    {
+      "name": "reserved_quote",
+      "value": "octo/demo'other",
+      "why": "A reserved URL character is not repository syntax."
+    },
+    {
+      "name": "reserved_parentheses",
+      "value": "octo/demo(other)",
+      "why": "Reserved URL characters are not repository syntax."
+    },
+    {
+      "name": "reserved_asterisk",
+      "value": "octo/demo*",
+      "why": "A reserved URL character is not repository syntax."
+    },
+    {
+      "name": "reserved_plus",
+      "value": "octo/demo+other",
+      "why": "A reserved URL character is not repository syntax."
+    },
+    {
+      "name": "reserved_comma",
+      "value": "octo/demo,other",
+      "why": "A reserved URL character is not repository syntax."
+    },
+    {
+      "name": "reserved_semicolon",
+      "value": "octo/demo;other",
+      "why": "A reserved URL character is not repository syntax."
+    },
+    {
+      "name": "reserved_equals",
+      "value": "octo/demo=other",
+      "why": "A reserved URL character is not repository syntax."
+    },
+    {
+      "name": "reserved_brackets",
+      "value": "octo/demo[other]",
+      "why": "Reserved URL characters are not repository syntax."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Verifies each pushed commit is reachable from the branch named by the webhook and ignores hostile Git replacement objects.

Validates repository bindings at API, persistence, CLI, and use boundaries, then encodes repository URL paths consistently.

Closes #1139
Closes #1140