### PR TITLE
Preflight all target connector credentials

### DIFF
--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -435,6 +435,15 @@ pub struct BudgetConfig {
     pub max_usd_per_day: Option<f64>,
 }
 
+/// Artifacts prepared before deployment activation.
+pub struct PreparedDeployOutcome {
+    pub(crate) agent: Agent,
+    pub(crate) version: Version,
+    pub(crate) bundle: Bundle,
+    pub(crate) channel: ChannelOutcome,
+    pub(crate) repo_note: Option<String>,
+}
+
 /// The artifacts a deploy produces, for the summary printout.
 pub struct DeployOutcome {
     pub agent: Agent,
@@ -937,6 +946,58 @@ impl ApiClient {
             .context("decoding created deployment")
     }
 
+    /// Prepare a deploy through bundle upload without creating its deployment.
+    #[allow(clippy::too_many_arguments)] // one cohesive deploy call; a struct would not clarify it
+    pub async fn prepare_deploy(
+        &self,
+        agent_name: &str,
+        slack_channel: Option<&str>,
+        version_label: &str,
+        created_by: &str,
+        archive: Vec<u8>,
+        secrets: &std::collections::BTreeMap<String, String>,
+        repo_full_name: Option<&str>,
+    ) -> Result<PreparedDeployOutcome> {
+        let (agent, channel, repo_note) = self
+            .resolve_agent(agent_name, slack_channel, repo_full_name)
+            .await?;
+        // Bind per-agent connector secrets (ADR-0009, #429). A PATCH covers both
+        // a freshly created agent and a redeploy that rotates a value; an empty
+        // map leaves the agent's current secrets untouched.
+        if !secrets.is_empty() {
+            self.update_agent_secrets(&agent.id, secrets).await?;
+        }
+        let version = self
+            .create_version(&agent.id, version_label, created_by)
+            .await?;
+        let bundle = self.upload_bundle(&agent.id, &version.id, archive).await?;
+        Ok(PreparedDeployOutcome {
+            agent,
+            version,
+            bundle,
+            channel,
+            repo_note,
+        })
+    }
+
+    pub async fn activate_deploy(
+        &self,
+        prepared: PreparedDeployOutcome,
+        environment: &str,
+    ) -> Result<DeployOutcome> {
+        let deployment = self
+            .create_deployment(&prepared.agent.id, &prepared.version.id, environment)
+            .await?;
+        Ok(DeployOutcome {
+            agent: prepared.agent,
+            version: prepared.version,
+            bundle: prepared.bundle,
+            deployment,
+            channel: prepared.channel,
+            repo_note: prepared.repo_note,
+        })
+    }
+
     /// The full deploy flow: resolve agent (create or channel-reconcile),
     /// version, bundle, deployment.
     #[allow(clippy::too_many_arguments)] // one cohesive deploy call; a struct would not clarify it
@@ -951,30 +1012,18 @@ impl ApiClient {
         secrets: &std::collections::BTreeMap<String, String>,
         repo_full_name: Option<&str>,
     ) -> Result<DeployOutcome> {
-        let (agent, channel, repo_note) = self
-            .resolve_agent(agent_name, slack_channel, repo_full_name)
+        let prepared = self
+            .prepare_deploy(
+                agent_name,
+                slack_channel,
+                version_label,
+                created_by,
+                archive,
+                secrets,
+                repo_full_name,
+            )
             .await?;
-        // Bind per-agent connector secrets (ADR-0009, #429). A PATCH covers both
-        // a freshly created agent and a redeploy that rotates a value; an empty
-        // map leaves the agent's current secrets untouched.
-        if !secrets.is_empty() {
-            self.update_agent_secrets(&agent.id, secrets).await?;
-        }
-        let version = self
-            .create_version(&agent.id, version_label, created_by)
-            .await?;
-        let bundle = self.upload_bundle(&agent.id, &version.id, archive).await?;
-        let deployment = self
-            .create_deployment(&agent.id, &version.id, environment)
-            .await?;
-        Ok(DeployOutcome {
-            agent,
-            version,
-            bundle,
-            deployment,
-            channel,
-            repo_note,
-        })
+        self.activate_deploy(prepared, environment).await
     }
 
     /// Resolve an agent identifier (its `name`, or its `id`) to the full record

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -3485,7 +3485,32 @@ pub fn normalize_deploy_api_key(api_key: Option<String>) -> Option<String> {
     api_key.filter(|k| !k.trim().is_empty())
 }
 
-pub async fn deploy(opts: DeployOpts) -> Result<DeployOutput> {
+pub struct PreparedDeploy {
+    client: ApiClient,
+    outcome: crate::api::PreparedDeployOutcome,
+    plugin_name: String,
+    label: String,
+    env: String,
+    requested_repo: Option<String>,
+    connect_hint: String,
+    step: crate::ui::Step,
+}
+
+impl PreparedDeploy {
+    pub fn agent_id(&self) -> &str {
+        &self.outcome.agent.id
+    }
+
+    pub fn agent_name(&self) -> &str {
+        &self.outcome.agent.name
+    }
+
+    pub fn version_id(&self) -> &str {
+        &self.outcome.version.id
+    }
+}
+
+pub async fn prepare_deploy(opts: DeployOpts) -> Result<PreparedDeploy> {
     let plugin_dir = opts
         .plugin_dir
         .canonicalize()
@@ -3565,10 +3590,7 @@ pub async fn deploy(opts: DeployOpts) -> Result<DeployOutput> {
     // the sandbox (ADR-0009, #429). The value never appears in argv.
     let mut secrets: std::collections::BTreeMap<String, String> = std::collections::BTreeMap::new();
     for name in &opts.secret {
-        let value = std::env::var(name)
-            .ok()
-            .filter(|v| !v.is_empty())
-            .or(crate::secrets::get_value(name)?);
+        let value = crate::secrets::resolve_env_or_saved(name)?;
         match value {
             Some(v) => {
                 secrets.insert(name.clone(), v);
@@ -3601,28 +3623,62 @@ pub async fn deploy(opts: DeployOpts) -> Result<DeployOutput> {
     let cl = ui.checklist();
     let step = cl.step(&format!("deploying {plugin_name} as {agent_name}"));
     let outcome = match client
-        .deploy(
+        .prepare_deploy(
             &agent_name,
             opts.slack_channel
                 .as_deref()
                 .or_else(|| resolved.as_ref().and_then(|r| r.slack_channel.as_deref())),
             &label,
             &created_by,
-            env,
             archive,
             &secrets,
             opts.repo.as_deref(),
         )
         .await
     {
+        Ok(outcome) => outcome,
+        Err(err) => {
+            step.fail("failed");
+            if crate::exit::is_transient_reqwest(&err) {
+                return Err(crate::exit::operator_context(err, opts.connect_hint, None));
+            }
+            return Err(err);
+        }
+    };
+
+    Ok(PreparedDeploy {
+        client,
+        outcome,
+        plugin_name,
+        label,
+        env: env.to_string(),
+        requested_repo: opts.repo,
+        connect_hint: opts.connect_hint,
+        step,
+    })
+}
+
+pub async fn deploy_prepared(prepared: PreparedDeploy) -> Result<DeployOutput> {
+    let ui = crate::ui::ui();
+    let PreparedDeploy {
+        client,
+        outcome,
+        plugin_name,
+        label,
+        env,
+        requested_repo,
+        connect_hint,
+        step,
+    } = prepared;
+    let outcome = match client.activate_deploy(outcome, &env).await {
         Ok(outcome) => {
-            step.done(env);
+            step.done(&env);
             outcome
         }
         Err(err) => {
             step.fail("failed");
             if crate::exit::is_transient_reqwest(&err) {
-                return Err(crate::exit::operator_context(err, opts.connect_hint, None));
+                return Err(crate::exit::operator_context(err, connect_hint, None));
             }
             return Err(err);
         }
@@ -3638,8 +3694,7 @@ pub async fn deploy(opts: DeployOpts) -> Result<DeployOutput> {
     // which repository's pushes deploy this agent produced no output at all.
     // The value read here is the one the API stored, not the one asked for, so
     // a bind the platform dropped falls to the warning above instead (#1212).
-    let bound_repo = opts
-        .repo
+    let bound_repo = requested_repo
         .as_deref()
         .filter(|want| outcome.agent.repo_full_name.as_deref() == Some(*want));
     if let Some(repo) = bound_repo {
@@ -3662,7 +3717,7 @@ pub async fn deploy(opts: DeployOpts) -> Result<DeployOutput> {
     Ok(DeployOutput {
         plugin_name,
         label,
-        env: env.to_string(),
+        env,
         agent_name: outcome.agent.name,
         agent_id: outcome.agent.id,
         version_label: outcome.version.version_label,
@@ -3675,6 +3730,10 @@ pub async fn deploy(opts: DeployOpts) -> Result<DeployOutput> {
         deployment_environment: outcome.deployment.environment,
         deployment_status: outcome.deployment.status,
     })
+}
+
+pub async fn deploy(opts: DeployOpts) -> Result<DeployOutput> {
+    deploy_prepared(prepare_deploy(opts).await?).await
 }
 
 /// Output of `<tier> deploy`: the deployed agent/version/channel/bundle/deployment

--- a/cli/src/connectors.rs
+++ b/cli/src/connectors.rs
@@ -401,11 +401,7 @@ fn resolve_secret_values(keys: &[String]) -> Result<std::collections::BTreeMap<S
     let mut values = std::collections::BTreeMap::new();
     let mut missing = Vec::new();
     for k in keys {
-        match std::env::var(k)
-            .ok()
-            .filter(|v| !v.is_empty())
-            .or(crate::secrets::get_value(k)?)
-        {
+        match crate::secrets::resolve_env_or_saved(k)? {
             Some(v) => {
                 values.insert(k.clone(), v);
             }
@@ -422,49 +418,79 @@ fn resolve_secret_values(keys: &[String]) -> Result<std::collections::BTreeMap<S
     Ok(values)
 }
 
-/// Apply an agent's declared connectors, and prune what it no longer declares.
-///
-/// Called after the bundle is deployed, so the objects exist before the next
-/// turn reaches for them.
-pub async fn sync(
+/// An agent's fully resolved connector synchronization plan.
+pub struct PreparedConnectorSync {
+    namespace: String,
+    agent_name: String,
+    keep: Vec<String>,
+    apply_document: Option<String>,
+    result: ConnectorSync,
+}
+
+/// Resolve and render an agent's connector objects without writing to kubectl.
+pub fn prepare(
     manifests: &[Value],
     mcp_entries: &std::collections::BTreeMap<String, Value>,
     owned_secret_name: &str,
     owned_secret_keys: &[String],
     namespace: &str,
     agent_name: &str,
-) -> Result<ConnectorSync> {
-    let ui = crate::ui::ui();
+) -> Result<PreparedConnectorSync> {
     let mut objects = Vec::new();
 
     if let Some((secret_name, keys)) = owned_secret(owned_secret_name, owned_secret_keys) {
-        if !keys.is_empty() {
-            objects.push(render_secret(
-                &secret_name,
-                namespace,
-                &resolve_secret_values(&keys)?,
-            ));
-        }
+        objects.push(render_secret(
+            &secret_name,
+            namespace,
+            &resolve_secret_values(&keys)?,
+        ));
     }
     objects.extend_from_slice(manifests);
 
-    let mut sync = ConnectorSync::default();
+    let mut result = ConnectorSync::default();
     for (name, entry) in mcp_entries {
         if let Some(url) = entry.get("url").and_then(|u| u.as_str()) {
-            sync.urls.insert(name.clone(), url.to_string());
+            result.urls.insert(name.clone(), url.to_string());
         }
     }
 
     let labelled = label_objects(&objects, agent_name);
     let keep = object_names(&labelled);
+    let apply_document = if labelled.is_empty() {
+        None
+    } else {
+        Some(as_list_document(&labelled)?)
+    };
 
-    if !labelled.is_empty() {
-        let doc = as_list_document(&labelled)?;
-        let (ok, _out, err) = run(&apply_args(namespace), Some(&doc)).await?;
+    Ok(PreparedConnectorSync {
+        namespace: namespace.to_string(),
+        agent_name: agent_name.to_string(),
+        keep,
+        apply_document,
+        result,
+    })
+}
+
+/// Apply a prepared connector plan, and prune what it no longer declares.
+///
+/// Called after the bundle is deployed, so the objects exist before the next
+/// turn reaches for them.
+pub async fn sync(prepared: PreparedConnectorSync) -> Result<ConnectorSync> {
+    let ui = crate::ui::ui();
+    let PreparedConnectorSync {
+        namespace,
+        agent_name,
+        keep,
+        apply_document,
+        mut result,
+    } = prepared;
+
+    if let Some(doc) = apply_document {
+        let (ok, _out, err) = run(&apply_args(&namespace), Some(&doc)).await?;
         if !ok {
             anyhow::bail!("applying connectors failed: {}", err.trim());
         }
-        sync.applied = keep.clone();
+        result.applied = keep.clone();
         ui.note(&format!(
             "connectors: applied {} object(s) for {agent_name}",
             keep.len()
@@ -473,12 +499,12 @@ pub async fn sync(
 
     // Runs even with nothing declared -- that is the case where a connector was
     // REMOVED, and the whole reason this is not a bare `kubectl apply`.
-    let (ok, _out, err) = run(&prune_args(namespace, agent_name, &keep), None).await?;
+    let (ok, _out, err) = run(&prune_args(&namespace, &agent_name, &keep), None).await?;
     if !ok {
         ui.warn(&format!(
             "connectors: pruning stale objects for {agent_name} failed: {}",
             err.trim()
         ));
     }
-    Ok(sync)
+    Ok(result)
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -120,19 +120,61 @@ async fn sync_connectors(
     version_id: &str,
 ) -> anyhow::Result<()> {
     let app_name = curie::connectors::discover_app_name(namespace, release).await?;
+    let connector_version = ConnectorVersion {
+        agent_id,
+        agent_name,
+        version_id,
+    };
+    let prepared = prepare_connectors(
+        api_url,
+        api_key,
+        namespace,
+        release,
+        &app_name,
+        connector_version,
+    )
+    .await?;
+    apply_connectors(prepared).await
+}
+
+struct ConnectorVersion<'a> {
+    agent_id: &'a str,
+    agent_name: &'a str,
+    version_id: &'a str,
+}
+
+async fn prepare_connectors(
+    api_url: &str,
+    api_key: &str,
+    namespace: &str,
+    release: &str,
+    app_name: &str,
+    connector_version: ConnectorVersion<'_>,
+) -> anyhow::Result<curie::connectors::PreparedConnectorSync> {
     let client = curie::api::ApiClient::new(api_url, api_key)?;
     let rendered = client
-        .version_connectors(agent_id, version_id, release, namespace, &app_name)
+        .version_connectors(
+            connector_version.agent_id,
+            connector_version.version_id,
+            release,
+            namespace,
+            app_name,
+        )
         .await?;
-    let synced = curie::connectors::sync(
+    curie::connectors::prepare(
         &rendered.manifests,
         &rendered.mcp_entries,
         &rendered.owned_secret_name,
         &rendered.owned_secret_keys,
         namespace,
-        agent_name,
+        connector_version.agent_name,
     )
-    .await?;
+}
+
+async fn apply_connectors(
+    prepared: curie::connectors::PreparedConnectorSync,
+) -> anyhow::Result<()> {
+    let synced = curie::connectors::sync(prepared).await?;
     let ui = curie::ui::ui();
     for (name, url) in &synced.urls {
         ui.note(&format!("connector {name}: {url}"));
@@ -3134,13 +3176,122 @@ async fn run(command: Option<Command>) -> Result<()> {
                     vec![target]
                 };
 
-                // Single target deploy retains its existing output. All target
-                // deploy accumulates complete results in the API's declared order.
-                let mut last_deployed = None;
-                let mut completed = Vec::new();
-                for target in targets {
-                    let target_name = target.clone();
-                    let deployed = match commands::deploy(DeployOpts {
+                if all_targets {
+                    let first_target = targets
+                        .first()
+                        .cloned()
+                        .flatten()
+                        .expect("all target entries always have a target name");
+                    let app_name =
+                        match curie::connectors::discover_app_name(&namespace, &release).await {
+                            Ok(app_name) => app_name,
+                            Err(err) => {
+                                let payload = commands::all_targets_deploy_failure_json(
+                                    &first_target,
+                                    &[],
+                                    None,
+                                    &err,
+                                );
+                                return Err(curie::exit::with_json_payload(err, payload));
+                            }
+                        };
+
+                    // Resolve every target and every connector credential before
+                    // activating the first deployment. Preparation may create
+                    // agents and versions, but it does not POST a deployment.
+                    let mut prepared_targets = Vec::new();
+                    for target in targets {
+                        let target = target.expect("all target entries always have a target name");
+                        let prepared_deploy = match commands::prepare_deploy(DeployOpts {
+                            plugin_dir: plugin_dir.clone(),
+                            agent: agent.clone(),
+                            target: Some(target.clone()),
+                            api_url: api_url.clone(),
+                            api_key: api_key.clone(),
+                            slack_channel: slack_channel.clone(),
+                            repo: repo.clone(),
+                            env,
+                            label: label.clone(),
+                            secret: Vec::new(),
+                            secret_binding_supported: false,
+                            connect_hint: connect_hint.clone(),
+                        })
+                        .await
+                        {
+                            Ok(prepared) => prepared,
+                            Err(err) => {
+                                let payload = commands::all_targets_deploy_failure_json(
+                                    &target,
+                                    &[],
+                                    None,
+                                    &err,
+                                );
+                                return Err(curie::exit::with_json_payload(err, payload));
+                            }
+                        };
+                        let connector_version = ConnectorVersion {
+                            agent_id: prepared_deploy.agent_id(),
+                            agent_name: prepared_deploy.agent_name(),
+                            version_id: prepared_deploy.version_id(),
+                        };
+                        let prepared_connectors = match prepare_connectors(
+                            &api_url,
+                            &api_key,
+                            &namespace,
+                            &release,
+                            &app_name,
+                            connector_version,
+                        )
+                        .await
+                        {
+                            Ok(prepared) => prepared,
+                            Err(err) => {
+                                let payload = commands::all_targets_deploy_failure_json(
+                                    &target,
+                                    &[],
+                                    None,
+                                    &err,
+                                );
+                                return Err(curie::exit::with_json_payload(err, payload));
+                            }
+                        };
+                        prepared_targets.push((target, prepared_deploy, prepared_connectors));
+                    }
+
+                    // Activate and reconcile in the API's declared target order.
+                    let mut completed = Vec::new();
+                    for (target, prepared_deploy, prepared_connectors) in prepared_targets {
+                        let deployed = match commands::deploy_prepared(prepared_deploy).await {
+                            Ok(deployed) => deployed,
+                            Err(err) => {
+                                let payload = commands::all_targets_deploy_failure_json(
+                                    &target, &completed, None, &err,
+                                );
+                                return Err(curie::exit::with_json_payload(err, payload));
+                            }
+                        };
+
+                        if let Err(err) = apply_connectors(prepared_connectors).await {
+                            let payload = commands::all_targets_deploy_failure_json(
+                                &target,
+                                &completed,
+                                Some(&deployed),
+                                &err,
+                            );
+                            return Err(curie::exit::with_json_payload(err, payload));
+                        }
+                        completed.push(commands::AllTargetsDeployResult {
+                            target,
+                            result: deployed,
+                        });
+                    }
+                    emit(commands::AllTargetsDeployOutput { results: completed })
+                } else {
+                    let target = targets
+                        .into_iter()
+                        .next()
+                        .expect("the target list is never empty");
+                    let deployed = commands::deploy(DeployOpts {
                         plugin_dir: plugin_dir.clone(),
                         agent: agent.clone(),
                         target,
@@ -3160,23 +3311,7 @@ async fn run(command: Option<Command>) -> Result<()> {
                         secret_binding_supported: false,
                         connect_hint: connect_hint.clone(),
                     })
-                    .await
-                    {
-                        Ok(deployed) => deployed,
-                        Err(err) if all_targets => {
-                            let failed_target = target_name
-                                .as_deref()
-                                .expect("all target entries always have a target name");
-                            let payload = commands::all_targets_deploy_failure_json(
-                                failed_target,
-                                &completed,
-                                None,
-                                &err,
-                            );
-                            return Err(curie::exit::with_json_payload(err, payload));
-                        }
-                        Err(err) => return Err(err),
-                    };
+                    .await?;
 
                     // Stand up whatever the bundle's connectors.yaml declares
                     // (ADR-0086, #1063). After the deploy, so the objects exist
@@ -3184,7 +3319,7 @@ async fn run(command: Option<Command>) -> Result<()> {
                     // are the CONNECTOR's, resolved locally and written straight to
                     // a K8s Secret, which is a different path from the sandbox
                     // secret delivery #440 tracks.
-                    if let Err(err) = sync_connectors(
+                    sync_connectors(
                         &api_url,
                         &api_key,
                         &namespace,
@@ -3193,36 +3328,8 @@ async fn run(command: Option<Command>) -> Result<()> {
                         &deployed.agent_name,
                         &deployed.version_id,
                     )
-                    .await
-                    {
-                        if all_targets {
-                            let failed_target = target_name
-                                .as_deref()
-                                .expect("all target entries always have a target name");
-                            let payload = commands::all_targets_deploy_failure_json(
-                                failed_target,
-                                &completed,
-                                Some(&deployed),
-                                &err,
-                            );
-                            return Err(curie::exit::with_json_payload(err, payload));
-                        }
-                        return Err(err);
-                    }
-                    if all_targets {
-                        completed.push(commands::AllTargetsDeployResult {
-                            target: target_name
-                                .expect("all target entries always have a target name"),
-                            result: deployed,
-                        });
-                    } else {
-                        last_deployed = Some(deployed);
-                    }
-                }
-                if all_targets {
-                    emit(commands::AllTargetsDeployOutput { results: completed })
-                } else {
-                    emit(last_deployed.expect("the target list is never empty"))
+                    .await?;
+                    emit(deployed)
                 }
             }
             ClusterAction::Kill {

--- a/cli/src/secrets.rs
+++ b/cli/src/secrets.rs
@@ -113,6 +113,15 @@ pub fn get_value(name: &str) -> Result<Option<String>> {
     Ok(read_credentials()?.values.get(name).cloned())
 }
 
+pub(crate) fn resolve_env_or_saved(name: &str) -> Result<Option<String>> {
+    std::env::var(name)
+        .ok()
+        .filter(|value| !value.is_empty())
+        .map(Ok)
+        .or_else(|| get_value(name).transpose())
+        .transpose()
+}
+
 /// Check the non-secret index without opening any credential values.
 /// UI status rendering must use this instead of `get_value`.
 pub fn is_saved(name: &str) -> Result<bool> {

--- a/cli/tests/json_emit_contract.rs
+++ b/cli/tests/json_emit_contract.rs
@@ -1338,6 +1338,48 @@ enum DeployFixtureFailure {
     Deploy(&'static str),
 }
 
+#[derive(Clone, Copy)]
+enum ConnectorFixture {
+    Empty,
+    CredentialKeys,
+    Manifest,
+}
+
+#[derive(Clone, Copy)]
+enum KubectlFixtureFailure {
+    None,
+    Discovery,
+    Apply,
+}
+
+#[derive(Clone, Copy)]
+enum CredentialEnvironment {
+    Host,
+    BothWithoutHome,
+    DevOnlyWithEmptyVault,
+}
+
+#[derive(Clone, Copy)]
+struct ClusterDeployFixture {
+    all_targets: bool,
+    deploy_failure: DeployFixtureFailure,
+    connectors: ConnectorFixture,
+    kubectl_failure: KubectlFixtureFailure,
+    credentials: CredentialEnvironment,
+}
+
+impl Default for ClusterDeployFixture {
+    fn default() -> Self {
+        Self {
+            all_targets: true,
+            deploy_failure: DeployFixtureFailure::None,
+            connectors: ConnectorFixture::Empty,
+            kubectl_failure: KubectlFixtureFailure::None,
+            credentials: CredentialEnvironment::Host,
+        }
+    }
+}
+
 fn target_from_agent(agent: &str) -> &'static str {
     if agent.contains("prod") {
         "prod"
@@ -1358,7 +1400,11 @@ fn response_json(status: u16, value: serde_json::Value) -> Response {
     Response::json(status, &value.to_string())
 }
 
-fn deploy_api_response(req: &support::Request, failure: DeployFixtureFailure) -> Response {
+fn deploy_api_response(
+    req: &support::Request,
+    failure: DeployFixtureFailure,
+    connectors: ConnectorFixture,
+) -> Response {
     match (req.method.as_str(), req.path.as_str()) {
         ("POST", "/deploy-targets/list") => response_json(
             200,
@@ -1442,12 +1488,34 @@ fn deploy_api_response(req: &support::Request, failure: DeployFixtureFailure) ->
             )
         }
         ("GET", path) if path.contains("/versions/") && path.contains("/connectors?") => {
+            let target = target_from_agent(path);
+            let (manifests, owned_secret_name, owned_secret_keys) = match connectors {
+                ConnectorFixture::Empty => (Vec::new(), String::new(), Vec::new()),
+                ConnectorFixture::CredentialKeys => (
+                    Vec::new(),
+                    format!("acme-{target}-connector-credentials"),
+                    vec![format!("{}_TOKEN", target.to_ascii_uppercase())],
+                ),
+                ConnectorFixture::Manifest => (
+                    vec![json!({
+                        "apiVersion": "v1",
+                        "kind": "ConfigMap",
+                        "metadata": {
+                            "name": format!("acme-{target}-connector"),
+                            "namespace": "curie"
+                        },
+                        "data": {"target": target}
+                    })],
+                    String::new(),
+                    Vec::new(),
+                ),
+            };
             response_json(
                 200,
                 json!({
-                    "manifests": [],
-                    "owned_secret_name": "",
-                    "owned_secret_keys": [],
+                    "manifests": manifests,
+                    "owned_secret_name": owned_secret_name,
+                    "owned_secret_keys": owned_secret_keys,
                     "mcp_entries": {}
                 }),
             )
@@ -1466,11 +1534,19 @@ fn write_kubectl_stub(dir: &Path) -> PathBuf {
         r#"#!/bin/sh
 case "$*" in
   *"get deployment"*)
-    if [ "${CURIE_TEST_CONNECTOR_FAILURE:-}" = 1 ]; then
-      printf '%s\n' 'connector sync exploded' >&2
+    if [ "${CURIE_TEST_KUBECTL_FAILURE:-}" = discovery ]; then
+      printf '%s\n' 'app discovery exploded' >&2
       exit 1
     fi
     printf '%s' 'curie'
+    ;;
+  *"apply -f -"*)
+    cat >/dev/null
+    if [ "${CURIE_TEST_KUBECTL_FAILURE:-}" = apply ]; then
+      printf '%s\n' 'connector apply exploded' >&2
+      exit 1
+    fi
+    exit 0
     ;;
   *"delete deployment,service,networkpolicy,secret"*)
     exit 0
@@ -1499,11 +1575,7 @@ fn stub_path(bin_dir: &Path) -> std::ffi::OsString {
     std::env::join_paths(paths).expect("join stub PATH")
 }
 
-fn run_cluster_deploy_json(
-    all_targets: bool,
-    failure: DeployFixtureFailure,
-    connector_failure: bool,
-) -> Output {
+fn run_cluster_deploy_json(fixture: ClusterDeployFixture) -> (Output, Vec<support::Request>) {
     let plugin = tempfile::tempdir().expect("plugin tempdir");
     curie::scaffold::scaffold(plugin.path(), "acme-bundle").expect("scaffold test bundle");
     fs::write(
@@ -1514,7 +1586,10 @@ fn run_cluster_deploy_json(
 
     let tools = tempfile::tempdir().expect("tool tempdir");
     write_kubectl_stub(tools.path());
-    let server = serve(move |req| deploy_api_response(req, failure));
+    let deploy_failure = fixture.deploy_failure;
+    let connectors = fixture.connectors;
+    let server = serve(move |req| deploy_api_response(req, deploy_failure, connectors));
+    let empty_config_dir = tempfile::tempdir().expect("empty config tempdir");
 
     let mut command = Command::new(bin());
     command.args([
@@ -1533,7 +1608,7 @@ fn run_cluster_deploy_json(
         "--label",
         DEPLOY_LABEL,
     ]);
-    if all_targets {
+    if fixture.all_targets {
         command.arg("--all-targets");
     } else {
         command.args(["--target", "dev"]);
@@ -1542,13 +1617,44 @@ fn run_cluster_deploy_json(
         .arg("--json")
         .env("PATH", stub_path(tools.path()))
         .env_remove("CURIE_API_URL")
-        .env_remove("CURIE_API_KEY");
-    if connector_failure {
-        command.env("CURIE_TEST_CONNECTOR_FAILURE", "1");
-    } else {
-        command.env_remove("CURIE_TEST_CONNECTOR_FAILURE");
+        .env_remove("CURIE_API_KEY")
+        .env_remove("DEV_TOKEN")
+        .env_remove("PROD_TOKEN")
+        .env_remove("CURIE_TEST_KUBECTL_FAILURE");
+    match fixture.kubectl_failure {
+        KubectlFixtureFailure::None => {}
+        KubectlFixtureFailure::Discovery => {
+            command.env("CURIE_TEST_KUBECTL_FAILURE", "discovery");
+        }
+        KubectlFixtureFailure::Apply => {
+            command.env("CURIE_TEST_KUBECTL_FAILURE", "apply");
+        }
     }
-    command.output().expect("run cluster deploy JSON contract")
+    match fixture.credentials {
+        CredentialEnvironment::Host => {}
+        CredentialEnvironment::BothWithoutHome => {
+            command
+                .env("DEV_TOKEN", "dev-token-value")
+                .env("PROD_TOKEN", "prod-token-value")
+                .env_remove("HOME")
+                .env_remove("CURIE_CONFIG_DIR");
+        }
+        CredentialEnvironment::DevOnlyWithEmptyVault => {
+            command
+                .env("DEV_TOKEN", "dev-token-value")
+                .env_remove("PROD_TOKEN")
+                .env("CURIE_CONFIG_DIR", empty_config_dir.path());
+        }
+    }
+    let output = command.output().expect("run cluster deploy JSON contract");
+    (output, server.recorded())
+}
+
+fn deployment_request_count(requests: &[support::Request]) -> usize {
+    requests
+        .iter()
+        .filter(|request| request.method == "POST" && request.path == "/deployments")
+        .count()
 }
 
 fn one_stdout_object(output: &Output) -> serde_json::Value {
@@ -1620,7 +1726,7 @@ fn assert_failure_keys(value: &serde_json::Value, includes_failed_result: bool) 
 
 #[test]
 fn cluster_deploy_json_all_targets_emits_one_ordered_complete_object() {
-    let output = run_cluster_deploy_json(true, DeployFixtureFailure::None, false);
+    let (output, _) = run_cluster_deploy_json(ClusterDeployFixture::default());
     assert_eq!(
         output.status.code(),
         Some(0),
@@ -1640,7 +1746,10 @@ fn cluster_deploy_json_all_targets_emits_one_ordered_complete_object() {
 
 #[test]
 fn cluster_deploy_json_later_failure_names_target_and_completed_results() {
-    let output = run_cluster_deploy_json(true, DeployFixtureFailure::Deploy("prod"), false);
+    let (output, _) = run_cluster_deploy_json(ClusterDeployFixture {
+        deploy_failure: DeployFixtureFailure::Deploy("prod"),
+        ..ClusterDeployFixture::default()
+    });
     assert_eq!(output.status.code(), Some(1));
     let value = one_stdout_object(&output);
     assert_failure_keys(&value, false);
@@ -1660,7 +1769,10 @@ fn cluster_deploy_json_later_failure_names_target_and_completed_results() {
 
 #[test]
 fn cluster_deploy_json_first_failure_has_empty_completed_results() {
-    let output = run_cluster_deploy_json(true, DeployFixtureFailure::Deploy("dev"), false);
+    let (output, _) = run_cluster_deploy_json(ClusterDeployFixture {
+        deploy_failure: DeployFixtureFailure::Deploy("dev"),
+        ..ClusterDeployFixture::default()
+    });
     assert_eq!(output.status.code(), Some(1));
     let value = one_stdout_object(&output);
     assert_failure_keys(&value, false);
@@ -1676,8 +1788,100 @@ fn cluster_deploy_json_first_failure_has_empty_completed_results() {
 }
 
 #[test]
-fn cluster_deploy_json_connector_sync_failure_carries_failed_result() {
-    let output = run_cluster_deploy_json(true, DeployFixtureFailure::None, true);
+fn cluster_deploy_json_all_targets_env_credentials_ignore_unset_home() {
+    let (output, requests) = run_cluster_deploy_json(ClusterDeployFixture {
+        connectors: ConnectorFixture::CredentialKeys,
+        credentials: CredentialEnvironment::BothWithoutHome,
+        ..ClusterDeployFixture::default()
+    });
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "environment supplied connector credentials must not read the host vault: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        one_stdout_object(&output),
+        json!({
+            "results": [
+                {"target": "dev", "result": expected_deploy("dev")},
+                {"target": "prod", "result": expected_deploy("prod")}
+            ]
+        })
+    );
+    assert_eq!(
+        deployment_request_count(&requests),
+        2,
+        "both targets must activate after credential preparation succeeds"
+    );
+}
+
+#[test]
+fn cluster_deploy_json_later_connector_credential_failure_deploys_zero_targets() {
+    let (output, requests) = run_cluster_deploy_json(ClusterDeployFixture {
+        connectors: ConnectorFixture::CredentialKeys,
+        credentials: CredentialEnvironment::DevOnlyWithEmptyVault,
+        ..ClusterDeployFixture::default()
+    });
+    assert_eq!(output.status.code(), Some(2));
+    let value = one_stdout_object(&output);
+    assert_failure_keys(&value, false);
+    assert_eq!(value["failed_target"], json!("prod"));
+    assert_eq!(value["stage"], json!("deploy"));
+    assert_eq!(value["completed"], json!([]));
+    assert!(
+        value["error"]
+            .as_str()
+            .is_some_and(|error| error.contains("PROD_TOKEN")),
+        "failure must name the missing prod connector credential: {value}"
+    );
+    assert_eq!(
+        deployment_request_count(&requests),
+        0,
+        "all connector credentials must resolve before the first deployment"
+    );
+}
+
+#[test]
+fn cluster_deploy_json_app_discovery_failure_is_precondition_with_zero_deployments() {
+    let (output, requests) = run_cluster_deploy_json(ClusterDeployFixture {
+        kubectl_failure: KubectlFixtureFailure::Discovery,
+        ..ClusterDeployFixture::default()
+    });
+    assert_eq!(output.status.code(), Some(1));
+    let value = one_stdout_object(&output);
+    assert_failure_keys(&value, false);
+    assert_eq!(value["failed_target"], json!("dev"));
+    assert_eq!(value["stage"], json!("deploy"));
+    assert_eq!(value["completed"], json!([]));
+    assert!(
+        value["error"]
+            .as_str()
+            .is_some_and(|error| error.contains("app discovery exploded")),
+        "failure must retain the app discovery error: {value}"
+    );
+    assert_eq!(
+        deployment_request_count(&requests),
+        0,
+        "app discovery must complete before the first deployment"
+    );
+    let schema: serde_json::Value =
+        serde_json::from_str(include_str!("../schema/deploy.schema.json"))
+            .expect("deploy schema is valid JSON");
+    let validator = jsonschema::validator_for(&schema).expect("deploy schema compiles");
+    assert!(
+        validator.is_valid(&value),
+        "app discovery precondition failure must retain the deploy schema: {value}"
+    );
+}
+
+#[test]
+fn cluster_deploy_json_connector_apply_failure_carries_failed_result_after_activation() {
+    let (output, requests) = run_cluster_deploy_json(ClusterDeployFixture {
+        connectors: ConnectorFixture::Manifest,
+        kubectl_failure: KubectlFixtureFailure::Apply,
+        ..ClusterDeployFixture::default()
+    });
     assert_eq!(output.status.code(), Some(1));
     let value = one_stdout_object(&output);
     assert_failure_keys(&value, true);
@@ -1688,14 +1892,22 @@ fn cluster_deploy_json_connector_sync_failure_carries_failed_result() {
     assert!(
         value["error"]
             .as_str()
-            .is_some_and(|error| error.contains("connector sync exploded")),
-        "failure must retain the connector error: {value}"
+            .is_some_and(|error| error.contains("connector apply exploded")),
+        "failure must retain the connector apply error: {value}"
+    );
+    assert_eq!(
+        deployment_request_count(&requests),
+        1,
+        "connector apply must fail after the dev target activates"
     );
 }
 
 #[test]
 fn cluster_deploy_json_single_target_shape_is_unchanged() {
-    let output = run_cluster_deploy_json(false, DeployFixtureFailure::None, false);
+    let (output, _) = run_cluster_deploy_json(ClusterDeployFixture {
+        all_targets: false,
+        ..ClusterDeployFixture::default()
+    });
     assert_eq!(
         output.status.code(),
         Some(0),


### PR DESCRIPTION
Closes #1761\n\nConnector credentials now resolve from a nonempty environment value without consulting host storage.\n\nAll target deploys prepare every target and every connector credential before creating any deployment. Single target behavior and structured partial failure context remain unchanged.\n\n[x] Failing regressions were committed before implementation, and all three mutation pins report PINNED.\n[x] Production edits used separate test and implementation contexts.\n[x] No existing public return type was broadened.\n[x] Code review approved the final diff.\n[x] Scope review approved every changed hunk.\n[x] Sibling secret resolution now shares one helper.\n[x] Guard demonstrations passed for environment resolution and zero deployment preconditions.\n[x] Consolidation found no further simplification.\n[x] Security review was not applicable because authorization and credential exposure boundaries did not change.\n[x] Observable compiled CLI verification passed for HOME unset and for a missing later target credential.\n[x] The deployed ladder is not applicable to the changed contract because command output, exit codes, JSON shape, charts, RBAC, and runtime deployment infrastructure are unchanged. An extra local ladder attempt encountered preexisting duplicate active deployments and cleaned up its stack.\n[x] Formatting, locked clippy with warnings denied, focused regressions, and the full locked Rust suite passed.