### PR TITLE
Pin the deploy provider wire contract

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -5,6 +5,12 @@ Copyright 2026 CurieTech AI
 
 This product includes software developed at CurieTech AI.
 
+Curie adapts the deploy provider fixture contract design from Block Buzz,
+specifically crates/buzz-backend-kubernetes/tests/fixtures/provider-wire/ and
+crates/buzz-conformance/TRACE_SCHEMA.md. Block Buzz is licensed under the
+Apache License, Version 2.0. This is a design adaptation only; no Rust
+implementation code was copied.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/cli/tests/data/deploy-provider-wire.json
+++ b/cli/tests/data/deploy-provider-wire.json
@@ -1,0 +1,24 @@
+{
+  "plugin": "weather",
+  "label": "v1-123",
+  "environment": "dev",
+  "agent": {
+    "name": "weather",
+    "id": "agt_1"
+  },
+  "version": {
+    "label": "v1-123",
+    "id": "ver_1"
+  },
+  "channel": "unchanged (C0EXAMPLE1)",
+  "bundle": {
+    "ref": "bundles/abc.tar.gz",
+    "sha256": "deadbeef00",
+    "size_bytes": 4096
+  },
+  "deployment": {
+    "id": "dep_1",
+    "environment": "dev",
+    "status": "active"
+  }
+}

--- a/cli/tests/json_emit_contract.rs
+++ b/cli/tests/json_emit_contract.rs
@@ -1016,6 +1016,11 @@ fn delete_output_json_shape_is_pinned() {
 #[test]
 fn deploy_output_json_shape_is_pinned() {
     use curie::commands::DeployOutput;
+
+    let expected: serde_json::Value =
+        serde_json::from_str(include_str!("data/deploy-provider-wire.json"))
+            .expect("cli/tests/data/deploy-provider-wire.json must contain valid JSON");
+
     assert_eq!(
         DeployOutput {
             plugin_name: "weather".to_string(),
@@ -1025,7 +1030,7 @@ fn deploy_output_json_shape_is_pinned() {
             agent_id: "agt_1".to_string(),
             version_label: "v1-123".to_string(),
             version_id: "ver_1".to_string(),
-            channel: "unchanged (C123)".to_string(),
+            channel: "unchanged (C0EXAMPLE1)".to_string(),
             bundle_ref: "bundles/abc.tar.gz".to_string(),
             bundle_sha256: "deadbeef00".to_string(),
             bundle_size_bytes: 4096,
@@ -1034,16 +1039,7 @@ fn deploy_output_json_shape_is_pinned() {
             deployment_status: "active".to_string(),
         }
         .to_json(),
-        json!({
-            "plugin": "weather",
-            "label": "v1-123",
-            "environment": "dev",
-            "agent": {"name": "weather", "id": "agt_1"},
-            "version": {"label": "v1-123", "id": "ver_1"},
-            "channel": "unchanged (C123)",
-            "bundle": {"ref": "bundles/abc.tar.gz", "sha256": "deadbeef00", "size_bytes": 4096},
-            "deployment": {"id": "dep_1", "environment": "dev", "status": "active"},
-        })
+        expected
     );
 }
 

--- a/cli/tests/nightly_graded_ladder.rs
+++ b/cli/tests/nightly_graded_ladder.rs
@@ -454,6 +454,12 @@ const DIVERGENT_DIGEST: &str = "b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2
 /// answers with JSON either way, so tolerating it would hide a deploy that
 /// stopped asking for a receipt).
 fn write_ladder_stubs(dir: &Path) {
+    fs::write(
+        dir.join("deploy-provider-wire.json"),
+        include_str!("data/deploy-provider-wire.json"),
+    )
+    .expect("write deploy provider fixture");
+
     write_executable(
         &dir.join("curie"),
         r#"#!/bin/sh
@@ -504,7 +510,18 @@ print(digest.hexdigest())' "$1"
 # the ladder reads: bundle.sha256, agent.id, version.id, and
 # deployment.{id,environment,status}.
 emit_deploy() {
-    printf '{"plugin":"weather","label":"e2e","environment":"dev","agent":{"name":"weather","id":"%s"},"version":{"label":"e2e","id":"%s"},"channel":"C0LOCALDEV","bundle":{"ref":"weather-e2e.tar.gz","sha256":"%s","size_bytes":2048},"deployment":{"id":"%s","environment":"dev","status":"active"}}\n' "$STUB_AGENT_ID" "$STUB_VERSION_ID" "$1" "$STUB_DEPLOYMENT_ID"
+    python3 -c 'import json, sys
+fixture = json.load(open(sys.argv[1]))
+fixture["agent"]["id"] = sys.argv[2]
+fixture["version"]["id"] = sys.argv[3]
+fixture["deployment"]["id"] = sys.argv[4]
+fixture["bundle"]["sha256"] = sys.argv[5]
+print(json.dumps(fixture, separators=(",", ":")))' \
+        "$STUB_STATE/deploy-provider-wire.json" \
+        "$STUB_AGENT_ID" \
+        "$STUB_VERSION_ID" \
+        "$STUB_DEPLOYMENT_ID" \
+        "$1"
 }
 
 # The DryRunPlan shape (cli/src/ui.rs: {"dry_run":true,"plan":[lines]}) carrying


### PR DESCRIPTION
Closes #1610

Pins the deploy receipt as one committed fixture consumed by the real JSON producer contract and both parity ladder deploy stubs. Keeps the nightly workflow unchanged and records the Apache 2.0 design attribution in NOTICE.

Done check

* [x] Fixture contract was committed before ladder integration.
* [x] All tracked edits were delegated by owned path.
* [x] No return type changed.
* [x] Independent code review approved with source evidence.
* [x] Independent scope review approved all four changed paths.
* [x] Local and cluster ladder siblings consume the same fixture.
* [x] A temporary provider key mutation failed the focused test, and reverting only that mutation restored the pass.
* [x] Consolidation found no safe simplification to apply.
* [x] Security review is not applicable because no security or runtime behavior changed.
* [x] Runtime E2E is not applicable because this changes deterministic test evidence only.
* [x] Formatting, test type checking, clippy, and the complete locked CLI test suite pass.