### PR TITLE
Prepare v0.7.1 release

### DIFF
--- a/charts/curie/Chart.yaml
+++ b/charts/curie/Chart.yaml
@@ -8,8 +8,8 @@ description: >-
   and two install-time preflights ship baked in: a CPU-AVX / ClickHouse-pin
   check and a NetworkPolicy-enforcement probe.
 type: application
-version: 0.7.0
-appVersion: "0.7.0"
+version: 0.7.1
+appVersion: "0.7.1"
 kubeVersion: ">=1.25.0-0"
 maintainers:
   - name: Curie

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -749,7 +749,7 @@ dependencies = [
 
 [[package]]
 name = "curie"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anstream",
  "anstyle",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "curie"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 description = "Curie CLI: init/start/send/eval a plugin against a local runner (task I1)"
 


### PR DESCRIPTION
## Summary

Prepares the v0.7.1 bugfix release by aligning the CLI package and Helm chart release-coupled versions and refreshing the CLI lockfile. This is release packaging metadata; it changes no product runtime behavior.

## Related issue

Release preparation for v0.7.1.

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | Version metadata does not reach skill packaging or the runner loop. | n/a | n/a |
| local | n/a | No compose-service, local CLI behavior, or API wiring changes. | n/a | n/a |
| local-release | required | The generated release compose and released CLI/chart identity must carry v0.7.1. | fake | Candidate-bound ladder will run after this PR merges. |
| cluster | n/a | No chart template, RBAC, sandbox, or runtime-cluster behavior changes. | n/a | n/a |
| live provider | n/a | No provider routing, credential, or model behavior changes. | n/a | n/a |
| external integration | n/a | No external API or OAuth behavior changes. | n/a | n/a |

- [ ] Candidate-bound local-release evidence is collected after merge, before the release tag.
- [x] This change has no product runtime behavior beyond release identity and packaging.

## Checklist

- [x] `scripts/check-version-consistency.sh` passed.
- [x] `cargo fmt --check` passed.
- [x] `cargo test --test json_contract bump_version_output_validates` passed.