### PR TITLE
Clarify skill tier terminology

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -2,7 +2,9 @@
 
 Welcome. This gets you a first agent reply in about a minute — no credentials,
 no cluster, no Slack. It runs the `skill` target only: just the runner
-container on your host Docker daemon, talking straight to the agent. For the
+container on your host Docker daemon, talking straight to the agent. Here,
+`skill` names the runner only tier. The authored skill artifact lives at
+`skills/<name>/SKILL.md`. For the
 full tour across all three tiers through to production, see the
 [README Quickstart](README.md#quickstart); this doc goes deeper on the `skill`
 path itself — configuring a real model, alternate providers, and example

--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ the same plugin bundle climbs three tiers.
 
 - `cluster` runs it through that same full platform on Kubernetes.
 
+Here, `skill` names the runner only tier. An authored bundle skill is the
+artifact at `skills/<name>/SKILL.md`.
+
 An environment difference then shows up as a bug while progressing through these tiers, not a surprise
 your users hit - letting you iterate fast locally and ship with confidence.
 

--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -119,7 +119,7 @@ export const commandManifest = {
       "name": "init"
     },
     {
-      "about": "Work with a local runner session for a plugin bundle: `skill <up|down|status|message|eval|approvals>`. `versions` and `memory` are answered here too, reporting that this tier has neither",
+      "about": "Work with the runner only tier for a plugin bundle. `skill` names that tier, not a bundle skill artifact at `skills/<name>/SKILL.md`. Subcommands: `skill <up|down|status|message|eval|approvals>`. `versions` and `memory` are answered here too, reporting that this tier has neither",
       "hidden": false,
       "name": "skill",
       "subcommands": [

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -116,7 +116,7 @@
       "name": "init"
     },
     {
-      "about": "Work with a local runner session for a plugin bundle: `skill <up|down|status|message|eval|approvals>`. `versions` and `memory` are answered here too, reporting that this tier has neither",
+      "about": "Work with the runner only tier for a plugin bundle. `skill` names that tier, not a bundle skill artifact at `skills/<name>/SKILL.md`. Subcommands: `skill <up|down|status|message|eval|approvals>`. `versions` and `memory` are answered here too, reporting that this tier has neither",
       "hidden": false,
       "name": "skill",
       "subcommands": [

--- a/cli/src/guide.rs
+++ b/cli/src/guide.rs
@@ -180,6 +180,11 @@ pub fn primer() -> Primer {
         ],
         decision_logic: vec![
             Decision {
+                question: "skill tier vs bundle skill artifact",
+                answer: "The `skill` command names the runner only tier. A bundle skill is an \
+                         artifact at `skills/<name>/SKILL.md`.",
+            },
+            Decision {
                 question: "skill vs local vs cluster",
                 answer: "skill is the runner only (offline, no platform, no Slack) -- the tightest \
                          loop. local puts the full platform in front of the identical runner via \

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -243,7 +243,8 @@ enum Command {
         )]
         adopt: Option<PathBuf>,
     },
-    /// Work with a local runner session for a plugin bundle:
+    /// Work with the runner only tier for a plugin bundle. `skill` names that tier, not a
+    /// bundle skill artifact at `skills/<name>/SKILL.md`. Subcommands:
     /// `skill <up|down|status|message|eval|approvals>`. `versions` and `memory`
     /// are answered here too, reporting that this tier has neither.
     Skill {

--- a/cli/tests/command_surface.rs
+++ b/cli/tests/command_surface.rs
@@ -215,6 +215,31 @@ fn process_help_top_level_lists_new_surface_and_hides_retired_verbs() {
     }
 }
 
+#[test]
+fn process_skill_help_distinguishes_tier_from_bundle_artifact() {
+    let output = run_help(&["skill"]);
+    assert!(
+        output.status.success(),
+        "expected success for skill help\n{}",
+        output_text(&output)
+    );
+    let text = output_text(&output);
+    let distinction =
+        "`skill` names that tier, not a bundle skill artifact at `skills/<name>/SKILL.md`.";
+    assert!(
+        text.contains(distinction),
+        "skill help must clearly distinguish its runner tier from the bundle artifact\n{text}"
+    );
+    assert!(
+        text.contains("Subcommands: `skill <up|down|status|message|eval|approvals>`"),
+        "skill help must introduce its subcommand list separately\n{text}"
+    );
+    assert!(
+        !text.contains("skills/<name>/SKILL.md`: `skill <up|down|status|message|eval|approvals>"),
+        "skill help must not attach the subcommand list to the artifact distinction\n{text}"
+    );
+}
+
 /// `curie dev plugin-compat` is the operator-facing name of the outbound
 /// Claude-Code-compatibility gate (see the bundle-format seam doc). If the verb
 /// stops being reachable, the gate is still in CI but nobody can run it locally

--- a/cli/tests/guide.rs
+++ b/cli/tests/guide.rs
@@ -148,6 +148,33 @@ fn guide_prints_primer_to_stdout() {
 }
 
 #[test]
+fn guide_distinguishes_skill_tier_from_bundle_artifact() {
+    let markdown = run(&["guide"]);
+    assert!(
+        markdown.status.success(),
+        "curie guide failed:\n{}",
+        err_str(&markdown)
+    );
+    let json = run(&["guide", "--json"]);
+    assert!(
+        json.status.success(),
+        "curie guide --json failed:\n{}",
+        err_str(&json)
+    );
+
+    let markdown = out_str(&markdown);
+    let json = out_str(&json);
+    for (surface, text) in [("markdown", &markdown), ("json", &json)] {
+        for fact in ["runner only tier", "skills/<name>/SKILL.md"] {
+            assert!(
+                text.contains(fact),
+                "{surface} guide must distinguish its runner tier from the bundle artifact with `{fact}`\n{text}"
+            );
+        }
+    }
+}
+
+#[test]
 fn guide_json_emits_pure_structured_data_on_stdout() {
     let out = run(&["guide", "--json"]);
     assert!(

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -5,6 +5,8 @@ Curie is a harness that runs the same immutable bundle and the same eval suite
 (the bundle's own `evals/cases.json` and optional `evals/trajectory.json`)
 across three tiers, skill, local, and cluster, so an agent that worked locally
 does not silently break once deployed.
+Here, `skill` names the runner only tier. An authored bundle skill is the
+artifact at `skills/<name>/SKILL.md`.
 Its CLI's primary user is a coding agent driven by a developer, and this file is
 the contract that agent works to.
 

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -41,8 +41,10 @@ run, so only source builds need this.
 ## Pick a Target
 
 The three targets (`skill`, `local`, `cluster`) and when to reach for each are
-described in the [README target guide](../README.md#which-target-do-i-want). For
-onboarding, start with `skill` for the fastest proof a bundle answers, then move
+described in the [README target guide](../README.md#which-target-do-i-want).
+For onboarding, `skill` names the runner only tier; an authored bundle skill is
+the artifact at `skills/<name>/SKILL.md`. Start with `skill` for the fastest
+proof a bundle answers, then move
 to `local` for ticket verification — it puts the full platform in front of the
 runner with no Slack or Kubernetes. `curie init` scaffolds a bundle and
 targets no environment.


### PR DESCRIPTION
## Summary

Clarifies that curie skill names the runner only tier, while skills/<name>/SKILL.md is an authored bundle artifact. Keeps help, guide, onboarding docs, and generated command manifests consistent.

Closes #1667

## Done check

[x] Regressions were confirmed red before implementation, and both final mutation checks print PINNED.

[x] Source and test edits used separate delegated contexts. No public return type changed.

[x] Independent code and scope reviews approved the final diff. The consolidation review found no material simplification.

[x] Help, guide Markdown and JSON, README, QUICKSTART, onboarding, agent guidance, and generated manifests use consistent terminology.

[x] No guard, security surface, contract, schema, ADR, runtime behavior, command name, or flag changed.

[x] Candidate help and guide output were observed directly.

[x] The required local E2E ladder completed a real deploy and message round trip, then removed its stack.

[x] Cargo formatting, clippy, and the full CLI suite pass. UI lint, typecheck, and 147 tests pass. Documentation lint passes.