### PR TITLE
Add a single first run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ it.
 
 New here? [`Quickstart`](#quickstart) gets you a first agent reply in a few minutes.
 
+Run `curie try` for a first reply without configured credentials or prompts. Run
+`curie try --keep` to retain the standard bundle at `./curie-demo` for normal
+`curie skill` commands. The [`Quickstart`](#quickstart) covers the full parity ladder.
+
 Join the [Curie Discord community](https://discord.gg/YZASub2d5B) to connect with other builders.
 
 ## Why your agent breaks when it leaves your laptop

--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -62,6 +62,25 @@ export const commandManifest = {
   "name": "curie",
   "subcommands": [
     {
+      "about": "Scaffold a keyless first reply, using a saved or environment model credential when available",
+      "args": [
+        {
+          "global": false,
+          "help": "Keep the standard scaffold in ./curie-demo for normal skill commands",
+          "id": "keep",
+          "long": "keep",
+          "positional": false,
+          "possible_values": [
+            "true",
+            "false"
+          ],
+          "required": false
+        }
+      ],
+      "hidden": false,
+      "name": "try"
+    },
+    {
       "about": "Scaffold a new plugin bundle (Claude Code plugin shape)",
       "args": [
         {

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -59,6 +59,25 @@
   "name": "curie",
   "subcommands": [
     {
+      "about": "Scaffold a keyless first reply, using a saved or environment model credential when available",
+      "args": [
+        {
+          "global": false,
+          "help": "Keep the standard scaffold in ./curie-demo for normal skill commands",
+          "id": "keep",
+          "long": "keep",
+          "positional": false,
+          "possible_values": [
+            "true",
+            "false"
+          ],
+          "required": false
+        }
+      ],
+      "hidden": false,
+      "name": "try"
+    },
+    {
       "about": "Scaffold a new plugin bundle (Claude Code plugin shape)",
       "args": [
         {

--- a/cli/scripts/e2e.sh
+++ b/cli/scripts/e2e.sh
@@ -122,6 +122,211 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# These are every model credential and model routing input recognized by the
+# current CLI, plus the deprecated cluster credential alias. The empty private
+# store below is the other half of the negative control: making credential
+# discovery mandatory must make this first observation fail rather than quietly
+# borrowing a credential from the host running the E2E.
+TRY_ENV_UNSET=(
+    -u CURIE_CREDENTIALS
+    -u CURIE_MODEL_CREDENTIALS
+    -u CLAUDE_CODE_OAUTH_TOKEN
+    -u ANTHROPIC_API_KEY
+    -u CURIE_MODEL_BASE_URL
+    -u ANTHROPIC_BASE_URL
+    -u CURIE_MODEL
+    -u CURIE_FAKE_MODEL
+)
+TRY_RUNNER_CONTAINER="curie-runner-local"
+
+# `try` uses the product's standard local runner name. Refuse to exercise any
+# try path when it already belongs to somebody else; the EXIT trap only
+# removes the E2E-specific runner, never this shared name.
+if docker inspect "$TRY_RUNNER_CONTAINER" >/dev/null 2>&1; then
+    echo "error: try E2E needs $TRY_RUNNER_CONTAINER to be absent before it starts." >&2
+    echo "fix: stop the existing local runner, then rerun this E2E." >&2
+    exit 1
+fi
+
+echo
+echo "=== curie try (clean keyless first run, closed stdin) ==="
+TRY_ROOT="$WORKDIR/try-clean"
+TRY_CONFIG_DIR="$TRY_ROOT/config"
+TRY_TMPDIR="$TRY_ROOT/tmp"
+mkdir -p "$TRY_CONFIG_DIR" "$TRY_TMPDIR"
+TRY_JSON="$(
+    cd "$TRY_ROOT"
+    env "${TRY_ENV_UNSET[@]}" \
+        TMPDIR="$TRY_TMPDIR" \
+        CURIE_CONFIG_DIR="$TRY_CONFIG_DIR" \
+        "$BIN" --json try </dev/null
+)"
+printf '%s\n' "$TRY_JSON"
+printf '%s' "$TRY_JSON" | python3 -c '
+import json, sys
+
+raw = sys.stdin.read()
+try:
+    payload = json.loads(raw)
+except json.JSONDecodeError as error:
+    sys.exit(f"error: curie --json try must emit exactly one JSON value: {error}")
+if not isinstance(payload, dict):
+    sys.exit("error: curie --json try must emit one JSON object")
+if "all done" not in payload.get("reply", ""):
+    sys.exit(f"error: keyless curie try did not return the fake reply: {payload!r}")
+if payload.get("status") != "done":
+    sys.exit(f"error: keyless curie try did not finish done: {payload!r}")
+if payload.get("finalized") is not True:
+    sys.exit(f"error: keyless curie try did not emit a finalized reply: {payload!r}")
+print("confirmed: keyless curie try emitted exactly one finalized reply object")
+'
+if [[ -e "$TRY_ROOT/curie-demo" ]]; then
+    echo "error: plain \`curie try\` retained $TRY_ROOT/curie-demo; only --keep may create it." >&2
+    exit 1
+fi
+if [[ -n "$(find "$TRY_TMPDIR" -mindepth 1 -maxdepth 1 -print -quit)" ]]; then
+    echo "error: plain \`curie try\` left its disposable scaffold under $TRY_TMPDIR." >&2
+    exit 1
+fi
+echo "confirmed: plain curie try left no ./curie-demo or temporary scaffold"
+
+echo
+echo "=== curie try (discovered credential, safely rejected) ==="
+TRY_CREDENTIAL_ROOT="$WORKDIR/try-credential"
+TRY_CREDENTIAL_CONFIG_DIR="$TRY_CREDENTIAL_ROOT/config"
+TRY_CREDENTIAL_TMPDIR="$TRY_CREDENTIAL_ROOT/tmp"
+TRY_CREDENTIAL_STDOUT="$TRY_CREDENTIAL_ROOT/stdout"
+TRY_CREDENTIAL_STDERR="$TRY_CREDENTIAL_ROOT/stderr"
+TRY_CREDENTIAL_NAME="ANTHROPIC_API_KEY"
+TRY_CREDENTIAL_VALUE="curie-e2e-fake-credential-value"
+mkdir -p "$TRY_CREDENTIAL_CONFIG_DIR" "$TRY_CREDENTIAL_TMPDIR"
+
+if (
+    cd "$TRY_CREDENTIAL_ROOT"
+    env "${TRY_ENV_UNSET[@]}" \
+        TMPDIR="$TRY_CREDENTIAL_TMPDIR" \
+        CURIE_CONFIG_DIR="$TRY_CREDENTIAL_CONFIG_DIR" \
+        "$TRY_CREDENTIAL_NAME=$TRY_CREDENTIAL_VALUE" \
+        "$BIN" try </dev/null >"$TRY_CREDENTIAL_STDOUT" 2>"$TRY_CREDENTIAL_STDERR"
+); then
+    echo "error: curie try accepted the E2E's deliberately fake discovered credential." >&2
+    exit 1
+fi
+if ! grep -qF "$TRY_CREDENTIAL_NAME" "$TRY_CREDENTIAL_STDOUT" && \
+   ! grep -qF "$TRY_CREDENTIAL_NAME" "$TRY_CREDENTIAL_STDERR"; then
+    echo "error: curie try rejected the credential without naming its discovered source." >&2
+    exit 1
+fi
+if grep -qF "$TRY_CREDENTIAL_VALUE" "$TRY_CREDENTIAL_STDOUT" "$TRY_CREDENTIAL_STDERR"; then
+    echo "error: curie try exposed a discovered credential value in its output." >&2
+    exit 1
+fi
+if [[ -n "$(find "$TRY_CREDENTIAL_TMPDIR" -mindepth 1 -maxdepth 1 -print -quit)" ]]; then
+    echo "error: rejected credential run left its disposable scaffold under $TRY_CREDENTIAL_TMPDIR." >&2
+    exit 1
+fi
+if docker inspect "$TRY_RUNNER_CONTAINER" >/dev/null 2>&1; then
+    echo "error: rejected credential run left its local runner behind." >&2
+    exit 1
+fi
+echo "confirmed: discovered credential is named but never exposed, then its scaffold and runner are removed"
+
+echo
+echo "=== curie try --keep (graduate into normal skill commands) ==="
+TRY_KEEP_ROOT="$WORKDIR/try-keep"
+TRY_KEEP_CONFIG_DIR="$TRY_KEEP_ROOT/config"
+TRY_KEEP_PROJECT="$TRY_KEEP_ROOT/curie-demo"
+mkdir -p "$TRY_KEEP_CONFIG_DIR"
+TRY_KEEP_OUTPUT="$(
+    cd "$TRY_KEEP_ROOT"
+    env "${TRY_ENV_UNSET[@]}" \
+        CURIE_CONFIG_DIR="$TRY_KEEP_CONFIG_DIR" \
+        "$BIN" try --keep </dev/null 2>&1
+)"
+printf '%s\n' "$TRY_KEEP_OUTPUT"
+if ! printf '%s' "$TRY_KEEP_OUTPUT" | grep -qF "all done"; then
+    echo "error: keyless \`curie try --keep\` did not return the fake runner reply." >&2
+    exit 1
+fi
+if [[ ! -f "$TRY_KEEP_PROJECT/.claude-plugin/plugin.json" ]]; then
+    echo "error: \`curie try --keep\` did not retain the standard plugin manifest." >&2
+    exit 1
+fi
+python3 - "$TRY_KEEP_PROJECT/.claude-plugin/plugin.json" <<'PY'
+import json, sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    manifest = json.load(handle)
+if manifest.get("name") != "curie-demo":
+    raise SystemExit(f"error: retained scaffold has the wrong plugin name: {manifest!r}")
+print("confirmed: --keep retained the standard curie-demo scaffold")
+PY
+
+(
+    cd "$TRY_KEEP_PROJECT"
+
+    echo
+    echo "=== graduated project: curie skill up --fake-model ==="
+    "$BIN" skill up --fake-model
+
+    echo
+    echo "=== graduated project: curie skill status --json ==="
+    GRADUATED_STATUS_JSON="$("$BIN" skill status --json)"
+    printf '%s\n' "$GRADUATED_STATUS_JSON"
+    printf '%s' "$GRADUATED_STATUS_JSON" | python3 -c '
+import json, sys
+
+payload = json.load(sys.stdin)
+digest = payload.get("bundle_digest")
+if not isinstance(digest, str) or not digest:
+    sys.exit(f"error: graduated project status has no bundle digest: {payload!r}")
+print(f"confirmed: graduated project bundle digest is {digest}")
+'
+
+    echo
+    echo "=== graduated project: curie skill message ==="
+    GRADUATED_REPLY="$("$BIN" skill message "hello again")"
+    printf '%s\n' "$GRADUATED_REPLY"
+    if ! printf '%s' "$GRADUATED_REPLY" | grep -qF "all done"; then
+        echo "error: the graduated project did not return the fake runner reply." >&2
+        exit 1
+    fi
+
+    echo
+    echo "=== graduated project: curie skill down ==="
+    "$BIN" skill down
+    if [[ -e .curie/runner.json ]]; then
+        echo "error: graduated project teardown left .curie/runner.json behind." >&2
+        exit 1
+    fi
+)
+if [[ ! -d "$TRY_KEEP_PROJECT" ]]; then
+    echo "error: normal skill commands removed the graduated curie-demo project." >&2
+    exit 1
+fi
+echo "confirmed: normal skill up, status, message, and down operate on the retained project"
+
+echo
+echo "=== curie try --keep (refuse an existing graduated project) ==="
+TRY_KEEP_MANIFEST="$TRY_KEEP_PROJECT/.claude-plugin/plugin.json"
+TRY_KEEP_MANIFEST_SHA256="$(sha256sum "$TRY_KEEP_MANIFEST" | awk '{print $1}')"
+if TRY_KEEP_COLLISION_OUTPUT="$(
+    cd "$TRY_KEEP_ROOT"
+    env "${TRY_ENV_UNSET[@]}" \
+        CURIE_CONFIG_DIR="$TRY_KEEP_CONFIG_DIR" \
+        "$BIN" try --keep </dev/null 2>&1
+)"; then
+    printf '%s\n' "$TRY_KEEP_COLLISION_OUTPUT"
+    echo "error: curie try --keep overwrote an existing curie-demo project." >&2
+    exit 1
+fi
+printf '%s\n' "$TRY_KEEP_COLLISION_OUTPUT"
+if [[ "$(sha256sum "$TRY_KEEP_MANIFEST" | awk '{print $1}')" != "$TRY_KEEP_MANIFEST_SHA256" ]]; then
+    echo "error: refused curie try --keep altered the existing plugin manifest." >&2
+    exit 1
+fi
+echo "confirmed: a second --keep refuses and preserves the graduated plugin manifest"
+
 echo
 echo "=== Resolve the bundle under test ==="
 if [[ -n "${CURIE_E2E_BUNDLE:-}" ]]; then

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -431,6 +431,161 @@ impl crate::ui::CliOutput for InitOutput {
     }
 }
 
+/// Scaffold and drive the existing local skill path for one first reply.
+pub async fn try_first_run(keep: bool, image: String) -> Result<()> {
+    const DEMO_NAME: &str = "curie-demo";
+    const DEMO_PROMPT: &str = "hello, are you there?";
+
+    let ui = crate::ui::ui();
+    let dir = if keep {
+        PathBuf::from(DEMO_NAME)
+    } else {
+        std::env::temp_dir().join(format!("curie-try-{}", uuid::Uuid::new_v4()))
+    };
+
+    if let Err(err) = scaffold(&dir, DEMO_NAME) {
+        if !keep && dir.exists() {
+            if let Err(cleanup_err) = std::fs::remove_dir_all(&dir) {
+                ui.warn(&format!(
+                    "could not remove incomplete demo at {}: {cleanup_err}",
+                    dir.display()
+                ));
+            }
+        }
+        return Err(err);
+    }
+    ui.note(&format!("scaffolded demo at {}", dir.display()));
+
+    let mut credential_name = None;
+    let mut discovery_error = None;
+    for name in MODEL_CREDENTIAL_ENV_NAMES {
+        if env_credential_present(name) {
+            credential_name = Some(name);
+            break;
+        }
+        match crate::secrets::is_saved(name) {
+            Ok(true) => {
+                credential_name = Some(name);
+                break;
+            }
+            Ok(false) => {}
+            Err(err) => {
+                discovery_error = Some(err);
+                break;
+            }
+        }
+    }
+    if let Some(err) = discovery_error {
+        if !keep {
+            if let Err(cleanup_err) = std::fs::remove_dir_all(&dir) {
+                ui.warn(&format!(
+                    "could not remove temporary demo at {}: {cleanup_err}",
+                    dir.display()
+                ));
+            }
+        }
+        return Err(err);
+    }
+    let fake_model = credential_name.is_none();
+    if let Some(name) = credential_name {
+        ui.note(&format!("using discovered model credential {name}"));
+    } else {
+        ui.note("no model credential found; using the scripted fake model");
+    }
+
+    let started = start(StartOpts {
+        plugin_dir: dir.clone(),
+        image,
+        port: DEFAULT_PORT,
+        name: docker::RUNNER_CONTAINER_LOCAL.to_string(),
+        fake_model,
+        network: None,
+        otel_endpoint: None,
+        budget: DEFAULT_BUDGET.to_string(),
+        model: None,
+        local_model: None,
+        pull_model: false,
+        secret: Vec::new(),
+        env_file: None,
+        replace: false,
+    })
+    .await;
+    if let Err(err) = started {
+        if !keep {
+            if let Err(cleanup_err) = std::fs::remove_dir_all(&dir) {
+                ui.warn(&format!(
+                    "could not remove temporary demo at {}: {cleanup_err}",
+                    dir.display()
+                ));
+            }
+        }
+        return Err(err);
+    }
+
+    let message = send(
+        DEMO_PROMPT,
+        crate::message::DEFAULT_USER,
+        EventType::Message,
+        Some(format!("http://localhost:{DEFAULT_PORT}")),
+    )
+    .await;
+    let teardown = stop(None, &dir).await;
+
+    let classified_failure = match message {
+        Ok(classified_failure) => classified_failure,
+        Err(message_err) => {
+            if let Err(cleanup_err) = &teardown {
+                ui.warn(&format!(
+                    "could not tear down the demo at {}: {cleanup_err}",
+                    dir.display()
+                ));
+            } else if !keep {
+                if let Err(cleanup_err) = std::fs::remove_dir_all(&dir) {
+                    ui.warn(&format!(
+                        "could not remove temporary demo at {}: {cleanup_err}",
+                        dir.display()
+                    ));
+                }
+            }
+            return Err(message_err);
+        }
+    };
+
+    if let Err(cleanup_err) = teardown {
+        ui.failure(&format!(
+            "could not tear down the demo at {}: {cleanup_err}",
+            dir.display()
+        ));
+        ui.note(&format!(
+            "recover with: cd {} && curie skill down",
+            dir.display()
+        ));
+        std::process::exit(1);
+    }
+
+    if keep {
+        let next = if fake_model {
+            "cd curie-demo && curie skill up --fake-model"
+        } else {
+            "cd curie-demo && curie skill up"
+        };
+        ui.note(&format!("kept ./curie-demo; next: {next}"));
+    } else if let Err(cleanup_err) = std::fs::remove_dir_all(&dir) {
+        ui.failure(&format!(
+            "could not remove temporary demo at {}: {cleanup_err}",
+            dir.display()
+        ));
+        std::process::exit(1);
+    } else {
+        ui.note(&format!("removed temporary demo at {}", dir.display()));
+    }
+
+    if classified_failure {
+        std::process::exit(1);
+    }
+    Ok(())
+}
+
 /// `curie build`: build the runner image locally from the repo's Dockerfile.
 /// The one-command equivalent of `docker build -f runner/Dockerfile -t <tag> .`
 /// run from the repo root. Errors clearly when Docker is missing or when run
@@ -1996,8 +2151,7 @@ async fn remove_container_tolerating_absence(
     Ok(())
 }
 
-pub async fn stop(name: Option<String>) -> Result<()> {
-    let dir = Path::new(".");
+pub async fn stop(name: Option<String>, dir: &Path) -> Result<()> {
     let ui = crate::ui::ui();
     let saved = state::load(dir)?;
     let recorded = saved.as_ref().map(|s| s.container_name.clone());
@@ -2305,7 +2459,7 @@ pub async fn send(
     user: &str,
     event_type: EventType,
     url: Option<String>,
-) -> Result<()> {
+) -> Result<bool> {
     let url = resolve_url(url)?;
     let client = RunnerClient::new(&url)?;
     let ui = crate::ui::ui();
@@ -2397,10 +2551,7 @@ pub async fn send(
                 status: status_str(status).to_string(),
                 finalized: true,
             });
-            if *status == SessionStatus::ClassifiedFailure {
-                std::process::exit(1);
-            }
-            return Ok(());
+            return Ok(*status == SessionStatus::ClassifiedFailure);
         }
         // Close the streamed answer on stdout only if the last thing written was
         // un-terminated token text; if a note already added its own newline (or
@@ -2410,11 +2561,9 @@ pub async fn send(
             ui.print_tokens("\n");
         }
         ui.note(&format!("-- final ({})", status_str(status)));
-        if *status == SessionStatus::ClassifiedFailure {
-            std::process::exit(1);
-        }
+        return Ok(*status == SessionStatus::ClassifiedFailure);
     }
-    Ok(())
+    Ok(false)
 }
 
 /// Output of `skill message` under `--json`: the full buffered reply plus the

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -218,6 +218,12 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Command {
+    /// Scaffold a keyless first reply, using a saved or environment model credential when available.
+    Try {
+        /// Keep the standard scaffold in ./curie-demo for normal skill commands.
+        #[arg(long)]
+        keep: bool,
+    },
     /// Scaffold a new plugin bundle (Claude Code plugin shape).
     Init {
         /// Kebab-case plugin name (e.g. deal-desk). Omit when using --from-spec.
@@ -1981,6 +1987,11 @@ fn emit<T: curie::ui::CliOutput>(out: T) -> Result<()> {
 async fn run(command: Option<Command>) -> Result<()> {
     match command {
         None => curie::interactive::run().await,
+        Some(Command::Try { keep }) => {
+            let image =
+                artifacts::resolve_image(None, artifacts::Channel::current(), artifacts::version());
+            commands::try_first_run(keep, image).await
+        }
         Some(Command::Init {
             name,
             dir,
@@ -2133,14 +2144,21 @@ async fn run(command: Option<Command>) -> Result<()> {
             // the verb reports why and exits 4 (issue #459, ADR-0041).
             SkillAction::Versions => Err(commands::skill_versions_unavailable()),
             SkillAction::Memory => Err(commands::skill_memory_unavailable()),
-            SkillAction::Down { name } => commands::stop(name).await,
+            SkillAction::Down { name } => commands::stop(name, std::path::Path::new(".")).await,
             SkillAction::Status { url } => commands::status(url).await,
             SkillAction::Message {
                 text,
                 user,
                 event_type,
                 url,
-            } => commands::send(&text, &user, event_type.into(), url).await,
+            } => {
+                let classified_failure =
+                    commands::send(&text, &user, event_type.into(), url).await?;
+                if classified_failure {
+                    std::process::exit(1);
+                }
+                Ok(())
+            }
             SkillAction::Eval {
                 cases,
                 url,

--- a/cli/tests/command_surface.rs
+++ b/cli/tests/command_surface.rs
@@ -48,6 +48,7 @@ fn process_help_routes_positive_forms() {
         &["cluster", "message"],
         &["cluster", "eval"],
         &["cluster", "deploy"],
+        &["try"],
         &["init"],
         &["interactive"],
         &["secrets", "set"],
@@ -118,6 +119,7 @@ fn process_help_top_level_lists_new_surface_and_hides_retired_verbs() {
         "skill",
         "local",
         "cluster",
+        "try",
         "init",
         "interactive",
         "secrets",
@@ -254,6 +256,24 @@ fn help_flags(args: &[&str]) -> std::collections::BTreeSet<String> {
         .filter(|token| token.starts_with("--") && token.len() > 2)
         .map(|token| token.trim_end_matches(',').to_string())
         .collect()
+}
+
+#[test]
+fn process_try_help_lists_only_keep_beyond_global_flags() {
+    let top_level = output_text(&run_help(&[]));
+    assert!(
+        help_lists_subcommand(&top_level, "try"),
+        "top level help must list try\n{top_level}"
+    );
+
+    let global_flags = help_flags(&[]);
+    let try_flags = help_flags(&["try"]);
+    let command_flags: Vec<_> = try_flags.difference(&global_flags).cloned().collect();
+    assert_eq!(
+        command_flags,
+        vec!["--keep".to_string()],
+        "try must expose --keep as its only command specific flag"
+    );
 }
 
 /// The agent-target verbs share one `AgentTarget<T>` whose only per-tier

--- a/cli/tests/nightly_graded_ladder.rs
+++ b/cli/tests/nightly_graded_ladder.rs
@@ -517,6 +517,32 @@ case "$*" in
     "--version")
         echo "curie test harness"
         ;;
+    "--json try")
+        # The keyless first run is deliberately disposable: its finalized fake
+        # reply is the only observable result, so no project may be retained
+        # in the caller's clean directory.
+        printf '%s\n' '{"status":"done","finalized":true,"reply":"all done"}'
+        ;;
+    "try")
+        # The credential-discovery E2E supplies a known-invalid credential.
+        # Name its source without ever expanding its value, and create neither
+        # a scaffold nor a runner before the rejection.
+        echo "error: discovered credential source ANTHROPIC_API_KEY was rejected" >&2
+        exit 1
+        ;;
+    "try --keep")
+        # Graduation keeps the standard plugin shape, then the normal skill
+        # commands below operate on this directory exactly as they do for a
+        # user-created project. A second graduation must refuse before writing
+        # the retained manifest.
+        if [ -e curie-demo/.claude-plugin/plugin.json ]; then
+            echo "error: curie-demo already exists" >&2
+            exit 1
+        fi
+        mkdir -p curie-demo/.claude-plugin
+        printf '%s\n' '{"name":"curie-demo"}' > curie-demo/.claude-plugin/plugin.json
+        echo "stub try all done"
+        ;;
     "--json cluster status")
         # The case-ids-only control's single injection point: after the local
         # rung deployed and before the cluster rung does, rewrite ONLY the case
@@ -548,6 +574,16 @@ json.dump(d, open(p, "w"))' "$(cat "$STUB_STATE/last_plugin_dir")/evals/cases.js
         # sealed argv, so the sealed row is the honest answer to it.
         echo "  Model    fake (offline, no credential)"
         ;;
+    "skill up --fake-model")
+        # The graduated demo uses the unadorned normal command. It records a
+        # bundle digest and runner state so its status and teardown checks
+        # exercise the same state transition as a regular project.
+        mkdir -p .curie
+        printf '%s' "$(sha_of_bundle "$PWD")" > "$STUB_STATE/skill_digest"
+        printf '%s\n' '{"runner":"stub"}' > .curie/runner.json
+        echo "stub: runner up"
+        echo "  Model    fake (offline, no credential)"
+        ;;
     "skill up --fake-model --plugin-dir "*" --name "*)
         # The #747 leftover-runner case: a taken container name must be a usage
         # refusal (exit 2) carrying the operator's own remedy, never docker's raw
@@ -563,7 +599,7 @@ json.dump(d, open(p, "w"))' "$(cat "$STUB_STATE/last_plugin_dir")/evals/cases.js
         printf '{"bundle_digest":"%s"}\n' "$(cat "$STUB_STATE/skill_digest")"
         ;;
     "skill message "*)
-        echo "stub skill weather reply"
+        echo "stub skill all done reply"
         ;;
     "--json skill eval")
         # The bundle's OWN suite, read off the bundle e2e.sh cd'd into, because
@@ -585,6 +621,7 @@ print(json.dumps({
 }))' "$PWD/evals/cases.json"
         ;;
     "skill down")
+        rm -f .curie/runner.json
         echo "stub: runner down"
         ;;
     "skill down --name "*)
@@ -657,6 +694,13 @@ esac
         r#"#!/bin/sh
 set -u
 case "$*" in
+    "inspect curie-runner-local")
+        # The first-run credential check refuses to touch an existing shared
+        # local runner. Its harness begins with no such runner, while all
+        # other inspect shapes retain their existing configured behavior.
+        echo "stub docker: no such object: curie-runner-local" >&2
+        exit 1
+        ;;
     "inspect "*)
         # A failed env read, on its own knob: an inspect that dies (the worker
         # exited since the `docker ps`, or a daemon blip) prints nothing, which


### PR DESCRIPTION
Closes #1613

## Summary

* Adds `curie try` as one first run entry point over the existing scaffold, skill runner, and message path.
* Uses the scripted fake model when no credential exists, and names a discovered credential source without printing its value.
* Adds `curie try --keep` to retain `./curie-demo` for normal skill commands.
* Places the command near the top of the README.

## Acceptance evidence

Clean keyless run:

> $ env with no model credentials curie --json try
> {"done":true,"phase":"finalized","reply":"Looking into itall done"}
> confirmed: plain curie try left no ./curie-demo or temporary scaffold

Graduation run:

> $ curie try --keep
> kept ./curie-demo; next: cd curie-demo && curie skill up --fake-model
> $ cd curie-demo && curie skill up --fake-model
> started local runner for curie-demo
> $ curie skill status --json
> {"running":true,"bundle_digest":"sha256:..."}
> $ curie skill message "hello, are you there?"
> Looking into itall done

Saved credential run:

> $ curie try
> using discovered model credential CURIE_CREDENTIALS
> Yes, I'm here. What can I help you with?

The fake credential negative control named only `ANTHROPIC_API_KEY`, rejected the invalid value, removed its runner and scaffold, and confirmed the value never appeared in output. Temporarily making credential discovery mandatory made the E2E fail. Temporarily disabling cleanup made it fail on the retained temporary scaffold.

## Verification

* `cargo fmt --check`
* `cargo check`
* `cargo clippy -- -D warnings`
* `cargo test`, including 802 library tests and all CLI integration tests
* `bash scripts/check-docs.sh`
* `pnpm lint`, `pnpm typecheck`, and `pnpm test`, 147 UI tests
* `CURIE_E2E_TIERS=skill curie dev e2e-ladder`
* Full `cli/scripts/e2e.sh`

The local ladder refused to claim an artifact because the reused shared stack already contains two active deployments. This run did not wipe another owner's stack. The changed CLI path itself passed the full direct E2E above.

## Completion

* [x] Acceptance criteria verified
* [x] Review approved
* [x] Branch clean and pushed
* [x] Commit message gates passed
