### PR TITLE
Fail closed for Valkey tests in Python CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,8 @@ jobs:
   python:
     name: Python (ruff + mypy + pytest)
     runs-on: ubuntu-latest
+    env:
+      CI_REQUIRE_VALKEY_TESTS: "1"
     steps:
       - uses: actions/checkout@v7
         with:
@@ -101,8 +103,8 @@ jobs:
             langfuse-web langfuse-worker otel-collector
       # Langfuse web has no compose healthcheck, so --wait returns once its
       # container is merely running. Poll its public health endpoint until it is
-      # actually serving; the Langfuse-backed tests skip themselves when the
-      # stack is unreachable, so this gate is what keeps them running for real.
+      # actually serving, so the full-stack readiness gate fails fast with an
+      # actionable error before integration tests begin.
       - name: Wait for Langfuse to serve
         run: |
           for i in $(seq 1 60); do

--- a/packages/test-support/src/curie_test_support/valkey.py
+++ b/packages/test-support/src/curie_test_support/valkey.py
@@ -2,8 +2,9 @@
 
 The three constants read the same env vars with the same compose defaults every
 test site used before consolidation (compose.dev.yaml maps Valkey to host port
-26379, password ``valkeypass``); ``connect_or_skip`` is the sync build+ping+skip
-block those sites duplicated.
+26379, password ``valkeypass``); ``connect_or_skip`` is the sync build+ping
+block those sites duplicated. Local developer loops can skip an unreachable
+Valkey, but required CI must surface the original connection error.
 """
 
 from __future__ import annotations
@@ -19,11 +20,13 @@ VALKEY_PW = os.environ.get("TEST_VALKEY_PW", "valkeypass")
 
 
 def connect_or_skip(*, decode_responses: bool = True) -> redis.Redis:
-    """A sync Valkey client against the compose stack, or ``pytest.skip``.
+    """Connect to the compose Valkey, skipping only in optional local loops.
 
     Builds a ``redis.Redis`` on the shared ``TEST_VALKEY_*`` connection params,
-    pings it, and skips the test when Valkey is unreachable. The caller owns the
-    returned client (yield it from a fixture and ``.close()`` on teardown).
+    then pings it. An unreachable Valkey skips a local test only when
+    ``CI_REQUIRE_VALKEY_TESTS`` is absent. Its presence makes the original
+    ``RedisError`` fail the required CI job instead. The caller owns the returned
+    client (yield it from a fixture and ``.close()`` on teardown).
     """
     client: redis.Redis = redis.Redis(
         host=VALKEY_HOST,
@@ -34,5 +37,7 @@ def connect_or_skip(*, decode_responses: bool = True) -> redis.Redis:
     try:
         client.ping()
     except redis.exceptions.RedisError as exc:
+        if "CI_REQUIRE_VALKEY_TESTS" in os.environ:
+            raise
         pytest.skip(f"Valkey not reachable at {VALKEY_HOST}:{VALKEY_PORT}: {exc}")
     return client

--- a/packages/test-support/tests/test_valkey.py
+++ b/packages/test-support/tests/test_valkey.py
@@ -1,0 +1,40 @@
+"""Contract tests for the shared Valkey test helper."""
+
+from __future__ import annotations
+
+import socket
+
+import pytest
+import redis
+from curie_test_support import valkey
+
+
+def _configure_unreachable_valkey(monkeypatch: pytest.MonkeyPatch) -> socket.socket:
+    """Bind a loopback port without listening, preventing a port-reuse race."""
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.bind(("127.0.0.1", 0))
+    monkeypatch.setattr(valkey, "VALKEY_HOST", "127.0.0.1")
+    monkeypatch.setattr(valkey, "VALKEY_PORT", int(listener.getsockname()[1]))
+    return listener
+
+
+def test_connect_or_skip_skips_an_unreachable_valkey_locally(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("CI_REQUIRE_VALKEY_TESTS", raising=False)
+    listener = _configure_unreachable_valkey(monkeypatch)
+
+    with listener:
+        with pytest.raises(pytest.skip.Exception, match="Valkey not reachable"):
+            valkey.connect_or_skip()
+
+
+def test_connect_or_skip_fails_for_an_unreachable_valkey_when_required(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CI_REQUIRE_VALKEY_TESTS", "")
+    listener = _configure_unreachable_valkey(monkeypatch)
+
+    with listener:
+        with pytest.raises(redis.exceptions.ConnectionError):
+            valkey.connect_or_skip()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,6 +149,7 @@ testpaths = [
     "packages/aci-protocol/tests",
     "packages/channel-protocol/tests",
     "packages/plugin-format/tests",
+    "packages/test-support/tests",
     "apps/api/tests",
     "apps/dispatcher/tests",
     "apps/worker/tests",

--- a/release/tests/test_authorize.py
+++ b/release/tests/test_authorize.py
@@ -905,6 +905,14 @@ class TestRustValkeyWorkflowContract:
         assert "26379:6379" in valkey["ports"]
 
 
+class TestPythonValkeyWorkflowContract:
+    def test_python_job_requires_valkey_guarded_tests(self):
+        workflow = yaml.safe_load(CI_YAML.read_text())
+        python = workflow["jobs"]["python"]
+
+        assert python["env"]["CI_REQUIRE_VALKEY_TESTS"] == "1"
+
+
 class TestHelmCiCheckRunNames:
     def test_expands_matrix_include_rows(self, tmp_path, monkeypatch):
         workflow = tmp_path / "helm-ci.yaml"


### PR DESCRIPTION
Closes #1755

## Summary

* Makes unreachable Valkey fail the required Python CI job while preserving local skip loops.
* Adds default-collected guard and CI workflow regression coverage.
* Corrects the stale Langfuse readiness comment.

## Done check

- [x] Focused tests, lint, and mypy pass.
- [x] Closed-port required mode exits nonzero; local mode skips.
- [x] Code and scope review completed with no remaining findings.
- [x] Rust CI job unchanged; Python helper is the shared seam.