### PR TITLE
Pin the API Service NodePort

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -102,6 +102,13 @@ jobs:
           set -euo pipefail
           bash charts/curie/ci/render-assertions.sh
 
+      # Prove the API Service keeps a stable NodePort when enabled, allows an
+      # override, and omits the field for ClusterIP or explicit auto allocation.
+      - name: helm render assertions (api service NodePort)
+        run: |
+          set -euo pipefail
+          bash charts/curie/ci/api-service-nodeport-assertions.sh
+
       # Prove the BYO-model LiteLLM sidecar (issue #253) is off by default,
       # renders fully when its values flag is enabled, and yields to local
       # inference. Runs the chart-owned assertion script.

--- a/charts/curie/ci/api-service-nodeport-assertions.sh
+++ b/charts/curie/ci/api-service-nodeport-assertions.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+#
+# Structural assertions for the API Service NodePort contract (#1760):
+#   (a) the default ClusterIP Service omits nodePort;
+#   (b) switching to NodePort uses the pinned 30081 default;
+#   (c) an explicit NodePort override wins;
+#   (d) an empty NodePort value restores Kubernetes auto allocation by omitting
+#       the field from the rendered Service.
+set -euo pipefail
+
+CHART="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fail() { echo "FAIL [$1] $2" >&2; exit 1; }
+render() { helm template curie "$CHART" "$@" 2>&1; }
+
+assert_api_service() {
+  local case_id="$1" expected_type="$2" expected_node_port="$3"
+  shift 3
+
+  local out
+  if ! out="$(render -s templates/api.yaml "$@")"; then
+    fail "$case_id" "helm template failed
+$(head -3 <<<"$out")"
+  fi
+
+  CASE_ID="$case_id" python3 - "$out" "$expected_type" "$expected_node_port" <<'PY' || exit 1
+import os
+import sys
+
+import yaml
+
+case_id = os.environ["CASE_ID"]
+documents = [doc for doc in yaml.safe_load_all(sys.argv[1]) if doc]
+services = [
+    doc
+    for doc in documents
+    if doc.get("kind") == "Service"
+    and doc.get("metadata", {}).get("labels", {}).get("app.kubernetes.io/component") == "api"
+]
+if len(services) != 1:
+    print(
+        f"FAIL [{case_id}] expected exactly one API Service, found {len(services)}",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+service = services[0]
+expected_type = sys.argv[2]
+actual_type = service.get("spec", {}).get("type")
+if actual_type != expected_type:
+    print(
+        f"FAIL [{case_id}] Service type {actual_type!r}, expected {expected_type!r}",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+ports = [port for port in service["spec"].get("ports", []) if port.get("name") == "http"]
+if len(ports) != 1:
+    print(
+        f"FAIL [{case_id}] expected exactly one http port, found {len(ports)}",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+port = ports[0]
+expected_node_port = sys.argv[3]
+if expected_node_port == "absent":
+    if "nodePort" in port:
+        print(
+            f"FAIL [{case_id}] nodePort rendered unexpectedly: {port['nodePort']!r}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+else:
+    expected = int(expected_node_port)
+    actual = port.get("nodePort")
+    if actual != expected:
+        print(
+            f"FAIL [{case_id}] nodePort {actual!r}, expected {expected}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+PY
+}
+
+# (a) A nonempty pinned default must never leak into the default ClusterIP.
+assert_api_service a ClusterIP absent
+
+# (b) NodePort without an override must use the stable published port.
+assert_api_service b NodePort 30081 --set api.service.type=NodePort
+
+# (c) Operators can choose another safe NodePort.
+assert_api_service c NodePort 30181 \
+  --set api.service.type=NodePort \
+  --set api.service.nodePort=30181
+
+# (d) An explicit empty string omits nodePort so Kubernetes allocates one.
+assert_api_service d NodePort absent \
+  --set api.service.type=NodePort \
+  --set-string api.service.nodePort=
+
+echo "api-service-nodeport-assertions: all four assertions passed"

--- a/charts/curie/templates/NOTES.txt
+++ b/charts/curie/templates/NOTES.txt
@@ -31,6 +31,9 @@ Components deployed:
 App services:
 {{- if .Values.api.deploy }}
   - api ({{ .Values.api.image.repository }}:{{ .Values.api.image.tag }}) on Service {{ include "curie.fullname" . }}-api:{{ .Values.api.service.port }}
+{{- if and (eq .Values.api.service.type "NodePort") .Values.api.service.nodePort }}
+    NodePort {{ .Values.api.service.nodePort }} is pinned by api.service.nodePort. Set it to an empty string to let Kubernetes allocate a port.
+{{- end }}
 {{- end }}
 {{- if include "curie.dispatcher.enabled" . }}
   - dispatcher ({{ .Values.dispatcher.image.repository }}:{{ .Values.dispatcher.image.tag }}) [Slack Socket Mode, no Service]

--- a/charts/curie/templates/api.yaml
+++ b/charts/curie/templates/api.yaml
@@ -14,6 +14,9 @@ spec:
     - name: http
       port: {{ .Values.api.service.port }}
       targetPort: 8000
+      {{- if and (eq .Values.api.service.type "NodePort") .Values.api.service.nodePort }}
+      nodePort: {{ .Values.api.service.nodePort }}
+      {{- end }}
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/curie/values-e2e-harness.yaml
+++ b/charts/curie/values-e2e-harness.yaml
@@ -33,7 +33,9 @@ inference:
 otelCollector:
   deploy: false
 
-# First-party app services -- none are needed to exec a bound sandbox runner.
+# First-party app services. The runtime harness selectively enables a zero-replica
+# API to exercise its Service NodePort contract; no app workload is needed to exec
+# a bound sandbox runner.
 api:
   deploy: false
 dispatcher:

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -694,6 +694,13 @@ api:
   service:
     type: ClusterIP
     port: 8000
+    # Pinned NodePort used when service.type is set to NodePort. Empty lets
+    # Kubernetes allocate one from 30000-32767, but
+    # an auto-allocated port changes on every helm install/upgrade, breaking
+    # any URL or `curie deploy --api-url` that hardcodes a port. The default
+    # pins it so a down/up cycle keeps the same URL. Override or set to "" to
+    # restore auto-allocation.
+    nodePort: 30081
   # TLS for the API (issue #1238). Off by default because it cannot be
   # defaulted honestly -- it needs an ingress controller, a hostname, and a
   # certificate source, none of which the chart can invent. Rendering an

--- a/scripts/chart-runtime-e2e.sh
+++ b/scripts/chart-runtime-e2e.sh
@@ -11,17 +11,19 @@
 # and that dir sat on the `bundles` emptyDir the untrusted `runner` container
 # also mounts. The acceptance criterion is a RUNTIME exec:
 #   kubectl exec <sandbox> -c runner -- find /bundles -name config.json   # empty
-# This harness makes that check one command.
+# This harness makes that check and the API Service NodePort contract one
+# command.
 #
 # THE PATTERN (reusable -- this is NOT a #56 one-off)
 # ---------------------------------------------------
 # 1. Install a trimmed chart slice on k8scratch with RustFS and agent sandbox.
-# 2. Seed a real bundle object into RustFS.
-# 3. Render the SandboxTemplate.spec.podTemplate into a BOUND sandbox Pod
+# 2. Assert the API Service pinned and auto allocated NodePort cases.
+# 3. Seed a real bundle object into RustFS.
+# 4. Render the SandboxTemplate.spec.podTemplate into a BOUND sandbox Pod
 #    (CURIE_BUNDLE_REF pointing at the seeded object) and apply it -- so the
 #    real bundle-fetch/bundle-extract init containers actually run.
-# 4. Wait for the init pair to complete and the runner container to be Running.
-# 5. `kubectl exec` into the runner and ASSERT on what it can see.
+# 5. Wait for the init pair to complete and the runner container to be Running.
+# 6. `kubectl exec` into the runner and ASSERT on what it can see.
 #
 # HOW TO ADD ANOTHER RUNTIME ASSERTION
 # ------------------------------------
@@ -40,7 +42,7 @@ RELEASE="e2eharness"
 CHART="charts/curie"
 KEEP=0
 FORCE=0
-RUNNER_IMAGE=""
+RUNNER_IMAGE="${CURIE_CHART_E2E_RUNNER_IMAGE:-}"
 EXPECT_VULNERABLE=0
 POD_NAME="e2e-bound-sandbox"
 BUNDLE_REF="e2e/probe.tgz"
@@ -49,10 +51,11 @@ usage() {
   cat <<'EOF'
 Usage: scripts/chart-runtime-e2e.sh [options]
 
-Stands up a trimmed Curie chart slice on the k8scratch cluster, seeds a real
-bundle into RustFS, renders a bound agent-sandbox Pod, runs its bundle-fetch/
-extract init containers, and execs the runner to assert the #56 credential is
-NOT readable off the shared bundle volume (and the bundle really was provisioned).
+Stands up a trimmed Curie chart slice on the k8scratch cluster, proves the API
+Service pinned and auto allocated NodePort cases, seeds a real bundle into
+RustFS, renders a bound agent-sandbox Pod, runs its bundle-fetch/extract init
+containers, and execs the runner to assert the #56 credential is NOT readable
+off the shared bundle volume (and the bundle really was provisioned).
 
 Options:
   --namespace <ns>       Namespace to use (default: curie-e2eharness)
@@ -69,6 +72,11 @@ Options:
   --keep                 Skip teardown (leave namespace + release for debugging).
   --force                Allow running against a non-k8scratch kube context.
   --help                 Show this help.
+
+Environment:
+  CURIE_CHART_E2E_RUNNER_IMAGE
+                         Runner image fallback for callers that cannot forward
+                         flags. --runner-image takes precedence when supplied.
 EOF
 }
 
@@ -104,6 +112,9 @@ else
 fi
 SANDBOX_TEMPLATE="$FULLNAME-runner"
 RUSTFS_SVC="$FULLNAME-rustfs"
+API_SERVICE="$FULLNAME-api"
+PLATFORM_PRIORITY_CLASS="$FULLNAME-platform"
+SANDBOX_PRIORITY_CLASS="$FULLNAME-sandbox"
 SECRET_NAME="$FULLNAME-secrets"
 RUSTFS_BUCKET="curie-bundles"
 RUSTFS_ACCESS_KEY="rustfs"
@@ -148,6 +159,9 @@ teardown() {
   fi
   banner "TEARDOWN"
   helm uninstall "$RELEASE" -n "$NAMESPACE" --no-hooks >/dev/null 2>&1 || true
+  kubectl delete priorityclass \
+    "$PLATFORM_PRIORITY_CLASS" "$SANDBOX_PRIORITY_CLASS" \
+    --ignore-not-found --wait=true >/dev/null 2>&1 || true
   # Only ever delete a namespace THIS script created (carries the ownership label).
   if ns_is_owned "$NAMESPACE"; then
     kubectl delete ns "$NAMESPACE" --wait=false >/dev/null 2>&1 || true
@@ -364,6 +378,9 @@ if kubectl get ns "$NAMESPACE" >/dev/null 2>&1; then
   if ns_is_owned "$NAMESPACE"; then
     banner "namespace $NAMESPACE already exists (harness-owned) -- cleaning up before run"
     helm uninstall "$RELEASE" -n "$NAMESPACE" --no-hooks >/dev/null 2>&1 || true
+    kubectl delete priorityclass \
+      "$PLATFORM_PRIORITY_CLASS" "$SANDBOX_PRIORITY_CLASS" \
+      --ignore-not-found --wait=true >/dev/null 2>&1 || true
     kubectl delete ns "$NAMESPACE" --wait=true --timeout=120s >/dev/null 2>&1 || true
   else
     fail "namespace $NAMESPACE already exists and is NOT owned by this harness (missing label ${OWNED_LABEL}=true). Remove it manually or pick another --namespace."
@@ -375,17 +392,39 @@ fi
 create_owned_ns "$NAMESPACE"
 
 banner "INSTALL trimmed chart"
+CHART_VALUES=(
+  -f "$CHART_PATH/values-e2e-nogvisor.yaml"
+  -f "$CHART_PATH/values-e2e-harness.yaml"
+  --set api.deploy=true
+  --set api.replicas=0
+  --set api.service.type=NodePort
+  # The shared scratch cluster may already allocate the chart's public default.
+  --set api.service.nodePort=30181
+  # PriorityClasses are cluster scoped. Give this release unique names and let
+  # the chart create them so the harness never borrows another release's state.
+  --set priorityClasses.platform.create=true
+  --set-string priorityClasses.platform.name="$PLATFORM_PRIORITY_CLASS"
+  --set priorityClasses.sandbox.create=true
+  --set-string priorityClasses.sandbox.name="$SANDBOX_PRIORITY_CLASS"
+  # The trimmed overlay disables these backing stores. The zero-replica API
+  # still renders their environment, so satisfy the chart's BYO-host guards
+  # without creating reachable dependencies.
+  --set-string postgres.host=postgres.example.com
+  --set-string valkey.host=valkey.example.com
+)
 install_chart() {
   helm install "$RELEASE" "$CHART_PATH" \
     -n "$NAMESPACE" --no-hooks \
-    -f "$CHART_PATH/values-e2e-nogvisor.yaml" \
-    -f "$CHART_PATH/values-e2e-harness.yaml"
+    "${CHART_VALUES[@]}"
 }
 # k8scratch is shared and slightly flaky: a spurious "namespaces not found" at
 # install is usually API churn, so retry ONCE before failing.
 if ! install_chart; then
   echo "helm install failed once (likely transient API churn on shared node); retrying in 5s..."
   sleep 5
+  kubectl delete priorityclass \
+    "$PLATFORM_PRIORITY_CLASS" "$SANDBOX_PRIORITY_CLASS" \
+    --ignore-not-found --wait=true >/dev/null 2>&1 || true
   # Recreate the labeled namespace before retrying; only ever delete our own.
   if ns_is_owned "$NAMESPACE"; then
     kubectl delete ns "$NAMESPACE" --wait=true --timeout=60s >/dev/null 2>&1 || true
@@ -395,7 +434,117 @@ if ! install_chart; then
 fi
 
 # --------------------------------------------------------------------------
-# 2. Wait for RustFS Running. Gate on the pod, not Helm release status.
+# 2. Assert the API Service pinned NodePort, then restore auto allocation.
+# --------------------------------------------------------------------------
+banner "ASSERT API Service pinned NodePort"
+API_SERVICE_JSON="$(kubectl get service "$API_SERVICE" -n "$NAMESPACE" -o json)"
+python3 - "$API_SERVICE_JSON" <<'PY' || exit 1
+import json
+import sys
+
+service = json.loads(sys.argv[1])
+service_type = service.get("spec", {}).get("type")
+ports = [port for port in service.get("spec", {}).get("ports", []) if port.get("name") == "http"]
+if service_type != "NodePort":
+    print(f"FAIL: live API Service type {service_type!r}, expected 'NodePort'", file=sys.stderr)
+    sys.exit(1)
+if len(ports) != 1:
+    print(f"FAIL: live API Service has {len(ports)} http ports, expected 1", file=sys.stderr)
+    sys.exit(1)
+node_port = ports[0].get("nodePort")
+if node_port != 30181:
+    print(f"FAIL: live API Service nodePort {node_port!r}, expected 30181", file=sys.stderr)
+    sys.exit(1)
+print("live API Service: type=NodePort nodePort=30181")
+PY
+
+banner "UPGRADE API Service to auto allocated NodePort"
+helm upgrade "$RELEASE" "$CHART_PATH" \
+  -n "$NAMESPACE" --no-hooks \
+  "${CHART_VALUES[@]}" \
+  --set-string api.service.nodePort=
+
+STORED_VALUES_JSON="$(helm get values "$RELEASE" -n "$NAMESPACE" -o json)"
+python3 - "$STORED_VALUES_JSON" <<'PY' || exit 1
+import json
+import sys
+
+values = json.loads(sys.argv[1])
+service = values.get("api", {}).get("service", {})
+if "nodePort" not in service or service["nodePort"] != "":
+    print(
+        f"FAIL: stored api.service.nodePort is {service.get('nodePort')!r}, expected an explicit empty string",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+print('stored override: api.service.nodePort=""')
+PY
+
+API_SERVICE_MANIFEST="$(helm get manifest "$RELEASE" -n "$NAMESPACE" | awk -v name="$API_SERVICE" '
+  BEGIN { RS = "---" }
+  {
+    is_service = 0
+    has_name = 0
+    line_count = split($0, lines, "\n")
+    for (i = 1; i <= line_count; i++) {
+      line = lines[i]
+      if (line ~ /^[[:space:]]*kind:[[:space:]]*Service[[:space:]]*$/) {
+        is_service = 1
+      }
+      candidate = line
+      if (sub(/^[[:space:]]*name:[[:space:]]*/, "", candidate)) {
+        sub(/[[:space:]]*$/, "", candidate)
+        if (candidate == name) {
+          has_name = 1
+        }
+      }
+    }
+    if (is_service && has_name) {
+      print
+      found = 1
+      exit
+    }
+  }
+  END { if (!found) exit 1 }
+')" || fail "API Service is absent from the stored release manifest"
+if grep -q '^[[:space:]]*nodePort:' <<<"$API_SERVICE_MANIFEST"; then
+  fail "stored release manifest renders nodePort after the empty override"
+fi
+echo "stored release manifest: API Service nodePort omitted"
+
+kubectl delete service "$API_SERVICE" -n "$NAMESPACE" --wait=true
+if kubectl get service "$API_SERVICE" -n "$NAMESPACE" >/dev/null 2>&1; then
+  fail "API Service still exists after deletion"
+fi
+echo "live API Service deleted before auto allocation proof"
+
+printf '%s\n' "$API_SERVICE_MANIFEST" | kubectl create -n "$NAMESPACE" -f -
+API_SERVICE_JSON="$(kubectl get service "$API_SERVICE" -n "$NAMESPACE" -o json)"
+python3 - "$API_SERVICE_JSON" <<'PY' || exit 1
+import json
+import sys
+
+service = json.loads(sys.argv[1])
+service_type = service.get("spec", {}).get("type")
+ports = [port for port in service.get("spec", {}).get("ports", []) if port.get("name") == "http"]
+if service_type != "NodePort":
+    print(f"FAIL: live API Service type {service_type!r}, expected 'NodePort'", file=sys.stderr)
+    sys.exit(1)
+if len(ports) != 1:
+    print(f"FAIL: live API Service has {len(ports)} http ports, expected 1", file=sys.stderr)
+    sys.exit(1)
+node_port = ports[0].get("nodePort")
+if not isinstance(node_port, int) or not 30000 <= node_port <= 32767:
+    print(
+        f"FAIL: live auto allocated API Service nodePort {node_port!r} is outside 30000 through 32767",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+print(f"live API Service auto allocated nodePort={node_port}")
+PY
+
+# --------------------------------------------------------------------------
+# 3. Wait for RustFS Running. Gate on the pod, not Helm release status.
 # --------------------------------------------------------------------------
 banner "WAIT RustFS Running"
 if ! kubectl wait --for=condition=Ready pod \
@@ -407,7 +556,7 @@ if ! kubectl wait --for=condition=Ready pod \
 fi
 
 # --------------------------------------------------------------------------
-# 3. Seed a real bundle into RustFS
+# 4. Seed a real bundle into RustFS
 # --------------------------------------------------------------------------
 banner "SEED bundle into RustFS"
 # Build a VALID tar.gz (bundle-extract runs `set -eu; tar -xzf`, so a malformed
@@ -488,7 +637,7 @@ fi
 echo "bundle seeded: $BUNDLE_REF"
 
 # --------------------------------------------------------------------------
-# 4. Render + apply the bound sandbox Pod
+# 5. Render + apply the bound sandbox Pod
 # --------------------------------------------------------------------------
 banner "RENDER bound sandbox Pod from SandboxTemplate $SANDBOX_TEMPLATE"
 if [[ -n "$RUNNER_IMAGE" ]]; then
@@ -507,7 +656,7 @@ wait_for_init_complete
 echo "bound sandbox ready: init containers Completed, runner Running"
 
 # --------------------------------------------------------------------------
-# 5. Assertions
+# 6. Assertions
 # --------------------------------------------------------------------------
 banner "ASSERT runtime security (#56)"
 run_assertions
@@ -522,7 +671,7 @@ else
   echo "mode: default (expect secure)"
 fi
 if [[ "$RESULT" == "PASS" ]]; then
-  echo "PASS"
+  echo "PASS: API Service NodePort and runtime security assertions"
   exit 0
 else
   echo "FAIL"


### PR DESCRIPTION
## Summary

Pins the API Service NodePort to 30081 when the Service type is NodePort. The value is documented, overridable, and may be set to an empty string to restore Kubernetes auto allocation. The default Service type remains ClusterIP.

## Related issue

Closes #1760

## End to end verification

1. skill: Not applicable. This change does not reach plugin packaging, the runner turn loop, ACI events, skill eval, or skill check.
2. local: Not applicable. This change does not reach compose services, application wiring, the console, or CLI output behavior.
3. local-release: Not applicable. This change does not alter released binary identity, image identity, install paths, version pins, or release compose.
4. cluster: Required in fake mode. Candidate acb4a77fde12c1ff4b514cefff715034183c0140 passed `CURIE_CHART_E2E_RUNNER_IMAGE=busybox:1.36 curie dev chart-runtime-e2e`. The live Service reported `type=NodePort nodePort=30181`. With `api.service.nodePort=""`, the stored manifest omitted nodePort and a recreated live Service auto allocated 31923. The run ended with `PASS: API Service NodePort and runtime security assertions`.
5. live provider: Not applicable. This change does not reach model routing, credentials, provider authentication, tokens, or cost accounting.
6. external integration: Not applicable. This change does not reach Slack, git push webhooks, connector OAuth, or a third party API.

Positive and negative chart assertions also passed with `curie dev chart-check`: ClusterIP omits nodePort, NodePort defaults to 30081, an override renders 30181, and an empty value omits nodePort. `helm lint charts/curie` passed with 1 chart and 0 failures.

## Checklist

* [x] Every required tier names the exact command, candidate commit, mode, and observed outcome.
* [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or second independent path.
* [x] No required tier is left unproved.
* [x] Tests pass for the affected chart area.
* [x] Documentation is updated.
* [x] No ADR is needed because this follows the existing chart convention.
