### PR TITLE
Declare the SRE bot write path

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -161,9 +161,12 @@ You should get a real answer instead of the canned loop.
 The most complete example in this repo is a production triage bot:
 [`examples/sre-bot/`](examples/sre-bot/README.md). Ask it in plain English
 whether anything is broken and it reads your Kubernetes cluster and answers.
-Out of the box it cannot change anything: every tool it holds is read-only and
-its credential cannot even read Secrets. One write verb, rolling a single named
-Deployment behind a human approval card, ships in the box switched off.
+Kubernetes read remains the default capability: its credential cannot read
+Secrets. The `k8s-write` connector and its exact approval gate ship declared
+together, but `K8S_WRITE_KUBECONFIG` does not. Connector bring up cannot
+complete, and no connector container starts, until that separate credential
+exists. This clean refusal is specific to connector bring up; other deployment
+steps can still fail independently or partially.
 
 This one runs on the **cluster** tier, so unlike the loop above it needs a
 Kubernetes cluster, `kubectl` pointed at it, a model credential, and this repo
@@ -192,14 +195,33 @@ current-context: prod
 YAML
 )"
 curie secrets set K8S_READONLY_KUBECONFIG --from-env K8S_READONLY_KUBECONFIG
-
-# 4. Deploy the bundle. This is also what provisions the secret from step 3
-#    into the namespace; nothing else does.
-curie cluster deploy --plugin-dir examples/sre-bot
-
-# 5. Ask it something.
-curie cluster message "Is any pod crashlooping right now?"
 ```
+
+4. **Complete the gated write prerequisites.** Follow
+   [Level up: the gated write path](examples/sre-bot/README.md#level-up-the-gated-write-path)
+   to scope the writer identity and allowlist and store the separate
+   `K8S_WRITE_KUBECONFIG`. Then build and lock the declared connector with one
+   command:
+
+   ```bash
+   curie build --plugin-dir examples/sre-bot --registry <registry-reference>
+   ```
+
+   Do not continue until those prerequisites and the build succeed. Connector
+   bring up cannot complete, and no connector container starts, without them.
+
+5. **Deploy the bundle.** This provisions the secrets from the earlier steps
+   into the namespace; nothing else does.
+
+   ```bash
+   curie cluster deploy --plugin-dir examples/sre-bot
+   ```
+
+6. **Ask it something.**
+
+   ```bash
+   curie cluster message "Is any pod crashlooping right now?"
+   ```
 
 **Step 1 comes first for a reason.** `read-access.yaml` puts a ServiceAccount
 and a token Secret in the `curie` namespace, which does not exist until

--- a/cli/scripts/e2e-ladder.sh
+++ b/cli/scripts/e2e-ladder.sh
@@ -834,33 +834,12 @@ YAML
     done
 }
 
-# Turn the example's commented-out connectors on in ONE scratch copy, and give
-# the copy the approval gate that must travel with them.
-#
-# The gate is applied here rather than shipped as a second fixture file so it
-# cannot drift from the committed plugin.json it patches: bundle validation
-# rejects a gate naming an undeclared connector, so the two changes are one
-# change, and a fixture pair could be edited apart.
+# Copy the connector fixture into each scratch bundle. The shipped manifest
+# already carries the approval gate for the declared write connector.
 prepare_connector_bundle() {
     local dir="$1"
     cp "$CONNECTOR_FIXTURE" "$dir/connectors.yaml"
-    python3 -c '
-import json, sys
-path = sys.argv[1]
-with open(path) as fh:
-    manifest = json.load(fh)
-# The exact block examples/sre-bot/README.md documents at "Declare the approval
-# gate". The tool name carries no plugin infix, deliberately: a Curie connector
-# is a platform-supplied server, so the prefixed form the deploy error advises
-# validates, deploys and never fires.
-manifest["approvalPolicy"] = {
-    "gates": [{"gate": "mcp__k8s-write__restart_deployment", "route": "sre-approvals"}]
-}
-with open(path, "w") as fh:
-    json.dump(manifest, fh, indent=2)
-    fh.write("\n")
-' "$dir/.claude-plugin/plugin.json"
-    echo "connector fixture applied to $dir (connectors.yaml + the approvalPolicy gate that travels with it)"
+    echo "connector fixture applied to $dir (connectors.yaml)"
 }
 
 # One build before the first rung, so every rung consumes the same lock and the

--- a/cli/scripts/fixtures/sre-bot-connectors-enabled.yaml
+++ b/cli/scripts/fixtures/sre-bot-connectors-enabled.yaml
@@ -1,5 +1,6 @@
 # The parity ladder's connector fixture: `examples/sre-bot/connectors.yaml` with
-# every connector the example ships commented out turned ON (ADR 0113, #1690).
+# Tempo enabled and unhosted URLs removed so every connector hosts for parity
+# proof (ADR 0113, #1690).
 #
 # WHY A CHECKED-IN WHOLE FILE rather than a scripted uncomment of the example.
 # `sed` against a comment block is fragile in exactly the direction that hides a
@@ -8,17 +9,14 @@
 # ladder goes green having asserted nothing at all. A whole file cannot degrade
 # that way -- it either parses with three connectors or it fails loudly.
 #
-# WHY IT LIVES HERE and never under `examples/sre-bot/`. The shipped example is
-# read-only by default and stays that way (#1691): the write connector is a
-# deliberate opt-in with a credential and an approval route in front of it. This
-# is a test input, so it lives with the test.
+# WHY IT LIVES HERE and never under `examples/sre-bot/`. The shipped example
+# declares the write connector with its approval gate, but missing its separate
+# credential keeps bring-up closed (#1691). This is a test input, so it lives
+# with the test.
 #
 # The ladder copies the example into a throwaway workdir and overwrites
-# `connectors.yaml` with this file, then applies the `approvalPolicy` gate the
-# example's README documents to the copy's `plugin.json`. The gate TRAVELS WITH
-# the connector: bundle validation rejects a gate naming an undeclared
-# connector, so a bundle enabling `k8s-write` without it would host an ungated
-# write verb, which contradicts the example's whole security shape.
+# `connectors.yaml` with this file. The shipped plugin manifest carries the
+# approval gate for the declared write connector.
 #
 # Every value here is a public-repo placeholder. The credentials the three
 # connectors declare are provisioned by the ladder into the scratch copy and the

--- a/cli/src/examples.rs
+++ b/cli/src/examples.rs
@@ -38,6 +38,7 @@ const KUBECONFIG_SECRET_KEY: &str = "K8S_READONLY_KUBECONFIG";
 const TEMPO_IMAGE_REPOSITORY: &str = "ghcr.io/curie-eng/curie-sre-bot-tempo";
 const TEMPO_IMAGE_TAG: &str = "0.8.0";
 const TEMPO_TAGGED_IMAGE: &str = "ghcr.io/curie-eng/curie-sre-bot-tempo:0.8.0";
+const RUNTIME_PLUGIN_DESCRIPTION: &str = "SRE triage assistant for plain English production health and Kubernetes questions in Slack. This installer deploys read only Kubernetes, Grafana, and Tempo connectors. It omits the source bundle's gated write connector and approval policy; enable that path only through the documented explicit build and deploy flow.";
 const OCI_INDEX_MEDIA_TYPE: &str = "application/vnd.oci.image.index.v1+json";
 const DOCKER_INDEX_MEDIA_TYPE: &str = "application/vnd.docker.distribution.manifest.list.v2+json";
 
@@ -1076,27 +1077,11 @@ impl EmbeddedWorkspace {
         }
         for (name, contents) in BUNDLE_FILES {
             if *name == "connectors.yaml" {
-                let source = std::str::from_utf8(contents)
-                    .context("embedded SRE bot connectors.yaml is not UTF-8")?;
-                let mut declaration: serde_json::Value = serde_norway::from_str(source)
-                    .context("parsing embedded SRE bot connectors.yaml")?;
-                let tempo = declaration
-                    .get_mut("connectors")
-                    .and_then(|connectors| connectors.get_mut("tempo"))
-                    .and_then(serde_json::Value::as_object_mut)
-                    .context("embedded SRE bot must declare connectors.tempo")?;
-                if tempo.remove("build").is_none() || tempo.contains_key("image") {
-                    bail!(
-                        "embedded SRE bot Tempo connector must declare one build source and no image before immutable resolution"
-                    );
-                }
-                tempo.insert(
-                    "image".to_string(),
-                    serde_json::Value::String(format!("{TEMPO_IMAGE_REPOSITORY}@{tempo_digest}")),
-                );
-                let pinned = serde_norway::to_string(&declaration)
-                    .context("serializing the immutable SRE bot connector declaration")?;
-                workspace.write(&Path::new("bundle").join(name), pinned.as_bytes())?;
+                let runtime = runtime_connector_declaration(contents, tempo_digest)?;
+                workspace.write(&Path::new("bundle").join(name), &runtime)?;
+            } else if *name == ".claude-plugin/plugin.json" {
+                let runtime = runtime_plugin_manifest(contents)?;
+                workspace.write(&Path::new("bundle").join(name), &runtime)?;
             } else {
                 workspace.write(&Path::new("bundle").join(name), contents)?;
             }
@@ -1120,6 +1105,60 @@ impl EmbeddedWorkspace {
     fn bundle_dir(&self) -> PathBuf {
         self.root.join("bundle")
     }
+}
+
+fn runtime_connector_declaration(source: &[u8], tempo_digest: &str) -> Result<Vec<u8>> {
+    let source =
+        std::str::from_utf8(source).context("embedded SRE bot connectors.yaml is not UTF-8")?;
+    let mut declaration: serde_json::Value =
+        serde_norway::from_str(source).context("parsing embedded SRE bot connectors.yaml")?;
+    let connectors = declaration
+        .get_mut("connectors")
+        .and_then(serde_json::Value::as_object_mut)
+        .context("embedded SRE bot must declare connectors")?;
+    if connectors.remove("k8s-write").is_none() {
+        bail!("embedded SRE bot must declare connectors.k8s-write");
+    }
+    let tempo = connectors
+        .get_mut("tempo")
+        .and_then(serde_json::Value::as_object_mut)
+        .context("embedded SRE bot must declare connectors.tempo")?;
+    if tempo.remove("build").is_none() || tempo.contains_key("image") {
+        bail!(
+            "embedded SRE bot Tempo connector must declare one build source and no image before immutable resolution"
+        );
+    }
+    tempo.insert(
+        "image".to_string(),
+        serde_json::Value::String(format!("{TEMPO_IMAGE_REPOSITORY}@{tempo_digest}")),
+    );
+    serde_norway::to_string(&declaration)
+        .map(String::into_bytes)
+        .context("serializing the immutable SRE bot connector declaration")
+}
+
+fn runtime_plugin_manifest(source: &[u8]) -> Result<Vec<u8>> {
+    let mut manifest: serde_json::Value =
+        serde_json::from_slice(source).context("parsing embedded SRE bot plugin.json")?;
+    let expected_policy = serde_json::json!({
+        "gates": [{
+            "gate": "mcp__k8s-write__restart_deployment",
+            "route": "sre-approvals"
+        }]
+    });
+    if manifest.get("approvalPolicy") != Some(&expected_policy) {
+        bail!("embedded SRE bot must declare the exact k8s-write approval gate");
+    }
+    let manifest = manifest
+        .as_object_mut()
+        .context("embedded SRE bot plugin.json must be an object")?;
+    manifest.remove("approvalPolicy");
+    manifest.insert(
+        "description".to_string(),
+        serde_json::Value::String(RUNTIME_PLUGIN_DESCRIPTION.to_string()),
+    );
+    serde_json::to_vec_pretty(&manifest)
+        .context("serializing the read only SRE bot plugin manifest")
 }
 
 impl Drop for EmbeddedWorkspace {
@@ -1429,5 +1468,79 @@ mod tests {
         assert_eq!(parse_memory_quantity("1343488Ki").unwrap(), 1312 * MIB);
         assert_eq!(parse_memory_quantity("500M").unwrap(), 500_000_000);
         assert_eq!(parse_memory_quantity("1e6").unwrap(), 1_000_000);
+    }
+
+    #[test]
+    fn runtime_connector_transform_requires_the_declared_write_connector() {
+        let source = b"connectors:\n  tempo:\n    build:\n      context: connectors/tempo\n      platforms: [linux/amd64]\n";
+        let error = runtime_connector_declaration(source, "sha256:fixture")
+            .expect_err("missing k8s-write must be refused");
+        assert!(
+            error
+                .to_string()
+                .contains("must declare connectors.k8s-write"),
+            "unexpected error: {error:#}"
+        );
+    }
+
+    #[test]
+    fn runtime_plugin_transform_requires_the_exact_write_gate_policy() {
+        let exact_gate = serde_json::json!({
+            "gate": "mcp__k8s-write__restart_deployment",
+            "route": "sre-approvals"
+        });
+        let cases = [
+            (
+                "missing approval policy",
+                serde_json::json!({"name": "sre-bot", "description": "source"}),
+            ),
+            (
+                "renamed gate",
+                serde_json::json!({
+                    "name": "sre-bot",
+                    "description": "source",
+                    "approvalPolicy": {"gates": [{
+                        "gate": "mcp__k8s-write__rollout_restart",
+                        "route": "sre-approvals"
+                    }]}
+                }),
+            ),
+            (
+                "additional gate",
+                serde_json::json!({
+                    "name": "sre-bot",
+                    "description": "source",
+                    "approvalPolicy": {"gates": [
+                        exact_gate.clone(),
+                        {"gate": "mcp__other__write", "route": "sre-approvals"}
+                    ]}
+                }),
+            ),
+            (
+                "different route",
+                serde_json::json!({
+                    "name": "sre-bot",
+                    "description": "source",
+                    "approvalPolicy": {"gates": [{
+                        "gate": "mcp__k8s-write__restart_deployment",
+                        "route": "other-approvals"
+                    }]}
+                }),
+            ),
+        ];
+
+        for (case, manifest) in cases {
+            let source = serde_json::to_vec(&manifest).expect("serialize fixture manifest");
+            let error = match runtime_plugin_manifest(&source) {
+                Ok(_) => panic!("{case} must be refused"),
+                Err(error) => error,
+            };
+            assert!(
+                error
+                    .to_string()
+                    .contains("must declare the exact k8s-write approval gate"),
+                "unexpected error for {case}: {error:#}"
+            );
+        }
     }
 }

--- a/cli/tests/example_sre_bot_install.rs
+++ b/cli/tests/example_sre_bot_install.rs
@@ -1219,6 +1219,25 @@ fn successful_install_uploads_only_the_resolved_tempo_index_digest() {
         declaration["connectors"]["tempo"].get("build").is_none(),
         "the uploaded runtime declaration must not ask the cluster deploy path to build Tempo"
     );
+    assert!(
+        declaration["connectors"].get("k8s-write").is_none(),
+        "the credential free installer must omit the gated write connector from its runtime bundle"
+    );
+
+    let plugin: Value = serde_json::from_slice(&uploaded_bundle_file(
+        &fixture,
+        ".claude-plugin/plugin.json",
+    ))
+    .expect("uploaded plugin manifest must remain valid JSON");
+    assert!(
+        plugin.get("approvalPolicy").is_none(),
+        "the runtime bundle must remove the write gate with its omitted connector"
+    );
+    assert_eq!(
+        plugin["description"],
+        "SRE triage assistant for plain English production health and Kubernetes questions in Slack. This installer deploys read only Kubernetes, Grafana, and Tempo connectors. It omits the source bundle's gated write connector and approval policy; enable that path only through the documented explicit build and deploy flow.",
+        "the runtime manifest must describe the installer bundle's read only surface"
+    );
 
     // GitHub documents anonymous public GHCR pulls, and the Distribution token
     // specification defines the service and repository pull scope exchange:

--- a/examples/sre-bot/.claude-plugin/plugin.json
+++ b/examples/sre-bot/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sre-bot",
   "version": "0.1.0",
-  "description": "Read only SRE triage assistant. Answers plain English questions about production health and Kubernetes cluster state in Slack. Reads the Kubernetes API, Grafana logs and metrics, and Tempo traces through connectors that ship enabled. Every shipped tool is readOnlyHint, and the cluster credential cannot read Secrets. One optional write verb for rolling a single named Deployment ships disabled behind a human approval gate.",
+  "description": "SRE triage assistant for plain-English production health and Kubernetes questions in Slack. Read-only by default: the Kubernetes read connector exposes only read tools, and its credential cannot read Secrets or mutate resources. Grafana and Tempo connectors add observability reads. The one declared write verb rolls a single allowlisted Deployment using a separate credential and the exact human approval gate mcp__k8s-write__restart_deployment.",
   "license": "Apache-2.0",
   "author": {
     "name": "CurieTech"
@@ -28,5 +28,13 @@
     "Which services are logging the most errors today?",
     "Is the API slow right now?",
     "Show me slow traces from the last hour"
-  ]
+  ],
+  "approvalPolicy": {
+    "gates": [
+      {
+        "gate": "mcp__k8s-write__restart_deployment",
+        "route": "sre-approvals"
+      }
+    ]
+  }
 }

--- a/examples/sre-bot/README.md
+++ b/examples/sre-bot/README.md
@@ -16,21 +16,20 @@ What you get back: a one-line verdict first ("Nothing looks broken." / "Yes --
 `api` is throwing 500s"), then the evidence, then a link so you can look
 yourself.
 
-**Out of the box it cannot change anything.** Every shipped tool is
-`readOnlyHint`. Kubernetes access uses a ServiceAccount that cannot read
-Secrets or delete anything, and Grafana access uses the Viewer role. There is no
-write tool, so there is nothing to gate, so no approval policy is declared at
-all.
+**Read-only operation remains the default.** The Kubernetes read connector is
+on. The one write connector and its exact approval gate ship declared together,
+so the tool cannot be enabled without its gate. Its separate
+`K8S_WRITE_KUBECONFIG` does not ship, so an untouched bring-up refuses cleanly
+before any connector starts instead of silently acquiring write access.
 
-**One write verb ships in the box, switched off.** Enabling it takes a few
-deliberate steps and gives the bot exactly one thing it can change: rolling a
-single named Deployment, behind a human approval card. See
+Completing the deliberate setup gives the bot exactly one thing it can change:
+rolling one allowlisted Deployment behind a human approval card. See
 [Level up: the gated write path](#level-up-the-gated-write-path).
 
 This is the repo's most complete example bundle. It is a real bot, generalised:
-a skill, four connectors (three on, one off), the RBAC to stand it up, a
-purpose-built write connector with its source and tests, deploy targets, and a
-falsifiable eval suite.
+a skill, four declared connectors (Kubernetes read, gated write, Grafana and
+Tempo), the RBAC to stand it up, connector source and tests, deploy targets, and
+a falsifiable eval suite.
 
 ---
 
@@ -87,8 +86,11 @@ On a clean Kubernetes cluster, run one command:
 curie example sre-bot install --observability
 ```
 
-This installs the bot and its self referential observability stack. It requires
-no values files, connector edits, or supplied credentials.
+This installs the bot and its self referential observability stack with no
+values files. The installer makes a read only runtime copy of the checked in
+bundle by removing the write connector and its matching approval gate together.
+The declared write path remains in the source bundle for the explicit Level up
+build and deploy flow below.
 
 ---
 
@@ -121,14 +123,24 @@ Every call pauses the turn and posts an approval card, **and the person who
 asked can never be the person who approves** -- the platform blocks
 self-approval.
 
+The connector source declaration and the exact
+`mcp__k8s-write__restart_deployment` gate already ship together. There is no
+connector block to uncomment and no gate snippet to add. The remaining work is
+to scope the identity and allowlist, store the separate credential, then build
+and deploy from the declaration.
+
 Read the four-layer table above before starting, and
 [`manifests/write-role.yaml`](manifests/write-role.yaml) before applying it.
 
-**1. Create the write identity.**
+**1. Scope and create the write identity.**
 
 Edit the namespace and the `resourceNames` list in
 [`manifests/write-role.yaml`](manifests/write-role.yaml) first -- one Deployment,
-not a list, unless someone has actually asked for the second one. Then:
+not a list, unless someone has actually asked for the second one. Replace
+`<namespace>/<deployment>` under `K8S_WRITE_ALLOWLIST` in
+[`connectors.yaml`](connectors.yaml) with the same pair. Stating the ceiling in
+two places is deliberate: a ceiling stated once is a ceiling that moves when
+someone edits the other place. Then:
 
 ```bash
 kubectl apply -f examples/sre-bot/manifests/write-role.yaml
@@ -169,83 +181,32 @@ kubectl auth can-i --as=system:serviceaccount:"$NS":sre-bot-writer \
   delete deployments -n "$NS"                                 # NO
 ```
 
-**The credential comes before the connector, and that order is load-bearing.** A
-declared connector secret with no stored value fails the deploy, so a bundle
-that enables `k8s-write` before `K8S_WRITE_KUBECONFIG` exists cannot deploy at
-all. That is why this step sits ahead of the uncomment rather than beside it.
+**The credential comes before bring-up, and that order is load-bearing.** The
+declared `secret_files` entry has no bundled value. Without a stored
+`K8S_WRITE_KUBECONFIG`, bring-up refuses cleanly before any connector starts.
+The writer can never fall back to the read-only connector's credential.
 
-**3. Turn the connector on.**
-
-Uncomment the `k8s-write:` block in [`connectors.yaml`](connectors.yaml) and set
-`K8S_WRITE_ALLOWLIST` to `<namespace>/<deployment>` -- the same pair you put in
-`resourceNames`. Stating the ceiling in two places is deliberate: a ceiling
-stated once is a ceiling that moves when someone edits the other place.
-
-There is no `image:` line to fill in. The block declares a `build:` -- the source
-directory and the platforms -- and step 4 resolves it to a digest.
-
-**4. Build the connector image.**
+**3. Build the connector image.**
 
 ```bash
-curie build --plugin-dir examples/sre-bot --registry <your-registry>
+curie build --plugin-dir examples/sre-bot --registry <registry-reference>
 ```
 
-One command, after the uncomment rather than before it: `curie build` builds
-what the file currently declares, so a still-commented connector is not built.
-It builds every declared `build:` connector on every platform its `platforms:`
-line names, pushes them, and writes the resolved digests to
-`connectors.lock.yaml` beside `connectors.yaml`. The deploy renders those
-digests and nothing else, so the "pin it, never `:latest`" rule is enforced by
-the artifact rather than by remembering.
+The declaration builds `connectors/k8s-write` for `linux/amd64` and
+`linux/arm64` and writes its resolved digest to `connectors.lock.yaml`. This one
+command replaces the old manual image build and push ceremony. The exact
+approval gate is already versioned in the plugin manifest. There is no image
+line, connector uncomment, or gate edit in the bring-up path.
 
-There is no public image on purpose: the allowlist and the credential are yours,
-and so is the artifact. Multi-arch is not a flag you pass either -- the
-`platforms:` line in [`connectors.yaml`](connectors.yaml) carries it, because a
-single-arch image passes CI and then fails to pull on a node of the other
-architecture with "no matching manifest", which reads as a registry problem.
-
-If your registry defaults new packages to private, flip this one to public or
-give the cluster a pull secret. An anonymous pull otherwise 403s and surfaces as
-`ImagePullBackOff`.
-
-`connectors.lock.yaml` is gitignored in this example. It records your registry
-and the digests your build resolved, so it belongs to an install; the deploy
-packs it from your working tree.
-
-**5. Declare the approval gate.**
-
-Add this to `.claude-plugin/plugin.json`. It is not shipped, because bundle
-validation rejects a gate naming an undeclared connector -- so a gate for a
-commented-out connector would fail the build for everyone who never enables it.
-The consequence is that the gate travels with step 3's uncomment, in the same
-change: enabling the connector without it deploys an ungated write verb.
-
-```json
-  "approvalPolicy": {
-    "gates": [
-      {
-        "gate": "mcp__k8s-write__restart_deployment",
-        "route": "sre-approvals"
-      }
-    ]
-  }
-```
-
-**THE TOOL NAME IS NOT WHAT THE ERROR MESSAGE TELLS YOU.** It is
-`mcp__k8s-write__restart_deployment`, NOT
-`mcp__plugin_sre-bot_k8s-write__restart_deployment`. Curie connectors are
-platform-supplied servers, named like `mcp__curie__request_approval` with no
-plugin infix; only bundle-loaded MCP servers take the `plugin_<bundle>_` form.
-The deploy error advises the prefixed form. Following it yields a gate that
-validates, deploys, and never fires.
-
-**6. Redeploy.**
+**4. Deploy the bundle.**
 
 ```bash
 curie cluster deploy --plugin-dir examples/sre-bot
 ```
 
-**7. Bind the route, or the card has nowhere to post.**
+The deploy renders only the digest from `connectors.lock.yaml`.
+
+**5. Bind the route, or the card has nowhere to post.**
 
 ```bash
 curie cluster approvals sre-bot --route sre-approvals=C0EXAMPLE1
@@ -260,7 +221,7 @@ escalating rather than routing the card` and no card will appear.
 the whole map, so name every route you want on every invocation. Passing one
 route to add it silently drops the others.
 
-**8. Approve one.**
+**6. Request one restart, approve it as a second actor, and verify the rollout.**
 
 In Slack, someone other than the requester clicks the card. Self-approval is
 blocked by the platform, which in a one-person workspace is a dead end for a
@@ -291,6 +252,17 @@ curie cluster approvals sre-bot --resolve <approval-id> --as <someone-else> --ac
 `--as` must not name the requester. Raise `--timeout-secs` further if a human is
 doing the deciding rather than you in the next terminal.
 
+The resumed reply must verify with Kubernetes reads: new pods, their ages, and
+relevant events. A successful write response proves only that the patch was
+accepted. Independently wait for the rollout before calling the exercise done:
+
+```bash
+kubectl rollout status deployment/<deployment> -n "$NS"
+```
+
+Also request a restart for a different Deployment. The connector must reject it
+as outside `K8S_WRITE_ALLOWLIST`; no approval can widen that ceiling.
+
 ### Turning it off in a hurry
 
 **Kill the credential, not the pod.** The RoleBinding is the one thing Curie
@@ -305,9 +277,11 @@ still call it, but the API server refuses every patch with a 403 -- so the
 failure lands where you want it, at the credential, and the connector reports it
 honestly rather than pretending to have rolled something.
 
-Then remove it properly: comment the `k8s-write` block in
-[`connectors.yaml`](connectors.yaml) and redeploy. The connector disappears and
-so does the tool.
+Then remove it properly: remove the `k8s-write` declaration in
+[`connectors.yaml`](connectors.yaml) and its exact gate in
+`.claude-plugin/plugin.json` in the same change, then redeploy. The connector and
+tool disappear, while the bundle stays valid because no gate names an absent
+connector.
 
 ```bash
 curie cluster deploy --plugin-dir examples/sre-bot
@@ -486,13 +460,13 @@ in the environment section so the bot can say which one it hit.
 
 | Path | What it is |
 |---|---|
-| `.claude-plugin/plugin.json` | Identity, starter prompts. No `approvalPolicy`; see the optional write section |
+| `.claude-plugin/plugin.json` | Identity, starter prompts, and the exact write approval gate |
 | `skills/sre-bot/SKILL.md` | The persona and answering rules -- **the main thing to edit** |
-| `connectors.yaml` | What the bot needs running; Curie derives the Kubernetes |
+| `connectors.yaml` | Kubernetes read, gated write, Grafana and Tempo declarations |
 | `deploy.yaml` | Named deploy targets: which agent, which environment, which channel |
 | `evals/cases.json` | The falsifiable test suite / promotion gate |
 | `manifests/read-access.yaml` | The read-only ServiceAccount, ClusterRole and token |
-| `manifests/write-role.yaml` | The write identity, for the optional write path |
+| `manifests/write-role.yaml` | The write identity, for the gated write path |
 | `connectors/k8s-write/` | Source, Dockerfile and tests for the one-tool write connector |
 | `connectors/tempo/` | Source, Dockerfile and tests for the traces connector |
 

--- a/examples/sre-bot/connectors.yaml
+++ b/examples/sre-bot/connectors.yaml
@@ -10,18 +10,21 @@
 # WHAT SHIPS ON, AND WHAT SHIPS OFF
 # ---------------------------------------------------------------------------
 #
-#   kubernetes    ON.  Read-only cluster access. The only connector you need to
-#                      make this bot useful, and the only one with no external
-#                      dependency beyond the cluster itself.
-#   k8s-write     OFF. One gated write verb. Needs a second credential, an
-#                      approval route, and one `curie build` to turn the source
-#                      in `connectors/k8s-write/` into a pinned image. See
-#                      README.md, "Level up: the gated write path".
-#   grafana       ON. Logs, metrics, alerts and profiles from the bundled stack.
-#   tempo         ON. Distributed traces from the bundled stack.
+#   kubernetes    ON.       Read-only cluster access. The only connector you
+#                           need to make this bot useful, and the only one with
+#                           no external dependency beyond the cluster itself.
+#   k8s-write     DECLARED. One gated write verb. Its source build and exact
+#                           approval gate ship together, but its separate
+#                           K8S_WRITE_KUBECONFIG does not. Without that secret,
+#                           bring-up refuses cleanly before any connector starts,
+#                           so read-only operation remains the default. See
+#                           README.md, "Level up: the gated write path".
+#   grafana       ON.       Logs, metrics, alerts and profiles from the bundled
+#                           observability stack.
+#   tempo         ON.       Distributed traces from the bundled stack.
 #
-# The optional write connector remains commented out because it needs separate
-# credentials and an approval route.
+# Removing a declared connector removes its tools. Remove any matching approval
+# gate in the same change so the bundle remains valid.
 connectors:
   # Read-only Kubernetes: the questions metrics cannot answer. What the
   # scheduler actually said, what a crashed container logged, what a manifest
@@ -121,7 +124,7 @@ connectors:
       K8S_READONLY_KUBECONFIG: /secrets/kubeconfig
 
 # ---------------------------------------------------------------------------
-# THE GATED WRITE CONNECTOR -- SHIPS OFF. Uncomment to enable.
+# THE GATED WRITE CONNECTOR -- DECLARED, WITH ITS CREDENTIAL ABSENT BY DEFAULT.
 #
 # What it is: a purpose-built server exposing exactly ONE tool,
 # `restart_deployment`, behind a Curie approval gate. Calling it pauses the
@@ -134,29 +137,26 @@ connectors:
 # exposes one tool, so there is no second thing for a gate to miss. Source and
 # full reasoning: connectors/k8s-write/server.py.
 #
-# ENABLING IT IS NOT JUST UNCOMMENTING. You must:
+# The connector declaration and its gate in `.claude-plugin/plugin.json` ship
+# together. That closes the unsafe intermediate state where the tool exists but
+# its gate does not. It does NOT grant a write path by itself. Before bring-up:
 #
 #   1. Apply `manifests/write-role.yaml` (after editing its namespace and
 #      `resourceNames`) and store the resulting kubeconfig as
-#      K8S_WRITE_KUBECONFIG. This comes FIRST: a declared connector secret with
-#      no stored value fails the deploy, so the credential exists before the
-#      connector does.
-#   2. Set `K8S_WRITE_ALLOWLIST` below to the one `namespace/deployment` this
-#      bot may roll.
-#   3. Build the image:
+#      K8S_WRITE_KUBECONFIG.
+#   2. Replace the K8S_WRITE_ALLOWLIST placeholder below with the one
+#      `namespace/deployment` this bot may roll.
+#   3. Build and deploy the declared source:
 #
 #          curie build --plugin-dir examples/sre-bot --registry <your-registry>
 #
-#      That builds every connector this file declares a `build:` for, on every
-#      platform it names, pushes them, and records the resolved digests in
-#      `connectors.lock.yaml`. There is no public image for this on purpose --
-#      the allowlist and the credential are yours, and so is the artifact -- and
-#      no `image:` line to edit: the digest lives in the lock, never here.
-#   4. Add the approval gate to `.claude-plugin/plugin.json`. It is NOT shipped:
-#      bundle validation rejects a gate that names an undeclared connector, so a
-#      gate for a commented-out connector would fail the build for everyone who
-#      never enables this. The gate therefore travels WITH this uncomment, in
-#      the same change; README.md carries the exact JSON.
+#      That builds every connector with a `build:` declaration for every named
+#      platform and records the resolved digests in `connectors.lock.yaml`.
+#      There is no `image:` line to edit: the digest lives in the lock.
+#
+# The missing separate kubeconfig is load-bearing. An untouched bring-up
+# refuses before either connector starts instead of silently running a writer
+# with the read credential or an unreviewed target.
 #
 # Full walkthrough: README.md, "Level up: the gated write path".
 #
@@ -168,42 +168,38 @@ connectors:
 # the prefixed form; following it yields a gate that validates, deploys, and
 # never fires.
 #
-#   k8s-write:
-#     # Where the image comes FROM, instead of what it is. `curie build` builds
-#     # this context and records the digest it resolved in
-#     # `connectors.lock.yaml`; the deploy renders that digest and nothing else,
-#     # so the pinning note on `kubernetes` above -- which is not theoretical --
-#     # is satisfied by construction here rather than by remembering to type an
-#     # immutable tag.
-#     #
-#     # `platforms` is required rather than defaulted, because a silently
-#     # single-arch image builds clean, passes CI, and then fails to pull on a
-#     # node of the other architecture as "no matching manifest".
-#     #
-#     # PACKAGE VISIBILITY, if you push to a registry that has the concept: a
-#     # newly published package is often PRIVATE by default, and an anonymous
-#     # node pull then gets a 403 that surfaces as ImagePullBackOff rather than
-#     # as a permissions error. That trap is about the registry you pushed to,
-#     # so it survives the change of who does the building. Verify with an
-#     # anonymous manifest fetch before blaming the cluster.
-#     build:
-#       context: connectors/k8s-write
-#       platforms: [linux/amd64, linux/arm64]
-#     unhosted_url: ${K8S_WRITE_MCP_URL}
-#     env:
-#       # Defence in depth alongside the Role's `resourceNames`. A ceiling
-#       # stated in one place only is a ceiling that moves when someone edits
-#       # the other place. Format is `namespace/deployment`, comma-separated.
-#       # EMPTY MEANS THE CONNECTOR REFUSES TO START, not that everything is
-#       # permitted -- a missing config fails closed.
-#       K8S_WRITE_ALLOWLIST: <namespace>/<deployment>
-#     # A SEPARATE kubeconfig from the read-only one, bound to the
-#     # ServiceAccount in manifests/write-role.yaml: one namespace, get+patch on
-#     # exactly the named Deployments. Never the read-only connector's
-#     # credential -- that one is deliberately unable to write, and reusing it
-#     # here would mean widening it.
-#     secret_files:
-#       K8S_WRITE_KUBECONFIG: /secrets/kubeconfig
+  k8s-write:
+    # Where the image comes FROM, instead of what it is. `curie build` builds
+    # this context and records the digest it resolved in
+    # `connectors.lock.yaml`; the deploy renders that digest and nothing else,
+    # so the pinning note on `kubernetes` above, which is not theoretical, is
+    # satisfied by construction here rather than by remembering to type an
+    # immutable tag.
+    #
+    # `platforms` is required rather than defaulted, because a silently
+    # single-arch image builds clean, passes CI, and then fails to pull on a
+    # node of the other architecture as "no matching manifest".
+    build:
+      context: connectors/k8s-write
+      platforms: [linux/amd64, linux/arm64]
+    # Deliberately no `unhosted_url`: skill and local runs host this connector,
+    # so they exercise the separate secret requirement instead of silently
+    # dialing an operator-supplied copy. Re-run `curie build --plugin-dir`
+    # after source or declaration changes so the lock matches what is hosted.
+    env:
+      # Defence in depth alongside the Role's `resourceNames`. A ceiling
+      # stated in one place only is a ceiling that moves when someone edits
+      # the other place. Format is `namespace/deployment`, comma-separated.
+      # EMPTY MEANS THE CONNECTOR REFUSES TO START, not that everything is
+      # permitted -- a missing config fails closed.
+      K8S_WRITE_ALLOWLIST: <namespace>/<deployment>
+    # A SEPARATE kubeconfig from the read-only one, bound to the
+    # ServiceAccount in manifests/write-role.yaml: one namespace, get+patch on
+    # exactly the named Deployments. Never the read-only connector's
+    # credential -- that one is deliberately unable to write, and reusing it
+    # here would mean widening it.
+    secret_files:
+      K8S_WRITE_KUBECONFIG: /secrets/kubeconfig
 # ---------------------------------------------------------------------------
 
   grafana:
@@ -233,7 +229,6 @@ connectors:
       - name: GRAFANA_SERVICE_ACCOUNT_TOKEN
         from_secret: curie-grafana-connector
         key: GRAFANA_SERVICE_ACCOUNT_TOKEN
-
   tempo:
     build:
       context: connectors/tempo

--- a/examples/sre-bot/manifests/write-role.yaml
+++ b/examples/sre-bot/manifests/write-role.yaml
@@ -2,9 +2,9 @@
 #
 #     kubectl apply -f examples/sre-bot/manifests/write-role.yaml
 #
-# ONLY NEEDED IF YOU ENABLE THE WRITE PATH. The shipped bundle has the
-# `k8s-write` connector commented out, so applying this on its own grants a
-# credential nothing uses. Apply it as step 2 of README.md's
+# ONLY NEEDED FOR THE WRITE PATH. The shipped bundle declares the gated
+# `k8s-write` connector, but without `K8S_WRITE_KUBECONFIG` bring-up refuses
+# before any connector starts. Apply this as step 2 of README.md's
 # "Level up: the gated write path".
 #
 # EDIT TWO THINGS BEFORE APPLYING: the namespace (four occurrences) and the

--- a/packages/plugin-format/tests/test_approval_policy.py
+++ b/packages/plugin-format/tests/test_approval_policy.py
@@ -11,8 +11,10 @@ green at deploy resolves identically at runtime (#453).
 """
 
 import json
+import shutil
 from pathlib import Path
 
+import yaml
 from plugin_format import ApprovalGate, grantable_routes, validate_bundle
 
 
@@ -106,6 +108,58 @@ def test_route_matching_is_case_sensitive() -> None:
 # A gate may only name a connector the bundle declares -- #1495, and #1691's
 # constraint that it must keep holding once a third connector form exists
 # --------------------------------------------------------------------------- #
+def test_sre_bot_declares_gated_write_connector_and_validates(tmp_path: Path) -> None:
+    source = Path(__file__).resolve().parents[3] / "examples" / "sre-bot"
+    plugin = json.loads(
+        (source / ".claude-plugin" / "plugin.json").read_text(encoding="utf-8")
+    )
+    connectors = yaml.safe_load(
+        (source / "connectors.yaml").read_text(encoding="utf-8")
+    )
+
+    assert plugin["approvalPolicy"]["gates"] == [
+        {
+            "gate": "mcp__k8s-write__restart_deployment",
+            "route": "sre-approvals",
+        }
+    ]
+    assert connectors["connectors"]["k8s-write"]["build"] == {
+        "context": "connectors/k8s-write",
+        "platforms": ["linux/amd64", "linux/arm64"],
+    }
+    assert "unhosted_url" not in connectors["connectors"]["k8s-write"]
+    assert connectors["connectors"]["k8s-write"]["secret_files"] == {
+        "K8S_WRITE_KUBECONFIG": "/secrets/kubeconfig"
+    }
+
+    from plugin_format import connector_lock
+    from plugin_format.connectors import ConnectorBuild
+
+    bundle = tmp_path / "sre-bot"
+    shutil.copytree(source, bundle)
+    locked_connectors = {}
+    for name, declaration in connectors["connectors"].items():
+        if "build" not in declaration:
+            continue
+        build = ConnectorBuild.model_validate(declaration["build"])
+        context = bundle / declaration["build"]["context"]
+        locked_connectors[name] = {
+            "image": _LOCAL_IMAGE,
+            "delivery": "local-daemon",
+            "platforms": declaration["build"]["platforms"],
+            "source_digest": connector_lock.source_digest_of(context, build),
+        }
+    (bundle / connector_lock.CONNECTOR_LOCK_FILE).write_text(
+        yaml.safe_dump(
+            {"version": 1, "connectors": locked_connectors}, sort_keys=False
+        ),
+        encoding="utf-8",
+    )
+
+    result = validate_bundle(str(bundle))
+    assert result.valid, [(error.code, error.message) for error in result.errors]
+
+
 def _gated_bundle(root: Path, connectors_yaml: str, gate: str) -> Path:
     (root / ".claude-plugin").mkdir(parents=True, exist_ok=True)
     (root / ".claude-plugin" / "plugin.json").write_text(


### PR DESCRIPTION
Closes #1691

Declares the source built k8s-write connector with its exact restart approval gate while keeping the separate write credential absent by default. Updates the SRE bot setup and parity fixture for the single build path.

Done check

[x] Named bundle validation positive and undeclared connector negative pass
[x] Missing write credential exits 2 before any runner or connector starts
[x] Source rebuild hosts the digest pinned connector and reports the gate armed
[x] Code, scope, and security reviews are clean
[x] Full affected validation passes