### PR TITLE
Present actionable CLI errors

### DIFF
--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -601,14 +601,46 @@ impl ApiClient {
         bail!("{what} failed with {status}: {}", body.trim());
     }
 
+    async fn send_request(
+        &self,
+        request: reqwest::RequestBuilder,
+        operation: &'static str,
+    ) -> Result<reqwest::Response> {
+        match request.send().await {
+            Ok(response) => Ok(response),
+            Err(err) => {
+                let transient = err.is_connect() || err.is_timeout();
+                let source = anyhow::Error::new(err).context(operation);
+                let message = if transient {
+                    format!("the platform API at {} is unreachable", self.base_url)
+                } else {
+                    format!(
+                        "the platform API at {} could not send the requested operation",
+                        self.base_url
+                    )
+                };
+                let remedy = if transient {
+                    format!(
+                        "Run `curl -fsS {}/health` to check it, then retry.",
+                        self.base_url
+                    )
+                } else {
+                    "Set --api-url to an absolute http(s) URL, then retry.".to_string()
+                };
+                Err(crate::exit::operator_context(source, message, Some(remedy)))
+            }
+        }
+    }
+
     pub async fn list_agents(&self) -> Result<Vec<Agent>> {
         let resp = self
-            .http
-            .get(format!("{}/agents", self.base_url))
-            .header("X-API-Key", &self.api_key)
-            .send()
-            .await
-            .context("GET /agents")?;
+            .send_request(
+                self.http
+                    .get(format!("{}/agents", self.base_url))
+                    .header("X-API-Key", &self.api_key),
+                "GET /agents",
+            )
+            .await?;
         Self::expect_ok(resp, "listing agents")
             .await?
             .json()
@@ -624,13 +656,14 @@ impl ApiClient {
     ) -> Result<Agent> {
         let body = agent_create_body(name, slack_channel, repo_full_name);
         let resp = self
-            .http
-            .post(format!("{}/agents", self.base_url))
-            .header("X-API-Key", &self.api_key)
-            .json(&body)
-            .send()
-            .await
-            .context("POST /agents")?;
+            .send_request(
+                self.http
+                    .post(format!("{}/agents", self.base_url))
+                    .header("X-API-Key", &self.api_key)
+                    .json(&body),
+                "POST /agents",
+            )
+            .await?;
         Self::expect_ok(resp, "creating the agent")
             .await?
             .json()
@@ -655,13 +688,14 @@ impl ApiClient {
     /// stored it, so callers report what took rather than what they intended.
     pub async fn update_agent(&self, agent_id: &str, body: &serde_json::Value) -> Result<Agent> {
         let resp = self
-            .http
-            .patch(format!("{}/agents/{agent_id}", self.base_url))
-            .header("X-API-Key", &self.api_key)
-            .json(body)
-            .send()
-            .await
-            .context("PATCH /agents/{id}")?;
+            .send_request(
+                self.http
+                    .patch(format!("{}/agents/{agent_id}", self.base_url))
+                    .header("X-API-Key", &self.api_key)
+                    .json(body),
+                "PATCH /agents/{id}",
+            )
+            .await?;
         Self::expect_ok(resp, "updating the agent")
             .await?
             .json()
@@ -678,13 +712,14 @@ impl ApiClient {
         secrets: &std::collections::BTreeMap<String, String>,
     ) -> Result<Agent> {
         let resp = self
-            .http
-            .patch(format!("{}/agents/{agent_id}", self.base_url))
-            .header("X-API-Key", &self.api_key)
-            .json(&json!({ "secrets": secrets }))
-            .send()
-            .await
-            .context("PATCH /agents/{id}")?;
+            .send_request(
+                self.http
+                    .patch(format!("{}/agents/{agent_id}", self.base_url))
+                    .header("X-API-Key", &self.api_key)
+                    .json(&json!({ "secrets": secrets })),
+                "PATCH /agents/{id}",
+            )
+            .await?;
         Self::expect_ok(resp, "binding agent connector secrets")
             .await?
             .json()
@@ -793,13 +828,14 @@ impl ApiClient {
         created_by: &str,
     ) -> Result<Version> {
         let resp = self
-            .http
-            .post(format!("{}/agents/{agent_id}/versions", self.base_url))
-            .header("X-API-Key", &self.api_key)
-            .json(&json!({"version_label": version_label, "created_by": created_by}))
-            .send()
-            .await
-            .context("POST /agents/{id}/versions")?;
+            .send_request(
+                self.http
+                    .post(format!("{}/agents/{agent_id}/versions", self.base_url))
+                    .header("X-API-Key", &self.api_key)
+                    .json(&json!({"version_label": version_label, "created_by": created_by})),
+                "POST /agents/{id}/versions",
+            )
+            .await?;
         Self::expect_ok(resp, "creating the version")
             .await?
             .json()
@@ -819,16 +855,17 @@ impl ApiClient {
             .context("building multipart body")?;
         let form = reqwest::multipart::Form::new().part("file", part);
         let resp = self
-            .http
-            .put(format!(
-                "{}/agents/{agent_id}/versions/{version_id}/bundle",
-                self.base_url
-            ))
-            .header("X-API-Key", &self.api_key)
-            .multipart(form)
-            .send()
-            .await
-            .context("PUT bundle")?;
+            .send_request(
+                self.http
+                    .put(format!(
+                        "{}/agents/{agent_id}/versions/{version_id}/bundle",
+                        self.base_url
+                    ))
+                    .header("X-API-Key", &self.api_key)
+                    .multipart(form),
+                "PUT bundle",
+            )
+            .await?;
         Self::expect_ok(resp, "uploading the bundle")
             .await?
             .json()
@@ -843,17 +880,18 @@ impl ApiClient {
         environment: &str,
     ) -> Result<Deployment> {
         let resp = self
-            .http
-            .post(format!("{}/deployments", self.base_url))
-            .header("X-API-Key", &self.api_key)
-            .json(&json!({
-                "agent_id": agent_id,
-                "version_id": version_id,
-                "environment": environment,
-            }))
-            .send()
-            .await
-            .context("POST /deployments")?;
+            .send_request(
+                self.http
+                    .post(format!("{}/deployments", self.base_url))
+                    .header("X-API-Key", &self.api_key)
+                    .json(&json!({
+                        "agent_id": agent_id,
+                        "version_id": version_id,
+                        "environment": environment,
+                    })),
+                "POST /deployments",
+            )
+            .await?;
         Self::expect_ok(resp, "creating the deployment")
             .await?
             .json()
@@ -920,12 +958,13 @@ impl ApiClient {
     /// Flip the agent kill switch on: `POST /agents/{id}/kill` (no request body).
     pub async fn kill_agent(&self, agent_id: &str) -> Result<KillState> {
         let resp = self
-            .http
-            .post(format!("{}/agents/{agent_id}/kill", self.base_url))
-            .header("X-API-Key", &self.api_key)
-            .send()
-            .await
-            .context("POST /agents/{id}/kill")?;
+            .send_request(
+                self.http
+                    .post(format!("{}/agents/{agent_id}/kill", self.base_url))
+                    .header("X-API-Key", &self.api_key),
+                "POST /agents/{id}/kill",
+            )
+            .await?;
         Self::expect_ok(resp, "killing the agent")
             .await?
             .json()
@@ -936,12 +975,13 @@ impl ApiClient {
     /// Flip the agent kill switch off: `POST /agents/{id}/resume` (no request body).
     pub async fn resume_agent(&self, agent_id: &str) -> Result<KillState> {
         let resp = self
-            .http
-            .post(format!("{}/agents/{agent_id}/resume", self.base_url))
-            .header("X-API-Key", &self.api_key)
-            .send()
-            .await
-            .context("POST /agents/{id}/resume")?;
+            .send_request(
+                self.http
+                    .post(format!("{}/agents/{agent_id}/resume", self.base_url))
+                    .header("X-API-Key", &self.api_key),
+                "POST /agents/{id}/resume",
+            )
+            .await?;
         Self::expect_ok(resp, "resuming the agent")
             .await?
             .json()
@@ -955,15 +995,16 @@ impl ApiClient {
     /// its next message cold-creates a fresh sandbox.
     pub async fn reset_thread(&self, agent_id: &str, thread_key: &str) -> Result<ThreadResetState> {
         let resp = self
-            .http
-            .post(format!(
-                "{}/agents/{agent_id}/threads/{thread_key}/reset",
-                self.base_url
-            ))
-            .header("X-API-Key", &self.api_key)
-            .send()
-            .await
-            .context("POST /agents/{id}/threads/{thread_key}/reset")?;
+            .send_request(
+                self.http
+                    .post(format!(
+                        "{}/agents/{agent_id}/threads/{thread_key}/reset",
+                        self.base_url
+                    ))
+                    .header("X-API-Key", &self.api_key),
+                "POST /agents/{id}/threads/{thread_key}/reset",
+            )
+            .await?;
         Self::expect_ok(resp, "resetting the thread")
             .await?
             .json()
@@ -983,15 +1024,16 @@ impl ApiClient {
         thread_key: &str,
     ) -> Result<ThreadResetState> {
         let resp = self
-            .http
-            .get(format!(
-                "{}/agents/{agent_id}/threads/{thread_key}/reset",
-                self.base_url
-            ))
-            .header("X-API-Key", &self.api_key)
-            .send()
-            .await
-            .context("GET /agents/{id}/threads/{thread_key}/reset")?;
+            .send_request(
+                self.http
+                    .get(format!(
+                        "{}/agents/{agent_id}/threads/{thread_key}/reset",
+                        self.base_url
+                    ))
+                    .header("X-API-Key", &self.api_key),
+                "GET /agents/{id}/threads/{thread_key}/reset",
+            )
+            .await?;
         Self::expect_ok(resp, "polling the thread reset state")
             .await?
             .json()
@@ -1002,13 +1044,14 @@ impl ApiClient {
     /// Set the agent budget: `PUT /agents/{id}/budget` with a `BudgetConfig` body.
     pub async fn set_budget(&self, agent_id: &str, budget: &BudgetConfig) -> Result<BudgetConfig> {
         let resp = self
-            .http
-            .put(format!("{}/agents/{agent_id}/budget", self.base_url))
-            .header("X-API-Key", &self.api_key)
-            .json(budget)
-            .send()
-            .await
-            .context("PUT /agents/{id}/budget")?;
+            .send_request(
+                self.http
+                    .put(format!("{}/agents/{agent_id}/budget", self.base_url))
+                    .header("X-API-Key", &self.api_key)
+                    .json(budget),
+                "PUT /agents/{id}/budget",
+            )
+            .await?;
         Self::expect_ok(resp, "updating the budget")
             .await?
             .json()
@@ -1036,13 +1079,14 @@ impl ApiClient {
         target: &str,
     ) -> Result<ResolvedTarget> {
         let resp = self
-            .http
-            .post(format!("{}/deploy-targets/resolve", self.base_url))
-            .header("X-API-Key", &self.api_key)
-            .json(&serde_json::json!({"content": content, "target": target}))
-            .send()
-            .await
-            .context("resolving the deploy target")?;
+            .send_request(
+                self.http
+                    .post(format!("{}/deploy-targets/resolve", self.base_url))
+                    .header("X-API-Key", &self.api_key)
+                    .json(&serde_json::json!({"content": content, "target": target})),
+                "resolving the deploy target",
+            )
+            .await?;
         let status = resp.status();
         let body = resp.text().await.unwrap_or_default();
         if is_unrouted(status, &body) {
@@ -1066,13 +1110,14 @@ impl ApiClient {
     /// about where a deploy lands.
     pub async fn list_deploy_targets(&self, content: &str) -> Result<ListedTargets> {
         let resp = self
-            .http
-            .post(format!("{}/deploy-targets/list", self.base_url))
-            .header("X-API-Key", &self.api_key)
-            .json(&serde_json::json!({"content": content, "target": ""}))
-            .send()
-            .await
-            .context("listing the deploy targets")?;
+            .send_request(
+                self.http
+                    .post(format!("{}/deploy-targets/list", self.base_url))
+                    .header("X-API-Key", &self.api_key)
+                    .json(&serde_json::json!({"content": content, "target": ""})),
+                "listing the deploy targets",
+            )
+            .await?;
         let status = resp.status();
         let body = resp.text().await.unwrap_or_default();
         // Same skew guard as `resolve_deploy_target`: a platform predating this
@@ -1100,20 +1145,21 @@ impl ApiClient {
         app_name: &str,
     ) -> Result<ConnectorManifests> {
         let resp = self
-            .http
-            .get(format!(
-                "{}/agents/{agent_id}/versions/{version_id}/connectors",
-                self.base_url
-            ))
-            .query(&[
-                ("release", release),
-                ("namespace", namespace),
-                ("app_name", app_name),
-            ])
-            .header("X-API-Key", &self.api_key)
-            .send()
-            .await
-            .context("GET /agents/{id}/versions/{vid}/connectors")?;
+            .send_request(
+                self.http
+                    .get(format!(
+                        "{}/agents/{agent_id}/versions/{version_id}/connectors",
+                        self.base_url
+                    ))
+                    .query(&[
+                        ("release", release),
+                        ("namespace", namespace),
+                        ("app_name", app_name),
+                    ])
+                    .header("X-API-Key", &self.api_key),
+                "GET /agents/{id}/versions/{vid}/connectors",
+            )
+            .await?;
         Self::expect_ok(resp, "rendering declared connectors")
             .await?
             .json()
@@ -1123,12 +1169,13 @@ impl ApiClient {
 
     pub async fn list_versions(&self, agent_id: &str) -> Result<Vec<Version>> {
         let resp = self
-            .http
-            .get(format!("{}/agents/{agent_id}/versions", self.base_url))
-            .header("X-API-Key", &self.api_key)
-            .send()
-            .await
-            .context("GET /agents/{id}/versions")?;
+            .send_request(
+                self.http
+                    .get(format!("{}/agents/{agent_id}/versions", self.base_url))
+                    .header("X-API-Key", &self.api_key),
+                "GET /agents/{id}/versions",
+            )
+            .await?;
         Self::expect_ok(resp, "listing versions")
             .await?
             .json()
@@ -1139,12 +1186,13 @@ impl ApiClient {
     /// List an agent's learned memory, oldest first: `GET /agents/{id}/memory`.
     pub async fn list_memory(&self, agent_id: &str) -> Result<Vec<MemoryEntry>> {
         let resp = self
-            .http
-            .get(format!("{}/agents/{agent_id}/memory", self.base_url))
-            .header("X-API-Key", &self.api_key)
-            .send()
-            .await
-            .context("GET /agents/{id}/memory")?;
+            .send_request(
+                self.http
+                    .get(format!("{}/agents/{agent_id}/memory", self.base_url))
+                    .header("X-API-Key", &self.api_key),
+                "GET /agents/{id}/memory",
+            )
+            .await?;
         Self::expect_ok(resp, "listing memory")
             .await?
             .json()
@@ -1161,17 +1209,18 @@ impl ApiClient {
     pub async fn list_pending_approvals(&self, agent_id: &str) -> Result<Vec<ApprovalRecord>> {
         let limit = Self::APPROVALS_LIST_LIMIT.to_string();
         let resp = self
-            .http
-            .get(format!("{}/approvals", self.base_url))
-            .header("X-API-Key", &self.api_key)
-            .query(&[
-                ("status_filter", "pending"),
-                ("agent_id", agent_id),
-                ("limit", limit.as_str()),
-            ])
-            .send()
-            .await
-            .context("GET /approvals")?;
+            .send_request(
+                self.http
+                    .get(format!("{}/approvals", self.base_url))
+                    .header("X-API-Key", &self.api_key)
+                    .query(&[
+                        ("status_filter", "pending"),
+                        ("agent_id", agent_id),
+                        ("limit", limit.as_str()),
+                    ]),
+                "GET /approvals",
+            )
+            .await?;
         Self::expect_ok(resp, "listing pending approvals")
             .await?
             .json()
@@ -1200,13 +1249,14 @@ impl ApiClient {
             body["actor_channel"] = json!(chan);
         }
         let resp = self
-            .http
-            .post(format!("{}/approvals/{approval_id}/resolve", self.base_url))
-            .header("X-API-Key", &self.api_key)
-            .json(&body)
-            .send()
-            .await
-            .context("POST /approvals/{id}/resolve")?;
+            .send_request(
+                self.http
+                    .post(format!("{}/approvals/{approval_id}/resolve", self.base_url))
+                    .header("X-API-Key", &self.api_key)
+                    .json(&body),
+                "POST /approvals/{id}/resolve",
+            )
+            .await?;
         Self::expect_ok(resp, "resolving approval")
             .await?
             .json()
@@ -1219,13 +1269,14 @@ impl ApiClient {
     /// agent so the caller can echo the effective gates.
     pub async fn set_approval_tools(&self, agent_id: &str, tools: &[String]) -> Result<Agent> {
         let resp = self
-            .http
-            .patch(format!("{}/agents/{agent_id}", self.base_url))
-            .header("X-API-Key", &self.api_key)
-            .json(&json!({ "approval_required_tools": tools }))
-            .send()
-            .await
-            .context("PATCH /agents/{id} (approval gates)")?;
+            .send_request(
+                self.http
+                    .patch(format!("{}/agents/{agent_id}", self.base_url))
+                    .header("X-API-Key", &self.api_key)
+                    .json(&json!({ "approval_required_tools": tools })),
+                "PATCH /agents/{id} (approval gates)",
+            )
+            .await?;
         Self::expect_ok(resp, "updating approval gates")
             .await?
             .json()
@@ -1249,13 +1300,14 @@ impl ApiClient {
         routes: &std::collections::BTreeMap<String, ApprovalRouteBinding>,
     ) -> Result<Agent> {
         let resp = self
-            .http
-            .patch(format!("{}/agents/{agent_id}", self.base_url))
-            .header("X-API-Key", &self.api_key)
-            .json(&json!({ "approval_routes": routes }))
-            .send()
-            .await
-            .context("PATCH /agents/{id} (approval routes)")?;
+            .send_request(
+                self.http
+                    .patch(format!("{}/agents/{agent_id}", self.base_url))
+                    .header("X-API-Key", &self.api_key)
+                    .json(&json!({ "approval_routes": routes })),
+                "PATCH /agents/{id} (approval routes)",
+            )
+            .await?;
         Self::expect_ok(resp, "updating approval routes")
             .await?
             .json()
@@ -1281,13 +1333,14 @@ impl ApiClient {
             body["model"] = json!(model);
         }
         let resp = self
-            .http
-            .post(format!("{}/evals/trigger", self.base_url))
-            .header("X-API-Key", &self.api_key)
-            .json(&body)
-            .send()
-            .await
-            .context("POST /evals/trigger")?;
+            .send_request(
+                self.http
+                    .post(format!("{}/evals/trigger", self.base_url))
+                    .header("X-API-Key", &self.api_key)
+                    .json(&body),
+                "POST /evals/trigger",
+            )
+            .await?;
         Self::expect_ok(resp, "triggering the eval")
             .await?
             .json()
@@ -1310,13 +1363,14 @@ impl ApiClient {
             query.push(("stream_id", stream_id.to_string()));
         }
         let resp = self
-            .http
-            .get(format!("{}/evals/matrix", self.base_url))
-            .query(&query)
-            .header("X-API-Key", &self.api_key)
-            .send()
-            .await
-            .context("GET /evals/matrix")?;
+            .send_request(
+                self.http
+                    .get(format!("{}/evals/matrix", self.base_url))
+                    .query(&query)
+                    .header("X-API-Key", &self.api_key),
+                "GET /evals/matrix",
+            )
+            .await?;
         Self::expect_ok(resp, "reading the eval matrix")
             .await?
             .json()
@@ -1329,13 +1383,14 @@ impl ApiClient {
     /// `approvals` read must union in (#546).
     pub async fn list_deployments(&self, agent_id: &str) -> Result<Vec<Deployment>> {
         let resp = self
-            .http
-            .get(format!("{}/deployments", self.base_url))
-            .query(&[("agent_id", agent_id)])
-            .header("X-API-Key", &self.api_key)
-            .send()
-            .await
-            .context("GET /deployments")?;
+            .send_request(
+                self.http
+                    .get(format!("{}/deployments", self.base_url))
+                    .query(&[("agent_id", agent_id)])
+                    .header("X-API-Key", &self.api_key),
+                "GET /deployments",
+            )
+            .await?;
         Self::expect_ok(resp, "listing deployments")
             .await?
             .json()
@@ -1353,15 +1408,16 @@ impl ApiClient {
             files: Vec<BundleFile>,
         }
         let resp = self
-            .http
-            .get(format!(
-                "{}/agents/{agent_id}/versions/{version_id}/files",
-                self.base_url
-            ))
-            .header("X-API-Key", &self.api_key)
-            .send()
-            .await
-            .context("GET /agents/{id}/versions/{version_id}/files")?;
+            .send_request(
+                self.http
+                    .get(format!(
+                        "{}/agents/{agent_id}/versions/{version_id}/files",
+                        self.base_url
+                    ))
+                    .header("X-API-Key", &self.api_key),
+                "GET /agents/{id}/versions/{version_id}/files",
+            )
+            .await?;
         let files: BundleFiles = Self::expect_ok(resp, "reading bundle files")
             .await?
             .json()
@@ -1373,12 +1429,13 @@ impl ApiClient {
     /// Delete the agent: `DELETE /agents/{id}` (204 No Content on success).
     pub async fn delete_agent(&self, agent_id: &str) -> Result<()> {
         let resp = self
-            .http
-            .delete(format!("{}/agents/{agent_id}", self.base_url))
-            .header("X-API-Key", &self.api_key)
-            .send()
-            .await
-            .context("DELETE /agents/{id}")?;
+            .send_request(
+                self.http
+                    .delete(format!("{}/agents/{agent_id}", self.base_url))
+                    .header("X-API-Key", &self.api_key),
+                "DELETE /agents/{id}",
+            )
+            .await?;
         Self::expect_ok(resp, "deleting the agent").await?;
         Ok(())
     }

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -3558,7 +3558,7 @@ pub async fn deploy(opts: DeployOpts) -> Result<DeployOutput> {
         Err(err) => {
             step.fail("failed");
             if crate::exit::is_transient_reqwest(&err) {
-                return Err(err.context(opts.connect_hint));
+                return Err(crate::exit::operator_context(err, opts.connect_hint, None));
             }
             return Err(err);
         }
@@ -7462,8 +7462,8 @@ mod tests {
     }
 
     /// AC2: an unavailable verb must name the concept's absence AND point at the
-    /// tier that answers it. `main`'s human path renders `{err:#}` and discards
-    /// the fix, so both halves have to survive on the Display surface alone.
+    /// tier that answers it. The normal human path renders only the outer message
+    /// and does not emit this error's fix, so both halves must remain in Display.
     #[test]
     fn skill_versions_unavailable_message_names_reason_and_alternative() {
         let shown = format!("{:#}", super::skill_versions_unavailable());

--- a/cli/src/docker.rs
+++ b/cli/src/docker.rs
@@ -191,6 +191,17 @@ pub async fn docker_with_env(args: &[String], env: &[(String, String)]) -> Resul
     Ok(stdout)
 }
 
+fn docker_operator_error(source: anyhow::Error, message: &str) -> anyhow::Error {
+    crate::exit::operator_context(
+        source,
+        message,
+        Some(
+            "Run `docker info` to verify Docker is installed and the daemon is running, then retry."
+                .to_string(),
+        ),
+    )
+}
+
 /// Run a docker subcommand and capture its status plus both output streams.
 ///
 /// A check container's nonzero verdict is data, so unlike [`docker`] this does
@@ -212,7 +223,8 @@ pub async fn docker_capture_with_env(
     let output = cmd
         .output()
         .await
-        .context("failed to invoke docker; is Docker installed and on PATH?")?;
+        .context("failed to invoke docker; is Docker installed and on PATH?")
+        .map_err(|err| docker_operator_error(err, "Docker is unavailable for this command."))?;
     Ok((
         output.status,
         String::from_utf8_lossy(&output.stdout).trim().to_string(),
@@ -224,23 +236,15 @@ pub async fn docker_capture_with_env(
 /// `Ok(false)` when the network already existed, so the caller only claims
 /// ownership (and thus teardown responsibility) for networks it actually made.
 pub async fn create_network(name: &str) -> Result<bool> {
-    let output = Command::new("docker")
-        .args(["network", "create", name])
-        .output()
-        .await
-        .context("failed to invoke docker; is Docker installed and on PATH?")?;
-    if output.status.success() {
+    let args = ["network".into(), "create".into(), name.to_string()];
+    let (status, _stdout, stderr) = docker_capture(&args).await?;
+    if status.success() {
         return Ok(true);
     }
-    let stderr = String::from_utf8_lossy(&output.stderr);
     if stderr.contains("already exists") {
         return Ok(false);
     }
-    bail!(
-        "docker network create failed ({}): {}",
-        output.status,
-        stderr.trim()
-    )
+    bail!("docker network create failed ({}): {}", status, stderr)
 }
 
 pub async fn remove_network(name: &str) -> Result<()> {
@@ -674,19 +678,21 @@ pub async fn run_ollama(container: &str, network: &str, image: &str) -> Result<S
 pub async fn wait_ollama_ready(container: &str, timeout: Duration) -> Result<()> {
     let started = Instant::now();
     loop {
-        let output = Command::new("docker")
-            .args(["exec", container, "ollama", "list"])
-            .output()
-            .await
-            .context("failed to invoke docker; is Docker installed and on PATH?")?;
-        if output.status.success() {
+        let args = [
+            "exec".into(),
+            container.to_string(),
+            "ollama".into(),
+            "list".into(),
+        ];
+        let (status, _stdout, stderr) = docker_capture(&args).await?;
+        if status.success() {
             return Ok(());
         }
         if started.elapsed() >= timeout {
             bail!(
                 "ollama container '{container}' did not become ready within {}s: {}",
                 timeout.as_secs(),
-                String::from_utf8_lossy(&output.stderr).trim()
+                stderr
             );
         }
         tokio::time::sleep(Duration::from_secs(2)).await;

--- a/cli/src/exit.rs
+++ b/cli/src/exit.rs
@@ -53,6 +53,27 @@ pub struct CliError {
     pub class: ExitClass,
 }
 
+/// Operator facing context for normal terminal rendering. The original error
+/// remains its source so classification and debug output retain the full chain.
+#[derive(Debug)]
+struct OperatorContext {
+    message: String,
+    remedy: Option<String>,
+    source: anyhow::Error,
+}
+
+impl std::fmt::Display for OperatorContext {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for OperatorContext {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(self.source.as_ref())
+    }
+}
+
 /// An error whose JSON rendering is a command specific reconciliation
 /// payload instead of the ordinary `{error, fix}` object.
 #[derive(Debug)]
@@ -125,6 +146,31 @@ impl std::fmt::Display for CliError {
 
 impl std::error::Error for CliError {}
 
+/// Add operator facing context while preserving `source` for classification
+/// and debug output.
+pub fn operator_context(
+    source: anyhow::Error,
+    message: impl Into<String>,
+    remedy: Option<String>,
+) -> anyhow::Error {
+    anyhow::Error::from(OperatorContext {
+        message: message.into(),
+        remedy,
+        source,
+    })
+}
+
+/// Select the outermost operator context for normal terminal rendering. Errors
+/// without typed context expose only their outer display text.
+pub fn present_error(err: &anyhow::Error) -> (String, Option<String>) {
+    err.chain()
+        .find_map(|cause| cause.downcast_ref::<OperatorContext>())
+        .map_or_else(
+            || (err.to_string(), None),
+            |context| (context.message.clone(), context.remedy.clone()),
+        )
+}
+
 /// Build a usage error (exit 2) as an `anyhow::Error` ready to `return Err(..)`.
 pub fn usage(msg: impl Into<String>) -> anyhow::Error {
     anyhow::Error::from(CliError::usage(msg))
@@ -142,11 +188,10 @@ pub fn usage(msg: impl Into<String>) -> anyhow::Error {
 /// while the alternative ALSO rides in the fix. The redundancy is deliberate: the
 /// two consumers read different fields. A machine consumer branches on the
 /// ADR-0021 `{error, fix}` payload, where `fix` is the alternative alone and stays
-/// exactly the shape it was. A human consumer sees only `Display` (`main` renders
-/// `{err:#}` and discards the fix), so an alternative that lived only in `fix`
-/// would tell them why the verb cannot answer and never where it can -- half of
-/// AC2. Composing it into the message is the local fix; rendering `fix` for every
-/// command's human path is a shared-surface gap tracked separately.
+/// exactly the shape it was. A bare [`CliError`] contributes only its `Display`
+/// message to the human presenter, so an alternative that lived only in `fix`
+/// would tell them why the verb cannot answer and never where it can. Composing
+/// it into the message preserves both parts for that human path.
 pub fn unsupported(
     concept: impl std::fmt::Display,
     reason: impl std::fmt::Display,
@@ -263,8 +308,8 @@ mod tests {
 
     #[test]
     fn unsupported_message_carries_reason_and_alternative() {
-        // `main`'s non-json path renders `{err:#}` and drops the fix, so a human
-        // sees the Display surface alone. It must name BOTH why this tier cannot
+        // A bare CliError gives the human presenter its Display message without
+        // its machine fix field. The message must name both why this tier cannot
         // answer and the tier that can, or the redirect never reaches them.
         let err = unsupported(
             "versions",

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1997,8 +1997,9 @@ async fn main() {
     ui::init(Ui::from_process(cli.color, cli.debug, cli.quiet, cli.json));
     // main never returns Err (which would give anyhow's default exit 1 and skip
     // classification). Run the command, then map any error to a semantic exit
-    // code: the JSON payload goes to stdout under --json, else the human error
-    // to stderr (matching anyhow's default), and the class picks the exit code.
+    // code: the JSON payload goes to stdout under --json. Otherwise the human
+    // presentation goes to stderr, debug receives the full cause chain, and the
+    // class picks the exit code.
     if let Err(err) = run(cli.command).await {
         let (class, _fix) = curie::exit::classify(&err);
         if ui::ui().json() {
@@ -2006,7 +2007,12 @@ async fn main() {
                 .unwrap_or_else(|| curie::exit::error_json(&err));
             ui::ui().emit_json(&payload);
         } else {
-            eprintln!("Error: {err:#}");
+            let (message, remedy) = curie::exit::present_error(&err);
+            eprintln!("Error: {message}");
+            if let Some(remedy) = remedy {
+                eprintln!("Fix: {remedy}");
+            }
+            ui::ui().plumbing(&format!("{err:#}"));
         }
         std::process::exit(class.code());
     }

--- a/cli/src/runner.rs
+++ b/cli/src/runner.rs
@@ -61,7 +61,7 @@ impl RunnerClient {
             .get(format!("{}/status", self.base_url))
             .send()
             .await
-            .with_context(|| format!("GET {}/status", self.base_url))?;
+            .map_err(|error| self.request_error(error, format!("GET {}/status", self.base_url)))?;
         if !resp.status().is_success() {
             bail!("GET /status returned {}", resp.status());
         }
@@ -82,7 +82,9 @@ impl RunnerClient {
             .post(format!("{}/v1/reset", self.base_url))
             .send()
             .await
-            .with_context(|| format!("POST {}/v1/reset", self.base_url))?;
+            .map_err(|error| {
+                self.request_error(error, format!("POST {}/v1/reset", self.base_url))
+            })?;
         if !resp.status().is_success() {
             let status = resp.status();
             let body = resp.text().await.unwrap_or_default();
@@ -115,7 +117,9 @@ impl RunnerClient {
             .json(&frame)
             .send()
             .await
-            .with_context(|| format!("POST {}/v1/event", self.base_url))?;
+            .map_err(|error| {
+                self.request_error(error, format!("POST {}/v1/event", self.base_url))
+            })?;
         if !resp.status().is_success() {
             let status = resp.status();
             let body = resp.text().await.unwrap_or_default();
@@ -151,6 +155,32 @@ impl RunnerClient {
             );
         }
         Ok(events)
+    }
+
+    fn request_error(&self, error: reqwest::Error, operation: String) -> anyhow::Error {
+        let unreachable = error.is_connect() || error.is_timeout();
+        let source = anyhow::Error::from(error).context(operation);
+        if unreachable {
+            crate::exit::operator_context(
+                source,
+                format!(
+                    "The local runner at {} could not be reached.",
+                    self.base_url
+                ),
+                Some("Run `curie skill status` to check the local runner.".to_string()),
+            )
+        } else {
+            let remedy = if self.base_url.contains("://") {
+                "Pass an absolute runner URL beginning with `http://` or `https://`.".to_string()
+            } else {
+                format!("Pass the absolute runner URL `http://{}`.", self.base_url)
+            };
+            crate::exit::operator_context(
+                source,
+                format!("The configured runner URL `{}` is invalid.", self.base_url),
+                Some(remedy),
+            )
+        }
     }
 }
 

--- a/cli/tests/credential_resolution.rs
+++ b/cli/tests/credential_resolution.rs
@@ -376,7 +376,7 @@ fn vault_with_saved_anthropic_key() -> tempfile::TempDir {
 fn skill_up(fixture: &tempfile::TempDir, anthropic_key: Option<&str>) -> Output {
     let mut cmd = Command::new(bin());
     cmd.current_dir(fixture.path().join("bundle"))
-        .args(["skill", "up"])
+        .args(["--debug", "skill", "up"])
         .arg("--name")
         .arg(format!("curie-747-cred-test-{}", std::process::id()))
         .args(["--image", UNRESOLVABLE_IMAGE])

--- a/cli/tests/exit_codes.rs
+++ b/cli/tests/exit_codes.rs
@@ -11,6 +11,8 @@ use std::process::{Command, Output};
 
 const SEAL_VALUE: &str = "placeholder-seal-value";
 const UNREACHABLE_API_URL: &str = "http://127.0.0.1:1";
+const INVALID_API_URL: &str = "localhost:8000";
+const INVALID_RUNNER_URL: &str = "localhost:8787";
 const DOCKER_FAILURE_SENTINEL: &str = "curie-1655-docker-command-failure";
 
 fn run_seal(connector: &str, json: bool) -> Output {
@@ -66,6 +68,37 @@ fn run_unreachable_local_versions(debug: bool) -> Output {
         .expect("run unreachable local versions")
 }
 
+fn run_invalid_local_versions(debug: bool) -> Output {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_curie"));
+    if debug {
+        command.arg("--debug");
+    }
+    command
+        .args([
+            "local",
+            "versions",
+            "acme-agent",
+            "--api-url",
+            INVALID_API_URL,
+        ])
+        .output()
+        .expect("run local versions with an invalid API URL")
+}
+
+fn run_invalid_runner_message(debug: bool) -> Output {
+    let dir = tempfile::tempdir().expect("create runner state directory");
+    let mut command = Command::new(env!("CARGO_BIN_EXE_curie"));
+    if debug {
+        command.arg("--debug");
+    }
+    command
+        .args(["skill", "message", "hello", "--url", INVALID_RUNNER_URL])
+        .current_dir(dir.path())
+        .env("CURIE_CONFIG_DIR", dir.path().join("config"))
+        .output()
+        .expect("run skill message with an invalid runner URL")
+}
+
 fn run_skill_up_with_path(debug: bool, path: &Path, name: &str) -> Output {
     let dir = tempfile::tempdir().expect("create plugin directory");
     curie::scaffold::scaffold(dir.path(), "acme-agent").expect("scaffold plugin");
@@ -95,6 +128,29 @@ fn executable_docker_stub() -> tempfile::TempDir {
         .permissions();
     permissions.set_mode(0o755);
     fs::set_permissions(&docker, permissions).expect("make docker stub executable");
+    dir
+}
+
+fn executable_docker_lost_race_stub(container_name: &str) -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("create executable directory");
+    let docker = dir.path().join("docker");
+    fs::write(
+        &docker,
+        format!(
+            "#!/bin/sh\n\
+             case \"$1\" in\n\
+               ps) exit 0 ;;\n\
+               run) printf '%s\\n' 'docker: Error response from daemon: Conflict. The container name \"/{container_name}\" is already in use by container \"9f2c\".' >&2; exit 125 ;;\n\
+               *) printf '%s\\n' 'unexpected docker command' >&2; exit 93 ;;\n\
+             esac\n"
+        ),
+    )
+    .expect("write Docker race stub");
+    let mut permissions = fs::metadata(&docker)
+        .expect("read Docker race stub metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&docker, permissions).expect("make Docker race stub executable");
     dir
 }
 
@@ -142,6 +198,25 @@ fn classify_plain_anyhow_is_failure_with_no_fix() {
 }
 
 #[test]
+fn untyped_layered_error_presents_outer_context_and_keeps_debug_chain() {
+    let err = anyhow::anyhow!("raw transport detail").context("loading operator configuration");
+
+    let (message, fix) = exit::present_error(&err);
+    assert_eq!(message, "loading operator configuration");
+    assert_eq!(fix, None);
+    assert!(
+        !message.contains("raw transport detail"),
+        "normal presentation must hide the inner cause: {message}"
+    );
+
+    let debug = format!("{err:#}");
+    assert!(
+        debug.contains("loading operator configuration") && debug.contains("raw transport detail"),
+        "debug formatting must retain the complete cause chain: {debug}"
+    );
+}
+
+#[test]
 fn classify_finds_clierror_through_context_wrapping() {
     // A tagged CliError buried under an anyhow context layer must still be
     // discovered by walking the error chain: class + fix survive wrapping.
@@ -183,7 +258,7 @@ fn local_deploy_keeps_connection_causes_out_of_the_human_error() {
         "the human error must retain the remedy: {human_stderr}"
     );
     assert_eq!(
-        human_stderr.matches(UNREACHABLE_API_URL).count(),
+        error_line.matches(UNREACHABLE_API_URL).count(),
         1,
         "the specific local deploy error must name the API URL once: {human_stderr}"
     );
@@ -266,6 +341,96 @@ fn local_versions_unreachable_has_operator_message_and_runnable_remedy() {
 }
 
 #[test]
+fn local_versions_invalid_url_has_operator_message_and_hides_builder_detail() {
+    let human = run_invalid_local_versions(false);
+    let human_stderr = String::from_utf8_lossy(&human.stderr);
+    assert_eq!(
+        human.status.code(),
+        Some(ExitClass::Failure.code()),
+        "an invalid API URL must be a failure: {human_stderr}"
+    );
+
+    let error_line = single_line_with_prefix(&human_stderr, "Error: ");
+    assert!(
+        error_line.contains("platform API") && error_line.contains(INVALID_API_URL),
+        "the error must name the API surface and configured URL: {human_stderr}"
+    );
+    let fix_line = single_line_with_prefix(&human_stderr, "Fix: ");
+    assert!(
+        fix_line.len() > "Fix: ".len(),
+        "the invalid URL must carry an operator remedy: {human_stderr}"
+    );
+    assert!(
+        !human_stderr.contains("GET /agents")
+            && !human_stderr.contains("builder error")
+            && !human_stderr.contains("relative URL without a base"),
+        "normal output must hide request builder detail: {human_stderr}"
+    );
+
+    let debug = run_invalid_local_versions(true);
+    let debug_stderr = String::from_utf8_lossy(&debug.stderr);
+    assert_eq!(
+        debug.status.code(),
+        Some(ExitClass::Failure.code()),
+        "debug must preserve the semantic exit code: {debug_stderr}"
+    );
+    assert!(
+        debug_stderr.contains("GET /agents")
+            && debug_stderr.contains(
+                "builder error for url (localhost:8000/agents): URL scheme is not allowed"
+            ),
+        "debug plumbing must retain the request builder cause: {debug_stderr}"
+    );
+}
+
+#[test]
+fn skill_message_invalid_url_has_runner_message_and_absolute_url_remedy() {
+    let human = run_invalid_runner_message(false);
+    let human_stderr = String::from_utf8_lossy(&human.stderr);
+    assert_eq!(
+        human.status.code(),
+        Some(ExitClass::Failure.code()),
+        "an invalid runner URL must be a failure: {human_stderr}"
+    );
+
+    let error_line = single_line_with_prefix(&human_stderr, "Error: ");
+    assert!(
+        error_line.contains("runner") && error_line.contains(INVALID_RUNNER_URL),
+        "the error must name the runner surface and configured URL: {human_stderr}"
+    );
+    let fix_line = single_line_with_prefix(&human_stderr, "Fix: ");
+    assert!(
+        fix_line.contains("http://localhost:8787") || fix_line.contains("https://localhost:8787"),
+        "the remedy must provide an absolute runner URL: {human_stderr}"
+    );
+    assert!(
+        !fix_line.contains("curie skill status"),
+        "an invalid URL must not suggest probing that same URL: {human_stderr}"
+    );
+    assert!(
+        !human_stderr.contains("POST localhost:8787/v1/event")
+            && !human_stderr.contains("builder error")
+            && !human_stderr.contains("relative URL without a base"),
+        "normal output must hide runner request detail: {human_stderr}"
+    );
+
+    let debug = run_invalid_runner_message(true);
+    let debug_stderr = String::from_utf8_lossy(&debug.stderr);
+    assert_eq!(
+        debug.status.code(),
+        Some(ExitClass::Failure.code()),
+        "debug must preserve the semantic exit code: {debug_stderr}"
+    );
+    assert!(
+        debug_stderr.contains(
+            "POST localhost:8787/v1/event: builder error for url \
+             (localhost:8787/v1/event): URL scheme is not allowed"
+        ),
+        "debug plumbing must retain the runner request cause: {debug_stderr}"
+    );
+}
+
+#[test]
 fn skill_up_without_docker_has_operator_message_and_runnable_remedy() {
     let empty_path = tempfile::tempdir().expect("create empty executable directory");
     let human = run_skill_up_with_path(
@@ -314,7 +479,7 @@ fn skill_up_without_docker_has_operator_message_and_runnable_remedy() {
 }
 
 #[test]
-fn skill_up_docker_command_failure_has_operator_message_and_runnable_remedy() {
+fn skill_up_docker_command_failure_keeps_the_command_diagnosis() {
     let stub = executable_docker_stub();
     let human = run_skill_up_with_path(false, stub.path(), "acme-1655-docker-command-human");
     let human_stderr = String::from_utf8_lossy(&human.stderr);
@@ -325,17 +490,13 @@ fn skill_up_docker_command_failure_has_operator_message_and_runnable_remedy() {
     );
     let error_line = single_line_with_prefix(&human_stderr, "Error: ");
     assert!(
-        error_line.contains("Docker"),
-        "the error must name Docker in operator language: {human_stderr}"
-    );
-    let fix_line = single_line_with_prefix(&human_stderr, "Fix: ");
-    assert!(
-        fix_line.contains("docker info"),
-        "the remedy must contain a runnable Docker probe: {human_stderr}"
+        error_line.contains("docker ps failed") && error_line.contains(DOCKER_FAILURE_SENTINEL),
+        "the error must retain Docker's command diagnosis: {human_stderr}"
     );
     assert!(
-        !human_stderr.contains(DOCKER_FAILURE_SENTINEL),
-        "normal output must hide Docker stderr: {human_stderr}"
+        !human_stderr.contains("docker info")
+            && !human_stderr.lines().any(|line| line.starts_with("Fix: ")),
+        "a nonzero Docker command must not suggest a daemon probe: {human_stderr}"
     );
 
     let debug = run_skill_up_with_path(true, stub.path(), "acme-1655-docker-command-debug");
@@ -348,6 +509,33 @@ fn skill_up_docker_command_failure_has_operator_message_and_runnable_remedy() {
     assert!(
         debug_stderr.contains(DOCKER_FAILURE_SENTINEL),
         "debug plumbing must disclose Docker stderr: {debug_stderr}"
+    );
+}
+
+#[test]
+fn skill_up_lost_name_race_keeps_the_specialized_replacement_remedy() {
+    let container_name = "acme-1655-docker-name-race";
+    let stub = executable_docker_lost_race_stub(container_name);
+    let human = run_skill_up_with_path(false, stub.path(), container_name);
+    let human_stderr = String::from_utf8_lossy(&human.stderr);
+    assert_eq!(
+        human.status.code(),
+        Some(ExitClass::Usage.code()),
+        "a lost container name race must be a usage error: {human_stderr}"
+    );
+
+    let error_line = single_line_with_prefix(&human_stderr, "Error: ");
+    assert!(
+        error_line.contains("container name conflict")
+            && error_line.contains("--replace")
+            && error_line.contains(&format!("curie skill down --name {container_name}")),
+        "the race must retain its specific replacement remedies: {human_stderr}"
+    );
+    assert!(
+        !human_stderr.contains("already in use by container")
+            && !human_stderr.contains("exit status: 125")
+            && !human_stderr.contains("docker info"),
+        "the race remedy must replace the raw Docker diagnosis: {human_stderr}"
     );
 }
 

--- a/cli/tests/exit_codes.rs
+++ b/cli/tests/exit_codes.rs
@@ -4,9 +4,14 @@
 //! implementer adds it; that red state is the contract handoff.
 
 use curie::exit::{self, CliError, ExitClass};
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
 use std::process::{Command, Output};
 
 const SEAL_VALUE: &str = "placeholder-seal-value";
+const UNREACHABLE_API_URL: &str = "http://127.0.0.1:1";
+const DOCKER_FAILURE_SENTINEL: &str = "curie-1655-docker-command-failure";
 
 fn run_seal(connector: &str, json: bool) -> Output {
     let keypair = curie::sealing::generate_keypair();
@@ -28,6 +33,81 @@ fn run_seal(connector: &str, json: bool) -> Output {
         .env("CURIE_TEST_SEAL_VALUE", SEAL_VALUE)
         .output()
         .expect("run curie seal")
+}
+
+fn run_unreachable_local_deploy(debug: bool) -> Output {
+    let dir = tempfile::tempdir().expect("create plugin directory");
+    curie::scaffold::scaffold(dir.path(), "test-agent").expect("scaffold plugin");
+    let mut command = Command::new(env!("CARGO_BIN_EXE_curie"));
+    if debug {
+        command.arg("--debug");
+    }
+    command
+        .args(["local", "deploy", "--api-url", UNREACHABLE_API_URL])
+        .current_dir(dir.path())
+        .output()
+        .expect("run unreachable local deploy")
+}
+
+fn run_unreachable_local_versions(debug: bool) -> Output {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_curie"));
+    if debug {
+        command.arg("--debug");
+    }
+    command
+        .args([
+            "local",
+            "versions",
+            "acme-agent",
+            "--api-url",
+            UNREACHABLE_API_URL,
+        ])
+        .output()
+        .expect("run unreachable local versions")
+}
+
+fn run_skill_up_with_path(debug: bool, path: &Path, name: &str) -> Output {
+    let dir = tempfile::tempdir().expect("create plugin directory");
+    curie::scaffold::scaffold(dir.path(), "acme-agent").expect("scaffold plugin");
+    let mut command = Command::new(env!("CARGO_BIN_EXE_curie"));
+    if debug {
+        command.arg("--debug");
+    }
+    command
+        .args(["skill", "up", "--fake-model", "--name", name])
+        .current_dir(dir.path())
+        .env("CURIE_CONFIG_DIR", dir.path().join("config"))
+        .env("PATH", path)
+        .output()
+        .expect("run skill up")
+}
+
+fn executable_docker_stub() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("create executable directory");
+    let docker = dir.path().join("docker");
+    fs::write(
+        &docker,
+        format!("#!/bin/sh\nprintf '%s\\n' '{DOCKER_FAILURE_SENTINEL}' >&2\nexit 37\n"),
+    )
+    .expect("write docker stub");
+    let mut permissions = fs::metadata(&docker)
+        .expect("read docker stub metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&docker, permissions).expect("make docker stub executable");
+    dir
+}
+
+fn single_line_with_prefix<'a>(output: &'a str, prefix: &str) -> &'a str {
+    let mut matching = output.lines().filter(|line| line.starts_with(prefix));
+    let line = matching
+        .next()
+        .unwrap_or_else(|| panic!("output must contain one {prefix:?} line: {output}"));
+    assert!(
+        matching.next().is_none(),
+        "output must not repeat its {prefix:?} line: {output}"
+    );
+    line
 }
 
 #[test]
@@ -86,6 +166,189 @@ fn error_json_fix_is_null_for_plain_error() {
     let value = exit::error_json(&err);
     assert_eq!(value["error"], "kaboom");
     assert!(value["fix"].is_null());
+}
+
+#[test]
+fn local_deploy_keeps_connection_causes_out_of_the_human_error() {
+    let human = run_unreachable_local_deploy(false);
+    let human_stderr = String::from_utf8_lossy(&human.stderr);
+    assert_eq!(
+        human.status.code(),
+        Some(ExitClass::Transient.code()),
+        "unreachable local deploy must fail: {human_stderr}"
+    );
+    let error_line = single_line_with_prefix(&human_stderr, "Error: ");
+    assert!(
+        error_line.contains("Start the local stack first with `curie local up`"),
+        "the human error must retain the remedy: {human_stderr}"
+    );
+    assert_eq!(
+        human_stderr.matches(UNREACHABLE_API_URL).count(),
+        1,
+        "the specific local deploy error must name the API URL once: {human_stderr}"
+    );
+    assert!(
+        !human_stderr.contains("GET /agents")
+            && !human_stderr.contains("error sending request for url")
+            && !human_stderr.contains("os error"),
+        "the human error must not expose the raw connection cause: {human_stderr}"
+    );
+
+    let debug = run_unreachable_local_deploy(true);
+    let debug_stderr = String::from_utf8_lossy(&debug.stderr);
+    assert_eq!(
+        debug.status.code(),
+        Some(ExitClass::Transient.code()),
+        "debug must preserve the semantic exit code: {debug_stderr}"
+    );
+    assert!(
+        debug_stderr.contains("error sending request for url"),
+        "debug plumbing must retain the raw connection cause: {debug_stderr}"
+    );
+}
+
+#[test]
+fn local_versions_unreachable_has_operator_message_and_runnable_remedy() {
+    let human = run_unreachable_local_versions(false);
+    let human_stderr = String::from_utf8_lossy(&human.stderr);
+    assert_eq!(
+        human.status.code(),
+        Some(ExitClass::Transient.code()),
+        "an unreachable API must be transient: {human_stderr}"
+    );
+
+    let error_line = single_line_with_prefix(&human_stderr, "Error: ");
+    assert!(
+        error_line.contains("the platform API") && error_line.contains("is unreachable"),
+        "the error must name the failed operator surface: {human_stderr}"
+    );
+    assert_eq!(
+        error_line.matches(UNREACHABLE_API_URL).count(),
+        1,
+        "the error line must name the configured API once: {human_stderr}"
+    );
+
+    let remedy = format!("curl -fsS {UNREACHABLE_API_URL}/health");
+    let fix_line = single_line_with_prefix(&human_stderr, "Fix: ");
+    assert!(
+        fix_line.contains(&remedy),
+        "the remedy must contain a runnable health probe: {human_stderr}"
+    );
+    assert_eq!(
+        fix_line.matches(UNREACHABLE_API_URL).count(),
+        1,
+        "the remedy line must name the configured API once: {human_stderr}"
+    );
+    assert_eq!(
+        human_stderr.matches(UNREACHABLE_API_URL).count(),
+        2,
+        "normal output may name the API once in each relevant line: {human_stderr}"
+    );
+    assert!(
+        !human_stderr.contains("GET /agents")
+            && !human_stderr.contains("error sending request for url")
+            && !human_stderr.contains("os error"),
+        "normal output must hide the transport chain: {human_stderr}"
+    );
+
+    let debug = run_unreachable_local_versions(true);
+    let debug_stderr = String::from_utf8_lossy(&debug.stderr);
+    assert_eq!(
+        debug.status.code(),
+        Some(ExitClass::Transient.code()),
+        "debug must preserve the semantic exit code: {debug_stderr}"
+    );
+    assert!(
+        debug_stderr.contains("GET /agents")
+            || debug_stderr.contains("error sending request for url"),
+        "debug plumbing must disclose the transport source: {debug_stderr}"
+    );
+}
+
+#[test]
+fn skill_up_without_docker_has_operator_message_and_runnable_remedy() {
+    let empty_path = tempfile::tempdir().expect("create empty executable directory");
+    let human = run_skill_up_with_path(
+        false,
+        empty_path.path(),
+        "acme-1655-docker-unavailable-human",
+    );
+    let human_stderr = String::from_utf8_lossy(&human.stderr);
+    assert_eq!(
+        human.status.code(),
+        Some(ExitClass::Failure.code()),
+        "an unavailable Docker binary must be a failure: {human_stderr}"
+    );
+    let error_line = single_line_with_prefix(&human_stderr, "Error: ");
+    assert!(
+        error_line.contains("Docker"),
+        "the error must name Docker in operator language: {human_stderr}"
+    );
+    let fix_line = single_line_with_prefix(&human_stderr, "Fix: ");
+    assert!(
+        fix_line.contains("docker info"),
+        "the remedy must contain a runnable Docker probe: {human_stderr}"
+    );
+    assert!(
+        !human_stderr.contains("failed to invoke docker")
+            && !human_stderr.contains("No such file or directory")
+            && !human_stderr.contains("os error"),
+        "normal output must hide the process spawn source: {human_stderr}"
+    );
+
+    let debug = run_skill_up_with_path(
+        true,
+        empty_path.path(),
+        "acme-1655-docker-unavailable-debug",
+    );
+    let debug_stderr = String::from_utf8_lossy(&debug.stderr);
+    assert_eq!(
+        debug.status.code(),
+        Some(ExitClass::Failure.code()),
+        "debug must preserve the semantic exit code: {debug_stderr}"
+    );
+    assert!(
+        debug_stderr.contains("failed to invoke docker"),
+        "debug plumbing must disclose the process spawn source: {debug_stderr}"
+    );
+}
+
+#[test]
+fn skill_up_docker_command_failure_has_operator_message_and_runnable_remedy() {
+    let stub = executable_docker_stub();
+    let human = run_skill_up_with_path(false, stub.path(), "acme-1655-docker-command-human");
+    let human_stderr = String::from_utf8_lossy(&human.stderr);
+    assert_eq!(
+        human.status.code(),
+        Some(ExitClass::Failure.code()),
+        "a nonzero Docker command must be a failure: {human_stderr}"
+    );
+    let error_line = single_line_with_prefix(&human_stderr, "Error: ");
+    assert!(
+        error_line.contains("Docker"),
+        "the error must name Docker in operator language: {human_stderr}"
+    );
+    let fix_line = single_line_with_prefix(&human_stderr, "Fix: ");
+    assert!(
+        fix_line.contains("docker info"),
+        "the remedy must contain a runnable Docker probe: {human_stderr}"
+    );
+    assert!(
+        !human_stderr.contains(DOCKER_FAILURE_SENTINEL),
+        "normal output must hide Docker stderr: {human_stderr}"
+    );
+
+    let debug = run_skill_up_with_path(true, stub.path(), "acme-1655-docker-command-debug");
+    let debug_stderr = String::from_utf8_lossy(&debug.stderr);
+    assert_eq!(
+        debug.status.code(),
+        Some(ExitClass::Failure.code()),
+        "debug must preserve the semantic exit code: {debug_stderr}"
+    );
+    assert!(
+        debug_stderr.contains(DOCKER_FAILURE_SENTINEL),
+        "debug plumbing must disclose Docker stderr: {debug_stderr}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes #1655

Normal human errors now show one operator message and an optional runnable remedy. Raw cause chains remain available with `--debug`, while JSON output and semantic exit codes remain unchanged.

Regression coverage exercises local deploy, API, runner, Docker spawn, Docker command failure, and container name conflict paths. The full Rust format, clippy, and test gate passes. The skill parity rung passes, and `curie dev verify-fix-pin` reports `PINNED`.