### PR TITLE
Promote model configuration across tiers

### DIFF
--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -644,6 +644,14 @@ export const commandManifest = {
             },
             {
               "global": false,
+              "help": "Model id, forwarded as CURIE_MODEL. Omit for the SDK default. Setting it makes token usage attributable in Langfuse traces",
+              "id": "model",
+              "long": "model",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
               "help": "Run the named model through local Ollama",
               "id": "local_model",
               "long": "local-model",
@@ -732,6 +740,14 @@ export const commandManifest = {
                 "true",
                 "false"
               ],
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Model id, forwarded as CURIE_MODEL. Omit for the SDK default. Match the explicit model used by `local up`",
+              "id": "model",
+              "long": "model",
+              "positional": false,
               "required": false
             },
             {
@@ -888,6 +904,15 @@ export const commandManifest = {
                 "true",
                 "false"
               ],
+              "required": false
+            },
+            {
+              "env": "CURIE_MODEL",
+              "global": false,
+              "help": "Match the explicit model used by `local up`. Defaults from CURIE_MODEL",
+              "id": "model",
+              "long": "model",
+              "positional": false,
               "required": false
             },
             {
@@ -2000,6 +2025,14 @@ export const commandManifest = {
                 "true",
                 "false"
               ],
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Model id, forwarded as CURIE_MODEL. Omit for the SDK default. Setting it makes token usage attributable in Langfuse traces",
+              "id": "model",
+              "long": "model",
+              "positional": false,
               "required": false
             },
             {

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -641,6 +641,14 @@
             },
             {
               "global": false,
+              "help": "Model id, forwarded as CURIE_MODEL. Omit for the SDK default. Setting it makes token usage attributable in Langfuse traces",
+              "id": "model",
+              "long": "model",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
               "help": "Run the named model through local Ollama",
               "id": "local_model",
               "long": "local-model",
@@ -729,6 +737,14 @@
                 "true",
                 "false"
               ],
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Model id, forwarded as CURIE_MODEL. Omit for the SDK default. Match the explicit model used by `local up`",
+              "id": "model",
+              "long": "model",
+              "positional": false,
               "required": false
             },
             {
@@ -885,6 +901,15 @@
                 "true",
                 "false"
               ],
+              "required": false
+            },
+            {
+              "env": "CURIE_MODEL",
+              "global": false,
+              "help": "Match the explicit model used by `local up`. Defaults from CURIE_MODEL",
+              "id": "model",
+              "long": "model",
+              "positional": false,
               "required": false
             },
             {
@@ -1997,6 +2022,14 @@
                 "true",
                 "false"
               ],
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Model id, forwarded as CURIE_MODEL. Omit for the SDK default. Setting it makes token usage attributable in Langfuse traces",
+              "id": "model",
+              "long": "model",
+              "positional": false,
               "required": false
             },
             {

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -1395,7 +1395,7 @@ pub(crate) fn env_credential_present(name: &str) -> bool {
     std::env::var(name).is_ok_and(|value| !value.is_empty())
 }
 
-fn secret_store_env(name: &str) -> Result<Option<(String, String)>> {
+pub(crate) fn secret_store_env(name: &str) -> Result<Option<(String, String)>> {
     if env_credential_present(name) {
         return Ok(None);
     }
@@ -1423,9 +1423,12 @@ fn ambient_present_for(docker_env: &[(String, String)]) -> impl Fn(&str) -> bool
     move |name| std::env::var_os(name).is_some() || stored_env_contains(docker_env, name)
 }
 
-fn load_model_credentials_from_secret_store() -> Result<Vec<(String, String)>> {
+pub(crate) fn load_model_credentials_from_secret_store() -> Result<Vec<(String, String)>> {
     // Prefer an explicitly BYO Curie credential when saved, otherwise hydrate
     // the SDK credential names in the same order `select_passthrough_env` uses.
+    if env_credential_present("CURIE_CREDENTIALS") {
+        return Ok(Vec::new());
+    }
     if let Some(pair) = secret_store_env("CURIE_CREDENTIALS")? {
         return Ok(vec![pair]);
     }

--- a/cli/src/comms.rs
+++ b/cli/src/comms.rs
@@ -32,6 +32,10 @@ pub struct LocalCommsOpts {
     /// `fake_model_env_override` as `up_command` so `local comms` never
     /// silently downgrades a live stack back to the fake model.
     pub model_mode: ModelMode,
+    /// Model credentials resolved with the same precedence as `local up`.
+    pub model_credentials: Vec<(String, String)>,
+    /// Explicit provider model id to preserve from `local up`.
+    pub model: Option<String>,
     /// Whether the stack was brought up with `local up --minimal` (the `core`
     /// profile, no otel-collector). Same parity obligation as `model_mode`: the
     /// worker-restarting commands below apply the same
@@ -81,6 +85,9 @@ pub fn disconnect_commands(opts: &CommsOpts) -> Vec<OpsCommand> {
 pub fn local_connect_commands(o: &LocalCommsOpts) -> Vec<OpsCommand> {
     let mut env = vec![("SLACK_API_BASE_URL".into(), String::new())];
     env.extend(fake_model_env_override(o.model_mode));
+    if let Some(model) = &o.model {
+        env.push(("CURIE_MODEL".into(), model.clone()));
+    }
     env.extend(otel_endpoint_env_override(o.minimal));
     vec![OpsCommand::new(
         "docker",
@@ -100,10 +107,14 @@ pub fn local_connect_commands(o: &LocalCommsOpts) -> Vec<OpsCommand> {
         ],
     )
     .with_env(env)
-    .with_secret_env(vec![
-        ("SLACK_APP_TOKEN".into(), o.app_token.clone()),
-        ("SLACK_BOT_TOKEN".into(), o.bot_token.clone()),
-    ])]
+    .with_secret_env({
+        let mut secret_env = vec![
+            ("SLACK_APP_TOKEN".into(), o.app_token.clone()),
+            ("SLACK_BOT_TOKEN".into(), o.bot_token.clone()),
+        ];
+        secret_env.extend(o.model_credentials.clone());
+        secret_env
+    })]
 }
 
 pub fn local_disconnect_commands(o: &LocalCommsOpts) -> Vec<OpsCommand> {
@@ -112,6 +123,9 @@ pub fn local_disconnect_commands(o: &LocalCommsOpts) -> Vec<OpsCommand> {
         ("SLACK_BOT_TOKEN".into(), LOCAL_SLACK_STUB_BOT_TOKEN.into()),
     ];
     worker_env.extend(fake_model_env_override(o.model_mode));
+    if let Some(model) = &o.model {
+        worker_env.push(("CURIE_MODEL".into(), model.clone()));
+    }
     worker_env.extend(otel_endpoint_env_override(o.minimal));
     vec![
         OpsCommand::new(
@@ -142,7 +156,8 @@ pub fn local_disconnect_commands(o: &LocalCommsOpts) -> Vec<OpsCommand> {
                 plain("curie-worker"),
             ],
         )
-        .with_env(worker_env),
+        .with_env(worker_env)
+        .with_secret_env(o.model_credentials.clone()),
     ]
 }
 
@@ -612,6 +627,8 @@ mod tests {
             },
             disconnect,
             model_mode: mode,
+            model_credentials: vec![],
+            model: None,
             minimal,
         }
     }
@@ -625,6 +642,8 @@ mod tests {
             bot_token: "xoxb-1-secretsecret".into(),
             disconnect: false,
             model_mode: ModelMode::DefaultFake,
+            model_credentials: vec![],
+            model: None,
             minimal: false,
         });
         assert_eq!(cmds.len(), 1);

--- a/cli/src/local.rs
+++ b/cli/src/local.rs
@@ -248,6 +248,8 @@ pub struct LocalRebuildOpts {
     pub common: LocalOpts,
     /// The compose service to rebuild + recreate, e.g. `curie-worker`.
     pub service: String,
+    /// Explicit provider model id to preserve from `local up`.
+    pub model: Option<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -265,6 +267,10 @@ fn compose(file: &str, tail: &[&str]) -> OpsCommand {
 
 /// `docker compose --profile <core|full> [--profile local-model] [--profile slack] -f <file> up -d --wait`.
 pub fn up_command(o: &LocalOpts) -> OpsCommand {
+    up_command_with_model(o, None)
+}
+
+fn up_command_with_model(o: &LocalOpts, model: Option<&str>) -> OpsCommand {
     let profile = if o.minimal { "core" } else { "full" };
     let mut args = vec![plain("compose"), plain("--profile"), plain(profile)];
     if o.local_model.is_some() {
@@ -310,7 +316,12 @@ pub fn up_command(o: &LocalOpts) -> OpsCommand {
         // compose goes live, matching `skill up`. FakePinnedDespiteCredential
         // and DefaultFake inject nothing, so compose's
         // `${CURIE_FAKE_MODEL:-1}` default stands for those two modes.
-        fake_model_env_override(o.model_mode).into_iter().collect()
+        let mut env: Vec<(String, String)> =
+            fake_model_env_override(o.model_mode).into_iter().collect();
+        if let Some(model) = model {
+            env.push(("CURIE_MODEL".into(), model.to_string()));
+        }
+        env
     };
     // Delegate to `otel_endpoint_env_override`, the single source of truth for
     // the `core`-profile collector suppression. This sits AFTER the branch
@@ -336,7 +347,7 @@ pub fn up_command(o: &LocalOpts) -> OpsCommand {
 /// cost a debugging session getting a real agent working locally. `--no-deps`
 /// keeps the blast radius to the one named service; `--build` picks up a local
 /// code change before recreating.
-pub fn rebuild_command(o: &LocalOpts, service: &str) -> OpsCommand {
+pub fn rebuild_command(o: &LocalOpts, service: &str, model: Option<&str>) -> OpsCommand {
     let profile = if o.minimal { "core" } else { "full" };
     let mut args = vec![plain("compose"), plain("--profile"), plain(profile)];
     if o.local_model.is_some() {
@@ -376,7 +387,12 @@ pub fn rebuild_command(o: &LocalOpts, service: &str) -> OpsCommand {
             ("COMPOSE_PROJECT_NAME".into(), "curie".into()),
         ]
     } else {
-        fake_model_env_override(o.model_mode).into_iter().collect()
+        let mut env: Vec<(String, String)> =
+            fake_model_env_override(o.model_mode).into_iter().collect();
+        if let Some(model) = model {
+            env.push(("CURIE_MODEL".into(), model.to_string()));
+        }
+        env
     };
     env.extend(otel_endpoint_env_override(o.minimal));
     if !env.is_empty() {
@@ -469,43 +485,78 @@ impl crate::ui::CliOutput for LocalUpOutput {
     }
 }
 
-/// Apply the opt-in bundle `.env` plan (#749, ADR-0070) to a worker-starting
-/// verb's options, in place: fold a file-only model credential into the model
-/// mode so the stack boots live exactly as a shell credential would, emit a
-/// per-credential "loaded from --env-file" note, and return the credentials to
-/// attach as masked `secret_env` (never argv/logs). Shared by `local up` and
-/// `local rebuild` so a targeted rebuild comes back with the SAME
-/// credential/model-mode wiring the original `up` resolved from identical
-/// inputs (shell env + the same `--env-file`), rather than the fake-model revert
-/// #853 describes. A `None` env_file leaves the shell-resolved mode untouched
-/// and returns no credentials.
-fn apply_env_file_plan(o: &mut LocalOpts, ui: &crate::ui::Ui) -> Result<Vec<(String, String)>> {
-    // A name exported in the shell always wins; only a name absent from the
-    // shell is taken from the file. A `.env`-only credential still flips the
-    // stack live, so the model mode is recomputed with the file credential
-    // folded in.
-    let (env_creds, env_file_mode) = load_env_file_up_plan(o.env_file.as_deref())?;
-    if o.env_file.is_some() {
-        o.model_mode = env_file_mode;
-        for (name, _) in &env_creds {
+/// Resolve model credentials for a worker starting local verb. Private storage
+/// follows the shell and precedes the optional bundle `.env` file. Values are
+/// returned as masked `secret_env`, and every source contributes to the model
+/// mode decision. Shared by `local up` and `local rebuild` so both paths keep
+/// identical credential behavior.
+pub fn apply_credential_plan(
+    o: &mut LocalOpts,
+    ui: &crate::ui::Ui,
+) -> Result<Vec<(String, String)>> {
+    let explicit_fake_model = std::env::var("CURIE_FAKE_MODEL")
+        .ok()
+        .filter(|value| !value.is_empty());
+    let shell_has_credential = CREDENTIAL_ENV_VARS
+        .iter()
+        .any(|name| crate::commands::env_credential_present(name));
+    // A saved provider credential is an implicit input. Do not even open
+    // private storage when the operator explicitly selected the fake model or
+    // a local model, because neither path can use that credential. An explicit
+    // --env-file remains opt-in and retains its existing behavior below.
+    let skip_private_store = o.local_model.is_some()
+        || explicit_fake_model
+            .as_deref()
+            .is_some_and(fake_model_is_truthy);
+    let mut resolved = if skip_private_store {
+        Vec::new()
+    } else {
+        match crate::commands::load_model_credentials_from_secret_store() {
+            Ok(credentials) => credentials,
+            Err(error) => {
+                ui.warn(&format!(
+                    "Saved model credentials could not be read; continuing without them: {error}"
+                ));
+                Vec::new()
+            }
+        }
+    };
+    if let Some(path) = o.env_file.as_deref() {
+        let parsed = crate::commands::parse_credential_env_file(path)?;
+        let (from_file, model_mode) = resolve_env_file_up_plan(
+            &parsed,
+            &|name| {
+                crate::commands::env_credential_present(name)
+                    || resolved
+                        .iter()
+                        .any(|(resolved_name, _)| resolved_name == name)
+            },
+            explicit_fake_model.as_deref(),
+            shell_has_credential || !resolved.is_empty(),
+        );
+        for (name, _) in &from_file {
             ui.note(&format!(
                 "{name}: loaded from --env-file {} for this run",
-                o.env_file
-                    .as_deref()
-                    .map(|p| p.display().to_string())
-                    .unwrap_or_default()
+                path.display()
             ));
         }
+        resolved.extend(from_file);
+        o.model_mode = model_mode;
+    } else {
+        o.model_mode = resolve_model_mode(
+            explicit_fake_model.as_deref(),
+            shell_has_credential || !resolved.is_empty(),
+        );
     }
-    Ok(env_creds)
+    Ok(resolved)
 }
 
-pub async fn up(mut o: LocalOpts) -> Result<LocalUpOutput> {
+pub async fn up(mut o: LocalOpts, model: Option<String>) -> Result<LocalUpOutput> {
     let ui = crate::ui::ui();
     // #749/ADR-0070: an opt-in bundle `.env` is the LOWEST-priority model
     // credential source, injected into the compose child as masked `secret_env`.
-    let env_creds = apply_env_file_plan(&mut o, ui)?;
-    let mut cmd = up_command(&o);
+    let env_creds = apply_credential_plan(&mut o, ui)?;
+    let mut cmd = up_command_with_model(&o, model.as_deref());
     if !env_creds.is_empty() {
         cmd = cmd.with_secret_env(env_creds);
     }
@@ -531,15 +582,15 @@ pub async fn up(mut o: LocalOpts) -> Result<LocalUpOutput> {
     }
     let cl = ui.checklist();
     run_step(&cl, "starting dev stack", "up", &cmd).await?;
-    // `--local-model` is its own live path (routes to ollama); the shell-credential
-    // parity note only applies when no local model was requested.
+    // `--local-model` is its own live path (routes to ollama); the resolved
+    // credential parity note only applies when no local model was requested.
     if o.local_model.is_none() {
         match o.model_mode {
             ModelMode::LiveFromCredential => ui.note(
-                "Running the LIVE model: a credential is set in your shell (parity with `curie skill up`). Set CURIE_FAKE_MODEL=1 to force the offline fake model.",
+                "Running the LIVE model: a credential is available for this run (parity with `curie skill up`). Set CURIE_FAKE_MODEL=1 to force the offline fake model.",
             ),
             ModelMode::FakePinnedDespiteCredential => ui.warn(
-                "Running the FAKE model despite a credential in your shell: CURIE_FAKE_MODEL is pinned on. Unset it or set CURIE_FAKE_MODEL=0 to go live.",
+                "Running the FAKE model despite an available credential: CURIE_FAKE_MODEL is pinned on. Unset it or set CURIE_FAKE_MODEL=0 to go live.",
             ),
             ModelMode::DefaultFake => ui.note(
                 "Running the fake model (no credential set). Provide a credential (ANTHROPIC_API_KEY / CLAUDE_CODE_OAUTH_TOKEN / CURIE_CREDENTIALS) or --local-model to go live.",
@@ -595,13 +646,13 @@ impl crate::ui::CliOutput for LocalRebuildOutput {
                 ui.note(&format!("Rebuilt and recreated `{service}`."));
                 match model_mode {
                     ModelMode::LiveFromCredential => ui.note(
-                        "Came back up on the LIVE model: a credential is set in your shell.",
+                        "Came back up on the LIVE model: a credential is available for this run.",
                     ),
                     ModelMode::FakePinnedDespiteCredential => ui.warn(
-                        "Came back up on the FAKE model despite a credential in your shell: CURIE_FAKE_MODEL is pinned on.",
+                        "Came back up on the FAKE model despite an available credential: CURIE_FAKE_MODEL is pinned on.",
                     ),
                     ModelMode::DefaultFake => ui.note(
-                        "Came back up on the fake model (no credential set in this shell).",
+                        "Came back up on the fake model (no credential available for this run).",
                     ),
                 }
             }
@@ -626,8 +677,8 @@ pub async fn rebuild(mut o: LocalRebuildOpts) -> Result<LocalRebuildOutput> {
     // The same opt-in bundle `.env` plan `local up` applies: fold a file-only
     // credential into the model mode and inject it as masked `secret_env`, so
     // the resolved plan matches `up`'s for identical inputs (#853).
-    let env_creds = apply_env_file_plan(&mut o.common, ui)?;
-    let mut cmd = rebuild_command(&o.common, &o.service);
+    let env_creds = apply_credential_plan(&mut o.common, ui)?;
+    let mut cmd = rebuild_command(&o.common, &o.service, o.model.as_deref());
     if !env_creds.is_empty() {
         cmd = cmd.with_secret_env(env_creds);
     }
@@ -965,7 +1016,7 @@ mod tests {
     /// lands as the final token.
     #[test]
     fn rebuild_command_targets_one_service() {
-        let cmd = rebuild_command(&opts(DEFAULT_COMPOSE_FILE), "curie-worker");
+        let cmd = rebuild_command(&opts(DEFAULT_COMPOSE_FILE), "curie-worker", None);
         let display = cmd.display();
         assert!(display.contains("up -d --build --force-recreate --no-deps curie-worker"));
         assert!(!display.contains("--wait"));
@@ -979,15 +1030,28 @@ mod tests {
     fn rebuild_command_carries_live_model_parity() {
         let mut o = opts(DEFAULT_COMPOSE_FILE);
         o.model_mode = ModelMode::LiveFromCredential;
-        let cmd = rebuild_command(&o, "curie-worker");
+        let cmd = rebuild_command(&o, "curie-worker", None);
         assert!(cmd
             .env
             .contains(&(String::from("CURIE_FAKE_MODEL"), String::from("0"))));
     }
 
     #[test]
+    fn rebuild_command_carries_explicit_model_parity() {
+        let mut o = opts(DEFAULT_COMPOSE_FILE);
+        o.model_mode = ModelMode::LiveFromCredential;
+        let up = up_command_with_model(&o, Some("z-ai/glm-5.2"));
+        let rebuilt = rebuild_command(&o, "curie-worker", Some("z-ai/glm-5.2"));
+
+        assert_eq!(up.env, rebuilt.env, "rebuild model env drifted from up");
+        assert!(rebuilt
+            .env
+            .contains(&(String::from("CURIE_MODEL"), String::from("z-ai/glm-5.2"))));
+    }
+
+    #[test]
     fn rebuild_command_default_fake_injects_nothing() {
-        let cmd = rebuild_command(&opts(DEFAULT_COMPOSE_FILE), "curie-worker");
+        let cmd = rebuild_command(&opts(DEFAULT_COMPOSE_FILE), "curie-worker", None);
         assert!(cmd.env.is_empty(), "env={:?}", cmd.env);
     }
 
@@ -996,6 +1060,7 @@ mod tests {
         let cmd = rebuild_command(
             &opts_with_local_model(DEFAULT_COMPOSE_FILE, "qwen3:4b"),
             "curie-worker",
+            None,
         );
         assert!(cmd
             .env
@@ -1009,7 +1074,7 @@ mod tests {
     fn rebuild_command_minimal_suppresses_otel_endpoint() {
         let mut o = opts(DEFAULT_COMPOSE_FILE);
         o.minimal = true;
-        let cmd = rebuild_command(&o, "curie-worker");
+        let cmd = rebuild_command(&o, "curie-worker", None);
         assert!(cmd
             .env
             .contains(&(String::from("OTEL_EXPORTER_OTLP_ENDPOINT"), String::new())));
@@ -1020,7 +1085,7 @@ mod tests {
     fn rebuild_command_respects_slack_profile() {
         let mut o = opts(DEFAULT_COMPOSE_FILE);
         o.slack = true;
-        let display = rebuild_command(&o, "curie-dispatcher").display();
+        let display = rebuild_command(&o, "curie-dispatcher", None).display();
         assert!(display.contains("--profile slack"));
     }
 
@@ -1115,7 +1180,7 @@ mod tests {
     /// identical model/credential wiring, so the rebuilt service comes back LIVE
     /// rather than reverting to compose's fake default. Asserted on the resolved
     /// plan (the env and secret_env of the built command), not on flag presence.
-    /// Both verbs share `apply_env_file_plan`, so identical inputs cannot diverge.
+    /// Both verbs share `apply_credential_plan`, so identical inputs cannot diverge.
     #[test]
     fn rebuild_matches_up_env_file_wiring() {
         let secret = "sk-ant-fromfile";
@@ -1126,7 +1191,7 @@ mod tests {
         let creds = vec![("ANTHROPIC_API_KEY".to_string(), secret.to_string())];
 
         let up = up_command(&o).with_secret_env(creds.clone());
-        let rebuilt = rebuild_command(&o, "curie-worker").with_secret_env(creds.clone());
+        let rebuilt = rebuild_command(&o, "curie-worker", None).with_secret_env(creds.clone());
 
         // The live-model flip is present on both, and the plain env + masked
         // credential wiring match exactly across the two verbs.
@@ -1153,7 +1218,7 @@ mod tests {
         let secret = "sk-ant-supersecretvalue";
         let mut o = opts(DEFAULT_COMPOSE_FILE);
         o.model_mode = ModelMode::LiveFromCredential;
-        let cmd = rebuild_command(&o, "curie-worker")
+        let cmd = rebuild_command(&o, "curie-worker", None)
             .with_secret_env(vec![("ANTHROPIC_API_KEY".to_string(), secret.to_string())]);
         let display = cmd.display();
         assert!(

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -824,6 +824,10 @@ enum LocalAction {
         /// Bring up only the 7 core services (skip Langfuse/ClickHouse/OTel/UI).
         #[arg(long)]
         minimal: bool,
+        /// Model id, forwarded as CURIE_MODEL. Omit for the SDK default.
+        /// Setting it makes token usage attributable in Langfuse traces.
+        #[arg(long, conflicts_with = "local_model")]
+        model: Option<String>,
         /// Run the named model through local Ollama.
         #[arg(
             long,
@@ -870,6 +874,10 @@ enum LocalAction {
         /// Match how `local up` brought the stack up (core-only vs full).
         #[arg(long)]
         minimal: bool,
+        /// Model id, forwarded as CURIE_MODEL. Omit for the SDK default.
+        /// Match the explicit model used by `local up`.
+        #[arg(long, conflicts_with = "local_model")]
+        model: Option<String>,
         /// Match how `local up` brought the stack up (--local-model, if used).
         #[arg(
             long,
@@ -926,6 +934,9 @@ enum LocalAction {
         /// The stack runs only the 7 core services (skip Langfuse/ClickHouse/OTel/UI). Must match how `local up` brought it up.
         #[arg(long)]
         minimal: bool,
+        /// Match the explicit model used by `local up`. Defaults from CURIE_MODEL.
+        #[arg(long, env = "CURIE_MODEL")]
+        model: Option<String>,
         /// Slack app token. Defaults from SLACK_APP_TOKEN.
         #[arg(
             long,
@@ -1324,6 +1335,10 @@ enum ClusterAction {
         /// is set (dev/CI escape hatch); suppresses the fake-model warning.
         #[arg(long)]
         fake_model: bool,
+        /// Model id, forwarded as CURIE_MODEL. Omit for the SDK default.
+        /// Setting it makes token usage attributable in Langfuse traces.
+        #[arg(long, conflicts_with = "local_model")]
+        model: Option<String>,
         /// Run the named model through the chart inference deployment.
         #[arg(
             long,
@@ -2201,6 +2216,7 @@ async fn run(command: Option<Command>) -> Result<()> {
                 file,
                 dry_run,
                 minimal,
+                model,
                 local_model,
                 pull_model,
                 slack,
@@ -2208,16 +2224,19 @@ async fn run(command: Option<Command>) -> Result<()> {
             } => {
                 let file = resolve_compose_file(file, dry_run).await?;
                 emit(
-                    local::up(LocalOpts {
-                        file,
-                        dry_run,
-                        minimal,
-                        local_model,
-                        pull_model,
-                        slack,
-                        model_mode: local::model_mode_from_env(),
-                        env_file,
-                    })
+                    local::up(
+                        LocalOpts {
+                            file,
+                            dry_run,
+                            minimal,
+                            local_model,
+                            pull_model,
+                            slack,
+                            model_mode: local::model_mode_from_env(),
+                            env_file,
+                        },
+                        model,
+                    )
                     .await?,
                 )
             }
@@ -2226,6 +2245,7 @@ async fn run(command: Option<Command>) -> Result<()> {
                 file,
                 dry_run,
                 minimal,
+                model,
                 local_model,
                 slack,
                 env_file,
@@ -2244,6 +2264,7 @@ async fn run(command: Option<Command>) -> Result<()> {
                             env_file,
                         },
                         service,
+                        model,
                     })
                     .await?,
                 )
@@ -2293,6 +2314,7 @@ async fn run(command: Option<Command>) -> Result<()> {
                 slack,
                 disconnect,
                 minimal,
+                model,
                 app_token,
                 bot_token,
                 file,
@@ -2308,6 +2330,18 @@ async fn run(command: Option<Command>) -> Result<()> {
                     comms::resolve_local_slack_token("SLACK_APP_TOKEN", &app_token, disconnect)?;
                 let bot_token =
                     comms::resolve_local_slack_token("SLACK_BOT_TOKEN", &bot_token, disconnect)?;
+                let mut model_opts = LocalOpts {
+                    file: resolved_file.clone(),
+                    dry_run,
+                    minimal,
+                    local_model: None,
+                    pull_model: false,
+                    slack: true,
+                    model_mode: local::model_mode_from_env(),
+                    env_file: None,
+                };
+                let model_credentials =
+                    local::apply_credential_plan(&mut model_opts, crate::ui::ui())?;
                 emit(
                     comms::local_comms(LocalCommsOpts {
                         file: resolved_file,
@@ -2315,7 +2349,9 @@ async fn run(command: Option<Command>) -> Result<()> {
                         app_token,
                         bot_token,
                         disconnect,
-                        model_mode: local::model_mode_from_env(),
+                        model_mode: model_opts.model_mode,
+                        model_credentials,
+                        model,
                         minimal,
                     })
                     .await?,
@@ -2613,6 +2649,7 @@ async fn run(command: Option<Command>) -> Result<()> {
                 chart,
                 no_expose,
                 fake_model,
+                model,
                 local_model,
                 allow_egress_host,
                 allow_web_egress,
@@ -2630,10 +2667,10 @@ async fn run(command: Option<Command>) -> Result<()> {
                     std::path::Path::new("charts/curie").is_dir(),
                 )?;
                 let chart = materialize_artifact(resolved, dry_run, "chart").await?;
-                let credentials = if local_model.is_some() {
+                let credentials = if fake_model || local_model.is_some() {
                     None
                 } else {
-                    ops::resolve_up_credentials(fake_model, ops::model_credential_env())
+                    ops::resolve_up_credentials(fake_model, ops::model_credential_env()?)
                 };
                 emit(
                     ops::up(
@@ -2659,7 +2696,9 @@ async fn run(command: Option<Command>) -> Result<()> {
                             // Default `agentSandbox.runner.model` from the shell
                             // `CURIE_MODEL` (None when unset/empty) for cross-tier
                             // parity with `local up` (#361).
-                            model: std::env::var("CURIE_MODEL").ok().filter(|s| !s.is_empty()),
+                            model: model.or_else(|| {
+                                std::env::var("CURIE_MODEL").ok().filter(|s| !s.is_empty())
+                            }),
                             // Populated by ops::up (generate on fresh install / reuse on
                             // upgrade); empty here so the pure builder starts clean.
                             secrets: vec![],

--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -383,13 +383,14 @@ pub fn resolve_up_credentials(fake_model: bool, env_value: Option<String>) -> Op
 /// uses everywhere. The CLI's historical `CURIE_MODEL_CREDENTIALS` is accepted
 /// as a deprecated alias for one release, with a warning naming the replacement,
 /// so an operator who set the one name for `skill up` isn't met with a silent
-/// no-op at `cluster up` (#496). Returns None when neither is set non-empty.
-pub fn model_credential_env() -> Option<String> {
+/// no-op at `cluster up` (#496). Private storage is the final fallback. Returns
+/// None when no source has a nonempty value.
+pub fn model_credential_env() -> Result<Option<String>> {
     if let Some(value) = std::env::var("CURIE_CREDENTIALS")
         .ok()
         .filter(|v| !v.is_empty())
     {
-        return Some(value);
+        return Ok(Some(value));
     }
     if let Some(value) = std::env::var("CURIE_MODEL_CREDENTIALS")
         .ok()
@@ -399,9 +400,17 @@ pub fn model_credential_env() -> Option<String> {
             "warning: CURIE_MODEL_CREDENTIALS is deprecated and will be removed in a future \
              release; set CURIE_CREDENTIALS instead."
         );
-        return Some(value);
+        return Ok(Some(value));
     }
-    None
+    match crate::commands::secret_store_env("CURIE_CREDENTIALS") {
+        Ok(stored) => Ok(stored.map(|(_, value)| value)),
+        Err(error) => {
+            crate::ui::ui().warn(&format!(
+                "Saved model credentials could not be read; continuing without them: {error}"
+            ));
+            Ok(None)
+        }
+    }
 }
 
 /// The helm value key that pins the sandbox runner model in the chart.

--- a/cli/tests/credential_resolution.rs
+++ b/cli/tests/credential_resolution.rs
@@ -390,3 +390,484 @@ fn skill_up(fixture: &tempfile::TempDir, anthropic_key: Option<&str>) -> Output 
         .env_remove("CLAUDE_CODE_OAUTH_TOKEN");
     cmd.output().expect("run curie skill up")
 }
+
+const SAVED_CURIE_CREDENTIALS: &str = "vault-example-credential-sentinel";
+const SAVED_ANTHROPIC_CREDENTIALS: &str = "stored-anthropic-credential-sentinel";
+const SHELL_CURIE_CREDENTIALS: &str = "shell-example-credential-sentinel";
+const ENV_FILE_CURIE_CREDENTIALS: &str = "file-example-credential-sentinel";
+const EXPLICIT_MODEL: &str = "z-ai/glm-5.2";
+const CURIE_CREDENTIALS_VAULT_NOTE: &str =
+    "CURIE_CREDENTIALS: loaded from Curie private storage for this run";
+
+/// A private Curie config dir holding the provider neutral model credential.
+/// The fixture uses the public command, so the tests cover the same persisted
+/// shape a user creates rather than depending on vault internals.
+fn vault_with_saved_curie_credentials() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("tempdir");
+    save_model_credential(&dir, "CURIE_CREDENTIALS", SAVED_CURIE_CREDENTIALS);
+    dir
+}
+
+fn save_model_credential(fixture: &tempfile::TempDir, name: &str, value: &str) {
+    let seed = Command::new(bin())
+        .args(["secrets", "set", name, "--from-env", "SEED"])
+        .env("CURIE_CONFIG_DIR", fixture.path().join("cfg"))
+        .env("SEED", value)
+        .output()
+        .expect("run curie secrets set");
+    assert!(seed.status.success(), "seed vault: {}", err_str(&seed));
+}
+
+/// A saved credential whose index cannot be read. Credential-free modes must
+/// succeed against this fixture, which proves they never consult private
+/// storage rather than merely discarding a credential after loading it.
+fn unreadable_vault_with_saved_curie_credentials() -> tempfile::TempDir {
+    let dir = vault_with_saved_curie_credentials();
+    std::fs::write(dir.path().join("cfg/secrets.json"), "not valid json")
+        .expect("poison private store index");
+    dir
+}
+
+/// Start a real CLI process against the isolated credential store with every
+/// ambient model input removed. Individual tests can then add one explicit
+/// input without racing the test process environment.
+fn promotion_command(fixture: &tempfile::TempDir) -> Command {
+    let mut cmd = Command::new(bin());
+    cmd.env("CURIE_CONFIG_DIR", fixture.path().join("cfg"))
+        .env_remove("CURIE_CREDENTIALS")
+        .env_remove("CURIE_MODEL_CREDENTIALS")
+        .env_remove("ANTHROPIC_API_KEY")
+        .env_remove("CLAUDE_CODE_OAUTH_TOKEN")
+        .env_remove("CURIE_MODEL")
+        .env_remove("CURIE_FAKE_MODEL");
+    cmd
+}
+
+fn repository_path(relative: &str) -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("cli package has repository parent")
+        .join(relative)
+}
+
+fn assert_secret_absent(out: &Output, secret: &str) {
+    assert!(
+        !String::from_utf8_lossy(&out.stdout).contains(secret),
+        "raw credential must be absent from stdout"
+    );
+    assert!(
+        !String::from_utf8_lossy(&out.stderr).contains(secret),
+        "raw credential must be absent from stderr"
+    );
+}
+
+#[test]
+fn saved_curie_credentials_and_explicit_model_reach_local_up_dry_run() {
+    let fixture = vault_with_saved_curie_credentials();
+    let mut cmd = promotion_command(&fixture);
+    let out = cmd
+        .args([
+            "local",
+            "up",
+            "--dry-run",
+            "--model",
+            EXPLICIT_MODEL,
+            "--file",
+        ])
+        .arg(repository_path("compose.dev.yaml"))
+        .output()
+        .expect("run curie local up dry run");
+
+    assert!(out.status.success(), "local up dry run must succeed");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains(CURIE_CREDENTIALS_VAULT_NOTE));
+    assert!(stdout.contains("CURIE_FAKE_MODEL=0"));
+    assert!(stdout.contains("CURIE_MODEL=z-ai/glm-5.2"));
+    assert!(stdout.contains("CURIE_CREDENTIALS=vault-ex***"));
+    assert_secret_absent(&out, SAVED_CURIE_CREDENTIALS);
+}
+
+#[test]
+fn saved_curie_credentials_and_explicit_model_reach_local_rebuild_dry_run() {
+    let fixture = vault_with_saved_curie_credentials();
+    let mut cmd = promotion_command(&fixture);
+    let out = cmd
+        .args([
+            "local",
+            "rebuild",
+            "curie-worker",
+            "--dry-run",
+            "--model",
+            EXPLICIT_MODEL,
+            "--file",
+        ])
+        .arg(repository_path("compose.dev.yaml"))
+        .output()
+        .expect("run curie local rebuild dry run");
+
+    assert!(out.status.success(), "local rebuild dry run must succeed");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains(CURIE_CREDENTIALS_VAULT_NOTE));
+    assert!(stdout.contains("CURIE_FAKE_MODEL=0"));
+    assert!(stdout.contains("CURIE_MODEL=z-ai/glm-5.2"));
+    assert!(stdout.contains("CURIE_CREDENTIALS=vault-ex***"));
+    assert_secret_absent(&out, SAVED_CURIE_CREDENTIALS);
+}
+
+#[test]
+fn saved_curie_credentials_survive_local_comms_worker_recreation() {
+    let fixture = vault_with_saved_curie_credentials();
+    let mut cmd = promotion_command(&fixture);
+    let out = cmd
+        .args([
+            "local",
+            "comms",
+            "--slack",
+            "--dry-run",
+            "--model",
+            EXPLICIT_MODEL,
+            "--app-token",
+            "xapp-example",
+            "--bot-token",
+            "xoxb-example",
+            "--file",
+        ])
+        .arg(repository_path("compose.dev.yaml"))
+        .output()
+        .expect("run curie local comms dry run");
+
+    assert!(out.status.success(), "local comms dry run must succeed");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains(CURIE_CREDENTIALS_VAULT_NOTE));
+    assert!(stdout.contains("CURIE_FAKE_MODEL=0"));
+    assert!(stdout.contains("CURIE_MODEL=z-ai/glm-5.2"));
+    assert!(stdout.contains("CURIE_CREDENTIALS=vault-ex***"));
+    assert_secret_absent(&out, SAVED_CURIE_CREDENTIALS);
+}
+
+#[test]
+fn saved_curie_credentials_survive_local_comms_disconnect_worker_recreation() {
+    let fixture = vault_with_saved_curie_credentials();
+    let mut cmd = promotion_command(&fixture);
+    let out = cmd
+        .args([
+            "local",
+            "comms",
+            "--slack",
+            "--disconnect",
+            "--dry-run",
+            "--model",
+            EXPLICIT_MODEL,
+            "--file",
+        ])
+        .arg(repository_path("compose.dev.yaml"))
+        .output()
+        .expect("run curie local comms disconnect dry run");
+
+    assert!(out.status.success(), "local comms dry run must succeed");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains(CURIE_CREDENTIALS_VAULT_NOTE));
+    assert!(stdout.contains("CURIE_FAKE_MODEL=0"));
+    assert!(stdout.contains("CURIE_MODEL=z-ai/glm-5.2"));
+    assert!(stdout.contains("CURIE_CREDENTIALS=vault-ex***"));
+    assert_secret_absent(&out, SAVED_CURIE_CREDENTIALS);
+}
+
+#[test]
+fn shell_curie_credentials_take_priority_over_saved_credentials_for_local_up() {
+    let fixture = vault_with_saved_curie_credentials();
+    let mut cmd = promotion_command(&fixture);
+    let out = cmd
+        .args(["local", "up", "--dry-run", "--file"])
+        .arg(repository_path("compose.dev.yaml"))
+        .env("CURIE_CREDENTIALS", SHELL_CURIE_CREDENTIALS)
+        .output()
+        .expect("run curie local up dry run with shell credential");
+
+    assert!(out.status.success(), "local up dry run must succeed");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(!stderr.contains(CURIE_CREDENTIALS_VAULT_NOTE));
+    assert!(stdout.contains("CURIE_FAKE_MODEL=0"));
+    assert!(!stdout.contains("CURIE_CREDENTIALS=vault-ex***"));
+    assert_secret_absent(&out, SAVED_CURIE_CREDENTIALS);
+    assert_secret_absent(&out, SHELL_CURIE_CREDENTIALS);
+}
+
+#[test]
+fn shell_curie_credentials_do_not_hydrate_stored_sdk_credentials() {
+    let fixture = vault_with_saved_curie_credentials();
+    save_model_credential(&fixture, "ANTHROPIC_API_KEY", SAVED_ANTHROPIC_CREDENTIALS);
+    let mut cmd = promotion_command(&fixture);
+    let out = cmd
+        .args(["local", "up", "--dry-run", "--file"])
+        .arg(repository_path("compose.dev.yaml"))
+        .env("CURIE_CREDENTIALS", SHELL_CURIE_CREDENTIALS)
+        .output()
+        .expect("run curie local up with shell BYO credential");
+
+    assert!(out.status.success(), "local up dry run must succeed");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(!stderr.contains("ANTHROPIC_API_KEY: loaded from Curie private storage"));
+    assert!(!stdout.contains("ANTHROPIC_API_KEY="));
+    assert_secret_absent(&out, SHELL_CURIE_CREDENTIALS);
+    assert_secret_absent(&out, SAVED_ANTHROPIC_CREDENTIALS);
+}
+
+#[test]
+fn saved_curie_credentials_take_priority_over_env_file_for_local_up() {
+    let fixture = vault_with_saved_curie_credentials();
+    let env_file = fixture.path().join("bundle.env");
+    std::fs::write(
+        &env_file,
+        format!("CURIE_CREDENTIALS={ENV_FILE_CURIE_CREDENTIALS}\n"),
+    )
+    .expect("write credential env file");
+    let mut cmd = promotion_command(&fixture);
+    let out = cmd
+        .args(["local", "up", "--dry-run", "--env-file"])
+        .arg(&env_file)
+        .args(["--file"])
+        .arg(repository_path("compose.dev.yaml"))
+        .output()
+        .expect("run curie local up dry run with saved and file credentials");
+
+    assert!(out.status.success(), "local up dry run must succeed");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains(CURIE_CREDENTIALS_VAULT_NOTE));
+    assert!(!stderr.contains("loaded from --env-file"));
+    assert!(stdout.contains("CURIE_CREDENTIALS=vault-ex***"));
+    assert!(!stdout.contains("CURIE_CREDENTIALS=file-ex***"));
+    assert_secret_absent(&out, SAVED_CURIE_CREDENTIALS);
+    assert_secret_absent(&out, ENV_FILE_CURIE_CREDENTIALS);
+}
+
+#[test]
+fn saved_curie_credentials_and_explicit_model_reach_cluster_up_dry_run() {
+    let fixture = vault_with_saved_curie_credentials();
+    let mut cmd = promotion_command(&fixture);
+    let out = cmd
+        .args([
+            "cluster",
+            "up",
+            "--dry-run",
+            "--dev",
+            "--model",
+            EXPLICIT_MODEL,
+            "--chart",
+        ])
+        .arg(repository_path("charts/curie"))
+        .output()
+        .expect("run curie cluster up dry run");
+
+    assert!(out.status.success(), "cluster up dry run must succeed");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains(CURIE_CREDENTIALS_VAULT_NOTE));
+    assert!(stdout.contains("<secret values file: agentSandbox.runner.credentials=vault-ex***>"));
+    assert!(stdout.contains("agentSandbox.runner.model=z-ai/glm-5.2"));
+    assert_secret_absent(&out, SAVED_CURIE_CREDENTIALS);
+}
+
+#[test]
+fn shell_curie_credentials_take_priority_over_saved_credentials_for_cluster_up() {
+    let fixture = vault_with_saved_curie_credentials();
+    let mut cmd = promotion_command(&fixture);
+    let out = cmd
+        .args([
+            "cluster",
+            "up",
+            "--dry-run",
+            "--dev",
+            "--model",
+            EXPLICIT_MODEL,
+            "--chart",
+        ])
+        .arg(repository_path("charts/curie"))
+        .env("CURIE_CREDENTIALS", SHELL_CURIE_CREDENTIALS)
+        .output()
+        .expect("run curie cluster up dry run with shell credential");
+
+    assert!(out.status.success(), "cluster up dry run must succeed");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(!stderr.contains(CURIE_CREDENTIALS_VAULT_NOTE));
+    assert!(stdout.contains("<secret values file: agentSandbox.runner.credentials=shell-ex***>"));
+    assert!(!stdout.contains("agentSandbox.runner.credentials=vault-ex***"));
+    assert_secret_absent(&out, SAVED_CURIE_CREDENTIALS);
+    assert_secret_absent(&out, SHELL_CURIE_CREDENTIALS);
+}
+
+#[test]
+fn cluster_fake_model_suppresses_the_saved_credential_but_keeps_explicit_model() {
+    let fixture = vault_with_saved_curie_credentials();
+    let mut cmd = promotion_command(&fixture);
+    let out = cmd
+        .args([
+            "cluster",
+            "up",
+            "--dry-run",
+            "--dev",
+            "--fake-model",
+            "--model",
+            EXPLICIT_MODEL,
+            "--chart",
+        ])
+        .arg(repository_path("charts/curie"))
+        .output()
+        .expect("run curie cluster up dry run with fake model");
+
+    assert!(out.status.success(), "cluster up dry run must succeed");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(!stderr.contains(CURIE_CREDENTIALS_VAULT_NOTE));
+    assert!(stdout.contains("agentSandbox.runner.model=z-ai/glm-5.2"));
+    assert!(!stdout.contains("agentSandbox.runner.credentials="));
+    assert!(!stdout.contains("agentSandbox.runner.credentials=vault-ex***"));
+    assert!(!stdout.contains("agentSandbox.runner.fakeModel=false"));
+    assert_secret_absent(&out, SAVED_CURIE_CREDENTIALS);
+}
+
+#[test]
+fn local_credential_free_modes_do_not_read_private_storage() {
+    for (label, extra_args, fake_env) in [
+        ("local model", vec!["--local-model", "qwen3:8b"], None),
+        ("explicit fake", Vec::new(), Some("1")),
+    ] {
+        let fixture = unreadable_vault_with_saved_curie_credentials();
+        let mut cmd = promotion_command(&fixture);
+        cmd.args(["local", "up", "--dry-run", "--file"])
+            .arg(repository_path("compose.dev.yaml"))
+            .args(extra_args);
+        if let Some(value) = fake_env {
+            cmd.env("CURIE_FAKE_MODEL", value);
+        }
+        let out = cmd.output().expect("run credential-free local up dry run");
+
+        assert!(
+            out.status.success(),
+            "{label} must not be blocked by private storage: {}",
+            err_str(&out)
+        );
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(!stderr.contains(CURIE_CREDENTIALS_VAULT_NOTE));
+        assert!(!stdout.contains("CURIE_CREDENTIALS="));
+        assert_secret_absent(&out, SAVED_CURIE_CREDENTIALS);
+    }
+}
+
+#[test]
+fn cluster_credential_free_modes_do_not_read_private_storage() {
+    for (label, mode_args) in [
+        ("fake model", vec!["--fake-model"]),
+        ("local model", vec!["--local-model", "qwen3:8b"]),
+    ] {
+        let fixture = unreadable_vault_with_saved_curie_credentials();
+        let mut cmd = promotion_command(&fixture);
+        let out = cmd
+            .args(["cluster", "up", "--dry-run", "--dev", "--chart"])
+            .arg(repository_path("charts/curie"))
+            .args(mode_args)
+            .output()
+            .expect("run credential-free cluster up dry run");
+
+        assert!(
+            out.status.success(),
+            "{label} must not be blocked by private storage: {}",
+            err_str(&out)
+        );
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(!stderr.contains(CURIE_CREDENTIALS_VAULT_NOTE));
+        assert!(!stdout.contains("agentSandbox.runner.credentials="));
+        assert_secret_absent(&out, SAVED_CURIE_CREDENTIALS);
+    }
+}
+
+#[test]
+fn corrupt_private_storage_does_not_block_default_up_modes() {
+    for tier in ["local", "cluster"] {
+        let fixture = unreadable_vault_with_saved_curie_credentials();
+        let mut cmd = promotion_command(&fixture);
+        cmd.args([tier, "up", "--dry-run"]);
+        if tier == "local" {
+            cmd.arg("--file").arg(repository_path("compose.dev.yaml"));
+        } else {
+            cmd.args(["--dev", "--chart"])
+                .arg(repository_path("charts/curie"));
+        }
+        let out = cmd.output().expect("run up with corrupt private storage");
+
+        assert!(
+            out.status.success(),
+            "{tier} up must fall back when private storage is corrupt: {}",
+            err_str(&out)
+        );
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(stderr.contains("Saved model credentials could not be read"));
+        if tier == "local" {
+            assert!(!stdout.contains("CURIE_FAKE_MODEL=0"));
+            assert!(!stdout.contains("CURIE_CREDENTIALS="));
+        } else {
+            assert!(!stdout.contains("agentSandbox.runner.credentials="));
+        }
+        assert_secret_absent(&out, SAVED_CURIE_CREDENTIALS);
+    }
+}
+
+#[test]
+fn model_and_local_model_are_rejected_together_for_each_up_tier() {
+    for tier in ["local", "cluster"] {
+        let out = Command::new(bin())
+            .args([
+                tier,
+                "up",
+                "--model",
+                EXPLICIT_MODEL,
+                "--local-model",
+                "qwen3:8b",
+            ])
+            .output()
+            .expect("run curie up with conflicting model flags");
+
+        assert_eq!(out.status.code(), Some(2), "{tier} up must report usage");
+        let stderr = err_str(&out);
+        assert!(stderr.contains("--model"), "{tier}: {stderr}");
+        assert!(stderr.contains("--local-model"), "{tier}: {stderr}");
+        assert!(stderr.contains("cannot be used with"), "{tier}: {stderr}");
+    }
+}
+
+#[test]
+fn model_and_local_model_are_rejected_together_for_local_rebuild() {
+    let out = Command::new(bin())
+        .args([
+            "local",
+            "rebuild",
+            "curie-worker",
+            "--model",
+            EXPLICIT_MODEL,
+            "--local-model",
+            "qwen3:8b",
+        ])
+        .output()
+        .expect("run curie local rebuild with conflicting model flags");
+
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "local rebuild must report usage"
+    );
+    let stderr = err_str(&out);
+    assert!(stderr.contains("--model"), "{stderr}");
+    assert!(stderr.contains("--local-model"), "{stderr}");
+    assert!(stderr.contains("cannot be used with"), "{stderr}");
+}

--- a/cli/tests/installation_plan_parity.rs
+++ b/cli/tests/installation_plan_parity.rs
@@ -543,6 +543,7 @@ exit 0
             .env("CURIE_TEST_CALL_LOG", &self.log)
             .env("CURIE_TEST_MIGRATION_STATE", &self.migration_state)
             .env("CURIE_TEST_LAST_EXEC_SCRIPT", &self.last_exec_script)
+            .env("CURIE_CONFIG_DIR", self.temp.path().join("config"))
             .env_remove("CURIE_TEST_KUBECTL_STS")
             .env_remove("CURIE_TEST_KUBECTL_STS_AFTER_UPGRADE")
             .env_remove("CURIE_TEST_KUBECTL_FAIL")


### PR DESCRIPTION
Closes #1663

## Summary

* Promotes saved model credentials into local and cluster startup using the existing masked transports.
* Adds explicit model selection to local up, local rebuild, local comms, and cluster up.
* Preserves promoted credentials and models when local worker restart paths run.
* Keeps fake and local model modes isolated from private provider storage.

Conversation continuity remains unchanged because local and cluster turns do not share a state contract. No contract, schema, chart, or ADR change was made.

## Evidence

* Rust formatting and clippy pass.
* The affected CLI suites pass, including 23 credential regressions, 19 comms tests, and 13 command surface tests.
* UI lint, typecheck, and 147 tests pass against regenerated command manifests.
* The fix pin passes on commit `046a5d4d` and the selected regression fails when the production change is reversed.
* The local runtime ladder could not start because the issue 1661 run owns fixed ports 25432 and 26379. No issue 1663 containers remain.