### PR TITLE
Build, deliver, and host bundle declared connectors across all three tiers (ADR 0113)

### DIFF
--- a/.github/workflows/nightly-graded-ladder.yaml
+++ b/.github/workflows/nightly-graded-ladder.yaml
@@ -60,11 +60,43 @@ jobs:
 
   # Graded sibling of ci.yaml's e2e-ladder: same skill + local rung mechanics,
   # armed live against the real model instead of the fake fixture.
+  #
+  # Two legs, not one run of each mode in sequence: the `default` leg is the
+  # existing nightly coverage (the fixed weather bundle, no hosted connector,
+  # and the rung that asserts "declares none, starts none"), and the `connector`
+  # leg drives the SAME rungs through examples/sre-bot with its connectors
+  # turned on, so hosted connector builds are exercised nightly (ADR 0113,
+  # #1690). A matrix rather than a second step in one job because each leg needs
+  # the full 30-minute budget, and `fail-fast: false` so a red connector leg
+  # never cancels the default leg's graded result.
+  #
+  # The connector leg runs the FAKE model, not live. Its value is the hosting
+  # plumbing (source builds, lock identity, the hermetic and changed-source
+  # cases, teardown reaping), which the fake rungs assert fully. A live grade
+  # of the sre-bot suite cannot express what it is meant to assert here: its
+  # capability case requires reaching a real Kubernetes cluster, and this
+  # runner has none, so whether it reds or greens would turn on nothing but how
+  # the model phrases its non-answer -- the same falsifiability failure #1603
+  # removed from the cluster rung's weather grade. A live connector leg needs a
+  # cluster the runner can reach, or a report-only grade; either is a follow-up.
   ladder-skill-local:
-    name: Graded parity ladder (skill + local, live model)
+    name: Graded parity ladder (skill + local, ${{ matrix.mode }} bundle)
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: build-cli
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Empty is the OFF value the ladder reads (an unset/empty
+          # CURIE_E2E_CONNECTOR_BUNDLE leaves the fixed weather bundle in
+          # place), so this leg runs exactly what it ran before.
+          - mode: default
+            connector_bundle: ""
+            live: "1"
+          - mode: connector
+            connector_bundle: examples/sre-bot
+            live: ""
     steps:
       - uses: actions/checkout@v7
         with:
@@ -125,12 +157,22 @@ jobs:
       # the OpenRouter credential from CURIE_CREDENTIALS (the one env key the CLI
       # reads; an sk-or- key auto-selects OPENROUTER_BASE_URL). The secret
       # travels only as this env mapping, never on a run: or argv line.
-      - name: Graded parity ladder (skill + local rungs, live model)
+      # CURIE_E2E_CONNECTOR_BUNDLE is the matrix's only lever: empty on the
+      # default leg (the ladder keeps its fixed weather bundle and its
+      # hermetic no-hosting case), examples/sre-bot on the connector leg, where
+      # the ladder builds that bundle's `build:` connectors from source before
+      # the first rung and adds the hosting and changed-source rebuild cases.
+      # No CURIE_E2E_CONNECTOR_REGISTRY: these two rungs deliver into the local
+      # Docker daemon by design, which only the cluster rung refuses.
+      - name: Graded parity ladder (skill + local rungs)
         env:
           CURIE_BIN: cli/target/release/curie
           CURIE_BASE_TAG: ci-local
           CURIE_E2E_TIERS: skill,local
-          CURIE_E2E_LIVE: "1"
+          # Live on the default leg only; the connector leg is fake-model
+          # plumbing on purpose (see the job comment above).
+          CURIE_E2E_LIVE: ${{ matrix.live }}
+          CURIE_E2E_CONNECTOR_BUNDLE: ${{ matrix.connector_bundle }}
           CURIE_CREDENTIALS: ${{ secrets.OPENROUTER_API_KEY }}
           CURIE_MODEL: ${{ inputs.model || 'z-ai/glm-5.2' }}
         run: bash cli/scripts/e2e-ladder.sh
@@ -427,7 +469,12 @@ jobs:
       # -> `cluster message` (reply asserted). The model is baked at install
       # time, but apply_model_mode still hard-exits under CURIE_E2E_LIVE if no
       # credential is in env, so CURIE_CREDENTIALS is supplied here too.
-      # CURIE_E2E_LISTEN_HOST was exported to the job env above.
+      # CURIE_E2E_LISTEN_HOST was exported to the job env above. No
+      # CURIE_E2E_CONNECTOR_BUNDLE here: the cluster connector rung needs a
+      # registry it can push digest-pinned images to (the nodes cannot pull a
+      # local-daemon lock), and this job has none -- every image reaches the
+      # cluster through `kind load`, with no registry auth anywhere in the
+      # workflow -- so the cluster connector rung stays unwired until one exists.
       - name: Graded parity ladder (cluster rung, live model)
         env:
           CURIE_BIN: cli/target/release/curie

--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -3875,7 +3875,7 @@ export const commandManifest = {
       "name": "deploy-local"
     },
     {
-      "about": "Build the runner image locally from `runner/Dockerfile` (source checkout only)",
+      "about": "Build the runner image, or an agent bundle's declared connectors",
       "args": [
         {
           "default_values": [
@@ -3887,10 +3887,38 @@ export const commandManifest = {
           "long": "tag",
           "positional": false,
           "required": false
+        },
+        {
+          "global": false,
+          "help": "Build the connectors this agent bundle declares",
+          "id": "plugin_dir",
+          "long": "plugin-dir",
+          "positional": false,
+          "required": false
+        },
+        {
+          "global": false,
+          "help": "Push a multi-platform index to this registry (e.g. ghcr.io/acme-corp)",
+          "id": "registry",
+          "long": "registry",
+          "positional": false,
+          "required": false
+        },
+        {
+          "global": false,
+          "help": "Replace a registry lock with a local-daemon one deliberately",
+          "id": "force",
+          "long": "force",
+          "positional": false,
+          "possible_values": [
+            "true",
+            "false"
+          ],
+          "required": false
         }
       ],
       "hidden": false,
-      "long_about": "Build the runner image locally from `runner/Dockerfile` (source checkout only).\n\nRuns `docker build -f runner/Dockerfile -t <tag> .` from the repo root. A release binary pulls the pinned runner image from GHCR automatically and never needs this; it errors clearly if Docker is missing or there is no repo checkout.",
+      "long_about": "Build the runner image, or an agent bundle's declared connectors.\n\nWith no flags it runs `docker build -f runner/Dockerfile -t <tag> .` from the repo root (source checkout only; a release binary pulls the pinned runner image from GHCR automatically and never needs this).\n\nWith `--plugin-dir <PATH>` it builds every connector that bundle's `connectors.yaml` declares from source and writes `connectors.lock.yaml` beside it. With `--registry <REF>` it builds every declared platform, pushes, and records the registry manifest digest, which is what a cluster deploy requires. Without `--registry` it builds the host platform only into the local Docker daemon and records the local image id, which is usable at the skill and local tiers and refused at cluster.",
       "name": "build"
     },
     {

--- a/apps/worker/tests/binding/test_reserved_boot_env_pin.py
+++ b/apps/worker/tests/binding/test_reserved_boot_env_pin.py
@@ -1,6 +1,6 @@
 """Completeness + cross-language drift pin for the reserved boot-env policy (#457).
 
-Three guards, all checked at import time (no Postgres, no fixtures):
+Four guards, all checked at import time (no Postgres, no fixtures):
 
 (a) Every credential-key literal the runner's ``sdk_auth`` owns is caught by
     ``is_reserved_boot_env_name``. If a new model credential is added to
@@ -20,6 +20,12 @@ Three guards, all checked at import time (no Postgres, no fixtures):
     ``curie.reservedConnectorSecretNames`` define MUST list exactly the
     non-``CURIE_`` members of ``RESERVED_BOOT_ENV`` (the prefix rule covers
     ``CURIE_*`` on both sides). Fails CI if the two lists drift.
+(d) The same parity for the CLI's Rust copy
+    (``cli/src/connector_build.rs``'s ``RESERVED_CONNECTOR_SECRET_NAMES``). It
+    is a third language for the same reason Helm is a second: the skill and
+    local tiers resolve a connector's declared secret from the operator's
+    environment or vault before any Python sees the bundle, so the refusal has
+    to exist client-side.
 """
 
 from __future__ import annotations
@@ -176,3 +182,34 @@ def _reserved_names_from_helpers() -> set[str]:
 def test_helm_reserved_list_matches_non_prefixed_members() -> None:
     expected = {n for n in RESERVED_BOOT_ENV if not n.startswith("CURIE_")}
     assert _reserved_names_from_helpers() == expected
+
+
+# --- (d) Rust cross-language drift gate --------------------------------------
+
+# The CLI's copy, and the second unavoidable one (Rust cannot import Python
+# either). It exists because the skill and local tiers resolve a connector's
+# declared secret from the operator's own environment or vault BEFORE any
+# Python validates the bundle, so the client has to refuse a reserved name on
+# its own. Same rule as the Helm gate: list parity on the non-``CURIE_``
+# members, with the prefix rule covering ``CURIE_*`` on both sides.
+_CONNECTOR_BUILD_RS = Path(__file__).resolve().parents[4] / "cli" / "src" / "connector_build.rs"
+
+
+def _reserved_names_from_rust() -> set[str]:
+    text = _CONNECTOR_BUILD_RS.read_text(encoding="utf-8")
+    match = re.search(
+        r"RESERVED_CONNECTOR_SECRET_NAMES[^=]*=\s*\[(?P<body>.*?)\]",
+        text,
+        re.DOTALL,
+    )
+    assert match, (
+        "no `RESERVED_CONNECTOR_SECRET_NAMES` array found in "
+        f"{_CONNECTOR_BUILD_RS} -- the Rust reserved-name drift gate has no source"
+    )
+    tokens = set(_ENV_NAME_RE.findall(match.group("body")))
+    return {t for t in tokens if not t.startswith("CURIE_")}
+
+
+def test_rust_reserved_list_matches_non_prefixed_members() -> None:
+    expected = {n for n in RESERVED_BOOT_ENV if not n.startswith("CURIE_")}
+    assert _reserved_names_from_rust() == expected

--- a/apps/worker/tests/reconcile/test_connector_plan.py
+++ b/apps/worker/tests/reconcile/test_connector_plan.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from curie_worker.connector_agent import own
 from curie_worker.connector_reconcile import OWNER_LABEL, plan, stamp_hash
 
 
@@ -142,3 +143,71 @@ def test_a_mixed_state_converges_in_one_plan() -> None:
     assert p.delete == [("Secret", "stale")]
     assert p.unchanged == [("Service", "keep")]
     assert p.drifted == [("Deployment", "drift")]
+
+
+# --------------------------------------------------------------------------- #
+# The reconciler inherits the locked digest -- it never resolves a build
+# itself (ADR 0113, #1690)
+# --------------------------------------------------------------------------- #
+def test_a_built_connectors_desired_object_carries_the_locked_digest() -> None:
+    """`apply_lock` is the single resolution point (Section 3,
+    `connector_agent.py:62`: the worker "consumes what the API returns ...
+    inherits the digest from the API render"). `connector_reconcile.plan`
+    itself never touches a `build:` declaration or a lock -- it only ever sees
+    whatever `desired` the caller hands it -- so this drives the REAL
+    `apply_lock` -> `render` -> `own` -> `plan` path end to end rather than
+    poking a Deployment's `image` field by hand, and proves the object `plan`
+    decides to apply carries the resolved digest, not the source declaration.
+    """
+    from plugin_format import connector_render
+    from plugin_format.connector_lock import ConnectorLockFile, apply_lock
+    from plugin_format.connectors import validate_connectors
+
+    digest = "ghcr.io/acme-corp/acme-bot-k8s-write-mcp@sha256:" + "3" * 64
+    declared, errors = validate_connectors(
+        {
+            "connectors": {
+                "k8s-write": {
+                    "build": {
+                        "context": "connectors/k8s-write",
+                        "platforms": ["linux/amd64"],
+                    }
+                }
+            }
+        }
+    )
+    assert errors == [], errors
+    lock = ConnectorLockFile.model_validate(
+        {
+            "version": 1,
+            "connectors": {
+                "k8s-write": {
+                    "image": digest,
+                    "delivery": "registry",
+                    "platforms": ["linux/amd64"],
+                    "source_digest": "sha256:" + "4" * 64,
+                }
+            },
+        }
+    )
+    resolved = apply_lock(declared, lock, portable=True)
+    rendered = connector_render.render(
+        release="acme-bot",
+        agent="acme-bot",
+        namespace="acme-bot",
+        app_name="acme-bot",
+        connector="k8s-write",
+        spec=resolved.connectors["k8s-write"],
+        secret_name="conn-secrets",
+    )
+    desired = [own(o, "acme-bot") for o in rendered]
+
+    p = plan(desired=desired, live=[], agent="acme-bot")
+
+    deployment = next(o for o in p.apply if o["kind"] == "Deployment")
+    assert deployment["spec"]["template"]["spec"]["containers"][0]["image"] == digest
+    # The unresolved declaration never reaches the plan at all: only
+    # apply_lock's OUTPUT does. A caller that skipped apply_lock would either
+    # have `render` raise (its own guard) or, if that regressed, apply a
+    # Deployment with no image rather than the locked digest.
+    assert "build" not in str(rendered)

--- a/cli/CLAUDE.md
+++ b/cli/CLAUDE.md
@@ -115,7 +115,18 @@ Helm and the deployed release with `up`, `status`, `down`, `comms`, `message`,
   working with zero network access beyond the local Docker daemon and the local
   runner container. `skill up` stays offline once the runner image is present
   locally, or when `--image <local-tag>` names a local image. A release binary's
-  default runner image ref is pulled from GHCR on first run. `local deploy` and
+  default runner image ref is pulled from GHCR on first run. A bundle that
+  declares `build:` connectors moves that boundary by exactly one build: `skill
+  up` rebuilds a missing or stale `connectors.lock.yaml` before bring-up
+  (ADR 0113 Decision 3), and that is a `docker build` of the bundle's own
+  Dockerfiles, which reaches whatever they name -- a base image such as
+  `python:3.12-slim`, a `# syntax=` frontend if one is declared, and whatever
+  the Dockerfile's own steps fetch. So for those bundles the guarantee
+  is **offline after the first successful build, while the lock stays
+  current**: a lock whose `source_digest` still matches the tree computes no
+  rebuild and issues no `docker build`, so the verbs above again touch nothing
+  but the local daemon. A bundle that declares no `build:` connectors is
+  unaffected and keeps the zero-network guarantee as written above. `local deploy` and
   `cluster deploy` are the bundle shipping verbs that leave the machine: they
   package the bundle as
   tar.gz and push to the platform API (find-or-create agent, create version,

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -3872,7 +3872,7 @@
       "name": "deploy-local"
     },
     {
-      "about": "Build the runner image locally from `runner/Dockerfile` (source checkout only)",
+      "about": "Build the runner image, or an agent bundle's declared connectors",
       "args": [
         {
           "default_values": [
@@ -3884,10 +3884,38 @@
           "long": "tag",
           "positional": false,
           "required": false
+        },
+        {
+          "global": false,
+          "help": "Build the connectors this agent bundle declares",
+          "id": "plugin_dir",
+          "long": "plugin-dir",
+          "positional": false,
+          "required": false
+        },
+        {
+          "global": false,
+          "help": "Push a multi-platform index to this registry (e.g. ghcr.io/acme-corp)",
+          "id": "registry",
+          "long": "registry",
+          "positional": false,
+          "required": false
+        },
+        {
+          "global": false,
+          "help": "Replace a registry lock with a local-daemon one deliberately",
+          "id": "force",
+          "long": "force",
+          "positional": false,
+          "possible_values": [
+            "true",
+            "false"
+          ],
+          "required": false
         }
       ],
       "hidden": false,
-      "long_about": "Build the runner image locally from `runner/Dockerfile` (source checkout only).\n\nRuns `docker build -f runner/Dockerfile -t <tag> .` from the repo root. A release binary pulls the pinned runner image from GHCR automatically and never needs this; it errors clearly if Docker is missing or there is no repo checkout.",
+      "long_about": "Build the runner image, or an agent bundle's declared connectors.\n\nWith no flags it runs `docker build -f runner/Dockerfile -t <tag> .` from the repo root (source checkout only; a release binary pulls the pinned runner image from GHCR automatically and never needs this).\n\nWith `--plugin-dir <PATH>` it builds every connector that bundle's `connectors.yaml` declares from source and writes `connectors.lock.yaml` beside it. With `--registry <REF>` it builds every declared platform, pushes, and records the registry manifest digest, which is what a cluster deploy requires. Without `--registry` it builds the host platform only into the local Docker daemon and records the local image id, which is usable at the skill and local tiers and refused at cluster.",
       "name": "build"
     },
     {

--- a/cli/schema/baseline/build.schema.json
+++ b/cli/schema/baseline/build.schema.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.curietech.ai/cli/build/v1.json",
+  "title": "curie build --plugin-dir --json",
+  "description": "The `curie build --plugin-dir` receipt: one connector record per connector the bundle declared a `build:` for, in the order built. Always one object, even when the bundle declares nothing to build (#485): an empty `connectors` array is the honest 'nothing to build', distinguishable from a command that produced nothing.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "connectors": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The connector's declared name in connectors.yaml."
+          },
+          "image": {
+            "type": "string",
+            "description": "The resolved immutable identity recorded in connectors.lock.yaml: `<repo>@sha256:<64 hex>` for registry delivery, a bare `sha256:<64 hex>` image id for local-daemon delivery."
+          },
+          "delivery": {
+            "enum": [
+              "registry",
+              "local-daemon"
+            ],
+            "description": "How the built artifact is delivered to a tier: pushed to a registry the cluster can pull, or loaded into the local Docker daemon."
+          },
+          "platforms": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "The OCI platforms built, as declared (`os/arch`, optionally `/variant`)."
+          },
+          "source_digest": {
+            "type": "string",
+            "description": "The digest of the build context as shipped (the connectors.lock.yaml `source_digest`), which stale-lock detection compares against a recomputation."
+          }
+        },
+        "required": [
+          "name",
+          "image",
+          "delivery",
+          "platforms",
+          "source_digest"
+        ]
+      }
+    }
+  },
+  "required": [
+    "connectors"
+  ]
+}

--- a/cli/schema/build.schema.json
+++ b/cli/schema/build.schema.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.curietech.ai/cli/build/v1.json",
+  "title": "curie build --plugin-dir --json",
+  "description": "The `curie build --plugin-dir` receipt: one connector record per connector the bundle declared a `build:` for, in the order built. Always one object, even when the bundle declares nothing to build (#485): an empty `connectors` array is the honest 'nothing to build', distinguishable from a command that produced nothing.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "connectors": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The connector's declared name in connectors.yaml."
+          },
+          "image": {
+            "type": "string",
+            "description": "The resolved immutable identity recorded in connectors.lock.yaml: `<repo>@sha256:<64 hex>` for registry delivery, a bare `sha256:<64 hex>` image id for local-daemon delivery."
+          },
+          "delivery": {
+            "enum": [
+              "registry",
+              "local-daemon"
+            ],
+            "description": "How the built artifact is delivered to a tier: pushed to a registry the cluster can pull, or loaded into the local Docker daemon."
+          },
+          "platforms": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "The OCI platforms built, as declared (`os/arch`, optionally `/variant`)."
+          },
+          "source_digest": {
+            "type": "string",
+            "description": "The digest of the build context as shipped (the connectors.lock.yaml `source_digest`), which stale-lock detection compares against a recomputation."
+          }
+        },
+        "required": [
+          "name",
+          "image",
+          "delivery",
+          "platforms",
+          "source_digest"
+        ]
+      }
+    }
+  },
+  "required": [
+    "connectors"
+  ]
+}

--- a/cli/schema/index.json
+++ b/cli/schema/index.json
@@ -70,6 +70,12 @@
       "version": "1.0"
     },
     {
+      "result": "ConnectorBuildOutput",
+      "kind": "CliOutput",
+      "schema": "build.schema.json",
+      "version": "1.0"
+    },
+    {
       "result": "DeleteOutput",
       "kind": "CliOutput",
       "schema": "delete.schema.json",

--- a/cli/scripts/e2e-ladder.sh
+++ b/cli/scripts/e2e-ladder.sh
@@ -79,6 +79,25 @@
 #                            rung 1 (cli/scripts/e2e.sh reads this same var
 #                            itself rather than being told by the ladder).
 #   CURIE_BIN              path to a prebuilt curie binary (skip cargo build)
+#   CURIE_E2E_CONNECTOR_BUNDLE
+#                          opt-in: path to a bundle that declares connectors
+#                            (examples/sre-bot) to drive every named rung
+#                            through INSTEAD of the fixed weather bundle, so the
+#                            rungs assert hosted-connector parity (ADR 0113,
+#                            #1690). Unset by default: the default ladder's
+#                            bundle stays fixed, so this is an added rung input
+#                            rather than a change to the existing gate.
+#   CURIE_E2E_CONNECTOR_REGISTRY
+#                          registry ref (e.g. ghcr.io/acme-corp) for the
+#                            connector build. Unset builds the host platform
+#                            into the local Docker daemon, which the skill and
+#                            local rungs accept and the CLUSTER rung refuses by
+#                            design, so the cluster rung requires this.
+#   CURIE_E2E_CONNECTOR_OMIT_SECRET
+#                          name ONE of the fixture's three credentials to skip
+#                            provisioning. The falsifiable negative: the rung
+#                            must then fail closed on the missing credential
+#                            rather than starting a connector without it.
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -87,6 +106,48 @@ LIVE="${CURIE_E2E_LIVE:-0}"
 # Fixed, not an env knob: the ladder asserts PLUMBING, so the bundle it ships is
 # a fixed input of the test rather than something a caller varies.
 BUNDLE_SRC="$REPO_ROOT/examples/weather"
+
+# --- the connector rung input (ADR 0113, #1690), opt-in and off by default ---
+#
+# Set CURIE_E2E_CONNECTOR_BUNDLE and every named rung runs a scratch copy of
+# THAT bundle instead, with its connectors turned on by a checked-in fixture and
+# its images built from source before the first rung. The default above is
+# untouched, so this adds a rung input and changes no existing gate.
+CONNECTOR_BUNDLE="${CURIE_E2E_CONNECTOR_BUNDLE:-}"
+CONNECTOR_REGISTRY="${CURIE_E2E_CONNECTOR_REGISTRY:-}"
+CONNECTOR_OMIT_SECRET="${CURIE_E2E_CONNECTOR_OMIT_SECRET:-}"
+# A whole file, never a scripted uncomment: see the fixture's own header for why
+# a `sed` against a comment block is the green-but-vacuous failure this rung
+# exists to prevent.
+CONNECTOR_FIXTURE="$REPO_ROOT/cli/scripts/fixtures/sre-bot-connectors-enabled.yaml"
+# The connectors the fixture builds FROM SOURCE, and the tool set each must
+# serve. These two are the subject of the assertion; the fixture's third
+# connector is an ordinary `image:` one, hosted beside them as the control.
+CONNECTOR_BUILT=(k8s-write tempo)
+CONNECTOR_TOOLS_K8S_WRITE="restart_deployment"
+CONNECTOR_TOOLS_TEMPO="get_trace,list_trace_tag_values,list_trace_tags,search_traces"
+# The port every connector in the fixture serves on (`ConnectorSpec.port`'s
+# default). Release, agent and namespace are deliberately NOT constants here:
+# each rung reads them off the scope its own tier handed the runner, which is
+# what makes the assertion a parity check rather than a restatement.
+CONNECTOR_PORT=8000
+# Pinned by the first rung to report an entry set, matched by every later one --
+# the same shape as PARITY_DIGEST, and compared byte for byte.
+CONNECTOR_ENTRIES=""
+CONNECTOR_ENTRY_RUNGS=""
+# `name=image` lines from the one `curie build --plugin-dir` receipt this run
+# produced, so every rung is checked against what THIS run resolved.
+CONNECTOR_IMAGES=""
+# The scope the last rung's tier actually handed its runner, recorded by
+# assert_connector_parity so the post-teardown sweep looks for those exact
+# names.
+CONNECTOR_SCOPE_RELEASE=""
+CONNECTOR_SCOPE_AGENT=""
+CONNECTOR_SCOPE_NAMESPACE=""
+# The runner this script's own skill-tier connector case boots. Never the
+# default name: that one belongs to whatever real `skill up` a developer has
+# going on this box.
+CONNECTOR_RUNNER_NAME="curie-ladder-connectors-$$"
 # Hardcoded, and deliberately NOT an env knob: the stub port is the constant
 # DEFAULT_LOCAL_STUB_PORT in cli/src/message.rs, pinned to the compose worker's
 # SLACK_API_BASE_URL. An override would only move this script's precheck, so it
@@ -97,6 +158,27 @@ PROMPT="What is the weather in Denver right now?"
 # ONLY as a live-mode negative control -- "the reply must not be this" -- never
 # as a pass condition. Matching it to green is the #612 bypass.
 FAKE_SENTINEL="all done"
+
+# The component label every connector container carries, in both the skill start
+# path and the local compose overlay (cli/src/docker.rs
+# CONNECTOR_COMPONENT_LABEL). Teardown reaps by label, so this is the only
+# handle that selects a connector container; its NAME differs between the two
+# tiers (`curie-connector-<session>-<name>` vs compose's own).
+CONNECTOR_LABEL="curietech.ai/component=connector"
+
+if [[ -n "$CONNECTOR_BUNDLE" ]]; then
+    if [[ ! -d "$CONNECTOR_BUNDLE" ]]; then
+        echo "error: CURIE_E2E_CONNECTOR_BUNDLE is set to '$CONNECTOR_BUNDLE', which is not a directory." >&2
+        exit 1
+    fi
+    # Absolutized once: every later use is from another directory.
+    CONNECTOR_BUNDLE="$(cd "$CONNECTOR_BUNDLE" && pwd)"
+    BUNDLE_SRC="$CONNECTOR_BUNDLE"
+    # The connector bundle is not a weather bot, and a prompt it cannot answer
+    # would make a live rung's grade meaningless. Plumbing is still all a fake
+    # rung asserts.
+    PROMPT="Is any pod crashlooping right now?"
+fi
 
 # Set once the ladder itself brought the compose stack up. The thread that
 # brought a stack up owns tearing it down, so a stack that was already running
@@ -184,6 +266,20 @@ cleanup() {
     # the case itself once `skill down` has removed it.
     if (( CONFLICT_CREATED )); then
         docker rm -f "$CONFLICT_NAME" >/dev/null 2>&1
+    fi
+    # Connector containers this run's own bundle started, matched by the exact
+    # aliases derived from the scope a rung recorded -- never a bare sweep of
+    # the connector label, which is host-wide and would reach a concurrent
+    # session's connectors. A normal path has already reaped these through the
+    # tier's own `down`; this covers the run that died before reaching it.
+    if [[ -n "$CONNECTOR_SCOPE_RELEASE" ]]; then
+        local connector object survivor
+        for connector in kubernetes "${CONNECTOR_BUILT[@]}"; do
+            object="$(connector_object_name "$CONNECTOR_SCOPE_RELEASE" "$CONNECTOR_SCOPE_AGENT" "$connector" 2>/dev/null)" || continue
+            survivor="$(connector_container_for_alias "$object.$CONNECTOR_SCOPE_NAMESPACE.svc.cluster.local")" || continue
+            echo "sweeping stranded connector container $survivor"
+            docker rm -f "$survivor" >/dev/null 2>&1
+        done
     fi
     rm -rf "$WORKDIR"
     exit "$code"
@@ -666,6 +762,543 @@ case_leftover_runner_container() {
     echo "skill down --name cleared the leftover with no recorded state"
 }
 
+# ---------------------------------------------------------------------------
+# The connector rung (ADR 0113, #1690). Everything below is inert unless
+# CURIE_E2E_CONNECTOR_BUNDLE is set.
+# ---------------------------------------------------------------------------
+
+connector_mode() {
+    [[ -n "$CONNECTOR_BUNDLE" ]]
+}
+
+# Two distinct, well-formed, scratch-scoped kubeconfigs plus the tempo token,
+# provisioned into THIS RUN's process environment and the scratch bundle copies
+# only. Nothing of the operator's is read, written or restored: the CLI resolves
+# a connector credential from the environment first and the host vault second
+# (cli/src/commands.rs resolve_connector_secret), so exporting is sufficient and
+# `curie secrets set` -- which writes the operator's real store -- is never run.
+#
+# The kubeconfigs need no cluster. These rungs assert HOSTING, not live
+# Kubernetes access: the write connector refuses to start without a kubeconfig
+# file and starts with a well-formed one, which is exactly the fail-closed
+# behavior under test.
+provision_connector_credentials() {
+    local creds="$WORKDIR/connector-creds"
+    mkdir -p "$creds"
+    chmod 700 "$creds"
+
+    local name
+    for name in K8S_READONLY_KUBECONFIG K8S_WRITE_KUBECONFIG GRAFANA_SERVICE_ACCOUNT_TOKEN; do
+        if [[ "$CONNECTOR_OMIT_SECRET" == "$name" ]]; then
+            echo "connector credentials: SKIPPING $name deliberately (CURIE_E2E_CONNECTOR_OMIT_SECRET)."
+            echo "connector credentials: the rung below MUST now fail closed on the missing credential. A rung that starts a connector anyway is the failure this run is looking for."
+            continue
+        fi
+        case "$name" in
+            K8S_READONLY_KUBECONFIG|K8S_WRITE_KUBECONFIG)
+                # A SEPARATE credential per connector, never one reused: that is
+                # the example's own rule (examples/sre-bot/connectors.yaml), and
+                # reusing one here would quietly assert the opposite shape.
+                local user="ladder-reader" file="$creds/readonly.kubeconfig"
+                if [[ "$name" == "K8S_WRITE_KUBECONFIG" ]]; then
+                    user="ladder-writer"
+                    file="$creds/writer.kubeconfig"
+                fi
+                cat > "$file" <<YAML
+apiVersion: v1
+kind: Config
+clusters: [{name: ladder, cluster: {server: https://kubernetes.default.svc}}]
+users: [{name: $user, user: {token: not-a-real-token-$user}}]
+contexts: [{name: ladder, context: {cluster: ladder, user: $user}}]
+current-context: ladder
+YAML
+                chmod 600 "$file"
+                export "$name"="$(cat "$file")"
+                ;;
+            GRAFANA_SERVICE_ACCOUNT_TOKEN)
+                # A placeholder, and sufficient: the tempo connector refuses to
+                # start without one, and the tool call this rung makes is an
+                # input-validation path that never reaches Grafana.
+                export GRAFANA_SERVICE_ACCOUNT_TOKEN="not-a-real-token-ladder"
+                ;;
+        esac
+        echo "connector credentials: $name provisioned into this run's environment only"
+    done
+}
+
+# Turn the example's commented-out connectors on in ONE scratch copy, and give
+# the copy the approval gate that must travel with them.
+#
+# The gate is applied here rather than shipped as a second fixture file so it
+# cannot drift from the committed plugin.json it patches: bundle validation
+# rejects a gate naming an undeclared connector, so the two changes are one
+# change, and a fixture pair could be edited apart.
+prepare_connector_bundle() {
+    local dir="$1"
+    cp "$CONNECTOR_FIXTURE" "$dir/connectors.yaml"
+    python3 -c '
+import json, sys
+path = sys.argv[1]
+with open(path) as fh:
+    manifest = json.load(fh)
+# The exact block examples/sre-bot/README.md documents at "Declare the approval
+# gate". The tool name carries no plugin infix, deliberately: a Curie connector
+# is a platform-supplied server, so the prefixed form the deploy error advises
+# validates, deploys and never fires.
+manifest["approvalPolicy"] = {
+    "gates": [{"gate": "mcp__k8s-write__restart_deployment", "route": "sre-approvals"}]
+}
+with open(path, "w") as fh:
+    json.dump(manifest, fh, indent=2)
+    fh.write("\n")
+' "$dir/.claude-plugin/plugin.json"
+    echo "connector fixture applied to $dir (connectors.yaml + the approvalPolicy gate that travels with it)"
+}
+
+# One build before the first rung, so every rung consumes the same lock and the
+# bundle bytes each rung packs are identical (the PARITY_DIGEST assertion).
+#
+# Without --registry this builds the host platform into the local Docker daemon
+# and records the local image id, which the skill and local rungs accept and the
+# cluster rung refuses by design -- so the cluster rung requires a registry.
+build_connector_images() {
+    local dir="$1"
+    local out
+    local build_args=(--json build --plugin-dir "$dir")
+    if [[ -n "$CONNECTOR_REGISTRY" ]]; then
+        build_args+=(--registry "$CONNECTOR_REGISTRY")
+        echo "=== curie build --plugin-dir (registry delivery: $CONNECTOR_REGISTRY) ==="
+    else
+        echo "=== curie build --plugin-dir (local-daemon delivery) ==="
+    fi
+    out="$("$BIN" "${build_args[@]}")"
+    printf '%s\n' "$out"
+    # name=image lines, read back from the receipt rather than by parsing the
+    # lock file: the receipt is the CLI's own agent-facing contract, and it says
+    # what this run actually resolved.
+    CONNECTOR_IMAGES="$(printf '%s' "$out" | python3 -c '
+import json, sys
+payload = json.loads(sys.stdin.read())
+records = payload["connectors"]
+if not records:
+    sys.exit("the build receipt lists no connectors, so the fixture declared nothing to build")
+for record in records:
+    print("%s=%s" % (record["name"], record["image"]))
+')"
+    printf '%s\n' "$CONNECTOR_IMAGES"
+}
+
+# The image `curie build` resolved for one connector.
+connector_image() {
+    local want="$1" line
+    while IFS= read -r line; do
+        if [[ "$line" == "$want="* ]]; then
+            printf '%s' "${line#*=}"
+            return 0
+        fi
+    done <<< "$CONNECTOR_IMAGES"
+    echo "no build receipt entry for connector '$want'" >&2
+    return 1
+}
+
+# A hand mirror of connector_render.object_name / service_dns, which is what
+# BOTH sides derive independently: the CLI names the container's network alias
+# from it, and the runner derives the URL it dials from it. The ladder recomputes
+# it from the scope the RUNNER was actually given, so a tier whose two sides
+# disagree fails here instead of surfacing as a connection timeout mid-turn.
+connector_object_name() {
+    local release="$1" agent="$2" connector="$3"
+    local name="$release-$agent-mcp-$connector"
+    if (( ${#name} > 63 )); then
+        echo "connector object name '$name' exceeds 63 characters, so the CLI truncates it with a digest and this ladder's hand mirror no longer matches. Shorten the fixture's agent or connector name." >&2
+        return 1
+    fi
+    printf '%s' "$name"
+}
+
+# The one compose worker this ladder's stack is running, selected exactly the
+# way probe_local_fake_model selects it (project label plus service label), so
+# the connector scope is read off the same container whose model mode is read.
+local_worker_container() {
+    local line workers=()
+    while IFS= read -r line; do
+        [[ -n "$line" ]] && workers+=("$line")
+    done < <(docker ps --filter 'label=com.docker.compose.project=curie' --filter 'label=com.docker.compose.service=curie-worker' --format '{{.Names}}')
+    if (( ${#workers[@]} != 1 )); then
+        echo "connector scope probe: expected exactly one running curie-worker in the compose project 'curie', found ${#workers[@]} (${workers[*]:-none})." >&2
+        return 1
+    fi
+    printf '%s' "${workers[0]}"
+}
+
+# One env var read off a running container's inspected environment.
+container_env_value() {
+    local container="$1" key="$2" dump line
+    if ! dump="$(docker inspect "$container" --format '{{range .Config.Env}}{{println .}}{{end}}')"; then
+        echo "could not inspect '$container' to read $key" >&2
+        return 1
+    fi
+    while IFS= read -r line; do
+        if [[ "$line" == "$key="* ]]; then
+            printf '%s' "${line#*=}"
+            return 0
+        fi
+    done <<< "$dump"
+    printf ''
+}
+
+# The connector container answering to one alias, by LABEL then by alias --
+# never by name, which differs between the skill start path
+# (`curie-connector-<session>-<name>`) and the local compose overlay's own.
+connector_container_for_alias() {
+    local alias="$1" container aliases
+    while IFS= read -r container; do
+        [[ -n "$container" ]] || continue
+        aliases="$(docker inspect "$container" --format '{{range .NetworkSettings.Networks}}{{range .Aliases}}{{println .}}{{end}}{{end}}' 2>/dev/null || true)"
+        if grep -qxF "$alias" <<< "$aliases"; then
+            printf '%s' "$container"
+            return 0
+        fi
+    done < <(docker ps --filter "label=$CONNECTOR_LABEL" --format '{{.Names}}')
+    return 1
+}
+
+# The MCP probe itself: an initialize / notifications/initialized / tools/list
+# round trip, and optionally one deterministic tool call, against a connector's
+# real URL. Written once into $WORKDIR and piped to `python -` inside a
+# connector container, so it needs no image the ladder does not already run and
+# no host port -- connectors deliberately publish none.
+write_connector_probe() {
+    cat > "$WORKDIR/mcp_probe.py" <<'PY'
+"""Handshake with one connector over streamable HTTP and report its tools.
+
+argv: <url> <expected-tools-csv> [<tool-to-call>]
+
+Runs INSIDE a connector container, dialing another connector by the network
+alias Curie assigned it, so a pass covers three things at once: the alias
+resolves, the server is serving MCP, and its tool surface is the expected one.
+"""
+
+import json
+import sys
+import urllib.request
+
+url, expected_csv = sys.argv[1], sys.argv[2]
+call_tool = sys.argv[3] if len(sys.argv) > 3 else ""
+expected = sorted(name for name in expected_csv.split(",") if name)
+
+state = {"session": None, "version": "2024-11-05"}
+
+
+def post(body, notification=False):
+    headers = {
+        "Content-Type": "application/json",
+        # Both, because a streamable-HTTP server may answer either shape.
+        "Accept": "application/json, text/event-stream",
+        "MCP-Protocol-Version": state["version"],
+    }
+    if state["session"]:
+        headers["mcp-session-id"] = state["session"]
+    request = urllib.request.Request(
+        url, data=json.dumps(body).encode(), headers=headers, method="POST"
+    )
+    with urllib.request.urlopen(request, timeout=60) as response:
+        session = response.headers.get("mcp-session-id")
+        if session:
+            state["session"] = session
+        raw = response.read().decode("utf-8", "replace")
+    if notification:
+        return None
+    for line in raw.splitlines():
+        if line.startswith("data:"):
+            return json.loads(line[5:].strip())
+    return json.loads(raw)
+
+
+def fail(message):
+    sys.stderr.write("%s: %s\n" % (url, message))
+    raise SystemExit(1)
+
+
+try:
+    handshake = post(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": state["version"],
+                "capabilities": {},
+                "clientInfo": {"name": "curie-e2e-ladder", "version": "0"},
+            },
+        }
+    )
+except Exception as exc:
+    fail("the MCP handshake did not complete: %s: %s" % (type(exc).__name__, exc))
+
+if not isinstance(handshake, dict) or "result" not in handshake:
+    fail("initialize returned no result: %r" % (handshake,))
+state["version"] = handshake["result"].get("protocolVersion", state["version"])
+
+post({"jsonrpc": "2.0", "method": "notifications/initialized"}, notification=True)
+
+listed = post({"jsonrpc": "2.0", "id": 2, "method": "tools/list"})
+if not isinstance(listed, dict) or "result" not in listed:
+    fail("tools/list returned no result: %r" % (listed,))
+tools = sorted(tool["name"] for tool in listed["result"]["tools"])
+if expected and tools != expected:
+    fail("tools/list returned %s; expected %s" % (",".join(tools), ",".join(expected)))
+
+if call_tool:
+    # Deterministic and ungated by construction: an empty argument takes the
+    # server's own input-validation path, so it needs no live backend and
+    # cannot depend on data that changes between rungs.
+    called = post(
+        {
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {"name": call_tool, "arguments": {"trace_id": ""}},
+        }
+    )
+    body = json.dumps(called)
+    if "trace_id is required" not in body:
+        fail("%s did not take its input-validation path: %s" % (call_tool, body[:400]))
+
+print("OK %s" % ",".join(tools))
+PY
+}
+
+# Cross-rung entry parity. The entry the runner mounts is
+# `http://<release>-<agent>-mcp-<connector>.<namespace>.svc.cluster.local:<port>/mcp`,
+# and the NAMESPACE is the one component that legitimately differs between tiers
+# -- it is the namespace the connector is deployed into. So the pinned, byte-
+# compared value is everything else: the object name, the port and the path,
+# which is the part both sides derive independently and the part a release or
+# agent drift would move. Each rung's full URL is printed beside it.
+assert_connector_entries() {
+    local label="$1" entries="$2"
+    if [[ -z "$CONNECTOR_ENTRIES" ]]; then
+        CONNECTOR_ENTRIES="$entries"
+        CONNECTOR_ENTRY_RUNGS="$CONNECTOR_ENTRY_RUNGS $label"
+        echo "$label: connector MCP entries pinned for this ladder run:"
+        printf '%s\n' "$entries"
+        return 0
+    fi
+    if [[ "$entries" != "$CONNECTOR_ENTRIES" ]]; then
+        echo "$label: connector MCP entries DIVERGED from the pinned set." >&2
+        echo "pinned:" >&2
+        printf '%s\n' "$CONNECTOR_ENTRIES" >&2
+        echo "$label:" >&2
+        printf '%s\n' "$entries" >&2
+        echo "fix: the tiers do not agree on the address a connector answers to, so a turn on one of them dials a name nothing owns. Compare the connector scope each tier hands the runner." >&2
+        return 1
+    fi
+    CONNECTOR_ENTRY_RUNGS="$CONNECTOR_ENTRY_RUNGS $label"
+    echo "$label: connector MCP entries match the pinned set"
+}
+
+# The whole per-rung connector assertion.
+#
+# `kind` is docker (skill, local, local-release) or kubectl (cluster), and the
+# release/agent/namespace are read from the scope the TIER handed the runner --
+# never hardcoded here. That is what makes this a parity assertion rather than a
+# restatement: the ladder recomputes the address from the runner's own inputs
+# and then requires a connector to be answering on it.
+assert_connector_parity() {
+    local label="$1" kind="$2" release="$3" agent="$4" namespace="$5"
+    local connector object alias url entries="" host_ref="" image expected probe_pod=""
+
+    if [[ -z "$release" || -z "$agent" || -z "$namespace" ]]; then
+        echo "$label: the tier reported an incomplete connector scope (release='$release' agent='$agent' namespace='$namespace'), so no connector address can be derived. A partial scope switches connectors off entirely." >&2
+        return 1
+    fi
+    echo "$label: connector scope as the tier gave it to the runner: release=$release agent=$agent namespace=$namespace"
+    # Recorded so the post-teardown sweep looks for the same names this rung
+    # just proved were up, rather than re-deriving them once the tier that
+    # reported them is gone.
+    CONNECTOR_SCOPE_RELEASE="$release"
+    CONNECTOR_SCOPE_AGENT="$agent"
+    CONNECTOR_SCOPE_NAMESPACE="$namespace"
+
+    for connector in kubernetes "${CONNECTOR_BUILT[@]}"; do
+        object="$(connector_object_name "$release" "$agent" "$connector")" || return 1
+        alias="$object.$namespace.svc.cluster.local"
+        url="http://$alias:$CONNECTOR_PORT/mcp"
+        entries="$entries$connector=$object:$CONNECTOR_PORT/mcp"$'\n'
+
+        if [[ "$kind" == "docker" ]]; then
+            local container
+            if ! container="$(connector_container_for_alias "$alias")"; then
+                echo "$label: no running container labeled $CONNECTOR_LABEL answers to the alias '$alias', which is the name the runner derives and dials." >&2
+                docker ps --filter "label=$CONNECTOR_LABEL" --format '{{.Names}} {{.Image}}' >&2 || true
+                return 1
+            fi
+            image="$(docker inspect "$container" --format '{{.Config.Image}}')"
+            echo "$label: $connector is up as $container on $url"
+            [[ "$connector" == "tempo" ]] && host_ref="$container"
+        else
+            if ! kubectl -n "$namespace" get "deployment/$object" >/dev/null 2>&1; then
+                echo "$label: no Deployment $object exists in namespace $namespace, so the connector the runner would dial at $url is not running." >&2
+                return 1
+            fi
+            # Applied does not mean serving: the pod can still be pulling its
+            # image or starting up when the Deployment object first appears,
+            # which is exactly the race that sent the MCP probe below
+            # "Connection refused" against a live cluster. Wait for the
+            # rollout to finish before this connector is dialed.
+            if ! kubectl -n "$namespace" rollout status "deployment/$object" --timeout=120s; then
+                echo "$label: deployment/$object in namespace $namespace did not become available within 120s, so the MCP probe that follows would race pod startup." >&2
+                return 1
+            fi
+            image="$(kubectl -n "$namespace" get "deployment/$object" -o 'jsonpath={.spec.template.spec.containers[*].image}')"
+            echo "$label: $connector is up as deployment/$object on $url"
+            [[ "$connector" == "tempo" ]] && host_ref="$object"
+        fi
+
+        # The built connectors run the exact artifact the build resolved, and
+        # nothing else: that is the entire point of the lock (ADR 0113). The
+        # third connector is an ordinary pinned `image:`, checked against the
+        # fixture rather than the receipt.
+        if [[ " ${CONNECTOR_BUILT[*]} " == *" $connector "* ]]; then
+            expected="$(connector_image "$connector")" || return 1
+            if [[ "$image" != "$expected" ]]; then
+                echo "$label: $connector is running image '$image', but the build resolved '$expected'. A tier that starts anything else has lost the pin the lock exists to hold." >&2
+                return 1
+            fi
+            echo "$label: $connector runs the resolved image $image"
+        fi
+    done
+
+    if [[ -z "$host_ref" ]]; then
+        echo "$label: the tempo connector was not located, so there is nothing to run the MCP probe from." >&2
+        return 1
+    fi
+
+    # On a real cluster the connector NetworkPolicy admits ingress ONLY from
+    # pods labeled app.kubernetes.io/component=runner-sandbox (plus the
+    # release's own name/instance labels; see
+    # charts/curie/templates/security-networkpolicy.yaml) -- verified live: a
+    # plain pod dialing a healthy connector gets "Connection refused". Probing
+    # from a pod carrying those same three labels is the positive half of ADR
+    # 0113's proof ("the runner can use the same hosted MCP server
+    # configuration"); a bare pod being refused is the isolation negative, not
+    # a bug in this probe. The docker-hosted rungs have no such policy to
+    # satisfy, so only the kubectl kind needs this stand-in.
+    if [[ "$kind" != "docker" ]]; then
+        probe_pod="$release-$agent-mcp-probe"
+        kubectl -n "$namespace" delete pod "$probe_pod" --ignore-not-found --wait=true >/dev/null 2>&1 || true
+        kubectl -n "$namespace" run "$probe_pod" \
+            --image="$(connector_image tempo)" \
+            --restart=Never \
+            --labels="app.kubernetes.io/name=curie,app.kubernetes.io/instance=$release,app.kubernetes.io/component=runner-sandbox" \
+            --command -- sleep 300
+        if ! kubectl -n "$namespace" wait --for=condition=Ready "pod/$probe_pod" --timeout=60s; then
+            echo "$label: the runner-shaped probe pod $probe_pod never became Ready, so the MCP probe cannot run from it." >&2
+            kubectl -n "$namespace" delete pod "$probe_pod" --ignore-not-found --wait=false >/dev/null 2>&1 || true
+            return 1
+        fi
+    fi
+
+    # The probe runs FROM the tempo container (docker) or the runner-shaped
+    # probe pod (kubectl) and dials each built connector by its alias, so a
+    # pass covers alias resolution and netpol admission as well as serving.
+    local probe_out tools
+    for connector in "${CONNECTOR_BUILT[@]}"; do
+        object="$(connector_object_name "$release" "$agent" "$connector")" || return 1
+        url="http://$object.$namespace.svc.cluster.local:$CONNECTOR_PORT/mcp"
+        local probe_args=("$url")
+        if [[ "$connector" == "tempo" ]]; then
+            probe_args+=("$CONNECTOR_TOOLS_TEMPO" "get_trace")
+        else
+            probe_args+=("$CONNECTOR_TOOLS_K8S_WRITE")
+        fi
+        if [[ "$kind" == "docker" ]]; then
+            probe_out="$(docker exec -i "$host_ref" python - "${probe_args[@]}" < "$WORKDIR/mcp_probe.py")" || {
+                echo "$label: the MCP probe against $connector failed." >&2
+                return 1
+            }
+        else
+            probe_out="$(kubectl -n "$namespace" exec -i "$probe_pod" -- python - "${probe_args[@]}" < "$WORKDIR/mcp_probe.py")" || {
+                echo "$label: the MCP probe against $connector failed." >&2
+                kubectl -n "$namespace" delete pod "$probe_pod" --ignore-not-found --wait=false >/dev/null 2>&1 || true
+                return 1
+            }
+        fi
+        tools="${probe_out#OK }"
+        echo "$label: $connector handshook and served tools/list -> $tools"
+    done
+    echo "$label: the write verb was NOT exercised, deliberately: an approval round trip needs a second human actor, which no automated rung can supply without faking the thing under test. It is proved by the example's hands-on walkthrough instead."
+
+    if [[ -n "$probe_pod" ]]; then
+        kubectl -n "$namespace" delete pod "$probe_pod" --ignore-not-found --wait=false >/dev/null 2>&1 || true
+    fi
+
+    assert_connector_entries "$label" "$entries"
+}
+
+# After a teardown, nothing labeled as a connector may survive. Scoped to the
+# aliases this run's own bundle uses, never a bare host-wide label sweep: the
+# label is host-wide and another session's connectors are not this run's to
+# report on.
+assert_connectors_reaped() {
+    local label="$1" connector object alias survivor
+    if [[ -z "$CONNECTOR_SCOPE_RELEASE" ]]; then
+        echo "$label: no connector scope was recorded by this rung, so there is nothing to sweep for. assert_connector_parity must run before this." >&2
+        return 1
+    fi
+    for connector in kubernetes "${CONNECTOR_BUILT[@]}"; do
+        object="$(connector_object_name "$CONNECTOR_SCOPE_RELEASE" "$CONNECTOR_SCOPE_AGENT" "$connector")" || return 1
+        alias="$object.$CONNECTOR_SCOPE_NAMESPACE.svc.cluster.local"
+        if survivor="$(connector_container_for_alias "$alias")"; then
+            echo "$label: teardown left the connector container '$survivor' running (alias $alias)." >&2
+            return 1
+        fi
+    done
+    echo "$label: no connector containers survived teardown"
+}
+
+# The unchanged path, asserted rather than assumed: a bundle that declares no
+# hosted connector must start none. Scoped to the compose project this ladder
+# owns, for the same reason every other sweep here is.
+assert_no_connector_containers() {
+    local label="$1" survivors
+    survivors="$(docker ps --filter "label=$CONNECTOR_LABEL" --filter 'label=curietech.ai/project=curie' --format '{{.Names}}')"
+    if [[ -n "$survivors" ]]; then
+        echo "$label: this bundle declares no hosted connector, but connector containers are running for this project:" >&2
+        printf '%s\n' "$survivors" >&2
+        return 1
+    fi
+    echo "$label: no connector containers for a bundle that declares none"
+}
+
+# The skill tier's connector leg, run by the ladder itself rather than inside
+# cli/scripts/e2e.sh: that script owns its own up/message/down cycle and has
+# torn everything down by the time it returns, so there is no moment in it at
+# which a connector can be observed. Same bundle copy, its own runner name.
+case_connector_hosting_skill() {
+    echo
+    echo "=== case: the skill tier hosts the bundle's connectors (ADR 0113) ==="
+    # --fake-model unconditionally: this case sends no turn, so a model
+    # credential would be a prerequisite it does not need.
+    "$BIN" skill up --fake-model --plugin-dir "$WORKDIR/bundle" --name "$CONNECTOR_RUNNER_NAME"
+
+    local release agent namespace code=0
+    release="$(container_env_value "$CONNECTOR_RUNNER_NAME" CURIE_CONNECTOR_RELEASE)"
+    agent="$(container_env_value "$CONNECTOR_RUNNER_NAME" CURIE_CONNECTOR_AGENT)"
+    namespace="$(container_env_value "$CONNECTOR_RUNNER_NAME" CURIE_CONNECTOR_NAMESPACE)"
+    assert_connector_parity "skill" docker "$release" "$agent" "$namespace" || code=1
+
+    # Torn down whatever the assertion said, so a failed assertion cannot strand
+    # containers; the teardown sweep below only runs when there is a recorded
+    # scope to sweep for.
+    (cd "$WORKDIR/bundle" && "$BIN" skill down) || code=1
+    if (( code == 0 )); then
+        assert_connectors_reaped "skill" || code=1
+    fi
+    return "$code"
+}
+
 # Rung 1: the existing skill-tier round trip. Still exactly one implementation
 # and never copied -- but no longer unparameterized: it is handed THIS run's
 # bundle copy through CURIE_E2E_BUNDLE, so rung 1 boots and grades the same
@@ -713,6 +1346,10 @@ rung_skill() {
     assert_bundle_identity "skill" "$digest"
 
     case_leftover_runner_container
+
+    if connector_mode; then
+        case_connector_hosting_skill
+    fi
 }
 
 # Rung 2: the compose tier, cold start to teardown.
@@ -763,11 +1400,12 @@ rung_local() {
     # receipt's bundle.sha256 -- the platform's server-side hash of the bytes this
     # rung uploaded -- is the ONLY surface that reports this tier's artifact
     # identity. Read from stdout only; the human text is on stderr.
-    local deploy_json digest agent_id deployment_id
+    local deploy_json digest agent_id agent_name deployment_id
     deploy_json="$("$BIN" --json local deploy --plugin-dir "$WORKDIR/bundle")"
     printf '%s\n' "$deploy_json"
     digest="$(deploy_field "local" "$deploy_json" bundle.sha256)"
     agent_id="$(deploy_field "local" "$deploy_json" agent.id)"
+    agent_name="$(deploy_field "local" "$deploy_json" agent.name)"
     deployment_id="$(deploy_field "local" "$deploy_json" deployment.id)"
 
     echo
@@ -781,6 +1419,19 @@ rung_local() {
     local observed_mode
     observed_mode="$(probe_local_fake_model)"
     assert_model_mode "local" "$observed_mode"
+
+    echo
+    echo "=== assert the bundle's connectors (ADR 0113) ==="
+    if connector_mode; then
+        local worker
+        worker="$(local_worker_container)"
+        assert_connector_parity "local" docker \
+            "$(container_env_value "$worker" CURIE_RELEASE)" \
+            "$agent_name" \
+            "$(container_env_value "$worker" CURIE_NAMESPACE)"
+    else
+        assert_no_connector_containers "local"
+    fi
 
     echo
     echo "=== curie local message --json ==="
@@ -842,6 +1493,9 @@ rung_local() {
             return 1
         fi
         echo "no curie containers running"
+        if connector_mode; then
+            assert_connectors_reaped "local"
+        fi
     fi
 
     # Last, not at the deploy step: see assert_bundle_identity's comment. The
@@ -939,11 +1593,12 @@ rung_local_release() {
     # cold-start deploy. The copies now pack to the same digest by construction
     # (their regular-file mtimes are normalized where they are created), so a
     # separate copy no longer means a separate identity.
-    local deploy_json digest agent_id deployment_id
+    local deploy_json digest agent_id agent_name deployment_id
     deploy_json="$("$BIN" --json local deploy --plugin-dir "$WORKDIR/bundle-release")"
     printf '%s\n' "$deploy_json"
     digest="$(deploy_field "local-release" "$deploy_json" bundle.sha256)"
     agent_id="$(deploy_field "local-release" "$deploy_json" agent.id)"
+    agent_name="$(deploy_field "local-release" "$deploy_json" agent.name)"
     deployment_id="$(deploy_field "local-release" "$deploy_json" deployment.id)"
 
     echo
@@ -959,6 +1614,19 @@ rung_local_release() {
     local observed_mode
     observed_mode="$(probe_local_fake_model)"
     assert_model_mode "local-release" "$observed_mode"
+
+    echo
+    echo "=== assert the bundle's connectors (ADR 0113) ==="
+    if connector_mode; then
+        local worker
+        worker="$(local_worker_container)"
+        assert_connector_parity "local-release" docker \
+            "$(container_env_value "$worker" CURIE_RELEASE)" \
+            "$agent_name" \
+            "$(container_env_value "$worker" CURIE_NAMESPACE)"
+    else
+        assert_no_connector_containers "local-release"
+    fi
 
     echo
     echo "=== curie local message --json (release-compose stack) ==="
@@ -1004,6 +1672,9 @@ rung_local_release() {
             return 1
         fi
         echo "no curie containers running"
+        if connector_mode; then
+            assert_connectors_reaped "local-release"
+        fi
     fi
 
     assert_bundle_identity "local-release" "$digest"
@@ -1048,11 +1719,12 @@ print("yes" if isinstance(d, dict) and d.get("release_found") is True else "no")
     # --json for the receipt: `cluster status --json` carries no digest, so the
     # deploy receipt's bundle.sha256 is the only artifact-identity surface here
     # too.
-    local deploy_json digest agent_id deployment_id deployment_status deployment_environment
+    local deploy_json digest agent_id agent_name deployment_id deployment_status deployment_environment
     deploy_json="$("$BIN" --json cluster deploy --plugin-dir "$WORKDIR/bundle")"
     printf '%s\n' "$deploy_json"
     digest="$(deploy_field "cluster" "$deploy_json" bundle.sha256)"
     agent_id="$(deploy_field "cluster" "$deploy_json" agent.id)"
+    agent_name="$(deploy_field "cluster" "$deploy_json" agent.name)"
     deployment_id="$(deploy_field "cluster" "$deploy_json" deployment.id)"
     deployment_status="$(deploy_field "cluster" "$deploy_json" deployment.status)"
     deployment_environment="$(deploy_field "cluster" "$deploy_json" deployment.environment)"
@@ -1098,6 +1770,23 @@ print("yes" if isinstance(d, dict) and d.get("release_found") is True else "no")
     local observed_mode
     observed_mode="$(probe_cluster_fake_model)"
     assert_model_mode "cluster" "$observed_mode"
+
+    if connector_mode; then
+        echo
+        echo "=== assert the bundle's connectors (ADR 0113) ==="
+        # Read off the installed release's own worker, the same deployment
+        # probe_cluster_fake_model reads, so the scope is the one the cluster
+        # actually hands the runner rather than a ladder assumption. The
+        # namespace is genuinely different here from the skill and local rungs
+        # -- it is the namespace the release is installed into -- which is why
+        # the pinned entry set excludes it.
+        local cluster_release cluster_namespace
+        cluster_release="$(kubectl -n curie get deployment/curie-worker \
+            -o 'jsonpath={.spec.template.spec.containers[*].env[?(@.name=="CURIE_RELEASE")].value}')"
+        cluster_namespace="$(kubectl -n curie get deployment/curie-worker \
+            -o 'jsonpath={.spec.template.spec.containers[*].env[?(@.name=="CURIE_NAMESPACE")].value}')"
+        assert_connector_parity "cluster" kubectl "$cluster_release" "$agent_name" "$cluster_namespace"
+    fi
 
     echo
     echo "=== curie cluster message --json ==="
@@ -1218,6 +1907,31 @@ fi
 cp -r "$BUNDLE_SRC" "$WORKDIR/bundle"
 cp -r "$BUNDLE_SRC" "$WORKDIR/bundle-release"
 
+# The connector rung's inputs, and the ORDER is load-bearing. The fixture and
+# the lock are packed like any other bundle file, so both must land before the
+# mtime normalization below and before any rung packs -- otherwise the copies
+# pack to different bytes and every multi-rung run is red by construction.
+if connector_mode; then
+    echo
+    echo "=== connector bundle: fixture, credentials, build ==="
+    if (( RUN_CLUSTER )) && [[ -z "$CONNECTOR_REGISTRY" ]]; then
+        echo "error: the cluster rung is named and CURIE_E2E_CONNECTOR_REGISTRY is unset." >&2
+        echo "why: without a registry the build delivers into the local Docker daemon, and a cluster deploy refuses a local-daemon lock by design -- the nodes cannot pull it." >&2
+        echo "fix: export CURIE_E2E_CONNECTOR_REGISTRY=<ref you can push to>, or drop cluster from CURIE_E2E_TIERS." >&2
+        exit 1
+    fi
+    prepare_connector_bundle "$WORKDIR/bundle"
+    prepare_connector_bundle "$WORKDIR/bundle-release"
+    provision_connector_credentials
+    write_connector_probe
+    # ONE build, and its lock is COPIED to the second copy rather than built
+    # again: a second build would resolve its own image reference, and the two
+    # copies would then pack to different bytes. Every rung consumes this one
+    # lock unchanged, which is what makes the digest assertion meaningful.
+    build_connector_images "$WORKDIR/bundle"
+    cp "$WORKDIR/bundle/connectors.lock.yaml" "$WORKDIR/bundle-release/connectors.lock.yaml"
+fi
+
 # Normalize every regular file's mtime across both copies. This is load-bearing,
 # not hygiene: the digest every rung asserts on identifies an ARCHIVE, not a
 # source tree, because pack_tar_gz embeds per-file mtime (cli/src/bundle.rs), and
@@ -1297,6 +2011,21 @@ else
     echo "bundle identity: $PARITY_DIGEST, reported by rung(s):$PARITY_RUNGS"
     if (( $(wc -w <<< "$PARITY_RUNGS") < 2 )); then
         echo "note: only one rung reported a digest, so the CROSS-RUNG digest comparison was vacuous for this tier set -- only that rung's own identity was recorded. This is NOT a cross-rung parity claim."
+    fi
+fi
+if connector_mode; then
+    if [[ -z "$CONNECTOR_ENTRIES" ]]; then
+        echo "connectors: NOT asserted by any rung that ran, so nothing about connector hosting was proven."
+    else
+        echo "connectors: hosted and serving MCP at rung(s):$CONNECTOR_ENTRY_RUNGS, on the entries"
+        while IFS= read -r entry; do
+            [[ -n "$entry" ]] && echo "  $entry"
+        done <<< "$CONNECTOR_ENTRIES"
+        echo "connectors: the entry set above is the object name, port and path -- the part both sides derive independently. The namespace differs by tier by design and is printed per rung above."
+        if (( $(wc -w <<< "$CONNECTOR_ENTRY_RUNGS") < 2 )); then
+            echo "note: only one rung asserted connectors, so the CROSS-RUNG comparison was vacuous for this tier set. This is NOT a cross-tier connector parity claim."
+        fi
+        echo "connectors: the gated write verb was NOT exercised at any rung -- an approval round trip needs a second human actor. Read this as hosting parity only."
     fi
 fi
 echo "suite: \"$EXPECT_SUITE\" with $EXPECT_CASE_COUNT case(s), resolved by the tier's own loader at rung(s):$SUITE_RUNGS"

--- a/cli/scripts/e2e-ladder.sh
+++ b/cli/scripts/e2e-ladder.sh
@@ -148,6 +148,14 @@ CONNECTOR_SCOPE_NAMESPACE=""
 # default name: that one belongs to whatever real `skill up` a developer has
 # going on this box.
 CONNECTOR_RUNNER_NAME="curie-ladder-connectors-$$"
+# The runner the changed-source case boots, on its own scratch copy of the
+# bundle. A second name for the same reason as the one above, and a second name
+# rather than a reuse because both runners may be recorded at once if the first
+# case fails before its teardown.
+CHANGED_RUNNER_NAME="curie-ladder-changed-$$"
+# The runner the hermetic negative boots, in the runs where no connector bundle
+# is named at all. Same rule again: never the default name.
+HERMETIC_RUNNER_NAME="curie-ladder-hermetic-$$"
 # Hardcoded, and deliberately NOT an env knob: the stub port is the constant
 # DEFAULT_LOCAL_STUB_PORT in cli/src/message.rs, pinned to the compose worker's
 # SLACK_API_BASE_URL. An override would only move this script's precheck, so it
@@ -901,6 +909,32 @@ connector_image() {
     return 1
 }
 
+# One field of one connector's `connectors.lock.yaml` entry.
+#
+# An awk read of the two-space block serde_norway writes, not a YAML parse: the
+# ladder's python3 use is json-only on purpose and a YAML module would be a new
+# required input. It FAILS LOUDLY on a miss and dumps the file, rather than
+# returning an empty string -- an empty value compared against another empty
+# value is the vacuous green this ladder exists to prevent.
+lock_field() {
+    local dir="$1" connector="$2" key="$3" value
+    value="$(awk -v want="  $connector:" -v key="    $key: " '
+$0 == want { inside = 1; next }
+inside && /^  [^ ]/ { inside = 0 }
+inside && index($0, key) == 1 { print substr($0, length(key) + 1); found = 1; exit }
+END { exit(found ? 0 : 1) }
+' "$dir/connectors.lock.yaml")" || {
+        echo "no '$key' recorded for connector '$connector' in $dir/connectors.lock.yaml. That file's shape is what this read depends on; compare it against ConnectorLockEntryDecl in cli/src/connector_build.rs." >&2
+        cat "$dir/connectors.lock.yaml" >&2 || true
+        return 1
+    }
+    # Quoted only if the value needed it; the comparisons downstream are on the
+    # value, never on its rendering.
+    value="${value%\"}"; value="${value#\"}"
+    value="${value%\'}"; value="${value#\'}"
+    printf '%s' "$value"
+}
+
 # A hand mirror of connector_render.object_name / service_dns, which is what
 # BOTH sides derive independently: the CLI names the container's network alias
 # from it, and the runner derives the URL it dials from it. The ladder recomputes
@@ -1259,17 +1293,29 @@ assert_connectors_reaped() {
 }
 
 # The unchanged path, asserted rather than assumed: a bundle that declares no
-# hosted connector must start none. Scoped to the compose project this ladder
-# owns, for the same reason every other sweep here is.
+# hosted connector must start none.
+#
+# The PROJECT is a parameter and not a constant, because the tiers do not agree
+# on it: `connector_project_label` (cli/src/docker.rs) stamps the COMPOSE
+# PROJECT at the local tier and the runner's SESSION ID at the skill tier, so
+# the `curietech.ai/project=curie` this used to hardcode selects nothing at all
+# on a skill-tier container -- an empty survivor list every time, which is a
+# green that proves nothing. Scoped rather than swept host-wide for the same
+# reason every other sweep here is scoped: the component label is host-wide and
+# another session's connectors are not this run's to report on.
 assert_no_connector_containers() {
-    local label="$1" survivors
-    survivors="$(docker ps --filter "label=$CONNECTOR_LABEL" --filter 'label=curietech.ai/project=curie' --format '{{.Names}}')"
+    local label="$1" project="$2" survivors
+    if [[ -z "$project" ]]; then
+        echo "$label: no connector project scope was read, so this sweep would match nothing no matter what started. An unscoped negative is a green that proves nothing, which is exactly what this assertion exists to avoid." >&2
+        return 1
+    fi
+    survivors="$(docker ps --filter "label=$CONNECTOR_LABEL" --filter "label=curietech.ai/project=$project" --format '{{.Names}}')"
     if [[ -n "$survivors" ]]; then
-        echo "$label: this bundle declares no hosted connector, but connector containers are running for this project:" >&2
+        echo "$label: this bundle declares no hosted connector, but connector containers are running for project '$project':" >&2
         printf '%s\n' "$survivors" >&2
         return 1
     fi
-    echo "$label: no connector containers for a bundle that declares none"
+    echo "$label: no connector containers for a bundle that declares none (project $project)"
 }
 
 # The skill tier's connector leg, run by the ladder itself rather than inside
@@ -1297,6 +1343,209 @@ case_connector_hosting_skill() {
         assert_connectors_reaped "skill" || code=1
     fi
     return "$code"
+}
+
+# The hermetic negative at the skill tier, and the reason it boots a runner of
+# its own rather than sweeping after `cli/scripts/e2e.sh`: the project label a
+# skill-tier connector container carries is the RUNNER'S SESSION ID
+# (cli/src/docker.rs connector_project_label), which exists only while that
+# runner does. e2e.sh has torn its runner down by the time it returns, so a
+# sweep placed after it has no project to scope to and would assert nothing.
+# This boots the same bundle copy rung 1 just ran, reads the session off the
+# runner it started, and sweeps while it is up.
+case_no_connector_hosting_skill() {
+    echo
+    echo "=== case: a bundle declaring no hosted connector starts none (ADR 0113) ==="
+    # A scratch copy with connectors.yaml removed, because the shared bundle is
+    # NOT connector-free: examples/weather deliberately carries the hosted
+    # netpol-probe fixture (19f9cd48) for the cluster NetworkPolicy gate, and
+    # this case's first run against it proved the point by finding that
+    # connector hosted. The claim under test is about a bundle that declares
+    # none, so build one.
+    rm -rf "$WORKDIR/bundle-hermetic"
+    cp -R "$WORKDIR/bundle" "$WORKDIR/bundle-hermetic"
+    rm -rf "$WORKDIR/bundle-hermetic/.curie" "$WORKDIR/bundle-hermetic/connectors.yaml" \
+        "$WORKDIR/bundle-hermetic/connectors.lock.yaml"
+    # --fake-model unconditionally, for the same reason the connector case does
+    # it: this case sends no turn, so a model credential is a prerequisite it
+    # does not need.
+    "$BIN" skill up --fake-model --plugin-dir "$WORKDIR/bundle-hermetic" --name "$HERMETIC_RUNNER_NAME"
+
+    local session code=0
+    session="$(container_env_value "$HERMETIC_RUNNER_NAME" CURIE_SESSION_ID)"
+    assert_no_connector_containers "skill" "$session" || code=1
+
+    # Torn down whatever the assertion said, so a failed assertion cannot strand
+    # the runner.
+    (cd "$WORKDIR/bundle-hermetic" && "$BIN" skill down) || code=1
+    return "$code"
+}
+
+# An edited connector source must move the lock AND the container that runs it.
+# That is the entire reason `connectors.lock.yaml` records a `source_digest`
+# (ADR 0113): without this, a tier that brought up the previously locked image
+# after a source edit would look identical to a correct run, and every other
+# connector assertion here would still pass.
+#
+# It runs on a THIRD scratch copy, never `$WORKDIR/bundle`: the shared copy's
+# bytes are what every later rung packs and compares (assert_bundle_identity),
+# so mutating it would red the cross-rung digest assertion on a change this case
+# made rather than on a real divergence.
+case_connector_changed_source_skill() {
+    echo
+    echo "=== case: an edited connector source moves the lock and the running container (ADR 0113) ==="
+    local dir="$WORKDIR/bundle-changed"
+    rm -rf "$dir"
+    cp -r "$WORKDIR/bundle" "$dir"
+    # The copy inherits rung 1's recorded runner state, and `skill up` refuses a
+    # directory that already records one.
+    rm -rf "$dir/.curie"
+
+    local before_digest before_image
+    before_digest="$(lock_field "$dir" tempo source_digest)" || return 1
+    before_image="$(lock_field "$dir" tempo image)" || return 1
+    echo "tempo before the edit: source_digest=$before_digest image=$before_image"
+
+    # An appended comment: it moves the bytes the source digest covers and the
+    # layer the image is built from (server.py is the last COPY in the
+    # connector's Dockerfile), and changes nothing the server does.
+    echo "# curie parity ladder changed-source probe ($$)" >> "$dir/connectors/tempo/server.py"
+
+    if [[ -n "$CONNECTOR_REGISTRY" ]]; then
+        # `skill up`'s auto-rebuild resolves into the LOCAL DAEMON, and
+        # `write_lock` refuses to replace a registry-delivered lock with a
+        # local-daemon one behind a bring-up (cli/src/connector_build.rs
+        # lock_overwrite_refusal) -- by design, because only a pushed image is
+        # deployable to a cluster. So when this run built for a registry, the
+        # rebuild is the explicit one that refusal's own fix line names. The
+        # claim under test is unchanged either way: the edit must move the lock
+        # and the container.
+        echo "=== curie build --plugin-dir (changed source, registry delivery: $CONNECTOR_REGISTRY) ==="
+        "$BIN" build --plugin-dir "$dir" --registry "$CONNECTOR_REGISTRY"
+    else
+        echo "the rebuild below is skill up's OWN (cli/src/commands.rs, ADR 0113 Decision 3), not a hand-run build: the production consumer of a stale lock is the tier's bring-up, so that is what this case exercises."
+    fi
+
+    "$BIN" skill up --fake-model --plugin-dir "$dir" --name "$CHANGED_RUNNER_NAME"
+
+    local code=0
+    assert_connector_source_change "$dir" "$before_digest" "$before_image" || code=1
+
+    (cd "$dir" && "$BIN" skill down) || code=1
+    return "$code"
+}
+
+# The assertion half of the case above, split out so the teardown runs whatever
+# it says.
+assert_connector_source_change() {
+    local dir="$1" before_digest="$2" before_image="$3"
+    local after_digest after_image release agent namespace object alias container running
+
+    after_digest="$(lock_field "$dir" tempo source_digest)" || return 1
+    after_image="$(lock_field "$dir" tempo image)" || return 1
+    if [[ "$after_digest" == "$before_digest" ]]; then
+        echo "skill: the tempo connector's source was edited, but connectors.lock.yaml still records source_digest $after_digest. The lock did not notice the edit, so every later tier would bring up the pre-edit image believing it current." >&2
+        return 1
+    fi
+    if [[ "$after_image" == "$before_image" ]]; then
+        echo "skill: the tempo connector's source_digest moved to $after_digest, but the lock still names image '$after_image'. A moved digest that resolves the same artifact is the stale-image bug wearing a fresh label." >&2
+        return 1
+    fi
+    echo "skill: the edit moved the lock: source_digest $before_digest -> $after_digest, image $before_image -> $after_image"
+
+    release="$(container_env_value "$CHANGED_RUNNER_NAME" CURIE_CONNECTOR_RELEASE)"
+    agent="$(container_env_value "$CHANGED_RUNNER_NAME" CURIE_CONNECTOR_AGENT)"
+    namespace="$(container_env_value "$CHANGED_RUNNER_NAME" CURIE_CONNECTOR_NAMESPACE)"
+    if [[ -z "$release" || -z "$agent" || -z "$namespace" ]]; then
+        echo "skill: the runner started from the edited copy reported an incomplete connector scope (release='$release' agent='$agent' namespace='$namespace'), so no connector address can be derived." >&2
+        return 1
+    fi
+    object="$(connector_object_name "$release" "$agent" tempo)" || return 1
+    alias="$object.$namespace.svc.cluster.local"
+    if ! container="$(connector_container_for_alias "$alias")"; then
+        echo "skill: no running container labeled $CONNECTOR_LABEL answers to '$alias' after the rebuild, so the rebuilt connector is not up at all." >&2
+        docker ps --filter "label=$CONNECTOR_LABEL" --format '{{.Names}} {{.Image}}' >&2 || true
+        return 1
+    fi
+    running="$(docker inspect "$container" --format '{{.Config.Image}}')"
+    if [[ "$running" != "$after_image" ]]; then
+        echo "skill: the lock now resolves tempo to '$after_image', but container '$container' is running '$running'. The bring-up started the pre-edit artifact, which is the exact failure the lock's source_digest exists to catch." >&2
+        return 1
+    fi
+    echo "skill: the restarted tempo connector runs the rebuilt image $running"
+}
+
+# A cluster deploy whose locked image the REGISTRY cannot resolve must refuse,
+# and must refuse before it has touched the cluster (ADR 0113, cli/src/commands.rs
+# registry_preflight). The failure this guards against is not theoretical: the
+# lock is what a node pulls from, so an image that is gone from the registry
+# surfaces after apply as a pod stuck on ImagePullBackOff, with a healthy
+# connector Deployment already replaced. Refusing up front is what keeps the
+# running release intact, so both halves are asserted -- the refusal AND the
+# untouched Deployment.
+case_connector_registry_missing_cluster() {
+    local release="$1" agent="$2" namespace="$3"
+    echo
+    echo "=== case: cluster deploy refuses a lock the registry cannot resolve (ADR 0113) ==="
+    local lock="$WORKDIR/bundle/connectors.lock.yaml"
+    local backup="$WORKDIR/connectors.lock.yaml.good"
+    local object before after good bad out code=0
+
+    object="$(connector_object_name "$release" "$agent" tempo)" || return 1
+    before="$(kubectl -n "$namespace" get "deployment/$object" -o 'jsonpath={.spec.template.spec.containers[*].image}')"
+    if [[ -z "$before" ]]; then
+        echo "cluster: deployment/$object reports no container image, so there is no before-and-after to compare the refused deploy against." >&2
+        return 1
+    fi
+
+    good="$(connector_image tempo)" || return 1
+    # A tag `registry_image_ref` can never mint: it emits a hex prefix of the
+    # source digest and nothing else (cli/src/connector_build.rs), so this one
+    # cannot collide with a real push and is absent from the registry by
+    # construction rather than by luck.
+    bad="${good%:*}:ladder-absent"
+
+    cp "$lock" "$backup"
+    # The IMAGE only, never the source_digest: moving the digest trips
+    # `lock_preflight`'s staleness refusal first, and this case would then
+    # assert a green against the wrong refusal entirely.
+    sed -i "s|$good|$bad|" "$lock"
+    if ! grep -qF "$bad" "$lock"; then
+        echo "cluster: connectors.lock.yaml still does not name '$bad' after the edit, so the deploy below would run against a perfectly good lock and prove nothing." >&2
+        cp "$backup" "$lock"
+        touch -t 200001010000 "$lock"
+        return 1
+    fi
+    echo "cluster: tempo's locked image corrupted to '$bad' for this one deploy"
+
+    out="$("$BIN" --json cluster deploy --plugin-dir "$WORKDIR/bundle" 2>&1)" && code=0 || code=$?
+    printf '%s\n' "$out"
+
+    # Restored BEFORE the assertions, so a red one cannot carry a corrupt lock
+    # into the rest of this rung. Restored from the byte-for-byte backup rather
+    # than rebuilt: a rebuild costs minutes and, more to the point, re-stamps the
+    # file's mtime, which pack_tar_gz embeds -- and this copy's packed bytes are
+    # what assert_bundle_identity compares. The fixed epoch is the one the ladder
+    # normalizes every bundle file to.
+    cp "$backup" "$lock"
+    touch -t 200001010000 "$lock"
+
+    if (( code != 2 )); then
+        echo "cluster: a deploy whose locked image the registry cannot resolve must exit 2 (usage), got $code." >&2
+        return 1
+    fi
+    if [[ "$out" != *"registry could not resolve"* ]]; then
+        echo "cluster: the deploy failed, but not with the registry-resolution refusal, so this case never reached the preflight it is aimed at. A deploy that fails for some other reason is not evidence the lock is checked." >&2
+        return 1
+    fi
+    echo "cluster: cluster deploy refused the unresolvable image with exit 2"
+
+    after="$(kubectl -n "$namespace" get "deployment/$object" -o 'jsonpath={.spec.template.spec.containers[*].image}')"
+    if [[ "$after" != "$before" ]]; then
+        echo "cluster: the refused deploy still moved deployment/$object from '$before' to '$after'. A preflight that refuses after touching the cluster has already broken the release it was meant to protect." >&2
+        return 1
+    fi
+    echo "cluster: deployment/$object still runs $before -- the refusal changed nothing on the cluster"
 }
 
 # Rung 1: the existing skill-tier round trip. Still exactly one implementation
@@ -1349,6 +1598,12 @@ rung_skill() {
 
     if connector_mode; then
         case_connector_hosting_skill
+        case_connector_changed_source_skill
+    else
+        # The hermetic claim, exercised on every ordinary run rather than only
+        # in connector mode: the default bundle declares no hosted connector, so
+        # this rung is where "declares none, starts none" is actually testable.
+        case_no_connector_hosting_skill
     fi
 }
 
@@ -1430,7 +1685,10 @@ rung_local() {
             "$agent_name" \
             "$(container_env_value "$worker" CURIE_NAMESPACE)"
     else
-        assert_no_connector_containers "local"
+        # `curie` is the compose project the CLI pins (cli/src/local.rs
+        # COMPOSE_PROJECT), and the project this tier stamps on a connector
+        # container is that same name.
+        assert_no_connector_containers "local" curie
     fi
 
     echo
@@ -1625,7 +1883,9 @@ rung_local_release() {
             "$agent_name" \
             "$(container_env_value "$worker" CURIE_NAMESPACE)"
     else
-        assert_no_connector_containers "local-release"
+        # Same compose project as rung 2: the release compose file the CLI
+        # generates carries the same pinned project name.
+        assert_no_connector_containers "local-release" curie
     fi
 
     echo
@@ -1786,6 +2046,7 @@ print("yes" if isinstance(d, dict) and d.get("release_found") is True else "no")
         cluster_namespace="$(kubectl -n curie get deployment/curie-worker \
             -o 'jsonpath={.spec.template.spec.containers[*].env[?(@.name=="CURIE_NAMESPACE")].value}')"
         assert_connector_parity "cluster" kubectl "$cluster_release" "$agent_name" "$cluster_namespace"
+        case_connector_registry_missing_cluster "$cluster_release" "$agent_name" "$cluster_namespace"
     fi
 
     echo

--- a/cli/scripts/e2e-ladder.sh
+++ b/cli/scripts/e2e-ladder.sh
@@ -1499,11 +1499,15 @@ case_connector_registry_missing_cluster() {
     fi
 
     good="$(connector_image tempo)" || return 1
-    # A tag `registry_image_ref` can never mint: it emits a hex prefix of the
-    # source digest and nothing else (cli/src/connector_build.rs), so this one
-    # cannot collide with a real push and is absent from the registry by
-    # construction rather than by luck.
-    bad="${good%:*}:ladder-absent"
+    # The digest's 64 hex characters replaced, and NOTHING else: the reference
+    # stays `<repo>@sha256:<64 lowercase hex>`, the one shape `parse_lock`
+    # accepts for registry delivery (cli/src/connector_build.rs). A tag here
+    # would be refused at the read instead, and this case would then assert a
+    # green against the lock reader rather than against the registry preflight
+    # it is aimed at. All-f is absent from the registry by construction: it is
+    # the digest of no content anyone has ever pushed, and a sha256 collision
+    # with it is not a thing that happens.
+    bad="${good%@*}@sha256:$(printf 'f%.0s' {1..64})"
 
     cp "$lock" "$backup"
     # The IMAGE only, never the source_digest: moving the digest trips

--- a/cli/scripts/fixtures/sre-bot-connectors-enabled.yaml
+++ b/cli/scripts/fixtures/sre-bot-connectors-enabled.yaml
@@ -1,0 +1,84 @@
+# The parity ladder's connector fixture: `examples/sre-bot/connectors.yaml` with
+# every connector the example ships commented out turned ON (ADR 0113, #1690).
+#
+# WHY A CHECKED-IN WHOLE FILE rather than a scripted uncomment of the example.
+# `sed` against a comment block is fragile in exactly the direction that hides a
+# failure: the moment the example's comment formatting shifts, the uncomment
+# silently produces an EMPTY connector set, every rung hosts nothing, and the
+# ladder goes green having asserted nothing at all. A whole file cannot degrade
+# that way -- it either parses with three connectors or it fails loudly.
+#
+# WHY IT LIVES HERE and never under `examples/sre-bot/`. The shipped example is
+# read-only by default and stays that way (#1691): the write connector is a
+# deliberate opt-in with a credential and an approval route in front of it. This
+# is a test input, so it lives with the test.
+#
+# The ladder copies the example into a throwaway workdir and overwrites
+# `connectors.yaml` with this file, then applies the `approvalPolicy` gate the
+# example's README documents to the copy's `plugin.json`. The gate TRAVELS WITH
+# the connector: bundle validation rejects a gate naming an undeclared
+# connector, so a bundle enabling `k8s-write` without it would host an ungated
+# write verb, which contradicts the example's whole security shape.
+#
+# Every value here is a public-repo placeholder. The credentials the three
+# connectors declare are provisioned by the ladder into the scratch copy and the
+# rung's process env only -- never into the operator's secret store.
+connectors:
+  # Unchanged from the example except for `unhosted_url`, which is dropped
+  # below along with the other two: a connector declaring one is deliberately
+  # NOT hosted at the skill and local tiers (the operator is pointing at their
+  # own copy instead), and hosting parity is the only thing these rungs assert.
+  #
+  # If a future image of this server refuses to start without a reachable API
+  # server, give this one connector its `unhosted_url` back and drop
+  # K8S_READONLY_KUBECONFIG from the ladder's provisioning step: the built
+  # connectors below are the subject of the assertion, this one is the control
+  # that a plain `image:` connector hosts identically beside them.
+  kubernetes:
+    image: ghcr.io/containers/kubernetes-mcp-server:v0.0.66
+    args:
+      - --port
+      - "8000"
+      - --bind-address
+      - 0.0.0.0
+      - --read-only
+      - --toolsets
+      - core
+      - --disable-destructive
+      - --disable-multi-cluster
+      - --stateless
+      - --kubeconfig
+      - /secrets/kubeconfig
+    secret_files:
+      K8S_READONLY_KUBECONFIG: /secrets/kubeconfig
+
+  # The two `build:` connectors: no image reference anywhere, so every rung can
+  # only run what `curie build --plugin-dir` resolved and recorded in
+  # `connectors.lock.yaml`.
+  k8s-write:
+    build:
+      context: connectors/k8s-write
+      platforms: [linux/amd64, linux/arm64]
+    env:
+      # The connector refuses to start on an empty allowlist, so this is
+      # load-bearing for the rung and not decoration. A placeholder pair: the
+      # ladder never calls the write verb, which needs a second human actor.
+      K8S_WRITE_ALLOWLIST: acme-prod/acme-api
+    secret_files:
+      # A SEPARATE credential from the read-only one above, as the example
+      # requires. The ladder generates two distinct scratch kubeconfigs and
+      # never reuses one for both.
+      K8S_WRITE_KUBECONFIG: /secrets/kubeconfig
+
+  tempo:
+    build:
+      context: connectors/tempo
+      platforms: [linux/amd64, linux/arm64]
+    env:
+      GRAFANA_URL: https://grafana.example.com
+      TEMPO_DATASOURCE_UID: __Tempo__
+    secrets:
+      # The server refuses to start without it. The ladder supplies a
+      # rung-scoped placeholder: its tool call is an input-validation path that
+      # never reaches Grafana.
+      - GRAFANA_SERVICE_ACCOUNT_TOKEN

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -1062,6 +1062,10 @@ pub async fn deploy_named(folder: &str, opts: DeployNamedOpts) -> Result<DeployO
         secret: opts.secret,
         secret_binding_supported: true,
         connect_hint,
+        // The third local-deploy caller (block B1-11): it must reach the same
+        // preflight `local deploy` does, or a source-built bundle uploads with
+        // no lock check.
+        tier: DeployTier::Local,
     })
     .await
 }
@@ -1794,7 +1798,7 @@ pub async fn start(opts: StartOpts) -> Result<()> {
     // below reports the MODEL credential alone -- a `--secret` name riding in
     // `passthrough_env` is not one, and counting it would let the panel claim a
     // credential for a runner that has none.
-    let (model_cred_names, passthrough_env) = {
+    let (model_cred_names, mut passthrough_env) = {
         let ambient_present = ambient_present_for(&docker_env);
         let model_cred_names = select_passthrough_env(
             fake_model,
@@ -1826,6 +1830,60 @@ pub async fn start(opts: StartOpts) -> Result<()> {
             return Err(err.context("packaging the bundle snapshot for the runner"));
         }
     };
+
+    // Hosted connectors (ADR 0113). A bundle that declares none takes the
+    // existing hermetic path untouched; one that declares some gets a private
+    // network the runner and the connectors share, and the connector scope in
+    // the runner's boot env so `derive_mcp_servers` takes its normal path.
+    let connector_decl = crate::connector_build::load(&plugin_dir)?;
+    let mut connector_containers: Vec<String> = Vec::new();
+    let mut connector_network: Option<String> = None;
+    if connector_decl
+        .connectors
+        .values()
+        .any(|spec| spec.url.is_none() && spec.unhosted_url.is_none())
+    {
+        let net = match &network {
+            Some(net) => net.clone(),
+            None => {
+                let net = format!("{}-net", opts.name);
+                if docker::create_network(&net).await? {
+                    owned_network = Some(net.clone());
+                }
+                net
+            }
+        };
+        let identity = crate::connector_build::ConnectorScope {
+            release: "curie".to_string(),
+            agent: plugin_name.clone(),
+            namespace: "default".to_string(),
+        };
+        match start_skill_connectors(&plugin_dir, &connector_decl, &identity, &net, &session_id)
+            .await
+        {
+            Ok(started) => connector_containers = started,
+            Err(err) => {
+                // Nothing is recorded yet, so this is the only chance to release
+                // whatever the partial bring-up created (#747).
+                let steps = docker::connector_teardown_plan(
+                    &session_id,
+                    owned_network.as_deref(),
+                    Some(&plugin_dir),
+                );
+                let _ = docker::run_connector_teardown(&steps).await;
+                if let Some(ollama) = &ollama_container {
+                    let _ = docker::remove_container(ollama).await;
+                }
+                return Err(err.context("starting the bundle's connectors"));
+            }
+        }
+        for (key, value) in crate::connector_build::connector_scope_env(&identity) {
+            passthrough_env.push(key.clone());
+            docker_env.push((key, value));
+        }
+        network = Some(net.clone());
+        connector_network = Some(net);
+    }
 
     let spec = StartSpec {
         image: opts.image.clone(),
@@ -1916,6 +1974,8 @@ pub async fn start(opts: StartOpts) -> Result<()> {
             model_base_url: model_base_url.clone(),
             bundle_digest: Some(snapshot.digest.clone()),
             bundle_snapshot_dir: Some(snapshot.dir.display().to_string()),
+            connector_containers: connector_containers.clone(),
+            connector_network: connector_network.clone(),
         },
     ) {
         let _ = docker::remove_container(&opts.name).await;
@@ -2254,6 +2314,19 @@ async fn stop_recorded(
         ui.note(&format!(
             "kept model-cache volume '{volume}' for fast re-up; remove it with 'docker volume rm {volume}'"
         ));
+    }
+    // Connector containers, then the staged credential tree (ADR 0113,
+    // block B1-8). Label-scoped, so a connector this bundle started is reaped
+    // even if the record is incomplete; the network is left to the owned-network
+    // branch below, which alone knows whether this boot created it.
+    let connector_problems = docker::run_connector_teardown(&docker::connector_teardown_plan(
+        &saved.session_id,
+        None,
+        Some(dir),
+    ))
+    .await;
+    for problem in connector_problems {
+        ui.warn(&problem);
     }
     if let Some(net) = &saved.network {
         match docker::remove_network(net).await {
@@ -3422,6 +3495,20 @@ pub struct DeployOpts {
     /// `curie local up` for local). Naming the fix turns a raw
     /// "Connection refused" into something the operator can act on.
     pub connect_hint: String,
+    /// Which tier this deploy targets. Explicit and without a `Default` impl on
+    /// purpose: `local deploy`, `cluster deploy` and `deploy_named` all reach
+    /// one `deploy()`, so the cluster-only connector checks have nothing to
+    /// select on without it, and a new caller must not silently inherit
+    /// `Local` and skip them.
+    pub tier: DeployTier,
+}
+
+/// The tier a deploy targets. Two variants, no default: the compiler enumerates
+/// every construction site when the field is added.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeployTier {
+    Local,
+    Cluster,
 }
 
 /// The declared connector-secret NAMES not present in the operator's bound
@@ -3495,6 +3582,26 @@ pub async fn deploy(opts: DeployOpts) -> Result<DeployOutput> {
         .canonicalize()
         .with_context(|| format!("plugin dir not found: {}", opts.plugin_dir.display()))?;
     let (plugin_name, manifest_version) = read_manifest(&plugin_dir)?;
+
+    // Connector lock preflight (ADR 0113), before the bundle is packed so the
+    // failure names the operator's own directory rather than a temp path, and
+    // long before anything is applied. `opts.plugin_dir` (not the canonicalized
+    // copy) is the path they typed.
+    {
+        let decl = crate::connector_build::load(&plugin_dir)?;
+        if decl.connectors.values().any(|spec| spec.build.is_some()) {
+            let recomputed = recompute_source_digests(&plugin_dir, &decl)?;
+            let lock = crate::connector_build::load_lock(&plugin_dir)?;
+            lock_preflight(
+                &opts.plugin_dir,
+                &decl,
+                lock.as_ref(),
+                &recomputed,
+                opts.tier,
+            )?;
+        }
+    }
+
     let label = opts
         .label
         .unwrap_or_else(|| format!("{manifest_version}-{}", unix_now()));
@@ -3712,6 +3819,27 @@ pub async fn deploy(opts: DeployOpts) -> Result<DeployOutput> {
             }
         }
     };
+    // The local tier runs the bundle's connectors itself (ADR 0113). Reached by
+    // both local callers -- `local deploy` and `deploy-local` -- because both
+    // arrive here, so the shorthand cannot upload a source-built bundle and
+    // start no connector. The identity is the one the deploy RESOLVED, never
+    // re-read from plugin.json: `--agent`/`--target` can override it, and an
+    // alias built from the manifest name is one the runner never dials.
+    if opts.tier == DeployTier::Local {
+        let lock = crate::connector_build::load_lock(&plugin_dir)?.unwrap_or_else(|| {
+            crate::connector_build::ConnectorLockFileDecl {
+                version: crate::connector_build::LOCK_VERSION,
+                connectors: std::collections::BTreeMap::new(),
+            }
+        });
+        let identity = crate::connector_build::ConnectorScope {
+            release: "curie".to_string(),
+            agent: outcome.agent.name.clone(),
+            namespace: "default".to_string(),
+        };
+        bring_up_local(&plugin_dir, &lock, &identity, crate::local::COMPOSE_PROJECT).await?;
+    }
+
     Ok(DeployOutput {
         plugin_name,
         label,
@@ -6746,6 +6874,7 @@ mod tests {
             secret: vec![],
             secret_binding_supported: true,
             connect_hint: hint.to_string(),
+            tier: super::DeployTier::Local,
         };
         let err = super::deploy(opts).await.unwrap_err();
         let rendered = format!("{err:#}");
@@ -6818,6 +6947,7 @@ mod tests {
             secret: vec!["GH_TOKEN".to_string()],
             secret_binding_supported: true,
             connect_hint: "UNREACHABLE-HINT-SENTINEL".to_string(),
+            tier: super::DeployTier::Local,
         };
         let err = super::deploy(opts).await.unwrap_err();
         let rendered = format!("{err:#}");
@@ -6854,6 +6984,7 @@ mod tests {
             secret: vec![],
             secret_binding_supported: false,
             connect_hint: "UNREACHABLE-HINT-SENTINEL".to_string(),
+            tier: super::DeployTier::Cluster,
         };
         let err = super::deploy(opts).await.unwrap_err();
         let rendered = format!("{err:#}");
@@ -7780,6 +7911,8 @@ mod tests {
             model_base_url: None,
             bundle_digest: digest.map(str::to_string),
             bundle_snapshot_dir: snapshot_dir.map(str::to_string),
+            connector_containers: Vec::new(),
+            connector_network: None,
         }
     }
 
@@ -8467,4 +8600,554 @@ mod overrides_tests {
             OverrideChange::Set("m".into())
         );
     }
+}
+
+// ---------------------------------------------------------------------------
+// Connector source builds (ADR 0113): `curie build --plugin-dir`
+// ---------------------------------------------------------------------------
+
+/// One connector's resolved identity, as `curie build --plugin-dir` reports it.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ConnectorBuildRecord {
+    pub name: String,
+    pub image: String,
+    pub delivery: crate::connector_build::Delivery,
+    pub platforms: Vec<String>,
+    pub source_digest: String,
+}
+
+/// The `curie build --plugin-dir` receipt: one object, always, even when the
+/// bundle declares nothing to build. Empty stdout under `--json` is the #485
+/// failure -- an agent consumer cannot tell "nothing to build" from "the
+/// command produced nothing".
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ConnectorBuildOutput {
+    pub connectors: Vec<ConnectorBuildRecord>,
+}
+
+impl crate::ui::CliOutput for ConnectorBuildOutput {
+    fn to_json(&self) -> serde_json::Value {
+        // Delegated wholesale to the `Serialize` value rather than hand-picked
+        // field by field, so a record can never lose a field on the emit hop.
+        serde_json::to_value(self).unwrap_or_else(|_| serde_json::json!({ "connectors": [] }))
+    }
+
+    fn render(&self, ui: &crate::ui::Ui) {
+        if self.connectors.is_empty() {
+            ui.note("this bundle declares no connectors to build");
+            return;
+        }
+        for record in &self.connectors {
+            ui.payload_plain(&format!("{} -> {}", record.name, record.image));
+        }
+    }
+}
+
+/// The flags `curie build --plugin-dir` carries.
+pub struct ConnectorBuildOpts {
+    pub plugin_dir: PathBuf,
+    /// `Some(ref)` pushes a multi-platform index there; `None` builds the host
+    /// platform into the local Docker daemon.
+    pub registry: Option<String>,
+    /// Replace a registry lock with a local-daemon one deliberately.
+    pub force: bool,
+}
+
+/// `curie build --plugin-dir <dir>`: build every connector the bundle declares
+/// from source and write `connectors.lock.yaml`.
+///
+/// Deliberately does NOT look for a repo checkout the way `build` does: a
+/// released binary building a bundle's connectors has none, and requiring one
+/// would make the whole feature source-only.
+pub async fn build_connectors(opts: ConnectorBuildOpts) -> Result<ConnectorBuildOutput> {
+    use crate::connector_build as cb;
+
+    let plugin_dir = opts
+        .plugin_dir
+        .canonicalize()
+        .with_context(|| format!("plugin dir not found: {}", opts.plugin_dir.display()))?;
+    let decl = cb::load(&plugin_dir)?;
+    let buildable: Vec<(&String, &cb::ConnectorSpecDecl)> = decl
+        .connectors
+        .iter()
+        .filter(|(_, spec)| spec.build.is_some())
+        .collect();
+    if buildable.is_empty() {
+        return Ok(ConnectorBuildOutput {
+            connectors: Vec::new(),
+        });
+    }
+    if !on_path("docker") {
+        bail!(
+            "Docker is not installed or not on PATH. Install Docker \
+             (https://docs.docker.com/get-docker/) and retry."
+        );
+    }
+    let (bundle_name, _version) = read_manifest(&plugin_dir)?;
+
+    // buildx writes its build result here; a private per-run directory rather
+    // than the bundle, so a metadata file never rides the upload.
+    let metadata_dir = std::env::temp_dir().join(format!("curie-build-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&metadata_dir)
+        .with_context(|| format!("create {}", metadata_dir.display()))?;
+
+    let ui = crate::ui::ui();
+    let host = cb::host_platform();
+    let mut records = Vec::new();
+    let mut entries = std::collections::BTreeMap::new();
+    let mut failure = None;
+    for (connector, spec) in buildable {
+        let plan = match cb::build_plan(
+            &plugin_dir,
+            &bundle_name,
+            connector,
+            spec,
+            opts.registry.as_deref(),
+            &host,
+            &metadata_dir,
+        ) {
+            Ok(plan) => plan,
+            Err(err) => {
+                failure = Some(err);
+                break;
+            }
+        };
+        match run_one_connector_build(&plan, ui).await {
+            Ok(image) => {
+                entries.insert(
+                    connector.clone(),
+                    cb::ConnectorLockEntryDecl {
+                        image: image.clone(),
+                        delivery: plan.delivery,
+                        platforms: plan.platforms.clone(),
+                        source_digest: plan.source_digest.clone(),
+                    },
+                );
+                records.push(ConnectorBuildRecord {
+                    name: connector.clone(),
+                    image,
+                    delivery: plan.delivery,
+                    platforms: plan.platforms.clone(),
+                    source_digest: plan.source_digest,
+                });
+            }
+            Err(err) => {
+                failure = Some(err);
+                break;
+            }
+        }
+    }
+    let _ = std::fs::remove_dir_all(&metadata_dir);
+    if let Some(err) = failure {
+        // A build that could not run writes no lock: a partial lock would claim
+        // a resolved image for a connector that has none.
+        return Err(err);
+    }
+
+    cb::write_lock(
+        &plugin_dir,
+        &cb::ConnectorLockFileDecl {
+            version: cb::LOCK_VERSION,
+            connectors: entries,
+        },
+        opts.force,
+    )?;
+    Ok(ConnectorBuildOutput {
+        connectors: records,
+    })
+}
+
+/// Run one connector's build and read back the immutable reference it produced.
+async fn run_one_connector_build(
+    plan: &crate::connector_build::ConnectorBuildPlan,
+    ui: &crate::ui::Ui,
+) -> Result<String> {
+    use crate::connector_build as cb;
+
+    let command = cb::build_argv(plan);
+    ui.note(&format!("=== {} ===", command.display()));
+    // Inherit stdio so the build log streams like a hand-run build.
+    let status = tokio::process::Command::new(&command.program)
+        .args(command.argv())
+        .status()
+        .await
+        .context("failed to invoke docker")?;
+    if !status.success() {
+        bail!("building connector '{}' failed ({status})", plan.connector);
+    }
+    match plan.delivery {
+        cb::Delivery::Registry => {
+            let metadata_file = plan
+                .metadata_file
+                .as_ref()
+                .ok_or_else(|| anyhow::anyhow!("a registry build records no metadata file"))?;
+            let raw = std::fs::read_to_string(metadata_file)
+                .with_context(|| format!("read {}", metadata_file.display()))?;
+            Ok(cb::digest_pinned_ref(
+                &plan.image_ref,
+                &cb::digest_from_metadata(&raw)?,
+            ))
+        }
+        cb::Delivery::LocalDaemon => {
+            let inspect = cb::image_inspect_argv(&plan.image_ref);
+            crate::docker::docker(&inspect.argv()).await
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The deploy-time lock preflight (ADR 0113)
+// ---------------------------------------------------------------------------
+
+/// The command that clears a missing or stale lock, as the operator would type
+/// it against their own bundle directory.
+fn rebuild_hint(plugin_dir: &Path, registry: bool) -> String {
+    if registry {
+        format!(
+            "run `curie build --plugin-dir {} --registry <ref>` and redeploy",
+            plugin_dir.display()
+        )
+    } else {
+        format!(
+            "run `curie build --plugin-dir {}` and redeploy",
+            plugin_dir.display()
+        )
+    }
+}
+
+/// Refuse a deploy whose `build:` connectors have no usable lock.
+///
+/// The CLI mirror of the platform's intake rule, run before the bundle is even
+/// packed so the operator gets a local failure naming their own directory
+/// instead of an upload rejection about a file nobody told them to make. A
+/// bundle with no `build:` connector is untouched.
+pub fn lock_preflight(
+    plugin_dir: &Path,
+    decl: &crate::connector_build::ConnectorsFileDecl,
+    lock: Option<&crate::connector_build::ConnectorLockFileDecl>,
+    recomputed: &std::collections::BTreeMap<String, String>,
+    tier: DeployTier,
+) -> Result<()> {
+    use crate::connector_build::Delivery;
+
+    for (connector, spec) in &decl.connectors {
+        if spec.build.is_none() {
+            continue;
+        }
+        let Some(entry) = lock.and_then(|lock| lock.connectors.get(connector)) else {
+            return Err(anyhow::Error::from(
+                crate::exit::CliError::usage(format!(
+                    "connectors.{connector} builds from source, but {} records no image for it. \
+                     Build it before deploying.",
+                    crate::connector_build::CONNECTOR_LOCK_FILE
+                ))
+                .with_fix(rebuild_hint(plugin_dir, false)),
+            ));
+        };
+        if let Some(fresh) = recomputed.get(connector) {
+            if &entry.source_digest != fresh {
+                return Err(anyhow::Error::from(
+                    crate::exit::CliError::usage(format!(
+                        "connectors.{connector} has changed since {} was written, so the locked \
+                         image no longer matches this source.",
+                        crate::connector_build::CONNECTOR_LOCK_FILE
+                    ))
+                    .with_fix(rebuild_hint(plugin_dir, false)),
+                ));
+            }
+        }
+        if tier == DeployTier::Cluster && entry.delivery == Delivery::LocalDaemon {
+            return Err(anyhow::Error::from(
+                crate::exit::CliError::usage(format!(
+                    "connectors.{connector} is locked to an image in your local Docker daemon, \
+                     which no cluster node can pull. Push it to a registry first."
+                ))
+                .with_fix(rebuild_hint(plugin_dir, true)),
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Ask the REGISTRY, by digest, for the raw manifest.
+///
+/// `--raw` matters: without it `imagetools inspect` pretty-prints, and a parser
+/// reading that output is reading a presentation format that has changed before.
+pub fn registry_manifest_argv(image: &str) -> crate::ops::OpsCommand {
+    crate::connector_build::plain_command(
+        "docker",
+        vec![
+            "buildx".into(),
+            "imagetools".into(),
+            "inspect".into(),
+            image.to_string(),
+            "--raw".into(),
+        ],
+    )
+}
+
+/// The architectures the cluster's own nodes report.
+pub fn node_architectures_argv() -> crate::ops::OpsCommand {
+    crate::connector_build::plain_command(
+        "kubectl",
+        vec![
+            "get".into(),
+            "nodes".into(),
+            "-o".into(),
+            "jsonpath={.items[*].status.nodeInfo.architecture}".into(),
+        ],
+    )
+}
+
+/// Parse that jsonpath's output: one space-separated word per node, duplicates
+/// being the common case.
+pub fn node_architectures(raw: &str) -> std::collections::BTreeSet<String> {
+    raw.split_whitespace().map(str::to_string).collect()
+}
+
+/// The platform set an OCI image index actually covers.
+///
+/// buildx's attestation manifests are `unknown/unknown` and are neither a
+/// platform the image covers nor a defect: a real multi-arch `--push` emits
+/// them alongside the real entries by default. A plain single-platform manifest
+/// has no `manifests` array at all and covers nothing the declaration promised.
+pub fn manifest_platforms(raw: &str) -> Result<std::collections::BTreeSet<String>> {
+    let parsed: serde_json::Value =
+        serde_json::from_str(raw).context("parse the registry manifest")?;
+    let Some(manifests) = parsed.get("manifests").and_then(|m| m.as_array()) else {
+        return Ok(std::collections::BTreeSet::new());
+    };
+    Ok(manifests
+        .iter()
+        .filter_map(|entry| {
+            let platform = entry.get("platform")?;
+            let os = platform.get("os")?.as_str()?;
+            let arch = platform.get("architecture")?.as_str()?;
+            (os != "unknown" && arch != "unknown").then(|| format!("{os}/{arch}"))
+        })
+        .collect())
+}
+
+/// Refuse a cluster deploy whose locked image is gone from the registry, or
+/// whose resolved index cannot run on every node.
+///
+/// The comparison is against the REGISTRY's answer, never the lock's declared
+/// platforms: a lock declaring two platforms while the push went out single-arch
+/// passes a declaration check and fails after apply as `no matching manifest`.
+pub fn registry_preflight(
+    image: &str,
+    inspect: std::result::Result<&str, String>,
+    node_architectures: &std::collections::BTreeSet<String>,
+    declared_platforms: &[String],
+) -> Result<()> {
+    let raw = match inspect {
+        Ok(raw) => raw,
+        Err(stderr) => {
+            return Err(anyhow::Error::from(
+                crate::exit::CliError::usage(format!(
+                    "the registry could not resolve {image}: {}. The image the lock names is not \
+                     there, so no node could pull it.",
+                    stderr.trim()
+                ))
+                .with_fix(
+                    "rebuild and push it with `curie build --plugin-dir <dir> --registry <ref>`, \
+                     then redeploy",
+                ),
+            ));
+        }
+    };
+    let covered = manifest_platforms(raw).map_err(|err| {
+        anyhow::Error::from(
+            crate::exit::CliError::usage(format!(
+                "the registry's answer for {image} is not a manifest this build understands: {err}"
+            ))
+            .with_fix(
+                "rebuild and push it with `curie build --plugin-dir <dir> --registry <ref>`, \
+                 then redeploy",
+            ),
+        )
+    })?;
+    let missing: Vec<String> = node_architectures
+        .iter()
+        .filter(|arch| !covered.contains(&format!("linux/{arch}")))
+        .cloned()
+        .collect();
+    if missing.is_empty() {
+        return Ok(());
+    }
+    Err(anyhow::Error::from(
+        crate::exit::CliError::usage(format!(
+            "{image} covers [{}] in the registry, but this cluster's nodes report [{}], so [{}] \
+             has no image to run. The lock declares [{}].",
+            covered.iter().cloned().collect::<Vec<_>>().join(", "),
+            node_architectures
+                .iter()
+                .cloned()
+                .collect::<Vec<_>>()
+                .join(", "),
+            missing.join(", "),
+            declared_platforms.join(", "),
+        ))
+        .with_fix(
+            "rebuild every architecture the nodes run with `curie build --plugin-dir <dir> \
+             --registry <ref>`, then redeploy",
+        ),
+    ))
+}
+
+/// The recomputed `source_digest` of every `build:` connector in a bundle, for
+/// the preflight to compare the lock against.
+pub fn recompute_source_digests(
+    plugin_dir: &Path,
+    decl: &crate::connector_build::ConnectorsFileDecl,
+) -> Result<std::collections::BTreeMap<String, String>> {
+    let mut digests = std::collections::BTreeMap::new();
+    for (connector, spec) in &decl.connectors {
+        let Some(build) = &spec.build else { continue };
+        let context = crate::connector_build::resolve_context(plugin_dir, &build.context)
+            .with_context(|| format!("connectors.{connector}"))?;
+        digests.insert(
+            connector.clone(),
+            crate::connector_build::source_digest_of(&context, build)
+                .with_context(|| format!("connectors.{connector}"))?,
+        );
+    }
+    Ok(digests)
+}
+
+// ---------------------------------------------------------------------------
+// The local tier's connector bring-up
+// ---------------------------------------------------------------------------
+
+/// Generate the connector compose overlay for a deployed bundle and bring it up.
+///
+/// One helper, both local deploy callers (`local deploy` and `deploy-local`), so
+/// the shorthand cannot upload a source-built bundle and start no connector.
+/// The RESOLVED identity is passed in rather than re-derived from `plugin.json`:
+/// `--agent`/`--target` can override the manifest's name, and a helper that read
+/// it again would alias the connectors under one identity while the runner
+/// dialed another.
+pub async fn bring_up_local(
+    plugin_dir: &Path,
+    lock: &crate::connector_build::ConnectorLockFileDecl,
+    identity: &crate::connector_build::ConnectorScope,
+    project: &str,
+) -> Result<()> {
+    use crate::connector_build as cb;
+
+    let decl = cb::load(plugin_dir)?;
+    let hosted: Vec<(&String, &cb::ConnectorSpecDecl)> = decl
+        .connectors
+        .iter()
+        .filter(|(_, spec)| spec.url.is_none() && spec.unhosted_url.is_none())
+        .collect();
+    if hosted.is_empty() {
+        return Ok(());
+    }
+
+    let mut secret_values = std::collections::BTreeMap::new();
+    for (connector, spec) in &hosted {
+        cb::refuse_out_of_band_secrets(connector, spec)?;
+        for name in cb::declared_secret_names(spec) {
+            if let Some(value) = resolve_connector_secret(&name)? {
+                secret_values.insert(name, value);
+            }
+        }
+        // Credential files are staged where both emitters expect them, so the
+        // container finds bytes rather than an empty mount.
+        for (key, declared_path) in &spec.secret_files {
+            if let Some(value) = resolve_connector_secret(key)? {
+                cb::stage_secret_file(plugin_dir, connector, declared_path, &value)?;
+            }
+        }
+    }
+
+    let overlay = cb::compose_overlay(lock, &decl, identity, project, plugin_dir, &secret_values)?;
+    let path = cb::compose_overlay_path(plugin_dir);
+    std::fs::create_dir_all(path.parent().expect("the overlay path has a parent"))?;
+    std::fs::write(
+        &path,
+        serde_norway::to_string(&overlay).context("serialize the connector compose overlay")?,
+    )
+    .with_context(|| format!("write {}", path.display()))?;
+
+    let command = cb::compose_up_command(&path, project);
+    let (ok, _out, err) = crate::ops::run_capture(&command)
+        .await
+        .context("starting the bundle's connectors")?;
+    if !ok {
+        bail!("starting the bundle's connectors failed: {}", err.trim());
+    }
+    Ok(())
+}
+
+/// One connector credential, from the environment first and the host vault
+/// second. Never printed.
+fn resolve_connector_secret(name: &str) -> Result<Option<String>> {
+    if let Some(value) = std::env::var(name).ok().filter(|v| !v.is_empty()) {
+        return Ok(Some(value));
+    }
+    crate::secrets::get_value(name)
+}
+
+/// Start one container per hosted connector on the runner's private network.
+///
+/// Returns the container names so `skill down` reaps exactly what this boot
+/// created. Credentials are staged first, so each container finds bytes at its
+/// declared mount path rather than an empty file.
+async fn start_skill_connectors(
+    plugin_dir: &Path,
+    decl: &crate::connector_build::ConnectorsFileDecl,
+    identity: &crate::connector_build::ConnectorScope,
+    network: &str,
+    project: &str,
+) -> Result<Vec<String>> {
+    use crate::connector_build as cb;
+
+    let lock = cb::load_lock(plugin_dir)?.unwrap_or_else(|| cb::ConnectorLockFileDecl {
+        version: cb::LOCK_VERSION,
+        connectors: std::collections::BTreeMap::new(),
+    });
+    let mut started = Vec::new();
+    for (connector, spec) in &decl.connectors {
+        if spec.url.is_some() || spec.unhosted_url.is_some() {
+            continue;
+        }
+        cb::refuse_out_of_band_secrets(connector, spec)?;
+        let mut secret_values = std::collections::BTreeMap::new();
+        for name in cb::declared_secret_names(spec) {
+            if let Some(value) = resolve_connector_secret(&name)? {
+                secret_values.insert(name, value);
+            }
+        }
+        for (key, declared_path) in &spec.secret_files {
+            if let Some(value) = resolve_connector_secret(key)? {
+                cb::stage_secret_file(plugin_dir, connector, declared_path, &value)?;
+            }
+        }
+        let image = match lock.connectors.get(connector) {
+            Some(entry) => entry.image.clone(),
+            None => spec.image.clone().ok_or_else(|| {
+                crate::exit::usage(format!(
+                    "connectors.{connector} declares no `image` and {} records none for it.",
+                    cb::CONNECTOR_LOCK_FILE
+                ))
+            })?,
+        };
+        let start = docker::ConnectorStartSpec::from_declaration(
+            connector,
+            spec,
+            &image,
+            identity,
+            network,
+            project,
+            plugin_dir,
+            &secret_values,
+        )?;
+        docker::docker_with_env(&start.run_args(), &start.docker_env)
+            .await
+            .with_context(|| format!("starting connector '{connector}'"))?;
+        started.push(start.container_name);
+    }
+    Ok(started)
 }

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -1565,25 +1565,33 @@ fn short_digest(digest: &str) -> String {
 }
 
 /// Release everything a boot that has already packed its snapshot leaves behind
-/// when it aborts: the ollama sidecar, the network `start` owns, and the
-/// snapshot itself.
+/// when it aborts: the ollama sidecar, the hosted connectors, the network
+/// `start` owns, and the snapshot itself.
 ///
 /// One definition for all three abort arms between the pack and a recorded
 /// state, because nothing else will ever collect these: no state was saved, so
 /// no `skill down` can find them (#1087). A fourth abort path added later gets
 /// the whole sequence by calling this rather than by remembering three lines.
 ///
+/// Order is load bearing: the connectors are attached to the owned network, and
+/// `docker network rm` fails while any container is still on it, so every
+/// connector goes before the network does (ADR 0113).
+///
 /// Every release is best effort and deliberately swallows its error: these run
 /// while a command is already failing for its own reason, and must not change
 /// the error it reports or the code it exits with.
 async fn release_boot_scaffolding(
     ollama_container: Option<&String>,
+    connector_containers: &[String],
     owned_network: Option<&String>,
     snapshot_dir: &Path,
     plugin_dir: &Path,
 ) {
     if let Some(ollama) = ollama_container {
         let _ = docker::remove_container(ollama).await;
+    }
+    for connector in connector_containers {
+        let _ = docker::remove_container(connector).await;
     }
     if let Some(net) = owned_network {
         let _ = docker::remove_network(net).await;
@@ -1810,12 +1818,79 @@ pub async fn start(opts: StartOpts) -> Result<()> {
         (model_cred_names, passthrough)
     };
 
+    // Hosted-connector preflights (ADR 0113) run BEFORE the snapshot is packed:
+    // the runner validates the packed snapshot, so a lock rewritten after
+    // packing would leave the runner refusing the stale copy it was handed
+    // while the source directory holds the fresh one.
+    let connector_decl = crate::connector_build::load(&plugin_dir)?;
+    let declares_hosted_connectors = connector_decl
+        .connectors
+        .values()
+        .any(|spec| spec.url.is_none() && spec.unhosted_url.is_none());
+    if declares_hosted_connectors {
+        // Fail closed on a missing credential BEFORE anything is created. It
+        // runs ahead of the rebuild below because there is no point spending
+        // minutes building images for a bring-up that will refuse, and ahead of
+        // the network and every container because a partial bring-up that then
+        // aborts leaks work this checks for up front instead.
+        if let Err(err) = refuse_missing_connector_secrets(&connector_decl) {
+            if let Some(ollama) = &ollama_container {
+                let _ = docker::remove_container(ollama).await;
+            }
+            if let Some(net) = &owned_network {
+                let _ = docker::remove_network(net).await;
+            }
+            return Err(err);
+        }
+        // ADR 0113's Decision 3, and its deliberate asymmetry: at the skill tier
+        // a missing or stale `connectors.lock.yaml` is REBUILT here, where the
+        // source and a Docker daemon are both within reach; at the cluster tier
+        // `lock_preflight` refuses instead. Without this, an edit to a connector's
+        // source silently brings up the previously locked image. A fresh lock
+        // computes no rebuild and issues no `docker build`, so the offline
+        // guarantee `cli/CLAUDE.md` makes for `skill up` still holds. It runs
+        // before the snapshot pack so the runner's copy carries the lock this
+        // writes, and before `start_skill_connectors`, which re-reads the lock
+        // from disk and so picks up whatever this wrote.
+        let stale = connectors_needing_rebuild(
+            &connector_decl,
+            crate::connector_build::load_lock(&plugin_dir)?.as_ref(),
+            &recompute_source_digests(&plugin_dir, &connector_decl)?,
+        );
+        if !stale.is_empty() {
+            // Not forced: a lock resolved to a pushed registry image is the
+            // operator's, and `write_lock` refuses to quietly downgrade it to a
+            // local-daemon one behind a `skill up`.
+            if let Err(err) = build_connectors(ConnectorBuildOpts {
+                plugin_dir: plugin_dir.clone(),
+                registry: None,
+                force: false,
+            })
+            .await
+            {
+                // A build is minutes long and fails for ordinary reasons (a bad
+                // Dockerfile, no daemon), so it releases what boot has created so
+                // far rather than leaving an ollama sidecar to collide with the
+                // operator's next attempt. No snapshot or connector container
+                // exists yet.
+                if let Some(ollama) = &ollama_container {
+                    let _ = docker::remove_container(ollama).await;
+                }
+                if let Some(net) = &owned_network {
+                    let _ = docker::remove_network(net).await;
+                }
+                return Err(err.context("rebuilding the bundle's connectors"));
+            }
+        }
+    }
+
     // #1087: the skill tier executes an immutable, content-addressed snapshot,
     // not the editable source -- matching what local and cluster already do. The
     // packer is the deploy path's packer, so the digest is the same one the API
     // records for this source. Placed AFTER the --replace teardown above so a
     // re-up of unchanged source (same digest, same directory) cannot have the
-    // snapshot it just created torn down again.
+    // snapshot it just created torn down again, and after the connector
+    // rebuild above so the packed bundle carries the lock the runner validates.
     let snapshot = match crate::bundle::snapshot(&plugin_dir) {
         Ok(snapshot) => snapshot,
         Err(err) => {
@@ -1835,14 +1910,9 @@ pub async fn start(opts: StartOpts) -> Result<()> {
     // existing hermetic path untouched; one that declares some gets a private
     // network the runner and the connectors share, and the connector scope in
     // the runner's boot env so `derive_mcp_servers` takes its normal path.
-    let connector_decl = crate::connector_build::load(&plugin_dir)?;
     let mut connector_containers: Vec<String> = Vec::new();
     let mut connector_network: Option<String> = None;
-    if connector_decl
-        .connectors
-        .values()
-        .any(|spec| spec.url.is_none() && spec.unhosted_url.is_none())
-    {
+    if declares_hosted_connectors {
         let net = match &network {
             Some(net) => net.clone(),
             None => {
@@ -1911,9 +1981,11 @@ pub async fn start(opts: StartOpts) -> Result<()> {
         Ok(id) => id,
         Err(err) => {
             // Nothing recorded the snapshot, so no teardown will ever find it
-            // (#1087); release it here alongside the sidecar and the network.
+            // (#1087); release it here alongside the sidecar, the connectors,
+            // and the network.
             release_boot_scaffolding(
                 ollama_container.as_ref(),
+                &connector_containers,
                 owned_network.as_ref(),
                 &snapshot.dir,
                 &plugin_dir,
@@ -1944,6 +2016,7 @@ pub async fn start(opts: StartOpts) -> Result<()> {
         // chance to release it (#1087).
         release_boot_scaffolding(
             ollama_container.as_ref(),
+            &connector_containers,
             owned_network.as_ref(),
             &snapshot.dir,
             &plugin_dir,
@@ -1984,6 +2057,7 @@ pub async fn start(opts: StartOpts) -> Result<()> {
         // nothing behind (#1087).
         release_boot_scaffolding(
             ollama_container.as_ref(),
+            &connector_containers,
             owned_network.as_ref(),
             &snapshot.dir,
             &plugin_dir,
@@ -3599,6 +3673,12 @@ pub async fn deploy(opts: DeployOpts) -> Result<DeployOutput> {
                 &recomputed,
                 opts.tier,
             )?;
+            // What the REGISTRY answers for the locked digest, not what the lock
+            // claims about it, is what a node has to pull (see
+            // `registry_preflight`). Cluster only: no local deploy pulls this.
+            if opts.tier == DeployTier::Cluster {
+                run_registry_preflight(&decl, lock.as_ref()).await?;
+            }
         }
     }
 
@@ -8995,6 +9075,55 @@ pub fn registry_preflight(
     ))
 }
 
+/// The lock entries a cluster deploy has to ask the registry about: the entries
+/// of the `build:` connectors whose lock delivers through a registry.
+///
+/// Everything else is out of scope by construction -- an `image:` connector
+/// pulls a reference nobody here built, and a `local-daemon` build has already
+/// been refused by [`lock_preflight`] at this tier. An empty result is the
+/// common bundle, and it queries nothing.
+pub fn registry_preflight_targets<'a>(
+    decl: &crate::connector_build::ConnectorsFileDecl,
+    lock: Option<&'a crate::connector_build::ConnectorLockFileDecl>,
+) -> Vec<&'a crate::connector_build::ConnectorLockEntryDecl> {
+    decl.connectors
+        .iter()
+        .filter(|(_, spec)| spec.build.is_some())
+        .filter_map(|(connector, _)| lock.and_then(|lock| lock.connectors.get(connector)))
+        .filter(|entry| entry.delivery == crate::connector_build::Delivery::Registry)
+        .collect()
+}
+
+/// The impure half of [`registry_preflight`]: query the registry and the
+/// cluster, then hand both answers to the decision.
+///
+/// The node architectures are read ONCE and shared across every connector --
+/// they are a property of the cluster, not of the image, so one `kubectl get
+/// nodes` covers a bundle building any number of connectors.
+async fn run_registry_preflight(
+    decl: &crate::connector_build::ConnectorsFileDecl,
+    lock: Option<&crate::connector_build::ConnectorLockFileDecl>,
+) -> Result<()> {
+    let targets = registry_preflight_targets(decl, lock);
+    if targets.is_empty() {
+        return Ok(());
+    }
+
+    let (ok, out, err) = crate::ops::run_capture(&node_architectures_argv()).await?;
+    if !ok {
+        return Err(anyhow::anyhow!("{}", err.trim()))
+            .context("read the architectures this cluster's nodes report");
+    }
+    let node_archs = node_architectures(&out);
+
+    for entry in targets {
+        let (ok, raw, err) = crate::ops::run_capture(&registry_manifest_argv(&entry.image)).await?;
+        let inspect = if ok { Ok(raw.as_str()) } else { Err(err) };
+        registry_preflight(&entry.image, inspect, &node_archs, &entry.platforms)?;
+    }
+    Ok(())
+}
+
 /// The recomputed `source_digest` of every `build:` connector in a bundle, for
 /// the preflight to compare the lock against.
 pub fn recompute_source_digests(
@@ -9013,6 +9142,42 @@ pub fn recompute_source_digests(
         );
     }
     Ok(digests)
+}
+
+/// The hosted `build:` connectors whose locked image no longer stands for this
+/// source: either the lock records nothing for them, or it records a different
+/// `source_digest` than the tree hashes to now.
+///
+/// The staleness test is `lock_preflight`'s, verbatim -- a missing lock entry
+/// and a digest mismatch are the two failures it refuses a deploy on, and a
+/// connector the recompute could not weigh in on is left alone by both. What
+/// differs is only what the caller does with the answer: the skill tier rebuilds
+/// (ADR 0113's Decision 3), the cluster tier refuses.
+///
+/// An `image:`-hosted connector has no source to be stale against, and one
+/// pointed at an already-running process with `unhosted_url` is not started
+/// here, so neither can put this bundle into a build.
+pub fn connectors_needing_rebuild(
+    decl: &crate::connector_build::ConnectorsFileDecl,
+    lock: Option<&crate::connector_build::ConnectorLockFileDecl>,
+    recomputed: &std::collections::BTreeMap<String, String>,
+) -> Vec<String> {
+    let mut stale = Vec::new();
+    for (connector, spec) in &decl.connectors {
+        if spec.build.is_none() || spec.url.is_some() || spec.unhosted_url.is_some() {
+            continue;
+        }
+        let Some(entry) = lock.and_then(|lock| lock.connectors.get(connector)) else {
+            stale.push(connector.clone());
+            continue;
+        };
+        if let Some(fresh) = recomputed.get(connector) {
+            if &entry.source_digest != fresh {
+                stale.push(connector.clone());
+            }
+        }
+    }
+    stale
 }
 
 // ---------------------------------------------------------------------------
@@ -9079,6 +9244,40 @@ pub async fn bring_up_local(
         bail!("starting the bundle's connectors failed: {}", err.trim());
     }
     Ok(())
+}
+
+/// Refuse the WHOLE bundle when a hosted connector declares a secret that has
+/// no value on this box -- before a network, a build, or a container exists.
+///
+/// Bring-up used to skip an unresolved secret silently: `skill up` reported
+/// success, the connector container exited 1 on its own missing-credential
+/// check, and the runner was left holding an MCP URL that connection-refused
+/// mid-turn. Between a silent connection-refused mid-turn and an actionable
+/// refusal at bring-up, the refusal is the correct behavior. Every gap across
+/// every hosted connector is collected first so one run names them all, and the
+/// check is resolve-only -- nothing is staged and no value is retained.
+fn refuse_missing_connector_secrets(
+    decl: &crate::connector_build::ConnectorsFileDecl,
+) -> Result<()> {
+    // First, so a `from_secret` reference keeps its own, more specific refusal
+    // (`refuse_out_of_band_secrets` names all three ways forward) instead of
+    // being reported as an ordinary unset name by the sweep below.
+    for (connector, spec) in &decl.connectors {
+        if spec.url.is_some() || spec.unhosted_url.is_some() {
+            continue;
+        }
+        crate::connector_build::refuse_out_of_band_secrets(connector, spec)?;
+    }
+    let mut missing = Vec::new();
+    for name in crate::connector_build::hosted_secret_names(decl) {
+        if resolve_connector_secret(&name)?.is_none() {
+            missing.push(name);
+        }
+    }
+    if missing.is_empty() {
+        return Ok(());
+    }
+    Err(crate::connector_build::missing_secrets_error(&missing))
 }
 
 /// One connector credential, from the environment first and the host vault

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -1566,7 +1566,7 @@ fn short_digest(digest: &str) -> String {
 
 /// Release everything a boot that has already packed its snapshot leaves behind
 /// when it aborts: the ollama sidecar, the hosted connectors, the network
-/// `start` owns, and the snapshot itself.
+/// `start` owns, the credentials it staged, and the snapshot itself.
 ///
 /// One definition for all three abort arms between the pack and a recorded
 /// state, because nothing else will ever collect these: no state was saved, so
@@ -1596,6 +1596,11 @@ async fn release_boot_scaffolding(
     if let Some(net) = owned_network {
         let _ = docker::remove_network(net).await;
     }
+    // After the connectors, never before: a tree still bind-mounted into a
+    // running container cannot be wiped cleanly, the same ordering
+    // `connector_teardown_plan` holds. Resolved credentials must not outlive a
+    // boot that no `skill down` can find.
+    let _ = crate::connector_build::wipe_connector_secrets(plugin_dir);
     let _ = crate::bundle::remove_snapshot(snapshot_dir, plugin_dir);
 }
 
@@ -8285,6 +8290,41 @@ mod tests {
             vec![format!("{}:/plugin:ro", bundle.dir().display())]
         );
     }
+
+    /// An aborted boot releases the credentials it staged, not just the
+    /// containers. Deleting the wipe from `release_boot_scaffolding` fails here.
+    ///
+    /// Nothing else will ever collect them: no state was recorded, so no `skill
+    /// down` can find the bundle (#1087). Driven with no sidecar, no connector
+    /// and no network so it reaches no Docker daemon -- what is under test is
+    /// the release list, not the removals.
+    #[tokio::test]
+    async fn an_aborted_boot_releases_the_staged_credentials() {
+        let dir = tempfile::tempdir().unwrap();
+        crate::connector_build::stage_secret_file(
+            dir.path(),
+            "kubernetes",
+            "/secrets/kubeconfig",
+            "creds",
+        )
+        .unwrap();
+        let root = crate::connector_build::connector_secrets_root(dir.path());
+        assert!(root.exists());
+
+        super::release_boot_scaffolding(
+            None,
+            &[],
+            None,
+            &dir.path().join(".curie/snapshots/never-packed"),
+            dir.path(),
+        )
+        .await;
+
+        assert!(
+            !root.exists(),
+            "a resolved credential must not outlive the boot that staged it"
+        );
+    }
 }
 
 /// Which nullable override a `<tier> overrides` invocation intends to change.
@@ -8766,9 +8806,11 @@ pub async fn build_connectors(opts: ConnectorBuildOpts) -> Result<ConnectorBuild
     let (bundle_name, _version) = read_manifest(&plugin_dir)?;
 
     // buildx writes its build result here; a private per-run directory rather
-    // than the bundle, so a metadata file never rides the upload.
+    // than the bundle, so a metadata file never rides the upload. The system
+    // temp dir is shared with every other user on the box, so the directory is
+    // the owner's alone rather than the 0755 a default umask would give it.
     let metadata_dir = std::env::temp_dir().join(format!("curie-build-{}", uuid::Uuid::new_v4()));
-    std::fs::create_dir_all(&metadata_dir)
+    create_private_dir(&metadata_dir)
         .with_context(|| format!("create {}", metadata_dir.display()))?;
 
     let ui = crate::ui::ui();
@@ -8835,6 +8877,26 @@ pub async fn build_connectors(opts: ConnectorBuildOpts) -> Result<ConnectorBuild
     Ok(ConnectorBuildOutput {
         connectors: records,
     })
+}
+
+/// Create a directory only its owner can enter, in one step.
+///
+/// The mode rides the create rather than a `set_permissions` after it: in a
+/// shared `/tmp` the window between the two is a window in which anyone can
+/// read what lands there, and buildx starts writing as soon as it is handed the
+/// path. Non-unix keeps the platform default, as the other cfg splits here do.
+#[cfg(unix)]
+pub fn create_private_dir(path: &Path) -> std::io::Result<()> {
+    use std::os::unix::fs::DirBuilderExt;
+    std::fs::DirBuilder::new()
+        .recursive(true)
+        .mode(0o700)
+        .create(path)
+}
+
+#[cfg(not(unix))]
+pub fn create_private_dir(path: &Path) -> std::io::Result<()> {
+    std::fs::create_dir_all(path)
 }
 
 /// Run one connector's build and read back the immutable reference it produced.
@@ -9184,7 +9246,8 @@ pub fn connectors_needing_rebuild(
 // The local tier's connector bring-up
 // ---------------------------------------------------------------------------
 
-/// Generate the connector compose overlay for a deployed bundle and bring it up.
+/// Reconcile this agent's connector containers against the deployed bundle, then
+/// generate the connector compose overlay and bring the declared set up.
 ///
 /// One helper, both local deploy callers (`local deploy` and `deploy-local`), so
 /// the shorthand cannot upload a source-built bundle and start no connector.
@@ -9206,28 +9269,59 @@ pub async fn bring_up_local(
         .iter()
         .filter(|(_, spec)| spec.url.is_none() && spec.unhosted_url.is_none())
         .collect();
+
+    // Fail closed BEFORE anything is reaped, staged, written, or started -- the
+    // same refusal `skill up` performs, which this path used to skip. A declared
+    // secret with no value here would otherwise be written into the overlay as a
+    // `${NAME}` nothing populates: compose warns, expands it to empty, and the
+    // connector comes up authenticating with nothing. It runs above the reap so
+    // a bundle that cannot come up does not first tear down the connectors that
+    // are serving.
+    refuse_missing_connector_secrets(&decl)?;
+
+    // Reconcile before starting: compose only ADDS the services the overlay
+    // names, so a connector this bundle version dropped or renamed would keep
+    // running -- serving the runner an MCP endpoint the bundle no longer
+    // declares. It is deliberately NOT `--remove-orphans` and not a
+    // project-label sweep: this compose project holds the api/worker stack and
+    // every other locally deployed agent's connectors, so the reap is scoped to
+    // this agent's own containers and, within those, to the names the new
+    // desired set does not contain. A zero-connector bundle reaches this with an
+    // empty desired set, which is how the last one gets removed.
+    let desired: std::collections::BTreeSet<String> = hosted
+        .iter()
+        .map(|(connector, _)| {
+            cb::object_name(&identity.release, &identity.agent, connector.as_str())
+        })
+        .collect();
+    for problem in docker::reap_undesired_connectors(project, &identity.agent, &desired).await {
+        crate::ui::ui().warn(&problem);
+    }
+
     if hosted.is_empty() {
         return Ok(());
     }
 
     let mut secret_values = std::collections::BTreeMap::new();
     for (connector, spec) in &hosted {
-        cb::refuse_out_of_band_secrets(connector, spec)?;
         for name in cb::declared_secret_names(spec) {
-            if let Some(value) = resolve_connector_secret(&name)? {
-                secret_values.insert(name, value);
-            }
+            // The refusal above already proved every one of these resolves, so a
+            // gap here is reported as the missing credential it is rather than
+            // silently skipped.
+            let value = resolve_connector_secret(&name)?
+                .ok_or_else(|| cb::missing_secrets_error(std::slice::from_ref(&name)))?;
+            secret_values.insert(name, value);
         }
         // Credential files are staged where both emitters expect them, so the
         // container finds bytes rather than an empty mount.
         for (key, declared_path) in &spec.secret_files {
-            if let Some(value) = resolve_connector_secret(key)? {
-                cb::stage_secret_file(plugin_dir, connector, declared_path, &value)?;
-            }
+            let value = resolve_connector_secret(key)?
+                .ok_or_else(|| cb::missing_secrets_error(std::slice::from_ref(key)))?;
+            cb::stage_secret_file(plugin_dir, connector, declared_path, &value)?;
         }
     }
 
-    let overlay = cb::compose_overlay(lock, &decl, identity, project, plugin_dir, &secret_values)?;
+    let overlay = cb::compose_overlay(lock, &decl, identity, project, plugin_dir)?;
     let path = cb::compose_overlay_path(plugin_dir);
     std::fs::create_dir_all(path.parent().expect("the overlay path has a parent"))?;
     std::fs::write(
@@ -9236,7 +9330,10 @@ pub async fn bring_up_local(
     )
     .with_context(|| format!("write {}", path.display()))?;
 
-    let command = cb::compose_up_command(&path, project);
+    // The values reach the containers through the compose child's environment,
+    // where `${NAME}` in the file above expands from -- never through the file,
+    // never through argv, and masked in anything printed.
+    let command = cb::compose_up_command(&path, project, &secret_values);
     let (ok, _out, err) = crate::ops::run_capture(&command)
         .await
         .context("starting the bundle's connectors")?;
@@ -9246,8 +9343,10 @@ pub async fn bring_up_local(
     Ok(())
 }
 
-/// Refuse the WHOLE bundle when a hosted connector declares a secret that has
-/// no value on this box -- before a network, a build, or a container exists.
+/// Refuse the WHOLE bundle when a hosted connector declares a secret this box
+/// must not hand it, or has no value for -- before a network, a build, or a
+/// container exists. Both tiers' single pre-resolution gate, so a name the
+/// bundle must not own is refused here rather than at each caller.
 ///
 /// Bring-up used to skip an unresolved secret silently: `skill up` reported
 /// success, the connector container exited 1 on its own missing-credential
@@ -9259,7 +9358,12 @@ pub async fn bring_up_local(
 fn refuse_missing_connector_secrets(
     decl: &crate::connector_build::ConnectorsFileDecl,
 ) -> Result<()> {
-    // First, so a `from_secret` reference keeps its own, more specific refusal
+    // Ahead of every resolve below: a name the bundle must not own is refused
+    // before a single value is read, because reading it IS the exfiltration --
+    // the sweep below would resolve the operator's own model credential and
+    // report the declaration as satisfied.
+    crate::connector_build::refuse_reserved_secret_names(decl)?;
+    // Then, so a `from_secret` reference keeps its own, more specific refusal
     // (`refuse_out_of_band_secrets` names all three ways forward) instead of
     // being reported as an ordinary unset name by the sweep below.
     for (connector, spec) in &decl.connectors {
@@ -9289,6 +9393,36 @@ fn resolve_connector_secret(name: &str) -> Result<Option<String>> {
     crate::secrets::get_value(name)
 }
 
+/// Which hosted connectors a skill-tier boot starts, each paired with the image
+/// it runs, in declaration order.
+///
+/// The selection is `connector_build::resolved_image`'s, which is also what the
+/// local tier's overlay emits -- one rule, so the two tiers cannot resolve the
+/// same declaration to two different images. Extracted as a pure seam for two
+/// reasons: it is decidable with no Docker daemon, and it leaves the starter
+/// below with no image of its own to compute. The inline lock-first copy it
+/// replaces is what let a stale lock entry hijack a connector whose declaration
+/// had since switched from `build:` to `image:`.
+///
+/// Every image is resolved before the first container starts, so a bundle
+/// missing one is refused whole rather than half-started.
+pub fn skill_connector_plan(
+    decl: &crate::connector_build::ConnectorsFileDecl,
+    lock: &crate::connector_build::ConnectorLockFileDecl,
+) -> Result<Vec<(String, String)>> {
+    let mut plan = Vec::new();
+    for (connector, spec) in &decl.connectors {
+        if spec.url.is_some() || spec.unhosted_url.is_some() {
+            continue;
+        }
+        plan.push((
+            connector.clone(),
+            crate::connector_build::resolved_image(connector, spec, lock)?,
+        ));
+    }
+    Ok(plan)
+}
+
 /// Start one container per hosted connector on the runner's private network.
 ///
 /// Returns the container names so `skill down` reaps exactly what this boot
@@ -9308,10 +9442,12 @@ async fn start_skill_connectors(
         connectors: std::collections::BTreeMap::new(),
     });
     let mut started = Vec::new();
-    for (connector, spec) in &decl.connectors {
-        if spec.url.is_some() || spec.unhosted_url.is_some() {
-            continue;
-        }
+    for (connector, image) in skill_connector_plan(decl, &lock)? {
+        let connector = connector.as_str();
+        let spec = decl
+            .connectors
+            .get(connector)
+            .expect("the plan names only this declaration's own connectors");
         cb::refuse_out_of_band_secrets(connector, spec)?;
         let mut secret_values = std::collections::BTreeMap::new();
         for name in cb::declared_secret_names(spec) {
@@ -9324,15 +9460,6 @@ async fn start_skill_connectors(
                 cb::stage_secret_file(plugin_dir, connector, declared_path, &value)?;
             }
         }
-        let image = match lock.connectors.get(connector) {
-            Some(entry) => entry.image.clone(),
-            None => spec.image.clone().ok_or_else(|| {
-                crate::exit::usage(format!(
-                    "connectors.{connector} declares no `image` and {} records none for it.",
-                    cb::CONNECTOR_LOCK_FILE
-                ))
-            })?,
-        };
         let start = docker::ConnectorStartSpec::from_declaration(
             connector,
             spec,

--- a/cli/src/connector_build.rs
+++ b/cli/src/connector_build.rs
@@ -1420,6 +1420,38 @@ pub fn declared_secret_names(spec: &ConnectorSpecDecl) -> Vec<String> {
         .collect()
 }
 
+/// Every secret NAME this bundle's HOSTED connectors need before bring-up.
+///
+/// A connector carrying `url:` or `unhosted_url:` is not started here -- its
+/// secrets belong to the remote's client config and are expanded by the MCP
+/// client, so demanding them would refuse a bundle that works. Both channels a
+/// hosted connector resolves are covered: the `secrets:` list and the
+/// `secret_files:` keys. Names only; no value ever travels through this seam.
+pub fn hosted_secret_names(decl: &ConnectorsFileDecl) -> Vec<String> {
+    let mut names = std::collections::BTreeSet::new();
+    for spec in decl.connectors.values() {
+        if spec.url.is_some() || spec.unhosted_url.is_some() {
+            continue;
+        }
+        names.extend(declared_secret_names(spec));
+        names.extend(spec.secret_files.keys().cloned());
+    }
+    names.into_iter().collect()
+}
+
+/// The one refusal both tiers issue when declared secrets have no value here.
+///
+/// Shared so the skill tier and the cluster deploy path cannot drift into two
+/// near-identical strings. It names every gap at once rather than one per run,
+/// and it names only NAMES -- a value must never reach an error, a log, or argv.
+pub fn missing_secrets_error(missing: &[String]) -> anyhow::Error {
+    crate::exit::usage(format!(
+        "connectors.yaml declares secret(s) with no value available: {}. Export each in the \
+         environment, or store it once with `curie secrets set <NAME>`.",
+        missing.join(", ")
+    ))
+}
+
 /// A `from_secret` reference points at a Secret someone else provisioned, and
 /// nothing on a laptop corresponds to it. Starting without the credential would
 /// give a server that 401s on every call, which reads as a broken connector

--- a/cli/src/connector_build.rs
+++ b/cli/src/connector_build.rs
@@ -57,7 +57,7 @@ pub struct ConnectorsFileDecl {
 }
 
 /// One declared connector, a full mirror of `plugin_format.ConnectorSpec`.
-#[derive(Debug, Default, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ConnectorSpecDecl {
     // -- hosted form --
@@ -101,7 +101,7 @@ pub enum SecretDecl {
 }
 
 /// Where a connector's image comes from, when the bundle carries its source.
-#[derive(Debug, Default, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ConnectorBuildDecl {
     pub context: String,
@@ -117,6 +117,40 @@ fn default_port() -> u32 {
 
 fn default_dockerfile() -> String {
     "Dockerfile".to_string()
+}
+
+/// Hand-written rather than derived, so an omitted `port` is 8000 whether the
+/// value came from a parsed document or from a constructed default. A derived
+/// `Default` would say 0, which is not a port and is not what the Python model
+/// means by "unset".
+impl Default for ConnectorSpecDecl {
+    fn default() -> Self {
+        Self {
+            image: None,
+            build: None,
+            args: Vec::new(),
+            env: BTreeMap::new(),
+            port: default_port(),
+            unhosted_url: None,
+            url: None,
+            headers: BTreeMap::new(),
+            secrets: Vec::new(),
+            sealed_secrets: BTreeMap::new(),
+            secret_files: BTreeMap::new(),
+        }
+    }
+}
+
+/// Same rule for `dockerfile`: an omitted one is `Dockerfile`, never the empty
+/// path a derived `Default` would produce.
+impl Default for ConnectorBuildDecl {
+    fn default() -> Self {
+        Self {
+            context: String::new(),
+            dockerfile: default_dockerfile(),
+            platforms: Vec::new(),
+        }
+    }
 }
 
 // ─── The lock ────────────────────────────────────────────────────────────────
@@ -757,4 +791,653 @@ fn class_matches(class: &[char], candidate: char) -> bool {
         i += 1;
     }
     false
+}
+
+// ─── The build plan: what `curie build --plugin-dir` actually issues ──────────
+
+/// An [`crate::ops::OpsCommand`] whose every token is a plain (non-secret) one.
+/// Connector commands carry no credential in argv by construction, which is the
+/// property `docker_env` exists to keep.
+pub(crate) fn plain_command(program: &str, args: Vec<String>) -> crate::ops::OpsCommand {
+    crate::ops::OpsCommand {
+        program: program.to_string(),
+        args: args.into_iter().map(crate::ops::CmdArg::Plain).collect(),
+        env: Vec::new(),
+        secret_env: Vec::new(),
+    }
+}
+
+/// The tag a local-daemon build produces, before the daemon's image id replaces
+/// it in the lock. Ephemeral by construction: nothing pulls it, and a rebuild
+/// reuses it, which is exactly why the lock records the id instead.
+fn local_build_tag(bundle_name: &str, connector: &str) -> String {
+    format!("curie-connector-{bundle_name}-{connector}:build")
+}
+
+/// How many hex characters of the source digest become the pushed tag. Long
+/// enough that two sources cannot collide in practice, short enough to read.
+const TAG_DIGEST_LEN: usize = 16;
+
+/// The uid every connector container runs as, mirroring `render_deployment`'s
+/// `runAsUser` so a staged credential is readable by the same identity on both
+/// tiers.
+const CONNECTOR_UID: u32 = 65532;
+
+/// One connector's resolved build: the inputs, the command's target, and the
+/// identity the lock will record.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConnectorBuildPlan {
+    pub connector: String,
+    /// Canonical, inside the bundle.
+    pub context: PathBuf,
+    /// Canonical, inside the context.
+    pub dockerfile: PathBuf,
+    /// The DECLARED platform set, in declaration order. What the lock records,
+    /// and what the registry path builds; the local-daemon path builds
+    /// [`ConnectorBuildPlan::host_platform`] instead.
+    pub platforms: Vec<String>,
+    /// The one platform a local-daemon build can actually produce.
+    pub host_platform: String,
+    pub delivery: Delivery,
+    /// The `-t` tag this build produces.
+    pub image_ref: String,
+    pub source_digest: String,
+    /// Where buildx writes its build result metadata; registry delivery only.
+    pub metadata_file: Option<PathBuf>,
+}
+
+/// The OCI platform of the machine running the CLI.
+///
+/// A Linux platform always: `docker build --platform darwin/arm64` would ask
+/// the daemon for an image no container runtime can run. The host here means
+/// the ARCH of the machine, never its OS.
+pub fn host_platform() -> String {
+    let arch = match std::env::consts::ARCH {
+        "x86_64" | "x86" => "amd64",
+        "aarch64" => "arm64",
+        "arm" => "arm",
+        "powerpc64" => "ppc64le",
+        other => other,
+    };
+    format!("linux/{arch}")
+}
+
+/// Resolve everything one connector's build needs, without contacting anything.
+///
+/// Planning is where a bad declaration fails: a context outside the bundle, a
+/// symlinked Dockerfile, a missing Dockerfile. A planner that returned a plan
+/// for any of those would hand `docker` a path and surface Docker's error
+/// instead of one naming the connector.
+pub fn build_plan(
+    bundle_root: &Path,
+    bundle_name: &str,
+    connector: &str,
+    spec: &ConnectorSpecDecl,
+    registry: Option<&str>,
+    host_platform: &str,
+    metadata_dir: &Path,
+) -> Result<ConnectorBuildPlan> {
+    let build = spec.build.as_ref().ok_or_else(|| {
+        anyhow!("connectors.{connector}: declares no `build` block, so there is nothing to build")
+    })?;
+    check_build(connector, build)?;
+    let context = resolve_context(bundle_root, &build.context)
+        .with_context(|| format!("connectors.{connector}"))?;
+    let dockerfile = resolve_dockerfile(&context, &build.dockerfile)
+        .with_context(|| format!("connectors.{connector}"))?;
+    let source_digest =
+        source_digest_of(&context, build).with_context(|| format!("connectors.{connector}"))?;
+
+    let (delivery, image_ref, metadata_file) = match registry {
+        Some(registry) => (
+            Delivery::Registry,
+            registry_image_ref(registry, bundle_name, connector, &source_digest),
+            Some(metadata_dir.join(format!("{connector}.metadata.json"))),
+        ),
+        None => (
+            Delivery::LocalDaemon,
+            local_build_tag(bundle_name, connector),
+            None,
+        ),
+    };
+
+    Ok(ConnectorBuildPlan {
+        connector: connector.to_string(),
+        context,
+        dockerfile,
+        platforms: build.platforms.clone(),
+        host_platform: host_platform.to_string(),
+        delivery,
+        image_ref,
+        source_digest,
+        metadata_file,
+    })
+}
+
+/// The `docker` command this plan runs.
+///
+/// Two delivery paths, two commands. `docker build` cannot emit a multi-arch
+/// index, so the local-daemon path builds the host platform only; the declared
+/// set stays in the lock so `cluster deploy` can still refuse it.
+pub fn build_argv(plan: &ConnectorBuildPlan) -> crate::ops::OpsCommand {
+    let mut args: Vec<String> = Vec::new();
+    match plan.delivery {
+        Delivery::LocalDaemon => {
+            args.push("build".into());
+            args.push("--platform".into());
+            args.push(plan.host_platform.clone());
+        }
+        Delivery::Registry => {
+            args.push("buildx".into());
+            args.push("build".into());
+            args.push("--platform".into());
+            args.push(plan.platforms.join(","));
+            args.push("--push".into());
+            if let Some(metadata) = &plan.metadata_file {
+                args.push("--metadata-file".into());
+                args.push(metadata.display().to_string());
+            }
+        }
+    }
+    args.push("-f".into());
+    args.push(plan.dockerfile.display().to_string());
+    args.push("-t".into());
+    args.push(plan.image_ref.clone());
+    args.push(plan.context.display().to_string());
+    plain_command("docker", args)
+}
+
+/// Read back the daemon's immutable image id for a tag it just built. The id is
+/// what survives a later rebuild reusing the same tag.
+pub fn image_inspect_argv(tag: &str) -> crate::ops::OpsCommand {
+    plain_command(
+        "docker",
+        vec![
+            "image".into(),
+            "inspect".into(),
+            "--format".into(),
+            "{{.Id}}".into(),
+            tag.to_string(),
+        ],
+    )
+}
+
+/// The push target for one connector: a repository per bundle+connector, tagged
+/// with a prefix of the source digest.
+///
+/// Never a mutable name: `:latest` would let a second build silently replace the
+/// bytes a first deploy resolved.
+pub fn registry_image_ref(
+    registry: &str,
+    bundle: &str,
+    connector: &str,
+    source_digest: &str,
+) -> String {
+    let hex = source_digest
+        .strip_prefix("sha256:")
+        .unwrap_or(source_digest);
+    let tag: String = hex.chars().take(TAG_DIGEST_LEN).collect();
+    format!(
+        "{}/{bundle}-{connector}:{tag}",
+        registry.trim_end_matches('/')
+    )
+}
+
+/// The index digest buildx reports through `--metadata-file`.
+///
+/// `containerimage.digest` is the INDEX digest; `containerimage.config.digest`
+/// is a single-platform config blob and pulling by it fails on a multi-arch
+/// node, so the key is named explicitly rather than pattern-matched.
+pub fn digest_from_metadata(raw: &str) -> Result<String> {
+    let parsed: serde_json::Value =
+        serde_json::from_str(raw).context("parse the buildx metadata file")?;
+    parsed
+        .get("containerimage.digest")
+        .and_then(|d| d.as_str())
+        .map(str::to_string)
+        .ok_or_else(|| {
+            anyhow!(
+                "the buildx metadata file names no `containerimage.digest`, so the push did not \
+                 produce an image; recording an empty reference would surface much later as \
+                 ImagePullBackOff"
+            )
+        })
+}
+
+/// The repository at a digest, with the push tag dropped: a reference exactly
+/// one artifact can resolve.
+pub fn digest_pinned_ref(image_ref: &str, digest: &str) -> String {
+    let repo = match image_ref.split_once('@') {
+        Some((repo, _)) => repo,
+        None => {
+            let tag_start = image_ref
+                .rfind(':')
+                .filter(|colon| image_ref[*colon..].find('/').is_none());
+            match tag_start {
+                Some(colon) => &image_ref[..colon],
+                None => image_ref,
+            }
+        }
+    };
+    format!("{repo}@{digest}")
+}
+
+// ─── The lock write ──────────────────────────────────────────────────────────
+
+/// Why this write must not proceed, or `None` when it may.
+///
+/// The one-directional rule: a local-daemon resolution must not silently
+/// replace a registry one, because only the registry lock is deployable to a
+/// cluster. The reverse is a promotion and needs no ceremony.
+pub fn lock_overwrite_refusal(
+    existing: Option<&ConnectorLockFileDecl>,
+    next: &ConnectorLockFileDecl,
+    force: bool,
+) -> Option<String> {
+    if force {
+        return None;
+    }
+    let existing = existing?;
+    let downgraded: Vec<&str> = next
+        .connectors
+        .iter()
+        .filter(|(name, entry)| {
+            entry.delivery == Delivery::LocalDaemon
+                && existing
+                    .connectors
+                    .get(*name)
+                    .is_some_and(|prior| prior.delivery == Delivery::Registry)
+        })
+        .map(|(name, _)| name.as_str())
+        .collect();
+    if downgraded.is_empty() {
+        return None;
+    }
+    Some(format!(
+        "{CONNECTOR_LOCK_FILE} already resolves {} to a pushed registry image, and this build \
+         resolved it to the local daemon, which a cluster cannot pull. Re-run with --registry \
+         <ref> to keep a pushed image, or with --force to replace the lock deliberately.",
+        downgraded.join(", ")
+    ))
+}
+
+/// Write the lock at the bundle root, atomically, refusing a silent downgrade.
+///
+/// Byte-stable for an unchanged resolution: nothing here stamps a timestamp and
+/// every map is a `BTreeMap`, so "nothing changed" stays visible in
+/// `git status` instead of showing a diff on every rebuild.
+pub fn write_lock(bundle_root: &Path, lock: &ConnectorLockFileDecl, force: bool) -> Result<()> {
+    let existing = load_lock(bundle_root).unwrap_or(None);
+    if let Some(refusal) = lock_overwrite_refusal(existing.as_ref(), lock, force) {
+        return Err(crate::exit::usage(refusal));
+    }
+    let path = bundle_root.join(CONNECTOR_LOCK_FILE);
+    let body = serde_norway::to_string(lock).context("serialize the connector lock")?;
+    let temp = path.with_extension("yaml.tmp");
+    std::fs::write(&temp, body).with_context(|| format!("write {}", temp.display()))?;
+    std::fs::rename(&temp, &path).with_context(|| format!("write {}", path.display()))?;
+    Ok(())
+}
+
+// ─── The rendered container contract, shared by both local emitters ───────────
+
+/// The deployment identity every derived name is built from.
+///
+/// Passed in, never re-derived: `--agent`/`--target` can override the
+/// manifest's name, and a helper that read `plugin.json` again would alias the
+/// connectors under one identity while the runner dialed another.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConnectorScope {
+    pub release: String,
+    pub agent: String,
+    pub namespace: String,
+}
+
+/// Every name the sandbox might use to reach this connector, in the order
+/// `connector_render.host_aliases` emits them.
+fn host_aliases(scope: &ConnectorScope, connector: &str, port: u32) -> Vec<String> {
+    let short = object_name(&scope.release, &scope.agent, connector);
+    let dns = service_dns(&scope.release, &scope.agent, connector, &scope.namespace);
+    vec![
+        format!("{short}:{port}"),
+        format!("{short}.{}:{port}", scope.namespace),
+        format!("{dns}:{port}"),
+    ]
+}
+
+/// What each `${CURIE_*}` placeholder expands to for this connector.
+///
+/// A port of `connector_render.substitutions`. Every value is one the bundle
+/// author cannot know, because all of them derive from the Service name Curie
+/// invents.
+pub fn connector_substitutions(
+    scope: &ConnectorScope,
+    connector: &str,
+    port: u32,
+) -> BTreeMap<String, String> {
+    let short = object_name(&scope.release, &scope.agent, connector);
+    let dns = service_dns(&scope.release, &scope.agent, connector, &scope.namespace);
+    BTreeMap::from([
+        (
+            "CURIE_ALLOWED_HOSTS".to_string(),
+            host_aliases(scope, connector, port).join(","),
+        ),
+        ("CURIE_CONNECTOR_HOST".to_string(), short),
+        ("CURIE_CONNECTOR_PORT".to_string(), port.to_string()),
+        (
+            "CURIE_CONNECTOR_URL".to_string(),
+            format!("http://{dns}:{port}"),
+        ),
+    ])
+}
+
+/// Expand `${CURIE_*}` placeholders in one arg or env value.
+pub fn substitute(value: &str, subs: &BTreeMap<String, String>) -> String {
+    let mut out = value.to_string();
+    for (key, replacement) in subs {
+        out = out.replace(&format!("${{{key}}}"), replacement);
+    }
+    out
+}
+
+/// The connector scope the runner needs to derive the same URLs independently.
+///
+/// All three or none: the boot contract drops a partial set entirely, so
+/// emitting two of three silently switches connectors off.
+pub fn connector_scope_env(scope: &ConnectorScope) -> Vec<(String, String)> {
+    vec![
+        (
+            curie_aci_protocol::env_keys::CURIE_CONNECTOR_RELEASE.to_string(),
+            scope.release.clone(),
+        ),
+        (
+            curie_aci_protocol::env_keys::CURIE_CONNECTOR_AGENT.to_string(),
+            scope.agent.clone(),
+        ),
+        (
+            curie_aci_protocol::env_keys::CURIE_CONNECTOR_NAMESPACE.to_string(),
+            scope.namespace.clone(),
+        ),
+    ]
+}
+
+// ─── Staged credentials ──────────────────────────────────────────────────────
+
+/// Where resolved connector credentials are staged for a local bring-up.
+///
+/// Deterministic, not a per-run tempdir: teardown is label-driven and a reap
+/// that never inspected a container cannot discover a random path, so the
+/// credential would survive every `down`. Under `.curie/`, which the packer
+/// excludes and the scaffold gitignores.
+pub fn connector_secrets_root(plugin_dir: &Path) -> PathBuf {
+    plugin_dir.join(".curie").join("connector-secrets")
+}
+
+/// The host path one declared `secret_files` entry is staged at.
+pub fn staged_secret_path(plugin_dir: &Path, connector: &str, declared_path: &str) -> PathBuf {
+    let basename = declared_path.rsplit('/').next().unwrap_or(declared_path);
+    connector_secrets_root(plugin_dir)
+        .join(connector)
+        .join(basename)
+}
+
+/// Write one resolved credential where the container will find it.
+///
+/// The parent directories are `0700` because the file mode is not always
+/// enough: rootless Docker and Docker Desktop map uids differently, so the
+/// `chown` to the container's uid is not always permitted, and where it is not
+/// the file falls back to `0444` inside a private parent.
+pub fn stage_secret_file(
+    plugin_dir: &Path,
+    connector: &str,
+    declared_path: &str,
+    value: &str,
+) -> Result<PathBuf> {
+    let path = staged_secret_path(plugin_dir, connector, declared_path);
+    let parent = path
+        .parent()
+        .ok_or_else(|| anyhow!("staged credential path has no parent"))?;
+    std::fs::create_dir_all(parent).with_context(|| format!("create {}", parent.display()))?;
+    private_dir(&connector_secrets_root(plugin_dir))?;
+    private_dir(parent)?;
+    std::fs::write(&path, value).with_context(|| format!("write {}", path.display()))?;
+    harden_secret_file(&path)?;
+    Ok(path)
+}
+
+#[cfg(unix)]
+fn private_dir(path: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700))
+        .with_context(|| format!("restrict {}", path.display()))
+}
+
+#[cfg(not(unix))]
+fn private_dir(_path: &Path) -> Result<()> {
+    Ok(())
+}
+
+#[cfg(unix)]
+fn harden_secret_file(path: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o400))
+        .with_context(|| format!("restrict {}", path.display()))?;
+    // Where the CLI may not hand the file to the container's uid, the file must
+    // be world-readable instead -- the 0700 parent is what keeps it private.
+    if std::os::unix::fs::chown(path, Some(CONNECTOR_UID), Some(CONNECTOR_UID)).is_err() {
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o444))
+            .with_context(|| format!("widen {} for the container's uid", path.display()))?;
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn harden_secret_file(_path: &Path) -> Result<()> {
+    Ok(())
+}
+
+/// Remove the staged credential tree. A no-op when it is already gone, so
+/// `down` after `down` does not error.
+pub fn wipe_connector_secrets(plugin_dir: &Path) -> Result<()> {
+    let root = connector_secrets_root(plugin_dir);
+    if !root.exists() {
+        return Ok(());
+    }
+    std::fs::remove_dir_all(&root).with_context(|| format!("remove {}", root.display()))
+}
+
+// ─── The compose overlay (the local tier's emitter) ──────────────────────────
+
+/// The compose network the worker puts a sandboxed runner on. Joined, never
+/// created: a network of the overlay's own leaves the runner unable to resolve
+/// the alias.
+pub const RUNNER_NETWORK: &str = "curie_runner";
+
+/// Where the generated overlay is written: ephemeral state under `.curie/`, so
+/// it never enters the uploaded bundle and never perturbs the bundle digest.
+pub fn compose_overlay_path(plugin_dir: &Path) -> PathBuf {
+    plugin_dir.join(".curie").join("compose.connectors.yaml")
+}
+
+/// `docker compose ... up -d --wait` for the generated overlay, joined to the
+/// running stack's project so the services land on its network.
+pub fn compose_up_command(overlay: &Path, project: &str) -> crate::ops::OpsCommand {
+    plain_command(
+        "docker",
+        vec![
+            "compose".into(),
+            "-p".into(),
+            project.to_string(),
+            "-f".into(),
+            overlay.display().to_string(),
+            "up".into(),
+            "-d".into(),
+            "--wait".into(),
+        ],
+    )
+}
+
+/// Whether a declared connector is one Curie runs (as opposed to one already
+/// running somewhere else).
+fn is_hosted(spec: &ConnectorSpecDecl) -> bool {
+    spec.url.is_none() && spec.unhosted_url.is_none()
+}
+
+/// The image a hosted connector starts from: the locked digest when the bundle
+/// builds it, else the declared `image:`.
+fn resolved_image(
+    connector: &str,
+    spec: &ConnectorSpecDecl,
+    lock: &ConnectorLockFileDecl,
+) -> Result<String> {
+    if let Some(entry) = lock.connectors.get(connector) {
+        return Ok(entry.image.clone());
+    }
+    spec.image.clone().ok_or_else(|| {
+        anyhow!(
+            "connectors.{connector}: declares no `image` and {CONNECTOR_LOCK_FILE} has no entry \
+             for it. Run `curie build --plugin-dir <dir>` first."
+        )
+    })
+}
+
+/// The generated compose overlay: one service per hosted connector, the same
+/// rendered contract `ConnectorStartSpec` emits with `docker run`.
+pub fn compose_overlay(
+    lock: &ConnectorLockFileDecl,
+    decl: &ConnectorsFileDecl,
+    identity: &ConnectorScope,
+    project: &str,
+    plugin_dir: &Path,
+    secret_values: &BTreeMap<String, String>,
+) -> Result<serde_json::Value> {
+    let mut services = serde_json::Map::new();
+    for (connector, spec) in &decl.connectors {
+        if !is_hosted(spec) {
+            continue;
+        }
+        refuse_out_of_band_secrets(connector, spec)?;
+        let image = resolved_image(connector, spec, lock)?;
+        let subs = connector_substitutions(identity, connector, spec.port);
+        let name = object_name(&identity.release, &identity.agent, connector);
+        let alias = service_dns(
+            &identity.release,
+            &identity.agent,
+            connector,
+            &identity.namespace,
+        );
+
+        let mut environment = serde_json::Map::new();
+        for (key, value) in &spec.env {
+            environment.insert(
+                key.clone(),
+                serde_json::Value::String(substitute(value, &subs)),
+            );
+        }
+        for name in declared_secret_names(spec) {
+            // Compose has no secretKeyRef, so a declared secret is resolved
+            // locally. Its value stays out of argv: compose reads the file.
+            if let Some(value) = secret_values.get(&name) {
+                environment.insert(name, serde_json::Value::String(value.clone()));
+            }
+        }
+
+        let volumes: Vec<serde_json::Value> = spec
+            .secret_files
+            .values()
+            .map(|declared_path| {
+                serde_json::Value::String(format!(
+                    "{}:{declared_path}:ro",
+                    staged_secret_path(plugin_dir, connector, declared_path).display()
+                ))
+            })
+            .collect();
+
+        let mut service = serde_json::Map::new();
+        service.insert("image".into(), serde_json::Value::String(image));
+        if !spec.args.is_empty() {
+            service.insert(
+                "command".into(),
+                serde_json::Value::Array(
+                    spec.args
+                        .iter()
+                        .map(|arg| serde_json::Value::String(substitute(arg, &subs)))
+                        .collect(),
+                ),
+            );
+        }
+        if !environment.is_empty() {
+            service.insert("environment".into(), serde_json::Value::Object(environment));
+        }
+        if !volumes.is_empty() {
+            service.insert("volumes".into(), serde_json::Value::Array(volumes));
+        }
+        let mut attachment = serde_json::Map::new();
+        attachment.insert(
+            RUNNER_NETWORK.to_string(),
+            serde_json::json!({ "aliases": [alias] }),
+        );
+        service.insert("networks".into(), serde_json::Value::Object(attachment));
+        service.insert(
+            "labels".into(),
+            serde_json::json!({
+                "curietech.ai/component": "connector",
+                "curietech.ai/project": project,
+            }),
+        );
+        service.insert("read_only".into(), serde_json::Value::Bool(true));
+        service.insert(
+            "user".into(),
+            serde_json::Value::String(format!("{CONNECTOR_UID}:{CONNECTOR_UID}")),
+        );
+        service.insert("cap_drop".into(), serde_json::json!(["ALL"]));
+        service.insert(
+            "security_opt".into(),
+            serde_json::json!(["no-new-privileges"]),
+        );
+        services.insert(name, serde_json::Value::Object(service));
+    }
+
+    let mut networks = serde_json::Map::new();
+    networks.insert(
+        RUNNER_NETWORK.to_string(),
+        serde_json::json!({ "external": true, "name": RUNNER_NETWORK }),
+    );
+    Ok(serde_json::json!({
+        "services": services,
+        "networks": serde_json::Value::Object(networks),
+    }))
+}
+
+/// The env-var names a declaration's `secrets:` list asks to be forwarded.
+pub fn declared_secret_names(spec: &ConnectorSpecDecl) -> Vec<String> {
+    spec.secrets
+        .iter()
+        .map(|declared| match declared {
+            SecretDecl::Name(name) => name.clone(),
+            SecretDecl::Ref { name, .. } => name.clone(),
+        })
+        .collect()
+}
+
+/// A `from_secret` reference points at a Secret someone else provisioned, and
+/// nothing on a laptop corresponds to it. Starting without the credential would
+/// give a server that 401s on every call, which reads as a broken connector
+/// rather than a missing prerequisite, so bring-up fails closed.
+pub fn refuse_out_of_band_secrets(connector: &str, spec: &ConnectorSpecDecl) -> Result<()> {
+    for declared in &spec.secrets {
+        if let SecretDecl::Ref {
+            name, from_secret, ..
+        } = declared
+        {
+            return Err(crate::exit::usage(format!(
+                "connectors.{connector}: `{name}` references the out-of-band Secret \
+                 `{from_secret}`, which has no local equivalent. Either store the value once \
+                 with `curie secrets set {name}` and declare it as a plain `secrets:` entry, \
+                 point the connector at something already running with `unhosted_url`, or run \
+                 this connector at the cluster tier where the Secret exists."
+            )));
+        }
+    }
+    Ok(())
 }

--- a/cli/src/connector_build.rs
+++ b/cli/src/connector_build.rs
@@ -229,15 +229,49 @@ pub fn parse_connectors(document: &str) -> Result<ConnectorsFileDecl> {
     let file: ConnectorsFileDecl =
         serde_norway::from_str(document).with_context(|| format!("parse {CONNECTORS_FILE}"))?;
     for (name, spec) in &file.connectors {
+        check_name(name)?;
         check_spec(name, spec)?;
     }
     Ok(file)
 }
 
+/// The connector name cap and shape, mirroring `plugin_format.connectors`
+/// (`_NAME_MAX`, `_NAME_RE`): an RFC 1123 label, because the name becomes a
+/// Kubernetes object and a DNS label. Change one language and change the other,
+/// or the accept/reject parity this module exists to hold is gone.
+const CONNECTOR_NAME_MAX: usize = 40;
+
+/// Refuse a name neither the platform nor this CLI can carry.
+///
+/// Parity with Python is only half of it. The CLI joins the name into a host
+/// path of its own (`.curie/connector-secrets/<connector>/`), so an unchecked
+/// name is a bundle-authored path component: `../../evil` would put a resolved
+/// credential outside the bundle. Checking at load rather than at each use is
+/// what makes every downstream join safe by construction.
+fn check_name(name: &str) -> Result<()> {
+    let alnum = |c: char| c.is_ascii_lowercase() || c.is_ascii_digit();
+    let valid = !name.is_empty()
+        && name.len() <= CONNECTOR_NAME_MAX
+        && name.chars().all(|c| alnum(c) || c == '-')
+        && name.starts_with(alnum)
+        && name.ends_with(alnum);
+    if !valid {
+        bail!(
+            "connectors.{name}: a connector name becomes a Kubernetes object, a DNS label and a \
+             local directory, so it must be lowercase alphanumeric or dashes, start and end \
+             alphanumeric, and be at most {CONNECTOR_NAME_MAX} characters"
+        );
+    }
+    Ok(())
+}
+
 /// Parse and check a `connectors.lock.yaml` document.
 ///
 /// The version is checked here because it is the only thing that lets a future
-/// shape change be refused by an older reader instead of silently misread.
+/// shape change be refused by an older reader instead of silently misread, and
+/// every entry's image is checked against the delivery it claims because this
+/// reader is the last gate before the CLI runs or ships what the lock names
+/// (see [`check_lock_entry`]).
 pub fn parse_lock(document: &str) -> Result<ConnectorLockFileDecl> {
     let lock: ConnectorLockFileDecl =
         serde_norway::from_str(document).with_context(|| format!("parse {CONNECTOR_LOCK_FILE}"))?;
@@ -248,7 +282,81 @@ pub fn parse_lock(document: &str) -> Result<ConnectorLockFileDecl> {
             lock.version
         );
     }
+    // The lock is a second door onto the same names, and a bring-up reads it
+    // whether or not it re-read the declaration.
+    for (name, entry) in &lock.connectors {
+        check_name(name)?;
+        check_lock_entry(name, entry)?;
+    }
     Ok(lock)
+}
+
+/// The digest suffix both well-formed references carry: `sha256:` plus 64
+/// lowercase hex characters. Fixed by the OCI distribution spec's
+/// content-addressable digest grammar, not by anything in this repository.
+const IMAGE_DIGEST_PREFIX: &str = "sha256:";
+const IMAGE_DIGEST_HEX: usize = 64;
+
+/// Does the recorded reference match the delivery it claims?
+///
+/// The Rust twin of `plugin_format.connector_lock._image_matches_delivery`: a
+/// `registry` entry carries `<repo>@sha256:<64 lowercase hex>`, the manifest
+/// digest a registry pull resolves, and a `local-daemon` entry carries a bare
+/// `sha256:<64 lowercase hex>`, the id `docker image inspect --format {{.Id}}`
+/// reports. Nothing else, a tag included: a tag can be repointed at a different
+/// artifact after review, which is the failure ADR 0113 exists to close.
+fn image_matches_delivery(entry: &ConnectorLockEntryDecl) -> bool {
+    match entry.delivery {
+        // Split on the FIRST `@`, so a reference carrying a second one leaves it
+        // inside the digest half, where it is not hex -- the repository half
+        // admits neither an `@` nor whitespace, as Python's `[^@\s]+` does.
+        Delivery::Registry => entry.image.split_once('@').is_some_and(|(repo, digest)| {
+            !repo.is_empty() && !repo.contains(char::is_whitespace) && is_image_digest(digest)
+        }),
+        Delivery::LocalDaemon => is_image_digest(&entry.image),
+    }
+}
+
+fn is_image_digest(reference: &str) -> bool {
+    reference
+        .strip_prefix(IMAGE_DIGEST_PREFIX)
+        .is_some_and(|hex| {
+            hex.len() == IMAGE_DIGEST_HEX && hex.chars().all(|c| matches!(c, '0'..='9' | 'a'..='f'))
+        })
+}
+
+/// Refuse a lock entry whose image is not a digest of its delivery's shape.
+///
+/// Python refuses this in `apply_lock` rather than in `validate_connector_lock`,
+/// because there the two live one call apart. The CLI has no `apply_lock`: it
+/// reads the lock and runs or renders what it names, so the refusal belongs at
+/// the read. Without it a hand-edited `connectors.lock.yaml` carrying a mutable
+/// tag is run by `curie skill up` and shipped by a deploy, which is exactly the
+/// identity rule ADR 0113 states -- defeated at the one reader that never
+/// asks the platform.
+fn check_lock_entry(name: &str, entry: &ConnectorLockEntryDecl) -> Result<()> {
+    if image_matches_delivery(entry) {
+        return Ok(());
+    }
+    let (delivery, expected) = match entry.delivery {
+        Delivery::Registry => (
+            "registry",
+            "`<repo>@sha256:` plus 64 lowercase hex characters, the manifest digest a registry \
+             pull resolves",
+        ),
+        Delivery::LocalDaemon => (
+            "local-daemon",
+            "a bare `sha256:` plus 64 lowercase hex characters, the image id the local daemon \
+             reports",
+        ),
+    };
+    bail!(
+        "connectors.{name}: {CONNECTOR_LOCK_FILE} records image {:?} for delivery `{delivery}`, \
+         which is not that delivery's digest shape -- it must be {expected}. A mutable tag is \
+         never run or rendered: it can be repointed at a different artifact after review. \
+         Regenerate the lock with `curie build --plugin-dir <dir>`.",
+        entry.image
+    );
 }
 
 /// Read a bundle's `connectors.yaml`, or an empty declaration when it has none.
@@ -1174,11 +1282,35 @@ pub fn connector_secrets_root(plugin_dir: &Path) -> PathBuf {
 }
 
 /// The host path one declared `secret_files` entry is staged at.
+///
+/// The filename carries a digest of the WHOLE declared path, not just its
+/// basename: one connector may declare `/a/token` and `/b/token`, and a
+/// basename-only name stages the second over the first. Producer
+/// (`stage_secret_file`) and consumers (the `docker run` mounts, the compose
+/// overlay) all derive the path here, so the naming is theirs to share.
+///
+/// The basename is reduced to one path-free component because the declared path
+/// is the CONTAINER's: nothing constrains it to a shape the host can hold, and
+/// `..` or a drive-letter component would otherwise be joined verbatim.
 pub fn staged_secret_path(plugin_dir: &Path, connector: &str, declared_path: &str) -> PathBuf {
-    let basename = declared_path.rsplit('/').next().unwrap_or(declared_path);
+    let basename = declared_path
+        .rsplit(['/', '\\'])
+        .next()
+        .unwrap_or(declared_path);
+    let kept: String = basename
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric() || matches!(*c, '.' | '_' | '-'))
+        .collect();
+    // `..`, `.` and the empty basename all name a directory rather than a file.
+    let stem = if kept.trim_matches('.').is_empty() {
+        "secret"
+    } else {
+        kept.as_str()
+    };
+    let digest = hex(Sha256::digest(declared_path.as_bytes()).as_slice());
     connector_secrets_root(plugin_dir)
         .join(connector)
-        .join(basename)
+        .join(format!("{stem}-{}", &digest[..DIGEST_LEN]))
 }
 
 /// Write one resolved credential where the container will find it.
@@ -1200,6 +1332,14 @@ pub fn stage_secret_file(
     std::fs::create_dir_all(parent).with_context(|| format!("create {}", parent.display()))?;
     private_dir(&connector_secrets_root(plugin_dir))?;
     private_dir(parent)?;
+    // Replace, never write over: hardening left any previous staging 0400 (or
+    // 0444 where the chown fell back), so a plain write onto it is EACCES and
+    // a redeploy or credential rotation would wedge until the tree is removed
+    // by hand.
+    if path.exists() {
+        std::fs::remove_file(&path)
+            .with_context(|| format!("replace previously staged {}", path.display()))?;
+    }
     std::fs::write(&path, value).with_context(|| format!("write {}", path.display()))?;
     harden_secret_file(&path)?;
     Ok(path)
@@ -1236,14 +1376,22 @@ fn harden_secret_file(_path: &Path) -> Result<()> {
     Ok(())
 }
 
-/// Remove the staged credential tree. A no-op when it is already gone, so
-/// `down` after `down` does not error.
-pub fn wipe_connector_secrets(plugin_dir: &Path) -> Result<()> {
-    let root = connector_secrets_root(plugin_dir);
+/// Remove a staged credential tree. A no-op when it is already gone, so `down`
+/// after `down` does not error.
+///
+/// Addressed by the root rather than the bundle directory because teardown
+/// carries the root it recorded (`ConnectorTeardownStep::WipeSecrets`) while an
+/// aborting boot carries only the plugin dir; one implementation serves both.
+pub fn wipe_secrets_root(root: &Path) -> Result<()> {
     if !root.exists() {
         return Ok(());
     }
-    std::fs::remove_dir_all(&root).with_context(|| format!("remove {}", root.display()))
+    std::fs::remove_dir_all(root).with_context(|| format!("remove {}", root.display()))
+}
+
+/// The same wipe, addressed by the bundle directory a boot staged into.
+pub fn wipe_connector_secrets(plugin_dir: &Path) -> Result<()> {
+    wipe_secrets_root(&connector_secrets_root(plugin_dir))
 }
 
 // ─── The compose overlay (the local tier's emitter) ──────────────────────────
@@ -1261,7 +1409,18 @@ pub fn compose_overlay_path(plugin_dir: &Path) -> PathBuf {
 
 /// `docker compose ... up -d --wait` for the generated overlay, joined to the
 /// running stack's project so the services land on its network.
-pub fn compose_up_command(overlay: &Path, project: &str) -> crate::ops::OpsCommand {
+///
+/// The resolved secret values ride the compose child's environment as masked
+/// `secret_env`, which is the ONLY channel that carries them: the overlay on
+/// disk holds a `${NAME}` reference, and compose expands it from this
+/// environment at parse time. Taking them here rather than at the call site
+/// makes an up command that starts the overlay without its credentials
+/// unrepresentable.
+pub fn compose_up_command(
+    overlay: &Path,
+    project: &str,
+    secret_values: &BTreeMap<String, String>,
+) -> crate::ops::OpsCommand {
     plain_command(
         "docker",
         vec![
@@ -1275,6 +1434,12 @@ pub fn compose_up_command(overlay: &Path, project: &str) -> crate::ops::OpsComma
             "--wait".into(),
         ],
     )
+    .with_secret_env(
+        secret_values
+            .iter()
+            .map(|(name, value)| (name.clone(), value.clone()))
+            .collect(),
+    )
 }
 
 /// Whether a declared connector is one Curie runs (as opposed to one already
@@ -1284,32 +1449,51 @@ fn is_hosted(spec: &ConnectorSpecDecl) -> bool {
 }
 
 /// The image a hosted connector starts from: the locked digest when the bundle
-/// builds it, else the declared `image:`.
-fn resolved_image(
+/// BUILDS it, else the declared `image:`.
+///
+/// The `build:` check is the whole rule (ADR 0113): the lock records what a
+/// declared build resolved to, so it is the identity of a `build:` connector and
+/// of nothing else. Consulting it first -- which both emitters used to do --
+/// lets an entry outlive the declaration that produced it: a connector switched
+/// from `build:` to `image:` keeps running the last source build, and no output
+/// anywhere says the declared image was ignored.
+///
+/// The one rule, called by both emitters, so the skill tier and the local tier
+/// cannot answer this differently.
+pub fn resolved_image(
     connector: &str,
     spec: &ConnectorSpecDecl,
     lock: &ConnectorLockFileDecl,
 ) -> Result<String> {
-    if let Some(entry) = lock.connectors.get(connector) {
-        return Ok(entry.image.clone());
+    if spec.build.is_some() {
+        if let Some(entry) = lock.connectors.get(connector) {
+            return Ok(entry.image.clone());
+        }
     }
     spec.image.clone().ok_or_else(|| {
-        anyhow!(
+        // Usage (exit 2), not a generic failure: no retry of the same argv
+        // clears it, and the fix is the build this bundle never ran.
+        crate::exit::usage(format!(
             "connectors.{connector}: declares no `image` and {CONNECTOR_LOCK_FILE} has no entry \
              for it. Run `curie build --plugin-dir <dir>` first."
-        )
+        ))
     })
 }
 
 /// The generated compose overlay: one service per hosted connector, the same
 /// rendered contract `ConnectorStartSpec` emits with `docker run`.
+///
+/// No resolved secret value enters it. The overlay is serialized to a file under
+/// `.curie/` that outlives the stack, so a declared secret is written as the
+/// `${NAME}` compose reference and the value travels through
+/// [`compose_up_command`]'s masked `secret_env` instead -- the same rule
+/// `ConnectorStartSpec` follows with its bare `-e NAME`.
 pub fn compose_overlay(
     lock: &ConnectorLockFileDecl,
     decl: &ConnectorsFileDecl,
     identity: &ConnectorScope,
     project: &str,
     plugin_dir: &Path,
-    secret_values: &BTreeMap<String, String>,
 ) -> Result<serde_json::Value> {
     let mut services = serde_json::Map::new();
     for (connector, spec) in &decl.connectors {
@@ -1336,10 +1520,15 @@ pub fn compose_overlay(
         }
         for name in declared_secret_names(spec) {
             // Compose has no secretKeyRef, so a declared secret is resolved
-            // locally. Its value stays out of argv: compose reads the file.
-            if let Some(value) = secret_values.get(&name) {
-                environment.insert(name, serde_json::Value::String(value.clone()));
-            }
+            // locally -- but only the REFERENCE is written here. Compose expands
+            // `${NAME}` from its own process environment at parse time, so the
+            // container receives the literal value while this file, which
+            // survives `local down` at 0644, holds nothing but the name.
+            // Unconditional: every declared name must be present in the injected
+            // environment (`bring_up_local` refuses the bring-up otherwise), or
+            // compose warns and expands it to empty.
+            let reference = format!("${{{name}}}");
+            environment.insert(name, serde_json::Value::String(reference));
         }
 
         let volumes: Vec<serde_json::Value> = spec
@@ -1378,13 +1567,24 @@ pub fn compose_overlay(
             serde_json::json!({ "aliases": [alias] }),
         );
         service.insert("networks".into(), serde_json::Value::Object(attachment));
-        service.insert(
-            "labels".into(),
-            serde_json::json!({
-                "curietech.ai/component": "connector",
-                "curietech.ai/project": project,
-            }),
+        let mut labels = serde_json::Map::new();
+        labels.insert(
+            "curietech.ai/component".into(),
+            serde_json::Value::String("connector".into()),
         );
+        labels.insert(
+            "curietech.ai/project".into(),
+            serde_json::Value::String(project.to_string()),
+        );
+        // Which agent's connector, and which one: the local tier shares one
+        // compose project with the main stack and with every other agent, so
+        // these two are the only thing a redeploy can reconcile against
+        // (`docker::connectors_to_reap`). Emitted from the same pairs the skill
+        // tier's `docker run` labels carry, so one reap selector covers both.
+        for (key, value) in crate::docker::connector_identity_labels(&identity.agent, &name) {
+            labels.insert(key, serde_json::Value::String(value));
+        }
+        service.insert("labels".into(), serde_json::Value::Object(labels));
         service.insert("read_only".into(), serde_json::Value::Bool(true));
         service.insert(
             "user".into(),
@@ -1437,6 +1637,70 @@ pub fn hosted_secret_names(decl: &ConnectorsFileDecl) -> Vec<String> {
         names.extend(spec.secret_files.keys().cloned());
     }
     names.into_iter().collect()
+}
+
+/// The non-`CURIE_`-prefixed names a connector secret must never claim.
+///
+/// The twin of `_CREDENTIAL_KEYS | _REDIRECT_CAPTURE_KEYS` in
+/// `packages/plugin-format/src/plugin_format/reserved_env.py`, which is the
+/// policy's authority. This copy exists because the refusal has to fire on THIS
+/// box, before a value is read out of the operator's environment or vault and
+/// handed to a container the bundle controls, and no Python runs that early.
+/// `apps/worker/tests/binding/test_reserved_boot_env_pin.py` is the drift pin
+/// that fails CI if the two lists diverge -- the same mechanism that pins the
+/// Helm list.
+pub const RESERVED_CONNECTOR_SECRET_NAMES: [&str; 8] = [
+    "ANTHROPIC_BASE_URL",
+    "ANTHROPIC_API_KEY",
+    "CLAUDE_CODE_OAUTH_TOKEN",
+    "ANTHROPIC_AUTH_TOKEN",
+    "HTTPS_PROXY",
+    "HTTP_PROXY",
+    "NODE_EXTRA_CA_CERTS",
+    "ANTHROPIC_CUSTOM_HEADERS",
+];
+
+/// Whether `name` is reserved: an enumerated platform credential or
+/// redirect/capture key, or anything in the `CURIE_` boot namespace. The prefix
+/// rule is the forward-safe half, mirroring `is_reserved_boot_env_name`.
+fn is_reserved_secret_name(name: &str) -> bool {
+    name.starts_with("CURIE_") || RESERVED_CONNECTOR_SECRET_NAMES.contains(&name)
+}
+
+/// Refuse a hosted connector whose declared secret NAME it must not own.
+///
+/// Scoped to the hosted connectors for the same reason `hosted_secret_names` is:
+/// those are the only declarations this box resolves a value for. A connector
+/// declaring `ANTHROPIC_API_KEY` would otherwise have the operator's own model
+/// credential read out of their environment or vault and injected into a
+/// container the bundle chose the image for -- and at the skill and local tiers
+/// that happens before the runner validates the bundle, so the plugin-format
+/// fence never gets a turn. Names only: no value is read to decide this.
+pub fn refuse_reserved_secret_names(decl: &ConnectorsFileDecl) -> Result<()> {
+    for (connector, spec) in &decl.connectors {
+        if spec.url.is_some() || spec.unhosted_url.is_some() {
+            continue;
+        }
+        for name in declared_secret_names(spec)
+            .into_iter()
+            .chain(spec.secret_files.keys().cloned())
+        {
+            crate::secrets::validate_name(&name).map_err(|err| {
+                crate::exit::usage(format!(
+                    "connectors.{connector}: `{name}` is not a usable secret name: {err}"
+                ))
+            })?;
+            if is_reserved_secret_name(&name) {
+                return Err(crate::exit::usage(format!(
+                    "connectors.{connector}: `{name}` is a reserved platform boot-env or \
+                     model-credential key and cannot be a connector secret. Curie would resolve \
+                     the operator's own value for it and hand it to this connector's container. \
+                     Rename the variable the connector reads."
+                )));
+            }
+        }
+    }
+    Ok(())
 }
 
 /// The one refusal both tiers issue when declared secrets have no value here.

--- a/cli/src/connectors.rs
+++ b/cli/src/connectors.rs
@@ -413,11 +413,9 @@ fn resolve_secret_values(keys: &[String]) -> Result<std::collections::BTreeMap<S
         }
     }
     if !missing.is_empty() {
-        return Err(crate::exit::usage(format!(
-            "connectors.yaml declares secret(s) with no value available: {}. Export each in the \
-             environment, or store it once with `curie secrets set <NAME>`.",
-            missing.join(", ")
-        )));
+        // One message, both tiers: `skill up` refuses the same gap with the same
+        // words via `connector_build::missing_secrets_error`.
+        return Err(crate::connector_build::missing_secrets_error(&missing));
     }
     Ok(values)
 }

--- a/cli/src/docker.rs
+++ b/cli/src/docker.rs
@@ -1821,3 +1821,275 @@ driver failed programming external connectivity: port is already allocated."
         assert!(!joined.contains("CURIE_FAKE_MODEL"));
     }
 }
+
+// ---------------------------------------------------------------------------
+// Connector containers (ADR 0113): the skill tier's emitter
+// ---------------------------------------------------------------------------
+
+/// The component label every connector container carries, in both the skill
+/// start path and the compose overlay. Teardown resolves containers by label,
+/// never by a generated file, so a container that is not labeled at creation
+/// can never be reaped.
+pub const CONNECTOR_COMPONENT_LABEL: &str = "curietech.ai/component=connector";
+
+/// The per-stack label that keeps two concurrent bring-ups apart: the compose
+/// project at the local tier, the runner session id at the skill tier.
+pub fn connector_project_label(project: &str) -> String {
+    format!("curietech.ai/project={project}")
+}
+
+/// The uid a connector container runs as, mirroring `render_deployment`'s
+/// `runAsUser`.
+const CONNECTOR_UID: &str = "65532:65532";
+
+/// Everything `docker run` needs to start one hosted connector.
+///
+/// Field for field the container `connector_render.render_deployment` renders:
+/// substituted `args`, substituted `env`, declared secrets, `secret_files`, the
+/// hardening set and the port. An approximation does not degrade gracefully --
+/// dropping `args` silently restores a server's default tool surface.
+#[derive(Debug, Clone)]
+pub struct ConnectorStartSpec {
+    pub image: String,
+    pub container_name: String,
+    pub network: String,
+    /// The Service DNS name the runner independently derives and dials.
+    pub alias: String,
+    pub args: Vec<String>,
+    /// Substituted `env` entries, forwarded as `-e NAME=VALUE`.
+    pub env: Vec<(String, String)>,
+    /// Declared secret NAMES, forwarded as a bare `-e NAME`.
+    pub secret_names: Vec<String>,
+    /// `host:container:ro` bind mounts for the staged credential files.
+    pub mounts: Vec<String>,
+    pub labels: Vec<String>,
+    /// Resolved secret values handed to the Docker CLI child process only, so
+    /// they never enter argv. The same rule [`StartSpec::docker_env`] follows.
+    pub docker_env: Vec<(String, String)>,
+}
+
+impl ConnectorStartSpec {
+    /// Resolve one declared connector into the container that runs it.
+    #[allow(clippy::too_many_arguments)]
+    pub fn from_declaration(
+        connector: &str,
+        spec: &crate::connector_build::ConnectorSpecDecl,
+        image: &str,
+        identity: &crate::connector_build::ConnectorScope,
+        network: &str,
+        project: &str,
+        plugin_dir: &std::path::Path,
+        secret_values: &std::collections::BTreeMap<String, String>,
+    ) -> Result<Self> {
+        crate::connector_build::refuse_out_of_band_secrets(connector, spec)?;
+        let subs = crate::connector_build::connector_substitutions(identity, connector, spec.port);
+        let secret_names = crate::connector_build::declared_secret_names(spec);
+        let docker_env: Vec<(String, String)> = secret_names
+            .iter()
+            .filter_map(|name| {
+                secret_values
+                    .get(name)
+                    .map(|value| (name.clone(), value.clone()))
+            })
+            .collect();
+        Ok(Self {
+            image: image.to_string(),
+            container_name: format!("curie-connector-{project}-{connector}"),
+            network: network.to_string(),
+            alias: crate::connector_build::service_dns(
+                &identity.release,
+                &identity.agent,
+                connector,
+                &identity.namespace,
+            ),
+            args: spec
+                .args
+                .iter()
+                .map(|arg| crate::connector_build::substitute(arg, &subs))
+                .collect(),
+            env: spec
+                .env
+                .iter()
+                .map(|(key, value)| {
+                    (
+                        key.clone(),
+                        crate::connector_build::substitute(value, &subs),
+                    )
+                })
+                .collect(),
+            secret_names,
+            mounts: spec
+                .secret_files
+                .values()
+                .map(|declared_path| {
+                    format!(
+                        "{}:{declared_path}:ro",
+                        crate::connector_build::staged_secret_path(
+                            plugin_dir,
+                            connector,
+                            declared_path
+                        )
+                        .display()
+                    )
+                })
+                .collect(),
+            labels: vec![
+                CLI_MANAGED_LABEL.to_string(),
+                CONNECTOR_COMPONENT_LABEL.to_string(),
+                connector_project_label(project),
+            ],
+            docker_env,
+        })
+    }
+
+    /// The `docker run` argument vector (after the `docker` executable).
+    ///
+    /// No `-p`, ever: the runner reaches the connector over the private network
+    /// by alias, so a published port would collide between two concurrent
+    /// bundles and expose a credential-holding server on the host.
+    pub fn run_args(&self) -> Vec<String> {
+        let mut args: Vec<String> = vec![
+            "run".into(),
+            "-d".into(),
+            "--name".into(),
+            self.container_name.clone(),
+            "--network".into(),
+            self.network.clone(),
+            "--network-alias".into(),
+            self.alias.clone(),
+        ];
+        // Hardened by construction, exactly as the rendered pod is. The bundle
+        // author never writes this, so the author cannot omit it.
+        args.extend([
+            "--read-only".to_string(),
+            "--cap-drop".to_string(),
+            "ALL".to_string(),
+            "--security-opt".to_string(),
+            "no-new-privileges".to_string(),
+            "--user".to_string(),
+            CONNECTOR_UID.to_string(),
+        ]);
+        for label in &self.labels {
+            args.push("--label".into());
+            args.push(label.clone());
+        }
+        for (key, value) in &self.env {
+            args.push("-e".into());
+            args.push(format!("{key}={value}"));
+        }
+        // The bare NAME: the value travels to the Docker CLI child's
+        // environment instead, so it never lands in `ps -ef`.
+        for name in &self.secret_names {
+            args.push("-e".into());
+            args.push(name.clone());
+        }
+        for mount in &self.mounts {
+            args.push("-v".into());
+            args.push(mount.clone());
+        }
+        args.push(self.image.clone());
+        args.extend(self.args.iter().cloned());
+        args
+    }
+}
+
+/// One step of a connector teardown, in the order it must run.
+#[derive(Debug, Clone)]
+pub enum ConnectorTeardownStep {
+    /// List the containers this project's connectors created, by label.
+    ReapLabeled(crate::ops::OpsCommand),
+    RemoveNetwork(crate::ops::OpsCommand),
+    WipeSecrets(PathBuf),
+}
+
+/// Containers first, then the network, then the staged credential tree.
+///
+/// The order is the property: a network still attached to a running container
+/// cannot be removed, and a tree still bind-mounted into one cannot be wiped
+/// cleanly. Reaping is label-scoped rather than file-scoped because a `down`
+/// run from another directory carries no plugin directory and must still reap.
+pub fn connector_teardown_plan(
+    project: &str,
+    network: Option<&str>,
+    plugin_dir: Option<&std::path::Path>,
+) -> Vec<ConnectorTeardownStep> {
+    let mut steps = vec![ConnectorTeardownStep::ReapLabeled(
+        crate::connector_build::plain_command(
+            "docker",
+            vec![
+                "ps".into(),
+                "-a".into(),
+                "-q".into(),
+                "--filter".into(),
+                format!("label={CONNECTOR_COMPONENT_LABEL}"),
+                "--filter".into(),
+                format!("label={}", connector_project_label(project)),
+            ],
+        ),
+    )];
+    if let Some(network) = network {
+        steps.push(ConnectorTeardownStep::RemoveNetwork(
+            crate::connector_build::plain_command(
+                "docker",
+                vec!["network".into(), "rm".into(), network.to_string()],
+            ),
+        ));
+    }
+    if let Some(plugin_dir) = plugin_dir {
+        steps.push(ConnectorTeardownStep::WipeSecrets(
+            crate::connector_build::connector_secrets_root(plugin_dir),
+        ));
+    }
+    steps
+}
+
+/// Run a connector teardown plan, tolerating what is already gone.
+///
+/// Every failure is a warning rather than a hard stop: a teardown that refuses
+/// to finish leaves the operator worse off than one that reports what it could
+/// not remove.
+pub async fn run_connector_teardown(steps: &[ConnectorTeardownStep]) -> Vec<String> {
+    let mut problems = Vec::new();
+    for step in steps {
+        match step {
+            ConnectorTeardownStep::ReapLabeled(command) => match docker(&command.argv()).await {
+                Ok(listing) => {
+                    let ids: Vec<String> = listing
+                        .lines()
+                        .map(str::trim)
+                        .filter(|line| !line.is_empty())
+                        .map(str::to_string)
+                        .collect();
+                    if ids.is_empty() {
+                        continue;
+                    }
+                    let mut rm: Vec<String> = vec!["rm".into(), "-f".into()];
+                    rm.extend(ids);
+                    if let Err(err) = docker(&rm).await {
+                        problems.push(format!("could not remove connector containers: {err}"));
+                    }
+                }
+                Err(err) => problems.push(format!("could not list connector containers: {err}")),
+            },
+            ConnectorTeardownStep::RemoveNetwork(command) => {
+                if let Err(err) = docker(&command.argv()).await {
+                    let text = err.to_string();
+                    if !text.contains("No such network") && !text.contains("not found") {
+                        problems.push(format!("could not remove the connector network: {err}"));
+                    }
+                }
+            }
+            ConnectorTeardownStep::WipeSecrets(root) => {
+                if root.exists() {
+                    if let Err(err) = std::fs::remove_dir_all(root) {
+                        problems.push(format!(
+                            "could not wipe staged connector credentials at {}: {err}",
+                            root.display()
+                        ));
+                    }
+                }
+            }
+        }
+    }
+    problems
+}

--- a/cli/src/docker.rs
+++ b/cli/src/docker.rs
@@ -1838,6 +1838,134 @@ pub fn connector_project_label(project: &str) -> String {
     format!("curietech.ai/project={project}")
 }
 
+/// The agent a connector container belongs to.
+///
+/// The project label is not enough to name one agent's containers at the local
+/// tier: every locally deployed agent shares the single `curie` compose project
+/// with the api/worker stack, so reaping by project alone would take out another
+/// agent's connectors (and `--remove-orphans` would take out the stack itself).
+pub const CONNECTOR_AGENT_LABEL_KEY: &str = "curietech.ai/agent";
+
+/// Which declared connector a container is, as the object name both emitters
+/// derive from `(release, agent, connector)`. This is what a redeploy compares
+/// against the new desired set.
+pub const CONNECTOR_OBJECT_LABEL_KEY: &str = "curietech.ai/connector";
+
+/// The `label=key=value` filter that selects one agent's connector containers.
+pub fn connector_agent_label(agent: &str) -> String {
+    format!("{CONNECTOR_AGENT_LABEL_KEY}={agent}")
+}
+
+/// The identity labels every connector container carries, from ONE definition:
+/// the skill tier joins them into `--label key=value`, the compose overlay
+/// writes them as map entries. A container that is not labeled at creation can
+/// never be reconciled, so the two emitters cannot be allowed to drift.
+pub fn connector_identity_labels(agent: &str, object: &str) -> Vec<(String, String)> {
+    vec![
+        (CONNECTOR_AGENT_LABEL_KEY.to_string(), agent.to_string()),
+        (CONNECTOR_OBJECT_LABEL_KEY.to_string(), object.to_string()),
+    ]
+}
+
+/// One connector container Docker currently reports for an agent.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RunningConnector {
+    pub id: String,
+    /// The object name its [`CONNECTOR_OBJECT_LABEL_KEY`] label carries. Empty
+    /// for a container an older CLI started without the label.
+    pub object: String,
+}
+
+/// List THIS agent's connector containers, id and object name.
+///
+/// Three filters, all of them load-bearing: the component label excludes the
+/// runner and the sandbox, the project label excludes another stack, and the
+/// agent label excludes another agent deployed into this same compose project.
+pub fn agent_connectors_argv(project: &str, agent: &str) -> Vec<String> {
+    vec![
+        "ps".into(),
+        "-a".into(),
+        "--filter".into(),
+        format!("label={CONNECTOR_COMPONENT_LABEL}"),
+        "--filter".into(),
+        format!("label={}", connector_project_label(project)),
+        "--filter".into(),
+        format!("label={}", connector_agent_label(agent)),
+        "--format".into(),
+        format!("{{{{.ID}}}}\t{{{{.Label \"{CONNECTOR_OBJECT_LABEL_KEY}\"}}}}"),
+    ]
+}
+
+/// Parse [`agent_connectors_argv`]'s output.
+pub fn parse_agent_connectors(listing: &str) -> Vec<RunningConnector> {
+    listing
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(|line| {
+            let (id, object) = line.split_once('\t').unwrap_or((line, ""));
+            RunningConnector {
+                id: id.trim().to_string(),
+                object: object.trim().to_string(),
+            }
+        })
+        .collect()
+}
+
+/// Which of this agent's running connector containers a redeploy must remove:
+/// exactly those the new bundle no longer declares.
+///
+/// Pure, so the scope decision is testable without a daemon -- and the scope IS
+/// the decision. The input is already narrowed to one agent's containers by
+/// [`agent_connectors_argv`], so nothing here can reach the main stack or
+/// another agent; all this adds is "and it is not in the new desired set". A
+/// container carrying no object label (started before the label existed) matches
+/// no desired name and is removed, which is correct either way: if the bundle
+/// still declares it, the bring-up that follows recreates it labeled.
+pub fn connectors_to_reap(
+    running: &[RunningConnector],
+    desired: &std::collections::BTreeSet<String>,
+) -> Vec<String> {
+    running
+        .iter()
+        .filter(|container| !desired.contains(&container.object))
+        .map(|container| container.id.clone())
+        .collect()
+}
+
+/// Reconcile one agent's connector containers against what the bundle now
+/// declares, returning what it could not do.
+///
+/// Best-effort and warning-shaped, the same choice [`run_connector_teardown`]
+/// makes: a redeploy that refuses to finish because a leftover container would
+/// not die leaves the operator worse off than one that says so and continues.
+pub async fn reap_undesired_connectors(
+    project: &str,
+    agent: &str,
+    desired: &std::collections::BTreeSet<String>,
+) -> Vec<String> {
+    let listing = match docker(&agent_connectors_argv(project, agent)).await {
+        Ok(listing) => listing,
+        Err(err) => {
+            return vec![format!(
+                "could not list the connector containers already running for '{agent}': {err}"
+            )]
+        }
+    };
+    let stale = connectors_to_reap(&parse_agent_connectors(&listing), desired);
+    if stale.is_empty() {
+        return Vec::new();
+    }
+    let mut rm: Vec<String> = vec!["rm".into(), "-f".into()];
+    rm.extend(stale);
+    match docker(&rm).await {
+        Ok(_) => Vec::new(),
+        Err(err) => vec![format!(
+            "could not remove the connector containers this bundle no longer declares: {err}"
+        )],
+    }
+}
+
 /// The uid a connector container runs as, mirroring `render_deployment`'s
 /// `runAsUser`.
 const CONNECTOR_UID: &str = "65532:65532";
@@ -1933,11 +2061,26 @@ impl ConnectorStartSpec {
                     )
                 })
                 .collect(),
-            labels: vec![
-                CLI_MANAGED_LABEL.to_string(),
-                CONNECTOR_COMPONENT_LABEL.to_string(),
-                connector_project_label(project),
-            ],
+            labels: {
+                let mut labels = vec![
+                    CLI_MANAGED_LABEL.to_string(),
+                    CONNECTOR_COMPONENT_LABEL.to_string(),
+                    connector_project_label(project),
+                ];
+                labels.extend(
+                    connector_identity_labels(
+                        &identity.agent,
+                        &crate::connector_build::object_name(
+                            &identity.release,
+                            &identity.agent,
+                            connector,
+                        ),
+                    )
+                    .into_iter()
+                    .map(|(key, value)| format!("{key}={value}")),
+                );
+                labels
+            },
             docker_env,
         })
     }
@@ -2080,13 +2223,10 @@ pub async fn run_connector_teardown(steps: &[ConnectorTeardownStep]) -> Vec<Stri
                 }
             }
             ConnectorTeardownStep::WipeSecrets(root) => {
-                if root.exists() {
-                    if let Err(err) = std::fs::remove_dir_all(root) {
-                        problems.push(format!(
-                            "could not wipe staged connector credentials at {}: {err}",
-                            root.display()
-                        ));
-                    }
+                if let Err(err) = crate::connector_build::wipe_secrets_root(root) {
+                    problems.push(format!(
+                        "could not wipe staged connector credentials: {err}"
+                    ));
                 }
             }
         }

--- a/cli/src/local.rs
+++ b/cli/src/local.rs
@@ -8,7 +8,7 @@
 
 use std::path::Path;
 
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
 
 use crate::commands::OLLAMA_PORT;
 use crate::docker;
@@ -756,24 +756,52 @@ impl crate::ui::CliOutput for LocalDownOutput {
     }
 }
 
+/// The connector teardown `local down` runs, for a `down` invoked from `cwd`.
+///
+/// Container reaping stays label-scoped rather than file-scoped: `LocalDownOpts`
+/// carries no plugin directory, so a `down` run from anywhere must still reap
+/// what a `local deploy` started (ADR 0113, block B1-8). The staged credential
+/// tree can only be addressed by path, and the local tier records the deployed
+/// bundle's directory nowhere (`.curie/runner.json` is the skill tier's), so the
+/// honest resolution is the one `local deploy` itself defaults to: the current
+/// directory (`--plugin-dir .`). The wipe is added only when that directory
+/// actually holds a staged tree.
+///
+/// The limit that leaves: a `down` run from an unrelated directory, or after a
+/// deploy that pointed `--plugin-dir` elsewhere, still cannot find that bundle's
+/// tree. Accepted, because guessing at another bundle is worse than missing one
+/// -- the containers holding the credentials are reaped either way, and a `down`
+/// or `deploy` from the bundle's own directory clears the tree.
+pub fn connector_teardown_plan_for_down(cwd: &Path) -> Vec<docker::ConnectorTeardownStep> {
+    let staged = crate::connector_build::connector_secrets_root(cwd).is_dir();
+    docker::connector_teardown_plan(COMPOSE_PROJECT, None, staged.then_some(cwd))
+}
+
 pub async fn down(o: LocalDownOpts) -> Result<LocalDownOutput> {
     let ui = crate::ui::ui();
     let cmd = down_command(&o);
+    let cwd = std::env::current_dir().context("resolving the current directory")?;
+    let teardown = connector_teardown_plan_for_down(&cwd);
     if o.common.dry_run {
-        return Ok(LocalDownOutput::DryRun(crate::ui::DryRunPlan {
-            lines: vec![
-                cmd.display(),
-                format!(
-                    "docker rm -f $(docker ps -a --filter label={} -q)",
-                    docker::SANDBOX_LABEL
-                ),
-                format!(
-                    "docker rm -f $(docker ps -a -q --filter label={} --filter label={})",
-                    docker::CONNECTOR_COMPONENT_LABEL,
-                    docker::connector_project_label(COMPOSE_PROJECT)
-                ),
-            ],
-        }));
+        let mut lines = vec![
+            cmd.display(),
+            format!(
+                "docker rm -f $(docker ps -a --filter label={} -q)",
+                docker::SANDBOX_LABEL
+            ),
+            format!(
+                "docker rm -f $(docker ps -a -q --filter label={} --filter label={})",
+                docker::CONNECTOR_COMPONENT_LABEL,
+                docker::connector_project_label(COMPOSE_PROJECT)
+            ),
+        ];
+        // A removal of files on disk must not be a surprise the plan omitted.
+        for step in &teardown {
+            if let docker::ConnectorTeardownStep::WipeSecrets(path) = step {
+                lines.push(format!("rm -rf {}", path.display()));
+            }
+        }
+        return Ok(LocalDownOutput::DryRun(crate::ui::DryRunPlan { lines }));
     }
     if o.wipe {
         ui.warn(&format!(
@@ -797,16 +825,11 @@ pub async fn down(o: LocalDownOpts) -> Result<LocalDownOutput> {
         "stopping stack"
     };
     run_step(&cl, label, "stopped", &cmd).await?;
-    // Connector containers are label-scoped, never file-scoped: `LocalDownOpts`
-    // carries no plugin directory, so a `down` run from another directory must
-    // still reap what a `local deploy` started (ADR 0113, block B1-8).
-    for problem in docker::run_connector_teardown(&docker::connector_teardown_plan(
-        COMPOSE_PROJECT,
-        None,
-        None,
-    ))
-    .await
-    {
+    // Containers first, then this bundle's staged credential tree when the
+    // directory `down` was run from holds one -- see
+    // `connector_teardown_plan_for_down` for what that resolution can and
+    // cannot reach.
+    for problem in docker::run_connector_teardown(&teardown).await {
         ui.warn(&problem);
     }
     let report = docker::reap_labeled(docker::SANDBOX_LABEL).await;

--- a/cli/src/local.rs
+++ b/cli/src/local.rs
@@ -17,6 +17,11 @@ use crate::ops::{plain, require_on_path, run_capture, run_step, OpsCommand};
 /// Dev-channel local-candidate filename probed by the artifact resolver.
 pub const DEFAULT_COMPOSE_FILE: &str = "compose.dev.yaml";
 
+/// The compose project every local-tier command pins, injected as
+/// `COMPOSE_PROJECT_NAME`. Named once so the connector overlay joins the same
+/// project (and therefore the same `curie_runner` network) the stack runs under.
+pub const COMPOSE_PROJECT: &str = "curie";
+
 /// The Docker volume holding this tier's Ollama model cache: compose's
 /// `ollama_data` under the pinned `curie` project name that `up_command`
 /// injects as `COMPOSE_PROJECT_NAME`. Hardcoded to match the compose file, the
@@ -302,7 +307,7 @@ pub fn up_command(o: &LocalOpts) -> OpsCommand {
             // Pin the compose project name so the default network is always
             // `curie_default`, regardless of the working-directory basename
             // (which is what compose otherwise derives the project name from).
-            ("COMPOSE_PROJECT_NAME".into(), "curie".into()),
+            ("COMPOSE_PROJECT_NAME".into(), COMPOSE_PROJECT.into()),
         ]
     } else {
         // Delegate to `fake_model_env_override`, which discriminates on
@@ -373,7 +378,7 @@ pub fn rebuild_command(o: &LocalOpts, service: &str) -> OpsCommand {
             ),
             ("CURIE_MODEL".into(), model.clone()),
             ("CURIE_DOCKER_NETWORK".into(), "curie_runner".into()),
-            ("COMPOSE_PROJECT_NAME".into(), "curie".into()),
+            ("COMPOSE_PROJECT_NAME".into(), COMPOSE_PROJECT.into()),
         ]
     } else {
         fake_model_env_override(o.model_mode).into_iter().collect()
@@ -762,6 +767,11 @@ pub async fn down(o: LocalDownOpts) -> Result<LocalDownOutput> {
                     "docker rm -f $(docker ps -a --filter label={} -q)",
                     docker::SANDBOX_LABEL
                 ),
+                format!(
+                    "docker rm -f $(docker ps -a -q --filter label={} --filter label={})",
+                    docker::CONNECTOR_COMPONENT_LABEL,
+                    docker::connector_project_label(COMPOSE_PROJECT)
+                ),
             ],
         }));
     }
@@ -787,6 +797,18 @@ pub async fn down(o: LocalDownOpts) -> Result<LocalDownOutput> {
         "stopping stack"
     };
     run_step(&cl, label, "stopped", &cmd).await?;
+    // Connector containers are label-scoped, never file-scoped: `LocalDownOpts`
+    // carries no plugin directory, so a `down` run from another directory must
+    // still reap what a `local deploy` started (ADR 0113, block B1-8).
+    for problem in docker::run_connector_teardown(&docker::connector_teardown_plan(
+        COMPOSE_PROJECT,
+        None,
+        None,
+    ))
+    .await
+    {
+        ui.warn(&problem);
+    }
     let report = docker::reap_labeled(docker::SANDBOX_LABEL).await;
     if let Some(err) = report.error {
         // The stack stopped, but the runner reap did not complete cleanly. Fail

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -313,16 +313,32 @@ enum Command {
         #[arg(long = "secret", value_name = "NAME")]
         secret: Vec<String>,
     },
-    /// Build the runner image locally from `runner/Dockerfile` (source checkout only).
+    /// Build the runner image, or an agent bundle's declared connectors.
     ///
-    /// Runs `docker build -f runner/Dockerfile -t <tag> .` from the repo root. A
-    /// release binary pulls the pinned runner image from GHCR automatically and
-    /// never needs this; it errors clearly if Docker is missing or there is no
-    /// repo checkout.
+    /// With no flags it runs `docker build -f runner/Dockerfile -t <tag> .` from
+    /// the repo root (source checkout only; a release binary pulls the pinned
+    /// runner image from GHCR automatically and never needs this).
+    ///
+    /// With `--plugin-dir <PATH>` it builds every connector that bundle's
+    /// `connectors.yaml` declares from source and writes `connectors.lock.yaml`
+    /// beside it. With `--registry <REF>` it builds every declared platform,
+    /// pushes, and records the registry manifest digest, which is what a cluster
+    /// deploy requires. Without `--registry` it builds the host platform only
+    /// into the local Docker daemon and records the local image id, which is
+    /// usable at the skill and local tiers and refused at cluster.
     Build {
         /// Image tag to build.
-        #[arg(long, default_value = docker::RUNNER_IMAGE)]
+        #[arg(long, default_value = docker::RUNNER_IMAGE, conflicts_with = "plugin_dir")]
         tag: String,
+        /// Build the connectors this agent bundle declares.
+        #[arg(long, value_name = "PATH")]
+        plugin_dir: Option<PathBuf>,
+        /// Push a multi-platform index to this registry (e.g. ghcr.io/acme-corp).
+        #[arg(long, value_name = "REF", requires = "plugin_dir")]
+        registry: Option<String>,
+        /// Replace a registry lock with a local-daemon one deliberately.
+        #[arg(long, requires = "plugin_dir")]
+        force: bool,
     },
     /// Bootstrap or update a dev checkout: install deps and build, start nothing (source checkout only).
     ///
@@ -2017,7 +2033,22 @@ async fn run(command: Option<Command>) -> Result<()> {
             from_spec,
             adopt,
         }) => commands::init(name, dir, from_spec, adopt),
-        Some(Command::Build { tag }) => commands::build(&tag).await,
+        Some(Command::Build {
+            tag,
+            plugin_dir,
+            registry,
+            force,
+        }) => match plugin_dir {
+            Some(plugin_dir) => emit(
+                commands::build_connectors(commands::ConnectorBuildOpts {
+                    plugin_dir,
+                    registry,
+                    force,
+                })
+                .await?,
+            ),
+            None => commands::build(&tag).await,
+        },
         Some(Command::Install { update }) => commands::install(update).await,
         Some(Command::Update { image }) => commands::update(image).await,
         Some(Command::Interactive) => curie::interactive::run().await,
@@ -2452,6 +2483,7 @@ async fn run(command: Option<Command>) -> Result<()> {
                         // declared-secrets policy gate (#464).
                         secret_binding_supported: true,
                         connect_hint: connect_hint.clone(),
+                        tier: commands::DeployTier::Local,
                     })
                     .await?,
                 )
@@ -3145,6 +3177,7 @@ async fn run(command: Option<Command>) -> Result<()> {
                         // with a `--secret <NAME>` remediation this tier lacks.
                         secret_binding_supported: false,
                         connect_hint: connect_hint.clone(),
+                        tier: commands::DeployTier::Cluster,
                     })
                     .await
                     {
@@ -3737,13 +3770,13 @@ mod tests {
     fn build_defaults_tag_and_accepts_override() {
         let cli = Cli::try_parse_from(["curie", "build"]).expect("build should parse");
         match cli.command {
-            Some(Command::Build { tag }) => assert_eq!(tag, "curie-runner"),
+            Some(Command::Build { tag, .. }) => assert_eq!(tag, "curie-runner"),
             _ => panic!("expected build command"),
         }
         let cli = Cli::try_parse_from(["curie", "build", "--tag", "my-runner:dev"])
             .expect("build --tag should parse");
         match cli.command {
-            Some(Command::Build { tag }) => assert_eq!(tag, "my-runner:dev"),
+            Some(Command::Build { tag, .. }) => assert_eq!(tag, "my-runner:dev"),
             _ => panic!("expected build command"),
         }
     }

--- a/cli/src/state.rs
+++ b/cli/src/state.rs
@@ -43,6 +43,16 @@ pub struct RunnerState {
     /// (never re-derived) so teardown removes exactly what boot created.
     #[serde(default)]
     pub bundle_snapshot_dir: Option<String>,
+    /// The connector containers this boot created, recorded (never re-derived)
+    /// so `skill down` reaps exactly what `skill up` started. Without the
+    /// record a run that dies mid-turn leaves labeled containers holding a
+    /// resolved credential -- the failure class #747 fixed once for the runner.
+    #[serde(default)]
+    pub connector_containers: Vec<String>,
+    /// The network the connectors and the runner share, when this boot made
+    /// one. `None` for a bundle that declares no hosted connector.
+    #[serde(default)]
+    pub connector_network: Option<String>,
 }
 
 fn state_path(dir: &Path) -> PathBuf {
@@ -259,6 +269,8 @@ mod tests {
             model_base_url: None,
             bundle_digest: None,
             bundle_snapshot_dir: None,
+            connector_containers: Vec::new(),
+            connector_network: None,
         }
     }
 

--- a/cli/tests/api_deploy.rs
+++ b/cli/tests/api_deploy.rs
@@ -97,6 +97,7 @@ fn run_git(git: &Path, cwd: &Path, args: &[&str]) -> String {
 #[cfg(unix)]
 async fn run_command_deploy(server: &MockServer, plugin_dir: &Path) -> commands::DeployOutput {
     commands::deploy(DeployOpts {
+        tier: commands::DeployTier::Local,
         agent: None,
         target: None,
         plugin_dir: plugin_dir.to_path_buf(),

--- a/cli/tests/connector_build.rs
+++ b/cli/tests/connector_build.rs
@@ -68,11 +68,12 @@
 use std::collections::BTreeMap;
 use std::path::Path;
 
-use curie::commands::{ConnectorBuildOutput, ConnectorBuildRecord};
+use curie::commands::{connectors_needing_rebuild, ConnectorBuildOutput, ConnectorBuildRecord};
 use curie::connector_build::{
     self, build_argv, build_plan, digest_from_metadata, digest_pinned_ref, host_platform,
-    image_inspect_argv, lock_overwrite_refusal, registry_image_ref, write_lock, ConnectorBuildDecl,
-    ConnectorLockEntryDecl, ConnectorLockFileDecl, ConnectorSpecDecl, Delivery,
+    hosted_secret_names, image_inspect_argv, lock_overwrite_refusal, missing_secrets_error,
+    registry_image_ref, write_lock, ConnectorBuildDecl, ConnectorLockEntryDecl,
+    ConnectorLockFileDecl, ConnectorSpecDecl, Delivery, SecretDecl,
 };
 use curie::ui::CliOutput;
 use tempfile::TempDir;
@@ -791,4 +792,219 @@ fn a_bundle_with_nothing_to_build_still_emits_an_object() {
         Some(0),
         "an empty list, not a missing key: {json}"
     );
+}
+
+// ─── The skill tier's rebuild decision (ADR 0113, Decision 3) ────────────────
+
+/// A hosted connector built from source, with no `url`/`unhosted_url`.
+fn built_spec() -> ConnectorSpecDecl {
+    spec_for("tempo", &["linux/amd64"])
+}
+
+fn declaration(entries: &[(&str, ConnectorSpecDecl)]) -> connector_build::ConnectorsFileDecl {
+    connector_build::ConnectorsFileDecl {
+        connectors: entries
+            .iter()
+            .map(|(name, spec)| ((*name).to_string(), spec.clone()))
+            .collect(),
+    }
+}
+
+fn digests(entries: &[(&str, &str)]) -> BTreeMap<String, String> {
+    entries
+        .iter()
+        .map(|(name, digest)| ((*name).to_string(), (*digest).to_string()))
+        .collect()
+}
+
+const FRESH: &str = "sha256:5555555555555555555555555555555555555555555555555555555555555555";
+const CHANGED: &str = "sha256:6666666666666666666666666666666666666666666666666666666666666666";
+
+/// No lock at all: `skill up` has to build before it can start anything.
+#[test]
+fn an_absent_lock_names_every_built_connector() {
+    let decl = declaration(&[("tempo", built_spec())]);
+    assert_eq!(
+        connectors_needing_rebuild(&decl, None, &digests(&[("tempo", FRESH)])),
+        vec!["tempo".to_string()],
+        "a bundle with no lock has no image to start"
+    );
+}
+
+/// The driver-verified defect: the source moved on, the lock did not, and the
+/// old digest's container used to start with no warning.
+#[test]
+fn a_stale_digest_names_the_connector_that_moved() {
+    let decl = declaration(&[("tempo", built_spec())]);
+    let lock = lock_with(
+        "curie-connector-sre-bot-tempo:build",
+        Delivery::LocalDaemon,
+        FRESH,
+    );
+    assert_eq!(
+        connectors_needing_rebuild(&decl, Some(&lock), &digests(&[("tempo", CHANGED)])),
+        vec!["tempo".to_string()],
+        "the locked image no longer stands for this source"
+    );
+}
+
+/// The offline guarantee: a lock that still matches the tree triggers no build,
+/// so `skill up` stays runnable with no daemon build and no network.
+#[test]
+fn a_fresh_lock_asks_for_no_build() {
+    let decl = declaration(&[("tempo", built_spec())]);
+    let lock = lock_with(
+        "curie-connector-sre-bot-tempo:build",
+        Delivery::LocalDaemon,
+        FRESH,
+    );
+    assert!(
+        connectors_needing_rebuild(&decl, Some(&lock), &digests(&[("tempo", FRESH)])).is_empty(),
+        "an unchanged bundle must not invoke docker build"
+    );
+}
+
+/// Nothing to build: an `image:`-hosted connector carries no source, and a
+/// `build:` connector overridden to an already-running process is not started
+/// here. Neither may drag the bundle into a build.
+#[test]
+fn connectors_with_no_source_to_build_ask_for_no_build() {
+    let mut overridden = built_spec();
+    overridden.unhosted_url = Some("http://localhost:9000/mcp".to_string());
+    let decl = declaration(&[
+        (
+            "pinned",
+            ConnectorSpecDecl {
+                image: Some("ghcr.io/acme-corp/pinned:v1".to_string()),
+                ..Default::default()
+            },
+        ),
+        ("dev-override", overridden),
+    ]);
+    assert!(
+        connectors_needing_rebuild(&decl, None, &BTreeMap::new()).is_empty(),
+        "a bundle with no buildable hosted connector never reaches the build machinery"
+    );
+}
+
+// ─── The bring-up secret preflight (fail closed) ─────────────────────────────
+//
+// The driver-verified defect: `skill up` on a bundle whose hosted connector
+// declared a secret with no value here reported SUCCESS and started the
+// container anyway; the container exited 1 on its own missing-credential check
+// and the runner was left dialing an MCP URL that connection-refused mid-turn.
+// `hosted_secret_names` is the seam the refusal is computed from -- which NAMES
+// a bring-up must be able to resolve before it creates anything.
+
+/// A connector started locally, declaring one plain `secrets:` entry.
+fn hosted_with_secret(name: &str) -> ConnectorSpecDecl {
+    ConnectorSpecDecl {
+        image: Some("ghcr.io/acme-corp/grafana-mcp:v1".to_string()),
+        secrets: vec![SecretDecl::Name(name.to_string())],
+        ..Default::default()
+    }
+}
+
+/// THE RED. Without the preflight there is nothing to compute the refusal from,
+/// and bring-up proceeds to start a container that cannot serve a single call.
+#[test]
+fn a_hosted_connectors_declared_secret_is_demanded_at_bring_up() {
+    let decl = declaration(&[(
+        "grafana",
+        hosted_with_secret("GRAFANA_SERVICE_ACCOUNT_TOKEN"),
+    )]);
+    assert_eq!(
+        hosted_secret_names(&decl),
+        vec!["GRAFANA_SERVICE_ACCOUNT_TOKEN".to_string()],
+        "the name the container's own startup check would have died on"
+    );
+}
+
+/// The over-refusal guard. A connector pointed at something already running is
+/// not started here at all: its secrets belong to the remote's client config and
+/// are expanded by the MCP client, so demanding them would refuse a bundle that
+/// works perfectly.
+#[test]
+fn a_connector_that_is_not_hosted_here_has_its_secrets_left_alone() {
+    let mut remote = hosted_with_secret("REMOTE_API_KEY");
+    remote.image = None;
+    remote.url = Some("https://mcp.acme-corp.example/mcp".to_string());
+    let mut overridden = hosted_with_secret("DEV_OVERRIDE_TOKEN");
+    overridden.unhosted_url = Some("http://localhost:9000/mcp".to_string());
+    let decl = declaration(&[("remote", remote), ("dev-override", overridden)]);
+    assert!(
+        hosted_secret_names(&decl).is_empty(),
+        "neither connector is started by this bring-up, so neither credential is its prerequisite"
+    );
+}
+
+/// The second channel a hosted connector resolves: a credential written to a
+/// file the container mounts. An unstaged `secret_files` mount is the same
+/// broken container, so its KEY is a prerequisite too.
+#[test]
+fn a_credential_file_key_is_a_prerequisite_as_well() {
+    let mut spec = hosted_with_secret("GRAFANA_SERVICE_ACCOUNT_TOKEN");
+    spec.secret_files = BTreeMap::from([(
+        "K8S_READONLY_KUBECONFIG".to_string(),
+        "/secrets/kubeconfig".to_string(),
+    )]);
+    let decl = declaration(&[("grafana", spec)]);
+    assert_eq!(
+        hosted_secret_names(&decl),
+        vec![
+            "GRAFANA_SERVICE_ACCOUNT_TOKEN".to_string(),
+            "K8S_READONLY_KUBECONFIG".to_string(),
+        ],
+        "both resolution channels feed the one refusal"
+    );
+}
+
+/// Every hosted connector in the bundle is weighed before anything starts, so
+/// one run names every gap instead of one refusal per attempt.
+#[test]
+fn every_hosted_connector_in_the_bundle_is_weighed_at_once() {
+    let decl = declaration(&[
+        (
+            "grafana",
+            hosted_with_secret("GRAFANA_SERVICE_ACCOUNT_TOKEN"),
+        ),
+        ("kubernetes", hosted_with_secret("K8S_READONLY_KUBECONFIG")),
+    ]);
+    assert_eq!(
+        hosted_secret_names(&decl),
+        vec![
+            "GRAFANA_SERVICE_ACCOUNT_TOKEN".to_string(),
+            "K8S_READONLY_KUBECONFIG".to_string(),
+        ],
+        "a bring-up that refused one at a time would cost an operator a run per gap"
+    );
+}
+
+/// The refusal itself: one shared message for the skill tier and the cluster
+/// deploy path, classified as a usage error (exit 2), carrying the fix line and
+/// nothing but NAMES.
+#[test]
+fn the_refusal_is_a_usage_error_naming_every_gap_and_the_fix() {
+    let err = missing_secrets_error(&[
+        "GRAFANA_SERVICE_ACCOUNT_TOKEN".to_string(),
+        "K8S_READONLY_KUBECONFIG".to_string(),
+    ]);
+    let (class, _fix) = curie::exit::classify(&err);
+    assert_eq!(
+        class,
+        curie::exit::ExitClass::Usage,
+        "an operator prerequisite is a usage error, not a runtime failure"
+    );
+    let message = err.to_string();
+    for needle in [
+        "declares secret(s) with no value available",
+        "GRAFANA_SERVICE_ACCOUNT_TOKEN",
+        "K8S_READONLY_KUBECONFIG",
+        "curie secrets set <NAME>",
+    ] {
+        assert!(
+            message.contains(needle),
+            "the refusal must carry `{needle}`: {message}"
+        );
+    }
 }

--- a/cli/tests/connector_build.rs
+++ b/cli/tests/connector_build.rs
@@ -1,0 +1,794 @@
+//! RED contract for PR B / Stream B1: `curie build --plugin-dir` execution.
+//!
+//! PR A landed the *declaration* mirrors (`connectors.yaml`,
+//! `connectors.lock.yaml`, `source_digest_of`, `object_name`/`service_dns`) in
+//! `cli/src/connector_build.rs`. This file pins what B1 adds on top: the argv
+//! `curie build` actually issues, how a registry digest is recovered from
+//! buildx's metadata file, and the shape and overwrite rule of the lock it
+//! writes.
+//!
+//! Everything here is a PURE builder assertion, per the `OpsCommand`
+//! convention in `cli/CLAUDE.md:133-142`: no Docker daemon is contacted, no
+//! registry is dialed, and no `--dry-run` printer is involved. A builder that
+//! only produced the right argv when a daemon answered would be untestable in
+//! CI, which is exactly why the split exists.
+//!
+//! The builders this imports do not exist yet. That compile failure IS the
+//! intended RED, and it is isolated to this test target because the file
+//! imports from the `curie` lib rather than adding inline `#[cfg(test)]`
+//! blocks to production modules.
+//!
+//! Surface the implementer must add to `curie::connector_build`:
+//!
+//! ```ignore
+//! pub struct ConnectorBuildPlan {
+//!     pub connector: String,
+//!     pub context: PathBuf,          // canonical, inside the bundle
+//!     pub dockerfile: PathBuf,       // canonical, inside the context
+//!     pub platforms: Vec<String>,    // DECLARED order
+//!     pub delivery: Delivery,
+//!     pub image_ref: String,         // the `-t` tag this build produces
+//!     pub source_digest: String,
+//!     pub metadata_file: Option<PathBuf>, // registry delivery only
+//! }
+//!
+//! pub fn host_platform() -> String;
+//! pub fn build_plan(
+//!     bundle_root: &Path,
+//!     bundle_name: &str,
+//!     connector: &str,
+//!     spec: &ConnectorSpecDecl,
+//!     registry: Option<&str>,
+//!     host_platform: &str,
+//!     metadata_dir: &Path,
+//! ) -> anyhow::Result<ConnectorBuildPlan>;
+//! pub fn build_argv(plan: &ConnectorBuildPlan) -> curie::ops::OpsCommand;
+//! pub fn image_inspect_argv(tag: &str) -> curie::ops::OpsCommand;
+//! pub fn registry_image_ref(
+//!     registry: &str, bundle: &str, connector: &str, source_digest: &str,
+//! ) -> String;
+//! pub fn digest_from_metadata(raw: &str) -> anyhow::Result<String>;
+//! pub fn digest_pinned_ref(image_ref: &str, digest: &str) -> String;
+//! pub fn lock_overwrite_refusal(
+//!     existing: Option<&ConnectorLockFileDecl>,
+//!     next: &ConnectorLockFileDecl,
+//!     force: bool,
+//! ) -> Option<String>;
+//! pub fn write_lock(
+//!     bundle_root: &Path, lock: &ConnectorLockFileDecl, force: bool,
+//! ) -> anyhow::Result<()>;
+//! ```
+//!
+//! and to `curie::commands`: `ConnectorBuildOutput` / `ConnectorBuildRecord`
+//! implementing `curie::ui::CliOutput` (block B1-2).
+//!
+//! Registry placeholders throughout are `ghcr.io/acme-corp/...`; nothing here
+//! names a real registry, org, or namespace.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use curie::commands::{ConnectorBuildOutput, ConnectorBuildRecord};
+use curie::connector_build::{
+    self, build_argv, build_plan, digest_from_metadata, digest_pinned_ref, host_platform,
+    image_inspect_argv, lock_overwrite_refusal, registry_image_ref, write_lock, ConnectorBuildDecl,
+    ConnectorLockEntryDecl, ConnectorLockFileDecl, ConnectorSpecDecl, Delivery,
+};
+use curie::ui::CliOutput;
+use tempfile::TempDir;
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+/// A bundle carrying one buildable connector under `connectors/<name>/`.
+///
+/// Deliberately hand-built rather than read from `examples/sre-bot`: the
+/// example's `k8s-write` block ships commented out (it needs an image the
+/// reader builds), and Stream B3 owns the enabled fixture. A B1 unit test that
+/// depended on B3's file would go red for a reason that is not B1's.
+fn bundle_with(connector: &str) -> TempDir {
+    let dir = TempDir::new().expect("a scratch bundle");
+    let context = dir.path().join("connectors").join(connector);
+    std::fs::create_dir_all(&context).expect("mkdir -p the build context");
+    std::fs::write(
+        context.join("Dockerfile"),
+        "FROM python:3.13-slim\nCOPY server.py /server.py\n",
+    )
+    .expect("write Dockerfile");
+    std::fs::write(context.join("server.py"), "# the connector\n").expect("write server.py");
+    dir
+}
+
+fn spec_for(connector: &str, platforms: &[&str]) -> ConnectorSpecDecl {
+    ConnectorSpecDecl {
+        build: Some(ConnectorBuildDecl {
+            context: format!("connectors/{connector}"),
+            dockerfile: "Dockerfile".to_string(),
+            platforms: platforms.iter().map(|p| (*p).to_string()).collect(),
+        }),
+        ..Default::default()
+    }
+}
+
+fn plan_for(
+    root: &Path,
+    connector: &str,
+    platforms: &[&str],
+    registry: Option<&str>,
+    host: &str,
+    metadata_dir: &Path,
+) -> connector_build::ConnectorBuildPlan {
+    build_plan(
+        root,
+        "sre-bot",
+        connector,
+        &spec_for(connector, platforms),
+        registry,
+        host,
+        metadata_dir,
+    )
+    .unwrap_or_else(|error| panic!("build_plan for {connector}: {error}"))
+}
+
+/// The index of `needle` in `argv`, so adjacency of a flag and its value can be
+/// asserted rather than mere presence: `--platform` somewhere and
+/// `linux/amd64` somewhere else is not the same command.
+fn index_of(argv: &[String], needle: &str) -> usize {
+    argv.iter()
+        .position(|token| token == needle)
+        .unwrap_or_else(|| panic!("{needle:?} is missing from argv: {argv:?}"))
+}
+
+fn value_after(argv: &[String], flag: &str) -> String {
+    let at = index_of(argv, flag);
+    argv.get(at + 1)
+        .unwrap_or_else(|| panic!("{flag:?} has no value in argv: {argv:?}"))
+        .clone()
+}
+
+// ─── The two delivery paths produce two different commands ───────────────────
+
+/// (1) No `--registry`: a plain `docker build` for the HOST platform only,
+/// into the local daemon.
+///
+/// The host platform, not the declared set, is the whole point of this path:
+/// `docker build` cannot emit a multi-arch index, so building the declared
+/// `linux/amd64,linux/arm64` here would either fail or silently produce one
+/// arch under a name that claims two. The declared set stays in the lock (and
+/// in the source digest) so `cluster deploy` can still refuse it.
+#[test]
+fn the_local_daemon_path_builds_the_host_platform_with_plain_docker_build() {
+    let bundle = bundle_with("tempo");
+    let meta = TempDir::new().expect("a metadata dir");
+    let plan = plan_for(
+        bundle.path(),
+        "tempo",
+        &["linux/amd64", "linux/arm64"],
+        None,
+        "linux/arm64",
+        meta.path(),
+    );
+
+    assert_eq!(plan.delivery, Delivery::LocalDaemon);
+    let command = build_argv(&plan);
+    assert_eq!(command.program, "docker");
+    let argv = command.argv();
+
+    assert_eq!(argv.first().map(String::as_str), Some("build"), "{argv:?}");
+    assert_eq!(
+        value_after(&argv, "--platform"),
+        "linux/arm64",
+        "the local-daemon path builds exactly the host platform: {argv:?}"
+    );
+    assert_eq!(
+        value_after(&argv, "-f"),
+        plan.dockerfile.display().to_string(),
+        "the resolved (symlink-refused) Dockerfile is what -f names: {argv:?}"
+    );
+    assert_eq!(value_after(&argv, "-t"), plan.image_ref, "{argv:?}");
+    assert_eq!(
+        argv.last().map(String::as_str),
+        Some(plan.context.display().to_string().as_str()),
+        "the canonical context is the final positional: {argv:?}"
+    );
+
+    // Not buildx and not pushed. A local build that quietly pushed would put an
+    // artifact in a registry the operator never named.
+    assert!(!argv.iter().any(|t| t == "buildx"), "{argv:?}");
+    assert!(!argv.iter().any(|t| t == "--push"), "{argv:?}");
+    assert!(!argv.iter().any(|t| t == "--metadata-file"), "{argv:?}");
+    assert!(plan.metadata_file.is_none());
+}
+
+/// (2) `--registry <ref>`: `docker buildx build` over the DECLARED platform
+/// set, pushed, with a metadata file to read the index digest back out of.
+///
+/// The joined order is the declared order, matching `source_digest_of`'s
+/// canonical `build` block (`platform_order_is_significant` in
+/// `tests/vectors/connector-source-digest.json`). A builder that sorted them
+/// would make the argv and the digest disagree about what was declared.
+#[test]
+fn the_registry_path_builds_every_declared_platform_with_buildx_and_pushes() {
+    let bundle = bundle_with("tempo");
+    let meta = TempDir::new().expect("a metadata dir");
+    let plan = plan_for(
+        bundle.path(),
+        "tempo",
+        &["linux/arm64", "linux/amd64"],
+        Some("ghcr.io/acme-corp"),
+        "linux/amd64",
+        meta.path(),
+    );
+
+    assert_eq!(plan.delivery, Delivery::Registry);
+    let command = build_argv(&plan);
+    assert_eq!(command.program, "docker");
+    let argv = command.argv();
+
+    assert_eq!(
+        &argv[..2],
+        &["buildx".to_string(), "build".to_string()],
+        "{argv:?}"
+    );
+    assert_eq!(
+        value_after(&argv, "--platform"),
+        "linux/arm64,linux/amd64",
+        "declared order, comma-joined, not sorted: {argv:?}"
+    );
+    assert!(
+        argv.iter().any(|t| t == "--push"),
+        "an unpushed index cannot be pulled by a cluster node: {argv:?}"
+    );
+
+    let metadata_file = plan
+        .metadata_file
+        .as_ref()
+        .expect("the registry path records where buildx writes its metadata");
+    assert_eq!(
+        value_after(&argv, "--metadata-file"),
+        metadata_file.display().to_string(),
+        "{argv:?}"
+    );
+    assert!(
+        metadata_file.starts_with(meta.path()),
+        "the metadata file lands in the caller's directory, not next to the bundle: {}",
+        metadata_file.display()
+    );
+    assert_eq!(value_after(&argv, "-t"), plan.image_ref, "{argv:?}");
+}
+
+/// The host platform is a real OCI platform and is a Linux one.
+///
+/// `docker build --platform darwin/arm64` on a Mac would ask the daemon for an
+/// image no Linux container runtime can run; the host here means "the arch of
+/// the machine", never "the OS of the machine".
+#[test]
+fn the_host_platform_is_a_linux_oci_platform() {
+    let host = host_platform();
+    assert!(
+        host.starts_with("linux/"),
+        "the host build platform must be a linux one, got {host:?}"
+    );
+    let arch = host.trim_start_matches("linux/");
+    assert!(
+        !arch.is_empty()
+            && arch
+                .chars()
+                .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit()),
+        "{host:?} is not an os/arch platform"
+    );
+}
+
+// ─── The image reference and the digest that replaces it ─────────────────────
+
+/// The pushed tag is derived from the source digest, so two different sources
+/// never collide on one tag, and it is never a mutable name.
+///
+/// `apply_lock` on the Python side refuses a lock whose image ends in a tag, so
+/// the tag here is only ever the push target; what the lock records is the
+/// `@sha256:` form below. But a mutable push target (`:latest`, `:v1`) would
+/// still let a second build silently replace the bytes a first deploy resolved.
+#[test]
+fn the_pushed_tag_is_derived_from_the_source_digest_and_is_not_mutable() {
+    let first = registry_image_ref(
+        "ghcr.io/acme-corp",
+        "sre-bot",
+        "k8s-write",
+        "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    );
+    let second = registry_image_ref(
+        "ghcr.io/acme-corp",
+        "sre-bot",
+        "k8s-write",
+        "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    );
+
+    let (repo, tag) = first.rsplit_once(':').expect("a tagged reference");
+    assert_eq!(repo, "ghcr.io/acme-corp/sre-bot-k8s-write");
+    assert!(!tag.is_empty(), "an empty tag is `latest` by another name");
+    assert_ne!(tag, "latest");
+    assert!(
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".starts_with(tag),
+        "the tag is a prefix of the source digest hex, got {tag:?}"
+    );
+    assert_ne!(
+        first, second,
+        "two sources must not push to one tag, or the second build overwrites the first"
+    );
+}
+
+/// buildx reports the index digest through `--metadata-file`, keyed
+/// `containerimage.digest`.
+///
+/// External shape, not ours: the file is a JSON object of build-result keys,
+/// documented at
+/// <https://docs.docker.com/reference/cli/docker/buildx/build/#metadata-file>.
+/// Parsing it by hand (grepping stderr for `sha256:`) is how a digest for the
+/// wrong artifact gets recorded, so the key is named explicitly.
+#[test]
+fn the_index_digest_is_read_from_the_buildx_metadata_file() {
+    let raw = r#"{
+      "buildx.build.ref": "default/default/abcdef",
+      "containerimage.config.digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+      "containerimage.digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+      "image.name": "ghcr.io/acme-corp/sre-bot-tempo:abc123"
+    }"#;
+
+    let digest = digest_from_metadata(raw).expect("the metadata file names the index digest");
+    assert_eq!(
+        digest, "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+        "containerimage.digest is the INDEX digest; containerimage.config.digest is the \
+         single-platform config blob and pulling by it fails on a multi-arch node"
+    );
+}
+
+/// A metadata file with no digest is a failed push wearing a success costume.
+#[test]
+fn a_metadata_file_without_a_digest_is_an_error_not_an_empty_string() {
+    let raw = r#"{"buildx.build.ref": "default/default/abcdef"}"#;
+    assert!(
+        digest_from_metadata(raw).is_err(),
+        "a missing containerimage.digest must fail loudly; recording an empty image would \
+         surface much later as ImagePullBackOff"
+    );
+}
+
+/// What the lock records is the repository at a digest, with the push tag gone.
+#[test]
+fn the_locked_reference_pins_the_repository_at_the_digest_and_drops_the_tag() {
+    let pinned = digest_pinned_ref(
+        "ghcr.io/acme-corp/sre-bot-tempo:abc123",
+        "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+    );
+    assert_eq!(
+        pinned,
+        "ghcr.io/acme-corp/sre-bot-tempo@sha256:\
+         2222222222222222222222222222222222222222222222222222222222222222"
+    );
+    assert!(
+        !pinned.contains(":abc123"),
+        "a tag surviving next to the digest is a reference two things can resolve: {pinned}"
+    );
+}
+
+/// The local-daemon path records the daemon's immutable image id, not the
+/// ephemeral tag it built under.
+#[test]
+fn the_local_daemon_path_reads_back_an_immutable_image_id() {
+    let command = image_inspect_argv("curie-connector-sre-bot-tempo:build");
+    assert_eq!(command.program, "docker");
+    let argv = command.argv();
+    assert_eq!(
+        argv,
+        vec![
+            "image".to_string(),
+            "inspect".to_string(),
+            "--format".to_string(),
+            "{{.Id}}".to_string(),
+            "curie-connector-sre-bot-tempo:build".to_string(),
+        ],
+        "the id is what survives a later rebuild reusing the same tag"
+    );
+}
+
+// ─── The lock write ──────────────────────────────────────────────────────────
+
+fn lock_with(image: &str, delivery: Delivery, digest: &str) -> ConnectorLockFileDecl {
+    let mut connectors = BTreeMap::new();
+    connectors.insert(
+        "tempo".to_string(),
+        ConnectorLockEntryDecl {
+            image: image.to_string(),
+            delivery,
+            platforms: vec!["linux/amd64".into(), "linux/arm64".into()],
+            source_digest: digest.to_string(),
+        },
+    );
+    ConnectorLockFileDecl {
+        version: connector_build::LOCK_VERSION,
+        connectors,
+    }
+}
+
+/// The lock lands at the bundle root, at version 1, and reads back through the
+/// PR A parser with every field intact.
+#[test]
+fn the_written_lock_round_trips_through_the_reader() {
+    let bundle = TempDir::new().expect("a scratch bundle");
+    let lock = lock_with(
+        "ghcr.io/acme-corp/sre-bot-tempo@sha256:\
+         2222222222222222222222222222222222222222222222222222222222222222",
+        Delivery::Registry,
+        "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+    );
+    write_lock(bundle.path(), &lock, false).expect("write the lock");
+
+    let path = bundle.path().join(connector_build::CONNECTOR_LOCK_FILE);
+    assert!(
+        path.is_file(),
+        "the lock lands at the BUNDLE ROOT so the packer ships it"
+    );
+
+    let read = connector_build::load_lock(bundle.path())
+        .expect("read the lock")
+        .expect("the lock exists");
+    assert_eq!(read.version, connector_build::LOCK_VERSION);
+    let entry = read.connectors.get("tempo").expect("tempo is locked");
+    assert_eq!(entry.delivery, Delivery::Registry);
+    assert!(entry.image.contains("@sha256:"), "{}", entry.image);
+    assert_eq!(entry.platforms, vec!["linux/amd64", "linux/arm64"]);
+    assert_eq!(
+        entry.source_digest,
+        "sha256:3333333333333333333333333333333333333333333333333333333333333333"
+    );
+}
+
+/// Rewriting the same resolution produces byte-identical bytes.
+///
+/// This is what makes "nothing changed" observable to a human reading
+/// `git status` after a rebuild (AC B2's negative). A writer that stamped a
+/// build timestamp, or serialized a HashMap, would show a diff on every run and
+/// train the operator to ignore the file.
+#[test]
+fn rewriting_an_unchanged_resolution_is_byte_identical() {
+    let bundle = TempDir::new().expect("a scratch bundle");
+    let lock = lock_with(
+        "ghcr.io/acme-corp/sre-bot-tempo@sha256:\
+         2222222222222222222222222222222222222222222222222222222222222222",
+        Delivery::Registry,
+        "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+    );
+    let path = bundle.path().join(connector_build::CONNECTOR_LOCK_FILE);
+
+    write_lock(bundle.path(), &lock, false).expect("first write");
+    let first = std::fs::read(&path).expect("read the first lock");
+    write_lock(bundle.path(), &lock, false).expect("second write");
+    let second = std::fs::read(&path).expect("read the second lock");
+
+    assert_eq!(
+        first, second,
+        "an unchanged rebuild must not move a single byte of the lock"
+    );
+}
+
+/// An unchanged source keeps its digest across two independent resolutions,
+/// with different file mtimes.
+///
+/// `tests/vectors/connector-source-digest.json` freezes the algorithm's
+/// content rules; what it cannot cover is the property this build path depends
+/// on -- that `bundle.rs`'s ARCHIVE digest (which embeds mtime, uid and gid,
+/// `cli/src/bundle.rs:181-184`) was NOT reused here. Copy the same content into
+/// a second tree with a different mtime and the digest must not move.
+#[test]
+fn the_source_digest_is_content_derived_not_timestamp_derived() {
+    let first = bundle_with("tempo");
+    std::thread::sleep(std::time::Duration::from_millis(1100));
+    let second = bundle_with("tempo");
+
+    let meta = TempDir::new().expect("a metadata dir");
+    let a = plan_for(
+        first.path(),
+        "tempo",
+        &["linux/amd64"],
+        None,
+        "linux/amd64",
+        meta.path(),
+    );
+    let b = plan_for(
+        second.path(),
+        "tempo",
+        &["linux/amd64"],
+        None,
+        "linux/amd64",
+        meta.path(),
+    );
+
+    assert_eq!(
+        a.source_digest, b.source_digest,
+        "identical content in two trees with different mtimes must digest identically, or every \
+         fresh clone reports its lock as stale"
+    );
+    assert!(
+        a.source_digest.starts_with("sha256:"),
+        "{}",
+        a.source_digest
+    );
+}
+
+/// A changed source moves the digest, so the two halves of AC B2 are a real
+/// pair rather than one assertion stated twice.
+#[test]
+fn a_changed_source_moves_the_digest() {
+    let bundle = bundle_with("tempo");
+    let meta = TempDir::new().expect("a metadata dir");
+    let before = plan_for(
+        bundle.path(),
+        "tempo",
+        &["linux/amd64"],
+        None,
+        "linux/amd64",
+        meta.path(),
+    );
+
+    std::fs::write(
+        bundle.path().join("connectors/tempo/server.py"),
+        "# the connector, edited\n",
+    )
+    .expect("edit the source");
+
+    let after = plan_for(
+        bundle.path(),
+        "tempo",
+        &["linux/amd64"],
+        None,
+        "linux/amd64",
+        meta.path(),
+    );
+    assert_ne!(before.source_digest, after.source_digest);
+}
+
+// ─── The `--force` rule (Decision 1, review finding 2) ───────────────────────
+
+/// A local-daemon build must not silently replace a registry lock.
+///
+/// The registry lock is the one a cluster can deploy; the local-daemon one is
+/// not. Overwriting without asking turns "I rebuilt quickly to test something"
+/// into a cluster deploy that refuses hours later, with nothing in the working
+/// tree explaining what removed the pushed digest.
+#[test]
+fn a_local_daemon_build_refuses_to_overwrite_a_registry_lock_without_force() {
+    let existing = lock_with(
+        "ghcr.io/acme-corp/sre-bot-tempo@sha256:\
+         2222222222222222222222222222222222222222222222222222222222222222",
+        Delivery::Registry,
+        "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+    );
+    let next = lock_with(
+        "sha256:4444444444444444444444444444444444444444444444444444444444444444",
+        Delivery::LocalDaemon,
+        "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+    );
+
+    let refusal = lock_overwrite_refusal(Some(&existing), &next, false)
+        .expect("downgrading registry -> local-daemon must be refused");
+    assert!(
+        refusal.contains("--force"),
+        "the refusal must name the flag that proceeds: {refusal}"
+    );
+
+    assert!(
+        lock_overwrite_refusal(Some(&existing), &next, true).is_none(),
+        "--force is the deliberate override and must proceed"
+    );
+}
+
+/// The rule is one-directional, and absent on a first build.
+#[test]
+fn upgrading_to_a_registry_lock_and_first_writes_are_never_refused() {
+    let local = lock_with(
+        "sha256:4444444444444444444444444444444444444444444444444444444444444444",
+        Delivery::LocalDaemon,
+        "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+    );
+    let registry = lock_with(
+        "ghcr.io/acme-corp/sre-bot-tempo@sha256:\
+         2222222222222222222222222222222222222222222222222222222222222222",
+        Delivery::Registry,
+        "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+    );
+
+    assert!(
+        lock_overwrite_refusal(Some(&local), &registry, false).is_none(),
+        "local-daemon -> registry is a promotion and needs no ceremony"
+    );
+    assert!(
+        lock_overwrite_refusal(None, &local, false).is_none(),
+        "a bundle with no lock has nothing to protect"
+    );
+}
+
+/// The refusal must leave the file untouched, not half-written.
+///
+/// Asserting the refusal message alone would pass against a writer that
+/// truncated the lock and then errored, which is the worst of both outcomes:
+/// the registry resolution is gone AND the command failed.
+#[test]
+fn a_refused_overwrite_leaves_the_existing_lock_byte_identical() {
+    let bundle = TempDir::new().expect("a scratch bundle");
+    let existing = lock_with(
+        "ghcr.io/acme-corp/sre-bot-tempo@sha256:\
+         2222222222222222222222222222222222222222222222222222222222222222",
+        Delivery::Registry,
+        "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+    );
+    write_lock(bundle.path(), &existing, false).expect("seed the registry lock");
+    let path = bundle.path().join(connector_build::CONNECTOR_LOCK_FILE);
+    let before = std::fs::read(&path).expect("read the seeded lock");
+
+    let next = lock_with(
+        "sha256:4444444444444444444444444444444444444444444444444444444444444444",
+        Delivery::LocalDaemon,
+        "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+    );
+    let error = write_lock(bundle.path(), &next, false)
+        .expect_err("the downgrade must be refused at the write, not only by the predicate");
+    assert!(format!("{error:#}").contains("--force"), "{error:#}");
+
+    assert_eq!(
+        before,
+        std::fs::read(&path).expect("read the lock after the refusal"),
+        "a refused write must not have touched the file"
+    );
+
+    write_lock(bundle.path(), &next, true).expect("--force proceeds");
+    assert_ne!(
+        before,
+        std::fs::read(&path).expect("read the forced lock"),
+        "--force must actually write, or the escape hatch is decorative"
+    );
+}
+
+// ─── A build that cannot run writes no lock (AC B1's negative) ───────────────
+
+/// A context with no Dockerfile fails during planning, before any argv exists.
+///
+/// The negative for AC B1: the failure names the connector, and nothing is
+/// written. A planner that returned a plan here would hand `docker` a `-f` for
+/// a file that is not there and fail with Docker's error instead of ours.
+#[test]
+fn a_context_without_a_dockerfile_fails_planning_and_writes_no_lock() {
+    let bundle = TempDir::new().expect("a scratch bundle");
+    std::fs::create_dir_all(bundle.path().join("connectors/tempo")).expect("mkdir the context");
+    let meta = TempDir::new().expect("a metadata dir");
+
+    let error = build_plan(
+        bundle.path(),
+        "sre-bot",
+        "tempo",
+        &spec_for("tempo", &["linux/amd64"]),
+        None,
+        "linux/amd64",
+        meta.path(),
+    )
+    .expect_err("a context with no Dockerfile cannot be planned");
+    assert!(
+        format!("{error:#}").contains("tempo"),
+        "the failure must name the connector: {error:#}"
+    );
+    assert!(
+        !bundle
+            .path()
+            .join(connector_build::CONNECTOR_LOCK_FILE)
+            .exists(),
+        "a failed build must leave no lock behind"
+    );
+}
+
+/// A symlinked Dockerfile is refused before `docker` is ever handed a path
+/// (review finding 11): `curie build` reads it BEFORE the bundle is packed, so
+/// the packer's own symlink refusal never runs.
+#[cfg(unix)]
+#[test]
+fn a_symlinked_dockerfile_is_refused_during_planning() {
+    let bundle = bundle_with("tempo");
+    let host = TempDir::new().expect("a host directory outside the bundle");
+    std::fs::write(host.path().join("Dockerfile"), "FROM scratch\n").expect("write a host file");
+    let inside = bundle.path().join("connectors/tempo/Dockerfile");
+    std::fs::remove_file(&inside).expect("remove the real Dockerfile");
+    std::os::unix::fs::symlink(host.path().join("Dockerfile"), &inside).expect("symlink it");
+
+    let meta = TempDir::new().expect("a metadata dir");
+    assert!(
+        build_plan(
+            bundle.path(),
+            "sre-bot",
+            "tempo",
+            &spec_for("tempo", &["linux/amd64"]),
+            None,
+            "linux/amd64",
+            meta.path(),
+        )
+        .is_err(),
+        "a symlink out of the bundle must be refused, not dereferenced"
+    );
+}
+
+// ─── The `--json` receipt (block B1-2, AC B1) ────────────────────────────────
+
+/// `curie build --plugin-dir --json` emits one object naming every connector's
+/// resolved identity. Never empty stdout under `--json` (ADR-0021,
+/// `cli/CLAUDE.md:16-43`).
+#[test]
+fn the_json_receipt_names_each_connectors_resolved_identity() {
+    let output = ConnectorBuildOutput {
+        connectors: vec![
+            ConnectorBuildRecord {
+                name: "kubernetes".to_string(),
+                image: "ghcr.io/acme-corp/sre-bot-kubernetes@sha256:\
+                        1111111111111111111111111111111111111111111111111111111111111111"
+                    .to_string(),
+                delivery: Delivery::Registry,
+                platforms: vec!["linux/amd64".into(), "linux/arm64".into()],
+                source_digest: "sha256:\
+                                3333333333333333333333333333333333333333333333333333333333333333"
+                    .to_string(),
+            },
+            ConnectorBuildRecord {
+                name: "tempo".to_string(),
+                image: "ghcr.io/acme-corp/sre-bot-tempo@sha256:\
+                        2222222222222222222222222222222222222222222222222222222222222222"
+                    .to_string(),
+                delivery: Delivery::Registry,
+                platforms: vec!["linux/amd64".into(), "linux/arm64".into()],
+                source_digest: "sha256:\
+                                4444444444444444444444444444444444444444444444444444444444444444"
+                    .to_string(),
+            },
+        ],
+    };
+
+    let json = output.to_json();
+    let connectors = json["connectors"]
+        .as_array()
+        .unwrap_or_else(|| panic!("the receipt carries a `connectors` array: {json}"));
+    assert_eq!(connectors.len(), 2, "{json}");
+
+    for entry in connectors {
+        for key in ["name", "image", "delivery", "platforms", "source_digest"] {
+            assert!(
+                entry.get(key).is_some(),
+                "every record names {key}: {entry}"
+            );
+        }
+        assert_eq!(
+            entry["delivery"], "registry",
+            "delivery serializes kebab-case, matching the lock the platform reads: {entry}"
+        );
+        assert!(
+            entry["image"]
+                .as_str()
+                .expect("a string")
+                .contains("@sha256:"),
+            "a registry record reports the digest-pinned ref: {entry}"
+        );
+    }
+    assert_eq!(connectors[0]["name"], "kubernetes", "{json}");
+    assert_eq!(connectors[1]["name"], "tempo", "{json}");
+}
+
+/// A bundle declaring no buildable connectors still emits a JSON object.
+///
+/// Empty stdout under `--json` is the #485 failure: an agent driving the CLI
+/// cannot distinguish "nothing to build" from "the command produced nothing".
+#[test]
+fn a_bundle_with_nothing_to_build_still_emits_an_object() {
+    let json = ConnectorBuildOutput {
+        connectors: Vec::new(),
+    }
+    .to_json();
+    assert!(json.is_object(), "{json}");
+    assert_eq!(
+        json["connectors"].as_array().map(Vec::len),
+        Some(0),
+        "an empty list, not a missing key: {json}"
+    );
+}

--- a/cli/tests/connector_build.rs
+++ b/cli/tests/connector_build.rs
@@ -72,8 +72,8 @@ use curie::commands::{connectors_needing_rebuild, ConnectorBuildOutput, Connecto
 use curie::connector_build::{
     self, build_argv, build_plan, digest_from_metadata, digest_pinned_ref, host_platform,
     hosted_secret_names, image_inspect_argv, lock_overwrite_refusal, missing_secrets_error,
-    registry_image_ref, write_lock, ConnectorBuildDecl, ConnectorLockEntryDecl,
-    ConnectorLockFileDecl, ConnectorSpecDecl, Delivery, SecretDecl,
+    refuse_reserved_secret_names, registry_image_ref, write_lock, ConnectorBuildDecl,
+    ConnectorLockEntryDecl, ConnectorLockFileDecl, ConnectorSpecDecl, Delivery, SecretDecl,
 };
 use curie::ui::CliOutput;
 use tempfile::TempDir;
@@ -1007,4 +1007,122 @@ fn the_refusal_is_a_usage_error_naming_every_gap_and_the_fix() {
             "the refusal must carry `{needle}`: {message}"
         );
     }
+}
+
+// ─── The names a connector may not claim ─────────────────────────────────────
+
+/// THE RED for the exfiltration: a connector that declares a model-credential
+/// key gets that credential resolved out of the operator's own environment or
+/// vault and injected into a container the bundle chose the image for. The
+/// refusal is a pure decision over NAMES, so it lands before the resolve sweep
+/// rather than reporting the declaration as satisfied.
+#[test]
+fn a_connector_may_not_declare_a_reserved_model_credential_key() {
+    let decl = declaration(&[("grafana", hosted_with_secret("ANTHROPIC_API_KEY"))]);
+    let err = refuse_reserved_secret_names(&decl).expect_err("a reserved name must be refused");
+    let message = err.to_string();
+    for needle in ["grafana", "ANTHROPIC_API_KEY", "reserved"] {
+        assert!(
+            message.contains(needle),
+            "the refusal must carry `{needle}`: {message}"
+        );
+    }
+    assert_eq!(
+        curie::exit::classify(&err).0,
+        curie::exit::ExitClass::Usage,
+        "a bundle declaring a name it may not own is a usage error, not a runtime failure"
+    );
+}
+
+/// The forward-safe half: a boot key nobody remembered to enumerate is still
+/// refused because it carries the `CURIE_` prefix.
+#[test]
+fn a_connector_may_not_claim_the_curie_boot_namespace() {
+    let decl = declaration(&[("grafana", hosted_with_secret("CURIE_RUNNER_TOKEN"))]);
+    let message = refuse_reserved_secret_names(&decl)
+        .expect_err("the prefix rule must refuse it")
+        .to_string();
+    assert!(message.contains("CURIE_RUNNER_TOKEN"), "{message}");
+}
+
+/// The second channel: same name, same resolution, same operator credential --
+/// only the delivery differs, so the fence covers a `secret_files` key too.
+#[test]
+fn a_credential_file_key_is_held_to_the_same_fence() {
+    let mut spec = hosted_with_secret("GRAFANA_SERVICE_ACCOUNT_TOKEN");
+    spec.secret_files = BTreeMap::from([(
+        "NODE_EXTRA_CA_CERTS".to_string(),
+        "/secrets/ca.pem".to_string(),
+    )]);
+    let decl = declaration(&[("grafana", spec)]);
+    let message = refuse_reserved_secret_names(&decl)
+        .expect_err("a reserved secret_files key must be refused")
+        .to_string();
+    assert!(message.contains("NODE_EXTRA_CA_CERTS"), "{message}");
+}
+
+/// A name outside the env-var shape can never bind, and the check reuses the
+/// one validator `curie secrets set` already holds an operator to.
+#[test]
+fn a_malformed_secret_name_is_refused_by_the_same_gate() {
+    let decl = declaration(&[("grafana", hosted_with_secret("grafana-token"))]);
+    let message = refuse_reserved_secret_names(&decl)
+        .expect_err("a malformed name must be refused")
+        .to_string();
+    assert!(message.contains("grafana-token"), "{message}");
+    assert!(message.contains("environment variable"), "{message}");
+}
+
+/// The over-refusal control: an ordinary credential name passes this gate
+/// untouched and reaches the missing-value refusal exactly as before.
+#[test]
+fn an_ordinary_credential_name_passes_the_fence() {
+    let mut spec = hosted_with_secret("GRAFANA_SERVICE_ACCOUNT_TOKEN");
+    spec.secret_files = BTreeMap::from([(
+        "K8S_READONLY_KUBECONFIG".to_string(),
+        "/secrets/kubeconfig".to_string(),
+    )]);
+    let decl = declaration(&[("grafana", spec)]);
+    assert!(
+        refuse_reserved_secret_names(&decl).is_ok(),
+        "the names the shipped examples declare must keep working"
+    );
+    assert_eq!(
+        hosted_secret_names(&decl),
+        vec![
+            "GRAFANA_SERVICE_ACCOUNT_TOKEN".to_string(),
+            "K8S_READONLY_KUBECONFIG".to_string(),
+        ],
+        "and they still reach the missing-value refusal"
+    );
+}
+
+// ─── The buildx metadata directory ───────────────────────────────────────────
+
+/// buildx's build result lands in a per-run directory under the SHARED system
+/// temp dir, so its mode is the only thing keeping the other accounts on the
+/// box out of it. Created private in one step rather than widened afterwards:
+/// buildx starts writing as soon as it is handed the path.
+///
+/// The helper is asserted rather than `build_connectors` itself, which needs a
+/// Docker daemon and a real build; `build_connectors` has exactly one call site
+/// for it, at the create of `curie-build-<uuid>`.
+#[cfg(unix)]
+#[test]
+fn the_buildx_metadata_directory_is_readable_only_by_its_owner() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let tmp = TempDir::new().expect("a scratch temp dir");
+    let dir = tmp.path().join("curie-build-0000");
+    curie::commands::create_private_dir(&dir).expect("create the metadata dir");
+
+    let mode = std::fs::metadata(&dir)
+        .expect("stat the metadata dir")
+        .permissions()
+        .mode()
+        & 0o777;
+    assert_eq!(
+        mode, 0o700,
+        "a world-readable directory in /tmp hands every account on the box the build's metadata"
+    );
 }

--- a/cli/tests/connector_build_decl_vectors.rs
+++ b/cli/tests/connector_build_decl_vectors.rs
@@ -145,6 +145,54 @@ fn the_rust_reader_accepts_and_rejects_exactly_the_documents_python_does() {
 }
 
 #[test]
+fn a_connector_name_python_refuses_is_refused_at_load_by_the_rust_reader() {
+    // Parity is only half of it. `curie skill up` joins the connector name into
+    // a host path under `.curie/connector-secrets/`, so a name the CLI accepted
+    // without checking is a bundle-authored path component and `../../evil`
+    // writes a resolved credential outside the bundle. Checking at load is what
+    // makes every downstream join safe by construction.
+    let too_long = "t".repeat(41);
+    for name in [
+        "../../evil",
+        "Tempo",
+        "tempo_1",
+        "-tempo",
+        "tempo-",
+        "",
+        too_long.as_str(),
+    ] {
+        let document = format!("connectors:\n  \"{name}\":\n    image: ghcr.io/acme/x:1\n");
+        let error = connector_build::parse_connectors(&document)
+            .expect_err(&format!("{name:?} must be refused"));
+        assert!(
+            error.to_string().contains(name),
+            "the refusal must name the connector: {error}"
+        );
+    }
+
+    connector_build::parse_connectors("connectors:\n  tempo-1:\n    image: ghcr.io/acme/x:1\n")
+        .expect("an RFC 1123 label is still accepted");
+}
+
+#[test]
+fn a_lock_entry_carrying_a_refused_name_is_refused_too() {
+    // The lock is a second door onto the same names: `curie skill up` reads it
+    // to resolve the image and stages that connector's credentials, whether or
+    // not the declaration was re-read in the same process.
+    // The entry itself is well formed, so the NAME is the only thing left to
+    // refuse it -- a truncated digest here would green this test through the
+    // image-shape rule instead.
+    let document = "version: 1\nconnectors:\n  \"../../evil\":\n    \
+                    image: ghcr.io/acme/x@sha256:\
+                    0000000000000000000000000000000000000000000000000000000000000000\n    \
+                    delivery: registry\n    source_digest: sha256:bb\n";
+    assert!(
+        connector_build::parse_lock(document).is_err(),
+        "a name refused in connectors.yaml must be refused in the lock"
+    );
+}
+
+#[test]
 fn an_unknown_key_inside_a_build_block_is_refused_not_dropped() {
     // The `deny_unknown_fields` proof. Without the attribute the field is
     // silently dropped and `curie dev field-parity` stays green, which is
@@ -223,6 +271,24 @@ fn a_context_outside_the_bundle_is_refused() {
 
 // ─── connectors.lock.yaml ────────────────────────────────────────────────────
 
+/// The corpus vectors whose refusal is the IMAGE SHAPE rule -- Python's
+/// `_image_matches_delivery`, applied inside `apply_lock`.
+///
+/// Python can afford to refuse these one call later because nothing between
+/// `validate_connector_lock` and `apply_lock` runs an image. The CLI has no
+/// `apply_lock`: whatever `parse_lock` returns is what `curie skill up` starts
+/// and what a deploy ships, so the same rule has to fire at the read. Listing
+/// them by name rather than re-deriving the rule keeps this an independent
+/// oracle: a reader that stopped refusing one fails here, and a NEW shape
+/// vector added to the corpus fails here too until it is named, which is the
+/// direction that failure should point.
+const SHAPE_REFUSALS: &[&str] = &[
+    "a_tag_shaped_image_is_refused",
+    "a_truncated_digest_is_refused",
+    "an_uppercase_digest_is_refused",
+    "a_bare_digest_is_refused_for_registry_delivery",
+];
+
 #[test]
 fn the_rust_lock_reader_agrees_with_python_on_every_vector() {
     // `curie cluster deploy` preflights the lock locally so the operator gets
@@ -236,9 +302,21 @@ fn the_rust_lock_reader_agrees_with_python_on_every_vector() {
         }
         let document = serde_norway::to_string(&vector["lock"]).expect("serialize lock");
         let parsed = connector_build::parse_lock(&document);
-        match vector["expect"].as_str().expect("expect") {
-            // "raise" documents parse and are refused by apply_lock, which is
-            // the Python side's job; the Rust reader only has to accept them.
+        let expect = vector["expect"].as_str().expect("expect");
+        if expect == "raise" && SHAPE_REFUSALS.contains(&name_of(&vector)) {
+            assert!(
+                parsed.is_err(),
+                "{} records an image that is not a digest of its delivery's shape, which the \
+                 Rust reader refuses at the read",
+                name_of(&vector)
+            );
+            continue;
+        }
+        match expect {
+            // The remaining "raise" documents are well formed and refused by
+            // apply_lock for a reason only the DECLARATION can supply -- a
+            // local-daemon image at a portable tier, an entry the lock does not
+            // carry. That is the platform's job and this reader accepts them.
             "apply" | "raise" => assert!(
                 parsed.is_ok(),
                 "{} must parse on the Rust side",
@@ -268,6 +346,99 @@ fn an_unknown_key_in_a_lock_entry_is_refused_not_dropped() {
         connector_build::parse_lock(document).is_err(),
         "an unmodelled key in a lock entry must be refused, not dropped"
     );
+}
+
+/// One lock document carrying one entry, so a case varies only what it is about.
+fn lock_document(image: &str, delivery: &str) -> String {
+    format!(
+        "version: 1\nconnectors:\n  tempo:\n    image: {image}\n    delivery: {delivery}\n    \
+         platforms: [linux/amd64]\n    source_digest: sha256:{}\n",
+        "2".repeat(64)
+    )
+}
+
+const REGISTRY_DIGEST_IMAGE: &str = "ghcr.io/acme-corp/acme-bot-tempo-mcp@sha256:\
+                                     0000000000000000000000000000000000000000000000000000000000000000";
+const LOCAL_DAEMON_IMAGE: &str =
+    "sha256:1111111111111111111111111111111111111111111111111111111111111111";
+
+#[test]
+fn a_registry_entry_carries_a_repository_digest_as_pythons_image_matches_delivery_requires() {
+    // `_image_matches_delivery` in packages/plugin-format/src/plugin_format/
+    // connector_lock.py: `[^@\s]+@sha256:[0-9a-f]{64}` for delivery `registry`.
+    // A tag is the case the rule exists for -- it can be repointed at a
+    // different artifact after review -- and the other three are the ways a
+    // substring check for `@sha256:` would pass while resolving to nothing.
+    connector_build::parse_lock(&lock_document(REGISTRY_DIGEST_IMAGE, "registry"))
+        .expect("a repository digest is the registry shape");
+
+    for image in [
+        "ghcr.io/acme-corp/acme-bot-tempo-mcp:v1",
+        "ghcr.io/acme-corp/acme-bot-tempo-mcp@sha256:0000",
+        "ghcr.io/acme-corp/acme-bot-tempo-mcp@sha256:\
+         AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        LOCAL_DAEMON_IMAGE,
+    ] {
+        assert!(
+            connector_build::parse_lock(&lock_document(image, "registry")).is_err(),
+            "{image} is not a registry manifest digest and must be refused at the read"
+        );
+    }
+}
+
+#[test]
+fn a_local_daemon_entry_carries_a_bare_image_id_as_pythons_image_matches_delivery_requires() {
+    // The other half of the same rule: `sha256:[0-9a-f]{64}`, the id `docker
+    // image inspect --format {{.Id}}` reports. A repository reference means
+    // nothing to the local daemon, so delivery and shape must agree or the two
+    // fields are decoration.
+    connector_build::parse_lock(&lock_document(LOCAL_DAEMON_IMAGE, "local-daemon"))
+        .expect("a bare image id is the local-daemon shape");
+
+    for image in [
+        REGISTRY_DIGEST_IMAGE,
+        "curie-connector-sre-bot-tempo:build",
+        "sha256:1111",
+    ] {
+        assert!(
+            connector_build::parse_lock(&lock_document(image, "local-daemon")).is_err(),
+            "{image} is not a local image id and must be refused at the read"
+        );
+    }
+}
+
+#[test]
+fn a_refused_lock_image_names_the_connector_and_how_to_regenerate_the_lock() {
+    // The operator reading this failure edited or inherited a lock and has to
+    // know WHICH connector is wrong and what to run; a refusal that only says
+    // the file is malformed sends them reading YAML by eye.
+    let error = connector_build::parse_lock(&lock_document(
+        "ghcr.io/acme-corp/acme-bot-tempo-mcp:v1",
+        "registry",
+    ))
+    .expect_err("a tag must be refused");
+    let message = error.to_string();
+    assert!(message.contains("tempo"), "{message}");
+    assert!(
+        message.contains("ghcr.io/acme-corp/acme-bot-tempo-mcp:v1"),
+        "{message}"
+    );
+    assert!(message.contains("curie build --plugin-dir"), "{message}");
+}
+
+#[test]
+fn a_source_digest_shape_is_not_this_readers_to_judge_because_python_does_not_judge_it() {
+    // `ConnectorLockEntry.source_digest` is a plain `str` in Python, and
+    // staleness is decided by comparing it against a recomputed value, never by
+    // its shape. A reader that refused a short one here would refuse a document
+    // bundle intake accepts, which is the accept/reject parity this whole
+    // corpus exists to hold.
+    let document = format!(
+        "version: 1\nconnectors:\n  tempo:\n    image: {REGISTRY_DIGEST_IMAGE}\n    \
+         delivery: registry\n    platforms: [linux/amd64]\n    source_digest: sha256:bb\n"
+    );
+    connector_build::parse_lock(&document)
+        .expect("the source digest's shape is the platform's to judge, not this reader's");
 }
 
 // ─── The field-name corpus ───────────────────────────────────────────────────

--- a/cli/tests/connector_compose.rs
+++ b/cli/tests/connector_compose.rs
@@ -21,6 +21,12 @@
 //! argv assertion passes against an empty mount, which is the failure this
 //! replaces. The daemon-backed half of that proof is the ladder's job (B3).
 //!
+//! One test calls a function that WOULD reach the daemon --
+//! `bring_up_local_refuses_a_declared_secret_with_no_value` -- precisely because
+//! the property under test is that it refuses before getting there. Its
+//! assertion that no overlay file was written is what pins the refusal's
+//! position; a regression there turns it into a slow test, which is the signal.
+//!
 //! Surface the implementer must add:
 //!
 //! ```ignore
@@ -43,9 +49,13 @@
 //!     identity: &ConnectorScope,
 //!     project: &str,
 //!     plugin_dir: &Path,
-//!     secret_values: &BTreeMap<String, String>,
 //! ) -> anyhow::Result<serde_json::Value>;
-//! pub fn compose_up_command(overlay: &Path, project: &str) -> curie::ops::OpsCommand;
+//! /// Resolved secret values handed to the compose child's environment only,
+//! /// where the overlay's `${NAME}` references expand from; the file on disk
+//! /// never holds a value.
+//! pub fn compose_up_command(
+//!     overlay: &Path, project: &str, secret_values: &BTreeMap<String, String>,
+//! ) -> curie::ops::OpsCommand;
 //!
 //! // curie::docker
 //! pub const CONNECTOR_COMPONENT_LABEL: &str = "curietech.ai/component=connector";
@@ -77,6 +87,11 @@
 //!     project: &str, network: Option<&str>, plugin_dir: Option<&Path>,
 //! ) -> Vec<ConnectorTeardownStep>;
 //!
+//! // curie::local
+//! /// The plan `local down` runs: the label-scoped reap, plus the staged tree
+//! /// when the directory it ran from holds one.
+//! pub fn connector_teardown_plan_for_down(cwd: &Path) -> Vec<ConnectorTeardownStep>;
+//!
 //! // curie::state::RunnerState
 //! pub connector_containers: Vec<String>,
 //! pub connector_network: Option<String>,
@@ -88,13 +103,15 @@ use std::path::Path;
 use curie::connector_build::{
     compose_overlay, compose_overlay_path, compose_up_command, connector_scope_env,
     connector_secrets_root, connector_substitutions, object_name, service_dns, stage_secret_file,
-    substitute, wipe_connector_secrets, ConnectorLockEntryDecl, ConnectorLockFileDecl,
-    ConnectorScope, ConnectorSpecDecl, ConnectorsFileDecl, Delivery, SecretDecl, LOCK_VERSION,
+    staged_secret_path, substitute, ConnectorBuildDecl, ConnectorLockEntryDecl,
+    ConnectorLockFileDecl, ConnectorScope, ConnectorSpecDecl, ConnectorsFileDecl, Delivery,
+    SecretDecl, LOCK_VERSION,
 };
 use curie::docker::{
-    connector_project_label, connector_teardown_plan, ConnectorStartSpec, ConnectorTeardownStep,
-    CLI_MANAGED_LABEL, CONNECTOR_COMPONENT_LABEL,
+    connector_project_label, connector_teardown_plan, run_connector_teardown, ConnectorStartSpec,
+    ConnectorTeardownStep, CLI_MANAGED_LABEL, CONNECTOR_COMPONENT_LABEL,
 };
+use curie::local::connector_teardown_plan_for_down;
 use curie_aci_protocol::env_keys;
 use serde_json::Value;
 use tempfile::TempDir;
@@ -571,12 +588,18 @@ fn a_secret_file_is_staged_readable_and_mounted_where_declared() {
     )
     .expect("stage the credential");
 
+    let connector_dir = connector_secrets_root(dir.path()).join("kubernetes");
     assert_eq!(
-        staged,
-        connector_secrets_root(dir.path())
-            .join("kubernetes")
-            .join("kubeconfig"),
+        staged.parent(),
+        Some(connector_dir.as_path()),
         "the path is recomputable by `skill down` from the plugin dir alone"
+    );
+    assert!(
+        staged
+            .file_name()
+            .and_then(|n| n.to_str())
+            .is_some_and(|n| n.starts_with("kubeconfig-")),
+        "the declared name still leads, so an operator can read the tree: {staged:?}"
     );
     assert!(
         connector_secrets_root(dir.path()).starts_with(dir.path().join(".curie")),
@@ -603,6 +626,67 @@ fn a_secret_file_is_staged_readable_and_mounted_where_declared() {
             .any(|m| m == &format!("{}:/secrets/kubeconfig:ro", staged.display())),
         "the declared mount path is the container's, not the host's: {argv:?}"
     );
+}
+
+/// Two `secret_files` entries sharing a basename must not stage over each other.
+///
+/// `/a/token` and `/b/token` are two different credentials in the container, and
+/// a name derived from the basename alone silently leaves the connector holding
+/// the second value at both mount points.
+#[test]
+fn two_secret_files_sharing_a_basename_stage_to_distinct_paths() {
+    let dir = TempDir::new().expect("a scratch bundle");
+    let first =
+        stage_secret_file(dir.path(), "kubernetes", "/a/token", "alpha").expect("stage /a/token");
+    let second =
+        stage_secret_file(dir.path(), "kubernetes", "/b/token", "bravo").expect("stage /b/token");
+
+    assert_ne!(first, second, "one basename, two declarations, two files");
+    assert_eq!(
+        std::fs::read_to_string(&first).expect("read the first credential"),
+        "alpha",
+        "staging the second must not overwrite the first"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&second).expect("read the second credential"),
+        "bravo"
+    );
+}
+
+/// Restaging replaces the hardened file. The first staging leaves 0400/0444,
+/// so a plain write onto it is EACCES and a redeploy or rotation would wedge;
+/// deleting the replace-before-write from `stage_secret_file` fails this.
+#[test]
+fn restaging_replaces_the_hardened_credential() {
+    let dir = TempDir::new().expect("a scratch bundle");
+    let first = stage_secret_file(dir.path(), "kubernetes", "/secrets/kubeconfig", "old-creds")
+        .expect("first staging");
+    let again = stage_secret_file(dir.path(), "kubernetes", "/secrets/kubeconfig", "new-creds")
+        .expect("restaging over the hardened file must succeed");
+    assert_eq!(first, again, "one declaration, one staged path");
+    assert_eq!(
+        std::fs::read_to_string(&again).expect("read the rotated credential"),
+        "new-creds",
+        "rotation must land the new value"
+    );
+}
+
+/// A declared path is the CONTAINER's, so nothing constrains its shape. Every
+/// one of these must still land inside the connector's own directory: the
+/// staged path is a host filesystem write, and the bundle author picks its input.
+#[test]
+fn a_hostile_declared_path_cannot_escape_the_connector_directory() {
+    let dir = TempDir::new().expect("a scratch bundle");
+    let expected_parent = connector_secrets_root(dir.path()).join("kubernetes");
+
+    for declared in ["..", "../../evil", "/secrets/../../evil", "c:\\evil", "/"] {
+        let staged = staged_secret_path(dir.path(), "kubernetes", declared);
+        assert_eq!(
+            staged.parent(),
+            Some(expected_parent.as_path()),
+            "{declared:?} escaped to {staged:?}"
+        );
+    }
 }
 
 /// The parent directory is 0700, so the fallback file mode is still private.
@@ -645,22 +729,34 @@ fn the_staging_tree_is_private_even_when_the_file_must_be_world_readable() {
     );
 }
 
-/// Teardown removes the tree. Deleting the wipe step must fail this.
-#[test]
-fn teardown_wipes_the_staged_credentials() {
+/// Teardown removes the tree. Deleting the `WipeSecrets` arm must fail this.
+///
+/// Driven through `run_connector_teardown`, the executor production runs, not
+/// through the helper it calls -- a test of the helper alone stays green while
+/// the arm that reaches it is gone. The step is built on its own because its
+/// two siblings shell to docker.
+#[tokio::test]
+async fn teardown_wipes_the_staged_credentials() {
     let dir = TempDir::new().expect("a scratch bundle");
     stage_secret_file(dir.path(), "kubernetes", "/secrets/kubeconfig", "creds")
         .expect("stage the credential");
-    assert!(connector_secrets_root(dir.path()).exists());
+    let root = connector_secrets_root(dir.path());
+    assert!(root.exists());
 
-    wipe_connector_secrets(dir.path()).expect("wipe the tree");
+    let steps = vec![ConnectorTeardownStep::WipeSecrets(root.clone())];
     assert!(
-        !connector_secrets_root(dir.path()).exists(),
+        run_connector_teardown(&steps).await.is_empty(),
+        "the wipe must report no problem"
+    );
+    assert!(
+        !root.exists(),
         "a resolved credential must not outlive the containers that used it"
     );
 
-    wipe_connector_secrets(dir.path())
-        .expect("a second wipe is a no-op; `down` after `down` must not error");
+    assert!(
+        run_connector_teardown(&steps).await.is_empty(),
+        "a second wipe is a no-op; `down` after `down` must not error"
+    );
 }
 
 // ─── Teardown ordering (block B1-8) ──────────────────────────────────────────
@@ -732,14 +828,89 @@ fn teardown_without_a_plugin_dir_still_reaps_the_containers() {
     );
 }
 
+/// `curie local down` run from the bundle's own directory also removes the tree
+/// a `local deploy` staged there.
+///
+/// The local tier records the deployed bundle's directory nowhere, so the
+/// resolution is the directory `down` ran from -- the one `local deploy`
+/// defaults `--plugin-dir` to. Built through the same resolver `down` calls, so
+/// what stays unpinned here is only its `current_dir()` hand-off. The wipe is
+/// run on its own because its two siblings shell to docker.
+#[tokio::test]
+async fn local_down_wipes_the_staged_tree_of_the_bundle_it_was_run_from() {
+    let dir = TempDir::new().expect("a scratch bundle");
+    stage_secret_file(dir.path(), "kubernetes", "/secrets/kubeconfig", "creds")
+        .expect("stage the credential");
+    let root = connector_secrets_root(dir.path());
+
+    let steps = connector_teardown_plan_for_down(dir.path());
+    assert_eq!(
+        steps.len(),
+        2,
+        "the reap is unchanged; the wipe is added: {steps:?}"
+    );
+    assert!(
+        matches!(steps[0], ConnectorTeardownStep::ReapLabeled(_)),
+        "containers first, or the tree is still bind-mounted: {steps:?}"
+    );
+    match &steps[1] {
+        ConnectorTeardownStep::WipeSecrets(path) => assert_eq!(path, &root),
+        other => panic!("the staged tree is wiped last, got {other:?}"),
+    }
+
+    assert!(
+        run_connector_teardown(&[ConnectorTeardownStep::WipeSecrets(root.clone())])
+            .await
+            .is_empty(),
+        "the wipe must report no problem"
+    );
+    assert!(
+        !root.exists(),
+        "a resolved credential must not outlive `curie local down`"
+    );
+}
+
+/// A `down` from a directory holding no staged tree plans no wipe: the
+/// resolution never guesses at another bundle's credentials.
+#[test]
+fn local_down_plans_no_wipe_without_a_staged_tree() {
+    let dir = TempDir::new().expect("a directory that is not a staged bundle");
+    let steps = connector_teardown_plan_for_down(dir.path());
+    assert_eq!(steps.len(), 1, "{steps:?}");
+    assert!(
+        matches!(steps[0], ConnectorTeardownStep::ReapLabeled(_)),
+        "{steps:?}"
+    );
+}
+
 // ─── The compose overlay (block B1-9) ────────────────────────────────────────
+
+/// The `build:` form of a declaration, which is the only form a lock entry
+/// stands for (ADR 0113): the digest in the lock is what building THIS source
+/// resolved to, so a fixture that expects the overlay to be digest-pinned
+/// declares the build rather than an `image:` the author would have to keep in
+/// sync with it. `image` is cleared because exactly one of `image`/`build`/`url`
+/// may be set.
+fn built(mut spec: ConnectorSpecDecl, context: &str) -> ConnectorSpecDecl {
+    spec.image = None;
+    spec.build = Some(ConnectorBuildDecl {
+        context: context.to_string(),
+        dockerfile: "Dockerfile".to_string(),
+        platforms: vec!["linux/amd64".to_string(), "linux/arm64".to_string()],
+    });
+    spec
+}
 
 fn overlay_fixture(agent: &str, plugin_dir: &Path) -> Value {
     let mut decl = ConnectorsFileDecl::default();
-    decl.connectors
-        .insert("kubernetes".to_string(), kubernetes_spec());
-    decl.connectors
-        .insert("k8s-write".to_string(), k8s_write_spec());
+    decl.connectors.insert(
+        "kubernetes".to_string(),
+        built(kubernetes_spec(), "connectors/kubernetes"),
+    );
+    decl.connectors.insert(
+        "k8s-write".to_string(),
+        built(k8s_write_spec(), "connectors/k8s-write"),
+    );
 
     let mut lock = ConnectorLockFileDecl {
         version: LOCK_VERSION,
@@ -759,15 +930,7 @@ fn overlay_fixture(agent: &str, plugin_dir: &Path) -> Value {
         );
     }
 
-    compose_overlay(
-        &lock,
-        &decl,
-        &scope(agent),
-        "curie",
-        plugin_dir,
-        &BTreeMap::from([("K8S_WRITE_TOKEN".to_string(), "s3cr3t-value".to_string())]),
-    )
-    .expect("generate the overlay")
+    compose_overlay(&lock, &decl, &scope(agent), "curie", plugin_dir).expect("generate the overlay")
 }
 
 /// One service per hosted connector, pinned to the locked digest, joined to the
@@ -875,8 +1038,10 @@ fn the_overlay_reproduces_the_same_args_env_and_secret_files() {
         "{write}"
     );
     assert_eq!(
-        env["K8S_WRITE_TOKEN"], "s3cr3t-value",
-        "a declared secret is resolved locally; compose has no secretKeyRef: {write}"
+        env["K8S_WRITE_TOKEN"], "${K8S_WRITE_TOKEN}",
+        "compose has no secretKeyRef, so a declared secret is resolved locally -- but the \
+         overlay carries only the reference compose expands from its own environment, never \
+         the resolved value: {write}"
     );
 
     let mounts: Vec<&str> = write["volumes"]
@@ -901,7 +1066,7 @@ fn the_overlay_is_written_under_the_bundles_state_directory() {
     let path = compose_overlay_path(dir.path());
     assert_eq!(path, dir.path().join(".curie/compose.connectors.yaml"));
 
-    let command = compose_up_command(&path, "curie");
+    let command = compose_up_command(&path, "curie", &BTreeMap::new());
     assert_eq!(command.program, "docker");
     let argv = command.argv();
     assert_eq!(
@@ -918,6 +1083,117 @@ fn the_overlay_is_written_under_the_bundles_state_directory() {
         "{argv:?}"
     );
     assert!(argv.iter().any(|t| t == "--wait"), "{argv:?}");
+}
+
+// ─── The overlay file holds references, the child env holds the values ───────
+
+/// The bytes that actually land on disk carry the `${NAME}` reference and no
+/// resolved value.
+///
+/// The overlay is written to a 0644 file under `.curie/` that outlives the
+/// stack and every `local down`, so a value embedded here is a credential left
+/// on disk indefinitely. Asserted on the SERIALIZED form, the way
+/// `bring_up_local` writes it, rather than on the JSON tree: a value could
+/// otherwise hide in a field the tree assertions do not name. The resolved value
+/// is exported into this process first, so an emitter that reached for the
+/// ambient value instead of emitting the reference fails here.
+#[test]
+fn the_serialized_overlay_carries_the_reference_and_never_the_resolved_value() {
+    let dir = TempDir::new().expect("a scratch bundle");
+    std::env::set_var("K8S_WRITE_TOKEN", "s3cr3t-value");
+    let overlay = overlay_fixture("sre-bot", dir.path());
+    let written = serde_norway::to_string(&overlay).expect("serialize the overlay");
+
+    assert!(
+        written.contains("${K8S_WRITE_TOKEN}"),
+        "compose expands the reference from its own environment: {written}"
+    );
+    assert!(
+        !written.contains("s3cr3t-value"),
+        "a resolved credential must never reach the overlay file: {written}"
+    );
+}
+
+/// The value travels on the compose child's environment, masked, and never in
+/// argv -- the one channel `${NAME}` in the overlay expands from.
+#[test]
+fn the_up_command_carries_the_secret_in_the_child_env_never_in_argv() {
+    let dir = TempDir::new().expect("a scratch bundle");
+    let path = compose_overlay_path(dir.path());
+    let command = compose_up_command(
+        &path,
+        "curie",
+        &BTreeMap::from([("K8S_WRITE_TOKEN".to_string(), "s3cr3t-value".to_string())]),
+    );
+
+    assert!(
+        command
+            .secret_env
+            .contains(&("K8S_WRITE_TOKEN".to_string(), "s3cr3t-value".to_string())),
+        "compose reads `${{K8S_WRITE_TOKEN}}` from its own environment: {:?}",
+        command.secret_env
+    );
+    let argv = command.argv();
+    assert!(
+        !argv.iter().any(|t| t.contains("s3cr3t-value")),
+        "a credential in argv is readable from `ps -ef`: {argv:?}"
+    );
+    let printed = command.display();
+    assert!(
+        !printed.contains("s3cr3t-value"),
+        "the printed command line masks the credential: {printed}"
+    );
+    assert!(
+        printed.contains("K8S_WRITE_TOKEN=s3cr3t-v***"),
+        "the operator still sees WHICH credential is applied: {printed}"
+    );
+}
+
+/// The local tier refuses the whole bring-up when a declared secret has no value
+/// here, instead of writing a `${NAME}` nothing will populate.
+///
+/// It used to skip an unresolved secret silently -- the check `skill up` has
+/// always performed. With the overlay carrying references, skipping is worse
+/// than before: compose would warn, expand the reference to empty, and start the
+/// connector authenticating with nothing. The overlay file is asserted absent
+/// because it is written before `docker compose` is invoked, so its absence is
+/// the proof that the refusal came first and no container was ever started.
+#[tokio::test]
+async fn bring_up_local_refuses_a_declared_secret_with_no_value() {
+    let dir = TempDir::new().expect("a scratch bundle");
+    // Point the credential vault at an empty directory: the refusal must come
+    // from the declaration having no value HERE, not from whatever this box's
+    // operator happens to have stored (and the redirect keeps the test off the
+    // OS credential store entirely).
+    std::env::set_var("CURIE_CONFIG_DIR", dir.path().join("config"));
+    std::env::remove_var("CURIE_TEST_UNSET_CONNECTOR_TOKEN");
+    std::fs::write(
+        dir.path().join("connectors.yaml"),
+        "connectors:\n  \
+           gated:\n    \
+             image: ghcr.io/acme-corp/gated:v1\n    \
+             secrets:\n      \
+               - CURIE_TEST_UNSET_CONNECTOR_TOKEN\n",
+    )
+    .expect("write connectors.yaml");
+
+    let lock = ConnectorLockFileDecl {
+        version: LOCK_VERSION,
+        connectors: BTreeMap::new(),
+    };
+    let error = curie::commands::bring_up_local(dir.path(), &lock, &scope("sre-bot"), "curie")
+        .await
+        .expect_err("a declared secret with no value must refuse the bring-up");
+
+    let message = format!("{error:#}");
+    assert!(
+        message.contains("CURIE_TEST_UNSET_CONNECTOR_TOKEN"),
+        "the refusal names the missing credential: {message}"
+    );
+    assert!(
+        !compose_overlay_path(dir.path()).exists(),
+        "the refusal must land before anything is written or started"
+    );
 }
 
 // ─── Identity: one struct drives the alias and the runner scope (B1-11) ──────

--- a/cli/tests/connector_compose.rs
+++ b/cli/tests/connector_compose.rs
@@ -1,0 +1,1103 @@
+//! RED contract for PR B / Stream B1: running a locked connector locally.
+//!
+//! Two emitters, one set of semantics. The skill tier starts each hosted
+//! connector with `docker run` (`docker::ConnectorStartSpec`, block B1-4); the
+//! local tier generates a compose overlay and brings it up (block B1-9). Both
+//! must reproduce `connector_render.render_deployment` field for field --
+//! substituted `args`, substituted `env`, declared secrets, `secret_files`,
+//! the hardening set, and the port -- because the runner derives the URL it
+//! dials from the PYTHON copy. An approximation here does not degrade: it
+//! either times out against a name no container owns, or (the review's finding
+//! 5) silently drops `args` and restores general write plus the
+//! credential-exposing `configuration_view` tool.
+//!
+//! This file also carries the three smaller B1 pins that have nowhere better
+//! to live: `RunnerState` recording what boot created, the packer's treatment
+//! of the lock and the overlay, and the teardown ordering.
+//!
+//! Everything is pure. Nothing here starts a container, and the credential
+//! staging is asserted at the filesystem level (write it, read the exact bytes
+//! back, wipe it, assert it is gone) rather than by inspecting flags -- an
+//! argv assertion passes against an empty mount, which is the failure this
+//! replaces. The daemon-backed half of that proof is the ladder's job (B3).
+//!
+//! Surface the implementer must add:
+//!
+//! ```ignore
+//! // curie::connector_build
+//! pub struct ConnectorScope { pub release: String, pub agent: String, pub namespace: String }
+//! pub fn connector_substitutions(
+//!     scope: &ConnectorScope, connector: &str, port: u32,
+//! ) -> BTreeMap<String, String>;
+//! pub fn substitute(value: &str, subs: &BTreeMap<String, String>) -> String;
+//! pub fn connector_scope_env(scope: &ConnectorScope) -> Vec<(String, String)>;
+//! pub fn connector_secrets_root(plugin_dir: &Path) -> PathBuf;
+//! pub fn stage_secret_file(
+//!     plugin_dir: &Path, connector: &str, declared_path: &str, value: &str,
+//! ) -> anyhow::Result<PathBuf>;
+//! pub fn wipe_connector_secrets(plugin_dir: &Path) -> anyhow::Result<()>;
+//! pub fn compose_overlay_path(plugin_dir: &Path) -> PathBuf;
+//! pub fn compose_overlay(
+//!     lock: &ConnectorLockFileDecl,
+//!     decl: &ConnectorsFileDecl,
+//!     identity: &ConnectorScope,
+//!     project: &str,
+//!     plugin_dir: &Path,
+//!     secret_values: &BTreeMap<String, String>,
+//! ) -> anyhow::Result<serde_json::Value>;
+//! pub fn compose_up_command(overlay: &Path, project: &str) -> curie::ops::OpsCommand;
+//!
+//! // curie::docker
+//! pub const CONNECTOR_COMPONENT_LABEL: &str = "curietech.ai/component=connector";
+//! pub fn connector_project_label(project: &str) -> String;
+//! pub struct ConnectorStartSpec {
+//!     // .. image / container_name / network / alias / args / env ..
+//!     /// Resolved secret values handed to the Docker CLI child process only,
+//!     /// forwarded by bare `-e NAME` so they never enter argv. Same rule
+//!     /// `StartSpec::docker_env` already follows.
+//!     pub docker_env: Vec<(String, String)>,
+//! }
+//! impl ConnectorStartSpec {
+//!     pub fn from_declaration(
+//!         connector: &str,
+//!         spec: &ConnectorSpecDecl,
+//!         image: &str,
+//!         identity: &ConnectorScope,
+//!         network: &str,
+//!         project: &str,
+//!         plugin_dir: &Path,
+//!         secret_values: &BTreeMap<String, String>,
+//!     ) -> anyhow::Result<Self>;
+//!     pub fn run_args(&self) -> Vec<String>;
+//! }
+//! pub enum ConnectorTeardownStep {
+//!     ReapLabeled(OpsCommand), RemoveNetwork(OpsCommand), WipeSecrets(PathBuf),
+//! }
+//! pub fn connector_teardown_plan(
+//!     project: &str, network: Option<&str>, plugin_dir: Option<&Path>,
+//! ) -> Vec<ConnectorTeardownStep>;
+//!
+//! // curie::state::RunnerState
+//! pub connector_containers: Vec<String>,
+//! pub connector_network: Option<String>,
+//! ```
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use curie::connector_build::{
+    compose_overlay, compose_overlay_path, compose_up_command, connector_scope_env,
+    connector_secrets_root, connector_substitutions, object_name, service_dns, stage_secret_file,
+    substitute, wipe_connector_secrets, ConnectorLockEntryDecl, ConnectorLockFileDecl,
+    ConnectorScope, ConnectorSpecDecl, ConnectorsFileDecl, Delivery, SecretDecl, LOCK_VERSION,
+};
+use curie::docker::{
+    connector_project_label, connector_teardown_plan, ConnectorStartSpec, ConnectorTeardownStep,
+    CLI_MANAGED_LABEL, CONNECTOR_COMPONENT_LABEL,
+};
+use curie_aci_protocol::env_keys;
+use serde_json::Value;
+use tempfile::TempDir;
+
+const TEMPO_IMAGE: &str = "ghcr.io/acme-corp/sre-bot-tempo@sha256:\
+                           2222222222222222222222222222222222222222222222222222222222222222";
+const WRITE_IMAGE: &str = "ghcr.io/acme-corp/sre-bot-k8s-write@sha256:\
+                           5555555555555555555555555555555555555555555555555555555555555555";
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+fn scope(agent: &str) -> ConnectorScope {
+    ConnectorScope {
+        release: "curie".to_string(),
+        agent: agent.to_string(),
+        namespace: "default".to_string(),
+    }
+}
+
+/// The read-only `kubernetes` connector exactly as `examples/sre-bot`
+/// declares it: the flag list is load-bearing security, not configuration.
+fn kubernetes_spec() -> ConnectorSpecDecl {
+    ConnectorSpecDecl {
+        image: Some("ghcr.io/containers/kubernetes-mcp-server:v0.0.66".to_string()),
+        args: [
+            "--port",
+            "8000",
+            "--bind-address",
+            "0.0.0.0",
+            "--read-only",
+            "--toolsets",
+            "core",
+            "--disable-destructive",
+            "--disable-multi-cluster",
+            "--stateless",
+            "--kubeconfig",
+            "/secrets/kubeconfig",
+        ]
+        .iter()
+        .map(|a| (*a).to_string())
+        .collect(),
+        secret_files: BTreeMap::from([(
+            "K8S_READONLY_KUBECONFIG".to_string(),
+            "/secrets/kubeconfig".to_string(),
+        )]),
+        ..Default::default()
+    }
+}
+
+/// The gated write connector from the README's enable ceremony: a declared
+/// env var, a declared secret env var, and a credential file.
+fn k8s_write_spec() -> ConnectorSpecDecl {
+    ConnectorSpecDecl {
+        env: BTreeMap::from([
+            (
+                "K8S_WRITE_ALLOWLIST".to_string(),
+                "acme-ns/checkout-api".to_string(),
+            ),
+            (
+                "K8S_WRITE_SELF_URL".to_string(),
+                "${CURIE_CONNECTOR_URL}".to_string(),
+            ),
+        ]),
+        args: vec![
+            "--allowed-hosts".to_string(),
+            "${CURIE_ALLOWED_HOSTS}".to_string(),
+        ],
+        secrets: vec![SecretDecl::Name("K8S_WRITE_TOKEN".to_string())],
+        secret_files: BTreeMap::from([(
+            "K8S_WRITE_KUBECONFIG".to_string(),
+            "/secrets/kubeconfig".to_string(),
+        )]),
+        ..Default::default()
+    }
+}
+
+fn start_spec(
+    connector: &str,
+    spec: &ConnectorSpecDecl,
+    image: &str,
+    identity: &ConnectorScope,
+    plugin_dir: &Path,
+    secret_values: &BTreeMap<String, String>,
+) -> ConnectorStartSpec {
+    ConnectorStartSpec::from_declaration(
+        connector,
+        spec,
+        image,
+        identity,
+        "curie-skill-net",
+        "curie-skill-abc123",
+        plugin_dir,
+        secret_values,
+    )
+    .unwrap_or_else(|error| panic!("start spec for {connector}: {error:#}"))
+}
+
+fn pairs_after(argv: &[String], flag: &str) -> Vec<String> {
+    argv.windows(2)
+        .filter(|w| w[0] == flag)
+        .map(|w| w[1].clone())
+        .collect()
+}
+
+fn vector_file() -> Value {
+    let path =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("../tests/vectors/connector-service-dns.json");
+    let body = std::fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("read {}: {error}", path.display()));
+    serde_json::from_str(&body).expect("parse connector-service-dns.json")
+}
+
+// ─── The start spec mirrors the rendered container ───────────────────────────
+
+/// The alias is the Service DNS name, and it is frozen against the same corpus
+/// the Python renderer is.
+///
+/// The runner never learns this name from the CLI: it derives it independently
+/// from `connector_render.service_dns` using the boot-env scope. A hand port
+/// that drifts leaves the sandbox dialing a name no container answers to, which
+/// surfaces as a bare connection timeout with nothing logged on either side.
+#[test]
+fn the_network_alias_is_the_frozen_service_dns_for_every_vector() {
+    let dir = TempDir::new().expect("a scratch bundle");
+    for vector in vector_file()["vectors"].as_array().expect("vectors") {
+        let identity = ConnectorScope {
+            release: vector["release"].as_str().expect("release").to_string(),
+            agent: vector["agent"].as_str().expect("agent").to_string(),
+            namespace: vector["namespace"].as_str().expect("namespace").to_string(),
+        };
+        let connector = vector["connector"].as_str().expect("connector");
+        let expected = vector["service_dns"].as_str().expect("service_dns");
+
+        let argv = start_spec(
+            connector,
+            &kubernetes_spec(),
+            TEMPO_IMAGE,
+            &identity,
+            dir.path(),
+            &BTreeMap::new(),
+        )
+        .run_args();
+
+        assert!(
+            pairs_after(&argv, "--network-alias").contains(&expected.to_string()),
+            "{}: the alias must be {expected}, got {argv:?}",
+            vector["name"]
+        );
+    }
+}
+
+/// No published port, ever.
+///
+/// ADR 0113's "no host port dependency": the runner reaches the connector over
+/// the private network by alias. A `-p` would collide the moment two bundles
+/// ran at once, and would expose a credential-holding server on the host.
+#[test]
+fn the_connector_container_publishes_no_host_port() {
+    let dir = TempDir::new().expect("a scratch bundle");
+    let argv = start_spec(
+        "tempo",
+        &kubernetes_spec(),
+        TEMPO_IMAGE,
+        &scope("sre-bot"),
+        dir.path(),
+        &BTreeMap::new(),
+    )
+    .run_args();
+
+    assert!(
+        !argv.iter().any(|t| t == "-p" || t == "--publish"),
+        "a connector must not be reachable from the host: {argv:?}"
+    );
+    assert!(
+        !argv.iter().any(|t| t == "-P" || t == "--publish-all"),
+        "{argv:?}"
+    );
+}
+
+/// Every declared `arg` survives, in order.
+///
+/// This is the guard finding 5 asked for. `--read-only`, `--toolsets core` and
+/// `--disable-destructive` are what keep this connector from exposing general
+/// write and `configuration_view` (which returns the kubeconfig, bearer token
+/// included, and is annotated readOnlyHint=true). Dropping the args mirroring
+/// starts the same image with its DEFAULT tool surface and nothing anywhere
+/// reports a problem.
+#[test]
+fn every_declared_arg_reaches_the_container_in_declaration_order() {
+    let dir = TempDir::new().expect("a scratch bundle");
+    let spec = kubernetes_spec();
+    let argv = start_spec(
+        "kubernetes",
+        &spec,
+        TEMPO_IMAGE,
+        &scope("sre-bot"),
+        dir.path(),
+        &BTreeMap::new(),
+    )
+    .run_args();
+
+    let image_at = argv
+        .iter()
+        .position(|t| t == TEMPO_IMAGE)
+        .unwrap_or_else(|| panic!("the image is in argv: {argv:?}"));
+    let tail = &argv[image_at + 1..];
+    assert_eq!(
+        tail, spec.args,
+        "the container's argv tail is exactly the declared args, in order: {argv:?}"
+    );
+
+    for guard in [
+        "--read-only",
+        "--toolsets",
+        "core",
+        "--disable-destructive",
+        "--disable-multi-cluster",
+    ] {
+        assert!(
+            tail.iter().any(|t| t == guard),
+            "{guard} is security, not configuration: {tail:?}"
+        );
+    }
+}
+
+/// The hardening set is applied by construction, exactly as `render_deployment`
+/// applies it. The author never writes it, so the author cannot omit it.
+#[test]
+fn the_connector_container_is_hardened_the_same_way_the_pod_is() {
+    let dir = TempDir::new().expect("a scratch bundle");
+    let argv = start_spec(
+        "tempo",
+        &kubernetes_spec(),
+        TEMPO_IMAGE,
+        &scope("sre-bot"),
+        dir.path(),
+        &BTreeMap::new(),
+    )
+    .run_args();
+    let joined = argv.join(" ");
+
+    for flag in [
+        "--read-only",
+        "--cap-drop ALL",
+        "--security-opt no-new-privileges",
+        "--user 65532:65532",
+    ] {
+        assert!(
+            joined.contains(flag),
+            "the pod runs with {flag}'s equivalent; the container must too: {joined}"
+        );
+    }
+}
+
+/// Both labels, on every connector container, because teardown resolves them.
+///
+/// B1-8's whole point: the overlay file is regenerated state and must never be
+/// load-bearing for teardown. If a container is not labeled at creation, no
+/// `down` from any directory can find it.
+#[test]
+fn every_connector_container_carries_the_component_and_project_labels() {
+    let dir = TempDir::new().expect("a scratch bundle");
+    let argv = start_spec(
+        "tempo",
+        &kubernetes_spec(),
+        TEMPO_IMAGE,
+        &scope("sre-bot"),
+        dir.path(),
+        &BTreeMap::new(),
+    )
+    .run_args();
+    let labels = pairs_after(&argv, "--label");
+
+    assert!(
+        labels.iter().any(|l| l == CONNECTOR_COMPONENT_LABEL),
+        "{labels:?}"
+    );
+    assert!(
+        labels
+            .iter()
+            .any(|l| *l == connector_project_label("curie-skill-abc123")),
+        "{labels:?}"
+    );
+    assert!(
+        labels.iter().any(|l| l == CLI_MANAGED_LABEL),
+        "a leftover connector must be identifiable as the CLI's (#747): {labels:?}"
+    );
+}
+
+// ─── Substitution: the placeholders only Curie can fill ──────────────────────
+
+/// `${CURIE_*}` placeholders expand from the identity, in both `args` and `env`.
+///
+/// Ported from `connector_render.substitutions` (`:143`) and `substitute`
+/// (`:167`). `CURIE_ALLOWED_HOSTS` in particular carries all three host forms:
+/// a server that validates the Host header rejects an in-cluster caller with
+/// `forbidden: host not allowed` when the list is short one form (ADR-0086),
+/// and which form the sandbox dials depends on how the URL was written.
+#[test]
+fn the_curie_placeholders_expand_from_the_identity() {
+    let identity = scope("sre-bot");
+    let subs = connector_substitutions(&identity, "tempo", 8000);
+    let short = object_name(&identity.release, &identity.agent, "tempo");
+    let dns = service_dns(
+        &identity.release,
+        &identity.agent,
+        "tempo",
+        &identity.namespace,
+    );
+
+    assert_eq!(subs.get("CURIE_CONNECTOR_HOST"), Some(&short));
+    assert_eq!(subs.get("CURIE_CONNECTOR_PORT"), Some(&"8000".to_string()));
+    assert_eq!(
+        subs.get("CURIE_CONNECTOR_URL"),
+        Some(&format!("http://{dns}:8000"))
+    );
+
+    let allowed = subs
+        .get("CURIE_ALLOWED_HOSTS")
+        .expect("the host allowlist is derived, never authored");
+    assert_eq!(
+        allowed,
+        &format!("{short}:8000,{short}.default:8000,{dns}:8000"),
+        "all three forms, in this order, matching connector_render.host_aliases"
+    );
+
+    assert_eq!(
+        substitute("--hosts=${CURIE_ALLOWED_HOSTS}", &subs),
+        format!("--hosts={allowed}")
+    );
+    assert_eq!(
+        substitute("nothing to expand", &subs),
+        "nothing to expand",
+        "a value with no placeholder passes through untouched"
+    );
+}
+
+/// The substituted values reach the container, in args and in env alike.
+#[test]
+fn substituted_args_and_env_reach_the_container() {
+    let dir = TempDir::new().expect("a scratch bundle");
+    let identity = scope("sre-bot");
+    let subs = connector_substitutions(&identity, "k8s-write", 8000);
+    let argv = start_spec(
+        "k8s-write",
+        &k8s_write_spec(),
+        WRITE_IMAGE,
+        &identity,
+        dir.path(),
+        &BTreeMap::from([("K8S_WRITE_TOKEN".to_string(), "s3cr3t-value".to_string())]),
+    )
+    .run_args();
+
+    let expanded_arg = subs.get("CURIE_ALLOWED_HOSTS").expect("the allowlist");
+    assert!(
+        argv.iter().any(|t| t == expanded_arg),
+        "an unexpanded ${{CURIE_ALLOWED_HOSTS}} reaches the server as a literal: {argv:?}"
+    );
+    assert!(
+        !argv.iter().any(|t| t.contains("${CURIE_")),
+        "no placeholder may survive into argv: {argv:?}"
+    );
+
+    let env = pairs_after(&argv, "-e");
+    assert!(
+        env.iter()
+            .any(|e| e == "K8S_WRITE_ALLOWLIST=acme-ns/checkout-api"),
+        "{env:?}"
+    );
+    assert!(
+        env.iter().any(|e| e
+            == &format!(
+                "K8S_WRITE_SELF_URL={}",
+                subs.get("CURIE_CONNECTOR_URL").expect("the url")
+            )),
+        "{env:?}"
+    );
+}
+
+// ─── Secrets: never in argv, readable on disk, gone after teardown ───────────
+
+/// A declared secret is forwarded by NAME; its value never enters argv.
+///
+/// Same rule `StartSpec` already follows for model credentials: `-e NAME` with
+/// the value supplied to the Docker CLI process only, so it never lands in
+/// `ps -ef` or `/proc/<pid>/cmdline`.
+#[test]
+fn a_declared_secrets_value_never_appears_in_argv() {
+    let dir = TempDir::new().expect("a scratch bundle");
+    let spec = start_spec(
+        "k8s-write",
+        &k8s_write_spec(),
+        WRITE_IMAGE,
+        &scope("sre-bot"),
+        dir.path(),
+        &BTreeMap::from([("K8S_WRITE_TOKEN".to_string(), "s3cr3t-value".to_string())]),
+    );
+    let argv = spec.run_args();
+
+    assert!(
+        pairs_after(&argv, "-e")
+            .iter()
+            .any(|e| e == "K8S_WRITE_TOKEN"),
+        "the bare name is what is forwarded: {argv:?}"
+    );
+    assert!(
+        !argv.iter().any(|t| t.contains("s3cr3t-value")),
+        "the credential value leaked into the process table: {argv:?}"
+    );
+    assert!(
+        spec.docker_env
+            .iter()
+            .any(|(k, v)| k == "K8S_WRITE_TOKEN" && v == "s3cr3t-value"),
+        "the value travels to the Docker CLI child's environment instead"
+    );
+}
+
+/// A `from_secret` reference has no local equivalent, so bring-up fails closed.
+///
+/// The Kubernetes form points at a Secret someone else provisioned (#1163);
+/// there is nothing on a laptop that corresponds to it. Starting the container
+/// without the credential would give a server that 401s on every call, which
+/// reads as a broken connector rather than a missing prerequisite. The refusal
+/// has to name all three ways forward (7.3, review round 2 finding r2-8).
+#[test]
+fn an_out_of_band_secret_reference_fails_closed_with_all_three_alternatives() {
+    let dir = TempDir::new().expect("a scratch bundle");
+    let spec = ConnectorSpecDecl {
+        secrets: vec![SecretDecl::Ref {
+            name: "GRAFANA_TOKEN".to_string(),
+            from_secret: "grafana-sa".to_string(),
+            key: None,
+        }],
+        ..Default::default()
+    };
+
+    let error = ConnectorStartSpec::from_declaration(
+        "grafana",
+        &spec,
+        TEMPO_IMAGE,
+        &scope("sre-bot"),
+        "curie-skill-net",
+        "curie-skill-abc123",
+        dir.path(),
+        &BTreeMap::new(),
+    )
+    .expect_err("a SecretRef has no local-daemon equivalent");
+
+    let text = format!("{error:#}");
+    for needle in ["GRAFANA_TOKEN", "curie secrets set", "unhosted_url"] {
+        assert!(
+            text.contains(needle),
+            "the refusal must name {needle}: {text}"
+        );
+    }
+}
+
+/// The credential file is staged at a DETERMINISTIC path, holds exactly the
+/// resolved value, and is bind-mounted read-only where the declaration says.
+///
+/// Deterministic, not a per-run tempdir: teardown is label-driven and a reap
+/// that never inspected a container cannot discover a random path, so the
+/// credential would survive every `down` (review round 3, finding r3-9). The
+/// content assertion is what an argv check cannot make -- an empty mount
+/// satisfies every flag.
+#[test]
+fn a_secret_file_is_staged_readable_and_mounted_where_declared() {
+    let dir = TempDir::new().expect("a scratch bundle");
+    let staged = stage_secret_file(
+        dir.path(),
+        "kubernetes",
+        "/secrets/kubeconfig",
+        "apiVersion: v1\nkind: Config\n",
+    )
+    .expect("stage the credential");
+
+    assert_eq!(
+        staged,
+        connector_secrets_root(dir.path())
+            .join("kubernetes")
+            .join("kubeconfig"),
+        "the path is recomputable by `skill down` from the plugin dir alone"
+    );
+    assert!(
+        connector_secrets_root(dir.path()).starts_with(dir.path().join(".curie")),
+        "the tree lives under .curie/, which the packer excludes and the scaffold gitignores"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&staged).expect("read the staged credential"),
+        "apiVersion: v1\nkind: Config\n",
+        "an empty file mounts just as successfully as a correct one"
+    );
+
+    let argv = start_spec(
+        "kubernetes",
+        &kubernetes_spec(),
+        TEMPO_IMAGE,
+        &scope("sre-bot"),
+        dir.path(),
+        &BTreeMap::new(),
+    )
+    .run_args();
+    assert!(
+        pairs_after(&argv, "-v")
+            .iter()
+            .any(|m| m == &format!("{}:/secrets/kubeconfig:ro", staged.display())),
+        "the declared mount path is the container's, not the host's: {argv:?}"
+    );
+}
+
+/// The parent directory is 0700, so the fallback file mode is still private.
+///
+/// Rootless Docker and Docker Desktop map uids differently, so the `chown` to
+/// 65532 is not always permitted; where it is not, the file falls back to 0444
+/// and the private parent is the only thing keeping the credential unreadable.
+/// That is why the parent mode is load-bearing rather than tidiness.
+#[cfg(unix)]
+#[test]
+fn the_staging_tree_is_private_even_when_the_file_must_be_world_readable() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = TempDir::new().expect("a scratch bundle");
+    let staged = stage_secret_file(dir.path(), "kubernetes", "/secrets/kubeconfig", "creds")
+        .expect("stage the credential");
+
+    let root_mode = std::fs::metadata(connector_secrets_root(dir.path()))
+        .expect("stat the root")
+        .permissions()
+        .mode()
+        & 0o777;
+    assert_eq!(root_mode, 0o700, "connector-secrets/ must be private");
+
+    let connector_mode = std::fs::metadata(staged.parent().expect("a parent"))
+        .expect("stat the connector dir")
+        .permissions()
+        .mode()
+        & 0o777;
+    assert_eq!(connector_mode, 0o700, "each connector's subdirectory too");
+
+    let file_mode = std::fs::metadata(&staged)
+        .expect("stat the file")
+        .permissions()
+        .mode()
+        & 0o777;
+    assert!(
+        file_mode == 0o400 || file_mode == 0o444,
+        "0400 when chown succeeded, 0444 inside the 0700 parent when it could not; got {file_mode:o}"
+    );
+}
+
+/// Teardown removes the tree. Deleting the wipe step must fail this.
+#[test]
+fn teardown_wipes_the_staged_credentials() {
+    let dir = TempDir::new().expect("a scratch bundle");
+    stage_secret_file(dir.path(), "kubernetes", "/secrets/kubeconfig", "creds")
+        .expect("stage the credential");
+    assert!(connector_secrets_root(dir.path()).exists());
+
+    wipe_connector_secrets(dir.path()).expect("wipe the tree");
+    assert!(
+        !connector_secrets_root(dir.path()).exists(),
+        "a resolved credential must not outlive the containers that used it"
+    );
+
+    wipe_connector_secrets(dir.path())
+        .expect("a second wipe is a no-op; `down` after `down` must not error");
+}
+
+// ─── Teardown ordering (block B1-8) ──────────────────────────────────────────
+
+/// Containers first, then the network, then the credential tree.
+///
+/// The order is the property: a network still attached to a running container
+/// cannot be removed, and a tree still bind-mounted into one cannot be wiped
+/// cleanly. Reaping is label-scoped rather than file-scoped because
+/// `LocalDownOpts` carries no plugin directory and a `down` run from another
+/// directory must still reap (review round 2, finding r2-4).
+#[test]
+fn teardown_reaps_by_label_then_removes_the_network_then_wipes_the_tree() {
+    let dir = TempDir::new().expect("a scratch bundle");
+    let steps = connector_teardown_plan("curie", Some("curie-skill-net"), Some(dir.path()));
+
+    assert_eq!(steps.len(), 3, "{steps:?}");
+
+    match &steps[0] {
+        ConnectorTeardownStep::ReapLabeled(command) => {
+            assert_eq!(command.program, "docker");
+            let argv = command.argv();
+            let filters = pairs_after(&argv, "--filter");
+            assert!(
+                filters
+                    .iter()
+                    .any(|f| f == &format!("label={CONNECTOR_COMPONENT_LABEL}")),
+                "{argv:?}"
+            );
+            assert!(
+                filters
+                    .iter()
+                    .any(|f| f == &format!("label={}", connector_project_label("curie"))),
+                "the project label is what keeps two concurrent stacks apart: {argv:?}"
+            );
+            assert!(
+                argv.iter().any(|t| t == "-a" || t == "--all"),
+                "a stopped connector still holds the mount: {argv:?}"
+            );
+        }
+        other => panic!("the first step must reap containers, got {other:?}"),
+    }
+
+    match &steps[1] {
+        ConnectorTeardownStep::RemoveNetwork(command) => {
+            let argv = command.argv();
+            assert!(argv.iter().any(|t| t == "curie-skill-net"), "{argv:?}");
+        }
+        other => panic!("the network comes after the containers, got {other:?}"),
+    }
+
+    match &steps[2] {
+        ConnectorTeardownStep::WipeSecrets(path) => {
+            assert_eq!(path, &connector_secrets_root(dir.path()));
+        }
+        other => panic!("the credential tree is wiped last, got {other:?}"),
+    }
+}
+
+/// `curie local down` from any directory still reaps, with no plugin dir and no
+/// network of its own to remove.
+#[test]
+fn teardown_without_a_plugin_dir_still_reaps_the_containers() {
+    let steps = connector_teardown_plan("curie", None, None);
+    assert_eq!(steps.len(), 1, "{steps:?}");
+    assert!(
+        matches!(steps[0], ConnectorTeardownStep::ReapLabeled(_)),
+        "{steps:?}"
+    );
+}
+
+// ─── The compose overlay (block B1-9) ────────────────────────────────────────
+
+fn overlay_fixture(agent: &str, plugin_dir: &Path) -> Value {
+    let mut decl = ConnectorsFileDecl::default();
+    decl.connectors
+        .insert("kubernetes".to_string(), kubernetes_spec());
+    decl.connectors
+        .insert("k8s-write".to_string(), k8s_write_spec());
+
+    let mut lock = ConnectorLockFileDecl {
+        version: LOCK_VERSION,
+        connectors: BTreeMap::new(),
+    };
+    for (name, image) in [("kubernetes", TEMPO_IMAGE), ("k8s-write", WRITE_IMAGE)] {
+        lock.connectors.insert(
+            name.to_string(),
+            ConnectorLockEntryDecl {
+                image: image.to_string(),
+                delivery: Delivery::Registry,
+                platforms: vec!["linux/amd64".into(), "linux/arm64".into()],
+                source_digest: "sha256:\
+                                3333333333333333333333333333333333333333333333333333333333333333"
+                    .to_string(),
+            },
+        );
+    }
+
+    compose_overlay(
+        &lock,
+        &decl,
+        &scope(agent),
+        "curie",
+        plugin_dir,
+        &BTreeMap::from([("K8S_WRITE_TOKEN".to_string(), "s3cr3t-value".to_string())]),
+    )
+    .expect("generate the overlay")
+}
+
+/// One service per hosted connector, pinned to the locked digest, joined to the
+/// running stack's network under the Service-DNS alias, with no published port.
+#[test]
+fn the_overlay_declares_one_digest_pinned_service_per_hosted_connector() {
+    let dir = TempDir::new().expect("a scratch bundle");
+    let overlay = overlay_fixture("sre-bot", dir.path());
+    let services = overlay["services"].as_object().expect("services");
+    assert_eq!(services.len(), 2, "{overlay}");
+
+    for connector in ["kubernetes", "k8s-write"] {
+        let key = object_name("curie", "sre-bot", connector);
+        let service = services
+            .get(&key)
+            .unwrap_or_else(|| panic!("a service named {key}: {overlay}"));
+
+        let image = service["image"].as_str().expect("an image");
+        assert!(
+            image.contains("@sha256:"),
+            "compose must start the SAME digest the cluster pulls: {image}"
+        );
+        assert!(
+            service.get("ports").is_none(),
+            "a connector is reachable by alias, never by host port: {service}"
+        );
+
+        let networks = service["networks"].as_object().expect("a networks mapping");
+        assert_eq!(networks.len(), 1, "{service}");
+        let (network_key, attachment) = networks.iter().next().expect("one network");
+        let aliases: Vec<&str> = attachment["aliases"]
+            .as_array()
+            .expect("aliases")
+            .iter()
+            .map(|a| a.as_str().expect("a string"))
+            .collect();
+        assert!(
+            aliases.contains(&service_dns("curie", "sre-bot", connector, "default").as_str()),
+            "{service}"
+        );
+
+        let declared = &overlay["networks"][network_key];
+        assert_eq!(
+            declared["external"], true,
+            "the overlay JOINS the stack's existing curie_runner network; creating its own \
+             leaves the worker's sandbox unable to resolve the alias: {overlay}"
+        );
+        assert!(
+            network_key.contains("curie_runner")
+                || declared["name"]
+                    .as_str()
+                    .is_some_and(|n| n.contains("curie_runner")),
+            "the network is the one the worker puts the runner on: {overlay}"
+        );
+    }
+}
+
+/// The overlay carries both teardown labels, since it is not itself
+/// load-bearing for teardown.
+#[test]
+fn every_overlay_service_carries_the_teardown_labels() {
+    let dir = TempDir::new().expect("a scratch bundle");
+    let overlay = overlay_fixture("sre-bot", dir.path());
+
+    for (_name, service) in overlay["services"].as_object().expect("services") {
+        let labels = &service["labels"];
+        assert_eq!(labels["curietech.ai/component"], "connector", "{service}");
+        assert_eq!(labels["curietech.ai/project"], "curie", "{service}");
+    }
+}
+
+/// The overlay's command, environment and mounts are the same rendered
+/// contract the start spec emits: one set of semantics, two emitters.
+#[test]
+fn the_overlay_reproduces_the_same_args_env_and_secret_files() {
+    let dir = TempDir::new().expect("a scratch bundle");
+    let overlay = overlay_fixture("sre-bot", dir.path());
+    let service = &overlay["services"][object_name("curie", "sre-bot", "kubernetes")];
+
+    let command: Vec<&str> = service["command"]
+        .as_array()
+        .expect("a command list")
+        .iter()
+        .map(|a| a.as_str().expect("a string"))
+        .collect();
+    assert_eq!(
+        command,
+        kubernetes_spec().args,
+        "dropping the args here restores the default tool surface exactly as it would in the \
+         start spec: {service}"
+    );
+
+    let write = &overlay["services"][object_name("curie", "sre-bot", "k8s-write")];
+    let env = &write["environment"];
+    assert_eq!(
+        env["K8S_WRITE_ALLOWLIST"], "acme-ns/checkout-api",
+        "{write}"
+    );
+    assert_eq!(
+        env["K8S_WRITE_SELF_URL"],
+        format!(
+            "http://{}:8000",
+            service_dns("curie", "sre-bot", "k8s-write", "default")
+        ),
+        "{write}"
+    );
+    assert_eq!(
+        env["K8S_WRITE_TOKEN"], "s3cr3t-value",
+        "a declared secret is resolved locally; compose has no secretKeyRef: {write}"
+    );
+
+    let mounts: Vec<&str> = write["volumes"]
+        .as_array()
+        .expect("volumes")
+        .iter()
+        .map(|v| v.as_str().expect("a string"))
+        .collect();
+    assert!(
+        mounts
+            .iter()
+            .any(|m| m.ends_with(":/secrets/kubeconfig:ro")),
+        "the credential file mounts read-only at its declared path: {mounts:?}"
+    );
+}
+
+/// The overlay is ephemeral state under `.curie/`, so it never enters the
+/// uploaded bundle and never perturbs the digest the ladder asserts.
+#[test]
+fn the_overlay_is_written_under_the_bundles_state_directory() {
+    let dir = TempDir::new().expect("a scratch bundle");
+    let path = compose_overlay_path(dir.path());
+    assert_eq!(path, dir.path().join(".curie/compose.connectors.yaml"));
+
+    let command = compose_up_command(&path, "curie");
+    assert_eq!(command.program, "docker");
+    let argv = command.argv();
+    assert_eq!(
+        argv.first().map(String::as_str),
+        Some("compose"),
+        "{argv:?}"
+    );
+    assert!(
+        pairs_after(&argv, "-p").contains(&"curie".to_string()),
+        "the services must join the RUNNING stack's project: {argv:?}"
+    );
+    assert!(
+        pairs_after(&argv, "-f").contains(&path.display().to_string()),
+        "{argv:?}"
+    );
+    assert!(argv.iter().any(|t| t == "--wait"), "{argv:?}");
+}
+
+// ─── Identity: one struct drives the alias and the runner scope (B1-11) ──────
+
+/// `--agent <override>` moves the alias AND the runner scope together.
+///
+/// `DeployOpts.agent` and `DeployOpts.target` can both override the manifest's
+/// name, and `object_name` is agent-scoped since #1116. A helper that
+/// re-derived the name from `plugin.json` would alias the connectors under the
+/// manifest identity while the runner dialed the override -- reachable at a
+/// name nothing answers to, with no error anywhere. Passing the RESOLVED
+/// identity in makes the divergence unrepresentable.
+#[test]
+fn an_agent_override_moves_the_alias_and_the_runner_scope_together() {
+    let dir = TempDir::new().expect("a scratch bundle");
+    let manifest_name = "sre-bot";
+    let override_name = "sre-bot-prod";
+
+    let overlay = overlay_fixture(override_name, dir.path());
+    let services = overlay["services"].as_object().expect("services");
+    assert!(
+        services.contains_key(&object_name("curie", override_name, "kubernetes")),
+        "the service is named for the OVERRIDE: {overlay}"
+    );
+    assert!(
+        !services.contains_key(&object_name("curie", manifest_name, "kubernetes")),
+        "the manifest name must not survive the override: {overlay}"
+    );
+
+    let alias = service_dns("curie", override_name, "kubernetes", "default");
+    let attachment = &services[&object_name("curie", override_name, "kubernetes")]["networks"];
+    assert!(
+        attachment.to_string().contains(&alias),
+        "{attachment} must alias {alias}"
+    );
+
+    let env: BTreeMap<String, String> = connector_scope_env(&scope(override_name))
+        .into_iter()
+        .collect();
+    assert_eq!(
+        env.get(env_keys::CURIE_CONNECTOR_AGENT),
+        Some(&override_name.to_string()),
+        "the runner scope must carry the same identity the alias was built from: {env:?}"
+    );
+    assert_eq!(
+        env.get(env_keys::CURIE_CONNECTOR_RELEASE),
+        Some(&"curie".to_string()),
+        "{env:?}"
+    );
+    assert_eq!(
+        env.get(env_keys::CURIE_CONNECTOR_NAMESPACE),
+        Some(&"default".to_string()),
+        "{env:?}"
+    );
+    assert_eq!(
+        env.len(),
+        3,
+        "the scope is all-or-nothing: a partial set is dropped entirely by the boot contract, \
+         so emitting two of three silently switches connectors off: {env:?}"
+    );
+}
+
+// ─── RunnerState records what boot created (block B1-6) ──────────────────────
+
+fn runner_state(dir: &Path) -> curie::state::RunnerState {
+    curie::state::RunnerState {
+        container_id: "abc123".to_string(),
+        container_name: "curie-runner-local".to_string(),
+        image: "curie-runner".to_string(),
+        port: 7245,
+        base_url: "http://127.0.0.1:7245".to_string(),
+        session_id: "curie-skill-abc123".to_string(),
+        plugin_dir: dir.display().to_string(),
+        fake_model: false,
+        ollama_container: None,
+        network: Some("curie-skill-net".to_string()),
+        model_base_url: None,
+        bundle_digest: None,
+        bundle_snapshot_dir: None,
+        connector_containers: vec!["conn-kubernetes".to_string(), "conn-k8s-write".to_string()],
+        connector_network: Some("curie-skill-net".to_string()),
+    }
+}
+
+/// `skill up` records the connector containers and the network so `skill down`
+/// reaps exactly what boot created.
+///
+/// Without the record, a run that dies mid-turn leaves labeled containers
+/// holding a resolved credential -- the failure class #747 already fixed once
+/// for the runner itself.
+#[test]
+fn runner_state_round_trips_the_connector_containers_and_network() {
+    let dir = TempDir::new().expect("a scratch bundle");
+    curie::state::save(dir.path(), &runner_state(dir.path())).expect("save the state");
+
+    let loaded = curie::state::load(dir.path())
+        .expect("load the state")
+        .expect("the state exists");
+    assert_eq!(
+        loaded.connector_containers,
+        vec!["conn-kubernetes".to_string(), "conn-k8s-write".to_string()]
+    );
+    assert_eq!(
+        loaded.connector_network,
+        Some("curie-skill-net".to_string())
+    );
+}
+
+/// A state file written before this change still loads.
+///
+/// `skill down` on a runner booted by the previous CLI must not fail to parse
+/// its own state file and orphan the runner it was asked to reap.
+#[test]
+fn a_state_file_predating_connectors_still_loads() {
+    let dir = TempDir::new().expect("a scratch bundle");
+    std::fs::create_dir_all(dir.path().join(".curie")).expect("mkdir .curie");
+    std::fs::write(
+        dir.path().join(".curie/runner.json"),
+        r#"{"container_id":"abc123","container_name":"curie-runner-local",
+            "image":"curie-runner","port":7245,"base_url":"http://127.0.0.1:7245",
+            "session_id":"s","plugin_dir":"/tmp/b","fake_model":false}"#,
+    )
+    .expect("write a legacy state file");
+
+    let loaded = curie::state::load(dir.path())
+        .expect("a legacy state file still parses")
+        .expect("the state exists");
+    assert!(loaded.connector_containers.is_empty());
+    assert_eq!(loaded.connector_network, None);
+}
+
+// ─── The packer ships the lock and never the overlay ─────────────────────────
+
+/// `connectors.lock.yaml` reaches the platform; `.curie/` does not.
+///
+/// Both halves matter. Without the lock the API cannot resolve the `build:`
+/// declaration and intake refuses the bundle. With the overlay, a resolved
+/// credential (staged under the same `.curie/`) would ride the upload into
+/// stored bundle bytes.
+///
+/// Listed through `tar` rather than a decoder because `flate2`/`tar` are
+/// library dependencies, not dev-dependencies, and this target must not add
+/// any.
+#[test]
+fn the_packed_bundle_carries_the_lock_and_no_runtime_state() {
+    let dir = TempDir::new().expect("a scratch bundle");
+    curie::scaffold::scaffold(dir.path(), "sre-bot").expect("scaffold a bundle");
+    std::fs::write(
+        dir.path().join("connectors.lock.yaml"),
+        "version: 1\nconnectors: {}\n",
+    )
+    .expect("write the lock");
+    std::fs::create_dir_all(dir.path().join(".curie")).expect("mkdir .curie");
+    std::fs::write(compose_overlay_path(dir.path()), "services: {}\n").expect("write the overlay");
+    stage_secret_file(dir.path(), "kubernetes", "/secrets/kubeconfig", "creds")
+        .expect("stage a credential");
+
+    let archive = dir.path().join("bundle.tar.gz");
+    std::fs::write(
+        &archive,
+        curie::bundle::pack_tar_gz(dir.path()).expect("pack the bundle"),
+    )
+    .expect("write the archive");
+
+    let listing = std::process::Command::new("tar")
+        .arg("-tzf")
+        .arg(&archive)
+        .output()
+        .expect("list the archive with tar");
+    assert!(listing.status.success(), "{listing:?}");
+    let names = String::from_utf8_lossy(&listing.stdout);
+
+    assert!(
+        names
+            .lines()
+            .any(|n| n.trim_start_matches("./") == "connectors.lock.yaml"),
+        "the lock must reach the platform or intake refuses the bundle: {names}"
+    );
+    assert!(
+        !names.contains(".curie"),
+        "runtime state, including a staged credential, must never enter the upload: {names}"
+    );
+}

--- a/cli/tests/connector_lock.rs
+++ b/cli/tests/connector_lock.rs
@@ -61,7 +61,7 @@ use std::path::{Path, PathBuf};
 
 use curie::commands::{
     lock_preflight, manifest_platforms, node_architectures, node_architectures_argv,
-    registry_manifest_argv, registry_preflight, DeployOpts, DeployTier,
+    registry_manifest_argv, registry_preflight, registry_preflight_targets, DeployOpts, DeployTier,
 };
 use curie::connector_build::{
     ConnectorBuildDecl, ConnectorLockEntryDecl, ConnectorLockFileDecl, ConnectorSpecDecl,
@@ -558,6 +558,49 @@ fn coverage_is_against_the_node_set_not_equality_with_the_declaration() {
         &["linux/amd64".to_string(), "linux/arm64".to_string()],
     )
     .expect("an amd64 image on an amd64-only cluster is fine");
+}
+
+/// Which connectors the cluster deploy actually asks the registry about.
+///
+/// The selection decides whether a deploy contacts a registry at all, so it is
+/// the seam that keeps every existing bundle untouched: an `image:` connector
+/// builds nothing, and a `local-daemon` build is not in any registry to be
+/// found (`lock_preflight` has already refused that one at this tier).
+#[test]
+fn only_registry_delivered_build_connectors_are_queried() {
+    assert!(
+        registry_preflight_targets(&declaring_a_build("tempo"), None).is_empty(),
+        "with no lock there is nothing to ask about; lock_preflight already refused this"
+    );
+    assert!(
+        registry_preflight_targets(
+            &declaring_an_image("kubernetes"),
+            Some(&lock_for("kubernetes", PUSHED, Delivery::Registry, FRESH)),
+        )
+        .is_empty(),
+        "an image: connector builds nothing, so no lock entry of its own is checked"
+    );
+    assert!(
+        registry_preflight_targets(
+            &declaring_a_build("tempo"),
+            Some(&lock_for("tempo", LOCAL_ID, Delivery::LocalDaemon, FRESH)),
+        )
+        .is_empty(),
+        "a local-daemon build is never in a registry to be found"
+    );
+
+    let pushed_lock = lock_for("tempo", PUSHED, Delivery::Registry, FRESH);
+    let targets = registry_preflight_targets(&declaring_a_build("tempo"), Some(&pushed_lock));
+    assert_eq!(targets.len(), 1, "{targets:?}");
+    assert_eq!(
+        targets[0].image, PUSHED,
+        "the digest-pinned reference is what gets queried"
+    );
+    assert_eq!(
+        targets[0].platforms,
+        vec!["linux/amd64".to_string(), "linux/arm64".to_string()],
+        "the declared platforms ride along for the refusal to name"
+    );
 }
 
 // ─── The preflight runs before the upload ────────────────────────────────────

--- a/cli/tests/connector_lock.rs
+++ b/cli/tests/connector_lock.rs
@@ -1,0 +1,593 @@
+//! RED contract for PR B / Stream B1: the deploy-time lock preflight.
+//!
+//! `curie local deploy` and `curie cluster deploy` share one `commands::deploy`,
+//! so both reach the same preflight and it discriminates on an explicit tier
+//! (block B1-10's `DeployOpts::tier`). The rules it enforces, per B1-7:
+//!
+//!   both tiers   -- a `build:` connector with no lock entry, or with a
+//!                   `source_digest` that no longer matches the tree, is
+//!                   refused naming `curie build --plugin-dir <dir>`;
+//!   cluster only -- a `delivery: local-daemon` lock is refused naming
+//!                   `--registry <ref>`. Intake deliberately accepts either
+//!                   delivery, because a local deploy legitimately uploads a
+//!                   local-daemon lock (review round 2, finding r2-3);
+//!   cluster only -- the REGISTRY is queried for the manifest the lock names,
+//!                   and the deploy is refused when the digest does not resolve
+//!                   (AC B6) or the resolved index does not cover every
+//!                   architecture the nodes report (AC B7).
+//!
+//! Purity. The decision functions take canned inputs -- a recomputed digest
+//! map, the raw `imagetools inspect --raw` body, the node architecture set --
+//! so no registry and no cluster is contacted here. What is asserted about the
+//! impure half is only the argv it would issue. That split is the same one
+//! `cli/CLAUDE.md:133-142` already requires of every operator verb.
+//!
+//! Exit class. All five refusals are `ExitClass::Usage` (exit 2). The operative
+//! clause is ADR-0021's own: "retrying the same argv will fail identically, so
+//! fix the input". A missing lock, a stale lock, a local-daemon lock at
+//! cluster, a deleted package and a single-arch index are all conditions no
+//! retry clears -- each needs the operator to do something first, and each
+//! carries the `fix` line that says what. Nothing here is Transient: none of
+//! them is an endpoint that might come back up.
+//!
+//! Surface the implementer must add to `curie::commands`:
+//!
+//! ```ignore
+//! #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+//! pub enum DeployTier { Local, Cluster }        // no Default impl, by design
+//!
+//! pub fn lock_preflight(
+//!     plugin_dir: &Path,
+//!     decl: &ConnectorsFileDecl,
+//!     lock: Option<&ConnectorLockFileDecl>,
+//!     recomputed: &BTreeMap<String, String>,   // connector -> source_digest
+//!     tier: DeployTier,
+//! ) -> anyhow::Result<()>;
+//!
+//! pub fn registry_manifest_argv(image: &str) -> curie::ops::OpsCommand;
+//! pub fn node_architectures_argv() -> curie::ops::OpsCommand;
+//! pub fn node_architectures(raw: &str) -> BTreeSet<String>;
+//! pub fn manifest_platforms(raw: &str) -> anyhow::Result<BTreeSet<String>>;
+//! pub fn registry_preflight(
+//!     image: &str,
+//!     inspect: Result<&str, String>,           // Ok(raw manifest) | Err(stderr)
+//!     node_architectures: &BTreeSet<String>,
+//!     declared_platforms: &[String],
+//! ) -> anyhow::Result<()>;
+//! ```
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+
+use curie::commands::{
+    lock_preflight, manifest_platforms, node_architectures, node_architectures_argv,
+    registry_manifest_argv, registry_preflight, DeployOpts, DeployTier,
+};
+use curie::connector_build::{
+    ConnectorBuildDecl, ConnectorLockEntryDecl, ConnectorLockFileDecl, ConnectorSpecDecl,
+    ConnectorsFileDecl, Delivery, LOCK_VERSION,
+};
+use curie::exit::{classify, error_json, ExitClass};
+
+const FRESH: &str = "sha256:3333333333333333333333333333333333333333333333333333333333333333";
+const STALE: &str = "sha256:9999999999999999999999999999999999999999999999999999999999999999";
+const PUSHED: &str = "ghcr.io/acme-corp/sre-bot-tempo@sha256:\
+                      2222222222222222222222222222222222222222222222222222222222222222";
+const LOCAL_ID: &str = "sha256:4444444444444444444444444444444444444444444444444444444444444444";
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+fn declaring_a_build(connector: &str) -> ConnectorsFileDecl {
+    let mut connectors = BTreeMap::new();
+    connectors.insert(
+        connector.to_string(),
+        ConnectorSpecDecl {
+            build: Some(ConnectorBuildDecl {
+                context: format!("connectors/{connector}"),
+                dockerfile: "Dockerfile".to_string(),
+                platforms: vec!["linux/amd64".into(), "linux/arm64".into()],
+            }),
+            ..Default::default()
+        },
+    );
+    ConnectorsFileDecl { connectors }
+}
+
+fn declaring_an_image(connector: &str) -> ConnectorsFileDecl {
+    let mut connectors = BTreeMap::new();
+    connectors.insert(
+        connector.to_string(),
+        ConnectorSpecDecl {
+            image: Some("ghcr.io/containers/kubernetes-mcp-server:v0.0.66".to_string()),
+            ..Default::default()
+        },
+    );
+    ConnectorsFileDecl { connectors }
+}
+
+fn lock_for(
+    connector: &str,
+    image: &str,
+    delivery: Delivery,
+    digest: &str,
+) -> ConnectorLockFileDecl {
+    let mut connectors = BTreeMap::new();
+    connectors.insert(
+        connector.to_string(),
+        ConnectorLockEntryDecl {
+            image: image.to_string(),
+            delivery,
+            platforms: vec!["linux/amd64".into(), "linux/arm64".into()],
+            source_digest: digest.to_string(),
+        },
+    );
+    ConnectorLockFileDecl {
+        version: LOCK_VERSION,
+        connectors,
+    }
+}
+
+fn recomputed(connector: &str, digest: &str) -> BTreeMap<String, String> {
+    BTreeMap::from([(connector.to_string(), digest.to_string())])
+}
+
+fn plugin_dir() -> PathBuf {
+    PathBuf::from("/home/operator/agents/sre-bot")
+}
+
+/// Every refusal is a Usage error carrying a non-empty `fix`, rendered into the
+/// `{"error","fix"}` body ADR-0021 freezes. Asserted through the real
+/// `exit::classify` / `exit::error_json`, not a hand-rolled reimplementation of
+/// them, so a refusal that forgot to tag itself as a `CliError` fails here.
+fn assert_actionable_usage_refusal(error: &anyhow::Error, must_name: &[&str]) {
+    let (class, fix) = classify(error);
+    assert_eq!(
+        class,
+        ExitClass::Usage,
+        "a lock refusal is a deterministic input error (exit 2): {error:#}"
+    );
+    let fix = fix.expect("every lock refusal names the command that clears it");
+
+    let json = error_json(error);
+    let body = json.as_object().expect("the error payload is an object");
+    assert!(body.contains_key("error"), "{json}");
+    assert!(body.contains_key("fix"), "{json}");
+    assert!(
+        !json["fix"].is_null(),
+        "a null fix leaves the operator with nowhere to go: {json}"
+    );
+
+    let haystack = format!("{}\n{}", json["error"], fix);
+    for needle in must_name {
+        assert!(
+            haystack.contains(needle),
+            "the refusal must name {needle:?}; got {haystack}"
+        );
+    }
+}
+
+// ─── Both tiers ──────────────────────────────────────────────────────────────
+
+/// A bundle with no `build:` connector never reaches any of this.
+///
+/// The overwhelmingly common bundle declares `image:` or nothing at all, and a
+/// preflight that fired for it would break every existing deploy.
+#[test]
+fn a_bundle_with_no_build_connectors_is_a_no_op_at_both_tiers() {
+    for tier in [DeployTier::Local, DeployTier::Cluster] {
+        lock_preflight(
+            &plugin_dir(),
+            &declaring_an_image("kubernetes"),
+            None,
+            &BTreeMap::new(),
+            tier,
+        )
+        .unwrap_or_else(|error| {
+            panic!("an image-only bundle must not be gated ({tier:?}): {error:#}")
+        });
+    }
+}
+
+/// A `build:` connector with no lock at all is refused, at BOTH tiers.
+///
+/// This is the CLI mirror of the platform's `connectors.lock_missing` intake
+/// rule (block A17). Without it the operator learns only after the upload, from
+/// a rejection whose message is about a file they were never told to make.
+#[test]
+fn a_build_connector_with_no_lock_is_refused_at_both_tiers() {
+    for tier in [DeployTier::Local, DeployTier::Cluster] {
+        let error = lock_preflight(
+            &plugin_dir(),
+            &declaring_a_build("tempo"),
+            None,
+            &recomputed("tempo", FRESH),
+            tier,
+        )
+        .expect_err("a lockless build bundle must be refused");
+        assert_actionable_usage_refusal(&error, &["tempo", "curie build --plugin-dir", "sre-bot"]);
+    }
+}
+
+/// A lock that exists but omits this connector is the same failure.
+///
+/// A whole-file existence check would pass here while the connector it needs
+/// has no resolved image at all -- the exact shape a partially-successful build
+/// leaves behind.
+#[test]
+fn a_lock_missing_this_connectors_entry_is_refused() {
+    let mut decl = declaring_a_build("tempo");
+    decl.connectors
+        .extend(declaring_a_build("k8s-write").connectors);
+
+    let error = lock_preflight(
+        &plugin_dir(),
+        &decl,
+        Some(&lock_for("tempo", PUSHED, Delivery::Registry, FRESH)),
+        &BTreeMap::from([
+            ("tempo".to_string(), FRESH.to_string()),
+            ("k8s-write".to_string(), FRESH.to_string()),
+        ]),
+        DeployTier::Cluster,
+    )
+    .expect_err("a lock covering only one of two build connectors must be refused");
+    assert_actionable_usage_refusal(&error, &["k8s-write", "curie build --plugin-dir"]);
+}
+
+/// A source edited since the lock was written is refused, at BOTH tiers.
+///
+/// The stale case is the one that would otherwise deploy: the image resolves,
+/// the pull succeeds, and the operator watches a container running code they
+/// changed an hour ago. The lock's recorded digest and the recomputed one are
+/// the only things that disagree.
+#[test]
+fn a_stale_source_digest_is_refused_at_both_tiers() {
+    for tier in [DeployTier::Local, DeployTier::Cluster] {
+        let error = lock_preflight(
+            &plugin_dir(),
+            &declaring_a_build("tempo"),
+            Some(&lock_for("tempo", PUSHED, Delivery::Registry, STALE)),
+            &recomputed("tempo", FRESH),
+            tier,
+        )
+        .expect_err("a stale lock must be refused");
+        assert_actionable_usage_refusal(&error, &["tempo", "curie build --plugin-dir"]);
+    }
+}
+
+/// A fresh registry lock passes at both tiers. The gate has an open state.
+#[test]
+fn a_fresh_registry_lock_passes_at_both_tiers() {
+    for tier in [DeployTier::Local, DeployTier::Cluster] {
+        lock_preflight(
+            &plugin_dir(),
+            &declaring_a_build("tempo"),
+            Some(&lock_for("tempo", PUSHED, Delivery::Registry, FRESH)),
+            &recomputed("tempo", FRESH),
+            tier,
+        )
+        .unwrap_or_else(|error| panic!("a fresh registry lock must deploy ({tier:?}): {error:#}"));
+    }
+}
+
+// ─── Cluster only: the delivery rule ─────────────────────────────────────────
+
+/// A `local-daemon` lock deploys locally and is refused at cluster.
+///
+/// One test, both halves, because the pair IS the property (AC B11): a rule
+/// stated only as "cluster refuses" would pass just as well if local refused
+/// too, and that variant breaks the fast path this whole delivery mode exists
+/// for. Cluster nodes cannot see the operator's Docker daemon; a local run
+/// legitimately can.
+#[test]
+fn a_local_daemon_lock_deploys_locally_and_is_refused_at_cluster() {
+    let decl = declaring_a_build("tempo");
+    let lock = lock_for("tempo", LOCAL_ID, Delivery::LocalDaemon, FRESH);
+
+    lock_preflight(
+        &plugin_dir(),
+        &decl,
+        Some(&lock),
+        &recomputed("tempo", FRESH),
+        DeployTier::Local,
+    )
+    .expect("a local-daemon lock is exactly what `curie local deploy` is for");
+
+    let error = lock_preflight(
+        &plugin_dir(),
+        &decl,
+        Some(&lock),
+        &recomputed("tempo", FRESH),
+        DeployTier::Cluster,
+    )
+    .expect_err("a cluster node cannot pull from the operator's local daemon");
+    assert_actionable_usage_refusal(&error, &["tempo", "--registry"]);
+}
+
+/// The tier is a required field with no default, so a new deploy caller cannot
+/// silently inherit `Local` and skip every cluster-only check (block B1-10).
+///
+/// The compiler is the real enforcement -- adding the field without a `Default`
+/// impl makes it enumerate all three call sites. This test pins that the field
+/// exists, is public, and that the two variants are distinguishable, so the
+/// discrimination above has something to discriminate on.
+#[test]
+fn deploy_opts_carries_an_explicit_tier() {
+    let opts = DeployOpts {
+        agent: None,
+        target: None,
+        plugin_dir: plugin_dir(),
+        api_url: "http://127.0.0.1:8000".to_string(),
+        api_key: "curie-dev-key".to_string(),
+        slack_channel: None,
+        repo: None,
+        env: None,
+        label: None,
+        secret: Vec::new(),
+        secret_binding_supported: false,
+        connect_hint: "run `curie cluster up` first".to_string(),
+        tier: DeployTier::Cluster,
+    };
+    assert_eq!(opts.tier, DeployTier::Cluster);
+    assert_ne!(
+        DeployTier::Cluster,
+        DeployTier::Local,
+        "the two tiers must be distinguishable, or the cluster-only checks select on nothing"
+    );
+}
+
+// ─── Cluster only: the registry query (AC B6, AC B7) ─────────────────────────
+
+/// An OCI image index, the shape a multi-platform `buildx --push` produces.
+/// Spec: <https://github.com/opencontainers/image-spec/blob/main/image-index.md>
+fn index_covering(platforms: &[(&str, &str)]) -> String {
+    let manifests: Vec<String> = platforms
+        .iter()
+        .map(|(os, arch)| {
+            format!(
+                r#"{{"mediaType":"application/vnd.oci.image.manifest.v1+json",
+                     "digest":"sha256:0000000000000000000000000000000000000000000000000000000000000000",
+                     "size":1234,
+                     "platform":{{"architecture":"{arch}","os":"{os}"}}}}"#
+            )
+        })
+        .collect();
+    format!(
+        r#"{{"schemaVersion":2,
+            "mediaType":"application/vnd.oci.image.index.v1+json",
+            "manifests":[{}]}}"#,
+        manifests.join(",")
+    )
+}
+
+/// A single-platform image manifest: what a `docker build && docker push`
+/// produces, with no `manifests` array at all.
+/// Spec: <https://github.com/opencontainers/image-spec/blob/main/manifest.md>
+fn single_platform_manifest() -> String {
+    r#"{"schemaVersion":2,
+        "mediaType":"application/vnd.oci.image.manifest.v1+json",
+        "config":{"mediaType":"application/vnd.oci.image.config.v1+json",
+                  "digest":"sha256:0000000000000000000000000000000000000000000000000000000000000000",
+                  "size":42},
+        "layers":[]}"#
+        .to_string()
+}
+
+/// The preflight asks the REGISTRY, by digest, for the raw manifest.
+///
+/// `--raw` matters: without it `imagetools inspect` pretty-prints and a parser
+/// reading that output is reading a presentation format that has changed before.
+#[test]
+fn the_registry_is_queried_by_digest_for_the_raw_manifest() {
+    let command = registry_manifest_argv(PUSHED);
+    assert_eq!(command.program, "docker");
+    let argv = command.argv();
+    assert_eq!(
+        &argv[..3],
+        &[
+            "buildx".to_string(),
+            "imagetools".to_string(),
+            "inspect".to_string()
+        ],
+        "{argv:?}"
+    );
+    assert!(argv.iter().any(|t| t == PUSHED), "{argv:?}");
+    assert!(argv.iter().any(|t| t == "--raw"), "{argv:?}");
+    assert!(
+        argv.iter().any(|t| t.contains("@sha256:")),
+        "the query is by DIGEST, not by tag; a tag can move between the check and the pull: \
+         {argv:?}"
+    );
+}
+
+/// The node architecture set comes from the cluster, not from the lock.
+#[test]
+fn the_node_architectures_are_read_from_the_cluster() {
+    let command = node_architectures_argv();
+    assert_eq!(command.program, "kubectl");
+    let argv = command.argv();
+    assert!(argv.iter().any(|t| t == "nodes"), "{argv:?}");
+    assert!(
+        argv.iter()
+            .any(|t| t.contains("status.nodeInfo.architecture")),
+        "{argv:?}"
+    );
+
+    assert_eq!(
+        node_architectures("amd64 arm64 amd64"),
+        BTreeSet::from(["amd64".to_string(), "arm64".to_string()]),
+        "jsonpath emits one space-separated word per node; duplicates are the common case"
+    );
+    assert!(
+        node_architectures("   ").is_empty(),
+        "whitespace must not become an architecture named \"\""
+    );
+}
+
+/// The resolved index's platform set is read from the registry's own answer.
+#[test]
+fn the_platform_set_is_parsed_out_of_the_resolved_index() {
+    let platforms = manifest_platforms(&index_covering(&[("linux", "amd64"), ("linux", "arm64")]))
+        .expect("an index parses");
+    assert_eq!(
+        platforms,
+        BTreeSet::from(["linux/amd64".to_string(), "linux/arm64".to_string()])
+    );
+
+    let single = manifest_platforms(&single_platform_manifest()).expect("a single manifest parses");
+    assert!(
+        single.len() <= 1,
+        "a plain image manifest is at most one platform, never the declared set: {single:?}"
+    );
+}
+
+/// buildx's attestation manifests are `unknown/unknown` and must not be read as
+/// a platform the image covers, nor treated as a defect.
+///
+/// A real multi-arch `buildx --push` emits them alongside the real entries by
+/// default. A parser that choked on them, or that reported `unknown/unknown` as
+/// coverage, would fail (or pass) every genuine multi-arch push.
+/// See <https://docs.docker.com/build/metadata/attestations/>.
+#[test]
+fn attestation_manifests_are_not_platforms() {
+    let raw = index_covering(&[
+        ("linux", "amd64"),
+        ("linux", "arm64"),
+        ("unknown", "unknown"),
+        ("unknown", "unknown"),
+    ]);
+    let platforms = manifest_platforms(&raw).expect("an attested index parses");
+    assert_eq!(
+        platforms,
+        BTreeSet::from(["linux/amd64".to_string(), "linux/arm64".to_string()]),
+        "unknown/unknown is an attestation, not an architecture"
+    );
+
+    registry_preflight(
+        PUSHED,
+        Ok(&raw),
+        &BTreeSet::from(["amd64".to_string(), "arm64".to_string()]),
+        &["linux/amd64".to_string(), "linux/arm64".to_string()],
+    )
+    .expect("an attested multi-arch push must deploy");
+}
+
+/// AC B6: a digest that does not resolve stops the deploy.
+///
+/// The falsifiable negative for this is the test above it: the same command
+/// with the artifact present succeeds. Implemented against the registry, not
+/// against the lock's declaration -- a declaration-only check would pass this
+/// with the package deleted, which is the failure it exists to catch.
+#[test]
+fn an_unresolvable_digest_is_refused_before_anything_is_applied() {
+    let error = registry_preflight(
+        PUSHED,
+        Err("ERROR: failed to resolve reference: manifest unknown".to_string()),
+        &BTreeSet::from(["amd64".to_string()]),
+        &["linux/amd64".to_string(), "linux/arm64".to_string()],
+    )
+    .expect_err("a deleted package must stop the deploy");
+
+    assert_actionable_usage_refusal(
+        &error,
+        &[
+            "2222222222222222222222222222222222222222222222222222222222222222",
+            "curie build --plugin-dir",
+        ],
+    );
+}
+
+/// AC B7: the resolved index must cover every architecture the nodes report.
+///
+/// The refusal names BOTH sets. "Architecture mismatch" alone leaves the
+/// operator guessing which side to change; naming the registry's set and the
+/// node set makes the next action obvious.
+#[test]
+fn an_index_that_does_not_cover_every_node_architecture_is_refused() {
+    let error = registry_preflight(
+        PUSHED,
+        Ok(&index_covering(&[("linux", "amd64")])),
+        &BTreeSet::from(["amd64".to_string(), "arm64".to_string()]),
+        &["linux/amd64".to_string(), "linux/arm64".to_string()],
+    )
+    .expect_err("an amd64-only index cannot run on an arm64 node");
+
+    assert_actionable_usage_refusal(&error, &["linux/amd64", "arm64"]);
+}
+
+/// The comparison reads the REGISTRY, never the lock's declaration.
+///
+/// The second independent path AC B7 names: the lock still declares both
+/// platforms while the push went out single-arch. A preflight comparing node
+/// architectures against `lock.platforms` passes this and the failure resurfaces
+/// after apply as `no matching manifest for linux/arm64`.
+#[test]
+fn a_lock_declaring_two_platforms_does_not_excuse_a_single_arch_push() {
+    let declared = ["linux/amd64".to_string(), "linux/arm64".to_string()];
+
+    registry_preflight(
+        PUSHED,
+        Ok(&index_covering(&[("linux", "amd64"), ("linux", "arm64")])),
+        &BTreeSet::from(["amd64".to_string(), "arm64".to_string()]),
+        &declared,
+    )
+    .expect("a genuinely multi-arch push deploys");
+
+    assert!(
+        registry_preflight(
+            PUSHED,
+            Ok(&single_platform_manifest()),
+            &BTreeSet::from(["amd64".to_string(), "arm64".to_string()]),
+            &declared,
+        )
+        .is_err(),
+        "the lock's declared platforms must not be able to vouch for what was actually pushed"
+    );
+}
+
+/// A single-node amd64 cluster is covered by an amd64-only image.
+///
+/// The gate is coverage of the node set, not equality with the declared set:
+/// otherwise every homogeneous cluster would be refused for an image that runs
+/// on it perfectly well.
+#[test]
+fn coverage_is_against_the_node_set_not_equality_with_the_declaration() {
+    registry_preflight(
+        PUSHED,
+        Ok(&index_covering(&[("linux", "amd64")])),
+        &BTreeSet::from(["amd64".to_string()]),
+        &["linux/amd64".to_string(), "linux/arm64".to_string()],
+    )
+    .expect("an amd64 image on an amd64-only cluster is fine");
+}
+
+// ─── The preflight runs before the upload ────────────────────────────────────
+
+/// The refusal names the bundle directory it wants rebuilt, not a temp path.
+///
+/// `curie build --plugin-dir /tmp/.tmpXYZ` is a command the operator cannot
+/// run; the fix line has to point at the directory they actually have. Guards
+/// the case where the preflight is moved after the pack and starts describing
+/// the extracted copy.
+#[test]
+fn the_fix_line_names_the_operators_own_bundle_directory() {
+    let dir = Path::new("/home/operator/agents/sre-bot");
+    let error = lock_preflight(
+        dir,
+        &declaring_a_build("tempo"),
+        None,
+        &recomputed("tempo", FRESH),
+        DeployTier::Cluster,
+    )
+    .expect_err("a lockless bundle is refused");
+
+    let (_class, fix) = classify(&error);
+    let fix = fix.expect("a fix line");
+    assert!(
+        fix.contains("/home/operator/agents/sre-bot"),
+        "the fix must be runnable as written: {fix}"
+    );
+    assert!(
+        !fix.contains("/tmp/"),
+        "a temp path means the preflight ran after the pack: {fix}"
+    );
+}

--- a/cli/tests/connector_selection.rs
+++ b/cli/tests/connector_selection.rs
@@ -1,0 +1,418 @@
+//! Which image a connector runs, and which containers a redeploy removes.
+//!
+//! Two defects, one seam each, both pinned here without a Docker daemon.
+//!
+//! **Selection.** `connectors.lock.yaml` records what a declared `build:`
+//! resolved to, so under ADR 0113 it is the identity of a `build:` connector and
+//! of nothing else. Both emitters -- the skill tier's `docker run` and the local
+//! tier's compose overlay -- used to consult the lock FIRST, unconditionally, so
+//! a connector whose declaration had since switched from `build:` to `image:`
+//! silently kept running the last source build while its author read the image
+//! they had declared. `connector_build::resolved_image` is now the one rule and
+//! both emitters route through it; the Python cluster render already gated on
+//! the same condition (`connector_lock.apply_lock`: `if spec.build is None`).
+//!
+//! **Reconcile.** `local deploy` only ever ADDED services: compose starts what
+//! the overlay names and leaves everything else alone, so a connector a new
+//! bundle version dropped or renamed kept serving the runner an endpoint the
+//! bundle no longer declares. The reap that fixes it is the scope decision, and
+//! the scope is the whole risk -- the local tier shares ONE compose project
+//! (`curie`) with the api/worker stack and with every other locally deployed
+//! agent, so `--remove-orphans` would remove the platform and a project-label
+//! sweep would remove another agent's connectors. The containers are therefore
+//! labeled with their agent and their object name at creation, in both emitters,
+//! and the reap selects on all three labels and then removes only what the new
+//! desired set does not name.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use curie::commands::skill_connector_plan;
+use curie::connector_build::{
+    compose_overlay, object_name, resolved_image, ConnectorBuildDecl, ConnectorLockEntryDecl,
+    ConnectorLockFileDecl, ConnectorScope, ConnectorSpecDecl, ConnectorsFileDecl, Delivery,
+    LOCK_VERSION,
+};
+use curie::docker::{
+    agent_connectors_argv, connector_identity_labels, connector_project_label, connectors_to_reap,
+    parse_agent_connectors, ConnectorStartSpec, RunningConnector, CONNECTOR_AGENT_LABEL_KEY,
+    CONNECTOR_COMPONENT_LABEL, CONNECTOR_OBJECT_LABEL_KEY,
+};
+use curie::exit::{classify, ExitClass};
+use tempfile::TempDir;
+
+/// What the author declares TODAY.
+const DECLARED_IMAGE: &str = "ghcr.io/acme-corp/sre-bot-tempo:v2";
+/// What a build recorded in the lock BEFORE the declaration changed.
+const LOCKED_IMAGE: &str = "ghcr.io/acme-corp/sre-bot-tempo@sha256:\
+                            2222222222222222222222222222222222222222222222222222222222222222";
+
+const AGENT: &str = "sre-bot";
+const RELEASE: &str = "curie";
+const PROJECT: &str = "curie";
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+fn scope() -> ConnectorScope {
+    ConnectorScope {
+        release: RELEASE.to_string(),
+        agent: AGENT.to_string(),
+        namespace: "default".to_string(),
+    }
+}
+
+fn image_spec() -> ConnectorSpecDecl {
+    ConnectorSpecDecl {
+        image: Some(DECLARED_IMAGE.to_string()),
+        ..Default::default()
+    }
+}
+
+fn build_spec() -> ConnectorSpecDecl {
+    ConnectorSpecDecl {
+        build: Some(ConnectorBuildDecl {
+            context: "connectors/tempo".to_string(),
+            dockerfile: "Dockerfile".to_string(),
+            platforms: vec!["linux/amd64".to_string()],
+        }),
+        ..Default::default()
+    }
+}
+
+/// A lock entry for `connector`, as `curie build` writes one.
+fn lock_for(connector: &str) -> ConnectorLockFileDecl {
+    ConnectorLockFileDecl {
+        version: LOCK_VERSION,
+        connectors: BTreeMap::from([(
+            connector.to_string(),
+            ConnectorLockEntryDecl {
+                image: LOCKED_IMAGE.to_string(),
+                delivery: Delivery::Registry,
+                platforms: vec!["linux/amd64".to_string()],
+                source_digest: "sha256:\
+                                3333333333333333333333333333333333333333333333333333333333333333"
+                    .to_string(),
+            },
+        )]),
+    }
+}
+
+fn empty_lock() -> ConnectorLockFileDecl {
+    ConnectorLockFileDecl {
+        version: LOCK_VERSION,
+        connectors: BTreeMap::new(),
+    }
+}
+
+fn declaring(connector: &str, spec: ConnectorSpecDecl) -> ConnectorsFileDecl {
+    ConnectorsFileDecl {
+        connectors: BTreeMap::from([(connector.to_string(), spec)]),
+    }
+}
+
+// ─── The shared selection rule ───────────────────────────────────────────────
+
+/// The defect: a lock entry outliving the `build:` that produced it.
+///
+/// The declaration is the author's statement of what to run. A lock entry left
+/// behind by an earlier `build:` form of the same connector is stale by
+/// construction -- nothing rebuilds it, nothing invalidates it, and consulting
+/// it first means the bundle runs an image no one reading `connectors.yaml` can
+/// see.
+#[test]
+fn a_stale_lock_entry_never_hijacks_an_image_connector() {
+    let image = resolved_image("tempo", &image_spec(), &lock_for("tempo"))
+        .expect("an `image:` connector always has an image");
+    assert_eq!(
+        image, DECLARED_IMAGE,
+        "the declared image wins over a lock entry no current `build:` produced"
+    );
+}
+
+/// The other half of the rule, and the reason it is not simply "ignore the
+/// lock": a `build:` connector has no image of its own to run.
+#[test]
+fn a_build_connector_resolves_to_its_locked_image() {
+    let image = resolved_image("tempo", &build_spec(), &lock_for("tempo"))
+        .expect("a locked `build:` connector resolves");
+    assert_eq!(image, LOCKED_IMAGE);
+}
+
+/// Unchanged behavior, restated so the gate above cannot be "fixed" by
+/// dropping the lock consultation altogether.
+#[test]
+fn a_build_connector_with_no_lock_entry_names_curie_build() {
+    let error = resolved_image("tempo", &build_spec(), &empty_lock())
+        .expect_err("an unbuilt `build:` connector has nothing to run");
+    let (class, _fix) = classify(&error);
+    assert_eq!(
+        class,
+        ExitClass::Usage,
+        "no retry of the same argv clears an unbuilt connector: {error:#}"
+    );
+    let text = format!("{error:#}");
+    assert!(
+        text.contains("curie build"),
+        "the refusal must name the command that clears it: {text}"
+    );
+    assert!(text.contains("tempo"), "{text}");
+}
+
+// ─── Both emitters route through it ──────────────────────────────────────────
+
+/// The local tier. The overlay IS the local tier's image decision: whatever it
+/// writes into `image:` is what compose starts.
+#[test]
+fn the_local_overlay_starts_the_declared_image_despite_a_stale_lock_entry() {
+    let dir = TempDir::new().expect("tempdir");
+    let overlay = compose_overlay(
+        &lock_for("tempo"),
+        &declaring("tempo", image_spec()),
+        &scope(),
+        PROJECT,
+        dir.path(),
+    )
+    .expect("the overlay renders");
+    let service = &overlay["services"][object_name(RELEASE, AGENT, "tempo")];
+    assert_eq!(service["image"], DECLARED_IMAGE, "{overlay}");
+}
+
+/// A `build:` connector's overlay still carries the locked digest, so the fix
+/// above did not cost the source-build path its image.
+#[test]
+fn the_local_overlay_starts_the_locked_image_for_a_build_connector() {
+    let dir = TempDir::new().expect("tempdir");
+    let overlay = compose_overlay(
+        &lock_for("tempo"),
+        &declaring("tempo", build_spec()),
+        &scope(),
+        PROJECT,
+        dir.path(),
+    )
+    .expect("the overlay renders");
+    let service = &overlay["services"][object_name(RELEASE, AGENT, "tempo")];
+    assert_eq!(service["image"], LOCKED_IMAGE, "{overlay}");
+}
+
+/// The skill tier. `skill_connector_plan` is what `start_skill_connectors`
+/// iterates, and it hands each container its image -- the starter computes none
+/// of its own, so the inline lock-first copy this replaces cannot come back
+/// without deleting this call.
+#[test]
+fn the_skill_plan_starts_the_declared_image_despite_a_stale_lock_entry() {
+    let plan = skill_connector_plan(&declaring("tempo", image_spec()), &lock_for("tempo"))
+        .expect("the plan resolves");
+    assert_eq!(
+        plan,
+        vec![("tempo".to_string(), DECLARED_IMAGE.to_string())]
+    );
+}
+
+#[test]
+fn the_skill_plan_starts_the_locked_image_for_a_build_connector() {
+    let plan = skill_connector_plan(&declaring("tempo", build_spec()), &lock_for("tempo"))
+        .expect("the plan resolves");
+    assert_eq!(plan, vec![("tempo".to_string(), LOCKED_IMAGE.to_string())]);
+}
+
+/// Refused whole, before the first container starts, rather than half-started.
+#[test]
+fn the_skill_plan_refuses_a_build_connector_with_no_lock_entry() {
+    let mut decl = declaring("tempo", build_spec());
+    decl.connectors
+        .insert("kubernetes".to_string(), image_spec());
+    let error = skill_connector_plan(&decl, &empty_lock())
+        .expect_err("an unbuilt `build:` connector refuses the boot");
+    let (class, _fix) = classify(&error);
+    assert_eq!(class, ExitClass::Usage, "{error:#}");
+    assert!(format!("{error:#}").contains("curie build"), "{error:#}");
+}
+
+/// A connector Curie does not host has no image to resolve, and demanding one
+/// would refuse a bundle that works.
+#[test]
+fn the_skill_plan_skips_a_connector_curie_does_not_host() {
+    let remote = ConnectorSpecDecl {
+        url: Some("https://mcp.example.com/mcp".to_string()),
+        ..Default::default()
+    };
+    let plan =
+        skill_connector_plan(&declaring("remote", remote), &empty_lock()).expect("nothing to run");
+    assert!(plan.is_empty(), "{plan:?}");
+}
+
+// ─── The identity labels both emitters write ─────────────────────────────────
+
+/// Teardown resolves containers by label, never by a generated file, so a
+/// container that is not labeled at creation can never be reconciled. Both
+/// emitters, one pair of labels.
+#[test]
+fn both_emitters_label_a_connector_with_its_agent_and_object_name() {
+    let dir = TempDir::new().expect("tempdir");
+    let object = object_name(RELEASE, AGENT, "tempo");
+
+    let argv = ConnectorStartSpec::from_declaration(
+        "tempo",
+        &image_spec(),
+        DECLARED_IMAGE,
+        &scope(),
+        "curie-skill-net",
+        "curie-skill-abc123",
+        dir.path(),
+        &BTreeMap::new(),
+    )
+    .expect("the start spec renders")
+    .run_args();
+    let labels: Vec<String> = argv
+        .windows(2)
+        .filter(|w| w[0] == "--label")
+        .map(|w| w[1].clone())
+        .collect();
+    assert!(
+        labels.contains(&format!("{CONNECTOR_AGENT_LABEL_KEY}={AGENT}")),
+        "{labels:?}"
+    );
+    assert!(
+        labels.contains(&format!("{CONNECTOR_OBJECT_LABEL_KEY}={object}")),
+        "{labels:?}"
+    );
+
+    let overlay = compose_overlay(
+        &empty_lock(),
+        &declaring("tempo", image_spec()),
+        &scope(),
+        PROJECT,
+        dir.path(),
+    )
+    .expect("the overlay renders");
+    let service_labels = &overlay["services"][&object]["labels"];
+    assert_eq!(
+        service_labels[CONNECTOR_AGENT_LABEL_KEY], AGENT,
+        "{overlay}"
+    );
+    assert_eq!(
+        service_labels[CONNECTOR_OBJECT_LABEL_KEY], object,
+        "{overlay}"
+    );
+}
+
+// ─── The reap's scope ────────────────────────────────────────────────────────
+
+/// The selector is the safety property. All three filters, and nothing that
+/// reaches beyond them: this compose project also holds the api/worker stack
+/// and every other locally deployed agent's connectors.
+#[test]
+fn the_reap_selects_one_agents_connectors_in_a_shared_compose_project() {
+    let argv = agent_connectors_argv(PROJECT, AGENT);
+    let joined = argv.join(" ");
+    assert!(
+        argv.contains(&format!("label={CONNECTOR_COMPONENT_LABEL}")),
+        "without the component filter the reap can see the api/worker stack: {joined}"
+    );
+    assert!(
+        argv.contains(&format!("label={}", connector_project_label(PROJECT))),
+        "{joined}"
+    );
+    assert!(
+        argv.contains(&format!("label={CONNECTOR_AGENT_LABEL_KEY}={AGENT}")),
+        "without the agent filter the reap can see another agent's connectors: {joined}"
+    );
+    assert!(
+        !joined.contains("--remove-orphans"),
+        "--remove-orphans in this project removes the platform itself: {joined}"
+    );
+    assert!(
+        joined.contains(CONNECTOR_OBJECT_LABEL_KEY),
+        "the listing must report the object name the desired set is compared against: {joined}"
+    );
+}
+
+/// The selector and the emitters must agree on the label, or the reap silently
+/// selects nothing and every dropped connector leaks.
+#[test]
+fn the_reap_filters_on_the_label_the_emitters_write() {
+    let written = connector_identity_labels(AGENT, "ignored");
+    let (key, value) = &written[0];
+    assert!(
+        agent_connectors_argv(PROJECT, AGENT).contains(&format!("label={key}={value}")),
+        "{written:?}"
+    );
+}
+
+/// The decision itself: dropped connectors go, declared ones stay.
+#[test]
+fn a_redeploy_removes_only_the_connectors_the_bundle_dropped() {
+    let running = vec![
+        RunningConnector {
+            id: "aaa".to_string(),
+            object: object_name(RELEASE, AGENT, "tempo"),
+        },
+        RunningConnector {
+            id: "bbb".to_string(),
+            object: object_name(RELEASE, AGENT, "kubernetes"),
+        },
+    ];
+    let desired = BTreeSet::from([object_name(RELEASE, AGENT, "tempo")]);
+    assert_eq!(
+        connectors_to_reap(&running, &desired),
+        vec!["bbb".to_string()],
+        "the connector the new bundle still declares must keep running"
+    );
+}
+
+/// The zero case, which is the one the early return used to skip entirely.
+#[test]
+fn a_redeploy_to_zero_connectors_removes_every_one_of_this_agents() {
+    let running = vec![
+        RunningConnector {
+            id: "aaa".to_string(),
+            object: object_name(RELEASE, AGENT, "tempo"),
+        },
+        RunningConnector {
+            id: "bbb".to_string(),
+            object: object_name(RELEASE, AGENT, "kubernetes"),
+        },
+    ];
+    assert_eq!(
+        connectors_to_reap(&running, &BTreeSet::new()),
+        vec!["aaa".to_string(), "bbb".to_string()]
+    );
+}
+
+/// An unchanged redeploy removes nothing, so a `local deploy` that changed no
+/// connector does not restart them.
+#[test]
+fn an_unchanged_redeploy_removes_nothing() {
+    let running = vec![RunningConnector {
+        id: "aaa".to_string(),
+        object: object_name(RELEASE, AGENT, "tempo"),
+    }];
+    let desired = BTreeSet::from([object_name(RELEASE, AGENT, "tempo")]);
+    assert!(connectors_to_reap(&running, &desired).is_empty());
+}
+
+/// The listing's shape, including a container an older CLI started before the
+/// object label existed: it matches no desired name and is removed, and the
+/// bring-up that follows recreates it labeled if the bundle still declares it.
+#[test]
+fn a_container_with_no_object_label_is_listed_and_reaped() {
+    let object = object_name(RELEASE, AGENT, "tempo");
+    let listing = format!("aaa\t{object}\nbbb\t\n");
+    let running = parse_agent_connectors(&listing);
+    assert_eq!(
+        running,
+        vec![
+            RunningConnector {
+                id: "aaa".to_string(),
+                object: object.clone(),
+            },
+            RunningConnector {
+                id: "bbb".to_string(),
+                object: String::new(),
+            },
+        ]
+    );
+    assert_eq!(
+        connectors_to_reap(&running, &BTreeSet::from([object])),
+        vec!["bbb".to_string()]
+    );
+}

--- a/cli/tests/fake_tier_plumbing.rs
+++ b/cli/tests/fake_tier_plumbing.rs
@@ -115,6 +115,8 @@ fn record_runner(bundle: &Path, base_url: &str, fake_model: bool) {
             model_base_url: None,
             bundle_digest: None,
             bundle_snapshot_dir: None,
+            connector_containers: Vec::new(),
+            connector_network: None,
         },
     )
     .expect("record runner state");

--- a/cli/tests/json_contract.rs
+++ b/cli/tests/json_contract.rs
@@ -840,9 +840,10 @@ fn eval_schema_gate_has_teeth() {
 use curie::api::{ApprovalRecord, MemoryEntry, Version};
 use curie::commands::{
     ApprovalsOutput, BudgetOutput, BumpVersionOutput, ChartCheckOutcome, ChartCheckOutput,
-    CheckMatch, CheckReport, DeclaredServer, DeleteOutput, DeployOutput, KillOutput,
-    ListAgentsOutput, LocalAgentSummary, MemoryOutput, ResetThreadOutput, ResumeOutput,
-    SkillApprovalsOutput, SkillMessageOutput, SweepRow, VersionsOutput,
+    CheckMatch, CheckReport, ConnectorBuildOutput, ConnectorBuildRecord, DeclaredServer,
+    DeleteOutput, DeployOutput, KillOutput, ListAgentsOutput, LocalAgentSummary, MemoryOutput,
+    ResetThreadOutput, ResumeOutput, SkillApprovalsOutput, SkillMessageOutput, SweepRow,
+    VersionsOutput,
 };
 use curie::comms::CommsOutput;
 use curie::local::{
@@ -1776,6 +1777,24 @@ fn cluster_down_output_validates_all_variants() {
         lines: vec!["helm uninstall".to_string()],
     });
     assert_valid("cluster-down.schema.json", &dry.to_json());
+}
+
+#[test]
+fn connector_build_output_validates_empty_and_populated() {
+    // Empty is a real emission, not an accident: `curie build` on a bundle
+    // declaring nothing to build still prints one object (#485).
+    let empty = ConnectorBuildOutput { connectors: vec![] };
+    assert_valid("build.schema.json", &empty.to_json());
+    let built = ConnectorBuildOutput {
+        connectors: vec![ConnectorBuildRecord {
+            name: "tempo".to_string(),
+            image: format!("ghcr.io/acme-corp/tempo@sha256:{}", "a".repeat(64)),
+            delivery: curie::connector_build::Delivery::Registry,
+            platforms: vec!["linux/amd64".to_string(), "linux/arm64".to_string()],
+            source_digest: "b".repeat(64),
+        }],
+    };
+    assert_valid("build.schema.json", &built.to_json());
 }
 
 #[test]

--- a/cli/tests/nightly_graded_ladder.rs
+++ b/cli/tests/nightly_graded_ladder.rs
@@ -601,6 +601,14 @@ json.dump(d, open(p, "w"))' "$(cat "$STUB_STATE/last_plugin_dir")/evals/cases.js
         echo "stub: runner up"
         echo "  Model    fake (offline, no credential)"
         ;;
+    "skill up --fake-model --plugin-dir "*"/bundle-hermetic --name curie-ladder-hermetic-"*)
+        # The hermetic negative (ADR 0113): a scratch bundle declaring no
+        # hosted connector boots cleanly. Must sit ABOVE the #747 arm, whose
+        # pattern also matches this argv; the case then reads the session off
+        # `docker inspect` and sweeps for connector containers, both answered
+        # by the docker stub below.
+        echo "stub: hermetic runner up"
+        ;;
     "skill up --fake-model --plugin-dir "*" --name "*)
         # The #747 leftover-runner case: a taken container name must be a usage
         # refusal (exit 2) carrying the operator's own remedy, never docker's raw
@@ -717,6 +725,12 @@ case "$*" in
         # other inspect shapes retain their existing configured behavior.
         echo "stub docker: no such object: curie-runner-local" >&2
         exit 1
+        ;;
+    "inspect curie-ladder-hermetic-"*)
+        # The hermetic negative's session read: assert_no_connector_containers
+        # refuses an empty project scope by design, so the runner env must
+        # carry a session id for the sweep to be non-vacuous.
+        echo "CURIE_SESSION_ID=local-stub-hermetic"
         ;;
     "inspect "*)
         # A failed env read, on its own knob: an inspect that dies (the worker

--- a/cli/tests/skill_bundle_snapshot.rs
+++ b/cli/tests/skill_bundle_snapshot.rs
@@ -60,6 +60,8 @@ fn recorded_runner(base_url: &str, dir: &Path) -> RunnerState {
         model_base_url: None,
         bundle_digest: None,
         bundle_snapshot_dir: None,
+        connector_containers: Vec::new(),
+        connector_network: None,
     }
 }
 

--- a/cli/tests/skill_up_replace.rs
+++ b/cli/tests/skill_up_replace.rs
@@ -56,6 +56,8 @@ fn bundle_with_recorded_runner(with_local_model: bool) -> (tempfile::TempDir, Ru
         model_base_url: None,
         bundle_digest: None,
         bundle_snapshot_dir: None,
+        connector_containers: Vec::new(),
+        connector_network: None,
     };
     state::save(&dir.path().join("bundle"), &recorded).expect("save recorded runner");
     (dir, recorded)

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -590,8 +590,10 @@ services:
       # are the synthetic local-tier scope: the same release/namespace pair
       # `connector_render.service_dns` uses to compute the Docker network
       # alias the local connector container starts under, so the runner
-      # derives the identical name it would derive on cluster.
-      - CURIE_RELEASE=${CURIE_RELEASE:-local}
+      # derives the identical name it would derive on cluster. The default
+      # here must match the CLI's local connector bring-up identity: release
+      # `curie` (cli/src/commands.rs), the same as `local::COMPOSE_PROJECT`.
+      - CURIE_RELEASE=${CURIE_RELEASE:-curie}
       - CURIE_NAMESPACE=${CURIE_NAMESPACE:-default}
     restart: unless-stopped
 

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -580,6 +580,19 @@ services:
       - CURIE_FALSE_COMPLETION_CHECK=${CURIE_FALSE_COMPLETION_CHECK:-}
       - CURIE_DOCKER_NETWORK=${CURIE_DOCKER_NETWORK:-curie_runner}
       - OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT-http://otel-collector:4318}
+      # config.py's connector_release/connector_namespace (CURIE_RELEASE /
+      # CURIE_NAMESPACE) both default empty, which was built for the cluster
+      # tier (#1118) where Helm supplies the real release name and namespace.
+      # There is no Helm release at local tier, so without these two a plain
+      # `curie local up` leaves both empty, binding.py emits no connector
+      # scope, and every hosted connector logs "declared but not exercisable
+      # in this tier" (#1093) even once its local container is running. These
+      # are the synthetic local-tier scope: the same release/namespace pair
+      # `connector_render.service_dns` uses to compute the Docker network
+      # alias the local connector container starts under, so the runner
+      # derives the identical name it would derive on cluster.
+      - CURIE_RELEASE=${CURIE_RELEASE:-local}
+      - CURIE_NAMESPACE=${CURIE_NAMESPACE:-default}
     restart: unless-stopped
 
   # Optional real Slack ingress for local development.

--- a/compose/tests/test_generate_release_compose.py
+++ b/compose/tests/test_generate_release_compose.py
@@ -479,6 +479,45 @@ def test_worker_traces_to_shipped_collector_by_default():
         )
 
 
+# --- Local-tier connector scope (#1690, ADR 0113 Stream B2) -----------------
+#
+# `config.py`'s `connector_release` / `connector_namespace` already read
+# CURIE_RELEASE / CURIE_NAMESPACE (both default empty), and `binding.py`
+# already forwards them into the sandbox boot env unchanged -- that plumbing
+# was built for the cluster tier (#1118), where Helm supplies `.Release.Name`
+# / `.Release.Namespace`. There is no Helm release at skill/local tier, so
+# nothing has ever set these two on curie-worker: a plain `curie local up`
+# leaves both empty, `binding.py` emits no connector scope at all, and the
+# runner logs "declared but not exercisable in this tier" (#1093) for every
+# hosted connector even once a build-form connector container is started
+# beside it on `curie_runner`. This is the synthetic scope that makes the
+# Docker network alias `connector_render.service_dns(...)` computes for the
+# local connector container and the cluster Service DNS the same string.
+
+
+def test_worker_carries_a_local_tier_connector_scope():
+    """`curie-worker` must resolve a non-empty CURIE_RELEASE and CURIE_NAMESPACE
+    with no manual export, in both the dev document and the generated release
+    document -- the generator copies env through untouched, and a guard on only
+    one of the two leaves the other free to drift (the same reasoning as the
+    OTEL/CURIE_DOCKER_NETWORK pin above).
+    """
+    for label, doc in compose_docs():
+        env = env_map(doc["services"]["curie-worker"])
+        release = resolve_shell_default(env.get("CURIE_RELEASE"))
+        namespace = resolve_shell_default(env.get("CURIE_NAMESPACE"))
+        assert release, (
+            f"{label}: curie-worker CURIE_RELEASE resolves to {release!r}; "
+            "config.py's connector_release stays empty and binding.py emits no "
+            "connector scope for the sandbox to mount, so every hosted "
+            "connector local tier starts is unreachable"
+        )
+        assert namespace, (
+            f"{label}: curie-worker CURIE_NAMESPACE resolves to {namespace!r}; "
+            "config.py's connector_namespace stays empty for the same reason"
+        )
+
+
 def assert_init_containers_adopted(compose_text, label):
     """Assert every one-shot init container is adopted via
     `service_completed_successfully` in every profile combo `curie local up`

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -29,7 +29,7 @@ is documentation of where the code already draws the line, not a new abstraction
 | Memory | CLEAN | 1 loader (StateApiMemoryStore) | not separately graded | #28 | [Memory](interfaces/memory/INTERFACE.md) |
 | Conversation history | CLEAN | 1 loader (StateApiTranscriptStore) | not separately graded | #20 | [Conversation history](interfaces/conversation-history/INTERFACE.md) |
 | Triggers | SOFT | 3 hardcoded (Slack, GH push, commit poll) | not separately graded | #29 | [Triggers](interfaces/triggers/INTERFACE.md) |
-| CLI output (agent-facing `--json`) | CLEAN | 40 outputs behind one trait | not separately graded | #456 | [CLI output (agent-facing `--json`)](interfaces/cli-output/INTERFACE.md) |
+| CLI output (agent-facing `--json`) | CLEAN | 41 outputs behind one trait | not separately graded | #456 | [CLI output (agent-facing `--json`)](interfaces/cli-output/INTERFACE.md) |
 | Harness package (declared contribution) | CLEAN | 1 (built-in Claude) behind the entry-point registry | not separately graded | #844 | [Harness package (declared contribution)](interfaces/harness-package/INTERFACE.md) |
 | Connector host (bundle-declared MCP servers) | CLEAN | 1 (Kubernetes) + in-memory fake | not separately graded | #1063, #1184 | [Connector host (bundle-declared MCP servers)](interfaces/connector-host/INTERFACE.md) |
 | Sealed credential (cluster-sealed connector secrets) | SOFT | 2 halves (Rust sealer, Python opener) over one frozen wire | not separately graded | #1240 | [Sealed credential (cluster-sealed connector secrets)](interfaces/sealed-credential/INTERFACE.md) |

--- a/docs/interfaces/cli-output/INTERFACE.md
+++ b/docs/interfaces/cli-output/INTERFACE.md
@@ -1,7 +1,7 @@
 ---
 seam: CLI output (agent-facing `--json`)
 kind: CLEAN
-impls: 40 outputs behind one trait
+impls: 41 outputs behind one trait
 grade: not separately graded
 epics:
   - "#456"
@@ -13,7 +13,7 @@ order: 18
 > Part of the Curie swappable-seam catalog — see the [seam index](../../interfaces.md).
 
 <!-- BEGIN GENERATED: header (curie dev docs-lint) -->
-> **Kind:** CLEAN &nbsp;·&nbsp; **Implementations today:** 40 outputs behind one trait &nbsp;·&nbsp; **Swap-readiness grade:** not separately graded
+> **Kind:** CLEAN &nbsp;·&nbsp; **Implementations today:** 41 outputs behind one trait &nbsp;·&nbsp; **Swap-readiness grade:** not separately graded
 <!-- END GENERATED: header -->
 
 **Kind legend:** CLEAN = a real `Protocol`/typed port class · SOFT = swap via env/URL/prefix/wire, no code interface · NONE = not built yet.
@@ -65,7 +65,7 @@ This is the catalog's first **Rust** seam. It is listed here because the agent-f
 
 ## Implementations today
 
-40 `CliOutput` implementations, all in the CLI crate, grouped by owning module:
+41 `CliOutput` implementations, all in the CLI crate, grouped by owning module:
 
 - **`DryRunPlan`** (`cli/src/ui.rs`) — the generic `--dry-run` plan; JSON is
   `{"dry_run":true,"plan":[lines]}` and the human render is the same lines verbatim,
@@ -80,7 +80,11 @@ This is the catalog's first **Rust** seam. It is listed here because the agent-f
   `EvalOutput`, `DeployOutput`, `AllTargetsDeployOutput`, `KillOutput`, `ResumeOutput`,
   `BudgetOutput`, `ResetThreadOutput`,
   `DeleteOutput`, `VersionsOutput`, `MemoryOutput`, `ApprovalsOutput`,
-  `SkillApprovalsOutput`, `OverridesOutput`.
+  `SkillApprovalsOutput`, `OverridesOutput`, `ConnectorBuildOutput`. The last is
+  the `curie build --plugin-dir` receipt for connector source builds (ADR-0113):
+  it emits one object even when the bundle declares nothing to build, because
+  under `--json` an agent cannot tell "nothing to build" from "the command
+  produced nothing" — the #485 failure this seam exists to prevent.
 - **`cli/src/local.rs`** and **`cli/src/ops.rs`**, the operator verbs, one output per
   verb per tier: `LocalUpOutput`, `LocalRebuildOutput`, `LocalStatusOutput`,
   `LocalDownOutput`; `ClusterUpOutput`, `ClusterStatusOutput`, `ClusterDownOutput`.
@@ -115,10 +119,10 @@ That set is not hand-maintained prose: `cli/schema/index.json` carries one
   syntactic call-site inventory, not a type-level proof that *every* verb returns
   a `CliOutput`.
 - **Committed JSON Schemas with a drift gate (since #841).** Each `to_json` is no
-  longer schema-free: there are 40 committed schemas under `cli/schema/` with an
+  longer schema-free: there are 41 committed schemas under `cli/schema/` with an
   index (`cli/schema/index.json`), a `syn`-based inventory gate over every `impl
-  CliOutput`, and per-family output validation — all 40 are validated against real
-  `to_json()` output across 65 tests in `cli/tests/json_contract.rs`. Those tests
+  CliOutput`, and per-family output validation — all 41 are validated against real
+  `to_json()` output across 66 tests in `cli/tests/json_contract.rs`. Those tests
   drive each output type's `to_json()` once per output variant rather than calling
   the pure builder functions behind it, so a variant whose `to_json()` arm drifts
   from the schema is caught even when the builder it delegates to still validates.

--- a/examples/sre-bot/.gitignore
+++ b/examples/sre-bot/.gitignore
@@ -1,1 +1,5 @@
 .curie/
+# Written by `curie build --plugin-dir`, and it records YOUR registry and the
+# digests YOUR build resolved, so it belongs to an install rather than to this
+# example.
+connectors.lock.yaml

--- a/examples/sre-bot/README.md
+++ b/examples/sre-bot/README.md
@@ -230,24 +230,7 @@ self-approval.
 Read the four-layer table above before starting, and
 [`manifests/write-role.yaml`](manifests/write-role.yaml) before applying it.
 
-**1. Build and push the connector image.**
-
-There is no public image on purpose: the allowlist and the credential are yours,
-and so is the artifact. Build multi-arch -- a single-arch image passes CI and
-then fails to pull on a node of the other architecture with "no matching
-manifest", which reads as a registry problem.
-
-```bash
-docker buildx build --platform linux/amd64,linux/arm64 \
-  -t <your-registry>/sre-bot-k8s-write-mcp:v1 --push \
-  examples/sre-bot/connectors/k8s-write
-```
-
-If your registry defaults new packages to private, flip this one to public or
-give the cluster a pull secret. An anonymous pull otherwise 403s and surfaces as
-`ImagePullBackOff`.
-
-**2. Create the write identity.**
+**1. Create the write identity.**
 
 Edit the namespace and the `resourceNames` list in
 [`manifests/write-role.yaml`](manifests/write-role.yaml) first -- one Deployment,
@@ -257,9 +240,9 @@ not a list, unless someone has actually asked for the second one. Then:
 kubectl apply -f examples/sre-bot/manifests/write-role.yaml
 ```
 
-**3. Assemble and store the write kubeconfig.**
+**2. Assemble and store the write kubeconfig.**
 
-Same shape as the read-only one, from the `sre-bot-writer-token` Secret step 2
+Same shape as the read-only one, from the `sre-bot-writer-token` Secret step 1
 minted. This must be a SEPARATE credential -- never the read-only connector's,
 which is deliberately unable to write. Use the namespace you set in
 `write-role.yaml`:
@@ -292,19 +275,56 @@ kubectl auth can-i --as=system:serviceaccount:"$NS":sre-bot-writer \
   delete deployments -n "$NS"                                 # NO
 ```
 
-**4. Turn the connector on.**
+**The credential comes before the connector, and that order is load-bearing.** A
+declared connector secret with no stored value fails the deploy, so a bundle
+that enables `k8s-write` before `K8S_WRITE_KUBECONFIG` exists cannot deploy at
+all. That is why this step sits ahead of the uncomment rather than beside it.
 
-Uncomment the `k8s-write:` block in [`connectors.yaml`](connectors.yaml), set
-`image:` to what you pushed, and set `K8S_WRITE_ALLOWLIST` to
-`<namespace>/<deployment>` -- the same pair you put in `resourceNames`. Stating
-the ceiling in two places is deliberate: a ceiling stated once is a ceiling that
-moves when someone edits the other place.
+**3. Turn the connector on.**
+
+Uncomment the `k8s-write:` block in [`connectors.yaml`](connectors.yaml) and set
+`K8S_WRITE_ALLOWLIST` to `<namespace>/<deployment>` -- the same pair you put in
+`resourceNames`. Stating the ceiling in two places is deliberate: a ceiling
+stated once is a ceiling that moves when someone edits the other place.
+
+There is no `image:` line to fill in. The block declares a `build:` -- the source
+directory and the platforms -- and step 4 resolves it to a digest.
+
+**4. Build the connector image.**
+
+```bash
+curie build --plugin-dir examples/sre-bot --registry <your-registry>
+```
+
+One command, after the uncomment rather than before it: `curie build` builds
+what the file currently declares, so a still-commented connector is not built.
+It builds every declared `build:` connector on every platform its `platforms:`
+line names, pushes them, and writes the resolved digests to
+`connectors.lock.yaml` beside `connectors.yaml`. The deploy renders those
+digests and nothing else, so the "pin it, never `:latest`" rule is enforced by
+the artifact rather than by remembering.
+
+There is no public image on purpose: the allowlist and the credential are yours,
+and so is the artifact. Multi-arch is not a flag you pass either -- the
+`platforms:` line in [`connectors.yaml`](connectors.yaml) carries it, because a
+single-arch image passes CI and then fails to pull on a node of the other
+architecture with "no matching manifest", which reads as a registry problem.
+
+If your registry defaults new packages to private, flip this one to public or
+give the cluster a pull secret. An anonymous pull otherwise 403s and surfaces as
+`ImagePullBackOff`.
+
+`connectors.lock.yaml` is gitignored in this example. It records your registry
+and the digests your build resolved, so it belongs to an install; the deploy
+packs it from your working tree.
 
 **5. Declare the approval gate.**
 
 Add this to `.claude-plugin/plugin.json`. It is not shipped, because bundle
 validation rejects a gate naming an undeclared connector -- so a gate for a
 commented-out connector would fail the build for everyone who never enables it.
+The consequence is that the gate travels with step 3's uncomment, in the same
+change: enabling the connector without it deploys an ungated write verb.
 
 ```json
   "approvalPolicy": {
@@ -450,9 +470,11 @@ platform-side per-target override is the proper fix and does not exist yet.
 **Tempo** adds distributed traces. `mcp-grafana` has no tool that speaks Tempo,
 so without this connector the bot can see the datasource and never read a span.
 It needs the Grafana connector on (it reuses the same token, reaching an endpoint
-mcp-grafana has no tool for) and an image you build from
-[`connectors/tempo/`](connectors/tempo/) -- same `docker buildx` shape as the
-write connector.
+mcp-grafana has no tool for) and its own image, built from
+[`connectors/tempo/`](connectors/tempo/) by the same
+`curie build --plugin-dir examples/sre-bot --registry <your-registry>` that
+builds the write connector. Uncomment both blocks and run it once; there is
+nothing extra to run for this one.
 
 Three off-the-shelf routes were measured and rejected before this connector was
 written; [`connectors/tempo/server.py`](connectors/tempo/server.py) records what

--- a/examples/sre-bot/connectors.yaml
+++ b/examples/sre-bot/connectors.yaml
@@ -13,12 +13,14 @@
 #   kubernetes    ON.  Read-only cluster access. The only connector you need to
 #                      make this bot useful, and the only one with no external
 #                      dependency beyond the cluster itself.
-#   k8s-write     OFF. One gated write verb. Needs an image you build, a second
-#                      credential, and an approval route. See README.md,
-#                      "Level up: the gated write path".
+#   k8s-write     OFF. One gated write verb. Needs a second credential, an
+#                      approval route, and one `curie build` to turn the source
+#                      in `connectors/k8s-write/` into a pinned image. See
+#                      README.md, "Level up: the gated write path".
 #   grafana       OFF. Logs, metrics, alerts, profiles. Needs a Grafana and a
 #                      Viewer service-account token.
-#   tempo         OFF. Distributed traces. Needs Grafana plus an image you build.
+#   tempo         OFF. Distributed traces. Needs Grafana, plus the same
+#                      `curie build` the write connector needs.
 #
 # Turning one on is uncommenting its block and supplying its secret. Turning one
 # off is commenting it back out -- the connector disappears and so do its tools,
@@ -137,19 +139,27 @@ connectors:
 #
 # ENABLING IT IS NOT JUST UNCOMMENTING. You must:
 #
-#   1. Build the image from `connectors/k8s-write/` and push it to a registry
-#      your cluster can pull from. There is no public image for this on purpose
-#      -- the allowlist and the credential are yours, and so is the artifact.
-#      Build it multi-arch; the Dockerfile says why.
-#   2. Apply `manifests/write-role.yaml` (after editing its namespace and
+#   1. Apply `manifests/write-role.yaml` (after editing its namespace and
 #      `resourceNames`) and store the resulting kubeconfig as
-#      K8S_WRITE_KUBECONFIG.
-#   3. Set `image:` below to what you pushed, and `K8S_WRITE_ALLOWLIST` to the
-#      one `namespace/deployment` this bot may roll.
+#      K8S_WRITE_KUBECONFIG. This comes FIRST: a declared connector secret with
+#      no stored value fails the deploy, so the credential exists before the
+#      connector does.
+#   2. Set `K8S_WRITE_ALLOWLIST` below to the one `namespace/deployment` this
+#      bot may roll.
+#   3. Build the image:
+#
+#          curie build --plugin-dir examples/sre-bot --registry <your-registry>
+#
+#      That builds every connector this file declares a `build:` for, on every
+#      platform it names, pushes them, and records the resolved digests in
+#      `connectors.lock.yaml`. There is no public image for this on purpose --
+#      the allowlist and the credential are yours, and so is the artifact -- and
+#      no `image:` line to edit: the digest lives in the lock, never here.
 #   4. Add the approval gate to `.claude-plugin/plugin.json`. It is NOT shipped:
 #      bundle validation rejects a gate that names an undeclared connector, so a
 #      gate for a commented-out connector would fail the build for everyone who
-#      never enables this. README.md carries the exact JSON.
+#      never enables this. The gate therefore travels WITH this uncomment, in
+#      the same change; README.md carries the exact JSON.
 #
 # Full walkthrough: README.md, "Level up: the gated write path".
 #
@@ -162,16 +172,26 @@ connectors:
 # never fires.
 #
 #   k8s-write:
-#     # Whatever you built and pushed in step 1. Pinned by digest or an
-#     # immutable tag, never `:latest` -- see the pinning note on `kubernetes`
-#     # above, which is not theoretical.
+#     # Where the image comes FROM, instead of what it is. `curie build` builds
+#     # this context and records the digest it resolved in
+#     # `connectors.lock.yaml`; the deploy renders that digest and nothing else,
+#     # so the pinning note on `kubernetes` above -- which is not theoretical --
+#     # is satisfied by construction here rather than by remembering to type an
+#     # immutable tag.
+#     #
+#     # `platforms` is required rather than defaulted, because a silently
+#     # single-arch image builds clean, passes CI, and then fails to pull on a
+#     # node of the other architecture as "no matching manifest".
 #     #
 #     # PACKAGE VISIBILITY, if you push to a registry that has the concept: a
 #     # newly published package is often PRIVATE by default, and an anonymous
 #     # node pull then gets a 403 that surfaces as ImagePullBackOff rather than
-#     # as a permissions error. Verify with an anonymous manifest fetch before
-#     # blaming the cluster.
-#     image: <your-registry>/sre-bot-k8s-write-mcp:v1
+#     # as a permissions error. That trap is about the registry you pushed to,
+#     # so it survives the change of who does the building. Verify with an
+#     # anonymous manifest fetch before blaming the cluster.
+#     build:
+#       context: connectors/k8s-write
+#       platforms: [linux/amd64, linux/arm64]
 #     unhosted_url: ${K8S_WRITE_MCP_URL}
 #     env:
 #       # Defence in depth alongside the Role's `resourceNames`. A ceiling
@@ -288,14 +308,18 @@ connectors:
 # Grafana, just to an endpoint mcp-grafana has no tool for: the datasource
 # proxy. So this adds a capability without adding a credential.
 #
-# NO PUBLIC IMAGE. Build it from `connectors/tempo/` and push it to a registry
-# your cluster pulls from, then set `image:` to what you pushed. Pin it by
-# digest or an immutable tag -- a floating `:latest` already cost this connector
-# a CrashLoopBackOff once, when the flags verified at check time were not the
-# flags present at pull time.
+# NO PUBLIC IMAGE, and nothing to build by hand: the `build:` block below is
+# built by the same `curie build --plugin-dir examples/sre-bot --registry
+# <your-registry>` that builds the write connector. What that resolves to is a
+# digest, recorded in `connectors.lock.yaml` and rendered verbatim -- which is
+# the point, because a floating `:latest` already cost this connector a
+# CrashLoopBackOff once, when the flags verified at check time were not the
+# flags present at pull time. A digest cannot be repointed after review.
 #
 #   tempo:
-#     image: <your-registry>/sre-bot-tempo-mcp:v1
+#     build:
+#       context: connectors/tempo
+#       platforms: [linux/amd64, linux/arm64]
 #     unhosted_url: ${TEMPO_MCP_URL}
 #     env:
 #       # Same install-specific line as the grafana block above, same reason.

--- a/examples/sre-bot/connectors/k8s-write/Dockerfile
+++ b/examples/sre-bot/connectors/k8s-write/Dockerfile
@@ -4,8 +4,10 @@
 # clean, passes CI, and then fails to pull on the node with "no matching
 # manifest" -- which reads as a registry problem rather than a build one.
 #
-#   docker buildx build --platform linux/amd64,linux/arm64 \
-#     -t <your-registry>/sre-bot-k8s-write-mcp:v1 --push examples/sre-bot/connectors/k8s-write
+# Nothing here is run by hand. `build.platforms` in the bundle's connectors.yaml
+# names both architectures, and one
+# `curie build --plugin-dir <bundle> --registry <ref>` builds exactly what it
+# declares.
 FROM python:3.12-slim
 
 # uid 65532 (nonroot) matches the other connectors, so the same securityContext

--- a/examples/sre-bot/connectors/tempo/Dockerfile
+++ b/examples/sre-bot/connectors/tempo/Dockerfile
@@ -4,8 +4,10 @@
 # and then fails to pull on the node with "no matching manifest" -- which reads
 # as a registry problem rather than a build one.
 #
-#   docker buildx build --platform linux/amd64,linux/arm64 \
-#     -t <your-registry>/sre-bot-tempo-mcp:v1 --push examples/sre-bot/connectors/tempo
+# Nothing here is run by hand. `build.platforms` in the bundle's connectors.yaml
+# names both architectures, and one
+# `curie build --plugin-dir <bundle> --registry <ref>` builds exactly what it
+# declares.
 FROM python:3.12-slim
 
 # uid 65532 (nonroot) matches the other connectors, so the same securityContext

--- a/packages/plugin-format/src/plugin_format/connectors.py
+++ b/packages/plugin-format/src/plugin_format/connectors.py
@@ -43,6 +43,8 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from .reserved_env import SECRET_NAME_RE, is_reserved_boot_env_name
+
 # The file this module parses. Defined here, with the parser, so every reader
 # (the deploy validator, the approval-policy gate-name derivation, the API's
 # bundle reader) names one constant rather than its own copy of the string.
@@ -572,6 +574,37 @@ def validate_connectors(data: Any) -> tuple[ConnectorsFile | None, list[tuple[st
                     "Use `secrets:` until then.",
                 )
             )
+        # A connector-declared secret NAME is held to exactly the policy a
+        # manifest `secrets` name gets (`validate._validate_secrets`): the same
+        # env-var shape and the same reserved fence, from the same module, so
+        # the two declaration sites cannot drift apart. Without this the fence
+        # was bypassable by moving the name from `plugin.json` to here: a bundle
+        # declaring `secrets: [ANTHROPIC_API_KEY]` has the operator's own model
+        # credential resolved from their environment or vault and handed to the
+        # bundle's own container, and at the skill tier that happens before this
+        # validator ever runs.
+        declared_names = [s if isinstance(s, str) else s.name for s in spec.secrets]
+        declared_names += list(spec.secret_files)
+        for declared_name in declared_names:
+            if not SECRET_NAME_RE.match(declared_name):
+                errors.append(
+                    (
+                        "connectors.secret_name_invalid",
+                        f"{where}: secret name {declared_name!r} must be an env-var-style "
+                        "name (uppercase letters, digits, underscore; not starting with a "
+                        "digit) -- it is delivered as an environment variable, so a name "
+                        "outside that shape can never bind",
+                    )
+                )
+            elif is_reserved_boot_env_name(declared_name):
+                errors.append(
+                    (
+                        "connectors.secret_name_reserved",
+                        f"{where}: secret name {declared_name!r} is reserved: it is a "
+                        "platform boot-env, model-credential, or redirect/capture-capable "
+                        "key and cannot be used for a connector secret",
+                    )
+                )
         seen_secret_names: set[str] = set()
         for secret_name in spec.secret_names():
             if secret_name in seen_secret_names:

--- a/packages/plugin-format/src/plugin_format/reserved_env.py
+++ b/packages/plugin-format/src/plugin_format/reserved_env.py
@@ -23,10 +23,22 @@ credential keys) and ``apps/worker/src/curie_worker/binding.py`` (the
 ``CURIE_*`` boot keys). This module re-enumerates them so the policy is
 greppable from one place; ``apps/worker/tests/binding/test_reserved_boot_env_pin.py``
 is the completeness + cross-language drift pin that fails CI if a boot or
-credential key is added there but not covered here (or if the Helm list drifts).
+credential key is added there but not covered here (or if the Helm or Rust list
+drifts).
+
+``SECRET_NAME_RE`` rides here too. Every seam that consults the reserved fence
+also holds a connector secret name to an env-var SHAPE, so both halves of the
+name policy come from one import rather than a regex copied per validator.
 """
 
 from __future__ import annotations
+
+import re
+
+# The shape a connector secret name must have, wherever it is declared: the
+# value is delivered to the sandbox as an environment variable and consumed by
+# ``${VAR}`` expansion, so a name that is not env-var-shaped can never bind.
+SECRET_NAME_RE = re.compile(r"^[A-Z_][A-Z0-9_]*$")
 
 # The four runner ``sdk_auth`` credential keys that are NOT ``CURIE_``-prefixed.
 # These are the exact gap #457 closes. Together with ``_REDIRECT_CAPTURE_KEYS``

--- a/packages/plugin-format/src/plugin_format/validate.py
+++ b/packages/plugin-format/src/plugin_format/validate.py
@@ -40,7 +40,7 @@ from .models import (
     SkillFrontmatter,
     TriggerDeclaration,
 )
-from .reserved_env import is_reserved_boot_env_name
+from .reserved_env import SECRET_NAME_RE, is_reserved_boot_env_name
 from .yaml_loader import DuplicateKeyError, safe_load_unique
 
 # The hooks field is a mapping of event name -> list of matcher entries. Reused
@@ -731,9 +731,6 @@ def _gate_not_namespaced_message(
     )
 
 
-_SECRET_NAME_RE = re.compile(r"^[A-Z_][A-Z0-9_]*$")
-
-
 def _validate_secrets(manifest: PluginManifest, c: _Collector) -> None:
     """Validate the manifest ``secrets`` policy (deploy-time gate, ADR-0009 / #429).
 
@@ -753,7 +750,7 @@ def _validate_secrets(manifest: PluginManifest, c: _Collector) -> None:
 
     for i, name in enumerate(declared):
         loc = f"plugin.json (secrets[{i}])"
-        if not isinstance(name, str) or not _SECRET_NAME_RE.match(name):
+        if not isinstance(name, str) or not SECRET_NAME_RE.match(name):
             c.error(
                 "secrets.name_invalid",
                 f"secret name {name!r} must be an env-var-style name "

--- a/packages/plugin-format/tests/test_connectors.py
+++ b/packages/plugin-format/tests/test_connectors.py
@@ -343,6 +343,94 @@ def test_both_forms_can_be_mixed_on_one_connector() -> None:
     assert parsed.connectors["g"].resolved_secrets() == ["OWNED"]
 
 
+# --------------------------------------------------------------------------- #
+# A connector-declared secret NAME gets the manifest `secrets` policy -- #457
+# --------------------------------------------------------------------------- #
+def test_a_reserved_name_cannot_be_declared_as_a_connector_secret() -> None:
+    # The hole: the fence lived only on plugin.json `secrets`, so moving the
+    # name here bought a connector the operator's own model credential --
+    # resolved from their environment or vault and handed to the bundle's
+    # container before any validator runs at the skill tier.
+    assert "connectors.secret_name_reserved" in _codes(
+        {"connectors": {"g": {"image": "x:1", "secrets": ["ANTHROPIC_API_KEY"]}}}
+    )
+
+
+def test_a_reserved_name_cannot_be_declared_as_a_secret_file_key() -> None:
+    # Same name, same resolution, same per-agent Secret -- only the delivery
+    # differs, so the fence has to cover this key too.
+    assert "connectors.secret_name_reserved" in _codes(
+        {
+            "connectors": {
+                "g": {"image": "x:1", "secret_files": {"HTTPS_PROXY": "/secrets/proxy"}}
+            }
+        }
+    )
+
+
+def test_a_reserved_name_is_refused_through_validate_bundle(tmp_path: Path) -> None:
+    # The consumer path that matters: the API validates an uploaded bundle
+    # through validate_bundle, and the runner validates the packed snapshot
+    # through the same parser -- so a hostile connectors.yaml is refused at
+    # upload rather than discovered at apply.
+    root = _bundle(
+        tmp_path,
+        "connectors:\n  g:\n    image: x:1\n    secrets: [CLAUDE_CODE_OAUTH_TOKEN]\n",
+    )
+    result = validate_bundle(str(root))
+    assert not result.valid
+    assert any(e.code == "connectors.secret_name_reserved" for e in result.errors)
+
+
+def test_the_curie_prefix_is_fenced_for_a_connector_secret() -> None:
+    # The forward-safe half of the rule: a boot key nobody remembered to
+    # enumerate is still reserved because it carries the prefix.
+    assert "connectors.secret_name_reserved" in _codes(
+        {"connectors": {"g": {"image": "x:1", "secrets": ["CURIE_RUNNER_TOKEN"]}}}
+    )
+
+
+def test_a_malformed_secret_name_is_refused() -> None:
+    # A lowercase name cannot be delivered as an env var and consumed by
+    # `${VAR}` expansion, so it would bind to nothing at runtime.
+    codes = _codes({"connectors": {"g": {"image": "x:1", "secrets": ["grafana-token"]}}})
+    assert "connectors.secret_name_invalid" in codes
+    assert "connectors.secret_name_reserved" not in codes, "shape is reported once, not twice"
+
+
+def test_an_ordinary_connector_secret_name_still_validates() -> None:
+    # The over-refusal control: the names the shipped examples declare must
+    # keep validating clean, in both delivery forms.
+    _, errors = validate_connectors(
+        {
+            "connectors": {
+                "grafana": {"image": "x:1", "secrets": ["GRAFANA_SERVICE_ACCOUNT_TOKEN"]},
+                "kubernetes": {
+                    "image": "y:1",
+                    "secret_files": {"K8S_READONLY_KUBECONFIG": "/secrets/kubeconfig"},
+                },
+            }
+        }
+    )
+    assert errors == []
+
+
+def test_the_secret_ref_form_is_held_to_the_same_name_policy() -> None:
+    # `from_secret` moves who holds the VALUE, not which env var the connector
+    # container ends up reading -- a secretKeyRef named ANTHROPIC_BASE_URL
+    # redirects the session exactly the same way.
+    assert "connectors.secret_name_reserved" in _codes(
+        {
+            "connectors": {
+                "g": {
+                    "image": "x:1",
+                    "secrets": [{"name": "ANTHROPIC_BASE_URL", "from_secret": "s"}],
+                }
+            }
+        }
+    )
+
+
 def test_an_empty_from_secret_is_rejected() -> None:
     # It renders a secretKeyRef at a Secret named '', which the API server
     # rejects at APPLY -- long after the deploy looked like it worked.

--- a/runner/tests/test_connectors.py
+++ b/runner/tests/test_connectors.py
@@ -16,6 +16,7 @@ from curie_runner import RunnerConfig
 from curie_runner.__main__ import build_runner
 from curie_runner.approval import APPROVAL_SERVER_NAME
 from curie_runner.connectors import build_mcp_servers, derive_mcp_servers
+from curie_runner.plugin import PluginBundleError
 from curie_runner.state import STATE_SERVER_NAME
 from plugin_format.connectors import RESERVED_CONNECTOR_NAMES
 
@@ -439,6 +440,110 @@ def test_the_boot_path_mounts_the_platform_approval_server_over_a_colliding_conn
     # The control on the boot path: the platform winning must not cost the
     # bundle the connectors it declared.
     assert mounted["grafana"] is grafana
+
+
+# --------------------------------------------------------------------------- #
+# A third-party server in the bundle's own `.mcp.json` stays external
+# (#1690, ADR 0113)
+#
+# Hosting is a `connectors.yaml` decision and only a `connectors.yaml` decision:
+# `_read` opens that one file, and the entries it derives are the only ones
+# Curie ever creates a Service and Deployment for. A bundle's own `.mcp.json` is
+# a different channel entirely -- it rides `ClaudeAgentOptions.plugins` as the
+# read-only bundle directory the SDK loads for itself, never through
+# `build_mcp_servers`, which merges only the platform's servers with the
+# connectors.yaml-derived ones. So a remote upstream declared there is dialed at
+# the address its author wrote, and no container of Curie's is started for it.
+#
+# The tests below are the pin on that separation. THE RED: make
+# `derive_mcp_servers` enumerate `.mcp.json` -- the plausible regression, since
+# both files name MCP servers -- and the exact-set assertions
+# (`set(servers) == {"conn"}` here, `set(mounted) == {APPROVAL_SERVER_NAME,
+# "grafana"}` on the boot path) go red on the extra key. Make it REWRITE the
+# upstream entry to a Service DNS URL and the byte-identity assertion on
+# `.mcp.json` plus the "no derived entry carries the upstream host" assertion go
+# red as well.
+# --------------------------------------------------------------------------- #
+UPSTREAM = "https://mcp.example-upstream.com/mcp"
+UPSTREAM_MCP_JSON = {"mcpServers": {"github-upstream": {"type": "http", "url": UPSTREAM}}}
+
+
+def test_a_third_party_mcp_json_server_is_not_a_connector_curie_hosts(tmp_path: Path) -> None:
+    # One bundle, both channels: a `build:` connector Curie hosts, and a remote
+    # upstream the author reaches directly. Only the first is Curie's to create
+    # a Service for, so only the first may appear in the derived entries -- the
+    # upstream is not there, not renamed, and not rewritten to Service DNS.
+    servers = derive_mcp_servers(_bundle(tmp_path, BUILT, mcp=UPSTREAM_MCP_JSON), **SCOPE)
+    assert set(servers) == {"conn"}
+    assert not any(UPSTREAM in entry.get("url", "") for entry in servers.values())
+    # The control on the same bundle: the connector Curie DOES host still gets
+    # the Service it created, so "the upstream is absent" is not bought by
+    # deriving nothing at all.
+    assert "svc.cluster.local" in servers["conn"]["url"]
+
+
+def test_mounting_connectors_never_rewrites_the_bundles_own_mcp_json(tmp_path: Path) -> None:
+    # "Nothing rewrites `.mcp.json`; the bundle stays the read-only artifact that
+    # was deployed" (connectors.py). Byte identity is the check, because an
+    # injected entry or a rewritten URL would both be a silent edit to a signed,
+    # deployed artifact.
+    root = _bundle(tmp_path, BUILT, mcp=UPSTREAM_MCP_JSON)
+    before = (root / ".mcp.json").read_bytes()
+    build_mcp_servers(
+        platform={APPROVAL_SERVER_NAME: {"platform": "approval"}},
+        derived=derive_mcp_servers(root, **SCOPE),
+    )
+    assert (root / ".mcp.json").read_bytes() == before
+    assert json.loads(before)["mcpServers"]["github-upstream"]["url"] == UPSTREAM
+
+
+def test_the_boot_path_mounts_nothing_for_a_third_party_mcp_json_entry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The pin on the WIRING rather than the helper, through a boot env the
+    # worker really renders. The bundle's own upstream must reach the SDK on the
+    # plugins channel -- the read-only bundle directory, loaded verbatim -- and
+    # must never appear on the platform `mcp_servers` channel, which is where
+    # the servers Curie hosts and derives URLs for ride.
+    monkeypatch.delenv("CURIE_STATE_URL", raising=False)
+    root = _bundle(tmp_path, HOSTED, mcp=UPSTREAM_MCP_JSON)
+    config = _config_for(root, release="curie", agent="acme-dev", namespace="curie")
+    options = build_runner(config, fake_model=False)._factory()._options
+
+    mounted = options.mcp_servers
+    # Exact, not `"github-upstream" not in mounted`: an extra key of any name is
+    # a server Curie would be hosting that the bundle never declared to it.
+    assert set(mounted) == {APPROVAL_SERVER_NAME, "grafana"}
+    assert "svc.cluster.local" in mounted["grafana"]["url"]
+
+    # The other half of "stays external": it is not dropped either. The SDK gets
+    # the bundle directory itself, and the upstream entry in it is untouched.
+    assert options.plugins == [{"type": "local", "path": str(root)}]
+    loaded = json.loads((Path(options.plugins[0]["path"]) / ".mcp.json").read_text())
+    assert loaded["mcpServers"]["github-upstream"] == {"type": "http", "url": UPSTREAM}
+
+
+def test_a_name_in_both_channels_fails_the_boot_instead_of_picking_a_winner(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The collision precedence, pinned where the code actually decides it: there
+    # is none. `_reject_connector_name_collisions` refuses the bundle ("one
+    # name, one owner"), and the runner runs that same validator through
+    # load_plugins at boot, so the bundle never loads. A residual collision
+    # therefore cannot reach build_mcp_servers, whose platform-wins rule is a
+    # separate fence over Curie's OWN server names (#1200), not over this one.
+    monkeypatch.delenv("CURIE_STATE_URL", raising=False)
+    collide = {"mcpServers": {"grafana": {"type": "http", "url": UPSTREAM}}}
+    config = _config_for(
+        _bundle(tmp_path, HOSTED, mcp=collide),
+        release="curie",
+        agent="acme-dev",
+        namespace="curie",
+    )
+    with pytest.raises(PluginBundleError) as exc:
+        build_runner(config, fake_model=False)
+    assert "connectors.duplicate_server" in str(exc.value)
+    assert "grafana" in str(exc.value)
 
 
 def test_the_reserved_list_matches_the_runner_constants() -> None:

--- a/runner/tests/test_connectors.py
+++ b/runner/tests/test_connectors.py
@@ -7,8 +7,10 @@ URL the agent dials is the one the Service actually has.
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 
+import pytest
 from aci_protocol import BootEnv, Budget
 from curie_runner import RunnerConfig
 from curie_runner.__main__ import build_runner
@@ -244,6 +246,90 @@ def test_a_boot_that_renders_no_scope_still_mounts_no_hosted_connector(tmp_path:
         namespace=config.connector_namespace,
     )
     assert servers == {}
+
+
+# --------------------------------------------------------------------------- #
+# A build-form connector reaches the runner identically to an image one
+# (#1690, ADR 0113 Stream B2)
+#
+# The runner never resolves a build: `_read` parses connectors.yaml as shipped
+# in the bundle, and `mcp_entry` derives the URL from `is_hosted` and the
+# Service DNS naming convention alone -- it never reads `.image` (Section 3,
+# `connector_render.py:450`: "no code change ... skill, local and cluster
+# produce byte-identical entries"). `is_hosted` is True for a `build:`
+# connector whether or not its lock has been applied (`connectors.py:245`), so
+# these must already pass with no runner change; the digest resolution these
+# pin against lives entirely in `apply_lock`, upstream of the runner.
+# --------------------------------------------------------------------------- #
+BUILT = (
+    "connectors:\n"
+    "  conn:\n"
+    "    build:\n"
+    "      context: connectors/conn\n"
+    "      platforms: [linux/amd64]\n"
+)
+IMAGED = "connectors:\n  conn:\n    image: acme/conn-mcp:1.0\n"
+
+
+def test_a_build_form_connector_yields_the_same_entry_as_an_image_one(tmp_path: Path) -> None:
+    built = derive_mcp_servers(_bundle(tmp_path / "built", BUILT), **SCOPE)
+    imaged = derive_mcp_servers(_bundle(tmp_path / "imaged", IMAGED), **SCOPE)
+    assert built == imaged
+    assert built["conn"]["url"] == (
+        "http://curie-acme-dev-mcp-conn.curie.svc.cluster.local:8000/mcp"
+    )
+
+
+def test_a_build_form_connector_with_no_lock_applied_is_still_hosted(tmp_path: Path) -> None:
+    # A `build:` connector with no lock applied is hosted-and-unrenderable at
+    # the cluster's render step, but the runner's own scope check must not
+    # treat it as unhosted: an unresolved build with a scope present still
+    # mounts, exactly like an image connector does.
+    servers = derive_mcp_servers(_bundle(tmp_path, BUILT), **SCOPE)
+    assert "conn" in servers
+
+
+# --------------------------------------------------------------------------- #
+# The #1093 log: fires for a stranded hosted connector, silent once scoped
+# --------------------------------------------------------------------------- #
+def test_the_1093_log_fires_for_a_scope_less_hosted_connector(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    # "declared but not exercisable in this tier" must still fire when neither
+    # a connector scope nor an unhosted_url reaches the bundle -- the honest
+    # answer at the skill tier, and the regression this build-form addition
+    # must not silently swallow.
+    with caplog.at_level(logging.INFO, logger="curie_runner.connectors"):
+        derive_mcp_servers(_bundle(tmp_path, HOSTED), release=None, agent=None, namespace=None)
+    assert any(
+        "declared but not exercisable in this tier" in r.message
+        for r in caplog.records
+    )
+
+
+def test_the_1093_log_fires_for_a_scope_less_build_form_connector(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    with caplog.at_level(logging.INFO, logger="curie_runner.connectors"):
+        derive_mcp_servers(_bundle(tmp_path, BUILT), release=None, agent=None, namespace=None)
+    assert any(
+        "declared but not exercisable in this tier" in r.message
+        for r in caplog.records
+    )
+
+
+def test_the_1093_log_does_not_fire_once_a_scope_reaches_the_connector(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    # The scope this ticket makes the local tier able to supply must silence
+    # the log, exactly as it already does on cluster: a connector that is
+    # exercisable here is not "declared but not exercisable" here.
+    with caplog.at_level(logging.INFO, logger="curie_runner.connectors"):
+        derive_mcp_servers(_bundle(tmp_path, HOSTED), **SCOPE)
+    assert not any(
+        "declared but not exercisable in this tier" in r.message
+        for r in caplog.records
+    )
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Closes #1691

Blocked on #1727 merging first: this is the execution half of ADR 0113, stacked on the contract branch. Retarget to `next` after #1727 lands (GitHub does this automatically on merge).

## What this adds

- `curie build --plugin-dir` builds every declared `build:` connector, resolves the digest through docker or buildx metadata, and writes `connectors.lock.yaml` atomically, with a force rule protecting registry locks and a versioned CLI receipt (`ConnectorBuildOutput`, schema in the inventory).
- Tier delivery: skill hosts connectors on the runner's private network with service DNS aliases, staged secret files, and identity labels; local generates a compose overlay joined to the running stack; cluster renders and applies digest pinned objects, with a registry preflight that refuses a lock the registry cannot resolve or that misses a node architecture, before any object changes.
- Fail closed everywhere: stale locks rebuild automatically at skill up before the snapshot packs, unresolved secrets refuse bring up naming every gap, aborted boots reap their connectors and wipe staged credentials, and a redeploy reaps exactly the containers the bundle no longer declares.
- Security hardening from five reviewer passes: connector names validated at the Rust readers, staged filenames collision proof and traversal safe, no resolved secret value ever written to disk at the local tier (compose references plus the masked `secret_env` channel), lock image shapes validated against their delivery, restaging replaces the hardened file, and connector declared secret names held to the manifest name policy (reserved boot env and model credential names refused in the Python validator for every consumer and in the CLI before any value is resolved, drift pinned).
- `examples/sre-bot` adopts the flow as the end to end proof: the k8s-write and tempo connectors build from bundle source with `curie build`, replacing the manual buildx ceremony in the docs.
- A bundle's own `.mcp.json` stays external: it travels on the plugin config channel, never through the platform's connector derivation, pinned by runner tests including the name collision refusal.
- E2E: the parity ladder gains connector rungs and negatives (hermetic no hosting, changed source rebuild, cluster registry missing), and the nightly graded ladder gains a fake model connector leg driving `examples/sre-bot`.

## Evidence (all on the final stack, this box)

- Skill tier, connector mode: LADDER PASS, including the changed source case (edited connector source moved both the lock digest and the running container) and the hermetic negative (a bundle declaring no connector starts none).
- Cluster tier (k8scratch, self hosted registry): LADDER PASS. `curie build --registry` pushed multi arch digest pinned images, the deploy applied 13 objects, all three connector MCP endpoints served, and the registry missing negative refused pre apply with exit 2 and an unchanged Deployment.
- Suites: cli 1444 across 50 suites green at every commit of the series (one known flaky `chat_enqueue` blip, green on retry, file untouched here); plugin-format 448, runner 569, api 895, worker 856 all green.

## Adjudications and deviations

- The mutable tag refusal binds `build:` resolved images; a pinned `image:` declaration is the author's own choice and its own review surface.
- Registry evidence used a self hosted registry:2 (no hosted registry credentials on this box); the flow is registry agnostic.
- Buildx multi arch digests are not deterministic across rebuilds; the single build lock is the binding identity, which is the ADR's point.
- The nightly connector leg runs the fake model on purpose: the sre-bot suite's capability case needs a reachable cluster the CI runner does not have, the same falsifiability failure #1603 removed from the weather grade. A live leg needs a runner reachable cluster or a report only grade.
- The nightly cluster rung stays unwired for connector mode because the workflow provides no pushable registry; wiring it needs a registry plus a container driver buildx builder.

## Follow ups to file

- Skill tier session ids (`local-<unix seconds>`) are collision prone across concurrent sessions.
- A dual network design for `--internal` connector isolation at the skill tier.
- Pre existing: the connector NetworkPolicy admits any release scoped runner (S10), and the local tier shares the `curie_runner` network across agents (S11).