### PR TITLE
Add agent install runbook

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@ git history (`git log -- docs/`).
 
 ## Living documentation
 
+* [`agent-install.md`](agent-install.md): an unattended release install, verification, and result reporting procedure for a coding agent.
 - [`agents.md`](agents.md): the verification contract for an agent driving
   Curie. The exact commands that prove an outcome, what to automate versus what
   to ask a human for, and the rule that a file existing or a string appearing in

--- a/docs/agent-install.md
+++ b/docs/agent-install.md
@@ -1,0 +1,128 @@
+# Agent install
+
+This runbook lets a coding agent install the released Curie CLI without a
+source checkout, verify its signature and checksum, create an isolated bundle,
+and report the result without human input.
+
+Use this canonical raw URL when instructing a coding agent:
+
+<!-- doclint:ignore-line -->
+`https://raw.githubusercontent.com/curie-eng/curie/main/docs/agent-install.md`
+
+The calling environment must already hold one real, nonempty
+`CURIE_CREDENTIALS`, `CLAUDE_CODE_OAUTH_TOKEN`, or `ANTHROPIC_API_KEY` value.
+This runbook never creates a credential, substitutes a placeholder, or prints a
+credential value. Curie reports only the credential name.
+
+## Execute
+
+Run this block unchanged in one Bash session.
+
+```bash
+set -euo pipefail
+
+step=preflight
+finish() {
+  status=$?
+  if [ "$status" -ne 0 ]; then
+    printf '{"INSTALL_RESULT":{"status":"failed","version":null,"doctor_ready":false,"summary":null,"step":"%s","exit_code":%s}}\n' "$step" "$status"
+  fi
+}
+trap finish EXIT
+
+# Step 1: preflight
+case "$(uname -s)/$(uname -m)" in
+  Linux/x86_64|Darwin/arm64|Darwin/aarch64) ;;
+  *)
+    printf 'unsupported platform: %s/%s\n' "$(uname -s)" "$(uname -m)" >&2
+    exit 1
+    ;;
+esac
+command -v curl >/dev/null
+command -v cosign >/dev/null
+command -v docker >/dev/null
+command -v jq >/dev/null
+if ! command -v sha256sum >/dev/null && ! command -v shasum >/dev/null; then
+  printf 'missing sha256sum or shasum\n' >&2
+  exit 1
+fi
+docker info >/dev/null
+CREDENTIAL_NAME=
+for candidate in CURIE_CREDENTIALS CLAUDE_CODE_OAUTH_TOKEN ANTHROPIC_API_KEY; do
+  if [ -n "${!candidate:-}" ]; then
+    CREDENTIAL_NAME="$candidate"
+    break
+  fi
+done
+if [ -z "$CREDENTIAL_NAME" ]; then
+  printf 'missing supported model credential in the environment\n' >&2
+  exit 1
+fi
+RUN_ROOT="$(mktemp -d)"
+printf 'step=preflight result=success workspace=%s credential_name=%s\n' "$RUN_ROOT" "$CREDENTIAL_NAME"
+
+# Step 2: download, verify, and install the release
+step=install
+curl -fsSL https://raw.githubusercontent.com/curie-eng/curie/main/get-curie.sh | CURIE_REQUIRE_COSIGN=1 bash 2>&1 | tee "$RUN_ROOT/install.log"
+grep -Fq '==> cosign verify-blob' "$RUN_ROOT/install.log"
+grep -Fq '==> verifying sha256' "$RUN_ROOT/install.log"
+if [ -w /usr/local/bin ]; then
+  CURIE_BIN=/usr/local/bin/curie
+  export PATH="/usr/local/bin:$PATH"
+else
+  CURIE_BIN="$HOME/.local/bin/curie"
+  export PATH="$HOME/.local/bin:$PATH"
+fi
+test -x "$CURIE_BIN"
+printf 'step=install result=success binary=%s\n' "$CURIE_BIN"
+
+# Step 3: prove the installed binary is executable
+step=version
+CURIE_VERSION="$(curie --version)"
+printf 'step=version result=success curie_version=%s\n' "$CURIE_VERSION"
+
+# Step 4: create a clean bundle for the doctor check
+step=bundle
+cd "$RUN_ROOT"
+curie init agent-install-check
+cd agent-install-check
+test -f .claude-plugin/plugin.json
+printf 'step=bundle result=success bundle_dir=%s\n' "$PWD"
+
+# Step 5: require Curie doctor to report ready
+step=doctor
+KUBECONFIG="$RUN_ROOT/no-kubeconfig" curie --json doctor | tee doctor.json
+jq -e '.ready == true and ([.checks[] | select(.state == "missing")] | length == 0)' doctor.json >/dev/null
+DOCTOR_SUMMARY="$(jq -er '.summary' doctor.json)"
+jq -cn \
+  --arg version "$CURIE_VERSION" \
+  --arg summary "$DOCTOR_SUMMARY" \
+  --arg workspace "$RUN_ROOT" \
+  '{INSTALL_RESULT:{status:"success",version:$version,doctor_ready:true,summary:$summary,workspace:$workspace}}'
+```
+
+## Exit signals
+
+1. Preflight succeeds only when it prints
+   `step=preflight result=success`. An unsupported platform, missing command,
+   stopped Docker daemon, or absent credential exits nonzero and emits an
+   `INSTALL_RESULT` line with `status` set to `failed` and `step` set to
+   `preflight`.
+2. Installation succeeds only when the shell pipeline exits zero and the
+   transcript contains both the cosign and sha256 verification lines. Cosign is
+   mandatory because `CURIE_REQUIRE_COSIGN=1` is set. Any download, signature,
+   checksum, install, or transcript assertion failure exits nonzero with
+   `step` set to `install`.
+3. Binary verification succeeds only when `curie --version` exits zero and
+   prints `step=version result=success`. Any failure exits nonzero with `step`
+   set to `version`.
+4. Bundle setup succeeds only when `curie init agent-install-check` exits zero,
+   the manifest exists, and the block prints `step=bundle result=success`.
+   Any failure exits nonzero with `step` set to `bundle`.
+5. Doctor verification succeeds only when the isolated laptop rung produces
+   valid JSON, `ready` is `true`, and no check has state `missing`. It finishes
+   by printing one compact `INSTALL_RESULT` JSON line. A false readiness value,
+   missing check, invalid JSON, or command failure exits nonzero with `step`
+   set to `doctor`.
+
+Return the final `INSTALL_RESULT` line unchanged with the command transcript.

--- a/llms.txt
+++ b/llms.txt
@@ -7,6 +7,7 @@ The point of the three targets (`skill` in-process, `local` via docker compose, 
 ## Start here
 
 - [QUICKSTART.md](QUICKSTART.md): first agent reply in about a minute, the fastest path in.
+* [docs/agent-install.md](docs/agent-install.md): an unattended release install, verification, and result reporting procedure for a coding agent.
 - [README.md](README.md): what Curie is, how to run it, and the target-by-target CLI walkthroughs.
 - [docs/agents.md](docs/agents.md): the verification contract for an agent driving Curie. The exact commands that prove an outcome, and the rule that a file existing or a string appearing in output is never evidence.
 - [docs/vision.md](docs/vision.md): the north star, who it is for, and the parity thesis new features are held against.


### PR DESCRIPTION
## Summary

Adds one unattended agent install runbook at `docs/agent-install.md` and links it from the machine map and documentation index.

The runbook requires cosign and SHA256 verification, initializes an isolated bundle, requires `curie doctor` to report ready, and emits one machine readable `INSTALL_RESULT` record.

Canonical URL after the release train reaches `main`:

`https://raw.githubusercontent.com/curie-eng/curie/main/docs/agent-install.md`

Verified branch URL:

`https://raw.githubusercontent.com/curie-eng/curie/refs/heads/task/1612-agent-install-runbook/docs/agent-install.md`

Closes #1612

## Verification transcript

The runbook Bash block was extracted from the committed document and executed unchanged inside a fresh Ubuntu 24.04 container. The container received only the declared command prerequisites, the Docker socket, and a real credential by environment name.

```text
debconf: delaying package configuration, since apt-utils is not installed
step=preflight result=success workspace=/tmp/tmp.yIkSXPOJfe credential_name=CLAUDE_CODE_OAUTH_TOKEN
==> downloading curie-x86_64-unknown-linux-gnu (v0.7.0)
==> cosign verify-blob (signed checksums manifest)
Verified OK
==> verifying sha256
curie-x86_64-unknown-linux-gnu: OK
==> installed curie to /usr/local/bin/curie
curie 0.7.0
step=install result=success binary=/usr/local/bin/curie
step=version result=success curie_version=curie 0.7.0
✓ initialized plugin bundle 'agent-install-check' in agent-install-check
created agent-install-check/.claude-plugin/plugin.json
created agent-install-check/skills/agent-install-check/SKILL.md
created agent-install-check/.mcp.json
created agent-install-check/connectors.yaml
created agent-install-check/deploy.yaml
created agent-install-check/evals/cases.json
created agent-install-check/.gitignore
created agent-install-check/AGENTS.md
created agent-install-check/.claude/skills/using-curie/SKILL.md
Next: cd agent-install-check && curie skill up
step=bundle result=success bundle_dir=/tmp/tmp.yIkSXPOJfe/agent-install-check
{"checks":[{"detail":"CLAUDE_CODE_OAUTH_TOKEN (environment)","id":"model-credential","state":"ok","title":"Model credential"},{"detail":"running","id":"docker","state":"ok","title":"Docker"},{"detail":"agent-install-check","id":"bundle","state":"ok","title":"Bundle in this directory"},{"detail":"no kube context — laptop rung only, which is fine","id":"cluster","state":"not_applicable","title":"Cluster"},{"detail":"needs a cluster","id":"release","state":"not_applicable","title":"Curie release"},{"detail":"needs a cluster","id":"slack","state":"not_applicable","title":"Slack"},{"detail":"needs a cluster","id":"clone-credential","state":"not_applicable","title":"Clone credential"},{"detail":"needs a cluster","id":"webhook","state":"not_applicable","title":"Webhook exposure"},{"detail":"needs a cluster","id":"repo-binding","state":"not_applicable","title":"Repo binding"}],"guidance":null,"ready":true,"summary":"Ready to run locally. No cluster release yet, so no Slack and no deploys."}
{"INSTALL_RESULT":{"status":"success","version":"curie 0.7.0","doctor_ready":true,"summary":"Ready to run locally. No cluster release yet, so no Slack and no deploys.","workspace":"/tmp/tmp.yIkSXPOJfe"}}
```

The negative control removed all accepted credential variables. It exited 1 and emitted:

```json
{"INSTALL_RESULT":{"status":"failed","version":null,"doctor_ready":false,"summary":null,"step":"preflight","exit_code":1}}
```

`bash scripts/check-docs.sh` passed with the interface catalog drift free, citations resolved, and documented commands confirmed real. `git diff --check` passed.

## Completion checklist

* [x] Failing tests committed first: not applicable because this changes documentation only.
* [x] Delegated edits: the runbook and index edits were authored by a scoped documentation worker.
* [x] Broadened return types: not applicable because no code changed.
* [x] Correctness review: approved after the doctor command was isolated from unrelated host Kubernetes contexts.
* [x] Scope review: approved with every hunk mapped to issue 1612.
* [x] Sibling path parity: not applicable because no runtime seam changed.
* [x] Guard demonstration: not applicable because no product guard changed. The runbook failure path was still executed as a negative control.
* [x] Consolidation: not applicable on the quick documentation path.
* [x] Security review: not applicable because no auth, data handling, or secret storage changed. The runbook prints credential names only.
* [x] Observable verification: the committed Bash block passed in a clean container and ended with doctor ready.
* [x] Deployed surface: not applicable because the change has no runtime behavior. The required install run was executed directly.
* [x] Full affected validation: `bash scripts/check-docs.sh` and `git diff --check` passed.
