### PR TITLE
Connector build declaration and lock contract (ADR 0113)

### DIFF
--- a/apps/api/src/curie_api/bundles.py
+++ b/apps/api/src/curie_api/bundles.py
@@ -25,6 +25,11 @@ from plugin_format import (
     safe_extract,
     validate_bundle,
 )
+from plugin_format.connector_lock import (
+    CONNECTOR_LOCK_FILE,
+    ConnectorLockFile,
+    validate_connector_lock,
+)
 from plugin_format.connectors import CONNECTORS_FILE, ConnectorsFile, validate_connectors
 from plugin_format.deploy_targets import DeployTargetsFile, validate_deploy_targets
 from plugin_format.validate import DEPLOY_FILE
@@ -111,6 +116,25 @@ def read_connectors(root: Path) -> ConnectorsFile:
     parsed, errors = validate_connectors(safe_load_unique(path.read_text(encoding="utf-8")))
     if errors or parsed is None:  # pragma: no cover -- validate_bundle gates this
         return ConnectorsFile()
+    return parsed
+
+
+def read_connector_lock(root: Path) -> ConnectorLockFile | None:
+    """Parse a validated bundle's ``connectors.lock.yaml``, or None (ADR 0113).
+
+    None is not an error and is the common case: an ordinary ``image:`` bundle
+    carries no lock and never will. Safe to call only after ``validate_bundle``
+    has passed, exactly like ``read_connectors`` -- a malformed lock, a lockless
+    ``build:`` bundle, and a stale digest are all already rejected there, so this
+    cannot be the place a bad lock first surfaces.
+    """
+
+    path = bundle_root(root) / CONNECTOR_LOCK_FILE
+    if not path.is_file():
+        return None
+    parsed, errors = validate_connector_lock(safe_load_unique(path.read_text(encoding="utf-8")))
+    if errors or parsed is None:  # pragma: no cover -- validate_bundle gates this
+        return None
     return parsed
 
 

--- a/apps/api/src/curie_api/routers/agents.py
+++ b/apps/api/src/curie_api/routers/agents.py
@@ -294,14 +294,34 @@ async def read_version_connectors(
             # Resolve every `build:` connector to the digest the bundle already
             # records before anything renders (ADR 0113). `apply_lock` reads a
             # recorded fact and never resolves or builds one, so the API stays a
-            # pure renderer under ADR-0087; `portable=False` because a
-            # local-tier version is a legitimate stored artifact whose manifests
-            # nothing applies.
-            declared = connector_lock.apply_lock(
-                bundles.read_connectors(Path(tmp)),
-                bundles.read_connector_lock(Path(tmp)),
-                portable=False,
-            )
+            # pure renderer under ADR-0087.
+            #
+            # `portable=True` because EVERY consumer of this route applies what
+            # it returns to a Kubernetes cluster: the worker's connector
+            # reconcile loop (`curie_worker.connector_loop.HttpManifestSource`,
+            # ADR-0090) and `curie cluster deploy`'s `sync_connectors`
+            # (`cli/src/main.rs`, ADR-0086). Nothing reads these manifests for
+            # display. A `local-daemon` lock records a bare docker image id that
+            # names nothing a node can pull, so rendering one here yields a
+            # Deployment that ImagePullBackOffs long after the deploy reported
+            # success -- with every gate green. Bundle intake keeps
+            # `portable=False` (`plugin_format.validate`): a local-tier version
+            # is a legitimate stored artifact. The refusal belongs at the render
+            # that feeds an applier, which is this one.
+            try:
+                declared = connector_lock.apply_lock(
+                    bundles.read_connectors(Path(tmp)),
+                    bundles.read_connector_lock(Path(tmp)),
+                    portable=True,
+                )
+            except ValueError as exc:
+                # 422, matching how this service reports a stored bundle that
+                # cannot yield a deployable artifact (`create_deployment`,
+                # `upload_bundle`): the request is well formed, the bundle is
+                # not applicable. A 500 would read as an API fault and send the
+                # operator to the API logs instead of to `curie build
+                # --plugin-dir <dir> --registry <ref>`, which the message names.
+                raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, str(exc)) from exc
             # Per-agent too: a release-scoped Secret means deploying the prod
             # agent overwrites the dev agent's token in place (#1116).
             secret_name = f"{release}-{agent_name}-connector-secrets"

--- a/apps/api/src/curie_api/routers/agents.py
+++ b/apps/api/src/curie_api/routers/agents.py
@@ -6,6 +6,7 @@ import uuid
 from pathlib import Path
 
 from fastapi import APIRouter, Depends, HTTPException, status
+from plugin_format import connector_lock
 from sqlalchemy.exc import IntegrityError
 from starlette.concurrency import run_in_threadpool
 
@@ -290,7 +291,17 @@ async def read_version_connectors(
                 max_compression_ratio=settings.bundle_max_compression_ratio,
                 max_members=settings.bundle_max_members,
             )
-            declared = bundles.read_connectors(Path(tmp))
+            # Resolve every `build:` connector to the digest the bundle already
+            # records before anything renders (ADR 0113). `apply_lock` reads a
+            # recorded fact and never resolves or builds one, so the API stays a
+            # pure renderer under ADR-0087; `portable=False` because a
+            # local-tier version is a legitimate stored artifact whose manifests
+            # nothing applies.
+            declared = connector_lock.apply_lock(
+                bundles.read_connectors(Path(tmp)),
+                bundles.read_connector_lock(Path(tmp)),
+                portable=False,
+            )
             # Per-agent too: a release-scoped Secret means deploying the prod
             # agent overwrites the dev agent's token in place (#1116).
             secret_name = f"{release}-{agent_name}-connector-secrets"

--- a/apps/api/tests/test_bundle_connectors.py
+++ b/apps/api/tests/test_bundle_connectors.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any
 
 import pytest
 from curie_api import bundles
@@ -270,3 +271,235 @@ def test_a_referenced_secret_points_outside_curies_own_secret(tmp_path: Path) ->
     ref = next(e for e in env if e["name"] == "GRAFANA_TOKEN")["valueFrom"]["secretKeyRef"]
     assert ref["name"] == "grafana-mcp"
     assert "value" not in next(e for e in env if e["name"] == "GRAFANA_TOKEN")
+
+
+# --------------------------------------------------------------------------- #
+# A source-built connector resolves to its pinned digest before render -- ADR 0113
+#
+# The API stays a pure renderer: `apply_lock` reads a fact the bundle already
+# carries and never resolves, builds, or contacts a registry. What changes is
+# that the render path must APPLY it. An earlier draft of this work claimed the
+# resolution happened in `render_connector_manifests` and never wired it, which
+# is the defect these tests exist to make impossible.
+# --------------------------------------------------------------------------- #
+BUILT = (
+    "connectors:\n"
+    "  k8s-write:\n"
+    "    build:\n"
+    "      context: connectors/k8s-write\n"
+    "      platforms: [linux/amd64, linux/arm64]\n"
+    "    env: {K8S_WRITE_ALLOWLIST: 'acme-ns/acme-api'}\n"
+)
+
+# `<repo>@sha256:` plus 64 lowercase hex is the OCI manifest digest form
+# (https://github.com/opencontainers/distribution-spec/blob/main/spec.md#pulling-manifests),
+# which is what `docker buildx build --push --metadata-file` reports as
+# `containerimage.digest`. Spelled out rather than derived from the
+# implementation, so a change to how Curie composes the reference fails here.
+DIGEST_IMAGE = (
+    "ghcr.io/acme-corp/acme-bot-k8s-write-mcp@sha256:"
+    "0000000000000000000000000000000000000000000000000000000000000000"
+)
+
+
+def _built(root: Path) -> Path:
+    """A bundle whose one connector is declared as source, with its context."""
+
+    _bundle(root, BUILT)
+    context = root / "b" / "connectors" / "k8s-write"
+    context.mkdir(parents=True, exist_ok=True)
+    (context / "Dockerfile").write_text(
+        "FROM scratch\nCOPY server.py /server.py\n", encoding="utf-8"
+    )
+    (context / "server.py").write_text("print('acme')\n", encoding="utf-8")
+    return root
+
+
+def _write_lock(root: Path, *, image: str = DIGEST_IMAGE, delivery: str = "registry") -> None:
+    from plugin_format import connector_lock
+    from plugin_format.connectors import ConnectorBuild
+
+    build = ConnectorBuild.model_validate(
+        {"context": "connectors/k8s-write", "platforms": ["linux/amd64", "linux/arm64"]}
+    )
+    digest = connector_lock.source_digest_of(root / "b" / "connectors" / "k8s-write", build)
+    (root / "b" / connector_lock.CONNECTOR_LOCK_FILE).write_text(
+        "version: 1\n"
+        "connectors:\n"
+        "  k8s-write:\n"
+        f"    image: {image}\n"
+        f"    delivery: {delivery}\n"
+        "    platforms: [linux/amd64, linux/arm64]\n"
+        f"    source_digest: {digest}\n",
+        encoding="utf-8",
+    )
+
+
+def test_read_connector_lock_returns_none_when_the_bundle_carries_no_lock(tmp_path: Path) -> None:
+    # None is the shape every caller must handle: an ordinary `image:` bundle
+    # has no lock and never will. Raising here would break every existing
+    # version's render.
+    assert bundles.read_connector_lock(_bundle(tmp_path, HOSTED)) is None
+
+
+def test_a_built_connector_renders_the_locked_digest_and_no_build(tmp_path: Path) -> None:
+    from plugin_format import connector_lock
+
+    root = _built(tmp_path)
+    _write_lock(root)
+    declared = connector_lock.apply_lock(
+        bundles.read_connectors(root), bundles.read_connector_lock(root), portable=False
+    )
+    dep = next(
+        o
+        for o in bundles.render_connector_manifests(
+            declared,
+            release=RELEASE,
+            agent=AGENT,
+            namespace=NAMESPACE,
+            app_name=APP_NAME,
+            secret_name=SECRET_NAME,
+        )
+        if o["kind"] == "Deployment"
+    )
+    assert dep["spec"]["template"]["spec"]["containers"][0]["image"] == DIGEST_IMAGE
+
+
+def test_render_connector_manifests_stays_a_pure_function_of_its_arguments(tmp_path: Path) -> None:
+    # The resolution happens one level up, in the router. This function keeps
+    # receiving an ordinary ConnectorsFile and grew no lock parameter, which is
+    # what keeps it a pure function of its arguments under ADR-0087. Handed an
+    # UNRESOLVED build it must raise rather than quietly emit `image: null`.
+    root = _built(tmp_path)
+    _write_lock(root)
+    with pytest.raises(ValueError):
+        bundles.render_connector_manifests(
+            bundles.read_connectors(root),
+            release=RELEASE,
+            agent=AGENT,
+            namespace=NAMESPACE,
+            app_name=APP_NAME,
+            secret_name=SECRET_NAME,
+        )
+
+
+def test_the_mcp_entry_is_the_same_before_and_after_the_lock_is_applied(tmp_path: Path) -> None:
+    # The URL is derived from the Service, never from the image, so skill,
+    # local and cluster mount one byte-identical entry whether the connector was
+    # built from source or pulled by an authored reference. That identity is
+    # what ADR 0113's parity claim rests on, and it is why nothing in the runner
+    # or in `.mcp.json` has to learn that a connector was built.
+    from plugin_format import connector_lock
+    from plugin_format.connectors import validate_connectors
+
+    root = _built(tmp_path)
+    _write_lock(root)
+    resolved = connector_lock.apply_lock(
+        bundles.read_connectors(root), bundles.read_connector_lock(root), portable=False
+    )
+    authored, errors = validate_connectors(
+        {
+            "connectors": {
+                "k8s-write": {
+                    "image": DIGEST_IMAGE,
+                    "env": {"K8S_WRITE_ALLOWLIST": "acme-ns/acme-api"},
+                }
+            }
+        }
+    )
+    assert errors == []
+    kwargs = {"release": RELEASE, "agent": AGENT, "namespace": NAMESPACE}
+    assert bundles.connector_mcp_entries(resolved, **kwargs) == bundles.connector_mcp_entries(
+        authored, **kwargs
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Through the real route: the API consumer that must apply the lock (AC-A17)
+#
+# Real Postgres + real RustFS from the compose stack, matching the round-trip
+# tests in test_bundles.py: nothing here is mocked. Asserting on the helper
+# alone would leave the router free to keep calling `read_connectors` directly,
+# which is exactly the wiring gap review finding 8 named -- the resolution was
+# claimed and never wired. Deleting the `apply_lock` call in the router must
+# make this fail, and it fails as `image: None`, not as an import error.
+# --------------------------------------------------------------------------- #
+def _archive(root: Path) -> bytes:
+    import io
+    import tarfile
+
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tf:
+        tf.add(root / "b", arcname="acme-bot")
+    return buf.getvalue()
+
+
+def _version_with_bundle(client: Any, headers: dict[str, str], archive: bytes) -> tuple[str, str]:
+    agent = client.post(
+        "/agents",
+        json={"name": "acme-bot", "channel": {"kind": "slack", "address": "C0EXAMPLE1"}},
+        headers=headers,
+    ).json()
+    version = client.post(
+        f"/agents/{agent['id']}/versions",
+        json={"version_label": "v1", "created_by": "acme"},
+        headers=headers,
+    ).json()
+    upload = client.put(
+        f"/agents/{agent['id']}/versions/{version['id']}/bundle",
+        files={"file": ("acme-bot.tar.gz", archive)},
+        headers=headers,
+    )
+    assert upload.status_code == 201, upload.text
+    return agent["id"], version["id"]
+
+
+def test_the_connectors_route_renders_the_locked_digest(
+    tmp_path: Path, client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    root = _built(tmp_path)
+    _write_lock(root)
+    agent_id, version_id = _version_with_bundle(client, auth_headers, _archive(root))
+
+    resp = client.get(
+        f"/agents/{agent_id}/versions/{version_id}/connectors",
+        params={"release": RELEASE, "namespace": NAMESPACE, "app_name": APP_NAME},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    dep = next(o for o in body["manifests"] if o["kind"] == "Deployment")
+    image = dep["spec"]["template"]["spec"]["containers"][0]["image"]
+    assert image == DIGEST_IMAGE, "the router must apply the lock before rendering"
+    # The entry is Service-derived, so it is identical to the entry an authored
+    # `image:` connector of the same name produces. That is the parity claim.
+    assert body["mcp_entries"]["k8s-write"]["url"].startswith(
+        f"http://{RELEASE}-acme-bot-mcp-k8s-write.{NAMESPACE}.svc.cluster.local:"
+    )
+
+
+def test_a_lockless_build_bundle_never_becomes_a_version(
+    tmp_path: Path, client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    # The upload path's half of the intake rule. The bundle is refused before it
+    # is stored, so the version carries no bundle_ref and the connectors route
+    # has nothing to render -- rather than the deployment going active with a
+    # connector that was never built.
+    root = _built(tmp_path)  # no lock written
+    agent = client.post(
+        "/agents",
+        json={"name": "acme-bot", "channel": {"kind": "slack", "address": "C0EXAMPLE1"}},
+        headers=auth_headers,
+    ).json()
+    version = client.post(
+        f"/agents/{agent['id']}/versions",
+        json={"version_label": "v1", "created_by": "acme"},
+        headers=auth_headers,
+    ).json()
+    resp = client.put(
+        f"/agents/{agent['id']}/versions/{version['id']}/bundle",
+        files={"file": ("acme-bot.tar.gz", _archive(root))},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 422, resp.text
+    assert "connectors.lock_missing" in resp.text

--- a/apps/api/tests/test_bundle_connectors.py
+++ b/apps/api/tests/test_bundle_connectors.py
@@ -301,6 +301,12 @@ DIGEST_IMAGE = (
     "0000000000000000000000000000000000000000000000000000000000000000"
 )
 
+# What `curie build --plugin-dir <dir>` records with no `--registry`: the local
+# Docker daemon's image id. Bare `sha256:<hex>` with no repository, so nothing
+# outside that one daemon can pull it -- which is exactly why the render that
+# feeds a cluster applier has to refuse it.
+LOCAL_DAEMON_IMAGE = "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+
 
 def _built(root: Path) -> Path:
     """A bundle whose one connector is declared as source, with its context."""
@@ -476,6 +482,36 @@ def test_the_connectors_route_renders_the_locked_digest(
     assert body["mcp_entries"]["k8s-write"]["url"].startswith(
         f"http://{RELEASE}-acme-bot-mcp-k8s-write.{NAMESPACE}.svc.cluster.local:"
     )
+
+
+def test_the_connectors_route_refuses_a_local_daemon_lock(
+    tmp_path: Path, client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    # Everything that calls this route APPLIES what it returns to a cluster --
+    # the worker's connector reconcile loop
+    # (`curie_worker.connector_loop.HttpManifestSource`, ADR-0090) and
+    # `curie cluster deploy`'s `sync_connectors` (`cli/src/main.rs`, ADR-0086).
+    # A `local-daemon` lock records a bare image id no node can pull, so
+    # rendering it hands the applier a Deployment that ImagePullBackOffs minutes
+    # after the deploy reported success, with every gate green. The bundle
+    # itself is valid and stores fine (intake keeps `portable=False`, since a
+    # local-tier version is a legitimate artifact) -- the refusal has to happen
+    # at the render, which is what this pins.
+    root = _built(tmp_path)
+    _write_lock(root, image=LOCAL_DAEMON_IMAGE, delivery="local-daemon")
+    agent_id, version_id = _version_with_bundle(client, auth_headers, _archive(root))
+
+    resp = client.get(
+        f"/agents/{agent_id}/versions/{version_id}/connectors",
+        params={"release": RELEASE, "namespace": NAMESPACE, "app_name": APP_NAME},
+        headers=auth_headers,
+    )
+    # 422, not 500: the request is well formed and the bundle is stored; what
+    # cannot be produced is an applicable manifest. A 500 sends the operator to
+    # the API logs instead of to the rebuild the message names.
+    assert resp.status_code == 422, resp.text
+    assert "local-daemon" in resp.text
+    assert "--registry" in resp.text, "the refusal must name the rebuild that fixes it"
 
 
 def test_a_lockless_build_bundle_never_becomes_a_version(

--- a/apps/api/tests/test_gitflow_integration.py
+++ b/apps/api/tests/test_gitflow_integration.py
@@ -774,3 +774,135 @@ def test_a_scaffolded_deploy_yaml_reads_back_as_an_empty_map(tmp_path: Path) -> 
     targets = bundles.read_deploy_targets(tmp_path)
     assert targets is not None, "a present deploy.yaml must not read back as absent"
     assert targets.targets == {}
+
+
+# --------------------------------------------------------------------------- #
+# A source-built connector arriving by git push (ADR 0113)
+#
+# VERIFY ONLY: nothing in gitflow.py changes. The push path routes through
+# `bundles.extract_and_validate`, so the intake rules added to
+# `plugin_format.validate.py` cover it with no second implementation -- which is
+# the whole reason they live in `validate_bundle` rather than in the CLI upload
+# router (apps/api/CLAUDE.md: the validator is the ONE gate a bundle passes
+# through, whatever entry point it arrives by). These tests prove that rather
+# than assuming it, and they assert on the ABSENCE of the Version row, not on a
+# log line: `gitflow.py` creates the Version and stores the bundle only after
+# validation passes, so a rule that fired but did not block would still leave a
+# row behind.
+# --------------------------------------------------------------------------- #
+BUILT_CONNECTORS = (
+    "connectors:\n"
+    "  k8s-write:\n"
+    "    build:\n"
+    "      context: connectors/k8s-write\n"
+    "      platforms: [linux/amd64, linux/arm64]\n"
+)
+
+_BUILT_FILES = {
+    **VALID_FILES,
+    "connectors.yaml": BUILT_CONNECTORS,
+    "connectors/k8s-write/Dockerfile": "FROM scratch\nCOPY server.py /server.py\n",
+    "connectors/k8s-write/server.py": "print('acme')\n",
+}
+
+_REGISTRY_IMAGE = (
+    "ghcr.io/acme-corp/acme-bot-k8s-write-mcp@sha256:"
+    "0000000000000000000000000000000000000000000000000000000000000000"
+)
+
+
+def _lock_text(source_digest: str) -> str:
+    return (
+        "version: 1\n"
+        "connectors:\n"
+        "  k8s-write:\n"
+        f"    image: {_REGISTRY_IMAGE}\n"
+        "    delivery: registry\n"
+        "    platforms: [linux/amd64, linux/arm64]\n"
+        f"    source_digest: {source_digest}\n"
+    )
+
+
+def _source_digest(tmp_path: Path, files: dict[str, str]) -> str:
+    """Hash the build context exactly as the validator will after extraction."""
+
+    from plugin_format import connector_lock
+    from plugin_format.connectors import ConnectorBuild
+
+    for rel, content in files.items():
+        path = tmp_path / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+    build = ConnectorBuild.model_validate(
+        {"context": "connectors/k8s-write", "platforms": ["linux/amd64", "linux/arm64"]}
+    )
+    return connector_lock.source_digest_of(tmp_path / "connectors" / "k8s-write", build)
+
+
+def test_a_git_push_of_a_locked_build_bundle_deploys(
+    client: Any,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    trusted_clone_base: Path,
+    tmp_path: Path,
+) -> None:
+    # The control. Without it, a rule that rejected every build: bundle outright
+    # would pass both negatives below.
+    agent_id = _register_agent(client, auth_headers)
+    files = dict(_BUILT_FILES)
+    files["connectors.lock.yaml"] = _lock_text(_source_digest(tmp_path / "ctx", _BUILT_FILES))
+    clone_url, sha = _build_bare_repo(trusted_clone_base, REPO, files)
+
+    resp = _post(client, "push", _push_payload("refs/heads/dev", sha, clone_url))
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["status"] == "deployed"
+    versions = client.get(f"/agents/{agent_id}/versions", headers=auth_headers).json()
+    assert [v["commit_sha"] for v in versions] == [sha]
+
+
+def test_a_git_push_of_a_lockless_build_bundle_creates_no_version(
+    client: Any,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    trusted_clone_base: Path,
+) -> None:
+    agent_id = _register_agent(client, auth_headers)
+    clone_url, sha = _build_bare_repo(trusted_clone_base, REPO, _BUILT_FILES)
+
+    resp = _post(client, "push", _push_payload("refs/heads/dev", sha, clone_url))
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "rejected"
+    assert "connectors.lock_missing" in {e["code"] for e in body["errors"]}
+
+    # The row itself, not the response: this is what stops the deployment going
+    # active while the runner derives a hosted URL for a connector nobody built.
+    assert client.get(f"/agents/{agent_id}/versions", headers=auth_headers).json() == []
+    assert (
+        client.get("/deployments", params={"agent_id": agent_id}, headers=auth_headers).json() == []
+    )
+
+
+def test_a_git_push_of_a_stale_build_bundle_creates_no_version(
+    client: Any,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    trusted_clone_base: Path,
+    tmp_path: Path,
+) -> None:
+    # The push path is the one an author uses without ever running `curie
+    # build`, so it is where a stale lock actually reaches production: the
+    # previous digest is activated and the deployed connector silently stops
+    # matching the reviewed source.
+    agent_id = _register_agent(client, auth_headers)
+    files = dict(_BUILT_FILES)
+    files["connectors.lock.yaml"] = _lock_text(_source_digest(tmp_path / "ctx", _BUILT_FILES))
+    files["connectors/k8s-write/server.py"] = "print('acme, but different')\n"
+    clone_url, sha = _build_bare_repo(trusted_clone_base, REPO, files)
+
+    resp = _post(client, "push", _push_payload("refs/heads/dev", sha, clone_url))
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "rejected"
+    assert "connectors.lock_stale" in {e["code"] for e in body["errors"]}
+    assert client.get(f"/agents/{agent_id}/versions", headers=auth_headers).json() == []

--- a/cli/plugin-format-mirrors.json
+++ b/cli/plugin-format-mirrors.json
@@ -51,6 +51,31 @@
   ],
   "non_mirrors": [
     {
+      "struct": "ConnectorsFileDecl",
+      "file": "cli/src/connector_build.rs",
+      "reason": "Mirrors plugin_format.connectors.ConnectorsFile, but plugin-format.schema.json carries no Connector* $defs (schema_export.py imports only from .models), so field-by-field comparison against the schema does not apply. The seam is frozen in tests/vectors/connector-build-decl.json and tests/vectors/connector-fields.json instead, read by both packages/plugin-format/tests/test_connectors.py and cli/tests/connector_build_decl_vectors.rs."
+    },
+    {
+      "struct": "ConnectorSpecDecl",
+      "file": "cli/src/connector_build.rs",
+      "reason": "Mirrors plugin_format.connectors.ConnectorSpec; same missing Connector* $defs, same vector-frozen seam (tests/vectors/connector-build-decl.json, tests/vectors/connector-fields.json)."
+    },
+    {
+      "struct": "ConnectorBuildDecl",
+      "file": "cli/src/connector_build.rs",
+      "reason": "Mirrors plugin_format.connectors.ConnectorBuild; same missing Connector* $defs, same vector-frozen seam (tests/vectors/connector-build-decl.json, tests/vectors/connector-fields.json)."
+    },
+    {
+      "struct": "ConnectorLockFileDecl",
+      "file": "cli/src/connector_build.rs",
+      "reason": "Mirrors plugin_format.connector_lock.ConnectorLockFile; same missing Connector* $defs, frozen in tests/vectors/connector-lock.json and tests/vectors/connector-fields.json."
+    },
+    {
+      "struct": "ConnectorLockEntryDecl",
+      "file": "cli/src/connector_build.rs",
+      "reason": "Mirrors plugin_format.connector_lock.ConnectorLockEntry; same missing Connector* $defs, frozen in tests/vectors/connector-lock.json and tests/vectors/connector-fields.json."
+    },
+    {
       "struct": "CheckReport",
       "file": "cli/src/commands.rs",
       "reason": "Mirrors the frozen curie_runner.check report contract (parse_check_report), a different local contract entirely -- unrelated to plugin_format and out of scope for #701."

--- a/cli/src/connector_build.rs
+++ b/cli/src/connector_build.rs
@@ -1,0 +1,760 @@
+//! The CLI's hand mirrors of the connector declaration and lock (ADR 0113).
+//!
+//! `packages/plugin-format` owns `connectors.yaml` and `connectors.lock.yaml`,
+//! but the CLI reads both before the platform ever sees the bundle: `curie
+//! build --plugin-dir` builds what the declaration names and writes the lock,
+//! and `curie cluster deploy` preflights that lock. Rust cannot import the
+//! Pydantic models, so the shapes are mirrored here and the seam is frozen in
+//! `tests/vectors/connector-build-decl.json`, `connector-lock.json`,
+//! `connector-fields.json`, `connector-service-dns.json` and
+//! `connector-source-digest.json` -- every one of them read by both this
+//! crate's tests and the Python suite, so a change made in one language and not
+//! the other fails that language.
+//!
+//! Every struct here carries `#[serde(deny_unknown_fields)]`. A tolerant reader
+//! would silently drop a key the bundle author wrote, which is how an operator
+//! ends up believing they declared something they did not, and it would leave
+//! `curie dev field-parity` green while the two languages had already diverged.
+//!
+//! `plugin_format.validate_bundle` remains the full gate: it enforces every
+//! other rule in `validate_connectors` (names, ports, secret paths,
+//! placeholders) and the lock's freshness against the extracted tree. What this
+//! module mirrors is what the CLI itself must decide locally -- which form a
+//! connector declares, whether its build inputs are inside the bundle, and what
+//! the source hashes to.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Component, Path, PathBuf};
+
+use anyhow::{anyhow, bail, Context, Result};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+/// The declaration this module reads, named once (its Python twin is
+/// `plugin_format.connectors.CONNECTORS_FILE`).
+pub const CONNECTORS_FILE: &str = "connectors.yaml";
+
+/// The lock `curie build` writes, named once (its Python twin is
+/// `plugin_format.connector_lock.CONNECTOR_LOCK_FILE`).
+pub const CONNECTOR_LOCK_FILE: &str = "connectors.lock.yaml";
+
+/// The only lock shape this build understands.
+pub const LOCK_VERSION: u32 = 1;
+
+/// Kubernetes DNS label ceiling and the digest suffix a truncated name keeps.
+/// Mirrors `connector_render._DNS_LABEL_MAX` / `_DIGEST_LEN`.
+const DNS_LABEL_MAX: usize = 63;
+const DIGEST_LEN: usize = 8;
+
+// ─── The declaration ─────────────────────────────────────────────────────────
+
+/// `connectors.yaml` itself.
+#[derive(Debug, Default, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ConnectorsFileDecl {
+    #[serde(default)]
+    pub connectors: BTreeMap<String, ConnectorSpecDecl>,
+}
+
+/// One declared connector, a full mirror of `plugin_format.ConnectorSpec`.
+#[derive(Debug, Default, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ConnectorSpecDecl {
+    // -- hosted form --
+    pub image: Option<String>,
+    pub build: Option<ConnectorBuildDecl>,
+    #[serde(default)]
+    pub args: Vec<String>,
+    #[serde(default)]
+    pub env: BTreeMap<String, String>,
+    #[serde(default = "default_port")]
+    pub port: u32,
+    pub unhosted_url: Option<String>,
+
+    // -- remote form --
+    pub url: Option<String>,
+    #[serde(default)]
+    pub headers: BTreeMap<String, String>,
+
+    // -- both --
+    #[serde(default)]
+    pub secrets: Vec<SecretDecl>,
+    #[serde(default)]
+    pub sealed_secrets: BTreeMap<String, String>,
+    #[serde(default)]
+    pub secret_files: BTreeMap<String, String>,
+}
+
+/// A declared secret: a bare env var name, or a reference to a Secret someone
+/// else provisioned. Both forms exist on the Python side and the CLI only ever
+/// carries them through, so this reads either without choosing between them.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum SecretDecl {
+    Name(String),
+    Ref {
+        name: String,
+        from_secret: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        key: Option<String>,
+    },
+}
+
+/// Where a connector's image comes from, when the bundle carries its source.
+#[derive(Debug, Default, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ConnectorBuildDecl {
+    pub context: String,
+    #[serde(default = "default_dockerfile")]
+    pub dockerfile: String,
+    #[serde(default)]
+    pub platforms: Vec<String>,
+}
+
+fn default_port() -> u32 {
+    8000
+}
+
+fn default_dockerfile() -> String {
+    "Dockerfile".to_string()
+}
+
+// ─── The lock ────────────────────────────────────────────────────────────────
+
+/// `connectors.lock.yaml` itself.
+#[derive(Debug, Default, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ConnectorLockFileDecl {
+    pub version: u32,
+    #[serde(default)]
+    pub connectors: BTreeMap<String, ConnectorLockEntryDecl>,
+}
+
+/// The resolved identity of one built connector.
+#[derive(Debug, Default, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ConnectorLockEntryDecl {
+    pub image: String,
+    pub delivery: Delivery,
+    #[serde(default)]
+    pub platforms: Vec<String>,
+    pub source_digest: String,
+}
+
+/// How the built image reaches the tier that runs it. Control bearing: it is
+/// what the cluster deploy preflight refuses on, so an unmodelled value is
+/// rejected loudly rather than degraded to a default (ADR-0036's rule).
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Delivery {
+    #[default]
+    Registry,
+    LocalDaemon,
+}
+
+// ─── Field names: the Python/Rust parity corpus ──────────────────────────────
+
+/// The wire field names of one mirror struct.
+///
+/// Read off a serialized default rather than a hand-typed list, so a field
+/// added to the struct shows up here without anyone remembering to update a
+/// second copy -- the whole point of `tests/vectors/connector-fields.json` is
+/// that neither language can drift alone.
+fn field_names<T: Serialize + Default>() -> BTreeSet<String> {
+    match serde_json::to_value(T::default()) {
+        Ok(serde_json::Value::Object(map)) => map.keys().cloned().collect(),
+        _ => BTreeSet::new(),
+    }
+}
+
+pub fn spec_field_names() -> BTreeSet<String> {
+    field_names::<ConnectorSpecDecl>()
+}
+
+pub fn build_field_names() -> BTreeSet<String> {
+    field_names::<ConnectorBuildDecl>()
+}
+
+pub fn lock_file_field_names() -> BTreeSet<String> {
+    field_names::<ConnectorLockFileDecl>()
+}
+
+pub fn lock_entry_field_names() -> BTreeSet<String> {
+    field_names::<ConnectorLockEntryDecl>()
+}
+
+// ─── Parsing ─────────────────────────────────────────────────────────────────
+
+/// Parse and check a `connectors.yaml` document.
+///
+/// Accept/reject parity with the Python validator is the property that matters:
+/// a document the CLI accepts and the platform rejects means an operator builds
+/// and pushes an image for a bundle that can never deploy, and the reverse
+/// means a bundle that deploys through git flow but cannot be built locally.
+pub fn parse_connectors(document: &str) -> Result<ConnectorsFileDecl> {
+    let file: ConnectorsFileDecl =
+        serde_norway::from_str(document).with_context(|| format!("parse {CONNECTORS_FILE}"))?;
+    for (name, spec) in &file.connectors {
+        check_spec(name, spec)?;
+    }
+    Ok(file)
+}
+
+/// Parse and check a `connectors.lock.yaml` document.
+///
+/// The version is checked here because it is the only thing that lets a future
+/// shape change be refused by an older reader instead of silently misread.
+pub fn parse_lock(document: &str) -> Result<ConnectorLockFileDecl> {
+    let lock: ConnectorLockFileDecl =
+        serde_norway::from_str(document).with_context(|| format!("parse {CONNECTOR_LOCK_FILE}"))?;
+    if lock.version != LOCK_VERSION {
+        bail!(
+            "{CONNECTOR_LOCK_FILE}: version {} is not a shape this build understands \
+             (expected {LOCK_VERSION})",
+            lock.version
+        );
+    }
+    Ok(lock)
+}
+
+/// Read a bundle's `connectors.yaml`, or an empty declaration when it has none.
+pub fn load(bundle_dir: &Path) -> Result<ConnectorsFileDecl> {
+    let path = bundle_dir.join(CONNECTORS_FILE);
+    if !path.is_file() {
+        return Ok(ConnectorsFileDecl::default());
+    }
+    let body =
+        std::fs::read_to_string(&path).with_context(|| format!("read {}", path.display()))?;
+    parse_connectors(&body)
+}
+
+/// Read a bundle's `connectors.lock.yaml`, or `None` when it has none.
+///
+/// `None` is the common case and not an error: an ordinary `image:` bundle
+/// carries no lock and never will.
+pub fn load_lock(bundle_dir: &Path) -> Result<Option<ConnectorLockFileDecl>> {
+    let path = bundle_dir.join(CONNECTOR_LOCK_FILE);
+    if !path.is_file() {
+        return Ok(None);
+    }
+    let body =
+        std::fs::read_to_string(&path).with_context(|| format!("read {}", path.display()))?;
+    parse_lock(&body).map(Some)
+}
+
+fn check_spec(name: &str, spec: &ConnectorSpecDecl) -> Result<()> {
+    let forms = [
+        spec.image.is_some(),
+        spec.build.is_some(),
+        spec.url.is_some(),
+    ];
+    let declared = forms.iter().filter(|set| **set).count();
+    if declared > 1 {
+        bail!(
+            "connectors.{name}: set exactly one of `image`, `build` or `url` -- otherwise it \
+             is unclear who owns the process"
+        );
+    }
+    if declared == 0 {
+        bail!(
+            "connectors.{name}: set `image` for Curie to run it, `build` for Curie to build it \
+             from source in this bundle, or `url` to point at something already running"
+        );
+    }
+    // Keyed to hosted-ness, not to `image`: a built connector is equally hosted,
+    // so a remote-only field must not ride the build form.
+    if (spec.image.is_some() || spec.build.is_some()) && !spec.headers.is_empty() {
+        bail!(
+            "connectors.{name}: `headers` apply to a remote endpoint; configure a hosted \
+             connector with `env` and `args` instead"
+        );
+    }
+    if let Some(build) = &spec.build {
+        check_build(name, build)?;
+    }
+    Ok(())
+}
+
+fn check_build(name: &str, build: &ConnectorBuildDecl) -> Result<()> {
+    if escapes(&build.context) {
+        bail!(
+            "connectors.{name}: `build.context` is {:?}; it must be a path inside the bundle",
+            build.context
+        );
+    }
+    if escapes(&build.dockerfile) {
+        bail!(
+            "connectors.{name}: `build.dockerfile` is {:?}; it must be a path inside the build \
+             context",
+            build.dockerfile
+        );
+    }
+    if build.platforms.is_empty() {
+        bail!(
+            "connectors.{name}: `build.platforms` is empty. A silently single-arch build fails \
+             after apply as `no matching manifest`, so the target set is stated, never guessed"
+        );
+    }
+    for platform in &build.platforms {
+        if !is_platform(platform) {
+            bail!(
+                "connectors.{name}: `{platform}` is not an OCI platform. Use `os/arch` or \
+                 `os/arch/variant`, such as `linux/amd64` or `linux/arm/v7`"
+            );
+        }
+    }
+    Ok(())
+}
+
+/// `os/arch`, optionally `os/arch/variant`. Mirrors `connectors._PLATFORM_RE`.
+fn is_platform(platform: &str) -> bool {
+    let parts: Vec<&str> = platform.split('/').collect();
+    let alnum = |s: &&str| {
+        !s.is_empty()
+            && s.chars()
+                .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit())
+    };
+    match parts.as_slice() {
+        [os, arch] => alnum(os) && alnum(arch),
+        [os, arch, variant] => {
+            alnum(os)
+                && alnum(arch)
+                && variant.starts_with('v')
+                && variant.len() > 1
+                && variant[1..].chars().all(|c| c.is_ascii_digit())
+        }
+        _ => false,
+    }
+}
+
+/// Is this bundle-relative path empty, absolute, or outside its root?
+///
+/// Textual, the same check the Python validator performs on a declaration it
+/// may be reading without a tree. The resolvers below add what only a
+/// filesystem can answer.
+fn escapes(path: &str) -> bool {
+    if path.trim().is_empty() {
+        return true;
+    }
+    let mut depth: i32 = 0;
+    for component in Path::new(path).components() {
+        match component {
+            Component::RootDir | Component::Prefix(_) => return true,
+            Component::ParentDir => {
+                depth -= 1;
+                if depth < 0 {
+                    return true;
+                }
+            }
+            Component::CurDir => {}
+            Component::Normal(_) => depth += 1,
+        }
+    }
+    false
+}
+
+// ─── Path resolution ─────────────────────────────────────────────────────────
+
+/// The canonical build context, required to sit inside the bundle.
+///
+/// ADR 0113 requires a build context constrained to the extracted bundle
+/// "without accepting arbitrary host paths". Canonicalization is what decides,
+/// so a symlinked directory cannot walk out of the bundle either -- and a
+/// symlink is refused rather than dereferenced, the same rule
+/// `cli/src/bundle.rs`'s packer applies for the same reason.
+pub fn resolve_context(bundle_root: &Path, context: &str) -> Result<PathBuf> {
+    if escapes(context) {
+        bail!("build context {context:?} must be a path inside the bundle");
+    }
+    let root = bundle_root
+        .canonicalize()
+        .with_context(|| format!("resolve bundle root {}", bundle_root.display()))?;
+    let candidate = root.join(context);
+    refuse_symlink(&candidate)?;
+    let resolved = candidate
+        .canonicalize()
+        .with_context(|| format!("resolve build context {}", candidate.display()))?;
+    if !resolved.starts_with(&root) {
+        bail!(
+            "build context {context:?} resolves to {} which is outside the bundle",
+            resolved.display()
+        );
+    }
+    Ok(resolved)
+}
+
+/// The canonical Dockerfile, required to sit inside the canonical context.
+///
+/// The textual check alone is not enough here: a bundle can ship
+/// `connectors/x/Dockerfile` as a symlink to a host file, and `curie build`
+/// reads that Dockerfile BEFORE the bundle is packed, so the packer's symlink
+/// refusal never runs.
+pub fn resolve_dockerfile(context_canonical: &Path, dockerfile: &str) -> Result<PathBuf> {
+    if escapes(dockerfile) {
+        bail!("dockerfile {dockerfile:?} must be a path inside the build context");
+    }
+    let candidate = context_canonical.join(dockerfile);
+    refuse_symlink(&candidate)?;
+    let resolved = candidate
+        .canonicalize()
+        .with_context(|| format!("resolve dockerfile {}", candidate.display()))?;
+    if !resolved.starts_with(context_canonical) {
+        bail!(
+            "dockerfile {dockerfile:?} resolves to {} which is outside the build context",
+            resolved.display()
+        );
+    }
+    Ok(resolved)
+}
+
+fn refuse_symlink(path: &Path) -> Result<()> {
+    if let Ok(meta) = std::fs::symlink_metadata(path) {
+        if meta.file_type().is_symlink() {
+            bail!(
+                "{} is a symlink; Curie refuses to follow one out of the bundle rather than \
+                 build whatever it points at",
+                path.display()
+            );
+        }
+    }
+    Ok(())
+}
+
+// ─── object_name / service_dns: the Docker network alias ─────────────────────
+
+/// The Kubernetes object name for a connector, and the Docker network alias the
+/// same connector is started under at the skill and local tiers.
+///
+/// A hand port of `connector_render.object_name`, frozen against
+/// `tests/vectors/connector-service-dns.json`, because the runner derives the
+/// URL it dials from the PYTHON copy: a mismatch leaves it dialing a name no
+/// container owns, which surfaces as a bare connection timeout.
+pub fn object_name(release: &str, agent: &str, connector: &str) -> String {
+    let base = format!("{release}-{agent}-mcp-{connector}");
+    if base.len() <= DNS_LABEL_MAX {
+        return base;
+    }
+    // Truncate WITH a digest of the full name: clipping alone maps two long
+    // names sharing a prefix onto one object.
+    let digest = hex(Sha256::digest(base.as_bytes()).as_slice());
+    let keep = DNS_LABEL_MAX - DIGEST_LEN - 1;
+    let head = base[..keep].trim_end_matches('-');
+    format!("{head}-{}", &digest[..DIGEST_LEN])
+}
+
+/// The in-cluster DNS name of a connector's Service.
+pub fn service_dns(release: &str, agent: &str, connector: &str, namespace: &str) -> String {
+    format!(
+        "{}.{namespace}.svc.cluster.local",
+        object_name(release, agent, connector)
+    )
+}
+
+// ─── source_digest ───────────────────────────────────────────────────────────
+
+/// The content-derived identity of a build input.
+///
+/// A port of `plugin_format.connector_lock.source_digest_of`, frozen against
+/// `tests/vectors/connector-source-digest.json`, whose `comment` states the
+/// algorithm in full and why each rule is there. The CLI writes this value into
+/// the lock and the platform validator recomputes it from the extracted bundle
+/// to refuse a stale one, so two algorithms would make every build look stale on
+/// one side of the seam.
+///
+/// Content plus ONE bit of mode per file, the owner execute bit: the build
+/// context tar carries each file's mode and BuildKit keys its cache on it, so an
+/// exec-bit flip on an entrypoint is a changed build input.
+pub fn source_digest_of(context_dir: &Path, build: &ConnectorBuildDecl) -> Result<String> {
+    let rules = dockerignore_rules(context_dir, &build.dockerfile)?;
+    let mut included: Vec<String> = Vec::new();
+    collect_files(
+        context_dir,
+        context_dir,
+        &rules,
+        is_bundle_root_context(&build.context),
+        &mut included,
+    )?;
+    included.sort_by(|a, b| a.as_bytes().cmp(b.as_bytes()));
+
+    let mut stream: Vec<u8> = Vec::new();
+    for relative in &included {
+        let path = context_dir.join(relative);
+        let bytes = std::fs::read(&path).with_context(|| format!("read {relative}"))?;
+        stream.extend_from_slice(relative.as_bytes());
+        stream.push(0);
+        stream.extend_from_slice(hex(Sha256::digest(&bytes).as_slice()).as_bytes());
+        stream.push(0);
+        stream.push(if is_owner_executable(&path)? {
+            b'1'
+        } else {
+            b'0'
+        });
+        stream.push(b'\n');
+    }
+    // The declared build block, so editing `platforms` or `dockerfile` alone
+    // still invalidates the lock. Keys sorted, no whitespace, platforms in
+    // DECLARED order -- a lane that sorted them would split the two digests.
+    let canonical = format!(
+        "{{\"context\":{},\"dockerfile\":{},\"platforms\":[{}]}}",
+        json_string(&build.context),
+        json_string(&build.dockerfile),
+        build
+            .platforms
+            .iter()
+            .map(|p| json_string(p))
+            .collect::<Vec<_>>()
+            .join(",")
+    );
+    stream.extend_from_slice(b"build\0");
+    stream.extend_from_slice(canonical.as_bytes());
+    stream.push(b'\n');
+
+    Ok(format!(
+        "sha256:{}",
+        hex(Sha256::digest(&stream).as_slice())
+    ))
+}
+
+/// Does the declared `build.context` name the bundle root?
+///
+/// Decided from the DECLARATION, not the tree: `curie build` writes the
+/// generated `connectors.lock.yaml` at the bundle root only, so a
+/// `connectors.lock.yaml` is this context's own generated file exactly when the
+/// declared context names that root. The Python twin normalizes identically --
+/// strip a trailing `/`, then `.` and the empty string are the root.
+fn is_bundle_root_context(context: &str) -> bool {
+    matches!(context.trim_end_matches('/'), "." | "")
+}
+
+/// Is this file executable by its owner? The one bit of mode the digest carries.
+///
+/// Docker's build context tar carries each file's mode and BuildKit keys its
+/// cache on it, so flipping the exec bit on an entrypoint changes the build
+/// input while the bytes stay put.
+#[cfg(unix)]
+fn is_owner_executable(path: &Path) -> Result<bool> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let mode = std::fs::metadata(path)
+        .with_context(|| format!("stat {}", path.display()))?
+        .permissions()
+        .mode();
+    Ok(mode & 0o100 != 0)
+}
+
+/// Off-unix there is no owner execute bit to read, so every file hashes as
+/// non-executable -- the same normalization docker itself applies on Windows,
+/// where the context tar is written with a fixed mode.
+#[cfg(not(unix))]
+fn is_owner_executable(_path: &Path) -> Result<bool> {
+    Ok(false)
+}
+
+fn json_string(value: &str) -> String {
+    serde_json::to_string(value).unwrap_or_else(|_| String::from("\"\""))
+}
+
+fn hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+/// One `.dockerignore` line: the pattern, and whether it re-includes.
+struct IgnoreRule {
+    negated: bool,
+    pattern: String,
+}
+
+/// The context's own `.dockerignore` exclusion set, in file order, or an empty
+/// one.
+///
+/// Docker's file, so honoring it means the digest covers exactly what the
+/// daemon receives. `.curieignore` governs bundle packing, a different
+/// question, and is not consulted.
+///
+/// Order is load-bearing: `*` followed by `!Dockerfile` and `!Dockerfile`
+/// followed by `*` are different exclusion sets, and the last matching rule is
+/// the one that decides. The two trailing rules mirror the docker CLI's own
+/// `TrimBuildFilesFromExcludes`, which puts the Dockerfile and `.dockerignore`
+/// back into the context however the patterns read.
+fn dockerignore_rules(context_dir: &Path, dockerfile: &str) -> Result<Vec<IgnoreRule>> {
+    let path = context_dir.join(".dockerignore");
+    if !path.is_file() {
+        return Ok(Vec::new());
+    }
+    let body =
+        std::fs::read_to_string(&path).with_context(|| format!("read {}", path.display()))?;
+    let mut rules: Vec<IgnoreRule> = Vec::new();
+    for line in body.lines().map(str::trim) {
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        match line.strip_prefix('!') {
+            // The `!` is removed and the remainder used verbatim, as Docker
+            // does; a bare `!` names nothing and is skipped rather than being
+            // read as a re-include of everything.
+            Some("") => continue,
+            Some(remainder) => rules.push(IgnoreRule {
+                negated: true,
+                pattern: remainder.to_string(),
+            }),
+            None => rules.push(IgnoreRule {
+                negated: false,
+                pattern: line.to_string(),
+            }),
+        }
+    }
+    for build_file in [".dockerignore", dockerfile] {
+        if is_excluded(&rules, build_file) {
+            rules.push(IgnoreRule {
+                negated: true,
+                pattern: build_file.to_string(),
+            });
+        }
+    }
+    Ok(rules)
+}
+
+fn collect_files(
+    root: &Path,
+    dir: &Path,
+    rules: &[IgnoreRule],
+    exclude_lock: bool,
+    out: &mut Vec<String>,
+) -> Result<()> {
+    for entry in std::fs::read_dir(dir).with_context(|| format!("read {}", dir.display()))? {
+        let entry = entry?;
+        let path = entry.path();
+        let kind = entry.file_type()?;
+        // A symlink is never followed and never hashed; the context resolver
+        // refuses one before hashing begins.
+        if kind.is_symlink() {
+            continue;
+        }
+        let relative = path
+            .strip_prefix(root)
+            .map_err(|_| anyhow!("{} is outside {}", path.display(), root.display()))?
+            .to_string_lossy()
+            .replace('\\', "/");
+        if kind.is_dir() {
+            // Descended even when the directory itself matches an exclusion: a
+            // later `!` can re-include a file beneath it, which is exactly what
+            // Docker does once the ignore set carries any exclusion. The
+            // per-file check below evaluates the same ancestor paths, so
+            // pruning here would only ever LOSE a re-included file.
+            collect_files(root, &path, rules, exclude_lock, out)?;
+            continue;
+        }
+        // Only the context's OWN generated lock: `curie build` writes it at the
+        // BUNDLE root, so it is skipped only when the declared context IS that
+        // root. Under a subdirectory context a `connectors.lock.yaml` at the top
+        // is authored input the daemon receives, and so is one nested deeper
+        // under any context.
+        if exclude_lock && relative == CONNECTOR_LOCK_FILE {
+            continue;
+        }
+        if is_excluded(rules, &relative) {
+            continue;
+        }
+        out.push(relative);
+    }
+    Ok(())
+}
+
+/// Is this path excluded once every rule has had its say, in file order?
+///
+/// Docker's rule, not "the first exclusion wins": every rule is evaluated and
+/// the last one that matches decides, so a later `!` re-includes what an earlier
+/// pattern excluded. Each rule is matched segment by segment against the path
+/// and each of its ancestor directory paths, so `*` and `?` never cross a `/`
+/// and a pattern naming a directory excludes everything beneath it.
+fn is_excluded(rules: &[IgnoreRule], relative: &str) -> bool {
+    let segments: Vec<&str> = relative.split('/').collect();
+    let candidates: Vec<String> = (0..segments.len())
+        .map(|i| segments[..=i].join("/"))
+        .collect();
+    let mut excluded = false;
+    for rule in rules {
+        if matches_any(&rule.pattern, &candidates) {
+            excluded = !rule.negated;
+        }
+    }
+    excluded
+}
+
+fn matches_any(pattern: &str, candidates: &[String]) -> bool {
+    let parts: Vec<&str> = pattern.split('/').collect();
+    for candidate in candidates {
+        let against: Vec<&str> = candidate.split('/').collect();
+        if parts.len() != against.len() {
+            continue;
+        }
+        if parts
+            .iter()
+            .zip(against.iter())
+            .all(|(p, a)| matches_segment(p, a))
+        {
+            return true;
+        }
+    }
+    false
+}
+
+/// One path segment against one glob segment: `*`, `?` and `[...]` classes,
+/// matching Python's `fnmatch.fnmatchcase` on the other side of the seam.
+fn matches_segment(pattern: &str, name: &str) -> bool {
+    let p: Vec<char> = pattern.chars().collect();
+    let n: Vec<char> = name.chars().collect();
+    glob_match(&p, &n)
+}
+
+fn glob_match(pattern: &[char], name: &[char]) -> bool {
+    if pattern.is_empty() {
+        return name.is_empty();
+    }
+    match pattern[0] {
+        '*' => {
+            for split in 0..=name.len() {
+                if glob_match(&pattern[1..], &name[split..]) {
+                    return true;
+                }
+            }
+            false
+        }
+        '?' => !name.is_empty() && glob_match(&pattern[1..], &name[1..]),
+        '[' => {
+            let Some(close) = pattern.iter().position(|c| *c == ']').filter(|i| *i > 1) else {
+                // An unterminated class is a literal `[`, as fnmatch reads it.
+                return !name.is_empty() && name[0] == '[' && glob_match(&pattern[1..], &name[1..]);
+            };
+            if name.is_empty() {
+                return false;
+            }
+            let mut class = &pattern[1..close];
+            let negated = matches!(class.first(), Some('!'));
+            if negated {
+                class = &class[1..];
+            }
+            let hit = class_matches(class, name[0]);
+            (hit != negated) && glob_match(&pattern[close + 1..], &name[1..])
+        }
+        literal => !name.is_empty() && name[0] == literal && glob_match(&pattern[1..], &name[1..]),
+    }
+}
+
+fn class_matches(class: &[char], candidate: char) -> bool {
+    let mut i = 0;
+    while i < class.len() {
+        if i + 2 < class.len() && class[i + 1] == '-' {
+            if class[i] <= candidate && candidate <= class[i + 2] {
+                return true;
+            }
+            i += 3;
+            continue;
+        }
+        if class[i] == candidate {
+            return true;
+        }
+        i += 1;
+    }
+    false
+}

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -11,6 +11,7 @@ pub mod channel;
 pub mod chat;
 pub mod commands;
 pub mod comms;
+pub mod connector_build;
 pub mod connectors;
 pub mod credcheck;
 pub mod discover;

--- a/cli/tests/connector_build_decl_vectors.rs
+++ b/cli/tests/connector_build_decl_vectors.rs
@@ -1,0 +1,455 @@
+// The Rust half of the frozen connector declaration / lock / DNS seam (ADR 0113).
+//
+// `curie build --plugin-dir` reads a bundle's `connectors.yaml` and writes
+// `connectors.lock.yaml` before the platform ever sees the bundle, and
+// `curie skill up` / `curie local deploy` start the connector containers under
+// a Docker network alias the runner independently derives on the Python side.
+// So the CLI carries hand mirrors of shapes and derivations that
+// `packages/plugin-format` owns, in a language that cannot import them.
+//
+// The usual gate does not cover this seam. `curie dev field-parity` compares a
+// Rust struct against `packages/plugin-format/schema/plugin-format.schema.json`,
+// and `schema_export.py` imports only from `.models`, so the committed schema
+// carries no `Connector*` `$defs` at all -- the connector structs are declared
+// in `cli/plugin-format-mirrors.json`'s `non_mirrors` array and the field
+// comparison is a no-op for them today. This file is the seam instead: it reads
+// the same five corpora the Python suite reads, so a change made in one
+// language and not the other fails that language's suite.
+//
+//   tests/vectors/connector-build-decl.json    the `build:` declaration
+//   tests/vectors/connector-lock.json          connectors.lock.yaml + apply_lock
+//   tests/vectors/connector-fields.json        the exact field-name sets
+//   tests/vectors/connector-service-dns.json   object_name / service_dns
+//   tests/vectors/connector-source-digest.json source_digest_of
+//
+// Same mechanism as `tests/vectors/approval-action-ids.json` for the
+// dispatcher-versus-CLI action ids.
+
+use curie::connector_build;
+use serde_json::Value;
+use std::collections::BTreeSet;
+use std::path::Path;
+use tempfile::TempDir;
+
+// ─── Loaders ─────────────────────────────────────────────────────────────────
+
+fn vector_file(name: &str) -> Value {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../tests/vectors")
+        .join(name);
+    let body = std::fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("read {}: {error}", path.display()));
+    serde_json::from_str(&body).unwrap_or_else(|error| panic!("parse {}: {error}", path.display()))
+}
+
+fn vectors(name: &str) -> Vec<Value> {
+    vector_file(name)["vectors"]
+        .as_array()
+        .unwrap_or_else(|| panic!("{name} has no `vectors` array"))
+        .clone()
+}
+
+fn name_of(vector: &Value) -> &str {
+    vector["name"].as_str().expect("vector has a name")
+}
+
+/// Materialize a `{relative path: file}` map under a fresh directory.
+///
+/// A value is either a content string, or `{"content": ..., "executable": true}`
+/// for a file written with the owner execute bit set. The mode is part of the
+/// digest -- the build context tar carries it -- so a materializer that ignored
+/// the object form would write the executable vectors non-executable and fail
+/// against a corpus that is right.
+fn materialize(root: &Path, tree: &Value) {
+    for (rel, value) in tree.as_object().expect("tree is an object") {
+        let path = root.join(rel);
+        std::fs::create_dir_all(path.parent().expect("a parent")).expect("mkdir -p");
+        let (content, executable) = match value {
+            Value::String(content) => (content.as_str(), false),
+            Value::Object(file) => (
+                file["content"].as_str().expect("file content is a string"),
+                file.get("executable")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false),
+            ),
+            other => panic!("a tree value is a string or an object, got {other}"),
+        };
+        std::fs::write(&path, content).expect("write");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&path).expect("stat").permissions().mode() & 0o7777;
+            let mode = if executable {
+                mode | 0o100
+            } else {
+                mode & !0o111
+            };
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(mode))
+                .expect("chmod the materialized file");
+        }
+        #[cfg(not(unix))]
+        let _ = executable;
+    }
+}
+
+fn scratch() -> TempDir {
+    TempDir::new().expect("a scratch directory")
+}
+
+// ─── The `build:` declaration ────────────────────────────────────────────────
+
+#[test]
+fn the_rust_reader_accepts_and_rejects_exactly_the_documents_python_does() {
+    // Accept/reject parity is the whole point: `curie build` reads the bundle
+    // BEFORE upload, so a document the CLI accepts and the platform validator
+    // rejects means an operator builds and pushes an image for a bundle that
+    // can never deploy, and a document the CLI rejects and the platform accepts
+    // means a bundle that deploys through git flow but cannot be built locally.
+    for vector in vectors("connector-build-decl.json") {
+        if vector.get("fixture").is_some() {
+            continue; // filesystem cases have their own test below
+        }
+        let document = serde_norway::to_string(&vector["document"]).expect("serialize document");
+        let parsed = connector_build::parse_connectors(&document);
+        match vector["expect"].as_str().expect("expect") {
+            "accept" => {
+                let file = parsed.unwrap_or_else(|error| {
+                    panic!("{} must be accepted, got {error}", name_of(&vector))
+                });
+                if let Some(expected) = vector.get("resolved_dockerfile") {
+                    for (connector, dockerfile) in expected.as_object().expect("an object") {
+                        let spec = file
+                            .connectors
+                            .get(connector)
+                            .unwrap_or_else(|| panic!("{connector} is declared"));
+                        let build = spec.build.as_ref().expect("a build block");
+                        assert_eq!(
+                            build.dockerfile,
+                            dockerfile.as_str().expect("a string"),
+                            "{}: resolved dockerfile",
+                            name_of(&vector)
+                        );
+                    }
+                }
+            }
+            "reject" => {
+                assert!(
+                    parsed.is_err(),
+                    "{} must be rejected by the Rust reader",
+                    name_of(&vector)
+                );
+            }
+            other => panic!("unknown expect {other:?}"),
+        }
+    }
+}
+
+#[test]
+fn an_unknown_key_inside_a_build_block_is_refused_not_dropped() {
+    // The `deny_unknown_fields` proof. Without the attribute the field is
+    // silently dropped and `curie dev field-parity` stays green, which is
+    // exactly the tolerance gap review finding 9 named: a future Python field
+    // would vanish on the Rust side with every gate reporting success.
+    // REMOVING the attribute makes this test pass, which is how the attribute
+    // is proved to be the thing that catches it.
+    let document = "connectors:\n  tempo:\n    build:\n      context: connectors/tempo\n      \
+                    platforms: [linux/amd64]\n      target: runtime\n";
+    assert!(
+        connector_build::parse_connectors(document).is_err(),
+        "an unmodelled key inside build: must be refused, not dropped"
+    );
+}
+
+#[test]
+fn a_symlinked_dockerfile_leaving_the_context_is_refused() {
+    // The textual absolute / `..` check the Python validator performs cannot
+    // see this: the declared path is clean and only the filesystem knows the
+    // file is a link out of the bundle. `curie build` reads the Dockerfile
+    // BEFORE the bundle is packed, so `cli/src/bundle.rs`'s symlink refusal
+    // never runs. `resolve_dockerfile` must refuse rather than dereference,
+    // for the same reason that packer guard exists.
+    let vector = vectors("connector-build-decl.json")
+        .into_iter()
+        .find(|v| v.get("fixture").is_some())
+        .expect("the corpus carries a filesystem fixture");
+    let fixture = &vector["fixture"];
+    let tmp = scratch();
+    let root = tmp.path();
+    let bundle = root.join("bundle");
+    std::fs::create_dir_all(&bundle).expect("mkdir bundle");
+    materialize(root, &fixture["outside_files"]);
+    materialize(&bundle, &fixture["bundle_files"]);
+    for (link, target) in fixture["bundle_symlinks"]
+        .as_object()
+        .expect("symlink recipe")
+    {
+        let path = bundle.join(link);
+        std::fs::create_dir_all(path.parent().expect("a parent")).expect("mkdir -p");
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(target.as_str().expect("a target"), &path).expect("symlink");
+    }
+
+    let context = connector_build::resolve_context(&bundle, "connectors/k8s-write")
+        .expect("the context itself is inside the bundle");
+    assert!(
+        connector_build::resolve_dockerfile(&context, "Dockerfile").is_err(),
+        "a Dockerfile that resolves through a symlink out of the context must be refused"
+    );
+}
+
+#[test]
+fn a_context_outside_the_bundle_is_refused() {
+    // The other half of the containment rule, on the filesystem rather than in
+    // the declaration: canonicalization must be what decides, so a symlinked
+    // directory cannot walk out of the bundle either.
+    let tmp = scratch();
+    let root = tmp.path();
+    let bundle = root.join("bundle");
+    std::fs::create_dir_all(bundle.join("connectors/k8s-write")).expect("mkdir -p");
+    std::fs::create_dir_all(root.join("outside")).expect("mkdir -p");
+
+    assert!(connector_build::resolve_context(&bundle, "connectors/k8s-write").is_ok());
+    assert!(connector_build::resolve_context(&bundle, "../outside").is_err());
+    assert!(connector_build::resolve_context(&bundle, "/etc").is_err());
+    #[cfg(unix)]
+    {
+        std::os::unix::fs::symlink(root.join("outside"), bundle.join("escape")).expect("symlink");
+        assert!(
+            connector_build::resolve_context(&bundle, "escape").is_err(),
+            "a symlinked context directory must not walk out of the bundle"
+        );
+    }
+}
+
+// ─── connectors.lock.yaml ────────────────────────────────────────────────────
+
+#[test]
+fn the_rust_lock_reader_agrees_with_python_on_every_vector() {
+    // `curie cluster deploy` preflights the lock locally so the operator gets
+    // an actionable failure instead of an upload rejection, and the platform
+    // validates the same file at intake so a git push cannot bypass it. The two
+    // halves must agree on which documents are well formed, or one of them is
+    // the only gate that ever fires.
+    for vector in vectors("connector-lock.json") {
+        if vector["lock"].is_null() {
+            continue;
+        }
+        let document = serde_norway::to_string(&vector["lock"]).expect("serialize lock");
+        let parsed = connector_build::parse_lock(&document);
+        match vector["expect"].as_str().expect("expect") {
+            // "raise" documents parse and are refused by apply_lock, which is
+            // the Python side's job; the Rust reader only has to accept them.
+            "apply" | "raise" => assert!(
+                parsed.is_ok(),
+                "{} must parse on the Rust side",
+                name_of(&vector)
+            ),
+            "invalid" => assert!(
+                parsed.is_err(),
+                "{} must be refused by the Rust reader too",
+                name_of(&vector)
+            ),
+            other => panic!("unknown expect {other:?}"),
+        }
+    }
+}
+
+#[test]
+fn an_unknown_key_in_a_lock_entry_is_refused_not_dropped() {
+    // The `deny_unknown_fields` proof for the lock mirrors. An operator who
+    // believes they pinned something they did not is the failure this refuses.
+    let document = "version: 1\nconnectors:\n  tempo:\n    image: \
+                    ghcr.io/acme-corp/acme-bot-tempo-mcp@sha256:\
+                    0000000000000000000000000000000000000000000000000000000000000000\n    \
+                    delivery: registry\n    platforms: [linux/amd64]\n    source_digest: \
+                    sha256:2222222222222222222222222222222222222222222222222222222222222222\n    \
+                    digest: sha256:0000\n";
+    assert!(
+        connector_build::parse_lock(document).is_err(),
+        "an unmodelled key in a lock entry must be refused, not dropped"
+    );
+}
+
+// ─── The field-name corpus ───────────────────────────────────────────────────
+
+#[test]
+fn the_mirror_structs_carry_exactly_the_frozen_field_names() {
+    // The mechanism that answers review finding r2-1's exact scenario. Adding a
+    // Python field with no vector edit fails the Python suite; editing the
+    // vector to make that pass then fails HERE until the mirror gains the
+    // field. The loop cannot be exited by touching one language.
+    let fields = vector_file("connector-fields.json");
+    let expect = |model: &str| -> BTreeSet<String> {
+        fields["models"][model]
+            .as_array()
+            .unwrap_or_else(|| panic!("{model} is listed in the vector"))
+            .iter()
+            .map(|v| v.as_str().expect("a field name").to_string())
+            .collect()
+    };
+
+    assert_eq!(connector_build::spec_field_names(), expect("ConnectorSpec"));
+    assert_eq!(
+        connector_build::build_field_names(),
+        expect("ConnectorBuild")
+    );
+    assert_eq!(
+        connector_build::lock_file_field_names(),
+        expect("ConnectorLockFile")
+    );
+    assert_eq!(
+        connector_build::lock_entry_field_names(),
+        expect("ConnectorLockEntry")
+    );
+}
+
+// ─── object_name / service_dns: the Docker network alias ─────────────────────
+
+#[test]
+fn the_connector_dns_derivation_matches_the_frozen_vector() {
+    // This string is the Docker network alias the connector container is
+    // started under at the skill and local tiers, and the runner derives the
+    // URL it dials from the PYTHON copy of this derivation. A mismatch leaves
+    // the runner dialing a name no container owns: a bare connection timeout
+    // with nothing logged at either end. The over-63-character truncation
+    // branch is in the corpus because that is the half a hand port gets wrong.
+    for vector in vectors("connector-service-dns.json") {
+        let release = vector["release"].as_str().expect("release");
+        let agent = vector["agent"].as_str().expect("agent");
+        let connector = vector["connector"].as_str().expect("connector");
+        let namespace = vector["namespace"].as_str().expect("namespace");
+        assert_eq!(
+            connector_build::object_name(release, agent, connector),
+            vector["object_name"].as_str().expect("object_name"),
+            "{}: object_name",
+            name_of(&vector)
+        );
+        assert_eq!(
+            connector_build::service_dns(release, agent, connector, namespace),
+            vector["service_dns"].as_str().expect("service_dns"),
+            "{}: service_dns",
+            name_of(&vector)
+        );
+    }
+}
+
+// ─── source_digest ───────────────────────────────────────────────────────────
+
+#[test]
+fn the_source_digest_port_agrees_with_python_on_every_tree() {
+    // "A changed source produces a distinct digest" is only a real proof if
+    // both lanes compute the same value: the CLI writes the digest into the
+    // lock and the platform validator recomputes it from the extracted bundle
+    // to refuse a stale one. Two algorithms means every build looks stale on
+    // one side of the seam. The corpus covers a nested tree, a `.dockerignore`d
+    // file, a bundle-root context carrying `connectors.lock.yaml` and a
+    // subdirectory one that hashes its own, a file that differs only in its
+    // owner execute bit, and two edits that touch only the declaration.
+    let tmp = scratch();
+    let root = tmp.path();
+    for (i, vector) in vectors("connector-source-digest.json").iter().enumerate() {
+        let context = root.join(format!("ctx{i}"));
+        std::fs::create_dir_all(&context).expect("mkdir ctx");
+        materialize(&context, &vector["tree"]);
+        let build: connector_build::ConnectorBuildDecl =
+            serde_json::from_value(vector["build"].clone()).expect("parse the build block");
+        assert_eq!(
+            connector_build::source_digest_of(&context, &build).expect("hash the context"),
+            vector["source_digest"].as_str().expect("source_digest"),
+            "{}: source_digest",
+            name_of(vector)
+        );
+    }
+}
+
+#[test]
+fn the_source_digest_relations_hold() {
+    // Where the exclusion rules are actually falsified. A port that ignores
+    // `.dockerignore` still passes every single-vector assertion by recording
+    // whatever it computes; it cannot satisfy both halves of a relation, since
+    // one pair must come out equal and another must not.
+    let doc = vector_file("connector-source-digest.json");
+    let by_name: std::collections::BTreeMap<String, Value> = doc["vectors"]
+        .as_array()
+        .expect("vectors")
+        .iter()
+        .map(|v| (name_of(v).to_string(), v.clone()))
+        .collect();
+    let tmp = scratch();
+    let root = tmp.path();
+
+    for (i, relation) in doc["relations"]
+        .as_array()
+        .expect("relations")
+        .iter()
+        .enumerate()
+    {
+        let (names, same) = match relation.get("same") {
+            Some(v) => (v, true),
+            None => (&relation["distinct"], false),
+        };
+        let mut digests = Vec::new();
+        for (j, name) in names.as_array().expect("a pair").iter().enumerate() {
+            let vector = &by_name[name.as_str().expect("a name")];
+            let context = root.join(format!("r{i}-{j}"));
+            std::fs::create_dir_all(&context).expect("mkdir ctx");
+            materialize(&context, &vector["tree"]);
+            let build: connector_build::ConnectorBuildDecl =
+                serde_json::from_value(vector["build"].clone()).expect("parse the build block");
+            digests.push(
+                connector_build::source_digest_of(&context, &build).expect("hash the context"),
+            );
+        }
+        let why = relation["why"].as_str().unwrap_or("");
+        if same {
+            assert_eq!(digests[0], digests[1], "{why}");
+        } else {
+            assert_ne!(digests[0], digests[1], "{why}");
+        }
+    }
+}
+
+/// The one digest rule the JSON corpus cannot state, since a vector's `tree` is
+/// a path-to-content map and cannot express a link.
+///
+/// Its Python twin is
+/// `test_a_symlink_inside_the_context_is_neither_followed_nor_hashed`. Both must
+/// hold or the digest stops being one cross-language identity: a bundle with a
+/// linked file in its context would report its lock stale on one side of the
+/// seam and current on the other. Asserted as an equality against the same tree
+/// WITHOUT the links rather than as a frozen literal, so it survives any future
+/// change to the stream layout.
+#[test]
+#[cfg(unix)]
+fn a_symlink_inside_the_context_is_neither_followed_nor_hashed() {
+    let tmp = scratch();
+    let root = tmp.path();
+    let outside = root.join("outside");
+    std::fs::create_dir_all(outside.join("lib")).expect("mkdir -p");
+    std::fs::write(outside.join("secret.env"), "TOKEN=abc\n").expect("write");
+    std::fs::write(outside.join("lib/vendored.py"), "VENDORED = 1\n").expect("write");
+
+    let plain = root.join("plain");
+    let linked = root.join("linked");
+    for context in [&plain, &linked] {
+        std::fs::create_dir_all(context).expect("mkdir");
+        std::fs::write(context.join("Dockerfile"), "FROM scratch\n").expect("write");
+    }
+    std::os::unix::fs::symlink(outside.join("secret.env"), linked.join("secret.env"))
+        .expect("symlink a file");
+    std::os::unix::fs::symlink(outside.join("lib"), linked.join("lib"))
+        .expect("symlink a directory");
+
+    let build: connector_build::ConnectorBuildDecl = serde_json::from_value(serde_json::json!({
+        "context": "connectors/tempo",
+        "dockerfile": "Dockerfile",
+        "platforms": ["linux/amd64"],
+    }))
+    .expect("parse the build block");
+
+    assert_eq!(
+        connector_build::source_digest_of(&linked, &build).expect("hash the linked context"),
+        connector_build::source_digest_of(&plain, &build).expect("hash the plain context"),
+        "a symlink is never followed and never hashed, on both sides of the seam"
+    );
+}

--- a/cli/tests/plugin_format_field_parity.rs
+++ b/cli/tests/plugin_format_field_parity.rs
@@ -163,6 +163,96 @@ fn spec_rs_has_no_plugin_format_field_parity_violations() {
 }
 
 #[test]
+fn connector_build_rs_has_no_plugin_format_field_parity_violations() {
+    // The third mirror site (ADR 0113). Without this per-file test the gate's
+    // `UndeclaredStruct` check never walks `cli/src/connector_build.rs` at all,
+    // and the `non_mirrors` entries `cli/plugin-format-mirrors.json` carries
+    // for its structs are decoration rather than enforcement: a new
+    // `Deserialize` mirror of a frozen connector shape could land undeclared.
+    //
+    // The FIELD comparison is deliberately a no-op for these structs today,
+    // because `plugin-format.schema.json` carries no `Connector*` `$defs`
+    // (`schema_export.py` imports only from `.models`), which is why they are
+    // declared as non_mirrors and why `tests/vectors/connector-fields.json`
+    // exists alongside this gate rather than being redundant with it. When the
+    // schema-export follow-up lands, those entries move to `mirrors` and this
+    // test starts comparing fields too, with no change here.
+    let src = repo_text("cli/src/connector_build.rs");
+    let schema = plugin_format_schema_as_components();
+    let manifest = repo_json("cli/plugin-format-mirrors.json");
+    let scoped = manifest_for_file(&manifest, "cli/src/connector_build.rs");
+
+    let vs = violations(&src, &schema, &scoped);
+    assert!(
+        vs.is_empty(),
+        "cli/src/connector_build.rs has drifted from packages/plugin-format/schema/plugin-format.schema.json. \
+         Each entry below is fixed by either adding the field to the struct or declaring the \
+         omission (with a justification) in cli/plugin-format-mirrors.json:\n{vs:#?}"
+    );
+}
+
+#[test]
+fn every_connector_mirror_struct_is_declared_in_the_manifest() {
+    // The scenario the per-file test above is checked against, stated as its
+    // own assertion so a manifest mistake elsewhere cannot hide it: each of the
+    // connector declaration and lock mirrors must appear in exactly one of
+    // `mirrors` / `non_mirrors` for its file. Adding a scratch `Deserialize`
+    // struct to `cli/src/connector_build.rs` and leaving it undeclared must
+    // fail, which is how `curie dev field-parity` is proved to see this module.
+    let src = repo_text("cli/src/connector_build.rs");
+    let schema = plugin_format_schema_as_components();
+    let manifest = repo_json("cli/plugin-format-mirrors.json");
+    let scoped = manifest_for_file(&manifest, "cli/src/connector_build.rs");
+    let vs = violations(&src, &schema, &scoped);
+
+    for name in [
+        "ConnectorsFileDecl",
+        "ConnectorSpecDecl",
+        "ConnectorBuildDecl",
+        "ConnectorLockFileDecl",
+        "ConnectorLockEntryDecl",
+    ] {
+        assert!(
+            !has_undeclared_struct(&vs, name),
+            "{name} is a Deserialize mirror in cli/src/connector_build.rs with no \
+             mirrors/non_mirrors entry in cli/plugin-format-mirrors.json:\n{vs:#?}"
+        );
+        assert!(
+            src.contains(&format!("struct {name}")),
+            "{name} is declared in cli/plugin-format-mirrors.json but does not exist in \
+             cli/src/connector_build.rs -- a stale manifest entry hides a real drift"
+        );
+    }
+}
+
+#[test]
+fn every_connector_mirror_struct_denies_unknown_fields() {
+    // The runtime half of the tolerance gap review finding 9 named. The field
+    // vector catches a Python field that never reached the Rust mirror; this
+    // catches a real `connectors.yaml` or lock in the wild carrying a field the
+    // Rust side does not model, which without the attribute is silently dropped
+    // and the operator believes they declared something they did not.
+    let src = repo_text("cli/src/connector_build.rs");
+    for name in [
+        "ConnectorsFileDecl",
+        "ConnectorSpecDecl",
+        "ConnectorBuildDecl",
+        "ConnectorLockFileDecl",
+        "ConnectorLockEntryDecl",
+    ] {
+        let at = src
+            .find(&format!("struct {name}"))
+            .unwrap_or_else(|| panic!("{name} is defined in cli/src/connector_build.rs"));
+        let attrs = &src[at.saturating_sub(400)..at];
+        assert!(
+            attrs.contains("deny_unknown_fields"),
+            "{name} must carry #[serde(deny_unknown_fields)] so an unmodelled key is refused \
+             rather than dropped"
+        );
+    }
+}
+
+#[test]
 fn approval_gate_and_policy_mirrors_stay_fully_covered() {
     // The issue's named drift class hinges on ApprovalGate/ApprovalPolicy
     // never silently losing coverage across BOTH mirror sites (commands.rs's

--- a/docs/interfaces/bundle-format/INTERFACE.md
+++ b/docs/interfaces/bundle-format/INTERFACE.md
@@ -30,13 +30,18 @@ extensions** — `systemPrompt`, `starterPrompts`, `secrets`, `triggers`, `appro
 does not define. Leniency is what lets the Claude Code base and these extensions coexist; the
 earlier "does not invent format extensions" framing was wrong.
 
-The manifest is not the whole bundle either. Two **Curie-only root files** sit beside the Claude
-Code surfaces and are validated by the same entry point: `connectors.yaml` (ADR-0086, Accepted) and
-`deploy.yaml` (ADR-0089, Accepted). Neither has a Claude Code counterpart, so neither is lenient:
-both parse under `extra="forbid"` (`packages/plugin-format/src/plugin_format/connectors.py::ConnectorSpec`,
+The manifest is not the whole bundle either. Three **Curie-only root files** sit beside the Claude
+Code surfaces and are validated by the same entry point: `connectors.yaml` (ADR-0086, Accepted), its
+generated companion `connectors.lock.yaml` (ADR-0113, Accepted), and `deploy.yaml` (ADR-0089,
+Accepted). None has a Claude Code counterpart, so none is lenient:
+all three parse under `extra="forbid"` (`packages/plugin-format/src/plugin_format/connectors.py::ConnectorSpec`,
+`packages/plugin-format/src/plugin_format/connector_lock.py::ConnectorLockEntry`,
 `packages/plugin-format/src/plugin_format/deploy_targets.py::DeployTarget`), because there is no
 external producer that could legitimately carry a key the models do not know, so an unrecognised key
-is a typo rather than a future Claude Code field. What a bundle actually is, then, is the Claude Code
+is a typo rather than a future Claude Code field. The lock is the one root file no human authors --
+`curie build` writes it and the bundle carries it -- but it is part of the format all the same,
+because a second consumer that ignores it deploys a different image than the one the bundle's source
+was built into. What a bundle actually is, then, is the Claude Code
 plugin shape verbatim plus a strict Curie-only overlay, not a Claude Code plugin end to end.
 
 ## Current contract
@@ -55,20 +60,59 @@ with `name`/`description` required and `allowed_tools` aliased to the verbatim `
 `.mcp.json` file) where the validator enforces each server define `command` (stdio) or `url`
 (remote).
 
-Those are the Claude-Code-shaped surfaces. `validate_bundle` also validates two **Curie-only root
-files**, both optional, both invisible to Claude Code:
+Those are the Claude-Code-shaped surfaces. `validate_bundle` also validates three **Curie-only root
+files**, each absent from a bundle that needs none, all three invisible to Claude Code:
 
 - `connectors.yaml` (ADR-0086, `packages/plugin-format/src/plugin_format/connectors.py::ConnectorsFile`)
   declares the MCP servers Curie should run or reach on the bundle's behalf, keyed by connector name.
   Each entry is a `packages/plugin-format/src/plugin_format/connectors.py::ConnectorSpec` in exactly
-  one of two forms, hosted (`image`, plus `args`/`env`/`port`) or remote (`url`, plus `headers`), and
-  names the credentials it needs (`secrets`, `secret_files`, `sealed_secrets`) by NAME only, never by
+  one of three mutually exclusive forms: hosted by reference (`image`, plus `args`/`env`/`port`),
+  hosted from source (`build`, ADR-0113, the same hosted form with the image sourced rather than
+  named), or remote (`url`, plus `headers`). More than one set on one connector is
+  `connectors.ambiguous`, none set is `connectors.underspecified`. A `build` block
+  (`packages/plugin-format/src/plugin_format/connectors.py::ConnectorBuild`) carries a
+  bundle-relative `context`, a `dockerfile` under it, and a required non-empty `platforms` list; it
+  never carries a digest, which lives only in the lock. Every entry names the credentials it needs
+  (`secrets`, `secret_files`, `sealed_secrets`) by NAME only, never by
   value. Validated by `packages/plugin-format/src/plugin_format/validate.py::_validate_connectors`,
   which emits `connectors.*` codes (`connectors.not_object`, `connectors.ambiguous`,
   `connectors.underspecified`, `connectors.reserved_name`, `connectors.duplicate_connector`,
-  `connectors.duplicate_server`, and others). Authored mapping keys are checked for
+  `connectors.duplicate_server`, `connectors.build_context_escapes`,
+  `connectors.build_no_platforms`, and others). Authored mapping keys are checked for
   duplicates before validation, so a repeated connector name is rejected rather than
   silently replaced by the last YAML value.
+- `connectors.lock.yaml` (ADR-0113,
+  `packages/plugin-format/src/plugin_format/connector_lock.py::ConnectorLockFile`) records what each
+  declared `build` resolved to. It is **generated, not authored**: `curie build` writes it and it is
+  packed into the bundle like any other file, so the platform holds the exact digest a version
+  deployed rather than that fact living in local CLI state. One
+  `packages/plugin-format/src/plugin_format/connector_lock.py::ConnectorLockEntry` per built
+  connector carries `image`, `delivery` (`registry` or `local-daemon`), the `platforms` the build
+  targeted, and `source_digest`. Identity is a digest and only a digest: `image` is
+  `<repo>@sha256:<64 hex>` for `registry` delivery and a bare `sha256:<64 hex>` image ID for
+  `local-daemon`, and a mutable tag is refused, because a tag can be repointed at a different
+  artifact after review. `source_digest` is the content-derived identity of the build INPUT
+  (`packages/plugin-format/src/plugin_format/connector_lock.py::source_digest_of`), hashing the
+  context's files -- each one's bytes plus whether it is executable by its owner, the one mode bit
+  the build context tar carries into the image -- and the declared `build` block together, honoring
+  the context's `.dockerignore`. The generated `connectors.lock.yaml` is excluded so writing the
+  lock cannot invalidate the digest it just recorded, but only when the declared `build.context` is
+  the bundle root (`.` or empty), which is the one place `curie build` writes it. Under a
+  subdirectory context, a `connectors.lock.yaml` at the top of that context is authored input the
+  daemon receives and is hashed like any other file.
+  `packages/plugin-format/src/plugin_format/validate.py::_validate_connector_lock` is where intake
+  refuses: a `build` connector whose declared context is not in the bundle is
+  `connectors.build_context_missing`, one with no lock entry is `connectors.lock_missing`, one whose
+  recomputed
+  source digest no longer matches is `connectors.lock_stale`, an unreadable or unknown-version file
+  is `connectors.lock_unreadable` / `connectors.lock_unsupported_version`, and a lock whose image
+  does not match the delivery it claims is `connectors.lock_invalid`. That last check is delegated to
+  `packages/plugin-format/src/plugin_format/connector_lock.py::apply_lock`, the single place a
+  `build` connector becomes an ordinary `image` one, so a hand-edited lock is refused by the same
+  rule a generated one passes. The recomputation is pure hashing over the extracted tree -- no
+  Docker, no registry, no network -- which is what lets the API run it and stay a pure renderer
+  (ADR-0087). Delivery is deliberately NOT judged here: a `local-daemon` lock is legitimate for a
+  local-tier deploy, and refusing it belongs to the cluster preflight.
 - `deploy.yaml` (ADR-0089, `packages/plugin-format/src/plugin_format/deploy_targets.py::DeployTargetsFile`)
   declares named deploy targets under a `targets` map, each a
   `packages/plugin-format/src/plugin_format/deploy_targets.py::DeployTarget` of
@@ -80,7 +124,7 @@ files**, both optional, both invisible to Claude Code:
   checked for duplicates before validation, so a repeated target name fails closed instead of
   silently selecting the last YAML value.
 
-The two overlay files are not independent of the manifest, which is the part a second consumer is
+The overlay files are not independent of the manifest, which is the part a second consumer is
 most likely to miss: `connectors.yaml` feeds manifest validation. The set of gate names
 `approvalPolicy` may legally use is built from BOTH the bundle's declared MCP servers and its
 `connectors.yaml` connectors, under two different namespacing rules (a plugin-loaded server's live
@@ -192,4 +236,4 @@ error codes).
 - **Guide:** [workflow-agent-conversion.md](./workflow-agent-conversion.md) — converting an existing workflow agent (deterministic pipeline + LLM at the edges) onto a bundle end to end (#275).
 - **Epic(s):** [#30](https://github.com/curie-eng/curie/issues/30) — document the dead `hooks` field and new approval/trigger declarations: each field's meaning, validation contract, and runner consumption
 - **Vision doc:** [architecture-vision.md](../../architecture-vision.md) — the plugin format is the distribution wedge; not one of the six swap-readiness Jobs
-- **ADR(s):** [ADR-0005](../../adr/0005-claude-agent-sdk-adapter-and-frozen-aci.md) — freezes `plugin-format` (with `aci-protocol`) as an interface built first; [ADR-0086](../../adr/0086-bundles-declare-connectors-the-platform-hosts-them.md) (Accepted) — adds `connectors.yaml` to the bundle root; [ADR-0089](../../adr/0089-bundles-declare-their-deploy-targets.md) (Accepted) — adds `deploy.yaml` to the bundle root
+- **ADR(s):** [ADR-0005](../../adr/0005-claude-agent-sdk-adapter-and-frozen-aci.md) — freezes `plugin-format` (with `aci-protocol`) as an interface built first; [ADR-0086](../../adr/0086-bundles-declare-connectors-the-platform-hosts-them.md) (Accepted) — adds `connectors.yaml` to the bundle root; [ADR-0089](../../adr/0089-bundles-declare-their-deploy-targets.md) (Accepted) — adds `deploy.yaml` to the bundle root; [ADR-0113](../../adr/0113-bundles-declare-connector-build-inputs-and-tiers-deliver-pinned-images.md) (Accepted) — adds the `build:` connector form and the generated `connectors.lock.yaml` that pins what it resolved to

--- a/docs/interfaces/connector-host/INTERFACE.md
+++ b/docs/interfaces/connector-host/INTERFACE.md
@@ -92,7 +92,11 @@ The declaration side is frozen in the bundle format: `CONNECTORS_FILE`
 (`packages/plugin-format/src/plugin_format/connectors.py::ConnectorsFile`), a
 mapping of name to `ConnectorSpec`
 (`packages/plugin-format/src/plugin_format/connectors.py::ConnectorSpec`). A spec
-is one of two forms, hosted (`image`) or remote (`url`), and unlike the rest of
+is one of three mutually exclusive forms — hosted by reference (`image`), hosted
+from source (`build`, ADR-0113, a `ConnectorBuild`
+(`packages/plugin-format/src/plugin_format/connectors.py::ConnectorBuild`) naming
+a bundle-relative `context`, its `dockerfile` and the `platforms` to build), or
+remote (`url`) — and unlike the rest of
 that package it forbids unknown keys: `connectors.yaml` is Curie's own file with
 no external producer, so an unrecognised key is a typo rather than a Claude Code
 extension to tolerate. Credentials are declared by **name** in three holder
@@ -110,6 +114,18 @@ the version subresource `read_version_connectors`
 the file and `connector_mcp_entries`
 (`apps/api/src/curie_api/bundles.py::connector_mcp_entries`) deriving the
 `.mcp.json` the sandbox dials.
+
+A `build` spec never reaches `render` unresolved. `read_version_connectors` puts
+the declaration and the bundle's `connectors.lock.yaml` (parsed by
+`read_connector_lock`,
+`apps/api/src/curie_api/bundles.py::read_connector_lock`) through `apply_lock`
+(`packages/plugin-format/src/plugin_format/connector_lock.py::apply_lock`), which
+rewrites every `build` connector into an ordinary `image` one carrying the locked
+digest — so `render`, the MCP entry derivation and `is_hosted` are untouched by
+the new form, and there is exactly one place a mutable tag can be refused.
+`apply_lock` reads a recorded fact and never resolves or builds one, which is what
+keeps the API a pure renderer under ADR-0087, and `render` raises rather than
+emitting a null image if it is ever handed an unresolved `build` spec.
 
 The reconciler is off by default. `WorkerConfig`
 (`apps/worker/src/curie_worker/config.py::WorkerConfig`) reads

--- a/packages/plugin-format/src/plugin_format/connector_lock.py
+++ b/packages/plugin-format/src/plugin_format/connector_lock.py
@@ -1,0 +1,406 @@
+"""``connectors.lock.yaml``: what a declared build resolved to (ADR 0113).
+
+The declaration says where the source is; the lock says which image that source
+produced on this install. It is written by ``curie build``, packed into the
+bundle like any other file, and read back by the bundle validator, the API and
+the CLI -- so the platform holds the exact digest a version deployed, rather
+than that fact living only in local CLI state.
+
+    version: 1
+    connectors:
+      k8s-write:
+        image: ghcr.io/acme-corp/sre-bot-k8s-write-mcp@sha256:<64 hex>
+        delivery: registry            # or: local-daemon, the dev fast path
+        platforms: [linux/amd64, linux/arm64]
+        source_digest: sha256:<64 hex>
+
+``apply_lock`` is the single enforcement point for ADR 0113's "the resolved
+digest is the only identity rendered into a Deployment or used to start the
+local connector": it returns a derived ``ConnectorsFile`` in which every
+``build:`` connector has become an ordinary ``image:`` connector, so ``render``,
+``mcp_entry``, ``is_hosted`` and the worker's reconcile plan all work unchanged
+and there is exactly one place a mutable tag can be refused.
+
+Models and pure functions only. No registry access, no build, no ``docker`` --
+that is what lets the API call this and stay a pure renderer under ADR-0087.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import hashlib
+import json
+import re
+from pathlib import Path
+from typing import Any, Literal, NamedTuple
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from .connectors import ConnectorBuild, ConnectorsFile
+
+# The file this module parses. Defined here, with the parser, for the same
+# reason CONNECTORS_FILE lives beside `validate_connectors`: the CLI writes it,
+# the packer must not exclude it, the validator reads it and the API reads it
+# again, and four hand-typed copies of a filename is how one of them ends up
+# plural.
+CONNECTOR_LOCK_FILE = "connectors.lock.yaml"
+
+# The only shape this reader understands. Refusing an unknown version is what
+# lets a future shape change be rejected by an older reader instead of silently
+# misread.
+LOCK_VERSION = 1
+
+# An image reference is well formed in exactly two shapes and nothing else:
+# `<repo>@sha256:<64 lowercase hex>`, the OCI content-addressable manifest
+# digest a registry pull resolves
+# (https://github.com/opencontainers/distribution-spec/blob/main/spec.md#pulling-manifests),
+# and a bare `sha256:<64 lowercase hex>`, the image ID `docker image inspect
+# --format {{.Id}}` reports for a locally built image. A tag is refused because
+# it can be repointed at a different artifact after review and between tier
+# runs, which is the failure this platform has already hit.
+_HEX = "[0-9a-f]{64}"
+
+
+class ConnectorLockEntry(BaseModel):
+    """The resolved identity of one built connector.
+
+    Strict for the same reason ``ConnectorSpec`` is: this is Curie's own file
+    with no external producer, so an unrecognised key is a mistake, and a
+    plausible one -- an operator who writes `digest:` beside `image:` believes
+    they pinned something they did not.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    # `<repo>@sha256:...` for registry delivery, bare `sha256:...` for
+    # local-daemon. Checked in `apply_lock`, not here, so a malformed reference
+    # is refused at the one place an image reaches a Deployment.
+    image: str
+    # Control-bearing: it decides whether the cluster preflight refuses, so an
+    # unmodelled value is rejected loudly rather than degraded to a default
+    # (the rule ADR-0036 sets for control-bearing enums).
+    delivery: Literal["registry", "local-daemon"]
+    # What the build targeted, recorded so an operator reading the lock can see
+    # whether the artifact covers the nodes they are deploying to.
+    platforms: list[str]
+    # The content-derived identity of the build INPUT (see `source_digest_of`).
+    # Bundle intake recomputes it and refuses a lock that no longer matches.
+    source_digest: str
+
+
+class ConnectorLockFile(BaseModel):
+    """The parsed ``connectors.lock.yaml``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    version: int
+    connectors: dict[str, ConnectorLockEntry] = Field(default_factory=dict)
+
+
+def validate_connector_lock(data: Any) -> tuple[ConnectorLockFile | None, list[tuple[str, str]]]:
+    """Validate parsed ``connectors.lock.yaml`` content.
+
+    Returns ``(parsed, errors)`` in the same shape ``validate_connectors`` uses,
+    so a malformed lock is rejected at bundle intake rather than stored and hit
+    at render time, where the failure is an opaque parse error inside the API on
+    a version that already looks deployed.
+    """
+
+    errors: list[tuple[str, str]] = []
+    if not isinstance(data, dict):
+        return None, [
+            (
+                "connectors.lock_invalid",
+                f"{CONNECTOR_LOCK_FILE} must be a mapping with `version` and `connectors`",
+            )
+        ]
+
+    try:
+        parsed = ConnectorLockFile.model_validate(data)
+    except Exception as exc:  # pydantic ValidationError -- surface it verbatim
+        return None, [("connectors.lock_invalid", f"{CONNECTOR_LOCK_FILE}: {str(exc)[:400]}")]
+
+    if parsed.version != LOCK_VERSION:
+        errors.append(
+            (
+                "connectors.lock_unsupported_version",
+                f"{CONNECTOR_LOCK_FILE}: version {parsed.version} is not a shape this build "
+                f"understands (expected {LOCK_VERSION}). Rebuild the lock with `curie build "
+                "--plugin-dir <dir>` rather than reading it with the wrong rules",
+            )
+        )
+
+    return (parsed if not errors else None), errors
+
+
+def _image_matches_delivery(entry: ConnectorLockEntry) -> bool:
+    """Does the recorded reference match the delivery it claims?
+
+    Delivery and image shape must agree or the two fields are decoration: a bare
+    image ID carries no repository, so nothing can pull it, and a repository
+    reference means nothing to the local daemon.
+    """
+
+    if entry.delivery == "registry":
+        return bool(re.fullmatch(rf"[^@\s]+@sha256:{_HEX}", entry.image))
+    return bool(re.fullmatch(rf"sha256:{_HEX}", entry.image))
+
+
+def apply_lock(
+    connectors: ConnectorsFile, lock: ConnectorLockFile | None, *, portable: bool
+) -> ConnectorsFile:
+    """Resolve every ``build:`` connector to its locked digest.
+
+    ``portable`` is keyword-only because two callers pass different values and
+    the wrong one silently deploys an unpullable image to a cluster: the
+    Kubernetes manifest route passes ``True``, because every consumer of that
+    route applies its result to a cluster. Intake validation passes ``False``,
+    because a local-tier version is a legitimate stored artifact until
+    something asks to apply it.
+
+    Raises ``ValueError`` rather than returning errors: every condition here
+    means the caller is about to render an object that cannot start, so there is
+    no partial answer worth returning.
+    """
+
+    resolved: dict[str, Any] = {}
+    entries = lock.connectors if lock is not None else {}
+    for name, spec in connectors.connectors.items():
+        if spec.build is None:
+            # An `image:` or `url:` connector is carried through byte-identical.
+            # Every bundle in the wild is one of these, and `apply_lock` runs on
+            # every version the API renders.
+            resolved[name] = spec
+            continue
+        entry = entries.get(name)
+        if entry is None:
+            raise ValueError(
+                f"connector {name!r} declares `build:` but {CONNECTOR_LOCK_FILE} has no entry "
+                "for it. Run `curie build --plugin-dir <dir>` to build it and record what it "
+                "resolved to."
+            )
+        if not _image_matches_delivery(entry):
+            raise ValueError(
+                f"connector {name!r}: {CONNECTOR_LOCK_FILE} records image {entry.image!r} for "
+                f"delivery {entry.delivery!r}, which is not a digest of that delivery's shape. "
+                "A mutable tag is never rendered into a Deployment: it can be repointed at a "
+                "different artifact after review."
+            )
+        if portable and entry.delivery == "local-daemon":
+            raise ValueError(
+                f"connector {name!r}: {CONNECTOR_LOCK_FILE} records a local-daemon image, which "
+                "names nothing a Kubernetes node can pull -- applying it yields "
+                "ImagePullBackOff on every node, long after the deploy reported success. "
+                "Rebuild with `curie build --plugin-dir <dir> --registry <ref>`."
+            )
+        resolved[name] = spec.model_copy(update={"image": entry.image, "build": None})
+    return ConnectorsFile(connectors=resolved)
+
+
+# --------------------------------------------------------------------------- #
+# source_digest: the content-derived identity of a build INPUT
+#
+# The full algorithm, and why each rule exists, is stated in
+# tests/vectors/connector-source-digest.json, which freezes it against a corpus
+# both this function and the Rust port in cli/src/connector_build.rs are read
+# against. It lives here rather than in the CLI so the validator that refuses a
+# stale lock and the builder that writes one cannot compute two different values.
+#
+# The `.dockerignore` half is ORDERED, Docker's own semantics: the LAST rule
+# that matches decides, and a `!` rule re-includes. The first version of this
+# function returned on the first matching exclusion and had no `!` at all, which
+# broke the one property the digest exists to have -- it changes exactly when
+# the bytes Docker builds from change -- in both directions: `*.log` plus
+# `!keep.log` shipped keep.log to the daemon while hashing nothing of it (a
+# stale lock passing review), and `*` alone emptied the digest entirely, so the
+# lock could never go stale. That is a change to a frozen cross-language
+# algorithm, taken because the old one contradicted its own specification and no
+# stored digest depends on it (a lock is regenerated by the next `curie build`).
+# --------------------------------------------------------------------------- #
+class _IgnoreRule(NamedTuple):
+    """One `.dockerignore` line: the pattern, and whether it re-includes."""
+
+    negated: bool
+    pattern: str
+
+
+def _dockerignore_rules(context: Path, dockerfile: str) -> list[_IgnoreRule]:
+    """The context's own exclusion set, in file order, or an empty one.
+
+    Docker's file, so honoring it means the digest covers exactly what the
+    daemon receives. ``.curieignore`` governs bundle packing, which is a
+    different question, and is deliberately not consulted.
+
+    Order is preserved because it is load-bearing: ``*`` followed by
+    ``!Dockerfile`` and ``!Dockerfile`` followed by ``*`` are different
+    exclusion sets, and the last matching rule is the one that decides.
+
+    The two trailing rules mirror the docker CLI's own
+    ``TrimBuildFilesFromExcludes``: the daemon always receives the Dockerfile
+    and ``.dockerignore`` even when the patterns exclude them, so a digest that
+    dropped them would not move when the file that decides what is built is
+    edited.
+    """
+
+    path = context / ".dockerignore"
+    if not path.is_file():
+        return []
+    rules: list[_IgnoreRule] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if stripped.startswith("!"):
+            # The `!` is removed and the remainder used verbatim, as Docker
+            # does; a bare `!` names nothing and is skipped rather than being
+            # read as a re-include of everything.
+            remainder = stripped[1:]
+            if remainder:
+                rules.append(_IgnoreRule(True, remainder))
+            continue
+        rules.append(_IgnoreRule(False, stripped))
+    for build_file in (".dockerignore", dockerfile):
+        if _is_excluded(rules, build_file):
+            rules.append(_IgnoreRule(True, build_file))
+    return rules
+
+
+def _matches(pattern: str, candidates: list[str]) -> bool:
+    """Go ``filepath.Match`` semantics, the matcher Docker's own client uses.
+
+    Matched segment by segment against the path and each of its ancestor
+    directory paths, so ``*`` and ``?`` never cross a ``/`` and a pattern naming
+    a directory excludes everything beneath it.
+    """
+
+    parts = pattern.split("/")
+    for candidate in candidates:
+        against = candidate.split("/")
+        if len(parts) != len(against):
+            continue
+        if all(fnmatch.fnmatchcase(b, a) for a, b in zip(parts, against, strict=True)):
+            return True
+    return False
+
+
+def _is_excluded(rules: list[_IgnoreRule], relative: str) -> bool:
+    """Is this path excluded once every rule has had its say, in file order?
+
+    Docker's rule, not "the first exclusion wins": every rule is evaluated and
+    the last one that matches decides, so a later ``!`` re-includes what an
+    earlier pattern excluded and a later pattern excludes what an earlier ``!``
+    re-included.
+    """
+
+    segments = relative.split("/")
+    candidates = ["/".join(segments[: i + 1]) for i in range(len(segments))]
+    excluded = False
+    for rule in rules:
+        if _matches(rule.pattern, candidates):
+            excluded = not rule.negated
+    return excluded
+
+
+def resolve_context(bundle_root: Path, context: str) -> Path:
+    """The canonical build context, required to sit inside the bundle.
+
+    The Python twin of ``cli/src/connector_build.rs``'s ``resolve_context``, and
+    it must stay its twin: whatever bytes this returns are the bytes
+    ``source_digest_of`` hashes, so a resolver that admits a directory the CLI
+    refuses lets an author steer the digest with content the bundle does not
+    contain -- and one that refuses a directory the CLI admits reports every such
+    bundle as unbuildable at intake.
+
+    ``connectors._escapes`` is the textual half and already refuses an absolute,
+    empty or ``..``-climbing declaration; only the filesystem can see the rest.
+    A symlinked context is REFUSED rather than dereferenced (the rule
+    ``cli/src/bundle.rs``'s packer applies, for the same reason), and the
+    resolved path must still be inside the resolved bundle root, so a chain of
+    links cannot walk out of it. Files INSIDE the context are handled the same
+    way by both walks: a symlink is never followed and never hashed.
+
+    Raises ``ValueError`` so the caller can turn it into one validator error
+    rather than deciding what a half-resolved path means.
+    """
+
+    root = Path(bundle_root).resolve()
+    candidate = root / context
+    if candidate.is_symlink():
+        raise ValueError(
+            f"`build.context` is {context!r}, which is a symlink. Curie refuses to follow one "
+            "rather than hash and build whatever it points at, which may be nothing this bundle "
+            "contains."
+        )
+    resolved = candidate.resolve()
+    if resolved != root and root not in resolved.parents:
+        raise ValueError(
+            f"`build.context` is {context!r}, which resolves to {resolved} -- outside the bundle. "
+            "The build input must be content the bundle carries, or the digest pins bytes no "
+            "reviewer of this bundle ever saw."
+        )
+    return resolved
+
+
+def source_digest_of(context_dir: Path, build: ConnectorBuild) -> str:
+    """Hash a build context and its declaration into one stable identity.
+
+    Content only: no mtime, uid or gid, deliberately unlike
+    ``cli/src/bundle.rs``'s archive digest, which embeds all three because it
+    identifies an ARCHIVE and not a source tree. Reusing that computation here
+    would report every fresh checkout as a changed source.
+
+    Content and ONE bit of mode: whether the file is executable by its owner.
+    Docker's build context tar carries each file's mode and BuildKit keys its
+    cache on it, so flipping the exec bit on an entrypoint changes the build
+    input; a digest blind to it leaves the lock looking fresh while a stale image
+    deploys.
+
+    The declared ``build:`` block is hashed alongside the files, so editing
+    ``platforms`` or ``dockerfile`` alone still invalidates the lock. The
+    generated ``connectors.lock.yaml`` is excluded so that writing the lock does
+    not invalidate the digest it records -- but ONLY when the declared context is
+    the bundle root, which is the one place `curie build` writes it. Under a
+    subdirectory context a file of that name is authored input the daemon
+    receives like any other, and so is a file of that name nested deeper under
+    any context.
+    """
+
+    root = Path(context_dir)
+    rules = _dockerignore_rules(root, build.dockerfile)
+    # Decided from the DECLARATION, not the tree: `curie build` writes the
+    # generated lock at the bundle root only, so it is this context's own
+    # generated file exactly when the declared context names that root.
+    exclude_lock = build.context.rstrip("/") in {".", ""}
+    included: list[str] = []
+    for path in root.rglob("*"):
+        if not path.is_file() or path.is_symlink():
+            continue
+        relative = path.relative_to(root).as_posix()
+        if exclude_lock and relative == CONNECTOR_LOCK_FILE:
+            continue
+        if _is_excluded(rules, relative):
+            continue
+        included.append(relative)
+
+    stream = bytearray()
+    for relative in sorted(included, key=lambda r: r.encode("utf-8")):
+        path = root / relative
+        content = hashlib.sha256(path.read_bytes()).hexdigest()
+        executable = b"1" if path.stat().st_mode & 0o100 else b"0"
+        stream += (
+            relative.encode("utf-8") + b"\0" + content.encode("ascii") + b"\0" + executable + b"\n"
+        )
+    canonical = json.dumps(
+        {
+            "context": build.context,
+            "dockerfile": build.dockerfile,
+            # Declared order, not sorted: a lane that sorts platforms and one
+            # that does not would silently compute two digests for one build.
+            "platforms": list(build.platforms),
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    )
+    stream += b"build\0" + canonical.encode("utf-8") + b"\n"
+    return "sha256:" + hashlib.sha256(bytes(stream)).hexdigest()

--- a/packages/plugin-format/src/plugin_format/connector_render.py
+++ b/packages/plugin-format/src/plugin_format/connector_render.py
@@ -420,10 +420,23 @@ def render(
     no pod: every connector tool call dies as a bare connection timeout with no
     policy error anywhere. A positional call site cannot express that mistake
     here because there is no positional call site.
+
+    A `build:` connector whose lock has not been applied raises instead of
+    rendering (ADR 0113). The alternative is `render_deployment` emitting
+    `"image": None`, which applies as an invalid Deployment and surfaces as an
+    opaque Kubernetes error a long way from its cause. `connector_lock.apply_lock`
+    is what resolves it, so the message names the artifact that is missing.
     """
 
     if not spec.is_hosted:
         return []
+    if spec.image is None:
+        raise ValueError(
+            f"connector {connector!r} declares `build:` and has no resolved image. "
+            "Its digest lives in connectors.lock.yaml, which `curie build "
+            "--plugin-dir <dir>` writes, and connector_lock.apply_lock applies "
+            "before anything renders."
+        )
     return [
         render_service(release, agent, connector, spec),
         render_deployment(release, agent, namespace, connector, spec, secret_name),

--- a/packages/plugin-format/src/plugin_format/connectors.py
+++ b/packages/plugin-format/src/plugin_format/connectors.py
@@ -7,7 +7,7 @@ and a NetworkPolicy -- roughly 180 lines of Kubernetes to stand up one server,
 per bundle, each copy independently right or wrong.
 
 ``connectors.yaml`` closes that. A bundle declares intent; the platform derives
-the objects. Two forms:
+the objects. Three forms:
 
     connectors:
       grafana:                                  # hosted: Curie runs the image
@@ -16,9 +16,19 @@ the objects. Two forms:
         env: {GRAFANA_URL: "https://grafana.example.com"}
         secrets: [GRAFANA_SERVICE_ACCOUNT_TOKEN]
 
+      k8s-write:                                # hosted: Curie BUILDS the image
+        build:
+          context: connectors/k8s-write
+          platforms: [linux/amd64, linux/arm64]
+        secret_files: {K8S_WRITE_KUBECONFIG: /secrets/kubeconfig}
+
       internal:                                 # remote: already running
         url: https://mcp.internal/mcp
         secrets: [INTERNAL_TOKEN]
+
+The ``build`` form (ADR 0113) replaces only where the image comes FROM. Every
+other field keeps its exact meaning, and the resolved digest lives in
+``connectors.lock.yaml``, never here -- see ``connector_lock``.
 
 Secrets are NAMES only. Values arrive at deploy time through the existing
 mechanism (ADR-0009), so this introduces no new way to carry a credential and
@@ -28,6 +38,7 @@ a bundle stays safe to commit.
 from __future__ import annotations
 
 import re
+from pathlib import PurePosixPath
 from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -65,8 +76,38 @@ class SecretRef(BaseModel):
         return self.key or self.name
 
 
+class ConnectorBuild(BaseModel):
+    """Where a connector's image comes FROM, when the bundle carries its source.
+
+    ADR 0113: an operator should not have to build an image, put it somewhere
+    pullable, and paste a reference back into the bundle by hand. The bundle
+    declares the build input -- which is what a reviewer can actually read in a
+    source change -- and `curie build` records what it resolved to in
+    ``connectors.lock.yaml``. The digest never appears here.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    # Bundle-relative by construction. ADR 0113 requires the context be
+    # constrained to the extracted bundle "without accepting arbitrary host
+    # paths", so an absolute path or one that normalizes out of the bundle root
+    # is refused by `validate_connectors` rather than resolved.
+    context: str
+    # Relative to the context, defaulted because the common case omits it. A
+    # reader that left this empty would build whatever the daemon's own default
+    # happens to be, which is a different file in a different place.
+    dockerfile: str = "Dockerfile"
+    # Required rather than defaulted. A silently single-arch build passes every
+    # declaration check and then fails after apply as "no matching manifest for
+    # linux/arm64" -- the exact failure
+    # `examples/sre-bot/connectors/k8s-write/Dockerfile:1-5` documents -- and a
+    # default would pick an architecture on the author's behalf without saying
+    # so.
+    platforms: list[str]
+
+
 class ConnectorSpec(BaseModel):
-    """One declared connector. Exactly one of ``image`` or ``url``.
+    """One declared connector. Exactly one of ``image``, ``build`` or ``url``.
 
     Strict, unlike the rest of this package. The leniency mandate exists because
     real Claude Code plugin bundles carry keys this MVP does not model, and
@@ -80,6 +121,11 @@ class ConnectorSpec(BaseModel):
 
     # -- hosted form --
     image: str | None = None
+    # The same hosted form, sourced rather than referenced (ADR 0113). Mutually
+    # exclusive with `image`: two image sources on one connector means whichever
+    # the reader picks silently ignores the other, and the ignored one is the
+    # one the author edited last.
+    build: ConnectorBuild | None = None
     args: list[str] = Field(default_factory=list)
     env: dict[str, str] = Field(default_factory=dict)
     port: int = 8000
@@ -197,7 +243,11 @@ class ConnectorSpec(BaseModel):
 
     @property
     def is_hosted(self) -> bool:
-        return self.image is not None
+        # Hosted-ness is about WHO RUNS THE PROCESS, not about whether the image
+        # reference has been resolved yet. A `build:` connector with no lock
+        # applied is hosted and unrenderable, which `connector_render.render`
+        # refuses explicitly rather than emitting `image: null`.
+        return self.image is not None or self.build is not None
 
 
 class ConnectorsFile(BaseModel):
@@ -262,6 +312,87 @@ def _is_valid_name(name: str) -> bool:
     return len(name) <= _NAME_MAX and bool(_NAME_RE.fullmatch(name))
 
 
+# An OCI platform string: `os/arch`, optionally `os/arch/variant` (`linux/arm/v7`
+# is a real target, so rejecting the third segment would be a false positive that
+# blocks a legitimate build). A typo like `linux/amd_64` otherwise reaches buildx
+# verbatim and fails there with a message about the daemon rather than the bundle.
+_PLATFORM_RE = re.compile(r"[a-z0-9]+/[a-z0-9]+(/v[0-9]+)?")
+
+
+def _escapes(path: str) -> bool:
+    """Is this bundle-relative path absolute, empty, or outside the bundle root?
+
+    Textual, because this validator sees a declaration and not always a tree:
+    the CLI's ``resolve_context`` / ``resolve_dockerfile`` canonicalize on top of
+    this and additionally refuse a symlink, which no amount of string inspection
+    can see.
+    """
+
+    if not path.strip():
+        return True
+    parts = PurePosixPath(path).parts
+    if PurePosixPath(path).is_absolute():
+        return True
+    depth = 0
+    for part in parts:
+        if part == "..":
+            depth -= 1
+            if depth < 0:
+                return True
+        elif part != ".":
+            depth += 1
+    return False
+
+
+def _validate_build(
+    where: str, build: ConnectorBuild, errors: list[tuple[str, str]]
+) -> None:
+    """The `build:` form's own rules (ADR 0113).
+
+    Each condition carries its own code so a caller can assert the exact outcome
+    rather than "something was wrong", and all of them accumulate like every
+    other check here, so an author sees the whole file in one pass.
+    """
+
+    if _escapes(build.context):
+        errors.append(
+            (
+                "connectors.build_context_escapes",
+                f"{where}: `build.context` is {build.context!r}; it must be a path inside "
+                "the bundle. An absolute path makes the operator's own machine the build "
+                "context, and an empty one normalizes to the bundle root on one reader "
+                "and to the process working directory on another",
+            )
+        )
+    if _escapes(build.dockerfile):
+        errors.append(
+            (
+                "connectors.build_dockerfile_escapes",
+                f"{where}: `build.dockerfile` is {build.dockerfile!r}; it must be a path "
+                "inside the build context. The CLI reads this file before the bundle is "
+                "packed, which is before every other guard in the pipeline",
+            )
+        )
+    if not build.platforms:
+        errors.append(
+            (
+                "connectors.build_no_platforms",
+                f"{where}: `build.platforms` is empty. A silently single-arch build passes "
+                "every declaration check and then fails after apply as `no matching "
+                "manifest for linux/arm64`, so the target set is stated, never guessed",
+            )
+        )
+    for platform in build.platforms:
+        if not _PLATFORM_RE.fullmatch(platform):
+            errors.append(
+                (
+                    "connectors.build_bad_platform",
+                    f"{where}: `{platform}` is not an OCI platform. Use `os/arch` or "
+                    "`os/arch/variant`, such as `linux/amd64` or `linux/arm/v7`",
+                )
+            )
+
+
 def validate_connectors(data: Any) -> tuple[ConnectorsFile | None, list[tuple[str, str]]]:
     """Validate parsed ``connectors.yaml`` content.
 
@@ -304,22 +435,28 @@ def validate_connectors(data: Any) -> tuple[ConnectorsFile | None, list[tuple[st
                     f"the agent would lose {lost} -- rename the connector",
                 )
             )
-        if spec.image and spec.url:
+        forms = [bool(spec.image), bool(spec.build), bool(spec.url)]
+        if sum(forms) > 1:
             errors.append(
                 (
                     "connectors.ambiguous",
-                    f"{where}: set either `image` (Curie runs it) or `url` (already "
-                    "running), not both -- otherwise it is unclear who owns the process",
+                    f"{where}: set exactly one of `image` (Curie runs it), `build` (Curie "
+                    "builds it, then runs it) or `url` (already running) -- otherwise it "
+                    "is unclear who owns the process, and which image source wins is "
+                    "decided by whichever reader looks first",
                 )
             )
-        if not spec.image and not spec.url:
+        if not any(forms):
             errors.append(
                 (
                     "connectors.underspecified",
-                    f"{where}: set `image` for Curie to run it, or `url` to point at "
-                    "something already running",
+                    f"{where}: set `image` for Curie to run it, `build` for Curie to build "
+                    "it from source in this bundle, or `url` to point at something already "
+                    "running",
                 )
             )
+        if spec.build is not None:
+            _validate_build(where, spec.build, errors)
         if spec.url and (spec.args or spec.env):
             errors.append(
                 (
@@ -389,7 +526,7 @@ def validate_connectors(data: Any) -> tuple[ConnectorsFile | None, list[tuple[st
                     "the places it can leak from for no benefit",
                 )
             )
-        if spec.image and spec.headers:
+        if spec.is_hosted and spec.headers:
             errors.append(
                 (
                     "connectors.hosted_has_headers",

--- a/packages/plugin-format/src/plugin_format/validate.py
+++ b/packages/plugin-format/src/plugin_format/validate.py
@@ -13,12 +13,20 @@ from typing import Any
 import yaml
 from pydantic import BaseModel, TypeAdapter, ValidationError
 
+from . import connector_lock
 from .approval_policy import (
     connector_server_names,
     connector_tool_prefix,
     declared_mcp_server_names,
     effective_tool_prefix,
     grantable_routes,
+)
+from .connector_lock import (
+    CONNECTOR_LOCK_FILE,
+    ConnectorLockFile,
+    resolve_context,
+    source_digest_of,
+    validate_connector_lock,
 )
 from .connectors import CONNECTORS_FILE, ConnectorsFile, validate_connectors
 from .deploy_targets import validate_deploy_targets
@@ -91,6 +99,7 @@ def validate_bundle(path: str | Path) -> ValidationResult:
         _validate_secrets(manifest, c)
         _validate_scripts(root, c)
         _validate_connectors(root, c)
+        _validate_connector_lock(root, c)
         _validate_deploy_targets(root, c)
 
     return c.result()
@@ -156,6 +165,132 @@ def _validate_connectors(root: Path, c: _Collector) -> None:
         c.error(code, message, CONNECTORS_FILE)
     if parsed is not None:
         _reject_connector_name_collisions(root, parsed, c)
+
+
+def _read_connectors(root: Path) -> ConnectorsFile | None:
+    """The bundle's parsed ``connectors.yaml``, or None when it is absent or bad.
+
+    ``_validate_connectors`` has already reported whatever made it bad, so the
+    lock arm stays silent about a declaration it cannot trust rather than
+    reporting a second, confusing error about the same file.
+    """
+
+    path = root / CONNECTORS_FILE
+    if not path.is_file():
+        return None
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError):
+        return None
+    parsed, errors = validate_connectors(data)
+    return None if errors else parsed
+
+
+def _validate_connector_lock(root: Path, c: _Collector) -> None:
+    """Validate ``connectors.lock.yaml`` and the bundle's builds against it (ADR 0113).
+
+    ``validate_bundle`` is the ONE gate a bundle passes through whatever entry
+    point it arrives by -- the CLI upload, the console's create-agent modal, and
+    the git push path all route through it -- so these rules live here and cover
+    all three with one implementation.
+
+    Delivery is deliberately NOT checked. ``curie local deploy`` legitimately
+    uploads a bundle carrying a ``local-daemon`` lock; the registry-only rule
+    belongs to the cluster deploy preflight, the only path that needs an
+    artifact a Kubernetes node can pull.
+    """
+
+    lock: ConnectorLockFile | None = None
+    path = root / CONNECTOR_LOCK_FILE
+    if path.is_file():
+        try:
+            data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        except (OSError, yaml.YAMLError) as exc:
+            c.error(
+                "connectors.lock_unreadable",
+                f"{CONNECTOR_LOCK_FILE}: {exc}",
+                CONNECTOR_LOCK_FILE,
+            )
+            return
+        lock, errors = validate_connector_lock(data)
+        for code, message in errors:
+            c.error(code, message, CONNECTOR_LOCK_FILE)
+        if lock is None:
+            return
+
+    declared = _read_connectors(root)
+    if declared is None:
+        return
+
+    complete = True
+    for name, spec in sorted(declared.connectors.items()):
+        if spec.build is None:
+            continue
+        try:
+            # Resolved, not merely joined: `source_digest_of` hashes whatever
+            # tree this names, so a symlinked context would let a bundle pin
+            # bytes it does not contain -- and the CLI (`resolve_context` in
+            # cli/src/connector_build.rs) already refuses that before it builds.
+            # Intake accepting what the builder refuses is the seam this closes.
+            context = resolve_context(root, spec.build.context)
+        except ValueError as exc:
+            complete = False
+            c.error(
+                "connectors.build_context_escapes",
+                f"connectors.{name}: {exc}",
+                CONNECTORS_FILE,
+            )
+            continue
+        if not context.is_dir():
+            # Refused here rather than skipped: a bundle whose declared build
+            # input is not in it can never be built, and letting it through
+            # means the version is created, the deployment goes active, and the
+            # failure surfaces at render time far from its cause.
+            complete = False
+            c.error(
+                "connectors.build_context_missing",
+                f"connectors.{name}: `build.context` is {spec.build.context!r}, which this "
+                "bundle does not contain, so there is nothing to build or to hash. Add the "
+                "build context to the bundle or correct the path.",
+                CONNECTORS_FILE,
+            )
+            continue
+        entry = lock.connectors.get(name) if lock is not None else None
+        if entry is None:
+            complete = False
+            c.error(
+                "connectors.lock_missing",
+                f"connectors.{name}: declares `build:` but {CONNECTOR_LOCK_FILE} has no entry "
+                "for it, so nothing pins what would be deployed. Run `curie build --plugin-dir "
+                "<dir>` and commit the lock it writes.",
+                CONNECTOR_LOCK_FILE,
+            )
+            continue
+        # Pure hashing over the already-extracted tree: no docker, no registry,
+        # no network, so the API stays a pure renderer under ADR-0087. Without
+        # it a git push after a source or `platforms` edit activates the
+        # PREVIOUS digest and the deployed connector silently stops matching the
+        # reviewed source.
+        if source_digest_of(context, spec.build) != entry.source_digest:
+            complete = False
+            c.error(
+                "connectors.lock_stale",
+                f"connectors.{name}: {CONNECTOR_LOCK_FILE} records a source digest that no "
+                "longer matches this bundle's build input, so the recorded image was built "
+                "from something else. Rebuild it with `curie build --plugin-dir <dir>`.",
+                CONNECTOR_LOCK_FILE,
+            )
+
+    if complete and lock is not None:
+        # The last rule the model cannot express: an image that is not a digest
+        # of its delivery's shape. `apply_lock` owns that refusal, so intake
+        # asks it rather than carrying a second copy -- a hand-edited lock
+        # reaches here exactly as a generated one does, and a version whose
+        # connector can never render must not be stored.
+        try:
+            connector_lock.apply_lock(declared, lock, portable=False)
+        except ValueError as exc:
+            c.error("connectors.lock_invalid", f"{CONNECTOR_LOCK_FILE}: {exc}", CONNECTOR_LOCK_FILE)
 
 
 def _reject_connector_name_collisions(root: Path, parsed: ConnectorsFile, c: _Collector) -> None:

--- a/packages/plugin-format/tests/test_approval_policy.py
+++ b/packages/plugin-format/tests/test_approval_policy.py
@@ -10,7 +10,10 @@ mirroring ``load_approval_policy``'s normalization so a config that validates
 green at deploy resolves identically at runtime (#453).
 """
 
-from plugin_format import ApprovalGate, grantable_routes
+import json
+from pathlib import Path
+
+from plugin_format import ApprovalGate, grantable_routes, validate_bundle
 
 
 def _gate(gate: str, route: str, grantable: bool = False) -> ApprovalGate:
@@ -97,3 +100,102 @@ def test_route_matching_is_case_sensitive() -> None:
     )
     assert routes == {"Deal-Desk": "close_issue", "deal-desk": "escalate"}
     assert ambiguous == set()
+
+
+# --------------------------------------------------------------------------- #
+# A gate may only name a connector the bundle declares -- #1495, and #1691's
+# constraint that it must keep holding once a third connector form exists
+# --------------------------------------------------------------------------- #
+def _gated_bundle(root: Path, connectors_yaml: str, gate: str) -> Path:
+    (root / ".claude-plugin").mkdir(parents=True, exist_ok=True)
+    (root / ".claude-plugin" / "plugin.json").write_text(
+        json.dumps(
+            {
+                "name": "acme-bot",
+                "version": "0.1.0",
+                "description": "t",
+                "approvalPolicy": {"gates": [{"gate": gate, "route": "acme-oncall"}]},
+            }
+        ),
+        encoding="utf-8",
+    )
+    (root / "skills" / "acme-bot").mkdir(parents=True, exist_ok=True)
+    (root / "skills" / "acme-bot" / "SKILL.md").write_text(
+        "---\nname: acme-bot\ndescription: t\n---\nhi\n", encoding="utf-8"
+    )
+    (root / "connectors.yaml").write_text(connectors_yaml, encoding="utf-8")
+    _materialize_build_inputs(root)
+    return root
+
+
+BUILD_ONLY = (
+    "connectors:\n"
+    "  k8s-write:\n"
+    "    build:\n"
+    "      context: connectors/k8s-write\n"
+    "      platforms: [linux/amd64, linux/arm64]\n"
+)
+
+# A bare `sha256:` plus 64 lowercase hex is the local image id
+# `docker image inspect --format {{.Id}}` reports, which is the form a
+# `delivery: local-daemon` lock records. Placeholder hex, not a real digest.
+_LOCAL_IMAGE = "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+
+
+def _materialize_build_inputs(root: Path) -> None:
+    """Make the declared build context real and lock it.
+
+    A `build:` declaration names a directory inside the bundle and a lock that
+    pins what it resolved to; a fixture that ships neither is not a bundle
+    intake would ever accept, so a gate test written against one would be
+    asserting about a shape that cannot exist. These two tests are about the
+    APPROVAL GATE, so the bundle around the gate has to be otherwise valid or a
+    failure here says nothing about the gate.
+    """
+
+    from plugin_format import connector_lock
+    from plugin_format.connectors import ConnectorBuild
+
+    context = root / "connectors" / "k8s-write"
+    context.mkdir(parents=True, exist_ok=True)
+    (context / "Dockerfile").write_text(
+        "FROM scratch\nCOPY server.py /server.py\n", encoding="utf-8"
+    )
+    (context / "server.py").write_text("print('acme')\n", encoding="utf-8")
+
+    build = ConnectorBuild.model_validate(
+        {"context": "connectors/k8s-write", "platforms": ["linux/amd64", "linux/arm64"]}
+    )
+    (root / connector_lock.CONNECTOR_LOCK_FILE).write_text(
+        "version: 1\n"
+        "connectors:\n"
+        "  k8s-write:\n"
+        f"    image: {_LOCAL_IMAGE}\n"
+        "    delivery: local-daemon\n"
+        "    platforms: [linux/amd64, linux/arm64]\n"
+        f"    source_digest: {connector_lock.source_digest_of(context, build)}\n",
+        encoding="utf-8",
+    )
+
+
+def test_a_gate_naming_a_build_only_connector_validates(tmp_path: Path) -> None:
+    # The accepted tool-name prefix set is derived from the DECLARED connector
+    # names, and a bundle whose whole tool surface is source-built has only
+    # build: forms. If the derivation ever narrows to connectors carrying an
+    # `image:`, every gate such a bundle could write is rejected and no
+    # connector tool can be gated at all -- which is #1691's write connector,
+    # ungatable, so the example could not ship its security shape.
+    root = _gated_bundle(tmp_path, BUILD_ONLY, "mcp__k8s-write__resources_create_or_update")
+    result = validate_bundle(str(root))
+    assert result.valid, [e.code for e in result.errors]
+
+
+def test_a_gate_naming_an_undeclared_connector_still_fails(tmp_path: Path) -> None:
+    # The other half, and the one that makes the test above mean something: a
+    # derivation that accepted every prefix would pass the positive case
+    # vacuously. A typo'd connector name arms a literal the runtime never
+    # produces, so the gate validates green and silently never fires (#453).
+    root = _gated_bundle(tmp_path, BUILD_ONLY, "mcp__k8s-write-typo__resources_create_or_update")
+    result = validate_bundle(str(root))
+    assert not result.valid
+    assert "approval_policy.gate_not_namespaced" in {e.code for e in result.errors}

--- a/packages/plugin-format/tests/test_connector_lock.py
+++ b/packages/plugin-format/tests/test_connector_lock.py
@@ -1,0 +1,488 @@
+"""``connectors.lock.yaml``: resolving a declared build to one pinned image (ADR 0113).
+
+``apply_lock`` is the single enforcement point for the ADR's "the resolved
+digest is the only identity rendered into a Deployment or used to start the
+local connector". It takes the declaration and the lock and returns a derived
+``ConnectorsFile`` in which every ``build:`` connector has become an ordinary
+``image:`` connector, so ``render``, ``mcp_entry``, ``is_hosted``, and the
+worker's reconcile plan all work unchanged downstream and there is exactly one
+place a mutable tag can be refused.
+
+Every case here asserts through that function or through ``validate_bundle``,
+never against a model's fields: a lock whose entry parses and is then ignored
+is the failure this file exists to catch.
+
+The corpus lives in ``tests/vectors/connector-lock.json`` and
+``tests/vectors/connector-source-digest.json`` because the Rust CLI reads the
+same bytes -- it writes the lock and preflights it before the platform ever sees
+the bundle, and the two lanes cannot share code.
+
+The module under test is imported inside each test rather than at module scope
+so the corpus still collects while it does not exist yet: the contract is
+readable before the implementation is.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+from plugin_format.connectors import validate_connectors
+
+_VECTORS = Path(__file__).parents[3] / "tests" / "vectors"
+
+
+def _vector_file(name: str) -> dict:
+    return json.loads((_VECTORS / name).read_text(encoding="utf-8"))
+
+
+_LOCKS = _vector_file("connector-lock.json")
+_DIGESTS = _vector_file("connector-source-digest.json")
+
+_LOCK_KEYS = {"name", "why", "connectors", "lock", "portable", "expect", "resolved", "codes"}
+_DIGEST_KEYS = {"name", "why", "tree", "build", "source_digest"}
+
+# A registry manifest digest is `<repo>@sha256:` plus 64 lowercase hex
+# characters; a local image id is the bare `sha256:` form `docker image inspect
+# --format {{.Id}}` reports. Both are fixed by the OCI distribution spec's
+# content-addressable digest grammar
+# (https://github.com/opencontainers/distribution-spec/blob/main/spec.md#pulling-manifests),
+# not by anything in this repository, which is why the literals below are
+# spelled out rather than derived from the implementation.
+_REGISTRY_IMAGE = (
+    "ghcr.io/acme-corp/acme-bot-k8s-write-mcp@sha256:"
+    "0000000000000000000000000000000000000000000000000000000000000000"
+)
+_LOCAL_IMAGE = "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+_SOURCE_DIGEST = "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+
+BUILT = {
+    "connectors": {
+        "k8s-write": {
+            "build": {
+                "context": "connectors/k8s-write",
+                "platforms": ["linux/amd64", "linux/arm64"],
+            }
+        }
+    }
+}
+
+
+def _declared(document: Any) -> Any:
+    parsed, errors = validate_connectors(document)
+    assert errors == [], errors
+    return parsed
+
+
+def _lock(image: str, delivery: str = "registry") -> dict:
+    return {
+        "version": 1,
+        "connectors": {
+            "k8s-write": {
+                "image": image,
+                "delivery": delivery,
+                "platforms": ["linux/amd64", "linux/arm64"],
+                "source_digest": _SOURCE_DIGEST,
+            }
+        },
+    }
+
+
+def _parse_lock(document: Any) -> Any:
+    from plugin_format import connector_lock
+
+    parsed, errors = connector_lock.validate_connector_lock(document)
+    assert errors == [], errors
+    assert parsed is not None
+    return parsed
+
+
+# --------------------------------------------------------------------------- #
+# The file name every lane names once
+# --------------------------------------------------------------------------- #
+def test_the_lock_file_name_is_defined_beside_its_parser() -> None:
+    # Same reason CONNECTORS_FILE lives beside validate_connectors: the CLI
+    # writes this file, the packer must not exclude it, the validator reads it,
+    # and the API reads it again. Four hand-typed copies of a filename is how
+    # one of them ends up plural.
+    from plugin_format import connector_lock
+
+    assert connector_lock.CONNECTOR_LOCK_FILE == "connectors.lock.yaml"
+
+
+# --------------------------------------------------------------------------- #
+# apply_lock: the single enforcement point
+# --------------------------------------------------------------------------- #
+def test_a_locked_build_becomes_an_ordinary_image_connector() -> None:
+    # The property every downstream reader depends on. `build` is cleared as
+    # well as `image` being set: leaving it in place means a second reader can
+    # still see an unresolved build and take the wrong branch.
+    from plugin_format import connector_lock
+
+    resolved = connector_lock.apply_lock(
+        _declared(BUILT), _parse_lock(_lock(_REGISTRY_IMAGE)), portable=True
+    )
+    spec = resolved.connectors["k8s-write"]
+    assert spec.image == _REGISTRY_IMAGE
+    assert spec.build is None
+    assert spec.is_hosted
+
+
+def test_apply_lock_does_not_mutate_the_declaration_it_was_given() -> None:
+    # The API calls this on every render of every version. A reader that
+    # rewrote the parsed declaration in place would leave a resolved image on a
+    # cached ConnectorsFile and quietly serve it to the next caller.
+    from plugin_format import connector_lock
+
+    declared = _declared(BUILT)
+    connector_lock.apply_lock(declared, _parse_lock(_lock(_REGISTRY_IMAGE)), portable=True)
+    assert declared.connectors["k8s-write"].image is None
+    assert declared.connectors["k8s-write"].build is not None
+
+
+def test_a_declared_build_with_no_lock_at_all_is_refused() -> None:
+    # `None` is the shape read_connector_lock returns for a bundle carrying no
+    # lock file, and it must not degrade to "render it anyway with image None".
+    from plugin_format import connector_lock
+
+    with pytest.raises(ValueError) as exc:
+        connector_lock.apply_lock(_declared(BUILT), None, portable=False)
+    assert "k8s-write" in str(exc.value)
+
+
+def test_a_tag_shaped_image_is_refused() -> None:
+    # The outcome test for "the renderer and applier never deploy a mutable
+    # connector tag" (ADR 0113). A tag can be repointed at a different artifact
+    # after review and between tier runs, which is the failure mode this
+    # platform has already hit. The reference below is otherwise perfectly well
+    # formed, so only a real digest check refuses it.
+    from plugin_format import connector_lock
+
+    with pytest.raises(ValueError):
+        connector_lock.apply_lock(
+            _declared(BUILT),
+            _parse_lock(_lock("ghcr.io/acme-corp/acme-bot-k8s-write-mcp:v1")),
+            portable=True,
+        )
+
+
+def test_a_local_daemon_image_is_refused_where_portability_is_required() -> None:
+    # A local image id names nothing a Kubernetes node can pull. Applying it
+    # yields ImagePullBackOff on every node, long after the deploy reported
+    # success.
+    from plugin_format import connector_lock
+
+    with pytest.raises(ValueError):
+        connector_lock.apply_lock(
+            _declared(BUILT), _parse_lock(_lock(_LOCAL_IMAGE, "local-daemon")), portable=True
+        )
+
+
+def test_the_same_local_daemon_image_applies_where_portability_is_not_required() -> None:
+    # The regression pin for review round 2 finding r2-3. A local-tier version
+    # is a legitimate stored artifact and rendering its manifests is harmless,
+    # because nothing applies them at local tier. Refusing here broke every
+    # `curie local deploy` in an earlier draft, so the two halves of this pair
+    # must stay a pair: making the refusal unconditional turns this green test
+    # red.
+    from plugin_format import connector_lock
+
+    resolved = connector_lock.apply_lock(
+        _declared(BUILT), _parse_lock(_lock(_LOCAL_IMAGE, "local-daemon")), portable=False
+    )
+    assert resolved.connectors["k8s-write"].image == _LOCAL_IMAGE
+
+
+def test_portable_is_keyword_only() -> None:
+    # Two callers pass different values and the wrong one silently deploys an
+    # unpullable image to a cluster. A positional call site cannot express that
+    # mistake if there is no positional call site.
+    from plugin_format import connector_lock
+
+    with pytest.raises(TypeError):
+        connector_lock.apply_lock(_declared(BUILT), _parse_lock(_lock(_REGISTRY_IMAGE)), True)
+
+
+def test_a_resolved_build_renders_where_an_unresolved_one_raises() -> None:
+    # The two halves of the guard, in one place: render refuses an unresolved
+    # build (test_connector_render.py owns that assertion) and accepts the
+    # resolved one, with the locked digest reaching the container spec. This is
+    # the only path an image reaches a Deployment, so a lock that parses but is
+    # never applied shows up here as `image: None`.
+    from plugin_format import connector_lock, connector_render
+
+    resolved = connector_lock.apply_lock(
+        _declared(BUILT), _parse_lock(_lock(_REGISTRY_IMAGE)), portable=True
+    )
+    objects = connector_render.render(
+        release="acme-rel",
+        agent="acme-bot",
+        namespace="acme-ns",
+        app_name="curie",
+        connector="k8s-write",
+        spec=resolved.connectors["k8s-write"],
+        secret_name="acme-rel-acme-bot-connector-secrets",
+    )
+    deployment = next(o for o in objects if o["kind"] == "Deployment")
+    container = deployment["spec"]["template"]["spec"]["containers"][0]
+    assert container["image"] == _REGISTRY_IMAGE
+
+
+# --------------------------------------------------------------------------- #
+# The Python half of the frozen Python/Rust lock seam
+# --------------------------------------------------------------------------- #
+def test_every_lock_vector_declares_only_modelled_keys() -> None:
+    for vector in _LOCKS["vectors"]:
+        extra = set(vector) - _LOCK_KEYS
+        assert not extra, f"{vector['name']}: unmodelled vector keys {sorted(extra)}"
+        assert vector["expect"] in {"apply", "raise", "invalid"}
+
+
+@pytest.mark.parametrize("vector", _LOCKS["vectors"], ids=lambda v: v["name"])
+def test_lock_vectors(vector: dict) -> None:
+    # Driven off tests/vectors/connector-lock.json so the Rust mirror in
+    # cli/src/connector_build.rs cannot diverge. "invalid" means the document
+    # does not survive validate_connector_lock, so a malformed lock is rejected
+    # at bundle intake rather than surfacing at render time; "raise" means it
+    # parses and apply_lock refuses it.
+    from plugin_format import connector_lock
+
+    declared = _declared(vector["connectors"])
+    if vector["lock"] is None:
+        parsed_lock = None
+    else:
+        parsed_lock, errors = connector_lock.validate_connector_lock(vector["lock"])
+        codes = [code for code, _ in errors]
+        if vector["expect"] == "invalid":
+            assert parsed_lock is None
+            assert codes, f"{vector['name']} must be rejected by validate_connector_lock"
+            for expected in vector["codes"]:
+                assert expected in codes, f"{vector['name']} expected {expected}, got {codes}"
+            return
+        assert errors == [], f"{vector['name']} must parse cleanly, got {codes}"
+
+    if vector["expect"] == "raise":
+        with pytest.raises(ValueError):
+            connector_lock.apply_lock(declared, parsed_lock, portable=vector["portable"])
+        return
+
+    resolved = connector_lock.apply_lock(declared, parsed_lock, portable=vector["portable"])
+    for name, image in vector["resolved"].items():
+        assert resolved.connectors[name].image == image
+        assert resolved.connectors[name].build is None
+
+
+def test_lock_model_field_names_match_the_frozen_vector() -> None:
+    # See tests/vectors/connector-fields.json: the schema-driven field-parity
+    # gate compares nothing for these structs because plugin-format.schema.json
+    # carries no Connector* $defs, so this pair of assertions plus the Rust half
+    # is the only thing that keeps the two languages in step.
+    from plugin_format.connector_lock import ConnectorLockEntry, ConnectorLockFile
+
+    fields = _vector_file("connector-fields.json")["models"]
+    assert set(ConnectorLockFile.model_fields) == set(fields["ConnectorLockFile"])
+    assert set(ConnectorLockEntry.model_fields) == set(fields["ConnectorLockEntry"])
+
+
+# --------------------------------------------------------------------------- #
+# source_digest: what makes "unchanged source, identical digest" a real proof
+# --------------------------------------------------------------------------- #
+def _materialize(root: Path, tree: dict[str, Any]) -> Path:
+    # A tree value is either a content string or `{"content", "executable"}`.
+    # The mode is part of the digest -- the build context tar carries it -- so a
+    # materializer that dropped the object form would silently write the
+    # executable vectors non-executable and fail against a corpus that is right.
+    for rel, value in tree.items():
+        path = root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        if isinstance(value, str):
+            content, executable = value, False
+        else:
+            content, executable = value["content"], bool(value.get("executable"))
+        path.write_text(content, encoding="utf-8")
+        mode = path.stat().st_mode & 0o7777
+        path.chmod(mode | 0o100 if executable else mode & ~0o111)
+    return root
+
+
+def test_every_source_digest_vector_declares_only_modelled_keys() -> None:
+    for vector in _DIGESTS["vectors"]:
+        extra = set(vector) - _DIGEST_KEYS
+        assert not extra, f"{vector['name']}: unmodelled vector keys {sorted(extra)}"
+
+
+@pytest.mark.parametrize("vector", _DIGESTS["vectors"], ids=lambda v: v["name"])
+def test_source_digest_vectors(vector: dict, tmp_path: Path) -> None:
+    # The corpus is the algorithm's specification; the file's own `comment`
+    # states it in full, because a corpus alone cannot say why two readers
+    # disagree. The Rust port is frozen against the same bytes.
+    from plugin_format import connector_lock
+    from plugin_format.connectors import ConnectorBuild
+
+    context = _materialize(tmp_path / "ctx", vector["tree"])
+    build = ConnectorBuild.model_validate(vector["build"])
+    assert connector_lock.source_digest_of(context, build) == vector["source_digest"]
+
+
+@pytest.mark.parametrize("relation", _DIGESTS["relations"], ids=lambda r: r.get("why", "")[:40])
+def test_source_digest_relations(relation: dict, tmp_path: Path) -> None:
+    # Where the exclusion and build-block rules are actually falsified. A reader
+    # that ignores .dockerignore still passes every single-vector assertion by
+    # recording whatever it computes; it cannot satisfy both halves of a
+    # relation, because one pair must come out equal and another must not.
+    from plugin_format import connector_lock
+    from plugin_format.connectors import ConnectorBuild
+
+    by_name = {v["name"]: v for v in _DIGESTS["vectors"]}
+    computed = []
+    for i, name in enumerate(relation.get("same") or relation["distinct"]):
+        vector = by_name[name]
+        context = _materialize(tmp_path / f"ctx{i}", vector["tree"])
+        computed.append(
+            connector_lock.source_digest_of(context, ConnectorBuild.model_validate(vector["build"]))
+        )
+    if "same" in relation:
+        assert computed[0] == computed[1], relation["why"]
+    else:
+        assert computed[0] != computed[1], relation["why"]
+
+
+def test_the_digest_ignores_mtime_and_every_mode_bit_but_owner_execute(tmp_path: Path) -> None:
+    # Deliberately unlike cli/src/bundle.rs's archive digest, which embeds
+    # per-file mtime, uid and gid by design because it identifies an ARCHIVE and
+    # not a source tree. Reusing that computation here would report every fresh
+    # checkout as a changed source, so every build after a clone would look
+    # stale and rebuild. The owner execute bit is the one exception (pinned by
+    # the test below); a group or other bit differing by umask is not.
+    from plugin_format import connector_lock
+    from plugin_format.connectors import ConnectorBuild
+
+    tree = {"Dockerfile": "FROM scratch\n", "server.py": "print('acme')\n"}
+    first = _materialize(tmp_path / "a", tree)
+    second = _materialize(tmp_path / "b", tree)
+    for path in second.rglob("*"):
+        if path.is_file():
+            os.utime(path, (1_000_000_000, 1_000_000_000))
+            # Group and other bits, not owner execute: a checkout under a
+            # different umask must not read as a changed source.
+            path.chmod(0o644 if path.name == "Dockerfile" else 0o600)
+    build = ConnectorBuild.model_validate(
+        {"context": "connectors/tempo", "platforms": ["linux/amd64"]}
+    )
+    assert connector_lock.source_digest_of(first, build) == connector_lock.source_digest_of(
+        second, build
+    )
+
+
+def test_making_a_file_executable_moves_the_digest(tmp_path: Path) -> None:
+    # RED before the fix: `chmod +x entrypoint.sh` with no byte changed produced
+    # the same digest, so the lock looked fresh while the image that would be
+    # built from it differs -- Docker's context tar carries the mode and
+    # BuildKit keys its cache on it. Asserted as an inequality against the same
+    # tree rather than as a frozen literal, so it survives a stream change; the
+    # corpus pair `an_entrypoint_without_the_executable_bit` /
+    # `chmod_plus_x_on_the_entrypoint_moves_the_digest` pins the exact values on
+    # both sides of the seam.
+    from plugin_format import connector_lock
+    from plugin_format.connectors import ConnectorBuild
+
+    tree = {"Dockerfile": "FROM scratch\n", "entrypoint.sh": "#!/bin/sh\nexec server\n"}
+    plain = _materialize(tmp_path / "plain", tree)
+    executable = _materialize(
+        tmp_path / "exec",
+        {
+            "Dockerfile": tree["Dockerfile"],
+            "entrypoint.sh": {"content": tree["entrypoint.sh"], "executable": True},
+        },
+    )
+    build = ConnectorBuild.model_validate(
+        {"context": "connectors/tempo", "platforms": ["linux/amd64"]}
+    )
+    assert connector_lock.source_digest_of(plain, build) != connector_lock.source_digest_of(
+        executable, build
+    ), "the owner execute bit is part of the build input, so it is part of the digest"
+
+
+# --------------------------------------------------------------------------- #
+# Symlinks: the one rule the JSON corpus cannot express
+#
+# A vector's `tree` is a path-to-content map, so it can state every ordering and
+# exclusion rule but not a link. Both languages must agree here or the digest
+# stops being a cross-language identity: `cli/src/connector_build.rs` refuses a
+# symlinked context in `resolve_context` and skips every symlink in
+# `collect_files`, so these are the Python twins of assertions the CLI suite
+# already makes (`a_context_outside_the_bundle_is_refused`).
+# --------------------------------------------------------------------------- #
+def test_a_symlink_inside_the_context_is_neither_followed_nor_hashed(tmp_path: Path) -> None:
+    # RED if the walk ever dereferences a link: the digest gains a record and
+    # stops matching the CLI's, so every bundle with a symlinked file in its
+    # context reports its lock stale on one side of the seam and current on the
+    # other. Asserted as an equality against the same tree WITHOUT the links,
+    # rather than as a frozen literal, so it survives any future stream change.
+    from plugin_format import connector_lock
+    from plugin_format.connectors import ConnectorBuild
+
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "secret.env").write_text("TOKEN=abc\n", encoding="utf-8")
+    (outside / "lib").mkdir()
+    (outside / "lib" / "vendored.py").write_text("VENDORED = 1\n", encoding="utf-8")
+
+    plain = _materialize(tmp_path / "plain", {"Dockerfile": "FROM scratch\n"})
+    linked = _materialize(tmp_path / "linked", {"Dockerfile": "FROM scratch\n"})
+    (linked / "secret.env").symlink_to(outside / "secret.env")
+    (linked / "lib").symlink_to(outside / "lib", target_is_directory=True)
+
+    build = ConnectorBuild.model_validate(
+        {"context": "connectors/tempo", "platforms": ["linux/amd64"]}
+    )
+    assert connector_lock.source_digest_of(linked, build) == connector_lock.source_digest_of(
+        plain, build
+    ), "a symlink is never followed and never hashed, on both sides of the seam"
+
+
+def test_a_symlinked_build_context_is_refused_rather_than_dereferenced(tmp_path: Path) -> None:
+    # RED before the fix: `resolve_context` did not exist on the Python side at
+    # all, so intake joined the path and hashed whatever it landed on. The digest
+    # would then pin bytes the bundle does not carry, which can change under the
+    # lock without the lock ever going stale.
+    from plugin_format import connector_lock
+
+    bundle = tmp_path / "bundle"
+    (bundle / "connectors").mkdir(parents=True)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (bundle / "connectors" / "k8s-write").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="symlink"):
+        connector_lock.resolve_context(bundle, "connectors/k8s-write")
+
+
+def test_a_context_resolving_outside_the_bundle_is_refused(tmp_path: Path) -> None:
+    # The containment half, matching the CLI's `resolve_context` exactly: an
+    # absolute path and a `..` climb both name a tree the bundle does not carry.
+    from plugin_format import connector_lock
+
+    bundle = tmp_path / "bundle"
+    (bundle / "connectors" / "k8s-write").mkdir(parents=True)
+    (tmp_path / "outside").mkdir()
+
+    for context in ("../outside", "/etc"):
+        with pytest.raises(ValueError, match="outside the bundle"):
+            connector_lock.resolve_context(bundle, context)
+
+
+def test_a_context_inside_the_bundle_resolves(tmp_path: Path) -> None:
+    # The positive control. Without it every assertion above is satisfied by a
+    # resolver that refuses everything, which would refuse every real bundle.
+    from plugin_format import connector_lock
+
+    bundle = tmp_path / "bundle"
+    (bundle / "connectors" / "k8s-write").mkdir(parents=True)
+
+    resolved = connector_lock.resolve_context(bundle, "connectors/k8s-write")
+    assert resolved == (bundle / "connectors" / "k8s-write").resolve()
+    assert connector_lock.resolve_context(bundle, ".") == bundle.resolve()

--- a/packages/plugin-format/tests/test_connector_render.py
+++ b/packages/plugin-format/tests/test_connector_render.py
@@ -7,6 +7,7 @@ refactor cannot quietly reintroduce them.
 
 from __future__ import annotations
 
+import json
 import shutil
 import subprocess
 from pathlib import Path
@@ -888,3 +889,152 @@ def test_connector_env_port_placeholders_use_the_declared_port(port: int) -> Non
             f"http://acme-bot-acme-bot-mcp-grafana.acme-bot.svc.cluster.local:{port}"
         ),
     }
+
+
+# --------------------------------------------------------------------------- #
+# An unresolved `build:` connector never renders -- ADR 0113
+# --------------------------------------------------------------------------- #
+def _build_spec(**overrides: object) -> ConnectorSpec:
+    payload: dict = {
+        "build": {
+            "context": "connectors/k8s-write",
+            "platforms": ["linux/amd64", "linux/arm64"],
+        }
+    }
+    payload.update(overrides)
+    return ConnectorSpec.model_validate(payload)
+
+
+def test_rendering_an_unresolved_build_raises_instead_of_emitting_a_null_image() -> None:
+    # The alternative is render_deployment emitting `"image": None`, which
+    # applies as an invalid Deployment and surfaces as an opaque Kubernetes
+    # error a long way from its cause. The message must name the artifact that
+    # is missing, because the fix is to produce it, not to edit the bundle.
+    with pytest.raises(ValueError) as exc:
+        _objs(spec=_build_spec())
+    assert "connectors.lock.yaml" in str(exc.value)
+
+
+def test_the_guard_fires_before_any_object_is_produced() -> None:
+    # A guard that ran per-object would emit a Service and a NetworkPolicy for a
+    # connector that can never start, and a caller applying the partial list
+    # leaves them orphaned in the namespace.
+    with pytest.raises(ValueError):
+        r.render(
+            release="acme-rel",
+            agent="acme-bot",
+            namespace="acme-ns",
+            app_name="curie",
+            connector="k8s-write",
+            spec=_build_spec(),
+            secret_name="conn-secrets",
+        )
+
+
+def test_a_remote_connector_still_renders_nothing_rather_than_raising() -> None:
+    # The guard is scoped to hosted-ness. A `url` connector has no image by
+    # design and must keep returning an empty object list, not an error.
+    assert _objs(spec=REMOTE) == []
+
+
+# --------------------------------------------------------------------------- #
+# Hosted-ness is image-independent: the derivations a build connector inherits
+# --------------------------------------------------------------------------- #
+def test_a_build_connector_with_no_unhosted_url_is_declared_but_not_exercisable() -> None:
+    # Matching the `image:` form exactly. Reverting `is_hosted` to
+    # `self.image is not None` makes this return the REMOTE-form entry built
+    # from a `url` that is None, so the runner mounts an entry whose URL is
+    # null instead of reporting the connector as unavailable here (#1093).
+    assert r.unhosted_mcp_entry(_build_spec()) is None
+    assert r.unhosted_mcp_entry(HOSTED) is None
+
+
+def test_a_build_connector_may_declare_where_to_reach_it_when_unhosted() -> None:
+    spec = _build_spec(unhosted_url="http://127.0.0.1:8765/mcp")
+    assert r.unhosted_mcp_entry(spec) == {"type": "http", "url": "http://127.0.0.1:8765/mcp"}
+
+
+def test_the_mcp_entry_for_a_build_connector_is_the_service_derived_url() -> None:
+    # The URL derivation reads the Service name, never the image, so it is
+    # identical before and after the lock is applied. That is what lets the
+    # skill, local and cluster tiers mount one byte-identical entry.
+    entry = r.mcp_entry("acme-rel", "acme-bot", "acme-ns", "k8s-write", _build_spec())
+    assert entry == {
+        "type": "http",
+        "url": "http://acme-rel-acme-bot-mcp-k8s-write.acme-ns.svc.cluster.local:8000/mcp",
+    }
+    assert entry == r.mcp_entry(
+        "acme-rel",
+        "acme-bot",
+        "acme-ns",
+        "k8s-write",
+        ConnectorSpec(image="ghcr.io/acme-corp/acme-bot-k8s-write-mcp@sha256:" + "0" * 64),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# The frozen Python/Rust object-name and Service-DNS seam -- ADR 0113 Decision 2
+# --------------------------------------------------------------------------- #
+_DNS_VECTORS = json.loads(
+    (Path(__file__).parents[3] / "tests" / "vectors" / "connector-service-dns.json").read_text(
+        encoding="utf-8"
+    )
+)
+
+_DNS_VECTOR_KEYS = {
+    "name",
+    "why",
+    "release",
+    "agent",
+    "connector",
+    "namespace",
+    "object_name",
+    "service_dns",
+}
+
+
+def test_every_service_dns_vector_declares_only_modelled_keys() -> None:
+    for vector in _DNS_VECTORS["vectors"]:
+        extra = set(vector) - _DNS_VECTOR_KEYS
+        assert not extra, f"{vector['name']}: unmodelled vector keys {sorted(extra)}"
+
+
+@pytest.mark.parametrize("vector", _DNS_VECTORS["vectors"], ids=lambda v: v["name"])
+def test_service_dns_vectors(vector: dict) -> None:
+    # This string is the Docker network alias the CLI starts a skill-tier and
+    # local-tier connector container under, and the runner derives the URL it
+    # dials from THIS function. The two lanes cannot share code, so a change to
+    # either derivation that is not made to both has to fail both suites --
+    # otherwise the runner dials a DNS name no container owns and the failure is
+    # a bare connection timeout with nothing logged at either end. Same
+    # mechanism as tests/vectors/approval-action-ids.json.
+    assert (
+        r.object_name(vector["release"], vector["agent"], vector["connector"])
+        == vector["object_name"]
+    )
+    assert (
+        r.service_dns(
+            vector["release"], vector["agent"], vector["connector"], vector["namespace"]
+        )
+        == vector["service_dns"]
+    )
+
+
+def test_the_dns_corpus_covers_the_truncation_branch() -> None:
+    # Without an over-long name in the corpus the vectors freeze only the
+    # concatenation, and the truncation-with-digest branch -- the half a hand
+    # port gets wrong -- stays unpinned in both languages.
+    bases = [
+        f"{v['release']}-{v['agent']}-mcp-{v['connector']}" for v in _DNS_VECTORS["vectors"]
+    ]
+    assert any(len(base) > 63 for base in bases)
+    truncated = [
+        v
+        for v in _DNS_VECTORS["vectors"]
+        if len(f"{v['release']}-{v['agent']}-mcp-{v['connector']}") > 63
+    ]
+    # A truncated name must still be a legal DNS label, and two long names
+    # sharing a prefix must not collapse onto one object.
+    assert all(len(v["object_name"]) <= 63 for v in truncated)
+    assert all(not v["object_name"].endswith("-") for v in truncated)
+    assert len({v["object_name"] for v in truncated}) == len(truncated)

--- a/packages/plugin-format/tests/test_connectors.py
+++ b/packages/plugin-format/tests/test_connectors.py
@@ -35,6 +35,32 @@ def _codes(data: object) -> list[str]:
     return [c for c, _ in errors]
 
 
+# The cross-language corpora. Both live at the repository root because the Rust
+# CLI reads the same bytes; see each file's own `comment` for why the seam needs
+# freezing rather than a shared import.
+_VECTORS = Path(__file__).parents[3] / "tests" / "vectors"
+
+
+def _vector_file(name: str) -> dict:
+    return json.loads((_VECTORS / name).read_text(encoding="utf-8"))
+
+
+_BUILD_DECL = _vector_file("connector-build-decl.json")
+
+# Every key a vector may carry. Asserted, so a key added for the Rust lane alone
+# cannot pass vacuously here -- the failure mode the model-credential-forwarding
+# and approval-action-id vectors both guard the same way.
+_BUILD_DECL_KEYS = {
+    "name",
+    "why",
+    "document",
+    "expect",
+    "codes",
+    "resolved_dockerfile",
+    "fixture",
+}
+
+
 # --------------------------------------------------------------------------- #
 # Accepted shapes
 # --------------------------------------------------------------------------- #
@@ -383,3 +409,192 @@ def test_a_reserved_name_and_a_bad_shape_report_both() -> None:
     codes = _codes({"connectors": {"curie": {"secrets": ["T"]}}})
     assert "connectors.reserved_name" in codes
     assert "connectors.underspecified" in codes
+
+
+# --------------------------------------------------------------------------- #
+# The `build:` form: a bundle declares source, not a hand-pasted image -- ADR 0113
+# --------------------------------------------------------------------------- #
+def test_a_build_only_connector_is_accepted_and_is_hosted() -> None:
+    # Hosted-ness is about WHO RUNS THE PROCESS, not about whether the image ref
+    # has been resolved yet. Keeping `is_hosted` keyed to `image` would make a
+    # source-built connector look remote to `render`, `mcp_entry` and the
+    # runner all at once: no objects rendered, and `unhosted_mcp_entry` handing
+    # back a remote-form entry built from a `url` that is None.
+    parsed, errors = validate_connectors(
+        {
+            "connectors": {
+                "k8s-write": {
+                    "build": {
+                        "context": "connectors/k8s-write",
+                        "dockerfile": "Dockerfile",
+                        "platforms": ["linux/amd64", "linux/arm64"],
+                    },
+                    "env": {"K8S_WRITE_ALLOWLIST": "acme-ns/acme-api"},
+                    "secret_files": {"K8S_WRITE_KUBECONFIG": "/secrets/kubeconfig"},
+                }
+            }
+        }
+    )
+    assert errors == []
+    assert parsed is not None
+    spec = parsed.connectors["k8s-write"]
+    assert spec.is_hosted
+    assert spec.image is None, "the digest lives in connectors.lock.yaml, never in the declaration"
+    assert spec.build is not None
+    assert spec.build.context == "connectors/k8s-write"
+    assert spec.build.platforms == ["linux/amd64", "linux/arm64"]
+
+
+def test_dockerfile_defaults_to_Dockerfile() -> None:
+    # The common case omits it. A reader that leaves the resolved path empty
+    # builds nothing, or builds whatever the daemon's own default happens to
+    # be, which is a different file in a different place.
+    parsed, errors = validate_connectors(
+        {
+            "connectors": {
+                "tempo": {"build": {"context": "connectors/tempo", "platforms": ["linux/amd64"]}}
+            }
+        }
+    )
+    assert errors == []
+    assert parsed is not None
+    assert parsed.connectors["tempo"].build is not None
+    assert parsed.connectors["tempo"].build.dockerfile == "Dockerfile"
+
+
+def test_platforms_has_no_default() -> None:
+    # Required rather than defaulted, because a silently single-arch build is
+    # the exact failure ADR 0113 names: it passes every declaration check and
+    # fails after apply as "no matching manifest for linux/arm64". A default
+    # would pick one arch on the author's behalf and never say so.
+    assert _codes({"connectors": {"tempo": {"build": {"context": "connectors/tempo"}}}}) != []
+
+
+@pytest.mark.parametrize("second", ["image", "url"])
+def test_build_beside_another_form_is_ambiguous(second: str) -> None:
+    # Two image sources, or an image source plus a claim that the process is
+    # already running elsewhere. Picking either silently ignores the other, and
+    # the one ignored is the one the author edited last.
+    value = "ghcr.io/acme-corp/acme-bot-k8s-write-mcp:v1" if second == "image" else "https://mcp.acme.example.com/mcp"
+    codes = _codes(
+        {
+            "connectors": {
+                "k8s-write": {
+                    second: value,
+                    "build": {"context": "connectors/k8s-write", "platforms": ["linux/amd64"]},
+                }
+            }
+        }
+    )
+    assert "connectors.ambiguous" in codes
+
+
+def test_the_underspecified_message_names_the_build_form() -> None:
+    # An author who meant to declare source and mistyped the key is told the
+    # form exists. A message that still names only `image` and `url` sends them
+    # back to hand-building and pasting a digest, which is the workflow ADR 0113
+    # exists to delete.
+    _, errors = validate_connectors({"connectors": {"k8s-write": {"secrets": ["K8S_WRITE_TOKEN"]}}})
+    message = next(m for code, m in errors if code == "connectors.underspecified")
+    assert "`build`" in message
+
+
+def test_headers_are_rejected_on_a_build_connector_exactly_as_on_an_image_one() -> None:
+    # SIBLING PATH (AGENTS.md's parity-seam rule). The guard was keyed to
+    # `image`, and a `build:` connector is equally hosted, so without widening
+    # it to hosted-ness a built connector could declare `headers` and be
+    # accepted -- a remote-only field riding the build form, silently ignored by
+    # the renderer. Armed here through the build form ONLY, so reverting the
+    # guard to `spec.image and spec.headers` fails this test while the
+    # image-form test above still passes. That gap IS the seam.
+    build_form = _codes(
+        {
+            "connectors": {
+                "k8s-write": {
+                    "build": {"context": "connectors/k8s-write", "platforms": ["linux/amd64"]},
+                    "headers": {"Authorization": "Bearer ${ACME_TOKEN}"},
+                }
+            }
+        }
+    )
+    image_form = _codes(
+        {"connectors": {"k8s-write": {"image": "x:1", "headers": {"Authorization": "Bearer x"}}}}
+    )
+    assert "connectors.hosted_has_headers" in build_form
+    assert "connectors.hosted_has_headers" in image_form
+
+
+def test_an_unknown_key_inside_build_is_rejected_not_ignored() -> None:
+    # `target:` is a plausible thing to reach for and Curie models none of it.
+    # Silently dropping it means a build that produces the wrong stage while
+    # reporting success.
+    assert (
+        _codes(
+            {
+                "connectors": {
+                    "tempo": {
+                        "build": {
+                            "context": "connectors/tempo",
+                            "platforms": ["linux/amd64"],
+                            "target": "runtime",
+                        }
+                    }
+                }
+            }
+        )
+        != []
+    )
+
+
+# --------------------------------------------------------------------------- #
+# The Python half of the frozen Python/Rust declaration seam
+# --------------------------------------------------------------------------- #
+def test_every_build_declaration_vector_declares_only_modelled_keys() -> None:
+    # A key added for the Rust lane alone would otherwise sit here unread, so
+    # the corpus would grow a field this suite silently ignores.
+    for vector in _BUILD_DECL["vectors"]:
+        extra = set(vector) - _BUILD_DECL_KEYS
+        assert not extra, f"{vector['name']}: unmodelled vector keys {sorted(extra)}"
+        assert vector["expect"] in {"accept", "reject"}
+
+
+@pytest.mark.parametrize(
+    "vector",
+    [v for v in _BUILD_DECL["vectors"] if "fixture" not in v],
+    ids=lambda v: v["name"],
+)
+def test_build_declaration_vectors(vector: dict) -> None:
+    # Driven off tests/vectors/connector-build-decl.json rather than inline
+    # literals so the Rust reader in cli/src/connector_build.rs cannot diverge:
+    # changing an expectation here fails both suites, and changing one language
+    # without the vector fails that language. A vector carrying `fixture` is a
+    # filesystem case only the CLI's path resolver can see (a symlinked
+    # Dockerfile), so it is skipped here and materialized by the Rust suite.
+    parsed, errors = validate_connectors(vector["document"])
+    codes = [code for code, _ in errors]
+    if vector["expect"] == "accept":
+        assert errors == [], f"{vector['name']} must validate clean, got {codes}"
+        assert parsed is not None
+        for connector, dockerfile in vector.get("resolved_dockerfile", {}).items():
+            build = parsed.connectors[connector].build
+            assert build is not None
+            assert build.dockerfile == dockerfile
+    else:
+        assert parsed is None
+        # Subset, never equality: validate_connectors accumulates every problem
+        # in one pass so an author sees the whole file at once.
+        for expected in vector["codes"]:
+            assert expected in codes, f"{vector['name']} expected {expected}, got {codes}"
+
+
+def test_connector_declaration_field_names_match_the_frozen_vector() -> None:
+    # The gap review finding r2-1 named: plugin-format.schema.json carries no
+    # Connector* $defs, so `curie dev field-parity` compares nothing for the
+    # Rust mirrors and a new Python field would land with every gate green.
+    # Adding one without editing the vector fails here; editing the vector to
+    # make this pass then fails the Rust half until the mirror gains the field.
+    from plugin_format.connectors import ConnectorBuild, ConnectorSpec
+
+    fields = _vector_file("connector-fields.json")["models"]
+    assert set(ConnectorSpec.model_fields) == set(fields["ConnectorSpec"])
+    assert set(ConnectorBuild.model_fields) == set(fields["ConnectorBuild"])

--- a/packages/plugin-format/tests/test_validate.py
+++ b/packages/plugin-format/tests/test_validate.py
@@ -1,3 +1,4 @@
+import shutil
 from pathlib import Path
 
 import pytest
@@ -839,3 +840,271 @@ def test_gate_check_stays_silent_when_connectors_yaml_is_unreadable(tmp_path: Pa
     codes = _codes(bundle)
     assert "connectors.unreadable" in codes
     assert _GATE_CODE not in codes
+
+
+# --------------------------------------------------------------------------- #
+# Bundle intake for a source-built connector -- ADR 0113
+#
+# `validate_bundle` is the ONE gate a bundle passes through whatever entry point
+# it arrives by (apps/api/CLAUDE.md): the CLI upload, the console's create-agent
+# modal, and the git push path all route through it. That is why these rules
+# live here rather than in the API router, and why every assertion below goes
+# through `validate_bundle` rather than through the lock model directly.
+# --------------------------------------------------------------------------- #
+_REGISTRY_IMAGE = (
+    "ghcr.io/acme-corp/acme-bot-k8s-write-mcp@sha256:"
+    "0000000000000000000000000000000000000000000000000000000000000000"
+)
+_LOCAL_IMAGE = "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+
+_BUILT_CONNECTORS = (
+    "connectors:\n"
+    "  k8s-write:\n"
+    "    build:\n"
+    "      context: connectors/k8s-write\n"
+    "      platforms: [linux/amd64, linux/arm64]\n"
+)
+
+
+def _built_bundle(tmp_path: Path, connectors_yaml: str = _BUILT_CONNECTORS) -> Path:
+    """A minimal bundle whose only connector is declared as source."""
+
+    root = _bundle(
+        tmp_path, '{"name": "acme-bot", "version": "0.1.0", "description": "t"}'
+    )
+    (root / "skills" / "acme-bot").mkdir(parents=True, exist_ok=True)
+    (root / "skills" / "acme-bot" / "SKILL.md").write_text(
+        "---\nname: acme-bot\ndescription: t\n---\nhi\n", encoding="utf-8"
+    )
+    (root / "connectors.yaml").write_text(connectors_yaml, encoding="utf-8")
+    context = root / "connectors" / "k8s-write"
+    context.mkdir(parents=True, exist_ok=True)
+    (context / "Dockerfile").write_text(
+        "FROM scratch\nCOPY server.py /server.py\n", encoding="utf-8"
+    )
+    (context / "server.py").write_text("print('acme')\n", encoding="utf-8")
+    return root
+
+
+def _write_lock(
+    root: Path,
+    *,
+    image: str = _REGISTRY_IMAGE,
+    delivery: str = "registry",
+    source_digest: str | None = None,
+) -> None:
+    """Write a well-formed lock for the bundle's one built connector."""
+
+    from plugin_format import connector_lock
+    from plugin_format.connectors import ConnectorBuild
+
+    build = ConnectorBuild.model_validate(
+        {"context": "connectors/k8s-write", "platforms": ["linux/amd64", "linux/arm64"]}
+    )
+    digest = source_digest or connector_lock.source_digest_of(
+        root / "connectors" / "k8s-write", build
+    )
+    (root / connector_lock.CONNECTOR_LOCK_FILE).write_text(
+        "version: 1\n"
+        "connectors:\n"
+        "  k8s-write:\n"
+        f"    image: {image}\n"
+        f"    delivery: {delivery}\n"
+        "    platforms: [linux/amd64, linux/arm64]\n"
+        f"    source_digest: {digest}\n",
+        encoding="utf-8",
+    )
+
+
+def test_a_locked_build_bundle_validates(tmp_path: Path) -> None:
+    # The control for every negative below. Without it a rule that rejected
+    # every build: bundle outright would pass all of them.
+    root = _built_bundle(tmp_path)
+    _write_lock(root)
+    result = validate_bundle(root)
+    assert result.valid, [e.code for e in result.errors]
+
+
+def test_a_build_bundle_with_no_lock_is_refused(tmp_path: Path) -> None:
+    # gitflow.py creates the Version and stores the bundle only AFTER validation
+    # passes, so this is what stops a lockless build: version from ever
+    # existing. Without it the deployment goes active, the runner still derives
+    # a hosted URL for the connector, and the reconciler retries forever against
+    # something that was never built.
+    root = _built_bundle(tmp_path)
+    result = validate_bundle(root)
+    assert not result.valid
+    issue = next(i for i in result.errors if i.code == "connectors.lock_missing")
+    assert "k8s-write" in issue.message
+
+
+def test_an_image_bundle_with_no_lock_still_validates(tmp_path: Path) -> None:
+    # Every rule this ticket adds is conditioned on a build: declaration, and no
+    # bundle in the wild has one. A lock requirement that fired on the image:
+    # form would reject every hosted-connector bundle that exists.
+    root = _built_bundle(
+        tmp_path,
+        "connectors:\n  grafana:\n    image: ghcr.io/acme-corp/mcp-grafana:0.17.2\n",
+    )
+    assert validate_bundle(root).valid
+
+
+def test_a_lock_missing_only_one_of_two_built_connectors_is_refused(tmp_path: Path) -> None:
+    # Per connector, not per file. A lock that covers the first connector and
+    # not the second would otherwise satisfy a file-level presence check while
+    # the second renders `image: null`.
+    root = _built_bundle(
+        tmp_path,
+        _BUILT_CONNECTORS
+        + "  tempo:\n    build:\n      context: connectors/tempo\n      platforms: [linux/amd64]\n",
+    )
+    (root / "connectors" / "tempo").mkdir(parents=True, exist_ok=True)
+    (root / "connectors" / "tempo" / "Dockerfile").write_text("FROM scratch\n", encoding="utf-8")
+    _write_lock(root)
+    result = validate_bundle(root)
+    assert not result.valid
+    issue = next(i for i in result.errors if i.code == "connectors.lock_missing")
+    assert "tempo" in issue.message
+
+
+def test_a_stale_lock_is_refused_when_the_source_changed(tmp_path: Path) -> None:
+    # Without it, a git push after a source edit activates the PREVIOUS digest
+    # and the deployed connector silently stops matching the reviewed source.
+    # The recomputation is pure hashing over the already extracted tree -- no
+    # docker, no registry, no network -- so the API stays a pure renderer.
+    root = _built_bundle(tmp_path)
+    _write_lock(root)
+    assert validate_bundle(root).valid, "the control: unchanged source validates"
+
+    (root / "connectors" / "k8s-write" / "server.py").write_text(
+        "print('acme, but different')\n", encoding="utf-8"
+    )
+    result = validate_bundle(root)
+    assert not result.valid
+    issue = next(i for i in result.errors if i.code == "connectors.lock_stale")
+    assert "k8s-write" in issue.message
+
+
+def test_a_stale_lock_is_refused_when_only_the_declaration_changed(tmp_path: Path) -> None:
+    # The second, independent path: not one byte of the build context changed,
+    # only `platforms` in connectors.yaml. The previous lock names a
+    # single-arch artifact that cannot run on half the nodes. A digest computed
+    # over the tree alone would report this bundle as fresh.
+    root = _built_bundle(tmp_path)
+    _write_lock(root)
+    (root / "connectors.yaml").write_text(
+        _BUILT_CONNECTORS.replace("[linux/amd64, linux/arm64]", "[linux/amd64]"), encoding="utf-8"
+    )
+    result = validate_bundle(root)
+    assert not result.valid
+    assert "connectors.lock_stale" in {i.code for i in result.errors}
+
+
+def test_a_valid_local_daemon_lock_passes_intake(tmp_path: Path) -> None:
+    # The regression pin for review round 2 finding r2-3, and it is a pin
+    # against a rule being ADDED rather than removed. `curie local deploy`
+    # legitimately uploads a bundle carrying a local-daemon lock; the
+    # registry-only rule belongs to the cluster deploy preflight, which is the
+    # only path that needs an artifact a Kubernetes node can pull. Making
+    # intake refuse local-daemon turns this test red, which is the point.
+    root = _built_bundle(tmp_path)
+    _write_lock(root, image=_LOCAL_IMAGE, delivery="local-daemon")
+    result = validate_bundle(root)
+    assert result.valid, [e.code for e in result.errors]
+
+
+def test_a_lock_carrying_a_tag_is_refused_at_intake(tmp_path: Path) -> None:
+    # A hand-edited lock reaches intake exactly as a generated one does. The
+    # mutable-tag refusal has to fire here too, not only at render time, or a
+    # version whose connector can never be rendered is stored and activated.
+    root = _built_bundle(tmp_path)
+    _write_lock(root, image="ghcr.io/acme-corp/acme-bot-k8s-write-mcp:v1")
+    result = validate_bundle(root)
+    assert not result.valid
+    assert any(i.code.startswith("connectors.lock") for i in result.errors)
+
+
+def test_a_malformed_lock_is_refused_at_intake(tmp_path: Path) -> None:
+    # Rejected here rather than stored and hit at render time, where the failure
+    # is an opaque parse error inside the API on a version that already looks
+    # deployed.
+    root = _built_bundle(tmp_path)
+    (root / "connectors.lock.yaml").write_text(
+        "version: 1\nconnectors:\n  k8s-write:\n    image: [unclosed\n", encoding="utf-8"
+    )
+    result = validate_bundle(root)
+    assert not result.valid
+    assert any(i.code.startswith("connectors.lock") for i in result.errors)
+
+
+def test_a_lock_beside_no_connectors_file_is_still_validated(tmp_path: Path) -> None:
+    # A leftover lock with no connectors.yaml at all is a bundle that lost its
+    # declaration. Ignoring the file entirely would let a malformed one ride
+    # along into the stored artifact unread.
+    root = _bundle(tmp_path, '{"name": "acme-bot", "version": "0.1.0", "description": "t"}')
+    (root / "skills" / "acme-bot").mkdir(parents=True, exist_ok=True)
+    (root / "skills" / "acme-bot" / "SKILL.md").write_text(
+        "---\nname: acme-bot\ndescription: t\n---\nhi\n", encoding="utf-8"
+    )
+    (root / "connectors.lock.yaml").write_text("version: 1\nconnectors: nope\n", encoding="utf-8")
+    result = validate_bundle(root)
+    assert not result.valid
+    assert any(i.code.startswith("connectors.lock") for i in result.errors)
+
+
+def test_a_build_connector_with_a_missing_context_dir_is_refused(tmp_path: Path) -> None:
+    # A declared context that does not exist in the bundle is a malformed
+    # bundle, and it must be refused HERE rather than skipped. Skipping it makes
+    # the lock rules fail open: the staleness recomputation has no tree to hash,
+    # so the lockless and stale refusals silently do not apply, the version is
+    # created, the deployment goes active, and the first thing anyone learns is
+    # a render-time failure on a connector nobody could have built. Refusing at
+    # intake is the same reason every other rule in this file lives here.
+    root = _built_bundle(tmp_path)
+    _write_lock(root)
+    shutil.rmtree(root / "connectors" / "k8s-write")
+
+    result = validate_bundle(root)
+    assert not result.valid
+    issue = next(i for i in result.errors if i.code == "connectors.build_context_missing")
+    assert "k8s-write" in issue.message
+    assert "connectors/k8s-write" in issue.message, "name the path the author declared"
+
+
+def test_the_same_bundle_with_the_context_present_validates(tmp_path: Path) -> None:
+    # The sibling positive, and the thing that stops the refusal above from
+    # being satisfiable by rejecting every build: bundle outright. Identical in
+    # every respect except that the declared directory exists.
+    root = _built_bundle(tmp_path)
+    _write_lock(root)
+    assert (root / "connectors" / "k8s-write").is_dir()
+    result = validate_bundle(root)
+    assert result.valid, [e.code for e in result.errors]
+
+
+def test_a_build_context_symlinked_out_of_the_bundle_is_refused(tmp_path: Path) -> None:
+    # RED before the fix: `connectors.build_context_escapes` is absent from
+    # result.errors and the bundle validates, because intake joined the declared
+    # path onto the root and asked only `is_dir()`. The declaration is textually
+    # clean, so `_escapes` cannot see this, and `safe_extract` guards a different
+    # entry point (an uploaded archive) than the gitflow path, which hands
+    # validate_bundle a real tree.
+    #
+    # What that bought an author: `source_digest_of` hashes whatever tree the
+    # context names, so a symlink makes the pinned digest a function of bytes
+    # outside the bundle -- content no reviewer of this bundle ever saw, and
+    # content that can change under the lock without the lock going stale. The
+    # CLI's `resolve_context` has refused exactly this since day one, so intake
+    # was the more permissive of the two gates on the same rule.
+    root = _built_bundle(tmp_path)
+    _write_lock(root)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "Dockerfile").write_text("FROM scratch\nRUN whoami\n", encoding="utf-8")
+    shutil.rmtree(root / "connectors" / "k8s-write")
+    (root / "connectors" / "k8s-write").symlink_to(outside, target_is_directory=True)
+
+    result = validate_bundle(root)
+    assert not result.valid
+    issue = next(i for i in result.errors if i.code == "connectors.build_context_escapes")
+    assert "k8s-write" in issue.message

--- a/tests/vectors/connector-build-decl.json
+++ b/tests/vectors/connector-build-decl.json
@@ -1,0 +1,312 @@
+{
+  "comment": "Single source of truth for the `build:` connector declaration (ADR 0113), which is read independently by two languages. Python owns it as ConnectorBuild / ConnectorSpec and validate_connectors (packages/plugin-format/src/plugin_format/connectors.py); the Rust CLI owns hand mirrors in cli/src/connector_build.rs because `curie build --plugin-dir` reads the same connectors.yaml before a bundle is ever uploaded, and packages/plugin-format/schema/plugin-format.schema.json carries no Connector* $defs, so the schema driven field-parity gate compares nothing for these structs. This file is the seam instead: changing one language without changing this file fails that language's test. Read by packages/plugin-format/tests/test_connectors.py and by cli/tests/connector_build_decl_vectors.rs. Same mechanism as tests/vectors/approval-action-ids.json. Both lanes reject unknown keys inside a vector, so adding a field here without teaching both lanes fails both.\n\nEach vector carries: `name`, `why`, `document` (the parsed connectors.yaml content, as JSON), `expect` (\"accept\" or \"reject\"), `codes` (the validate_connectors error codes that MUST appear when expect is \"reject\"; empty when expect is \"accept\"), and optionally `resolved_dockerfile` (the Dockerfile path the reader must resolve for the named connector, pinning the default) and `fixture` (a filesystem recipe only the Rust resolver can see). A vector carrying `fixture` is SKIPPED by the Python suite and materialized by the Rust suite: the escape it describes is a symlink, which a pure declaration validator cannot detect and which `curie build` must refuse before docker ever reads the file. `codes` is a subset assertion, never an equality assertion, because validate_connectors accumulates every problem in one pass so an author sees the whole file at once.",
+  "vectors": [
+    {
+      "name": "build_only_connector_is_accepted",
+      "why": "The whole point of ADR 0113: a bundle declares source, not an image reference an operator had to build and paste in by hand.",
+      "document": {
+        "connectors": {
+          "k8s-write": {
+            "build": {
+              "context": "connectors/k8s-write",
+              "dockerfile": "Dockerfile",
+              "platforms": ["linux/amd64", "linux/arm64"]
+            },
+            "env": { "K8S_WRITE_ALLOWLIST": "acme-ns/acme-api" },
+            "secret_files": { "K8S_WRITE_KUBECONFIG": "/secrets/kubeconfig" }
+          }
+        }
+      },
+      "expect": "accept",
+      "codes": [],
+      "resolved_dockerfile": { "k8s-write": "Dockerfile" }
+    },
+    {
+      "name": "dockerfile_defaults_to_Dockerfile",
+      "why": "The common case omits it. A reader that leaves the resolved path empty builds nothing, or builds whatever the daemon's own default happens to be, which is a different file in a different place.",
+      "document": {
+        "connectors": {
+          "tempo": {
+            "build": {
+              "context": "connectors/tempo",
+              "platforms": ["linux/amd64"]
+            }
+          }
+        }
+      },
+      "expect": "accept",
+      "codes": [],
+      "resolved_dockerfile": { "tempo": "Dockerfile" }
+    },
+    {
+      "name": "a_named_dockerfile_inside_the_context_is_accepted",
+      "why": "A context holding two Dockerfiles is legal; only escaping the context is not.",
+      "document": {
+        "connectors": {
+          "tempo": {
+            "build": {
+              "context": "connectors/tempo",
+              "dockerfile": "build/Dockerfile.tempo",
+              "platforms": ["linux/amd64", "linux/arm64"]
+            }
+          }
+        }
+      },
+      "expect": "accept",
+      "codes": [],
+      "resolved_dockerfile": { "tempo": "build/Dockerfile.tempo" }
+    },
+    {
+      "name": "build_and_image_together_are_ambiguous",
+      "why": "Two image sources on one connector. Picking either silently ignores the other, and the one ignored is the one the author edited last.",
+      "document": {
+        "connectors": {
+          "k8s-write": {
+            "image": "ghcr.io/acme-corp/acme-bot-k8s-write-mcp:v1",
+            "build": {
+              "context": "connectors/k8s-write",
+              "platforms": ["linux/amd64"]
+            }
+          }
+        }
+      },
+      "expect": "reject",
+      "codes": ["connectors.ambiguous"]
+    },
+    {
+      "name": "build_and_url_together_are_ambiguous",
+      "why": "`url` says the process is already running elsewhere and `build` says Curie must produce and run it. It is unclear who owns the process, which is the same defect the image/url pair has always been rejected for.",
+      "document": {
+        "connectors": {
+          "k8s-write": {
+            "url": "https://mcp.acme.example.com/mcp",
+            "build": {
+              "context": "connectors/k8s-write",
+              "platforms": ["linux/amd64"]
+            }
+          }
+        }
+      },
+      "expect": "reject",
+      "codes": ["connectors.ambiguous"]
+    },
+    {
+      "name": "none_of_the_three_forms_is_underspecified",
+      "why": "The message must now name all three forms. An author who meant to write `build:` and typed it wrong gets told the form exists.",
+      "document": {
+        "connectors": {
+          "k8s-write": { "secrets": ["K8S_WRITE_TOKEN"] }
+        }
+      },
+      "expect": "reject",
+      "codes": ["connectors.underspecified"]
+    },
+    {
+      "name": "build_with_headers_is_rejected",
+      "why": "SIBLING PATH. `headers` apply to a remote endpoint, and the existing guard keyed off `image`, so a build connector could carry them and be accepted. Armed through the build form only, so reverting the guard to `spec.image and spec.headers` fails this vector while the image form's own test still passes.",
+      "document": {
+        "connectors": {
+          "k8s-write": {
+            "build": {
+              "context": "connectors/k8s-write",
+              "platforms": ["linux/amd64"]
+            },
+            "headers": { "Authorization": "Bearer ${ACME_TOKEN}" }
+          }
+        }
+      },
+      "expect": "reject",
+      "codes": ["connectors.hosted_has_headers"]
+    },
+    {
+      "name": "empty_platforms_is_rejected",
+      "why": "A silently single-arch build is the exact failure ADR 0113 names: it passes every declaration check and fails after apply as `no matching manifest for linux/arm64`.",
+      "document": {
+        "connectors": {
+          "tempo": {
+            "build": { "context": "connectors/tempo", "platforms": [] }
+          }
+        }
+      },
+      "expect": "reject",
+      "codes": ["connectors.build_no_platforms"]
+    },
+    {
+      "name": "a_malformed_platform_string_is_rejected",
+      "why": "`amd64` alone, or a typo like `linux/amd_64`, reaches buildx verbatim and fails there with a message about the daemon rather than about the bundle.",
+      "document": {
+        "connectors": {
+          "tempo": {
+            "build": {
+              "context": "connectors/tempo",
+              "platforms": ["linux/amd64", "nonsense"]
+            }
+          }
+        }
+      },
+      "expect": "reject",
+      "codes": ["connectors.build_bad_platform"]
+    },
+    {
+      "name": "a_variant_qualified_platform_is_accepted",
+      "why": "`linux/arm/v7` is a real OCI platform string. Rejecting it would be a false positive that blocks a legitimate target.",
+      "document": {
+        "connectors": {
+          "tempo": {
+            "build": {
+              "context": "connectors/tempo",
+              "platforms": ["linux/amd64", "linux/arm/v7"]
+            }
+          }
+        }
+      },
+      "expect": "accept",
+      "codes": [],
+      "resolved_dockerfile": { "tempo": "Dockerfile" }
+    },
+    {
+      "name": "an_absolute_context_is_rejected",
+      "why": "ADR 0113 requires the build context be constrained to the extracted bundle without accepting arbitrary host paths. An absolute context makes the operator's own machine the build context.",
+      "document": {
+        "connectors": {
+          "k8s-write": {
+            "build": { "context": "/etc", "platforms": ["linux/amd64"] }
+          }
+        }
+      },
+      "expect": "reject",
+      "codes": ["connectors.build_context_escapes"]
+    },
+    {
+      "name": "a_context_with_a_parent_traversal_is_rejected",
+      "why": "The same escape by relative path. `../..` normalizes outside the bundle root, so a bundle would cause a build to read files that are not part of it.",
+      "document": {
+        "connectors": {
+          "k8s-write": {
+            "build": {
+              "context": "connectors/../../secrets",
+              "platforms": ["linux/amd64"]
+            }
+          }
+        }
+      },
+      "expect": "reject",
+      "codes": ["connectors.build_context_escapes"]
+    },
+    {
+      "name": "an_empty_context_is_rejected",
+      "why": "An empty string normalizes to the bundle root on one reader and to the process working directory on another. Both are wrong and only one is obviously wrong.",
+      "document": {
+        "connectors": {
+          "k8s-write": { "build": { "context": "", "platforms": ["linux/amd64"] } }
+        }
+      },
+      "expect": "reject",
+      "codes": ["connectors.build_context_escapes"]
+    },
+    {
+      "name": "a_dockerfile_with_a_parent_traversal_is_rejected",
+      "why": "A Dockerfile can sit outside its context, so the context check alone does not cover it. `../../../etc/passwd` as a Dockerfile is read by the CLI before packing, which is before every other guard in the pipeline.",
+      "document": {
+        "connectors": {
+          "k8s-write": {
+            "build": {
+              "context": "connectors/k8s-write",
+              "dockerfile": "../../Dockerfile",
+              "platforms": ["linux/amd64"]
+            }
+          }
+        }
+      },
+      "expect": "reject",
+      "codes": ["connectors.build_dockerfile_escapes"]
+    },
+    {
+      "name": "an_absolute_dockerfile_is_rejected",
+      "why": "Same escape, stated absolutely. Both spellings must be refused or the check is decoration.",
+      "document": {
+        "connectors": {
+          "k8s-write": {
+            "build": {
+              "context": "connectors/k8s-write",
+              "dockerfile": "/etc/Dockerfile",
+              "platforms": ["linux/amd64"]
+            }
+          }
+        }
+      },
+      "expect": "reject",
+      "codes": ["connectors.build_dockerfile_escapes"]
+    },
+    {
+      "name": "a_symlinked_dockerfile_leaving_the_context_is_refused",
+      "why": "RUST ONLY, and the reason the Rust resolver canonicalizes rather than only matching text. The declared path is textually clean, so a pure declaration validator accepts it; only a filesystem resolver sees that connectors/k8s-write/Dockerfile is a symlink to a host file. `curie build` reads the Dockerfile BEFORE the bundle is packed, so cli/src/bundle.rs's symlink refusal never runs. resolve_dockerfile must refuse rather than dereference, matching the reason that packer guard exists.",
+      "document": {
+        "connectors": {
+          "k8s-write": {
+            "build": {
+              "context": "connectors/k8s-write",
+              "dockerfile": "Dockerfile",
+              "platforms": ["linux/amd64"]
+            }
+          }
+        }
+      },
+      "expect": "reject",
+      "codes": ["connectors.build_dockerfile_escapes"],
+      "fixture": {
+        "outside_files": { "outside/Dockerfile": "FROM scratch\n" },
+        "bundle_files": { "connectors/k8s-write/server.py": "print('hi')\n" },
+        "bundle_symlinks": { "connectors/k8s-write/Dockerfile": "../../../outside/Dockerfile" }
+      }
+    },
+    {
+      "name": "an_unknown_key_inside_build_is_rejected",
+      "why": "The deny_unknown_fields proof for ConnectorBuild. `target:` is a plausible thing to reach for and Curie models none of it; silently dropping it means a build that produces the wrong stage while reporting success. Removing extra=\"forbid\" on the Python side or #[serde(deny_unknown_fields)] on the Rust side makes this vector pass, which is how the attribute is proved to be what catches it.",
+      "document": {
+        "connectors": {
+          "k8s-write": {
+            "build": {
+              "context": "connectors/k8s-write",
+              "platforms": ["linux/amd64"],
+              "target": "runtime"
+            }
+          }
+        }
+      },
+      "expect": "reject",
+      "codes": ["connectors.invalid"]
+    },
+    {
+      "name": "an_existing_image_connector_is_untouched",
+      "why": "REGRESSION. Every hosted connector bundle in the wild uses this form, and ADR 0113 requires the schema change be compatible. A three-way exclusion written as an if/elif chain is the natural way to break it.",
+      "document": {
+        "connectors": {
+          "grafana": {
+            "image": "ghcr.io/acme-corp/mcp-grafana:0.17.2",
+            "args": ["-t", "streamable-http", "-disable-write"],
+            "env": { "GRAFANA_URL": "https://grafana.example.com" },
+            "secrets": ["GRAFANA_SERVICE_ACCOUNT_TOKEN"]
+          }
+        }
+      },
+      "expect": "accept",
+      "codes": []
+    },
+    {
+      "name": "an_existing_url_connector_is_untouched",
+      "why": "REGRESSION, the other pre-existing form. A remote connector owned by its provider must keep validating exactly as it did before `build:` existed.",
+      "document": {
+        "connectors": {
+          "internal": {
+            "url": "https://mcp.acme.example.com/mcp",
+            "headers": { "Authorization": "Bearer ${INTERNAL_TOKEN}" },
+            "secrets": ["INTERNAL_TOKEN"]
+          }
+        }
+      },
+      "expect": "accept",
+      "codes": []
+    }
+  ]
+}

--- a/tests/vectors/connector-fields.json
+++ b/tests/vectors/connector-fields.json
@@ -1,0 +1,21 @@
+{
+  "comment": "The exact field-name set of every connector model that exists in two languages. Python owns the models in packages/plugin-format/src/plugin_format/connectors.py and connector_lock.py; the Rust CLI hand mirrors them in cli/src/connector_build.rs.\n\nThis file exists because the ordinary field-parity gate cannot see this seam. `curie dev field-parity` compares a Rust struct against packages/plugin-format/schema/plugin-format.schema.json, and schema_export.py imports only from .models, so the committed schema carries no Connector* $defs at all. The connector structs are therefore declared in cli/plugin-format-mirrors.json's non_mirrors array and the field-by-field comparison is a no-op for them today. Without this file, adding a field to the Python ConnectorSpec and touching nothing else leaves every gate green while the Rust reader silently drops it.\n\nThe loop is closed in one direction by each half of the pair. packages/plugin-format/tests/test_connectors.py asserts set(Model.model_fields) equals the list here, so adding a Python field without editing this file fails the Python suite. cli/tests/connector_build_decl_vectors.rs asserts each mirror struct's serde field names equal the same list, so editing this file to make Python pass then fails the Rust suite until the mirror gains the field. Neither half can be satisfied by touching one language.\n\nWhen the follow-up that exports these models into plugin-format.schema.json lands, the non_mirrors entries move to mirrors, `curie dev field-parity` subsumes this file, and it can be deleted. Until then it is the only thing standing.\n\nNames are the model's own field names, not their serialized aliases; both lanes compare against the same list, so a rename in one language fails there. The list for each model is sorted.",
+  "models": {
+    "ConnectorSpec": [
+      "args",
+      "build",
+      "env",
+      "headers",
+      "image",
+      "port",
+      "sealed_secrets",
+      "secret_files",
+      "secrets",
+      "unhosted_url",
+      "url"
+    ],
+    "ConnectorBuild": ["context", "dockerfile", "platforms"],
+    "ConnectorLockFile": ["connectors", "version"],
+    "ConnectorLockEntry": ["delivery", "image", "platforms", "source_digest"]
+  }
+}

--- a/tests/vectors/connector-lock.json
+++ b/tests/vectors/connector-lock.json
@@ -1,0 +1,345 @@
+{
+  "comment": "Single source of truth for connectors.lock.yaml, the per install record of what a bundle's declared connector source resolved to (ADR 0113). Python owns ConnectorLockFile / ConnectorLockEntry, validate_connector_lock and apply_lock in packages/plugin-format/src/plugin_format/connector_lock.py; the Rust CLI owns hand mirrors in cli/src/connector_build.rs because `curie build` writes the file and `curie cluster deploy` preflights it, both before the platform ever sees the bundle. plugin-format.schema.json carries no Connector* $defs, so the schema driven field-parity gate compares nothing here and this file is the seam instead. Read by packages/plugin-format/tests/test_connector_lock.py and by cli/tests/connector_build_decl_vectors.rs.\n\napply_lock is the SINGLE enforcement point for \"the resolved digest is the only identity rendered into a Deployment or used to start the local connector\" (ADR 0113). It returns a derived ConnectorsFile in which each build: connector's image is the locked digest and its build is cleared, so every downstream reader (render, mcp_entry, is_hosted, the worker reconciler's plan) works unchanged against an ordinary image: spec.\n\nAn image reference is well formed in exactly two shapes and nothing else: `<repo>@sha256:<64 lowercase hex>` for delivery `registry`, which is the OCI content-addressable manifest digest form documented at https://github.com/opencontainers/distribution-spec/blob/main/spec.md#pulling-manifests, and a bare `sha256:<64 lowercase hex>` for delivery `local-daemon`, which is the image ID `docker image inspect --format {{.Id}}` reports for a locally built image. Anything else, a tag included, is refused: a tag can be repointed after review, which is the mutable-tag failure this platform has already hit.\n\nEach vector carries: `name`, `why`, `connectors` (the connectors.yaml content), `lock` (the connectors.lock.yaml content), `portable` (the apply_lock keyword; only the cluster deploy preflight passes true), `expect` (\"apply\", \"raise\" or \"invalid\"), and on \"apply\" a `resolved` map of connector name to the image every downstream reader must then see. \"raise\" means validate_connector_lock accepts the document but apply_lock refuses it. \"invalid\" means the document does not survive validate_connector_lock at all, so it is rejected at bundle intake rather than at render time; `codes` names the reported error codes, all of which are namespaced under `connectors.lock`. Both lanes reject unknown keys inside a vector.",
+  "vectors": [
+    {
+      "name": "a_registry_entry_resolves_the_declaration_to_its_digest",
+      "why": "The ordinary cluster path. After apply_lock the spec is indistinguishable from a hand authored image: connector, which is what lets render, mcp_entry and the reconciler stay unchanged.",
+      "connectors": {
+        "connectors": {
+          "k8s-write": {
+            "build": {
+              "context": "connectors/k8s-write",
+              "platforms": ["linux/amd64", "linux/arm64"]
+            },
+            "env": { "K8S_WRITE_ALLOWLIST": "acme-ns/acme-api" }
+          }
+        }
+      },
+      "lock": {
+        "version": 1,
+        "connectors": {
+          "k8s-write": {
+            "image": "ghcr.io/acme-corp/acme-bot-k8s-write-mcp@sha256:0000000000000000000000000000000000000000000000000000000000000000",
+            "delivery": "registry",
+            "platforms": ["linux/amd64", "linux/arm64"],
+            "source_digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+          }
+        }
+      },
+      "portable": true,
+      "expect": "apply",
+      "resolved": {
+        "k8s-write": "ghcr.io/acme-corp/acme-bot-k8s-write-mcp@sha256:0000000000000000000000000000000000000000000000000000000000000000"
+      }
+    },
+    {
+      "name": "a_local_daemon_entry_applies_when_portability_is_not_required",
+      "why": "The dev fast path. A local tier version is a legitimate stored artifact and rendering its manifests is harmless because nothing applies them at local tier, so the API render path passes portable=false. Refusing here is what broke every `curie local deploy` in an earlier draft.",
+      "connectors": {
+        "connectors": {
+          "tempo": {
+            "build": { "context": "connectors/tempo", "platforms": ["linux/amd64"] }
+          }
+        }
+      },
+      "lock": {
+        "version": 1,
+        "connectors": {
+          "tempo": {
+            "image": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+            "delivery": "local-daemon",
+            "platforms": ["linux/amd64"],
+            "source_digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+          }
+        }
+      },
+      "portable": false,
+      "expect": "apply",
+      "resolved": {
+        "tempo": "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+      }
+    },
+    {
+      "name": "a_local_daemon_entry_is_refused_where_portability_is_required",
+      "why": "A local image id names nothing a Kubernetes node can pull. Applying it produces an ImagePullBackOff on every node, long after the deploy reported success. The refusal belongs to the cluster path only, which is the sole caller passing portable=true.",
+      "connectors": {
+        "connectors": {
+          "tempo": {
+            "build": { "context": "connectors/tempo", "platforms": ["linux/amd64"] }
+          }
+        }
+      },
+      "lock": {
+        "version": 1,
+        "connectors": {
+          "tempo": {
+            "image": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+            "delivery": "local-daemon",
+            "platforms": ["linux/amd64"],
+            "source_digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+          }
+        }
+      },
+      "portable": true,
+      "expect": "raise"
+    },
+    {
+      "name": "a_tag_shaped_image_is_refused",
+      "why": "The mutable-tag failure mode ADR 0113 exists to close: a tag can be repointed at a different artifact after review and between tier runs. This is the outcome test for \"the renderer and applier never deploy a mutable connector tag\", and it must refuse even though the reference is otherwise perfectly well formed.",
+      "connectors": {
+        "connectors": {
+          "k8s-write": {
+            "build": {
+              "context": "connectors/k8s-write",
+              "platforms": ["linux/amd64"]
+            }
+          }
+        }
+      },
+      "lock": {
+        "version": 1,
+        "connectors": {
+          "k8s-write": {
+            "image": "ghcr.io/acme-corp/acme-bot-k8s-write-mcp:v1",
+            "delivery": "registry",
+            "platforms": ["linux/amd64"],
+            "source_digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+          }
+        }
+      },
+      "portable": true,
+      "expect": "raise"
+    },
+    {
+      "name": "a_truncated_digest_is_refused",
+      "why": "A digest that is the right shape but the wrong length resolves to nothing. Accepting it means the refusal is a substring check for `@sha256:` rather than a check of the digest itself, which a hand edited lock trips immediately.",
+      "connectors": {
+        "connectors": {
+          "k8s-write": {
+            "build": {
+              "context": "connectors/k8s-write",
+              "platforms": ["linux/amd64"]
+            }
+          }
+        }
+      },
+      "lock": {
+        "version": 1,
+        "connectors": {
+          "k8s-write": {
+            "image": "ghcr.io/acme-corp/acme-bot-k8s-write-mcp@sha256:0000",
+            "delivery": "registry",
+            "platforms": ["linux/amd64"],
+            "source_digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+          }
+        }
+      },
+      "portable": true,
+      "expect": "raise"
+    },
+    {
+      "name": "an_uppercase_digest_is_refused",
+      "why": "An OCI digest is lowercase hex by specification, and two spellings of one digest would compare unequal everywhere the lock is checked for staleness or matched against a registry manifest.",
+      "connectors": {
+        "connectors": {
+          "k8s-write": {
+            "build": {
+              "context": "connectors/k8s-write",
+              "platforms": ["linux/amd64"]
+            }
+          }
+        }
+      },
+      "lock": {
+        "version": 1,
+        "connectors": {
+          "k8s-write": {
+            "image": "ghcr.io/acme-corp/acme-bot-k8s-write-mcp@sha256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            "delivery": "registry",
+            "platforms": ["linux/amd64"],
+            "source_digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+          }
+        }
+      },
+      "portable": true,
+      "expect": "raise"
+    },
+    {
+      "name": "a_bare_digest_is_refused_for_registry_delivery",
+      "why": "A local image id carries no repository, so nothing can pull it. Delivery and image shape must agree or the two fields are decoration.",
+      "connectors": {
+        "connectors": {
+          "k8s-write": {
+            "build": {
+              "context": "connectors/k8s-write",
+              "platforms": ["linux/amd64"]
+            }
+          }
+        }
+      },
+      "lock": {
+        "version": 1,
+        "connectors": {
+          "k8s-write": {
+            "image": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+            "delivery": "registry",
+            "platforms": ["linux/amd64"],
+            "source_digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+          }
+        }
+      },
+      "portable": true,
+      "expect": "raise"
+    },
+    {
+      "name": "a_declared_build_connector_with_no_lock_entry_is_refused",
+      "why": "Without this the derived spec keeps image None and render_deployment emits `image: null`, which applies as an invalid Deployment and surfaces as an opaque Kubernetes error far from the cause.",
+      "connectors": {
+        "connectors": {
+          "k8s-write": {
+            "build": {
+              "context": "connectors/k8s-write",
+              "platforms": ["linux/amd64"]
+            }
+          },
+          "tempo": {
+            "build": { "context": "connectors/tempo", "platforms": ["linux/amd64"] }
+          }
+        }
+      },
+      "lock": {
+        "version": 1,
+        "connectors": {
+          "k8s-write": {
+            "image": "ghcr.io/acme-corp/acme-bot-k8s-write-mcp@sha256:0000000000000000000000000000000000000000000000000000000000000000",
+            "delivery": "registry",
+            "platforms": ["linux/amd64"],
+            "source_digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+          }
+        }
+      },
+      "portable": true,
+      "expect": "raise"
+    },
+    {
+      "name": "an_image_connector_is_carried_through_untouched",
+      "why": "REGRESSION. apply_lock runs on every version the API renders, including the bundles in the wild that declare no build at all. A lock entry is not required for them and their image must survive byte identical.",
+      "connectors": {
+        "connectors": {
+          "grafana": {
+            "image": "ghcr.io/acme-corp/mcp-grafana:0.17.2",
+            "args": ["-t", "streamable-http", "-disable-write"]
+          }
+        }
+      },
+      "lock": null,
+      "portable": true,
+      "expect": "apply",
+      "resolved": { "grafana": "ghcr.io/acme-corp/mcp-grafana:0.17.2" }
+    },
+    {
+      "name": "a_url_connector_survives_a_lock_that_does_not_mention_it",
+      "why": "REGRESSION for the remote form. A bundle mixing a built connector and a provider owned endpoint must keep the endpoint exactly as declared; only the built one is rewritten.",
+      "connectors": {
+        "connectors": {
+          "internal": { "url": "https://mcp.acme.example.com/mcp" },
+          "tempo": {
+            "build": { "context": "connectors/tempo", "platforms": ["linux/amd64"] }
+          }
+        }
+      },
+      "lock": {
+        "version": 1,
+        "connectors": {
+          "tempo": {
+            "image": "ghcr.io/acme-corp/acme-bot-tempo-mcp@sha256:0000000000000000000000000000000000000000000000000000000000000000",
+            "delivery": "registry",
+            "platforms": ["linux/amd64"],
+            "source_digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+          }
+        }
+      },
+      "portable": true,
+      "expect": "apply",
+      "resolved": {
+        "tempo": "ghcr.io/acme-corp/acme-bot-tempo-mcp@sha256:0000000000000000000000000000000000000000000000000000000000000000"
+      }
+    },
+    {
+      "name": "an_unknown_key_in_a_lock_entry_is_rejected_at_intake",
+      "why": "The deny_unknown_fields proof for the lock. `digest:` is a plausible thing to reach for beside `image:`; silently dropping it means an operator believes they pinned something they did not. Rejected by validate_connector_lock, so a malformed lock never reaches apply_lock.",
+      "connectors": {
+        "connectors": {
+          "tempo": {
+            "build": { "context": "connectors/tempo", "platforms": ["linux/amd64"] }
+          }
+        }
+      },
+      "lock": {
+        "version": 1,
+        "connectors": {
+          "tempo": {
+            "image": "ghcr.io/acme-corp/acme-bot-tempo-mcp@sha256:0000000000000000000000000000000000000000000000000000000000000000",
+            "delivery": "registry",
+            "platforms": ["linux/amd64"],
+            "source_digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+            "digest": "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+          }
+        }
+      },
+      "portable": true,
+      "expect": "invalid",
+      "codes": ["connectors.lock_invalid"]
+    },
+    {
+      "name": "an_unknown_delivery_is_rejected_at_intake",
+      "why": "Delivery is control bearing: it decides whether the cluster preflight refuses. An unmodelled value must be refused loudly rather than degraded to a default, the same rule ADR 0036 sets for control bearing enums.",
+      "connectors": {
+        "connectors": {
+          "tempo": {
+            "build": { "context": "connectors/tempo", "platforms": ["linux/amd64"] }
+          }
+        }
+      },
+      "lock": {
+        "version": 1,
+        "connectors": {
+          "tempo": {
+            "image": "ghcr.io/acme-corp/acme-bot-tempo-mcp@sha256:0000000000000000000000000000000000000000000000000000000000000000",
+            "delivery": "node-import",
+            "platforms": ["linux/amd64"],
+            "source_digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+          }
+        }
+      },
+      "portable": true,
+      "expect": "invalid",
+      "codes": ["connectors.lock_invalid"]
+    },
+    {
+      "name": "an_unknown_lock_version_is_rejected_at_intake",
+      "why": "The version field is the only thing that lets a future shape change be refused by an older reader instead of silently misread. A reader that ignores it makes the field decoration.",
+      "connectors": {
+        "connectors": {
+          "tempo": {
+            "build": { "context": "connectors/tempo", "platforms": ["linux/amd64"] }
+          }
+        }
+      },
+      "lock": {
+        "version": 2,
+        "connectors": {
+          "tempo": {
+            "image": "ghcr.io/acme-corp/acme-bot-tempo-mcp@sha256:0000000000000000000000000000000000000000000000000000000000000000",
+            "delivery": "registry",
+            "platforms": ["linux/amd64"],
+            "source_digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+          }
+        }
+      },
+      "portable": true,
+      "expect": "invalid",
+      "codes": ["connectors.lock_unsupported_version"]
+    }
+  ]
+}

--- a/tests/vectors/connector-service-dns.json
+++ b/tests/vectors/connector-service-dns.json
@@ -1,0 +1,65 @@
+{
+  "comment": "Single source of truth for the connector object-name and Service-DNS derivation, which exists independently in two languages. Python owns it as connector_render.object_name / connector_render.service_dns (packages/plugin-format/src/plugin_format/connector_render.py); the Rust CLI owns a hand port because the same string is the Docker network alias a skill-tier and local-tier connector container is started under (ADR 0113), and the runner derives the URL it dials from the Python side. A mismatch leaves the runner dialing a DNS name no container owns, which surfaces as a connection timeout with nothing logged on either end. The two lanes cannot share code, so the derivation is frozen here: changing one language without changing this file fails that language's test. Read by packages/plugin-format/tests/test_connector_render.py and by the Rust alias test in cli/tests/connector_build_decl_vectors.rs. Same mechanism as tests/vectors/approval-action-ids.json. Both lanes reject unknown keys, so adding a field here without teaching both lanes fails both: a key one lane cannot see would otherwise pass vacuously. The corpus deliberately includes an over-63-character base name, two over-long names sharing their first 54 characters, and a truncation boundary that lands on a dash, because those are the three branches a hand port gets wrong.",
+  "vectors": [
+    {
+      "name": "short_name_is_used_verbatim",
+      "why": "A base name inside the 63 character DNS label limit is emitted unchanged, so the ordinary case pins the plain concatenation order release-agent-mcp-connector.",
+      "release": "acme-rel",
+      "agent": "acme-bot",
+      "connector": "tempo",
+      "namespace": "acme-ns",
+      "object_name": "acme-rel-acme-bot-mcp-tempo",
+      "service_dns": "acme-rel-acme-bot-mcp-tempo.acme-ns.svc.cluster.local"
+    },
+    {
+      "name": "agent_scoping_keeps_two_agents_apart",
+      "why": "Same release, same connector, different agent. Release scoped naming made these identical and one agent's Deployment silently overwrote the other's (#1116), so the two derivations must stay distinct in both languages.",
+      "release": "acme-rel",
+      "agent": "sre-prod",
+      "connector": "tempo",
+      "namespace": "acme-ns",
+      "object_name": "acme-rel-sre-prod-mcp-tempo",
+      "service_dns": "acme-rel-sre-prod-mcp-tempo.acme-ns.svc.cluster.local"
+    },
+    {
+      "name": "namespace_only_reaches_the_dns_suffix",
+      "why": "The namespace is not part of the object name; it appears only after the first dot. A port that folded it into the object name would still produce a plausible looking string.",
+      "release": "acme-rel",
+      "agent": "acme-bot",
+      "connector": "tempo",
+      "namespace": "acme-other-ns",
+      "object_name": "acme-rel-acme-bot-mcp-tempo",
+      "service_dns": "acme-rel-acme-bot-mcp-tempo.acme-other-ns.svc.cluster.local"
+    },
+    {
+      "name": "long_name_truncates_with_a_digest",
+      "why": "Base name is 80 characters, over the 63 character limit, so the truncation-with-digest branch runs. This is the branch a hand port is most likely to get wrong.",
+      "release": "acme-corp-platform-release",
+      "agent": "site-reliability-engineering-bot",
+      "connector": "kubernetes-write",
+      "namespace": "acme-ns",
+      "object_name": "acme-corp-platform-release-site-reliability-engineerin-a33177ed",
+      "service_dns": "acme-corp-platform-release-site-reliability-engineerin-a33177ed.acme-ns.svc.cluster.local"
+    },
+    {
+      "name": "long_names_sharing_a_prefix_stay_distinct",
+      "why": "Two over-long names whose first 54 characters are identical. Clipping alone would map both onto one object name, which is the collision the digest suffix exists to prevent.",
+      "release": "acme-corp-platform-release",
+      "agent": "site-reliability-engineering-bot",
+      "connector": "kubernetes-write-two",
+      "namespace": "acme-ns",
+      "object_name": "acme-corp-platform-release-site-reliability-engineerin-6ed3033d",
+      "service_dns": "acme-corp-platform-release-site-reliability-engineerin-6ed3033d.acme-ns.svc.cluster.local"
+    },
+    {
+      "name": "truncation_strips_a_trailing_dash",
+      "why": "The 54 character prefix of this base ends in a dash. A DNS label may not contain two adjacent dashes at that position and may not end in one, so the truncated prefix is right-stripped before the digest is appended. Omitting the strip yields a double dash and a name Kubernetes rejects at apply.",
+      "release": "acme-corp-platform-release",
+      "agent": "platform-observability-bot",
+      "connector": "kubernetes-write",
+      "namespace": "acme-ns",
+      "object_name": "acme-corp-platform-release-platform-observability-bot-396096ee",
+      "service_dns": "acme-corp-platform-release-platform-observability-bot-396096ee.acme-ns.svc.cluster.local"
+    }
+  ]
+}

--- a/tests/vectors/connector-source-digest.json
+++ b/tests/vectors/connector-source-digest.json
@@ -1,0 +1,548 @@
+{
+  "comment": "Single source of truth for source_digest, the content derived identity of a connector's build input (ADR 0113). Python owns it as connector_lock.source_digest_of, which the bundle validator calls to recompute the digest from an already extracted tree and refuse a stale lock; the Rust CLI ports it because `curie build` computes the same value before writing the lock. The two cannot share code, so the algorithm is frozen here as a corpus of small trees with their expected digests: a lane that computes anything else fails its own suite.\n\nTHE ALGORITHM, stated completely, because a vector corpus alone cannot say why two readers disagree.\n  stream = b\"\"\n  for each included file, ordered by the bytewise ascending order of its UTF-8 encoded POSIX relative path:\n      stream += relpath (UTF-8) + b\"\\0\" + lowercase hex sha256 of the file's bytes (ASCII) + b\"\\0\" + b\"1\" if the file is executable by its owner else b\"0\" + b\"\\n\"\n  stream += b\"build\\0\" + canonical JSON of the build block (UTF-8) + b\"\\n\"\n  source_digest = \"sha256:\" + lowercase hex sha256 of stream\nThe build block is {context, dockerfile, platforms} with dockerfile already defaulted to \"Dockerfile\" and platforms in DECLARED order, serialized with sorted keys, no whitespace between tokens, and no non-ASCII escaping.\n\nTHE EXECUTABLE BIT is the third field of every per-file record, and it is exactly one bit: is the file executable by its OWNER (POSIX mode & 0o100), written as ASCII 1 or 0. Docker's build context tar carries each file's mode and BuildKit keys its cache on it, so `chmod +x entrypoint.sh` with no byte changed is a different build input producing a different image. A digest blind to it leaves the lock looking fresh while a stale image deploys. Only the owner bit is read, not the group or other bits and not the rest of the mode: those do not survive uniformly into an image layer, and hashing them would report a source changed on a machine with a different umask. Off-unix, where there is no owner execute bit to read, every file hashes as 0 -- the same normalization docker itself applies on Windows.\n\nINCLUDED FILES are every regular file at any depth under the canonicalized context, EXCEPT the generated connectors.lock.yaml, and any path excluded by the context's own .dockerignore. The lock exclusion is exactly one path under exactly one condition: `connectors.lock.yaml` at the TOP of the context, and only when the declared `build.context` names the BUNDLE ROOT. That condition is decided from the declaration, never from the tree: normalize the declared context by stripping a trailing `/`, and it is the bundle root when what remains is `.` or the empty string. `curie build` writes the generated lock at the bundle root and nowhere else, so that is the only place a `connectors.lock.yaml` can be the file the digest is being recorded into; excluding it there is what stops writing the lock from invalidating the digest it records. Everywhere else a file of that name is ORDINARY BUILD INPUT and is hashed: at the top of a subdirectory context (the common case, `context: connectors/tempo`), because `curie build` never wrote it there and the daemon receives it like any other authored file; and nested deeper under any context, for the same reason. Excluding by basename at any depth, or excluding at the context root whatever the declared context is, both let an edit to real source leave the digest unmoved -- a stale lock passing review. A symlink is never followed and never hashed; the context resolver refuses one before hashing begins, on both sides (`connector_lock.resolve_context` and `cli/src/connector_build.rs`'s `resolve_context`), so a symlinked context cannot steer the digest with bytes outside the bundle.\n\n.dockerignore is Docker's own exclusion set, so honoring it means the digest covers exactly what the daemon receives (https://docs.docker.com/build/concepts/context/#dockerignore-files). .curieignore is a different question, governing bundle packing, and is NOT consulted. Blank lines and lines whose first non-space character is # are skipped; every other line is stripped and matched against the file's POSIX relative path and against each of its ancestor directory paths, segment by segment, so * and ? never cross a / and a pattern naming a directory excludes everything beneath it. That is Go filepath.Match, the matcher Docker's own client uses.\n\nTHE RULE SET IS ORDERED, and this is where a naive port goes wrong. A line beginning with ! is a re-include, its ! stripped and the remainder used verbatim (a bare ! names nothing and is skipped). EVERY rule is evaluated against every candidate path and the LAST one that matches decides: a later ! re-includes what an earlier pattern excluded, and a later pattern excludes what an earlier ! re-included. A reader that returns on the first matching exclusion, or that has no ! at all, breaks the digest's one property in both directions -- `*.log` plus `!keep.log` ships keep.log to the daemon while hashing nothing of it, so editing keep.log leaves a stale lock looking current; and `*` alone excludes the entire tree, so the digest is a constant and the lock can NEVER go stale. A directory is therefore never pruned during the walk either: a ! can re-include a file beneath an excluded directory, exactly as Docker descends whenever the ignore set carries any exclusion. Finally, two rules are appended after the file's own, mirroring the docker CLI's TrimBuildFilesFromExcludes: if the patterns would exclude `.dockerignore` or the declared dockerfile, `!` that path back in, because the daemon receives those two whatever the patterns say. .dockerignore itself IS hashed: changing the exclusion set changes what gets built.\n\nCONTENT AND ONE MODE BIT, NOTHING ELSE. No mtime, uid or gid, and of the mode only the owner execute bit above -- deliberately unlike cli/src/bundle.rs's archive digest, which documents at cli/src/bundle.rs:181-184 that it embeds all three because it identifies an ARCHIVE and not a source tree. Reusing that computation here would report every fresh checkout as a changed source. The two-directories-same-content-different-mtimes proof lives in the CLI suite, since a JSON corpus cannot express a timestamp.\n\nEach vector carries `name`, `why`, `tree` (POSIX relative path to file, materialized verbatim by both suites), `build` (the declared build block), and `source_digest`. A `tree` VALUE is either a string, which is the file's content with no execute bit, or an object {\"content\": \"...\", \"executable\": true}, which is the same content materialized with the owner execute bit set. Both suites' materializers honor the object form; a suite that read only the string form would materialize the executable vectors non-executable and compute a digest the corpus does not carry. `relations` then names the pairs whose digests must be equal and the pairs that must differ, which is where the exclusion and build-block rules are actually falsified: a reader that ignores .dockerignore still passes every single-vector assertion by recording whatever it computes, but cannot satisfy both halves of a relation. Read by packages/plugin-format/tests/test_connector_lock.py and by cli/tests/connector_build_decl_vectors.rs.",
+  "vectors": [
+    {
+      "name": "single_file_context",
+      "why": "The minimum tree. Pins the per file record layout (relative path, NUL, lowercase hex sha256 of the content, NUL, the ASCII owner-execute bit, newline) and the trailing build block record, with nothing else in the stream to hide an ordering mistake.",
+      "tree": {
+        "Dockerfile": "FROM scratch\nCOPY server.py /server.py\n"
+      },
+      "build": {
+        "context": "connectors/tempo",
+        "dockerfile": "Dockerfile",
+        "platforms": [
+          "linux/amd64"
+        ]
+      },
+      "source_digest": "sha256:b0d3efedb7c89e479095b9e9893b22f964f171f831e9b0813d1515a46a911f77"
+    },
+    {
+      "name": "nested_tree_is_walked_in_sorted_path_order",
+      "why": "Files at three depths whose sorted order differs from any natural filesystem walk order. A reader that walks directories depth first, or sorts basenames rather than full relative paths, produces a different stream and therefore a different digest on the same source.",
+      "tree": {
+        "Dockerfile": "FROM scratch\n",
+        "server.py": "print('acme')\n",
+        "lib/a.py": "A = 1\n",
+        "lib/inner/b.py": "B = 2\n",
+        "README.md": "acme tempo connector\n"
+      },
+      "build": {
+        "context": "connectors/tempo",
+        "dockerfile": "Dockerfile",
+        "platforms": [
+          "linux/amd64"
+        ]
+      },
+      "source_digest": "sha256:bed90b9da771703347cdd0f06f99174036045629886fdf63b54fe66170228790"
+    },
+    {
+      "name": "dockerignore_excludes_a_matching_file",
+      "why": "The context the daemon receives is the context minus what .dockerignore names, so the digest must cover exactly that. Hashing an ignored file makes every build report itself stale after a log rotates.",
+      "tree": {
+        "Dockerfile": "FROM scratch\n",
+        ".dockerignore": "# scratch output, never part of the image\n*.log\n",
+        "server.py": "print('acme')\n",
+        "debug.log": "first run\n"
+      },
+      "build": {
+        "context": "connectors/tempo",
+        "dockerfile": "Dockerfile",
+        "platforms": [
+          "linux/amd64"
+        ]
+      },
+      "source_digest": "sha256:b6a919e33ab673f96b7b7d88f0569d5d6f44024e2769d4d1c369ef632747f91b"
+    },
+    {
+      "name": "an_ignored_files_content_does_not_move_the_digest",
+      "why": "Same tree as dockerignore_excludes_a_matching_file with the ignored file's content changed. The digest must be identical: this is the pair that proves the exclusion is real rather than the pattern list merely being parsed.",
+      "tree": {
+        "Dockerfile": "FROM scratch\n",
+        ".dockerignore": "# scratch output, never part of the image\n*.log\n",
+        "server.py": "print('acme')\n",
+        "debug.log": "second run, different bytes entirely\n"
+      },
+      "build": {
+        "context": "connectors/tempo",
+        "dockerfile": "Dockerfile",
+        "platforms": [
+          "linux/amd64"
+        ]
+      },
+      "source_digest": "sha256:b6a919e33ab673f96b7b7d88f0569d5d6f44024e2769d4d1c369ef632747f91b"
+    },
+    {
+      "name": "editing_dockerignore_moves_the_digest",
+      "why": "Same files, one more exclusion pattern. .dockerignore is itself hashed, and it must be: adding a pattern changes what the daemon builds, so a digest that ignored the file would report an unchanged source for a materially different image.",
+      "tree": {
+        "Dockerfile": "FROM scratch\n",
+        ".dockerignore": "# scratch output, never part of the image\n*.log\nREADME.md\n",
+        "server.py": "print('acme')\n",
+        "debug.log": "first run\n"
+      },
+      "build": {
+        "context": "connectors/tempo",
+        "dockerfile": "Dockerfile",
+        "platforms": [
+          "linux/amd64"
+        ]
+      },
+      "source_digest": "sha256:0db7365347781cd8a32b3249e03fea8caf350ce21da83386d625c8e9a2db696f"
+    },
+    {
+      "name": "dockerignore_excludes_a_whole_directory",
+      "why": "A pattern naming a directory excludes everything beneath it, matched against each ancestor path. A reader that only compares the pattern against the full relative path leaves the directory's contents in the digest.",
+      "tree": {
+        "Dockerfile": "FROM scratch\n",
+        ".dockerignore": "scratch\n",
+        "server.py": "print('acme')\n",
+        "scratch/tmp.txt": "throwaway\n",
+        "scratch/deep/tmp2.txt": "throwaway\n"
+      },
+      "build": {
+        "context": "connectors/tempo",
+        "dockerfile": "Dockerfile",
+        "platforms": [
+          "linux/amd64"
+        ]
+      },
+      "source_digest": "sha256:c62eba33187d2ae6f11d7b790359c9237caaf65c1ab9ed973fbb304ffabf0c17"
+    },
+    {
+      "name": "a_negation_reincludes_what_an_earlier_pattern_excluded",
+      "why": "`*.log` then `!keep.log`, the ordering rule stated as a tree. Docker sends keep.log to the daemon because the LAST matching rule wins, so the digest must cover it. A reader that returns on the first matching exclusion, or that never implements `!`, drops keep.log and computes something else here.",
+      "tree": {
+        "Dockerfile": "FROM scratch\n",
+        ".dockerignore": "*.log\n!keep.log\n",
+        "server.py": "print('acme')\n",
+        "debug.log": "first run\n",
+        "keep.log": "kept\n"
+      },
+      "build": {
+        "context": "connectors/tempo",
+        "dockerfile": "Dockerfile",
+        "platforms": [
+          "linux/amd64"
+        ]
+      },
+      "source_digest": "sha256:18a8a5e047469e33dea44abe28b85fc4383c03adf0645893a37581dc446c523a"
+    },
+    {
+      "name": "editing_a_reincluded_file_moves_the_digest",
+      "why": "The same tree with the re-included keep.log edited. Its bytes are in the image, so the digest must move; a first-match-wins reader excludes the file and reports the source unchanged, which is a stale lock passing review.",
+      "tree": {
+        "Dockerfile": "FROM scratch\n",
+        ".dockerignore": "*.log\n!keep.log\n",
+        "server.py": "print('acme')\n",
+        "debug.log": "first run\n",
+        "keep.log": "kept, then edited\n"
+      },
+      "build": {
+        "context": "connectors/tempo",
+        "dockerfile": "Dockerfile",
+        "platforms": [
+          "linux/amd64"
+        ]
+      },
+      "source_digest": "sha256:758f094c3e477a83f1d1a3a36281d88a2685afddedaf7e94a41d0d07b79b084d"
+    },
+    {
+      "name": "a_still_ignored_file_beside_a_negation_does_not_move_the_digest",
+      "why": "The other half of the ordering rule: `!keep.log` re-includes exactly one path and leaves `*.log` governing every other log. debug.log's bytes must stay out. A reader that treats any `!` as switching the whole set off passes the pair above and fails here.",
+      "tree": {
+        "Dockerfile": "FROM scratch\n",
+        ".dockerignore": "*.log\n!keep.log\n",
+        "server.py": "print('acme')\n",
+        "debug.log": "second run, different bytes entirely\n",
+        "keep.log": "kept\n"
+      },
+      "build": {
+        "context": "connectors/tempo",
+        "dockerfile": "Dockerfile",
+        "platforms": [
+          "linux/amd64"
+        ]
+      },
+      "source_digest": "sha256:18a8a5e047469e33dea44abe28b85fc4383c03adf0645893a37581dc446c523a"
+    },
+    {
+      "name": "a_negation_reaches_beneath_an_excluded_directory",
+      "why": "`scratch` excludes the directory and `!scratch/keep.txt` puts one file back, which Docker honors by descending into an excluded directory whenever the ignore set carries any exclusion. A walk that PRUNES an excluded directory never sees keep.txt and cannot re-include it, which is the shape the Rust port had.",
+      "tree": {
+        "Dockerfile": "FROM scratch\nCOPY scratch/keep.txt /keep.txt\n",
+        ".dockerignore": "scratch\n!scratch/keep.txt\n",
+        "server.py": "print('acme')\n",
+        "scratch/keep.txt": "kept\n",
+        "scratch/tmp.txt": "throwaway\n"
+      },
+      "build": {
+        "context": "connectors/tempo",
+        "dockerfile": "Dockerfile",
+        "platforms": [
+          "linux/amd64"
+        ]
+      },
+      "source_digest": "sha256:9988fccabef3c1680c6a7a2e014785f271c7ee7622cb9c517dc163df33aac88b"
+    },
+    {
+      "name": "editing_a_file_reincluded_beneath_an_excluded_directory_moves_the_digest",
+      "why": "The same tree with the re-included file edited. Its bytes are copied into the image, so the digest must move; a pruning walk reports the source unchanged. scratch/tmp.txt stays excluded in both, so the pair isolates the re-inclusion.",
+      "tree": {
+        "Dockerfile": "FROM scratch\nCOPY scratch/keep.txt /keep.txt\n",
+        ".dockerignore": "scratch\n!scratch/keep.txt\n",
+        "server.py": "print('acme')\n",
+        "scratch/keep.txt": "kept, then edited\n",
+        "scratch/tmp.txt": "throwaway\n"
+      },
+      "build": {
+        "context": "connectors/tempo",
+        "dockerfile": "Dockerfile",
+        "platforms": [
+          "linux/amd64"
+        ]
+      },
+      "source_digest": "sha256:276b2417e9d1fea606bcfe7f0f3a5f2b565a9029f2bbbbf63106c73b94e2a5bd"
+    },
+    {
+      "name": "a_star_ignore_still_covers_the_build_files",
+      "why": "`*` excludes the whole tree, and the docker CLI puts the Dockerfile and .dockerignore back before sending the context, so those two are exactly what the digest covers. Without that rule the digest is a CONSTANT for every `*`-ignoring bundle: the lock can never go stale, and a Dockerfile rewrite deploys under the digest reviewers approved for the old one.",
+      "tree": {
+        "Dockerfile": "FROM scratch\nCOPY server.py /server.py\n",
+        ".dockerignore": "*\n",
+        "server.py": "print('acme')\n",
+        "notes.md": "scratch notes\n"
+      },
+      "build": {
+        "context": "connectors/tempo",
+        "dockerfile": "Dockerfile",
+        "platforms": [
+          "linux/amd64"
+        ]
+      },
+      "source_digest": "sha256:b2f97cb3fb2edb9f045b550a7ec630e312f1e4a511e3dbca4a33f1308b8d9640"
+    },
+    {
+      "name": "editing_the_dockerfile_under_a_star_ignore_moves_the_digest",
+      "why": "The same `*`-ignoring tree with the Dockerfile rewritten to run as a different user. That is a materially different image from the same declaration, so the digest must move.",
+      "tree": {
+        "Dockerfile": "FROM scratch\nUSER 65532\nCOPY server.py /server.py\n",
+        ".dockerignore": "*\n",
+        "server.py": "print('acme')\n",
+        "notes.md": "scratch notes\n"
+      },
+      "build": {
+        "context": "connectors/tempo",
+        "dockerfile": "Dockerfile",
+        "platforms": [
+          "linux/amd64"
+        ]
+      },
+      "source_digest": "sha256:e67fc21201027e29037fe591e748f98bf8d36783d41853ac1b9d06d354ebc978"
+    },
+    {
+      "name": "a_nested_lock_file_is_ordinary_build_input",
+      "why": "The bundle root carries the generated connectors.lock.yaml, excluded; fixtures/connectors.lock.yaml is a source file that happens to share the name, and the daemon receives it like any other. Excluding by BASENAME at any depth drops it from the digest.",
+      "tree": {
+        "Dockerfile": "FROM scratch\nCOPY fixtures /fixtures\n",
+        "server.py": "print('acme')\n",
+        "connectors.lock.yaml": "version: 1\nconnectors:\n  tempo:\n    image: sha256:1111111111111111111111111111111111111111111111111111111111111111\n",
+        "fixtures/connectors.lock.yaml": "version: 1\nconnectors: {}\n"
+      },
+      "build": {
+        "context": ".",
+        "dockerfile": "Dockerfile",
+        "platforms": [
+          "linux/amd64"
+        ]
+      },
+      "source_digest": "sha256:c0f1eed228d555f0bb223a6ba6c2527154b06f338add59113893806aa7830260"
+    },
+    {
+      "name": "editing_a_nested_lock_file_moves_the_digest",
+      "why": "The same tree with only the nested fixture edited. It is build input, so the digest must move; a basename exclusion reports the source unchanged and the lock stays green over a changed image.",
+      "tree": {
+        "Dockerfile": "FROM scratch\nCOPY fixtures /fixtures\n",
+        "server.py": "print('acme')\n",
+        "connectors.lock.yaml": "version: 1\nconnectors:\n  tempo:\n    image: sha256:1111111111111111111111111111111111111111111111111111111111111111\n",
+        "fixtures/connectors.lock.yaml": "version: 1\nconnectors:\n  tempo:\n    image: sha256:2222222222222222222222222222222222222222222222222222222222222222\n"
+      },
+      "build": {
+        "context": ".",
+        "dockerfile": "Dockerfile",
+        "platforms": [
+          "linux/amd64"
+        ]
+      },
+      "source_digest": "sha256:8849f554eb82ebdbd9b6a8c3e20294cf8393693d6de8dc07296be5cf73c3e06a"
+    },
+    {
+      "name": "a_bundle_root_context_carrying_the_lock",
+      "why": "The context is the bundle root, which is where connectors.lock.yaml is written. It is excluded by name at any depth.",
+      "tree": {
+        "Dockerfile": "FROM scratch\n",
+        "server.py": "print('acme')\n",
+        "connectors.yaml": "connectors:\n  tempo:\n    build:\n      context: .\n      platforms: [linux/amd64]\n",
+        "connectors.lock.yaml": "version: 1\nconnectors:\n  tempo:\n    image: sha256:1111111111111111111111111111111111111111111111111111111111111111\n"
+      },
+      "build": {
+        "context": ".",
+        "dockerfile": "Dockerfile",
+        "platforms": [
+          "linux/amd64"
+        ]
+      },
+      "source_digest": "sha256:7d85c20e48a0af27bedd4ee73a7f2ebefc739cfb4b83ad25bf41b01a313a52f6"
+    },
+    {
+      "name": "the_same_bundle_root_context_before_the_lock_was_written",
+      "why": "Same tree with connectors.lock.yaml absent. The digest must be identical to a_bundle_root_context_carrying_the_lock: without the exclusion, writing the lock changes the digest and the very next validation reports the lock stale against the source it was just built from.",
+      "tree": {
+        "Dockerfile": "FROM scratch\n",
+        "server.py": "print('acme')\n",
+        "connectors.yaml": "connectors:\n  tempo:\n    build:\n      context: .\n      platforms: [linux/amd64]\n"
+      },
+      "build": {
+        "context": ".",
+        "dockerfile": "Dockerfile",
+        "platforms": [
+          "linux/amd64"
+        ]
+      },
+      "source_digest": "sha256:7d85c20e48a0af27bedd4ee73a7f2ebefc739cfb4b83ad25bf41b01a313a52f6"
+    },
+    {
+      "name": "a_subdirectory_context_hashes_a_context_root_lock_file",
+      "why": "The declared context is a subdirectory, the common case, and it carries a connectors.lock.yaml at its own top. `curie build` writes the generated lock at the BUNDLE root, never here, so this file is authored input the daemon receives and the digest covers it. A reader that skips connectors.lock.yaml at the context root whatever the declared context is drops it.",
+      "tree": {
+        "Dockerfile": "FROM scratch\nCOPY connectors.lock.yaml /connectors.lock.yaml\n",
+        "server.py": "print('acme')\n",
+        "connectors.lock.yaml": "version: 1\nconnectors:\n  tempo:\n    image: sha256:1111111111111111111111111111111111111111111111111111111111111111\n"
+      },
+      "build": {
+        "context": "connectors/tempo",
+        "dockerfile": "Dockerfile",
+        "platforms": [
+          "linux/amd64"
+        ]
+      },
+      "source_digest": "sha256:302dd5e6ac8644ec090381a52195d1291a15b69c8cf463a85505dc5552fbf0ca"
+    },
+    {
+      "name": "editing_a_context_root_lock_file_under_a_subdirectory_context_moves_the_digest",
+      "why": "The same subdirectory context with only that file's content changed. It is build input, so the digest must move; an unconditional context-root exclusion reports the source unchanged and the lock stays green over a changed image. Held against the bundle-root pair above, this is what the unconditional rule cannot satisfy: the root pair must be equal AND this pair distinct.",
+      "tree": {
+        "Dockerfile": "FROM scratch\nCOPY connectors.lock.yaml /connectors.lock.yaml\n",
+        "server.py": "print('acme')\n",
+        "connectors.lock.yaml": "version: 1\nconnectors:\n  tempo:\n    image: sha256:2222222222222222222222222222222222222222222222222222222222222222\n"
+      },
+      "build": {
+        "context": "connectors/tempo",
+        "dockerfile": "Dockerfile",
+        "platforms": [
+          "linux/amd64"
+        ]
+      },
+      "source_digest": "sha256:2da2c41c4b5998a6ba5ab904d6dffd80e3bac9b223c0f8ac826a5e30db5e5aac"
+    },
+    {
+      "name": "an_entrypoint_without_the_executable_bit",
+      "why": "Baseline for the mode pair. Every byte here is identical to the vector below; the only difference on disk is that entrypoint.sh is not executable.",
+      "tree": {
+        "Dockerfile": "FROM scratch\nCOPY entrypoint.sh /entrypoint.sh\nENTRYPOINT [\"/entrypoint.sh\"]\n",
+        "entrypoint.sh": "#!/bin/sh\nexec python -m server\n",
+        "server.py": "print('acme')\n"
+      },
+      "build": {
+        "context": "connectors/tempo",
+        "dockerfile": "Dockerfile",
+        "platforms": [
+          "linux/amd64"
+        ]
+      },
+      "source_digest": "sha256:cbecbbee6a33b549a284b718bbb734c29284a3a3bd38494194b31cd6486b98dd"
+    },
+    {
+      "name": "chmod_plus_x_on_the_entrypoint_moves_the_digest",
+      "why": "The same bytes with entrypoint.sh made executable. Docker's context tar carries the mode and BuildKit keys its cache on it, so this is a materially different image built from the same declaration: an image whose ENTRYPOINT starts versus one that exits with permission denied. A digest that hashes content alone cannot tell the two apart, so the lock looks fresh and the stale image deploys.",
+      "tree": {
+        "Dockerfile": "FROM scratch\nCOPY entrypoint.sh /entrypoint.sh\nENTRYPOINT [\"/entrypoint.sh\"]\n",
+        "entrypoint.sh": {
+          "content": "#!/bin/sh\nexec python -m server\n",
+          "executable": true
+        },
+        "server.py": "print('acme')\n"
+      },
+      "build": {
+        "context": "connectors/tempo",
+        "dockerfile": "Dockerfile",
+        "platforms": [
+          "linux/amd64"
+        ]
+      },
+      "source_digest": "sha256:4b5130f3e6868bfb977593e2caf409e7a37b8a6f85443ebc6bd3ef2e9d51e09b"
+    },
+    {
+      "name": "two_dockerfiles_baseline",
+      "why": "Baseline for the two declaration-only edits below. The tree is held constant so the only thing that can move the digest is the build block.",
+      "tree": {
+        "Dockerfile": "FROM scratch\n",
+        "Dockerfile.alt": "FROM scratch\nUSER 65532\n",
+        "server.py": "print('acme')\n"
+      },
+      "build": {
+        "context": "connectors/tempo",
+        "dockerfile": "Dockerfile",
+        "platforms": [
+          "linux/amd64"
+        ]
+      },
+      "source_digest": "sha256:0836fa52dcd5c4fea1ad38d27a809ca9272a5f6c8f0ad0329d5531736672b4ac"
+    },
+    {
+      "name": "choosing_the_other_dockerfile_moves_the_digest",
+      "why": "Identical bytes on disk, a different Dockerfile selected. Without the build block in the stream this builds a different image and reports the same source digest, so the lock never looks stale and the deployed connector silently stops matching the reviewed declaration.",
+      "tree": {
+        "Dockerfile": "FROM scratch\n",
+        "Dockerfile.alt": "FROM scratch\nUSER 65532\n",
+        "server.py": "print('acme')\n"
+      },
+      "build": {
+        "context": "connectors/tempo",
+        "dockerfile": "Dockerfile.alt",
+        "platforms": [
+          "linux/amd64"
+        ]
+      },
+      "source_digest": "sha256:ad001bb5459689b1993118a70c1171dd8fb0224cb336e936ad902ed8d609142e"
+    },
+    {
+      "name": "adding_a_platform_moves_the_digest",
+      "why": "Identical bytes on disk, a second target architecture declared. The previous lock names a single-arch artifact that cannot run on half the nodes, so the digest must move or the staleness check never fires on a platforms edit.",
+      "tree": {
+        "Dockerfile": "FROM scratch\n",
+        "Dockerfile.alt": "FROM scratch\nUSER 65532\n",
+        "server.py": "print('acme')\n"
+      },
+      "build": {
+        "context": "connectors/tempo",
+        "dockerfile": "Dockerfile",
+        "platforms": [
+          "linux/amd64",
+          "linux/arm64"
+        ]
+      },
+      "source_digest": "sha256:2984ebbd27a5ae451b9892722b665e24c32b2626fe457854628de54dd4d155b9"
+    },
+    {
+      "name": "platform_order_is_significant",
+      "why": "The declared order is hashed as declared rather than sorted first. Stated as a pinned decision, not left to whichever side happened to sort: two readers disagreeing here disagree on every multi-arch lock.",
+      "tree": {
+        "Dockerfile": "FROM scratch\n",
+        "Dockerfile.alt": "FROM scratch\nUSER 65532\n",
+        "server.py": "print('acme')\n"
+      },
+      "build": {
+        "context": "connectors/tempo",
+        "dockerfile": "Dockerfile",
+        "platforms": [
+          "linux/arm64",
+          "linux/amd64"
+        ]
+      },
+      "source_digest": "sha256:837584781dd494634229dec09f47a9b73434445ccb25029ddd6f936a080bee1e"
+    }
+  ],
+  "relations": [
+    {
+      "same": [
+        "dockerignore_excludes_a_matching_file",
+        "an_ignored_files_content_does_not_move_the_digest"
+      ],
+      "why": "An excluded file's content is not in the digest, so a build that changes only ignored output is not stale."
+    },
+    {
+      "same": [
+        "a_bundle_root_context_carrying_the_lock",
+        "the_same_bundle_root_context_before_the_lock_was_written"
+      ],
+      "why": "The context's own root-level connectors.lock.yaml is excluded, so writing the lock does not invalidate the digest it records."
+    },
+    {
+      "distinct": [
+        "a_nested_lock_file_is_ordinary_build_input",
+        "editing_a_nested_lock_file_moves_the_digest"
+      ],
+      "why": "Only the generated lock at the context root is excluded. A file of that name nested inside the build context is source the daemon receives, so editing it must move the digest. Paired with the relation above, this is what a basename exclusion cannot satisfy: it needs the root pair equal AND the nested pair distinct."
+    },
+    {
+      "distinct": [
+        "a_subdirectory_context_hashes_a_context_root_lock_file",
+        "editing_a_context_root_lock_file_under_a_subdirectory_context_moves_the_digest"
+      ],
+      "why": "The generated lock is written at the BUNDLE root only, so under a subdirectory context a context-root connectors.lock.yaml is authored input and editing it must move the digest. Held against `a_bundle_root_context_carrying_the_lock` / `the_same_bundle_root_context_before_the_lock_was_written`, which must stay EQUAL, this is what an unconditional context-root exclusion cannot satisfy: the exclusion has to key on the declared context, not on the path."
+    },
+    {
+      "distinct": [
+        "an_entrypoint_without_the_executable_bit",
+        "chmod_plus_x_on_the_entrypoint_moves_the_digest"
+      ],
+      "why": "Byte-for-byte identical trees differing only in one file's owner execute bit. The context tar carries the mode and BuildKit keys its cache on it, so these build two different images and the digest must tell them apart. A content-only reader computes one value for both, which is a lock that stays green across `chmod +x`."
+    },
+    {
+      "distinct": [
+        "a_negation_reincludes_what_an_earlier_pattern_excluded",
+        "editing_a_reincluded_file_moves_the_digest"
+      ],
+      "why": "`!keep.log` puts keep.log back into the context, so its bytes are in the image and must be in the digest. A first-match-wins reader computes one value for both trees."
+    },
+    {
+      "same": [
+        "a_negation_reincludes_what_an_earlier_pattern_excluded",
+        "a_still_ignored_file_beside_a_negation_does_not_move_the_digest"
+      ],
+      "why": "A negation re-includes exactly what it names. debug.log stays excluded by `*.log`, so its bytes cannot move the digest. Held together with the distinct pair above, this pins last-match-wins rather than any-negation-disables-the-set."
+    },
+    {
+      "distinct": [
+        "a_negation_reaches_beneath_an_excluded_directory",
+        "editing_a_file_reincluded_beneath_an_excluded_directory_moves_the_digest"
+      ],
+      "why": "An excluded directory is descended, not pruned, so a `!` inside it re-includes the file it names and that file's bytes move the digest. A walk that prunes computes one value for both trees."
+    },
+    {
+      "distinct": [
+        "a_star_ignore_still_covers_the_build_files",
+        "editing_the_dockerfile_under_a_star_ignore_moves_the_digest"
+      ],
+      "why": "Under `*` the daemon still receives the Dockerfile and .dockerignore, so the digest still moves when the Dockerfile is rewritten. A reader that lets `*` empty the file list computes the same constant for both trees, which is a lock that can never go stale."
+    },
+    {
+      "distinct": [
+        "dockerignore_excludes_a_matching_file",
+        "editing_dockerignore_moves_the_digest"
+      ],
+      "why": ".dockerignore is hashed, so changing the exclusion set changes what is built and must change the digest."
+    },
+    {
+      "distinct": [
+        "two_dockerfiles_baseline",
+        "choosing_the_other_dockerfile_moves_the_digest"
+      ],
+      "why": "The build block is in the digest, so a dockerfile edit alone invalidates the lock."
+    },
+    {
+      "distinct": [
+        "two_dockerfiles_baseline",
+        "adding_a_platform_moves_the_digest"
+      ],
+      "why": "The build block is in the digest, so a platforms edit alone invalidates the lock."
+    },
+    {
+      "distinct": [
+        "adding_a_platform_moves_the_digest",
+        "platform_order_is_significant"
+      ],
+      "why": "Platform order is hashed as declared. Sorting on one side and not the other silently splits the two lanes."
+    }
+  ]
+}


### PR DESCRIPTION
Closes #1690

The contract half of ADR 0113, landing first so the execution PR builds on a reviewed shape.

## What this adds

- `connectors.yaml` gains the `build:` form: hosted from source, mutually exclusive with `image:` and `url:`, carrying a bundle relative `context`, a `dockerfile` under it, and a required non empty `platforms` list. A build block never carries a digest.
- `connectors.lock.yaml` records what each declared build resolved to: `delivery` (`registry` or `local-daemon`), the resolved `image` (digest reference or bare image id, mutable tags refused), the platforms built, and `source_digest`.
- `source_digest` is the content identity of the build input: each file's bytes plus its owner executable bit (the one mode bit the build context tar carries), the context's `.dockerignore` honored with Docker's own ordered last match wins semantics including `!` re-includes and the auto re-included build files, symlinked contexts refused, and the generated lock excluded only when the declared context is the bundle root. The algorithm is frozen as a cross language vector corpus (`tests/vectors/connector-source-digest.json`) gating the Python authority and the Rust port against each other.
- `apply_lock` rewrites a build connector into its locked image form, so the renderer, the MCP entry derivation, and `is_hosted` never see an unresolved build and a mutable tag has exactly one refusal point. The API render route applies the lock portably and refuses a local daemon lock with a 422, because every consumer of that route applies its output to a cluster.
- Intake refuses a missing context, a missing or stale lock entry, an image whose shape does not match its delivery, and an unknown lock version.

## Notes for review

- An older reader rejects a bundle carrying `build:` as an unknown field. That is deliberate fail closed behavior: an older runner cannot host a source built connector, and silently ignoring the declaration would be worse. This stacked pair of PRs is the contract lands first rollout ADR 0113 asks for.
- The digest deliberately hashes no mtime, uid, or gid: it identifies a source tree, not an archive.
- Cross engine reviews ran on this branch (three rounds plus a final stack review); the final round's digest fidelity findings (executable bit, lock exclusion scope) are fixed here.