### PR TITLE
Read state before suggesting CLI recovery

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -968,18 +968,14 @@ fn resolve_agent_folder(folder: &str) -> Result<std::path::PathBuf> {
 /// for that tier.
 pub async fn deploy_named(folder: &str, opts: DeployNamedOpts) -> Result<DeployOutput> {
     let plugin_dir = resolve_agent_folder(folder)?;
-    let connect_hint = format!(
-        "the platform API at {} is unreachable. Start the local stack first with `curie local \
-         up`, then re-run (or pass --api-url if your API is elsewhere).",
-        opts.api_url
-    );
-    deploy(DeployOpts {
+    let api_url = opts.api_url.clone();
+    let result = deploy(DeployOpts {
         plugin_dir,
         // deploy_named is the multi-agent-folder path: the folder IS the agent
         // identity there, so there is nothing to override.
         agent: None,
         target: None,
-        api_url: opts.api_url,
+        api_url,
         api_key: opts.api_key,
         slack_channel: opts.slack_channel,
         repo: opts.repo,
@@ -987,9 +983,10 @@ pub async fn deploy_named(folder: &str, opts: DeployNamedOpts) -> Result<DeployO
         label: opts.label,
         secret: opts.secret,
         secret_binding_supported: true,
-        connect_hint,
+        connect_hint: "the platform API is unreachable.".to_string(),
     })
-    .await
+    .await;
+    crate::local::with_deploy_unreachable_hint(result, &opts.api_url).await
 }
 
 /// The `curie deploy-local <folder>` flags, mirroring `local deploy`'s minus
@@ -6605,7 +6602,12 @@ mod tests {
     async fn deploy_names_the_remediation_when_api_is_unreachable() {
         let dir = tempfile::tempdir().unwrap();
         crate::scaffold::scaffold(dir.path(), "test-agent").unwrap();
-        let hint = "kubectl -n curie port-forward svc/curie-api 8000:8000";
+        // Exercise local state guidance with its default URL while port 1 below
+        // remains the deterministic connection refusal target.
+        let hint = crate::local::deploy_unreachable_hint(
+            crate::message::DEFAULT_LOCAL_API_URL,
+            Some("curie-api-1   curie-api:dev   curie-api   Up 8 seconds (health: starting)"),
+        );
         let opts = super::DeployOpts {
             agent: None,
             target: None,
@@ -6619,13 +6621,21 @@ mod tests {
             label: Some("v0".to_string()),
             secret: vec![],
             secret_binding_supported: true,
-            connect_hint: hint.to_string(),
+            connect_hint: hint.clone(),
         };
         let err = super::deploy(opts).await.unwrap_err();
         let rendered = format!("{err:#}");
         assert!(
-            rendered.contains(hint),
-            "hint missing from error: {rendered}"
+            rendered.contains("local stack is still starting"),
+            "the connection error must retain the state aware recovery: {rendered}"
+        );
+        assert!(
+            rendered.contains("curie local status"),
+            "the connection error must direct the operator to inspect local state: {rendered}"
+        );
+        assert!(
+            !rendered.contains("curie local up"),
+            "a starting stack must not be told to start again: {rendered}"
         );
     }
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -46,3 +46,6 @@ pub mod state;
 pub mod ui;
 
 pub use retired::retired_hint;
+
+#[cfg(test)]
+pub(crate) static PROCESS_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());

--- a/cli/src/local.rs
+++ b/cli/src/local.rs
@@ -417,6 +417,80 @@ pub fn status_command(o: &LocalOpts) -> OpsCommand {
     compose(&o.file, &["ps"])
 }
 
+/// Whether the URL points at the default local deploy API.
+fn uses_default_local_api(api_url: &str) -> bool {
+    api_url.trim_end_matches('/') == crate::message::DEFAULT_LOCAL_API_URL
+}
+
+/// Format recovery for a local deploy that could not reach its API. The
+/// compose output is deliberately an input so its state classification is
+/// testable without Docker.
+pub fn deploy_unreachable_hint(api_url: &str, compose_ps: Option<&str>) -> String {
+    if !uses_default_local_api(api_url) {
+        return format!(
+            "the platform API at {api_url} is unreachable. Check that --api-url points to a reachable API, then re-run. If you meant to use the local stack, inspect it with `curie local status`."
+        );
+    }
+
+    let lines: Vec<_> = compose_ps
+        .unwrap_or_default()
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .collect();
+    let rows = if lines
+        .first()
+        .is_some_and(|line| line.starts_with("NAME") && line.contains("STATUS"))
+    {
+        &lines[1..]
+    } else {
+        &lines[..]
+    };
+
+    if rows.iter().any(|line| {
+        let status = line.to_ascii_lowercase();
+        status.contains("(starting)") || status.contains("(health: starting)")
+    }) {
+        format!(
+            "the platform API at {api_url} is unreachable because the local stack is still starting. Run `curie local status`, wait for the API to become healthy, then re-run."
+        )
+    } else if rows.is_empty() {
+        format!(
+            "the platform API at {api_url} is unreachable because no local services are running. Start them with `curie local up`, confirm with `curie local status`, then re-run."
+        )
+    } else {
+        format!(
+            "the platform API at {api_url} is unreachable although local services are present. Inspect them with `curie local status`, then re-run."
+        )
+    }
+}
+
+/// Attach a compose state aware recovery only after a local deploy's API
+/// request has already failed as transient. The diagnostic itself is best
+/// effort: a missing Docker binary must not hide the original API failure.
+pub async fn with_deploy_unreachable_hint<T>(result: Result<T>, api_url: &str) -> Result<T> {
+    match result {
+        Err(err) if crate::exit::is_transient_reqwest(&err) => {
+            if !uses_default_local_api(api_url) {
+                return Err(err.context(deploy_unreachable_hint(api_url, None)));
+            }
+
+            let cmd = OpsCommand::new(
+                "docker",
+                vec![plain("compose"), plain("-p"), plain("curie"), plain("ps")],
+            );
+            let hint = match run_capture(&cmd).await {
+                Ok((true, out, _)) => deploy_unreachable_hint(api_url, Some(&out)),
+                Ok((false, _, _)) | Err(_) => format!(
+                    "the platform API at {api_url} is unreachable, and Curie could not read local compose state. Run `curie local status`, then re-run."
+                ),
+            };
+            Err(err.context(hint))
+        }
+        result => result,
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Verb handlers
 // ---------------------------------------------------------------------------
@@ -811,6 +885,68 @@ pub async fn down(o: LocalDownOpts) -> Result<LocalDownOutput> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    struct DeployDiagnosisEnvRestore {
+        path: Option<std::ffi::OsString>,
+        log: Option<std::ffi::OsString>,
+        output: Option<std::ffi::OsString>,
+        fail: Option<std::ffi::OsString>,
+    }
+
+    impl Drop for DeployDiagnosisEnvRestore {
+        fn drop(&mut self) {
+            for (name, previous) in [
+                ("PATH", &self.path),
+                ("CURIE_TEST_DOCKER_LOG", &self.log),
+                ("CURIE_TEST_DOCKER_OUTPUT", &self.output),
+                ("CURIE_TEST_DOCKER_FAIL", &self.fail),
+            ] {
+                match previous {
+                    Some(value) => std::env::set_var(name, value),
+                    None => std::env::remove_var(name),
+                }
+            }
+        }
+    }
+
+    fn install_recording_docker(
+        tools: &std::path::Path,
+        log: &std::path::Path,
+    ) -> DeployDiagnosisEnvRestore {
+        let docker = tools.join("docker");
+        std::fs::write(
+            &docker,
+            "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$CURIE_TEST_DOCKER_LOG\"\n\
+             if [ \"$*\" = 'compose -p curie ps' ]; then\n\
+               if [ \"$CURIE_TEST_DOCKER_FAIL\" = '1' ]; then exit 91; fi\n\
+               printf '%s\\n' \"$CURIE_TEST_DOCKER_OUTPUT\"\n\
+               exit 0\n\
+             fi\n\
+             exit 91\n",
+        )
+        .expect("write fake docker executable");
+        use std::os::unix::fs::PermissionsExt;
+        let mut permissions = std::fs::metadata(&docker)
+            .expect("read fake docker metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&docker, permissions)
+            .expect("make fake docker executable runnable");
+
+        let restore = DeployDiagnosisEnvRestore {
+            path: std::env::var_os("PATH"),
+            log: std::env::var_os("CURIE_TEST_DOCKER_LOG"),
+            output: std::env::var_os("CURIE_TEST_DOCKER_OUTPUT"),
+            fail: std::env::var_os("CURIE_TEST_DOCKER_FAIL"),
+        };
+        let mut path = vec![tools.to_path_buf()];
+        path.extend(std::env::split_paths(
+            &std::env::var_os("PATH").unwrap_or_default(),
+        ));
+        std::env::set_var("PATH", std::env::join_paths(path).expect("join test PATH"));
+        std::env::set_var("CURIE_TEST_DOCKER_LOG", log);
+        restore
+    }
 
     fn opts(file: &str) -> LocalOpts {
         LocalOpts {
@@ -1363,6 +1499,212 @@ mod tests {
     fn status_runs_ps() {
         let cmd = status_command(&opts(DEFAULT_COMPOSE_FILE));
         assert_eq!(cmd.display(), "docker compose -f compose.dev.yaml ps");
+    }
+
+    #[test]
+    fn deploy_unreachable_hint_reports_a_starting_local_stack_without_restarting_it() {
+        let hint = deploy_unreachable_hint(
+            "http://localhost:28000",
+            Some(
+                "NAME              IMAGE             SERVICE     STATUS\n\
+                 curie-api-1       curie-api:dev     curie-api   Up 8 seconds (health: starting)",
+            ),
+        );
+
+        assert!(
+            hint.contains("local stack is still starting"),
+            "starting compose state must be named in the deploy recovery: {hint}"
+        );
+        assert!(
+            hint.contains("curie local status"),
+            "the deploy recovery must direct the operator to inspect the stack: {hint}"
+        );
+        assert!(
+            !hint.contains("curie local up"),
+            "a stack already starting must not be told to start again: {hint}"
+        );
+    }
+
+    #[test]
+    fn deploy_unreachable_hint_reports_an_absent_local_stack_and_status_recovery() {
+        for compose_ps in [
+            None,
+            Some(""),
+            Some("NAME   IMAGE   COMMAND   SERVICE   CREATED   STATUS   PORTS"),
+        ] {
+            let hint = deploy_unreachable_hint("http://localhost:28000", compose_ps);
+
+            assert!(
+                hint.contains("no local services are running"),
+                "an empty compose state must be named in the deploy recovery: {hint}"
+            );
+            assert!(
+                hint.contains("curie local up"),
+                "an absent stack must be told how to start: {hint}"
+            );
+            assert!(
+                hint.contains("curie local status"),
+                "the recovery must include state inspection: {hint}"
+            );
+        }
+    }
+
+    #[test]
+    fn deploy_unreachable_hint_treats_restarting_as_services_present() {
+        let hint = deploy_unreachable_hint(
+            crate::message::DEFAULT_LOCAL_API_URL,
+            Some(
+                "NAME          IMAGE           SERVICE     STATUS\n\
+                 curie-api-1   curie-api:dev   curie-api   Restarting (1) 2 seconds ago",
+            ),
+        );
+
+        assert!(
+            hint.contains("local services are present"),
+            "a restarting service is present, not starting: {hint}"
+        );
+        assert!(
+            !hint.contains("local stack is still starting"),
+            "restarting must not be reported as initial startup: {hint}"
+        );
+        assert!(
+            !hint.contains("curie local up"),
+            "a present service must not be told to start again: {hint}"
+        );
+    }
+
+    #[test]
+    fn deploy_unreachable_hint_reports_nonstarting_services_as_present() {
+        let hint = deploy_unreachable_hint(
+            crate::message::DEFAULT_LOCAL_API_URL,
+            Some(
+                "NAME          IMAGE           SERVICE     STATUS\n\
+                 curie-api-1   curie-api:dev   curie-api   Up 30 seconds (healthy)",
+            ),
+        );
+
+        assert!(
+            hint.contains("local services are present"),
+            "a running service must be reported as present: {hint}"
+        );
+        assert!(
+            hint.contains("curie local status"),
+            "present service guidance must retain status inspection: {hint}"
+        );
+        assert!(
+            !hint.contains("curie local up"),
+            "a running service must not be told to start again: {hint}"
+        );
+    }
+
+    #[tokio::test]
+    async fn custom_api_deploy_failure_does_not_read_local_compose_state() {
+        let _lock = crate::PROCESS_ENV_LOCK
+            .lock()
+            .expect("lock deploy diagnosis environment");
+        let tools = tempfile::tempdir().expect("create fake docker directory");
+        let log = tools.path().join("docker.log");
+        let _restore = install_recording_docker(tools.path(), &log);
+        let transient = reqwest::Client::new()
+            .get("http://127.0.0.1:1")
+            .send()
+            .await
+            .expect_err("port 1 must refuse the test connection");
+
+        let result: anyhow::Result<()> = Err(transient.into());
+        let error = with_deploy_unreachable_hint(result, "https://api.example.com")
+            .await
+            .expect_err("the original deploy failure must remain an error");
+        let rendered = format!("{error:#}");
+
+        assert!(
+            rendered.contains("Check that --api-url points to a reachable API"),
+            "custom API guidance was replaced: {rendered}"
+        );
+        assert!(
+            !log.exists(),
+            "custom API failure must not invoke docker; calls: {}",
+            std::fs::read_to_string(&log).unwrap_or_default()
+        );
+    }
+
+    #[tokio::test]
+    async fn default_api_deploy_failure_reads_the_running_curie_project() {
+        let _lock = crate::PROCESS_ENV_LOCK
+            .lock()
+            .expect("lock deploy diagnosis environment");
+        let tools = tempfile::tempdir().expect("create fake docker directory");
+        let log = tools.path().join("docker.log");
+        let _restore = install_recording_docker(tools.path(), &log);
+        std::env::set_var(
+            "CURIE_TEST_DOCKER_OUTPUT",
+            "curie-api-1   curie-api:dev   curie-api   Up 8 seconds (health: starting)",
+        );
+        let transient = reqwest::Client::new()
+            .get("http://127.0.0.1:1")
+            .send()
+            .await
+            .expect_err("port 1 must refuse the test connection");
+
+        let result: anyhow::Result<()> = Err(transient.into());
+        let error = with_deploy_unreachable_hint(result, crate::message::DEFAULT_LOCAL_API_URL)
+            .await
+            .expect_err("the original deploy failure must remain an error");
+        let rendered = format!("{error:#}");
+        let invocations = std::fs::read_to_string(&log).expect("read docker invocation log");
+
+        assert_eq!(
+            invocations.trim(),
+            "compose -p curie ps",
+            "diagnosis must inspect the running Curie project by name"
+        );
+        assert!(
+            rendered.contains("local stack is still starting"),
+            "starting state was not reported: {rendered}"
+        );
+        assert!(
+            rendered.contains("curie local status"),
+            "state inspection guidance was omitted: {rendered}"
+        );
+        assert!(
+            !rendered.contains("curie local up"),
+            "a starting stack must not be told to start again: {rendered}"
+        );
+    }
+
+    #[tokio::test]
+    async fn default_api_deploy_failure_keeps_status_guidance_when_compose_is_unreadable() {
+        let _lock = crate::PROCESS_ENV_LOCK
+            .lock()
+            .expect("lock deploy diagnosis environment");
+        let tools = tempfile::tempdir().expect("create fake docker directory");
+        let log = tools.path().join("docker.log");
+        let _restore = install_recording_docker(tools.path(), &log);
+        std::env::set_var("CURIE_TEST_DOCKER_FAIL", "1");
+        let transient = reqwest::Client::new()
+            .get("http://127.0.0.1:1")
+            .send()
+            .await
+            .expect_err("port 1 must refuse the test connection");
+
+        let result: anyhow::Result<()> = Err(transient.into());
+        let error = with_deploy_unreachable_hint(result, crate::message::DEFAULT_LOCAL_API_URL)
+            .await
+            .expect_err("the original deploy failure must remain an error");
+        let rendered = format!("{error:#}");
+
+        assert!(
+            rendered.contains("could not read local compose state"),
+            "compose failure must remain explicit: {rendered}"
+        );
+        assert!(
+            rendered.contains("curie local status"),
+            "unreadable compose state must retain status guidance: {rendered}"
+        );
+        assert!(
+            !rendered.contains("curie local up"),
+            "unreadable state must not claim services are absent: {rendered}"
+        );
     }
 
     #[test]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -2451,28 +2451,25 @@ async fn run(command: Option<Command>) -> Result<()> {
                 label,
                 secret,
             } => {
-                let connect_hint = format!(
-                    "the platform API at {api_url} is unreachable. Start the local stack first with `curie local up`, then re-run (or pass --api-url if your API is elsewhere)."
-                );
-                emit(
-                    commands::deploy(DeployOpts {
-                        plugin_dir,
-                        agent,
-                        target,
-                        api_url,
-                        api_key,
-                        slack_channel,
-                        repo,
-                        env,
-                        label,
-                        secret,
-                        // `local deploy` offers `--secret`, so enforce the
-                        // declared-secrets policy gate (#464).
-                        secret_binding_supported: true,
-                        connect_hint: connect_hint.clone(),
-                    })
-                    .await?,
-                )
+                let local_api_url = api_url.clone();
+                let result = commands::deploy(DeployOpts {
+                    plugin_dir,
+                    agent,
+                    target,
+                    api_url,
+                    api_key,
+                    slack_channel,
+                    repo,
+                    env,
+                    label,
+                    secret,
+                    // `local deploy` offers `--secret`, so enforce the
+                    // declared-secrets policy gate (#464).
+                    secret_binding_supported: true,
+                    connect_hint: "the platform API is unreachable.".to_string(),
+                })
+                .await;
+                emit(local::with_deploy_unreachable_hint(result, &local_api_url).await?)
             }
             LocalAction::Versions { target } => emit(commands::versions(target.into()).await?),
             LocalAction::Memory { target } => emit(commands::memory(target.into()).await?),

--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -1677,6 +1677,336 @@ mod release_secret_name_tests {
 }
 
 #[cfg(test)]
+mod api_key_discovery_tests {
+    use super::*;
+
+    struct EnvRestore {
+        path: Option<std::ffi::OsString>,
+        requested: Option<std::ffi::OsString>,
+        requested_default: Option<std::ffi::OsString>,
+        all: Option<std::ffi::OsString>,
+        all_default: Option<std::ffi::OsString>,
+        all_forbidden: Option<std::ffi::OsString>,
+        log: Option<std::ffi::OsString>,
+    }
+
+    impl Drop for EnvRestore {
+        fn drop(&mut self) {
+            for (name, previous) in [
+                ("PATH", &self.path),
+                ("CURIE_TEST_HELM_REQUESTED", &self.requested),
+                ("CURIE_TEST_HELM_REQUESTED_DEFAULT", &self.requested_default),
+                ("CURIE_TEST_HELM_ALL", &self.all),
+                ("CURIE_TEST_HELM_ALL_DEFAULT", &self.all_default),
+                ("CURIE_TEST_HELM_ALL_FORBIDDEN", &self.all_forbidden),
+                ("CURIE_TEST_HELM_LOG", &self.log),
+            ] {
+                match previous {
+                    Some(value) => std::env::set_var(name, value),
+                    None => std::env::remove_var(name),
+                }
+            }
+        }
+    }
+
+    fn write_executable(path: &std::path::Path, body: &str) {
+        std::fs::write(path, body).expect("write fake cluster executable");
+        use std::os::unix::fs::PermissionsExt;
+        let mut permissions = std::fs::metadata(path)
+            .expect("read fake cluster executable metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(path, permissions).expect("make fake cluster executable runnable");
+    }
+
+    fn install_cluster_diagnosis_tools(tools: &std::path::Path) -> EnvRestore {
+        write_executable(
+            &tools.join("kubectl"),
+            r#"#!/bin/sh
+case "$*" in
+  *"get secret -l app.kubernetes.io/instance=curie"*)
+    printf '%s\n' 'curie-secrets'
+    ;;
+  *"get secret curie-secrets"*)
+    printf '%s\n' 'Error from server (NotFound): secrets "curie-secrets" not found' >&2
+    exit 1
+    ;;
+  *)
+    printf 'unexpected kubectl invocation: %s\n' "$*" >&2
+    exit 64
+    ;;
+esac
+"#,
+        );
+        write_executable(
+            &tools.join("helm"),
+            r#"#!/bin/sh
+printf '%s\n' "$*" >> "$CURIE_TEST_HELM_LOG"
+case "$*" in
+  *"-n curie"*)
+    case "$*" in
+      *"--all"*) printf '%s\n' "$CURIE_TEST_HELM_REQUESTED" ;;
+      *) printf '%s\n' "${CURIE_TEST_HELM_REQUESTED_DEFAULT:-$CURIE_TEST_HELM_REQUESTED}" ;;
+    esac
+    ;;
+  *)
+    if [ "${CURIE_TEST_HELM_ALL_FORBIDDEN:-}" = 1 ]; then
+      printf '%s\n' 'forbidden: cannot list releases across namespaces' >&2
+      exit 1
+    fi
+    case "$*" in
+      *"--all"*) printf '%s\n' "$CURIE_TEST_HELM_ALL" ;;
+      *) printf '%s\n' "${CURIE_TEST_HELM_ALL_DEFAULT:-$CURIE_TEST_HELM_ALL}" ;;
+    esac
+    ;;
+esac
+"#,
+        );
+
+        let restore = EnvRestore {
+            path: std::env::var_os("PATH"),
+            requested: std::env::var_os("CURIE_TEST_HELM_REQUESTED"),
+            requested_default: std::env::var_os("CURIE_TEST_HELM_REQUESTED_DEFAULT"),
+            all: std::env::var_os("CURIE_TEST_HELM_ALL"),
+            all_default: std::env::var_os("CURIE_TEST_HELM_ALL_DEFAULT"),
+            all_forbidden: std::env::var_os("CURIE_TEST_HELM_ALL_FORBIDDEN"),
+            log: std::env::var_os("CURIE_TEST_HELM_LOG"),
+        };
+        let mut path = vec![tools.to_path_buf()];
+        path.extend(std::env::split_paths(
+            &std::env::var_os("PATH").unwrap_or_default(),
+        ));
+        std::env::set_var("PATH", std::env::join_paths(path).expect("join test PATH"));
+        restore
+    }
+
+    fn assert_state_was_read(log: &std::path::Path) {
+        let invocations = std::fs::read_to_string(log).expect("read Helm invocation log");
+        assert!(
+            invocations
+                .lines()
+                .any(|line| line == "list -n curie --all -o json"),
+            "the requested release state was not read: {invocations}"
+        );
+        assert!(
+            invocations
+                .lines()
+                .any(|line| line == "list -A --all -o json"),
+            "the all namespace release state was not read: {invocations}"
+        );
+    }
+
+    #[tokio::test]
+    async fn api_key_failure_names_a_deployed_same_name_release_in_another_namespace() {
+        let _lock = crate::PROCESS_ENV_LOCK
+            .lock()
+            .expect("lock test environment");
+        let tools = tempfile::tempdir().expect("create fake cluster tools");
+        let _restore = install_cluster_diagnosis_tools(tools.path());
+        let log = tools.path().join("helm.log");
+        std::env::set_var("CURIE_TEST_HELM_LOG", &log);
+        std::env::set_var(
+            "CURIE_TEST_HELM_REQUESTED",
+            r#"[{"name":"curie","namespace":"curie","status":"failed"}]"#,
+        );
+        std::env::set_var(
+            "CURIE_TEST_HELM_ALL",
+            r#"[{"name":"curie","namespace":"curie","status":"failed"},{"name":"curie","namespace":"healthy","status":"deployed"}]"#,
+        );
+
+        let error = discover_api_key("curie", "curie")
+            .await
+            .expect_err("an unreadable secret must not yield an API key");
+        let message = error.to_string();
+
+        assert_eq!(
+            crate::exit::classify(&error).0,
+            crate::exit::ExitClass::Usage,
+            "release state guidance must preserve the command's usage exit"
+        );
+        assert!(
+            message.contains("failed"),
+            "missing requested state: {message}"
+        );
+        assert!(
+            message.contains("healthy"),
+            "missing deployed alternate namespace: {message}"
+        );
+        assert!(
+            !message.contains("--api-key") && !message.contains("CURIE_API_KEY"),
+            "a failed release cannot be repaired by supplying its key: {message}"
+        );
+        assert_state_was_read(&log);
+    }
+
+    #[tokio::test]
+    async fn api_key_failure_without_a_deployed_alternate_does_not_offer_a_key_remedy() {
+        let _lock = crate::PROCESS_ENV_LOCK
+            .lock()
+            .expect("lock test environment");
+        let tools = tempfile::tempdir().expect("create fake cluster tools");
+        let _restore = install_cluster_diagnosis_tools(tools.path());
+        let log = tools.path().join("helm.log");
+        std::env::set_var("CURIE_TEST_HELM_LOG", &log);
+        std::env::set_var(
+            "CURIE_TEST_HELM_REQUESTED",
+            r#"[{"name":"curie","namespace":"curie","status":"failed"}]"#,
+        );
+        std::env::set_var(
+            "CURIE_TEST_HELM_ALL",
+            r#"[{"name":"curie","namespace":"curie","status":"failed"}]"#,
+        );
+
+        let error = discover_api_key("curie", "curie")
+            .await
+            .expect_err("a failed release with no healthy alternate must fail");
+        let message = error.to_string();
+
+        assert!(
+            message.contains("failed"),
+            "missing requested state: {message}"
+        );
+        assert!(
+            !message.contains("--api-key") && !message.contains("CURIE_API_KEY"),
+            "a failed release cannot be repaired by supplying its key: {message}"
+        );
+        assert_state_was_read(&log);
+    }
+
+    #[tokio::test]
+    async fn deployed_release_key_failure_does_not_require_all_namespace_access() {
+        let _lock = crate::PROCESS_ENV_LOCK
+            .lock()
+            .expect("lock test environment");
+        let tools = tempfile::tempdir().expect("create fake cluster tools");
+        let _restore = install_cluster_diagnosis_tools(tools.path());
+        let log = tools.path().join("helm.log");
+        std::env::set_var("CURIE_TEST_HELM_LOG", &log);
+        std::env::set_var(
+            "CURIE_TEST_HELM_REQUESTED",
+            r#"[{"name":"curie","namespace":"curie","status":"deployed"}]"#,
+        );
+        std::env::set_var("CURIE_TEST_HELM_ALL", "[]");
+
+        let error = discover_api_key("curie", "curie")
+            .await
+            .expect_err("an unreadable secret must not yield an API key");
+        let message = error.to_string();
+
+        assert_eq!(
+            crate::exit::classify(&error).0,
+            crate::exit::ExitClass::Usage,
+            "a missing deployed release key remains a usage error"
+        );
+        assert!(
+            message.contains("--api-key"),
+            "missing flag remedy: {message}"
+        );
+        assert!(
+            message.contains("CURIE_API_KEY"),
+            "missing environment remedy: {message}"
+        );
+
+        let invocations = std::fs::read_to_string(&log).expect("read Helm invocation log");
+        assert!(
+            invocations
+                .lines()
+                .any(|line| line == "list -n curie --all -o json"),
+            "the requested release state was not read: {invocations}"
+        );
+        assert!(
+            !invocations
+                .lines()
+                .any(|line| line == "list -A --all -o json"),
+            "cluster wide Helm access is forbidden once the requested release is deployed: {invocations}"
+        );
+    }
+
+    #[tokio::test]
+    async fn pending_upgrade_is_read_instead_of_reported_as_a_missing_release() {
+        let _lock = crate::PROCESS_ENV_LOCK
+            .lock()
+            .expect("lock test environment");
+        let tools = tempfile::tempdir().expect("create fake cluster tools");
+        let _restore = install_cluster_diagnosis_tools(tools.path());
+        let log = tools.path().join("helm.log");
+        std::env::set_var("CURIE_TEST_HELM_LOG", &log);
+        std::env::set_var(
+            "CURIE_TEST_HELM_REQUESTED",
+            r#"[{"name":"curie","namespace":"curie","status":"pending-upgrade"}]"#,
+        );
+        std::env::set_var("CURIE_TEST_HELM_REQUESTED_DEFAULT", "[]");
+        std::env::set_var(
+            "CURIE_TEST_HELM_ALL",
+            r#"[{"name":"curie","namespace":"curie","status":"pending-upgrade"}]"#,
+        );
+        std::env::set_var("CURIE_TEST_HELM_ALL_DEFAULT", "[]");
+
+        let error = discover_api_key("curie", "curie")
+            .await
+            .expect_err("a pending release must not yield an API key");
+        let message = error.to_string();
+
+        assert!(
+            message.contains("pending-upgrade"),
+            "pending Helm state was hidden: {message}"
+        );
+        assert!(
+            !message.contains("no deployed release named")
+                && !message.contains("deploy the release"),
+            "pending state was mistaken for a missing release: {message}"
+        );
+        assert!(
+            !message.contains("--api-key") && !message.contains("CURIE_API_KEY"),
+            "a pending release cannot be repaired by configuring its key: {message}"
+        );
+        assert_state_was_read(&log);
+    }
+
+    #[tokio::test]
+    async fn failed_release_state_survives_a_forbidden_all_namespace_scan() {
+        let _lock = crate::PROCESS_ENV_LOCK
+            .lock()
+            .expect("lock test environment");
+        let tools = tempfile::tempdir().expect("create fake cluster tools");
+        let _restore = install_cluster_diagnosis_tools(tools.path());
+        let log = tools.path().join("helm.log");
+        std::env::set_var("CURIE_TEST_HELM_LOG", &log);
+        std::env::set_var(
+            "CURIE_TEST_HELM_REQUESTED",
+            r#"[{"name":"curie","namespace":"curie","status":"failed"}]"#,
+        );
+        std::env::set_var("CURIE_TEST_HELM_ALL", "[]");
+        std::env::set_var("CURIE_TEST_HELM_ALL_FORBIDDEN", "1");
+
+        let error = discover_api_key("curie", "curie")
+            .await
+            .expect_err("a failed release must not yield an API key");
+        let message = error.to_string();
+        let (class, fix) = crate::exit::classify(&error);
+
+        assert_eq!(class, crate::exit::ExitClass::Usage);
+        assert!(
+            message.contains("failed"),
+            "known requested release state was discarded: {message}"
+        );
+        assert!(
+            !message.contains("could not inspect Helm state across namespaces"),
+            "the optional namespace scan replaced known state: {message}"
+        );
+        assert!(
+            !message.contains("--api-key") && !message.contains("CURIE_API_KEY"),
+            "a failed release cannot be repaired by configuring its key: {message}"
+        );
+        assert!(
+            fix.as_deref()
+                .is_some_and(|guidance| guidance.contains("curie cluster status")),
+            "missing cluster status guidance: {fix:?}"
+        );
+    }
+}
+
+#[cfg(test)]
 mod sealing_preservation_tests {
     use super::*;
 
@@ -4091,6 +4421,73 @@ fn api_key_usage_err(msg: impl Into<String>) -> anyhow::Error {
         .into()
 }
 
+/// A release-state failure while discovering an API key. The release cannot be
+/// authenticated until its state is known, so do not suggest an API key as a
+/// remedy for an unreadable Helm inspection.
+fn api_key_state_err(namespace: &str, release: &str, msg: impl Into<String>) -> anyhow::Error {
+    crate::exit::CliError::usage(msg)
+        .with_fix(format!(
+            "run `curie cluster status --namespace {namespace} --release {release}` and retry"
+        ))
+        .into()
+}
+
+fn helm_release_entries(output: &str) -> Result<Vec<serde_json::Value>> {
+    let releases: serde_json::Value =
+        serde_json::from_str(output.trim()).context("malformed Helm release list JSON")?;
+    releases
+        .as_array()
+        .cloned()
+        .context("malformed Helm release list JSON: expected an array")
+}
+
+/// Find the requested release's Helm status in a `helm list -o json` result.
+/// Missing releases are a valid result; malformed Helm output is not.
+fn helm_release_status(output: &str, release: &str) -> Result<Option<String>> {
+    let releases = helm_release_entries(output)?;
+    let Some(found) = releases
+        .iter()
+        .find(|entry| entry.get("name").and_then(|name| name.as_str()) == Some(release))
+    else {
+        return Ok(None);
+    };
+    found
+        .get("status")
+        .and_then(|status| status.as_str())
+        .map(|status| Some(status.to_string()))
+        .context("malformed Helm release list JSON: release has no status")
+}
+
+/// Find a deployed release with the requested name in another namespace.
+/// The all-namespace Helm listing makes a same-name alternate explicit rather
+/// than guessing that a credential override can repair a failed release.
+fn deployed_release_namespace(
+    output: &str,
+    release: &str,
+    requested_namespace: &str,
+) -> Result<Option<String>> {
+    let releases = helm_release_entries(output)?;
+
+    for entry in releases {
+        if entry.get("name").and_then(|name| name.as_str()) != Some(release)
+            || !entry
+                .get("status")
+                .and_then(|status| status.as_str())
+                .is_some_and(|status| status.eq_ignore_ascii_case("deployed"))
+        {
+            continue;
+        }
+        let namespace = entry
+            .get("namespace")
+            .and_then(|namespace| namespace.as_str())
+            .context("malformed Helm release list JSON: deployed release has no namespace")?;
+        if namespace != requested_namespace {
+            return Ok(Some(namespace.to_string()));
+        }
+    }
+    Ok(None)
+}
+
 /// Discover a Helm release's platform API key by reading it out of the chart
 /// Secret (`<release>-secrets`, data key `apiKey`), decoded server-side by
 /// kubectl's `base64decode` so the plaintext never lands in argv (#524). The
@@ -4100,14 +4497,104 @@ fn api_key_usage_err(msg: impl Into<String>) -> anyhow::Error {
 /// wins (the caller only reaches here when neither was supplied). The value is
 /// never printed — it flows straight into the `X-API-Key` header.
 pub async fn discover_api_key(namespace: &str, release: &str) -> Result<String> {
-    read_release_secret(namespace, release, "apiKey")
+    if let Some(api_key) = read_release_secret(namespace, release, "apiKey").await {
+        return Ok(api_key);
+    }
+
+    let requested_cmd = OpsCommand::new(
+        "helm",
+        vec![
+            plain("list"),
+            plain("-n"),
+            plain(namespace),
+            plain("--all"),
+            plain("-o"),
+            plain("json"),
+        ],
+    );
+    let (requested_ok, requested_output, requested_error) = run_capture(&requested_cmd)
         .await
-        .ok_or_else(|| {
-            api_key_usage_err(format!(
-                "could not read the API key from the chart Secret for release {release} in namespace {namespace}; \
-                 pass --api-key or set CURIE_API_KEY to the release's api.apiKey"
-            ))
-        })
+        .map_err(|error| {
+            api_key_state_err(
+                namespace,
+                release,
+                format!("could not inspect Helm state for release {release} in namespace {namespace}: {error}"),
+            )
+        })?;
+    if !requested_ok {
+        return Err(api_key_state_err(
+            namespace,
+            release,
+            format!(
+                "could not inspect Helm state for release {release} in namespace {namespace}: {}",
+                failure_reason(&requested_error)
+            ),
+        ));
+    }
+    let requested_status = helm_release_status(&requested_output, release).map_err(|error| {
+        api_key_state_err(
+            namespace,
+            release,
+            format!("could not inspect Helm state for release {release} in namespace {namespace}: {error}"),
+        )
+    })?;
+
+    if requested_status
+        .as_deref()
+        .is_some_and(|status| status.eq_ignore_ascii_case("deployed"))
+    {
+        return Err(api_key_usage_err(format!(
+            "release {release} in namespace {namespace} is deployed, but its chart Secret API key could not be read; \
+             pass --api-key or set CURIE_API_KEY to the release's api.apiKey"
+        )));
+    }
+
+    let all_cmd = OpsCommand::new(
+        "helm",
+        vec![
+            plain("list"),
+            plain("-A"),
+            plain("--all"),
+            plain("-o"),
+            plain("json"),
+        ],
+    );
+    let deployed_alternate = match run_capture(&all_cmd).await {
+        Ok((true, all_output, _)) => {
+            deployed_release_namespace(&all_output, release, namespace).unwrap_or(None)
+        }
+        _ => None,
+    };
+
+    let status_command =
+        format!("`curie cluster status --namespace {namespace} --release {release}`");
+    let (message, fix) = match (requested_status, deployed_alternate) {
+        (Some(status), Some(alternate_namespace)) => (
+            format!(
+                "release {release} in namespace {namespace} is {status}, not deployed; a deployed release named {release} is available in namespace {alternate_namespace}. Inspect the failed release with {status_command} or retry this command with `--namespace {alternate_namespace}`"
+            ),
+            format!("retry this command with `--namespace {alternate_namespace}`"),
+        ),
+        (Some(status), None) => (
+            format!(
+                "release {release} in namespace {namespace} is {status}, not deployed; inspect its state with {status_command}"
+            ),
+            format!("run {status_command} and repair or redeploy the release"),
+        ),
+        (None, Some(alternate_namespace)) => (
+            format!(
+                "no release named {release} was found in namespace {namespace}; a deployed release with that name is available in namespace {alternate_namespace}. Retry this command with `--namespace {alternate_namespace}`"
+            ),
+            format!("retry this command with `--namespace {alternate_namespace}`"),
+        ),
+        (None, None) => (
+            format!(
+                "no deployed release named {release} was found in namespace {namespace}; inspect the target with {status_command}"
+            ),
+            format!("run {status_command} and deploy the release before retrying"),
+        ),
+    };
+    Err(crate::exit::CliError::usage(message).with_fix(fix).into())
 }
 
 /// A usage error (exit 2) whose fix hint points the operator at


### PR DESCRIPTION
## Summary\n\nReads the running Curie compose project after default local deploy connection failures and gives recovery based on starting, absent, present, or unreadable state.\n\nReads complete Helm release state after credential discovery fails. Known nondeployed state takes precedence, optional namespace discovery is best effort, and credential remedies remain limited to deployed releases.\n\nCloses #1656\n\n## Done check\n\nChecked: Regression tests were committed red before implementation.\n\nChecked: All production edits came from delegated native workers.\n\nChecked: No public return type was broadened.\n\nChecked: Independent code and scope reviews report zero blocking findings.\n\nChecked: Both local deploy entry points share one diagnostic helper, and all cluster callers share credential discovery.\n\nChecked: Rust formatting, clippy with warnings denied, and the complete cargo test suite pass.\n\nChecked: A deliberate startup detection mutation makes the starting stack regression fail.\n\nChecked: The real CLI in a private network namespace reports starting state and local status without suggesting local up.\n\nChecked: The real CLI against fake Kubernetes process boundaries reports failed Helm state and a healthy alternate namespace without suggesting API key configuration.\n\nChecked: Consolidation completed and its rereview found no remaining blocker.\n\nNot applicable: No contract, schema, ADR, command surface, chart, provider, or external integration changed.