### PR TITLE
Fix doctor provider recovery

### DIFF
--- a/cli/src/doctor.rs
+++ b/cli/src/doctor.rs
@@ -67,6 +67,9 @@ pub struct Facts {
     pub model_credential: Option<String>,
     /// Where it came from, for the detail line.
     pub model_credential_source: Option<String>,
+    /// Non-secret provider inferred from the bound `CURIE_CREDENTIALS` value.
+    /// The credential itself is deliberately discarded during observation.
+    pub model_credential_provider: Option<&'static str>,
     pub docker_ok: bool,
     /// Plugin name from `.claude-plugin/plugin.json` in the working directory.
     pub bundle_name: Option<String>,
@@ -120,6 +123,17 @@ fn skipped(id: &'static str, title: &'static str, detail: impl Into<String>) -> 
         detail: detail.into(),
         fix: None,
     }
+}
+
+/// The recovery command for a missing cluster release. Provider egress follows
+/// the same credential-prefix map as `cluster up`; an absent or unrecognized
+/// credential leaves egress sealed rather than guessing Anthropic.
+fn missing_release_recovery(provider: Option<&str>) -> String {
+    let mut command = "curie cluster up --namespace <ns> --release <name>".to_string();
+    if let Some(provider) = provider {
+        command.push_str(&format!(" --allow-egress-host {provider}"));
+    }
+    command
 }
 
 /// Judge the gathered facts. Pure.
@@ -190,7 +204,7 @@ pub fn evaluate(f: &Facts) -> Vec<Check> {
             "release",
             "Curie release",
             "not installed in this namespace",
-            "curie cluster up --namespace <ns> --release <name> --allow-egress-host anthropic",
+            missing_release_recovery(f.model_credential_provider),
         ));
         for (id, title) in [
             ("slack", "Slack"),
@@ -479,18 +493,86 @@ mod tests {
         );
     }
 
+    fn missing_release_with_credential(credential: Option<&str>) -> Facts {
+        Facts {
+            model_credential: credential.map(|_| "CURIE_CREDENTIALS".into()),
+            model_credential_source: credential.map(|_| "environment".into()),
+            model_credential_provider: credential
+                .and_then(crate::ops::provider_from_credential_prefix),
+            kube_context: Some("minikube".into()),
+            ..laptop()
+        }
+    }
+
+    /// Doctor's recovery command must follow the same prefix map as `cluster
+    /// up`; otherwise accepting its advice can fail closed under ADR-0114.
+    #[test]
+    fn missing_release_recovery_infers_egress_from_credential_prefix() {
+        let openrouter_checks =
+            evaluate(&missing_release_with_credential(Some("sk-or-PLACEHOLDER")));
+        let openrouter = find(&openrouter_checks, "release")
+            .fix
+            .as_deref()
+            .expect("missing release must offer a recovery command");
+        assert!(
+            openrouter.starts_with("curie cluster up --namespace <ns> --release <name>"),
+            "recovery command must be runnable: {openrouter}"
+        );
+        assert!(
+            openrouter.contains("--allow-egress-host openrouter"),
+            "OpenRouter credential must select OpenRouter egress: {openrouter}"
+        );
+        assert!(
+            !openrouter.contains("--allow-egress-host anthropic"),
+            "OpenRouter credential must not select Anthropic egress: {openrouter}"
+        );
+
+        let anthropic_checks =
+            evaluate(&missing_release_with_credential(Some("sk-ant-PLACEHOLDER")));
+        let anthropic = find(&anthropic_checks, "release")
+            .fix
+            .as_deref()
+            .expect("missing release must offer a recovery command");
+        assert!(
+            anthropic.contains("--allow-egress-host anthropic"),
+            "Anthropic credential must select Anthropic egress: {anthropic}"
+        );
+
+        for credential in [None, Some("unknown-PLACEHOLDER")] {
+            let checks = evaluate(&missing_release_with_credential(credential));
+            let fix = find(&checks, "release")
+                .fix
+                .as_deref()
+                .expect("missing release must offer a recovery command");
+            assert_eq!(
+                fix, "curie cluster up --namespace <ns> --release <name>",
+                "no unambiguous provider means egress remains sealed"
+            );
+        }
+    }
+
     /// This output gets pasted into issues and chat.
     #[test]
     fn no_check_can_carry_a_credential_value() {
+        let credential = "sk-or-PLACEHOLDER";
         let f = Facts {
             model_credential: Some("CURIE_CREDENTIALS".into()),
             model_credential_source: Some("environment".into()),
+            model_credential_provider: crate::ops::provider_from_credential_prefix(credential),
             clone_credential: Some("github app (app_id=4475970)".into()),
             slack_configured: true,
             ..laptop()
         };
         let rendered = format!("{:?}", evaluate(&f));
-        for leaked in ["sk-ant-", "xoxb-", "xapp-", "ghp_", "-----BEGIN"] {
+        for leaked in [
+            credential,
+            "sk-or-",
+            "sk-ant-",
+            "xoxb-",
+            "xapp-",
+            "ghp_",
+            "-----BEGIN",
+        ] {
             assert!(!rendered.contains(leaked), "{leaked} leaked: {rendered}");
         }
     }
@@ -742,9 +824,18 @@ pub async fn gather(namespace: &str, release: &str, api: Option<(&str, &str)>) -
     };
 
     for name in crate::commands::MODEL_CREDENTIAL_ENV_NAMES {
-        if std::env::var(name).map(|v| !v.is_empty()).unwrap_or(false) {
+        if let Ok(value) = std::env::var(name) {
+            if value.is_empty() {
+                continue;
+            }
             f.model_credential = Some(name.to_string());
             f.model_credential_source = Some("environment".into());
+            // `cluster up` binds its real-model credential from the canonical
+            // CURIE_CREDENTIALS variable. Derive only its safe provider name
+            // for the recovery command, then drop the credential value.
+            f.model_credential_provider = (name == "CURIE_CREDENTIALS")
+                .then(|| crate::ops::provider_from_credential_prefix(&value))
+                .flatten();
             break;
         }
         if crate::secrets::is_saved(name).unwrap_or(false) {

--- a/cli/src/doctor.rs
+++ b/cli/src/doctor.rs
@@ -493,64 +493,6 @@ mod tests {
         );
     }
 
-    fn missing_release_with_credential(credential: Option<&str>) -> Facts {
-        Facts {
-            model_credential: credential.map(|_| "CURIE_CREDENTIALS".into()),
-            model_credential_source: credential.map(|_| "environment".into()),
-            model_credential_provider: credential
-                .and_then(crate::ops::provider_from_credential_prefix),
-            kube_context: Some("minikube".into()),
-            ..laptop()
-        }
-    }
-
-    /// Doctor's recovery command must follow the same prefix map as `cluster
-    /// up`; otherwise accepting its advice can fail closed under ADR-0114.
-    #[test]
-    fn missing_release_recovery_infers_egress_from_credential_prefix() {
-        let openrouter_checks =
-            evaluate(&missing_release_with_credential(Some("sk-or-PLACEHOLDER")));
-        let openrouter = find(&openrouter_checks, "release")
-            .fix
-            .as_deref()
-            .expect("missing release must offer a recovery command");
-        assert!(
-            openrouter.starts_with("curie cluster up --namespace <ns> --release <name>"),
-            "recovery command must be runnable: {openrouter}"
-        );
-        assert!(
-            openrouter.contains("--allow-egress-host openrouter"),
-            "OpenRouter credential must select OpenRouter egress: {openrouter}"
-        );
-        assert!(
-            !openrouter.contains("--allow-egress-host anthropic"),
-            "OpenRouter credential must not select Anthropic egress: {openrouter}"
-        );
-
-        let anthropic_checks =
-            evaluate(&missing_release_with_credential(Some("sk-ant-PLACEHOLDER")));
-        let anthropic = find(&anthropic_checks, "release")
-            .fix
-            .as_deref()
-            .expect("missing release must offer a recovery command");
-        assert!(
-            anthropic.contains("--allow-egress-host anthropic"),
-            "Anthropic credential must select Anthropic egress: {anthropic}"
-        );
-
-        for credential in [None, Some("unknown-PLACEHOLDER")] {
-            let checks = evaluate(&missing_release_with_credential(credential));
-            let fix = find(&checks, "release")
-                .fix
-                .as_deref()
-                .expect("missing release must offer a recovery command");
-            assert_eq!(
-                fix, "curie cluster up --namespace <ns> --release <name>",
-                "no unambiguous provider means egress remains sealed"
-            );
-        }
-    }
-
     /// This output gets pasted into issues and chat.
     #[test]
     fn no_check_can_carry_a_credential_value() {

--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -718,7 +718,12 @@ pub fn default_route_egress_warning(cidrs: &[String]) -> Option<String> {
 const CREDENTIAL_PREFIX_PROVIDERS: &[(&str, &str)] =
     &[("sk-ant-", "anthropic"), ("sk-or-", "openrouter")];
 
-fn provider_from_credential_prefix(credential: &str) -> Option<&'static str> {
+/// Return the provider unambiguously selected by a credential prefix.
+///
+/// Callers that inspect a credential must discard it after deriving this
+/// non-secret provider name; it is safe to render the returned value but never
+/// the credential itself.
+pub fn provider_from_credential_prefix(credential: &str) -> Option<&'static str> {
     CREDENTIAL_PREFIX_PROVIDERS
         .iter()
         .find(|(prefix, _)| credential.starts_with(prefix))

--- a/cli/tests/doctor_recovery.rs
+++ b/cli/tests/doctor_recovery.rs
@@ -1,0 +1,52 @@
+//! Integration: the missing-release recovery command uses the provider inferred
+//! by the same credential-prefix map as `curie cluster up`.
+
+use curie::doctor::{evaluate, Facts};
+use curie::ops::provider_from_credential_prefix;
+
+fn missing_release_recovery(credential: Option<&str>) -> String {
+    let facts = Facts {
+        model_credential: credential.map(|_| "CURIE_CREDENTIALS".into()),
+        model_credential_source: credential.map(|_| "environment".into()),
+        model_credential_provider: credential.and_then(provider_from_credential_prefix),
+        kube_context: Some("minikube".into()),
+        ..Default::default()
+    };
+
+    evaluate(&facts)
+        .into_iter()
+        .find(|check| check.id == "release")
+        .and_then(|check| check.fix)
+        .expect("a missing release must offer a recovery command")
+}
+
+#[test]
+fn missing_release_recovery_infers_egress_from_credential_prefix() {
+    let openrouter = missing_release_recovery(Some("sk-or-PLACEHOLDER"));
+    assert!(
+        openrouter.starts_with("curie cluster up --namespace <ns> --release <name>"),
+        "recovery command must be runnable: {openrouter}"
+    );
+    assert!(
+        openrouter.contains("--allow-egress-host openrouter"),
+        "OpenRouter credential must select OpenRouter egress: {openrouter}"
+    );
+    assert!(
+        !openrouter.contains("--allow-egress-host anthropic"),
+        "OpenRouter credential must not select Anthropic egress: {openrouter}"
+    );
+
+    let anthropic = missing_release_recovery(Some("sk-ant-PLACEHOLDER"));
+    assert!(
+        anthropic.contains("--allow-egress-host anthropic"),
+        "Anthropic credential must select Anthropic egress: {anthropic}"
+    );
+
+    for credential in [None, Some("unknown-PLACEHOLDER")] {
+        assert_eq!(
+            missing_release_recovery(credential),
+            "curie cluster up --namespace <ns> --release <name>",
+            "no unambiguous provider means egress remains sealed"
+        );
+    }
+}

--- a/cli/tests/json_contract.rs
+++ b/cli/tests/json_contract.rs
@@ -1346,6 +1346,7 @@ fn doctor_output_validates() {
     let facts = curie::doctor::Facts {
         model_credential: Some("CURIE_CREDENTIALS".to_string()),
         model_credential_source: Some("environment".to_string()),
+        model_credential_provider: None,
         docker_ok: true,
         bundle_name: Some("my-agent".to_string()),
         kube_context: Some("minikube".to_string()),


### PR DESCRIPTION
Closes #1813

Reuse cluster-up credential inference for doctor recovery commands, preserving sealed egress when no provider is known.