### PR TITLE
Add cluster namespace inference

### DIFF
--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -1952,6 +1952,7 @@ export const commandManifest = {
               "default_values": [
                 "curie"
               ],
+              "env": "CURIE_NAMESPACE",
               "global": false,
               "help": "Kubernetes namespace",
               "id": "namespace",
@@ -2094,6 +2095,7 @@ export const commandManifest = {
               "default_values": [
                 "curie"
               ],
+              "env": "CURIE_NAMESPACE",
               "global": false,
               "help": "Kubernetes namespace",
               "id": "namespace",
@@ -2159,6 +2161,7 @@ export const commandManifest = {
               "default_values": [
                 "curie"
               ],
+              "env": "CURIE_NAMESPACE",
               "global": false,
               "help": "Kubernetes namespace",
               "id": "namespace",
@@ -2232,6 +2235,7 @@ export const commandManifest = {
               "default_values": [
                 "curie"
               ],
+              "env": "CURIE_NAMESPACE",
               "global": false,
               "help": "Kubernetes namespace",
               "id": "namespace",
@@ -2273,6 +2277,7 @@ export const commandManifest = {
               "default_values": [
                 "curie"
               ],
+              "env": "CURIE_NAMESPACE",
               "global": false,
               "help": "Kubernetes namespace",
               "id": "namespace",
@@ -2374,6 +2379,7 @@ export const commandManifest = {
               "default_values": [
                 "curie"
               ],
+              "env": "CURIE_NAMESPACE",
               "global": false,
               "help": "Kubernetes namespace",
               "id": "namespace",
@@ -2468,6 +2474,7 @@ export const commandManifest = {
               "default_values": [
                 "curie"
               ],
+              "env": "CURIE_NAMESPACE",
               "global": false,
               "help": "Kubernetes namespace",
               "id": "namespace",
@@ -2549,6 +2556,7 @@ export const commandManifest = {
               "required": false
             },
             {
+              "env": "CURIE_NAMESPACE",
               "global": false,
               "help": "Kubernetes namespace of the release. Default: curie",
               "id": "namespace",
@@ -2701,6 +2709,7 @@ export const commandManifest = {
               "default_values": [
                 "curie"
               ],
+              "env": "CURIE_NAMESPACE",
               "global": false,
               "help": "Kubernetes namespace of the release. Default: curie",
               "id": "namespace",
@@ -2902,6 +2911,7 @@ export const commandManifest = {
               "default_values": [
                 "curie"
               ],
+              "env": "CURIE_NAMESPACE",
               "global": false,
               "help": "Kubernetes namespace of the release (for the port-forward + key discovery). Default: curie",
               "id": "namespace",
@@ -3009,6 +3019,7 @@ export const commandManifest = {
               "default_values": [
                 "curie"
               ],
+              "env": "CURIE_NAMESPACE",
               "global": false,
               "help": "Kubernetes namespace of the release. Default: curie",
               "id": "namespace",
@@ -3087,6 +3098,7 @@ export const commandManifest = {
               "default_values": [
                 "curie"
               ],
+              "env": "CURIE_NAMESPACE",
               "global": false,
               "help": "Kubernetes namespace of the release. Default: curie",
               "id": "namespace",
@@ -3193,6 +3205,7 @@ export const commandManifest = {
               "default_values": [
                 "curie"
               ],
+              "env": "CURIE_NAMESPACE",
               "global": false,
               "help": "Kubernetes namespace of the release. Default: curie",
               "id": "namespace",
@@ -3268,6 +3281,7 @@ export const commandManifest = {
               "default_values": [
                 "curie"
               ],
+              "env": "CURIE_NAMESPACE",
               "global": false,
               "help": "Kubernetes namespace of the release. Default: curie",
               "id": "namespace",
@@ -3342,6 +3356,7 @@ export const commandManifest = {
               "default_values": [
                 "curie"
               ],
+              "env": "CURIE_NAMESPACE",
               "global": false,
               "help": "Kubernetes namespace of the release. Default: curie",
               "id": "namespace",
@@ -3420,6 +3435,7 @@ export const commandManifest = {
               "default_values": [
                 "curie"
               ],
+              "env": "CURIE_NAMESPACE",
               "global": false,
               "help": "Kubernetes namespace of the release. Default: curie",
               "id": "namespace",
@@ -3498,6 +3514,7 @@ export const commandManifest = {
               "default_values": [
                 "curie"
               ],
+              "env": "CURIE_NAMESPACE",
               "global": false,
               "help": "Kubernetes namespace of the release. Default: curie",
               "id": "namespace",
@@ -3563,6 +3580,7 @@ export const commandManifest = {
               "default_values": [
                 "curie"
               ],
+              "env": "CURIE_NAMESPACE",
               "global": false,
               "help": "Kubernetes namespace of the release. Default: curie",
               "id": "namespace",
@@ -3628,6 +3646,7 @@ export const commandManifest = {
               "default_values": [
                 "curie"
               ],
+              "env": "CURIE_NAMESPACE",
               "global": false,
               "help": "Kubernetes namespace of the release. Default: curie",
               "id": "namespace",

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -1949,6 +1949,7 @@
               "default_values": [
                 "curie"
               ],
+              "env": "CURIE_NAMESPACE",
               "global": false,
               "help": "Kubernetes namespace",
               "id": "namespace",
@@ -2091,6 +2092,7 @@
               "default_values": [
                 "curie"
               ],
+              "env": "CURIE_NAMESPACE",
               "global": false,
               "help": "Kubernetes namespace",
               "id": "namespace",
@@ -2156,6 +2158,7 @@
               "default_values": [
                 "curie"
               ],
+              "env": "CURIE_NAMESPACE",
               "global": false,
               "help": "Kubernetes namespace",
               "id": "namespace",
@@ -2229,6 +2232,7 @@
               "default_values": [
                 "curie"
               ],
+              "env": "CURIE_NAMESPACE",
               "global": false,
               "help": "Kubernetes namespace",
               "id": "namespace",
@@ -2270,6 +2274,7 @@
               "default_values": [
                 "curie"
               ],
+              "env": "CURIE_NAMESPACE",
               "global": false,
               "help": "Kubernetes namespace",
               "id": "namespace",
@@ -2371,6 +2376,7 @@
               "default_values": [
                 "curie"
               ],
+              "env": "CURIE_NAMESPACE",
               "global": false,
               "help": "Kubernetes namespace",
               "id": "namespace",
@@ -2465,6 +2471,7 @@
               "default_values": [
                 "curie"
               ],
+              "env": "CURIE_NAMESPACE",
               "global": false,
               "help": "Kubernetes namespace",
               "id": "namespace",
@@ -2546,6 +2553,7 @@
               "required": false
             },
             {
+              "env": "CURIE_NAMESPACE",
               "global": false,
               "help": "Kubernetes namespace of the release. Default: curie",
               "id": "namespace",
@@ -2698,6 +2706,7 @@
               "default_values": [
                 "curie"
               ],
+              "env": "CURIE_NAMESPACE",
               "global": false,
               "help": "Kubernetes namespace of the release. Default: curie",
               "id": "namespace",
@@ -2899,6 +2908,7 @@
               "default_values": [
                 "curie"
               ],
+              "env": "CURIE_NAMESPACE",
               "global": false,
               "help": "Kubernetes namespace of the release (for the port-forward + key discovery). Default: curie",
               "id": "namespace",
@@ -3006,6 +3016,7 @@
               "default_values": [
                 "curie"
               ],
+              "env": "CURIE_NAMESPACE",
               "global": false,
               "help": "Kubernetes namespace of the release. Default: curie",
               "id": "namespace",
@@ -3084,6 +3095,7 @@
               "default_values": [
                 "curie"
               ],
+              "env": "CURIE_NAMESPACE",
               "global": false,
               "help": "Kubernetes namespace of the release. Default: curie",
               "id": "namespace",
@@ -3190,6 +3202,7 @@
               "default_values": [
                 "curie"
               ],
+              "env": "CURIE_NAMESPACE",
               "global": false,
               "help": "Kubernetes namespace of the release. Default: curie",
               "id": "namespace",
@@ -3265,6 +3278,7 @@
               "default_values": [
                 "curie"
               ],
+              "env": "CURIE_NAMESPACE",
               "global": false,
               "help": "Kubernetes namespace of the release. Default: curie",
               "id": "namespace",
@@ -3339,6 +3353,7 @@
               "default_values": [
                 "curie"
               ],
+              "env": "CURIE_NAMESPACE",
               "global": false,
               "help": "Kubernetes namespace of the release. Default: curie",
               "id": "namespace",
@@ -3417,6 +3432,7 @@
               "default_values": [
                 "curie"
               ],
+              "env": "CURIE_NAMESPACE",
               "global": false,
               "help": "Kubernetes namespace of the release. Default: curie",
               "id": "namespace",
@@ -3495,6 +3511,7 @@
               "default_values": [
                 "curie"
               ],
+              "env": "CURIE_NAMESPACE",
               "global": false,
               "help": "Kubernetes namespace of the release. Default: curie",
               "id": "namespace",
@@ -3560,6 +3577,7 @@
               "default_values": [
                 "curie"
               ],
+              "env": "CURIE_NAMESPACE",
               "global": false,
               "help": "Kubernetes namespace of the release. Default: curie",
               "id": "namespace",
@@ -3625,6 +3643,7 @@
               "default_values": [
                 "curie"
               ],
+              "env": "CURIE_NAMESPACE",
               "global": false,
               "help": "Kubernetes namespace of the release. Default: curie",
               "id": "namespace",

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -83,7 +83,7 @@ struct ClusterConn {
     #[arg(long, env = "CURIE_API_KEY")]
     api_key: Option<String>,
     /// Kubernetes namespace of the release. Default: curie.
-    #[arg(long, default_value = "curie")]
+    #[arg(long, default_value = "curie", env = "CURIE_NAMESPACE")]
     namespace: String,
     /// Helm release name. Default: curie.
     #[arg(long, default_value = "curie")]
@@ -1309,7 +1309,7 @@ enum ClusterAction {
     /// credential and named egress.
     Up {
         /// Kubernetes namespace.
-        #[arg(long, default_value = "curie")]
+        #[arg(long, default_value = "curie", env = "CURIE_NAMESPACE")]
         namespace: String,
         /// Helm release name.
         #[arg(long, default_value = "curie")]
@@ -1382,7 +1382,7 @@ enum ClusterAction {
     /// kubectl delete namespace). The agents.x-k8s.io CRDs are left in place.
     Down {
         /// Kubernetes namespace.
-        #[arg(long, default_value = "curie")]
+        #[arg(long, default_value = "curie", env = "CURIE_NAMESPACE")]
         namespace: String,
         /// Helm release name.
         #[arg(long, default_value = "curie")]
@@ -1428,7 +1428,7 @@ enum ClusterAction {
         #[arg(long, value_parser = ["export", "import"])]
         phase: Option<String>,
         /// Kubernetes namespace.
-        #[arg(long, default_value = "curie")]
+        #[arg(long, default_value = "curie", env = "CURIE_NAMESPACE")]
         namespace: String,
         /// Helm release name.
         #[arg(long, default_value = "curie")]
@@ -1452,7 +1452,7 @@ enum ClusterAction {
     /// Report release health and access URLs (read-only: helm status + kubectl).
     Status {
         /// Kubernetes namespace.
-        #[arg(long, default_value = "curie")]
+        #[arg(long, default_value = "curie", env = "CURIE_NAMESPACE")]
         namespace: String,
         /// Helm release name.
         #[arg(long, default_value = "curie")]
@@ -1464,7 +1464,7 @@ enum ClusterAction {
     /// Show the release's observability surfaces (Curie Console + Langfuse traces/cost + API base).
     Observability {
         /// Kubernetes namespace.
-        #[arg(long, default_value = "curie")]
+        #[arg(long, default_value = "curie", env = "CURIE_NAMESPACE")]
         namespace: String,
         /// Helm release name.
         #[arg(long, default_value = "curie")]
@@ -1504,7 +1504,7 @@ enum ClusterAction {
         )]
         bot_token: String,
         /// Kubernetes namespace.
-        #[arg(long, default_value = "curie")]
+        #[arg(long, default_value = "curie", env = "CURIE_NAMESPACE")]
         namespace: String,
         /// Helm release name.
         #[arg(long, default_value = "curie")]
@@ -1532,7 +1532,7 @@ enum ClusterAction {
         #[arg(long)]
         disconnect: bool,
         /// Kubernetes namespace.
-        #[arg(long, default_value = "curie")]
+        #[arg(long, default_value = "curie", env = "CURIE_NAMESPACE")]
         namespace: String,
         /// Helm release name.
         #[arg(long, default_value = "curie")]
@@ -1563,7 +1563,7 @@ enum ClusterAction {
         #[arg(long = "continue")]
         r#continue: bool,
         /// Kubernetes namespace of the release. Default: curie.
-        #[arg(long)]
+        #[arg(long, env = "CURIE_NAMESPACE")]
         namespace: Option<String>,
         /// Helm release name. Default: curie.
         #[arg(long)]
@@ -1630,7 +1630,7 @@ enum ClusterAction {
         #[arg(long)]
         channel: Option<String>,
         /// Kubernetes namespace of the release. Default: curie.
-        #[arg(long, default_value = "curie")]
+        #[arg(long, default_value = "curie", env = "CURIE_NAMESPACE")]
         namespace: String,
         /// Helm release name. Default: curie.
         #[arg(long, default_value = "curie")]
@@ -1722,7 +1722,7 @@ enum ClusterAction {
         #[arg(long, env = "CURIE_API_URL")]
         api_url: Option<String>,
         /// Kubernetes namespace of the release (for the port-forward + key discovery). Default: curie.
-        #[arg(long, default_value = "curie")]
+        #[arg(long, default_value = "curie", env = "CURIE_NAMESPACE")]
         namespace: String,
         /// Helm release name (for the port-forward + key discovery). Default: curie.
         #[arg(long, default_value = "curie")]

--- a/cli/src/message.rs
+++ b/cli/src/message.rs
@@ -3646,6 +3646,91 @@ mod tests {
         assert!(!prefers_docker_internal_host("my-eks.example.com", true));
     }
 
+    const ADVERTISE_HOST_CHILD_CASE: &str = "CURIE_TEST_ADVERTISE_HOST_CASE";
+
+    fn run_advertise_host_child(case: &str, path: &std::path::Path) {
+        let output =
+            std::process::Command::new(std::env::current_exe().expect("resolve test executable"))
+                .arg("message::tests::advertise_host_child")
+                .arg("--exact")
+                .arg("--nocapture")
+                .env(ADVERTISE_HOST_CHILD_CASE, case)
+                .env("PATH", path)
+                .output()
+                .expect("run advertise host child");
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            output.status.success(),
+            "advertise host child failed\nstdout:\n{stdout}\nstderr:\n{stderr}"
+        );
+        let sentinel = format!("ADVERTISE_HOST_OK {case}");
+        assert!(
+            stdout
+                .lines()
+                .any(|line| line.trim() == sentinel.as_str()),
+            "advertise host child did not prove case {case} ran\nstdout:\n{stdout}\nstderr:\n{stderr}"
+        );
+    }
+
+    #[tokio::test]
+    async fn advertise_host_child() {
+        let Ok(case) = std::env::var(ADVERTISE_HOST_CHILD_CASE) else {
+            return;
+        };
+        match case.as_str() {
+            "kernel_route" => {
+                let target = "192.0.2.1";
+                let socket =
+                    std::net::UdpSocket::bind("0.0.0.0:0").expect("bind route source probe");
+                socket
+                    .connect((target, 6443))
+                    .expect("select route toward documentation address");
+                let expected = socket.local_addr().expect("read route source").ip();
+                let actual = resolve_advertise_host(None)
+                    .await
+                    .expect("derive advertise host");
+                assert_eq!(actual, expected.to_string());
+                assert_ne!(actual, target);
+            }
+            "explicit" => {
+                let actual = resolve_advertise_host(Some("192.0.2.44"))
+                    .await
+                    .expect("accept explicit listen host");
+                assert_eq!(actual, "192.0.2.44");
+            }
+            other => panic!("unknown advertise host child case {other}"),
+        }
+        println!("ADVERTISE_HOST_OK {case}");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_advertise_host_uses_kernel_route_source() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tools = tempfile::tempdir().expect("create kubectl stub directory");
+        let kubectl = tools.path().join("kubectl");
+        std::fs::write(
+            &kubectl,
+            "#!/bin/sh\nprintf '%s\\n' 'https://192.0.2.1:6443'\n",
+        )
+        .expect("write kubectl stub");
+        let mut permissions = std::fs::metadata(&kubectl)
+            .expect("read kubectl stub metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&kubectl, permissions).expect("make kubectl stub executable");
+
+        run_advertise_host_child("kernel_route", tools.path());
+    }
+
+    #[test]
+    fn explicit_listen_host_bypasses_auto_detection() {
+        let no_tools = tempfile::tempdir().expect("create empty executable directory");
+        run_advertise_host_child("explicit", no_tools.path());
+    }
+
     #[test]
     fn dry_run_lists_the_valkey_forward_and_the_enqueue_with_the_reply_endpoint() {
         let lines = dry_run_lines(&opts(Some("C123")), "10.1.2.3");

--- a/cli/tests/command_surface.rs
+++ b/cli/tests/command_surface.rs
@@ -18,6 +18,69 @@ fn output_text(output: &std::process::Output) -> String {
     String::from_utf8_lossy(&output.stdout).into_owned() + &String::from_utf8_lossy(&output.stderr)
 }
 
+fn live_command_manifest() -> serde_json::Value {
+    let output = Command::new(bin())
+        .arg("schema")
+        .output()
+        .expect("run curie schema");
+    assert!(
+        output.status.success(),
+        "curie schema failed\n{}",
+        output_text(&output)
+    );
+    serde_json::from_slice(&output.stdout).expect("curie schema emits JSON")
+}
+
+fn cluster_status_plan(env_namespace: &str, flag_namespace: Option<&str>) -> Vec<String> {
+    let mut command = Command::new(bin());
+    command
+        .arg("--json")
+        .args(["cluster", "status", "--dry-run"])
+        .env("CURIE_NAMESPACE", env_namespace);
+    if let Some(namespace) = flag_namespace {
+        command.args(["--namespace", namespace]);
+    }
+    let output = command.output().expect("run curie cluster status dry run");
+    assert!(
+        output.status.success(),
+        "curie cluster status dry run failed\n{}",
+        output_text(&output)
+    );
+    let value: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("status dry run emits JSON");
+    value["plan"]
+        .as_array()
+        .expect("status dry run includes a plan")
+        .iter()
+        .map(|line| {
+            line.as_str()
+                .expect("status plan entries are strings")
+                .to_string()
+        })
+        .collect()
+}
+
+fn assert_status_plan_namespace(plan: &[String], namespace: &str) {
+    let namespaced: Vec<_> = plan.iter().filter(|line| line.contains(" -n ")).collect();
+    assert!(
+        !namespaced.is_empty(),
+        "status plan must include namespace aware commands: {plan:?}"
+    );
+    let expected = format!(" -n {namespace}");
+    assert!(
+        namespaced.iter().all(|line| line.contains(&expected)),
+        "every namespace aware command must use {namespace}: {plan:?}"
+    );
+    assert!(
+        namespaced.iter().any(|line| line.starts_with("helm ")),
+        "the Helm status command must use {namespace}: {plan:?}"
+    );
+    assert!(
+        namespaced.iter().any(|line| line.starts_with("kubectl ")),
+        "the kubectl status commands must use {namespace}: {plan:?}"
+    );
+}
+
 fn help_lists_subcommand(text: &str, name: &str) -> bool {
     text.lines().any(|line| {
         let line = line.trim_start();
@@ -224,6 +287,58 @@ fn command_manifest_matches_committed_artifact() {
         generated, committed,
         "cli/command-manifest.json is stale; regenerate with \
          `cargo run -- schema > cli/command-manifest.json`"
+    );
+}
+
+#[test]
+fn cluster_namespace_env_reaches_every_cluster_verb() {
+    let manifest = live_command_manifest();
+    let cluster = manifest["subcommands"]
+        .as_array()
+        .expect("manifest has top level subcommands")
+        .iter()
+        .find(|command| command["name"] == "cluster")
+        .expect("manifest has the cluster command");
+    let subcommands = cluster["subcommands"]
+        .as_array()
+        .expect("cluster has subcommands");
+    assert!(
+        !subcommands.is_empty(),
+        "cluster namespace coverage must not be vacuous"
+    );
+
+    for subcommand in subcommands {
+        let name = subcommand["name"]
+            .as_str()
+            .expect("cluster subcommand has a name");
+        let namespace_args: Vec<_> = subcommand["args"]
+            .as_array()
+            .expect("cluster subcommand has arguments")
+            .iter()
+            .filter(|arg| arg["id"] == "namespace")
+            .collect();
+        assert_eq!(
+            namespace_args.len(),
+            1,
+            "cluster {name} must expose exactly one namespace argument"
+        );
+        assert_eq!(
+            namespace_args[0]["env"], "CURIE_NAMESPACE",
+            "cluster {name} must read CURIE_NAMESPACE"
+        );
+    }
+}
+
+#[test]
+fn cluster_namespace_flag_wins_over_environment() {
+    let env_plan = cluster_status_plan("env-namespace", None);
+    assert_status_plan_namespace(&env_plan, "env-namespace");
+
+    let flag_plan = cluster_status_plan("env-namespace", Some("flag-namespace"));
+    assert_status_plan_namespace(&flag_plan, "flag-namespace");
+    assert!(
+        flag_plan.iter().all(|line| !line.contains("env-namespace")),
+        "the environment namespace must not survive an explicit flag: {flag_plan:?}"
     );
 }
 


### PR DESCRIPTION
Closes #1664

Adds CURIE_NAMESPACE as the fallback for every cluster verb while preserving explicit flag precedence and existing defaults. Regenerates both command manifests. Pins Linux kernel route source inference and explicit listen host override with regression coverage.

Trace id and Langfuse URL emission is not included because truthful propagation requires changes to the frozen ACI Final contract and the closed message result schema. Per the task constraint, those contract changes need separate review.

Implementation checklist

* [x] Failing namespace tests committed before production code
* [x] Production edits delegated
* [x] No public return type broadened
* [x] Correctness and scope reviews approved
* [x] Every cluster verb and both manifests covered
* [x] Regression reversal proof passed
* [x] Security review not applicable
* [x] User facing behavior observed
* [x] Cluster end to end passed and namespace cleaned
* [x] Full affected CLI and UI gates passed