### PR TITLE
Stop duplicate boot notices on job redelivery

### DIFF
--- a/apps/worker/src/curie_worker/kernel.py
+++ b/apps/worker/src/curie_worker/kernel.py
@@ -1307,13 +1307,11 @@ class Kernel:
         # the critical section. Fires once per attempt (retries re-affirm it).
         # Suppressed under no-edit streaming: that mode's contract is exactly one
         # chat.update (the final edit), so it opts out of the pre-boot edit too.
-        if not self._config.slack_no_edit_streaming:
+        # A placeholderless job must route first. Otherwise every busy redelivery
+        # posts a notice for a turn that never started.
+        defer_job_booting = qevent.reply_handle.placeholder is None and qevent.source.is_job
+        if not self._config.slack_no_edit_streaming and not defer_job_booting:
             try:
-                # Through the adopting helper, not a bare ``_reply``: on a
-                # placeholder-less turn this booting notice is the delivery that
-                # CREATES the message, and the stream that follows has to edit it.
-                # A bare reply here would post the notice, leave no ref behind, and
-                # the first delta would post a second message beside it.
                 await self._reply_for(qevent, route, self._config.booting_text)
             except Exception:
                 logger.warning("booting-state update failed for %s", qevent.event_id)
@@ -1367,6 +1365,14 @@ class Kernel:
             logger.warning("turn start failed for %s: %r", qevent.event_id, exc)
             return TurnOutcome(terminal_ok=False, classification="runner-error")
         release_order()
+
+        if not self._config.slack_no_edit_streaming and defer_job_booting:
+            try:
+                # Routing succeeded, so this delivery owns a real turn. Adopt the
+                # minted ref before streaming so every later update edits it.
+                await self._reply_for(qevent, route, self._config.booting_text)
+            except Exception:
+                logger.warning("booting-state update failed for %s", qevent.event_id)
 
         if routed.canned_reply is not None:
             # An enabled greeting/help pack matched a provably-fresh thread under

--- a/apps/worker/tests/kernel/test_kernel.py
+++ b/apps/worker/tests/kernel/test_kernel.py
@@ -151,12 +151,15 @@ def test_a_job_never_steers_a_live_session(make_harness) -> None:
     async def go() -> None:
         async with make_harness() as h:
             h.runner.turn_active = True
+            event = _qevent(
+                "nightly digest", placeholder=None, source=TurnSource.CRON
+            )
 
-            with pytest.raises(ThreadBusyError):
-                await h.kernel.process_event(
-                    _qevent("nightly digest", placeholder=None, source=TurnSource.CRON)
-                )
+            for _ in range(5):
+                with pytest.raises(ThreadBusyError):
+                    await h.kernel.process_event(event)
 
+            assert h.sink.text_posts == [], "a deferred job left a booting notice"
             assert h.runner.steers == [], "a job steered a live session"
             assert h.runner.opened == [], "a job opened a turn beside a live one"
 


### PR DESCRIPTION
Closes #1639

Defers placeholderless job booting notices until routing succeeds, so a busy thread can reject every redelivery without minting orphan messages. Placeholder carrying turns still edit their existing notice before routing.

Done check

CHECKED: Five busy redeliveries create zero notices, zero steers, and zero turns. Reverting the production fix produced five notices and failed the regression test.
CHECKED: Correctness, scope, and concurrency side effect reviews approved with file and line evidence.
CHECKED: Placeholder behavior and message adoption remain covered by the affected kernel suite.
CHECKED: `uv run pytest apps/worker/tests/kernel -q` passed with 173 tests.
CHECKED: Ruff and the production kernel typecheck passed.
CHECKED: `CURIE_E2E_TIERS=local curie dev e2e-ladder` passed and tore down the stack.
N/A: No frozen contract, security surface, parity seam, or documentation contract changed.
N/A: Consolidation is skipped for the quick tier.