### PR TITLE
Install self observing SRE bot stack

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -407,7 +407,7 @@ jobs:
   # Build the first-party images on every PR/push -- build only, never push --
   # so a Dockerfile break is caught here instead of only at release time. This
   # mirrors release.yaml's build step (same contexts, same pinned actions, same
-  # gha layer cache) minus the registry login and push. All five app images
+  # gha layer cache) minus the registry login and push. All six images
   # build from public bases (python/node/nginx), so no GHCR credentials are
   # needed; the worker-local overlay is handled separately below.
   images:
@@ -418,15 +418,23 @@ jobs:
       matrix:
         include:
           - name: runner
+            context: .
             dockerfile: runner/Dockerfile
           - name: api
+            context: .
             dockerfile: apps/api/Dockerfile
           - name: dispatcher
+            context: .
             dockerfile: apps/dispatcher/Dockerfile
           - name: worker
+            context: .
             dockerfile: apps/worker/Dockerfile
           - name: ui
+            context: .
             dockerfile: apps/ui/Dockerfile
+          - name: sre-bot-tempo
+            context: examples/sre-bot/connectors/tempo
+            dockerfile: examples/sre-bot/connectors/tempo/Dockerfile
     steps:
       - uses: actions/checkout@v7
         with:
@@ -436,7 +444,7 @@ jobs:
       - name: Build (no push)
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
-          context: .
+          context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
           push: false
           load: false

--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -13,6 +13,7 @@ on:
     branches: [main, next]
     paths:
       - "charts/curie/**"
+      - "examples/sre-bot/observability/**"
       - ".github/workflows/helm-ci.yaml"
       # The object-store web-identity gate below EXECUTES these repository
       # files, so a change to one of them can break the gate without touching
@@ -139,6 +140,11 @@ jobs:
         run: |
           set -euo pipefail
           bash charts/curie/ci/otel-collector-checksum-assertions.sh
+
+      - name: helm render assertions (SRE bot observability stack)
+        run: |
+          set -euo pipefail
+          bash charts/curie/ci/observability-stack-assertions.sh
 
       # Prove the collector's Langfuse credential and the Secret that carries it
       # stay the same decision (issue #1563): under `langfuse.existingSecret` the

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -106,19 +106,27 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        name: [runner, api, dispatcher, worker, ui]
+        name: [runner, api, dispatcher, worker, ui, sre-bot-tempo]
         platform: [linux/amd64, linux/arm64]
         include:
           - name: runner
+            context: .
             dockerfile: runner/Dockerfile
           - name: api
+            context: .
             dockerfile: apps/api/Dockerfile
           - name: dispatcher
+            context: .
             dockerfile: apps/dispatcher/Dockerfile
           - name: worker
+            context: .
             dockerfile: apps/worker/Dockerfile
           - name: ui
+            context: .
             dockerfile: apps/ui/Dockerfile
+          - name: sre-bot-tempo
+            context: examples/sre-bot/connectors/tempo
+            dockerfile: examples/sre-bot/connectors/tempo/Dockerfile
           - platform: linux/amd64
             runner: ubuntu-latest
             arch: amd64
@@ -177,7 +185,7 @@ jobs:
         id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
-          context: .
+          context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -215,7 +223,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        name: [runner, api, dispatcher, worker, ui]
+        name: [runner, api, dispatcher, worker, ui, sre-bot-tempo]
     steps:
       - name: Download digests
         id: download_digests

--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -3840,6 +3840,59 @@ export const commandManifest = {
       ]
     },
     {
+      "about": "Install a complete first party example workflow",
+      "hidden": false,
+      "name": "example",
+      "subcommands": [
+        {
+          "about": "Install the self referential SRE bot example",
+          "hidden": false,
+          "name": "sre-bot",
+          "subcommands": [
+            {
+              "about": "Install Curie, its observability stack, and the SRE bot bundle",
+              "args": [
+                {
+                  "global": false,
+                  "help": "Install the fixed self referential Grafana, Loki, Alloy, Tempo, and Prometheus stack",
+                  "id": "observability",
+                  "long": "observability",
+                  "positional": false,
+                  "possible_values": [
+                    "true",
+                    "false"
+                  ],
+                  "required": true
+                },
+                {
+                  "global": false,
+                  "help": "Print the ordered plan without mutating the cluster",
+                  "id": "dry_run",
+                  "long": "dry-run",
+                  "positional": false,
+                  "possible_values": [
+                    "true",
+                    "false"
+                  ],
+                  "required": false
+                },
+                {
+                  "global": false,
+                  "help": "Bind the installed bot to this Slack channel",
+                  "id": "slack_channel",
+                  "long": "slack-channel",
+                  "positional": false,
+                  "required": false
+                }
+              ],
+              "hidden": false,
+              "name": "install"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "about": "List locally-authored agent bundles under `agents/` (source checkout only) -- a personal, gitignored directory (sibling of `examples/`) for in-progress agent projects ready to hand to `deploy-local`. Empty, not an error, when the directory doesn't exist",
       "hidden": false,
       "name": "list-agents"

--- a/charts/curie/README.md
+++ b/charts/curie/README.md
@@ -150,6 +150,27 @@ App services emit OTLP (OpenTelemetry Protocol) to the **collector**, never
 straight to Langfuse (Langfuse OTLP ingest is HTTP-only): `curie-otel-collector:4317` (gRPC) /
 `:4318` (HTTP). The collector forwards to Langfuse over HTTP.
 
+Additional trace destinations are configured through
+`otelCollector.extraExporters`, a map of exporter names to collector exporter
+configuration, and `otelCollector.extraPipelineExporters`, an ordered list of
+those names. The map is rendered under `exporters` and the list is appended to
+the traces pipeline; built-in `otlphttp/langfuse` and `debug` exporters may
+also be named. Helm fails with the missing exporter name if a pipeline entry is
+undefined. For example, this adds a Tempo exporter:
+
+```yaml
+otelCollector:
+  extraExporters:
+    otlp/tempo:
+      endpoint: tempo:4317
+      tls:
+        insecure: true
+  extraPipelineExporters: [otlp/tempo]
+```
+
+Changes to either value roll the collector Deployment through its config
+checksum, so the configured pipeline is applied on `helm upgrade`.
+
 ## Components
 
 | Component | Image | Notes |

--- a/charts/curie/ci/observability-stack-assertions.sh
+++ b/charts/curie/ci/observability-stack-assertions.sh
@@ -1,0 +1,630 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$CHART/../.." && pwd)"
+ASSETS="$REPO_ROOT/examples/sre-bot/observability"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+required_assets=(
+  grafana-values.yaml
+  loki-values.yaml
+  alloy-values.yaml
+  prometheus-values.yaml
+  tempo.yaml
+  curie-values.yaml
+)
+for asset in "${required_assets[@]}"; do
+  [[ -f "$ASSETS/$asset" ]] || fail "missing canonical installer asset $ASSETS/$asset"
+done
+
+# Keep repository state untouched while Helm downloads the exact upstream pins.
+export HELM_CACHE_HOME="$TMP/helm/cache"
+export HELM_CONFIG_HOME="$TMP/helm/config"
+export HELM_DATA_HOME="$TMP/helm/data"
+helm repo add grafana-community https://grafana-community.github.io/helm-charts >/dev/null
+helm repo add grafana https://grafana.github.io/helm-charts >/dev/null
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts >/dev/null
+helm repo update >/dev/null
+
+# These release names are part of the migration contract. In particular, Grafana
+# must upgrade the existing grafana release so its PVC and service account remain.
+helm template grafana grafana-community/grafana \
+  --version 12.11.1 \
+  --namespace observability \
+  -f "$ASSETS/grafana-values.yaml" >"$TMP/grafana.yaml"
+helm template loki grafana-community/loki \
+  --version 18.10.1 \
+  --namespace observability \
+  -f "$ASSETS/loki-values.yaml" >"$TMP/loki.yaml"
+helm template alloy grafana/alloy \
+  --version 1.11.1 \
+  --namespace observability \
+  -f "$ASSETS/alloy-values.yaml" >"$TMP/alloy.yaml"
+helm template prometheus prometheus-community/prometheus \
+  --version 29.27.0 \
+  --namespace observability \
+  -f "$ASSETS/prometheus-values.yaml" >"$TMP/prometheus.yaml"
+
+helm template curie "$CHART" \
+  --namespace curie \
+  -f "$ASSETS/curie-values.yaml" >"$TMP/curie-install.yaml"
+helm template curie "$CHART" \
+  --namespace curie \
+  --is-upgrade \
+  -f "$ASSETS/curie-values.yaml" >"$TMP/curie-upgrade.yaml"
+helm template curie "$CHART" --namespace curie >"$TMP/curie-default.yaml"
+
+python3 - \
+  "$ASSETS" \
+  "$CHART" \
+  "$TMP/grafana.yaml" \
+  "$TMP/loki.yaml" \
+  "$TMP/alloy.yaml" \
+  "$TMP/prometheus.yaml" \
+  "$ASSETS/tempo.yaml" \
+  "$TMP/curie-install.yaml" \
+  "$TMP/curie-upgrade.yaml" \
+  "$TMP/curie-default.yaml" \
+  "${OBSERVABILITY_ASSERTION_MUTATION:-}" <<'PY'
+import base64
+from decimal import Decimal
+from pathlib import Path
+import re
+import sys
+
+import yaml
+
+(
+    assets_path,
+    chart_path,
+    grafana_path,
+    loki_path,
+    alloy_path,
+    prometheus_path,
+    tempo_path,
+    curie_install_path,
+    curie_upgrade_path,
+    curie_default_path,
+    mutation,
+) = sys.argv[1:]
+assert mutation in {
+    "",
+    "loki-cache",
+    "tempo-image",
+    "tempo-exporter",
+    "cleanup-tag",
+    "delete-hook",
+    "token-cleanup",
+    "token-data",
+    "updater-tag",
+    "viewer-role",
+    "rotation-restart",
+    "restart-scope",
+}, f"unknown mutation {mutation!r}"
+
+assets = Path(assets_path)
+chart = Path(chart_path)
+
+
+def load_one(path):
+    return yaml.safe_load(Path(path).read_text())
+
+
+def load_docs(path):
+    result = []
+    for doc in yaml.safe_load_all(Path(path).read_text()):
+        if not doc:
+            continue
+        if doc.get("kind") == "List":
+            result.extend(doc.get("items", []))
+        else:
+            result.append(doc)
+    return result
+
+
+def at(value, *keys):
+    for key in keys:
+        assert isinstance(value, dict) and key in value, (
+            f"{'.'.join(keys)} is missing at {key!r}"
+        )
+        value = value[key]
+    return value
+
+
+def assert_quantity(actual, expected, label):
+    assert str(actual) == expected, f"{label}: expected {expected}, got {actual}"
+
+
+def memory_mi(quantity):
+    text = str(quantity)
+    match = re.fullmatch(r"([0-9]+(?:\.[0-9]+)?)([KMGTE]i)?", text)
+    assert match, f"unsupported memory quantity {text!r}"
+    amount = Decimal(match.group(1))
+    unit = match.group(2) or ""
+    factors = {"": Decimal(1) / (1024 * 1024), "Ki": Decimal(1) / 1024,
+               "Mi": Decimal(1), "Gi": Decimal(1024), "Ti": Decimal(1024**2)}
+    return amount * factors[unit]
+
+
+def pod_specs(docs):
+    for doc in docs:
+        kind = doc.get("kind")
+        spec = doc.get("spec", {})
+        if kind in {"Deployment", "DaemonSet", "StatefulSet", "ReplicaSet", "Job"}:
+            yield doc, spec.get("template", {}).get("spec", {})
+        elif kind == "Pod":
+            yield doc, spec
+
+
+def containers(docs):
+    for doc, pod_spec in pod_specs(docs):
+        for container in pod_spec.get("containers", []):
+            yield doc, pod_spec, container
+
+
+def image_container(docs, fragment, label):
+    matches = [item for item in containers(docs) if fragment in str(item[2].get("image", ""))]
+    assert len(matches) == 1, f"expected one {label} container, found {len(matches)}"
+    return matches[0]
+
+
+def embedded_yaml(docs):
+    for doc in docs:
+        if doc.get("kind") not in {"ConfigMap", "Secret"}:
+            continue
+        for field in ("data", "stringData"):
+            for key, value in (doc.get(field) or {}).items():
+                if not isinstance(value, str):
+                    continue
+                candidate = value
+                if field == "data" and doc.get("kind") == "Secret":
+                    try:
+                        candidate = base64.b64decode(value, validate=True).decode()
+                    except Exception:
+                        pass
+                try:
+                    parsed = yaml.safe_load(candidate)
+                except yaml.YAMLError:
+                    continue
+                if isinstance(parsed, (dict, list)):
+                    yield doc, key, parsed, candidate
+
+
+def find_nested_dicts(value, key):
+    if isinstance(value, dict):
+        if key in value:
+            yield value[key]
+        for child in value.values():
+            yield from find_nested_dicts(child, key)
+    elif isinstance(value, list):
+        for child in value:
+            yield from find_nested_dicts(child, key)
+
+
+def hook_annotations(doc):
+    return str(doc.get("metadata", {}).get("annotations", {}).get("helm.sh/hook", ""))
+
+
+def storage_requests(docs):
+    requests = []
+    for doc in docs:
+        if doc.get("kind") == "PersistentVolumeClaim":
+            requests.append(at(doc, "spec", "resources", "requests", "storage"))
+        if doc.get("kind") == "StatefulSet":
+            for claim in doc.get("spec", {}).get("volumeClaimTemplates", []):
+                requests.append(at(claim, "spec", "resources", "requests", "storage"))
+    return requests
+
+
+grafana_values = load_one(assets / "grafana-values.yaml")
+loki_values = load_one(assets / "loki-values.yaml")
+alloy_values = load_one(assets / "alloy-values.yaml")
+prometheus_values = load_one(assets / "prometheus-values.yaml")
+curie_values = load_one(assets / "curie-values.yaml")
+
+assert at(grafana_values, "image", "tag") == "13.2.0"
+assert at(grafana_values, "admin", "existingSecret") == "grafana-admin"
+assert at(grafana_values, "admin", "userKey") == "admin-user"
+assert at(grafana_values, "admin", "passwordKey") == "admin-password"
+assert at(grafana_values, "persistence", "enabled") is True
+assert_quantity(at(grafana_values, "persistence", "size"), "2Gi", "Grafana PVC")
+assert at(grafana_values, "persistence", "storageClassName") == "local-path"
+assert at(grafana_values, "testFramework", "enabled") is False
+
+assert at(loki_values, "deploymentMode") == "SingleBinary"
+for component in ("chunksCache", "resultsCache", "gateway", "lokiCanary", "test"):
+    if mutation == "loki-cache" and component == "chunksCache":
+        loki_values[component]["enabled"] = True
+    assert at(loki_values, component, "enabled") is False, f"Loki {component} must be disabled"
+assert at(loki_values, "singleBinary", "replicas") == 1
+assert at(loki_values, "read", "replicas") == 0
+assert at(loki_values, "write", "replicas") == 0
+assert at(loki_values, "backend", "replicas") == 0
+assert at(loki_values, "loki", "storage", "type") == "filesystem"
+assert_quantity(at(loki_values, "singleBinary", "persistence", "size"), "10Gi", "Loki PVC")
+assert at(loki_values, "singleBinary", "persistence", "storageClass") == "local-path"
+assert at(loki_values, "loki", "ingester", "wal", "replay_memory_ceiling") == "512MB"
+disk_threshold = at(loki_values, "loki", "ingester", "wal", "disk_full_threshold")
+assert disk_threshold, "Loki 3.7 disk_full_threshold must be set"
+
+assert at(alloy_values, "controller", "type") == "daemonset"
+assert at(alloy_values, "alloy", "storagePath") == "/var/lib/alloy/data"
+host_paths = [
+    volume.get("hostPath", {}).get("path")
+    for volume in at(alloy_values, "controller", "volumes", "extra")
+]
+assert "/var/lib/alloy" in host_paths, "Alloy positions must use durable hostPath storage"
+alloy_content = at(alloy_values, "alloy", "configMap", "content")
+assert "stage.cri" in alloy_content, "Alloy must parse containerd CRI log lines"
+assert "/var/log/pods/" in alloy_content, "Alloy must discover Kubernetes pod logs"
+
+assert at(prometheus_values, "alertmanager", "enabled") is False
+assert at(prometheus_values, "prometheus-pushgateway", "enabled") is False
+assert at(prometheus_values, "configmapReload", "prometheus", "enabled") is False
+assert_quantity(at(prometheus_values, "server", "persistentVolume", "size"), "8Gi", "Prometheus PVC")
+assert at(prometheus_values, "server", "persistentVolume", "storageClass") == "local-path"
+
+grafana_docs = load_docs(grafana_path)
+loki_docs = load_docs(loki_path)
+alloy_docs = load_docs(alloy_path)
+prometheus_docs = load_docs(prometheus_path)
+tempo_docs = load_docs(tempo_path)
+curie_install_docs = load_docs(curie_install_path)
+curie_upgrade_docs = load_docs(curie_upgrade_path)
+curie_default_docs = load_docs(curie_default_path)
+
+expected_requests = {
+    "Grafana": (grafana_docs, "grafana/grafana", Decimal(128)),
+    "Loki": (loki_docs, "grafana/loki", Decimal(256)),
+    "Alloy": (alloy_docs, "grafana/alloy", Decimal(128)),
+    "Tempo": (tempo_docs, "grafana/tempo", Decimal(192)),
+    "Prometheus": (prometheus_docs, "prometheus/prometheus", Decimal(512)),
+    "kube-state-metrics": (prometheus_docs, "kube-state-metrics", Decimal(64)),
+    "node-exporter": (prometheus_docs, "node-exporter", Decimal(32)),
+}
+request_total = Decimal(0)
+for label, (docs, image, expected) in expected_requests.items():
+    _, _, container = image_container(docs, image, label)
+    actual = memory_mi(at(container, "resources", "requests", "memory"))
+    assert actual == expected, f"{label} request must be {expected}Mi, got {actual}Mi"
+    request_total += actual
+assert request_total == 1312, f"observability request total must be 1312Mi, got {request_total}Mi"
+
+# The chart image itself closes the Loki config and image version contract.
+_, _, loki_container = image_container(loki_docs, "grafana/loki", "Loki")
+loki_image = str(loki_container["image"])
+assert re.search(r":(?:v)?3\.7(?:\.|$)", loki_image), f"Loki image must be 3.7.x, got {loki_image}"
+loki_configs = []
+for _, _, parsed, _ in embedded_yaml(loki_docs):
+    if isinstance(parsed, dict) and "ingester" in parsed and "schema_config" in parsed:
+        loki_configs.append(parsed)
+assert len(loki_configs) == 1, f"expected one rendered Loki config, found {len(loki_configs)}"
+rendered_wal = at(loki_configs[0], "ingester", "wal")
+assert rendered_wal.get("disk_full_threshold") == disk_threshold
+assert rendered_wal.get("replay_memory_ceiling") == "512MB"
+assert sum(1 for value in find_nested_dicts(loki_configs[0], "disk_full_threshold")) == 1, (
+    "disk_full_threshold must render exactly once at ingester.wal"
+)
+
+# Absence is checked in rendered output as well as values, preventing an enabled
+# default from silently returning under a new chart value path.
+loki_render = Path(loki_path).read_text().lower()
+for forbidden in ("chunks-cache", "chunkscache", "results-cache", "resultscache", "gateway", "canary", "helm-test"):
+    assert forbidden not in loki_render, f"disabled Loki component {forbidden!r} rendered"
+
+grafana_pvcs = [doc for doc in grafana_docs if doc.get("kind") == "PersistentVolumeClaim"]
+assert grafana_pvcs, "Grafana must render a persistent PVC"
+assert any(at(doc, "spec", "resources", "requests", "storage") == "2Gi" for doc in grafana_pvcs)
+assert "10Gi" in storage_requests(loki_docs), "Loki must render a 10Gi persistent claim"
+assert "8Gi" in storage_requests(prometheus_docs), "Prometheus must render an 8Gi persistent claim"
+
+_, alloy_pod, alloy_container = image_container(alloy_docs, "grafana/alloy", "Alloy")
+assert any(volume.get("hostPath", {}).get("path") == "/var/lib/alloy" for volume in alloy_pod.get("volumes", []))
+assert any(mount.get("mountPath") == "/var/lib/alloy" for mount in alloy_container.get("volumeMounts", []))
+assert any(
+    "stage.cri { }" in value
+    for doc in alloy_docs
+    if doc.get("kind") == "ConfigMap"
+    for value in (doc.get("data") or {}).values()
+    if isinstance(value, str)
+)
+
+tempo_statefulsets = [doc for doc in tempo_docs if doc.get("kind") == "StatefulSet"]
+assert len(tempo_statefulsets) == 1, "Tempo must render one StatefulSet"
+assert all(doc.get("metadata", {}).get("namespace") == "observability" for doc in tempo_docs), (
+    "every Tempo resource must be installed in the observability namespace"
+)
+tempo_claims = at(tempo_statefulsets[0], "spec", "volumeClaimTemplates")
+assert any(at(claim, "spec", "resources", "requests", "storage") == "5Gi" for claim in tempo_claims)
+_, _, tempo_container = image_container(tempo_docs, "grafana/tempo", "Tempo")
+if mutation == "tempo-image":
+    tempo_container["image"] = tempo_container["image"].split("@", 1)[0]
+assert tempo_container["image"] == (
+    "docker.io/grafana/tempo:2.9.1@sha256:"
+    "290414580eabd1bde91f22e4a4579242fe77377c425223f45d59b8ad1540ce3c"
+), f"Tempo backend must use the reviewed multiarch digest, got {tempo_container['image']}"
+tempo_configs = [parsed for _, _, parsed, _ in embedded_yaml(tempo_docs)
+                 if isinstance(parsed, dict) and "distributor" in parsed and "storage" in parsed]
+assert len(tempo_configs) == 1, f"expected one Tempo config, found {len(tempo_configs)}"
+protocols = at(tempo_configs[0], "distributor", "receivers", "otlp", "protocols")
+assert at(protocols, "grpc", "endpoint") == "0.0.0.0:4317"
+assert at(protocols, "http", "endpoint") == "0.0.0.0:4318"
+
+datasources = []
+for _, _, parsed, _ in embedded_yaml(grafana_docs):
+    for candidate in find_nested_dicts(parsed, "datasources"):
+        if isinstance(candidate, list):
+            datasources.extend(item for item in candidate if isinstance(item, dict))
+assert len(datasources) == 3, f"Grafana must provision exactly three datasources, got {len(datasources)}"
+assert {item.get("type") for item in datasources} == {"loki", "tempo", "prometheus"}
+tempo_datasources = [item for item in datasources if item.get("name") == "Tempo"]
+assert len(tempo_datasources) == 1
+assert tempo_datasources[0].get("uid") == "__Tempo__"
+assert sum(item.get("uid") == "__Tempo__" for item in datasources) == 1
+expected_urls = {
+    "Loki": "http://loki.observability.svc.cluster.local:3100",
+    "Tempo": "http://tempo.observability.svc.cluster.local:3200",
+    "Prometheus": "http://prometheus-server.observability.svc.cluster.local",
+}
+assert {item.get("name"): item.get("url") for item in datasources} == expected_urls
+
+
+def collector_config(docs):
+    matches = []
+    for doc, key, parsed, _ in embedded_yaml(docs):
+        if key == "collector-config.yaml" and isinstance(parsed, dict):
+            matches.append(parsed)
+    assert len(matches) == 1, f"expected one collector config, found {len(matches)}"
+    return matches[0]
+
+
+for label, docs in (("install", curie_install_docs), ("upgrade", curie_upgrade_docs)):
+    config = collector_config(docs)
+    if mutation == "tempo-exporter" and label == "upgrade":
+        config.get("exporters", {}).pop("otlphttp/tempo", None)
+        exporters = at(config, "service", "pipelines", "traces", "exporters")
+        config["service"]["pipelines"]["traces"]["exporters"] = [
+            value for value in exporters if value != "otlphttp/tempo"
+        ]
+    tempo_exporter = at(config, "exporters", "otlphttp/tempo")
+    assert tempo_exporter.get("endpoint") == "http://tempo.observability.svc.cluster.local:4318"
+    trace_exporters = at(config, "service", "pipelines", "traces", "exporters")
+    assert trace_exporters == ["otlphttp/langfuse", "debug", "otlphttp/tempo"], (
+        f"{label} render must export traces to Langfuse and Tempo"
+    )
+
+default_render = Path(curie_default_path).read_text()
+assert "GRAFANA_SERVICE_ACCOUNT_TOKEN" not in default_render, (
+    "Grafana connector token integration must stay opt in"
+)
+
+token_secret_name = at(curie_values, "grafanaConnector", "secretName")
+token_secret_key = at(curie_values, "grafanaConnector", "secretKey")
+for label, docs in (("install", curie_install_docs), ("upgrade", curie_upgrade_docs)):
+    token_secrets = [
+        doc for doc in docs
+        if doc.get("kind") == "Secret"
+        and doc.get("metadata", {}).get("name") == token_secret_name
+    ]
+    assert len(token_secrets) == 1, (
+        f"expected one chart managed Grafana token Secret on {label}, "
+        f"found {len(token_secrets)}"
+    )
+    token_secret = token_secrets[0]
+    if mutation == "token-data" and label == "upgrade":
+        token_secret["data"] = {token_secret_key: "observability-token-sentinel"}
+    assert not hook_annotations(token_secret), "Grafana token Secret must be a regular Helm resource"
+    assert "data" not in token_secret and "stringData" not in token_secret, (
+        f"Grafana token material must not enter the Helm {label} release manifest"
+    )
+
+jobs = [doc for doc in curie_install_docs if doc.get("kind") == "Job"]
+updaters = []
+for job in jobs:
+    container_dump = yaml.safe_dump(at(job, "spec", "template", "spec", "containers"))
+    if token_secret_name in container_dump and "api/serviceaccounts" in container_dump:
+        updaters.append(job)
+assert len(updaters) == 1, f"expected one Grafana token updater Job, found {len(updaters)}"
+updater = updaters[0]
+assert set(hook_annotations(updater).split(",")) == {"post-install", "post-upgrade"}
+updater_container = at(updater, "spec", "template", "spec", "containers")[0]
+updater_command_parts = updater_container.get("command", [])
+updater_command = "\n".join(str(part) for part in updater_command_parts)
+updater_source = updater_command_parts[-1]
+compile(updater_source, "<grafana-token-updater>", "exec")
+if mutation == "updater-tag":
+    updater_container["image"] = updater_container["image"].split("@", 1)[0]
+updater_image = updater_container["image"]
+assert updater_image == (
+    "python:3.12-alpine@sha256:"
+    "d09d15e60962ca365d1cd544a48773bac9d33f2fb1b00f2aa0deec78ade7dc31"
+), f"Grafana token updater must use the reviewed image digest, got {updater_image}"
+assert "set -x" not in updater_command
+for sensitive_name in ("existing_token", "new_token", "admin_password", "kube_token"):
+    assert f"print({sensitive_name}" not in updater_command
+assert not re.search(
+    r"(?:echo|printf)[^\n]*\$(?:\{?[A-Za-z_][A-Za-z0-9_]*(?:TOKEN|KEY))",
+    updater_command,
+), (
+    "Grafana token updater must never print token variables"
+)
+for required_api in ("/api/health", "/api/serviceaccounts"):
+    assert required_api in updater_command, f"Grafana updater is missing {required_api} handling"
+assert "sleep" in updater_command, "Grafana updater must poll readiness instead of racing startup"
+if mutation == "token-cleanup":
+    updater_command = updater_command.replace('method="DELETE"', 'method="GET"')
+assert 'method="DELETE"' in updater_command, "Grafana updater must revoke stale tokens"
+assert "status, body = grafana_request(tokens_path, basic=admin)" in updater_command, (
+    "Grafana updater must list existing service account tokens before creating one"
+)
+assert "token_records = json.loads(body)" in updater_command
+assert ".startswith(token_prefix)" in updater_command, (
+    "Grafana updater must limit cleanup to its configured token prefix"
+)
+assert updater_command.count("delete_token(new_token_id)") >= 2, (
+    "Grafana updater must revoke a newly created token on incomplete output or Secret PATCH failure"
+)
+assert "Grafana connector token is valid and was reused" not in updater_command, (
+    "Grafana updater must not accept an unbound bearer from the Kubernetes Secret"
+)
+if mutation == "rotation-restart":
+    updater_command = updater_command.replace(
+        "/apis/apps/v1/namespaces/{encoded_namespace}/deployments/{encoded_name}",
+        "/apis/apps/v1/namespaces/{encoded_namespace}/statefulsets/{encoded_name}",
+    )
+assert "/apis/apps/v1/namespaces/{encoded_namespace}/deployments/{encoded_name}" in updater_command, (
+    "Grafana token rotation must restart the scoped connector Deployments"
+)
+for rollout_field in (
+    "observedGeneration",
+    "updatedReplicas",
+    "readyReplicas",
+    "availableReplicas",
+    "unavailableReplicas",
+):
+    assert rollout_field in updater_command, (
+        f"Grafana token rotation must wait for Deployment {rollout_field}"
+    )
+assert updater_command.rindex("patch_token_secret(new_token)") < updater_command.rindex(
+    "restart_connector_deployments()"
+) < updater_command.rindex("delete_token(stale_token_id)"), (
+    "Grafana token rotation must patch the Secret, roll every connector, then revoke old tokens"
+)
+if mutation == "viewer-role":
+    updater_command = updater_command.replace(
+        'payload={"role": "Viewer"}', 'payload={"role": "Editor"}'
+    )
+assert 'account.get("role") != "Viewer"' in updater_command, (
+    "Grafana updater must detect a dedicated service account whose role drifted"
+)
+assert 'payload={"role": "Viewer"}' in updater_command, (
+    "Grafana updater must restore the dedicated service account to Viewer"
+)
+assert updater_command.index("/api/serviceaccounts/search") < updater_command.rindex(
+    "patch_token_secret(new_token)"
+), "Grafana updater must constrain the Viewer account before publishing its new token"
+
+admin_volumes = [
+    volume for volume in at(updater, "spec", "template", "spec", "volumes")
+    if volume.get("name") == "grafana-admin"
+]
+assert len(admin_volumes) == 1
+assert at(admin_volumes[0], "secret", "secretName") == "grafana-admin"
+
+service_account_name = at(updater, "spec", "template", "spec", "serviceAccountName")
+service_accounts = [doc for doc in curie_install_docs if doc.get("kind") == "ServiceAccount"
+                    and doc.get("metadata", {}).get("name") == service_account_name]
+assert len(service_accounts) == 1
+
+role_bindings = [doc for doc in curie_install_docs if doc.get("kind") == "RoleBinding"
+                 and any(subject.get("name") == service_account_name for subject in doc.get("subjects", []))]
+assert len(role_bindings) == 1
+role_name = at(role_bindings[0], "roleRef", "name")
+roles = [doc for doc in curie_install_docs if doc.get("kind") == "Role"
+         and doc.get("metadata", {}).get("name") == role_name]
+assert len(roles) == 1
+restart_deployments = set(at(curie_values, "grafanaConnector", "restartDeploymentNames"))
+assert restart_deployments == {"curie-sre-bot-grafana", "curie-sre-bot-tempo"}
+if mutation == "restart-scope":
+    for rule in roles[0].get("rules", []):
+        if "deployments" in rule.get("resources", []):
+            rule["resourceNames"] = ["*"]
+for resource in (service_accounts[0], role_bindings[0], roles[0]):
+    assert set(hook_annotations(resource).split(",")) == {"post-install", "post-upgrade"}
+for rule in roles[0].get("rules", []):
+    assert "*" not in rule.get("resources", [])
+    assert "*" not in rule.get("verbs", [])
+    assert set(rule.get("resources", [])) <= {"secrets", "deployments"}
+    if "secrets" in rule.get("resources", []):
+        assert token_secret_name in rule.get("resourceNames", [])
+        assert set(rule.get("verbs", [])) == {"get", "patch", "update"}
+    if "deployments" in rule.get("resources", []):
+        assert set(rule.get("resourceNames", [])) == restart_deployments, (
+            "Grafana updater Deployment access must be limited to the two SRE bot connectors"
+        )
+        assert set(rule.get("verbs", [])) == {"get", "patch"}
+
+cleanup_jobs = [job for job in jobs if hook_annotations(job) == "pre-delete"]
+assert len(cleanup_jobs) == 1, f"expected one pre-delete Grafana cleanup Job, found {len(cleanup_jobs)}"
+cleanup = cleanup_jobs[0]
+cleanup_pod = at(cleanup, "spec", "template", "spec")
+assert cleanup_pod.get("automountServiceAccountToken") is False
+assert "serviceAccountName" not in cleanup_pod
+cleanup_container = at(cleanup_pod, "containers")[0]
+if mutation == "cleanup-tag":
+    cleanup_container["image"] = cleanup_container["image"].split("@", 1)[0]
+assert cleanup_container["image"] == updater_image, (
+    "Grafana pre-delete cleanup must use the reviewed updater digest"
+)
+cleanup_source = cleanup_container.get("command", [])[-1]
+compile(cleanup_source, "<grafana-token-cleanup>", "exec")
+if mutation == "delete-hook":
+    cleanup_source = cleanup_source.replace('method="DELETE"', 'method="GET"')
+for required_source in (
+    "/api/serviceaccounts/search",
+    "/api/serviceaccounts/{account_id}/tokens",
+    'method="DELETE"',
+    ".startswith(token_prefix)",
+):
+    assert required_source in cleanup_source, (
+        f"Grafana pre-delete cleanup is missing {required_source}"
+    )
+assert "set -x" not in cleanup_source
+assert not re.search(
+    r"(?:echo|printf)[^\n]*\$(?:\{?[A-Za-z_][A-Za-z0-9_]*(?:TOKEN|KEY))",
+    cleanup_source,
+)
+assert not any(
+    name.startswith("KUBERNETES_") or name.startswith("TOKEN_SECRET_")
+    for name in (
+        item.get("name", "")
+        for item in cleanup_container.get("env", [])
+    )
+)
+assert at(cleanup_pod, "securityContext", "runAsNonRoot") is True
+assert at(cleanup_pod, "securityContext", "runAsUser") == 65532
+assert at(cleanup_pod, "securityContext", "runAsGroup") == 65532
+assert at(cleanup_pod, "securityContext", "fsGroup") == 65532
+assert at(cleanup_pod, "securityContext", "seccompProfile", "type") == "RuntimeDefault"
+assert at(cleanup_container, "securityContext", "runAsNonRoot") is True
+assert at(cleanup_container, "securityContext", "runAsUser") == 65532
+assert at(cleanup_container, "securityContext", "runAsGroup") == 65532
+assert at(cleanup_container, "securityContext", "allowPrivilegeEscalation") is False
+assert at(cleanup_container, "securityContext", "readOnlyRootFilesystem") is True
+assert at(cleanup_container, "securityContext", "capabilities", "drop") == ["ALL"]
+assert at(cleanup_container, "securityContext", "seccompProfile", "type") == "RuntimeDefault"
+for sensitive_name in ("admin", "token_id", "token_record"):
+    assert f"print({sensitive_name}" not in cleanup_source
+cleanup_admin_volumes = [
+    volume for volume in cleanup_pod.get("volumes", [])
+    if volume.get("name") == "grafana-admin"
+]
+assert len(cleanup_admin_volumes) == 1
+assert at(cleanup_admin_volumes[0], "secret", "secretName") == "grafana-admin"
+assert not any(
+    hook_annotations(doc) == "pre-delete"
+    for doc in curie_install_docs
+    if doc.get("kind") in {"Role", "RoleBinding", "ClusterRole", "ClusterRoleBinding"}
+), "Grafana pre-delete cleanup must not receive Kubernetes RBAC"
+
+token_template_source = (chart / "templates" / "grafana-connector-token.yaml").read_text()
+assert 'lookup "v1" "Secret"' not in token_template_source, (
+    "Grafana token must never be copied into a Helm release manifest"
+)
+
+full_render = "\n".join(Path(path).read_text() for path in (
+    grafana_path, loki_path, alloy_path, prometheus_path, tempo_path,
+    curie_install_path, curie_upgrade_path,
+))
+assert "observability-token-sentinel" not in full_render
+assert not re.search(r"glsa_[A-Za-z0-9_-]{16,}", full_render), (
+    "rendered manifests contain literal Grafana service account token material"
+)
+
+print("observability stack render assertions passed")
+PY

--- a/charts/curie/ci/otel-collector-checksum-assertions.sh
+++ b/charts/curie/ci/otel-collector-checksum-assertions.sh
@@ -24,8 +24,23 @@ manifest_for() {
 render default
 render port-3001 --set langfuse.web.service.port=3001
 render auth-header --set otelCollector.otlpAuthHeader='Basic YXNzZXJ0OmFzc2VydA=='
+render tempo \
+  --set 'otelCollector.extraExporters.otlphttp/tempo.endpoint=http://tempo:4318' \
+  --set 'otelCollector.extraPipelineExporters[0]=otlphttp/tempo'
 
-python3 - "$(manifest_for "$TMP/default")" "$(manifest_for "$TMP/port-3001")" "$(manifest_for "$TMP/auth-header")" <<'PY'
+missing_exporter_stderr="$TMP/missing-exporter.stderr"
+if helm template curie "$CHART" \
+  --set 'otelCollector.extraPipelineExporters[0]=otlphttp/tempo' \
+  >/dev/null 2>"$missing_exporter_stderr"; then
+  fail "Helm accepted missing exporter otlphttp/tempo; add it under otelCollector.extraExporters"
+fi
+missing_exporter_error="$(<"$missing_exporter_stderr")"
+[[ "$missing_exporter_error" == *"otlphttp/tempo"* ]] || \
+  fail "Missing exporter error did not name otlphttp/tempo"
+[[ "$missing_exporter_error" == *"otelCollector.extraExporters"* ]] || \
+  fail "Missing exporter error did not name otelCollector.extraExporters"
+
+python3 - "$(manifest_for "$TMP/default")" "$(manifest_for "$TMP/port-3001")" "$(manifest_for "$TMP/auth-header")" "$(manifest_for "$TMP/tempo")" <<'PY'
 import sys
 import yaml
 
@@ -44,6 +59,31 @@ def config_and_checksum(path):
 default_config, default_checksum = config_and_checksum(sys.argv[1])
 changed_config, changed_checksum = config_and_checksum(sys.argv[2])
 auth_config, auth_checksum = config_and_checksum(sys.argv[3])
+tempo_config, tempo_checksum = config_and_checksum(sys.argv[4])
+
+default_parsed = yaml.safe_load(default_config)
+tempo_parsed = yaml.safe_load(tempo_config)
+default_exporters = default_parsed["exporters"]
+default_trace_exporters = default_parsed["service"]["pipelines"]["traces"]["exporters"]
+tempo_exporters = tempo_parsed["exporters"]
+tempo_trace_exporters = tempo_parsed["service"]["pipelines"]["traces"]["exporters"]
+
+assert set(default_exporters) == {"otlphttp/langfuse", "debug"}, (
+    "Default collector exporters changed or unexpectedly include Tempo"
+)
+assert default_trace_exporters == ["otlphttp/langfuse", "debug"], (
+    "Default traces pipeline exporters changed or unexpectedly include Tempo"
+)
+assert tempo_exporters.get("otlphttp/tempo") == {"endpoint": "http://tempo:4318"}, (
+    "Tempo exporter configuration was not rendered exactly"
+)
+assert tempo_trace_exporters == ["otlphttp/langfuse", "debug", "otlphttp/tempo"], (
+    "Tempo exporter was not appended to the traces pipeline"
+)
+assert default_config != tempo_config, "Tempo values did not change the collector ConfigMap body"
+assert default_checksum != tempo_checksum, (
+    "Tempo values changed but Deployment checksum/config stayed identical. The pod would not roll."
+)
 
 assert default_config != changed_config, "Langfuse service port did not change the collector ConfigMap body"
 assert default_checksum != changed_checksum, (

--- a/charts/curie/templates/_helpers.tpl
+++ b/charts/curie/templates/_helpers.tpl
@@ -240,6 +240,12 @@ true
 {{- end -}}
 
 {{- define "curie.otelCollector.config" -}}
+{{- $builtInExporters := dict "otlphttp/langfuse" true "debug" true -}}
+{{- range $exporter := .Values.otelCollector.extraPipelineExporters }}
+{{- if not (or (hasKey $builtInExporters $exporter) (hasKey $.Values.otelCollector.extraExporters $exporter)) }}
+{{- fail (printf "otelCollector.extraPipelineExporters references undefined exporter %q. Add it under otelCollector.extraExporters." $exporter) }}
+{{- end }}
+{{- end }}
 # Receives OTLP over gRPC (4317) and HTTP (4318) from app services and
 # forwards to Langfuse over HTTP. Langfuse OTLP ingest is HTTP-only (gRPC is
 # silently unsupported), so the collector is the adapter. Langfuse appends
@@ -260,6 +266,9 @@ exporters:
       Authorization: ${env:LANGFUSE_OTLP_AUTH_HEADER}
   debug:
     verbosity: normal
+{{- with .Values.otelCollector.extraExporters }}
+{{ toYaml . | nindent 2 }}
+{{- end }}
 extensions:
   health_check:
     endpoint: 0.0.0.0:13133
@@ -272,7 +281,7 @@ service:
     traces:
       receivers: [otlp]
       processors: [batch]
-      exporters: [otlphttp/langfuse, debug]
+      exporters: [otlphttp/langfuse, debug{{- range .Values.otelCollector.extraPipelineExporters }}, {{ . }}{{- end }}]
 {{- end }}
 
 {{/* ---- Default-credential gate (issue #198) ----

--- a/charts/curie/templates/grafana-connector-token.yaml
+++ b/charts/curie/templates/grafana-connector-token.yaml
@@ -1,0 +1,599 @@
+{{- if .Values.grafanaConnector.enabled }}
+{{- $secretName := required "grafanaConnector.secretName is required" .Values.grafanaConnector.secretName -}}
+{{- $secretKey := .Values.grafanaConnector.secretKey | default "GRAFANA_SERVICE_ACCOUNT_TOKEN" -}}
+{{- $grafanaNamespace := required "grafanaConnector.namespace is required" .Values.grafanaConnector.namespace -}}
+{{- $grafanaURL := required "grafanaConnector.url is required" .Values.grafanaConnector.url -}}
+{{- $restartDeploymentNames := .Values.grafanaConnector.restartDeploymentNames -}}
+{{- $hookName := printf "%s-grafana-token-updater" (include "curie.fullname" .) -}}
+{{- $cleanupName := printf "%s-grafana-token-cleanup" (include "curie.fullname" .) -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "curie.labels" . | nindent 4 }}
+type: Opaque
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $hookName }}
+  namespace: {{ $grafanaNamespace }}
+  labels:
+    {{- include "curie.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-3"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $hookName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "curie.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-3"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: [{{ $secretName | quote }}]
+    verbs: ["get", "patch", "update"]
+{{- if $restartDeploymentNames }}
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    resourceNames:
+      {{- toYaml $restartDeploymentNames | nindent 6 }}
+    verbs: ["get", "patch"]
+{{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $hookName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "curie.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-2"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $hookName }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ $hookName }}
+    namespace: {{ $grafanaNamespace }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $hookName }}
+  namespace: {{ $grafanaNamespace }}
+  labels:
+    {{- include "curie.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
+spec:
+  backoffLimit: 0
+  activeDeadlineSeconds: {{ .Values.grafanaConnector.updater.activeDeadlineSeconds }}
+  template:
+    metadata:
+      labels:
+        {{- include "curie.labels" . | nindent 8 }}
+        {{- include "curie.selectorLabels" (dict "root" . "component" "grafana-token-updater") | nindent 8 }}
+    spec:
+      serviceAccountName: {{ $hookName }}
+      restartPolicy: Never
+      securityContext:
+        {{- toYaml .Values.grafanaConnector.updater.podSecurityContext | nindent 8 }}
+      containers:
+        - name: grafana-token-updater
+          image: {{ .Values.grafanaConnector.updater.image }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          securityContext:
+            {{- toYaml .Values.grafanaConnector.updater.containerSecurityContext | nindent 12 }}
+          env:
+            - name: PYTHONDONTWRITEBYTECODE
+              value: "1"
+            - name: GRAFANA_URL
+              value: {{ $grafanaURL | quote }}
+            - name: GRAFANA_SERVICE_ACCOUNT_NAME
+              value: {{ .Values.grafanaConnector.serviceAccountName | quote }}
+            - name: GRAFANA_TOKEN_NAME
+              value: {{ .Values.grafanaConnector.tokenName | quote }}
+            - name: TOKEN_SECRET_NAMESPACE
+              value: {{ .Release.Namespace | quote }}
+            - name: TOKEN_SECRET_NAME
+              value: {{ $secretName | quote }}
+            - name: TOKEN_SECRET_KEY
+              value: {{ $secretKey | quote }}
+            - name: CONNECTOR_DEPLOYMENTS
+              value: {{ join "," $restartDeploymentNames | quote }}
+            - name: READINESS_ATTEMPTS
+              value: {{ .Values.grafanaConnector.updater.readinessAttempts | quote }}
+            - name: READINESS_INTERVAL_SECONDS
+              value: {{ .Values.grafanaConnector.updater.readinessIntervalSeconds | quote }}
+          command:
+            - python3
+            - -c
+            - |
+              import base64
+              import json
+              import os
+              import ssl
+              import time
+              import urllib.error
+              import urllib.parse
+              import urllib.request
+
+              grafana_url = os.environ["GRAFANA_URL"].rstrip("/")
+              account_name = os.environ["GRAFANA_SERVICE_ACCOUNT_NAME"]
+              token_name = os.environ["GRAFANA_TOKEN_NAME"]
+              secret_namespace = os.environ["TOKEN_SECRET_NAMESPACE"]
+              secret_name = os.environ["TOKEN_SECRET_NAME"]
+              secret_key = os.environ["TOKEN_SECRET_KEY"]
+              connector_deployments = [
+                  name
+                  for name in os.environ["CONNECTOR_DEPLOYMENTS"].split(",")
+                  if name
+              ]
+
+              def read_file(path):
+                  with open(path, encoding="utf-8") as handle:
+                      return handle.read().strip()
+
+              def grafana_request(
+                  path, method="GET", payload=None, bearer=None, basic=None, timeout=5
+              ):
+                  headers = {"Accept": "application/json"}
+                  if payload is not None:
+                      headers["Content-Type"] = "application/json"
+                  if bearer:
+                      headers["Authorization"] = "Bearer " + bearer
+                  elif basic:
+                      encoded = base64.b64encode((basic[0] + ":" + basic[1]).encode()).decode()
+                      headers["Authorization"] = "Basic " + encoded
+                  request = urllib.request.Request(
+                      grafana_url + path,
+                      data=None if payload is None else json.dumps(payload).encode(),
+                      headers=headers,
+                      method=method,
+                  )
+                  try:
+                      with urllib.request.urlopen(request, timeout=timeout) as response:
+                          return response.status, response.read()
+                  except urllib.error.HTTPError as error:
+                      return error.code, b""
+                  except urllib.error.URLError:
+                      return 0, b""
+
+              kube_host = os.environ["KUBERNETES_SERVICE_HOST"]
+              kube_port = os.environ.get("KUBERNETES_SERVICE_PORT_HTTPS", "443")
+              kube_base = "https://" + kube_host + ":" + kube_port
+              kube_token = read_file("/var/run/secrets/kubernetes.io/serviceaccount/token")
+              kube_context = ssl.create_default_context(
+                  cafile="/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+              )
+              encoded_namespace = urllib.parse.quote(secret_namespace, safe="")
+              encoded_secret = urllib.parse.quote(secret_name, safe="")
+              secret_path = f"/api/v1/namespaces/{encoded_namespace}/secrets/{encoded_secret}"
+
+              def kubernetes_request(path, method="GET", payload=None):
+                  headers = {
+                      "Accept": "application/json",
+                      "Authorization": "Bearer " + kube_token,
+                  }
+                  if payload is not None:
+                      headers["Content-Type"] = "application/merge-patch+json"
+                  request = urllib.request.Request(
+                      kube_base + path,
+                      data=None if payload is None else json.dumps(payload).encode(),
+                      headers=headers,
+                      method=method,
+                  )
+                  try:
+                      with urllib.request.urlopen(
+                          request, context=kube_context, timeout=5
+                      ) as response:
+                          return response.status, json.loads(response.read() or b"{}")
+                  except urllib.error.HTTPError as error:
+                      return error.code, {}
+
+              def patch_token_secret(new_token):
+                  status, _ = kubernetes_request(
+                      secret_path,
+                      method="PATCH",
+                      payload={
+                          "data": {
+                              secret_key: base64.b64encode(new_token.encode()).decode()
+                          }
+                      },
+                  )
+                  if status != 200:
+                      raise RuntimeError(
+                          f"Kubernetes Secret request returned HTTP {status}"
+                      )
+
+              def deployment_ready(deployment, generation, replicas):
+                  status = deployment.get("status", {})
+                  return (
+                      status.get("observedGeneration", 0) >= generation
+                      and status.get("updatedReplicas", 0) == replicas
+                      and status.get("readyReplicas", 0) == replicas
+                      and status.get("availableReplicas", 0) == replicas
+                      and status.get("unavailableReplicas", 0) == 0
+                  )
+
+              def restart_connector_deployments():
+                  pending = []
+                  rotation = str(time.time_ns())
+                  for deployment_name in connector_deployments:
+                      encoded_name = urllib.parse.quote(deployment_name, safe="")
+                      deployment_path = f"/apis/apps/v1/namespaces/{encoded_namespace}/deployments/{encoded_name}"
+                      status, current = kubernetes_request(deployment_path)
+                      if status == 404:
+                          continue
+                      if status != 200:
+                          raise RuntimeError(
+                              f"Kubernetes Deployment request returned HTTP {status}"
+                          )
+                      status, changed = kubernetes_request(
+                          deployment_path,
+                          method="PATCH",
+                          payload={
+                              "spec": {
+                                  "template": {
+                                      "metadata": {
+                                          "annotations": {
+                                              "curie.dev/grafana-token-rotation": rotation
+                                          }
+                                      }
+                                  }
+                              }
+                          },
+                      )
+                      if status != 200:
+                          raise RuntimeError(
+                              f"Kubernetes Deployment restart returned HTTP {status}"
+                          )
+                      generation = changed.get("metadata", {}).get("generation")
+                      replicas = changed.get("spec", {}).get("replicas", 1)
+                      if not isinstance(generation, int) or not isinstance(replicas, int):
+                          raise RuntimeError("Kubernetes Deployment restart response was incomplete")
+                      pending.append((deployment_name, deployment_path, generation, replicas))
+
+                  for deployment_name, deployment_path, generation, replicas in pending:
+                      for attempt in range(1, attempts + 1):
+                          status, deployment = kubernetes_request(deployment_path)
+                          if status == 200 and deployment_ready(
+                              deployment, generation, replicas
+                          ):
+                              break
+                          if status not in (200,):
+                              raise RuntimeError(
+                                  f"Kubernetes Deployment rollout request returned HTTP {status}"
+                              )
+                          if attempt == attempts:
+                              raise RuntimeError(
+                                  f"Connector Deployment {deployment_name} did not complete token rotation"
+                              )
+                          time.sleep(interval)
+
+              attempts = int(os.environ["READINESS_ATTEMPTS"])
+              interval = int(os.environ["READINESS_INTERVAL_SECONDS"])
+              for attempt in range(1, attempts + 1):
+                  status, _ = grafana_request("/api/health", timeout=2)
+                  if status == 200:
+                      break
+                  if attempt == attempts:
+                      raise RuntimeError(
+                          f"Grafana was not ready after {attempts} attempts"
+                      )
+                  time.sleep(interval)
+
+              secret_status, _ = kubernetes_request(secret_path)
+              if secret_status != 200:
+                  raise RuntimeError(
+                      f"Kubernetes Secret request returned HTTP {secret_status}"
+                  )
+
+              admin_user = read_file("/var/run/grafana-admin/user")
+              admin_password = read_file("/var/run/grafana-admin/password")
+              admin = (admin_user, admin_password)
+              query = urllib.parse.quote(account_name, safe="")
+              status, body = grafana_request(
+                  "/api/serviceaccounts/search?perpage=100&page=1&query=" + query,
+                  basic=admin,
+              )
+              if status != 200:
+                  raise RuntimeError(
+                      f"Grafana service account search returned HTTP {status}"
+                  )
+              accounts = [
+                  item
+                  for item in json.loads(body).get("serviceAccounts", [])
+                  if item.get("name") == account_name
+              ]
+              if len(accounts) > 1:
+                  raise RuntimeError(
+                      "Grafana returned duplicate service accounts for the configured name"
+                  )
+              if accounts:
+                  account = accounts[0]
+                  account_id = account["id"]
+                  if account.get("role") != "Viewer":
+                      status, _ = grafana_request(
+                          f"/api/serviceaccounts/{account_id}",
+                          method="PATCH",
+                          payload={"role": "Viewer"},
+                          basic=admin,
+                      )
+                      if status != 200:
+                          raise RuntimeError(
+                              f"Grafana service account Viewer restoration returned HTTP {status}"
+                          )
+              else:
+                  status, body = grafana_request(
+                      "/api/serviceaccounts",
+                      method="POST",
+                      payload={"name": account_name, "role": "Viewer"},
+                      basic=admin,
+                  )
+                  if status not in (200, 201):
+                      raise RuntimeError(
+                          f"Grafana service account creation returned HTTP {status}"
+                      )
+                  account_id = json.loads(body)["id"]
+
+              # API contract:
+              # https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/serviceaccount/
+              tokens_path = f"/api/serviceaccounts/{account_id}/tokens"
+              status, body = grafana_request(tokens_path, basic=admin)
+              if status != 200:
+                  raise RuntimeError(
+                      f"Grafana service account token listing returned HTTP {status}"
+                  )
+              token_records = json.loads(body)
+              if not isinstance(token_records, list):
+                  raise RuntimeError("Grafana service account token listing was not a list")
+              token_prefix = token_name + "-"
+
+              def delete_token(token_id):
+                  status, _ = grafana_request(
+                      f"{tokens_path}/{token_id}", method="DELETE", basic=admin
+                  )
+                  if status not in (200, 404):
+                      raise RuntimeError(
+                          f"Grafana service account token deletion returned HTTP {status}"
+                      )
+
+              status, body = grafana_request(
+                  tokens_path,
+                  method="POST",
+                  payload={"name": token_prefix + str(int(time.time()))},
+                  basic=admin,
+              )
+              if status not in (200, 201):
+                  raise RuntimeError(
+                      f"Grafana token creation returned HTTP {status}"
+                  )
+              created_token = json.loads(body)
+              new_token = created_token.get("key", "")
+              new_token_id = created_token.get("id")
+              if not new_token:
+                  if new_token_id is not None:
+                      delete_token(new_token_id)
+                  raise RuntimeError("Grafana token creation returned no key")
+              if new_token_id is None:
+                  raise RuntimeError("Grafana token creation returned no id")
+              try:
+                  patch_token_secret(new_token)
+              except Exception:
+                  delete_token(new_token_id)
+                  raise
+              restart_connector_deployments()
+              for token_record in token_records:
+                  if not str(token_record.get("name", "")).startswith(token_prefix):
+                      continue
+                  stale_token_id = token_record.get("id")
+                  if stale_token_id is None:
+                      raise RuntimeError("Grafana service account token had no id")
+                  if stale_token_id != new_token_id:
+                      delete_token(stale_token_id)
+              print("Grafana connector token was rotated and stored")
+          resources:
+            {{- toYaml .Values.grafanaConnector.updater.resources | nindent 12 }}
+          volumeMounts:
+            - name: grafana-admin
+              mountPath: /var/run/grafana-admin
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: grafana-admin
+          secret:
+            secretName: {{ .Values.grafanaConnector.adminSecretName }}
+            items:
+              - key: {{ .Values.grafanaConnector.adminUserKey }}
+                path: user
+              - key: {{ .Values.grafanaConnector.adminPasswordKey }}
+                path: password
+        - name: tmp
+          emptyDir: {}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $cleanupName }}
+  namespace: {{ $grafanaNamespace }}
+  labels:
+    {{- include "curie.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
+spec:
+  backoffLimit: 0
+  activeDeadlineSeconds: {{ .Values.grafanaConnector.updater.activeDeadlineSeconds }}
+  template:
+    metadata:
+      labels:
+        {{- include "curie.labels" . | nindent 8 }}
+        {{- include "curie.selectorLabels" (dict "root" . "component" "grafana-token-cleanup") | nindent 8 }}
+    spec:
+      automountServiceAccountToken: false
+      restartPolicy: Never
+      securityContext:
+        {{- toYaml .Values.grafanaConnector.updater.podSecurityContext | nindent 8 }}
+      containers:
+        - name: grafana-token-cleanup
+          image: {{ .Values.grafanaConnector.updater.image }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          securityContext:
+            {{- toYaml .Values.grafanaConnector.updater.containerSecurityContext | nindent 12 }}
+          env:
+            - name: PYTHONDONTWRITEBYTECODE
+              value: "1"
+            - name: GRAFANA_URL
+              value: {{ $grafanaURL | quote }}
+            - name: GRAFANA_SERVICE_ACCOUNT_NAME
+              value: {{ .Values.grafanaConnector.serviceAccountName | quote }}
+            - name: GRAFANA_TOKEN_NAME
+              value: {{ .Values.grafanaConnector.tokenName | quote }}
+            - name: READINESS_ATTEMPTS
+              value: {{ .Values.grafanaConnector.updater.readinessAttempts | quote }}
+            - name: READINESS_INTERVAL_SECONDS
+              value: {{ .Values.grafanaConnector.updater.readinessIntervalSeconds | quote }}
+          command:
+            - python3
+            - -c
+            - |
+              import base64
+              import json
+              import os
+              import time
+              import urllib.error
+              import urllib.parse
+              import urllib.request
+
+              grafana_url = os.environ["GRAFANA_URL"].rstrip("/")
+              account_name = os.environ["GRAFANA_SERVICE_ACCOUNT_NAME"]
+              token_prefix = os.environ["GRAFANA_TOKEN_NAME"] + "-"
+
+              def read_file(path):
+                  with open(path, encoding="utf-8") as handle:
+                      return handle.read().strip()
+
+              admin = (
+                  read_file("/var/run/grafana-admin/user"),
+                  read_file("/var/run/grafana-admin/password"),
+              )
+
+              def grafana_request(path, method="GET", basic=None, timeout=5):
+                  headers = {"Accept": "application/json"}
+                  if basic:
+                      encoded = base64.b64encode((basic[0] + ":" + basic[1]).encode()).decode()
+                      headers["Authorization"] = "Basic " + encoded
+                  request = urllib.request.Request(
+                      grafana_url + path,
+                      headers=headers,
+                      method=method,
+                  )
+                  try:
+                      with urllib.request.urlopen(request, timeout=timeout) as response:
+                          return response.status, response.read()
+                  except urllib.error.HTTPError as error:
+                      return error.code, b""
+                  except urllib.error.URLError:
+                      return 0, b""
+
+              attempts = int(os.environ["READINESS_ATTEMPTS"])
+              interval = int(os.environ["READINESS_INTERVAL_SECONDS"])
+              for attempt in range(1, attempts + 1):
+                  status, _ = grafana_request("/api/health", timeout=2)
+                  if status == 200:
+                      break
+                  if attempt == attempts:
+                      raise RuntimeError(
+                          f"Grafana was not ready for token cleanup after {attempts} attempts"
+                      )
+                  time.sleep(interval)
+
+              query = urllib.parse.quote(account_name, safe="")
+              status, body = grafana_request(
+                  "/api/serviceaccounts/search?perpage=100&page=1&query=" + query,
+                  basic=admin,
+              )
+              if status != 200:
+                  raise RuntimeError(
+                      f"Grafana service account search returned HTTP {status}"
+                  )
+              accounts = [
+                  item
+                  for item in json.loads(body).get("serviceAccounts", [])
+                  if item.get("name") == account_name
+              ]
+              if len(accounts) > 1:
+                  raise RuntimeError(
+                      "Grafana returned duplicate service accounts for the configured name"
+                  )
+              if not accounts:
+                  print("Grafana connector service account does not exist; no tokens to revoke")
+                  raise SystemExit(0)
+
+              account_id = accounts[0]["id"]
+              tokens_path = f"/api/serviceaccounts/{account_id}/tokens"
+              status, body = grafana_request(tokens_path, basic=admin)
+              if status != 200:
+                  raise RuntimeError(
+                      f"Grafana service account token listing returned HTTP {status}"
+                  )
+              token_records = json.loads(body)
+              if not isinstance(token_records, list):
+                  raise RuntimeError("Grafana service account token listing was not a list")
+
+              revoked = 0
+              for token_record in token_records:
+                  if not str(token_record.get("name", "")).startswith(token_prefix):
+                      continue
+                  token_id = token_record.get("id")
+                  if token_id is None:
+                      raise RuntimeError("Grafana service account token had no id")
+                  status, _ = grafana_request(
+                      f"{tokens_path}/{token_id}", method="DELETE", basic=admin
+                  )
+                  if status not in (200, 404):
+                      raise RuntimeError(
+                          f"Grafana service account token deletion returned HTTP {status}"
+                      )
+                  revoked += 1
+              print(f"Grafana connector token cleanup revoked {revoked} managed token(s)")
+          resources:
+            {{- toYaml .Values.grafanaConnector.updater.resources | nindent 12 }}
+          volumeMounts:
+            - name: grafana-admin
+              mountPath: /var/run/grafana-admin
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: grafana-admin
+          secret:
+            secretName: {{ .Values.grafanaConnector.adminSecretName }}
+            items:
+              - key: {{ .Values.grafanaConnector.adminUserKey }}
+                path: user
+              - key: {{ .Values.grafanaConnector.adminPasswordKey }}
+                path: password
+        - name: tmp
+          emptyDir: {}
+{{- end }}

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -493,6 +493,11 @@ otelCollector:
   # CreateContainerConfigError. Setting it to the published dev header trips
   # security.checkDefaultCredentials.
   otlpAuthHeader: ""
+  # Additional collector exporter definitions rendered verbatim under exporters.
+  extraExporters: {}
+  # Exporter names appended in order to the traces pipeline. Each name must
+  # identify an exporter configured above or in extraExporters.
+  extraPipelineExporters: []
   service:
     grpcPort: 4317
     httpPort: 4318

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -518,6 +518,48 @@ otelCollector:
     seccompProfile:
       type: RuntimeDefault
 
+# Grafana service account token bridge for the self observing SRE bot example.
+# The regular Secret stays in the Curie namespace. The updater runs beside
+# Grafana so it can mount the installer managed admin Secret, while its
+# Role can read and patch only the named connector Secret.
+grafanaConnector:
+  enabled: false
+  url: http://grafana.observability.svc.cluster.local
+  namespace: observability
+  adminSecretName: grafana-admin
+  adminUserKey: admin-user
+  adminPasswordKey: admin-password
+  serviceAccountName: curie-sre-bot
+  tokenName: curie-sre-bot
+  secretName: curie-grafana-connector
+  secretKey: GRAFANA_SERVICE_ACCOUNT_TOKEN
+  restartDeploymentNames: []
+  updater:
+    image: python:3.12-alpine@sha256:d09d15e60962ca365d1cd544a48773bac9d33f2fb1b00f2aa0deec78ade7dc31
+    readinessAttempts: 36
+    readinessIntervalSeconds: 5
+    activeDeadlineSeconds: 280
+    resources:
+      requests: { cpu: 10m, memory: 32Mi }
+      limits: { cpu: 100m, memory: 64Mi }
+    podSecurityContext:
+      runAsNonRoot: true
+      runAsUser: 65532
+      runAsGroup: 65532
+      fsGroup: 65532
+      seccompProfile:
+        type: RuntimeDefault
+    containerSecurityContext:
+      runAsNonRoot: true
+      runAsUser: 65532
+      runAsGroup: 65532
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      capabilities:
+        drop: [ALL]
+      seccompProfile:
+        type: RuntimeDefault
+
 # ---------------------------------------------------------------------------
 # First-party app services (A4). The control plane the runner fleet serves:
 #   - api        FastAPI control-plane REST API (agents/versions/deployments,

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -3837,6 +3837,59 @@
       ]
     },
     {
+      "about": "Install a complete first party example workflow",
+      "hidden": false,
+      "name": "example",
+      "subcommands": [
+        {
+          "about": "Install the self referential SRE bot example",
+          "hidden": false,
+          "name": "sre-bot",
+          "subcommands": [
+            {
+              "about": "Install Curie, its observability stack, and the SRE bot bundle",
+              "args": [
+                {
+                  "global": false,
+                  "help": "Install the fixed self referential Grafana, Loki, Alloy, Tempo, and Prometheus stack",
+                  "id": "observability",
+                  "long": "observability",
+                  "positional": false,
+                  "possible_values": [
+                    "true",
+                    "false"
+                  ],
+                  "required": true
+                },
+                {
+                  "global": false,
+                  "help": "Print the ordered plan without mutating the cluster",
+                  "id": "dry_run",
+                  "long": "dry-run",
+                  "positional": false,
+                  "possible_values": [
+                    "true",
+                    "false"
+                  ],
+                  "required": false
+                },
+                {
+                  "global": false,
+                  "help": "Bind the installed bot to this Slack channel",
+                  "id": "slack_channel",
+                  "long": "slack-channel",
+                  "positional": false,
+                  "required": false
+                }
+              ],
+              "hidden": false,
+              "name": "install"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "about": "List locally-authored agent bundles under `agents/` (source checkout only) -- a personal, gitignored directory (sibling of `examples/`) for in-progress agent projects ready to hand to `deploy-local`. Empty, not an error, when the directory doesn't exist",
       "hidden": false,
       "name": "list-agents"

--- a/cli/scripts/fixtures/sre-bot-connectors-enabled.yaml
+++ b/cli/scripts/fixtures/sre-bot-connectors-enabled.yaml
@@ -76,7 +76,6 @@ connectors:
       platforms: [linux/amd64, linux/arm64]
     env:
       GRAFANA_URL: https://grafana.example.com
-      TEMPO_DATASOURCE_UID: __Tempo__
     secrets:
       # The server refuses to start without it. The ladder supplies a
       # rung-scoped placeholder: its tool call is an input-validation path that

--- a/cli/src/artifacts.rs
+++ b/cli/src/artifacts.rs
@@ -16,6 +16,10 @@ impl Channel {
     /// Read the build-stamped channel. Uses option_env! so it compiles even
     /// before build.rs exists; defaults to Dev when unset or unrecognized.
     pub fn current() -> Channel {
+        #[cfg(debug_assertions)]
+        if std::env::var("CURIE_TEST_ARTIFACT_CHANNEL").as_deref() == Ok("release") {
+            return Channel::Release;
+        }
         match option_env!("CURIE_BUILD_CHANNEL") {
             Some("release") => Channel::Release,
             _ => Channel::Dev,

--- a/cli/src/connectors.rs
+++ b/cli/src/connectors.rs
@@ -397,15 +397,21 @@ pub async fn discover_app_name(namespace: &str, release: &str) -> Result<String>
 /// Fails naming every gap at once rather than one per run. A connector that
 /// starts without its credential does not fail at apply -- it comes up and
 /// returns 401s to the agent, which reads as "the tool is broken".
-fn resolve_secret_values(keys: &[String]) -> Result<std::collections::BTreeMap<String, String>> {
+fn resolve_secret_values(
+    keys: &[String],
+    overrides: &std::collections::BTreeMap<String, String>,
+) -> Result<std::collections::BTreeMap<String, String>> {
     let mut values = std::collections::BTreeMap::new();
     let mut missing = Vec::new();
     for k in keys {
-        match std::env::var(k)
-            .ok()
-            .filter(|v| !v.is_empty())
-            .or(crate::secrets::get_value(k)?)
-        {
+        let value = match overrides.get(k) {
+            Some(value) => (!value.is_empty()).then(|| value.clone()),
+            None => std::env::var(k)
+                .ok()
+                .filter(|v| !v.is_empty())
+                .or(crate::secrets::get_value(k)?),
+        };
+        match value {
             Some(v) => {
                 values.insert(k.clone(), v);
             }
@@ -431,6 +437,7 @@ pub async fn sync(
     owned_secret_keys: &[String],
     namespace: &str,
     agent_name: &str,
+    secret_overrides: &std::collections::BTreeMap<String, String>,
 ) -> Result<ConnectorSync> {
     let ui = crate::ui::ui();
     let mut objects = Vec::new();
@@ -440,7 +447,7 @@ pub async fn sync(
             objects.push(render_secret(
                 &secret_name,
                 namespace,
-                &resolve_secret_values(&keys)?,
+                &resolve_secret_values(&keys, secret_overrides)?,
             ));
         }
     }
@@ -479,4 +486,45 @@ pub async fn sync(
         ));
     }
     Ok(sync)
+}
+
+/// Render and reconcile the connectors declared by one deployed version.
+///
+/// The API owns rendering and the CLI owns applying under the operator's
+/// kubectl identity. Callers must always state their locally owned secret
+/// overrides explicitly, including the normal deploy path's empty map.
+pub async fn sync_deployed_version(
+    api_url: &str,
+    api_key: &str,
+    namespace: &str,
+    release: &str,
+    deployed: &crate::commands::DeployOutput,
+    secret_overrides: &std::collections::BTreeMap<String, String>,
+) -> Result<()> {
+    let app_name = discover_app_name(namespace, release).await?;
+    let client = crate::api::ApiClient::new(api_url, api_key)?;
+    let rendered = client
+        .version_connectors(
+            &deployed.agent_id,
+            &deployed.version_id,
+            release,
+            namespace,
+            &app_name,
+        )
+        .await?;
+    let synced = sync(
+        &rendered.manifests,
+        &rendered.mcp_entries,
+        &rendered.owned_secret_name,
+        &rendered.owned_secret_keys,
+        namespace,
+        &deployed.agent_name,
+        secret_overrides,
+    )
+    .await?;
+    let ui = crate::ui::ui();
+    for (name, url) in &synced.urls {
+        ui.note(&format!("connector {name}: {url}"));
+    }
+    Ok(())
 }

--- a/cli/src/examples.rs
+++ b/cli/src/examples.rs
@@ -1,0 +1,1433 @@
+//! Self contained example installation workflows.
+//!
+//! The SRE bot installer embeds both its observability values and its runtime
+//! bundle so a released CLI drives the same one command path as a source
+//! checkout. Kubernetes remains the source of capacity truth and every
+//! cluster mutation happens only after that read succeeds.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::time::Duration;
+
+use anyhow::{anyhow, bail, Context, Result};
+use base64::Engine as _;
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+use tokio::io::AsyncWriteExt;
+
+use crate::commands::{self, DeployOpts, DeployTier};
+use crate::ui::DryRunPlan;
+
+const OBSERVABILITY_NAMESPACE: &str = "observability";
+const CURIE_NAMESPACE: &str = "curie";
+const CURIE_RELEASE: &str = "curie";
+// The issue text says 1248Mi, but its seven exact appendix requests total
+// 1312Mi on one node once the enabled 64Mi kube-state-metrics request is
+// included. Alloy and node exporter add 160Mi on every Ready schedulable node.
+const FIXED_MEMORY_MIB: u128 = 1152;
+const PER_READY_NODE_MEMORY_MIB: u128 = 160;
+const MIB: u128 = 1024 * 1024;
+const HELM_TIMEOUT: &str = "10m";
+const MANAGED_HELM_RELEASES: [&str; 4] = ["grafana", "loki", "alloy", "prometheus"];
+const GRAFANA_ADMIN_SECRET: &str = "grafana-admin";
+const GRAFANA_RELEASE: &str = "grafana";
+const READER_TOKEN_SECRET: &str = "sre-bot-reader-token";
+const READER_TOKEN_TIMEOUT: &str = "2m";
+const KUBECONFIG_SECRET_KEY: &str = "K8S_READONLY_KUBECONFIG";
+const TEMPO_IMAGE_REPOSITORY: &str = "ghcr.io/curie-eng/curie-sre-bot-tempo";
+const TEMPO_IMAGE_TAG: &str = "0.8.0";
+const TEMPO_TAGGED_IMAGE: &str = "ghcr.io/curie-eng/curie-sre-bot-tempo:0.8.0";
+const OCI_INDEX_MEDIA_TYPE: &str = "application/vnd.oci.image.index.v1+json";
+const DOCKER_INDEX_MEDIA_TYPE: &str = "application/vnd.docker.distribution.manifest.list.v2+json";
+
+const OBSERVABILITY_FILES: &[(&str, &[u8])] = &[
+    (
+        "grafana-values.yaml",
+        include_bytes!("../../examples/sre-bot/observability/grafana-values.yaml"),
+    ),
+    (
+        "loki-values.yaml",
+        include_bytes!("../../examples/sre-bot/observability/loki-values.yaml"),
+    ),
+    (
+        "alloy-values.yaml",
+        include_bytes!("../../examples/sre-bot/observability/alloy-values.yaml"),
+    ),
+    (
+        "prometheus-values.yaml",
+        include_bytes!("../../examples/sre-bot/observability/prometheus-values.yaml"),
+    ),
+    (
+        "tempo.yaml",
+        include_bytes!("../../examples/sre-bot/observability/tempo.yaml"),
+    ),
+    (
+        "curie-values.yaml",
+        include_bytes!("../../examples/sre-bot/observability/curie-values.yaml"),
+    ),
+];
+
+const BUNDLE_FILES: &[(&str, &[u8])] = &[
+    (
+        ".claude-plugin/plugin.json",
+        include_bytes!("../../examples/sre-bot/.claude-plugin/plugin.json"),
+    ),
+    (
+        "connectors.yaml",
+        include_bytes!("../../examples/sre-bot/connectors.yaml"),
+    ),
+    (
+        "deploy.yaml",
+        include_bytes!("../../examples/sre-bot/deploy.yaml"),
+    ),
+    (
+        "evals/cases.json",
+        include_bytes!("../../examples/sre-bot/evals/cases.json"),
+    ),
+    (
+        "manifests/read-access.yaml",
+        include_bytes!("../../examples/sre-bot/manifests/read-access.yaml"),
+    ),
+    (
+        "manifests/write-role.yaml",
+        include_bytes!("../../examples/sre-bot/manifests/write-role.yaml"),
+    ),
+    (
+        "skills/sre-bot/SKILL.md",
+        include_bytes!("../../examples/sre-bot/skills/sre-bot/SKILL.md"),
+    ),
+];
+
+pub struct SreBotInstallOpts {
+    pub observability: bool,
+    pub dry_run: bool,
+    pub slack_channel: Option<String>,
+}
+
+pub enum SreBotInstallResult {
+    DryRun(DryRunPlan),
+    Installed(Box<commands::DeployOutput>),
+}
+
+#[derive(Clone)]
+enum CommandArg {
+    Plain(String),
+    ObservabilityFile(&'static str),
+    BundleFile(&'static str),
+    CurieChart,
+}
+
+impl CommandArg {
+    fn display(&self, chart: &Path) -> String {
+        match self {
+            Self::Plain(value) => value.clone(),
+            Self::ObservabilityFile(name) => {
+                format!("examples/sre-bot/observability/{name}")
+            }
+            Self::BundleFile(name) => format!("examples/sre-bot/{name}"),
+            Self::CurieChart => chart.display().to_string(),
+        }
+    }
+
+    fn live(&self, workspace: &EmbeddedWorkspace, chart: &Path) -> String {
+        match self {
+            Self::Plain(value) => value.clone(),
+            Self::ObservabilityFile(name) => workspace
+                .observability_dir()
+                .join(name)
+                .display()
+                .to_string(),
+            Self::BundleFile(name) => workspace.bundle_dir().join(name).display().to_string(),
+            Self::CurieChart => chart.display().to_string(),
+        }
+    }
+}
+
+#[derive(Clone)]
+struct InstallCommand {
+    program: &'static str,
+    args: Vec<CommandArg>,
+    helm_target: Option<HelmTarget>,
+}
+
+impl InstallCommand {
+    fn display(&self, chart: &Path) -> String {
+        std::iter::once(self.program.to_string())
+            .chain(self.args.iter().map(|arg| arg.display(chart)))
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
+}
+
+#[derive(Clone)]
+struct HelmTarget {
+    release: &'static str,
+    namespace: &'static str,
+}
+
+fn plain(value: impl Into<String>) -> CommandArg {
+    CommandArg::Plain(value.into())
+}
+
+fn helm_repo_commands() -> Vec<InstallCommand> {
+    vec![
+        InstallCommand {
+            program: "helm",
+            args: vec![
+                plain("repo"),
+                plain("add"),
+                plain("grafana-community"),
+                plain("https://grafana-community.github.io/helm-charts"),
+                plain("--force-update"),
+            ],
+            helm_target: None,
+        },
+        InstallCommand {
+            program: "helm",
+            args: vec![
+                plain("repo"),
+                plain("add"),
+                plain("grafana"),
+                plain("https://grafana.github.io/helm-charts"),
+                plain("--force-update"),
+            ],
+            helm_target: None,
+        },
+        InstallCommand {
+            program: "helm",
+            args: vec![
+                plain("repo"),
+                plain("add"),
+                plain("prometheus-community"),
+                plain("https://prometheus-community.github.io/helm-charts"),
+                plain("--force-update"),
+            ],
+            helm_target: None,
+        },
+        InstallCommand {
+            program: "helm",
+            args: vec![
+                plain("repo"),
+                plain("update"),
+                plain("grafana-community"),
+                plain("grafana"),
+                plain("prometheus-community"),
+            ],
+            helm_target: None,
+        },
+    ]
+}
+
+fn upstream_upgrade(
+    release: &'static str,
+    chart: &'static str,
+    version: &'static str,
+    values: &'static str,
+) -> InstallCommand {
+    InstallCommand {
+        program: "helm",
+        args: vec![
+            plain("upgrade"),
+            plain("--install"),
+            plain(release),
+            plain(chart),
+            plain("--version"),
+            plain(version),
+            plain("--namespace"),
+            plain(OBSERVABILITY_NAMESPACE),
+            plain("--create-namespace"),
+            plain("-f"),
+            CommandArg::ObservabilityFile(values),
+            plain("--wait"),
+            plain("--timeout"),
+            plain(HELM_TIMEOUT),
+        ],
+        helm_target: Some(HelmTarget {
+            release,
+            namespace: OBSERVABILITY_NAMESPACE,
+        }),
+    }
+}
+
+fn stack_install_commands() -> Vec<InstallCommand> {
+    let mut commands = helm_repo_commands();
+    commands.extend([
+        upstream_upgrade(
+            "grafana",
+            "grafana-community/grafana",
+            "12.11.1",
+            "grafana-values.yaml",
+        ),
+        upstream_upgrade(
+            "loki",
+            "grafana-community/loki",
+            "18.10.1",
+            "loki-values.yaml",
+        ),
+        upstream_upgrade("alloy", "grafana/alloy", "1.11.1", "alloy-values.yaml"),
+        upstream_upgrade(
+            "prometheus",
+            "prometheus-community/prometheus",
+            "29.27.0",
+            "prometheus-values.yaml",
+        ),
+        InstallCommand {
+            program: "kubectl",
+            args: vec![
+                plain("apply"),
+                plain("--namespace"),
+                plain(OBSERVABILITY_NAMESPACE),
+                plain("-f"),
+                CommandArg::ObservabilityFile("tempo.yaml"),
+            ],
+            helm_target: None,
+        },
+        InstallCommand {
+            program: "kubectl",
+            args: vec![
+                plain("rollout"),
+                plain("status"),
+                plain("statefulset/tempo"),
+                plain("--namespace"),
+                plain(OBSERVABILITY_NAMESPACE),
+                plain(format!("--timeout={HELM_TIMEOUT}")),
+            ],
+            helm_target: None,
+        },
+    ]);
+    commands
+}
+
+fn curie_integration_command() -> InstallCommand {
+    InstallCommand {
+        program: "helm",
+        args: vec![
+            plain("upgrade"),
+            plain(CURIE_RELEASE),
+            CommandArg::CurieChart,
+            plain("--namespace"),
+            plain(CURIE_NAMESPACE),
+            plain("--reuse-values"),
+            plain("-f"),
+            CommandArg::ObservabilityFile("curie-values.yaml"),
+            plain("--wait"),
+            plain("--timeout"),
+            plain(HELM_TIMEOUT),
+        ],
+        helm_target: Some(HelmTarget {
+            release: CURIE_RELEASE,
+            namespace: CURIE_NAMESPACE,
+        }),
+    }
+}
+
+fn read_access_command() -> InstallCommand {
+    InstallCommand {
+        program: "kubectl",
+        args: vec![
+            plain("apply"),
+            plain("-f"),
+            CommandArg::BundleFile("manifests/read-access.yaml"),
+        ],
+        helm_target: None,
+    }
+}
+
+pub async fn install_sre_bot(opts: SreBotInstallOpts) -> Result<SreBotInstallResult> {
+    if !opts.observability {
+        return Err(crate::exit::usage(
+            "the SRE bot example installer currently requires --observability",
+        ));
+    }
+
+    preflight_capacity().await?;
+
+    let resolved_chart = crate::artifacts::resolve_chart(
+        None,
+        crate::artifacts::Channel::current(),
+        crate::artifacts::version(),
+        crate::artifacts::cache_root,
+        Path::new("charts/curie").is_dir(),
+    )?;
+    let stack_commands = stack_install_commands();
+    let integration_command = curie_integration_command();
+    let read_access_command = read_access_command();
+
+    if opts.dry_run {
+        let chart = resolved_chart.planned_target();
+        let mut lines = vec![format!(
+            "resolve {TEMPO_TAGGED_IMAGE} to its immutable OCI image index digest before cluster mutation"
+        )];
+        lines.push(format!(
+            "preserve or create Secret {GRAFANA_ADMIN_SECRET} in namespace {OBSERVABILITY_NAMESPACE} without exposing its generated password"
+        ));
+        lines.extend(stack_commands.iter().map(|command| command.display(&chart)));
+        lines.extend(apply_curie_platform(&chart, true).await?);
+        lines.push(integration_command.display(&chart));
+        lines.push(read_access_command.display(&chart));
+        lines.push(format!(
+            "kubectl wait --namespace {CURIE_NAMESPACE} --for=jsonpath={{.data.token}} secret/{READER_TOKEN_SECRET} --timeout={READER_TOKEN_TIMEOUT}"
+        ));
+        lines.push(
+            "build the read only Kubernetes connector kubeconfig in memory from the ServiceAccount token"
+                .to_string(),
+        );
+        let mut deploy = "curie cluster deploy --plugin-dir embedded:examples/sre-bot --namespace curie --release curie".to_string();
+        if let Some(channel) = &opts.slack_channel {
+            deploy.push_str(&format!(" --slack-channel {channel}"));
+        }
+        lines.push(deploy);
+        lines.push(
+            "render and reconcile the deployed version connectors with the owned Kubernetes kubeconfig Secret override"
+                .to_string(),
+        );
+        return Ok(SreBotInstallResult::DryRun(DryRunPlan { lines }));
+    }
+
+    let tempo_digest = resolve_tempo_index_digest().await?;
+    let chart = crate::artifacts::ensure_cached(&resolved_chart).await?;
+    crate::ops::require_on_path("helm")?;
+    let workspace = EmbeddedWorkspace::create(&tempo_digest)?;
+    ensure_grafana_admin_secret().await?;
+    for command in &stack_commands {
+        run_install_command(command, &workspace, &chart).await?;
+    }
+    apply_curie_platform(&chart, false).await?;
+    run_install_command(&integration_command, &workspace, &chart).await?;
+    run_install_command(&read_access_command, &workspace, &chart).await?;
+    let kubeconfig = read_only_connector_kubeconfig().await?;
+
+    let bundle_dir = workspace.bundle_dir();
+    let connection = resolve_embedded_cluster_connection().await?;
+    let deployed =
+        deploy_embedded_sre_bot(&bundle_dir, &connection, opts.slack_channel.as_deref()).await?;
+    let secret_overrides = BTreeMap::from([(KUBECONFIG_SECRET_KEY.to_string(), kubeconfig)]);
+    crate::connectors::sync_deployed_version(
+        &connection.api_url,
+        &connection.api_key,
+        CURIE_NAMESPACE,
+        CURIE_RELEASE,
+        &deployed,
+        &secret_overrides,
+    )
+    .await?;
+    Ok(SreBotInstallResult::Installed(Box::new(deployed)))
+}
+
+async fn apply_curie_platform(chart: &Path, dry_run: bool) -> Result<Vec<String>> {
+    let installation = crate::installation::Installation {
+        version: crate::installation::SUPPORTED_VERSION,
+        install: crate::installation::Install {
+            namespace: CURIE_NAMESPACE.to_string(),
+            release: CURIE_RELEASE.to_string(),
+        },
+        platform: crate::installation::Platform::default(),
+        credentials: crate::installation::Credentials::default(),
+        comms: crate::installation::Comms::default(),
+        set: BTreeMap::new(),
+    };
+    let local = crate::installation::plan_installation(installation, dry_run)?;
+    match crate::installation::apply(crate::installation::ApplyOpts {
+        local,
+        chart: chart.display().to_string(),
+        allow_stateful_removal: false,
+        migrate_store: false,
+    })
+    .await?
+    {
+        crate::installation::ApplyOutput::DryRun(plan) => Ok(plan.lines),
+        crate::installation::ApplyOutput::Applied { .. } => Ok(Vec::new()),
+    }
+}
+
+#[derive(Deserialize)]
+struct RegistryToken {
+    #[serde(alias = "access_token")]
+    token: String,
+}
+
+async fn resolve_tempo_index_digest() -> Result<String> {
+    let registry = std::env::var("CURIE_TEST_SRE_BOT_REGISTRY_ENDPOINT")
+        .unwrap_or_else(|_| "https://ghcr.io".to_string());
+    let registry = registry.trim_end_matches('/');
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .build()
+        .context("building the anonymous GHCR client")?;
+    let token_response = client
+        .get(format!("{registry}/token"))
+        .query(&[
+            ("service", "ghcr.io"),
+            ("scope", "repository:curie-eng/curie-sre-bot-tempo:pull"),
+        ])
+        .send()
+        .await
+        .with_context(|| format!("resolving {TEMPO_TAGGED_IMAGE} before cluster mutation"))?;
+    if !token_response.status().is_success() {
+        bail!(
+            "could not resolve {TEMPO_TAGGED_IMAGE} before cluster mutation: anonymous GHCR token request returned HTTP {}",
+            token_response.status()
+        );
+    }
+    let token: RegistryToken = token_response
+        .json()
+        .await
+        .with_context(|| format!("reading the anonymous token for {TEMPO_TAGGED_IMAGE}"))?;
+    if token.token.is_empty() {
+        bail!("could not resolve {TEMPO_TAGGED_IMAGE}: GHCR returned an empty token");
+    }
+
+    let manifest_response = client
+        .get(format!(
+            "{registry}/v2/curie-eng/curie-sre-bot-tempo/manifests/{TEMPO_IMAGE_TAG}"
+        ))
+        .bearer_auth(&token.token)
+        .header(
+            reqwest::header::ACCEPT,
+            format!("{OCI_INDEX_MEDIA_TYPE}, {DOCKER_INDEX_MEDIA_TYPE}"),
+        )
+        .send()
+        .await
+        .with_context(|| format!("fetching the OCI image index for {TEMPO_TAGGED_IMAGE}"))?;
+    if !manifest_response.status().is_success() {
+        bail!(
+            "could not resolve {TEMPO_TAGGED_IMAGE}: OCI index request returned HTTP {}",
+            manifest_response.status()
+        );
+    }
+    let body = manifest_response
+        .bytes()
+        .await
+        .with_context(|| format!("reading the OCI image index for {TEMPO_TAGGED_IMAGE}"))?;
+    let manifest: serde_json::Value = serde_json::from_slice(&body)
+        .with_context(|| format!("{TEMPO_TAGGED_IMAGE} returned a malformed OCI index"))?;
+    let media_type = manifest
+        .get("mediaType")
+        .and_then(serde_json::Value::as_str);
+    let is_index_media_type = matches!(
+        media_type,
+        Some(OCI_INDEX_MEDIA_TYPE) | Some(DOCKER_INDEX_MEDIA_TYPE)
+    );
+    let is_index = is_index_media_type
+        && manifest
+            .get("schemaVersion")
+            .and_then(serde_json::Value::as_u64)
+            == Some(2)
+        && manifest
+            .get("manifests")
+            .is_some_and(serde_json::Value::is_array);
+    if !is_index {
+        bail!(
+            "could not resolve {TEMPO_TAGGED_IMAGE}: expected an OCI image index, got {}",
+            media_type.unwrap_or("no mediaType")
+        );
+    }
+    let digest_hex = Sha256::digest(&body)
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    let digest = format!("sha256:{digest_hex}");
+    validate_sha256_digest(&digest)?;
+    Ok(digest)
+}
+
+fn validate_sha256_digest(digest: &str) -> Result<()> {
+    let Some(hex) = digest.strip_prefix("sha256:") else {
+        bail!("resolved Tempo image digest must start with sha256:");
+    };
+    if hex.len() != 64 || !hex.chars().all(|character| character.is_ascii_hexdigit()) {
+        bail!("resolved Tempo image digest must contain 64 lowercase hexadecimal characters");
+    }
+    if hex != hex.to_ascii_lowercase() {
+        bail!("resolved Tempo image digest must contain 64 lowercase hexadecimal characters");
+    }
+    Ok(())
+}
+
+async fn ensure_grafana_admin_secret() -> Result<()> {
+    ensure_observability_namespace().await?;
+    let inspect = tokio::process::Command::new("kubectl")
+        .args([
+            "get",
+            "secret",
+            GRAFANA_ADMIN_SECRET,
+            "--namespace",
+            OBSERVABILITY_NAMESPACE,
+            "-o",
+            "json",
+        ])
+        .output()
+        .await
+        .context("inspecting the Grafana admin Secret")?;
+    if inspect.status.success() {
+        return Ok(());
+    }
+    let stderr = String::from_utf8_lossy(&inspect.stderr);
+    let lower = stderr.to_ascii_lowercase();
+    if !lower.contains("notfound") && !lower.contains("not found") {
+        bail!(
+            "could not inspect Secret {GRAFANA_ADMIN_SECRET} in namespace {OBSERVABILITY_NAMESPACE} with `kubectl get secret {GRAFANA_ADMIN_SECRET} -n {OBSERVABILITY_NAMESPACE}`: {}",
+            stderr.trim()
+        );
+    }
+
+    if grafana_release_exists().await? {
+        return migrate_grafana_admin_secret().await;
+    }
+
+    let password = random_hex(32)?;
+    let manifest = serde_json::to_vec(&serde_json::json!({
+        "apiVersion": "v1",
+        "kind": "Secret",
+        "metadata": {
+            "name": GRAFANA_ADMIN_SECRET,
+            "namespace": OBSERVABILITY_NAMESPACE,
+        },
+        "type": "Opaque",
+        "stringData": {
+            "admin-user": "admin",
+            "admin-password": password,
+        },
+    }))?;
+    apply_private_manifest(&manifest, "Grafana admin Secret").await
+}
+
+async fn grafana_release_exists() -> Result<bool> {
+    let output = tokio::process::Command::new("helm")
+        .args([
+            "status",
+            GRAFANA_RELEASE,
+            "--namespace",
+            OBSERVABILITY_NAMESPACE,
+            "-o",
+            "json",
+        ])
+        .output()
+        .await
+        .context("inspecting the existing Grafana release")?;
+    if output.status.success() {
+        return Ok(true);
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if stderr.trim() == "Error: release: not found" {
+        return Ok(false);
+    }
+    bail!(
+        "could not determine whether Grafana is already installed; run `helm status {GRAFANA_RELEASE} -n {OBSERVABILITY_NAMESPACE}` and retry"
+    )
+}
+
+#[derive(Clone)]
+struct SecretKeyReference {
+    name: String,
+    key: String,
+}
+
+async fn migrate_grafana_admin_secret() -> Result<()> {
+    let output = tokio::process::Command::new("kubectl")
+        .args([
+            "get",
+            "deployment,statefulset",
+            "--namespace",
+            OBSERVABILITY_NAMESPACE,
+            "-l",
+            "app.kubernetes.io/instance=grafana",
+            "-o",
+            "json",
+        ])
+        .output()
+        .await
+        .context("discovering the existing Grafana admin credential")?;
+    if !output.status.success() {
+        bail!("could not read the existing Grafana admin credential");
+    }
+    let workloads: serde_json::Value = serde_json::from_slice(&output.stdout)
+        .context("the existing Grafana workload response was malformed")?;
+    let user = find_grafana_secret_reference(&workloads, "GF_SECURITY_ADMIN_USER")?;
+    let password = find_grafana_secret_reference(&workloads, "GF_SECURITY_ADMIN_PASSWORD")?;
+
+    let mut source_secrets = BTreeMap::new();
+    for source_name in [&user.name, &password.name] {
+        if source_secrets.contains_key(source_name) {
+            continue;
+        }
+        let source = tokio::process::Command::new("kubectl")
+            .args([
+                "get",
+                "secret",
+                source_name,
+                "--namespace",
+                OBSERVABILITY_NAMESPACE,
+                "-o",
+                "json",
+            ])
+            .output()
+            .await
+            .context("reading the existing Grafana admin credential")?;
+        if !source.status.success() {
+            bail!("could not read the existing Grafana admin credential");
+        }
+        let secret: serde_json::Value = serde_json::from_slice(&source.stdout)
+            .context("the existing Grafana admin Secret response was malformed")?;
+        source_secrets.insert(source_name.clone(), secret);
+    }
+
+    let user_data = secret_data_value(&source_secrets, &user)?;
+    let password_data = secret_data_value(&source_secrets, &password)?;
+    let manifest = serde_json::to_vec(&serde_json::json!({
+        "apiVersion": "v1",
+        "kind": "Secret",
+        "metadata": {
+            "name": GRAFANA_ADMIN_SECRET,
+            "namespace": OBSERVABILITY_NAMESPACE,
+        },
+        "type": "Opaque",
+        "data": {
+            "admin-user": user_data,
+            "admin-password": password_data,
+        },
+    }))?;
+    apply_private_manifest(&manifest, "Grafana admin Secret").await
+}
+
+fn find_grafana_secret_reference(
+    workloads: &serde_json::Value,
+    env_name: &str,
+) -> Result<SecretKeyReference> {
+    let mut references = Vec::new();
+    for item in workloads
+        .get("items")
+        .and_then(serde_json::Value::as_array)
+        .into_iter()
+        .flatten()
+    {
+        for container in item
+            .pointer("/spec/template/spec/containers")
+            .and_then(serde_json::Value::as_array)
+            .into_iter()
+            .flatten()
+        {
+            for env in container
+                .get("env")
+                .and_then(serde_json::Value::as_array)
+                .into_iter()
+                .flatten()
+            {
+                if env.get("name").and_then(serde_json::Value::as_str) != Some(env_name) {
+                    continue;
+                }
+                let reference = env.pointer("/valueFrom/secretKeyRef").ok_or_else(|| {
+                    anyhow!("could not read the existing Grafana admin credential")
+                })?;
+                let name = reference
+                    .get("name")
+                    .and_then(serde_json::Value::as_str)
+                    .filter(|value| !value.is_empty())
+                    .ok_or_else(|| {
+                        anyhow!("could not read the existing Grafana admin credential")
+                    })?;
+                let key = reference
+                    .get("key")
+                    .and_then(serde_json::Value::as_str)
+                    .filter(|value| !value.is_empty())
+                    .ok_or_else(|| {
+                        anyhow!("could not read the existing Grafana admin credential")
+                    })?;
+                references.push(SecretKeyReference {
+                    name: name.to_string(),
+                    key: key.to_string(),
+                });
+            }
+        }
+    }
+    if references.len() != 1 {
+        bail!("could not read the existing Grafana admin credential");
+    }
+    Ok(references.remove(0))
+}
+
+fn secret_data_value(
+    secrets: &BTreeMap<String, serde_json::Value>,
+    reference: &SecretKeyReference,
+) -> Result<String> {
+    let encoded = secrets
+        .get(&reference.name)
+        .and_then(|secret| secret.get("data"))
+        .and_then(|data| data.get(&reference.key))
+        .and_then(serde_json::Value::as_str)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| anyhow!("could not read the existing Grafana admin credential"))?;
+    base64::engine::general_purpose::STANDARD
+        .decode(encoded)
+        .ok()
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| anyhow!("could not read the existing Grafana admin credential"))?;
+    Ok(encoded.to_string())
+}
+
+async fn ensure_observability_namespace() -> Result<()> {
+    let inspect = tokio::process::Command::new("kubectl")
+        .args(["get", "namespace", OBSERVABILITY_NAMESPACE, "-o", "json"])
+        .output()
+        .await
+        .context("inspecting the observability namespace")?;
+    if inspect.status.success() {
+        return Ok(());
+    }
+    let stderr = String::from_utf8_lossy(&inspect.stderr);
+    let lower = stderr.to_ascii_lowercase();
+    if !lower.contains("notfound") && !lower.contains("not found") {
+        bail!(
+            "could not inspect namespace {OBSERVABILITY_NAMESPACE} with `kubectl get namespace {OBSERVABILITY_NAMESPACE}`: {}",
+            stderr.trim()
+        );
+    }
+    let output = tokio::process::Command::new("kubectl")
+        .args(["create", "namespace", OBSERVABILITY_NAMESPACE])
+        .output()
+        .await
+        .context("creating the observability namespace")?;
+    if !output.status.success() {
+        bail!(
+            "could not create namespace {OBSERVABILITY_NAMESPACE}; run `kubectl create namespace {OBSERVABILITY_NAMESPACE}` and retry"
+        );
+    }
+    Ok(())
+}
+
+async fn apply_private_manifest(manifest: &[u8], description: &str) -> Result<()> {
+    let mut child = tokio::process::Command::new("kubectl")
+        .args(["apply", "-f", "-"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .with_context(|| format!("starting kubectl for {description}"))?;
+    let mut stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| anyhow!("kubectl stdin was unavailable for {description}"))?;
+    stdin
+        .write_all(manifest)
+        .await
+        .with_context(|| format!("writing {description} to kubectl stdin"))?;
+    drop(stdin);
+    let output = child
+        .wait_with_output()
+        .await
+        .with_context(|| format!("waiting for kubectl to apply {description}"))?;
+    if !output.status.success() {
+        bail!(
+            "could not apply {description} {GRAFANA_ADMIN_SECRET} in namespace {OBSERVABILITY_NAMESPACE}; inspect access with `kubectl auth can-i create secret -n {OBSERVABILITY_NAMESPACE}`"
+        );
+    }
+    Ok(())
+}
+
+fn random_hex(bytes: usize) -> Result<String> {
+    let mut value = vec![0u8; bytes];
+    getrandom::fill(&mut value)
+        .map_err(|error| anyhow!("OS random number generator unavailable: {error}"))?;
+    Ok(value.iter().map(|byte| format!("{byte:02x}")).collect())
+}
+
+async fn run_install_command(
+    command: &InstallCommand,
+    workspace: &EmbeddedWorkspace,
+    chart: &Path,
+) -> Result<()> {
+    let args = command
+        .args
+        .iter()
+        .map(|arg| arg.live(workspace, chart))
+        .collect::<Vec<_>>();
+    crate::ui::ui().plumbing(&format!("+ {} {}", command.program, args.join(" ")));
+    let output = tokio::process::Command::new(command.program)
+        .args(&args)
+        .output()
+        .await
+        .with_context(|| format!("failed to invoke `{}`; is it on PATH?", command.program))?;
+    if output.status.success() {
+        return Ok(());
+    }
+
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    if let Some(target) = &command.helm_target {
+        if is_helm_timeout(&stderr) {
+            let recovery = helm_pending_upgrade_recovery(target);
+            return Err(crate::exit::CliError::failure(format!(
+                "Helm timed out waiting for release {} in namespace {}: {}. Recover the pending upgrade with: {}",
+                target.release,
+                target.namespace,
+                if stderr.is_empty() { "command timed out" } else { &stderr },
+                recovery,
+            ))
+            .with_fix(recovery)
+            .into());
+        }
+    }
+    bail!(
+        "`{}` failed: {}",
+        command.display(chart),
+        if stderr.is_empty() {
+            "command exited nonzero"
+        } else {
+            &stderr
+        }
+    )
+}
+
+fn is_helm_timeout(stderr: &str) -> bool {
+    let lower = stderr.to_ascii_lowercase();
+    lower.contains("timed out")
+        || lower.contains("timeout")
+        || lower.contains("context deadline exceeded")
+}
+
+fn helm_pending_upgrade_recovery(target: &HelmTarget) -> String {
+    format!(
+        "kubectl delete secret -n {} -l 'owner=helm,name={},status=pending-upgrade'",
+        target.namespace, target.release
+    )
+}
+
+async fn read_only_connector_kubeconfig() -> Result<String> {
+    let wait_args = [
+        "wait",
+        "--namespace",
+        CURIE_NAMESPACE,
+        "--for=jsonpath={.data.token}",
+        &format!("secret/{READER_TOKEN_SECRET}"),
+        &format!("--timeout={READER_TOKEN_TIMEOUT}"),
+    ];
+    crate::ui::ui().plumbing(&format!("+ kubectl {}", wait_args.join(" ")));
+    let wait = tokio::process::Command::new("kubectl")
+        .args(wait_args)
+        .output()
+        .await
+        .context("waiting for the SRE bot reader ServiceAccount token")?;
+    if !wait.status.success() {
+        let stderr = String::from_utf8_lossy(&wait.stderr);
+        bail!(
+            "the read only connector token {READER_TOKEN_SECRET} was not populated within {READER_TOKEN_TIMEOUT}: {}. Inspect it with `kubectl get secret {READER_TOKEN_SECRET} -n {CURIE_NAMESPACE}` and retry",
+            if stderr.trim().is_empty() {
+                "kubectl wait exited nonzero"
+            } else {
+                stderr.trim()
+            }
+        );
+    }
+
+    let get_args = [
+        "get",
+        "secret",
+        READER_TOKEN_SECRET,
+        "--namespace",
+        CURIE_NAMESPACE,
+        "-o",
+        "json",
+    ];
+    let output = tokio::process::Command::new("kubectl")
+        .args(get_args)
+        .output()
+        .await
+        .context("reading the SRE bot reader ServiceAccount token")?;
+    if !output.status.success() {
+        bail!(
+            "could not read Secret {READER_TOKEN_SECRET} in namespace {CURIE_NAMESPACE}; inspect it with `kubectl get secret {READER_TOKEN_SECRET} -n {CURIE_NAMESPACE}` and retry"
+        );
+    }
+    let secret: serde_json::Value = serde_json::from_slice(&output.stdout)
+        .context("the SRE bot reader token Secret returned malformed JSON")?;
+    let data = secret
+        .get("data")
+        .and_then(serde_json::Value::as_object)
+        .context("the SRE bot reader token Secret has no data")?;
+    let ca = data
+        .get("ca.crt")
+        .and_then(serde_json::Value::as_str)
+        .context("the SRE bot reader token Secret has no ca.crt")?;
+    base64::engine::general_purpose::STANDARD
+        .decode(ca)
+        .context("the SRE bot reader token Secret contains an invalid ca.crt")?;
+    let token = data
+        .get("token")
+        .and_then(serde_json::Value::as_str)
+        .context("the SRE bot reader token Secret has no token")?;
+    let token = base64::engine::general_purpose::STANDARD
+        .decode(token)
+        .context("the SRE bot reader token Secret contains an invalid token")?;
+    let token = String::from_utf8(token)
+        .context("the SRE bot reader token Secret contains a non UTF-8 token")?;
+    if token.is_empty() {
+        bail!("the SRE bot reader token Secret contains an empty token");
+    }
+
+    serde_json::to_string(&serde_json::json!({
+        "apiVersion": "v1",
+        "kind": "Config",
+        "clusters": [{
+            "name": "in-cluster",
+            "cluster": {
+                "server": "https://kubernetes.default.svc",
+                "certificate-authority-data": ca,
+            },
+        }],
+        "users": [{
+            "name": "sre-bot-reader",
+            "user": {"token": token},
+        }],
+        "contexts": [{
+            "name": "sre-bot-reader",
+            "context": {"cluster": "in-cluster", "user": "sre-bot-reader"},
+        }],
+        "current-context": "sre-bot-reader",
+    }))
+    .context("serializing the read only connector kubeconfig")
+}
+
+struct EmbeddedClusterConnection {
+    api_url: String,
+    api_key: String,
+    _port_forward: Option<tokio::process::Child>,
+}
+
+async fn resolve_embedded_cluster_connection() -> Result<EmbeddedClusterConnection> {
+    let api_key = crate::ops::discover_api_key(CURIE_NAMESPACE, CURIE_RELEASE).await?;
+    let explicit_api_url = std::env::var("CURIE_API_URL")
+        .ok()
+        .filter(|value| !value.trim().is_empty());
+    let local_port = crate::message::DEFAULT_API_LOCAL_PORT;
+    let (api_url, port_forward) = match commands::deploy_port_forward(
+        explicit_api_url.as_deref(),
+        CURIE_NAMESPACE,
+        CURIE_RELEASE,
+        local_port,
+        crate::message::API_REMOTE_PORT,
+    ) {
+        Some(command) => {
+            let port_forward = Some(
+                crate::message::start_port_forward(&command, local_port, "SRE bot deploy API")
+                    .await?,
+            );
+            (format!("http://localhost:{local_port}"), port_forward)
+        }
+        None => {
+            let url = explicit_api_url.expect("explicit API URL when no port forward is planned");
+            if crate::api::is_insecure_endpoint(&url) {
+                bail!(
+                    "refusing to send the auto-discovered release key over cleartext HTTP to {url}; use an https:// URL or unset CURIE_API_URL to use the loopback port-forward"
+                );
+            }
+            (url, None)
+        }
+    };
+    Ok(EmbeddedClusterConnection {
+        api_url,
+        api_key,
+        _port_forward: port_forward,
+    })
+}
+
+async fn deploy_embedded_sre_bot(
+    bundle_dir: &Path,
+    connection: &EmbeddedClusterConnection,
+    slack_channel: Option<&str>,
+) -> Result<commands::DeployOutput> {
+    let connect_hint = format!(
+        "the platform API at {} is unreachable; confirm the Curie release with `curie cluster status` and retry this installer",
+        connection.api_url
+    );
+    commands::deploy(DeployOpts {
+        agent: None,
+        target: None,
+        plugin_dir: bundle_dir.to_path_buf(),
+        api_url: connection.api_url.clone(),
+        api_key: connection.api_key.clone(),
+        slack_channel: slack_channel.map(str::to_string),
+        repo: None,
+        env: None,
+        label: None,
+        secret: vec![],
+        secret_binding_supported: false,
+        connect_hint,
+        tier: DeployTier::Cluster,
+    })
+    .await
+}
+
+struct EmbeddedWorkspace {
+    root: PathBuf,
+}
+
+impl EmbeddedWorkspace {
+    fn create(tempo_digest: &str) -> Result<Self> {
+        let root = std::env::temp_dir().join(format!(
+            "curie-sre-bot-install-{}-{}",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir(&root)
+            .with_context(|| format!("creating embedded SRE bot workspace {}", root.display()))?;
+        let workspace = Self { root };
+        for (name, contents) in OBSERVABILITY_FILES {
+            workspace.write(&Path::new("observability").join(name), contents)?;
+        }
+        for (name, contents) in BUNDLE_FILES {
+            if *name == "connectors.yaml" {
+                let source = std::str::from_utf8(contents)
+                    .context("embedded SRE bot connectors.yaml is not UTF-8")?;
+                let mut declaration: serde_json::Value = serde_norway::from_str(source)
+                    .context("parsing embedded SRE bot connectors.yaml")?;
+                let tempo = declaration
+                    .get_mut("connectors")
+                    .and_then(|connectors| connectors.get_mut("tempo"))
+                    .and_then(serde_json::Value::as_object_mut)
+                    .context("embedded SRE bot must declare connectors.tempo")?;
+                if tempo.remove("build").is_none() || tempo.contains_key("image") {
+                    bail!(
+                        "embedded SRE bot Tempo connector must declare one build source and no image before immutable resolution"
+                    );
+                }
+                tempo.insert(
+                    "image".to_string(),
+                    serde_json::Value::String(format!("{TEMPO_IMAGE_REPOSITORY}@{tempo_digest}")),
+                );
+                let pinned = serde_norway::to_string(&declaration)
+                    .context("serializing the immutable SRE bot connector declaration")?;
+                workspace.write(&Path::new("bundle").join(name), pinned.as_bytes())?;
+            } else {
+                workspace.write(&Path::new("bundle").join(name), contents)?;
+            }
+        }
+        Ok(workspace)
+    }
+
+    fn write(&self, relative: &Path, contents: &[u8]) -> Result<()> {
+        let path = self.root.join(relative);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("creating {}", parent.display()))?;
+        }
+        std::fs::write(&path, contents).with_context(|| format!("writing {}", path.display()))
+    }
+
+    fn observability_dir(&self) -> PathBuf {
+        self.root.join("observability")
+    }
+
+    fn bundle_dir(&self) -> PathBuf {
+        self.root.join("bundle")
+    }
+}
+
+impl Drop for EmbeddedWorkspace {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.root);
+    }
+}
+
+#[derive(Deserialize)]
+struct KubeList<T> {
+    items: Vec<T>,
+}
+
+#[derive(Deserialize)]
+struct Node {
+    metadata: ObjectMeta,
+    #[serde(default)]
+    spec: NodeSpec,
+    status: NodeStatus,
+}
+
+#[derive(Deserialize)]
+struct ObjectMeta {
+    name: String,
+    #[serde(default)]
+    namespace: String,
+    #[serde(default)]
+    labels: BTreeMap<String, String>,
+}
+
+#[derive(Default, Deserialize)]
+struct NodeSpec {
+    #[serde(default)]
+    unschedulable: bool,
+}
+
+#[derive(Deserialize)]
+struct NodeStatus {
+    allocatable: BTreeMap<String, String>,
+    conditions: Vec<NodeCondition>,
+}
+
+#[derive(Deserialize)]
+struct NodeCondition {
+    #[serde(rename = "type")]
+    kind: String,
+    status: String,
+}
+
+#[derive(Deserialize)]
+struct Pod {
+    metadata: ObjectMeta,
+    spec: PodSpec,
+    status: PodStatus,
+}
+
+#[derive(Deserialize)]
+struct PodStatus {
+    phase: String,
+}
+
+#[derive(Default, Deserialize)]
+struct PodSpec {
+    #[serde(rename = "nodeName")]
+    node_name: Option<String>,
+    containers: Vec<Container>,
+    #[serde(rename = "initContainers", default)]
+    init_containers: Vec<Container>,
+    #[serde(default)]
+    resources: ResourceRequirements,
+    #[serde(default)]
+    overhead: BTreeMap<String, String>,
+}
+
+#[derive(Deserialize)]
+struct Container {
+    name: String,
+    #[serde(default)]
+    resources: ResourceRequirements,
+    #[serde(rename = "restartPolicy")]
+    restart_policy: Option<String>,
+}
+
+#[derive(Default, Deserialize)]
+struct ResourceRequirements {
+    #[serde(default)]
+    requests: BTreeMap<String, String>,
+}
+
+async fn preflight_capacity() -> Result<()> {
+    crate::ops::require_on_path("kubectl")?;
+    let node_command = "kubectl get nodes -o json";
+    let nodes: KubeList<Node> = read_kubernetes_json(
+        &["get", "nodes", "-o", "json"],
+        node_command,
+        "node allocatable memory",
+    )
+    .await?;
+
+    let mut ready_nodes = BTreeMap::new();
+    for node in nodes.items {
+        let ready = node
+            .status
+            .conditions
+            .iter()
+            .any(|condition| condition.kind == "Ready" && condition.status == "True");
+        if !ready || node.spec.unschedulable {
+            continue;
+        }
+        let memory = node.status.allocatable.get("memory").ok_or_else(|| {
+            anyhow!(
+                "Ready node {} has no status.allocatable.memory; inspect with `{node_command}`",
+                node.metadata.name
+            )
+        })?;
+        ready_nodes.insert(
+            node.metadata.name,
+            parse_memory_quantity(memory)
+                .with_context(|| format!("parsing allocatable memory from `{node_command}`"))?,
+        );
+    }
+    if ready_nodes.is_empty() {
+        bail!(
+            "no Ready schedulable nodes expose allocatable memory; inspect the cluster prerequisite with `{node_command}`"
+        );
+    }
+
+    let pod_command = "kubectl get pods --all-namespaces -o json";
+    let pods: KubeList<Pod> = read_kubernetes_json(
+        &["get", "pods", "--all-namespaces", "-o", "json"],
+        pod_command,
+        "scheduled pod memory requests",
+    )
+    .await?;
+    let ready_names = ready_nodes.keys().cloned().collect::<BTreeSet<_>>();
+    let mut scheduled_requests = 0u128;
+    for pod in pods.items {
+        if matches!(pod.status.phase.as_str(), "Succeeded" | "Failed") {
+            continue;
+        }
+        if is_managed_observability_pod(&pod) {
+            continue;
+        }
+        let Some(node_name) = pod.spec.node_name.as_deref() else {
+            continue;
+        };
+        if !ready_names.contains(node_name) {
+            continue;
+        }
+        scheduled_requests = scheduled_requests
+            .checked_add(effective_pod_memory_request(&pod)?)
+            .ok_or_else(|| anyhow!("scheduled pod memory request total overflowed"))?;
+    }
+
+    let allocatable = ready_nodes.values().try_fold(0u128, |total, memory| {
+        total
+            .checked_add(*memory)
+            .ok_or_else(|| anyhow!("Ready node allocatable memory total overflowed"))
+    })?;
+    let available = allocatable.saturating_sub(scheduled_requests);
+    let required_memory_mib = FIXED_MEMORY_MIB
+        .checked_add(
+            PER_READY_NODE_MEMORY_MIB
+                .checked_mul(ready_nodes.len() as u128)
+                .ok_or_else(|| anyhow!("Ready node memory requirement overflowed"))?,
+        )
+        .ok_or_else(|| anyhow!("observability memory requirement overflowed"))?;
+    let required_memory_bytes = required_memory_mib
+        .checked_mul(MIB)
+        .ok_or_else(|| anyhow!("observability memory byte requirement overflowed"))?;
+    if available < required_memory_bytes {
+        bail!(
+            "curie example sre-bot install --observability has insufficient schedulable memory: required {required_memory_mib}Mi, available {}Mi; reduce scheduled pod requests or add Ready node memory, then rerun this command",
+            available / MIB
+        );
+    }
+    Ok(())
+}
+
+fn is_managed_observability_pod(pod: &Pod) -> bool {
+    if pod.metadata.namespace != OBSERVABILITY_NAMESPACE {
+        return false;
+    }
+    let labels = &pod.metadata.labels;
+    labels
+        .get("app.kubernetes.io/instance")
+        .is_some_and(|instance| MANAGED_HELM_RELEASES.contains(&instance.as_str()))
+        || labels
+            .get("app.kubernetes.io/name")
+            .is_some_and(|name| name == "tempo")
+}
+
+async fn read_kubernetes_json<T: for<'de> Deserialize<'de>>(
+    args: &[&str],
+    display: &str,
+    purpose: &str,
+) -> Result<T> {
+    let output = tokio::process::Command::new("kubectl")
+        .args(args)
+        .output()
+        .await
+        .with_context(|| format!("failed to invoke `{display}`"))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        bail!(
+            "could not read {purpose} with `{display}`: {}",
+            if stderr.is_empty() {
+                "kubectl exited nonzero"
+            } else {
+                &stderr
+            }
+        );
+    }
+    serde_json::from_slice(&output.stdout)
+        .with_context(|| format!("malformed JSON from `{display}` while reading {purpose}"))
+}
+
+fn effective_pod_memory_request(pod: &Pod) -> Result<u128> {
+    let mut application = 0u128;
+    for container in &pod.spec.containers {
+        application = checked_add(
+            application,
+            resource_memory(&container.resources, &pod.metadata.name, &container.name)?,
+        )?;
+    }
+
+    let mut restartable = 0u128;
+    let mut max_init_stage = 0u128;
+    for container in &pod.spec.init_containers {
+        let request = resource_memory(&container.resources, &pod.metadata.name, &container.name)?;
+        let stage = if container.restart_policy.as_deref() == Some("Always") {
+            restartable = checked_add(restartable, request)?;
+            restartable
+        } else {
+            checked_add(restartable, request)?
+        };
+        max_init_stage = max_init_stage.max(stage);
+    }
+
+    let steady_state = checked_add(application, restartable)?;
+    let container_request = steady_state.max(max_init_stage);
+    let pod_level = resource_memory(&pod.spec.resources, &pod.metadata.name, "pod")?;
+    let overhead = optional_memory(&pod.spec.overhead, &pod.metadata.name, "pod overhead")?;
+    checked_add(container_request.max(pod_level), overhead)
+}
+
+fn resource_memory(resources: &ResourceRequirements, pod: &str, container: &str) -> Result<u128> {
+    optional_memory(&resources.requests, pod, container)
+}
+
+fn optional_memory(requests: &BTreeMap<String, String>, pod: &str, owner: &str) -> Result<u128> {
+    requests.get("memory").map_or(Ok(0), |quantity| {
+        parse_memory_quantity(quantity)
+            .with_context(|| format!("invalid memory request for {pod}/{owner}"))
+    })
+}
+
+fn checked_add(left: u128, right: u128) -> Result<u128> {
+    left.checked_add(right)
+        .ok_or_else(|| anyhow!("pod memory request overflowed"))
+}
+
+fn parse_memory_quantity(quantity: &str) -> Result<u128> {
+    let quantity = quantity.trim();
+    let (number, multiplier) = [
+        ("Ei", 1024f64.powi(6)),
+        ("Pi", 1024f64.powi(5)),
+        ("Ti", 1024f64.powi(4)),
+        ("Gi", 1024f64.powi(3)),
+        ("Mi", 1024f64.powi(2)),
+        ("Ki", 1024f64),
+        ("E", 1000f64.powi(6)),
+        ("P", 1000f64.powi(5)),
+        ("T", 1000f64.powi(4)),
+        ("G", 1000f64.powi(3)),
+        ("M", 1000f64.powi(2)),
+        ("K", 1000f64),
+        ("k", 1000f64),
+        ("m", 0.001f64),
+        ("u", 0.000_001f64),
+        ("n", 0.000_000_001f64),
+    ]
+    .into_iter()
+    .find_map(|(suffix, multiplier)| {
+        quantity
+            .strip_suffix(suffix)
+            .map(|number| (number, multiplier))
+    })
+    .unwrap_or((quantity, 1f64));
+    let number = number
+        .parse::<f64>()
+        .with_context(|| format!("unsupported Kubernetes memory quantity {quantity:?}"))?;
+    let bytes = number * multiplier;
+    if !bytes.is_finite() || bytes < 0.0 || bytes > u128::MAX as f64 {
+        bail!("unsupported Kubernetes memory quantity {quantity:?}");
+    }
+    Ok(bytes.ceil() as u128)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn memory_quantities_cover_the_kubernetes_shapes_used_by_nodes_and_pods() {
+        assert_eq!(parse_memory_quantity("1Gi").unwrap(), 1024 * 1024 * 1024);
+        assert_eq!(parse_memory_quantity("1343488Ki").unwrap(), 1312 * MIB);
+        assert_eq!(parse_memory_quantity("500M").unwrap(), 500_000_000);
+        assert_eq!(parse_memory_quantity("1e6").unwrap(), 1_000_000);
+    }
+}

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -19,6 +19,7 @@ pub mod docker;
 pub mod doctor;
 pub mod eval_init;
 pub mod evals;
+pub mod examples;
 pub mod exit;
 pub mod github_app;
 pub mod guide;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -4,6 +4,7 @@
 //! platform API. Task I1; contracts are frozen in packages/aci-protocol and
 //! packages/plugin-format.
 
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 use anyhow::{bail, Result};
@@ -101,47 +102,6 @@ struct ClusterAgentTarget {
     conn: ClusterConn,
     #[arg(long)]
     dry_run: bool,
-}
-
-/// Stand up the connectors this version declares, and prune what it dropped.
-///
-/// Split across the two components on purpose (ADR-0086): the API RENDERS the
-/// Kubernetes objects -- a pure function of the bundle, so it needs no cluster
-/// access and keeps its read-only RBAC on the service that receives internet
-/// webhooks -- and the CLI APPLIES them under the operator's own kubectl
-/// credentials, where cluster-write authority already lived.
-///
-/// A bundle with no `connectors.yaml` still reaches the prune: that is the case
-/// where a connector was REMOVED, and leaving it running with a credential
-/// mounted and nothing referencing it is the leak nobody notices.
-async fn sync_connectors(
-    api_url: &str,
-    api_key: &str,
-    namespace: &str,
-    release: &str,
-    agent_id: &str,
-    agent_name: &str,
-    version_id: &str,
-) -> anyhow::Result<()> {
-    let app_name = curie::connectors::discover_app_name(namespace, release).await?;
-    let client = curie::api::ApiClient::new(api_url, api_key)?;
-    let rendered = client
-        .version_connectors(agent_id, version_id, release, namespace, &app_name)
-        .await?;
-    let synced = curie::connectors::sync(
-        &rendered.manifests,
-        &rendered.mcp_entries,
-        &rendered.owned_secret_name,
-        &rendered.owned_secret_keys,
-        namespace,
-        agent_name,
-    )
-    .await?;
-    let ui = curie::ui::ui();
-    for (name, url) in &synced.urls {
-        ui.note(&format!("connector {name}: {url}"));
-    }
-    Ok(())
 }
 
 /// Resolve a cluster verb's `(api_url, api_key)`: an explicit flag/env value wins;
@@ -259,6 +219,11 @@ enum Command {
     Cluster {
         #[command(subcommand)]
         action: ClusterAction,
+    },
+    /// Install a complete first party example workflow.
+    Example {
+        #[command(subcommand)]
+        action: ExampleAction,
     },
     /// List locally-authored agent bundles under `agents/` (source checkout
     /// only) -- a personal, gitignored directory (sibling of `examples/`) for
@@ -510,6 +475,31 @@ enum Command {
         /// Path to the installation file.
         #[arg(short = 'f', long = "file", default_value = "curie.yaml")]
         file: std::path::PathBuf,
+    },
+}
+
+#[derive(Subcommand)]
+enum ExampleAction {
+    /// Install the self referential SRE bot example.
+    SreBot {
+        #[command(subcommand)]
+        action: SreBotAction,
+    },
+}
+
+#[derive(Subcommand)]
+enum SreBotAction {
+    /// Install Curie, its observability stack, and the SRE bot bundle.
+    Install {
+        /// Install the fixed self referential Grafana, Loki, Alloy, Tempo, and Prometheus stack.
+        #[arg(long, required = true)]
+        observability: bool,
+        /// Print the ordered plan without mutating the cluster.
+        #[arg(long)]
+        dry_run: bool,
+        /// Bind the installed bot to this Slack channel.
+        #[arg(long, value_name = "CHANNEL")]
+        slack_channel: Option<String>,
     },
 }
 
@@ -2048,6 +2038,26 @@ async fn run(command: Option<Command>) -> Result<()> {
             from_spec,
             adopt,
         }) => commands::init(name, dir, from_spec, adopt),
+        Some(Command::Example {
+            action:
+                ExampleAction::SreBot {
+                    action:
+                        SreBotAction::Install {
+                            observability,
+                            dry_run,
+                            slack_channel,
+                        },
+                },
+        }) => match curie::examples::install_sre_bot(curie::examples::SreBotInstallOpts {
+            observability,
+            dry_run,
+            slack_channel,
+        })
+        .await?
+        {
+            curie::examples::SreBotInstallResult::DryRun(plan) => emit(plan),
+            curie::examples::SreBotInstallResult::Installed(deployed) => emit(*deployed),
+        },
         Some(Command::Build {
             tag,
             plugin_dir,
@@ -3242,14 +3252,13 @@ async fn run(command: Option<Command>) -> Result<()> {
                     // are the CONNECTOR's, resolved locally and written straight to
                     // a K8s Secret, which is a different path from the sandbox
                     // secret delivery #440 tracks.
-                    if let Err(err) = sync_connectors(
+                    if let Err(err) = curie::connectors::sync_deployed_version(
                         &api_url,
                         &api_key,
                         &namespace,
                         &release,
-                        &deployed.agent_id,
-                        &deployed.agent_name,
-                        &deployed.version_id,
+                        &deployed,
+                        &BTreeMap::new(),
                     )
                     .await
                     {

--- a/cli/tests/example_sre_bot_install.rs
+++ b/cli/tests/example_sre_bot_install.rs
@@ -1,0 +1,1788 @@
+//! Binary contract for the self contained SRE bot observability installer.
+//!
+//! Every case drives the released command surface with recording `kubectl` and
+//! `helm` peers. The cluster capacity cases stop at the Helm boundary on
+//! purpose: they prove the preflight permits or refuses mutation without
+//! replacing Helm, Kubernetes, or the platform API with internal mocks.
+
+mod support;
+
+use std::fs;
+use std::io::{Cursor, Read};
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use flate2::read::GzDecoder;
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
+use support::{serve, MockServer, Response};
+
+const OBSERVABILITY_NAMESPACE: &str = "observability";
+const FIRST_RELEASE: &str = "grafana";
+const REQUIRED_MIB: u64 = 1312;
+const TEMPO_TAGGED_IMAGE: &str = "ghcr.io/curie-eng/curie-sre-bot-tempo:0.8.0";
+const REGISTRY_INDEX: &str =
+    r#"{"schemaVersion":2,"mediaType":"application/vnd.oci.image.index.v1+json","manifests":[]}"#;
+const REGISTRY_INDEX_WITHOUT_REQUIRED_FIELDS: &str =
+    r#"{"mediaType":"application/vnd.oci.image.index.v1+json"}"#;
+const AGENT_ID: &str = "00000000-0000-0000-0000-000000000001";
+const VERSION_ID: &str = "00000000-0000-0000-0000-000000000002";
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_curie")
+}
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("cli has a repository parent")
+        .to_path_buf()
+}
+
+fn write_exec(dir: &Path, name: &str, body: &str) {
+    let path = dir.join(name);
+    fs::write(&path, body).unwrap_or_else(|error| panic!("write {name}: {error}"));
+    let mut permissions = fs::metadata(&path)
+        .unwrap_or_else(|error| panic!("read {name} metadata: {error}"))
+        .permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&path, permissions)
+        .unwrap_or_else(|error| panic!("make {name} executable: {error}"));
+}
+
+struct Fixture {
+    _temp: tempfile::TempDir,
+    bin_dir: PathBuf,
+    helm_log: PathBuf,
+    kubectl_log: PathBuf,
+    action_log: PathBuf,
+    grafana_stdin: PathBuf,
+    connector_stdin: PathBuf,
+    nodes: String,
+    pods: String,
+    nodes_mode: &'static str,
+    pods_mode: &'static str,
+    helm_mode: &'static str,
+    grafana_secret_mode: &'static str,
+    reader_token_mode: &'static str,
+    helm_values: String,
+    api: MockServer,
+    registry: MockServer,
+    registry_endpoint: String,
+}
+
+impl Fixture {
+    fn new(nodes: Value, pods: Value) -> Self {
+        Self::with_modes(nodes, pods, "success", "success", "stop")
+    }
+
+    fn with_modes(
+        nodes: Value,
+        pods: Value,
+        nodes_mode: &'static str,
+        pods_mode: &'static str,
+        helm_mode: &'static str,
+    ) -> Self {
+        let temp = tempfile::tempdir().expect("temporary directory");
+        let bin_dir = temp.path().join("bin");
+        fs::create_dir(&bin_dir).expect("create fake binary directory");
+        let helm_log = temp.path().join("helm.log");
+        let kubectl_log = temp.path().join("kubectl.log");
+        let action_log = temp.path().join("actions.log");
+        let grafana_stdin = temp.path().join("grafana.stdin");
+        let connector_stdin = temp.path().join("connector.stdin");
+
+        write_exec(
+            &bin_dir,
+            "kubectl",
+            r#"#!/bin/sh
+printf '%s\n' "$*" >> "$CURIE_TEST_KUBECTL_LOG"
+printf 'KUBECTL %s\n' "$*" >> "$CURIE_TEST_ACTION_LOG"
+
+case " $* " in
+    *" get nodes "*|*" get node "*)
+        case "$CURIE_TEST_NODES_MODE" in
+            success) printf '%s\n' "$CURIE_TEST_NODES_JSON" ;;
+            malformed) printf '%s\n' '{"apiVersion":"v1","items":[' ;;
+            failure)
+                printf '%s\n' 'Error from server (Forbidden): nodes is forbidden' >&2
+                exit 1
+                ;;
+        esac
+        exit 0
+        ;;
+    *" get pods "*|*" get pod "*)
+        case "$CURIE_TEST_PODS_MODE" in
+            success) printf '%s\n' "$CURIE_TEST_PODS_JSON" ;;
+            malformed) printf '%s\n' '{"apiVersion":"v1","items":[{"spec":' ;;
+            failure)
+                printf '%s\n' 'Error from server (Forbidden): pods is forbidden' >&2
+                exit 1
+                ;;
+        esac
+        exit 0
+        ;;
+    *" get statefulset "*|*" get statefulsets "*)
+        printf '%s\n' '{"apiVersion":"v1","items":[],"kind":"List","metadata":{"resourceVersion":""}}'
+        exit 0
+        ;;
+    *" get namespace "*)
+        exit 0
+        ;;
+    *" get priorityclass "*|*" get priorityclasses "*)
+        exit 0
+        ;;
+    *" get secret grafana-admin "*)
+        case "$CURIE_TEST_GRAFANA_SECRET_MODE" in
+            existing) printf '%s\n' '{"apiVersion":"v1","kind":"Secret","metadata":{"name":"grafana-admin"}}' ;;
+            absent|apply-failure|migrate|migration-source-failure)
+                printf '%s\n' 'Error from server (NotFound): secrets "grafana-admin" not found' >&2
+                exit 1
+                ;;
+            read-failure)
+                printf '%s\n' 'Error from server (Forbidden): secrets "grafana-admin" is forbidden' >&2
+                exit 1
+                ;;
+        esac
+        exit 0
+        ;;
+    *" get deployment,statefulset "*" app.kubernetes.io/instance=grafana "*)
+        printf '%s\n' '{"apiVersion":"v1","kind":"List","items":[{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"name":"grafana"},"spec":{"template":{"spec":{"containers":[{"name":"grafana","env":[{"name":"GF_SECURITY_ADMIN_USER","valueFrom":{"secretKeyRef":{"name":"grafana","key":"admin-user"}}},{"name":"GF_SECURITY_ADMIN_PASSWORD","valueFrom":{"secretKeyRef":{"name":"grafana","key":"admin-password"}}}] }]}}}}]}'
+        exit 0
+        ;;
+    *" get secret grafana "*)
+        if [ "$CURIE_TEST_GRAFANA_SECRET_MODE" = "migration-source-failure" ]; then
+            printf '%s\n' 'Error from server (Forbidden): secrets "grafana" is forbidden' >&2
+            exit 1
+        fi
+        printf '%s\n' '{"apiVersion":"v1","kind":"Secret","metadata":{"name":"grafana"},"data":{"admin-user":"bWlncmF0ZWQtYWRtaW4=","admin-password":"cHc="}}'
+        exit 0
+        ;;
+    *" wait "*" secret/sre-bot-reader-token "*)
+        case "$CURIE_TEST_READER_TOKEN_MODE" in
+            success|read-failure) exit 0 ;;
+            timeout)
+                printf '%s\n' 'error: timed out waiting for the condition' >&2
+                exit 1
+                ;;
+        esac
+        ;;
+    *" get secret sre-bot-reader-token "*)
+        case "$CURIE_TEST_READER_TOKEN_MODE" in
+            success)
+                printf '%s\n' '{"apiVersion":"v1","kind":"Secret","data":{"ca.crt":"Zml4dHVyZS1jYQ==","token":"YWJj"}}'
+                exit 0
+                ;;
+            read-failure)
+                printf '%s\n' 'Error from server (Forbidden): secrets "sre-bot-reader-token" is forbidden' >&2
+                exit 1
+                ;;
+        esac
+        ;;
+    *" -n curie apply -f - "*)
+        cat > "$CURIE_TEST_CONNECTOR_STDIN"
+        printf '%s\n' 'connector objects configured'
+        exit 0
+        ;;
+    *" apply -f - "*)
+        cat > "$CURIE_TEST_GRAFANA_STDIN"
+        if [ "$CURIE_TEST_GRAFANA_SECRET_MODE" = "apply-failure" ]; then
+            printf '%s\n' 'Error from server (Forbidden): cannot apply grafana-admin' >&2
+            exit 1
+        fi
+        printf '%s\n' 'secret/grafana-admin configured'
+        exit 0
+        ;;
+    *" -n curie get deployment "*" app.kubernetes.io/instance=curie "*)
+        printf '%s\n' 'curie'
+        exit 0
+        ;;
+    *" -n curie delete deployment,service,networkpolicy,secret "*)
+        exit 0
+        ;;
+    *" apply "*|*" rollout status "*)
+        exit 0
+        ;;
+    *" get secret "*" app.kubernetes.io/instance=curie "*)
+        printf '%s\n' 'curie-secrets'
+        exit 0
+        ;;
+    *" get secret curie-secrets "*)
+        printf '%s\n' 'test-api-key'
+        exit 0
+        ;;
+    *" get secret "*)
+        printf '%s\n' '{"data":{"API_KEY":"aw=="}}'
+        exit 0
+        ;;
+esac
+
+printf 'unexpected kubectl invocation: %s\n' "$*" >&2
+exit 64
+"#,
+        );
+
+        write_exec(
+            &bin_dir,
+            "helm",
+            r#"#!/bin/sh
+printf '%s\n' "$*" >> "$CURIE_TEST_HELM_LOG"
+printf 'HELM %s\n' "$*" >> "$CURIE_TEST_ACTION_LOG"
+
+if [ "$1" = "get" ] && [ "$2" = "values" ]; then
+    if [ "${CURIE_TEST_HELM_VALUES:-absent}" = "absent" ]; then
+        printf '%s\n' 'Error: release: not found' >&2
+        exit 1
+    fi
+    printf '%s\n' "$CURIE_TEST_HELM_VALUES"
+    exit 0
+fi
+
+if [ "$1" = "status" ] && [ "$2" = "grafana" ]; then
+    case "$CURIE_TEST_GRAFANA_SECRET_MODE" in
+        migrate|migration-source-failure)
+            printf '%s\n' '{"name":"grafana","namespace":"observability","info":{"status":"deployed"}}'
+            exit 0
+            ;;
+        *)
+            printf '%s\n' 'Error: release: not found' >&2
+            exit 1
+            ;;
+    esac
+fi
+
+if [ "$1" = "repo" ]; then
+    exit 0
+fi
+
+if [ "$1" = "template" ]; then
+    exit 0
+fi
+
+if [ "$1" = "upgrade" ] && [ "$2" = "--install" ]; then
+    case "$CURIE_TEST_HELM_MODE" in
+        timeout)
+            printf '%s\n' 'Error: UPGRADE FAILED: context deadline exceeded' >&2
+            exit 1
+            ;;
+        stop)
+            printf '%s\n' 'intentional fixture stop after Helm mutation boundary' >&2
+            exit 42
+            ;;
+        success)
+            exit 0
+            ;;
+    esac
+fi
+
+if [ "$1" = "upgrade" ] && [ "$2" = "curie" ]; then
+    exit 0
+fi
+
+printf 'unexpected helm invocation: %s\n' "$*" >&2
+exit 64
+"#,
+        );
+
+        let api = serve(
+            |request| match (request.method.as_str(), request.path.as_str()) {
+                ("GET", "/agents") => Response::json(200, "[]"),
+                ("POST", "/agents") => Response::json(
+                    201,
+                    &format!(
+                        r##"{{"id":"{AGENT_ID}","name":"sre-bot","channel":{{"kind":"slack","address":"#local-dev"}},"created_at":"2026-08-21T00:00:00Z"}}"##
+                    ),
+                ),
+                ("POST", path) if path == format!("/agents/{AGENT_ID}/versions") => Response::json(
+                    201,
+                    &format!(
+                        r#"{{"id":"{VERSION_ID}","agent_id":"{AGENT_ID}","version_label":"0.1.0-test","bundle_ref":null,"bundle_sha256":null,"created_by":"tester","created_at":"2026-08-21T00:00:00Z"}}"#
+                    ),
+                ),
+                ("PUT", path)
+                    if path == format!("/agents/{AGENT_ID}/versions/{VERSION_ID}/bundle") =>
+                {
+                    Response::json(
+                        201,
+                        &format!(
+                            r#"{{"version_id":"{VERSION_ID}","bundle_ref":"bundles/sre-bot.tar.gz","bundle_sha256":"fixture-digest","size_bytes":512}}"#
+                        ),
+                    )
+                }
+                ("POST", "/deployments") => Response::json(
+                    201,
+                    &format!(
+                        r#"{{"id":"00000000-0000-0000-0000-000000000003","agent_id":"{AGENT_ID}","version_id":"{VERSION_ID}","environment":"dev","status":"active","deployed_at":"2026-08-21T00:00:00Z"}}"#
+                    ),
+                ),
+                ("GET", path)
+                    if path.starts_with(&format!(
+                        "/agents/{AGENT_ID}/versions/{VERSION_ID}/connectors?"
+                    )) =>
+                {
+                    Response::json(
+                        200,
+                        r#"{"manifests":[{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"name":"curie-sre-bot-kubernetes"}}],"owned_secret_name":"curie-sre-bot-connector-secrets","owned_secret_keys":["K8S_READONLY_KUBECONFIG"],"mcp_entries":{"kubernetes":{"url":"http://curie-sre-bot-kubernetes.curie.svc.cluster.local:8000/mcp"}}}"#,
+                    )
+                }
+                _ => Response::json(500, r#"{"error":"unexpected API request"}"#),
+            },
+        );
+        let registry = serve(|request| {
+            if request.path.starts_with("/failure/") {
+                return Response::json(503, r#"{"error":"registry unavailable"}"#);
+            }
+            if request.path.starts_with("/token?")
+                || request.path.starts_with("/wrong-shape/token?")
+            {
+                return Response::json(200, r#"{"token":"anonymous-pull-token"}"#);
+            }
+            if request.path == "/wrong-shape/v2/curie-eng/curie-sre-bot-tempo/manifests/0.8.0" {
+                return Response {
+                    status: 200,
+                    content_type: "application/vnd.oci.image.index.v1+json".into(),
+                    body: REGISTRY_INDEX_WITHOUT_REQUIRED_FIELDS.as_bytes().to_vec(),
+                };
+            }
+            if request.path == "/v2/curie-eng/curie-sre-bot-tempo/manifests/0.8.0" {
+                return Response {
+                    status: 200,
+                    content_type: "application/vnd.oci.image.index.v1+json".into(),
+                    body: REGISTRY_INDEX.as_bytes().to_vec(),
+                };
+            }
+            Response::json(404, r#"{"error":"not found"}"#)
+        });
+        let registry_endpoint = registry.base_url.clone();
+
+        Self {
+            _temp: temp,
+            bin_dir,
+            helm_log,
+            kubectl_log,
+            action_log,
+            grafana_stdin,
+            connector_stdin,
+            nodes: nodes.to_string(),
+            pods: pods.to_string(),
+            nodes_mode,
+            pods_mode,
+            helm_mode,
+            grafana_secret_mode: "existing",
+            reader_token_mode: "success",
+            helm_values: "absent".to_string(),
+            api,
+            registry,
+            registry_endpoint,
+        }
+    }
+
+    fn with_grafana_secret_mode(mut self, mode: &'static str) -> Self {
+        self.grafana_secret_mode = mode;
+        self
+    }
+
+    fn with_registry_failure(mut self) -> Self {
+        self.registry_endpoint = format!("{}/failure", self.registry.base_url);
+        self
+    }
+
+    fn with_registry_wrong_shape(mut self) -> Self {
+        self.registry_endpoint = format!("{}/wrong-shape", self.registry.base_url);
+        self
+    }
+
+    fn with_reader_token_mode(mut self, mode: &'static str) -> Self {
+        self.reader_token_mode = mode;
+        self
+    }
+
+    fn with_helm_values(mut self, values: Value) -> Self {
+        self.helm_values = values.to_string();
+        self
+    }
+
+    fn run(&self, extra: &[&str]) -> Output {
+        self.run_from(extra, &repo_root(), None)
+    }
+
+    fn run_from(&self, extra: &[&str], current_dir: &Path, release_cache: Option<&Path>) -> Output {
+        let mut paths = vec![self.bin_dir.clone()];
+        if let Some(current) = std::env::var_os("PATH") {
+            paths.extend(std::env::split_paths(&current));
+        }
+        let path = std::env::join_paths(paths).expect("join PATH");
+
+        let mut args = vec![
+            "--color",
+            "never",
+            "example",
+            "sre-bot",
+            "install",
+            "--observability",
+        ];
+        args.extend_from_slice(extra);
+
+        let mut command = Command::new(bin());
+        command
+            .current_dir(current_dir)
+            .args(args)
+            .env("PATH", path)
+            .env("CI", "1")
+            .env("TERM", "dumb")
+            .env("NO_COLOR", "1")
+            .env("CURIE_API_URL", &self.api.base_url)
+            .env("CURIE_TEST_HELM_LOG", &self.helm_log)
+            .env("CURIE_TEST_KUBECTL_LOG", &self.kubectl_log)
+            .env("CURIE_TEST_ACTION_LOG", &self.action_log)
+            .env("CURIE_TEST_GRAFANA_STDIN", &self.grafana_stdin)
+            .env("CURIE_TEST_CONNECTOR_STDIN", &self.connector_stdin)
+            .env("CURIE_TEST_NODES_JSON", &self.nodes)
+            .env("CURIE_TEST_PODS_JSON", &self.pods)
+            .env("CURIE_TEST_NODES_MODE", self.nodes_mode)
+            .env("CURIE_TEST_PODS_MODE", self.pods_mode)
+            .env("CURIE_TEST_HELM_MODE", self.helm_mode)
+            .env("CURIE_TEST_HELM_VALUES", &self.helm_values)
+            .env("CURIE_TEST_GRAFANA_SECRET_MODE", self.grafana_secret_mode)
+            .env("CURIE_TEST_READER_TOKEN_MODE", self.reader_token_mode)
+            .env(
+                "CURIE_TEST_SRE_BOT_REGISTRY_ENDPOINT",
+                &self.registry_endpoint,
+            )
+            .env_remove("CURIE_API_KEY")
+            .env_remove("CURIE_CREDENTIALS")
+            .env_remove("CURIE_MODEL_CREDENTIALS")
+            .env_remove("CURIE_GITHUB_TOKEN")
+            .env_remove("CURIE_MODEL")
+            .env_remove("GRAFANA_ADMIN_PASSWORD")
+            .env_remove("GRAFANA_SERVICE_ACCOUNT_TOKEN");
+        if let Some(cache) = release_cache {
+            command
+                .env("CURIE_TEST_ARTIFACT_CHANNEL", "release")
+                .env("XDG_CACHE_HOME", cache);
+        } else {
+            command.env_remove("CURIE_TEST_ARTIFACT_CHANNEL");
+        }
+        command.output().expect("run SRE bot example installer")
+    }
+
+    fn helm_calls(&self) -> Vec<String> {
+        lines(&self.helm_log)
+    }
+
+    fn kubectl_calls(&self) -> Vec<String> {
+        lines(&self.kubectl_log)
+    }
+
+    fn kubectl_stdin(&self) -> Vec<u8> {
+        fs::read(&self.grafana_stdin).unwrap_or_default()
+    }
+
+    fn connector_stdin(&self) -> Vec<u8> {
+        fs::read(&self.connector_stdin).unwrap_or_default()
+    }
+
+    fn actions(&self) -> Vec<String> {
+        lines(&self.action_log)
+    }
+}
+
+fn lines(path: &Path) -> Vec<String> {
+    fs::read_to_string(path)
+        .unwrap_or_default()
+        .lines()
+        .map(str::to_string)
+        .collect()
+}
+
+fn shown(output: &Output) -> String {
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+fn expected_tempo_digest() -> String {
+    let hex = Sha256::digest(REGISTRY_INDEX.as_bytes())
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    format!("sha256:{hex}")
+}
+
+fn uploaded_bundle_file(fixture: &Fixture, wanted: &str) -> Vec<u8> {
+    let upload = fixture
+        .api
+        .recorded()
+        .into_iter()
+        .find(|request| request.method == "PUT" && request.path.ends_with("/bundle"))
+        .unwrap_or_else(|| panic!("deploy must upload the embedded bundle"));
+    let gzip_start = upload
+        .body
+        .windows(2)
+        .position(|window| window == [0x1f, 0x8b])
+        .expect("multipart upload must contain a gzip archive");
+    let decoder = GzDecoder::new(Cursor::new(&upload.body[gzip_start..]));
+    let mut archive = tar::Archive::new(decoder);
+    for entry in archive.entries().expect("read uploaded bundle archive") {
+        let mut entry = entry.expect("read uploaded bundle entry");
+        if entry.path().expect("bundle path").as_ref() == Path::new(wanted) {
+            let mut contents = Vec::new();
+            entry
+                .read_to_end(&mut contents)
+                .expect("read uploaded bundle file");
+            return contents;
+        }
+    }
+    panic!("uploaded bundle must contain {wanted}");
+}
+
+fn node(name: &str, memory: &str, ready: bool) -> Value {
+    json!({
+        "metadata": {"name": name},
+        "status": {
+            "allocatable": {"memory": memory},
+            "conditions": [{
+                "type": "Ready",
+                "status": if ready { "True" } else { "False" }
+            }]
+        }
+    })
+}
+
+fn nodes(items: Vec<Value>) -> Value {
+    json!({"apiVersion": "v1", "kind": "List", "items": items})
+}
+
+fn pods(items: Vec<Value>) -> Value {
+    json!({"apiVersion": "v1", "kind": "List", "items": items})
+}
+
+fn pod(name: &str, node_name: Option<&str>, phase: &str, containers: Value) -> Value {
+    let mut spec = json!({"containers": containers});
+    if let Some(node_name) = node_name {
+        spec["nodeName"] = json!(node_name);
+    }
+    json!({
+        "metadata": {"name": name, "namespace": "fixture"},
+        "spec": spec,
+        "status": {"phase": phase}
+    })
+}
+
+fn labeled_pod(name: &str, node_name: &str, namespace: &str, labels: Value, memory: &str) -> Value {
+    let mut value = pod(
+        name,
+        Some(node_name),
+        "Running",
+        json!([memory_container("app", memory)]),
+    );
+    value["metadata"]["namespace"] = json!(namespace);
+    value["metadata"]["labels"] = labels;
+    value
+}
+
+fn managed_stack_pods(node_name: &str) -> Vec<Value> {
+    vec![
+        labeled_pod(
+            "grafana",
+            node_name,
+            OBSERVABILITY_NAMESPACE,
+            json!({"app.kubernetes.io/instance": "grafana"}),
+            "128Mi",
+        ),
+        labeled_pod(
+            "loki",
+            node_name,
+            OBSERVABILITY_NAMESPACE,
+            json!({"app.kubernetes.io/instance": "loki"}),
+            "256Mi",
+        ),
+        labeled_pod(
+            "alloy",
+            node_name,
+            OBSERVABILITY_NAMESPACE,
+            json!({"app.kubernetes.io/instance": "alloy"}),
+            "128Mi",
+        ),
+        labeled_pod(
+            "tempo",
+            node_name,
+            OBSERVABILITY_NAMESPACE,
+            json!({"app.kubernetes.io/name": "tempo"}),
+            "192Mi",
+        ),
+        labeled_pod(
+            "prometheus-server",
+            node_name,
+            OBSERVABILITY_NAMESPACE,
+            json!({"app.kubernetes.io/instance": "prometheus"}),
+            "512Mi",
+        ),
+        labeled_pod(
+            "kube-state-metrics",
+            node_name,
+            OBSERVABILITY_NAMESPACE,
+            json!({"app.kubernetes.io/instance": "prometheus"}),
+            "64Mi",
+        ),
+        labeled_pod(
+            "node-exporter",
+            node_name,
+            OBSERVABILITY_NAMESPACE,
+            json!({"app.kubernetes.io/instance": "prometheus"}),
+            "32Mi",
+        ),
+    ]
+}
+
+fn memory_container(name: &str, memory: &str) -> Value {
+    json!({"name": name, "resources": {"requests": {"memory": memory}}})
+}
+
+fn assert_reached_helm_upgrade(fixture: &Fixture, output: &Output) -> String {
+    let calls = fixture.helm_calls();
+    assert!(
+        calls
+            .iter()
+            .any(|call| call.starts_with("upgrade --install ")),
+        "capacity should pass through to the Helm mutation boundary\nstdout:\n{}\nstderr:\n{}\nhelm calls: {calls:?}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let text = shown(output);
+    assert!(
+        !text.contains("required 1312Mi") && !text.contains("available"),
+        "a cluster with enough capacity must not be refused: {text}"
+    );
+    text
+}
+
+fn assert_refused_before_helm(fixture: &Fixture, output: &Output) -> String {
+    let text = shown(output);
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "a failed capacity read is a normal runtime refusal: {text}"
+    );
+    assert!(
+        fixture.helm_calls().is_empty(),
+        "capacity must be known before any Helm command: {:?}",
+        fixture.helm_calls()
+    );
+    assert!(
+        fixture.api.recorded().is_empty(),
+        "capacity refusal must make no platform API mutation"
+    );
+    text
+}
+
+#[test]
+fn clap_routes_the_one_command_and_exposes_no_operator_configuration_or_credential_flags() {
+    let output = Command::new(bin())
+        .args(["example", "sre-bot", "install", "--help"])
+        .output()
+        .expect("run example installer help");
+    let text = shown(&output);
+    assert!(output.status.success(), "new command must parse: {text}");
+    assert!(
+        text.contains("--observability"),
+        "the install surface must expose the one observability flag: {text}"
+    );
+    assert!(
+        text.contains("--slack-channel"),
+        "the install surface must permit the optional Slack binding: {text}"
+    );
+    for forbidden in [
+        "--values",
+        "--file",
+        "--namespace",
+        "--release",
+        "--api-key",
+        "--grafana-token",
+        "--service-account-token",
+        "--model",
+        "--credentials",
+    ] {
+        assert!(
+            !text.contains(forbidden),
+            "the zero configuration command must not ask for {forbidden}: {text}"
+        );
+    }
+}
+
+#[test]
+fn json_dry_run_is_one_object_and_orders_apply_before_bundle_deploy() {
+    let fixture = Fixture::new(nodes(vec![node("node-a", "4Gi", true)]), pods(vec![]));
+    let output = fixture.run(&["--dry-run", "--json"]);
+    let text = shown(&output);
+    assert!(output.status.success(), "dry run must succeed: {text}");
+
+    let documents: Vec<Value> = serde_json::Deserializer::from_slice(&output.stdout)
+        .into_iter::<Value>()
+        .collect::<Result<_, _>>()
+        .unwrap_or_else(|error| panic!("dry run stdout must contain only JSON: {error}; {text}"));
+    assert_eq!(
+        documents.len(),
+        1,
+        "dry run must emit exactly one JSON object to stdout"
+    );
+    let object = documents[0]
+        .as_object()
+        .expect("dry run JSON must be an object");
+    let plan = object
+        .get("plan")
+        .and_then(Value::as_array)
+        .expect("dry run object must carry its ordered plan");
+    let lines: Vec<&str> = plan
+        .iter()
+        .map(|line| line.as_str().expect("plan entries are strings"))
+        .collect();
+    let expected_repositories = [
+        (
+            "grafana-community",
+            "https://grafana-community.github.io/helm-charts",
+        ),
+        ("grafana", "https://grafana.github.io/helm-charts"),
+        (
+            "prometheus-community",
+            "https://prometheus-community.github.io/helm-charts",
+        ),
+    ];
+    for (alias, url) in expected_repositories {
+        assert!(
+            lines
+                .iter()
+                .any(|line| line == &format!("helm repo add {alias} {url} --force-update")),
+            "plan must configure the exact {alias} repository: {lines:?}"
+        );
+    }
+    assert!(
+        lines.iter().any(|line| {
+            *line == "helm repo update grafana-community grafana prometheus-community"
+        }),
+        "plan must update every configured repository: {lines:?}"
+    );
+    let expected_upgrades = [
+        ("grafana", "grafana-community/grafana", "12.11.1"),
+        ("loki", "grafana-community/loki", "18.10.1"),
+        ("alloy", "grafana/alloy", "1.11.1"),
+        ("prometheus", "prometheus-community/prometheus", "29.27.0"),
+    ];
+    let mut previous = None;
+    for (release, chart, version) in expected_upgrades {
+        let index = lines
+            .iter()
+            .position(|line| {
+                line.contains(&format!("helm upgrade --install {release} {chart}"))
+                    && line.contains(&format!("--version {version}"))
+                    && line.contains("--namespace observability")
+            })
+            .unwrap_or_else(|| panic!("plan must contain pinned {release} upgrade: {lines:?}"));
+        if let Some(previous) = previous {
+            assert!(
+                previous < index,
+                "upstream release order drifted: {lines:?}"
+            );
+        }
+        previous = Some(index);
+    }
+    let tempo = lines
+        .iter()
+        .position(|line| {
+            line.contains("kubectl apply")
+                && line.contains("--namespace observability")
+                && line.contains("tempo.yaml")
+        })
+        .unwrap_or_else(|| panic!("plan must apply embedded Tempo: {lines:?}"));
+    let tempo_ready = lines
+        .iter()
+        .position(|line| {
+            line.contains("kubectl rollout status statefulset/tempo")
+                && line.contains("--namespace observability")
+                && line.contains("--timeout=")
+        })
+        .unwrap_or_else(|| panic!("plan must wait for Tempo readiness: {lines:?}"));
+    let curie_apply = lines
+        .iter()
+        .position(|line| {
+            line.contains("helm upgrade --install curie")
+                && line.contains(" -n curie ")
+                && !line.contains("curie-values.yaml")
+        })
+        .unwrap_or_else(|| {
+            panic!("plan must run the guarded Curie installation planner: {lines:?}")
+        });
+    let curie_integration = lines
+        .iter()
+        .position(|line| {
+            line.contains("helm upgrade curie")
+                && !line.contains("--install")
+                && line.contains("--reuse-values")
+                && line.contains("curie-values.yaml")
+                && line.contains("--wait")
+                && line.contains("--timeout 10m")
+        })
+        .unwrap_or_else(|| {
+            panic!("plan must add Curie integration values after guarded apply: {lines:?}")
+        });
+    let read_access = lines
+        .iter()
+        .position(|line| {
+            line.contains("kubectl apply") && line.contains("manifests/read-access.yaml")
+        })
+        .unwrap_or_else(|| panic!("plan must apply the read only connector RBAC: {lines:?}"));
+    let token_wait = lines
+        .iter()
+        .position(|line| {
+            line.contains("kubectl wait")
+                && line.contains("secret/sre-bot-reader-token")
+                && line.contains("--timeout=2m")
+        })
+        .unwrap_or_else(|| panic!("plan must wait boundedly for the reader token: {lines:?}"));
+    let deploy = lines
+        .iter()
+        .position(|line| line.contains("deploy") && line.contains("sre-bot"))
+        .unwrap_or_else(|| panic!("plan must contain SRE bot bundle deployment: {lines:?}"));
+    let connector_sync = lines
+        .iter()
+        .position(|line| line.contains("render and reconcile") && line.contains("connectors"))
+        .unwrap_or_else(|| panic!("plan must reconcile connectors after deploy: {lines:?}"));
+    assert!(
+        previous.is_some_and(|previous| previous < tempo)
+            && tempo < tempo_ready
+            && tempo_ready < curie_apply
+            && curie_apply < curie_integration
+            && curie_integration < read_access
+            && read_access < token_wait
+            && token_wait < deploy
+            && deploy < connector_sync,
+        "the stack, guarded platform apply, integration, RBAC, deploy, and connector sync order drifted: {lines:?}"
+    );
+    let plan_text = lines.join("\n").to_ascii_lowercase();
+    for forbidden in [
+        "grafana_service_account_token=",
+        "grafana-service-account-token=",
+        "--api-key",
+        "--credentials",
+    ] {
+        assert!(
+            !plan_text.contains(forbidden),
+            "dry run must not carry operator credential input or token material: {lines:?}"
+        );
+    }
+    assert!(
+        fixture.api.recorded().is_empty(),
+        "dry run must not mutate the platform API"
+    );
+    assert!(
+        lines.iter().any(|line| {
+            line.contains(TEMPO_TAGGED_IMAGE)
+                && line.to_ascii_lowercase().contains("immutable")
+                && line.to_ascii_lowercase().contains("digest")
+        }),
+        "dry run must disclose immutable Tempo image resolution: {lines:?}"
+    );
+    assert!(
+        fixture.registry.recorded().is_empty(),
+        "dry run must not contact the image registry"
+    );
+    assert!(
+        !fixture
+            .helm_calls()
+            .iter()
+            .any(|call| call.starts_with("upgrade --install ")),
+        "dry run must not execute Helm upgrade"
+    );
+}
+
+#[test]
+fn small_node_names_required_and_available_memory_before_any_mutation() {
+    let existing = pod(
+        "existing",
+        Some("node-a"),
+        "Running",
+        json!([memory_container("app", "1Gi")]),
+    );
+    let fixture = Fixture::new(
+        nodes(vec![node("node-a", "2Gi", true)]),
+        pods(vec![existing]),
+    );
+    let output = fixture.run(&[]);
+    let text = assert_refused_before_helm(&fixture, &output);
+    assert!(
+        text.contains(&format!("required {REQUIRED_MIB}Mi")),
+        "refusal must name the pinned stack footprint: {text}"
+    );
+    assert!(
+        text.contains("available 1024Mi"),
+        "refusal must name the measured remaining capacity: {text}"
+    );
+    assert!(
+        text.contains("curie example sre-bot install --observability"),
+        "refusal must name the command whose prerequisite failed: {text}"
+    );
+    assert!(
+        fixture.registry.recorded().is_empty() && fixture.kubectl_stdin().is_empty(),
+        "capacity refusal must precede registry access and Secret mutation"
+    );
+}
+
+#[test]
+fn absent_grafana_admin_secret_is_generated_via_stdin_without_credential_exposure() {
+    let fixture = Fixture::new(nodes(vec![node("node-a", "4Gi", true)]), pods(vec![]))
+        .with_grafana_secret_mode("absent");
+    let output = fixture.run(&[]);
+    assert_reached_helm_upgrade(&fixture, &output);
+
+    let apply_calls = fixture
+        .kubectl_calls()
+        .into_iter()
+        .filter(|call| call.contains("apply -f -"))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        apply_calls,
+        ["apply -f -"],
+        "a missing admin Secret must be created through stdin exactly once"
+    );
+    let manifest: Value = serde_json::from_slice(&fixture.kubectl_stdin())
+        .expect("Grafana admin Secret stdin must be JSON");
+    assert_eq!(manifest["kind"], "Secret");
+    assert_eq!(manifest["metadata"]["name"], "grafana-admin");
+    assert_eq!(manifest["metadata"]["namespace"], OBSERVABILITY_NAMESPACE);
+    assert_eq!(manifest["stringData"]["admin-user"], "admin");
+    let password = manifest["stringData"]["admin-password"]
+        .as_str()
+        .expect("generated admin password is a string");
+    assert_eq!(password.len(), 64, "password must contain 32 random bytes");
+    assert!(
+        password
+            .chars()
+            .all(|character| character.is_ascii_hexdigit())
+            && password == password.to_ascii_lowercase(),
+        "generated admin password must be lowercase hex"
+    );
+    let observable = format!(
+        "{}\n{:?}\n{:?}",
+        shown(&output),
+        fixture.kubectl_calls(),
+        fixture.helm_calls()
+    );
+    assert!(
+        !observable.contains(password),
+        "generated credentials must never reach argv, logs, stdout, or stderr"
+    );
+}
+
+#[test]
+fn existing_grafana_admin_secret_is_preserved_without_apply() {
+    let fixture = Fixture::new(nodes(vec![node("node-a", "4Gi", true)]), pods(vec![]));
+    let output = fixture.run(&[]);
+    assert_reached_helm_upgrade(&fixture, &output);
+    let calls = fixture.kubectl_calls();
+    assert!(
+        calls
+            .iter()
+            .any(|call| call.contains("get secret grafana-admin")),
+        "installer must inspect the migration Secret: {calls:?}"
+    );
+    assert!(
+        !calls.iter().any(|call| call.contains("apply -f -")) && fixture.kubectl_stdin().is_empty(),
+        "an existing Grafana admin Secret must not be replaced: {calls:?}"
+    );
+}
+
+#[test]
+fn existing_grafana_release_migrates_its_live_admin_credential_without_exposure() {
+    let fixture = Fixture::new(nodes(vec![node("node-a", "4Gi", true)]), pods(vec![]))
+        .with_grafana_secret_mode("migrate");
+    let output = fixture.run(&[]);
+    assert_reached_helm_upgrade(&fixture, &output);
+
+    let manifest: Value = serde_json::from_slice(&fixture.kubectl_stdin())
+        .expect("migrated Grafana admin Secret stdin must be JSON");
+    assert_eq!(manifest["metadata"]["name"], "grafana-admin");
+    assert_eq!(manifest["metadata"]["namespace"], OBSERVABILITY_NAMESPACE);
+    assert_eq!(manifest["data"]["admin-user"], "bWlncmF0ZWQtYWRtaW4=");
+    assert_eq!(manifest["data"]["admin-password"], "cHc=");
+    assert!(manifest.get("stringData").is_none());
+
+    let calls = fixture.kubectl_calls();
+    let target_read = calls
+        .iter()
+        .position(|call| call.contains("get secret grafana-admin"))
+        .expect("installer must inspect the target Secret");
+    let workload_read = calls
+        .iter()
+        .position(|call| {
+            call.contains("get deployment,statefulset")
+                && call.contains("app.kubernetes.io/instance=grafana")
+        })
+        .expect("migration must discover the credential source from the live workload");
+    let source_read = calls
+        .iter()
+        .position(|call| call.contains("get secret grafana --namespace observability"))
+        .expect("migration must read the currently mounted admin Secret");
+    let apply = calls
+        .iter()
+        .position(|call| call.contains("apply -f -"))
+        .expect("migration must create grafana-admin through private stdin");
+    assert!(target_read < workload_read && workload_read < source_read && source_read < apply);
+
+    let observable = format!(
+        "{}\n{:?}\n{:?}",
+        shown(&output),
+        fixture.kubectl_calls(),
+        fixture.helm_calls()
+    );
+    for secret in ["migrated-admin", "pw"] {
+        assert!(
+            !observable.contains(secret),
+            "migrated credentials must not reach argv, logs, stdout, or stderr"
+        );
+    }
+}
+
+#[test]
+fn existing_grafana_release_with_unreadable_live_credential_fails_closed() {
+    let fixture = Fixture::new(nodes(vec![node("node-a", "4Gi", true)]), pods(vec![]))
+        .with_grafana_secret_mode("migration-source-failure");
+    let output = fixture.run(&[]);
+    let text = shown(&output);
+
+    assert_eq!(output.status.code(), Some(1), "migration must fail: {text}");
+    assert!(
+        text.contains("could not read the existing Grafana admin credential"),
+        "failure must name the blocked migration without exposing values: {text}"
+    );
+    assert!(fixture.kubectl_stdin().is_empty());
+    assert!(
+        fixture
+            .helm_calls()
+            .iter()
+            .all(|call| !call.starts_with("upgrade")),
+        "an unreadable migration credential must stop before Helm mutation"
+    );
+}
+
+#[test]
+fn grafana_admin_secret_read_failure_stops_before_mutation() {
+    let fixture = Fixture::new(nodes(vec![node("node-a", "4Gi", true)]), pods(vec![]))
+        .with_grafana_secret_mode("read-failure");
+    let output = fixture.run(&[]);
+    let text = shown(&output);
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "Secret read must fail: {text}"
+    );
+    assert!(
+        text.contains("could not inspect Secret grafana-admin"),
+        "failure must name the unreadable prerequisite: {text}"
+    );
+    assert!(fixture.helm_calls().is_empty());
+    assert!(fixture.api.recorded().is_empty());
+    assert!(fixture.kubectl_stdin().is_empty());
+    assert!(
+        fixture
+            .kubectl_calls()
+            .iter()
+            .all(|call| !call.contains("apply") && !call.contains("create")),
+        "an ambiguous Secret read must fail closed before mutation"
+    );
+}
+
+#[test]
+fn grafana_admin_secret_creation_failure_stops_before_helm_without_leaking_password() {
+    let fixture = Fixture::new(nodes(vec![node("node-a", "4Gi", true)]), pods(vec![]))
+        .with_grafana_secret_mode("apply-failure");
+    let output = fixture.run(&[]);
+    let manifest: Value = serde_json::from_slice(&fixture.kubectl_stdin())
+        .expect("failed apply still receives the Secret manifest");
+    let password = manifest["stringData"]["admin-password"]
+        .as_str()
+        .expect("generated password");
+    let text = shown(&output);
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "Secret failure must fail: {text}"
+    );
+    assert!(
+        fixture
+            .helm_calls()
+            .iter()
+            .all(|call| !call.starts_with("upgrade")),
+        "Secret creation must complete before Helm mutation"
+    );
+    assert!(
+        text.contains("grafana-admin") && !text.contains(password),
+        "failure must name the Secret without exposing its credential: {text}"
+    );
+}
+
+#[test]
+fn tempo_index_resolution_failure_precedes_every_cluster_mutation() {
+    let fixture = Fixture::new(nodes(vec![node("node-a", "4Gi", true)]), pods(vec![]))
+        .with_registry_failure();
+    let output = fixture.run(&[]);
+    let text = shown(&output);
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "registry failure must fail: {text}"
+    );
+    assert!(
+        text.contains(TEMPO_TAGGED_IMAGE),
+        "registry error must name the image it could not pin: {text}"
+    );
+    assert!(fixture.helm_calls().is_empty());
+    assert!(fixture.api.recorded().is_empty());
+    assert!(fixture.kubectl_stdin().is_empty());
+    assert!(
+        fixture
+            .kubectl_calls()
+            .iter()
+            .all(|call| call.starts_with("get nodes") || call.starts_with("get pods")),
+        "registry failure may perform capacity reads but no cluster mutation: {:?}",
+        fixture.kubectl_calls()
+    );
+}
+
+#[test]
+fn tempo_resolution_rejects_an_incomplete_index_before_cluster_mutation() {
+    let fixture = Fixture::new(nodes(vec![node("node-a", "4Gi", true)]), pods(vec![]))
+        .with_registry_wrong_shape();
+    let output = fixture.run(&[]);
+    let text = shown(&output);
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "invalid index must fail: {text}"
+    );
+    assert!(
+        text.contains("expected an OCI image index"),
+        "failure must identify the invalid registry representation: {text}"
+    );
+    assert!(fixture.helm_calls().is_empty());
+    assert!(fixture.api.recorded().is_empty());
+    assert!(fixture.kubectl_stdin().is_empty());
+    assert!(
+        fixture
+            .kubectl_calls()
+            .iter()
+            .all(|call| call.starts_with("get nodes") || call.starts_with("get pods")),
+        "an invalid index must fail before cluster mutation: {:?}",
+        fixture.kubectl_calls()
+    );
+}
+
+#[test]
+fn successful_install_uploads_only_the_resolved_tempo_index_digest() {
+    let fixture = Fixture::with_modes(
+        nodes(vec![node("node-a", "4Gi", true)]),
+        pods(vec![]),
+        "success",
+        "success",
+        "success",
+    );
+    let output = fixture.run(&[]);
+    let text = shown(&output);
+    assert!(
+        output.status.success(),
+        "full install fixture must deploy: {text}"
+    );
+
+    let connectors = String::from_utf8(uploaded_bundle_file(&fixture, "connectors.yaml"))
+        .expect("uploaded connectors are UTF-8");
+    let pinned = format!(
+        "ghcr.io/curie-eng/curie-sre-bot-tempo@{}",
+        expected_tempo_digest()
+    );
+    assert!(
+        connectors.contains(&pinned),
+        "resolved digest must reach deploy"
+    );
+    assert!(
+        !connectors.contains(TEMPO_TAGGED_IMAGE),
+        "the declared mutable tag must never reach deploy"
+    );
+    let declaration: Value =
+        serde_norway::from_str(&connectors).expect("uploaded connectors must remain valid YAML");
+    assert_eq!(
+        declaration["connectors"]["tempo"]["image"], pinned,
+        "the runtime bundle must replace the local build declaration with the release image"
+    );
+    assert!(
+        declaration["connectors"]["tempo"].get("build").is_none(),
+        "the uploaded runtime declaration must not ask the cluster deploy path to build Tempo"
+    );
+
+    // GitHub documents anonymous public GHCR pulls, and the Distribution token
+    // specification defines the service and repository pull scope exchange:
+    // https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry
+    // https://distribution.github.io/distribution/spec/auth/token/
+    let registry = fixture.registry.recorded();
+    assert_eq!(
+        registry.len(),
+        2,
+        "resolution must use token then index requests"
+    );
+    assert!(
+        registry[0].path.starts_with("/token?")
+            && registry[0]
+                .path
+                .contains("repository%3Acurie-eng%2Fcurie-sre-bot-tempo%3Apull")
+    );
+    assert_eq!(
+        registry[1].header("authorization"),
+        Some("Bearer anonymous-pull-token")
+    );
+    assert!(
+        registry[1]
+            .header("accept")
+            .is_some_and(|accept| accept.contains("application/vnd.oci.image.index.v1+json")),
+        "manifest request must require a multi-platform image index"
+    );
+}
+
+#[test]
+fn released_binary_path_uses_cached_chart_and_embedded_assets_outside_checkout() {
+    let fixture = Fixture::with_modes(
+        nodes(vec![node("node-a", "4Gi", true)]),
+        pods(vec![]),
+        "success",
+        "success",
+        "success",
+    );
+    let outside = fixture._temp.path().join("outside-source-checkout");
+    fs::create_dir(&outside).expect("create working directory outside the source checkout");
+    let cache = fixture._temp.path().join("release-cache");
+    let chart = cache
+        .join("curie")
+        .join(format!("v{}", env!("CARGO_PKG_VERSION")))
+        .join(format!("curie-{}.tgz", env!("CARGO_PKG_VERSION")));
+    fs::create_dir_all(chart.parent().expect("release chart has a cache parent"))
+        .expect("create release chart cache");
+    fs::write(&chart, b"cached release chart fixture")
+        .expect("seed the released chart artifact cache");
+
+    let output = fixture.run_from(&[], &outside, Some(&cache));
+    let text = shown(&output);
+    assert!(
+        output.status.success(),
+        "released binary path must install outside a source checkout: {text}"
+    );
+    assert!(
+        !outside.join("charts/curie").exists(),
+        "the release path must not gain a source chart"
+    );
+    let chart_arg = chart.display().to_string();
+    assert!(
+        fixture.helm_calls().iter().any(|call| {
+            call.starts_with("upgrade --install curie ") && call.contains(&chart_arg)
+        }),
+        "the guarded platform apply must use the cached released chart {chart_arg}: {:?}",
+        fixture.helm_calls()
+    );
+    assert!(
+        !fixture
+            .actions()
+            .iter()
+            .any(|action| action.contains("charts/curie")),
+        "the released command must not fall back to a source chart: {:?}",
+        fixture.actions()
+    );
+    assert!(
+        !uploaded_bundle_file(&fixture, "connectors.yaml").is_empty(),
+        "the binary must deploy its embedded SRE bot bundle outside the checkout"
+    );
+}
+
+#[test]
+fn guarded_platform_apply_precedes_additive_integration_and_reader_access() {
+    let fixture = Fixture::with_modes(
+        nodes(vec![node("node-a", "4Gi", true)]),
+        pods(vec![]),
+        "success",
+        "success",
+        "success",
+    )
+    .with_helm_values(json!({"api": {"apiKey": "fixture-existing-api-key"}}));
+    let output = fixture.run(&[]);
+    let text = shown(&output);
+    assert!(output.status.success(), "full install must succeed: {text}");
+
+    let actions = fixture.actions();
+    let planner = actions
+        .iter()
+        .position(|call| call.starts_with("HELM upgrade --install curie "))
+        .unwrap_or_else(|| {
+            panic!("the installer must use the installation apply planner: {actions:?}")
+        });
+    let integration = actions
+        .iter()
+        .position(|call| call.starts_with("HELM upgrade curie "))
+        .unwrap_or_else(|| {
+            panic!("the installer must run the additive integration upgrade: {actions:?}")
+        });
+    let read_access = actions
+        .iter()
+        .position(|call| {
+            call.starts_with("KUBECTL apply -f ") && call.ends_with("manifests/read-access.yaml")
+        })
+        .unwrap_or_else(|| panic!("the installer must apply the reader RBAC: {actions:?}"));
+    let token_wait = actions
+        .iter()
+        .position(|call| {
+            call.contains("KUBECTL wait")
+                && call.contains("secret/sre-bot-reader-token")
+                && call.contains("--timeout=2m")
+        })
+        .unwrap_or_else(|| {
+            panic!("the installer must wait boundedly for the reader token: {actions:?}")
+        });
+    assert!(
+        planner < integration && integration < read_access && read_access < token_wait,
+        "platform apply, additive integration, RBAC, and token order drifted: {actions:?}"
+    );
+
+    let planner_call = &actions[planner];
+    assert!(
+        !planner_call.contains("curie-values.yaml")
+            && !planner_call.contains("fixture-existing-api-key"),
+        "the guarded full apply must preserve existing values through its private planner path: {planner_call}"
+    );
+    let integration_call = &actions[integration];
+    assert!(
+        !integration_call.contains("--install")
+            && integration_call.contains("--reuse-values")
+            && integration_call.contains("curie-values.yaml")
+            && integration_call.contains("--wait")
+            && integration_call.contains("--timeout 10m"),
+        "the integration step must be additive, bounded, and never install: {integration_call}"
+    );
+}
+
+#[test]
+fn reader_kubeconfig_is_owned_secret_stdin_and_connectors_reconcile_after_deploy() {
+    let fixture = Fixture::with_modes(
+        nodes(vec![node("node-a", "4Gi", true)]),
+        pods(vec![]),
+        "success",
+        "success",
+        "success",
+    );
+    let output = fixture.run(&[]);
+    let text = shown(&output);
+    assert!(output.status.success(), "full install must succeed: {text}");
+
+    let requests = fixture.api.recorded();
+    let deployment = requests
+        .iter()
+        .position(|request| request.method == "POST" && request.path == "/deployments")
+        .expect("the bundle must be deployed");
+    let render = requests
+        .iter()
+        .position(|request| {
+            request.method == "GET"
+                && request.path.starts_with(&format!(
+                    "/agents/{AGENT_ID}/versions/{VERSION_ID}/connectors?"
+                ))
+        })
+        .expect("the deployed version connectors must be rendered through the API");
+    assert!(
+        deployment < render,
+        "connector rendering must happen only after deploy: {requests:?}"
+    );
+
+    let document: Value = serde_json::from_slice(&fixture.connector_stdin())
+        .expect("connector reconciliation must send one JSON List on stdin");
+    let items = document["items"]
+        .as_array()
+        .expect("connector reconciliation stdin must contain items");
+    let secret = items
+        .iter()
+        .find(|item| item["kind"] == "Secret")
+        .expect("connector reconciliation must include its owned Secret");
+    assert_eq!(
+        secret["metadata"]["name"],
+        "curie-sre-bot-connector-secrets"
+    );
+    let kubeconfig = secret["stringData"]["K8S_READONLY_KUBECONFIG"]
+        .as_str()
+        .expect("the owned Secret must carry the generated kubeconfig");
+    let config: Value = serde_json::from_str(kubeconfig).expect("kubeconfig is structured JSON");
+    assert_eq!(
+        config["clusters"][0]["cluster"]["server"],
+        "https://kubernetes.default.svc"
+    );
+    assert_eq!(config["users"][0]["user"]["token"], "abc");
+    assert_eq!(
+        config["clusters"][0]["cluster"]["certificate-authority-data"],
+        "Zml4dHVyZS1jYQ=="
+    );
+
+    let kubectl = fixture.kubectl_calls();
+    assert!(
+        kubectl.iter().any(|call| call == "-n curie apply -f -"),
+        "rendered connector objects must be applied from stdin: {kubectl:?}"
+    );
+    assert!(
+        kubectl.iter().any(|call| {
+            call.starts_with("-n curie delete deployment,service,networkpolicy,secret ")
+        }),
+        "stale connector objects must be reconciled after apply: {kubectl:?}"
+    );
+    let observable = format!("{text}\n{kubectl:?}\n{:?}", fixture.helm_calls());
+    assert!(
+        !observable.contains("abc") && !observable.contains("YWJj"),
+        "the generated kubeconfig credential must not reach output or argv: {observable}"
+    );
+}
+
+#[test]
+fn reader_token_timeout_and_read_failure_are_bounded_and_stop_before_deploy() {
+    for (mode, expected) in [
+        ("timeout", "was not populated within 2m"),
+        ("read-failure", "could not read Secret sre-bot-reader-token"),
+    ] {
+        let fixture = Fixture::with_modes(
+            nodes(vec![node("node-a", "4Gi", true)]),
+            pods(vec![]),
+            "success",
+            "success",
+            "success",
+        )
+        .with_reader_token_mode(mode);
+        let output = fixture.run(&[]);
+        let text = shown(&output);
+        assert_eq!(
+            output.status.code(),
+            Some(1),
+            "reader token failure must fail: {text}"
+        );
+        assert!(
+            text.contains(expected)
+                && text.contains("kubectl get secret sre-bot-reader-token -n curie"),
+            "reader token failure must be actionable: {text}"
+        );
+        let wait = fixture
+            .kubectl_calls()
+            .into_iter()
+            .find(|call| call.starts_with("wait "))
+            .expect("reader token must use kubectl wait");
+        assert!(
+            wait.contains("--timeout=2m"),
+            "token wait must be bounded: {wait}"
+        );
+        assert!(
+            fixture.api.recorded().is_empty() && fixture.connector_stdin().is_empty(),
+            "a reader token failure must stop before bundle deploy and connector apply"
+        );
+    }
+}
+
+#[test]
+fn optional_slack_channel_reaches_the_same_embedded_deploy_path() {
+    let fixture = Fixture::with_modes(
+        nodes(vec![node("node-a", "4Gi", true)]),
+        pods(vec![]),
+        "success",
+        "success",
+        "success",
+    );
+    let output = fixture.run(&["--slack-channel", "C0EXAMPLE1"]);
+    let text = shown(&output);
+    assert!(
+        output.status.success(),
+        "Slack install must succeed: {text}"
+    );
+    let create = fixture
+        .api
+        .recorded()
+        .into_iter()
+        .find(|request| request.method == "POST" && request.path == "/agents")
+        .expect("embedded deploy must create or resolve the agent");
+    let body = String::from_utf8(create.body).expect("agent create request is UTF-8");
+    assert!(
+        body.contains("C0EXAMPLE1"),
+        "the example Slack channel must reach the normal deploy request: {body}"
+    );
+}
+
+#[test]
+fn exactly_required_memory_and_more_both_pass_the_capacity_gate() {
+    for memory in ["1343488Ki", "2Gi"] {
+        let fixture = Fixture::new(nodes(vec![node("node-a", memory, true)]), pods(vec![]));
+        let output = fixture.run(&[]);
+        assert_reached_helm_upgrade(&fixture, &output);
+    }
+}
+
+#[test]
+fn rerun_replaces_managed_stack_requests_but_keeps_unrelated_observability_load() {
+    let mut items = managed_stack_pods("node-a");
+    items.push(labeled_pod(
+        "unrelated",
+        "node-a",
+        OBSERVABILITY_NAMESPACE,
+        json!({"app.kubernetes.io/instance": "other"}),
+        "64Mi",
+    ));
+
+    let fixture = Fixture::new(
+        nodes(vec![node("node-a", "1376Mi", true)]),
+        pods(items.clone()),
+    );
+    let output = fixture.run(&[]);
+    assert_reached_helm_upgrade(&fixture, &output);
+
+    let insufficient = Fixture::new(nodes(vec![node("node-a", "1375Mi", true)]), pods(items));
+    let output = insufficient.run(&[]);
+    let text = assert_refused_before_helm(&insufficient, &output);
+    assert!(
+        text.contains("required 1312Mi") && text.contains("available 1311Mi"),
+        "only managed stack requests may be replaced during a rerun: {text}"
+    );
+}
+
+#[test]
+fn daemonset_requests_scale_the_required_memory_per_ready_node() {
+    let enough = Fixture::new(
+        nodes(vec![
+            node("node-a", "736Mi", true),
+            node("node-b", "736Mi", true),
+        ]),
+        pods(vec![]),
+    );
+    let output = enough.run(&[]);
+    assert_reached_helm_upgrade(&enough, &output);
+
+    let insufficient = Fixture::new(
+        nodes(vec![
+            node("node-a", "736Mi", true),
+            node("node-b", "735Mi", true),
+        ]),
+        pods(vec![]),
+    );
+    let output = insufficient.run(&[]);
+    let text = assert_refused_before_helm(&insufficient, &output);
+    assert!(
+        text.contains("required 1472Mi") && text.contains("available 1471Mi"),
+        "two Ready nodes must reserve two Alloy and node exporter requests: {text}"
+    );
+}
+
+#[test]
+fn capacity_aggregates_ready_nodes_and_only_their_nonterminal_scheduled_pods() {
+    let items = vec![
+        pod(
+            "ready-a-load",
+            Some("ready-a"),
+            "Running",
+            json!([memory_container("app", "256Mi")]),
+        ),
+        pod(
+            "ready-b-load",
+            Some("ready-b"),
+            "Pending",
+            json!([memory_container("app", "544Mi")]),
+        ),
+        pod(
+            "not-ready-load",
+            Some("not-ready"),
+            "Running",
+            json!([memory_container("app", "8Gi")]),
+        ),
+        pod(
+            "completed",
+            Some("ready-a"),
+            "Succeeded",
+            json!([memory_container("app", "8Gi")]),
+        ),
+        pod(
+            "unscheduled",
+            None,
+            "Pending",
+            json!([memory_container("app", "8Gi")]),
+        ),
+    ];
+    let fixture = Fixture::new(
+        nodes(vec![
+            node("ready-a", "1Gi", true),
+            node("ready-b", "1248Mi", true),
+            node("not-ready", "16Gi", false),
+        ]),
+        pods(items),
+    );
+    let output = fixture.run(&[]);
+    assert_reached_helm_upgrade(&fixture, &output);
+}
+
+fn restartable_init_pod() -> Value {
+    let mut value = pod(
+        "restartable-init-accounting",
+        Some("node-a"),
+        "Running",
+        json!([
+            memory_container("app-a", "110Mi"),
+            memory_container("app-b", "90Mi")
+        ]),
+    );
+    value["spec"]["initContainers"] = json!([
+        {
+            "name": "sidecar-a",
+            "restartPolicy": "Always",
+            "resources": {"requests": {"memory": "120Mi"}}
+        },
+        memory_container("setup", "380Mi"),
+        {
+            "name": "sidecar-b",
+            "restartPolicy": "Always",
+            "resources": {"requests": {"memory": "80Mi"}}
+        },
+        memory_container("migrate", "250Mi")
+    ]);
+    value
+}
+
+#[test]
+fn restartable_init_scheduling_semantics_pin_the_exact_five_hundred_mib_request() {
+    // Effective request is 500Mi: sidecar-a plus setup is the largest init
+    // stage. The steady state is 400Mi: both app containers plus both
+    // restartable sidecars. Summing every init container would overcount;
+    // taking only the largest single init container would undercount.
+    let exact = Fixture::new(
+        nodes(vec![node("node-a", "1812Mi", true)]),
+        pods(vec![restartable_init_pod()]),
+    );
+    let exact_output = exact.run(&[]);
+    assert_reached_helm_upgrade(&exact, &exact_output);
+
+    let one_short = Fixture::new(
+        nodes(vec![node("node-a", "1811Mi", true)]),
+        pods(vec![restartable_init_pod()]),
+    );
+    let one_short_output = one_short.run(&[]);
+    let text = assert_refused_before_helm(&one_short, &one_short_output);
+    assert!(
+        text.contains("required 1312Mi") && text.contains("available 1311Mi"),
+        "the capacity boundary must use the effective 500Mi pod request: {text}"
+    );
+}
+
+#[test]
+fn zero_ready_nodes_fails_closed_with_the_cluster_prerequisite() {
+    let fixture = Fixture::new(nodes(vec![node("node-a", "8Gi", false)]), pods(vec![]));
+    let output = fixture.run(&[]);
+    let text = assert_refused_before_helm(&fixture, &output);
+    assert!(
+        text.to_ascii_lowercase().contains("no ready")
+            && text.contains("kubectl get nodes")
+            && text.contains("allocatable"),
+        "zero Ready nodes must name the failed prerequisite and inspection command: {text}"
+    );
+}
+
+#[test]
+fn kubectl_failure_and_malformed_pod_json_both_fail_closed() {
+    let cases = [
+        ("failure", "success", "nodes is forbidden"),
+        ("success", "malformed", "kubectl get pods"),
+    ];
+    for (nodes_mode, pods_mode, expected) in cases {
+        let fixture = Fixture::with_modes(
+            nodes(vec![node("node-a", "8Gi", true)]),
+            pods(vec![]),
+            nodes_mode,
+            pods_mode,
+            "stop",
+        );
+        let output = fixture.run(&[]);
+        let text = assert_refused_before_helm(&fixture, &output);
+        assert!(
+            text.contains(expected),
+            "capacity read error must preserve the cause or inspection command `{expected}`: {text}"
+        );
+        assert!(
+            text.contains("kubectl get nodes") || text.contains("kubectl get pods"),
+            "capacity read error must give the exact kubectl inspection surface: {text}"
+        );
+    }
+}
+
+#[test]
+fn helm_wait_is_bounded_and_timeout_names_safe_pending_upgrade_recovery() {
+    let fixture = Fixture::with_modes(
+        nodes(vec![node("node-a", "8Gi", true)]),
+        pods(vec![]),
+        "success",
+        "success",
+        "timeout",
+    );
+    let output = fixture.run(&[]);
+    let text = shown(&output);
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "Helm timeout must fail: {text}"
+    );
+    let upgrade = fixture
+        .helm_calls()
+        .into_iter()
+        .find(|call| call.starts_with("upgrade --install "))
+        .unwrap_or_else(|| panic!("installer must reach helm upgrade: {text}"));
+    assert!(
+        upgrade.split_whitespace().any(|token| token == "--wait"),
+        "installer must wait for the Grafana token updater hook: {upgrade}"
+    );
+    assert!(
+        upgrade
+            .split_whitespace()
+            .any(|token| token == "--timeout" || token.starts_with("--timeout=")),
+        "Helm wait must carry an explicit timeout: {upgrade}"
+    );
+
+    let normalized = text.replace(['\'', '"'], "");
+    let recovery = format!(
+        "kubectl delete secret -n {OBSERVABILITY_NAMESPACE} -l owner=helm,name={FIRST_RELEASE},status=pending-upgrade"
+    );
+    assert!(
+        normalized.contains(FIRST_RELEASE)
+            && normalized.contains("context deadline exceeded")
+            && normalized.contains(&recovery),
+        "timeout must name the release and exact pending upgrade recovery command `{recovery}`: {text}"
+    );
+}
+
+#[test]
+fn all_capacity_reads_are_cluster_wide_and_json_shaped() {
+    let fixture = Fixture::new(nodes(vec![]), pods(vec![]));
+    let _ = fixture.run(&[]);
+    let calls = fixture.kubectl_calls();
+    let node_read = calls
+        .iter()
+        .find(|call| call.contains("get nodes") || call.contains("get node"))
+        .unwrap_or_else(|| panic!("capacity preflight must read nodes: {calls:?}"));
+    assert!(
+        node_read.contains("-o json") || node_read.contains("--output json"),
+        "node accounting must consume structured JSON: {node_read}"
+    );
+    // Zero Ready nodes may fail before reading pods. A cluster with a Ready
+    // node proves the second read is cluster wide rather than namespace local.
+    let ready = Fixture::new(nodes(vec![node("node-a", "8Gi", true)]), pods(vec![]));
+    let _ = ready.run(&[]);
+    let pod_read = ready
+        .kubectl_calls()
+        .into_iter()
+        .find(|call| call.contains("get pods") || call.contains("get pod"))
+        .unwrap_or_else(|| panic!("capacity preflight must read pods"));
+    assert!(
+        (pod_read.contains("--all-namespaces") || pod_read.contains(" -A"))
+            && (pod_read.contains("-o json") || pod_read.contains("--output json")),
+        "pod request accounting must be cluster wide structured JSON: {pod_read}"
+    );
+}

--- a/cli/tests/json_emit_contract.rs
+++ b/cli/tests/json_emit_contract.rs
@@ -59,7 +59,8 @@ fn placeholder(id: &str) -> &'static str {
 
 /// Every LEAF verb path (e.g. `["cluster", "kill"]`) whose `args` include an arg
 /// with `"id": "dry_run"`, paired with the argv fragment of its required-arg
-/// placeholders (positional value, or `--<long>` + value for a required flag).
+/// placeholders. Required boolean switches contribute only `--<long>`; value
+/// options and positionals also contribute their placeholder value.
 fn dry_run_verbs() -> Vec<(Vec<String>, Vec<String>)> {
     let mut out = Vec::new();
     fn args_of(node: &serde_json::Value) -> &[serde_json::Value] {
@@ -112,7 +113,17 @@ fn dry_run_verbs() -> Vec<(Vec<String>, Vec<String>)> {
                             .and_then(|l| l.as_str())
                             .expect("required non-positional arg has a --long");
                         required.push(format!("--{long}"));
-                        required.push(placeholder(id).to_string());
+                        let boolean_switch = a
+                            .get("possible_values")
+                            .and_then(|values| values.as_array())
+                            .is_some_and(|values| {
+                                values.len() == 2
+                                    && values.iter().any(|value| value == "true")
+                                    && values.iter().any(|value| value == "false")
+                            });
+                        if !boolean_switch {
+                            required.push(placeholder(id).to_string());
+                        }
                     }
                 }
                 out.push((path, required));

--- a/examples/sre-bot/.claude-plugin/plugin.json
+++ b/examples/sre-bot/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sre-bot",
   "version": "0.1.0",
-  "description": "Read-only SRE triage assistant. Answers plain-English questions about production health and Kubernetes cluster state in Slack. Reads the Kubernetes API directly (Events, describe, previous-container logs, live top) and, when the optional connectors are enabled, Grafana (Loki logs, Prometheus metrics, alerts, dashboard panel queries) and distributed traces through Tempo. Read-only by construction: every shipped tool is readOnlyHint and the cluster credential cannot read Secrets. One optional write verb -- rolling a single named Deployment -- ships disabled, behind a human approval gate.",
+  "description": "Read only SRE triage assistant. Answers plain English questions about production health and Kubernetes cluster state in Slack. Reads the Kubernetes API, Grafana logs and metrics, and Tempo traces through connectors that ship enabled. Every shipped tool is readOnlyHint, and the cluster credential cannot read Secrets. One optional write verb for rolling a single named Deployment ships disabled behind a human approval gate.",
   "license": "Apache-2.0",
   "author": {
     "name": "CurieTech"

--- a/examples/sre-bot/README.md
+++ b/examples/sre-bot/README.md
@@ -17,10 +17,10 @@ What you get back: a one-line verdict first ("Nothing looks broken." / "Yes --
 yourself.
 
 **Out of the box it cannot change anything.** Every shipped tool is
-`readOnlyHint`, and the credential behind them is a ServiceAccount that cannot
-read Secrets and cannot delete anything. There is no write tool, so there is
-nothing to gate, so no approval policy is declared at all -- the safest
-configuration is the absence of configuration.
+`readOnlyHint`. Kubernetes access uses a ServiceAccount that cannot read
+Secrets or delete anything, and Grafana access uses the Viewer role. There is no
+write tool, so there is nothing to gate, so no approval policy is declared at
+all.
 
 **One write verb ships in the box, switched off.** Enabling it takes a few
 deliberate steps and gives the bot exactly one thing it can change: rolling a
@@ -28,7 +28,7 @@ single named Deployment, behind a human approval card. See
 [Level up: the gated write path](#level-up-the-gated-write-path).
 
 This is the repo's most complete example bundle. It is a real bot, generalised:
-a skill, four connectors (one on, three off), the RBAC to stand it up, a
+a skill, four connectors (three on, one off), the RBAC to stand it up, a
 purpose-built write connector with its source and tests, deploy targets, and a
 falsifiable eval suite.
 
@@ -81,100 +81,14 @@ code execution across it.
 
 ## Quick deploy
 
-Needs a Kubernetes cluster, `kubectl` pointed at it, and this repo checked out.
-The short version lives in
-[QUICKSTART.md](../../QUICKSTART.md#deploy-your-own-sre-bot); this is the same
-path with the reasoning attached.
-
-**1. Bring up the platform.**
+On a clean Kubernetes cluster, run one command:
 
 ```bash
-export CURIE_CREDENTIALS=sk-ant-...
-curie cluster up --allow-egress-host anthropic --set security.gvisor.mode=off
+curie example sre-bot install --observability
 ```
 
-`--allow-egress-host` opens the model call: the cluster sandbox is fail-closed by
-default, so a credential alone is not enough. Drop
-`--set security.gvisor.mode=off` on a cluster that has `runsc` installed.
-
-**This step is first because it creates the `curie` namespace**, and step 2
-installs a ServiceAccount and a token Secret into it. Run step 2 on a fresh
-cluster and the apply PARTIALLY fails in a way that reads like success: the
-cluster-scoped ClusterRole and ClusterRoleBinding are created and print
-`created`, the two namespaced objects are not, and `kubectl` exits 1.
-
-**2. Create the read-only identity.**
-
-```bash
-kubectl apply -f examples/sre-bot/manifests/read-access.yaml
-```
-
-Read that file before you apply it -- it explains why it enumerates permissions
-instead of binding the built-in `view` role, and why `configmaps` is in the list
-and `secrets` is not. Then prove it is genuinely read-only:
-
-```bash
-kubectl auth can-i --as=system:serviceaccount:curie:sre-bot-reader list pods -A       # yes
-kubectl auth can-i --as=system:serviceaccount:curie:sre-bot-reader get secrets -A     # NO
-kubectl auth can-i --as=system:serviceaccount:curie:sre-bot-reader delete pods -A     # NO
-kubectl auth can-i --as=system:serviceaccount:curie:sre-bot-reader create pods/exec -A  # NO
-```
-
-**Three `no`s are the passing result.** A `yes` on secrets means the binding
-picked up something broader -- fix the role, not the connector flags.
-
-**3. Assemble the kubeconfig and store it.**
-
-The connector authenticates from a kubeconfig FILE (`secret_files:` in
-`connectors.yaml`), not an env var, so it needs a complete config -- server URL,
-CA, token. Inside the cluster the API server is always reachable at
-`https://kubernetes.default.svc`:
-
-```bash
-kubectl -n curie get secret sre-bot-reader-token \
-  -o jsonpath='{.data.token}' | base64 -d > /tmp/sre-token
-CA=$(kubectl -n curie get secret sre-bot-reader-token -o jsonpath='{.data.ca\.crt}')
-
-cat > /tmp/sre-bot.kubeconfig <<YAML
-apiVersion: v1
-kind: Config
-clusters: [{name: prod, cluster: {server: https://kubernetes.default.svc, certificate-authority-data: $CA}}]
-users: [{name: sre-bot-reader, user: {token: $(cat /tmp/sre-token)}}]
-contexts: [{name: prod, context: {cluster: prod, user: sre-bot-reader}}]
-current-context: prod
-YAML
-
-export K8S_READONLY_KUBECONFIG="$(cat /tmp/sre-bot.kubeconfig)"
-curie secrets set K8S_READONLY_KUBECONFIG --from-env K8S_READONLY_KUBECONFIG
-shred -u /tmp/sre-bot.kubeconfig /tmp/sre-token 2>/dev/null || rm -f /tmp/sre-bot.kubeconfig /tmp/sre-token
-```
-
-`curie secrets set` has no stdin form -- `--from-env` is how a multi-line value
-gets in. It writes to Curie's own storage on this machine; the value never
-enters this repository, and it does NOT yet exist in the cluster (step 4 puts it
-there).
-
-Reaching a DIFFERENT cluster from the one Curie runs on? Use that cluster's
-external API endpoint and its CA instead of `kubernetes.default.svc`, and check
-the sandbox egress allowlist can express the route before minting anything.
-
-**4. Deploy the bundle.**
-
-```bash
-curie cluster deploy --plugin-dir examples/sre-bot
-```
-
-This is the step that provisions the secret from step 3 into the namespace.
-Nothing else does -- not `curie secrets set`, and not a git-flow push. **The
-connector CrashLoops with `references non-existent secret key` if you skip it**,
-and the worker logs the reason plainly: `connector credentials are
-operator-supplied and not yet provisioned in this namespace`.
-
-**5. Ask it something.**
-
-```bash
-curie cluster message "Is any pod crashlooping right now?"
-```
+This installs the bot and its self referential observability stack. It requires
+no values files, connector edits, or supplied credentials.
 
 ---
 
@@ -188,7 +102,7 @@ export SLACK_APP_TOKEN=xapp-...
 export SLACK_BOT_TOKEN=xoxb-...
 curie cluster comms --slack
 
-curie cluster deploy --plugin-dir examples/sre-bot --slack-channel C0EXAMPLE1
+curie example sre-bot install --observability --slack-channel C0EXAMPLE1
 ```
 
 Then invite the bot to the channel and `@mention` it.
@@ -197,26 +111,6 @@ Then invite the bot to the channel and `@mention` it.
 binds nothing and the deploy still reports success -- the bot simply goes silent
 with nothing in any log to explain it. Right-click the channel in Slack -> View
 channel details -> the ID is at the bottom, starting with `C`.
-
-`deploy.yaml` is the better home for that ID once you have more than one
-environment. It declares named targets -- a dev agent in a dev channel, a prod
-agent in a prod channel -- so the routing is a reviewable diff rather than a flag
-somebody typed:
-
-```bash
-curie cluster deploy --plugin-dir examples/sre-bot --target prod
-curie cluster deploy --plugin-dir examples/sre-bot --all-targets
-```
-
-The bundle is IDENTICAL across targets; only the binding differs. That is what
-lets prod promote the exact artifact dev validated.
-
-**[`deploy.yaml`](deploy.yaml) is read only when you pass `--target` or
-`--all-targets`.** A plain `curie cluster deploy --plugin-dir examples/sre-bot`
-ignores it: the agent name comes from `plugin.json` and the binding is the CLI's
-own stub channel. So the documentation IDs shipped in that file are inert on the
-golden path, and you replace them at the point you start naming targets, not
-before.
 
 ---
 
@@ -446,42 +340,6 @@ you wanted.
 
 ---
 
-## Optional: Grafana and traces
-
-Both ship commented out in [`connectors.yaml`](connectors.yaml).
-
-**Grafana** adds logs, metrics, alerts, on-call schedules, profiles, and the
-ability to run the query behind a dashboard panel. It costs one credential: a
-service account with the **Viewer** role, which is the real read-only
-enforcement -- the `-disable-*` flags are defense in depth.
-
-```bash
-export GRAFANA_TOKEN=glsa_...
-curie secrets set GRAFANA_SERVICE_ACCOUNT_TOKEN --from-env GRAFANA_TOKEN
-```
-
-Then uncomment the block and set `GRAFANA_URL`. **That is the one line to edit
-per install**, and it cannot be a placeholder: Curie substitutes exactly four
-`${CURIE_*}` names in connector `args`/`env`, all derived from the Service it
-creates, and rejects any other `${...}` at validation. None of them carries
-per-environment configuration, so a second environment must edit that line. A
-platform-side per-target override is the proper fix and does not exist yet.
-
-**Tempo** adds distributed traces. `mcp-grafana` has no tool that speaks Tempo,
-so without this connector the bot can see the datasource and never read a span.
-It needs the Grafana connector on (it reuses the same token, reaching an endpoint
-mcp-grafana has no tool for) and its own image, built from
-[`connectors/tempo/`](connectors/tempo/) by the same
-`curie build --plugin-dir examples/sre-bot --registry <your-registry>` that
-builds the write connector. Uncomment both blocks and run it once; there is
-nothing extra to run for this one.
-
-Three off-the-shelf routes were measured and rejected before this connector was
-written; [`connectors/tempo/server.py`](connectors/tempo/server.py) records what
-each one actually returned, including `run_panel_query` refusing tempo outright.
-
----
-
 ## Make it yours
 
 **`SKILL.md` is the brain.** Tone, what it checks first, its defaults, its hard
@@ -628,7 +486,7 @@ in the environment section so the bot can say which one it hit.
 
 | Path | What it is |
 |---|---|
-| `.claude-plugin/plugin.json` | Identity, starter prompts. No `approvalPolicy` -- see step 5 above |
+| `.claude-plugin/plugin.json` | Identity, starter prompts. No `approvalPolicy`; see the optional write section |
 | `skills/sre-bot/SKILL.md` | The persona and answering rules -- **the main thing to edit** |
 | `connectors.yaml` | What the bot needs running; Curie derives the Kubernetes |
 | `deploy.yaml` | Named deploy targets: which agent, which environment, which channel |

--- a/examples/sre-bot/connectors.yaml
+++ b/examples/sre-bot/connectors.yaml
@@ -17,14 +17,11 @@
 #                      approval route, and one `curie build` to turn the source
 #                      in `connectors/k8s-write/` into a pinned image. See
 #                      README.md, "Level up: the gated write path".
-#   grafana       OFF. Logs, metrics, alerts, profiles. Needs a Grafana and a
-#                      Viewer service-account token.
-#   tempo         OFF. Distributed traces. Needs Grafana, plus the same
-#                      `curie build` the write connector needs.
+#   grafana       ON. Logs, metrics, alerts and profiles from the bundled stack.
+#   tempo         ON. Distributed traces from the bundled stack.
 #
-# Turning one on is uncommenting its block and supplying its secret. Turning one
-# off is commenting it back out -- the connector disappears and so do its tools,
-# which is the fastest honest way to remove a capability.
+# The optional write connector remains commented out because it needs separate
+# credentials and an approval route.
 connectors:
   # Read-only Kubernetes: the questions metrics cannot answer. What the
   # scheduler actually said, what a crashed container logged, what a manifest
@@ -63,7 +60,7 @@ connectors:
     # v0.0.66 verified directly: carries --port/--bind-address/--read-only/
     # --disable-destructive/--disable-multi-cluster/--stateless/--kubeconfig,
     # and publishes both amd64 and arm64.
-    image: ghcr.io/containers/kubernetes-mcp-server:v0.0.66
+    image: ghcr.io/containers/kubernetes-mcp-server@sha256:6d650f4bd6ac303ad82713c997e73a2d001602f9bf17392c9b9a0e30e29c6423
     args:
       - --port
       - "8000"
@@ -209,125 +206,42 @@ connectors:
 #       K8S_WRITE_KUBECONFIG: /secrets/kubeconfig
 # ---------------------------------------------------------------------------
 
-# ---------------------------------------------------------------------------
-# GRAFANA -- SHIPS OFF. Uncomment if you have a Grafana.
-#
-# Adds logs (Loki), metrics (Prometheus), alerts, on-call schedules, profiles,
-# and the ability to run the query behind a dashboard panel. That is a large
-# capability jump and it costs exactly one credential: a service-account token
-# with the **Viewer** role.
-#
-# THE VIEWER ROLE IS THE REAL READ-ONLY ENFORCEMENT. The `-disable-*` flags
-# below are defense in depth: a write returns 403 server-side regardless. But
-# the agent is prompt-injectable, so write-shaped tools should never reach its
-# context at all -- it cannot be talked into calling a tool it cannot see.
-#
-# Store the token before deploying:
-#
-#     curie secrets set GRAFANA_SERVICE_ACCOUNT_TOKEN
-#
-#   grafana:
-#     image: docker.io/grafana/mcp-grafana:1.0.0
-#     args:
-#       - -t
-#       - streamable-http
-#       - -address
-#       - 0.0.0.0:8000
-#       # Curie names the Service, so Curie supplies every name the sandbox may
-#       # dial. Hardcoding these was wrong the moment one bundle served both a
-#       # dev and a prod agent: the names are agent-scoped and differ per agent.
-#       - -allowed-hosts
-#       - ${CURIE_ALLOWED_HOSTS}
-#       # `-enabled-tools` REPLACES the default category list rather than
-#       # extending it, so the default list is repeated VERBATIM here and the
-#       # additions are appended. Naming only the categories you want silently
-#       # drops the rest -- that is how `suggest_loki_alloy_label_config`
-#       # vanished in a first attempt.
-#       #
-#       # `cloudwatch` is OFF in the upstream default list, so it has to be
-#       # named explicitly. Before enabling it, check what identity your
-#       # CloudWatch datasource authenticates as and confirm that identity is
-#       # strictly read-only: the Viewer role does NOT constrain what a
-#       # datasource query can do, because querying datasources is exactly what
-#       # Viewer is for.
-#       #
-#       # `runpanelquery` is the useful addition: it executes the query BEHIND a
-#       # dashboard panel, so "what does the API latency panel actually say
-#       # right now" stops requiring the agent to reconstruct a query it can
-#       # already see. `examples` returns Grafana's own sample queries. Both are
-#       # reads.
-#       - -enabled-tools
-#       - search,datasource,incident,prometheus,loki,alerting,dashboard,folder,oncall,asserts,sift,pyroscope,navigation,proxied,annotations,rendering,snapshot,plugin,api,config,provisioning,cloudwatch,runpanelquery,examples
-#       # The load-bearing one: removes create/update/delete across every group
-#       # in a single flag.
-#       - -disable-write
-#       # grafana_api_request is a generic passthrough to ANY Grafana API
-#       # endpoint. It defeats per-group tool scoping by construction, so it
-#       # goes even though the token would still reject a mutation.
-#       - -disable-api
-#       - -disable-plugin
-#       - -disable-provisioning
-#       - -disable-snapshot
-#       - -disable-admin
-#       - -disable-incident
-#       - -disable-proxied
-#       - -disable-rendering
-#     unhosted_url: ${GRAFANA_MCP_URL}
-#     env:
-#       # ***** THE ONE LINE TO EDIT PER INSTALL. *****
-#       #
-#       # This cannot be a placeholder today. Curie substitutes exactly four
-#       # names in `args`/`env` -- ${CURIE_ALLOWED_HOSTS}, ${CURIE_CONNECTOR_HOST},
-#       # ${CURIE_CONNECTOR_PORT}, ${CURIE_CONNECTOR_URL} -- all derived from the
-#       # Service Curie itself creates, and any other ${...} is rejected at
-#       # validation as `connectors.unknown_placeholder`. None of them carries
-#       # per-environment configuration, and `deploy.yaml` targets bind an agent
-#       # and a channel, not connector env.
-#       #
-#       # So the identical-bundle promise ("only the binding differs") does not
-#       # hold for this value: a second environment must edit this line. Fixing
-#       # it properly needs a platform-side per-target override (ADR-0089
-#       # shape); until that exists, treat this as the one line to change.
-#       GRAFANA_URL: https://grafana.example.com
-#     # NAME only. The value is resolved at deploy time and written to a
-#     # per-agent Kubernetes Secret; it never appears in this repository.
-#     secrets:
-#       - GRAFANA_SERVICE_ACCOUNT_TOKEN
-# ---------------------------------------------------------------------------
+  grafana:
+    image: docker.io/grafana/mcp-grafana@sha256:5efeafd01cd7e1aea9c4b0f03305951f2944db8f43e5ae290cce9578c977f241
+    args:
+      - -t
+      - streamable-http
+      - -address
+      - 0.0.0.0:8000
+      - -allowed-hosts
+      - ${CURIE_ALLOWED_HOSTS}
+      - -enabled-tools
+      - search,datasource,incident,prometheus,loki,alerting,dashboard,folder,oncall,asserts,sift,pyroscope,navigation,proxied,annotations,rendering,snapshot,plugin,api,config,provisioning,cloudwatch,runpanelquery,examples
+      - -disable-write
+      - -disable-api
+      - -disable-plugin
+      - -disable-provisioning
+      - -disable-snapshot
+      - -disable-admin
+      - -disable-incident
+      - -disable-proxied
+      - -disable-rendering
+    unhosted_url: ${GRAFANA_MCP_URL}
+    env:
+      GRAFANA_URL: http://grafana.observability.svc.cluster.local
+    secrets:
+      - name: GRAFANA_SERVICE_ACCOUNT_TOKEN
+        from_secret: curie-grafana-connector
+        key: GRAFANA_SERVICE_ACCOUNT_TOKEN
 
-# ---------------------------------------------------------------------------
-# TEMPO (DISTRIBUTED TRACES) -- SHIPS OFF, and needs `grafana` on as well.
-#
-# `mcp-grafana` has no tool that speaks Tempo, so without this the bot can see
-# the datasource in `list_datasources` and never read a span. Three off-the-shelf
-# routes were measured and rejected first -- `proxied`, Sift, and
-# `run_panel_query`, the last of which refuses tempo outright. See
-# connectors/tempo/server.py for what each one actually returned.
-#
-# It holds the SAME Grafana token as the grafana connector and talks to the same
-# Grafana, just to an endpoint mcp-grafana has no tool for: the datasource
-# proxy. So this adds a capability without adding a credential.
-#
-# NO PUBLIC IMAGE, and nothing to build by hand: the `build:` block below is
-# built by the same `curie build --plugin-dir examples/sre-bot --registry
-# <your-registry>` that builds the write connector. What that resolves to is a
-# digest, recorded in `connectors.lock.yaml` and rendered verbatim -- which is
-# the point, because a floating `:latest` already cost this connector a
-# CrashLoopBackOff once, when the flags verified at check time were not the
-# flags present at pull time. A digest cannot be repointed after review.
-#
-#   tempo:
-#     build:
-#       context: connectors/tempo
-#       platforms: [linux/amd64, linux/arm64]
-#     unhosted_url: ${TEMPO_MCP_URL}
-#     env:
-#       # Same install-specific line as the grafana block above, same reason.
-#       GRAFANA_URL: https://grafana.example.com
-#       # The Tempo datasource's uid. `__Tempo__` is the server's default and is
-#       # what a provisioned datasource commonly carries; confirm yours with the
-#       # grafana connector's `list_datasources` rather than assuming.
-#       TEMPO_DATASOURCE_UID: __Tempo__
-#     secrets:
-#       - GRAFANA_SERVICE_ACCOUNT_TOKEN
-# ---------------------------------------------------------------------------
+  tempo:
+    build:
+      context: connectors/tempo
+      platforms: [linux/amd64, linux/arm64]
+    unhosted_url: ${TEMPO_MCP_URL}
+    env:
+      GRAFANA_URL: http://grafana.observability.svc.cluster.local
+    secrets:
+      - name: GRAFANA_SERVICE_ACCOUNT_TOKEN
+        from_secret: curie-grafana-connector
+        key: GRAFANA_SERVICE_ACCOUNT_TOKEN

--- a/examples/sre-bot/connectors/tempo/server.py
+++ b/examples/sre-bot/connectors/tempo/server.py
@@ -62,11 +62,6 @@ log = logging.getLogger("tempo-mcp")
 
 GRAFANA_URL = os.environ.get("GRAFANA_URL", "").rstrip("/")
 TOKEN = os.environ.get("GRAFANA_SERVICE_ACCOUNT_TOKEN", "")
-# `__Tempo__` is the uid a provisioned Tempo datasource commonly carries, and it
-# is stable once provisioned -- but it is an env var rather than a constant so a
-# second install does not need a code change. Find yours with the grafana
-# connector's `list_datasources` before assuming this default fits.
-DS_UID = os.environ.get("TEMPO_DATASOURCE_UID", "__Tempo__")
 TIMEOUT = float(os.environ.get("TEMPO_TIMEOUT_SECONDS", "30"))
 
 # Tempo will happily stream a very large trace. The sandbox pays for that in
@@ -121,12 +116,60 @@ def _proxy(path: str, params: dict[str, Any] | None = None) -> Any:
 
     if not GRAFANA_URL or not TOKEN:
         return "not configured: GRAFANA_URL and GRAFANA_SERVICE_ACCOUNT_TOKEN must both be set"
-    url = f"{GRAFANA_URL}/api/datasources/proxy/uid/{quote(DS_UID)}{path}"
+    headers = {"Authorization": f"Bearer {TOKEN}", "Accept": "application/json"}
+    try:
+        discovery = httpx.get(
+            f"{GRAFANA_URL}/api/datasources",
+            headers=headers,
+            timeout=TIMEOUT,
+        )
+    except httpx.TimeoutException:
+        return f"Grafana did not respond within {TIMEOUT:g}s while finding Tempo."
+    except httpx.HTTPError as exc:
+        return f"could not reach Grafana while finding Tempo: {exc}"
+
+    if discovery.status_code in (401, 403):
+        return (
+            f"Grafana refused datasource discovery ({discovery.status_code}). The service "
+            "account token is missing or lacks datasource access. This will not fix itself "
+            "on retry."
+        )
+    if discovery.status_code >= 400:
+        return (
+            f"Grafana datasource discovery returned {discovery.status_code}: "
+            f"{discovery.text[:300]}"
+        )
+
+    try:
+        datasources = discovery.json()
+    except ValueError:
+        return f"Grafana datasource discovery returned non JSON: {discovery.text[:300]}"
+    matches = [
+        datasource
+        for datasource in datasources
+        if isinstance(datasource, dict) and datasource.get("name") == "Tempo"
+    ]
+    if len(matches) != 1:
+        return (
+            "expected exactly one Grafana datasource named Tempo, "
+            f"found {len(matches)}. Refusing to proxy the request."
+        )
+    datasource_uid = matches[0].get("uid")
+    if not isinstance(datasource_uid, str) or not datasource_uid:
+        return (
+            "the Grafana datasource named Tempo has no usable uid. "
+            "Refusing to proxy the request."
+        )
+
+    url = (
+        f"{GRAFANA_URL}/api/datasources/proxy/uid/"
+        f"{quote(datasource_uid, safe='')}{path}"
+    )
     try:
         r = httpx.get(
             url,
             params=params or {},
-            headers={"Authorization": f"Bearer {TOKEN}", "Accept": "application/json"},
+            headers=headers,
             timeout=TIMEOUT,
         )
     except httpx.TimeoutException:
@@ -141,10 +184,7 @@ def _proxy(path: str, params: dict[str, Any] | None = None) -> Any:
             "missing or lacks access to the Tempo datasource. This will not fix itself on retry."
         )
     if r.status_code == 404:
-        return (
-            f"no such Tempo endpoint or datasource uid {DS_UID!r} ({r.status_code}). "
-            "Check TEMPO_DATASOURCE_UID."
-        )
+        return f"Grafana could not proxy the Tempo request ({r.status_code})."
     if r.status_code >= 400:
         return f"Tempo returned {r.status_code}: {r.text[:300]}"
 
@@ -234,7 +274,7 @@ def get_trace(trace_id: str) -> Any:
     trace_id = trace_id.strip()
     if not trace_id:
         return "trace_id is required -- get one from search_traces"
-    return _proxy(f"/api/traces/{quote(trace_id)}")
+    return _proxy(f"/api/traces/{quote(trace_id, safe='')}")
 
 
 @mcp.tool(annotations=READ_ONLY)
@@ -258,7 +298,7 @@ def list_trace_tag_values(tag: str) -> Any:
     tag = tag.strip()
     if not tag:
         return "tag is required, e.g. resource.service.name"
-    return _proxy(f"/api/v2/search/tag/{quote(tag)}/values")
+    return _proxy(f"/api/v2/search/tag/{quote(tag, safe='')}/values")
 
 
 def main() -> int:
@@ -271,7 +311,7 @@ def main() -> int:
         # Kubernetes and is useless to the agent.
         log.error("refusing to start: missing %s", ", ".join(missing))
         return 1
-    log.info("tempo connector -> %s (datasource %s)", GRAFANA_URL, DS_UID)
+    log.info("tempo connector connected to %s", GRAFANA_URL)
     mcp.run(transport="streamable-http")
     return 0
 

--- a/examples/sre-bot/connectors/tempo/test_server.py
+++ b/examples/sre-bot/connectors/tempo/test_server.py
@@ -40,7 +40,7 @@ def _load(**env):
         "GRAFANA_SERVICE_ACCOUNT_TOKEN": "glsa_test",
     }
     base.update(env)
-    for k in ("GRAFANA_URL", "GRAFANA_SERVICE_ACCOUNT_TOKEN", "TEMPO_DATASOURCE_UID"):
+    for k in ("GRAFANA_URL", "GRAFANA_SERVICE_ACCOUNT_TOKEN"):
         os.environ.pop(k, None)
     os.environ.update({k: v for k, v in base.items() if v is not None})
 
@@ -54,52 +54,88 @@ def _load(**env):
     return module
 
 
+def _with_one_tempo(monkeypatch, srv, proxy_get, uid="tempo-prod"):
+    """Route Grafana datasource discovery, then delegate the Tempo proxy call."""
+
+    def fake_get(url, *args, **kwargs):
+        if url == "https://grafana.example.com/api/datasources":
+            return httpx.Response(200, json=[{"name": "Tempo", "uid": uid}])
+        return proxy_get(url, *args, **kwargs)
+
+    monkeypatch.setattr(srv.httpx, "get", fake_get)
+
+
 # --------------------------------------------------------------------------- #
 # The URL. Getting this wrong yields 404s that look like "no traces".
 # --------------------------------------------------------------------------- #
-def test_requests_go_through_grafanas_datasource_proxy(monkeypatch):
+def test_discovers_tempo_then_returns_a_curie_span_through_grafanas_proxy(monkeypatch):
     srv = _load()
-    seen = {}
+    seen = []
+    payload = {
+        "batches": [
+            {
+                "resource": {"service.name": "curie-worker"},
+                "spans": [{"name": "curie.run", "traceId": "curie-trace"}],
+            }
+        ]
+    }
 
     def fake_get(url, params=None, headers=None, timeout=None):
-        seen["url"] = url
-        seen["params"] = params
-        seen["auth"] = headers.get("Authorization")
-        return httpx.Response(200, json={"traces": []})
+        seen.append((url, params, headers))
+        if url == "https://grafana.example.com/api/datasources":
+            return httpx.Response(
+                200,
+                json=[
+                    {"name": "Loki", "uid": "loki"},
+                    {"name": "Tempo", "uid": "tempo/prod arm64"},
+                ],
+            )
+        return httpx.Response(200, json=payload)
 
     monkeypatch.setattr(srv.httpx, "get", fake_get)
-    srv.search_traces("{duration > 500ms}")
-    assert seen["url"] == (
-        "https://grafana.example.com/api/datasources/proxy/uid/__Tempo__/api/search"
-    )
-    # The token goes to Grafana and nowhere else. It must never be a query
-    # parameter, where it would land in Grafana's access log.
-    assert seen["auth"] == "Bearer glsa_test"
-    assert "token" not in str(seen["params"]).lower()
+    assert srv.get_trace("curie/trace id") == payload
+    assert [call[0] for call in seen] == [
+        "https://grafana.example.com/api/datasources",
+        (
+            "https://grafana.example.com/api/datasources/proxy/uid/"
+            "tempo%2Fprod%20arm64/api/traces/curie%2Ftrace%20id"
+        ),
+    ]
+    assert all(headers["Authorization"] == "Bearer glsa_test" for _, _, headers in seen)
+    assert all("token" not in str(params).lower() for _, params, _ in seen)
 
 
-def test_datasource_uid_is_configurable(monkeypatch):
-    srv = _load(TEMPO_DATASOURCE_UID="tempo-prod")
-    seen = {}
+@pytest.mark.parametrize(
+    "datasources",
+    [
+        [],
+        [
+            {"name": "Tempo", "uid": "tempo-a"},
+            {"name": "Tempo", "uid": "tempo-b"},
+        ],
+    ],
+)
+def test_zero_or_duplicate_tempo_datasources_refuse_before_proxy(monkeypatch, datasources):
+    srv = _load()
+    seen = []
 
-    # NOT `seen.setdefault(...) or Response(...)`: setdefault returns the
-    # stored value, which is truthy, so `or` short-circuits and the fake
-    # returns a dict where a Response belongs.
-    def fake_get(url, **kw):
-        seen["url"] = url
-        return httpx.Response(200, json={})
+    def fake_get(url, **kwargs):
+        seen.append(url)
+        assert url == "https://grafana.example.com/api/datasources"
+        return httpx.Response(200, json=datasources)
 
     monkeypatch.setattr(srv.httpx, "get", fake_get)
-    srv.list_trace_tags()
-    assert "/uid/tempo-prod/" in seen["url"]
+    result = srv.list_trace_tags()
+    assert isinstance(result, str)
+    assert "exactly one" in result
+    assert "Tempo" in result
+    assert seen == ["https://grafana.example.com/api/datasources"]
 
 
 # --------------------------------------------------------------------------- #
 # Limits. An uncapped trace fetch is a context-window denial of service.
 # --------------------------------------------------------------------------- #
-@pytest.mark.parametrize(
-    "asked,expected", [(99, 50), (0, 1), (-5, 1), (10, 10), ("7", 7)]
-)
+@pytest.mark.parametrize("asked,expected", [(99, 50), (0, 1), (-5, 1), (10, 10), ("7", 7)])
 def test_limit_is_clamped(monkeypatch, asked, expected):
     srv = _load()
     seen = {}
@@ -108,7 +144,7 @@ def test_limit_is_clamped(monkeypatch, asked, expected):
         seen["p"] = params
         return httpx.Response(200, json={})
 
-    monkeypatch.setattr(srv.httpx, "get", fake_get)
+    _with_one_tempo(monkeypatch, srv, fake_get)
     srv.search_traces("{}", limit=asked)
     assert seen["p"]["limit"] == expected
 
@@ -122,14 +158,16 @@ def test_limit_is_clamped(monkeypatch, asked, expected):
     [
         (403, "refused"),
         (401, "refused"),
-        (404, "TEMPO_DATASOURCE_UID"),
+        (404, "Tempo"),
         (500, "500"),
     ],
 )
 def test_http_errors_become_readable_strings(monkeypatch, status, must_contain):
     srv = _load()
-    monkeypatch.setattr(
-        srv.httpx, "get", lambda *a, **kw: httpx.Response(status, text="boom")
+    _with_one_tempo(
+        monkeypatch,
+        srv,
+        lambda *a, **kw: httpx.Response(status, text="boom"),
     )
     out = srv.search_traces("{}")
     assert isinstance(out, str)
@@ -151,9 +189,9 @@ def test_oversized_body_is_refused_by_content_length(monkeypatch):
     # path must refuse without materialising the megabytes it is refusing.
     srv = _load()
     oversized = str(srv.MAX_RESPONSE_BYTES + 1)
-    monkeypatch.setattr(
-        srv.httpx,
-        "get",
+    _with_one_tempo(
+        monkeypatch,
+        srv,
         lambda *a, **kw: httpx.Response(
             200, json={"ok": True}, headers={"content-length": oversized}
         ),
@@ -174,7 +212,7 @@ def test_oversized_body_is_refused_when_content_length_is_absent(monkeypatch):
     big = {"spans": ["x" * 1000] * ((srv.MAX_RESPONSE_BYTES // 1000) + 20)}
     resp = httpx.Response(200, json=big)
     del resp.headers["content-length"]
-    monkeypatch.setattr(srv.httpx, "get", lambda *a, **kw: resp)
+    _with_one_tempo(monkeypatch, srv, lambda *a, **kw: resp)
     out = srv.get_trace("abc123")
     assert isinstance(out, str)
     assert "cap" in out
@@ -185,7 +223,7 @@ def test_a_normal_sized_trace_is_still_returned(monkeypatch):
     # the refusal would pass with the cap set to zero.
     srv = _load()
     payload = {"batches": [{"spans": [{"name": "GET /health"}]}]}
-    monkeypatch.setattr(srv.httpx, "get", lambda *a, **kw: httpx.Response(200, json=payload))
+    _with_one_tempo(monkeypatch, srv, lambda *a, **kw: httpx.Response(200, json=payload))
     assert srv.get_trace("abc123") == payload
 
 
@@ -194,9 +232,9 @@ def test_search_results_are_capped_too(monkeypatch):
     # covered -- a wide TraceQL search can also return more than the ceiling.
     srv = _load()
     oversized = str(srv.MAX_RESPONSE_BYTES + 1)
-    monkeypatch.setattr(
-        srv.httpx,
-        "get",
+    _with_one_tempo(
+        monkeypatch,
+        srv,
         lambda *a, **kw: httpx.Response(
             200, json={"traces": []}, headers={"content-length": oversized}
         ),
@@ -207,7 +245,7 @@ def test_search_results_are_capped_too(monkeypatch):
 def test_auth_failure_says_it_will_not_fix_itself(monkeypatch):
     # Without this the agent retries a 403 three times and reports a timeout.
     srv = _load()
-    monkeypatch.setattr(srv.httpx, "get", lambda *a, **kw: httpx.Response(403))
+    _with_one_tempo(monkeypatch, srv, lambda *a, **kw: httpx.Response(403))
     assert "not fix itself" in srv.search_traces("{}")
 
 
@@ -217,7 +255,7 @@ def test_timeout_is_not_an_exception(monkeypatch):
     def boom(*a, **kw):
         raise httpx.TimeoutException("too slow")
 
-    monkeypatch.setattr(srv.httpx, "get", boom)
+    _with_one_tempo(monkeypatch, srv, boom)
     out = srv.search_traces("{}")
     assert isinstance(out, str) and "did not respond" in out
 
@@ -228,7 +266,7 @@ def test_transport_error_does_not_leak_the_token(monkeypatch):
     def boom(*a, **kw):
         raise httpx.ConnectError("connection refused")
 
-    monkeypatch.setattr(srv.httpx, "get", boom)
+    _with_one_tempo(monkeypatch, srv, boom)
     out = srv.search_traces("{}")
     assert "glsa_test" not in out
 

--- a/examples/sre-bot/observability/alloy-values.yaml
+++ b/examples/sre-bot/observability/alloy-values.yaml
@@ -1,0 +1,117 @@
+crds:
+  create: false
+controller:
+  type: daemonset
+  volumes:
+    extra:
+      - name: alloy-data
+        hostPath:
+          path: /var/lib/alloy
+          type: DirectoryOrCreate
+configReloader:
+  enabled: false
+rbac:
+  create: true
+  rules:
+    - apiGroups: [""]
+      resources: [pods]
+      verbs: [get, list, watch]
+alloy:
+  storagePath: /var/lib/alloy/data
+  mounts:
+    varlog: true
+    dockercontainers: false
+    extra:
+      - name: alloy-data
+        mountPath: /var/lib/alloy
+  clustering:
+    enabled: false
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      memory: 512Mi
+  configMap:
+    content: |-
+      logging {
+        level  = "info"
+        format = "logfmt"
+      }
+
+      discovery.kubernetes "pods" {
+        role = "pod"
+        selectors {
+          role  = "pod"
+          field = "spec.nodeName=" + coalesce(sys.env("HOSTNAME"), constants.hostname)
+        }
+      }
+
+      discovery.relabel "pod_logs" {
+        targets = discovery.kubernetes.pods.targets
+
+        rule {
+          source_labels = ["__meta_kubernetes_namespace"]
+          action        = "replace"
+          target_label  = "namespace"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_pod_name"]
+          action        = "replace"
+          target_label  = "pod"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_pod_container_name"]
+          action        = "replace"
+          target_label  = "container"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_component"]
+          action        = "replace"
+          target_label  = "component"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_container_name"]
+          separator     = "/"
+          action        = "replace"
+          target_label  = "job"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
+          separator     = "/"
+          action        = "replace"
+          replacement   = "/var/log/pods/*$1/*.log"
+          target_label  = "__path__"
+        }
+      }
+
+      local.file_match "pod_logs" {
+        path_targets = discovery.relabel.pod_logs.output
+      }
+
+      loki.source.file "pod_logs" {
+        targets       = local.file_match.pod_logs.targets
+        tail_from_end = true
+        forward_to    = [loki.process.pod_logs.receiver]
+      }
+
+      loki.process "pod_logs" {
+        stage.cri { }
+
+        stage.labels {
+          values = { stream = "" }
+        }
+
+        stage.label_drop {
+          values = ["filename"]
+        }
+
+        forward_to = [loki.write.default.receiver]
+      }
+
+      loki.write "default" {
+        endpoint {
+          url = "http://loki.observability.svc.cluster.local:3100/loki/api/v1/push"
+        }
+        external_labels = { cluster = "curie-example" }
+      }

--- a/examples/sre-bot/observability/curie-values.yaml
+++ b/examples/sre-bot/observability/curie-values.yaml
@@ -1,0 +1,16 @@
+otelCollector:
+  extraExporters:
+    otlphttp/tempo:
+      endpoint: http://tempo.observability.svc.cluster.local:4318
+  extraPipelineExporters:
+    - otlphttp/tempo
+grafanaConnector:
+  enabled: true
+  url: http://grafana.observability.svc.cluster.local
+  namespace: observability
+  adminSecretName: grafana-admin
+  secretName: curie-grafana-connector
+  secretKey: GRAFANA_SERVICE_ACCOUNT_TOKEN
+  restartDeploymentNames:
+    - curie-sre-bot-grafana
+    - curie-sre-bot-tempo

--- a/examples/sre-bot/observability/grafana-values.yaml
+++ b/examples/sre-bot/observability/grafana-values.yaml
@@ -1,0 +1,52 @@
+image:
+  tag: 13.2.0
+admin:
+  existingSecret: grafana-admin
+  userKey: admin-user
+  passwordKey: admin-password
+persistence:
+  enabled: true
+  size: 2Gi
+  storageClassName: local-path
+service:
+  type: ClusterIP
+testFramework:
+  enabled: false
+rbac:
+  pspEnabled: false
+resources:
+  requests:
+    cpu: 50m
+    memory: 128Mi
+  limits:
+    memory: 384Mi
+grafana.ini:
+  analytics:
+    reporting_enabled: false
+    check_for_updates: false
+  users:
+    allow_sign_up: false
+  auth.anonymous:
+    enabled: false
+datasources:
+  datasources.yaml:
+    apiVersion: 1
+    datasources:
+      - name: Loki
+        type: loki
+        uid: loki
+        url: http://loki.observability.svc.cluster.local:3100
+        access: proxy
+        isDefault: true
+      - name: Tempo
+        type: tempo
+        uid: __Tempo__
+        url: http://tempo.observability.svc.cluster.local:3200
+        access: proxy
+      - name: Prometheus
+        type: prometheus
+        uid: prometheus
+        url: http://prometheus-server.observability.svc.cluster.local
+        access: proxy
+        jsonData:
+          timeInterval: 60s

--- a/examples/sre-bot/observability/loki-values.yaml
+++ b/examples/sre-bot/observability/loki-values.yaml
@@ -1,0 +1,108 @@
+deploymentMode: SingleBinary
+loki:
+  image:
+    tag: 3.7.6
+  auth_enabled: false
+  config: |
+    auth_enabled: {{ .Values.loki.auth_enabled }}
+    analytics:
+      reporting_enabled: false
+    common:
+      path_prefix: /var/loki
+      replication_factor: {{ .Values.loki.commonConfig.replication_factor }}
+      ring:
+        kvstore:
+          store: inmemory
+      storage:
+        filesystem:
+          chunks_directory: /var/loki/chunks
+          rules_directory: /var/loki/rules
+    compactor:
+      {{- toYaml .Values.loki.compactor | nindent 6 }}
+    ingester:
+      {{- toYaml .Values.loki.ingester | nindent 6 }}
+    limits_config:
+      {{- toYaml .Values.loki.limits_config | nindent 6 }}
+    ruler:
+      storage:
+        type: local
+      wal:
+        dir: /var/loki/ruler-wal
+    runtime_config:
+      file: /etc/loki/runtime-config/runtime-config.yaml
+    schema_config:
+      {{- toYaml .Values.loki.schemaConfig | nindent 6 }}
+    server:
+      graceful_shutdown_timeout: 5s
+      grpc_listen_port: 9095
+      http_listen_port: 3100
+      log_level: info
+    tracing:
+      enabled: false
+  commonConfig:
+    replication_factor: 1
+  storage:
+    type: filesystem
+  schemaConfig:
+    configs:
+      - from: "2024-04-01"
+        store: tsdb
+        object_store: filesystem
+        schema: v13
+        index:
+          prefix: index_
+          period: 24h
+  limits_config:
+    retention_period: 168h
+    allow_structured_metadata: true
+    volume_enabled: true
+    ingestion_rate_mb: 2
+    ingestion_burst_size_mb: 4
+    per_stream_rate_limit: 1MB
+    per_stream_rate_limit_burst: 2MB
+    max_global_streams_per_user: 1000
+    reject_old_samples: true
+    reject_old_samples_max_age: 24h
+    max_line_size: 64KB
+  ingester:
+    chunk_idle_period: 1h
+    wal:
+      enabled: true
+      dir: /var/loki/wal
+      replay_memory_ceiling: 512MB
+      disk_full_threshold: 0.9
+  compactor:
+    retention_enabled: true
+    delete_request_store: filesystem
+singleBinary:
+  replicas: 1
+  persistence:
+    enabled: true
+    size: 10Gi
+    storageClass: local-path
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      memory: 768Mi
+read:
+  replicas: 0
+write:
+  replicas: 0
+backend:
+  replicas: 0
+chunksCache:
+  enabled: false
+resultsCache:
+  enabled: false
+gateway:
+  enabled: false
+lokiCanary:
+  enabled: false
+test:
+  enabled: false
+minio:
+  enabled: false
+rollout_operator:
+  enabled: false

--- a/examples/sre-bot/observability/prometheus-values.yaml
+++ b/examples/sre-bot/observability/prometheus-values.yaml
@@ -1,0 +1,39 @@
+alertmanager:
+  enabled: false
+prometheus-pushgateway:
+  enabled: false
+configmapReload:
+  prometheus:
+    enabled: false
+kube-state-metrics:
+  enabled: true
+  resources:
+    requests:
+      cpu: 10m
+      memory: 64Mi
+    limits:
+      memory: 128Mi
+prometheus-node-exporter:
+  enabled: true
+  resources:
+    requests:
+      cpu: 20m
+      memory: 32Mi
+    limits:
+      memory: 64Mi
+server:
+  retention: 7d
+  retentionSize: 3GB
+  global:
+    scrape_interval: 60s
+    evaluation_interval: 60s
+  persistentVolume:
+    enabled: true
+    size: 8Gi
+    storageClass: local-path
+  resources:
+    requests:
+      cpu: 100m
+      memory: 512Mi
+    limits:
+      memory: 1Gi

--- a/examples/sre-bot/observability/tempo.yaml
+++ b/examples/sre-bot/observability/tempo.yaml
@@ -1,0 +1,122 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tempo
+  namespace: observability
+data:
+  tempo.yaml: |
+    server:
+      http_listen_port: 3200
+      grpc_listen_port: 9095
+    distributor:
+      receivers:
+        otlp:
+          protocols:
+            grpc:
+              endpoint: 0.0.0.0:4317
+            http:
+              endpoint: 0.0.0.0:4318
+    ingester:
+      max_block_duration: 5m
+    compactor:
+      compaction:
+        block_retention: 48h
+    storage:
+      trace:
+        backend: local
+        local:
+          path: /var/tempo/blocks
+        wal:
+          path: /var/tempo/wal
+    usage_report:
+      reporting_enabled: false
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tempo
+  namespace: observability
+spec:
+  selector:
+    app.kubernetes.io/name: tempo
+  ports:
+    - name: http
+      port: 3200
+      targetPort: 3200
+    - name: otlp-grpc
+      port: 4317
+      targetPort: 4317
+    - name: otlp-http
+      port: 4318
+      targetPort: 4318
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: tempo
+  namespace: observability
+spec:
+  serviceName: tempo
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: tempo
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: tempo
+      annotations:
+        checksum/config: v1
+    spec:
+      securityContext:
+        fsGroup: 10001
+        runAsUser: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: tempo
+          image: docker.io/grafana/tempo:2.9.1@sha256:290414580eabd1bde91f22e4a4579242fe77377c425223f45d59b8ad1540ce3c
+          args: ["-config.file=/conf/tempo.yaml"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ALL]
+          ports:
+            - name: http
+              containerPort: 3200
+            - name: otlp-grpc
+              containerPort: 4317
+            - name: otlp-http
+              containerPort: 4318
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 3200
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 50m
+              memory: 192Mi
+            limits:
+              memory: 512Mi
+          volumeMounts:
+            - name: config
+              mountPath: /conf
+            - name: data
+              mountPath: /var/tempo
+      volumes:
+        - name: config
+          configMap:
+            name: tempo
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: [ReadWriteOnce]
+        storageClassName: local-path
+        resources:
+          requests:
+            storage: 5Gi

--- a/examples/tests/test_example_mcp_declarations.py
+++ b/examples/tests/test_example_mcp_declarations.py
@@ -19,6 +19,8 @@ import json
 import os
 from pathlib import Path
 
+import yaml
+
 EXAMPLES = Path(__file__).resolve().parents[1]
 
 # A string that ends in one of these is a reference to a script shipped inside
@@ -83,3 +85,48 @@ def test_example_mcp_server_script_args_are_cwd_independent() -> None:
     assert not violations, "cwd-dependent MCP server script args found:\n" + "\n".join(
         violations
     )
+
+
+def test_sre_bot_observability_connectors_ship_self_configured() -> None:
+    path = EXAMPLES / "sre-bot" / "connectors.yaml"
+    raw = path.read_text()
+    connectors = yaml.safe_load(raw)["connectors"]
+
+    kubernetes = connectors["kubernetes"]
+    grafana = connectors["grafana"]
+    tempo = connectors["tempo"]
+    expected_url = "http://grafana.observability.svc.cluster.local"
+    expected_token_ref = {
+        "name": "GRAFANA_SERVICE_ACCOUNT_TOKEN",
+        "from_secret": "curie-grafana-connector",
+        "key": "GRAFANA_SERVICE_ACCOUNT_TOKEN",
+    }
+
+    assert (
+        kubernetes["image"]
+        == "ghcr.io/containers/kubernetes-mcp-server@sha256:"
+        "6d650f4bd6ac303ad82713c997e73a2d001602f9bf17392c9b9a0e30e29c6423"
+    )
+    assert (
+        grafana["image"]
+        == "docker.io/grafana/mcp-grafana@sha256:"
+        "5efeafd01cd7e1aea9c4b0f03305951f2944db8f43e5ae290cce9578c977f241"
+    )
+    assert tempo["build"] == {
+        "context": "connectors/tempo",
+        "platforms": ["linux/amd64", "linux/arm64"],
+    }
+    assert "image" not in tempo
+    assert grafana["env"]["GRAFANA_URL"] == expected_url
+    assert tempo["env"] == {"GRAFANA_URL": expected_url}
+    assert grafana["secrets"] == [expected_token_ref]
+    assert tempo["secrets"] == [expected_token_ref]
+    assert "build" not in kubernetes
+    assert "build" not in grafana
+
+    assert "__Tempo__" not in raw
+    assert "https://grafana.example.com" not in raw
+    assert "THE ONE LINE TO EDIT PER INSTALL" not in raw
+    assert "curie secrets set GRAFANA_SERVICE_ACCOUNT_TOKEN" not in raw
+    assert "GRAFANA -- SHIPS OFF" not in raw
+    assert "TEMPO (DISTRIBUTED TRACES) -- SHIPS OFF" not in raw

--- a/examples/tests/test_sre_bot_observability_runtime.py
+++ b/examples/tests/test_sre_bot_observability_runtime.py
@@ -1,0 +1,757 @@
+"""Docker backed behavioral proof for the SRE bot observability connectors.
+
+This is deliberately not a Kubernetes substitute. Chart rendering owns the
+Kubernetes object contract. Here, the exact configured backends and real MCP
+connector artifacts are driven over their network protocols so a green test
+means a LogQL result and a Tempo span actually crossed the connector boundary.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import re
+import shutil
+import socket
+import subprocess
+import tempfile
+import textwrap
+import time
+import urllib.error
+import urllib.request
+import uuid
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+from aci_protocol import OtelConfig
+from curie_runner import RunTracer, build_tracer_provider
+from plugin_format.connector_render import host_aliases, object_name, service_dns
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+OBSERVABILITY = REPO_ROOT / "examples" / "sre-bot" / "observability"
+CONNECTORS = REPO_ROOT / "examples" / "sre-bot" / "connectors.yaml"
+TEMPO_CONNECTOR = REPO_ROOT / "examples" / "sre-bot" / "connectors" / "tempo"
+
+RELEASE = "curie"
+AGENT = "sre-bot"
+NAMESPACE = "curie"
+CONNECTOR_PORT = 8000
+
+
+MCP_PROBE = r"""
+import json
+import sys
+import urllib.request
+
+url, tool, raw_arguments = sys.argv[1:]
+state = {"session": None, "version": "2024-11-05"}
+
+
+def post(body, notification=False):
+    headers = {
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream",
+        "MCP-Protocol-Version": state["version"],
+    }
+    if state["session"]:
+        headers["mcp-session-id"] = state["session"]
+    request = urllib.request.Request(
+        url, data=json.dumps(body).encode(), headers=headers, method="POST"
+    )
+    with urllib.request.urlopen(request, timeout=60) as response:
+        session = response.headers.get("mcp-session-id")
+        if session:
+            state["session"] = session
+        raw = response.read().decode("utf-8", "replace")
+    if notification:
+        return None
+    for line in raw.splitlines():
+        if line.startswith("data:"):
+            return json.loads(line[5:].strip())
+    return json.loads(raw)
+
+
+initialized = post(
+    {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": state["version"],
+            "capabilities": {},
+            "clientInfo": {"name": "curie-observability-runtime", "version": "0"},
+        },
+    }
+)
+state["version"] = initialized["result"].get("protocolVersion", state["version"])
+post({"jsonrpc": "2.0", "method": "notifications/initialized"}, notification=True)
+response = post(
+    {
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "tools/call",
+        "params": {"name": tool, "arguments": json.loads(raw_arguments)},
+    }
+)
+print(json.dumps(response))
+"""
+
+
+def _run(
+    command: list[str],
+    *,
+    input_text: str | None = None,
+    environment: dict[str, str] | None = None,
+    timeout: int = 180,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        command,
+        input=input_text,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+        env=None if environment is None else {**os.environ, **environment},
+    )
+    if check and result.returncode != 0:
+        raise AssertionError(
+            f"command failed ({result.returncode}): {' '.join(command)}\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+    return result
+
+
+def _docker(*args: str, **kwargs: Any) -> subprocess.CompletedProcess[str]:
+    return _run(["docker", *args], **kwargs)
+
+
+def _require_docker() -> None:
+    if shutil.which("docker") is None:
+        pytest.skip("Docker is unavailable: docker CLI is not installed")
+    result = _docker("info", "--format", "{{.ServerVersion}}", check=False, timeout=15)
+    if result.returncode != 0:
+        reason = result.stderr.strip() or result.stdout.strip()
+        pytest.skip(f"Docker is unavailable: {reason}")
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    value = yaml.safe_load(path.read_text())
+    assert isinstance(value, dict), f"{path} must contain one YAML mapping"
+    return value
+
+
+def _resolve(mapping: dict[str, Any], dotted: str) -> Any:
+    value: Any = mapping
+    for part in dotted.split("."):
+        value = value[part]
+    return value
+
+
+def _render_loki_config(values: dict[str, Any]) -> str:
+    """Resolve the small Helm expression subset in the committed Loki config."""
+
+    loki = values["loki"]
+    rendered = str(loki["config"])
+    rendered = rendered.replace(
+        "{{ .Values.loki.auth_enabled }}",
+        str(bool(loki["auth_enabled"])).lower(),
+    )
+    rendered = rendered.replace(
+        "{{ .Values.loki.commonConfig.replication_factor }}",
+        str(loki["commonConfig"]["replication_factor"]),
+    )
+    block = re.compile(
+        r"(?m)^[ ]*{{- toYaml \.Values\.loki\.([A-Za-z0-9_]+) \| nindent ([0-9]+) }}$"
+    )
+
+    def replace(match: re.Match[str]) -> str:
+        source = _resolve(loki, match.group(1))
+        dumped = yaml.safe_dump(source, sort_keys=False).rstrip()
+        return textwrap.indent(dumped, " " * int(match.group(2)))
+
+    rendered = block.sub(replace, rendered)
+    assert "{{" not in rendered, f"unresolved Loki Helm expression:\n{rendered}"
+    parsed = yaml.safe_load(rendered)
+    assert parsed["ingester"]["wal"]["disk_full_threshold"] == 0.9
+    return rendered
+
+
+def _tempo_config_and_image() -> tuple[str, str]:
+    documents = [
+        document
+        for document in yaml.safe_load_all((OBSERVABILITY / "tempo.yaml").read_text())
+        if document
+    ]
+    config = next(document for document in documents if document["kind"] == "ConfigMap")
+    stateful_set = next(document for document in documents if document["kind"] == "StatefulSet")
+    image = stateful_set["spec"]["template"]["spec"]["containers"][0]["image"]
+    return config["data"]["tempo.yaml"], image
+
+
+def _collector_config_and_image() -> tuple[dict[str, Any], str]:
+    config = _load_yaml(REPO_ROOT / "otel" / "collector-config.yaml")
+    integration = _load_yaml(OBSERVABILITY / "curie-values.yaml")["otelCollector"]
+    config["exporters"].update(integration["extraExporters"])
+    config["service"]["pipelines"]["traces"]["exporters"].extend(
+        integration["extraPipelineExporters"]
+    )
+    assert config["service"]["pipelines"]["traces"]["exporters"] == [
+        "otlphttp/langfuse",
+        "debug",
+        "otlphttp/tempo",
+    ]
+    chart_values = _load_yaml(REPO_ROOT / "charts" / "curie" / "values.yaml")
+    return config, chart_values["otelCollector"]["image"]
+
+
+def _write_runtime_configs(root: Path) -> dict[str, str]:
+    root.mkdir(parents=True, exist_ok=True)
+
+    loki_values = _load_yaml(OBSERVABILITY / "loki-values.yaml")
+    (root / "loki.yaml").write_text(_render_loki_config(loki_values))
+    (root / "loki-runtime.yaml").write_text("{}\n")
+
+    tempo_config, tempo_image = _tempo_config_and_image()
+    (root / "tempo.yaml").write_text(tempo_config)
+
+    grafana_values = _load_yaml(OBSERVABILITY / "grafana-values.yaml")
+    provisioning = {
+        "apiVersion": 1,
+        "datasources": grafana_values["datasources"]["datasources.yaml"]["datasources"],
+    }
+    (root / "grafana-datasources.yaml").write_text(yaml.safe_dump(provisioning, sort_keys=False))
+
+    collector_config, collector_image = _collector_config_and_image()
+    (root / "collector.yaml").write_text(yaml.safe_dump(collector_config, sort_keys=False))
+    return {
+        "loki": f"docker.io/grafana/loki:{loki_values['loki']['image']['tag']}",
+        "tempo": tempo_image,
+        "grafana": f"docker.io/grafana/grafana:{grafana_values['image']['tag']}",
+        "collector": collector_image,
+    }
+
+
+def _request(
+    url: str,
+    *,
+    method: str = "GET",
+    body: dict[str, Any] | None = None,
+    headers: dict[str, str] | None = None,
+    expected: tuple[int, ...] = (200,),
+    timeout: float = 5,
+) -> tuple[int, bytes]:
+    data = None if body is None else json.dumps(body).encode()
+    request_headers = dict(headers or {})
+    if data is not None:
+        request_headers["Content-Type"] = "application/json"
+    request = urllib.request.Request(
+        url,
+        data=data,
+        headers=request_headers,
+        method=method,
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            status = response.status
+            response_body = response.read()
+    except urllib.error.HTTPError as error:
+        status = error.code
+        response_body = error.read()
+    if status not in expected:
+        raise AssertionError(
+            f"{method} {url} returned HTTP {status}, expected {expected}: "
+            f"{response_body.decode(errors='replace')}"
+        )
+    return status, response_body
+
+
+def _wait_http(url: str, container: str, timeout: float = 90) -> None:
+    deadline = time.monotonic() + timeout
+    last_error = "not attempted"
+    while time.monotonic() < deadline:
+        try:
+            status, _ = _request(url, expected=(200, 204), timeout=2)
+            if status in (200, 204):
+                return
+        except Exception as error:  # noqa: BLE001
+            last_error = str(error)
+        time.sleep(1)
+    result = _docker("logs", container, check=False)
+    logs = result.stdout + result.stderr
+    raise AssertionError(f"{url} never became ready: {last_error}\n{logs}")
+
+
+def _wait_port(host: str, port: int, container: str, timeout: float = 60) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection((host, port), timeout=1):
+                return
+        except OSError:
+            time.sleep(0.5)
+    logs = _docker("logs", container, check=False).stdout
+    raise AssertionError(f"{host}:{port} never became reachable\n{logs}")
+
+
+def _host_port(container: str, port: int) -> int:
+    output = _docker("port", container, f"{port}/tcp").stdout.strip().splitlines()
+    assert output, f"container {container} publishes no host port for {port}"
+    return int(output[0].rsplit(":", 1)[1])
+
+
+def _container_name(prefix: str, suffix: str) -> str:
+    return f"curie-obs-{prefix}-{suffix}"
+
+
+@dataclass
+class RuntimeStack:
+    suffix: str
+    front_network: str
+    back_network: str
+    tempo_probe_container: str
+    grafana_url: str
+    loki_url: str
+    collector_url: str
+    token: str
+    containers: list[str]
+    volumes: list[str]
+    tempo_connector_image: str
+
+    def connector_url(self, connector: str) -> str:
+        return f"http://{service_dns(RELEASE, AGENT, connector, NAMESPACE)}:{CONNECTOR_PORT}/mcp"
+
+    def call(self, connector: str, tool: str, arguments: dict[str, Any]) -> dict[str, Any]:
+        result = _docker(
+            "exec",
+            "-i",
+            self.tempo_probe_container,
+            "python",
+            "-",
+            self.connector_url(connector),
+            tool,
+            json.dumps(arguments),
+            input_text=MCP_PROBE,
+            timeout=90,
+        )
+        return json.loads(result.stdout.strip().splitlines()[-1])
+
+    def call_text(self, connector: str, tool: str, arguments: dict[str, Any]) -> str:
+        response = self.call(connector, tool, arguments)
+        assert "error" not in response, response
+        result = response["result"]
+        assert result.get("isError") is not True, response
+        return "\n".join(
+            item["text"] for item in result.get("content", []) if item.get("type") == "text"
+        )
+
+    def eventually_call_text(
+        self,
+        connector: str,
+        tool: str,
+        arguments: dict[str, Any],
+        marker: str,
+        timeout: float = 45,
+    ) -> str:
+        deadline = time.monotonic() + timeout
+        last = ""
+        while time.monotonic() < deadline:
+            last = self.call_text(connector, tool, arguments)
+            if marker in last:
+                return last
+            time.sleep(1)
+        raise AssertionError(
+            f"{connector}.{tool} never returned marker {marker!r}; last response: {last}"
+        )
+
+
+def _run_container(
+    stack: RuntimeStack,
+    name: str,
+    image: str,
+    network: str,
+    *,
+    aliases: tuple[str, ...] = (),
+    env: dict[str, str] | None = None,
+    volumes: tuple[tuple[Path, str], ...] = (),
+    named_volumes: tuple[tuple[str, str], ...] = (),
+    publish: tuple[int, ...] = (),
+    args: tuple[str, ...] = (),
+) -> None:
+    command = ["run", "-d", "--name", name, "--network", network]
+    for alias in aliases:
+        command.extend(["--network-alias", alias])
+    for key in env or {}:
+        command.extend(["-e", key])
+    for source, target in volumes:
+        command.extend(["-v", f"{source.resolve()}:{target}:ro"])
+    for source, target in named_volumes:
+        command.extend(["-v", f"{source}:{target}"])
+    for port in publish:
+        command.extend(["-p", f"127.0.0.1::{port}"])
+    command.append(image)
+    command.extend(args)
+    stack.containers.append(name)
+    _docker(*command, environment=env, timeout=300)
+
+
+def _mint_grafana_token(grafana_url: str, password: str) -> str:
+    authorization = base64.b64encode(f"admin:{password}".encode()).decode()
+    headers = {"Authorization": f"Basic {authorization}"}
+    _, body = _request(
+        f"{grafana_url}/api/serviceaccounts",
+        method="POST",
+        body={"name": "curie-observability-runtime", "role": "Viewer"},
+        headers=headers,
+        expected=(200, 201),
+    )
+    account_id = json.loads(body)["id"]
+    _, body = _request(
+        f"{grafana_url}/api/serviceaccounts/{account_id}/tokens",
+        method="POST",
+        body={"name": "runtime"},
+        headers=headers,
+        expected=(200, 201),
+    )
+    token = json.loads(body)["key"]
+    assert token
+    return token
+
+
+def _start_runtime_stack(root: Path) -> RuntimeStack:
+    suffix = uuid.uuid4().hex[:10]
+    front = f"curie-obs-front-{suffix}"
+    back = f"curie-obs-back-{suffix}"
+    images = _write_runtime_configs(root)
+    tempo_connector_image = f"curie-sre-bot-tempo-runtime:{suffix}"
+    stack = RuntimeStack(
+        suffix=suffix,
+        front_network=front,
+        back_network=back,
+        tempo_probe_container="",
+        grafana_url="",
+        loki_url="",
+        collector_url="",
+        token="",
+        containers=[],
+        volumes=[],
+        tempo_connector_image=tempo_connector_image,
+    )
+    try:
+        _docker("network", "create", front)
+        _docker("network", "create", back)
+        _populate_runtime_stack(stack, root, images)
+        return stack
+    except Exception:
+        _stop_runtime_stack(stack)
+        raise
+
+
+def _create_volume(stack: RuntimeStack, purpose: str) -> str:
+    name = f"curie-obs-{purpose}-{stack.suffix}"
+    _docker("volume", "create", name)
+    stack.volumes.append(name)
+    _docker(
+        "run",
+        "--rm",
+        "--user",
+        "0",
+        "-v",
+        f"{name}:/data",
+        "docker.io/library/alpine:3.22",
+        "chown",
+        "10001:10001",
+        "/data",
+    )
+    return name
+
+
+def _populate_runtime_stack(stack: RuntimeStack, root: Path, images: dict[str, str]) -> None:
+    suffix = stack.suffix
+    back = stack.back_network
+    front = stack.front_network
+    loki_data = _create_volume(stack, "loki-data")
+    tempo_data = _create_volume(stack, "tempo-data")
+
+    loki = _container_name("loki", suffix)
+    _run_container(
+        stack,
+        loki,
+        images["loki"],
+        back,
+        aliases=("loki.observability.svc.cluster.local",),
+        volumes=(
+            (root / "loki.yaml", "/etc/loki/loki.yaml"),
+            (
+                root / "loki-runtime.yaml",
+                "/etc/loki/runtime-config/runtime-config.yaml",
+            ),
+        ),
+        named_volumes=((loki_data, "/var/loki"),),
+        publish=(3100,),
+        args=("-config.file=/etc/loki/loki.yaml",),
+    )
+    stack.loki_url = f"http://127.0.0.1:{_host_port(loki, 3100)}"
+    _wait_http(f"{stack.loki_url}/ready", loki)
+
+    tempo = _container_name("tempo", suffix)
+    _run_container(
+        stack,
+        tempo,
+        images["tempo"],
+        back,
+        aliases=("tempo.observability.svc.cluster.local",),
+        volumes=((root / "tempo.yaml", "/conf/tempo.yaml"),),
+        named_volumes=((tempo_data, "/var/tempo"),),
+        publish=(3200,),
+        args=("-config.file=/conf/tempo.yaml",),
+    )
+    tempo_url = f"http://127.0.0.1:{_host_port(tempo, 3200)}"
+    _wait_http(f"{tempo_url}/ready", tempo)
+
+    grafana = _container_name("grafana", suffix)
+    admin_password = uuid.uuid4().hex + uuid.uuid4().hex
+    _run_container(
+        stack,
+        grafana,
+        images["grafana"],
+        front,
+        aliases=("grafana.observability.svc.cluster.local",),
+        env={
+            "GF_SECURITY_ADMIN_USER": "admin",
+            "GF_SECURITY_ADMIN_PASSWORD": admin_password,
+            "GF_AUTH_ANONYMOUS_ENABLED": "false",
+            "GF_SERVER_ROUTER_LOGGING": "true",
+            "GF_SERVER_HTTP_PORT": "80",
+        },
+        volumes=(
+            (
+                root / "grafana-datasources.yaml",
+                "/etc/grafana/provisioning/datasources/runtime.yaml",
+            ),
+        ),
+        publish=(80,),
+    )
+    _docker("network", "connect", back, grafana)
+    stack.grafana_url = f"http://127.0.0.1:{_host_port(grafana, 80)}"
+    _wait_http(f"{stack.grafana_url}/api/health", grafana)
+    stack.token = _mint_grafana_token(stack.grafana_url, admin_password)
+
+    collector = _container_name("collector", suffix)
+    _run_container(
+        stack,
+        collector,
+        images["collector"],
+        back,
+        env={"LANGFUSE_OTLP_AUTH_HEADER": "Basic runtime-test"},
+        volumes=((root / "collector.yaml", "/etc/otel/collector.yaml"),),
+        publish=(4318,),
+        args=("--config=/etc/otel/collector.yaml",),
+    )
+    collector_port = _host_port(collector, 4318)
+    stack.collector_url = f"http://127.0.0.1:{collector_port}"
+    _wait_port("127.0.0.1", collector_port, collector)
+
+    _docker(
+        "build",
+        "-t",
+        stack.tempo_connector_image,
+        str(TEMPO_CONNECTOR),
+        timeout=300,
+    )
+
+    declaration = _load_yaml(CONNECTORS)["connectors"]
+    grafana_spec = declaration["grafana"]
+    grafana_args = [
+        ",".join(host_aliases(RELEASE, AGENT, "grafana", NAMESPACE, CONNECTOR_PORT))
+        if argument == "${CURIE_ALLOWED_HOSTS}"
+        else argument
+        for argument in grafana_spec["args"]
+    ]
+    grafana_connector = _container_name("mcp-grafana", suffix)
+    grafana_alias = service_dns(RELEASE, AGENT, "grafana", NAMESPACE)
+    _run_container(
+        stack,
+        grafana_connector,
+        grafana_spec["image"],
+        front,
+        aliases=(grafana_alias, object_name(RELEASE, AGENT, "grafana")),
+        env={
+            "GRAFANA_URL": grafana_spec["env"]["GRAFANA_URL"],
+            "GRAFANA_SERVICE_ACCOUNT_TOKEN": stack.token,
+        },
+        args=tuple(grafana_args),
+    )
+
+    tempo_connector = _container_name("mcp-tempo", suffix)
+    tempo_alias = service_dns(RELEASE, AGENT, "tempo", NAMESPACE)
+    _run_container(
+        stack,
+        tempo_connector,
+        stack.tempo_connector_image,
+        front,
+        aliases=(tempo_alias, object_name(RELEASE, AGENT, "tempo")),
+        env={
+            "GRAFANA_URL": declaration["tempo"]["env"]["GRAFANA_URL"],
+            "GRAFANA_SERVICE_ACCOUNT_TOKEN": stack.token,
+        },
+    )
+    stack.tempo_probe_container = tempo_connector
+
+    deadline = time.monotonic() + 60
+    last_error = "connectors were not probed"
+    while time.monotonic() < deadline:
+        try:
+            stack.call("grafana", "list_datasources", {})
+            stack.call("tempo", "list_trace_tags", {})
+            return
+        except Exception as error:  # noqa: BLE001
+            last_error = str(error)
+            time.sleep(1)
+    logs = "\n".join(
+        _docker("logs", container, check=False).stdout
+        for container in (grafana_connector, tempo_connector)
+    )
+    raise AssertionError(f"MCP connectors never became ready: {last_error}\n{logs}")
+
+
+def _stop_runtime_stack(stack: RuntimeStack) -> None:
+    for container in reversed(stack.containers):
+        _docker("rm", "-f", container, check=False, timeout=30)
+    _docker("network", "rm", stack.front_network, check=False, timeout=30)
+    _docker("network", "rm", stack.back_network, check=False, timeout=30)
+    _docker("image", "rm", "-f", stack.tempo_connector_image, check=False, timeout=30)
+    for volume in reversed(stack.volumes):
+        _docker("volume", "rm", "-f", volume, check=False, timeout=30)
+
+
+@pytest.fixture(scope="module")
+def observability_runtime() -> Iterator[RuntimeStack]:
+    _require_docker()
+    with tempfile.TemporaryDirectory(prefix="curie-sre-bot-observability-runtime-") as root:
+        stack: RuntimeStack | None = None
+        try:
+            stack = _start_runtime_stack(Path(root))
+            yield stack
+        finally:
+            if stack is not None:
+                _stop_runtime_stack(stack)
+
+
+def _response_text(response: dict[str, Any]) -> str:
+    result = response["result"]
+    return "\n".join(
+        item["text"] for item in result.get("content", []) if item.get("type") == "text"
+    )
+
+
+def test_logql_through_the_bots_real_grafana_connector_returns_a_curie_log(
+    observability_runtime: RuntimeStack,
+) -> None:
+    marker = f"curie-api observability-runtime-{uuid.uuid4().hex}"
+    _request(
+        f"{observability_runtime.loki_url}/loki/api/v1/push",
+        method="POST",
+        body={
+            "streams": [
+                {
+                    "stream": {
+                        "namespace": "curie",
+                        "container": "api",
+                        "job": "curie/api",
+                    },
+                    "values": [[str(time.time_ns()), marker]],
+                }
+            ]
+        },
+        expected=(204,),
+    )
+
+    query = {
+        "datasourceUid": "loki",
+        "logql": f'{{namespace="curie", container="api"}} |= "{marker}"',
+        "limit": 10,
+        "direction": "backward",
+    }
+    result = observability_runtime.eventually_call_text("grafana", "query_loki_logs", query, marker)
+    assert marker in result
+
+    missing = observability_runtime.call_text(
+        "grafana",
+        "query_loki_logs",
+        {
+            **query,
+            "logql": '{namespace="curie", container="api"} |= "absent-runtime-marker"',
+        },
+    )
+    assert marker not in missing
+    assert '"data":[]' in missing.replace(" ", "")
+
+
+@contextmanager
+def _otel_environment(endpoint: str) -> Iterator[None]:
+    keys = (
+        "OTEL_EXPORTER_OTLP_ENDPOINT",
+        "OTEL_EXPORTER_OTLP_PROTOCOL",
+        "OTEL_EXPORTER_OTLP_HEADERS",
+    )
+    old = {key: os.environ.get(key) for key in keys}
+    os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = endpoint
+    os.environ["OTEL_EXPORTER_OTLP_PROTOCOL"] = "http/protobuf"
+    os.environ.pop("OTEL_EXPORTER_OTLP_HEADERS", None)
+    try:
+        yield
+    finally:
+        for key, value in old.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
+def test_tempo_connector_returns_a_real_curie_span_through_grafanas_uid_proxy(
+    observability_runtime: RuntimeStack,
+) -> None:
+    marker = f"curie-observability-runtime-{uuid.uuid4().hex}"
+    with _otel_environment(observability_runtime.collector_url):
+        provider = build_tracer_provider(
+            OtelConfig(endpoint=observability_runtime.collector_url),
+            marker,
+            "runtime-sandbox",
+        )
+        assert provider is not None
+        tracer = RunTracer(provider)
+        with tracer.run_span(marker, "fake-model") as generation:
+            generation.record_usage({"input_tokens": 1, "output_tokens": 1})
+        tracer.shutdown()
+
+    search = {
+        "query": '{ resource.service.name = "curie-runner" }',
+        "limit": 20,
+    }
+    result = observability_runtime.eventually_call_text(
+        "tempo", "search_traces", search, "curie-runner", timeout=60
+    )
+    payload = json.loads(result)
+    traces = payload.get("traces", [])
+    assert traces, payload
+    trace_id = traces[0]["traceID"]
+
+    trace = observability_runtime.eventually_call_text(
+        "tempo", "get_trace", {"trace_id": trace_id}, marker
+    )
+    assert marker in trace
+    assert "curie-runner" in trace
+
+    missing = observability_runtime.call_text(
+        "tempo",
+        "search_traces",
+        {"query": '{ resource.service.name = "curie-runtime-absent" }', "limit": 20},
+    )
+    assert json.loads(missing).get("traces") == []

--- a/release/authorize.py
+++ b/release/authorize.py
@@ -80,6 +80,7 @@ REQUIRED_CHECK_NAMES = frozenset(
         "Build dispatcher image (no push)",
         "Build worker image (no push)",
         "Build ui image (no push)",
+        "Build sre-bot-tempo image (no push)",
         "Build worker-local overlay image (no push)",
         "Dispatcher image imports resolve",
         "Eval falsifiability gate (fake model, offline)",

--- a/release/tests/test_authorize.py
+++ b/release/tests/test_authorize.py
@@ -916,6 +916,66 @@ jobs:
 
 
 class TestReleaseWorkflowContract:
+    def test_sre_bot_tempo_connector_builds_in_ordinary_ci(self):
+        workflow = yaml.load(CI_YAML.read_text(), Loader=yaml.BaseLoader)
+        image_job = workflow["jobs"]["images"]
+        tempo_rows = [
+            row
+            for row in image_job["strategy"]["matrix"]["include"]
+            if row.get("name") == "sre-bot-tempo"
+        ]
+        assert tempo_rows == [
+            {
+                "name": "sre-bot-tempo",
+                "context": "examples/sre-bot/connectors/tempo",
+                "dockerfile": "examples/sre-bot/connectors/tempo/Dockerfile",
+            }
+        ]
+        build_step = next(
+            step for step in image_job["steps"] if step.get("name") == "Build (no push)"
+        )
+        assert build_step["with"]["context"] == "${{ matrix.context }}"
+        assert "Build sre-bot-tempo image (no push)" in authorize_module.REQUIRED_CHECK_NAMES
+
+    def test_observability_stack_assertions_run_in_helm_ci(self):
+        workflow = yaml.load(HELM_CI_YAML.read_text(), Loader=yaml.BaseLoader)
+        chart_steps = workflow["jobs"]["helm"]["steps"]
+        matching = [
+            step
+            for step in chart_steps
+            if "observability-stack-assertions.sh" in step.get("run", "")
+        ]
+        assert len(matching) == 1
+
+    def test_sre_bot_tempo_connector_is_a_first_party_release_image(self):
+        workflow = yaml.load(RELEASE_YAML.read_text(), Loader=yaml.BaseLoader)
+        build_matrix = workflow["jobs"]["build"]["strategy"]["matrix"]
+        merge_matrix = workflow["jobs"]["merge"]["strategy"]["matrix"]
+
+        assert "sre-bot-tempo" in build_matrix["name"]
+        assert "sre-bot-tempo" in merge_matrix["name"]
+        tempo_rows = [
+            row
+            for row in build_matrix["include"]
+            if row.get("name") == "sre-bot-tempo"
+        ]
+        assert tempo_rows == [
+            {
+                "name": "sre-bot-tempo",
+                "context": "examples/sre-bot/connectors/tempo",
+                "dockerfile": "examples/sre-bot/connectors/tempo/Dockerfile",
+            }
+        ]
+        build_step = next(
+            step
+            for step in workflow["jobs"]["build"]["steps"]
+            if step.get("name") == "Build and push by digest"
+        )
+        assert build_step["with"]["context"] == "${{ matrix.context }}"
+        tempo_context = REPO_ROOT / tempo_rows[0]["context"]
+        assert (tempo_context / "requirements.txt").is_file()
+        assert (tempo_context / "server.py").is_file()
+
     def test_release_branch_sources_are_anchored_and_wired_to_authorization(self):
         source = RELEASE_YAML.read_text()
         workflow = yaml.load(source, Loader=yaml.BaseLoader)
@@ -1047,6 +1107,7 @@ class TestHelmCiWorkflowTriggers:
         # credential fix) must still match this filter or the gate never runs.
         assert triggers["pull_request"]["paths"] == [
             "charts/curie/**",
+            "examples/sre-bot/observability/**",
             ".github/workflows/helm-ci.yaml",
             "packages/aci-protocol/src/aci_protocol/s3.py",
             "apps/api/src/curie_api/config.py",


### PR DESCRIPTION
Closes #1765

Adds `curie example sre-bot install --observability` as the single install path for the SRE bot, Grafana, Loki, Alloy, Tempo, and Prometheus. The command embeds the pinned values, rejects insufficient memory before mutation, preserves the Grafana release and credential, provisions scoped connector credentials, and resolves connector images immutably.

The exact appendix requests total 1312Mi on one node because the listed 64Mi kube state metrics request is part of the seven enabled components. The preflight retains those exact requests and uses 1152Mi plus 160Mi per Ready schedulable node.

Depends on #1794 for the independently useful collector exporter values hook.