### PR TITLE
Deny host credentials to agent children

### DIFF
--- a/apps/worker/src/curie_worker/sandbox/docker.py
+++ b/apps/worker/src/curie_worker/sandbox/docker.py
@@ -73,6 +73,7 @@ from .types import (
     OperatingMode,
     SandboxError,
     SandboxView,
+    filter_agent_child_env,
 )
 
 logger = logging.getLogger(__name__)
@@ -298,7 +299,7 @@ class DockerSandboxClient:
         env: dict[str, str] | None = None,
         labels: dict[str, str] | None = None,
     ) -> None:
-        env = dict(env or {})
+        env = filter_agent_child_env(env)
         plugin_dir = env.get(PLUGIN_DIR_ENV, self._default_plugin_dir)
         args = [
             "run",

--- a/apps/worker/src/curie_worker/sandbox/k8s.py
+++ b/apps/worker/src/curie_worker/sandbox/k8s.py
@@ -25,6 +25,7 @@ from .types import (
     OperatingMode,
     QuotaRejection,
     SandboxView,
+    filter_agent_child_env,
 )
 
 CORE_GROUP = "agents.x-k8s.io"
@@ -237,6 +238,7 @@ class KubernetesSandboxClient:
         env: dict[str, str] | None = None,
         labels: dict[str, str] | None = None,
     ) -> None:
+        env = filter_agent_child_env(env)
         body: dict[str, Any] = {
             "apiVersion": f"{EXT_GROUP}/{EXT_VERSION}",
             "kind": "SandboxClaim",

--- a/apps/worker/src/curie_worker/sandbox/types.py
+++ b/apps/worker/src/curie_worker/sandbox/types.py
@@ -11,10 +11,15 @@ from __future__ import annotations
 
 import hashlib
 import json
+from collections.abc import Mapping
 from dataclasses import asdict, dataclass
 from datetime import datetime
 from enum import StrEnum
 from typing import Literal, Protocol
+
+from aci_protocol import BootEnv
+from aci_protocol.service_config import API_KEY_ENV
+from plugin_format import is_reserved_boot_env_name
 
 # Substrate-neutral labels: every backend tags its managed objects with these
 # (the Kubernetes adapter on claims, the Docker adapter on containers), so they
@@ -22,6 +27,43 @@ from typing import Literal, Protocol
 MANAGED_BY_LABEL = "curietech.ai/managed-by"
 MANAGED_BY_VALUE = "curie-sandbox-substrate"
 THREAD_HASH_LABEL = "curietech.ai/thread-hash"
+
+HOST_APPLICATION_CREDENTIAL_ENV_NAMES: frozenset[str] = frozenset(
+    {
+        "POSTGRES_PASSWORD",
+        "DATABASE_URL",
+        "VALKEY_PASSWORD",
+        "SLACK_BOT_TOKEN",
+        "S3_ACCESS_KEY",
+        "S3_SECRET_KEY",
+        API_KEY_ENV,
+        "LANGFUSE_SECRET_KEY",
+        "CURIE_ADAPTER_CREDENTIALS",
+        "CURIE_SEALING_PRIVATE_KEY",
+        "CURIE_SEALING_PREVIOUS_PRIVATE_KEY",
+    }
+)
+
+
+def filter_agent_child_env(env: Mapping[str, str] | None) -> dict[str, str]:
+    """Return a copied child environment without host application credentials."""
+
+    if env is None:
+        return {}
+    declared_connector_secret_names = {
+        name
+        for name in env.get(BootEnv.env_key("connector_secret_keys"), "").split(",")
+        if name
+    }
+    return {
+        name: value
+        for name, value in env.items()
+        if name not in HOST_APPLICATION_CREDENTIAL_ENV_NAMES
+        or (
+            name in declared_connector_secret_names
+            and not is_reserved_boot_env_name(name)
+        )
+    }
 
 
 class RouteState(StrEnum):
@@ -195,7 +237,14 @@ class SandboxClient(Protocol):
         pool: str,
         env: dict[str, str] | None = None,
         labels: dict[str, str] | None = None,
-    ) -> None: ...
+    ) -> None:
+        """Create a claim after excluding host credentials from the child environment.
+
+        Implementations must apply ``filter_agent_child_env`` before constructing
+        any agent child environment.
+        """
+
+        ...
 
     def get_claim(self, name: str) -> ClaimView | None: ...
 

--- a/apps/worker/tests/sandbox/test_docker.py
+++ b/apps/worker/tests/sandbox/test_docker.py
@@ -9,10 +9,12 @@ from __future__ import annotations
 
 import io
 import logging
+import os
 import tarfile
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
+import pytest
 from curie_worker.bundle_store import extract_bundle
 from curie_worker.sandbox.docker import (
     RUNNER_CONTAINER_PORT,
@@ -71,6 +73,77 @@ def test_create_claim_argv_carries_boot_env() -> None:
     assert "CURIE_FAKE_MODEL=1" in envs
     assert "OTEL_EXPORTER_OTLP_ENDPOINT=http://otel:4318" in envs
     assert argv[-1] == "curie-runner"
+
+
+def test_create_claim_excludes_host_credentials_from_child_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    denied_names = {
+        "POSTGRES_PASSWORD",
+        "DATABASE_URL",
+        "VALKEY_PASSWORD",
+        "SLACK_BOT_TOKEN",
+        "S3_ACCESS_KEY",
+        "S3_SECRET_KEY",
+        "CURIE_API_KEY",
+        "LANGFUSE_SECRET_KEY",
+        "CURIE_ADAPTER_CREDENTIALS",
+        "CURIE_SEALING_PRIVATE_KEY",
+        "CURIE_SEALING_PREVIOUS_PRIVATE_KEY",
+    }
+    for name in denied_names:
+        monkeypatch.setenv(name, "placeholder")
+    monkeypatch.setenv("CURIE_BUDGET", "{}")
+    monkeypatch.setenv("CURIE_CREDENTIALS", "placeholder")
+    monkeypatch.delenv("CURIE_BUNDLE_REF", raising=False)
+    monkeypatch.delenv("CURIE_FAKE_MODEL", raising=False)
+    monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
+    monkeypatch.delenv("CURIE_CONNECTOR_SECRET_KEYS", raising=False)
+
+    client = _RecordingDocker(image="curie-runner", bundle_store=_FakeBundleStore())
+    client.create_claim("thread-credentials", pool="pool", env=os.environ)
+
+    child_env_names = {
+        entry.partition("=")[0] for entry in _flag_values(client.calls[0], "-e")
+    }
+    assert denied_names.isdisjoint(child_env_names)
+    assert "CURIE_BUDGET" in child_env_names
+    assert "CURIE_CREDENTIALS" in child_env_names
+
+
+def test_create_claim_preserves_declared_connector_secret() -> None:
+    client = _RecordingDocker(image="curie-runner", bundle_store=_FakeBundleStore())
+    client.create_claim(
+        "thread-connector-secret",
+        pool="pool",
+        env={
+            "CURIE_CONNECTOR_SECRET_KEYS": "SLACK_BOT_TOKEN",
+            "SLACK_BOT_TOKEN": "placeholder",
+        },
+    )
+
+    child_env_names = {
+        entry.partition("=")[0] for entry in _flag_values(client.calls[0], "-e")
+    }
+    assert {"CURIE_CONNECTOR_SECRET_KEYS", "SLACK_BOT_TOKEN"} <= child_env_names
+
+
+def test_create_claim_connector_marker_cannot_readmit_reserved_curie_credential() -> None:
+    client = _RecordingDocker(image="curie-runner", bundle_store=_FakeBundleStore())
+    client.create_claim(
+        "thread-reserved-connector-secret",
+        pool="pool",
+        env={
+            "CURIE_CONNECTOR_SECRET_KEYS": "CURIE_SEALING_PRIVATE_KEY",
+            "CURIE_SEALING_PRIVATE_KEY": "placeholder",
+        },
+    )
+
+    child_env_names = {
+        entry.partition("=")[0] for entry in _flag_values(client.calls[0], "-e")
+    }
+    assert "CURIE_CONNECTOR_SECRET_KEYS" in child_env_names
+    assert "CURIE_SEALING_PRIVATE_KEY" not in child_env_names
 
 
 def test_create_claim_fetches_and_unwraps_bundle() -> None:

--- a/apps/worker/tests/sandbox/test_k8s_claim.py
+++ b/apps/worker/tests/sandbox/test_k8s_claim.py
@@ -10,6 +10,7 @@ named entries fails ``test_bundle_ref_targets_init_containers_by_name``.
 from __future__ import annotations
 
 import copy
+import os
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
@@ -129,6 +130,37 @@ def test_credential_is_never_written_to_the_claim() -> None:
     assert all("super-secret-token" not in e.get("value", "") for e in entries)
     # The rest of the boot env is still written.
     assert {"name": "CURIE_BUDGET", "value": "{}"} in entries
+
+
+def test_host_credentials_are_never_written_to_the_claim(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    denied_names = {
+        "POSTGRES_PASSWORD",
+        "DATABASE_URL",
+        "VALKEY_PASSWORD",
+        "SLACK_BOT_TOKEN",
+        "S3_ACCESS_KEY",
+        "S3_SECRET_KEY",
+        "CURIE_API_KEY",
+        "LANGFUSE_SECRET_KEY",
+        "CURIE_ADAPTER_CREDENTIALS",
+        "CURIE_SEALING_PRIVATE_KEY",
+        "CURIE_SEALING_PREVIOUS_PRIVATE_KEY",
+    }
+    for name in denied_names:
+        monkeypatch.setenv(name, "placeholder")
+    monkeypatch.setenv("CURIE_BUDGET", "{}")
+    monkeypatch.setenv("CURIE_CREDENTIALS", "placeholder")
+    monkeypatch.delenv("CURIE_CONNECTOR_SECRET_KEYS", raising=False)
+
+    api = _FakeApi()
+    _client(api).create_claim("claim-credentials", pool="pool", env=os.environ)
+
+    claim_env_names = {entry["name"] for entry in _env_entries(api)}
+    assert denied_names.isdisjoint(claim_env_names)
+    assert "CURIE_BUDGET" in claim_env_names
+    assert "CURIE_CREDENTIALS" not in claim_env_names
 
 
 def test_runner_token_is_a_plaintext_env_entry_credential_excluded() -> None:


### PR DESCRIPTION
Closes #1617

Issue #1459 shipped the channel port without this child environment boundary, so this lands as a follow up rather than folded scope.

Filters host application credentials before Docker and Kubernetes agent child construction. Preserves declared agent connector secrets while reserved names remain denied.