### PR TITLE
End deployments before deleting agents

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -5939,6 +5939,56 @@
       }
     },
     "/deployments/{deployment_id}": {
+      "delete": {
+        "operationId": "end_deployment_deployments__deployment_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "deployment_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Deployment Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "End Deployment",
+        "tags": [
+          "deployments"
+        ]
+      },
       "get": {
         "operationId": "get_deployment_deployments__deployment_id__get",
         "parameters": [

--- a/apps/api/src/curie_api/crud.py
+++ b/apps/api/src/curie_api/crud.py
@@ -392,6 +392,11 @@ async def get_deployment(session: AsyncSession, deployment_id: uuid.UUID) -> Dep
     return await session.get(Deployment, deployment_id)
 
 
+async def end_deployment(session: AsyncSession, deployment: Deployment) -> None:
+    deployment.status = "stopped"
+    await session.commit()
+
+
 # -- approvals (#244, ADR-0010) -------------------------------------------------
 
 
@@ -903,4 +908,3 @@ async def revoke_console_session(
     await session.commit()
     await session.refresh(row)
     return row
-

--- a/apps/api/src/curie_api/routers/deployments.py
+++ b/apps/api/src/curie_api/routers/deployments.py
@@ -52,3 +52,11 @@ async def get_deployment(
     if deployment is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "deployment not found")
     return DeploymentOut.model_validate(deployment)
+
+
+@router.delete("/{deployment_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def end_deployment(deployment_id: uuid.UUID, session: SessionDep) -> None:
+    deployment = await crud.get_deployment(session, deployment_id)
+    if deployment is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "deployment not found")
+    await crud.end_deployment(session, deployment)

--- a/apps/api/tests/test_crud.py
+++ b/apps/api/tests/test_crud.py
@@ -285,3 +285,141 @@ def test_delete_missing_agent_returns_404(
     missing = "00000000-0000-0000-0000-000000000000"
     resp = client.delete(f"/agents/{missing}", headers=auth_headers)
     assert resp.status_code == 404
+
+
+def _create_active_deployment(
+    client: Any, auth_headers: dict[str, str], *, name: str
+) -> tuple[str, str, str]:
+    agent_resp = client.post(
+        "/agents",
+        json={
+            "name": name,
+            "channel": {"kind": "slack", "address": "C0EXAMPLE1"},
+        },
+        headers=auth_headers,
+    )
+    assert agent_resp.status_code == 201, agent_resp.text
+    agent = agent_resp.json()
+
+    version_resp = client.post(
+        f"/agents/{agent['id']}/versions",
+        json={"version_label": "v1", "created_by": "bconn"},
+        headers=auth_headers,
+    )
+    assert version_resp.status_code == 201, version_resp.text
+    version = version_resp.json()
+
+    deployment_resp = client.post(
+        "/deployments",
+        json={
+            "agent_id": agent["id"],
+            "version_id": version["id"],
+            "environment": "dev",
+        },
+        headers=auth_headers,
+    )
+    assert deployment_resp.status_code == 201, deployment_resp.text
+    deployment = deployment_resp.json()
+    assert deployment["status"] == "active"
+    return agent["id"], version["id"], deployment["id"]
+
+
+def test_end_deployment_marks_row_stopped_and_preserves_history(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    agent_id, _, deployment_id = _create_active_deployment(
+        client, auth_headers, name="stop-history"
+    )
+
+    resp = client.delete(f"/deployments/{deployment_id}", headers=auth_headers)
+    assert resp.status_code == 204, resp.text
+
+    got = client.get(f"/deployments/{deployment_id}", headers=auth_headers)
+    assert got.status_code == 200, got.text
+    assert got.json()["id"] == deployment_id
+    assert got.json()["status"] == "stopped"
+
+    listed = client.get(
+        "/deployments", params={"agent_id": agent_id}, headers=auth_headers
+    )
+    assert listed.status_code == 200, listed.text
+    assert [deployment["id"] for deployment in listed.json()] == [deployment_id]
+    assert listed.json()[0]["status"] == "stopped"
+
+
+def test_end_deployment_is_idempotent(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    _, _, deployment_id = _create_active_deployment(
+        client, auth_headers, name="stop-idempotent"
+    )
+
+    first = client.delete(f"/deployments/{deployment_id}", headers=auth_headers)
+    assert first.status_code == 204, first.text
+    second = client.delete(f"/deployments/{deployment_id}", headers=auth_headers)
+    assert second.status_code == 204, second.text
+
+    got = client.get(f"/deployments/{deployment_id}", headers=auth_headers)
+    assert got.status_code == 200, got.text
+    assert got.json()["status"] == "stopped"
+
+
+def test_end_missing_deployment_returns_404(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    missing = "00000000-0000-0000-0000-000000000000"
+    resp = client.delete(f"/deployments/{missing}", headers=auth_headers)
+    assert resp.status_code == 404, resp.text
+
+
+def test_end_deployment_requires_authentication(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    _, _, deployment_id = _create_active_deployment(
+        client, auth_headers, name="stop-auth"
+    )
+
+    resp = client.delete(f"/deployments/{deployment_id}")
+    assert resp.status_code == 401, resp.text
+
+    got = client.get(f"/deployments/{deployment_id}", headers=auth_headers)
+    assert got.status_code == 200, got.text
+    assert got.json()["status"] == "active"
+
+
+def test_agent_delete_requires_every_deployment_to_be_stopped(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    agent_id, version_id, first_deployment_id = _create_active_deployment(
+        client, auth_headers, name="stop-before-delete"
+    )
+
+    first_stop = client.delete(
+        f"/deployments/{first_deployment_id}", headers=auth_headers
+    )
+    assert first_stop.status_code == 204, first_stop.text
+
+    redeploy_resp = client.post(
+        "/deployments",
+        json={
+            "agent_id": agent_id,
+            "version_id": version_id,
+            "environment": "dev",
+        },
+        headers=auth_headers,
+    )
+    assert redeploy_resp.status_code == 201, redeploy_resp.text
+    redeployment_id = redeploy_resp.json()["id"]
+    assert redeploy_resp.json()["status"] == "active"
+
+    blocked_delete = client.delete(f"/agents/{agent_id}", headers=auth_headers)
+    assert blocked_delete.status_code == 409, blocked_delete.text
+
+    second_stop = client.delete(
+        f"/deployments/{redeployment_id}", headers=auth_headers
+    )
+    assert second_stop.status_code == 204, second_stop.text
+
+    delete = client.delete(f"/agents/{agent_id}", headers=auth_headers)
+    assert delete.status_code == 204, delete.text
+    assert client.get(f"/agents/{agent_id}", headers=auth_headers).status_code == 404

--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -1877,6 +1877,66 @@ export const commandManifest = {
           ],
           "hidden": false,
           "name": "reset-thread"
+        },
+        {
+          "about": "Delete an agent via the local platform API",
+          "args": [
+            {
+              "global": false,
+              "help": "Agent name or id to delete",
+              "id": "agent",
+              "positional": true,
+              "required": true
+            },
+            {
+              "default_values": [
+                "http://localhost:28000"
+              ],
+              "env": "CURIE_API_URL",
+              "global": false,
+              "id": "api_url",
+              "long": "api-url",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "curie-dev-key"
+              ],
+              "env": "CURIE_API_KEY",
+              "global": false,
+              "id": "api_key",
+              "long": "api-key",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Confirm this destructive action",
+              "id": "yes",
+              "long": "yes",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Print what would be done and exit without making a request",
+              "id": "dry_run",
+              "long": "dry-run",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "name": "delete"
         }
       ]
     },

--- a/cli/README.md
+++ b/cli/README.md
@@ -237,7 +237,7 @@ disk and targets no environment.
 | Target | What runs | Slack | Kubernetes | Verbs | Reach for it to |
 |---|---|---|---|---|---|
 | `skill` | Just the runner container on the host Docker daemon. No platform, no queue, no API, no Slack. Fully offline. | none | none | `up` `check` `down` `status` `message` `eval` | Iterate a plugin/skill against a local runner, the fastest loop. |
-| `local` | The full platform via docker compose (Postgres + Valkey + Langfuse + API + worker). | stub by default, optional real Slack with `--slack` | none | `up` `down` `status` `comms` `message` `eval` `deploy` `overrides` `reset-thread` | Exercise the real queue -> worker -> sandbox -> reply product loop with zero Slack and zero Kubernetes. Its API is published on host port `28000`. |
+| `local` | The full platform via docker compose (Postgres + Valkey + Langfuse + API + worker). | stub by default, optional real Slack with `--slack` | none | `up` `down` `status` `comms` `message` `eval` `deploy` `overrides` `reset-thread` `delete` | Exercise the real queue -> worker -> sandbox -> reply product loop with zero Slack and zero Kubernetes. Its API is published on host port `28000`. |
 | `cluster` | The platform on Kubernetes (a Helm release). | optional | yes | `up` `down` `status` `comms` `message` `eval` `deploy` `kill` `resume` `budget` `overrides` `reset-thread` `delete` | Operate and drive a deployed cluster release, and control its agents' lifecycle. |
 
 `eval` is on all three, running the SAME `evals/cases.json` with the SAME
@@ -346,6 +346,7 @@ the optional Slack dispatcher.
 | `curie local deploy` | Package the bundle as tar.gz and push it to the compose platform API (`--api-url`, default `http://localhost:28000`). Auth via `--api-key` or `CURIE_API_KEY`. |
 | `curie local overrides <agent> [--model V\|--clear-model] [--thinking V\|--clear-thinking]` | Read or change the agent's two nullable operator overrides via the compose platform API (`PATCH /agents/{id}`).<br>• With no change flags it INSPECTS and writes nothing.<br>• `--clear-<field>` sends explicit JSON null, restoring the platform default; an omitted field is left alone, which is a different request the API tells apart with `model_fields_set`.<br>• A blank value is refused rather than forwarded: an empty override skips the platform default instead of restoring it. |
 | `curie local reset-thread <agent> --thread-key <key> --yes` | Force a stuck thread's sandbox to be released via the compose platform API (`POST /agents/{id}/threads/{thread_key}/reset`, #737).<br>• The worker's next maintenance tick releases the thread's claim and route, so its next message cold-creates a fresh sandbox; conversation history is not deleted.<br>• Interrupts a live turn on the thread first, so it refuses without `--yes`. |
+| `curie local delete <agent> --yes` | End every active deployment, then delete the agent through the compose platform API. Destructive and irreversible: refuses without `--yes`.<br>• If the final agent deletion fails, the agent remains present but any deployments already ended stay ended. |
 
 ##### `curie local message`: the same roundtrip against the compose stack
 
@@ -406,7 +407,7 @@ Wraps the umbrella Helm chart and the deployed release, the way `linkerd` or
 | `curie cluster budget <agent> --limit <n>` | Set the agent's daily spend cap in USD via the platform API (`PUT /agents/{id}/budget`, `BudgetConfig.max_usd_per_day`); the per-run token cap is left at the platform default. |
 | `curie cluster overrides <agent> [--model V\|--clear-model] [--thinking V\|--clear-thinking]` | Read or change the agent's two nullable operator overrides via the platform API (`PATCH /agents/{id}`).<br>• With no change flags it INSPECTS and writes nothing.<br>• `--clear-<field>` sends explicit JSON null, restoring the platform default; an omitted field is left alone, which is a different request the API tells apart with `model_fields_set`.<br>• A blank value is refused rather than forwarded: an empty override skips the platform default instead of restoring it. |
 | `curie cluster reset-thread <agent> --thread-key <key> --yes` | Force a stuck thread's sandbox to be released via the platform API (`POST /agents/{id}/threads/{thread_key}/reset`, #737).<br>• The worker's next maintenance tick releases the thread's claim and route, so its next message cold-creates a fresh sandbox; conversation history is not deleted.<br>• Interrupts a live turn on the thread first, so it refuses without `--yes`. |
-| `curie cluster delete <agent> --yes` | Delete an agent via the platform API (`DELETE /agents/{id}`). Destructive and irreversible: refuses without `--yes`. |
+| `curie cluster delete <agent> --yes` | End every active deployment, then delete the agent through the platform API. Destructive and irreversible: refuses without `--yes`.<br>• If the final agent deletion fails, the agent remains present but any deployments already ended stay ended. |
 
 The six lifecycle verbs (`kill`, `resume`, `budget`, `overrides`, `reset-thread`,
 `delete`)

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -1874,6 +1874,66 @@
           ],
           "hidden": false,
           "name": "reset-thread"
+        },
+        {
+          "about": "Delete an agent via the local platform API",
+          "args": [
+            {
+              "global": false,
+              "help": "Agent name or id to delete",
+              "id": "agent",
+              "positional": true,
+              "required": true
+            },
+            {
+              "default_values": [
+                "http://localhost:28000"
+              ],
+              "env": "CURIE_API_URL",
+              "global": false,
+              "id": "api_url",
+              "long": "api-url",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "curie-dev-key"
+              ],
+              "env": "CURIE_API_KEY",
+              "global": false,
+              "id": "api_key",
+              "long": "api-key",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Confirm this destructive action",
+              "id": "yes",
+              "long": "yes",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Print what would be done and exit without making a request",
+              "id": "dry_run",
+              "long": "dry-run",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "name": "delete"
         }
       ]
     },

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -1339,6 +1339,19 @@ impl ApiClient {
             .context("decoding deployment list")
     }
 
+    /// End the deployment: `DELETE /deployments/{id}` (204 No Content on success).
+    pub async fn end_deployment(&self, deployment_id: &str) -> Result<()> {
+        let resp = self
+            .http
+            .delete(format!("{}/deployments/{deployment_id}", self.base_url))
+            .header("X-API-Key", &self.api_key)
+            .send()
+            .await
+            .context("DELETE /deployments/{id}")?;
+        Self::expect_ok(resp, "ending the deployment").await?;
+        Ok(())
+    }
+
     /// Read a version's authored text files (skills, manifest, eval cases):
     /// `GET /agents/{id}/versions/{version_id}/files`. The `approvals` read pulls
     /// the deployed bundle's manifest from here to recover its `approvalPolicy`

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -4221,23 +4221,30 @@ impl crate::ui::CliOutput for DeleteOutput {
     }
 }
 
-/// `curie cluster delete <agent> --yes`: delete the agent
-/// (`DELETE /agents/{id}`). Destructive and irreversible, so it refuses without
-/// `--yes`, mirroring `cluster down`. `--dry-run` returns the plan and makes no
-/// request.
+/// `curie <tier> delete <agent> --yes`: end active deployments, then delete the
+/// agent. Destructive and irreversible, so it refuses without `--yes`.
+/// `--dry-run` returns the plan and makes no request.
 pub async fn delete(opts: AgentActionOpts, yes: bool) -> Result<DeleteOutput> {
     let ui = crate::ui::ui();
     if opts.dry_run {
         return Ok(DeleteOutput::DryRun(crate::ui::DryRunPlan {
-            lines: vec![format!(
-                "DELETE {}/agents/<id>  (would resolve agent {:?} first)",
-                opts.api_url, opts.agent
-            )],
+            lines: vec![
+                format!(
+                    "GET {}/agents  (would resolve agent {:?})",
+                    opts.api_url, opts.agent
+                ),
+                format!("GET {}/deployments?agent_id=<id>", opts.api_url),
+                format!(
+                    "DELETE {}/deployments/<id>  (for each active deployment)",
+                    opts.api_url
+                ),
+                format!("DELETE {}/agents/<id>", opts.api_url),
+            ],
         }));
     }
     if !yes {
         return Err(crate::exit::CliError::usage(format!(
-            "`curie cluster delete {}` permanently deletes the agent; re-run with --yes to confirm",
+            "`curie ... delete {}` permanently deletes the agent; re-run with --yes to confirm",
             opts.agent
         ))
         .with_fix("re-run with --yes")
@@ -4246,6 +4253,16 @@ pub async fn delete(opts: AgentActionOpts, yes: bool) -> Result<DeleteOutput> {
     let client = ApiClient::new(&opts.api_url, &opts.api_key)?;
     let agent = client.find_agent(&opts.agent).await?;
     let cl = ui.checklist();
+    for deployment in client.list_deployments(&agent.id).await? {
+        if deployment.status == "active" {
+            let step = cl.step(&format!("ending deployment {}", deployment.id));
+            if let Err(err) = client.end_deployment(&deployment.id).await {
+                step.fail("failed");
+                return Err(err);
+            }
+            step.done("ended");
+        }
+    }
     let step = cl.step(&format!("deleting {}", agent.name));
     match client.delete_agent(&agent.id).await {
         Ok(()) => step.done("deleted"),

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1271,6 +1271,25 @@ enum LocalAction {
         #[arg(long)]
         dry_run: bool,
     },
+    /// Delete an agent via the local platform API.
+    Delete {
+        /// Agent name or id to delete.
+        agent: String,
+        #[arg(
+            long,
+            default_value = message::DEFAULT_LOCAL_API_URL,
+            env = "CURIE_API_URL"
+        )]
+        api_url: String,
+        #[arg(long, default_value = message::DEFAULT_API_KEY, env = "CURIE_API_KEY", value_parser = message::api_key_or_default)]
+        api_key: String,
+        /// Confirm this destructive action.
+        #[arg(long)]
+        yes: bool,
+        /// Print what would be done and exit without making a request.
+        #[arg(long)]
+        dry_run: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -2564,6 +2583,24 @@ async fn run(command: Option<Command>) -> Result<()> {
                         dry_run,
                     },
                     thread_key,
+                    yes,
+                )
+                .await?,
+            ),
+            LocalAction::Delete {
+                agent,
+                api_url,
+                api_key,
+                yes,
+                dry_run,
+            } => emit(
+                commands::delete(
+                    AgentActionOpts {
+                        api_url,
+                        api_key,
+                        agent,
+                        dry_run,
+                    },
                     yes,
                 )
                 .await?,

--- a/cli/tests/api_lifecycle.rs
+++ b/cli/tests/api_lifecycle.rs
@@ -141,6 +141,28 @@ async fn delete_agent_issues_a_delete() {
 }
 
 #[tokio::test]
+async fn end_deployment_issues_an_authenticated_delete_with_no_body() {
+    let deployment_id = "deployment-active-dev";
+    let server = serve(move |req| match (req.method.as_str(), req.path.as_str()) {
+        ("DELETE", p) if *p == format!("/deployments/{deployment_id}") => Response {
+            status: 204,
+            content_type: "application/json".into(),
+            body: Vec::new(),
+        },
+        other => panic!("unexpected request: {other:?}"),
+    });
+    let client = ApiClient::new(&server.base_url, "k").unwrap();
+    client.end_deployment(deployment_id).await.unwrap();
+
+    let rec = server.recorded();
+    assert_eq!(rec.len(), 1);
+    assert_eq!(rec[0].method, "DELETE");
+    assert_eq!(rec[0].path, format!("/deployments/{deployment_id}"));
+    assert!(rec[0].body.is_empty(), "ending a deployment sends no body");
+    assert_eq!(rec[0].header("x-api-key"), Some("k"));
+}
+
+#[tokio::test]
 async fn find_agent_errors_when_no_agent_matches() {
     let server = serve(|req| match (req.method.as_str(), req.path.as_str()) {
         ("GET", "/agents") => Response::json(200, "[]"),
@@ -285,6 +307,187 @@ async fn delete_without_yes_refuses_and_makes_no_request() {
     assert!(
         server.recorded().is_empty(),
         "a refused delete must make no request"
+    );
+}
+
+#[tokio::test]
+async fn delete_handler_ends_every_active_deployment_then_deletes_agent() {
+    let active_dev = "deployment-active-dev";
+    let stopped = "deployment-stopped";
+    let active_prod = "deployment-active-prod";
+    let server = serve(move |req| match (req.method.as_str(), req.path.as_str()) {
+        ("GET", "/agents") => agent_list(),
+        ("GET", p) if *p == format!("/deployments?agent_id={AGENT_ID}") => Response::json(
+            200,
+            &format!(
+                r#"[{{"id":"{active_dev}","environment":"dev","status":"active"}},{{"id":"{stopped}","environment":"staging","status":"stopped"}},{{"id":"{active_prod}","environment":"prod","status":"active"}}]"#
+            ),
+        ),
+        ("DELETE", p)
+            if *p == format!("/deployments/{active_dev}")
+                || *p == format!("/deployments/{active_prod}") =>
+        {
+            Response {
+                status: 204,
+                content_type: "application/json".into(),
+                body: Vec::new(),
+            }
+        }
+        ("DELETE", p) if *p == format!("/agents/{AGENT_ID}") => Response {
+            status: 204,
+            content_type: "application/json".into(),
+            body: Vec::new(),
+        },
+        other => panic!("unexpected request: {other:?}"),
+    });
+
+    let out = commands::delete(opts(&server.base_url, "deal-desk", false), true)
+        .await
+        .unwrap();
+    assert!(matches!(out, commands::DeleteOutput::Done { .. }));
+
+    let rec = server.recorded();
+    let flow: Vec<(String, String)> = rec
+        .iter()
+        .map(|request| (request.method.clone(), request.path.clone()))
+        .collect();
+    assert_eq!(
+        flow,
+        vec![
+            ("GET".to_string(), "/agents".to_string()),
+            (
+                "GET".to_string(),
+                format!("/deployments?agent_id={AGENT_ID}")
+            ),
+            ("DELETE".to_string(), format!("/deployments/{active_dev}")),
+            ("DELETE".to_string(), format!("/deployments/{active_prod}")),
+            ("DELETE".to_string(), format!("/agents/{AGENT_ID}")),
+        ]
+    );
+    assert!(
+        rec.iter()
+            .all(|request| request.header("x-api-key") == Some("k")),
+        "every lifecycle request must be authenticated"
+    );
+}
+
+#[tokio::test]
+async fn delete_handler_stops_when_ending_an_active_deployment_fails() {
+    let first = "deployment-active-first";
+    let failing = "deployment-active-failing";
+    let later = "deployment-active-later";
+    let server = serve(move |req| match (req.method.as_str(), req.path.as_str()) {
+        ("GET", "/agents") => agent_list(),
+        ("GET", p) if *p == format!("/deployments?agent_id={AGENT_ID}") => Response::json(
+            200,
+            &format!(
+                r#"[{{"id":"{first}","environment":"dev","status":"active"}},{{"id":"{failing}","environment":"staging","status":"active"}},{{"id":"{later}","environment":"prod","status":"active"}}]"#
+            ),
+        ),
+        ("DELETE", p) if *p == format!("/deployments/{first}") => Response {
+            status: 204,
+            content_type: "application/json".into(),
+            body: Vec::new(),
+        },
+        ("DELETE", p) if *p == format!("/deployments/{failing}") => {
+            Response::json(500, r#"{"detail":"deployment teardown failed"}"#)
+        }
+        other => panic!("unexpected request: {other:?}"),
+    });
+
+    let err = commands::delete(opts(&server.base_url, "deal-desk", false), true)
+        .await
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("500 Internal Server Error"),
+        "{err}"
+    );
+
+    let flow: Vec<(String, String)> = server
+        .recorded()
+        .iter()
+        .map(|request| (request.method.clone(), request.path.clone()))
+        .collect();
+    assert_eq!(
+        flow,
+        vec![
+            ("GET".to_string(), "/agents".to_string()),
+            (
+                "GET".to_string(),
+                format!("/deployments?agent_id={AGENT_ID}")
+            ),
+            ("DELETE".to_string(), format!("/deployments/{first}")),
+            ("DELETE".to_string(), format!("/deployments/{failing}")),
+        ],
+        "a failed deployment end must stop all later deletion requests"
+    );
+}
+
+#[tokio::test]
+async fn delete_handler_propagates_a_concurrent_deployment_conflict_without_retry() {
+    let server = serve(|req| match (req.method.as_str(), req.path.as_str()) {
+        ("GET", "/agents") => agent_list(),
+        ("GET", p) if *p == format!("/deployments?agent_id={AGENT_ID}") => {
+            Response::json(200, "[]")
+        }
+        ("DELETE", p) if *p == format!("/agents/{AGENT_ID}") => {
+            Response::json(409, r#"{"detail":"active deployment exists"}"#)
+        }
+        other => panic!("unexpected request: {other:?}"),
+    });
+
+    let err = commands::delete(opts(&server.base_url, "deal-desk", false), true)
+        .await
+        .unwrap_err();
+    assert!(err.to_string().contains("409 Conflict"), "{err}");
+
+    let flow: Vec<(String, String)> = server
+        .recorded()
+        .iter()
+        .map(|request| (request.method.clone(), request.path.clone()))
+        .collect();
+    assert_eq!(
+        flow,
+        vec![
+            ("GET".to_string(), "/agents".to_string()),
+            (
+                "GET".to_string(),
+                format!("/deployments?agent_id={AGENT_ID}")
+            ),
+            ("DELETE".to_string(), format!("/agents/{AGENT_ID}")),
+        ],
+        "the final conflict must not be retried or swallowed"
+    );
+}
+
+#[tokio::test]
+async fn delete_dry_run_returns_the_generic_lifecycle_plan_without_requests() {
+    let server = serve(|req| panic!("dry run must not request, got {} {}", req.method, req.path));
+
+    let out = commands::delete(opts(&server.base_url, "deal-desk", true), false)
+        .await
+        .unwrap();
+    match out {
+        commands::DeleteOutput::DryRun(plan) => assert_eq!(
+            plan.lines,
+            vec![
+                format!(
+                    "GET {}/agents  (would resolve agent {:?})",
+                    server.base_url, "deal-desk"
+                ),
+                format!("GET {}/deployments?agent_id=<id>", server.base_url),
+                format!(
+                    "DELETE {}/deployments/<id>  (for each active deployment)",
+                    server.base_url
+                ),
+                format!("DELETE {}/agents/<id>", server.base_url),
+            ]
+        ),
+        other => panic!("expected dry run output, got {other:?}"),
+    }
+    assert!(
+        server.recorded().is_empty(),
+        "delete dry run must make no request"
     );
 }
 


### PR DESCRIPTION
## Summary

* Adds an authenticated idempotent route that transitions a deployment to `stopped`.
* Makes local and cluster agent deletion end every active deployment before the guarded agent delete.
* Regenerates the API and command contracts.

## Evidence

* [x] Tests were committed before implementation.
* [x] All production edits were performed by delegated native workers.
* [x] No broadened return type remains.
* [x] Code review approved with all findings resolved.
* [x] Scope review found every hunk justified.
* [x] Local and cluster parity share one delete handler.
* [x] Guard behavior was executed: active agent delete returned 409 and unauthenticated deployment teardown returned 401.
* [x] Consolidation removed an unnecessary refresh race and pinned partial failure stopping behavior.
* [x] Security review approved with no new blockers.
* [x] Candidate `69102c24` deployed an agent through the CLI, deleted it without 409, emitted one structured success object, and left zero matching agents.
* [x] API and CLI regression selectors are pinned to product code at `69102c24`.
* [x] Python checks passed, API focused tests passed 18, the complete CLI suite passed, focused CLI tests passed 70, and UI tests passed 147.

Closes #1628