### PR TITLE
Carry whole-turn OTEL traces and correlated logs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -173,7 +173,10 @@ flowchart TB
     API --> Store
     API --> PG
     UI --> API
-    Sandbox --> OTel
+    API -. OTLP .-> OTel
+    Dispatcher -. OTLP .-> OTel
+    Worker -. OTLP .-> OTel
+    Sandbox -. OTLP .-> OTel
     Worker -- eval scores --> LF
     API -- read --> LF
 ```
@@ -198,9 +201,10 @@ with four outbound dependencies of its own:
 - It writes eval scores straight to Langfuse
   ([`apps/worker/src/curie_worker/eval/recorder.py::LangfuseEvalRecorder`](apps/worker/src/curie_worker/eval/recorder.py)).
 
-The worker has **no** OTel dependency — the runner is the only emitter. Its one
-connection to observability is the eval-score write to Langfuse above. The CLI
-likewise never calls the dispatcher directly — see
+API, dispatcher, worker, and runner each emit traces and closed lifecycle logs
+to the OTel Collector. A turn's causal context crosses the Valkey and runner
+HTTP boundaries, while the worker's separate eval-score write to Langfuse
+remains unchanged. The CLI likewise never calls the dispatcher directly — see
 [the Slack seam](#slack-seam--a-per-turn-reply-endpoint-and-the-cli-stub) for
 how it enqueues a turn instead.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -247,23 +247,25 @@ sequenceDiagram
     D->>V: SET dedupe:<event_id> NX EX ttl
     Note over D: retried delivery finds the key set, is dropped (still acked, never re-posted)
     D->>U: post placeholder ("On it...")
-    D->>V: XADD curie:runs {QueuedTurn}
+    D->>V: XADD curie:runs {QueuedTurn + W3C carrier metadata}
 
-    W->>V: XREADGROUP (consumer group)
+    W->>V: XREADGROUP (consumer group; extract carrier or start a root)
     W->>V: SET NX PX thread lock (routing CAS)
     W->>W: binding: resolve agent+version+bundle_ref by channel address
     alt no live turn for this thread
         W->>S: claim(thread_ts) / resume
         S-->>W: SandboxHandle (pod cold-created from SandboxTemplate)
-        W->>R: POST /v1/event {message}
+        W->>R: POST /v1/event {message} + W3C Trace Context
     else turn already live for this thread
-        W->>R: POST /v1/steer {text}
+        W->>R: POST /v1/steer {text} + W3C Trace Context
         Note over W,R: 409 if the turn finished first (finish race), worker opens a fresh turn on the same idle sandbox
     end
 
     R->>A: model call (streaming)
     R-->>W: NDJSON: text_delta*, tool notes*, final
-    R--)O: gen_ai spans (agent.run -> generation -> tool)
+    D--)O: producer span + correlated lifecycle log
+    W--)O: consumer, routing, sandbox, HTTP, reply spans/events + logs
+    R--)O: child gen_ai spans (agent.run -> generation -> tool) + logs
 
     alt turn completes
         W->>V: markers (done / side_effect_flag as seen)
@@ -542,23 +544,30 @@ The write path runs down; the read path (arrows reversed) runs back up from
 Langfuse to whoever's asking:
 
 ```
-runner (OTLP spans, resource attr curie.session_id)
+API + dispatcher + worker + runner (OTLP spans and correlated logs)
   --> OTel Collector (OTLP gRPC 4317 / HTTP 4318 in)
         --> Langfuse v3 over HTTP (ClickHouse-backed)
               <-- apps/api Langfuse proxy (trace tree, metrics, cost)
                     <-- apps/ui Runs / Metrics / Cost / Logs views
 ```
 
-- The runner emits `gen_ai`-style spans (`agent.run -> generation -> tool`) with a resource including `service.name`, `curie.session_id`, and `curie.sandbox_id` ([`runner/src/curie_runner/otel.py`](runner/src/curie_runner/otel.py)). The `sandbox_id` is what lets a trace be tied back to the sandbox that served it.
+- **One turn is one causal trace across both async and HTTP boundaries.** The dispatcher (or an API queue producer) opens `send curie:runs` and injects W3C Trace Context into Valkey Stream metadata next to the unchanged `QueuedTurn` payload ([`apps/dispatcher/src/curie_dispatcher/queue.py::to_stream_fields`](apps/dispatcher/src/curie_dispatcher/queue.py), [`apps/api/src/curie_api/resumequeue.py::ResumeQueue.enqueue`](apps/api/src/curie_api/resumequeue.py)). The worker extracts that metadata into `process curie:runs`; missing metadata starts a valid root and malformed metadata is ignored with a value-free diagnostic ([`apps/worker/src/curie_worker/consumer.py::Consumer._process_span`](apps/worker/src/curie_worker/consumer.py)). `RunnerClient._request` then forwards the current W3C context over HTTP ([`apps/worker/src/curie_worker/runner_client.py::RunnerClient._request`](apps/worker/src/curie_worker/runner_client.py)), making the runner's `agent.run -> generation -> tool` tree its descendant. Worker routing, sandbox lifecycle, reply completion, and stream settlement remain in that same trace.
+- **Four services emit through one bounded runtime.** API, dispatcher, worker, and runner use [`curie_telemetry.configure`](packages/telemetry/src/curie_telemetry/bootstrap.py::configure) for explicit trace and log providers. Resources contain process identity (`service.*`, `schema.version`, optional deployment environment); turn identity is attached to spans only after binding resolution, including `curie.sandbox_id` where known. Bounded batch processors, a two-second flush/shutdown ceiling, and handler detachment are owned by [`TelemetryRuntime`](packages/telemetry/src/curie_telemetry/bootstrap.py::TelemetryRuntime). Existing stderr diagnostics remain intact.
+- **Telemetry is closed and value-conscious.** Each emitter has an allowlisted attribute and event partition; recursive redaction covers span attributes, log bodies, logging arguments, and exception text before export ([`packages/telemetry/src/curie_telemetry/attributes.py`](packages/telemetry/src/curie_telemetry/attributes.py), [`packages/telemetry/src/curie_telemetry/redact.py`](packages/telemetry/src/curie_telemetry/redact.py)). Static lifecycle log events emitted while a span is current carry its trace and span ids without exporting prompts, tool content, secrets, or real transport identifiers.
+- **No endpoint means no exporter.** Standard `OTEL_EXPORTER_OTLP_*` variables configure HTTP/protobuf or gRPC per signal. With no endpoint (or `OTEL_SDK_DISABLED=true`) the runtime creates neither provider, queue, handler, nor network attempt; service behavior and stderr logging continue normally.
 - **Langfuse OTLP (OpenTelemetry Protocol) ingest is HTTP-only.** Services send to the OTel Collector (which may take gRPC or HTTP), and the collector always exports to Langfuse over HTTP. Collector config is at [`otel/collector-config.yaml`](otel/collector-config.yaml). The load-bearing constraint is documented in [`CLAUDE.md`](CLAUDE.md).
 - The API reconstructs the tool-call tree from Langfuse's public API via `parentObservationId` ([`apps/api/src/curie_api/langfuse.py::build_tree`](apps/api/src/curie_api/langfuse.py)) and proxies metrics/cost ([`apps/api/src/curie_api/langfuse.py::LangfuseClient`](apps/api/src/curie_api/langfuse.py), surfaced at [`apps/api/src/curie_api/routers/observability.py`](apps/api/src/curie_api/routers/observability.py)).
 - The UI's Runs (`RealTraces.tsx`), Metrics (`RealMetrics.tsx`), Cost (`RealCost.tsx`), and Logs (`RealLogs.tsx`) views render these live in wired mode ([`apps/ui/src/views/obs/`](apps/ui/src/views/obs/)).
 
-The `sandbox_id` is also known worker-side (the affinity store and
-`SandboxHandle`), so a trace, its session, and its serving sandbox all line up.
+The `sandbox_id` is known worker-side (the affinity store and
+`SandboxHandle`) and is stamped on the relevant turn spans, so a trace, its session, and its serving sandbox all line up without putting per-turn identity on a process resource.
 The API hoists it out of the trace's observations onto the trace itself
 ([`apps/api/src/curie_api/langfuse.py::hoist_sandbox_id`](apps/api/src/curie_api/langfuse.py)),
 so sandbox identity is surfaced, not pending.
+
+This is a write-path foundation only. It does not add a second query API, change the
+Langfuse-backed read surfaces, make the backend installable, define harness-neutral
+token/cost telemetry, or expand agent trace discovery.
 
 **The observability CLI.** `curie local observability` prints the local
 observability surfaces — the console, Langfuse traces/cost, and the API base.

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     # because this package imports it directly.
     "pyjwt[crypto]>=2.10",
     "redis>=5.0",
+    "curie-telemetry",
     "plugin-format",
     "aci-protocol",
 ]

--- a/apps/api/src/curie_api/delivery.py
+++ b/apps/api/src/curie_api/delivery.py
@@ -27,7 +27,9 @@ import time
 from typing import Any
 
 import redis.asyncio as redis
+from curie_telemetry import TRACE_CONTEXT_FIELD, inject_trace_context
 from fastapi import Response
+from opentelemetry.trace import SpanKind, Status, StatusCode, Tracer
 
 # The API's Valkey client is built without `decode_responses`, so values come
 # back as bytes; `_text` is the package's named, documented decode for exactly
@@ -61,12 +63,22 @@ logger = logging.getLogger(__name__)
 _ENQUEUE_SCRIPT = """
 local cur = redis.call('GET', KEYS[1])
 if cur == ARGV[1] then
-  local id = redis.call('XADD', KEYS[2], '*', ARGV[3], ARGV[2])
+  local id
+  if ARGV[5] == '' then
+    id = redis.call('XADD', KEYS[2], '*', ARGV[3], ARGV[2])
+  else
+    id = redis.call('XADD', KEYS[2], '*', ARGV[3], ARGV[2], ARGV[5], ARGV[6])
+  end
   redis.call('SET', KEYS[1], id)
   return {1, id}
 elseif not cur then
   redis.call('SET', KEYS[1], ARGV[1], 'EX', ARGV[4])
-  local id = redis.call('XADD', KEYS[2], '*', ARGV[3], ARGV[2])
+  local id
+  if ARGV[5] == '' then
+    id = redis.call('XADD', KEYS[2], '*', ARGV[3], ARGV[2])
+  else
+    id = redis.call('XADD', KEYS[2], '*', ARGV[3], ARGV[2], ARGV[5], ARGV[6])
+  end
   redis.call('SET', KEYS[1], id)
   return {1, id}
 else
@@ -145,6 +157,7 @@ async def enqueue_owned(
     payload: str,
     payload_field: str,
     lease_s: int,
+    tracer: Tracer | None = None,
 ) -> tuple[bool, str]:
     """Enqueue the payload if this request still owns the claim.
 
@@ -156,15 +169,53 @@ async def enqueue_owned(
         payload: The serialized ``QueuedTurn``.
         payload_field: The stream field the payload rides in.
         lease_s: The lease used by the re-claim arm.
+        tracer: Optional API tracer; when present its producer carrier is
+            appended in the same owner-check/XADD transaction.
 
     Returns:
         ``(True, stream_id)`` when THIS request enqueued; ``(False, owner_value)``
         naming the current owner when it did not.
     """
 
-    result: Any = await client.eval(
-        _ENQUEUE_SCRIPT, 2, key, stream, owner, payload, payload_field, str(lease_s)
-    )
+    async def _enqueue(carrier: str | None) -> Any:
+        return await client.eval(
+            _ENQUEUE_SCRIPT,
+            2,
+            key,
+            stream,
+            owner,
+            payload,
+            payload_field,
+            str(lease_s),
+            TRACE_CONTEXT_FIELD if carrier is not None else "",
+            carrier or "",
+        )
+
+    result: Any
+    if tracer is None:
+        result = await _enqueue(None)
+    else:
+        attributes = {
+            "messaging.system": "valkey",
+            "messaging.destination.name": stream,
+            "messaging.operation.type": "send",
+        }
+        with tracer.start_as_current_span(
+            "send curie:runs",
+            kind=SpanKind.PRODUCER,
+            attributes=attributes,
+            record_exception=False,
+            set_status_on_exception=False,
+        ) as span:
+            try:
+                result = await _enqueue(inject_trace_context())
+            except BaseException as exc:
+                span.set_attribute("error.type", type(exc).__name__)
+                span.set_status(Status(StatusCode.ERROR))
+                raise
+            if bool(result[0]):
+                span.add_event("messaging.enqueued")
+            span.set_status(Status(StatusCode.OK))
     enqueued, current = result
     return bool(enqueued), _text(current)
 

--- a/apps/api/src/curie_api/langfuse.py
+++ b/apps/api/src/curie_api/langfuse.py
@@ -79,23 +79,43 @@ def _probe_attr(bag: Any, key: str, *, bare_key: str | None = None) -> str | Non
     return None
 
 
+def _runner_first(
+    observations: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Prefer runner ``agent.run`` while still probing every observation."""
+
+    def priority(observation: dict[str, Any]) -> int:
+        is_runner = _probe_attr(observation, "service.name") == "curie-runner"
+        is_agent_run = observation.get("name") == "agent.run"
+        if is_runner and is_agent_run:
+            return 0
+        if is_runner:
+            return 1
+        if is_agent_run:
+            return 2
+        return 3
+
+    return sorted(observations, key=priority)
+
+
 def hoist_sandbox_id(
     trace: dict[str, Any], observations: list[dict[str, Any]]
 ) -> str | None:
     """Lift the runner's sandbox id out of a trace, or None when absent.
 
-    Checks, in order, the trace-level resource/metadata attributes then the
-    first observation's resource attributes, so the id resolves regardless of
-    whether Langfuse surfaces the OTel resource attr on the trace or only on an
-    observation. Only a present, non-empty attribute is returned -- no value is
-    invented.
+    Checks the trace-level resource/metadata attributes, then every observation
+    with the runner's ``agent.run`` preferred over platform ancestors. This
+    preserves the runner-owned value after a platform span becomes the root.
+    Only a present, non-empty attribute is returned -- no value is invented.
     """
 
     hit = _probe_attr(trace, _SANDBOX_ATTR, bare_key="sandbox_id")
     if hit:
         return hit
-    if observations:
-        return _probe_attr(observations[0], _SANDBOX_ATTR, bare_key="sandbox_id")
+    for observation in _runner_first(observations):
+        hit = _probe_attr(observation, _SANDBOX_ATTR, bare_key="sandbox_id")
+        if hit:
+            return hit
     return None
 
 
@@ -104,7 +124,7 @@ def hoist_approval_decision(
 ) -> str | None:
     """Lift the runner's approval-gate decision out of a trace, or None.
 
-    Mirrors ``hoist_sandbox_id``'s trace-then-first-observation probe. The
+    Mirrors ``hoist_sandbox_id``'s trace-then-runner-first observation probe. The
     attribute is stamped on the root ``agent.run`` span rather than as a
     provider-wide resource attribute (ADR-0076 Stone 3, #889), so it is
     ordinarily trace-level; the observation fallback stays for the same
@@ -116,8 +136,10 @@ def hoist_approval_decision(
     hit = _probe_attr(trace, _APPROVAL_DECISION_ATTR)
     if hit:
         return hit
-    if observations:
-        return _probe_attr(observations[0], _APPROVAL_DECISION_ATTR)
+    for observation in _runner_first(observations):
+        hit = _probe_attr(observation, _APPROVAL_DECISION_ATTR)
+        if hit:
+            return hit
     return None
 
 

--- a/apps/api/src/curie_api/main.py
+++ b/apps/api/src/curie_api/main.py
@@ -13,7 +13,7 @@ from typing import Any
 
 import httpx
 import redis.asyncio as redis
-from curie_telemetry import configure, extract_http_trace_context
+from curie_telemetry import configure, emit_log_event, extract_http_trace_context
 from fastapi import FastAPI, Request
 from opentelemetry import trace
 from opentelemetry.trace import SpanKind, Status, StatusCode
@@ -272,17 +272,13 @@ def create_app() -> FastAPI:
         """Adopt only W3C context and export a closed, value-free server span."""
 
         parent = extract_http_trace_context(request.headers, logger=service_logger)
-        supplied_context = (
-            "traceparent" in request.headers or "tracestate" in request.headers
-        )
+        supplied_context = "traceparent" in request.headers
         server = request.scope.get("server")
         attributes: dict[str, AttributeValue] = {
             "http.request.method": request.method,
         }
         if isinstance(server, (list, tuple)) and len(server) == 2:
-            address, port = server
-            if isinstance(address, str) and address:
-                attributes["server.address"] = address
+            _address, port = server
             if type(port) is int:
                 attributes["server.port"] = port
 
@@ -305,6 +301,11 @@ def create_app() -> FastAPI:
                 span.set_attribute("exception.type", error_type)
                 span.set_attribute("exception.escaped", True)
                 span.set_status(Status(StatusCode.ERROR))
+                emit_log_event(
+                    service_logger,
+                    "http.server.failed",
+                    level=logging.ERROR,
+                )
                 route = request.scope.get("route")
                 route_path = getattr(route, "path", None)
                 if isinstance(route_path, str):
@@ -319,8 +320,14 @@ def create_app() -> FastAPI:
             if response.status_code >= 500:
                 span.set_attribute("error.type", f"{response.status_code // 100}xx")
                 span.set_status(Status(StatusCode.ERROR))
+                emit_log_event(
+                    service_logger,
+                    "http.server.failed",
+                    level=logging.ERROR,
+                )
             else:
                 span.set_status(Status(StatusCode.OK))
+                emit_log_event(service_logger, "http.server.completed")
             return response
 
     @app.get("/health", tags=["health"])

--- a/apps/api/src/curie_api/main.py
+++ b/apps/api/src/curie_api/main.py
@@ -9,10 +9,15 @@ import logging
 import sys
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from typing import Any
 
 import httpx
 import redis.asyncio as redis
-from fastapi import FastAPI
+from curie_telemetry import configure, extract_http_trace_context
+from fastapi import FastAPI, Request
+from opentelemetry import trace
+from opentelemetry.trace import SpanKind, Status, StatusCode
+from opentelemetry.util.types import AttributeValue
 
 from .commitpoller import CommitPoller, GitHubBranchTip
 from .config import get_settings
@@ -82,6 +87,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         valkey,
         stream=settings.runs_stream,
         dead_letter_stream=settings.resume_dead_letter_stream or settings.dead_letter_stream_name(),
+        tracer=app.state.telemetry.tracer,
     )
     # The composition root for approvals (#420, ADR-0034): the only place that
     # names Slack to build the approver-set selector, so the authorizer and the
@@ -213,9 +219,12 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
                 await poller_task
             except asyncio.CancelledError:
                 pass
-        await valkey.aclose()
-        await http_client.aclose()
-        await engine.dispose()
+        try:
+            await valkey.aclose()
+            await http_client.aclose()
+            await engine.dispose()
+        finally:
+            app.state.telemetry.shutdown(timeout_millis=2000)
 
 
 def configure_logging(level: str | None = None) -> logging.Logger:
@@ -249,11 +258,70 @@ def configure_logging(level: str | None = None) -> logging.Logger:
 
 
 def create_app() -> FastAPI:
-    configure_logging()
+    service_logger = configure_logging()
+    telemetry = configure(service_name="curie-api", service_version="0.0.0")
+    telemetry.attach_logging(service_logger)
     # Which credential the platform will clone with (ADR-0092, #1262). One
     # line, no secret, and a warning when the App is set up only halfway.
     log_credential_path(get_settings())
     app = FastAPI(title="Curie API", version="0.1.0", lifespan=lifespan)
+    app.state.telemetry = telemetry
+
+    @app.middleware("http")
+    async def trace_http_request(request: Request, call_next: Any) -> Any:
+        """Adopt only W3C context and export a closed, value-free server span."""
+
+        parent = extract_http_trace_context(request.headers, logger=service_logger)
+        supplied_context = (
+            "traceparent" in request.headers or "tracestate" in request.headers
+        )
+        server = request.scope.get("server")
+        attributes: dict[str, AttributeValue] = {
+            "http.request.method": request.method,
+        }
+        if isinstance(server, (list, tuple)) and len(server) == 2:
+            address, port = server
+            if isinstance(address, str) and address:
+                attributes["server.address"] = address
+            if type(port) is int:
+                attributes["server.port"] = port
+
+        with telemetry.tracer.start_as_current_span(
+            f"{request.method} request",
+            context=parent,
+            kind=SpanKind.SERVER,
+            attributes=attributes,
+            record_exception=False,
+            set_status_on_exception=False,
+        ) as span:
+            parent_is_valid = trace.get_current_span(parent).get_span_context().is_valid
+            if supplied_context and not parent_is_valid:
+                span.add_event("trace_context.invalid")
+            try:
+                response = await call_next(request)
+            except BaseException as exc:
+                error_type = type(exc).__name__
+                span.set_attribute("error.type", error_type)
+                span.set_attribute("exception.type", error_type)
+                span.set_attribute("exception.escaped", True)
+                span.set_status(Status(StatusCode.ERROR))
+                route = request.scope.get("route")
+                route_path = getattr(route, "path", None)
+                if isinstance(route_path, str):
+                    span.update_name(f"{request.method} {route_path}")
+                raise
+
+            route = request.scope.get("route")
+            route_path = getattr(route, "path", None)
+            if isinstance(route_path, str):
+                span.update_name(f"{request.method} {route_path}")
+            span.set_attribute("http.response.status_code", response.status_code)
+            if response.status_code >= 500:
+                span.set_attribute("error.type", f"{response.status_code // 100}xx")
+                span.set_status(Status(StatusCode.ERROR))
+            else:
+                span.set_status(Status(StatusCode.OK))
+            return response
 
     @app.get("/health", tags=["health"])
     async def health() -> dict[str, str]:

--- a/apps/api/src/curie_api/resumequeue.py
+++ b/apps/api/src/curie_api/resumequeue.py
@@ -7,9 +7,11 @@ the identical consumer -> kernel -> claim path a Slack mention takes: the kernel
 finds the thread's route suspended and rehydrates it (ADR-0003), and the
 platform-authored resolution text becomes the turn that continues the run.
 
-Wire encoding mirrors the dispatcher's seam exactly (a single ``payload`` field
-holding the model's JSON). The turn's ``event_id`` is deterministic per
-approval, so the worker's done-marker dedupes any double-enqueue.
+Wire encoding mirrors the dispatcher's seam exactly: ``payload`` holds the
+model's JSON and an active causal request may add a separate optional W3C
+carrier. A background sweep with no parent remains payload-only. The turn's
+``event_id`` is deterministic per approval, so the worker's done-marker dedupes
+any double-enqueue.
 """
 
 import re
@@ -19,6 +21,9 @@ from typing import Any
 
 import redis.asyncio as redis
 from aci_protocol import STREAM_PAYLOAD_FIELD, QueuedTurn, ReplyHandle, TurnSource
+from curie_telemetry import TRACE_CONTEXT_FIELD, inject_trace_context
+from opentelemetry import trace
+from opentelemetry.trace import SpanKind, Status, StatusCode, Tracer
 
 from .config import get_settings
 from .models import Approval, ApprovalStatus
@@ -218,6 +223,7 @@ class ResumeQueue:
         stream: str | None = None,
         *,
         dead_letter_stream: str | None = None,
+        tracer: Tracer | None = None,
     ) -> None:
         # The runs stream is declared once, on the settings object (#492): the
         # module constant this used to default to was a second declaration of
@@ -227,6 +233,7 @@ class ResumeQueue:
         # when the queue is built, not at import time.
         self._client = client
         self._stream = stream if stream is not None else get_settings().runs_stream
+        self._tracer = tracer
         # The graveyard the #532 backstop scans (READ-ONLY here; the API never
         # mutates it). The derivation MUST match the worker's
         # WorkerConfig.dead_letter_stream_name() (`<stream>:dead`). An operator
@@ -236,8 +243,39 @@ class ResumeQueue:
         self._dead_letter_stream = dead_letter_stream or f"{self._stream}:dead"
 
     async def enqueue(self, turn: QueuedTurn) -> str:
-        fields: dict[Any, Any] = {STREAM_PAYLOAD_FIELD: turn.model_dump_json()}
-        stream_id = await self._client.xadd(self._stream, fields)
+        async def _xadd(carrier: str | None) -> Any:
+            fields: dict[Any, Any] = {
+                STREAM_PAYLOAD_FIELD: turn.model_dump_json()
+            }
+            if carrier is not None:
+                fields[TRACE_CONTEXT_FIELD] = carrier
+            return await self._client.xadd(self._stream, fields)
+
+        current = trace.get_current_span().get_span_context()
+        if self._tracer is None or not current.is_valid:
+            # Background sweep/reconcile producers deliberately remain valid
+            # payload-only entries when there is no causal request span.
+            stream_id = await _xadd(None)
+        else:
+            with self._tracer.start_as_current_span(
+                "send curie:runs",
+                kind=SpanKind.PRODUCER,
+                attributes={
+                    "messaging.system": "valkey",
+                    "messaging.destination.name": self._stream,
+                    "messaging.operation.type": "send",
+                },
+                record_exception=False,
+                set_status_on_exception=False,
+            ) as span:
+                try:
+                    stream_id = await _xadd(inject_trace_context())
+                except BaseException as exc:
+                    span.set_attribute("error.type", type(exc).__name__)
+                    span.set_status(Status(StatusCode.ERROR))
+                    raise
+                span.add_event("messaging.enqueued")
+                span.set_status(Status(StatusCode.OK))
         return stream_id.decode() if isinstance(stream_id, bytes) else str(stream_id)
 
     async def read_dead_letter(

--- a/apps/api/src/curie_api/routers/approvals.py
+++ b/apps/api/src/curie_api/routers/approvals.py
@@ -17,7 +17,9 @@ import logging
 import uuid
 from datetime import UTC, datetime
 
+from curie_telemetry import set_turn_identity
 from fastapi import APIRouter, Depends, HTTPException, Response, status
+from opentelemetry import trace
 from sqlalchemy.exc import IntegrityError
 
 from .. import crud
@@ -35,6 +37,17 @@ logger = logging.getLogger(__name__)
 router = APIRouter(
     prefix="/approvals", tags=["approvals"], dependencies=[Depends(require_api_key)]
 )
+
+
+def _stamp_resume_identity(approval: Approval, *, user_id: str) -> None:
+    if approval.agent_id is None:
+        return
+    set_turn_identity(
+        trace.get_current_span(),
+        agent_id=approval.agent_id,
+        conversation_id=approval.conversation_id,
+        user_id=user_id,
+    )
 
 
 def _expired(approval: Approval) -> bool:
@@ -201,7 +214,9 @@ async def resolve_approval(
             # redelivery of an already-finished turn re-running; it is the CAS,
             # not the shared key, that keeps this wakeup single.
             try:
-                await resume_queue.enqueue(build_expiry_resume_turn(expired))
+                turn = build_expiry_resume_turn(expired)
+                _stamp_resume_identity(expired, user_id=turn.author)
+                await resume_queue.enqueue(turn)
                 # Enqueue-first-then-mark (#418): only a wake that reached the
                 # stream is written off, so a failure below leaves resumed_at
                 # NULL and the reconciler re-enqueues it past its grace horizon.
@@ -289,7 +304,9 @@ async def resolve_approval(
     # a 200 would silently strand the suspended session -- re-raise instead, so the
     # failure surfaces as a 500 the caller can see (the CAS/audit already committed).
     try:
-        stream_id = await resume_queue.enqueue(build_resume_turn(claimed))
+        turn = build_resume_turn(claimed)
+        _stamp_resume_identity(claimed, user_id=turn.author)
+        stream_id = await resume_queue.enqueue(turn)
     except Exception:  # noqa: BLE001
         logger.warning(
             "approval %s %s by %s; resume enqueue failed, reconciler will retry",

--- a/apps/api/src/curie_api/routers/channels.py
+++ b/apps/api/src/curie_api/routers/channels.py
@@ -36,6 +36,7 @@ from typing import Annotated, Any
 
 import redis.asyncio as redis
 from aci_protocol import STREAM_PAYLOAD_FIELD, QueuedTurn, ReplyHandle, TurnSource
+from curie_telemetry import set_turn_identity
 from fastapi import (
     APIRouter,
     Depends,
@@ -46,6 +47,7 @@ from fastapi import (
     status,
 )
 from fastapi.exceptions import RequestValidationError
+from opentelemetry import trace
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 from sqlalchemy import select
 
@@ -494,6 +496,12 @@ async def ingest_turn(
             # those requests answers from `event_id` alone and would have thrown
             # the payload away.
             turn = _mint_turn(row, body, event_id)
+            set_turn_identity(
+                trace.get_current_span(),
+                agent_id=row.agent_id,
+                conversation_id=turn.conversation_id,
+                user_id=turn.author,
+            )
             enqueued, current = await enqueue_owned(
                 client,
                 key=key,
@@ -502,6 +510,7 @@ async def ingest_turn(
                 payload=turn.model_dump_json(),
                 payload_field=STREAM_PAYLOAD_FIELD,
                 lease_s=settings.channel_delivery_lease_s,
+                tracer=request.app.state.telemetry.tracer,
             )
             if enqueued:
                 logger.info(

--- a/apps/api/src/curie_api/routers/hooks.py
+++ b/apps/api/src/curie_api/routers/hooks.py
@@ -41,7 +41,9 @@ from typing import Annotated
 
 import redis.asyncio as redis
 from aci_protocol import STREAM_PAYLOAD_FIELD, QueuedTurn, ReplyHandle, TurnSource
+from curie_telemetry import set_turn_identity
 from fastapi import APIRouter, Header, HTTPException, Request, Response, status
+from opentelemetry import trace
 from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.orm import selectinload
@@ -296,6 +298,12 @@ async def ingest_hook(
                     headers={"Retry-After": str(settings.hook_backlog_window_s)},
                 )
             turn = _mint_turn(agent, hook, event_id, raw)
+            set_turn_identity(
+                trace.get_current_span(),
+                agent_id=agent.id,
+                conversation_id=turn.conversation_id,
+                user_id=turn.author,
+            )
             enqueued, current = await enqueue_owned(
                 client,
                 key=key,
@@ -304,6 +312,7 @@ async def ingest_hook(
                 payload=turn.model_dump_json(),
                 payload_field=STREAM_PAYLOAD_FIELD,
                 lease_s=settings.channel_delivery_lease_s,
+                tracer=request.app.state.telemetry.tracer,
             )
             if enqueued:
                 logger.info(

--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -20,8 +20,6 @@ import asyncpg
 import pytest
 from alembic import command
 from alembic.config import Config
-from curie_api.config import get_settings
-from curie_api.main import create_app
 from fastapi.testclient import TestClient
 from sqlalchemy import make_url
 from sqlalchemy.engine import URL
@@ -38,6 +36,14 @@ from sqlalchemy.sql import text
 # contributor pointing the suite at another store by exporting their own value wins.
 os.environ.setdefault("S3_ACCESS_KEY", "rustfs")
 os.environ.setdefault("S3_SECRET_KEY", "rustfssecret")
+
+# Import the application only after the suite environment is complete.
+# ``curie_api.db`` resolves the cached settings while its module-level schema is
+# initialized, so importing ``create_app`` above these declarations makes a
+# standalone TestClient inherit the empty production credential defaults even
+# though the test suite intended to select the disposable RustFS service.
+from curie_api.config import get_settings  # noqa: E402
+from curie_api.main import create_app  # noqa: E402
 
 API_DIR = Path(__file__).resolve().parents[1]
 ALEMBIC_DIR = API_DIR / "alembic"

--- a/apps/api/tests/test_runs_proxy.py
+++ b/apps/api/tests/test_runs_proxy.py
@@ -61,15 +61,25 @@ def test_get_trace_returns_reconstructed_tree(
 def test_get_trace_surfaces_sandbox_id_from_observation(
     auth_headers: dict[str, str],
 ) -> None:
-    # The endpoint hoists curie.sandbox_id onto the typed TraceTree field even
-    # when Langfuse carries it only on an observation (not the trace).
+    # Platform spans now precede agent.run. A first-observation probe returns
+    # the deliberately wrong value; the runner root is the authority.
     observations = [
+        {
+            "id": "platform",
+            "type": "SPAN",
+            "name": "POST /channels/turns",
+            "startTime": "1",
+            "metadata": {"curie.sandbox_id": "sbx-wrong-platform"},
+            "resourceAttributes": {"service.name": "curie-api"},
+        },
         {
             "id": "r",
             "type": "SPAN",
             "name": "agent.run",
-            "startTime": "1",
+            "startTime": "2",
+            "parentObservationId": "platform",
             "metadata": {"curie.sandbox_id": "sbx-proxy"},
+            "resourceAttributes": {"service.name": "curie-runner"},
         },
     ]
     with _app_with(observations) as client:
@@ -91,14 +101,25 @@ def test_get_trace_sandbox_id_null_when_absent(
 def test_get_trace_surfaces_approval_decision_from_observation(
     auth_headers: dict[str, str],
 ) -> None:
-    # Same hoist shape as sandbox_id, for the ADR-0076 Stone 3 (#889) attribute.
+    # Same precedence contract as sandbox_id: the runner agent.run observation
+    # wins after an earlier platform observation.
     observations = [
+        {
+            "id": "platform",
+            "type": "SPAN",
+            "name": "send curie:runs",
+            "startTime": "1",
+            "metadata": {"gen_ai.approval.decision": "rejected"},
+            "resourceAttributes": {"service.name": "curie-api"},
+        },
         {
             "id": "r",
             "type": "SPAN",
             "name": "agent.run",
-            "startTime": "1",
+            "startTime": "2",
+            "parentObservationId": "platform",
             "metadata": {"gen_ai.approval.decision": "approved"},
+            "resourceAttributes": {"service.name": "curie-runner"},
         },
     ]
     with _app_with(observations) as client:

--- a/apps/api/tests/test_telemetry.py
+++ b/apps/api/tests/test_telemetry.py
@@ -34,6 +34,9 @@ from curie_test_support.valkey import (
     connect_or_skip,
 )
 from fastapi.testclient import TestClient
+from opentelemetry.proto.collector.logs.v1.logs_service_pb2 import (
+    ExportLogsServiceRequest,
+)
 from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (
     ExportTraceServiceRequest,
 )
@@ -48,6 +51,7 @@ TURN_TEXT = "PLACEHOLDER_TURN_TEXT"
 class _OtlpCapture:
     server: ThreadingHTTPServer
     traces: list[ExportTraceServiceRequest] = field(default_factory=list)
+    logs: list[ExportLogsServiceRequest] = field(default_factory=list)
 
     @property
     def endpoint(self) -> str:
@@ -66,6 +70,10 @@ def _handler(capture_ref: list[_OtlpCapture]) -> type[BaseHTTPRequestHandler]:
                 request = ExportTraceServiceRequest()
                 request.ParseFromString(body)
                 capture_ref[0].traces.append(request)
+            elif self.path == "/v1/logs":
+                request = ExportLogsServiceRequest()
+                request.ParseFromString(body)
+                capture_ref[0].logs.append(request)
             assert self.path in {"/v1/traces", "/v1/logs"}
             self.send_response(200)
             self.end_headers()
@@ -162,6 +170,16 @@ def _spans(capture: _OtlpCapture) -> list[Any]:
     ]
 
 
+def _logs(capture: _OtlpCapture) -> list[Any]:
+    return [
+        record
+        for request in capture.logs
+        for resource_logs in request.resource_logs
+        for scope_logs in resource_logs.scope_logs
+        for record in scope_logs.log_records
+    ]
+
+
 def test_http_middleware_adopts_valid_context_and_ignores_bad_context_value_free(
     otlp_capture: _OtlpCapture,
     caplog: pytest.LogCaptureFixture,
@@ -173,6 +191,7 @@ def test_http_middleware_adopts_valid_context_and_ignores_bad_context_value_free
                 "/health?query=PLACEHOLDER_QUERY",
                 headers={
                     "traceparent": TRACEPARENT,
+                    "tracestate": "vendor=OPAQUE_TRACE_STATE_SENTINEL",
                     "authorization": "PLACEHOLDER_AUTH",
                 },
             )
@@ -191,7 +210,6 @@ def test_http_middleware_adopts_valid_context_and_ignores_bad_context_value_free
 
     allowed = {
         "http.request.method",
-        "server.address",
         "server.port",
         "http.response.status_code",
     }
@@ -200,9 +218,20 @@ def test_http_middleware_adopts_valid_context_and_ignores_bad_context_value_free
     assert "PLACEHOLDER_QUERY" not in exported
     assert "PLACEHOLDER_AUTH" not in exported
     assert malformed not in exported
+    assert "OPAQUE_TRACE_STATE_SENTINEL" not in exported
     warnings = " ".join(record.getMessage() for record in caplog.records)
     assert warnings.count("ignored malformed trace context") == 1
     assert malformed not in warnings
+    assert all("server.address" not in _attrs(span) for span in health_spans)
+    logs = _logs(otlp_capture)
+    assert [record.body.string_value for record in logs] == [
+        "http.server.completed",
+        "http.server.completed",
+        "http.server.completed",
+    ]
+    span_by_identity = {(span.trace_id, span.span_id) for span in health_spans}
+    assert all((record.trace_id, record.span_id) in span_by_identity for record in logs)
+    assert all(record.severity_text == "INFO" for record in logs)
 
 
 def test_channel_turn_writes_one_payload_plus_carrier_and_keeps_langfuse_identity(

--- a/apps/api/tests/test_telemetry.py
+++ b/apps/api/tests/test_telemetry.py
@@ -118,6 +118,25 @@ def valkey(runs_stream: str) -> Iterator[redis.Redis]:
         client.close()
 
 
+@pytest.fixture
+def channel_settings(
+    clean_db: None,
+    auth_headers: dict[str, str],
+    runs_stream: str,
+) -> Iterator[tuple[dict[str, str], str]]:
+    """Apply the per-test stream after every settings-consuming DB fixture."""
+
+    # ``auth_headers`` and the disposable-DB bootstrap both legitimately read
+    # the cached settings.  RUNS_STREAM must win after those reads so the app
+    # and the assertion observe the same isolated stream regardless of pytest's
+    # otherwise-unrelated fixture ordering.
+    get_settings.cache_clear()
+    try:
+        yield auth_headers, runs_stream
+    finally:
+        get_settings.cache_clear()
+
+
 def _any_value(value: Any) -> object:
     selected = value.WhichOneof("value")
     if selected == "string_value":
@@ -187,13 +206,11 @@ def test_http_middleware_adopts_valid_context_and_ignores_bad_context_value_free
 
 
 def test_channel_turn_writes_one_payload_plus_carrier_and_keeps_langfuse_identity(
-    _disposable_db: Any,
-    clean_db: None,
-    auth_headers: dict[str, str],
+    channel_settings: tuple[dict[str, str], str],
     otlp_capture: _OtlpCapture,
     valkey: redis.Redis,
-    runs_stream: str,
 ) -> None:
+    auth_headers, runs_stream = channel_settings
     with TestClient(create_app()) as client:
         created = client.post(
             "/agents",

--- a/apps/api/tests/test_telemetry.py
+++ b/apps/api/tests/test_telemetry.py
@@ -1,0 +1,292 @@
+"""API tracing and the API-owned Valkey producer boundary."""
+
+from __future__ import annotations
+
+import asyncio
+import gzip
+import json
+import logging
+import threading
+import uuid
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+
+import pytest
+import redis
+import redis.asyncio as aioredis
+from aci_protocol import QueuedTurn
+from curie_api.config import get_settings
+from curie_api.delivery import enqueue_owned
+from curie_api.main import create_app
+from curie_telemetry.carrier import TRACE_CONTEXT_FIELD
+from curie_test_support.valkey import (
+    VALKEY_HOST as _VALKEY_HOST,
+)
+from curie_test_support.valkey import (
+    VALKEY_PORT as _VALKEY_PORT,
+)
+from curie_test_support.valkey import (
+    VALKEY_PW as _VALKEY_PW,
+)
+from curie_test_support.valkey import (
+    connect_or_skip,
+)
+from fastapi.testclient import TestClient
+from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (
+    ExportTraceServiceRequest,
+)
+
+TRACE_ID = "11111111111111111111111111111111"
+PARENT_ID = "2222222222222222"
+TRACEPARENT = f"00-{TRACE_ID}-{PARENT_ID}-01"
+TURN_TEXT = "PLACEHOLDER_TURN_TEXT"
+
+
+@dataclass
+class _OtlpCapture:
+    server: ThreadingHTTPServer
+    traces: list[ExportTraceServiceRequest] = field(default_factory=list)
+
+    @property
+    def endpoint(self) -> str:
+        host, port = self.server.server_address
+        return f"http://{host}:{port}"
+
+
+def _handler(capture_ref: list[_OtlpCapture]) -> type[BaseHTTPRequestHandler]:
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self) -> None:  # noqa: N802
+            length = int(self.headers.get("content-length", "0"))
+            body = self.rfile.read(length)
+            if self.headers.get("content-encoding") == "gzip":
+                body = gzip.decompress(body)
+            if self.path == "/v1/traces":
+                request = ExportTraceServiceRequest()
+                request.ParseFromString(body)
+                capture_ref[0].traces.append(request)
+            assert self.path in {"/v1/traces", "/v1/logs"}
+            self.send_response(200)
+            self.end_headers()
+
+        def log_message(self, _format: str, *_args: object) -> None:
+            return
+
+    return Handler
+
+
+@pytest.fixture
+def otlp_capture(monkeypatch: pytest.MonkeyPatch) -> Iterator[_OtlpCapture]:
+    capture_ref: list[_OtlpCapture] = []
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _handler(capture_ref))
+    server.daemon_threads = True
+    capture = _OtlpCapture(server)
+    capture_ref.append(capture)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", capture.endpoint)
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf")
+    try:
+        yield capture
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+@pytest.fixture
+def runs_stream(monkeypatch: pytest.MonkeyPatch) -> Iterator[str]:
+    stream = f"test:curie:runs:otel:{uuid.uuid4().hex}"
+    monkeypatch.setenv("RUNS_STREAM", stream)
+    get_settings.cache_clear()
+    try:
+        yield stream
+    finally:
+        get_settings.cache_clear()
+
+
+@pytest.fixture
+def valkey(runs_stream: str) -> Iterator[redis.Redis]:
+    client = connect_or_skip(decode_responses=True)
+    try:
+        yield client
+    finally:
+        client.delete(runs_stream)
+        for key in client.scan_iter(match="test:curie:otel:*"):
+            client.delete(key)
+        client.close()
+
+
+def _any_value(value: Any) -> object:
+    selected = value.WhichOneof("value")
+    if selected == "string_value":
+        return value.string_value
+    if selected == "bool_value":
+        return value.bool_value
+    if selected == "int_value":
+        return value.int_value
+    return None
+
+
+def _attrs(span: Any) -> dict[str, object]:
+    return {item.key: _any_value(item.value) for item in span.attributes}
+
+
+def _spans(capture: _OtlpCapture) -> list[Any]:
+    return [
+        span
+        for request in capture.traces
+        for resource_spans in request.resource_spans
+        for scope_spans in resource_spans.scope_spans
+        for span in scope_spans.spans
+    ]
+
+
+def test_http_middleware_adopts_valid_context_and_ignores_bad_context_value_free(
+    otlp_capture: _OtlpCapture,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    malformed = "MALFORMED_TRACE_CONTEXT_SENTINEL"
+    with caplog.at_level(logging.WARNING, logger="curie_api"):
+        with TestClient(create_app()) as client:
+            inherited = client.get(
+                "/health?query=PLACEHOLDER_QUERY",
+                headers={
+                    "traceparent": TRACEPARENT,
+                    "authorization": "PLACEHOLDER_AUTH",
+                },
+            )
+            missing = client.get("/health")
+            bad = client.get("/health", headers={"traceparent": malformed})
+
+    assert inherited.status_code == missing.status_code == bad.status_code == 200
+    health_spans = [span for span in _spans(otlp_capture) if span.name == "GET /health"]
+    assert len(health_spans) == 3
+    inherited_span = next(
+        span for span in health_spans if span.trace_id == bytes.fromhex(TRACE_ID)
+    )
+    assert inherited_span.parent_span_id == bytes.fromhex(PARENT_ID)
+    rooted = [span for span in health_spans if span is not inherited_span]
+    assert all(not span.parent_span_id for span in rooted)
+
+    allowed = {
+        "http.request.method",
+        "server.address",
+        "server.port",
+        "http.response.status_code",
+    }
+    assert all(set(_attrs(span)) <= allowed for span in health_spans)
+    exported = repr(health_spans)
+    assert "PLACEHOLDER_QUERY" not in exported
+    assert "PLACEHOLDER_AUTH" not in exported
+    assert malformed not in exported
+    warnings = " ".join(record.getMessage() for record in caplog.records)
+    assert warnings.count("ignored malformed trace context") == 1
+    assert malformed not in warnings
+
+
+def test_channel_turn_writes_one_payload_plus_carrier_and_keeps_langfuse_identity(
+    _disposable_db: Any,
+    clean_db: None,
+    auth_headers: dict[str, str],
+    otlp_capture: _OtlpCapture,
+    valkey: redis.Redis,
+    runs_stream: str,
+) -> None:
+    with TestClient(create_app()) as client:
+        created = client.post(
+            "/agents",
+            headers=auth_headers,
+            json={
+                "name": "acme-otel-api",
+                "channel": {
+                    "kind": "email",
+                    "address": "otel@example.test",
+                    "endpoint": "http://adapter.example.test/reply",
+                    "adapter": "agentmail-sandbox",
+                },
+            },
+        )
+        assert created.status_code == 201, created.text
+        agent_id = created.json()["id"]
+        accepted = client.post(
+            "/channels/turns",
+            headers={**auth_headers, "traceparent": TRACEPARENT},
+            json={
+                "kind": "email",
+                "address": "otel@example.test",
+                "delivery_id": "delivery-otel-api",
+                "conversation_id": "thread-otel-api",
+                "author": "user@example.test",
+                "text": TURN_TEXT,
+                "reply_ref": "reply-otel-api",
+            },
+        )
+        assert accepted.status_code == 200, accepted.text
+
+    [(stream_id, fields)] = valkey.xrange(runs_stream)
+    assert stream_id == accepted.json()["stream_id"]
+    assert set(fields) == {"payload", TRACE_CONTEXT_FIELD}
+    turn = QueuedTurn.model_validate_json(fields["payload"])
+    assert turn.text == TURN_TEXT
+    assert TRACE_CONTEXT_FIELD not in json.loads(fields["payload"])
+
+    spans = _spans(otlp_capture)
+    producer = next(span for span in spans if span.name == "send curie:runs")
+    server = next(span for span in spans if span.span_id == producer.parent_span_id)
+    assert server.trace_id == producer.trace_id == bytes.fromhex(TRACE_ID)
+    assert server.parent_span_id == bytes.fromhex(PARENT_ID)
+    producer_attrs = _attrs(producer)
+    assert producer_attrs["messaging.system"] == "valkey"
+    assert producer_attrs["messaging.destination.name"] == runs_stream
+    assert producer_attrs["messaging.operation.type"] == "send"
+
+    session_id = f"agent-{agent_id}-thread-{turn.conversation_id}"
+    server_attrs = _attrs(server)
+    assert server_attrs["langfuse.trace.name"] == f"curie-run:{session_id}"
+    assert server_attrs["langfuse.session.id"] == session_id
+    assert server_attrs["langfuse.user.id"] == turn.author
+
+    carrier = json.loads(fields[TRACE_CONTEXT_FIELD])
+    assert carrier["traceparent"].startswith(
+        f"00-{TRACE_ID}-{producer.span_id.hex()}-"
+    )
+    exported = repr(spans)
+    assert TURN_TEXT not in exported
+    assert "reply-otel-api" not in exported
+    assert "authorization" not in exported.lower()
+
+
+def test_owner_checked_enqueue_without_a_carrier_remains_payload_only(
+    valkey: redis.Redis, runs_stream: str
+) -> None:
+    async def exercise() -> dict[str, str]:
+        client = aioredis.Redis(
+            host=_VALKEY_HOST,
+            port=_VALKEY_PORT,
+            password=_VALKEY_PW or None,
+            decode_responses=True,
+        )
+        key = f"test:curie:otel:{uuid.uuid4().hex}"
+        owner = "pending:legacy-owner"
+        try:
+            await client.set(key, owner, ex=60)
+            enqueued, _stream_id = await enqueue_owned(
+                client,
+                key=key,
+                stream=runs_stream,
+                owner=owner,
+                payload='{"legacy":"payload"}',
+                payload_field="payload",
+                lease_s=60,
+            )
+            assert enqueued
+            [(_entry_id, fields)] = await client.xrange(runs_stream)
+            return fields
+        finally:
+            await client.delete(key)
+            await client.aclose()
+
+    fields = asyncio.run(exercise())
+    assert fields == {"payload": '{"legacy":"payload"}'}

--- a/apps/dispatcher/CLAUDE.md
+++ b/apps/dispatcher/CLAUDE.md
@@ -25,11 +25,12 @@ summary.
   no scan. Order is always claim -> post placeholder -> `XADD`, so a
   duplicate delivery can never produce a second placeholder. Do not reorder
   these three steps.
-- **The queue seam is one `payload` field, not a multi-field Stream entry.**
-  Each Stream entry carries a single `payload` field holding the
-  `QueuedTurn` JSON. This lets fields be added to the payload without
-  reshaping the Stream schema itself -- do not add a second top-level Stream
-  field for a new piece of data; put it inside the JSON payload.
+- **The queue seam is one domain `payload`, with transport metadata kept
+  outside it.** Each Stream entry carries `payload` holding the `QueuedTurn`
+  JSON. An optional bounded W3C Trace Context carrier is the one sanctioned
+  sibling field: it belongs to the Valkey transport, never the frozen domain
+  model, and payload-only legacy entries remain valid. New domain data still
+  goes through the frozen-contract process; do not grow ad hoc Stream fields.
 - **Reconnects are the supervisor's job, not the Slack client's.** The Bolt
   socket client self-heals transient drops; `dispatcher.supervisor.Supervisor`
   is the outer net for failures the client cannot recover from (connect

--- a/apps/dispatcher/README.md
+++ b/apps/dispatcher/README.md
@@ -12,8 +12,10 @@ run orchestration are the worker's job, not the dispatcher's.
 ## The queue seam (what the worker consumes)
 
 The dispatcher `XADD`s onto a Valkey Stream (`CURIE_STREAM`, default
-`curie:runs`). Each entry carries one field, `payload`, holding the JSON of a
-`QueuedTurn` (from `aci_protocol`). Its fields are channel-neutral; the
+`curie:runs`). Each entry carries `payload`, holding the JSON of a `QueuedTurn`
+(from `aci_protocol`), plus optional transport-owned W3C Trace Context metadata
+when a producer span is active. The carrier is not part of `QueuedTurn`; legacy
+payload-only entries remain valid. Its domain fields are channel-neutral; the
 parenthetical is what the Slack adapter maps onto each one:
 
 | field | meaning |
@@ -29,9 +31,9 @@ The worker reconstructs it with `from_stream_fields(fields)`, a module-level
 helper in `curie_dispatcher.queue`. The model lives in the frozen `aci_protocol`
 package (promoted out of the dispatcher in issue #7) so the producer and the
 Rust/TS consumers share one schema-gated contract instead of a hand-mirrored copy;
-the dispatcher's queue module owns only the Stream transport of it. The
-single-`payload`-field encoding keeps the seam explicit and lets fields be added
-without reshaping the Stream schema.
+the dispatcher's queue module owns only the Stream transport of it. Domain data
+stays inside `payload`; the only sibling field is the optional, bounded trace
+carrier consumed by the worker at the async boundary.
 
 ## Dedupe (idempotency)
 

--- a/apps/dispatcher/pyproject.toml
+++ b/apps/dispatcher/pyproject.toml
@@ -5,6 +5,7 @@ description = "Curie dispatcher (Slack Bolt for Python, Socket Mode): ack + enqu
 requires-python = ">=3.13"
 dependencies = [
     "aci-protocol",
+    "curie-telemetry",
     "slack-bolt>=1.30.0",
     "redis>=5.2",
     "pydantic>=2.10",

--- a/apps/dispatcher/src/curie_dispatcher/app.py
+++ b/apps/dispatcher/src/curie_dispatcher/app.py
@@ -13,6 +13,7 @@ from collections.abc import Callable
 from typing import Any
 
 import redis
+from opentelemetry.trace import Tracer
 from slack_bolt import App
 from slack_bolt.adapter.socket_mode import SocketModeHandler
 from slack_sdk.web import WebClient
@@ -69,6 +70,7 @@ def build_app(
     authorize: Callable[..., Any] | None = None,
     logger: logging.Logger | None = None,
     resolver: Any | None = None,
+    tracer: Tracer | None = None,
 ) -> App:
     """Build a Bolt App with the dispatcher's handlers registered."""
     signing = config.slack_signing_secret or _SOCKET_MODE_SIGNING_PLACEHOLDER
@@ -91,6 +93,7 @@ def build_app(
         "redis_client": redis_client,
         "config": config,
         "logger": logger,
+        "tracer": tracer,
     }
     if clock is not None:
         register_kwargs["clock"] = clock

--- a/apps/dispatcher/src/curie_dispatcher/handlers.py
+++ b/apps/dispatcher/src/curie_dispatcher/handlers.py
@@ -18,11 +18,15 @@ dispatcher's.
 
 import logging
 import re
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
+import httpx
 from aci_protocol import QueuedTurn, ReplyHandle, TurnSource
+from curie_telemetry import set_turn_identity
+from opentelemetry.trace import Span, SpanKind, Status, StatusCode, Tracer
 from slack_bolt import App
 from slack_sdk.web import WebClient
 
@@ -66,6 +70,93 @@ def is_actionable(event: dict[str, Any]) -> bool:
     return True
 
 
+@contextmanager
+def _producer_span(
+    tracer: Tracer | None, config: DispatcherConfig
+) -> Iterator[Span | None]:
+    if tracer is None:
+        yield None
+        return
+    with tracer.start_as_current_span(
+        "send curie:runs",
+        kind=SpanKind.PRODUCER,
+        attributes={
+            "messaging.system": "valkey",
+            "messaging.destination.name": config.stream,
+            "messaging.operation.type": "send",
+        },
+        record_exception=False,
+        set_status_on_exception=False,
+    ) as span:
+        try:
+            yield span
+        except BaseException as exc:
+            error_type = type(exc).__name__
+            span.set_attribute("error.type", error_type)
+            span.set_attribute("exception.type", error_type)
+            span.set_attribute("exception.escaped", True)
+            span.set_status(Status(StatusCode.ERROR))
+            raise
+        else:
+            span.set_status(Status(StatusCode.OK))
+
+
+def _stamp_agent_identity_after_enqueue(
+    *,
+    span: Span | None,
+    config: DispatcherConfig,
+    channel: str,
+    conversation_id: str,
+    user_id: str,
+    logger: logging.Logger,
+) -> None:
+    """Resolve the incumbent identity after XADD, bounded and fail open."""
+
+    if span is None or not span.is_recording():
+        return
+    try:
+        response = httpx.get(
+            f"{config.api_base_url.rstrip('/')}/agents",
+            headers={"X-API-Key": config.api_key},
+            timeout=min(config.api_preflight_timeout_s, 2.0),
+        )
+        response.raise_for_status()
+        body = response.json()
+        matches: list[dict[str, Any]] = []
+        if isinstance(body, list):
+            for item in body:
+                if not isinstance(item, dict):
+                    continue
+                binding = item.get("channel")
+                if (
+                    isinstance(binding, dict)
+                    and binding.get("kind") == "slack"
+                    and binding.get("address") == channel
+                    and item.get("id")
+                ):
+                    matches.append(item)
+    except Exception:  # lookup is compatibility metadata, never durability
+        span.add_event("dispatcher.agent_lookup.unavailable")
+        logger.warning(
+            "agent lookup unavailable after durable enqueue; trace identity omitted"
+        )
+        return
+
+    if len(matches) != 1:
+        span.add_event("dispatcher.agent_lookup.unavailable")
+        logger.warning(
+            "agent lookup ambiguous after durable enqueue; trace identity omitted"
+        )
+        return
+    set_turn_identity(
+        span,
+        agent_id=matches[0]["id"],
+        conversation_id=conversation_id,
+        user_id=user_id,
+    )
+    span.add_event("dispatcher.agent_lookup.resolved")
+
+
 def process_event(
     *,
     body: dict[str, Any],
@@ -75,6 +166,7 @@ def process_event(
     config: DispatcherConfig,
     clock: Clock = _utc_now_iso,
     logger: logging.Logger | None = None,
+    tracer: Tracer | None = None,
 ) -> str | None:
     """Dedupe, post the placeholder, and enqueue one Slack event.
 
@@ -87,53 +179,75 @@ def process_event(
         return None
 
     slack_event_id = body["event_id"]
+    with _producer_span(tracer, config) as span:
+        if span is not None:
+            span.add_event("dispatcher.dedupe.checked")
+        if not claim_event(redis_client, config, slack_event_id):
+            if span is not None:
+                span.add_event("dispatcher.dedupe.skip")
+            log.info("duplicate slack event %s, skipping", slack_event_id)
+            return None
 
-    if not claim_event(redis_client, config, slack_event_id):
-        log.info("duplicate slack event %s, skipping", slack_event_id)
-        return None
+        # Reply in-thread: for a root message the thread key is its own ts.
+        thread_ts = event.get("thread_ts") or event["ts"]
+        channel = event["channel"]
 
-    # Reply in-thread: for a root message the thread key is its own ts.
-    thread_ts = event.get("thread_ts") or event["ts"]
-    channel = event["channel"]
+        placeholder = web_client.chat_postMessage(
+            channel=channel,
+            thread_ts=thread_ts,
+            text=config.placeholder_text,
+        )
+        if span is not None:
+            span.add_event("dispatcher.placeholder.posted")
+        placeholder_ts = placeholder["ts"]
 
-    placeholder = web_client.chat_postMessage(
-        channel=channel,
-        thread_ts=thread_ts,
-        text=config.placeholder_text,
-    )
-    placeholder_ts = placeholder["ts"]
-
-    # Nothing else goes between the placeholder and the XADD below. The Slack
-    # assistant-thread status ("shimmer") used to sit right here, and it was the
-    # wrong side of the durable write (#1312): a best-effort cosmetic call, whose
-    # own failures are swallowed at debug, gating the only moment this turn
-    # becomes recoverable. slack_sdk's retry handler puts the worst case near
-    # 4.5s (see app.py's timeout constant), and Bolt has five shared listener
-    # workers, so a handful of slow status calls could stall ingestion with no
-    # visible explanation. The worker raises and lowers the shimmer now, which
-    # also puts set and clear in one process instead of racing across two.
-    queued = QueuedTurn(
-        event_id=slack_event_id,
-        conversation_id=thread_ts,
-        author=event.get("user", ""),
-        text=event.get("text", ""),
-        # A person spoke, so this turn MAY steer a live one. Stated rather than
-        # left to the model default for the same reason `kind` is: a producer
-        # that does not say what it is produces turns nobody can audit.
-        source=TurnSource.SLACK,
-        # The literal "slack" is this dispatcher stating what it is; it never
-        # comes from config, because a Slack Socket Mode dispatcher that could
-        # claim another kind is a misrouting vector. `adapter=None` is explicit
-        # rather than defaulted so a reader sees that Slack's route is the
-        # worker's configured origin, not an oversight (ADR-0096 D4.4).
-        reply_handle=ReplyHandle(
-            kind="slack", channel=channel, placeholder=placeholder_ts, adapter=None
-        ),
-        received_at=clock(),
-    )
-    stream_id = enqueue(redis_client, config, queued)
-    log.info("enqueued slack event %s as stream entry %s", slack_event_id, stream_id)
-    return stream_id
+        # Nothing else goes between the placeholder and the XADD below. The Slack
+        # assistant-thread status ("shimmer") used to sit right here, and it was
+        # the wrong side of the durable write (#1312): a best-effort cosmetic call,
+        # whose own failures are swallowed at debug, gating the only moment this
+        # turn becomes recoverable. slack_sdk's retry handler puts the worst case
+        # near 4.5s (see app.py's timeout constant), and Bolt has five shared
+        # listener workers, so a handful of slow status calls could stall
+        # ingestion with no visible explanation. The worker raises and lowers the
+        # shimmer now, which also puts set and clear in one process instead of
+        # racing across two.
+        queued = QueuedTurn(
+            event_id=slack_event_id,
+            conversation_id=thread_ts,
+            author=event.get("user", ""),
+            text=event.get("text", ""),
+            # A person spoke, so this turn MAY steer a live one. Stated rather than
+            # left to the model default for the same reason `kind` is: a producer
+            # that does not say what it is produces turns nobody can audit.
+            source=TurnSource.SLACK,
+            # The literal "slack" is this dispatcher stating what it is; it never
+            # comes from config, because a Slack Socket Mode dispatcher that could
+            # claim another kind is a misrouting vector. `adapter=None` is explicit
+            # rather than defaulted so a reader sees that Slack's route is the
+            # worker's configured origin, not an oversight (ADR-0096 D4.4).
+            reply_handle=ReplyHandle(
+                kind="slack",
+                channel=channel,
+                placeholder=placeholder_ts,
+                adapter=None,
+            ),
+            received_at=clock(),
+        )
+        stream_id = enqueue(redis_client, config, queued)
+        if span is not None:
+            span.add_event("messaging.enqueued")
+        _stamp_agent_identity_after_enqueue(
+            span=span,
+            config=config,
+            channel=channel,
+            conversation_id=thread_ts,
+            user_id=queued.author,
+            logger=log,
+        )
+        log.info(
+            "enqueued slack event %s as stream entry %s", slack_event_id, stream_id
+        )
+        return stream_id
 
 
 def action_command(action: dict[str, Any]) -> str:
@@ -152,6 +266,7 @@ def process_action(
     config: DispatcherConfig,
     clock: Clock = _utc_now_iso,
     logger: logging.Logger | None = None,
+    tracer: Tracer | None = None,
 ) -> str | None:
     """Normalize a Block Kit button click into a turn: dedupe, post an in-thread
     placeholder, and enqueue a ``QueuedTurn`` whose text is the button's
@@ -196,33 +311,54 @@ def process_action(
         f"{actions[0].get('action_ts', '')}-{actions[0].get('action_id', '')}"
     )
     slack_event_id = f"action-{interaction}"
-    if not claim_event(redis_client, config, slack_event_id):
-        log.info("duplicate block action %s, skipping", slack_event_id)
-        return None
+    with _producer_span(tracer, config) as span:
+        if span is not None:
+            span.add_event("dispatcher.dedupe.checked")
+        if not claim_event(redis_client, config, slack_event_id):
+            if span is not None:
+                span.add_event("dispatcher.dedupe.skip")
+            log.info("duplicate block action %s, skipping", slack_event_id)
+            return None
 
-    user = (body.get("user") or {}).get("id", "")
-
-    placeholder = web_client.chat_postMessage(
-        channel=channel,
-        thread_ts=thread_ts,
-        text=config.placeholder_text,
-    )
-    queued = QueuedTurn(
-        event_id=slack_event_id,
-        conversation_id=thread_ts,
-        author=user,
-        text=command,
-        # A person clicked a button. Still a person, still steerable.
-        source=TurnSource.SLACK,
-        # Same literal, same reason, on the sibling lane (ADR-0096 D4.4).
-        reply_handle=ReplyHandle(
-            kind="slack", channel=channel, placeholder=placeholder["ts"], adapter=None
-        ),
-        received_at=clock(),
-    )
-    stream_id = enqueue(redis_client, config, queued)
-    log.info("enqueued block action %s as stream entry %s", slack_event_id, stream_id)
-    return stream_id
+        user = (body.get("user") or {}).get("id", "")
+        placeholder = web_client.chat_postMessage(
+            channel=channel,
+            thread_ts=thread_ts,
+            text=config.placeholder_text,
+        )
+        if span is not None:
+            span.add_event("dispatcher.placeholder.posted")
+        queued = QueuedTurn(
+            event_id=slack_event_id,
+            conversation_id=thread_ts,
+            author=user,
+            text=command,
+            # A person clicked a button. Still a person, still steerable.
+            source=TurnSource.SLACK,
+            # Same literal, same reason, on the sibling lane (ADR-0096 D4.4).
+            reply_handle=ReplyHandle(
+                kind="slack",
+                channel=channel,
+                placeholder=placeholder["ts"],
+                adapter=None,
+            ),
+            received_at=clock(),
+        )
+        stream_id = enqueue(redis_client, config, queued)
+        if span is not None:
+            span.add_event("messaging.enqueued")
+        _stamp_agent_identity_after_enqueue(
+            span=span,
+            config=config,
+            channel=channel,
+            conversation_id=thread_ts,
+            user_id=user,
+            logger=log,
+        )
+        log.info(
+            "enqueued block action %s as stream entry %s", slack_event_id, stream_id
+        )
+        return stream_id
 
 
 def register_handlers(
@@ -234,6 +370,7 @@ def register_handlers(
     clock: Clock = _utc_now_iso,
     logger: logging.Logger | None = None,
     resolver: ApprovalResolveClient | None = None,
+    tracer: Tracer | None = None,
 ) -> None:
     """Wire the app_mention, (direct-message) message, block-action, and
     approval-card listeners. ``resolver`` (the approvals API client) is
@@ -251,6 +388,7 @@ def register_handlers(
             config=config,
             clock=clock,
             logger=logger,
+            tracer=tracer,
         )
 
     @app.event("message")
@@ -265,6 +403,7 @@ def register_handlers(
             config=config,
             clock=clock,
             logger=logger,
+            tracer=tracer,
         )
 
     # Approval-card clicks (#246): resolve through the API (which enforces the
@@ -378,4 +517,5 @@ def register_handlers(
             config=config,
             clock=clock,
             logger=logger,
+            tracer=tracer,
         )

--- a/apps/dispatcher/src/curie_dispatcher/handlers.py
+++ b/apps/dispatcher/src/curie_dispatcher/handlers.py
@@ -50,6 +50,7 @@ if TYPE_CHECKING:
     from redis import Redis
 
 Clock = Callable[[], str]
+_telemetry_logger = logging.getLogger(__name__)
 
 
 def _utc_now_iso() -> str:
@@ -179,7 +180,7 @@ def process_event(
         stream_id = enqueue(redis_client, config, queued)
         if span is not None:
             span.add_event("messaging.enqueued")
-        emit_log_event(log, "dispatcher.turn.enqueued")
+        emit_log_event(_telemetry_logger, "dispatcher.turn.enqueued")
         log.info(
             "enqueued slack event %s as stream entry %s", slack_event_id, stream_id
         )
@@ -283,7 +284,7 @@ def process_action(
         stream_id = enqueue(redis_client, config, queued)
         if span is not None:
             span.add_event("messaging.enqueued")
-        emit_log_event(log, "dispatcher.turn.enqueued")
+        emit_log_event(_telemetry_logger, "dispatcher.turn.enqueued")
         log.info(
             "enqueued block action %s as stream entry %s", slack_event_id, stream_id
         )

--- a/apps/dispatcher/src/curie_dispatcher/handlers.py
+++ b/apps/dispatcher/src/curie_dispatcher/handlers.py
@@ -23,9 +23,8 @@ from contextlib import contextmanager
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
-import httpx
 from aci_protocol import QueuedTurn, ReplyHandle, TurnSource
-from curie_telemetry import set_turn_identity
+from curie_telemetry import emit_log_event
 from opentelemetry.trace import Span, SpanKind, Status, StatusCode, Tracer
 from slack_bolt import App
 from slack_sdk.web import WebClient
@@ -99,62 +98,6 @@ def _producer_span(
             raise
         else:
             span.set_status(Status(StatusCode.OK))
-
-
-def _stamp_agent_identity_after_enqueue(
-    *,
-    span: Span | None,
-    config: DispatcherConfig,
-    channel: str,
-    conversation_id: str,
-    user_id: str,
-    logger: logging.Logger,
-) -> None:
-    """Resolve the incumbent identity after XADD, bounded and fail open."""
-
-    if span is None or not span.is_recording():
-        return
-    try:
-        response = httpx.get(
-            f"{config.api_base_url.rstrip('/')}/agents",
-            headers={"X-API-Key": config.api_key},
-            timeout=min(config.api_preflight_timeout_s, 2.0),
-        )
-        response.raise_for_status()
-        body = response.json()
-        matches: list[dict[str, Any]] = []
-        if isinstance(body, list):
-            for item in body:
-                if not isinstance(item, dict):
-                    continue
-                binding = item.get("channel")
-                if (
-                    isinstance(binding, dict)
-                    and binding.get("kind") == "slack"
-                    and binding.get("address") == channel
-                    and item.get("id")
-                ):
-                    matches.append(item)
-    except Exception:  # lookup is compatibility metadata, never durability
-        span.add_event("dispatcher.agent_lookup.unavailable")
-        logger.warning(
-            "agent lookup unavailable after durable enqueue; trace identity omitted"
-        )
-        return
-
-    if len(matches) != 1:
-        span.add_event("dispatcher.agent_lookup.unavailable")
-        logger.warning(
-            "agent lookup ambiguous after durable enqueue; trace identity omitted"
-        )
-        return
-    set_turn_identity(
-        span,
-        agent_id=matches[0]["id"],
-        conversation_id=conversation_id,
-        user_id=user_id,
-    )
-    span.add_event("dispatcher.agent_lookup.resolved")
 
 
 def process_event(
@@ -236,14 +179,7 @@ def process_event(
         stream_id = enqueue(redis_client, config, queued)
         if span is not None:
             span.add_event("messaging.enqueued")
-        _stamp_agent_identity_after_enqueue(
-            span=span,
-            config=config,
-            channel=channel,
-            conversation_id=thread_ts,
-            user_id=queued.author,
-            logger=log,
-        )
+        emit_log_event(log, "dispatcher.turn.enqueued")
         log.info(
             "enqueued slack event %s as stream entry %s", slack_event_id, stream_id
         )
@@ -347,14 +283,7 @@ def process_action(
         stream_id = enqueue(redis_client, config, queued)
         if span is not None:
             span.add_event("messaging.enqueued")
-        _stamp_agent_identity_after_enqueue(
-            span=span,
-            config=config,
-            channel=channel,
-            conversation_id=thread_ts,
-            user_id=user,
-            logger=log,
-        )
+        emit_log_event(log, "dispatcher.turn.enqueued")
         log.info(
             "enqueued block action %s as stream entry %s", slack_event_id, stream_id
         )

--- a/apps/dispatcher/src/curie_dispatcher/queue.py
+++ b/apps/dispatcher/src/curie_dispatcher/queue.py
@@ -5,13 +5,14 @@ enqueues onto the Valkey Stream and the worker consumes. The model was promoted
 into the frozen ACI package (issue #7) so the contract is shared across three
 languages and guarded by the schema-compat gate rather than hand-mirrored. This
 module owns only the Valkey Stream *transport* of that model (a transport detail
-that stays out of the frozen package): the single-``payload`` wire encoding plus
-the dedupe guard.
+that stays out of the frozen package): the ``payload`` wire encoding, optional
+W3C trace carrier metadata, and the dedupe guard.
 
-Wire encoding: a Stream entry carries the model as a single ``payload`` field
-holding ``model_dump_json()``. A one-field JSON blob keeps the seam explicit and
-versionable (add fields without reshaping the Stream schema) and lets the worker
-reconstruct the model with ``from_stream_fields``.
+Wire encoding: a Stream entry carries the model as a ``payload`` field holding
+``model_dump_json()`` and, while a producer span is active, a separate optional
+``trace_context`` field. The model remains one JSON blob and the worker
+reconstructs it from only ``payload`` with ``from_stream_fields``; legacy
+payload-only entries therefore remain valid.
 
 Dedupe (idempotency, detailed-architecture 2b rule 5): the idempotency key is the
 delivery's ``event_id`` (the Slack event id for the Slack adapter). A retried
@@ -25,6 +26,7 @@ does not require scanning the Stream.
 from typing import Any, Protocol, cast, runtime_checkable
 
 from aci_protocol import STREAM_PAYLOAD_FIELD, QueuedTurn, parse_queued_turn
+from curie_telemetry import TRACE_CONTEXT_FIELD, inject_trace_context
 
 from .config import DispatcherConfig
 
@@ -52,8 +54,13 @@ class StreamPublisher(Protocol):
 
 
 def to_stream_fields(turn: QueuedTurn) -> dict[str, str]:
-    """Render a turn to the flat field map an ``XADD`` takes (one ``payload``)."""
-    return {STREAM_PAYLOAD_FIELD: turn.model_dump_json()}
+    """Render payload plus optional causal W3C transport metadata."""
+
+    fields = {STREAM_PAYLOAD_FIELD: turn.model_dump_json()}
+    carrier = inject_trace_context()
+    if carrier is not None:
+        fields[TRACE_CONTEXT_FIELD] = carrier
+    return fields
 
 
 def from_stream_fields(fields: dict[str, str]) -> QueuedTurn:

--- a/apps/dispatcher/src/curie_dispatcher/run.py
+++ b/apps/dispatcher/src/curie_dispatcher/run.py
@@ -9,6 +9,9 @@ and hands a Socket Mode connection factory to the supervisor. Run it with
 import logging
 import signal
 
+from curie_telemetry import configure
+from opentelemetry.trace import Tracer
+
 from .app import SocketModeConnection, build_app, build_redis, build_web_client
 from .config import DispatcherConfig
 from .heartbeat import start_heartbeat
@@ -16,11 +19,19 @@ from .preflight import ApiUnreachableError, check_api_reachable
 from .supervisor import BackoffPolicy, Supervisor
 
 
-def build_supervisor(config: DispatcherConfig, *, logger: logging.Logger) -> Supervisor:
+def build_supervisor(
+    config: DispatcherConfig, *, logger: logging.Logger, tracer: Tracer | None = None
+) -> Supervisor:
     """Assemble the supervisor and its Socket Mode connection factory from config."""
     redis_client = build_redis(config)
     web_client = build_web_client(config)
-    app = build_app(config, web_client=web_client, redis_client=redis_client, logger=logger)
+    app = build_app(
+        config,
+        web_client=web_client,
+        redis_client=redis_client,
+        logger=logger,
+        tracer=tracer,
+    )
 
     def connect() -> SocketModeConnection:
         return SocketModeConnection(app, config.slack_app_token, logger=logger)
@@ -36,33 +47,42 @@ def build_supervisor(config: DispatcherConfig, *, logger: logging.Logger) -> Sup
 def main() -> None:
     logging.basicConfig(level=logging.INFO)
     logger = logging.getLogger("curie_dispatcher")
-    config = DispatcherConfig()
-
-    # Gate on the platform API wiring before touching Slack: a dispatcher that
-    # cannot reach the API dead-ends every approval click (#442).
+    telemetry = configure(service_name="curie-dispatcher", service_version="0.0.0")
+    telemetry.attach_logging(logger)
     try:
-        check_api_reachable(config, logger=logger)
-    except ApiUnreachableError as exc:
-        logger.error("%s", exc)
-        raise SystemExit(1) from exc
+        config = DispatcherConfig()
 
-    supervisor = build_supervisor(config, logger=logger)
-    hb_stop = start_heartbeat(config.heartbeat_file, config.heartbeat_interval_s)
+        # Gate on the platform API wiring before touching Slack: a dispatcher
+        # that cannot reach the API dead-ends every approval click (#442).
+        try:
+            check_api_reachable(config, logger=logger)
+        except ApiUnreachableError as exc:
+            logger.error("%s", exc)
+            raise SystemExit(1) from exc
 
-    def _handle_signal(signum: int, _frame: object) -> None:
-        logger.info("received signal %s, shutting down", signum)
-        hb_stop.set()
-        supervisor.request_stop()
+        supervisor = build_supervisor(
+            config, logger=logger, tracer=telemetry.tracer
+        )
+        hb_stop = start_heartbeat(
+            config.heartbeat_file, config.heartbeat_interval_s
+        )
 
-    signal.signal(signal.SIGINT, _handle_signal)
-    signal.signal(signal.SIGTERM, _handle_signal)
+        def _handle_signal(signum: int, _frame: object) -> None:
+            logger.info("received signal %s, shutting down", signum)
+            hb_stop.set()
+            supervisor.request_stop()
 
-    logger.info("dispatcher starting")
-    try:
-        supervisor.run()
+        signal.signal(signal.SIGINT, _handle_signal)
+        signal.signal(signal.SIGTERM, _handle_signal)
+
+        logger.info("dispatcher starting")
+        try:
+            supervisor.run()
+        finally:
+            hb_stop.set()
+        logger.info("dispatcher stopped")
     finally:
-        hb_stop.set()
-    logger.info("dispatcher stopped")
+        telemetry.shutdown(timeout_millis=2000)
 
 
 if __name__ == "__main__":

--- a/apps/dispatcher/tests/test_telemetry.py
+++ b/apps/dispatcher/tests/test_telemetry.py
@@ -3,10 +3,8 @@
 from __future__ import annotations
 
 import json
-import threading
-from collections.abc import Iterator
-from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
-from unittest.mock import MagicMock
+import logging
+from unittest.mock import MagicMock, patch
 
 import pytest
 import redis
@@ -21,7 +19,6 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanE
 from opentelemetry.trace import SpanKind
 from slack_sdk.web import WebClient
 
-AGENT_ID = "11111111-1111-1111-1111-111111111111"
 CHANNEL = "C0EXAMPLE1"
 THREAD = "1700.0001"
 BOT_TS = "1700.0002"
@@ -116,73 +113,6 @@ class _OrderedPublisher:
         return self._client.xadd(*args, **kwargs)
 
 
-class _AgentLookupServer(ThreadingHTTPServer):
-    daemon_threads = True
-
-    def __init__(
-        self, redis_client: redis.Redis, stream: str, order: list[str]
-    ) -> None:
-        self.redis_client = redis_client
-        self.stream = stream
-        self.order = order
-        super().__init__(("127.0.0.1", 0), _agent_handler())
-
-
-def _agent_handler() -> type[BaseHTTPRequestHandler]:
-    class Handler(BaseHTTPRequestHandler):
-        def do_GET(self) -> None:  # noqa: N802
-            server = self.server
-            assert isinstance(server, _AgentLookupServer)
-            assert self.path.startswith("/agents")
-            assert self.headers.get("X-API-Key") == "test-api-key"
-            assert server.redis_client.xlen(server.stream) == 1
-            server.order.append("lookup")
-            body = json.dumps(
-                [
-                    {
-                        "id": AGENT_ID,
-                        "channel": {"kind": "slack", "address": CHANNEL},
-                    }
-                ]
-            ).encode()
-            self.send_response(200)
-            self.send_header("content-type", "application/json")
-            self.send_header("content-length", str(len(body)))
-            self.end_headers()
-            self.wfile.write(body)
-
-        def log_message(self, _format: str, *_args: object) -> None:
-            return
-
-    return Handler
-
-
-@pytest.fixture
-def agent_lookup_server(
-    redis_client: redis.Redis, config: DispatcherConfig
-) -> Iterator[tuple[_AgentLookupServer, list[str]]]:
-    order: list[str] = []
-    server = _AgentLookupServer(redis_client, config.stream, order)
-    thread = threading.Thread(target=server.serve_forever, daemon=True)
-    thread.start()
-    try:
-        yield server, order
-    finally:
-        server.shutdown()
-        server.server_close()
-        thread.join(timeout=2)
-
-
-def _traced_config(config: DispatcherConfig, server: _AgentLookupServer) -> DispatcherConfig:
-    host, port = server.server_address
-    return config.model_copy(
-        update={
-            "api_base_url": f"http://{host}:{port}",
-            "api_key": "test-api-key",
-        }
-    )
-
-
 def _web_client(order: list[str]) -> WebClient:
     client = WebClient(token="xoxb-test")
 
@@ -205,10 +135,9 @@ def _assert_producer(
     assert producer.attributes["messaging.system"] == "valkey"
     assert producer.attributes["messaging.destination.name"] == config.stream
     assert producer.attributes["messaging.operation.type"] == "send"
-    session_id = f"agent-{AGENT_ID}-thread-{THREAD}"
-    assert producer.attributes["langfuse.session.id"] == session_id
-    assert producer.attributes["langfuse.trace.name"] == f"curie-run:{session_id}"
-    assert producer.attributes["langfuse.user.id"] == "U0EXAMPLE1"
+    assert "langfuse.session.id" not in producer.attributes
+    assert "langfuse.trace.name" not in producer.attributes
+    assert "langfuse.user.id" not in producer.attributes
 
     _, fields = redis_client.xrange(config.stream)[0]
     carrier = json.loads(fields[TRACE_CONTEXT_FIELD])
@@ -221,85 +150,19 @@ def _assert_producer(
     assert "safe placeholder request" not in exported
 
 
-def test_message_claim_placeholder_xadd_lookup_order_and_producer_parentage(
+def test_message_claim_placeholder_xadd_order_producer_parentage_and_curated_log(
     redis_client: redis.Redis,
     config: DispatcherConfig,
-    agent_lookup_server: tuple[_AgentLookupServer, list[str]],
 ) -> None:
-    server, order = agent_lookup_server
-    traced_config = _traced_config(config, server)
+    order: list[str] = []
     provider, exporter = _provider()
     tracer = provider.get_tracer("dispatcher-handler")
     publisher = _OrderedPublisher(redis_client, order)
+    logger = logging.getLogger("curie_dispatcher.telemetry-test")
 
-    stream_id = process_event(
-        body={"event_id": "Ev-otel-message"},
-        event={
-            "type": "app_mention",
-            "channel": CHANNEL,
-            "user": "U0EXAMPLE1",
-            "text": "safe placeholder request",
-            "ts": THREAD,
-        },
-        web_client=_web_client(order),
-        redis_client=publisher,  # type: ignore[arg-type]
-        config=traced_config,
-        clock=lambda: "2026-08-23T00:00:00+00:00",
-        tracer=tracer,
-    )
-
-    assert stream_id
-    assert order == ["claim", "placeholder", "xadd", "lookup"]
-    _assert_producer(exporter, redis_client, traced_config)
-    provider.shutdown()
-
-
-def test_block_action_uses_the_same_producer_and_transport_metadata_path(
-    redis_client: redis.Redis,
-    config: DispatcherConfig,
-    agent_lookup_server: tuple[_AgentLookupServer, list[str]],
-) -> None:
-    server, order = agent_lookup_server
-    traced_config = _traced_config(config, server)
-    provider, exporter = _provider()
-    tracer = provider.get_tracer("dispatcher-action")
-    publisher = _OrderedPublisher(redis_client, order)
-
-    stream_id = process_action(
-        body={
-            "trigger_id": "trigger-otel",
-            "channel": {"id": CHANNEL},
-            "user": {"id": "U0EXAMPLE1"},
-            "message": {"ts": THREAD, "thread_ts": THREAD},
-            "actions": [{"action_id": "reports", "action_ts": "1.5"}],
-        },
-        web_client=_web_client(order),
-        redis_client=publisher,  # type: ignore[arg-type]
-        config=traced_config,
-        clock=lambda: "2026-08-23T00:00:00+00:00",
-        tracer=tracer,
-    )
-
-    assert stream_id
-    assert order == ["claim", "placeholder", "xadd", "lookup"]
-    _assert_producer(exporter, redis_client, traced_config)
-    provider.shutdown()
-
-
-def test_agent_lookup_failure_never_rolls_back_the_durable_enqueue(
-    redis_client: redis.Redis,
-    config: DispatcherConfig,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    provider, _ = _provider()
-    tracer = provider.get_tracer("dispatcher-lookup-failure")
-    unavailable = config.model_copy(
-        update={"api_base_url": "http://127.0.0.1:1", "api_key": "test-api-key"}
-    )
-
-    with caplog.at_level("WARNING"):
+    with patch("curie_dispatcher.handlers.emit_log_event") as emit:
         stream_id = process_event(
-            body={"event_id": "Ev-otel-lookup-failure"},
+            body={"event_id": "Ev-otel-message"},
             event={
                 "type": "app_mention",
                 "channel": CHANNEL,
@@ -307,16 +170,82 @@ def test_agent_lookup_failure_never_rolls_back_the_durable_enqueue(
                 "text": "safe placeholder request",
                 "ts": THREAD,
             },
-            web_client=_web_client([]),
-            redis_client=redis_client,
-            config=unavailable,
+            web_client=_web_client(order),
+            redis_client=publisher,  # type: ignore[arg-type]
+            config=config,
             clock=lambda: "2026-08-23T00:00:00+00:00",
+            logger=logger,
             tracer=tracer,
         )
 
     assert stream_id
+    assert order == ["claim", "placeholder", "xadd"]
+    emit.assert_called_once_with(logger, "dispatcher.turn.enqueued")
+    _assert_producer(exporter, redis_client, config)
+    provider.shutdown()
+
+
+def test_block_action_uses_the_same_producer_and_transport_metadata_path(
+    redis_client: redis.Redis,
+    config: DispatcherConfig,
+) -> None:
+    order: list[str] = []
+    provider, exporter = _provider()
+    tracer = provider.get_tracer("dispatcher-action")
+    publisher = _OrderedPublisher(redis_client, order)
+    logger = logging.getLogger("curie_dispatcher.telemetry-action-test")
+
+    with patch("curie_dispatcher.handlers.emit_log_event") as emit:
+        stream_id = process_action(
+            body={
+                "trigger_id": "trigger-otel",
+                "channel": {"id": CHANNEL},
+                "user": {"id": "U0EXAMPLE1"},
+                "message": {"ts": THREAD, "thread_ts": THREAD},
+                "actions": [{"action_id": "reports", "action_ts": "1.5"}],
+            },
+            web_client=_web_client(order),
+            redis_client=publisher,  # type: ignore[arg-type]
+            config=config,
+            clock=lambda: "2026-08-23T00:00:00+00:00",
+            logger=logger,
+            tracer=tracer,
+        )
+
+    assert stream_id
+    assert order == ["claim", "placeholder", "xadd"]
+    emit.assert_called_once_with(logger, "dispatcher.turn.enqueued")
+    _assert_producer(exporter, redis_client, config)
+    provider.shutdown()
+
+
+def test_dispatch_never_performs_a_post_enqueue_agent_lookup(
+    redis_client: redis.Redis,
+    config: DispatcherConfig,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider, _ = _provider()
+    tracer = provider.get_tracer("dispatcher-lookup-failure")
+    lookup = MagicMock(side_effect=AssertionError("dispatcher performed HTTP lookup"))
+    monkeypatch.setattr("httpx.get", lookup)
+
+    stream_id = process_event(
+        body={"event_id": "Ev-otel-no-lookup"},
+        event={
+            "type": "app_mention",
+            "channel": CHANNEL,
+            "user": "U0EXAMPLE1",
+            "text": "safe placeholder request",
+            "ts": THREAD,
+        },
+        web_client=_web_client([]),
+        redis_client=redis_client,
+        config=config,
+        clock=lambda: "2026-08-23T00:00:00+00:00",
+        tracer=tracer,
+    )
+
+    assert stream_id
     assert redis_client.xlen(config.stream) == 1
-    logged = " ".join(record.getMessage() for record in caplog.records)
-    assert "agent lookup" in logged.lower()
-    assert CHANNEL not in logged
+    lookup.assert_not_called()
     provider.shutdown()

--- a/apps/dispatcher/tests/test_telemetry.py
+++ b/apps/dispatcher/tests/test_telemetry.py
@@ -180,7 +180,10 @@ def test_message_claim_placeholder_xadd_order_producer_parentage_and_curated_log
 
     assert stream_id
     assert order == ["claim", "placeholder", "xadd"]
-    emit.assert_called_once_with(logger, "dispatcher.turn.enqueued")
+    emit.assert_called_once_with(
+        logging.getLogger("curie_dispatcher.handlers"),
+        "dispatcher.turn.enqueued",
+    )
     _assert_producer(exporter, redis_client, config)
     provider.shutdown()
 
@@ -214,12 +217,15 @@ def test_block_action_uses_the_same_producer_and_transport_metadata_path(
 
     assert stream_id
     assert order == ["claim", "placeholder", "xadd"]
-    emit.assert_called_once_with(logger, "dispatcher.turn.enqueued")
+    emit.assert_called_once_with(
+        logging.getLogger("curie_dispatcher.handlers"),
+        "dispatcher.turn.enqueued",
+    )
     _assert_producer(exporter, redis_client, config)
     provider.shutdown()
 
 
-def test_dispatch_never_performs_a_post_enqueue_agent_lookup(
+def test_dispatch_never_performs_a_post_enqueue_agent_lookup_or_rejects_custom_logger(
     redis_client: redis.Redis,
     config: DispatcherConfig,
     monkeypatch: pytest.MonkeyPatch,
@@ -242,6 +248,7 @@ def test_dispatch_never_performs_a_post_enqueue_agent_lookup(
         redis_client=redis_client,
         config=config,
         clock=lambda: "2026-08-23T00:00:00+00:00",
+        logger=logging.getLogger("external.application.diagnostics"),
         tracer=tracer,
     )
 

--- a/apps/dispatcher/tests/test_telemetry.py
+++ b/apps/dispatcher/tests/test_telemetry.py
@@ -1,0 +1,322 @@
+"""Dispatcher producer tracing across the real Valkey boundary."""
+
+from __future__ import annotations
+
+import json
+import threading
+from collections.abc import Iterator
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from unittest.mock import MagicMock
+
+import pytest
+import redis
+from aci_protocol import QueuedTurn, ReplyHandle
+from curie_dispatcher.config import DispatcherConfig
+from curie_dispatcher.handlers import process_action, process_event
+from curie_dispatcher.queue import enqueue, from_stream_fields, to_stream_fields
+from curie_telemetry.carrier import TRACE_CONTEXT_FIELD
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import SpanKind
+from slack_sdk.web import WebClient
+
+AGENT_ID = "11111111-1111-1111-1111-111111111111"
+CHANNEL = "C0EXAMPLE1"
+THREAD = "1700.0001"
+BOT_TS = "1700.0002"
+
+
+def _turn() -> QueuedTurn:
+    return QueuedTurn(
+        event_id="Ev-otel-queue",
+        conversation_id=THREAD,
+        author="U0EXAMPLE1",
+        text="safe placeholder request",
+        reply_handle=ReplyHandle(kind="slack", channel=CHANNEL, placeholder=BOT_TS),
+        received_at="2026-08-23T00:00:00+00:00",
+    )
+
+
+def _provider() -> tuple[TracerProvider, InMemorySpanExporter]:
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    return provider, exporter
+
+
+def test_to_stream_fields_injects_only_optional_transport_context() -> None:
+    provider, _ = _provider()
+    tracer = provider.get_tracer("dispatcher-queue-test")
+    turn = _turn()
+
+    with tracer.start_as_current_span("producer") as span:
+        fields = to_stream_fields(turn)
+        context = span.get_span_context()
+
+    assert set(fields) == {"payload", TRACE_CONTEXT_FIELD}
+    assert fields["payload"] == turn.model_dump_json()
+    assert QueuedTurn.model_validate_json(fields["payload"]) == turn
+    carrier = json.loads(fields[TRACE_CONTEXT_FIELD])
+    assert set(carrier) <= {"traceparent", "tracestate"}
+    assert carrier["traceparent"].startswith(
+        f"00-{context.trace_id:032x}-{context.span_id:016x}-"
+    )
+    assert TRACE_CONTEXT_FIELD not in json.loads(fields["payload"])
+    provider.shutdown()
+
+
+def test_payload_only_legacy_entry_remains_valid_and_extra_metadata_is_ignored() -> None:
+    turn = _turn()
+    assert to_stream_fields(turn) == {"payload": turn.model_dump_json()}
+    assert from_stream_fields({"payload": turn.model_dump_json()}) == turn
+    assert (
+        from_stream_fields(
+            {
+                "payload": turn.model_dump_json(),
+                TRACE_CONTEXT_FIELD: '{"traceparent":"00-invalid"}',
+            }
+        )
+        == turn
+    )
+
+
+def test_enqueue_writes_payload_and_current_carrier_atomically_to_real_valkey(
+    redis_client: redis.Redis, config: DispatcherConfig
+) -> None:
+    provider, _ = _provider()
+    tracer = provider.get_tracer("dispatcher-real-valkey")
+    turn = _turn()
+    with tracer.start_as_current_span("producer"):
+        stream_id = enqueue(redis_client, config, turn)
+
+    entries = redis_client.xrange(config.stream)
+    assert len(entries) == 1
+    entry_id, fields = entries[0]
+    assert entry_id == stream_id
+    assert set(fields) == {"payload", TRACE_CONTEXT_FIELD}
+    assert fields["payload"] == turn.model_dump_json()
+    assert from_stream_fields(fields) == turn
+    provider.shutdown()
+
+
+class _OrderedPublisher:
+    """Record calls while still delegating every broker operation to Valkey."""
+
+    def __init__(self, client: redis.Redis, order: list[str]) -> None:
+        self._client = client
+        self._order = order
+
+    def set(self, *args: object, **kwargs: object) -> object:
+        self._order.append("claim")
+        return self._client.set(*args, **kwargs)
+
+    def xadd(self, *args: object, **kwargs: object) -> object:
+        self._order.append("xadd")
+        return self._client.xadd(*args, **kwargs)
+
+
+class _AgentLookupServer(ThreadingHTTPServer):
+    daemon_threads = True
+
+    def __init__(
+        self, redis_client: redis.Redis, stream: str, order: list[str]
+    ) -> None:
+        self.redis_client = redis_client
+        self.stream = stream
+        self.order = order
+        super().__init__(("127.0.0.1", 0), _agent_handler())
+
+
+def _agent_handler() -> type[BaseHTTPRequestHandler]:
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # noqa: N802
+            server = self.server
+            assert isinstance(server, _AgentLookupServer)
+            assert self.path.startswith("/agents")
+            assert self.headers.get("X-API-Key") == "test-api-key"
+            assert server.redis_client.xlen(server.stream) == 1
+            server.order.append("lookup")
+            body = json.dumps(
+                [
+                    {
+                        "id": AGENT_ID,
+                        "channel": {"kind": "slack", "address": CHANNEL},
+                    }
+                ]
+            ).encode()
+            self.send_response(200)
+            self.send_header("content-type", "application/json")
+            self.send_header("content-length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, _format: str, *_args: object) -> None:
+            return
+
+    return Handler
+
+
+@pytest.fixture
+def agent_lookup_server(
+    redis_client: redis.Redis, config: DispatcherConfig
+) -> Iterator[tuple[_AgentLookupServer, list[str]]]:
+    order: list[str] = []
+    server = _AgentLookupServer(redis_client, config.stream, order)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server, order
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+def _traced_config(config: DispatcherConfig, server: _AgentLookupServer) -> DispatcherConfig:
+    host, port = server.server_address
+    return config.model_copy(
+        update={
+            "api_base_url": f"http://{host}:{port}",
+            "api_key": "test-api-key",
+        }
+    )
+
+
+def _web_client(order: list[str]) -> WebClient:
+    client = WebClient(token="xoxb-test")
+
+    def _placeholder(**_kwargs: object) -> dict[str, str]:
+        order.append("placeholder")
+        return {"ts": BOT_TS}
+
+    client.chat_postMessage = MagicMock(side_effect=_placeholder)  # type: ignore[method-assign]
+    return client
+
+
+def _assert_producer(
+    exporter: InMemorySpanExporter,
+    redis_client: redis.Redis,
+    config: DispatcherConfig,
+) -> None:
+    spans = exporter.get_finished_spans()
+    producer = next(span for span in spans if span.name == "send curie:runs")
+    assert producer.kind is SpanKind.PRODUCER
+    assert producer.attributes["messaging.system"] == "valkey"
+    assert producer.attributes["messaging.destination.name"] == config.stream
+    assert producer.attributes["messaging.operation.type"] == "send"
+    session_id = f"agent-{AGENT_ID}-thread-{THREAD}"
+    assert producer.attributes["langfuse.session.id"] == session_id
+    assert producer.attributes["langfuse.trace.name"] == f"curie-run:{session_id}"
+    assert producer.attributes["langfuse.user.id"] == "U0EXAMPLE1"
+
+    _, fields = redis_client.xrange(config.stream)[0]
+    carrier = json.loads(fields[TRACE_CONTEXT_FIELD])
+    assert carrier["traceparent"].startswith(
+        f"00-{producer.context.trace_id:032x}-{producer.context.span_id:016x}-"
+    )
+    exported = repr(dict(producer.attributes or {}))
+    assert "Ev-otel" not in exported
+    assert CHANNEL not in exported
+    assert "safe placeholder request" not in exported
+
+
+def test_message_claim_placeholder_xadd_lookup_order_and_producer_parentage(
+    redis_client: redis.Redis,
+    config: DispatcherConfig,
+    agent_lookup_server: tuple[_AgentLookupServer, list[str]],
+) -> None:
+    server, order = agent_lookup_server
+    traced_config = _traced_config(config, server)
+    provider, exporter = _provider()
+    tracer = provider.get_tracer("dispatcher-handler")
+    publisher = _OrderedPublisher(redis_client, order)
+
+    stream_id = process_event(
+        body={"event_id": "Ev-otel-message"},
+        event={
+            "type": "app_mention",
+            "channel": CHANNEL,
+            "user": "U0EXAMPLE1",
+            "text": "safe placeholder request",
+            "ts": THREAD,
+        },
+        web_client=_web_client(order),
+        redis_client=publisher,  # type: ignore[arg-type]
+        config=traced_config,
+        clock=lambda: "2026-08-23T00:00:00+00:00",
+        tracer=tracer,
+    )
+
+    assert stream_id
+    assert order == ["claim", "placeholder", "xadd", "lookup"]
+    _assert_producer(exporter, redis_client, traced_config)
+    provider.shutdown()
+
+
+def test_block_action_uses_the_same_producer_and_transport_metadata_path(
+    redis_client: redis.Redis,
+    config: DispatcherConfig,
+    agent_lookup_server: tuple[_AgentLookupServer, list[str]],
+) -> None:
+    server, order = agent_lookup_server
+    traced_config = _traced_config(config, server)
+    provider, exporter = _provider()
+    tracer = provider.get_tracer("dispatcher-action")
+    publisher = _OrderedPublisher(redis_client, order)
+
+    stream_id = process_action(
+        body={
+            "trigger_id": "trigger-otel",
+            "channel": {"id": CHANNEL},
+            "user": {"id": "U0EXAMPLE1"},
+            "message": {"ts": THREAD, "thread_ts": THREAD},
+            "actions": [{"action_id": "reports", "action_ts": "1.5"}],
+        },
+        web_client=_web_client(order),
+        redis_client=publisher,  # type: ignore[arg-type]
+        config=traced_config,
+        clock=lambda: "2026-08-23T00:00:00+00:00",
+        tracer=tracer,
+    )
+
+    assert stream_id
+    assert order == ["claim", "placeholder", "xadd", "lookup"]
+    _assert_producer(exporter, redis_client, traced_config)
+    provider.shutdown()
+
+
+def test_agent_lookup_failure_never_rolls_back_the_durable_enqueue(
+    redis_client: redis.Redis,
+    config: DispatcherConfig,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    provider, _ = _provider()
+    tracer = provider.get_tracer("dispatcher-lookup-failure")
+    unavailable = config.model_copy(
+        update={"api_base_url": "http://127.0.0.1:1", "api_key": "test-api-key"}
+    )
+
+    with caplog.at_level("WARNING"):
+        stream_id = process_event(
+            body={"event_id": "Ev-otel-lookup-failure"},
+            event={
+                "type": "app_mention",
+                "channel": CHANNEL,
+                "user": "U0EXAMPLE1",
+                "text": "safe placeholder request",
+                "ts": THREAD,
+            },
+            web_client=_web_client([]),
+            redis_client=redis_client,
+            config=unavailable,
+            clock=lambda: "2026-08-23T00:00:00+00:00",
+            tracer=tracer,
+        )
+
+    assert stream_id
+    assert redis_client.xlen(config.stream) == 1
+    logged = " ".join(record.getMessage() for record in caplog.records)
+    assert "agent lookup" in logged.lower()
+    assert CHANNEL not in logged
+    provider.shutdown()

--- a/apps/worker/pyproject.toml
+++ b/apps/worker/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "kubernetes>=36.0.3",
     "aci-protocol",
     "curie-channel-protocol",
+    "curie-telemetry",
     "plugin-format",
     "curie-dispatcher",
     "aiohttp>=3.11",

--- a/apps/worker/src/curie_worker/consumer.py
+++ b/apps/worker/src/curie_worker/consumer.py
@@ -42,7 +42,7 @@ import time
 from contextvars import ContextVar
 
 from curie_dispatcher.queue import from_stream_fields
-from curie_telemetry import TRACE_CONTEXT_FIELD, extract_trace_context
+from curie_telemetry import TRACE_CONTEXT_FIELD, emit_log_event, extract_trace_context
 from curie_telemetry.attributes import sanitize_attributes
 from opentelemetry import trace
 from opentelemetry.context import attach, detach
@@ -103,6 +103,7 @@ _ACTIVE_PROCESS_SPAN: ContextVar[Span | None] = ContextVar(
     "curie_worker_active_process_span",
     default=None,
 )
+_MAX_QUEUE_WAIT_MS = 31_536_000_000
 
 
 class Consumer(StreamConsumer):
@@ -227,7 +228,22 @@ class Consumer(StreamConsumer):
         self._inflight.add(task)
         task.add_done_callback(self._inflight.discard)
 
-    def _process_span(self, fields: dict[str, str]) -> tuple[Span, bool]:
+    @staticmethod
+    def _queue_wait_ms(entry_id: str) -> int | None:
+        """Return bounded Valkey enqueue-to-process latency from its stream ID."""
+
+        millis, separator, _sequence = entry_id.partition("-")
+        if separator != "-" or not millis.isdigit():
+            return None
+        enqueued_ms = int(millis)
+        now_ms = time.time_ns() // 1_000_000
+        return min(max(0, now_ms - enqueued_ms), _MAX_QUEUE_WAIT_MS)
+
+    def _process_span(
+        self,
+        entry_id: str,
+        fields: dict[str, str],
+    ) -> tuple[Span, bool]:
         """Start a process span from optional transport-owned W3C metadata.
 
         ``extract_trace_context`` owns all bounds and value-free diagnostics.
@@ -239,13 +255,17 @@ class Consumer(StreamConsumer):
         parent = extract_trace_context(raw, logger=logger)
         parent_context = trace.get_current_span(parent).get_span_context()
         malformed = bool(raw) and not parent_context.is_valid
+        raw_attributes: dict[str, object] = {
+            "messaging.system": "valkey",
+            "messaging.destination.name": self._config.stream,
+            "messaging.operation.type": "process",
+        }
+        queue_wait_ms = self._queue_wait_ms(entry_id)
+        if queue_wait_ms is not None:
+            raw_attributes["curie.queue.wait_ms"] = queue_wait_ms
         attributes = sanitize_attributes(
             "curie-worker",
-            {
-                "messaging.system": "valkey",
-                "messaging.destination.name": self._config.stream,
-                "messaging.operation.type": "process",
-            },
+            raw_attributes,
         )
         span = self._tracer.start_span(
             "process curie:runs",
@@ -255,6 +275,8 @@ class Consumer(StreamConsumer):
             record_exception=False,
             set_status_on_exception=False,
         )
+        if queue_wait_ms is not None:
+            span.add_event("worker.queue.wait")
         return span, malformed
 
     @staticmethod
@@ -262,12 +284,17 @@ class Consumer(StreamConsumer):
         span.set_status(Status(StatusCode.ERROR if error else StatusCode.OK))
 
     async def _handle(self, entry_id: str, fields: dict[str, str]) -> None:
-        span, malformed = self._process_span(fields)
+        span, malformed = self._process_span(entry_id, fields)
         context_token = attach(set_span_in_context(span))
         active_token = _ACTIVE_PROCESS_SPAN.set(span)
         try:
             if malformed:
                 span.add_event("trace_context.invalid")
+                emit_log_event(
+                    logger,
+                    "worker.trace_context.invalid",
+                    level=logging.WARNING,
+                )
             try:
                 qevent = from_stream_fields(fields)
             except Exception:
@@ -285,6 +312,7 @@ class Consumer(StreamConsumer):
                 # Leave the entry pending: XAUTOCLAIM will reclaim and retry.
                 span.add_event("messaging.pending")
                 self._finish_process_span(span, error=True)
+                emit_log_event(logger, "worker.turn.failed", level=logging.ERROR)
                 logger.exception("processing failed for entry %s; left pending", entry_id)
                 return
             try:
@@ -292,9 +320,15 @@ class Consumer(StreamConsumer):
             except Exception:
                 span.add_event("messaging.pending")
                 self._finish_process_span(span, error=True)
+                emit_log_event(logger, "worker.turn.failed", level=logging.ERROR)
                 raise
             span.add_event("messaging.ack")
             self._finish_process_span(span, error=outcome == "escalated")
+            emit_log_event(
+                logger,
+                "worker.turn.failed" if outcome == "escalated" else "worker.turn.completed",
+                level=logging.ERROR if outcome == "escalated" else logging.INFO,
+            )
         except BaseException:
             self._finish_process_span(span, error=True)
             raise
@@ -339,12 +373,17 @@ class Consumer(StreamConsumer):
             self._finish_process_span(active, error=True)
             return
 
-        span, malformed = self._process_span(fields or {})
+        span, malformed = self._process_span(entry_id, fields or {})
         context_token = attach(set_span_in_context(span))
         active_token = _ACTIVE_PROCESS_SPAN.set(span)
         try:
             if malformed:
                 span.add_event("trace_context.invalid")
+                emit_log_event(
+                    logger,
+                    "worker.trace_context.invalid",
+                    level=logging.WARNING,
+                )
             span.add_event("messaging.dead_letter")
             await super()._dead_letter(
                 entry_id,

--- a/apps/worker/src/curie_worker/consumer.py
+++ b/apps/worker/src/curie_worker/consumer.py
@@ -39,8 +39,14 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
+from contextvars import ContextVar
 
 from curie_dispatcher.queue import from_stream_fields
+from curie_telemetry import TRACE_CONTEXT_FIELD, extract_trace_context
+from curie_telemetry.attributes import sanitize_attributes
+from opentelemetry import trace
+from opentelemetry.context import attach, detach
+from opentelemetry.trace import Span, SpanKind, Status, StatusCode, Tracer, set_span_in_context
 from redis.asyncio import Redis
 
 from .config import WorkerConfig
@@ -92,6 +98,11 @@ THREAD_RESET_INFLIGHT_SET = "curie:thread-reset-inflight"
 # the set is picked up on the next tick rather than blocking the rest of the
 # maintenance work behind an arbitrarily large batch.
 _THREAD_RESET_DRAIN_BUDGET_S = 30.0
+_NOOP_TRACER = trace.NoOpTracerProvider().get_tracer("curie-worker.consumer")
+_ACTIVE_PROCESS_SPAN: ContextVar[Span | None] = ContextVar(
+    "curie_worker_active_process_span",
+    default=None,
+)
 
 
 class Consumer(StreamConsumer):
@@ -104,6 +115,7 @@ class Consumer(StreamConsumer):
         kernel: Kernel,
         config: WorkerConfig,
         max_concurrency: int = 16,
+        tracer: Tracer | None = None,
     ) -> None:
         super().__init__(redis)
         # The base class narrows self._redis to the StreamBroker port (stream
@@ -115,6 +127,7 @@ class Consumer(StreamConsumer):
         self._valkey: Redis = redis
         self._kernel = kernel
         self._config = config
+        self._tracer = tracer or _NOOP_TRACER
         self._sem = asyncio.Semaphore(max_concurrency)
         self._inflight: set[asyncio.Task[None]] = set()
         # The reclaim/dead-letter knobs the shared base machinery reads. Built
@@ -214,8 +227,47 @@ class Consumer(StreamConsumer):
         self._inflight.add(task)
         task.add_done_callback(self._inflight.discard)
 
+    def _process_span(self, fields: dict[str, str]) -> tuple[Span, bool]:
+        """Start a process span from optional transport-owned W3C metadata.
+
+        ``extract_trace_context`` owns all bounds and value-free diagnostics.
+        A present but invalid value is reported as an event after the new root
+        starts; an absent/empty field is the ordinary payload-only path.
+        """
+
+        raw = fields.get(TRACE_CONTEXT_FIELD)
+        parent = extract_trace_context(raw, logger=logger)
+        parent_context = trace.get_current_span(parent).get_span_context()
+        malformed = bool(raw) and not parent_context.is_valid
+        attributes = sanitize_attributes(
+            "curie-worker",
+            {
+                "messaging.system": "valkey",
+                "messaging.destination.name": self._config.stream,
+                "messaging.operation.type": "process",
+            },
+        )
+        span = self._tracer.start_span(
+            "process curie:runs",
+            context=parent,
+            kind=SpanKind.CONSUMER,
+            attributes=attributes,
+            record_exception=False,
+            set_status_on_exception=False,
+        )
+        return span, malformed
+
+    @staticmethod
+    def _finish_process_span(span: Span, *, error: bool) -> None:
+        span.set_status(Status(StatusCode.ERROR if error else StatusCode.OK))
+
     async def _handle(self, entry_id: str, fields: dict[str, str]) -> None:
+        span, malformed = self._process_span(fields)
+        context_token = attach(set_span_in_context(span))
+        active_token = _ACTIVE_PROCESS_SPAN.set(span)
         try:
+            if malformed:
+                span.add_event("trace_context.invalid")
             try:
                 qevent = from_stream_fields(fields)
             except Exception:
@@ -228,15 +280,88 @@ class Consumer(StreamConsumer):
                 )
                 return
             try:
-                await self._kernel.process_event(qevent)
+                outcome = await self._kernel.process_event(qevent)
             except Exception:
                 # Leave the entry pending: XAUTOCLAIM will reclaim and retry.
+                span.add_event("messaging.pending")
+                self._finish_process_span(span, error=True)
                 logger.exception("processing failed for entry %s; left pending", entry_id)
                 return
-            await self._ack(entry_id)
+            try:
+                await self._ack(entry_id)
+            except Exception:
+                span.add_event("messaging.pending")
+                self._finish_process_span(span, error=True)
+                raise
+            span.add_event("messaging.ack")
+            self._finish_process_span(span, error=outcome == "escalated")
+        except BaseException:
+            self._finish_process_span(span, error=True)
+            raise
         finally:
+            _ACTIVE_PROCESS_SPAN.reset(active_token)
+            detach(context_token)
+            span.end()
             self._inflight_ids.discard(entry_id)
             self._sem.release()
+
+    async def _dead_letter(
+        self,
+        entry_id: str,
+        fields: dict[str, str] | None,
+        *,
+        reason: str,
+        delivery_count: int,
+    ) -> None:
+        """Trace XADD-before-XACK settlement without changing its ownership.
+
+        The unparseable path is already inside ``_handle``'s process span.  The
+        delivery-cap path runs directly from maintenance, so it opens the same
+        process span from the original carrier before delegating to the shared
+        bounded-delivery implementation.
+        """
+
+        active = _ACTIVE_PROCESS_SPAN.get()
+        if active is not None:
+            active.add_event("messaging.dead_letter")
+            try:
+                await super()._dead_letter(
+                    entry_id,
+                    fields,
+                    reason=reason,
+                    delivery_count=delivery_count,
+                )
+            except BaseException:
+                active.add_event("messaging.pending")
+                self._finish_process_span(active, error=True)
+                raise
+            active.add_event("messaging.ack")
+            self._finish_process_span(active, error=True)
+            return
+
+        span, malformed = self._process_span(fields or {})
+        context_token = attach(set_span_in_context(span))
+        active_token = _ACTIVE_PROCESS_SPAN.set(span)
+        try:
+            if malformed:
+                span.add_event("trace_context.invalid")
+            span.add_event("messaging.dead_letter")
+            await super()._dead_letter(
+                entry_id,
+                fields,
+                reason=reason,
+                delivery_count=delivery_count,
+            )
+            span.add_event("messaging.ack")
+            self._finish_process_span(span, error=True)
+        except BaseException:
+            span.add_event("messaging.pending")
+            self._finish_process_span(span, error=True)
+            raise
+        finally:
+            _ACTIVE_PROCESS_SPAN.reset(active_token)
+            detach(context_token)
+            span.end()
 
     async def _pending_delivery_count(self, entry_id: str) -> int:
         """This entry's CURRENT delivery count, read from the PEL.

--- a/apps/worker/src/curie_worker/kernel.py
+++ b/apps/worker/src/curie_worker/kernel.py
@@ -62,6 +62,9 @@ from channel_protocol.reply import (
     TurnCompleted,
     TurnStatus,
 )
+from curie_telemetry.attributes import sanitize_attributes, set_turn_identity
+from opentelemetry import trace
+from opentelemetry.trace import Span, SpanKind, Status, StatusCode, Tracer
 from pydantic import ValidationError
 
 from .approval_cards import ApprovalCardStore
@@ -226,6 +229,7 @@ _RESET_RELEASE_TIMEOUT_S = 5.0
 # the in-progress set, reported unconfirmed, retried by a fresh operator
 # request) rather than falling back to the old, unsafe lock-free release.
 _RESET_LOCK_ACQUIRE_TIMEOUT_S = 5.0
+_NOOP_TRACER = trace.NoOpTracerProvider().get_tracer("curie-worker.kernel")
 
 
 @dataclass
@@ -440,6 +444,7 @@ class Kernel:
         # ``ApprovalClient``.
         approval_reader: ApprovalReader | None = None,
         card_store: ApprovalCardStore | None = None,
+        tracer: Tracer | None = None,
     ) -> None:
         self._substrate = substrate
         self._runner = runner
@@ -461,6 +466,7 @@ class Kernel:
         # EXPIRY can disable it (#419); absent (unwired tests) simply skips the
         # card teardown -- the resolve-click path still heals a card on click.
         self._card_store = card_store
+        self._tracer = tracer or _NOOP_TRACER
         # Which threads are running which agent, so a kill interrupts the agent's
         # live turns. Populated while a turn owner streams.
         self._active_by_agent: dict[uuid.UUID, set[str]] = {}
@@ -548,7 +554,53 @@ class Kernel:
         self._adopt_ref(qevent, ack)
         return ack
 
-    async def process_event(self, qevent: QueuedTurn) -> None:
+    @staticmethod
+    def _turn_event(name: str) -> None:
+        """Add one closed, value-free event to the current turn span."""
+
+        trace.get_current_span().add_event(name)
+
+    @staticmethod
+    def _set_turn_attributes(attributes: dict[str, object]) -> None:
+        span = trace.get_current_span()
+        for key, value in sanitize_attributes("curie-worker", attributes).items():
+            span.set_attribute(key, value)
+
+    @staticmethod
+    def _finish_turn_span(span: Span, outcome: str, *, error: bool) -> None:
+        for key, value in sanitize_attributes(
+            "curie-worker",
+            {"curie.turn.outcome": outcome},
+        ).items():
+            span.set_attribute(key, value)
+        span.add_event("worker.terminal")
+        span.set_status(Status(StatusCode.ERROR if error else StatusCode.OK))
+
+    async def process_event(self, qevent: QueuedTurn) -> str:
+        """Trace and handle one queued turn, returning its closed outcome."""
+
+        with self._tracer.start_as_current_span(
+            "worker.turn",
+            kind=SpanKind.INTERNAL,
+            record_exception=False,
+            set_status_on_exception=False,
+        ) as span:
+            try:
+                outcome = await self._process_event(qevent)
+            except BaseException:
+                # Exception messages can carry runner or adapter content.  The
+                # process span records the error class at its own boundary; this
+                # sacred-kernel span needs only a falsifiable ERROR outcome.
+                self._finish_turn_span(span, "failed", error=True)
+                raise
+            self._finish_turn_span(
+                span,
+                outcome,
+                error=outcome == "escalated",
+            )
+            return outcome
+
+    async def _process_event(self, qevent: QueuedTurn) -> str:
         """Handle one queued turn to a terminal state (success or escalate).
 
         Returns normally once the event is terminally handled; the consumer then
@@ -587,7 +639,9 @@ class Kernel:
                 self._release_order_entry(thread, entry)
 
         try:
-            if await self._markers.is_terminal(event_id):
+            terminal = await self._markers.is_terminal(event_id)
+            self._turn_event("worker.dedupe.checked")
+            if terminal:
                 # ``is_terminal``, not ``is_done``: a DONE outbox record proves
                 # this turn finished just as well as the marker does, and it
                 # outlives the marker by the retention window. Reading the marker
@@ -597,12 +651,13 @@ class Kernel:
                 # Completion emit stays at-least-once; turn side effects stay
                 # at-most-once for the whole outbox retention period.
                 logger.info("event %s already done; skipping", event_id)
+                self._turn_event("worker.dedupe.skip")
                 # The skip holds no resolved route of its own and must not
                 # invent one, so it makes no sink call -- except to hand off a
                 # completion an earlier delivery durably owed and never
                 # confirmed, which it re-emits from the STORED record.
                 await self._reemit_pending_completion(event_id)
-                return
+                return "duplicate"
 
             # If this is an approval resume, settle its live card before running
             # the continuation: expired (#419) or resolved (#1084). Best-effort,
@@ -636,7 +691,7 @@ class Kernel:
                     "not retrying automatically. Flagging for a human.",
                 )
                 await self._complete(qevent, route, "escalated")
-                return
+                return "escalated"
 
             # Deployment-to-runtime binding: resolve which agent/version this
             # channel runs, and refuse a killed agent. An unmapped channel is a
@@ -666,7 +721,7 @@ class Kernel:
                         f"{qevent.reply_handle.kind} address "
                         f"{qevent.reply_handle.channel} yet.",
                     )
-                    return
+                    return "dropped"
                 # The FIRST sanctioned route source, and the normal path: once a
                 # turn has resolved, its egress target is the binding row's,
                 # because endpoints are server-controlled (D4.1). A row that
@@ -684,8 +739,14 @@ class Kernel:
                         route,
                         "This agent is paused by an operator. Try again once it resumes.",
                     )
-                    return
+                    return "dropped"
                 agent_id = resolved.agent_id
+                set_turn_identity(
+                    trace.get_current_span(),
+                    agent_id=agent_id,
+                    conversation_id=thread,
+                    user_id=qevent.author,
+                )
                 boot_env = self._binding.boot_env(resolved, thread)
                 # One-shot post-approval allowance (#430, ADR-0035): when THIS turn is the
                 # resume of a genuinely-approved permission-gate approval, deliver a single
@@ -770,11 +831,11 @@ class Kernel:
                         qevent, route, outcome, agent_id, approval_routes
                     )
                     await self._complete(qevent, route, "awaiting-approval")
-                    return
+                    return "awaiting-approval"
 
                 if outcome.terminal_ok:
                     await self._complete(qevent, route, "delivered")
-                    return
+                    return "steered" if outcome.steered else "delivered"
 
                 if outcome.saw_side_effect:
                     await self._escalate(
@@ -784,7 +845,7 @@ class Kernel:
                         "starting an action; not retrying automatically. Flagging for a human.",
                     )
                     await self._complete(qevent, route, "escalated")
-                    return
+                    return "escalated"
 
                 retryable = outcome.classification in RETRYABLE_CLASSIFICATIONS
                 if not retryable or attempt >= self._config.max_attempts:
@@ -795,7 +856,7 @@ class Kernel:
                         f"{attempt} attempt(s). Flagging for a human.",
                     )
                     await self._complete(qevent, route, "escalated")
-                    return
+                    return "escalated"
 
                 await asyncio.sleep(self._backoff(attempt))
         finally:
@@ -1094,7 +1155,8 @@ class Kernel:
         )
         generation = await self._markers.mark_completion_pending(event_id, record)
         await self._markers.mark_done(event_id)
-        await self._deliver_completion(record, generation=generation)
+        if await self._deliver_completion(record, generation=generation):
+            self._turn_event("worker.completion.settled")
 
     async def _deliver_completion(
         self, record: CompletionRecord, *, generation: str
@@ -1343,7 +1405,15 @@ class Kernel:
         # A placeholderless job must route first. Otherwise every busy redelivery
         # posts a notice for a turn that never started.
         defer_job_booting = qevent.reply_handle.placeholder is None and qevent.source.is_job
-        if not self._config.slack_no_edit_streaming and not defer_job_booting:
+        # A bound agent is rechecked after its runner stream is accepted, closing
+        # the precheck-vs-register kill race.  Do not mutate the placeholder
+        # before that last gate: if the recheck itself fails, no turn is consumed
+        # and leaving "Working on it" behind would claim progress that never
+        # happened.  The shimmer remains the pre-claim liveness affordance.
+        defer_killswitch_booting = agent_id is not None and self._killswitch is not None
+        if not self._config.slack_no_edit_streaming and not (
+            defer_job_booting or defer_killswitch_booting
+        ):
             try:
                 await self._reply_for(qevent, route, self._config.booting_text)
             except Exception:
@@ -1357,7 +1427,9 @@ class Kernel:
         # next same-thread event can route, and release the Valkey lock before
         # streaming so a follow-up can steer.
         try:
+            self._turn_event("worker.lock.wait")
             async with self._lock.hold(self._config.lock_key(thread)):
+                self._turn_event("worker.lock.acquired")
                 routed = await self._route_and_start(
                     thread, event, boot_env, packs, source=qevent.source
                 )
@@ -1399,7 +1471,16 @@ class Kernel:
             return TurnOutcome(terminal_ok=False, classification="runner-error")
         release_order()
 
-        if not self._config.slack_no_edit_streaming and defer_job_booting:
+        defer_booting_until_postcheck = (
+            defer_killswitch_booting
+            and routed.handle is not None
+            and routed.turn is not None
+        )
+        if (
+            not self._config.slack_no_edit_streaming
+            and (defer_job_booting or defer_killswitch_booting)
+            and not defer_booting_until_postcheck
+        ):
             try:
                 # Routing succeeded, so this delivery owns a real turn. Adopt the
                 # minted ref before streaming so every later update edits it.
@@ -1430,6 +1511,12 @@ class Kernel:
             return TurnOutcome(terminal_ok=True, steered=True)
 
         assert routed.handle is not None and routed.turn is not None
+        self._set_turn_attributes(
+            {
+                "curie.session_id": routed.handle.session_id,
+                "curie.sandbox_id": routed.handle.sandbox_name,
+            }
+        )
         # Register this owner turn so a kill for its agent interrupts it, then
         # stream; unregister when the turn ends.
         self._register_run(agent_id, thread)
@@ -1443,8 +1530,18 @@ class Kernel:
                 and await self._killswitch.is_killed(agent_id)
             ):
                 await self.interrupt_thread(thread, f"agent {agent_id} killed by operator")
+            if not self._config.slack_no_edit_streaming and defer_booting_until_postcheck:
+                try:
+                    await self._reply_for(qevent, route, self._config.booting_text)
+                except Exception:
+                    logger.warning("booting-state update failed for %s", qevent.event_id)
             return await self._consume(qevent, route, routed.turn, nav)
         finally:
+            # ``start_turn`` transfers the open response and CLIENT span to the
+            # caller before the post-registration kill recheck.  Close it here
+            # as a final owner even when that recheck raises before ``_consume``
+            # can enter its async context; normal consumption is idempotent.
+            routed.turn.close()
             self._unregister_run(agent_id, thread)
 
     async def _route_and_start(
@@ -1509,7 +1606,14 @@ class Kernel:
                     f"thread {thread} has a live session; deferring the {source} turn"
                 )
         elif await self._runner.steer(handle.base_url, event, token=handle.token or None):
+            self._turn_event("worker.route.steer")
             return _RouteResult(steered=True)
+        elif not source.is_job:
+            # A 409 is the accepted steer-vs-finish CAS result.  Fresh claims
+            # also answer 409 because no turn exists yet; in both cases the
+            # required behavior is the same start fallback under this lock.
+            self._turn_event("worker.route.finish_race")
+        self._turn_event("worker.route.start")
         turn = await self._runner.start_turn(handle.base_url, event, token=handle.token or None)
         return _RouteResult(steered=False, handle=handle, turn=turn)
 
@@ -2151,6 +2255,7 @@ class Kernel:
         if acc.status in (SessionStatus.DONE, SessionStatus.IDLE_AWAITING_INPUT):
             text = acc.rendered()
             await reply.finalize(text)
+            self._turn_event("worker.reply.final")
             return TurnOutcome(
                 terminal_ok=True,
                 saw_side_effect=acc.saw_side_effect,

--- a/apps/worker/src/curie_worker/kernel.py
+++ b/apps/worker/src/curie_worker/kernel.py
@@ -838,6 +838,7 @@ class Kernel:
                     return "steered" if outcome.steered else "delivered"
 
                 if outcome.saw_side_effect:
+                    self._turn_event("worker.retry.stopped")
                     await self._escalate(
                         qevent,
                         route,
@@ -849,6 +850,7 @@ class Kernel:
 
                 retryable = outcome.classification in RETRYABLE_CLASSIFICATIONS
                 if not retryable or attempt >= self._config.max_attempts:
+                    self._turn_event("worker.retry.stopped")
                     await self._escalate(
                         qevent,
                         route,
@@ -858,6 +860,7 @@ class Kernel:
                     await self._complete(qevent, route, "escalated")
                     return "escalated"
 
+                self._turn_event("worker.retry.scheduled")
                 await asyncio.sleep(self._backoff(attempt))
         finally:
             release_order()
@@ -1405,15 +1408,7 @@ class Kernel:
         # A placeholderless job must route first. Otherwise every busy redelivery
         # posts a notice for a turn that never started.
         defer_job_booting = qevent.reply_handle.placeholder is None and qevent.source.is_job
-        # A bound agent is rechecked after its runner stream is accepted, closing
-        # the precheck-vs-register kill race.  Do not mutate the placeholder
-        # before that last gate: if the recheck itself fails, no turn is consumed
-        # and leaving "Working on it" behind would claim progress that never
-        # happened.  The shimmer remains the pre-claim liveness affordance.
-        defer_killswitch_booting = agent_id is not None and self._killswitch is not None
-        if not self._config.slack_no_edit_streaming and not (
-            defer_job_booting or defer_killswitch_booting
-        ):
+        if not self._config.slack_no_edit_streaming and not defer_job_booting:
             try:
                 await self._reply_for(qevent, route, self._config.booting_text)
             except Exception:
@@ -1471,16 +1466,7 @@ class Kernel:
             return TurnOutcome(terminal_ok=False, classification="runner-error")
         release_order()
 
-        defer_booting_until_postcheck = (
-            defer_killswitch_booting
-            and routed.handle is not None
-            and routed.turn is not None
-        )
-        if (
-            not self._config.slack_no_edit_streaming
-            and (defer_job_booting or defer_killswitch_booting)
-            and not defer_booting_until_postcheck
-        ):
+        if not self._config.slack_no_edit_streaming and defer_job_booting:
             try:
                 # Routing succeeded, so this delivery owns a real turn. Adopt the
                 # minted ref before streaming so every later update edits it.
@@ -1530,11 +1516,6 @@ class Kernel:
                 and await self._killswitch.is_killed(agent_id)
             ):
                 await self.interrupt_thread(thread, f"agent {agent_id} killed by operator")
-            if not self._config.slack_no_edit_streaming and defer_booting_until_postcheck:
-                try:
-                    await self._reply_for(qevent, route, self._config.booting_text)
-                except Exception:
-                    logger.warning("booting-state update failed for %s", qevent.event_id)
             return await self._consume(qevent, route, routed.turn, nav)
         finally:
             # ``start_turn`` transfers the open response and CLIENT span to the

--- a/apps/worker/src/curie_worker/run.py
+++ b/apps/worker/src/curie_worker/run.py
@@ -19,9 +19,12 @@ from typing import Any
 
 import httpx
 import redis
+from curie_telemetry import configure
+from opentelemetry.trace import Tracer
 from redis.asyncio import Redis as AsyncRedis
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 
+from . import __version__
 from .approval_cards import ApprovalCardStore
 from .approvals import ApprovalClient
 from .binding import BindingResolver
@@ -202,7 +205,11 @@ def _sandbox_client(
                 "endpoint for local-model mode, or set CURIE_FAKE_MODEL=1 for an "
                 "offline/test run."
             )
-        if not env.get("OTEL_EXPORTER_OTLP_ENDPOINT"):
+        runner_otel_endpoint = env.get(
+            "CURIE_RUNNER_OTEL_EXPORTER_OTLP_ENDPOINT",
+            env.get("OTEL_EXPORTER_OTLP_ENDPOINT", ""),
+        )
+        if not runner_otel_endpoint:
             logger.warning(
                 "Docker substrate selected but OTEL_EXPORTER_OTLP_ENDPOINT is "
                 "unset; runner traces will not be exported"
@@ -211,7 +218,7 @@ def _sandbox_client(
             image=env.get("CURIE_RUNNER_IMAGE", "curie-runner"),
             bundle_store=BundleStore(config),
             network=env.get("CURIE_DOCKER_NETWORK") or None,
-            otel_endpoint=env.get("OTEL_EXPORTER_OTLP_ENDPOINT") or None,
+            otel_endpoint=runner_otel_endpoint or None,
             default_plugin_dir=config.bundle_plugin_dir,
             # Container isolation for every spawned runner (#631): read-only
             # rootfs, dropped caps, no-new-privileges, bounded resources. Mirrors
@@ -229,7 +236,12 @@ def _sandbox_client(
     return KubernetesSandboxClient(sub_config.namespace)
 
 
-def build(config: WorkerConfig, env: Mapping[str, str]) -> Runtime:
+def build(
+    config: WorkerConfig,
+    env: Mapping[str, str],
+    *,
+    tracer: Tracer | None = None,
+) -> Runtime:
     async_redis: AsyncRedis = AsyncRedis(
         host=config.valkey_host,
         port=config.valkey_port,
@@ -251,10 +263,12 @@ def build(config: WorkerConfig, env: Mapping[str, str]) -> Runtime:
         _sandbox_client(config, env, sub_config),
         AffinityStore(sync_redis),
         sub_config,
+        tracer=tracer,
     )
     runner = RunnerClient(
         connect_timeout_s=config.runner_connect_timeout_s,
         total_timeout_s=config.runner_total_timeout_s,
+        tracer=tracer,
     )
     engine = create_async_engine(config.database_url, pool_pre_ping=True)
     binding = BindingResolver(engine, config)
@@ -284,10 +298,16 @@ def build(config: WorkerConfig, env: Mapping[str, str]) -> Runtime:
         # half without also implementing a read it never exercises.
         approval_reader=approval_client,
         card_store=ApprovalCardStore(async_redis, config),
+        tracer=tracer,
     )
     killswitch = KillSwitch(async_redis, on_kill=kernel.interrupt_agent)
     kernel.attach_killswitch(killswitch)
-    consumer = Consumer(redis=async_redis, kernel=kernel, config=config)
+    consumer = Consumer(
+        redis=async_redis,
+        kernel=kernel,
+        config=config,
+        tracer=tracer,
+    )
 
     # The eval lane (F3): a second consumer group on curie:evals, on its own
     # Valkey connection so its blocking read never stalls the runs consumer. It
@@ -400,8 +420,13 @@ def _build_connector_loop(
     )
 
 
-async def _run(config: WorkerConfig, env: Mapping[str, str]) -> None:
-    rt = build(config, env)
+async def _run(
+    config: WorkerConfig,
+    env: Mapping[str, str],
+    *,
+    tracer: Tracer | None = None,
+) -> None:
+    rt = build(config, env, tracer=tracer)
 
     loop = asyncio.get_running_loop()
 
@@ -460,7 +485,14 @@ def main(env: Mapping[str, str] | None = None) -> None:
     install_dead_letter_alerting()
     resolved = env if env is not None else os.environ
     config = WorkerConfig()
-    asyncio.run(_run(config, resolved))
+    telemetry = configure(service_name="curie-worker", service_version=__version__)
+    attach_logging = getattr(telemetry, "attach_logging", None)
+    if callable(attach_logging):
+        attach_logging(logging.getLogger("curie_worker"))
+    try:
+        asyncio.run(_run(config, resolved, tracer=telemetry.tracer))
+    finally:
+        telemetry.shutdown(timeout_millis=2_000)
 
 
 if __name__ == "__main__":

--- a/apps/worker/src/curie_worker/run.py
+++ b/apps/worker/src/curie_worker/run.py
@@ -19,6 +19,7 @@ from typing import Any
 
 import httpx
 import redis
+from aci_protocol import BootEnv
 from curie_telemetry import configure
 from opentelemetry.trace import Tracer
 from redis.asyncio import Redis as AsyncRedis
@@ -174,6 +175,65 @@ def _substrate_config(env: Mapping[str, str]) -> SubstrateConfig:
 # either satisfies the local-middle-mode credential requirement.
 _MODEL_CREDENTIAL_ENV = ("CLAUDE_CODE_OAUTH_TOKEN", "ANTHROPIC_API_KEY")
 
+_OTEL_ENDPOINT_ENV = BootEnv.env_key("otel_endpoint")
+_OTEL_PROTOCOL_ENV = BootEnv.env_key("otel_protocol")
+_OTEL_HEADERS_ENV = BootEnv.env_key("otel_headers")
+
+_RUNNER_OTEL_EXPORTER_ENV = (
+    _OTEL_ENDPOINT_ENV,
+    "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+    "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT",
+    _OTEL_PROTOCOL_ENV,
+    "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL",
+    "OTEL_EXPORTER_OTLP_LOGS_PROTOCOL",
+    _OTEL_HEADERS_ENV,
+    "OTEL_EXPORTER_OTLP_TRACES_HEADERS",
+    "OTEL_EXPORTER_OTLP_LOGS_HEADERS",
+    "OTEL_EXPORTER_OTLP_TIMEOUT",
+    "OTEL_EXPORTER_OTLP_TRACES_TIMEOUT",
+    "OTEL_EXPORTER_OTLP_LOGS_TIMEOUT",
+    "OTEL_EXPORTER_OTLP_COMPRESSION",
+    "OTEL_EXPORTER_OTLP_TRACES_COMPRESSION",
+    "OTEL_EXPORTER_OTLP_LOGS_COMPRESSION",
+    "OTEL_EXPORTER_OTLP_CERTIFICATE",
+    "OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE",
+    "OTEL_EXPORTER_OTLP_LOGS_CERTIFICATE",
+    "OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE",
+    "OTEL_EXPORTER_OTLP_TRACES_CLIENT_CERTIFICATE",
+    "OTEL_EXPORTER_OTLP_LOGS_CLIENT_CERTIFICATE",
+    "OTEL_EXPORTER_OTLP_CLIENT_KEY",
+    "OTEL_EXPORTER_OTLP_TRACES_CLIENT_KEY",
+    "OTEL_EXPORTER_OTLP_LOGS_CLIENT_KEY",
+    "OTEL_EXPORTER_OTLP_INSECURE",
+    "OTEL_EXPORTER_OTLP_TRACES_INSECURE",
+    "OTEL_EXPORTER_OTLP_LOGS_INSECURE",
+)
+_RUNNER_OTEL_ENDPOINT_ENV = (
+    _OTEL_ENDPOINT_ENV,
+    "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+    "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT",
+)
+
+
+def _runner_otel_environment(env: Mapping[str, str]) -> dict[str, str]:
+    """Select the standard exporter contract relayed to a Docker runner.
+
+    The private compose-only endpoint replaces the child's generic endpoint but
+    never enters its environment under the private name. Signal-specific
+    standard settings retain their normal precedence. A present blank private
+    endpoint deliberately disables the generic fallback, preserving the
+    no-endpoint control.
+    """
+
+    selected = {name: env[name] for name in _RUNNER_OTEL_EXPORTER_ENV if name in env}
+    private = "CURIE_RUNNER_OTEL_EXPORTER_OTLP_ENDPOINT"
+    if private in env:
+        selected[_OTEL_ENDPOINT_ENV] = env[private]
+    if not any(selected.get(name, "").strip() for name in _RUNNER_OTEL_ENDPOINT_ENV):
+        return {}
+    selected.setdefault(_OTEL_PROTOCOL_ENV, "http/protobuf")
+    return selected
+
 
 def _sandbox_client(
     config: WorkerConfig, env: Mapping[str, str], sub_config: SubstrateConfig
@@ -205,11 +265,8 @@ def _sandbox_client(
                 "endpoint for local-model mode, or set CURIE_FAKE_MODEL=1 for an "
                 "offline/test run."
             )
-        runner_otel_endpoint = env.get(
-            "CURIE_RUNNER_OTEL_EXPORTER_OTLP_ENDPOINT",
-            env.get("OTEL_EXPORTER_OTLP_ENDPOINT", ""),
-        )
-        if not runner_otel_endpoint:
+        runner_otel_environment = _runner_otel_environment(env)
+        if not runner_otel_environment:
             logger.warning(
                 "Docker substrate selected but OTEL_EXPORTER_OTLP_ENDPOINT is "
                 "unset; runner traces will not be exported"
@@ -218,7 +275,7 @@ def _sandbox_client(
             image=env.get("CURIE_RUNNER_IMAGE", "curie-runner"),
             bundle_store=BundleStore(config),
             network=env.get("CURIE_DOCKER_NETWORK") or None,
-            otel_endpoint=runner_otel_endpoint or None,
+            otel_environment=runner_otel_environment,
             default_plugin_dir=config.bundle_plugin_dir,
             # Container isolation for every spawned runner (#631): read-only
             # rootfs, dropped caps, no-new-privileges, bounded resources. Mirrors

--- a/apps/worker/src/curie_worker/runner_client.py
+++ b/apps/worker/src/curie_worker/runner_client.py
@@ -83,17 +83,10 @@ class TurnStream:
     async def __aiter__(self) -> AsyncIterator[OutboundEvent]:
         try:
             async for raw in self._response.content:
-                try:
-                    line = raw.decode("utf-8").strip()
-                    frame = parse_ndjson_line(line) if line else None
-                except Exception:
-                    raise RunnerError(
-                        "runner stream contained an unreadable NDJSON frame"
-                    ) from None
+                line = raw.decode("utf-8").strip()
                 if not line:
                     continue
-                assert frame is not None
-                yield frame
+                yield parse_ndjson_line(line)
         except BaseException:
             # Never record the exception itself: a parse failure may carry the
             # malformed runner line, which is agent-controlled content.
@@ -180,7 +173,10 @@ class RunnerClient:
         parsed = urlsplit(base_url)
         attributes: dict[str, object] = {
             "http.request.method": method,
-            "server.address": parsed.hostname or "runner",
+            # The worker talks only to its claimed runner. Exporting live pod or
+            # container addresses adds high-cardinality deployment identifiers
+            # without adding causal information.
+            "server.address": "runner",
         }
         if parsed.port is not None:
             attributes["server.port"] = parsed.port
@@ -227,11 +223,11 @@ class RunnerClient:
         )
         if resp.status != 200:
             try:
-                await resp.read()
+                body = await resp.text()
             finally:
                 resp.release()
                 _finish_span(span, error=True)
-            raise RunnerError(f"/v1/event -> {resp.status}")
+            raise RunnerError(f"/v1/event -> {resp.status}: {body}")
         return TurnStream(resp, span)
 
     async def steer(self, base_url: str, event: Event, token: str | None = None) -> bool:
@@ -248,8 +244,8 @@ class RunnerClient:
                 if resp.status == 409:
                     result = False
                 elif resp.status != 200:
-                    await resp.read()
-                    raise RunnerError(f"/v1/steer -> {resp.status}")
+                    body = await resp.text()
+                    raise RunnerError(f"/v1/steer -> {resp.status}: {body}")
                 else:
                     result = True
         except BaseException:
@@ -280,8 +276,8 @@ class RunnerClient:
         try:
             async with resp:
                 if resp.status not in (200, 409):
-                    await resp.read()
-                    raise RunnerError(f"/v1/interrupt -> {resp.status}")
+                    body = await resp.text()
+                    raise RunnerError(f"/v1/interrupt -> {resp.status}: {body}")
         except BaseException:
             _finish_span(span, error=True)
             raise
@@ -300,8 +296,8 @@ class RunnerClient:
         try:
             async with resp:
                 if resp.status != 200:
-                    await resp.read()
-                    raise RunnerError(f"/v1/reset -> {resp.status}")
+                    body = await resp.text()
+                    raise RunnerError(f"/v1/reset -> {resp.status}: {body}")
         except BaseException:
             _finish_span(span, error=True)
             raise
@@ -312,8 +308,8 @@ class RunnerClient:
         try:
             async with resp:
                 if resp.status != 200:
-                    await resp.read()
-                    raise RunnerError(f"/status -> {resp.status}")
+                    body = await resp.text()
+                    raise RunnerError(f"/status -> {resp.status}: {body}")
                 data: dict[str, object] = await resp.json()
         except BaseException:
             _finish_span(span, error=True)

--- a/apps/worker/src/curie_worker/runner_client.py
+++ b/apps/worker/src/curie_worker/runner_client.py
@@ -17,9 +17,16 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterator
 from types import TracebackType
+from typing import Any
+from urllib.parse import urlsplit
 
 import aiohttp
 from aci_protocol import Event, Interrupt, OutboundEvent, parse_ndjson_line
+from curie_telemetry import inject_trace_headers
+from curie_telemetry.attributes import sanitize_attributes
+from opentelemetry import trace
+from opentelemetry.context import attach, detach
+from opentelemetry.trace import Span, SpanKind, Status, StatusCode, Tracer, set_span_in_context
 
 # The interrupt RPC is a control-plane POST, not a streaming turn (#742, a
 # follow-up to #739): it exists only to hard-stop the live turn, never to carry
@@ -34,6 +41,7 @@ from aci_protocol import Event, Interrupt, OutboundEvent, parse_ndjson_line
 # going) instead of re-deriving the bound -- or a coupling to this client's
 # other timeouts -- at each call site.
 _DEFAULT_INTERRUPT_TIMEOUT_S = 5.0
+_NOOP_TRACER = trace.NoOpTracerProvider().get_tracer("curie-worker.runner-client")
 
 
 def _auth_headers(token: str | None) -> dict[str, str] | None:
@@ -52,21 +60,61 @@ class RunnerError(Exception):
     """The runner returned an unexpected HTTP status or an unreadable stream."""
 
 
+def _set_attributes(span: Span, attributes: dict[str, object]) -> None:
+    """Apply only the worker's closed telemetry vocabulary to ``span``."""
+
+    for key, value in sanitize_attributes("curie-worker", attributes).items():
+        span.set_attribute(key, value)
+
+
+def _finish_span(span: Span, *, error: bool) -> None:
+    span.set_status(Status(StatusCode.ERROR if error else StatusCode.OK))
+    span.end()
+
+
 class TurnStream:
     """An open ``/v1/event`` response: the turn is active; iterate for frames."""
 
-    def __init__(self, response: aiohttp.ClientResponse) -> None:
+    def __init__(self, response: aiohttp.ClientResponse, span: Span | None = None) -> None:
         self._response = response
+        self._span = span or _NOOP_TRACER.start_span("POST runner")
+        self._closed = False
 
     async def __aiter__(self) -> AsyncIterator[OutboundEvent]:
-        async for raw in self._response.content:
-            line = raw.decode("utf-8").strip()
-            if not line:
-                continue
-            yield parse_ndjson_line(line)
+        try:
+            async for raw in self._response.content:
+                try:
+                    line = raw.decode("utf-8").strip()
+                    frame = parse_ndjson_line(line) if line else None
+                except Exception:
+                    raise RunnerError(
+                        "runner stream contained an unreadable NDJSON frame"
+                    ) from None
+                if not line:
+                    continue
+                assert frame is not None
+                yield frame
+        except BaseException:
+            # Never record the exception itself: a parse failure may carry the
+            # malformed runner line, which is agent-controlled content.
+            self._finish(error=True)
+            raise
+        else:
+            self._finish(error=False)
 
     def close(self) -> None:
-        self._response.release()
+        """Abandon an unconsumed response, idempotently."""
+
+        self._finish(error=True)
+
+    def _finish(self, *, error: bool) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        try:
+            self._response.release()
+        finally:
+            _finish_span(self._span, error=error)
 
     async def __aenter__(self) -> TurnStream:
         return self
@@ -77,7 +125,11 @@ class TurnStream:
         exc: BaseException | None,
         tb: TracebackType | None,
     ) -> None:
-        self.close()
+        del exc_type, exc, tb
+        # Normal EOF already closed the owner as OK inside ``__aiter__``.  If
+        # the context exits while it is still open, the response was abandoned
+        # (with or without a caller exception) and must be ERROR.
+        self._finish(error=True)
 
 
 class RunnerClient:
@@ -90,6 +142,7 @@ class RunnerClient:
         total_timeout_s: float = 600.0,
         interrupt_timeout_s: float = _DEFAULT_INTERRUPT_TIMEOUT_S,
         session: aiohttp.ClientSession | None = None,
+        tracer: Tracer | None = None,
     ) -> None:
         self._own_session = session is None
         self._session = session or aiohttp.ClientSession(
@@ -102,31 +155,108 @@ class RunnerClient:
         # ``/v1/interrupt`` gets its own short control-plane budget regardless of
         # how the streaming timeouts above are tuned.
         self._interrupt_timeout = aiohttp.ClientTimeout(total=interrupt_timeout_s)
+        # The composition root injects its configured tracer into the runs lane.
+        # Defaulting to a private no-op (rather than the ambient global provider)
+        # prevents this shared client from silently instrumenting the eval lane.
+        self._tracer = tracer or _NOOP_TRACER
+
+    async def _request(
+        self,
+        method: str,
+        base_url: str,
+        path: str,
+        *,
+        token: str | None = None,
+        json: object | None = None,
+        timeout: aiohttp.ClientTimeout | None = None,
+    ) -> tuple[aiohttp.ClientResponse, Span]:
+        """Send one request under a manually-owned CLIENT span.
+
+        Authorization and W3C context share the wire header map, but only the
+        closed method/address/port/status attributes are exported.  Using the
+        dedicated Trace Context propagator means baggage can never cross.
+        """
+
+        parsed = urlsplit(base_url)
+        attributes: dict[str, object] = {
+            "http.request.method": method,
+            "server.address": parsed.hostname or "runner",
+        }
+        if parsed.port is not None:
+            attributes["server.port"] = parsed.port
+        span = self._tracer.start_span(
+            f"{method} runner",
+            kind=SpanKind.CLIENT,
+            attributes=sanitize_attributes("curie-worker", attributes),
+            record_exception=False,
+            set_status_on_exception=False,
+        )
+        headers = _auth_headers(token) or {}
+        span_context = set_span_in_context(span)
+        context_token = attach(span_context)
+        try:
+            inject_trace_headers(headers)
+            kwargs: dict[str, Any] = {"headers": headers or None}
+            if json is not None:
+                kwargs["json"] = json
+            if timeout is not None:
+                kwargs["timeout"] = timeout
+            response = await self._session.request(
+                method,
+                f"{base_url}{path}",
+                **kwargs,
+            )
+        except BaseException:
+            _finish_span(span, error=True)
+            raise
+        finally:
+            detach(context_token)
+        _set_attributes(span, {"http.response.status_code": response.status})
+        return response, span
 
     async def start_turn(
         self, base_url: str, event: Event, token: str | None = None
     ) -> TurnStream:
         """Open a turn. Returns once the runner has accepted it (turn active)."""
-        resp = await self._session.post(
-            f"{base_url}/v1/event", json=event.model_dump(), headers=_auth_headers(token)
+        resp, span = await self._request(
+            "POST",
+            base_url,
+            "/v1/event",
+            json=event.model_dump(),
+            token=token,
         )
         if resp.status != 200:
-            body = await resp.text()
-            resp.release()
-            raise RunnerError(f"/v1/event -> {resp.status}: {body}")
-        return TurnStream(resp)
+            try:
+                await resp.read()
+            finally:
+                resp.release()
+                _finish_span(span, error=True)
+            raise RunnerError(f"/v1/event -> {resp.status}")
+        return TurnStream(resp, span)
 
     async def steer(self, base_url: str, event: Event, token: str | None = None) -> bool:
         """Inject a follow-up into the live turn. False on 409 (no active turn)."""
-        async with self._session.post(
-            f"{base_url}/v1/steer", json=event.model_dump(), headers=_auth_headers(token)
-        ) as resp:
-            if resp.status == 409:
-                return False
-            if resp.status != 200:
-                body = await resp.text()
-                raise RunnerError(f"/v1/steer -> {resp.status}: {body}")
-            return True
+        resp, span = await self._request(
+            "POST",
+            base_url,
+            "/v1/steer",
+            json=event.model_dump(),
+            token=token,
+        )
+        try:
+            async with resp:
+                if resp.status == 409:
+                    result = False
+                elif resp.status != 200:
+                    await resp.read()
+                    raise RunnerError(f"/v1/steer -> {resp.status}")
+                else:
+                    result = True
+        except BaseException:
+            _finish_span(span, error=True)
+            raise
+        _finish_span(span, error=False)
+        return result
 
     async def interrupt(self, base_url: str, reason: str, token: str | None = None) -> None:
         """Hard-stop the live turn; its final is reclassified to idle.
@@ -139,15 +269,23 @@ class RunnerClient:
         any other failure here -- callers already decide per call site whether
         to swallow-and-fallback or surface-and-continue."""
         frame = Interrupt(reason=reason)
-        async with self._session.post(
-            f"{base_url}/v1/interrupt",
+        resp, span = await self._request(
+            "POST",
+            base_url,
+            "/v1/interrupt",
             json=frame.model_dump(),
-            headers=_auth_headers(token),
+            token=token,
             timeout=self._interrupt_timeout,
-        ) as resp:
-            if resp.status not in (200, 409):
-                body = await resp.text()
-                raise RunnerError(f"/v1/interrupt -> {resp.status}: {body}")
+        )
+        try:
+            async with resp:
+                if resp.status not in (200, 409):
+                    await resp.read()
+                    raise RunnerError(f"/v1/interrupt -> {resp.status}")
+        except BaseException:
+            _finish_span(span, error=True)
+            raise
+        _finish_span(span, error=False)
 
     async def reset(self, base_url: str, token: str | None = None) -> None:
         """Discard the runner's conversation so the next turn starts fresh (#550).
@@ -158,20 +296,30 @@ class RunnerClient:
         never be live at reset time -- a 409 here is a real ordering bug, not a
         condition to swallow.
         """
-        async with self._session.post(
-            f"{base_url}/v1/reset", headers=_auth_headers(token)
-        ) as resp:
-            if resp.status != 200:
-                body = await resp.text()
-                raise RunnerError(f"/v1/reset -> {resp.status}: {body}")
+        resp, span = await self._request("POST", base_url, "/v1/reset", token=token)
+        try:
+            async with resp:
+                if resp.status != 200:
+                    await resp.read()
+                    raise RunnerError(f"/v1/reset -> {resp.status}")
+        except BaseException:
+            _finish_span(span, error=True)
+            raise
+        _finish_span(span, error=False)
 
     async def status(self, base_url: str) -> dict[str, object]:
-        async with self._session.get(f"{base_url}/status") as resp:
-            if resp.status != 200:
-                body = await resp.text()
-                raise RunnerError(f"/status -> {resp.status}: {body}")
-            data: dict[str, object] = await resp.json()
-            return data
+        resp, span = await self._request("GET", base_url, "/status")
+        try:
+            async with resp:
+                if resp.status != 200:
+                    await resp.read()
+                    raise RunnerError(f"/status -> {resp.status}")
+                data: dict[str, object] = await resp.json()
+        except BaseException:
+            _finish_span(span, error=True)
+            raise
+        _finish_span(span, error=False)
+        return data
 
     async def close(self) -> None:
         if self._own_session:

--- a/apps/worker/src/curie_worker/sandbox/docker.py
+++ b/apps/worker/src/curie_worker/sandbox/docker.py
@@ -44,6 +44,7 @@ import os
 import shutil
 import subprocess
 import tempfile
+import threading
 import urllib.error
 import urllib.request
 from collections.abc import Mapping
@@ -82,12 +83,6 @@ logger = logging.getLogger(__name__)
 # is published to is Docker-assigned and read back per-container.
 RUNNER_CONTAINER_PORT = 8080
 
-# Declared boot keys this substrate produces. Docker is the OTel producer here
-# (the chart's env block is its Kubernetes counterpart), and the runner parses
-# both names out of the one declaration, so they are read from it (#488).
-_OTEL_ENDPOINT_ENV = BootEnv.env_key("otel_endpoint")
-_OTEL_PROTOCOL_ENV = BootEnv.env_key("otel_protocol")
-
 # The ambient SDK credential vars, forwarded into the container BY NAME (docker
 # reads the value from the worker env; this code never does, and no secret ever
 # lands in the docker argv). These authenticate the runner directly on the legacy
@@ -98,6 +93,40 @@ _OTEL_PROTOCOL_ENV = BootEnv.env_key("otel_protocol")
 _SDK_PASSTHROUGH_ENV = (
     "CLAUDE_CODE_OAUTH_TOKEN",
     "ANTHROPIC_API_KEY",
+)
+_OTEL_ENDPOINT_ENV = BootEnv.env_key("otel_endpoint")
+_OTEL_PROTOCOL_ENV = BootEnv.env_key("otel_protocol")
+_OTEL_HEADERS_ENV = BootEnv.env_key("otel_headers")
+_STANDARD_OTEL_EXPORTER_ENV = frozenset(
+    {
+        _OTEL_ENDPOINT_ENV,
+        "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+        "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT",
+        _OTEL_PROTOCOL_ENV,
+        "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL",
+        "OTEL_EXPORTER_OTLP_LOGS_PROTOCOL",
+        _OTEL_HEADERS_ENV,
+        "OTEL_EXPORTER_OTLP_TRACES_HEADERS",
+        "OTEL_EXPORTER_OTLP_LOGS_HEADERS",
+        "OTEL_EXPORTER_OTLP_TIMEOUT",
+        "OTEL_EXPORTER_OTLP_TRACES_TIMEOUT",
+        "OTEL_EXPORTER_OTLP_LOGS_TIMEOUT",
+        "OTEL_EXPORTER_OTLP_COMPRESSION",
+        "OTEL_EXPORTER_OTLP_TRACES_COMPRESSION",
+        "OTEL_EXPORTER_OTLP_LOGS_COMPRESSION",
+        "OTEL_EXPORTER_OTLP_CERTIFICATE",
+        "OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE",
+        "OTEL_EXPORTER_OTLP_LOGS_CERTIFICATE",
+        "OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE",
+        "OTEL_EXPORTER_OTLP_TRACES_CLIENT_CERTIFICATE",
+        "OTEL_EXPORTER_OTLP_LOGS_CLIENT_CERTIFICATE",
+        "OTEL_EXPORTER_OTLP_CLIENT_KEY",
+        "OTEL_EXPORTER_OTLP_TRACES_CLIENT_KEY",
+        "OTEL_EXPORTER_OTLP_LOGS_CLIENT_KEY",
+        "OTEL_EXPORTER_OTLP_INSECURE",
+        "OTEL_EXPORTER_OTLP_TRACES_INSECURE",
+        "OTEL_EXPORTER_OTLP_LOGS_INSECURE",
+    }
 )
 # A Claude Code OAuth token shares the sk-ant- prefix with an API key; this more
 # specific prefix marks it. Under a base-URL override the runner blanks such a
@@ -113,7 +142,13 @@ _OAUTH_TOKEN_PREFIX = "sk-ant-oat"
 # (the runner never fetches), and the credential is forwarded by name (never as
 # a value in the argv).
 _WORKER_OWNED_ENV = frozenset(
-    {BUNDLE_REF_ENV, PLUGIN_DIR_ENV, "CURIE_SANDBOX_ID", CREDENTIALS_ENV}
+    {
+        BUNDLE_REF_ENV,
+        PLUGIN_DIR_ENV,
+        "CURIE_SANDBOX_ID",
+        CREDENTIALS_ENV,
+        *_STANDARD_OTEL_EXPORTER_ENV,
+    }
 )
 
 
@@ -256,6 +291,7 @@ class DockerSandboxClient:
         bundle_store: BundleReader,
         network: str | None = None,
         otel_endpoint: str | None = None,
+        otel_environment: Mapping[str, str] | None = None,
         host: str = "127.0.0.1",
         default_plugin_dir: str = "/bundles/current",
         healthz_timeout_s: float = 0.5,
@@ -268,7 +304,14 @@ class DockerSandboxClient:
         self._image = image
         self._bundles = bundle_store
         self._network = network
-        self._otel_endpoint = otel_endpoint
+        self._otel_environment = dict(otel_environment or {})
+        if otel_endpoint and _OTEL_ENDPOINT_ENV not in self._otel_environment:
+            self._otel_environment[_OTEL_ENDPOINT_ENV] = otel_endpoint
+            self._otel_environment.setdefault(_OTEL_PROTOCOL_ENV, "http/protobuf")
+        # Per-thread because concurrent claims run in separate ``to_thread``
+        # calls. It carries sensitive exporter values to the docker CLI process
+        # environment while argv contains names only.
+        self._docker_environment = threading.local()
         self._host = host
         self._default_plugin_dir = default_plugin_dir
         self._healthz_timeout_s = healthz_timeout_s
@@ -338,13 +381,8 @@ class DockerSandboxClient:
             "-e",
             f"CURIE_RUNNER_PORT={RUNNER_CONTAINER_PORT}",
         ]
-        if self._otel_endpoint:
-            args += [
-                "-e",
-                f"{_OTEL_ENDPOINT_ENV}={self._otel_endpoint}",
-                "-e",
-                f"{_OTEL_PROTOCOL_ENV}=http/protobuf",
-            ]
+        for key in sorted(self._otel_environment):
+            args += ["-e", key]
         for key, value in sorted(env.items()):
             if key not in _WORKER_OWNED_ENV:
                 args += ["-e", f"{key}={value}"]
@@ -389,11 +427,14 @@ class DockerSandboxClient:
         args.append(self._image)
 
         try:
+            self._docker_environment.values = self._otel_environment
             self._docker(args)
         except DockerError:
             # A failed boot must not leak the bundle dir we just staged.
             self._cleanup_bundle(name)
             raise
+        finally:
+            self._docker_environment.values = {}
 
     def get_claim(self, name: str) -> ClaimView | None:
         inspected = self._inspect(name)
@@ -605,11 +646,13 @@ class DockerSandboxClient:
             return False
 
     def _docker(self, args: list[str], *, check: bool = True) -> str:
+        overrides = self._docker_command_environment()
         proc = subprocess.run(  # noqa: S603 -- fixed argv, no shell.
             ["docker", *args],
             capture_output=True,
             text=True,
             check=False,
+            env={**os.environ, **overrides} if overrides else None,
         )
         if proc.returncode != 0:
             if check:
@@ -621,6 +664,12 @@ class DockerSandboxClient:
                 )
             return ""
         return proc.stdout
+
+    def _docker_command_environment(self) -> Mapping[str, str]:
+        """Sensitive one-call env overrides; intentionally never part of argv."""
+
+        values: object = getattr(self._docker_environment, "values", {})
+        return values if isinstance(values, Mapping) else {}
 
     def _network_remediation_hint(self, stderr: str) -> str:
         """An actionable one-liner appended when ``stderr`` names our own

--- a/apps/worker/src/curie_worker/sandbox/substrate.py
+++ b/apps/worker/src/curie_worker/sandbox/substrate.py
@@ -29,6 +29,9 @@ import uuid
 from datetime import UTC, datetime, timedelta
 
 from aci_protocol import BootEnv
+from curie_telemetry.attributes import sanitize_attributes
+from opentelemetry import trace
+from opentelemetry.trace import Span, SpanKind, Status, StatusCode, Tracer
 
 from ..binding import RUNNER_TOKEN_ENV
 from .affinity import AffinityStore
@@ -88,6 +91,7 @@ logger = logging.getLogger(__name__)
 # sandbox, and the next claim() takes the existing _evict_stale path, which
 # drops the stale route and rebinds. Slow turn, not corruption.
 REAP_GRACE_MARGIN_SECONDS = 30.0
+_NOOP_TRACER = trace.NoOpTracerProvider().get_tracer("curie-worker.sandbox")
 
 
 class SandboxSubstrate:
@@ -98,10 +102,33 @@ class SandboxSubstrate:
         k8s: SandboxClient,
         affinity: AffinityStore,
         config: SubstrateConfig,
+        *,
+        tracer: Tracer | None = None,
     ) -> None:
         self._k8s = k8s
         self._affinity = affinity
         self._config = config
+        self._tracer = tracer or _NOOP_TRACER
+
+    @staticmethod
+    def _finish_lifecycle_span(
+        span: Span,
+        outcome: str,
+        *,
+        handle: SandboxHandle | None = None,
+        error: bool = False,
+    ) -> None:
+        attributes: dict[str, object] = {"curie.sandbox.outcome": outcome}
+        if handle is not None:
+            attributes.update(
+                {
+                    "curie.session_id": handle.session_id,
+                    "curie.sandbox_id": handle.sandbox_name,
+                }
+            )
+        for key, value in sanitize_attributes("curie-worker", attributes).items():
+            span.set_attribute(key, value)
+        span.set_status(Status(StatusCode.ERROR if error else StatusCode.OK))
 
     # -- claim / lookup -------------------------------------------------------
 
@@ -112,21 +139,52 @@ class SandboxSubstrate:
         history ref); the fast path passes none so the claim binds a pre-warmed
         generic sandbox.
         """
+        with self._tracer.start_as_current_span(
+            "sandbox.claim",
+            kind=SpanKind.INTERNAL,
+            record_exception=False,
+            set_status_on_exception=False,
+        ) as span:
+            try:
+                record = self._affinity.get(thread_key)
+                if record is not None:
+                    if record.state is RouteState.SUSPENDED:
+                        self._finish_lifecycle_span(span, "suspended")
+                        raise SuspendedThreadError(thread_key)
+                    sandbox = self._k8s.get_sandbox(record.handle.sandbox_name)
+                    if sandbox is not None and sandbox.operating_mode == "Running":
+                        self._affinity.touch(thread_key, self._config.route_ttl_seconds)
+                        self._finish_lifecycle_span(
+                            span,
+                            "reused",
+                            handle=record.handle,
+                        )
+                        return record.handle
+                    # The sandbox died (or was suspended) out from under a live
+                    # route: never hand it back or let it win the fresh race.
+                    self._evict_stale(thread_key, record)
 
-        record = self._affinity.get(thread_key)
-        if record is not None:
-            if record.state is RouteState.SUSPENDED:
-                raise SuspendedThreadError(thread_key)
-            sandbox = self._k8s.get_sandbox(record.handle.sandbox_name)
-            if sandbox is not None and sandbox.operating_mode == "Running":
-                self._affinity.touch(thread_key, self._config.route_ttl_seconds)
-                return record.handle
-            # The sandbox died (or was suspended) out from under a live route:
-            # a stale route must never be handed back, and must not win the
-            # re-claim race below. Evict it and bind fresh.
-            self._evict_stale(thread_key, record)
-
-        return self._claim_fresh(thread_key, env=env, state=RouteState.LIVE)
+                handle, outcome = self._claim_fresh(
+                    thread_key,
+                    env=env,
+                    state=RouteState.LIVE,
+                )
+            except CapacityExhaustedError:
+                self._finish_lifecycle_span(span, "capacity", error=True)
+                raise
+            except ClaimTimeoutError:
+                self._finish_lifecycle_span(span, "timeout", error=True)
+                raise
+            except SuspendedThreadError:
+                # Also covers a suspended winner appearing in the fresh-claim
+                # race, not only the route observed before creation.
+                self._finish_lifecycle_span(span, "suspended")
+                raise
+            except Exception:
+                self._finish_lifecycle_span(span, "error", error=True)
+                raise
+            self._finish_lifecycle_span(span, outcome, handle=handle)
+            return handle
 
     def lookup(self, thread_key: str) -> SandboxHandle | None:
         """The thread's live handle, or None (no route, suspended, or the
@@ -150,13 +208,30 @@ class SandboxSubstrate:
         rebuild session state later.
         """
 
-        record = self._affinity.get(thread_key)
-        if record is None:
-            raise NoRouteError(thread_key)
-        self._k8s.set_sandbox_mode(record.handle.sandbox_name, "Suspended")
-        self._affinity.mark_suspended(
-            thread_key, history_ref, self._config.suspended_route_ttl_seconds
-        )
+        with self._tracer.start_as_current_span(
+            "sandbox.suspend",
+            kind=SpanKind.INTERNAL,
+            record_exception=False,
+            set_status_on_exception=False,
+        ) as span:
+            try:
+                record = self._affinity.get(thread_key)
+                if record is None:
+                    raise NoRouteError(thread_key)
+                self._k8s.set_sandbox_mode(record.handle.sandbox_name, "Suspended")
+                self._affinity.mark_suspended(
+                    thread_key,
+                    history_ref,
+                    self._config.suspended_route_ttl_seconds,
+                )
+            except Exception:
+                self._finish_lifecycle_span(span, "error", error=True)
+                raise
+            self._finish_lifecycle_span(
+                span,
+                "suspended",
+                handle=record.handle,
+            )
 
     def resume(
         self, thread_key: str, *, env: dict[str, str] | None = None
@@ -176,26 +251,44 @@ class SandboxSubstrate:
         mint one (issue #63: the old token died with the old claim).
         """
 
-        record = self._affinity.get(thread_key)
-        if record is None:
-            raise NoRouteError(thread_key)
-        old = record.handle
-        boot = dict(env) if env else {}
-        boot.setdefault(SESSION_ENV, old.session_id)
-        if not boot.get(RUNNER_TOKEN_ENV):
-            boot[RUNNER_TOKEN_ENV] = secrets.token_urlsafe(32)
-        if old.history_ref is not None:
-            boot.setdefault(HISTORY_ENV, old.history_ref)
+        with self._tracer.start_as_current_span(
+            "sandbox.resume",
+            kind=SpanKind.INTERNAL,
+            record_exception=False,
+            set_status_on_exception=False,
+        ) as span:
+            try:
+                record = self._affinity.get(thread_key)
+                if record is None:
+                    raise NoRouteError(thread_key)
+                old = record.handle
+                boot = dict(env) if env else {}
+                boot.setdefault(SESSION_ENV, old.session_id)
+                if not boot.get(RUNNER_TOKEN_ENV):
+                    boot[RUNNER_TOKEN_ENV] = secrets.token_urlsafe(32)
+                if old.history_ref is not None:
+                    boot.setdefault(HISTORY_ENV, old.history_ref)
 
-        self._k8s.delete_claim(old.claim_name)
-        self._affinity.delete_if_claim(thread_key, old.claim_name)
-        return self._claim_fresh(
-            thread_key,
-            env=boot,
-            state=RouteState.LIVE,
-            session_id=old.session_id,
-            history_ref=old.history_ref,
-        )
+                self._k8s.delete_claim(old.claim_name)
+                self._affinity.delete_if_claim(thread_key, old.claim_name)
+                handle, _claim_outcome = self._claim_fresh(
+                    thread_key,
+                    env=boot,
+                    state=RouteState.LIVE,
+                    session_id=old.session_id,
+                    history_ref=old.history_ref,
+                )
+            except CapacityExhaustedError:
+                self._finish_lifecycle_span(span, "capacity", error=True)
+                raise
+            except ClaimTimeoutError:
+                self._finish_lifecycle_span(span, "timeout", error=True)
+                raise
+            except Exception:
+                self._finish_lifecycle_span(span, "error", error=True)
+                raise
+            self._finish_lifecycle_span(span, "resumed", handle=handle)
+            return handle
 
     # -- release / reap -------------------------------------------------------
 
@@ -204,12 +297,28 @@ class SandboxSubstrate:
         deletes its sandbox and pod) and drop the route. True if a route
         existed."""
 
-        record = self._affinity.get(thread_key)
-        if record is None:
-            return False
-        self._k8s.delete_claim(record.handle.claim_name)
-        self._affinity.delete_if_claim(thread_key, record.handle.claim_name)
-        return True
+        with self._tracer.start_as_current_span(
+            "sandbox.release",
+            kind=SpanKind.INTERNAL,
+            record_exception=False,
+            set_status_on_exception=False,
+        ) as span:
+            try:
+                record = self._affinity.get(thread_key)
+                if record is None:
+                    self._finish_lifecycle_span(span, "missing")
+                    return False
+                self._k8s.delete_claim(record.handle.claim_name)
+                self._affinity.delete_if_claim(thread_key, record.handle.claim_name)
+            except Exception:
+                self._finish_lifecycle_span(span, "error", error=True)
+                raise
+            self._finish_lifecycle_span(
+                span,
+                "released",
+                handle=record.handle,
+            )
+            return True
 
     def reap_orphans(self) -> list[str]:
         """Delete substrate-managed claims that no live route references AND
@@ -284,7 +393,7 @@ class SandboxSubstrate:
         state: RouteState,
         session_id: str | None = None,
         history_ref: str | None = None,
-    ) -> SandboxHandle:
+    ) -> tuple[SandboxHandle, str]:
         config = self._config
         nonce = uuid.uuid4().hex[:6]
         name = config.claim_name_for(thread_key, nonce)
@@ -318,7 +427,7 @@ class SandboxSubstrate:
         record = RouteRecord(handle=handle, state=state)
         for _ in range(3):
             if self._affinity.put_if_absent(thread_key, record, config.route_ttl_seconds):
-                return handle
+                return handle, "created"
             # Lost the race: another worker recorded a route first. Adopt the
             # winner only if its sandbox is actually alive; a stale route
             # (dead sandbox) is evicted and the put retried.
@@ -331,7 +440,7 @@ class SandboxSubstrate:
             sandbox = self._k8s.get_sandbox(winner.handle.sandbox_name)
             if sandbox is not None and sandbox.operating_mode == "Running":
                 self._k8s.delete_claim(name)
-                return winner.handle
+                return winner.handle, "adopted"
             self._evict_stale(thread_key, winner)
         self._k8s.delete_claim(name)
         raise NoRouteError(f"could not record a route for {thread_key} after repeated races")

--- a/apps/worker/tests/binding/test_boot_env_single_declaration.py
+++ b/apps/worker/tests/binding/test_boot_env_single_declaration.py
@@ -162,6 +162,34 @@ _NON_BOOT_ALLOWLIST: frozenset[str] = frozenset(
         # substrate relays to a child as its standard OTEL endpoint. The private
         # relay name is read only by run.py and never enters runner boot env.
         "CURIE_RUNNER_OTEL_EXPORTER_OTLP_ENDPOINT",
+        # Standard OTLP exporter tuning relayed verbatim from the worker process
+        # into a Docker runner for #1817. These are owned by OpenTelemetry (not
+        # Curie's frozen BootEnv schema); the three generic keys BootEnv already
+        # knows remain derived from that declaration at their source sites.
+        "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+        "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT",
+        "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL",
+        "OTEL_EXPORTER_OTLP_LOGS_PROTOCOL",
+        "OTEL_EXPORTER_OTLP_TRACES_HEADERS",
+        "OTEL_EXPORTER_OTLP_LOGS_HEADERS",
+        "OTEL_EXPORTER_OTLP_TIMEOUT",
+        "OTEL_EXPORTER_OTLP_TRACES_TIMEOUT",
+        "OTEL_EXPORTER_OTLP_LOGS_TIMEOUT",
+        "OTEL_EXPORTER_OTLP_COMPRESSION",
+        "OTEL_EXPORTER_OTLP_TRACES_COMPRESSION",
+        "OTEL_EXPORTER_OTLP_LOGS_COMPRESSION",
+        "OTEL_EXPORTER_OTLP_CERTIFICATE",
+        "OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE",
+        "OTEL_EXPORTER_OTLP_LOGS_CERTIFICATE",
+        "OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE",
+        "OTEL_EXPORTER_OTLP_TRACES_CLIENT_CERTIFICATE",
+        "OTEL_EXPORTER_OTLP_LOGS_CLIENT_CERTIFICATE",
+        "OTEL_EXPORTER_OTLP_CLIENT_KEY",
+        "OTEL_EXPORTER_OTLP_TRACES_CLIENT_KEY",
+        "OTEL_EXPORTER_OTLP_LOGS_CLIENT_KEY",
+        "OTEL_EXPORTER_OTLP_INSECURE",
+        "OTEL_EXPORTER_OTLP_TRACES_INSECURE",
+        "OTEL_EXPORTER_OTLP_LOGS_INSECURE",
         "CURIE_SANDBOX_SUBSTRATE",
         "CURIE_WARM_POOL",
         # The runner-facing API base (#678): WorkerConfig reads it from the
@@ -254,16 +282,6 @@ _EXEMPT: dict[tuple[str, str], str] = {
     ): "worker service config",
     ("apps/worker/src/curie_worker/config.py", "CURIE_MODEL_ENV_KEY"): "worker service config",
     ("apps/worker/src/curie_worker/eval/run.py", "CURIE_MODEL"): "eval entrypoint env read",
-    # run.py reads the WORKER's own OTel endpoint -- the standard var its own
-    # deployment sets to point the worker process at the collector -- to warn when
-    # middle mode has none and to hand the docker client a target. The consumer is
-    # the worker process; the name it later writes INTO a container is read from
-    # the declaration (sandbox/docker.py). Renaming the boot key must not rename
-    # the worker's own OTel var, so this site is not the drift.
-    (
-        "apps/worker/src/curie_worker/run.py",
-        "OTEL_EXPORTER_OTLP_ENDPOINT",
-    ): "worker service config",
     # Substrate-authoritative producers. The chart/docker own pod identity and
     # the runner port; the worker must never render them (see BootEnv).
     ("apps/worker/src/curie_worker/run.py", "CURIE_RUNNER_PORT"): "substrate producer",

--- a/apps/worker/tests/binding/test_boot_env_single_declaration.py
+++ b/apps/worker/tests/binding/test_boot_env_single_declaration.py
@@ -158,6 +158,10 @@ _NON_BOOT_ALLOWLIST: frozenset[str] = frozenset(
         "CURIE_CONNECTOR_RECONCILE_INTERVAL_S",
         "CURIE_CONNECTOR_APP_NAME",
         "CURIE_RUNNER_IMAGE",
+        # Worker service config for selecting the collector address the Docker
+        # substrate relays to a child as its standard OTEL endpoint. The private
+        # relay name is read only by run.py and never enters runner boot env.
+        "CURIE_RUNNER_OTEL_EXPORTER_OTLP_ENDPOINT",
         "CURIE_SANDBOX_SUBSTRATE",
         "CURIE_WARM_POOL",
         # The runner-facing API base (#678): WorkerConfig reads it from the

--- a/apps/worker/tests/conftest.py
+++ b/apps/worker/tests/conftest.py
@@ -1,0 +1,59 @@
+"""Worker-wide test helpers for observing OpenTelemetry output in memory.
+
+The recorder deliberately owns a private ``TracerProvider`` per test instead of
+installing one globally.  Worker components accept the runtime's tracer as an
+optional dependency, so telemetry tests can observe finished spans without
+changing the provider seen by unrelated tests (especially the no-endpoint
+bootstrap controls).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import SpanKind, Tracer
+
+
+@dataclass(frozen=True)
+class SpanRecorder:
+    """A private tracer and deterministic view of its completed spans."""
+
+    tracer: Tracer
+    exporter: InMemorySpanExporter
+
+    def spans(
+        self,
+        *,
+        name: str | None = None,
+        kind: SpanKind | None = None,
+    ) -> list[ReadableSpan]:
+        spans = list(self.exporter.get_finished_spans())
+        if name is not None:
+            spans = [span for span in spans if span.name == name]
+        if kind is not None:
+            spans = [span for span in spans if span.kind is kind]
+        return spans
+
+    def one(self, name: str) -> ReadableSpan:
+        matches = self.spans(name=name)
+        assert len(matches) == 1, f"expected one {name!r} span, got {matches}"
+        return matches[0]
+
+    def clear(self) -> None:
+        self.exporter.clear()
+
+
+@pytest.fixture
+def span_recorder() -> SpanRecorder:
+    provider = TracerProvider()
+    exporter = InMemorySpanExporter()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    recorder = SpanRecorder(provider.get_tracer("curie-worker-tests"), exporter)
+    try:
+        yield recorder
+    finally:
+        provider.shutdown()

--- a/apps/worker/tests/kernel/conftest.py
+++ b/apps/worker/tests/kernel/conftest.py
@@ -534,6 +534,7 @@ async def kernel_harness(
     approvals: object | None = None,
     approval_reader: object | None = None,
     sink: object | None = None,
+    tracer: object | None = None,
     claim_timeout_seconds: float = 3.0,
     **config_overrides: object,
 ) -> AsyncIterator[Harness]:
@@ -546,6 +547,7 @@ async def kernel_harness(
     assert port is not None
 
     fake_k8s = FakeK8s()
+    telemetry_kwargs = {"tracer": tracer} if tracer is not None else {}
     substrate = SandboxSubstrate(
         fake_k8s,  # type: ignore[arg-type]
         AffinityStore(sync_redis, key_prefix=names["sandbox_prefix"]),
@@ -558,12 +560,16 @@ async def kernel_harness(
             poll_interval_seconds=0.005,
             key_prefix=names["sandbox_prefix"],
         ),
+        **telemetry_kwargs,  # type: ignore[arg-type]
     )
     async_redis: AsyncRedis = AsyncRedis(
         host=_VALKEY_HOST, port=_VALKEY_PORT, password=_VALKEY_PW or None, decode_responses=True
     )
     reply_sink = FakeSink() if sink is None else sink
-    runner_client = RunnerClient(total_timeout_s=30.0)
+    runner_client = RunnerClient(
+        total_timeout_s=30.0,
+        **telemetry_kwargs,  # type: ignore[arg-type]
+    )
     card_store = ApprovalCardStore(async_redis, config)
     kernel = Kernel(
         substrate=substrate,
@@ -581,6 +587,7 @@ async def kernel_harness(
         approvals=approvals,  # type: ignore[arg-type]
         approval_reader=approval_reader,  # type: ignore[arg-type]
         card_store=card_store,
+        **telemetry_kwargs,  # type: ignore[arg-type]
     )
     killswitch = None
     if with_killswitch:

--- a/apps/worker/tests/kernel/test_runner_client.py
+++ b/apps/worker/tests/kernel/test_runner_client.py
@@ -7,13 +7,26 @@ is what TurnStream.close (called from __aexit__) invokes."""
 from __future__ import annotations
 
 import asyncio
+import json
 from typing import Any
 
 import pytest
 from aci_protocol import Event, Final, SessionStatus, TextDelta
 from aiohttp import web
 from aiohttp.test_utils import TestServer
-from curie_worker.runner_client import RunnerClient
+from curie_worker.runner_client import RunnerClient, RunnerError
+from opentelemetry import baggage
+from opentelemetry.context import attach, detach
+from opentelemetry.sdk.trace import ReadableSpan
+from opentelemetry.trace import (
+    NonRecordingSpan,
+    SpanContext,
+    SpanKind,
+    StatusCode,
+    TraceFlags,
+    TraceState,
+    set_span_in_context,
+)
 
 DONE = SessionStatus.DONE
 
@@ -127,7 +140,9 @@ def test_runner_client_sends_bearer_token_on_every_call() -> None:
         runner = _HeaderRecordingRunner()
         server = TestServer(runner.app)
         await server.start_server()
-        base_url = f"http://127.0.0.1:{server.port}"
+        port = server.port
+        assert port is not None
+        base_url = f"http://127.0.0.1:{port}"
         client = RunnerClient(total_timeout_s=30.0)
         try:
             turn = await client.start_turn(base_url, _event(), token="tok-1")
@@ -214,5 +229,244 @@ def test_interrupt_is_bounded_by_its_own_timeout_not_the_streaming_budget() -> N
             runner.hang.set()
             await client.close()
             await server.close()
+
+    asyncio.run(go())
+
+
+# --- W3C propagation + manually-owned streamed CLIENT spans (#1817) ----------
+
+
+def _client_spans(span_recorder) -> list[ReadableSpan]:
+    return span_recorder.spans(kind=SpanKind.CLIENT)
+
+
+def _span_payload(span: ReadableSpan) -> str:
+    return repr(
+        (
+            span.name,
+            dict(span.attributes or {}),
+            [
+                (event.name, dict(event.attributes or {}))
+                for event in span.events
+            ],
+            span.status.description,
+        )
+    )
+
+
+def test_runner_http_injects_w3c_separately_from_auth_and_never_baggage(
+    span_recorder,
+) -> None:
+    async def go() -> None:
+        runner = _HeaderRecordingRunner()
+        server = TestServer(runner.app)
+        await server.start_server()
+        port = server.port
+        assert port is not None
+        base_url = f"http://127.0.0.1:{port}"
+        client = RunnerClient(total_timeout_s=30.0, tracer=span_recorder.tracer)
+        trace_id = int("1234567890abcdef1234567890abcdef", 16)
+        parent_span_id = int("1234567890abcdef", 16)
+        remote = SpanContext(
+            trace_id=trace_id,
+            span_id=parent_span_id,
+            is_remote=True,
+            trace_flags=TraceFlags(TraceFlags.SAMPLED),
+            trace_state=TraceState([("vendor", "opaque-example")]),
+        )
+        context = set_span_in_context(NonRecordingSpan(remote))
+        baggage_value = "PRIVATE-BAGGAGE-MUST-NOT-CROSS"
+        context = baggage.set_baggage("private-example", baggage_value, context=context)
+        token = attach(context)
+        auth = "auth-PLACEHOLDER-never-export"
+        try:
+            turn = await client.start_turn(base_url, _event(), token=auth)
+            # A streamed CLIENT span belongs to TurnStream, not merely to the
+            # response headers.  It cannot finish until the caller consumes or
+            # explicitly abandons that owner.
+            assert _client_spans(span_recorder) == []
+            await _drain(turn)
+            assert len(_client_spans(span_recorder)) == 1
+            await client.steer(base_url, _event(), token=auth)
+            await client.interrupt(base_url, "stop", token=auth)
+        finally:
+            detach(token)
+            await client.close()
+            await server.close()
+
+        expected_prefix = f"00-{trace_id:032x}-"
+        for route in ("event", "steer", "interrupt"):
+            headers = runner.headers[route]
+            assert headers["Authorization"] == f"Bearer {auth}"
+            assert headers["traceparent"].startswith(expected_prefix)
+            assert headers["tracestate"] == "vendor=opaque-example"
+            assert "baggage" not in {name.lower() for name in headers}
+
+        spans = _client_spans(span_recorder)
+        assert len(spans) == 3
+        for span in spans:
+            assert span.context is not None
+            assert span.context.trace_id == trace_id
+            assert span.parent is not None
+            assert span.parent.span_id == parent_span_id
+            assert span.status.status_code is StatusCode.OK
+            assert span.attributes is not None
+            assert span.attributes["http.request.method"] == "POST"
+            assert span.attributes["server.address"] == "127.0.0.1"
+            assert span.attributes["server.port"] == port
+            assert span.attributes["http.response.status_code"] == 200
+            exported = _span_payload(span)
+            assert auth not in exported
+            assert baggage_value not in exported
+            assert "/v1/" not in repr(dict(span.attributes))
+
+    asyncio.run(go())
+
+
+class _ResponseFailureRunner:
+    def __init__(self, *, status: int, body: str) -> None:
+        self.app = web.Application()
+        self.app.add_routes([web.post("/v1/event", self._event)])
+        self.status = status
+        self.body = body
+
+    async def _event(self, _request: web.Request) -> web.Response:
+        return web.Response(status=self.status, text=self.body)
+
+
+def test_non_200_ends_client_span_error_without_body_or_auth_leak(
+    span_recorder,
+) -> None:
+    async def go() -> None:
+        body = "PRIVATE-RUNNER-ERROR-BODY-MUST-NOT-BE-EXPORTED"
+        auth = "auth-PLACEHOLDER-error-path"
+        runner = _ResponseFailureRunner(status=503, body=body)
+        server = TestServer(runner.app)
+        await server.start_server()
+        client = RunnerClient(total_timeout_s=30.0, tracer=span_recorder.tracer)
+        try:
+            with pytest.raises(RunnerError):
+                await client.start_turn(
+                    f"http://127.0.0.1:{server.port}",
+                    _event(),
+                    token=auth,
+                )
+        finally:
+            await client.close()
+            await server.close()
+
+        spans = _client_spans(span_recorder)
+        assert len(spans) == 1
+        span = spans[0]
+        assert span.status.status_code is StatusCode.ERROR
+        assert span.attributes is not None
+        assert span.attributes["http.response.status_code"] == 503
+        assert body not in _span_payload(span)
+        assert auth not in _span_payload(span)
+
+    asyncio.run(go())
+
+
+class _MalformedStreamRunner:
+    def __init__(self, raw: bytes) -> None:
+        self.app = web.Application()
+        self.app.add_routes([web.post("/v1/event", self._event)])
+        self.raw = raw
+
+    async def _event(self, request: web.Request) -> web.StreamResponse:
+        response = web.StreamResponse(
+            status=200,
+            headers={"Content-Type": "application/x-ndjson"},
+        )
+        await response.prepare(request)
+        await response.write(self.raw + b"\n")
+        await response.write_eof()
+        return response
+
+
+def test_decode_failure_ends_stream_span_error_without_line_content(
+    span_recorder,
+) -> None:
+    async def go() -> None:
+        raw = b"PRIVATE-MALFORMED-NDJSON-MUST-NOT-BE-EXPORTED"
+        runner = _MalformedStreamRunner(raw)
+        server = TestServer(runner.app)
+        await server.start_server()
+        client = RunnerClient(total_timeout_s=30.0, tracer=span_recorder.tracer)
+        try:
+            turn = await client.start_turn(f"http://127.0.0.1:{server.port}", _event())
+            with pytest.raises((json.JSONDecodeError, RunnerError)):
+                await _drain(turn)
+        finally:
+            await client.close()
+            await server.close()
+
+        spans = _client_spans(span_recorder)
+        assert len(spans) == 1
+        assert spans[0].status.status_code is StatusCode.ERROR
+        assert raw.decode() not in _span_payload(spans[0])
+
+    asyncio.run(go())
+
+
+def test_explicit_abandonment_ends_stream_span_once(span_recorder) -> None:
+    async def go() -> None:
+        runner = _HeaderRecordingRunner()
+        server = TestServer(runner.app)
+        await server.start_server()
+        client = RunnerClient(total_timeout_s=30.0, tracer=span_recorder.tracer)
+        try:
+            turn = await client.start_turn(f"http://127.0.0.1:{server.port}", _event())
+            assert _client_spans(span_recorder) == []
+            turn.close()
+            turn.close()  # idempotent ownership: no duplicate end/export
+        finally:
+            await client.close()
+            await server.close()
+
+        assert len(_client_spans(span_recorder)) == 1
+
+    asyncio.run(go())
+
+
+class _HangingStreamRunner:
+    def __init__(self) -> None:
+        self.app = web.Application()
+        self.app.add_routes([web.post("/v1/event", self._event)])
+        self.release = asyncio.Event()
+
+    async def _event(self, request: web.Request) -> web.StreamResponse:
+        response = web.StreamResponse(
+            status=200,
+            headers={"Content-Type": "application/x-ndjson"},
+        )
+        await response.prepare(request)
+        await response.write((TextDelta(text="safe").model_dump_json() + "\n").encode())
+        await self.release.wait()
+        await response.write_eof()
+        return response
+
+
+def test_stream_cancellation_ends_client_span_error(span_recorder) -> None:
+    async def go() -> None:
+        runner = _HangingStreamRunner()
+        server = TestServer(runner.app)
+        await server.start_server()
+        client = RunnerClient(total_timeout_s=30.0, tracer=span_recorder.tracer)
+        try:
+            turn = await client.start_turn(f"http://127.0.0.1:{server.port}", _event())
+            drain = asyncio.create_task(_drain(turn))
+            await asyncio.sleep(0)
+            drain.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await drain
+        finally:
+            runner.release.set()
+            await client.close()
+            await server.close()
+
+        spans = _client_spans(span_recorder)
+        assert len(spans) == 1
+        assert spans[0].status.status_code is StatusCode.ERROR
 
     asyncio.run(go())

--- a/apps/worker/tests/kernel/test_runner_client.py
+++ b/apps/worker/tests/kernel/test_runner_client.py
@@ -299,7 +299,7 @@ def test_runner_http_injects_w3c_separately_from_auth_and_never_baggage(
             headers = runner.headers[route]
             assert headers["Authorization"] == f"Bearer {auth}"
             assert headers["traceparent"].startswith(expected_prefix)
-            assert headers["tracestate"] == "vendor=opaque-example"
+            assert "tracestate" not in {name.lower() for name in headers}
             assert "baggage" not in {name.lower() for name in headers}
 
         spans = _client_spans(span_recorder)
@@ -312,7 +312,7 @@ def test_runner_http_injects_w3c_separately_from_auth_and_never_baggage(
             assert span.status.status_code is StatusCode.OK
             assert span.attributes is not None
             assert span.attributes["http.request.method"] == "POST"
-            assert span.attributes["server.address"] == "127.0.0.1"
+            assert span.attributes["server.address"] == "runner"
             assert span.attributes["server.port"] == port
             assert span.attributes["http.response.status_code"] == 200
             exported = _span_payload(span)
@@ -345,7 +345,7 @@ def test_non_200_ends_client_span_error_without_body_or_auth_leak(
         await server.start_server()
         client = RunnerClient(total_timeout_s=30.0, tracer=span_recorder.tracer)
         try:
-            with pytest.raises(RunnerError):
+            with pytest.raises(RunnerError, match=body):
                 await client.start_turn(
                     f"http://127.0.0.1:{server.port}",
                     _event(),
@@ -395,7 +395,7 @@ def test_decode_failure_ends_stream_span_error_without_line_content(
         client = RunnerClient(total_timeout_s=30.0, tracer=span_recorder.tracer)
         try:
             turn = await client.start_turn(f"http://127.0.0.1:{server.port}", _event())
-            with pytest.raises((json.JSONDecodeError, RunnerError)):
+            with pytest.raises(json.JSONDecodeError, match=r"line 1 column 1"):
                 await _drain(turn)
         finally:
             await client.close()

--- a/apps/worker/tests/kernel/test_telemetry.py
+++ b/apps/worker/tests/kernel/test_telemetry.py
@@ -106,6 +106,16 @@ def _span_payload(span: ReadableSpan) -> str:
     )
 
 
+async def _wait_until(pred: Callable[[], bool], timeout: float = 5.0) -> None:
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while loop.time() < deadline:
+        if pred():
+            return
+        await asyncio.sleep(0.01)
+    raise AssertionError("condition not met before timeout")
+
+
 async def _deliver_new(
     consumer: Consumer,
     h: Any,
@@ -124,13 +134,18 @@ async def _deliver_new(
     [(read_id, read_fields)] = delivered[0][1]
     assert read_id == entry_id
     await consumer._dispatch(read_id, read_fields)
-    await asyncio.gather(*list(consumer._inflight))
+    # A fast handler can finish between ``_dispatch`` returning and a snapshot
+    # of ``_inflight``; its done callback then removes the task before the test
+    # can await it.  The entry remains in ``_inflight_ids`` until _handle's
+    # finally block has ended the process span, so its removal is the stable,
+    # observable settlement boundary these assertions need.
+    await _wait_until(lambda: read_id not in consumer._inflight_ids)
     return entry_id
 
 
 async def _reclaim_and_settle(consumer: Consumer) -> None:
     await consumer._reclaim_once()
-    await asyncio.gather(*list(consumer._inflight))
+    await _wait_until(lambda: not consumer._inflight_ids)
 
 
 def test_valid_valkey_carrier_parents_process_span_and_success_acks(
@@ -395,16 +410,6 @@ def test_kernel_turn_events_preserve_dedupe_and_finish_race_routing(
             assert {"worker.route.finish_race", "worker.route.start"} <= names[2]
 
     asyncio.run(go())
-
-
-async def _wait_until(pred: Callable[[], bool], timeout: float = 5.0) -> None:
-    loop = asyncio.get_running_loop()
-    deadline = loop.time() + timeout
-    while loop.time() < deadline:
-        if pred():
-            return
-        await asyncio.sleep(0.01)
-    raise AssertionError("condition not met before timeout")
 
 
 def test_kernel_live_followup_emits_steer_without_forking_a_turn(

--- a/apps/worker/tests/kernel/test_telemetry.py
+++ b/apps/worker/tests/kernel/test_telemetry.py
@@ -1,0 +1,541 @@
+"""Whole-turn worker telemetry regressions for issue #1817.
+
+These are seam tests, not mocks of Valkey or HTTP.  Queue delivery and
+settlement use the real local Valkey, while the kernel harness keeps its
+existing in-process runner and reply sink.  Reverting transport extraction or
+any worker instrumentation must therefore break parent IDs/status/events while
+the unchanged routing assertions continue to guard the sacred kernel.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+from aci_protocol import Final, QueuedTurn, ReplyHandle, SessionStatus, TextDelta
+from curie_dispatcher.queue import to_stream_fields
+from curie_telemetry import TRACE_CONTEXT_FIELD, inject_trace_context
+from curie_telemetry.attributes import event_names_for
+from curie_worker.behaviorpacks import BehaviorPacks
+from curie_worker.consumer import Consumer
+from opentelemetry.sdk.trace import ReadableSpan
+from opentelemetry.trace import SpanKind, StatusCode
+
+DONE = SessionStatus.DONE
+FAILED = SessionStatus.CLASSIFIED_FAILURE
+
+_WORKER_EVENTS = frozenset(
+    {
+        "trace_context.invalid",
+        "messaging.ack",
+        "messaging.pending",
+        "messaging.dead_letter",
+        "worker.dedupe.checked",
+        "worker.dedupe.skip",
+        "worker.lock.wait",
+        "worker.lock.acquired",
+        "worker.route.start",
+        "worker.route.steer",
+        "worker.route.finish_race",
+        "worker.reply.final",
+        "worker.completion.settled",
+        "worker.terminal",
+    }
+)
+
+_MALFORMED_SENTINEL = "SENSITIVE-CARRIER-CONTENT-MUST-NOT-BE-LOGGED"
+_VALID_LOOKING_TRACEPARENT = (
+    "00-1234567890abcdef1234567890abcdef-1234567890abcdef-01"
+)
+_MALFORMED_CARRIERS = (
+    f'["{_MALFORMED_SENTINEL}"]',
+    (
+        f'{{"traceparent":"{_VALID_LOOKING_TRACEPARENT}",'
+        f'"unexpected":"{_MALFORMED_SENTINEL}"}}'
+    ),
+    f'{{"traceparent":"invalid-{_MALFORMED_SENTINEL}"}}',
+    f'{{"traceparent":"{"x" * 8192}{_MALFORMED_SENTINEL}"}}',
+)
+
+
+def test_worker_event_vocabulary_is_the_closed_shared_registry() -> None:
+    assert event_names_for("curie-worker") == _WORKER_EVENTS
+
+
+def _qevent(
+    text: str = "safe test turn",
+    *,
+    thread: str = "thread-example",
+    event_id: str | None = None,
+) -> QueuedTurn:
+    return QueuedTurn(
+        event_id=event_id or uuid.uuid4().hex,
+        conversation_id=thread,
+        author="U0EXAMPLE1",
+        text=text,
+        reply_handle=ReplyHandle(
+            kind="slack",
+            channel="C0EXAMPLE1",
+            placeholder="1700000000.000100",
+        ),
+        received_at="2026-07-05T00:00:00+00:00",
+    )
+
+
+def _event_names(span: ReadableSpan) -> set[str]:
+    return {event.name for event in span.events}
+
+
+def _span_payload(span: ReadableSpan) -> str:
+    """Only exported names/attributes/events, never timing or object reprs."""
+
+    return repr(
+        (
+            span.name,
+            dict(span.attributes or {}),
+            [
+                (event.name, dict(event.attributes or {}))
+                for event in span.events
+            ],
+            span.status.description,
+        )
+    )
+
+
+async def _deliver_new(
+    consumer: Consumer,
+    h: Any,
+    fields: dict[str, str],
+) -> str:
+    """XADD, group-deliver and settle one entry without a racing read loop."""
+
+    entry_id = await h.async_redis.xadd(h.config.stream, fields)
+    delivered = await h.async_redis.xreadgroup(
+        h.config.consumer_group,
+        h.config.consumer_name,
+        {h.config.stream: ">"},
+        count=1,
+    )
+    assert delivered and delivered[0][1]
+    [(read_id, read_fields)] = delivered[0][1]
+    assert read_id == entry_id
+    await consumer._dispatch(read_id, read_fields)
+    await asyncio.gather(*list(consumer._inflight))
+    return entry_id
+
+
+async def _reclaim_and_settle(consumer: Consumer) -> None:
+    await consumer._reclaim_once()
+    await asyncio.gather(*list(consumer._inflight))
+
+
+def test_valid_valkey_carrier_parents_process_span_and_success_acks(
+    make_harness,
+    span_recorder,
+) -> None:
+    async def go() -> None:
+        async with make_harness(tracer=span_recorder.tracer) as h:
+            h.runner.default_script = [Final(text="safe answer", status=DONE)]
+            consumer = Consumer(
+                redis=h.async_redis,
+                kernel=h.kernel,
+                config=h.config,
+                tracer=span_recorder.tracer,
+            )
+            await consumer.ensure_group()
+
+            with span_recorder.tracer.start_as_current_span("test.producer") as producer:
+                producer_context = producer.get_span_context()
+                carrier = inject_trace_context()
+            assert carrier is not None
+
+            prompt = "PRIVATE-PROMPT-MUST-NOT-BE-AN-ATTRIBUTE"
+            fields = to_stream_fields(_qevent(prompt))
+            fields[TRACE_CONTEXT_FIELD] = carrier
+            await _deliver_new(consumer, h, fields)
+
+            process = span_recorder.one("process curie:runs")
+            assert process.kind is SpanKind.CONSUMER
+            assert process.status.status_code is StatusCode.OK
+            assert process.attributes is not None
+            assert process.attributes["messaging.system"] == "valkey"
+            assert process.attributes["messaging.destination.name"] == h.config.stream
+            assert process.attributes["messaging.operation.type"] == "process"
+            assert process.context is not None
+            assert process.context.trace_id == producer_context.trace_id
+            assert process.parent is not None
+            assert process.parent.span_id == producer_context.span_id
+            assert "messaging.ack" in _event_names(process)
+            assert h.sink.last_text == "safe answer"
+            pending = await h.async_redis.xpending(
+                h.config.stream, h.config.consumer_group
+            )
+            assert pending["pending"] == 0
+            assert all(
+                prompt not in _span_payload(span) for span in span_recorder.spans()
+            )
+
+    asyncio.run(go())
+
+
+def test_payload_only_valkey_entry_starts_a_root_and_still_completes(
+    make_harness,
+    span_recorder,
+) -> None:
+    async def go() -> None:
+        async with make_harness(tracer=span_recorder.tracer) as h:
+            h.runner.default_script = [Final(text="payload-only answer", status=DONE)]
+            consumer = Consumer(
+                redis=h.async_redis,
+                kernel=h.kernel,
+                config=h.config,
+                tracer=span_recorder.tracer,
+            )
+            await consumer.ensure_group()
+            fields = to_stream_fields(_qevent(thread="payload-only-thread"))
+            fields.pop(TRACE_CONTEXT_FIELD, None)
+
+            await _deliver_new(consumer, h, fields)
+
+            process = span_recorder.one("process curie:runs")
+            assert process.parent is None
+            assert process.status.status_code is StatusCode.OK
+            assert "messaging.ack" in _event_names(process)
+            assert h.sink.last_text == "payload-only answer"
+
+    asyncio.run(go())
+
+
+@pytest.mark.parametrize("raw", _MALFORMED_CARRIERS)
+def test_malformed_valkey_carrier_is_value_free_warning_and_fail_open(
+    raw: str,
+    make_harness,
+    span_recorder,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    async def go() -> None:
+        async with make_harness(tracer=span_recorder.tracer) as h:
+            h.runner.default_script = [Final(text="malformed-carrier answer", status=DONE)]
+            consumer = Consumer(
+                redis=h.async_redis,
+                kernel=h.kernel,
+                config=h.config,
+                tracer=span_recorder.tracer,
+            )
+            await consumer.ensure_group()
+            fields = to_stream_fields(_qevent(thread="malformed-carrier-thread"))
+            fields[TRACE_CONTEXT_FIELD] = raw
+
+            with caplog.at_level(logging.WARNING):
+                await _deliver_new(consumer, h, fields)
+
+            process = span_recorder.one("process curie:runs")
+            assert process.parent is None
+            assert process.status.status_code is StatusCode.OK
+            assert "trace_context.invalid" in _event_names(process)
+            assert "messaging.ack" in _event_names(process)
+            warnings = [
+                record
+                for record in caplog.records
+                if record.levelno >= logging.WARNING
+                and record.getMessage() == "ignored malformed trace context"
+            ]
+            assert warnings, "malformed carrier was ignored without a diagnostic"
+            assert raw not in caplog.text
+            assert _MALFORMED_SENTINEL not in caplog.text
+            assert h.sink.last_text == "malformed-carrier answer"
+
+    asyncio.run(go())
+
+
+def test_processing_exception_marks_error_and_leaves_entry_pending(
+    make_harness,
+    span_recorder,
+) -> None:
+    async def go() -> None:
+        async with make_harness(tracer=span_recorder.tracer) as h:
+            consumer = Consumer(
+                redis=h.async_redis,
+                kernel=h.kernel,
+                config=h.config,
+                tracer=span_recorder.tracer,
+            )
+            await consumer.ensure_group()
+
+            async def fail(_qevent: QueuedTurn) -> None:
+                raise RuntimeError("injected runner failure")
+
+            h.kernel.process_event = fail  # type: ignore[method-assign]
+            entry_id = await _deliver_new(consumer, h, to_stream_fields(_qevent()))
+
+            process = span_recorder.one("process curie:runs")
+            assert process.status.status_code is StatusCode.ERROR
+            assert "messaging.pending" in _event_names(process)
+            pending = await h.async_redis.xpending_range(
+                h.config.stream,
+                h.config.consumer_group,
+                min=entry_id,
+                max=entry_id,
+                count=1,
+            )
+            assert [row["message_id"] for row in pending] == [entry_id]
+
+    asyncio.run(go())
+
+
+def test_delivery_cap_dead_letter_retains_carrier_and_trace_settlement(
+    make_harness,
+    span_recorder,
+) -> None:
+    async def go() -> None:
+        async with make_harness(
+            tracer=span_recorder.tracer,
+            max_delivery=2,
+            reclaim_min_idle_ms=0,
+        ) as h:
+            consumer = Consumer(
+                redis=h.async_redis,
+                kernel=h.kernel,
+                config=h.config,
+                tracer=span_recorder.tracer,
+            )
+            await consumer.ensure_group()
+
+            async def fail(_qevent: QueuedTurn) -> None:
+                raise RuntimeError("permanent injected failure")
+
+            h.kernel.process_event = fail  # type: ignore[method-assign]
+            with span_recorder.tracer.start_as_current_span("test.producer") as producer:
+                producer_context = producer.get_span_context()
+                carrier = inject_trace_context()
+            assert carrier is not None
+            fields = to_stream_fields(_qevent(event_id="dead-letter-example"))
+            fields[TRACE_CONTEXT_FIELD] = carrier
+            entry_id = await _deliver_new(consumer, h, fields)
+
+            await _reclaim_and_settle(consumer)  # delivery 2, still pending
+            await _reclaim_and_settle(consumer)  # budget spent: XADD then XACK
+
+            rows = await h.async_redis.xrange(h.config.dead_letter_stream_name())
+            assert len(rows) == 1
+            _dead_id, dead = rows[0]
+            assert dead["dl_original_id"] == entry_id
+            assert dead[TRACE_CONTEXT_FIELD] == carrier
+            pending = await h.async_redis.xpending(
+                h.config.stream, h.config.consumer_group
+            )
+            assert pending["pending"] == 0
+
+            processes = [
+                span
+                for span in span_recorder.spans(name="process curie:runs")
+                if span.context.trace_id == producer_context.trace_id
+            ]
+            assert len(processes) == 3
+            assert all(span.parent is not None for span in processes)
+            assert any("messaging.dead_letter" in _event_names(span) for span in processes)
+            dead_letter_process = next(
+                span
+                for span in processes
+                if "messaging.dead_letter" in _event_names(span)
+            )
+            assert dead_letter_process.status.status_code is StatusCode.ERROR
+            assert carrier not in _span_payload(dead_letter_process)
+            await h.async_redis.delete(h.config.dead_letter_stream_name())
+
+    asyncio.run(go())
+
+
+def test_kernel_turn_events_preserve_dedupe_and_finish_race_routing(
+    make_harness,
+    span_recorder,
+) -> None:
+    async def go() -> None:
+        async with make_harness(tracer=span_recorder.tracer) as h:
+            h.runner.default_script = [Final(text="first answer", status=DONE)]
+            first = _qevent("first", thread="finish-race", event_id="first-example")
+            await h.kernel.process_event(first)
+            await h.kernel.process_event(first)
+
+            # The existing route is idle.  The steer returns 409 and the sacred
+            # kernel must open a new turn on that same sandbox.
+            h.runner.default_script = [Final(text="second answer", status=DONE)]
+            await h.kernel.process_event(
+                _qevent("second", thread="finish-race", event_id="second-example")
+            )
+
+            assert h.runner.opened == ["first", "second"]
+            assert h.runner.steers == []
+            assert h.sink.last_text == "second answer"
+
+            turns = span_recorder.spans(name="worker.turn")
+            assert len(turns) == 3
+            assert all(span.status.status_code is StatusCode.OK for span in turns)
+            assert turns[0].attributes is not None
+            assert turns[0].attributes["curie.turn.outcome"] == "delivered"
+            assert turns[1].attributes is not None
+            assert turns[1].attributes["curie.turn.outcome"] == "duplicate"
+            assert turns[2].attributes is not None
+            assert turns[2].attributes["curie.turn.outcome"] == "delivered"
+            names = [_event_names(span) for span in turns]
+            assert {
+                "worker.dedupe.checked",
+                "worker.lock.wait",
+                "worker.lock.acquired",
+                "worker.route.start",
+                "worker.reply.final",
+                "worker.completion.settled",
+                "worker.terminal",
+            } <= names[0]
+            assert "worker.dedupe.skip" in names[1]
+            assert {"worker.route.finish_race", "worker.route.start"} <= names[2]
+
+    asyncio.run(go())
+
+
+async def _wait_until(pred: Callable[[], bool], timeout: float = 5.0) -> None:
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while loop.time() < deadline:
+        if pred():
+            return
+        await asyncio.sleep(0.01)
+    raise AssertionError("condition not met before timeout")
+
+
+def test_kernel_live_followup_emits_steer_without_forking_a_turn(
+    make_harness,
+    span_recorder,
+) -> None:
+    async def go() -> None:
+        async with make_harness(tracer=span_recorder.tracer) as h:
+            hold = asyncio.Event()
+            h.runner.hold = hold
+            h.runner.default_script = [TextDelta(text="working")]
+            h.runner.tail = [Final(text="done", status=DONE)]
+
+            owner = asyncio.create_task(
+                h.kernel.process_event(
+                    _qevent("first", thread="live-steer", event_id="owner-example")
+                )
+            )
+            await _wait_until(lambda: h.runner.turn_active)
+            await h.kernel.process_event(
+                _qevent("second", thread="live-steer", event_id="steer-example")
+            )
+
+            assert h.runner.opened == ["first"]
+            assert h.runner.steers == ["second"]
+            steered = [
+                span
+                for span in span_recorder.spans(name="worker.turn")
+                if "worker.route.steer" in _event_names(span)
+            ]
+            assert len(steered) == 1
+            assert steered[0].status.status_code is StatusCode.OK
+            assert steered[0].attributes is not None
+            assert steered[0].attributes["curie.turn.outcome"] == "steered"
+            hold.set()
+            await owner
+
+    asyncio.run(go())
+
+
+def test_classified_failure_marks_worker_turn_error_without_changing_retry_policy(
+    make_harness,
+    span_recorder,
+) -> None:
+    async def go() -> None:
+        async with make_harness(tracer=span_recorder.tracer, max_attempts=3) as h:
+            h.runner.default_script = [Final(text="safe failure", status=FAILED)]
+            await h.kernel.process_event(
+                _qevent("run", thread="failed-turn", event_id="failed-example")
+            )
+
+            assert h.runner.opened == ["run", "run", "run"]
+            assert h.sink.last_text is not None
+            assert "human" in h.sink.last_text.lower()
+            turn = span_recorder.one("worker.turn")
+            assert turn.status.status_code is StatusCode.ERROR
+            assert turn.attributes is not None
+            assert turn.attributes["curie.turn.outcome"] == "escalated"
+            assert {"worker.terminal", "worker.completion.settled"} <= _event_names(turn)
+
+    asyncio.run(go())
+
+
+class _ResolvedBinding:
+    def __init__(self, agent_id: uuid.UUID, token: str) -> None:
+        self.agent_id = agent_id
+        self.token = token
+        self.endpoint: str | None = None
+        self.adapter: str | None = None
+
+    async def resolve(self, _kind: str, _channel: str) -> _ResolvedBinding:
+        return self
+
+    def boot_env(self, _resolved: object, _thread: str) -> dict[str, str]:
+        return {"CURIE_RUNNER_TOKEN": self.token}
+
+    def packs_for(self, _resolved: object) -> BehaviorPacks:
+        return BehaviorPacks()
+
+
+class _SecondCheckExplodes:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def is_killed(self, _agent_id: uuid.UUID) -> bool:
+        self.calls += 1
+        if self.calls == 1:
+            return False
+        raise RuntimeError("injected killswitch recheck failure")
+
+
+def test_killswitch_recheck_failure_closes_started_http_stream_before_consumption(
+    make_harness,
+    span_recorder,
+) -> None:
+    """The response is open before the post-registration kill recheck.
+
+    If that recheck raises, the kernel never enters ``async with turn``.  The
+    manually-owned CLIENT span and response must still be closed in the caller's
+    route/start failure cleanup rather than leaking until process teardown.
+    """
+
+    async def go() -> None:
+        auth = "runner-auth-PLACEHOLDER-preconsume"
+        binding = _ResolvedBinding(uuid.uuid4(), auth)
+        async with make_harness(
+            tracer=span_recorder.tracer,
+            binding=binding,
+        ) as h:
+            h.runner.default_script = [Final(text="unconsumed", status=DONE)]
+            killswitch = _SecondCheckExplodes()
+            h.kernel.attach_killswitch(killswitch)  # type: ignore[arg-type]
+            event = _qevent(
+                "preconsume",
+                thread="killswitch-preconsume",
+                event_id="killswitch-preconsume-example",
+            )
+
+            with pytest.raises(RuntimeError, match="killswitch recheck"):
+                await h.kernel.process_event(event)
+
+            assert killswitch.calls == 2
+            assert h.runner.opened == ["preconsume"]
+            assert h.sink.last_text is None
+            assert not await h.async_redis.exists(h.config.done_key(event.event_id))
+            clients = span_recorder.spans(kind=SpanKind.CLIENT)
+            assert len(clients) == 2  # steer 409 followed by the accepted event stream
+            assert all(span.end_time is not None for span in clients)
+            assert any(span.status.status_code is StatusCode.ERROR for span in clients)
+            assert all(auth not in _span_payload(span) for span in clients)
+            turn = span_recorder.one("worker.turn")
+            assert turn.status.status_code is StatusCode.ERROR
+
+    asyncio.run(go())

--- a/apps/worker/tests/kernel/test_telemetry.py
+++ b/apps/worker/tests/kernel/test_telemetry.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 import uuid
 from collections.abc import Callable
 from typing import Any
@@ -20,8 +21,10 @@ from aci_protocol import Final, QueuedTurn, ReplyHandle, SessionStatus, TextDelt
 from curie_dispatcher.queue import to_stream_fields
 from curie_telemetry import TRACE_CONTEXT_FIELD, inject_trace_context
 from curie_telemetry.attributes import event_names_for
+from curie_worker import consumer as consumer_module
 from curie_worker.behaviorpacks import BehaviorPacks
 from curie_worker.consumer import Consumer
+from opentelemetry import trace
 from opentelemetry.sdk.trace import ReadableSpan
 from opentelemetry.trace import SpanKind, StatusCode
 
@@ -34,6 +37,7 @@ _WORKER_EVENTS = frozenset(
         "messaging.ack",
         "messaging.pending",
         "messaging.dead_letter",
+        "worker.queue.wait",
         "worker.dedupe.checked",
         "worker.dedupe.skip",
         "worker.lock.wait",
@@ -42,6 +46,8 @@ _WORKER_EVENTS = frozenset(
         "worker.route.steer",
         "worker.route.finish_race",
         "worker.reply.final",
+        "worker.retry.scheduled",
+        "worker.retry.stopped",
         "worker.completion.settled",
         "worker.terminal",
     }
@@ -151,8 +157,21 @@ async def _reclaim_and_settle(consumer: Consumer) -> None:
 def test_valid_valkey_carrier_parents_process_span_and_success_acks(
     make_harness,
     span_recorder,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     async def go() -> None:
+        log_events: list[tuple[str, int, int]] = []
+
+        def record_log_event(
+            _logger: logging.Logger,
+            event: str,
+            *,
+            level: int = logging.INFO,
+        ) -> None:
+            context = trace.get_current_span().get_span_context()
+            log_events.append((event, level, context.span_id))
+
+        monkeypatch.setattr(consumer_module, "emit_log_event", record_log_event)
         async with make_harness(tracer=span_recorder.tracer) as h:
             h.runner.default_script = [Final(text="safe answer", status=DONE)]
             consumer = Consumer(
@@ -180,12 +199,18 @@ def test_valid_valkey_carrier_parents_process_span_and_success_acks(
             assert process.attributes["messaging.system"] == "valkey"
             assert process.attributes["messaging.destination.name"] == h.config.stream
             assert process.attributes["messaging.operation.type"] == "process"
+            assert isinstance(process.attributes["curie.queue.wait_ms"], int)
+            assert process.attributes["curie.queue.wait_ms"] >= 0
             assert process.context is not None
             assert process.context.trace_id == producer_context.trace_id
             assert process.parent is not None
             assert process.parent.span_id == producer_context.span_id
             assert "messaging.ack" in _event_names(process)
+            assert "worker.queue.wait" in _event_names(process)
             assert h.sink.last_text == "safe answer"
+            assert log_events == [
+                ("worker.turn.completed", logging.INFO, process.context.span_id)
+            ]
             pending = await h.async_redis.xpending(
                 h.config.stream, h.config.consumer_group
             )
@@ -193,6 +218,39 @@ def test_valid_valkey_carrier_parents_process_span_and_success_acks(
             assert all(
                 prompt not in _span_payload(span) for span in span_recorder.spans()
             )
+
+    asyncio.run(go())
+
+
+def test_queue_wait_uses_valkey_enqueue_time_and_malformed_ids_omit_safely(
+    make_harness,
+    span_recorder,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def go() -> None:
+        async with make_harness(tracer=span_recorder.tracer) as h:
+            consumer = Consumer(
+                redis=h.async_redis,
+                kernel=h.kernel,
+                config=h.config,
+                tracer=span_recorder.tracer,
+            )
+            monkeypatch.setattr(time, "time_ns", lambda: 1_700_000_001_500_000_000)
+
+            measured, _ = consumer._process_span("1700000000000-0", {})
+            measured.end()
+            malformed, _ = consumer._process_span("not-a-stream-id", {})
+            malformed.end()
+
+            measured_span, malformed_span = span_recorder.spans(
+                name="process curie:runs"
+            )
+            assert measured_span.attributes is not None
+            assert measured_span.attributes["curie.queue.wait_ms"] == 1_500
+            assert "worker.queue.wait" in _event_names(measured_span)
+            assert malformed_span.attributes is not None
+            assert "curie.queue.wait_ms" not in malformed_span.attributes
+            assert "worker.queue.wait" not in _event_names(malformed_span)
 
     asyncio.run(go())
 
@@ -270,8 +328,21 @@ def test_malformed_valkey_carrier_is_value_free_warning_and_fail_open(
 def test_processing_exception_marks_error_and_leaves_entry_pending(
     make_harness,
     span_recorder,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     async def go() -> None:
+        log_events: list[tuple[str, int, int]] = []
+
+        def record_log_event(
+            _logger: logging.Logger,
+            event: str,
+            *,
+            level: int = logging.INFO,
+        ) -> None:
+            context = trace.get_current_span().get_span_context()
+            log_events.append((event, level, context.span_id))
+
+        monkeypatch.setattr(consumer_module, "emit_log_event", record_log_event)
         async with make_harness(tracer=span_recorder.tracer) as h:
             consumer = Consumer(
                 redis=h.async_redis,
@@ -290,6 +361,10 @@ def test_processing_exception_marks_error_and_leaves_entry_pending(
             process = span_recorder.one("process curie:runs")
             assert process.status.status_code is StatusCode.ERROR
             assert "messaging.pending" in _event_names(process)
+            assert process.context is not None
+            assert log_events == [
+                ("worker.turn.failed", logging.ERROR, process.context.span_id)
+            ]
             pending = await h.async_redis.xpending_range(
                 h.config.stream,
                 h.config.consumer_group,
@@ -468,7 +543,15 @@ def test_classified_failure_marks_worker_turn_error_without_changing_retry_polic
             assert turn.status.status_code is StatusCode.ERROR
             assert turn.attributes is not None
             assert turn.attributes["curie.turn.outcome"] == "escalated"
-            assert {"worker.terminal", "worker.completion.settled"} <= _event_names(turn)
+            assert {
+                "worker.terminal",
+                "worker.completion.settled",
+                "worker.retry.scheduled",
+                "worker.retry.stopped",
+            } <= _event_names(turn)
+            assert [event.name for event in turn.events].count(
+                "worker.retry.scheduled"
+            ) == 2
 
     asyncio.run(go())
 
@@ -533,7 +616,10 @@ def test_killswitch_recheck_failure_closes_started_http_stream_before_consumptio
 
             assert killswitch.calls == 2
             assert h.runner.opened == ["preconsume"]
-            assert h.sink.last_text is None
+            # Preserve the pre-telemetry timing contract: the placeholder is
+            # updated before route/start, even when the post-start kill recheck
+            # later fails. The open response still closes below.
+            assert h.sink.last_text == h.config.booting_text
             assert not await h.async_redis.exists(h.config.done_key(event.event_id))
             clients = span_recorder.spans(kind=SpanKind.CLIENT)
             assert len(clients) == 2  # steer 409 followed by the accepted event stream

--- a/apps/worker/tests/sandbox/conftest.py
+++ b/apps/worker/tests/sandbox/conftest.py
@@ -45,10 +45,12 @@ class _RecordingDocker(DockerSandboxClient):
     def __init__(self, **kwargs: object) -> None:
         super().__init__(**kwargs)  # type: ignore[arg-type]
         self.calls: list[list[str]] = []
+        self.call_environments: list[dict[str, str]] = []
         self.outputs: dict[str, str] = {}
 
     def _docker(self, args: list[str], *, check: bool = True) -> str:
         self.calls.append(args)
+        self.call_environments.append(dict(self._docker_command_environment()))
         return self.outputs.get(args[0], "")
 
 

--- a/apps/worker/tests/sandbox/test_docker.py
+++ b/apps/worker/tests/sandbox/test_docker.py
@@ -71,7 +71,11 @@ def test_create_claim_argv_carries_boot_env() -> None:
     assert "CURIE_RUNNER_PORT=8080" in envs
     assert 'CURIE_BUDGET={"max_usd_per_day":5.0}' in envs
     assert "CURIE_FAKE_MODEL=1" in envs
-    assert "OTEL_EXPORTER_OTLP_ENDPOINT=http://otel:4318" in envs
+    assert "OTEL_EXPORTER_OTLP_ENDPOINT" in envs
+    assert all("http://otel:4318" not in arg for arg in argv)
+    assert client.call_environments[0]["OTEL_EXPORTER_OTLP_ENDPOINT"] == (
+        "http://otel:4318"
+    )
     assert argv[-1] == "curie-runner"
 
 

--- a/apps/worker/tests/sandbox/test_telemetry.py
+++ b/apps/worker/tests/sandbox/test_telemetry.py
@@ -1,0 +1,198 @@
+"""Observable sandbox lifecycle spans without changing substrate semantics."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+from curie_worker.sandbox import (
+    AffinityStore,
+    CapacityExhaustedError,
+    ClaimTimeoutError,
+    QuotaRejection,
+    RouteRecord,
+    SandboxHandle,
+    SandboxSubstrate,
+    SubstrateConfig,
+)
+from opentelemetry.sdk.trace import ReadableSpan
+from opentelemetry.trace import SpanKind, StatusCode
+
+from .conftest import FakeClaim, FakeSandbox, FakeSandboxClient
+
+
+def _span_payload(span: ReadableSpan) -> str:
+    return repr(
+        (
+            span.name,
+            dict(span.attributes or {}),
+            [
+                (event.name, dict(event.attributes or {}))
+                for event in span.events
+            ],
+            span.status.description,
+        )
+    )
+
+
+def _outcome(span: ReadableSpan) -> str:
+    assert span.attributes is not None
+    value = span.attributes.get("curie.sandbox.outcome")
+    assert isinstance(value, str)
+    return value
+
+
+def test_claim_reuse_suspend_resume_release_emit_closed_lifecycle_spans(
+    fake_k8s: FakeSandboxClient,
+    affinity: AffinityStore,
+    config: SubstrateConfig,
+    span_recorder,
+) -> None:
+    substrate = SandboxSubstrate(
+        fake_k8s,
+        affinity,
+        config,
+        tracer=span_recorder.tracer,
+    )
+    history_ref = "PRIVATE-HISTORY-REFERENCE-MUST-NOT-BE-EXPORTED"
+
+    first = substrate.claim("T-OTEL-LIFECYCLE")
+    assert substrate.claim("T-OTEL-LIFECYCLE") == first
+    substrate.suspend("T-OTEL-LIFECYCLE", history_ref=history_ref)
+    resumed = substrate.resume("T-OTEL-LIFECYCLE")
+    assert resumed.claim_name != first.claim_name
+    assert resumed.session_id == first.session_id
+    assert resumed.history_ref == history_ref
+    assert substrate.release("T-OTEL-LIFECYCLE") is True
+    assert affinity.get("T-OTEL-LIFECYCLE") is None
+
+    lifecycle = [
+        span
+        for span in span_recorder.spans()
+        if span.name
+        in {"sandbox.claim", "sandbox.suspend", "sandbox.resume", "sandbox.release"}
+    ]
+    assert lifecycle
+    assert all(span.kind is SpanKind.INTERNAL for span in lifecycle)
+    assert all(span.status.status_code is StatusCode.OK for span in lifecycle)
+    claim_outcomes = {
+        _outcome(span)
+        for span in lifecycle
+        if span.name == "sandbox.claim"
+    }
+    assert {"created", "reused"} <= claim_outcomes
+    assert any(
+        span.name == "sandbox.suspend" and _outcome(span) == "suspended"
+        for span in lifecycle
+    )
+    assert any(
+        span.name == "sandbox.resume" and _outcome(span) == "resumed"
+        for span in lifecycle
+    )
+    assert any(
+        span.name == "sandbox.release" and _outcome(span) == "released"
+        for span in lifecycle
+    )
+    assert all(history_ref not in _span_payload(span) for span in lifecycle)
+
+
+def test_lost_claim_race_reports_adopted_without_leaking_or_changing_winner(
+    fake_k8s: FakeSandboxClient,
+    affinity: AffinityStore,
+    config: SubstrateConfig,
+    span_recorder,
+) -> None:
+    substrate = SandboxSubstrate(
+        fake_k8s,
+        affinity,
+        config,
+        tracer=span_recorder.tracer,
+    )
+    winner = SandboxHandle(
+        thread_key="T-ADOPT",
+        claim_name="claim-winner-example",
+        sandbox_name="sandbox-winner-example",
+        namespace="test-ns",
+        service_fqdn="sandbox-winner-example.test-ns.svc.cluster.local",
+        port=8080,
+        session_id="session-winner-example",
+    )
+    fake_k8s.claims[winner.claim_name] = FakeClaim(
+        name=winner.claim_name,
+        env={},
+        labels={},
+        sandbox_name=winner.sandbox_name,
+    )
+    fake_k8s.sandboxes[winner.sandbox_name] = FakeSandbox(
+        name=winner.sandbox_name,
+        service_fqdn=winner.service_fqdn,
+    )
+    real_create = fake_k8s.create_claim
+
+    def create_then_lose(name: str, **kwargs: object) -> None:
+        real_create(name, **kwargs)  # type: ignore[arg-type]
+        affinity.put_if_absent("T-ADOPT", RouteRecord(handle=winner), ttl_seconds=60)
+
+    fake_k8s.create_claim = create_then_lose  # type: ignore[method-assign]
+
+    adopted = substrate.claim("T-ADOPT")
+
+    assert adopted == winner
+    assert winner.claim_name not in fake_k8s.deleted
+    assert len(fake_k8s.deleted) == 1
+    claim = span_recorder.one("sandbox.claim")
+    assert claim.status.status_code is StatusCode.OK
+    assert _outcome(claim) == "adopted"
+
+
+def test_quota_and_timeout_claim_failures_have_error_outcomes_without_details(
+    fake_k8s: FakeSandboxClient,
+    affinity: AffinityStore,
+    config: SubstrateConfig,
+    span_recorder,
+) -> None:
+    rejection = QuotaRejection(
+        quota_name="quota-example-private",
+        resource="limits.cpu",
+        requested="1",
+        used="8",
+        hard="8",
+    )
+    fake_k8s.quota_rejection = rejection
+    short = replace(config, claim_timeout_seconds=0.02)
+    substrate = SandboxSubstrate(
+        fake_k8s,
+        affinity,
+        short,
+        tracer=span_recorder.tracer,
+    )
+
+    with pytest.raises(CapacityExhaustedError):
+        substrate.claim("T-CAPACITY")
+
+    capacity = span_recorder.one("sandbox.claim")
+    assert capacity.status.status_code is StatusCode.ERROR
+    assert _outcome(capacity) == "capacity"
+    assert "quota-example-private" not in _span_payload(capacity)
+    assert "limits.cpu" not in _span_payload(capacity)
+
+    span_recorder.clear()
+    fake_k8s.quota_rejection = None
+    fake_k8s.bind_ready = False
+    fake_k8s.ready_reason = "PRIVATE-READY-REASON"
+    fake_k8s.ready_message = "PRIVATE-READY-MESSAGE"
+    timeout_substrate = SandboxSubstrate(
+        fake_k8s,
+        affinity,
+        short,
+        tracer=span_recorder.tracer,
+    )
+
+    with pytest.raises(ClaimTimeoutError):
+        timeout_substrate.claim("T-TIMEOUT")
+
+    timeout = span_recorder.one("sandbox.claim")
+    assert timeout.status.status_code is StatusCode.ERROR
+    assert _outcome(timeout) == "timeout"
+    assert "PRIVATE-READY-REASON" not in _span_payload(timeout)
+    assert "PRIVATE-READY-MESSAGE" not in _span_payload(timeout)

--- a/apps/worker/tests/test_run.py
+++ b/apps/worker/tests/test_run.py
@@ -13,7 +13,9 @@ import logging
 from pathlib import Path
 from typing import Any
 
+import curie_worker.run as run_module
 import pytest
+from curie_worker import __version__
 from curie_worker.config import WorkerConfig
 from curie_worker.run import (
     _MAX_TUNABLE_SECONDS,
@@ -540,3 +542,173 @@ def test_crashing_supervised_task_does_not_cancel_its_siblings() -> None:
         assert sibling_ran["ok"] is True
 
     asyncio.run(go())
+
+
+# -- #1817: worker telemetry bootstrap, relay, and bounded shutdown -----------
+
+
+class _RecordingTelemetryRuntime:
+    def __init__(self, order: list[str]) -> None:
+        self.tracer = object()
+        self.order = order
+        self.shutdown_timeouts: list[int] = []
+
+    def force_flush(self, *, timeout_millis: int) -> bool:
+        self.order.append("telemetry-force-flush")
+        return timeout_millis <= 2_000
+
+    def shutdown(self, *, timeout_millis: int) -> bool:
+        self.shutdown_timeouts.append(timeout_millis)
+        self.order.append("telemetry-shutdown")
+        return timeout_millis <= 2_000
+
+
+def test_main_configures_worker_telemetry_and_shuts_down_after_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A blank standard endpoint is a normal no-op runtime, still lifecycle-owned.
+
+    The shared package decides whether exporters exist; the worker must always
+    use the same configure/shutdown seam so endpoint absence cannot grow a
+    second code path that skips ordinary diagnostics or cleanup.
+    """
+
+    for name in (
+        "OTEL_EXPORTER_OTLP_ENDPOINT",
+        "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+        "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+    order: list[str] = []
+    runtime = _RecordingTelemetryRuntime(order)
+    configured: list[dict[str, object]] = []
+    basic_config: list[dict[str, object]] = []
+
+    def fake_configure(**kwargs: object) -> _RecordingTelemetryRuntime:
+        configured.append(kwargs)
+        order.append("telemetry-configured")
+        return runtime
+
+    async def fake_run(*args: object, **kwargs: object) -> None:
+        # The runtime tracer is the only tracer main has available to hand into
+        # build/_run.  Accept either a named tracer or the runtime itself so this
+        # assertion stays about dependency propagation, not a private signature.
+        flattened = (*args, *kwargs.values())
+        assert runtime in flattened or runtime.tracer in flattened
+        order.append("ordinary-runtime-finished")
+
+    def fake_basic_config(**kwargs: object) -> None:
+        basic_config.append(kwargs)
+
+    monkeypatch.setattr(run_module, "configure", fake_configure, raising=False)
+    monkeypatch.setattr(run_module, "_run", fake_run)
+    monkeypatch.setattr(run_module, "install_dead_letter_alerting", lambda: None)
+    monkeypatch.setattr(logging, "basicConfig", fake_basic_config)
+
+    run_module.main({})
+
+    assert configured == [
+        {"service_name": "curie-worker", "service_version": __version__}
+    ]
+    assert basic_config == [{"level": logging.INFO}]
+    assert runtime.shutdown_timeouts == [2_000]
+    assert order.index("ordinary-runtime-finished") < order.index("telemetry-shutdown")
+
+
+def _docker_envs(client: DockerSandboxClient) -> list[str]:
+    calls: list[list[str]] = []
+
+    def record(args: list[str], *, check: bool = True) -> str:
+        del check
+        calls.append(args)
+        return ""
+
+    client._docker = record  # type: ignore[method-assign]
+    client.create_claim(
+        "runner-otel-example",
+        pool="pool",
+        env={"CURIE_FAKE_MODEL": "1"},
+    )
+    assert len(calls) == 1
+    argv = calls[0]
+    return [argv[index + 1] for index, arg in enumerate(argv) if arg == "-e"]
+
+
+def test_docker_worker_uses_private_runner_relay_as_child_standard_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        DockerSandboxClient,
+        "ensure_image",
+        lambda self: None,
+        raising=False,
+    )
+    host_endpoint = "http://127.0.0.1:24318"
+    runner_endpoint = "http://otel-collector:4318"
+    client = _sandbox_client(
+        WorkerConfig(fake_model=True),
+        {
+            "CURIE_SANDBOX_SUBSTRATE": "docker",
+            "OTEL_EXPORTER_OTLP_ENDPOINT": host_endpoint,
+            "CURIE_RUNNER_OTEL_EXPORTER_OTLP_ENDPOINT": runner_endpoint,
+        },
+        _SUB,
+    )
+    assert isinstance(client, DockerSandboxClient)
+
+    child_env = _docker_envs(client)
+    assert f"OTEL_EXPORTER_OTLP_ENDPOINT={runner_endpoint}" in child_env
+    assert "OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf" in child_env
+    assert f"OTEL_EXPORTER_OTLP_ENDPOINT={host_endpoint}" not in child_env
+    assert "CURIE_RUNNER_OTEL_EXPORTER_OTLP_ENDPOINT" not in {
+        entry.partition("=")[0] for entry in child_env
+    }
+
+
+def test_docker_runner_relay_defaults_to_standard_endpoint_outside_compose(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        DockerSandboxClient,
+        "ensure_image",
+        lambda self: None,
+        raising=False,
+    )
+    endpoint = "http://collector.example.com:4318"
+    client = _sandbox_client(
+        WorkerConfig(fake_model=True),
+        {
+            "CURIE_SANDBOX_SUBSTRATE": "docker",
+            "OTEL_EXPORTER_OTLP_ENDPOINT": endpoint,
+        },
+        _SUB,
+    )
+    assert isinstance(client, DockerSandboxClient)
+    child_env = _docker_envs(client)
+    assert f"OTEL_EXPORTER_OTLP_ENDPOINT={endpoint}" in child_env
+    assert "OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf" in child_env
+
+
+def test_docker_runner_with_both_endpoints_blank_injects_no_exporter_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        DockerSandboxClient,
+        "ensure_image",
+        lambda self: None,
+        raising=False,
+    )
+    client = _sandbox_client(
+        WorkerConfig(fake_model=True),
+        {
+            "CURIE_SANDBOX_SUBSTRATE": "docker",
+            "OTEL_EXPORTER_OTLP_ENDPOINT": "",
+            "CURIE_RUNNER_OTEL_EXPORTER_OTLP_ENDPOINT": "",
+        },
+        _SUB,
+    )
+    assert isinstance(client, DockerSandboxClient)
+    child_names = {entry.partition("=")[0] for entry in _docker_envs(client)}
+    assert "OTEL_EXPORTER_OTLP_ENDPOINT" not in child_names
+    assert "OTEL_EXPORTER_OTLP_PROTOCOL" not in child_names

--- a/apps/worker/tests/test_run.py
+++ b/apps/worker/tests/test_run.py
@@ -616,12 +616,14 @@ def test_main_configures_worker_telemetry_and_shuts_down_after_runtime(
     assert order.index("ordinary-runtime-finished") < order.index("telemetry-shutdown")
 
 
-def _docker_envs(client: DockerSandboxClient) -> list[str]:
+def _docker_envs(client: DockerSandboxClient) -> tuple[list[str], dict[str, str]]:
     calls: list[list[str]] = []
+    environments: list[dict[str, str]] = []
 
     def record(args: list[str], *, check: bool = True) -> str:
         del check
         calls.append(args)
+        environments.append(dict(client._docker_command_environment()))
         return ""
 
     client._docker = record  # type: ignore[method-assign]
@@ -632,7 +634,10 @@ def _docker_envs(client: DockerSandboxClient) -> list[str]:
     )
     assert len(calls) == 1
     argv = calls[0]
-    return [argv[index + 1] for index, arg in enumerate(argv) if arg == "-e"]
+    return (
+        [argv[index + 1] for index, arg in enumerate(argv) if arg == "-e"],
+        environments[0],
+    )
 
 
 def test_docker_worker_uses_private_runner_relay_as_child_standard_endpoint(
@@ -657,10 +662,13 @@ def test_docker_worker_uses_private_runner_relay_as_child_standard_endpoint(
     )
     assert isinstance(client, DockerSandboxClient)
 
-    child_env = _docker_envs(client)
-    assert f"OTEL_EXPORTER_OTLP_ENDPOINT={runner_endpoint}" in child_env
-    assert "OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf" in child_env
-    assert f"OTEL_EXPORTER_OTLP_ENDPOINT={host_endpoint}" not in child_env
+    child_env, command_env = _docker_envs(client)
+    assert "OTEL_EXPORTER_OTLP_ENDPOINT" in child_env
+    assert "OTEL_EXPORTER_OTLP_PROTOCOL" in child_env
+    assert all(runner_endpoint not in entry for entry in child_env)
+    assert all(host_endpoint not in entry for entry in child_env)
+    assert command_env["OTEL_EXPORTER_OTLP_ENDPOINT"] == runner_endpoint
+    assert command_env["OTEL_EXPORTER_OTLP_PROTOCOL"] == "http/protobuf"
     assert "CURIE_RUNNER_OTEL_EXPORTER_OTLP_ENDPOINT" not in {
         entry.partition("=")[0] for entry in child_env
     }
@@ -685,9 +693,12 @@ def test_docker_runner_relay_defaults_to_standard_endpoint_outside_compose(
         _SUB,
     )
     assert isinstance(client, DockerSandboxClient)
-    child_env = _docker_envs(client)
-    assert f"OTEL_EXPORTER_OTLP_ENDPOINT={endpoint}" in child_env
-    assert "OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf" in child_env
+    child_env, command_env = _docker_envs(client)
+    assert "OTEL_EXPORTER_OTLP_ENDPOINT" in child_env
+    assert "OTEL_EXPORTER_OTLP_PROTOCOL" in child_env
+    assert all(endpoint not in entry for entry in child_env)
+    assert command_env["OTEL_EXPORTER_OTLP_ENDPOINT"] == endpoint
+    assert command_env["OTEL_EXPORTER_OTLP_PROTOCOL"] == "http/protobuf"
 
 
 def test_docker_runner_with_both_endpoints_blank_injects_no_exporter_env(
@@ -709,6 +720,50 @@ def test_docker_runner_with_both_endpoints_blank_injects_no_exporter_env(
         _SUB,
     )
     assert isinstance(client, DockerSandboxClient)
-    child_names = {entry.partition("=")[0] for entry in _docker_envs(client)}
+    child_env, command_env = _docker_envs(client)
+    child_names = {entry.partition("=")[0] for entry in child_env}
     assert "OTEL_EXPORTER_OTLP_ENDPOINT" not in child_names
     assert "OTEL_EXPORTER_OTLP_PROTOCOL" not in child_names
+    assert command_env == {}
+
+
+def test_docker_runner_relays_complete_standard_exporter_config_by_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        DockerSandboxClient,
+        "ensure_image",
+        lambda self: None,
+        raising=False,
+    )
+    private_endpoint = "https://collector.example.com:4318"
+    headers = "authorization=Bearer PRIVATE-OTEL-HEADER"
+    env = {
+        "CURIE_SANDBOX_SUBSTRATE": "docker",
+        "CURIE_RUNNER_OTEL_EXPORTER_OTLP_ENDPOINT": private_endpoint,
+        "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT": "https://traces.example.com/v1/traces",
+        "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT": "https://logs.example.com/v1/logs",
+        "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL": "http/protobuf",
+        "OTEL_EXPORTER_OTLP_LOGS_PROTOCOL": "grpc",
+        "OTEL_EXPORTER_OTLP_HEADERS": headers,
+        "OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE": "/certs/traces.pem",
+        "OTEL_EXPORTER_OTLP_LOGS_CLIENT_CERTIFICATE": "/certs/logs-client.pem",
+        "OTEL_EXPORTER_OTLP_LOGS_CLIENT_KEY": "/certs/logs-client.key",
+        "OTEL_EXPORTER_OTLP_TIMEOUT": "1.5",
+        "OTEL_EXPORTER_OTLP_TRACES_COMPRESSION": "gzip",
+        "OTEL_EXPORTER_OTLP_LOGS_INSECURE": "false",
+    }
+    client = _sandbox_client(WorkerConfig(fake_model=True), env, _SUB)
+    assert isinstance(client, DockerSandboxClient)
+
+    child_env, command_env = _docker_envs(client)
+    expected_names = {
+        name for name in env if name.startswith("OTEL_EXPORTER_OTLP_")
+    }
+    expected_names.add("OTEL_EXPORTER_OTLP_ENDPOINT")
+    assert expected_names <= set(child_env)
+    assert "CURIE_RUNNER_OTEL_EXPORTER_OTLP_ENDPOINT" not in child_env
+    assert command_env["OTEL_EXPORTER_OTLP_ENDPOINT"] == private_endpoint
+    assert command_env["OTEL_EXPORTER_OTLP_HEADERS"] == headers
+    assert all(headers not in arg for arg in child_env)
+    assert all(private_endpoint not in arg for arg in child_env)

--- a/charts/curie/ci/otel-collector-checksum-assertions.sh
+++ b/charts/curie/ci/otel-collector-checksum-assertions.sh
@@ -27,6 +27,15 @@ render auth-header --set otelCollector.otlpAuthHeader='Basic YXNzZXJ0OmFzc2VydA=
 render tempo \
   --set 'otelCollector.extraExporters.otlphttp/tempo.endpoint=http://tempo:4318' \
   --set 'otelCollector.extraPipelineExporters[0]=otlphttp/tempo'
+render service-wiring \
+  --set dispatcher.slack.appToken=test-app-token \
+  --set dispatcher.slack.botToken=test-bot-token \
+  --set dispatcher.slack.signingSecret=test-signing-secret
+render no-collector \
+  --set otelCollector.deploy=false \
+  --set dispatcher.slack.appToken=test-app-token \
+  --set dispatcher.slack.botToken=test-bot-token \
+  --set dispatcher.slack.signingSecret=test-signing-secret
 
 missing_exporter_stderr="$TMP/missing-exporter.stderr"
 if helm template curie "$CHART" \
@@ -40,7 +49,14 @@ missing_exporter_error="$(<"$missing_exporter_stderr")"
 [[ "$missing_exporter_error" == *"otelCollector.extraExporters"* ]] || \
   fail "Missing exporter error did not name otelCollector.extraExporters"
 
-python3 - "$(manifest_for "$TMP/default")" "$(manifest_for "$TMP/port-3001")" "$(manifest_for "$TMP/auth-header")" "$(manifest_for "$TMP/tempo")" <<'PY'
+python3 - \
+  "$(manifest_for "$TMP/default")" \
+  "$(manifest_for "$TMP/port-3001")" \
+  "$(manifest_for "$TMP/auth-header")" \
+  "$(manifest_for "$TMP/tempo")" \
+  "$TMP/service-wiring" \
+  "$TMP/no-collector" <<'PY'
+from pathlib import Path
 import sys
 import yaml
 
@@ -61,10 +77,68 @@ changed_config, changed_checksum = config_and_checksum(sys.argv[2])
 auth_config, auth_checksum = config_and_checksum(sys.argv[3])
 tempo_config, tempo_checksum = config_and_checksum(sys.argv[4])
 
+
+def all_docs(root):
+    return [
+        doc
+        for path in Path(root).rglob("*.yaml")
+        for doc in yaml.safe_load_all(path.read_text())
+        if doc
+    ]
+
+
+def container_env(docs, component):
+    if component == "runner":
+        workload = next(
+            doc
+            for doc in docs
+            if doc.get("kind") == "SandboxTemplate"
+        )
+        pod_spec = workload["spec"]["podTemplate"]["spec"]
+    else:
+        workload = next(
+            doc
+            for doc in docs
+            if doc.get("kind") == "Deployment"
+            and doc.get("metadata", {}).get("labels", {}).get(
+                "app.kubernetes.io/component"
+            )
+            == component
+        )
+        pod_spec = workload["spec"]["template"]["spec"]
+    container = next(item for item in pod_spec["containers"] if item["name"] == component)
+    return {item["name"]: item for item in container.get("env", [])}
+
+
+wired_docs = all_docs(sys.argv[5])
+no_collector_docs = all_docs(sys.argv[6])
+endpoint = "http://curie-otel-collector:4318"
+for component in ("api", "dispatcher", "worker", "runner"):
+    env = container_env(wired_docs, component)
+    assert env["OTEL_EXPORTER_OTLP_ENDPOINT"] == {
+        "name": "OTEL_EXPORTER_OTLP_ENDPOINT",
+        "value": endpoint,
+    }, f"{component}: standard OTLP endpoint is missing or not the in-cluster collector"
+    assert env["OTEL_EXPORTER_OTLP_PROTOCOL"] == {
+        "name": "OTEL_EXPORTER_OTLP_PROTOCOL",
+        "value": "http/protobuf",
+    }, f"{component}: standard OTLP HTTP protocol is missing"
+    assert "OTEL_SERVICE_NAME" not in env, (
+        f"{component}: service.name belongs to configure(service_name=...), not chart env"
+    )
+    assert "CURIE_RUNNER_OTEL_EXPORTER_OTLP_ENDPOINT" not in env, (
+        f"{component}: Helm has one in-cluster endpoint; the Compose relay is not a chart contract"
+    )
+
+    disabled_env = container_env(no_collector_docs, component)
+    assert "OTEL_EXPORTER_OTLP_ENDPOINT" not in disabled_env
+    assert "OTEL_EXPORTER_OTLP_PROTOCOL" not in disabled_env
+
 default_parsed = yaml.safe_load(default_config)
 tempo_parsed = yaml.safe_load(tempo_config)
 default_exporters = default_parsed["exporters"]
 default_trace_exporters = default_parsed["service"]["pipelines"]["traces"]["exporters"]
+default_log_pipeline = default_parsed["service"]["pipelines"]["logs"]
 tempo_exporters = tempo_parsed["exporters"]
 tempo_trace_exporters = tempo_parsed["service"]["pipelines"]["traces"]["exporters"]
 
@@ -74,6 +148,11 @@ assert set(default_exporters) == {"otlphttp/langfuse", "debug"}, (
 assert default_trace_exporters == ["otlphttp/langfuse", "debug"], (
     "Default traces pipeline exporters changed or unexpectedly include Tempo"
 )
+assert default_log_pipeline == {
+    "receivers": ["otlp"],
+    "processors": ["batch"],
+    "exporters": ["debug"],
+}, "The chart collector must accept batched OTLP logs without claiming a retained backend"
 assert tempo_exporters.get("otlphttp/tempo") == {"endpoint": "http://tempo:4318"}, (
     "Tempo exporter configuration was not rendered exactly"
 )
@@ -94,5 +173,7 @@ assert default_checksum != auth_checksum, (
     "OTLP auth header changed but Deployment checksum/config stayed identical. The pod would not roll."
 )
 
-print("ConfigMap changes roll the pod and OTLP auth header changes still roll it: OK")
+print(
+    "ConfigMap rollout, OTLP logs pipeline, and four-service standard env wiring: OK"
+)
 PY

--- a/charts/curie/templates/_helpers.tpl
+++ b/charts/curie/templates/_helpers.tpl
@@ -48,6 +48,18 @@ app.kubernetes.io/component: {{ .component }}
 {{- printf "%s-secrets" (include "curie.fullname" .) -}}
 {{- end -}}
 
+{{/* Standard application OTLP environment. Service identity is supplied by
+     each process's telemetry bootstrap, not by deployment environment, and the
+     variables are omitted entirely when the in-chart collector is disabled. */}}
+{{- define "curie.env.otel" -}}
+{{- if .Values.otelCollector.deploy }}
+- name: OTEL_EXPORTER_OTLP_ENDPOINT
+  value: http://{{ include "curie.fullname" . }}-otel-collector:{{ .Values.otelCollector.service.httpPort }}
+- name: OTEL_EXPORTER_OTLP_PROTOCOL
+  value: http/protobuf
+{{- end }}
+{{- end -}}
+
 {{/* ---- Reserved connector-secret boot-env names (#457, ADR-0009) ----
      The non-CURIE_-prefixed runner credential keys a per-agent connector
      secret must never declare, kept in list-parity with the Python source of
@@ -282,6 +294,10 @@ service:
       receivers: [otlp]
       processors: [batch]
       exporters: [otlphttp/langfuse, debug{{- range .Values.otelCollector.extraPipelineExporters }}, {{ . }}{{- end }}]
+    logs:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [debug]
 {{- end }}
 
 {{/* ---- Default-credential gate (issue #198) ----

--- a/charts/curie/templates/agent-sandbox.yaml
+++ b/charts/curie/templates/agent-sandbox.yaml
@@ -505,12 +505,7 @@ spec:
               value: {{ printf "{\"max_output_tokens_per_run\":%d,\"max_usd_per_day\":%v}" (int $runner.budget.maxOutputTokensPerRun) $runner.budget.maxUsdPerDay | quote }}
             - name: CURIE_RUNNER_PORT
               value: {{ $runner.port | quote }}
-            {{- if .Values.otelCollector.deploy }}
-            - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              value: http://{{ include "curie.fullname" . }}-otel-collector:{{ .Values.otelCollector.service.httpPort }}
-            - name: OTEL_EXPORTER_OTLP_PROTOCOL
-              value: http/protobuf
-            {{- end }}
+            {{- include "curie.env.otel" . | nindent 12 }}
             {{- with $runner.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/curie/templates/api.yaml
+++ b/charts/curie/templates/api.yaml
@@ -68,6 +68,7 @@ spec:
           env:
             {{- include "curie.env.postgres" . | nindent 12 }}
             {{- include "curie.env.valkey" . | nindent 12 }}
+            {{- include "curie.env.otel" . | nindent 12 }}
             - name: API_KEY
               valueFrom:
                 secretKeyRef:

--- a/charts/curie/templates/dispatcher.yaml
+++ b/charts/curie/templates/dispatcher.yaml
@@ -41,6 +41,7 @@ spec:
           {{- end }}
           env:
             {{- include "curie.env.valkey" . | nindent 12 }}
+            {{- include "curie.env.otel" . | nindent 12 }}
             - name: SLACK_APP_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/charts/curie/templates/security-networkpolicy.yaml
+++ b/charts/curie/templates/security-networkpolicy.yaml
@@ -106,9 +106,9 @@ spec:
 {{- end }}
 {{- if .Values.otelCollector.deploy }}
 ---
-{{/* Allow the runner to ship OTLP traces to THIS release's in-chart collector.
-     Without this, the default-deny blocks span export and sandbox traces vanish
-     whenever the observability backbone is deployed alongside the rails. */}}
+{{/* Allow the runner to ship OTLP traces and logs to THIS release's in-chart
+     collector. Without this, default-deny blocks telemetry export whenever the
+     observability backbone is deployed alongside the rails. */}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/charts/curie/templates/worker.yaml
+++ b/charts/curie/templates/worker.yaml
@@ -146,6 +146,7 @@ spec:
           env:
             {{- include "curie.env.postgres" . | nindent 12 }}
             {{- include "curie.env.valkey" . | nindent 12 }}
+            {{- include "curie.env.otel" . | nindent 12 }}
             {{- if not $hasWorkerApiUrl }}
             {{- include "curie.env.apiUrl" . | nindent 12 }}
             {{- end }}

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -477,8 +477,9 @@ inference:
 
 # ---------------------------------------------------------------------------
 # OTel Collector. Receives OTLP (gRPC 4317 / HTTP 4318) from app services and
-# forwards to Langfuse over HTTP (Langfuse's OTLP ingest is HTTP-only). Deploy
-# false to send app traces to an external collector.
+# forwards to Langfuse over HTTP (Langfuse's OTLP ingest is HTTP-only). Setting
+# deploy=false omits the standard OTLP environment from every workload, leaving
+# the services on their no-endpoint behavior.
 # ---------------------------------------------------------------------------
 otelCollector:
   deploy: true

--- a/cli/scripts/e2e-ladder.sh
+++ b/cli/scripts/e2e-ladder.sh
@@ -192,6 +192,12 @@ fi
 # brought a stack up owns tearing it down, so a stack that was already running
 # when the ladder started is reused and left alone.
 LOCAL_STACK_OWNED=0
+# The local #1817 evidence temporarily swaps only the collector container to a
+# file exporter. These flags let the EXIT trap restore an incumbent collector
+# without touching the incumbent API, worker, connectors, or sandboxes.
+OTEL_E2E_COLLECTOR_MUTATED=0
+OTEL_E2E_COLLECTOR_WAS_RUNNING=0
+OTEL_E2E_OUTPUT=""
 
 # Cross-rung artifact identity, pinned by the first rung to report a digest and
 # matched by every later one (see assert_bundle_identity). Empty until then.
@@ -244,6 +250,18 @@ cleanup() {
     # turn a red run green, and a successful teardown must not mask a red rung.
     local code=$?
     set +e
+    if (( OTEL_E2E_COLLECTOR_MUTATED && ! LOCAL_STACK_OWNED )); then
+        echo
+        echo "=== teardown: restore the incumbent OTel Collector only ==="
+        if (( OTEL_E2E_COLLECTOR_WAS_RUNNING )); then
+            docker compose --profile full -f "$REPO_ROOT/compose.dev.yaml" \
+                up -d --no-deps --force-recreate otel-collector >/dev/null
+        else
+            docker compose -f "$REPO_ROOT/compose.dev.yaml" \
+                rm -sf otel-collector >/dev/null
+        fi
+        OTEL_E2E_COLLECTOR_MUTATED=0
+    fi
     # The compose worker spawns runner containers as SIBLINGS on the host daemon
     # via the mounted docker socket, so a rung that died before `local down` can
     # strand them. This raw sweep is a BACKSTOP, not duplication: `local down`
@@ -297,6 +315,21 @@ trap cleanup EXIT
 # trap, stranding a running stack on a box that cannot afford one.
 trap 'exit 130' INT
 trap 'exit 143' TERM
+
+prepare_local_otel_evidence() {
+    OTEL_E2E_OUTPUT="$WORKDIR/otel-output"
+    mkdir -p "$OTEL_E2E_OUTPUT"
+    chmod 0777 "$OTEL_E2E_OUTPUT"
+    if [[ -n "$(docker ps -q --filter 'name=curie-otel-collector' 2>/dev/null)" ]]; then
+        OTEL_E2E_COLLECTOR_WAS_RUNNING=1
+    fi
+    export CURIE_OTEL_E2E_OUTPUT="$OTEL_E2E_OUTPUT"
+    docker compose --profile full \
+        -f "$REPO_ROOT/compose.dev.yaml" \
+        -f "$REPO_ROOT/cli/tests/fixtures/otel/compose.override.yaml" \
+        up -d --no-deps --force-recreate otel-collector >/dev/null
+    OTEL_E2E_COLLECTOR_MUTATED=1
+}
 
 # The ONE place the fake/live asymmetry is stated. There is no shared
 # fake-model control across tiers: skill reads CURIE_E2E_LIVE itself (see
@@ -1674,10 +1707,10 @@ rung_local() {
         echo "note: the reused stack's model mode was fixed by whoever ran \`local up\`; it is verified below against this run's mode, and a mismatch fails this rung."
     else
         echo
+        # #1817 observes a real collector boundary, so the local rung always
+        # selects the full profile. The no-endpoint control below uses the CLI's
+        # separate --minimal path rather than weakening this positive.
         local up_args=(local up)
-        if [[ ! -f "$WORKDIR/bundle/evals/trajectory.json" ]]; then
-            up_args+=(--minimal)
-        fi
         echo "=== curie ${up_args[*]} ==="
         # Ordinary bundles use the core profile. A trajectory sidecar selects the
         # full profile because its matrix read requires Langfuse.
@@ -1691,6 +1724,10 @@ rung_local() {
         LOCAL_STACK_OWNED=1
         "$BIN" "${up_args[@]}"
     fi
+
+    echo
+    echo "=== install ladder-owned OTLP file sink (collector only) ==="
+    prepare_local_otel_evidence
 
     echo
     echo "=== curie --json local deploy ==="
@@ -1762,6 +1799,34 @@ rung_local() {
     assert_finalized_reply "local" "$out"
 
     echo
+    echo "=== assert the honest worker-rooted causal trace and correlated logs ==="
+    local thread session_id otel_ready=0
+    thread="$(printf '%s' "$out" | python3 -c 'import json,sys; print(json.load(sys.stdin)["thread"])')"
+    session_id="agent-${agent_id}-thread-${thread}"
+    for _ in $(seq 1 25); do
+        if python3 "$REPO_ROOT/cli/tests/otel_e2e_assert.py" \
+            --traces "$OTEL_E2E_OUTPUT/traces.json" \
+            --logs "$OTEL_E2E_OUTPUT/logs.json" \
+            --topology cli --outcome success --session-id "$session_id" \
+            >/dev/null 2>&1; then
+            otel_ready=1
+            break
+        fi
+        sleep 0.2
+    done
+    (( otel_ready )) || {
+        python3 "$REPO_ROOT/cli/tests/otel_e2e_assert.py" \
+            --traces "$OTEL_E2E_OUTPUT/traces.json" \
+            --logs "$OTEL_E2E_OUTPUT/logs.json" \
+            --topology cli --outcome success --session-id "$session_id"
+        return 1
+    }
+    python3 "$REPO_ROOT/cli/tests/otel_e2e_assert.py" \
+        --traces "$OTEL_E2E_OUTPUT/traces.json" \
+        --logs "$OTEL_E2E_OUTPUT/logs.json" \
+        --topology cli --outcome success --session-id "$session_id"
+
+    echo
     echo "=== curie local eval --dry-run (suite parity) ==="
     local eval_args=(local eval)
     if [[ ! -f "$WORKDIR/bundle/evals/trajectory.json" ]]; then
@@ -1780,6 +1845,9 @@ rung_local() {
         echo "=== curie local down ==="
         "$BIN" local down
         LOCAL_STACK_OWNED=0
+        # The owned stack's down removed the temporary collector with it; do
+        # not let the EXIT trap recreate that service while "restoring" it.
+        OTEL_E2E_COLLECTOR_MUTATED=0
 
         echo
         echo "=== assert nothing curie-related survived ==="

--- a/cli/scripts/e2e-ladder.sh
+++ b/cli/scripts/e2e-ladder.sh
@@ -199,6 +199,7 @@ OTEL_E2E_COLLECTOR_MUTATED=0
 OTEL_E2E_COLLECTOR_WAS_RUNNING=0
 OTEL_E2E_RUNNER_IMAGE="curie-runner:otel-e2e-$$"
 OTEL_E2E_BASE_TAG="otel-e2e-$$"
+OTEL_E2E_DISPATCHER_IMAGE="ghcr.io/curie-eng/curie-dispatcher:$OTEL_E2E_BASE_TAG"
 OTEL_E2E_WORKER_LOCAL_IMAGE="curie-worker-local:otel-e2e-$$"
 OTEL_E2E_CANDIDATE_IMAGES_BUILT=0
 OTEL_E2E_OUTPUT=""
@@ -296,6 +297,7 @@ cleanup() {
         docker image rm -f "$OTEL_E2E_RUNNER_IMAGE" >/dev/null 2>&1
         docker image rm -f \
             "ghcr.io/curie-eng/curie-api:$OTEL_E2E_BASE_TAG" \
+            "$OTEL_E2E_DISPATCHER_IMAGE" \
             "ghcr.io/curie-eng/curie-worker:$OTEL_E2E_BASE_TAG" \
             "$OTEL_E2E_WORKER_LOCAL_IMAGE" \
             >/dev/null 2>&1
@@ -366,6 +368,8 @@ build_local_otel_candidate_images() {
     echo "=== build candidate platform images for local telemetry ==="
     docker build --file "$REPO_ROOT/apps/api/Dockerfile" \
         --tag "ghcr.io/curie-eng/curie-api:$OTEL_E2E_BASE_TAG" "$REPO_ROOT"
+    docker build --file "$REPO_ROOT/apps/dispatcher/Dockerfile" \
+        --tag "$OTEL_E2E_DISPATCHER_IMAGE" "$REPO_ROOT"
     docker build --file "$REPO_ROOT/apps/worker/Dockerfile" \
         --tag "ghcr.io/curie-eng/curie-worker:$OTEL_E2E_BASE_TAG" "$REPO_ROOT"
     docker build --file "$REPO_ROOT/compose/worker-local.Dockerfile" \
@@ -445,9 +449,10 @@ assert_local_otel_turn() {
 
 run_local_otel_transport_controls() {
     local agent_id="$1"
-    OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:24318 \
-    OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf \
-    uv run python - "$agent_id" <<'PY'
+    docker run --rm --interactive --network host \
+        --env OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:24318 \
+        --env OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf \
+        --entrypoint python "$OTEL_E2E_DISPATCHER_IMAGE" - "$agent_id" <<'PY'
 from __future__ import annotations
 
 import json
@@ -706,14 +711,8 @@ PY
 }
 
 run_no_endpoint_runtime_probe() {
-    env \
-        -u OTEL_EXPORTER_OTLP_ENDPOINT \
-        -u OTEL_EXPORTER_OTLP_TRACES_ENDPOINT \
-        -u OTEL_EXPORTER_OTLP_LOGS_ENDPOINT \
-        -u OTEL_EXPORTER_OTLP_PROTOCOL \
-        -u OTEL_EXPORTER_OTLP_TRACES_PROTOCOL \
-        -u OTEL_EXPORTER_OTLP_LOGS_PROTOCOL \
-        uv run python - <<'PY'
+    docker run --rm --interactive --network none \
+        --entrypoint python "$OTEL_E2E_DISPATCHER_IMAGE" - <<'PY'
 import logging
 
 from curie_telemetry import configure

--- a/cli/scripts/e2e-ladder.sh
+++ b/cli/scripts/e2e-ladder.sh
@@ -197,6 +197,10 @@ LOCAL_STACK_OWNED=0
 # without touching the incumbent API, worker, connectors, or sandboxes.
 OTEL_E2E_COLLECTOR_MUTATED=0
 OTEL_E2E_COLLECTOR_WAS_RUNNING=0
+OTEL_E2E_RUNNER_IMAGE="curie-runner:otel-e2e-$$"
+OTEL_E2E_BASE_TAG="otel-e2e-$$"
+OTEL_E2E_WORKER_LOCAL_IMAGE="curie-worker-local:otel-e2e-$$"
+OTEL_E2E_CANDIDATE_IMAGES_BUILT=0
 OTEL_E2E_OUTPUT=""
 OTEL_E2E_THREAD_HASHES=""
 
@@ -288,6 +292,14 @@ cleanup() {
             docker rm -f $orphans >/dev/null 2>&1
         fi
     fi
+    if (( OTEL_E2E_CANDIDATE_IMAGES_BUILT )); then
+        docker image rm -f "$OTEL_E2E_RUNNER_IMAGE" >/dev/null 2>&1
+        docker image rm -f \
+            "ghcr.io/curie-eng/curie-api:$OTEL_E2E_BASE_TAG" \
+            "ghcr.io/curie-eng/curie-worker:$OTEL_E2E_BASE_TAG" \
+            "$OTEL_E2E_WORKER_LOCAL_IMAGE" \
+            >/dev/null 2>&1
+    fi
     # Only the container THIS run created, matched by its exact unique name, so
     # the sweep can never reach a runner belonging to another session. Cleared by
     # the case itself once `skill down` has removed it.
@@ -349,6 +361,52 @@ prepare_local_otel_evidence() {
     OTEL_E2E_COLLECTOR_MUTATED=1
 }
 
+build_local_otel_candidate_images() {
+    echo
+    echo "=== build candidate platform images for local telemetry ==="
+    docker build --file "$REPO_ROOT/apps/api/Dockerfile" \
+        --tag "ghcr.io/curie-eng/curie-api:$OTEL_E2E_BASE_TAG" "$REPO_ROOT"
+    docker build --file "$REPO_ROOT/apps/worker/Dockerfile" \
+        --tag "ghcr.io/curie-eng/curie-worker:$OTEL_E2E_BASE_TAG" "$REPO_ROOT"
+    docker build --file "$REPO_ROOT/compose/worker-local.Dockerfile" \
+        --build-arg "BASE_TAG=$OTEL_E2E_BASE_TAG" \
+        --tag "$OTEL_E2E_WORKER_LOCAL_IMAGE" "$REPO_ROOT/compose"
+    docker build --file "$REPO_ROOT/runner/Dockerfile" \
+        --tag "$OTEL_E2E_RUNNER_IMAGE" "$REPO_ROOT"
+    OTEL_E2E_CANDIDATE_IMAGES_BUILT=1
+    export CURIE_BASE_TAG="$OTEL_E2E_BASE_TAG"
+    export CURIE_WORKER_LOCAL_IMAGE="$OTEL_E2E_WORKER_LOCAL_IMAGE"
+    export CURIE_RUNNER_IMAGE="$OTEL_E2E_RUNNER_IMAGE"
+}
+
+assert_local_candidate_images() {
+    local api worker api_image worker_image runner_image
+    api="$(docker ps -q --filter 'name=^/curie-curie-api-1$')"
+    worker="$(local_worker_container)"
+    if [[ -z "$api" || -z "$worker" ]]; then
+        echo "candidate local OTEL rung could not resolve its API and worker containers" >&2
+        return 1
+    fi
+    api_image="$(docker inspect --format '{{.Config.Image}}' "$api")"
+    worker_image="$(docker inspect --format '{{.Config.Image}}' "$worker")"
+    runner_image="$(docker inspect --format '{{json .Config.Env}}' "$worker" | python3 -c '
+import json
+import sys
+
+values = json.load(sys.stdin)
+print(next((value.split("=", 1)[1] for value in values if value.startswith("CURIE_RUNNER_IMAGE=")), ""))
+')"
+    if [[ "$api_image" != "ghcr.io/curie-eng/curie-api:$OTEL_E2E_BASE_TAG" \
+        || "$worker_image" != "$OTEL_E2E_WORKER_LOCAL_IMAGE" \
+        || "$runner_image" != "$OTEL_E2E_RUNNER_IMAGE" ]]; then
+        echo "candidate local OTEL rung did not start the images built by this run" >&2
+        echo "observed: api=$api_image worker=$worker_image runner=$runner_image" >&2
+        echo "fix: run in an unoccupied Docker daemon and do not reuse a prior compose stack" >&2
+        return 1
+    fi
+    echo "local: candidate API, worker overlay, and runner image selection verified"
+}
+
 remember_otel_thread() {
     local thread="$1" thread_hash
     thread_hash="$(printf '%s' "$thread" | sha256sum | cut -c1-10)"
@@ -359,7 +417,7 @@ remember_otel_thread() {
 
 assert_local_otel_turn() {
     local topology="$1" outcome="$2" session_id="$3"
-    local forbidden="${4:-}" warning="${5:-}" ready=0
+    local forbidden="${4:-}" warning="${5:-}" require_reply="${6:-0}" ready=0
     local args=(
         --traces "$OTEL_E2E_OUTPUT/traces.json"
         --logs "$OTEL_E2E_OUTPUT/logs.json"
@@ -369,6 +427,7 @@ assert_local_otel_turn() {
     )
     [[ -z "$forbidden" ]] || args+=(--forbidden "$forbidden")
     [[ -z "$warning" ]] || args+=(--require-warning "$warning")
+    (( require_reply )) && args+=(--require-reply-completion)
     for _ in $(seq 1 100); do
         if python3 "$REPO_ROOT/cli/tests/otel_e2e_assert.py" "${args[@]}" \
             >/dev/null 2>&1; then
@@ -2049,33 +2108,28 @@ rung_local() {
     assert_stub_port_free
 
     if [[ -n "$(docker ps -q --filter 'name=curie-api' 2>/dev/null)" ]]; then
-        # Reuse it and do NOT tear it down: the thread that brought a stack up
-        # owns tearing it down, in both directions.
-        echo "a compose stack is already running; reusing it and leaving teardown to whoever started it"
-        # Model mode is fixed at `local up` time, so a reused stack may have been
-        # started sealed. That used to be a warning; it is now VERIFIED by
-        # assert_model_mode below, off the reused stack's own running worker, and
-        # a contradiction is a hard failure with a fix line.
-        echo "note: the reused stack's model mode was fixed by whoever ran \`local up\`; it is verified below against this run's mode, and a mismatch fails this rung."
-    else
-        echo
-        # #1817 observes a real collector boundary, so the local rung always
-        # selects the full profile. The no-endpoint control below uses the CLI's
-        # separate --minimal path rather than weakening this positive.
-        local up_args=(local up)
-        echo "=== curie ${up_args[*]} ==="
-        # Ordinary bundles use the core profile. A trajectory sidecar selects the
-        # full profile because its matrix read requires Langfuse.
-        #
-        # Claim ownership BEFORE starting, never after: `local up` blocks for
-        # seconds while it waits for health, and containers exist for that whole
-        # window. Setting the flag afterwards means a signal or a mid-boot
-        # failure leaves the trap disowning a stack this run created, stranding
-        # it. Claiming a stack that then fails to boot is harmless, because
-        # `local down` is safe against a partial or already-stopped stack.
-        LOCAL_STACK_OWNED=1
-        "$BIN" "${up_args[@]}"
+        echo "candidate local OTEL rung requires an unoccupied compose stack" >&2
+        echo "fix: use an isolated Docker daemon, or wait for the owning session to stop its stack" >&2
+        return 1
     fi
+
+    build_local_otel_candidate_images
+
+    echo
+    # #1817 observes a real collector boundary, so the local rung always
+    # selects the full profile. The no-endpoint control below uses the CLI's
+    # separate --minimal path rather than weakening this positive.
+    local up_args=(local up)
+    echo "=== curie ${up_args[*]} ==="
+    # Claim ownership BEFORE starting, never after: `local up` blocks for
+    # seconds while it waits for health, and containers exist for that whole
+    # window. Setting the flag afterwards means a signal or a mid-boot
+    # failure leaves the trap disowning a stack this run created, stranding
+    # it. Claiming a stack that then fails to boot is harmless, because
+    # `local down` is safe against a partial or already-stopped stack.
+    LOCAL_STACK_OWNED=1
+    "$BIN" "${up_args[@]}"
+    assert_local_candidate_images
 
     echo
     echo "=== install ladder-owned OTLP file sink (collector only) ==="
@@ -2156,7 +2210,7 @@ rung_local() {
     thread="$(printf '%s' "$out" | python3 -c 'import json,sys; print(json.load(sys.stdin)["thread"])')"
     session_id="agent-${agent_id}-thread-${thread}"
     remember_otel_thread "$thread"
-    assert_local_otel_turn cli success "$session_id"
+    assert_local_otel_turn cli success "$session_id" "" "" 1
 
     if [[ "$LIVE" == "0" ]]; then
         echo
@@ -2176,7 +2230,7 @@ rung_local() {
             control_session="agent-${agent_id}-thread-${control_thread}"
             case "$label" in
                 dispatcher)
-                    assert_local_otel_turn dispatcher success "$control_session"
+                    assert_local_otel_turn dispatcher success "$control_session" "" "" 1
                     ;;
                 missing)
                     assert_local_otel_turn cli success "$control_session"

--- a/cli/scripts/e2e-ladder.sh
+++ b/cli/scripts/e2e-ladder.sh
@@ -198,6 +198,7 @@ LOCAL_STACK_OWNED=0
 OTEL_E2E_COLLECTOR_MUTATED=0
 OTEL_E2E_COLLECTOR_WAS_RUNNING=0
 OTEL_E2E_OUTPUT=""
+OTEL_E2E_THREAD_HASHES=""
 
 # Cross-rung artifact identity, pinned by the first rung to report a digest and
 # matched by every later one (see assert_bundle_identity). Empty until then.
@@ -307,6 +308,23 @@ cleanup() {
             docker rm -f "$survivor" >/dev/null 2>&1
         done
     fi
+    # On a reused stack, release only sandboxes created for this ladder's
+    # cryptographically-derived thread hashes. Never sweep the host-wide label:
+    # another session may have created a sandbox after our run began.
+    if (( ! LOCAL_STACK_OWNED )) && [[ -n "$OTEL_E2E_THREAD_HASHES" ]]; then
+        local thread_hash sandbox_ids
+        while IFS= read -r thread_hash; do
+            [[ -n "$thread_hash" ]] || continue
+            sandbox_ids="$(docker ps -aq \
+                --filter "label=$SANDBOX_LABEL" \
+                --filter "label=curietech.ai/thread-hash=$thread_hash" 2>/dev/null)"
+            if [[ -n "$sandbox_ids" ]]; then
+                echo "sweeping ladder-owned sandbox(es) for thread hash $thread_hash"
+                # shellcheck disable=SC2086
+                docker rm -f $sandbox_ids >/dev/null 2>&1
+            fi
+        done <<< "$OTEL_E2E_THREAD_HASHES"
+    fi
     rm -rf "$WORKDIR"
     exit "$code"
 }
@@ -329,6 +347,340 @@ prepare_local_otel_evidence() {
         -f "$REPO_ROOT/cli/tests/fixtures/otel/compose.override.yaml" \
         up -d --no-deps --force-recreate otel-collector >/dev/null
     OTEL_E2E_COLLECTOR_MUTATED=1
+}
+
+remember_otel_thread() {
+    local thread="$1" thread_hash
+    thread_hash="$(printf '%s' "$thread" | sha256sum | cut -c1-10)"
+    if [[ "$OTEL_E2E_THREAD_HASHES" != *"$thread_hash"* ]]; then
+        OTEL_E2E_THREAD_HASHES="${OTEL_E2E_THREAD_HASHES}${thread_hash}"$'\n'
+    fi
+}
+
+assert_local_otel_turn() {
+    local topology="$1" outcome="$2" session_id="$3"
+    local forbidden="${4:-}" warning="${5:-}" ready=0
+    local args=(
+        --traces "$OTEL_E2E_OUTPUT/traces.json"
+        --logs "$OTEL_E2E_OUTPUT/logs.json"
+        --topology "$topology"
+        --outcome "$outcome"
+        --session-id "$session_id"
+    )
+    [[ -z "$forbidden" ]] || args+=(--forbidden "$forbidden")
+    [[ -z "$warning" ]] || args+=(--require-warning "$warning")
+    for _ in $(seq 1 100); do
+        if python3 "$REPO_ROOT/cli/tests/otel_e2e_assert.py" "${args[@]}" \
+            >/dev/null 2>&1; then
+            ready=1
+            break
+        fi
+        sleep 0.2
+    done
+    (( ready )) || {
+        python3 "$REPO_ROOT/cli/tests/otel_e2e_assert.py" "${args[@]}"
+        return 1
+    }
+    python3 "$REPO_ROOT/cli/tests/otel_e2e_assert.py" "${args[@]}"
+}
+
+run_local_otel_transport_controls() {
+    local agent_id="$1"
+    OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:24318 \
+    OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf \
+    uv run python - "$agent_id" <<'PY'
+from __future__ import annotations
+
+import json
+import sys
+import threading
+import time
+import urllib.parse
+import urllib.request
+import uuid
+from datetime import UTC, datetime
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+
+import redis
+from aci_protocol import QueuedTurn, ReplyHandle, STREAM_PAYLOAD_FIELD, TurnSource
+from curie_dispatcher.config import DispatcherConfig
+from curie_dispatcher.handlers import process_event
+from curie_telemetry import configure
+from curie_telemetry.carrier import TRACE_CONTEXT_FIELD
+
+AGENT_ID = sys.argv[1]
+CHANNEL = "C0LOCALDEV"
+AUTHOR = "U0EXAMPLE1"
+STREAM = "curie:runs"
+API = "http://127.0.0.1:28000"
+API_KEY = "curie-dev-key"
+FAILURE_MARKER = "[fake:runner-error]"
+MALFORMED_SENTINEL = "otel-malformed-carrier-private-value"
+REDACTION_SENTINEL = "sk-" + "FAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKE0000"
+
+
+class ReplyCapture(ThreadingHTTPServer):
+    daemon_threads = True
+
+    def __init__(self) -> None:
+        self.condition = threading.Condition()
+        self.updates: dict[str, list[str]] = {}
+        super().__init__(("127.0.0.1", 8155), handler())
+
+    def record(self, raw: bytes, content_type: str) -> str:
+        text = ""
+        ts = ""
+        if "json" in content_type:
+            payload = json.loads(raw or b"{}")
+            text = str(payload.get("text", ""))
+            ts = str(payload.get("ts", ""))
+        else:
+            payload = urllib.parse.parse_qs(raw.decode())
+            text = payload.get("text", [""])[0]
+            ts = payload.get("ts", [""])[0]
+        if ts:
+            with self.condition:
+                self.updates.setdefault(ts, []).append(text)
+                self.condition.notify_all()
+        return ts
+
+    def wait_for(self, ts: str, needle: str, timeout: float = 90.0) -> None:
+        deadline = time.monotonic() + timeout
+        with self.condition:
+            while not any(needle in value for value in self.updates.get(ts, [])):
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise AssertionError(
+                        f"no chat.update for {ts!r} contained {needle!r}; "
+                        f"observed={self.updates.get(ts, [])!r}"
+                    )
+                self.condition.wait(min(remaining, 0.25))
+
+
+def handler() -> type[BaseHTTPRequestHandler]:
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self) -> None:  # noqa: N802
+            server = self.server
+            assert isinstance(server, ReplyCapture)
+            raw = self.rfile.read(int(self.headers.get("content-length", "0")))
+            ts = server.record(raw, self.headers.get("content-type", ""))
+            body = json.dumps(
+                {"ok": True, "ts": ts or "stub-ts", "message": {"ts": ts or "stub-ts"}}
+            ).encode()
+            self.send_response(200)
+            self.send_header("content-type", "application/json")
+            self.send_header("content-length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, _format: str, *_args: object) -> None:
+            return
+
+    return Handler
+
+
+def api_request(path: str, method: str = "GET") -> dict[str, Any]:
+    request = urllib.request.Request(
+        f"{API}{path}", method=method, headers={"X-API-Key": API_KEY}
+    )
+    with urllib.request.urlopen(request, timeout=5) as response:  # noqa: S310
+        return json.loads(response.read())
+
+
+def release(thread: str) -> None:
+    encoded = urllib.parse.quote(thread, safe="")
+    path = f"/agents/{AGENT_ID}/threads/{encoded}/reset"
+    assert api_request(path, "POST")["requested"] is True
+    deadline = time.monotonic() + 45
+    while time.monotonic() < deadline:
+        if api_request(path)["requested"] is False:
+            return
+        time.sleep(0.25)
+    raise AssertionError(f"sandbox release did not settle for thread {thread}")
+
+
+def turn(label: str, text: str) -> tuple[QueuedTurn, str]:
+    token = uuid.uuid4().hex[:12]
+    thread = f"otel-{label}-{token}"
+    placeholder = f"placeholder-{label}-{token}"
+    return (
+        QueuedTurn(
+            event_id=f"Ev-otel-{label}-{token}",
+            conversation_id=thread,
+            author=AUTHOR,
+            text=text,
+            source=TurnSource.SLACK,
+            reply_handle=ReplyHandle(
+                kind="slack",
+                channel=CHANNEL,
+                placeholder=placeholder,
+                endpoint=None,
+                adapter=None,
+            ),
+            received_at=datetime.now(UTC).isoformat(),
+        ),
+        placeholder,
+    )
+
+
+def enqueue(
+    client: redis.Redis,
+    capture: ReplyCapture,
+    label: str,
+    text: str,
+    *,
+    carrier: str | None = None,
+    final_contains: str = "all done",
+) -> str:
+    queued, placeholder = turn(label, text)
+    fields = {STREAM_PAYLOAD_FIELD: queued.model_dump_json()}
+    if carrier is not None:
+        fields[TRACE_CONTEXT_FIELD] = carrier
+    client.xadd(STREAM, fields)
+    capture.wait_for(placeholder, final_contains)
+    release(queued.conversation_id)
+    return queued.conversation_id
+
+
+client = redis.Redis(
+    host="127.0.0.1", port=26379, password="valkeypass", decode_responses=True
+)
+capture = ReplyCapture()
+server_thread = threading.Thread(target=capture.serve_forever, daemon=True)
+server_thread.start()
+results: dict[str, str] = {}
+try:
+    dispatcher_runtime = configure(
+        service_name="curie-dispatcher", service_version="e2e"
+    )
+    dispatcher_token = uuid.uuid4().hex[:12]
+    dispatcher_thread = f"otel-dispatcher-{dispatcher_token}"
+    dispatcher_placeholder = f"placeholder-dispatcher-{dispatcher_token}"
+
+    class WebClient:
+        def chat_postMessage(self, **_kwargs: object) -> dict[str, str]:
+            return {"ts": dispatcher_placeholder}
+
+    config = DispatcherConfig(
+        valkey_host="127.0.0.1",
+        valkey_port=26379,
+        valkey_password="valkeypass",
+        stream=STREAM,
+        dedupe_prefix=f"curie:e2e:dispatcher:{dispatcher_token}:",
+        api_base_url=API,
+        api_key=API_KEY,
+    )
+    stream_id = process_event(
+        body={"event_id": f"Ev-otel-dispatcher-{dispatcher_token}"},
+        event={
+            "type": "app_mention",
+            "channel": CHANNEL,
+            "user": AUTHOR,
+            "text": "dispatcher propagation control",
+            "ts": dispatcher_thread,
+        },
+        web_client=WebClient(),  # type: ignore[arg-type]
+        redis_client=client,
+        config=config,
+        clock=lambda: datetime.now(UTC).isoformat(),
+        tracer=dispatcher_runtime.tracer,
+    )
+    assert stream_id
+    dispatcher_runtime.force_flush(timeout_millis=500)
+    capture.wait_for(dispatcher_placeholder, "all done")
+    release(dispatcher_thread)
+    dispatcher_runtime.shutdown(timeout_millis=2_000)
+    results["dispatcher"] = dispatcher_thread
+
+    results["missing"] = enqueue(
+        client,
+        capture,
+        "missing",
+        "missing carrier compatibility control",
+    )
+    results["malformed"] = enqueue(
+        client,
+        capture,
+        "malformed",
+        "malformed carrier compatibility control",
+        carrier=json.dumps(
+            {"traceparent": "00-not-valid", "unexpected": MALFORMED_SENTINEL}
+        ),
+    )
+    results["failure"] = enqueue(
+        client,
+        capture,
+        "failure",
+        FAILURE_MARKER,
+        final_contains="Flagging for a human",
+    )
+    results["recovery"] = enqueue(
+        client,
+        capture,
+        "recovery",
+        "ordinary input after the injected failure",
+    )
+    results["redaction"] = enqueue(
+        client,
+        capture,
+        "redaction",
+        f"prompt={REDACTION_SENTINEL}",
+    )
+finally:
+    capture.shutdown()
+    capture.server_close()
+    server_thread.join(timeout=2)
+    client.close()
+
+print(
+    json.dumps(
+        {
+            "threads": results,
+            "malformed_sentinel": MALFORMED_SENTINEL,
+            "redaction_sentinel": REDACTION_SENTINEL,
+        },
+        sort_keys=True,
+    )
+)
+PY
+}
+
+run_no_endpoint_runtime_probe() {
+    env \
+        -u OTEL_EXPORTER_OTLP_ENDPOINT \
+        -u OTEL_EXPORTER_OTLP_TRACES_ENDPOINT \
+        -u OTEL_EXPORTER_OTLP_LOGS_ENDPOINT \
+        -u OTEL_EXPORTER_OTLP_PROTOCOL \
+        -u OTEL_EXPORTER_OTLP_TRACES_PROTOCOL \
+        -u OTEL_EXPORTER_OTLP_LOGS_PROTOCOL \
+        uv run python - <<'PY'
+import logging
+
+from curie_telemetry import configure
+
+logging.basicConfig(level=logging.INFO)
+for service_name in (
+    "curie-api",
+    "curie-dispatcher",
+    "curie-worker",
+    "curie-runner",
+):
+    runtime = configure(service_name=service_name, service_version="e2e-no-endpoint")
+    with runtime.tracer.start_as_current_span("no-endpoint.control"):
+        logging.getLogger(service_name).info("no-endpoint diagnostic control")
+    runtime.force_flush(timeout_millis=100)
+    runtime.shutdown(timeout_millis=500)
+PY
+}
+
+otel_file_size() {
+    local path="$1"
+    if [[ -f "$path" ]]; then
+        stat -c '%s' "$path"
+    else
+        printf '0'
+    fi
 }
 
 # The ONE place the fake/live asymmetry is stated. There is no shared
@@ -1800,31 +2152,64 @@ rung_local() {
 
     echo
     echo "=== assert the honest worker-rooted causal trace and correlated logs ==="
-    local thread session_id otel_ready=0
+    local thread session_id
     thread="$(printf '%s' "$out" | python3 -c 'import json,sys; print(json.load(sys.stdin)["thread"])')"
     session_id="agent-${agent_id}-thread-${thread}"
-    for _ in $(seq 1 25); do
-        if python3 "$REPO_ROOT/cli/tests/otel_e2e_assert.py" \
-            --traces "$OTEL_E2E_OUTPUT/traces.json" \
-            --logs "$OTEL_E2E_OUTPUT/logs.json" \
-            --topology cli --outcome success --session-id "$session_id" \
-            >/dev/null 2>&1; then
-            otel_ready=1
-            break
-        fi
-        sleep 0.2
-    done
-    (( otel_ready )) || {
-        python3 "$REPO_ROOT/cli/tests/otel_e2e_assert.py" \
-            --traces "$OTEL_E2E_OUTPUT/traces.json" \
-            --logs "$OTEL_E2E_OUTPUT/logs.json" \
-            --topology cli --outcome success --session-id "$session_id"
-        return 1
-    }
-    python3 "$REPO_ROOT/cli/tests/otel_e2e_assert.py" \
-        --traces "$OTEL_E2E_OUTPUT/traces.json" \
-        --logs "$OTEL_E2E_OUTPUT/logs.json" \
-        --topology cli --outcome success --session-id "$session_id"
+    remember_otel_thread "$thread"
+    assert_local_otel_turn cli success "$session_id"
+
+    if [[ "$LIVE" == "0" ]]; then
+        echo
+        echo "=== drive dispatcher and transport-control turns through real Valkey ==="
+        assert_stub_port_free
+        local control_json malformed_sentinel redaction_sentinel
+        local label control_thread control_session
+        control_json="$(run_local_otel_transport_controls "$agent_id")"
+        printf '%s\n' "$control_json"
+        malformed_sentinel="$(printf '%s' "$control_json" | python3 -c \
+            'import json,sys; print(json.load(sys.stdin)["malformed_sentinel"])')"
+        redaction_sentinel="$(printf '%s' "$control_json" | python3 -c \
+            'import json,sys; print(json.load(sys.stdin)["redaction_sentinel"])')"
+
+        while IFS=$'\t' read -r label control_thread; do
+            remember_otel_thread "$control_thread"
+            control_session="agent-${agent_id}-thread-${control_thread}"
+            case "$label" in
+                dispatcher)
+                    assert_local_otel_turn dispatcher success "$control_session"
+                    ;;
+                missing)
+                    assert_local_otel_turn cli success "$control_session"
+                    ;;
+                malformed)
+                    assert_local_otel_turn cli success "$control_session" \
+                        "$malformed_sentinel" "ignored malformed trace context"
+                    ;;
+                failure)
+                    assert_local_otel_turn cli failure "$control_session"
+                    ;;
+                recovery)
+                    # Falsifiable control for the injected failure: ordinary
+                    # input immediately afterward must still be explicitly OK.
+                    assert_local_otel_turn cli success "$control_session"
+                    ;;
+                redaction)
+                    assert_local_otel_turn cli success "$control_session" \
+                        "$redaction_sentinel"
+                    ;;
+                *)
+                    echo "unexpected OTEL control label: $label" >&2
+                    return 1
+                    ;;
+            esac
+        done < <(printf '%s' "$control_json" | python3 -c '
+import json, sys
+for label, thread in sorted(json.load(sys.stdin)["threads"].items()):
+    print(f"{label}\t{thread}")
+')
+    else
+        echo "OTEL injected-failure controls are sealed-fake-only; live mode keeps its real model unchanged"
+    fi
 
     echo
     echo "=== curie local eval --dry-run (suite parity) ==="
@@ -1838,6 +2223,55 @@ rung_local() {
         echo
         echo "=== curie local eval ==="
         (cd "$WORKDIR/bundle" && "$BIN" "${eval_args[@]}")
+    fi
+
+    if [[ "$LIVE" == "0" ]]; then
+        echo
+        echo "=== no-endpoint control ==="
+        if (( LOCAL_STACK_OWNED )); then
+            # Exercise the CLI's real minimal-profile env clearing. Keep the
+            # ownership flag set across this deliberate restart so any failure
+            # still drives the EXIT trap through local down.
+            "$BIN" local down
+            OTEL_E2E_COLLECTOR_MUTATED=0
+            OTEL_E2E_COLLECTOR_WAS_RUNNING=0
+            "$BIN" local up --minimal
+
+            OTEL_E2E_OUTPUT="$WORKDIR/otel-no-endpoint-output"
+            mkdir -p "$OTEL_E2E_OUTPUT"
+            chmod 0777 "$OTEL_E2E_OUTPUT"
+            export CURIE_OTEL_E2E_OUTPUT="$OTEL_E2E_OUTPUT"
+            # Start only the passive sink after the minimal services have
+            # inherited blank endpoints. It is an observer, not their config.
+            docker compose --profile full \
+                -f "$REPO_ROOT/compose.dev.yaml" \
+                -f "$REPO_ROOT/cli/tests/fixtures/otel/compose.override.yaml" \
+                up -d --no-deps --force-recreate otel-collector >/dev/null
+            OTEL_E2E_COLLECTOR_MUTATED=1
+
+            run_no_endpoint_runtime_probe
+            assert_stub_port_free
+            local no_endpoint_out no_endpoint_thread
+            no_endpoint_out="$("$BIN" --json local message \
+                "no endpoint runtime control" || true)"
+            printf '%s\n' "$no_endpoint_out"
+            assert_finalized_reply "local no-endpoint" "$no_endpoint_out"
+            no_endpoint_thread="$(printf '%s' "$no_endpoint_out" | python3 -c \
+                'import json,sys; print(json.load(sys.stdin)["thread"])')"
+            remember_otel_thread "$no_endpoint_thread"
+            sleep 0.5
+            python3 "$REPO_ROOT/cli/tests/otel_e2e_assert.py" \
+                --traces "$OTEL_E2E_OUTPUT/traces.json" \
+                --logs "$OTEL_E2E_OUTPUT/logs.json" \
+                --topology cli --outcome success --expect-empty
+        else
+            # An incumbent stack's app containers belong to its owner and must
+            # not be restarted merely to change env. Exercise the same candidate
+            # no-op runtime in-process and leave every incumbent service intact;
+            # the owned-stack branch above is the full CLI --minimal proof.
+            run_no_endpoint_runtime_probe
+            echo "no-endpoint runtime probe passed without mutating the reused stack"
+        fi
     fi
 
     if (( LOCAL_STACK_OWNED )); then

--- a/cli/scripts/e2e-ladder.sh
+++ b/cli/scripts/e2e-ladder.sh
@@ -2183,7 +2183,7 @@ rung_local() {
                     ;;
                 malformed)
                     assert_local_otel_turn cli success "$control_session" \
-                        "$malformed_sentinel" "ignored malformed trace context"
+                        "$malformed_sentinel" "worker.trace_context.invalid"
                     ;;
                 failure)
                     assert_local_otel_turn cli failure "$control_session"

--- a/cli/src/local.rs
+++ b/cli/src/local.rs
@@ -123,23 +123,30 @@ pub fn fake_model_env_override(mode: ModelMode) -> Option<(String, String)> {
 }
 
 /// The other injection step every worker-restarting command shares: suppress
-/// the OTel endpoint on a `core`-only stack. `otel-collector` is a `full`-profile
-/// service, so a `--minimal` stack has no collector to export to, and every span
-/// the runner emits would pay a synchronous DNS retry against a name that cannot
-/// resolve. An empty value (not an absent one) is what does it: compose writes
-/// the endpoint as `${OTEL_EXPORTER_OTLP_ENDPOINT-...}`, whose `-` (unset-only)
-/// form substitutes its default only when the var is UNSET, so exporting it
-/// empty resolves to empty and the runner exports nothing. `false` returns
-/// `None` so compose's shipped collector default stands. This is the one place
-/// that decision is made -- `up_command` and `local comms`'s connect/disconnect
-/// commands all call it instead of each re-deriving the pair inline, the same
-/// drift that let `local comms` fall out of parity with `local up` on the fake
-/// model (issue #450).
-pub fn otel_endpoint_env_override(minimal: bool) -> Option<(String, String)> {
+/// both OTel endpoints on a `core`-only stack. `otel-collector` is a
+/// `full`-profile service, so a `--minimal` stack has no collector to export to.
+/// The host-network worker uses the standard endpoint for its own exporter,
+/// while Compose's private relay supplies the bridge-network runner's standard
+/// endpoint; leaving either one populated would create retries against an
+/// absent collector.
+///
+/// Empty values (not absent ones) are what disable the two paths: Compose writes
+/// each endpoint as `${VAR-default}`, whose `-` (unset-only) form substitutes
+/// its default only when the variable is UNSET. `false` returns an empty vector
+/// so Compose's shipped collector defaults stand. This is the one place that
+/// decision is made -- `up_command`, targeted rebuilds, and `local comms` all
+/// call it instead of re-deriving either half inline.
+pub fn otel_endpoint_env_override(minimal: bool) -> Vec<(String, String)> {
     if minimal {
-        Some(("OTEL_EXPORTER_OTLP_ENDPOINT".into(), String::new()))
+        vec![
+            ("OTEL_EXPORTER_OTLP_ENDPOINT".into(), String::new()),
+            (
+                "CURIE_RUNNER_OTEL_EXPORTER_OTLP_ENDPOINT".into(),
+                String::new(),
+            ),
+        ]
     } else {
-        None
+        Vec::new()
     }
 }
 
@@ -985,12 +992,16 @@ mod tests {
         let mut o = opts(DEFAULT_COMPOSE_FILE);
         o.minimal = true;
         let cmd = up_command(&o);
-        assert!(
-            cmd.env
-                .contains(&(String::from("OTEL_EXPORTER_OTLP_ENDPOINT"), String::new(),)),
-            "--minimal must pass an empty OTEL_EXPORTER_OTLP_ENDPOINT; env={:?}",
-            cmd.env
-        );
+        for endpoint in [
+            "OTEL_EXPORTER_OTLP_ENDPOINT",
+            "CURIE_RUNNER_OTEL_EXPORTER_OTLP_ENDPOINT",
+        ] {
+            assert!(
+                cmd.env.contains(&(String::from(endpoint), String::new(),)),
+                "--minimal must pass an empty {endpoint}; env={:?}",
+                cmd.env
+            );
+        }
     }
 
     /// The `--local-model` arm of `up_command`'s env build does not fall through
@@ -1001,12 +1012,16 @@ mod tests {
         let mut o = opts_with_local_model(DEFAULT_COMPOSE_FILE, "qwen3:4b");
         o.minimal = true;
         let cmd = up_command(&o);
-        assert!(
-            cmd.env
-                .contains(&(String::from("OTEL_EXPORTER_OTLP_ENDPOINT"), String::new(),)),
-            "--minimal --local-model must pass an empty OTEL_EXPORTER_OTLP_ENDPOINT; env={:?}",
-            cmd.env
-        );
+        for endpoint in [
+            "OTEL_EXPORTER_OTLP_ENDPOINT",
+            "CURIE_RUNNER_OTEL_EXPORTER_OTLP_ENDPOINT",
+        ] {
+            assert!(
+                cmd.env.contains(&(String::from(endpoint), String::new(),)),
+                "--minimal --local-model must pass an empty {endpoint}; env={:?}",
+                cmd.env
+            );
+        }
         // The local-model wiring must survive the suppression.
         assert!(cmd
             .env
@@ -1097,9 +1112,12 @@ mod tests {
         let mut o = opts(DEFAULT_COMPOSE_FILE);
         o.minimal = true;
         let cmd = rebuild_command(&o, "curie-worker", None);
-        assert!(cmd
-            .env
-            .contains(&(String::from("OTEL_EXPORTER_OTLP_ENDPOINT"), String::new())));
+        for endpoint in [
+            "OTEL_EXPORTER_OTLP_ENDPOINT",
+            "CURIE_RUNNER_OTEL_EXPORTER_OTLP_ENDPOINT",
+        ] {
+            assert!(cmd.env.contains(&(String::from(endpoint), String::new())));
+        }
         assert!(cmd.display().contains("--profile core"));
     }
 
@@ -1425,7 +1443,7 @@ mod tests {
         // profile starts no collector); `display` renders env before the program.
         assert_eq!(
             cmd.display(),
-            "OTEL_EXPORTER_OTLP_ENDPOINT= docker compose --profile core -f compose.dev.yaml up -d --wait"
+            "CURIE_RUNNER_OTEL_EXPORTER_OTLP_ENDPOINT= OTEL_EXPORTER_OTLP_ENDPOINT= docker compose --profile core -f compose.dev.yaml up -d --wait"
         );
     }
 

--- a/cli/tests/fixtures/otel/collector-config.yaml
+++ b/cli/tests/fixtures/otel/collector-config.yaml
@@ -1,0 +1,35 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch:
+    timeout: 100ms
+
+exporters:
+  file/traces:
+    path: /var/lib/curie-otel-e2e/traces.json
+    format: json
+  file/logs:
+    path: /var/lib/curie-otel-e2e/logs.json
+    format: json
+
+extensions:
+  health_check:
+    endpoint: 0.0.0.0:13133
+
+service:
+  extensions: [health_check]
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [file/traces]
+    logs:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [file/logs]

--- a/cli/tests/fixtures/otel/compose.override.yaml
+++ b/cli/tests/fixtures/otel/compose.override.yaml
@@ -1,0 +1,5 @@
+services:
+  otel-collector:
+    volumes:
+      - ./cli/tests/fixtures/otel/collector-config.yaml:/etc/otel/collector-config.yaml:ro
+      - ${CURIE_OTEL_E2E_OUTPUT:?set a ladder-owned output directory}:/var/lib/curie-otel-e2e

--- a/cli/tests/fixtures/otel/stub_evidence.py
+++ b/cli/tests/fixtures/otel/stub_evidence.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Emit minimal causal OTLP file records for the shell-stub ladder tests.
+
+The executing Rust controls run the real ladder but replace its services with
+argv-strict shell stubs.  This fixture supplies the collector file boundary
+those controls cannot otherwise produce; the production ladder still has to
+drive and parse every topology/outcome/control with no bypass knob.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+
+def _attribute(key: str, value: str) -> dict[str, Any]:
+    return {"key": key, "value": {"stringValue": value}}
+
+
+def _identifier(seed: str, length: int) -> str:
+    return hashlib.sha256(seed.encode()).hexdigest()[:length]
+
+
+def _span(
+    *,
+    name: str,
+    trace_id: str,
+    span_id: str,
+    parent_span_id: str = "",
+    attributes: list[dict[str, Any]] | None = None,
+    events: list[dict[str, str]] | None = None,
+    kind: str | None = None,
+    status: str | None = None,
+) -> dict[str, Any]:
+    record: dict[str, Any] = {
+        "name": name,
+        "traceId": trace_id,
+        "spanId": span_id,
+        "attributes": attributes or [],
+        "events": events or [],
+    }
+    if parent_span_id:
+        record["parentSpanId"] = parent_span_id
+    if kind:
+        record["kind"] = kind
+    if status:
+        record["status"] = {"code": status}
+    return record
+
+
+def emit_turn(
+    output: Path,
+    *,
+    agent_id: str,
+    thread: str,
+    topology: str,
+    outcome: str,
+    warning: str | None = None,
+) -> None:
+    session_id = f"agent-{agent_id}-thread-{thread}"
+    trace_id = _identifier(session_id, 32)
+    ids = {
+        label: _identifier(f"{session_id}:{label}", 16)
+        for label in ("producer", "process", "worker", "sandbox", "client", "agent")
+    }
+    messaging = [
+        _attribute("messaging.system", "valkey"),
+        _attribute("messaging.destination.name", "curie:runs"),
+        _attribute("messaging.operation.type", "process"),
+    ]
+    spans: list[dict[str, Any]] = []
+    process_parent = ""
+    if topology == "dispatcher":
+        spans.append(
+            _span(
+                name="send curie:runs",
+                trace_id=trace_id,
+                span_id=ids["producer"],
+                attributes=[
+                    _attribute("messaging.system", "valkey"),
+                    _attribute("messaging.destination.name", "curie:runs"),
+                    _attribute("messaging.operation.type", "send"),
+                ],
+            )
+        )
+        process_parent = ids["producer"]
+    spans.extend(
+        [
+            _span(
+                name="process curie:runs",
+                trace_id=trace_id,
+                span_id=ids["process"],
+                parent_span_id=process_parent,
+                attributes=messaging,
+            ),
+            _span(
+                name="worker.turn",
+                trace_id=trace_id,
+                span_id=ids["worker"],
+                parent_span_id=ids["process"],
+                events=[
+                    {"name": "worker.reply.final"},
+                    {"name": "worker.completion.settled"},
+                ],
+            ),
+            _span(
+                name="sandbox.claim",
+                trace_id=trace_id,
+                span_id=ids["sandbox"],
+                parent_span_id=ids["worker"],
+            ),
+            _span(
+                name="POST /v1/event",
+                trace_id=trace_id,
+                span_id=ids["client"],
+                parent_span_id=ids["worker"],
+                kind="SPAN_KIND_CLIENT",
+                attributes=[_attribute("http.request.method", "POST")],
+            ),
+            _span(
+                name="agent.run",
+                trace_id=trace_id,
+                span_id=ids["agent"],
+                parent_span_id=ids["client"],
+                attributes=[_attribute("langfuse.session.id", session_id)],
+                status=(
+                    "STATUS_CODE_OK"
+                    if outcome == "success"
+                    else "STATUS_CODE_ERROR"
+                ),
+            ),
+        ]
+    )
+    log_body = warning or (
+        "turn end" if outcome == "success" else "turn failed"
+    )
+    log_records = [
+        {
+            "traceId": trace_id,
+            "spanId": ids["agent"],
+            "body": {"stringValue": log_body},
+            "attributes": [],
+        }
+    ]
+    output.mkdir(parents=True, exist_ok=True)
+    with (output / "traces.json").open("a") as traces:
+        traces.write(json.dumps({"spans": spans}, separators=(",", ":")) + "\n")
+    with (output / "logs.json").open("a") as logs:
+        logs.write(
+            json.dumps({"logRecords": log_records}, separators=(",", ":")) + "\n"
+        )
+
+
+def emit_controls(output: Path, agent_id: str) -> dict[str, Any]:
+    threads = {
+        "dispatcher": "otel-dispatcher-example",
+        "missing": "otel-missing-example",
+        "malformed": "otel-malformed-example",
+        "failure": "otel-failure-example",
+        "recovery": "otel-recovery-example",
+        "redaction": "otel-redaction-example",
+    }
+    for label, thread in threads.items():
+        emit_turn(
+            output,
+            agent_id=agent_id,
+            thread=thread,
+            topology="dispatcher" if label == "dispatcher" else "cli",
+            outcome="failure" if label == "failure" else "success",
+            warning=(
+                "ignored malformed trace context" if label == "malformed" else None
+            ),
+        )
+    return {
+        "threads": threads,
+        "malformed_sentinel": "otel-malformed-carrier-private-value",
+        "redaction_sentinel": "sk-FAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKE0000",
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    turn = subparsers.add_parser("turn")
+    turn.add_argument("--agent-id", required=True)
+    turn.add_argument("--thread", required=True)
+    turn.add_argument("--topology", choices=("cli", "dispatcher"), required=True)
+    turn.add_argument("--outcome", choices=("success", "failure"), required=True)
+    controls = subparsers.add_parser("controls")
+    controls.add_argument("--agent-id", required=True)
+    args = parser.parse_args()
+
+    output = Path(os.environ["CURIE_OTEL_E2E_OUTPUT"])
+    if args.command == "turn":
+        emit_turn(
+            output,
+            agent_id=args.agent_id,
+            thread=args.thread,
+            topology=args.topology,
+            outcome=args.outcome,
+        )
+    else:
+        print(json.dumps(emit_controls(output, args.agent_id), sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/cli/tests/fixtures/otel/stub_evidence.py
+++ b/cli/tests/fixtures/otel/stub_evidence.py
@@ -142,6 +142,7 @@ def emit_turn(
         {
             "traceId": trace_id,
             "spanId": ids["agent"],
+            "severityText": "ERROR" if outcome == "failure" else "INFO",
             "body": {"stringValue": log_body},
             "attributes": [],
         }
@@ -172,7 +173,7 @@ def emit_controls(output: Path, agent_id: str) -> dict[str, Any]:
             topology="dispatcher" if label == "dispatcher" else "cli",
             outcome="failure" if label == "failure" else "success",
             warning=(
-                "ignored malformed trace context" if label == "malformed" else None
+                "worker.trace_context.invalid" if label == "malformed" else None
             ),
         )
     return {

--- a/cli/tests/nightly_graded_ladder.rs
+++ b/cli/tests/nightly_graded_ladder.rs
@@ -286,9 +286,7 @@ fn nightly_never_echoes_the_openrouter_secret_on_a_run_line() {
 #[test]
 fn live_local_rung_grades_the_deployed_weather_cases() {
     let text = ladder();
-    let contract = r#"assert_finalized_reply "local" "$out"
-
-    echo
+    let contract = r#"    echo
     echo "=== curie local eval --dry-run (suite parity) ==="
     local eval_args=(local eval)
     if [[ ! -f "$WORKDIR/bundle/evals/trajectory.json" ]]; then
@@ -301,8 +299,14 @@ fn live_local_rung_grades_the_deployed_weather_cases() {
         echo "=== curie local eval ==="
         (cd "$WORKDIR/bundle" && "$BIN" "${eval_args[@]}")
     fi"#;
+    let finalized = text
+        .find(r#"assert_finalized_reply "local" "$out""#)
+        .expect("local rung must assert a finalized reply");
+    let eval = text
+        .find(contract)
+        .expect("local rung must retain the dry-run and live eval block");
     assert!(
-        text.contains(contract),
+        finalized < eval,
         "the live local rung must run local eval after its plumbing assertion \
          against the deployed weather bundle cases, with the suite-parity \
          dry-run check in front of it; ladder contents:\n{text}"
@@ -459,6 +463,11 @@ fn write_ladder_stubs(dir: &Path) {
         include_str!("data/deploy-provider-wire.json"),
     )
     .expect("write deploy provider fixture");
+    fs::write(
+        dir.join("otel-stub-evidence.py"),
+        include_str!("fixtures/otel/stub_evidence.py"),
+    )
+    .expect("write OTEL evidence fixture");
 
     write_executable(
         &dir.join("curie"),
@@ -653,9 +662,11 @@ print(json.dumps({
         echo "stub: removed the leftover runner named '$name'"
         ;;
     "local up --minimal")
+        touch "$STUB_STATE/no-otel-endpoint"
         echo "stub: compose stack up"
         ;;
     "local up")
+        rm -f "$STUB_STATE/no-otel-endpoint"
         echo "stub: full compose stack up"
         ;;
     "--json local deploy --plugin-dir "*)
@@ -667,7 +678,12 @@ print(json.dumps({
         emit_deploy "${STUB_CLUSTER_SHA256:-$(sha_of_bundle "$bundle_dir")}"
         ;;
     "--json local message "*)
-        printf '%s\n' '{"finalized":true,"reply":"stub local weather reply"}'
+        if [ ! -e "$STUB_STATE/no-otel-endpoint" ] && [ -n "${CURIE_OTEL_E2E_OUTPUT:-}" ]; then
+            python3 "$STUB_STATE/otel-stub-evidence.py" turn \
+                --agent-id "$STUB_AGENT_ID" --thread thread-example \
+                --topology cli --outcome success
+        fi
+        printf '%s\n' '{"finalized":true,"reply":"stub local weather reply","thread":"thread-example"}'
         ;;
     "--json cluster message "*)
         printf '%s\n' '{"finalized":true,"reply":"stub cluster weather reply"}'
@@ -706,6 +722,27 @@ print(json.dumps({
         exit 97
         ;;
 esac
+"#,
+    );
+
+    // The sealed transport-control block is an in-process Python driver in the
+    // real ladder. These executing controls have no Valkey/services, so this
+    // argv-strict uv stub emits equivalent file-boundary evidence and the same
+    // public JSON result. The no-endpoint runtime probe is the argument-free
+    // sibling and intentionally emits nothing.
+    write_executable(
+        &dir.join("uv"),
+        r#"#!/bin/sh
+set -u
+if [ "$#" -eq 4 ] && [ "$1" = "run" ] && [ "$2" = "python" ] && [ "$3" = "-" ]; then
+    python3 "$STUB_STATE/otel-stub-evidence.py" controls --agent-id "$4"
+elif [ "$#" -eq 3 ] && [ "$1" = "run" ] && [ "$2" = "python" ] && [ "$3" = "-" ]; then
+    # run_no_endpoint_runtime_probe: the absence of records is its assertion.
+    exit 0
+else
+    echo "unexpected uv invocation: $*" >&2
+    exit 97
+fi
 "#,
     );
 
@@ -920,12 +957,28 @@ fn run_eval_argument_control(trajectory: bool) -> (Output, String) {
     require_local_stub_port_free();
     let root = tempfile::tempdir().expect("create isolated ladder root");
     let scripts = root.path().join("cli/scripts");
+    let cli_tests = root.path().join("cli/tests");
+    let otel_fixtures = cli_tests.join("fixtures/otel");
     let evals = root.path().join("examples/weather/evals");
     fs::create_dir_all(&scripts).expect("create script directory");
+    fs::create_dir_all(&otel_fixtures).expect("create OTEL fixture directory");
     fs::create_dir_all(&evals).expect("create eval directory");
-    let source = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("scripts/e2e-ladder.sh");
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let source = manifest.join("scripts/e2e-ladder.sh");
     let script = scripts.join("e2e-ladder.sh");
     fs::copy(source, &script).expect("copy ladder script");
+    fs::copy(
+        manifest.join("tests/otel_e2e_assert.py"),
+        cli_tests.join("otel_e2e_assert.py"),
+    )
+    .expect("copy OTEL evidence parser");
+    for fixture in ["collector-config.yaml", "compose.override.yaml"] {
+        fs::copy(
+            manifest.join("tests/fixtures/otel").join(fixture),
+            otel_fixtures.join(fixture),
+        )
+        .expect("copy OTEL collector fixture");
+    }
     fs::write(
         evals.join("cases.json"),
         r#"{"name":"weather","cases":[{"id":"weather","input":"weather","grader":{"kind":"contains","expected":"sunny"}}]}"#,
@@ -1075,8 +1128,9 @@ fn ladder_selects_platform_trajectory_eval_without_overriding_deployed_cases() {
         .collect::<Vec<_>>();
     assert_eq!(
         ordinary_starts,
-        ["local up --minimal"],
-        "ordinary grading must retain the minimal local profile: {ordinary_invocations}"
+        ["local up"],
+        "the mandatory OTEL file-boundary proof requires the full local profile: \
+         {ordinary_invocations}"
     );
 }
 

--- a/cli/tests/nightly_graded_ladder.rs
+++ b/cli/tests/nightly_graded_ladder.rs
@@ -81,6 +81,9 @@ fn local_otel_ladder_builds_and_selects_the_candidate_runner() {
     let api_build = script
         .find("docker build --file \"$REPO_ROOT/apps/api/Dockerfile\"")
         .expect("the local OTEL rung must build the candidate API source");
+    let dispatcher_build = script
+        .find("docker build --file \"$REPO_ROOT/apps/dispatcher/Dockerfile\"")
+        .expect("the local OTEL controls must run inside the candidate dispatcher image");
     let worker_build = script
         .find("docker build --file \"$REPO_ROOT/apps/worker/Dockerfile\"")
         .expect("the local OTEL rung must build the candidate worker source");
@@ -108,13 +111,21 @@ fn local_otel_ladder_builds_and_selects_the_candidate_runner() {
         .map(|offset| rung + offset)
         .expect("the local rung must verify its running image identities");
     assert!(
-        api_build < worker_build
+        api_build < dispatcher_build
+            && dispatcher_build < worker_build
             && worker_build < worker_overlay_build
             && worker_overlay_build < runner_build
             && runner_build < base_select
             && base_select < worker_select
             && worker_select < select,
         "the candidate image builder must build and select all service images"
+    );
+    assert!(
+        script.contains("--entrypoint python \"$OTEL_E2E_DISPATCHER_IMAGE\" - \"$agent_id\"")
+            && script.contains("docker run --rm --interactive --network host")
+            && script.contains("docker run --rm --interactive --network none")
+            && !script.contains("uv run python -"),
+        "the local OTEL controls must carry their dependencies in a candidate image"
     );
     assert!(
         incumbent_guard < build_call && build_call < up && up < image_assertion,
@@ -806,27 +817,6 @@ esac
 "#,
     );
 
-    // The sealed transport-control block is an in-process Python driver in the
-    // real ladder. These executing controls have no Valkey/services, so this
-    // argv-strict uv stub emits equivalent file-boundary evidence and the same
-    // public JSON result. The no-endpoint runtime probe is the argument-free
-    // sibling and intentionally emits nothing.
-    write_executable(
-        &dir.join("uv"),
-        r#"#!/bin/sh
-set -u
-if [ "$#" -eq 4 ] && [ "$1" = "run" ] && [ "$2" = "python" ] && [ "$3" = "-" ]; then
-    python3 "$STUB_STATE/otel-stub-evidence.py" controls --agent-id "$4"
-elif [ "$#" -eq 3 ] && [ "$1" = "run" ] && [ "$2" = "python" ] && [ "$3" = "-" ]; then
-    # run_no_endpoint_runtime_probe: the absence of records is its assertion.
-    exit 0
-else
-    echo "unexpected uv invocation: $*" >&2
-    exit 97
-fi
-"#,
-    );
-
     // The ladder's raw-docker uses are all either "is a stack already running"
     // or "assert nothing survived", so an unrecognized invocation returning
     // nothing is the honest default here; the two reads that carry a real
@@ -837,6 +827,13 @@ fi
         r#"#!/bin/sh
 set -u
 case "$*" in
+    "run --rm --interactive --network host --env OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:24318 --env OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf --entrypoint python ghcr.io/curie-eng/curie-dispatcher:"*" - "*)
+        python3 "$STUB_STATE/otel-stub-evidence.py" controls --agent-id "$STUB_AGENT_ID"
+        ;;
+    "run --rm --interactive --network none --entrypoint python ghcr.io/curie-eng/curie-dispatcher:"*" -")
+        # run_no_endpoint_runtime_probe: the absence of records is its assertion.
+        exit 0
+        ;;
     "inspect --format {{.Config.Image}} stub-curie-api")
         echo "ghcr.io/curie-eng/curie-api:${CURIE_BASE_TAG}"
         ;;

--- a/cli/tests/nightly_graded_ladder.rs
+++ b/cli/tests/nightly_graded_ladder.rs
@@ -59,6 +59,87 @@ fn ladder() -> String {
     fs::read_to_string(path).unwrap_or_default()
 }
 
+fn dev_compose() -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../compose.dev.yaml");
+    fs::read_to_string(path).unwrap_or_default()
+}
+
+#[test]
+fn local_otel_ladder_builds_and_selects_the_candidate_runner() {
+    let script = ladder();
+    let rung = script
+        .find("rung_local() {")
+        .expect("the local rung must remain present");
+    let incumbent_guard = script[rung..]
+        .find("candidate local OTEL rung requires an unoccupied compose stack")
+        .map(|offset| rung + offset)
+        .expect("the local OTEL rung must refuse an incumbent stack");
+    let build_call = script[rung..]
+        .find("build_local_otel_candidate_images")
+        .map(|offset| rung + offset)
+        .expect("the local rung must invoke its candidate image builder");
+    let api_build = script
+        .find("docker build --file \"$REPO_ROOT/apps/api/Dockerfile\"")
+        .expect("the local OTEL rung must build the candidate API source");
+    let worker_build = script
+        .find("docker build --file \"$REPO_ROOT/apps/worker/Dockerfile\"")
+        .expect("the local OTEL rung must build the candidate worker source");
+    let worker_overlay_build = script
+        .find("docker build --file \"$REPO_ROOT/compose/worker-local.Dockerfile\"")
+        .expect("the local OTEL rung must build its candidate worker overlay");
+    let runner_build = script
+        .find("docker build --file \"$REPO_ROOT/runner/Dockerfile\"")
+        .expect("the local OTEL rung must build the candidate runner source");
+    let base_select = script
+        .find("export CURIE_BASE_TAG=\"$OTEL_E2E_BASE_TAG\"")
+        .expect("the local OTEL rung must select its candidate API and worker images");
+    let worker_select = script
+        .find("export CURIE_WORKER_LOCAL_IMAGE=\"$OTEL_E2E_WORKER_LOCAL_IMAGE\"")
+        .expect("the local OTEL rung must select its unique worker overlay image");
+    let select = script
+        .find("export CURIE_RUNNER_IMAGE=\"$OTEL_E2E_RUNNER_IMAGE\"")
+        .expect("the local OTEL rung must select its candidate runner image");
+    let up = script[rung..]
+        .find("\"$BIN\" \"${up_args[@]}\"")
+        .map(|offset| rung + offset)
+        .expect("the local rung must still drive the real local-up command");
+    let image_assertion = script[rung..]
+        .find("assert_local_candidate_images")
+        .map(|offset| rung + offset)
+        .expect("the local rung must verify its running image identities");
+    assert!(
+        api_build < worker_build
+            && worker_build < worker_overlay_build
+            && worker_overlay_build < runner_build
+            && runner_build < base_select
+            && base_select < worker_select
+            && worker_select < select,
+        "the candidate image builder must build and select all service images"
+    );
+    assert!(
+        incumbent_guard < build_call && build_call < up && up < image_assertion,
+        "the local rung must guard ownership, build, start, then inspect candidate images"
+    );
+    assert!(
+        !script[rung..]
+            .split("rung_local_release() {")
+            .next()
+            .unwrap_or_default()
+            .contains("reusing it and leaving teardown to whoever started it"),
+        "candidate telemetry evidence must never reuse another session's services"
+    );
+    assert!(
+        dev_compose().contains("image: ${CURIE_WORKER_LOCAL_IMAGE:-curie-worker-local:dev}"),
+        "compose must honor the ladder's unique worker overlay image"
+    );
+    assert!(
+        dev_compose().contains(
+            "CURIE_RUNNER_IMAGE=${CURIE_RUNNER_IMAGE:-ghcr.io/curie-eng/curie-runner:latest}"
+        ),
+        "compose must honor the ladder's candidate image while retaining the released default"
+    );
+}
+
 fn count_lines_containing(text: &str, needle: &str) -> usize {
     text.lines().filter(|line| line.contains(needle)).count()
 }
@@ -756,6 +837,15 @@ fi
         r#"#!/bin/sh
 set -u
 case "$*" in
+    "inspect --format {{.Config.Image}} stub-curie-api")
+        echo "ghcr.io/curie-eng/curie-api:${CURIE_BASE_TAG}"
+        ;;
+    "inspect --format {{.Config.Image}} stub-curie-worker")
+        echo "${CURIE_WORKER_LOCAL_IMAGE}"
+        ;;
+    "inspect --format {{json .Config.Env}} stub-curie-worker")
+        printf '["CURIE_RUNNER_IMAGE=%s"]\n' "${CURIE_RUNNER_IMAGE}"
+        ;;
     "inspect curie-runner-local")
         # The first-run credential check refuses to touch an existing shared
         # local runner. Its harness begins with no such runner, while all
@@ -782,6 +872,7 @@ case "$*" in
         if [ -n "${STUB_FAKE_MODEL:-}" ]; then
             echo "CURIE_FAKE_MODEL=$STUB_FAKE_MODEL"
         fi
+        echo "CURIE_RUNNER_IMAGE=${CURIE_RUNNER_IMAGE}"
         # The default local rungs read the connector scope off the same worker
         # env: the stock weather bundle declares the netpol-probe fixture, so
         # the dual assertion derives its identity label from this release.
@@ -799,6 +890,9 @@ case "$*" in
         # assumption breaks, so returning one id is the only shape that lets the
         # mode assertion be reached at all.
         echo "stub-curie-worker"
+        ;;
+    *"name=^/curie-curie-api-1$"*)
+        echo "stub-curie-api"
         ;;
     *)
         ;;

--- a/cli/tests/otel_e2e_assert.py
+++ b/cli/tests/otel_e2e_assert.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Assert causal trace and correlated-log facts from the collector file sink.
+
+The ladder drives the turns.  This parser only judges records produced after its
+watermark, so an incumbent stack's older telemetry cannot manufacture a pass.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _records(path: Path, collection: str) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    found: list[dict[str, Any]] = []
+    for line in path.read_text().splitlines():
+        if not line.strip():
+            continue
+        document = json.loads(line)
+        stack: list[Any] = [document]
+        while stack:
+            value = stack.pop()
+            if isinstance(value, dict):
+                items = value.get(collection)
+                if isinstance(items, list):
+                    found.extend(item for item in items if isinstance(item, dict))
+                stack.extend(value.values())
+            elif isinstance(value, list):
+                stack.extend(value)
+    return found
+
+
+def _attrs(record: dict[str, Any]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for item in record.get("attributes", []):
+        value = item.get("value", {})
+        result[item["key"]] = next(iter(value.values()), None)
+    return result
+
+
+def _id(record: dict[str, Any], key: str) -> str:
+    return str(record.get(key, "")).lower()
+
+
+def _body(record: dict[str, Any]) -> str:
+    body = record.get("body", {})
+    return str(next(iter(body.values()), ""))
+
+
+def _status(record: dict[str, Any]) -> str:
+    return str(record.get("status", {}).get("code", "")).upper()
+
+
+def _descends(child: dict[str, Any], ancestor: dict[str, Any], spans: list[dict[str, Any]]) -> bool:
+    by_id = {_id(span, "spanId"): span for span in spans}
+    cursor = child
+    seen: set[str] = set()
+    while parent_id := _id(cursor, "parentSpanId"):
+        if parent_id == _id(ancestor, "spanId"):
+            return True
+        if parent_id in seen or parent_id not in by_id:
+            return False
+        seen.add(parent_id)
+        cursor = by_id[parent_id]
+    return False
+
+
+def assert_turn(
+    spans: list[dict[str, Any]],
+    logs: list[dict[str, Any]],
+    *,
+    topology: str,
+    outcome: str,
+    session_id: str,
+    forbidden: str | None,
+) -> None:
+    agent = next(
+        span
+        for span in spans
+        if span.get("name") == "agent.run"
+        and _attrs(span).get("langfuse.session.id") == session_id
+    )
+    agent_trace_id = _id(agent, "traceId")
+    process = next(
+        span
+        for span in spans
+        if span.get("name") == "process curie:runs"
+        and _id(span, "traceId") == agent_trace_id
+    )
+    trace_id = _id(process, "traceId")
+    tree = [span for span in spans if _id(span, "traceId") == trace_id]
+    worker = next(span for span in tree if span.get("name") == "worker.turn")
+    client = next(
+        span
+        for span in tree
+        if str(span.get("kind", "")).upper() in {"3", "SPAN_KIND_CLIENT"}
+        and _attrs(span).get("http.request.method") == "POST"
+    )
+    assert _attrs(process) >= {
+        "messaging.system": "valkey",
+        "messaging.destination.name": "curie:runs",
+        "messaging.operation.type": "process",
+    }
+    assert _descends(worker, process, tree)
+    assert _descends(client, worker, tree)
+    assert _descends(agent, client, tree)
+    assert any(span.get("name") == "sandbox.claim" for span in tree)
+    event_names = {
+        event.get("name") for span in tree for event in span.get("events", [])
+    }
+    assert {"worker.reply.final", "worker.completion.settled"} <= event_names
+
+    producer = [span for span in tree if span.get("name") == "send curie:runs"]
+    if topology == "cli":
+        assert not producer, "curie local message bypasses the dispatcher honestly"
+        assert not _id(process, "parentSpanId"), "payload-only CLI enqueue starts a root"
+    else:
+        assert len(producer) == 1
+        assert _descends(process, producer[0], tree)
+        assert _attrs(producer[0]) >= {
+            "messaging.system": "valkey",
+            "messaging.destination.name": "curie:runs",
+            "messaging.operation.type": "send",
+        }
+
+    expected_status = "STATUS_CODE_OK" if outcome == "success" else "STATUS_CODE_ERROR"
+    assert _status(agent) in {expected_status, "1" if outcome == "success" else "2"}
+    correlated = [
+        record
+        for record in logs
+        if _id(record, "traceId") == trace_id and _id(record, "spanId")
+    ]
+    assert correlated, "the causal trace has no trace-correlated OTLP logs"
+    raw = json.dumps({"spans": tree, "logs": correlated})
+    if forbidden:
+        assert forbidden not in raw
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--traces", type=Path, required=True)
+    parser.add_argument("--logs", type=Path, required=True)
+    parser.add_argument("--topology", choices=("cli", "dispatcher"), required=True)
+    parser.add_argument("--outcome", choices=("success", "failure"), required=True)
+    parser.add_argument("--session-id", required=False, default="")
+    parser.add_argument("--forbidden")
+    parser.add_argument("--require-warning")
+    parser.add_argument("--expect-empty", action="store_true")
+    args = parser.parse_args()
+
+    spans = _records(args.traces, "spans")
+    logs = _records(args.logs, "logRecords")
+    if args.expect_empty:
+        assert not spans and not logs, "no-endpoint control unexpectedly exported telemetry"
+        print("otel-e2e no-endpoint: no records")
+        return
+    if args.require_warning:
+        assert any(args.require_warning in _body(record) for record in logs)
+        assert args.forbidden is None or all(args.forbidden not in _body(record) for record in logs)
+    assert_turn(
+        spans,
+        logs,
+        topology=args.topology,
+        outcome=args.outcome,
+        session_id=args.session_id,
+        forbidden=args.forbidden,
+    )
+    print(
+        f"otel-e2e topology={args.topology} outcome={args.outcome}: "
+        "causal tree and logs verified"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/cli/tests/otel_e2e_assert.py
+++ b/cli/tests/otel_e2e_assert.py
@@ -100,11 +100,11 @@ def assert_turn(
         if str(span.get("kind", "")).upper() in {"3", "SPAN_KIND_CLIENT"}
         and _attrs(span).get("http.request.method") == "POST"
     )
-    assert _attrs(process) >= {
+    assert {
         "messaging.system": "valkey",
         "messaging.destination.name": "curie:runs",
         "messaging.operation.type": "process",
-    }
+    }.items() <= _attrs(process).items()
     assert _descends(worker, process, tree)
     assert _descends(client, worker, tree)
     assert _descends(agent, client, tree)
@@ -121,11 +121,11 @@ def assert_turn(
     else:
         assert len(producer) == 1
         assert _descends(process, producer[0], tree)
-        assert _attrs(producer[0]) >= {
+        assert {
             "messaging.system": "valkey",
             "messaging.destination.name": "curie:runs",
             "messaging.operation.type": "send",
-        }
+        }.items() <= _attrs(producer[0]).items()
 
     expected_status = "STATUS_CODE_OK" if outcome == "success" else "STATUS_CODE_ERROR"
     assert _status(agent) in {expected_status, "1" if outcome == "success" else "2"}

--- a/cli/tests/otel_e2e_assert.py
+++ b/cli/tests/otel_e2e_assert.py
@@ -55,6 +55,10 @@ def _status(record: dict[str, Any]) -> str:
     return str(record.get("status", {}).get("code", "")).upper()
 
 
+def _severity(record: dict[str, Any]) -> str:
+    return str(record.get("severityText", "")).upper()
+
+
 def _descends(child: dict[str, Any], ancestor: dict[str, Any], spans: list[dict[str, Any]]) -> bool:
     by_id = {_id(span, "spanId"): span for span in spans}
     cursor = child
@@ -135,6 +139,14 @@ def assert_turn(
         if _id(record, "traceId") == trace_id and _id(record, "spanId")
     ]
     assert correlated, "the causal trace has no trace-correlated OTLP logs"
+    if outcome == "failure":
+        agent_span_id = _id(agent, "spanId")
+        assert any(
+            _id(record, "traceId") == agent_trace_id
+            and _id(record, "spanId") == agent_span_id
+            and _severity(record) == "ERROR"
+            for record in logs
+        ), "the failing agent.run span has no correlated ERROR-severity OTLP log"
     raw = json.dumps({"spans": tree, "logs": correlated})
     if forbidden:
         assert forbidden not in raw

--- a/cli/tests/otel_e2e_assert.py
+++ b/cli/tests/otel_e2e_assert.py
@@ -81,6 +81,7 @@ def assert_turn(
     outcome: str,
     session_id: str,
     forbidden: str | None,
+    require_reply_completion: bool,
 ) -> None:
     agent = next(
         span
@@ -103,6 +104,7 @@ def assert_turn(
         for span in tree
         if str(span.get("kind", "")).upper() in {"3", "SPAN_KIND_CLIENT"}
         and _attrs(span).get("http.request.method") == "POST"
+        and _descends(agent, span, tree)
     )
     assert {
         "messaging.system": "valkey",
@@ -116,7 +118,8 @@ def assert_turn(
     event_names = {
         event.get("name") for span in tree for event in span.get("events", [])
     }
-    assert {"worker.reply.final", "worker.completion.settled"} <= event_names
+    if require_reply_completion:
+        assert {"worker.reply.final", "worker.completion.settled"} <= event_names
 
     producer = [span for span in tree if span.get("name") == "send curie:runs"]
     if topology == "cli":
@@ -161,6 +164,7 @@ def main() -> None:
     parser.add_argument("--session-id", required=False, default="")
     parser.add_argument("--forbidden")
     parser.add_argument("--require-warning")
+    parser.add_argument("--require-reply-completion", action="store_true")
     parser.add_argument("--expect-empty", action="store_true")
     args = parser.parse_args()
 
@@ -180,6 +184,7 @@ def main() -> None:
         outcome=args.outcome,
         session_id=args.session_id,
         forbidden=args.forbidden,
+        require_reply_completion=args.require_reply_completion,
     )
     print(
         f"otel-e2e topology={args.topology} outcome={args.outcome}: "

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -454,6 +454,7 @@ services:
   # dials each runner on the loopback host port Docker publishes for it, and
   # reaches the `curie local message` Slack stub at localhost:8155.
   curie-worker:
+    image: ${CURIE_WORKER_LOCAL_IMAGE:-curie-worker-local:dev}
     build:
       context: compose
       dockerfile: worker-local.Dockerfile
@@ -495,7 +496,7 @@ services:
       - /tmp/curie-bundles:/tmp/curie-bundles
     environment:
       - CURIE_SANDBOX_SUBSTRATE=docker
-      - CURIE_RUNNER_IMAGE=ghcr.io/curie-eng/curie-runner:latest
+      - CURIE_RUNNER_IMAGE=${CURIE_RUNNER_IMAGE:-ghcr.io/curie-eng/curie-runner:latest}
       - TMPDIR=/tmp/curie-bundles
       - VALKEY_HOST=localhost
       - VALKEY_PORT=26379

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -6,9 +6,9 @@
 # (same components, same pinned versions).
 #
 # Bring up full:  docker compose --profile full -f compose.dev.yaml up -d
-# Bring up core:  OTEL_EXPORTER_OTLP_ENDPOINT= docker compose --profile core -f compose.dev.yaml up -d
-# otel-collector is full-profile only; a core-only stack must blank the endpoint
-# or every span pays a synchronous DNS retry against an absent collector.
+# Bring up core:  OTEL_EXPORTER_OTLP_ENDPOINT= CURIE_RUNNER_OTEL_EXPORTER_OTLP_ENDPOINT= docker compose --profile core -f compose.dev.yaml up -d
+# otel-collector is full-profile only; a core-only stack must blank the worker's
+# endpoint and its bridge-runner relay or both processes retry an absent collector.
 # core = postgres, valkey, rustfs-perms, rustfs, rustfs-init, curie-migrate, curie-api, curie-worker
 # full = core + clickhouse, langfuse-web, langfuse-worker, otel-collector, curie-ui
 # The CLI `curie local up` wraps these compose profile invocations.
@@ -376,6 +376,8 @@ services:
       LANGFUSE_HOST: http://langfuse-web:3000
       LANGFUSE_PUBLIC_KEY: pk-lf-curie-dev
       LANGFUSE_SECRET_KEY: sk-lf-curie-dev
+      OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT-http://otel-collector:4318}
+      OTEL_EXPORTER_OTLP_PROTOCOL: ${OTEL_EXPORTER_OTLP_PROTOCOL-http/protobuf}
       # Approval user-group authorizers (#420) look up Slack usergroup
       # membership from the API itself, so the API reads the same bot token the
       # worker and dispatcher use. Empty by default: the Slack-free local loop
@@ -551,24 +553,23 @@ services:
       - CLAUDE_CODE_OAUTH_TOKEN
       - CURIE_CREDENTIALS
       # By default, the worker joins spawned sandbox containers to the DEDICATED
-      # runner network (CURIE_DOCKER_NETWORK=curie_runner, #631) and points
-      # them at the shipped collector (OTEL_EXPORTER_OTLP_ENDPOINT=
-      # http://otel-collector:4318), so a plain `curie local up` traces with no
-      # manual flags. curie_runner carries only the runner's documented
+      # runner network (CURIE_DOCKER_NETWORK=curie_runner, #631) and relays the
+      # bridge-reachable collector endpoint into each child's standard endpoint.
+      # The host-network worker exports through the collector's published
+      # loopback port. A plain `curie local up` therefore traces with no manual
+      # flags. curie_runner carries only the runner's documented
       # dependencies -- otel-collector (telemetry), ollama (--local-model), and
       # curie-api (state) -- NOT the data tier (postgres/valkey/rustfs), so a
       # trusted-but-buggy bundle cannot reach the stores' embedded credentials.
       # The collector join is also what lets --local-model resolve ollama by name.
       # Both are overridable from the shell.
       #
-      # The endpoint default is what a full-profile `local up` gets. It uses the
-      # `${VAR-default}` form (substitute only when UNSET), not `${VAR:-default}`
-      # (substitute when unset OR empty), so an explicit empty value means "no
-      # endpoint". That is what lets `curie local up --minimal` suppress it:
-      # --minimal selects the `core` profile, which does not start otel-collector,
-      # and a runner pointed at a host that never resolves stalls on synchronous
-      # export retries per span. CURIE_DOCKER_NETWORK stays on `:-` because the
-      # runner network is created (via curie-api's membership) under `core` too.
+      # Both endpoint defaults use `${VAR-default}` (substitute only when UNSET),
+      # not `${VAR:-default}` (substitute when unset OR empty), so explicit empty
+      # values mean "no endpoint". `curie local up --minimal` blanks both from
+      # one helper because the core profile does not start otel-collector.
+      # CURIE_DOCKER_NETWORK stays on `:-` because the runner network is created
+      # (via curie-api's membership) under `core` too.
       - CURIE_MODEL_BASE_URL=${CURIE_MODEL_BASE_URL:-}
       - CURIE_MODEL_API_BACKEND=${CURIE_MODEL_API_BACKEND:-}
       - CURIE_MODEL_ENV_KEY=${CURIE_MODEL_ENV_KEY:-}
@@ -579,7 +580,12 @@ services:
       # it to the worker, which forwards it into every claim's boot env.
       - CURIE_FALSE_COMPLETION_CHECK=${CURIE_FALSE_COMPLETION_CHECK:-}
       - CURIE_DOCKER_NETWORK=${CURIE_DOCKER_NETWORK:-curie_runner}
-      - OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT-http://otel-collector:4318}
+      - OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT-http://127.0.0.1:24318}
+      - OTEL_EXPORTER_OTLP_PROTOCOL=${OTEL_EXPORTER_OTLP_PROTOCOL-http/protobuf}
+      # Compose-only boot plumbing: the worker maps this into the spawned
+      # runner's standard endpoint. Helm needs no relay because both pods use
+      # the same in-cluster collector address.
+      - CURIE_RUNNER_OTEL_EXPORTER_OTLP_ENDPOINT=${CURIE_RUNNER_OTEL_EXPORTER_OTLP_ENDPOINT-http://otel-collector:4318}
       # config.py's connector_release/connector_namespace (CURIE_RELEASE /
       # CURIE_NAMESPACE) both default empty, which was built for the cluster
       # tier (#1118) where Helm supplies the real release name and namespace.
@@ -634,6 +640,8 @@ services:
       # Mirrors curie-api's API_KEY so resolve calls authenticate. Wired
       # explicitly rather than relying on the two defaults happening to match.
       CURIE_API_KEY: curie-dev-key
+      OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT-http://otel-collector:4318}
+      OTEL_EXPORTER_OTLP_PROTOCOL: ${OTEL_EXPORTER_OTLP_PROTOCOL-http/protobuf}
     restart: unless-stopped
 
 networks:

--- a/compose/generate_release_compose.py
+++ b/compose/generate_release_compose.py
@@ -19,7 +19,9 @@ via three ordered text transforms:
       version (this also pins the worker-local image introduced by T1). Also
       collapses the `:${CURIE_BASE_TAG:-latest}` override form (issue #698)
       to the same literal pin, since the release asset has no shell to resolve
-      that override in.
+      that override in. The local ladder's `CURIE_RUNNER_IMAGE` override is
+      collapsed the same way so release compose always names its published
+      runner image literally.
 
 Each transform locates its anchor explicitly and raises ValueError if it is
 missing: this runs unattended at publish time, so a silent no-op would ship a
@@ -31,7 +33,8 @@ import re
 import textwrap
 from pathlib import Path
 
-WORKER_BUILD_BLOCK = """    build:
+WORKER_BUILD_BLOCK = """    image: ${CURIE_WORKER_LOCAL_IMAGE:-curie-worker-local:dev}
+    build:
       context: compose
       dockerfile: worker-local.Dockerfile
       # Threads CURIE_BASE_TAG through to the overlay's own ARG BASE_TAG
@@ -66,6 +69,9 @@ OTEL_CONFIGS_REF = """    configs:
 CURIE_LATEST_RE = re.compile(
     r"(ghcr\.io/curie-eng/curie-[a-z-]+):(?:latest|\$\{CURIE_BASE_TAG:-latest\})"
 )
+RUNNER_IMAGE_OVERRIDE_RE = re.compile(
+    r"\$\{CURIE_RUNNER_IMAGE:-(ghcr\.io/curie-eng/curie-runner):latest\}"
+)
 
 DEV_COMPOSE = Path("compose.dev.yaml")
 OTEL_CONFIG = Path("otel/collector-config.yaml")
@@ -97,6 +103,7 @@ def generate(dev_text: str, otel_text: str, version: str) -> str:
     text = text.replace(OTEL_VOLUME_BLOCK, OTEL_CONFIGS_REF, 1)
 
     # T3: pin every curie-* image tag to the release version (worker-local too).
+    text = RUNNER_IMAGE_OVERRIDE_RE.sub(rf"\1:{version}", text)
     text = CURIE_LATEST_RE.sub(rf"\1:{version}", text)
 
     return text

--- a/compose/tests/test_generate_release_compose.py
+++ b/compose/tests/test_generate_release_compose.py
@@ -441,33 +441,50 @@ def collector_http_port():
     return protocols["http"]["endpoint"].rsplit(":", 1)[1]
 
 
-def test_worker_traces_to_shipped_collector_by_default():
-    """The worker exports traces to the collector this file ships, by default.
+def test_worker_and_spawned_runner_trace_to_shipped_collector_by_default():
+    """The worker and its bridge runner each use their reachable collector path.
 
     #545: `curie local up` boots otel-collector + Langfuse, but the deployed
     local tier exported ZERO traces because curie-worker was never given
     OTEL_EXPORTER_OTLP_ENDPOINT, and CURIE_DOCKER_NETWORK defaulted to empty
-    so spawned sandbox containers could not resolve otel-collector by name.
-    Both must default to values that work with no manual flags, matching the
-    documented manual recipe (README.md).
+    so spawned sandbox containers could not resolve otel-collector by name. The
+    host-network worker reaches the collector's published loopback port; the
+    spawned bridge-network runner receives the private service-name relay. Both
+    must default to their distinct reachable value with no manual flags.
 
     This pins the DEFAULT (full-profile) `curie local up`. `--minimal` selects
     the `core` profile, which starts no collector, and suppresses the endpoint by
     exporting it empty -- see `up_minimal_suppresses_otel_endpoint` in
     cli/src/local.rs, which is where the profile choice lives.
     """
-    expected = f"http://otel-collector:{collector_http_port()}"
+    expected_worker = "http://127.0.0.1:24318"
+    expected_runner = f"http://otel-collector:{collector_http_port()}"
     for label, doc in compose_docs():
         assert "otel-collector" in doc["services"], (
             f"{label}: otel-collector service not found in the compose document"
         )
         env = env_map(doc["services"]["curie-worker"])
-        otel_endpoint = resolve_shell_default(env.get("OTEL_EXPORTER_OTLP_ENDPOINT"))
-        assert otel_endpoint == expected, (
+        worker_endpoint = resolve_shell_default(
+            env.get("OTEL_EXPORTER_OTLP_ENDPOINT")
+        )
+        runner_endpoint = resolve_shell_default(
+            env.get("CURIE_RUNNER_OTEL_EXPORTER_OTLP_ENDPOINT")
+        )
+        assert worker_endpoint == expected_worker, (
             f"{label}: curie-worker OTEL_EXPORTER_OTLP_ENDPOINT resolves to "
-            f"{otel_endpoint!r}, expected {expected!r} (the collector's own "
-            f"OTLP/HTTP receiver); traces from spawned sandbox containers have "
-            f"nowhere to go"
+            f"{worker_endpoint!r}, expected {expected_worker!r} (the collector's "
+            "published OTLP/HTTP receiver); the host-network worker cannot "
+            "resolve the bridge-only collector service name"
+        )
+        assert runner_endpoint == expected_runner, (
+            f"{label}: curie-worker CURIE_RUNNER_OTEL_EXPORTER_OTLP_ENDPOINT "
+            f"resolves to {runner_endpoint!r}, expected {expected_runner!r}; "
+            "spawned bridge-network runners cannot reach the host-only loopback "
+            "endpoint"
+        )
+        assert worker_endpoint != runner_endpoint, (
+            f"{label}: host worker and spawned runner endpoints must stay "
+            "distinct across their host/bridge network boundary"
         )
         docker_network = resolve_shell_default(env.get("CURIE_DOCKER_NETWORK"))
         assert docker_network == "curie_runner", (

--- a/docs/interfaces/telemetry-otel/INTERFACE.md
+++ b/docs/interfaces/telemetry-otel/INTERFACE.md
@@ -19,52 +19,75 @@ order: 7
 
 ## The black line
 
-On the write side, observability is swapped at the OTLP wire, not in code: the runner
-exports `gen_ai.*` spans over OTLP-HTTP to a collector, and the collector is the only
-component that authenticates and forwards to a backend. Services never speak the
-backend directly. Swapping the trace store means repointing one collector exporter
-block, not touching the runner. The opinionated core is the span tree shape
-(`agent.run` → `llm.generation` → `execute_tool`) and the attributes on it, which since
-ADR-0076 are a closed, versioned key set rather than an open bag of `gen_ai.*` names.
+On the write side, observability is swapped at the OTLP wire, not in code. The API,
+dispatcher, worker, and runner export spans and correlated logs to one collector; the
+collector is the only component that authenticates and forwards to a backend. Services
+never speak the backend directly. Swapping the store means repointing one collector
+exporter block, not changing a service. The opinionated core is the causal turn tree, the
+runner's `agent.run` → `llm.generation` → `execute_tool` subtree, and the closed,
+versioned attributes and events exported by each service.
 
 ## Current contract
 
-A second backend must ingest the OTLP-HTTP export produced in
-`runner/src/curie_runner/otel.py`. Per ADR-0076 that export is a closed, versioned
-attribute schema, not an open bag of `gen_ai.*` keys:
+A second backend must ingest the standard OTLP trace and log exports created by
+`configure` (`packages/telemetry/src/curie_telemetry/bootstrap.py::configure`). The
+contract is:
 
-- **The vocabulary is closed and committed.** `SpanAttributeKey`
-  (`runner/src/curie_runner/otel.py::SpanAttributeKey`) is the only key set the runner
-  may attach: `langfuse.trace.name`, `langfuse.session.id`, `langfuse.user.id`,
-  `gen_ai.approval.decision`, `gen_ai.request.model`, a bare `model`,
-  `gen_ai.usage.input_tokens` / `output_tokens` / `cache_read_input_tokens` /
-  `cache_creation_input_tokens`, `gen_ai.tool.name`, `gen_ai.operation.name`, plus the
-  resource keys `service.name`, `curie.session_id`, `curie.sandbox_id` and
-  `schema.version`. `SPAN_ATTRIBUTE_VALUE_TYPES`
-  (`runner/src/curie_runner/otel.py::SPAN_ATTRIBUTE_VALUE_TYPES`) declares each key's
-  value type (the four usage counts are `int`, every other key is `str`).
-- **The schema is versioned.** `SCHEMA_VERSION`
-  (`runner/src/curie_runner/otel.py::SCHEMA_VERSION`) is `v1`, stamped on the resource as
-  `schema.version`, and bumps only when a key is removed, renamed, or retyped; a new
-  optional key is additive. `runner/schema/otel-attributes.schema.json` is the committed
-  mirror, and `runner/tests/test_otel_schema_drift.py` fails CI when the mirror, the enum,
-  the declared types, or a real run's emitted attributes disagree.
-- `build_tracer_provider` (`runner/src/curie_runner/otel.py::build_tracer_provider`) takes
-  `(otel, session_id, sandbox_id=None)` and returns `None` when `otel.endpoint` is unset
-  (so offline runs neither export nor fail). Otherwise the `TracerProvider`'s `Resource`
-  carries `service.name` (`curie-runner`), `curie.session_id`, `schema.version`, and
-  `curie.sandbox_id` when that value is non-empty.
-- **A fail-closed validator runs ahead of the exporter.** The provider registers
-  `_SchemaValidatingSpanProcessor`
-  (`runner/src/curie_runner/otel.py::_SchemaValidatingSpanProcessor`) first, then
-  `SimpleSpanProcessor(OTLPSpanExporter())`. On each span ending the validator strips any
-  attribute whose key falls outside the closed set, or whose value (or any element of a
-  sequence value) still matches a redaction pattern after the `redact.py` scrub. It drops
-  the offending attribute, never the span, so the exporter only ever sees schema-legal
-  attributes.
-- Endpoint/headers come from the standard `OTEL_EXPORTER_OTLP_*` env vars, read by the
-  opentelemetry SDK itself because the exporter is constructed argument-free;
-  `SessionConfig.otel` is the typed view of the same vars.
+- **Four emitters, one bootstrap.** The API, dispatcher, worker, and runner configure
+  `curie-api`, `curie-dispatcher`, `curie-worker`, and `curie-runner` runtimes
+  respectively. Each runtime owns explicit trace and log providers; it does not install a
+  process-global provider or replace stderr logging.
+- **Standard environment, including an honest off switch.** Signal-specific
+  `OTEL_EXPORTER_OTLP_TRACES_*` / `OTEL_EXPORTER_OTLP_LOGS_*` values override the generic
+  `OTEL_EXPORTER_OTLP_*` endpoint, protocol, and headers. HTTP/protobuf and gRPC are both
+  accepted on the service-to-collector hop. When neither signal has an endpoint (or
+  `OTEL_SDK_DISABLED=true`), `configure` returns a true no-op runtime: no provider,
+  exporter, queue, handler, or network attempt is created.
+- **Resources identify processes; spans identify turns.** `service_resource`
+  (`packages/telemetry/src/curie_telemetry/bootstrap.py::service_resource`) emits only
+  process facts such as `service.name`, namespace, version, instance id,
+  `deployment.environment.name`, and `schema.version`. Agent, session, user, and sandbox
+  identity is attached only after the worker resolves the binding, then carried on the
+  relevant worker and runner spans. A process resource never freezes one turn's identity
+  onto later turns.
+- **The vocabulary and privacy boundary are closed per service.** The shared schema in
+  `attributes.py` (`packages/telemetry/src/curie_telemetry/attributes.py`) partitions
+  allowed attributes and event names by emitter. `SchemaValidatingSpanProcessor`
+  (`packages/telemetry/src/curie_telemetry/attributes.py::SchemaValidatingSpanProcessor`)
+  drops unknown, mistyped, or recursively leaking attributes and unlisted events before
+  export. `SchemaValidatingLogRecordProcessor`
+  (`packages/telemetry/src/curie_telemetry/attributes.py::SchemaValidatingLogRecordProcessor`)
+  applies the same closed/redacted policy to logs. Prompts, tool content, secrets, and
+  transport identifiers are not telemetry attributes.
+- **Export is bounded and lifecycle-owned.** Both signals use bounded batch queues and
+  export timeouts. `TelemetryRuntime.force_flush`
+  (`packages/telemetry/src/curie_telemetry/bootstrap.py::TelemetryRuntime.force_flush`)
+  and `TelemetryRuntime.shutdown`
+  (`packages/telemetry/src/curie_telemetry/bootstrap.py::TelemetryRuntime.shutdown`)
+  share a hard two-second ceiling and detach only the handlers that runtime installed.
+- **Trace Context crosses transports, not domain models.** Dispatcher and API producer
+  spans inject only a W3C `traceparent`/optional `tracestate` carrier into Valkey Stream
+  metadata beside the unchanged `QueuedTurn` payload. The worker consumer extracts it,
+  and `RunnerClient._request`
+  (`apps/worker/src/curie_worker/runner_client.py::RunnerClient._request`) injects the
+  current context into the worker-to-runner HTTP headers. Missing metadata deliberately
+  starts a valid worker root; malformed metadata is ignored with a value-free warning and
+  a `trace_context.invalid` event rather than rejecting the turn.
+- **The causal tree is observable at its real ownership boundaries.** A dispatcher or API
+  `send curie:runs` producer parents the worker's `process curie:runs` consumer. Worker
+  routing, sandbox claim/start/stop, and the runner HTTP client are descendants; the
+  runner accepts that HTTP parent and opens its `agent.run` server span. Reply completion
+  and broker settlement remain events on the worker side. Static, value-free lifecycle
+  records emitted while those spans are current become trace/span-correlated OTLP logs;
+  stderr diagnostics remain available independently.
+- **The runner keeps its established GenAI subtree.** `SpanAttributeKey`
+  (`runner/src/curie_runner/otel.py::SpanAttributeKey`) and
+  `SPAN_ATTRIBUTE_VALUE_TYPES`
+  (`runner/src/curie_runner/otel.py::SPAN_ATTRIBUTE_VALUE_TYPES`) mirror the shared plus
+  runner-owned key set for the ADR-0076 drift gate. `RunTracer.run_span`
+  (`runner/src/curie_runner/otel.py::RunTracer.run_span`) opens `agent.run` and
+  `llm.generation`; model, token-usage, approval-decision, and `execute_tool` children
+  retain their existing semantics.
 - `RunTracer.run_span` (`runner/src/curie_runner/otel.py::RunTracer.run_span`) takes
   `(trace_name, model, session_id=None, user_id=None, approval_decision=None)`, opens the
   root `agent.run` (`SpanKind.SERVER`) and a child `llm.generation` span. It always stamps
@@ -82,14 +105,11 @@ attribute schema, not an open bag of `gen_ai.*` keys:
 
 ## Implementations today
 
-One: Langfuse, reached through the OTel Collector (which authenticates and forwards,
-since Langfuse OTLP ingest is HTTP-only). The runner does not know it is Langfuse — it
-only knows OTLP. The runner is also the only span producer: neither the API nor the
-worker builds a tracer, and the chart hands `OTEL_EXPORTER_OTLP_ENDPOINT` only to the
-sandbox pod (`charts/curie/templates/agent-sandbox.yaml`). The read side (trace list, tree
-reconstruction) is a separate concern in the API — Langfuse's query model spans several
-API modules plus routers, not one isolated module — and is out of scope for this
-write-side seam, though it is not attribute-blind (see leakage below).
+One backend: Langfuse, reached through the OTel Collector (which authenticates and
+forwards because Langfuse OTLP ingest is HTTP-only). Four services emit into that wire,
+but none knows which backend sits behind it. This foundation adds no query model,
+installable backend, agent-discovery surface, token/cost semantics, or console log-tail
+backend. The existing API Langfuse proxy and UI read path remain separate and unchanged.
 
 ## Known leakage
 

--- a/docs/interfaces/telemetry-otel/INTERFACE.md
+++ b/docs/interfaces/telemetry-otel/INTERFACE.md
@@ -66,7 +66,7 @@ contract is:
   (`packages/telemetry/src/curie_telemetry/bootstrap.py::TelemetryRuntime.shutdown`)
   share a hard two-second ceiling and detach only the handlers that runtime installed.
 - **Trace Context crosses transports, not domain models.** Dispatcher and API producer
-  spans inject only a W3C `traceparent`/optional `tracestate` carrier into Valkey Stream
+  spans inject only a W3C `traceparent` carrier into Valkey Stream
   metadata beside the unchanged `QueuedTurn` payload. The worker consumer extracts it,
   and `RunnerClient._request`
   (`apps/worker/src/curie_worker/runner_client.py::RunnerClient._request`) injects the

--- a/otel/collector-config.yaml
+++ b/otel/collector-config.yaml
@@ -35,3 +35,10 @@ service:
       receivers: [otlp]
       processors: [batch]
       exporters: [otlphttp/langfuse, debug]
+    # Logs are accepted and batched for correlation with the trace stream. The
+    # stock stack deliberately has no retained log backend yet (#1765), so the
+    # debug exporter preserves diagnostics without claiming query/storage.
+    logs:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [debug]

--- a/packages/telemetry/pyproject.toml
+++ b/packages/telemetry/pyproject.toml
@@ -1,0 +1,17 @@
+[project]
+name = "curie-telemetry"
+version = "0.0.0"
+description = "Closed, redacted OpenTelemetry foundations for Curie services"
+requires-python = ">=3.13"
+dependencies = [
+    "opentelemetry-sdk>=1.44.0,<1.45.0",
+    "opentelemetry-exporter-otlp-proto-http>=1.44.0,<1.45.0",
+    "opentelemetry-exporter-otlp-proto-grpc>=1.44.0,<1.45.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/curie_telemetry"]

--- a/packages/telemetry/src/curie_telemetry/__init__.py
+++ b/packages/telemetry/src/curie_telemetry/__init__.py
@@ -1,0 +1,50 @@
+"""Shared OpenTelemetry bootstrap, privacy policy, and propagation for Curie."""
+
+from .attributes import (
+    SCHEMA_VERSION,
+    attribute_types_for,
+    event_names_for,
+    sanitize_attributes,
+    set_turn_identity,
+)
+from .bootstrap import TelemetryRuntime, configure
+from .carrier import (
+    TRACE_CONTEXT_FIELD,
+    extract_http_trace_context,
+    extract_trace_context,
+    inject_trace_context,
+    inject_trace_headers,
+)
+from .redact import (
+    REDACTION_BOUNDARIES,
+    REDACTION_RULES,
+    RedactingLogFilter,
+    RedactionRule,
+    install_logging_redaction,
+    redact_span_attribute,
+    redact_text,
+    redact_value,
+)
+
+__all__ = [
+    "REDACTION_BOUNDARIES",
+    "REDACTION_RULES",
+    "SCHEMA_VERSION",
+    "TRACE_CONTEXT_FIELD",
+    "RedactingLogFilter",
+    "RedactionRule",
+    "TelemetryRuntime",
+    "attribute_types_for",
+    "configure",
+    "event_names_for",
+    "extract_http_trace_context",
+    "extract_trace_context",
+    "inject_trace_context",
+    "inject_trace_headers",
+    "install_logging_redaction",
+    "redact_span_attribute",
+    "redact_text",
+    "redact_value",
+    "sanitize_attributes",
+    "set_turn_identity",
+]

--- a/packages/telemetry/src/curie_telemetry/__init__.py
+++ b/packages/telemetry/src/curie_telemetry/__init__.py
@@ -4,6 +4,7 @@ from .attributes import (
     SCHEMA_VERSION,
     attribute_types_for,
     event_names_for,
+    log_event_names_for,
     sanitize_attributes,
     set_turn_identity,
 )
@@ -15,6 +16,7 @@ from .carrier import (
     inject_trace_context,
     inject_trace_headers,
 )
+from .logs import emit_log_event
 from .redact import (
     REDACTION_BOUNDARIES,
     REDACTION_RULES,
@@ -37,11 +39,13 @@ __all__ = [
     "attribute_types_for",
     "configure",
     "event_names_for",
+    "emit_log_event",
     "extract_http_trace_context",
     "extract_trace_context",
     "inject_trace_context",
     "inject_trace_headers",
     "install_logging_redaction",
+    "log_event_names_for",
     "redact_span_attribute",
     "redact_text",
     "redact_value",

--- a/packages/telemetry/src/curie_telemetry/attributes.py
+++ b/packages/telemetry/src/curie_telemetry/attributes.py
@@ -64,6 +64,7 @@ _SERVICES: dict[str, dict[str, str]] = {
         **_MESSAGING,
         **_ERROR,
         "curie.sandbox.outcome": "str",
+        "curie.queue.wait_ms": "int",
         "curie.turn.outcome": "str",
     },
     "curie-runner": {
@@ -89,8 +90,6 @@ _EVENTS: dict[str, frozenset[str]] = {
     ),
     "curie-dispatcher": frozenset(
         {
-            "dispatcher.agent_lookup.resolved",
-            "dispatcher.agent_lookup.unavailable",
             "dispatcher.dedupe.checked",
             "dispatcher.dedupe.skip",
             "dispatcher.placeholder.posted",
@@ -108,7 +107,10 @@ _EVENTS: dict[str, frozenset[str]] = {
             "worker.dedupe.skip",
             "worker.lock.acquired",
             "worker.lock.wait",
+            "worker.queue.wait",
             "worker.reply.final",
+            "worker.retry.scheduled",
+            "worker.retry.stopped",
             "worker.route.finish_race",
             "worker.route.start",
             "worker.route.steer",
@@ -116,6 +118,19 @@ _EVENTS: dict[str, frozenset[str]] = {
         }
     ),
     "curie-runner": frozenset(),
+}
+
+_LOG_EVENTS: dict[str, frozenset[str]] = {
+    "curie-api": frozenset({"http.server.completed", "http.server.failed"}),
+    "curie-dispatcher": frozenset({"dispatcher.turn.enqueued"}),
+    "curie-worker": frozenset(
+        {
+            "worker.trace_context.invalid",
+            "worker.turn.completed",
+            "worker.turn.failed",
+        }
+    ),
+    "curie-runner": frozenset({"agent.run.completed", "agent.run.failed"}),
 }
 
 _EXACT_TYPES: dict[str, type[object]] = {
@@ -163,6 +178,13 @@ def event_names_for(service_name: str) -> frozenset[str]:
 
     _require_service(service_name)
     return _EVENTS[service_name]
+
+
+def log_event_names_for(service_name: str) -> frozenset[str]:
+    """Return the exact value-free application log vocabulary for a service."""
+
+    _require_service(service_name)
+    return _LOG_EVENTS[service_name]
 
 
 def sanitize_attributes(
@@ -257,7 +279,7 @@ class SchemaValidatingSpanProcessor(SpanProcessor):
 
 
 class SchemaValidatingLogRecordProcessor(LogRecordProcessor):
-    """Redact bodies and close log attributes before the batch exporter."""
+    """Redact bodies and enforce value-free records before batch export."""
 
     def __init__(self, service_name: str) -> None:
         _require_service(service_name)
@@ -268,9 +290,15 @@ class SchemaValidatingLogRecordProcessor(LogRecordProcessor):
         record.body = cast(Any, redact_value(record.body))
         raw = record.attributes
         if isinstance(raw, BoundedAttributes):
-            _sanitize_bounded_attributes(self._service_name, raw)
+            was_immutable = raw._immutable  # noqa: SLF001
+            raw._immutable = False  # noqa: SLF001
+            try:
+                for key in list(raw.keys()):
+                    del raw[key]
+            finally:
+                raw._immutable = was_immutable  # noqa: SLF001
         else:
-            record.attributes = sanitize_attributes(self._service_name, raw)
+            record.attributes = {}
 
     def shutdown(self) -> None:
         return

--- a/packages/telemetry/src/curie_telemetry/attributes.py
+++ b/packages/telemetry/src/curie_telemetry/attributes.py
@@ -1,0 +1,280 @@
+"""Closed per-service OTEL attribute and event vocabulary."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, cast
+
+from opentelemetry.attributes import BoundedAttributes
+from opentelemetry.context import Context
+from opentelemetry.sdk._logs import LogRecordProcessor, ReadWriteLogRecord
+from opentelemetry.sdk.trace import Event, ReadableSpan, Span, SpanProcessor
+from opentelemetry.trace import Status
+from opentelemetry.util.types import AttributeValue
+
+from .redact import redact_value, still_leaks
+
+SCHEMA_VERSION = "v1"
+
+_SHARED: dict[str, str] = {
+    "curie.sandbox_id": "str",
+    "curie.session_id": "str",
+    "deployment.environment.name": "str",
+    "langfuse.session.id": "str",
+    "langfuse.trace.name": "str",
+    "langfuse.user.id": "str",
+    "schema.version": "str",
+    "service.instance.id": "str",
+    "service.name": "str",
+    "service.namespace": "str",
+    "service.version": "str",
+}
+
+_MESSAGING: dict[str, str] = {
+    "messaging.destination.name": "str",
+    "messaging.operation.type": "str",
+    "messaging.system": "str",
+}
+
+_HTTP: dict[str, str] = {
+    "http.request.method": "str",
+    "http.response.status_code": "int",
+    "server.address": "str",
+    "server.port": "int",
+}
+
+_ERROR: dict[str, str] = {
+    "error.type": "str",
+    "exception.escaped": "bool",
+    "exception.type": "str",
+}
+
+_SERVICES: dict[str, dict[str, str]] = {
+    "curie-api": {
+        **_HTTP,
+        **_MESSAGING,
+        **_ERROR,
+    },
+    "curie-dispatcher": {
+        **_MESSAGING,
+        **_ERROR,
+    },
+    "curie-worker": {
+        **_HTTP,
+        **_MESSAGING,
+        **_ERROR,
+        "curie.sandbox.outcome": "str",
+        "curie.turn.outcome": "str",
+    },
+    "curie-runner": {
+        **_ERROR,
+        "gen_ai.approval.decision": "str",
+        "gen_ai.operation.name": "str",
+        "gen_ai.request.model": "str",
+        "gen_ai.tool.name": "str",
+        "gen_ai.usage.cache_creation_input_tokens": "int",
+        "gen_ai.usage.cache_read_input_tokens": "int",
+        "gen_ai.usage.input_tokens": "int",
+        "gen_ai.usage.output_tokens": "int",
+        "model": "str",
+    },
+}
+
+_EVENTS: dict[str, frozenset[str]] = {
+    "curie-api": frozenset(
+        {
+            "messaging.enqueued",
+            "trace_context.invalid",
+        }
+    ),
+    "curie-dispatcher": frozenset(
+        {
+            "dispatcher.agent_lookup.resolved",
+            "dispatcher.agent_lookup.unavailable",
+            "dispatcher.dedupe.checked",
+            "dispatcher.dedupe.skip",
+            "dispatcher.placeholder.posted",
+            "messaging.enqueued",
+        }
+    ),
+    "curie-worker": frozenset(
+        {
+            "messaging.ack",
+            "messaging.dead_letter",
+            "messaging.pending",
+            "trace_context.invalid",
+            "worker.completion.settled",
+            "worker.dedupe.checked",
+            "worker.dedupe.skip",
+            "worker.lock.acquired",
+            "worker.lock.wait",
+            "worker.reply.final",
+            "worker.route.finish_race",
+            "worker.route.start",
+            "worker.route.steer",
+            "worker.terminal",
+        }
+    ),
+    "curie-runner": frozenset(),
+}
+
+_EXACT_TYPES: dict[str, type[object]] = {
+    "str": str,
+    "int": int,
+    "bool": bool,
+}
+
+
+def _require_service(service_name: str) -> None:
+    if service_name not in _SERVICES:
+        expected = ", ".join(sorted(_SERVICES))
+        raise ValueError(
+            f"unsupported telemetry service {service_name!r}; expected one of {expected}"
+        )
+
+
+def shared_attribute_types() -> dict[str, str]:
+    """Return a copy of the platform-wide safe attribute partition."""
+
+    return dict(_SHARED)
+
+
+def service_attribute_types() -> dict[str, dict[str, str]]:
+    """Return copies of every service-owned attribute partition."""
+
+    return {service: dict(values) for service, values in _SERVICES.items()}
+
+
+def service_event_names() -> dict[str, frozenset[str]]:
+    """Return copies of the service-owned event vocabularies."""
+
+    return {service: frozenset(values) for service, values in _EVENTS.items()}
+
+
+def attribute_types_for(service_name: str) -> dict[str, str]:
+    """Return only ``shared`` plus the named service's closed partition."""
+
+    _require_service(service_name)
+    return {**_SHARED, **_SERVICES[service_name]}
+
+
+def event_names_for(service_name: str) -> frozenset[str]:
+    """Return the exact event vocabulary exported by one service."""
+
+    _require_service(service_name)
+    return _EVENTS[service_name]
+
+
+def sanitize_attributes(
+    service_name: str, attributes: Mapping[str, object] | None
+) -> dict[str, AttributeValue]:
+    """Drop unknown, wrong-type, or recursively leaking attributes."""
+
+    if not attributes:
+        return {}
+    declared = attribute_types_for(service_name)
+    sanitized: dict[str, AttributeValue] = {}
+    for key, value in attributes.items():
+        expected_name = declared.get(key)
+        if expected_name is None or still_leaks(value):
+            continue
+        expected_type = _EXACT_TYPES[expected_name]
+        if type(value) is not expected_type:
+            continue
+        sanitized[key] = cast(AttributeValue, redact_value(value))
+    return sanitized
+
+
+def set_turn_identity(
+    span: Any,
+    *,
+    agent_id: object,
+    conversation_id: str,
+    user_id: str | None = None,
+) -> str:
+    """Stamp the exact incumbent Langfuse name/session/user identity."""
+
+    session_id = f"agent-{agent_id}-thread-{conversation_id}"
+    span.set_attribute("langfuse.trace.name", f"curie-run:{session_id}")
+    span.set_attribute("langfuse.session.id", session_id)
+    if user_id:
+        span.set_attribute("langfuse.user.id", user_id)
+    return session_id
+
+
+def _sanitize_bounded_attributes(
+    service_name: str, attributes: BoundedAttributes
+) -> None:
+    clean = sanitize_attributes(service_name, dict(attributes))
+    was_immutable = attributes._immutable  # noqa: SLF001
+    attributes._immutable = False  # noqa: SLF001
+    try:
+        for key in list(attributes.keys()):
+            del attributes[key]
+        for key, value in clean.items():
+            attributes[key] = value
+    finally:
+        attributes._immutable = was_immutable  # noqa: SLF001
+
+
+class SchemaValidatingSpanProcessor(SpanProcessor):
+    """Export-time privacy backstop for spans and their event vocabulary."""
+
+    def __init__(self, service_name: str) -> None:
+        _require_service(service_name)
+        self._service_name = service_name
+        self._events = event_names_for(service_name)
+
+    def on_start(
+        self, span: Span, parent_context: Context | None = None
+    ) -> None:
+        del span, parent_context
+
+    def on_end(self, span: ReadableSpan) -> None:
+        raw = span._attributes  # noqa: SLF001
+        if isinstance(raw, BoundedAttributes):
+            _sanitize_bounded_attributes(self._service_name, raw)
+
+        kept: list[Event] = []
+        for event in span.events:
+            if event.name not in self._events:
+                continue
+            attributes = sanitize_attributes(self._service_name, event.attributes)
+            kept.append(Event(event.name, attributes=attributes, timestamp=event.timestamp))
+        span._events = tuple(kept)  # noqa: SLF001
+
+        # SDK-generated status descriptions include exception messages. The
+        # status code and closed ``error.type`` retain the useful classification.
+        if span.status.description is not None:
+            span._status = Status(span.status.status_code)  # noqa: SLF001
+
+    def shutdown(self) -> None:
+        return
+
+    def force_flush(self, timeout_millis: int = 30_000) -> bool:
+        del timeout_millis
+        return True
+
+
+class SchemaValidatingLogRecordProcessor(LogRecordProcessor):
+    """Redact bodies and close log attributes before the batch exporter."""
+
+    def __init__(self, service_name: str) -> None:
+        _require_service(service_name)
+        self._service_name = service_name
+
+    def on_emit(self, log_record: ReadWriteLogRecord) -> None:
+        record = log_record.log_record
+        record.body = cast(Any, redact_value(record.body))
+        raw = record.attributes
+        if isinstance(raw, BoundedAttributes):
+            _sanitize_bounded_attributes(self._service_name, raw)
+        else:
+            record.attributes = sanitize_attributes(self._service_name, raw)
+
+    def shutdown(self) -> None:
+        return
+
+    def force_flush(self, timeout_millis: int = 30_000) -> bool:
+        del timeout_millis
+        return True

--- a/packages/telemetry/src/curie_telemetry/bootstrap.py
+++ b/packages/telemetry/src/curie_telemetry/bootstrap.py
@@ -25,6 +25,7 @@ from .attributes import (
     SchemaValidatingSpanProcessor,
     attribute_types_for,
 )
+from .logs import CuratedLogEventFilter
 from .redact import RedactingLogFilter, install_logging_redaction
 
 _MAX_QUEUE_SIZE = 2048
@@ -164,18 +165,6 @@ def _logger_provider(
     return provider
 
 
-class _ServiceLogFilter(logging.Filter):
-    def __init__(self, service_name: str) -> None:
-        super().__init__()
-        self._prefixes = (
-            service_name,
-            service_name.replace("-", "_"),
-        )
-
-    def filter(self, record: logging.LogRecord) -> bool:
-        return record.name.startswith(self._prefixes)
-
-
 def _bounded_calls(
     calls: tuple[Callable[[], object], ...], timeout_millis: int
 ) -> bool:
@@ -248,13 +237,13 @@ class TelemetryRuntime:
             if self._shutdown_started:
                 return
             if not any(
+                isinstance(item, CuratedLogEventFilter) for item in handler.filters
+            ):
+                handler.addFilter(CuratedLogEventFilter(self.service_name))
+            if not any(
                 isinstance(item, RedactingLogFilter) for item in handler.filters
             ):
                 handler.addFilter(RedactingLogFilter())
-            if not any(
-                isinstance(item, _ServiceLogFilter) for item in handler.filters
-            ):
-                handler.addFilter(_ServiceLogFilter(self.service_name))
             if (
                 default_level is not None
                 and logger.level == logging.NOTSET

--- a/packages/telemetry/src/curie_telemetry/bootstrap.py
+++ b/packages/telemetry/src/curie_telemetry/bootstrap.py
@@ -1,0 +1,359 @@
+"""Bounded, explicit OTEL trace and log bootstrap for one Curie service."""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+import uuid
+from collections.abc import Callable
+from typing import Any, Protocol, cast
+from urllib.parse import unquote
+
+from opentelemetry import trace
+from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
+from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.trace import Tracer
+
+from .attributes import (
+    SCHEMA_VERSION,
+    SchemaValidatingLogRecordProcessor,
+    SchemaValidatingSpanProcessor,
+    attribute_types_for,
+)
+from .redact import RedactingLogFilter, install_logging_redaction
+
+_MAX_QUEUE_SIZE = 2048
+_MAX_EXPORT_BATCH_SIZE = 256
+_SCHEDULE_DELAY_MILLIS = 250
+_EXPORT_TIMEOUT_MILLIS = 750
+_MAX_SHUTDOWN_MILLIS = 2000
+
+_INSTANCE_LOCK = threading.Lock()
+_INSTANCE_PID = 0
+_INSTANCE_ID = ""
+
+
+class _ProviderInspectableTracer(Protocol):
+    _tracer_provider: TracerProvider
+
+
+def _service_instance_id() -> str:
+    global _INSTANCE_ID, _INSTANCE_PID
+    pid = os.getpid()
+    with _INSTANCE_LOCK:
+        if _INSTANCE_PID != pid or not _INSTANCE_ID:
+            _INSTANCE_PID = pid
+            _INSTANCE_ID = str(uuid.uuid4())
+        return _INSTANCE_ID
+
+
+def _deployment_environment() -> str | None:
+    raw = os.getenv("OTEL_RESOURCE_ATTRIBUTES", "")
+    for item in raw.split(","):
+        try:
+            key, value = item.split("=", 1)
+        except ValueError:
+            continue
+        if key.strip() == "deployment.environment.name":
+            resolved = unquote(value.strip())
+            return resolved or None
+    return None
+
+
+def service_resource(service_name: str, service_version: str) -> Resource:
+    """Build the closed process resource shared by every Curie emitter."""
+
+    attributes: dict[str, str] = {
+        "schema.version": SCHEMA_VERSION,
+        "service.instance.id": _service_instance_id(),
+        "service.name": service_name,
+        "service.namespace": "curie",
+        "service.version": service_version,
+    }
+    environment = _deployment_environment()
+    if environment:
+        attributes["deployment.environment.name"] = environment
+    return Resource(attributes)
+
+
+def _disabled() -> bool:
+    return os.getenv("OTEL_SDK_DISABLED", "").strip().lower() == "true"
+
+
+def _endpoint(signal: str) -> str:
+    specific_name = f"OTEL_EXPORTER_OTLP_{signal.upper()}_ENDPOINT"
+    if specific_name in os.environ:
+        return os.environ[specific_name].strip()
+    return os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "").strip()
+
+
+def _protocol(signal: str) -> str:
+    specific = os.getenv(f"OTEL_EXPORTER_OTLP_{signal.upper()}_PROTOCOL", "").strip()
+    generic = os.getenv("OTEL_EXPORTER_OTLP_PROTOCOL", "").strip()
+    return specific or generic or "http/protobuf"
+
+
+def _trace_exporter(protocol: str) -> Any:
+    if protocol == "grpc":
+        from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
+            OTLPSpanExporter as GrpcOTLPSpanExporter,
+        )
+
+        return GrpcOTLPSpanExporter()
+    from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
+        OTLPSpanExporter as HttpOTLPSpanExporter,
+    )
+
+    return HttpOTLPSpanExporter()
+
+
+def _log_exporter(protocol: str) -> Any:
+    if protocol == "grpc":
+        from opentelemetry.exporter.otlp.proto.grpc._log_exporter import (
+            OTLPLogExporter as GrpcOTLPLogExporter,
+        )
+
+        return GrpcOTLPLogExporter()
+    from opentelemetry.exporter.otlp.proto.http._log_exporter import (
+        OTLPLogExporter as HttpOTLPLogExporter,
+    )
+
+    return HttpOTLPLogExporter()
+
+
+def _tracer_provider(
+    service_name: str, resource: Resource
+) -> TracerProvider | None:
+    if not _endpoint("traces"):
+        return None
+    provider = TracerProvider(resource=resource, shutdown_on_exit=False)
+    provider.add_span_processor(SchemaValidatingSpanProcessor(service_name))
+    provider.add_span_processor(
+        BatchSpanProcessor(
+            _trace_exporter(_protocol("traces")),
+            max_queue_size=_MAX_QUEUE_SIZE,
+            schedule_delay_millis=_SCHEDULE_DELAY_MILLIS,
+            max_export_batch_size=_MAX_EXPORT_BATCH_SIZE,
+            export_timeout_millis=_EXPORT_TIMEOUT_MILLIS,
+        )
+    )
+    return provider
+
+
+def _logger_provider(
+    service_name: str, resource: Resource
+) -> LoggerProvider | None:
+    if not _endpoint("logs"):
+        return None
+    provider = LoggerProvider(resource=resource, shutdown_on_exit=False)
+    provider.add_log_record_processor(SchemaValidatingLogRecordProcessor(service_name))
+    provider.add_log_record_processor(
+        BatchLogRecordProcessor(
+            _log_exporter(_protocol("logs")),
+            max_queue_size=_MAX_QUEUE_SIZE,
+            schedule_delay_millis=_SCHEDULE_DELAY_MILLIS,
+            max_export_batch_size=_MAX_EXPORT_BATCH_SIZE,
+            export_timeout_millis=_EXPORT_TIMEOUT_MILLIS,
+        )
+    )
+    return provider
+
+
+class _ServiceLogFilter(logging.Filter):
+    def __init__(self, service_name: str) -> None:
+        super().__init__()
+        self._prefixes = (
+            service_name,
+            service_name.replace("-", "_"),
+        )
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        return record.name.startswith(self._prefixes)
+
+
+def _bounded_calls(
+    calls: tuple[Callable[[], object], ...], timeout_millis: int
+) -> bool:
+    if not calls:
+        return True
+    deadline = time.monotonic() + max(timeout_millis, 0) / 1000
+    outcomes: list[object | BaseException | None] = [None] * len(calls)
+
+    def invoke(index: int, call: Callable[[], object]) -> None:
+        try:
+            outcomes[index] = call()
+        except BaseException as exc:  # provider teardown must remain fail open
+            outcomes[index] = exc
+
+    threads = [
+        threading.Thread(target=invoke, args=(index, call), daemon=True)
+        for index, call in enumerate(calls)
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=max(0.0, deadline - time.monotonic()))
+    if any(thread.is_alive() for thread in threads):
+        return False
+    return all(not isinstance(result, BaseException) and result is not False for result in outcomes)
+
+
+class TelemetryRuntime:
+    """One service's explicit tracer/log providers and bounded lifecycle."""
+
+    def __init__(
+        self,
+        *,
+        service_name: str,
+        tracer: Tracer,
+        tracer_provider: TracerProvider | None,
+        logger_provider: LoggerProvider | None,
+        log_handler: LoggingHandler | None,
+    ) -> None:
+        self.service_name = service_name
+        self.tracer = tracer
+        self.log_handler = log_handler
+        self._tracer_provider = tracer_provider
+        self._logger_provider = logger_provider
+        self._attached: list[logging.Logger] = []
+        self._level_overrides: dict[logging.Logger, tuple[int, int]] = {}
+        self._lock = threading.Lock()
+        self._shutdown_started = False
+
+    def attach_logging(
+        self,
+        logger: logging.Logger,
+        *,
+        default_level: int | None = None,
+    ) -> None:
+        """Keep diagnostics and attach the scoped OTEL handler once.
+
+        ``default_level`` only replaces an inherited, stricter threshold. An
+        operator's explicit logger level always wins, and any temporary default
+        is restored at shutdown. This lets service lifecycle records remain
+        observable in an embedding that never configured root logging without
+        weakening an intentional service-specific threshold.
+        """
+
+        install_logging_redaction(logger)
+        handler = self.log_handler
+        if handler is None:
+            return
+        with self._lock:
+            if self._shutdown_started:
+                return
+            if not any(
+                isinstance(item, RedactingLogFilter) for item in handler.filters
+            ):
+                handler.addFilter(RedactingLogFilter())
+            if not any(
+                isinstance(item, _ServiceLogFilter) for item in handler.filters
+            ):
+                handler.addFilter(_ServiceLogFilter(self.service_name))
+            if (
+                default_level is not None
+                and logger.level == logging.NOTSET
+                and logger.getEffectiveLevel() > default_level
+            ):
+                self._level_overrides[logger] = (logger.level, default_level)
+                logger.setLevel(default_level)
+            if handler not in logger.handlers:
+                logger.addHandler(handler)
+            if logger not in self._attached:
+                self._attached.append(logger)
+
+    def force_flush(self, *, timeout_millis: int = _MAX_SHUTDOWN_MILLIS) -> bool:
+        """Flush both signal queues within one aggregate hard deadline."""
+
+        with self._lock:
+            if self._shutdown_started:
+                return True
+        bounded = min(max(timeout_millis, 0), _MAX_SHUTDOWN_MILLIS)
+        calls: list[Callable[[], object]] = []
+        tracer_provider = self._tracer_provider
+        if tracer_provider is not None:
+            calls.append(lambda: tracer_provider.force_flush(bounded))
+        logger_provider = self._logger_provider
+        if logger_provider is not None:
+            calls.append(lambda: logger_provider.force_flush(bounded))
+        return _bounded_calls(tuple(calls), bounded)
+
+    def shutdown(self, *, timeout_millis: int = _MAX_SHUTDOWN_MILLIS) -> bool:
+        """Flush and close both providers once, never past two seconds total."""
+
+        with self._lock:
+            if self._shutdown_started:
+                return True
+            self._shutdown_started = True
+            attached = tuple(self._attached)
+            self._attached.clear()
+            level_overrides = dict(self._level_overrides)
+            self._level_overrides.clear()
+        if self.log_handler is not None:
+            for logger in attached:
+                if self.log_handler in logger.handlers:
+                    logger.removeHandler(self.log_handler)
+        for logger, (original, applied) in level_overrides.items():
+            # Do not overwrite a level an embedding deliberately changed after
+            # attachment; only undo the exact temporary default we installed.
+            if logger.level == applied:
+                logger.setLevel(original)
+
+        bounded = min(max(timeout_millis, 0), _MAX_SHUTDOWN_MILLIS)
+        calls: list[Callable[[], object]] = []
+        if self._tracer_provider is not None:
+            calls.append(self._tracer_provider.shutdown)
+        if self._logger_provider is not None:
+            calls.append(self._logger_provider.shutdown)
+        return _bounded_calls(tuple(calls), bounded)
+
+
+def configure(*, service_name: str, service_version: str) -> TelemetryRuntime:
+    """Build explicit trace/log providers, or a true no-endpoint no-op."""
+
+    # Validate the caller even in no-op mode. A typo must not silently switch a
+    # service onto another partition when an endpoint is later configured.
+    attribute_types_for(service_name)
+    disabled = _disabled()
+    traces_enabled = bool(_endpoint("traces")) and not disabled
+    logs_enabled = bool(_endpoint("logs")) and not disabled
+    if not traces_enabled and not logs_enabled:
+        tracer = trace.NoOpTracerProvider().get_tracer(service_name, service_version)
+        return TelemetryRuntime(
+            service_name=service_name,
+            tracer=tracer,
+            tracer_provider=None,
+            logger_provider=None,
+            log_handler=None,
+        )
+
+    resource = service_resource(service_name, service_version)
+    tracer_provider = _tracer_provider(service_name, resource) if traces_enabled else None
+    logger_provider = _logger_provider(service_name, resource) if logs_enabled else None
+    tracer = (
+        tracer_provider.get_tracer(service_name, service_version)
+        if tracer_provider is not None
+        else trace.NoOpTracerProvider().get_tracer(service_name, service_version)
+    )
+    if tracer_provider is not None:
+        # SDK 1.44 no longer retains the owning provider on the returned tracer.
+        # Keep it reachable for bounded-runtime inspection without installing a
+        # process-global provider; TelemetryRuntime still owns its lifecycle.
+        cast(_ProviderInspectableTracer, tracer)._tracer_provider = tracer_provider
+    handler = (
+        LoggingHandler(level=logging.NOTSET, logger_provider=logger_provider)
+        if logger_provider is not None
+        else None
+    )
+    return TelemetryRuntime(
+        service_name=service_name,
+        tracer=tracer,
+        tracer_provider=tracer_provider,
+        logger_provider=logger_provider,
+        log_handler=handler,
+    )

--- a/packages/telemetry/src/curie_telemetry/carrier.py
+++ b/packages/telemetry/src/curie_telemetry/carrier.py
@@ -1,0 +1,182 @@
+"""Bounded W3C trace-context propagation for Stream metadata and HTTP."""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from collections.abc import Mapping, MutableMapping
+
+from opentelemetry import trace
+from opentelemetry.context import Context
+from opentelemetry.propagators.textmap import CarrierT
+from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
+
+TRACE_CONTEXT_FIELD = "trace_context"
+
+_ALLOWED_KEYS = frozenset({"traceparent", "tracestate"})
+_MAX_CARRIER_BYTES = 4096
+_MAX_INJECTED_CARRIER_BYTES = 512
+_PROPAGATOR = TraceContextTextMapPropagator()
+_TRACEPARENT_RE = re.compile(
+    r"^00-([0-9a-f]{32})-([0-9a-f]{16})-([0-9a-f]{2})$"
+)
+_TRACESTATE_SIMPLE_KEY_RE = re.compile(r"^[a-z0-9][_0-9a-z\-*/]{0,255}$")
+_TRACESTATE_MULTI_KEY_RE = re.compile(
+    r"^[a-z0-9][_0-9a-z\-*/]{0,240}@[a-z][_0-9a-z\-*/]{0,13}$"
+)
+
+
+def _warn(logger: logging.Logger | None) -> None:
+    (logger or logging.getLogger(__name__)).warning("ignored malformed trace context")
+
+
+def _valid_traceparent(value: str) -> bool:
+    match = _TRACEPARENT_RE.fullmatch(value)
+    return bool(
+        match
+        and match.group(1) != "0" * 32
+        and match.group(2) != "0" * 16
+    )
+
+
+def _valid_tracestate(value: str) -> bool:
+    """Validate W3C tracestate before the SDK can diagnose its raw value."""
+
+    if not value or len(value) > 512:
+        return False
+    members = [member.strip(" \t") for member in value.split(",")]
+    if len(members) > 32 or any(not member for member in members):
+        return False
+    seen: set[str] = set()
+    for member in members:
+        if "=" not in member:
+            return False
+        key, member_value = member.split("=", 1)
+        if not (
+            _TRACESTATE_SIMPLE_KEY_RE.fullmatch(key)
+            or _TRACESTATE_MULTI_KEY_RE.fullmatch(key)
+        ):
+            return False
+        if key in seen:
+            return False
+        seen.add(key)
+        if (
+            not member_value
+            or len(member_value) > 256
+            or member_value.endswith(" ")
+            or any(
+                char in ",=" or ord(char) < 0x20 or ord(char) > 0x7E
+                for char in member_value
+            )
+        ):
+            return False
+    return True
+
+
+def _valid_carrier(carrier: Mapping[str, str]) -> bool:
+    traceparent = carrier.get("traceparent")
+    tracestate = carrier.get("tracestate")
+    return bool(
+        traceparent is not None
+        and _valid_traceparent(traceparent)
+        and (tracestate is None or _valid_tracestate(tracestate))
+    )
+
+
+def inject_trace_headers(
+    headers: MutableMapping[str, str] | None = None,
+    *,
+    context: Context | None = None,
+) -> dict[str, str]:
+    """Inject only W3C trace headers, returning a plain string dictionary."""
+
+    carrier: dict[str, str] = {}
+    _PROPAGATOR.inject(carrier, context=context)
+    bounded = {
+        key: value
+        for key, value in carrier.items()
+        if key in _ALLOWED_KEYS and isinstance(value, str)
+    }
+    if headers is not None:
+        headers.update(bounded)
+        return dict(headers)
+    return bounded
+
+
+def inject_trace_context(context: Context | None = None) -> str | None:
+    """Serialize the valid current W3C carrier for a Stream field, if any."""
+
+    carrier = inject_trace_headers(context=context)
+    if "traceparent" not in carrier:
+        return None
+    encoded = json.dumps(carrier, separators=(",", ":"), sort_keys=True)
+    if len(encoded.encode("utf-8")) > _MAX_INJECTED_CARRIER_BYTES:
+        return None
+    return encoded
+
+
+def _extract(carrier: CarrierT, logger: logging.Logger | None) -> Context:
+    if not isinstance(carrier, Mapping) or not _valid_carrier(carrier):
+        _warn(logger)
+        return Context()
+    context = _PROPAGATOR.extract(carrier)
+    span_context = trace.get_current_span(context).get_span_context()
+    if not span_context.is_valid or not span_context.is_remote:
+        _warn(logger)
+        return Context()
+    return context
+
+
+def extract_trace_context(
+    raw: str | None, *, logger: logging.Logger | None = None
+) -> Context:
+    """Decode Stream trace metadata, failing open without exposing its value."""
+
+    if raw is None or raw == "":
+        return Context()
+    if len(raw.encode("utf-8", errors="replace")) > _MAX_CARRIER_BYTES:
+        _warn(logger)
+        return Context()
+    try:
+        decoded = json.loads(raw)
+    except (TypeError, ValueError):
+        _warn(logger)
+        return Context()
+    if (
+        not isinstance(decoded, dict)
+        or not decoded
+        or not set(decoded) <= _ALLOWED_KEYS
+        or "traceparent" not in decoded
+        or any(not isinstance(value, str) for value in decoded.values())
+    ):
+        _warn(logger)
+        return Context()
+    carrier = {str(key): str(value) for key, value in decoded.items()}
+    return _extract(carrier, logger)
+
+
+def extract_http_trace_context(
+    headers: Mapping[str, str], *, logger: logging.Logger | None = None
+) -> Context:
+    """Extract only traceparent/tracestate from HTTP headers."""
+
+    carrier: dict[str, str] = {}
+    saw_trace_header = False
+    for raw_key, raw_value in headers.items():
+        key = str(raw_key).lower()
+        if key not in _ALLOWED_KEYS:
+            continue
+        saw_trace_header = True
+        if not isinstance(raw_value, str) or not raw_value:
+            _warn(logger)
+            return Context()
+        carrier[key] = raw_value
+    if not carrier:
+        if saw_trace_header:
+            _warn(logger)
+        return Context()
+    if len(json.dumps(carrier, separators=(",", ":")).encode()) > _MAX_CARRIER_BYTES:
+        _warn(logger)
+        return Context()
+    return _extract(carrier, logger)

--- a/packages/telemetry/src/curie_telemetry/carrier.py
+++ b/packages/telemetry/src/curie_telemetry/carrier.py
@@ -14,16 +14,12 @@ from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapProp
 
 TRACE_CONTEXT_FIELD = "trace_context"
 
-_ALLOWED_KEYS = frozenset({"traceparent", "tracestate"})
+_ALLOWED_KEYS = frozenset({"traceparent"})
 _MAX_CARRIER_BYTES = 4096
 _MAX_INJECTED_CARRIER_BYTES = 512
 _PROPAGATOR = TraceContextTextMapPropagator()
 _TRACEPARENT_RE = re.compile(
     r"^00-([0-9a-f]{32})-([0-9a-f]{16})-([0-9a-f]{2})$"
-)
-_TRACESTATE_SIMPLE_KEY_RE = re.compile(r"^[a-z0-9][_0-9a-z\-*/]{0,255}$")
-_TRACESTATE_MULTI_KEY_RE = re.compile(
-    r"^[a-z0-9][_0-9a-z\-*/]{0,240}@[a-z][_0-9a-z\-*/]{0,13}$"
 )
 
 
@@ -40,48 +36,9 @@ def _valid_traceparent(value: str) -> bool:
     )
 
 
-def _valid_tracestate(value: str) -> bool:
-    """Validate W3C tracestate before the SDK can diagnose its raw value."""
-
-    if not value or len(value) > 512:
-        return False
-    members = [member.strip(" \t") for member in value.split(",")]
-    if len(members) > 32 or any(not member for member in members):
-        return False
-    seen: set[str] = set()
-    for member in members:
-        if "=" not in member:
-            return False
-        key, member_value = member.split("=", 1)
-        if not (
-            _TRACESTATE_SIMPLE_KEY_RE.fullmatch(key)
-            or _TRACESTATE_MULTI_KEY_RE.fullmatch(key)
-        ):
-            return False
-        if key in seen:
-            return False
-        seen.add(key)
-        if (
-            not member_value
-            or len(member_value) > 256
-            or member_value.endswith(" ")
-            or any(
-                char in ",=" or ord(char) < 0x20 or ord(char) > 0x7E
-                for char in member_value
-            )
-        ):
-            return False
-    return True
-
-
 def _valid_carrier(carrier: Mapping[str, str]) -> bool:
     traceparent = carrier.get("traceparent")
-    tracestate = carrier.get("tracestate")
-    return bool(
-        traceparent is not None
-        and _valid_traceparent(traceparent)
-        and (tracestate is None or _valid_tracestate(tracestate))
-    )
+    return bool(traceparent is not None and _valid_traceparent(traceparent))
 
 
 def inject_trace_headers(
@@ -89,7 +46,7 @@ def inject_trace_headers(
     *,
     context: Context | None = None,
 ) -> dict[str, str]:
-    """Inject only W3C trace headers, returning a plain string dictionary."""
+    """Inject only W3C traceparent, returning a plain string dictionary."""
 
     carrier: dict[str, str] = {}
     _PROPAGATOR.inject(carrier, context=context)
@@ -159,7 +116,7 @@ def extract_trace_context(
 def extract_http_trace_context(
     headers: Mapping[str, str], *, logger: logging.Logger | None = None
 ) -> Context:
-    """Extract only traceparent/tracestate from HTTP headers."""
+    """Extract only traceparent from HTTP headers."""
 
     carrier: dict[str, str] = {}
     saw_trace_header = False

--- a/packages/telemetry/src/curie_telemetry/logs.py
+++ b/packages/telemetry/src/curie_telemetry/logs.py
@@ -1,0 +1,89 @@
+"""Closed, value-free application events for correlated OTEL logs."""
+
+from __future__ import annotations
+
+import logging
+
+from .attributes import log_event_names_for
+
+_EVENT_MARKER = "_curie_otel_application_event"
+_SERVICE_MARKER = "_curie_otel_service"
+_SERVICE_ROOTS = {
+    "curie-api": "curie_api",
+    "curie-dispatcher": "curie_dispatcher",
+    "curie-worker": "curie_worker",
+    "curie-runner": "curie_runner",
+}
+_STANDARD_RECORD_FIELDS = frozenset(
+    vars(
+        logging.LogRecord(
+            name="",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="",
+            args=(),
+            exc_info=None,
+        )
+    )
+) | {"asctime", "message"}
+
+
+def _logger_service(logger_name: str) -> str | None:
+    normalized = logger_name.replace("-", "_")
+    for service_name, root in _SERVICE_ROOTS.items():
+        if normalized == root or normalized.startswith(f"{root}."):
+            return service_name
+    return None
+
+
+def emit_log_event(
+    logger: logging.Logger,
+    event: str,
+    *,
+    level: int = logging.INFO,
+) -> None:
+    """Emit one audited, value-free event through the existing logger path.
+
+    The event body is the entire record: callers cannot attach arbitrary
+    messages, arguments, exceptions, or attributes. Normal diagnostics keep
+    flowing to stderr, but the OTEL handler accepts only records created here.
+    """
+
+    service_name = _logger_service(logger.name)
+    if service_name is None or event not in log_event_names_for(service_name):
+        raise ValueError(f"unsupported telemetry log event {event!r}")
+    logger.log(
+        level,
+        event,
+        extra={
+            _EVENT_MARKER: event,
+            _SERVICE_MARKER: service_name,
+        },
+    )
+
+
+class CuratedLogEventFilter(logging.Filter):
+    """Admit only marked events in this handler's closed service vocabulary."""
+
+    def __init__(self, service_name: str) -> None:
+        super().__init__()
+        self._service_name = service_name
+        self._events = log_event_names_for(service_name)
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        event = getattr(record, _EVENT_MARKER, None)
+        extras = set(vars(record)) - _STANDARD_RECORD_FIELDS - {
+            _EVENT_MARKER,
+            _SERVICE_MARKER,
+        }
+        return bool(
+            getattr(record, _SERVICE_MARKER, None) == self._service_name
+            and isinstance(event, str)
+            and event in self._events
+            and record.msg == event
+            and not record.args
+            and record.exc_info is None
+            and record.stack_info is None
+            and not extras
+        )

--- a/packages/telemetry/src/curie_telemetry/redact.py
+++ b/packages/telemetry/src/curie_telemetry/redact.py
@@ -1,0 +1,187 @@
+"""Secret redaction shared by console, log, and span export boundaries."""
+
+from __future__ import annotations
+
+import logging
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class RedactionRule:
+    """One secret class and its stable replacement marker."""
+
+    name: str
+    pattern: re.Pattern[str]
+    placeholder: str
+
+
+def _placeholder(name: str) -> str:
+    return f"[REDACTED:{name}]"
+
+
+# Registry order is load bearing. More specific URL and JWT cases run before
+# their generic bearer/assignment siblings so every match has one stable class.
+REDACTION_RULES: tuple[RedactionRule, ...] = (
+    RedactionRule(
+        "pem_private_key",
+        re.compile(
+            r"-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----"
+        ),
+        _placeholder("pem_private_key"),
+    ),
+    RedactionRule(
+        "url_secret_param",
+        re.compile(
+            r"[?&](?:token|secret|password|passwd|pwd|api_key|apikey|access_token|key|sig"
+            r"|signature)=[^&\s]+",
+            re.IGNORECASE,
+        ),
+        _placeholder("url_secret_param"),
+    ),
+    RedactionRule(
+        "jwt",
+        re.compile(r"\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+"),
+        _placeholder("jwt"),
+    ),
+    RedactionRule(
+        "bearer_token",
+        re.compile(r"\bBearer\s+[A-Za-z0-9._~+/=-]+"),
+        _placeholder("bearer_token"),
+    ),
+    RedactionRule(
+        "api_key",
+        re.compile(r"\b(?:sk|xai)[-_][A-Za-z0-9_-]{16,}"),
+        _placeholder("api_key"),
+    ),
+    RedactionRule(
+        "aws_access_key_id",
+        re.compile(r"\b(?:AKIA|ASIA)[A-Z0-9]{16,}"),
+        _placeholder("aws_access_key_id"),
+    ),
+    RedactionRule(
+        "github_pat",
+        re.compile(r"\b(?:github_pat_[A-Za-z0-9_]{20,}|gh[pousr]_[A-Za-z0-9]{20,})"),
+        _placeholder("github_pat"),
+    ),
+    RedactionRule(
+        "gitlab_token",
+        re.compile(r"\bglpat-[A-Za-z0-9_-]{16,}"),
+        _placeholder("gitlab_token"),
+    ),
+    RedactionRule(
+        "slack_token",
+        re.compile(r"\bxox[baps]-[A-Za-z0-9-]{10,}"),
+        _placeholder("slack_token"),
+    ),
+    RedactionRule(
+        "google_api_key",
+        re.compile(r"\bAIza[A-Za-z0-9_-]{30,}"),
+        _placeholder("google_api_key"),
+    ),
+    RedactionRule(
+        "secret_assignment",
+        re.compile(
+            r"\b(?:secret|password|passwd|pwd|api_key|apikey|access_token|token)=\S+",
+            re.IGNORECASE,
+        ),
+        _placeholder("secret_assignment"),
+    ),
+    RedactionRule(
+        "home_path",
+        re.compile(r"/(?:home|Users)/[^/\s]+"),
+        _placeholder("home_path"),
+    ),
+)
+
+REDACTION_BOUNDARIES: tuple[str, ...] = (
+    "stderr",
+    "otel_log",
+    "otel_span",
+)
+
+
+def redact_text(text: str) -> str:
+    """Apply every registered rule to one string."""
+
+    for rule in REDACTION_RULES:
+        text = rule.pattern.sub(rule.placeholder, text)
+    return text
+
+
+def redact_value(value: object) -> object:
+    """Recursively scrub strings while preserving container and scalar types."""
+
+    if isinstance(value, str):
+        return redact_text(value)
+    if isinstance(value, list):
+        return [redact_value(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(redact_value(item) for item in value)
+    if isinstance(value, Mapping):
+        return {key: redact_value(item) for key, item in value.items()}
+    return value
+
+
+# Compatibility name retained for runner call sites while redaction moves into
+# the shared package.
+redact_span_attribute = redact_value
+
+
+def still_leaks(value: object) -> bool:
+    """Return true when any nested string still matches a secret rule."""
+
+    if isinstance(value, str):
+        return redact_text(value) != value
+    if isinstance(value, Mapping):
+        return any(still_leaks(key) or still_leaks(item) for key, item in value.items())
+    if isinstance(value, (list, tuple)):
+        return any(still_leaks(item) for item in value)
+    return False
+
+
+class RedactingLogFilter(logging.Filter):
+    """Scrub a record after args-style formatting and before any handler emits."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        message = record.getMessage()
+        redacted = redact_text(message)
+        if redacted != message:
+            record.msg = redacted
+            record.args = ()
+        if record.exc_info:
+            rendered = logging.Formatter().formatException(record.exc_info)
+            record.exc_text = redact_text(rendered)
+        if record.stack_info:
+            record.stack_info = redact_text(record.stack_info)
+        # Extra attributes can be translated independently by the OTEL handler.
+        for name, value in tuple(vars(record).items()):
+            scrubbed = redact_value(value)
+            if scrubbed != value:
+                setattr(record, name, scrubbed)
+        return True
+
+
+def _ensure_filter(handler: logging.Handler) -> None:
+    if not any(isinstance(item, RedactingLogFilter) for item in handler.filters):
+        handler.addFilter(RedactingLogFilter())
+
+
+def install_logging_redaction(logger: logging.Logger) -> None:
+    """Install redaction on this logger's effective console path, idempotently."""
+
+    current: logging.Logger | None = logger
+    while current is not None:
+        for handler in current.handlers:
+            _ensure_filter(handler)
+        if not current.propagate:
+            break
+        current = current.parent
+
+
+def redact_mapping(values: Mapping[str, Any]) -> dict[str, object]:
+    """Typed convenience for callers sanitizing arbitrary attribute maps."""
+
+    return {key: redact_value(value) for key, value in values.items()}

--- a/packages/telemetry/tests/conftest.py
+++ b/packages/telemetry/tests/conftest.py
@@ -1,0 +1,107 @@
+"""Local OTLP HTTP capture used by the shared telemetry contract tests."""
+
+from __future__ import annotations
+
+import gzip
+import threading
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import pytest
+from opentelemetry.proto.collector.logs.v1.logs_service_pb2 import (
+    ExportLogsServiceRequest,
+)
+from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (
+    ExportTraceServiceRequest,
+)
+
+
+@dataclass
+class OtlpHttpCapture:
+    """Decoded OTLP requests received by one loopback HTTP server."""
+
+    server: ThreadingHTTPServer
+    traces: list[ExportTraceServiceRequest] = field(default_factory=list)
+    logs: list[ExportLogsServiceRequest] = field(default_factory=list)
+    _lock: threading.Lock = field(default_factory=threading.Lock)
+
+    @property
+    def endpoint(self) -> str:
+        host, port = self.server.server_address
+        return f"http://{host}:{port}"
+
+    def append(self, path: str, body: bytes) -> None:
+        with self._lock:
+            if path == "/v1/traces":
+                request = ExportTraceServiceRequest()
+                request.ParseFromString(body)
+                self.traces.append(request)
+            elif path == "/v1/logs":
+                request = ExportLogsServiceRequest()
+                request.ParseFromString(body)
+                self.logs.append(request)
+            else:
+                raise AssertionError(f"unexpected OTLP path {path!r}")
+
+
+def _handler(capture_ref: list[OtlpHttpCapture]) -> type[BaseHTTPRequestHandler]:
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self) -> None:  # noqa: N802
+            length = int(self.headers.get("content-length", "0"))
+            body = self.rfile.read(length)
+            if self.headers.get("content-encoding") == "gzip":
+                body = gzip.decompress(body)
+            capture_ref[0].append(self.path, body)
+            self.send_response(200)
+            self.end_headers()
+
+        def log_message(self, _format: str, *_args: object) -> None:
+            return
+
+    return Handler
+
+
+@pytest.fixture
+def otlp_http_capture() -> Iterator[OtlpHttpCapture]:
+    capture_ref: list[OtlpHttpCapture] = []
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _handler(capture_ref))
+    server.daemon_threads = True
+    capture = OtlpHttpCapture(server)
+    capture_ref.append(capture)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield capture
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+_OTEL_ENV = (
+    "OTEL_SDK_DISABLED",
+    "OTEL_SERVICE_NAME",
+    "OTEL_RESOURCE_ATTRIBUTES",
+    "OTEL_EXPORTER_OTLP_ENDPOINT",
+    "OTEL_EXPORTER_OTLP_PROTOCOL",
+    "OTEL_EXPORTER_OTLP_HEADERS",
+    "OTEL_EXPORTER_OTLP_TIMEOUT",
+    "OTEL_EXPORTER_OTLP_COMPRESSION",
+    "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+    "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL",
+    "OTEL_EXPORTER_OTLP_TRACES_HEADERS",
+    "OTEL_EXPORTER_OTLP_TRACES_TIMEOUT",
+    "OTEL_EXPORTER_OTLP_TRACES_COMPRESSION",
+    "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT",
+    "OTEL_EXPORTER_OTLP_LOGS_PROTOCOL",
+    "OTEL_EXPORTER_OTLP_LOGS_HEADERS",
+    "OTEL_EXPORTER_OTLP_LOGS_TIMEOUT",
+    "OTEL_EXPORTER_OTLP_LOGS_COMPRESSION",
+)
+
+
+@pytest.fixture(autouse=True)
+def clean_otel_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in _OTEL_ENV:
+        monkeypatch.delenv(name, raising=False)

--- a/packages/telemetry/tests/test_attributes.py
+++ b/packages/telemetry/tests/test_attributes.py
@@ -1,0 +1,174 @@
+"""The one committed schema remains closed independently for each service."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from curie_telemetry.attributes import (
+    SchemaValidatingSpanProcessor,
+    attribute_types_for,
+    event_names_for,
+    sanitize_attributes,
+)
+from opentelemetry.attributes import BoundedAttributes
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+SCHEMA_PATH = Path(__file__).resolve().parents[3] / "runner/schema/otel-attributes.schema.json"
+SERVICES = ("curie-api", "curie-dispatcher", "curie-worker", "curie-runner")
+FAKE_API_KEY = "sk-" + "FAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKE0000"
+WORKER_EVENTS = frozenset(
+    {
+        "trace_context.invalid",
+        "messaging.ack",
+        "messaging.pending",
+        "messaging.dead_letter",
+        "worker.dedupe.checked",
+        "worker.dedupe.skip",
+        "worker.lock.wait",
+        "worker.lock.acquired",
+        "worker.route.start",
+        "worker.route.steer",
+        "worker.route.finish_race",
+        "worker.reply.final",
+        "worker.completion.settled",
+        "worker.terminal",
+    }
+)
+
+
+def _schema() -> dict[str, object]:
+    return json.loads(SCHEMA_PATH.read_text())
+
+
+def test_committed_artifact_has_shared_and_per_service_partitions() -> None:
+    schema = _schema()
+    assert schema["schema_version"] == "v1"
+    assert isinstance(schema["shared"], dict)
+    services = schema["services"]
+    assert isinstance(services, dict)
+    assert set(services) == set(SERVICES)
+    events = schema["events"]
+    assert isinstance(events, dict)
+    assert set(events) == set(SERVICES)
+
+    runner = {**schema["shared"], **services["curie-runner"]}
+    assert {
+        "gen_ai.request.model",
+        "gen_ai.usage.input_tokens",
+        "langfuse.trace.name",
+        "langfuse.session.id",
+        "langfuse.user.id",
+        "curie.session_id",
+        "curie.sandbox_id",
+    } <= set(runner)
+    assert "http.request.method" in attribute_types_for("curie-api")
+    assert "messaging.system" in attribute_types_for("curie-dispatcher")
+    assert attribute_types_for("curie-worker")["curie.turn.outcome"] == "str"
+    assert attribute_types_for("curie-worker")["curie.sandbox.outcome"] == "str"
+    assert set(runner.values()) <= {"str", "int", "bool"}
+
+
+def test_worker_event_vocabulary_is_closed_in_the_same_service_artifact() -> None:
+    assert WORKER_EVENTS <= event_names_for("curie-worker")
+    assert "worker.terminal" not in event_names_for("curie-api")
+
+
+def test_service_allowlist_is_shared_plus_its_partition_only() -> None:
+    schema = _schema()
+    services = schema["services"]
+    assert isinstance(services, dict)
+    shared = schema["shared"]
+    assert isinstance(shared, dict)
+
+    for service_name in SERVICES:
+        expected = {**shared, **services[service_name]}
+        assert attribute_types_for(service_name) == expected
+
+
+def test_sanitizer_rejects_another_services_valid_key_and_unknown_keys() -> None:
+    api_types = attribute_types_for("curie-api")
+    runner_types = attribute_types_for("curie-runner")
+    runner_only = next(key for key in runner_types if key not in api_types)
+    safe_api_key = next(key for key, value_type in api_types.items() if value_type == "str")
+
+    sanitized = sanitize_attributes(
+        "curie-api",
+        {
+            safe_api_key: "safe",
+            runner_only: "otherwise valid",
+            "unknown.attribute": "must not export",
+        },
+    )
+
+    assert sanitized[safe_api_key] == "safe"
+    assert runner_only not in sanitized
+    assert "unknown.attribute" not in sanitized
+
+
+def test_declared_types_are_exact_so_bool_never_passes_as_int() -> None:
+    schema = _schema()
+    services = schema["services"]
+    assert isinstance(services, dict)
+    bool_case = next(
+        (service, key)
+        for service, keys in services.items()
+        for key, value_type in keys.items()
+        if value_type == "bool"
+    )
+    service, key = bool_case
+
+    assert sanitize_attributes(service, {key: True}) == {key: True}
+    assert sanitize_attributes(service, {key: 1}) == {}
+
+    int_case = next(
+        (candidate, attr)
+        for candidate in SERVICES
+        for attr, value_type in attribute_types_for(candidate).items()
+        if value_type == "int"
+    )
+    int_service, int_key = int_case
+    assert sanitize_attributes(int_service, {int_key: 7}) == {int_key: 7}
+    assert sanitize_attributes(int_service, {int_key: True}) == {}
+
+
+def test_sanitizer_drops_recursively_leaking_values_instead_of_exporting_them() -> None:
+    key = next(
+        key
+        for key, value_type in attribute_types_for("curie-runner").items()
+        if value_type == "str"
+    )
+    assert sanitize_attributes("curie-runner", {key: FAKE_API_KEY}) == {}
+    assert sanitize_attributes("curie-runner", {key: ["safe", FAKE_API_KEY]}) == {}
+
+
+def test_export_processor_strips_bypasses_before_the_exporter_sees_them() -> None:
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SchemaValidatingSpanProcessor("curie-api"))
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    tracer = provider.get_tracer("schema-backstop")
+
+    with tracer.start_as_current_span("GET /health") as span:
+        span.set_attribute("http.request.method", "GET")
+        span.set_attribute("gen_ai.request.model", "runner-only")
+        span.set_attribute("unknown.attribute", "not closed")
+        span.set_attribute("error.type", FAKE_API_KEY)
+
+    (finished,) = exporter.get_finished_spans()
+    assert finished.attributes["http.request.method"] == "GET"
+    assert "gen_ai.request.model" not in finished.attributes
+    assert "unknown.attribute" not in finished.attributes
+    assert FAKE_API_KEY not in repr(dict(finished.attributes or {}))
+    provider.shutdown()
+
+
+def test_sdk_private_attribute_surface_is_compatible_with_export_mutation() -> None:
+    attributes = BoundedAttributes(attributes={"http.request.method": "GET"})
+    assert hasattr(attributes, "_immutable"), (
+        "OpenTelemetry BoundedAttributes no longer exposes _immutable; the "
+        "export backstop must be adapted before the SDK bound changes"
+    )
+    assert hasattr(attributes, "__delitem__")

--- a/packages/telemetry/tests/test_attributes.py
+++ b/packages/telemetry/tests/test_attributes.py
@@ -9,6 +9,7 @@ from curie_telemetry.attributes import (
     SchemaValidatingSpanProcessor,
     attribute_types_for,
     event_names_for,
+    log_event_names_for,
     sanitize_attributes,
 )
 from opentelemetry.attributes import BoundedAttributes
@@ -29,6 +30,9 @@ WORKER_EVENTS = frozenset(
         "worker.dedupe.skip",
         "worker.lock.wait",
         "worker.lock.acquired",
+        "worker.queue.wait",
+        "worker.retry.scheduled",
+        "worker.retry.stopped",
         "worker.route.start",
         "worker.route.steer",
         "worker.route.finish_race",
@@ -53,6 +57,12 @@ def test_committed_artifact_has_shared_and_per_service_partitions() -> None:
     events = schema["events"]
     assert isinstance(events, dict)
     assert set(events) == set(SERVICES)
+    log_events = schema["log_events"]
+    assert isinstance(log_events, dict)
+    assert set(log_events) == set(SERVICES)
+    assert {
+        service: sorted(event_names_for(service)) for service in SERVICES
+    } == events
 
     runner = {**schema["shared"], **services["curie-runner"]}
     assert {
@@ -74,6 +84,33 @@ def test_committed_artifact_has_shared_and_per_service_partitions() -> None:
 def test_worker_event_vocabulary_is_closed_in_the_same_service_artifact() -> None:
     assert WORKER_EVENTS <= event_names_for("curie-worker")
     assert "worker.terminal" not in event_names_for("curie-api")
+
+
+def test_application_log_vocabulary_and_worker_queue_wait_type_are_closed() -> None:
+    assert log_event_names_for("curie-api") == frozenset(
+        {"http.server.completed", "http.server.failed"}
+    )
+    assert log_event_names_for("curie-runner") == frozenset(
+        {"agent.run.completed", "agent.run.failed"}
+    )
+    assert log_event_names_for("curie-dispatcher") == frozenset(
+        {"dispatcher.turn.enqueued"}
+    )
+    assert {
+        "worker.trace_context.invalid",
+        "worker.turn.completed",
+        "worker.turn.failed",
+    } <= log_event_names_for("curie-worker")
+    assert "worker.turn.completed" not in log_event_names_for("curie-api")
+    assert attribute_types_for("curie-worker")["curie.queue.wait_ms"] == "int"
+    assert sanitize_attributes("curie-worker", {"curie.queue.wait_ms": 17}) == {
+        "curie.queue.wait_ms": 17
+    }
+    assert sanitize_attributes("curie-worker", {"curie.queue.wait_ms": True}) == {}
+    schema = _schema()
+    assert {
+        service: sorted(log_event_names_for(service)) for service in SERVICES
+    } == schema["log_events"]
 
 
 def test_service_allowlist_is_shared_plus_its_partition_only() -> None:

--- a/packages/telemetry/tests/test_bootstrap.py
+++ b/packages/telemetry/tests/test_bootstrap.py
@@ -8,7 +8,7 @@ import time
 from typing import Any
 
 import pytest
-from curie_telemetry import TelemetryRuntime, configure
+from curie_telemetry import TelemetryRuntime, configure, emit_log_event
 from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
@@ -127,7 +127,7 @@ def test_signal_specific_endpoint_gates_are_independent(
     logs_only.shutdown(timeout_millis=1000)
 
 
-def test_configured_runtime_preserves_console_logs_and_exports_correlated_records(
+def test_configured_runtime_preserves_console_logs_and_exports_only_curated_records(
     monkeypatch: pytest.MonkeyPatch, otlp_http_capture: OtlpHttpCapture
 ) -> None:
     monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", otlp_http_capture.endpoint)
@@ -161,6 +161,7 @@ def test_configured_runtime_preserves_console_logs_and_exports_correlated_record
             span.set_attribute("error.type", FAKE_API_KEY)
             span_context = span.get_span_context()
             logger.info("request completed credential=%s", FAKE_API_KEY)
+            emit_log_event(logger, "http.server.completed")
 
         assert runtime.force_flush(timeout_millis=1000) is True
     finally:
@@ -203,7 +204,53 @@ def test_configured_runtime_preserves_console_logs_and_exports_correlated_record
     assert exported_log.trace_id == span_context.trace_id.to_bytes(16, "big")
     assert exported_log.span_id == span_context.span_id.to_bytes(8, "big")
     assert FAKE_API_KEY not in repr(exported_log)
-    assert "[REDACTED:" in str(_any_value(exported_log.body))
+    assert _any_value(exported_log.body) == "http.server.completed"
+
+
+def test_unmarked_arbitrary_diagnostics_never_reach_otel_but_remain_on_stderr(
+    monkeypatch: pytest.MonkeyPatch, otlp_http_capture: OtlpHttpCapture
+) -> None:
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", otlp_http_capture.endpoint)
+    runtime = configure(service_name="curie-api", service_version="1.2.3")
+    logger = logging.getLogger("curie_api.arbitrary_diagnostics")
+    stderr = io.StringIO()
+    console = logging.StreamHandler(stderr)
+    prior_handlers = list(logger.handlers)
+    prior_level = logger.level
+    prior_propagate = logger.propagate
+    logger.handlers = [console]
+    logger.setLevel(logging.INFO)
+    logger.propagate = False
+    try:
+        runtime.attach_logging(logger)
+        with runtime.tracer.start_as_current_span("GET /health"):
+            arbitrary_prompt = "prompt fragment: compare the quarterly strategy"
+            logger.info(arbitrary_prompt)
+            logger.warning(
+                "model output: the forecast changed",
+                extra={"curie.session_id": "arbitrary-tool-session"},
+            )
+            try:
+                raise RuntimeError("tool exception: calendar lookup failed")
+            except RuntimeError:
+                logger.exception("tool execution failed")
+            with pytest.raises(ValueError, match="unsupported telemetry log event"):
+                emit_log_event(logger, arbitrary_prompt)
+            emit_log_event(logger, "http.server.completed")
+        assert runtime.force_flush(timeout_millis=1000)
+    finally:
+        runtime.shutdown(timeout_millis=1000)
+        logger.handlers = prior_handlers
+        logger.setLevel(prior_level)
+        logger.propagate = prior_propagate
+
+    diagnostics = stderr.getvalue()
+    assert "prompt fragment: compare the quarterly strategy" in diagnostics
+    assert "model output: the forecast changed" in diagnostics
+    assert "tool exception: calendar lookup failed" in diagnostics
+    assert [_any_value(record.body) for _, record in _exported_logs(otlp_http_capture)] == [
+        "http.server.completed"
+    ]
 
 
 @pytest.mark.parametrize("protocol", ["http/protobuf", "grpc"])

--- a/packages/telemetry/tests/test_bootstrap.py
+++ b/packages/telemetry/tests/test_bootstrap.py
@@ -1,0 +1,278 @@
+"""Shared trace and log bootstrap honors standard OTEL behavior safely."""
+
+from __future__ import annotations
+
+import io
+import logging
+import time
+from typing import Any
+
+import pytest
+from curie_telemetry import TelemetryRuntime, configure
+from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+from .conftest import OtlpHttpCapture
+
+FAKE_API_KEY = "sk-" + "FAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKE0000"
+
+
+def _any_value(value: Any) -> object:
+    selected = value.WhichOneof("value")
+    if selected == "string_value":
+        return value.string_value
+    if selected == "bool_value":
+        return value.bool_value
+    if selected == "int_value":
+        return value.int_value
+    if selected == "double_value":
+        return value.double_value
+    if selected == "array_value":
+        return tuple(_any_value(item) for item in value.array_value.values)
+    return None
+
+
+def _attributes(items: object) -> dict[str, object]:
+    return {item.key: _any_value(item.value) for item in items}  # type: ignore[attr-defined]
+
+
+def _exported_spans(capture: OtlpHttpCapture) -> list[tuple[object, object]]:
+    out: list[tuple[object, object]] = []
+    for request in capture.traces:
+        for resource_spans in request.resource_spans:
+            for scope_spans in resource_spans.scope_spans:
+                out.extend((resource_spans.resource, span) for span in scope_spans.spans)
+    return out
+
+
+def _exported_logs(capture: OtlpHttpCapture) -> list[tuple[object, object]]:
+    out: list[tuple[object, object]] = []
+    for request in capture.logs:
+        for resource_logs in request.resource_logs:
+            for scope_logs in resource_logs.scope_logs:
+                out.extend((resource_logs.resource, record) for record in scope_logs.log_records)
+    return out
+
+
+def _span_batch(runtime: TelemetryRuntime) -> BatchSpanProcessor:
+    provider = runtime.tracer._tracer_provider  # type: ignore[attr-defined]
+    processors = provider._active_span_processor._span_processors  # noqa: SLF001
+    return next(item for item in processors if isinstance(item, BatchSpanProcessor))
+
+
+def _log_batch(runtime: TelemetryRuntime) -> BatchLogRecordProcessor:
+    assert runtime.log_handler is not None
+    provider = runtime.log_handler._logger_provider  # noqa: SLF001
+    processors = provider._multi_log_record_processor._log_record_processors  # noqa: SLF001
+    return next(item for item in processors if isinstance(item, BatchLogRecordProcessor))
+
+
+def _batch_settings(processor: object) -> dict[str, object]:
+    batch = processor._batch_processor  # type: ignore[attr-defined]  # noqa: SLF001
+    return {
+        "queue": batch._max_queue_size,  # noqa: SLF001
+        "delay": batch._schedule_delay_millis,  # noqa: SLF001
+        "batch": batch._max_export_batch_size,  # noqa: SLF001
+        "timeout": batch._export_timeout_millis,  # noqa: SLF001
+        "exporter_module": type(batch._exporter).__module__,  # noqa: SLF001
+    }
+
+
+def test_no_endpoint_is_a_true_noop_and_never_mutates_root_logging() -> None:
+    root = logging.getLogger()
+    before = tuple(root.handlers)
+    runtime = configure(service_name="curie-api", service_version="1.2.3")
+
+    with runtime.tracer.start_as_current_span("not-recorded") as span:
+        assert not span.is_recording()
+    assert runtime.log_handler is None
+    assert tuple(root.handlers) == before
+    assert runtime.force_flush(timeout_millis=10) is True
+    assert runtime.shutdown(timeout_millis=10) is True
+    assert runtime.shutdown(timeout_millis=10) is True
+
+
+def test_otel_sdk_disabled_wins_even_when_an_endpoint_is_configured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://collector.example.test:4318")
+    monkeypatch.setenv("OTEL_SDK_DISABLED", "true")
+    runtime = configure(service_name="curie-api", service_version="1.2.3")
+    with runtime.tracer.start_as_current_span("disabled") as span:
+        assert not span.is_recording()
+    assert runtime.log_handler is None
+    runtime.shutdown(timeout_millis=10)
+
+
+def test_signal_specific_endpoint_gates_are_independent(
+    monkeypatch: pytest.MonkeyPatch, otlp_http_capture: OtlpHttpCapture
+) -> None:
+    monkeypatch.setenv(
+        "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", f"{otlp_http_capture.endpoint}/v1/traces"
+    )
+    traces_only = configure(service_name="curie-api", service_version="1.2.3")
+    assert traces_only.log_handler is None
+    with traces_only.tracer.start_as_current_span("trace-only") as span:
+        assert span.is_recording()
+    traces_only.shutdown(timeout_millis=1000)
+
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT")
+    monkeypatch.setenv(
+        "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT", f"{otlp_http_capture.endpoint}/v1/logs"
+    )
+    logs_only = configure(service_name="curie-api", service_version="1.2.3")
+    assert logs_only.log_handler is not None
+    with logs_only.tracer.start_as_current_span("not-recorded") as span:
+        assert not span.is_recording()
+    logs_only.shutdown(timeout_millis=1000)
+
+
+def test_configured_runtime_preserves_console_logs_and_exports_correlated_records(
+    monkeypatch: pytest.MonkeyPatch, otlp_http_capture: OtlpHttpCapture
+) -> None:
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", otlp_http_capture.endpoint)
+    monkeypatch.setenv(
+        "OTEL_RESOURCE_ATTRIBUTES",
+        "deployment.environment.name=local,curie.session_id=must-not-be-a-resource,"
+        "host.name=private-host.example.test",
+    )
+    monkeypatch.setenv("OTEL_SERVICE_NAME", "must-not-override-caller")
+
+    runtime = configure(service_name="curie-api", service_version="1.2.3")
+    root_before = tuple(logging.getLogger().handlers)
+    stderr = io.StringIO()
+    console = logging.StreamHandler(stderr)
+    logger = logging.getLogger("curie_api.telemetry_contract")
+    prior_handlers = list(logger.handlers)
+    prior_level = logger.level
+    prior_propagate = logger.propagate
+    logger.handlers = [console]
+    logger.setLevel(logging.INFO)
+    logger.propagate = False
+    try:
+        runtime.attach_logging(logger)
+        runtime.attach_logging(logger)
+        assert logger.handlers.count(runtime.log_handler) == 1
+        assert tuple(logging.getLogger().handlers) == root_before
+
+        with runtime.tracer.start_as_current_span("GET /health") as span:
+            span.set_attribute("http.request.method", "GET")
+            span.set_attribute("http.request.header.authorization", FAKE_API_KEY)
+            span.set_attribute("error.type", FAKE_API_KEY)
+            span_context = span.get_span_context()
+            logger.info("request completed credential=%s", FAKE_API_KEY)
+
+        assert runtime.force_flush(timeout_millis=1000) is True
+    finally:
+        runtime.shutdown(timeout_millis=1000)
+        logger.handlers = prior_handlers
+        logger.setLevel(prior_level)
+        logger.propagate = prior_propagate
+
+    console_output = stderr.getvalue()
+    assert FAKE_API_KEY not in console_output
+    assert "[REDACTED:" in console_output
+
+    spans = _exported_spans(otlp_http_capture)
+    logs = _exported_logs(otlp_http_capture)
+    assert len(spans) == 1
+    assert len(logs) == 1
+    span_resource, exported_span = spans[0]
+    log_resource, exported_log = logs[0]
+
+    for resource in (span_resource, log_resource):
+        resource_attrs = _attributes(resource.attributes)
+        assert resource_attrs["service.namespace"] == "curie"
+        assert resource_attrs["service.name"] == "curie-api"
+        assert resource_attrs["service.version"] == "1.2.3"
+        assert resource_attrs["deployment.environment.name"] == "local"
+        assert isinstance(resource_attrs["service.instance.id"], str)
+        assert resource_attrs["service.instance.id"]
+        assert "curie.session_id" not in resource_attrs
+        assert "curie.sandbox_id" not in resource_attrs
+        assert "host.name" not in resource_attrs
+
+    assert _attributes(span_resource.attributes)["service.instance.id"] == _attributes(
+        log_resource.attributes
+    )["service.instance.id"]
+    span_attrs = _attributes(exported_span.attributes)
+    assert span_attrs["http.request.method"] == "GET"
+    assert "http.request.header.authorization" not in span_attrs
+    assert FAKE_API_KEY not in repr(span_attrs)
+
+    assert exported_log.trace_id == span_context.trace_id.to_bytes(16, "big")
+    assert exported_log.span_id == span_context.span_id.to_bytes(8, "big")
+    assert FAKE_API_KEY not in repr(exported_log)
+    assert "[REDACTED:" in str(_any_value(exported_log.body))
+
+
+@pytest.mark.parametrize("protocol", ["http/protobuf", "grpc"])
+def test_protocol_selection_uses_the_declared_real_exporter_dependencies(
+    protocol: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://127.0.0.1:1")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_PROTOCOL", protocol)
+    runtime = configure(service_name="curie-api", service_version="1.2.3")
+    span_module = str(_batch_settings(_span_batch(runtime))["exporter_module"])
+    log_module = str(_batch_settings(_log_batch(runtime))["exporter_module"])
+    expected = ".grpc." if protocol == "grpc" else ".http."
+    assert expected in span_module
+    assert expected in log_module
+    runtime.shutdown(timeout_millis=100)
+
+
+def test_unset_protocol_defaults_to_http_and_exporters_parse_standard_environment(
+    monkeypatch: pytest.MonkeyPatch, otlp_http_capture: OtlpHttpCapture
+) -> None:
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", otlp_http_capture.endpoint)
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_HEADERS", "x-test-header=safe")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_TIMEOUT", "0.75")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_COMPRESSION", "gzip")
+    runtime = configure(service_name="curie-api", service_version="1.2.3")
+
+    span_exporter = _span_batch(runtime)._batch_processor._exporter  # noqa: SLF001
+    log_exporter = _log_batch(runtime)._batch_processor._exporter  # noqa: SLF001
+    assert ".http." in type(span_exporter).__module__
+    assert ".http." in type(log_exporter).__module__
+    assert span_exporter._endpoint == f"{otlp_http_capture.endpoint}/v1/traces"  # noqa: SLF001
+    assert log_exporter._endpoint == f"{otlp_http_capture.endpoint}/v1/logs"  # noqa: SLF001
+    assert span_exporter._headers.get("x-test-header") == "safe"  # noqa: SLF001
+    assert log_exporter._headers.get("x-test-header") == "safe"  # noqa: SLF001
+    assert span_exporter._timeout == 0.75  # noqa: SLF001
+    assert log_exporter._timeout == 0.75  # noqa: SLF001
+    runtime.shutdown(timeout_millis=1000)
+
+
+def test_both_batch_processors_are_bounded_and_subsecond(
+    monkeypatch: pytest.MonkeyPatch, otlp_http_capture: OtlpHttpCapture
+) -> None:
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", otlp_http_capture.endpoint)
+    runtime = configure(service_name="curie-api", service_version="1.2.3")
+
+    for processor in (_span_batch(runtime), _log_batch(runtime)):
+        settings = _batch_settings(processor)
+        assert 0 < settings["queue"] <= 2048
+        assert 0 < settings["batch"] <= settings["queue"]
+        assert 0 < settings["delay"] < 1000
+        assert 0 < settings["timeout"] <= 1000
+
+    runtime.shutdown(timeout_millis=1000)
+
+
+def test_flush_and_shutdown_are_idempotent_and_honor_the_callers_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://127.0.0.1:1")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_TIMEOUT", "30")
+    runtime = configure(service_name="curie-api", service_version="1.2.3")
+    with runtime.tracer.start_as_current_span("queued-before-shutdown"):
+        pass
+
+    started = time.monotonic()
+    runtime.shutdown(timeout_millis=200)
+    elapsed = time.monotonic() - started
+    assert elapsed < 0.8
+
+    repeated = time.monotonic()
+    assert runtime.shutdown(timeout_millis=200) is True
+    assert time.monotonic() - repeated < 0.1

--- a/packages/telemetry/tests/test_bootstrap.py
+++ b/packages/telemetry/tests/test_bootstrap.py
@@ -14,7 +14,7 @@ from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
 from .conftest import OtlpHttpCapture
 
-FAKE_API_KEY = "sk-" + "FAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKE0000"
+PRIVATE_MARKER = "sk-" + "FAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKE0000"
 
 
 def _any_value(value: Any) -> object:
@@ -157,10 +157,10 @@ def test_configured_runtime_preserves_console_logs_and_exports_only_curated_reco
 
         with runtime.tracer.start_as_current_span("GET /health") as span:
             span.set_attribute("http.request.method", "GET")
-            span.set_attribute("http.request.header.authorization", FAKE_API_KEY)
-            span.set_attribute("error.type", FAKE_API_KEY)
+            span.set_attribute("http.request.header.authorization", PRIVATE_MARKER)
+            span.set_attribute("error.type", PRIVATE_MARKER)
             span_context = span.get_span_context()
-            logger.info("request completed credential=%s", FAKE_API_KEY)
+            logger.info("request completed credential=%s", PRIVATE_MARKER)
             emit_log_event(logger, "http.server.completed")
 
         assert runtime.force_flush(timeout_millis=1000) is True
@@ -171,7 +171,7 @@ def test_configured_runtime_preserves_console_logs_and_exports_only_curated_reco
         logger.propagate = prior_propagate
 
     console_output = stderr.getvalue()
-    assert FAKE_API_KEY not in console_output
+    assert PRIVATE_MARKER not in console_output
     assert "[REDACTED:" in console_output
 
     spans = _exported_spans(otlp_http_capture)
@@ -199,11 +199,11 @@ def test_configured_runtime_preserves_console_logs_and_exports_only_curated_reco
     span_attrs = _attributes(exported_span.attributes)
     assert span_attrs["http.request.method"] == "GET"
     assert "http.request.header.authorization" not in span_attrs
-    assert FAKE_API_KEY not in repr(span_attrs)
+    assert PRIVATE_MARKER not in repr(span_attrs)
 
     assert exported_log.trace_id == span_context.trace_id.to_bytes(16, "big")
     assert exported_log.span_id == span_context.span_id.to_bytes(8, "big")
-    assert FAKE_API_KEY not in repr(exported_log)
+    assert PRIVATE_MARKER not in repr(exported_log)
     assert _any_value(exported_log.body) == "http.server.completed"
 
 

--- a/packages/telemetry/tests/test_carrier.py
+++ b/packages/telemetry/tests/test_carrier.py
@@ -27,11 +27,23 @@ def test_carrier_field_is_transport_metadata_not_a_payload_key() -> None:
     assert TRACE_CONTEXT_FIELD == "trace_context"
 
 
-def test_inject_emits_only_w3c_trace_headers_and_never_baggage() -> None:
+def test_inject_emits_only_traceparent_and_never_baggage_or_tracestate() -> None:
     provider = TracerProvider()
     tracer = provider.get_tracer("carrier-test")
     baggage_context = baggage.set_baggage("prompt", "do not transport this")
-    token = attach(baggage_context)
+    remote = trace.set_span_in_context(
+        trace.NonRecordingSpan(
+            trace.SpanContext(
+                trace_id=int(TRACE_ID, 16),
+                span_id=int(PARENT_ID, 16),
+                is_remote=True,
+                trace_flags=trace.TraceFlags(trace.TraceFlags.SAMPLED),
+                trace_state=trace.TraceState((("vendor", "opaque-state"),)),
+            )
+        ),
+        baggage_context,
+    )
+    token = attach(remote)
     try:
         with tracer.start_as_current_span("producer") as span:
             raw = inject_trace_context()
@@ -42,8 +54,10 @@ def test_inject_emits_only_w3c_trace_headers_and_never_baggage() -> None:
         detach(token)
         provider.shutdown()
 
-    assert set(carrier) <= {"traceparent", "tracestate"}
+    assert set(carrier) == {"traceparent"}
     assert "baggage" not in carrier
+    assert "tracestate" not in carrier
+    assert "opaque-state" not in raw
     assert "do not transport this" not in raw
     assert carrier["traceparent"].startswith(
         f"00-{span_context.trace_id:032x}-{span_context.span_id:016x}-"
@@ -76,6 +90,12 @@ def test_missing_carrier_returns_an_empty_context_without_a_warning(
             {
                 "traceparent": f"00-{TRACE_ID}-{PARENT_ID}-01",
                 "baggage": "prompt=never",
+            }
+        ),
+        json.dumps(
+            {
+                "traceparent": f"00-{TRACE_ID}-{PARENT_ID}-01",
+                "tracestate": "vendor=opaque-state",
             }
         ),
         "x" * 4097,

--- a/packages/telemetry/tests/test_carrier.py
+++ b/packages/telemetry/tests/test_carrier.py
@@ -1,0 +1,107 @@
+"""W3C trace context transport metadata remains bounded and fail open."""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import pytest
+from curie_telemetry.carrier import (
+    TRACE_CONTEXT_FIELD,
+    extract_trace_context,
+    inject_trace_context,
+)
+from opentelemetry import baggage, trace
+from opentelemetry.context import attach, detach
+from opentelemetry.sdk.trace import TracerProvider
+
+TRACE_ID = "11111111111111111111111111111111"
+PARENT_ID = "2222222222222222"
+
+
+def _is_valid(context: object) -> bool:
+    return trace.get_current_span(context).get_span_context().is_valid  # type: ignore[arg-type]
+
+
+def test_carrier_field_is_transport_metadata_not_a_payload_key() -> None:
+    assert TRACE_CONTEXT_FIELD == "trace_context"
+
+
+def test_inject_emits_only_w3c_trace_headers_and_never_baggage() -> None:
+    provider = TracerProvider()
+    tracer = provider.get_tracer("carrier-test")
+    baggage_context = baggage.set_baggage("prompt", "do not transport this")
+    token = attach(baggage_context)
+    try:
+        with tracer.start_as_current_span("producer") as span:
+            raw = inject_trace_context()
+            assert raw is not None
+            carrier = json.loads(raw)
+            span_context = span.get_span_context()
+    finally:
+        detach(token)
+        provider.shutdown()
+
+    assert set(carrier) <= {"traceparent", "tracestate"}
+    assert "baggage" not in carrier
+    assert "do not transport this" not in raw
+    assert carrier["traceparent"].startswith(
+        f"00-{span_context.trace_id:032x}-{span_context.span_id:016x}-"
+    )
+    assert len(raw.encode()) <= 512
+
+
+def test_inject_without_a_valid_current_span_omits_the_optional_carrier() -> None:
+    assert inject_trace_context() is None
+
+
+@pytest.mark.parametrize("raw", [None, ""])
+def test_missing_carrier_returns_an_empty_context_without_a_warning(
+    raw: str | None, caplog: pytest.LogCaptureFixture
+) -> None:
+    logger = logging.getLogger("carrier-missing")
+    with caplog.at_level(logging.WARNING, logger=logger.name):
+        context = extract_trace_context(raw, logger=logger)
+    assert not _is_valid(context)
+    assert caplog.records == []
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "not-json",
+        "[]",
+        '{"traceparent":"00-bad"}',
+        json.dumps(
+            {
+                "traceparent": f"00-{TRACE_ID}-{PARENT_ID}-01",
+                "baggage": "prompt=never",
+            }
+        ),
+        "x" * 4097,
+    ],
+)
+def test_malformed_oversized_or_extra_key_carriers_are_ignored_value_free(
+    raw: str, caplog: pytest.LogCaptureFixture
+) -> None:
+    logger = logging.getLogger("carrier-malformed")
+    with caplog.at_level(logging.WARNING, logger=logger.name):
+        context = extract_trace_context(raw, logger=logger)
+
+    assert not _is_valid(context)
+    logged = " ".join(record.getMessage() for record in caplog.records)
+    assert "ignored malformed trace context" in logged
+    assert raw not in logged
+    assert TRACE_ID not in logged
+    assert "prompt=never" not in logged
+
+
+def test_valid_carrier_extracts_the_remote_parent() -> None:
+    raw = json.dumps({"traceparent": f"00-{TRACE_ID}-{PARENT_ID}-01"})
+    context = extract_trace_context(raw, logger=logging.getLogger("carrier-valid"))
+    span_context = trace.get_current_span(context).get_span_context()
+
+    assert span_context.is_valid
+    assert span_context.is_remote
+    assert f"{span_context.trace_id:032x}" == TRACE_ID
+    assert f"{span_context.span_id:016x}" == PARENT_ID

--- a/packages/telemetry/tests/test_redact.py
+++ b/packages/telemetry/tests/test_redact.py
@@ -1,0 +1,57 @@
+"""Every shared telemetry value boundary uses the same recursive scrub."""
+
+from __future__ import annotations
+
+import io
+import logging
+
+from curie_telemetry.redact import RedactingLogFilter, redact_text, redact_value
+
+FAKE_API_KEY = "sk-" + "FAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKE0000"
+FAKE_BEARER = "Bearer " + "abc0000FAKEFAKEFAKEFAKEFAKEFAKE"
+FAKE_TOOL_CONTENT = f"tool input token={FAKE_API_KEY}"
+
+
+def test_args_style_logging_is_redacted_after_formatting() -> None:
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    handler.addFilter(RedactingLogFilter())
+    logger = logging.getLogger("curie-telemetry-redact-args")
+    logger.handlers = [handler]
+    logger.propagate = False
+    logger.setLevel(logging.INFO)
+
+    logger.info("authorization=%s", FAKE_BEARER)
+
+    output = stream.getvalue()
+    assert FAKE_BEARER not in output
+    assert "[REDACTED:" in output
+
+
+def test_recursive_value_redaction_preserves_container_and_scalar_types() -> None:
+    value = {
+        "scalar": FAKE_API_KEY,
+        "list": ["safe", FAKE_TOOL_CONTENT],
+        "tuple": (FAKE_BEARER, 3, True),
+        "nested": {"prompt": FAKE_API_KEY},
+    }
+
+    scrubbed = redact_value(value)
+
+    assert isinstance(scrubbed, dict)
+    assert isinstance(scrubbed["list"], list)
+    assert isinstance(scrubbed["tuple"], tuple)
+    assert scrubbed["tuple"][1:] == (3, True)
+    rendered = repr(scrubbed)
+    assert FAKE_API_KEY not in rendered
+    assert FAKE_BEARER not in rendered
+    assert "[REDACTED:" in rendered
+
+
+def test_redaction_keeps_safe_correlation_and_exact_non_string_types() -> None:
+    safe = "trace_id=11111111111111111111111111111111 outcome=success"
+    assert redact_text(safe) == safe
+    for value in (0, 42, True, False, 1.5, None):
+        redacted = redact_value(value)
+        assert redacted == value
+        assert type(redacted) is type(value)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ requires-python = ">=3.13"
 dependencies = [
     "aci-protocol",
     "curie-channel-protocol",
+    "curie-telemetry",
     "plugin-format",
     "curie-api",
     "curie-dispatcher",
@@ -21,6 +22,7 @@ members = [
     "packages/aci-protocol",
     "packages/channel-protocol",
     "packages/plugin-format",
+    "packages/telemetry",
     "packages/test-support",
     "apps/api",
     "apps/dispatcher",
@@ -33,6 +35,7 @@ members = [
 [tool.uv.sources]
 aci-protocol = { workspace = true }
 curie-channel-protocol = { workspace = true }
+curie-telemetry = { workspace = true }
 plugin-format = { workspace = true }
 curie-test-support = { workspace = true }
 curie-api = { workspace = true }
@@ -70,6 +73,7 @@ root_packages = [
     "curie_worker",
     "curie_dispatcher",
     "curie_runner",
+    "curie_telemetry",
     # The frozen contract packages (#961). Outside the graph, no contract could
     # ever fire on them, which left the worst possible place for an SDK import
     # ungated. Clean today; the contract below keeps them that way.
@@ -87,7 +91,7 @@ include_external_packages = true
 # direction that is hardest to see in review.
 name = "The platform never imports a harness SDK"
 type = "forbidden"
-source_modules = ["curie_api", "curie_worker", "curie_dispatcher"]
+source_modules = ["curie_api", "curie_worker", "curie_dispatcher", "curie_telemetry"]
 forbidden_modules = ["claude_agent_sdk"]
 
 [[tool.importlinter.contracts]]
@@ -127,6 +131,7 @@ testpaths = [
     "packages/aci-protocol/tests",
     "packages/channel-protocol/tests",
     "packages/plugin-format/tests",
+    "packages/telemetry/tests",
     "apps/api/tests",
     "apps/dispatcher/tests",
     "apps/worker/tests",
@@ -169,6 +174,7 @@ mypy_path = [
     "packages/aci-protocol/src",
     "packages/channel-protocol/src",
     "packages/plugin-format/src",
+    "packages/telemetry/src",
     "packages/test-support/src",
     "apps/api/src",
     "apps/dispatcher/src",
@@ -181,6 +187,7 @@ files = [
     "packages/aci-protocol/src",
     "packages/channel-protocol/src",
     "packages/plugin-format/src",
+    "packages/telemetry/src",
     "packages/test-support/src",
     "apps/api/src",
     "apps/dispatcher/src",

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -44,22 +44,24 @@ RUN npm install -g @modelcontextprotocol/server-github@2025.4.8
 
 WORKDIR /app
 
-# The three source trees the runner needs: the two frozen workspace packages and
-# the runner itself. Copied by path so the image is reproducible from the lockfile
-# above them (root pyproject/uv.lock are the workspace source of truth).
+# The four source trees the runner needs: the two frozen workspace packages, the
+# platform telemetry package, and the runner itself. Copied by path so the image
+# is reproducible from the lockfile above them (root pyproject/uv.lock are the
+# workspace source of truth).
 COPY uv.lock ./uv.lock
 COPY packages/aci-protocol ./packages/aci-protocol
 COPY packages/plugin-format ./packages/plugin-format
+COPY packages/telemetry ./packages/telemetry
 COPY runner ./runner
 
 # One venv. Install every local project without dependencies, then install the
 # full registry dependency closure exported from the tested workspace uv.lock.
 # The local packages are installed by path first so the
-# "aci-protocol"/"plugin-format" requirements resolve to the copied trees, not
-# a same-named PyPI distribution.
+# "aci-protocol"/"plugin-format"/"curie-telemetry" requirements resolve to the
+# copied trees, not a same-named PyPI distribution.
 RUN python3 -m venv /app/.venv \
     && /app/.venv/bin/pip install --no-cache-dir --upgrade pip \
-    && /app/.venv/bin/pip install --no-cache-dir --no-deps ./packages/aci-protocol ./packages/plugin-format \
+    && /app/.venv/bin/pip install --no-cache-dir --no-deps ./packages/aci-protocol ./packages/plugin-format ./packages/telemetry \
     && /app/.venv/bin/pip install --no-cache-dir --no-deps ./runner \
     && python3 runner/export_dependency_pins.py < uv.lock > /tmp/runner-dependency-pins.txt \
     && /app/.venv/bin/pip install --no-cache-dir --no-deps -r /tmp/runner-dependency-pins.txt

--- a/runner/pyproject.toml
+++ b/runner/pyproject.toml
@@ -6,6 +6,7 @@ requires-python = ">=3.13"
 dependencies = [
     "aci-protocol",
     "plugin-format",
+    "curie-telemetry",
     "claude-agent-sdk>=0.2.135",
     "aiohttp>=3.14.3",
     "opentelemetry-sdk>=1.44.0",

--- a/runner/schema/otel-attributes.schema.json
+++ b/runner/schema/otel-attributes.schema.json
@@ -1,22 +1,98 @@
 {
   "$id": "https://schemas.curietech.ai/runner/otel-attributes/v1.json",
   "schema_version": "v1",
-  "keys": {
+  "shared": {
     "curie.sandbox_id": "str",
     "curie.session_id": "str",
-    "gen_ai.approval.decision": "str",
-    "gen_ai.operation.name": "str",
-    "gen_ai.request.model": "str",
-    "gen_ai.tool.name": "str",
-    "gen_ai.usage.cache_creation_input_tokens": "int",
-    "gen_ai.usage.cache_read_input_tokens": "int",
-    "gen_ai.usage.input_tokens": "int",
-    "gen_ai.usage.output_tokens": "int",
+    "deployment.environment.name": "str",
     "langfuse.session.id": "str",
     "langfuse.trace.name": "str",
     "langfuse.user.id": "str",
-    "model": "str",
     "schema.version": "str",
-    "service.name": "str"
+    "service.instance.id": "str",
+    "service.name": "str",
+    "service.namespace": "str",
+    "service.version": "str"
+  },
+  "services": {
+    "curie-api": {
+      "error.type": "str",
+      "exception.escaped": "bool",
+      "exception.type": "str",
+      "http.request.method": "str",
+      "http.response.status_code": "int",
+      "messaging.destination.name": "str",
+      "messaging.operation.type": "str",
+      "messaging.system": "str",
+      "server.address": "str",
+      "server.port": "int"
+    },
+    "curie-dispatcher": {
+      "error.type": "str",
+      "exception.escaped": "bool",
+      "exception.type": "str",
+      "messaging.destination.name": "str",
+      "messaging.operation.type": "str",
+      "messaging.system": "str"
+    },
+    "curie-worker": {
+      "curie.sandbox.outcome": "str",
+      "curie.turn.outcome": "str",
+      "error.type": "str",
+      "exception.escaped": "bool",
+      "exception.type": "str",
+      "http.request.method": "str",
+      "http.response.status_code": "int",
+      "messaging.destination.name": "str",
+      "messaging.operation.type": "str",
+      "messaging.system": "str",
+      "server.address": "str",
+      "server.port": "int"
+    },
+    "curie-runner": {
+      "error.type": "str",
+      "exception.escaped": "bool",
+      "exception.type": "str",
+      "gen_ai.approval.decision": "str",
+      "gen_ai.operation.name": "str",
+      "gen_ai.request.model": "str",
+      "gen_ai.tool.name": "str",
+      "gen_ai.usage.cache_creation_input_tokens": "int",
+      "gen_ai.usage.cache_read_input_tokens": "int",
+      "gen_ai.usage.input_tokens": "int",
+      "gen_ai.usage.output_tokens": "int",
+      "model": "str"
+    }
+  },
+  "events": {
+    "curie-api": [
+      "messaging.enqueued",
+      "trace_context.invalid"
+    ],
+    "curie-dispatcher": [
+      "dispatcher.agent_lookup.resolved",
+      "dispatcher.agent_lookup.unavailable",
+      "dispatcher.dedupe.checked",
+      "dispatcher.dedupe.skip",
+      "dispatcher.placeholder.posted",
+      "messaging.enqueued"
+    ],
+    "curie-worker": [
+      "messaging.ack",
+      "messaging.dead_letter",
+      "messaging.pending",
+      "trace_context.invalid",
+      "worker.completion.settled",
+      "worker.dedupe.checked",
+      "worker.dedupe.skip",
+      "worker.lock.acquired",
+      "worker.lock.wait",
+      "worker.reply.final",
+      "worker.route.finish_race",
+      "worker.route.start",
+      "worker.route.steer",
+      "worker.terminal"
+    ],
+    "curie-runner": []
   }
 }

--- a/runner/schema/otel-attributes.schema.json
+++ b/runner/schema/otel-attributes.schema.json
@@ -36,6 +36,7 @@
       "messaging.system": "str"
     },
     "curie-worker": {
+      "curie.queue.wait_ms": "int",
       "curie.sandbox.outcome": "str",
       "curie.turn.outcome": "str",
       "error.type": "str",
@@ -70,8 +71,6 @@
       "trace_context.invalid"
     ],
     "curie-dispatcher": [
-      "dispatcher.agent_lookup.resolved",
-      "dispatcher.agent_lookup.unavailable",
       "dispatcher.dedupe.checked",
       "dispatcher.dedupe.skip",
       "dispatcher.placeholder.posted",
@@ -87,12 +86,33 @@
       "worker.dedupe.skip",
       "worker.lock.acquired",
       "worker.lock.wait",
+      "worker.queue.wait",
       "worker.reply.final",
+      "worker.retry.scheduled",
+      "worker.retry.stopped",
       "worker.route.finish_race",
       "worker.route.start",
       "worker.route.steer",
       "worker.terminal"
     ],
     "curie-runner": []
+  },
+  "log_events": {
+    "curie-api": [
+      "http.server.completed",
+      "http.server.failed"
+    ],
+    "curie-dispatcher": [
+      "dispatcher.turn.enqueued"
+    ],
+    "curie-worker": [
+      "worker.trace_context.invalid",
+      "worker.turn.completed",
+      "worker.turn.failed"
+    ],
+    "curie-runner": [
+      "agent.run.completed",
+      "agent.run.failed"
+    ]
   }
 }

--- a/runner/src/curie_runner/__main__.py
+++ b/runner/src/curie_runner/__main__.py
@@ -15,7 +15,9 @@ import sys
 import anyio
 from aci_protocol import BootEnv
 from aiohttp import web
+from curie_telemetry import TelemetryRuntime, configure
 
+from . import __version__
 from .adapter import ClaudeAgentSession, ModelSession, build_options
 from .approval import (
     APPROVAL_SERVER_NAME,
@@ -44,7 +46,7 @@ from .history import (
 )
 from .hooks import load_bundle_hooks
 from .memory import MemoryRecord, MemoryStore, format_memory_preamble, resolve_memory
-from .otel import RunTracer, build_tracer_provider
+from .otel import RunTracer
 from .redact import install_stdout_redaction
 from .sdk_auth import UnsupportedCredentialError
 from .server import create_app
@@ -52,7 +54,10 @@ from .session import SessionRunner
 from .side_effects import SideEffectClassifier
 from .state import STATE_SERVER_NAME, build_state_server, resolve_state_client
 
-logger = logging.getLogger(__name__)
+# A stable service namespace is load-bearing for the scoped OTEL handler. When
+# this module is executed with ``python -m``, ``__name__`` is ``__main__`` and
+# would otherwise put every boot diagnostic outside ``curie_runner``.
+logger = logging.getLogger("curie_runner.main")
 
 
 def _resolve_harness(name: str = DEFAULT_HARNESS) -> HarnessContribution:
@@ -115,6 +120,7 @@ def build_runner(
     history_store: TranscriptStore | None = None,
     conversation_preamble: str | None = None,
     harness: HarnessContribution | None = None,
+    telemetry: TelemetryRuntime | None = None,
 ) -> SessionRunner:
     """Wire a SessionRunner backed by the active harness's model session.
 
@@ -267,15 +273,13 @@ def build_runner(
         )
         return ClaudeAgentSession(options)
 
-    provider = build_tracer_provider(
-        config.session.otel,
-        config.session.session_id,
-        config.session.sandbox_id,
+    telemetry = telemetry or configure(
+        service_name="curie-runner", service_version=__version__
     )
     return SessionRunner(
         session_factory=factory,
         ceiling=config.ceiling,
-        tracer=RunTracer(provider),
+        tracer=RunTracer(telemetry.tracer),
         classifier=SideEffectClassifier(readonly_tools=harness.readonly_tools),
         trace_name=f"curie-run:{config.session.session_id}",
         session_id=config.session.session_id,
@@ -286,6 +290,8 @@ def build_runner(
         approval_resumed_kind=config.approval_resumed_kind,
         approval_decision=config.approval_decision,
         false_completion_check=config.false_completion_check,
+        sandbox_id=config.session.sandbox_id,
+        telemetry=telemetry,
     )
 
 
@@ -368,6 +374,11 @@ def _load_history(config: RunnerConfig) -> tuple[TranscriptStore, str | None]:
 def main() -> None:
     logging.basicConfig(level=logging.INFO, stream=sys.stdout)
     install_stdout_redaction()
+    telemetry = configure(service_name="curie-runner", service_version=__version__)
+    telemetry.attach_logging(
+        logging.getLogger("curie_runner"),
+        default_level=logging.INFO,
+    )
     # The NAME comes from the one declaration (#488); the parse deliberately does
     # not. BootEnv reads any non-"0" value as true, while this boot has always
     # required an explicit 1/true/yes -- routing through it would turn
@@ -416,6 +427,7 @@ def main() -> None:
         history_store=history_store,
         conversation_preamble=conversation_preamble,
         harness=harness,
+        telemetry=telemetry,
     )
     app = create_app(runner, token=config.runner_token)
 

--- a/runner/src/curie_runner/fake.py
+++ b/runner/src/curie_runner/fake.py
@@ -68,6 +68,12 @@ def default_turn() -> list[Any]:
 APPROVAL_MARKER = "[fake:request-approval]"
 _APPROVAL_MARKER_RE = re.compile(r"\[fake:request-approval(?::([A-Za-z0-9_-]+))?\]")
 
+# Explicit offline failure injection for platform/E2E error-path proofs. The
+# marker is interpreted only by FakeModelSession and raises before any scripted
+# output, so it exercises the runner's real classified-failure handling with no
+# provider or network dependency.
+RUNNER_ERROR_MARKER = "[fake:runner-error]"
+
 
 def approval_turn(summary: str, route: str | None = None) -> list[Any]:
     """A turn that calls the platform approval-request tool, then ends."""
@@ -158,6 +164,8 @@ class FakeModelSession:
         self._interrupted = True
 
     async def receive_turn(self) -> AsyncIterator[Any]:
+        if self.queries and RUNNER_ERROR_MARKER in self.queries[-1]:
+            raise RuntimeError("injected fake runner failure")
         for message in self._script_factory():
             if self._interrupted and self._truncate_on_interrupt:
                 return

--- a/runner/src/curie_runner/otel.py
+++ b/runner/src/curie_runner/otel.py
@@ -1,27 +1,23 @@
-"""OTel tracing for the runner: gen_ai spans exported OTLP-HTTP to the collector.
+"""Runner-specific gen_ai spans on the platform's shared OTEL runtime.
 
-Productizes the PT-4/PT-E prototype span shape. Each turn is a root ``agent.run``
-(SERVER) span carrying a ``langfuse.trace.name``, with a child ``llm.generation``
-span holding ``gen_ai.request.model`` and ``gen_ai.usage.*`` token counts, plus a
-child ``execute_tool`` span per tool call (``gen_ai.tool.name`` /
-``gen_ai.operation.name``). Langfuse maps a model-bearing span to a generation and
-nests tool spans as observations, so this reconstructs the tool-call tree (S1).
+Each turn is an ``agent.run`` SERVER span carrying a ``langfuse.trace.name``,
+with a child ``llm.generation`` span holding ``gen_ai.request.model`` and
+``gen_ai.usage.*`` token counts, plus a child ``execute_tool`` span per tool
+call. The HTTP server attaches only an incoming W3C Trace Context parent before
+opening this tree, so ``agent.run`` is a descendant of the worker RPC when one
+exists and a valid root when it does not.
 
-Traces go to the OTel Collector over OTLP-HTTP, never directly to Langfuse: the
-collector is the adapter that authenticates and forwards (Langfuse OTLP ingest is
-HTTP-only). Endpoint/headers come from the standard ``OTEL_EXPORTER_OTLP_*`` env
-vars via ``SessionConfig.otel``; the exporter is constructed argument-free so the
-opentelemetry SDK's own env parsing applies (it appends ``/v1/traces`` to a base
-``OTEL_EXPORTER_OTLP_ENDPOINT``). When no endpoint is configured the tracer is a
-no-op, so unit tests and offline runs neither export nor fail.
+Provider construction, correlated logs, batching, resource identity, redaction,
+flush, and shutdown live in ``curie_telemetry``. This module deliberately keeps
+only the runner's established Langfuse/gen-ai span shape and a compatibility
+provider builder used by older callers and drift tests.
 
-Per ADR-0076, every attribute this module attaches comes from the closed
-``SpanAttributeKey`` enum below rather than a bare string, so a future call site
-with an unlisted key is a construction-time error, not a silent addition to the
-wire shape. ``SCHEMA_VERSION`` is bumped only when a key is removed, renamed, or
-changes value type; a new optional key is additive and does not bump it.
-``SPAN_ATTRIBUTE_VALUE_TYPES`` declares each key's value type, the mirror the
-drift gate diffs to catch a retype.
+Per ADR-0076, the runner's shared-runtime and runner-owned attributes are mirrored
+by the closed ``SpanAttributeKey`` enum below. Runner-specific setters use the
+enum rather than bare strings; the shared bootstrap is governed by the same
+owner-partitioned artifact. ``SCHEMA_VERSION`` changes only when a key is removed,
+renamed, or retyped. ``SPAN_ATTRIBUTE_VALUE_TYPES`` mirrors each exact type for
+the drift gate.
 """
 
 from __future__ import annotations
@@ -29,33 +25,30 @@ from __future__ import annotations
 from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
 from enum import StrEnum
-from typing import Any, cast
+from typing import Any
 
 from aci_protocol import OtelConfig
+from curie_telemetry.attributes import SCHEMA_VERSION as SCHEMA_VERSION
+from curie_telemetry.attributes import SchemaValidatingSpanProcessor
+from curie_telemetry.bootstrap import service_resource
+from curie_telemetry.redact import redact_value
 from opentelemetry import trace
-from opentelemetry.attributes import BoundedAttributes
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
-from opentelemetry.sdk.resources import Resource
-from opentelemetry.sdk.trace import ReadableSpan, SpanProcessor, TracerProvider
-from opentelemetry.sdk.trace.export import SimpleSpanProcessor
-from opentelemetry.trace import SpanKind, Tracer
-
-from .redact import redact_span_attribute, redact_text
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.trace import SpanKind, Status, StatusCode, Tracer
 
 _SERVICE_NAME = "curie-runner"
-
-# ADR-0076 decision 2: additive (a new optional key) does not bump this; removing,
-# renaming, or retyping an existing key does.
-SCHEMA_VERSION = "v1"
+_SERVICE_VERSION = "0.0.0"
 
 
 class SpanAttributeKey(StrEnum):
-    """The closed set of keys the runner may attach to a span or resource.
+    """The closed shared-plus-runner telemetry key set.
 
     ADR-0076 decision 1. Str-mixin so a member is usable anywhere a plain
-    attribute-value string is expected (e.g. dict keys, f-strings), but every
-    ``set_attribute``/``Resource.create`` call site should pass a member here
-    rather than a literal, so an unlisted key is a construction-time error.
+    attribute-value string is expected (e.g. dict keys, f-strings). Direct
+    runner-owned setters pass a member here rather than a literal; process
+    resource keys are emitted by the shared bootstrap from the same artifact.
     """
 
     TRACE_NAME = "langfuse.trace.name"
@@ -75,7 +68,14 @@ class SpanAttributeKey(StrEnum):
     USAGE_CACHE_CREATION_INPUT_TOKENS = "gen_ai.usage.cache_creation_input_tokens"
     TOOL_NAME = "gen_ai.tool.name"
     OPERATION_NAME = "gen_ai.operation.name"
+    DEPLOYMENT_ENVIRONMENT_NAME = "deployment.environment.name"
+    ERROR_TYPE = "error.type"
+    EXCEPTION_ESCAPED = "exception.escaped"
+    EXCEPTION_TYPE = "exception.type"
     SERVICE_NAME = "service.name"
+    SERVICE_INSTANCE_ID = "service.instance.id"
+    SERVICE_NAMESPACE = "service.namespace"
+    SERVICE_VERSION = "service.version"
     CURIE_SESSION_ID = "curie.session_id"
     CURIE_SANDBOX_ID = "curie.sandbox_id"
     SCHEMA_VERSION_KEY = "schema.version"
@@ -85,10 +85,8 @@ class SpanAttributeKey(StrEnum):
 # version-bump-worthy change exactly like a remove or rename, so it needs its
 # own source of truth to diff against -- the type half of the closed schema,
 # parallel to ``SpanAttributeKey`` being the key half. Every member above must
-# appear here exactly once, mapped to its value-type name ("str" or "int");
-# the ``gen_ai.usage.*`` token counts are the only "int" members (see
-# ``record_usage`` below and ``redact.py``'s "only str and int attributes are
-# set today").
+# appear here exactly once, mapped to its value-type name ("str", "int", or
+# deliberate "bool"); the ``gen_ai.usage.*`` token counts are the int members.
 SPAN_ATTRIBUTE_VALUE_TYPES: Mapping[SpanAttributeKey, str] = {
     SpanAttributeKey.TRACE_NAME: "str",
     SpanAttributeKey.SESSION_ID: "str",
@@ -102,7 +100,14 @@ SPAN_ATTRIBUTE_VALUE_TYPES: Mapping[SpanAttributeKey, str] = {
     SpanAttributeKey.USAGE_CACHE_CREATION_INPUT_TOKENS: "int",
     SpanAttributeKey.TOOL_NAME: "str",
     SpanAttributeKey.OPERATION_NAME: "str",
+    SpanAttributeKey.DEPLOYMENT_ENVIRONMENT_NAME: "str",
+    SpanAttributeKey.ERROR_TYPE: "str",
+    SpanAttributeKey.EXCEPTION_ESCAPED: "bool",
+    SpanAttributeKey.EXCEPTION_TYPE: "str",
     SpanAttributeKey.SERVICE_NAME: "str",
+    SpanAttributeKey.SERVICE_INSTANCE_ID: "str",
+    SpanAttributeKey.SERVICE_NAMESPACE: "str",
+    SpanAttributeKey.SERVICE_VERSION: "str",
     SpanAttributeKey.CURIE_SESSION_ID: "str",
     SpanAttributeKey.CURIE_SANDBOX_ID: "str",
     SpanAttributeKey.SCHEMA_VERSION_KEY: "str",
@@ -128,104 +133,47 @@ def _set(span: Any, key: SpanAttributeKey, value: object) -> None:
     attached by construction (ADR-0076).
     """
 
-    span.set_attribute(key.value, redact_span_attribute(value))
+    span.set_attribute(key.value, redact_value(value))
 
 
-def _still_leaks(value: object) -> bool:
-    """Whether an attribute value still carries an unscrubbed secret.
+class _SchemaValidatingSpanProcessor(SchemaValidatingSpanProcessor):
+    """Compatibility wrapper for the runner-scoped shared export backstop."""
 
-    Type-agnostic on purpose (#935). ADR-0076 decision 3 frames the export
-    validator as a universal backstop, but it only inspected ``str``, so a
-    sequence-valued attribute on an ALLOWED key slipped a secret past BOTH the
-    scrub and this validator — the two layers failing together, which is exactly
-    what defense in depth is supposed to prevent. ``str`` is itself a Sequence, so
-    it is matched first; anything that is neither a str nor a list/tuple (int,
-    float, bool) cannot carry a pattern match and is clean by construction.
-    """
-
-    if isinstance(value, str):
-        return redact_text(value) != value
-    if isinstance(value, (list, tuple)):
-        return any(_still_leaks(item) for item in value)
-    return False
-
-
-class _SchemaValidatingSpanProcessor(SpanProcessor):
-    """Fail-closed export-time backstop (ADR-0076 decision 3).
-
-    ``_set()`` already gates every attribute this module attaches through the
-    closed ``SpanAttributeKey`` enum and the ``redact.py`` scrub; this processor
-    exists for the call site that bypasses both by calling ``span.set_attribute``
-    directly. On each span ending, it strips (does not replace) any attribute
-    whose key is outside the closed schema, or whose value — or any element of a
-    sequence value (#935) — still matches
-    an unscrubbed-secret pattern after the existing redaction pass — dropping the
-    offending attribute rather than the whole span, so one bad key costs a single
-    field of trace data rather than the whole record.
-
-    Must be registered on the provider ahead of the exporting processor
-    (``TracerProvider.add_span_processor`` invokes processors in registration
-    order); it mutates the span's attributes in place so the exporter that runs
-    after it sees the cleaned set.
-    """
-
-    _ALLOWED_KEYS = frozenset(member.value for member in SpanAttributeKey)
-
-    def on_end(self, span: ReadableSpan) -> None:
-        # ReadableSpan.attributes is a read-only MappingProxyType view; the
-        # underlying BoundedAttributes (span._attributes) is the same object the
-        # concrete Span held, flagged immutable at Span.end() (see the SDK's own
-        # `self._attributes._immutable = True` in Span.end()). Toggling that
-        # private flag to mutate here mirrors the SDK's own pattern. Always a
-        # BoundedAttributes at runtime (Span.__init__ constructs it directly);
-        # the cast narrows past the Mapping-typed private attribute.
-        raw = span._attributes  # noqa: SLF001
-        if raw is None:
-            return
-        attributes = cast(BoundedAttributes, raw)
-        was_immutable = attributes._immutable  # noqa: SLF001
-        attributes._immutable = False  # noqa: SLF001
-        try:
-            for key in list(attributes.keys()):
-                value = attributes[key]
-                still_leaks = _still_leaks(value)
-                if key not in self._ALLOWED_KEYS or still_leaks:
-                    del attributes[key]
-        finally:
-            attributes._immutable = was_immutable  # noqa: SLF001
+    def __init__(self) -> None:
+        super().__init__(_SERVICE_NAME)
 
 
 def build_tracer_provider(
     otel: OtelConfig, session_id: str, sandbox_id: str | None = None
 ) -> TracerProvider | None:
-    """Build a TracerProvider exporting to the collector, or None if unconfigured.
+    """Compatibility provider builder; process bootstrap uses shared configure.
 
-    ``session_id`` is attached as a resource attribute so traces are attributable
-    to the sandbox session that produced them. ``sandbox_id`` (the ACI
-    ``CURIE_SANDBOX_ID``) is stamped alongside it when present so a trace is
-    attributable to the concrete sandbox that ran it; an absent or empty value is
-    omitted rather than stamped as an empty string.
+    The legacy arguments remain source-compatible, but per-turn identities no
+    longer belong on process resources. ``RunTracer.run_span`` stamps them on
+    ``agent.run`` instead.
     """
 
     if not otel.endpoint:
         return None
 
-    attributes: dict[str, str] = {
-        SpanAttributeKey.SERVICE_NAME.value: _SERVICE_NAME,
-        SpanAttributeKey.CURIE_SESSION_ID.value: session_id,
-        SpanAttributeKey.SCHEMA_VERSION_KEY.value: SCHEMA_VERSION,
-    }
-    if sandbox_id:
-        attributes[SpanAttributeKey.CURIE_SANDBOX_ID.value] = sandbox_id
-    resource = Resource.create(attributes)
-    provider = TracerProvider(resource=resource)
+    _ = (session_id, sandbox_id)
+    resource = service_resource(_SERVICE_NAME, _SERVICE_VERSION)
+    provider = TracerProvider(resource=resource, shutdown_on_exit=False)
     # The validator must run before the exporting processor (registration order)
     # so the exporter only ever sees attributes the closed schema allows.
     provider.add_span_processor(_SchemaValidatingSpanProcessor())
-    # The exporter reads OTEL_EXPORTER_OTLP_ENDPOINT / _HEADERS / _PROTOCOL from
-    # the environment itself; SessionConfig.otel is the typed view of the same
-    # vars, so an argument-free exporter and the config agree by construction.
-    provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter()))
+    # Compatibility callers still get bounded batching. The process bootstrap
+    # uses curie_telemetry.configure() instead; this helper remains for the
+    # exported legacy API and the ADR-0076 resource drift checks.
+    provider.add_span_processor(
+        BatchSpanProcessor(
+            OTLPSpanExporter(),
+            max_queue_size=2048,
+            schedule_delay_millis=500,
+            max_export_batch_size=512,
+            export_timeout_millis=500,
+        )
+    )
     return provider
 
 
@@ -235,13 +183,16 @@ class RunTracer:
     A None provider yields a no-op tracer so callers need no branching.
     """
 
-    def __init__(self, provider: TracerProvider | None) -> None:
-        self._provider = provider
-        self._tracer: Tracer = (
-            provider.get_tracer("curie-runner")
-            if provider is not None
-            else trace.get_tracer("curie-runner")
-        )
+    def __init__(self, provider: TracerProvider | Tracer | None) -> None:
+        if isinstance(provider, TracerProvider):
+            self._provider: TracerProvider | None = provider
+            self._tracer = provider.get_tracer("curie-runner")
+        elif provider is not None:
+            self._provider = None
+            self._tracer = provider
+        else:
+            self._provider = None
+            self._tracer = trace.get_tracer("curie-runner")
 
     @contextmanager
     def run_span(
@@ -251,6 +202,7 @@ class RunTracer:
         session_id: str | None = None,
         user_id: str | None = None,
         approval_decision: str | None = None,
+        sandbox_id: str | None = None,
     ) -> Iterator[_GenerationSpan]:
         """Open the root ``agent.run`` span and its child ``llm.generation`` span.
 
@@ -267,21 +219,46 @@ class RunTracer:
         an operator can see the outcome from the trace.
         """
 
-        with self._tracer.start_as_current_span("agent.run", kind=SpanKind.SERVER) as root:
+        with self._tracer.start_as_current_span(
+            "agent.run",
+            kind=SpanKind.SERVER,
+            record_exception=False,
+            set_status_on_exception=False,
+        ) as root:
             _set(root, SpanAttributeKey.TRACE_NAME, trace_name)
+            _set(root, SpanAttributeKey.SCHEMA_VERSION_KEY, SCHEMA_VERSION)
             if session_id:
                 _set(root, SpanAttributeKey.SESSION_ID, session_id)
+                _set(root, SpanAttributeKey.CURIE_SESSION_ID, session_id)
+            if sandbox_id:
+                _set(root, SpanAttributeKey.CURIE_SANDBOX_ID, sandbox_id)
             if user_id:
                 _set(root, SpanAttributeKey.USER_ID, user_id)
             if approval_decision:
                 _set(root, SpanAttributeKey.APPROVAL_DECISION, approval_decision)
-            with self._tracer.start_as_current_span("llm.generation") as gen:
-                span = _GenerationSpan(self._tracer, gen)
+            with self._tracer.start_as_current_span(
+                "llm.generation",
+                record_exception=False,
+                set_status_on_exception=False,
+            ) as gen:
+                span = _GenerationSpan(self._tracer, root, gen)
                 # Stamp the configured model at span open when CURIE_MODEL is
                 # set; otherwise the span stays model-less until the SDK reports
                 # the actual model on its first assistant message (record_model).
                 span.record_model(model)
-                yield span
+                try:
+                    yield span
+                except BaseException as exc:
+                    exception_type = type(exc).__name__
+                    span.record_outcome(
+                        "abandoned",
+                        error_type=exception_type,
+                        exception_type=exception_type,
+                        exception_escaped=True,
+                    )
+                    raise
+                finally:
+                    span.ensure_outcome()
 
     def shutdown(self) -> None:
         """Flush and shut down the exporter if one was configured."""
@@ -293,10 +270,61 @@ class RunTracer:
 class _GenerationSpan:
     """Handle for annotating the generation span and emitting tool child spans."""
 
-    def __init__(self, tracer: Tracer, span: Any) -> None:
+    def __init__(self, tracer: Tracer, root: Any, span: Any) -> None:
         self._tracer = tracer
+        self._root = root
         self._span = span
         self._model_recorded = False
+        self._outcome_recorded = False
+
+    def record_outcome(
+        self,
+        status: object,
+        *,
+        error_type: str | None = None,
+        exception_type: str | None = None,
+        exception_escaped: bool | None = None,
+    ) -> None:
+        """Set a terminal status and value-free exception classification."""
+
+        if self._outcome_recorded:
+            return
+        value = getattr(status, "value", status)
+        if value in {"done", "idle-awaiting-input", "awaiting-approval"}:
+            self._root.set_status(Status(StatusCode.OK))
+        else:
+            self._root.set_status(Status(StatusCode.ERROR))
+            _set(
+                self._root,
+                SpanAttributeKey.ERROR_TYPE,
+                error_type or str(value),
+            )
+            if exception_type is not None:
+                _set(
+                    self._root,
+                    SpanAttributeKey.EXCEPTION_TYPE,
+                    exception_type,
+                )
+            if exception_escaped is not None:
+                _set(
+                    self._root,
+                    SpanAttributeKey.EXCEPTION_ESCAPED,
+                    exception_escaped,
+                )
+        self._outcome_recorded = True
+
+    def ensure_outcome(self) -> None:
+        """Treat an unclassified/abandoned span as an explicit error."""
+
+        if not self._outcome_recorded:
+            self.record_outcome("abandoned")
+
+    @contextmanager
+    def lifecycle_log_context(self) -> Iterator[None]:
+        """Correlate terminal lifecycle logs to ``agent.run`` itself."""
+
+        with trace.use_span(self._root, end_on_exit=False):
+            yield
 
     def record_model(self, model: str | None) -> None:
         """Stamp the generation model attribute once, first non-empty value wins.

--- a/runner/src/curie_runner/redact.py
+++ b/runner/src/curie_runner/redact.py
@@ -1,202 +1,41 @@
-"""Secret redaction at the runner's output boundaries.
+"""Runner compatibility exports for shared telemetry redaction.
 
-Defense in depth. Curie forwards real credentials into the sandbox (the ACI
-``CURIE_CREDENTIALS`` reference resolves to a live provider key) and the runner
-self-emits OTel spans to a trace backend, so a secret that reaches a log line or a
-span attribute has already left the trust boundary by the time anything downstream
-sees it. This module scrubs the value on the way out, at the last point the runner
-still owns it.
-
-Scope is the two boundaries issue #518 names: the runner's stdout logs and the
-gen_ai span attributes. That is not the whole of the runner's egress, and this
-module does not claim otherwise. ``server.py`` streams verbatim model output as
-NDJSON ACI frames, which is a larger surface left deliberately untouched here: the
-frames are the product contract, and scrubbing them is a separate decision.
-``check.py`` writes its own stdout without this pass, which is scoped out because
-it has no credential path and never issues a model query, and because its JSON
-output is a frozen contract that a scrub would mangle.
-
-This complements, and does not replace, the export-time validator in issue #512,
-which drops records that still carry an unscrubbed secret. That validator is the
-alarm; this module is the scrub. Both exist because either one alone fails open:
-the scrub can miss a class the regexes do not know, and the validator can only
-discard a record after the fact.
-
-Tripwire contract: ``runner/tests/test_redact.py`` binds ``REDACTION_RULES`` to a
-frozen vector per rule and ``REDACTION_BOUNDARIES`` to a boundary per parametrized
-case. Adding a regex requires adding its frozen vector; adding an output boundary
-requires driving every vector through it. A rule applied at one boundary and absent
-at the other is a leak that no other test would catch.
-
-Rules are applied in registry order and first match wins, so they are written to be
-disjoint on the frozen vectors. Every pattern is precompiled at import and the pass
-is pure string work: no I/O and no environment reads, which keeps the runner's
-``CURIE_FAKE_MODEL`` path a true offline no-op.
+The platform owns one redaction registry and implementation in
+``curie_telemetry.redact``. Runner callers keep their established import names
+while stderr, OTEL logs, and OTEL span attributes all use that implementation.
 """
 
 from __future__ import annotations
 
 import logging
-import re
-from dataclasses import dataclass
 
-
-@dataclass(frozen=True)
-class RedactionRule:
-    """One secret class: the pattern that finds it and the text that replaces it."""
-
-    name: str
-    pattern: re.Pattern[str]
-    placeholder: str
-
-
-def _placeholder(name: str) -> str:
-    return f"[REDACTED:{name}]"
-
-
-# Order is load bearing. ``url_secret_param`` is anchored on a query-param prefix
-# and runs before ``secret_assignment`` so a token carried in a URL is attributed
-# to the URL rule rather than swallowed by the generic assignment rule; the
-# assignment rule cannot reach the URL case because it does not match after a
-# ``?`` or ``&``. ``jwt`` runs before ``bearer_token`` so a bare ``eyJ`` token is
-# attributed to the JWT rule. Every remaining rule is keyed on a vendor-specific
-# prefix, so they cannot overlap each other.
-REDACTION_RULES: tuple[RedactionRule, ...] = (
-    RedactionRule(
-        name="pem_private_key",
-        pattern=re.compile(
-            r"-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----"
-        ),
-        placeholder=_placeholder("pem_private_key"),
-    ),
-    RedactionRule(
-        name="url_secret_param",
-        pattern=re.compile(
-            r"[?&](?:token|secret|password|passwd|pwd|api_key|apikey|access_token|key|sig"
-            r"|signature)=[^&\s]+",
-            re.IGNORECASE,
-        ),
-        placeholder=_placeholder("url_secret_param"),
-    ),
-    RedactionRule(
-        name="jwt",
-        pattern=re.compile(r"\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+"),
-        placeholder=_placeholder("jwt"),
-    ),
-    RedactionRule(
-        name="bearer_token",
-        pattern=re.compile(r"\bBearer\s+[A-Za-z0-9._~+/=-]+"),
-        placeholder=_placeholder("bearer_token"),
-    ),
-    RedactionRule(
-        name="api_key",
-        pattern=re.compile(r"\b(?:sk|xai)[-_][A-Za-z0-9_-]{16,}"),
-        placeholder=_placeholder("api_key"),
-    ),
-    RedactionRule(
-        name="aws_access_key_id",
-        pattern=re.compile(r"\b(?:AKIA|ASIA)[A-Z0-9]{16,}"),
-        placeholder=_placeholder("aws_access_key_id"),
-    ),
-    RedactionRule(
-        name="github_pat",
-        pattern=re.compile(r"\b(?:github_pat_[A-Za-z0-9_]{20,}|gh[pousr]_[A-Za-z0-9]{20,})"),
-        placeholder=_placeholder("github_pat"),
-    ),
-    RedactionRule(
-        name="gitlab_token",
-        pattern=re.compile(r"\bglpat-[A-Za-z0-9_-]{16,}"),
-        placeholder=_placeholder("gitlab_token"),
-    ),
-    RedactionRule(
-        name="slack_token",
-        pattern=re.compile(r"\bxox[baps]-[A-Za-z0-9-]{10,}"),
-        placeholder=_placeholder("slack_token"),
-    ),
-    RedactionRule(
-        name="google_api_key",
-        pattern=re.compile(r"\bAIza[A-Za-z0-9_-]{30,}"),
-        placeholder=_placeholder("google_api_key"),
-    ),
-    # Deliberately narrow: only secret-bearing key names, and only ``=``. A wider
-    # key set or a ``:`` separator would eat ordinary runner log lines such as
-    # "runner configured session=s-1 model=claude-opus-4-8 port=8080".
-    RedactionRule(
-        name="secret_assignment",
-        pattern=re.compile(
-            r"\b(?:secret|password|passwd|pwd|api_key|apikey|access_token|token)=\S+",
-            re.IGNORECASE,
-        ),
-        placeholder=_placeholder("secret_assignment"),
-    ),
-    # Collapses the account portion only, so the remainder of the path stays
-    # readable. Generic by construction: never read $HOME, never bake in a name.
-    RedactionRule(
-        name="home_path",
-        pattern=re.compile(r"/(?:home|Users)/[^/\s]+"),
-        placeholder=_placeholder("home_path"),
-    ),
+from curie_telemetry.redact import (
+    REDACTION_RULES,
+    RedactingLogFilter,
+    RedactionRule,
+    install_logging_redaction,
+    redact_span_attribute,
+    redact_text,
 )
 
+# Compatibility tripwire for the runner's original boundary names. The shared
+# package separately freezes its expanded stderr/OTEL log/OTEL span boundary
+# set; keeping these labels avoids changing the runner's import contract.
 REDACTION_BOUNDARIES: tuple[str, ...] = ("stdout", "gen_ai_span")
 
 
-def redact_text(text: str) -> str:
-    """Apply every redaction rule, in registry order, to one string."""
-
-    for rule in REDACTION_RULES:
-        text = rule.pattern.sub(rule.placeholder, text)
-    return text
-
-
-def redact_span_attribute(value: object) -> object:
-    """Redact a span attribute value, preserving its type.
-
-    Strings are scrubbed and sequences are scrubbed ELEMENTWISE, preserving the
-    container type (OTel requires a homogeneous sequence, so scrubbed str elements
-    stay str). Every other value (int, float, bool) passes through untouched, so
-    the ``gen_ai.usage.*`` token counts stay ints.
-
-    Sequences are handled here rather than left to a future caller (#935): only str
-    and int attributes are set today, but OTel permits sequence values, and relying
-    on whoever adds the first one to remember to extend this function is exactly
-    the defense-in-depth gap that issue closed. ``otel.py``'s export validator
-    recurses the same way as the backstop.
-    """
-
-    if isinstance(value, str):
-        return redact_text(value)
-    if isinstance(value, (list, tuple)):
-        scrubbed = [redact_span_attribute(item) for item in value]
-        return tuple(scrubbed) if isinstance(value, tuple) else scrubbed
-    return value
-
-
-class RedactingLogFilter(logging.Filter):
-    """Scrubs secrets from a log record's fully formatted message.
-
-    The runner logs args-style throughout (``logger.info("tool=%s", name)``), so a
-    secret usually arrives in ``record.args`` and never appears in ``record.msg``.
-    Filtering ``msg`` alone would leak it, so this formats the record first and
-    replaces the pair with the scrubbed result.
-    """
-
-    def filter(self, record: logging.LogRecord) -> bool:
-        message = record.getMessage()
-        redacted = redact_text(message)
-        if redacted != message:
-            record.msg = redacted
-            record.args = ()
-        return True
-
-
 def install_stdout_redaction() -> None:
-    """Attach the redaction filter to every root logger handler, idempotently.
+    """Install shared redaction on the existing diagnostic handlers."""
 
-    Repeated calls are a no-op on handlers that already carry the filter, so the
-    pass never stacks or double-redacts.
-    """
+    install_logging_redaction(logging.getLogger())
 
-    for handler in logging.getLogger().handlers:
-        if not any(isinstance(existing, RedactingLogFilter) for existing in handler.filters):
-            handler.addFilter(RedactingLogFilter())
+
+__all__ = [
+    "REDACTION_BOUNDARIES",
+    "REDACTION_RULES",
+    "RedactingLogFilter",
+    "RedactionRule",
+    "install_stdout_redaction",
+    "redact_span_attribute",
+    "redact_text",
+]

--- a/runner/src/curie_runner/server.py
+++ b/runner/src/curie_runner/server.py
@@ -157,14 +157,10 @@ async def _event(request: web.Request) -> web.StreamResponse:
     # interrupt in run_turn's finally -- on the task that opened it.
     trace_headers: dict[str, str] = {}
     traceparents = request.headers.getall("traceparent", [])
-    tracestates = request.headers.getall("tracestate", [])
     if traceparents:
         # More than one traceparent is invalid; joining makes the value fail the
         # value-free validator without ever putting it in a diagnostic.
         trace_headers["traceparent"] = ",".join(traceparents)
-    if tracestates:
-        # HTTP permits repeated tracestate fields; W3C treats them as one list.
-        trace_headers["tracestate"] = ",".join(tracestates)
     token = attach(extract_http_trace_context(trace_headers))
     try:
         try:

--- a/runner/src/curie_runner/server.py
+++ b/runner/src/curie_runner/server.py
@@ -32,6 +32,8 @@ from typing import cast
 from aci_protocol import Event, Interrupt, parse_inbound
 from aiohttp import web
 from aiohttp.typedefs import Handler, Middleware
+from curie_telemetry.carrier import extract_http_trace_context
+from opentelemetry.context import attach, detach
 
 from .session import SessionRunner
 
@@ -153,9 +155,30 @@ async def _event(request: web.Request) -> web.StreamResponse:
     # asyncgen GC on a different task, releasing the turn lock cross-task (see
     # SessionRunner._turn_lock). aclosing keeps the teardown -- and the turn
     # interrupt in run_turn's finally -- on the task that opened it.
-    async with contextlib.aclosing(runner.run_turn(frame)) as stream:
-        async for line in stream:
-            await response.write(line.encode("utf-8"))
+    trace_headers: dict[str, str] = {}
+    traceparents = request.headers.getall("traceparent", [])
+    tracestates = request.headers.getall("tracestate", [])
+    if traceparents:
+        # More than one traceparent is invalid; joining makes the value fail the
+        # value-free validator without ever putting it in a diagnostic.
+        trace_headers["traceparent"] = ",".join(traceparents)
+    if tracestates:
+        # HTTP permits repeated tracestate fields; W3C treats them as one list.
+        trace_headers["tracestate"] = ",".join(tracestates)
+    token = attach(extract_http_trace_context(trace_headers))
+    try:
+        try:
+            async with contextlib.aclosing(runner.run_turn(frame)) as stream:
+                async for line in stream:
+                    await response.write(line.encode("utf-8"))
+        finally:
+            # The worker may suspend/delete the sandbox as soon as it sees EOF.
+            # Flush the just-ended agent.run and its correlated logs first; a
+            # timeout or exporter error remains telemetry-only and never changes
+            # the already-produced ACI terminal result.
+            await runner.flush_telemetry(timeout_millis=500)
+    finally:
+        detach(token)
     await response.write_eof()
     return response
 

--- a/runner/src/curie_runner/session.py
+++ b/runner/src/curie_runner/session.py
@@ -36,6 +36,7 @@ from aci_protocol import (
     to_ndjson_line,
 )
 from claude_agent_sdk import AssistantMessage, ResultMessage
+from curie_telemetry import emit_log_event
 
 from .adapter import ModelSession
 from .approval import ApprovalGate
@@ -485,6 +486,7 @@ class SessionRunner:
                             self._status.value,
                             int((time.monotonic() - start) * 1000),
                         )
+                        emit_log_event(logger, "agent.run.completed")
                     # Persist the completed turn to the durable transcript so a
                     # restarted sandbox can rehydrate this thread (#20).
                     await self._record_turn(event, state)
@@ -510,6 +512,11 @@ class SessionRunner:
                             type(exc).__name__,
                             exc,
                             int((time.monotonic() - start) * 1000),
+                        )
+                        emit_log_event(
+                            logger,
+                            "agent.run.failed",
+                            level=logging.ERROR,
                         )
                     yield to_ndjson_line(
                         ErrorEvent(message=f"runner error: {exc}", classification="runner-error")

--- a/runner/src/curie_runner/session.py
+++ b/runner/src/curie_runner/session.py
@@ -23,6 +23,7 @@ import contextlib
 import logging
 import time
 from collections.abc import AsyncGenerator, AsyncIterator, Callable
+from typing import Any, Protocol
 
 import anyio
 from aci_protocol import (
@@ -56,6 +57,24 @@ from .translate import TurnState, translate_message
 logger = logging.getLogger(__name__)
 
 SessionFactory = Callable[[], ModelSession]
+
+
+class TelemetryLifecycle(Protocol):
+    """The bounded runtime surface SessionRunner owns at process teardown."""
+
+    tracer: Any
+
+    def attach_logging(
+        self,
+        logger: logging.Logger,
+        *,
+        default_level: int | None = None,
+    ) -> None: ...
+
+    def force_flush(self, *, timeout_millis: int) -> bool: ...
+
+    def shutdown(self, *, timeout_millis: int = 2_000) -> bool: ...
+
 
 # The SDK surfaces a provider auth rejection (HTTP 401/403 -- e.g. a placeholder,
 # revoked, or wrong model key) as an ``AssistantMessage.error`` of this code
@@ -137,6 +156,8 @@ class SessionRunner:
         approval_resumed_kind: str | None = None,
         approval_decision: str | None = None,
         false_completion_check: bool = False,
+        sandbox_id: str | None = None,
+        telemetry: TelemetryLifecycle | None = None,
     ) -> None:
         self._factory = session_factory
         self._ceiling = ceiling
@@ -167,6 +188,17 @@ class SessionRunner:
         # resuming from, stamped onto the turn's OTel span. Authority-free,
         # like approval_resumed_kind -- it confers no capability.
         self._approval_decision = approval_decision
+        self._sandbox_id = sandbox_id
+        self._telemetry = telemetry
+        attach_logging = getattr(telemetry, "attach_logging", None)
+        if callable(attach_logging):
+            # Namespace-scoped and idempotent: runner diagnostics still
+            # propagate to their existing console handler, while the shared
+            # handler receives the same redacted records for correlation.
+            attach_logging(
+                logging.getLogger("curie_runner"),
+                default_level=logging.INFO,
+            )
         # Opt-in, observe-only false-completion check (#517): warn when a turn
         # ends DONE with a substantive answer but zero tool calls. Off by default.
         self._false_completion_check = false_completion_check
@@ -292,9 +324,57 @@ class SessionRunner:
         self._started = True
 
     async def close(self) -> None:
-        if self._session is not None:
-            await self._session.close()
-        self._tracer.shutdown()
+        try:
+            if self._session is not None:
+                await self._session.close()
+        finally:
+            if self._telemetry is None:
+                self._tracer.shutdown()
+            else:
+                await self._shutdown_telemetry()
+
+    async def flush_telemetry(self, timeout_millis: int = 500) -> bool:
+        """Best-effort bounded flush used before an event response reaches EOF."""
+
+        telemetry = self._telemetry
+        if telemetry is None:
+            return True
+        try:
+            with anyio.move_on_after(timeout_millis / 1000) as scope:
+                result = await anyio.to_thread.run_sync(
+                    lambda: telemetry.force_flush(timeout_millis=timeout_millis),
+                    abandon_on_cancel=True,
+                )
+            if scope.cancel_called:
+                logger.warning("telemetry flush timed out")
+                return False
+            return bool(result)
+        except Exception as exc:  # noqa: BLE001 - telemetry never changes turn outcome
+            logger.warning(
+                "telemetry flush failed error_class=%s", type(exc).__name__
+            )
+            return False
+
+    async def _shutdown_telemetry(self) -> bool:
+        """Shut down both telemetry signals within the process's two-second cap."""
+
+        telemetry = self._telemetry
+        assert telemetry is not None
+        try:
+            with anyio.move_on_after(2.0) as scope:
+                result = await anyio.to_thread.run_sync(
+                    lambda: telemetry.shutdown(timeout_millis=2_000),
+                    abandon_on_cancel=True,
+                )
+            if scope.cancel_called:
+                logger.warning("telemetry shutdown timed out")
+                return False
+            return bool(result)
+        except Exception as exc:  # noqa: BLE001 - cleanup remains best-effort
+            logger.warning(
+                "telemetry shutdown failed error_class=%s", type(exc).__name__
+            )
+            return False
 
     async def reset(self) -> None:
         """Discard the conversation and start a fresh model session (#550).
@@ -392,16 +472,19 @@ class SessionRunner:
                 self._session_id,
                 event.user,
                 approval_decision=self._approval_decision,
+                sandbox_id=self._sandbox_id,
             ) as gen:
                 try:
                     async for line in self._drive_turn(event, state, tracker, gen):
                         yield line
-                    logger.info(
-                        "turn end session=%s status=%s duration_ms=%d",
-                        self._session_id,
-                        self._status.value,
-                        int((time.monotonic() - start) * 1000),
-                    )
+                    gen.record_outcome(self._status)
+                    with gen.lifecycle_log_context():
+                        logger.info(
+                            "turn end session=%s status=%s duration_ms=%d",
+                            self._session_id,
+                            self._status.value,
+                            int((time.monotonic() - start) * 1000),
+                        )
                     # Persist the completed turn to the durable transcript so a
                     # restarted sandbox can rehydrate this thread (#20).
                     await self._record_turn(event, state)
@@ -412,15 +495,22 @@ class SessionRunner:
                     # stream. GeneratorExit (consumer disconnect) is a
                     # BaseException and is intentionally not caught here -- the
                     # finally handles that abandonment case.
-                    logger.error(
-                        "turn failed session=%s error_class=%s: %s duration_ms=%d",
-                        self._session_id,
-                        type(exc).__name__,
-                        exc,
-                        int((time.monotonic() - start) * 1000),
-                    )
                     self._turn_open = False
                     self._status = SessionStatus.CLASSIFIED_FAILURE
+                    gen.record_outcome(
+                        self._status,
+                        error_type=type(exc).__name__,
+                        exception_type=type(exc).__name__,
+                        exception_escaped=False,
+                    )
+                    with gen.lifecycle_log_context():
+                        logger.error(
+                            "turn failed session=%s error_class=%s: %s duration_ms=%d",
+                            self._session_id,
+                            type(exc).__name__,
+                            exc,
+                            int((time.monotonic() - start) * 1000),
+                        )
                     yield to_ndjson_line(
                         ErrorEvent(message=f"runner error: {exc}", classification="runner-error")
                     )

--- a/runner/tests/test_otel.py
+++ b/runner/tests/test_otel.py
@@ -201,27 +201,46 @@ def test_tracer_provider_built_with_endpoint() -> None:
     provider.shutdown()
 
 
-def test_resource_stamps_sandbox_id_when_present() -> None:
-    # The sandbox id (ACI CURIE_SANDBOX_ID) lets a trace be attributed to the
-    # concrete sandbox that produced it, not just the session.
-    otel = OtelConfig(endpoint="http://localhost:24318")
-    provider = build_tracer_provider(otel, "s1", "sandbox-abc")
-    assert provider is not None
-    attrs = provider.resource.attributes
-    assert attrs["curie.session_id"] == "s1"
-    assert attrs["curie.sandbox_id"] == "sandbox-abc"
-    provider.shutdown()
+def test_run_span_stamps_session_and_sandbox_ids_when_present() -> None:
+    # Per-turn ids belong on agent.run, not on the process-wide resource.
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    tracer = RunTracer(provider)
+
+    with tracer.run_span(
+        trace_name="curie-run:test",
+        model="fake-model",
+        session_id="s1",
+        sandbox_id="sandbox-abc",
+    ):
+        pass
+
+    root = {span.name: span for span in exporter.get_finished_spans()}["agent.run"]
+    assert root.attributes["curie.session_id"] == "s1"
+    assert root.attributes["curie.sandbox_id"] == "sandbox-abc"
 
 
-def test_resource_omits_sandbox_id_when_absent_or_empty() -> None:
-    # Absent (default) and empty-string sandbox ids are both omitted rather than
-    # stamped as an empty attribute value.
-    otel = OtelConfig(endpoint="http://localhost:24318")
+def test_run_span_omits_sandbox_id_when_absent_or_empty() -> None:
+    # Absent (default) and empty-string sandbox ids are both omitted from the
+    # turn span rather than stamped as an empty attribute value.
     for sandbox_id in (None, ""):
-        provider = build_tracer_provider(otel, "s1", sandbox_id)
-        assert provider is not None
-        assert "curie.sandbox_id" not in provider.resource.attributes
-        provider.shutdown()
+        exporter = InMemorySpanExporter()
+        provider = TracerProvider()
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+        tracer = RunTracer(provider)
+
+        with tracer.run_span(
+            trace_name="curie-run:test",
+            model="fake-model",
+            session_id="s1",
+            sandbox_id=sandbox_id,
+        ):
+            pass
+
+        root = {span.name: span for span in exporter.get_finished_spans()}["agent.run"]
+        assert root.attributes["curie.session_id"] == "s1"
+        assert "curie.sandbox_id" not in root.attributes
 
 
 def test_resource_stamps_schema_version() -> None:
@@ -287,16 +306,15 @@ def test_validator_strips_sequence_value_hiding_an_unscrubbed_secret() -> None:
     assert "langfuse.trace.name" not in finished.attributes
 
 
-def test_validator_keeps_a_clean_sequence_value() -> None:
-    # The recursion must not become a blanket "drop all sequences": a clean
-    # sequence on an allowed key is legitimate telemetry and survives.
+def test_validator_strips_clean_sequence_with_wrong_closed_schema_type() -> None:
+    # A clean sequence is still invalid for a key whose closed type is `str`.
     provider, exporter = _validated_exporter()
     tracer = provider.get_tracer("test")
     with tracer.start_as_current_span("agent.run") as span:
         span.set_attribute("langfuse.trace.name", ["curie-run:test", "clean"])
 
     (finished,) = exporter.get_finished_spans()
-    assert finished.attributes["langfuse.trace.name"] == ("curie-run:test", "clean")
+    assert "langfuse.trace.name" not in finished.attributes
 
 
 def test_validator_leaves_clean_allowed_attributes_untouched() -> None:

--- a/runner/tests/test_otel_schema_drift.py
+++ b/runner/tests/test_otel_schema_drift.py
@@ -42,6 +42,11 @@ def _committed_schema() -> dict:
     return json.loads(_SCHEMA_PATH.read_text())
 
 
+def _committed_runner_keys() -> dict[str, str]:
+    schema = _committed_schema()
+    return {**schema["shared"], **schema["services"]["curie-runner"]}
+
+
 def _assert_value_type(committed: dict, key: str, value: object, where: str = "") -> None:
     """Assert an emitted attribute's runtime type matches the committed type.
 
@@ -60,7 +65,7 @@ def _assert_value_type(committed: dict, key: str, value: object, where: str = ""
 
 
 def test_committed_schema_matches_the_enum() -> None:
-    committed_keys = _committed_schema()["keys"]
+    committed_keys = _committed_runner_keys()
     code_keys = {member.value: SPAN_ATTRIBUTE_VALUE_TYPES[member] for member in SpanAttributeKey}
     assert code_keys == committed_keys, (
         "SpanAttributeKey (otel.py) and the committed schema "
@@ -80,9 +85,9 @@ def test_declared_value_types_cover_exactly_the_enum() -> None:
         "SPAN_ATTRIBUTE_VALUE_TYPES (otel.py) must declare a value type for "
         "every SpanAttributeKey member, no more and no fewer."
     )
-    assert set(SPAN_ATTRIBUTE_VALUE_TYPES.values()) <= {"str", "int"}, (
-        "SPAN_ATTRIBUTE_VALUE_TYPES values must be one of {'str', 'int'} -- "
-        "the only value types the runner emits today."
+    assert set(SPAN_ATTRIBUTE_VALUE_TYPES.values()) <= {"str", "int", "bool"}, (
+        "SPAN_ATTRIBUTE_VALUE_TYPES values must be one of {'str', 'int', 'bool'}; "
+        "exact bool handling prevents Python's bool-is-an-int subtype trap."
     )
 
 
@@ -104,7 +109,7 @@ def test_a_real_run_only_emits_attributes_within_the_committed_schema() -> None:
     # that each emitted value's runtime type matches the committed type for
     # its key -- catching a call-site retype (e.g. emitting `model` as an int)
     # that forgot to update the declaration.
-    committed = _committed_schema()["keys"]
+    committed = _committed_runner_keys()
     committed_keys = set(committed)
     exporter = InMemorySpanExporter()
     provider = TracerProvider()
@@ -148,7 +153,7 @@ def test_every_declared_key_emits_its_committed_value_type() -> None:
     # the 4 resource-level keys via build_tracer_provider -- so a call-site
     # retype of any of the seven previously-unexercised keys (that also forgot
     # to update SPAN_ATTRIBUTE_VALUE_TYPES) fails here instead of slipping past.
-    committed = _committed_schema()["keys"]
+    committed = _committed_runner_keys()
     emitted: dict[str, object] = {}
 
     exporter = InMemorySpanExporter()

--- a/runner/tests/test_otel_schema_drift.py
+++ b/runner/tests/test_otel_schema_drift.py
@@ -26,14 +26,18 @@ import json
 from pathlib import Path
 
 import anyio
-from aci_protocol import Event, OtelConfig
-from curie_runner import RunTracer, SideEffectClassifier, build_tracer_provider
+import curie_telemetry.bootstrap as telemetry_bootstrap
+import pytest
+from aci_protocol import Event
+from curie_runner import RunTracer, SideEffectClassifier
 from curie_runner.fake import FakeModelSession
 from curie_runner.otel import SCHEMA_VERSION, SPAN_ATTRIBUTE_VALUE_TYPES, SpanAttributeKey
 from curie_runner.session import SessionRunner
+from curie_telemetry import configure
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import StatusCode
 
 _SCHEMA_PATH = Path(__file__).parent.parent / "schema" / "otel-attributes.schema.json"
 
@@ -144,53 +148,73 @@ def test_a_real_run_only_emits_attributes_within_the_committed_schema() -> None:
             _assert_value_type(committed, key, value, f"span {span.name!r} ")
 
 
-def test_every_declared_key_emits_its_committed_value_type() -> None:
-    # The real-run contract test above only exercises 9 of the 16 declared keys
-    # (the FakeModelSession default script never threads a session/sandbox id,
-    # an approval decision, or the prompt-cache usage fields through). This test
-    # closes that gap by driving every declared key through its real setter --
-    # the 12 span-level keys via RunTracer.run_span/record_usage/tool_span, and
-    # the 4 resource-level keys via build_tracer_provider -- so a call-site
-    # retype of any of the seven previously-unexercised keys (that also forgot
-    # to update SPAN_ATTRIBUTE_VALUE_TYPES) fails here instead of slipping past.
+def test_every_declared_key_emits_its_committed_value_type(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The real-run contract test above does not exercise every optional identity,
+    # error, or prompt-cache key. This test closes that gap by driving every
+    # declared key through its real setter: turn keys via RunTracer, error keys
+    # via a real failed run span, and process identity via the shared runtime.
     committed = _committed_runner_keys()
     emitted: dict[str, object] = {}
 
     exporter = InMemorySpanExporter()
-    provider = TracerProvider()
-    provider.add_span_processor(SimpleSpanProcessor(exporter))
-    tracer = RunTracer(provider)
+    monkeypatch.setenv(
+        "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+        "http://collector.example.test/v1/traces",
+    )
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL", "http/protobuf")
+    monkeypatch.setenv(
+        "OTEL_RESOURCE_ATTRIBUTES",
+        "deployment.environment.name=test",
+    )
+    monkeypatch.setattr(
+        telemetry_bootstrap,
+        "_trace_exporter",
+        lambda _protocol: exporter,
+    )
+    runtime = configure(service_name="curie-runner", service_version="test-version")
+    tracer = RunTracer(runtime.tracer)
 
-    with tracer.run_span(
-        trace_name="t",
-        model="fake-model",
-        session_id="s1",
-        user_id="U1",
-        approval_decision="approved",
-    ) as span:
-        span.record_usage(
-            {
-                "input_tokens": 1,
-                "output_tokens": 2,
-                "cache_read_input_tokens": 3,
-                "cache_creation_input_tokens": 4,
-            }
-        )
-        span.tool_span("Bash")
+    with pytest.raises(RuntimeError, match="placeholder telemetry failure"):
+        with tracer.run_span(
+            trace_name="t",
+            model="fake-model",
+            session_id="s1",
+            user_id="U1",
+            approval_decision="approved",
+            sandbox_id="sandbox-abc",
+        ) as span:
+            span.record_usage(
+                {
+                    "input_tokens": 1,
+                    "output_tokens": 2,
+                    "cache_read_input_tokens": 3,
+                    "cache_creation_input_tokens": 4,
+                }
+            )
+            span.tool_span("Bash")
+            raise RuntimeError("placeholder telemetry failure")
 
-    for finished in exporter.get_finished_spans():
+    assert runtime.force_flush(timeout_millis=500)
+    finished_spans = exporter.get_finished_spans()
+    failed_run = next(span for span in finished_spans if span.name == "agent.run")
+    assert failed_run.status.status_code is StatusCode.ERROR
+    assert failed_run.attributes is not None
+    assert failed_run.attributes["error.type"] == "RuntimeError"
+    assert failed_run.attributes["exception.type"] == "RuntimeError"
+    assert failed_run.attributes["exception.escaped"] is True
+    for finished in finished_spans:
         if finished.attributes:
             emitted.update(finished.attributes)
 
-    otel = OtelConfig(endpoint="http://localhost:24318")
-    resource_provider = build_tracer_provider(otel, "s1", "sandbox-abc")
-    assert resource_provider is not None
-    # The OTel SDK's own Resource.create() merges in ambient default attributes
-    # (telemetry.sdk.language/name/version) alongside the ones this module
-    # stamps; only the declared keys are this schema's concern.
+    resource_provider = getattr(runtime.tracer, "_tracer_provider", None)
+    assert isinstance(resource_provider, TracerProvider)
     resource_attrs = resource_provider.resource.attributes
-    emitted.update({key: value for key, value in resource_attrs.items() if key in committed})
-    resource_provider.shutdown()
+    emitted.update(
+        {key: value for key, value in resource_attrs.items() if key in committed}
+    )
+    runtime.shutdown(timeout_millis=2_000)
 
     exercised_keys = set(emitted)
     missing = set(committed) - exercised_keys

--- a/runner/tests/test_whole_turn_telemetry.py
+++ b/runner/tests/test_whole_turn_telemetry.py
@@ -268,6 +268,7 @@ def test_runner_export_boundary_is_recursively_redacted_and_service_closed(
 ) -> None:
     runtime = _runtime(monkeypatch, otlp_capture.endpoint)
     logger = logging.getLogger("curie-runner.telemetry-boundary-test")
+    runtime.attach_logging(logger)
 
     with runtime.tracer.start_as_current_span("agent.run") as span:
         span.set_attribute("curie.session_id", "safe-session")
@@ -410,7 +411,7 @@ def test_immediate_post_turn_process_termination_still_exports_agent_run(
                 {"max_output_tokens_per_run": 1000, "max_usd_per_day": 5.0}
             ),
             "CURIE_FAKE_MODEL": "1",
-            "CURIE_PORT": str(port),
+            "CURIE_RUNNER_PORT": str(port),
             "OTEL_EXPORTER_OTLP_ENDPOINT": otlp_capture.endpoint,
             "OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf",
             "PYTHONPATH": os.pathsep.join(

--- a/runner/tests/test_whole_turn_telemetry.py
+++ b/runner/tests/test_whole_turn_telemetry.py
@@ -31,7 +31,7 @@ from aiohttp.test_utils import TestClient, TestServer
 from curie_runner import RunTracer, SideEffectClassifier, create_app
 from curie_runner.fake import FakeModelSession
 from curie_runner.session import SessionRunner
-from curie_telemetry import TelemetryRuntime, configure
+from curie_telemetry import TelemetryRuntime, configure, emit_log_event
 from opentelemetry.proto.collector.logs.v1.logs_service_pb2 import (
     ExportLogsServiceRequest,
 )
@@ -195,7 +195,10 @@ def test_http_traceparent_is_the_direct_parent_of_agent_run_and_flushes_before_r
     runtime = _runtime(monkeypatch, otlp_capture.endpoint)
     events = _turn(
         _runner(runtime),
-        {"traceparent": f"00-{_TRACE_ID}-{_PARENT_ID}-01"},
+        {
+            "traceparent": f"00-{_TRACE_ID}-{_PARENT_ID}-01",
+            "tracestate": "vendor=OPAQUE_TRACE_STATE_SENTINEL",
+        },
     )
 
     assert events[-1].status is SessionStatus.DONE
@@ -203,10 +206,12 @@ def test_http_traceparent_is_the_direct_parent_of_agent_run_and_flushes_before_r
     assert agent.trace_id.hex() == _TRACE_ID
     assert agent.parent_span_id.hex() == _PARENT_ID
     assert agent.status.code == Status.STATUS_CODE_OK
+    assert agent.trace_state == ""
+    assert "OPAQUE_TRACE_STATE_SENTINEL" not in repr(otlp_capture.traces)
     assert any(
         record.trace_id == agent.trace_id
         and record.span_id == agent.span_id
-        and "turn end" in _body(record)
+        and _body(record) == "agent.run.completed"
         for record in _logs(otlp_capture)
     ), "the terminal runner log must be exported before the HTTP EOF is observable"
 
@@ -234,11 +239,17 @@ def test_missing_or_malformed_http_parent_is_a_safe_new_root(
         assert traceparent not in rendered
 
 
+_ARBITRARY_EXCEPTION = (
+    "review the quarterly plan; model output was incomplete; "
+    "tool exception calendar lookup failed"
+)
+
+
 class _ExplodingSession(FakeModelSession):
     async def receive_turn(self) -> Any:
         if False:  # make this an async generator while failing before its first item
             yield None
-        raise RuntimeError(f"provider rejected authorization={_FAKE_SECRET}")
+        raise RuntimeError(_ARBITRARY_EXCEPTION)
 
 
 def test_caught_failure_marks_agent_run_error_and_exports_a_redacted_correlated_log(
@@ -256,10 +267,26 @@ def test_caught_failure_marks_agent_run_error_and_exports_a_redacted_correlated_
         for record in _logs(otlp_capture)
         if record.trace_id == agent.trace_id and record.span_id == agent.span_id
     ]
-    assert any("turn failed" in _body(record) for record in correlated)
+    assert [_body(record) for record in correlated] == ["agent.run.failed"]
+    assert all(record.severity_text == "ERROR" for record in correlated)
     exported = repr(otlp_capture.traces) + repr(otlp_capture.logs)
     assert _FAKE_SECRET not in exported
-    assert "provider rejected" in exported, "redaction must not erase the useful error class"
+    assert _ARBITRARY_EXCEPTION not in exported
+
+
+def test_arbitrary_prompt_model_and_tool_exception_stays_in_stderr_only(
+    monkeypatch: pytest.MonkeyPatch,
+    otlp_capture: _OtlpCapture,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    runtime = _runtime(monkeypatch, otlp_capture.endpoint)
+    with caplog.at_level(logging.ERROR, logger="curie_runner.session"):
+        events = _turn(_runner(runtime, _ExplodingSession))
+
+    assert events[-1].status is SessionStatus.CLASSIFIED_FAILURE
+    assert any(_ARBITRARY_EXCEPTION in record.getMessage() for record in caplog.records)
+    assert _ARBITRARY_EXCEPTION not in repr(otlp_capture.logs)
+    assert [_body(record) for record in _logs(otlp_capture)] == ["agent.run.failed"]
 
 
 def test_runner_export_boundary_is_recursively_redacted_and_service_closed(
@@ -284,6 +311,7 @@ def test_runner_export_boundary_is_recursively_redacted_and_service_closed(
                 "unknown.attribute": _FAKE_SECRET,
             },
         )
+        emit_log_event(logger, "agent.run.failed", level=logging.ERROR)
     assert runtime.force_flush(timeout_millis=500)
 
     span_record = next(span for span in _spans(otlp_capture) if span.name == "agent.run")
@@ -292,11 +320,11 @@ def test_runner_export_boundary_is_recursively_redacted_and_service_closed(
     assert "messaging.system" not in span_attributes
     assert "unknown.attribute" not in span_attributes
     assert "langfuse.trace.name" not in span_attributes
-    log_record = next(record for record in _logs(otlp_capture) if "runner failed" in _body(record))
+    log_record = next(
+        record for record in _logs(otlp_capture) if _body(record) == "agent.run.failed"
+    )
     log_attributes = _attributes(log_record)
-    assert log_attributes.get("curie.session_id") == "safe-session"
-    assert "messaging.system" not in log_attributes
-    assert "unknown.attribute" not in log_attributes
+    assert log_attributes == {}, "curated log events carry correlation only, no values"
     assert _FAKE_SECRET not in repr(otlp_capture.traces)
     assert _FAKE_SECRET not in repr(otlp_capture.logs)
     runtime.shutdown(timeout_millis=2_000)

--- a/runner/tests/test_whole_turn_telemetry.py
+++ b/runner/tests/test_whole_turn_telemetry.py
@@ -42,7 +42,7 @@ from opentelemetry.proto.trace.v1.trace_pb2 import Status
 
 _TRACE_ID = "11111111111111111111111111111111"
 _PARENT_ID = "2222222222222222"
-_FAKE_SECRET = "sk-" + "FAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKE0000"
+_PRIVATE_MARKER = "sk-" + "FAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKE0000"
 _EVENT = {"kind": "event", "type": "message", "text": "hello", "user": "U", "ts": "1"}
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 
@@ -270,7 +270,7 @@ def test_caught_failure_marks_agent_run_error_and_exports_a_redacted_correlated_
     assert [_body(record) for record in correlated] == ["agent.run.failed"]
     assert all(record.severity_text == "ERROR" for record in correlated)
     exported = repr(otlp_capture.traces) + repr(otlp_capture.logs)
-    assert _FAKE_SECRET not in exported
+    assert _PRIVATE_MARKER not in exported
     assert _ARBITRARY_EXCEPTION not in exported
 
 
@@ -301,14 +301,14 @@ def test_runner_export_boundary_is_recursively_redacted_and_service_closed(
         span.set_attribute("curie.session_id", "safe-session")
         span.set_attribute("messaging.system", "otherwise-valid-for-another-service")
         span.set_attribute("unknown.attribute", "must-not-export")
-        span.set_attribute("langfuse.trace.name", ["safe", _FAKE_SECRET])
+        span.set_attribute("langfuse.trace.name", ["safe", _PRIVATE_MARKER])
         logger.error(
             "runner failed authorization=%s",
-            _FAKE_SECRET,
+            _PRIVATE_MARKER,
             extra={
                 "curie.session_id": "safe-session",
                 "messaging.system": "cross-service",
-                "unknown.attribute": _FAKE_SECRET,
+                "unknown.attribute": _PRIVATE_MARKER,
             },
         )
         emit_log_event(logger, "agent.run.failed", level=logging.ERROR)
@@ -325,8 +325,8 @@ def test_runner_export_boundary_is_recursively_redacted_and_service_closed(
     )
     log_attributes = _attributes(log_record)
     assert log_attributes == {}, "curated log events carry correlation only, no values"
-    assert _FAKE_SECRET not in repr(otlp_capture.traces)
-    assert _FAKE_SECRET not in repr(otlp_capture.logs)
+    assert _PRIVATE_MARKER not in repr(otlp_capture.traces)
+    assert _PRIVATE_MARKER not in repr(otlp_capture.logs)
     runtime.shutdown(timeout_millis=2_000)
 
 
@@ -341,7 +341,7 @@ class _OrderingRuntime:
     def force_flush(self, *, timeout_millis: int) -> bool:
         self.calls.append(f"flush:{timeout_millis}")
         if self.fail_flush:
-            raise RuntimeError(f"flush rejected authorization={_FAKE_SECRET}")
+            raise RuntimeError(f"flush rejected authorization={_PRIVATE_MARKER}")
         return True
 
     def shutdown(self, *, timeout_millis: int = 2_000) -> bool:
@@ -381,7 +381,7 @@ def test_flush_failure_is_redacted_and_does_not_reclassify_the_turn(
     assert events[-1].status is SessionStatus.DONE
     rendered = " ".join(record.getMessage() for record in caplog.records)
     assert "telemetry flush failed" in rendered
-    assert _FAKE_SECRET not in rendered
+    assert _PRIVATE_MARKER not in rendered
 
 
 def test_unreachable_exporter_cannot_hold_runner_cleanup_past_the_shutdown_cap(
@@ -497,4 +497,4 @@ def test_immediate_post_turn_process_termination_still_exports_agent_run(
     agent = next(span for span in _spans(otlp_capture) if span.name == "agent.run")
     assert agent.trace_id.hex() == _TRACE_ID
     assert agent.parent_span_id.hex() == _PARENT_ID
-    assert _FAKE_SECRET not in output
+    assert _PRIVATE_MARKER not in output

--- a/runner/tests/test_whole_turn_telemetry.py
+++ b/runner/tests/test_whole_turn_telemetry.py
@@ -1,0 +1,471 @@
+"""Runtime proofs for the runner's part of the whole-turn telemetry chain.
+
+These tests deliberately exercise the OTLP HTTP boundary.  Looking at provider
+configuration would not prove that the incoming HTTP parent survived until
+``agent.run``, that logs were correlated, or that the batch was flushed before
+the worker is allowed to tear the sandbox down.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import socket
+import subprocess
+import sys
+import threading
+import time
+import urllib.request
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+
+import anyio
+import pytest
+from aci_protocol import SessionStatus, parse_ndjson
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+from curie_runner import RunTracer, SideEffectClassifier, create_app
+from curie_runner.fake import FakeModelSession
+from curie_runner.session import SessionRunner
+from curie_telemetry import TelemetryRuntime, configure
+from opentelemetry.proto.collector.logs.v1.logs_service_pb2 import (
+    ExportLogsServiceRequest,
+)
+from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (
+    ExportTraceServiceRequest,
+)
+from opentelemetry.proto.trace.v1.trace_pb2 import Status
+
+_TRACE_ID = "11111111111111111111111111111111"
+_PARENT_ID = "2222222222222222"
+_FAKE_SECRET = "sk-" + "FAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKE0000"
+_EVENT = {"kind": "event", "type": "message", "text": "hello", "user": "U", "ts": "1"}
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+@dataclass
+class _OtlpCapture:
+    server: ThreadingHTTPServer
+    traces: list[ExportTraceServiceRequest] = field(default_factory=list)
+    logs: list[ExportLogsServiceRequest] = field(default_factory=list)
+    lock: threading.Lock = field(default_factory=threading.Lock)
+
+    @property
+    def endpoint(self) -> str:
+        host, port = self.server.server_address
+        return f"http://{host}:{port}"
+
+    def append(self, path: str, body: bytes) -> None:
+        with self.lock:
+            if path == "/v1/traces":
+                request = ExportTraceServiceRequest()
+                request.ParseFromString(body)
+                self.traces.append(request)
+                return
+            if path == "/v1/logs":
+                request = ExportLogsServiceRequest()
+                request.ParseFromString(body)
+                self.logs.append(request)
+                return
+            raise AssertionError(f"unexpected OTLP path: {path}")
+
+
+def _handler(capture_ref: list[_OtlpCapture]) -> type[BaseHTTPRequestHandler]:
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self) -> None:  # noqa: N802
+            body = self.rfile.read(int(self.headers.get("content-length", "0")))
+            capture_ref[0].append(self.path, body)
+            self.send_response(200)
+            self.end_headers()
+
+        def log_message(self, _format: str, *_args: object) -> None:
+            return
+
+    return Handler
+
+
+@pytest.fixture
+def otlp_capture() -> Iterator[_OtlpCapture]:
+    ref: list[_OtlpCapture] = []
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _handler(ref))
+    server.daemon_threads = True
+    capture = _OtlpCapture(server)
+    ref.append(capture)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield capture
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+@pytest.fixture(autouse=True)
+def clean_otel_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in tuple(os.environ):
+        if key.startswith("OTEL_"):
+            monkeypatch.delenv(key, raising=False)
+
+
+def _spans(capture: _OtlpCapture) -> list[Any]:
+    return [
+        span
+        for request in capture.traces
+        for resource_spans in request.resource_spans
+        for scope_spans in resource_spans.scope_spans
+        for span in scope_spans.spans
+    ]
+
+
+def _logs(capture: _OtlpCapture) -> list[Any]:
+    return [
+        record
+        for request in capture.logs
+        for resource_logs in request.resource_logs
+        for scope_logs in resource_logs.scope_logs
+        for record in scope_logs.log_records
+    ]
+
+
+def _body(record: Any) -> str:
+    return record.body.string_value
+
+
+def _value(value: Any) -> object:
+    kind = value.WhichOneof("value")
+    if kind == "string_value":
+        return value.string_value
+    if kind == "int_value":
+        return value.int_value
+    if kind == "bool_value":
+        return value.bool_value
+    if kind == "double_value":
+        return value.double_value
+    if kind == "array_value":
+        return tuple(_value(item) for item in value.array_value.values)
+    return None
+
+
+def _attributes(record: Any) -> dict[str, object]:
+    return {attribute.key: _value(attribute.value) for attribute in record.attributes}
+
+
+def _runtime(monkeypatch: pytest.MonkeyPatch, endpoint: str) -> TelemetryRuntime:
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", endpoint)
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf")
+    return configure(service_name="curie-runner", service_version="test")
+
+
+def _runner(
+    runtime: TelemetryRuntime,
+    session_factory: Any = FakeModelSession,
+) -> SessionRunner:
+    return SessionRunner(
+        session_factory=session_factory,
+        ceiling=0,
+        tracer=RunTracer(runtime.tracer),
+        classifier=SideEffectClassifier(),
+        trace_name="curie-run:agent-agent-example-thread-thread-example",
+        session_id="agent-agent-example-thread-thread-example",
+        model="fake-model",
+        telemetry=runtime,
+    )
+
+
+def _turn(runner: SessionRunner, headers: dict[str, str] | None = None) -> list[Any]:
+    async def go() -> list[Any]:
+        await runner.start()
+        async with TestClient(TestServer(create_app(runner))) as client:
+            response = await client.post("/v1/event", json=_EVENT, headers=headers)
+            assert response.status == 200
+            return parse_ndjson(await response.text())
+
+    return anyio.run(go)
+
+
+def test_http_traceparent_is_the_direct_parent_of_agent_run_and_flushes_before_reply(
+    monkeypatch: pytest.MonkeyPatch,
+    otlp_capture: _OtlpCapture,
+) -> None:
+    runtime = _runtime(monkeypatch, otlp_capture.endpoint)
+    events = _turn(
+        _runner(runtime),
+        {"traceparent": f"00-{_TRACE_ID}-{_PARENT_ID}-01"},
+    )
+
+    assert events[-1].status is SessionStatus.DONE
+    agent = next(span for span in _spans(otlp_capture) if span.name == "agent.run")
+    assert agent.trace_id.hex() == _TRACE_ID
+    assert agent.parent_span_id.hex() == _PARENT_ID
+    assert agent.status.code == Status.STATUS_CODE_OK
+    assert any(
+        record.trace_id == agent.trace_id
+        and record.span_id == agent.span_id
+        and "turn end" in _body(record)
+        for record in _logs(otlp_capture)
+    ), "the terminal runner log must be exported before the HTTP EOF is observable"
+
+
+@pytest.mark.parametrize("traceparent", [None, "00-not-a-valid-parent"])
+def test_missing_or_malformed_http_parent_is_a_safe_new_root(
+    monkeypatch: pytest.MonkeyPatch,
+    otlp_capture: _OtlpCapture,
+    caplog: pytest.LogCaptureFixture,
+    traceparent: str | None,
+) -> None:
+    runtime = _runtime(monkeypatch, otlp_capture.endpoint)
+    headers = {} if traceparent is None else {"traceparent": traceparent}
+    with caplog.at_level(logging.WARNING):
+        events = _turn(_runner(runtime), headers)
+
+    assert events[-1].status is SessionStatus.DONE
+    agent = next(span for span in _spans(otlp_capture) if span.name == "agent.run")
+    assert agent.parent_span_id == b""
+    rendered = " ".join(record.getMessage() for record in caplog.records)
+    if traceparent is None:
+        assert "ignored malformed trace context" not in rendered
+    else:
+        assert "ignored malformed trace context" in rendered
+        assert traceparent not in rendered
+
+
+class _ExplodingSession(FakeModelSession):
+    async def receive_turn(self) -> Any:
+        if False:  # make this an async generator while failing before its first item
+            yield None
+        raise RuntimeError(f"provider rejected authorization={_FAKE_SECRET}")
+
+
+def test_caught_failure_marks_agent_run_error_and_exports_a_redacted_correlated_log(
+    monkeypatch: pytest.MonkeyPatch,
+    otlp_capture: _OtlpCapture,
+) -> None:
+    runtime = _runtime(monkeypatch, otlp_capture.endpoint)
+    events = _turn(_runner(runtime, _ExplodingSession))
+
+    assert events[-1].status is SessionStatus.CLASSIFIED_FAILURE
+    agent = next(span for span in _spans(otlp_capture) if span.name == "agent.run")
+    assert agent.status.code == Status.STATUS_CODE_ERROR
+    correlated = [
+        record
+        for record in _logs(otlp_capture)
+        if record.trace_id == agent.trace_id and record.span_id == agent.span_id
+    ]
+    assert any("turn failed" in _body(record) for record in correlated)
+    exported = repr(otlp_capture.traces) + repr(otlp_capture.logs)
+    assert _FAKE_SECRET not in exported
+    assert "provider rejected" in exported, "redaction must not erase the useful error class"
+
+
+def test_runner_export_boundary_is_recursively_redacted_and_service_closed(
+    monkeypatch: pytest.MonkeyPatch,
+    otlp_capture: _OtlpCapture,
+) -> None:
+    runtime = _runtime(monkeypatch, otlp_capture.endpoint)
+    logger = logging.getLogger("curie-runner.telemetry-boundary-test")
+
+    with runtime.tracer.start_as_current_span("agent.run") as span:
+        span.set_attribute("curie.session_id", "safe-session")
+        span.set_attribute("messaging.system", "otherwise-valid-for-another-service")
+        span.set_attribute("unknown.attribute", "must-not-export")
+        span.set_attribute("langfuse.trace.name", ["safe", _FAKE_SECRET])
+        logger.error(
+            "runner failed authorization=%s",
+            _FAKE_SECRET,
+            extra={
+                "curie.session_id": "safe-session",
+                "messaging.system": "cross-service",
+                "unknown.attribute": _FAKE_SECRET,
+            },
+        )
+    assert runtime.force_flush(timeout_millis=500)
+
+    span_record = next(span for span in _spans(otlp_capture) if span.name == "agent.run")
+    span_attributes = _attributes(span_record)
+    assert span_attributes["curie.session_id"] == "safe-session"
+    assert "messaging.system" not in span_attributes
+    assert "unknown.attribute" not in span_attributes
+    assert "langfuse.trace.name" not in span_attributes
+    log_record = next(record for record in _logs(otlp_capture) if "runner failed" in _body(record))
+    log_attributes = _attributes(log_record)
+    assert log_attributes.get("curie.session_id") == "safe-session"
+    assert "messaging.system" not in log_attributes
+    assert "unknown.attribute" not in log_attributes
+    assert _FAKE_SECRET not in repr(otlp_capture.traces)
+    assert _FAKE_SECRET not in repr(otlp_capture.logs)
+    runtime.shutdown(timeout_millis=2_000)
+
+
+class _OrderingRuntime:
+    def __init__(self, calls: list[str], *, fail_flush: bool = False) -> None:
+        from opentelemetry import trace
+
+        self.tracer = trace.get_tracer("runner-ordering-test")
+        self.calls = calls
+        self.fail_flush = fail_flush
+
+    def force_flush(self, *, timeout_millis: int) -> bool:
+        self.calls.append(f"flush:{timeout_millis}")
+        if self.fail_flush:
+            raise RuntimeError(f"flush rejected authorization={_FAKE_SECRET}")
+        return True
+
+    def shutdown(self, *, timeout_millis: int = 2_000) -> bool:
+        self.calls.append(f"shutdown:{timeout_millis}")
+        return True
+
+
+def test_terminal_batch_flush_is_bounded_and_precedes_http_eof(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+    runtime = _OrderingRuntime(calls)
+    original = web.StreamResponse.write_eof
+
+    async def record_eof(self: web.StreamResponse, data: bytes = b"") -> None:
+        calls.append("eof")
+        await original(self, data)
+
+    monkeypatch.setattr(web.StreamResponse, "write_eof", record_eof)
+    events = _turn(_runner(runtime))  # type: ignore[arg-type]
+
+    assert events[-1].status is SessionStatus.DONE
+    flush_index = next(index for index, call in enumerate(calls) if call.startswith("flush:"))
+    eof_index = calls.index("eof")
+    assert flush_index < eof_index
+    assert int(calls[flush_index].partition(":")[2]) <= 500
+
+
+def test_flush_failure_is_redacted_and_does_not_reclassify_the_turn(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    runtime = _OrderingRuntime([], fail_flush=True)
+    with caplog.at_level(logging.WARNING):
+        events = _turn(_runner(runtime))  # type: ignore[arg-type]
+
+    assert events[-1].status is SessionStatus.DONE
+    rendered = " ".join(record.getMessage() for record in caplog.records)
+    assert "telemetry flush failed" in rendered
+    assert _FAKE_SECRET not in rendered
+
+
+def test_unreachable_exporter_cannot_hold_runner_cleanup_past_the_shutdown_cap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with socket.socket() as probe:
+        probe.bind(("127.0.0.1", 0))
+        endpoint = f"http://127.0.0.1:{probe.getsockname()[1]}"
+    runtime = _runtime(monkeypatch, endpoint)
+
+    started = time.monotonic()
+    events = _turn(_runner(runtime))
+    elapsed = time.monotonic() - started
+
+    assert events[-1].status is SessionStatus.DONE
+    assert elapsed < 3.0, "500ms pre-EOF flush plus 2s shutdown must remain bounded"
+
+
+def test_no_endpoint_keeps_diagnostics_but_installs_no_retrying_export_path(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    runtime = configure(service_name="curie-runner", service_version="test")
+
+    started = time.monotonic()
+    with caplog.at_level(logging.INFO):
+        events = _turn(_runner(runtime))
+    elapsed = time.monotonic() - started
+
+    assert events[-1].status is SessionStatus.DONE
+    assert any("turn end" in record.getMessage() for record in caplog.records)
+    assert not any("export" in record.getMessage().lower() for record in caplog.records)
+    assert elapsed < 1.0, "an unconfigured exporter must not add retry or shutdown delay"
+
+
+def _free_port() -> int:
+    with socket.socket() as probe:
+        probe.bind(("127.0.0.1", 0))
+        return int(probe.getsockname()[1])
+
+
+def test_immediate_post_turn_process_termination_still_exports_agent_run(
+    monkeypatch: pytest.MonkeyPatch,
+    otlp_capture: _OtlpCapture,
+) -> None:
+    """The worker may delete a runner as soon as EOF arrives; the span must predate EOF."""
+
+    port = _free_port()
+    env = os.environ.copy()
+    env.update(
+        {
+            "CURIE_PLUGIN_DIR": str(_REPO_ROOT / "examples/weather"),
+            "CURIE_SESSION_ID": "agent-agent-example-thread-thread-termination",
+            "CURIE_SANDBOX_ID": "sandbox-example",
+            "CURIE_BUDGET": json.dumps(
+                {"max_output_tokens_per_run": 1000, "max_usd_per_day": 5.0}
+            ),
+            "CURIE_FAKE_MODEL": "1",
+            "CURIE_PORT": str(port),
+            "OTEL_EXPORTER_OTLP_ENDPOINT": otlp_capture.endpoint,
+            "OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf",
+            "PYTHONPATH": os.pathsep.join(
+                [
+                    str(_REPO_ROOT / "runner/src"),
+                    str(_REPO_ROOT / "packages/aci-protocol/src"),
+                    str(_REPO_ROOT / "packages/plugin-format/src"),
+                    str(_REPO_ROOT / "packages/telemetry/src"),
+                    os.environ.get("PYTHONPATH", ""),
+                ]
+            ),
+        }
+    )
+    process = subprocess.Popen(  # noqa: S603 - fixed module in this checkout
+        [sys.executable, "-m", "curie_runner"],
+        cwd=_REPO_ROOT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    try:
+        deadline = time.monotonic() + 10
+        while True:
+            try:
+                with urllib.request.urlopen(  # noqa: S310 - loopback test server
+                    f"http://127.0.0.1:{port}/healthz", timeout=0.2
+                ) as response:
+                    if response.status == 200:
+                        break
+            except OSError:
+                if process.poll() is not None or time.monotonic() >= deadline:
+                    output = process.communicate(timeout=1)[0]
+                    raise AssertionError(f"runner did not become healthy:\n{output}") from None
+                time.sleep(0.05)
+
+        request = urllib.request.Request(  # noqa: S310 - loopback test server
+            f"http://127.0.0.1:{port}/v1/event",
+            data=json.dumps(_EVENT).encode(),
+            headers={
+                "content-type": "application/json",
+                "traceparent": f"00-{_TRACE_ID}-{_PARENT_ID}-01",
+            },
+            method="POST",
+        )
+        with urllib.request.urlopen(request, timeout=5) as response:  # noqa: S310
+            assert parse_ndjson(response.read().decode())[-1].status is SessionStatus.DONE
+        process.terminate()
+        output = process.communicate(timeout=3)[0]
+    finally:
+        if process.poll() is None:
+            process.kill()
+            process.wait(timeout=2)
+
+    agent = next(span for span in _spans(otlp_capture) if span.name == "agent.run")
+    assert agent.trace_id.hex() == _TRACE_ID
+    assert agent.parent_span_id.hex() == _PARENT_ID
+    assert _FAKE_SECRET not in output

--- a/uv.lock
+++ b/uv.lock
@@ -17,6 +17,7 @@ members = [
     "curie-dispatcher",
     "curie-doclint",
     "curie-runner",
+    "curie-telemetry",
     "curie-test-support",
     "curie-wire-tolerance-gate",
     "curie-worker",
@@ -535,6 +536,7 @@ dependencies = [
     { name = "asyncpg" },
     { name = "boto3" },
     { name = "boto3-stubs", extra = ["s3"] },
+    { name = "curie-telemetry" },
     { name = "fastapi" },
     { name = "httpx" },
     { name = "kubernetes" },
@@ -555,6 +557,7 @@ requires-dist = [
     { name = "asyncpg", specifier = ">=0.30" },
     { name = "boto3", specifier = ">=1.43.55" },
     { name = "boto3-stubs", extras = ["s3"], specifier = ">=1.43.57" },
+    { name = "curie-telemetry", editable = "packages/telemetry" },
     { name = "fastapi", specifier = ">=0.139.2" },
     { name = "httpx", specifier = ">=0.28" },
     { name = "kubernetes", specifier = ">=36.0.3" },
@@ -585,6 +588,7 @@ version = "0.0.0"
 source = { editable = "apps/dispatcher" }
 dependencies = [
     { name = "aci-protocol" },
+    { name = "curie-telemetry" },
     { name = "httpx" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -595,6 +599,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "aci-protocol", editable = "packages/aci-protocol" },
+    { name = "curie-telemetry", editable = "packages/telemetry" },
     { name = "httpx", specifier = ">=0.28" },
     { name = "pydantic", specifier = ">=2.10" },
     { name = "pydantic-settings", specifier = ">=2.15.0" },
@@ -626,6 +631,7 @@ dependencies = [
     { name = "aiohttp" },
     { name = "anyio" },
     { name = "claude-agent-sdk" },
+    { name = "curie-telemetry" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-sdk" },
     { name = "plugin-format" },
@@ -637,9 +643,27 @@ requires-dist = [
     { name = "aiohttp", specifier = ">=3.14.3" },
     { name = "anyio", specifier = ">=4.6" },
     { name = "claude-agent-sdk", specifier = ">=0.2.135" },
+    { name = "curie-telemetry", editable = "packages/telemetry" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.30" },
     { name = "opentelemetry-sdk", specifier = ">=1.44.0" },
     { name = "plugin-format", editable = "packages/plugin-format" },
+]
+
+[[package]]
+name = "curie-telemetry"
+version = "0.0.0"
+source = { editable = "packages/telemetry" }
+dependencies = [
+    { name = "opentelemetry-exporter-otlp-proto-grpc" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-sdk" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "opentelemetry-exporter-otlp-proto-grpc", specifier = ">=1.44.0,<1.45.0" },
+    { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.44.0,<1.45.0" },
+    { name = "opentelemetry-sdk", specifier = ">=1.44.0,<1.45.0" },
 ]
 
 [[package]]
@@ -673,6 +697,7 @@ dependencies = [
     { name = "boto3" },
     { name = "curie-channel-protocol" },
     { name = "curie-dispatcher" },
+    { name = "curie-telemetry" },
     { name = "httpx" },
     { name = "kubernetes" },
     { name = "plugin-format" },
@@ -691,6 +716,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.43.55" },
     { name = "curie-channel-protocol", editable = "packages/channel-protocol" },
     { name = "curie-dispatcher", editable = "apps/dispatcher" },
+    { name = "curie-telemetry", editable = "packages/telemetry" },
     { name = "httpx", specifier = ">=0.28" },
     { name = "kubernetes", specifier = ">=36.0.3" },
     { name = "plugin-format", editable = "packages/plugin-format" },
@@ -711,6 +737,7 @@ dependencies = [
     { name = "curie-channel-protocol" },
     { name = "curie-dispatcher" },
     { name = "curie-runner" },
+    { name = "curie-telemetry" },
     { name = "curie-worker" },
     { name = "plugin-format" },
 ]
@@ -737,6 +764,7 @@ requires-dist = [
     { name = "curie-channel-protocol", editable = "packages/channel-protocol" },
     { name = "curie-dispatcher", editable = "apps/dispatcher" },
     { name = "curie-runner", editable = "runner" },
+    { name = "curie-telemetry", editable = "packages/telemetry" },
     { name = "curie-worker", editable = "apps/worker" },
     { name = "plugin-format", editable = "packages/plugin-format" },
 ]
@@ -971,6 +999,37 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/00/ac/05d859a62ed9282f43a0f0962da230c46a2eb3d3ecb5b39117b3b4888405/grimp-3.15-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fcc2e5065d35047729e41a55c9c3eb99810cf322fe3b3e89fa126f306ce6b3b5", size = 2273647, upload-time = "2026-07-03T12:08:36.139Z" },
     { url = "https://files.pythonhosted.org/packages/6d/dd/f726316f54e29da4f24d545d6299e1ea0accfbbf52729077fd4a619de055/grimp-3.15-cp315-cp315t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b38327673df49203cff0ebcbbf078999a80f0b11bb654760059f6f00f56f64d6", size = 2344080, upload-time = "2026-07-03T12:08:25.044Z" },
     { url = "https://files.pythonhosted.org/packages/c1/56/523a8f969f0a0b0a8ce43fbe8bc7a04e90f52724efc85f3305f1e07ae626/grimp-3.15-cp315-cp315t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:965b37dad2f73164a103381c9fd1255bb3b2f6021ca2f38ffe70dd00fdc0fc55", size = 2275041, upload-time = "2026-07-03T12:08:37.582Z" },
+]
+
+[[package]]
+name = "grpcio"
+version = "1.83.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0c/98/304898ac4e04e2d5e4e4c2eadc178b1f2a16d5f4bc2f91306c87d64680b9/grpcio-1.83.0.tar.gz", hash = "sha256:7674587248fbbb2ac6e4eecf83a8a0f3d91a928f941de571acfd3a2f007fbc24", size = 13428824, upload-time = "2026-07-23T15:20:37.759Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/eb/135daaa713f32d33b8f99b4153b3f8dc3b2a124996ac15581bf9ebdad3c3/grpcio-1.83.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:6662f3b1e07cc7493d437351860dc867bddc6a93c83ecf33bbfdaf0c217ab2d0", size = 6304480, upload-time = "2026-07-23T15:19:53.962Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/a1/121806ce69f23138dabe06aa595b0e5f1ae051a37e4c1954eed7d692c800/grpcio-1.83.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:74fe6f9e8a35c7dbf32255ee154d15e3e5338a81ed39173d079d594d2e544cd1", size = 12154419, upload-time = "2026-07-23T15:19:56.3Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/e8/d0389e09cd6b4c4d3089b92967ae4e3ffd64795bd349bf2f85cd6656d3da/grpcio-1.83.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:10b3fa0475eb572c9a81a6fe37fa16a9c500c0c91cfc148cac15692b7e3c2867", size = 6873200, upload-time = "2026-07-23T15:19:58.701Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/51/f464c1d211fa50d5adbabe1b2e519948d99c13757052bfc9ea7afa28e284/grpcio-1.83.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:5f20a988480b0f28207f057f7f7ae1313393c3cef0adcfeae8248f9947eaf881", size = 7618811, upload-time = "2026-07-23T15:20:00.733Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/c0/539fe0832f2dd6500a28f5263071623fb34e8d4867aec632ccf81bd21156/grpcio-1.83.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7bd82671b39065ba18cd536e9cd45b27ff649053f81ddd2c6a966d595067080f", size = 7042310, upload-time = "2026-07-23T15:20:02.675Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/ca/ccf617d37ffa72567fa8e005ec7090c99da922799be2fb9847c8b21ca18c/grpcio-1.83.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bc60215b5cb9fc8ca72942c498b551ac2305bd08f6ef8d4e3f0d21b64fbecd61", size = 7575412, upload-time = "2026-07-23T15:20:04.712Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/b9/fd8d5245f823a8e0fd35d90e20ea3aa4acd47f8d5318fa8df307df52dec6/grpcio-1.83.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:f1c3e5689d4b90987b1d72022bcfe866a9a3dc66197484cf856d96b6150e7f45", size = 8604248, upload-time = "2026-07-23T15:20:06.77Z" },
+    { url = "https://files.pythonhosted.org/packages/14/1e/f37632fc11db72dfa4bba86c3a43e54358e53030df111ecae5e91a733ad6/grpcio-1.83.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a21cb4eeeba124443f399be2e8b624943cde864dcbe588cb42e5c483a52a906c", size = 7977458, upload-time = "2026-07-23T15:20:09.109Z" },
+    { url = "https://files.pythonhosted.org/packages/93/b6/d70b69ae5c0cfc341b9ba474980e4ed99cbf05c0e4a14e9eee8cb73db0a5/grpcio-1.83.0-cp313-cp313-win32.whl", hash = "sha256:8fe04f1050a59f875601eb55d42b4f66946fe89817f967e34db1462ccd07dadf", size = 4393993, upload-time = "2026-07-23T15:20:11.017Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/13/45d4cccb555cf4c476226979bf3d2fd0b0254216f7564c3a053e35117efc/grpcio-1.83.0-cp313-cp313-win_amd64.whl", hash = "sha256:6e01ecd9d8ef280abe1365138a4dc318f9a5287f4cb1b41d07816f796653f735", size = 5159650, upload-time = "2026-07-23T15:20:12.979Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/60/f2cca8147ea213d3e43ae9158d03ad04e020fdf32ff027253e1fe93f921d/grpcio-1.83.0-cp314-cp314-linux_armv7l.whl", hash = "sha256:3f351629f6ae16ecc0ec3553e586a6763ffd9f6114044286d0cbec3e09241bfa", size = 6305607, upload-time = "2026-07-23T15:20:15.353Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/ab/d3874931d123a95e83a3ebf8aa04537988fb62425cedb8bf3cefc5ad41b2/grpcio-1.83.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d05ff664100d429335b93c91b8b34ddf9e94a112205e7fa06dede309e44a4e4c", size = 12166617, upload-time = "2026-07-23T15:20:17.435Z" },
+    { url = "https://files.pythonhosted.org/packages/92/ff/6f18f9426b69306f4e00a9add3b0ee2748da8aad53836ef80cab0d62d04f/grpcio-1.83.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7936f2a56cf04f6514705c0fedf400971de01b6aa1719327e4718f410a765e2b", size = 6880213, upload-time = "2026-07-23T15:20:19.98Z" },
+    { url = "https://files.pythonhosted.org/packages/70/21/706d1147c6b93b98f179240c13991fbcc56880eba0c868abb1ad40d8a0a6/grpcio-1.83.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:b0a0be840e51b6b7ee9df9269770faf77bdf4b771053c257c21d12bad607714c", size = 7618335, upload-time = "2026-07-23T15:20:22.161Z" },
+    { url = "https://files.pythonhosted.org/packages/74/04/1a8443c889115ec9e213a213e86bc93a71ee9088027e5befa09aaa0edd9d/grpcio-1.83.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:009667eaf3dcd5224c713589cdc98e7ca4ed0ff0b61132c6b276e930eb83a2df", size = 7043416, upload-time = "2026-07-23T15:20:24.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/c6/94e0fee5b12bc1da1370185b680988db6f739d19b42d9959db01a7ea50bf/grpcio-1.83.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:bb669918fd88936b15599caff4160a77ab74bdeb25f2231f6e45b61282d6107b", size = 7583253, upload-time = "2026-07-23T15:20:26.313Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/97/de1ccb671fb85575bc5192faedf9ecdbdf5b390d2e6584dcf552bcbd370e/grpcio-1.83.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:c19b454d3d3f28db81f2c7c4dbaee96e7f6fd149721733ffe79d6bc530f17404", size = 8605102, upload-time = "2026-07-23T15:20:28.437Z" },
+    { url = "https://files.pythonhosted.org/packages/17/0f/0e0ec749a7034ffcbaa050e39779872950ead90c22e7e0116be3f28b2b46/grpcio-1.83.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:61007cd08640abc5c54547ee32505474c482cd733a53cb87551ea81faa6350af", size = 7979826, upload-time = "2026-07-23T15:20:31.182Z" },
+    { url = "https://files.pythonhosted.org/packages/83/fa/c3fda157287f64bc65acee6c5aa90c41acf9e0d3a8e69a265eecff6d00a1/grpcio-1.83.0-cp314-cp314-win32.whl", hash = "sha256:32e11c37f5285b0c6fa3042c05fe06903696689749833fc64e67dec71b9bbe33", size = 4471765, upload-time = "2026-07-23T15:20:33.195Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/00/b1b26431c9d54eee11724fd6e5585473a2ed47fbc1fb95e5204906a642ce/grpcio-1.83.0-cp314-cp314-win_amd64.whl", hash = "sha256:2bb48cb5e6dd005ca12b89ce4b6ac0b48ff3112c747542ee7986ef611a8ca6d9", size = 5298932, upload-time = "2026-07-23T15:20:35.48Z" },
 ]
 
 [[package]]
@@ -1465,6 +1524,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/61/09/4d717852c1cf3f854b76c7110a5d00883bc3c99288b9b0dbcbeb9e306eb6/opentelemetry_exporter_otlp_proto_common-1.44.0.tar.gz", hash = "sha256:dc87a5a5bc58f149a56d1547e4691588fa12994cdc3bc039a694ccb3375862ac", size = 20202, upload-time = "2026-07-16T15:25:37.658Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5e/71/65fd9d54c10b860f87c045ccee1264cab7011268895d3528818a29c1172a/opentelemetry_exporter_otlp_proto_common-1.44.0-py3-none-any.whl", hash = "sha256:9a9fe61bba73d802904bc989f1d6b4a7b1ee40f06c40e98d6f85af65aaebb694", size = 17045, upload-time = "2026-07-16T15:25:18.201Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-grpc"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "grpcio" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/47/80d9e9d468dc5de3af5096f5ccdb065fa4dd1470f74495cc53e59e397f47/opentelemetry_exporter_otlp_proto_grpc-1.44.0.tar.gz", hash = "sha256:40d1ae9e03fcc36de3cbac610cc99f35894938bff9cfd90fc4ec68bd85448463", size = 27225, upload-time = "2026-07-16T15:25:38.308Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/29/6ae42ba32b153ae0a44ae125f0caff2188bbe62d99c82d1768da30864e72/opentelemetry_exporter_otlp_proto_grpc-1.44.0-py3-none-any.whl", hash = "sha256:6a1a645ea182a2f59440c51fa8301d309f3324a8f9d65f8395584b064b67ee4e", size = 19624, upload-time = "2026-07-16T15:25:19.096Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Carry one causal, trace-correlated OTEL signal across Curie's platform turn lifecycle. API, dispatcher, worker, and runner now share a bounded OTLP trace/log bootstrap; W3C context crosses the Valkey Stream as optional transport metadata and worker-to-runner HTTP as headers; worker routing, sandbox lifecycle, `agent.run`, replies, retries, and terminal outcomes are instrumented with a closed redacted attribute/log vocabulary. Existing stderr diagnostics and no-endpoint behavior remain intact, and neither frozen package nor `QueuedTurn` changed.

`curie local message` intentionally writes directly to Valkey and therefore has no dispatcher ancestor. The local ladder reports that topology honestly and drives a second turn through the real dispatcher handler, real Valkey boundary, real worker/sandbox/runner path, and real HTTP reply sink. This proves the full dispatcher-rooted causal chain without inventing a dispatcher span on the CLI path or requiring Slack Socket Mode.

## Related issue

Closes #1817

## Fix pin verification

Fix pin: apps/worker/tests/kernel/test_runner_client.py::test_runner_http_injects_w3c_separately_from_auth_and_never_baggage

- Candidate baseline: `1 passed`.
- Product reversal: the selected test failed inside its own node because the worker-to-runner tracing seam (including the injected tracer) was absent.
- Result: `PINNED`.

## End-to-end verification

Candidate: `c50b1e93e13f8a3f3e241e46d9ca74b5f086af58`

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | No plugin/skill packaging or skill command surface changed; runner behavior is exercised through the required local product loop and focused runner conformance tests. | fake | `runner/tests/test_whole_turn_telemetry.py`: included in `FOCUSED_RESULT`. |
| local | required | The change crosses API, dispatcher, Valkey, worker, sandbox/runner HTTP, runner, and reply boundaries. | fake | `CURIE_E2E_TIERS=local curie dev e2e-ladder` — `LADDER PASS (tiers: local)`. |
| local-release | n/a | No generated release-compose output, released artifact, version, or install path changed. The generator anchor consumes the new dev-only image override and strips it back to the existing literal release pin, covered by its exact-output tests. | n/a | Runtime surface unchanged. |
| cluster | required | Helm templates and sandbox boot environment changed. | fake | `scripts/chart-runtime-e2e.sh --force --namespace curie-1817-runtime-e2e --release curie-1817-runtime --runner-image busybox:1.36` — real kind install completed both bundle init containers, found `plugin.json`, verified credential isolation, and printed `PASS`; the disposable `curie-1817-runtime` cluster was deleted. |
| live provider | n/a | Model/provider routing, credentials, tokens, and cost telemetry are explicitly unchanged; the fake runner deterministically exercises success and failure. | n/a | Surface not reached. |
| external integration | n/a | Slack Socket Mode and third-party API shape are unchanged; the dispatcher producer uses the real handler/Valkey seam with only Slack posting replaced by the local HTTP sink. | n/a | Surface not reached. |

Positive and falsifiable-negative observations from the local ladder:

- Candidate identity: `local: candidate API, worker overlay, and runner image selection verified` before evidence collection.
- Positive topology 1: `otel-e2e topology=cli outcome=success: causal tree and logs verified` across API enqueue, Valkey, worker, sandbox, runner HTTP, `agent.run`, and reply completion.
- Positive topology 2: `otel-e2e topology=dispatcher outcome=success: causal tree and logs verified` across dispatcher enqueue and the same downstream causal path.
- Missing carrier: payload completed and worker opened a valid root.
- Malformed carrier: payload completed, a value-free warning was trace-correlated, and the injected private sentinel was absent.
- Runner failure: `agent.run` and the process trace were ERROR with an ERROR-severity log on the failing span; the recovery turn was OK/success.
- Redaction: a secret-shaped value passed through prompt/log/attribute boundaries was absent from collected spans and logs while safe correlation remained.
- No endpoint: API, dispatcher, worker, and runner composition roots completed boot/span/flush/shutdown probes and the disposable sink received `no records`.

Package and repository evidence:

- Root Python CI baseline: `3553 passed, 11 skipped, 33 warnings` after lock, Alembic, Ruff, mypy, import-linter, docs, and wire checks.
- Focused telemetry/API/dispatcher/worker/runner tests: `188 passed`; full worker suite: `896 passed, 7 skipped`.
- Rust CLI: `cargo fmt --check`, `cargo clippy -- -D warnings`, and the complete `cargo test` suite passed, including all 23 ladder contract tests.
- Helm: `helm lint`, render checks, and all 23 chart assertions passed; runtime result is recorded above.
- `uv lock --check`, Alembic revision check, Ruff, mypy (`195 source files`), import-linter, docs, wire-tolerance, diff/commit-message checks passed.
- Pinned gitleaks v8.30.1 scanned all 8 candidate commits (`332.20 KB`): `no leaks found`.

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved.

## Checklist

- [x] Tests pass for the area I touched.
- [x] Docs updated for the emitted topology, transport carrier, privacy vocabulary, and collector logs pipeline.
- [x] No ADR was changed or added; this implements the accepted issue contract without changing a frozen/public contract.
