### PR TITLE
Correct the cluster tier's local-model download claim

### DIFF
--- a/docs/local-model.md
+++ b/docs/local-model.md
@@ -65,8 +65,13 @@ download from a wedged one (issue #1183). Once both assets are cached the flag i
 never needed again and `up` is unchanged — measured at **17.9s warm**, against
 **232s** for the same command on a cold machine over a fast link.
 
-`cluster up --local-model` is unaffected: it has no host-side Ollama to
-provision, so there is nothing to preflight and no `--pull-model` flag.
+`cluster up --local-model` has **no** such preflight and no `--pull-model` flag,
+because there is no host-side Ollama to provision. That is not the same as
+nothing being downloaded: the chart's inference Deployment pulls the weights
+*inside the cluster* instead, and does it implicitly. See
+[the cluster tier](#the-cluster-tier-downloads-implicitly) below before running
+this against a real cluster with a large model
+([#1779](https://github.com/curie-eng/curie/issues/1779)).
 
 ## How it runs
 
@@ -81,6 +86,36 @@ reclaimed with `docker volume rm <volume>` — after which the next
 `cluster up` uses the in-chart inference Deployment; the chart renders the Ollama
 Service and Deployment, opens the runner egress carve-out automatically, and
 bakes `ANTHROPIC_BASE_URL` plus the inference model into the runner template.
+
+### The cluster tier downloads implicitly
+
+Unlike the other two tiers, the cluster tier fetches the weights for you, and
+nothing announces it. `inference.pullModel` defaults to `true`, and the chart
+pulls from a `postStart` lifecycle hook on the Ollama container, so:
+
+- **the pod is not-ready for the whole download.** kubelet does not mark a
+  container started until `postStart` returns, so the readiness probe has not
+  begun yet and the wait is unbounded. A large model looks identical to a wedged
+  deploy, which is the failure ADR-0093 removed at the other two tiers;
+- **a failed pull restarts the container.** A non-zero `postStart` makes kubelet
+  kill it, so a network error or an unknown model name surfaces as
+  `CrashLoopBackOff` with the reason in a `FailedPostStartHook` event, and each
+  restart retries the whole download;
+- **the default does not keep the weights.** `inference.persistence.enabled`
+  defaults to `false`, so the data directory is an `emptyDir` and `cluster up`
+  requests no PVC. Any restart, eviction, or node drain re-downloads the model in
+  full.
+
+With the `qwen3:4b` default (~2.5GB) this is mostly invisible. With a documented
+upgrade such as `qwen3-coder:30b` (~17-19GB) it is not. Until
+[#1779](https://github.com/curie-eng/curie/issues/1779) is resolved, deploy a
+large model with persistence turned on so a restart does not re-fetch it:
+
+```bash
+curie cluster up --local-model qwen3-coder:30b --set inference.persistence.enabled=true --set inference.persistence.size=40Gi
+```
+
+and expect that first `up` to sit at not-ready for as long as the pull takes.
 
 ## Choosing a model
 

--- a/docs/local-model.md
+++ b/docs/local-model.md
@@ -103,13 +103,16 @@ pulls from a `postStart` lifecycle hook on the Ollama container, so:
   restart retries the whole download;
 - **the default does not keep the weights.** `inference.persistence.enabled`
   defaults to `false`, so the data directory is an `emptyDir` and `cluster up`
-  requests no PVC. Any restart, eviction, or node drain re-downloads the model in
-  full.
+  requests no PVC. Kubernetes preserves an `emptyDir` across a container restart
+  within the same Pod, so that alone does not touch the weights. Pod removal or
+  replacement -- eviction, node drain -- does: the replacement Pod's `postStart`
+  pulls the weights again.
 
 With the `qwen3:4b` default (~2.5GB) this is mostly invisible. With a documented
 upgrade such as `qwen3-coder:30b` (~17-19GB) it is not. Until
 [#1779](https://github.com/curie-eng/curie/issues/1779) is resolved, deploy a
-large model with persistence turned on so a restart does not re-fetch it:
+large model with persistence turned on so an evicted or rescheduled Pod does not
+re-fetch it:
 
 ```bash
 curie cluster up --local-model qwen3-coder:30b --set inference.persistence.enabled=true --set inference.persistence.size=40Gi


### PR DESCRIPTION
## What this is

A docs-only correction. `docs/local-model.md` currently tells operators that the
cluster tier has nothing to download, and that is false today.

Filed alongside #1779, which carries the behaviour defects and the decisions they
need.

## The wrong claim

> `cluster up --local-model` is unaffected: it has no host-side Ollama to
> provision, so there is nothing to preflight and no `--pull-model` flag.

The first clause is true. The conclusion is not: there is no *host-side* Ollama
because the chart runs Ollama *in the cluster*, and it pulls the weights there
implicitly.

## What actually happens

`cluster up --local-model <model>` sets `inference.deploy=true` and
`inference.model` (`cli/src/ops.rs`, `up_value_plan`). With
`inference.pullModel` (default `true`) the chart pulls from a **`postStart`
lifecycle hook** on the Ollama container, which means:

- **the pod is not-ready for the entire download.** kubelet does not mark a
  container started until `postStart` returns, so the readiness probe has not
  begun and the wait is unbounded. This is the #1183 failure shape ADR-0093
  removed at the other two tiers;
- **a failed pull kills the container.** A non-zero `postStart` makes kubelet
  kill it, so a network error or an unknown model name becomes
  `CrashLoopBackOff`, cause buried in a `FailedPostStartHook` event, and each
  restart retries the whole download;
- **the default discards the weights.** `inference.persistence.enabled` defaults
  to `false` and `cluster up` requests no PVC, so the data directory is an
  `emptyDir` and any restart or eviction re-downloads in full.

`qwen3:4b` (~2.5GB) hides all of it. The documented upgrade `qwen3-coder:30b` is
~17-19GB, where it does not hide at all.

## What this PR changes

Only the prose. It corrects the claim, adds a **"The cluster tier downloads
implicitly"** subsection under "How it runs" describing the three behaviours
above, and gives the interim mitigation for a large model:

```bash
curie cluster up --local-model qwen3-coder:30b --set inference.persistence.enabled=true --set inference.persistence.size=40Gi
```

That routes through `curie cluster up --set` (`ClusterAction::Up`) rather than a
raw `helm upgrade`, per the one-entry-point rule in `CLAUDE.md`. My first draft
had the raw helm command; this is the corrected form.

## What this PR deliberately does not change

**ADR-0093's text.** It excluded the cluster tier on the premise that
"`cluster up` never faces the question: it does not run Ollama", which no longer
holds. Per ADR-0045 that stays exactly as written -- the status line, a
back-link, and pointer repairs are the only permitted edits, and "the gap between
what was decided and what was built is the record's whole point". The stale
premise is reported in #1779 instead.

**Any chart default or behaviour.** Whether this tier gets a preflight, whether
`pullModel` keeps defaulting to true, whether the pull moves out of `postStart`,
and whether `persistence` should default on when inference is deployed are four
separate calls that each change an operator-visible default. They are enumerated
in #1779 for a maintainer rather than picked here.

## Related

- #1779 the behaviour defects and decision points (filed with this PR)
- #1666 verb parity: same verb, different flags and defaults per tier -- this is
  a concrete instance, since `--pull-model` exists at two tiers and not the third
- #1183 the original silent-download report that produced ADR-0093
- #1233 letting `--local-model` target a host-installed Ollama
- ADR-0093, ADR-0045, and ADR-0041 (every verb answered at every tier)

## Verification

`bash scripts/check-docs.sh` passes: no catalog drift, every citation resolves.
`scripts/check-commit-messages.sh` clean. No code paths touched, so behaviour is
unchanged by construction.
