### PR TITLE
Report missing gVisor RuntimeClass promptly

### DIFF
--- a/cli/src/guide.rs
+++ b/cli/src/guide.rs
@@ -323,8 +323,12 @@ pub fn primer() -> Primer {
                 fix: "The stack is down. Run `curie local up`, then retry.",
             },
             Recovery {
-                symptom: "`curie cluster up` hangs ~2 min then dies with `job curie-preflight-gvisor failed: DeadlineExceeded`",
+                symptom: "`curie cluster up` fails immediately when `curie-preflight-gvisor` reports `FailedCreate`: `RuntimeClass \"gvisor\" not found`",
                 fix: "A real-model install on a cluster with no `runsc` RuntimeClass fails closed under `security.gvisor.mode=auto`. Opt out with `curie cluster up --set security.gvisor.mode=off`, or use `--fake-model`, or install runsc on the nodes.",
+            },
+            Recovery {
+                symptom: "`curie cluster up` hangs ~2 min then dies with `job curie-preflight-gvisor failed: DeadlineExceeded`",
+                fix: "The Kubernetes Event watch was unavailable, so Helm reported the later deadline. A real-model install on a cluster with no `runsc` RuntimeClass still fails closed. Opt out with `curie cluster up --set security.gvisor.mode=off`, or use `--fake-model`, or install runsc on the nodes.",
             },
             Recovery {
                 symptom: "\"(no response)\" or an empty reply",

--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -9,10 +9,13 @@
 //! them. That split keeps the argv construction unit-testable with no cluster
 //! and gives one place to mask secrets before anything is printed.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
+use std::process::Stdio;
+use std::time::Duration;
 
 use anyhow::{bail, Context, Result};
-use tokio::process::Command;
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, BufReader};
+use tokio::process::{Child, ChildStdout, Command};
 
 /// One external command: the program plus its argument vector, with secret
 /// argument values tagged so they can be masked in any printed form.
@@ -2416,6 +2419,62 @@ pub(crate) fn up_value_plan(o: &UpOpts) -> UpValuePlan {
     plan
 }
 
+fn gvisor_preflight_job_name_from_render(rendered: &str) -> Result<Option<String>> {
+    let mut found = None;
+    for document in rendered.split("\n---") {
+        let document = document.trim();
+        if document.is_empty() {
+            continue;
+        }
+        let value: serde_json::Value = serde_norway::from_str(document)
+            .context("could not parse the rendered gVisor preflight Job")?;
+        if value.is_null() {
+            continue;
+        }
+        if value.get("kind").and_then(|kind| kind.as_str()) != Some("Job") {
+            continue;
+        }
+        let name = value
+            .get("metadata")
+            .and_then(|metadata| metadata.get("name"))
+            .and_then(|name| name.as_str())
+            .filter(|name| !name.is_empty())
+            .context("the rendered gVisor preflight Job has no name")?;
+        if found.replace(name.to_string()).is_some() {
+            bail!("the gVisor preflight template rendered more than one Job");
+        }
+    }
+    Ok(found)
+}
+
+async fn rendered_gvisor_preflight_job(
+    chart: &str,
+    common: &CommonOpts,
+    plan: &UpValuePlan,
+) -> Result<Option<String>> {
+    let mut args = vec![
+        plain("template"),
+        plain(&common.release),
+        plain(chart),
+        plain("-n"),
+        plain(&common.namespace),
+    ];
+    plan.append_command_args(&mut args);
+    args.push(plain("--show-only"));
+    args.push(plain("templates/preflight-gvisor.yaml"));
+    let (ok, out, err) = run_capture(&OpsCommand::new("helm", args)).await?;
+    if !ok {
+        if err.trim() == "Error: could not find template templates/preflight-gvisor.yaml in chart" {
+            return Ok(None);
+        }
+        bail!(
+            "could not render the gVisor preflight Job: {}",
+            failure_reason(&err)
+        );
+    }
+    gvisor_preflight_job_name_from_render(&out)
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum PriorityClassRole {
     Platform,
@@ -3246,6 +3305,453 @@ pub async fn run_capture(cmd: &OpsCommand) -> Result<(bool, String, String)> {
     ))
 }
 
+fn finish_captured_step(
+    step: crate::ui::Step,
+    ok_detail: &str,
+    cmd: &OpsCommand,
+    ok: bool,
+    out: String,
+    err: String,
+) -> Result<String> {
+    let ui = crate::ui::ui();
+    if ok {
+        step.done(ok_detail);
+    } else {
+        step.fail("failed");
+    }
+    for line in out.lines().chain(err.lines()) {
+        ui.plumbing(line);
+    }
+    // One implementation, shared with the teardown Display message (#1230):
+    // an inline second copy of this rule is how the two drifted before.
+    if !ok {
+        let reason = failure_reason(&err);
+        ui.failure(&format!("`{}` failed: {reason}", cmd.program));
+        bail!("`{}` exited nonzero", cmd.program);
+    }
+    Ok(out)
+}
+
+struct RunningInstall {
+    child: Child,
+    stdout: tokio::task::JoinHandle<std::io::Result<Vec<u8>>>,
+    stderr: tokio::task::JoinHandle<std::io::Result<Vec<u8>>>,
+    _secret_files: Vec<SecretValuesFileGuard>,
+    program: String,
+}
+
+impl RunningInstall {
+    fn spawn(cmd: &OpsCommand) -> Result<Self> {
+        let (cmd, secret_files) = cmd.materialize_secret_files()?;
+        let mut child = Command::new(&cmd.program)
+            .args(cmd.argv())
+            .envs(cmd.env.iter().chain(cmd.secret_env.iter()).cloned())
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true)
+            .spawn()
+            .with_context(|| format!("failed to invoke `{}`; is it on PATH?", cmd.program))?;
+        let mut stdout = child
+            .stdout
+            .take()
+            .expect("piped install stdout must be available");
+        let mut stderr = child
+            .stderr
+            .take()
+            .expect("piped install stderr must be available");
+        let stdout = tokio::spawn(async move {
+            let mut output = Vec::new();
+            stdout.read_to_end(&mut output).await?;
+            Ok(output)
+        });
+        let stderr = tokio::spawn(async move {
+            let mut output = Vec::new();
+            stderr.read_to_end(&mut output).await?;
+            Ok(output)
+        });
+        Ok(Self {
+            child,
+            stdout,
+            stderr,
+            _secret_files: secret_files,
+            program: cmd.program,
+        })
+    }
+
+    async fn finish(
+        mut self,
+        status: std::io::Result<std::process::ExitStatus>,
+    ) -> Result<(bool, String, String)> {
+        let status = match status {
+            Ok(status) => status,
+            Err(error) => {
+                let _ = terminate_process(&mut self.child).await;
+                return Err(error).with_context(|| {
+                    format!("failed to invoke `{}`; is it on PATH?", self.program)
+                });
+            }
+        };
+        let stdout = self
+            .stdout
+            .await
+            .context("joining the Helm stdout reader")??;
+        let stderr = self
+            .stderr
+            .await
+            .context("joining the Helm stderr reader")??;
+        Ok((
+            status.success(),
+            String::from_utf8_lossy(&stdout).to_string(),
+            String::from_utf8_lossy(&stderr).to_string(),
+        ))
+    }
+
+    async fn terminate(mut self) {
+        let _ = terminate_helm_process(&mut self.child).await;
+        self.stdout.abort();
+        self.stderr.abort();
+        let _ = self.stdout.await;
+        let _ = self.stderr.await;
+    }
+}
+
+struct RunningGvisorEventWatch {
+    child: Child,
+    stdout: tokio::io::Lines<BufReader<ChildStdout>>,
+    existing_event_uids: BTreeSet<String>,
+}
+
+fn gvisor_event_selector(namespace: &str, job: &str) -> String {
+    format!(
+        "involvedObject.kind=Job,involvedObject.namespace={namespace},involvedObject.name={job},reason=FailedCreate"
+    )
+}
+
+fn gvisor_event_watch_cmd(namespace: &str, job: &str) -> OpsCommand {
+    OpsCommand::new(
+        "kubectl",
+        vec![
+            plain("get"),
+            plain("events"),
+            plain("-n"),
+            plain(namespace),
+            plain("--field-selector"),
+            plain(gvisor_event_selector(namespace, job)),
+            plain("--watch"),
+            plain("--output-watch-events"),
+            plain("-o"),
+            plain(
+                r#"jsonpath={.type}{"\u001f"}{.object.metadata.uid}{"\u001f"}{.object.involvedObject.kind}{"\u001f"}{.object.involvedObject.namespace}{"\u001f"}{.object.involvedObject.name}{"\u001f"}{.object.reason}{"\u001f"}{.object.message}{"\n"}"#,
+            ),
+        ],
+    )
+}
+
+fn gvisor_existing_event_uids_cmd(namespace: &str, job: &str) -> OpsCommand {
+    OpsCommand::new(
+        "kubectl",
+        vec![
+            plain("get"),
+            plain("events"),
+            plain("-n"),
+            plain(namespace),
+            plain("--field-selector"),
+            plain(gvisor_event_selector(namespace, job)),
+            plain("-o"),
+            plain(r#"jsonpath={range .items[*]}{.metadata.uid}{"\n"}{end}"#),
+        ],
+    )
+}
+
+enum GvisorEventWatchStart {
+    Watching(Box<RunningGvisorEventWatch>),
+    Unavailable,
+}
+
+enum GvisorEventWatchLine {
+    RuntimeClassRejected(String),
+    Ignore,
+}
+
+async fn gvisor_existing_event_uids(namespace: &str, job: &str) -> Option<BTreeSet<String>> {
+    let ui = crate::ui::ui();
+    let snapshot = gvisor_existing_event_uids_cmd(namespace, job);
+    ui.plumbing(&format!("+ {}", snapshot.display()));
+    match run_capture(&snapshot).await {
+        Ok((true, out, _)) => Some(
+            out.lines()
+                .map(str::trim)
+                .filter(|uid| !uid.is_empty())
+                .map(str::to_string)
+                .collect(),
+        ),
+        Ok((false, out, err)) => {
+            let detail = [err.trim(), out.trim()]
+                .into_iter()
+                .find(|detail| !detail.is_empty())
+                .unwrap_or("kubectl exited nonzero with no output");
+            ui.plumbing(&format!("gVisor event snapshot unavailable: {detail}"));
+            None
+        }
+        Err(error) => {
+            ui.plumbing(&format!("gVisor event snapshot unavailable: {error}"));
+            None
+        }
+    }
+}
+
+fn start_gvisor_event_watch(
+    namespace: &str,
+    job: &str,
+    existing_event_uids: BTreeSet<String>,
+) -> GvisorEventWatchStart {
+    let ui = crate::ui::ui();
+    let watch = gvisor_event_watch_cmd(namespace, job);
+    ui.plumbing(&format!("+ {}", watch.display()));
+    let mut child = match Command::new(&watch.program)
+        .args(watch.argv())
+        .envs(watch.env.iter().chain(watch.secret_env.iter()).cloned())
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .kill_on_drop(true)
+        .spawn()
+    {
+        Ok(child) => child,
+        Err(error) => {
+            ui.plumbing(&format!("gVisor event watch unavailable: {error}"));
+            return GvisorEventWatchStart::Unavailable;
+        }
+    };
+    let stdout = child
+        .stdout
+        .take()
+        .expect("piped kubectl event stdout must be available");
+    GvisorEventWatchStart::Watching(Box::new(RunningGvisorEventWatch {
+        child,
+        stdout: BufReader::new(stdout).lines(),
+        existing_event_uids,
+    }))
+}
+
+fn gvisor_event_watch_line(
+    line: &str,
+    namespace: &str,
+    job: &str,
+    existing_event_uids: &BTreeSet<String>,
+) -> GvisorEventWatchLine {
+    let mut fields = line.splitn(7, '\u{001f}');
+    let source = fields.next().unwrap_or_default();
+    let uid = fields.next().unwrap_or_default();
+    let inspect = match source {
+        "ADDED" | "MODIFIED" => !existing_event_uids.contains(uid),
+        _ => false,
+    };
+    if uid.is_empty() || !inspect {
+        return GvisorEventWatchLine::Ignore;
+    }
+    let kind = fields.next().unwrap_or_default();
+    let event_namespace = fields.next().unwrap_or_default();
+    let name = fields.next().unwrap_or_default();
+    let reason = fields.next().unwrap_or_default();
+    let message = fields.next().unwrap_or_default();
+    let missing_runtimeclass = message.contains("RuntimeClass") && message.contains("not found");
+    if kind == "Job"
+        && event_namespace == namespace
+        && name == job
+        && reason == "FailedCreate"
+        && missing_runtimeclass
+    {
+        GvisorEventWatchLine::RuntimeClassRejected(message.to_string())
+    } else {
+        GvisorEventWatchLine::Ignore
+    }
+}
+
+async fn terminate_process(child: &mut Child) -> std::io::Result<std::process::ExitStatus> {
+    if let Ok(Some(status)) = child.try_wait() {
+        return Ok(status);
+    }
+    let _ = child.start_kill();
+    child.wait().await
+}
+
+/// Give Helm its interrupt path so it can mark the release failed before a
+/// bounded forced cleanup. A pending install would block the printed recovery.
+async fn terminate_helm_process(child: &mut Child) -> std::io::Result<std::process::ExitStatus> {
+    if let Ok(Some(status)) = child.try_wait() {
+        return Ok(status);
+    }
+    let interrupted = match child.id() {
+        Some(pid) => Command::new("kill")
+            .arg("-INT")
+            .arg(pid.to_string())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .await
+            .is_ok_and(|status| status.success()),
+        None => false,
+    };
+    if interrupted {
+        if let Ok(status) = tokio::time::timeout(Duration::from_secs(2), child.wait()).await {
+            return status;
+        }
+    }
+    terminate_process(child).await
+}
+
+enum GvisorInstallRace {
+    Helm(std::io::Result<std::process::ExitStatus>),
+    RuntimeClassRejected(String),
+}
+
+async fn run_install_with_gvisor_observer(
+    cl: &crate::ui::Checklist,
+    label: &str,
+    ok_detail: &str,
+    cmd: &OpsCommand,
+    namespace: &str,
+    job: &str,
+    namespace_existed_before_install: bool,
+) -> Result<String> {
+    let ui = crate::ui::ui();
+    ui.plumbing(&format!("+ {}", cmd.display()));
+    let step = cl.step(label);
+    let mut watch_start = if namespace_existed_before_install {
+        Some(match gvisor_existing_event_uids(namespace, job).await {
+            Some(existing_event_uids) => {
+                start_gvisor_event_watch(namespace, job, existing_event_uids)
+            }
+            None => GvisorEventWatchStart::Unavailable,
+        })
+    } else {
+        None
+    };
+    let mut install = match RunningInstall::spawn(cmd) {
+        Ok(install) => install,
+        Err(error) => {
+            if let Some(GvisorEventWatchStart::Watching(watch)) = &mut watch_start {
+                let _ = terminate_process(&mut watch.child).await;
+            }
+            step.fail("failed");
+            return Err(error);
+        }
+    };
+
+    let mut early_helm_status = None;
+    if !namespace_existed_before_install {
+        // Helm owns `--create-namespace`. Wait for that one object, then use a
+        // single list and watch request that cannot lose an Event between calls.
+        let mut retry_delay = Duration::from_millis(50);
+        loop {
+            match namespace_exists(namespace).await {
+                Ok(true) => {
+                    watch_start = Some(start_gvisor_event_watch(namespace, job, BTreeSet::new()));
+                    break;
+                }
+                Ok(false) => {}
+                Err(error) => {
+                    ui.plumbing(&format!(
+                        "gVisor event watch unavailable while waiting for namespace: {error:#}"
+                    ));
+                    watch_start = Some(GvisorEventWatchStart::Unavailable);
+                    break;
+                }
+            }
+            match install.child.try_wait() {
+                Ok(Some(status)) => {
+                    early_helm_status = Some(Ok(status));
+                    break;
+                }
+                Err(error) => {
+                    early_helm_status = Some(Err(error));
+                    break;
+                }
+                Ok(None) => {}
+            }
+            tokio::time::sleep(retry_delay).await;
+            retry_delay = retry_delay
+                .saturating_mul(2)
+                .min(Duration::from_millis(500));
+        }
+    }
+
+    let watch_start = watch_start.unwrap_or(GvisorEventWatchStart::Unavailable);
+    let mut watch = None;
+    let race = if let Some(status) = early_helm_status {
+        GvisorInstallRace::Helm(status)
+    } else {
+        match watch_start {
+            GvisorEventWatchStart::Watching(running_watch) => {
+                watch = Some(*running_watch);
+                let running_watch = watch.as_mut().expect("watch was just installed");
+                let existing_event_uids = running_watch.existing_event_uids.clone();
+                loop {
+                    let outcome = tokio::select! {
+                        status = install.child.wait() => Some(GvisorInstallRace::Helm(status)),
+                        line = running_watch.stdout.next_line() => {
+                            match line {
+                                Ok(Some(line)) => match gvisor_event_watch_line(
+                                    &line,
+                                    namespace,
+                                    job,
+                                    &existing_event_uids,
+                                ) {
+                                    GvisorEventWatchLine::RuntimeClassRejected(rejection) => {
+                                        Some(GvisorInstallRace::RuntimeClassRejected(rejection))
+                                    }
+                                    GvisorEventWatchLine::Ignore => None,
+                                },
+                                Ok(None) | Err(_) => {
+                                    let _ = terminate_process(&mut running_watch.child).await;
+                                    Some(GvisorInstallRace::Helm(install.child.wait().await))
+                                }
+                            }
+                        }
+                    };
+                    if let Some(outcome) = outcome {
+                        break outcome;
+                    }
+                }
+            }
+            GvisorEventWatchStart::Unavailable => {
+                GvisorInstallRace::Helm(install.child.wait().await)
+            }
+        }
+    };
+
+    match race {
+        GvisorInstallRace::Helm(status) => {
+            if let Some(watch) = watch.as_mut() {
+                let _ = terminate_process(&mut watch.child).await;
+            }
+            let captured = install.finish(status).await;
+            match captured {
+                Ok((ok, out, err)) => finish_captured_step(step, ok_detail, cmd, ok, out, err),
+                Err(error) => {
+                    step.fail("failed");
+                    Err(error)
+                }
+            }
+        }
+        GvisorInstallRace::RuntimeClassRejected(rejection) => {
+            if let Some(watch) = watch.as_mut() {
+                let _ = terminate_process(&mut watch.child).await;
+            }
+            install.terminate().await;
+            step.fail("failed");
+            let fix = "curie cluster up --set security.gvisor.mode=off";
+            Err(crate::exit::CliError::failure(format!(
+                "gVisor preflight Job `{job}` could not create its pod: {rejection}. To install without gVisor isolation, run `{fix}`."
+            ))
+            .with_fix(fix)
+            .into())
+        }
+    }
+}
+
 /// Run one command under a checklist `step` labeled `label`, capturing its
 /// stdio. Echoes the masked command line and replays the captured output as dim
 /// plumbing (both no-ops unless `--debug`, so default runs stay quiet and the
@@ -3262,22 +3768,7 @@ pub(crate) async fn run_step(
     ui.plumbing(&format!("+ {}", cmd.display()));
     let step = cl.step(label);
     let (ok, out, err) = run_capture(cmd).await?;
-    if ok {
-        step.done(ok_detail);
-    } else {
-        step.fail("failed");
-    }
-    for line in out.lines().chain(err.lines()) {
-        ui.plumbing(line);
-    }
-    if !ok {
-        // One implementation, shared with the teardown Display message (#1230):
-        // an inline second copy of this rule is how the two drifted before.
-        let reason = failure_reason(&err);
-        ui.failure(&format!("`{}` failed: {reason}", cmd.program));
-        bail!("`{}` exited nonzero", cmd.program);
-    }
-    Ok(out)
+    finish_captured_step(step, ok_detail, cmd, ok, out, err)
 }
 
 // ---------------------------------------------------------------------------
@@ -3603,12 +4094,31 @@ async fn run_prepared_up(
             lines: cmds.iter().map(|cmd| cmd.display()).collect(),
         }));
     }
+    let release_namespace_existed_before_install = ownership_candidates
+        .iter()
+        .find_map(|(namespace, existed)| (namespace == &opts.common.namespace).then_some(*existed))
+        .unwrap_or(false);
     require_on_path("helm")?;
     preflight_priority_class_ownership(&opts, &value_plan).await?;
+    let gvisor_preflight_job =
+        rendered_gvisor_preflight_job(&opts.chart, &opts.common, &value_plan).await?;
     let cl = ui.checklist();
     let label = format!("installing release {}", opts.common.release);
     for cmd in &cmds {
-        run_step(&cl, &label, "installed", cmd).await?;
+        if let Some(job) = gvisor_preflight_job.as_deref() {
+            run_install_with_gvisor_observer(
+                &cl,
+                &label,
+                "installed",
+                cmd,
+                &opts.common.namespace,
+                job,
+                release_namespace_existed_before_install,
+            )
+            .await?;
+        } else {
+            run_step(&cl, &label, "installed", cmd).await?;
+        }
     }
 
     // #707 stamp ownership only on namespaces this run actually created. A

--- a/cli/tests/cluster_up_gvisor_preflight.rs
+++ b/cli/tests/cluster_up_gvisor_preflight.rs
@@ -1,0 +1,749 @@
+//! Binary integration contract for the gVisor preflight diagnosis in issue
+//! #1653. Every case drives the real `curie cluster up` entrypoint with fake
+//! Helm and kubectl executables on PATH.
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::thread;
+use std::time::{Duration, Instant};
+
+const TARGET_RELEASE: &str = "target-release";
+const TARGET_NAMESPACE: &str = "target-namespace";
+const RENDERED_JOB: &str = "acme-runtime-preflight-gvisor";
+const RUNTIME_CLASS_REJECTION: &str = "Error creating: pods \"acme-runtime-preflight-gvisor-example\" is forbidden: pod rejected: RuntimeClass \"gvisor\" not found";
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_curie")
+}
+
+fn chart() -> &'static str {
+    concat!(env!("CARGO_MANIFEST_DIR"), "/../charts/curie")
+}
+
+fn write_exec(dir: &Path, name: &str, body: &str) {
+    let path = dir.join(name);
+    fs::write(&path, body).unwrap_or_else(|error| panic!("write {name}: {error}"));
+    let mut permissions = fs::metadata(&path)
+        .unwrap_or_else(|error| panic!("read {name} metadata: {error}"))
+        .permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&path, permissions)
+        .unwrap_or_else(|error| panic!("make {name} executable: {error}"));
+}
+
+struct Fixture {
+    _temp: tempfile::TempDir,
+    bin_dir: PathBuf,
+    upgrade_log: PathBuf,
+    event_log: PathBuf,
+    helm_pid: PathBuf,
+    helm_termination_log: PathBuf,
+    helm_pending: PathBuf,
+    namespace_ready: PathBuf,
+    fresh_event: PathBuf,
+    watch_pid: PathBuf,
+    event_emitted: PathBuf,
+    event_mode: String,
+}
+
+impl Fixture {
+    fn new(event_mode: &str) -> Self {
+        let temp = tempfile::tempdir().expect("temporary directory");
+        let bin_dir = temp.path().join("bin");
+        fs::create_dir(&bin_dir).expect("create fake binary directory");
+        let upgrade_log = temp.path().join("upgrades.log");
+        let event_log = temp.path().join("event-queries.log");
+        let helm_pid = temp.path().join("helm.pid");
+        let helm_termination_log = temp.path().join("helm-termination.log");
+        let helm_pending = temp.path().join("helm-pending");
+        let namespace_ready = temp.path().join("namespace-ready");
+        let fresh_event = temp.path().join("fresh-event");
+        let watch_pid = temp.path().join("watch.pid");
+        let event_emitted = temp.path().join("event-emitted");
+
+        write_exec(
+            &bin_dir,
+            "helm",
+            r#"#!/bin/sh
+if [ "$1" = "get" ] && [ "$2" = "values" ]; then
+    printf '%s\n' 'Error: release: not found' >&2
+    exit 1
+fi
+
+if [ "$1" = "template" ]; then
+    fullname="target-release"
+    platform_create="true"
+    sandbox_create="true"
+    gvisor_mode="auto"
+    fake_model="true"
+    install_runtimeclass="false"
+    show_only=""
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            --set|--set-string)
+                shift
+                case "$1" in
+                    fullnameOverride=*) fullname=${1#*=} ;;
+                    priorityClasses.platform.create=*) platform_create=${1#*=} ;;
+                    priorityClasses.sandbox.create=*) sandbox_create=${1#*=} ;;
+                    security.gvisor.mode=*) gvisor_mode=${1#*=} ;;
+                    security.gvisor.installRuntimeClass=*) install_runtimeclass=${1#*=} ;;
+                    agentSandbox.runner.fakeModel=*) fake_model=${1#*=} ;;
+                esac
+                ;;
+            --show-only)
+                shift
+                show_only="$1"
+                ;;
+            --show-only=*)
+                show_only=${1#*=}
+                ;;
+        esac
+        shift
+    done
+
+    if [ "$show_only" = "templates/preflight-gvisor.yaml" ]; then
+        if [ "$gvisor_mode" = "off" ] || { [ "$gvisor_mode" = "auto" ] && [ "$fake_model" = "true" ]; }; then
+            printf '%s\n' 'Error: could not find template templates/preflight-gvisor.yaml in chart' >&2
+            exit 1
+        fi
+        if [ "$install_runtimeclass" = "true" ]; then
+            printf '%s\n' \
+                'apiVersion: node.k8s.io/v1' \
+                'kind: RuntimeClass' \
+                'metadata:' \
+                '  name: gvisor' \
+                'handler: runsc' \
+                '---'
+        fi
+        printf '%s\n' \
+            'apiVersion: batch/v1' \
+            'kind: Job' \
+            'metadata:' \
+            "  name: $fullname-preflight-gvisor" \
+            'spec:' \
+            '  backoffLimit: 0'
+        exit 0
+    fi
+
+    if [ "$show_only" = "templates/priorityclass.yaml" ]; then
+        first="true"
+        if [ "$platform_create" = "true" ]; then
+            printf '%s\n' \
+                'apiVersion: scheduling.k8s.io/v1' \
+                'kind: PriorityClass' \
+                'metadata:' \
+                '  name: curie-platform' \
+                'value: 1000000' \
+                'globalDefault: false'
+            first="false"
+        fi
+        if [ "$sandbox_create" = "true" ]; then
+            if [ "$first" = "false" ]; then
+                printf '%s\n' '---'
+            fi
+            printf '%s\n' \
+                'apiVersion: scheduling.k8s.io/v1' \
+                'kind: PriorityClass' \
+                'metadata:' \
+                '  name: curie-sandbox' \
+                'value: 100000' \
+                'globalDefault: false'
+        fi
+        exit 0
+    fi
+
+    printf 'unexpected helm template invocation: %s\n' "$*" >&2
+    exit 64
+fi
+
+if [ "$1" = "upgrade" ] && [ "$2" = "--install" ]; then
+    printf '%s\n' "$*" >> "$CURIE_TEST_UPGRADE_LOG"
+    printf '%s\n' "$$" > "$CURIE_TEST_HELM_PID"
+    gvisor_mode="auto"
+    for argument in "$@"; do
+        case "$argument" in
+            security.gvisor.mode=*) gvisor_mode=${argument#*=} ;;
+        esac
+    done
+    if [ -e "$CURIE_TEST_HELM_PENDING" ]; then
+        printf '%s\n' 'Error: UPGRADE FAILED: another operation (install/upgrade/rollback) is in progress' >&2
+        exit 1
+    fi
+    if { [ "$CURIE_TEST_EVENT_MODE" = "matching" ] || [ "$CURIE_TEST_EVENT_MODE" = "fresh-namespace" ]; } && [ "$gvisor_mode" = "require" ]; then
+        : > "$CURIE_TEST_HELM_PENDING"
+        graceful_exit() {
+            signal="$1"
+            if [ -n "${sleep_pid:-}" ]; then
+                kill "$sleep_pid" 2>/dev/null || true
+                wait "$sleep_pid" 2>/dev/null || true
+            fi
+            rm -f "$CURIE_TEST_HELM_PENDING"
+            printf '%s\n' "$signal" >> "$CURIE_TEST_HELM_TERMINATION_LOG"
+            exit 1
+        }
+        trap 'graceful_exit HUP' HUP
+        trap 'graceful_exit INT' INT
+        trap 'graceful_exit TERM' TERM
+        if [ "$CURIE_TEST_EVENT_MODE" = "fresh-namespace" ]; then
+            : > "$CURIE_TEST_NAMESPACE_READY"
+            : > "$CURIE_TEST_FRESH_EVENT"
+        fi
+        sleep 5 &
+        sleep_pid=$!
+        wait "$sleep_pid"
+        trap - HUP INT TERM
+        rm -f "$CURIE_TEST_HELM_PENDING"
+        printf '%s\n' 'Error: UPGRADE FAILED: pre-upgrade hooks failed: job target-release-preflight-gvisor failed: DeadlineExceeded' >&2
+        exit 1
+    fi
+    sleep 1
+    printf '%s\n' 'Release installed'
+    exit 0
+fi
+
+printf 'unexpected helm invocation: %s\n' "$*" >&2
+exit 64
+"#,
+        );
+
+        write_exec(
+            &bin_dir,
+            "kubectl",
+            r#"#!/bin/sh
+if [ "$1" = "get" ] && [ "$2" = "namespace" ]; then
+    if [ "$3" = "target-namespace" ] && [ "$CURIE_TEST_EVENT_MODE" = "fresh-namespace" ] && [ ! -e "$CURIE_TEST_NAMESPACE_READY" ]; then
+        printf '%s\n' 'Error from server (NotFound): namespaces "target-namespace" not found' >&2
+        exit 1
+    fi
+    exit 0
+fi
+
+if [ "$1" = "get" ] && [ "$2" = "priorityclass" ]; then
+    exit 0
+fi
+
+if [ "$1" = "get" ] && { [ "$2" = "event" ] || [ "$2" = "events" ]; }; then
+    printf '%s\n' "$*" >> "$CURIE_TEST_EVENT_LOG"
+    case " $* " in
+        *" --all-namespaces "*)
+            printf '%s\n' 'Error from server (Forbidden): events is forbidden at the cluster scope' >&2
+            exit 1
+            ;;
+        *" -n target-namespace "*) ;;
+        *)
+            printf 'event query was not scoped to target-namespace: %s\n' "$*" >&2
+            exit 64
+            ;;
+    esac
+    watch="false"
+    watch_only="false"
+    output_watch_events="false"
+    combined_jsonpath="false"
+    unit_separator_jsonpath="false"
+    uid_snapshot="false"
+    for arg in "$@"; do
+        case "$arg" in
+            --watch|--watch=true|-w) watch="true" ;;
+            --watch-only) watch_only="true" ;;
+            --output-watch-events) output_watch_events="true" ;;
+            jsonpath=*items*metadata.uid*) uid_snapshot="true" ;;
+            jsonpath=*.object.metadata.uid*object.involvedObject.kind*) combined_jsonpath="true" ;;
+        esac
+        case "$arg" in
+            *\\u001f*) unit_separator_jsonpath="true" ;;
+        esac
+    done
+
+    if [ "$CURIE_TEST_EVENT_MODE" = "watch-unavailable" ]; then
+        printf '%s\n' 'Error from server (Forbidden): events is forbidden in target-namespace' >&2
+        exit 1
+    fi
+    if [ "$watch" != "true" ]; then
+        if [ "$uid_snapshot" != "true" ] || [ "$watch_only" = "true" ] || [ "$output_watch_events" = "true" ]; then
+            printf 'unexpected Event UID snapshot invocation: %s\n' "$*" >&2
+            exit 64
+        fi
+        if [ "$CURIE_TEST_EVENT_MODE" = "matching" ]; then
+            printf '%s\n' 'existing-event-uid'
+        fi
+        exit 0
+    fi
+    if [ "$watch" != "true" ] || [ "$watch_only" = "true" ] || [ "$output_watch_events" != "true" ] || [ "$combined_jsonpath" != "true" ] || [ "$unit_separator_jsonpath" != "true" ]; then
+        printf 'unexpected list and watch invocation: %s\n' "$*" >&2
+        exit 64
+    fi
+    if [ "$CURIE_TEST_EVENT_MODE" = "fresh-namespace" ] && [ ! -e "$CURIE_TEST_NAMESPACE_READY" ]; then
+        printf '%s\n' 'Error from server (NotFound): namespaces "target-namespace" not found' >&2
+        exit 1
+    fi
+    printf '%s\n' "$$" > "$CURIE_TEST_WATCH_PID"
+    trap 'exit 0' HUP INT TERM
+    if [ "$CURIE_TEST_EVENT_MODE" = "fresh-namespace" ] && [ -e "$CURIE_TEST_FRESH_EVENT" ]; then
+        : > "$CURIE_TEST_EVENT_EMITTED"
+        printf '%s\037%s\037%s\037%s\037%s\037%s\037%s\n' \
+            'ADDED' 'fresh-event-uid' 'Job' 'target-namespace' 'acme-runtime-preflight-gvisor' 'FailedCreate' \
+            'Error creating: pods "acme-runtime-preflight-gvisor-example" is forbidden: pod rejected: RuntimeClass "gvisor" not found'
+    fi
+    if [ "$CURIE_TEST_EVENT_MODE" = "fresh-namespace" ]; then
+        sleep 30
+        exit 0
+    fi
+    if [ "$CURIE_TEST_EVENT_MODE" = "matching" ]; then
+        printf '%s\037%s\037%s\037%s\037%s\037%s\037%s\n' \
+            'ADDED' 'existing-event-uid' 'Job' 'target-namespace' 'acme-runtime-preflight-gvisor' 'FailedCreate' \
+            'Error creating: pods "stale-added-preflight-example" is forbidden: pod rejected: RuntimeClass "stale-added" not found'
+    fi
+    attempts=0
+    while [ ! -e "$CURIE_TEST_HELM_PID" ] && [ "$attempts" -lt 100 ]; do
+        sleep 0.01
+        attempts=$((attempts + 1))
+    done
+    if [ ! -e "$CURIE_TEST_HELM_PID" ]; then
+        printf '%s\n' 'Helm did not start while the Event stream had no initial row' >&2
+        exit 64
+    fi
+    sleep 0.15
+    if [ "$CURIE_TEST_EVENT_MODE" = "matching" ]; then
+        printf '%s\037%s\037%s\037%s\037%s\037%s\037%s\n' \
+            'MODIFIED' 'existing-event-uid' 'Job' 'target-namespace' 'acme-runtime-preflight-gvisor' 'FailedCreate' \
+            'Error creating: pods "stale-modified-preflight-example" is forbidden: pod rejected: RuntimeClass "stale-modified" not found'
+        sleep 0.05
+        event_type='ADDED'
+        event_uid='new-event-uid'
+        message='Error creating: pods "acme-runtime-preflight-gvisor-example" is forbidden: pod rejected: RuntimeClass "gvisor" not found'
+    else
+        event_type='ADDED'
+        event_uid='new-event-uid'
+        message='admission webhook "images.example.com" denied the request'
+    fi
+    : > "$CURIE_TEST_EVENT_EMITTED"
+    printf '%s\037%s\037%s\037%s\037%s\037%s\037%s\n' \
+        "$event_type" "$event_uid" 'Job' 'target-namespace' 'acme-runtime-preflight-gvisor' 'FailedCreate' "$message"
+    sleep 30
+    exit 0
+fi
+
+printf 'unexpected kubectl invocation: %s\n' "$*" >&2
+exit 64
+"#,
+        );
+
+        Self {
+            _temp: temp,
+            bin_dir,
+            upgrade_log,
+            event_log,
+            helm_pid,
+            helm_termination_log,
+            helm_pending,
+            namespace_ready,
+            fresh_event,
+            watch_pid,
+            event_emitted,
+            event_mode: event_mode.to_string(),
+        }
+    }
+
+    fn run(&self, extra: &[&str]) -> (Output, Duration) {
+        let mut paths = vec![self.bin_dir.clone()];
+        if let Some(current) = std::env::var_os("PATH") {
+            paths.extend(std::env::split_paths(&current));
+        }
+        let path = std::env::join_paths(paths).expect("join PATH");
+
+        let mut args = vec![
+            "--color",
+            "never",
+            "cluster",
+            "up",
+            "--chart",
+            chart(),
+            "--namespace",
+            TARGET_NAMESPACE,
+            "--release",
+            TARGET_RELEASE,
+            "--dev",
+            "--no-expose",
+            "--fake-model",
+            "--set",
+            "security.gvisor.mode=require",
+            "--set",
+            "fullnameOverride=acme-runtime",
+        ];
+        args.extend_from_slice(extra);
+
+        let started = Instant::now();
+        let output = Command::new(bin())
+            .args(args)
+            .env("PATH", path)
+            .env("CI", "1")
+            .env("TERM", "dumb")
+            .env("NO_COLOR", "1")
+            .env("CURIE_TEST_UPGRADE_LOG", &self.upgrade_log)
+            .env("CURIE_TEST_EVENT_LOG", &self.event_log)
+            .env("CURIE_TEST_HELM_PID", &self.helm_pid)
+            .env(
+                "CURIE_TEST_HELM_TERMINATION_LOG",
+                &self.helm_termination_log,
+            )
+            .env("CURIE_TEST_HELM_PENDING", &self.helm_pending)
+            .env("CURIE_TEST_NAMESPACE_READY", &self.namespace_ready)
+            .env("CURIE_TEST_FRESH_EVENT", &self.fresh_event)
+            .env("CURIE_TEST_WATCH_PID", &self.watch_pid)
+            .env("CURIE_TEST_EVENT_EMITTED", &self.event_emitted)
+            .env("CURIE_TEST_EVENT_MODE", &self.event_mode)
+            .env_remove("CURIE_CREDENTIALS")
+            .env_remove("CURIE_MODEL_CREDENTIALS")
+            .env_remove("CURIE_GITHUB_TOKEN")
+            .env_remove("CURIE_MODEL")
+            .output()
+            .expect("run curie cluster up");
+        (output, started.elapsed())
+    }
+
+    fn upgrade_count(&self) -> usize {
+        fs::read_to_string(&self.upgrade_log)
+            .unwrap_or_default()
+            .lines()
+            .count()
+    }
+
+    fn assert_event_was_observed_for_rendered_job(&self) {
+        assert!(
+            self.event_emitted.is_file(),
+            "the fake kubectl watch must emit an event before the command finishes"
+        );
+        let invocations = fs::read_to_string(&self.event_log).unwrap_or_default();
+        assert!(
+            invocations.contains(&format!("involvedObject.name={RENDERED_JOB}")),
+            "the event selector must use the rendered fullname override:\n{invocations}"
+        );
+        let watch_invocations: Vec<&str> = invocations
+            .lines()
+            .filter(|line| line.contains("--watch"))
+            .collect();
+        assert_eq!(
+            watch_invocations.len(),
+            1,
+            "exactly one list and watch stream must observe the install:\n{invocations}"
+        );
+        assert!(
+            watch_invocations[0].contains("{.object.metadata.uid}")
+                && watch_invocations[0].contains("{.object.involvedObject.kind}")
+                && watch_invocations[0].contains(r#"{"\u001f"}"#)
+                && !watch_invocations[0].contains("--watch-only")
+                && !invocations.contains("--resource-version"),
+            "one list and watch stream must cover current and future Events:\n{invocations}"
+        );
+        if self.event_mode != "fresh-namespace" {
+            let snapshots: Vec<&str> = invocations
+                .lines()
+                .filter(|line| !line.contains("--watch"))
+                .collect();
+            assert_eq!(
+                snapshots.len(),
+                1,
+                "an existing namespace must snapshot matching Event UIDs once:\n{invocations}"
+            );
+            assert!(
+                snapshots[0].contains(r#"{range .items[*]}{.metadata.uid}"#),
+                "the stale Event boundary must use object UIDs, not list resource versions:\n{invocations}"
+            );
+        }
+        assert!(
+            invocations
+                .lines()
+                .all(|line| line.contains("-n target-namespace")
+                    && !line.contains("--all-namespaces")),
+            "every event query must use namespaced permissions:\n{invocations}"
+        );
+    }
+
+    fn assert_graceful_helm_interruption(&self) {
+        let signals = fs::read_to_string(&self.helm_termination_log).unwrap_or_default();
+        assert_eq!(
+            signals, "INT\n",
+            "Helm must receive one graceful interrupt before any forced cleanup"
+        );
+        assert!(
+            !self.helm_pending.exists(),
+            "the interrupted Helm operation must not leave a pending release"
+        );
+    }
+
+    fn assert_no_event_watch(&self) {
+        assert!(
+            fs::read_to_string(&self.event_log)
+                .unwrap_or_default()
+                .is_empty(),
+            "a nonrendering gVisor preflight must not query Events"
+        );
+        assert!(
+            !self.watch_pid.exists(),
+            "a nonrendering gVisor preflight must not spawn an Event watch"
+        );
+    }
+
+    fn assert_children_stopped(&self) {
+        assert_process_stopped(&self.helm_pid, "helm upgrade");
+        assert_process_stopped(&self.watch_pid, "kubectl event watch");
+    }
+}
+
+fn stderr(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stderr).into_owned()
+}
+
+fn assert_process_stopped(pid_file: &Path, label: &str) {
+    let pid = fs::read_to_string(pid_file)
+        .unwrap_or_else(|error| panic!("read {label} pid: {error}"))
+        .trim()
+        .parse::<u32>()
+        .unwrap_or_else(|error| panic!("parse {label} pid: {error}"));
+    let process = PathBuf::from(format!("/proc/{pid}"));
+    for _ in 0..50 {
+        if !process.exists() {
+            return;
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+    panic!("{label} process {pid} survived curie cluster up");
+}
+
+#[test]
+fn matching_runtimeclass_rejection_wins_before_helm_deadline() {
+    let fixture = Fixture::new("matching");
+    let (output, elapsed) = fixture.run(&[]);
+    let shown = stderr(&output);
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "the RuntimeClass rejection must be a permanent runtime failure\nstdout:\n{}\nstderr:\n{shown}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert!(
+        elapsed < Duration::from_secs(3),
+        "the event must win well before the five second fake Helm deadline, elapsed {elapsed:?}\nstderr:\n{shown}"
+    );
+    assert!(
+        shown.contains(RUNTIME_CLASS_REJECTION),
+        "the original Kubernetes rejection must be preserved:\n{shown}"
+    );
+    assert!(
+        !shown.contains("stale-added") && !shown.contains("stale-modified"),
+        "Events that existed before this install must be ignored even when modified:\n{shown}"
+    );
+    assert!(
+        shown.contains("--set security.gvisor.mode=off"),
+        "the failure must name the explicit opt out:\n{shown}"
+    );
+    assert!(
+        !shown.contains("DeadlineExceeded"),
+        "the later Helm timeout must not become the diagnosis:\n{shown}"
+    );
+    assert_eq!(
+        fixture.upgrade_count(),
+        1,
+        "helm upgrade --install must start exactly once"
+    );
+    fixture.assert_event_was_observed_for_rendered_job();
+    fixture.assert_graceful_helm_interruption();
+    fixture.assert_children_stopped();
+}
+
+#[test]
+fn runtimeclass_document_before_job_still_observes_the_rendered_job() {
+    let fixture = Fixture::new("nonmatching");
+    let (output, _) = fixture.run(&["--set", "security.gvisor.installRuntimeClass=true"]);
+    assert!(
+        output.status.success(),
+        "a RuntimeClass document before the Job must not block the install\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        stderr(&output)
+    );
+    assert_eq!(fixture.upgrade_count(), 1);
+    fixture.assert_event_was_observed_for_rendered_job();
+    fixture.assert_children_stopped();
+}
+
+#[test]
+fn fresh_namespace_rejection_is_observed_after_helm_creates_the_namespace() {
+    let fixture = Fixture::new("fresh-namespace");
+    let (output, elapsed) = fixture.run(&[]);
+    let shown = stderr(&output);
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "a fresh namespace must preserve the RuntimeClass failure classification\nstdout:\n{}\nstderr:\n{shown}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert!(
+        elapsed < Duration::from_secs(3),
+        "the post Helm namespace retry must still beat the fake deadline, elapsed {elapsed:?}\nstderr:\n{shown}"
+    );
+    assert!(
+        shown.contains(RUNTIME_CLASS_REJECTION),
+        "the initial watch list must preserve the RuntimeClass rejection:\n{shown}"
+    );
+    assert!(
+        shown.contains("--set security.gvisor.mode=off"),
+        "the fresh namespace failure must retain the recovery:\n{shown}"
+    );
+    assert!(
+        !shown.contains("DeadlineExceeded"),
+        "the Helm deadline must not replace the fresh namespace diagnosis:\n{shown}"
+    );
+    assert_eq!(fixture.upgrade_count(), 1);
+    assert!(
+        fixture.namespace_ready.is_file() && fixture.event_emitted.is_file(),
+        "Helm must create the namespace and event before the retry observes them"
+    );
+    let invocations = fs::read_to_string(&fixture.event_log).unwrap_or_default();
+    assert_eq!(
+        invocations.lines().count(),
+        1,
+        "fresh namespace recovery must use one list and watch request after Helm starts:\n{invocations}"
+    );
+    assert!(
+        invocations.contains("{.object.metadata.uid}")
+            && invocations.contains("{.object.involvedObject.kind}")
+            && invocations.contains(r#"{"\u001f"}"#)
+            && !invocations.contains("--resource-version"),
+        "the stream must inspect current Events without an EventList resource version:\n{invocations}"
+    );
+    assert!(
+        invocations
+            .lines()
+            .all(|line| line.contains("-n target-namespace") && !line.contains("--all-namespaces")),
+        "fresh namespace retries must retain namespaced permissions:\n{invocations}"
+    );
+    fixture.assert_graceful_helm_interruption();
+    fixture.assert_children_stopped();
+}
+
+#[test]
+fn nonmatching_failedcreate_does_not_abort_successful_install() {
+    let fixture = Fixture::new("nonmatching");
+    let (output, _) = fixture.run(&[]);
+    let shown = stderr(&output);
+
+    assert!(
+        output.status.success(),
+        "an unrelated FailedCreate event must not abort cluster up\nstdout:\n{}\nstderr:\n{shown}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert_eq!(
+        fixture.upgrade_count(),
+        1,
+        "helm upgrade --install must run exactly once"
+    );
+    assert!(
+        !shown.contains("--set security.gvisor.mode=off"),
+        "an unrelated event must not produce the gVisor remediation:\n{shown}"
+    );
+    fixture.assert_event_was_observed_for_rendered_job();
+    fixture.assert_children_stopped();
+}
+
+#[test]
+fn matching_runtimeclass_rejection_has_one_json_error() {
+    let fixture = Fixture::new("matching");
+    let (output, elapsed) = fixture.run(&["--json"]);
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "the JSON path must preserve the permanent failure classification\nstderr:\n{}",
+        stderr(&output)
+    );
+    assert!(
+        elapsed < Duration::from_secs(3),
+        "the JSON path must also beat the fake Helm deadline, elapsed {elapsed:?}"
+    );
+    let payload: serde_json::Value = serde_json::from_slice(&output.stdout)
+        .unwrap_or_else(|error| panic!("--json must emit exactly one error object: {error}"));
+    assert!(
+        payload["error"]
+            .as_str()
+            .is_some_and(|error| error.contains(RUNTIME_CLASS_REJECTION)),
+        "the machine readable error must preserve the Kubernetes rejection: {payload}"
+    );
+    assert!(
+        payload["fix"]
+            .as_str()
+            .is_some_and(|fix| fix.contains("curie cluster up --set security.gvisor.mode=off")),
+        "the machine readable fix must name the explicit opt out: {payload}"
+    );
+    assert_eq!(fixture.upgrade_count(), 1);
+    fixture.assert_event_was_observed_for_rendered_job();
+    fixture.assert_graceful_helm_interruption();
+    fixture.assert_children_stopped();
+}
+
+#[test]
+fn graceful_interruption_allows_the_mode_off_recovery_to_run_next() {
+    let fixture = Fixture::new("matching");
+    let (first, _) = fixture.run(&[]);
+    assert_eq!(
+        first.status.code(),
+        Some(1),
+        "the first install must observe the RuntimeClass rejection\nstderr:\n{}",
+        stderr(&first)
+    );
+    fixture.assert_graceful_helm_interruption();
+
+    let (recovery, _) = fixture.run(&["--set", "security.gvisor.mode=off"]);
+    assert!(
+        recovery.status.success(),
+        "the advertised mode off recovery must not be blocked by a pending Helm operation\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&recovery.stdout),
+        stderr(&recovery)
+    );
+    assert_eq!(
+        fixture.upgrade_count(),
+        2,
+        "the rejected install and its recovery must each invoke Helm once"
+    );
+    assert!(
+        !fixture.helm_pending.exists(),
+        "the successful recovery must leave no pending Helm operation"
+    );
+}
+
+#[test]
+fn fake_model_auto_and_mode_off_skip_the_event_observer() {
+    for setting in ["security.gvisor.mode=auto", "security.gvisor.mode=off"] {
+        let fixture = Fixture::new("matching");
+        let (output, _) = fixture.run(&["--set", setting]);
+        assert!(
+            output.status.success(),
+            "{setting} must proceed when Helm reports that the conditional template rendered nothing\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            stderr(&output)
+        );
+        assert_eq!(fixture.upgrade_count(), 1);
+        fixture.assert_no_event_watch();
+    }
+}
+
+#[test]
+fn unavailable_event_watch_preserves_the_helm_result() {
+    let fixture = Fixture::new("watch-unavailable");
+    let (output, _) = fixture.run(&[]);
+    assert!(
+        output.status.success(),
+        "an unavailable Event read must fall back to Helm's result\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        stderr(&output)
+    );
+    assert_eq!(fixture.upgrade_count(), 1);
+    assert!(
+        !fixture.watch_pid.exists(),
+        "a failed Event snapshot must not spawn the watch process"
+    );
+}

--- a/cli/tests/cluster_up_priorityclass_preflight.rs
+++ b/cli/tests/cluster_up_priorityclass_preflight.rs
@@ -61,6 +61,7 @@ if [ "$1" = "template" ]; then
     platform_create="true"
     sandbox_create="true"
     show_priorityclass="false"
+    show_gvisor_preflight="false"
     while [ "$#" -gt 0 ]; do
         case "$1" in
             --set|--set-string)
@@ -76,14 +77,24 @@ if [ "$1" = "template" ]; then
                 shift
                 if [ "$1" = "templates/priorityclass.yaml" ]; then
                     show_priorityclass="true"
+                elif [ "$1" = "templates/preflight-gvisor.yaml" ]; then
+                    show_gvisor_preflight="true"
                 fi
                 ;;
             --show-only=templates/priorityclass.yaml)
                 show_priorityclass="true"
                 ;;
+            --show-only=templates/preflight-gvisor.yaml)
+                show_gvisor_preflight="true"
+                ;;
         esac
         shift
     done
+
+    if [ "$show_gvisor_preflight" = "true" ]; then
+        printf '%s\n' 'Error: could not find template templates/preflight-gvisor.yaml in chart' >&2
+        exit 1
+    fi
 
     first="true"
     if [ "$platform_create" = "true" ]; then

--- a/cli/tests/installation_plan_parity.rs
+++ b/cli/tests/installation_plan_parity.rs
@@ -141,6 +141,10 @@ if [ "$1" = get ] && [ "$2" = values ]; then
 fi
 if [ "$1" = template ]; then
     case " $* " in
+        *" --show-only templates/preflight-gvisor.yaml "*)
+            printf '%s\n' 'Error: could not find template templates/preflight-gvisor.yaml in chart' >&2
+            exit 1
+            ;;
         *" --show-only templates/priorityclass.yaml "*)
             case " $* " in
                 *" --set priorityClasses.sandbox.create=false "*)


### PR DESCRIPTION
Closes #1653

Curie now observes the gVisor preflight admission Event and reports the missing RuntimeClass before Helm reaches its deadline. It filters stale Events, handles fresh namespaces, and interrupts Helm cleanly so the mode off recovery can run immediately.

Regression coverage models real conditional Helm rendering and kubectl watch bytes. `cargo fmt --check`, `cargo clippy -- -D warnings`, the full `cargo test` suite, and `curie dev verify-fix-pin` pass. A disposable kind cluster reported the missing RuntimeClass in 5 seconds, then deployed the same release with gVisor mode off.

No contract, schema, chart, or ADR change was required.