### PR TITLE
Publish Helm index and listing drafts

### DIFF
--- a/.github/workflows/chart-index.yaml
+++ b/.github/workflows/chart-index.yaml
@@ -161,34 +161,33 @@ jobs:
           export GIT_CONFIG_VALUE_0="AUTHORIZATION: basic $auth_header"
           export CR_TOKEN="$GH_TOKEN"
 
-          if git ls-remote --exit-code --heads origin refs/heads/gh-pages >/dev/null 2>&1; then
-            pages_dir="$(mktemp -d "$RUNNER_TEMP/curie-pages.XXXXXX")"
-            git fetch --force --no-tags origin refs/heads/gh-pages:refs/remotes/origin/gh-pages
-            git worktree add --detach "$pages_dir" origin/gh-pages
-            unrelated="$(find "$pages_dir" -mindepth 1 -maxdepth 1 \
-              ! -name .git ! -name index.yaml ! -name .nojekyll -print -quit)"
-            if [ -n "$unrelated" ]; then
-              echo "The gh-pages branch contains unrelated content at $unrelated" >&2
-              exit 1
-            fi
-            git worktree remove "$pages_dir"
-          else
+          if ! git ls-remote --exit-code --heads origin refs/heads/gh-pages >/dev/null 2>&1; then
             seed_dir="$(mktemp -d "$RUNNER_TEMP/curie-pages-seed.XXXXXX")"
             (
               cd "$seed_dir"
               git init
               git checkout --orphan gh-pages
-              git config user.name github-actions
-              git config user.email github-actions@users.noreply.github.com
               touch .nojekyll
               git add .nojekyll
-              git commit -m "Initialize Helm chart index"
+              git -c user.name=github-actions \
+                -c user.email=github-actions@users.noreply.github.com \
+                commit -m "Initialize Helm chart index"
               git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
               git push origin gh-pages
             )
-            git fetch --force --no-tags origin \
-              refs/heads/gh-pages:refs/remotes/origin/gh-pages
           fi
+
+          git fetch --force --no-tags origin \
+            refs/heads/gh-pages:refs/remotes/origin/gh-pages
+          pages_dir="$(mktemp -d "$RUNNER_TEMP/curie-pages.XXXXXX")"
+          git worktree add --detach "$pages_dir" origin/gh-pages
+          unrelated="$(find "$pages_dir" -mindepth 1 -maxdepth 1 \
+            ! -name .git ! -name index.yaml ! -name .nojekyll -print -quit)"
+          if [ -n "$unrelated" ]; then
+            echo "The gh-pages branch contains unrelated content at $unrelated" >&2
+            exit 1
+          fi
+          git worktree remove "$pages_dir"
 
           git config user.name github-actions
           git config user.email github-actions@users.noreply.github.com

--- a/.github/workflows/chart-index.yaml
+++ b/.github/workflows/chart-index.yaml
@@ -194,6 +194,9 @@ jobs:
           git config user.email github-actions@users.noreply.github.com
           cr index --config cr.yaml --push
 
+      - name: Install Helm
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+
       - name: Verify the public Helm consumer path
         env:
           RELEASE_VERSION: ${{ steps.release.outputs.version }}
@@ -207,7 +210,7 @@ jobs:
           export HELM_DATA_HOME="$helm_home/data"
           mkdir -p "$HELM_CONFIG_HOME" "$HELM_CACHE_HOME" "$HELM_DATA_HOME" "$pull_dir"
 
-          for attempt in $(seq 1 12); do
+          for attempt in $(seq 1 36); do
             if helm repo add curie "$repository_url" --force-update \
               && helm repo update curie; then
               search_output="$(helm search repo curie/curie \
@@ -221,7 +224,7 @@ jobs:
                 exit 0
               fi
             fi
-            echo "The public index is not current on attempt $attempt of 12" >&2
+            echo "The public index is not current on attempt $attempt of 36" >&2
             sleep 10
           done
           echo "The public Helm consumer path did not expose the release" >&2

--- a/.github/workflows/chart-index.yaml
+++ b/.github/workflows/chart-index.yaml
@@ -18,10 +18,12 @@ concurrency:
 jobs:
   publish-index:
     name: Verify the release and publish its chart index
+    if: github.event_name != 'release' || github.event.release.prerelease == false
     runs-on: ubuntu-latest
     permissions:
       contents: write
       attestations: read
+      checks: read
     steps:
       - name: Check out the repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -31,19 +33,23 @@ jobs:
 
       - name: Resolve the published release
         id: release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           if [ "$GITHUB_EVENT_NAME" = "release" ]; then
             release_tag="$(jq -r '.release.tag_name' "$GITHUB_EVENT_PATH")"
           else
-            chart_version="$(awk '$1 == "version:" { print $2; exit }' charts/curie/Chart.yaml)"
-            release_tag="v${chart_version}"
+            release_tag="$(gh api "repos/$GITHUB_REPOSITORY/releases/latest" --jq .tag_name)"
           fi
-          if ! [[ "$release_tag" =~ ^v[0-9] ]]; then
+          if ! [[ "$release_tag" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
             echo "The release tag is invalid" >&2
             exit 1
           fi
-          git fetch --force --no-tags origin "refs/tags/${release_tag}:refs/tags/${release_tag}"
+          git fetch --force --no-tags origin \
+            refs/heads/main:refs/remotes/origin/main \
+            refs/heads/next:refs/remotes/origin/next \
+            "refs/tags/${release_tag}:refs/tags/${release_tag}"
           release_commit="$(git rev-list -n 1 "$release_tag")"
           if [ -z "$release_commit" ]; then
             echo "The release commit could not be resolved" >&2
@@ -53,34 +59,53 @@ jobs:
           echo "version=${release_tag#v}" >> "$GITHUB_OUTPUT"
           echo "commit=$release_commit" >> "$GITHUB_OUTPUT"
 
+      - name: Authorize the release commit with the reviewed gate
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_COMMIT: ${{ steps.release.outputs.commit }}
+        run: |
+          set -euo pipefail
+          git checkout origin/main -- release/
+          python3 release/authorize.py "$RELEASE_COMMIT" \
+            --repo "$GITHUB_REPOSITORY" \
+            --reviewed-ref origin/main \
+            --reviewed-ref origin/next
+
       - name: Download every release asset
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
         run: |
           set -euo pipefail
           mkdir -p dist
-          gh release download "${{ steps.release.outputs.tag }}" \
+          gh release download "$RELEASE_TAG" \
             --repo "$GITHUB_REPOSITORY" --dir dist
 
       - name: Verify the closed world release asset set
+        env:
+          RELEASE_VERSION: ${{ steps.release.outputs.version }}
         run: |
           python3 release/integrity.py verify \
-            --dist dist --version "${{ steps.release.outputs.version }}"
+            --dist dist --version "$RELEASE_VERSION"
 
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Verify the checksum manifest signature
+        env:
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
         run: |
           cosign verify-blob \
             --bundle dist/checksums.txt.sigstore.json \
-            --certificate-identity "https://github.com/${GITHUB_REPOSITORY}/.github/workflows/release.yaml@refs/tags/${{ steps.release.outputs.tag }}" \
+            --certificate-identity "https://github.com/${GITHUB_REPOSITORY}/.github/workflows/release.yaml@refs/tags/${RELEASE_TAG}" \
             --certificate-oidc-issuer https://token.actions.githubusercontent.com \
             dist/checksums.txt
 
       - name: Verify every asset provenance statement
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
+          RELEASE_COMMIT: ${{ steps.release.outputs.commit }}
         run: |
           set -euo pipefail
           for asset in dist/*; do
@@ -88,15 +113,17 @@ jobs:
             gh attestation verify "$asset" \
               --repo "$GITHUB_REPOSITORY" \
               --signer-workflow "$GITHUB_REPOSITORY/.github/workflows/release.yaml" \
-              --source-ref "refs/tags/${{ steps.release.outputs.tag }}" \
-              --source-digest "${{ steps.release.outputs.commit }}"
+              --source-ref "refs/tags/${RELEASE_TAG}" \
+              --source-digest "$RELEASE_COMMIT"
           done
 
       - name: Stage the exact verified chart archive
+        env:
+          RELEASE_VERSION: ${{ steps.release.outputs.version }}
         run: |
           set -euo pipefail
           chart_asset="$(awk '$2 ~ /^curie-.+\.tgz$/ { print $2 }' dist/checksums.txt)"
-          if [ "$chart_asset" != "curie-${{ steps.release.outputs.version }}.tgz" ]; then
+          if [ "$chart_asset" != "curie-${RELEASE_VERSION}.tgz" ]; then
             echo "The checksum manifest does not name exactly one expected chart archive" >&2
             exit 1
           fi
@@ -108,16 +135,11 @@ jobs:
           set -euo pipefail
           tool_dir="$(mktemp -d "$RUNNER_TEMP/chart-releaser.XXXXXX")"
           archive="chart-releaser_1.7.0_linux_amd64.tar.gz"
+          expected_sha256="121a16d4e38b348decb977b8257d4bddab3323681c1819bab4870603138087cf"
           curl -fsSLo "$tool_dir/$archive" "https://github.com/helm/chart-releaser/releases/download/v1.7.0/chart-releaser_1.7.0_linux_amd64.tar.gz"
-          curl -fsSLo "$tool_dir/checksums.txt" "https://github.com/helm/chart-releaser/releases/download/v1.7.0/checksums.txt"
           (
             cd "$tool_dir"
-            checksum_line="$(grep " $archive" checksums.txt)"
-            if [ -z "$checksum_line" ]; then
-              echo "The chart releaser checksum is absent" >&2
-              exit 1
-            fi
-            printf '%s\n' "$checksum_line" | sha256sum --check
+            printf '%s  %s\n' "$expected_sha256" "$archive" | sha256sum --check
             tar -xzf "$archive"
           )
           mkdir -p "$RUNNER_TEMP/bin"
@@ -130,6 +152,7 @@ jobs:
         run: |
           set -euo pipefail
           auth_header="$(printf 'x-access-token:%s' "$GH_TOKEN" | base64 -w0)"
+          echo "::add-mask::$auth_header"
           export GIT_CONFIG_COUNT=1
           export GIT_CONFIG_KEY_0=http.https://github.com/.extraheader
           export GIT_CONFIG_VALUE_0="AUTHORIZATION: basic $auth_header"
@@ -160,6 +183,43 @@ jobs:
               git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
               git push origin gh-pages
             )
+            git fetch --force --no-tags origin \
+              refs/heads/gh-pages:refs/remotes/origin/gh-pages
           fi
 
+          git config user.name github-actions
+          git config user.email github-actions@users.noreply.github.com
           cr index --config cr.yaml --push
+
+      - name: Verify the public Helm consumer path
+        env:
+          RELEASE_VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          set -euo pipefail
+          repository_url="https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/gh-pages"
+          helm_home="$(mktemp -d "$RUNNER_TEMP/curie-helm.XXXXXX")"
+          pull_dir="$helm_home/pull"
+          export HELM_CONFIG_HOME="$helm_home/config"
+          export HELM_CACHE_HOME="$helm_home/cache"
+          export HELM_DATA_HOME="$helm_home/data"
+          mkdir -p "$HELM_CONFIG_HOME" "$HELM_CACHE_HOME" "$HELM_DATA_HOME" "$pull_dir"
+
+          for attempt in $(seq 1 12); do
+            if helm repo add curie "$repository_url" --force-update \
+              && helm repo update curie; then
+              search_output="$(helm search repo curie/curie \
+                --versions --version "$RELEASE_VERSION")"
+              if printf '%s\n' "$search_output" | awk -v expected="$RELEASE_VERSION" \
+                '$1 == "curie/curie" && $2 == expected { found=1 } END { exit !found }' \
+                && helm pull curie/curie --version "$RELEASE_VERSION" \
+                  --destination "$pull_dir" \
+                && test -f "$pull_dir/curie-${RELEASE_VERSION}.tgz"; then
+                printf '%s\n' "$search_output"
+                exit 0
+              fi
+            fi
+            echo "The public index is not current on attempt $attempt of 12" >&2
+            sleep 10
+          done
+          echo "The public Helm consumer path did not expose the release" >&2
+          exit 1

--- a/.github/workflows/chart-index.yaml
+++ b/.github/workflows/chart-index.yaml
@@ -1,8 +1,9 @@
 name: Publish Helm chart index
 
 on:
-  release:
-    types: [published]
+  workflow_run:
+    workflows: [Release images and binaries]
+    types: [completed]
   push:
     branches: [next]
     paths:
@@ -18,7 +19,13 @@ concurrency:
 jobs:
   publish-index:
     name: Verify the release and publish its chart index
-    if: github.event_name != 'release' || github.event.release.prerelease == false
+    if: >-
+      github.event_name == 'push' ||
+      (github.event_name == 'workflow_run' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      startsWith(github.event.workflow_run.head_branch, 'v') &&
+      !contains(github.event.workflow_run.head_branch, '-'))
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -37,11 +44,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          if [ "$GITHUB_EVENT_NAME" = "release" ]; then
-            release_tag="$(jq -r '.release.tag_name' "$GITHUB_EVENT_PATH")"
-          else
-            release_tag="$(gh api "repos/$GITHUB_REPOSITORY/releases/latest" --jq .tag_name)"
-          fi
+          release_tag="$(gh api "repos/$GITHUB_REPOSITORY/releases/latest" --jq .tag_name)"
           if ! [[ "$release_tag" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
             echo "The release tag is invalid" >&2
             exit 1

--- a/.github/workflows/chart-index.yaml
+++ b/.github/workflows/chart-index.yaml
@@ -1,0 +1,165 @@
+name: Publish Helm chart index
+
+on:
+  release:
+    types: [published]
+  push:
+    branches: [next]
+    paths:
+      - .github/workflows/chart-index.yaml
+      - cr.yaml
+
+permissions: {}
+
+concurrency:
+  group: helm-chart-index
+  cancel-in-progress: false
+
+jobs:
+  publish-index:
+    name: Verify the release and publish its chart index
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      attestations: read
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Resolve the published release
+        id: release
+        run: |
+          set -euo pipefail
+          if [ "$GITHUB_EVENT_NAME" = "release" ]; then
+            release_tag="$(jq -r '.release.tag_name' "$GITHUB_EVENT_PATH")"
+          else
+            chart_version="$(awk '$1 == "version:" { print $2; exit }' charts/curie/Chart.yaml)"
+            release_tag="v${chart_version}"
+          fi
+          if ! [[ "$release_tag" =~ ^v[0-9] ]]; then
+            echo "The release tag is invalid" >&2
+            exit 1
+          fi
+          git fetch --force --no-tags origin "refs/tags/${release_tag}:refs/tags/${release_tag}"
+          release_commit="$(git rev-list -n 1 "$release_tag")"
+          if [ -z "$release_commit" ]; then
+            echo "The release commit could not be resolved" >&2
+            exit 1
+          fi
+          echo "tag=$release_tag" >> "$GITHUB_OUTPUT"
+          echo "version=${release_tag#v}" >> "$GITHUB_OUTPUT"
+          echo "commit=$release_commit" >> "$GITHUB_OUTPUT"
+
+      - name: Download every release asset
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          gh release download "${{ steps.release.outputs.tag }}" \
+            --repo "$GITHUB_REPOSITORY" --dir dist
+
+      - name: Verify the closed world release asset set
+        run: |
+          python3 release/integrity.py verify \
+            --dist dist --version "${{ steps.release.outputs.version }}"
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Verify the checksum manifest signature
+        run: |
+          cosign verify-blob \
+            --bundle dist/checksums.txt.sigstore.json \
+            --certificate-identity "https://github.com/${GITHUB_REPOSITORY}/.github/workflows/release.yaml@refs/tags/${{ steps.release.outputs.tag }}" \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            dist/checksums.txt
+
+      - name: Verify every asset provenance statement
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          for asset in dist/*; do
+            echo "== $asset"
+            gh attestation verify "$asset" \
+              --repo "$GITHUB_REPOSITORY" \
+              --signer-workflow "$GITHUB_REPOSITORY/.github/workflows/release.yaml" \
+              --source-ref "refs/tags/${{ steps.release.outputs.tag }}" \
+              --source-digest "${{ steps.release.outputs.commit }}"
+          done
+
+      - name: Stage the exact verified chart archive
+        run: |
+          set -euo pipefail
+          chart_asset="$(awk '$2 ~ /^curie-.+\.tgz$/ { print $2 }' dist/checksums.txt)"
+          if [ "$chart_asset" != "curie-${{ steps.release.outputs.version }}.tgz" ]; then
+            echo "The checksum manifest does not name exactly one expected chart archive" >&2
+            exit 1
+          fi
+          mkdir -p .cr-release-packages
+          cp "dist/${chart_asset}" ".cr-release-packages/"
+
+      - name: Install the verified chart releaser CLI
+        run: |
+          set -euo pipefail
+          tool_dir="$(mktemp -d "$RUNNER_TEMP/chart-releaser.XXXXXX")"
+          archive="chart-releaser_1.7.0_linux_amd64.tar.gz"
+          curl -fsSLo "$tool_dir/$archive" "https://github.com/helm/chart-releaser/releases/download/v1.7.0/chart-releaser_1.7.0_linux_amd64.tar.gz"
+          curl -fsSLo "$tool_dir/checksums.txt" "https://github.com/helm/chart-releaser/releases/download/v1.7.0/checksums.txt"
+          (
+            cd "$tool_dir"
+            checksum_line="$(grep " $archive" checksums.txt)"
+            if [ -z "$checksum_line" ]; then
+              echo "The chart releaser checksum is absent" >&2
+              exit 1
+            fi
+            printf '%s\n' "$checksum_line" | sha256sum --check
+            tar -xzf "$archive"
+          )
+          mkdir -p "$RUNNER_TEMP/bin"
+          install -m 0755 "$tool_dir/cr" "$RUNNER_TEMP/bin/cr"
+          echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
+
+      - name: Guard the Pages branch and publish the index
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          auth_header="$(printf 'x-access-token:%s' "$GH_TOKEN" | base64 -w0)"
+          export GIT_CONFIG_COUNT=1
+          export GIT_CONFIG_KEY_0=http.https://github.com/.extraheader
+          export GIT_CONFIG_VALUE_0="AUTHORIZATION: basic $auth_header"
+          export CR_TOKEN="$GH_TOKEN"
+
+          if git ls-remote --exit-code --heads origin refs/heads/gh-pages >/dev/null 2>&1; then
+            pages_dir="$(mktemp -d "$RUNNER_TEMP/curie-pages.XXXXXX")"
+            git fetch --force --no-tags origin refs/heads/gh-pages:refs/remotes/origin/gh-pages
+            git worktree add --detach "$pages_dir" origin/gh-pages
+            unrelated="$(find "$pages_dir" -mindepth 1 -maxdepth 1 \
+              ! -name .git ! -name index.yaml ! -name .nojekyll -print -quit)"
+            if [ -n "$unrelated" ]; then
+              echo "The gh-pages branch contains unrelated content at $unrelated" >&2
+              exit 1
+            fi
+            git worktree remove "$pages_dir"
+          else
+            seed_dir="$(mktemp -d "$RUNNER_TEMP/curie-pages-seed.XXXXXX")"
+            (
+              cd "$seed_dir"
+              git init
+              git checkout --orphan gh-pages
+              git config user.name github-actions
+              git config user.email github-actions@users.noreply.github.com
+              touch .nojekyll
+              git add .nojekyll
+              git commit -m "Initialize Helm chart index"
+              git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+              git push origin gh-pages
+            )
+          fi
+
+          cr index --config cr.yaml --push

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ venv/
 .pytest_cache/
 .mypy_cache/
 .ruff_cache/
+.cr-release-packages/
 
 # Rust
 target/

--- a/charts/curie/README.md
+++ b/charts/curie/README.md
@@ -14,7 +14,19 @@ the single-node footprint controllable and avoids the Bitnami-catalog
 (`bitnamilegacy/*`) instability. It still follows the Langfuse chart *idiom*:
 every backing store is toggle-gated with a single-block bring-your-own surface.
 
-## Install
+## Install a released chart
+
+Add the public chart repository, refresh its index, and confirm the available
+Curie versions before installing:
+
+```bash
+helm repo add curie https://raw.githubusercontent.com/curie-eng/curie/gh-pages
+helm repo update
+helm search repo curie/curie --versions
+helm install curie curie/curie --namespace curie --create-namespace
+```
+
+## Install from a source checkout
 
 The defaults are the flagship path: GHCR (GitHub Container Registry) images, the runner substrate and its
 controller on, a modest single-node footprint, and graceful degradation when the

--- a/charts/curie/README.md
+++ b/charts/curie/README.md
@@ -26,6 +26,11 @@ helm search repo curie/curie --versions
 helm install curie curie/curie --namespace curie --create-namespace
 ```
 
+The Helm index supplies discovery and download metadata only. It does not
+verify the release signature or provenance. Follow the
+[release verification instructions](../../docs/release-verification.md) when
+you need that stronger guarantee.
+
 ## Install from a source checkout
 
 The defaults are the flagship path: GHCR (GitHub Container Registry) images, the runner substrate and its

--- a/cr.yaml
+++ b/cr.yaml
@@ -1,6 +1,5 @@
 owner: curie-eng
 git-repo: curie
 pages-branch: gh-pages
-charts-repo: https://raw.githubusercontent.com/curie-eng/curie/gh-pages
 release-name-template: "v{{ .Version }}"
 package-path: .cr-release-packages

--- a/cr.yaml
+++ b/cr.yaml
@@ -1,0 +1,6 @@
+owner: curie-eng
+git-repo: curie
+pages-branch: gh-pages
+charts-repo: https://raw.githubusercontent.com/curie-eng/curie/gh-pages
+release-name-template: "v{{ .Version }}"
+package-path: .cr-release-packages

--- a/docs/listing-submission-drafts.md
+++ b/docs/listing-submission-drafts.md
@@ -4,13 +4,13 @@ All sections are prepared only. Nothing in this file has been submitted.
 
 ## Shared context
 
-Curie is an Apache 2.0, open source, self hosted delivery platform for production AI agents. It lets authors build Claude Code format plugin bundles containing skills, tools, and MCP configuration, then run the same immutable bundle at skill, local Docker Compose, and Kubernetes cluster tiers. Curie is an MCP host, not an MCP server. Its repository is https://github.com/curie-eng/curie. Released CLI binaries support Linux x86 64, Linux arm64, and macOS Apple silicon. Its implementation languages are Python, Rust, and TypeScript.
+Curie is an Apache 2.0, open source, self hosted delivery platform for production AI agents. It lets authors build Claude Code format plugin bundles containing skills, tools, and MCP configuration, then run the same immutable bundle at skill, local Docker Compose, and Kubernetes cluster tiers. Curie is an MCP host, not an MCP server. Its repository is https://github.com/curie-eng/curie. Released CLI binaries support Linux x86_64, Linux arm64, and macOS Apple silicon. Its implementation languages are Python, Rust, and TypeScript.
 
-These free discoverability surfaces are not evidence of adoption. Three MCP servers merged into a 92,281 star awesome list on 2026 07 29 had 0, 0, and 10 stars sixteen days later.
+These free discoverability surfaces are not evidence of adoption. Three MCP servers merged into a 92,281 star awesome list on 2026-07-29 had 0, 0, and 10 stars sixteen days later.
 
 ## hesreallyhim/awesome-claude-code
 
-Prepared only. Do not submit without Brian's decision.
+Prepared only. Do not submit without maintainer approval.
 
 Destination: https://github.com/hesreallyhim/awesome-claude-code/issues/new?template=recommend-resource.yml
 
@@ -39,7 +39,7 @@ Complete the required checklist as follows:
 
 ## punkpeye/awesome-mcp-clients
 
-Prepared only. Do not submit without Brian's decision.
+Prepared only. Do not submit without maintainer approval.
 
 Destination: https://github.com/punkpeye/awesome-mcp-clients/compare
 
@@ -53,7 +53,7 @@ Mechanism: fork https://github.com/punkpeye/awesome-mcp-clients, create a branch
   <tr><td>Website</td><td><a href="https://github.com/curie-eng/curie">github.com/curie-eng/curie</a></td></tr>
   <tr><td>License</td><td>Apache 2.0</td></tr>
   <tr><td>Type</td><td>MCP host</td></tr>
-  <tr><td>Platforms</td><td>Linux x86 64, Linux arm64, macOS Apple silicon</td></tr>
+  <tr><td>Platforms</td><td>Linux x86_64, Linux arm64, macOS Apple silicon</td></tr>
   <tr><td>Pricing</td><td>Free and open source</td></tr>
   <tr><td>Programming Languages</td><td>Python, Rust, TypeScript</td></tr>
 </table>
@@ -69,11 +69,11 @@ Add Curie MCP host
 
 ## openalternative.co
 
-Prepared only. Do not submit without Brian's decision.
+Prepared only. Do not submit without maintainer approval.
 
 Destination: https://openalternative.co/submit
 
-Mechanism: sign in with an authorized email magic link, Google account, or GitHub account. The public route redirects to https://openalternative.co/auth/login?next=/submit. Field labels inside the authenticated submission dashboard remain unverified until Brian signs in, so map this content into the displayed fields without inventing labels.
+Mechanism: sign in with an authorized email magic link, Google account, or GitHub account. The public route redirects to https://openalternative.co/auth/login?next=/submit. Field labels inside the authenticated submission dashboard remain unverified until a maintainer signs in, so map this content into the displayed fields without inventing labels.
 
 Ready to paste content pack:
 
@@ -84,6 +84,6 @@ License: Apache 2.0
 Pricing: Free and open source
 Positioning: Self hosted delivery platform for production AI agents.
 Description: Curie lets teams author Claude Code format plugin bundles with skills, tools, and MCP configuration, then run the same immutable bundle locally through Docker Compose and in production on Kubernetes. It provides a CLI, traces, evals, budgets, and git driven deploys.
-Platforms: Linux x86 64, Linux arm64, macOS Apple silicon, Docker Compose, Kubernetes
+Platforms: Linux x86_64, Linux arm64, macOS Apple silicon, Docker Compose, Kubernetes
 Implementation languages: Python, Rust, TypeScript
 ```

--- a/docs/listing-submission-drafts.md
+++ b/docs/listing-submission-drafts.md
@@ -1,0 +1,89 @@
+# Curie listing submission drafts
+
+All sections are prepared only. Nothing in this file has been submitted.
+
+## Shared context
+
+Curie is an Apache 2.0, open source, self hosted delivery platform for production AI agents. It lets authors build Claude Code format plugin bundles containing skills, tools, and MCP configuration, then run the same immutable bundle at skill, local Docker Compose, and Kubernetes cluster tiers. Curie is an MCP host, not an MCP server. Its repository is https://github.com/curie-eng/curie. Released CLI binaries support Linux x86 64, Linux arm64, and macOS Apple silicon. Its implementation languages are Python, Rust, and TypeScript.
+
+These free discoverability surfaces are not evidence of adoption. Three MCP servers merged into a 92,281 star awesome list on 2026 07 29 had 0, 0, and 10 stars sixteen days later.
+
+## hesreallyhim/awesome-claude-code
+
+Prepared only. Do not submit without Brian's decision.
+
+Destination: https://github.com/hesreallyhim/awesome-claude-code/issues/new?template=recommend-resource.yml
+
+Mechanism: open the GitHub web issue form. The maintainers require this form and do not accept pull requests for recommendations.
+
+Paste these verified required fields:
+
+```text
+Display Name: Curie
+Category: Infrastructure and DevOps
+Link: https://github.com/curie-eng/curie
+Author Name: curie-eng
+Author Link: https://github.com/curie-eng
+Description: Curie is an Apache 2.0 self hosted delivery platform for Claude Code format plugin bundles. It runs the same immutable bundle locally with Docker Compose and in production on Kubernetes.
+```
+
+Complete the required checklist as follows:
+
+```text
+[x] The resource is Claude Code specific because Curie authors, validates, and runs Claude Code format plugin bundles.
+[x] The resource is publicly accessible at https://github.com/curie-eng/curie.
+[x] The resource is not already listed.
+[x] The resource meets the active development requirement of at least 14 days after its first default branch commit.
+[x] This submission recommends one resource only.
+```
+
+## punkpeye/awesome-mcp-clients
+
+Prepared only. Do not submit without Brian's decision.
+
+Destination: https://github.com/punkpeye/awesome-mcp-clients/compare
+
+Mechanism: fork https://github.com/punkpeye/awesome-mcp-clients, create a branch, edit README.md, push it to the fork, then open a pull request from the GitHub comparison flow. Add the following H3 section and HTML table in alphabetical order in the Clients category. Add the table of contents anchor if the destination README still maintains it manually.
+
+```html
+### Curie
+
+<table>
+  <tr><td>GitHub</td><td><a href="https://github.com/curie-eng/curie">curie-eng/curie</a></td></tr>
+  <tr><td>Website</td><td><a href="https://github.com/curie-eng/curie">github.com/curie-eng/curie</a></td></tr>
+  <tr><td>License</td><td>Apache 2.0</td></tr>
+  <tr><td>Type</td><td>MCP host</td></tr>
+  <tr><td>Platforms</td><td>Linux x86 64, Linux arm64, macOS Apple silicon</td></tr>
+  <tr><td>Pricing</td><td>Free and open source</td></tr>
+  <tr><td>Programming Languages</td><td>Python, Rust, TypeScript</td></tr>
+</table>
+
+Apache 2.0 self hosted delivery platform for production AI agents that runs Claude Code format plugin bundles through local Docker Compose and Kubernetes tiers.
+```
+
+Suggested pull request title:
+
+```text
+Add Curie MCP host
+```
+
+## openalternative.co
+
+Prepared only. Do not submit without Brian's decision.
+
+Destination: https://openalternative.co/submit
+
+Mechanism: sign in with an authorized email magic link, Google account, or GitHub account. The public route redirects to https://openalternative.co/auth/login?next=/submit. Field labels inside the authenticated submission dashboard remain unverified until Brian signs in, so map this content into the displayed fields without inventing labels.
+
+Ready to paste content pack:
+
+```text
+Name: Curie
+Repository: https://github.com/curie-eng/curie
+License: Apache 2.0
+Pricing: Free and open source
+Positioning: Self hosted delivery platform for production AI agents.
+Description: Curie lets teams author Claude Code format plugin bundles with skills, tools, and MCP configuration, then run the same immutable bundle locally through Docker Compose and in production on Kubernetes. It provides a CLI, traces, evals, budgets, and git driven deploys.
+Platforms: Linux x86 64, Linux arm64, macOS Apple silicon, Docker Compose, Kubernetes
+Implementation languages: Python, Rust, TypeScript
+```

--- a/release/tests/test_chart_index_workflow.py
+++ b/release/tests/test_chart_index_workflow.py
@@ -144,6 +144,29 @@ class TestChartIndexWorkflowContract:
         assert "index.yaml" in ownership_guard
         assert re.search(r"\b(?:find|ls|git\s+ls-files)\b", ownership_guard)
 
+    def test_absent_pages_seed_is_pushed_before_indexing(self):
+        workflow = load_yaml(WORKFLOW_PATH)
+        publication_script = next(
+            run_script(step)
+            for step in workflow_steps(workflow)
+            if re.search(r"\bcr\s+index\b", run_script(step))
+        )
+
+        orphan = re.search(
+            r"git\s+(?:checkout|switch)\s+--orphan\s+gh-pages\b",
+            publication_script,
+        )
+        seed_push = re.search(
+            r"git\s+push\s+origin\s+gh-pages\b",
+            publication_script,
+        )
+        index = re.search(r"\bcr\s+index\b", publication_script)
+
+        assert orphan is not None
+        assert seed_push is not None
+        assert index is not None
+        assert orphan.start() < seed_push.start() < index.start()
+
     def test_chart_releaser_cli_is_checksum_verified_before_it_can_run(self):
         workflow = load_yaml(WORKFLOW_PATH)
         steps = workflow_steps(workflow)

--- a/release/tests/test_chart_index_workflow.py
+++ b/release/tests/test_chart_index_workflow.py
@@ -1,0 +1,246 @@
+"""Contract tests for publishing the verified release chart through a Helm index."""
+
+import re
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "chart-index.yaml"
+CONFIG_PATH = REPO_ROOT / "cr.yaml"
+
+
+def load_yaml(path: Path) -> dict:
+    return yaml.load(path.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+
+
+def workflow_steps(workflow: dict) -> list[dict]:
+    jobs = workflow["jobs"]
+    assert len(jobs) == 1
+    return next(iter(jobs.values()))["steps"]
+
+
+def run_script(step: dict) -> str:
+    return step.get("run", "")
+
+
+class TestChartIndexWorkflowContract:
+    def test_only_published_releases_and_the_narrow_next_bootstrap_trigger_it(self):
+        workflow = load_yaml(WORKFLOW_PATH)
+        trigger = workflow["on"]
+
+        assert set(trigger) == {"release", "push"}
+        assert trigger["release"] == {"types": ["published"]}
+        assert trigger["push"]["branches"] == ["next"]
+        assert len(trigger["push"]["paths"]) == 2
+        assert set(trigger["push"]["paths"]) == {
+            ".github/workflows/chart-index.yaml",
+            "cr.yaml",
+        }
+
+    def test_write_permission_is_job_scoped_and_checkout_cannot_reuse_it(self):
+        workflow = load_yaml(WORKFLOW_PATH)
+        assert (workflow.get("permissions") or {}).get("contents") != "write"
+
+        jobs = workflow["jobs"]
+        writers = [
+            job
+            for job in jobs.values()
+            if (job.get("permissions") or {}).get("contents") == "write"
+        ]
+        assert len(jobs) == len(writers) == 1
+        assert writers[0]["permissions"] == {"contents": "write"}
+
+        checkouts = [
+            step
+            for step in workflow_steps(workflow)
+            if step.get("uses", "").startswith("actions/checkout@")
+        ]
+        assert checkouts
+        assert all(
+            step.get("with", {}).get("persist-credentials") == "false"
+            for step in checkouts
+        )
+
+    def test_every_remote_action_is_pinned_to_a_full_commit_sha(self):
+        workflow = load_yaml(WORKFLOW_PATH)
+        actions = [step["uses"] for step in workflow_steps(workflow) if "uses" in step]
+
+        assert actions
+        assert all(re.fullmatch(r"[^@\s]+@[0-9a-f]{40}", action) for action in actions)
+
+    def test_release_assets_are_fully_verified_before_pages_can_change(self):
+        workflow = load_yaml(WORKFLOW_PATH)
+        steps = workflow_steps(workflow)
+
+        def index_of(pattern: str) -> int:
+            matches = [
+                index
+                for index, step in enumerate(steps)
+                if re.search(pattern, run_script(step), re.IGNORECASE)
+            ]
+            assert matches, pattern
+            return matches[0]
+
+        download = index_of(r"\bgh\s+release\s+download\b")
+        closed_world = index_of(r"release/integrity\.py\s+verify\b")
+        signature = index_of(r"\bcosign\s+verify-blob\b")
+        provenance = index_of(r"\bgh\s+attestation\s+verify\b")
+
+        signature_script = run_script(steps[signature])
+        assert "checksums.txt.sigstore.json" in signature_script
+        assert "--certificate-identity" in signature_script
+        assert "--certificate-oidc-issuer" in signature_script
+        assert re.search(r"\bchecksums\.txt\b", signature_script)
+
+        provenance_script = run_script(steps[provenance])
+        assert '--repo "$GITHUB_REPOSITORY"' in provenance_script
+        assert "--signer-workflow" in provenance_script
+        assert ".github/workflows/release.yaml" in provenance_script
+        assert "--source-ref" in provenance_script
+        assert "--source-digest" in provenance_script
+
+        mutations = [
+            index
+            for index, step in enumerate(steps)
+            if re.search(
+                r"\bgit\s+push\b|\bgit\s+(?:checkout|switch)\s+--orphan\b|"
+                r"\bcr\s+index\b[^\n]*\s--push\b",
+                run_script(step),
+            )
+        ]
+        assert mutations
+        assert download < closed_world < signature < provenance < min(mutations)
+
+        download_script = run_script(steps[download])
+        assert "--pattern" not in download_script
+        assert "--archive" not in download_script
+
+    def test_only_an_absent_pages_branch_can_be_initialized(self):
+        workflow = load_yaml(WORKFLOW_PATH)
+        scripts = "\n".join(run_script(step) for step in workflow_steps(workflow))
+
+        assert re.search(
+            r"git\s+ls-remote\b[^\n]*--heads\b[^\n]*(?:refs/heads/)?gh-pages\b",
+            scripts,
+        )
+        assert re.search(r"git\s+(?:checkout|switch)\s+--orphan\s+gh-pages\b", scripts)
+        assert re.search(r"(?:mktemp\s+-d|\$RUNNER_TEMP)", scripts)
+
+        ownership_guard = next(
+            run_script(step)
+            for step in workflow_steps(workflow)
+            if "gh-pages" in run_script(step)
+            and re.search(r"\b(?:exit|return)\s+1\b", run_script(step))
+        )
+        assert "index.yaml" in ownership_guard
+        assert re.search(r"\b(?:find|ls|git\s+ls-files)\b", ownership_guard)
+
+    def test_chart_releaser_cli_is_checksum_verified_before_it_can_run(self):
+        workflow = load_yaml(WORKFLOW_PATH)
+        steps = workflow_steps(workflow)
+        scripts = [run_script(step) for step in steps]
+        all_runs = "\n".join(scripts)
+
+        assert "helm/chart-releaser-action" not in WORKFLOW_PATH.read_text(
+            encoding="utf-8"
+        )
+        assert re.search(
+            r"https://github\.com/helm/chart-releaser/releases/download/v1\.7\.0/"
+            r"chart-releaser_1\.7\.0_linux_amd64\.tar\.gz",
+            all_runs,
+        )
+        assert re.search(
+            r"https://github\.com/helm/chart-releaser/releases/download/v1\.7\.0/"
+            r"checksums\.txt",
+            all_runs,
+        )
+
+        def command_position(pattern: str) -> tuple[int, int]:
+            for index, script in enumerate(scripts):
+                match = re.search(pattern, script)
+                if match is not None:
+                    return index, match.start()
+            raise AssertionError(pattern)
+
+        checksum = command_position(r"\bsha256sum\s+(?:--check\b|-c\b)")
+        extract = command_position(r"\btar\b[^\n]*\s(?:-x|-\w*x\w*)")
+        execute = command_position(r"\bcr\s+index\b")
+        assert checksum < extract < execute
+
+        checksum_script = scripts[checksum[0]]
+        assert "checksums.txt" in checksum_script
+        assert "chart-releaser_1.7.0_linux_amd64.tar.gz" in checksum_script
+
+        index_line = next(
+            line
+            for script in scripts
+            for line in script.splitlines()
+            if re.search(r"\bcr\s+index\b", line)
+        )
+        assert re.search(r"(?:--config|-c)\s+['\"]?cr\.yaml['\"]?", index_line)
+        assert re.search(r"\s--push(?:\s|$)", index_line)
+        assert len(re.findall(r"\bcr\s+index\b", all_runs)) == 1
+        assert not re.search(r"\bcr\s+(?:package|upload)\b", all_runs)
+
+    def test_exact_verified_chart_is_the_only_input_to_indexing(self):
+        workflow = load_yaml(WORKFLOW_PATH)
+        steps = workflow_steps(workflow)
+        scripts = [run_script(step) for step in steps]
+
+        integrity_index = next(
+            index
+            for index, script in enumerate(scripts)
+            if re.search(r"release/integrity\.py\s+verify\b", script)
+        )
+        index_command = next(
+            index
+            for index, script in enumerate(scripts)
+            if re.search(r"\bcr\s+index\b", script)
+        )
+
+        staging = [
+            script
+            for script in scripts[integrity_index + 1 : index_command]
+            if "checksums.txt" in script
+            and re.search(r"curie-.+(?:\\)?\.tgz", script)
+            and ".cr-release-packages" in script
+        ]
+        assert len(staging) == 1
+        chart_selection = re.search(
+            r"(?P<variable>[A-Za-z_][A-Za-z0-9_]*)=[\"']?\$\("
+            r"(?P<selector>.*?checksums\.txt.*?)\)[\"']?",
+            staging[0],
+            re.DOTALL,
+        )
+        assert chart_selection is not None
+        assert re.search(
+            r"curie-.+(?:\\)?\.tgz", chart_selection.group("selector")
+        )
+        variable = re.escape(chart_selection.group("variable"))
+        assert re.search(
+            rf"\bcp\s+[\"']?dist/\$\{{?{variable}\}}?[\"']?\s+"
+            r"[\"']?\.cr-release-packages(?:/|[\"'])",
+            staging[0],
+        )
+
+        all_runs = "\n".join(scripts)
+        assert not re.search(r"\bhelm\s+package\b", all_runs)
+        assert not re.search(r"\bcr\s+(?:package|upload)\b", all_runs)
+        assert not re.search(r"\bgh\s+release\s+(?:create|upload)\b", all_runs)
+        assert all(
+            "softprops/action-gh-release" not in step.get("uses", "")
+            for step in steps
+        )
+
+
+class TestChartReleaserConfigContract:
+    def test_index_resolves_the_existing_curie_release_asset(self):
+        config = load_yaml(CONFIG_PATH)
+
+        assert config["owner"] == "curie-eng"
+        assert config["git-repo"] == "curie"
+        assert config["pages-branch"] == "gh-pages"
+        assert config["charts-repo"] == "https://curie-eng.github.io/curie"
+        assert config["release-name-template"] == "v{{ .Version }}"

--- a/release/tests/test_chart_index_workflow.py
+++ b/release/tests/test_chart_index_workflow.py
@@ -313,15 +313,27 @@ class TestChartIndexWorkflowContract:
             for index, step in enumerate(steps)
             if re.search(r"\bhelm\s+repo\s+add\b", run_script(step))
         )
+        helm_setup = next(
+            index
+            for index, step in enumerate(steps)
+            if step.get("uses", "").startswith("azure/setup-helm@")
+        )
         consumer_script = run_script(steps[consumer])
 
-        assert publication < consumer
+        assert steps[helm_setup]["uses"] == (
+            "azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310"
+        )
+        assert publication < helm_setup < consumer
         assert "https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/gh-pages" in consumer_script
         assert re.search(r"\bhelm\s+repo\s+update\b", consumer_script)
         assert re.search(r"\bhelm\s+search\s+repo\s+curie/curie\b", consumer_script)
         assert re.search(r"\bhelm\s+pull\s+curie/curie\b", consumer_script)
         assert consumer_script.count('"$RELEASE_VERSION"') >= 3
-        assert re.search(r"\bfor\s+attempt\s+in\b", consumer_script)
+        attempts = re.search(r"\bseq\s+1\s+(\d+)\b", consumer_script)
+        delay = re.search(r"\bsleep\s+(\d+)\b", consumer_script)
+        assert attempts is not None
+        assert delay is not None
+        assert int(attempts.group(1)) * int(delay.group(1)) > 300
 
     def test_exact_verified_chart_is_the_only_input_to_indexing(self):
         workflow = load_yaml(WORKFLOW_PATH)

--- a/release/tests/test_chart_index_workflow.py
+++ b/release/tests/test_chart_index_workflow.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 import yaml
 
-
 REPO_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "chart-index.yaml"
 CONFIG_PATH = REPO_ROOT / "cr.yaml"
@@ -50,7 +49,15 @@ class TestChartIndexWorkflowContract:
             if (job.get("permissions") or {}).get("contents") == "write"
         ]
         assert len(jobs) == len(writers) == 1
-        assert writers[0]["permissions"] == {"contents": "write"}
+        assert writers[0]["permissions"] == {
+            "contents": "write",
+            "attestations": "read",
+        }
+        assert {
+            name
+            for name, access in writers[0]["permissions"].items()
+            if access == "write"
+        } == {"contents"}
 
         checkouts = [
             step
@@ -242,5 +249,7 @@ class TestChartReleaserConfigContract:
         assert config["owner"] == "curie-eng"
         assert config["git-repo"] == "curie"
         assert config["pages-branch"] == "gh-pages"
-        assert config["charts-repo"] == "https://curie-eng.github.io/curie"
+        assert config["charts-repo"] == (
+            "https://raw.githubusercontent.com/curie-eng/curie/gh-pages"
+        )
         assert config["release-name-template"] == "v{{ .Version }}"

--- a/release/tests/test_chart_index_workflow.py
+++ b/release/tests/test_chart_index_workflow.py
@@ -26,23 +26,29 @@ def run_script(step: dict) -> str:
 
 
 class TestChartIndexWorkflowContract:
-    def test_only_published_releases_and_the_narrow_next_bootstrap_trigger_it(self):
+    def test_successful_stable_release_runs_and_the_next_bootstrap_trigger_it(self):
         workflow = load_yaml(WORKFLOW_PATH)
         trigger = workflow["on"]
         job = next(iter(workflow["jobs"].values()))
 
-        assert set(trigger) == {"release", "push"}
-        assert trigger["release"] == {"types": ["published"]}
+        assert set(trigger) == {"workflow_run", "push"}
+        assert trigger["workflow_run"] == {
+            "workflows": ["Release images and binaries"],
+            "types": ["completed"],
+        }
         assert trigger["push"]["branches"] == ["next"]
         assert len(trigger["push"]["paths"]) == 2
         assert set(trigger["push"]["paths"]) == {
             ".github/workflows/chart-index.yaml",
             "cr.yaml",
         }
-        assert job["if"] == (
-            "github.event_name != 'release' || "
-            "github.event.release.prerelease == false"
-        )
+        condition = " ".join(job["if"].split())
+        assert "github.event_name == 'push'" in condition
+        assert "github.event_name == 'workflow_run'" in condition
+        assert "github.event.workflow_run.conclusion == 'success'" in condition
+        assert "github.event.workflow_run.event == 'push'" in condition
+        assert "startsWith(github.event.workflow_run.head_branch, 'v')" in condition
+        assert "!contains(github.event.workflow_run.head_branch, '-')" in condition
 
     def test_next_bootstrap_selects_the_latest_stable_release(self):
         workflow = load_yaml(WORKFLOW_PATH)
@@ -54,6 +60,8 @@ class TestChartIndexWorkflowContract:
 
         assert 'repos/$GITHUB_REPOSITORY/releases/latest' in resolve_script
         assert "Chart.yaml" not in resolve_script
+        assert "GITHUB_EVENT_PATH" not in resolve_script
+        assert "workflow_run.head_branch" not in resolve_script
         assert re.search(
             r"\^v\(0\|\[1-9\]\[0-9\]\*\)\\\."
             r"\(0\|\[1-9\]\[0-9\]\*\)\\\."

--- a/release/tests/test_chart_index_workflow.py
+++ b/release/tests/test_chart_index_workflow.py
@@ -8,6 +8,7 @@ import yaml
 REPO_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "chart-index.yaml"
 CONFIG_PATH = REPO_ROOT / "cr.yaml"
+GITIGNORE_PATH = REPO_ROOT / ".gitignore"
 
 
 def load_yaml(path: Path) -> dict:
@@ -28,6 +29,7 @@ class TestChartIndexWorkflowContract:
     def test_only_published_releases_and_the_narrow_next_bootstrap_trigger_it(self):
         workflow = load_yaml(WORKFLOW_PATH)
         trigger = workflow["on"]
+        job = next(iter(workflow["jobs"].values()))
 
         assert set(trigger) == {"release", "push"}
         assert trigger["release"] == {"types": ["published"]}
@@ -37,6 +39,27 @@ class TestChartIndexWorkflowContract:
             ".github/workflows/chart-index.yaml",
             "cr.yaml",
         }
+        assert job["if"] == (
+            "github.event_name != 'release' || "
+            "github.event.release.prerelease == false"
+        )
+
+    def test_next_bootstrap_selects_the_latest_stable_release(self):
+        workflow = load_yaml(WORKFLOW_PATH)
+        resolve_script = next(
+            run_script(step)
+            for step in workflow_steps(workflow)
+            if step.get("id") == "release"
+        )
+
+        assert 'repos/$GITHUB_REPOSITORY/releases/latest' in resolve_script
+        assert "Chart.yaml" not in resolve_script
+        assert re.search(
+            r"\^v\(0\|\[1-9\]\[0-9\]\*\)\\\."
+            r"\(0\|\[1-9\]\[0-9\]\*\)\\\."
+            r"\(0\|\[1-9\]\[0-9\]\*\)\$",
+            resolve_script,
+        )
 
     def test_write_permission_is_job_scoped_and_checkout_cannot_reuse_it(self):
         workflow = load_yaml(WORKFLOW_PATH)
@@ -52,6 +75,7 @@ class TestChartIndexWorkflowContract:
         assert writers[0]["permissions"] == {
             "contents": "write",
             "attestations": "read",
+            "checks": "read",
         }
         assert {
             name
@@ -91,6 +115,7 @@ class TestChartIndexWorkflowContract:
             return matches[0]
 
         download = index_of(r"\bgh\s+release\s+download\b")
+        authorization = index_of(r"release/authorize\.py\b")
         closed_world = index_of(r"release/integrity\.py\s+verify\b")
         signature = index_of(r"\bcosign\s+verify-blob\b")
         provenance = index_of(r"\bgh\s+attestation\s+verify\b")
@@ -118,11 +143,45 @@ class TestChartIndexWorkflowContract:
             )
         ]
         assert mutations
-        assert download < closed_world < signature < provenance < min(mutations)
+        assert authorization < download < closed_world < signature < provenance
+        assert provenance < min(mutations)
+
+        authorization_script = run_script(steps[authorization])
+        assert re.search(
+            r"git\s+checkout\s+origin/main\s+--\s+release/",
+            authorization_script,
+        )
+        assert "--reviewed-ref origin/main" in authorization_script
+        assert "--reviewed-ref origin/next" in authorization_script
+
+        resolve_script = run_script(
+            next(step for step in steps if step.get("id") == "release")
+        )
+        assert "refs/heads/main:refs/remotes/origin/main" in resolve_script
+        assert "refs/heads/next:refs/remotes/origin/next" in resolve_script
 
         download_script = run_script(steps[download])
         assert "--pattern" not in download_script
         assert "--archive" not in download_script
+
+    def test_release_outputs_are_passed_to_shell_through_the_environment(self):
+        workflow = load_yaml(WORKFLOW_PATH)
+        steps = workflow_steps(workflow)
+
+        assert all(
+            "${{ steps.release.outputs" not in run_script(step) for step in steps
+        )
+        output_environment = {
+            name
+            for step in steps
+            for name, value in step.get("env", {}).items()
+            if "steps.release.outputs" in value
+        }
+        assert output_environment == {
+            "RELEASE_TAG",
+            "RELEASE_VERSION",
+            "RELEASE_COMMIT",
+        }
 
     def test_only_an_absent_pages_branch_can_be_initialized(self):
         workflow = load_yaml(WORKFLOW_PATH)
@@ -165,9 +224,16 @@ class TestChartIndexWorkflowContract:
         assert orphan is not None
         assert seed_push is not None
         assert index is not None
-        assert orphan.start() < seed_push.start() < index.start()
+        tracking_fetch = re.search(
+            r"git\s+fetch\b.*?refs/heads/gh-pages:refs/remotes/origin/gh-pages",
+            publication_script[seed_push.end() :],
+            re.DOTALL,
+        )
+        assert tracking_fetch is not None
+        tracking_position = seed_push.end() + tracking_fetch.start()
+        assert orphan.start() < seed_push.start() < tracking_position < index.start()
 
-    def test_chart_releaser_cli_is_checksum_verified_before_it_can_run(self):
+    def test_chart_releaser_cli_is_literal_digest_verified_before_it_can_run(self):
         workflow = load_yaml(WORKFLOW_PATH)
         steps = workflow_steps(workflow)
         scripts = [run_script(step) for step in steps]
@@ -181,11 +247,8 @@ class TestChartIndexWorkflowContract:
             r"chart-releaser_1\.7\.0_linux_amd64\.tar\.gz",
             all_runs,
         )
-        assert re.search(
-            r"https://github\.com/helm/chart-releaser/releases/download/v1\.7\.0/"
-            r"checksums\.txt",
-            all_runs,
-        )
+        assert "121a16d4e38b348decb977b8257d4bddab3323681c1819bab4870603138087cf" in all_runs
+        assert "chart-releaser/releases/download/v1.7.0/checksums.txt" not in all_runs
 
         def command_position(pattern: str) -> tuple[int, int]:
             for index, script in enumerate(scripts):
@@ -200,7 +263,7 @@ class TestChartIndexWorkflowContract:
         assert checksum < extract < execute
 
         checksum_script = scripts[checksum[0]]
-        assert "checksums.txt" in checksum_script
+        assert "expected_sha256" in checksum_script
         assert "chart-releaser_1.7.0_linux_amd64.tar.gz" in checksum_script
 
         index_line = next(
@@ -213,6 +276,44 @@ class TestChartIndexWorkflowContract:
         assert re.search(r"\s--push(?:\s|$)", index_line)
         assert len(re.findall(r"\bcr\s+index\b", all_runs)) == 1
         assert not re.search(r"\bcr\s+(?:package|upload)\b", all_runs)
+
+    def test_git_authentication_is_masked_before_index_publication(self):
+        workflow = load_yaml(WORKFLOW_PATH)
+        publication_script = next(
+            run_script(step)
+            for step in workflow_steps(workflow)
+            if re.search(r"\bcr\s+index\b", run_script(step))
+        )
+
+        auth_header = publication_script.index("auth_header=")
+        mask = publication_script.index("::add-mask::$auth_header")
+        credential = publication_script.index("GIT_CONFIG_VALUE_0")
+        index = publication_script.index("cr index")
+
+        assert auth_header < mask < credential < index
+
+    def test_public_consumer_path_proves_the_exact_release_after_publication(self):
+        workflow = load_yaml(WORKFLOW_PATH)
+        steps = workflow_steps(workflow)
+        publication = next(
+            index
+            for index, step in enumerate(steps)
+            if re.search(r"\bcr\s+index\b", run_script(step))
+        )
+        consumer = next(
+            index
+            for index, step in enumerate(steps)
+            if re.search(r"\bhelm\s+repo\s+add\b", run_script(step))
+        )
+        consumer_script = run_script(steps[consumer])
+
+        assert publication < consumer
+        assert "https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/gh-pages" in consumer_script
+        assert re.search(r"\bhelm\s+repo\s+update\b", consumer_script)
+        assert re.search(r"\bhelm\s+search\s+repo\s+curie/curie\b", consumer_script)
+        assert re.search(r"\bhelm\s+pull\s+curie/curie\b", consumer_script)
+        assert consumer_script.count('"$RELEASE_VERSION"') >= 3
+        assert re.search(r"\bfor\s+attempt\s+in\b", consumer_script)
 
     def test_exact_verified_chart_is_the_only_input_to_indexing(self):
         workflow = load_yaml(WORKFLOW_PATH)
@@ -238,6 +339,7 @@ class TestChartIndexWorkflowContract:
             and ".cr-release-packages" in script
         ]
         assert len(staging) == 1
+        package_path = load_yaml(CONFIG_PATH)["package-path"]
         chart_selection = re.search(
             r"(?P<variable>[A-Za-z_][A-Za-z0-9_]*)=[\"']?\$\("
             r"(?P<selector>.*?checksums\.txt.*?)\)[\"']?",
@@ -251,7 +353,7 @@ class TestChartIndexWorkflowContract:
         variable = re.escape(chart_selection.group("variable"))
         assert re.search(
             rf"\bcp\s+[\"']?dist/\$\{{?{variable}\}}?[\"']?\s+"
-            r"[\"']?\.cr-release-packages(?:/|[\"'])",
+            rf"[\"']?{re.escape(package_path)}(?:/|[\"'])",
             staging[0],
         )
 
@@ -272,7 +374,11 @@ class TestChartReleaserConfigContract:
         assert config["owner"] == "curie-eng"
         assert config["git-repo"] == "curie"
         assert config["pages-branch"] == "gh-pages"
-        assert config["charts-repo"] == (
-            "https://raw.githubusercontent.com/curie-eng/curie/gh-pages"
-        )
         assert config["release-name-template"] == "v{{ .Version }}"
+        assert config["package-path"] == ".cr-release-packages"
+        assert "charts-repo" not in config
+
+    def test_local_chart_releaser_packages_are_ignored(self):
+        ignored = GITIGNORE_PATH.read_text(encoding="utf-8").splitlines()
+
+        assert ".cr-release-packages/" in ignored

--- a/tools/ci-retry-gate/tests/test_retry_eligibility.py
+++ b/tools/ci-retry-gate/tests/test_retry_eligibility.py
@@ -149,10 +149,9 @@ NON_INVOCATION_HEADS = frozenset(
 )
 SHELL_KEYWORDS = frozenset({"do", "done", "fi", "then", "else", "esac", "true", "false"})
 
-# The one step in the repository that has the shape of a retry loop without
-# being one: a readiness poll. It waits for a service it did not build to start
-# answering, and it never re invokes a command whose failure would be a defect,
-# so a second iteration cannot bury anything. A readiness poll is not a retry.
+# The steps below have the shape of a retry loop without being retries. They are
+# readiness polls for external state, and they never re invoke repository code
+# or a mutation whose failure would be a defect. A readiness poll is not a retry.
 #
 # This is the ONLY escape from the closed world rule 4 draws around in `run:`
 # retry constructs. Every other step in every workflow must either be on
@@ -161,6 +160,9 @@ SHELL_KEYWORDS = frozenset({"do", "done", "fi", "then", "else", "esac", "true", 
 RUN_RETRY_EXEMPT: frozenset[tuple[str, str, str]] = frozenset(
     {
         ("ci.yaml", "python", "Wait for Langfuse to serve"),
+        # The raw CDN is eventually consistent after publication. This poll
+        # never reruns repository code or the Pages publication mutation.
+        ("chart-index.yaml", "publish-index", "Verify the public Helm consumer path"),
     }
 )
 
@@ -567,15 +569,14 @@ def test_rule_4_no_protected_step_carries_a_retry() -> None:
         "retry and it is closed world like the other two: either the step is an "
         "eligible acquisition, or it is not retrying:\n" + _render(unaccounted)
     )
-    # Positive exercise of `_run_retry_construct` against a real workflow step,
-    # and the only one in this file. `Wait for Langfuse to serve` is a loop
-    # keyword together with a sleep, so all this guards is the LOOP_KEYWORDS
-    # and SLEEP_CALL half of the helper: a typo in either would satisfy every
-    # rule above just as well as a clean repository.
+    # Positive exercise of `_run_retry_construct` against real workflow steps.
+    # Both readiness polls use a loop keyword together with a sleep, so all this
+    # guards is the LOOP_KEYWORDS and SLEEP_CALL half of the helper: a typo in
+    # either would satisfy every rule above just as well as a clean repository.
     #
     # It says nothing about COMMAND_SEPARATORS or NON_INVOCATION_HEADS. The
     # helper returns from the loop branch before the duplicate invocation
-    # splitter ever runs, so this exemption never exercises that branch at all.
+    # splitter ever runs, so these exemptions never exercise that branch at all.
     # The duplicate invocation branch is guarded instead by
     # test_run_retry_construct_detects_every_constructed_shape below, which
     # calls the helper directly on constructed `cmd || cmd` bodies and asserts
@@ -702,13 +703,12 @@ def test_run_retry_construct_detects_every_constructed_shape() -> None:
     """Direct unit test over `_run_retry_construct`, independent of any workflow file.
 
     Rule 4's closed world sweep only ever exercises the helper positively
-    through RUN_RETRY_EXEMPT, and that single exemption (`Wait for Langfuse to
-    serve`) is a loop keyword together with a sleep. It returns from the loop
-    branch before the duplicate invocation splitter ever runs, so the branch
-    that catches a hand rolled `cmd || cmd` retry with no loop and no sleep has
-    zero positive coverage anywhere in this file: setting COMMAND_SEPARATORS so
-    it never matches deletes `cmd || cmd` detection outright, and every rule
-    above still passes.
+    through RUN_RETRY_EXEMPT, whose readiness polls use a loop keyword together
+    with a sleep. They return from the loop branch before the duplicate
+    invocation splitter ever runs, so the branch that catches a hand rolled
+    `cmd || cmd` retry with no loop and no sleep has zero positive coverage
+    anywhere in this file: setting COMMAND_SEPARATORS so it never matches
+    deletes `cmd || cmd` detection outright, and every rule above still passes.
 
     This test builds `run:` bodies directly and calls the helper on each,
     asserting both directions: constructed retries must be found, and


### PR DESCRIPTION
Closes #1621

Publishes the existing verified release chart through a raw GitHub Helm index after the trusted release workflow completes. The index workflow authorizes the release commit, verifies the closed world asset set, verifies the checksum signature and attestations, pins chart releaser by digest, and proves the public Helm consumer path after publication.

The root plugin manifest is intentionally absent. An isolated marketplace install of a candidate manifest and a control without its inline MCP declaration both exposed the contributor Playwright MCP:

```
Successfully installed plugin: curie-probe@curie-probe-marketplace
Component inventory
  Skills (1) implement
  MCP servers (1) playwright
```

The manifest alone cannot isolate repository contributor tooling, so adding it would make repository installation misleading and unsafe.

The local release probe used the verified v0.7.0 archive and produced this consumer transcript:

```
Before repo add:
Error: no repositories configured

"curie-probe" has been added to your repositories
...Successfully got an update from the "curie-probe" chart repository
NAME              CHART VERSION  APP VERSION
curie-probe/curie 0.7.0          0.7.0

90a6981a0744e7a7ebeb3f5af6bfc537fe8cab26e782e0f32731822d6fce65d8  curie-0.7.0.tgz
```

The pulled archive digest exactly matched the signed release checksum. The workflow repeats helm repo add, helm repo update, helm search repo, and helm pull against the public raw branch after each publication.

Ready to send drafts for the three qualified listing surfaces are committed, with their exact destinations and mechanisms. Nothing was submitted to a third party.

Validation completed with 120 affected tests passing, Ruff clean, mypy clean across 188 source files, documentation checks clean, Helm lint and render clean, the full Rust formatting, Clippy, and test sequence clean, and commit policy checks clean.
