### PR TITLE
Split approval notification targets

### DIFF
--- a/apps/api/alembic/versions/0034_approval_route_targets.py
+++ b/apps/api/alembic/versions/0034_approval_route_targets.py
@@ -1,0 +1,201 @@
+"""split approval notification from the resolution target (#1460)
+
+The approval route's old ``channel`` field fused where humans were notified
+with where a verified identity could act. Existing durable JSONB rows are
+rewritten here so the application and worker can reject that retired shape at
+every runtime boundary without silently unbinding deployed routes.
+
+Downgrade is loss-aware. The legacy shape can represent only one Slack
+resolution channel and no second notification target, so any richer row is
+named and refused before the first write.
+
+Revision ID: 0034
+Revises: 0033
+Create Date: 2026-08-23
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0034"
+down_revision: str | None = "0033"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+SCHEMA = "curie"
+TABLE = "agents"
+SLACK = "slack"
+
+
+def _lock_agents() -> None:
+    """Freeze approval-route writers for this transaction's inspect/rewrite."""
+
+    # The preflight and rewrite are one decision. Without this table lock, a
+    # concurrent agent PATCH can insert a malformed legacy/split binding after
+    # inspection and before the UPDATE, defeating the migration's all-or-none
+    # claim. SHARE ROW EXCLUSIVE blocks INSERT/UPDATE/DELETE while preserving
+    # ordinary reads, and PostgreSQL holds it until Alembic commits or rolls back.
+    op.get_bind().execute(
+        sa.text(f"LOCK TABLE {SCHEMA}.{TABLE} IN SHARE ROW EXCLUSIVE MODE")
+    )
+
+
+def _rows_with_routes() -> list[tuple[str, Any]]:
+    return [
+        (row.name, row.approval_routes)
+        for row in op.get_bind()
+        .execute(
+            sa.text(
+                f"""
+                SELECT name, approval_routes
+                FROM {SCHEMA}.{TABLE}
+                WHERE approval_routes IS NOT NULL
+                  AND approval_routes <> 'null'::jsonb
+                ORDER BY name
+                """
+            )
+        )
+        .all()
+    ]
+
+
+def _legacy_violations() -> list[str]:
+    violations: list[str] = []
+    for agent, routes in _rows_with_routes():
+        if not isinstance(routes, Mapping):
+            violations.append(f"{agent} (<approval_routes>: expected an object)")
+            continue
+        for route, binding in routes.items():
+            route_label = str(route)
+            if not isinstance(route, str) or not route.strip():
+                violations.append(f"{agent} ({route_label!r}: invalid route name)")
+                continue
+            if not isinstance(binding, Mapping):
+                violations.append(f"{agent} ({route}: binding is not an object)")
+                continue
+            unknown = sorted(set(binding) - {"channel", "approvers"})
+            channel = binding.get("channel")
+            if unknown:
+                violations.append(f"{agent} ({route}: unknown keys {unknown})")
+            elif not isinstance(channel, str) or not channel.strip():
+                violations.append(f"{agent} ({route}: channel is not a non-empty string)")
+            elif "approvers" in binding and not isinstance(binding["approvers"], Mapping):
+                violations.append(f"{agent} ({route}: approvers is not an object)")
+    return violations
+
+
+def upgrade() -> None:
+    _lock_agents()
+    violations = _legacy_violations()
+    if violations:
+        raise RuntimeError(
+            "cannot split approval resolution from notification (#1460): these "
+            "legacy bindings are malformed and no row was rewritten -- "
+            + "; ".join(violations)
+            + ". Repair or remove the named routes, then re-run this migration."
+        )
+
+    # One statement after the complete preflight: every populated map changes
+    # together, route names and approvers are retained byte-for-byte as JSONB,
+    # and NULL/empty maps stay NULL/empty.
+    op.get_bind().execute(
+        sa.text(
+            f"""
+            UPDATE {SCHEMA}.{TABLE} AS a
+            SET approval_routes = (
+                SELECT jsonb_object_agg(
+                    route.key,
+                    (route.value - 'channel') || jsonb_build_object(
+                        'resolution',
+                        jsonb_build_object(
+                            'kind', CAST(:slack AS text),
+                            'address', route.value -> 'channel'
+                        )
+                    )
+                )
+                FROM jsonb_each(a.approval_routes) AS route
+            )
+            WHERE a.approval_routes IS NOT NULL
+              AND a.approval_routes <> 'null'::jsonb
+              AND a.approval_routes <> '{{}}'::jsonb
+            """
+        ),
+        {"slack": SLACK},
+    )
+
+
+def _split_violations() -> list[str]:
+    violations: list[str] = []
+    for agent, routes in _rows_with_routes():
+        if not isinstance(routes, Mapping):
+            violations.append(f"{agent} (<approval_routes>: expected an object)")
+            continue
+        for route, binding in routes.items():
+            route_label = str(route)
+            if not isinstance(route, str) or not route.strip():
+                violations.append(f"{agent} ({route_label!r}: invalid route name)")
+                continue
+            if not isinstance(binding, Mapping):
+                violations.append(f"{agent} ({route}: binding is not an object)")
+                continue
+            if "notification" in binding:
+                violations.append(f"{agent} ({route}: has a notification target)")
+                continue
+            unknown = sorted(set(binding) - {"resolution", "approvers"})
+            resolution = binding.get("resolution")
+            if unknown:
+                violations.append(f"{agent} ({route}: unknown keys {unknown})")
+            elif not isinstance(resolution, Mapping):
+                violations.append(f"{agent} ({route}: resolution is not an object)")
+            elif set(resolution) != {"kind", "address"}:
+                violations.append(f"{agent} ({route}: malformed resolution target)")
+            elif resolution.get("kind") != SLACK:
+                violations.append(
+                    f"{agent} ({route}: resolution kind {resolution.get('kind')!r} is not slack)"
+                )
+            elif (
+                not isinstance(resolution.get("address"), str) or not resolution["address"].strip()
+            ):
+                violations.append(f"{agent} ({route}: resolution address is invalid)")
+            elif "approvers" in binding and not isinstance(binding["approvers"], Mapping):
+                violations.append(f"{agent} ({route}: approvers is not an object)")
+    return violations
+
+
+def downgrade() -> None:
+    _lock_agents()
+    violations = _split_violations()
+    if violations:
+        raise RuntimeError(
+            "cannot restore the fused approval route channel (#1460): these "
+            "bindings cannot be represented without losing a notification or "
+            "relabeling a resolver, and no row was rewritten -- "
+            + "; ".join(violations)
+            + ". Remove the notification targets or restore Slack-only "
+            "resolutions on the named routes, then re-run this downgrade."
+        )
+
+    op.get_bind().execute(
+        sa.text(
+            f"""
+            UPDATE {SCHEMA}.{TABLE} AS a
+            SET approval_routes = (
+                SELECT jsonb_object_agg(
+                    route.key,
+                    (route.value - 'resolution') || jsonb_build_object(
+                        'channel', route.value #> '{{resolution,address}}'
+                    )
+                )
+                FROM jsonb_each(a.approval_routes) AS route
+            )
+            WHERE a.approval_routes IS NOT NULL
+              AND a.approval_routes <> 'null'::jsonb
+              AND a.approval_routes <> '{{}}'::jsonb
+            """
+        )
+    )

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -624,7 +624,9 @@
           "approval_routes": {
             "anyOf": [
               {
-                "additionalProperties": true,
+                "additionalProperties": {
+                  "$ref": "#/components/schemas/ApprovalRouteBindingOut"
+                },
                 "type": "object"
               },
               {
@@ -844,7 +846,7 @@
       },
       "ApprovalApprovers": {
         "additionalProperties": false,
-        "description": "WHO may resolve a route's approvals (#420), as opposed to the binding's\n``channel``, which is only WHERE the card posts.\n\nDeclaring an approvers block is what lets a request sit in a broad channel\nwhere everyone can see it while only a narrow set may act on it. Omitting it\nkeeps the zero-setup default: the card channel's members are the approvers.",
+        "description": "WHO may resolve a route's approvals (#420), as opposed to the binding's\n``resolution``, which is only WHERE the interactive card posts.\n\nDeclaring an approvers block is what lets a request sit in a broad channel\nwhere everyone can see it while only a narrow set may act on it. Omitting it\nkeeps the zero-setup default: the resolution-card channel's members are the\napprovers. Notification recipients never enter this policy.",
         "properties": {
           "group": {
             "anyOf": [
@@ -873,6 +875,38 @@
           }
         },
         "title": "ApprovalApprovers",
+        "type": "object"
+      },
+      "ApprovalApproversOut": {
+        "description": "Repair-oriented read projection of the stored approver declaration.",
+        "properties": {
+          "group": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Group"
+          },
+          "users": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Users"
+          }
+        },
+        "title": "ApprovalApproversOut",
         "type": "object"
       },
       "ApprovalAuditOut": {
@@ -962,6 +996,48 @@
           "created_at"
         ],
         "title": "ApprovalAuditOut",
+        "type": "object"
+      },
+      "ApprovalNotificationTarget": {
+        "additionalProperties": false,
+        "description": "A visibility-only approval ping target and its server-side transport.\n\nSlack may use the worker's configured default transport. Every other kind\nneeds the full endpoint/adapter pair at write time, so a declared\nnotification cannot persist as a permanently undeliverable best-effort\nbranch.",
+        "properties": {
+          "adapter": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Adapter"
+          },
+          "address": {
+            "title": "Address",
+            "type": "string"
+          },
+          "endpoint": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Endpoint"
+          },
+          "kind": {
+            "title": "Kind",
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "address"
+        ],
+        "title": "ApprovalNotificationTarget",
         "type": "object"
       },
       "ApprovalOut": {
@@ -1296,6 +1372,27 @@
         "title": "ApprovalRequest",
         "type": "object"
       },
+      "ApprovalResolutionTarget": {
+        "additionalProperties": false,
+        "description": "The one target permitted to carry an approval-resolving affordance.\n\n``kind`` is an explicit extension point, but it is intentionally Slack-only\nuntil a second adapter can present the scoped verified identity ADR-0096\nrequires. Merely teaching an adapter to render buttons cannot widen this\nauthority boundary.",
+        "properties": {
+          "address": {
+            "title": "Address",
+            "type": "string"
+          },
+          "kind": {
+            "const": "slack",
+            "title": "Kind",
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "address"
+        ],
+        "title": "ApprovalResolutionTarget",
+        "type": "object"
+      },
       "ApprovalResolve": {
         "description": "One resolution attempt. Exactly one attempt wins (compare-and-set), and\nthe server-side authorizer (#246) decides first whether this actor may\nresolve at all: ordinary self-approval is blocked, while a server-linked\npublication requester must still prove membership. ``actor_channel`` is the\nchannel the resolution attempt was made from (the card click's channel,\nrelayed by the dispatcher; asserted explicitly by API-key operators).",
         "properties": {
@@ -1344,7 +1441,7 @@
       },
       "ApprovalRouteBinding": {
         "additionalProperties": false,
-        "description": "One workspace binding for a manifest-declared approval route (#247):\nthe Slack channel whose members are that route's approvers (under the\nchannel-membership authorizer), and optionally the ``approvers`` block that\nnarrows WHO may act (#420), leaving ``channel`` to mean only WHERE the card\nposts.",
+        "description": "One strict workspace binding for a declared approval route (#1460).\n\n``resolution`` is the single verified-identity action surface.\n``notification`` may make the pending request visible elsewhere, but its\nmessage carries no interaction. ``approvers`` continues to narrow WHO may\nact through the resolution card path and is never inferred from notification\nrecipients.",
         "properties": {
           "approvers": {
             "anyOf": [
@@ -1356,15 +1453,76 @@
               }
             ]
           },
-          "channel": {
-            "title": "Channel",
+          "notification": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ApprovalNotificationTarget"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "resolution": {
+            "$ref": "#/components/schemas/ApprovalResolutionTarget"
+          }
+        },
+        "required": [
+          "resolution"
+        ],
+        "title": "ApprovalRouteBinding",
+        "type": "object"
+      },
+      "ApprovalRouteBindingOut": {
+        "description": "The required resolution plus optional, redacted visibility policy.",
+        "properties": {
+          "approvers": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ApprovalApproversOut"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "notification": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ApprovalTargetOut"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "resolution": {
+            "$ref": "#/components/schemas/ApprovalTargetOut"
+          }
+        },
+        "required": [
+          "resolution"
+        ],
+        "title": "ApprovalRouteBindingOut",
+        "type": "object"
+      },
+      "ApprovalTargetOut": {
+        "description": "Display-safe target identity; stored transport is write-only.\n\nThis is deliberately a tolerant read projection. Write models validate the\nchannel kind/address pair before persistence, while reads must still expose\na malformed historical address so an operator can repair it.",
+        "properties": {
+          "address": {
+            "title": "Address",
+            "type": "string"
+          },
+          "kind": {
+            "title": "Kind",
             "type": "string"
           }
         },
         "required": [
-          "channel"
+          "kind",
+          "address"
         ],
-        "title": "ApprovalRouteBinding",
+        "title": "ApprovalTargetOut",
         "type": "object"
       },
       "BehaviorPacksConfig": {

--- a/apps/api/src/curie_api/crud.py
+++ b/apps/api/src/curie_api/crud.py
@@ -390,7 +390,8 @@ async def update_agent_approval_routes(
     session: AsyncSession, agent: Agent, routes: dict[str, Any]
 ) -> Agent:
     """Set the agent's approval route bindings (#247). An empty dict clears
-    them (stored as NULL: unbound routes fall back to the requesting channel)."""
+    them (stored as NULL: unbound routes escalate rather than inventing a
+    resolution surface)."""
 
     agent.approval_routes = routes or None
     await session.commit()

--- a/apps/api/src/curie_api/models.py
+++ b/apps/api/src/curie_api/models.py
@@ -102,11 +102,12 @@ class Agent(Base):
     # Per-agent approval route bindings (#247, ADR-0010): the workspace half of
     # the split policy. The bundle manifest declares gate points and route
     # NAMES (versioned with the agent); this maps each declared name to
-    # workspace specifics, today a Slack channel: {"managers": {"channel":
-    # "C0123..."}}. The worker resolves a raised route through this map to
-    # decide where the approval card goes (and therefore who the
-    # channel-membership authorizer counts as approvers). NULL means no
-    # bindings; an unbound route falls back to the requesting channel.
+    # workspace specifics: one Slack-only resolution target and an optional
+    # channel-neutral notification target. The worker posts the sole resolving
+    # card at ``resolution`` (whose address is persisted on the Approval row for
+    # authorization) and may send a text-only ping at ``notification``. NULL
+    # means no bindings; a named unbound route escalates rather than widening to
+    # the requesting channel.
     approval_routes: Mapped[dict[str, Any] | None] = mapped_column(JSONB, default=None)
     # Per-agent connector secrets (ADR-0009, #429): the named secret VALUES the
     # bundle's authed MCP servers need (e.g. GITHUB_PERSONAL_ACCESS_TOKEN). The

--- a/apps/api/src/curie_api/schemas.py
+++ b/apps/api/src/curie_api/schemas.py
@@ -180,25 +180,6 @@ _CHANNEL_ADDRESS_SHAPES: dict[str, tuple[re.Pattern[str], Callable[[str], str]]]
 }
 
 
-def _validate_slack_channel_id(value: str | None) -> str | None:
-    """Enforce a Slack channel-ID shape on an APPROVAL ROUTE's destination.
-
-    Scoped to `ApprovalRouteBinding` since ADR-0096 (#1459). The agent's channel
-    binding is validated by `_validate_channel_binding` below instead: an
-    approval route's channel is a different concept that merely shared this
-    validator (bf717203d), so it keeps a Slack-specific rule of its own rather
-    than being dragged through a kind dispatch it has no kind for. Making it
-    neutral is #1460's work, not this one's.
-
-    None (an omitted PATCH field) passes through as a no-op.
-    """
-    if value is None:
-        return value
-    if not _SLACK_CHANNEL_ID.match(value):
-        raise ValueError(_slack_shape_error(value))
-    return value
-
-
 def _validate_channel_binding(kind: str, address: str) -> str:
     """Enforce the address shape a channel KIND requires, and return the address.
 
@@ -467,11 +448,12 @@ class _StoredWithoutNulls(BaseModel):
 
 class ApprovalApprovers(_StoredWithoutNulls):
     """WHO may resolve a route's approvals (#420), as opposed to the binding's
-    ``channel``, which is only WHERE the card posts.
+    ``resolution``, which is only WHERE the interactive card posts.
 
     Declaring an approvers block is what lets a request sit in a broad channel
     where everyone can see it while only a narrow set may act on it. Omitting it
-    keeps the zero-setup default: the card channel's members are the approvers.
+    keeps the zero-setup default: the resolution-card channel's members are the
+    approvers. Notification recipients never enter this policy.
     """
 
     # A typo in an optional key must not be ignored: silently dropping it would
@@ -531,28 +513,9 @@ class ApprovalApprovers(_StoredWithoutNulls):
         return self
 
 
-class ApprovalRouteBinding(_StoredWithoutNulls):
-    """One workspace binding for a manifest-declared approval route (#247):
-    the Slack channel whose members are that route's approvers (under the
-    channel-membership authorizer), and optionally the ``approvers`` block that
-    narrows WHO may act (#420), leaving ``channel`` to mean only WHERE the card
-    posts.
-    """
-
-    # Rejects a typo'd ``approver`` rather than storing a channel-only binding
-    # the operator believes narrows authority. Pre-#420 bindings are
-    # ``{"channel": ...}`` only, so forbidding extras does not reject them.
-    model_config = ConfigDict(extra="forbid")
-
-    channel: str
-    approvers: ApprovalApprovers | None = None
-
-    _check_channel = field_validator("channel")(_validate_slack_channel_id)
-
-
 def _validate_route_names(
-    value: dict[str, ApprovalRouteBinding] | None,
-) -> dict[str, ApprovalRouteBinding] | None:
+    value: "dict[str, ApprovalRouteBinding] | None",
+) -> "dict[str, ApprovalRouteBinding] | None":
     """Route names must be non-empty; they are matched verbatim against the
     manifest's declared route names."""
     if value is None:
@@ -597,7 +560,7 @@ def _reject_retired_binding_keys(data: Any) -> Any:
             raise ValueError(
                 "slack_channel is no longer an agent field: it was replaced by "
                 "the channel-neutral binding (ADR-0096), so sending it would "
-                'leave the agent bound where it already was. Send channel: '
+                "leave the agent bound where it already was. Send channel: "
                 '{"kind": "slack", "address": "C0123ABCD"} instead.'
             )
         if "channels" in data:
@@ -801,6 +764,99 @@ class ChannelBindingPatch(ChannelBindingWrite):
         return self
 
 
+class ApprovalResolutionTarget(ChannelBinding):
+    """The one target permitted to carry an approval-resolving affordance.
+
+    ``kind`` is an explicit extension point, but it is intentionally Slack-only
+    until a second adapter can present the scoped verified identity ADR-0096
+    requires. Merely teaching an adapter to render buttons cannot widen this
+    authority boundary.
+    """
+
+    kind: Literal["slack"]
+
+
+class ApprovalNotificationTarget(ChannelBindingWrite, _StoredWithoutNulls):
+    """A visibility-only approval ping target and its server-side transport.
+
+    Slack may use the worker's configured default transport. Every other kind
+    needs the full endpoint/adapter pair at write time, so a declared
+    notification cannot persist as a permanently undeliverable best-effort
+    branch.
+    """
+
+    @model_validator(mode="after")
+    def _require_non_slack_transport(self) -> "ApprovalNotificationTarget":
+        if self.kind != "slack" and self.endpoint is None:
+            raise ValueError(
+                "a non-slack approval notification target requires both endpoint "
+                "and adapter; only slack can use the worker's configured default "
+                "transport"
+            )
+        return self
+
+
+class ApprovalRouteBinding(_StoredWithoutNulls):
+    """One strict workspace binding for a declared approval route (#1460).
+
+    ``resolution`` is the single verified-identity action surface.
+    ``notification`` may make the pending request visible elsewhere, but its
+    message carries no interaction. ``approvers`` continues to narrow WHO may
+    act through the resolution card path and is never inferred from notification
+    recipients.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    resolution: ApprovalResolutionTarget
+    notification: ApprovalNotificationTarget | None = None
+    approvers: ApprovalApprovers | None = None
+
+    @model_validator(mode="after")
+    def _targets_must_differ(self) -> "ApprovalRouteBinding":
+        if self.notification is not None and (
+            self.resolution.kind,
+            self.resolution.address,
+        ) == (self.notification.kind, self.notification.address):
+            raise ValueError(
+                "approval notification must differ from the resolution target; "
+                "a duplicate target adds no notification surface"
+            )
+        return self
+
+
+class ApprovalTargetOut(ChannelBindingOut):
+    """Display-safe target identity; stored transport is write-only.
+
+    This is deliberately a tolerant read projection. Write models validate the
+    channel kind/address pair before persistence, while reads must still expose
+    a malformed historical address so an operator can repair it.
+    """
+
+    # Stored bindings contain endpoint/adapter. Accept and discard those
+    # server-controlled fields so AgentOut never discloses them.
+    model_config = ConfigDict(extra="ignore")
+
+
+class ApprovalApproversOut(BaseModel):
+    """Repair-oriented read projection of the stored approver declaration."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    group: str | None = None
+    users: list[str] | None = None
+
+
+class ApprovalRouteBindingOut(BaseModel):
+    """The required resolution plus optional, redacted visibility policy."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    resolution: ApprovalTargetOut
+    notification: ApprovalTargetOut | None = None
+    approvers: ApprovalApproversOut | None = None
+
+
 class AgentCreate(BaseModel):
     name: str
     # Required, and singular. Every create path supplies exactly one binding
@@ -823,9 +879,9 @@ class AgentCreate(BaseModel):
     # Per-agent permission gates (#245): tool names requiring human approval.
     # None means no gates (the bypass posture).
     approval_required_tools: list[str] | None = None
-    # Per-agent approval route bindings (#247): manifest route name -> workspace
-    # channel. None means no bindings (unbound routes fall back to the
-    # requesting channel).
+    # Per-agent approval route bindings (#247/#1460): manifest route name -> one
+    # verified Slack resolution target and optional visibility-only notification
+    # target. None means no bindings; a named unbound route escalates.
     approval_routes: dict[str, ApprovalRouteBinding] | None = None
     # Per-agent connector secret VALUES (ADR-0009, #429): env-var-style name ->
     # secret. Stored on the agent row for the local tier and forwarded into the
@@ -923,7 +979,7 @@ class AgentOut(BaseModel):
     model: str | None
     thinking: str | None
     approval_required_tools: list[str] | None
-    approval_routes: dict[str, Any] | None
+    approval_routes: dict[str, ApprovalRouteBindingOut] | None
     # Connector secret NAMES only (#429) -- values are never returned. The stored
     # column is a name->value map; expose just the sorted names so an operator can
     # see which secrets an agent has bound without the material leaving the API.

--- a/apps/api/tests/test_agents.py
+++ b/apps/api/tests/test_agents.py
@@ -71,6 +71,44 @@ def _binding_row(agent_id: str) -> Any:
     return asyncio.run(run())
 
 
+def _approval_routes_row(agent_id: str) -> dict[str, Any] | None:
+    """Read the unredacted durable route config straight from Postgres."""
+
+    async def run() -> dict[str, Any] | None:
+        engine = create_async_engine(get_settings().database_url)
+        try:
+            async with engine.connect() as conn:
+                result = await conn.execute(
+                    sql_text("SELECT approval_routes FROM curie.agents WHERE id = :aid"),
+                    {"aid": agent_id},
+                )
+                return result.scalar_one()
+        finally:
+            await engine.dispose()
+
+    return asyncio.run(run())
+
+
+def _set_approval_routes_row(agent_id: str, routes: dict[str, Any]) -> None:
+    """Seed an out-of-band route shape to prove read-side repairability."""
+
+    async def run() -> None:
+        engine = create_async_engine(get_settings().database_url)
+        try:
+            async with engine.begin() as conn:
+                await conn.execute(
+                    sql_text(
+                        "UPDATE curie.agents SET approval_routes = CAST(:routes AS jsonb) "
+                        "WHERE id = :aid"
+                    ),
+                    {"aid": agent_id, "routes": json.dumps(routes)},
+                )
+        finally:
+            await engine.dispose()
+
+    asyncio.run(run())
+
+
 def test_duplicate_name_is_409(client: Any, auth_headers: dict[str, str], clean_db: None) -> None:
     first = _create(client, auth_headers, name="dup-name", channel=_slack("C0AAAAAA1"))
     assert first.status_code == 201, first.text
@@ -777,36 +815,269 @@ def test_agent_approval_routes_round_trip(
         "/agents",
         json={
             "name": "routed-agent",
-            "channel": {"kind": "slack", "address": "C000000R01"},
-            "approval_routes": {"managers": {"channel": "C000000R02"}},
+            "channel": _slack("C0EXAMPLE0"),
+            "approval_routes": {"managers": {"resolution": _slack("C0EXAMPLE1")}},
         },
         headers=auth_headers,
     )
     assert created.status_code == 201, created.text
     body = created.json()
-    assert body["approval_routes"] == {"managers": {"channel": "C000000R02"}}
+    assert body["approval_routes"] == {
+        "managers": {
+            "resolution": _slack("C0EXAMPLE1"),
+            "notification": None,
+            "approvers": None,
+        }
+    }
 
     # PATCH replaces the map; an explicit empty dict clears it.
     patched = client.patch(
         f"/agents/{body['id']}",
-        json={"approval_routes": {"legal": {"channel": "C000000R03"}}},
+        json={"approval_routes": {"legal": {"resolution": _slack("C0EXAMPLE2")}}},
         headers=auth_headers,
     )
-    assert patched.json()["approval_routes"] == {"legal": {"channel": "C000000R03"}}
+    assert patched.json()["approval_routes"] == {
+        "legal": {
+            "resolution": _slack("C0EXAMPLE2"),
+            "notification": None,
+            "approvers": None,
+        }
+    }
     cleared = client.patch(
         f"/agents/{body['id']}", json={"approval_routes": {}}, headers=auth_headers
     )
     assert cleared.json()["approval_routes"] is None
 
 
+@pytest.mark.parametrize(
+    ("case", "binding", "reason"),
+    [
+        ("missing-resolution", {}, "field required"),
+        ("retired-channel", {"channel": "C0EXAMPLE1"}, "extra inputs are not permitted"),
+        (
+            "non-slack-resolution",
+            {"resolution": {"kind": "email", "address": "human@example.com"}},
+            "input should be 'slack'",
+        ),
+        (
+            "notification-without-transport",
+            {
+                "resolution": _slack("C0EXAMPLE1"),
+                "notification": {"kind": "email", "address": "human@example.com"},
+            },
+            "requires both endpoint and adapter",
+        ),
+        (
+            "notification-without-adapter",
+            {
+                "resolution": _slack("C0EXAMPLE1"),
+                "notification": {
+                    "kind": "email",
+                    "address": "human@example.com",
+                    "endpoint": "https://adapter.example.com/replies",
+                },
+            },
+            "half-configured",
+        ),
+        (
+            "notification-without-endpoint",
+            {
+                "resolution": _slack("C0EXAMPLE1"),
+                "notification": {
+                    "kind": "email",
+                    "address": "human@example.com",
+                    "adapter": "mail",
+                },
+            },
+            "half-configured",
+        ),
+        (
+            "duplicate-target",
+            {
+                "resolution": _slack("C0EXAMPLE1"),
+                "notification": _slack("C0EXAMPLE1"),
+            },
+            "approval notification must differ",
+        ),
+    ],
+)
+def test_approval_route_create_rejects_invalid_split_bindings(
+    case: str,
+    binding: dict[str, Any],
+    reason: str,
+    client: Any,
+    auth_headers: dict[str, str],
+    clean_db: None,
+) -> None:
+    """Every authority/transport violation is a reasoned 422 at the write gate."""
+
+    response = client.post(
+        "/agents",
+        json={
+            "name": f"invalid-route-{case}",
+            "channel": _slack("C0EXAMPLE0"),
+            "approval_routes": {"managers": binding},
+        },
+        headers=auth_headers,
+    )
+    assert response.status_code == 422, f"{binding!r} was accepted: {response.text}"
+    assert reason in response.text.lower(), response.text
+
+
+def test_approval_route_patch_rejects_missing_or_retired_resolution(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    """The migration-only cutover remains fail closed on PATCH as well as create."""
+
+    seed = _create(
+        client,
+        auth_headers,
+        name="strict-route-patch",
+        channel=_slack("C0EXAMPLE0"),
+    )
+    assert seed.status_code == 201, seed.text
+    for binding, reason in (
+        ({}, "field required"),
+        ({"channel": "C0EXAMPLE1"}, "extra inputs are not permitted"),
+    ):
+        patched = client.patch(
+            f"/agents/{seed.json()['id']}",
+            json={"approval_routes": {"managers": binding}},
+            headers=auth_headers,
+        )
+        assert patched.status_code == 422, f"{binding!r} was accepted: {patched.text}"
+        assert reason in patched.text.lower(), patched.text
+
+
+def test_nested_notification_nulls_are_not_persisted(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    created = client.post(
+        "/agents",
+        json={
+            "name": "minimal-slack-notification",
+            "channel": _slack("C0EXAMPLE0"),
+            "approval_routes": {
+                "managers": {
+                    "resolution": _slack("C0EXAMPLE1"),
+                    "notification": {
+                        "kind": "slack",
+                        "address": "C0EXAMPLE2",
+                        "endpoint": None,
+                        "adapter": None,
+                    },
+                }
+            },
+        },
+        headers=auth_headers,
+    )
+    assert created.status_code == 201, created.text
+    assert _approval_routes_row(created.json()["id"]) == {
+        "managers": {
+            "resolution": _slack("C0EXAMPLE1"),
+            "notification": _slack("C0EXAMPLE2"),
+        }
+    }
+
+
+def test_notification_transport_is_stored_but_never_returned(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    transport = {
+        "kind": "email",
+        "address": "approvals@example.com",
+        "endpoint": "https://adapter.example.com/replies",
+        "adapter": "mail",
+    }
+    created = client.post(
+        "/agents",
+        json={
+            "name": "redacted-notification",
+            "channel": _slack("C0EXAMPLE0"),
+            "approval_routes": {
+                "managers": {
+                    "resolution": _slack("C0EXAMPLE1"),
+                    "notification": transport,
+                }
+            },
+        },
+        headers=auth_headers,
+    )
+    assert created.status_code == 201, created.text
+    agent_id = created.json()["id"]
+    public_route = {
+        "resolution": _slack("C0EXAMPLE1"),
+        "notification": {
+            "kind": "email",
+            "address": "approvals@example.com",
+        },
+        "approvers": None,
+    }
+    assert created.json()["approval_routes"] == {"managers": public_route}
+    assert _approval_routes_row(agent_id) == {
+        "managers": {
+            "resolution": _slack("C0EXAMPLE1"),
+            "notification": transport,
+        }
+    }
+
+    fetched = client.get(f"/agents/{agent_id}", headers=auth_headers)
+    assert fetched.status_code == 200, fetched.text
+    assert fetched.json()["approval_routes"] == {"managers": public_route}
+
+
+def test_malformed_stored_route_addresses_remain_readable_for_repair(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    created = _create(
+        client,
+        auth_headers,
+        name="repairable-route",
+        channel=_slack("C0EXAMPLE0"),
+        approval_routes={"managers": {"resolution": _slack("C0EXAMPLE1")}},
+    )
+    assert created.status_code == 201, created.text
+    agent_id = created.json()["id"]
+    _set_approval_routes_row(
+        agent_id,
+        {
+            "managers": {
+                "resolution": {"kind": "slack", "address": "#legacy-resolution"},
+                "notification": {
+                    "kind": "email",
+                    "address": "bad address",
+                    "endpoint": "https://adapter.example.com/replies",
+                    "adapter": "mail",
+                },
+                "approvers": {"group": "not-a-group", "users": ["not-a-user"]},
+            }
+        },
+    )
+    public_routes = {
+        "managers": {
+            "resolution": {"kind": "slack", "address": "#legacy-resolution"},
+            "notification": {"kind": "email", "address": "bad address"},
+            "approvers": {"group": "not-a-group", "users": ["not-a-user"]},
+        }
+    }
+
+    fetched = client.get(f"/agents/{agent_id}", headers=auth_headers)
+    listed = client.get("/agents", headers=auth_headers)
+    assert fetched.status_code == 200, fetched.text
+    assert listed.status_code == 200, listed.text
+    assert fetched.json()["approval_routes"] == public_routes
+    listed_agent = next(agent for agent in listed.json() if agent["id"] == agent_id)
+    assert listed_agent["approval_routes"] == public_routes
+
+
 def test_agent_approval_routes_rejects_bad_bindings(
     client: Any, auth_headers: dict[str, str], clean_db: None
 ) -> None:
-    # A binding must carry a Slack channel ID, not a #name; route names must be
-    # non-empty.
+    # A resolution target must carry a Slack channel ID, not a #name; route
+    # names must be non-empty.
     for routes in (
-        {"managers": {"channel": "#managers"}},
-        {" ": {"channel": "C000000R04"}},
+        {"managers": {"resolution": _slack("#managers")}},
+        {" ": {"resolution": _slack("C0EXAMPLE1")}},
     ):
         resp = client.post(
             "/agents",
@@ -822,7 +1093,7 @@ def test_agent_approval_routes_rejects_bad_bindings(
 
 # --- #420: the approvers block on a route binding ------------------------------
 #
-# `approvers` is the WHO, sitting alongside the binding's `channel` (the WHERE).
+# `approvers` is the WHO, sitting alongside the binding's `resolution` (the WHERE).
 # It is workspace deployment config, so it is validated on write with the same
 # allowlist-ID discipline #143 established for channels: real IDs, never
 # @handles or bare names, which never resolve and fail silently.
@@ -844,7 +1115,10 @@ def test_agent_approval_routes_with_approvers_round_trip(
             "name": "approvers-agent",
             "channel": {"kind": "slack", "address": "C000000A01"},
             "approval_routes": {
-                "managers": {"channel": "C000000A02", "approvers": {"group": "S000000G1"}}
+                "managers": {
+                    "resolution": _slack("C0EXAMPLE1"),
+                    "approvers": {"group": "S000000G1"},
+                }
             },
         },
         headers=auth_headers,
@@ -852,7 +1126,11 @@ def test_agent_approval_routes_with_approvers_round_trip(
     assert created.status_code == 201, created.text
     body = created.json()
     assert body["approval_routes"] == {
-        "managers": {"channel": "C000000A02", "approvers": {"group": "S000000G1"}}
+        "managers": {
+            "resolution": _slack("C0EXAMPLE1"),
+            "notification": None,
+            "approvers": {"group": "S000000G1", "users": None},
+        }
     }
 
     patched = client.patch(
@@ -860,7 +1138,7 @@ def test_agent_approval_routes_with_approvers_round_trip(
         json={
             "approval_routes": {
                 "managers": {
-                    "channel": "C000000A02",
+                    "resolution": _slack("C0EXAMPLE1"),
                     "approvers": {"users": ["U000000U1", "W000000E1"]},
                 }
             }
@@ -870,8 +1148,12 @@ def test_agent_approval_routes_with_approvers_round_trip(
     assert patched.status_code == 200, patched.text
     assert patched.json()["approval_routes"] == {
         "managers": {
-            "channel": "C000000A02",
-            "approvers": {"users": ["U000000U1", "W000000E1"]},
+            "resolution": _slack("C0EXAMPLE1"),
+            "notification": None,
+            "approvers": {
+                "group": None,
+                "users": ["U000000U1", "W000000E1"],
+            },
         }
     }
 
@@ -890,7 +1172,7 @@ def test_agent_approval_routes_accepts_both_users_and_group(
             "channel": {"kind": "slack", "address": "C000000B01"},
             "approval_routes": {
                 "managers": {
-                    "channel": "C000000B02",
+                    "resolution": _slack("C0EXAMPLE1"),
                     "approvers": {"group": "S000000G2", "users": ["U000000U2"]},
                 }
             },
@@ -937,7 +1219,12 @@ def test_agent_approval_routes_rejects_bad_approvers(
             json={
                 "name": f"bad-approvers-{index}",
                 "channel": {"kind": "slack", "address": "C000000C01"},
-                "approval_routes": {"managers": {"channel": "C000000C02", "approvers": approvers}},
+                "approval_routes": {
+                    "managers": {
+                        "resolution": _slack("C0EXAMPLE1"),
+                        "approvers": approvers,
+                    }
+                },
             },
             headers=auth_headers,
         )
@@ -959,14 +1246,29 @@ def test_agent_approval_routes_rejects_unknown_keys(
 
     bad_bindings = [
         # `approver`, missing the `s`: the whole approvers block disappears.
-        {"channel": "C000000E02", "approver": {"users": ["U000000U1"]}},
+        {"resolution": _slack("C0EXAMPLE1"), "approver": {"users": ["U000000U1"]}},
         # A typo inside the approvers block: `user` instead of `users` leaves a
         # group-only spec, or nothing at all.
-        {"channel": "C000000E02", "approvers": {"user": ["U000000U1"]}},
-        {"channel": "C000000E02", "approvers": {"groups": "S000000G1"}},
+        {"resolution": _slack("C0EXAMPLE1"), "approvers": {"user": ["U000000U1"]}},
+        {"resolution": _slack("C0EXAMPLE1"), "approvers": {"groups": "S000000G1"}},
         {
-            "channel": "C000000E02",
+            "resolution": _slack("C0EXAMPLE1"),
             "approvers": {"users": ["U000000U1"], "unknown": "x"},
+        },
+        {
+            "resolution": {
+                "kind": "slack",
+                "address": "C0EXAMPLE1",
+                "unknown": "x",
+            }
+        },
+        {
+            "resolution": _slack("C0EXAMPLE1"),
+            "notification": {
+                "kind": "slack",
+                "address": "C0EXAMPLE2",
+                "interaction": "confirm",
+            },
         },
     ]
     for index, binding in enumerate(bad_bindings):
@@ -997,8 +1299,11 @@ def test_agent_approval_routes_patch_rejects_unknown_keys(
     agent_id = created.json()["id"]
 
     for binding in (
-        {"channel": "C000000F02", "approver": {"users": ["U000000U1"]}},
-        {"channel": "C000000F02", "approvers": {"users": ["U000000U1"], "extra": 1}},
+        {"resolution": _slack("C0EXAMPLE1"), "approver": {"users": ["U000000U1"]}},
+        {
+            "resolution": _slack("C0EXAMPLE1"),
+            "approvers": {"users": ["U000000U1"], "extra": 1},
+        },
     ):
         patched = client.patch(
             f"/agents/{agent_id}",
@@ -1024,7 +1329,12 @@ def test_agent_approval_routes_patch_rejects_bad_approvers(
     patched = client.patch(
         f"/agents/{created.json()['id']}",
         json={
-            "approval_routes": {"managers": {"channel": "C000000D02", "approvers": {"users": []}}}
+            "approval_routes": {
+                "managers": {
+                    "resolution": _slack("C0EXAMPLE1"),
+                    "approvers": {"users": []},
+                }
+            }
         },
         headers=auth_headers,
     )

--- a/apps/api/tests/test_approvals.py
+++ b/apps/api/tests/test_approvals.py
@@ -823,7 +823,7 @@ def test_bound_approver_is_accepted_and_requesting_channel_is_not(
             "channel": {"kind": "slack", "address": "C0LOCALDEV"},
             "approval_routes": {
                 "deal-desk": {
-                    "channel": "C0BOUND01",
+                    "resolution": {"kind": "slack", "address": "C0EXAMPLE1"},
                     "approvers": {"users": ["U0BOUND01"]},
                 }
             },
@@ -839,7 +839,7 @@ def test_bound_approver_is_accepted_and_requesting_channel_is_not(
             author="U0AUTHOR1",
             reply_channel="C0LOCALDEV",
             route="deal-desk",
-            card_channel="C0BOUND01",
+            card_channel="C0EXAMPLE1",
             gate_kind="policy",
         ),
         headers=auth_headers,
@@ -874,7 +874,7 @@ def test_bound_approver_is_accepted_and_requesting_channel_is_not(
         json={
             "decision": "approved",
             "resolved_by": "U0BOUND01",
-            "actor_channel": "C0BOUND01",
+            "actor_channel": "C0EXAMPLE1",
         },
         headers=auth_headers,
     )
@@ -1683,8 +1683,9 @@ def test_run_expiry_sweeper_loop_sweeps_and_stops(
 
 # --- #420: approver sets unfused from the card's channel -----------------------
 #
-# Setup shape throughout: an agent binds route "managers" to the BROAD channel
-# (where the card posts) and, optionally, an `approvers` block (who may act).
+# Setup shape throughout: an agent binds route "managers" to a resolution target
+# in the BROAD channel (where the card posts) and, optionally, an `approvers`
+# block (who may act).
 # The approval then names that agent + route, with card_channel=C_BROAD -- the
 # exact shape the worker produces at kernel.py:626-627.
 #
@@ -1716,6 +1717,10 @@ def _agent_with_routes(
     )
     assert created.status_code == 201, created.text
     return str(created.json()["id"])
+
+
+def _slack_resolution(address: str) -> dict[str, str]:
+    return {"kind": "slack", "address": address}
 
 
 def _routed_payload(agent_id: str | None, **overrides: Any) -> dict[str, Any]:
@@ -1792,7 +1797,7 @@ def test_group_bound_route_denies_non_group_member_even_in_card_channel(
     agent_id = _agent_with_routes(
         approvals_client,
         auth_headers,
-        {"managers": {"channel": _BROAD, "approvers": {"group": _GROUP}}},
+        {"managers": {"resolution": _slack_resolution(_BROAD), "approvers": {"group": _GROUP}}},
     )
     created = approvals_client.post(
         "/approvals", json=_routed_payload(agent_id), headers=auth_headers
@@ -1824,7 +1829,7 @@ def test_group_member_resolves_and_session_resumes(
     agent_id = _agent_with_routes(
         approvals_client,
         auth_headers,
-        {"managers": {"channel": _BROAD, "approvers": {"group": _GROUP}}},
+        {"managers": {"resolution": _slack_resolution(_BROAD), "approvers": {"group": _GROUP}}},
     )
     payload = _routed_payload(agent_id)
     created = approvals_client.post(
@@ -1860,7 +1865,7 @@ def test_user_list_bound_route_denies_an_unlisted_actor_without_calling_slack(
     agent_id = _agent_with_routes(
         approvals_client,
         auth_headers,
-        {"managers": {"channel": _BROAD, "approvers": {"users": [_LISTED]}}},
+        {"managers": {"resolution": _slack_resolution(_BROAD), "approvers": {"users": [_LISTED]}}},
     )
     created = approvals_client.post(
         "/approvals", json=_routed_payload(agent_id), headers=auth_headers
@@ -1887,7 +1892,12 @@ def test_user_list_bound_route_resolves_for_a_listed_actor(
     agent_id = _agent_with_routes(
         approvals_client,
         auth_headers,
-        {"managers": {"channel": _BROAD, "approvers": {"users": [_LISTED, _APPROVER]}}},
+        {
+            "managers": {
+                "resolution": _slack_resolution(_BROAD),
+                "approvers": {"users": [_LISTED, _APPROVER]},
+            }
+        },
     )
     created = approvals_client.post(
         "/approvals", json=_routed_payload(agent_id), headers=auth_headers
@@ -1917,7 +1927,7 @@ def test_explicit_user_list_wins_over_the_group_binding(
         auth_headers,
         {
             "managers": {
-                "channel": _BROAD,
+                "resolution": _slack_resolution(_BROAD),
                 "approvers": {"group": _GROUP, "users": [_LISTED]},
             }
         },
@@ -1959,7 +1969,7 @@ def test_requester_cannot_self_approve_under_the_group_authorizer(
     agent_id = _agent_with_routes(
         approvals_client,
         auth_headers,
-        {"managers": {"channel": _BROAD, "approvers": {"group": _GROUP}}},
+        {"managers": {"resolution": _slack_resolution(_BROAD), "approvers": {"group": _GROUP}}},
     )
     created = approvals_client.post(
         "/approvals",
@@ -1991,7 +2001,12 @@ def test_requester_cannot_self_approve_under_the_user_list_authorizer(
     agent_id = _agent_with_routes(
         approvals_client,
         auth_headers,
-        {"managers": {"channel": _BROAD, "approvers": {"users": [_LISTED, _APPROVER]}}},
+        {
+            "managers": {
+                "resolution": _slack_resolution(_BROAD),
+                "approvers": {"users": [_LISTED, _APPROVER]},
+            }
+        },
     )
     created = approvals_client.post(
         "/approvals",
@@ -2019,7 +2034,7 @@ def test_requester_cannot_self_approve_under_a_bound_channel_authorizer(
     route."""
 
     agent_id = _agent_with_routes(
-        approvals_client, auth_headers, {"managers": {"channel": _BROAD}}
+        approvals_client, auth_headers, {"managers": {"resolution": _slack_resolution(_BROAD)}}
     )
     created = approvals_client.post(
         "/approvals",
@@ -2055,7 +2070,7 @@ def test_audit_names_authorizer_and_membership_evidence(
     agent_id = _agent_with_routes(
         approvals_client,
         auth_headers,
-        {"managers": {"channel": _BROAD, "approvers": {"group": _GROUP}}},
+        {"managers": {"resolution": _slack_resolution(_BROAD), "approvers": {"group": _GROUP}}},
     )
     created = approvals_client.post(
         "/approvals", json=_routed_payload(agent_id), headers=auth_headers
@@ -2102,7 +2117,12 @@ def test_audit_evidence_for_a_user_list_decision(
     agent_id = _agent_with_routes(
         approvals_client,
         auth_headers,
-        {"managers": {"channel": _BROAD, "approvers": {"users": [_LISTED, _APPROVER]}}},
+        {
+            "managers": {
+                "resolution": _slack_resolution(_BROAD),
+                "approvers": {"users": [_LISTED, _APPROVER]},
+            }
+        },
     )
     created = approvals_client.post(
         "/approvals", json=_routed_payload(agent_id), headers=auth_headers
@@ -2135,7 +2155,7 @@ def test_audit_evidence_for_a_channel_decision(
     channel that held the authority and the channel the click came from."""
 
     agent_id = _agent_with_routes(
-        approvals_client, auth_headers, {"managers": {"channel": _BROAD}}
+        approvals_client, auth_headers, {"managers": {"resolution": _slack_resolution(_BROAD)}}
     )
     created = approvals_client.post(
         "/approvals", json=_routed_payload(agent_id), headers=auth_headers
@@ -2210,7 +2230,7 @@ def test_group_binding_without_a_bot_token_denies_instead_of_channel_fallback(
     agent_id = _agent_with_routes(
         approvals_client,
         auth_headers,
-        {"managers": {"channel": _BROAD, "approvers": {"group": _GROUP}}},
+        {"managers": {"resolution": _slack_resolution(_BROAD), "approvers": {"group": _GROUP}}},
     )
     created = approvals_client.post(
         "/approvals", json=_routed_payload(agent_id), headers=auth_headers
@@ -2242,7 +2262,7 @@ def test_group_lookup_failure_denies_and_audits_the_failure(
     agent_id = _agent_with_routes(
         approvals_client,
         auth_headers,
-        {"managers": {"channel": _BROAD, "approvers": {"group": _GROUP}}},
+        {"managers": {"resolution": _slack_resolution(_BROAD), "approvers": {"group": _GROUP}}},
     )
     created = approvals_client.post(
         "/approvals", json=_routed_payload(agent_id), headers=auth_headers
@@ -2274,6 +2294,60 @@ def test_group_lookup_failure_denies_and_audits_the_failure(
 # --- AC4: no approvers declared keeps today's behavior exactly -----------------
 
 
+def test_notification_target_cannot_widen_card_channel_authorization(
+    approvals_client: TestClient,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    valkey: redis.Redis,
+    runs_stream: str,
+) -> None:
+    """A notification address is visibility, never verified resolver evidence.
+
+    The stored route deliberately names both Slack channels. The actor presents
+    the notification channel first; authorization must still use the durable
+    ``Approval.card_channel`` that held the sole interactive resolution card.
+    """
+
+    agent_id = _agent_with_routes(
+        approvals_client,
+        auth_headers,
+        {
+            "managers": {
+                "resolution": _slack_resolution(_BROAD),
+                "notification": _slack_resolution(_ELSEWHERE),
+            }
+        },
+    )
+    created = approvals_client.post(
+        "/approvals", json=_routed_payload(agent_id), headers=auth_headers
+    ).json()
+    assert created["card_channel"] == _BROAD
+
+    notified_actor = _resolve(
+        approvals_client,
+        auth_headers,
+        created["id"],
+        _OTHER,
+        _ELSEWHERE,
+    )
+    assert notified_actor.status_code == 403, notified_actor.text
+    record = approvals_client.get(
+        f"/approvals/{created['id']}", headers=auth_headers
+    )
+    assert record.json()["status"] == "pending"
+    assert valkey.xrange(runs_stream) == []
+
+    card_actor = _resolve(
+        approvals_client,
+        auth_headers,
+        created["id"],
+        _OTHER,
+        _BROAD,
+    )
+    assert card_actor.status_code == 200, card_actor.text
+    assert len(valkey.xrange(runs_stream)) == 1
+
+
 def test_binding_without_approvers_keeps_channel_membership(
     approvals_client: TestClient,
     auth_headers: dict[str, str],
@@ -2281,12 +2355,14 @@ def test_binding_without_approvers_keeps_channel_membership(
     valkey: redis.Redis,
     runs_stream: str,
 ) -> None:
-    """AC4: an existing deployment's bare ``{channel}`` binding keeps resolving
-    against ``card_channel`` -- anyone in the card channel, nobody outside it.
-    Zero-setup stays zero-setup."""
+    """AC4: a bare resolution binding keeps resolving against ``card_channel``.
+
+    Anyone in the card channel may act and nobody outside it may. Zero-setup
+    stays zero-setup.
+    """
 
     agent_id = _agent_with_routes(
-        approvals_client, auth_headers, {"managers": {"channel": _BROAD}}
+        approvals_client, auth_headers, {"managers": {"resolution": _slack_resolution(_BROAD)}}
     )
     created = approvals_client.post(
         "/approvals", json=_routed_payload(agent_id), headers=auth_headers
@@ -2348,7 +2424,7 @@ def test_unbound_route_name_keeps_channel_membership(
     agent_id = _agent_with_routes(
         approvals_client,
         auth_headers,
-        {"legal": {"channel": _ELSEWHERE, "approvers": {"users": [_LISTED]}}},
+        {"legal": {"resolution": _slack_resolution(_ELSEWHERE), "approvers": {"users": [_LISTED]}}},
     )
     created = approvals_client.post(
         "/approvals",

--- a/apps/api/tests/test_migration_0034_approval_route_targets.py
+++ b/apps/api/tests/test_migration_0034_approval_route_targets.py
@@ -1,0 +1,292 @@
+"""Migration 0034 splits approval notification from the resolution target.
+
+The runtime intentionally has no compatibility reader for the retired
+``{"channel": ...}`` binding. The data revision therefore owns the cutover for
+existing durable agent rows, atomically and without changing route names or
+approver policy. Downgrade is loss-aware: a second notification target or a
+non-Slack resolution cannot be represented by the old shape and must be refused
+before any row is rewritten.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Any
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from curie_api.config import get_settings
+from sqlalchemy.exc import DBAPIError
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlalchemy.sql import text
+
+ALEMBIC_DIR = Path(__file__).resolve().parents[1] / "alembic"
+BELOW = "0033"
+
+
+def _alembic_config() -> Config:
+    cfg = Config()
+    cfg.set_main_option("script_location", str(ALEMBIC_DIR))
+    return cfg
+
+
+def _sql(statement: str, params: dict[str, Any] | None = None) -> list[Any]:
+    async def _go() -> list[Any]:
+        engine = create_async_engine(get_settings().database_url)
+        try:
+            async with engine.begin() as conn:
+                result = await conn.execute(text(statement), params or {})
+                return list(result.all()) if result.returns_rows else []
+        finally:
+            await engine.dispose()
+
+    return asyncio.run(_go())
+
+
+def _seed_agent(name: str, routes: dict[str, Any] | None) -> uuid.UUID:
+    agent_id = uuid.uuid4()
+    _sql(
+        "INSERT INTO curie.agents (id, name, approval_routes) "
+        "VALUES (:id, :name, CAST(:routes AS jsonb))",
+        {
+            "id": agent_id,
+            "name": name,
+            "routes": None if routes is None else json.dumps(routes),
+        },
+    )
+    return agent_id
+
+
+def _routes_by_name() -> dict[str, dict[str, Any] | None]:
+    rows = _sql("SELECT name, approval_routes FROM curie.agents ORDER BY name")
+    return {row[0]: row[1] for row in rows}
+
+
+def test_upgrade_rewrites_legacy_routes_preserving_approvers(
+    isolated_migration_db: None,
+) -> None:
+    cfg = _alembic_config()
+    command.upgrade(cfg, BELOW)
+    _seed_agent(
+        "legacy-route",
+        {
+            "managers": {
+                "channel": "C0EXAMPLE1",
+                "approvers": {"group": "S0EXAMPLE1"},
+            },
+            "legal": {"channel": "C0EXAMPLE2"},
+        },
+    )
+    _seed_agent("empty-routes", {})
+    _seed_agent("null-routes", None)
+    json_null_id = uuid.uuid4()
+    _sql(
+        "INSERT INTO curie.agents (id, name, approval_routes) "
+        "VALUES (:id, :name, 'null'::jsonb)",
+        {"id": json_null_id, "name": "json-null-routes"},
+    )
+
+    command.upgrade(cfg, "head")
+
+    json_null_preserved = _sql(
+        "SELECT approval_routes = 'null'::jsonb FROM curie.agents WHERE id = :id",
+        {"id": json_null_id},
+    )
+    assert json_null_preserved == [(True,)]
+
+    assert _routes_by_name() == {
+        "empty-routes": {},
+        "json-null-routes": None,
+        "legacy-route": {
+            "managers": {
+                "resolution": {"kind": "slack", "address": "C0EXAMPLE1"},
+                "approvers": {"group": "S0EXAMPLE1"},
+            },
+            "legal": {"resolution": {"kind": "slack", "address": "C0EXAMPLE2"}},
+        },
+        "null-routes": None,
+    }
+
+
+def test_upgrade_refuses_malformed_legacy_routes_without_partial_rewrite(
+    isolated_migration_db: None,
+) -> None:
+    cfg = _alembic_config()
+    command.upgrade(cfg, BELOW)
+    _seed_agent("a-valid", {"managers": {"channel": "C0EXAMPLE1"}})
+    _seed_agent("z-malformed", {"legal": {"channel": 17}})
+    before = _routes_by_name()
+
+    with pytest.raises(RuntimeError) as caught:
+        command.upgrade(cfg, "head")
+
+    message = str(caught.value)
+    assert "z-malformed" in message
+    assert "legal" in message
+    assert _routes_by_name() == before
+
+
+def test_upgrade_table_lock_blocks_a_concurrent_agent_write(
+    isolated_migration_db: None,
+) -> None:
+    """The preflight and rewrite exclude writes for the whole transaction."""
+
+    cfg = _alembic_config()
+    command.upgrade(cfg, BELOW)
+    _seed_agent("slow-route", {"managers": {"channel": "C0EXAMPLE1"}})
+    writer_id = _seed_agent("writer-agent", None)
+    _sql(
+        """
+        CREATE FUNCTION curie.pause_approval_route_rewrite() RETURNS trigger
+        LANGUAGE plpgsql AS $$
+        BEGIN
+            IF OLD.name = 'slow-route' THEN
+                PERFORM pg_sleep(1);
+            END IF;
+            RETURN NEW;
+        END;
+        $$
+        """
+    )
+    _sql(
+        """
+        CREATE TRIGGER pause_approval_route_rewrite
+        BEFORE UPDATE ON curie.agents
+        FOR EACH ROW EXECUTE FUNCTION curie.pause_approval_route_rewrite()
+        """
+    )
+
+    def concurrent_write() -> None:
+        async def run() -> None:
+            engine = create_async_engine(get_settings().database_url)
+            try:
+                async with engine.begin() as conn:
+                    await conn.execute(text("SET LOCAL lock_timeout = '100ms'"))
+                    await conn.execute(
+                        text("UPDATE curie.agents SET name = 'writer-moved' WHERE id = :id"),
+                        {"id": writer_id},
+                    )
+            finally:
+                await engine.dispose()
+
+        asyncio.run(run())
+
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        migration = pool.submit(command.upgrade, cfg, "head")
+        deadline = time.monotonic() + 3
+        while not _sql(
+            """
+            SELECT 1 FROM pg_stat_activity
+            WHERE query LIKE '%UPDATE curie.agents AS a%'
+              AND wait_event = 'PgSleep'
+            """
+        ):
+            if migration.done():
+                migration.result()
+                pytest.fail("migration completed before the concurrent-write probe")
+            assert time.monotonic() < deadline, "migration never entered the delayed rewrite"
+            time.sleep(0.02)
+
+        with pytest.raises(DBAPIError, match="lock timeout"):
+            concurrent_write()
+        migration.result(timeout=5)
+
+    assert _sql("SELECT name FROM curie.agents WHERE id = :id", {"id": writer_id}) == [
+        ("writer-agent",)
+    ]
+
+
+def test_downgrade_restores_lossless_slack_only_routes(
+    isolated_migration_db: None,
+) -> None:
+    cfg = _alembic_config()
+    command.upgrade(cfg, BELOW)
+    _seed_agent(
+        "round-trip",
+        {
+            "managers": {
+                "channel": "C0EXAMPLE1",
+                "approvers": {"users": ["U0EXAMPLE1"]},
+            },
+            "legal": {"channel": "C0EXAMPLE2"},
+        },
+    )
+
+    command.upgrade(cfg, "head")
+    command.downgrade(cfg, BELOW)
+
+    assert _routes_by_name() == {
+        "round-trip": {
+            "managers": {
+                "channel": "C0EXAMPLE1",
+                "approvers": {"users": ["U0EXAMPLE1"]},
+            },
+            "legal": {"channel": "C0EXAMPLE2"},
+        }
+    }
+
+
+@pytest.mark.parametrize(
+    ("agent_name", "routes", "reason"),
+    [
+        (
+            "notified-agent",
+            {
+                "managers": {
+                    "resolution": {"kind": "slack", "address": "C0EXAMPLE1"},
+                    "notification": {
+                        "kind": "email",
+                        "address": "approvals@example.com",
+                        "endpoint": "https://adapter.example.com/replies",
+                        "adapter": "mail",
+                    },
+                }
+            },
+            "notification target",
+        ),
+        (
+            "future-resolver",
+            {
+                "managers": {
+                    "resolution": {"kind": "email", "address": "human@example.com"}
+                }
+            },
+            "email",
+        ),
+    ],
+    ids=("notification-target", "non-slack-resolution"),
+)
+def test_downgrade_refuses_lossy_split_routes_without_partial_rewrite(
+    agent_name: str,
+    routes: dict[str, Any],
+    reason: str,
+    isolated_migration_db: None,
+) -> None:
+    cfg = _alembic_config()
+    command.upgrade(cfg, BELOW)
+    agent_id = _seed_agent(agent_name, {"managers": {"channel": "C0EXAMPLE1"}})
+    _seed_agent("healthy-agent", {"legal": {"channel": "C0EXAMPLE2"}})
+    command.upgrade(cfg, "head")
+    _sql(
+        "UPDATE curie.agents SET approval_routes = CAST(:routes AS jsonb) WHERE id = :id",
+        {
+            "id": agent_id,
+            "routes": json.dumps(routes),
+        },
+    )
+    before = _routes_by_name()
+
+    with pytest.raises(RuntimeError) as caught:
+        command.downgrade(cfg, BELOW)
+
+    message = str(caught.value)
+    assert agent_name in message
+    assert "managers" in message
+    assert reason in message
+    assert _routes_by_name() == before

--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -383,15 +383,15 @@ export const commandManifest = {
             },
             {
               "global": false,
-              "help": "Bind an approval route to a channel. Accepted so it can be DECLINED with a reason rather than error like a typo: a route binding is per-agent platform config, and the skill tier has no platform",
-              "id": "route",
-              "long": "route",
+              "help": "Bind a route's verified Slack resolution card. Accepted so it can be DECLINED with a reason: the skill tier has no platform agent record",
+              "id": "route_resolution",
+              "long": "route-resolution",
               "positional": false,
               "required": false
             },
             {
               "global": false,
-              "help": "Narrow a route's approvers. Declined at this tier for the same reason as --route",
+              "help": "Narrow a route's approvers. Declined at this tier for the same reason as --route-resolution",
               "id": "route_approvers",
               "long": "route-approvers",
               "positional": false,
@@ -399,7 +399,7 @@ export const commandManifest = {
             },
             {
               "global": false,
-              "help": "Read the route map from a JSON file. Declined at this tier for the same reason as --route",
+              "help": "Read the complete route map, including optional notifications, from JSON. Declined at this tier for the same reason as --route-resolution",
               "id": "routes_from",
               "long": "routes-from",
               "positional": false,
@@ -407,7 +407,7 @@ export const commandManifest = {
             },
             {
               "global": false,
-              "help": "Show the agent's route bindings. Declined at this tier for the same reason as --route",
+              "help": "Show the agent's route bindings. Declined at this tier for the same reason as --route-resolution",
               "id": "list_routes",
               "long": "list-routes",
               "positional": false,
@@ -419,7 +419,7 @@ export const commandManifest = {
             },
             {
               "global": false,
-              "help": "Remove every route binding. Declined at this tier for the same reason as --route",
+              "help": "Remove every route binding. Declined at this tier for the same reason as --route-resolution",
               "id": "clear_routes",
               "long": "clear-routes",
               "positional": false,
@@ -1566,15 +1566,15 @@ export const commandManifest = {
             },
             {
               "global": false,
-              "help": "Bind a manifest approval route to the channel its card posts in, as NAME=CHANNEL (e.g. deal_desk=C0123ABCD). Repeatable. A write REPLACES the whole route map, like --gate does for tool gates",
-              "id": "route",
-              "long": "route",
+              "help": "Bind a manifest route's verified Slack resolution card, as NAME=CHANNEL (e.g. deal_desk=C0123ABCD). Repeatable. A write REPLACES the whole route map, like --gate does for tool gates",
+              "id": "route_resolution",
+              "long": "route-resolution",
               "positional": false,
               "required": false
             },
             {
               "global": false,
-              "help": "Narrow WHO may resolve a route, independently of where its card posts, as NAME=users:U1,U2 or NAME=group:S1. Repeatable. Omit to leave the card channel's members as the approvers",
+              "help": "Narrow WHO may resolve a route, independently of its resolution target, as NAME=users:U1,U2 or NAME=group:S1. Repeatable. Omit to leave the resolution card's channel members as the approvers",
               "id": "route_approvers",
               "long": "route-approvers",
               "positional": false,
@@ -1582,7 +1582,7 @@ export const commandManifest = {
             },
             {
               "global": false,
-              "help": "Read the whole route map from a JSON file, e.g. {\"deal_desk\": {\"channel\": \"C0123ABCD\"}}. The repeatable flags apply on top of it",
+              "help": "Read the whole route map from a JSON file, e.g. {\"deal_desk\":{\"resolution\":{\"kind\":\"slack\",\"address\":\"C0123ABCD\"}}}. Notifications, including endpoint+adapter transport, are declared in this strict map. The repeatable override flags apply on top of it",
               "id": "routes_from",
               "long": "routes-from",
               "positional": false,
@@ -4039,15 +4039,15 @@ export const commandManifest = {
             },
             {
               "global": false,
-              "help": "Bind a manifest approval route to the channel its card posts in, as NAME=CHANNEL (e.g. deal_desk=C0123ABCD). Repeatable. A write REPLACES the whole route map, like --gate does for tool gates",
-              "id": "route",
-              "long": "route",
+              "help": "Bind a manifest route's verified Slack resolution card, as NAME=CHANNEL (e.g. deal_desk=C0123ABCD). Repeatable. A write REPLACES the whole route map, like --gate does for tool gates",
+              "id": "route_resolution",
+              "long": "route-resolution",
               "positional": false,
               "required": false
             },
             {
               "global": false,
-              "help": "Narrow WHO may resolve a route, independently of where its card posts, as NAME=users:U1,U2 or NAME=group:S1. Repeatable. Omit to leave the card channel's members as the approvers",
+              "help": "Narrow WHO may resolve a route, independently of its resolution target, as NAME=users:U1,U2 or NAME=group:S1. Repeatable. Omit to leave the resolution card's channel members as the approvers",
               "id": "route_approvers",
               "long": "route-approvers",
               "positional": false,
@@ -4055,7 +4055,7 @@ export const commandManifest = {
             },
             {
               "global": false,
-              "help": "Read the whole route map from a JSON file, e.g. {\"deal_desk\": {\"channel\": \"C0123ABCD\"}}. The repeatable flags apply on top of it",
+              "help": "Read the whole route map from a JSON file, e.g. {\"deal_desk\":{\"resolution\":{\"kind\":\"slack\",\"address\":\"C0123ABCD\"}}}. Notifications, including endpoint+adapter transport, are declared in this strict map. The repeatable override flags apply on top of it",
               "id": "routes_from",
               "long": "routes-from",
               "positional": false,

--- a/apps/worker/src/curie_worker/binding.py
+++ b/apps/worker/src/curie_worker/binding.py
@@ -238,8 +238,8 @@ class ResolvedDeployment(BaseModel):
     # forwarded as CURIE_APPROVAL_REQUIRED_TOOLS at boot. None means no gates.
     approval_required_tools: list[str] | None = None
     # The agent's approval route bindings (#247): manifest route name ->
-    # workspace binding ({"channel": "C..."}), resolved by the kernel when a
-    # raised approval names a route. None means no bindings.
+    # binding with one verified-card resolution target and an optional
+    # text-only notification target. None means no bindings.
     approval_routes: dict[str, Any] | None = None
     # The agent's connector secrets (ADR-0009, #429): env-var name -> secret
     # value, injected by name into the sandbox boot env so a bundle's authed MCP

--- a/apps/worker/src/curie_worker/kernel.py
+++ b/apps/worker/src/curie_worker/kernel.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 import time
 import uuid
 from collections.abc import Callable
@@ -33,7 +34,7 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, cast
-from urllib.parse import quote
+from urllib.parse import quote, urlsplit
 
 import aiohttp
 from aci_protocol import (
@@ -278,15 +279,102 @@ RETRYABLE_CLASSIFICATIONS = frozenset({"rate-limit", "runner-error"})
 # platform contract on a platform-authored turn -- not user-intent guessing.
 _EXPIRY_RESUME_MARKER = "[approval expired]"
 
-# The channel kind a POLICY-ROUTED approval card posts to (#247). The one place
-# the kernel names a kind, and it is a fact about the route binding rather than a
-# branch on the turn: ``ApprovalRouteBinding.channel`` is validated as a Slack
-# channel id (``apps/api/src/curie_api/schemas.py``), the channel-membership
-# authorizer proves approver membership through Slack, and widening that binding
-# to other kinds is explicitly out of scope for ADR-0096 phase 2. Its route is
-# empty on both halves, which means the worker's DEFAULT Slack transport (#451):
-# the card is policy, so its transport is policy too, never the trigger's.
+# The only channel kind a POLICY-ROUTED approval RESOLUTION target may name
+# (#1460). The explicit kind is the future extension point, but accepting another
+# resolver now would bypass the verified Slack identity on which the API's
+# authorizer relies. Its route is empty on both halves, which means the worker's
+# DEFAULT Slack transport (#451): the card is policy, so its transport is policy
+# too, never the trigger's or the notification target's.
 POLICY_CARD_KIND = "slack"
+_POLICY_CARD_ADDRESS = re.compile(r"^[CDG][A-Z0-9]{7,}$")
+_NOTIFICATION_ADDRESS_SHAPES = {POLICY_CARD_KIND: _POLICY_CARD_ADDRESS}
+_CHANNEL_SLUG = re.compile(r"^[a-z0-9]+(?:[-_][a-z0-9]+)*$")
+_ROUTE_WHITESPACE = re.compile(r"\s")
+
+
+def _valid_notification_endpoint(endpoint: Any) -> bool:
+    """Mirror the API's absolute HTTP(S), host, and no-userinfo endpoint gate."""
+
+    if not isinstance(endpoint, str):
+        return False
+    try:
+        parsed = urlsplit(endpoint)
+    except ValueError:
+        return False
+    return (
+        parsed.scheme in {"http", "https"}
+        and bool(parsed.hostname)
+        and parsed.username is None
+        and parsed.password is None
+    )
+
+
+def _parse_approval_targets(
+    binding: Any,
+) -> tuple[tuple[str, str], tuple[str, str, TargetRoute] | None] | None:
+    """Parse one stored approval binding, or fail closed with ``None``.
+
+    The API owns complete config validation. This worker boundary independently
+    reasserts the authority-bearing envelope and Slack resolution-ID shape
+    because JSONB may be written out of band: the retired ``channel`` key, a
+    non-Slack resolver, an unknown target field, a half-configured transport,
+    or duplicate targets must not produce a durable approval with ambiguous
+    authority.
+    """
+
+    if not isinstance(binding, dict) or set(binding) - {
+        "resolution",
+        "notification",
+        "approvers",
+    }:
+        return None
+
+    resolution = binding.get("resolution")
+    if (
+        not isinstance(resolution, dict)
+        or set(resolution) != {"kind", "address"}
+        or resolution.get("kind") != POLICY_CARD_KIND
+        or not isinstance(resolution.get("address"), str)
+        or _POLICY_CARD_ADDRESS.fullmatch(resolution["address"]) is None
+    ):
+        return None
+    resolution_pair = (POLICY_CARD_KIND, resolution["address"])
+
+    notification = binding.get("notification")
+    if notification is None:
+        return resolution_pair, None
+    if not isinstance(notification, dict) or set(notification) - {
+        "kind",
+        "address",
+        "endpoint",
+        "adapter",
+    }:
+        return None
+
+    kind = notification.get("kind")
+    address = notification.get("address")
+    endpoint = notification.get("endpoint")
+    adapter = notification.get("adapter")
+    address_shape = (
+        _NOTIFICATION_ADDRESS_SHAPES.get(kind) if isinstance(kind, str) else None
+    )
+    if (
+        not isinstance(kind, str)
+        or _CHANNEL_SLUG.fullmatch(kind) is None
+        or not isinstance(address, str)
+        or not address
+        or _ROUTE_WHITESPACE.search(address) is not None
+        or (address_shape is not None and address_shape.fullmatch(address) is None)
+        or (adapter is not None and (
+            not isinstance(adapter, str) or _CHANNEL_SLUG.fullmatch(adapter) is None
+        ))
+        or (endpoint is None) != (adapter is None)
+        or (endpoint is not None and not _valid_notification_endpoint(endpoint))
+        or (kind != POLICY_CARD_KIND and endpoint is None)
+        or (kind, address) == resolution_pair
+    ):
+        return None
+    return resolution_pair, (kind, address, TargetRoute(endpoint=endpoint, adapter=adapter))
 
 
 def _approval_id_from_resume_event(event_id: str) -> str | None:
@@ -2291,13 +2379,13 @@ class Kernel:
         resume path cold-claims a fresh sandbox regardless (ADR-0003).
 
         ``approval_routes`` is the agent's per-deployment route-binding map
-        (#247): when the request named a route bound to a channel, the card is
-        routed there and that channel's members become the approvers. A named
-        but UNBOUND route (declared in the manifest, not bound in this agent's
-        deployment config) is ESCALATED loudly rather than routed to the
-        requesting channel (#544, Decision B, reversing #247): silently widening
-        authority to whoever happens to be in the requesting channel is exactly
-        the failure AC2 closes. No approval is created in that case.
+        (#247/#1460): ``resolution`` owns the sole interactive card and verified
+        identity path; ``notification`` may receive a separate text-only ping.
+        A named but UNBOUND or malformed route is ESCALATED loudly rather than
+        routed to the requesting channel (#544, Decision B, reversing #247):
+        silently widening authority to whoever happens to be in the requesting
+        channel is exactly the failure AC2 closes. No approval is created in
+        that case.
         """
 
         # Both identities are live in this function and they are not
@@ -2333,18 +2421,13 @@ class Kernel:
         # happens to equal a Slack policy channel as "the requesting channel".
         card_kind = qevent.reply_handle.kind
         card_channel = qevent.reply_handle.channel
+        notification_target: tuple[str, str, TargetRoute] | None = None
         if route_name:
             binding = (approval_routes or {}).get(route_name)
-            bound = binding.get("channel") if isinstance(binding, dict) else None
-            if bound:
-                # A policy channel is a Slack channel id by construction
-                # (POLICY_CARD_KIND), so the routed card's pair is that kind
-                # with that address -- whatever kind the requesting turn had.
-                card_kind = POLICY_CARD_KIND
-                card_channel = str(bound)
-            else:
+            targets = _parse_approval_targets(binding)
+            if targets is None:
                 logger.warning(
-                    "approval route %r is not bound for agent %s; escalating "
+                    "approval route %r is not bound or is malformed for agent %s; escalating "
                     "rather than routing the card to the requesting channel",
                     route_name,
                     agent_id,
@@ -2353,10 +2436,12 @@ class Kernel:
                     qevent,
                     route,
                     f"The run requested approval via route {route_name!r}, but that "
-                    "route is not bound to a channel for this agent; flagging for "
-                    "a human instead of widening the request to this channel.",
+                    "route is not bound to a valid resolution target for this "
+                    "agent; flagging for a human instead of widening the request "
+                    "to this channel.",
                 )
                 return
+            (card_kind, card_channel), notification_target = targets
 
         if not is_publication and self._approvals is None:
             await self._escalate(
@@ -2593,10 +2678,11 @@ class Kernel:
         # requesting channel the card joins the thread and rides the trigger's
         # own transport. A route-bound channel has no such thread and is policy,
         # not a per-turn reply: it posts top-level over the worker's default
-        # Slack transport, because an ``ApprovalRouteBinding`` is a Slack channel
-        # id by construction (``schemas.py`` validates it as one, and #247's
-        # binding shape is explicitly out of scope for ADR-0096 phase 2), and the
-        # authorizer proves membership of that channel through Slack.
+        # Slack transport, because ``ApprovalRouteBinding.resolution`` is
+        # Slack-only by construction (``schemas.py`` validates the explicit
+        # pair), and the authorizer proves membership of that channel through a
+        # verified Slack card click. Notification transport never feeds this
+        # comparison or these route fields.
         #
         # Keeping the requesting turn's kind and adapter here was a fail-closed
         # bug: an email-originated approval routed to a Slack policy channel kept
@@ -2724,6 +2810,38 @@ class Kernel:
                     )
                 except Exception as exc:  # noqa: BLE001 - best-effort memory
                     logger.warning("remembering approval card for %s failed: %s", created.id, exc)
+        # Visibility is independent of card delivery. This is a second post, not
+        # a second card: there is deliberately no ConfirmIntent, action value, or
+        # remembered card ref. A failed notification cannot invalidate or move
+        # the durable approval, and a failed resolution-card transport must not
+        # suppress the notification attempt.
+        if notification_target is not None:
+            notification_kind, notification_address, notification_route = notification_target
+            try:
+                await self._sink.emit(
+                    ReplyPost(
+                        version=REPLY_WIRE_VERSION,
+                        event="reply.post",
+                        target=ReplyTarget(
+                            kind=notification_kind,
+                            address=notification_address,
+                            conversation_id=None,
+                            reply_ref=None,
+                        ),
+                        message=OutboundMessage(
+                            version=MESSAGE_VERSION,
+                            text=(
+                                f"Approval {created.id} requires review: {notice_summary}. "
+                                "Resolve in the configured approval channel."
+                            ),
+                            interaction=None,
+                        ),
+                        requested_by=qevent.author,
+                    ),
+                    route=notification_route,
+                )
+            except Exception as exc:  # noqa: BLE001 - the durable pause stands
+                logger.warning("approval notification post failed for %s: %s", created.id, exc)
         logger.info("thread %s suspended awaiting approval %s", thread_key, created.id)
 
     async def _consume(

--- a/apps/worker/tests/binding/test_resolver.py
+++ b/apps/worker/tests/binding/test_resolver.py
@@ -165,8 +165,13 @@ async def _seed_deployment(
                 "(id, agent_id, version_label, bundle_ref, created_by) "
                 "VALUES (:id, :agent_id, :label, :ref, :by)"
             ),
-            {"id": version_id, "agent_id": agent_id, "label": f"v-{environment}",
-             "ref": bundle_ref, "by": "test"},
+            {
+                "id": version_id,
+                "agent_id": agent_id,
+                "label": f"v-{environment}",
+                "ref": bundle_ref,
+                "by": "test",
+            },
         )
         # The real schema's `environment` column is a `curie.environment` enum,
         # which is why the cast target defaults to that type and stays pinned to
@@ -182,8 +187,13 @@ async def _seed_deployment(
                 "VALUES (:id, :agent_id, :version_id, "
                 f"CAST(:env AS {environment_type}), :status)"
             ),
-            {"id": uuid.uuid4(), "agent_id": agent_id, "version_id": version_id,
-             "env": environment, "status": status},
+            {
+                "id": uuid.uuid4(),
+                "agent_id": agent_id,
+                "version_id": version_id,
+                "env": environment,
+                "status": status,
+            },
         )
 
 
@@ -844,12 +854,8 @@ def test_resolve_warns_when_two_agents_are_bound_to_one_channel(
                     environment_type="text",
                 )
 
-                resolver = BindingResolver(
-                    engine, WorkerConfig(db_schema=tmp_schema)
-                )
-                with caplog.at_level(
-                    "WARNING", logger="curie_worker.binding"
-                ):
+                resolver = BindingResolver(engine, WorkerConfig(db_schema=tmp_schema))
+                with caplog.at_level("WARNING", logger="curie_worker.binding"):
                     resolved = await resolver.resolve("slack", channel)
 
                 assert resolved is not None
@@ -869,9 +875,7 @@ def test_resolve_warns_when_two_agents_are_bound_to_one_channel(
                     # IF EXISTS so this cleanup can never raise 3F000 "schema
                     # does not exist" from inside the `finally` and mask the real
                     # failure that brought us here.
-                    await conn.execute(
-                        text(f"DROP SCHEMA IF EXISTS {tmp_schema} CASCADE")
-                    )
+                    await conn.execute(text(f"DROP SCHEMA IF EXISTS {tmp_schema} CASCADE"))
         finally:
             await engine.dispose()
 
@@ -1221,7 +1225,8 @@ def test_boot_env_mints_no_token_when_the_signing_key_is_empty() -> None:
 
 def test_resolves_approval_routes_from_the_agent_row() -> None:
     # Route bindings (#247): the per-agent JSONB map survives the SQL resolve
-    # (decode included) so the kernel can route approval cards through it.
+    # (decode included) so the kernel receives the strict split target and its
+    # server-side notification transport unchanged.
     async def go() -> None:
         engine = create_async_engine(_DB_URL)
         try:
@@ -1239,7 +1244,17 @@ def test_resolves_approval_routes_from_the_agent_row() -> None:
                 name=f"agent-{token}",
                 max_usd=None,
                 max_tokens=None,
-                approval_routes={"managers": {"channel": "C_MGRS"}},
+                approval_routes={
+                    "managers": {
+                        "resolution": {"kind": "slack", "address": "C0EXAMPLE1"},
+                        "notification": {
+                            "kind": "email",
+                            "address": "approvals@example.com",
+                            "endpoint": "https://adapter.example.com/replies",
+                            "adapter": "mail",
+                        },
+                    }
+                },
             )
             await _seed_deployment(
                 engine, agent_id=agent_id, environment="prod", bundle_ref=f"b/{token}.zip"
@@ -1247,7 +1262,17 @@ def test_resolves_approval_routes_from_the_agent_row() -> None:
             try:
                 resolved = await _resolver(engine).resolve("slack", channel)
                 assert resolved is not None
-                assert resolved.approval_routes == {"managers": {"channel": "C_MGRS"}}
+                assert resolved.approval_routes == {
+                    "managers": {
+                        "resolution": {"kind": "slack", "address": "C0EXAMPLE1"},
+                        "notification": {
+                            "kind": "email",
+                            "address": "approvals@example.com",
+                            "endpoint": "https://adapter.example.com/replies",
+                            "adapter": "mail",
+                        },
+                    }
+                }
             finally:
                 await _cleanup(engine, [agent_id])
         finally:

--- a/apps/worker/tests/kernel/test_approval_lifecycle.py
+++ b/apps/worker/tests/kernel/test_approval_lifecycle.py
@@ -17,7 +17,7 @@ import aiohttp
 import pytest
 from aci_protocol import Final, QueuedTurn, ReplyHandle, SessionStatus, TextDelta
 from channel_protocol import ConfirmIntent
-from channel_protocol.reply import ReplyAck, ReplyEvent
+from channel_protocol.reply import ReplyAck, ReplyEvent, ReplyPost
 from curie_worker.approvals import (
     ApprovalBackendError,
     ApprovalRequest,
@@ -87,6 +87,7 @@ def _qevent(
     placeholder: str | None = "p-1",
     endpoint: str | None = None,
     kind: str = "slack",
+    channel: str = "C1",
     adapter: str | None = None,
 ) -> QueuedTurn:
     return QueuedTurn(
@@ -96,7 +97,7 @@ def _qevent(
         text=text,
         reply_handle=ReplyHandle(
             kind=kind,
-            channel="C1",
+            channel=channel,
             placeholder=placeholder,
             endpoint=endpoint,
             adapter=adapter,
@@ -778,7 +779,7 @@ def test_every_posted_card_carries_the_note_variant(make_harness) -> None:
             unrouted = h.sink.posts[0]
 
         # Routed: the card posts top-level in the bound channel.
-        binding = RoutedBinding({"finance": {"channel": "C_FINANCE"}})
+        binding = RoutedBinding({"finance": _resolution_route("C0EXAMPLE2")})
         async with make_harness(approvals=RecordingApprovals(), binding=binding) as h:
             h.runner.default_script = _awaiting_routed_script("Approve the invoice", "finance")
             await h.kernel.process_event(_qevent("please invoice", thread="th-routed"))
@@ -859,6 +860,51 @@ class RoutedBinding:
         return {"CURIE_SESSION_ID": f"s-{thread_key}"}
 
 
+_NOTIFICATION_ENDPOINT = "https://adapter.example.com/replies"
+
+
+def _resolution_route(address: str = "C0EXAMPLE1") -> dict:
+    return {"resolution": {"kind": "slack", "address": address}}
+
+
+def _notification_route(**changes) -> dict:
+    notification = {
+        "kind": "email",
+        "address": "approvals@example.com",
+        "endpoint": _NOTIFICATION_ENDPOINT,
+        "adapter": "mail",
+    }
+    notification.update(changes)
+    return {**_resolution_route(), "notification": notification}
+
+
+def _split_approval_routes() -> dict:
+    return {"managers": _notification_route()}
+
+
+_MALFORMED_NOTIFICATION_OVERRIDES = [
+    ("extra-key", {"unexpected": True}),
+    ("kind-whitespace", {"kind": " email"}),
+    ("kind-uppercase", {"kind": "Email"}),
+    ("address-whitespace", {"address": "approvals team@example.com"}),
+    (
+        "slack-name-is-not-an-id",
+        {"kind": "slack", "address": "#notify", "endpoint": None, "adapter": None},
+    ),
+    ("adapter-whitespace", {"adapter": "mail adapter"}),
+    ("adapter-uppercase", {"adapter": "Mail"}),
+    (
+        "same-as-resolution",
+        {"kind": "slack", "address": "C0EXAMPLE1", "endpoint": None, "adapter": None},
+    ),
+    ("half-configured-transport", {"adapter": None}),
+    ("non-slack-needs-transport", {"endpoint": None, "adapter": None}),
+    ("endpoint-http-only", {"endpoint": "ftp://adapter.example.com/replies"}),
+    ("endpoint-needs-host", {"endpoint": "https:///replies"}),
+    ("endpoint-no-userinfo", {"endpoint": "https://user@adapter.example.com/replies"}),
+]
+
+
 def test_routed_approval_cards_go_to_the_bound_channel(make_harness) -> None:
     """#247: the manifest route resolves through the agent's bindings; the card
     lands in the bound channel (top-level, no foreign thread) and the record
@@ -868,22 +914,152 @@ def test_routed_approval_cards_go_to_the_bound_channel(make_harness) -> None:
 
     async def go() -> None:
         approvals = RecordingApprovals()
-        binding = RoutedBinding({"managers": {"channel": "C_MGRS"}})
+        binding = RoutedBinding({"managers": _resolution_route()})
         async with make_harness(approvals=approvals, binding=binding) as h:
-            h.runner.default_script = _awaiting_routed_script(
-                "Discount for ACME", "managers"
-            )
+            h.runner.default_script = _awaiting_routed_script("Discount for ACME", "managers")
             await h.kernel.process_event(_qevent("discount?", thread="th-routed"))
 
             req = approvals.requests[0]
             assert req.route == "managers"
-            assert req.card_channel == "C_MGRS"
+            assert req.card_channel == "C0EXAMPLE1"
             # Card posted to the bound channel, top-level (no thread there).
             channel, message, _requested_by, thread_ts, endpoint = h.sink.posts[0]
-            assert channel == "C_MGRS"
+            assert channel == "C0EXAMPLE1"
             assert thread_ts is None
             assert isinstance(message.interaction, ConfirmIntent)
             assert endpoint is None
+
+    asyncio.run(go())
+
+
+def test_routed_approval_posts_one_interactive_resolution_card_and_one_text_only_notification(
+    make_harness,
+) -> None:
+    """The split adds visibility without adding a second resolver.
+
+    The resolution target owns the only ``ConfirmIntent`` and the only durable
+    card ref. The notification directs readers back to that configured surface,
+    but carries neither its identifier nor an interaction payload.
+    """
+
+    async def go() -> None:
+        approvals = RecordingApprovals()
+        async with make_harness(
+            approvals=approvals, binding=RoutedBinding(_split_approval_routes())
+        ) as h:
+            h.runner.default_script = _awaiting_routed_script("Discount for ACME", "managers")
+            await h.kernel.process_event(_qevent("discount?", thread="th-split"))
+
+            assert len(approvals.requests) == 1
+            assert approvals.requests[0].card_channel == "C0EXAMPLE1"
+
+            posts = [
+                (event, route)
+                for event, route, _best_effort in h.sink.events
+                if isinstance(event, ReplyPost)
+            ]
+            assert len(posts) == 2
+            (card, card_route), (notification, notification_route) = posts
+
+            assert card.target.kind == "slack"
+            assert card.target.address == "C0EXAMPLE1"
+            assert card.target.conversation_id is None
+            assert isinstance(card.message.interaction, ConfirmIntent)
+            assert card_route.endpoint is None
+            assert card_route.adapter is None
+
+            assert notification.target.kind == "email"
+            assert notification.target.address == "approvals@example.com"
+            assert notification.target.conversation_id is None
+            assert notification.message.interaction is None
+            assert notification.message.text == (
+                "Approval appr-1 requires review: Discount for ACME. "
+                "Resolve in the configured approval channel."
+            )
+            assert "C0EXAMPLE1" not in notification.message.text
+            assert notification_route.endpoint == _NOTIFICATION_ENDPOINT
+            assert notification_route.adapter == "mail"
+
+            card_keys = [
+                key async for key in h.async_redis.scan_iter(match=h.config.approval_card_key("*"))
+            ]
+            assert card_keys == [h.config.approval_card_key(_thread_key("th-split"))]
+
+    asyncio.run(go())
+
+
+def test_notification_failure_leaves_resolution_card_and_durable_pause_intact(
+    make_harness, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async def go() -> None:
+        approvals = RecordingApprovals()
+        async with make_harness(
+            approvals=approvals, binding=RoutedBinding(_split_approval_routes())
+        ) as h:
+            original_emit = h.sink.emit
+            notification_attempted = False
+
+            async def fail_notification(event, **kwargs):
+                nonlocal notification_attempted
+                if isinstance(event, ReplyPost) and event.message.interaction is None:
+                    notification_attempted = True
+                    raise RuntimeError("injected notification delivery failure")
+                return await original_emit(event, **kwargs)
+
+            monkeypatch.setattr(h.sink, "emit", fail_notification)
+            h.runner.default_script = _awaiting_routed_script("Discount for ACME", "managers")
+            await h.kernel.process_event(_qevent("discount?", thread="th-notification-failure"))
+
+            assert notification_attempted
+            assert len(approvals.requests) == 1
+            assert len(h.sink.posts) == 1
+            assert isinstance(h.sink.posts[0][1].interaction, ConfirmIntent)
+            remembered = await _peek_card_ref(h, "th-notification-failure")
+            assert remembered is not None
+            assert remembered["channel"] == "C0EXAMPLE1"
+            assert [s.operating_mode for s in h.fake_k8s.sandboxes.values()] == ["Suspended"]
+
+    asyncio.run(go())
+
+
+def test_resolution_card_transport_failure_still_posts_text_notification_and_preserves_durable_pause(  # noqa: E501
+    make_harness, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async def go() -> None:
+        approvals = RecordingApprovals()
+        async with make_harness(
+            approvals=approvals, binding=RoutedBinding(_split_approval_routes())
+        ) as h:
+            original_emit = h.sink.emit
+            card_attempted = False
+
+            async def fail_resolution_card(event, **kwargs):
+                nonlocal card_attempted
+                if isinstance(event, ReplyPost) and isinstance(
+                    event.message.interaction, ConfirmIntent
+                ):
+                    card_attempted = True
+                    raise RuntimeError("injected resolution card delivery failure")
+                return await original_emit(event, **kwargs)
+
+            monkeypatch.setattr(h.sink, "emit", fail_resolution_card)
+            h.runner.default_script = _awaiting_routed_script("Discount for ACME", "managers")
+            await h.kernel.process_event(_qevent("discount?", thread="th-card-failure"))
+
+            assert card_attempted
+            assert len(approvals.requests) == 1
+            assert approvals.requests[0].card_channel == "C0EXAMPLE1"
+            assert [s.operating_mode for s in h.fake_k8s.sandboxes.values()] == ["Suspended"]
+            assert len(h.sink.posts) == 1
+            channel, message, _requested_by, thread_ts, endpoint = h.sink.posts[0]
+            assert channel == "approvals@example.com"
+            assert message.interaction is None
+            assert "appr-1" in message.text
+            assert "C0EXAMPLE1" not in message.text
+            assert "configured approval channel" in message.text
+            assert thread_ts is None
+            assert endpoint == _NOTIFICATION_ENDPOINT
+            assert await _peek_card_ref(h, "th-card-failure") is None
 
     asyncio.run(go())
 
@@ -919,6 +1095,61 @@ def test_unbound_route_escalates_instead_of_routing_to_the_requesting_channel(
     asyncio.run(go())
 
 
+@pytest.mark.parametrize(
+    "route_binding",
+    [
+        pytest.param(
+            {"resolution": {"kind": "slack", "address": "#finance"}},
+            id="slack-name-is-not-an-id",
+        ),
+        pytest.param(
+            {"resolution": {"kind": "email", "address": "review@example.com"}},
+            id="non-slack-resolution",
+        ),
+        pytest.param(
+            {
+                "resolution": {
+                    "kind": "slack",
+                    "address": "C0EXAMPLE3",
+                    "unexpected": True,
+                }
+            },
+            id="resolution-extra-key",
+        ),
+        pytest.param({"channel": "C0EXAMPLE3"}, id="retired-channel-key"),
+        *[
+            pytest.param(_notification_route(**overrides), id=f"notification-{case}")
+            for case, overrides in _MALFORMED_NOTIFICATION_OVERRIDES
+        ],
+    ],
+)
+def test_malformed_route_target_escalates_without_creating_an_approval(
+    make_harness, route_binding: dict
+) -> None:
+    """Out-of-band JSONB cannot widen or invent a resolution surface.
+
+    The worker independently pins the API's target identity, transport pair,
+    endpoint, strict-envelope, and retired-key rules. The database migration is
+    the only legacy-shape translator.
+    """
+
+    async def go() -> None:
+        approvals = RecordingApprovals()
+        binding = RoutedBinding({"managers": route_binding})
+        async with make_harness(approvals=approvals, binding=binding) as h:
+            h.runner.default_script = _awaiting_routed_script("Anything", "managers")
+            ev = _qevent("gate", thread="th-malformed-route")
+            await h.kernel.process_event(ev)
+
+            assert approvals.requests == []
+            assert h.sink.posts == []
+            assert h.sink.last_text is not None
+            assert "managers" in h.sink.last_text
+            assert await h.async_redis.exists(h.config.done_key(ev.event_id))
+
+    asyncio.run(go())
+
+
 def test_routeless_approval_keeps_prior_behavior(make_harness) -> None:
     async def go() -> None:
         approvals = RecordingApprovals()
@@ -947,17 +1178,15 @@ def test_routed_card_ignores_the_triggering_turns_endpoint(make_harness) -> None
 
     async def go() -> None:
         approvals = RecordingApprovals()
-        binding = RoutedBinding({"managers": {"channel": "C_MGRS"}})
+        binding = RoutedBinding({"managers": _resolution_route()})
         async with make_harness(approvals=approvals, binding=binding) as h:
-            h.runner.default_script = _awaiting_routed_script(
-                "Discount for ACME", "managers"
-            )
+            h.runner.default_script = _awaiting_routed_script("Discount for ACME", "managers")
             await h.kernel.process_event(
                 _qevent("discount?", thread="th-cli-routed", endpoint=_CLI_STUB)
             )
 
             channel, _message, _requested_by, thread_ts, endpoint = h.sink.posts[0]
-            assert channel == "C_MGRS"
+            assert channel == "C0EXAMPLE1"
             assert thread_ts is None
             assert endpoint is None
 
@@ -974,15 +1203,21 @@ def test_card_routed_to_requesting_channel_keeps_the_trigger_endpoint(
 
     async def go() -> None:
         approvals = RecordingApprovals()
-        binding = RoutedBinding({"managers": {"channel": "C1"}})  # the requesting channel
+        # The policy target is the requesting channel itself.
+        binding = RoutedBinding({"managers": _resolution_route("C0EXAMPLE4")})
         async with make_harness(approvals=approvals, binding=binding) as h:
             h.runner.default_script = _awaiting_routed_script("Ship it", "managers")
             await h.kernel.process_event(
-                _qevent("ship?", thread="th-self-routed", endpoint=_CLI_STUB)
+                _qevent(
+                    "ship?",
+                    thread="th-self-routed",
+                    endpoint=_CLI_STUB,
+                    channel="C0EXAMPLE4",
+                )
             )
 
             channel, _message, _requested_by, thread_ts, endpoint = h.sink.posts[0]
-            assert channel == "C1"
+            assert channel == "C0EXAMPLE4"
             assert thread_ts == "th-self-routed"
             assert endpoint == _CLI_STUB
 

--- a/cli/api-mirrors.json
+++ b/cli/api-mirrors.json
@@ -32,13 +32,38 @@
       "omissions": []
     },
     {
-      "struct": "ApprovalRouteBinding",
-      "schema": "ApprovalRouteBinding",
+      "struct": "ApprovalRouteBindingResponse",
+      "schema": "ApprovalRouteBindingOut",
+      "omissions": []
+    },
+    {
+      "struct": "ApprovalResolutionTargetResponse",
+      "schema": "ApprovalTargetOut",
+      "omissions": []
+    },
+    {
+      "struct": "ApprovalNotificationTargetResponse",
+      "schema": "ApprovalTargetOut",
       "omissions": []
     },
     {
       "struct": "ApprovalApprovers",
-      "schema": "ApprovalApprovers",
+      "schema": "ApprovalApproversOut",
+      "omissions": []
+    },
+    {
+      "struct": "ApprovalRouteBindingWrite",
+      "schema": "ApprovalRouteBinding",
+      "omissions": []
+    },
+    {
+      "struct": "ApprovalResolutionTargetWrite",
+      "schema": "ApprovalResolutionTarget",
+      "omissions": []
+    },
+    {
+      "struct": "NotificationTargetWrite",
+      "schema": "ApprovalNotificationTarget",
       "omissions": []
     },
     {

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -380,15 +380,15 @@
             },
             {
               "global": false,
-              "help": "Bind an approval route to a channel. Accepted so it can be DECLINED with a reason rather than error like a typo: a route binding is per-agent platform config, and the skill tier has no platform",
-              "id": "route",
-              "long": "route",
+              "help": "Bind a route's verified Slack resolution card. Accepted so it can be DECLINED with a reason: the skill tier has no platform agent record",
+              "id": "route_resolution",
+              "long": "route-resolution",
               "positional": false,
               "required": false
             },
             {
               "global": false,
-              "help": "Narrow a route's approvers. Declined at this tier for the same reason as --route",
+              "help": "Narrow a route's approvers. Declined at this tier for the same reason as --route-resolution",
               "id": "route_approvers",
               "long": "route-approvers",
               "positional": false,
@@ -396,7 +396,7 @@
             },
             {
               "global": false,
-              "help": "Read the route map from a JSON file. Declined at this tier for the same reason as --route",
+              "help": "Read the complete route map, including optional notifications, from JSON. Declined at this tier for the same reason as --route-resolution",
               "id": "routes_from",
               "long": "routes-from",
               "positional": false,
@@ -404,7 +404,7 @@
             },
             {
               "global": false,
-              "help": "Show the agent's route bindings. Declined at this tier for the same reason as --route",
+              "help": "Show the agent's route bindings. Declined at this tier for the same reason as --route-resolution",
               "id": "list_routes",
               "long": "list-routes",
               "positional": false,
@@ -416,7 +416,7 @@
             },
             {
               "global": false,
-              "help": "Remove every route binding. Declined at this tier for the same reason as --route",
+              "help": "Remove every route binding. Declined at this tier for the same reason as --route-resolution",
               "id": "clear_routes",
               "long": "clear-routes",
               "positional": false,
@@ -1563,15 +1563,15 @@
             },
             {
               "global": false,
-              "help": "Bind a manifest approval route to the channel its card posts in, as NAME=CHANNEL (e.g. deal_desk=C0123ABCD). Repeatable. A write REPLACES the whole route map, like --gate does for tool gates",
-              "id": "route",
-              "long": "route",
+              "help": "Bind a manifest route's verified Slack resolution card, as NAME=CHANNEL (e.g. deal_desk=C0123ABCD). Repeatable. A write REPLACES the whole route map, like --gate does for tool gates",
+              "id": "route_resolution",
+              "long": "route-resolution",
               "positional": false,
               "required": false
             },
             {
               "global": false,
-              "help": "Narrow WHO may resolve a route, independently of where its card posts, as NAME=users:U1,U2 or NAME=group:S1. Repeatable. Omit to leave the card channel's members as the approvers",
+              "help": "Narrow WHO may resolve a route, independently of its resolution target, as NAME=users:U1,U2 or NAME=group:S1. Repeatable. Omit to leave the resolution card's channel members as the approvers",
               "id": "route_approvers",
               "long": "route-approvers",
               "positional": false,
@@ -1579,7 +1579,7 @@
             },
             {
               "global": false,
-              "help": "Read the whole route map from a JSON file, e.g. {\"deal_desk\": {\"channel\": \"C0123ABCD\"}}. The repeatable flags apply on top of it",
+              "help": "Read the whole route map from a JSON file, e.g. {\"deal_desk\":{\"resolution\":{\"kind\":\"slack\",\"address\":\"C0123ABCD\"}}}. Notifications, including endpoint+adapter transport, are declared in this strict map. The repeatable override flags apply on top of it",
               "id": "routes_from",
               "long": "routes-from",
               "positional": false,
@@ -4036,15 +4036,15 @@
             },
             {
               "global": false,
-              "help": "Bind a manifest approval route to the channel its card posts in, as NAME=CHANNEL (e.g. deal_desk=C0123ABCD). Repeatable. A write REPLACES the whole route map, like --gate does for tool gates",
-              "id": "route",
-              "long": "route",
+              "help": "Bind a manifest route's verified Slack resolution card, as NAME=CHANNEL (e.g. deal_desk=C0123ABCD). Repeatable. A write REPLACES the whole route map, like --gate does for tool gates",
+              "id": "route_resolution",
+              "long": "route-resolution",
               "positional": false,
               "required": false
             },
             {
               "global": false,
-              "help": "Narrow WHO may resolve a route, independently of where its card posts, as NAME=users:U1,U2 or NAME=group:S1. Repeatable. Omit to leave the card channel's members as the approvers",
+              "help": "Narrow WHO may resolve a route, independently of its resolution target, as NAME=users:U1,U2 or NAME=group:S1. Repeatable. Omit to leave the resolution card's channel members as the approvers",
               "id": "route_approvers",
               "long": "route-approvers",
               "positional": false,
@@ -4052,7 +4052,7 @@
             },
             {
               "global": false,
-              "help": "Read the whole route map from a JSON file, e.g. {\"deal_desk\": {\"channel\": \"C0123ABCD\"}}. The repeatable flags apply on top of it",
+              "help": "Read the whole route map from a JSON file, e.g. {\"deal_desk\":{\"resolution\":{\"kind\":\"slack\",\"address\":\"C0123ABCD\"}}}. Notifications, including endpoint+adapter transport, are declared in this strict map. The repeatable override flags apply on top of it",
               "id": "routes_from",
               "long": "routes-from",
               "positional": false,

--- a/cli/schema/approvals.schema.json
+++ b/cli/schema/approvals.schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://schemas.curietech.ai/cli/approvals/v1.2.json",
+  "$id": "https://schemas.curietech.ai/cli/approvals/v2.0.json",
   "title": "curie <tier> approvals --json",
-  "description": "The agent-facing payload of `curie <tier> approvals <agent>`: the dry-run plan; the gate list (`manifest_unreadable` non-null when the deployed manifest could not be read); the pending approval records (`truncated` true when the server page cap was hit); a single resolved record; or the agent's approval route bindings, where each route's `channel` is where its card posts and its optional `approvers` block is who may resolve it.",
+  "description": "The agent-facing payload of `curie <tier> approvals <agent>`: the dry-run plan; the gate list (`manifest_unreadable` non-null when the deployed manifest could not be read); the pending approval records (`truncated` true when the server page cap was hit); a single resolved record; or the agent's approval route bindings. Each binding separates its verified interactive Slack `resolution`, optional text-only `notification`, and optional `approvers` authority.",
   "$defs": {
     "dryRun": {
       "type": "object",
@@ -96,10 +96,42 @@
     "approvalRouteBinding": {
       "type": "object",
       "additionalProperties": false,
-      "description": "One route's workspace binding. `channel` is WHERE the card posts; the optional `approvers` block is WHO may act on it, and its absence means the card channel's members are the approvers (the zero-setup default).",
+      "description": "One route's display binding. `resolution` is the single verified interactive Slack card; `notification` is an optional text-only ping carrying no resolving affordance; `approvers` is WHO may act, and its absence means the resolution card channel's members are the approvers.",
       "properties": {
-        "channel": {
-          "type": "string"
+        "resolution": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "kind": {
+              "type": "string"
+            },
+            "address": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "address"
+          ]
+        },
+        "notification": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "kind": {
+              "type": "string"
+            },
+            "address": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "address"
+          ]
         },
         "approvers": {
           "type": [
@@ -127,7 +159,7 @@
         }
       },
       "required": [
-        "channel"
+        "resolution"
       ]
     }
   },

--- a/cli/schema/baseline/approvals.schema.json
+++ b/cli/schema/baseline/approvals.schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://schemas.curietech.ai/cli/approvals/v1.2.json",
+  "$id": "https://schemas.curietech.ai/cli/approvals/v2.0.json",
   "title": "curie <tier> approvals --json",
-  "description": "The agent-facing payload of `curie <tier> approvals <agent>`: the dry-run plan; the gate list (`manifest_unreadable` non-null when the deployed manifest could not be read); the pending approval records (`truncated` true when the server page cap was hit); a single resolved record; or the agent's approval route bindings, where each route's `channel` is where its card posts and its optional `approvers` block is who may resolve it.",
+  "description": "The agent-facing payload of `curie <tier> approvals <agent>`: the dry-run plan; the gate list (`manifest_unreadable` non-null when the deployed manifest could not be read); the pending approval records (`truncated` true when the server page cap was hit); a single resolved record; or the agent's approval route bindings. Each binding separates its verified interactive Slack `resolution`, optional text-only `notification`, and optional `approvers` authority.",
   "$defs": {
     "dryRun": {
       "type": "object",
@@ -96,10 +96,42 @@
     "approvalRouteBinding": {
       "type": "object",
       "additionalProperties": false,
-      "description": "One route's workspace binding. `channel` is WHERE the card posts; the optional `approvers` block is WHO may act on it, and its absence means the card channel's members are the approvers (the zero-setup default).",
+      "description": "One route's display binding. `resolution` is the single verified interactive Slack card; `notification` is an optional text-only ping carrying no resolving affordance; `approvers` is WHO may act, and its absence means the resolution card channel's members are the approvers.",
       "properties": {
-        "channel": {
-          "type": "string"
+        "resolution": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "kind": {
+              "type": "string"
+            },
+            "address": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "address"
+          ]
+        },
+        "notification": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "kind": {
+              "type": "string"
+            },
+            "address": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "address"
+          ]
         },
         "approvers": {
           "type": [
@@ -127,7 +159,7 @@
         }
       },
       "required": [
-        "channel"
+        "resolution"
       ]
     }
   },

--- a/cli/schema/index.json
+++ b/cli/schema/index.json
@@ -19,7 +19,7 @@
       "result": "ApprovalsOutput",
       "kind": "CliOutput",
       "schema": "approvals.schema.json",
-      "version": "1.2"
+      "version": "2.0"
     },
     {
       "result": "BudgetOutput",

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -98,12 +98,13 @@ pub struct Agent {
     /// `#[serde(default)]` keeps older/leaner responses parsing to None.
     #[serde(default)]
     pub approval_required_tools: Option<Vec<String>>,
-    /// Manifest route name -> workspace binding (#247, #420). Read back by
-    /// `approvals --list-routes` and written by `--route`/`--route-approvers`.
+    /// Manifest route name -> workspace binding (#247, #420, #1460). Read back
+    /// by `approvals --list-routes`; writes use a separate strict DTO so this
+    /// display-only, transport-redacted response can never become PATCH input.
     /// `#[serde(default)]` keeps a pre-#247 response parsing to None, which is
     /// the same fact as "no routes bound".
     #[serde(default)]
-    pub approval_routes: Option<std::collections::BTreeMap<String, ApprovalRouteBinding>>,
+    pub approval_routes: Option<std::collections::BTreeMap<String, ApprovalRouteBindingResponse>>,
     /// Per-agent model override, forwarded as `CURIE_MODEL` at sandbox boot
     /// (#254). `None` means no override: the platform default applies. Modeled
     /// since #1311 gave the CLI a verb that reads and writes it -- until then
@@ -125,26 +126,35 @@ pub struct Agent {
     pub memory: bool,
 }
 
-/// One route's workspace binding, mirroring the committed `ApprovalRouteBinding`.
+/// One route's display-only binding, mirroring `ApprovalRouteBindingOut`.
 ///
-/// The two fields are the axes ADR-0034 unfused and the CLI must keep visibly
-/// apart: `channel` is WHERE the card posts, `approvers` is WHO may act on it.
-/// Collapsing them in the output would re-fuse in presentation what the schema
-/// separates.
+/// `resolution` is the one interactive Slack card, `notification` is an
+/// optional text-only ping, and `approvers` is WHO may act. The response model
+/// intentionally has no transport fields and no conversion into the strict
+/// PATCH graph below.
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
-pub struct ApprovalRouteBinding {
-    // The deployed API can return a route binding with no `channel` after a
-    // live rebind, which previously hard-failed every verb that lists agents.
-    // Defaulting to empty is deliberate tolerance, not the fix: the
-    // underlying API/CLI schema mismatch (#1533) is still owed.
+pub struct ApprovalRouteBindingResponse {
+    pub resolution: ApprovalResolutionTargetResponse,
     #[serde(default)]
-    pub channel: String,
-    /// Absent means the card channel's members are the approvers, the zero-setup
-    /// default. Skipped on serialize so a channel-only write sends no `approvers`
-    /// key at all: the API models the block with `extra="forbid"`, and an explicit
-    /// null is a different statement from an omitted key.
+    pub notification: Option<ApprovalNotificationTargetResponse>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub approvers: Option<ApprovalApprovers>,
+}
+
+/// Interactive target returned by the API. The current resolver supports Slack
+/// only, but response decoding stays tolerant of a future server extension.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct ApprovalResolutionTargetResponse {
+    pub kind: String,
+    pub address: String,
+}
+
+/// Text-only notification target returned by the API. Endpoint and adapter are
+/// deliberately absent: transport belongs to the write/stored model only.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct ApprovalNotificationTargetResponse {
+    pub kind: String,
+    pub address: String,
 }
 
 /// Who may resolve a route's approvals, mirroring the committed
@@ -161,16 +171,15 @@ pub struct ApprovalApprovers {
 
 // --- The input side of the same contract (#1072) -------------------------------
 //
-// The two structs above decode API RESPONSES and must stay tolerant: a field a
-// newer server adds should not break an older CLI. The two below decode an
+// The structs above decode API RESPONSES and must stay tolerant: a field a newer
+// server adds should not break an older CLI. The graph below decodes an
 // OPERATOR-AUTHORED `--routes-from` file and must do the opposite.
 //
 // The asymmetry is the whole fix, so the pair lives here next to its lenient
 // twin rather than off in the command module. A typo'd key in a route file is
-// not a harmless unknown: dropping `approver` (for `approvers`) leaves a
-// channel-only binding, and a binding with no approvers block falls back to
-// card-channel membership, so the operator who meant to narrow authority to one
-// group has instead granted it to everyone in the channel.
+// not a harmless unknown: dropping `approver` (for `approvers`) leaves a route
+// whose authority falls back to resolution-card membership, so the operator who
+// meant to narrow authority to one group has widened it instead.
 //
 // The API already guards this with `extra="forbid"` on `ApprovalRouteBinding`,
 // on the stated premise that it is the binding's only writer. #1057 made the
@@ -180,11 +189,47 @@ pub struct ApprovalApprovers {
 // operator-authored files: an authoring typo fails loud rather than silently
 // dropping the intended field.
 
-/// One route binding as written in a `--routes-from` file. Strict by design.
+/// The only route shape accepted by `ApiClient::set_approval_routes`.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ApprovalRouteBindingWrite {
+    pub resolution: ApprovalResolutionTargetWrite,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub notification: Option<NotificationTargetWrite>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub approvers: Option<ApprovalApprovers>,
+}
+
+/// Slack-only interactive resolution target. `kind` is kept explicit as the
+/// future extension point, while command validation currently refuses anything
+/// except `slack`.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ApprovalResolutionTargetWrite {
+    pub kind: String,
+    pub address: String,
+}
+
+/// Optional notification target with write-only transport routing.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct NotificationTargetWrite {
+    pub kind: String,
+    pub address: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub endpoint: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub adapter: Option<String>,
+}
+
+/// One route binding as written in a `--routes-from` file. Strict by design and
+/// intentionally separate from both the tolerant response and the PATCH DTO.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct RouteBindingInput {
-    pub channel: String,
+    pub resolution: ApprovalResolutionTargetWrite,
+    #[serde(default)]
+    pub notification: Option<NotificationTargetWrite>,
     #[serde(default)]
     pub approvers: Option<ApproversInput>,
 }
@@ -208,10 +253,11 @@ impl From<ApproversInput> for ApprovalApprovers {
     }
 }
 
-impl From<RouteBindingInput> for ApprovalRouteBinding {
+impl From<RouteBindingInput> for ApprovalRouteBindingWrite {
     fn from(input: RouteBindingInput) -> Self {
-        ApprovalRouteBinding {
-            channel: input.channel,
+        ApprovalRouteBindingWrite {
+            resolution: input.resolution,
+            notification: input.notification,
             approvers: input.approvers.map(Into::into),
         }
     }
@@ -1428,7 +1474,7 @@ impl ApiClient {
     pub async fn set_approval_routes(
         &self,
         agent_id: &str,
-        routes: &std::collections::BTreeMap<String, ApprovalRouteBinding>,
+        routes: &std::collections::BTreeMap<String, ApprovalRouteBindingWrite>,
     ) -> Result<Agent> {
         let resp = self
             .http

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -5063,8 +5063,8 @@ pub struct ApprovalCmd {
     pub reject: bool,
     pub note: Option<String>,
     pub actor_channel: Option<String>,
-    /// `--route NAME=CHANNEL`, repeatable.
-    pub route: Vec<String>,
+    /// `--route-resolution NAME=CHANNEL`, repeatable.
+    pub route_resolution: Vec<String>,
     /// `--route-approvers NAME=users:U1,U2` or `NAME=group:S1`, repeatable.
     pub route_approvers: Vec<String>,
     /// `--routes-from FILE`: the whole binding map as JSON.
@@ -5075,16 +5075,17 @@ pub struct ApprovalCmd {
 
 // --- Approval route bindings (#1052) -----------------------------------------
 //
-// Which channel an approval card posts to, and who may resolve it, live in the
-// agent's `approval_routes` map. Until this verb existed the only way to write
-// one was a hand-rolled `PATCH /agents/{id}`, against the repo's own "one entry
-// point: curie <command>" rule.
+// The verified resolution card, optional text-only notification, and who may
+// resolve live as separate fields in the agent's `approval_routes` map. Until
+// this verb existed the only way to write one was a hand-rolled
+// `PATCH /agents/{id}`, against the repo's own "one entry point: curie
+// <command>" rule.
 //
 // Two properties shape the code below.
 //
 // The write is a FULL REPLACEMENT, exactly as `--gate` already is for
 // `approval_required_tools`. That is the field's semantics on `AgentUpdate`, and
-// a merge would make `--route` unable to express removal.
+// a merge would make the route inputs unable to express removal.
 //
 // Every parse and shape error is collected BEFORE any HTTP call. A partial write
 // of a binding map is a silently widened (or silently narrowed) approver set,
@@ -5100,6 +5101,9 @@ static SLACK_USERGROUP_ID: std::sync::LazyLock<regex::Regex> =
     std::sync::LazyLock::new(|| regex::Regex::new(r"^S[A-Z0-9]{7,}$").expect("usergroup id re"));
 static SLACK_USER_ID: std::sync::LazyLock<regex::Regex> =
     std::sync::LazyLock::new(|| regex::Regex::new(r"^[UW][A-Z0-9]{7,}$").expect("user id re"));
+static CHANNEL_KIND: std::sync::LazyLock<regex::Regex> = std::sync::LazyLock::new(|| {
+    regex::Regex::new(r"^[a-z0-9]+(?:[-_][a-z0-9]+)*$").expect("channel kind re")
+});
 
 /// Split `NAME=VALUE` once, rejecting an empty half.
 ///
@@ -5109,7 +5113,7 @@ static SLACK_USER_ID: std::sync::LazyLock<regex::Regex> =
 fn split_route_arg<'a>(flag: &str, raw: &'a str) -> Result<(&'a str, &'a str)> {
     let (name, value) = raw.split_once('=').ok_or_else(|| {
         crate::exit::usage(format!(
-            "{flag} {raw:?} is not NAME=VALUE; pass e.g. {flag} deal_desk=C0123ABCD"
+            "{flag} {raw:?} is not NAME=VALUE; pass e.g. {flag} deal_desk=C0EXAMPLE1"
         ))
     })?;
     let (name, value) = (name.trim(), value.trim());
@@ -5194,23 +5198,24 @@ fn parse_route_approvers(value: &str) -> Result<crate::api::ApprovalApprovers> {
     }
 }
 
-/// Build the binding map a write should send, from the three input forms.
+/// Build the binding map a write should send from a strict file plus overrides.
 ///
 /// `--routes-from` seeds the map and the repeatable flags apply on top, so a
 /// committed file can be spot-overridden on the command line. Every error is a
 /// usage error raised before the caller opens a connection.
 fn build_route_bindings(
-    route: &[String],
+    route_resolution: &[String],
     route_approvers: &[String],
     routes_from: Option<&PathBuf>,
-) -> Result<BTreeMap<String, crate::api::ApprovalRouteBinding>> {
-    let mut bindings: BTreeMap<String, crate::api::ApprovalRouteBinding> = BTreeMap::new();
+) -> Result<BTreeMap<String, crate::api::ApprovalRouteBindingWrite>> {
+    let mut bindings: BTreeMap<String, crate::api::ApprovalRouteBindingWrite> = BTreeMap::new();
 
     if let Some(path) = routes_from {
         let text = std::fs::read_to_string(path).map_err(|e| {
             crate::exit::usage(format!(
                 "--routes-from {}: {e}; the file must be JSON shaped \
-                 {{\"<route>\": {{\"channel\": \"C0123ABCD\"}}}}",
+                 {{\"<route>\": {{\"resolution\": \
+                 {{\"kind\": \"slack\", \"address\": \"C0EXAMPLE1\"}}}}}}",
                 path.display()
             ))
         })?;
@@ -5223,7 +5228,8 @@ fn build_route_bindings(
             serde_json::from_str(&text).map_err(|e| {
                 crate::exit::usage(format!(
                     "--routes-from {}: {e}; expected JSON shaped \
-                     {{\"<route>\": {{\"channel\": \"C0123ABCD\", \
+                     {{\"<route>\": {{\"resolution\": \
+                     {{\"kind\": \"slack\", \"address\": \"C0EXAMPLE1\"}}, \
                      \"approvers\": {{\"group\": \"S0123ABCD\"}}}}}}",
                     path.display()
                 ))
@@ -5231,8 +5237,8 @@ fn build_route_bindings(
         for (name, value) in raw {
             // RouteBindingInput is the strict, operator-file twin of the
             // response-side type: it refuses an unknown key instead of dropping
-            // it (#1072). A dropped `approver` would leave a channel-only
-            // binding, which widens the approver set to the whole card channel.
+            // it (#1072). A dropped `approver` would leave authority falling
+            // back to the whole resolution-card channel.
             let input: crate::api::RouteBindingInput =
                 serde_json::from_value(value).map_err(|e| {
                     anyhow::Error::from(
@@ -5241,30 +5247,34 @@ fn build_route_bindings(
                             path.display()
                         ))
                         .with_fix(
-                            "a route binding takes `channel` and an optional `approvers` \
-                             block of `group` or `users`, and nothing else. A dropped \
-                             sibling key would leave a channel-only binding, which makes \
-                             every member of that channel an approver",
+                            "a route binding requires `resolution: {kind: \"slack\", \
+                             address: \"C...\"}` and accepts optional `notification` and \
+                             `approvers` blocks, and nothing else. The retired `channel` key \
+                             is not accepted",
                         ),
                     )
                 })?;
-            let binding: crate::api::ApprovalRouteBinding = input.into();
-            validate_route_channel(&name, &binding.channel)?;
-            if let Some(approvers) = &binding.approvers {
-                validate_parsed_approvers(&name, approvers)?;
-            }
+            let binding: crate::api::ApprovalRouteBindingWrite = input.into();
             bindings.insert(name, binding);
         }
     }
 
-    for raw in route {
-        let (name, channel) = split_route_arg("--route", raw)?;
-        validate_route_channel(name, channel)?;
+    for raw in route_resolution {
+        let (name, channel) = split_route_arg("--route-resolution", raw)?;
         bindings
             .entry(name.to_string())
-            .and_modify(|b| b.channel = channel.to_string())
-            .or_insert_with(|| crate::api::ApprovalRouteBinding {
-                channel: channel.to_string(),
+            .and_modify(|b| {
+                b.resolution = crate::api::ApprovalResolutionTargetWrite {
+                    kind: "slack".to_string(),
+                    address: channel.to_string(),
+                }
+            })
+            .or_insert_with(|| crate::api::ApprovalRouteBindingWrite {
+                resolution: crate::api::ApprovalResolutionTargetWrite {
+                    kind: "slack".to_string(),
+                    address: channel.to_string(),
+                },
+                notification: None,
                 approvers: None,
             });
     }
@@ -5272,17 +5282,15 @@ fn build_route_bindings(
     for raw in route_approvers {
         let (name, value) = split_route_arg("--route-approvers", raw)?;
         let approvers = parse_route_approvers(value)?;
-        // Approvers narrow an EXISTING binding; without a channel there is
-        // nowhere for the card to post, and the API's model requires one. Refuse
-        // rather than invent a channel.
+        // Approvers narrow an EXISTING binding; without a resolution there is
+        // no verified card surface. Refuse rather than invent one.
         let binding = bindings.get_mut(name).ok_or_else(|| {
             anyhow::Error::from(
                 crate::exit::CliError::usage(format!(
-                    "--route-approvers {name:?} names a route with no channel to post its \
-                     card in"
+                    "--route-approvers {name:?} names a route with no resolution"
                 ))
                 .with_fix(format!(
-                    "add --route {name}=<CHANNEL> to the same invocation (or name the \
+                    "add --route-resolution {name}=<CHANNEL> to the same invocation (or name the \
                      route in --routes-from): a write replaces the whole route map, so \
                      every route it should keep must be present"
                 )),
@@ -5291,7 +5299,136 @@ fn build_route_bindings(
         binding.approvers = Some(approvers);
     }
 
+    // Overrides can invalidate a previously valid file binding (for example,
+    // by moving resolution onto its notification target), so validate only the
+    // complete final map. Nothing reaches HTTP unless every binding survives.
+    for (name, binding) in &bindings {
+        validate_resolution_target(name, &binding.resolution)?;
+        if let Some(notification) = &binding.notification {
+            validate_notification_target(name, notification)?;
+            reject_identical_targets(name, &binding.resolution, notification)?;
+        }
+        if let Some(approvers) = &binding.approvers {
+            validate_parsed_approvers(name, approvers)?;
+        }
+    }
+
     Ok(bindings)
+}
+
+/// The interactive extension point is explicit but remains Slack-only until a
+/// second channel can mint a scoped, verified resolver credential.
+fn validate_resolution_target(
+    route: &str,
+    target: &crate::api::ApprovalResolutionTargetWrite,
+) -> Result<()> {
+    if target.kind != "slack" {
+        return Err(crate::exit::usage(format!(
+            "route {route:?}: resolution kind {:?} is unsupported; only slack can carry \
+             a verified resolver identity",
+            target.kind
+        )));
+    }
+    validate_route_channel(route, &target.address)
+}
+
+/// Validate the notification identity and its independent transport route.
+fn validate_notification_target(
+    route: &str,
+    target: &crate::api::NotificationTargetWrite,
+) -> Result<()> {
+    if !CHANNEL_KIND.is_match(&target.kind) {
+        return Err(crate::exit::usage(format!(
+            "route {route:?}: notification kind {:?} is not a lowercase channel-kind slug",
+            target.kind
+        )));
+    }
+    if target.kind == "slack" {
+        validate_route_channel(route, &target.address)?;
+    } else if target.address.is_empty() || target.address.chars().any(char::is_whitespace) {
+        return Err(crate::exit::usage(format!(
+            "route {route:?}: notification address must be non-empty and contain no whitespace"
+        )));
+    }
+    let complete_transport = target.endpoint.is_some() && target.adapter.is_some();
+    let empty_transport = target.endpoint.is_none() && target.adapter.is_none();
+    if !complete_transport && !empty_transport {
+        return Err(crate::exit::usage(format!(
+            "route {route:?}: notification endpoint and adapter must be supplied together"
+        )));
+    }
+    if target.kind != "slack" && !complete_transport {
+        return Err(crate::exit::CliError::usage(format!(
+            "route {route:?}: non-Slack notification kind {:?} requires both endpoint and adapter",
+            target.kind
+        ))
+        .with_fix(
+            "put the complete notification object in --routes-from, including an absolute \
+             endpoint URL and adapter name",
+        )
+        .into());
+    }
+    if let Some(adapter) = &target.adapter {
+        if !CHANNEL_KIND.is_match(adapter) {
+            return Err(crate::exit::usage(format!(
+                "route {route:?}: notification adapter is not a lowercase slug"
+            )));
+        }
+    }
+    if let Some(endpoint) = &target.endpoint {
+        let parsed = reqwest::Url::parse(endpoint).map_err(|_| {
+            crate::exit::usage(format!(
+                "route {route:?}: notification endpoint must be an absolute http(s) URL with a host"
+            ))
+        })?;
+        if !matches!(parsed.scheme(), "http" | "https") || parsed.host_str().is_none() {
+            return Err(crate::exit::usage(format!(
+                "route {route:?}: notification endpoint must be an absolute http(s) URL with a host"
+            )));
+        }
+        if !parsed.username().is_empty() || parsed.password().is_some() {
+            return Err(crate::exit::usage(format!(
+                "route {route:?}: notification endpoint must not contain userinfo; use adapter credentials"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn reject_identical_targets(
+    route: &str,
+    resolution: &crate::api::ApprovalResolutionTargetWrite,
+    notification: &crate::api::NotificationTargetWrite,
+) -> Result<()> {
+    if resolution.kind == notification.kind && resolution.address == notification.address {
+        return Err(crate::exit::usage(format!(
+            "route {route:?}: notification must differ from resolution; a duplicate target \
+             is not a second notification surface"
+        )));
+    }
+    Ok(())
+}
+
+/// Render route bindings for a dry-run without exposing credential-bearing
+/// adapter URL paths, queries, or fragments. The origin is enough to identify
+/// the transport destination; the real PATCH retains the complete endpoint.
+fn route_bindings_plan_json(
+    bindings: &BTreeMap<String, crate::api::ApprovalRouteBindingWrite>,
+) -> String {
+    let mut display = bindings.clone();
+    for binding in display.values_mut() {
+        let Some(endpoint) = binding
+            .notification
+            .as_mut()
+            .and_then(|target| target.endpoint.as_mut())
+        else {
+            continue;
+        };
+        *endpoint = reqwest::Url::parse(endpoint)
+            .map(|url| url.origin().ascii_serialization())
+            .unwrap_or_else(|_| "<redacted>".to_string());
+    }
+    serde_json::to_string(&display).unwrap_or_else(|_| "<unserializable>".to_string())
 }
 
 /// Channel-shape check for one route binding, with the route named in the error.
@@ -5303,8 +5440,8 @@ fn validate_route_channel(route: &str, channel: &str) -> Result<()> {
              receives messages"
         ))
         .with_fix(
-            "pass the channel ID (e.g. C0123ABCD): find it in the channel's About tab, \
-             or at the end of the channel URL (.../archives/C0123ABCD)",
+            "pass the channel ID (e.g. C0EXAMPLE1): find it in the channel's About tab, \
+             or at the end of the channel URL (.../archives/C0EXAMPLE1)",
         )
         .into());
     }
@@ -5381,7 +5518,7 @@ pub enum ApprovalsOutput {
     /// bundle names escalates to a human rather than posting a card.
     Routes {
         agent: String,
-        routes: BTreeMap<String, crate::api::ApprovalRouteBinding>,
+        routes: BTreeMap<String, crate::api::ApprovalRouteBindingResponse>,
     },
 }
 
@@ -5508,10 +5645,21 @@ impl crate::ui::CliOutput for ApprovalsOutput {
                         routes.len()
                     ));
                     for (name, binding) in routes {
-                        // Print WHERE and WHO as separate labelled facts: ADR-0034
-                        // unfused these two axes, and a single collapsed line would
-                        // re-fuse them in the operator's head.
-                        ui.kv(name, &format!("channel {}", binding.channel));
+                        // Keep resolution, notification, and authority as three
+                        // labelled facts. The notification is never presented as
+                        // a place where an operator can act.
+                        let resolution =
+                            format!("{}:{}", binding.resolution.kind, binding.resolution.address);
+                        ui.kv(
+                            name,
+                            &format!("resolution {resolution} (verified interactive card)"),
+                        );
+                        let notification = binding
+                            .notification
+                            .as_ref()
+                            .map(|target| format!("{}:{} (text-only)", target.kind, target.address))
+                            .unwrap_or_else(|| "(none)".to_string());
+                        ui.kv("", &format!("  notification: {notification}"));
                         ui.kv("", &format!("  approvers: {}", describe_approvers(binding)));
                     }
                 }
@@ -5521,11 +5669,11 @@ impl crate::ui::CliOutput for ApprovalsOutput {
 }
 
 /// One line naming who may resolve a route's approvals, including the default.
-fn describe_approvers(binding: &crate::api::ApprovalRouteBinding) -> String {
+fn describe_approvers(binding: &crate::api::ApprovalRouteBindingResponse) -> String {
     match &binding.approvers {
         None => format!(
-            "members of {} (the default: no approvers block declared)",
-            binding.channel
+            "members of {}:{} (the default: no approvers block declared)",
+            binding.resolution.kind, binding.resolution.address
         ),
         Some(a) => match (&a.users, &a.group) {
             // Mirror the API's precedence in the wording rather than hiding it:
@@ -5587,20 +5735,19 @@ pub async fn approvals(
 ) -> Result<ApprovalsOutput> {
     let gate_mode = clear || !gate.is_empty();
 
-    // --route/--route-approvers/--routes-from/--list-routes/--clear-routes (#1052):
-    // the agent's route bindings, which decide WHERE a card posts and WHO may
-    // resolve it. Handled ahead of every other branch because it is a distinct
+    // The split target/approver flags address the agent's approval route map.
+    // Handled ahead of every other branch because it is a distinct
     // object from both the tool gates and the pending records, and mixing it with
     // either in one invocation would make the write's replace-the-whole-map
     // semantics ambiguous.
-    let route_write = !cmd.route.is_empty()
+    let route_write = !cmd.route_resolution.is_empty()
         || !cmd.route_approvers.is_empty()
         || cmd.routes_from.is_some()
         || cmd.clear_routes;
     if route_write || cmd.list_routes {
         if gate_mode || cmd.list || cmd.resolve.is_some() {
             return Err(crate::exit::usage(
-                "the route-binding flags (--route/--route-approvers/--routes-from/\
+                "the route-binding flags (--route-resolution/--route-approvers/--routes-from/\
                  --list-routes/--clear-routes) address the agent's approval ROUTES; they \
                  cannot be combined with --gate/--clear (tool gates) or --list/--resolve \
                  (pending records). Run them as separate invocations",
@@ -5612,13 +5759,14 @@ pub async fn approvals(
             ));
         }
         if cmd.clear_routes
-            && (!cmd.route.is_empty()
+            && (!cmd.route_resolution.is_empty()
                 || !cmd.route_approvers.is_empty()
                 || cmd.routes_from.is_some())
         {
             return Err(crate::exit::usage(
-                "--clear-routes cannot be combined with --route/--route-approvers/\
-                 --routes-from (clear removes every binding)",
+                "--clear-routes cannot be combined with --route-resolution/\
+                 --route-approvers/--routes-from \
+                 (clear removes every binding)",
             ));
         }
 
@@ -5627,7 +5775,11 @@ pub async fn approvals(
         let bindings = if cmd.clear_routes {
             BTreeMap::new()
         } else {
-            build_route_bindings(&cmd.route, &cmd.route_approvers, cmd.routes_from.as_ref())?
+            build_route_bindings(
+                &cmd.route_resolution,
+                &cmd.route_approvers,
+                cmd.routes_from.as_ref(),
+            )?
         };
 
         if opts.dry_run {
@@ -5635,9 +5787,10 @@ pub async fn approvals(
                 format!(
                     "PATCH {}/agents/<id> approval_routes={} (a FULL REPLACEMENT of the map)",
                     opts.api_url,
-                    // Deliberately not valid JSON. "{}" is the real clear payload, so a
-                    // fallback that looked like "{}" would misreport a full revocation.
-                    serde_json::to_string(&bindings).unwrap_or_else(|_| "<unserializable>".into())
+                    // Deliberately not valid JSON on serialization failure. "{}" is the
+                    // real clear payload, so a fallback that looked like "{}" would
+                    // misreport a full revocation.
+                    route_bindings_plan_json(&bindings)
                 )
             } else {
                 format!(
@@ -5838,7 +5991,7 @@ pub async fn observability(open: bool) -> Result<crate::observability::Observabi
 /// answered authoritatively by the API.
 ///
 /// The `slack` arm rejects a `#name` rather than a channel ID: real Slack
-/// events carry the channel **ID** (e.g. `C0123ABCD`), and the worker's
+/// events carry the channel **ID** (e.g. `C0EXAMPLE1`), and the worker's
 /// binding resolver matches on that ID, so a `#name` value is stored verbatim
 /// and never routes -- a silently dead binding. Fail the deploy up front
 /// instead.
@@ -5846,9 +5999,9 @@ fn validate_channel_binding(kind: &str, address: &str) -> Result<()> {
     if kind == "slack" && address.trim_start().starts_with('#') {
         return Err(crate::exit::usage(format!(
             "slack channel {address:?} is a name, not an ID: real Slack events carry the \
-             channel ID (e.g. C0123ABCD) and the worker routes on it, so a #name binding \
+             channel ID (e.g. C0EXAMPLE1) and the worker routes on it, so a #name binding \
              never receives messages. Pass the channel ID instead -- find it in the \
-             channel's About tab, or the channel URL (.../archives/C0123ABCD)."
+             channel's About tab, or the channel URL (.../archives/C0EXAMPLE1)."
         )));
     }
     Ok(())
@@ -6482,15 +6635,14 @@ pub const APPROVALS_ROUTES_REASON: &str =
     "an approval route binding is per-agent platform config (agents.approval_routes), and the skill tier runs a bare runner with no platform, no agent record, and therefore nothing to bind a route on";
 /// Where to bind approval routes instead.
 pub const APPROVALS_ROUTES_ALT: &str =
-    "use `curie local approvals <agent> --route <name>=<channel>` or `curie cluster approvals <agent> --route <name>=<channel>` for a deployed agent; the bundle-side half (which routes exist) is the manifest's approvalPolicy, which `curie skill approvals` does show";
+    "use `curie local approvals <agent> --route-resolution <name>=<channel>` or `curie cluster approvals <agent> --route-resolution <name>=<channel>` for a deployed agent; use `--routes-from <file>` to declare a complete route with a text-only notification; the bundle-side half (which routes exist) is the manifest's approvalPolicy, which `curie skill approvals` does show";
 
-/// `skill approvals --route`/`--route-approvers`/`--routes-from`/`--list-routes`/
-/// `--clear-routes`: answered, but unavailable at this tier by construction
-/// (ADR-0041). Accepted so the tier reports WHY (exit 4) rather than erroring
-/// like an unknown-flag typo, matching `--list`/`--resolve` above.
+/// The route-binding inputs are answered but unavailable at this tier by
+/// construction (ADR-0041). Accepted so the tier reports WHY (exit 4) rather
+/// than erroring like an unknown-flag typo, matching `--list`/`--resolve` above.
 pub fn skill_approval_routes_unavailable() -> anyhow::Error {
     crate::exit::unsupported(
-        "approvals --route/--route-approvers/--routes-from/--list-routes/--clear-routes",
+        "approvals --route-resolution/--route-approvers/--routes-from/--list-routes/--clear-routes",
         APPROVALS_ROUTES_REASON,
         APPROVALS_ROUTES_ALT,
     )

--- a/cli/src/guide.rs
+++ b/cli/src/guide.rs
@@ -239,11 +239,18 @@ pub fn primer() -> Primer {
                     detail: "A bundle declares routes in .claude-plugin/plugin.json under \
                              approvalPolicy.gates[], each entry {gate: <tool name>, route: \
                              <route name>}. An operator then binds each route per agent with \
-                             `approvals <AGENT> --route <name>=<channel>` (and optionally \
-                             `--route-approvers <name>=users:U1,U2` or `<name>=group:S1`). \
-                             `channel` is WHERE the card posts; `approvers` is WHO may act \
-                             on it. A write REPLACES the whole route map, so name every \
-                             route it should keep.",
+                             `approvals <AGENT> --route-resolution <name>=<channel>` (and optionally \
+                             `--route-approvers <name>=users:U1,U2` or `<name>=group:S1`). Declare \
+                             a notification in the strict `--routes-from` JSON map. \
+                             `resolution` is the single verified Slack card where an identity \
+                             acts; `notification` is a text-only ping with interaction=None, \
+                             and `approvers` is WHO may act. A notification directs humans to \
+                             the configured approval channel without disclosing its identifier \
+                             and carries no resolving affordance. Slack uses \
+                             its configured transport; a non-Slack notification needs both \
+                             endpoint and adapter in --routes-from. Resolution on another \
+                             channel remains a future extension requiring a scoped credential. \
+                             A write REPLACES the whole route map, so name every route it should keep.",
                 },
                 ApprovalFact {
                     title: "Who may resolve is independent of where the card is",
@@ -295,7 +302,7 @@ pub fn primer() -> Primer {
             },
             Landmine {
                 title: "Silence after a request usually means an unbound route",
-                detail: "A route the bundle names but the agent's approval_routes never bound is escalated to a human rather than widened to the requesting channel, so no card appears anywhere and the turn still reports the request as pending. Bind the route with `--route <name>=<channel>` and re-run the turn; check that before suspecting the gate.",
+                detail: "A route the bundle names but the agent's approval_routes never bound is escalated to a human rather than widened to the requesting channel, so no card appears anywhere and the turn still reports the request as pending. Bind its verified Slack resolution with `--route-resolution <name>=<channel>` and re-run the turn; check that before suspecting the gate.",
             },
             Landmine {
                 title: "Fake vs live model is symmetric across skill and local",

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -716,25 +716,24 @@ enum SkillAction {
         /// declined cleanly at this tier.
         #[arg(long)]
         reject: bool,
-        /// Bind an approval route to a channel. Accepted so it can be DECLINED
-        /// with a reason rather than error like a typo: a route binding is
-        /// per-agent platform config, and the skill tier has no platform.
-        #[arg(long = "route", value_name = "NAME=CHANNEL")]
-        route: Vec<String>,
+        /// Bind a route's verified Slack resolution card. Accepted so it can be
+        /// DECLINED with a reason: the skill tier has no platform agent record.
+        #[arg(long = "route-resolution", value_name = "NAME=CHANNEL")]
+        route_resolution: Vec<String>,
         /// Narrow a route's approvers. Declined at this tier for the same reason
-        /// as --route.
+        /// as --route-resolution.
         #[arg(long = "route-approvers", value_name = "NAME=KIND:VALUES")]
         route_approvers: Vec<String>,
-        /// Read the route map from a JSON file. Declined at this tier for the
-        /// same reason as --route.
+        /// Read the complete route map, including optional notifications, from
+        /// JSON. Declined at this tier for the same reason as --route-resolution.
         #[arg(long = "routes-from", value_name = "FILE")]
         routes_from: Option<PathBuf>,
         /// Show the agent's route bindings. Declined at this tier for the same
-        /// reason as --route.
+        /// reason as --route-resolution.
         #[arg(long)]
         list_routes: bool,
         /// Remove every route binding. Declined at this tier for the same reason
-        /// as --route.
+        /// as --route-resolution.
         #[arg(long)]
         clear_routes: bool,
     },
@@ -1198,19 +1197,20 @@ enum LocalAction {
         /// channel-authorized approval gates (with --resolve).
         #[arg(long)]
         actor_channel: Option<String>,
-        /// Bind a manifest approval route to the channel its card posts in, as
+        /// Bind a manifest route's verified Slack resolution card, as
         /// NAME=CHANNEL (e.g. deal_desk=C0123ABCD). Repeatable. A write REPLACES
         /// the whole route map, like --gate does for tool gates.
-        #[arg(long = "route", value_name = "NAME=CHANNEL")]
-        route: Vec<String>,
-        /// Narrow WHO may resolve a route, independently of where its card posts,
+        #[arg(long = "route-resolution", value_name = "NAME=CHANNEL")]
+        route_resolution: Vec<String>,
+        /// Narrow WHO may resolve a route, independently of its resolution target,
         /// as NAME=users:U1,U2 or NAME=group:S1. Repeatable. Omit to leave the
-        /// card channel's members as the approvers.
+        /// resolution card's channel members as the approvers.
         #[arg(long = "route-approvers", value_name = "NAME=KIND:VALUES")]
         route_approvers: Vec<String>,
         /// Read the whole route map from a JSON file, e.g.
-        /// {"deal_desk": {"channel": "C0123ABCD"}}. The repeatable flags apply on
-        /// top of it.
+        /// {"deal_desk":{"resolution":{"kind":"slack","address":"C0123ABCD"}}}.
+        /// Notifications, including endpoint+adapter transport, are declared in
+        /// this strict map. The repeatable override flags apply on top of it.
         #[arg(long = "routes-from", value_name = "FILE")]
         routes_from: Option<PathBuf>,
         /// Show the agent's approval route bindings instead of its tool gates.
@@ -2024,19 +2024,20 @@ enum ClusterAction {
         /// channel-authorized approval gates (with --resolve).
         #[arg(long)]
         actor_channel: Option<String>,
-        /// Bind a manifest approval route to the channel its card posts in, as
+        /// Bind a manifest route's verified Slack resolution card, as
         /// NAME=CHANNEL (e.g. deal_desk=C0123ABCD). Repeatable. A write REPLACES
         /// the whole route map, like --gate does for tool gates.
-        #[arg(long = "route", value_name = "NAME=CHANNEL")]
-        route: Vec<String>,
-        /// Narrow WHO may resolve a route, independently of where its card posts,
+        #[arg(long = "route-resolution", value_name = "NAME=CHANNEL")]
+        route_resolution: Vec<String>,
+        /// Narrow WHO may resolve a route, independently of its resolution target,
         /// as NAME=users:U1,U2 or NAME=group:S1. Repeatable. Omit to leave the
-        /// card channel's members as the approvers.
+        /// resolution card's channel members as the approvers.
         #[arg(long = "route-approvers", value_name = "NAME=KIND:VALUES")]
         route_approvers: Vec<String>,
         /// Read the whole route map from a JSON file, e.g.
-        /// {"deal_desk": {"channel": "C0123ABCD"}}. The repeatable flags apply on
-        /// top of it.
+        /// {"deal_desk":{"resolution":{"kind":"slack","address":"C0123ABCD"}}}.
+        /// Notifications, including endpoint+adapter transport, are declared in
+        /// this strict map. The repeatable override flags apply on top of it.
         #[arg(long = "routes-from", value_name = "FILE")]
         routes_from: Option<PathBuf>,
         /// Show the agent's approval route bindings instead of its tool gates.
@@ -2282,7 +2283,7 @@ async fn run(command: Option<Command>) -> Result<()> {
                 clear,
                 list,
                 resolve,
-                route,
+                route_resolution,
                 route_approvers,
                 routes_from,
                 list_routes,
@@ -2298,7 +2299,7 @@ async fn run(command: Option<Command>) -> Result<()> {
                 // record is absent because this tier keeps no durable store, but a
                 // route binding is absent because it is per-agent platform config
                 // and this tier has no agent. Same wrong answer, different fix.
-                let routes_asked = !route.is_empty()
+                let routes_asked = !route_resolution.is_empty()
                     || !route_approvers.is_empty()
                     || routes_from.is_some()
                     || list_routes
@@ -2654,7 +2655,7 @@ async fn run(command: Option<Command>) -> Result<()> {
                 reject,
                 note,
                 actor_channel,
-                route,
+                route_resolution,
                 route_approvers,
                 routes_from,
                 list_routes,
@@ -2671,7 +2672,7 @@ async fn run(command: Option<Command>) -> Result<()> {
                         reject,
                         note,
                         actor_channel,
-                        route,
+                        route_resolution,
                         route_approvers,
                         routes_from,
                         list_routes,
@@ -3617,7 +3618,7 @@ async fn run(command: Option<Command>) -> Result<()> {
                 reject,
                 note,
                 actor_channel,
-                route,
+                route_resolution,
                 route_approvers,
                 routes_from,
                 list_routes,
@@ -3646,7 +3647,7 @@ async fn run(command: Option<Command>) -> Result<()> {
                             reject,
                             note,
                             actor_channel,
-                            route,
+                            route_resolution,
                             route_approvers,
                             routes_from,
                             list_routes,

--- a/cli/src/recipes.rs
+++ b/cli/src/recipes.rs
@@ -284,7 +284,7 @@ pub(crate) fn recipes() -> Vec<Recipe> {
         // single verb. The two recipes above configure a gate and read what it
         // produced; neither shows an agent author how a declaration becomes a
         // resolved card. That path was not expressible without curl until
-        // #1057's --route flags merged, which is why the catalog carried only
+        // #1057's route flags merged, which is why the catalog carried only
         // the --list step.
         //
         // Anchored on the bind because that is the step an operator types and
@@ -296,13 +296,13 @@ pub(crate) fn recipes() -> Vec<Recipe> {
         Recipe {
             tabs: &["platform"],
             title: "Approvals end to end (declare, bind, drive, resolve)",
-            description: "Take a gated tool from its bundle declaration to a resolved card, with no curl.",
+            description: "Take a gated tool from its bundle declaration to one verified resolution card and an optional text-only notification, with no curl.",
             kind: RecipeKind::Command,
             args: vec![
                 ArgPart::Tier,
                 ArgPart::Literal("approvals"),
                 ArgPart::Field("agent"),
-                ArgPart::Literal("--route"),
+                ArgPart::Literal("--route-resolution"),
                 ArgPart::Field("route"),
             ],
             fields: vec![
@@ -314,7 +314,7 @@ pub(crate) fn recipes() -> Vec<Recipe> {
                 },
                 Field {
                     key: "route",
-                    label: "Route binding (name=channel)",
+                    label: "Resolution binding (name=Slack channel)",
                     default: Some("managers=C0EXAMPLE1"),
                     required: true,
                 },
@@ -322,7 +322,8 @@ pub(crate) fn recipes() -> Vec<Recipe> {
             notes: &[
                 "1. Declare the gate in the bundle: .claude-plugin/plugin.json, approvalPolicy.gates[] = {gate: <tool name>, route: <route name>}. Both keys are required and an incomplete gate is rejected at deploy.",
                 "2. Deploy it: `deploy --plugin-dir <dir> --slack-channel <C...>`. The declaration reaches the platform with the bundle, not separately.",
-                "3. Bind the route (the command above). `channel` is WHERE the card posts. Add `--route-approvers <name>=users:U1,U2` to say WHO may act; without it the card channel's members are the approver set.",
+                "3. Bind the route (the command above). `resolution` is the one verified Slack card. Add `--route-approvers <name>=users:U1,U2` to say WHO may act; without it the resolution card channel's members are the approver set.",
+                "Declare an optional notification in the strict --routes-from JSON map; non-Slack notifications include their complete endpoint and adapter there. The text-only ping has interaction=None, directs humans to the configured approval channel without disclosing its identifier, and is not a resolving surface. Extending resolution to a second channel requires a scoped credential and is not built here.",
                 "4. Drive a turn that calls the gated tool. The call is denied before it runs and the turn ends awaiting approval, with a card in the bound channel.",
                 "5. Resolve it: `approvals <AGENT> --list` for the id, then `--resolve <id> --as <user> --actor-channel <channel>`. Self-approval is refused, so `--as` must name someone other than the author of the turn.",
                 "A route write REPLACES the whole map, so pass every route the agent should keep. `--list-routes` shows what is bound now.",

--- a/cli/tests/api_field_parity.rs
+++ b/cli/tests/api_field_parity.rs
@@ -186,6 +186,34 @@ fn real_tree_has_no_field_parity_violations() {
 }
 
 #[test]
+fn approval_routes_declare_separate_response_and_write_mirrors() {
+    let manifest = repo_json("cli/api-mirrors.json");
+    let mirrors = manifest["mirrors"].as_array().expect("mirrors array");
+    let schema_for = |name: &str| {
+        mirrors
+            .iter()
+            .find(|entry| entry["struct"] == name)
+            .and_then(|entry| entry["schema"].as_str())
+    };
+
+    assert_eq!(
+        schema_for("ApprovalRouteBindingResponse"),
+        Some("ApprovalRouteBindingOut"),
+        "the tolerant/redacted GET model needs its own API mirror"
+    );
+    assert_eq!(
+        schema_for("ApprovalRouteBindingWrite"),
+        Some("ApprovalRouteBinding"),
+        "the strict PATCH model must mirror the full stored binding"
+    );
+    assert_eq!(
+        schema_for("NotificationTargetWrite"),
+        Some("ApprovalNotificationTarget"),
+        "notification endpoint and adapter belong only to the write mirror"
+    );
+}
+
+#[test]
 fn version_struct_carries_the_full_version_out() {
     // The issue's named drift: `Version` must cover `agent_id` and `bundle_ref`.
     // Checked independently of the generic sweep so a manifest mistake cannot

--- a/cli/tests/approval_route_bindings.rs
+++ b/cli/tests/approval_route_bindings.rs
@@ -11,8 +11,8 @@
 //! body, or in the ABSENCE of one:
 //!
 //! - a write must send the whole map (the field replaces, it does not merge);
-//! - `channel` and `approvers` must stay separate on the wire, since ADR-0034
-//!   exists to keep WHERE a card posts unfused from WHO may resolve it;
+//! - the interactive `resolution` target, text-only `notification` target, and
+//!   `approvers` must stay separate on the wire;
 //! - and a malformed input must send NOTHING. A half-written binding map is a
 //!   silently widened or narrowed approver set, which is exactly the failure the
 //!   approval gate exists to prevent, so validation runs before the connection
@@ -22,6 +22,7 @@ mod support;
 
 use curie::commands::{approvals, AgentActionOpts, ApprovalCmd, ApprovalsOutput};
 use curie::credcheck::check_channel_id;
+use curie::ui::CliOutput;
 use std::sync::{Arc, Mutex};
 use support::{serve, MockServer, Response};
 
@@ -31,14 +32,14 @@ const AGENT_ID: &str = "ag_1";
 /// `GET /agents` payload: the handler resolves the agent by name first.
 fn agents_list(routes_json: &str) -> String {
     format!(
-        r#"[{{"id":"{AGENT_ID}","name":"deal-desk","channels":[{{"kind":"slack","address":"C0INTAKE00"}}],"approval_required_tools":null,"approval_routes":{routes_json},"memory":false}}]"#
+        r#"[{{"id":"{AGENT_ID}","name":"deal-desk","channels":[{{"kind":"slack","address":"C0EXAMPLE0"}}],"approval_required_tools":null,"approval_routes":{routes_json},"memory":false}}]"#
     )
 }
 
 /// `PATCH /agents/{id}` echo: the updated agent the CLI renders from.
 fn patched_agent(routes_json: &str) -> String {
     format!(
-        r#"{{"id":"{AGENT_ID}","name":"deal-desk","channels":[{{"kind":"slack","address":"C0INTAKE00"}}],"approval_required_tools":null,"approval_routes":{routes_json},"memory":false}}"#
+        r#"{{"id":"{AGENT_ID}","name":"deal-desk","channels":[{{"kind":"slack","address":"C0EXAMPLE0"}}],"approval_required_tools":null,"approval_routes":{routes_json},"memory":false}}"#
     )
 }
 
@@ -179,25 +180,118 @@ fn assert_no_write(server: &MockServer) {
     );
 }
 
+/// Run one rejected flag invocation and prove it fails before any PATCH.
+async fn rejected(cmd: ApprovalCmd, reason: &str) -> String {
+    let server = stub("null", "null");
+    let err = match run(&server, cmd).await {
+        Ok(_) => panic!("{reason}"),
+        Err(err) => err,
+    };
+    assert_no_write(&server);
+    err.to_string()
+}
+
+/// Write one strict `--routes-from` input and reuse the same no-PATCH proof.
+async fn rejected_routes_file(route: serde_json::Value, reason: &str) -> String {
+    rejected_routes_file_with(route, ApprovalCmd::default(), reason).await
+}
+
+/// Write one strict file, apply any flag overrides, and prove rejection is
+/// still decided from the complete map before a PATCH.
+async fn rejected_routes_file_with(
+    route: serde_json::Value,
+    mut cmd: ApprovalCmd,
+    reason: &str,
+) -> String {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("routes.json");
+    std::fs::write(&path, route.to_string()).expect("write routes file");
+    cmd.routes_from = Some(path);
+    rejected(cmd, reason).await
+}
+
+#[test]
+fn old_route_flag_is_unknown() {
+    let out = std::process::Command::new(env!("CARGO_BIN_EXE_curie"))
+        .args([
+            "local",
+            "approvals",
+            "deal-desk",
+            "--route",
+            "deal_desk=C0EXAMPLE1",
+        ])
+        .output()
+        .expect("run curie");
+
+    assert_eq!(out.status.code(), Some(2), "retired syntax must be usage");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("unexpected argument '--route'")
+            || stderr.contains("unrecognized option '--route'"),
+        "the retired flag must not remain an alias or fallback:\n{stderr}"
+    );
+}
+
+#[test]
+fn tolerant_response_binding_cannot_be_reused_as_a_patch_body() {
+    let api = include_str!("../src/api.rs");
+    assert!(
+        api.contains("pub struct ApprovalRouteBindingResponse"),
+        "the API read model must be explicitly display-only"
+    );
+    assert!(
+        api.contains("pub struct ApprovalRouteBindingWrite"),
+        "the PATCH body needs a separate strict writer"
+    );
+    let setter = api
+        .split("pub async fn set_approval_routes")
+        .nth(1)
+        .expect("set_approval_routes exists")
+        .split('{')
+        .next()
+        .expect("set_approval_routes signature");
+    assert!(
+        setter.contains("ApprovalRouteBindingWrite"),
+        "set_approval_routes must accept only the strict write DTO: {setter}"
+    );
+    assert!(
+        !setter.contains("ApprovalRouteBindingResponse"),
+        "a tolerant/redacted response must never become the PATCH body: {setter}"
+    );
+    assert!(
+        !api.contains("From<ApprovalRouteBindingResponse> for ApprovalRouteBindingWrite"),
+        "no conversion may turn the tolerant response into a writer"
+    );
+}
+
 #[tokio::test]
-async fn route_flag_writes_the_channel_binding() {
-    let bound = r#"{"deal_desk":{"channel":"C0MANAGERS"}}"#;
+async fn routes_from_builds_the_strict_split_route_shape() {
+    let bound = r#"{"deal_desk":{"resolution":{"kind":"slack","address":"C0EXAMPLE1"},"notification":{"kind":"slack","address":"C0EXAMPLE2"}}}"#;
     let server = stub("null", bound);
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("routes.json");
+    std::fs::write(&path, bound).expect("write routes file");
 
     let out = run(
         &server,
         ApprovalCmd {
-            route: vec!["deal_desk=C0MANAGERS".to_string()],
+            routes_from: Some(path),
             ..ApprovalCmd::default()
         },
     )
     .await
-    .expect("a well-formed --route should succeed");
+    .expect("a well-formed split route file should succeed");
 
     let body = patch_body(&server);
     assert_eq!(
-        body["approval_routes"]["deal_desk"]["channel"], "C0MANAGERS",
-        "the PATCH must carry the binding, got {body:?}"
+        body["approval_routes"]["deal_desk"]["resolution"],
+        serde_json::json!({"kind":"slack", "address":"C0EXAMPLE1"}),
+        "the PATCH must carry the one interactive target, got {body:?}"
+    );
+    assert_eq!(
+        body["approval_routes"]["deal_desk"]["notification"],
+        serde_json::json!({"kind":"slack", "address":"C0EXAMPLE2"}),
+        "the PATCH must carry the separate text-only target, got {body:?}"
     );
     // No approvers block was asked for, so none may be sent: an explicit null is
     // a different statement from an omitted key against a model that forbids
@@ -206,13 +300,21 @@ async fn route_flag_writes_the_channel_binding() {
         body["approval_routes"]["deal_desk"]
             .get("approvers")
             .is_none(),
-        "a channel-only write must send no approvers key, got {body:?}"
+        "a route without declared approvers must send no approvers key, got {body:?}"
     );
 
     match out {
         ApprovalsOutput::Routes { routes, .. } => {
-            assert_eq!(routes["deal_desk"].channel, "C0MANAGERS");
-            assert!(routes["deal_desk"].approvers.is_none());
+            let binding = &routes["deal_desk"];
+            assert_eq!(binding.resolution.address, "C0EXAMPLE1");
+            assert_eq!(
+                binding
+                    .notification
+                    .as_ref()
+                    .map(|target| target.address.as_str()),
+                Some("C0EXAMPLE2")
+            );
+            assert!(binding.approvers.is_none());
         }
         _ => panic!("expected the Routes output"),
     }
@@ -229,15 +331,24 @@ fn guided_channel_validation_accepts_slack_channel_kinds() {
 #[tokio::test]
 async fn direct_and_group_channels_reach_the_route_request() {
     for (channel, bound) in [
-        ("C0EXAMPLE1", r#"{"team":{"channel":"C0EXAMPLE1"}}"#),
-        ("D0EXAMPLE1", r#"{"team":{"channel":"D0EXAMPLE1"}}"#),
-        ("G0EXAMPLE1", r#"{"team":{"channel":"G0EXAMPLE1"}}"#),
+        (
+            "C0EXAMPLE1",
+            r#"{"team":{"resolution":{"kind":"slack","address":"C0EXAMPLE1"}}}"#,
+        ),
+        (
+            "D0EXAMPLE1",
+            r#"{"team":{"resolution":{"kind":"slack","address":"D0EXAMPLE1"}}}"#,
+        ),
+        (
+            "G0EXAMPLE1",
+            r#"{"team":{"resolution":{"kind":"slack","address":"G0EXAMPLE1"}}}"#,
+        ),
     ] {
         let server = stub("null", bound);
         run(
             &server,
             ApprovalCmd {
-                route: vec![format!("team={channel}")],
+                route_resolution: vec![format!("team={channel}")],
                 ..ApprovalCmd::default()
             },
         )
@@ -245,22 +356,25 @@ async fn direct_and_group_channels_reach_the_route_request() {
         .unwrap_or_else(|error| panic!("route validation rejected {channel}: {error}"));
 
         let body = patch_body(&server);
-        assert_eq!(body["approval_routes"]["team"]["channel"], channel);
+        assert_eq!(
+            body["approval_routes"]["team"]["resolution"]["address"],
+            channel
+        );
     }
 }
 
 #[tokio::test]
 async fn route_approvers_narrows_who_without_moving_where() {
-    // The ADR-0034 property, asserted on the wire: `channel` and `approvers` are
+    // The ADR-0034 property, asserted on the wire: resolution and `approvers` are
     // independent axes, so narrowing WHO must leave WHERE untouched and must not
     // collapse the two into one field.
-    let bound = r#"{"finance":{"channel":"C0FINANCE0","approvers":{"group":"S0FINGRP0"}}}"#;
+    let bound = r#"{"finance":{"resolution":{"kind":"slack","address":"C0EXAMPLE3"},"approvers":{"group":"S0FINGRP0"}}}"#;
     let server = stub("null", bound);
 
     let out = run(
         &server,
         ApprovalCmd {
-            route: vec!["finance=C0FINANCE0".to_string()],
+            route_resolution: vec!["finance=C0EXAMPLE3".to_string()],
             route_approvers: vec!["finance=group:S0FINGRP0".to_string()],
             ..ApprovalCmd::default()
         },
@@ -269,7 +383,10 @@ async fn route_approvers_narrows_who_without_moving_where() {
     .expect("a well-formed group binding should succeed");
 
     let body = patch_body(&server);
-    assert_eq!(body["approval_routes"]["finance"]["channel"], "C0FINANCE0");
+    assert_eq!(
+        body["approval_routes"]["finance"]["resolution"]["address"],
+        "C0EXAMPLE3"
+    );
     assert_eq!(
         body["approval_routes"]["finance"]["approvers"]["group"],
         "S0FINGRP0"
@@ -284,7 +401,7 @@ async fn route_approvers_narrows_who_without_moving_where() {
     match out {
         ApprovalsOutput::Routes { routes, .. } => {
             let binding = &routes["finance"];
-            assert_eq!(binding.channel, "C0FINANCE0");
+            assert_eq!(binding.resolution.address, "C0EXAMPLE3");
             assert_eq!(
                 binding.approvers.as_ref().and_then(|a| a.group.as_deref()),
                 Some("S0FINGRP0")
@@ -296,14 +413,13 @@ async fn route_approvers_narrows_who_without_moving_where() {
 
 #[tokio::test]
 async fn route_approvers_users_forwards_the_whole_list() {
-    let bound =
-        r#"{"cro_cfo":{"channel":"C0EXEC0000","approvers":{"users":["U0CRO00000","W0CFO00000"]}}}"#;
+    let bound = r#"{"cro_cfo":{"resolution":{"kind":"slack","address":"C0EXAMPLE4"},"approvers":{"users":["U0CRO00000","W0CFO00000"]}}}"#;
     let server = stub("null", bound);
 
     run(
         &server,
         ApprovalCmd {
-            route: vec!["cro_cfo=C0EXEC0000".to_string()],
+            route_resolution: vec!["cro_cfo=C0EXAMPLE4".to_string()],
             // A W-prefixed id is a valid enterprise-grid user, so the shape check
             // must accept it rather than assuming every user id starts with U.
             route_approvers: vec!["cro_cfo=users:U0CRO00000, W0CFO00000".to_string()],
@@ -323,7 +439,7 @@ async fn route_approvers_users_forwards_the_whole_list() {
 
 #[tokio::test]
 async fn list_routes_reads_without_writing() {
-    let bound = r#"{"deal_desk":{"channel":"C0MANAGERS"}}"#;
+    let bound = r#"{"deal_desk":{"resolution":{"kind":"slack","address":"C0EXAMPLE1"}}}"#;
     let server = stub(bound, bound);
 
     let out = run(
@@ -340,7 +456,7 @@ async fn list_routes_reads_without_writing() {
     match out {
         ApprovalsOutput::Routes { agent, routes } => {
             assert_eq!(agent, "deal-desk");
-            assert_eq!(routes["deal_desk"].channel, "C0MANAGERS");
+            assert_eq!(routes["deal_desk"].resolution.address, "C0EXAMPLE1");
         }
         _ => panic!("expected the Routes output"),
     }
@@ -354,7 +470,10 @@ async fn clear_routes_sends_an_empty_object_not_null() {
     // An empty object is the only spelling that passes the guard and reaches
     // `crud.update_agent_approval_routes`, whose `routes or None` is a STORAGE
     // normalization applied after the guard, not the wire contract (#1071).
-    let server = stub(r#"{"deal_desk":{"channel":"C0MANAGERS"}}"#, "null");
+    let server = stub(
+        r#"{"deal_desk":{"resolution":{"kind":"slack","address":"C0EXAMPLE1"}}}"#,
+        "null",
+    );
 
     run(
         &server,
@@ -383,7 +502,8 @@ async fn clear_routes_actually_clears_the_bindings() {
     // router's guard, then read what it hands back. A spelling the guard skips
     // leaves the binding in place, so the operator is told "updated" while the
     // approver set they meant to revoke is still live.
-    let server = router_stub(r#"{"deal_desk":{"channel":"C0MANAGERS"}}"#);
+    let server =
+        router_stub(r#"{"deal_desk":{"resolution":{"kind":"slack","address":"C0EXAMPLE1"}}}"#);
 
     let out = run(
         &server,
@@ -408,7 +528,8 @@ async fn a_routes_file_holding_an_empty_map_clears_the_bindings() {
     let path = dir.path().join("routes.json");
     std::fs::write(&path, "{}").expect("write routes file");
 
-    let server = router_stub(r#"{"deal_desk":{"channel":"C0MANAGERS"}}"#);
+    let server =
+        router_stub(r#"{"deal_desk":{"resolution":{"kind":"slack","address":"C0EXAMPLE1"}}}"#);
 
     let out = run(
         &server,
@@ -429,7 +550,10 @@ async fn the_dry_run_plan_names_the_payload_the_real_clear_sends() {
     // reading if it names the same request. Both halves are read back from what
     // the code produced; comparing two literals would prove nothing.
     let planned = {
-        let server = stub(r#"{"deal_desk":{"channel":"C0MANAGERS"}}"#, "null");
+        let server = stub(
+            r#"{"deal_desk":{"resolution":{"kind":"slack","address":"C0EXAMPLE1"}}}"#,
+            "null",
+        );
         let out = approvals(
             AgentActionOpts {
                 api_url: server.base_url.clone(),
@@ -454,7 +578,10 @@ async fn the_dry_run_plan_names_the_payload_the_real_clear_sends() {
         }
     };
 
-    let server = stub(r#"{"deal_desk":{"channel":"C0MANAGERS"}}"#, "null");
+    let server = stub(
+        r#"{"deal_desk":{"resolution":{"kind":"slack","address":"C0EXAMPLE1"}}}"#,
+        "null",
+    );
     run(
         &server,
         ApprovalCmd {
@@ -473,6 +600,64 @@ async fn the_dry_run_plan_names_the_payload_the_real_clear_sends() {
 }
 
 #[tokio::test]
+async fn dry_run_redacts_notification_endpoint_path_query_and_fragment() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("routes.json");
+    std::fs::write(
+        &path,
+        serde_json::json!({
+            "finance": {
+                "resolution": {"kind": "slack", "address": "C0EXAMPLE3"},
+                "notification": {
+                    "kind": "email",
+                    "address": "approvals@example.com",
+                    "endpoint": "https://adapter.example.com/private/replies?token=secret#credential",
+                    "adapter": "mail"
+                }
+            }
+        })
+        .to_string(),
+    )
+    .expect("write routes file");
+    let server = stub("null", "null");
+
+    let out = approvals(
+        AgentActionOpts {
+            api_url: server.base_url.clone(),
+            api_key: TEST_API_KEY.to_string(),
+            agent: "deal-desk".to_string(),
+            dry_run: true,
+        },
+        vec![],
+        false,
+        ApprovalCmd {
+            routes_from: Some(path),
+            ..ApprovalCmd::default()
+        },
+    )
+    .await
+    .expect("a valid notification route should produce a dry-run plan");
+
+    assert_no_write(&server);
+    let ApprovalsOutput::DryRun(plan) = out else {
+        panic!("expected the DryRun output");
+    };
+    let planned = planned_routes_payload(&plan.lines);
+    let notification = &planned["finance"]["notification"];
+    assert_eq!(notification["endpoint"], "https://adapter.example.com");
+    assert_eq!(notification["kind"], "email");
+    assert_eq!(notification["address"], "approvals@example.com");
+    assert_eq!(notification["adapter"], "mail");
+    let rendered = planned.to_string();
+    for secret_detail in ["private/replies", "token=secret", "credential"] {
+        assert!(
+            !rendered.contains(secret_detail),
+            "dry-run output leaked endpoint detail {secret_detail:?}: {rendered}"
+        );
+    }
+}
+
+#[tokio::test]
 async fn a_malformed_channel_writes_nothing() {
     let server = stub("null", "null");
 
@@ -481,9 +666,9 @@ async fn a_malformed_channel_writes_nothing() {
         ApprovalCmd {
             // The second route is well-formed; the first is not. Neither may be
             // written, or the resulting map is one an operator never asked for.
-            route: vec![
+            route_resolution: vec![
                 "deal_desk=#managers".to_string(),
-                "finance=C0FINANCE0".to_string(),
+                "finance=C0EXAMPLE3".to_string(),
             ],
             ..ApprovalCmd::default()
         },
@@ -507,8 +692,8 @@ async fn a_channel_id_where_a_usergroup_belongs_writes_nothing() {
     let Err(err) = run(
         &server,
         ApprovalCmd {
-            route: vec!["finance=C0FINANCE0".to_string()],
-            route_approvers: vec!["finance=group:C0FINANCE0".to_string()],
+            route_resolution: vec!["finance=C0EXAMPLE3".to_string()],
+            route_approvers: vec!["finance=group:C0EXAMPLE3".to_string()],
             ..ApprovalCmd::default()
         },
     )
@@ -525,7 +710,7 @@ async fn a_channel_id_where_a_usergroup_belongs_writes_nothing() {
 }
 
 #[tokio::test]
-async fn approvers_without_a_channel_writes_nothing() {
+async fn approvers_without_a_resolution_writes_nothing() {
     // A write replaces the whole map, so narrowing a route the invocation never
     // gives a channel would produce a binding with nowhere to post.
     let server = stub("null", "null");
@@ -539,11 +724,11 @@ async fn approvers_without_a_channel_writes_nothing() {
     )
     .await
     else {
-        panic!("approvers with no channel must be refused");
+        panic!("approvers with no resolution must be refused");
     };
 
     assert!(
-        err.to_string().contains("no channel"),
+        err.to_string().contains("no resolution"),
         "unexpected error: {err}"
     );
     assert_no_write(&server);
@@ -559,7 +744,7 @@ async fn route_flags_cannot_be_mixed_with_gate_or_record_flags() {
     let Err(err) = run(
         &server,
         ApprovalCmd {
-            route: vec!["finance=C0FINANCE0".to_string()],
+            route_resolution: vec!["finance=C0EXAMPLE3".to_string()],
             list: true,
             ..ApprovalCmd::default()
         },
@@ -582,18 +767,18 @@ async fn routes_from_seeds_the_map_and_flags_override_it() {
     let path = dir.path().join("routes.json");
     std::fs::write(
         &path,
-        r#"{"deal_desk":{"channel":"C0OLDROOM0"},"finance":{"channel":"C0FINANCE0","approvers":{"group":"S0FINGRP0"}}}"#,
+        r#"{"deal_desk":{"resolution":{"kind":"slack","address":"C0EXAMPLE5"}},"finance":{"resolution":{"kind":"slack","address":"C0EXAMPLE3"},"approvers":{"group":"S0FINGRP0"}}}"#,
     )
     .expect("write routes file");
 
-    let bound = r#"{"deal_desk":{"channel":"C0MANAGERS"},"finance":{"channel":"C0FINANCE0","approvers":{"group":"S0FINGRP0"}}}"#;
+    let bound = r#"{"deal_desk":{"resolution":{"kind":"slack","address":"C0EXAMPLE1"}},"finance":{"resolution":{"kind":"slack","address":"C0EXAMPLE3"},"approvers":{"group":"S0FINGRP0"}}}"#;
     let server = stub("null", bound);
 
     run(
         &server,
         ApprovalCmd {
             routes_from: Some(path),
-            route: vec!["deal_desk=C0MANAGERS".to_string()],
+            route_resolution: vec!["deal_desk=C0EXAMPLE1".to_string()],
             ..ApprovalCmd::default()
         },
     )
@@ -602,7 +787,7 @@ async fn routes_from_seeds_the_map_and_flags_override_it() {
 
     let body = patch_body(&server);
     assert_eq!(
-        body["approval_routes"]["deal_desk"]["channel"], "C0MANAGERS",
+        body["approval_routes"]["deal_desk"]["resolution"]["address"], "C0EXAMPLE1",
         "the flag must win over the file's value, got {body:?}"
     );
     assert_eq!(
@@ -612,77 +797,186 @@ async fn routes_from_seeds_the_map_and_flags_override_it() {
 }
 
 #[tokio::test]
-async fn a_routes_file_with_an_unknown_binding_key_writes_nothing() {
+async fn routes_from_preserves_non_slack_notification_transport_in_the_write_dto() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("routes.json");
+    let route = serde_json::json!({
+        "finance": {
+            "resolution": {"kind": "slack", "address": "C0EXAMPLE3"},
+            "notification": {
+                "kind": "email",
+                "address": "approvals@example.com",
+                "endpoint": "https://adapter.example.com/replies",
+                "adapter": "mail"
+            }
+        }
+    });
+    std::fs::write(&path, route.to_string()).expect("write");
+    let leaked_echo = route.to_string();
+    let leaked_echo: &'static str = Box::leak(leaked_echo.into_boxed_str());
+    let server = stub("null", leaked_echo);
+
+    let out = run(
+        &server,
+        ApprovalCmd {
+            routes_from: Some(path),
+            ..ApprovalCmd::default()
+        },
+    )
+    .await
+    .expect("a complete adapter notification route should succeed");
+
+    let body = patch_body(&server);
+    assert_eq!(
+        body["approval_routes"]["finance"]["notification"], route["finance"]["notification"],
+        "the strict PATCH DTO must retain both adapter credentials"
+    );
+    let json = out.to_json();
+    assert!(
+        json["routes"]["finance"]["notification"]
+            .get("endpoint")
+            .is_none(),
+        "the tolerant display DTO must redact notification transport: {json}"
+    );
+    assert!(
+        json["routes"]["finance"]["notification"]
+            .get("adapter")
+            .is_none(),
+        "the tolerant display DTO must redact adapter identity: {json}"
+    );
+}
+
+#[tokio::test]
+async fn routes_from_rejections_fail_before_write() {
     // #1072: the typo that matters. `approver` (for `approvers`) used to be
     // silently stripped, and the write that landed was a channel-only binding --
     // which falls back to card-channel membership, so an operator who meant to
     // narrow authority to one group had instead granted it to everyone in the
     // channel. The API guards this with `extra="forbid"`; #1057 made the CLI a
     // second writer that re-serialized a parsed struct, so the operator's bytes
-    // never reached that guard.
-    let dir = tempfile::tempdir().expect("tempdir");
-    let path = dir.path().join("routes.json");
-    std::fs::write(
-        &path,
-        r#"{"deal_desk":{"channel":"C0GENERAL0","approver":{"group":"S0DESKGRP"}}}"#,
-    )
-    .expect("write");
-
-    let server = stub("null", "null");
-
-    let Err(err) = run(
-        &server,
-        ApprovalCmd {
-            routes_from: Some(path),
-            ..ApprovalCmd::default()
-        },
-    )
-    .await
-    else {
-        panic!("an unknown key at the binding level must be refused, not stripped");
-    };
-
-    let msg = err.to_string();
-    assert!(
-        msg.contains("approver"),
-        "the error must name the key: {msg}"
-    );
-    assert!(
-        msg.contains("deal_desk"),
-        "the error must name the route carrying it: {msg}"
-    );
-    assert_no_write(&server);
+    // never reached that guard. The sibling typo inside `approvers` must fail at
+    // the same strict boundary.
+    for (route, reason, needles) in [
+        (
+            serde_json::json!({"finance": {"channel": "C0EXAMPLE3"}}),
+            "the retired fused shape must be refused, not migrated at runtime",
+            &["channel", "finance"][..],
+        ),
+        (
+            serde_json::json!({
+                "finance": {
+                    "resolution": {"kind": "slack", "address": "C0EXAMPLE3"},
+                    "notification": {"kind": "email", "address": "approvals@example.com"}
+                }
+            }),
+            "a non-Slack notification without transport must be refused",
+            &["endpoint", "adapter"][..],
+        ),
+        (
+            serde_json::json!({
+                "finance": {
+                    "resolution": {"kind": "slack", "address": "C0EXAMPLE3"},
+                    "notification": {"kind": "email", "address": "approvals@example.com", "endpoint": "https://adapter.example.com/replies"}
+                }
+            }),
+            "an endpoint without an adapter must be refused",
+            &["endpoint", "adapter"][..],
+        ),
+        (
+            serde_json::json!({
+                "finance": {
+                    "resolution": {"kind": "slack", "address": "C0EXAMPLE3"},
+                    "notification": {"kind": "email", "address": "approvals@example.com", "adapter": "mail"}
+                }
+            }),
+            "an adapter without an endpoint must be refused",
+            &["endpoint", "adapter"][..],
+        ),
+        (
+            serde_json::json!({
+                "finance": {
+                    "resolution": {"kind": "email", "address": "approvals@example.com"}
+                }
+            }),
+            "a non-Slack resolution must be refused",
+            &["slack"][..],
+        ),
+        (
+            serde_json::json!({
+                "finance": {
+                    "resolution": {"kind": "slack", "address": "C0EXAMPLE3"},
+                    "notification": {"kind": "slack", "address": "C0EXAMPLE2", "interactive": true}
+                }
+            }),
+            "an unknown notification key must be refused",
+            &["interactive"][..],
+        ),
+        (
+            serde_json::json!({
+                "deal_desk": {
+                    "resolution": {"kind": "slack", "address": "C0EXAMPLE6"},
+                    "approver": {"group": "S0DESKGRP"}
+                }
+            }),
+            "an unknown key at the binding level must be refused, not stripped",
+            &["approver", "deal_desk"][..],
+        ),
+        (
+            serde_json::json!({
+                "finance": {
+                    "resolution": {"kind": "slack", "address": "C0EXAMPLE3"},
+                    "approvers": {"grup": "S0FINGRP0"}
+                }
+            }),
+            "an unknown key inside approvers must be refused",
+            &["grup"][..],
+        ),
+        (
+            serde_json::json!({
+                "finance": {
+                    "resolution": {"kind": "slack", "address": "finance-room"}
+                }
+            }),
+            "a bad channel in the file must be refused",
+            &["not a Slack channel ID"][..],
+        ),
+        (
+            serde_json::json!({"legacy": {}}),
+            "a binding without resolution must be refused",
+            &["resolution"][..],
+        ),
+    ] {
+        let message = rejected_routes_file(route, reason).await;
+        let lowercase = message.to_lowercase();
+        assert!(
+            needles
+                .iter()
+                .all(|needle| lowercase.contains(&needle.to_lowercase())),
+            "{reason}; expected {needles:?} in {message:?}"
+        );
+    }
 }
 
 #[tokio::test]
-async fn a_routes_file_with_an_unknown_approvers_key_writes_nothing() {
-    // The sibling case one level down. Already refused before #1072 (the
-    // approvers block was validated when present), and it must stay refused --
-    // the fix moved where parsing happens, so this pins that it did not regress.
-    let dir = tempfile::tempdir().expect("tempdir");
-    let path = dir.path().join("routes.json");
-    std::fs::write(
-        &path,
-        r#"{"finance":{"channel":"C0FINANCE0","approvers":{"grup":"S0FINGRP0"}}}"#,
-    )
-    .expect("write");
-
-    let server = stub("null", "null");
-
-    let Err(err) = run(
-        &server,
+async fn resolution_override_cannot_duplicate_file_notification() {
+    let message = rejected_routes_file_with(
+        serde_json::json!({
+            "finance": {
+                "resolution": {"kind": "slack", "address": "C0EXAMPLE3"},
+                "notification": {"kind": "slack", "address": "C0EXAMPLE4"}
+            }
+        }),
         ApprovalCmd {
-            routes_from: Some(path),
+            route_resolution: vec!["finance=C0EXAMPLE4".to_string()],
             ..ApprovalCmd::default()
         },
+        "the final binding map must be revalidated after flag overrides",
     )
-    .await
-    else {
-        panic!("an unknown key inside approvers must be refused");
-    };
-
-    assert!(err.to_string().contains("grup"), "unexpected error: {err}");
-    assert_no_write(&server);
+    .await;
+    assert!(
+        message.contains("must differ from resolution"),
+        "the override-created duplicate must fail closed: {message}"
+    );
 }
 
 #[tokio::test]
@@ -691,7 +985,7 @@ async fn an_api_response_tolerates_a_field_the_cli_does_not_model() {
     // struct rather than `deny_unknown_fields` on the existing one: the RESPONSE
     // side must keep decoding a binding a newer server has added a field to,
     // or an older CLI breaks against a newer platform.
-    let bound = r#"{"deal_desk":{"channel":"C0MANAGERS","escalation_after_s":3600}}"#;
+    let bound = r#"{"deal_desk":{"resolution":{"kind":"slack","address":"C0EXAMPLE1"},"notification":{"kind":"email","address":"approvals@example.com"},"escalation_after_s":3600}}"#;
     let server = stub(bound, bound);
 
     let out = run(
@@ -706,38 +1000,12 @@ async fn an_api_response_tolerates_a_field_the_cli_does_not_model() {
 
     match out {
         ApprovalsOutput::Routes { routes, .. } => {
-            assert_eq!(routes["deal_desk"].channel, "C0MANAGERS");
+            let json = serde_json::to_value(&routes["deal_desk"]).unwrap();
+            assert_eq!(json["resolution"]["address"], "C0EXAMPLE1");
+            assert_eq!(json["notification"]["address"], "approvals@example.com");
+            assert!(json["notification"].get("endpoint").is_none());
+            assert!(json["notification"].get("adapter").is_none());
         }
         _ => panic!("expected the Routes output"),
     }
-}
-
-#[tokio::test]
-async fn a_malformed_routes_file_writes_nothing() {
-    let dir = tempfile::tempdir().expect("tempdir");
-    let path = dir.path().join("routes.json");
-    // Valid JSON, invalid binding: the file path must be validated with the same
-    // rules the flag path uses, or the two input forms disagree about what a
-    // legal binding is.
-    std::fs::write(&path, r#"{"finance":{"channel":"finance-room"}}"#).expect("write");
-
-    let server = stub("null", "null");
-
-    let Err(err) = run(
-        &server,
-        ApprovalCmd {
-            routes_from: Some(path),
-            ..ApprovalCmd::default()
-        },
-    )
-    .await
-    else {
-        panic!("a bad channel in the file must be refused");
-    };
-
-    assert!(
-        err.to_string().contains("not a Slack channel ID"),
-        "unexpected error: {err}"
-    );
-    assert_no_write(&server);
 }

--- a/cli/tests/cli_output_variants.rs
+++ b/cli/tests/cli_output_variants.rs
@@ -289,31 +289,23 @@ fn registry() -> BTreeMap<&'static str, Vec<VariantJson>> {
                 truncated: false,
             },
             "Resolved" => ApprovalsOutput::Resolved { record: approval_record() },
-            // Both binding shapes in one sample so the schema gate sees a route
-            // WITH an approvers block and one without: the absent block is the
-            // zero-setup default (card-channel membership), which is a distinct
-            // wire state from a declared one, not merely a missing key.
+            // Both binding shapes in one sample so the schema gate sees the
+            // resolution/notification split and the optional approvers block.
+            // Response deserialization is deliberate: transport fields are
+            // write-only and must never be constructible in display output.
             "Routes" => ApprovalsOutput::Routes {
                 agent: "a".to_string(),
-                routes: std::collections::BTreeMap::from([
-                    (
-                        "deal_desk".to_string(),
-                        curie::api::ApprovalRouteBinding {
-                            channel: "C0MANAGERS".to_string(),
-                            approvers: None,
-                        },
-                    ),
-                    (
-                        "finance".to_string(),
-                        curie::api::ApprovalRouteBinding {
-                            channel: "C0FINANCE0".to_string(),
-                            approvers: Some(curie::api::ApprovalApprovers {
-                                group: Some("S0FINGRP0".to_string()),
-                                users: None,
-                            }),
-                        },
-                    ),
-                ]),
+                routes: serde_json::from_value(serde_json::json!({
+                    "deal_desk": {
+                        "resolution": {"kind": "slack", "address": "C0EXAMPLE1"},
+                        "notification": {"kind": "slack", "address": "C0EXAMPLE2"}
+                    },
+                    "finance": {
+                        "resolution": {"kind": "slack", "address": "C0EXAMPLE3"},
+                        "approvers": {"group": "S0FINGRP0"}
+                    }
+                }))
+                .expect("approval route response mirror deserializes its display shape"),
             },
         ],
     );

--- a/cli/tests/command_surface.rs
+++ b/cli/tests/command_surface.rs
@@ -522,6 +522,27 @@ fn agent_target_verbs_expose_the_same_flags_on_both_tiers() {
     }
 }
 
+#[test]
+fn approval_help_exposes_strict_route_inputs_and_retires_convenience_flags() {
+    for tier in ["skill", "local", "cluster"] {
+        let flags = help_flags(&[tier, "approvals"]);
+        for required in ["--route-resolution", "--route-approvers", "--routes-from"] {
+            assert!(
+                flags.contains(required),
+                "{tier} approvals is missing {required}: {flags:?}"
+            );
+        }
+        assert!(
+            !flags.contains("--route"),
+            "{tier} approvals still exposes the retired compatibility flag: {flags:?}"
+        );
+        assert!(
+            !flags.contains("--route-notification"),
+            "{tier} approvals still exposes the removed convenience flag: {flags:?}"
+        );
+    }
+}
+
 fn to_argv(parts: &[&str]) -> Vec<String> {
     parts.iter().map(|part| (*part).to_string()).collect()
 }

--- a/cli/tests/guide.rs
+++ b/cli/tests/guide.rs
@@ -243,7 +243,17 @@ fn guide_documents_the_approval_plane() {
         for needle in [
             "mcp__curie__request_approval",
             "approval_routes",
+            "--route-resolution",
+            "--routes-from",
             "approvers.group",
+            "text-only",
+            "interaction=None",
+            "configured approval channel",
+            "without disclosing its identifier",
+            "endpoint",
+            "adapter",
+            "verified Slack",
+            "scoped credential",
             "self-approval",
             "[approval resolved]",
             // #1086. Each is a fact an agent cannot derive from the command

--- a/cli/tests/json_contract.rs
+++ b/cli/tests/json_contract.rs
@@ -1638,6 +1638,21 @@ fn approvals_output_validates_all_variants() {
         record: approval_record(),
     };
     assert_valid("approvals.schema.json", &resolved.to_json());
+    let routes = ApprovalsOutput::Routes {
+        agent: "d".to_string(),
+        routes: serde_json::from_value(serde_json::json!({
+            "finance": {
+                "resolution": {"kind": "slack", "address": "C0EXAMPLE1"}
+            }
+        }))
+        .expect("the route response carries its required resolution"),
+    };
+    let routes_json = routes.to_json();
+    assert_eq!(
+        routes_json["routes"]["finance"]["resolution"]["address"],
+        "C0EXAMPLE1"
+    );
+    assert_valid("approvals.schema.json", &routes_json);
     let dry = ApprovalsOutput::DryRun(DryRunPlan {
         lines: vec!["GET /approvals".to_string()],
     });

--- a/cli/tests/schema_inventory.rs
+++ b/cli/tests/schema_inventory.rs
@@ -116,6 +116,45 @@ fn every_committed_schema_compiles_and_declares_a_version() {
 }
 
 #[test]
+fn approval_route_split_is_a_v2_schema_contract() {
+    let schema: Value = serde_json::from_str(
+        &std::fs::read_to_string(repo_path("cli/schema/approvals.schema.json"))
+            .expect("read approvals schema"),
+    )
+    .expect("approvals schema is JSON");
+    assert_eq!(
+        schema["$id"], "https://schemas.curietech.ai/cli/approvals/v2.0.json",
+        "removing the fused channel field and requiring resolution is a major schema break"
+    );
+
+    let binding = &schema["$defs"]["approvalRouteBinding"];
+    assert!(
+        binding["properties"].get("channel").is_none(),
+        "the retired fused field must not remain in the v2 result schema"
+    );
+    assert!(binding["properties"].get("resolution").is_some());
+    assert!(binding["properties"].get("notification").is_some());
+    assert_eq!(
+        binding["properties"]["resolution"]["type"],
+        serde_json::json!("object"),
+        "the v2 display schema requires the sole resolution surface"
+    );
+    let required = binding["required"]
+        .as_array()
+        .expect("binding required list");
+    assert!(required.iter().any(|field| field == "resolution"));
+
+    let index = index_json();
+    let approvals = index["results"]
+        .as_array()
+        .expect("results")
+        .iter()
+        .find(|entry| entry["result"] == "ApprovalsOutput")
+        .expect("ApprovalsOutput inventory entry");
+    assert_eq!(approvals["version"], "2.0");
+}
+
+#[test]
 fn version_from_id_parses_the_v_segment() {
     let v = |major, minor| Some(SchemaVersion { major, minor });
     assert_eq!(

--- a/docs/approvals.md
+++ b/docs/approvals.md
@@ -13,11 +13,13 @@ authorizer over swappable approver sets). This page is the "how do I use it".
 ## The one-paragraph version
 
 A run raises an approval. The worker persists a durable record, suspends the sandbox,
-and posts a card to the channel the request's **route** is bound to. A human resolves
-it; the platform authorizes that person **server-side**, wakes the suspended session
-with a platform-authored turn carrying the decision, and the agent finishes the job it
-started. Nothing about the decision is trusted from inside the sandbox, and nothing
-holds a worker slot while a human thinks.
+and posts one interactive card to the request route's **resolution** target. The route
+may also name a **notification** target, which receives a text-only ping directing humans
+to the configured approval channel without disclosing its identifier. A human resolves on
+the one card; the platform authorizes that person
+**server-side**, wakes the suspended session with a platform-authored turn carrying the
+decision, and the agent finishes the job it started. Nothing about the decision is
+trusted from inside the sandbox, and nothing holds a worker slot while a human thinks.
 
 ## Two ways a turn pauses
 
@@ -84,18 +86,41 @@ next click rather than the next restart:
 {
   "approval_routes": {
     "finance": {
-      "channel": "C0EXAMPLE3",
+      "resolution": {
+        "kind": "slack",
+        "address": "C0EXAMPLE3"
+      },
+      "notification": {
+        "kind": "email",
+        "address": "finance-approvals@example.com",
+        "endpoint": "https://adapter.example.com/replies",
+        "adapter": "mail"
+      },
       "approvers": { "group": "S0123ABCD" }
     }
   }
 }
 ```
 
-Two independent axes, and keeping them separate is the point:
+Three independent axes, and keeping them separate is the point:
 
-- **`channel` is WHERE the card posts.**
-- **`approvers` is WHO may act on it.** Omit it and the card channel's members are the
-  approvers, which is the zero-setup default.
+- **`resolution` is WHERE the one interactive card posts.** It is required and currently
+  accepts only `{ "kind": "slack", "address": "C..." }`, because Slack's authenticated
+  interaction path supplies the verified resolver identity.
+- **`notification` is WHERE else humans are told.** It is optional. Its text includes the
+  approval ID and directs humans to the configured approval channel without naming its
+  kind or address. It has no interaction, buttons, action values, or other resolving
+  affordance.
+- **`approvers` is WHO may act on the resolution card.** Omit it and that Slack channel's
+  members are the approvers, which is the zero-setup default. Notification recipients never
+  become approvers merely by receiving the ping.
+
+A Slack notification can use the worker's default transport. Any other notification kind
+must store both `endpoint` and `adapter`; those transport details are write-only and are
+redacted from API and `--list-routes` output. The target's `kind` and `address` remain visible.
+Resolution deliberately has a channel-neutral shape but remains Slack-only. Making another
+channel interactive requires a future adapter-scoped credential that establishes a verified
+resolver identity; this split does not add one or accept resolution through a notification.
 
 A route the bundle names but the agent never bound is **escalated to a human**, not
 posted to the requesting channel. Silently widening a request to whoever happens to be
@@ -106,17 +131,19 @@ Bind one from the CLI rather than by hand. A write REPLACES the whole map, so na
 every route it should keep:
 
 ```bash
-curie local approvals my-agent --route finance=C0EXAMPLE3 \
-  --route-approvers finance=group:S0123ABCD
+curie local approvals my-agent --routes-from approval-routes.json
 
 curie local approvals my-agent --list-routes
 ```
 
-`--route-approvers` also takes `users:U0123ABCD,W0456DEFG`, `--routes-from <file>` reads
-the whole map as JSON, and `--clear-routes` removes every binding. A `--routes-from`
-file containing `{}` clears every binding too, the same as `--clear-routes`. Nothing
-is written unless every entry parses, so a typo cannot leave a half-written map
-behind.
+The strict `--routes-from` JSON uses the complete binding shape shown above and is the only
+way to declare a notification, including the `endpoint` and `adapter` required for a
+non-Slack target. `--route-resolution` and `--route-approvers` can override resolution and
+authority from that file; the latter takes `users:U0123ABCD,W0456DEFG` or `group:S0123ABCD`.
+`--clear-routes` removes every binding. A `--routes-from` file containing `{}` clears every
+binding too, the same as `--clear-routes`. The retired `--route` flag and `channel` JSON key
+are not accepted. Nothing is written unless every entry parses, so a typo cannot leave a
+half-written map behind.
 
 ## Who may resolve
 
@@ -218,9 +245,10 @@ Resolution is **once-only**: the first authorized resolver wins the compare-and-
 a later one is told who won rather than overwriting the decision.
 
 `--actor-channel` is what proves channel membership for the default approver set. The
-channel to pass is the one that record's route is bound to, or the requesting channel
-when `--list` shows the record named no route. A route that declares `approvers.users`
-or `approvers.group` ignores the channel entirely, so passing it there is harmless.
+channel to pass is the record's route resolution address, or the requesting channel when
+`--list` shows the record named no route. The notification address is never valid channel
+evidence. A route that declares `approvers.users` or `approvers.group` ignores the channel
+entirely, so passing it there is harmless.
 
 ## Operational guarantees
 
@@ -250,6 +278,7 @@ or `approvers.group` ignores the channel entirely, so passing it there is harmle
 | `409 already resolved by ...` | Someone else won the claim. The decision stands. |
 | `410 expired` | The record passed its deadline. The session was already woken down its timeout branch. |
 | Agent says a request is pending, no card anywhere | The named route is not bound for this agent, so the turn escalated instead of posting. Add the binding. |
+| Notification arrived, but it has no buttons | Expected: notification is visibility-only. Use its approval ID and go to the configured approval channel to find the verified Slack resolution card; the ping deliberately does not disclose that channel's identifier. |
 | Card resolved, but the agent never continued | The skill has no instruction for the `[approval resolved]` prefix. |
 
 ## Where the code is

--- a/docs/interfaces/approval/INTERFACE.md
+++ b/docs/interfaces/approval/INTERFACE.md
@@ -210,20 +210,25 @@ in code now:
   silently arm nothing. A manifest with zero declared routes yields a generic approval
   (`route=None`), for which ADR-0034's channel-membership default is correct. Route names are
   bound to workspace
-  channels per agent (`agents.approval_routes`, deployment config, never in the bundle);
-  the worker resolves a raised route through the binding and posts the card into the bound
-  channel (`card_channel` on the record), whose members the authorizer then counts as the
-  approvers. **A named-but-unbound route now escalates loudly and creates no approval**
+  targets per agent (`agents.approval_routes`, deployment config, never in the bundle);
+  the worker resolves a raised route through its required Slack `resolution` target, posts
+  the one interactive card there, and persists that address as `card_channel` on the durable
+  record. The optional `notification` target receives a separate text-only ping with the
+  approval id and a direction to use the configured approval channel, but no channel
+  identifier, `ConfirmIntent`, action value, card-store entry, or other resolving
+  affordance. **A named-but-unbound route now escalates
+  loudly and creates no approval**
   (#544, ADR-0046, AC2), reversing #247's earlier warn-and-route-to-requesting-channel
-  fallback — authority must never silently widen. This is distinct from the API's
-  `get_approval_route_binding` channel fallback (`apps/api/src/curie_api/crud.py`), which is
-  for genuinely agent-less generic approvals (ADR-0034) and is UNCHANGED. The
-  card's transport follows the same split (#451): a bound channel that differs from the
+  fallback — authority must never silently widen. This is distinct from genuinely
+  agent-less generic approvals, which are unchanged. The card's transport follows the same
+  split (#451): a bound resolution channel that differs from the
   requesting channel is deployment policy, not part of the triggering conversation, so the
   card posts top-level over the worker's default Slack transport rather than the trigger's
   per-turn endpoint (this is what lets a non-Slack-triggered turn, e.g. CLI or API, still
-  deliver a real Slack card); the requesting-channel case (including the unbound fallback)
-  keeps the trigger's endpoint and threads under the conversation as before. Every
+  deliver a real Slack card); the requesting-channel case keeps the trigger's endpoint and
+  threads under the conversation as before. Notification transport is independent: a Slack
+  notification may use the default transport, while another kind stores its own required
+  `endpoint` and `adapter`. Those transport fields are redacted from API/CLI reads. Every
   resolution attempt appends to the platform audit log (`approval_audit_entries`,
   `GET /approvals/{id}/audit`): actor, channel evidence, decision, and the authorizer
   snapshot -- who resolved, and why they counted (or were refused).
@@ -337,17 +342,27 @@ name, so `approval_audit.authorizer` still records `ChannelMembershipAuthorizer`
 column is append-only history and rows already on main carry those values, so renaming the
 vocabulary would make old rows lie about what decided.
 
-### Unfusing who from where
+### Unfusing notification, resolution, and authority
 
-The route binding keeps `channel` as *where the card posts* and gains an optional
-`approvers` block as *who may approve*, so a card can be visible in a broad channel while
-authority stays narrow:
+The route binding has three separate concerns: required `resolution` says where the one
+verified interactive card posts; optional `notification` says where else to announce the
+request without making that place interactive; and optional `approvers` says who may act.
+That lets a second channel carry visibility without widening the single resolution surface:
 
 ```
 approval_routes: {
   "<route-name>": {
-    "channel": "C0123ABCD",                 # where the card posts (unchanged)
-    "approvers": {                          # optional; absent means channel membership
+    "resolution": {
+      "kind": "slack",                     # only verified interactive surface today
+      "address": "C0123ABCD"
+    },
+    "notification": {                       # optional text-only ping, never a card
+      "kind": "email",
+      "address": "approvals@example.com",
+      "endpoint": "https://adapter.example.com/replies",
+      "adapter": "mail"
+    },
+    "approvers": {                          # optional; absent means resolution membership
       "group": "S0123ABCD",                 # Slack user-group ID
       "users": ["U0123ABCD", "U0456EFGH"]   # explicit allowlist
     }
@@ -355,9 +370,19 @@ approval_routes: {
 }
 ```
 
-Both take IDs, never `@handles` or names, matching the channel-ID precedent (#143): names
-never route and fail silently. The group and user-list authorizers deliberately ignore
-`actor_channel` — the whole point is that authority does not depend on card location.
+Resolution, group, and user entries take IDs, never `@handles` or names, matching the
+channel-ID precedent (#143): names never route and fail silently. Notification text carries
+the durable approval ID and directs humans to the configured approval channel without
+disclosing its kind or address; its message has `interaction=None` and no action values.
+Only the resolution card is remembered for later settlement. The group and user-list
+authorizers deliberately ignore `actor_channel` — the whole point is that authority does
+not depend on card location.
+
+`resolution.kind` is the explicit extension point, but the writer rejects every kind except
+Slack today. A second interactive channel first needs an adapter-scoped credential that
+establishes a verified resolver identity; this change does not build that credential or
+turn notification delivery into resolution. Notification `endpoint` and `adapter` remain
+stored server-side for egress and are omitted from read responses.
 
 **Precedence: `users` > `group` > channel membership.** When `users` is set, `group` is
 ignored and no Slack call is made. When neither is declared, channel membership decides.
@@ -448,11 +473,14 @@ into the sandbox as the memory/transcript token, and because `POST /approvals/{i
 is guarded by the same platform key, a compromised sandbox could self-approve its own
 gated tool call. ADR-0033 (#410) closed that gap by minting a scoped, agent-bound `state`
 token for the sandbox that only the state router accepts; the resolve endpoint stays
-platform-key-only, so the sandbox credential can no longer resolve an approval. The
-runtime `canUseTool` gate (#245) will block the *tool call*, but
+platform-key-only, so the sandbox credential can no longer resolve an approval. A
+notification transport credential likewise confers no resolution capability: the
+notification contains no interaction, and this contract exposes no second-channel resolver.
+The runtime `canUseTool` gate (#245) will block the *tool call*, but
 the authorization decision (who may resolve a pending approval) stays on the server that
 owns the durable `Approval` record. Policy gate points ship versioned in the bundle; route
-bindings (which channel, who may approve) are per-agent deployment config (#247).
+bindings (where the verified card resolves, where a text-only notification goes, and who may
+approve) are per-agent deployment config (#247, #1460).
 
 One limit the audit trail must not be read as overstating (#420, ADR-0034): the evidence
 proves that the ASSERTED identity satisfied policy at click time; it does not prove who

--- a/examples/sre-bot/README.md
+++ b/examples/sre-bot/README.md
@@ -236,7 +236,7 @@ The deploy renders only the digest from `connectors.lock.yaml`.
 **5. Bind the route, or the card has nowhere to post.**
 
 ```bash
-curie cluster approvals sre-bot --route sre-approvals=C0EXAMPLE1
+curie cluster approvals sre-bot --route-resolution sre-approvals=C0EXAMPLE1
 curie cluster approvals sre-bot --list-routes
 ```
 
@@ -244,8 +244,10 @@ An unbound route fails SAFE -- it escalates to a human rather than executing --
 but you will see `approval route 'sre-approvals' is not bound for agent ...;
 escalating rather than routing the card` and no card will appear.
 
-**`--route` and `--gate` are FULL REPLACEMENTS, not additive.** A write replaces
-the whole map, so name every route you want on every invocation. Passing one
+**Route-binding writes and `--gate` are FULL REPLACEMENTS, not additive.** A
+write using `--route-resolution`, `--route-approvers`, or `--routes-from`
+replaces the whole route map, so name every route you want on every invocation.
+Notifications are declared only in the complete `--routes-from` map. Passing one
 route to add it silently drops the others.
 
 **6. Request one restart, approve it as a second actor, and verify the rollout.**
@@ -481,8 +483,9 @@ stream surgery is needed.
 
 **The bot says it escalated and no approval card appeared.** The route named in
 `approvalPolicy` is not bound for that agent. Bind it with
-`curie cluster approvals <agent> --route <name>=<channel>` and confirm with
-`--list-routes`. This fails safe -- an unbound route escalates, it never executes.
+`curie cluster approvals <agent> --route-resolution <name>=<channel>` and
+confirm with `--list-routes`. This fails safe -- an unbound route escalates, it
+never executes.
 
 **The write fails AFTER a human approved it.** The worst shape: the approval is
 spent, nothing rolled, and the operator's attention is gone. Both instances of


### PR DESCRIPTION
## Summary

- Split each approval route into one required Slack resolution target and one optional text-only notification target.
- Keep resolution on the verified-identity Slack card path; notification delivery has no interaction, action value, or card-store reference.
- Migrate durable bindings atomically and reject the retired fused route shape at API, CLI, and worker boundaries.
- Keep the specified second-channel resolution extension point unimplemented.

## Release-train choice

Retargeting to `next`: after the original PR was opened, this feature became part of the unreleased feature train represented by `next`. The branch is rebased as one commit on `2caced8e`.

## Simplification review

- Removed the hand-maintained Pydantic serializer graph and duplicate Slack validator.
- Removed the CLI missing-resolution compatibility path.
- Removed the dedicated `--route-notification` convenience flag; `--routes-from` remains the strict complete declaration surface.
- Consolidated repeated API, CLI, worker, and migration negative tests into table-driven cases.
- Reduced the branch from 2,926 insertions / 653 deletions to 2,769 insertions / 567 deletions while adding migration concurrency, read-repair, and out-of-band worker-validation coverage required by review.

Independent spec, security, and correctness/simplification reviews finished ALL-MET / CLEAN / CLEAN.

## Invariants

- Enforcement remains outside the sandbox.
- Resolution remains single-use through the existing pending-status CAS.
- Approval records remain durable before either delivery attempt.
- Only the Slack card path supplies a verified resolving identity.

## Validation

- Focused Python: `194 passed`; final affected worker rerun: `94 passed, 3 skipped`.
- Full Python run: `4189 passed, 11 skipped` plus one prior-intent source guard failure; after replacing the direct channel-kind branch with validator dispatch, the exact affected suites passed (`94 passed, 3 skipped`).
- Rust: `cargo fmt --check`, `cargo clippy -- -D warnings`, and full `cargo test` exited 0; focused contract suites passed 149 tests.
- UI: lint and typecheck passed; Vitest `24 files, 154 tests`; Playwright `38 passed`.
- Python quality and contracts: Ruff passed; mypy passed across 229 files; import contracts `3 kept, 0 broken`; docs, Alembic head `0034`, schema baseline, and wire lock passed.
- Regression pin: `curie dev verify-fix-pin HEAD apps/worker/tests/kernel/test_approval_lifecycle.py::test_routed_approval_posts_one_interactive_resolution_card_and_one_text_only_notification` reported `PINNED`.
- Gitleaks scanned the candidate commit and reported `no leaks found`.
- Candidate-image local rung deployed the bundle and finalized a real queued turn with `{"finalized":true,"reply":"all done"}`. The rung subsequently failed only its trace-freshness assertion despite observing the complete expected span set; this is recorded as a verification caveat, not a passing rung.

Closes #1460
