### PR TITLE
Warn when local up falls back to the fake model

### DIFF
--- a/cli/src/local.rs
+++ b/cli/src/local.rs
@@ -541,7 +541,7 @@ pub async fn up(mut o: LocalOpts) -> Result<LocalUpOutput> {
             ModelMode::FakePinnedDespiteCredential => ui.warn(
                 "Running the FAKE model despite a credential in your shell: CURIE_FAKE_MODEL is pinned on. Unset it or set CURIE_FAKE_MODEL=0 to go live.",
             ),
-            ModelMode::DefaultFake => ui.note(
+            ModelMode::DefaultFake => ui.warn(
                 "Running the fake model (no credential set). Provide a credential (ANTHROPIC_API_KEY / CLAUDE_CODE_OAUTH_TOKEN / CURIE_CREDENTIALS) or --local-model to go live.",
             ),
         }

--- a/cli/tests/local_up_fake_warning.rs
+++ b/cli/tests/local_up_fake_warning.rs
@@ -1,0 +1,77 @@
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+use std::process::Command;
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_curie")
+}
+
+fn write_exec(root: &Path, name: &str, body: &str) {
+    let path = root.join(name);
+    fs::write(&path, body).expect("write executable");
+    let mut permissions = fs::metadata(&path)
+        .expect("executable metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(path, permissions).expect("make executable");
+}
+
+#[test]
+fn local_up_without_credentials_warns_about_fake_model() {
+    let temp = tempfile::tempdir().expect("create temporary directory");
+    let tools = temp.path().join("tools");
+    fs::create_dir(&tools).expect("create tools directory");
+    write_exec(&tools, "docker", "#!/bin/sh\nexit 0\n");
+
+    let compose_file = temp.path().join("compose.yaml");
+    fs::write(&compose_file, "services: {}\n").expect("write compose file");
+
+    let mut paths = vec![tools];
+    if let Some(path) = std::env::var_os("PATH") {
+        paths.extend(std::env::split_paths(&path));
+    }
+    let path = std::env::join_paths(paths).expect("join PATH");
+
+    let output = Command::new(bin())
+        .current_dir(temp.path())
+        .args([
+            "--color=never",
+            "local",
+            "up",
+            "--minimal",
+            "-f",
+            compose_file.to_str().expect("compose path is UTF 8"),
+        ])
+        .env("PATH", path)
+        .env("LC_ALL", "C")
+        .env_remove("CURIE_CREDENTIALS")
+        .env_remove("ANTHROPIC_API_KEY")
+        .env_remove("CLAUDE_CODE_OAUTH_TOKEN")
+        .env_remove("CURIE_FAKE_MODEL")
+        .output()
+        .expect("run curie local up");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "local up must succeed\nstdout: {}\nstderr: {stderr}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+
+    let guidance = "Running the fake model (no credential set). Provide a credential (ANTHROPIC_API_KEY / CLAUDE_CODE_OAUTH_TOKEN / CURIE_CREDENTIALS) or --local-model to go live.";
+    assert!(
+        stderr.contains(guidance),
+        "stderr must retain the fake model recovery guidance\n{stderr}"
+    );
+
+    let expected_warning = format!("! warn  {guidance}");
+    let warning_count = stderr
+        .lines()
+        .filter(|line| *line == expected_warning.as_str())
+        .count();
+    assert_eq!(
+        warning_count, 1,
+        "stderr must report the fake model fallback as one warning\n{stderr}"
+    );
+}


### PR DESCRIPTION
Summary

Raise the no credential fake model fallback from a dim note to an amber warning while preserving the recovery guidance.

Add a binary regression that proves reverting the severity change removes the warning marker.

Done check

* [x] Regression was red before the implementation and is green after it.
* [x] Production and test edits were delegated in separate contexts.
* [x] No public return type changed.
* [x] Blocking code review approved with file and line evidence.
* [x] Blocking scope review approved every hunk.
* [x] Local rebuild was enumerated and left unchanged because the issue scopes local up only.
* [x] No guard or security surface changed.
* [x] Consolidation was skipped because the production diff is one line.
* [x] Observable binary proof and mutation reversal both passed.
* [x] Full CLI tests, format, and lint passed from an isolated Cargo target.
* [ ] The local ladder reused the existing stack but stopped because six stale active weather deployments made candidate binding unprovable. The stack was left running for its owner.

Closes #1659