### PR TITLE
Harden CLI secret cleanup and rendering

### DIFF
--- a/cli/CLAUDE.md
+++ b/cli/CLAUDE.md
@@ -141,10 +141,14 @@ Helm and the deployed release with `up`, `status`, `down`, `comms`, `message`,
   fetch via `ensure_cached`; pure argv builders never fetch, and `--dry-run`
   never touches the network.
 - **Credentials are masked, never printed.** Secret `helm --set` values use the
-  `CmdArg::SecretSet` variant (only a masked prefix is echoed, in dry-run or the
-  printed command line) and token flags read from env with `hide_env_values`.
-  Never widen a secret to `Plain` or otherwise print it. The `up` model
-  credential (from `CURIE_MODEL_CREDENTIALS`) flows through this path.
+  `CmdArg::SecretSet` variant, while generic `--set` and `--set-string`
+  credential-shaped values use `CmdArg::HelmSetExpression`: raw expressions stay
+  unchanged for execution, but every rendered form masks them. Malformed
+  expressions fail safe: an unbalanced brace list renders as a fully masked
+  placeholder.
+  Token flags read from env with `hide_env_values`; never widen a secret to
+  `Plain` or otherwise print it. The `up` model credential (from
+  `CURIE_MODEL_CREDENTIALS`) flows through this path.
   `curie cluster comms --slack` uses the same `SecretSet` masking for
   `SLACK_APP_TOKEN` and `SLACK_BOT_TOKEN`, while `--disconnect --dry-run`
   prints only the empty clears. After the helm upgrade it also rolls the

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -780,6 +780,7 @@ dependencies = [
  "serde_norway",
  "serde_urlencoded",
  "sha2 0.11.0",
+ "signal-hook",
  "syn 3.0.3",
  "tar",
  "tempfile",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -47,6 +47,7 @@ serde_urlencoded = "0.7"
 # Content-addressed bundle identity: sha256 of the packed tar.gz, the same
 # digest `apps/api` records for that bundle on deploy (#1087).
 sha2 = "0.11"
+signal-hook = "0.3"
 tar = "0.4"
 time = { version = "0.3", features = ["formatting", "parsing"] }
 uuid = { version = "1", features = ["v4"] }

--- a/cli/src/guide.rs
+++ b/cli/src/guide.rs
@@ -320,7 +320,7 @@ pub fn primer() -> Primer {
         recovery: vec![
             Recovery {
                 symptom: "\"platform API ... unreachable\" on a local deploy or message",
-                fix: "The stack is down. Run `curie local up`, then retry.",
+                fix: "Check the API URL and follow the local status guidance. Run `curie local up` only if local services are absent, then retry.",
             },
             Recovery {
                 symptom: "`curie cluster up` fails immediately when `curie-preflight-gvisor` reports `FailedCreate`: `RuntimeClass \"gvisor\" not found`",

--- a/cli/src/local.rs
+++ b/cli/src/local.rs
@@ -1660,6 +1660,7 @@ mod tests {
             .expect_err("the original deploy failure must remain an error");
         let (normal_message, _) = crate::exit::present_error(&error);
         let rendered = format!("{error:#}");
+        let (presented, _) = crate::exit::present_error(&error);
         let invocations = std::fs::read_to_string(&log).expect("read docker invocation log");
 
         assert_eq!(
@@ -1686,6 +1687,18 @@ mod tests {
         assert!(
             !rendered.contains("curie local up"),
             "a starting stack must not be told to start again: {rendered}"
+        );
+        assert!(
+            presented.contains("local stack is still starting"),
+            "presented error lost the starting state: {presented}"
+        );
+        assert!(
+            presented.contains("curie local status"),
+            "presented error lost the state inspection guidance: {presented}"
+        );
+        assert!(
+            !presented.contains("curie local up"),
+            "presented error must not tell a starting stack to start again: {presented}"
         );
     }
 

--- a/cli/src/local.rs
+++ b/cli/src/local.rs
@@ -1660,7 +1660,6 @@ mod tests {
             .expect_err("the original deploy failure must remain an error");
         let (normal_message, _) = crate::exit::present_error(&error);
         let rendered = format!("{error:#}");
-        let (presented, _) = crate::exit::present_error(&error);
         let invocations = std::fs::read_to_string(&log).expect("read docker invocation log");
 
         assert_eq!(
@@ -1687,18 +1686,6 @@ mod tests {
         assert!(
             !rendered.contains("curie local up"),
             "a starting stack must not be told to start again: {rendered}"
-        );
-        assert!(
-            presented.contains("local stack is still starting"),
-            "presented error lost the starting state: {presented}"
-        );
-        assert!(
-            presented.contains("curie local status"),
-            "presented error lost the state inspection guidance: {presented}"
-        );
-        assert!(
-            !presented.contains("curie local up"),
-            "presented error must not tell a starting stack to start again: {presented}"
         );
     }
 

--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -12,6 +12,8 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::process::Stdio;
 use std::time::Duration;
+#[cfg(unix)]
+use std::sync::{LazyLock, Mutex, MutexGuard, OnceLock};
 
 use anyhow::{bail, Context, Result};
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, BufReader};
@@ -29,6 +31,10 @@ pub struct OpsCommand {
 
 /// A single argv token.
 ///
+/// `HelmSetExpression` preserves a complete `--set` or `--set-string`
+/// expression for execution while masking credential shaped values in every
+/// rendered form.
+///
 /// `SecretSet` is a `helm --set key=value` whose value is a credential: the real
 /// value is used for execution, but only a masked prefix is ever printed (dry-run
 /// or the echoed command line). Note the value still lands in the process argv --
@@ -43,6 +49,7 @@ pub struct OpsCommand {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CmdArg {
     Plain(String),
+    HelmSetExpression(String),
     SecretSet { key: String, value: String },
     SecretValuesFile(Vec<(String, String)>),
 }
@@ -56,6 +63,7 @@ impl CmdArg {
     fn value_tokens(&self) -> Vec<String> {
         match self {
             CmdArg::Plain(s) => vec![s.clone()],
+            CmdArg::HelmSetExpression(expression) => vec![expression.clone()],
             CmdArg::SecretSet { key, value } => vec![format!("{key}={value}")],
             CmdArg::SecretValuesFile(_) => {
                 debug_assert!(
@@ -74,6 +82,9 @@ impl CmdArg {
     fn masked_tokens(&self) -> Vec<String> {
         match self {
             CmdArg::Plain(s) => vec![s.clone()],
+            CmdArg::HelmSetExpression(expression) => {
+                vec![mask_helm_set_expression(expression)]
+            }
             CmdArg::SecretSet { key, value } => vec![format!("{key}={}", mask_secret(value))],
             CmdArg::SecretValuesFile(pairs) => {
                 let masked: Vec<String> = pairs
@@ -144,9 +155,10 @@ impl OpsCommand {
     /// Materialize every [`CmdArg::SecretValuesFile`] into a private (0600)
     /// temporary values file and return an equivalent command whose secrets are
     /// delivered via `helm -f <path>` instead of the argv, plus RAII guards that
-    /// delete those files when dropped (so they are cleaned up even if the helm
-    /// run fails). Commands without a secret values file are returned unchanged
-    /// with no guards. Hold the returned guards until the process has finished.
+    /// delete any remaining files when dropped. The signal cleanup handler also
+    /// removes registered files on SIGINT or SIGTERM. Commands without a secret
+    /// values file are returned unchanged with no guards. Hold the returned guards
+    /// until the process has finished.
     pub(crate) fn materialize_secret_files(
         &self,
     ) -> Result<(OpsCommand, Vec<SecretValuesFileGuard>)> {
@@ -175,8 +187,124 @@ impl OpsCommand {
     }
 }
 
-/// A 0600 temporary helm values file holding secret values; deleted on drop so
-/// the secret never outlives the `helm` invocation, even on error.
+#[cfg(unix)]
+#[derive(Default)]
+struct SecretFileRegistry {
+    terminating: bool,
+    paths: BTreeSet<std::path::PathBuf>,
+}
+
+#[cfg(unix)]
+static SECRET_FILE_REGISTRY: LazyLock<Mutex<SecretFileRegistry>> =
+    LazyLock::new(|| Mutex::new(SecretFileRegistry::default()));
+
+#[cfg(unix)]
+static SECRET_SIGNAL_INSTALLATION: OnceLock<std::result::Result<(), String>> = OnceLock::new();
+
+#[cfg(unix)]
+fn lock_secret_file_registry() -> MutexGuard<'static, SecretFileRegistry> {
+    SECRET_FILE_REGISTRY
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+#[cfg(unix)]
+fn ensure_secret_signal_cleanup() -> Result<()> {
+    match SECRET_SIGNAL_INSTALLATION
+        .get_or_init(|| install_secret_signal_cleanup().map_err(|error| error.to_string()))
+    {
+        Ok(()) => Ok(()),
+        Err(error) => bail!("installing secret values signal cleanup: {error}"),
+    }
+}
+
+#[cfg(not(unix))]
+fn ensure_secret_signal_cleanup() -> Result<()> {
+    Ok(())
+}
+
+#[cfg(unix)]
+fn install_secret_signal_cleanup() -> std::io::Result<()> {
+    let mut signals = signal_hook::iterator::Signals::new([
+        signal_hook::consts::signal::SIGINT,
+        signal_hook::consts::signal::SIGTERM,
+    ])?;
+    std::thread::Builder::new()
+        .name("curie-secret-cleanup".to_string())
+        .spawn(move || {
+            if let Some(signal) = signals.forever().next() {
+                terminate_after_secret_cleanup(signal);
+            }
+        })?;
+    Ok(())
+}
+
+#[cfg(unix)]
+fn terminate_after_secret_cleanup(signal: i32) -> ! {
+    {
+        let mut registry = lock_secret_file_registry();
+        registry.terminating = true;
+        for path in std::mem::take(&mut registry.paths) {
+            let _ = std::fs::remove_file(path);
+        }
+    }
+
+    test_mark_coordination("CURIE_TEST_SECRET_SIGNAL_CLEANED");
+    test_wait_for_coordination("CURIE_TEST_SECRET_RESUME_SIGNAL");
+
+    let _ = signal_hook::low_level::emulate_default_handler(signal);
+    signal_hook::low_level::exit(128 + signal);
+}
+
+#[cfg(unix)]
+fn park_terminating_secret_writer() -> ! {
+    test_mark_coordination("CURIE_TEST_SECRET_WRITER_PARKED");
+    loop {
+        std::thread::park();
+    }
+}
+
+#[cfg(debug_assertions)]
+fn test_mark_coordination(env_name: &str) {
+    if let Some(path) = std::env::var_os(env_name).map(std::path::PathBuf::from) {
+        let _ = std::fs::write(path, b"ready");
+    }
+}
+
+#[cfg(not(debug_assertions))]
+fn test_mark_coordination(_env_name: &str) {}
+
+#[cfg(debug_assertions)]
+fn test_wait_for_coordination(env_name: &str) {
+    if let Some(path) = std::env::var_os(env_name).map(std::path::PathBuf::from) {
+        while !path.exists() {
+            std::thread::sleep(std::time::Duration::from_millis(1));
+        }
+    }
+}
+
+#[cfg(not(debug_assertions))]
+fn test_wait_for_coordination(_env_name: &str) {}
+
+#[cfg(debug_assertions)]
+fn test_pause_after_first_secret_file() {
+    static PAUSED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+    if std::env::var_os("CURIE_TEST_SECRET_FIRST_FILE_WRITTEN").is_none()
+        || PAUSED.swap(true, std::sync::atomic::Ordering::SeqCst)
+    {
+        return;
+    }
+    test_mark_coordination("CURIE_TEST_SECRET_FIRST_FILE_WRITTEN");
+    test_wait_for_coordination("CURIE_TEST_SECRET_RESUME_WRITER");
+}
+
+#[cfg(not(debug_assertions))]
+fn test_pause_after_first_secret_file() {}
+
+/// A 0600 temporary helm values file holding secret values. Signal cleanup
+/// removes it on SIGINT or SIGTERM; `Drop` removes it on normal completion or
+/// error, so the secret never outlives the `helm` invocation.
 pub(crate) struct SecretValuesFileGuard {
     path: std::path::PathBuf,
 }
@@ -187,40 +315,83 @@ impl SecretValuesFileGuard {
     /// with restrictive permissions atomically so the secret is never briefly
     /// world-readable.
     fn write(pairs: &[(String, String)]) -> Result<Self> {
+        ensure_secret_signal_cleanup()?;
+
         let doc = nest_dotted_keys(pairs);
         let body = serde_json::to_vec(&doc).context("serializing secret helm values")?;
 
         let mut path = std::env::temp_dir();
         path.push(format!("curie-helm-values-{}.yaml", uuid::Uuid::new_v4()));
 
-        let mut opts = std::fs::OpenOptions::new();
-        opts.write(true).create_new(true);
         #[cfg(unix)]
         {
-            use std::os::unix::fs::OpenOptionsExt;
-            opts.mode(0o600);
+            let mut registry = lock_secret_file_registry();
+            if registry.terminating {
+                drop(registry);
+                park_terminating_secret_writer();
+            }
+            if !registry.paths.insert(path.clone()) {
+                bail!(
+                    "secret helm values file path collision at {}",
+                    path.display()
+                );
+            }
+            if let Err(error) = create_secret_values_file(&path, &body) {
+                let _ = std::fs::remove_file(&path);
+                registry.paths.remove(&path);
+                return Err(error);
+            }
         }
-        let mut file = opts
-            .open(&path)
-            .with_context(|| format!("creating secret helm values file {}", path.display()))?;
-        // Belt-and-suspenders on platforms where create-time mode is not honored.
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
-                .with_context(|| format!("securing secret helm values file {}", path.display()))?;
+
+        #[cfg(not(unix))]
+        if let Err(error) = create_secret_values_file(&path, &body) {
+            let _ = std::fs::remove_file(&path);
+            return Err(error);
         }
-        use std::io::Write;
-        file.write_all(&body)
-            .with_context(|| format!("writing secret helm values file {}", path.display()))?;
-        Ok(Self { path })
+
+        let guard = Self { path };
+        test_pause_after_first_secret_file();
+        Ok(guard)
     }
+}
+
+fn create_secret_values_file(path: &std::path::Path, body: &[u8]) -> Result<()> {
+    let mut opts = std::fs::OpenOptions::new();
+    opts.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        opts.mode(0o600);
+    }
+    let mut file = opts
+        .open(path)
+        .with_context(|| format!("creating secret helm values file {}", path.display()))?;
+    // Belt-and-suspenders on platforms where create-time mode is not honored.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
+            .with_context(|| format!("securing secret helm values file {}", path.display()))?;
+    }
+    use std::io::Write;
+    file.write_all(body)
+        .with_context(|| format!("writing secret helm values file {}", path.display()))?;
+    Ok(())
 }
 
 impl Drop for SecretValuesFileGuard {
     fn drop(&mut self) {
         // Best-effort cleanup; nothing actionable if the temp file is already gone.
-        let _ = std::fs::remove_file(&self.path);
+        #[cfg(unix)]
+        {
+            let mut registry = lock_secret_file_registry();
+            let _ = std::fs::remove_file(&self.path);
+            registry.paths.remove(&self.path);
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = std::fs::remove_file(&self.path);
+        }
     }
 }
 
@@ -259,10 +430,12 @@ pub(crate) fn secret_set(key: &str, value: &str) -> CmdArg {
     }
 }
 
-/// Mask a secret for display: the first 8 characters, then `***`. Long enough to
-/// recognise a token by its prefix (e.g. `xoxb-...`), short enough to leak
-/// nothing usable.
+/// Mask a secret for display. Values of eight characters or fewer are fully
+/// masked; longer values retain the first eight characters for recognition.
 pub fn mask_secret(value: &str) -> String {
+    if value.chars().nth(8).is_none() {
+        return "***".to_string();
+    }
     let shown: String = value.chars().take(8).collect();
     format!("{shown}***")
 }
@@ -972,10 +1145,18 @@ fn random_hex(n_bytes: usize) -> Result<String> {
     Ok(out)
 }
 
-/// The operator's `--set` arguments split into raw `(key, value)` halves: the
-/// single parser behind [`operator_set_keys`] and
-/// [`set_passthrough_leaks_github_token`], though not the only reader of this
-/// grammar in the file ([`explicit_runner_model`] hand-rolls a last-wins
+/// Split one Helm set element into raw `(key, value)` halves. This is the one
+/// entry parser shared by rendering and the consumers of operator sets.
+fn operator_set_entry(part: &str) -> Option<(&str, &str)> {
+    part.split_once('=')
+}
+
+/// The operator's `--set` arguments split into raw `(key, value)` halves for
+/// [`operator_set_keys`] and [`set_passthrough_leaks_github_token`]. Rendering
+/// uses the separate [`mask_helm_set_expression`] parser, which preserves
+/// escaped commas and brace lists while masking credential-shaped values; do
+/// not reuse this naive split for rendering. This is not the only reader of
+/// this grammar in the file ([`explicit_runner_model`] hand-rolls a last-wins
 /// prefix match with different semantics, and is deliberately left alone).
 /// Handles both repeated
 /// `--set` flags and helm's comma-joined `a=1,b=2` form; an element with no `=`
@@ -989,8 +1170,62 @@ fn random_hex(n_bytes: usize) -> Result<String> {
 fn operator_set_entries(sets: &[String]) -> Vec<(&str, &str)> {
     sets.iter()
         .flat_map(|s| s.split(','))
-        .filter_map(|part| part.split_once('='))
+        .filter_map(operator_set_entry)
         .collect()
+}
+
+/// Render one complete Helm set expression while preserving every executed
+/// byte except credential values, which are replaced by their standard mask.
+fn mask_helm_set_expression(expression: &str) -> String {
+    let render_part = |part: &str| match operator_set_entry(part) {
+        Some((key, value)) if !value.is_empty() && is_secret_value_key(key.trim()) => {
+            format!("{key}={}", mask_secret(value))
+        }
+        _ => part.to_string(),
+    };
+
+    let mut rendered = String::with_capacity(expression.len());
+    let mut start = 0;
+    let mut in_brace_list = false;
+    let mut escaped = false;
+    let mut has_equals = false;
+    let mut at_value_start = false;
+
+    for (index, ch) in expression.char_indices() {
+        if escaped {
+            escaped = false;
+            at_value_start = false;
+            continue;
+        }
+
+        match ch {
+            '\\' => escaped = true,
+            '=' if !has_equals => {
+                has_equals = true;
+                at_value_start = true;
+            }
+            '{' if at_value_start => {
+                in_brace_list = true;
+                at_value_start = false;
+            }
+            '}' if in_brace_list => in_brace_list = false,
+            ',' if !in_brace_list => {
+                rendered.push_str(&render_part(&expression[start..index]));
+                rendered.push(',');
+                start = index + ch.len_utf8();
+                has_equals = false;
+                at_value_start = false;
+            }
+            _ => at_value_start = false,
+        }
+    }
+
+    if in_brace_list {
+        return "<secret helm set expression>".to_string();
+    }
+
+    rendered.push_str(&render_part(&expression[start..]));
+    rendered
 }
 
 /// The bare value keys an operator already pinned through `--set` (so the CLI
@@ -2437,9 +2672,9 @@ pub(crate) fn complete_up_opts(
 /// [`GITHUB_TOKEN_KEY`], i.e. whether the complete token is riding in argv.
 ///
 /// The pass-through stays legal (it is verbatim by design and breaking it would
-/// break existing operators), but a non-empty one leaks into the process table,
-/// shell history and the printed plan, so `up` steers the operator to the
-/// private input. An EMPTY assignment is the operator clearing the key by hand:
+/// break existing operators), but a non-empty one leaks into the process table
+/// and shell history, so `up` steers the operator to the private input. An EMPTY
+/// assignment is the operator clearing the key by hand:
 /// nothing leaks, so warning about it would be noise on a correct command.
 /// Reads the same [`operator_set_entries`] parse the rest of this file does,
 /// since helm accepts the comma-joined `a=1,b=2` form.
@@ -2645,7 +2880,7 @@ impl UpValuePlan {
                         HelmSetFlag::Set => "--set",
                         HelmSetFlag::SetString => "--set-string",
                     }));
-                    args.push(plain(expression));
+                    args.push(CmdArg::HelmSetExpression(expression.clone()));
                 }
                 PlannedHelmValues::SecretFile { values, .. } => {
                     args.push(CmdArg::SecretValuesFile(values.clone()));
@@ -4360,7 +4595,7 @@ async fn run_prepared_up(
         }
     }
     if set_passthrough_leaks_github_token(&opts.operator_sets()) {
-        ui.warn("a GitHub credential passed with --set lands in the process table, shell history and the printed plan; use --github-token, or CURIE_GITHUB_TOKEN to keep it out of shell history too");
+        ui.warn("a GitHub credential passed with --set lands in the process table and shell history; use --github-token, or CURIE_GITHUB_TOKEN to keep it out of shell history too");
     }
 
     if !opts.allow_egress_host.is_empty()
@@ -7481,9 +7716,15 @@ mod tests {
     }
 
     #[test]
-    fn mask_secret_shows_eight_then_stars() {
+    fn mask_secret_uses_shared_long_and_short_contract() {
         assert_eq!(mask_secret("xoxb-abcdefghijk"), "xoxb-abc***");
-        assert_eq!(mask_secret("short"), "short***");
+        for value in ["", "a", "short", "12345678"] {
+            assert_eq!(
+                mask_secret(value),
+                "***",
+                "values of eight characters or fewer must reveal no characters: {value:?}"
+            );
+        }
     }
 
     #[test]

--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -11,9 +11,9 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::process::Stdio;
-use std::time::Duration;
 #[cfg(unix)]
 use std::sync::{LazyLock, Mutex, MutexGuard, OnceLock};
+use std::time::Duration;
 
 use anyhow::{bail, Context, Result};
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, BufReader};

--- a/cli/tests/cluster_secret_hardening.rs
+++ b/cli/tests/cluster_secret_hardening.rs
@@ -1,0 +1,807 @@
+//! Binary and public surface regressions for cluster secret lifecycle and
+//! rendered Helm passthrough values.
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::os::unix::process::ExitStatusExt;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, ExitStatus, Output, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use curie::ops::{up_commands, CmdArg, CommonOpts, GithubTokenPlan, OpsCommand, UpOpts};
+use curie::ui::{CliOutput, DryRunPlan};
+
+const TARGET_RELEASE: &str = "acme-release";
+const TARGET_NAMESPACE: &str = "acme-namespace";
+
+const SET_SECRET: &str = "ghp-SET-SENTINEL-1138";
+const SET_MASKED: &str = "ghp-SET-***";
+const SET_EXPRESSION: &str =
+    "worker.replicas=2,connector.accessToken=ghp-SET-SENTINEL-1138,api.githubToken=,bare";
+const MASKED_SET_EXPRESSION: &str =
+    "worker.replicas=2,connector.accessToken=ghp-SET-***,api.githubToken=,bare";
+
+const SET_STRING_SECRET: &str = "xoxb-STRING-SENTINEL-1138";
+const SET_STRING_MASKED: &str = "xoxb-STR***";
+const SET_STRING_EXPRESSION: &str =
+    "worker.label=blue,connector.clientSecret=xoxb-STRING-SENTINEL-1138";
+const MASKED_SET_STRING_EXPRESSION: &str = "worker.label=blue,connector.clientSecret=xoxb-STR***";
+
+const ESCAPED_COMMA_EXPRESSION: &str = r"connector.accessToken=ghp-ESC\,CLEAR-COMMA-TAIL-1138";
+const ESCAPED_COMMA_MASKED: &str = r"connector.accessToken=ghp-ESC\***";
+const BRACE_LIST_EXPRESSION: &str =
+    "connector.accessTokens={ghp-BRACE-FIRST-1138,ghp-BRACE-SECOND-1138}";
+const BRACE_LIST_MASKED: &str = "connector.accessTokens={ghp-BRA***";
+const SHORT_SECRET_EXPRESSION: &str = "connector.auth=abc";
+const UNMATCHED_BRACE_GITHUB_SECRET: &str = "ghp-Y";
+const UNMATCHED_BRACE_EXPRESSION: &str =
+    "worker.note=literal{brace,api.githubToken=ghp-Y";
+const UNCLOSED_LIST_GITHUB_SECRET: &str = "ghp-X";
+const UNCLOSED_LIST_EXPRESSION: &str =
+    "worker.note={literal,api.githubToken=ghp-X";
+
+const MODEL_CREDENTIAL: &str = "sk-ant-PLACEHOLDER-SIGNAL-1137";
+const GITHUB_CREDENTIAL: &str = "ghp-PLACEHOLDER-SIGNAL-1137";
+
+const FIRST_FILE_WRITTEN_ENV: &str = "CURIE_TEST_SECRET_FIRST_FILE_WRITTEN";
+const RESUME_WRITER_ENV: &str = "CURIE_TEST_SECRET_RESUME_WRITER";
+const SIGNAL_CLEANED_ENV: &str = "CURIE_TEST_SECRET_SIGNAL_CLEANED";
+const RESUME_SIGNAL_ENV: &str = "CURIE_TEST_SECRET_RESUME_SIGNAL";
+const WRITER_PARKED_ENV: &str = "CURIE_TEST_SECRET_WRITER_PARKED";
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_curie")
+}
+
+fn chart() -> &'static str {
+    concat!(env!("CARGO_MANIFEST_DIR"), "/../charts/curie")
+}
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("cli has a repository parent")
+        .to_path_buf()
+}
+
+fn write_exec(dir: &Path, name: &str, body: &str) {
+    let path = dir.join(name);
+    fs::write(&path, body).unwrap_or_else(|error| panic!("write {name}: {error}"));
+    let mut permissions = fs::metadata(&path)
+        .unwrap_or_else(|error| panic!("read {name} metadata: {error}"))
+        .permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&path, permissions)
+        .unwrap_or_else(|error| panic!("make {name} executable: {error}"));
+}
+
+struct Fixture {
+    temp: tempfile::TempDir,
+    bin_dir: PathBuf,
+    helm_log: PathBuf,
+    installation: PathBuf,
+    secret_tmp: PathBuf,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let temp = tempfile::tempdir().expect("temporary directory");
+        let bin_dir = temp.path().join("bin");
+        let secret_tmp = temp.path().join("tmp");
+        fs::create_dir(&bin_dir).expect("create fake binary directory");
+        fs::create_dir(&secret_tmp).expect("create secret temporary directory");
+        let helm_log = temp.path().join("helm.log");
+        let installation = temp.path().join("curie.yaml");
+        fs::write(
+            &installation,
+            format!(
+                "version: 1\ninstall:\n  namespace: {TARGET_NAMESPACE}\n  release: {TARGET_RELEASE}\nset:\n  worker.label: \"blue,connector.clientSecret={SET_STRING_SECRET}\"\n"
+            ),
+        )
+        .expect("write installation fixture");
+
+        write_exec(
+            &bin_dir,
+            "helm",
+            r#"#!/bin/sh
+if [ "$1" = "get" ] && [ "$2" = "values" ]; then
+    printf '%s\n' 'Error: release: not found' >&2
+    exit 1
+fi
+
+if [ "$1" = "template" ]; then
+    case " $* " in
+        *" --show-only templates/priorityclass.yaml "*)
+            printf '%s\n' 'Error: could not find template templates/priorityclass.yaml in chart' >&2
+            exit 1
+            ;;
+    esac
+    exit 0
+fi
+
+if [ "$1" = "upgrade" ] && [ "$2" = "--install" ]; then
+    printf '%s\n' "$*" >> "$CURIE_TEST_HELM_LOG"
+    exit 0
+fi
+
+printf 'unexpected helm invocation: %s\n' "$*" >&2
+exit 64
+"#,
+        );
+
+        write_exec(
+            &bin_dir,
+            "kubectl",
+            r#"#!/bin/sh
+if [ "$1" = "get" ] && [ "$2" = "namespace" ]; then
+    exit 0
+fi
+
+if [ "$1" = "get" ] && [ "$2" = "statefulset" ]; then
+    printf '%s\n' '{"apiVersion":"v1","items":[],"kind":"List","metadata":{}}'
+    exit 0
+fi
+
+printf 'unexpected kubectl invocation: %s\n' "$*" >&2
+exit 64
+"#,
+        );
+
+        Self {
+            temp,
+            bin_dir,
+            helm_log,
+            installation,
+            secret_tmp,
+        }
+    }
+
+    fn path(&self) -> std::ffi::OsString {
+        let mut paths = vec![self.bin_dir.clone()];
+        if let Some(current) = std::env::var_os("PATH") {
+            paths.extend(std::env::split_paths(&current));
+        }
+        std::env::join_paths(paths).expect("join PATH")
+    }
+
+    fn base_command(&self) -> Command {
+        let mut command = Command::new(bin());
+        command
+            .current_dir(repo_root())
+            .env("PATH", self.path())
+            .env("TMPDIR", &self.secret_tmp)
+            .env("CURIE_TEST_HELM_LOG", &self.helm_log)
+            .env("CI", "1")
+            .env("TERM", "dumb")
+            .env("NO_COLOR", "1")
+            .env_remove("CURIE_CREDENTIALS")
+            .env_remove("CURIE_MODEL_CREDENTIALS")
+            .env_remove("CURIE_GITHUB_TOKEN")
+            .env_remove("CURIE_MODEL");
+        command
+    }
+
+    fn debug_cluster_up(&self) -> Output {
+        self.base_command()
+            .args([
+                "--color",
+                "never",
+                "--debug",
+                "cluster",
+                "up",
+                "--chart",
+                chart(),
+                "--namespace",
+                TARGET_NAMESPACE,
+                "--release",
+                TARGET_RELEASE,
+                "--dev",
+                "--no-expose",
+                "--fake-model",
+                "--set",
+                SET_EXPRESSION,
+                "--set",
+                ESCAPED_COMMA_EXPRESSION,
+                "--set",
+                BRACE_LIST_EXPRESSION,
+                "--set",
+                SHORT_SECRET_EXPRESSION,
+            ])
+            .output()
+            .expect("run debug cluster up")
+    }
+
+    fn apply(&self, dry_run: bool, json: bool, debug: bool) -> Output {
+        let mut command = self.base_command();
+        command.args(["--color", "never"]);
+        if json {
+            command.arg("--json");
+        }
+        if debug {
+            command.arg("--debug");
+        }
+        command.args([
+            "apply",
+            "--file",
+            self.installation.to_str().expect("UTF 8 installation path"),
+            "--chart",
+            chart(),
+        ]);
+        if dry_run {
+            command.arg("--dry-run");
+        }
+        command.output().expect("run installation apply")
+    }
+
+    fn signal_cluster_up(&self, signal_name: &str) -> SignalRun {
+        let case_dir = self.temp.path().join(signal_name);
+        fs::create_dir(&case_dir).expect("create signal coordination directory");
+        let first_file_written = case_dir.join("first-file-written");
+        let resume_writer = case_dir.join("resume-writer");
+        let signal_cleaned = case_dir.join("signal-cleaned");
+        let resume_signal = case_dir.join("resume-signal");
+        let writer_parked = case_dir.join("writer-parked");
+
+        let child = self
+            .base_command()
+            .args([
+                "--color",
+                "never",
+                "cluster",
+                "up",
+                "--chart",
+                chart(),
+                "--namespace",
+                TARGET_NAMESPACE,
+                "--release",
+                TARGET_RELEASE,
+                "--dev",
+                "--no-expose",
+            ])
+            .env("CURIE_CREDENTIALS", MODEL_CREDENTIAL)
+            .env("CURIE_GITHUB_TOKEN", GITHUB_CREDENTIAL)
+            .env(FIRST_FILE_WRITTEN_ENV, &first_file_written)
+            .env(RESUME_WRITER_ENV, &resume_writer)
+            .env(SIGNAL_CLEANED_ENV, &signal_cleaned)
+            .env(RESUME_SIGNAL_ENV, &resume_signal)
+            .env(WRITER_PARKED_ENV, &writer_parked)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("start cluster up for signal test");
+
+        SignalRun {
+            child: ChildGuard { child },
+            first_file_written,
+            resume_writer,
+            signal_cleaned,
+            resume_signal,
+            writer_parked,
+        }
+    }
+
+    fn helm_log(&self) -> String {
+        fs::read_to_string(&self.helm_log).unwrap_or_default()
+    }
+
+    fn secret_files(&self) -> Vec<PathBuf> {
+        fs::read_dir(&self.secret_tmp)
+            .expect("read secret temporary directory")
+            .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+            .filter(|path| {
+                path.file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| {
+                        name.starts_with("curie-helm-values-") && name.ends_with(".yaml")
+                    })
+            })
+            .collect()
+    }
+}
+
+struct ChildGuard {
+    child: Child,
+}
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+struct SignalRun {
+    child: ChildGuard,
+    first_file_written: PathBuf,
+    resume_writer: PathBuf,
+    signal_cleaned: PathBuf,
+    resume_signal: PathBuf,
+    writer_parked: PathBuf,
+}
+
+fn wait_for_path(child: &mut Child, path: &Path, label: &str) {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        if path.exists() {
+            return;
+        }
+        if let Some(status) = child.try_wait().expect("poll cluster up") {
+            panic!("cluster up exited as {status} before {label}");
+        }
+        assert!(Instant::now() < deadline, "timed out waiting for {label}");
+        thread::sleep(Duration::from_millis(10));
+    }
+}
+
+fn wait_for_exit(child: &mut Child) -> ExitStatus {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        if let Some(status) = child.try_wait().expect("poll cluster up exit") {
+            return status;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "cluster up did not terminate after signal cleanup was released"
+        );
+        thread::sleep(Duration::from_millis(10));
+    }
+}
+
+fn send_signal(pid: u32, signal: i32) {
+    unsafe extern "C" {
+        fn kill(pid: i32, signal: i32) -> i32;
+    }
+
+    let result = unsafe { kill(pid as i32, signal) };
+    assert_eq!(result, 0, "send signal {signal} to process {pid}");
+}
+
+fn output_text(output: &Output) -> String {
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+fn assert_parser_edge_cases_are_masked(rendered: &str, surface: &str) {
+    assert!(
+        rendered.contains("connector.accessToken=") && rendered.contains("ghp-ESC"),
+        "escaped comma credential disappeared from {surface}: {rendered}"
+    );
+    assert!(
+        !rendered.contains("CLEAR-COMMA-TAIL-1138"),
+        "escaped comma credential tail leaked through {surface}: {rendered}"
+    );
+    assert!(
+        rendered.contains("connector.accessTokens=") && rendered.contains("ghp-BRA"),
+        "brace list credential disappeared from {surface}: {rendered}"
+    );
+    assert!(
+        !rendered.contains("ghp-BRACE-FIRST-1138") && !rendered.contains("ghp-BRACE-SECOND-1138"),
+        "brace list credential member leaked through {surface}: {rendered}"
+    );
+    assert!(
+        !rendered.contains(SHORT_SECRET_EXPRESSION),
+        "short credential was reproduced in full through {surface}: {rendered}"
+    );
+    let short_value = rendered
+        .split_once("connector.auth=")
+        .map(|(_, value)| value)
+        .unwrap_or_else(|| panic!("short credential disappeared from {surface}: {rendered}"));
+    let mask_offset = short_value
+        .find("***")
+        .unwrap_or_else(|| panic!("short credential has no mask in {surface}: {rendered}"));
+    assert!(
+        mask_offset < "abc".len(),
+        "short credential mask retained the complete value through {surface}: {rendered}"
+    );
+}
+
+fn pure_up() -> UpOpts {
+    UpOpts {
+        common: CommonOpts {
+            namespace: TARGET_NAMESPACE.to_string(),
+            release: TARGET_RELEASE.to_string(),
+            dry_run: true,
+        },
+        chart: chart().to_string(),
+        no_expose: true,
+        set: vec![
+            SET_EXPRESSION.to_string(),
+            ESCAPED_COMMA_EXPRESSION.to_string(),
+            BRACE_LIST_EXPRESSION.to_string(),
+            SHORT_SECRET_EXPRESSION.to_string(),
+            UNMATCHED_BRACE_EXPRESSION.to_string(),
+            UNCLOSED_LIST_EXPRESSION.to_string(),
+        ],
+        set_string: vec![SET_STRING_EXPRESSION.to_string()],
+        allow_egress_host: vec![],
+        resolved_egress_cidrs: vec![],
+        allow_web_egress: vec![],
+        fake_model: true,
+        credentials: None,
+        local_model: None,
+        model: None,
+        secrets: vec![],
+        github_token: GithubTokenPlan::Untouched,
+        dev: true,
+    }
+}
+
+#[test]
+fn set_passthrough_is_masked_in_every_rendered_form() {
+    let commands = up_commands(&pure_up());
+    let helm = &commands[0];
+
+    let display = helm.display();
+    assert!(
+        display.contains(MASKED_SET_EXPRESSION),
+        "direct display lost or exposed the set expression: {display}"
+    );
+    assert!(
+        display.contains(MASKED_SET_STRING_EXPRESSION),
+        "direct display lost or exposed the set string expression: {display}"
+    );
+    assert!(!display.contains(SET_SECRET), "set leak: {display}");
+    assert!(
+        !display.contains(SET_STRING_SECRET),
+        "set string leak: {display}"
+    );
+    assert!(display.contains(SET_MASKED), "missing set mask: {display}");
+    assert!(
+        display.contains(SET_STRING_MASKED),
+        "missing set string mask: {display}"
+    );
+    assert!(display.contains(ESCAPED_COMMA_MASKED), "{display}");
+    assert!(display.contains(BRACE_LIST_MASKED), "{display}");
+    assert_parser_edge_cases_are_masked(&display, "direct display");
+    assert!(display.contains("worker.replicas=2"), "{display}");
+    assert!(display.contains("api.githubToken="), "{display}");
+    assert!(display.contains("bare"), "{display}");
+    assert!(display.contains("worker.note="), "{display}");
+    assert!(
+        !display.contains(UNMATCHED_BRACE_GITHUB_SECRET),
+        "an unmatched brace in an ordinary value hid a later credential from direct display masking: {display}"
+    );
+    assert!(
+        !display.contains(UNCLOSED_LIST_GITHUB_SECRET),
+        "an unclosed ordinary list exposed a later GitHub credential in direct display: {display}"
+    );
+
+    let argv = helm.argv();
+    let set_index = argv
+        .windows(2)
+        .position(|pair| pair[0] == "--set" && pair[1] == SET_EXPRESSION)
+        .expect("exact set flag and expression pair in argv");
+    let set_string_index = argv
+        .windows(2)
+        .position(|pair| pair[0] == "--set-string" && pair[1] == SET_STRING_EXPRESSION)
+        .expect("exact set string flag and expression pair in argv");
+    assert_eq!(argv[set_index + 1], SET_EXPRESSION);
+    assert_eq!(argv[set_string_index + 1], SET_STRING_EXPRESSION);
+    for expression in [
+        ESCAPED_COMMA_EXPRESSION,
+        BRACE_LIST_EXPRESSION,
+        SHORT_SECRET_EXPRESSION,
+        UNMATCHED_BRACE_EXPRESSION,
+        UNCLOSED_LIST_EXPRESSION,
+    ] {
+        assert!(
+            argv.windows(2)
+                .any(|pair| pair[0] == "--set" && pair[1] == expression),
+            "executed set expression changed bytes: {expression:?} in {argv:?}"
+        );
+    }
+    assert!(
+        set_index < set_string_index,
+        "set string precedence must remain after set: {argv:?}"
+    );
+
+    let plan = DryRunPlan {
+        lines: commands.iter().map(|command| command.display()).collect(),
+    };
+    let human_plan = plan.lines.join("\n");
+    assert!(human_plan.contains(MASKED_SET_EXPRESSION), "{human_plan}");
+    assert!(
+        human_plan.contains(MASKED_SET_STRING_EXPRESSION),
+        "{human_plan}"
+    );
+    assert!(!human_plan.contains(SET_SECRET), "{human_plan}");
+    assert!(!human_plan.contains(SET_STRING_SECRET), "{human_plan}");
+    assert!(human_plan.contains(ESCAPED_COMMA_MASKED), "{human_plan}");
+    assert!(human_plan.contains(BRACE_LIST_MASKED), "{human_plan}");
+    assert_parser_edge_cases_are_masked(&human_plan, "human dry run plan");
+    assert!(
+        !human_plan.contains(UNMATCHED_BRACE_GITHUB_SECRET),
+        "an unmatched brace exposed the later GitHub credential in the human plan: {human_plan}"
+    );
+    assert!(
+        !human_plan.contains(UNCLOSED_LIST_GITHUB_SECRET),
+        "an unclosed ordinary list exposed the later GitHub credential in the human plan: {human_plan}"
+    );
+
+    let json = plan.to_json().to_string();
+    assert!(json.contains(MASKED_SET_EXPRESSION), "{json}");
+    assert!(json.contains(MASKED_SET_STRING_EXPRESSION), "{json}");
+    assert!(!json.contains(SET_SECRET), "{json}");
+    assert!(!json.contains(SET_STRING_SECRET), "{json}");
+    assert_parser_edge_cases_are_masked(&json, "dry run plan JSON");
+    assert!(
+        !json.contains(UNMATCHED_BRACE_GITHUB_SECRET),
+        "an unmatched brace exposed the later GitHub credential in plan JSON: {json}"
+    );
+    assert!(
+        !json.contains(UNCLOSED_LIST_GITHUB_SECRET),
+        "an unclosed ordinary list exposed the later GitHub credential in plan JSON: {json}"
+    );
+
+    let human_output = Command::new(bin())
+        .current_dir(repo_root())
+        .args([
+            "--color",
+            "never",
+            "cluster",
+            "up",
+            "--chart",
+            chart(),
+            "--dev",
+            "--no-expose",
+            "--fake-model",
+            "--dry-run",
+            "--set",
+            SET_EXPRESSION,
+            "--set",
+            ESCAPED_COMMA_EXPRESSION,
+            "--set",
+            BRACE_LIST_EXPRESSION,
+            "--set",
+            SHORT_SECRET_EXPRESSION,
+        ])
+        .env("CI", "1")
+        .env("TERM", "dumb")
+        .env("NO_COLOR", "1")
+        .env_remove("CURIE_CREDENTIALS")
+        .env_remove("CURIE_MODEL_CREDENTIALS")
+        .env_remove("CURIE_GITHUB_TOKEN")
+        .env_remove("CURIE_MODEL")
+        .output()
+        .expect("run human dry run");
+    assert!(
+        human_output.status.success(),
+        "human dry run failed: {}",
+        output_text(&human_output)
+    );
+    let human_output = output_text(&human_output);
+    assert!(
+        human_output.contains(MASKED_SET_EXPRESSION),
+        "{human_output}"
+    );
+    assert!(!human_output.contains(SET_SECRET), "{human_output}");
+    assert_parser_edge_cases_are_masked(&human_output, "binary human dry run");
+
+    let fixture = Fixture::new();
+    let set_string_human_output = fixture.apply(true, false, false);
+    assert!(
+        set_string_human_output.status.success(),
+        "set string human dry run failed: {}",
+        output_text(&set_string_human_output)
+    );
+    let set_string_human_output = output_text(&set_string_human_output);
+    assert!(
+        set_string_human_output.contains("--set-string")
+            && set_string_human_output.contains(MASKED_SET_STRING_EXPRESSION),
+        "{set_string_human_output}"
+    );
+    assert!(
+        !set_string_human_output.contains(SET_STRING_SECRET),
+        "{set_string_human_output}"
+    );
+
+    let json_output = Command::new(bin())
+        .current_dir(repo_root())
+        .args([
+            "--color",
+            "never",
+            "--json",
+            "cluster",
+            "up",
+            "--chart",
+            chart(),
+            "--dev",
+            "--no-expose",
+            "--fake-model",
+            "--dry-run",
+            "--set",
+            SET_EXPRESSION,
+            "--set",
+            ESCAPED_COMMA_EXPRESSION,
+            "--set",
+            BRACE_LIST_EXPRESSION,
+            "--set",
+            SHORT_SECRET_EXPRESSION,
+        ])
+        .env("CI", "1")
+        .env("TERM", "dumb")
+        .env("NO_COLOR", "1")
+        .env_remove("CURIE_CREDENTIALS")
+        .env_remove("CURIE_MODEL_CREDENTIALS")
+        .env_remove("CURIE_GITHUB_TOKEN")
+        .env_remove("CURIE_MODEL")
+        .output()
+        .expect("run JSON dry run");
+    assert!(
+        json_output.status.success(),
+        "JSON dry run failed: {}",
+        output_text(&json_output)
+    );
+    let parsed: serde_json::Value =
+        serde_json::from_slice(&json_output.stdout).expect("dry run emits one JSON object");
+    let json_output = parsed.to_string();
+    assert!(json_output.contains(MASKED_SET_EXPRESSION), "{json_output}");
+    assert!(!json_output.contains(SET_SECRET), "{json_output}");
+    assert_parser_edge_cases_are_masked(&json_output, "binary dry run JSON");
+
+    let set_string_json_output = fixture.apply(true, true, false);
+    assert!(
+        set_string_json_output.status.success(),
+        "set string JSON dry run failed: {}",
+        output_text(&set_string_json_output)
+    );
+    let parsed: serde_json::Value = serde_json::from_slice(&set_string_json_output.stdout)
+        .expect("set string dry run emits one JSON object");
+    let set_string_json_output = parsed.to_string();
+    assert!(
+        set_string_json_output.contains("--set-string")
+            && set_string_json_output.contains(MASKED_SET_STRING_EXPRESSION),
+        "{set_string_json_output}"
+    );
+    assert!(
+        !set_string_json_output.contains(SET_STRING_SECRET),
+        "{set_string_json_output}"
+    );
+
+    let debug_output = fixture.debug_cluster_up();
+    assert!(
+        debug_output.status.success(),
+        "debug cluster up failed: {}",
+        output_text(&debug_output)
+    );
+    let debug_echo = String::from_utf8_lossy(&debug_output.stderr);
+    assert!(debug_echo.contains(MASKED_SET_EXPRESSION), "{debug_echo}");
+    assert!(!debug_echo.contains(SET_SECRET), "{debug_echo}");
+    assert_parser_edge_cases_are_masked(&debug_echo, "binary debug echo");
+
+    let set_string_debug_output = fixture.apply(false, false, true);
+    assert!(
+        set_string_debug_output.status.success(),
+        "set string debug apply failed: {}",
+        output_text(&set_string_debug_output)
+    );
+    let set_string_debug_echo = String::from_utf8_lossy(&set_string_debug_output.stderr);
+    assert!(
+        set_string_debug_echo.contains("--set-string")
+            && set_string_debug_echo.contains(MASKED_SET_STRING_EXPRESSION),
+        "{set_string_debug_echo}"
+    );
+    assert!(
+        !set_string_debug_echo.contains(SET_STRING_SECRET),
+        "{set_string_debug_echo}"
+    );
+    let helm_log = fixture.helm_log();
+    assert!(
+        helm_log.contains(&format!("--set {SET_EXPRESSION}")),
+        "the executed set argv must retain the original bytes: {helm_log}"
+    );
+    assert!(
+        helm_log.contains(&format!("--set-string {SET_STRING_EXPRESSION}")),
+        "the executed set string argv must retain the original bytes: {helm_log}"
+    );
+}
+
+#[test]
+fn secret_values_file_short_value_does_not_reproduce_complete_secret() {
+    let command = OpsCommand {
+        program: "helm".to_string(),
+        args: vec![CmdArg::SecretValuesFile(vec![(
+            "api.githubToken".to_string(),
+            "abc".to_string(),
+        )])],
+        env: vec![],
+        secret_env: vec![],
+    };
+
+    let display = command.display();
+    assert!(
+        display.contains("<secret values file: api.githubToken="),
+        "secret values file disappeared from display: {display}"
+    );
+    assert!(
+        !display.contains("api.githubToken=abc"),
+        "shared secret masking reproduced the complete three character value: {display}"
+    );
+    let shown = display
+        .split_once("api.githubToken=")
+        .map(|(_, value)| value)
+        .expect("displayed secret values file key");
+    let mask_offset = shown.find("***").expect("displayed secret mask");
+    assert!(
+        mask_offset < "abc".len(),
+        "shared secret mask retained all three characters: {display}"
+    );
+}
+
+#[test]
+#[cfg_attr(
+    not(debug_assertions),
+    ignore = "requires debug only signal coordination hooks"
+)]
+fn signal_interrupt_removes_every_secret_values_file() {
+    for (signal_name, signal) in [("sigint", 2), ("sigterm", 15)] {
+        let fixture = Fixture::new();
+        let mut run = fixture.signal_cluster_up(signal_name);
+
+        wait_for_path(
+            &mut run.child.child,
+            &run.first_file_written,
+            "the first secret values file",
+        );
+        let first_files = fixture.secret_files();
+        assert_eq!(
+            first_files.len(),
+            1,
+            "the coordination point must pause after exactly one materialization: {first_files:?}"
+        );
+        let first_body = fs::read_to_string(&first_files[0]).expect("read first secret file");
+        assert!(
+            first_body.contains(MODEL_CREDENTIAL),
+            "the first materialization must be the model credential: {first_body}"
+        );
+
+        send_signal(run.child.child.id(), signal);
+        wait_for_path(
+            &mut run.child.child,
+            &run.signal_cleaned,
+            "signal cleanup barrier",
+        );
+        assert!(
+            fixture.secret_files().is_empty(),
+            "{signal_name} left a cleartext values file after cleanup: {:?}",
+            fixture.secret_files()
+        );
+
+        fs::write(&run.resume_writer, b"resume").expect("release the materializer");
+        wait_for_path(
+            &mut run.child.child,
+            &run.writer_parked,
+            "the racing secret writer to park",
+        );
+        assert!(
+            run.child
+                .child
+                .try_wait()
+                .expect("poll blocked materializer")
+                .is_none(),
+            "a writer racing {signal_name} returned normally instead of parking for signal death"
+        );
+        assert!(
+            fixture.secret_files().is_empty(),
+            "a writer racing {signal_name} created a second cleartext values file: {:?}",
+            fixture.secret_files()
+        );
+
+        fs::write(&run.resume_signal, b"resume").expect("release signal termination");
+        let status = wait_for_exit(&mut run.child.child);
+        assert_eq!(
+            status.signal(),
+            Some(signal),
+            "cluster up must retain the original {signal_name} termination: {status}"
+        );
+        assert!(
+            fixture.secret_files().is_empty(),
+            "{signal_name} left a cleartext values file after process death: {:?}",
+            fixture.secret_files()
+        );
+    }
+}

--- a/cli/tests/cluster_secret_hardening.rs
+++ b/cli/tests/cluster_secret_hardening.rs
@@ -35,11 +35,9 @@ const BRACE_LIST_EXPRESSION: &str =
 const BRACE_LIST_MASKED: &str = "connector.accessTokens={ghp-BRA***";
 const SHORT_SECRET_EXPRESSION: &str = "connector.auth=abc";
 const UNMATCHED_BRACE_GITHUB_SECRET: &str = "ghp-Y";
-const UNMATCHED_BRACE_EXPRESSION: &str =
-    "worker.note=literal{brace,api.githubToken=ghp-Y";
+const UNMATCHED_BRACE_EXPRESSION: &str = "worker.note=literal{brace,api.githubToken=ghp-Y";
 const UNCLOSED_LIST_GITHUB_SECRET: &str = "ghp-X";
-const UNCLOSED_LIST_EXPRESSION: &str =
-    "worker.note={literal,api.githubToken=ghp-X";
+const UNCLOSED_LIST_EXPRESSION: &str = "worker.note={literal,api.githubToken=ghp-X";
 
 const MODEL_CREDENTIAL: &str = "sk-ant-PLACEHOLDER-SIGNAL-1137";
 const GITHUB_CREDENTIAL: &str = "ghp-PLACEHOLDER-SIGNAL-1137";


### PR DESCRIPTION
## Summary

Installs process wide SIGINT and SIGTERM cleanup for secret Helm values files and closes the creation race during termination. Masks secret values passed through both `--set` lanes in the human preview, dry run plan, plan JSON, and verbose echo while preserving exact execution bytes.

## Related issues

Closes #1137
Closes #1138

## End to end verification

Skill: not applicable because no plugin packaging, runner loop, or ACI event changed.

Local: required in fake mode on candidate `c7cbc76f`. `CURIE_E2E_TIERS=local CURIE_BIN=/home/theconnman/.cargo/shared-targets/agentos/debug/curie curie dev e2e-ladder` ended with `LADDER PASS (tiers: local)`, finalized a real local turn, and removed its stack and runner.

Local release: not applicable because release identity, installation, images, and release Compose did not change.

Cluster: not applicable because chart templates, RBAC, security contexts, network policy, and sandbox behavior did not change. The changed `cluster up` binary surface is exercised directly by the candidate integration binary.

Live provider: not applicable because credential resolution, provider authentication, and executed credential bytes are unchanged.

External integration: not applicable because no third party API shape or OAuth path changed.

Positive proof: `cargo test --manifest-path cli/Cargo.toml --test cluster_secret_hardening` passed all three tests. The candidate binary received SIGINT and SIGTERM between two secret file materializations, exited with the original signal, and left no secret values file. The same binary masked set and set string credentials in all four render paths while the fake Helm log received the exact raw values.

Falsifiable negative: `curie dev verify-fix-pin` reported `PINNED` for both `signal_interrupt_removes_every_secret_values_file` and `set_passthrough_is_masked_in_every_rendered_form`; each test failed after only the product hunks were reversed.

## Checklist

Tests complete: `cd cli && cargo fmt --check && cargo clippy -- -D warnings && cargo test` exited 0 after rebasing on current main. This includes 816 unit tests, the three new integration tests, and the CLI chart assertion subprocesses.

Docs complete: the scoped CLI contract and code comments describe signal cleanup and masked display behavior.

Architecture decision record: not applicable because this is a bounded hardening fix within the existing OpsCommand contract.

Review complete: architecture, code, scope, and three security passes found no remaining blocker. The external review advisory about release mode test coordination is closed by ignoring only that debug hook dependent test in release builds; the normal debug regression still runs.

Parity complete: set and set string use the same masking sink. Credential resolution and execution bytes remain unchanged.

Residual scope: the Slack guide generic set example noted on #1138 and the separate migration store temporary file are outside this OpsCommand change.