### PR TITLE
Quiet expected startup race failures

### DIFF
--- a/apps/worker/src/curie_worker/connector_loop.py
+++ b/apps/worker/src/curie_worker/connector_loop.py
@@ -9,10 +9,12 @@ Three things make this safe to run unattended, and each is a deliberate choice
 rather than a default:
 
 **One agent's failure ends with that agent.** A pass reconciles every agent with
-an active deployment. An exception in one is caught, logged and counted; the
-rest of the pass continues. A reconciler that aborts the sweep on the first bad
-agent leaves every later agent unreconciled indefinitely, and the ordering is
-arbitrary, so which agents those are changes between passes.
+an active deployment. An exception in one is caught and logged. Recognized
+platform 5xx responses have a bounded quiet retry window before failed
+accounting and traceback escalation; other exceptions are counted immediately.
+The rest of the pass continues. A reconciler that aborts the sweep on the first
+bad agent leaves every later agent unreconciled indefinitely, and the ordering
+is arbitrary, so which agents those are changes between passes.
 
 **A pass never kills the worker.** The loop's body is wrapped whole. This shares
 a process with the kernel, whose four correctness rules are not negotiable, so
@@ -50,6 +52,8 @@ from .connector_agent import (
 from .connector_apply import ConnectorClient
 
 logger = logging.getLogger(__name__)
+
+_PLATFORM_5XX_GRACE_PASSES = 3
 
 
 # Every agent with an in-force deployment, and the version that deployment
@@ -154,6 +158,7 @@ class ConnectorReconcileLoop:
         self._client = client
         self._namespace = namespace
         self._interval = interval_seconds
+        self._platform_5xx_streaks: dict[uuid.UUID, int] = {}
         # Table identifiers are not user input; the schema comes from config.
         self._sql = text(_TARGETS_SQL.format(schema=db_schema))
 
@@ -183,11 +188,34 @@ class ConnectorReconcileLoop:
         """Reconcile every deployed agent once."""
 
         summary = PassSummary()
-        for target in await self.targets():
+        targets = await self.targets()
+        for target in targets:
             summary.reconciled += 1
             try:
                 outcome = await asyncio.to_thread(self._reconcile_one, target)
-            except Exception:
+            except Exception as exc:
+                if (
+                    isinstance(exc, httpx.HTTPStatusError)
+                    and 500 <= exc.response.status_code <= 599
+                ):
+                    streak = min(
+                        self._platform_5xx_streaks.get(target.agent_id, 0) + 1,
+                        _PLATFORM_5XX_GRACE_PASSES + 1,
+                    )
+                    self._platform_5xx_streaks[target.agent_id] = streak
+                    if streak <= _PLATFORM_5XX_GRACE_PASSES:
+                        logger.warning(
+                            "connector reconcile platform API returned %d for agent=%s; "
+                            "retrying next pass (%d/%d)",
+                            exc.response.status_code,
+                            target.agent_name,
+                            streak,
+                            _PLATFORM_5XX_GRACE_PASSES,
+                        )
+                        continue
+                else:
+                    self._platform_5xx_streaks.pop(target.agent_id, None)
+
                 # Ends with this agent. Aborting the sweep would leave every
                 # later agent unreconciled, and the order is arbitrary.
                 summary.failed += 1
@@ -197,6 +225,7 @@ class ConnectorReconcileLoop:
                 )
                 continue
 
+            self._platform_5xx_streaks.pop(target.agent_id, None)
             if outcome.skipped:
                 summary.skipped += 1
                 # A skip means "no operator-supplied Secret", not "nothing

--- a/apps/worker/tests/reconcile/test_connector_loop.py
+++ b/apps/worker/tests/reconcile/test_connector_loop.py
@@ -8,8 +8,10 @@ wrong: one bad agent, a raising client, a database that will not answer.
 from __future__ import annotations
 
 import asyncio
+import logging
 from typing import Any
 
+import httpx
 import pytest
 from curie_worker.connector_agent import AgentOutcome, RenderedConnectors
 from curie_worker.connector_apply import ApplyReport
@@ -37,11 +39,17 @@ class Loop(ConnectorReconcileLoop):
     """
 
     def __init__(self, targets: list[AgentTarget], outcomes: dict[str, Any], **kw: Any) -> None:
+        super().__init__(
+            engine=None,  # type: ignore[arg-type]
+            source=None,  # type: ignore[arg-type]
+            client=None,  # type: ignore[arg-type]
+            namespace="curie",
+            db_schema="curie",
+            interval_seconds=kw.get("interval_seconds", 0.01),
+        )
         self._targets = targets
         self._outcomes = outcomes
         self.seen: list[str] = []
-        self._namespace = "curie"
-        self._interval = kw.get("interval_seconds", 0.01)
 
     async def targets(self) -> list[AgentTarget]:  # type: ignore[override]
         return list(self._targets)
@@ -61,6 +69,16 @@ def ok(agent: str, applied: int = 0, deleted: int = 0) -> AgentOutcome:
             applied=[("Service", f"s{i}") for i in range(applied)],
             deleted=[("Service", f"d{i}") for i in range(deleted)],
         ),
+    )
+
+
+def platform_server_error(status_code: int = 503) -> httpx.HTTPStatusError:
+    request = httpx.Request("GET", "http://api:8000/agents/a/connectors")
+    response = httpx.Response(status_code, request=request)
+    return httpx.HTTPStatusError(
+        f"platform API returned {status_code}",
+        request=request,
+        response=response,
     )
 
 
@@ -152,6 +170,165 @@ async def test_a_pass_that_did_work_says_so(caplog) -> None:
     with caplog.at_level("INFO", logger="curie_worker.connector_loop"):
         await Loop([target("a")], {"a": ok("a", applied=2, deleted=1)}).one_pass()
     assert any("2 applied, 1 deleted" in r.getMessage() for r in caplog.records)
+
+
+async def test_platform_5xx_escalates_only_after_three_consecutive_passes(caplog) -> None:
+    loop = Loop([target("a")], {"a": platform_server_error()})
+
+    with caplog.at_level(logging.DEBUG, logger="curie_worker.connector_loop"):
+        for pass_number in range(1, 6):
+            caplog.clear()
+            summary = await loop.one_pass()
+            agent_records = [r for r in caplog.records if "agent=a" in r.getMessage()]
+
+            assert agent_records, f"pass {pass_number} did not log the retry"
+            if pass_number <= 3:
+                assert summary.failed == 0
+                assert all(r.levelno < logging.ERROR for r in agent_records)
+                assert all(r.exc_info is None for r in agent_records)
+                assert all("returned 503" in r.getMessage() for r in agent_records)
+                assert all(f"({pass_number}/3)" in r.getMessage() for r in agent_records)
+            else:
+                assert summary.failed == 1
+                assert any(
+                    r.levelno >= logging.ERROR and r.exc_info is not None for r in agent_records
+                )
+
+
+async def test_platform_5xx_streak_is_per_agent(caplog) -> None:
+    loop = Loop([target("a")], {"a": platform_server_error()})
+
+    with caplog.at_level(logging.DEBUG, logger="curie_worker.connector_loop"):
+        for _ in range(3):
+            await loop.one_pass()
+
+        loop._targets = [target("b")]
+        loop._outcomes = {"b": platform_server_error()}
+        caplog.clear()
+        summary = await loop.one_pass()
+
+    agent_records = [r for r in caplog.records if "agent=b" in r.getMessage()]
+    assert summary.failed == 0
+    assert agent_records
+    assert all(r.levelno < logging.ERROR for r in agent_records)
+    assert all(r.exc_info is None for r in agent_records)
+    assert all("returned 503" in r.getMessage() for r in agent_records)
+    assert all("(1/3)" in r.getMessage() for r in agent_records)
+
+
+async def test_non_5xx_failure_resets_platform_5xx_streak_for_the_same_agent(caplog) -> None:
+    loop = Loop([target("a")], {"a": platform_server_error()})
+
+    with caplog.at_level(logging.DEBUG, logger="curie_worker.connector_loop"):
+        for _ in range(3):
+            assert (await loop.one_pass()).failed == 0
+
+        loop._outcomes["a"] = platform_server_error(404)
+        caplog.clear()
+        loud_summary = await loop.one_pass()
+        loud_records = [r for r in caplog.records if "agent=a" in r.getMessage()]
+
+        loop._outcomes["a"] = platform_server_error()
+        caplog.clear()
+        quiet_summary = await loop.one_pass()
+
+    quiet_records = [r for r in caplog.records if "agent=a" in r.getMessage()]
+    assert loud_summary.failed == 1
+    assert len(loud_records) == 1
+    assert loud_records[0].levelno >= logging.ERROR
+    assert loud_records[0].exc_info is not None
+    assert quiet_summary.failed == 0
+    assert quiet_records
+    assert all(r.levelno < logging.ERROR for r in quiet_records)
+    assert all(r.exc_info is None for r in quiet_records)
+    assert all("returned 503" in r.getMessage() for r in quiet_records)
+    assert all("(1/3)" in r.getMessage() for r in quiet_records)
+
+
+async def test_platform_5xx_streaks_are_isolated_within_one_pass(caplog) -> None:
+    agent_a = target("a")
+    agent_b = target("b")
+    loop = Loop([agent_a], {"a": platform_server_error()})
+
+    with caplog.at_level(logging.DEBUG, logger="curie_worker.connector_loop"):
+        for _ in range(3):
+            await loop.one_pass()
+
+        loop._targets = [agent_a, agent_b]
+        loop._outcomes = {
+            "a": platform_server_error(),
+            "b": platform_server_error(),
+        }
+        loop.seen.clear()
+        caplog.clear()
+        summary = await loop.one_pass()
+
+    agent_a_records = [r for r in caplog.records if "agent=a" in r.getMessage()]
+    agent_b_records = [r for r in caplog.records if "agent=b" in r.getMessage()]
+    error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
+
+    assert loop.seen == ["a", "b"]
+    assert summary.reconciled == 2
+    assert summary.failed == 1
+    assert agent_a_records
+    assert any(
+        r.levelno >= logging.ERROR and r.exc_info is not None for r in agent_a_records
+    )
+    assert agent_b_records
+    assert all(r.levelno < logging.ERROR for r in agent_b_records)
+    assert all(r.exc_info is None for r in agent_b_records)
+    assert all("returned 503" in r.getMessage() for r in agent_b_records)
+    assert all("(1/3)" in r.getMessage() for r in agent_b_records)
+    assert len(error_records) == 1
+    assert "agent=a" in error_records[0].getMessage()
+
+
+async def test_success_resets_platform_5xx_streak_for_the_same_agent(caplog) -> None:
+    loop = Loop([target("a")], {"a": platform_server_error()})
+
+    with caplog.at_level(logging.DEBUG, logger="curie_worker.connector_loop"):
+        for _ in range(3):
+            await loop.one_pass()
+
+        loop._outcomes["a"] = ok("a")
+        assert (await loop.one_pass()).failed == 0
+
+        loop._outcomes["a"] = platform_server_error()
+        caplog.clear()
+        summary = await loop.one_pass()
+
+    agent_records = [r for r in caplog.records if "agent=a" in r.getMessage()]
+    assert summary.failed == 0
+    assert agent_records
+    assert all(r.levelno < logging.ERROR for r in agent_records)
+    assert all(r.exc_info is None for r in agent_records)
+    assert all("returned 503" in r.getMessage() for r in agent_records)
+    assert all("(1/3)" in r.getMessage() for r in agent_records)
+
+
+async def test_non_5xx_exception_fails_immediately_with_traceback(caplog) -> None:
+    loop = Loop([target("a")], {"a": RuntimeError("render is invalid")})
+
+    with caplog.at_level(logging.DEBUG, logger="curie_worker.connector_loop"):
+        summary = await loop.one_pass()
+
+    agent_records = [r for r in caplog.records if "agent=a" in r.getMessage()]
+    assert summary.failed == 1
+    assert any(r.levelno >= logging.ERROR and r.exc_info is not None for r in agent_records)
+
+
+async def test_platform_404_fails_immediately_with_traceback(caplog) -> None:
+    loop = Loop([target("a")], {"a": platform_server_error(404)})
+
+    with caplog.at_level(logging.DEBUG, logger="curie_worker.connector_loop"):
+        summary = await loop.one_pass()
+
+    agent_records = [r for r in caplog.records if "agent=a" in r.getMessage()]
+    assert summary.reconciled == 1
+    assert summary.failed == 1
+    assert len(agent_records) == 1
+    assert agent_records[0].levelno >= logging.ERROR
+    assert agent_records[0].exc_info is not None
 
 
 # --------------------------------------------------------------------------- #

--- a/charts/curie/ci/render-assertions.sh
+++ b/charts/curie/ci/render-assertions.sh
@@ -35,6 +35,10 @@
 # repos only") and an explicit value must render verbatim. The negative control
 # routes it through the generating helper and requires the assert to fire.
 #
+# Issue #1762 (quiet API migration startup), Assertion 14 and its negative
+# control. The migration init container must wait for Postgres with bounded,
+# quiet retries before preserving the original Alembic upgrade command.
+#
 # Runnable locally (from anywhere) and from CI. Fails loudly, naming the key.
 set -euo pipefail
 
@@ -1286,5 +1290,284 @@ if failures:
 print(f"  ok: DATATIER_TARGETS includes {expected!r} and excludes {forbidden!r}")
 PYEOF
 
+echo "=== Assertion 14: API migration waits quietly for Postgres before Alembic (#1762) ==="
+API_MIGRATE_OUT="$TMP/api_migrate"
+helm template curie "$CHART" --output-dir "$API_MIGRATE_OUT" >/dev/null
+API_MIGRATE_RENDER="$API_MIGRATE_OUT/curie/templates/api.yaml"
+[[ -f "$API_MIGRATE_RENDER" ]] || fail "api.yaml did not render"
+
+API_MIGRATE_CHECK="$TMP/check_api_migrate_wait.py"
+cat > "$API_MIGRATE_CHECK" <<'PYEOF'
+"""Execute the rendered API migration init command with fake dependencies."""
+
+import os
+import pathlib
+import subprocess
+import sys
+import tempfile
+
+import yaml
+
+
+def fail(message):
+    raise SystemExit(message)
+
+
+def migrate_container(manifest):
+    matches = []
+    for doc in yaml.safe_load_all(pathlib.Path(manifest).read_text()):
+        if not isinstance(doc, dict) or doc.get("kind") != "Deployment":
+            continue
+        containers = (
+            doc.get("spec", {})
+            .get("template", {})
+            .get("spec", {})
+            .get("initContainers", [])
+        )
+        matches.extend(item for item in containers if item.get("name") == "migrate")
+    if len(matches) != 1:
+        fail(f"expected exactly one migrate init container, found {len(matches)}")
+    return matches[0]
+
+
+def shell_process(container):
+    process = list(container.get("command") or []) + list(container.get("args") or [])
+    if len(process) < 3 or pathlib.Path(process[0]).name not in {"sh", "bash"}:
+        fail(
+            "migrate init container must use a shell readiness wait before "
+            "exec alembic; a direct Alembic command is not retry-safe"
+        )
+    if process[1] != "-c":
+        fail("migrate init container shell command must use -c")
+    script = process[2]
+    migration = "exec alembic -c alembic.ini upgrade head"
+    if migration not in script:
+        fail(f"migrate init command must preserve {migration!r}")
+    if not any(token in script[: script.index(migration)] for token in ("python", "python3")):
+        fail("migrate init command has no supported Postgres readiness probe before Alembic")
+    env_names = {item.get("name") for item in container.get("env", [])}
+    if "DATABASE_URL" not in env_names:
+        fail("migrate init container must receive DATABASE_URL from the Postgres environment")
+    return process
+
+
+def write_program(path, text):
+    path.write_text("#!/bin/sh\n" + text)
+    path.chmod(0o755)
+
+
+def run_case(process, readiness_failures):
+    with tempfile.TemporaryDirectory() as temp:
+        root = pathlib.Path(temp)
+        fake_bin = root / "bin"
+        fake_bin.mkdir()
+        (fake_bin / "python").symlink_to(sys.executable)
+        fake_modules = root / "modules"
+        fake_modules.mkdir()
+        attempts = root / "readiness-attempts"
+        alembic_calls = root / "alembic-calls"
+
+        write_program(fake_bin / "sleep", "exit 0\n")
+        write_program(
+            fake_bin / "alembic",
+            "printf '%s\\n' \"$*\" >> \"$ALEMBIC_CALLS\"\n",
+        )
+        (fake_modules / "asyncpg.py").write_text(
+            """\
+import os
+import pathlib
+
+
+class InvalidPasswordError(Exception):
+    pass
+
+
+class Connection:
+    async def close(self):
+        pass
+
+
+async def connect(database_url, timeout):
+    attempts = pathlib.Path(os.environ["READINESS_ATTEMPTS"])
+    lines = attempts.read_text().splitlines() if attempts.exists() else []
+    count = int(lines[-1]) + 1 if lines else 1
+    with attempts.open("a") as stream:
+        stream.write(f"{count}\\n")
+    if count <= int(os.environ["READINESS_FAILURES"]):
+        raise InvalidPasswordError("asyncpg-password-sentinel-must-not-leak")
+    return Connection()
+"""
+        )
+
+        env = os.environ.copy()
+        env.update(
+            {
+                "ALEMBIC_CALLS": str(alembic_calls),
+                "DATABASE_URL": (
+                    "postgresql+asyncpg://curie:EXAMPLE_NOT_A_SECRET@postgres:5432/curie"
+                ),
+                "PATH": f"{fake_bin}:{env['PATH']}",
+                "PYTHONPATH": (
+                    f"{fake_modules}{os.pathsep}{env['PYTHONPATH']}"
+                    if env.get("PYTHONPATH")
+                    else str(fake_modules)
+                ),
+                "READINESS_ATTEMPTS": str(attempts),
+                "READINESS_FAILURES": str(readiness_failures),
+            }
+        )
+        try:
+            result = subprocess.run(
+                process,
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=60,
+                check=False,
+            )
+        except subprocess.TimeoutExpired:
+            fail("migrate readiness wait did not terminate within 60 seconds with fake sleep")
+
+        attempt_lines = attempts.read_text().splitlines() if attempts.exists() else []
+        calls = alembic_calls.read_text().splitlines() if alembic_calls.exists() else []
+        return result, attempt_lines, calls
+
+
+container = migrate_container(sys.argv[1])
+process = shell_process(container)
+
+ready, ready_attempts, ready_calls = run_case(process, 0)
+if ready.returncode != 0:
+    fail(f"immediate readiness exited {ready.returncode}: {ready.stdout}{ready.stderr}")
+if len(ready_attempts) != 1:
+    fail(f"immediate readiness ran the probe {len(ready_attempts)} times, expected once")
+if ready_calls != ["-c alembic.ini upgrade head"]:
+    fail(f"immediate readiness did not invoke the original Alembic command: {ready_calls!r}")
+
+delayed, delayed_attempts, delayed_calls = run_case(process, 2)
+if delayed.returncode != 0:
+    fail(f"delayed readiness exited {delayed.returncode}: {delayed.stdout}{delayed.stderr}")
+if len(delayed_attempts) != 3:
+    fail(f"delayed readiness ran the probe {len(delayed_attempts)} times, expected three")
+if delayed_calls != ["-c alembic.ini upgrade head"]:
+    fail(f"delayed readiness did not invoke the original Alembic command: {delayed_calls!r}")
+delayed_output = [
+    line.strip()
+    for line in (delayed.stdout + delayed.stderr).splitlines()
+    if line.strip()
+]
+if delayed_output != ["Waiting for Postgres readiness"]:
+    fail(f"delayed readiness must log one concise wait line: {delayed_output!r}")
+
+exhausted, exhausted_attempts, exhausted_calls = run_case(process, 60)
+if exhausted.returncode == 0:
+    fail("readiness exhaustion must exit nonzero so the init container can restart")
+if len(exhausted_attempts) != 60:
+    fail(f"readiness exhaustion must make exactly 60 attempts; observed {len(exhausted_attempts)}")
+if exhausted_calls:
+    fail(f"readiness exhaustion must not invoke Alembic; got {exhausted_calls!r}")
+
+output_lines = [
+    line.strip()
+    for line in (exhausted.stdout + exhausted.stderr).splitlines()
+    if line.strip()
+]
+if not output_lines:
+    fail("readiness exhaustion must emit one concise terminal message")
+if len(output_lines) > 2:
+    fail(f"readiness exhaustion emitted {len(output_lines)} lines, expected at most 2")
+if output_lines[0] != "Waiting for Postgres readiness":
+    fail(f"first readiness failure must emit one concise wait message: {output_lines!r}")
+lower_output = " ".join(output_lines).lower()
+if "postgres" not in lower_output or not any(
+    word in lower_output for word in ("ready", "wait", "timeout", "unavailable")
+):
+    fail(f"readiness exhaustion message must explain the Postgres wait: {output_lines!r}")
+if "InvalidPasswordError" not in " ".join(output_lines):
+    fail(f"readiness exhaustion must retain the final probe error class: {output_lines!r}")
+if "traceback" in lower_output or "sqlalchemy.exc" in lower_output:
+    fail(f"readiness exhaustion emitted a traceback: {output_lines!r}")
+if any(
+    secret in lower_output
+    for secret in (
+        "example_not_a_secret",
+        "postgresql+asyncpg://",
+        "asyncpg-password-sentinel-must-not-leak",
+    )
+):
+    fail(f"readiness exhaustion exposed database credentials: {output_lines!r}")
+
+print(
+    "  ok: immediate and delayed readiness run the original migration; bounded "
+    "exhaustion stays concise, exits nonzero, and never invokes Alembic"
+)
+PYEOF
+
+python3 "$API_MIGRATE_CHECK" "$API_MIGRATE_RENDER" \
+  || fail "API migrate init command does not implement the bounded quiet readiness contract."
+
+echo "=== Assertion 14 negative control: changed readiness bound FAILS ==="
+API_MIGRATE_BOUND_MUTANT="$TMP/mutant-api-migrate-bound"
+cp -a "$CHART" "$API_MIGRATE_BOUND_MUTANT"
+python3 - "$API_MIGRATE_BOUND_MUTANT/templates/api.yaml" <<'PYEOF'
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+text = path.read_text()
+old = "              max_attempts=60\n"
+if text.count(old) != 1:
+    sys.stderr.write("bound negative control could not find the readiness bound\n")
+    sys.exit(1)
+path.write_text(text.replace(old, "              max_attempts=4\n", 1))
+PYEOF
+API_MIGRATE_BOUND_MUTANT_OUT="$TMP/api_migrate_bound_mutant"
+helm template curie "$API_MIGRATE_BOUND_MUTANT" \
+  --output-dir "$API_MIGRATE_BOUND_MUTANT_OUT" >/dev/null
+API_MIGRATE_BOUND_MUTANT_RENDER="$API_MIGRATE_BOUND_MUTANT_OUT/curie/templates/api.yaml"
+[[ -f "$API_MIGRATE_BOUND_MUTANT_RENDER" ]] || fail "bound mutant api.yaml did not render"
+api_migrate_bound_negative_output=""
+if api_migrate_bound_negative_output="$(python3 "$API_MIGRATE_CHECK" "$API_MIGRATE_BOUND_MUTANT_RENDER" 2>&1)"; then
+  fail "negative control did not fire: a changed readiness bound passed the contract."
+fi
+if [[ "$api_migrate_bound_negative_output" != *"must make exactly 60 attempts"* ]]; then
+  fail "readiness-bound negative control failed unexpectedly: $api_migrate_bound_negative_output"
+fi
+echo "  ok: a changed readiness bound is rejected (the boundedness assert can fail)"
+
+echo "=== Assertion 14 negative control: direct Alembic migration FAILS ==="
+# Mutate a temporary chart copy to the pre-fix command and require the same
+# rendered-command checker to reject it.
+API_MIGRATE_MUTANT="$TMP/mutant-api-migrate"
+cp -a "$CHART" "$API_MIGRATE_MUTANT"
+python3 - "$API_MIGRATE_MUTANT/templates/api.yaml" <<'PYEOF'
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+text = path.read_text()
+start_marker = '          command: ["/bin/sh", "-c"]\n'
+end_marker = "          env:\n"
+start = text.find(start_marker)
+end = text.find(end_marker, start)
+if start == -1 or end == -1:
+    sys.stderr.write("negative control could not find the migration readiness command\n")
+    sys.exit(1)
+direct_command = '          command: ["alembic", "-c", "alembic.ini", "upgrade", "head"]\n'
+path.write_text(text[:start] + direct_command + text[end:])
+PYEOF
+API_MIGRATE_MUTANT_OUT="$TMP/api_migrate_mutant"
+helm template curie "$API_MIGRATE_MUTANT" --output-dir "$API_MIGRATE_MUTANT_OUT" >/dev/null
+API_MIGRATE_MUTANT_RENDER="$API_MIGRATE_MUTANT_OUT/curie/templates/api.yaml"
+[[ -f "$API_MIGRATE_MUTANT_RENDER" ]] || fail "mutant api.yaml did not render"
+api_migrate_negative_output=""
+if api_migrate_negative_output="$(python3 "$API_MIGRATE_CHECK" "$API_MIGRATE_MUTANT_RENDER" 2>&1)"; then
+  fail "negative control did not fire: the pre-fix direct Alembic command passed the readiness contract."
+fi
+if [[ "$api_migrate_negative_output" != *"direct Alembic command is not retry-safe"* ]]; then
+  fail "direct-Alembic negative control failed unexpectedly: $api_migrate_negative_output"
+fi
+echo "  ok: the reverted direct-Alembic command is rejected (the assert can fail)"
+
 echo
-echo "PASS: sealed render generates strong values for all 11 keys (encryptionKey 64-hex and Langfuse init credentials 32 alphanumeric); dev overlay keeps published defaults; explicit credential and OTel overrides win on the sealed path; default OTel Basic auth uses the resolved Langfuse project secret; every runner boot-env name is a declared contract key (proven by a failing negative control); every control-plane pod, the agent-sandbox controller, and the sandbox render with the expected priorityClassName, including under operator override; the runner SandboxTemplate opts the controller out of its own permissive NetworkPolicy whenever Rail 1 is on, and leaves it to the controller's default when Rail 1 is off; api.githubToken stays a plain pass-through (empty renders empty, an explicit value renders verbatim, and it is never generated), proven by a failing negative control; every rendered pod surface receives its exact placement class while empty defaults omit placement fields and a platform-only label does not leak across classes; the worker renders exactly one API URL plus exactly one correctly sourced API key in default, connector enabled, release name, configured port, BYO API, and operator override cases; and the security probe uses the configured RustFS port in DATATIER_TARGETS."
+echo "PASS: sealed render generates strong values for all 11 keys (encryptionKey 64-hex and Langfuse init credentials 32 alphanumeric); dev overlay keeps published defaults; explicit credential and OTel overrides win on the sealed path; default OTel Basic auth uses the resolved Langfuse project secret; every runner boot-env name is a declared contract key (proven by a failing negative control); every control-plane pod, the agent-sandbox controller, and the sandbox render with the expected priorityClassName, including under operator override; the runner SandboxTemplate opts the controller out of its own permissive NetworkPolicy whenever Rail 1 is on, and leaves it to the controller's default when Rail 1 is off; api.githubToken stays a plain pass-through (empty renders empty, an explicit value renders verbatim, and it is never generated), proven by a failing negative control; every rendered pod surface receives its exact placement class while empty defaults omit placement fields and a platform-only label does not leak across classes; the worker renders exactly one API URL plus exactly one correctly sourced API key in default, connector enabled, release name, configured port, BYO API, and operator override cases; the security probe uses the configured RustFS port in DATATIER_TARGETS; and the API migration init command waits quietly with bounded retries before preserving the original Alembic upgrade, with readiness exhaustion proven to exit nonzero without invoking Alembic."

--- a/charts/curie/templates/api.yaml
+++ b/charts/curie/templates/api.yaml
@@ -58,8 +58,8 @@ spec:
       {{- end }}
       {{- if .Values.api.migrate.enabled }}
       # Bring the schema to head before the server boots. The init container
-      # re-runs until it succeeds, so it also serves as a wait-for-Postgres gate
-      # on a fresh install (migration 0001 creates the `curie` schema).
+      # waits quietly for Postgres before migrating. Kubernetes restarts remain
+      # the backstop after bounded readiness attempts or migration failure.
       initContainers:
         - name: migrate
           image: {{ include "curie.image" (dict "repository" .Values.api.image.repository "tag" .Values.api.image.tag "digest" .Values.api.image.digest "defaultTag" .Chart.AppVersion) | quote }}
@@ -67,7 +67,44 @@ spec:
           {{- with .Values.api.containerSecurityContext }}
           {{- include "curie.containerSecurityContext" . | nindent 10 }}
           {{- end }}
-          command: ["alembic", "-c", "alembic.ini", "upgrade", "head"]
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              attempt=1
+              max_attempts=60
+              probe_error_class=""
+              while [ "$attempt" -le "$max_attempts" ]; do
+                if probe_error_class=$(python -c '
+              import asyncio
+              import os
+
+              try:
+                  import asyncpg
+
+                  async def probe():
+                      database_url = os.environ["DATABASE_URL"].replace(
+                          "postgresql+asyncpg://", "postgresql://", 1
+                      )
+                      connection = await asyncpg.connect(database_url, timeout=2)
+                      await connection.close()
+
+                  asyncio.run(probe())
+              except Exception as error:
+                  print(type(error).__name__)
+                  raise SystemExit(1)
+              ' 2>/dev/null); then
+                  exec alembic -c alembic.ini upgrade head
+                fi
+                if [ "$attempt" -eq 1 ]; then
+                  echo "Waiting for Postgres readiness"
+                fi
+                if [ "$attempt" -lt "$max_attempts" ]; then
+                  sleep 2
+                fi
+                attempt=$((attempt + 1))
+              done
+              echo "Postgres unavailable after $max_attempts readiness attempts; final probe error class: $probe_error_class; exiting for init container restart" >&2
+              exit 1
           env:
             {{- include "curie.env.postgres" . | nindent 12 }}
       {{- end }}


### PR DESCRIPTION
## Summary

Treat two expected rollout races as bounded waiting conditions. The API migration initContainer now probes Postgres quietly before running Alembic, while terminal probe exhaustion and migration failures remain nonzero. The worker connector loop now gives each agent three consecutive platform API 5xx passes below ERROR before restoring failure accounting and traceback logging on the fourth and later passes.

## Related issue

Closes #1762

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | No plugin packaging, runner loop, ACI event, skill eval, or skill check behavior changed. | n/a | n/a |
| local | required | The worker connector reconcile loop and its failure accounting changed. | fake | At `c201f4c9`, `TEST_DATABASE_URL='postgresql+asyncpg://postgres:postgres@localhost:55432/postgres' LANGFUSE_HOST='http://localhost:53000' TEST_LANGFUSE_HOST='http://localhost:53000' TEST_VALKEY_HOST='localhost' TEST_VALKEY_PORT='56379' TEST_VALKEY_PW='valkeypass' TEST_S3_ENDPOINT_URL='http://localhost:59000' uv run pytest apps/worker` completed with `859 passed, 7 skipped`. The focused connector loop suite completed with `22 passed`; reverting the bounded retry made its first three grace assertions fail. |
| local-release | n/a | No released binary, image identity, install path, version pin, or release compose behavior changed. | n/a | n/a |
| cluster | required | The API migration initContainer command changed. | fake | At `c201f4c9`, two independent disposable kind runs exercised the initContainer from `helm template curie charts/curie` against deliberately delayed Postgres. Before readiness, the initContainer was running with restart count `0`; its entire log was exactly `Waiting for Postgres readiness`. After readiness, it completed with exit code `0`, restart count `0`, no traceback, and the database reported Alembic version `0027`. `bash charts/curie/ci/render-assertions.sh` also rejected both a changed retry bound and the reverted direct Alembic command. |
| live provider | n/a | No model routing, provider authentication, credential resolution, token, or cost behavior changed. | n/a | n/a |
| external integration | n/a | No Slack, webhook, OAuth, or third party API contract changed. | n/a | n/a |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.
- [ ] Or: this change is not behavior-bearing, so no tier applies, and the summary says why.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed. The initContainer comment and connector loop module contract describe the new behavior; no user-facing documentation was affected.
- [ ] An ADR is added under `docs/adr/` if this is an architectural decision. Not applicable because this is bounded retry and logging behavior within existing ownership boundaries.
