### PR TITLE
Preserve live turn progress above skill tier

### DIFF
--- a/apps/worker/src/curie_worker/kernel.py
+++ b/apps/worker/src/curie_worker/kernel.py
@@ -2127,7 +2127,7 @@ class Kernel:
             # Surfaced for context but not part of the answer buffer.
             note = (
                 f"  -> [{frame.tool}] {frame.text}"
-                if frame.tool
+                if frame.tool is not None
                 else f"  -> {frame.text}"
             )
             answer = acc.rendered()

--- a/apps/worker/src/curie_worker/kernel.py
+++ b/apps/worker/src/curie_worker/kernel.py
@@ -332,6 +332,7 @@ class _ThrottledReply:
         self._min_interval_s = min_interval_s
         self._no_edit = no_edit
         self._last = 0.0
+        self._last_context: float | None = None
         self._last_text: str | None = None
         # Whether this turn's reply delivery is best-effort (#708): set only for an
         # approval-resume turn (the caller derives it from _is_approval_resume). The
@@ -360,6 +361,36 @@ class _ThrottledReply:
         self._last = now
         self._last_text = text
         await self._emit(text)
+
+    async def context(self, text: str) -> None:
+        if self._no_edit:
+            return
+        if not text or text == self._last_text:
+            return
+        now = time.monotonic()
+        # The first context preview is separately eligible even after text;
+        # later previews share the sustained write cadence with text updates.
+        if (
+            self._last_context is not None
+            and now - max(self._last, self._last_context) < self._min_interval_s
+        ):
+            return
+        # Stamp before emitting so a failed edit cannot create a hot retry loop.
+        self._last_context = now
+        self._last = now
+        # A message creating emit must stay fail loud so ref minting and turn
+        # retry semantics remain intact. Only an existing message edit is soft.
+        if self._target.reply_ref is None:
+            await self._emit(text)
+            self._last_text = text
+            return
+        try:
+            await self._emit(text)
+            # Delivery state advances only after the edit succeeds, so a failed
+            # preview cannot suppress an identical final flush.
+            self._last_text = text
+        except Exception as exc:  # noqa: BLE001 - cosmetic progress is best effort
+            logger.warning("context reply update failed: %s", type(exc).__name__)
 
     async def finalize(self, text: str) -> None:
         if text == self._last_text:
@@ -2094,7 +2125,14 @@ class Kernel:
             await reply.stream(acc.rendered())
         elif isinstance(frame, ToolNote):
             # Surfaced for context but not part of the answer buffer.
-            await reply.stream(acc.rendered())
+            note = (
+                f"  -> [{frame.tool}] {frame.text}"
+                if frame.tool
+                else f"  -> {frame.text}"
+            )
+            answer = acc.rendered()
+            preview = f"{answer}\n{note}" if answer else note
+            await reply.context(preview)
         elif isinstance(frame, SideEffectFlag):
             acc.saw_side_effect = True
             # Persist immediately so a crash before done still blocks auto-retry.

--- a/apps/worker/tests/kernel/test_kernel.py
+++ b/apps/worker/tests/kernel/test_kernel.py
@@ -117,6 +117,28 @@ def test_tool_context_streams_immediately_without_polluting_final_reply(
     asyncio.run(go())
 
 
+def test_tool_context_distinguishes_empty_and_absent_tool_names(
+    make_harness,
+) -> None:
+    async def go() -> None:
+        async with make_harness(slack_edit_min_interval_s=0.0) as h:
+            h.runner.default_script = [
+                TextDelta(text="Answer so far"),
+                ToolNote(text="empty name", tool=""),
+                ToolNote(text="unnamed", tool=None),
+                Final(text="Final answer", status=DONE),
+            ]
+
+            await h.kernel.process_event(_qevent("research this"))
+
+            texts = [text for _, _, text in h.sink.updates]
+            assert "Answer so far\n  -> [] empty name" in texts
+            assert "Answer so far\n  -> unnamed" in texts
+            assert h.sink.last_text == "Final answer"
+
+    asyncio.run(go())
+
+
 def test_tool_context_delivery_failure_is_fail_soft(make_harness) -> None:
     async def go() -> None:
         async with make_harness(slack_edit_min_interval_s=60.0) as h:

--- a/apps/worker/tests/kernel/test_kernel.py
+++ b/apps/worker/tests/kernel/test_kernel.py
@@ -1025,6 +1025,7 @@ def test_kernel_delivers_claim_token_as_bearer_header(make_harness) -> None:
 
 _MULTI_DELTA = [
     TextDelta(text="a"),
+    ToolNote(text="checking", tool="ExampleTool"),
     TextDelta(text="b"),
     TextDelta(text="c"),
     Final(text="abc final", status=DONE),
@@ -1034,7 +1035,7 @@ _MULTI_DELTA = [
 def test_no_edit_streaming_edits_placeholder_once(make_harness) -> None:
     async def go() -> None:
         async with make_harness(slack_no_edit_streaming=True) as h:
-            # Text frames arrive, but no edit mode updates only the final.
+            # Text and tool frames arrive, but no edit mode updates only the final.
             h.runner.default_script = list(_MULTI_DELTA)
             await h.kernel.process_event(_qevent("go"))
 

--- a/apps/worker/tests/kernel/test_kernel.py
+++ b/apps/worker/tests/kernel/test_kernel.py
@@ -22,6 +22,7 @@ from aci_protocol import (
     SessionStatus,
     SideEffectFlag,
     TextDelta,
+    ToolNote,
     TurnSource,
 )
 from channel_protocol.reply import ReplyAck, ReplyEvent, ReplyTarget
@@ -82,6 +83,168 @@ def test_new_turn_streams_to_slack_and_acks(make_harness) -> None:
             assert h.runner.opened == ["hi"]
             assert h.sink.last_text == "Hello world"
             assert await h.async_redis.exists(h.config.done_key(ev.event_id))
+
+    asyncio.run(go())
+
+
+def test_tool_context_streams_immediately_without_polluting_final_reply(
+    make_harness,
+) -> None:
+    async def go() -> None:
+        async with make_harness(slack_edit_min_interval_s=60.0) as h:
+            h.runner.default_script = [
+                TextDelta(text="Answer so far"),
+                ToolNote(text="searching...", tool="WebSearch"),
+                TextDelta(text=" and more"),
+                ToolNote(text="opening result", tool="WebSearch"),
+                Final(text="Final answer", status=DONE),
+            ]
+            event = _qevent("research this")
+
+            await h.kernel.process_event(event)
+
+            texts = [text for _, _, text in h.sink.updates]
+            preview = "Answer so far\n  -> [WebSearch] searching..."
+            assert preview in texts
+            assert texts.index(preview) == texts.index("Answer so far") + 1
+            assert [text for text in texts if "  -> " in text] == [preview]
+            assert "Answer so far and more" not in texts
+            assert all("opening result" not in text for text in texts)
+            final_text = h.sink.last_text
+            assert final_text == "Final answer"
+            assert "WebSearch" not in final_text
+
+    asyncio.run(go())
+
+
+def test_tool_context_delivery_failure_is_fail_soft(make_harness) -> None:
+    async def go() -> None:
+        async with make_harness(slack_edit_min_interval_s=60.0) as h:
+            h.runner.default_script = [
+                TextDelta(text="Partial answer"),
+                ToolNote(text="running command", tool="Bash"),
+                ToolNote(text="reading output", tool="Bash"),
+                Final(text="Completed answer", status=DONE),
+            ]
+            context_preview = "Partial answer\n  -> [Bash] running command"
+            original_emit = h.sink.emit
+            context_attempts: list[str] = []
+
+            async def fail_context_emit(
+                reply_event: ReplyEvent,
+                *,
+                route: TargetRoute,
+                best_effort_unreachable: bool = False,
+            ) -> ReplyAck:
+                text = getattr(reply_event, "text", None)
+                if isinstance(text, str) and "\n  -> " in text:
+                    context_attempts.append(text)
+                    raise RuntimeError("injected context delivery failure")
+                return await original_emit(
+                    reply_event,
+                    route=route,
+                    best_effort_unreachable=best_effort_unreachable,
+                )
+
+            h.sink.emit = fail_context_emit  # type: ignore[method-assign]
+            event = _qevent("run it")
+
+            await h.kernel.process_event(event)
+
+            assert context_attempts == [context_preview]
+            assert h.sink.last_text == "Completed answer"
+            assert await h.async_redis.exists(h.config.done_key(event.event_id))
+
+    asyncio.run(go())
+
+
+def test_failed_context_edit_does_not_suppress_identical_final_delivery(
+    make_harness,
+) -> None:
+    async def go() -> None:
+        async with make_harness(slack_edit_min_interval_s=60.0) as h:
+            final_text = "Partial answer\n  -> [Bash] running command"
+            h.runner.default_script = [
+                TextDelta(text="Partial answer"),
+                ToolNote(text="running command", tool="Bash"),
+                Final(text=final_text, status=DONE),
+            ]
+            original_emit = h.sink.emit
+            matching_attempts = 0
+
+            async def fail_first_matching_emit(
+                reply_event: ReplyEvent,
+                *,
+                route: TargetRoute,
+                best_effort_unreachable: bool = False,
+            ) -> ReplyAck:
+                nonlocal matching_attempts
+                if getattr(reply_event, "text", None) == final_text:
+                    matching_attempts += 1
+                    if matching_attempts == 1:
+                        raise RuntimeError("injected context delivery failure")
+                return await original_emit(
+                    reply_event,
+                    route=route,
+                    best_effort_unreachable=best_effort_unreachable,
+                )
+
+            h.sink.emit = fail_first_matching_emit  # type: ignore[method-assign]
+            event = _qevent("run it")
+
+            await h.kernel.process_event(event)
+
+            assert matching_attempts == 2, (
+                "final delivery was not attempted after the failed context edit"
+            )
+            assert h.sink.last_text == final_text
+            assert await h.async_redis.exists(h.config.done_key(event.event_id))
+
+    asyncio.run(go())
+
+
+def test_message_creating_tool_context_delivery_failure_stays_loud(
+    make_harness,
+) -> None:
+    async def go() -> None:
+        async with make_harness() as h:
+            h.runner.default_script = [
+                ToolNote(text="running command", tool="Bash"),
+                Final(text="Completed answer", status=DONE),
+            ]
+            context_preview = "  -> [Bash] running command"
+            booting = h.config.booting_text
+            original_emit = h.sink.emit
+            failed_updates: list[str] = []
+
+            async def fail_context_emit(
+                reply_event: ReplyEvent,
+                *,
+                route: TargetRoute,
+                best_effort_unreachable: bool = False,
+            ) -> ReplyAck:
+                text = getattr(reply_event, "text", None)
+                if text == booting:
+                    failed_updates.append(text)
+                    raise RuntimeError("injected booting delivery failure")
+                if text == context_preview:
+                    failed_updates.append(text)
+                    raise RuntimeError("injected message creation failure")
+                return await original_emit(
+                    reply_event,
+                    route=route,
+                    best_effort_unreachable=best_effort_unreachable,
+                )
+
+            h.sink.emit = fail_context_emit  # type: ignore[method-assign]
+            event = _qevent("run it", placeholder=None)
+
+            with pytest.raises(RuntimeError, match="message creation failure"):
+                await h.kernel.process_event(event)
+
+            assert failed_updates == [booting, context_preview]
+            assert not await h.async_redis.exists(h.config.done_key(event.event_id))
+            assert h.sink.last_text is None
 
     asyncio.run(go())
 
@@ -871,13 +1034,30 @@ _MULTI_DELTA = [
 def test_no_edit_streaming_edits_placeholder_once(make_harness) -> None:
     async def go() -> None:
         async with make_harness(slack_no_edit_streaming=True) as h:
-            # Multiple TextDeltas stream, but in no-edit mode the placeholder is
-            # edited EXACTLY once -- the final. No intermediate chat.update calls.
+            # Text frames arrive, but no edit mode updates only the final.
             h.runner.default_script = list(_MULTI_DELTA)
             await h.kernel.process_event(_qevent("go"))
 
             assert len(h.sink.updates) == 1
             assert h.sink.last_text == "abc final"
+
+    asyncio.run(go())
+
+
+def test_no_edit_streaming_suppresses_tool_context_and_finalizes_once(
+    make_harness,
+) -> None:
+    async def go() -> None:
+        async with make_harness(slack_no_edit_streaming=True) as h:
+            h.runner.default_script = [
+                TextDelta(text="answer in progress"),
+                ToolNote(text="checking", tool="ExampleTool"),
+                Final(text="final answer", status=DONE),
+            ]
+
+            await h.kernel.process_event(_qevent("go"))
+
+            assert h.sink.updates == [("C1", "p-1", "final answer")]
 
     asyncio.run(go())
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -76,6 +76,10 @@ always goes to **stdout**; every diagnostic (progress, spinners, helm/kubectl/
 compose chatter) always goes to **stderr** -- so piping or redirecting the
 payload never picks up progress noise.
 
+For `local message` and `cluster message`, interim answer text and tool context
+are transient progress on stderr. Only the finalized reply is the stdout
+result. In JSON mode, stdout remains exactly one JSON object.
+
 On an interactive terminal, progress renders as spinners and a live checklist;
 it degrades automatically to plain, colorless status lines on a non-TTY, in
 CI, or when `NO_COLOR`/`TERM=dumb` are set.

--- a/cli/src/chat.rs
+++ b/cli/src/chat.rs
@@ -127,6 +127,25 @@ pub fn placeholder_update_text<'a>(call: &'a SlackCall, placeholder_ts: &str) ->
     }
 }
 
+/// Notify the caller immediately for each distinct edit to the tracked placeholder,
+/// then retain that snapshot as the latest reply. Both the normal receive arm and
+/// the final drain use this helper so their filtering and notification cannot drift.
+fn observe_placeholder_update(
+    call: &SlackCall,
+    placeholder_ts: &str,
+    latest: &mut Option<String>,
+    observer: &mut impl FnMut(&str),
+) {
+    let Some(text) = placeholder_update_text(call, placeholder_ts) else {
+        return;
+    };
+    if latest.as_deref() == Some(text) {
+        return;
+    }
+    observer(text);
+    *latest = Some(text.to_string());
+}
+
 /// Extract `channel`, `ts`, `text` from a Slack Web API request body, which
 /// slack_sdk sends form-urlencoded by default and JSON when a param is complex.
 pub fn extract_fields(
@@ -284,6 +303,8 @@ pub enum Outcome {
 /// Wait for the worker to consume and finalize the turn. Terminal signal is the
 /// XACK of our entry; the reply is the latest `chat.update` we captured. Shared
 /// by `chat` and `message` (both stand up the same stub + enqueue + ack seam).
+/// The observer sees each distinct matching edit immediately, but the returned
+/// outcome still uses the latest edit only after XACK and the final drain.
 ///
 /// The turn counts as awaiting approval on EITHER of two signals:
 ///
@@ -307,6 +328,7 @@ pub async fn await_reply(
     entry_id: &str,
     placeholder_ts: &str,
     timeout: Duration,
+    observer: &mut impl FnMut(&str),
 ) -> Outcome {
     let deadline = Instant::now() + timeout;
     let mut latest: Option<String> = None;
@@ -319,9 +341,7 @@ pub async fn await_reply(
             call = stub.recv() => {
                 if let Some(call) = call {
                     awaiting_approval |= call.approval_card;
-                    if let Some(text) = placeholder_update_text(&call, placeholder_ts) {
-                        latest = Some(text.to_string());
-                    }
+                    observe_placeholder_update(&call, placeholder_ts, &mut latest, observer);
                 }
             }
             _ = poll.tick() => {
@@ -341,9 +361,7 @@ pub async fn await_reply(
                     // Drain any final edit still in flight before deciding.
                     while let Ok(Some(call)) = tokio::time::timeout(FINAL_DRAIN, stub.recv()).await {
                         awaiting_approval |= call.approval_card;
-                        if let Some(text) = placeholder_update_text(&call, placeholder_ts) {
-                            latest = Some(text.to_string());
-                        }
+                        observe_placeholder_update(&call, placeholder_ts, &mut latest, observer);
                     }
                     // Either signal parks the turn: the card seen here, or an
                     // authoritative approval notice in the latest placeholder
@@ -481,6 +499,7 @@ pub struct ResumeObservation {
 /// a stalled Valkey cannot block past `timeout`. A failed or overrunning scan is
 /// treated as "not found yet" and retried until the deadline, so a blip cannot be
 /// misread as a resolution; a persistently failing scan warns once.
+#[allow(clippy::too_many_arguments)]
 pub async fn await_resume(
     stub: &mut SlackStub,
     conn: &mut redis::aio::MultiplexedConnection,
@@ -489,6 +508,7 @@ pub async fn await_resume(
     after_id: &str,
     placeholder_ts: &str,
     timeout: Duration,
+    observer: &mut impl FnMut(&str),
 ) -> ResumeObservation {
     let deadline = Instant::now() + timeout;
     let mut cursor = after_id.to_string();
@@ -528,6 +548,7 @@ pub async fn await_resume(
                 &resume_stream_id,
                 placeholder_ts,
                 remaining,
+                observer,
             )
             .await;
             return ResumeObservation {

--- a/cli/src/message.rs
+++ b/cli/src/message.rs
@@ -1040,15 +1040,23 @@ async fn message_local(opts: MessageOpts) -> Result<()> {
     let cl = ui.checklist();
     let step = cl.step("waiting for worker reply");
     let wait_started = Instant::now();
-    let outcome = await_reply(
-        &mut stub,
-        &mut conn,
-        &opts.stream,
-        &stream_id,
-        &placeholder_ts,
-        Duration::from_secs(opts.timeout_secs),
-    )
-    .await;
+    let outcome = {
+        let mut observe_update = |text: &str| {
+            if let Some(line) = text.lines().rev().find(|line| !line.trim().is_empty()) {
+                step.tick_detail(line.trim());
+            }
+        };
+        await_reply(
+            &mut stub,
+            &mut conn,
+            &opts.stream,
+            &stream_id,
+            &placeholder_ts,
+            Duration::from_secs(opts.timeout_secs),
+            &mut observe_update,
+        )
+        .await
+    };
 
     match outcome {
         Outcome::Replied(reply) => {
@@ -1324,16 +1332,27 @@ async fn resume_after_approval(
         // (`resumequeue.resume_event_id`), which is how we recognize that turn on
         // the shared runs stream.
         let resume_event_id = format!("approval-{current_id}-resolved");
-        let observed = await_resume(
-            stub,
-            conn,
-            &opts.stream,
-            &resume_event_id,
-            after_id,
-            placeholder_ts,
-            remaining,
-        )
-        .await;
+        let cl = ui.checklist();
+        let step = cl.step("waiting for resumed worker reply");
+        let observed = {
+            let mut observe_update = |text: &str| {
+                if let Some(line) = text.lines().rev().find(|line| !line.trim().is_empty()) {
+                    step.tick_detail(line.trim());
+                }
+            };
+            await_resume(
+                stub,
+                conn,
+                &opts.stream,
+                &resume_event_id,
+                after_id,
+                placeholder_ts,
+                remaining,
+                &mut observe_update,
+            )
+            .await
+        };
+        step.clear();
         match observed.outcome {
             Outcome::Replied(reply) => {
                 ui.emit(&MessageOutcomeOutput::Replied {
@@ -1821,15 +1840,23 @@ pub async fn message(mut opts: MessageOpts) -> Result<()> {
     let cl = ui.checklist();
     let step = cl.step("waiting for worker reply");
     let wait_started = Instant::now();
-    let outcome = await_reply(
-        &mut stub,
-        &mut conn,
-        &opts.stream,
-        &stream_id,
-        &placeholder_ts,
-        Duration::from_secs(opts.timeout_secs),
-    )
-    .await;
+    let outcome = {
+        let mut observe_update = |text: &str| {
+            if let Some(line) = text.lines().rev().find(|line| !line.trim().is_empty()) {
+                step.tick_detail(line.trim());
+            }
+        };
+        await_reply(
+            &mut stub,
+            &mut conn,
+            &opts.stream,
+            &stream_id,
+            &placeholder_ts,
+            Duration::from_secs(opts.timeout_secs),
+            &mut observe_update,
+        )
+        .await
+    };
 
     match outcome {
         Outcome::Replied(reply) => {
@@ -2207,6 +2234,7 @@ async fn run_eval_turns(
         );
         let started = Instant::now();
         let stream_id = xadd(conn, &opts.stream, &event).await?;
+        let mut observe_update = |_: &str| {};
         let outcome = await_reply(
             stub,
             conn,
@@ -2214,6 +2242,7 @@ async fn run_eval_turns(
             &stream_id,
             &placeholder_ts,
             Duration::from_secs(opts.timeout_secs),
+            &mut observe_update,
         )
         .await;
         let elapsed = started.elapsed().as_secs_f64();

--- a/cli/tests/resume_wait.rs
+++ b/cli/tests/resume_wait.rs
@@ -11,9 +11,12 @@
 //! unaffected; run it locally with the compose Valkey up, or point
 //! `TEST_VALKEY_URL` at another instance.
 
+#[cfg(target_os = "linux")]
 use std::process::{Command, Stdio};
 use std::sync::{Arc, Mutex};
-use std::time::{Duration, Instant};
+use std::time::Duration;
+#[cfg(target_os = "linux")]
+use std::time::Instant;
 
 use tokio::sync::Notify;
 

--- a/cli/tests/resume_wait.rs
+++ b/cli/tests/resume_wait.rs
@@ -11,7 +11,11 @@
 //! unaffected; run it locally with the compose Valkey up, or point
 //! `TEST_VALKEY_URL` at another instance.
 
-use std::time::Duration;
+use std::process::{Command, Stdio};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use tokio::sync::Notify;
 
 use curie::chat::{await_reply, await_resume, parse_approval_id, Outcome, SlackStub};
 use curie::queue::{synthetic_turn, xadd, WORKER_GROUP};
@@ -21,6 +25,11 @@ mod support;
 use support::{unique_stream, valkey_or_skip};
 
 const PLACEHOLDER_TS: &str = "1720000000.000200";
+
+#[cfg(target_os = "linux")]
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_curie")
+}
 
 /// A resume turn under the deterministic `approval-<id>-resolved` event id, the
 /// exact shape `resumequeue._build_turn` appends when a human resolves an
@@ -142,6 +151,7 @@ async fn await_resume_returns_the_finalized_reply_once_the_resume_entry_is_acked
         .unwrap();
     assert_eq!(resp["ok"], true, "stub accepted the final edit");
 
+    let mut observe_update = |_: &str| {};
     let observed = await_resume(
         &mut stub,
         &mut conn,
@@ -150,6 +160,7 @@ async fn await_resume_returns_the_finalized_reply_once_the_resume_entry_is_acked
         &original_id,
         PLACEHOLDER_TS,
         Duration::from_secs(3),
+        &mut observe_update,
     )
     .await;
 
@@ -198,6 +209,7 @@ async fn await_resume_times_out_when_the_approval_is_never_resolved() {
     let original_id = xadd(&mut conn, &stream, &original).await.unwrap();
 
     let resume_event_id = "approval-00000000-0000-4000-8000-000000000000-resolved";
+    let mut observe_update = |_: &str| {};
     let observed = await_resume(
         &mut stub,
         &mut conn,
@@ -206,6 +218,7 @@ async fn await_resume_times_out_when_the_approval_is_never_resolved() {
         &original_id,
         PLACEHOLDER_TS,
         Duration::from_millis(400),
+        &mut observe_update,
     )
     .await;
 
@@ -228,11 +241,15 @@ async fn await_resume_times_out_when_the_approval_is_never_resolved() {
 /// Post a `chat.update` editing the tracked placeholder, exactly as the worker
 /// does. Deliberately carries NO approval card: this is the notice-only path.
 async fn post_placeholder_edit(endpoint: &str, text: &str) {
+    post_reply_edit(endpoint, PLACEHOLDER_TS, text).await;
+}
+
+async fn post_reply_edit(endpoint: &str, placeholder_ts: &str, text: &str) {
     let resp: serde_json::Value = reqwest::Client::new()
         .post(format!("{endpoint}chat.update"))
         .form(&[
             ("channel", "C-SIM-x"),
-            ("ts", PLACEHOLDER_TS),
+            ("ts", placeholder_ts),
             ("text", text),
         ])
         .send()
@@ -242,6 +259,249 @@ async fn post_placeholder_edit(endpoint: &str, text: &str) {
         .await
         .unwrap();
     assert_eq!(resp["ok"], true, "stub accepted the placeholder edit");
+}
+
+#[tokio::test]
+async fn await_reply_observes_matching_live_updates_but_returns_only_the_final_edit() {
+    let Some(mut conn) = valkey_or_skip(
+        "await_reply_observes_matching_live_updates_but_returns_only_the_final_edit",
+    )
+    .await
+    else {
+        return;
+    };
+    let stream = unique_stream("curie:test:resume:");
+
+    let mut stub = SlackStub::start("localhost", 0, "localhost").await.unwrap();
+    let endpoint = stub.base_api_url().to_string();
+    let turn = synthetic_turn(
+        "slack",
+        "C-SIM-x",
+        "U-curie-message",
+        "show live progress",
+        "1720000000.000100",
+        PLACEHOLDER_TS,
+        Some(endpoint.clone()),
+    );
+    let entry_id = xadd(&mut conn, &stream, &turn).await.unwrap();
+    let mut producer_conn = conn.clone();
+
+    let wrong_placeholder = "1720000000.999999";
+    let wrong_text = "wrong placeholder update";
+    let interim_text = "draft answer\n  -> [WebSearch] searching...";
+    let final_text = "final answer";
+    let observed_updates = Arc::new(Mutex::new(Vec::new()));
+    let wait_started = Arc::new(Notify::new());
+    let interim_observed = Arc::new(Notify::new());
+
+    let wait_observed_updates = Arc::clone(&observed_updates);
+    let wait_started_signal = Arc::clone(&wait_started);
+    let interim_observed_signal = Arc::clone(&interim_observed);
+    let wait = async {
+        wait_started_signal.notify_one();
+        let mut observe_update = move |text: &str| {
+            wait_observed_updates.lock().unwrap().push(text.to_string());
+            if text == interim_text {
+                interim_observed_signal.notify_one();
+            }
+        };
+        await_reply(
+            &mut stub,
+            &mut conn,
+            &stream,
+            &entry_id,
+            PLACEHOLDER_TS,
+            Duration::from_secs(3),
+            &mut observe_update,
+        )
+        .await
+    };
+
+    let producer_observed_updates = Arc::clone(&observed_updates);
+    let producer = async {
+        wait_started.notified().await;
+        post_reply_edit(&endpoint, wrong_placeholder, wrong_text).await;
+        post_reply_edit(&endpoint, PLACEHOLDER_TS, interim_text).await;
+        tokio::time::timeout(Duration::from_secs(2), interim_observed.notified())
+            .await
+            .expect(
+                "the interim observer callback must run before the final edit and acknowledgement",
+            );
+        assert_eq!(
+            producer_observed_updates.lock().unwrap().clone(),
+            vec![interim_text.to_string()],
+            "the interim callback runs immediately and filters another placeholder"
+        );
+        post_reply_edit(&endpoint, PLACEHOLDER_TS, final_text).await;
+        deliver_and_ack(&mut producer_conn, &stream).await;
+    };
+
+    let (outcome, ()) = tokio::join!(wait, producer);
+
+    let _: i64 = redis::cmd("DEL")
+        .arg(&stream)
+        .query_async(&mut conn)
+        .await
+        .unwrap();
+
+    match outcome {
+        Outcome::Replied(reply) => assert_eq!(
+            reply, final_text,
+            "the terminal outcome remains the final edit rather than the live preview"
+        ),
+        other => panic!("expected Replied, got a different terminal: {other:?}"),
+    }
+    let observed_updates = observed_updates.lock().unwrap().clone();
+    assert_eq!(
+        observed_updates,
+        vec![interim_text.to_string(), final_text.to_string()],
+        "the observer receives matching live updates in order and ignores another placeholder"
+    );
+    assert!(
+        !observed_updates.iter().any(|text| text == wrong_text),
+        "the observer never receives an update for another placeholder"
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn local_message_renders_the_interim_update_before_the_terminal_reply() {
+    if support::valkey_url() != support::DEFAULT_VALKEY_URL {
+        eprintln!("skipping local message terminal test: the command uses compose Valkey defaults");
+        return;
+    }
+    let Some(mut conn) =
+        valkey_or_skip("local_message_renders_the_interim_update_before_the_terminal_reply").await
+    else {
+        return;
+    };
+    let stream = unique_stream("curie:test:resume:");
+    let workspace = tempfile::tempdir().expect("create isolated command directory");
+    let capture_path = workspace.path().join("terminal.log");
+    let shell_command = format!(
+        "exec {} local message --color never --channel C-SIM-x --stream {} --timeout-secs 8 'show live progress'",
+        bin(), stream
+    );
+    let mut child = Command::new("script")
+        .args(["--quiet", "--return", "--flush", "--command"])
+        .arg(shell_command)
+        .arg(&capture_path)
+        .current_dir(workspace.path())
+        .env("TERM", "xterm-256color")
+        .env("NO_COLOR", "1")
+        .env("DOCKER_HOST", "unix:///tmp/curie-test-no-docker.sock")
+        .env_remove("CI")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("start local message in a terminal");
+
+    let turn_deadline = Instant::now() + Duration::from_secs(5);
+    let turn = loop {
+        let entries: Vec<(String, Vec<(String, String)>)> = redis::cmd("XRANGE")
+            .arg(&stream)
+            .arg("-")
+            .arg("+")
+            .query_async(&mut conn)
+            .await
+            .unwrap();
+        if let Some((_id, fields)) = entries.first() {
+            let payload = fields
+                .iter()
+                .find(|(key, _)| key == "payload")
+                .map(|(_, value)| value)
+                .expect("queued turn carries payload");
+            let turn: QueuedTurn = serde_json::from_str(payload).unwrap();
+            break turn;
+        }
+        if child.try_wait().unwrap().is_some() || Instant::now() >= turn_deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            let capture = std::fs::read_to_string(&capture_path).unwrap_or_default();
+            panic!("local message did not enqueue a turn: {capture}");
+        }
+        tokio::time::sleep(Duration::from_millis(40)).await;
+    };
+
+    let endpoint = turn
+        .reply_handle
+        .endpoint
+        .as_deref()
+        .expect("local message turn carries the live reply endpoint");
+    let placeholder = turn
+        .reply_handle
+        .placeholder
+        .as_deref()
+        .expect("local message turn carries its placeholder");
+    let wrong_text = "wrong placeholder update";
+    let interim_text = "draft answer\n  -> [WebSearch] searching...";
+    let final_text = "final answer";
+    post_reply_edit(endpoint, "1720000000.999999", wrong_text).await;
+    post_reply_edit(endpoint, placeholder, interim_text).await;
+
+    let render_deadline = Instant::now() + Duration::from_secs(3);
+    loop {
+        let capture = std::fs::read_to_string(&capture_path).unwrap_or_default();
+        if capture.contains("[WebSearch] searching...") {
+            assert!(
+                !capture.contains(wrong_text),
+                "another placeholder is never rendered as live progress"
+            );
+            break;
+        }
+        if child.try_wait().unwrap().is_some() || Instant::now() >= render_deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            let _: redis::RedisResult<i64> =
+                redis::cmd("DEL").arg(&stream).query_async(&mut conn).await;
+            panic!(
+                "the interim update was not visible before the final edit and acknowledgement: {capture}"
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(40)).await;
+    }
+
+    post_reply_edit(endpoint, placeholder, final_text).await;
+    deliver_and_ack(&mut conn, &stream).await;
+
+    let exit_deadline = Instant::now() + Duration::from_secs(5);
+    let status = loop {
+        if let Some(status) = child.try_wait().unwrap() {
+            break status;
+        }
+        if Instant::now() >= exit_deadline {
+            let _ = child.kill();
+            let status = child.wait().unwrap();
+            let capture = std::fs::read_to_string(&capture_path).unwrap_or_default();
+            let _: redis::RedisResult<i64> =
+                redis::cmd("DEL").arg(&stream).query_async(&mut conn).await;
+            panic!("local message did not exit after XACK: {status:?}\n{capture}");
+        }
+        tokio::time::sleep(Duration::from_millis(40)).await;
+    };
+    let _: i64 = redis::cmd("DEL")
+        .arg(&stream)
+        .query_async(&mut conn)
+        .await
+        .unwrap();
+
+    let capture = std::fs::read_to_string(&capture_path).unwrap();
+    assert!(status.success(), "local message failed: {capture}");
+    let interim_position = capture
+        .find("[WebSearch] searching...")
+        .expect("terminal capture includes the interim tool update");
+    let final_position = capture
+        .rfind(final_text)
+        .expect("terminal capture includes the final reply");
+    assert!(
+        interim_position < final_position,
+        "the live tool update is visible before the terminal reply"
+    );
+    assert!(
+        !capture.contains(wrong_text),
+        "the terminal never renders another placeholder"
+    );
 }
 
 /// Route-bound approval (#766): when the approval route is bound to a channel
@@ -284,6 +544,7 @@ async fn a_notice_without_a_card_parks_the_turn_and_the_keepalive_delivers_the_r
     post_placeholder_edit(&endpoint, &notice).await;
     deliver_and_ack(&mut conn, &stream).await;
 
+    let mut observe_update = |_: &str| {};
     let outcome = await_reply(
         &mut stub,
         &mut conn,
@@ -291,6 +552,7 @@ async fn a_notice_without_a_card_parks_the_turn_and_the_keepalive_delivers_the_r
         &original_id,
         PLACEHOLDER_TS,
         Duration::from_secs(3),
+        &mut observe_update,
     )
     .await;
 
@@ -327,6 +589,7 @@ async fn a_notice_without_a_card_parks_the_turn_and_the_keepalive_delivers_the_r
         &original_id,
         PLACEHOLDER_TS,
         Duration::from_secs(3),
+        &mut observe_update,
     )
     .await;
 
@@ -396,6 +659,7 @@ async fn a_blank_line_summary_notice_parks_the_turn_and_the_keepalive_delivers_t
     post_placeholder_edit(&endpoint, &notice).await;
     deliver_and_ack(&mut conn, &stream).await;
 
+    let mut observe_update = |_: &str| {};
     let outcome = await_reply(
         &mut stub,
         &mut conn,
@@ -403,6 +667,7 @@ async fn a_blank_line_summary_notice_parks_the_turn_and_the_keepalive_delivers_t
         &original_id,
         PLACEHOLDER_TS,
         Duration::from_secs(3),
+        &mut observe_update,
     )
     .await;
 
@@ -439,6 +704,7 @@ async fn a_blank_line_summary_notice_parks_the_turn_and_the_keepalive_delivers_t
         &original_id,
         PLACEHOLDER_TS,
         Duration::from_secs(3),
+        &mut observe_update,
     )
     .await;
 


### PR DESCRIPTION
## Summary

* Streams bounded tool context through worker reply edits without polluting the final answer.
* Renders matching interim edits in local and cluster message progress while preserving XACK finality, stdout, JSON, quiet mode, and approval resume behavior.
* Adds worker and terminal regressions that fail when the production change is reversed.

Closes #1661

## Contract boundary

Final input and output token counts are not included. Carrying them above the worker requires adding fields to the channel protocol schema. Per the task constraint, this PR stops at that contract boundary rather than changing a contract or schema.

## Verification

<table>
<tr><th>Tier</th><th>Decision</th><th>Evidence</th></tr>
<tr><td>skill</td><td>n/a</td><td>The runner turn loop and skill surface are unchanged.</td></tr>
<tr><td>local</td><td>required</td><td>Fake mode on c41712b5: <code>CURIE_E2E_TIERS=local curie dev e2e-ladder</code> reported <code>LADDER PASS (tiers: local)</code>, finalized with reply <code>all done</code>, pinned bundle digest <code>6f8115068e7f7dbeda979f757f74c936816d96e0e10279f138bf31b59b967524</code>, and left no Curie containers.</td></tr>
<tr><td>local release</td><td>n/a</td><td>No released image identity, install path, version pin, or release compose changed.</td></tr>
<tr><td>cluster</td><td>n/a</td><td>No chart, RBAC, security context, network policy, sandbox claim, or init container changed.</td></tr>
<tr><td>live provider</td><td>n/a</td><td>No model routing, provider authentication, or cost accounting path changed.</td></tr>
<tr><td>external integration</td><td>n/a</td><td>No Slack API request shape or credential path changed. The internal reply stub path is exercised locally.</td></tr>
</table>

* Positive proof: <code>uv run pytest apps/worker/tests/kernel -q</code> passed 182 tests. <code>cargo test --test resume_wait</code> passed 6 tests with real Valkey.
* Lint proof: <code>uv run ruff check .</code>, <code>uv run mypy</code>, <code>uv run lint-imports</code>, <code>cargo fmt --check</code>, <code>cargo clippy -- -D warnings</code>, and <code>bash scripts/check-docs.sh</code> passed.
* Negative proof: reversing only the final production hunks made the ToolNote regression fail and made the CLI regression fail to compile against the removed observer contract. Restoring the hunks returned a clean worktree.

* [x] Every required tier names the exact command, candidate commit, mode, and observed outcome.
* [x] Positive and falsifiable negative proof are recorded.
* [x] Tests and documentation checks pass for every affected area.
* [x] No ADR was added because this change makes no architectural decision.