### PR TITLE
Ship a worked curie.yaml example

### DIFF
--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -4164,7 +4164,7 @@ export const commandManifest = {
         }
       ],
       "hidden": false,
-      "long_about": "Converge a cluster to a `curie.yaml` installation file (ADR-0097).\n\nThe file states the whole intent, so `apply` never has to be told what it was told last time -- the gap behind the dropped-settings failures the `--set`/`--reuse-values` shape kept producing.",
+      "long_about": "Converge a cluster to a `curie.yaml` installation file (ADR-0097).\n\nThe file states the whole intent, so `apply` never has to be told what it was told last time -- the gap behind the dropped-settings failures the `--set`/`--reuse-values` shape kept producing.\n\nA worked common installation is available at `examples/curie.yaml` in the Curie repository.",
       "name": "apply"
     },
     {

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -4161,7 +4161,7 @@
         }
       ],
       "hidden": false,
-      "long_about": "Converge a cluster to a `curie.yaml` installation file (ADR-0097).\n\nThe file states the whole intent, so `apply` never has to be told what it was told last time -- the gap behind the dropped-settings failures the `--set`/`--reuse-values` shape kept producing.",
+      "long_about": "Converge a cluster to a `curie.yaml` installation file (ADR-0097).\n\nThe file states the whole intent, so `apply` never has to be told what it was told last time -- the gap behind the dropped-settings failures the `--set`/`--reuse-values` shape kept producing.\n\nA worked common installation is available at `examples/curie.yaml` in the Curie repository.",
       "name": "apply"
     },
     {

--- a/cli/src/installation.rs
+++ b/cli/src/installation.rs
@@ -1675,6 +1675,36 @@ mod diff_tests {
         }
     }
 
+    #[test]
+    fn shipped_curie_yaml_example_plans_for_apply() {
+        let _lock = CREDENTIAL_ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let names = ["ANTHROPIC_API_KEY", "SLACK_APP_TOKEN", "SLACK_BOT_TOKEN"];
+        let env = CredentialEnvRestore::clear(&names);
+        for name in names {
+            env.set(name, "example credential");
+        }
+
+        let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("../examples/curie.yaml");
+        let cfg = Installation::load(&path).expect("the shipped curie.yaml example must parse");
+
+        assert_eq!(cfg.install.namespace, "acme-bot");
+        assert_eq!(cfg.install.release, "acme-bot");
+        assert_eq!(
+            cfg.helm_sets(),
+            vec!["ui.deploy=false", "inference.deploy=false"]
+        );
+        assert_eq!(
+            cfg.egress_hosts().first().map(String::as_str),
+            Some("anthropic")
+        );
+        assert_eq!(cfg.credential_names(), names.map(str::to_string));
+
+        plan_installation(cfg, true)
+            .expect("the shipped curie.yaml example must plan through curie apply");
+    }
+
     fn live(json: serde_json::Value) -> serde_json::Value {
         json
     }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -429,6 +429,9 @@ enum Command {
     /// The file states the whole intent, so `apply` never has to be told what
     /// it was told last time -- the gap behind the dropped-settings failures
     /// the `--set`/`--reuse-values` shape kept producing.
+    ///
+    /// A worked common installation is available at `examples/curie.yaml` in
+    /// the Curie repository.
     Apply {
         /// Path to the installation file.
         #[arg(short = 'f', long = "file", default_value = "curie.yaml")]

--- a/cli/tests/command_surface.rs
+++ b/cli/tests/command_surface.rs
@@ -20,6 +20,35 @@ fn output_text(output: &std::process::Output) -> String {
     String::from_utf8_lossy(&output.stdout).into_owned() + &String::from_utf8_lossy(&output.stderr)
 }
 
+#[test]
+fn apply_help_references_shipped_curie_yaml_example() {
+    let output = run_help(&["apply"]);
+    assert!(
+        output.status.success(),
+        "expected success for apply help\n{}",
+        output_text(&output)
+    );
+    let text = output_text(&output);
+    assert!(
+        text.contains("examples/curie.yaml"),
+        "apply help must reference the shipped example\n{text}"
+    );
+}
+
+#[test]
+fn operations_references_shipped_curie_yaml_example() {
+    let repo_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("cli crate has a repository root");
+    let operations = fs::read_to_string(repo_root.join("docs/operations.md"))
+        .expect("read the operations guide");
+
+    assert!(
+        operations.contains("[`examples/curie.yaml`](../examples/curie.yaml)"),
+        "operations guide must link to the shipped example"
+    );
+}
+
 fn help_lists_subcommand(text: &str, name: &str) -> bool {
     text.lines().any(|line| {
         let line = line.trim_start();

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -72,6 +72,24 @@ Two things to know:
   will not start on an older distro. The ones named for a full Rust target
   triple (`curie-<target>-<sha>`) are the portable pair.
 
+### `curie apply`
+
+Copy [`examples/curie.yaml`](../examples/curie.yaml) into your repository as
+`curie.yaml` and customize it. Credential fields contain credential names, not
+secret values.
+Before either command, provide values for `ANTHROPIC_API_KEY`,
+`SLACK_APP_TOKEN`, and `SLACK_BOT_TOKEN` in the environment or store them with
+`curie secrets set <NAME>`.
+
+Preview the installation, then apply it:
+
+```bash
+curie apply --dry-run
+curie apply
+```
+
+Use `curie cluster up` below for flag driven installs.
+
 ### `curie cluster up`
 
 Installs (or upgrades) Curie's Helm chart onto the cluster you're pointed at:

--- a/examples/curie.yaml
+++ b/examples/curie.yaml
@@ -1,0 +1,19 @@
+version: 1
+
+install:
+  namespace: acme-bot
+  release: acme-bot
+
+platform:
+  ui: false
+  inference: false
+  egress:
+    - host: anthropic
+
+credentials:
+  model: ANTHROPIC_API_KEY
+
+comms:
+  slack:
+    app_token: SLACK_APP_TOKEN
+    bot_token: SLACK_BOT_TOKEN


### PR DESCRIPTION
Closes #1660

Adds a worked examples/curie.yaml, links it from operations and apply help, and validates the file through apply planning.

Validation

[x] Full isolated CLI suite, cargo fmt, and clippy passed.
[x] Docs lint, UI lint, UI typecheck, and 147 UI tests passed.
[x] Help and operations tests are fix pinned.
[x] Final code and scope reviews have no blocking findings.
[ ] Local parity rung is blocked by a reused shared stack with stale active weather deployments. The stack owner must run curie local down --wipe --yes before this rung can bind deterministically.