### PR TITLE
Warn when skill bundle snapshot is stale

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -12,6 +12,7 @@ use anyhow::{bail, Context, Result};
 use clap::ValueEnum;
 use curie_aci_protocol::{Budget, EventType, OutboundEvent, SessionStatus};
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 
 use crate::api::{ApiClient, BudgetConfig, ChannelOutcome};
 use crate::bundle::pack_tar_gz;
@@ -2389,8 +2390,13 @@ pub async fn send(
     url: Option<String>,
 ) -> Result<()> {
     let url = resolve_url(url)?;
+    let saved = state::load(Path::new(".")).unwrap_or(None);
+    let bundle_warning = editable_bundle_warning(saved.as_ref(), &url);
     let client = RunnerClient::new(&url)?;
     let ui = crate::ui::ui();
+    if let Some(warning) = bundle_warning {
+        ui.warn(&warning);
+    }
     let mut printer = TurnPrinter::default();
 
     // Under `--json`, answer tokens are suppressed on stdout (they route through
@@ -2509,6 +2515,31 @@ pub struct SkillMessageOutput {
     pub finalized: bool,
 }
 
+fn editable_bundle_warning(saved: Option<&state::RunnerState>, url: &str) -> Option<String> {
+    let saved = saved.filter(|saved| saved.base_url == url)?;
+    let recorded_digest = saved.bundle_digest.as_deref()?;
+    let archive = match pack_tar_gz(Path::new(&saved.plugin_dir)) {
+        Ok(archive) => archive,
+        Err(_) => {
+            return Some(
+                "could not compare the editable bundle with the running snapshot. Run `curie skill up --replace` after fixing the bundle."
+                    .to_string(),
+            );
+        }
+    };
+    let editable_digest: String = Sha256::digest(&archive)
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect();
+    if editable_digest == recorded_digest {
+        return None;
+    }
+    Some(
+        "editable bundle differs from the running snapshot. Run `curie skill up --replace` to load the changes."
+            .to_string(),
+    )
+}
+
 impl crate::ui::CliOutput for SkillMessageOutput {
     fn to_json(&self) -> serde_json::Value {
         serde_json::json!({
@@ -2535,8 +2566,6 @@ pub async fn eval(
 ) -> Result<()> {
     let saved = state::load(Path::new("."))?;
     let state_plugin_dir = saved.as_ref().map(|s| PathBuf::from(s.plugin_dir.clone()));
-    let cases_path = resolve_cases_path(cases_path, Path::new("."), state_plugin_dir.as_deref())?;
-    let loaded = load_eval(&cases_path)?;
 
     // Model selection (#526): with `--model`, boot a transient runner per model,
     // run the suite against each, and report pass-rate per model -- the one
@@ -2544,6 +2573,14 @@ pub async fn eval(
     // manual `skill up --model X` + `skill eval` loop per model. Without it, the
     // default path drives the already-running runner (whatever model it booted).
     if !models.is_empty() {
+        let recorded_snapshot_dir = sweep_snapshot(saved.as_ref()).map(|(dir, _)| dir);
+        let cases_path = resolve_cases_path(
+            cases_path,
+            Path::new("."),
+            recorded_snapshot_dir.as_deref(),
+            state_plugin_dir.as_deref(),
+        )?;
+        let loaded = load_eval(&cases_path)?;
         return eval_sweep(
             &loaded.suite,
             loaded.trajectory.as_ref(),
@@ -2558,6 +2595,18 @@ pub async fn eval(
 
     let fake = drives_a_fake_runner(saved.as_ref(), url.as_deref());
     let url = resolve_url(url)?;
+    let recorded_snapshot_dir = saved
+        .as_ref()
+        .filter(|saved| saved.base_url == url)
+        .and_then(|saved| saved.bundle_snapshot_dir.as_ref())
+        .map(PathBuf::from);
+    let cases_path = resolve_cases_path(
+        cases_path,
+        Path::new("."),
+        recorded_snapshot_dir.as_deref(),
+        state_plugin_dir.as_deref(),
+    )?;
+    let loaded = load_eval(&cases_path)?;
     // #1087 AC2: the bundle this eval graded, on the machine surface, so an
     // agent can confirm it is the SAME digest `skill status`/`skill message`
     // report without reading a human note off stderr (docs/agents.md bans
@@ -3281,16 +3330,30 @@ impl crate::ui::CliOutput for EvalOutput<'_> {
 }
 
 /// Where the eval cases live: an explicit `--cases` wins; otherwise
-/// `evals/cases.json` in the current directory, falling back to the started
-/// runner's recorded bundle directory (so `curie skill eval` works from
-/// wherever `curie skill up` was run).
+/// `evals/cases.json` in the recorded running snapshot wins, then the current
+/// directory and, only when no snapshot is recorded, the started runner's
+/// recorded bundle directory (so `curie skill eval` works from wherever `curie
+/// skill up` was run).
 pub fn resolve_cases_path(
     explicit: Option<PathBuf>,
     cwd: &Path,
+    recorded_snapshot_dir: Option<&Path>,
     state_plugin_dir: Option<&Path>,
 ) -> Result<PathBuf> {
     if let Some(path) = explicit {
         return Ok(path);
+    }
+    if let Some(snapshot_dir) = recorded_snapshot_dir {
+        let in_snapshot = snapshot_dir.join("evals/cases.json");
+        if in_snapshot.is_file() {
+            return Ok(in_snapshot);
+        }
+        return Err(crate::exit::CliError::usage(format!(
+            "no eval cases found in the running snapshot: {}. Run `curie skill up --replace` or pass --cases",
+            in_snapshot.display()
+        ))
+        .with_fix("run `curie skill up --replace` or pass --cases")
+        .into());
     }
     let local = cwd.join("evals/cases.json");
     if local.is_file() {
@@ -6266,13 +6329,33 @@ mod tests {
 
     #[test]
     fn explicit_cases_path_wins() {
+        let snapshot = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(snapshot.path().join("evals")).unwrap();
+        std::fs::write(snapshot.path().join("evals/cases.json"), "[]").unwrap();
         let path = resolve_cases_path(
             Some(PathBuf::from("/x/cases.json")),
             std::path::Path::new("/nowhere"),
+            Some(snapshot.path()),
             None,
         )
         .unwrap();
         assert_eq!(path, PathBuf::from("/x/cases.json"));
+    }
+
+    #[test]
+    fn missing_recorded_snapshot_cases_do_not_fall_back_to_cwd() {
+        let cwd = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(cwd.path().join("evals")).unwrap();
+        std::fs::write(cwd.path().join("evals/cases.json"), "[]").unwrap();
+        let snapshot = tempfile::tempdir().unwrap();
+
+        let err = resolve_cases_path(None, cwd.path(), Some(snapshot.path()), None).unwrap_err();
+        let message = err.to_string();
+        assert!(
+            message.contains("no eval cases found in the running snapshot"),
+            "{message}"
+        );
+        assert!(message.contains("--cases"), "{message}");
     }
 
     #[test]
@@ -6283,20 +6366,20 @@ mod tests {
         std::fs::write(bundle.path().join("evals/cases.json"), "[]").unwrap();
 
         // cwd has no cases: resolve into the bundle dir from the state file.
-        let resolved = resolve_cases_path(None, cwd.path(), Some(bundle.path())).unwrap();
+        let resolved = resolve_cases_path(None, cwd.path(), None, Some(bundle.path())).unwrap();
         assert_eq!(resolved, bundle.path().join("evals/cases.json"));
 
         // cwd cases take precedence once present.
         std::fs::create_dir_all(cwd.path().join("evals")).unwrap();
         std::fs::write(cwd.path().join("evals/cases.json"), "[]").unwrap();
-        let resolved = resolve_cases_path(None, cwd.path(), Some(bundle.path())).unwrap();
+        let resolved = resolve_cases_path(None, cwd.path(), None, Some(bundle.path())).unwrap();
         assert_eq!(resolved, cwd.path().join("evals/cases.json"));
     }
 
     #[test]
     fn errors_when_nothing_is_found() {
         let cwd = tempfile::tempdir().unwrap();
-        let err = resolve_cases_path(None, cwd.path(), None).unwrap_err();
+        let err = resolve_cases_path(None, cwd.path(), None, None).unwrap_err();
         assert!(err.to_string().contains("--cases"), "{err}");
     }
 

--- a/cli/src/message.rs
+++ b/cli/src/message.rs
@@ -2225,8 +2225,12 @@ pub fn eval_dry_run_lines(opts: &EvalOpts, suite_name: &str, case_count: usize) 
 /// wins, else `evals/cases.json` in the cwd, then the recorded bundle dir.
 fn resolve_eval(explicit: Option<PathBuf>) -> Result<LoadedEval> {
     let state_plugin_dir = crate::state::load(Path::new("."))?.map(|s| PathBuf::from(s.plugin_dir));
-    let path =
-        crate::commands::resolve_cases_path(explicit, Path::new("."), state_plugin_dir.as_deref())?;
+    let path = crate::commands::resolve_cases_path(
+        explicit,
+        Path::new("."),
+        None,
+        state_plugin_dir.as_deref(),
+    )?;
     crate::evals::load_eval(&path)
 }
 

--- a/cli/tests/skill_bundle_snapshot.rs
+++ b/cli/tests/skill_bundle_snapshot.rs
@@ -12,9 +12,11 @@
 mod support;
 
 use std::path::Path;
-use std::process::Command;
+use std::process::{Command, Output};
 
+use curie::bundle;
 use curie::state::{self, RunnerState};
+use curie_aci_protocol::PROTOCOL_VERSION;
 use support::{serve, Response};
 
 fn bin() -> &'static str {
@@ -61,6 +63,181 @@ fn recorded_runner(base_url: &str, dir: &Path) -> RunnerState {
         bundle_digest: None,
         bundle_snapshot_dir: None,
     }
+}
+
+fn frame(value: serde_json::Value) -> String {
+    serde_json::to_string(&value).expect("serialize ACI frame")
+}
+
+fn done_turn(text: &str) -> Response {
+    Response::ndjson(&[
+        frame(serde_json::json!({
+            "type": "text_delta",
+            "version": PROTOCOL_VERSION,
+            "text": text,
+        })),
+        frame(serde_json::json!({
+            "type": "final",
+            "version": PROTOCOL_VERSION,
+            "text": text,
+            "status": "done",
+        })),
+    ])
+}
+
+fn skill_message(dir: &Path, url: &str) -> Output {
+    Command::new(bin())
+        .current_dir(dir)
+        .args(["skill", "message", "hello", "--url", url])
+        .output()
+        .expect("run curie skill message")
+}
+
+fn eval_cases(input: &str) -> String {
+    serde_json::json!({
+        "name": "snapshot suite",
+        "cases": [{
+            "id": "snapshot case",
+            "input": input,
+            "grader": {"kind": "contains", "expected": "answer"},
+        }],
+    })
+    .to_string()
+}
+
+#[test]
+fn skill_message_warns_when_the_editable_bundle_differs_from_the_running_snapshot() {
+    let server = serve(
+        |request| match (request.method.as_str(), request.path.as_str()) {
+            ("POST", "/v1/event") => done_turn("snapshot reply"),
+            _ => Response::json(404, r#"{"error":"unexpected request"}"#),
+        },
+    );
+    let dir = tempfile::tempdir().expect("tempdir");
+    let skill = dir.path().join("SKILL.md");
+    std::fs::write(&skill, "before the runner started").expect("write initial bundle");
+    let snapshot = bundle::snapshot(dir.path()).expect("snapshot initial bundle");
+    std::fs::write(&skill, "edited after the runner started").expect("edit bundle");
+    state::save(
+        dir.path(),
+        &RunnerState {
+            bundle_digest: Some(snapshot.digest),
+            bundle_snapshot_dir: Some(snapshot.dir.display().to_string()),
+            ..recorded_runner(&server.base_url, dir.path())
+        },
+    )
+    .expect("record the runner");
+
+    let output = skill_message(dir.path(), &server.base_url);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "skill message must still answer from the running snapshot; stderr: {stderr}"
+    );
+    assert_eq!(
+        stdout, "snapshot reply\n",
+        "the reply must remain unchanged"
+    );
+    assert!(
+        stderr.contains("editable bundle differs from the running snapshot"),
+        "the source edit must be named before it is mistaken for a running change: {stderr}"
+    );
+    assert!(
+        stderr.contains("curie skill up --replace"),
+        "the warning must name the command that loads the edited bundle: {stderr}"
+    );
+}
+
+#[test]
+fn skill_message_does_not_warn_when_the_editable_bundle_matches_the_running_snapshot() {
+    let server = serve(
+        |request| match (request.method.as_str(), request.path.as_str()) {
+            ("POST", "/v1/event") => done_turn("snapshot reply"),
+            _ => Response::json(404, r#"{"error":"unexpected request"}"#),
+        },
+    );
+    let dir = tempfile::tempdir().expect("tempdir");
+    let skill = dir.path().join("SKILL.md");
+    std::fs::write(&skill, "bundle used by the runner").expect("write bundle");
+    let snapshot = bundle::snapshot(dir.path()).expect("snapshot bundle");
+    state::save(
+        dir.path(),
+        &RunnerState {
+            bundle_digest: Some(snapshot.digest),
+            bundle_snapshot_dir: Some(snapshot.dir.display().to_string()),
+            ..recorded_runner(&server.base_url, dir.path())
+        },
+    )
+    .expect("record the runner");
+
+    let output = skill_message(dir.path(), &server.base_url);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "skill message must answer from the matching snapshot; stderr: {stderr}"
+    );
+    assert_eq!(stdout, "snapshot reply\n");
+    assert!(
+        !stderr.contains("editable bundle differs from the running snapshot"),
+        "a matching source must not produce a mismatch warning: {stderr}"
+    );
+}
+
+#[test]
+fn skill_eval_uses_cases_from_the_running_snapshot_by_default() {
+    let server = serve(
+        |request| match (request.method.as_str(), request.path.as_str()) {
+            ("POST", "/v1/reset") => Response::json(200, "{}"),
+            ("POST", "/v1/event") => done_turn("answer"),
+            _ => Response::json(404, r#"{"error":"unexpected request"}"#),
+        },
+    );
+    let dir = tempfile::tempdir().expect("tempdir");
+    let cases_path = dir.path().join("evals/cases.json");
+    std::fs::create_dir_all(cases_path.parent().expect("evals parent")).expect("create evals");
+    std::fs::write(&cases_path, eval_cases("snapshot input")).expect("write initial cases");
+    let snapshot = bundle::snapshot(dir.path()).expect("snapshot initial bundle");
+    std::fs::write(&cases_path, eval_cases("edited source input")).expect("edit cases");
+    state::save(
+        dir.path(),
+        &RunnerState {
+            bundle_digest: Some(snapshot.digest),
+            bundle_snapshot_dir: Some(snapshot.dir.display().to_string()),
+            ..recorded_runner(&server.base_url, dir.path())
+        },
+    )
+    .expect("record the runner");
+
+    let output = Command::new(bin())
+        .current_dir(dir.path())
+        .args(["skill", "eval", "--json"])
+        .output()
+        .expect("run curie skill eval");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "skill eval must run the recorded snapshot suite; stderr: {stderr}"
+    );
+    let body: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("skill eval must emit JSON");
+    assert_eq!(body["cases"][0]["id"], "snapshot case", "{body}");
+
+    let events = server
+        .recorded()
+        .into_iter()
+        .filter(|request| request.path == "/v1/event")
+        .collect::<Vec<_>>();
+    assert_eq!(events.len(), 1, "the suite must send one case");
+    let event: serde_json::Value =
+        serde_json::from_slice(&events[0].body).expect("parse eval event");
+    assert_eq!(
+        event["text"], "snapshot input",
+        "default eval must use the case the running snapshot contains"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes #1657

Warns before `skill message` when the editable bundle no longer matches the running snapshot and makes default `skill eval` read cases from that snapshot.

1. [x] Regression tests cover stale and matching bundles
2. [x] Skill eval uses the recorded snapshot while explicit `--cases` still wins
3. [x] Local and cluster eval behavior remains unchanged
4. [x] Code and scope reviews approved
5. [x] Full CLI checks and the skill ladder pass