### PR TITLE
ADR-0117: a tool that changes the world reports what it changed, and the platform can put it back

### DIFF
--- a/docs/adr/0117-a-tool-that-changes-the-world-reports-what-it-changed.md
+++ b/docs/adr/0117-a-tool-that-changes-the-world-reports-what-it-changed.md
@@ -1,0 +1,351 @@
+# 117. A tool that changes the world reports what it changed, and the platform can put it back
+
+Date: 2026-08-21
+
+Status: Accepted
+
+Issue: #1861
+
+Completes the pair [ADR-0010](0010-approval-gates-and-human-in-the-loop.md)
+opened. That decision answers a mutating action **before** it happens; this one
+answers it **after**. It changes no isolation boundary:
+[ADR-0006](0006-security-rails-as-chart-defaults.md)'s rails and
+[ADR-0008](0008-multi-tenancy.md)'s tenant compute stand as they are, and a
+sandbox reaches nothing new.
+
+## Context
+
+Curie already detects that a turn changed the world, and records one bit.
+
+[`runner/src/curie_runner/side_effects.py`](../../runner/src/curie_runner/side_effects.py)
+classifies every tool absent from a harness-declared read-only allowlist as
+side-effecting, deny-by-default, so an unknown tool is assumed to mutate. The
+runner emits a `side_effect_flag`, and the kernel reduces the whole stream to
+`saw_side_effect: bool`
+([`apps/worker/src/curie_worker/kernel.py`](../../apps/worker/src/curie_worker/kernel.py))
+for exactly one purpose: refusing to auto-retry a failed turn that already
+touched something (ADR-0013).
+
+That is the entire memory the platform keeps of an agent acting on production.
+Not which tool. Not with what arguments. Not against what resource. Not whether
+it worked. So when a bot changes something, the person who asked gets a sentence
+of prose from the model and no account from the platform, and there is nothing to
+act on afterwards.
+
+The gap is not that the information is hard to obtain. It is that the information
+is already in hand and is being discarded, in three separate places.
+
+- **The arguments.** The frame is built at
+  [`runner/src/curie_runner/translate.py::_translate_assistant`](../../runner/src/curie_runner/translate.py)
+  from the SDK's tool-use block, which carries the call's input. The frame is
+  built as `SideEffectFlag(tool=block.name, detail="non-idempotent tool
+  executed")`: the tool name kept, the arguments dropped, and `detail` filled
+  with a constant string.
+
+- **The result.** A tool result arrives as a `UserMessage`, and the v0.1 contract
+  drops that message whole, with the comment "carry no outbound-visible
+  content in the v0.1 contract; they are intentionally dropped."
+
+- **The prior state.** The example's own write connector reads the resource
+  before patching it and throws the object away, keeping only the status code
+  ([`examples/sre-bot/connectors/k8s-write/server.py::restart_deployment`](../../examples/sre-bot/connectors/k8s-write/server.py)).
+  Its RBAC says so out loud: `get` "is needed to read the Deployment before
+  patching it and to confirm the patch was accepted afterwards"
+  ([`examples/sre-bot/manifests/write-role.yaml`](../../examples/sre-bot/manifests/write-role.yaml)).
+
+There is also a cap that only makes sense for a boolean consumer: the flag fires
+**once per turn**, because a boolean cannot be set twice. A turn that calls three
+mutating tools reports one.
+
+### What a spike ruled out
+
+The first design took the snapshot in the runner's pre-execution permission
+callback, `build_can_use_tool` in
+[`runner/src/curie_runner/approval.py`](../../runner/src/curie_runner/approval.py),
+which does see the arguments before the call executes and cannot be skipped by
+the model. That seam cannot reach a snapshot. The runner never invokes an MCP
+tool outside the model loop: MCP servers are handed to the SDK
+([`runner/src/curie_runner/adapter.py`](../../runner/src/curie_runner/adapter.py)),
+the SDK owns those client sessions, and every out-of-loop call the runner makes
+([`runner/src/curie_runner/state.py`](../../runner/src/curie_runner/state.py),
+[`runner/src/curie_runner/memory.py`](../../runner/src/curie_runner/memory.py))
+is plain HTTP to the platform API. Taking a snapshot there would mean building a
+second MCP client inside the runner, which is a large new mechanism for one job.
+
+That finding came out of a throwaway spike, which was removed with the rest of
+the prototype before this ADR merged.
+
+## Decision
+
+**A tool that changes the world reports what it changed, in its own reply. The
+platform records that report as an action, and can replay the recorded prior
+state to put it back, with no model in the path.**
+
+1. **The tool's reply is the declaration.** There is **no manifest surface** for
+   reversibility. A connector that can be undone returns the state it read
+   immediately before it wrote; a connector that cannot says why, in the same
+   reply. Reversibility is deny-by-default: a tool that reports neither is not
+   undoable, and third-party MCP servers land in that case without anyone
+   declaring anything.
+
+   A manifest declaration was considered and rejected. It would be a second
+   source of truth that can disagree with what the tool actually returned, and
+   the disagreement resolves the wrong way: the manifest says reversible, the
+   reply carries nothing, and the platform either lies to the user or ignores the
+   manifest. One source, and it is the one that was there when the write
+   happened.
+
+2. **The platform executes the compensation deterministically.** Undo replays the
+   recorded prior state through the same tool. It is not a turn, the model is not
+   asked, and nothing is inferred. If the answer to "I am afraid to let a bot
+   touch production" is a bot reasoning about how to un-touch it, the fear
+   doubles rather than resolving.
+
+3. **An undo requires the authorization the forward action required, and no
+   more.** If the tool was gated by an approval policy, undoing it needs an
+   authorizer of that same route, resolved in the API against membership the way
+   [ADR-0034](0034-approval-authorizers-resolve-membership-in-the-api.md) resolves
+   an approver. If the tool was not gated, the undo is not gated either.
+
+   The rule follows from what a restore does. The state being restored is one the
+   cluster was already in, and it got there without anyone approving it, because
+   it predates the action. Nobody needs permission to put back what was there.
+   What they need is to be someone who could have permitted the change in the
+   first place, which is exactly the symmetry above.
+
+4. **A restore is refused when the world has moved.** Before replaying, the
+   platform compares the resource's live state to what the action left. On a
+   mismatch it refuses and names both states. This is the rule the feature lives
+   or dies on: a blind restore silently reverts a human's manual fix, which turns
+   an undo button into a way for the platform to fight the operator.
+
+5. **A recorded action does not expire.** Approvals carry `expires_at` because a
+   question left unanswered goes stale. A record of something that happened does
+   not. Time is also the wrong bound: a change one minute later makes a restore
+   unsafe and a quiet week does not make it safer, so decision 4's conflict check
+   is the real bound and a TTL would refuse safe undos while permitting unsafe
+   ones inside the window.
+
+6. **The action is the unit, not the turn.** The side-effect frame fires once per
+   call rather than once per turn, and the record, the receipt line, and the undo
+   are all per action. `saw_side_effect` still latches on the first, so the
+   no-retry rule reads exactly the signal it read before.
+
+7. **The user acts on a receipt.** A turn that changed anything ends with a card
+   listing each action, each carrying either an undo control or the stated reason
+   it has none, rendered through the existing approval-card path. Whole-turn undo
+   is a later, thin layer over the same rows and is not decided here.
+
+**The ledger invariant** (what we test and review to): every side-effecting call
+produces exactly one durable record; a record claims to be undoable only when it
+holds a prior state, a target, and a successful outcome; and an undo either
+restores the recorded state or changes nothing at all.
+
+## Business case
+
+**The fear this answers is the one that stops the sale.** Curie's premiere
+example is an SRE bot, and the objection to an SRE bot is never "can it read
+metrics". It is that somebody has to let it write. ADR-0010 answered the half
+before the action. The half after is empty: today a bot changes production and
+the platform's entire account of it is prose the model wrote about itself.
+
+**It converts the platform's most conservative posture into a feature.** The
+read-only allowlist means Curie already treats every unknown tool as dangerous.
+That posture currently produces nothing except a refusal to retry. The same
+classification, recorded rather than reduced, is a per-action receipt, and the
+same deny-by-default gives a truthful answer for tools nobody declared anything
+about.
+
+**"Undo" is a category Curie's competitors do not have, because they do not have
+the pieces.** Reversal needs a per-conversation durable record, a gated tool
+surface, an audit trail, and a channel that can render an interactive card.
+Curie has all four already, built for approvals. This is the second product built
+on machinery that was paid for once.
+
+**The honest half sells as well as the undoable half.** A receipt that says
+"restarting pods cannot be undone" next to one that says "scaled 3 to 10, undo"
+tells an operator the system knows the difference. That is the thing they are
+actually buying: not a bot that cannot make mistakes, but a platform that knows
+which mistakes it can take back.
+
+## What a prototype established
+
+A prototype was built to argue this decision from something that ran, and was
+removed before this ADR merged. It authorizes nothing and it is not the
+implementation: under
+[ADR-0085](0085-acceptance-not-implementation-authorizes-an-adr.md) as amended by
+[ADR-0102](0102-accepted-alongside-implementation-with-explicit-approval.md),
+acceptance is the authority for implementation and existing code cannot supply
+it. The implementing work is tracked in #1861 and lands slice by slice against
+this decision. What the prototype produced is a set of findings, recorded here
+because each one narrows that work.
+
+**A connector can report prior state on every path, including refusals.** A reply
+of `{"ok", "summary", "prior", "target"}` was sufficient, and a failed read has to
+refuse to write at all: an action that happened and cannot be undone is worse than
+one that did not, because it leaves the platform holding a record it cannot act
+on.
+
+**A reversible scale tool belongs beside
+[`examples/sre-bot/connectors/k8s-write/server.py`](../../examples/sre-bot/connectors/k8s-write/server.py),
+not inside it.** That server's own argument is that it exposes one tool with no
+parameter through which a caller could reach a replica count. Separating them is
+also the narrower grant: a rollout restart is a PATCH of the pod template, so RBAC
+`patch` on `deployments` is the same grant as `set image`, which is why `k8s-write`
+enforces that separation in Python, while scaling has `deployments/scale` as its
+own subresource, so Kubernetes refuses an image change rather than this codebase
+doing it.
+
+**Carrying the call's arguments and result on `SideEffectFlag` is a patch, not a
+minor.** Both fields are optional with a `None` default, and
+[`packages/aci-protocol/src/aci_protocol/version.py`](../../packages/aci-protocol/src/aci_protocol/version.py)
+states that a new optional field is a patch because tolerant consumers ignore it,
+with the minor reserved for breaking changes under 0.x. This is
+[ADR-0036](0036-aci-semver-and-reader-policy.md)'s reader policy applied, and the
+wire-lock fingerprint moves with it, which is that gate working as designed.
+
+**Framing per call does not disturb the signal the kernel reads.** Dropping the
+once-per-turn cap widens the stream, but `saw_side_effect` latches on the first
+frame, so ADR-0013's no-retry rule reads exactly what it read before. Tool
+results are worth forwarding for side-effecting calls only, matched to their call
+by `tool_use_id`: read-only results are the model's working material rather than
+wire traffic. A prose reply carries no structured result, deliberately, because
+guessing structure out of a sentence is how something downstream restores a guess.
+
+**The ledger migration has to be hand-written.** Alembic autogenerate compares
+against the wrong search path and proposes dropping Langfuse's `monitors`,
+`table_view_presets` and `default_llm_models`, which share the database. A
+hand-written revision round-trips upgrade, downgrade, upgrade against a real
+Postgres.
+
+**The round trip closes, and decision 4 is what makes it safe.** With real code at
+every step, the sequence the prototype ran was:
+
+```
+world before   public/api replicas = 3
+[1] connector scales it           reply carries prior {"spec": {"replicas": 3}}
+[2] the runner emits 2 frames     record.prior captured, undoable = True
+[3] conflict check, then undo     world back to 3
+[4] the irreversible tool         prose reply, no prior state, undoable = False
+[5] a human sets it to 7 by hand  REFUSED, world stays 7
+```
+
+Step 5 is decision 4 working: a refused undo changes nothing, so a manual fix
+survives an undo pressed after it. Step 4 is deny-by-default falling out on its
+own, with nothing special-casing the irreversible tool.
+
+**What the prototype could not close** is where the undo executor lives, which is
+the one decision this ADR does not make, below.
+
+## Alternatives considered
+
+- **A mapping DSL: "tool X is undone by calling Y with arguments derived from
+  X's."** Rejected on two grounds, and the second is the decisive one. It needs
+  an expression language, which is the commodity-engine category
+  [ADR-0007](0007-adopt-not-build-boundaries.md) exists to keep out. And it does
+  not have the information: undoing `scale_deployment(replicas=10)` needs the
+  count from **before** the call, which no function of the forward arguments can
+  produce. Snapshot-restore is not the safer mechanism, it is the only one that
+  knows the answer.
+
+- **Snapshot in the pre-execution permission callback.** Rejected by the spike
+  above: the runner cannot invoke an MCP tool outside the model loop without a
+  second MCP client that exists for this one job.
+
+- **A reversibility declaration in `plugin.json`, beside `approvalPolicy`.**
+  Rejected per decision 1. Two sources of truth for one fact, and the failure
+  mode is the platform telling a user an action is undoable when nothing captured
+  the state.
+
+- **Letting the agent perform the undo as another turn.** Rejected per decision
+  2. It is more flexible and strictly less trustworthy, and the undo would itself
+  be a side-effecting turn needing its own record and its own approval, which
+  regresses infinitely.
+
+- **A TTL on undoability, mirroring `approvals.expires_at`.** Rejected per
+  decision 5. Symmetry with approvals is not a reason, and time is the wrong
+  variable.
+
+- **Whole-turn undo as the primary surface.** Deferred, not rejected. Per-action
+  is the honest unit because actions succeed and fail independently, and a
+  turn-level control has to answer what "undo" means when two of three actions
+  are reversible. It is a thin layer over these rows once they exist.
+
+## Consequences
+
+- **A connector that wants to be undoable has to return JSON.** That is a real
+  cost to every write connector anyone writes, and the reason it is acceptable is
+  that the connector was already reading the state; the change is to report it
+  rather than discard it.
+
+- **Third-party MCP write tools are not undoable, and will say so on the
+  receipt.** This is the honest outcome and it is also a gap a user will notice.
+  It is the same shape as the read-only allowlist's deny-by-default, and the
+  remedy is the same: wrap the tool in a connector that reports.
+
+- **An additive ACI field is free for readers and not for constructors.** The
+  reader policy holds: a consumer that predates `arguments` and `result` parses
+  the frame unchanged. But the generated Rust is an enum with struct variants,
+  and a struct-variant literal has to name every field, so
+  [`cli/src/render.rs`](../../cli/src/render.rs) will not compile until it names
+  the two new ones, as the prototype found. Pattern matches with `..` are
+  unaffected. The lesson is that "additive" describes the wire, not every language
+  binding, and the Rust build is what says so.
+
+- **The kernel will see more side-effect frames than before.** It reads the same
+  signal (`saw_side_effect` still latches on the first), so the no-retry rule is
+  unchanged, but `kernel.py` is sacred under ADR-0013 and the widened stream is
+  the part of this change to review hardest.
+
+- **The receipt is a new surface that can be noisy.** A turn with many small
+  writes produces many lines. Whole-turn undo and grouping are the answers, and
+  both are out of scope here, so the first version will be verbose for a busy
+  agent.
+
+- **Snapshots can hold secrets.** A snapshot of a Kubernetes object can carry
+  environment variables and secret references. They pass through the existing
+  redaction path, which means some resources are honestly not snapshot-able and
+  must report themselves irreversible rather than storing credentials in the
+  control plane.
+
+- **Undo is a new write path into a customer's infrastructure**, authorized by
+  decision 3 and audited by `action_audit_entries`. It reuses the connector's own
+  credential and allowlist, so it can reach nothing the forward action could not.
+
+## The one decision this ADR does not make
+
+**Where the undo executor lives is open, and taking the prototype end to end is
+what surfaced it.** Nothing in the platform can reach a connector today: neither
+`apps/api` nor `apps/worker` has an MCP client, and every out-of-loop HTTP call
+either makes is to the platform's own API. So the API rules on an undo and
+returns, and something else has to perform the call the ruling authorizes.
+
+Three candidates, none settled here:
+
+- **An MCP client in the worker.** The dependency is already present
+  transitively, so this is the smallest change. It also makes the control plane
+  a direct client of tenant connectors, which is a reachability question ADR-0008
+  has opinions about.
+- **A new ACI verb, executed by the runner in a sandbox.** Architecturally the
+  most conservative, because the sandbox is where a connector's credential,
+  allowlist and network policy already apply, so an undo could reach nothing the
+  forward call could not. It is also the most work: the runner would need to
+  invoke an MCP tool outside the model loop, which is precisely what the spike
+  found it cannot do today.
+- **The connector exposes a plain HTTP replay endpoint.** Avoids MCP entirely and
+  changes the connector contract for every author.
+
+The ruling and the execution are already separate in the code, which is what
+makes deferring this safe: a refusal is recorded and returned before anything
+could act on it, so whichever executor lands cannot bypass the check by holding
+the connector's address.
+
+## Out of scope
+
+- **Whole-turn and time-windowed undo**, per the alternatives above.
+- **Preview before acting.** Showing what a tool *would* do without doing it is
+  the other half of the same intuition and is its own decision.
+- **Retention and pruning of the ledger.** Rows accumulate; nothing here decides
+  when they leave.
+- **Undo from the console.** The receipt lands on the channel that asked. The UI
+  surface is a separate piece of work.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -145,4 +145,5 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0114 | [Managed repository workspaces and approval-gated publication are platform capabilities](0114-managed-repository-workspaces-and-approval-gated-publication.md) | Accepted |
 | 0115 | [Runtime repository selection is sticky authorized thread state](0115-runtime-repository-selection-is-sticky-authorized-thread-state.md) | Accepted |
 | 0116 | [Session identity arrives over the ACI so a sandbox can be pre-bound](0116-session-identity-arrives-over-the-aci-so-a-sandbox-can-be-pre-bound.md) | Draft |
+| 0117 | [A tool that changes the world reports what it changed, and the platform can put it back](0117-a-tool-that-changes-the-world-reports-what-it-changed.md) | Accepted |
 <!-- END GENERATED: adr-index -->

--- a/docs/design/action-ledger-and-undo.md
+++ b/docs/design/action-ledger-and-undo.md
@@ -1,0 +1,348 @@
+# Design pass: the action ledger and undo
+
+> Status: **Design pass** behind
+> [ADR-0117](../adr/0117-a-tool-that-changes-the-world-reports-what-it-changed.md)
+> (Accepted), which settles the open questions this document raised and is the
+> decision of record. Where the two differ, the ADR governs; this document is the
+> working-out that preceded it, and the implementing work is tracked in #1861.
+>
+> Related: [ADR-0010](../adr/0010-approval-gates-and-human-in-the-loop.md)
+> (approval gates, the pre-action half of this),
+> [ADR-0013](../adr/0013-concurrency-and-delivery-model.md) (the kernel
+> invariants, including the no-retry-after-side-effects rule this builds on),
+> [ADR-0046](../adr/0046-converged-approval-gates-and-durable-provenance.md)
+> (durable provenance), [ADR-0060](../adr/0060-the-harness-is-a-declared-package.md)
+> (the harness declares its own tool semantics),
+> [ADR-0078](../adr/0078-approval-cards-over-connected-transport.md) (cards on a
+> channel), and [ADR-0007](../adr/0007-adopt-not-build-boundaries.md), which is
+> why one of the three mechanisms below is rejected outright.
+
+## The problem in one paragraph
+
+Curie already detects that a turn changed the world. It records **one bit**. The
+runner classifies every tool that is not on a harness-declared read-only
+allowlist as side-effecting, emits a `side_effect_flag`, and the kernel reduces
+that to `saw_side_effect: bool` used for exactly one purpose: refusing to retry.
+Nothing records **what** was changed, on **what**, with **what arguments**, or
+whether it worked. So when a bot changes production, the person who asked gets a
+sentence of prose from the model and no account from the platform, and there is
+nothing to act on afterwards. Approval gates (ADR-0010) answer this **before** an
+action. Nothing answers it **after**.
+
+## What already exists, and why the scope is smaller than it looks
+
+The pieces are unusually well positioned, and the design below is mostly a matter
+of not discarding what is already computed.
+
+- **The classifier is already deny-by-default.**
+  [`runner/src/curie_runner/side_effects.py`](../../runner/src/curie_runner/side_effects.py)
+  is a read-only allowlist: a harness declares which of its tools only read, and
+  everything else is treated as potentially side-effecting. A new or unknown tool
+  escalates rather than being silently retried. The same posture is exactly right
+  for reversibility, and this design reuses the shape rather than inventing one.
+
+- **The ACI frame already names the tool.** `SideEffectFlag` carries `tool` and an
+  optional `detail`. The runner fills them at
+  [`runner/src/curie_runner/translate.py::_translate_assistant`](../../runner/src/curie_runner/translate.py):
+
+  ```python
+  SideEffectFlag(tool=block.name, detail="non-idempotent tool executed")
+  ```
+
+  `detail` is a constant string. The arguments are in `block` at that exact
+  moment and are dropped on the floor.
+
+- **There is already a pre-execution seam that sees the arguments.**
+  `build_can_use_tool` in
+  [`runner/src/curie_runner/approval.py`](../../runner/src/curie_runner/approval.py)
+  is the SDK permission callback, and it receives `tool_name` **and
+  `tool_input`** *before the call executes*. Its own docstring draws the
+  distinction this design needs: the decision is "proactive -- the call is
+  blocked before execution -- unlike the reactive `side_effect_flag` classifier,
+  which only reports after the fact." A snapshot has to be taken before the
+  mutation, and this is where that is possible. ADR-0099's bundle-declared
+  `PreToolUse` hooks are the second such seam.
+
+- **The durable-record pattern exists, with an audit trail.** `approvals` and
+  `approval_audit_entries` in
+  [`apps/api/src/curie_api/models.py`](../../apps/api/src/curie_api/models.py)
+  already model "a thing that happened to a conversation, with routing back to
+  the surface that asked, a status lifecycle, an expiry, a resolver, and an
+  evidence blob."
+
+- **Cards with buttons on a channel already work.** `ApprovalCardStore` and
+  `apps/worker/src/curie_worker/blocks.py` in the worker render and track interactive cards, and the API
+  exposes `GET /{approval_id}`, `GET /{approval_id}/audit`, and
+  `POST /{approval_id}/resolve`. A receipt with an Undo button is that machinery
+  pointed at a different row.
+
+- **The read-before-write habit is already in the example's RBAC.**
+  [`examples/sre-bot/manifests/write-role.yaml`](../../examples/sre-bot/manifests/write-role.yaml)
+  grants `get` because it "is needed to read the Deployment before patching it
+  and to confirm the patch was accepted afterwards." The snapshot this design
+  needs is a read the write path was already making.
+
+## Decisions taken
+
+These were settled during the design conversation and are recorded here so the
+ADR can cite them rather than re-argue them.
+
+**1. The platform executes a compensation, deterministically, with no model in
+the path.** Undo is a replay of a declared inverse, not a second round of
+inference. If the answer to "I am afraid to let a bot touch production" is a bot
+reasoning about how to un-touch it, the fear doubles. It also keeps the demo
+reproducible, and it means an undo cannot invent an action nobody recorded.
+
+**2. The mechanism is snapshot-then-restore, and a compensation is declared, not
+inferred.** Before a declared-reversible tool executes, the platform captures the
+prior state of its target through a declared read; undo restores that state
+through a declared write. Reversibility is deny-by-default: a tool with no
+declaration is not reversible, exactly as a tool absent from the read-only
+allowlist is assumed to mutate.
+
+**3. The user acts on individual actions, through a receipt.** A turn that
+changed anything ends with a card listing each action, each carrying either an
+Undo control or the declared reason it cannot be undone. Whole-turn undo is a
+later, thin layer over the same rows and is not in this design.
+
+**4. The ledger is Postgres, beside `approvals`.** It is product state that gets
+executed against, not telemetry. Langfuse is the observability and eval backbone
+(ADR-0004) and is the wrong home for a row whose lifecycle a user drives.
+
+## Rejected: a mapping DSL
+
+The obvious alternative to snapshot-restore is to declare "tool X is undone by
+calling tool Y with arguments derived from X's arguments." That needs an
+expression language for the derivation, which is a small engine, which is the
+category [ADR-0007](../adr/0007-adopt-not-build-boundaries.md) exists to keep out
+of this codebase. It also fails in the case that matters most: the argument to
+the inverse call is usually not derivable from the forward call at all. Undoing
+`scale_deployment(replicas=10)` needs the replica count from **before** the call,
+which no function of the forward arguments can produce. Snapshot-restore is not
+merely the safer mechanism, it is the one that has the information.
+
+## Architecture
+
+```
+turn                                                     ledger
+----                                                     ------
+model asks to call a mutating tool
+   |
+   v
+can_use_tool / PreToolUse  ........ approval gate (exists, ADR-0010)
+   |                       \
+   |                        \..... snapshot hook (NEW)
+   |                                  declared read -> prior state
+   v
+tool executes
+   |
+   v
+SideEffectFlag(tool, detail)  ..... detail carries the recorded action (CHANGED)
+   |
+   v
+worker kernel  .................... writes an agent_actions row (NEW)
+   |
+   v
+receipt card on the channel ....... reuses ApprovalCardStore + blocks.py
+   |
+   v
+[Undo] -> POST /actions/{id}/undo . platform replays the declared restore (NEW)
+```
+
+The turn path gains one hook and one field. Everything after the flag is new but
+sits on machinery that already exists.
+
+### Where the snapshot runs (revised after a spike)
+
+The first draft put the snapshot in `can_use_tool`, on the reasoning that it runs
+before the tool and cannot be skipped by the model. **A spike showed that seam
+cannot reach a snapshot.** The runner never invokes an MCP tool outside the model
+loop: MCP servers are handed to the SDK
+([`runner/src/curie_runner/adapter.py`](../../runner/src/curie_runner/adapter.py)),
+the SDK owns those client sessions, and every out-of-loop call the runner does
+make ([`runner/src/curie_runner/state.py`](../../runner/src/curie_runner/state.py),
+[`runner/src/curie_runner/memory.py`](../../runner/src/curie_runner/memory.py),
+[`runner/src/curie_runner/history.py`](../../runner/src/curie_runner/history.py))
+is plain HTTP to the platform API. Taking a snapshot there would mean building a
+second MCP client inside the runner, which is a large new mechanism for the one
+job.
+
+The spike also found the snapshot is already being taken. The example's write
+tool reads the resource before patching it and then discards what it read:
+
+```python
+# examples/sre-bot/connectors/k8s-write/server.py::restart_deployment
+existing = client.get(path)
+if existing.status_code == 404: ...
+```
+
+And tool results already reach the runner. They arrive as `UserMessage` content
+and are dropped on purpose:
+
+```python
+# runner/src/curie_runner/translate.py, _translate_message
+# UserMessage, SystemMessage, and StreamEvent carry no outbound-visible
+# content in the v0.1 contract; they are intentionally dropped.
+```
+
+**So the snapshot is taken by the connector and travels in its tool result.** The
+connector already holds the prior state; it returns prose today and returns prose
+plus a structured prior-state block instead. The runner stops dropping tool
+results for side-effecting tools and forwards what it finds. No new MCP client,
+no new pre-execution hook, and the platform still never asks a model what
+happened.
+
+The cost of the revision is honest and matches the deny-by-default posture: a
+connector that does not report prior state produces an action that is not
+undoable. Third-party MCP servers will not report it, and that is exactly the
+`undeclared` case the receipt already has to render.
+
+### One flag per turn is not enough
+
+`_translate_assistant` emits at most one `SideEffectFlag` per turn, guarded by
+`state.side_effect_emitted`, because its only consumer is a boolean. A ledger
+needs one record per action, so that cap is lifted and the flag becomes
+per-call. This is the change with the widest blast radius in the runner and the
+one to review hardest, because the existing no-retry rule reads the same signal.
+
+### Why not in the connector alone
+
+The snapshot must be taken by something that runs before the tool and cannot be
+skipped by the model. `can_use_tool` is that thing. Putting the snapshot inside
+the connector instead would mean every connector implements it, third-party MCP
+servers never will, and a bundle author has no way to add it for a tool they do
+not own.
+
+### What a declaration looks like
+
+Shape is illustrative, not a proposed grammar; the ADR settles it. It lives in
+the bundle manifest beside `approvalPolicy`, because that is where the bundle
+already declares per-tool policy that is validated at deploy time (ADR-0050), and
+because the bundle is the versioned unit an operator reviews.
+
+```yaml
+reversibility:
+  tools:
+    - tool: mcp__k8s-write__scale_deployment
+      snapshot: { via: mcp__kubernetes__get_deployment, keys: [namespace, name] }
+      restore:  { via: mcp__k8s-write__scale_deployment, from: spec.replicas }
+    - tool: mcp__k8s-write__restart_deployment
+      irreversible: "restarting pods cannot be undone"
+```
+
+Two things carry weight here. `irreversible` is a **declared string the user
+sees**, not a silence: today a bot restarts a Deployment and the platform says
+nothing, and the improvement is as much about naming what cannot be undone as
+undoing what can. And an undeclared tool is treated as irreversible with an
+unattributed reason, which keeps the default safe while making the gap visible
+rather than silent.
+
+### Data model
+
+`agent_actions`, mirroring `Approval`'s shape because the routing, lifecycle and
+evidence requirements are the same:
+
+| column | why |
+| --- | --- |
+| `id`, `agent_id`, `conversation_id`, `turn_id` | identity and the turn it belongs to |
+| `tool`, `arguments` | what was called; arguments redacted through `runner/src/curie_runner/redact.py` |
+| `target` | the declared key of the thing changed, so two actions on one resource can be reasoned about |
+| `snapshot`, `snapshot_status` | prior state, or why there is none |
+| `outcome`, `outcome_detail` | whether the call succeeded; a failed call still gets a row |
+| `reversibility`, `irreversible_reason` | `reversible` / `irreversible` / `undeclared` plus the declared sentence |
+| `undo_status`, `undone_at`, `undone_by` | lifecycle, mirroring `Approval.status` / `resolved_by` |
+| `reply_kind`, `reply_channel`, `card_channel` | routing back to the surface, copied from `Approval` |
+| `created_at` | ordering, and the basis for reverse-order replay later |
+
+An `action_audit_entries` table mirrors `ApprovalAuditEntry` for the undo
+decisions themselves, so an undo is as auditable as an approval.
+
+### Undo execution
+
+`POST /actions/{id}/undo` validates authorization, checks the world has not moved
+(below), then executes the declared restore through the same connector path the
+forward call used, and records the result. The model is not involved. The undo is
+itself a mutating action and gets its own ledger row, linked to the row it
+reverses, so an undo can be seen and audited but the chain terminates: an undo
+row is never itself reversible.
+
+## Failure modes, which are most of the design
+
+- **The snapshot fails.** The action still executes and still gets a row, marked
+  `snapshot_status: failed` and therefore not undoable. Refusing the action
+  because a snapshot failed would turn a new feature into a new outage.
+- **The world moved.** Someone scaled the Deployment by hand after the bot did.
+  Restoring blindly would clobber them. The restore compares current state to the
+  post-action state it expects and, on mismatch, refuses and says what changed.
+  This is the single most important correctness rule here.
+- **A partial undo.** Each action undoes independently; there is no transaction
+  across actions. That is why the receipt is per-action rather than per-turn, and
+  why whole-turn undo is deferred rather than assumed.
+- **Undo of an undo.** Not supported. The forward action can be re-run as a new
+  turn if that is what someone wants.
+- **A stale declaration.** The bundle version that recorded the action is the one
+  whose declaration is used to undo it, read from the immutable version, not from
+  whatever is deployed now.
+- **The connector is gone.** A deployment can be deleted between action and undo.
+  The undo fails with a named reason rather than a traceback.
+
+## Security
+
+- **Authorization mirrors approvals.** Who may undo is resolved the way
+  [ADR-0034](../adr/0034-approval-authorizers-resolve-membership-in-the-api.md)
+  resolves who may approve: in the API, against membership, not from a
+  caller-asserted identity.
+- **Undo is a side effect.** Whether an undo of a gated tool needs its own
+  approval is a real question and the ADR must answer it rather than assume.
+  The default proposed here is that it does not, on the grounds that restoring a
+  recorded prior state is strictly less dangerous than the action that was
+  already approved. That is arguable and should be argued.
+- **Snapshots can hold secrets.** A snapshot of a Kubernetes object can contain
+  environment variables and secret references. Snapshots go through the existing
+  redaction path (`runner/src/curie_runner/redact.py`) and are stored redacted,
+  which means some resources are honestly not snapshot-able and must be declared
+  irreversible instead of silently storing credentials.
+
+## What proves it
+
+- The `scale_deployment` round trip end to end on a real cluster: scale, receipt
+  renders with one undoable and one irreversible row, undo, and the Deployment
+  returns to its prior replica count, verified by reading the cluster and not by
+  reading the ledger.
+- A conflict case: change the Deployment by hand between action and undo, and the
+  undo refuses with the mismatch named.
+- A snapshot-failure case: the action still lands and is recorded as not
+  undoable.
+- An undeclared-tool case: the action appears on the receipt as irreversible with
+  an unattributed reason.
+- Mutation coverage on the "world moved" comparison specifically, since it is the
+  rule whose absence would let this feature destroy someone's manual fix.
+
+## Out of scope
+
+- Whole-turn undo, which is a later thin layer over these rows.
+- Time-windowed undo ("undo the last ten minutes"), which crosses conversations
+  and other people's changes.
+- Preview or dry-run before acting, which is the other half of the same intuition
+  and is its own decision.
+- Any change to what a sandbox may reach. This design records and reverses; it
+  does not widen.
+
+## Open questions, and how the ADR settled them
+
+1. ~~Does undoing a gated tool require its own approval?~~ **An undo requires the
+   authorization the forward action required, and no more.** The state being
+   restored is one the cluster was already in, reached without anyone approving
+   it, so nobody needs permission to put back what was there; what they need is
+   to be someone who could have permitted the change.
+2. ~~Does the declaration live in `plugin.json` or in `connectors.yaml`?~~
+   **Neither. The tool's reply is the declaration.** A manifest surface would be
+   a second source of truth, and the disagreement resolves the wrong way: the
+   manifest claims reversible, nothing captured the state, and the platform
+   either lies or ignores the manifest.
+3. ~~Is `target` declared per tool or derived from the snapshot read?~~ **It comes
+   from the tool's reply, with the same reasoning as 2**, and its absence is one
+   of the three things that make a row not undoable.
+4. ~~How long does a row stay undoable?~~ **It does not expire.** Time is the
+   wrong bound: a change one minute later makes a restore unsafe and a quiet week
+   does not make it safer. The world-moved check is the real bound.


### PR DESCRIPTION
## What this is

**ADR-0117, Accepted, and nothing else.** Per the review: prototype stripped, ADR
ready to merge, implementation to follow as real work.

The diff is three files — the ADR, the regenerated index, and the design pass
behind it. `bash scripts/check-docs.sh` passes.

## What came off

Everything the prototype added: the ACI `arguments`/`result` fields and the
regenerated Rust/TS bindings, the per-call frames in the runner, the `k8s-scale`
connector, the `agent_actions` migration and the actions API, the receipt card,
the probes, the demo and its recording. Thirty-two files, ~4.9k lines.

That is the process working rather than a loss. Under
[ADR-0085](https://github.com/curie-eng/curie/blob/next/docs/adr/0085-acceptance-not-implementation-authorizes-an-adr.md)
as amended by
[ADR-0102](https://github.com/curie-eng/curie/blob/next/docs/adr/0102-accepted-alongside-implementation-with-explicit-approval.md),
acceptance is what authorizes implementation, and none of that code had it. It
survives on **`spike/adr-0117-action-ledger`** as a reference for the slices, not
as code to land.

## What the ADR kept, and what it gave up

The findings stay; the claims go. The old "Evidence (built and measured)" section
is now **"What a prototype established"** — same findings, each stated because it
narrows a slice, and not one citation to a path this PR removes:

- a connector can report prior state on every path, and a failed read must refuse
  to write at all
- the scale tool belongs beside `k8s-write`, and that is also the narrower RBAC
  grant
- `arguments` and `result` on `SideEffectFlag` are a **patch** under ADR-0036, not
  a minor
- per-call framing leaves `saw_side_effect` latching on the first frame, so
  ADR-0013's no-retry rule reads exactly what it read before
- the ledger migration has to be hand-written, because autogenerate proposes
  dropping Langfuse's tables
- the round trip closes, and the refused undo is the step the feature lives on

Claims about code that is no longer changed go back to present tense: the frame
*is* built with a constant `detail` string, the v0.1 contract *drops* the tool
result, the flag *fires* once per turn. Status is `Accepted` with `Issue: #1861`.

## The implementation

Tracked in #1861, one PR per slice against `next`:

| | |
| --- | --- |
| #1862 | the ACI carries a call's arguments and result, one frame per call |
| #1863 | the ledger tables, and the kernel writes a record per call |
| #1864 | the actions API: record, list, and rule on an undo |
| #1865 | a write connector reports the state it read before writing |
| #1866 | the receipt: a per-action card with an undo control or a stated reason |
| #1867 | where the undo executor lives — **needs its own ADR first** |

#1867 is the decision this ADR deliberately does not make: nothing in the platform
can reach a connector today, so the API can rule on an undo but cannot perform
one.

Also filed: #1868, the latent migration-head pin in
`test_migration_0021a_v0_6_x_reconcile.py`. Its fix came off with the migration
that provoked it, so the defect is still live on `next` and will bite the next
migration author.
