### PR TITLE
Remove unused approval decision helper

### DIFF
--- a/apps/dispatcher/src/curie_dispatcher/approval_actions.py
+++ b/apps/dispatcher/src/curie_dispatcher/approval_actions.py
@@ -116,12 +116,6 @@ def is_approval_action(action_id: str) -> bool:
     return action_id in _APPROVAL_ACTION_IDS
 
 
-def decision_for_action(action_id: str) -> str | None:
-    """The decision an approval action id resolves to, or None if it is not one."""
-
-    return _DECISION_BY_ACTION_ID.get(action_id)
-
-
 @dataclass(frozen=True)
 class ResolveOutcome:
     """The API's verdict on one resolution attempt, normalized for rendering."""


### PR DESCRIPTION
## Summary
- Delete the uncalled `decision_for_action` helper from dispatcher approval actions.
- Retain `_DECISION_BY_ACTION_ID` and `is_approval_action`.

## Validation
- `uv run ruff check apps/dispatcher/src/curie_dispatcher/approval_actions.py`
- `uv run mypy`
- `uv run pytest -q apps/dispatcher/tests/test_approval_actions.py apps/dispatcher/tests/test_approval_note_dialog.py` (8 passed, 32 skipped)

## Tier decision
Strictly behavior-preserving refactor: this removes a module-local helper with no callers, so it reaches no runtime surface. All six E2E tiers are not applicable under the AGENTS.md tier-decision-rule exemption for a strictly behavior-preserving refactor.