### PR TITLE
Carry what a side-effecting call did, one record per call

### DIFF
--- a/cli/src/render.rs
+++ b/cli/src/render.rs
@@ -218,6 +218,13 @@ mod tests {
             version: v(),
             tool: Some("Bash".into()),
             detail: None,
+            // Optional on the wire, but a Rust struct-variant literal has to
+            // name every field: "additive" describes the wire, not every
+            // language binding, and this constructor is what says so (ADR-0117).
+            call_id: None,
+            arguments: None,
+            result: None,
+            failed: None,
         };
         let error = OutboundEvent::ErrorEvent {
             version: v(),

--- a/docs/interfaces/aci-producer/implementing-an-aci-server.md
+++ b/docs/interfaces/aci-producer/implementing-an-aci-server.md
@@ -64,7 +64,9 @@ Import everything from `aci_protocol`; do not hand-roll JSON.
 - `Final` → `final` `{version, text, status}` where `status ∈ {done,
   idle-awaiting-input, classified-failure}`
 - `ErrorEvent` → `error` `{version, message, classification?}`
-- `SideEffectFlag` → `side_effect_flag` `{version, tool?, detail?}`
+- `SideEffectFlag` → `side_effect_flag` `{version, tool?, detail?, call_id?,
+  arguments?, result?, failed?}`, emitted once when a side-effecting call is
+  made and once when its result arrives, joined on `call_id` (ADR-0117)
 
 **Version gate (strict producer, tolerant consumer).** Your producer emits its
 **exact build `PROTOCOL_VERSION`** (currently `0.2.0`) on every outbound event and

--- a/packages/aci-protocol/generated/rust/src/lib.rs
+++ b/packages/aci-protocol/generated/rust/src/lib.rs
@@ -6,7 +6,7 @@
 
 use serde::{Deserialize, Serialize};
 
-pub const PROTOCOL_VERSION: &str = "0.4.1";
+pub const PROTOCOL_VERSION: &str = "0.4.2";
 
 pub const RUNS_STREAM_DEFAULT: &str = "curie:runs";
 
@@ -386,6 +386,14 @@ pub enum OutboundEvent {
         tool: Option<String>,
         #[serde(default)]
         detail: Option<String>,
+        #[serde(default)]
+        call_id: Option<String>,
+        #[serde(default)]
+        arguments: Option<serde_json::Map<String, serde_json::Value>>,
+        #[serde(default)]
+        result: Option<serde_json::Map<String, serde_json::Value>>,
+        #[serde(default)]
+        failed: Option<bool>,
     },
 }
 
@@ -474,13 +482,13 @@ mod tests {
 
     #[test]
     fn accepts_compatible_patch() {
-        let raw = r#"{"type":"final","version":"0.4.2","text":"x","status":"done"}"#;
+        let raw = r#"{"type":"final","version":"0.4.3","text":"x","status":"done"}"#;
         assert!(serde_json::from_str::<OutboundEvent>(raw).is_ok());
     }
 
     #[test]
     fn accepts_unknown_fields() {
-        let raw = r#"{"type":"final","version":"0.4.1","text":"x","status":"done","extra":1}"#;
+        let raw = r#"{"type":"final","version":"0.4.2","text":"x","status":"done","extra":1}"#;
         assert!(serde_json::from_str::<OutboundEvent>(raw).is_ok());
     }
 }

--- a/packages/aci-protocol/generated/ts/aci-protocol.ts
+++ b/packages/aci-protocol/generated/ts/aci-protocol.ts
@@ -20,7 +20,7 @@ export type ExpiresInSeconds = number | null;
  * authority-bearing per #544/ADR-0046, so the value domain is a named, exported
  * part of the contract rather than an inline annotation.
  *
- * This interface was referenced by `ACIProtocolV041`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV042`'s JSON-Schema
  * via the `definition` "GateKind".
  */
 export type GateKind = "permission" | "policy";
@@ -107,14 +107,14 @@ export type Text1 = string;
 export type Type2 = "final";
 export type Version1 = string;
 /**
- * This interface was referenced by `ACIProtocolV041`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV042`'s JSON-Schema
  * via the `definition` "InboundMessage".
  */
 export type InboundMessage = Event | Interrupt;
 export type Kind1 = "interrupt";
 export type Reason = string;
 /**
- * This interface was referenced by `ACIProtocolV041`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV042`'s JSON-Schema
  * via the `definition` "OutboundEvent".
  */
 export type OutboundEvent = TextDelta | ToolNote | Final | ErrorEvent | SideEffectFlag;
@@ -125,7 +125,15 @@ export type Text3 = string;
 export type Tool = string | null;
 export type Type4 = "tool_note";
 export type Version3 = string;
+export type Arguments = {
+  [k: string]: unknown;
+} | null;
+export type CallId = string | null;
 export type Detail = string | null;
+export type Failed = boolean | null;
+export type Result = {
+  [k: string]: unknown;
+} | null;
 export type Tool1 = string | null;
 export type Type5 = "side_effect_flag";
 export type Version4 = string;
@@ -170,7 +178,7 @@ export type Text4 = string;
  * Wire tokens follow the section 0 spelling; ``classified failure`` in prose
  * becomes the token ``classified-failure`` on the wire.
  *
- * This interface was referenced by `ACIProtocolV041`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV042`'s JSON-Schema
  * via the `definition` "SessionStatus".
  */
 export type SessionStatus1 = "done" | "idle-awaiting-input" | "classified-failure" | "awaiting-approval";
@@ -198,12 +206,12 @@ export type SessionStatus1 = "done" | "idle-awaiting-input" | "classified-failur
  * ENUM VALUE -- breaking under this package's rules, so it is a deliberate,
  * separately-decided bump rather than something this change assumes.
  *
- * This interface was referenced by `ACIProtocolV041`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV042`'s JSON-Schema
  * via the `definition` "TurnSource".
  */
 export type TurnSource1 = "slack" | "webhook" | "cron";
 
-export interface ACIProtocolV041 {
+export interface ACIProtocolV042 {
   [k: string]: unknown;
 }
 /**
@@ -227,7 +235,7 @@ export interface ACIProtocolV041 {
  * nullable because ``slack`` legitimately has no adapter -- its route is the
  * worker's configured Slack origin.
  *
- * This interface was referenced by `ACIProtocolV041`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV042`'s JSON-Schema
  * via the `definition` "ApprovalRequest".
  */
 export interface ApprovalRequest {
@@ -274,7 +282,7 @@ export interface ApprovalRequest {
  * baked template default, the worker's value is per-agent model routing. Do not
  * collapse either producer list to a single value.
  *
- * This interface was referenced by `ACIProtocolV041`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV042`'s JSON-Schema
  * via the `definition` "BootEnv".
  */
 export interface BootEnv {
@@ -313,7 +321,7 @@ export interface BootEnv {
  * section 0 describes these as per-tool secrets via K8s Secret refs, so the
  * contract carries the reference, not the secret material itself.
  *
- * This interface was referenced by `ACIProtocolV041`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV042`'s JSON-Schema
  * via the `definition` "SessionConfig".
  */
 export interface SessionConfig {
@@ -332,7 +340,7 @@ export interface SessionConfig {
  * ``task_budget_hint`` is the optional hint passed through to the model so it
  * self paces (section 6b); it is not a hard ceiling.
  *
- * This interface was referenced by `ACIProtocolV041`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV042`'s JSON-Schema
  * via the `definition` "Budget".
  */
 export interface Budget {
@@ -348,7 +356,7 @@ export interface Budget {
  * fields the prototype used (endpoint, headers, protocol); any others pass
  * through as raw env vars untouched and are out of scope for this typed view.
  *
- * This interface was referenced by `ACIProtocolV041`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV042`'s JSON-Schema
  * via the `definition` "OtelConfig".
  */
 export interface OtelConfig {
@@ -360,7 +368,7 @@ export interface OtelConfig {
 /**
  * A classified failure surfaced to the platform.
  *
- * This interface was referenced by `ACIProtocolV041`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV042`'s JSON-Schema
  * via the `definition` "ErrorEvent".
  */
 export interface ErrorEvent {
@@ -377,7 +385,7 @@ export interface ErrorEvent {
  * worker consumes off it (formerly the API's ``EvalJobRequest`` and the
  * worker's ``EvalWorkItem``, which had drifted on ``bundle_ref``).
  *
- * This interface was referenced by `ACIProtocolV041`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV042`'s JSON-Schema
  * via the `definition` "EvalJob".
  */
 export interface EvalJob {
@@ -397,7 +405,7 @@ export interface EvalJob {
  * Byte-identical across both lanes before this promotion, so it carries no
  * semantic decisions.
  *
- * This interface was referenced by `ACIProtocolV041`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV042`'s JSON-Schema
  * via the `definition` "EvalReport".
  */
 export interface EvalReport {
@@ -411,7 +419,7 @@ export interface EvalReport {
 /**
  * An inbound event delivered into a live session (initial or follow-up).
  *
- * This interface was referenced by `ACIProtocolV041`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV042`'s JSON-Schema
  * via the `definition` "Event".
  */
 export interface Event {
@@ -456,7 +464,7 @@ export interface Event {
  * scalars: a tolerant consumer decoding an older producer's ``final`` simply
  * sees them absent.
  *
- * This interface was referenced by `ACIProtocolV041`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV042`'s JSON-Schema
  * via the `definition` "Final".
  */
 export interface Final {
@@ -475,7 +483,7 @@ export interface Final {
 /**
  * A hard stop delivered on the control channel, distinct from a steer.
  *
- * This interface was referenced by `ACIProtocolV041`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV042`'s JSON-Schema
  * via the `definition` "Interrupt".
  */
 export interface Interrupt {
@@ -486,7 +494,7 @@ export interface Interrupt {
 /**
  * A streamed chunk of assistant text.
  *
- * This interface was referenced by `ACIProtocolV041`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV042`'s JSON-Schema
  * via the `definition` "TextDelta".
  */
 export interface TextDelta {
@@ -498,7 +506,7 @@ export interface TextDelta {
 /**
  * A human readable note about a tool call the harness is making.
  *
- * This interface was referenced by `ACIProtocolV041`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV042`'s JSON-Schema
  * via the `definition` "ToolNote".
  */
 export interface ToolNote {
@@ -514,11 +522,28 @@ export interface ToolNote {
  * Its presence gates the no-retry-after-side-effects rule (section 2b): a
  * failed run carrying this flag escalates to a human instead of retrying.
  *
- * This interface was referenced by `ACIProtocolV041`'s JSON-Schema
+ * It also reports WHAT the call did (ADR-0117). The information was already in
+ * hand where the frame is built and was being replaced by a constant ``detail``
+ * string, so a consumer could know that something mutated and never what. Every
+ * field below is optional with a ``None`` default, which is why carrying them
+ * is a patch under ADR-0036: a reader that predates them decodes the frame
+ * unchanged.
+ *
+ * One CALL produces two frames -- an opening one when the call is made, so the
+ * no-retry rule latches even if the turn dies mid-call, and a closing one
+ * carrying what came back. ``call_id`` is what joins them into one record; a
+ * turn that calls the same tool twice is otherwise indistinguishable from one
+ * that called it once.
+ *
+ * This interface was referenced by `ACIProtocolV042`'s JSON-Schema
  * via the `definition` "SideEffectFlag".
  */
 export interface SideEffectFlag {
+  arguments?: Arguments;
+  call_id?: CallId;
   detail?: Detail;
+  failed?: Failed;
+  result?: Result;
   tool?: Tool1;
   type: Type5;
   version: Version4;
@@ -540,7 +565,7 @@ export interface SideEffectFlag {
  * to the non-job value is also the safe direction -- an unset ``source`` reads
  * as a person's message, so a job can never be created by omission.
  *
- * This interface was referenced by `ACIProtocolV041`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV042`'s JSON-Schema
  * via the `definition` "QueuedTurn".
  */
 export interface QueuedTurn {
@@ -589,7 +614,7 @@ export interface QueuedTurn {
  * third-party or pre-upgrade producer is not rejected outright, but every
  * first-party mint site sets it explicitly.
  *
- * This interface was referenced by `ACIProtocolV041`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV042`'s JSON-Schema
  * via the `definition` "ReplyHandle".
  */
 export interface ReplyHandle {

--- a/packages/aci-protocol/schema/aci-protocol.schema.json
+++ b/packages/aci-protocol/schema/aci-protocol.schema.json
@@ -1185,8 +1185,33 @@
       "type": "string"
     },
     "SideEffectFlag": {
-      "description": "Marks that a non-idempotent tool call executed during the run.\n\nIts presence gates the no-retry-after-side-effects rule (section 2b): a\nfailed run carrying this flag escalates to a human instead of retrying.",
+      "description": "Marks that a non-idempotent tool call executed during the run.\n\nIts presence gates the no-retry-after-side-effects rule (section 2b): a\nfailed run carrying this flag escalates to a human instead of retrying.\n\nIt also reports WHAT the call did (ADR-0117). The information was already in\nhand where the frame is built and was being replaced by a constant ``detail``\nstring, so a consumer could know that something mutated and never what. Every\nfield below is optional with a ``None`` default, which is why carrying them\nis a patch under ADR-0036: a reader that predates them decodes the frame\nunchanged.\n\nOne CALL produces two frames -- an opening one when the call is made, so the\nno-retry rule latches even if the turn dies mid-call, and a closing one\ncarrying what came back. ``call_id`` is what joins them into one record; a\nturn that calls the same tool twice is otherwise indistinguishable from one\nthat called it once.",
       "properties": {
+        "arguments": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Arguments"
+        },
+        "call_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Call Id"
+        },
         "detail": {
           "anyOf": [
             {
@@ -1198,6 +1223,31 @@
           ],
           "default": null,
           "title": "Detail"
+        },
+        "failed": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Failed"
+        },
+        "result": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Result"
         },
         "tool": {
           "anyOf": [
@@ -1306,6 +1356,6 @@
   },
   "$id": "https://curietech.ai/schemas/aci-protocol.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "protocolVersion": "0.4.1",
-  "title": "ACI Protocol v0.4.1"
+  "protocolVersion": "0.4.2",
+  "title": "ACI Protocol v0.4.2"
 }

--- a/packages/aci-protocol/schema/wire.lock
+++ b/packages/aci-protocol/schema/wire.lock
@@ -1,4 +1,4 @@
 {
-  "protocol_version": "0.4.1",
-  "wire_sha256": "33039696a891d02429e97419cfd2066cf8597b1548ff781132cb94c8ababc6ed"
+  "protocol_version": "0.4.2",
+  "wire_sha256": "359045d1f5ba7459b989026411beb01c5de6bf9cb04eaa81193be5dfe4701aec"
 }

--- a/packages/aci-protocol/src/aci_protocol/events.py
+++ b/packages/aci-protocol/src/aci_protocol/events.py
@@ -192,11 +192,36 @@ class SideEffectFlag(_OutboundBase):
 
     Its presence gates the no-retry-after-side-effects rule (section 2b): a
     failed run carrying this flag escalates to a human instead of retrying.
+
+    It also reports WHAT the call did (ADR-0117). The information was already in
+    hand where the frame is built and was being replaced by a constant ``detail``
+    string, so a consumer could know that something mutated and never what. Every
+    field below is optional with a ``None`` default, which is why carrying them
+    is a patch under ADR-0036: a reader that predates them decodes the frame
+    unchanged.
+
+    One CALL produces two frames -- an opening one when the call is made, so the
+    no-retry rule latches even if the turn dies mid-call, and a closing one
+    carrying what came back. ``call_id`` is what joins them into one record; a
+    turn that calls the same tool twice is otherwise indistinguishable from one
+    that called it once.
     """
 
     type: Literal["side_effect_flag"] = "side_effect_flag"
     tool: str | None = None
     detail: str | None = None
+    # The harness's own id for the call. The join key, not a display value.
+    call_id: str | None = None
+    # What the call was made with, and what it answered. ``result`` is present
+    # only for a structured reply: a connector that answers in prose has none,
+    # deliberately, because guessing structure out of a sentence is how something
+    # downstream restores a guess.
+    arguments: dict[str, Any] | None = None
+    result: dict[str, Any] | None = None
+    # Whether the tool reported failure. ``None`` means unknown (an opening
+    # frame, or a producer that predates this). A record is undoable only on a
+    # successful outcome, so the outcome has to travel with the result.
+    failed: bool | None = None
 
 
 OutboundEvent = Annotated[

--- a/packages/aci-protocol/src/aci_protocol/rust_export.py
+++ b/packages/aci-protocol/src/aci_protocol/rust_export.py
@@ -134,6 +134,17 @@ def _rust_bare_type(annotation: Any) -> str:
             # fallback for any future single-valued literal field.
             return "String"
         raise TypeError(f"unexpected literal field {annotation!r}")
+    if origin is dict:
+        key, value = get_args(annotation)
+        if key is not str or value is not Any:
+            # Anything narrower than the fully open shape deserves a named type
+            # on both sides rather than a free-form map, so it is not mapped
+            # here: the schema would claim a structure the Rust would not hold.
+            raise TypeError(f"only dict[str, Any] maps to a Rust map, got {annotation!r}")
+        # The crate already depends on serde_json, and a Map preserves the
+        # object-ness the JSON Schema declares -- a bare Value would also accept
+        # a string or a number, widening the contract on the Rust side only.
+        return "serde_json::Map<String, serde_json::Value>"
     if isinstance(annotation, type) and issubclass(annotation, BaseModel):
         return annotation.__name__
     if isinstance(annotation, type) and issubclass(annotation, Enum):

--- a/packages/aci-protocol/src/aci_protocol/version.py
+++ b/packages/aci-protocol/src/aci_protocol/version.py
@@ -20,7 +20,7 @@ the guard.
 import re
 from typing import Final
 
-PROTOCOL_VERSION: Final = "0.4.1"
+PROTOCOL_VERSION: Final = "0.4.2"
 
 # The wire field carrying the protocol version on every outbound event. Both
 # exporters special-case this field by name; do not rename without updating them.

--- a/packages/aci-protocol/tests/test_events.py
+++ b/packages/aci-protocol/tests/test_events.py
@@ -100,3 +100,54 @@ def test_awaiting_approval_wire_value_and_final_round_trip() -> None:
     # summary to None -- the additive-change guarantee.
     legacy = Final.model_validate({"type": "final", "text": "ok", "status": "done"})
     assert legacy.approval_summary is None
+
+
+# --- What a side-effecting call reports (ADR-0117) -----------------------------
+
+
+def test_side_effect_flag_carries_the_call_its_arguments_and_its_result() -> None:
+    """The frame is the only place the platform learns what a call did.
+
+    Before ADR-0117 it carried a tool name and a constant ``detail`` string, so a
+    consumer could know that something mutated and never what.
+    """
+
+    flag = SideEffectFlag(
+        tool="scale_deployment",
+        call_id="toolu_01",
+        arguments={"name": "api", "replicas": 10},
+        result={"ok": True, "prior": {"spec": {"replicas": 3}}},
+        failed=False,
+    )
+    assert flag.call_id == "toolu_01"
+    assert flag.arguments == {"name": "api", "replicas": 10}
+    assert flag.result == {"ok": True, "prior": {"spec": {"replicas": 3}}}
+    assert flag.failed is False
+
+
+def test_side_effect_flag_fields_are_optional_for_an_older_producer() -> None:
+    """ADR-0036's reader policy: an additive optional field costs readers nothing.
+
+    A producer that predates ADR-0117 emits neither, and the frame it wrote still
+    decodes -- which is what makes this a patch bump and not a minor.
+    """
+
+    decoded = _OUTBOUND.validate_python({"type": "side_effect_flag", "version": "0.4.1"})
+    assert decoded.call_id is None
+    assert decoded.arguments is None
+    assert decoded.result is None
+    assert decoded.failed is None
+
+
+def test_two_frames_of_one_call_are_joinable_by_call_id() -> None:
+    """One call, two frames, one record.
+
+    The opening frame is emitted when the call is made, so the no-retry rule
+    latches even if the turn dies mid-call; the closing frame carries what came
+    back. Without a shared call id a consumer cannot join them, and a turn that
+    calls the same tool twice would collapse into one record or three.
+    """
+
+    opened = SideEffectFlag(tool="scale_deployment", call_id="toolu_01", arguments={"replicas": 10})
+    closed = SideEffectFlag(tool="scale_deployment", call_id="toolu_01", result={"ok": True})
+    assert opened.call_id == closed.call_id

--- a/runner/src/curie_runner/translate.py
+++ b/runner/src/curie_runner/translate.py
@@ -15,8 +15,9 @@ translation serve both the live HTTP turn and the conformance producer.
 
 from __future__ import annotations
 
+import json
 from collections.abc import Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from aci_protocol import (
     ErrorEvent,
@@ -32,12 +33,22 @@ from claude_agent_sdk import (
     RateLimitEvent,
     ResultMessage,
     TextBlock,
+    ToolResultBlock,
     ToolUseBlock,
+    UserMessage,
 )
 
 from .approval import APPROVAL_TOOL_NAME, guard_reserved_summary
 from .otel import _GenerationSpan
 from .side_effects import SideEffectClassifier
+
+# Longest raw tool reply this will parse into a recordable ``result``. The reply
+# travels the wire and lands in a durable record, so an unbounded connector
+# response would be an unbounded row; the existing analogue is the approval
+# summary's 300-char input rendering, which is far tighter because a human reads
+# it. A prior-state snapshot of a Kubernetes object is tens of kilobytes, so this
+# is set to clear a realistic snapshot and refuse a blob.
+RESULT_MAX_BYTES = 64_000
 
 
 @dataclass
@@ -80,6 +91,12 @@ class TurnState:
     # reply recorded into the conversation transcript (#20); left None on a
     # failure/budget/auth final so those turns are not persisted as history.
     final_text: str | None = None
+    # Call id -> tool name, for side-effecting calls whose result has not arrived
+    # yet. A tool result lands on a LATER message, so the name has to be
+    # remembered to attribute it, and the id is what joins the two frames of one
+    # call into one record (ADR-0117). An entry is popped when its result
+    # arrives; one left standing is a call that never came back.
+    pending_actions: dict[str, str] = field(default_factory=dict)
 
 
 def translate_message(
@@ -94,6 +111,8 @@ def translate_message(
         return _translate_assistant(message, state, classifier, gen)
     if isinstance(message, ResultMessage):
         return _translate_result(message, state, gen)
+    if isinstance(message, UserMessage):
+        return _translate_user(message, state)
     if isinstance(message, RateLimitEvent):
         # status is one of allowed / allowed_warning / rejected; only a hard
         # rejection is an ACI error. The warning states are advisory (the model
@@ -159,12 +178,108 @@ def _translate_assistant(
                     # approval_granted_tool None so the worker can never mint a
                     # bypass grant from a model-authored request (#430).
                     state.approval_gate_kind = "policy"
-            if classifier.is_side_effecting(block.name) and not state.side_effect_emitted:
+            if classifier.is_side_effecting(block.name):
+                # One frame per CALL, not per turn. The cap was once-per-turn
+                # because the only consumer was a boolean, so a turn that called
+                # three mutating tools reported one; a consumer that records what
+                # happened needs each call (ADR-0117). ``side_effect_emitted``
+                # still latches below, so ADR-0013's no-retry rule and the
+                # false-completion check read exactly the signal they read before.
+                #
+                # This frame is emitted when the call is MADE, before its result
+                # exists, so a turn that dies mid-call has still reported that
+                # something mutated. Its result arrives on a later message and
+                # closes it in ``_translate_user``.
+                state.pending_actions[block.id] = block.name
                 events.append(
-                    SideEffectFlag(tool=block.name, detail="non-idempotent tool executed")
+                    SideEffectFlag(
+                        tool=block.name,
+                        detail="non-idempotent tool executed",
+                        call_id=block.id,
+                        arguments=block.input if isinstance(block.input, dict) else None,
+                    )
                 )
                 state.side_effect_emitted = True
     return events
+
+
+def _translate_user(message: UserMessage, state: TurnState) -> list[OutboundEvent]:
+    """Close a side-effecting call with what its tool answered, and nothing else.
+
+    A tool result arrives on a ``UserMessage``, which the v0.1 contract dropped
+    whole ("carry no outbound-visible content"). Read-only results stay dropped:
+    file contents are the model's working material, and forwarding them would put
+    a repository on the wire. A side-effecting call is different -- its reply is
+    the only place a connector can report what the call did to the world, which is
+    what makes the action recordable at all (ADR-0117).
+    """
+
+    if isinstance(message.content, str):
+        # UserMessage.content is a plain string OR a block list. A string carries
+        # no tool result, and iterating it would walk single characters.
+        return []
+    events: list[OutboundEvent] = []
+    for block in message.content:
+        if not isinstance(block, ToolResultBlock):
+            continue
+        tool = state.pending_actions.pop(block.tool_use_id, None)
+        if tool is None:
+            # Read-only, or a result for a call this turn never saw, or a second
+            # result for a call already closed. There is nothing to attribute it
+            # to, and minting a frame anyway would mint a second record.
+            continue
+        payload, oversized = _result_payload(block)
+        events.append(
+            SideEffectFlag(
+                tool=tool,
+                detail=(
+                    "tool result too large to record"
+                    if oversized
+                    else "non-idempotent tool completed"
+                ),
+                call_id=block.tool_use_id,
+                result=payload,
+                failed=bool(block.is_error),
+            )
+        )
+    return events
+
+
+def _result_payload(block: ToolResultBlock) -> tuple[dict[str, object] | None, bool]:
+    """The tool's structured reply, or None, plus whether size is why it is None.
+
+    Deliberately not a parse of prose. A connector that answers in a sentence has
+    no structured reply, and guessing one out of the sentence is how something
+    downstream ends up restoring a guess. No JSON object means no result, which
+    downstream means not undoable.
+    """
+
+    content = block.content
+    if isinstance(content, list):
+        # The SDK wraps an MCP tool's reply in content blocks.
+        for part in content:
+            if not isinstance(part, dict):
+                continue
+            parsed, oversized = _loads_object(part.get("text"))
+            if parsed is not None or oversized:
+                return parsed, oversized
+        return None, False
+    return _loads_object(content)
+
+
+def _loads_object(raw: object) -> tuple[dict[str, object] | None, bool]:
+    if not isinstance(raw, str):
+        return None, False
+    if len(raw.encode()) > RESULT_MAX_BYTES:
+        # Dropped, never truncated. A truncated JSON object either fails to parse
+        # or parses into a smaller object that is not what the tool said, and a
+        # restore would act on the difference.
+        return None, True
+    try:
+        parsed = json.loads(raw)
+    except (TypeError, ValueError):
+        return None, False
+    return (parsed if isinstance(parsed, dict) else None), False
 
 
 def _translate_result(

--- a/runner/tests/test_translate.py
+++ b/runner/tests/test_translate.py
@@ -1,5 +1,7 @@
 """SDK-message to ACI-outbound-event translation."""
 
+import json
+
 from aci_protocol import SessionStatus
 from claude_agent_sdk import (
     AssistantMessage,
@@ -7,11 +9,13 @@ from claude_agent_sdk import (
     ResultMessage,
     TextBlock,
     ThinkingBlock,
+    ToolResultBlock,
     ToolUseBlock,
+    UserMessage,
 )
 from claude_agent_sdk.types import RateLimitInfo
 from curie_runner import SideEffectClassifier
-from curie_runner.translate import TurnState, translate_message
+from curie_runner.translate import RESULT_MAX_BYTES, TurnState, translate_message
 
 
 def _translate(message: object, state: TurnState | None = None) -> list:
@@ -25,7 +29,7 @@ def test_text_block_becomes_text_delta() -> None:
     assert events[0].text == "hi there"
 
 
-def test_tool_use_emits_note_and_side_effect_once() -> None:
+def test_tool_use_emits_a_note_and_a_flag_per_side_effecting_call() -> None:
     state = TurnState()
     msg = AssistantMessage(
         content=[
@@ -36,9 +40,11 @@ def test_tool_use_emits_note_and_side_effect_once() -> None:
     )
     events = _translate(msg, state)
     types = [e.type for e in events]
-    # Two tool notes, but the side-effect flag fires once per run (dedup).
+    # A note and a flag for each call. The flag was capped at once per run while
+    # its only consumer was a boolean; the action is the unit now (ADR-0117), and
+    # ``side_effect_emitted`` still latches for the consumers that read presence.
     assert types.count("tool_note") == 2
-    assert types.count("side_effect_flag") == 1
+    assert types.count("side_effect_flag") == 2
     assert state.side_effect_emitted
 
 
@@ -166,3 +172,153 @@ def test_rate_limit_warning_is_dropped() -> None:
         info = RateLimitInfo(status=status)
         events = _translate(RateLimitEvent(rate_limit_info=info, uuid="u", session_id="s"))
         assert events == []
+
+
+# --- One frame per call, and what each carries (ADR-0117) ----------------------
+
+
+def _tool_result(
+    tool_use_id: str,
+    content: object,
+    *,
+    is_error: bool | None = None,
+) -> UserMessage:
+    return UserMessage(
+        content=[
+            ToolResultBlock(tool_use_id=tool_use_id, content=content, is_error=is_error)
+        ]
+    )
+
+
+def test_each_side_effecting_call_gets_its_own_flag() -> None:
+    """The cap was once-per-turn because a boolean cannot be set twice.
+
+    A turn that calls three mutating tools reported one. The record, the receipt
+    line and the undo are all per action, so the frame is too.
+    """
+
+    state = TurnState()
+    msg = AssistantMessage(
+        content=[
+            ToolUseBlock(id="1", name="Bash", input={"command": "ls"}),
+            ToolUseBlock(id="2", name="Write", input={"file_path": "/tmp/x"}),
+        ],
+        model="m",
+    )
+    flags = [e for e in _translate(msg, state) if e.type == "side_effect_flag"]
+    assert [f.call_id for f in flags] == ["1", "2"]
+    assert [f.arguments for f in flags] == [{"command": "ls"}, {"file_path": "/tmp/x"}]
+
+
+def test_the_no_retry_signal_still_latches() -> None:
+    """ADR-0013's rule reads presence, not count, and kernel.py is sacred."""
+
+    state = TurnState()
+    msg = AssistantMessage(content=[ToolUseBlock(id="1", name="Bash", input={})], model="m")
+    _translate(msg, state)
+    assert state.side_effect_emitted
+
+
+def test_a_side_effecting_result_closes_its_call() -> None:
+    state = TurnState()
+    _translate(
+        AssistantMessage(content=[ToolUseBlock(id="1", name="Bash", input={})], model="m"),
+        state,
+    )
+    events = _translate(_tool_result("1", '{"ok": true, "prior": {"replicas": 3}}'), state)
+    assert [e.type for e in events] == ["side_effect_flag"]
+    assert events[0].call_id == "1"
+    assert events[0].result == {"ok": True, "prior": {"replicas": 3}}
+    assert events[0].failed is False
+
+
+def test_a_read_only_result_is_still_dropped_whole() -> None:
+    """File contents are the model's working material, not wire traffic."""
+
+    state = TurnState()
+    _translate(
+        AssistantMessage(content=[ToolUseBlock(id="1", name="Read", input={})], model="m"),
+        state,
+    )
+    assert _translate(_tool_result("1", "the whole file"), state) == []
+
+
+def test_a_prose_reply_carries_no_structured_result() -> None:
+    """Guessing structure out of a sentence is how a restore acts on a guess."""
+
+    state = TurnState()
+    _translate(
+        AssistantMessage(content=[ToolUseBlock(id="1", name="Bash", input={})], model="m"),
+        state,
+    )
+    events = _translate(_tool_result("1", "restarted the deployment"), state)
+    assert events[0].result is None
+
+
+def test_a_failed_call_says_so() -> None:
+    """A record is undoable only on a successful outcome, so the outcome travels."""
+
+    state = TurnState()
+    _translate(
+        AssistantMessage(content=[ToolUseBlock(id="1", name="Bash", input={})], model="m"),
+        state,
+    )
+    events = _translate(_tool_result("1", '{"ok": false}', is_error=True), state)
+    assert events[0].failed is True
+
+
+def test_an_oversized_result_is_dropped_not_truncated() -> None:
+    """A truncated JSON object is a lie a restore would act on."""
+
+    state = TurnState()
+    _translate(
+        AssistantMessage(content=[ToolUseBlock(id="1", name="Bash", input={})], model="m"),
+        state,
+    )
+    huge = json.dumps({"prior": {"blob": "x" * (RESULT_MAX_BYTES + 1)}})
+    events = _translate(_tool_result("1", huge), state)
+    assert events[0].result is None
+    assert events[0].detail == "tool result too large to record"
+
+
+def test_a_result_for_an_unknown_call_is_ignored() -> None:
+    state = TurnState()
+    assert _translate(_tool_result("nope", '{"ok": true}'), state) == []
+
+
+def test_a_call_is_closed_exactly_once() -> None:
+    """A duplicate result must not mint a second record for one call."""
+
+    state = TurnState()
+    _translate(
+        AssistantMessage(content=[ToolUseBlock(id="1", name="Bash", input={})], model="m"),
+        state,
+    )
+    assert len(_translate(_tool_result("1", '{"ok": true}'), state)) == 1
+    assert _translate(_tool_result("1", '{"ok": true}'), state) == []
+
+
+def test_a_string_user_message_is_not_iterated_as_characters() -> None:
+    """UserMessage.content is str OR a block list; the str case has no results."""
+
+    assert _translate(UserMessage(content="just text"), TurnState()) == []
+
+
+def test_a_call_whose_result_never_arrives_leaves_its_opening_frame() -> None:
+    """A turn that died mid-call still reported that something mutated.
+
+    The opening frame is the honest record of an attempt: arguments, no result,
+    and therefore not undoable downstream.
+    """
+
+    state = TurnState()
+    events = _translate(
+        AssistantMessage(
+            content=[ToolUseBlock(id="1", name="Bash", input={"command": "rm"})], model="m"
+        ),
+        state,
+    )
+    flags = [e for e in events if e.type == "side_effect_flag"]
+    assert len(flags) == 1
+    assert flags[0].result is None
+    assert state.pending_actions == {"1": "Bash"}


### PR DESCRIPTION
**Merge after #1805.** That PR carries ADR-0117 at `Accepted`, which is what authorizes this. Slice 1 of #1861. Closes #1862.

## What was there

The side-effect frame carried a tool name and the constant string `"non-idempotent tool executed"`, and fired **once per turn**, because its only consumer was a boolean. A turn that called three mutating tools reported one, and nothing recorded which tool, with what arguments, or whether it worked.

## What this changes

`SideEffectFlag` gains `call_id`, `arguments`, `result` and `failed` — all optional, `None` default, so this is a **patch** under ADR-0036 and not a minor: a reader that predates them decodes the frame unchanged. `0.4.1` → `0.4.2`, wire-lock fingerprint moved with it.

**One call now produces two frames, and this is the part to review.** The opening frame is emitted when the call is *made*, carrying its arguments; the closing frame carries the result. `call_id` joins them.

- Emitting at call time is deliberate. A turn that dies mid-call has still changed the world and must still report it — moving the frame to result time would quietly weaken ADR-0013's no-retry rule to "reported only if the tool answered".
- `call_id` is what the prototype in #1805 lacked. Without it a consumer cannot join the two frames: two calls to the same tool in one turn are indistinguishable from one, so "exactly one durable record per call" is not implementable. Frames per call: two. Records per call: one, keyed on `call_id`.
- `failed` travels with the result because a record is undoable only on a successful outcome, and the SDK carries the flag on the result block. The prototype dropped it.

## Three deliberate refusals

| | why |
| --- | --- |
| read-only results stay dropped | a file's contents are the model's working material; forwarding them would put a repository on the wire |
| a prose reply carries no structured result | guessing structure out of a sentence is how something downstream restores a guess |
| an oversized reply is dropped, not truncated | a truncated JSON object either fails to parse or parses into something smaller than what the tool said, and a restore would act on the difference. `RESULT_MAX_BYTES = 64_000` clears a Kubernetes object snapshot and refuses a blob; the frame's `detail` says why it is empty |

## What is untouched

`kernel.py` — sacred under ADR-0013. It sets `saw_side_effect` and marks the event, both idempotent, so a widened stream reads as the same signal. `side_effect_emitted` still latches, so the false-completion check in `session.py` is unchanged too.

## The cost of an additive field

The generated Rust is an enum with struct variants, and a struct-variant literal has to name every field, so `cli/src/render.rs` failed to compile until it named the four new ones. Pattern matches with `..` were fine. "Additive" describes the wire, not every language binding.

## Verification

```
runner            599 passed, 4 skipped
aci-protocol      178 passed
aci + kernel      189 passed, 175 skipped   (kernel suite, 11m30s)
cli (lib)         810 passed
ruff check .      All checks passed
mypy              no issues in 200 source files
check-contracts   all committed contract artifacts current
check-docs        catalog drift-free, every citation resolves
```

`cli --test chart_check` fails on this branch and fails identically on an untouched checkout — a pre-existing local `render-assertions.sh` failure, not this change.

Nothing consumes the new fields yet. #1863 is the ledger that does.
