### PR TITLE
Infer detected facts during cluster up

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -120,6 +120,9 @@ regexes = [
   '''\bi-0123456789abcdef0\b''',
   '''\b000000000000\b''',
   '''\bexample\.com\b''',
+  # The provider prefix is intentionally present in the public fixture. The
+  # complete finding is anchored so no other OpenRouter shaped value is covered.
+  '''^credentials":"sk-or-v1-PLACEHOLDER"$''',
   # Slack token fixtures. The prefix is the whole point of the test that uses
   # them (curie seal / credcheck), so they cannot be shortened past it -- the
   # EXAMPLE marker is what makes them obviously not a live token.

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ minikube start
 Then:
 
 ```bash
-curie cluster up --allow-egress-host anthropic --set security.gvisor.mode=off
+curie cluster up
 curie cluster deploy --plugin-dir . --repo <owner>/<name>
 curie cluster message "hello, are you there?"
 ```
@@ -182,12 +182,13 @@ the agent is first created and cannot be changed afterwards, so substitute your 
 before running it: getting it wrong means deleting the agent and recreating it. See
 [`cli/README.md`](cli/README.md) for the lifecycle verbs.
 
-`--set security.gvisor.mode=off` skips gVisor's extra kernel isolation, which a real-model install
-otherwise requires and minikube doesn't ship by default - drop it on a cluster that has `runsc`
-installed. 
-
-`--allow-egress-host` opens the model call; a credential alone doesn't, since the cluster sandbox is
-fail-closed by default (skill/local aren't).
+Plain `cluster up` infers Anthropic or OpenRouter egress from an unambiguous
+credential prefix. On minikube, the first admission attempt reports that its
+`gvisor` RuntimeClass is absent, so Curie applies
+`security.gvisor.mode=off` and retries once. Each inference is printed with the
+equivalent override. Ambiguous credential shapes still need an explicit
+`--allow-egress-host`, and explicit values that contradict detected facts are
+errors.
 
 See [`docs/operations.md`](docs/operations.md#installing-and-inspecting-the-curie-platform-on-the-cluster) for cluster prerequisites and the full egress model.
 

--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -1867,7 +1867,7 @@ export const commandManifest = {
       "name": "cluster",
       "subcommands": [
         {
-          "about": "Install or upgrade the Curie release via Helm (helm upgrade --install). By default it puts the UI and Langfuse on node ports for tailnet/LAN access; pass --no-expose to keep them ClusterIP-only. Set CURIE_CREDENTIALS to a supported model provider credential (CURIE_MODEL_CREDENTIALS is a deprecated alias) to install with the real model. A fresh install without it uses fake mode. A rerun preserves the recorded model configuration. Use --fake-model to explicitly downgrade to fake mode. A real model is still unreachable behind the fail-closed sandbox until you open its egress with --allow-egress-host <provider> (or --allow-web-egress <CIDR> for a raw range). Zhipu, Moonshot, and DeepSeek also require their matching base URL in worker runtime configuration, in addition to a credential and named egress",
+          "about": "Install or upgrade the Curie release via Helm (helm upgrade --install). By default it puts the UI and Langfuse on node ports for tailnet/LAN access; pass --no-expose to keep them ClusterIP-only. Set CURIE_CREDENTIALS to a supported model provider credential (CURIE_MODEL_CREDENTIALS is a deprecated alias) to install with the real model. A fresh install without it uses fake mode. A rerun preserves the recorded model configuration. Use --fake-model to explicitly downgrade to fake mode. An sk-ant- or sk-or- credential infers its provider egress when --allow-egress-host is absent. Other credential shapes remain sealed until their provider or a raw range is explicit. Existing singleton resources are reused only from complete Helm ownership metadata. An exact admission result that the gvisor RuntimeClass is absent applies security.gvisor.mode=off and retries once. Every inferred value is printed",
           "args": [
             {
               "default_values": [
@@ -1937,7 +1937,7 @@ export const commandManifest = {
             },
             {
               "global": false,
-              "help": "Open runner egress to a named model provider's API host(s), resolved to narrow host routes at install time (repeatable). One of: anthropic, openrouter, zhipu, moonshot, deepseek. Provider native Zhipu, Moonshot, and DeepSeek also need their matching worker runtime base URL; a credential plus egress alone does not reach them. For a raw CIDR, use --allow-web-egress",
+              "help": "Explicitly open runner egress to a named model provider's API host(s), resolved to narrow host routes at install time (repeatable). An sk-ant- or sk-or- credential infers anthropic or openrouter when this flag is absent. An explicit list that omits the detected provider is an error. One of: anthropic, openrouter, zhipu, moonshot, deepseek. Provider native Zhipu, Moonshot, and DeepSeek also need their matching worker runtime base URL; a credential plus egress alone does not reach them. For a raw CIDR, use --allow-web-egress",
               "id": "allow_egress_host",
               "long": "allow-egress-host",
               "positional": false,
@@ -1945,7 +1945,7 @@ export const commandManifest = {
             },
             {
               "global": false,
-              "help": "Open runner egress to a declared destination for skill web access, repeatable CIDR, TCP 443. Additive to the provider egress; omit to stay fully sealed",
+              "help": "Open runner egress to a declared destination for skill web access, repeatable CIDR, TCP 443. Additive to provider egress. Omit to keep general web egress sealed",
               "id": "allow_web_egress",
               "long": "allow-web-egress",
               "positional": false,

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -1864,7 +1864,7 @@
       "name": "cluster",
       "subcommands": [
         {
-          "about": "Install or upgrade the Curie release via Helm (helm upgrade --install). By default it puts the UI and Langfuse on node ports for tailnet/LAN access; pass --no-expose to keep them ClusterIP-only. Set CURIE_CREDENTIALS to a supported model provider credential (CURIE_MODEL_CREDENTIALS is a deprecated alias) to install with the real model. A fresh install without it uses fake mode. A rerun preserves the recorded model configuration. Use --fake-model to explicitly downgrade to fake mode. A real model is still unreachable behind the fail-closed sandbox until you open its egress with --allow-egress-host <provider> (or --allow-web-egress <CIDR> for a raw range). Zhipu, Moonshot, and DeepSeek also require their matching base URL in worker runtime configuration, in addition to a credential and named egress",
+          "about": "Install or upgrade the Curie release via Helm (helm upgrade --install). By default it puts the UI and Langfuse on node ports for tailnet/LAN access; pass --no-expose to keep them ClusterIP-only. Set CURIE_CREDENTIALS to a supported model provider credential (CURIE_MODEL_CREDENTIALS is a deprecated alias) to install with the real model. A fresh install without it uses fake mode. A rerun preserves the recorded model configuration. Use --fake-model to explicitly downgrade to fake mode. An sk-ant- or sk-or- credential infers its provider egress when --allow-egress-host is absent. Other credential shapes remain sealed until their provider or a raw range is explicit. Existing singleton resources are reused only from complete Helm ownership metadata. An exact admission result that the gvisor RuntimeClass is absent applies security.gvisor.mode=off and retries once. Every inferred value is printed",
           "args": [
             {
               "default_values": [
@@ -1934,7 +1934,7 @@
             },
             {
               "global": false,
-              "help": "Open runner egress to a named model provider's API host(s), resolved to narrow host routes at install time (repeatable). One of: anthropic, openrouter, zhipu, moonshot, deepseek. Provider native Zhipu, Moonshot, and DeepSeek also need their matching worker runtime base URL; a credential plus egress alone does not reach them. For a raw CIDR, use --allow-web-egress",
+              "help": "Explicitly open runner egress to a named model provider's API host(s), resolved to narrow host routes at install time (repeatable). An sk-ant- or sk-or- credential infers anthropic or openrouter when this flag is absent. An explicit list that omits the detected provider is an error. One of: anthropic, openrouter, zhipu, moonshot, deepseek. Provider native Zhipu, Moonshot, and DeepSeek also need their matching worker runtime base URL; a credential plus egress alone does not reach them. For a raw CIDR, use --allow-web-egress",
               "id": "allow_egress_host",
               "long": "allow-egress-host",
               "positional": false,
@@ -1942,7 +1942,7 @@
             },
             {
               "global": false,
-              "help": "Open runner egress to a declared destination for skill web access, repeatable CIDR, TCP 443. Additive to the provider egress; omit to stay fully sealed",
+              "help": "Open runner egress to a declared destination for skill web access, repeatable CIDR, TCP 443. Additive to provider egress. Omit to keep general web egress sealed",
               "id": "allow_web_egress",
               "long": "allow-web-egress",
               "positional": false,

--- a/cli/src/guide.rs
+++ b/cli/src/guide.rs
@@ -297,8 +297,8 @@ pub fn primer() -> Primer {
                 detail: "`curie skill up` and `curie local up` both run the real model when a credential is present and the fake model otherwise; `curie skill up --fake-model` or CURIE_FAKE_MODEL=1 forces the offline fake at either tier.",
             },
             Landmine {
-                title: "A real model in-cluster needs its provider's egress opened",
-                detail: "The runner sandbox is default-deny egress, so `curie cluster up` with a credential is still sealed and the model unreachable until you pass --allow-egress-host <provider> (anthropic/openrouter/zhipu/moonshot/deepseek). Zhipu, Moonshot, and DeepSeek also need their matching base URL in worker runtime configuration; a web-fetching skill additionally needs --allow-web-egress <CIDR> for its hosts.",
+                title: "Ambiguous provider credentials need explicit cluster egress",
+                detail: "Direct `curie cluster up` infers anthropic from sk-ant- and openrouter from sk-or- when --allow-egress-host is absent. Other credential shapes stay sealed until you pass --allow-egress-host <provider> (zhipu/moonshot/deepseek) or a raw range. An explicit provider list that omits the detected provider is an error. Zhipu, Moonshot, and DeepSeek also need their matching base URL in worker runtime configuration; a web fetching skill additionally needs --allow-web-egress <CIDR> for its hosts.",
             },
             Landmine {
                 title: "The skill runner executes an immutable snapshot taken at `skill up`",
@@ -313,8 +313,8 @@ pub fn primer() -> Primer {
                 detail: "When you are asked to get a bundle running, do the plumbing yourself -- source the bundle's dotenv, run `curie local up`, `curie local deploy`, and `curie local comms --slack`, then tear down -- rather than handing the human a shell checklist to copy-paste. Two parts are irreducibly manual and stay with the human: supplying the actual secret VALUES (never type a credential or API key yourself) and creating an external app in a browser to mint its tokens (e.g. the Slack app). Automate everything between. If a credential already lives in the environment or the bundle's own `.env`, use it instead of asking for it to be exported.",
             },
             Landmine {
-                title: "A real-model `cluster up` fails closed without a gVisor runtime",
-                detail: "On a cluster with no `runsc` RuntimeClass, the default `security.gvisor.mode=auto` renders a blocking enforcement preflight for a real (non-fake) model, so `curie cluster up` fails closed instead of running runner pods on the host kernel. Install anyway with `curie cluster up --set security.gvisor.mode=off` (no kernel isolation, knowingly), use `--fake-model` (the sealed path skips the preflight), or install runsc on the nodes. This is the security posture, not a bug.",
+                title: "Missing gVisor is inferred only from admission",
+                detail: "A real model install first keeps the gVisor chart default. When admission reports exactly that RuntimeClass gvisor is not found, direct `curie cluster up` applies security.gvisor.mode=off, prints the override, and retries once. Other failures remain closed. Explicit auto or require modes contradict the detected result and are errors.",
             },
         ],
         recovery: vec![
@@ -324,7 +324,7 @@ pub fn primer() -> Primer {
             },
             Recovery {
                 symptom: "`curie cluster up` fails immediately when `curie-preflight-gvisor` reports `FailedCreate`: `RuntimeClass \"gvisor\" not found`",
-                fix: "A real-model install on a cluster with no `runsc` RuntimeClass fails closed under `security.gvisor.mode=auto`. Opt out with `curie cluster up --set security.gvisor.mode=off`, or use `--fake-model`, or install runsc on the nodes.",
+                fix: "Plain `curie cluster up` now infers security.gvisor.mode=off from this exact admission result and retries once. If you explicitly set auto or require, remove that setting to accept the detected posture, or install runsc on the nodes.",
             },
             Recovery {
                 symptom: "`curie cluster up` hangs ~2 min then dies with `job curie-preflight-gvisor failed: DeadlineExceeded`",
@@ -332,7 +332,7 @@ pub fn primer() -> Primer {
             },
             Recovery {
                 symptom: "\"(no response)\" or an empty reply",
-                fix: "You are on the fake model (--fake-model, or a sealed install). Provide a credential to go live; on cluster, also open the provider egress with --allow-egress-host <provider>. Zhipu, Moonshot, and DeepSeek also need their matching base URL in worker runtime configuration or the model stays unreachable.",
+                fix: "You are on the fake model (--fake-model, or a sealed install). Provide a credential to go live. On cluster, sk-ant- and sk-or- infer their provider egress; other providers need --allow-egress-host <provider>. Zhipu, Moonshot, and DeepSeek also need their matching base URL in worker runtime configuration or the model stays unreachable.",
             },
             Recovery {
                 symptom: "the agent answers but never calls your MCP tools",

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1327,12 +1327,12 @@ enum ClusterAction {
     /// (CURIE_MODEL_CREDENTIALS is a deprecated alias) to install with the real
     /// model. A fresh install without it uses fake mode. A rerun preserves the
     /// recorded model configuration. Use --fake-model to explicitly downgrade
-    /// to fake mode. A real model is still unreachable behind the fail-closed
-    /// sandbox until you
-    /// open its egress with --allow-egress-host <provider> (or --allow-web-egress
-    /// <CIDR> for a raw range). Zhipu, Moonshot, and DeepSeek also require their
-    /// matching base URL in worker runtime configuration, in addition to a
-    /// credential and named egress.
+    /// to fake mode. An sk-ant- or sk-or- credential infers its provider egress
+    /// when --allow-egress-host is absent. Other credential shapes remain sealed
+    /// until their provider or a raw range is explicit. Existing singleton
+    /// resources are reused only from complete Helm ownership metadata. An exact
+    /// admission result that the gvisor RuntimeClass is absent applies
+    /// security.gvisor.mode=off and retries once. Every inferred value is printed.
     Up {
         /// Kubernetes namespace.
         #[arg(long, default_value = "curie")]
@@ -1359,8 +1359,11 @@ enum ClusterAction {
             conflicts_with = "fake_model"
         )]
         local_model: Option<String>,
-        /// Open runner egress to a named model provider's API host(s), resolved to
-        /// narrow host routes at install time (repeatable). One of: anthropic,
+        /// Explicitly open runner egress to a named model provider's API host(s),
+        /// resolved to narrow host routes at install time (repeatable). An sk-ant-
+        /// or sk-or- credential infers anthropic or openrouter when this flag is
+        /// absent. An explicit list that omits the detected provider is an error.
+        /// One of: anthropic,
         /// openrouter, zhipu, moonshot, deepseek. Provider native Zhipu,
         /// Moonshot, and DeepSeek also need their matching worker runtime base
         /// URL; a credential plus egress alone does not reach them. For a raw
@@ -1368,8 +1371,8 @@ enum ClusterAction {
         #[arg(long = "allow-egress-host", value_name = "PROVIDER")]
         allow_egress_host: Vec<String>,
         /// Open runner egress to a declared destination for skill web access,
-        /// repeatable CIDR, TCP 443. Additive to the provider egress; omit to stay
-        /// fully sealed.
+        /// repeatable CIDR, TCP 443. Additive to provider egress. Omit to keep
+        /// general web egress sealed.
         #[arg(long = "allow-web-egress", value_name = "CIDR")]
         allow_web_egress: Vec<String>,
         /// GitHub credential the API uses for the git-flow bundle clone and the

--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -1490,7 +1490,7 @@ fn resolve_preserved_runner_egress_values(
     existing: Option<&serde_json::Value>,
     operator_sets: &[String],
     provider_was_inferred: bool,
-) -> usize {
+) -> (usize, BTreeSet<String>) {
     let overridden = operator_set_keys(operator_sets);
     let egress_replaced = (!opts.allow_egress_host.is_empty() && !provider_was_inferred)
         || !opts.allow_web_egress.is_empty()
@@ -1498,7 +1498,7 @@ fn resolve_preserved_runner_egress_values(
             .iter()
             .any(|key| key_is_or_descends_from(key, ALLOWED_EGRESS_KEY));
     if egress_replaced {
-        return 0;
+        return (0, BTreeSet::new());
     }
 
     let mut recorded = BTreeMap::new();
@@ -1517,13 +1517,21 @@ fn resolve_preserved_runner_egress_values(
         })
         .max()
         .map_or(0, |index| index + 1);
+    let recorded_cidrs = recorded
+        .iter()
+        .filter_map(|(key, value)| {
+            let suffix = key.strip_prefix(ALLOWED_EGRESS_KEY)?.strip_prefix('[')?;
+            let (index, field) = suffix.split_once(']')?;
+            (index.parse::<usize>().is_ok() && field == ".cidr").then(|| value.clone())
+        })
+        .collect();
     opts.set.extend(
         recorded
             .into_iter()
             .filter(|(key, _)| key_is_or_descends_from(key, ALLOWED_EGRESS_KEY))
             .map(|(key, value)| format!("{key}={value}")),
     );
-    next_index
+    (next_index, recorded_cidrs)
 }
 
 fn resolve_provider_egress_for_up(opts: &mut UpOpts, resolve: bool) -> Result<()> {
@@ -1535,9 +1543,17 @@ fn resolve_provider_egress_for_up(opts: &mut UpOpts, resolve: bool) -> Result<()
     Ok(())
 }
 
-fn reindex_inferred_provider_egress(opts: &mut UpOpts, start_index: usize) {
+fn reindex_inferred_provider_egress(
+    opts: &mut UpOpts,
+    start_index: usize,
+    recorded_cidrs: &BTreeSet<String>,
+) {
     let resolved = std::mem::take(&mut opts.resolved_egress_cidrs);
-    for (offset, cidr) in resolved.into_iter().enumerate() {
+    for (offset, cidr) in resolved
+        .into_iter()
+        .filter(|cidr| !recorded_cidrs.contains(cidr))
+        .enumerate()
+    {
         let index = start_index + offset;
         opts.set
             .push(format!("{ALLOWED_EGRESS_KEY}[{index}].cidr={cidr}"));
@@ -4861,15 +4877,20 @@ pub async fn up(
         inferences.push(inference);
     }
     let operator_sets = opts.operator_sets();
-    let next_preserved_egress_index = resolve_preserved_runner_egress_values(
-        &mut opts,
-        existing.as_ref(),
-        &operator_sets,
-        provider_was_inferred,
-    );
+    let (next_preserved_egress_index, recorded_egress_cidrs) =
+        resolve_preserved_runner_egress_values(
+            &mut opts,
+            existing.as_ref(),
+            &operator_sets,
+            provider_was_inferred,
+        );
     resolve_provider_egress_for_up(&mut opts, resolve_provider_egress)?;
     if provider_was_inferred && next_preserved_egress_index > 0 {
-        reindex_inferred_provider_egress(&mut opts, next_preserved_egress_index);
+        reindex_inferred_provider_egress(
+            &mut opts,
+            next_preserved_egress_index,
+            &recorded_egress_cidrs,
+        );
     }
     let value_plan = up_value_plan(&opts);
     run_prepared_up(

--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -1489,27 +1489,65 @@ fn resolve_preserved_runner_egress_values(
     opts: &mut UpOpts,
     existing: Option<&serde_json::Value>,
     operator_sets: &[String],
-) {
+    provider_was_inferred: bool,
+) -> usize {
     let overridden = operator_set_keys(operator_sets);
-    let egress_replaced = !opts.allow_egress_host.is_empty()
+    let egress_replaced = (!opts.allow_egress_host.is_empty() && !provider_was_inferred)
         || !opts.allow_web_egress.is_empty()
         || overridden
             .iter()
             .any(|key| key_is_or_descends_from(key, ALLOWED_EGRESS_KEY));
     if egress_replaced {
-        return;
+        return 0;
     }
 
     let mut recorded = BTreeMap::new();
     if let Some(values) = existing {
         crate::installation::flatten_values(values, "", &mut recorded);
     }
+    let next_index = recorded
+        .keys()
+        .filter_map(|key| {
+            key.strip_prefix(ALLOWED_EGRESS_KEY)?
+                .strip_prefix('[')?
+                .split_once(']')?
+                .0
+                .parse::<usize>()
+                .ok()
+        })
+        .max()
+        .map_or(0, |index| index + 1);
     opts.set.extend(
         recorded
             .into_iter()
             .filter(|(key, _)| key_is_or_descends_from(key, ALLOWED_EGRESS_KEY))
             .map(|(key, value)| format!("{key}={value}")),
     );
+    next_index
+}
+
+fn resolve_provider_egress_for_up(opts: &mut UpOpts, resolve: bool) -> Result<()> {
+    if resolve && !opts.allow_egress_host.is_empty() && opts.resolved_egress_cidrs.is_empty() {
+        opts.resolved_egress_cidrs =
+            resolve_provider_egress_cidrs_for_current_environment(&opts.allow_egress_host)
+                .context("resolving named provider egress hosts")?;
+    }
+    Ok(())
+}
+
+fn reindex_inferred_provider_egress(opts: &mut UpOpts, start_index: usize) {
+    let resolved = std::mem::take(&mut opts.resolved_egress_cidrs);
+    for (offset, cidr) in resolved.into_iter().enumerate() {
+        let index = start_index + offset;
+        opts.set
+            .push(format!("{ALLOWED_EGRESS_KEY}[{index}].cidr={cidr}"));
+        opts.set.push(format!(
+            "{ALLOWED_EGRESS_KEY}[{index}].ports[0].protocol=TCP"
+        ));
+        opts.set.push(format!(
+            "{ALLOWED_EGRESS_KEY}[{index}].ports[0].port={EGRESS_TCP_PORT}"
+        ));
+    }
 }
 
 /// Does a plain `cluster up` carry this key forward when nothing re-passes it?
@@ -2691,15 +2729,8 @@ pub(crate) fn complete_up_opts(
     let mut opts =
         complete_up_opts_without_runner_egress(opts, existing, github_token, clear_github_token)?;
     let operator_sets = opts.operator_sets();
-    resolve_preserved_runner_egress_values(&mut opts, existing, &operator_sets);
-    if resolve_provider_egress
-        && !opts.allow_egress_host.is_empty()
-        && opts.resolved_egress_cidrs.is_empty()
-    {
-        opts.resolved_egress_cidrs =
-            resolve_provider_egress_cidrs_for_current_environment(&opts.allow_egress_host)
-                .context("resolving named provider egress hosts")?;
-    }
+    resolve_preserved_runner_egress_values(&mut opts, existing, &operator_sets, false);
+    resolve_provider_egress_for_up(&mut opts, resolve_provider_egress)?;
     Ok(opts)
 }
 
@@ -4824,18 +4855,21 @@ pub async fn up(
     )?;
     let completed_identity_plan = up_value_plan(&opts);
     let mut inferences = Vec::new();
-    if let Some(inference) = reconcile_provider_inference(&mut opts, &completed_identity_plan)? {
+    let provider_inference = reconcile_provider_inference(&mut opts, &completed_identity_plan)?;
+    let provider_was_inferred = provider_inference.is_some();
+    if let Some(inference) = provider_inference {
         inferences.push(inference);
     }
     let operator_sets = opts.operator_sets();
-    resolve_preserved_runner_egress_values(&mut opts, existing.as_ref(), &operator_sets);
-    if resolve_provider_egress
-        && !opts.allow_egress_host.is_empty()
-        && opts.resolved_egress_cidrs.is_empty()
-    {
-        opts.resolved_egress_cidrs =
-            resolve_provider_egress_cidrs_for_current_environment(&opts.allow_egress_host)
-                .context("resolving named provider egress hosts")?;
+    let next_preserved_egress_index = resolve_preserved_runner_egress_values(
+        &mut opts,
+        existing.as_ref(),
+        &operator_sets,
+        provider_was_inferred,
+    );
+    resolve_provider_egress_for_up(&mut opts, resolve_provider_egress)?;
+    if provider_was_inferred && next_preserved_egress_index > 0 {
+        reindex_inferred_provider_egress(&mut opts, next_preserved_egress_index);
     }
     let value_plan = up_value_plan(&opts);
     run_prepared_up(
@@ -6557,6 +6591,38 @@ mod tests {
             namespace: "curie".into(),
             release: "curie".into(),
             dry_run: false,
+        }
+    }
+
+    #[test]
+    fn credential_prefix_inference_matches_the_shared_provider_registry() {
+        #[derive(serde::Deserialize)]
+        struct Registry {
+            providers: Vec<Provider>,
+        }
+
+        #[derive(serde::Deserialize)]
+        struct Provider {
+            name: String,
+            inferred_provider: Option<String>,
+            credential_examples: Vec<String>,
+        }
+
+        let registry: Registry = serde_json::from_str(include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../tests/vectors/model-provider-registry.json"
+        )))
+        .expect("parse provider registry");
+
+        for provider in registry.providers {
+            for credential in provider.credential_examples {
+                assert_eq!(
+                    provider_from_credential_prefix(&credential),
+                    provider.inferred_provider.as_deref(),
+                    "credential example for {}",
+                    provider.name
+                );
+            }
         }
     }
 

--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -711,6 +711,20 @@ pub fn default_route_egress_warning(cidrs: &[String]) -> Option<String> {
     ))
 }
 
+/// Credential prefixes whose runtime routing selects one unambiguous provider.
+/// Keep this aligned with `runner/src/curie_runner/sdk_auth.py`: credentials
+/// outside these exact prefixes do not carry enough information to infer an
+/// egress destination.
+const CREDENTIAL_PREFIX_PROVIDERS: &[(&str, &str)] =
+    &[("sk-ant-", "anthropic"), ("sk-or-", "openrouter")];
+
+fn provider_from_credential_prefix(credential: &str) -> Option<&'static str> {
+    CREDENTIAL_PREFIX_PROVIDERS
+        .iter()
+        .find(|(prefix, _)| credential.starts_with(prefix))
+        .map(|(_, provider)| *provider)
+}
+
 /// The canonical model providers `--allow-egress-host` accepts, each paired with
 /// the API hostname(s) its runner must reach, in the order shown in help and
 /// error text. The single source of truth for both the accepted-provider set and
@@ -1447,7 +1461,7 @@ fn key_is_or_descends_from(key: &str, parent: &str) -> bool {
 
 /// Carry the runner configuration recorded by a prior real model install into
 /// a plain rerun. Explicit inputs replace their recorded family.
-fn resolve_preserved_runner_values(
+fn resolve_preserved_runner_identity_values(
     opts: &mut UpOpts,
     existing: Option<&serde_json::Value>,
     operator_sets: &[String],
@@ -1469,7 +1483,14 @@ fn resolve_preserved_runner_values(
     {
         opts.model = preserved_value(existing, RUNNER_MODEL_KEY);
     }
+}
 
+fn resolve_preserved_runner_egress_values(
+    opts: &mut UpOpts,
+    existing: Option<&serde_json::Value>,
+    operator_sets: &[String],
+) {
+    let overridden = operator_set_keys(operator_sets);
     let egress_replaced = !opts.allow_egress_host.is_empty()
         || !opts.allow_web_egress.is_empty()
         || overridden
@@ -1495,8 +1516,9 @@ fn resolve_preserved_runner_values(
 ///
 /// The honest half of `curie diff`. `up` does a FULL upgrade, so a key present
 /// on the release but absent from `curie.yaml` is normally reset to the chart
-/// default -- except for the families [`resolve_preserved_values`] and
-/// [`resolve_preserved_runner_values`] re-supply, which survive untouched.
+/// default -- except for the families [`resolve_preserved_values`],
+/// [`resolve_preserved_runner_identity_values`], and
+/// [`resolve_preserved_runner_egress_values`] re-supply, which survive untouched.
 /// Reporting those as removals would be the exact
 /// "proposing to delete what it did not create" failure ADR-0097 named.
 ///
@@ -2635,18 +2657,14 @@ fn resolve_github_token(
     }
 }
 
-/// Finish an already validated up plan with the one live values read and, when
-/// requested, resolved provider addresses. This is kept separate from command
-/// execution so apply and diff can compare the same completed values.
-pub(crate) fn complete_up_opts(
+fn complete_up_opts_without_runner_egress(
     mut opts: UpOpts,
     existing: Option<&serde_json::Value>,
     github_token: Option<&str>,
     clear_github_token: bool,
-    resolve_provider_egress: bool,
 ) -> Result<UpOpts> {
     let operator_sets = opts.operator_sets();
-    resolve_preserved_runner_values(&mut opts, existing, &operator_sets);
+    resolve_preserved_runner_identity_values(&mut opts, existing, &operator_sets);
     if !opts.dev {
         opts.secrets = resolve_generated_secrets(existing, &operator_sets)?;
         opts.secrets.extend(resolve_managed_values_for_up(
@@ -2657,6 +2675,23 @@ pub(crate) fn complete_up_opts(
     }
     opts.github_token =
         resolve_github_token(existing, &operator_sets, github_token, clear_github_token);
+    Ok(opts)
+}
+
+/// Finish an already validated up plan with the one live values read and, when
+/// requested, resolved provider addresses. This is kept separate from command
+/// execution so apply and diff can compare the same completed values.
+pub(crate) fn complete_up_opts(
+    opts: UpOpts,
+    existing: Option<&serde_json::Value>,
+    github_token: Option<&str>,
+    clear_github_token: bool,
+    resolve_provider_egress: bool,
+) -> Result<UpOpts> {
+    let mut opts =
+        complete_up_opts_without_runner_egress(opts, existing, github_token, clear_github_token)?;
+    let operator_sets = opts.operator_sets();
+    resolve_preserved_runner_egress_values(&mut opts, existing, &operator_sets);
     if resolve_provider_egress
         && !opts.allow_egress_host.is_empty()
         && opts.resolved_egress_cidrs.is_empty()
@@ -3064,6 +3099,112 @@ impl PriorityClassRole {
     }
 }
 
+const CONTROLLER_DEPLOYMENT_NAME: &str = "agent-sandbox-controller";
+const CONTROLLER_DEPLOYMENT_NAMESPACE: &str = "agent-sandbox-system";
+const CONTROLLER_DEPLOY_KEY: &str = "agentSandbox.controller.deploy";
+const GVISOR_MODE_KEY: &str = "security.gvisor.mode";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ClusterUpInference {
+    Provider {
+        provider: &'static str,
+    },
+    PriorityClassReuse {
+        role: PriorityClassRole,
+        name: String,
+        owner_release: String,
+    },
+    ControllerReuse {
+        owner_release: String,
+    },
+    GvisorOff,
+}
+
+impl ClusterUpInference {
+    fn render(&self, ui: &crate::ui::Ui) {
+        match self {
+            Self::Provider { provider } => ui.note(&format!(
+                "inferred model provider from the bound credential prefix; applying `--allow-egress-host {provider}`"
+            )),
+            Self::PriorityClassReuse {
+                role,
+                name,
+                owner_release,
+            } => ui.note(&format!(
+                "inferred reuse of PriorityClass `{name}` from Helm release `{owner_release}`; applying `--set priorityClasses.{}.create=false`",
+                role.key()
+            )),
+            Self::ControllerReuse { owner_release } => ui.note(&format!(
+                "inferred reuse of `{CONTROLLER_DEPLOYMENT_NAME}` from Helm release `{owner_release}`; applying `--set {CONTROLLER_DEPLOY_KEY}=false`"
+            )),
+            Self::GvisorOff => ui.note(&format!(
+                "inferred that the cluster has no `gvisor` RuntimeClass from admission; applying `--set {GVISOR_MODE_KEY}=off`"
+            )),
+        }
+    }
+}
+
+fn final_operator_value<'a>(opts: &'a UpOpts, key: &str) -> Option<&'a str> {
+    let in_lane = |sets: &'a [String]| {
+        operator_set_entries(sets)
+            .into_iter()
+            .rev()
+            .find_map(|(candidate, value)| (candidate.trim() == key).then_some(value.trim()))
+    };
+    in_lane(&opts.set_string).or_else(|| in_lane(&opts.set))
+}
+
+fn detected_provider_from_plan(opts: &UpOpts, plan: &UpValuePlan) -> Option<&'static str> {
+    if opts.fake_model || opts.local_model.is_some() {
+        return None;
+    }
+    plan.effective_values()
+        .get(MODEL_CREDENTIAL_KEY)
+        .and_then(|credential| provider_from_credential_prefix(credential))
+}
+
+fn provider_contradiction(opts: &UpOpts, plan: &UpValuePlan) -> Result<()> {
+    let Some(provider) = detected_provider_from_plan(opts, plan) else {
+        return Ok(());
+    };
+    if opts.allow_egress_host.is_empty()
+        || opts
+            .allow_egress_host
+            .iter()
+            .any(|declared| declared == provider)
+    {
+        return Ok(());
+    }
+    let declared = opts
+        .allow_egress_host
+        .iter()
+        .map(|value| format!("--allow-egress-host {value}"))
+        .collect::<Vec<_>>()
+        .join(" ");
+    let fix =
+        format!("include `--allow-egress-host {provider}`, or remove the explicit provider list");
+    Err(crate::exit::CliError::usage(format!(
+        "the bound credential selects provider `{provider}`, but the explicit provider list `{declared}` omits it; {fix}"
+    ))
+    .with_fix(fix)
+    .into())
+}
+
+fn reconcile_provider_inference(
+    opts: &mut UpOpts,
+    plan: &UpValuePlan,
+) -> Result<Option<ClusterUpInference>> {
+    provider_contradiction(opts, plan)?;
+    let Some(provider) = detected_provider_from_plan(opts, plan) else {
+        return Ok(None);
+    };
+    if !opts.allow_egress_host.is_empty() {
+        return Ok(None);
+    }
+    opts.allow_egress_host.push(provider.to_string());
+    Ok(Some(ClusterUpInference::Provider { provider }))
+}
+
 #[derive(Debug, PartialEq, Eq)]
 struct PriorityClassOwner {
     release: String,
@@ -3285,28 +3426,23 @@ async fn priority_class_owner(name: &str) -> Result<PriorityClassOwnership> {
     })))
 }
 
-async fn preflight_priority_class_ownership(opts: &UpOpts, plan: &UpValuePlan) -> Result<()> {
+async fn priority_class_observations(
+    opts: &UpOpts,
+    plan: &UpValuePlan,
+) -> Result<Vec<PriorityClassConflict>> {
     let rendered = rendered_priority_classes(&opts.chart, &opts.common, plan).await?;
-    let mut conflicts = Vec::new();
+    let mut observations = Vec::new();
     for (role, name) in rendered {
         let owner = match priority_class_owner(&name).await? {
             PriorityClassOwnership::Absent => continue,
             PriorityClassOwnership::Existing(owner) => owner,
         };
-        let conflicts_with_target = match owner.as_ref() {
-            None => true,
-            Some(owner) => {
-                owner.release != opts.common.release || owner.namespace != opts.common.namespace
-            }
-        };
-        if conflicts_with_target {
-            conflicts.push(PriorityClassConflict { role, name, owner });
-        }
+        observations.push(PriorityClassConflict { role, name, owner });
     }
-    if conflicts.is_empty() {
-        return Ok(());
-    }
+    Ok(observations)
+}
 
+fn priority_class_conflict_error(conflicts: Vec<PriorityClassConflict>) -> anyhow::Error {
     let mut message = String::from("PriorityClass ownership conflicts block installation:");
     for conflict in conflicts {
         if let Some(owner) = conflict.owner {
@@ -3331,7 +3467,240 @@ async fn preflight_priority_class_ownership(opts: &UpOpts, plan: &UpValuePlan) -
             conflict.role.key()
         ));
     }
-    Err(crate::exit::CliError::failure(message).into())
+    crate::exit::CliError::failure(message).into()
+}
+
+async fn preflight_priority_class_ownership(opts: &UpOpts, plan: &UpValuePlan) -> Result<()> {
+    let mut conflicts = Vec::new();
+    for observation in priority_class_observations(opts, plan).await? {
+        let PriorityClassConflict { role, name, owner } = observation;
+        let conflicts_with_target = match owner.as_ref() {
+            None => true,
+            Some(owner) => {
+                owner.release != opts.common.release || owner.namespace != opts.common.namespace
+            }
+        };
+        if conflicts_with_target {
+            conflicts.push(PriorityClassConflict { role, name, owner });
+        }
+    }
+    if conflicts.is_empty() {
+        return Ok(());
+    }
+
+    Err(priority_class_conflict_error(conflicts))
+}
+
+async fn reconcile_priority_class_ownership(
+    opts: &UpOpts,
+    plan: &mut UpValuePlan,
+) -> Result<Vec<ClusterUpInference>> {
+    let mut conflicts = Vec::new();
+    let mut inferred = Vec::new();
+    for observation in priority_class_observations(opts, plan).await? {
+        let PriorityClassConflict { role, name, owner } = observation;
+        let Some(owner) = owner else {
+            conflicts.push(PriorityClassConflict {
+                role,
+                name,
+                owner: None,
+            });
+            continue;
+        };
+        if owner.release == opts.common.release && owner.namespace == opts.common.namespace {
+            continue;
+        }
+        let key = format!("priorityClasses.{}.create", role.key());
+        match final_operator_value(opts, &key) {
+            Some("true") => {
+                let assignment = format!("{key}=true");
+                let fix = format!("remove `--set {assignment}`, or pass `--set {key}=false`");
+                return Err(crate::exit::CliError::usage(format!(
+                    "PriorityClass `{name}` is owned by Helm release `{}` in namespace `{}`, which contradicts explicit `{assignment}`; {fix}",
+                    owner.release, owner.namespace
+                ))
+                .with_fix(fix)
+                .into());
+            }
+            Some(_) => {}
+            None => inferred.push(ClusterUpInference::PriorityClassReuse {
+                role,
+                name,
+                owner_release: owner.release,
+            }),
+        }
+    }
+    if !conflicts.is_empty() {
+        return Err(priority_class_conflict_error(conflicts));
+    }
+    for inference in &inferred {
+        if let ClusterUpInference::PriorityClassReuse { role, .. } = inference {
+            plan.set(format!("priorityClasses.{}.create", role.key()), "false");
+        }
+    }
+    Ok(inferred)
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum ControllerOwnership {
+    Absent,
+    Existing(Option<PriorityClassOwner>),
+}
+
+fn controller_read_error(detail: impl std::fmt::Display, transient: bool) -> anyhow::Error {
+    let fix = "run `curie cluster status`".to_string();
+    let message = format!(
+        "could not inspect Deployment `{CONTROLLER_DEPLOYMENT_NAME}` in namespace `{CONTROLLER_DEPLOYMENT_NAMESPACE}`: {detail}; {fix}"
+    );
+    let error = if transient {
+        crate::exit::CliError::transient(message)
+    } else {
+        crate::exit::CliError::failure(message)
+    };
+    error.with_fix(fix).into()
+}
+
+fn controller_metadata_map<'a>(
+    metadata: &'a serde_json::Map<String, serde_json::Value>,
+    field: &str,
+) -> Result<Option<&'a serde_json::Map<String, serde_json::Value>>> {
+    match metadata.get(field) {
+        None => Ok(None),
+        Some(serde_json::Value::Object(values)) => Ok(Some(values)),
+        Some(_) => Err(controller_read_error(
+            format!("kubectl returned invalid object JSON with nonobject metadata.{field}"),
+            false,
+        )),
+    }
+}
+
+fn controller_metadata_value<'a>(
+    values: Option<&'a serde_json::Map<String, serde_json::Value>>,
+    key: &str,
+) -> Result<Option<&'a str>> {
+    match values.and_then(|values| values.get(key)) {
+        None => Ok(None),
+        Some(serde_json::Value::String(value)) => Ok(Some(value)),
+        Some(_) => Err(controller_read_error(
+            format!("kubectl returned invalid object JSON at metadata key `{key}`"),
+            false,
+        )),
+    }
+}
+
+async fn controller_owner() -> Result<ControllerOwnership> {
+    let cmd = OpsCommand::new(
+        "kubectl",
+        vec![
+            plain("get"),
+            plain("deployment"),
+            plain(CONTROLLER_DEPLOYMENT_NAME),
+            plain("-n"),
+            plain(CONTROLLER_DEPLOYMENT_NAMESPACE),
+            plain("--ignore-not-found"),
+            plain("-o"),
+            plain("json"),
+        ],
+    );
+    let (ok, out, err) = run_capture(&cmd).await?;
+    if !ok {
+        let missing_namespace = err.contains("NotFound")
+            && err.contains("namespaces")
+            && err.contains(CONTROLLER_DEPLOYMENT_NAMESPACE);
+        if missing_namespace {
+            return Ok(ControllerOwnership::Absent);
+        }
+        return Err(controller_read_error(
+            failure_reason(&err),
+            is_connectivity_failure(&err),
+        ));
+    }
+    if out.trim().is_empty() {
+        return Ok(ControllerOwnership::Absent);
+    }
+    let value: serde_json::Value = serde_json::from_str(out.trim())
+        .map_err(|_| controller_read_error("kubectl returned invalid JSON", false))?;
+    let object = value
+        .as_object()
+        .ok_or_else(|| controller_read_error("kubectl returned invalid object JSON", false))?;
+    if object.get("kind").and_then(|value| value.as_str()) != Some("Deployment") {
+        return Err(controller_read_error(
+            "kubectl returned an object that is not a Deployment",
+            false,
+        ));
+    }
+    let metadata = object
+        .get("metadata")
+        .and_then(|metadata| metadata.as_object())
+        .ok_or_else(|| {
+            controller_read_error(
+                "kubectl returned invalid object JSON without metadata",
+                false,
+            )
+        })?;
+    if metadata.get("name").and_then(|value| value.as_str()) != Some(CONTROLLER_DEPLOYMENT_NAME) {
+        return Err(controller_read_error(
+            "kubectl returned invalid object JSON with another metadata.name",
+            false,
+        ));
+    }
+    let labels = controller_metadata_map(metadata, "labels")?;
+    if controller_metadata_value(labels, "app.kubernetes.io/managed-by")? != Some("Helm") {
+        return Ok(ControllerOwnership::Existing(None));
+    }
+    let annotations = controller_metadata_map(metadata, "annotations")?;
+    let Some(release) = controller_metadata_value(annotations, "meta.helm.sh/release-name")? else {
+        return Ok(ControllerOwnership::Existing(None));
+    };
+    let Some(namespace) = controller_metadata_value(annotations, "meta.helm.sh/release-namespace")?
+    else {
+        return Ok(ControllerOwnership::Existing(None));
+    };
+    Ok(ControllerOwnership::Existing(Some(PriorityClassOwner {
+        release: release.to_string(),
+        namespace: namespace.to_string(),
+    })))
+}
+
+async fn reconcile_controller_ownership(
+    opts: &UpOpts,
+    plan: &mut UpValuePlan,
+) -> Result<Option<ClusterUpInference>> {
+    let explicit = final_operator_value(opts, CONTROLLER_DEPLOY_KEY);
+    if explicit == Some("false") {
+        return Ok(None);
+    }
+    let owner = match controller_owner().await? {
+        ControllerOwnership::Absent => return Ok(None),
+        ControllerOwnership::Existing(Some(owner)) => owner,
+        ControllerOwnership::Existing(None) => {
+            return Err(controller_read_error(
+                "the Deployment exists without complete Helm ownership metadata",
+                false,
+            ));
+        }
+    };
+    if owner.release == opts.common.release && owner.namespace == opts.common.namespace {
+        return Ok(None);
+    }
+    if explicit == Some("true") {
+        let assignment = format!("{CONTROLLER_DEPLOY_KEY}=true");
+        let fix =
+            format!("remove `--set {assignment}`, or pass `--set {CONTROLLER_DEPLOY_KEY}=false`");
+        return Err(crate::exit::CliError::usage(format!(
+            "Deployment `{CONTROLLER_DEPLOYMENT_NAME}` is owned by Helm release `{}` in namespace `{}`, which contradicts explicit `{assignment}`; {fix}",
+            owner.release, owner.namespace
+        ))
+        .with_fix(fix)
+        .into());
+    }
+    if explicit.is_some() {
+        return Ok(None);
+    }
+    plan.set(CONTROLLER_DEPLOY_KEY, "false");
+    Ok(Some(ClusterUpInference::ControllerReuse {
+        owner_release: owner.release,
+    }))
 }
 
 fn up_commands_with_plan(o: &UpOpts, plan: &UpValuePlan) -> Vec<OpsCommand> {
@@ -4159,7 +4528,7 @@ fn gvisor_event_watch_line(
     let name = fields.next().unwrap_or_default();
     let reason = fields.next().unwrap_or_default();
     let message = fields.next().unwrap_or_default();
-    let missing_runtimeclass = message.contains("RuntimeClass") && message.contains("not found");
+    let missing_runtimeclass = message.contains("RuntimeClass \"gvisor\" not found");
     if kind == "Job"
         && event_namespace == namespace
         && name == job
@@ -4210,6 +4579,11 @@ enum GvisorInstallRace {
     RuntimeClassRejected(String),
 }
 
+enum GvisorInstallOutcome {
+    Installed,
+    RuntimeClassRejected(String),
+}
+
 async fn run_install_with_gvisor_observer(
     cl: &crate::ui::Checklist,
     label: &str,
@@ -4218,7 +4592,7 @@ async fn run_install_with_gvisor_observer(
     namespace: &str,
     job: &str,
     namespace_existed_before_install: bool,
-) -> Result<String> {
+) -> Result<GvisorInstallOutcome> {
     let ui = crate::ui::ui();
     ui.plumbing(&format!("+ {}", cmd.display()));
     let step = cl.step(label);
@@ -4332,7 +4706,10 @@ async fn run_install_with_gvisor_observer(
             }
             let captured = install.finish(status).await;
             match captured {
-                Ok((ok, out, err)) => finish_captured_step(step, ok_detail, cmd, ok, out, err),
+                Ok((ok, out, err)) => {
+                    finish_captured_step(step, ok_detail, cmd, ok, out, err)?;
+                    Ok(GvisorInstallOutcome::Installed)
+                }
                 Err(error) => {
                     step.fail("failed");
                     Err(error)
@@ -4345,12 +4722,7 @@ async fn run_install_with_gvisor_observer(
             }
             install.terminate().await;
             step.fail("failed");
-            let fix = "curie cluster up --set security.gvisor.mode=off";
-            Err(crate::exit::CliError::failure(format!(
-                "gVisor preflight Job `{job}` could not create its pod: {rejection}. To install without gVisor isolation, run `{fix}`."
-            ))
-            .with_fix(fix)
-            .into())
+            Ok(GvisorInstallOutcome::RuntimeClassRejected(rejection))
         }
     }
 }
@@ -4425,12 +4797,18 @@ fn should_read_existing(dev: bool, dry_run: bool) -> bool {
     !dry_run
 }
 
+enum UpInferencePolicy {
+    Detect(Vec<ClusterUpInference>),
+    Disabled,
+}
+
 pub async fn up(
-    opts: UpOpts,
+    mut opts: UpOpts,
     github_token: Option<String>,
     clear_github_token: bool,
 ) -> Result<ClusterUpOutput> {
     validate_up_inputs(&opts, github_token.as_deref(), clear_github_token)?;
+    provider_contradiction(&opts, &up_value_plan(&opts))?;
     let resolve_provider_egress = !opts.common.dry_run;
     let existing = if should_read_existing(opts.dev, opts.common.dry_run) {
         require_on_path("helm")?;
@@ -4438,15 +4816,36 @@ pub async fn up(
     } else {
         None
     };
-    let opts = complete_up_opts(
+    opts = complete_up_opts_without_runner_egress(
         opts,
         existing.as_ref(),
         github_token.as_deref(),
         clear_github_token,
-        resolve_provider_egress,
     )?;
+    let completed_identity_plan = up_value_plan(&opts);
+    let mut inferences = Vec::new();
+    if let Some(inference) = reconcile_provider_inference(&mut opts, &completed_identity_plan)? {
+        inferences.push(inference);
+    }
+    let operator_sets = opts.operator_sets();
+    resolve_preserved_runner_egress_values(&mut opts, existing.as_ref(), &operator_sets);
+    if resolve_provider_egress
+        && !opts.allow_egress_host.is_empty()
+        && opts.resolved_egress_cidrs.is_empty()
+    {
+        opts.resolved_egress_cidrs =
+            resolve_provider_egress_cidrs_for_current_environment(&opts.allow_egress_host)
+                .context("resolving named provider egress hosts")?;
+    }
     let value_plan = up_value_plan(&opts);
-    run_prepared_up(opts, value_plan, existing, github_token.as_deref()).await
+    run_prepared_up(
+        opts,
+        value_plan,
+        existing,
+        github_token.as_deref(),
+        UpInferencePolicy::Detect(inferences),
+    )
+    .await
 }
 
 /// Execute an up plan whose local validation and live completion already ran.
@@ -4459,16 +4858,31 @@ pub(crate) async fn up_prepared(
     github_token: Option<String>,
 ) -> Result<ClusterUpOutput> {
     validate_up_inputs(&opts, github_token.as_deref(), false)?;
-    run_prepared_up(opts, value_plan, existing, github_token.as_deref()).await
+    run_prepared_up(
+        opts,
+        value_plan,
+        existing,
+        github_token.as_deref(),
+        UpInferencePolicy::Disabled,
+    )
+    .await
 }
 
 async fn run_prepared_up(
     opts: UpOpts,
-    value_plan: UpValuePlan,
+    mut value_plan: UpValuePlan,
     existing: Option<serde_json::Value>,
     github_token: Option<&str>,
+    inference_policy: UpInferencePolicy,
 ) -> Result<ClusterUpOutput> {
     let ui = crate::ui::ui();
+    let (detect_facts, initial_inferences) = match inference_policy {
+        UpInferencePolicy::Detect(inferences) => (true, inferences),
+        UpInferencePolicy::Disabled => (false, Vec::new()),
+    };
+    for inference in &initial_inferences {
+        inference.render(ui);
+    }
     if !opts.dev {
         let operator_sets = opts.operator_sets();
         let preserved = resolve_preserved_values(existing.as_ref(), &operator_sets);
@@ -4706,14 +5120,24 @@ async fn run_prepared_up(
         .find_map(|(namespace, existed)| (namespace == &opts.common.namespace).then_some(*existed))
         .unwrap_or(false);
     require_on_path("helm")?;
-    preflight_priority_class_ownership(&opts, &value_plan).await?;
+    if detect_facts {
+        for inference in reconcile_priority_class_ownership(&opts, &mut value_plan).await? {
+            inference.render(ui);
+        }
+        if let Some(inference) = reconcile_controller_ownership(&opts, &mut value_plan).await? {
+            inference.render(ui);
+        }
+    } else {
+        preflight_priority_class_ownership(&opts, &value_plan).await?;
+    }
+    cmds = up_commands_with_plan(&opts, &value_plan);
     let gvisor_preflight_job =
         rendered_gvisor_preflight_job(&opts.chart, &opts.common, &value_plan).await?;
     let cl = ui.checklist();
     let label = format!("installing release {}", opts.common.release);
     for cmd in &cmds {
         if let Some(job) = gvisor_preflight_job.as_deref() {
-            run_install_with_gvisor_observer(
+            let outcome = run_install_with_gvisor_observer(
                 &cl,
                 &label,
                 "installed",
@@ -4723,6 +5147,39 @@ async fn run_prepared_up(
                 release_namespace_existed_before_install,
             )
             .await?;
+            match outcome {
+                GvisorInstallOutcome::Installed => {}
+                GvisorInstallOutcome::RuntimeClassRejected(rejection) if detect_facts => {
+                    if let Some(mode @ ("auto" | "require")) =
+                        final_operator_value(&opts, GVISOR_MODE_KEY)
+                    {
+                        let assignment = format!("{GVISOR_MODE_KEY}={mode}");
+                        let fix = format!(
+                            "remove the explicit `{assignment}` setting and rerun to accept the inferred gVisor posture"
+                        );
+                        return Err(crate::exit::CliError::usage(format!(
+                            "explicit `{assignment}` contradicts the detected admission result `{rejection}`; {fix}"
+                        ))
+                        .with_fix(fix)
+                        .into());
+                    }
+                    value_plan.set(GVISOR_MODE_KEY, "off");
+                    ClusterUpInference::GvisorOff.render(ui);
+                    let retry = up_commands_with_plan(&opts, &value_plan)
+                        .into_iter()
+                        .next()
+                        .expect("cluster up always has one Helm command");
+                    run_step(&cl, &label, "installed", &retry).await?;
+                }
+                GvisorInstallOutcome::RuntimeClassRejected(rejection) => {
+                    let fix = "curie cluster up --set security.gvisor.mode=off";
+                    return Err(crate::exit::CliError::failure(format!(
+                        "gVisor preflight Job `{job}` could not create its pod: {rejection}. To install without gVisor isolation, run `{fix}`."
+                    ))
+                    .with_fix(fix)
+                    .into());
+                }
+            }
         } else {
             run_step(&cl, &label, "installed", cmd).await?;
         }

--- a/cli/tests/cluster_secret_hardening.rs
+++ b/cli/tests/cluster_secret_hardening.rs
@@ -136,6 +136,13 @@ if [ "$1" = "get" ] && [ "$2" = "namespace" ]; then
     exit 0
 fi
 
+if [ "$1" = "get" ] && [ "$2" = "deployment" ] &&
+   [ "$3" = "agent-sandbox-controller" ] && [ "$4" = "-n" ] &&
+   [ "$5" = "agent-sandbox-system" ] && [ "$6" = "--ignore-not-found" ] &&
+   [ "$7" = "-o" ] && [ "$8" = "json" ] && [ -z "$9" ]; then
+    exit 0
+fi
+
 if [ "$1" = "get" ] && [ "$2" = "statefulset" ]; then
     printf '%s\n' '{"apiVersion":"v1","items":[],"kind":"List","metadata":{}}'
     exit 0

--- a/cli/tests/cluster_up_gvisor_preflight.rs
+++ b/cli/tests/cluster_up_gvisor_preflight.rs
@@ -234,8 +234,12 @@ if [ "$1" = "get" ] && [ "$2" = "namespace" ]; then
 fi
 
 if [ "$1" = "get" ] && [ "$2" = "statefulset" ]; then
-    printf '%s\n' '{"apiVersion":"v1","kind":"List","items":[]}'
-    exit 0
+    if [ "$3" = "-n" ] && [ "$4" = "target-namespace" ] && [ "$5" = "-o" ] && [ "$6" = "json" ]; then
+        printf '%s\n' '{"apiVersion":"v1","kind":"List","items":[]}'
+        exit 0
+    fi
+    printf 'unexpected StatefulSet query: %s\n' "$*" >&2
+    exit 64
 fi
 
 if [ "$1" = "label" ] && [ "$2" = "namespace" ] && [ "$3" = "target-namespace" ]; then

--- a/cli/tests/cluster_up_gvisor_preflight.rs
+++ b/cli/tests/cluster_up_gvisor_preflight.rs
@@ -13,6 +13,7 @@ const TARGET_RELEASE: &str = "target-release";
 const TARGET_NAMESPACE: &str = "target-namespace";
 const RENDERED_JOB: &str = "acme-runtime-preflight-gvisor";
 const RUNTIME_CLASS_REJECTION: &str = "Error creating: pods \"acme-runtime-preflight-gvisor-example\" is forbidden: pod rejected: RuntimeClass \"gvisor\" not found";
+const OPENROUTER_CREDENTIAL: &str = "sk-or-v1-PLACEHOLDER";
 
 fn bin() -> &'static str {
     env!("CARGO_BIN_EXE_curie")
@@ -46,10 +47,12 @@ struct Fixture {
     watch_pid: PathBuf,
     event_emitted: PathBuf,
     event_mode: String,
+    singleton_mode: String,
+    credential: String,
 }
 
 impl Fixture {
-    fn new(event_mode: &str) -> Self {
+    fn new(event_mode: &str, singleton_mode: &str, credential: &str) -> Self {
         let temp = tempfile::tempdir().expect("temporary directory");
         let bin_dir = temp.path().join("bin");
         fs::create_dir(&bin_dir).expect("create fake binary directory");
@@ -163,16 +166,18 @@ if [ "$1" = "upgrade" ] && [ "$2" = "--install" ]; then
     printf '%s\n' "$*" >> "$CURIE_TEST_UPGRADE_LOG"
     printf '%s\n' "$$" > "$CURIE_TEST_HELM_PID"
     gvisor_mode="auto"
+    fake_model="true"
     for argument in "$@"; do
         case "$argument" in
             security.gvisor.mode=*) gvisor_mode=${argument#*=} ;;
+            agentSandbox.runner.fakeModel=*) fake_model=${argument#*=} ;;
         esac
     done
     if [ -e "$CURIE_TEST_HELM_PENDING" ]; then
         printf '%s\n' 'Error: UPGRADE FAILED: another operation (install/upgrade/rollback) is in progress' >&2
         exit 1
     fi
-    if { [ "$CURIE_TEST_EVENT_MODE" = "matching" ] || [ "$CURIE_TEST_EVENT_MODE" = "fresh-namespace" ]; } && [ "$gvisor_mode" = "require" ]; then
+    if { [ "$CURIE_TEST_EVENT_MODE" = "matching" ] || [ "$CURIE_TEST_EVENT_MODE" = "fresh-namespace" ]; } && { [ "$gvisor_mode" = "require" ] || { [ "$gvisor_mode" = "auto" ] && [ "$fake_model" = "false" ]; }; }; then
         : > "$CURIE_TEST_HELM_PENDING"
         graceful_exit() {
             signal="$1"
@@ -222,8 +227,27 @@ if [ "$1" = "get" ] && [ "$2" = "namespace" ]; then
 fi
 
 if [ "$1" = "get" ] && [ "$2" = "priorityclass" ]; then
+    if [ "$CURIE_TEST_SINGLETON_MODE" = "foreign" ]; then
+        printf '{"apiVersion":"scheduling.k8s.io/v1","kind":"PriorityClass","metadata":{"name":"%s","labels":{"app.kubernetes.io/managed-by":"Helm"},"annotations":{"meta.helm.sh/release-name":"shared-owner","meta.helm.sh/release-namespace":"shared-owner-namespace"}}}\n' "$3"
+    fi
     exit 0
 fi
+
+case " $* " in
+    *" get deployment agent-sandbox-controller "*)
+        case " $* " in
+            *" -n agent-sandbox-system "*) ;;
+            *)
+                printf 'controller query was not scoped to agent-sandbox-system: %s\n' "$*" >&2
+                exit 64
+                ;;
+        esac
+        if [ "$CURIE_TEST_SINGLETON_MODE" = "foreign" ]; then
+            printf '%s\n' '{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"name":"agent-sandbox-controller","labels":{"app.kubernetes.io/managed-by":"Helm"},"annotations":{"meta.helm.sh/release-name":"shared-controller","meta.helm.sh/release-namespace":"shared-owner-namespace"}}}'
+        fi
+        exit 0
+        ;;
+esac
 
 if [ "$1" = "get" ] && { [ "$2" = "event" ] || [ "$2" = "events" ]; }; then
     printf '%s\n' "$*" >> "$CURIE_TEST_EVENT_LOG"
@@ -344,6 +368,8 @@ exit 64
             watch_pid,
             event_emitted,
             event_mode: event_mode.to_string(),
+            singleton_mode: singleton_mode.to_string(),
+            credential: credential.to_string(),
         }
     }
 
@@ -367,16 +393,14 @@ exit 64
             TARGET_RELEASE,
             "--dev",
             "--no-expose",
-            "--fake-model",
-            "--set",
-            "security.gvisor.mode=require",
             "--set",
             "fullnameOverride=acme-runtime",
         ];
         args.extend_from_slice(extra);
 
         let started = Instant::now();
-        let output = Command::new(bin())
+        let mut command = Command::new(bin());
+        command
             .args(args)
             .env("PATH", path)
             .env("CI", "1")
@@ -395,12 +419,20 @@ exit 64
             .env("CURIE_TEST_WATCH_PID", &self.watch_pid)
             .env("CURIE_TEST_EVENT_EMITTED", &self.event_emitted)
             .env("CURIE_TEST_EVENT_MODE", &self.event_mode)
-            .env_remove("CURIE_CREDENTIALS")
+            .env("CURIE_TEST_SINGLETON_MODE", &self.singleton_mode)
+            .env(
+                "CURIE_TEST_PROVIDER_EGRESS_JSON",
+                r#"{"openrouter.ai":["1.1.1.1"],"api.anthropic.com":["8.8.8.8"]}"#,
+            )
             .env_remove("CURIE_MODEL_CREDENTIALS")
             .env_remove("CURIE_GITHUB_TOKEN")
-            .env_remove("CURIE_MODEL")
-            .output()
-            .expect("run curie cluster up");
+            .env_remove("CURIE_MODEL");
+        if self.credential.is_empty() {
+            command.env_remove("CURIE_CREDENTIALS");
+        } else {
+            command.env("CURIE_CREDENTIALS", &self.credential);
+        }
+        let output = command.output().expect("run curie cluster up");
         (output, started.elapsed())
     }
 
@@ -513,42 +545,66 @@ fn assert_process_stopped(pid_file: &Path, label: &str) {
     panic!("{label} process {pid} survived curie cluster up");
 }
 
+fn assert_inference_once(shown: &str, applied_override: &str) {
+    assert_eq!(
+        shown.matches(applied_override).count(),
+        1,
+        "the applied override must be disclosed exactly once: {applied_override}\n{shown}"
+    );
+}
+
 #[test]
-fn matching_runtimeclass_rejection_wins_before_helm_deadline() {
-    let fixture = Fixture::new("matching");
+fn bare_cluster_up_infers_all_detected_facts_and_retries_once() {
+    let fixture = Fixture::new("matching", "foreign", OPENROUTER_CREDENTIAL);
     let (output, elapsed) = fixture.run(&[]);
     let shown = stderr(&output);
 
-    assert_eq!(
-        output.status.code(),
-        Some(1),
-        "the RuntimeClass rejection must be a permanent runtime failure\nstdout:\n{}\nstderr:\n{shown}",
-        String::from_utf8_lossy(&output.stdout)
+    assert!(
+        output.status.success(),
+        "the bare command must converge on the detected cluster facts\nstdout:\n{}\nstderr:\n{shown}",
+        String::from_utf8_lossy(&output.stdout),
     );
     assert!(
         elapsed < Duration::from_secs(3),
         "the event must win well before the five second fake Helm deadline, elapsed {elapsed:?}\nstderr:\n{shown}"
     );
     assert!(
-        shown.contains(RUNTIME_CLASS_REJECTION),
-        "the original Kubernetes rejection must be preserved:\n{shown}"
-    );
-    assert!(
         !shown.contains("stale-added") && !shown.contains("stale-modified"),
         "Events that existed before this install must be ignored even when modified:\n{shown}"
     );
-    assert!(
-        shown.contains("--set security.gvisor.mode=off"),
-        "the failure must name the explicit opt out:\n{shown}"
-    );
+    for applied in [
+        "--allow-egress-host openrouter",
+        "--set priorityClasses.platform.create=false",
+        "--set priorityClasses.sandbox.create=false",
+        "--set agentSandbox.controller.deploy=false",
+        "--set security.gvisor.mode=off",
+    ] {
+        assert_inference_once(&shown, applied);
+    }
     assert!(
         !shown.contains("DeadlineExceeded"),
         "the later Helm timeout must not become the diagnosis:\n{shown}"
     );
     assert_eq!(
         fixture.upgrade_count(),
-        1,
-        "helm upgrade --install must start exactly once"
+        2,
+        "the matching admission result permits exactly one retry"
+    );
+    let upgrades = fs::read_to_string(&fixture.upgrade_log).expect("read Helm upgrade log");
+    assert!(
+        upgrades.contains("security.networkPolicy.allowedEgress[0].cidr=1.1.1.1/32"),
+        "the inferred OpenRouter route must reach Helm:\n{upgrades}"
+    );
+    assert!(
+        upgrades
+            .lines()
+            .last()
+            .is_some_and(|line| line.contains("security.gvisor.mode=off")),
+        "the retry must carry the inferred mode off value:\n{upgrades}"
+    );
+    assert!(
+        !shown.contains(OPENROUTER_CREDENTIAL),
+        "credential leaked: {shown}"
     );
     fixture.assert_event_was_observed_for_rendered_job();
     fixture.assert_graceful_helm_interruption();
@@ -557,8 +613,14 @@ fn matching_runtimeclass_rejection_wins_before_helm_deadline() {
 
 #[test]
 fn runtimeclass_document_before_job_still_observes_the_rendered_job() {
-    let fixture = Fixture::new("nonmatching");
-    let (output, _) = fixture.run(&["--set", "security.gvisor.installRuntimeClass=true"]);
+    let fixture = Fixture::new("nonmatching", "absent", "");
+    let (output, _) = fixture.run(&[
+        "--fake-model",
+        "--set",
+        "security.gvisor.mode=require",
+        "--set",
+        "security.gvisor.installRuntimeClass=true",
+    ]);
     assert!(
         output.status.success(),
         "a RuntimeClass document before the Job must not block the install\nstdout:\n{}\nstderr:\n{}",
@@ -572,33 +634,25 @@ fn runtimeclass_document_before_job_still_observes_the_rendered_job() {
 
 #[test]
 fn fresh_namespace_rejection_is_observed_after_helm_creates_the_namespace() {
-    let fixture = Fixture::new("fresh-namespace");
+    let fixture = Fixture::new("fresh-namespace", "absent", OPENROUTER_CREDENTIAL);
     let (output, elapsed) = fixture.run(&[]);
     let shown = stderr(&output);
 
-    assert_eq!(
-        output.status.code(),
-        Some(1),
-        "a fresh namespace must preserve the RuntimeClass failure classification\nstdout:\n{}\nstderr:\n{shown}",
-        String::from_utf8_lossy(&output.stdout)
+    assert!(
+        output.status.success(),
+        "a fresh namespace must converge after the observed RuntimeClass rejection\nstdout:\n{}\nstderr:\n{shown}",
+        String::from_utf8_lossy(&output.stdout),
     );
     assert!(
         elapsed < Duration::from_secs(3),
         "the post Helm namespace retry must still beat the fake deadline, elapsed {elapsed:?}\nstderr:\n{shown}"
     );
-    assert!(
-        shown.contains(RUNTIME_CLASS_REJECTION),
-        "the initial watch list must preserve the RuntimeClass rejection:\n{shown}"
-    );
-    assert!(
-        shown.contains("--set security.gvisor.mode=off"),
-        "the fresh namespace failure must retain the recovery:\n{shown}"
-    );
+    assert_inference_once(&shown, "--set security.gvisor.mode=off");
     assert!(
         !shown.contains("DeadlineExceeded"),
         "the Helm deadline must not replace the fresh namespace diagnosis:\n{shown}"
     );
-    assert_eq!(fixture.upgrade_count(), 1);
+    assert_eq!(fixture.upgrade_count(), 2);
     assert!(
         fixture.namespace_ready.is_file() && fixture.event_emitted.is_file(),
         "Helm must create the namespace and event before the retry observes them"
@@ -628,8 +682,8 @@ fn fresh_namespace_rejection_is_observed_after_helm_creates_the_namespace() {
 
 #[test]
 fn nonmatching_failedcreate_does_not_abort_successful_install() {
-    let fixture = Fixture::new("nonmatching");
-    let (output, _) = fixture.run(&[]);
+    let fixture = Fixture::new("nonmatching", "absent", "");
+    let (output, _) = fixture.run(&["--fake-model", "--set", "security.gvisor.mode=require"]);
     let shown = stderr(&output);
 
     assert!(
@@ -651,75 +705,78 @@ fn nonmatching_failedcreate_does_not_abort_successful_install() {
 }
 
 #[test]
-fn matching_runtimeclass_rejection_has_one_json_error() {
-    let fixture = Fixture::new("matching");
+fn bare_cluster_up_json_keeps_inferences_on_stderr_and_one_success_on_stdout() {
+    let fixture = Fixture::new("matching", "foreign", OPENROUTER_CREDENTIAL);
     let (output, elapsed) = fixture.run(&["--json"]);
+    let shown = stderr(&output);
 
-    assert_eq!(
-        output.status.code(),
-        Some(1),
-        "the JSON path must preserve the permanent failure classification\nstderr:\n{}",
-        stderr(&output)
+    assert!(
+        output.status.success(),
+        "the JSON path must converge on detected facts\nstderr:\n{shown}"
     );
     assert!(
         elapsed < Duration::from_secs(3),
         "the JSON path must also beat the fake Helm deadline, elapsed {elapsed:?}"
     );
     let payload: serde_json::Value = serde_json::from_slice(&output.stdout)
-        .unwrap_or_else(|error| panic!("--json must emit exactly one error object: {error}"));
+        .unwrap_or_else(|error| panic!("--json must emit exactly one success object: {error}"));
     assert!(
-        payload["error"]
-            .as_str()
-            .is_some_and(|error| error.contains(RUNTIME_CLASS_REJECTION)),
-        "the machine readable error must preserve the Kubernetes rejection: {payload}"
+        payload.get("error").is_none(),
+        "successful output must not retain the recovered rejection: {payload}"
     );
-    assert!(
-        payload["fix"]
-            .as_str()
-            .is_some_and(|fix| fix.contains("curie cluster up --set security.gvisor.mode=off")),
-        "the machine readable fix must name the explicit opt out: {payload}"
-    );
-    assert_eq!(fixture.upgrade_count(), 1);
+    for applied in [
+        "--allow-egress-host openrouter",
+        "--set priorityClasses.platform.create=false",
+        "--set priorityClasses.sandbox.create=false",
+        "--set agentSandbox.controller.deploy=false",
+        "--set security.gvisor.mode=off",
+    ] {
+        assert_inference_once(&shown, applied);
+    }
+    assert_eq!(fixture.upgrade_count(), 2);
     fixture.assert_event_was_observed_for_rendered_job();
     fixture.assert_graceful_helm_interruption();
     fixture.assert_children_stopped();
 }
 
 #[test]
-fn graceful_interruption_allows_the_mode_off_recovery_to_run_next() {
-    let fixture = Fixture::new("matching");
-    let (first, _) = fixture.run(&[]);
-    assert_eq!(
-        first.status.code(),
-        Some(1),
-        "the first install must observe the RuntimeClass rejection\nstderr:\n{}",
-        stderr(&first)
-    );
-    fixture.assert_graceful_helm_interruption();
+fn explicit_gvisor_mode_contradicting_admission_is_rejected_before_retry() {
+    for setting in ["security.gvisor.mode=auto", "security.gvisor.mode=require"] {
+        let fixture = Fixture::new("matching", "absent", OPENROUTER_CREDENTIAL);
+        let (output, elapsed) = fixture.run(&["--set", setting]);
+        let shown = stderr(&output);
 
-    let (recovery, _) = fixture.run(&["--set", "security.gvisor.mode=off"]);
-    assert!(
-        recovery.status.success(),
-        "the advertised mode off recovery must not be blocked by a pending Helm operation\nstdout:\n{}\nstderr:\n{}",
-        String::from_utf8_lossy(&recovery.stdout),
-        stderr(&recovery)
-    );
-    assert_eq!(
-        fixture.upgrade_count(),
-        2,
-        "the rejected install and its recovery must each invoke Helm once"
-    );
-    assert!(
-        !fixture.helm_pending.exists(),
-        "the successful recovery must leave no pending Helm operation"
-    );
+        assert_eq!(
+            output.status.code(),
+            Some(2),
+            "{setting} contradicts the observed missing RuntimeClass\nstdout:\n{}\nstderr:\n{shown}",
+            String::from_utf8_lossy(&output.stdout)
+        );
+        assert!(elapsed < Duration::from_secs(3), "{setting}: {elapsed:?}");
+        assert_eq!(
+            fixture.upgrade_count(),
+            1,
+            "the explicit contradiction must stop before retry"
+        );
+        assert!(
+            shown.contains(RUNTIME_CLASS_REJECTION),
+            "{setting}: {shown}"
+        );
+        assert!(shown.contains(setting), "{setting}: {shown}");
+        assert!(
+            !shown.contains("--set security.gvisor.mode=off"),
+            "the explicit value must not be silently overridden: {shown}"
+        );
+        fixture.assert_graceful_helm_interruption();
+        fixture.assert_children_stopped();
+    }
 }
 
 #[test]
 fn fake_model_auto_and_mode_off_skip_the_event_observer() {
     for setting in ["security.gvisor.mode=auto", "security.gvisor.mode=off"] {
-        let fixture = Fixture::new("matching");
-        let (output, _) = fixture.run(&["--set", setting]);
+        let fixture = Fixture::new("matching", "absent", "");
+        let (output, _) = fixture.run(&["--fake-model", "--set", setting]);
         assert!(
             output.status.success(),
             "{setting} must proceed when Helm reports that the conditional template rendered nothing\nstdout:\n{}\nstderr:\n{}",
@@ -733,8 +790,8 @@ fn fake_model_auto_and_mode_off_skip_the_event_observer() {
 
 #[test]
 fn unavailable_event_watch_preserves_the_helm_result() {
-    let fixture = Fixture::new("watch-unavailable");
-    let (output, _) = fixture.run(&[]);
+    let fixture = Fixture::new("watch-unavailable", "absent", "");
+    let (output, _) = fixture.run(&["--fake-model", "--set", "security.gvisor.mode=require"]);
     assert!(
         output.status.success(),
         "an unavailable Event read must fall back to Helm's result\nstdout:\n{}\nstderr:\n{}",

--- a/cli/tests/cluster_up_gvisor_preflight.rs
+++ b/cli/tests/cluster_up_gvisor_preflight.rs
@@ -226,6 +226,12 @@ if [ "$1" = "get" ] && [ "$2" = "namespace" ]; then
     exit 0
 fi
 
+if [ "$1" = "label" ] && [ "$2" = "namespace" ] && [ "$3" = "target-namespace" ]; then
+    case " $* " in
+        *" --overwrite "*) exit 0 ;;
+    esac
+fi
+
 if [ "$1" = "get" ] && [ "$2" = "priorityclass" ]; then
     if [ "$CURIE_TEST_SINGLETON_MODE" = "foreign" ]; then
         printf '{"apiVersion":"scheduling.k8s.io/v1","kind":"PriorityClass","metadata":{"name":"%s","labels":{"app.kubernetes.io/managed-by":"Helm"},"annotations":{"meta.helm.sh/release-name":"shared-owner","meta.helm.sh/release-namespace":"shared-owner-namespace"}}}\n' "$3"

--- a/cli/tests/cluster_up_gvisor_preflight.rs
+++ b/cli/tests/cluster_up_gvisor_preflight.rs
@@ -37,6 +37,7 @@ fn write_exec(dir: &Path, name: &str, body: &str) {
 struct Fixture {
     _temp: tempfile::TempDir,
     bin_dir: PathBuf,
+    plan_file: PathBuf,
     upgrade_log: PathBuf,
     event_log: PathBuf,
     helm_pid: PathBuf,
@@ -56,6 +57,12 @@ impl Fixture {
         let temp = tempfile::tempdir().expect("temporary directory");
         let bin_dir = temp.path().join("bin");
         fs::create_dir(&bin_dir).expect("create fake binary directory");
+        let plan_file = temp.path().join("curie.yaml");
+        fs::write(
+            &plan_file,
+            "version: 1\ninstall:\n  namespace: target-namespace\n  release: target-release\ncredentials:\n  model: CURIE_CREDENTIALS\nset:\n  fullnameOverride: acme-runtime\n  security.gvisor.mode: require\n",
+        )
+        .expect("write prepared apply plan");
         let upgrade_log = temp.path().join("upgrades.log");
         let event_log = temp.path().join("event-queries.log");
         let helm_pid = temp.path().join("helm.pid");
@@ -226,6 +233,11 @@ if [ "$1" = "get" ] && [ "$2" = "namespace" ]; then
     exit 0
 fi
 
+if [ "$1" = "get" ] && [ "$2" = "statefulset" ]; then
+    printf '%s\n' '{"apiVersion":"v1","kind":"List","items":[]}'
+    exit 0
+fi
+
 if [ "$1" = "label" ] && [ "$2" = "namespace" ] && [ "$3" = "target-namespace" ]; then
     case " $* " in
         *" --overwrite "*) exit 0 ;;
@@ -364,6 +376,7 @@ exit 64
         Self {
             _temp: temp,
             bin_dir,
+            plan_file,
             upgrade_log,
             event_log,
             helm_pid,
@@ -380,12 +393,6 @@ exit 64
     }
 
     fn run(&self, extra: &[&str]) -> (Output, Duration) {
-        let mut paths = vec![self.bin_dir.clone()];
-        if let Some(current) = std::env::var_os("PATH") {
-            paths.extend(std::env::split_paths(&current));
-        }
-        let path = std::env::join_paths(paths).expect("join PATH");
-
         let mut args = vec![
             "--color",
             "never",
@@ -403,6 +410,27 @@ exit 64
             "fullnameOverride=acme-runtime",
         ];
         args.extend_from_slice(extra);
+        self.run_args(&args)
+    }
+
+    fn run_apply(&self) -> (Output, Duration) {
+        self.run_args(&[
+            "--color",
+            "never",
+            "apply",
+            "--file",
+            self.plan_file.to_str().expect("UTF 8 plan path"),
+            "--chart",
+            chart(),
+        ])
+    }
+
+    fn run_args(&self, args: &[&str]) -> (Output, Duration) {
+        let mut paths = vec![self.bin_dir.clone()];
+        if let Some(current) = std::env::var_os("PATH") {
+            paths.extend(std::env::split_paths(&current));
+        }
+        let path = std::env::join_paths(paths).expect("join PATH");
 
         let started = Instant::now();
         let mut command = Command::new(bin());
@@ -438,7 +466,7 @@ exit 64
         } else {
             command.env("CURIE_CREDENTIALS", &self.credential);
         }
-        let output = command.output().expect("run curie cluster up");
+        let output = command.output().expect("run curie command");
         (output, started.elapsed())
     }
 
@@ -776,6 +804,33 @@ fn explicit_gvisor_mode_contradicting_admission_is_rejected_before_retry() {
         fixture.assert_graceful_helm_interruption();
         fixture.assert_children_stopped();
     }
+}
+
+#[test]
+fn prepared_apply_keeps_the_exact_gvisor_rejection_fail_closed() {
+    let fixture = Fixture::new("matching", "absent", OPENROUTER_CREDENTIAL);
+    let (output, elapsed) = fixture.run_apply();
+    let shown = stderr(&output);
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "prepared apply must fail closed\nstdout:\n{}\nstderr:\n{shown}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert!(elapsed < Duration::from_secs(3), "{elapsed:?}: {shown}");
+    assert!(shown.contains(RUNTIME_CLASS_REJECTION), "{shown}");
+    assert!(
+        shown.contains("curie cluster up --set security.gvisor.mode=off"),
+        "prepared apply must retain the explicit recovery: {shown}"
+    );
+    assert!(
+        !shown.contains("inferred that the cluster has no"),
+        "prepared apply must not infer a posture: {shown}"
+    );
+    assert_eq!(fixture.upgrade_count(), 1, "prepared apply must not retry");
+    fixture.assert_graceful_helm_interruption();
+    fixture.assert_children_stopped();
 }
 
 #[test]

--- a/cli/tests/cluster_up_inference.rs
+++ b/cli/tests/cluster_up_inference.rs
@@ -349,7 +349,7 @@ fn inference_uses_the_effective_credential_precedence() {
     let output = final_helm_value.run(
         &[("CURIE_CREDENTIALS", OPENROUTER_CREDENTIAL)],
         VALID_RESOLVER,
-        &["--set-string", explicit_credential.as_str()],
+        &["--set", explicit_credential.as_str()],
     );
     assert_success(&final_helm_value, &output);
     assert!(final_helm_value.upgrade_log().contains("8.8.8.8/32"));

--- a/cli/tests/cluster_up_inference.rs
+++ b/cli/tests/cluster_up_inference.rs
@@ -245,6 +245,32 @@ fn recognized_credential_prefixes_infer_provider_egress() {
 }
 
 #[test]
+fn inferred_provider_refresh_preserves_recorded_web_egress() {
+    let fixture = Fixture::new(
+        r#"{
+          "agentSandbox":{"runner":{"credentials":"sk-or-v1-PLACEHOLDER"}},
+          "security":{"networkPolicy":{"allowedEgress":[{
+            "cidr":"203.0.113.0/24",
+            "ports":[{"protocol":"TCP","port":443}]
+          }]}}
+        }"#,
+    );
+    let output = fixture.run(&[], VALID_RESOLVER, &[]);
+    assert_success(&fixture, &output);
+
+    let upgrade = fixture.upgrade_log();
+    assert!(
+        upgrade.contains("security.networkPolicy.allowedEgress[0].cidr=203.0.113.0/24"),
+        "the recorded web route must survive the inferred provider refresh: {upgrade}"
+    );
+    assert!(
+        upgrade.contains("security.networkPolicy.allowedEgress[1].cidr=1.1.1.1/32"),
+        "the refreshed provider route must use a noncolliding index: {upgrade}"
+    );
+    assert_inference_once(&stderr(&output), "--allow-egress-host openrouter");
+}
+
+#[test]
 fn explicit_provider_list_containing_the_detected_provider_wins_silently() {
     let fixture = Fixture::new("");
     let output = fixture.run(
@@ -267,6 +293,40 @@ fn explicit_provider_list_containing_the_detected_provider_wins_silently() {
     let upgrade = fixture.upgrade_log();
     assert!(upgrade.contains("1.1.1.1/32"), "{upgrade}");
     assert!(upgrade.contains("8.8.8.8/32"), "{upgrade}");
+}
+
+#[test]
+fn preserved_credential_contradiction_fails_after_the_values_read() {
+    let fixture =
+        Fixture::new(r#"{"agentSandbox":{"runner":{"credentials":"sk-or-v1-PLACEHOLDER"}}}"#);
+    let output = fixture.run(
+        &[],
+        "not resolver JSON",
+        &["--allow-egress-host", "anthropic"],
+    );
+    let shown = all_output(&output);
+
+    assert_eq!(output.status.code(), Some(2), "{shown}");
+    assert!(shown.contains("openrouter"), "{shown}");
+    assert!(shown.contains("--allow-egress-host anthropic"), "{shown}");
+    assert!(
+        !shown.contains("resolver JSON"),
+        "the resolver ran: {shown}"
+    );
+    assert!(
+        !shown.contains(OPENROUTER_CREDENTIAL),
+        "credential leaked: {shown}"
+    );
+    assert!(
+        fixture.helm_log().contains("get values"),
+        "the preserved credential must come from the live values read: {}",
+        fixture.helm_log()
+    );
+    assert_eq!(
+        fixture.upgrade_count(),
+        0,
+        "the contradiction must stop before installation"
+    );
 }
 
 #[test]

--- a/cli/tests/cluster_up_inference.rs
+++ b/cli/tests/cluster_up_inference.rs
@@ -1,0 +1,364 @@
+//! Binary contract for facts inferred by `curie cluster up`.
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+const TARGET_RELEASE: &str = "target-release";
+const TARGET_NAMESPACE: &str = "target-namespace";
+const OPENROUTER_CREDENTIAL: &str = "sk-or-v1-PLACEHOLDER";
+const ANTHROPIC_CREDENTIAL: &str = "sk-ant-api03-PLACEHOLDER";
+const AMBIGUOUS_CREDENTIAL: &str = "sk-MOONSHOT-PLACEHOLDER";
+const VALID_RESOLVER: &str = r#"{
+  "openrouter.ai": ["1.1.1.1"],
+  "api.anthropic.com": ["8.8.8.8"],
+  "api.moonshot.ai": ["9.9.9.9"]
+}"#;
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_curie")
+}
+
+fn chart() -> &'static str {
+    concat!(env!("CARGO_MANIFEST_DIR"), "/../charts/curie")
+}
+
+fn write_exec(dir: &Path, name: &str, body: &str) {
+    let path = dir.join(name);
+    fs::write(&path, body).unwrap_or_else(|error| panic!("write {name}: {error}"));
+    let mut permissions = fs::metadata(&path)
+        .unwrap_or_else(|error| panic!("read {name} metadata: {error}"))
+        .permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&path, permissions)
+        .unwrap_or_else(|error| panic!("make {name} executable: {error}"));
+}
+
+struct Fixture {
+    _temp: tempfile::TempDir,
+    bin_dir: PathBuf,
+    helm_log: PathBuf,
+    upgrade_log: PathBuf,
+    existing_values: String,
+}
+
+impl Fixture {
+    fn new(existing_values: &str) -> Self {
+        let temp = tempfile::tempdir().expect("temporary directory");
+        let bin_dir = temp.path().join("bin");
+        fs::create_dir(&bin_dir).expect("create fake binary directory");
+        let helm_log = temp.path().join("helm.log");
+        let upgrade_log = temp.path().join("upgrades.log");
+
+        write_exec(
+            &bin_dir,
+            "helm",
+            r#"#!/bin/sh
+printf '%s\n' "$*" >> "$CURIE_TEST_HELM_LOG"
+
+if [ "$1" = "get" ] && [ "$2" = "values" ]; then
+    if [ -z "$CURIE_TEST_EXISTING_VALUES" ]; then
+        printf '%s\n' 'Error: release: not found' >&2
+        exit 1
+    fi
+    printf '%s\n' "$CURIE_TEST_EXISTING_VALUES"
+    exit 0
+fi
+
+if [ "$1" = "template" ]; then
+    case " $* " in
+        *" --show-only templates/priorityclass.yaml "*|*" --show-only=templates/priorityclass.yaml "*)
+            printf '%s\n' 'Error: could not find template templates/priorityclass.yaml in chart' >&2
+            exit 1
+            ;;
+        *" --show-only templates/preflight-gvisor.yaml "*|*" --show-only=templates/preflight-gvisor.yaml "*)
+            printf '%s\n' 'Error: could not find template templates/preflight-gvisor.yaml in chart' >&2
+            exit 1
+            ;;
+    esac
+    printf 'unexpected helm template invocation: %s\n' "$*" >&2
+    exit 64
+fi
+
+if [ "$1" = "upgrade" ] && [ "$2" = "--install" ]; then
+    printf '%s\n' "$*" >> "$CURIE_TEST_UPGRADE_LOG"
+    exit 0
+fi
+
+printf 'unexpected helm invocation: %s\n' "$*" >&2
+exit 64
+"#,
+        );
+
+        write_exec(
+            &bin_dir,
+            "kubectl",
+            r#"#!/bin/sh
+if [ "$1" = "get" ] && [ "$2" = "namespace" ]; then
+    exit 0
+fi
+
+case " $* " in
+    *" get deployment agent-sandbox-controller "*)
+        case " $* " in
+            *" -n agent-sandbox-system "*) exit 0 ;;
+            *)
+                printf 'controller query was not scoped to agent-sandbox-system: %s\n' "$*" >&2
+                exit 64
+                ;;
+        esac
+        ;;
+esac
+
+printf 'unexpected kubectl invocation: %s\n' "$*" >&2
+exit 64
+"#,
+        );
+
+        Self {
+            _temp: temp,
+            bin_dir,
+            helm_log,
+            upgrade_log,
+            existing_values: existing_values.to_string(),
+        }
+    }
+
+    fn run(
+        &self,
+        credential_environment: &[(&str, &str)],
+        resolver: &str,
+        extra: &[&str],
+    ) -> Output {
+        let mut paths = vec![self.bin_dir.clone()];
+        if let Some(current) = std::env::var_os("PATH") {
+            paths.extend(std::env::split_paths(&current));
+        }
+        let path = std::env::join_paths(paths).expect("join PATH");
+
+        let mut args = vec![
+            "--color",
+            "never",
+            "cluster",
+            "up",
+            "--chart",
+            chart(),
+            "--namespace",
+            TARGET_NAMESPACE,
+            "--release",
+            TARGET_RELEASE,
+            "--dev",
+            "--no-expose",
+        ];
+        args.extend_from_slice(extra);
+
+        let mut command = Command::new(bin());
+        command
+            .args(args)
+            .env("PATH", path)
+            .env("CI", "1")
+            .env("TERM", "dumb")
+            .env("NO_COLOR", "1")
+            .env("CURIE_TEST_HELM_LOG", &self.helm_log)
+            .env("CURIE_TEST_UPGRADE_LOG", &self.upgrade_log)
+            .env("CURIE_TEST_EXISTING_VALUES", &self.existing_values)
+            .env("CURIE_TEST_PROVIDER_EGRESS_JSON", resolver)
+            .env_remove("CURIE_CREDENTIALS")
+            .env_remove("CURIE_MODEL_CREDENTIALS")
+            .env_remove("CURIE_GITHUB_TOKEN")
+            .env_remove("CURIE_MODEL");
+        for (key, value) in credential_environment {
+            command.env(key, value);
+        }
+        command.output().expect("run curie cluster up")
+    }
+
+    fn helm_log(&self) -> String {
+        fs::read_to_string(&self.helm_log).unwrap_or_default()
+    }
+
+    fn upgrade_log(&self) -> String {
+        fs::read_to_string(&self.upgrade_log).unwrap_or_default()
+    }
+
+    fn upgrade_count(&self) -> usize {
+        self.upgrade_log().lines().count()
+    }
+}
+
+fn stderr(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stderr).into_owned()
+}
+
+fn all_output(output: &Output) -> String {
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+fn assert_success(fixture: &Fixture, output: &Output) {
+    assert!(
+        output.status.success(),
+        "cluster up failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        stderr(output)
+    );
+    assert_eq!(fixture.upgrade_count(), 1, "Helm must install exactly once");
+}
+
+fn assert_inference_once(shown: &str, applied_override: &str) {
+    assert_eq!(
+        shown.matches(applied_override).count(),
+        1,
+        "the applied override must be disclosed exactly once: {applied_override}\n{shown}"
+    );
+}
+
+#[test]
+fn recognized_credential_prefixes_infer_provider_egress() {
+    for (credential, provider, cidr) in [
+        (ANTHROPIC_CREDENTIAL, "anthropic", "8.8.8.8/32"),
+        (OPENROUTER_CREDENTIAL, "openrouter", "1.1.1.1/32"),
+    ] {
+        let fixture = Fixture::new("");
+        let output = fixture.run(&[("CURIE_CREDENTIALS", credential)], VALID_RESOLVER, &[]);
+        assert_success(&fixture, &output);
+
+        let shown = stderr(&output);
+        assert_inference_once(&shown, &format!("--allow-egress-host {provider}"));
+        assert!(
+            fixture.upgrade_log().contains(cidr),
+            "the inferred {provider} route must reach Helm"
+        );
+        assert!(
+            !shown.contains("sandbox is sealed"),
+            "inferred provider egress must remove the sealed warning: {shown}"
+        );
+        assert!(
+            !all_output(&output).contains(credential),
+            "credential leaked"
+        );
+    }
+}
+
+#[test]
+fn explicit_provider_list_containing_the_detected_provider_wins_silently() {
+    let fixture = Fixture::new("");
+    let output = fixture.run(
+        &[("CURIE_CREDENTIALS", OPENROUTER_CREDENTIAL)],
+        VALID_RESOLVER,
+        &[
+            "--allow-egress-host",
+            "openrouter",
+            "--allow-egress-host",
+            "anthropic",
+        ],
+    );
+    assert_success(&fixture, &output);
+
+    let shown = stderr(&output);
+    assert!(
+        !shown.contains("--allow-egress-host openrouter"),
+        "an explicit list must not be reported as inferred: {shown}"
+    );
+    let upgrade = fixture.upgrade_log();
+    assert!(upgrade.contains("1.1.1.1/32"), "{upgrade}");
+    assert!(upgrade.contains("8.8.8.8/32"), "{upgrade}");
+}
+
+#[test]
+fn provider_contradiction_fails_before_resolver_or_helm_without_secret_bytes() {
+    let fixture = Fixture::new("");
+    let output = fixture.run(
+        &[("CURIE_CREDENTIALS", OPENROUTER_CREDENTIAL)],
+        "not resolver JSON",
+        &["--allow-egress-host", "anthropic"],
+    );
+    let shown = all_output(&output);
+
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "a detected provider contradiction is a usage error: {shown}"
+    );
+    assert!(shown.contains("openrouter"), "{shown}");
+    assert!(shown.contains("--allow-egress-host anthropic"), "{shown}");
+    assert!(
+        !shown.contains("resolver JSON"),
+        "the resolver ran: {shown}"
+    );
+    assert!(
+        !shown.contains(OPENROUTER_CREDENTIAL),
+        "credential leaked: {shown}"
+    );
+    assert!(
+        fixture.helm_log().is_empty(),
+        "no Helm read or mutation may precede the contradiction: {}",
+        fixture.helm_log()
+    );
+}
+
+#[test]
+fn ambiguous_credentials_stay_sealed_unless_an_explicit_provider_wins() {
+    let sealed = Fixture::new("");
+    let output = sealed.run(
+        &[("CURIE_CREDENTIALS", AMBIGUOUS_CREDENTIAL)],
+        VALID_RESOLVER,
+        &[],
+    );
+    assert_success(&sealed, &output);
+    let shown = stderr(&output);
+    assert!(shown.contains("sandbox is sealed"), "{shown}");
+    assert!(!shown.contains("--allow-egress-host anthropic"), "{shown}");
+    assert!(!shown.contains("--allow-egress-host openrouter"), "{shown}");
+    assert!(!sealed.upgrade_log().contains("allowedEgress"));
+
+    let explicit = Fixture::new("");
+    let output = explicit.run(
+        &[("CURIE_CREDENTIALS", AMBIGUOUS_CREDENTIAL)],
+        VALID_RESOLVER,
+        &["--allow-egress-host", "moonshot"],
+    );
+    assert_success(&explicit, &output);
+    let shown = stderr(&output);
+    assert!(!shown.contains("sandbox is sealed"), "{shown}");
+    assert!(!shown.contains("--allow-egress-host moonshot"), "{shown}");
+    assert!(explicit.upgrade_log().contains("9.9.9.9/32"));
+}
+
+#[test]
+fn inference_uses_the_effective_credential_precedence() {
+    let canonical = Fixture::new("");
+    let output = canonical.run(
+        &[
+            ("CURIE_CREDENTIALS", OPENROUTER_CREDENTIAL),
+            ("CURIE_MODEL_CREDENTIALS", ANTHROPIC_CREDENTIAL),
+        ],
+        VALID_RESOLVER,
+        &[],
+    );
+    assert_success(&canonical, &output);
+    assert!(canonical.upgrade_log().contains("1.1.1.1/32"));
+    assert!(!canonical.upgrade_log().contains("8.8.8.8/32"));
+
+    let final_helm_value = Fixture::new("");
+    let explicit_credential = format!("agentSandbox.runner.credentials={ANTHROPIC_CREDENTIAL}");
+    let output = final_helm_value.run(
+        &[("CURIE_CREDENTIALS", OPENROUTER_CREDENTIAL)],
+        VALID_RESOLVER,
+        &["--set-string", explicit_credential.as_str()],
+    );
+    assert_success(&final_helm_value, &output);
+    assert!(final_helm_value.upgrade_log().contains("8.8.8.8/32"));
+    assert!(!final_helm_value.upgrade_log().contains("1.1.1.1/32"));
+
+    let preserved =
+        Fixture::new(r#"{"agentSandbox":{"runner":{"credentials":"sk-or-v1-PLACEHOLDER"}}}"#);
+    let output = preserved.run(&[], VALID_RESOLVER, &[]);
+    assert_success(&preserved, &output);
+    assert!(preserved.upgrade_log().contains("1.1.1.1/32"));
+    assert_inference_once(&stderr(&output), "--allow-egress-host openrouter");
+}

--- a/cli/tests/cluster_up_inference.rs
+++ b/cli/tests/cluster_up_inference.rs
@@ -233,6 +233,15 @@ fn recognized_credential_prefixes_infer_provider_egress() {
             fixture.upgrade_log().contains(cidr),
             "the inferred {provider} route must reach Helm"
         );
+        let upgrade = fixture.upgrade_log();
+        assert!(
+            upgrade.contains("security.networkPolicy.allowedEgress[0].ports[0].protocol=TCP"),
+            "the inferred {provider} route must use TCP: {upgrade}"
+        );
+        assert!(
+            upgrade.contains("security.networkPolicy.allowedEgress[0].ports[0].port=443"),
+            "the inferred {provider} route must use port 443: {upgrade}"
+        );
         assert!(
             !shown.contains("sandbox is sealed"),
             "inferred provider egress must remove the sealed warning: {shown}"
@@ -266,6 +275,49 @@ fn inferred_provider_refresh_preserves_recorded_web_egress() {
     assert!(
         upgrade.contains("security.networkPolicy.allowedEgress[1].cidr=1.1.1.1/32"),
         "the refreshed provider route must use a noncolliding index: {upgrade}"
+    );
+    assert!(
+        upgrade.contains("security.networkPolicy.allowedEgress[1].ports[0].protocol=TCP"),
+        "the refreshed provider route must use TCP: {upgrade}"
+    );
+    assert!(
+        upgrade.contains("security.networkPolicy.allowedEgress[1].ports[0].port=443"),
+        "the refreshed provider route must use port 443: {upgrade}"
+    );
+    assert_inference_once(&stderr(&output), "--allow-egress-host openrouter");
+}
+
+#[test]
+fn repeated_bare_up_does_not_duplicate_the_recorded_inferred_provider_route() {
+    let fixture = Fixture::new(
+        r#"{
+          "agentSandbox":{"runner":{"credentials":"sk-or-v1-PLACEHOLDER"}},
+          "security":{"networkPolicy":{"allowedEgress":[
+            {"cidr":"1.1.1.1/32","ports":[{"protocol":"TCP","port":443}]},
+            {"cidr":"203.0.113.0/24","ports":[{"protocol":"TCP","port":443}]}
+          ]}}
+        }"#,
+    );
+    let output = fixture.run(&[], VALID_RESOLVER, &[]);
+    assert_success(&fixture, &output);
+
+    let upgrade = fixture.upgrade_log();
+    assert_eq!(
+        upgrade.matches("1.1.1.1/32").count(),
+        1,
+        "the recorded provider route must not accumulate on a bare rerun: {upgrade}"
+    );
+    assert!(
+        upgrade.contains("security.networkPolicy.allowedEgress[0].cidr=1.1.1.1/32"),
+        "the recorded provider route must retain its index: {upgrade}"
+    );
+    assert!(
+        upgrade.contains("security.networkPolicy.allowedEgress[1].cidr=203.0.113.0/24"),
+        "the recorded web route must survive: {upgrade}"
+    );
+    assert!(
+        !upgrade.contains("security.networkPolicy.allowedEgress[2]"),
+        "the repeated run must not append another route: {upgrade}"
     );
     assert_inference_once(&stderr(&output), "--allow-egress-host openrouter");
 }
@@ -314,7 +366,7 @@ fn preserved_credential_contradiction_fails_after_the_values_read() {
         "the resolver ran: {shown}"
     );
     assert!(
-        !shown.contains(OPENROUTER_CREDENTIAL),
+        !shown.contains("sk-or-v1-PLACEHOLDER"),
         "credential leaked: {shown}"
     );
     assert!(

--- a/cli/tests/cluster_up_priorityclass_preflight.rs
+++ b/cli/tests/cluster_up_priorityclass_preflight.rs
@@ -36,6 +36,7 @@ struct Fixture {
     bin_dir: PathBuf,
     upgrade_log: PathBuf,
     query_log: PathBuf,
+    controller_query_log: PathBuf,
 }
 
 impl Fixture {
@@ -45,6 +46,7 @@ impl Fixture {
         fs::create_dir(&bin_dir).expect("create fake binary directory");
         let upgrade_log = temp.path().join("upgrades.log");
         let query_log = temp.path().join("priorityclass-queries.log");
+        let controller_query_log = temp.path().join("controller-queries.log");
 
         write_exec(
             &bin_dir,
@@ -145,6 +147,51 @@ if [ "$1" = "get" ] && [ "$2" = "namespace" ]; then
     exit 0
 fi
 
+case " $* " in
+    *" get deployment agent-sandbox-controller "*)
+        case " $* " in
+            *" -n agent-sandbox-system "*) ;;
+            *)
+                printf 'controller query was not scoped to agent-sandbox-system: %s\n' "$*" >&2
+                exit 64
+                ;;
+        esac
+        printf '%s\n' "$*" >> "$CURIE_TEST_CONTROLLER_QUERY_LOG"
+        case "$CURIE_TEST_CONTROLLER_MODE" in
+            absent)
+                exit 0
+                ;;
+            malformed)
+                printf '%s\n' '{"metadata":'
+                exit 0
+                ;;
+            incomplete)
+                printf '%s\n' '{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"name":"agent-sandbox-controller","labels":{"app.kubernetes.io/managed-by":"Helm"}}}'
+                exit 0
+                ;;
+            failure)
+                printf '%s\n' 'Error from server (Forbidden): deployments.apps "agent-sandbox-controller" is forbidden' >&2
+                exit 1
+                ;;
+            same)
+                owner_release="$CURIE_TEST_TARGET_RELEASE"
+                owner_namespace="$CURIE_TEST_TARGET_NAMESPACE"
+                ;;
+            foreign)
+                owner_release="controller-owner"
+                owner_namespace="controller-owner-namespace"
+                ;;
+            *)
+                printf 'unknown controller response mode: %s\n' "$CURIE_TEST_CONTROLLER_MODE" >&2
+                exit 64
+                ;;
+        esac
+        printf '{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"name":"agent-sandbox-controller","labels":{"app.kubernetes.io/managed-by":"Helm"},"annotations":{"meta.helm.sh/release-name":"%s","meta.helm.sh/release-namespace":"%s"}}}\n' \
+            "$owner_release" "$owner_namespace"
+        exit 0
+        ;;
+esac
+
 if [ "$1" != "get" ] || [ "$2" != "priorityclass" ] || [ -z "$3" ]; then
     printf 'unexpected kubectl invocation: %s\n' "$*" >&2
     exit 64
@@ -223,6 +270,7 @@ exit 0
             bin_dir,
             upgrade_log,
             query_log,
+            controller_query_log,
         }
     }
 
@@ -232,6 +280,7 @@ exit 0
         platform_mode: &str,
         sandbox_name: &str,
         sandbox_mode: &str,
+        controller_mode: &str,
         extra: &[&str],
     ) -> Output {
         let mut paths = vec![self.bin_dir.clone()];
@@ -265,6 +314,11 @@ exit 0
             .env("NO_COLOR", "1")
             .env("CURIE_TEST_UPGRADE_LOG", &self.upgrade_log)
             .env("CURIE_TEST_QUERY_LOG", &self.query_log)
+            .env(
+                "CURIE_TEST_CONTROLLER_QUERY_LOG",
+                &self.controller_query_log,
+            )
+            .env("CURIE_TEST_CONTROLLER_MODE", controller_mode)
             .env("CURIE_TEST_TARGET_RELEASE", TARGET_RELEASE)
             .env("CURIE_TEST_TARGET_NAMESPACE", TARGET_NAMESPACE)
             .env("CURIE_TEST_PLATFORM_NAME", platform_name)
@@ -292,6 +346,17 @@ exit 0
             .lines()
             .map(str::to_string)
             .collect()
+    }
+
+    fn controller_query_count(&self) -> usize {
+        fs::read_to_string(&self.controller_query_log)
+            .unwrap_or_default()
+            .lines()
+            .count()
+    }
+
+    fn upgrade_log(&self) -> String {
+        fs::read_to_string(&self.upgrade_log).unwrap_or_default()
     }
 }
 
@@ -329,6 +394,14 @@ fn assert_upgrade_ran_once(fixture: &Fixture, output: &Output) {
     );
 }
 
+fn assert_inference_once(shown: &str, applied_override: &str) {
+    assert_eq!(
+        shown.matches(applied_override).count(),
+        1,
+        "the applied override must be disclosed exactly once: {applied_override}\n{shown}"
+    );
+}
+
 fn assert_read_recovery_hint(shown: &str, class_name: &str) {
     let lower = shown.to_ascii_lowercase();
     assert!(
@@ -342,13 +415,14 @@ fn assert_read_recovery_hint(shown: &str, class_name: &str) {
 }
 
 #[test]
-fn foreign_owners_for_both_roles_block_with_exact_remediation() {
+fn foreign_owners_for_both_roles_are_reused_with_disclosed_overrides() {
     let fixture = Fixture::new();
     let output = fixture.run(
         "shared-platform",
         "foreign",
         "shared-sandbox",
         "foreign",
+        "absent",
         &[
             "--set",
             "priorityClasses.platform.name=shared-platform",
@@ -356,30 +430,185 @@ fn foreign_owners_for_both_roles_block_with_exact_remediation() {
             "priorityClasses.sandbox.name=shared-sandbox",
         ],
     );
-    let shown = assert_failed_before_upgrade(&fixture, &output);
-
-    for expected in [
-        "shared-platform",
-        "platform-owner",
-        "platform-owner-namespace",
-        "shared-sandbox",
-        "sandbox-owner",
-        "sandbox-owner-namespace",
-        "--set priorityClasses.platform.create=false --set priorityClasses.platform.name=shared-platform",
-        "--set priorityClasses.platform.name=<different-name>",
-        "--set priorityClasses.sandbox.create=false --set priorityClasses.sandbox.name=shared-sandbox",
-        "--set priorityClasses.sandbox.name=<different-name>",
-    ] {
-        assert!(
-            shown.contains(expected),
-            "the aggregate ownership error must contain `{expected}`:\n{shown}"
-        );
-    }
+    assert_upgrade_ran_once(&fixture, &output);
+    let shown = stderr(&output);
+    assert_inference_once(&shown, "--set priorityClasses.platform.create=false");
+    assert_inference_once(&shown, "--set priorityClasses.sandbox.create=false");
+    let upgrade = fixture.upgrade_log();
+    assert!(
+        upgrade.contains("priorityClasses.platform.create=false")
+            && upgrade.contains("priorityClasses.sandbox.create=false"),
+        "the applied reuse values must reach Helm:\n{upgrade}"
+    );
     assert_eq!(
         fixture.queries(),
         ["shared-platform", "shared-sandbox"],
-        "the preflight must aggregate both rendered conflicts before failing"
+        "the preflight must inspect both rendered classes before converging"
     );
+}
+
+#[test]
+fn explicit_priorityclass_creation_contradicting_foreign_ownership_is_rejected() {
+    let fixture = Fixture::new();
+    let output = fixture.run(
+        DEFAULT_PLATFORM,
+        "foreign",
+        DEFAULT_SANDBOX,
+        "absent",
+        "absent",
+        &["--set", "priorityClasses.platform.create=true"],
+    );
+    let shown = stderr(&output);
+
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "an explicit create value that contradicts observed ownership is a usage error\nstdout:\n{}\nstderr:\n{shown}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert_eq!(
+        fixture.upgrade_count(),
+        0,
+        "Helm must not mutate the release"
+    );
+    assert!(shown.contains(DEFAULT_PLATFORM), "{shown}");
+    assert!(
+        shown.contains("priorityClasses.platform.create=true"),
+        "{shown}"
+    );
+    assert!(shown.contains("platform-owner"), "{shown}");
+}
+
+#[test]
+fn foreign_controller_is_reused_with_one_disclosed_override() {
+    let fixture = Fixture::new();
+    let output = fixture.run(
+        DEFAULT_PLATFORM,
+        "absent",
+        DEFAULT_SANDBOX,
+        "absent",
+        "foreign",
+        &[],
+    );
+
+    assert_upgrade_ran_once(&fixture, &output);
+    assert_eq!(fixture.controller_query_count(), 1);
+    let shown = stderr(&output);
+    assert_inference_once(&shown, "--set agentSandbox.controller.deploy=false");
+    assert!(
+        fixture
+            .upgrade_log()
+            .contains("agentSandbox.controller.deploy=false"),
+        "the inferred controller reuse value must reach Helm"
+    );
+}
+
+#[test]
+fn explicit_controller_reuse_wins_without_an_inference_line() {
+    let fixture = Fixture::new();
+    let output = fixture.run(
+        DEFAULT_PLATFORM,
+        "absent",
+        DEFAULT_SANDBOX,
+        "absent",
+        "foreign",
+        &["--set", "agentSandbox.controller.deploy=false"],
+    );
+
+    assert_upgrade_ran_once(&fixture, &output);
+    assert!(
+        !stderr(&output).contains("--set agentSandbox.controller.deploy=false"),
+        "an explicit value must not be reported as an inference"
+    );
+}
+
+#[test]
+fn explicit_controller_creation_contradicting_foreign_ownership_is_rejected() {
+    let fixture = Fixture::new();
+    let output = fixture.run(
+        DEFAULT_PLATFORM,
+        "absent",
+        DEFAULT_SANDBOX,
+        "absent",
+        "foreign",
+        &["--set", "agentSandbox.controller.deploy=true"],
+    );
+    let shown = stderr(&output);
+
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "stdout:\n{}\nstderr:\n{shown}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert_eq!(
+        fixture.upgrade_count(),
+        0,
+        "Helm must not mutate the release"
+    );
+    assert!(shown.contains("agent-sandbox-controller"), "{shown}");
+    assert!(
+        shown.contains("agentSandbox.controller.deploy=true"),
+        "{shown}"
+    );
+    assert!(shown.contains("controller-owner"), "{shown}");
+}
+
+#[test]
+fn absent_and_target_owned_controller_do_not_infer_reuse() {
+    for mode in ["absent", "same"] {
+        let fixture = Fixture::new();
+        let output = fixture.run(
+            DEFAULT_PLATFORM,
+            "absent",
+            DEFAULT_SANDBOX,
+            "absent",
+            mode,
+            &[],
+        );
+
+        assert_upgrade_ran_once(&fixture, &output);
+        assert_eq!(fixture.controller_query_count(), 1, "mode {mode}");
+        assert!(
+            !stderr(&output).contains("agentSandbox.controller.deploy=false"),
+            "mode {mode} must not infer controller reuse"
+        );
+        assert!(
+            !fixture
+                .upgrade_log()
+                .contains("agentSandbox.controller.deploy=false"),
+            "mode {mode} must retain chart controller creation"
+        );
+    }
+}
+
+#[test]
+fn unreadable_or_incomplete_controller_ownership_fails_closed() {
+    for mode in ["malformed", "incomplete", "failure"] {
+        let fixture = Fixture::new();
+        let output = fixture.run(
+            DEFAULT_PLATFORM,
+            "absent",
+            DEFAULT_SANDBOX,
+            "absent",
+            mode,
+            &[],
+        );
+        let shown = assert_failed_before_upgrade(&fixture, &output);
+
+        assert!(
+            shown.contains("agent-sandbox-controller"),
+            "mode {mode}: {shown}"
+        );
+        assert!(
+            shown.to_ascii_lowercase().contains("cluster status"),
+            "mode {mode} needs a named recovery: {shown}"
+        );
+        assert!(
+            !shown.contains("--set agentSandbox.controller.deploy=false"),
+            "mode {mode} must not infer from uncertain ownership: {shown}"
+        );
+    }
 }
 
 #[test]
@@ -389,6 +618,7 @@ fn unmanaged_platform_class_blocks_with_exact_remediation() {
         "shared-platform",
         "unmanaged",
         DEFAULT_SANDBOX,
+        "absent",
         "absent",
         &["--set", "priorityClasses.platform.name=shared-platform"],
     );
@@ -416,6 +646,7 @@ fn helm_labelled_sandbox_class_without_release_annotations_blocks_with_exact_rem
         "absent",
         "shared-sandbox",
         "helm-without-annotations",
+        "absent",
         &["--set", "priorityClasses.sandbox.name=shared-sandbox"],
     );
     let shown = assert_failed_before_upgrade(&fixture, &output);
@@ -442,6 +673,7 @@ fn helm_labelled_platform_class_without_release_namespace_blocks_with_exact_reme
         "helm-without-release-namespace",
         DEFAULT_SANDBOX,
         "absent",
+        "absent",
         &["--set", "priorityClasses.platform.name=shared-platform"],
     );
     let shown = assert_failed_before_upgrade(&fixture, &output);
@@ -463,33 +695,35 @@ fn helm_labelled_platform_class_without_release_namespace_blocks_with_exact_reme
 #[test]
 fn classes_owned_by_the_target_release_and_namespace_proceed() {
     let fixture = Fixture::new();
-    let output = fixture.run(DEFAULT_PLATFORM, "same", DEFAULT_SANDBOX, "same", &[]);
+    let output = fixture.run(
+        DEFAULT_PLATFORM,
+        "same",
+        DEFAULT_SANDBOX,
+        "same",
+        "absent",
+        &[],
+    );
 
     assert_upgrade_ran_once(&fixture, &output);
     assert_eq!(fixture.queries(), [DEFAULT_PLATFORM, DEFAULT_SANDBOX]);
 }
 
 #[test]
-fn same_release_name_in_another_namespace_is_foreign() {
+fn same_release_name_in_another_namespace_is_reused() {
     let fixture = Fixture::new();
     let output = fixture.run(
         DEFAULT_PLATFORM,
         "wrong-namespace",
         DEFAULT_SANDBOX,
         "absent",
+        "absent",
         &[],
     );
-    let shown = assert_failed_before_upgrade(&fixture, &output);
-
-    for expected in [
-        DEFAULT_PLATFORM,
-        TARGET_RELEASE,
-        "another-namespace",
-        "--set priorityClasses.platform.create=false --set priorityClasses.platform.name=curie-platform",
-        "--set priorityClasses.platform.name=<different-name>",
-    ] {
-        assert!(shown.contains(expected), "missing `{expected}`:\n{shown}");
-    }
+    assert_upgrade_ran_once(&fixture, &output);
+    assert_inference_once(
+        &stderr(&output),
+        "--set priorityClasses.platform.create=false",
+    );
 }
 
 #[test]
@@ -499,6 +733,7 @@ fn create_false_skips_the_foreign_class_and_proceeds() {
         DEFAULT_PLATFORM,
         "foreign",
         DEFAULT_SANDBOX,
+        "absent",
         "absent",
         &["--set", "priorityClasses.platform.create=false"],
     );
@@ -519,6 +754,7 @@ fn renamed_class_is_discovered_from_the_rendered_chart() {
         "absent",
         DEFAULT_SANDBOX,
         "absent",
+        "absent",
         &["--set", "priorityClasses.platform.name=renamed-platform"],
     );
 
@@ -533,7 +769,14 @@ fn renamed_class_is_discovered_from_the_rendered_chart() {
 #[test]
 fn absent_classes_proceed() {
     let fixture = Fixture::new();
-    let output = fixture.run(DEFAULT_PLATFORM, "absent", DEFAULT_SANDBOX, "absent", &[]);
+    let output = fixture.run(
+        DEFAULT_PLATFORM,
+        "absent",
+        DEFAULT_SANDBOX,
+        "absent",
+        "absent",
+        &[],
+    );
 
     assert_upgrade_ran_once(&fixture, &output);
     assert_eq!(fixture.queries(), [DEFAULT_PLATFORM, DEFAULT_SANDBOX]);
@@ -542,7 +785,14 @@ fn absent_classes_proceed() {
 #[test]
 fn kubectl_failure_blocks_with_a_recovery_hint() {
     let fixture = Fixture::new();
-    let output = fixture.run(DEFAULT_PLATFORM, "failure", DEFAULT_SANDBOX, "absent", &[]);
+    let output = fixture.run(
+        DEFAULT_PLATFORM,
+        "failure",
+        DEFAULT_SANDBOX,
+        "absent",
+        "absent",
+        &[],
+    );
     let shown = assert_failed_before_upgrade(&fixture, &output);
 
     assert!(
@@ -559,6 +809,7 @@ fn priorityclass_read_failure_json_fix_uses_cluster_status() {
         DEFAULT_PLATFORM,
         "failure",
         DEFAULT_SANDBOX,
+        "absent",
         "absent",
         &["--json"],
     );
@@ -597,6 +848,7 @@ fn malformed_successful_json_blocks_with_a_recovery_hint() {
         DEFAULT_PLATFORM,
         "malformed",
         DEFAULT_SANDBOX,
+        "absent",
         "absent",
         &[],
     );

--- a/cli/tests/guide.rs
+++ b/cli/tests/guide.rs
@@ -180,24 +180,35 @@ fn guide_json_emits_pure_structured_data_on_stdout() {
 }
 
 #[test]
-fn guide_documents_gvisor_fail_closed_opt_out() {
-    // AC (#363): a real-model `cluster up` on a no-runsc cluster fails closed under
-    // the default gVisor mode; the opt-out and its preflight symptom must both be
-    // discoverable in the primer -- in the Markdown default and the --json variant.
+fn guide_documents_cluster_up_gvisor_inference_and_fail_closed_contradictions() {
+    // AC (#1662, ADR 0114): a real-model `cluster up` may infer gVisor off only
+    // from the exact admission symptom, retry once, and keep every other failure
+    // closed. Explicit auto or require modes contradict that detected result.
     let md = out_str(&run(&["guide"]));
     let json = out_str(&run(&["guide", "--json"]));
     for (label, text) in [("markdown", &md), ("json", &json)] {
         assert!(
             text.contains("security.gvisor.mode=off"),
-            "{label} primer missing the gVisor opt-out `security.gvisor.mode=off`\n{text}"
+            "{label} primer missing the inferred override `security.gvisor.mode=off`\n{text}"
         );
         assert!(
-            text.contains("curie-preflight-gvisor"),
-            "{label} primer missing the preflight symptom `curie-preflight-gvisor`\n{text}"
+            text.contains("curie-preflight-gvisor")
+                && text.contains("RuntimeClass gvisor is not found"),
+            "{label} primer missing the exact admission symptom\n{text}"
         );
         assert!(
-            text.contains("running runner pods on the host kernel"),
-            "{label} primer missing the Landmine detail `running runner pods on the host kernel`\n{text}"
+            text.contains("retries once"),
+            "{label} primer missing the one retry limit\n{text}"
+        );
+        assert!(
+            text.contains("Other failures remain closed"),
+            "{label} primer missing the fail closed behavior for other failures\n{text}"
+        );
+        assert!(
+            text.contains(
+                "Explicit auto or require modes contradict the detected result and are errors"
+            ),
+            "{label} primer missing the explicit mode contradiction error\n{text}"
         );
     }
 }

--- a/cli/tests/installation_plan_parity.rs
+++ b/cli/tests/installation_plan_parity.rs
@@ -361,6 +361,12 @@ persist_source() {{
     cat "$migration_source"
 }}
 case "$verb $object" in
+'get deployment')
+    case "$all" in
+        'get deployment agent-sandbox-controller -n agent-sandbox-system --ignore-not-found -o json') : ;;
+        *) unexpected ;;
+    esac
+    ;;
 'get priorityclass')
     # Empty stdout with exit 0 is kubectl --ignore-not-found for an absent class.
     :

--- a/cli/tests/model_provider_registry.rs
+++ b/cli/tests/model_provider_registry.rs
@@ -12,6 +12,7 @@ use serde::Deserialize;
 struct ProviderRow {
     name: String,
     base_url: Option<String>,
+    inferred_provider: Option<String>,
     egress_hosts: Vec<String>,
     credential_examples: Vec<String>,
 }
@@ -84,6 +85,13 @@ fn every_supported_provider_passes_credential_and_egress_checks() {
                     provider.name
                 )
             });
+        }
+
+        if let Some(inferred) = &provider.inferred_provider {
+            assert_eq!(
+                inferred, &provider.name,
+                "an inferred credential prefix must select its registry provider"
+            );
         }
 
         assert_eq!(

--- a/cli/tests/model_provider_registry.rs
+++ b/cli/tests/model_provider_registry.rs
@@ -88,10 +88,10 @@ fn every_supported_provider_passes_credential_and_egress_checks() {
         }
 
         if let Some(inferred) = &provider.inferred_provider {
-            assert!(
-                names.contains(inferred.as_str()),
-                "{} points to unknown inferred provider {inferred}",
-                provider.name
+            assert_eq!(
+                inferred, &provider.name,
+                "{} must infer its own provider name",
+                provider.name,
             );
         }
 

--- a/cli/tests/model_provider_registry.rs
+++ b/cli/tests/model_provider_registry.rs
@@ -88,9 +88,10 @@ fn every_supported_provider_passes_credential_and_egress_checks() {
         }
 
         if let Some(inferred) = &provider.inferred_provider {
-            assert_eq!(
-                inferred, &provider.name,
-                "an inferred credential prefix must select its registry provider"
+            assert!(
+                names.contains(inferred.as_str()),
+                "{} points to unknown inferred provider {inferred}",
+                provider.name
             );
         }
 

--- a/docs/adr/0006-security-rails-as-chart-defaults.md
+++ b/docs/adr/0006-security-rails-as-chart-defaults.md
@@ -3,6 +3,11 @@
 Date: 2026-07-04
 Status: Accepted
 
+**Superseded in part by [ADR 0114](0114-cluster-up-infers-detected-install-facts.md).**
+The gVisor item in the Decision and the final Consequences clause no longer
+require `curie cluster up` to fail when admission reports exactly that the
+`gvisor` RuntimeClass is absent. Every other security rail remains unchanged.
+
 ## Context
 
 The input channel (Slack) is prompt-injectable by anyone in the channel, and the runner holds customer credentials. An enterprise leave-behind will be security-reviewed. Retrofitting isolation costs more than defaulting it, and a boundary that is *believed* to hold but doesn't (e.g. an egress policy on a non-enforcing CNI) ships an incident. So the security posture had to be proven, not assumed.

--- a/docs/adr/0006-security-rails-as-chart-defaults.md
+++ b/docs/adr/0006-security-rails-as-chart-defaults.md
@@ -4,9 +4,10 @@ Date: 2026-07-04
 Status: Accepted
 
 **Superseded in part by [ADR 0114](0114-cluster-up-infers-detected-install-facts.md).**
-The gVisor item in the Decision and the final Consequences clause no longer
-require `curie cluster up` to fail when admission reports exactly that the
-`gvisor` RuntimeClass is absent. Every other security rail remains unchanged.
+The final Consequences clause no longer requires gVisor absence to fail review
+when `curie cluster up` receives the exact admission rejection that the
+`gvisor` RuntimeClass is absent. The Decision still keeps gVisor enabled by
+default, and every other security rail remains unchanged.
 
 ## Context
 

--- a/docs/adr/0032-explicit-provider-egress.md
+++ b/docs/adr/0032-explicit-provider-egress.md
@@ -3,6 +3,11 @@
 Date: 2026-07-13
 Status: Accepted
 
+**Superseded in part by [ADR 0114](0114-cluster-up-infers-detected-install-facts.md).**
+The first Decision clause and rejected Alternative 1 no longer require an
+explicit provider when the effective credential prefix selects one provider.
+Every other egress rule remains unchanged.
+
 Implements [#362](https://github.com/curie-eng/curie/issues/362).
 
 ## Context

--- a/docs/adr/0114-cluster-up-infers-detected-install-facts.md
+++ b/docs/adr/0114-cluster-up-infers-detected-install-facts.md
@@ -13,10 +13,10 @@ exactly these clauses:
    reachable.
 2. ADR 0032 rejected Alternative 1, which rejects provider detection from a
    credential prefix.
-3. The ADR 0006 Decision item that makes gVisor a default security rail, and
-   the final Consequences clause that says the absence of every listed rail
-   fails review, only when `curie cluster up` observes the exact admission
-   rejection `RuntimeClass "gvisor" not found`.
+3. The ADR 0006 final Consequences clause that says the absence of every listed
+   rail fails review, only as it applies to gVisor when `curie cluster up`
+   observes the exact admission rejection `RuntimeClass "gvisor" not found`.
+   The ADR 0006 Decision that keeps gVisor enabled by default remains unchanged.
 
 Every other ADR 0032 egress rule and ADR 0006 security rail remains unchanged.
 

--- a/docs/adr/0114-cluster-up-infers-detected-install-facts.md
+++ b/docs/adr/0114-cluster-up-infers-detected-install-facts.md
@@ -1,0 +1,132 @@
+# 114. Cluster up infers detected install facts
+
+Date: 2026-08-20
+
+Status: Accepted
+
+**Supersedes in part [ADR 0032](0032-explicit-provider-egress.md) and
+[ADR 0006](0006-security-rails-as-chart-defaults.md).** This ADR replaces
+exactly these clauses:
+
+1. ADR 0032 Decision clause 1, which says that a model credential alone opens
+   no egress and requires an explicit provider choice before the model is
+   reachable.
+2. ADR 0032 rejected Alternative 1, which rejects provider detection from a
+   credential prefix.
+3. The ADR 0006 Decision item that makes gVisor a default security rail, and
+   the final Consequences clause that says the absence of every listed rail
+   fails review, only when `curie cluster up` observes the exact admission
+   rejection `RuntimeClass "gvisor" not found`.
+
+Every other ADR 0032 egress rule and ADR 0006 security rail remains unchanged.
+
+This ADR is Accepted alongside its implementation under
+[ADR 0102](0102-accepted-alongside-implementation-with-explicit-approval.md).
+Explicit maintainer approval is recorded in [issue
+#1662](https://github.com/curie-eng/curie/issues/1662) on 2026-08-20. The
+realizing code path is `cli/src/ops.rs::up`, including its provider, singleton,
+and gVisor reconciliation in `cli/src/ops.rs`.
+
+## Context
+
+On a reachable stock cluster, a successful install required five explicit
+overrides even though Curie already had direct evidence for every value. The
+effective credential selected the runtime provider. Existing singleton objects
+recorded their Helm owner. Kubernetes admission reported that the requested
+RuntimeClass did not exist.
+
+The explicit provider flag also created an unsafe split. An OpenRouter
+credential combined with `--allow-egress-host anthropic` installed
+successfully, opened the Anthropic host, and left the runner dialing
+OpenRouter. A green install therefore produced a model route that NetworkPolicy
+blocked.
+
+Requiring a human to copy facts already held by the credential and the cluster
+does not add a security decision. It adds opportunities for contradiction and
+turns ordinary cluster discovery into a sequence of failed installs.
+
+## Decision
+
+### 1. Infer provider egress from an unambiguous effective credential
+
+Direct `curie cluster up` reads the effective credential after existing release
+values have been reconciled. When no provider flag is present, an `sk-ant-`
+prefix applies `--allow-egress-host anthropic` and an `sk-or-` prefix applies
+`--allow-egress-host openrouter`.
+
+Other credential shapes do not identify one provider and therefore infer
+nothing. They remain sealed unless the operator supplies provider or web
+egress. This decision does not expand the provider registry.
+
+An explicit provider list wins only when it includes the detected provider. A
+list that omits the detected provider is a usage error. A list that includes it
+may include additional providers and is used unchanged.
+
+### 2. Infer reuse from complete Helm ownership
+
+Direct `curie cluster up` inspects both rendered PriorityClasses and the
+`agent-sandbox-controller` Deployment. An existing singleton is reusable only
+when its metadata states `app.kubernetes.io/managed-by=Helm` and carries both
+`meta.helm.sh/release-name` and `meta.helm.sh/release-namespace`.
+
+When complete metadata names another release, Curie applies the matching
+`priorityClasses.platform.create=false`,
+`priorityClasses.sandbox.create=false`, or
+`agentSandbox.controller.deploy=false` value. An explicit creation value that
+contradicts the observed owner is a usage error. Other explicit values remain
+authoritative.
+
+Missing, malformed, unreadable, or incomplete ownership evidence does not
+authorize reuse. Curie fails closed and reports the conflicting object.
+
+### 3. Infer gVisor off from the exact admission result
+
+Direct `curie cluster up` first installs with the chart default intact. If the
+gVisor preflight pod receives the exact admission rejection `RuntimeClass
+"gvisor" not found`, the cluster has supplied the authoritative fact that it
+cannot run that pod with gVisor. Curie then applies
+`security.gvisor.mode=off`, prints the inference, and retries the same install
+once.
+
+This is the right posture because admission is the enforcement point. It proves
+that this cluster cannot satisfy the requested RuntimeClass, while a copied
+flag adds no further knowledge or consent. Applying the detected posture makes
+the reduced isolation explicit and lets a reachable stock cluster install.
+
+The waiver is narrow. An explicit `security.gvisor.mode=auto` or
+`security.gvisor.mode=require` contradicts the admission fact and is a usage
+error. Any other rejection, an unavailable event watch, or unreadable evidence
+still fails closed. Curie does not retry more than once.
+
+### 4. Make every inference visible
+
+Curie prints one line to standard error for each applied inference, naming the
+equivalent override. Structured output remains one object on standard output.
+Prepared apply and diff paths do not infer cluster facts.
+
+## Consequences
+
+1. A bare `curie cluster up` succeeds in the stock cluster case from issue
+   #1662 without requiring the operator to transcribe five discovered facts.
+2. Provider egress cannot silently disagree with an unambiguous bound
+   credential.
+3. A cluster without gVisor runs with less kernel isolation after the exact
+   admission result. The inference line makes that posture visible.
+4. Ambiguous credentials, incomplete ownership, unreadable cluster state, and
+   nonmatching admission failures retain fail closed behavior.
+5. Provider discovery remains limited to prefixes whose runtime routing is
+   unambiguous. Adding more providers remains separate work.
+
+## Alternatives considered
+
+1. **Keep all five overrides explicit.** Rejected because the operator would be
+   copying detected facts, and a wrong provider value can produce a successful
+   but unusable install.
+2. **Disable gVisor before admission on clusters that appear not to support
+   it.** Rejected because an inventory guess is weaker than the result from the
+   enforcement point.
+3. **Disable gVisor after any Helm failure.** Rejected because unrelated or
+   unreadable failures provide no fact that authorizes a security posture
+   change.
+4. **Reuse any existing singleton by name.** Rejected because a name alone does
+   not prove Helm ownership. Only complete ownership metadata authorizes reuse.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -142,4 +142,5 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0110 | [Deterministic security posture classification distinguishes manifest declarations from operator gates](0110-deterministic-security-posture-classification.md) | Draft |
 | 0111 | [The default memory compaction algorithm](0111-the-default-memory-compaction-algorithm.md) | Draft |
 | 0113 | [Bundles declare connector build inputs and tiers deliver pinned images](0113-bundles-declare-connector-build-inputs-and-tiers-deliver-pinned-images.md) | Accepted |
+| 0114 | [Cluster up infers detected install facts](0114-cluster-up-infers-detected-install-facts.md) | Accepted |
 <!-- END GENERATED: adr-index -->

--- a/docs/interfaces/model-provider/INTERFACE.md
+++ b/docs/interfaces/model-provider/INTERFACE.md
@@ -119,13 +119,15 @@ committed shared vector in `tests/vectors/model-provider-registry.json` pins the
 contract by projecting runner base URLs into CLI credential shapes and exact egress
 hosts for Anthropic, OpenRouter, Zhipu, Moonshot, and DeepSeek.
 
-- **Credential validation is not egress authorization.** A recognized credential
-  shape can be saved without selecting a provider or opening a route. The sandbox
-  remains sealed until `--allow-egress-host` names one of the five lowercase exact
-  providers, or the operator explicitly supplies `--allow-web-egress`. Unknown,
-  mixed case, URL, and host literal provider names remain usage errors. Local Ollama
-  has no named remote egress entry.
-- **Two mirrors of the non-forwardable-credential rule.** The runner is the authority
+1. **Credential validation and egress authorization remain distinct.** The
+  unambiguous `sk-ant-` and `sk-or-` prefixes let direct `cluster up` infer one
+  named provider route when no provider flag is present. Other recognized
+  credential shapes can be saved without selecting a provider or opening a
+  route. An explicit provider list that omits the provider selected by either
+  unambiguous prefix is a usage error. Unknown, mixed case, URL, and host literal
+  provider names remain usage errors. Local Ollama has no named remote egress
+  entry.
+2. **Two mirrors of the non-forwardable-credential rule.** The runner is the authority
   for the `sk-ant-oat` prefix
   (`runner/src/curie_runner/sdk_auth.py::OAUTH_TOKEN_PREFIX`), and it is already
   declared per harness rather than hardcoded

--- a/docs/interfaces/model-provider/INTERFACE.md
+++ b/docs/interfaces/model-provider/INTERFACE.md
@@ -119,7 +119,7 @@ committed shared vector in `tests/vectors/model-provider-registry.json` pins the
 contract by projecting runner base URLs into CLI credential shapes and exact egress
 hosts for Anthropic, OpenRouter, Zhipu, Moonshot, and DeepSeek.
 
-1. **Credential validation and egress authorization remain distinct.** The
+- **Credential validation and egress authorization remain distinct.** The
   unambiguous `sk-ant-` and `sk-or-` prefixes let direct `cluster up` infer one
   named provider route when no provider flag is present. Other recognized
   credential shapes can be saved without selecting a provider or opening a
@@ -127,7 +127,7 @@ hosts for Anthropic, OpenRouter, Zhipu, Moonshot, and DeepSeek.
   unambiguous prefix is a usage error. Unknown, mixed case, URL, and host literal
   provider names remain usage errors. Local Ollama has no named remote egress
   entry.
-2. **Two mirrors of the non-forwardable-credential rule.** The runner is the authority
+- **Two mirrors of the non-forwardable-credential rule.** The runner is the authority
   for the `sk-ant-oat` prefix
   (`runner/src/curie_runner/sdk_auth.py::OAUTH_TOKEN_PREFIX`), and it is already
   declared per harness rather than hardcoded

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -18,7 +18,7 @@ Targets, see the target comparison table in the
 |---|---|
 | `kubectl` and `helm` on PATH | Every `cluster` verb wraps one or both of them. |
 | A reachable cluster | Every verb talks to the cluster's Kubernetes API server directly -- there's nothing to install onto or inspect without one. The chart's own preflights additionally need the `agents.x-k8s.io` Agent Sandbox CRDs (Custom Resource Definitions) installable and a NetworkPolicy-enforcing CNI (Container Network Interface) already present; see `charts/curie/README.md`. |
-| `runsc` (gVisor) on every node -- **real models only** | Real-model installs refuse to start without it, as a safety measure against running a live model in a less-isolated sandbox. Skip the check with `--set security.gvisor.mode=off` if your cluster doesn't have it. Fake-model installs don't need it. |
+| `runsc` (gVisor) on every node for full kernel isolation | A real model first installs with gVisor enabled. If admission reports exactly that the `gvisor` RuntimeClass is absent, plain `cluster up` applies `security.gvisor.mode=off` and retries once. Other preflight failures remain closed. Fake model installs do not need it. |
 
 **For testing**, pick between **k3s**, **kind**, and **minikube** based on
 your host and how disposable the cluster needs to be. A single-node **k3s**
@@ -104,11 +104,11 @@ curie cluster up
 | `-f <compose>` | Override a resolved local-dev artifact path. |
 | `--image <ref>` | Override a resolved image reference. |
 | `--no-expose` | Keep the UI and Langfuse ClusterIP-only instead of exposing them on node ports. |
-| `CURIE_CREDENTIALS` (alias `CURIE_MODEL_CREDENTIALS`) | A real model credential. The interactive check accepts Anthropic `sk-ant-`, OpenRouter `sk-or-`, Zhipu `id.secret`, and bare `sk-` shapes for Moonshot or DeepSeek. It checks only shape, not provider identity or liveness. Present credentials install live through masked `--set` machinery, so `--dry-run` never prints them. An absent credential uses fake mode on a fresh install and preserves the recorded model configuration on a rerun. |
+| `CURIE_CREDENTIALS` (alias `CURIE_MODEL_CREDENTIALS`) | A real model credential. The interactive check accepts Anthropic `sk-ant-`, OpenRouter `sk-or-`, Zhipu `id.secret`, and bare `sk-` shapes for Moonshot or DeepSeek. The first two prefixes select one provider and infer its egress when no provider flag is present. Other shapes do not identify a provider. Present credentials install live through masked `--set` machinery, so `--dry-run` never prints them. An absent credential uses fake mode on a fresh install and preserves the recorded model configuration on a rerun. |
 | `--fake-model` | Explicitly downgrade to fake mode, even when a credential is present or a rerun has recorded live model configuration. |
 | `--github-token <token>` (or `CURIE_GITHUB_TOKEN`) | The Curie API's own GitHub credential, for cloning a PRIVATE repo during a git-flow bundle deploy and for posting the eval commit status. Goes to helm through a private mode-0600 values file, never a command-line argument, so it never appears in the helm command, the printed plan, or that plan's JSON. Prefer the environment variable: a token typed after the flag still sits in `curie`'s own argv, so it still reaches your shell history and `ps`. Omitting both on a later `cluster up` preserves whatever the release already has. Errors if combined with `--set api.githubToken=`. |
 | `--clear-github-token` | Remove the stored GitHub credential. Not a revocation: the running API keeps the old token until its pod restarts (`cluster up` prints the restart command), and the token itself stays valid at GitHub until you revoke it there. |
-| `--allow-egress-host <provider>` (repeatable) | Open runner egress on TCP 443 to one named model provider: `anthropic`, `openrouter`, `zhipu`, `moonshot`, or `deepseek`. Names are lowercase exact; any other provider name is rejected. |
+| `--allow-egress-host <provider>` (repeatable) | Explicitly open runner egress on TCP 443 to one named model provider: `anthropic`, `openrouter`, `zhipu`, `moonshot`, or `deepseek`. Names are lowercase exact. An explicit list must include the provider detected from an `sk-ant-` or `sk-or-` credential. |
 | `--allow-web-egress <CIDR>` (repeatable) | Open runner egress on TCP 443 to an arbitrary CIDR (Classless Inter-Domain Routing block) -- for skill/tool web access, or a provider not covered above. |
 
 A downloaded release binary needs no repo checkout; the chart resolves from
@@ -119,14 +119,16 @@ their matching documented `CURIE_MODEL_BASE_URL` in worker runtime configuration
 as well as a credential and their named egress entry. Their credential shapes do
 not identify the provider: the base URL selects it.
 
-**Egress is sealed by default.** A model credential alone opens no egress:
-the sandbox stays fail-closed until you open its provider egress with one of
-the two flags above. Neither flag bakes provider IPs into the binary --
-only hostnames are resolved (to narrow `/32`+`/128` host routes) at install
-time, because provider/CDN IPs rotate; re-run `up` to re-resolve if calls
-start failing. Credential shape validation does not select a provider or open a
-route. The named provider allowlist admits only the five documented lowercase
-names above; unknown names stay denied. `--allow-web-egress` is for agents whose
+**Ambiguous egress stays sealed.** An effective credential beginning `sk-ant-`
+or `sk-or-` selects Anthropic or OpenRouter and plain `cluster up` infers the
+matching named egress. Other credential shapes do not identify one provider,
+so the sandbox stays fail closed until the operator opens its provider or web
+egress. An explicit provider list that omits a detected provider is a usage
+error. Neither flag bakes provider IPs into the binary. Only hostnames are
+resolved to narrow `/32` and `/128` host routes at install time because
+provider and CDN IPs rotate. Re-run `up` to resolve them again if calls start
+failing. The named provider allowlist admits only the five documented lowercase
+names above. Unknown names stay denied. `--allow-web-egress` is for agents whose
 skills need open web access, such as search or weather lookup, beyond the named
 model providers. `curie cluster up --allow-web-egress 0.0.0.0/0` opens the
 internet except `169.254.169.254`; narrow the CIDR to a specific destination for
@@ -138,6 +140,22 @@ You don't need to worry about ordering when using the CLI flags together --
 `cluster up` composes `--allow-egress-host` and `--allow-web-egress` into
 one list automatically, with named-provider entries first and web-egress
 CIDRs after.
+
+**Cluster facts are inferred only when they are complete.** Direct
+`curie cluster up` inspects the two PriorityClasses and the
+`agent-sandbox-controller` Deployment. When complete Helm ownership metadata
+names another release, Curie applies the matching creation or deployment value
+as false. Missing, malformed, unreadable, or incomplete ownership does not
+authorize reuse and blocks the install. An explicit true value that contradicts
+the detected owner is a usage error.
+
+The first gVisor preflight keeps the chart default. Only the exact admission
+result `RuntimeClass "gvisor" not found` authorizes
+`security.gvisor.mode=off` and one retry. An explicit `auto` or `require` mode
+contradicts that result and errors. Other admission failures and an unavailable
+event watch remain closed. Curie prints one standard error line for every
+inference, including the equivalent override. Prepared `apply` and `diff`
+paths do not infer live cluster facts.
 
 ### `curie cluster status`
 
@@ -475,8 +493,9 @@ next operator.
   agent-sandbox CRDs, but the vendored controller is gated behind
   `agentSandbox.controller.deploy`. A cluster that has the CRDs but no
   controller silently never binds claims, so a first install must set
-  `agentSandbox.controller.deploy=true` unless the cluster already runs the
-  controller.
+  `agentSandbox.controller.deploy=true`. Plain `cluster up` preserves that
+  default when the controller is absent and infers false only when the existing
+  Deployment has complete Helm ownership metadata.
 - **gVisor stays off without runsc on the node.** Use the
   `values-e2e-nogvisor` overlay on nodes without `runsc`. All other
   security rails were verified ON in the first fresh-cluster install:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -489,13 +489,13 @@ and the rollback re-attaches it with the data intact. Keep the export anyway.
 Notes from the first installs of the chart on fresh clusters, kept for the
 next operator.
 
-- **The agent-sandbox controller is opt-in.** The chart ships the
-  agent-sandbox CRDs, but the vendored controller is gated behind
-  `agentSandbox.controller.deploy`. A cluster that has the CRDs but no
-  controller silently never binds claims, so a first install must set
-  `agentSandbox.controller.deploy=true`. Plain `cluster up` preserves that
-  default when the controller is absent and infers false only when the existing
-  Deployment has complete Helm ownership metadata.
+- **The agent-sandbox controller is enabled by default.** The chart ships the
+  agent-sandbox CRDs and deploys the vendored controller when
+  `agentSandbox.controller.deploy=true`, which is the default. A cluster that
+  has the CRDs but no controller silently never binds claims. Plain `cluster
+  up` keeps the default when the controller is absent and infers
+  `agentSandbox.controller.deploy=false` only when an existing Deployment has
+  complete Helm ownership metadata for another release.
 - **gVisor stays off without runsc on the node.** Use the
   `values-e2e-nogvisor` overlay on nodes without `runsc`. All other
   security rails were verified ON in the first fresh-cluster install:

--- a/docs/your-first-slack-agent.md
+++ b/docs/your-first-slack-agent.md
@@ -63,9 +63,7 @@ channel → *View channel details*, it's at the bottom and looks like `C0…`.
 ## 3. Put it on the cluster (10 min)
 
 ```bash
-curie cluster up --namespace my-agent --release my-agent \
-  --set agentSandbox.runner.credentials="$CURIE_CREDENTIALS" \
-  --allow-egress-host anthropic
+curie cluster up --namespace my-agent --release my-agent
 
 curie cluster comms --slack --namespace my-agent --release my-agent \
   --app-token "$SLACK_APP_TOKEN" --bot-token "$SLACK_BOT_TOKEN"
@@ -73,6 +71,13 @@ curie cluster comms --slack --namespace my-agent --release my-agent \
 curie cluster deploy --plugin-dir . --namespace my-agent --release my-agent \
   --repo <owner>/<repo> --slack-channel C0YOURCHANNEL
 ```
+
+The plain install reads the exported `sk-ant-` credential and infers Anthropic
+egress. If admission reports that the cluster has no `gvisor` RuntimeClass,
+Curie applies `security.gvisor.mode=off` and retries once. It also reuses
+PriorityClasses and the sandbox controller when their complete Helm ownership
+metadata names an existing release. Every applied inference is printed with
+its equivalent override.
 
 `@mention` the bot in that channel. That's the whole thing.
 

--- a/runner/tests/test_sdk_auth.py
+++ b/runner/tests/test_sdk_auth.py
@@ -55,13 +55,20 @@ _PROVIDER_REGISTRY_KEYS = frozenset(
     {"providers", "unknown_provider_names", "rejected_credential_examples"}
 )
 _PROVIDER_ROW_KEYS = frozenset(
-    {"name", "base_url", "egress_hosts", "credential_examples"}
+    {
+        "name",
+        "base_url",
+        "inferred_provider",
+        "egress_hosts",
+        "credential_examples",
+    }
 )
 
 
 class _ProviderRow(TypedDict):
     name: str
     base_url: str | None
+    inferred_provider: str | None
     egress_hosts: list[str]
     credential_examples: list[str]
 
@@ -87,6 +94,9 @@ def _load_provider_registry(raw: str | None = None) -> _ProviderRegistryDocument
         assert set(provider) == _PROVIDER_ROW_KEYS
         assert isinstance(provider["name"], str)
         assert provider["base_url"] is None or isinstance(provider["base_url"], str)
+        assert provider["inferred_provider"] is None or isinstance(
+            provider["inferred_provider"], str
+        )
         assert isinstance(provider["egress_hosts"], list)
         assert provider["egress_hosts"]
         assert all(isinstance(host, str) and host for host in provider["egress_hosts"])
@@ -287,6 +297,30 @@ def test_provider_registry_matches_runner_authority() -> None:
 
     assert not set(registry["unknown_provider_names"]) & set(by_name)
 
+
+def test_provider_registry_inferred_prefixes_match_runtime_routing() -> None:
+    registry = _load_provider_registry()
+
+    for provider in registry["providers"]:
+        for credential in provider["credential_examples"]:
+            env = {CREDENTIALS_ENV: credential}
+            try:
+                resolve_model_credential(env)
+            except UnsupportedCredentialError:
+                routed_provider = None
+            else:
+                if env.get(BASE_URL_ENV) == OPENROUTER_BASE_URL:
+                    routed_provider = "openrouter"
+                elif credential.startswith("sk-ant-"):
+                    routed_provider = "anthropic"
+                else:
+                    routed_provider = None
+
+            assert routed_provider == provider["inferred_provider"], (
+                provider["name"],
+                credential,
+                routed_provider,
+            )
 
 @pytest.mark.parametrize(
     "base_url",

--- a/tests/vectors/model-provider-registry.json
+++ b/tests/vectors/model-provider-registry.json
@@ -3,6 +3,7 @@
     {
       "name": "anthropic",
       "base_url": null,
+      "inferred_provider": "anthropic",
       "egress_hosts": ["api.anthropic.com"],
       "credential_examples": [
         "sk-ant-api03-PLACEHOLDER",
@@ -12,24 +13,28 @@
     {
       "name": "openrouter",
       "base_url": "https://openrouter.ai/api",
+      "inferred_provider": "openrouter",
       "egress_hosts": ["openrouter.ai"],
       "credential_examples": ["sk-or-v1-PLACEHOLDER"]
     },
     {
       "name": "zhipu",
       "base_url": "https://api.z.ai/api/anthropic",
+      "inferred_provider": null,
       "egress_hosts": ["api.z.ai"],
       "credential_examples": ["zhipu-id.PLACEHOLDER"]
     },
     {
       "name": "moonshot",
       "base_url": "https://api.moonshot.ai/anthropic",
+      "inferred_provider": null,
       "egress_hosts": ["api.moonshot.ai"],
       "credential_examples": ["sk-MOONSHOT-PLACEHOLDER"]
     },
     {
       "name": "deepseek",
       "base_url": "https://api.deepseek.com/anthropic",
+      "inferred_provider": null,
       "egress_hosts": ["api.deepseek.com"],
       "credential_examples": ["sk-DEEPSEEK-PLACEHOLDER"]
     }


### PR DESCRIPTION
Closes #1662

Summary

Makes direct `curie cluster up` infer provider egress from an unambiguous bound credential, singleton reuse from complete Helm ownership annotations, and gVisor off from the exact missing RuntimeClass admission result. Every applied inference is disclosed on standard error, while explicit contradictions return a usage error.

Adds Accepted ADR 0114 in the same change. It supersedes the exact ADR 0032 provider clauses and the ADR 0006 final fail review consequence for the admitted missing gVisor fact. The gVisor chart default and every other security rail remain unchanged.

A provider list containing the detected provider plus additional explicit providers wins unchanged. Ambiguous credential prefixes remain sealed unless the operator supplies a provider.

Evidence

`bash scripts/check-docs.sh` passed. The complete CLI format, Clippy, and Cargo test suite passed. Runner credential tests passed with 79 tests, Ruff passed, and Mypy passed across 190 source files.

A literal cluster install against the isolated branch binary in throwaway namespace `test-1662` printed all five inference lines, interrupted the first Helm attempt on the missing gVisor RuntimeClass, retried once, and reported `curie is up`. The namespace was deleted and verified absent. An OpenRouter shaped credential with explicit `--allow-egress-host anthropic` returned exit 2 before namespace mutation.

Limits

The local ladder could not start because the separate issue 1661 stack owns fixed ports 25432 and 26379. No real provider credential was available for a live model turn. The real Kubernetes install path and its negative contradiction path both passed.

Both required deletion proofs reported `PINNED`: the bare all facts cluster case and the explicit provider contradiction case.