### PR TITLE
Reject escaped newlines in PR bodies

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,10 +5,6 @@ on:
     branches: [main, next]
   pull_request:
     branches: [main, next]
-    # A PR body can be edited without a new commit. Re-run the literal-newline
-    # guard on that event so a formerly valid closing keyword cannot become
-    # inert after the rest of CI has already passed.
-    types: [opened, synchronize, reopened, edited]
 
 # Supersede an in-flight run when a branch is pushed again so runs stop
 # stacking. Keyed per workflow+ref: each PR branch and main have independent
@@ -21,41 +17,6 @@ permissions:
   contents: read
 
 jobs:
-  pr-body:
-    name: PR body (real newlines)
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          persist-credentials: false
-      # Keep untrusted PR text out of shell source. github-script reads the
-      # payload directly and writes its bytes to a runner-owned temporary file.
-      - name: Write the pull request body to a temporary file
-        uses: actions/github-script@v8
-        env:
-          PR_BODY_FILE: ${{ runner.temp }}/curie-pr-body.md
-        with:
-          script: |
-            const fs = require("node:fs");
-            const body = context.payload.pull_request?.body ?? "";
-            if (typeof body !== "string") {
-              core.setFailed("pull request body must be a string or null");
-              return;
-            }
-            fs.writeFileSync(process.env.PR_BODY_FILE, body, { encoding: "utf8", mode: 0o600 });
-      # Prove both branches of the matcher can still be reached before trusting
-      # its verdict against the event payload.
-      - name: PR body guard self-test
-        run: bash scripts/check-pr-body.sh --self-test
-      - name: Reject literal newline escapes in the pull request body
-        env:
-          PR_BODY_FILE: ${{ runner.temp }}/curie-pr-body.md
-        run: |
-          set -euo pipefail
-          trap 'rm -f -- "$PR_BODY_FILE"' EXIT
-          bash scripts/check-pr-body.sh "$PR_BODY_FILE"
-
   python:
     name: Python (ruff + mypy + pytest)
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,10 @@ on:
     branches: [main, next]
   pull_request:
     branches: [main, next]
+    # A PR body can be edited without a new commit. Re-run the literal-newline
+    # guard on that event so a formerly valid closing keyword cannot become
+    # inert after the rest of CI has already passed.
+    types: [opened, synchronize, reopened, edited]
 
 # Supersede an in-flight run when a branch is pushed again so runs stop
 # stacking. Keyed per workflow+ref: each PR branch and main have independent
@@ -17,6 +21,41 @@ permissions:
   contents: read
 
 jobs:
+  pr-body:
+    name: PR body (real newlines)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      # Keep untrusted PR text out of shell source. github-script reads the
+      # payload directly and writes its bytes to a runner-owned temporary file.
+      - name: Write the pull request body to a temporary file
+        uses: actions/github-script@v8
+        env:
+          PR_BODY_FILE: ${{ runner.temp }}/curie-pr-body.md
+        with:
+          script: |
+            const fs = require("node:fs");
+            const body = context.payload.pull_request?.body ?? "";
+            if (typeof body !== "string") {
+              core.setFailed("pull request body must be a string or null");
+              return;
+            }
+            fs.writeFileSync(process.env.PR_BODY_FILE, body, { encoding: "utf8", mode: 0o600 });
+      # Prove both branches of the matcher can still be reached before trusting
+      # its verdict against the event payload.
+      - name: PR body guard self-test
+        run: bash scripts/check-pr-body.sh --self-test
+      - name: Reject literal newline escapes in the pull request body
+        env:
+          PR_BODY_FILE: ${{ runner.temp }}/curie-pr-body.md
+        run: |
+          set -euo pipefail
+          trap 'rm -f -- "$PR_BODY_FILE"' EXIT
+          bash scripts/check-pr-body.sh "$PR_BODY_FILE"
+
   python:
     name: Python (ruff + mypy + pytest)
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-body.yaml
+++ b/.github/workflows/pr-body.yaml
@@ -19,7 +19,6 @@ jobs:
   pr-body:
     name: PR body (real newlines)
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/pr-body.yaml
+++ b/.github/workflows/pr-body.yaml
@@ -1,0 +1,52 @@
+name: PR body guard
+
+on:
+  pull_request:
+    branches: [main, next]
+    # A PR body can be edited without a new commit. Re-run the literal-newline
+    # guard on that event so a formerly valid closing keyword cannot become
+    # inert after the rest of CI has already passed.
+    types: [opened, synchronize, reopened, edited]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  pr-body:
+    name: PR body (real newlines)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      # Keep untrusted PR text out of shell source. github-script reads the
+      # payload directly and writes its bytes to a runner-owned temporary file.
+      - name: Write the pull request body to a temporary file
+        uses: actions/github-script@v8
+        env:
+          PR_BODY_FILE: ${{ runner.temp }}/curie-pr-body.md
+        with:
+          script: |
+            const fs = require("node:fs");
+            const body = context.payload.pull_request?.body ?? "";
+            if (typeof body !== "string") {
+              core.setFailed("pull request body must be a string or null");
+              return;
+            }
+            fs.writeFileSync(process.env.PR_BODY_FILE, body, { encoding: "utf8", mode: 0o600 });
+      # Prove both branches of the matcher can still be reached before trusting
+      # its verdict against the event payload.
+      - name: PR body guard self-test
+        run: bash scripts/check-pr-body.sh --self-test
+      - name: Reject literal newline escapes in the pull request body
+        env:
+          PR_BODY_FILE: ${{ runner.temp }}/curie-pr-body.md
+        run: |
+          set -euo pipefail
+          trap 'rm -f -- "$PR_BODY_FILE"' EXIT
+          bash scripts/check-pr-body.sh "$PR_BODY_FILE"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -563,6 +563,10 @@ branch list, restores the `RELEASE_NEXT_BRANCH` environment alias and the
   keyword in a PR that targets `next` never fires on its own. Issues referenced
   by a `next` targeted PR are closed at the `next` into `main` merge, where the
   magic words fire once on the default branch.
+- PR bodies must contain real line breaks. The PR body guard rejects escaped
+  newline sequences because GitHub treats them as text, making closing keywords
+  inert. Run `scripts/check-pr-body.sh <body-file>` before opening or editing a
+  PR.
 - **Never mention any AI assistant (Claude, Codex, GPT, etc.) or AI in general in
   commit messages, and never add `Co-Authored-By` lines referencing AI.**
   CI enforces this on every PR (issue #962); check before pushing with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -208,6 +208,10 @@ branch list, restores the `RELEASE_NEXT_BRANCH` environment alias and the
 - **Reference the issue in the PR body** with `Closes #123` (or `Ref #123`). Do
   not put the issue number in the PR or commit title; use a plain descriptive
   title.
+- **Use real line breaks in the PR body**. The PR body guard rejects escaped
+  newline sequences because GitHub treats them as text, which makes closing
+  keywords inert. Before opening or editing a PR, run
+  `scripts/check-pr-body.sh <body-file>`.
 - **No dashes or emdashes in prose; no emojis** in code or docs.
 - **Never mention any AI assistant** (or AI in general) in commit messages, and
   never add `Co-Authored-By` lines referencing an AI.

--- a/scripts/check-pr-body.sh
+++ b/scripts/check-pr-body.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Reject PR bodies that contain a literal "\\n" escape. GitHub displays that
+# escape as text rather than a line break, so a following `Closes #<issue>` is
+# not parsed as a closing keyword.
+#
+# Usage:
+#   scripts/check-pr-body.sh <body-file>
+#   scripts/check-pr-body.sh --self-test
+set -euo pipefail
+
+SCRIPT_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
+
+usage() {
+    echo "Usage: scripts/check-pr-body.sh <body-file>" >&2
+    echo "       scripts/check-pr-body.sh --self-test" >&2
+}
+
+check_body_file() {
+    local body_file="$1"
+    local grep_status
+
+    if [[ ! -f "$body_file" ]]; then
+        echo "PR body check failed: '$body_file' is not a regular file" >&2
+        return 1
+    fi
+    if [[ ! -r "$body_file" ]]; then
+        echo "PR body check failed: '$body_file' is not readable" >&2
+        return 1
+    fi
+
+    # Single quotes deliberately preserve the two literal bytes (backslash and
+    # n). Real line-feed bytes do not match this fixed string.
+    if LC_ALL=C grep -F -q '\n' -- "$body_file"; then
+        echo "PR body check failed: found a literal \\n escape sequence." >&2
+        echo "Replace each literal \\n with a real newline before opening or editing the PR." >&2
+        return 1
+    else
+        grep_status=$?
+        if ((grep_status != 1)); then
+            echo "PR body check failed: could not read '$body_file' while checking for literal \\n escapes" >&2
+            return 1
+        fi
+    fi
+
+    echo "PR body check passed: no literal \\n escape sequences"
+}
+
+self_test() {
+    local temp_dir real_newline_body literal_escape_body
+
+    temp_dir="$(mktemp -d "${TMPDIR:-/tmp}/curie-pr-body-check.XXXXXX")"
+    trap 'rm -rf -- "$temp_dir"' RETURN
+    real_newline_body="$temp_dir/real-newline.md"
+    literal_escape_body="$temp_dir/literal-escape.md"
+
+    printf 'Describe a fix.\n\nCloses #1713\n' >"$real_newline_body"
+    printf 'Describe a fix.\\n\\nCloses #1713\n' >"$literal_escape_body"
+
+    if ! bash "$SCRIPT_PATH" "$real_newline_body" >/dev/null; then
+        echo "PR body check self-test failed: real newlines were rejected" >&2
+        return 1
+    fi
+    if bash "$SCRIPT_PATH" "$literal_escape_body" >/dev/null 2>&1; then
+        echo "PR body check self-test failed: literal \\n was accepted" >&2
+        return 1
+    fi
+
+    echo "PR body check self-test passed: real newlines accepted, literal \\n rejected"
+}
+
+if [[ "${1:-}" == "--self-test" ]]; then
+    if (($# != 1)); then
+        usage
+        exit 2
+    fi
+    self_test
+    exit 0
+fi
+
+if (($# != 1)); then
+    usage
+    exit 2
+fi
+
+check_body_file "$1"

--- a/tools/ci-retry-gate/tests/test_pr_body.py
+++ b/tools/ci-retry-gate/tests/test_pr_body.py
@@ -1,0 +1,55 @@
+"""Executable regression for PR bodies that defeat GitHub auto-close (#1713)."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CHECKER = REPO_ROOT / "scripts" / "check-pr-body.sh"
+
+
+def _check_body(tmp_path: Path, body: str) -> subprocess.CompletedProcess[str]:
+    body_path = tmp_path / "pull-request-body.md"
+    body_path.write_text(body, encoding="utf-8")
+    return subprocess.run(
+        ["bash", str(CHECKER), str(body_path)],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _diagnostics(completed: subprocess.CompletedProcess[str]) -> str:
+    return (
+        f"exit code: {completed.returncode}\n"
+        f"stdout:\n{completed.stdout}\n"
+        f"stderr:\n{completed.stderr}"
+    )
+
+
+@pytest.mark.parametrize(
+    "body",
+    (
+        "Describe a maintenance change without a closing keyword.\n",
+        "Describe a fix.\n\nCloses #1713\n",
+    ),
+)
+def test_pr_body_check_accepts_plain_text_and_real_newlines(tmp_path: Path, body: str) -> None:
+    completed = _check_body(tmp_path, body)
+
+    assert completed.returncode == 0, _diagnostics(completed)
+
+
+def test_pr_body_check_rejects_literal_backslash_n_before_it_inerts_a_closing_keyword(
+    tmp_path: Path,
+) -> None:
+    completed = _check_body(tmp_path, "Describe a fix.\\n\\nCloses #1713\n")
+    diagnostics = _diagnostics(completed)
+
+    assert completed.returncode != 0, diagnostics
+    assert r"\n" in diagnostics, diagnostics
+    assert "replace" in diagnostics.lower(), diagnostics

--- a/tools/ci-retry-gate/tests/test_retry_eligibility.py
+++ b/tools/ci-retry-gate/tests/test_retry_eligibility.py
@@ -187,7 +187,7 @@ def _load_workflows() -> dict[str, dict[str, Any]]:
     """Parse every workflow file. Also a free structural check on the YAML.
 
     Memoised: the argument list is empty and the input is immutable on disk for
-    the length of a run, so the six rules would otherwise reparse all eight
+    the length of a run, so the six rules would otherwise reparse all nine
     files once each. Every consumer treats the parsed documents as read only,
     and the one place that needs to alter a step (`_iter_steps`, folding a job
     level `continue-on-error`) builds a shallow copy rather than writing back.

--- a/tools/ci-workflow-paths/tests/test_workflow_paths.py
+++ b/tools/ci-workflow-paths/tests/test_workflow_paths.py
@@ -553,6 +553,93 @@ def _tokens_of(filename: str, job_id: str, step_name: str) -> list[str]:
     ]
 
 
+def _pull_request_body_workflow_steps() -> list[dict[str, Any]]:
+    """Return the dedicated PR-body workflow's steps, rejecting a CI transplant.
+
+    This guard is intentionally rooted in the separate workflow GitHub runs for
+    pull-request body edits. `ci.yaml` only runs on commits, so placing the
+    checker there would leave a post-CI body edit unchecked.
+    """
+    workflows = _load_workflows()
+    assert "pr-body.yaml" in workflows, (
+        "the dedicated PR-body workflow is missing. Do not move this guard into "
+        "ci.yaml: GitHub can edit a pull request body without creating a commit."
+    )
+    assert "check-pr-body.sh" not in (
+        WORKFLOWS_DIR / "ci.yaml"
+    ).read_text(encoding="utf-8"), (
+        "the PR-body guard must remain independent of ci.yaml, whose commit-driven "
+        "runs cannot observe a body-only edit."
+    )
+    jobs = workflows["pr-body.yaml"].get("jobs")
+    assert isinstance(jobs, dict), "pr-body.yaml must declare the PR-body guard job"
+    job = jobs.get("pr-body")
+    assert isinstance(job, dict), "pr-body.yaml must retain its dedicated `pr-body` job"
+    steps = job.get("steps")
+    assert isinstance(steps, list), "the dedicated `pr-body` job must have steps"
+    return [step for step in steps if isinstance(step, dict)]
+
+
+def test_pr_body_guard_workflow_handles_body_only_pull_request_edits() -> None:
+    """Pin #1713's runner wiring over the real workflow GitHub executes.
+
+    A unit test of the shell matcher is not enough: the historical failure was a
+    PR body containing literal ``\\n`` characters, and GitHub can create that
+    failure through `edited` without starting commit-triggered CI. The test
+    therefore checks the dedicated event wiring, safe github-script byte write,
+    checker self-test, and the event-payload invocation as one executable
+    contract. Removing any link makes this test red.
+    """
+    workflow = _load_workflows()["pr-body.yaml"]
+    trigger = workflow.get(True, workflow.get("on"))
+    assert isinstance(trigger, dict), "pr-body.yaml must be triggered by `pull_request`"
+    pull_request = trigger.get("pull_request")
+    assert isinstance(pull_request, dict), "pr-body.yaml must configure pull_request events"
+    assert set(pull_request.get("types") or []) == {
+        "opened",
+        "reopened",
+        "synchronize",
+        "edited",
+    }, (
+        "the PR-body guard must run on opened, reopened, synchronize, and edited. "
+        "In particular, `edited` closes the body-only bypass that ci.yaml cannot see."
+    )
+
+    steps = _pull_request_body_workflow_steps()
+    script_steps = [
+        step
+        for step in steps
+        if isinstance(step.get("uses"), str)
+        and step["uses"].split("@", 1)[0] == "actions/github-script"
+    ]
+    assert len(script_steps) == 1, "the PR payload must be serialized by one github-script step"
+    script_step = script_steps[0]
+    assert script_step.get("env", {}).get("PR_BODY_FILE") == (
+        "${{ runner.temp }}/curie-pr-body.md"
+    ), "github-script must write only to a runner-owned temporary file"
+    script = script_step.get("with", {}).get("script")
+    assert isinstance(script, str), "github-script must contain the payload serialization script"
+    assert "context.payload.pull_request?.body ?? \"\"" in script
+    assert "fs.writeFileSync(process.env.PR_BODY_FILE, body" in script
+    assert "github.event.pull_request.body" not in script, (
+        "untrusted PR text must be read from context.payload, not interpolated into script source"
+    )
+
+    run_bodies = [step.get("run") for step in steps if isinstance(step.get("run"), str)]
+    assert "bash scripts/check-pr-body.sh --self-test" in run_bodies, (
+        "the workflow must execute the matcher's self-test before guarding event data"
+    )
+    guard_runs = [
+        body
+        for body in run_bodies
+        if isinstance(body, str) and 'bash scripts/check-pr-body.sh "$PR_BODY_FILE"' in body
+    ]
+    assert len(guard_runs) == 1, "the event check must pass the runner temp file to the guard"
+    assert "${{ github.event.pull_request.body }}" not in guard_runs[0], (
+        "the guard must receive the temporary file, never an interpolated PR body"
+    )
+
+
 def _render(entries: list[Identity]) -> str:
     return "\n".join(f"  {filename} :: {job} :: {name}" for filename, job, name in sorted(entries))
 

--- a/tools/ci-workflow-paths/tests/test_workflow_paths.py
+++ b/tools/ci-workflow-paths/tests/test_workflow_paths.py
@@ -12,6 +12,12 @@ on every tag and no GitHub Release was published at all. The gate encodes the
 invariant rather than the string, so the next workflow that acquires the same
 defect elsewhere reds too.
 
+Issue #1713 is intentionally co-located here because the `pr-body.yaml`
+workflow wiring is itself a repository-path contract: its PR-body checks must
+invoke the checked-in gate from the workspace it runs in. Keeping that wiring
+under the same real-workflow path sweep catches a moved or missing test path
+where CI would otherwise fail only after the workflow starts.
+
 The gate parses `.github/workflows/*.yaml` and `*.yml` directly and takes the
 tracked path set from `git ls-files`. There are no fixtures and no mocks: the
 whole value of this gate is that it reads what CI actually runs.


### PR DESCRIPTION
## Summary

Reject escaped newline sequences in pull-request bodies before they can make a closing keyword inert. The guard consumes GitHub event payload safely, self-tests its matcher, and has CLI-level regression coverage.

## Related issue

Closes #1713

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | Does not reach plugins, runner, ACI, or skill eval. | n/a | n/a |
| local | n/a | Does not reach Compose services, CLI behavior, or UI. | n/a | n/a |
| local-release | n/a | Does not change released binaries, images, install paths, or release compose. | n/a | n/a |
| cluster | n/a | Does not reach charts, sandbox, RBAC, or Kubernetes runtime. | n/a | n/a |
| live provider | n/a | Does not use model routing or provider credentials. | n/a | n/a |
| external integration | required | Guard consumes GitHub live pull_request event body. | live | On c906b7b8, GitHub Actions PR body check passed with this restored real-line-break body. The same PR was temporarily set to an escaped-newline body; its PR body check failed, proving the negative. Workflow command: bash scripts/check-pr-body.sh event-body-file. |

- [x] Local regression coverage and guard self-test pass.
- [x] Required live negative: an escaped-newline body made the dedicated GitHub Actions check fail.
- [x] Independent positive: ordinary text and real newline bodies pass locally; restored-body live check passes.
- [x] No required tier is left unproved.