### PR TITLE
Add released database upgrade gate

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
+          fetch-depth: 0
           persist-credentials: false
       # Retry eligibility (#1106): only a step whose whole job is to ACQUIRE a
       # third-party dependency (a tool binary, an image, a registry session, a
@@ -111,6 +112,10 @@ jobs:
             sleep 3
           done
           echo "Langfuse did not become ready within 180s"; exit 1
+      - name: Released database upgrade gate
+        run: |
+          uv run python scripts/check-released-upgrade.py --self-test
+          uv run python scripts/check-released-upgrade.py
       # The apps/api suite provisions a throwaway migrated DB per run, but the
       # worker binding integration tests dial the shared default database and
       # assume the curie schema already exists (as it does on a dev box).
@@ -122,9 +127,9 @@ jobs:
       # The committed-lock test only proves the lock matches the current wire; it
       # passes even if the lock was regenerated without a version bump. Compare
       # against the BASE branch's lock so an unbumped wire change actually fails
-      # CI. The shallow checkout has no base ref, so fetch it depth=1; a missing
-      # or empty base lock (base predates the lock) skips cleanly (exit 0), and
-      # only a genuine unbumped wire change vs an existing base lock exits 1.
+      # CI. Refresh that remote ref before reading it; a missing or empty base
+      # lock (base predates the lock) skips cleanly (exit 0), and only a genuine
+      # unbumped wire change vs an existing base lock exits 1.
       - name: ACI wire-lock base gate
         run: |
           git fetch --no-tags --depth=1 origin "${{ github.base_ref || 'main' }}" || true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,9 @@ Set `base=next` when your worktree targets `next`.
     sleep 3
   done
   curl -fsS http://localhost:23000/api/public/health >/dev/null
+git fetch --force --tags origin refs/heads/main:refs/remotes/origin/main
+  uv run python scripts/check-released-upgrade.py --self-test
+  uv run python scripts/check-released-upgrade.py
   (cd apps/api && uv run alembic upgrade head)
   git fetch --no-tags --depth=1 origin "$base" || true
   git show "origin/$base:packages/aci-protocol/schema/wire.lock" > "$wire_lock" 2>/dev/null || true

--- a/apps/api/tests/test_alembic_revision_gate.py
+++ b/apps/api/tests/test_alembic_revision_gate.py
@@ -71,6 +71,78 @@ def test_duplicate_numeric_filename_prefix_fails_before_graph_validation(
     assert "0001_collision.py" in result.stderr
 
 
+def test_unrecognized_migration_filename_fails_before_graph_validation(
+    tmp_path: Path,
+) -> None:
+    _write_revision(tmp_path, "custom_base.py", "self_cycle", "self_cycle")
+
+    result = _run_gate(tmp_path)
+
+    assert result.returncode == 1, result.stderr
+    assert "unrecognized migration filename" in result.stderr.lower()
+    assert "custom_base.py" in result.stderr
+    assert "expected exactly one alembic head" not in result.stderr.lower()
+
+
+def test_non_migration_files_are_ignored_when_valid_migration_passes(
+    tmp_path: Path,
+) -> None:
+    _write_revision(tmp_path, "0001_base.py", "base", None)
+    versions = tmp_path / "versions"
+    (versions / "__init__.py").write_text("", encoding="utf-8")
+    (versions / "migration-notes.txt").write_text("notes", encoding="utf-8")
+
+    result = _run_gate(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    assert "base" in result.stdout
+
+
+def test_one_letter_suffixed_revision_in_valid_chain_passes(tmp_path: Path) -> None:
+    _write_revision(tmp_path, "0001_base.py", "base", None)
+    _write_revision(tmp_path, "0001a_reconcile.py", "reconciled", "base")
+
+    result = _run_gate(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    assert "reconciled" in result.stdout
+
+
+def test_duplicate_identical_suffixed_revision_tokens_fail(tmp_path: Path) -> None:
+    _write_revision(tmp_path, "0001_base.py", "base", None)
+    _write_revision(tmp_path, "0001a_first.py", "first", "base")
+    _write_revision(tmp_path, "0001a_second.py", "second", "base")
+
+    result = _run_gate(tmp_path)
+
+    assert result.returncode == 1, result.stderr
+    assert "duplicate numeric revision" in result.stderr.lower()
+    assert "0001a" in result.stderr
+    assert "0001a_first.py" in result.stderr
+    assert "0001a_second.py" in result.stderr
+
+
+def test_different_suffixed_revision_tokens_are_distinct(tmp_path: Path) -> None:
+    _write_revision(tmp_path, "0001_base.py", "base", None)
+    _write_revision(tmp_path, "0001a_reconcile.py", "reconciled", "base")
+    _write_revision(tmp_path, "0001b_followup.py", "followup", "reconciled")
+
+    result = _run_gate(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    assert "followup" in result.stdout
+
+
+def test_multi_letter_suffixed_revision_filename_is_rejected(tmp_path: Path) -> None:
+    _write_revision(tmp_path, "0001ab_bad.py", "bad", None)
+
+    result = _run_gate(tmp_path)
+
+    assert result.returncode == 1, result.stderr
+    assert "unrecognized migration filename" in result.stderr.lower()
+    assert "0001ab_bad.py" in result.stderr
+
+
 def test_unique_numbered_sibling_revisions_fail_with_both_heads(tmp_path: Path) -> None:
     _write_revision(tmp_path, "0001_base.py", "base", None)
     _write_revision(tmp_path, "0002_left.py", "left_branch", "base")
@@ -114,3 +186,57 @@ def test_python_ci_job_runs_exact_gate_before_dev_stack() -> None:
         index for index, step in enumerate(steps) if step.get("name") == "Start dev stack"
     )
     assert gate_index < stack_index
+
+
+def test_python_ci_runs_released_upgrade_after_stack_ready_and_before_fresh_install(
+) -> None:
+    workflow = yaml.safe_load((REPO_ROOT / ".github/workflows/ci.yaml").read_text())
+    steps = workflow["jobs"]["python"]["steps"]
+
+    checkout_steps = [
+        step for step in steps if step.get("uses") == "actions/checkout@v7"
+    ]
+    assert len(checkout_steps) == 1
+    assert checkout_steps[0]["with"]["fetch-depth"] == 0
+
+    released_upgrade_steps = [
+        step for step in steps if step.get("name") == "Released database upgrade gate"
+    ]
+    assert len(released_upgrade_steps) == 1
+    released_upgrade_step = released_upgrade_steps[0]
+    released_upgrade_commands = [
+        line.strip()
+        for line in released_upgrade_step["run"].splitlines()
+        if line.strip().startswith("uv run python scripts/check-released-upgrade.py")
+    ]
+    assert released_upgrade_commands == [
+        "uv run python scripts/check-released-upgrade.py --self-test",
+        "uv run python scripts/check-released-upgrade.py",
+    ]
+
+    stack_index = next(
+        index for index, step in enumerate(steps) if step.get("name") == "Start dev stack"
+    )
+    readiness_index = next(
+        index
+        for index, step in enumerate(steps)
+        if step.get("name") == "Wait for Langfuse to serve"
+    )
+    released_upgrade_index = steps.index(released_upgrade_step)
+    fresh_install_steps = [
+        step for step in steps if step.get("name") == "Migrate the shared database"
+    ]
+    assert len(fresh_install_steps) == 1
+    assert fresh_install_steps[0]["run"] == "uv run alembic upgrade head"
+    fresh_install_index = steps.index(fresh_install_steps[0])
+
+    assert stack_index < readiness_index < released_upgrade_index < fresh_install_index
+
+
+def test_baseline_main_fetch_uses_a_fully_qualified_refspec() -> None:
+    instructions = (REPO_ROOT / "AGENTS.md").read_text(encoding="utf-8")
+    safe_command = "git fetch --force --tags origin refs/heads/main:refs/remotes/origin/main"
+    unsafe_command = "git fetch --force --tags origin main:refs/remotes/origin/main"
+
+    assert safe_command in instructions
+    assert unsafe_command not in instructions

--- a/scripts/check-alembic-revisions.py
+++ b/scripts/check-alembic-revisions.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from alembic.script import ScriptDirectory
 
-FILENAME_PATTERN = re.compile(r"^(\d+)_.*\.py$")
+FILENAME_PATTERN = re.compile(r"^(\d+[a-z]?)_.+\.py$")
 DEFAULT_SCRIPT_LOCATION = (
     Path(__file__).resolve().parents[1] / "apps" / "api" / "alembic"
 )
@@ -42,14 +42,21 @@ def main() -> int:
         )
         return 1
 
-    filenames_by_number: dict[str, list[str]] = defaultdict(list)
+    filenames_by_token: dict[str, list[str]] = defaultdict(list)
+    unrecognized_filenames: list[str] = []
     try:
         for path in versions.iterdir():
-            if not path.is_file():
+            if (
+                not path.is_file()
+                or path.suffix != ".py"
+                or path.name == "__init__.py"
+            ):
                 continue
             match = FILENAME_PATTERN.fullmatch(path.name)
-            if match is not None:
-                filenames_by_number[match.group(1)].append(path.name)
+            if match is None:
+                unrecognized_filenames.append(path.name)
+                continue
+            filenames_by_token[match.group(1)].append(path.name)
     except OSError as exc:
         print(
             f"Alembic revision gate failed: could not scan versions directory "
@@ -58,24 +65,39 @@ def main() -> int:
         )
         return 1
 
+    if unrecognized_filenames:
+        print(
+            "Alembic revision gate failed: unrecognized migration filenames "
+            "found:",
+            file=sys.stderr,
+        )
+        for filename in sorted(unrecognized_filenames):
+            print(f"  {filename}", file=sys.stderr)
+        print(
+            "Name every migration <digits><optional lowercase letter>_"
+            "<description>.py.",
+            file=sys.stderr,
+        )
+        return 1
+
     duplicates = {
-        number: sorted(filenames)
-        for number, filenames in filenames_by_number.items()
+        token: sorted(filenames)
+        for token, filenames in filenames_by_token.items()
         if len(filenames) > 1
     }
     if duplicates:
         print(
-            "Alembic revision gate failed: duplicate numeric revision "
-            "filename tokens found:",
+            "Alembic revision gate failed: duplicate numeric revision or "
+            "suffixed revision filename tokens found:",
             file=sys.stderr,
         )
-        for number in sorted(duplicates):
+        for token in sorted(duplicates):
             print(
-                f"  {number}: {', '.join(duplicates[number])}",
+                f"  {token}: {', '.join(duplicates[token])}",
                 file=sys.stderr,
             )
         print(
-            "Rename migrations so every leading numeric token is unique.",
+            "Rename migrations so every leading revision token is unique.",
             file=sys.stderr,
         )
         return 1

--- a/scripts/check-released-upgrade.py
+++ b/scripts/check-released-upgrade.py
@@ -1,0 +1,473 @@
+"""Verify that the candidate migrations upgrade the latest released database."""
+
+import argparse
+import os
+import re
+import secrets
+import signal
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from types import FrameType
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+COMPOSE_FILE = REPO_ROOT / "compose.dev.yaml"
+STABLE_TAG_PATTERN = re.compile(r"^v(\d+)\.(\d+)\.(\d+)$")
+COMMIT_PATTERN = re.compile(r"^[0-9a-f]+$")
+SELF_TEST_RELEASED_REF = "v0.6.2"
+SELF_TEST_CANDIDATE_REF = "v0.7.0-rc.1"
+
+
+class GateError(RuntimeError):
+    """A released upgrade gate setup or cleanup failure."""
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    returncode: int
+    output: str
+
+
+@dataclass(frozen=True)
+class PairResult:
+    phase: str
+    returncode: int
+    output: str
+
+
+def _run(command: list[str], *, cwd: Path = REPO_ROOT) -> CommandResult:
+    try:
+        completed = subprocess.run(
+            command,
+            cwd=cwd,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+    except OSError as exc:
+        raise GateError(f"could not run {command[0]}: {exc}") from exc
+    return CommandResult(completed.returncode, completed.stdout or "")
+
+
+def _checked_output(
+    command: list[str],
+    *,
+    description: str,
+    cwd: Path = REPO_ROOT,
+) -> str:
+    result = _run(command, cwd=cwd)
+    if result.returncode != 0:
+        if result.output:
+            print(result.output, end="" if result.output.endswith("\n") else "\n")
+        raise GateError(f"{description} failed with exit code {result.returncode}")
+    return result.output
+
+
+def _resolve_ref(ref: str) -> str:
+    commit = _checked_output(
+        ["git", "rev-parse", "--verify", "--end-of-options", f"{ref}^{{commit}}"],
+        description=f"resolving Git ref {ref}",
+    ).strip()
+    if not COMMIT_PATTERN.fullmatch(commit):
+        raise GateError(f"Git ref {ref} resolved to an invalid commit: {commit!r}")
+    return commit
+
+
+def _latest_released_tag() -> tuple[str, str]:
+    main_commit = _resolve_ref("origin/main")
+    tag_output = _checked_output(
+        ["git", "tag", "--merged", main_commit, "--list"],
+        description="listing stable tags reachable from origin/main",
+    )
+    stable_tags: list[tuple[tuple[int, int, int], str]] = []
+    for tag in tag_output.splitlines():
+        match = STABLE_TAG_PATTERN.fullmatch(tag)
+        if match is None:
+            continue
+        version = (int(match.group(1)), int(match.group(2)), int(match.group(3)))
+        stable_tags.append((version, tag))
+    if not stable_tags:
+        raise GateError("no stable vX.Y.Z release tag is reachable from origin/main")
+    _, latest_tag = max(stable_tags)
+    return latest_tag, _resolve_ref(latest_tag)
+
+
+def _compose_command(*arguments: str) -> list[str]:
+    return ["docker", "compose", "-f", str(COMPOSE_FILE), *arguments]
+
+
+def _check_postgres() -> None:
+    _checked_output(
+        ["docker", "compose", "version"],
+        description="checking Docker Compose availability",
+    )
+    _checked_output(
+        _compose_command(
+            "exec",
+            "-T",
+            "postgres",
+            "pg_isready",
+            "-U",
+            "postgres",
+            "-d",
+            "postgres",
+        ),
+        description="checking the compose Postgres service",
+    )
+
+
+def _database_command(sql: str) -> list[str]:
+    return _compose_command(
+        "exec",
+        "-T",
+        "postgres",
+        "psql",
+        "-U",
+        "postgres",
+        "-d",
+        "postgres",
+        "-v",
+        "ON_ERROR_STOP=1",
+        "-c",
+        sql,
+    )
+
+
+def _reset_database(database_name: str) -> None:
+    _checked_output(
+        _database_command(f'DROP DATABASE IF EXISTS "{database_name}" WITH (FORCE)'),
+        description=f"dropping stale scratch database {database_name}",
+    )
+    _checked_output(
+        _database_command(f'CREATE DATABASE "{database_name}"'),
+        description=f"creating scratch database {database_name}",
+    )
+
+
+def _add_worktree(path: Path, commit: str, *, label: str) -> None:
+    _checked_output(
+        ["git", "worktree", "add", "--detach", str(path), commit],
+        description=f"creating detached {label} worktree",
+    )
+
+
+def _alembic_command(tree: Path, *arguments: str) -> list[str]:
+    return [
+        "uv",
+        "run",
+        "--frozen",
+        "--project",
+        str(tree),
+        "--directory",
+        str(tree / "apps" / "api"),
+        "alembic",
+        *arguments,
+    ]
+
+
+def _run_alembic(
+    tree: Path,
+    *,
+    database_url: str,
+    phase: str,
+    ref: str,
+    commit: str,
+    arguments: tuple[str, ...],
+) -> CommandResult:
+    print(f"=== {phase}: {ref} ({commit}) ===", flush=True)
+    environment = os.environ.copy()
+    environment["DATABASE_URL"] = database_url
+    try:
+        completed = subprocess.run(
+            _alembic_command(tree, *arguments),
+            cwd=REPO_ROOT,
+            env=environment,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+    except OSError as exc:
+        raise GateError(f"could not run {phase}: {exc}") from exc
+    output = completed.stdout or ""
+    if output:
+        print(output, end="" if output.endswith("\n") else "\n")
+    return CommandResult(completed.returncode, output)
+
+
+def _upgrade_pair(
+    released_tree: Path,
+    candidate_tree: Path,
+    *,
+    database_url: str,
+    released_ref: str,
+    released_commit: str,
+    candidate_ref: str,
+    candidate_commit: str,
+) -> PairResult:
+    phases = (
+        (
+            "released upgrade",
+            released_tree,
+            released_ref,
+            released_commit,
+            ("upgrade", "head"),
+        ),
+        (
+            "released head check",
+            released_tree,
+            released_ref,
+            released_commit,
+            ("current", "--check-heads"),
+        ),
+        (
+            "candidate upgrade",
+            candidate_tree,
+            candidate_ref,
+            candidate_commit,
+            ("upgrade", "head"),
+        ),
+        (
+            "candidate head check",
+            candidate_tree,
+            candidate_ref,
+            candidate_commit,
+            ("current", "--check-heads"),
+        ),
+    )
+    for phase, tree, ref, commit, arguments in phases:
+        result = _run_alembic(
+            tree,
+            database_url=database_url,
+            phase=phase,
+            ref=ref,
+            commit=commit,
+            arguments=arguments,
+        )
+        if result.returncode != 0:
+            return PairResult(phase, result.returncode, result.output)
+    return PairResult("candidate head check", 0, "")
+
+
+def _cleanup(
+    worktrees: list[Path],
+    *,
+    database_name: str,
+    database_touched: bool,
+) -> None:
+    errors: list[str] = []
+    for worktree in reversed(worktrees):
+        try:
+            result = _run(
+                ["git", "worktree", "remove", "--force", str(worktree)]
+            )
+        except GateError as exc:
+            errors.append(str(exc))
+        else:
+            if result.returncode != 0:
+                errors.append(
+                    f"removing scratch worktree {worktree} failed: "
+                    f"{result.output.strip()}"
+                )
+    if database_touched:
+        try:
+            result = _run(
+                _database_command(
+                    f'DROP DATABASE IF EXISTS "{database_name}" WITH (FORCE)'
+                )
+            )
+        except GateError as exc:
+            errors.append(str(exc))
+        else:
+            if result.returncode != 0:
+                errors.append(
+                    f"dropping scratch database {database_name} failed: "
+                    f"{result.output.strip()}"
+                )
+    if errors:
+        rendered = "\n".join(f"  {error}" for error in errors)
+        raise GateError(f"scratch cleanup failed:\n{rendered}")
+
+
+def _run_pair(
+    *,
+    released_ref: str,
+    released_commit: str,
+    candidate_ref: str,
+    candidate_commit: str,
+    current_candidate: bool,
+) -> PairResult:
+    _check_postgres()
+    database_name = f"curie_upgrade_{os.getpid()}_{secrets.token_hex(4)}"
+    database_url = (
+        "postgresql+asyncpg://postgres:postgres@localhost:25432/"
+        f"{database_name}"
+    )
+    worktrees: list[Path] = []
+    database_touched = False
+    with tempfile.TemporaryDirectory(prefix="curie-released-upgrade-") as temp_dir:
+        temp_root = Path(temp_dir)
+        try:
+            database_touched = True
+            _reset_database(database_name)
+
+            released_tree = temp_root / "released"
+            _add_worktree(released_tree, released_commit, label="released")
+            worktrees.append(released_tree)
+
+            if current_candidate:
+                candidate_tree = REPO_ROOT
+            else:
+                candidate_tree = temp_root / "candidate"
+                _add_worktree(candidate_tree, candidate_commit, label="candidate")
+                worktrees.append(candidate_tree)
+
+            return _upgrade_pair(
+                released_tree,
+                candidate_tree,
+                database_url=database_url,
+                released_ref=released_ref,
+                released_commit=released_commit,
+                candidate_ref=candidate_ref,
+                candidate_commit=candidate_commit,
+            )
+        finally:
+            _cleanup(
+                worktrees,
+                database_name=database_name,
+                database_touched=database_touched,
+            )
+
+
+def _run_self_test() -> int:
+    released_commit = _resolve_ref(SELF_TEST_RELEASED_REF)
+    candidate_commit = _resolve_ref(SELF_TEST_CANDIDATE_REF)
+    result = _run_pair(
+        released_ref=SELF_TEST_RELEASED_REF,
+        released_commit=released_commit,
+        candidate_ref=SELF_TEST_CANDIDATE_REF,
+        candidate_commit=candidate_commit,
+        current_candidate=False,
+    )
+    if result.returncode == 0:
+        raise GateError("self test pair unexpectedly upgraded successfully")
+    if result.phase != "candidate upgrade":
+        raise GateError(
+            f"self test failed during {result.phase}, before the expected "
+            "candidate collision"
+        )
+    expected_markers = (
+        "asyncpg.exceptions.UndefinedTableError",
+        'relation "curie.agent_channels" does not exist',
+        "0022_approvals_reply_kind.py",
+    )
+    missing_markers = [
+        marker for marker in expected_markers if marker not in result.output
+    ]
+    if missing_markers:
+        raise GateError(
+            "self test candidate failure did not report the known revision "
+            f"collision markers: {', '.join(missing_markers)}"
+        )
+    print(
+        "Released upgrade self test passed by observing the known candidate "
+        "revision collision."
+    )
+    return 0
+
+
+def _run_requested_pair(released_ref: str, candidate_ref: str) -> int:
+    released_commit = _resolve_ref(released_ref)
+    candidate_commit = _resolve_ref(candidate_ref)
+    result = _run_pair(
+        released_ref=released_ref,
+        released_commit=released_commit,
+        candidate_ref=candidate_ref,
+        candidate_commit=candidate_commit,
+        current_candidate=False,
+    )
+    if result.returncode != 0:
+        print(
+            f"Released upgrade gate failed during {result.phase} with exit "
+            f"code {result.returncode}.",
+            file=sys.stderr,
+        )
+    return result.returncode
+
+
+def _run_normal() -> int:
+    released_ref, released_commit = _latest_released_tag()
+    candidate_commit = _resolve_ref("HEAD")
+    print(
+        f"Selected latest stable release {released_ref} ({released_commit}) "
+        "reachable from origin/main."
+    )
+    result = _run_pair(
+        released_ref=released_ref,
+        released_commit=released_commit,
+        candidate_ref="HEAD",
+        candidate_commit=candidate_commit,
+        current_candidate=True,
+    )
+    if result.returncode != 0:
+        print(
+            f"Released upgrade gate failed during {result.phase} with exit "
+            f"code {result.returncode}.",
+            file=sys.stderr,
+        )
+        return result.returncode
+    print(
+        f"Released upgrade gate passed from {released_ref} to candidate "
+        f"{candidate_commit}."
+    )
+    return 0
+
+
+def _raise_interrupted(_signum: int, _frame: FrameType | None) -> None:
+    raise KeyboardInterrupt
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Upgrade a released Curie database with candidate migrations."
+    )
+    parser.add_argument(
+        "--released-ref",
+        help="Released Git ref for an explicit upgrade pair.",
+    )
+    parser.add_argument(
+        "--candidate-ref",
+        help="Candidate Git ref for an explicit upgrade pair.",
+    )
+    parser.add_argument(
+        "--self-test",
+        action="store_true",
+        help="Require the known v0.6.2 to v0.7.0-rc.1 collision.",
+    )
+    args = parser.parse_args()
+
+    if args.self_test and (args.released_ref or args.candidate_ref):
+        parser.error("--self-test cannot be combined with explicit refs")
+    if bool(args.released_ref) != bool(args.candidate_ref):
+        parser.error("--released-ref and --candidate-ref must be provided together")
+
+    signal.signal(signal.SIGTERM, _raise_interrupted)
+    try:
+        if args.self_test:
+            return _run_self_test()
+        if args.released_ref and args.candidate_ref:
+            return _run_requested_pair(args.released_ref, args.candidate_ref)
+        return _run_normal()
+    except KeyboardInterrupt:
+        print("Released upgrade gate interrupted after cleanup.", file=sys.stderr)
+        return 130
+    except GateError as exc:
+        print(f"Released upgrade gate failed: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #1706

Adds a required Python CI gate that creates a scratch database at the latest stable release reachable from origin/main, upgrades that same database with the candidate tree, and preserves the existing fresh install migration. The historical v0.6.2 to v0.7.0 rc collision is exercised as a falsifiable negative. Unrecognized Python migration filenames now fail before graph validation.

Done check

* [x] Failing tests were committed before implementation and then squashed into the final commit
* [x] All code and test edits were delegated to separate fresh contexts
* [x] Blocking correctness review approved the exact collision oracle and checker behavior
* [x] Blocking scope review mapped every hunk to the acceptance criteria or mechanical CI needs
* [x] The CI and local baseline paths both run the same released upgrade harness while preserving the fresh migration
* [x] Guard demonstrations passed for malformed filenames and the known bad cross line pair
* [x] Consolidation found no material simplification
* [x] Security review is not applicable because auth, permissions, secrets, and data boundaries are unchanged
* [x] Real Postgres evidence reached 0027 at the released and candidate heads on the same database
* [x] Full Python validation passed with 3460 tests and 11 skips
* [x] Both fix pin mutations reported PINNED

The optional local parity ladder is not acceptance evidence for this migration gate. Its default project was blocked by stale shared deployments, and its isolated project probe hardcodes the default compose label. The exact database runtime path and complete Python baseline both passed.