### PR TITLE
Hoist the accepted model-credential list to one const

### DIFF
--- a/cli/src/interactive.rs
+++ b/cli/src/interactive.rs
@@ -34,6 +34,16 @@ use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 use crate::channel::{parse_terminal_message, TerminalAction, REPLY_FENCE};
 use crate::recipes::{build_argv, recipes, ArgPart, Recipe, RecipeKind, Tier, TuiAction, Workflow};
 
+/// The model credentials Curie accepts, in the order every lookup tries them.
+///
+/// One list so the workflow, the status readout, and the availability checks
+/// cannot drift apart.
+const MODEL_CREDENTIAL_NAMES: &[&str] = &[
+    "CURIE_CREDENTIALS",
+    "ANTHROPIC_API_KEY",
+    "CLAUDE_CODE_OAUTH_TOKEN",
+];
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 enum SecretNameChoice {
     Name(String),
@@ -977,11 +987,7 @@ fn env_credential_present(name: &str) -> bool {
 /// credential here (it lives on the chart Secret) but forwarding it is harmless.
 fn slack_secret_env() -> Result<Vec<(String, String)>> {
     let mut env = Vec::new();
-    for name in [
-        "CURIE_CREDENTIALS",
-        "ANTHROPIC_API_KEY",
-        "CLAUDE_CODE_OAUTH_TOKEN",
-    ] {
+    for name in MODEL_CREDENTIAL_NAMES.iter().copied() {
         if env_credential_present(name) {
             break;
         }
@@ -1111,19 +1117,11 @@ fn prompt_bundle_dir(
 
 fn example_secret_env(extra_secrets: &[&str]) -> Result<Vec<(String, String)>> {
     let mut env = Vec::new();
-    if ![
-        "CURIE_CREDENTIALS",
-        "ANTHROPIC_API_KEY",
-        "CLAUDE_CODE_OAUTH_TOKEN",
-    ]
-    .iter()
-    .any(|name| env_credential_present(name))
+    if !MODEL_CREDENTIAL_NAMES
+        .iter()
+        .any(|name| env_credential_present(name))
     {
-        for name in [
-            "CURIE_CREDENTIALS",
-            "ANTHROPIC_API_KEY",
-            "CLAUDE_CODE_OAUTH_TOKEN",
-        ] {
+        for name in MODEL_CREDENTIAL_NAMES.iter().copied() {
             if let Some(value) = crate::secrets::get_value(name)? {
                 env.push((name.to_string(), value));
                 break;
@@ -1178,12 +1176,7 @@ fn secret_available(name: &str) -> bool {
 
 /// Any accepted model credential, by the same rule `ensure_model_credential_available` uses.
 fn model_credential_available() -> bool {
-    const NAMES: &[&str] = &[
-        "CURIE_CREDENTIALS",
-        "ANTHROPIC_API_KEY",
-        "CLAUDE_CODE_OAUTH_TOKEN",
-    ];
-    NAMES.iter().any(|n| secret_available(n))
+    MODEL_CREDENTIAL_NAMES.iter().any(|n| secret_available(n))
 }
 
 /// What the workflow will actually ask for, given what is already in place.
@@ -1327,22 +1320,17 @@ fn ensure_model_credential_available(
     const RECOVERY: &str =
         "A model credential is required. `CURIE_MODEL_BASE_URL` selects the endpoint. Use \
         `curie secrets set <NAME>` or `export <NAME>=...`, then retry";
-    const NAMES: &[&str] = &[
-        "CURIE_CREDENTIALS",
-        "ANTHROPIC_API_KEY",
-        "CLAUDE_CODE_OAUTH_TOKEN",
-    ];
-    for name in NAMES {
+    for name in MODEL_CREDENTIAL_NAMES {
         if env_credential_present(name) {
             return Ok(());
         }
     }
-    for name in NAMES {
+    for name in MODEL_CREDENTIAL_NAMES {
         if crate::secrets::is_saved(name)? {
             return Ok(());
         }
     }
-    let legacy_names = NAMES
+    let legacy_names = MODEL_CREDENTIAL_NAMES
         .iter()
         .filter_map(|name| {
             crate::secrets::needs_vault_upgrade(name)
@@ -1357,7 +1345,7 @@ fn ensure_model_credential_available(
         }
     }
 
-    let choices = NAMES
+    let choices = MODEL_CREDENTIAL_NAMES
         .iter()
         .map(|name| SelectChoice {
             label: (*name).to_string(),
@@ -1391,11 +1379,7 @@ fn model_credential_status(
     saved_names: &BTreeSet<String>,
     legacy_names: &BTreeSet<String>,
 ) -> &'static str {
-    for name in [
-        "CURIE_CREDENTIALS",
-        "ANTHROPIC_API_KEY",
-        "CLAUDE_CODE_OAUTH_TOKEN",
-    ] {
+    for name in MODEL_CREDENTIAL_NAMES.iter().copied() {
         if env_credential_present(name) || saved_names.contains(name) {
             return "available";
         }


### PR DESCRIPTION
The three accepted model credentials — `CURIE_CREDENTIALS`, `ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN`, in lookup order — were written out verbatim at six sites in `cli/src/interactive.rs` (two of them behind a function-local `NAMES` const). This declares one module-level `MODEL_CREDENTIAL_NAMES` and references it from all six, so the Slack workflow env, the example env, the availability check, the ensure-gate, and the status readout cannot drift apart.

Strictly behavior-preserving: a literal hoist. No control flow moves, no signature changes, iteration order preserved at every site. The `for name in [...]` sites use `.iter().copied()` so the loop binding stays `&str` rather than `&&str`.

Deliberately out of scope: the `(name, description)` tuple list in `secret_name_choices_for` — a different shape (prompt copy over a wider set including `OPENAI_API_KEY` and `GITHUB_PERSONAL_ACCESS_TOKEN`).

**Tier exemption.** Per AGENTS.md "The tier decision rule", this is a strictly behavior-preserving refactor, so it records that reason once and is exempt from the six-tier E2E ladder.

**Base branch:** `main`. `cli/src/interactive.rs` is byte-identical on `origin/main` and `origin/next`, so this is code shared by both lines and bases on `main`.

### Validation
- `cargo fmt --check` — clean
- `cargo test interactive` — 32 passed, 0 failed
- `cargo test` (debug) — 1415 passed, 0 failed
- `cargo clippy --all-targets -- -D warnings` — exits 101, but **identically on the unmodified base** (verified by stashing and re-running): 9 `await_holding_lock` errors in `installation.rs` / `local.rs`, neither touched here. Local clippy 1.95 is newer than CI's.
- `git diff --stat origin/main...HEAD` — `cli/src/interactive.rs` only; no generated artifact.