### PR TITLE
Document parity ladder vision

### DIFF
--- a/docs/VISION_PARITY_LADDER.md
+++ b/docs/VISION_PARITY_LADDER.md
@@ -1,0 +1,25 @@
+# Vision: parity ladder
+
+## The guarantee
+
+The parity ladder makes one bounded guarantee: each named core rung packages one canonical source tree independently, requires matching SHA256 digests, including [evals/cases.json](../evals/cases.json), then exercises that artifact through its own `curie` path. It is evidence that the packers, artifact identity, case identity, and selected runtime path agree, not a claim that every environment is equivalent. [Ladder script](../cli/scripts/e2e-ladder.sh)
+
+## Skill
+
+Skill runs the bundle through the existing skill end to end flow and its evaluator. In a live nightly run, it is the content graded rung: the weather evaluation must report one passing case and no failures. [Ladder script](../cli/scripts/e2e-ladder.sh) [Nightly workflow](../.github/workflows/nightly-graded-ladder.yaml)
+
+## Local
+
+Local brings up the development compose stack, deploys the same bundle, sends a message, and tears the stack down. A live green requires a finalized, nonempty reply that is not the fake model sentinel. [Ladder script](../cli/scripts/e2e-ladder.sh) [ADR 0081](adr/0081-nightly-graded-parity-ladder.md)
+
+## Cluster
+
+Cluster deploys the bundle and messages an already installed release. The nightly cluster job uses kind, and a live green has the same finalized reply and fake sentinel checks as local. [Ladder script](../cli/scripts/e2e-ladder.sh) [Nightly workflow](../.github/workflows/nightly-graded-ladder.yaml) [ADR 0081](adr/0081-nightly-graded-parity-ladder.md)
+
+## What runs nightly
+
+GitHub Actions runs the core skill, local, and cluster rungs against a real OpenRouter model at 08:00 UTC. Local release is separate companion coverage of the generated release compose path, not a fourth core rung. [Nightly workflow](../.github/workflows/nightly-graded-ladder.yaml) [Ladder script](../cli/scripts/e2e-ladder.sh)
+
+## Honest costs
+
+The latest twenty nightly workflow runs, checked 2026 08 20, contain ten successes and ten failures. [Workflow history](https://github.com/curie-eng/curie/actions/workflows/nightly-graded-ladder.yaml) A green fake rung proves plumbing, never that a real model given the bundle answers. A green local or cluster live rung proves a real, nonempty, finalized reply rather than its content being correct. [ADR 0081](adr/0081-nightly-graded-parity-ladder.md) The warm pool cannot bind a real model claim because its bundle environment arrives after its init containers have run, so that claim still needs cold recreation. [Issue 1492](https://github.com/curie-eng/curie/issues/1492)


### PR DESCRIPTION
Closes #1614

States the bounded parity guarantee and the three core rungs for readers outside the ADR record.

Records nightly live coverage, the current 10 of 20 pass rate, and the limits a green rung does not prove.