### PR TITLE
Use ephemeral ports for cluster messages

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -856,7 +856,8 @@ jobs:
   # deploy`/`cluster message` self-plumb kubectl port-forwards and read the
   # release's UI `/api` NodePort. The hard leg is POD->HOST: the in-cluster
   # worker must POST its reply back to the host-bound Slack stub that `cluster
-  # message` binds on 0.0.0.0:8155 on THIS runner. `cluster message`
+  # message` binds on 0.0.0.0 with a kernel assigned ephemeral port on THIS
+  # runner. `cluster message`
   # auto-detects the host to advertise from the kubeconfig API-server address,
   # but a kind cluster's API server is bound on loopback (127.0.0.1:<port>), so
   # auto-detection yields 127.0.0.1 -- which an in-cluster pod cannot route to.
@@ -1114,9 +1115,10 @@ jobs:
       # with pullPolicy Never (the runner AND its prewarm DaemonSet), force gVisor
       # off (no runsc on kind nodes), and drop the dispatcher (no Slack; its
       # presence would trip the `cluster message` reply-hijack guard).
-      # worker.slackTrustedOrigins is a CI-only widening that lets the worker
-      # answer the host-side reply stub (port = STUB_PORT in
-      # cli/scripts/e2e-ladder.sh); the chart default stays empty and fail-closed.
+      # worker.slackTrustedOrigins is a CI only widening that lets the worker
+      # answer the host side reply stub on any kernel assigned port on this
+      # host. The portless origin is intentional because `cluster message`
+      # requests an ephemeral port; the chart default stays empty and fail closed.
       - name: Install the platform (curie cluster up)
         env:
           CURIE_BIN: cli/target/release/curie
@@ -1128,7 +1130,7 @@ jobs:
             --fake-model \
             --set security.gvisor.mode=off \
             --set dispatcher.deploy=false \
-            --set worker.slackTrustedOrigins="http://${CURIE_E2E_LISTEN_HOST}:8155" \
+            --set worker.slackTrustedOrigins="http://${CURIE_E2E_LISTEN_HOST}" \
             --set api.image.repository=curie-api --set api.image.tag=local --set api.image.pullPolicy=Never \
             --set worker.image.repository=curie-worker --set worker.image.tag=local --set worker.image.pullPolicy=Never \
             --set ui.image.repository=curie-ui --set ui.image.tag=local --set ui.image.pullPolicy=Never \

--- a/.github/workflows/nightly-graded-ladder.yaml
+++ b/.github/workflows/nightly-graded-ladder.yaml
@@ -388,10 +388,10 @@ jobs:
       # runsc on kind nodes -- a real-model install fails closed without this),
       # and drop the dispatcher (no Slack; its presence would trip the
       # `cluster message` reply-hijack guard). The secret travels in env, never
-      # on argv. worker.slackTrustedOrigins is a CI-only widening that lets the
-      # worker answer the host-side reply stub (port = STUB_PORT in
-      # cli/scripts/e2e-ladder.sh); the chart default stays empty and
-      # fail-closed.
+      # on argv. worker.slackTrustedOrigins is a CI only widening that lets the
+      # worker answer the host side reply stub on any kernel assigned port on
+      # this host. The portless origin is intentional because `cluster message`
+      # requests an ephemeral port; the chart default stays empty and fail closed.
       - name: Install the platform (curie cluster up, graded)
         env:
           CURIE_BIN: cli/target/release/curie
@@ -405,7 +405,7 @@ jobs:
             --allow-egress-host openrouter \
             --set security.gvisor.mode=off \
             --set dispatcher.deploy=false \
-            --set worker.slackTrustedOrigins="http://${CURIE_E2E_LISTEN_HOST}:8155" \
+            --set worker.slackTrustedOrigins="http://${CURIE_E2E_LISTEN_HOST}" \
             --set api.image.repository=curie-api --set api.image.tag=local --set api.image.pullPolicy=Never \
             --set worker.image.repository=curie-worker --set worker.image.tag=local --set worker.image.pullPolicy=Never \
             --set ui.image.repository=curie-ui --set ui.image.tag=local --set ui.image.pullPolicy=Never \

--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -2503,7 +2503,7 @@ export const commandManifest = {
             },
             {
               "default_values": [
-                "8155"
+                "0"
               ],
               "global": false,
               "help": "Port the stub binds (0.0.0.0); the worker posts here",
@@ -2514,7 +2514,7 @@ export const commandManifest = {
             },
             {
               "default_values": [
-                "56381"
+                "0"
               ],
               "global": false,
               "help": "Local port the Valkey port-forward binds",
@@ -2534,7 +2534,7 @@ export const commandManifest = {
             },
             {
               "default_values": [
-                "8123"
+                "0"
               ],
               "global": false,
               "help": "Local port the API port-forward binds (default-channel lookup)",

--- a/apps/worker/src/curie_worker/slack_sink.py
+++ b/apps/worker/src/curie_worker/slack_sink.py
@@ -115,11 +115,11 @@ def _configured_origins(origins: Sequence[str]) -> set[_TrustedOrigin]:
 
     An entry that names a PORT keeps it and is matched exactly. An entry that
     omits the port (``http://host.docker.internal``) carries ``None``, which
-    trusts any port on that scheme+host: the CLI's stub binds an EPHEMERAL port
-    on `curie chat` and on ``cluster message --listen-port 0``, so there is no
-    port an operator could write down in advance. It is a dev affordance and
-    nothing else -- it widens trust to every port on a named host, so it belongs
-    on a loopback or docker-host name, never in production.
+    trusts any port on that scheme and host. The CLI stub uses an EPHEMERAL
+    callback port by default for ``cluster message``, so an operator must use a
+    portless origin such as ``http://10.0.0.7`` for a LAN or kind callback host
+    to admit the kernel assigned port. This is dev only because it trusts every
+    port on that exact host. Leave the override empty in production.
     """
     configured: set[_TrustedOrigin] = set()
     for raw in origins:

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -893,12 +893,12 @@ worker:
   # Slack) is the only endpoint the worker will send the bot token to, and every
   # cross-origin endpoint a turn names is refused before any request.
   #
-  # DEV ONLY. It exists for `curie cluster message`, whose throwaway stub binds a
-  # host and port the single slackApiBaseUrl cannot also name -- and, with
-  # `--listen-port 0`, an EPHEMERAL port. An entry that omits the port
-  # (http://host.docker.internal) therefore trusts ANY port on that host, so
-  # setting one on a real deployment widens where the platform bot token can go.
-  # A LAN-host dev setup (`--listen-host <ip>`) must name that host here itself.
+  # DEV ONLY. `curie cluster message` uses an EPHEMERAL callback port by
+  # default. To trust a LAN or kind callback host, set a portless origin such as
+  # `http://10.0.0.7` or `http://host.docker.internal`; omitting the port admits
+  # the kernel assigned port. This trusts ANY port on that exact host, so it can
+  # widen where the platform bot token can go and belongs only in development.
+  # The empty default above remains the fail closed production posture.
   # Rendered only when non-empty.
   slackTrustedOrigins: ""
   # Per-ADAPTER egress credentials (ADR-0096 D4.2), a map of adapter slug ->

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -2500,7 +2500,7 @@
             },
             {
               "default_values": [
-                "8155"
+                "0"
               ],
               "global": false,
               "help": "Port the stub binds (0.0.0.0); the worker posts here",
@@ -2511,7 +2511,7 @@
             },
             {
               "default_values": [
-                "56381"
+                "0"
               ],
               "global": false,
               "help": "Local port the Valkey port-forward binds",
@@ -2531,7 +2531,7 @@
             },
             {
               "default_values": [
-                "8123"
+                "0"
               ],
               "global": false,
               "help": "Local port the API port-forward binds (default-channel lookup)",

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -175,8 +175,9 @@ async fn resolve_cluster_conn(
         message::API_REMOTE_PORT,
     ) {
         Some(pf_cmd) => {
-            let child = message::start_port_forward(&pf_cmd, local_port, "cluster api").await?;
-            (format!("http://localhost:{local_port}"), Some(child))
+            let (child, effective_port) =
+                message::start_port_forward(&pf_cmd, local_port, "cluster api").await?;
+            (format!("http://localhost:{effective_port}"), Some(child))
         }
         None => {
             let url = api_url.expect("explicit url when no port-forward");
@@ -1598,10 +1599,10 @@ enum ClusterAction {
         #[arg(long)]
         listen_host: Option<String>,
         /// Port the stub binds (0.0.0.0); the worker posts here.
-        #[arg(long, default_value_t = message::DEFAULT_LISTEN_PORT)]
+        #[arg(long, default_value_t = 0)]
         listen_port: u16,
         /// Local port the Valkey port-forward binds.
-        #[arg(long, default_value_t = message::DEFAULT_VALKEY_LOCAL_PORT)]
+        #[arg(long, default_value_t = 0)]
         valkey_local_port: u16,
         /// Valkey password. Omit to read the release's own password from its
         /// chart Secret. Prefer the CURIE_VALKEY_PASSWORD env var over passing
@@ -1615,7 +1616,7 @@ enum ClusterAction {
         )]
         valkey_password: Option<String>,
         /// Local port the API port-forward binds (default-channel lookup).
-        #[arg(long, default_value_t = message::DEFAULT_API_LOCAL_PORT)]
+        #[arg(long, default_value_t = 0)]
         api_local_port: u16,
         /// Platform API key for the default-channel lookup. Omit to read the
         /// release's own key from its chart Secret.
@@ -3046,13 +3047,13 @@ async fn run(command: Option<Command>) -> Result<()> {
                     message::API_REMOTE_PORT,
                 ) {
                     Some(pf_cmd) => {
-                        _deploy_pf = Some(
-                            message::start_port_forward(&pf_cmd, local_port, "deploy api").await?,
-                        );
+                        let (deploy_pf, effective_port) =
+                            message::start_port_forward(&pf_cmd, local_port, "deploy api").await?;
+                        _deploy_pf = Some(deploy_pf);
                         // svc/<release>-api serves the platform API at ROOT, so the
                         // base URL has NO /api suffix (the /api in ADR-0024 was only
                         // because the request went through the UI pod).
-                        format!("http://localhost:{local_port}")
+                        format!("http://localhost:{effective_port}")
                     }
                     None => {
                         _deploy_pf = None;

--- a/cli/src/message.rs
+++ b/cli/src/message.rs
@@ -30,6 +30,7 @@ use std::time::{Duration, Instant};
 use anyhow::{bail, Context, Result};
 use curie_aci_protocol::QueuedTurn;
 use redis::aio::MultiplexedConnection;
+use tokio::io::{AsyncBufReadExt, BufReader};
 
 use crate::api::{Agent, ApiClient};
 use crate::chat::{
@@ -825,25 +826,64 @@ fn detect_local_ip(host: &str, port: u16) -> Option<std::net::IpAddr> {
 }
 
 /// Spawn a `kubectl port-forward` child (killed on drop via `kill_on_drop`) and
-/// block until its local port accepts TCP, so callers can use it immediately.
+/// block until its effective local port accepts TCP, so callers can use it
+/// immediately. The returned port is the requested value unless kubectl assigns
+/// one for a zero request.
 pub async fn start_port_forward(
     cmd: &OpsCommand,
     local_port: u16,
     label: &str,
-) -> Result<tokio::process::Child> {
+) -> Result<(tokio::process::Child, u16)> {
     crate::ui::ui().plumbing(&format!("+ {}", cmd.display()));
     let mut child = tokio::process::Command::new(&cmd.program)
         .args(cmd.argv())
         .kill_on_drop(true)
-        .stdout(Stdio::null())
+        .stdout(if local_port == 0 {
+            Stdio::piped()
+        } else {
+            Stdio::null()
+        })
         .stderr(Stdio::null())
         .spawn()
         .with_context(|| format!("spawning `{}` (is kubectl on PATH?)", cmd.program))?;
-    wait_for_tcp(local_port, Duration::from_secs(15))
+    let timeout = Duration::from_secs(15);
+    let deadline = Instant::now() + timeout;
+    let effective_port = if local_port == 0 {
+        let stdout = child
+            .stdout
+            .take()
+            .context("capturing kubectl output for an assigned local port")?;
+        let mut lines = BufReader::new(stdout).lines();
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        let assigned = tokio::time::timeout(remaining, async {
+            loop {
+                let line = lines
+                    .next_line()
+                    .await
+                    .context("reading kubectl forwarding readiness")?
+                    .context("kubectl exited before reporting an assigned local port")?;
+                if let Some(port) = parse_forwarded_port(&line)? {
+                    return Ok::<u16, anyhow::Error>(port);
+                }
+            }
+        })
         .await
-        .with_context(|| format!("the {label} port-forward never opened localhost:{local_port}"))?;
+        .with_context(|| format!("the {label} port forward never reported an assigned port"))??;
+        std::mem::drop(tokio::spawn(async move {
+            while matches!(lines.next_line().await, Ok(Some(_))) {}
+        }));
+        assigned
+    } else {
+        local_port
+    };
+    let remaining = deadline.saturating_duration_since(Instant::now());
+    wait_for_tcp(effective_port, remaining)
+        .await
+        .with_context(|| {
+            format!("the {label} port-forward never opened localhost:{effective_port}")
+        })?;
     // The port accepting TCP is not proof WE bound it. If another process was
-    // already listening on localhost:{local_port}, kubectl could not bind, so it
+    // already listening on localhost:{effective_port}, kubectl could not bind, so it
     // exited, and the socket that just answered is the squatter's -- a caller
     // that then posts a discovered key would leak it to that process. If the
     // child has already exited by the time TCP connects, it never held the port;
@@ -851,11 +891,28 @@ pub async fn start_port_forward(
     // stays race-tolerant: only a definitely-exited child trips the guard).
     if child.try_wait()?.is_some() {
         bail!(
-            "the {label} port-forward exited immediately; localhost:{local_port} is already in \
+            "the {label} port-forward exited immediately; localhost:{effective_port} is already in \
              use by another process. Free that port or stop the conflicting process, then retry."
         );
     }
-    Ok(child)
+    Ok((child, effective_port))
+}
+
+fn parse_forwarded_port(line: &str) -> Result<Option<u16>> {
+    let Some(readiness) = line.strip_prefix("Forwarding from ") else {
+        return Ok(None);
+    };
+    let (source, _) = readiness
+        .split_once(" -> ")
+        .context("kubectl reported malformed forwarding readiness")?;
+    let port = source
+        .parse::<std::net::SocketAddr>()
+        .context("kubectl reported an invalid assigned local address")?
+        .port();
+    if port == 0 {
+        bail!("kubectl reported zero as its assigned local port");
+    }
+    Ok(Some(port))
 }
 
 /// Poll-connect to `localhost:port` until it accepts or the timeout elapses.
@@ -1627,7 +1684,7 @@ async fn resolve_cluster_channel(opts: &MessageOpts) -> Result<(String, Option<S
     match opts.channel.as_deref() {
         Some(channel) => Ok((channel.to_string(), None)),
         None => {
-            let _api_pf = start_port_forward(
+            let (_api_pf, api_local_port) = start_port_forward(
                 &port_forward_command(
                     &opts.namespace,
                     &opts.release,
@@ -1639,10 +1696,7 @@ async fn resolve_cluster_channel(opts: &MessageOpts) -> Result<(String, Option<S
                 "api",
             )
             .await?;
-            let api = ApiClient::new(
-                &format!("http://localhost:{}", opts.api_local_port),
-                &opts.api_key,
-            )?;
+            let api = ApiClient::new(&format!("http://localhost:{api_local_port}"), &opts.api_key)?;
             let agents = api
                 .list_agents()
                 .await
@@ -1665,7 +1719,7 @@ async fn message_connected(opts: MessageOpts) -> Result<()> {
     let ui = crate::ui::ui();
 
     // Valkey port-forward for the enqueue (killed on drop at fn end).
-    let _valkey_pf = start_port_forward(
+    let (_valkey_pf, valkey_local_port) = start_port_forward(
         &port_forward_command(
             &opts.namespace,
             &opts.release,
@@ -1711,7 +1765,7 @@ async fn message_connected(opts: MessageOpts) -> Result<()> {
 
     let valkey_url = format!(
         "redis://:{}@localhost:{}",
-        opts.valkey_password, opts.valkey_local_port
+        opts.valkey_password, valkey_local_port
     );
     let mut conn = connect(&valkey_url).await?;
     enqueue_over_connected_transport(&opts, &mut conn, TurnVerb::Cluster, &channel, &bot_token)
@@ -1769,7 +1823,7 @@ pub async fn message(mut opts: MessageOpts) -> Result<()> {
     ));
 
     // Valkey port-forward for the enqueue (killed on drop at fn end).
-    let _valkey_pf = start_port_forward(
+    let (_valkey_pf, valkey_local_port) = start_port_forward(
         &port_forward_command(
             &opts.namespace,
             &opts.release,
@@ -1794,7 +1848,7 @@ pub async fn message(mut opts: MessageOpts) -> Result<()> {
     // same worker keeps replying to real Slack.
     let valkey_url = format!(
         "redis://:{}@localhost:{}",
-        opts.valkey_password, opts.valkey_local_port
+        opts.valkey_password, valkey_local_port
     );
     let mut conn = connect(&valkey_url).await?;
     let (channel, thread_ts, placeholder_ts) =
@@ -2539,7 +2593,7 @@ async fn eval_sweep(opts: EvalOpts, suite: EvalSuite) -> Result<()> {
         (ApiClient::new(&base, &opts.api_key)?, None)
     } else {
         require_on_path("kubectl")?;
-        let pf = start_port_forward(
+        let (pf, api_local_port) = start_port_forward(
             &port_forward_command(
                 &opts.namespace,
                 &opts.release,
@@ -2551,7 +2605,7 @@ async fn eval_sweep(opts: EvalOpts, suite: EvalSuite) -> Result<()> {
             "api",
         )
         .await?;
-        let base = format!("http://localhost:{}", opts.api_local_port);
+        let base = format!("http://localhost:{api_local_port}");
         (ApiClient::new(&base, &opts.api_key)?, Some(pf))
     };
 
@@ -2685,7 +2739,7 @@ async fn eval_trajectory_platform(opts: EvalOpts, suite: EvalSuite) -> Result<()
         (ApiClient::new(&api_base, &opts.api_key)?, None)
     } else {
         require_on_path("kubectl")?;
-        let pf = start_port_forward(
+        let (pf, api_local_port) = start_port_forward(
             &port_forward_command(
                 &opts.namespace,
                 &opts.release,
@@ -2697,7 +2751,11 @@ async fn eval_trajectory_platform(opts: EvalOpts, suite: EvalSuite) -> Result<()
             "api",
         )
         .await?;
-        (ApiClient::new(&api_base, &opts.api_key)?, Some(pf))
+        let effective_api_base = format!("http://localhost:{api_local_port}");
+        (
+            ApiClient::new(&effective_api_base, &opts.api_key)?,
+            Some(pf),
+        )
     };
 
     let agents = api
@@ -3019,7 +3077,7 @@ async fn eval_cluster(opts: EvalOpts, suite: EvalSuite) -> Result<()> {
     ));
 
     // Valkey port-forward for the enqueue, kept alive for the whole eval loop.
-    let _valkey_pf = start_port_forward(
+    let (_valkey_pf, valkey_local_port) = start_port_forward(
         &port_forward_command(
             &opts.namespace,
             &opts.release,
@@ -3035,7 +3093,7 @@ async fn eval_cluster(opts: EvalOpts, suite: EvalSuite) -> Result<()> {
     let channel = match opts.channel.as_deref() {
         Some(channel) => channel.to_string(),
         None => {
-            let _api_pf = start_port_forward(
+            let (_api_pf, api_local_port) = start_port_forward(
                 &port_forward_command(
                     &opts.namespace,
                     &opts.release,
@@ -3047,10 +3105,7 @@ async fn eval_cluster(opts: EvalOpts, suite: EvalSuite) -> Result<()> {
                 "api",
             )
             .await?;
-            let api = ApiClient::new(
-                &format!("http://localhost:{}", opts.api_local_port),
-                &opts.api_key,
-            )?;
+            let api = ApiClient::new(&format!("http://localhost:{api_local_port}"), &opts.api_key)?;
             let agents = api
                 .list_agents()
                 .await
@@ -3062,7 +3117,7 @@ async fn eval_cluster(opts: EvalOpts, suite: EvalSuite) -> Result<()> {
 
     let valkey_url = format!(
         "redis://:{}@localhost:{}",
-        opts.valkey_password, opts.valkey_local_port
+        opts.valkey_password, valkey_local_port
     );
     let mut conn = connect(&valkey_url).await?;
 

--- a/cli/tests/message_ephemeral_ports.rs
+++ b/cli/tests/message_ephemeral_ports.rs
@@ -1,0 +1,150 @@
+use std::fs;
+use std::net::{TcpListener, TcpStream};
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+use curie::message::{port_forward_command, start_port_forward};
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_curie")
+}
+
+fn cluster_message_dry_run(extra: &[&str]) -> String {
+    let output = Command::new(bin())
+        .args(["cluster", "message", "hello"])
+        .args(extra)
+        .args(["--listen-host", "127.0.0.1", "--dry-run"])
+        .current_dir(concat!(env!("CARGO_MANIFEST_DIR"), "/.."))
+        .env_remove("CURIE_API_KEY")
+        .env_remove("CURIE_VALKEY_PASSWORD")
+        .output()
+        .expect("run cluster message dry run");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "cluster message dry run must succeed; stdout: {stdout}; stderr: {stderr}"
+    );
+    format!("{stdout}\n{stderr}")
+}
+
+fn write_fake_kubectl(dir: &Path, name: &str, readiness_host: &str) -> PathBuf {
+    let path = dir.join(name);
+    let body = r#"#!/usr/bin/env python3
+import socket
+import sys
+
+mapping = sys.argv[-1]
+requested, remote = mapping.split(":", 1)
+listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+listener.bind(("127.0.0.1", int(requested)))
+listener.listen()
+assigned = listener.getsockname()[1]
+ready_host = "__READY_HOST__"
+if ready_host == "::1":
+    print(f"Forwarding from [::1]:{assigned} -> {remote}", flush=True)
+else:
+    print(f"Forwarding from {ready_host}:{assigned} -> {remote}", flush=True)
+while True:
+    connection, _ = listener.accept()
+    connection.close()
+"#
+    .replace("__READY_HOST__", readiness_host);
+    fs::write(&path, body).expect("write fake kubectl");
+    let mut permissions = fs::metadata(&path)
+        .expect("read fake kubectl metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&path, permissions).expect("make fake kubectl executable");
+    path
+}
+
+async fn wait_until_released(port: u16) {
+    let deadline = Instant::now() + Duration::from_secs(3);
+    loop {
+        if let Ok(listener) = TcpListener::bind(("127.0.0.1", port)) {
+            drop(listener);
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "dropping the port forward guard must release assigned port {port}"
+        );
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+}
+
+#[tokio::test]
+async fn cluster_message_uses_ephemeral_defaults_and_propagates_assigned_ports() {
+    let plan = cluster_message_dry_run(&[]);
+    assert!(
+        plan.contains("kubectl -n curie port-forward svc/curie-valkey 0:6379"),
+        "an omitted Valkey local port must request zero: {plan}"
+    );
+    assert!(
+        plan.contains("kubectl -n curie port-forward svc/curie-api 0:8000"),
+        "an omitted API local port must request zero: {plan}"
+    );
+    assert!(
+        plan.contains("stub advertised at http://127.0.0.1:0/api/"),
+        "an omitted listen port must request zero: {plan}"
+    );
+
+    let dir = tempfile::tempdir().expect("create fake kubectl directory");
+    let ipv4 = write_fake_kubectl(dir.path(), "kubectl-ipv4", "127.0.0.1");
+    let ipv6 = write_fake_kubectl(dir.path(), "kubectl-ipv6", "::1");
+    let mut first_cmd = port_forward_command("acme-system", "acme-release", "valkey", 0, 6379);
+    first_cmd.program = ipv4.to_string_lossy().into_owned();
+    let mut second_cmd = port_forward_command("acme-system", "acme-release", "api", 0, 8000);
+    second_cmd.program = ipv6.to_string_lossy().into_owned();
+
+    let (first_guard, first_port) = start_port_forward(&first_cmd, 0, "Valkey")
+        .await
+        .expect("start zero requested IPv4 port forward");
+    let (second_guard, second_port) = start_port_forward(&second_cmd, 0, "API")
+        .await
+        .expect("start zero requested IPv6 readiness port forward");
+
+    assert_ne!(first_port, 0, "kubectl must report its assigned port");
+    assert_ne!(second_port, 0, "kubectl must report its assigned port");
+    assert_ne!(
+        first_port, second_port,
+        "independent zero requested forwards must not collide"
+    );
+    TcpStream::connect(("127.0.0.1", first_port))
+        .expect("returned Valkey port must reach the forward");
+    TcpStream::connect(("127.0.0.1", second_port))
+        .expect("returned API port must reach the forward");
+
+    drop(first_guard);
+    drop(second_guard);
+    wait_until_released(first_port).await;
+    wait_until_released(second_port).await;
+}
+
+#[test]
+fn cluster_message_preserves_explicit_port_overrides() {
+    let plan = cluster_message_dry_run(&[
+        "--listen-port",
+        "18155",
+        "--valkey-local-port",
+        "18156",
+        "--api-local-port",
+        "18157",
+    ]);
+    assert!(
+        plan.contains("kubectl -n curie port-forward svc/curie-valkey 18156:6379"),
+        "the explicit Valkey local port must remain exact: {plan}"
+    );
+    assert!(
+        plan.contains("kubectl -n curie port-forward svc/curie-api 18157:8000"),
+        "the explicit API local port must remain exact: {plan}"
+    );
+    assert!(
+        plan.contains("stub advertised at http://127.0.0.1:18155/api/"),
+        "the explicit listen port must remain exact: {plan}"
+    );
+}


### PR DESCRIPTION
Closes #1652

Cluster message now asks the kernel to assign its Slack stub, Valkey forward, and API forward ports, then propagates each assigned value to its consumer. Explicit port flags remain exact overrides.

The cluster ladder trust configuration accepts ephemeral callback ports while remaining scoped to the configured callback host.

Done check

* [x] Regression coverage fails when the implementation is removed
* [x] All forward callers consume the effective assigned port
* [x] Code review and scope review found no blocking issues
* [x] Rust formatting, lint, and full tests passed
* [x] UI lint, type checking, and 147 tests passed
* [x] Worker tests, Helm lint, and workflow lint passed
* [x] Cluster ladder finalized a fake model reply using kernel assigned port 36371
* [ ] Local ladder was blocked by another session reuse of a stack containing multiple active fixture deployments