### PR TITLE
Persist CLI deploy commit provenance

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -1239,6 +1239,17 @@
             "title": "Agent Id",
             "type": "string"
           },
+          "commit_sha": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Commit Sha"
+          },
           "environment": {
             "$ref": "#/components/schemas/Environment"
           },
@@ -2803,6 +2814,17 @@
               }
             ],
             "title": "Bundle Ref"
+          },
+          "commit_sha": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Commit Sha"
           },
           "created_by": {
             "title": "Created By",

--- a/apps/api/src/curie_api/commitpoller.py
+++ b/apps/api/src/curie_api/commitpoller.py
@@ -27,10 +27,9 @@ Three properties worth stating, because each is a way this could go wrong:
 - **It polls per REPOSITORY, not per agent.** Several agents share one
   repository (ADR-0091), so per-agent polling would make N identical API calls
   and race N deploys of the same commit against each other.
-- **It never deploys a commit it has already deployed.** The check is the
-  ``commit_sha`` already recorded for that repository, so a restart does not
-  redeploy the current HEAD, and a webhook that already handled a push makes
-  the next poll a no-op.
+- **It never redeploys a commit already deployed by Git flow.** Only Git flow
+  authored versions establish this baseline. A CLI deployment at the same SHA
+  must not suppress the build, evaluation, and deployment owned by Git flow.
 - **One failing repository does not stop the others.** A repo whose credential
   has been revoked, or that has been deleted, must not silently halt polling
   for every other agent on the cluster.
@@ -48,6 +47,7 @@ from typing import Any, Protocol
 import httpx
 
 from .config import Settings
+from .models import GIT_FLOW_CREATED_BY
 
 logger = logging.getLogger(__name__)
 
@@ -245,10 +245,11 @@ class GitHubBranchTip:
         return str(sha) if isinstance(sha, str) else None
 
 
-# The last commit deployed per (repository, environment). Environment rather
-# than branch because that is what a Deployment records; the caller maps
-# environments back to branch names via Settings, the same mapping
-# `environment_for_ref` uses in the other direction.
+# The last Git flow authored commit deployed per (repository, environment).
+# Public CLI artifacts do not settle this baseline. Environment rather than
+# branch because that is what a Deployment records; the caller maps environments
+# back to branch names via Settings, the same mapping `environment_for_ref` uses
+# in the other direction.
 _DEPLOYED_SQL = """
 SELECT DISTINCT ON (a.repo_full_name, d.environment)
        a.repo_full_name AS repo_full_name,
@@ -259,7 +260,7 @@ JOIN {schema}.agents a ON a.id = d.agent_id
 JOIN {schema}.agent_versions v ON v.id = d.version_id
 WHERE a.repo_full_name IS NOT NULL
   AND d.commit_sha IS NOT NULL
-  AND v.created_by = 'git-flow'
+  AND v.created_by = :git_flow_created_by
 ORDER BY a.repo_full_name, d.environment, d.deployed_at DESC
 """
 
@@ -363,7 +364,10 @@ class CommitPoller:
             ):
                 bindings.setdefault(str(repo), []).append(str(agent_name))
             deployed: dict[tuple[str, str], str] = {}
-            for repo, env, sha in await session.execute(text(_DEPLOYED_SQL.format(schema=schema))):
+            deployed_stmt = text(_DEPLOYED_SQL.format(schema=schema)).bindparams(
+                git_flow_created_by=GIT_FLOW_CREATED_BY
+            )
+            for repo, env, sha in await session.execute(deployed_stmt):
                 branch = branch_for_env.get(str(env))
                 if branch:
                     deployed[(str(repo), branch)] = str(sha)

--- a/apps/api/src/curie_api/commitpoller.py
+++ b/apps/api/src/curie_api/commitpoller.py
@@ -246,11 +246,12 @@ class GitHubBranchTip:
 
 
 # The last Git flow authored version commit deployed per (repository, environment).
-# Only matching version and deployment provenance settles this baseline, so
-# public CLI artifacts and console rollbacks do not redefine it. Environment
-# rather than branch because that is what a Deployment records; the caller maps
-# environments back to branch names via Settings, the same mapping
-# `environment_for_ref` uses in the other direction.
+# Only a Git flow authored version with recorded deployment provenance settles
+# this baseline. The authoritative value still comes from the version, so a
+# mutable deployment value cannot redefine it. Environment rather than branch
+# because that is what a Deployment records; the caller maps environments back
+# to branch names via Settings, the same mapping `environment_for_ref` uses in
+# the other direction.
 _DEPLOYED_SQL = """
 SELECT DISTINCT ON (a.repo_full_name, d.environment)
        a.repo_full_name AS repo_full_name,
@@ -260,7 +261,7 @@ FROM {schema}.deployments d
 JOIN {schema}.agents a ON a.id = d.agent_id
 JOIN {schema}.agent_versions v ON v.id = d.version_id
 WHERE a.repo_full_name IS NOT NULL
-  AND d.commit_sha = v.commit_sha
+  AND d.commit_sha IS NOT NULL
   AND v.created_by = :git_flow_created_by
 ORDER BY a.repo_full_name, d.environment, d.deployed_at DESC
 """

--- a/apps/api/src/curie_api/commitpoller.py
+++ b/apps/api/src/curie_api/commitpoller.py
@@ -246,10 +246,11 @@ class GitHubBranchTip:
 
 
 # The last Git flow authored version commit deployed per (repository, environment).
-# Public CLI artifacts do not settle this baseline. Environment rather than
-# branch because that is what a Deployment records; the caller maps environments
-# back to branch names via Settings, the same mapping `environment_for_ref` uses
-# in the other direction.
+# Only matching version and deployment provenance settles this baseline, so
+# public CLI artifacts and console rollbacks do not redefine it. Environment
+# rather than branch because that is what a Deployment records; the caller maps
+# environments back to branch names via Settings, the same mapping
+# `environment_for_ref` uses in the other direction.
 _DEPLOYED_SQL = """
 SELECT DISTINCT ON (a.repo_full_name, d.environment)
        a.repo_full_name AS repo_full_name,
@@ -259,7 +260,7 @@ FROM {schema}.deployments d
 JOIN {schema}.agents a ON a.id = d.agent_id
 JOIN {schema}.agent_versions v ON v.id = d.version_id
 WHERE a.repo_full_name IS NOT NULL
-  AND v.commit_sha IS NOT NULL
+  AND d.commit_sha = v.commit_sha
   AND v.created_by = :git_flow_created_by
 ORDER BY a.repo_full_name, d.environment, d.deployed_at DESC
 """

--- a/apps/api/src/curie_api/commitpoller.py
+++ b/apps/api/src/curie_api/commitpoller.py
@@ -256,7 +256,10 @@ SELECT DISTINCT ON (a.repo_full_name, d.environment)
        d.commit_sha     AS commit_sha
 FROM {schema}.deployments d
 JOIN {schema}.agents a ON a.id = d.agent_id
-WHERE a.repo_full_name IS NOT NULL AND d.commit_sha IS NOT NULL
+JOIN {schema}.agent_versions v ON v.id = d.version_id
+WHERE a.repo_full_name IS NOT NULL
+  AND d.commit_sha IS NOT NULL
+  AND v.created_by = 'git-flow'
 ORDER BY a.repo_full_name, d.environment, d.deployed_at DESC
 """
 

--- a/apps/api/src/curie_api/commitpoller.py
+++ b/apps/api/src/curie_api/commitpoller.py
@@ -259,7 +259,7 @@ FROM {schema}.deployments d
 JOIN {schema}.agents a ON a.id = d.agent_id
 JOIN {schema}.agent_versions v ON v.id = d.version_id
 WHERE a.repo_full_name IS NOT NULL
-  AND d.commit_sha IS NOT NULL
+  AND v.commit_sha IS NOT NULL
   AND v.created_by = :git_flow_created_by
 ORDER BY a.repo_full_name, d.environment, d.deployed_at DESC
 """

--- a/apps/api/src/curie_api/commitpoller.py
+++ b/apps/api/src/curie_api/commitpoller.py
@@ -245,7 +245,7 @@ class GitHubBranchTip:
         return str(sha) if isinstance(sha, str) else None
 
 
-# The last Git flow authored commit deployed per (repository, environment).
+# The last Git flow authored version commit deployed per (repository, environment).
 # Public CLI artifacts do not settle this baseline. Environment rather than
 # branch because that is what a Deployment records; the caller maps environments
 # back to branch names via Settings, the same mapping `environment_for_ref` uses
@@ -254,7 +254,7 @@ _DEPLOYED_SQL = """
 SELECT DISTINCT ON (a.repo_full_name, d.environment)
        a.repo_full_name AS repo_full_name,
        d.environment    AS environment,
-       d.commit_sha     AS commit_sha
+       v.commit_sha     AS commit_sha
 FROM {schema}.deployments d
 JOIN {schema}.agents a ON a.id = d.agent_id
 JOIN {schema}.agent_versions v ON v.id = d.version_id

--- a/apps/api/src/curie_api/crud.py
+++ b/apps/api/src/curie_api/crud.py
@@ -300,6 +300,7 @@ async def create_version(
         agent_id,
         version_label=data.version_label,
         created_by=data.created_by,
+        commit_sha=data.commit_sha,
         bundle_ref=data.bundle_ref,
     )
 
@@ -352,6 +353,7 @@ async def create_deployment(session: AsyncSession, data: DeploymentCreate) -> De
         agent_id=data.agent_id,
         version_id=data.version_id,
         environment=data.environment,
+        commit_sha=data.commit_sha,
         status=data.status,
     )
 
@@ -903,4 +905,3 @@ async def revoke_console_session(
     await session.commit()
     await session.refresh(row)
     return row
-

--- a/apps/api/src/curie_api/crud.py
+++ b/apps/api/src/curie_api/crud.py
@@ -306,12 +306,13 @@ async def create_version(
 
 
 async def get_version_by_commit(
-    session: AsyncSession, agent_id: uuid.UUID, commit_sha: str
+    session: AsyncSession, agent_id: uuid.UUID, commit_sha: str, created_by: str
 ) -> AgentVersion | None:
     version: AgentVersion | None = await session.scalar(
         select(AgentVersion).where(
             AgentVersion.agent_id == agent_id,
             AgentVersion.commit_sha == commit_sha,
+            AgentVersion.created_by == created_by,
         )
     )
     return version

--- a/apps/api/src/curie_api/gitflow.py
+++ b/apps/api/src/curie_api/gitflow.py
@@ -426,7 +426,9 @@ async def process_push(
         # correct and is what an unmatched branch already does.
         return WebhookResult(status="ignored")
 
-    version = await crud.get_version_by_commit(session, agent.id, after)
+    version = await crud.get_version_by_commit(
+        session, agent.id, after, created_by="git-flow"
+    )
     # Only a version whose bundle is actually stored may be reused for promote.
     # A row with bundle_ref still None is the residue of a prior attempt that
     # failed after the row committed; rebuild and store into it rather than
@@ -645,7 +647,9 @@ async def _sibling_bundle(
     for sibling in repo_agents:
         if sibling.id == agent_id:
             continue
-        existing = await crud.get_version_by_commit(session, sibling.id, commit_sha)
+        existing = await crud.get_version_by_commit(
+            session, sibling.id, commit_sha, created_by="git-flow"
+        )
         if existing is not None and existing.bundle_ref:
             return existing
     return None

--- a/apps/api/src/curie_api/gitflow.py
+++ b/apps/api/src/curie_api/gitflow.py
@@ -32,7 +32,7 @@ from . import bundles, crud, deploy
 from .config import Settings
 from .evalqueue import EvalQueue, now_iso
 from .github_app import credentials_for
-from .models import Agent, AgentVersion, Environment
+from .models import GIT_FLOW_CREATED_BY, Agent, AgentVersion, Environment
 from .schemas import WebhookResult
 from .storage import ObjectStore
 
@@ -427,7 +427,7 @@ async def process_push(
         return WebhookResult(status="ignored")
 
     version = await crud.get_version_by_commit(
-        session, agent.id, after, created_by="git-flow"
+        session, agent.id, after, created_by=GIT_FLOW_CREATED_BY
     )
     # Only a version whose bundle is actually stored may be reused for promote.
     # A row with bundle_ref still None is the residue of a prior attempt that
@@ -442,15 +442,16 @@ async def process_push(
                 session,
                 agent.id,
                 version_label=after[:12],
-                created_by="git-flow",
+                created_by=GIT_FLOW_CREATED_BY,
                 commit_sha=after,
             )
         # Bundle-once, bind-many (ADR-0091). A sibling agent in this repository
-        # may already hold this exact commit -- the dev push that ran minutes
-        # ago. Reuse its stored object rather than uploading the same bytes
-        # again: prod then promotes not merely an identical artifact but the
-        # SAME one, which is what makes "promote what you validated" a property
-        # of the schema rather than of discipline.
+        # may already hold this exact Git flow authored commit from the dev push
+        # that ran minutes ago. Only that provenance may be reused for promote.
+        # Reuse its stored object rather than uploading the same bytes again:
+        # prod then promotes not merely an identical artifact but the SAME one,
+        # which is what makes "promote what you validated" a property of the
+        # schema rather than of discipline.
         sibling = await _sibling_bundle(session, repo_agents, agent.id, after)
         if sibling is not None:
             version = await crud.attach_bundle(
@@ -648,7 +649,7 @@ async def _sibling_bundle(
         if sibling.id == agent_id:
             continue
         existing = await crud.get_version_by_commit(
-            session, sibling.id, commit_sha, created_by="git-flow"
+            session, sibling.id, commit_sha, created_by=GIT_FLOW_CREATED_BY
         )
         if existing is not None and existing.bundle_ref:
             return existing

--- a/apps/api/src/curie_api/models.py
+++ b/apps/api/src/curie_api/models.py
@@ -16,6 +16,8 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from .db import SCHEMA, Base
 
+GIT_FLOW_CREATED_BY = "git-flow"
+
 
 class Environment(enum.StrEnum):
     prod = "prod"
@@ -418,4 +420,3 @@ class ConsoleSession(Base):
     consumed_at: Mapped[datetime | None] = mapped_column(default=None)
     revoked_at: Mapped[datetime | None] = mapped_column(default=None)
     created_at: Mapped[datetime] = mapped_column(server_default=func.now())
-

--- a/apps/api/src/curie_api/schemas.py
+++ b/apps/api/src/curie_api/schemas.py
@@ -901,6 +901,7 @@ class EvalCaseOut(BaseModel):
 class VersionCreate(BaseModel):
     version_label: str
     bundle_ref: str | None = None
+    commit_sha: str | None = None
     created_by: str
 
 
@@ -1004,6 +1005,7 @@ class DeploymentCreate(BaseModel):
     agent_id: uuid.UUID
     version_id: uuid.UUID
     environment: Environment
+    commit_sha: str | None = None
     status: str = "active"
 
 

--- a/apps/api/src/curie_api/schemas.py
+++ b/apps/api/src/curie_api/schemas.py
@@ -28,7 +28,7 @@ from pydantic import (
 )
 
 from .config import get_settings
-from .models import Environment
+from .models import GIT_FLOW_CREATED_BY, Environment
 
 # Slack channel IDs start with C (public/private channel), D (DM), or G (legacy
 # private group) followed by uppercase-alphanumeric chars. Allowlist-shaped on
@@ -903,6 +903,13 @@ class VersionCreate(BaseModel):
     bundle_ref: str | None = None
     commit_sha: str | None = None
     created_by: str
+
+    @field_validator("created_by")
+    @classmethod
+    def reject_internal_provenance(cls, value: str) -> str:
+        if value == GIT_FLOW_CREATED_BY:
+            raise ValueError("created_by is reserved for internal Git flow versions")
+        return value
 
 
 class VersionOut(BaseModel):

--- a/apps/api/src/curie_api/schemas.py
+++ b/apps/api/src/curie_api/schemas.py
@@ -123,6 +123,14 @@ def _nullable_override_validator(field: str, examples: str) -> Callable[[str | N
     return _validate
 
 
+def _validate_optional_commit_sha(value: str | None) -> str | None:
+    if value is None:
+        return None
+    if not value.strip():
+        raise ValueError("commit_sha must not be empty; omit it when unavailable")
+    return value.strip()
+
+
 _validate_thinking_override = _nullable_override_validator(
     "thinking", "a value like 'disabled', 'adaptive' or 'enabled:2000'"
 )
@@ -904,6 +912,8 @@ class VersionCreate(BaseModel):
     commit_sha: str | None = None
     created_by: str
 
+    _check_commit_sha = field_validator("commit_sha")(_validate_optional_commit_sha)
+
     @field_validator("created_by")
     @classmethod
     def reject_internal_provenance(cls, value: str) -> str:
@@ -1014,6 +1024,8 @@ class DeploymentCreate(BaseModel):
     environment: Environment
     commit_sha: str | None = None
     status: str = "active"
+
+    _check_commit_sha = field_validator("commit_sha")(_validate_optional_commit_sha)
 
 
 class DeploymentOut(BaseModel):

--- a/apps/api/tests/test_commitpoller.py
+++ b/apps/api/tests/test_commitpoller.py
@@ -149,6 +149,72 @@ async def test_poll_once_sends_the_derived_clone_url_not_an_arbitrary_one(
     assert [p["repository"]["clone_url"] for p in seen] == [derived]
 
 
+@pytest.mark.anyio
+async def test_a_cli_deployment_at_the_branch_tip_does_not_suppress_git_flow(
+    clean_db: None, monkeypatch
+) -> None:
+    """A CLI archive at a Git SHA must not settle the Git flow poll baseline.
+
+    Git flow owns the branch deploy and development eval fan out. This drives
+    the real deployment baseline query because replacing the session would let
+    a provenance filter pass without ever exercising its SQL.
+    """
+
+    from curie_api import gitflow
+    from curie_api.commitpoller import CommitPoller
+    from curie_api.config import Settings
+    from curie_api.models import Agent, AgentVersion, Deployment, Environment
+    from curie_api.schemas import WebhookResult
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    sha = "branch-tip"
+    engine = create_async_engine(get_settings().database_url)
+    sessionmaker = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with sessionmaker() as session:
+            agent = Agent(name="poller-cli-baseline", repo_full_name=REPO)
+            session.add(agent)
+            await session.flush()
+            version = AgentVersion(
+                agent_id=agent.id,
+                version_label="cli-working-tree",
+                created_by="cli",
+                commit_sha=sha,
+            )
+            session.add(version)
+            await session.flush()
+            session.add(
+                Deployment(
+                    agent_id=agent.id,
+                    version_id=version.id,
+                    environment=Environment.dev,
+                    commit_sha=sha,
+                )
+            )
+            await session.commit()
+
+        pushes: list[dict] = []
+
+        async def capture(session, store, settings, eval_queue, payload):
+            pushes.append(payload)
+            return WebhookResult(status="deployed")
+
+        monkeypatch.setattr(gitflow, "process_push", capture)
+        poller = CommitPoller(
+            session_factory=sessionmaker,
+            store=object(),
+            settings=Settings(github_clone_base="https://github.com"),
+            eval_queue=object(),
+            tips=Tips({(REPO, "dev"): sha, (REPO, "main"): None}),
+            interval_seconds=60,
+        )
+        await poller.poll_once()
+    finally:
+        await engine.dispose()
+
+    assert [payload["after"] for payload in pushes] == [sha]
+
+
 @pytest.mark.parametrize("branches", [(), ("dev",), ("dev", "main")])
 def test_no_targets_or_no_branches_is_quiet(branches: tuple[str, ...]) -> None:
     tips = Tips({})

--- a/apps/api/tests/test_commitpoller.py
+++ b/apps/api/tests/test_commitpoller.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+from datetime import datetime, timedelta
 
 import httpx
 import pytest
@@ -219,7 +220,7 @@ async def test_a_cli_deployment_at_the_branch_tip_does_not_suppress_git_flow(
 async def test_a_git_flow_deployment_at_the_branch_tip_settles_the_poll_baseline(
     clean_db: None, monkeypatch
 ) -> None:
-    """The Git flow version is durable even without a deployment SHA copy."""
+    """Matching Git flow provenance is the poller's durable baseline."""
 
     from curie_api import gitflow
     from curie_api.commitpoller import CommitPoller
@@ -249,7 +250,7 @@ async def test_a_git_flow_deployment_at_the_branch_tip_settles_the_poll_baseline
                     agent_id=agent.id,
                     version_id=version.id,
                     environment=Environment.dev,
-                    commit_sha=None,
+                    commit_sha=sha,
                 )
             )
             await session.commit()
@@ -267,6 +268,92 @@ async def test_a_git_flow_deployment_at_the_branch_tip_settles_the_poll_baseline
             settings=Settings(github_clone_base="https://github.com"),
             eval_queue=object(),
             tips=Tips({(REPO, "dev"): sha, (REPO, "main"): None}),
+            interval_seconds=60,
+        )
+        await poller.poll_once()
+    finally:
+        await engine.dispose()
+
+    assert pushes == []
+
+
+@pytest.mark.anyio
+async def test_a_console_rollback_does_not_redefine_the_git_flow_poll_baseline(
+    clean_db: None, monkeypatch
+) -> None:
+    """A newer null deployment cannot replace the last Git flow baseline."""
+
+    from curie_api import gitflow
+    from curie_api.commitpoller import CommitPoller
+    from curie_api.config import Settings
+    from curie_api.models import Agent, AgentVersion, Deployment, Environment
+    from curie_api.schemas import WebhookResult
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    older_sha = "git-flow-commit-a"
+    current_sha = "git-flow-commit-b"
+    deployed_at = datetime(2026, 1, 1)
+    engine = create_async_engine(get_settings().database_url)
+    sessionmaker = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with sessionmaker() as session:
+            agent = Agent(name="poller-console-rollback", repo_full_name=REPO)
+            session.add(agent)
+            await session.flush()
+            older = AgentVersion(
+                agent_id=agent.id,
+                version_label="git-flow-commit-a",
+                created_by="git-flow",
+                commit_sha=older_sha,
+            )
+            current = AgentVersion(
+                agent_id=agent.id,
+                version_label="git-flow-commit-b",
+                created_by="git-flow",
+                commit_sha=current_sha,
+            )
+            session.add_all([older, current])
+            await session.flush()
+            session.add_all(
+                [
+                    Deployment(
+                        agent_id=agent.id,
+                        version_id=older.id,
+                        environment=Environment.dev,
+                        commit_sha=older_sha,
+                        deployed_at=deployed_at,
+                    ),
+                    Deployment(
+                        agent_id=agent.id,
+                        version_id=current.id,
+                        environment=Environment.dev,
+                        commit_sha=current_sha,
+                        deployed_at=deployed_at + timedelta(seconds=1),
+                    ),
+                    Deployment(
+                        agent_id=agent.id,
+                        version_id=older.id,
+                        environment=Environment.dev,
+                        commit_sha=None,
+                        deployed_at=deployed_at + timedelta(seconds=2),
+                    ),
+                ]
+            )
+            await session.commit()
+
+        pushes: list[dict] = []
+
+        async def capture(session, store, settings, eval_queue, payload):
+            pushes.append(payload)
+            return WebhookResult(status="deployed")
+
+        monkeypatch.setattr(gitflow, "process_push", capture)
+        poller = CommitPoller(
+            session_factory=sessionmaker,
+            store=object(),
+            settings=Settings(github_clone_base="https://github.com"),
+            eval_queue=object(),
+            tips=Tips({(REPO, "dev"): current_sha, (REPO, "main"): None}),
             interval_seconds=60,
         )
         await poller.poll_once()

--- a/apps/api/tests/test_commitpoller.py
+++ b/apps/api/tests/test_commitpoller.py
@@ -219,7 +219,7 @@ async def test_a_cli_deployment_at_the_branch_tip_does_not_suppress_git_flow(
 async def test_a_git_flow_deployment_at_the_branch_tip_settles_the_poll_baseline(
     clean_db: None, monkeypatch
 ) -> None:
-    """The matching Git flow deployment is the poller's durable baseline."""
+    """The Git flow version is durable even without a deployment SHA copy."""
 
     from curie_api import gitflow
     from curie_api.commitpoller import CommitPoller
@@ -249,7 +249,7 @@ async def test_a_git_flow_deployment_at_the_branch_tip_settles_the_poll_baseline
                     agent_id=agent.id,
                     version_id=version.id,
                     environment=Environment.dev,
-                    commit_sha=sha,
+                    commit_sha=None,
                 )
             )
             await session.commit()

--- a/apps/api/tests/test_commitpoller.py
+++ b/apps/api/tests/test_commitpoller.py
@@ -215,6 +215,67 @@ async def test_a_cli_deployment_at_the_branch_tip_does_not_suppress_git_flow(
     assert [payload["after"] for payload in pushes] == [sha]
 
 
+@pytest.mark.anyio
+async def test_a_git_flow_deployment_at_the_branch_tip_settles_the_poll_baseline(
+    clean_db: None, monkeypatch
+) -> None:
+    """The matching Git flow deployment is the poller's durable baseline."""
+
+    from curie_api import gitflow
+    from curie_api.commitpoller import CommitPoller
+    from curie_api.config import Settings
+    from curie_api.models import Agent, AgentVersion, Deployment, Environment
+    from curie_api.schemas import WebhookResult
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    sha = "branch-tip"
+    engine = create_async_engine(get_settings().database_url)
+    sessionmaker = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with sessionmaker() as session:
+            agent = Agent(name="poller-git-flow-baseline", repo_full_name=REPO)
+            session.add(agent)
+            await session.flush()
+            version = AgentVersion(
+                agent_id=agent.id,
+                version_label="git-flow-branch-tip",
+                created_by="git-flow",
+                commit_sha=sha,
+            )
+            session.add(version)
+            await session.flush()
+            session.add(
+                Deployment(
+                    agent_id=agent.id,
+                    version_id=version.id,
+                    environment=Environment.dev,
+                    commit_sha=sha,
+                )
+            )
+            await session.commit()
+
+        pushes: list[dict] = []
+
+        async def capture(session, store, settings, eval_queue, payload):
+            pushes.append(payload)
+            return WebhookResult(status="deployed")
+
+        monkeypatch.setattr(gitflow, "process_push", capture)
+        poller = CommitPoller(
+            session_factory=sessionmaker,
+            store=object(),
+            settings=Settings(github_clone_base="https://github.com"),
+            eval_queue=object(),
+            tips=Tips({(REPO, "dev"): sha, (REPO, "main"): None}),
+            interval_seconds=60,
+        )
+        await poller.poll_once()
+    finally:
+        await engine.dispose()
+
+    assert pushes == []
+
+
 @pytest.mark.parametrize("branches", [(), ("dev",), ("dev", "main")])
 def test_no_targets_or_no_branches_is_quiet(branches: tuple[str, ...]) -> None:
     tips = Tips({})

--- a/apps/api/tests/test_commitpoller.py
+++ b/apps/api/tests/test_commitpoller.py
@@ -276,6 +276,68 @@ async def test_a_git_flow_deployment_at_the_branch_tip_settles_the_poll_baseline
     assert pushes == []
 
 
+@pytest.mark.anyio
+async def test_a_deployment_sha_does_not_forge_a_git_flow_poll_baseline(
+    clean_db: None, monkeypatch
+) -> None:
+    """A Git flow version's commit is the baseline, not a mutable deployment SHA."""
+
+    from curie_api import gitflow
+    from curie_api.commitpoller import CommitPoller
+    from curie_api.config import Settings
+    from curie_api.models import Agent, AgentVersion, Deployment, Environment
+    from curie_api.schemas import WebhookResult
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    version_sha = "git-flow-commit-a"
+    deployment_sha = "deployment-commit-b"
+    engine = create_async_engine(get_settings().database_url)
+    sessionmaker = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with sessionmaker() as session:
+            agent = Agent(name="poller-forged-deployment-baseline", repo_full_name=REPO)
+            session.add(agent)
+            await session.flush()
+            version = AgentVersion(
+                agent_id=agent.id,
+                version_label="git-flow-commit-a",
+                created_by="git-flow",
+                commit_sha=version_sha,
+            )
+            session.add(version)
+            await session.flush()
+            session.add(
+                Deployment(
+                    agent_id=agent.id,
+                    version_id=version.id,
+                    environment=Environment.dev,
+                    commit_sha=deployment_sha,
+                )
+            )
+            await session.commit()
+
+        pushes: list[dict] = []
+
+        async def capture(session, store, settings, eval_queue, payload):
+            pushes.append(payload)
+            return WebhookResult(status="deployed")
+
+        monkeypatch.setattr(gitflow, "process_push", capture)
+        poller = CommitPoller(
+            session_factory=sessionmaker,
+            store=object(),
+            settings=Settings(github_clone_base="https://github.com"),
+            eval_queue=object(),
+            tips=Tips({(REPO, "dev"): deployment_sha, (REPO, "main"): None}),
+            interval_seconds=60,
+        )
+        await poller.poll_once()
+    finally:
+        await engine.dispose()
+
+    assert [payload["after"] for payload in pushes] == [deployment_sha]
+
+
 @pytest.mark.parametrize("branches", [(), ("dev",), ("dev", "main")])
 def test_no_targets_or_no_branches_is_quiet(branches: tuple[str, ...]) -> None:
     tips = Tips({})

--- a/apps/api/tests/test_commitpoller.py
+++ b/apps/api/tests/test_commitpoller.py
@@ -415,14 +415,14 @@ async def test_a_deployment_sha_does_not_forge_a_git_flow_poll_baseline(
             store=object(),
             settings=Settings(github_clone_base="https://github.com"),
             eval_queue=object(),
-            tips=Tips({(REPO, "dev"): deployment_sha, (REPO, "main"): None}),
+            tips=Tips({(REPO, "dev"): version_sha, (REPO, "main"): None}),
             interval_seconds=60,
         )
         await poller.poll_once()
     finally:
         await engine.dispose()
 
-    assert [payload["after"] for payload in pushes] == [deployment_sha]
+    assert pushes == []
 
 
 @pytest.mark.parametrize("branches", [(), ("dev",), ("dev", "main")])

--- a/apps/api/tests/test_crud.py
+++ b/apps/api/tests/test_crud.py
@@ -147,6 +147,29 @@ def test_version_and_deployment_persist_same_commit_sha(
     assert listed_deployments[0]["commit_sha"] == commit_sha
 
 
+def test_public_version_create_rejects_git_flow_provenance(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    agent = client.post(
+        "/agents",
+        json={
+            "name": "provenance_guard",
+            "channel": {"kind": "slack", "address": "C0EXAMPLE1"},
+        },
+        headers=auth_headers,
+    ).json()
+    agent_id = agent["id"]
+
+    version_resp = client.post(
+        f"/agents/{agent_id}/versions",
+        json={"version_label": "v1", "created_by": "git-flow"},
+        headers=auth_headers,
+    )
+
+    assert version_resp.status_code == 422, version_resp.text
+    assert client.get(f"/agents/{agent_id}/versions", headers=auth_headers).json() == []
+
+
 # The eval trigger fallback requires deployment provenance to remain independent.
 def test_version_and_deployment_persist_distinct_commit_shas(
     client: Any, auth_headers: dict[str, str], clean_db: None

--- a/apps/api/tests/test_crud.py
+++ b/apps/api/tests/test_crud.py
@@ -48,6 +48,7 @@ def test_full_round_trip(
     version = resp.json()
     version_id = version["id"]
     assert version["bundle_ref"] is None
+    assert version["commit_sha"] is None
     assert version["agent_id"] == agent_id
 
     # deploy to dev
@@ -65,6 +66,7 @@ def test_full_round_trip(
     deployment_id = deployment["id"]
     assert deployment["environment"] == "dev"
     assert deployment["status"] == "active"
+    assert deployment["commit_sha"] is None
 
     # list + get every resource
     listed_agents = client.get("/agents", headers=auth_headers).json()
@@ -78,17 +80,122 @@ def test_full_round_trip(
         f"/agents/{agent_id}/versions", headers=auth_headers
     ).json()
     assert [v["id"] for v in listed_versions] == [version_id]
+    assert listed_versions[0]["commit_sha"] is None
 
     listed_deployments = client.get(
         "/deployments", params={"agent_id": agent_id}, headers=auth_headers
     ).json()
     assert [d["id"] for d in listed_deployments] == [deployment_id]
+    assert listed_deployments[0]["commit_sha"] is None
 
     got_deployment = client.get(
         f"/deployments/{deployment_id}", headers=auth_headers
     )
     assert got_deployment.status_code == 200
     assert got_deployment.json()["version_id"] == version_id
+    assert got_deployment.json()["commit_sha"] is None
+
+
+def test_version_and_deployment_persist_same_commit_sha(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    commit_sha = "0123456789abcdef0123456789abcdef01234567"
+    agent = client.post(
+        "/agents",
+        json={
+            "name": "commit_same",
+            "channel": {"kind": "slack", "address": "C0EXAMPLE1"},
+        },
+        headers=auth_headers,
+    ).json()
+    agent_id = agent["id"]
+
+    version_resp = client.post(
+        f"/agents/{agent_id}/versions",
+        json={
+            "version_label": "v1",
+            "created_by": "bconn",
+            "commit_sha": commit_sha,
+        },
+        headers=auth_headers,
+    )
+    assert version_resp.status_code == 201, version_resp.text
+    version = version_resp.json()
+    assert version["commit_sha"] == commit_sha
+
+    deployment_resp = client.post(
+        "/deployments",
+        json={
+            "agent_id": agent_id,
+            "version_id": version["id"],
+            "environment": "dev",
+            "commit_sha": commit_sha,
+        },
+        headers=auth_headers,
+    )
+    assert deployment_resp.status_code == 201, deployment_resp.text
+    deployment = deployment_resp.json()
+    assert deployment["commit_sha"] == commit_sha
+
+    listed_versions = client.get(
+        f"/agents/{agent_id}/versions", headers=auth_headers
+    ).json()
+    assert listed_versions[0]["commit_sha"] == commit_sha
+    listed_deployments = client.get(
+        "/deployments", params={"agent_id": agent_id}, headers=auth_headers
+    ).json()
+    assert listed_deployments[0]["commit_sha"] == commit_sha
+
+
+def test_version_and_deployment_persist_distinct_commit_shas(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    version_sha = "0123456789abcdef0123456789abcdef01234567"
+    deployment_sha = "89abcdef0123456789abcdef0123456789abcdef"
+    agent = client.post(
+        "/agents",
+        json={
+            "name": "commit_distinct",
+            "channel": {"kind": "slack", "address": "C0EXAMPLE1"},
+        },
+        headers=auth_headers,
+    ).json()
+    agent_id = agent["id"]
+
+    version_resp = client.post(
+        f"/agents/{agent_id}/versions",
+        json={
+            "version_label": "v1",
+            "created_by": "bconn",
+            "commit_sha": version_sha,
+        },
+        headers=auth_headers,
+    )
+    assert version_resp.status_code == 201, version_resp.text
+    version = version_resp.json()
+
+    deployment_resp = client.post(
+        "/deployments",
+        json={
+            "agent_id": agent_id,
+            "version_id": version["id"],
+            "environment": "dev",
+            "commit_sha": deployment_sha,
+        },
+        headers=auth_headers,
+    )
+    assert deployment_resp.status_code == 201, deployment_resp.text
+    deployment = deployment_resp.json()
+
+    listed_versions = client.get(
+        f"/agents/{agent_id}/versions", headers=auth_headers
+    ).json()
+    assert listed_versions[0]["commit_sha"] == version_sha
+    got_deployment = client.get(
+        f"/deployments/{deployment['id']}", headers=auth_headers
+    )
+    assert got_deployment.status_code == 200, got_deployment.text
+    assert got_deployment.json()["commit_sha"] == deployment_sha
 
 
 def test_missing_agent_returns_404(

--- a/apps/api/tests/test_crud.py
+++ b/apps/api/tests/test_crud.py
@@ -147,6 +147,7 @@ def test_version_and_deployment_persist_same_commit_sha(
     assert listed_deployments[0]["commit_sha"] == commit_sha
 
 
+# The eval trigger fallback requires deployment provenance to remain independent.
 def test_version_and_deployment_persist_distinct_commit_shas(
     client: Any, auth_headers: dict[str, str], clean_db: None
 ) -> None:

--- a/apps/api/tests/test_crud.py
+++ b/apps/api/tests/test_crud.py
@@ -170,6 +170,46 @@ def test_public_version_create_rejects_git_flow_provenance(
     assert client.get(f"/agents/{agent_id}/versions", headers=auth_headers).json() == []
 
 
+def test_version_and_deployment_create_reject_blank_commit_sha(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    agent = client.post(
+        "/agents",
+        json={
+            "name": "commit_sha_guard",
+            "channel": {"kind": "slack", "address": "C0EXAMPLE1"},
+        },
+        headers=auth_headers,
+    ).json()
+    agent_id = agent["id"]
+
+    for value in ("", "   "):
+        response = client.post(
+            f"/agents/{agent_id}/versions",
+            json={"version_label": "invalid", "created_by": "bconn", "commit_sha": value},
+            headers=auth_headers,
+        )
+        assert response.status_code == 422, response.text
+
+    version = client.post(
+        f"/agents/{agent_id}/versions",
+        json={"version_label": "valid", "created_by": "bconn"},
+        headers=auth_headers,
+    ).json()
+    for value in ("", "   "):
+        response = client.post(
+            "/deployments",
+            json={
+                "agent_id": agent_id,
+                "version_id": version["id"],
+                "environment": "dev",
+                "commit_sha": value,
+            },
+            headers=auth_headers,
+        )
+        assert response.status_code == 422, response.text
+
+
 # The eval trigger fallback requires deployment provenance to remain independent.
 def test_version_and_deployment_persist_distinct_commit_shas(
     client: Any, auth_headers: dict[str, str], clean_db: None

--- a/apps/api/tests/test_gitflow_integration.py
+++ b/apps/api/tests/test_gitflow_integration.py
@@ -14,15 +14,19 @@ here is a test-only code branch.
 import asyncio
 import hashlib
 import hmac
+import io
 import json
 import os
 import subprocess
+import tarfile
 import uuid
 from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
 import pytest
+import redis
+from aci_protocol import STREAM_PAYLOAD_FIELD
 from curie_api import bundles, crud
 from curie_api.config import get_settings
 from curie_test_support.scaffold import scaffolded_deploy_yaml
@@ -338,6 +342,79 @@ def test_partial_version_is_rebuilt_not_reused(
     assert len(versions) == 1
     assert versions[0]["commit_sha"] == sha
     assert versions[0]["bundle_ref"] is not None
+
+
+def test_dev_push_does_not_reuse_a_cli_bundle_with_the_same_commit_sha(
+    client: Any,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    trusted_clone_base: Path,
+) -> None:
+    """A git push must build its own artifact and fan out its normal eval."""
+
+    agent_id = _register_agent(client, auth_headers)
+    clone_url, sha = _build_bare_repo(trusted_clone_base, REPO, VALID_FILES)
+
+    cli_version = client.post(
+        f"/agents/{agent_id}/versions",
+        json={
+            "version_label": "cli-working-tree",
+            "created_by": "cli",
+            "commit_sha": sha,
+        },
+        headers=auth_headers,
+    )
+    assert cli_version.status_code == 201, cli_version.text
+    cli_version_id = cli_version.json()["id"]
+
+    cli_files = {
+        **VALID_FILES,
+        "skills/alpha/SKILL.md": "---\nname: alpha\ndescription: cli working tree\n---\n",
+    }
+    cli_archive = io.BytesIO()
+    with tarfile.open(fileobj=cli_archive, mode="w:gz") as archive:
+        for rel, content in cli_files.items():
+            data = content.encode()
+            info = tarfile.TarInfo(f"cli-working-tree/{rel}")
+            info.size = len(data)
+            archive.addfile(info, io.BytesIO(data))
+    upload = client.put(
+        f"/agents/{agent_id}/versions/{cli_version_id}/bundle",
+        files={"file": ("cli-working-tree.tar.gz", cli_archive.getvalue())},
+        headers=auth_headers,
+    )
+    assert upload.status_code == 201, upload.text
+    cli_bundle_ref = upload.json()["bundle_ref"]
+
+    response = _post(client, "push", _push_payload("refs/heads/dev", sha, clone_url))
+    assert response.status_code == 200, response.text
+    assert response.json()["status"] == "deployed"
+
+    versions = client.get(f"/agents/{agent_id}/versions", headers=auth_headers).json()
+    git_versions = [version for version in versions if version["created_by"] == "git-flow"]
+    assert len(git_versions) == 1, versions
+    git_version = git_versions[0]
+    assert git_version["id"] != cli_version_id
+    assert git_version["bundle_ref"] != cli_bundle_ref
+
+    stored = client.get(
+        f"/agents/{agent_id}/versions/{git_version['id']}/bundle", headers=auth_headers
+    )
+    assert stored.status_code == 200, stored.text
+    assert stored.content != cli_archive.getvalue()
+
+    stream = redis.from_url(get_settings().valkey_dsn())
+    try:
+        eval_jobs = [
+            json.loads(fields[STREAM_PAYLOAD_FIELD.encode()])
+            for _id, fields in stream.xrevrange("curie:evals", count=200)
+            if json.loads(fields[STREAM_PAYLOAD_FIELD.encode()]).get("agent_id") == agent_id
+        ]
+    finally:
+        stream.close()
+    assert len(eval_jobs) == 1, eval_jobs
+    assert eval_jobs[0]["version_id"] == git_version["id"]
+    assert eval_jobs[0]["sha"] == sha
 
 
 def test_invalid_signature_is_401(

--- a/apps/api/tests/test_gitflow_integration.py
+++ b/apps/api/tests/test_gitflow_integration.py
@@ -691,6 +691,67 @@ def test_prod_promotes_the_exact_artifact_dev_validated(
     assert dev_version["commit_sha"] == prod_version["commit_sha"] == sha
 
 
+def test_dev_push_does_not_reuse_a_cli_bundle_from_a_sibling_agent(
+    client: Any,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    trusted_clone_base: Path,
+) -> None:
+    dev_id = _register(client, auth_headers, "two-agent-dev", "C000000D01")
+    prod_id = _register(client, auth_headers, "two-agent-prod", "C000000E01")
+    clone_url, sha = _build_bare_repo(trusted_clone_base, REPO, TWO_TARGET_FILES)
+
+    cli_version = client.post(
+        f"/agents/{prod_id}/versions",
+        json={
+            "version_label": "cli-sibling-working-tree",
+            "created_by": "cli",
+            "commit_sha": sha,
+        },
+        headers=auth_headers,
+    )
+    assert cli_version.status_code == 201, cli_version.text
+    cli_version_id = cli_version.json()["id"]
+
+    cli_files = {
+        **TWO_TARGET_FILES,
+        "skills/alpha/SKILL.md": "---\nname: alpha\ndescription: cli sibling tree\n---\n",
+    }
+    cli_archive = io.BytesIO()
+    with tarfile.open(fileobj=cli_archive, mode="w:gz") as archive:
+        for rel, content in cli_files.items():
+            data = content.encode()
+            info = tarfile.TarInfo(f"cli-sibling/{rel}")
+            info.size = len(data)
+            archive.addfile(info, io.BytesIO(data))
+    upload = client.put(
+        f"/agents/{prod_id}/versions/{cli_version_id}/bundle",
+        files={"file": ("cli-sibling.tar.gz", cli_archive.getvalue())},
+        headers=auth_headers,
+    )
+    assert upload.status_code == 201, upload.text
+    cli_bundle_ref = upload.json()["bundle_ref"]
+
+    response = _post(client, "push", _push_payload("refs/heads/dev", sha, clone_url))
+    assert response.status_code == 200, response.text
+    assert response.json()["status"] == "deployed"
+
+    versions = client.get(f"/agents/{dev_id}/versions", headers=auth_headers).json()
+    assert len(versions) == 1, versions
+    git_version = versions[0]
+    assert git_version["created_by"] == "git-flow"
+    assert git_version["bundle_ref"] != cli_bundle_ref
+
+    stored = client.get(
+        f"/agents/{dev_id}/versions/{git_version['id']}/bundle", headers=auth_headers
+    )
+    assert stored.status_code == 200, stored.text
+    with tarfile.open(fileobj=io.BytesIO(stored.content), mode="r:*") as archive:
+        skill = archive.extractfile("skills/alpha/SKILL.md")
+        assert skill is not None
+        assert skill.read().decode() == VALID_FILES["skills/alpha/SKILL.md"]
+
+
 def test_a_target_naming_another_repos_agent_is_rejected_end_to_end(
     client: Any,
     auth_headers: dict[str, str],

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -787,12 +787,17 @@ impl ApiClient {
         agent_id: &str,
         version_label: &str,
         created_by: &str,
+        commit_sha: Option<&str>,
     ) -> Result<Version> {
         let resp = self
             .http
             .post(format!("{}/agents/{agent_id}/versions", self.base_url))
             .header("X-API-Key", &self.api_key)
-            .json(&json!({"version_label": version_label, "created_by": created_by}))
+            .json(&json!({
+                "version_label": version_label,
+                "created_by": created_by,
+                "commit_sha": commit_sha,
+            }))
             .send()
             .await
             .context("POST /agents/{id}/versions")?;
@@ -837,6 +842,7 @@ impl ApiClient {
         agent_id: &str,
         version_id: &str,
         environment: &str,
+        commit_sha: Option<&str>,
     ) -> Result<Deployment> {
         let resp = self
             .http
@@ -846,6 +852,7 @@ impl ApiClient {
                 "agent_id": agent_id,
                 "version_id": version_id,
                 "environment": environment,
+                "commit_sha": commit_sha,
             }))
             .send()
             .await
@@ -870,6 +877,7 @@ impl ApiClient {
         archive: Vec<u8>,
         secrets: &std::collections::BTreeMap<String, String>,
         repo_full_name: Option<&str>,
+        commit_sha: Option<&str>,
     ) -> Result<DeployOutcome> {
         let (agent, channel, repo_note) = self
             .resolve_agent(agent_name, slack_channel, repo_full_name)
@@ -881,11 +889,11 @@ impl ApiClient {
             self.update_agent_secrets(&agent.id, secrets).await?;
         }
         let version = self
-            .create_version(&agent.id, version_label, created_by)
+            .create_version(&agent.id, version_label, created_by, commit_sha)
             .await?;
         let bundle = self.upload_bundle(&agent.id, &version.id, archive).await?;
         let deployment = self
-            .create_deployment(&agent.id, &version.id, environment)
+            .create_deployment(&agent.id, &version.id, environment, commit_sha)
             .await?;
         Ok(DeployOutcome {
             agent,

--- a/cli/src/bundle.rs
+++ b/cli/src/bundle.rs
@@ -101,16 +101,20 @@ impl Exclusions {
     }
 
     fn is_excluded(&self, rel: &Path) -> bool {
-        let name = rel.file_name().unwrap_or_default();
-        self.names.iter().any(|n| name == std::ffi::OsStr::new(n))
-            || self.paths.iter().any(|p| rel == p)
+        rel.components().any(|component| match component {
+            Component::Normal(name) => self
+                .names
+                .iter()
+                .any(|excluded| name == std::ffi::OsStr::new(excluded)),
+            _ => false,
+        }) || self.paths.iter().any(|path| rel.starts_with(path))
     }
 }
 
 /// Whether porcelain v1 `-z` output contains no change that can affect the
 /// packed bundle. Changes under excluded workstation directories are harmless;
 /// the exclusion file itself is not, because changing it changes what is packed.
-pub(crate) fn git_status_is_clean_for_pack(root: &Path, status: &[u8]) -> bool {
+pub(crate) fn git_status_is_clean_for_pack(root: &Path, repo_prefix: &Path, status: &[u8]) -> bool {
     let Ok(exclusions) = Exclusions::load(root) else {
         return false;
     };
@@ -122,6 +126,7 @@ pub(crate) fn git_status_is_clean_for_pack(root: &Path, status: &[u8]) -> bool {
                 .get(3..)
                 .and_then(|path| std::str::from_utf8(path).ok())
                 .map(Path::new)
+                .and_then(|path| path.strip_prefix(repo_prefix).ok())
             else {
                 return false;
             };

--- a/cli/src/bundle.rs
+++ b/cli/src/bundle.rs
@@ -506,6 +506,26 @@ mod tests {
     }
 
     #[test]
+    fn pack_cleanliness_ignores_excluded_descendants_but_not_the_exclusion_file() {
+        let dir = tempfile::tempdir().unwrap();
+        crate::scaffold::scaffold(dir.path(), "deal-desk").unwrap();
+        std::fs::write(dir.path().join(".curieignore"), "generated-output/\n").unwrap();
+        std::fs::create_dir(dir.path().join("generated-output")).unwrap();
+        std::fs::write(dir.path().join("generated-output/file.txt"), "generated\n").unwrap();
+
+        assert!(git_status_is_clean_for_pack(
+            dir.path(),
+            Path::new(""),
+            b"!! generated-output/file.txt\0",
+        ));
+        assert!(!git_status_is_clean_for_pack(
+            dir.path(),
+            Path::new(""),
+            b" M .curieignore\0",
+        ));
+    }
+
+    #[test]
     fn ignores_curieignore_patterns_that_reach_outside_the_bundle() {
         let dir = tempfile::tempdir().unwrap();
         crate::scaffold::scaffold(dir.path(), "deal-desk").unwrap();

--- a/cli/src/bundle.rs
+++ b/cli/src/bundle.rs
@@ -107,6 +107,28 @@ impl Exclusions {
     }
 }
 
+/// Whether porcelain v1 `-z` output contains no change that can affect the
+/// packed bundle. Changes under excluded workstation directories are harmless;
+/// the exclusion file itself is not, because changing it changes what is packed.
+pub(crate) fn git_status_is_clean_for_pack(root: &Path, status: &[u8]) -> bool {
+    let Ok(exclusions) = Exclusions::load(root) else {
+        return false;
+    };
+    status
+        .split(|byte| *byte == 0)
+        .filter(|entry| !entry.is_empty())
+        .all(|entry| {
+            let Some(path) = entry
+                .get(3..)
+                .and_then(|path| std::str::from_utf8(path).ok())
+                .map(Path::new)
+            else {
+                return false;
+            };
+            path != Path::new(IGNORE_FILE) && exclusions.is_excluded(path)
+        })
+}
+
 fn append_dir(
     builder: &mut tar::Builder<GzEncoder<Vec<u8>>>,
     root: &Path,

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -14,7 +14,7 @@ use curie_aci_protocol::{Budget, EventType, OutboundEvent, SessionStatus};
 use serde::{Deserialize, Serialize};
 
 use crate::api::{ApiClient, BudgetConfig, ChannelOutcome};
-use crate::bundle::pack_tar_gz;
+use crate::bundle::{git_status_is_clean_for_pack, pack_tar_gz};
 use crate::docker::{self, CheckSpec, StartSpec};
 use crate::evals::{
     graded_answer, load_eval, outcome_label, rollup_line, score_turn, turn_completed, CaseOutcome,
@@ -3535,6 +3535,8 @@ pub async fn deploy(opts: DeployOpts) -> Result<DeployOutput> {
         .args([
             "status",
             "--porcelain=v1",
+            "-z",
+            "--no-renames",
             "--untracked-files=all",
             "--ignored=matching",
             "--",
@@ -3547,7 +3549,10 @@ pub async fn deploy(opts: DeployOpts) -> Result<DeployOutput> {
         .await
         .ok();
     let commit_sha = match git_status {
-        Some(output) if output.status.success() && output.stdout.is_empty() => {
+        Some(output)
+            if output.status.success()
+                && git_status_is_clean_for_pack(&plugin_dir, &output.stdout) =>
+        {
             tokio::process::Command::new("git")
                 .args(["rev-parse", "HEAD"])
                 .current_dir(&plugin_dir)

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -3531,6 +3531,17 @@ pub async fn deploy(opts: DeployOpts) -> Result<DeployOutput> {
         validate_channel_binding("slack", channel)?;
     }
     let archive = pack_tar_gz(&plugin_dir)?;
+    let git_prefix = tokio::process::Command::new("git")
+        .args(["rev-parse", "--show-prefix"])
+        .current_dir(&plugin_dir)
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .output()
+        .await
+        .ok()
+        .filter(|output| output.status.success())
+        .and_then(|output| String::from_utf8(output.stdout).ok())
+        .map(|prefix| PathBuf::from(prefix.trim_end_matches(['\r', '\n'])));
     let git_status = tokio::process::Command::new("git")
         .args([
             "status",
@@ -3548,10 +3559,10 @@ pub async fn deploy(opts: DeployOpts) -> Result<DeployOutput> {
         .output()
         .await
         .ok();
-    let commit_sha = match git_status {
-        Some(output)
+    let commit_sha = match (git_prefix, git_status) {
+        (Some(prefix), Some(output))
             if output.status.success()
-                && git_status_is_clean_for_pack(&plugin_dir, &output.stdout) =>
+                && git_status_is_clean_for_pack(&plugin_dir, &prefix, &output.stdout) =>
         {
             tokio::process::Command::new("git")
                 .args(["rev-parse", "HEAD"])

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -3536,6 +3536,7 @@ pub async fn deploy(opts: DeployOpts) -> Result<DeployOutput> {
             "status",
             "--porcelain=v1",
             "--untracked-files=all",
+            "--ignored=matching",
             "--",
             ".",
         ])

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -3531,15 +3531,37 @@ pub async fn deploy(opts: DeployOpts) -> Result<DeployOutput> {
         validate_channel_binding("slack", channel)?;
     }
     let archive = pack_tar_gz(&plugin_dir)?;
-    let commit_sha = std::process::Command::new("git")
-        .args(["rev-parse", "HEAD"])
+    let git_status = tokio::process::Command::new("git")
+        .args([
+            "status",
+            "--porcelain=v1",
+            "--untracked-files=all",
+            "--",
+            ".",
+        ])
         .current_dir(&plugin_dir)
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
         .output()
-        .ok()
-        .filter(|output| output.status.success())
-        .and_then(|output| String::from_utf8(output.stdout).ok())
-        .map(|sha| sha.trim().to_string())
-        .filter(|sha| !sha.is_empty());
+        .await
+        .ok();
+    let commit_sha = match git_status {
+        Some(output) if output.status.success() && output.stdout.is_empty() => {
+            tokio::process::Command::new("git")
+                .args(["rev-parse", "HEAD"])
+                .current_dir(&plugin_dir)
+                .env_remove("GIT_DIR")
+                .env_remove("GIT_WORK_TREE")
+                .output()
+                .await
+                .ok()
+                .filter(|output| output.status.success())
+                .and_then(|output| String::from_utf8(output.stdout).ok())
+                .map(|sha| sha.trim().to_string())
+                .filter(|sha| !sha.is_empty())
+        }
+        _ => None,
+    };
     let client = ApiClient::new(&opts.api_url, &opts.api_key)?;
     // Resolve a declared target, if one was named (ADR-0089). The file is sent
     // as TEXT and parsed server-side: one parser means the CLI and the

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -3531,6 +3531,15 @@ pub async fn deploy(opts: DeployOpts) -> Result<DeployOutput> {
         validate_channel_binding("slack", channel)?;
     }
     let archive = pack_tar_gz(&plugin_dir)?;
+    let commit_sha = std::process::Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(&plugin_dir)
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .and_then(|output| String::from_utf8(output.stdout).ok())
+        .map(|sha| sha.trim().to_string())
+        .filter(|sha| !sha.is_empty());
     let client = ApiClient::new(&opts.api_url, &opts.api_key)?;
     // Resolve a declared target, if one was named (ADR-0089). The file is sent
     // as TEXT and parsed server-side: one parser means the CLI and the
@@ -3616,6 +3625,7 @@ pub async fn deploy(opts: DeployOpts) -> Result<DeployOutput> {
             archive,
             &secrets,
             opts.repo.as_deref(),
+            commit_sha.as_deref(),
         )
         .await
     {

--- a/cli/tests/api_deploy.rs
+++ b/cli/tests/api_deploy.rs
@@ -133,10 +133,10 @@ fn assert_command_deploy_wire(server: &MockServer, commit_sha: Option<&str>) {
     );
 
     let version_request = &recorded[2];
-    let mut version_body: serde_json::Value =
+    let version_body: serde_json::Value =
         serde_json::from_slice(&version_request.body).expect("version body should be JSON");
     let deployment_request = &recorded[4];
-    let mut deployment_body: serde_json::Value =
+    let deployment_body: serde_json::Value =
         serde_json::from_slice(&deployment_request.body).expect("deployment body should be JSON");
 
     if let Some(commit_sha) = commit_sha {
@@ -158,26 +158,12 @@ fn assert_command_deploy_wire(server: &MockServer, commit_sha: Option<&str>) {
             })
         );
     } else {
-        if version_body
-            .get("commit_sha")
-            .is_some_and(serde_json::Value::is_null)
-        {
-            version_body.as_object_mut().unwrap().remove("commit_sha");
-        }
-        if deployment_body
-            .get("commit_sha")
-            .is_some_and(serde_json::Value::is_null)
-        {
-            deployment_body
-                .as_object_mut()
-                .unwrap()
-                .remove("commit_sha");
-        }
         assert_eq!(
             version_body,
             serde_json::json!({
                 "version_label": "0.1.0-1",
                 "created_by": std::env::var("USER").unwrap_or_else(|_| "curie-cli".to_string()),
+                "commit_sha": null,
             })
         );
         assert_eq!(
@@ -186,6 +172,7 @@ fn assert_command_deploy_wire(server: &MockServer, commit_sha: Option<&str>) {
                 "agent_id": AGENT_ID,
                 "version_id": VERSION_ID,
                 "environment": "dev",
+                "commit_sha": null,
             })
         );
     }
@@ -193,7 +180,7 @@ fn assert_command_deploy_wire(server: &MockServer, commit_sha: Option<&str>) {
 
 #[cfg(unix)]
 #[tokio::test]
-async fn command_deploy_uses_one_bundle_head_and_omits_sha_for_a_non_git_bundle() {
+async fn command_deploy_uses_one_bundle_head_and_null_sha_for_a_non_git_bundle() {
     let git = real_git();
     let bundle = tempfile::tempdir().unwrap();
     scaffold(bundle.path(), "deal-desk").unwrap();

--- a/cli/tests/api_deploy.rs
+++ b/cli/tests/api_deploy.rs
@@ -185,24 +185,19 @@ fn assert_command_deploy_wire(server: &MockServer, commit_sha: Option<&str>) {
 #[tokio::test]
 async fn command_deploy_uses_head_only_for_a_clean_git_bundle_and_null_sha_otherwise() {
     let git = real_git();
-    let bundle = tempfile::tempdir().unwrap();
-    scaffold(bundle.path(), "deal-desk").unwrap();
-    std::fs::write(
-        bundle.path().join(".gitignore"),
-        ".curie/\nignored-packed.txt\n",
-    )
-    .unwrap();
-    std::fs::create_dir(bundle.path().join(".curie")).unwrap();
-    std::fs::write(
-        bundle.path().join(".curie/runner.json"),
-        "ignored runtime state\n",
-    )
-    .unwrap();
-    run_git(&git, bundle.path(), &["init", "--quiet"]);
-    run_git(&git, bundle.path(), &["add", "."]);
+    let repo = tempfile::tempdir().unwrap();
+    let bundle = repo.path().join("nested/deal-desk");
+    std::fs::create_dir_all(&bundle).unwrap();
+    scaffold(&bundle, "deal-desk").unwrap();
+    std::fs::write(bundle.join(".gitignore"), ".curie/\nignored-packed.txt\n").unwrap();
+    std::fs::write(bundle.join(".curieignore"), "# committed exclusions\n").unwrap();
+    std::fs::create_dir(bundle.join(".curie")).unwrap();
+    std::fs::write(bundle.join(".curie/runner.json"), "ignored runtime state\n").unwrap();
+    run_git(&git, repo.path(), &["init", "--quiet"]);
+    run_git(&git, repo.path(), &["add", "."]);
     run_git(
         &git,
-        bundle.path(),
+        repo.path(),
         &[
             "-c",
             "user.name=Curie Test",
@@ -214,7 +209,7 @@ async fn command_deploy_uses_head_only_for_a_clean_git_bundle_and_null_sha_other
             "Initial bundle",
         ],
     );
-    let bundle_head = run_git(&git, bundle.path(), &["rev-parse", "HEAD"]);
+    let bundle_head = run_git(&git, repo.path(), &["rev-parse", "HEAD"]);
     assert_eq!(bundle_head.len(), 40, "expected a full commit SHA");
     let outer_head = run_git(
         &git,
@@ -252,41 +247,45 @@ exec "$CURIE_TEST_REAL_GIT" "$@"
     let git_env = GitEnvGuard::install(&git, &count_file, wrapper_dir.path());
 
     let git_server = serve(|req| route(&req.method, &req.path));
-    let git_outcome = run_command_deploy(&git_server, bundle.path()).await;
+    let git_outcome = run_command_deploy(&git_server, &bundle).await;
     let lookup_count = std::fs::read_to_string(&count_file).unwrap();
 
     assert_eq!(git_outcome.bundle_sha256, "deadbeef");
     assert_eq!(lookup_count.trim(), "1", "HEAD must be resolved once");
     assert_command_deploy_wire(&git_server, Some(&bundle_head));
 
-    let tracked_path = bundle.path().join(".claude-plugin/plugin.json");
+    let tracked_path = bundle.join(".claude-plugin/plugin.json");
     let tracked_content = std::fs::read_to_string(&tracked_path).unwrap();
     std::fs::write(&tracked_path, format!("{tracked_content}\n")).unwrap();
     let tracked_dirty_server = serve(|req| route(&req.method, &req.path));
-    let tracked_dirty_outcome = run_command_deploy(&tracked_dirty_server, bundle.path()).await;
+    let tracked_dirty_outcome = run_command_deploy(&tracked_dirty_server, &bundle).await;
 
     assert_eq!(tracked_dirty_outcome.bundle_sha256, "deadbeef");
     assert_command_deploy_wire(&tracked_dirty_server, None);
 
     std::fs::write(&tracked_path, tracked_content).unwrap();
-    std::fs::write(bundle.path().join("uncommitted.txt"), "dirty bundle\n").unwrap();
+    std::fs::write(bundle.join("uncommitted.txt"), "dirty bundle\n").unwrap();
     let dirty_server = serve(|req| route(&req.method, &req.path));
-    let dirty_outcome = run_command_deploy(&dirty_server, bundle.path()).await;
+    let dirty_outcome = run_command_deploy(&dirty_server, &bundle).await;
 
     assert_eq!(dirty_outcome.bundle_sha256, "deadbeef");
     assert_command_deploy_wire(&dirty_server, None);
 
-    std::fs::remove_file(bundle.path().join("uncommitted.txt")).unwrap();
-    std::fs::write(
-        bundle.path().join("ignored-packed.txt"),
-        "ignored but packed\n",
-    )
-    .unwrap();
+    std::fs::remove_file(bundle.join("uncommitted.txt")).unwrap();
+    std::fs::write(bundle.join("ignored-packed.txt"), "ignored but packed\n").unwrap();
     let ignored_server = serve(|req| route(&req.method, &req.path));
-    let ignored_outcome = run_command_deploy(&ignored_server, bundle.path()).await;
+    let ignored_outcome = run_command_deploy(&ignored_server, &bundle).await;
 
     assert_eq!(ignored_outcome.bundle_sha256, "deadbeef");
     assert_command_deploy_wire(&ignored_server, None);
+
+    std::fs::remove_file(bundle.join("ignored-packed.txt")).unwrap();
+    std::fs::write(bundle.join(".curieignore"), "generated-output/\n").unwrap();
+    let exclusions_dirty_server = serve(|req| route(&req.method, &req.path));
+    let exclusions_dirty_outcome = run_command_deploy(&exclusions_dirty_server, &bundle).await;
+
+    assert_eq!(exclusions_dirty_outcome.bundle_sha256, "deadbeef");
+    assert_command_deploy_wire(&exclusions_dirty_server, None);
 
     drop(git_env);
 

--- a/cli/tests/api_deploy.rs
+++ b/cli/tests/api_deploy.rs
@@ -23,6 +23,9 @@ const VERSION_ID: &str = "22222222-2222-2222-2222-222222222222";
 const DEPLOYMENT_ID: &str = "33333333-3333-3333-3333-333333333333";
 
 #[cfg(unix)]
+static PATH_ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+#[cfg(unix)]
 struct GitEnvGuard {
     path: Option<OsString>,
     real_git: Option<OsString>,
@@ -180,7 +183,7 @@ fn assert_command_deploy_wire(server: &MockServer, commit_sha: Option<&str>) {
 
 #[cfg(unix)]
 #[tokio::test]
-async fn command_deploy_uses_one_bundle_head_and_null_sha_for_a_non_git_bundle() {
+async fn command_deploy_uses_head_only_for_a_clean_git_bundle_and_null_sha_otherwise() {
     let git = real_git();
     let bundle = tempfile::tempdir().unwrap();
     scaffold(bundle.path(), "deal-desk").unwrap();
@@ -215,14 +218,16 @@ async fn command_deploy_uses_one_bundle_head_and_null_sha_for_a_non_git_bundle()
         &wrapper,
         r#"#!/bin/sh
 count=0
-if [ -f "$CURIE_TEST_GIT_COUNT" ]; then
-  count=$(cat "$CURIE_TEST_GIT_COUNT")
-fi
-count=$((count + 1))
-printf '%s\n' "$count" > "$CURIE_TEST_GIT_COUNT"
-if [ "$count" -gt 1 ]; then
-  printf '%s\n' '0000000000000000000000000000000000000000'
-  exit 0
+if [ "$#" -eq 2 ] && [ "$1" = 'rev-parse' ] && [ "$2" = 'HEAD' ]; then
+  if [ -f "$CURIE_TEST_GIT_COUNT" ]; then
+    count=$(cat "$CURIE_TEST_GIT_COUNT")
+  fi
+  count=$((count + 1))
+  printf '%s\n' "$count" > "$CURIE_TEST_GIT_COUNT"
+  if [ "$count" -gt 1 ]; then
+    printf '%s\n' '0000000000000000000000000000000000000000'
+    exit 0
+  fi
 fi
 exec "$CURIE_TEST_REAL_GIT" "$@"
 "#,
@@ -232,16 +237,25 @@ exec "$CURIE_TEST_REAL_GIT" "$@"
     permissions.set_mode(0o755);
     std::fs::set_permissions(&wrapper, permissions).unwrap();
     let count_file = wrapper_dir.path().join("git-count");
+    let _path_env = PATH_ENV_LOCK.lock().await;
     let git_env = GitEnvGuard::install(&git, &count_file, wrapper_dir.path());
 
     let git_server = serve(|req| route(&req.method, &req.path));
     let git_outcome = run_command_deploy(&git_server, bundle.path()).await;
     let lookup_count = std::fs::read_to_string(&count_file).unwrap();
-    drop(git_env);
 
     assert_eq!(git_outcome.bundle_sha256, "deadbeef");
     assert_eq!(lookup_count.trim(), "1", "HEAD must be resolved once");
     assert_command_deploy_wire(&git_server, Some(&bundle_head));
+
+    std::fs::write(bundle.path().join("uncommitted.txt"), "dirty bundle\n").unwrap();
+    let dirty_server = serve(|req| route(&req.method, &req.path));
+    let dirty_outcome = run_command_deploy(&dirty_server, bundle.path()).await;
+
+    assert_eq!(dirty_outcome.bundle_sha256, "deadbeef");
+    assert_command_deploy_wire(&dirty_server, None);
+
+    drop(git_env);
 
     let non_git_bundle = tempfile::tempdir().unwrap();
     scaffold(non_git_bundle.path(), "deal-desk").unwrap();

--- a/cli/tests/api_deploy.rs
+++ b/cli/tests/api_deploy.rs
@@ -5,13 +5,265 @@ mod support;
 
 use curie::api::{ApiClient, ChannelOutcome, DeployOutcome};
 use curie::bundle::pack_tar_gz;
+use curie::commands::{self, DeployOpts};
 use curie::scaffold::scaffold;
+#[cfg(unix)]
+use std::ffi::OsString;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+#[cfg(unix)]
+use std::path::{Path, PathBuf};
+#[cfg(unix)]
+use std::process::Command;
 use support::{serve, MockServer, Response};
 
 const AGENT_ID: &str = "11111111-1111-1111-1111-111111111111";
 const AGENT_NAME: &str = "deal-desk";
 const VERSION_ID: &str = "22222222-2222-2222-2222-222222222222";
 const DEPLOYMENT_ID: &str = "33333333-3333-3333-3333-333333333333";
+
+#[cfg(unix)]
+struct GitEnvGuard {
+    path: Option<OsString>,
+    real_git: Option<OsString>,
+    count_file: Option<OsString>,
+}
+
+#[cfg(unix)]
+impl GitEnvGuard {
+    fn install(real_git: &Path, count_file: &Path, wrapper_dir: &Path) -> Self {
+        let guard = Self {
+            path: std::env::var_os("PATH"),
+            real_git: std::env::var_os("CURIE_TEST_REAL_GIT"),
+            count_file: std::env::var_os("CURIE_TEST_GIT_COUNT"),
+        };
+        let original_path = guard.path.clone().unwrap_or_default();
+        let paths =
+            std::iter::once(wrapper_dir.to_path_buf()).chain(std::env::split_paths(&original_path));
+        std::env::set_var("PATH", std::env::join_paths(paths).expect("join PATH"));
+        std::env::set_var("CURIE_TEST_REAL_GIT", real_git);
+        std::env::set_var("CURIE_TEST_GIT_COUNT", count_file);
+        guard
+    }
+}
+
+#[cfg(unix)]
+impl Drop for GitEnvGuard {
+    fn drop(&mut self) {
+        for (name, value) in [
+            ("PATH", self.path.take()),
+            ("CURIE_TEST_REAL_GIT", self.real_git.take()),
+            ("CURIE_TEST_GIT_COUNT", self.count_file.take()),
+        ] {
+            match value {
+                Some(value) => std::env::set_var(name, value),
+                None => std::env::remove_var(name),
+            }
+        }
+    }
+}
+
+#[cfg(unix)]
+fn real_git() -> PathBuf {
+    std::env::split_paths(&std::env::var_os("PATH").unwrap_or_default())
+        .map(|dir| dir.join("git"))
+        .find(|path| path.is_file())
+        .expect("git should be on PATH")
+        .canonicalize()
+        .expect("canonicalize git")
+}
+
+#[cfg(unix)]
+fn run_git(git: &Path, cwd: &Path, args: &[&str]) -> String {
+    let output = Command::new(git)
+        .current_dir(cwd)
+        .args(args)
+        .output()
+        .expect("run git");
+    assert!(
+        output.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout)
+        .expect("git output should be UTF 8")
+        .trim()
+        .to_string()
+}
+
+#[cfg(unix)]
+async fn run_command_deploy(server: &MockServer, plugin_dir: &Path) -> commands::DeployOutput {
+    commands::deploy(DeployOpts {
+        agent: None,
+        target: None,
+        plugin_dir: plugin_dir.to_path_buf(),
+        api_url: server.base_url.clone(),
+        api_key: "test-key".to_string(),
+        slack_channel: Some("#local-dev".to_string()),
+        repo: None,
+        env: None,
+        label: Some("0.1.0-1".to_string()),
+        secret: vec![],
+        secret_binding_supported: true,
+        connect_hint: "mock API should be reachable".to_string(),
+    })
+    .await
+    .unwrap()
+}
+
+#[cfg(unix)]
+fn assert_command_deploy_wire(server: &MockServer, commit_sha: Option<&str>) {
+    let recorded = server.recorded();
+    let flow: Vec<(String, String)> = recorded
+        .iter()
+        .map(|request| (request.method.clone(), request.path.clone()))
+        .collect();
+    assert_eq!(
+        flow,
+        vec![
+            ("GET".to_string(), "/agents".to_string()),
+            ("POST".to_string(), "/agents".to_string()),
+            ("POST".to_string(), format!("/agents/{AGENT_ID}/versions"),),
+            (
+                "PUT".to_string(),
+                format!("/agents/{AGENT_ID}/versions/{VERSION_ID}/bundle"),
+            ),
+            ("POST".to_string(), "/deployments".to_string()),
+        ]
+    );
+
+    let version_request = &recorded[2];
+    let mut version_body: serde_json::Value =
+        serde_json::from_slice(&version_request.body).expect("version body should be JSON");
+    let deployment_request = &recorded[4];
+    let mut deployment_body: serde_json::Value =
+        serde_json::from_slice(&deployment_request.body).expect("deployment body should be JSON");
+
+    if let Some(commit_sha) = commit_sha {
+        assert_eq!(
+            version_body,
+            serde_json::json!({
+                "version_label": "0.1.0-1",
+                "created_by": std::env::var("USER").unwrap_or_else(|_| "curie-cli".to_string()),
+                "commit_sha": commit_sha,
+            })
+        );
+        assert_eq!(
+            deployment_body,
+            serde_json::json!({
+                "agent_id": AGENT_ID,
+                "version_id": VERSION_ID,
+                "environment": "dev",
+                "commit_sha": commit_sha,
+            })
+        );
+    } else {
+        if version_body
+            .get("commit_sha")
+            .is_some_and(serde_json::Value::is_null)
+        {
+            version_body.as_object_mut().unwrap().remove("commit_sha");
+        }
+        if deployment_body
+            .get("commit_sha")
+            .is_some_and(serde_json::Value::is_null)
+        {
+            deployment_body
+                .as_object_mut()
+                .unwrap()
+                .remove("commit_sha");
+        }
+        assert_eq!(
+            version_body,
+            serde_json::json!({
+                "version_label": "0.1.0-1",
+                "created_by": std::env::var("USER").unwrap_or_else(|_| "curie-cli".to_string()),
+            })
+        );
+        assert_eq!(
+            deployment_body,
+            serde_json::json!({
+                "agent_id": AGENT_ID,
+                "version_id": VERSION_ID,
+                "environment": "dev",
+            })
+        );
+    }
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn command_deploy_uses_one_bundle_head_and_omits_sha_for_a_non_git_bundle() {
+    let git = real_git();
+    let bundle = tempfile::tempdir().unwrap();
+    scaffold(bundle.path(), "deal-desk").unwrap();
+    run_git(&git, bundle.path(), &["init", "--quiet"]);
+    run_git(&git, bundle.path(), &["add", "."]);
+    run_git(
+        &git,
+        bundle.path(),
+        &[
+            "-c",
+            "user.name=Curie Test",
+            "-c",
+            "user.email=curie@example.com",
+            "commit",
+            "--quiet",
+            "-m",
+            "Initial bundle",
+        ],
+    );
+    let bundle_head = run_git(&git, bundle.path(), &["rev-parse", "HEAD"]);
+    assert_eq!(bundle_head.len(), 40, "expected a full commit SHA");
+    let outer_head = run_git(
+        &git,
+        Path::new(env!("CARGO_MANIFEST_DIR")),
+        &["rev-parse", "HEAD"],
+    );
+    assert_ne!(bundle_head, outer_head, "fixture must have its own commit");
+
+    let wrapper_dir = tempfile::tempdir().unwrap();
+    let wrapper = wrapper_dir.path().join("git");
+    std::fs::write(
+        &wrapper,
+        r#"#!/bin/sh
+count=0
+if [ -f "$CURIE_TEST_GIT_COUNT" ]; then
+  count=$(cat "$CURIE_TEST_GIT_COUNT")
+fi
+count=$((count + 1))
+printf '%s\n' "$count" > "$CURIE_TEST_GIT_COUNT"
+if [ "$count" -gt 1 ]; then
+  printf '%s\n' '0000000000000000000000000000000000000000'
+  exit 0
+fi
+exec "$CURIE_TEST_REAL_GIT" "$@"
+"#,
+    )
+    .unwrap();
+    let mut permissions = std::fs::metadata(&wrapper).unwrap().permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&wrapper, permissions).unwrap();
+    let count_file = wrapper_dir.path().join("git-count");
+    let git_env = GitEnvGuard::install(&git, &count_file, wrapper_dir.path());
+
+    let git_server = serve(|req| route(&req.method, &req.path));
+    let git_outcome = run_command_deploy(&git_server, bundle.path()).await;
+    let lookup_count = std::fs::read_to_string(&count_file).unwrap();
+    drop(git_env);
+
+    assert_eq!(git_outcome.bundle_sha256, "deadbeef");
+    assert_eq!(lookup_count.trim(), "1", "HEAD must be resolved once");
+    assert_command_deploy_wire(&git_server, Some(&bundle_head));
+
+    let non_git_bundle = tempfile::tempdir().unwrap();
+    scaffold(non_git_bundle.path(), "deal-desk").unwrap();
+    let non_git_server = serve(|req| route(&req.method, &req.path));
+    let non_git_outcome = run_command_deploy(&non_git_server, non_git_bundle.path()).await;
+
+    assert_eq!(non_git_outcome.bundle_sha256, "deadbeef");
+    assert_command_deploy_wire(&non_git_server, None);
+}
 
 fn route(method: &str, path: &str) -> Response {
     match (method, path) {
@@ -64,6 +316,7 @@ async fn deploy_walks_the_full_contract_flow_with_auth() {
             "dev",
             archive,
             &std::collections::BTreeMap::new(),
+            None,
             None,
         )
         .await
@@ -236,6 +489,7 @@ async fn run_deploy(
             archive,
             &std::collections::BTreeMap::new(),
             repo,
+            None,
         )
         .await
         .unwrap()

--- a/cli/tests/api_deploy.rs
+++ b/cli/tests/api_deploy.rs
@@ -99,7 +99,7 @@ async fn run_command_deploy(server: &MockServer, plugin_dir: &Path) -> commands:
         plugin_dir: plugin_dir.to_path_buf(),
         api_url: server.base_url.clone(),
         api_key: "test-key".to_string(),
-        slack_channel: Some("#local-dev".to_string()),
+        slack_channel: Some("C0EXAMPLE1".to_string()),
         repo: None,
         env: None,
         label: Some("0.1.0-1".to_string()),

--- a/cli/tests/api_deploy.rs
+++ b/cli/tests/api_deploy.rs
@@ -187,7 +187,17 @@ async fn command_deploy_uses_head_only_for_a_clean_git_bundle_and_null_sha_other
     let git = real_git();
     let bundle = tempfile::tempdir().unwrap();
     scaffold(bundle.path(), "deal-desk").unwrap();
-    std::fs::write(bundle.path().join(".gitignore"), "ignored-packed.txt\n").unwrap();
+    std::fs::write(
+        bundle.path().join(".gitignore"),
+        ".curie/\nignored-packed.txt\n",
+    )
+    .unwrap();
+    std::fs::create_dir(bundle.path().join(".curie")).unwrap();
+    std::fs::write(
+        bundle.path().join(".curie/runner.json"),
+        "ignored runtime state\n",
+    )
+    .unwrap();
     run_git(&git, bundle.path(), &["init", "--quiet"]);
     run_git(&git, bundle.path(), &["add", "."]);
     run_git(
@@ -249,6 +259,16 @@ exec "$CURIE_TEST_REAL_GIT" "$@"
     assert_eq!(lookup_count.trim(), "1", "HEAD must be resolved once");
     assert_command_deploy_wire(&git_server, Some(&bundle_head));
 
+    let tracked_path = bundle.path().join(".claude-plugin/plugin.json");
+    let tracked_content = std::fs::read_to_string(&tracked_path).unwrap();
+    std::fs::write(&tracked_path, format!("{tracked_content}\n")).unwrap();
+    let tracked_dirty_server = serve(|req| route(&req.method, &req.path));
+    let tracked_dirty_outcome = run_command_deploy(&tracked_dirty_server, bundle.path()).await;
+
+    assert_eq!(tracked_dirty_outcome.bundle_sha256, "deadbeef");
+    assert_command_deploy_wire(&tracked_dirty_server, None);
+
+    std::fs::write(&tracked_path, tracked_content).unwrap();
     std::fs::write(bundle.path().join("uncommitted.txt"), "dirty bundle\n").unwrap();
     let dirty_server = serve(|req| route(&req.method, &req.path));
     let dirty_outcome = run_command_deploy(&dirty_server, bundle.path()).await;

--- a/cli/tests/api_deploy.rs
+++ b/cli/tests/api_deploy.rs
@@ -187,6 +187,7 @@ async fn command_deploy_uses_head_only_for_a_clean_git_bundle_and_null_sha_other
     let git = real_git();
     let bundle = tempfile::tempdir().unwrap();
     scaffold(bundle.path(), "deal-desk").unwrap();
+    std::fs::write(bundle.path().join(".gitignore"), "ignored-packed.txt\n").unwrap();
     run_git(&git, bundle.path(), &["init", "--quiet"]);
     run_git(&git, bundle.path(), &["add", "."]);
     run_git(
@@ -254,6 +255,18 @@ exec "$CURIE_TEST_REAL_GIT" "$@"
 
     assert_eq!(dirty_outcome.bundle_sha256, "deadbeef");
     assert_command_deploy_wire(&dirty_server, None);
+
+    std::fs::remove_file(bundle.path().join("uncommitted.txt")).unwrap();
+    std::fs::write(
+        bundle.path().join("ignored-packed.txt"),
+        "ignored but packed\n",
+    )
+    .unwrap();
+    let ignored_server = serve(|req| route(&req.method, &req.path));
+    let ignored_outcome = run_command_deploy(&ignored_server, bundle.path()).await;
+
+    assert_eq!(ignored_outcome.bundle_sha256, "deadbeef");
+    assert_command_deploy_wire(&ignored_server, None);
 
     drop(git_env);
 


### PR DESCRIPTION
## Summary

Persists optional commit SHAs from CLI deployment into versions and deployments.

Keeps Git flow artifacts and poll baselines authoritative across CLI deploys, sibling agents, and console rollbacks.

Proves a CLI created version can be graded through `/evals/trigger`.

Closes #1629