### PR TITLE
Fix sre-bot write-path docs that failed live E2E contact

### DIFF
--- a/examples/sre-bot/README.md
+++ b/examples/sre-bot/README.md
@@ -18,9 +18,11 @@ yourself.
 
 **Read-only operation remains the default.** The Kubernetes read connector is
 on. The one write connector and its exact approval gate ship declared together,
-so the tool cannot be enabled without its gate. Its separate
-`K8S_WRITE_KUBECONFIG` does not ship, so an untouched bring-up refuses cleanly
-before any connector starts instead of silently acquiring write access.
+so the tool cannot be enabled without its gate. On a genuinely untouched
+bring-up, `cluster deploy` refuses on the unbuilt `connectors.lock.yaml` before
+it ever reaches the secret check; once built, the still-missing separate
+`K8S_WRITE_KUBECONFIG` refuses just as cleanly before any connector starts,
+instead of silently acquiring write access.
 
 Completing the deliberate setup gives the bot exactly one thing it can change:
 rolling one allowlisted Deployment behind a human approval card. See
@@ -132,6 +134,21 @@ and deploy from the declaration.
 Read the four-layer table above before starting, and
 [`manifests/write-role.yaml`](manifests/write-role.yaml) before applying it.
 
+**Prerequisite: both kubeconfigs must be available to a manual `cluster
+deploy`.** `cluster deploy` refuses unless BOTH `K8S_READONLY_KUBECONFIG` and
+`K8S_WRITE_KUBECONFIG` are available -- exported in the environment or stored
+with `curie secrets set` -- the bundle declares both `secret_files` entries
+regardless of which path you're bringing up. This holds even on an
+install where `curie example sre-bot install` already ran: Quick-deploy mints
+the read-only kubeconfig and passes it to its own deploy as a one-off secret
+override, but never persists it to the host vault, so a later manual `cluster
+deploy` still needs `K8S_READONLY_KUBECONFIG` supplied in the environment or
+stored yourself. Apply
+[`manifests/read-access.yaml`](manifests/read-access.yaml) if it isn't already
+applied, then assemble and store `K8S_READONLY_KUBECONFIG` from its
+`sre-bot-reader-token` Secret the same way step 2 below builds the write
+kubeconfig from `sre-bot-writer-token`.
+
 **1. Scope and create the write identity.**
 
 Edit the namespace and the `resourceNames` list in
@@ -182,11 +199,21 @@ kubectl auth can-i --as=system:serviceaccount:"$NS":sre-bot-writer \
 ```
 
 **The credential comes before bring-up, and that order is load-bearing.** The
-declared `secret_files` entry has no bundled value. Without a stored
-`K8S_WRITE_KUBECONFIG`, bring-up refuses cleanly before any connector starts.
-The writer can never fall back to the read-only connector's credential.
+declared `secret_files` entry has no bundled value. On a genuinely untouched
+bring-up -- before `curie build` has ever run -- `cluster deploy` refuses on
+the unbuilt `connectors.lock.yaml` before it reaches the secret check at all.
+Once built (next step) with `K8S_WRITE_KUBECONFIG` still unstored, the bundle
+publishes to the API first and only then does deploy refuse cleanly on the
+missing secret, before any connector object is applied. The writer can never
+fall back to the read-only connector's credential.
 
 **3. Build the connector image.**
+
+**Needs a buildx driver that supports multi-platform builds.** The declaration
+builds both `linux/amd64` and `linux/arm64`, and the stock `docker` driver
+refuses that with `Multi-platform build is not supported for the docker
+driver`. Unblock it once with `docker buildx create --driver docker-container
+--use` (or enable the containerd image store).
 
 ```bash
 curie build --plugin-dir examples/sre-bot --registry <registry-reference>
@@ -251,6 +278,16 @@ curie cluster approvals sre-bot --resolve <approval-id> --as <someone-else> --ac
 
 `--as` must not name the requester. Raise `--timeout-secs` further if a human is
 doing the deciding rather than you in the next terminal.
+
+To reject instead, add `--reject`:
+
+```bash
+curie cluster approvals sre-bot --resolve <approval-id> --as <someone-else> \
+  --actor-channel C0EXAMPLE1 --reject
+```
+
+Shell 1's requester gets a no-action reply ("I won't retry it -- no rollout was
+triggered, and the deployment is unchanged") and nothing rolls.
 
 The resumed reply must verify with Kubernetes reads: new pods, their ages, and
 relevant events. A successful write response proves only that the patch was
@@ -404,13 +441,30 @@ failure than the one you were fixing.
 
 **`curie cluster message` hangs for the whole timeout, and the worker log says
 `UntrustedSlackEndpointError: refusing to send the Slack bot token to
-http://...`.** A previous `curie cluster comms --slack` recorded a bot token in
-the release, and `cluster up` preserves it across upgrades. `cluster message`
-serves its reply through a per-turn stub on your machine, and the worker will
-not hand a Slack bot token to an endpoint that is not Slack, so it refuses to
-deliver and the CLI waits forever. This is a platform bug rather than anything in
-this bundle, and it bites anyone who tries Slack first and the CLI second. Clear
-the recorded tokens:
+http://...`.** `cluster message` serves its reply through a per-turn stub on
+your machine, and the worker refuses to hand the Slack bot token to *any*
+reply endpoint whose origin is not in `CURIE_SLACK_TRUSTED_ORIGINS` -- it does
+not matter whether a token is even recorded. The guard fires on the endpoint
+origin, not on token presence. Diagnose by reading the origin the worker log
+names and comparing it against the configured list:
+
+```bash
+kubectl -n curie logs deployment/curie-worker --tail=60 | grep UntrustedSlackEndpointError
+kubectl -n curie exec deployment/curie-worker -- printenv CURIE_SLACK_TRUSTED_ORIGINS
+```
+
+The usual cause on a multi-interface box: `cluster message` auto-detects a
+local IP for its stub -- e.g. a Tailscale address -- that isn't in the
+trusted-origins list. Pin the stub to an address that is:
+
+```bash
+curie cluster message --listen-host <ip-in-CURIE_SLACK_TRUSTED_ORIGINS> ...
+```
+
+`curie cluster comms --slack --disconnect` is not a fix for this error -- the
+guard fires purely on the reply endpoint's origin, never on whether a token is
+stale or even present, so disconnecting cannot clear the refusal. It remains
+useful only for removing Slack comms from the install entirely:
 
 ```bash
 curie cluster comms --slack --disconnect
@@ -420,6 +474,10 @@ That rolls the worker for you (`kubectl -n curie rollout restart
 deployment/curie-worker`, then waits on the rollout), so the running pod picks
 up the cleared tokens. If you cleared them some other way, run that restart by
 hand or the pod keeps serving the stale Secret.
+
+A timed-out turn's entry on the `curie:runs` valkey stream is reclaimed by the
+platform's bounded-delivery/dead-letter backstop -- no manual XACK or other
+stream surgery is needed.
 
 **The bot says it escalated and no approval card appeared.** The route named in
 `approvalPolicy` is not bound for that agent. Bind it with

--- a/examples/sre-bot/connectors.yaml
+++ b/examples/sre-bot/connectors.yaml
@@ -154,9 +154,12 @@ connectors:
 #      platform and records the resolved digests in `connectors.lock.yaml`.
 #      There is no `image:` line to edit: the digest lives in the lock.
 #
-# The missing separate kubeconfig is load-bearing. An untouched bring-up
-# refuses before either connector starts instead of silently running a writer
-# with the read credential or an unreviewed target.
+# The missing separate kubeconfig is load-bearing -- but only once a lock file
+# exists. On a genuinely untouched bring-up, the unbuilt connectors.lock.yaml
+# refuses deploy before the secret check is ever reached; once built, the
+# still-missing kubeconfig refuses just as cleanly before either connector
+# starts, instead of silently running a writer with the read credential or an
+# unreviewed target.
 #
 # Full walkthrough: README.md, "Level up: the gated write path".
 #
@@ -202,6 +205,15 @@ connectors:
       K8S_WRITE_KUBECONFIG: /secrets/kubeconfig
 # ---------------------------------------------------------------------------
 
+  # Both grafana and tempo below read GRAFANA_SERVICE_ACCOUNT_TOKEN from the
+  # curie-grafana-connector Secret. Nothing in this bundle creates that
+  # Secret -- `curie example sre-bot install --observability` provisions the
+  # observability stack (see examples/sre-bot/observability/curie-values.yaml)
+  # and the chart mints it from there. A manual `cluster deploy` against a
+  # cluster that never ran that install leaves both connectors in
+  # CreateContainerConfigError with no matching Secret to mount -- and the
+  # deploy still exits 0, so "applied N object(s)" reads as success while
+  # these two are broken.
   grafana:
     image: docker.io/grafana/mcp-grafana@sha256:5efeafd01cd7e1aea9c4b0f03305951f2944db8f43e5ae290cce9578c977f241
     args:

--- a/examples/sre-bot/manifests/write-role.yaml
+++ b/examples/sre-bot/manifests/write-role.yaml
@@ -7,9 +7,18 @@
 # before any connector starts. Apply this as step 2 of README.md's
 # "Level up: the gated write path".
 #
-# EDIT TWO THINGS BEFORE APPLYING: the namespace (four occurrences) and the
+# EDIT TWO THINGS BEFORE APPLYING: the namespace (five occurrences -- one of
+# them is the RoleBinding's `subjects[0].namespace`, indented under `subjects:`
+# rather than sitting at `metadata.namespace`, so it's easy to miss) and the
 # `resourceNames` list. Re-applying is safe and idempotent; changing what it
 # grants is not, so read the two sections below first.
+#
+# Missing the `subjects[0].namespace` occurrence does NOT fail `kubectl apply`
+# -- every object still reports `created`. It fails silently instead: the
+# RoleBinding points at a ServiceAccount in the wrong namespace, so the
+# identity grants nothing. The tell is the first `can-i` ceiling proof below
+# printing `no` where it should print `yes` -- don't mistake it for one of the
+# reassuring `no`s the next two lines want.
 #
 # ---------------------------------------------------------------------------
 # The thing to understand before widening anything here


### PR DESCRIPTION
Executes the remaining scope of #1691: scope items 1-3 (connector-build adoption, write-path declaration, read-only default) were already merged via 19254f26 / cab22881, so this run performed the mandated behavioral verification and fixed every doc that did not survive contact.

**E2E (k8 cluster, scratch namespace, branch-built images):** all ten write-path steps passed — untouched-bring-up refusal, RBAC ceiling proofs (yes/no/no), build-to-lock registry delivery, deploy rendering the locked digest byte-identically, route binding, gate deny-by-default, second-actor approve with kubectl-verified rollout, rejection with no rollout, and the connector refusing a validly-approved out-of-allowlist restart.

**Fixed (8 E2E findings + 3 adversarial-review corrections):**
- Troubleshooting: the `cluster message` hang is an endpoint-origin refusal (`CURIE_SLACK_TRUSTED_ORIGINS`), not a stale-token one; documents `--listen-host`; drops the disconnect-as-fix and manual-XACK guidance (origin check is token-independent; dead-letter backstop reclaims timed-out turns).
- Level-up prerequisite: manual `cluster deploy` needs BOTH kubeconfigs available (env or `curie secrets set`); quick-deploy does not persist the read credential.
- `write-role.yaml`: namespace appears five times, not four; the `subjects[0]` one fails silently if missed.
- Bring-up refusal order (lock gate before secret gate; bundle publishes before the abort), `curie build --registry` buildx-driver prerequisite, the `--reject` branch, and the `curie-grafana-connector` Secret requirement.

No semantic YAML change (verified: parsed content identical to base for both YAML files). Scope review: every hunk maps to a finding, zero orphans. plugin-format approval-policy tests pass (11/11).

**Follow-up candidates (platform, not filed — your call):** partial bundle publish before the secret-gate abort; `cluster message` auto-detecting an untrusted interface IP instead of failing with guidance; `curie build --registry` could provision/select a container builder; manual deploys leave grafana/tempo in CreateContainerConfigError (exit 0) when `curie example sre-bot install --observability` never minted their Secret.

Ref #1691