### PR TITLE
Scaffold systemPrompt in curie init

### DIFF
--- a/cli/src/scaffold.rs
+++ b/cli/src/scaffold.rs
@@ -64,6 +64,7 @@ fn manifest(name: &str) -> String {
     serde_json::to_string_pretty(&serde_json::json!({
         "name": name,
         "description": format!("The {name} agent plugin."),
+        "systemPrompt": format!("You are the {name} agent. Help users with {name} requests."),
         "version": "0.1.0",
     }))
     .expect("static manifest serializes")
@@ -312,6 +313,13 @@ pub fn scaffold_from_spec(dir: &Path, spec: &AgentSpec) -> Result<Vec<PathBuf>> 
     let mut manifest_obj = serde_json::Map::new();
     manifest_obj.insert("name".into(), serde_json::json!(spec.name));
     manifest_obj.insert("description".into(), serde_json::json!(spec.description));
+    manifest_obj.insert(
+        "systemPrompt".into(),
+        serde_json::json!(format!(
+            "You are the {} agent. Help users with {} requests.",
+            spec.name, spec.name
+        )),
+    );
     manifest_obj.insert("version".into(), serde_json::json!("0.1.0"));
     if !spec.secrets.is_empty() {
         manifest_obj.insert("secrets".into(), serde_json::json!(spec.secrets));
@@ -526,6 +534,10 @@ mod tests {
         )
         .unwrap();
         assert_eq!(manifest["name"], "deal-desk");
+        assert_eq!(
+            manifest["systemPrompt"],
+            "You are the deal-desk agent. Help users with deal-desk requests."
+        );
 
         // Genericized starter skill for <name>: no weather anywhere.
         let skill = std::fs::read_to_string(dir.path().join("skills/deal-desk/SKILL.md")).unwrap();

--- a/cli/tests/spec_scaffold.rs
+++ b/cli/tests/spec_scaffold.rs
@@ -98,6 +98,10 @@ fn scaffolds_the_full_bundle_from_a_valid_spec() {
         manifest["description"],
         "Prices and reviews deal desk requests."
     );
+    assert_eq!(
+        manifest["systemPrompt"],
+        "You are the deal-desk agent. Help users with deal-desk requests."
+    );
 
     // 5. .gitignore ignores local workstation state.
     let gitignore = std::fs::read_to_string(out.join(".gitignore")).unwrap();

--- a/docs/interfaces/bundle-format/workflow-agent-conversion.md
+++ b/docs/interfaces/bundle-format/workflow-agent-conversion.md
@@ -52,7 +52,7 @@ to overwrite anything that already exists:
 
 ```
 deal-desk/
-  .claude-plugin/plugin.json   # manifest: {name, description, version}
+  .claude-plugin/plugin.json   # manifest: {name, description, systemPrompt, version}
   skills/deal-desk/SKILL.md     # skill with YAML frontmatter
   .mcp.json                     # { "mcpServers": {} }
   evals/cases.json              # { name, cases: [{id, input, grader}] }


### PR DESCRIPTION
Closes #1665

`curie init` now adds an always present identity prompt to both plain and spec based generated plugin manifests. Regression coverage pins both paths, and the interface example reflects the generated shape.

Done check

* [x] Regressions were verified red before production changes
* [x] Plain and spec scaffold paths emit the same prompt
* [x] No contract, schema, ADR, or runtime routing changed
* [x] Independent code and scope reviews approved
* [x] Full CLI tests, formatting, Clippy, and docs lint passed
* [x] Skill E2E and fix pin verification passed