### PR TITLE
Expose collector trace exporters

### DIFF
--- a/charts/curie/README.md
+++ b/charts/curie/README.md
@@ -150,6 +150,27 @@ App services emit OTLP (OpenTelemetry Protocol) to the **collector**, never
 straight to Langfuse (Langfuse OTLP ingest is HTTP-only): `curie-otel-collector:4317` (gRPC) /
 `:4318` (HTTP). The collector forwards to Langfuse over HTTP.
 
+Additional trace destinations are configured through
+`otelCollector.extraExporters`, a map of exporter names to collector exporter
+configuration, and `otelCollector.extraPipelineExporters`, an ordered list of
+those names. The map is rendered under `exporters` and the list is appended to
+the traces pipeline; built-in `otlphttp/langfuse` and `debug` exporters may
+also be named. Helm fails with the missing exporter name if a pipeline entry is
+undefined. For example, this adds a Tempo exporter:
+
+```yaml
+otelCollector:
+  extraExporters:
+    otlp/tempo:
+      endpoint: tempo:4317
+      tls:
+        insecure: true
+  extraPipelineExporters: [otlp/tempo]
+```
+
+Changes to either value roll the collector Deployment through its config
+checksum, so the configured pipeline is applied on `helm upgrade`.
+
 ## Components
 
 | Component | Image | Notes |

--- a/charts/curie/ci/otel-collector-checksum-assertions.sh
+++ b/charts/curie/ci/otel-collector-checksum-assertions.sh
@@ -24,8 +24,23 @@ manifest_for() {
 render default
 render port-3001 --set langfuse.web.service.port=3001
 render auth-header --set otelCollector.otlpAuthHeader='Basic YXNzZXJ0OmFzc2VydA=='
+render tempo \
+  --set 'otelCollector.extraExporters.otlphttp/tempo.endpoint=http://tempo:4318' \
+  --set 'otelCollector.extraPipelineExporters[0]=otlphttp/tempo'
 
-python3 - "$(manifest_for "$TMP/default")" "$(manifest_for "$TMP/port-3001")" "$(manifest_for "$TMP/auth-header")" <<'PY'
+missing_exporter_stderr="$TMP/missing-exporter.stderr"
+if helm template curie "$CHART" \
+  --set 'otelCollector.extraPipelineExporters[0]=otlphttp/tempo' \
+  >/dev/null 2>"$missing_exporter_stderr"; then
+  fail "Helm accepted missing exporter otlphttp/tempo; add it under otelCollector.extraExporters"
+fi
+missing_exporter_error="$(<"$missing_exporter_stderr")"
+[[ "$missing_exporter_error" == *"otlphttp/tempo"* ]] || \
+  fail "Missing exporter error did not name otlphttp/tempo"
+[[ "$missing_exporter_error" == *"otelCollector.extraExporters"* ]] || \
+  fail "Missing exporter error did not name otelCollector.extraExporters"
+
+python3 - "$(manifest_for "$TMP/default")" "$(manifest_for "$TMP/port-3001")" "$(manifest_for "$TMP/auth-header")" "$(manifest_for "$TMP/tempo")" <<'PY'
 import sys
 import yaml
 
@@ -44,6 +59,31 @@ def config_and_checksum(path):
 default_config, default_checksum = config_and_checksum(sys.argv[1])
 changed_config, changed_checksum = config_and_checksum(sys.argv[2])
 auth_config, auth_checksum = config_and_checksum(sys.argv[3])
+tempo_config, tempo_checksum = config_and_checksum(sys.argv[4])
+
+default_parsed = yaml.safe_load(default_config)
+tempo_parsed = yaml.safe_load(tempo_config)
+default_exporters = default_parsed["exporters"]
+default_trace_exporters = default_parsed["service"]["pipelines"]["traces"]["exporters"]
+tempo_exporters = tempo_parsed["exporters"]
+tempo_trace_exporters = tempo_parsed["service"]["pipelines"]["traces"]["exporters"]
+
+assert set(default_exporters) == {"otlphttp/langfuse", "debug"}, (
+    "Default collector exporters changed or unexpectedly include Tempo"
+)
+assert default_trace_exporters == ["otlphttp/langfuse", "debug"], (
+    "Default traces pipeline exporters changed or unexpectedly include Tempo"
+)
+assert tempo_exporters.get("otlphttp/tempo") == {"endpoint": "http://tempo:4318"}, (
+    "Tempo exporter configuration was not rendered exactly"
+)
+assert tempo_trace_exporters == ["otlphttp/langfuse", "debug", "otlphttp/tempo"], (
+    "Tempo exporter was not appended to the traces pipeline"
+)
+assert default_config != tempo_config, "Tempo values did not change the collector ConfigMap body"
+assert default_checksum != tempo_checksum, (
+    "Tempo values changed but Deployment checksum/config stayed identical. The pod would not roll."
+)
 
 assert default_config != changed_config, "Langfuse service port did not change the collector ConfigMap body"
 assert default_checksum != changed_checksum, (

--- a/charts/curie/templates/_helpers.tpl
+++ b/charts/curie/templates/_helpers.tpl
@@ -240,6 +240,12 @@ true
 {{- end -}}
 
 {{- define "curie.otelCollector.config" -}}
+{{- $builtInExporters := dict "otlphttp/langfuse" true "debug" true -}}
+{{- range $exporter := .Values.otelCollector.extraPipelineExporters }}
+{{- if not (or (hasKey $builtInExporters $exporter) (hasKey $.Values.otelCollector.extraExporters $exporter)) }}
+{{- fail (printf "otelCollector.extraPipelineExporters references undefined exporter %q. Add it under otelCollector.extraExporters." $exporter) }}
+{{- end }}
+{{- end }}
 # Receives OTLP over gRPC (4317) and HTTP (4318) from app services and
 # forwards to Langfuse over HTTP. Langfuse OTLP ingest is HTTP-only (gRPC is
 # silently unsupported), so the collector is the adapter. Langfuse appends
@@ -260,6 +266,9 @@ exporters:
       Authorization: ${env:LANGFUSE_OTLP_AUTH_HEADER}
   debug:
     verbosity: normal
+{{- with .Values.otelCollector.extraExporters }}
+{{ toYaml . | nindent 2 }}
+{{- end }}
 extensions:
   health_check:
     endpoint: 0.0.0.0:13133
@@ -272,7 +281,7 @@ service:
     traces:
       receivers: [otlp]
       processors: [batch]
-      exporters: [otlphttp/langfuse, debug]
+      exporters: [otlphttp/langfuse, debug{{- range .Values.otelCollector.extraPipelineExporters }}, {{ . }}{{- end }}]
 {{- end }}
 
 {{/* ---- Default-credential gate (issue #198) ----

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -493,6 +493,11 @@ otelCollector:
   # CreateContainerConfigError. Setting it to the published dev header trips
   # security.checkDefaultCredentials.
   otlpAuthHeader: ""
+  # Additional collector exporter definitions rendered verbatim under exporters.
+  extraExporters: {}
+  # Exporter names appended in order to the traces pipeline. Each name must
+  # identify an exporter configured above or in extraExporters.
+  extraPipelineExporters: []
   service:
     grpcPort: 4317
     httpPort: 4318


### PR DESCRIPTION
Adds supported values for extra OTel Collector exporters and trace pipeline membership. Undefined pipeline exporters now fail during Helm rendering with a repair instruction, and rendered checksum coverage proves an upgrade rolls the collector onto Tempo configuration.

Ref #1765

Done check

* [x] Failing render contracts committed before implementation
* [x] All edits delegated to fresh execution contexts
* [x] Code review approved after the undefined exporter guard
* [x] Scope review approved with no passengers
* [x] Undefined exporter guard demonstrated with exit 1 and a precise repair message
* [x] Consolidation found no simplification
* [x] Observable Helm render and checksum behavior verified
* [x] Full affected chart assertions, docs check, and Helm lint pass
* [x] Cluster runtime marked not applicable for this isolated render contract because this sandbox has no real cluster and the issue explicitly authorizes Helm render proof