### PR TITLE
Restore the shell gates on macOS bash 3.2

### DIFF
--- a/charts/curie/ci/render-assertions.sh
+++ b/charts/curie/ci/render-assertions.sh
@@ -56,19 +56,42 @@ KEYS=(
   apiKey
   githubWebhookSecret
 )
-declare -A DEFAULTS=(
-  [postgresPassword]="postgres"
-  [valkeyPassword]="valkeypass"
-  [clickhousePassword]="clickhouse"
-  [rustfsSecretKey]="rustfssecret"
-  [langfuseSalt]="dev-salt-change-me"
-  [langfuseEncryptionKey]="0000000000000000000000000000000000000000000000000000000000000000"
-  [langfuseNextauthSecret]="dev-nextauth-secret-change-me"
-  [langfuseInitProjectSecretKey]="sk-lf-curie-dev"
-  [langfuseInitUserPassword]="curie-dev-password"
-  [apiKey]="curie-dev-key"
-  [githubWebhookSecret]="dev-webhook-secret"
-)
+# The published dev default for each of those keys. A `case` lookup rather than
+# `declare -A`: associative arrays are bash 4+, and macOS ships bash 3.2 (the
+# last GPLv2 release) as /bin/bash, which `#!/usr/bin/env bash` finds unless the
+# contributor installed a newer one. Under `set -u` the unsupported `declare -A`
+# made the first key look like an unbound variable, so `curie dev chart-check`
+# failed on every stock Mac with "postgresPassword: unbound variable" -- an error
+# that named nothing real and pointed at no fix. The other twenty-one assertion
+# scripts already run on 3.2; this was the only one that did not.
+default_for() {
+  case "$1" in
+    postgresPassword)             printf '%s\n' "postgres" ;;
+    valkeyPassword)               printf '%s\n' "valkeypass" ;;
+    clickhousePassword)           printf '%s\n' "clickhouse" ;;
+    rustfsSecretKey)              printf '%s\n' "rustfssecret" ;;
+    langfuseSalt)                 printf '%s\n' "dev-salt-change-me" ;;
+    langfuseEncryptionKey)        printf '%s\n' "0000000000000000000000000000000000000000000000000000000000000000" ;;
+    langfuseNextauthSecret)       printf '%s\n' "dev-nextauth-secret-change-me" ;;
+    langfuseInitProjectSecretKey) printf '%s\n' "sk-lf-curie-dev" ;;
+    langfuseInitUserPassword)     printf '%s\n' "curie-dev-password" ;;
+    apiKey)                       printf '%s\n' "curie-dev-key" ;;
+    githubWebhookSecret)          printf '%s\n' "dev-webhook-secret" ;;
+    *) return 1 ;;
+  esac
+}
+
+# Prove the lookup is total over KEYS here, at startup, rather than relying on a
+# failure at the point of use. `default_for` is called inside a command
+# substitution, where a nonzero exit cannot abort the script the way the old
+# `set -u` array miss did -- and one call site sits under `||`, which suspends
+# `set -e` for the whole function body. Checking up front keeps the old property
+# that a key with no published default is a hard error, not a silent empty
+# string that makes the generation detector pass by accident.
+for key in "${KEYS[@]}"; do
+  default_for "$key" >/dev/null \
+    || { echo "FAIL: default_for() has no published default for key '$key'" >&2; exit 1; }
+done
 
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
@@ -106,7 +129,7 @@ check_generated_key() {
   # $1 = rendered Secret, $2 = key, $3 = render label
   local out="$1" key="$2" label="$3" val def
   val="$(read_key "$out" "$key")"
-  def="${DEFAULTS[$key]}"
+  def="$(default_for "$key")"
   if [[ "$val" == "$def" ]]; then
     echo "$label still emits the published dev default for '$key' (value == '$def'); expected a generated value." >&2
     return 1
@@ -156,7 +179,7 @@ echo "  ok: langfuseEncryptionKey is 64 lowercase-hex chars"
 echo "=== Assertion 3: dev overlay keeps the deterministic published defaults ==="
 for key in "${KEYS[@]}"; do
   val="$(read_key "$DEV" "$key")"
-  def="${DEFAULTS[$key]}"
+  def="$(default_for "$key")"
   if [[ "$val" != "$def" ]]; then
     fail "dev overlay must keep the published default for '$key'; expected '$def', got '$val'."
   fi
@@ -1164,7 +1187,11 @@ assert_worker_api() {
   [[ -f "$manifest" ]] || fail "$name: worker.yaml did not render"
   [[ -f "$secret_manifest" ]] || fail "$name: secrets.yaml did not render"
   local error
-  if ! error="$(python3 "$WORKER_API_CHECK" "$manifest" "$secret_manifest" "$expected_url" "$key_source" "${key_args[@]}" 2>&1)"; then
+  # `${a[@]+"${a[@]}"}` rather than a bare `"${key_args[@]}"`: expanding an EMPTY
+  # array under `set -u` is an "unbound variable" error until bash 4.4, and macOS
+  # ships 3.2. key_args is empty for every non-operator key source, which is most
+  # of the call sites below.
+  if ! error="$(python3 "$WORKER_API_CHECK" "$manifest" "$secret_manifest" "$expected_url" "$key_source" ${key_args[@]+"${key_args[@]}"} 2>&1)"; then
     fail "$name: $error"
   fi
 }

--- a/charts/curie/ci/worker-ttl-bounds-assertions.sh
+++ b/charts/curie/ci/worker-ttl-bounds-assertions.sh
@@ -145,7 +145,13 @@ assert_env() {
   local -a sets=()
   while [ "$1" != "--" ]; do sets+=("$1"); shift; done
   shift
-  if ! helm template curie "$CHART" -s templates/worker.yaml "${sets[@]}" >"$out" 2>&1; then
+  # `${sets[@]+"${sets[@]}"}` rather than a bare `"${sets[@]}"`: expanding an
+  # EMPTY array under `set -u` is an "unbound variable" error until bash 4.4, and
+  # macOS ships 3.2 as /bin/bash. Assertion (a) passes no --set at all, so `sets`
+  # is empty on the very first call -- and because the EXIT trap's own status
+  # replaces the script's in 3.2, the abort surfaced as exit 0 and chart-check
+  # reported PASS for a run that asserted NOTHING.
+  if ! helm template curie "$CHART" -s templates/worker.yaml ${sets[@]+"${sets[@]}"} >"$out" 2>&1; then
     fail "$letter" "the render FAILED; it must succeed
   $(head -5 "$out")"
   fi

--- a/cli/scripts/e2e-ladder.sh
+++ b/cli/scripts/e2e-ladder.sh
@@ -395,7 +395,11 @@ for entry in plan:
 # this assertion as a claim about pre-existing sandboxes.
 assert_model_mode() {
     local label="$1" observed="$2" truthy=0
-    case "${observed,,}" in
+    # `tr` rather than `${observed,,}`: case-conversion expansion is bash 4+ and
+    # macOS ships 3.2 as /bin/bash, where the `,,` is a syntax error that kills
+    # the whole ladder -- and AGENTS.md tells contributors to run these rungs
+    # locally before pushing.
+    case "$(printf '%s' "$observed" | tr '[:upper:]' '[:lower:]')" in
         1|true|yes) truthy=1 ;;
     esac
     if [[ "$LIVE" == "1" ]]; then

--- a/cli/scripts/eval-falsifiability.sh
+++ b/cli/scripts/eval-falsifiability.sh
@@ -49,7 +49,13 @@ fi
 "$BIN" --version
 
 # Discover every committed suite: examples/*/evals/cases.json + the scaffold seed.
-mapfile -t SUITES < <(find "$REPO_ROOT/examples" -mindepth 2 -maxdepth 3 -path '*/evals/cases.json' | sort)
+# A read loop rather than `mapfile`, which is bash 4+ while macOS still ships 3.2
+# as /bin/bash -- CONTRIBUTING.md points Mac contributors at this gate, so the
+# `mapfile` form aborted with "command not found" before it checked anything.
+SUITES=()
+while IFS= read -r suite; do
+    SUITES+=("$suite")
+done < <(find "$REPO_ROOT/examples" -mindepth 2 -maxdepth 3 -path '*/evals/cases.json' | sort)
 SUITES+=("$REPO_ROOT/apps/worker/schema/eval-cases.example.json")
 echo
 echo "=== Committed suites under gate (${#SUITES[@]}) ==="

--- a/cli/scripts/refresh-schema-baseline.sh
+++ b/cli/scripts/refresh-schema-baseline.sh
@@ -156,10 +156,16 @@ if (( ${#mismatched[@]} > 0 )); then
   exit 1
 fi
 
-for name in "${changed[@]}"; do
+# `${a[@]+"${a[@]}"}` rather than a bare `"${a[@]}"`: expanding an EMPTY array
+# under `set -u` is an "unbound variable" error until bash 4.4, and macOS ships
+# 3.2. Only ONE of these two lists has to be non-empty to get here (the both-empty
+# case exited above), so the ordinary refresh -- a schema edited, none deleted --
+# left baseline_only empty, copied the changed files, and only THEN aborted on the
+# second loop, leaving a half-applied baseline behind a bogus error.
+for name in ${changed[@]+"${changed[@]}"}; do
   cp "$schema_dir/$name" "$baseline_dir/$name"
 done
-for name in "${baseline_only[@]}"; do
+for name in ${baseline_only[@]+"${baseline_only[@]}"}; do
   rm -- "$baseline_dir/$name"
 done
 

--- a/get-curie.sh
+++ b/get-curie.sh
@@ -75,8 +75,13 @@ if [ "$MODE" = source ]; then
   echo "==> cargo install --path cli --force (build curie and install it to ~/.cargo/bin)"
   cargo install --path cli --force
 
-  echo "==> curie install ${UPDATE_ARGS[*]} (deps + runner image as needed)"
-  "$CURIE_BIN" install "${UPDATE_ARGS[@]}"
+  # `${a[@]+...}` rather than a bare `"${UPDATE_ARGS[*]}"`/`"${UPDATE_ARGS[@]}"`:
+  # expanding an EMPTY array under `set -u` is an "unbound variable" error until
+  # bash 4.4, and macOS ships 3.2 as /bin/bash. UPDATE_ARGS is empty on exactly
+  # the FIRST run (no installed binary yet, so no --update), which is the run
+  # this script exists for -- a fresh Mac clone aborted here before installing.
+  echo "==> curie install ${UPDATE_ARGS[*]+${UPDATE_ARGS[*]}} (deps + runner image as needed)"
+  "$CURIE_BIN" install ${UPDATE_ARGS[@]+"${UPDATE_ARGS[@]}"}
 
   echo
   echo "Done. If 'curie' is not found in this shell, add ~/.cargo/bin to PATH"


### PR DESCRIPTION
## Summary

macOS ships bash 3.2.57 as `/bin/bash` and `#!/usr/bin/env bash` finds it, so six scripts using bash 4+ constructs either failed or — worse — passed vacuously for every contributor on a Mac. `curie dev chart-check` died on `charts/curie/ci/render-assertions.sh` with `postgresPassword: unbound variable`, an error naming nothing real, because `declare -A` is unsupported on 3.2 and `set -u` made the first key of the unsupported builtin look unbound. Fixing that exposed two further 3.2 defects behind it, including one chart assertion script that was reporting **PASS while asserting nothing**. Linux CI has bash 4+, so all of this was green there and only bit contributors locally. This PR makes every tracked script 3.2-compatible, using the forms the repo already adopted for this exact reason in `scripts/check-glibc-floor.sh` and `scripts/check-commit-messages.sh`.

**The vacuous pass.** Expanding an *empty* array under `set -u` is an "unbound variable" error until bash 4.4. `worker-ttl-bounds-assertions.sh` hit it on its very first assertion, which passes no `--set` at all — and in bash 3.2 an EXIT trap's own status replaces that of a `set -u` abort:

| case | exit |
| --- | --- |
| explicit `exit 1` + EXIT trap | 1 |
| `set -u` abort, no trap | 1 |
| `set -u` abort **+ EXIT trap** | **0** |

The `rm -rf "$TMP"` cleanup laundered the failure into success, so `chart-check` counted a script that made zero assertions as green. A deliberate `fail()` still propagates correctly, so no other assertion script is vacuous. What was reported as "1 of 22 failing" was really 21 real passes, 1 loud failure, and 1 vacuous pass.

**Reviewer notes.**

- The `declare -A` table becomes a `case` lookup. Because that lookup runs inside a command substitution — where a nonzero exit cannot abort the script the way the old `set -u` array miss did, and where one call site sits under `||`, suspending `set -e` for the whole function body — a startup loop proves the lookup is total over `KEYS`. Without it an unknown key would silently become an empty string and let the generation detector pass by accident. That guard is the one non-mechanical part of this change.
- The same empty-array defect reached two scripts outside the chart gate on paths that are the **common** case, not the edge case. `get-curie.sh` left `UPDATE_ARGS` empty on exactly the *first* run (no installed binary, so no `--update`) — the run the bootstrap exists for; a fresh Mac clone aborted before installing anything. `refresh-schema-baseline.sh` needs only one of its two lists non-empty to reach its apply loops, so the ordinary refresh (a schema edited, none deleted) copied the changed files and *then* aborted, leaving a half-applied baseline behind a bogus error.
- Five other empty-array expansions (`SUITES`, `commits`, `CONNECTORS`, `changed_files`, `bundles`) were deliberately left alone; each is already guarded by a preceding emptiness check that exits.
- Not addressed here, as it is a design change rather than a fix: the trap-laundering means any *future* `set -u` abort in a script with an EXIT trap will silently PASS on macOS. `chart-check` trusts exit status alone. Asserting each script printed its expected terminal `PASS` line would close that hole — happy to file a follow-up.

## Related issue

No existing issue — found while running `curie dev chart-check` locally on macOS. Can file one retroactively if you would like the record.

## End-to-end verification

Not behavior-bearing at runtime: every change is to contributor-side shell gates and the source-checkout bootstrap. No product code, chart template, rendered manifest, or container image is touched — the chart renders byte-identically, which the now-passing assertions themselves prove. Verification is therefore the gates' own output on bash 3.2.57, plus mutation tests proving the gates can still fail.

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | No skill, bundle, or runner turn-loop code touched | — | — |
| local | n/a | No compose service, dispatcher, worker, API wiring, or `curie` verb output/exit-code/JSON shape changed; the only Rust-adjacent surface is which shell the existing `dev` handlers invoke | — | — |
| local-release | n/a | No released-binary or image identity, version pin, or release compose change. `get-curie.sh` is the source-checkout bootstrap, verified directly below | — | — |
| cluster | n/a | No chart template, RBAC, securityContext, NetworkPolicy, sandbox claim, or init container changed. `charts/curie/ci/*.sh` are render-assertion gates over the chart, not chart inputs | — | — |
| live provider | n/a | No model or provider call path touched | — | — |
| external integration | n/a | No external integration touched | — | — |

Ran against commit `6f563aa0` on `/bin/bash` 3.2.57(1)-release (arm64-apple-darwin25) — i.e. the shell that reproduced the original failure:

```
curie dev chart-check
  -> ✓ all 23 chart assertion scripts passed
     (render-assertions.sh PASS; worker-ttl-bounds-assertions.sh now prints
      "all nine assertions passed" instead of exiting 0 in silence)
```

Before this change, on the same shell: `render-assertions.sh` failed at line 59, and `worker-ttl-bounds-assertions.sh` printed `line 148: sets[@]: unbound variable` yet was still counted `PASS`.

Falsifiable negatives — every mutation exits non-zero, so the assertions are live rather than vacuous:

```
drop a case arm from default_for()        -> exit 1, "FAIL: default_for() has no
                                            published default for key 'langfuseSalt'"
corrupt a published default (apiKey)      -> exit 1, "FAIL: dev overlay must keep the
                                            published default for 'apiKey'"
wrong expected env (CURIE_ROUTE_TTL=9999) -> exit 1, "FAIL [a] CURIE_ROUTE_TTL_SECONDS
                                            rendered '3600', expected '9999'"
```

Second independent path, per script changed outside the chart gate:

```
41 tracked *.sh                     -> /bin/bash -n clean, 0 failures
refresh-schema-baseline.sh          -> --check and no-op refresh both exit 0; the
                                       previously-aborting path (schema edited, none
                                       deleted) exercised via a reversible mutation:
                                       "schema baseline refreshed for 1 schema(s)",
                                       exit 0, git status cli/schema/ clean after
get-curie.sh                        -> both branches argv-checked: argc=1 on first run
                                       (no spurious empty arg), argc=2 with --update
e2e-ladder.sh assert_model_mode     -> truthiness matrix unchanged vs ${observed,,}:
                                       1/true/TRUE/True/yes/YES truthy;
                                       no/NO/0/"" not truthy
eval-falsifiability.sh discovery    -> read loop finds all 4 committed suites, exit 0
```

`e2e-ladder` and `eval-falsifiability` were verified at the changed-function level rather than by a full ladder run, since the full rungs need cargo builds and a live stack and neither change alters what those rungs assert — flagging that scoping explicitly rather than implying a full run.

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.
- [x] Or: this change is not behavior-bearing, so no tier applies, and the summary says why.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed. (No behavior change; the *why* is captured as comments at each fix site, matching the existing bash-3.2 comments in `scripts/check-glibc-floor.sh` and `scripts/check-commit-messages.sh`.)
- [x] An ADR is added under `docs/adr/` if this is an architectural decision. (Not one — a portability fix restoring the intended behavior of existing gates, no decision changed.)
