### PR TITLE
Use an unprivileged local port in cluster status

### DIFF
--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -6335,6 +6335,12 @@ enum ServiceUrlKind {
 }
 
 impl ServiceUrl {
+    /// Build the shared port-forward text after the caller chooses whether the
+    /// URL target is plain (JSON) or styled (human output).
+    fn port_forward_hint(&self, local: u16, port: u16, target: &str) -> String {
+        port_forward_hint_with(&self.namespace, &self.name, local, port, target)
+    }
+
     fn to_json(&self) -> serde_json::Value {
         let (url, note): (Option<String>, Option<String>) = match &self.kind {
             ServiceUrlKind::NodePortUrl(url) => (Some(url.clone()), None),
@@ -6350,9 +6356,7 @@ impl ServiceUrl {
                 let suffix_path = api_suffix_path(self.api);
                 (
                     None,
-                    Some(port_forward_hint_with(
-                        &self.namespace,
-                        &self.name,
+                    Some(self.port_forward_hint(
                         *local,
                         *port,
                         &format!("http://localhost:{local}{suffix_path}"),
@@ -6383,9 +6387,7 @@ impl ServiceUrl {
                 let suffix_path = api_suffix_path(self.api);
                 ui.kv(
                     &self.label,
-                    &port_forward_hint_with(
-                        &self.namespace,
-                        &self.name,
+                    &self.port_forward_hint(
                         *local,
                         *port,
                         &ui.url(&format!("http://localhost:{local}{suffix_path}")),
@@ -9350,6 +9352,43 @@ mod tests {
                 "url": null,
                 "note": "kubectl -n curie port-forward svc/curie-ui 18080:80  then http://localhost:18080/?api=1",
             })
+        );
+    }
+
+    #[test]
+    fn service_url_port_forward_hint_preserves_a_human_identity_target() {
+        let service_url = ServiceUrl {
+            label: "UI".to_string(),
+            name: "curie-ui".to_string(),
+            namespace: "curie".to_string(),
+            api: true,
+            kind: ServiceUrlKind::PortForward {
+                local: 18080,
+                port: 80,
+            },
+        };
+        let ui = crate::ui::Ui::resolve(
+            crate::ui::ColorFlag::Never,
+            false,
+            false,
+            false,
+            &crate::ui::UiEnv {
+                no_color: false,
+                clicolor_zero: false,
+                clicolor_force: false,
+                term_dumb: false,
+                ci: false,
+                stderr_tty: true,
+                stdout_tty: true,
+                utf8: true,
+                truecolor: false,
+            },
+        );
+        let target = ui.url("http://localhost:18080/?api=1");
+        assert_eq!(target, "http://localhost:18080/?api=1");
+        assert_eq!(
+            service_url.port_forward_hint(18080, 80, &target),
+            "kubectl -n curie port-forward svc/curie-ui 18080:80  then http://localhost:18080/?api=1"
         );
     }
 

--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -6471,7 +6471,8 @@ pub enum ServiceEndpoint {
     /// Type NodePort but no nodePort assigned yet.
     UnassignedNodePort,
     /// ClusterIP/other: reachable only via a port-forward.
-    /// `local = if port == 0 { 8080 } else { port }`.
+    /// `local` is a non-privileged port: HTTP services on port 80 use 18080,
+    /// while an absent service port falls back to 8080.
     PortForwardHint { local: u16, port: u16 },
     /// `parse_service` returned None (malformed/unreadable JSON).
     Unreadable,
@@ -6497,7 +6498,11 @@ fn resolve_service_endpoint(svc_json: &str, host: &str, api: bool) -> ServiceEnd
             None => ServiceEndpoint::UnassignedNodePort,
         },
         Some((_, _, port)) => ServiceEndpoint::PortForwardHint {
-            local: if port == 0 { 8080 } else { port },
+            local: match port {
+                0 => 8080,
+                80 => 18080,
+                _ => port,
+            },
             port,
         },
         None => ServiceEndpoint::Unreadable,
@@ -9239,15 +9244,18 @@ mod tests {
 
     #[test]
     fn resolve_service_endpoint_clusterip_yields_a_port_forward_hint() {
-        // ClusterIP: not node-exposed, so the caller must port-forward. The local
-        // port mirrors the service port.
+        // ClusterIP: not node-exposed, so the caller must port-forward. HTTP's
+        // privileged service port maps to a non-privileged local port.
         let clusterip = r#"{"spec":{"type":"ClusterIP","ports":[{"port":80}]}}"#;
-        assert_eq!(
-            resolve_service_endpoint(clusterip, "10.0.0.5", true),
-            ServiceEndpoint::PortForwardHint {
-                local: 80,
-                port: 80
-            }
+        let endpoint = resolve_service_endpoint(clusterip, "10.0.0.5", true);
+        let ServiceEndpoint::PortForwardHint { local, port } = endpoint else {
+            panic!("ClusterIP services must yield a port-forward hint");
+        };
+        assert_eq!(local, 18080);
+        assert_eq!(port, 80);
+        assert!(
+            local >= 1024,
+            "the local port must be bindable by a non-root user"
         );
         // An absent port parses as 0, which falls back to local port 8080.
         let no_port = r#"{"spec":{"type":"ClusterIP","ports":[{}]}}"#;
@@ -9289,8 +9297,8 @@ mod tests {
         // The exact hint `cluster status` prints today for a ClusterIP service
         // (PR#34 visual-parity guard): two spaces before `then`.
         assert_eq!(
-            port_forward_hint("curie", "curie-ui", 80, 80, "/?api=1"),
-            "kubectl -n curie port-forward svc/curie-ui 80:80  then http://localhost:80/?api=1"
+            port_forward_hint("curie", "curie-ui", 18080, 80, "/?api=1"),
+            "kubectl -n curie port-forward svc/curie-ui 18080:80  then http://localhost:18080/?api=1"
         );
         // The 0-port fallback surfaces local 8080 while still forwarding to 0.
         assert_eq!(

--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -6471,8 +6471,8 @@ pub enum ServiceEndpoint {
     /// Type NodePort but no nodePort assigned yet.
     UnassignedNodePort,
     /// ClusterIP/other: reachable only via a port-forward.
-    /// `local` is a non-privileged port: HTTP services on port 80 use 18080,
-    /// while an absent service port falls back to 8080.
+    /// `local` is non-privileged: service ports below 1024 are offset by
+    /// 18000, while an absent service port falls back to 8080.
     PortForwardHint { local: u16, port: u16 },
     /// `parse_service` returned None (malformed/unreadable JSON).
     Unreadable,
@@ -6500,7 +6500,7 @@ fn resolve_service_endpoint(svc_json: &str, host: &str, api: bool) -> ServiceEnd
         Some((_, _, port)) => ServiceEndpoint::PortForwardHint {
             local: match port {
                 0 => 8080,
-                80 => 18080,
+                1..=1023 => port + 18000,
                 _ => port,
             },
             port,
@@ -9244,19 +9244,40 @@ mod tests {
 
     #[test]
     fn resolve_service_endpoint_clusterip_yields_a_port_forward_hint() {
-        // ClusterIP: not node-exposed, so the caller must port-forward. HTTP's
-        // privileged service port maps to a non-privileged local port.
-        let clusterip = r#"{"spec":{"type":"ClusterIP","ports":[{"port":80}]}}"#;
-        let endpoint = resolve_service_endpoint(clusterip, "10.0.0.5", true);
-        let ServiceEndpoint::PortForwardHint { local, port } = endpoint else {
+        // ClusterIP: not node-exposed, so the caller must port-forward. Each
+        // privileged service port maps to a deterministic non-privileged local port.
+        let http_clusterip = r#"{"spec":{"type":"ClusterIP","ports":[{"port":80}]}}"#;
+        let http_endpoint = resolve_service_endpoint(http_clusterip, "10.0.0.5", true);
+        let ServiceEndpoint::PortForwardHint {
+            local: http_local,
+            port: http_port,
+        } = http_endpoint
+        else {
             panic!("ClusterIP services must yield a port-forward hint");
         };
-        assert_eq!(local, 18080);
-        assert_eq!(port, 80);
+        assert_eq!(http_local, 18080);
+        assert_eq!(http_port, 80);
         assert!(
-            local >= 1024,
+            http_local >= 1024,
             "the local port must be bindable by a non-root user"
         );
+
+        let https_clusterip = r#"{"spec":{"type":"ClusterIP","ports":[{"port":443}]}}"#;
+        let https_endpoint = resolve_service_endpoint(https_clusterip, "10.0.0.5", true);
+        let ServiceEndpoint::PortForwardHint {
+            local: https_local,
+            port: https_port,
+        } = https_endpoint
+        else {
+            panic!("ClusterIP services must yield a port-forward hint");
+        };
+        assert_eq!(https_local, 18443);
+        assert_eq!(https_port, 443);
+        assert!(
+            https_local >= 1024,
+            "the local port must be bindable by a non-root user"
+        );
+
         // An absent port parses as 0, which falls back to local port 8080.
         let no_port = r#"{"spec":{"type":"ClusterIP","ports":[{}]}}"#;
         assert_eq!(
@@ -9304,6 +9325,31 @@ mod tests {
         assert_eq!(
             port_forward_hint("curie", "curie-langfuse-web", 8080, 0, ""),
             "kubectl -n curie port-forward svc/curie-langfuse-web 8080:0  then http://localhost:8080"
+        );
+    }
+
+    #[test]
+    fn service_url_json_uses_the_privileged_port_forward_hint() {
+        let clusterip = r#"{"spec":{"type":"ClusterIP","ports":[{"port":80}]}}"#;
+        let endpoint = resolve_service_endpoint(clusterip, "10.0.0.5", true);
+        let ServiceEndpoint::PortForwardHint { local, port } = endpoint else {
+            panic!("ClusterIP services must yield a port-forward hint");
+        };
+        let service_url = ServiceUrl {
+            label: "UI".to_string(),
+            name: "curie-ui".to_string(),
+            namespace: "curie".to_string(),
+            api: true,
+            kind: ServiceUrlKind::PortForward { local, port },
+        };
+
+        assert_eq!(
+            service_url.to_json(),
+            serde_json::json!({
+                "name": "UI",
+                "url": null,
+                "note": "kubectl -n curie port-forward svc/curie-ui 18080:80  then http://localhost:18080/?api=1",
+            })
         );
     }
 


### PR DESCRIPTION
Closes #1814

ClusterIP status hints now forward privileged service ports to deterministic unprivileged local ports, preserving the remote port. Regression coverage includes JSON and human status hint formatting.