### PR TITLE
Guard cluster provider consistency

### DIFF
--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -591,6 +591,50 @@ pub fn parse_egress_provider(value: &str) -> Result<&'static str, crate::exit::C
         })
 }
 
+fn credential_egress_provider(credential: &str) -> Option<&'static str> {
+    if credential.starts_with("sk-ant-") {
+        Some("anthropic")
+    } else if credential.starts_with("sk-or-") {
+        Some("openrouter")
+    } else {
+        None
+    }
+}
+
+fn validate_credential_egress_consistency(
+    opts: &UpOpts,
+) -> std::result::Result<(), crate::exit::CliError> {
+    let operator_sets = opts.operator_sets();
+    let explicit_credential = operator_set_entries(&operator_sets)
+        .into_iter()
+        .filter(|(key, _)| key.trim() == MODEL_CREDENTIAL_KEY)
+        .map(|(_, value)| value.trim())
+        .next_back();
+    let Some(detected) = explicit_credential
+        .or(opts.credentials.as_deref())
+        .and_then(credential_egress_provider)
+    else {
+        return Ok(());
+    };
+
+    if opts.allow_egress_host.is_empty()
+        || opts
+            .allow_egress_host
+            .iter()
+            .any(|provider| provider == detected)
+    {
+        return Ok(());
+    }
+
+    let explicit = opts.allow_egress_host.join(", ");
+    Err(crate::exit::CliError::usage(format!(
+        "the configured model credential identifies `{detected}`, but `--allow-egress-host` permits only: {explicit}"
+    ))
+    .with_fix(format!(
+        "include `--allow-egress-host {detected}`, or remove the contradictory provider selection"
+    )))
+}
+
 /// A resolved host address as a single-host CIDR: `/32` for IPv4, `/128` for
 /// IPv6. The egress rule opens exactly that address, nothing wider.
 pub fn ip_to_egress_cidr(ip: std::net::IpAddr) -> String {
@@ -3319,6 +3363,9 @@ pub async fn up(
     clear_github_token: bool,
 ) -> Result<ClusterUpOutput> {
     validate_up_inputs(&opts, github_token.as_deref(), clear_github_token)?;
+    // Reject contradictions already visible in argv or the environment before
+    // reading cluster state.
+    validate_credential_egress_consistency(&opts)?;
     let resolve_provider_egress = !opts.common.dry_run;
     let existing = if should_read_existing(opts.dev, opts.common.dry_run) {
         require_on_path("helm")?;
@@ -3326,13 +3373,24 @@ pub async fn up(
     } else {
         None
     };
-    let opts = complete_up_opts(
+    let mut opts = complete_up_opts(
         opts,
         existing.as_ref(),
         github_token.as_deref(),
         clear_github_token,
-        resolve_provider_egress,
+        false,
     )?;
+    // A release read can restore a credential that was absent from argv and the
+    // environment. Validate that effective value before provider DNS or Helm.
+    validate_credential_egress_consistency(&opts)?;
+    if resolve_provider_egress
+        && !opts.allow_egress_host.is_empty()
+        && opts.resolved_egress_cidrs.is_empty()
+    {
+        opts.resolved_egress_cidrs =
+            resolve_provider_egress_cidrs_for_current_environment(&opts.allow_egress_host)
+                .context("resolving named provider egress hosts")?;
+    }
     let value_plan = up_value_plan(&opts);
     run_prepared_up(opts, value_plan, existing, github_token.as_deref()).await
 }

--- a/cli/tests/installation_plan_parity.rs
+++ b/cli/tests/installation_plan_parity.rs
@@ -13,6 +13,9 @@ const GITHUB_VALUE: &str = "github-value-for-plan";
 const RERUN_CREDENTIAL_SENTINEL: &str = "placeholder credential sentinel";
 const RERUN_MODEL_SENTINEL: &str = "placeholder/model";
 const RERUN_EGRESS_CIDR: &str = "192.0.2.10/32";
+const ANTHROPIC_CREDENTIAL: &str = "sk-ant-PLACEHOLDER";
+const OPENROUTER_CREDENTIAL: &str = "sk-or-PLACEHOLDER";
+const AMBIGUOUS_MODEL_CREDENTIAL: &str = "sk-PLACEHOLDER";
 const OVERRIDE_MODEL_SET: &str = "agentSandbox.runner.model=operator/model";
 const OVERRIDE_EGRESS_SET: &str = "security.networkPolicy.allowedEgress[0].cidr=198.51.100.20/32";
 
@@ -673,9 +676,13 @@ fn provider_egress_fixture() -> String {
 }
 
 fn recorded_runner_values() -> HelmValuesResponse {
+    recorded_runner_values_with_credential(RERUN_CREDENTIAL_SENTINEL)
+}
+
+fn recorded_runner_values_with_credential(credential: &str) -> HelmValuesResponse {
     HelmValuesResponse::Object(json!({
         "agentSandbox": {"runner": {
-            "credentials": RERUN_CREDENTIAL_SENTINEL,
+            "credentials": credential,
             "fakeModel": false,
             "model": RERUN_MODEL_SENTINEL
         }},
@@ -723,6 +730,39 @@ fn json_error(output: Output, verb: &str) -> Value {
     assert!(json["error"].is_string(), "{verb} error payload: {json}");
     assert!(json.get("fix").is_some(), "{verb} error payload: {json}");
     json
+}
+
+fn assert_provider_contradiction(
+    output: Output,
+    credential: &str,
+    detected: &str,
+    allowed: &str,
+    verb: &str,
+) {
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "a contradictory provider is a usage error; stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let visible = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let error = json_error(output, verb);
+    let diagnostic = format!("{} {}", error["error"], error["fix"]).to_ascii_lowercase();
+    for expected in [detected, allowed, "--allow-egress-host"] {
+        assert!(
+            diagnostic.contains(expected),
+            "the contradiction must identify both providers and the correction: {error}"
+        );
+    }
+    assert!(
+        !visible.contains(credential),
+        "the rejected credential leaked into command output: {visible}"
+    );
 }
 
 fn plan(output: Output) -> String {
@@ -909,6 +949,10 @@ fn live_both_store_statefulsets() -> String {
 
 fn installation_with_effective_values() -> &'static str {
     "version: 1\ninstall:\n  namespace: parity\n  release: parity\ncredentials:\n  model: CURIE_APPLY_TEST_MODEL_KEY\n  github_token: CURIE_APPLY_TEST_GITHUB_TOKEN\nplatform:\n  ui: false\n  inference: true\nset:\n  example.mode: disabled\n  worker.replicas: \"3\"\n"
+}
+
+fn installation_with_provider_contradiction() -> &'static str {
+    "version: 1\ninstall:\n  namespace: parity\n  release: parity\ncredentials:\n  model: CURIE_APPLY_TEST_MODEL_KEY\nplatform:\n  egress:\n    - host: anthropic\n"
 }
 
 #[derive(Clone, Copy)]
@@ -1422,6 +1466,322 @@ fn cluster_up_rerun_preserves_existing_runner_model_and_egress_configuration() {
 }
 
 #[test]
+fn cluster_up_detected_credential_without_provider_installs_sealed() {
+    let fixture = HelmFixture::new(
+        installation_for_the_stateful_guard(),
+        HelmValuesResponse::Absent,
+    );
+
+    let output = fixture.cluster_up_with(&[], &[("CURIE_CREDENTIALS", OPENROUTER_CREDENTIAL)]);
+    let visible = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    json_output(output, "cluster up with a sealed OpenRouter credential");
+    assert!(
+        visible.contains("the sandbox is sealed -- no egress opened"),
+        "the bare credential must remain sealed: {visible}"
+    );
+    assert!(
+        !visible.contains(OPENROUTER_CREDENTIAL),
+        "the sealed credential leaked into command output: {visible}"
+    );
+
+    let calls = fixture.calls();
+    assert!(
+        calls.contains("HELM_CALL: upgrade "),
+        "the sealed credential must not block installation: {calls}"
+    );
+    assert!(
+        !calls.contains("security.networkPolicy.allowedEgress"),
+        "the bare credential must not open provider egress: {calls}"
+    );
+    assert!(
+        !calls.contains(OPENROUTER_CREDENTIAL),
+        "the sealed credential leaked into the command log: {calls}"
+    );
+}
+
+#[test]
+fn cluster_up_explicit_openrouter_egress_accepts_detected_credential() {
+    let fixture = HelmFixture::new(
+        installation_for_the_stateful_guard(),
+        HelmValuesResponse::Absent,
+    );
+    let provider_egress = json!({"openrouter.ai": [IPV4, IPV6]}).to_string();
+
+    let output = fixture.cluster_up_with(
+        &["--allow-egress-host", "openrouter"],
+        &[
+            ("CURIE_CREDENTIALS", OPENROUTER_CREDENTIAL),
+            ("CURIE_TEST_PROVIDER_EGRESS_JSON", provider_egress.as_str()),
+        ],
+    );
+    let visible = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    json_output(output, "cluster up with explicit OpenRouter egress");
+    assert!(
+        !visible.contains(OPENROUTER_CREDENTIAL),
+        "the OpenRouter credential leaked into command output: {visible}"
+    );
+
+    let calls = fixture.calls();
+    assert!(
+        calls.contains("HELM_CALL: upgrade "),
+        "the explicit provider must reach the Helm install: {calls}"
+    );
+    assert!(
+        calls.contains(&format!(
+            "security.networkPolicy.allowedEgress[0].cidr={IPV4}/32"
+        )),
+        "the explicit OpenRouter IPv4 route must reach Helm: {calls}"
+    );
+    assert!(
+        calls.contains(&format!(
+            "security.networkPolicy.allowedEgress[1].cidr={IPV6}/128"
+        )),
+        "the explicit OpenRouter IPv6 route must reach Helm: {calls}"
+    );
+    assert!(
+        !calls.contains(OPENROUTER_CREDENTIAL),
+        "the OpenRouter credential leaked into the command log: {calls}"
+    );
+}
+
+#[test]
+fn cluster_up_multi_provider_egress_accepts_matching_detected_credential() {
+    let fixture = HelmFixture::new(
+        installation_for_the_stateful_guard(),
+        HelmValuesResponse::Absent,
+    );
+    let provider_egress = json!({
+        "api.anthropic.com": [IPV4],
+        "openrouter.ai": [IPV6]
+    })
+    .to_string();
+
+    let output = fixture.cluster_up_with(
+        &[
+            "--allow-egress-host",
+            "anthropic",
+            "--allow-egress-host",
+            "openrouter",
+        ],
+        &[
+            ("CURIE_CREDENTIALS", OPENROUTER_CREDENTIAL),
+            ("CURIE_TEST_PROVIDER_EGRESS_JSON", provider_egress.as_str()),
+        ],
+    );
+    let visible = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    json_output(output, "cluster up with two explicit providers");
+    assert!(
+        !visible.contains(OPENROUTER_CREDENTIAL),
+        "the OpenRouter credential leaked into command output: {visible}"
+    );
+
+    let calls = fixture.calls();
+    assert!(
+        calls.contains("HELM_CALL: upgrade "),
+        "one matching provider in a larger list must allow installation: {calls}"
+    );
+    for expected in [
+        format!("security.networkPolicy.allowedEgress[0].cidr={IPV4}/32"),
+        format!("security.networkPolicy.allowedEgress[1].cidr={IPV6}/128"),
+    ] {
+        assert!(
+            calls.contains(&expected),
+            "both explicit provider routes must reach Helm: {calls}"
+        );
+    }
+    assert!(
+        !calls.contains(OPENROUTER_CREDENTIAL),
+        "the OpenRouter credential leaked into the command log: {calls}"
+    );
+}
+
+#[test]
+fn cluster_up_rejects_a_contradictory_provider_before_dns_and_helm() {
+    let fixture = HelmFixture::new(
+        installation_for_the_stateful_guard(),
+        HelmValuesResponse::Absent,
+    );
+
+    let output = fixture.cluster_up_with(
+        &["--allow-egress-host", "anthropic"],
+        &[
+            ("CURIE_CREDENTIALS", OPENROUTER_CREDENTIAL),
+            (
+                "CURIE_TEST_PROVIDER_EGRESS_JSON",
+                "PLACEHOLDER invalid provider DNS injection",
+            ),
+        ],
+    );
+    assert_provider_contradiction(
+        output,
+        OPENROUTER_CREDENTIAL,
+        "openrouter",
+        "anthropic",
+        "cluster up with a contradictory provider",
+    );
+    assert!(
+        fixture.calls().is_empty(),
+        "the contradiction must stop before Helm or kubectl: {}",
+        fixture.calls()
+    );
+}
+
+#[test]
+fn cluster_up_rejects_operator_set_credential_before_dns_and_helm() {
+    let fixture = HelmFixture::new(
+        installation_for_the_stateful_guard(),
+        HelmValuesResponse::Absent,
+    );
+    let credential_set = format!("agentSandbox.runner.credentials={OPENROUTER_CREDENTIAL}");
+
+    let output = fixture.cluster_up_with(
+        &[
+            "--allow-egress-host",
+            "anthropic",
+            "--set",
+            credential_set.as_str(),
+        ],
+        &[(
+            "CURIE_TEST_PROVIDER_EGRESS_JSON",
+            "PLACEHOLDER invalid provider DNS injection",
+        )],
+    );
+    assert_provider_contradiction(
+        output,
+        OPENROUTER_CREDENTIAL,
+        "openrouter",
+        "anthropic",
+        "cluster up with an operator set OpenRouter credential and Anthropic egress",
+    );
+    assert!(
+        fixture.calls().is_empty(),
+        "the operator set contradiction must stop before Helm or kubectl: {}",
+        fixture.calls()
+    );
+}
+
+#[test]
+fn cluster_up_rejects_anthropic_credential_with_openrouter_before_dns_and_helm() {
+    let fixture = HelmFixture::new(
+        installation_for_the_stateful_guard(),
+        HelmValuesResponse::Absent,
+    );
+
+    let output = fixture.cluster_up_with(
+        &["--allow-egress-host", "openrouter"],
+        &[
+            ("CURIE_CREDENTIALS", ANTHROPIC_CREDENTIAL),
+            (
+                "CURIE_TEST_PROVIDER_EGRESS_JSON",
+                "PLACEHOLDER invalid provider DNS injection",
+            ),
+        ],
+    );
+    assert_provider_contradiction(
+        output,
+        ANTHROPIC_CREDENTIAL,
+        "anthropic",
+        "openrouter",
+        "cluster up with an Anthropic credential and OpenRouter egress",
+    );
+    assert!(
+        fixture.calls().is_empty(),
+        "the Anthropic contradiction must stop before Helm or kubectl: {}",
+        fixture.calls()
+    );
+}
+
+#[test]
+fn cluster_up_explicit_openrouter_accepts_ambiguous_bare_sk_credential() {
+    let fixture = HelmFixture::new(
+        installation_for_the_stateful_guard(),
+        HelmValuesResponse::Absent,
+    );
+    let provider_egress = json!({"openrouter.ai": [IPV4, IPV6]}).to_string();
+
+    let output = fixture.cluster_up_with(
+        &["--allow-egress-host", "openrouter"],
+        &[
+            ("CURIE_CREDENTIALS", AMBIGUOUS_MODEL_CREDENTIAL),
+            ("CURIE_TEST_PROVIDER_EGRESS_JSON", provider_egress.as_str()),
+        ],
+    );
+    let visible = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    json_output(
+        output,
+        "cluster up with an explicit provider and an ambiguous bare sk credential",
+    );
+    assert!(
+        !visible.contains(AMBIGUOUS_MODEL_CREDENTIAL),
+        "the ambiguous credential leaked into command output: {visible}"
+    );
+
+    let calls = fixture.calls();
+    assert!(
+        calls.contains("HELM_CALL: upgrade "),
+        "an explicit provider must allow an ambiguous credential through to Helm: {calls}"
+    );
+    for expected in [
+        format!("security.networkPolicy.allowedEgress[0].cidr={IPV4}/32"),
+        format!("security.networkPolicy.allowedEgress[1].cidr={IPV6}/128"),
+    ] {
+        assert!(
+            calls.contains(&expected),
+            "the explicit OpenRouter route must reach Helm: {calls}"
+        );
+    }
+    assert!(
+        !calls.contains(AMBIGUOUS_MODEL_CREDENTIAL),
+        "the ambiguous credential leaked into the command log: {calls}"
+    );
+}
+
+#[test]
+fn cluster_up_rejects_preserved_openrouter_credential_before_dns_or_helm_mutation() {
+    let fixture = HelmFixture::new(
+        installation_for_the_stateful_guard(),
+        recorded_runner_values_with_credential(OPENROUTER_CREDENTIAL),
+    );
+
+    let output = fixture.cluster_up_with(
+        &["--allow-egress-host", "anthropic"],
+        &[(
+            "CURIE_TEST_PROVIDER_EGRESS_JSON",
+            "PLACEHOLDER invalid provider DNS injection",
+        )],
+    );
+    assert_provider_contradiction(
+        output,
+        OPENROUTER_CREDENTIAL,
+        "openrouter",
+        "anthropic",
+        "cluster up with a preserved OpenRouter credential and Anthropic egress",
+    );
+    assert_only_existing_values_read(&fixture, ExistingValuesConsumer::ClusterUp);
+    assert!(
+        !fixture.calls().contains(OPENROUTER_CREDENTIAL),
+        "the preserved credential leaked into the command log: {}",
+        fixture.calls()
+    );
+}
+
+#[test]
 fn cluster_up_explicit_model_modes_suppress_recorded_provider_configuration() {
     for (name, args, expected_value) in [
         (
@@ -1617,6 +1977,62 @@ fn absent_release_diff_matches_apply_dry_run_for_effective_installation_values()
         .map(String::as_str)
         .collect::<BTreeSet<_>>();
     assert_eq!(diff_keys, apply_keys, "apply plan: {apply}; diff: {diff}");
+}
+
+#[test]
+fn apply_and_diff_do_not_enforce_cluster_up_credential_provider_guard() {
+    let provider_egress = provider_egress_fixture();
+    let env = [
+        ("CURIE_APPLY_TEST_MODEL_KEY", OPENROUTER_CREDENTIAL),
+        ("CURIE_TEST_PROVIDER_EGRESS_JSON", provider_egress.as_str()),
+    ];
+
+    let apply_fixture = HelmFixture::new(
+        installation_with_provider_contradiction(),
+        HelmValuesResponse::Absent,
+    );
+    let apply_output = apply_fixture.apply(&[], &env);
+    let apply_visible = format!(
+        "{}{}",
+        String::from_utf8_lossy(&apply_output.stdout),
+        String::from_utf8_lossy(&apply_output.stderr)
+    );
+    json_output(
+        apply_output,
+        "apply with a cluster up provider contradiction",
+    );
+    assert!(
+        apply_fixture.calls().contains("HELM_CALL: upgrade "),
+        "apply must remain outside the cluster up guard: {}",
+        apply_fixture.calls()
+    );
+    assert!(
+        !apply_visible.contains(OPENROUTER_CREDENTIAL)
+            && !apply_fixture.calls().contains(OPENROUTER_CREDENTIAL),
+        "apply leaked the model credential"
+    );
+
+    let diff_fixture = HelmFixture::new(
+        installation_with_provider_contradiction(),
+        HelmValuesResponse::Absent,
+    );
+    let diff_output = diff_fixture.diff(&env);
+    let diff_visible = format!(
+        "{}{}",
+        String::from_utf8_lossy(&diff_output.stdout),
+        String::from_utf8_lossy(&diff_output.stderr)
+    );
+    let diff = json_output(diff_output, "diff with a cluster up provider contradiction");
+    assert_eq!(diff["release_exists"], false, "{diff}");
+    assert!(
+        diff["changes"].as_u64().is_some_and(|changes| changes > 0),
+        "diff must still produce an effective plan: {diff}"
+    );
+    assert!(
+        !diff_visible.contains(OPENROUTER_CREDENTIAL)
+            && !diff_fixture.calls().contains(OPENROUTER_CREDENTIAL),
+        "diff leaked the model credential"
+    );
 }
 
 #[test]

--- a/docs/interfaces/model-provider/INTERFACE.md
+++ b/docs/interfaces/model-provider/INTERFACE.md
@@ -124,7 +124,12 @@ hosts for Anthropic, OpenRouter, Zhipu, Moonshot, and DeepSeek.
   remains sealed until `--allow-egress-host` names one of the five lowercase exact
   providers, or the operator explicitly supplies `--allow-web-egress`. Unknown,
   mixed case, URL, and host literal provider names remain usage errors. Local Ollama
-  has no named remote egress entry.
+  has no named remote egress entry. During `cluster up`, an Anthropic or OpenRouter
+  credential shape from `CURIE_CREDENTIALS`, `--set agentSandbox.runner.credentials`,
+  or preserved release values is unambiguous, so an explicit named provider list must
+  include its matching provider or `cluster up` exits with a usage error before
+  mutation. This checks consistency only: it does not infer a provider or authorize
+  egress. Ambiguous credential shapes remain accepted with any known explicit provider.
 - **Two mirrors of the non-forwardable-credential rule.** The runner is the authority
   for the `sk-ant-oat` prefix
   (`runner/src/curie_runner/sdk_auth.py::OAUTH_TOKEN_PREFIX`), and it is already

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -86,7 +86,7 @@ curie cluster up
 | `-f <compose>` | Override a resolved local-dev artifact path. |
 | `--image <ref>` | Override a resolved image reference. |
 | `--no-expose` | Keep the UI and Langfuse ClusterIP-only instead of exposing them on node ports. |
-| `CURIE_CREDENTIALS` (alias `CURIE_MODEL_CREDENTIALS`) | A real model credential. The interactive check accepts Anthropic `sk-ant-`, OpenRouter `sk-or-`, Zhipu `id.secret`, and bare `sk-` shapes for Moonshot or DeepSeek. It checks only shape, not provider identity or liveness. Present credentials install live through masked `--set` machinery, so `--dry-run` never prints them. An absent credential uses fake mode on a fresh install and preserves the recorded model configuration on a rerun. |
+| `CURIE_CREDENTIALS` (alias `CURIE_MODEL_CREDENTIALS`) | A real model credential. The interactive check accepts Anthropic `sk-ant-`, OpenRouter `sk-or-`, Zhipu `id.secret`, and bare `sk-` shapes for Moonshot or DeepSeek. It checks only shape and does not prove liveness. During `cluster up`, Anthropic and OpenRouter shapes are recognized only to check consistency with explicit named egress. Present credentials install live through masked `--set` machinery, so `--dry-run` never prints them. An absent credential uses fake mode on a fresh install and preserves the recorded model configuration on a rerun. |
 | `--fake-model` | Explicitly downgrade to fake mode, even when a credential is present or a rerun has recorded live model configuration. |
 | `--github-token <token>` (or `CURIE_GITHUB_TOKEN`) | The Curie API's own GitHub credential, for cloning a PRIVATE repo during a git-flow bundle deploy and for posting the eval commit status. Goes to helm through a private mode-0600 values file, never a command-line argument, so it never appears in the helm command, the printed plan, or that plan's JSON. Prefer the environment variable: a token typed after the flag still sits in `curie`'s own argv, so it still reaches your shell history and `ps`. Omitting both on a later `cluster up` preserves whatever the release already has. Errors if combined with `--set api.githubToken=`. |
 | `--clear-github-token` | Remove the stored GitHub credential. Not a revocation: the running API keeps the old token until its pod restarts (`cluster up` prints the restart command), and the token itself stays valid at GitHub until you revoke it there. |
@@ -115,6 +115,14 @@ internet except `169.254.169.254`; narrow the CIDR to a specific destination for
 a tighter posture. A default route value (`0.0.0.0/0`, `::/0`, or any `/0`
 prefix) prints a distinct rail removal warning, since it removes the default
 deny rail for a prompt injectable sandbox.
+
+During `cluster up`, an unambiguous Anthropic or OpenRouter credential from
+`CURIE_CREDENTIALS`, `--set agentSandbox.runner.credentials`, or preserved
+release values requires an explicit `--allow-egress-host` list that includes the
+matching provider. Otherwise `cluster up` exits with a usage error before
+changing the cluster. This is a consistency check only: a credential never
+selects a provider or opens egress. Ambiguous credential shapes remain valid
+with any known explicit provider.
 
 You don't need to worry about ordering when using the CLI flags together --
 `cluster up` composes `--allow-egress-host` and `--allow-web-egress` into


### PR DESCRIPTION
Summary

* Keeps bare `curie cluster up` successful and sealed when no provider is selected.
* Rejects contradictory Anthropic or OpenRouter provider selections before DNS or Helm mutation.
* Covers ambient, `--set`, and preserved credentials without exposing secret values.
* Leaves `cluster apply` and `cluster diff` unchanged.

Boundary

Accepted ADR 0032 prohibits automatic provider inference from credentials. This PR does not change that contract, schema, or ADR. The singleton and gVisor failures remain outside this fix under #1535, #1636, and #1653.

Validation

* `cd cli && cargo fmt --check && cargo clippy -- -D warnings && cargo test` passed.
* `bash scripts/check-docs.sh` passed.
* `curie dev verify-fix-pin HEAD cli/tests/installation_plan_parity.rs::cluster_up_rejects_a_contradictory_provider_before_dns_and_helm` reported `PINNED`.
* The local ladder could not start because ports 25432 and 26379 remain occupied by the separate issue 1661 stack. No containers from that run were stopped.

Closes #1662