### PR TITLE
Collect E2E CI selection tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,6 +160,7 @@ testpaths = [
     "tools/wire-tolerance-gate/tests",
     "tools/ci-retry-gate/tests",
     "tools/ci-workflow-paths/tests",
+    "tools/e2e-ci-selection/tests",
     # Only the offline harness unit tests -- NOT the whole tree: the cluster
     # scenario in test_soak_resilience.py stays out of default collection and
     # runs only under CURIE_SOAK=1 (#499).


### PR DESCRIPTION
Adds tools/e2e-ci-selection/tests to the root pytest testpaths so the selector and aggregate validator coverage runs under the bare CI command.

Base choice: main, because this is a shared CI correctness fix for both release lines rather than a version 0.7 feature.

Collection increased from 3418 to 3461 cases. The newly included selector suite contributes 43 parametrized cases from 11 test functions.

Validation: uv run ruff check tools/e2e-ci-selection pyproject.toml passed. With the prescribed backing stack running, uv run pytest -q passed with 3450 passed and 11 skipped.

Closes #1752