### PR TITLE
Deduplicate declared server extraction

### DIFF
--- a/runner/src/curie_runner/check.py
+++ b/runner/src/curie_runner/check.py
@@ -138,31 +138,37 @@ def extract_declared(plugin_dir: str) -> list[dict[str, Any]]:
             )
             seen.add(name)
 
+    def _add_server(name: str, source: str, form: str, server: Any) -> None:
+        _add(
+            name,
+            source,
+            form,
+            _is_authed(server),
+            _cred_vars(server),
+            _is_remote(server),
+        )
+
     manifest_path = resolve_manifest(root)
     manifest = _read_json(manifest_path) if manifest_path is not None else None
     mcp = manifest.get("mcpServers") if isinstance(manifest, dict) else None
 
     if isinstance(mcp, dict):
         for name, server in mcp.items():
-            _add(
+            _add_server(
                 str(name),
                 "plugin.json",
                 "inline",
-                _is_authed(server),
-                _cred_vars(server),
-                _is_remote(server),
+                server,
             )
     elif isinstance(mcp, str):
         pointed = _servers_map(_read_json(root / mcp))
         if pointed:
             for name, server in pointed.items():
-                _add(
+                _add_server(
                     str(name),
                     "plugin.json",
                     "string_pointer",
-                    _is_authed(server),
-                    _cred_vars(server),
-                    _is_remote(server),
+                    server,
                 )
         else:
             # Pointed file missing/unparseable: the intent (a string-pointer
@@ -174,13 +180,11 @@ def extract_declared(plugin_dir: str) -> list[dict[str, Any]]:
 
     bare = _servers_map(_read_json(root / ".mcp.json"))
     for name, server in bare.items():
-        _add(
+        _add_server(
             str(name),
             ".mcp.json",
             "bare_file",
-            _is_authed(server),
-            _cred_vars(server),
-            _is_remote(server),
+            server,
         )
 
     return declared


### PR DESCRIPTION
## Summary
- extract server-backed declaration insertion into local `_add_server`
- preserve the direct `_add` fallback when no server object is available

## Verification
- `uv run ruff check runner/src/curie_runner/check.py`
- `uv run mypy`
- `uv run pytest -q runner/tests/test_check.py`
- `git diff --stat origin/main...HEAD` (one changed file)

## Tier decision
This is a strictly behavior-preserving refactor: `extract_declared` retains its signature, emitted records retain identical field values and insertion order, and each server-backed branch still calls the three derivation helpers once. Per AGENTS.md tier decision rule, it records this reason once and is exempt from all six E2E ladder tiers.