### PR TITLE
Fix architecture atlas preview history

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -333,6 +333,8 @@ jobs:
           git diff --exit-code -- packages/aci-protocol/generated/ts/aci-protocol.ts
       - name: tsc --noEmit on generated ACI types
         run: npx --yes -p typescript@5.9.3 tsc --noEmit -p packages/aci-protocol/generated/ts/tsconfig.json
+      - name: Architecture atlas preview route test
+        run: node --test docs/architecture-atlas/test-update-hash.mjs
 
   ui:
     name: UI (lint + vitest + build + Playwright)

--- a/docs/architecture-atlas/index.html
+++ b/docs/architecture-atlas/index.html
@@ -1544,7 +1544,10 @@
         return actions;
       }
 
-      function updateHash(type, id) { history.replaceState(null, '', `#${encodeURIComponent(type)}/${encodeURIComponent(id)}`); }
+      function updateHash(type, id) {
+        const hash = `#${encodeURIComponent(type)}/${encodeURIComponent(id)}`;
+        history.replaceState(null, '', `${location.origin}${location.pathname}${location.search}${hash}`);
+      }
 
       function applyHash() {
         const match = location.hash.match(/^#(node|seam|adr)\/(.+)$/);

--- a/docs/architecture-atlas/test-update-hash.mjs
+++ b/docs/architecture-atlas/test-update-hash.mjs
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const atlas = readFileSync(new URL('./index.html', import.meta.url), 'utf8');
+const [, body] = atlas.match(/function updateHash\(type, id\) \{([\s\S]*?)\n      \}\n\n      function applyHash/) || [];
+
+test('detail routes stay on the preview document origin', () => {
+  assert.ok(body, 'index.html defines updateHash');
+
+  const location = {
+    origin: 'https://htmlpreview.github.io',
+    pathname: '/',
+    search: '?https://github.com/curie-eng/curie/blob/main/docs/architecture-atlas/index.html',
+  };
+  let replacedUrl;
+  const history = {
+    replaceState(_state, _title, url) {
+      replacedUrl = url;
+      assert.equal(new URL(url).origin, location.origin);
+    },
+  };
+
+  new Function('history', 'location', 'type', 'id', body)(history, location, 'node', 'runner');
+
+  assert.equal(
+    replacedUrl,
+    'https://htmlpreview.github.io/?https://github.com/curie-eng/curie/blob/main/docs/architecture-atlas/index.html#node/runner',
+  );
+});


### PR DESCRIPTION
Fixes the atlas detail-route History.replaceState failure under htmlpreview.github.io by keeping fragment updates on the preview document origin. Adds a regression test and runs it in CI.