### PR TITLE
Unblock chart-runtime-e2e on macOS and expose its --force flag

### DIFF
--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -4000,6 +4000,20 @@ export const commandManifest = {
         },
         {
           "about": "Runtime E2E the Helm chart on a local cluster: install a trimmed slice, seed a bundle into RustFS, run the sandbox bundle-fetch init pair, and exec-assert the runner's view -- the one-command way to satisfy a chart/sandbox runtime acceptance criterion static checks cannot (#199, `bash scripts/chart-runtime-e2e.sh`)",
+          "args": [
+            {
+              "global": false,
+              "help": "Allow running against a kube context other than `k8scratch`",
+              "id": "force",
+              "long": "force",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            }
+          ],
           "hidden": false,
           "name": "chart-runtime-e2e"
         },

--- a/charts/curie/CLAUDE.md
+++ b/charts/curie/CLAUDE.md
@@ -115,10 +115,17 @@ Runtime check (the cheap default for a chart/sandbox/bundle change): installs a
 trimmed slice, runs the bundle-fetch init pair, and exec-asserts on the runner:
 ```bash
 curie dev chart-runtime-e2e            # implemented by scripts/chart-runtime-e2e.sh
+curie dev chart-runtime-e2e --force    # same, on a scratch context not named k8scratch
 ```
 A ticket whose AC is a runtime check (like #56, the bundle-fetch credential
 isolation) is only satisfied by running this and pasting its output -- lint /
 template do not exercise the init container or the live runner.
+
+It refuses any kube context not named `k8scratch`, because it installs and
+uninstalls a real release; `--force` is the override, and points at a disposable
+cluster only. The other script flags (`--namespace`, `--release`, `--chart`,
+`--runner-image`, `--expect-vulnerable`, `--keep`) are not yet exposed through
+`curie dev`; reach them with `bash scripts/chart-runtime-e2e.sh --help`.
 
 Cluster verification (a disposable local cluster, `kind` or `k3s`):
 ```bash

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -3997,6 +3997,20 @@
         },
         {
           "about": "Runtime E2E the Helm chart on a local cluster: install a trimmed slice, seed a bundle into RustFS, run the sandbox bundle-fetch init pair, and exec-assert the runner's view -- the one-command way to satisfy a chart/sandbox runtime acceptance criterion static checks cannot (#199, `bash scripts/chart-runtime-e2e.sh`)",
+          "args": [
+            {
+              "global": false,
+              "help": "Allow running against a kube context other than `k8scratch`",
+              "id": "force",
+              "long": "force",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            }
+          ],
           "hidden": false,
           "name": "chart-runtime-e2e"
         },

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -610,7 +610,16 @@ enum DevAction {
     /// exec-assert the runner's view -- the one-command way to satisfy a
     /// chart/sandbox runtime acceptance criterion static checks cannot (#199,
     /// `bash scripts/chart-runtime-e2e.sh`).
-    ChartRuntimeE2e,
+    ChartRuntimeE2e {
+        /// Allow running against a kube context other than `k8scratch`.
+        ///
+        /// The script refuses a non-`k8scratch` context and names `--force` as
+        /// the override. Without this passthrough that override was unreachable
+        /// from the `curie` surface, so a contributor whose scratch context has
+        /// another name could not run this gate the documented way at all.
+        #[arg(long)]
+        force: bool,
+    },
     /// Lint the interface catalog docs (`bash scripts/check-docs.sh`).
     DocsLint,
     /// Validate every `examples/` bundle against Claude Code (`bash scripts/check-plugin-compat.sh`).
@@ -2124,8 +2133,9 @@ async fn run(command: Option<Command>) -> Result<()> {
             } => {
                 commands::dev_e2e_ci_selection(&path, base.as_deref(), head.as_deref(), push).await
             }
-            DevAction::ChartRuntimeE2e => {
-                commands::dev_script("scripts/chart-runtime-e2e.sh", &[]).await
+            DevAction::ChartRuntimeE2e { force } => {
+                let args: &[&str] = if force { &["--force"] } else { &[] };
+                commands::dev_script("scripts/chart-runtime-e2e.sh", args).await
             }
             DevAction::DocsLint => commands::dev_script("scripts/check-docs.sh", &[]).await,
             DevAction::PluginCompat => {
@@ -4121,7 +4131,18 @@ mod tests {
         assert!(matches!(
             cli.command,
             Some(Command::Dev {
-                action: DevAction::ChartRuntimeE2e
+                action: DevAction::ChartRuntimeE2e { force: false }
+            })
+        ));
+        // The script's context guard names `--force` as its only override, so the
+        // flag has to survive the `curie dev` hop or the guard is unoverridable
+        // through the documented entry point.
+        let cli = Cli::try_parse_from(["curie", "dev", "chart-runtime-e2e", "--force"])
+            .expect("dev chart-runtime-e2e --force should parse");
+        assert!(matches!(
+            cli.command,
+            Some(Command::Dev {
+                action: DevAction::ChartRuntimeE2e { force: true }
             })
         ));
     }

--- a/scripts/chart-runtime-e2e.sh
+++ b/scripts/chart-runtime-e2e.sh
@@ -567,7 +567,13 @@ cat > "$SEED_DIR/myplugin/.claude-plugin/plugin.json" <<'JSON'
 {"name":"e2e-probe","version":"0.0.0"}
 JSON
 tar -czf "$SEED_DIR/probe.tgz" -C "$SEED_DIR" myplugin
-PROBE_B64="$(base64 -w0 "$SEED_DIR/probe.tgz" 2>/dev/null || base64 "$SEED_DIR/probe.tgz" | tr -d '\n')"
+# `base64 < file | tr -d '\n'` rather than GNU's `base64 -w0 file`: BSD base64
+# (macOS) rejects both the `-w` flag and a bare filename operand -- it wants
+# `-i file` -- so the previous `-w0` form fell through to a fallback that failed
+# just as hard with `base64: invalid argument <path>`, blocking this script on a
+# Mac at the seed step. Reading from stdin and stripping newlines here is the
+# form both userlands accept, and `binaryData` below needs the single line.
+PROBE_B64="$(base64 < "$SEED_DIR/probe.tgz" | tr -d '\n')"
 
 # ConfigMap carrying the archive plus a one shot AWS CLI Job that creates the
 # bucket and uploads the object using path addressing.


### PR DESCRIPTION
## Summary

Two macOS gaps in the `curie dev` surface that #1807 (`6f563aa0`, "Restore the shell gates on macOS bash 3.2") did not reach. `scripts/chart-runtime-e2e.sh` seeded the RustFS bundle with `base64 -w0 "$file"`; BSD base64 rejects both the `-w` flag and a bare filename operand — it wants `-i file` — and the existing `||` fallback repeated the same filename form, so both arms failed and the harness died at the SEED step with `base64: invalid argument <path>`. `base64 < "$file" | tr -d '\n'` is accepted by both userlands and still yields the single line `binaryData` needs. Separately, `curie dev chart-runtime-e2e` swallowed the script's `--force` flag, so the context guard named an override that was unreachable through the documented entry point — a contributor whose scratch context isn't called `k8scratch` could not run this gate the `curie` way at all, which inverts the one-entry-point rule in CLAUDE.md.

## Related issue

None — reported directly from a `curie dev` run on a Mac, no issue was filed. Follows on from #1807, which fixed the bash 3.2 constructs in the chart-check and ladder gates but did not touch `chart-runtime-e2e.sh` or the CLI wrapper.

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | No plugin/skill packaging, runner turn loop, ACI event, or skill eval surface is touched. | — | — |
| local | n/a | No compose service, dispatcher, worker, or API wiring, and no boot env crossing a service boundary. The one `curie` verb that changed is `dev chart-runtime-e2e`, a contributor-only script wrapper that `e2e-ladder` does not exercise; it is proved directly below instead. | fake | See "Direct verification" — the `--force` rows. |
| local-release | n/a | No released binary or image identity, install path, version pin, or release compose change. | — | — |
| cluster | **blocked** | `chart-runtime-e2e.sh` is itself the cluster-tier harness, and running it needs a k8scratch cluster this machine does not have. **Blocker: no cluster available.** No chart template, RBAC, securityContext, NetworkPolicy, sandbox claim, or init container changed — the diff touches only the harness's own seed step — and `curie dev chart-check` (23/23 PASS) confirms the rendered chart is unaffected. | fake | `curie dev chart-check` @ `207c0959` → `✓ all 23 chart assertion scripts passed` |
| live provider | n/a | No model routing, credential resolution, provider auth, or token/cost accounting. | — | — |
| external integration | n/a | No Slack, webhook, connector OAuth, or third-party API shape. | — | — |

### Direct verification

Run on macOS 15 / bash 3.2.57 (arm64) against `207c0959`. Each criterion has a positive and a falsifiable negative.

**base64 produces the exact bytes the ConfigMap needs**

- Positive: output is byte-identical to `base64.b64encode` of the same file, single line, 744 chars, and round-trips through `base64 -D` to a tar that `tar -tzf` lists clean.
- Negative: the previous form still fails on BSD — `base64 -w0 /tmp/p 2>/dev/null || base64 /tmp/p` → `base64: invalid argument /tmp/p`. This is the pre-fix failure reproduced, confirming the fallback arm was never a fallback on macOS.

**`--force` reaches the script's context guard**

- Positive: with an empty kubeconfig, `curie dev chart-runtime-e2e --force` proceeds past the guard to `== PRECHECK context= namespace=curie-e2eharness release=e2eharness ==`, failing later only on the absent cluster. `--help` advertises the flag.
- Negative: the same command without `--force` refuses — `FAIL: kube context is '', not 'k8scratch'. Refusing (override with --force).`, exit 1. Dropping the flag restores the old behavior, so the passthrough is what changed.

**No regression elsewhere**

- `curie dev chart-check` → 23/23 PASS.
- cli `cargo test` → 824 lib tests + 2 dev-parse tests pass; `cargo fmt --check` clean; no new clippy warnings (the 9 `MutexGuard` warnings are pre-existing, confirmed against a clean tree).

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [ ] No required tier is left unproved; any blocked tier names its blocker in the table. — **cluster is blocked on cluster availability and says so.** A reviewer with a k8scratch cluster should run `curie dev chart-runtime-e2e` and confirm the SEED step and everything after it.
- [ ] Or: this change is not behavior-bearing, so no tier applies, and the summary says why.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed.
- [ ] An ADR is added under `docs/adr/` if this is an architectural decision. — n/a, no architectural decision: a BSD-portable expression and a flag passthrough on an existing verb.

## Notes for the reviewer

While sweeping I also checked every tracked `*.sh` — wider than the three script directories, since #1807 showed this defect class reaches `get-curie.sh` at the repo root — for `declare -A`, `mapfile`, `readarray`, `${var,,}`, `${var^^}`, `sed -i` without a backup suffix, `date -d`, `stat -c`, `readlink -f`, `grep -P`, `base64 -w`, negative array indices, namerefs, and `wait -n`. No hits remain. Every empty-array `[@]` expansion left in the tree is reached only after an emptiness check that exits — including `verify-fix-pin.sh`, whose `include_args` is transitively non-empty because `product_files` is guarded at line 101. I had guarded that one before spotting the guard, and dropped the change rather than leave dead defensive code.

Two things worth considering separately, not done here:

1. **Nothing stops this from regressing.** CI is Linux-only by construction, so the next `declare -A` or `base64 -w0` lands green. A `shellcheck --shell=bash` job, or a macOS runner for the script gates, would make #1807 and this PR durable rather than a pair of one-time cleanups.
2. **The remaining `chart-runtime-e2e` flags.** `--namespace`, `--release`, `--chart`, `--runner-image`, `--expect-vulnerable`, and `--keep` are still unreachable through `curie dev`. I exposed only `--force` because that is the one a guard actively points at; the rest are documented as a `bash scripts/...` escape hatch, which is a compromise with the one-entry-point rule and may deserve its own pass.
