### PR TITLE
Name the skill up replace recovery

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -1542,9 +1542,13 @@ pub async fn start(opts: StartOpts) -> Result<()> {
         opts.replace,
     );
     if recorded_plan == RecordedStatePlan::Refuse {
+        let recorded_name = &recorded_runner
+            .as_ref()
+            .expect("a refusal requires a recorded runner")
+            .container_name;
         return Err(crate::exit::usage(format!(
-            "a local runner is already recorded in {}/.curie/runner.json; run 'curie skill down' there first",
-            plugin_dir.display()
+            "a local runner is already recorded in {}/.curie/runner.json; run 'curie skill down' there first, or rerun 'curie skill up --replace --name {recorded_name}' to replace it",
+            plugin_dir.display(),
         )));
     }
 

--- a/cli/tests/skill_up_replace.rs
+++ b/cli/tests/skill_up_replace.rs
@@ -16,7 +16,10 @@
 
 use std::process::{Command, Output};
 
-use curie::state::{self, RunnerState};
+use curie::{
+    docker::RUNNER_CONTAINER_LOCAL,
+    state::{self, RunnerState},
+};
 
 fn bin() -> &'static str {
     env!("CARGO_BIN_EXE_curie")
@@ -74,6 +77,32 @@ fn skill_up(dir: &tempfile::TempDir, recorded: &RunnerState, extra: &[&str]) -> 
         .args(extra)
         .output()
         .expect("run curie skill up")
+}
+
+#[test]
+fn a_recorded_runner_refusal_names_the_replace_recovery_command() {
+    let (dir, mut recorded) = bundle_with_recorded_runner(false);
+    recorded.container_name = RUNNER_CONTAINER_LOCAL.into();
+    state::save(&dir.path().join("bundle"), &recorded).expect("save default recorded runner");
+    let out = Command::new(bin())
+        .current_dir(dir.path().join("bundle"))
+        .args(["skill", "up"])
+        .output()
+        .expect("run curie skill up");
+    let stderr = err_str(&out);
+
+    assert!(
+        !out.status.success(),
+        "a recorded runner must refuse a new run"
+    );
+    assert!(
+        stderr.contains("curie skill down"),
+        "the stop first recovery must remain available, got stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("curie skill up --replace --name curie-runner-local"),
+        "the one step replace recovery must be named, got stderr: {stderr}"
+    );
 }
 
 /// The record survives a run that aborts before the replacement happens.


### PR DESCRIPTION
Closes #1658

* Names the actionable `curie skill up --replace --name <recorded runner>` recovery while preserving `skill down`
* Covers the real binary refusal path with a regression that fails when the guidance is reverted

Focused Rust tests, formatting, Clippy, and the skill E2E ladder pass. The full parallel Rust suite also exposed an unrelated concurrency sensitive credential test that passes in isolation.