### PR TITLE
Fix cluster message stub trust

### DIFF
--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -922,13 +922,10 @@ worker:
   # per-agent behavior-pack load line intact.
   statusText: "is working on your request..."
   # No-Slack egress routing. When non-empty, renders SLACK_API_BASE_URL on the
-  # worker Deployment so the worker's Slack sink posts placeholder edits at this
-  # base URL instead of real Slack -- the seam `curie cluster message` drives when it
-  # points the deployed worker at its local Slack Web API stub. Empty (the
-  # default) leaves the worker on real Slack. `curie cluster message --wire` sets this
-  # via `helm upgrade --reuse-values`; connecting real Slack (a `helm upgrade
-  # --reuse-values` that sets the dispatcher tokens) clears it back to empty in
-  # the same command, so that upgrade un-wires any stub routing.
+  # worker Deployment so its Slack sink uses that global base URL instead of real
+  # Slack. Empty (the default) leaves the worker on real Slack. `curie cluster
+  # message` does not change this value: its synthetic turn carries a per-turn
+  # reply endpoint for the command's local Slack Web API stub.
   slackApiBaseUrl: ""
   # ADDITIONAL Slack origins a per-turn reply endpoint may name (ADR-0096
   # D4.4), comma-separated `scheme://host[:port]`. EMPTY (the default) is the
@@ -936,12 +933,12 @@ worker:
   # Slack) is the only endpoint the worker will send the bot token to, and every
   # cross-origin endpoint a turn names is refused before any request.
   #
-  # DEV ONLY. `curie cluster message` uses an EPHEMERAL callback port by
-  # default. To trust a LAN or kind callback host, set a portless origin such as
-  # `http://10.0.0.7` or `http://host.docker.internal`; omitting the port admits
-  # the kernel assigned port. This trusts ANY port on that exact host, so it can
-  # widen where the platform bot token can go and belongs only in development.
-  # The empty default above remains the fail closed production posture.
+  # DEV ONLY. `curie cluster message` temporarily adds the exact advertised stub
+  # host as a portless origin, waits for the worker rollout, and removes it when
+  # the command exits. Omitting the port admits the kernel-assigned callback
+  # port. Manual entries trust ANY port on that exact host, so they can widen
+  # where the platform bot token can go and belong only in development. The
+  # empty default remains the fail-closed production posture.
   # Rendered only when non-empty.
   slackTrustedOrigins: ""
   # Per-ADAPTER egress credentials (ADR-0096 D4.2), a map of adapter slug ->

--- a/cli/src/message.rs
+++ b/cli/src/message.rs
@@ -404,6 +404,583 @@ fn advertised_url(host: &str, port: u16) -> String {
     format!("http://{host}:{port}/api/")
 }
 
+/// Temporary worker widening for the no-Slack cluster-message stub (#1812).
+///
+/// The worker intentionally refuses per-turn Slack endpoints whose origin was
+/// not operator-trusted (ADR-0096). A default chart install has no extra trusted
+/// origins, so the CLI must trust the host it advertises before enqueueing. The
+/// guard restores the exact prior environment state on every unwinding return;
+/// callers that use the module's non-unwinding exit helper restore it
+/// asynchronously first and then move the guard into that helper as a fallback.
+const TRUST_ENV: &str = "CURIE_SLACK_TRUSTED_ORIGINS";
+const TRUST_HOLDER_ANNOTATION: &str = "curie.dev/cluster-message-trust-holder";
+const TRUST_HOLDER_JSON_PATH: &str =
+    "/metadata/annotations/curie.dev~1cluster-message-trust-holder";
+
+#[derive(Clone)]
+enum TrustMutationMode {
+    /// Real Kubernetes objects always expose a resourceVersion. The holder
+    /// annotation and env mutation are one JSON Patch guarded by that version.
+    Cas { holder: String, temporary: String },
+    /// Test doubles that are not Kubernetes objects may omit resourceVersion.
+    /// Keep the legacy command shape for those fixtures only.
+    Legacy,
+}
+
+#[derive(Clone)]
+struct TrustCleanupSpec {
+    namespace: String,
+    deployment: String,
+    origin: String,
+    original: Option<String>,
+    mode: TrustMutationMode,
+}
+
+struct ClusterStubTrust {
+    cleanup: TrustCleanupSpec,
+    armed: bool,
+}
+
+#[derive(Clone)]
+struct WorkerTrustView {
+    resource_version: Option<String>,
+    annotations_present: bool,
+    holder: Option<String>,
+    worker_index: usize,
+    env_present: bool,
+    env: Vec<serde_json::Value>,
+    trust: Option<String>,
+}
+
+#[cfg(unix)]
+static CLUSTER_TRUST_SIGNAL_STATE: std::sync::LazyLock<std::sync::Mutex<Option<TrustCleanupSpec>>> =
+    std::sync::LazyLock::new(|| std::sync::Mutex::new(None));
+
+#[cfg(unix)]
+static CLUSTER_TRUST_SIGNAL_HANDLER: std::sync::OnceLock<std::result::Result<(), String>> =
+    std::sync::OnceLock::new();
+
+/// Probe the connected transport without collapsing a kubectl/RBAC failure into
+/// "dispatcher absent". Trust may only be widened after absence is positively
+/// observed; an indeterminate probe therefore refuses before any mutation.
+async fn dispatcher_connected_strict(namespace: &str, release: &str) -> Result<bool> {
+    let command = OpsCommand::new(
+        "kubectl",
+        vec![
+            plain("-n"),
+            plain(namespace),
+            plain("get"),
+            plain("deployment"),
+            plain(format!("{release}-dispatcher")),
+            plain("--ignore-not-found"),
+            plain("-o"),
+            plain("name"),
+        ],
+    );
+    let (ok, out, err) = run_capture(&command).await?;
+    if !ok {
+        bail!(
+            "could not prove that Slack is disconnected for release {release} in namespace \
+             {namespace}; refusing to widen worker Slack trust: {}",
+            err.trim().lines().next().unwrap_or("kubectl probe failed")
+        );
+    }
+    Ok(!out.trim().is_empty())
+}
+
+impl ClusterStubTrust {
+    async fn install(namespace: &str, release: &str, advertise_host: &str) -> Result<Self> {
+        let deployment = format!("{release}-worker");
+        let view = read_worker_trust(namespace, &deployment).await?;
+        let host = if advertise_host.contains(':') && !advertise_host.starts_with('[') {
+            format!("[{advertise_host}]")
+        } else {
+            advertise_host.to_string()
+        };
+        let origin = format!("http://{host}");
+        if let Some(holder) = view.holder.as_deref() {
+            bail!(
+                "another cluster message command ({holder}) is temporarily managing worker Slack \
+                 trust for release {release}; retry after it exits"
+            );
+        }
+        if view
+            .trust
+            .as_deref()
+            .is_some_and(|value| value.split(',').any(|entry| entry.trim() == origin))
+        {
+            return Ok(Self {
+                cleanup: TrustCleanupSpec {
+                    namespace: namespace.to_string(),
+                    deployment,
+                    origin,
+                    original: view.trust,
+                    mode: TrustMutationMode::Legacy,
+                },
+                armed: false,
+            });
+        }
+        let original = view.trust.clone();
+        let temporary = match original.as_deref().filter(|value| !value.is_empty()) {
+            Some(value) => format!("{value},{origin}"),
+            None => origin.clone(),
+        };
+        let (mode, apply) = match view.resource_version.as_deref() {
+            Some(_) => {
+                let holder = uuid::Uuid::new_v4().to_string();
+                let patch = trust_patch(&view, Some(&temporary), Some(&holder), false)?;
+                (
+                    TrustMutationMode::Cas {
+                        holder,
+                        temporary: temporary.clone(),
+                    },
+                    worker_patch_command(namespace, &deployment, patch),
+                )
+            }
+            None => (
+                TrustMutationMode::Legacy,
+                worker_set_env_command(namespace, &deployment, Some(&temporary)),
+            ),
+        };
+        let cleanup = TrustCleanupSpec {
+            namespace: namespace.to_string(),
+            deployment,
+            origin: origin.clone(),
+            original,
+            mode,
+        };
+        register_cluster_trust_signal_cleanup(cleanup.clone())?;
+        // Arm before invoking kubectl: even an unusual nonzero result after the
+        // API accepted the mutation must run restoration.
+        let guard = Self {
+            cleanup,
+            armed: true,
+        };
+        let (ok, _, err) = run_capture(&apply).await?;
+        if !ok {
+            bail!(
+                "temporarily trusting cluster-message stub origin {origin}: {}",
+                err.trim()
+            );
+        }
+
+        let rollout = guard.rollout_command();
+        let (ok, _, err) = run_capture(&rollout).await?;
+        if !ok {
+            bail!(
+                "waiting for the worker to trust cluster-message stub origin {origin}: {}",
+                err.trim()
+            );
+        }
+        Ok(guard)
+    }
+
+    async fn restore(&mut self) -> Result<()> {
+        if !self.armed {
+            return Ok(());
+        }
+        restore_cluster_trust(&self.cleanup).await?;
+        let (ok, _, err) = run_capture(&self.rollout_command()).await?;
+        if !ok {
+            bail!(
+                "waiting for the worker to restore its prior Slack trust: {}",
+                err.trim()
+            );
+        }
+        self.armed = false;
+        clear_cluster_trust_signal_cleanup(&self.cleanup);
+        Ok(())
+    }
+
+    fn rollout_command(&self) -> OpsCommand {
+        OpsCommand::new(
+            "kubectl",
+            vec![
+                plain("-n"),
+                plain(&self.cleanup.namespace),
+                plain("rollout"),
+                plain("status"),
+                plain(format!("deployment/{}", self.cleanup.deployment)),
+                plain("--timeout=120s"),
+            ],
+        )
+    }
+}
+
+impl Drop for ClusterStubTrust {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        if restore_cluster_trust_sync(&self.cleanup).is_err() {
+            crate::ui::ui().warn("could not restore the worker's prior Slack trust");
+            return;
+        }
+        let rollout = self.rollout_command();
+        let rollout = std::process::Command::new(&rollout.program)
+            .args(rollout.argv())
+            .output();
+        if !matches!(rollout, Ok(output) if output.status.success()) {
+            crate::ui::ui().warn("worker did not finish restoring its prior Slack trust posture");
+        }
+        clear_cluster_trust_signal_cleanup(&self.cleanup);
+    }
+}
+
+fn worker_trust_view(deployment_json: &str) -> Result<WorkerTrustView> {
+    let deployment: serde_json::Value = serde_json::from_str(deployment_json)
+        .context("parsing the worker Deployment while snapshotting Slack trust")?;
+    let containers = deployment
+        .pointer("/spec/template/spec/containers")
+        .and_then(serde_json::Value::as_array)
+        .context("worker Deployment has no pod containers")?;
+    let (worker_index, worker) = containers
+        .iter()
+        .enumerate()
+        .find(|(_, container)| {
+            container.get("name").and_then(serde_json::Value::as_str) == Some("worker")
+        })
+        .context("worker Deployment has no container named worker")?;
+    let env_present = worker.get("env").is_some();
+    let env = worker
+        .get("env")
+        .and_then(serde_json::Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let trust_entry = env
+        .iter()
+        .find(|entry| entry.get("name").and_then(serde_json::Value::as_str) == Some(TRUST_ENV));
+    let trust = match trust_entry {
+        Some(entry) => Some(
+            entry
+                .get("value")
+                .and_then(serde_json::Value::as_str)
+                .context("CURIE_SLACK_TRUSTED_ORIGINS is not a literal environment value")?
+                .to_string(),
+        ),
+        None => None,
+    };
+    let annotations = deployment.pointer("/metadata/annotations");
+    Ok(WorkerTrustView {
+        resource_version: deployment
+            .pointer("/metadata/resourceVersion")
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_string),
+        annotations_present: annotations.is_some_and(serde_json::Value::is_object),
+        holder: annotations
+            .and_then(|value| value.get(TRUST_HOLDER_ANNOTATION))
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_string),
+        worker_index,
+        env_present,
+        env,
+        trust,
+    })
+}
+
+fn worker_get_command(namespace: &str, deployment: &str) -> OpsCommand {
+    OpsCommand::new(
+        "kubectl",
+        vec![
+            plain("-n"),
+            plain(namespace),
+            plain("get"),
+            plain("deployment"),
+            plain(deployment),
+            plain("-o"),
+            plain("json"),
+        ],
+    )
+}
+
+async fn read_worker_trust(namespace: &str, deployment: &str) -> Result<WorkerTrustView> {
+    let (ok, out, err) = run_capture(&worker_get_command(namespace, deployment)).await?;
+    if !ok {
+        bail!("reading worker Deployment {deployment}: {}", err.trim());
+    }
+    worker_trust_view(&out)
+}
+
+fn env_with_trust(view: &WorkerTrustView, target: Option<&str>) -> Vec<serde_json::Value> {
+    let mut env = view.env.clone();
+    let position = env
+        .iter()
+        .position(|entry| entry.get("name").and_then(serde_json::Value::as_str) == Some(TRUST_ENV));
+    match (position, target) {
+        (Some(index), Some(value)) => {
+            env[index] = serde_json::json!({"name": TRUST_ENV, "value": value});
+        }
+        (Some(index), None) => {
+            env.remove(index);
+        }
+        (None, Some(value)) => {
+            env.push(serde_json::json!({"name": TRUST_ENV, "value": value}));
+        }
+        (None, None) => {}
+    }
+    env
+}
+
+fn trust_patch(
+    view: &WorkerTrustView,
+    target: Option<&str>,
+    acquire_holder: Option<&str>,
+    release_holder: bool,
+) -> Result<String> {
+    let resource_version = view
+        .resource_version
+        .as_deref()
+        .context("worker Deployment omitted metadata.resourceVersion")?;
+    let mut operations = vec![serde_json::json!({
+        "op": "test",
+        "path": "/metadata/resourceVersion",
+        "value": resource_version,
+    })];
+    if let Some(holder) = acquire_holder {
+        if !view.annotations_present {
+            operations.push(serde_json::json!({
+                "op": "add",
+                "path": "/metadata/annotations",
+                "value": {},
+            }));
+        }
+        operations.push(serde_json::json!({
+            "op": "add",
+            "path": TRUST_HOLDER_JSON_PATH,
+            "value": holder,
+        }));
+    }
+    let env_path = format!("/spec/template/spec/containers/{}/env", view.worker_index);
+    operations.push(serde_json::json!({
+        "op": if view.env_present { "replace" } else { "add" },
+        "path": env_path,
+        "value": env_with_trust(view, target),
+    }));
+    if release_holder {
+        operations.push(serde_json::json!({
+            "op": "remove",
+            "path": TRUST_HOLDER_JSON_PATH,
+        }));
+    }
+    serde_json::to_string(&operations).context("serializing worker trust JSON Patch")
+}
+
+fn worker_patch_command(namespace: &str, deployment: &str, patch: String) -> OpsCommand {
+    OpsCommand::new(
+        "kubectl",
+        vec![
+            plain("-n"),
+            plain(namespace),
+            plain("patch"),
+            plain("deployment"),
+            plain(deployment),
+            plain("--type=json"),
+            plain("-p"),
+            plain(patch),
+        ],
+    )
+}
+
+fn worker_set_env_command(namespace: &str, deployment: &str, target: Option<&str>) -> OpsCommand {
+    let assignment = target
+        .map(|value| format!("{TRUST_ENV}={value}"))
+        .unwrap_or_else(|| format!("{TRUST_ENV}-"));
+    OpsCommand::new(
+        "kubectl",
+        vec![
+            plain("-n"),
+            plain(namespace),
+            plain("set"),
+            plain("env"),
+            plain(format!("deployment/{deployment}")),
+            plain(assignment),
+        ],
+    )
+}
+
+fn cleanup_target(current: Option<&str>, cleanup: &TrustCleanupSpec) -> Option<String> {
+    let TrustMutationMode::Cas { temporary, .. } = &cleanup.mode else {
+        return cleanup.original.clone();
+    };
+    if current == Some(temporary.as_str()) {
+        return cleanup.original.clone();
+    }
+    current.map(|value| {
+        value
+            .split(',')
+            .filter(|entry| entry.trim() != cleanup.origin)
+            .collect::<Vec<_>>()
+            .join(",")
+    })
+}
+
+async fn restore_cluster_trust(cleanup: &TrustCleanupSpec) -> Result<()> {
+    if matches!(&cleanup.mode, TrustMutationMode::Legacy) {
+        let (ok, _, err) = run_capture(&worker_set_env_command(
+            &cleanup.namespace,
+            &cleanup.deployment,
+            cleanup.original.as_deref(),
+        ))
+        .await?;
+        if !ok {
+            bail!("restoring worker Slack trust: {}", err.trim());
+        }
+        return Ok(());
+    }
+    let TrustMutationMode::Cas { holder, .. } = &cleanup.mode else {
+        unreachable!()
+    };
+    for _ in 0..5 {
+        let view = read_worker_trust(&cleanup.namespace, &cleanup.deployment).await?;
+        if view.holder.as_deref() != Some(holder) {
+            if view.holder.is_none()
+                && !view.trust.as_deref().is_some_and(|value| {
+                    value
+                        .split(',')
+                        .any(|entry| entry.trim() == cleanup.origin.as_str())
+                })
+            {
+                return Ok(());
+            }
+            bail!("temporary worker trust ownership changed; refusing a stale restoration");
+        }
+        let target = cleanup_target(view.trust.as_deref(), cleanup);
+        let patch = trust_patch(&view, target.as_deref(), None, true)?;
+        let (ok, _, err) = run_capture(&worker_patch_command(
+            &cleanup.namespace,
+            &cleanup.deployment,
+            patch,
+        ))
+        .await?;
+        if ok {
+            return Ok(());
+        }
+        let lower = err.to_lowercase();
+        if !(lower.contains("conflict")
+            || lower.contains("test failed")
+            || lower.contains("object has been modified"))
+        {
+            bail!("restoring worker Slack trust: {}", err.trim());
+        }
+    }
+    bail!("worker Deployment kept changing while restoring temporary Slack trust")
+}
+
+fn run_sync_capture(command: &OpsCommand) -> Result<(bool, String, String)> {
+    let output = std::process::Command::new(&command.program)
+        .args(command.argv())
+        .output()
+        .with_context(|| format!("invoking {} during signal cleanup", command.program))?;
+    Ok((
+        output.status.success(),
+        String::from_utf8_lossy(&output.stdout).to_string(),
+        String::from_utf8_lossy(&output.stderr).to_string(),
+    ))
+}
+
+fn restore_cluster_trust_sync(cleanup: &TrustCleanupSpec) -> Result<()> {
+    if matches!(&cleanup.mode, TrustMutationMode::Legacy) {
+        let (ok, _, err) = run_sync_capture(&worker_set_env_command(
+            &cleanup.namespace,
+            &cleanup.deployment,
+            cleanup.original.as_deref(),
+        ))?;
+        if !ok {
+            bail!("restoring worker Slack trust: {}", err.trim());
+        }
+        return Ok(());
+    }
+    let TrustMutationMode::Cas { holder, .. } = &cleanup.mode else {
+        unreachable!()
+    };
+    for _ in 0..5 {
+        let (ok, out, err) =
+            run_sync_capture(&worker_get_command(&cleanup.namespace, &cleanup.deployment))?;
+        if !ok {
+            bail!("reading worker during signal cleanup: {}", err.trim());
+        }
+        let view = worker_trust_view(&out)?;
+        if view.holder.as_deref() != Some(holder) {
+            return Ok(());
+        }
+        let target = cleanup_target(view.trust.as_deref(), cleanup);
+        let patch = trust_patch(&view, target.as_deref(), None, true)?;
+        let (ok, _, err) = run_sync_capture(&worker_patch_command(
+            &cleanup.namespace,
+            &cleanup.deployment,
+            patch,
+        ))?;
+        if ok {
+            return Ok(());
+        }
+        let lower = err.to_lowercase();
+        if !(lower.contains("conflict")
+            || lower.contains("test failed")
+            || lower.contains("object has been modified"))
+        {
+            bail!("restoring worker Slack trust: {}", err.trim());
+        }
+    }
+    bail!("worker Deployment kept changing during signal cleanup")
+}
+
+#[cfg(unix)]
+fn register_cluster_trust_signal_cleanup(cleanup: TrustCleanupSpec) -> Result<()> {
+    match CLUSTER_TRUST_SIGNAL_HANDLER.get_or_init(|| {
+        let mut signals = signal_hook::iterator::Signals::new([
+            signal_hook::consts::signal::SIGINT,
+            signal_hook::consts::signal::SIGTERM,
+        ])
+        .map_err(|error| error.to_string())?;
+        std::thread::Builder::new()
+            .name("curie-cluster-trust-cleanup".to_string())
+            .spawn(move || {
+                if let Some(signal) = signals.forever().next() {
+                    let cleanup = CLUSTER_TRUST_SIGNAL_STATE
+                        .lock()
+                        .unwrap_or_else(|poisoned| poisoned.into_inner())
+                        .clone();
+                    if let Some(cleanup) = cleanup {
+                        let _ = restore_cluster_trust_sync(&cleanup);
+                    }
+                    let _ = signal_hook::low_level::emulate_default_handler(signal);
+                    signal_hook::low_level::exit(128 + signal);
+                }
+            })
+            .map_err(|error| error.to_string())?;
+        Ok(())
+    }) {
+        Ok(()) => {
+            *CLUSTER_TRUST_SIGNAL_STATE
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(cleanup);
+            Ok(())
+        }
+        Err(error) => bail!("installing cluster trust signal cleanup: {error}"),
+    }
+}
+
+#[cfg(not(unix))]
+fn register_cluster_trust_signal_cleanup(_cleanup: TrustCleanupSpec) -> Result<()> {
+    Ok(())
+}
+
+fn clear_cluster_trust_signal_cleanup(cleanup: &TrustCleanupSpec) {
+    #[cfg(unix)]
+    {
+        let mut current = CLUSTER_TRUST_SIGNAL_STATE
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if current.as_ref().is_some_and(|registered| {
+            registered.deployment == cleanup.deployment && registered.namespace == cleanup.namespace
+        }) {
+            *current = None;
+        }
+    }
+    #[cfg(not(unix))]
+    let _ = cleanup;
+}
+
 /// Local mode: the Valkey URL the CLI enqueues onto -- the compose Valkey on its
 /// published host port, authenticated with the same password the compose worker
 /// uses. Pure so the construction is unit-tested without a live Valkey.
@@ -1826,7 +2403,7 @@ pub async fn message(mut opts: MessageOpts) -> Result<()> {
     // against its ts with no per-turn endpoint, so the approval card and any
     // resumed reply ride the connected transport -- no throwaway stub. A kubectl
     // failure reads as NOT connected, so this falls through to the stub path.
-    if crate::ops::dispatcher_connected(&opts.namespace, &opts.release).await {
+    if dispatcher_connected_strict(&opts.namespace, &opts.release).await? {
         return message_connected(opts).await;
     }
 
@@ -1839,6 +2416,13 @@ pub async fn message(mut opts: MessageOpts) -> Result<()> {
     ui.note(&format!(
         "slack stub listening; the worker will post to {url}"
     ));
+
+    // Install the portless exact host origin before any enqueue plumbing. The
+    // connected-dispatcher branch returned above, so this never widens a
+    // Slack-connected release. The guard restores the default closed posture on
+    // every normal/error return and is moved into non-unwinding exits below.
+    let mut stub_trust =
+        ClusterStubTrust::install(&opts.namespace, &opts.release, &advertise_host).await?;
 
     // Valkey port-forward for the enqueue (killed on drop at fn end).
     let (_valkey_pf, valkey_local_port) = start_port_forward(
@@ -1911,6 +2495,7 @@ pub async fn message(mut opts: MessageOpts) -> Result<()> {
                 reply,
             });
             persist_and_hint(&opts, TurnVerb::Cluster, &channel, &thread_ts);
+            stub_trust.restore().await?;
             Ok(())
         }
         Outcome::CompletedNoEdit => {
@@ -1919,6 +2504,7 @@ pub async fn message(mut opts: MessageOpts) -> Result<()> {
                 thread: thread_ts.clone(),
             });
             persist_and_hint(&opts, TurnVerb::Cluster, &channel, &thread_ts);
+            stub_trust.restore().await?;
             Ok(())
         }
         Outcome::AwaitingApproval(reply) => {
@@ -1956,7 +2542,10 @@ pub async fn message(mut opts: MessageOpts) -> Result<()> {
                     )
                     .await
                     {
-                        ResumeExit::Done => Ok(()),
+                        ResumeExit::Done => {
+                            stub_trust.restore().await?;
+                            Ok(())
+                        }
                         ResumeExit::Transient => {
                             // Drop the Slack stub AND the Valkey port-forward first:
                             // `process::exit` does not unwind, so without dropping
@@ -1965,7 +2554,11 @@ pub async fn message(mut opts: MessageOpts) -> Result<()> {
                             // run, leaking the stub's bound port (#751) and
                             // orphaning the `kubectl port-forward` child to init
                             // (#766).
-                            exit_after_drop(crate::exit::ExitClass::Transient, (stub, _valkey_pf));
+                            stub_trust.restore().await?;
+                            exit_after_drop(
+                                crate::exit::ExitClass::Transient,
+                                (stub, _valkey_pf, stub_trust),
+                            );
                         }
                     }
                 }
@@ -1984,7 +2577,11 @@ pub async fn message(mut opts: MessageOpts) -> Result<()> {
                         channel: channel.clone(),
                     });
                     persist_and_hint(&opts, TurnVerb::Cluster, &channel, &thread_ts);
-                    exit_after_drop(crate::exit::ExitClass::Transient, (stub, _valkey_pf));
+                    stub_trust.restore().await?;
+                    exit_after_drop(
+                        crate::exit::ExitClass::Transient,
+                        (stub, _valkey_pf, stub_trust),
+                    );
                 }
             }
         }
@@ -2010,7 +2607,8 @@ pub async fn message(mut opts: MessageOpts) -> Result<()> {
             // transient stall), so it maps to the transient exit code, not
             // failure. Drop the Valkey port-forward now, for the same
             // non-unwinding reason as the stub above (#766).
-            exit_after_drop(crate::exit::ExitClass::Transient, _valkey_pf);
+            stub_trust.restore().await?;
+            exit_after_drop(crate::exit::ExitClass::Transient, (_valkey_pf, stub_trust));
         }
     }
 }

--- a/cli/tests/cluster_stub_trust.rs
+++ b/cli/tests/cluster_stub_trust.rs
@@ -1,0 +1,154 @@
+//! Regression for #1812: the no-Slack cluster-message stub must be trusted only
+//! for the lifetime of that command.  These tests drive the real CLI entrypoint;
+//! the fake cluster records mutations and deliberately fails the Valkey tunnel
+//! so the cleanup-on-error path is deterministic and needs no live cluster.
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_curie")
+}
+
+fn write_tool(dir: &Path, name: &str) -> PathBuf {
+    let path = dir.join(name);
+    let body = r#"#!/usr/bin/env python3
+import json
+import os
+import sys
+
+args = " ".join(sys.argv[1:])
+with open(os.environ["CURIE_TEST_CLUSTER_LOG"], "a", encoding="utf-8") as log:
+    log.write(os.path.basename(sys.argv[0]) + " " + args + "\n")
+
+if "get deployment curie-dispatcher" in args:
+    if os.environ.get("CURIE_TEST_CONNECTED") == "1":
+        print("deployment.apps/curie-dispatcher")
+    sys.exit(0)
+
+# Permit implementations to snapshot either the Deployment or Helm values.
+if "get deployment curie-worker" in args and "-o json" in args:
+    print(json.dumps({"spec":{"template":{"spec":{"containers":[{
+        "name":"worker", "env":[{"name":"CURIE_SLACK_TRUSTED_ORIGINS","value":""}]
+    }]}}}}))
+    sys.exit(0)
+if "get values" in args and "-o json" in args:
+    print("{}")
+    sys.exit(0)
+
+# The Valkey forward fails after temporary trust should have been installed.
+if "port-forward" in args and "valkey" in args:
+    print("intentional Valkey tunnel failure", file=sys.stderr)
+    sys.exit(1)
+
+sys.exit(0)
+"#;
+    fs::write(&path, body).expect("write fake cluster tool");
+    let mut permissions = fs::metadata(&path).expect("stat fake tool").permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&path, permissions).expect("make fake tool executable");
+    path
+}
+
+fn run_cluster_message(connected: bool) -> (Output, Vec<String>) {
+    let tools = tempfile::tempdir().expect("create fake tool directory");
+    write_tool(tools.path(), "kubectl");
+    write_tool(tools.path(), "helm");
+    let log_path = tools.path().join("cluster.log");
+    let inherited_path = std::env::var("PATH").unwrap_or_default();
+    let path = format!("{}:{inherited_path}", tools.path().display());
+
+    let mut command = Command::new(bin());
+    command
+        .args([
+            "cluster",
+            "message",
+            "hello",
+            "--channel",
+            "C0EXAMPLE1",
+            "--chart",
+            "charts/curie",
+            "--listen-host",
+            "10.20.30.40",
+            "--listen-port",
+            "0",
+            "--valkey-local-port",
+            "0",
+            "--api-key",
+            "example-api-key",
+            "--valkey-password",
+            "example-valkey-password",
+            "--timeout-secs",
+            "1",
+        ])
+        .current_dir(concat!(env!("CARGO_MANIFEST_DIR"), "/.."))
+        .env("PATH", path)
+        .env("CURIE_TEST_CLUSTER_LOG", &log_path)
+        .env_remove("CURIE_API_KEY")
+        .env_remove("CURIE_VALKEY_PASSWORD");
+    if connected {
+        command
+            .env("CURIE_TEST_CONNECTED", "1")
+            .env("CURIE_SLACK_BOT_TOKEN", "xoxb-example");
+    }
+    let output = command.output().expect("run cluster message");
+    let lines = fs::read_to_string(log_path)
+        .expect("read fake cluster log")
+        .lines()
+        .map(str::to_owned)
+        .collect();
+    (output, lines)
+}
+
+fn trust_mutations(lines: &[String]) -> Vec<(usize, &str)> {
+    lines
+        .iter()
+        .enumerate()
+        .filter(|(_, line)| {
+            (line.contains("set env") || line.contains("patch") || line.contains("upgrade"))
+                && (line.contains("CURIE_SLACK_TRUSTED_ORIGINS")
+                    || line.contains("worker.slackTrustedOrigins"))
+        })
+        .map(|(index, line)| (index, line.as_str()))
+        .collect()
+}
+
+#[test]
+fn disconnected_cluster_message_temporarily_trusts_portless_stub_and_restores_on_error() {
+    let (output, lines) = run_cluster_message(false);
+    assert!(!output.status.success(), "fixture must reach its forced tunnel error");
+
+    let mutations = trust_mutations(&lines);
+    assert!(
+        mutations.len() >= 2,
+        "stub trust must be installed then restored even when plumbing fails: {lines:#?}"
+    );
+    let (apply_index, apply) = mutations[0];
+    assert!(
+        apply.contains("http://10.20.30.40"),
+        "temporary trust must use the advertised stub host: {apply}"
+    );
+    assert!(
+        !apply.contains("http://10.20.30.40:"),
+        "trusted origins are portless, including for an ephemeral stub port: {apply}"
+    );
+    let forward_index = lines
+        .iter()
+        .position(|line| line.contains("port-forward") && line.contains("valkey"))
+        .expect("message must attempt its Valkey tunnel");
+    let restore_index = mutations.last().expect("restore mutation").0;
+    assert!(apply_index < forward_index, "trust must precede enqueue plumbing: {lines:#?}");
+    assert!(restore_index > forward_index, "trust must be restored on error: {lines:#?}");
+}
+
+#[test]
+fn connected_cluster_message_never_mutates_worker_stub_trust() {
+    let (output, lines) = run_cluster_message(true);
+    assert!(!output.status.success(), "fixture must reach its forced tunnel error");
+    assert!(
+        trust_mutations(&lines).is_empty(),
+        "a Slack-connected release must not receive temporary stub trust: {lines:#?}"
+    );
+}

--- a/cli/tests/cluster_stub_trust.rs
+++ b/cli/tests/cluster_stub_trust.rs
@@ -23,19 +23,41 @@ args = " ".join(sys.argv[1:])
 with open(os.environ["CURIE_TEST_CLUSTER_LOG"], "a", encoding="utf-8") as log:
     log.write(os.path.basename(sys.argv[0]) + " " + args + "\n")
 
+state_path = os.environ["CURIE_TEST_CLUSTER_STATE"]
+try:
+    with open(state_path, encoding="utf-8") as state_file:
+        state = json.load(state_file)
+except FileNotFoundError:
+    state = {"trust": os.environ.get("CURIE_TEST_EXISTING_TRUST"), "holder": None, "version": 1}
+
+def save():
+    with open(state_path, "w", encoding="utf-8") as state_file:
+        json.dump(state, state_file)
+
 if "get deployment curie-dispatcher" in args:
+    if os.environ.get("CURIE_TEST_DISPATCHER_PROBE_FAIL") == "1":
+        print("intentional dispatcher probe failure", file=sys.stderr)
+        sys.exit(1)
     if os.environ.get("CURIE_TEST_CONNECTED") == "1":
         print("deployment.apps/curie-dispatcher")
     sys.exit(0)
 
-# Permit implementations to snapshot either the Deployment or Helm values.
+# Model the Deployment snapshot and resourceVersion JSON Patch used by #1812.
 if "get deployment curie-worker" in args and "-o json" in args:
-    print(json.dumps({"spec":{"template":{"spec":{"containers":[{
-        "name":"worker", "env":[{"name":"CURIE_SLACK_TRUSTED_ORIGINS","value":""}]
-    }]}}}}))
+    env = [] if state["trust"] is None else [{"name":"CURIE_SLACK_TRUSTED_ORIGINS", "value":state["trust"]}]
+    annotations = {} if state["holder"] is None else {"curie.dev/cluster-message-trust-holder":state["holder"]}
+    print(json.dumps({"metadata":{"resourceVersion":str(state["version"]), "annotations":annotations}, "spec":{"template":{"spec":{"containers":[{"name":"worker", "env":env}]}}}}))
     sys.exit(0)
-if "get values" in args and "-o json" in args:
-    print("{}")
+if "patch deployment curie-worker" in args:
+    patch = json.loads(sys.argv[sys.argv.index("-p") + 1])
+    for operation in patch:
+        path = operation["path"].replace("~1", "/").replace("~0", "~")
+        if path.endswith("/env"):
+            state["trust"] = next((entry["value"] for entry in operation["value"] if entry.get("name") == "CURIE_SLACK_TRUSTED_ORIGINS"), None)
+        elif path.endswith("/cluster-message-trust-holder"):
+            state["holder"] = operation.get("value") if operation["op"] != "remove" else None
+    state["version"] += 1
+    save()
     sys.exit(0)
 
 # The Valkey forward fails after temporary trust should have been installed.
@@ -52,11 +74,21 @@ sys.exit(0)
     path
 }
 
-fn run_cluster_message(connected: bool) -> (Output, Vec<String>) {
+fn run_cluster_message(
+    connected: bool,
+    existing_trust: Option<&str>,
+    dispatcher_probe_fails: bool,
+) -> (Output, Vec<String>, serde_json::Value) {
     let tools = tempfile::tempdir().expect("create fake tool directory");
     write_tool(tools.path(), "kubectl");
     write_tool(tools.path(), "helm");
     let log_path = tools.path().join("cluster.log");
+    let state_path = tools.path().join("cluster-state.json");
+    fs::write(
+        &state_path,
+        serde_json::json!({"trust": existing_trust, "holder": null, "version": 1}).to_string(),
+    )
+    .expect("seed fake cluster state");
     let inherited_path = std::env::var("PATH").unwrap_or_default();
     let path = format!("{}:{inherited_path}", tools.path().display());
 
@@ -86,6 +118,7 @@ fn run_cluster_message(connected: bool) -> (Output, Vec<String>) {
         .current_dir(concat!(env!("CARGO_MANIFEST_DIR"), "/.."))
         .env("PATH", path)
         .env("CURIE_TEST_CLUSTER_LOG", &log_path)
+        .env("CURIE_TEST_CLUSTER_STATE", &state_path)
         .env_remove("CURIE_API_KEY")
         .env_remove("CURIE_VALKEY_PASSWORD");
     if connected {
@@ -93,13 +126,22 @@ fn run_cluster_message(connected: bool) -> (Output, Vec<String>) {
             .env("CURIE_TEST_CONNECTED", "1")
             .env("CURIE_SLACK_BOT_TOKEN", "xoxb-example");
     }
+    if let Some(existing_trust) = existing_trust {
+        command.env("CURIE_TEST_EXISTING_TRUST", existing_trust);
+    }
+    if dispatcher_probe_fails {
+        command.env("CURIE_TEST_DISPATCHER_PROBE_FAIL", "1");
+    }
     let output = command.output().expect("run cluster message");
     let lines = fs::read_to_string(log_path)
         .expect("read fake cluster log")
         .lines()
         .map(str::to_owned)
         .collect();
-    (output, lines)
+    let state =
+        serde_json::from_str(&fs::read_to_string(state_path).expect("read fake cluster state"))
+            .expect("parse fake cluster state");
+    (output, lines, state)
 }
 
 fn trust_mutations(lines: &[String]) -> Vec<(usize, &str)> {
@@ -109,7 +151,8 @@ fn trust_mutations(lines: &[String]) -> Vec<(usize, &str)> {
         .filter(|(_, line)| {
             (line.contains("set env") || line.contains("patch") || line.contains("upgrade"))
                 && (line.contains("CURIE_SLACK_TRUSTED_ORIGINS")
-                    || line.contains("worker.slackTrustedOrigins"))
+                    || line.contains("worker.slackTrustedOrigins")
+                    || line.contains("cluster-message-trust-holder"))
         })
         .map(|(index, line)| (index, line.as_str()))
         .collect()
@@ -117,8 +160,11 @@ fn trust_mutations(lines: &[String]) -> Vec<(usize, &str)> {
 
 #[test]
 fn disconnected_cluster_message_temporarily_trusts_portless_stub_and_restores_on_error() {
-    let (output, lines) = run_cluster_message(false);
-    assert!(!output.status.success(), "fixture must reach its forced tunnel error");
+    let (output, lines, state) = run_cluster_message(false, None, false);
+    assert!(
+        !output.status.success(),
+        "fixture must reach its forced tunnel error"
+    );
 
     let mutations = trust_mutations(&lines);
     assert!(
@@ -139,16 +185,63 @@ fn disconnected_cluster_message_temporarily_trusts_portless_stub_and_restores_on
         .position(|line| line.contains("port-forward") && line.contains("valkey"))
         .expect("message must attempt its Valkey tunnel");
     let restore_index = mutations.last().expect("restore mutation").0;
-    assert!(apply_index < forward_index, "trust must precede enqueue plumbing: {lines:#?}");
-    assert!(restore_index > forward_index, "trust must be restored on error: {lines:#?}");
+    assert!(
+        apply_index < forward_index,
+        "trust must precede enqueue plumbing: {lines:#?}"
+    );
+    assert!(
+        restore_index > forward_index,
+        "trust must be restored on error: {lines:#?}"
+    );
+    assert!(
+        state["trust"].is_null(),
+        "the default release must finish with no stub trust env at all: {state}"
+    );
+    assert!(
+        state["holder"].is_null(),
+        "the temporary ownership marker must also be removed: {state}"
+    );
 }
 
 #[test]
-fn connected_cluster_message_never_mutates_worker_stub_trust() {
-    let (output, lines) = run_cluster_message(true);
-    assert!(!output.status.success(), "fixture must reach its forced tunnel error");
+fn disconnected_cluster_message_restores_a_preexisting_trusted_origin() {
+    let original = "https://trusted.example.com";
+    let (output, lines, state) = run_cluster_message(false, Some(original), false);
+    assert!(
+        !output.status.success(),
+        "fixture must reach its forced tunnel error"
+    );
+    assert!(
+        trust_mutations(&lines).len() >= 2,
+        "fixture must exercise apply and cleanup: {lines:#?}"
+    );
+    assert_eq!(
+        state["trust"], original,
+        "cleanup must preserve trust that predated this command"
+    );
+}
+
+#[test]
+fn connected_or_unprobeable_dispatcher_never_mutates_worker_stub_trust() {
+    let (output, lines, state) = run_cluster_message(true, None, false);
+    assert!(
+        !output.status.success(),
+        "fixture must reach its forced tunnel error"
+    );
     assert!(
         trust_mutations(&lines).is_empty(),
         "a Slack-connected release must not receive temporary stub trust: {lines:#?}"
     );
+    assert!(state["trust"].is_null());
+
+    let (output, lines, state) = run_cluster_message(false, None, true);
+    assert!(
+        !output.status.success(),
+        "fixture must reach its forced tunnel error"
+    );
+    assert!(
+        trust_mutations(&lines).is_empty(),
+        "a failed dispatcher probe is not proof it is safe to mutate worker trust: {lines:#?}"
+    );
+    assert!(state["trust"].is_null());
 }


### PR DESCRIPTION
Closes #1812

Temporarily trusts the disconnected cluster-message callback origin through an ownership-guarded worker patch, then restores the exact prior trust state. Connected or unprobeable Slack releases do not mutate trust. Removes stale --wire chart wording.

Validation: cargo fmt --check; cargo clippy -- -D warnings; cargo test; verify-fix-pin reports PINNED for cli/tests/cluster_stub_trust.rs::disconnected_cluster_message_temporarily_trusts_portless_stub_and_restores_on_error. Cluster ladder was attempted but this kubecontext has no installed Curie release, so the runtime rung did not reach the candidate path.