### PR TITLE
Let chart-runtime-e2e reach its assertions, and twice in a row

### DIFF
--- a/scripts/chart-runtime-e2e.sh
+++ b/scripts/chart-runtime-e2e.sh
@@ -158,6 +158,7 @@ teardown() {
     return $rc
   fi
   banner "TEARDOWN"
+  [[ -n "${JSON_DIR:-}" ]] && rm -rf "$JSON_DIR"
   helm uninstall "$RELEASE" -n "$NAMESPACE" --no-hooks >/dev/null 2>&1 || true
   kubectl delete priorityclass \
     "$PLATFORM_PRIORITY_CLASS" "$SANDBOX_PRIORITY_CLASS" \
@@ -234,10 +235,30 @@ def bind_ref(container):
             e["name"] = "CURIE_BUNDLE_REF"
             e["value"] = bundle_ref
 
+# The runner reads CURIE_PLUGIN_DIR, which the SandboxTemplate bakes as
+# `/unused` for an unbound warm pod (the worker overrides it per claim). Binding
+# only CURIE_BUNDLE_REF therefore fetched and extracted the bundle into
+# /bundles/current -- both init logs proved it -- and then booted the runner
+# pointed at `/unused`, where it exits 1 on PluginBundleError one second later.
+# The wait loop reported that as "did not reach (init Completed + runner
+# Running) within 180s", which reads like a slow node, so the assertion below
+# could never pass. Point the runner at the extracted bundle too.
+def bind_plugin_dir(container, mount="/bundles/current"):
+    env = container.setdefault("env", [])
+    for e in env:
+        if e.get("name") == "CURIE_PLUGIN_DIR":
+            e.clear()
+            e["name"] = "CURIE_PLUGIN_DIR"
+            e["value"] = mount
+            return
+    env.append({"name": "CURIE_PLUGIN_DIR", "value": mount})
+
 for c in spec.get("initContainers", []):
     bind_ref(c)
 for c in spec.get("containers", []):
     bind_ref(c)
+    if c.get("name") == "runner":
+        bind_plugin_dir(c)
 
 # Use the default ServiceAccount (avoids a missing-SA scheduling failure).
 spec.pop("serviceAccountName", None)
@@ -307,6 +328,14 @@ print("yes" if (init_ok and runner_running) else "no")
       kubectl logs "$POD_NAME" -n "$NAMESPACE" -c bundle-fetch || true
       echo "--- bundle-extract logs"
       kubectl logs "$POD_NAME" -n "$NAMESPACE" -c bundle-extract || true
+      # The runner's own logs, which this block used to omit. When the runner is
+      # the container that failed -- the common case, since the init pair either
+      # completes or fails loudly -- its log is the only place the real reason
+      # appears, and without it the timeout above is the entire diagnosis.
+      echo "--- runner logs"
+      kubectl logs "$POD_NAME" -n "$NAMESPACE" -c runner 2>/dev/null \
+        || kubectl logs "$POD_NAME" -n "$NAMESPACE" -c runner --previous 2>/dev/null \
+        || true
       fail "bound sandbox did not reach (init Completed + runner Running) within ${timeout}s"
     fi
     sleep "$interval"
@@ -651,9 +680,18 @@ if [[ -n "$RUNNER_IMAGE" ]]; then
 else
   echo "runner image: real (from SandboxTemplate)"
 fi
-TEMPLATE_JSON="$(mktemp /tmp/e2e-sandboxtemplate.XXXXXX.json)"
+# One temp DIRECTORY rather than two temp files whose templates carry a suffix
+# after the X's. BSD mktemp only substitutes X's at the END of the template, so
+# `mktemp /tmp/e2e-sandboxtemplate.XXXXXX.json` on macOS creates a file named
+# literally `e2e-sandboxtemplate.XXXXXX.json`: no randomization, a predictable
+# /tmp path, and a second run of this script fails for the life of the machine
+# with `mkstemp failed ...: File exists`. `mktemp -d` with the X's last is
+# portable, keeps the .json names the kubectl calls below read better with, and
+# gives teardown one thing to remove.
+JSON_DIR="$(mktemp -d /tmp/e2e-json.XXXXXX)"
+TEMPLATE_JSON="$JSON_DIR/sandboxtemplate.json"
 kubectl get sandboxtemplate "$SANDBOX_TEMPLATE" -n "$NAMESPACE" -o json > "$TEMPLATE_JSON"
-POD_JSON="$(mktemp /tmp/e2e-bound-pod.XXXXXX.json)"
+POD_JSON="$JSON_DIR/bound-pod.json"
 build_bound_pod "$TEMPLATE_JSON" > "$POD_JSON"
 kubectl apply -n "$NAMESPACE" -f "$POD_JSON"
 


### PR DESCRIPTION
Follows #1808, which unblocked the bundle-seeding step of this gate on macOS.
Running it after that merge surfaced three more problems, each of which alone
stops the script before it asserts anything. All three are in
`scripts/chart-runtime-e2e.sh`; no product code changes.

## 1. The runner never received `CURIE_PLUGIN_DIR`

The binding step replaced `CURIE_BUNDLE_REF` wherever a container declared it,
and nothing else. So the init pair did its job perfectly and the harness printed
proof:

```
download: s3://curie-bundles/e2e/probe.tgz to ../bundles/.bundle-archive
extracted bundle 'e2e/probe.tgz' into /bundles/current
```

and then the runner booted with the SandboxTemplate's baked
`CURIE_PLUGIN_DIR=/unused` and exited 1 one second later:

```
runner:
  State:      Terminated
    Reason:   Error
    Exit Code: 1
    Started:  22:19:26
    Finished: 22:19:27
  Environment:
    CURIE_PLUGIN_DIR:   /unused
```

**The bundle is in `/bundles/current` and the runner is told to look at
`/unused`.** `/unused` is correct for an unbound warm pod, which is what the
template renders; the worker overrides it per claim, and this harness builds its
"bound" pod by hand and did not. So the #56 assertions were not failing, they
were unreachable.

## 2. The diagnostics block omitted the runner's own logs

On timeout it printed a `describe` plus `bundle-fetch` and `bundle-extract` logs
-- the two containers least likely to be at fault, since the init pair either
completes or fails loudly. When the runner is the one that failed, its log is the
only place the reason appears.

Without it the whole diagnosis was:

```
FAIL: bound sandbox did not reach (init Completed + runner Running) within 180s
```

which reads like a slow node. That is how problem 1 stayed invisible; finding it
needed a `kubectl describe` by hand. The runner's logs are now printed too.

## 3. Two `mktemp` templates carried a suffix after the X's

```
mktemp: mkstemp failed on /tmp/e2e-bound-pod.XXXXXX.json: File exists
```

BSD `mktemp` only substitutes X's at the **end** of a template. On macOS,
`mktemp /tmp/e2e-sandboxtemplate.XXXXXX.json` therefore creates a file named
literally `e2e-sandboxtemplate.XXXXXX.json`. Three consequences: no
randomization, a predictable `/tmp` path, and **every run after the first fails
for the life of the machine** until someone deletes the stale file by hand.
Confirmed directly:

```
$ mktemp /tmp/probe-mktemp.XXXXXX.json
created: /tmp/probe-mktemp.XXXXXX.json      # not randomized
```

Replaced with a single `mktemp -d` whose X's are last, holding both `.json`
files, removed in teardown. The three other `mktemp` calls in the script already
have their X's last and were fine.

## Verification

Fresh 4-cpu cluster, `curie dev chart-runtime-e2e --force`, run twice in a row:

```
########## RUN 1 ##########
PASS: API Service NodePort and runtime security assertions
RUN1_EXIT=0
########## RUN 2 (the mktemp regression) ##########
PASS: API Service NodePort and runtime security assertions
RUN2_EXIT=0
```

Both reach the assertions, including the runtime security checks, and the second
run is the one that used to be impossible. `bash -n` clean.

## Two preconditions worth knowing, not changed here

- This gate cannot run on a cluster that already has a Curie release: the
  `e2eharness` release collides on the cluster-scoped PriorityClass with
  `annotation "meta.helm.sh/release-name" must equal "e2eharness": current value
  is "curie"`, surfacing after two install attempts rather than as an up-front
  precondition check.
- Problem 1 is the same coupling that
  [ADR-0116](https://github.com/curie-eng/curie/pull/1804) is about: a sandbox's
  capability is decided by pod environment, so a caller that forgets one variable
  gets a booted, useless runner. That ADR now cites this harness as an
  independent reproduction, since nobody here was testing for it.
