### PR TITLE
Add chart placement classes

### DIFF
--- a/charts/curie/ci/render-assertions.sh
+++ b/charts/curie/ci/render-assertions.sh
@@ -759,6 +759,316 @@ if check_github_token_empty "$GHT_MUTANT_RENDER" "mutant (githubToken via curie.
 fi
 echo "  ok: a generated githubToken is rejected (the assert can fail)"
 
+echo "=== Placement assertion 1: every rendered pod surface receives its placement class ==="
+PLACEMENT_VALUES="$TMP/placement-values.yaml"
+cat > "$PLACEMENT_VALUES" <<'YAMLEOF'
+placement:
+  platform:
+    podLabels:
+      example.com/fargate-profile: platform
+    annotations:
+      example.com/placement: platform
+    nodeSelector:
+      example.com/node-class: platform
+    tolerations:
+      - key: example.com/dedicated
+        operator: Equal
+        value: platform
+        effect: NoSchedule
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: example.com/node-class
+                  operator: In
+                  values: [platform]
+  data:
+    podLabels:
+      example.com/fargate-profile: data
+    annotations:
+      example.com/placement: data
+    nodeSelector:
+      example.com/node-class: data
+    tolerations:
+      - key: example.com/dedicated
+        operator: Equal
+        value: data
+        effect: NoSchedule
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: example.com/node-class
+                  operator: In
+                  values: [data]
+  sandbox:
+    podLabels:
+      example.com/fargate-profile: sandbox
+    annotations:
+      example.com/placement: sandbox
+    nodeSelector:
+      example.com/node-class: sandbox
+    tolerations:
+      - key: example.com/dedicated
+        operator: Equal
+        value: sandbox
+        effect: NoSchedule
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: example.com/node-class
+                  operator: In
+                  values: [sandbox]
+  hooks:
+    podLabels:
+      example.com/fargate-profile: hooks
+    annotations:
+      example.com/placement: hooks
+    nodeSelector:
+      example.com/node-class: hooks
+    tolerations:
+      - key: example.com/dedicated
+        operator: Equal
+        value: hooks
+        effect: NoSchedule
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: example.com/node-class
+                  operator: In
+                  values: [hooks]
+  controller:
+    podLabels:
+      example.com/fargate-profile: controller
+    annotations:
+      example.com/placement: controller
+    nodeSelector:
+      example.com/node-class: controller
+    tolerations:
+      - key: example.com/dedicated
+        operator: Equal
+        value: controller
+        effect: NoSchedule
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: example.com/node-class
+                  operator: In
+                  values: [controller]
+YAMLEOF
+
+PLACEMENT_CHECK="$TMP/check_placement.py"
+cat > "$PLACEMENT_CHECK" <<'PYEOF'
+"""Assert placement classes on every chart rendered pod surface.
+
+argv: <rendered-dir> <populated|default|platform-only>
+Exits 0 on pass, 1 naming the missing, extra, or mismatched surface on failure.
+"""
+import pathlib
+import sys
+
+import yaml
+
+rendered, mode = sys.argv[1], sys.argv[2]
+prefix = "placement-render-curie"
+
+expected = {
+    ("Deployment", f"{prefix}-api"): "platform",
+    ("Deployment", f"{prefix}-dispatcher"): "platform",
+    ("Deployment", f"{prefix}-worker"): "platform",
+    ("Deployment", f"{prefix}-ui"): "platform",
+    ("Deployment", f"{prefix}-inference"): "platform",
+    ("Deployment", f"{prefix}-otel-collector"): "platform",
+    ("Deployment", f"{prefix}-langfuse-web"): "platform",
+    ("Deployment", f"{prefix}-langfuse-worker"): "platform",
+    ("StatefulSet", f"{prefix}-postgres"): "data",
+    ("StatefulSet", f"{prefix}-valkey"): "data",
+    ("StatefulSet", f"{prefix}-clickhouse"): "data",
+    ("StatefulSet", f"{prefix}-rustfs"): "data",
+    ("SandboxTemplate", f"{prefix}-runner"): "sandbox",
+    ("DaemonSet", f"{prefix}-runner-prewarm"): "sandbox",
+    ("Job", f"{prefix}-rustfs-init"): "hooks",
+    ("Job", f"{prefix}-preflight-avx"): "hooks",
+    ("Job", f"{prefix}-preflight-gvisor"): "hooks",
+    ("Job", f"{prefix}-preflight-controller"): "hooks",
+    ("Job", f"{prefix}-netpol-probe"): "hooks",
+    ("Job", f"{prefix}-security-probe"): "hooks",
+    ("Job", f"{prefix}-langfuse-model-pricing"): "hooks",
+    ("Pod", f"{prefix}-security-probe-hardening"): "hooks",
+    ("Deployment", "agent-sandbox-controller"): "controller",
+}
+
+
+def pod_surface(doc):
+    kind = doc.get("kind")
+    if kind in {"Deployment", "StatefulSet", "DaemonSet", "Job"}:
+        return doc.get("spec", {}).get("template", {}) or {}
+    if kind == "Pod":
+        return {"metadata": doc.get("metadata", {}) or {}, "spec": doc.get("spec", {}) or {}}
+    if kind == "SandboxTemplate":
+        return doc.get("spec", {}).get("podTemplate", {}) or {}
+    return None
+
+
+surfaces = {}
+for path in sorted(pathlib.Path(rendered).rglob("*.yaml")):
+    for doc in yaml.safe_load_all(path.read_text()):
+        if not isinstance(doc, dict):
+            continue
+        surface = pod_surface(doc)
+        if surface is None:
+            continue
+        key = (doc.get("kind"), doc.get("metadata", {}).get("name"))
+        if key in surfaces:
+            sys.stderr.write(f"duplicate rendered pod surface {key!r}\n")
+            sys.exit(1)
+        surfaces[key] = surface
+
+missing = sorted(set(expected) - set(surfaces))
+unexpected = sorted(set(surfaces) - set(expected))
+if missing or unexpected:
+    if missing:
+        sys.stderr.write(f"render is missing expected pod surfaces: {missing!r}\n")
+    if unexpected:
+        sys.stderr.write(f"render has unclassified pod surfaces: {unexpected!r}\n")
+    sys.exit(1)
+
+
+def wanted_placement(class_name):
+    return {
+        "label": class_name,
+        "annotation": class_name,
+        "nodeSelector": {"example.com/node-class": class_name},
+        "tolerations": [{
+            "key": "example.com/dedicated",
+            "operator": "Equal",
+            "value": class_name,
+            "effect": "NoSchedule",
+        }],
+        "affinity": {
+            "nodeAffinity": {
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                    "nodeSelectorTerms": [{
+                        "matchExpressions": [{
+                            "key": "example.com/node-class",
+                            "operator": "In",
+                            "values": [class_name],
+                        }],
+                    }],
+                },
+            },
+        },
+    }
+
+
+def assert_populated(key, surface, class_name):
+    metadata = surface.get("metadata", {}) or {}
+    spec = surface.get("spec", {}) or {}
+    labels = metadata.get("labels", {}) or {}
+    annotations = metadata.get("annotations", {}) or {}
+    want = wanted_placement(class_name)
+    got = {
+        "label": labels.get("example.com/fargate-profile"),
+        "annotation": annotations.get("example.com/placement"),
+        "nodeSelector": spec.get("nodeSelector"),
+        "tolerations": spec.get("tolerations"),
+        "affinity": spec.get("affinity"),
+    }
+    if got != want:
+        sys.stderr.write(
+            f"pod surface {key!r} has placement {got!r}, expected class "
+            f"{class_name!r} with placement {want!r}\n"
+        )
+        sys.exit(1)
+
+
+if mode == "populated":
+    for key, class_name in expected.items():
+        assert_populated(key, surfaces[key], class_name)
+    print(f"  ok: all {len(expected)} pod surfaces carry their exact populated placement class")
+elif mode == "default":
+    for key, surface in surfaces.items():
+        metadata = surface.get("metadata", {}) or {}
+        labels = metadata.get("labels", {}) or {}
+        annotations = metadata.get("annotations", {}) or {}
+        spec = surface.get("spec", {}) or {}
+        if "example.com/fargate-profile" in labels:
+            sys.stderr.write(f"default pod surface {key!r} unexpectedly has the placement marker label\n")
+            sys.exit(1)
+        if "example.com/placement" in annotations:
+            sys.stderr.write(f"default pod surface {key!r} unexpectedly has the placement marker annotation\n")
+            sys.exit(1)
+        present = [field for field in ("nodeSelector", "tolerations", "affinity") if field in spec]
+        if present:
+            sys.stderr.write(
+                f"default pod surface {key!r} unexpectedly has placement fields {present!r}\n"
+            )
+            sys.exit(1)
+    print(f"  ok: all {len(expected)} pod surfaces omit placement markers and scheduling fields by default")
+elif mode == "platform-only":
+    marker = "example.com/fargate-profile"
+    for key, class_name in expected.items():
+        labels = surfaces[key].get("metadata", {}).get("labels", {}) or {}
+        got = labels.get(marker)
+        if class_name == "platform" and got != "platform":
+            sys.stderr.write(
+                f"platform pod surface {key!r} has {marker}={got!r}, expected 'platform'\n"
+            )
+            sys.exit(1)
+        if class_name != "platform" and marker in labels:
+            sys.stderr.write(
+                f"unselected {class_name} pod surface {key!r} leaked platform marker {got!r}\n"
+            )
+            sys.exit(1)
+    print("  ok: the platform marker reaches only platform pods and is absent from data, sandbox, hooks, and controller pods")
+else:
+    sys.stderr.write(f"unknown placement check mode {mode!r}\n")
+    sys.exit(2)
+PYEOF
+
+# Enable every conditional pod surface so the expected inventory is exhaustive.
+PLACEMENT_HELM_ARGS=(
+  --set dispatcher.slack.appToken=xapp-placement-render
+  --set dispatcher.slack.botToken=xoxb-placement-render
+  --set inference.deploy=true
+  --set security.gvisor.mode=require
+)
+
+PLACEMENT_OUT="$(mktemp -d -p "$TMP")"
+helm template placement-render "$CHART" --output-dir "$PLACEMENT_OUT" \
+  -f "$PLACEMENT_VALUES" "${PLACEMENT_HELM_ARGS[@]}" > /dev/null
+python3 "$PLACEMENT_CHECK" "$PLACEMENT_OUT" populated \
+  || fail "populated placement classes did not reach every exact rendered pod surface."
+
+echo "=== Placement assertion 2: empty placement defaults preserve all pod surfaces ==="
+PLACEMENT_DEFAULT_OUT="$(mktemp -d -p "$TMP")"
+helm template placement-render "$CHART" --output-dir "$PLACEMENT_DEFAULT_OUT" \
+  "${PLACEMENT_HELM_ARGS[@]}" > /dev/null
+python3 "$PLACEMENT_CHECK" "$PLACEMENT_DEFAULT_OUT" default \
+  || fail "empty placement defaults changed rendered pod metadata or scheduling fields."
+
+echo "=== Placement assertion 3: a platform-only marker does not leak across classes ==="
+PLACEMENT_PLATFORM_ONLY="$TMP/placement-platform-only.yaml"
+cat > "$PLACEMENT_PLATFORM_ONLY" <<'YAMLEOF'
+placement:
+  platform:
+    podLabels:
+      example.com/fargate-profile: platform
+YAMLEOF
+PLACEMENT_PLATFORM_ONLY_OUT="$(mktemp -d -p "$TMP")"
+helm template placement-render "$CHART" --output-dir "$PLACEMENT_PLATFORM_ONLY_OUT" \
+  -f "$PLACEMENT_PLATFORM_ONLY" "${PLACEMENT_HELM_ARGS[@]}" > /dev/null
+python3 "$PLACEMENT_CHECK" "$PLACEMENT_PLATFORM_ONLY_OUT" platform-only \
+  || fail "the platform-only marker was absent from a platform pod or leaked into another placement class."
+
 echo "=== Assertion 12c: worker API URL and key wiring (#1529, #1578) ==="
 WORKER_API_CHECK="$TMP/check_worker_api.py"
 cat > "$WORKER_API_CHECK" <<'PYEOF'
@@ -950,4 +1260,4 @@ print(f"  ok: DATATIER_TARGETS includes {expected!r} and excludes {forbidden!r}"
 PYEOF
 
 echo
-echo "PASS: sealed render generates strong values for all 11 keys (encryptionKey 64-hex and Langfuse init credentials 32 alphanumeric); dev overlay keeps published defaults; explicit credential and OTel overrides win on the sealed path; default OTel Basic auth uses the resolved Langfuse project secret; every runner boot-env name is a declared contract key (proven by a failing negative control); every control-plane pod, the agent-sandbox controller, and the sandbox render with the expected priorityClassName, including under operator override; the runner SandboxTemplate opts the controller out of its own permissive NetworkPolicy whenever Rail 1 is on, and leaves it to the controller's default when Rail 1 is off; api.githubToken stays a plain pass-through (empty renders empty, an explicit value renders verbatim, and it is never generated), proven by a failing negative control; the worker renders exactly one API URL plus exactly one correctly sourced API key in default, connector enabled, release name, configured port, BYO API, and operator override cases; and the security probe uses the configured RustFS port in DATATIER_TARGETS."
+echo "PASS: sealed render generates strong values for all 11 keys (encryptionKey 64-hex and Langfuse init credentials 32 alphanumeric); dev overlay keeps published defaults; explicit credential and OTel overrides win on the sealed path; default OTel Basic auth uses the resolved Langfuse project secret; every runner boot-env name is a declared contract key (proven by a failing negative control); every control-plane pod, the agent-sandbox controller, and the sandbox render with the expected priorityClassName, including under operator override; the runner SandboxTemplate opts the controller out of its own permissive NetworkPolicy whenever Rail 1 is on, and leaves it to the controller's default when Rail 1 is off; api.githubToken stays a plain pass-through (empty renders empty, an explicit value renders verbatim, and it is never generated), proven by a failing negative control; every rendered pod surface receives its exact placement class while empty defaults omit placement fields and a platform-only label does not leak across classes; the worker renders exactly one API URL plus exactly one correctly sourced API key in default, connector enabled, release name, configured port, BYO API, and operator override cases; and the security probe uses the configured RustFS port in DATATIER_TARGETS."

--- a/charts/curie/templates/_helpers.tpl
+++ b/charts/curie/templates/_helpers.tpl
@@ -43,6 +43,33 @@ app.kubernetes.io/instance: {{ .root.Release.Name }}
 app.kubernetes.io/component: {{ .component }}
 {{- end -}}
 
+{{- define "curie.placement.labels" -}}
+{{- with .podLabels }}
+{{- toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{- define "curie.placement.annotations" -}}
+{{- with .annotations }}
+{{- toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{- define "curie.placement.spec" -}}
+{{- with .nodeSelector }}
+nodeSelector:
+{{- toYaml . | nindent 2 }}
+{{- end }}
+{{- with .tolerations }}
+tolerations:
+{{- toYaml . | nindent 2 }}
+{{- end }}
+{{- with .affinity }}
+affinity:
+{{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end -}}
+
 {{/* Secret name that carries all credential material. */}}
 {{- define "curie.secretName" -}}
 {{- printf "%s-secrets" (include "curie.fullname" .) -}}

--- a/charts/curie/templates/agent-sandbox.yaml
+++ b/charts/curie/templates/agent-sandbox.yaml
@@ -39,9 +39,25 @@ vendored file stays a static .Files.Get (not tpl-ed) and this value-dependent
 patch lives in the template layer alongside the #66 RBAC patch below.
 */}}
 {{- $controllerManifest := .Files.Get "files/agent-sandbox/controller.yaml" }}
-{{- with .Values.priorityClasses.platform.name }}
-{{- $controllerManifest = $controllerManifest | replace "      serviceAccountName: agent-sandbox-controller" (printf "      serviceAccountName: agent-sandbox-controller\n      priorityClassName: %s" .) }}
+{{- $controllerMetadataAnchor := "    metadata:\n      labels:\n        app: agent-sandbox-controller" }}
+{{- $controllerMetadata := "    metadata:\n      labels:" }}
+{{- with (include "curie.placement.labels" .Values.placement.controller) }}
+{{- $controllerMetadata = printf "%s\n%s" $controllerMetadata (indent 8 .) }}
 {{- end }}
+{{- $controllerMetadata = printf "%s\n        app: agent-sandbox-controller" $controllerMetadata }}
+{{- with (include "curie.placement.annotations" .Values.placement.controller) }}
+{{- $controllerMetadata = printf "%s\n      annotations:\n%s" $controllerMetadata (indent 8 .) }}
+{{- end }}
+{{- $controllerManifest = $controllerManifest | replace $controllerMetadataAnchor $controllerMetadata }}
+{{- $controllerServiceAccount := "      serviceAccountName: agent-sandbox-controller" }}
+{{- $controllerPodFields := $controllerServiceAccount }}
+{{- with .Values.priorityClasses.platform.name }}
+{{- $controllerPodFields = printf "%s\n      priorityClassName: %s" $controllerPodFields . }}
+{{- end }}
+{{- with (include "curie.placement.spec" .Values.placement.controller) }}
+{{- $controllerPodFields = printf "%s\n%s" $controllerPodFields (indent 6 .) }}
+{{- end }}
+{{- $controllerManifest = $controllerManifest | replace $controllerServiceAccount $controllerPodFields }}
 {{ $controllerManifest }}
 ---
 {{/*
@@ -172,11 +188,21 @@ spec:
   podTemplate:
     metadata:
       labels:
+        {{- with (include "curie.placement.labels" .Values.placement.sandbox) }}
+        {{- . | nindent 8 }}
+        {{- end }}
         {{- include "curie.selectorLabels" (dict "root" . "component" "runner-sandbox") | nindent 8 }}
         {{- if $agent }}
         curietech.ai/agent: {{ $agent | quote }}
         {{- end }}
+      {{- with (include "curie.placement.annotations" .Values.placement.sandbox) }}
+      annotations:
+        {{- . | nindent 8 }}
+      {{- end }}
     spec:
+      {{- with (include "curie.placement.spec" .Values.placement.sandbox) }}
+      {{- . | nindent 6 }}
+      {{- end }}
       {{- if $runner.serviceAccount.create }}
       serviceAccountName: {{ include "curie.fullname" . }}-runner
       automountServiceAccountToken: {{ $runner.serviceAccount.automountToken }}

--- a/charts/curie/templates/api.yaml
+++ b/charts/curie/templates/api.yaml
@@ -30,9 +30,19 @@ spec:
   template:
     metadata:
       labels:
+        {{- with (include "curie.placement.labels" .Values.placement.platform) }}
+        {{- . | nindent 8 }}
+        {{- end }}
         {{- include "curie.labels" . | nindent 8 }}
         {{- include "curie.selectorLabels" (dict "root" . "component" "api") | nindent 8 }}
+      {{- with (include "curie.placement.annotations" .Values.placement.platform) }}
+      annotations:
+        {{- . | nindent 8 }}
+      {{- end }}
     spec:
+      {{- with (include "curie.placement.spec" .Values.placement.platform) }}
+      {{- . | nindent 6 }}
+      {{- end }}
       # The runner-logs proxy lists pods and reads pod logs via the K8s API, so
       # the API pod runs as its own ServiceAccount (see api-rbac.yaml).
       serviceAccountName: {{ include "curie.fullname" . }}-api

--- a/charts/curie/templates/clickhouse.yaml
+++ b/charts/curie/templates/clickhouse.yaml
@@ -52,15 +52,24 @@ spec:
   template:
     metadata:
       annotations:
+        {{- with (include "curie.placement.annotations" .Values.placement.data) }}
+        {{- . | nindent 8 }}
+        {{- end }}
         # Roll the pod when the rendered logging overlay changes. Without this a
         # ConfigMap edit renders a new ConfigMap and the
         # running server keeps the old config until something else restarts it
         # -- i.e. the fix would appear applied while the node kept starving.
         checksum/config: {{ include "curie.clickhouse.loggingConfig" . | sha256sum }}
       labels:
+        {{- with (include "curie.placement.labels" .Values.placement.data) }}
+        {{- . | nindent 8 }}
+        {{- end }}
         {{- include "curie.labels" . | nindent 8 }}
         {{- include "curie.selectorLabels" (dict "root" . "component" "clickhouse") | nindent 8 }}
     spec:
+      {{- with (include "curie.placement.spec" .Values.placement.data) }}
+      {{- . | nindent 6 }}
+      {{- end }}
       {{- with .Values.priorityClasses.platform.name }}
       priorityClassName: {{ . }}
       {{- end }}

--- a/charts/curie/templates/dispatcher.yaml
+++ b/charts/curie/templates/dispatcher.yaml
@@ -22,9 +22,19 @@ spec:
   template:
     metadata:
       labels:
+        {{- with (include "curie.placement.labels" .Values.placement.platform) }}
+        {{- . | nindent 8 }}
+        {{- end }}
         {{- include "curie.labels" . | nindent 8 }}
         {{- include "curie.selectorLabels" (dict "root" . "component" "dispatcher") | nindent 8 }}
+      {{- with (include "curie.placement.annotations" .Values.placement.platform) }}
+      annotations:
+        {{- . | nindent 8 }}
+      {{- end }}
     spec:
+      {{- with (include "curie.placement.spec" .Values.placement.platform) }}
+      {{- . | nindent 6 }}
+      {{- end }}
       {{- with .Values.priorityClasses.platform.name }}
       priorityClassName: {{ . }}
       {{- end }}

--- a/charts/curie/templates/inference.yaml
+++ b/charts/curie/templates/inference.yaml
@@ -47,9 +47,19 @@ spec:
   template:
     metadata:
       labels:
+        {{- with (include "curie.placement.labels" .Values.placement.platform) }}
+        {{- . | nindent 8 }}
+        {{- end }}
         {{- include "curie.labels" . | nindent 8 }}
         {{- include "curie.selectorLabels" (dict "root" . "component" "inference") | nindent 8 }}
+      {{- with (include "curie.placement.annotations" .Values.placement.platform) }}
+      annotations:
+        {{- . | nindent 8 }}
+      {{- end }}
     spec:
+      {{- with (include "curie.placement.spec" .Values.placement.platform) }}
+      {{- . | nindent 6 }}
+      {{- end }}
       volumes:
         - name: ollama-data
           {{- if .Values.inference.persistence.enabled }}

--- a/charts/curie/templates/langfuse-model-pricing.yaml
+++ b/charts/curie/templates/langfuse-model-pricing.yaml
@@ -27,8 +27,18 @@ spec:
   template:
     metadata:
       labels:
+        {{- with (include "curie.placement.labels" .Values.placement.hooks) }}
+        {{- . | nindent 8 }}
+        {{- end }}
         {{- include "curie.selectorLabels" (dict "root" . "component" "langfuse-model-pricing") | nindent 8 }}
+      {{- with (include "curie.placement.annotations" .Values.placement.hooks) }}
+      annotations:
+        {{- . | nindent 8 }}
+      {{- end }}
     spec:
+      {{- with (include "curie.placement.spec" .Values.placement.hooks) }}
+      {{- . | nindent 6 }}
+      {{- end }}
       restartPolicy: Never
       containers:
         - name: model-pricing

--- a/charts/curie/templates/langfuse.yaml
+++ b/charts/curie/templates/langfuse.yaml
@@ -31,9 +31,19 @@ spec:
   template:
     metadata:
       labels:
+        {{- with (include "curie.placement.labels" .Values.placement.platform) }}
+        {{- . | nindent 8 }}
+        {{- end }}
         {{- include "curie.labels" . | nindent 8 }}
         {{- include "curie.selectorLabels" (dict "root" . "component" "langfuse-web") | nindent 8 }}
+      {{- with (include "curie.placement.annotations" .Values.placement.platform) }}
+      annotations:
+        {{- . | nindent 8 }}
+      {{- end }}
     spec:
+      {{- with (include "curie.placement.spec" .Values.placement.platform) }}
+      {{- . | nindent 6 }}
+      {{- end }}
       containers:
         - name: langfuse-web
           image: "{{ .Values.langfuse.image.web }}:{{ .Values.langfuse.image.tag }}"
@@ -116,9 +126,19 @@ spec:
   template:
     metadata:
       labels:
+        {{- with (include "curie.placement.labels" .Values.placement.platform) }}
+        {{- . | nindent 8 }}
+        {{- end }}
         {{- include "curie.labels" . | nindent 8 }}
         {{- include "curie.selectorLabels" (dict "root" . "component" "langfuse-worker") | nindent 8 }}
+      {{- with (include "curie.placement.annotations" .Values.placement.platform) }}
+      annotations:
+        {{- . | nindent 8 }}
+      {{- end }}
     spec:
+      {{- with (include "curie.placement.spec" .Values.placement.platform) }}
+      {{- . | nindent 6 }}
+      {{- end }}
       containers:
         - name: langfuse-worker
           image: "{{ .Values.langfuse.image.worker }}:{{ .Values.langfuse.image.tag }}"

--- a/charts/curie/templates/otel-collector.yaml
+++ b/charts/curie/templates/otel-collector.yaml
@@ -40,11 +40,20 @@ spec:
   template:
     metadata:
       annotations:
+        {{- with (include "curie.placement.annotations" .Values.placement.platform) }}
+        {{- . | nindent 8 }}
+        {{- end }}
         checksum/config: {{ printf "%s|%s" (include "curie.otelCollector.config" .) (include "curie.otlpAuthHeader" .) | sha256sum }}
       labels:
+        {{- with (include "curie.placement.labels" .Values.placement.platform) }}
+        {{- . | nindent 8 }}
+        {{- end }}
         {{- include "curie.labels" . | nindent 8 }}
         {{- include "curie.selectorLabels" (dict "root" . "component" "otel-collector") | nindent 8 }}
     spec:
+      {{- with (include "curie.placement.spec" .Values.placement.platform) }}
+      {{- . | nindent 6 }}
+      {{- end }}
       volumes:
         - name: config
           configMap:

--- a/charts/curie/templates/postgres.yaml
+++ b/charts/curie/templates/postgres.yaml
@@ -29,9 +29,19 @@ spec:
   template:
     metadata:
       labels:
+        {{- with (include "curie.placement.labels" .Values.placement.data) }}
+        {{- . | nindent 8 }}
+        {{- end }}
         {{- include "curie.labels" . | nindent 8 }}
         {{- include "curie.selectorLabels" (dict "root" . "component" "postgres") | nindent 8 }}
+      {{- with (include "curie.placement.annotations" .Values.placement.data) }}
+      annotations:
+        {{- . | nindent 8 }}
+      {{- end }}
     spec:
+      {{- with (include "curie.placement.spec" .Values.placement.data) }}
+      {{- . | nindent 6 }}
+      {{- end }}
       {{- with .Values.priorityClasses.platform.name }}
       priorityClassName: {{ . }}
       {{- end }}

--- a/charts/curie/templates/preflight-avx.yaml
+++ b/charts/curie/templates/preflight-avx.yaml
@@ -28,8 +28,18 @@ spec:
   template:
     metadata:
       labels:
+        {{- with (include "curie.placement.labels" .Values.placement.hooks) }}
+        {{- . | nindent 8 }}
+        {{- end }}
         {{- include "curie.selectorLabels" (dict "root" . "component" "preflight-avx") | nindent 8 }}
+      {{- with (include "curie.placement.annotations" .Values.placement.hooks) }}
+      annotations:
+        {{- . | nindent 8 }}
+      {{- end }}
     spec:
+      {{- with (include "curie.placement.spec" .Values.placement.hooks) }}
+      {{- . | nindent 6 }}
+      {{- end }}
       restartPolicy: Never
       containers:
         - name: avx-check

--- a/charts/curie/templates/preflight-controller.yaml
+++ b/charts/curie/templates/preflight-controller.yaml
@@ -85,9 +85,19 @@ spec:
   template:
     metadata:
       labels:
+        {{- with (include "curie.placement.labels" .Values.placement.hooks) }}
+        {{- . | nindent 8 }}
+        {{- end }}
         {{- include "curie.labels" . | nindent 8 }}
         {{- include "curie.selectorLabels" (dict "root" . "component" "preflight-controller") | nindent 8 }}
+      {{- with (include "curie.placement.annotations" .Values.placement.hooks) }}
+      annotations:
+        {{- . | nindent 8 }}
+      {{- end }}
     spec:
+      {{- with (include "curie.placement.spec" .Values.placement.hooks) }}
+      {{- . | nindent 6 }}
+      {{- end }}
       serviceAccountName: {{ include "curie.fullname" . }}-preflight-controller
       restartPolicy: Never
       containers:

--- a/charts/curie/templates/preflight-gvisor.yaml
+++ b/charts/curie/templates/preflight-gvisor.yaml
@@ -45,8 +45,18 @@ spec:
   template:
     metadata:
       labels:
+        {{- with (include "curie.placement.labels" .Values.placement.hooks) }}
+        {{- . | nindent 8 }}
+        {{- end }}
         {{- include "curie.selectorLabels" (dict "root" . "component" "preflight-gvisor") | nindent 8 }}
+      {{- with (include "curie.placement.annotations" .Values.placement.hooks) }}
+      annotations:
+        {{- . | nindent 8 }}
+      {{- end }}
     spec:
+      {{- with (include "curie.placement.spec" .Values.placement.hooks) }}
+      {{- . | nindent 6 }}
+      {{- end }}
       restartPolicy: Never
       runtimeClassName: {{ $gvisorClass }}
       containers:

--- a/charts/curie/templates/preflight-networkpolicy.yaml
+++ b/charts/curie/templates/preflight-networkpolicy.yaml
@@ -81,9 +81,19 @@ spec:
   template:
     metadata:
       labels:
+        {{- with (include "curie.placement.labels" .Values.placement.hooks) }}
+        {{- . | nindent 8 }}
+        {{- end }}
         {{- include "curie.labels" . | nindent 8 }}
         {{- include "curie.selectorLabels" (dict "root" . "component" "netpol-probe") | nindent 8 }}
+      {{- with (include "curie.placement.annotations" .Values.placement.hooks) }}
+      annotations:
+        {{- . | nindent 8 }}
+      {{- end }}
     spec:
+      {{- with (include "curie.placement.spec" .Values.placement.hooks) }}
+      {{- . | nindent 6 }}
+      {{- end }}
       serviceAccountName: {{ include "curie.fullname" . }}-netpol-probe
       restartPolicy: Never
       containers:

--- a/charts/curie/templates/runner-prewarm.yaml
+++ b/charts/curie/templates/runner-prewarm.yaml
@@ -37,14 +37,23 @@ spec:
   template:
     metadata:
       labels:
+        {{- with (include "curie.placement.labels" .Values.placement.sandbox) }}
+        {{- . | nindent 8 }}
+        {{- end }}
         {{- include "curie.labels" . | nindent 8 }}
         {{- include "curie.selectorLabels" (dict "root" . "component" "runner-prewarm") | nindent 8 }}
       annotations:
+        {{- with (include "curie.placement.annotations" .Values.placement.sandbox) }}
+        {{- . | nindent 8 }}
+        {{- end }}
         # Rolls the prewarm pods on every `helm upgrade` so imagePullPolicy Always
         # re-pulls a churned `latest` (a digest-only change does not otherwise
         # alter the pod spec). See the file header.
         curietech.ai/prewarm-revision: {{ .Release.Revision | quote }}
     spec:
+      {{- with (include "curie.placement.spec" .Values.placement.sandbox) }}
+      {{- . | nindent 6 }}
+      {{- end }}
       {{- with $runner.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/curie/templates/rustfs.yaml
+++ b/charts/curie/templates/rustfs.yaml
@@ -31,9 +31,19 @@ spec:
   template:
     metadata:
       labels:
+        {{- with (include "curie.placement.labels" .Values.placement.data) }}
+        {{- . | nindent 8 }}
+        {{- end }}
         {{- include "curie.labels" . | nindent 8 }}
         {{- include "curie.selectorLabels" (dict "root" . "component" "rustfs") | nindent 8 }}
+      {{- with (include "curie.placement.annotations" .Values.placement.data) }}
+      annotations:
+        {{- . | nindent 8 }}
+      {{- end }}
     spec:
+      {{- with (include "curie.placement.spec" .Values.placement.data) }}
+      {{- . | nindent 6 }}
+      {{- end }}
       {{- with .Values.priorityClasses.platform.name }}
       priorityClassName: {{ . }}
       {{- end }}
@@ -123,8 +133,18 @@ spec:
   template:
     metadata:
       labels:
+        {{- with (include "curie.placement.labels" .Values.placement.hooks) }}
+        {{- . | nindent 8 }}
+        {{- end }}
         {{- include "curie.selectorLabels" (dict "root" . "component" "rustfs-init") | nindent 8 }}
+      {{- with (include "curie.placement.annotations" .Values.placement.hooks) }}
+      annotations:
+        {{- . | nindent 8 }}
+      {{- end }}
     spec:
+      {{- with (include "curie.placement.spec" .Values.placement.hooks) }}
+      {{- . | nindent 6 }}
+      {{- end }}
       restartPolicy: OnFailure
       containers:
         - name: aws-cli

--- a/charts/curie/templates/security-probe.yaml
+++ b/charts/curie/templates/security-probe.yaml
@@ -103,12 +103,21 @@ kind: Pod
 metadata:
   name: {{ include "curie.fullname" . }}-security-probe-hardening
   labels:
+    {{- with (include "curie.placement.labels" .Values.placement.hooks) }}
+    {{- . | nindent 4 }}
+    {{- end }}
     {{- include "curie.labels" . | nindent 4 }}
   annotations:
+    {{- with (include "curie.placement.annotations" .Values.placement.hooks) }}
+    {{- . | nindent 4 }}
+    {{- end }}
     "helm.sh/hook": test
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": before-hook-creation
 spec:
+  {{- with (include "curie.placement.spec" .Values.placement.hooks) }}
+  {{- . | nindent 2 }}
+  {{- end }}
   restartPolicy: Never
   securityContext:
     runAsNonRoot: true
@@ -181,8 +190,18 @@ spec:
   template:
     metadata:
       labels:
+        {{- with (include "curie.placement.labels" .Values.placement.hooks) }}
+        {{- . | nindent 8 }}
+        {{- end }}
         {{- include "curie.selectorLabels" (dict "root" . "component" "security-probe") | nindent 8 }}
+      {{- with (include "curie.placement.annotations" .Values.placement.hooks) }}
+      annotations:
+        {{- . | nindent 8 }}
+      {{- end }}
     spec:
+      {{- with (include "curie.placement.spec" .Values.placement.hooks) }}
+      {{- . | nindent 6 }}
+      {{- end }}
       serviceAccountName: {{ include "curie.fullname" . }}-security-probe
       restartPolicy: Never
       containers:

--- a/charts/curie/templates/ui.yaml
+++ b/charts/curie/templates/ui.yaml
@@ -35,9 +35,19 @@ spec:
   template:
     metadata:
       labels:
+        {{- with (include "curie.placement.labels" .Values.placement.platform) }}
+        {{- . | nindent 8 }}
+        {{- end }}
         {{- include "curie.labels" . | nindent 8 }}
         {{- include "curie.selectorLabels" (dict "root" . "component" "ui") | nindent 8 }}
+      {{- with (include "curie.placement.annotations" .Values.placement.platform) }}
+      annotations:
+        {{- . | nindent 8 }}
+      {{- end }}
     spec:
+      {{- with (include "curie.placement.spec" .Values.placement.platform) }}
+      {{- . | nindent 6 }}
+      {{- end }}
       {{- with .Values.ui.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/curie/templates/valkey.yaml
+++ b/charts/curie/templates/valkey.yaml
@@ -29,9 +29,19 @@ spec:
   template:
     metadata:
       labels:
+        {{- with (include "curie.placement.labels" .Values.placement.data) }}
+        {{- . | nindent 8 }}
+        {{- end }}
         {{- include "curie.labels" . | nindent 8 }}
         {{- include "curie.selectorLabels" (dict "root" . "component" "valkey") | nindent 8 }}
+      {{- with (include "curie.placement.annotations" .Values.placement.data) }}
+      annotations:
+        {{- . | nindent 8 }}
+      {{- end }}
     spec:
+      {{- with (include "curie.placement.spec" .Values.placement.data) }}
+      {{- . | nindent 6 }}
+      {{- end }}
       {{- with .Values.priorityClasses.platform.name }}
       priorityClassName: {{ . }}
       {{- end }}

--- a/charts/curie/templates/worker.yaml
+++ b/charts/curie/templates/worker.yaml
@@ -101,6 +101,9 @@ spec:
   template:
     metadata:
       annotations:
+        {{- with (include "curie.placement.annotations" .Values.placement.platform) }}
+        {{- . | nindent 8 }}
+        {{- end }}
         # Roll the workers when the per-adapter egress credentials change
         # (ADR-0096 D4.2). They arrive as env from the chart Secret, and env is
         # read once at boot, so a `helm upgrade` that rotates a compromised
@@ -112,9 +115,15 @@ spec:
         # on any unrelated credential change in it.
         checksum/adapter-credentials: {{ .Values.worker.adapterCredentials | toJson | sha256sum }}
       labels:
+        {{- with (include "curie.placement.labels" .Values.placement.platform) }}
+        {{- . | nindent 8 }}
+        {{- end }}
         {{- include "curie.labels" . | nindent 8 }}
         {{- include "curie.selectorLabels" (dict "root" . "component" "worker") | nindent 8 }}
     spec:
+      {{- with (include "curie.placement.spec" .Values.placement.platform) }}
+      {{- . | nindent 6 }}
+      {{- end }}
       terminationGracePeriodSeconds: {{ .Values.worker.terminationGracePeriodSeconds }}
       {{- if .Values.worker.serviceAccount.create }}
       serviceAccountName: {{ include "curie.fullname" . }}-worker

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -24,6 +24,42 @@ global:
   # on k3s, gp3 on EKS).
   storageClass: ""
 
+# Named placement classes map to platform services, data stores, sandbox pods
+# and prewarm, Helm hooks, and the sandbox controller, respectively.
+# podLabels can drive platform selectors. nodeSelector, tolerations, and
+# affinity remain generic Kubernetes placement fields for any substrate.
+placement:
+  platform:
+    podLabels: {}
+    annotations: {}
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}
+  data:
+    podLabels: {}
+    annotations: {}
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}
+  sandbox:
+    podLabels: {}
+    annotations: {}
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}
+  hooks:
+    podLabels: {}
+    annotations: {}
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}
+  controller:
+    podLabels: {}
+    annotations: {}
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}
+
 # ---------------------------------------------------------------------------
 # PriorityClass (ADR-0059 decision 5): ranks the control plane -- worker, api,
 # dispatcher, and the data tier (postgres, valkey, clickhouse, rustfs) -- above


### PR DESCRIPTION
## Summary

* Add substrate neutral platform, data, sandbox, hooks, and controller placement classes.
* Apply pod labels, annotations, node selectors, tolerations, and affinity to all 23 rendered pod surfaces.
* Preserve existing default renders, PriorityClasses, security, gVisor, resources, and sandbox controller behavior.

## Evidence

* Focused render assertions passed for all 23 surfaces and all five fields.
* The negative render proved a platform selector label is absent from data, sandbox, hooks, and controller pods.
* All chart assertion scripts passed. All three Helm lint inputs passed. Kubeconform validated 78, 44, and 44 core resources with zero invalid resources.
* Chart runtime E2E passed on context k8 in namespace test chart placement seam. Both init containers completed, the bundle was visible, credential files were absent, and cleanup verified the namespace and test named cluster scope artifacts were absent.
* Commit message checks passed, including the self test.

## Workflow checks

[x] Failing behavior coverage was committed before implementation.
[x] Production edits were performed in a separate fresh implementation context.
[x] Independent code and scope reviews approved the complete branch diff.
[x] Every rendered pod sibling surface is classified and covered.
[x] No gate, validator, denylist, or preflight behavior changed.
[x] Consolidation found no worthwhile simplification beyond the shared helpers.
[x] Security review is not applicable because auth, permissions, secrets, and isolation behavior are unchanged.
[x] Observable render and runtime verification passed.
[x] Full affected chart validation passed.