### PR TITLE
Add a Discord channel adapter

### DIFF
--- a/adapters/discord/Dockerfile
+++ b/adapters/discord/Dockerfile
@@ -1,0 +1,17 @@
+# Build from the repository root:
+# docker build -f adapters/discord/Dockerfile -t curie-discord-adapter .
+FROM python:3.13-slim AS builder
+RUN pip install --no-cache-dir uv==0.10.7
+WORKDIR /app
+ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy UV_PYTHON_DOWNLOADS=never
+COPY . .
+RUN uv sync --frozen --no-dev --no-editable --package curie-discord-adapter
+
+FROM python:3.13-slim
+RUN groupadd -g 1000 app && useradd -u 1000 -g app -m -d /home/app app
+WORKDIR /app
+COPY --from=builder --chown=app:app /app/.venv /app/.venv
+ENV PATH="/app/.venv/bin:$PATH"
+USER 1000
+EXPOSE 8080
+CMD ["python", "-m", "curie_discord_adapter"]

--- a/adapters/discord/README.md
+++ b/adapters/discord/README.md
@@ -1,0 +1,51 @@
+# Curie Discord adapter
+
+This service connects Discord Gateway messages to Curie's channel-neutral
+ingress and renders Curie's neutral reply events through Discord REST. It is a
+real second surface adapter. The Curie worker does not import Discord and the
+adapter does not run an agent bundle.
+
+## Discord application
+
+Create a Discord application with a bot, enable the Message Content intent,
+and invite it with permission to view channels, send messages, create public
+threads, send messages in threads, read message history, and manage its own
+messages. Keep the bot token in this adapter only.
+
+## Configuration
+
+Set these environment variables:
+
+- `DISCORD_BOT_TOKEN`: Discord bot token.
+- `CURIE_DISCORD_ADAPTER_SECRET`: secret expected in `X-Curie-Adapter-Key` on
+  Curie reply requests.
+- `CURIE_API_URL`: Curie API origin, for example `http://api:8000`.
+- `CURIE_DISCORD_BINDINGS`: JSON array of parent channel bindings. Each item is
+  `{"parent_channel_id":"111111111111111111","address":"111111111111111111","token":"chn_example"}`.
+- `CURIE_DISCORD_BINDINGS_PATH`: optional path to the same JSON array. When set,
+  the adapter rereads this file for each intake so scoped tokens can rotate
+  without reconnecting the Gateway client.
+- `CURIE_DISCORD_STATE_PATH`: SQLite path. Default is
+  `/var/lib/curie-discord/state.sqlite3`.
+- `CURIE_DISCORD_REPLY_HOST` and `CURIE_DISCORD_REPLY_PORT`: reply HTTP bind.
+
+For each item, add the same agent surface through Curie and mint its scoped
+channel token. Configure the Curie binding's reply endpoint as this service's
+`/replies` URL and its adapter credential as the value of
+`CURIE_DISCORD_ADAPTER_SECRET`.
+
+## Behavior
+
+A bot mention in a configured parent channel creates a public thread and a
+placeholder. Messages in that adapter-created thread continue the same Curie
+conversation without another mention. Discord message ids are stable delivery
+ids, Discord thread ids are conversation ids, and placeholder ids are reply
+references.
+
+Discord v1 supports text, mentions, threads, streamed text edits, and text
+fallbacks for platform posts. It does not implement Discord buttons, direct
+messages, file attachments, or interactive approvals. A Discord delivery
+failure never falls back to Slack or another surface.
+
+SQLite stores thread routing and delivery ids but not scoped channel tokens.
+Those remain in the environment or mounted bindings file.

--- a/adapters/discord/README.md
+++ b/adapters/discord/README.md
@@ -17,7 +17,7 @@ messages. Keep the bot token in this adapter only.
 Set these environment variables:
 
 - `DISCORD_BOT_TOKEN`: Discord bot token.
-- `CURIE_DISCORD_ADAPTER_SECRET`: secret expected in `X-Curie-Adapter-Key` on
+- `CURIE_DISCORD_ADAPTER_SECRET`: secret expected in `X-Curie-Adapter-Secret` on
   Curie reply requests.
 - `CURIE_API_URL`: Curie API origin, for example `http://api:8000`.
 - `CURIE_DISCORD_BINDINGS`: JSON array of parent channel bindings. Each item is

--- a/adapters/discord/pyproject.toml
+++ b/adapters/discord/pyproject.toml
@@ -1,0 +1,20 @@
+[project]
+name = "curie-discord-adapter"
+version = "0.1.0"
+description = "Discord Gateway and REST adapter for Curie channel-neutral turns"
+requires-python = ">=3.13"
+dependencies = [
+    "curie-channel-protocol",
+    "discord.py>=2.6,<3",
+    "fastapi>=0.135",
+    "httpx>=0.28",
+    "pydantic-settings>=2.15",
+    "uvicorn>=0.41",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/curie_discord_adapter"]

--- a/adapters/discord/src/curie_discord_adapter/__init__.py
+++ b/adapters/discord/src/curie_discord_adapter/__init__.py
@@ -1,0 +1,1 @@
+"""Discord surface adapter for Curie."""

--- a/adapters/discord/src/curie_discord_adapter/__main__.py
+++ b/adapters/discord/src/curie_discord_adapter/__main__.py
@@ -1,0 +1,3 @@
+from .main import main
+
+main()

--- a/adapters/discord/src/curie_discord_adapter/config.py
+++ b/adapters/discord/src/curie_discord_adapter/config.py
@@ -1,0 +1,53 @@
+"""Environment configuration for the Discord adapter."""
+
+import json
+from pathlib import Path
+
+from pydantic import Field, TypeAdapter
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+from .ingress import DiscordBinding
+
+
+class DiscordConfig(BaseSettings):
+    model_config = SettingsConfigDict(
+        extra="ignore", populate_by_name=True, validate_default=True
+    )
+
+    discord_bot_token: str = Field(
+        default="", min_length=1, validation_alias="DISCORD_BOT_TOKEN"
+    )
+    adapter_secret: str = Field(
+        default="", min_length=1, validation_alias="CURIE_DISCORD_ADAPTER_SECRET"
+    )
+    curie_api_url: str = Field(
+        default="http://localhost:8000", validation_alias="CURIE_API_URL"
+    )
+    bindings: list[DiscordBinding] = Field(
+        default_factory=list, validation_alias="CURIE_DISCORD_BINDINGS"
+    )
+    bindings_path: Path | None = Field(
+        default=None, validation_alias="CURIE_DISCORD_BINDINGS_PATH"
+    )
+    state_path: Path = Field(
+        default=Path("/var/lib/curie-discord/state.sqlite3"),
+        validation_alias="CURIE_DISCORD_STATE_PATH",
+    )
+    reply_host: str = Field(default="0.0.0.0", validation_alias="CURIE_DISCORD_REPLY_HOST")
+    reply_port: int = Field(default=8080, validation_alias="CURIE_DISCORD_REPLY_PORT")
+    placeholder_text: str = Field(
+        default="On it. Working on your request.",
+        validation_alias="CURIE_DISCORD_PLACEHOLDER_TEXT",
+    )
+
+    def load_bindings(self) -> list[DiscordBinding]:
+        """Read the mounted binding map on every ingress selection.
+
+        Environment JSON remains the small local default. Production can mount
+        a file and rotate scoped tokens without restarting the Gateway client.
+        """
+
+        if self.bindings_path is None:
+            return list(self.bindings)
+        raw = json.loads(self.bindings_path.read_text())
+        return TypeAdapter(list[DiscordBinding]).validate_python(raw)

--- a/adapters/discord/src/curie_discord_adapter/egress.py
+++ b/adapters/discord/src/curie_discord_adapter/egress.py
@@ -1,0 +1,80 @@
+"""Neutral Curie reply events rendered onto Discord messages."""
+
+from typing import Protocol
+
+from channel_protocol import ReplyAck, ReplyEvent, ReplyPost, ReplyUpdate, TurnCompleted, TurnStatus
+
+from .state import DiscordState
+
+DISCORD_TEXT_LIMIT = 2000
+
+
+def split_discord_text(text: str) -> list[str]:
+    """Split on Python Unicode code points without dropping content."""
+
+    if not text:
+        return ["\u200b"]
+    return [
+        text[offset : offset + DISCORD_TEXT_LIMIT]
+        for offset in range(0, len(text), DISCORD_TEXT_LIMIT)
+    ]
+
+
+class DiscordPort(Protocol):
+    async def edit_message(self, channel_id: str, message_id: str, text: str) -> None: ...
+
+    async def post_message(self, channel_id: str, text: str) -> str: ...
+
+    async def delete_message(self, channel_id: str, message_id: str) -> None: ...
+
+
+class DiscordReplyService:
+    def __init__(self, discord: DiscordPort, state: DiscordState) -> None:
+        self._discord = discord
+        self._state = state
+
+    async def deliver(self, event: ReplyEvent) -> ReplyAck:
+        if event.target.kind != "discord":
+            raise ValueError(f"Discord adapter cannot render kind {event.target.kind!r}")
+        if isinstance(event, TurnStatus):
+            return ReplyAck(ref=None)
+        if isinstance(event, TurnCompleted):
+            self._state.mark_completed(event.event_id)
+            return ReplyAck(ref=None)
+        channel_id = event.target.conversation_id or event.target.address
+        if isinstance(event, ReplyPost):
+            ref = await self._discord.post_message(channel_id, event.message.text)
+            return ReplyAck(ref=ref)
+        if not isinstance(event, ReplyUpdate):
+            raise TypeError(f"unsupported reply event {type(event).__name__}")
+        text = (
+            event.text
+            if event.text is not None
+            else (event.message.text if event.message else "")
+        )
+        if event.settled is not None:
+            if event.settled.decision is None:
+                text = f"{text}\n\nApproval expired."
+            else:
+                resolver = event.settled.resolver or "an authorized operator"
+                text = f"{text}\n\n{event.settled.decision.title()} by {resolver}."
+        chunks = split_discord_text(text)
+        reply_ref = event.target.reply_ref
+        if reply_ref is None:
+            ref = await self._discord.post_message(channel_id, chunks[0])
+            reply_ref = ref
+        else:
+            await self._discord.edit_message(channel_id, reply_ref, chunks[0])
+        existing = self._state.continuations(channel_id, reply_ref)
+        continuation_ids: list[str] = []
+        for index, chunk in enumerate(chunks[1:]):
+            if index < len(existing):
+                message_id = existing[index]
+                await self._discord.edit_message(channel_id, message_id, chunk)
+            else:
+                message_id = await self._discord.post_message(channel_id, chunk)
+            continuation_ids.append(message_id)
+        for stale_id in existing[len(chunks) - 1 :]:
+            await self._discord.delete_message(channel_id, stale_id)
+        self._state.replace_continuations(channel_id, reply_ref, continuation_ids)
+        return ReplyAck(ref=reply_ref)

--- a/adapters/discord/src/curie_discord_adapter/http.py
+++ b/adapters/discord/src/curie_discord_adapter/http.py
@@ -1,0 +1,38 @@
+"""Authenticated HTTP ingress for Curie's neutral reply events."""
+
+import secrets
+from typing import Protocol
+
+from channel_protocol import ReplyAck, ReplyEvent
+from fastapi import FastAPI, Header, HTTPException, Request, status
+from pydantic import TypeAdapter, ValidationError
+
+_EVENT: TypeAdapter[ReplyEvent] = TypeAdapter(ReplyEvent)
+
+
+class ReplyService(Protocol):
+    async def deliver(self, event: ReplyEvent) -> ReplyAck: ...
+
+
+def create_reply_app(service: ReplyService, adapter_secret: str) -> FastAPI:
+    app = FastAPI(title="Curie Discord adapter", docs_url=None, redoc_url=None)
+
+    @app.post("/replies", response_model=ReplyAck)
+    async def replies(
+        request: Request,
+        x_curie_adapter_key: str | None = Header(default=None),
+    ) -> ReplyAck:
+        supplied = x_curie_adapter_key or ""
+        if not secrets.compare_digest(supplied, adapter_secret):
+            raise HTTPException(status.HTTP_401_UNAUTHORIZED, "missing or invalid credential")
+        try:
+            event = _EVENT.validate_json(await request.body())
+        except ValidationError as exc:
+            raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, exc.errors()) from exc
+        return await service.deliver(event)
+
+    @app.get("/healthz")
+    async def health() -> dict[str, str]:
+        return {"status": "ok"}
+
+    return app

--- a/adapters/discord/src/curie_discord_adapter/http.py
+++ b/adapters/discord/src/curie_discord_adapter/http.py
@@ -20,9 +20,17 @@ def create_reply_app(service: ReplyService, adapter_secret: str) -> FastAPI:
     @app.post("/replies", response_model=ReplyAck)
     async def replies(
         request: Request,
-        x_curie_adapter_key: str | None = Header(default=None),
+        # Matches the worker's own name for this header exactly
+        # (`ADAPTER_SECRET_HEADER` in `apps/worker/src/curie_worker/reply_sink.py`)
+        # -- that is the side that actually sends it, so it is the name that
+        # governs. A prior mismatch here (`X-Curie-Adapter-Key`) meant every
+        # reply delivery 401'd unconditionally: each side's own unit tests
+        # passed in isolation because each asserted its OWN (different) name,
+        # and only a genuine cross-service round trip ever exercised both at
+        # once.
+        x_curie_adapter_secret: str | None = Header(default=None),
     ) -> ReplyAck:
-        supplied = x_curie_adapter_key or ""
+        supplied = x_curie_adapter_secret or ""
         if not secrets.compare_digest(supplied, adapter_secret):
             raise HTTPException(status.HTTP_401_UNAUTHORIZED, "missing or invalid credential")
         try:

--- a/adapters/discord/src/curie_discord_adapter/ingress.py
+++ b/adapters/discord/src/curie_discord_adapter/ingress.py
@@ -1,0 +1,48 @@
+"""Pure Discord message to Curie turn translation."""
+
+import re
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class DiscordBinding:
+    parent_channel_id: str
+    address: str
+    token: str
+
+
+@dataclass(frozen=True)
+class DiscordMessage:
+    id: str
+    channel_id: str
+    thread_id: str
+    author_id: str
+    author_name: str
+    content: str
+    mentioned_user_ids: frozenset[str]
+
+
+def build_turn(
+    message: DiscordMessage,
+    *,
+    bot_user_id: str,
+    binding: DiscordBinding,
+    reply_ref: str,
+    require_mention: bool = True,
+) -> dict[str, str] | None:
+    """Build the exact `/channels/turns` body for one Discord delivery."""
+
+    if require_mention and bot_user_id not in message.mentioned_user_ids:
+        return None
+    text = re.sub(rf"<@!?{re.escape(bot_user_id)}>", "", message.content).strip()
+    if not text:
+        return None
+    return {
+        "kind": "discord",
+        "address": binding.address,
+        "delivery_id": message.id,
+        "conversation_id": message.thread_id,
+        "author": f"{message.author_name} ({message.author_id})",
+        "text": text,
+        "reply_ref": reply_ref,
+    }

--- a/adapters/discord/src/curie_discord_adapter/ingress.py
+++ b/adapters/discord/src/curie_discord_adapter/ingress.py
@@ -30,13 +30,23 @@ def build_turn(
     reply_ref: str,
     require_mention: bool = True,
 ) -> dict[str, str] | None:
-    """Build the exact `/channels/turns` body for one Discord delivery."""
+    """Build the exact `/channels/turns` body for one Discord delivery.
+
+    A mention with nothing else -- ``text`` empty after stripping it -- still
+    becomes a turn, carrying empty text. Whether "nothing to say" is itself a
+    meaningful instruction is the AGENT's call, not this adapter's: a
+    stack-shaped agent (squawk) treats it as "pop," and Slack's dispatcher
+    already forwards the same empty text unconditionally (`handlers.py`'s
+    `_strip_self_mention`) for exactly this reason. Refusing to build a turn
+    here would silently drop the delivery before it ever reaches Curie -- no
+    thread, no turn, nothing an operator could see -- which is a stronger,
+    and inconsistent, claim than Slack's ingress makes about the same
+    mention-only message.
+    """
 
     if require_mention and bot_user_id not in message.mentioned_user_ids:
         return None
     text = re.sub(rf"<@!?{re.escape(bot_user_id)}>", "", message.content).strip()
-    if not text:
-        return None
     return {
         "kind": "discord",
         "address": binding.address,

--- a/adapters/discord/src/curie_discord_adapter/main.py
+++ b/adapters/discord/src/curie_discord_adapter/main.py
@@ -1,0 +1,196 @@
+"""Run the Discord Gateway client and authenticated reply HTTP server."""
+
+import asyncio
+import logging
+from typing import Any
+
+import discord
+import httpx
+import uvicorn
+
+from .config import DiscordConfig
+from .egress import DiscordReplyService
+from .http import create_reply_app
+from .ingress import DiscordBinding, DiscordMessage, build_turn
+from .state import DiscordState
+
+logger = logging.getLogger(__name__)
+
+
+class DiscordAdapter(discord.Client):
+    def __init__(self, config: DiscordConfig, state: DiscordState) -> None:
+        intents = discord.Intents.none()
+        intents.guilds = True
+        intents.messages = True
+        intents.message_content = True
+        super().__init__(intents=intents)
+        self._config = config
+        self._state = state
+        self._disabled_tokens: dict[str, str] = {}
+        self._http = httpx.AsyncClient(timeout=20)
+
+    async def close(self) -> None:
+        await self._http.aclose()
+        await super().close()
+
+    async def on_ready(self) -> None:
+        if self.user is not None:
+            logger.info("Discord adapter connected as application user %s", self.user.id)
+
+    async def on_message(self, message: discord.Message) -> None:
+        if message.author.bot or self.user is None:
+            return
+        channel = message.channel
+        binding: DiscordBinding | None
+        require_mention: bool
+        thread: discord.Thread | None
+        if isinstance(channel, discord.Thread):
+            remembered = self._state.thread_binding(str(channel.id))
+            if remembered is None:
+                return
+            binding = self._binding_for_parent(remembered.parent_channel_id)
+            if binding is None or binding.address != remembered.address:
+                return
+            require_mention = False
+            thread = channel
+        else:
+            binding = self._binding_for_parent(str(channel.id))
+            if binding is None or self.user not in message.mentions:
+                return
+            require_mention = True
+            thread = None
+        preview = self._message(message, str(channel.id))
+        if build_turn(
+            preview,
+            bot_user_id=str(self.user.id),
+            binding=binding,
+            reply_ref="preview",
+            require_mention=require_mention,
+        ) is None:
+            return
+        delivery_id = str(message.id)
+        if not self._state.claim_delivery(delivery_id):
+            return
+        placeholder: discord.Message | None = None
+        try:
+            if thread is None:
+                thread = await message.create_thread(name=self._thread_name(message.content))
+                self._state.remember_thread(str(thread.id), binding)
+            placeholder = await thread.send(
+                self._config.placeholder_text,
+                allowed_mentions=discord.AllowedMentions.none(),
+            )
+            incoming = self._message(message, str(thread.id))
+            turn = build_turn(
+                incoming,
+                bot_user_id=str(self.user.id),
+                binding=binding,
+                reply_ref=str(placeholder.id),
+                require_mention=require_mention,
+            )
+            if turn is None:
+                self._state.release_delivery(delivery_id)
+                return
+            await self._post_turn(binding, turn)
+        except Exception:
+            self._state.release_delivery(delivery_id)
+            logger.exception("Failed to deliver Discord message %s to Curie", message.id)
+            if placeholder is not None:
+                await placeholder.edit(
+                    content="Curie could not accept this message. Please try again.",
+                    allowed_mentions=discord.AllowedMentions.none(),
+                )
+
+    def _binding_for_parent(self, parent_channel_id: str) -> DiscordBinding | None:
+        bindings = {
+            binding.parent_channel_id: binding
+            for binding in self._config.load_bindings()
+        }
+        binding = bindings.get(parent_channel_id)
+        if binding is None:
+            return None
+        disabled_token = self._disabled_tokens.get(binding.address)
+        if disabled_token == binding.token:
+            return None
+        if disabled_token is not None:
+            self._disabled_tokens.pop(binding.address, None)
+        return binding
+
+    def _message(self, message: discord.Message, thread_id: str) -> DiscordMessage:
+        return DiscordMessage(
+            id=str(message.id),
+            channel_id=str(message.channel.id),
+            thread_id=thread_id,
+            author_id=str(message.author.id),
+            author_name=message.author.display_name,
+            content=message.content,
+            mentioned_user_ids=frozenset(str(user.id) for user in message.mentions),
+        )
+
+    @staticmethod
+    def _thread_name(content: str) -> str:
+        clean = " ".join(content.split())
+        return (clean or "Curie conversation")[:100]
+
+    async def _post_turn(self, binding: DiscordBinding, turn: dict[str, str]) -> None:
+        endpoint = f"{self._config.curie_api_url.rstrip('/')}/channels/turns"
+        for attempt in range(3):
+            try:
+                response = await self._http.post(
+                    endpoint,
+                    headers={"X-API-Key": binding.token},
+                    json=turn,
+                )
+                if response.status_code == 401:
+                    self._disabled_tokens[binding.address] = binding.token
+                    logger.error(
+                        "Curie rejected the scoped token for Discord binding %s; "
+                        "ingress for that binding is disabled until the mounted token changes",
+                        binding.address,
+                    )
+                response.raise_for_status()
+                return
+            except httpx.TransportError:
+                if attempt == 2:
+                    raise
+                await asyncio.sleep(0.25 * (2**attempt))
+
+    async def _channel(self, channel_id: str) -> Any:
+        channel = self.get_channel(int(channel_id))
+        return channel if channel is not None else await self.fetch_channel(int(channel_id))
+
+    async def edit_message(self, channel_id: str, message_id: str, text: str) -> None:
+        channel = await self._channel(channel_id)
+        message = await channel.fetch_message(int(message_id))
+        await message.edit(content=text, allowed_mentions=discord.AllowedMentions.none())
+
+    async def post_message(self, channel_id: str, text: str) -> str:
+        channel = await self._channel(channel_id)
+        message = await channel.send(text, allowed_mentions=discord.AllowedMentions.none())
+        return str(message.id)
+
+    async def delete_message(self, channel_id: str, message_id: str) -> None:
+        channel = await self._channel(channel_id)
+        message = await channel.fetch_message(int(message_id))
+        await message.delete()
+
+
+async def run() -> None:
+    config = DiscordConfig()
+    state = DiscordState(config.state_path)
+    adapter = DiscordAdapter(config, state)
+    reply_service = DiscordReplyService(adapter, state)
+    app = create_reply_app(reply_service, config.adapter_secret)
+    server = uvicorn.Server(
+        uvicorn.Config(app, host=config.reply_host, port=config.reply_port, log_level="info")
+    )
+    try:
+        await asyncio.gather(server.serve(), adapter.start(config.discord_bot_token))
+    finally:
+        await adapter.close()
+        state.close()
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO)
+    asyncio.run(run())

--- a/adapters/discord/src/curie_discord_adapter/state.py
+++ b/adapters/discord/src/curie_discord_adapter/state.py
@@ -1,0 +1,114 @@
+"""Small durable state owned by the Discord adapter."""
+
+import sqlite3
+from pathlib import Path
+
+from .ingress import DiscordBinding
+
+
+class DiscordState:
+    def __init__(self, path: Path) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        self._db = sqlite3.connect(path)
+        path.chmod(0o600)
+        self._db.execute("PRAGMA journal_mode=WAL")
+        self._db.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS continuations (
+                conversation_id TEXT NOT NULL,
+                reply_ref TEXT NOT NULL,
+                position INTEGER NOT NULL,
+                message_id TEXT NOT NULL,
+                PRIMARY KEY (conversation_id, reply_ref, position)
+            );
+            CREATE TABLE IF NOT EXISTS completed_events (
+                event_id TEXT PRIMARY KEY
+            );
+            CREATE TABLE IF NOT EXISTS threads (
+                thread_id TEXT PRIMARY KEY,
+                parent_channel_id TEXT NOT NULL,
+                address TEXT NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS ingress_deliveries (
+                delivery_id TEXT PRIMARY KEY
+            );
+            """
+        )
+        self._db.commit()
+
+    def continuations(self, conversation_id: str, reply_ref: str) -> list[str]:
+        rows = self._db.execute(
+            "SELECT message_id FROM continuations "
+            "WHERE conversation_id = ? AND reply_ref = ? ORDER BY position",
+            (conversation_id, reply_ref),
+        ).fetchall()
+        return [str(row[0]) for row in rows]
+
+    def replace_continuations(
+        self, conversation_id: str, reply_ref: str, message_ids: list[str]
+    ) -> None:
+        with self._db:
+            self._db.execute(
+                "DELETE FROM continuations WHERE conversation_id = ? AND reply_ref = ?",
+                (conversation_id, reply_ref),
+            )
+            self._db.executemany(
+                "INSERT INTO continuations "
+                "(conversation_id, reply_ref, position, message_id) VALUES (?, ?, ?, ?)",
+                [
+                    (conversation_id, reply_ref, position, message_id)
+                    for position, message_id in enumerate(message_ids)
+                ],
+            )
+
+    def mark_completed(self, event_id: str) -> bool:
+        with self._db:
+            cursor = self._db.execute(
+                "INSERT OR IGNORE INTO completed_events (event_id) VALUES (?)",
+                (event_id,),
+            )
+        return cursor.rowcount == 1
+
+    def completed_count(self) -> int:
+        row = self._db.execute("SELECT count(*) FROM completed_events").fetchone()
+        return int(row[0]) if row is not None else 0
+
+    def remember_thread(self, thread_id: str, binding: DiscordBinding) -> None:
+        with self._db:
+            self._db.execute(
+                "INSERT OR REPLACE INTO threads "
+                "(thread_id, parent_channel_id, address) VALUES (?, ?, ?)",
+                (thread_id, binding.parent_channel_id, binding.address),
+            )
+
+    def thread_binding(self, thread_id: str) -> DiscordBinding | None:
+        row = self._db.execute(
+            "SELECT parent_channel_id, address FROM threads WHERE thread_id = ?",
+            (thread_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        # Scoped tokens are reloaded from configuration and never persisted in
+        # SQLite, whose WAL would otherwise become another credential store.
+        return DiscordBinding(parent_channel_id=str(row[0]), address=str(row[1]), token="")
+
+    def claim_delivery(self, delivery_id: str) -> bool:
+        """Atomically claim a Gateway delivery before provider side effects."""
+
+        with self._db:
+            cursor = self._db.execute(
+                "INSERT OR IGNORE INTO ingress_deliveries (delivery_id) VALUES (?)",
+                (delivery_id,),
+            )
+        return cursor.rowcount == 1
+
+    def release_delivery(self, delivery_id: str) -> None:
+        """Release a failed intake so a later Gateway retry can try again."""
+
+        with self._db:
+            self._db.execute(
+                "DELETE FROM ingress_deliveries WHERE delivery_id = ?", (delivery_id,)
+            )
+
+    def close(self) -> None:
+        self._db.close()

--- a/adapters/discord/tests/test_config.py
+++ b/adapters/discord/tests/test_config.py
@@ -1,0 +1,40 @@
+import json
+from pathlib import Path
+
+from curie_discord_adapter.config import DiscordConfig
+
+
+def test_bindings_are_parsed_from_environment_json(monkeypatch) -> None:
+    monkeypatch.setenv(
+        "CURIE_DISCORD_BINDINGS",
+        json.dumps(
+            [
+                {
+                    "parent_channel_id": "111",
+                    "address": "111",
+                    "token": "chn_example",
+                }
+            ]
+        ),
+    )
+    config = DiscordConfig(discord_bot_token="bot", adapter_secret="reply-secret")
+    assert config.bindings[0].parent_channel_id == "111"
+    assert config.bindings[0].token == "chn_example"
+
+
+def test_bindings_file_is_reread_for_token_rotation(tmp_path: Path) -> None:
+    path = tmp_path / "bindings.json"
+    path.write_text(
+        json.dumps([{"parent_channel_id": "111", "address": "111", "token": "chn_old"}])
+    )
+    config = DiscordConfig(
+        discord_bot_token="bot",
+        adapter_secret="reply-secret",
+        bindings_path=path,
+    )
+    assert config.load_bindings()[0].token == "chn_old"
+
+    path.write_text(
+        json.dumps([{"parent_channel_id": "111", "address": "111", "token": "chn_new"}])
+    )
+    assert config.load_bindings()[0].token == "chn_new"

--- a/adapters/discord/tests/test_egress.py
+++ b/adapters/discord/tests/test_egress.py
@@ -1,0 +1,127 @@
+import asyncio
+from pathlib import Path
+
+from channel_protocol import (
+    OutboundMessage,
+    ReplyPost,
+    ReplyTarget,
+    ReplyUpdate,
+    SettledOutcome,
+    TurnCompleted,
+    TurnStatus,
+)
+from curie_discord_adapter.egress import DiscordReplyService, split_discord_text
+from curie_discord_adapter.state import DiscordState
+
+
+class FakeDiscord:
+    def __init__(self) -> None:
+        self.edits: list[tuple[str, str, str]] = []
+        self.posts: list[tuple[str, str]] = []
+        self.deletes: list[tuple[str, str]] = []
+
+    async def edit_message(self, channel_id: str, message_id: str, text: str) -> None:
+        self.edits.append((channel_id, message_id, text))
+
+    async def post_message(self, channel_id: str, text: str) -> str:
+        self.posts.append((channel_id, text))
+        return f"posted-{len(self.posts)}"
+
+    async def delete_message(self, channel_id: str, message_id: str) -> None:
+        self.deletes.append((channel_id, message_id))
+
+
+def target() -> ReplyTarget:
+    return ReplyTarget(
+        kind="discord",
+        address="111",
+        conversation_id="222",
+        reply_ref="9002",
+    )
+
+
+def test_text_chunks_are_unicode_safe_and_within_discord_limit() -> None:
+    text = "x" * 1999 + "🙂" + "y" * 2001
+    chunks = split_discord_text(text)
+    assert "".join(chunks) == text
+    assert all(0 < len(chunk) <= 2000 for chunk in chunks)
+
+
+def test_reply_update_edits_placeholder_and_posts_continuations(tmp_path: Path) -> None:
+    port = FakeDiscord()
+    state = DiscordState(tmp_path / "state.sqlite3")
+    service = DiscordReplyService(port, state)
+    event = ReplyUpdate(version="1.0", event="reply.update", target=target(), text="a" * 2001)
+
+    ack = asyncio.run(service.deliver(event))
+
+    assert ack.ref == "9002"
+    assert port.edits == [("222", "9002", "a" * 2000)]
+    assert port.posts == [("222", "a")]
+    assert state.continuations("222", "9002") == ["posted-1"]
+
+    shorter = ReplyUpdate(version="1.0", event="reply.update", target=target(), text="done")
+    asyncio.run(service.deliver(shorter))
+    assert port.deletes == [("222", "posted-1")]
+    assert state.continuations("222", "9002") == []
+
+
+def test_settled_approval_uses_text_fallback_and_terminal_outcome(tmp_path: Path) -> None:
+    port = FakeDiscord()
+    state = DiscordState(tmp_path / "state.sqlite3")
+    service = DiscordReplyService(port, state)
+    event = ReplyUpdate(
+        version="1.0",
+        event="reply.update",
+        target=target(),
+        message=OutboundMessage(version="1.0", text="Deploy production?"),
+        settled=SettledOutcome(
+            requested_by="Ada",
+            decision="approved",
+            resolver="Grace",
+        ),
+    )
+
+    asyncio.run(service.deliver(event))
+
+    assert port.edits == [("222", "9002", "Deploy production?\n\nApproved by Grace.")]
+
+
+def test_status_is_noop_and_post_uses_text_fallback(tmp_path: Path) -> None:
+    port = FakeDiscord()
+    state = DiscordState(tmp_path / "state.sqlite3")
+    service = DiscordReplyService(port, state)
+
+    status = asyncio.run(service.deliver(
+        TurnStatus(version="1.0", event="turn.status", target=target(), status="working")
+    ))
+    posted = asyncio.run(service.deliver(
+        ReplyPost(
+            version="1.0",
+            event="reply.post",
+            target=target(),
+            message=OutboundMessage(version="1.0", text="approve in the Curie CLI"),
+            requested_by="Ada",
+        )
+    ))
+
+    assert status.ref is None
+    assert posted.ref == "posted-1"
+    assert port.posts == [("222", "approve in the Curie CLI")]
+
+
+def test_completion_is_deduped_durably(tmp_path: Path) -> None:
+    port = FakeDiscord()
+    state = DiscordState(tmp_path / "state.sqlite3")
+    service = DiscordReplyService(port, state)
+    event = TurnCompleted(
+        version="1.0",
+        event="turn.completed",
+        target=target(),
+        event_id="done-1",
+        outcome="delivered",
+    )
+
+    assert asyncio.run(service.deliver(event)).ref is None
+    assert asyncio.run(service.deliver(event)).ref is None
+    assert state.completed_count() == 1

--- a/adapters/discord/tests/test_http.py
+++ b/adapters/discord/tests/test_http.py
@@ -1,0 +1,43 @@
+from channel_protocol import ReplyAck
+from curie_discord_adapter.http import create_reply_app
+from fastapi.testclient import TestClient
+
+
+class Recorder:
+    def __init__(self) -> None:
+        self.events = []
+
+    async def deliver(self, event):
+        self.events.append(event)
+        return ReplyAck(ref=event.target.reply_ref)
+
+
+def payload() -> dict:
+    return {
+        "version": "1.0",
+        "event": "turn.status",
+        "target": {
+            "kind": "discord",
+            "address": "111",
+            "conversation_id": "222",
+            "reply_ref": "333",
+        },
+        "status": "working",
+    }
+
+
+def test_reply_endpoint_authenticates_and_parses_the_neutral_wire() -> None:
+    recorder = Recorder()
+    client = TestClient(create_reply_app(recorder, "reply-secret"))
+
+    assert client.post("/replies", json=payload()).status_code == 401
+    accepted = client.post(
+        "/replies",
+        json=payload(),
+        headers={"X-Curie-Adapter-Key": "reply-secret"},
+    )
+
+    assert accepted.status_code == 200
+    assert accepted.json() == {"ref": "333"}
+    assert len(recorder.events) == 1
+    assert recorder.events[0].event == "turn.status"

--- a/adapters/discord/tests/test_http.py
+++ b/adapters/discord/tests/test_http.py
@@ -34,7 +34,7 @@ def test_reply_endpoint_authenticates_and_parses_the_neutral_wire() -> None:
     accepted = client.post(
         "/replies",
         json=payload(),
-        headers={"X-Curie-Adapter-Key": "reply-secret"},
+        headers={"X-Curie-Adapter-Secret": "reply-secret"},
     )
 
     assert accepted.status_code == 200

--- a/adapters/discord/tests/test_ingress.py
+++ b/adapters/discord/tests/test_ingress.py
@@ -1,0 +1,41 @@
+from curie_discord_adapter.ingress import DiscordBinding, DiscordMessage, build_turn
+
+
+def test_parent_mention_becomes_a_stable_curie_turn() -> None:
+    binding = DiscordBinding(parent_channel_id="111", address="111", token="chn_test")
+    message = DiscordMessage(
+        id="9001",
+        channel_id="111",
+        thread_id="222",
+        author_id="333",
+        author_name="Ada",
+        content="<@42> summarize this",
+        mentioned_user_ids=frozenset({"42"}),
+    )
+
+    turn = build_turn(message, bot_user_id="42", binding=binding, reply_ref="9002")
+
+    assert turn == {
+        "kind": "discord",
+        "address": "111",
+        "delivery_id": "9001",
+        "conversation_id": "222",
+        "author": "Ada (333)",
+        "text": "summarize this",
+        "reply_ref": "9002",
+    }
+
+
+def test_message_without_the_bot_mention_is_not_a_new_turn() -> None:
+    binding = DiscordBinding(parent_channel_id="111", address="111", token="chn_test")
+    message = DiscordMessage(
+        id="9001",
+        channel_id="111",
+        thread_id="222",
+        author_id="333",
+        author_name="Ada",
+        content="summarize this",
+        mentioned_user_ids=frozenset(),
+    )
+
+    assert build_turn(message, bot_user_id="42", binding=binding, reply_ref="9002") is None

--- a/adapters/discord/tests/test_ingress.py
+++ b/adapters/discord/tests/test_ingress.py
@@ -26,6 +26,35 @@ def test_parent_mention_becomes_a_stable_curie_turn() -> None:
     }
 
 
+def test_a_mention_with_nothing_else_still_becomes_a_turn_with_empty_text() -> None:
+    # Whether "nothing to say" is meaningful is the agent's call (a
+    # stack-shaped agent treats it as pop), never this adapter's -- refusing
+    # to build a turn here would drop the delivery before Curie ever saw it,
+    # inconsistent with Slack's ingress forwarding the same empty text.
+    binding = DiscordBinding(parent_channel_id="111", address="111", token="chn_test")
+    message = DiscordMessage(
+        id="9001",
+        channel_id="111",
+        thread_id="222",
+        author_id="333",
+        author_name="Ada",
+        content="<@42>",
+        mentioned_user_ids=frozenset({"42"}),
+    )
+
+    turn = build_turn(message, bot_user_id="42", binding=binding, reply_ref="9002")
+
+    assert turn == {
+        "kind": "discord",
+        "address": "111",
+        "delivery_id": "9001",
+        "conversation_id": "222",
+        "author": "Ada (333)",
+        "text": "",
+        "reply_ref": "9002",
+    }
+
+
 def test_message_without_the_bot_mention_is_not_a_new_turn() -> None:
     binding = DiscordBinding(parent_channel_id="111", address="111", token="chn_test")
     message = DiscordMessage(

--- a/adapters/discord/tests/test_main.py
+++ b/adapters/discord/tests/test_main.py
@@ -1,0 +1,72 @@
+import asyncio
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+from curie_discord_adapter.config import DiscordConfig
+from curie_discord_adapter.ingress import DiscordBinding
+from curie_discord_adapter.main import DiscordAdapter
+from curie_discord_adapter.state import DiscordState
+
+
+class RejectingHttp:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def post(self, *args, **kwargs) -> httpx.Response:
+        self.calls += 1
+        return httpx.Response(401, request=httpx.Request("POST", "https://curie.example.com"))
+
+    async def aclose(self) -> None:
+        return None
+
+
+def config(path: Path, bindings_path: Path) -> DiscordConfig:
+    return DiscordConfig(
+        discord_bot_token="bot",
+        adapter_secret="reply-secret",
+        state_path=path,
+        bindings_path=bindings_path,
+        curie_api_url="https://curie.example.com",
+    )
+
+
+def test_rotated_binding_file_reenables_a_401_disabled_surface(tmp_path: Path) -> None:
+    bindings_path = tmp_path / "bindings.json"
+    bindings_path.write_text(
+        json.dumps([{"parent_channel_id": "111", "address": "111", "token": "chn_old"}])
+    )
+    state = DiscordState(tmp_path / "state.sqlite3")
+    adapter = DiscordAdapter(config(tmp_path / "state.sqlite3", bindings_path), state)
+    old = adapter._binding_for_parent("111")
+    assert old is not None
+    adapter._disabled_tokens["111"] = old.token
+    assert adapter._binding_for_parent("111") is None
+
+    bindings_path.write_text(
+        json.dumps([{"parent_channel_id": "111", "address": "111", "token": "chn_new"}])
+    )
+    rotated = adapter._binding_for_parent("111")
+    assert rotated is not None
+    assert rotated.token == "chn_new"
+    asyncio.run(adapter.close())
+    state.close()
+
+
+def test_curie_401_is_final_and_disables_only_that_token(tmp_path: Path) -> None:
+    bindings_path = tmp_path / "bindings.json"
+    bindings_path.write_text("[]")
+    state = DiscordState(tmp_path / "state.sqlite3")
+    adapter = DiscordAdapter(config(tmp_path / "state.sqlite3", bindings_path), state)
+    rejecting = RejectingHttp()
+    adapter._http = rejecting  # type: ignore[assignment]
+    binding = DiscordBinding(parent_channel_id="111", address="111", token="chn_bad")
+
+    with pytest.raises(httpx.HTTPStatusError):
+        asyncio.run(adapter._post_turn(binding, {"kind": "discord"}))
+
+    assert rejecting.calls == 1
+    assert adapter._disabled_tokens == {"111": "chn_bad"}
+    asyncio.run(adapter.close())
+    state.close()

--- a/adapters/discord/tests/test_state.py
+++ b/adapters/discord/tests/test_state.py
@@ -1,0 +1,37 @@
+from curie_discord_adapter.ingress import DiscordBinding
+from curie_discord_adapter.state import DiscordState
+
+
+def test_continuations_and_completion_dedupe_survive_reopen(tmp_path) -> None:
+    path = tmp_path / "discord.sqlite3"
+    state = DiscordState(path)
+    state.replace_continuations("thread-1", "placeholder-1", ["message-2", "message-3"])
+    assert state.mark_completed("event-1") is True
+    state.close()
+
+    reopened = DiscordState(path)
+    assert reopened.continuations("thread-1", "placeholder-1") == ["message-2", "message-3"]
+    assert reopened.mark_completed("event-1") is False
+    reopened.close()
+
+
+def test_delivery_claims_and_thread_routes_are_durable_without_persisting_tokens(tmp_path) -> None:
+    path = tmp_path / "discord.sqlite3"
+    state = DiscordState(path)
+    binding = DiscordBinding(parent_channel_id="111", address="111", token="chn_private")
+
+    assert state.claim_delivery("message-1") is True
+    assert state.claim_delivery("message-1") is False
+    state.release_delivery("message-1")
+    assert state.claim_delivery("message-1") is True
+    state.remember_thread("thread-1", binding)
+    state.close()
+
+    reopened = DiscordState(path)
+    remembered = reopened.thread_binding("thread-1")
+    assert remembered is not None
+    assert (remembered.parent_channel_id, remembered.address) == ("111", "111")
+    assert remembered.token == ""
+    assert reopened.claim_delivery("message-1") is False
+    reopened.close()
+    assert b"chn_private" not in path.read_bytes()

--- a/docs/guides/building-a-channel-adapter.md
+++ b/docs/guides/building-a-channel-adapter.md
@@ -1,5 +1,9 @@
 # Building a channel adapter
 
+For a complete production-shaped example, see
+[`adapters/discord`](../../adapters/discord/) and
+[`Connect one Curie agent to Discord and Slack`](discord-adapter.md).
+
 How to put Curie on a channel it has never heard of (a mail server, a support
 desk, a webhook bus) without changing the platform. Since ADR-0096 phase 2 the
 channel port is neutral: the platform never learns your channel's shape, and you

--- a/docs/guides/discord-adapter.md
+++ b/docs/guides/discord-adapter.md
@@ -1,0 +1,88 @@
+# Connect one Curie agent to Discord and Slack
+
+Multi surface is implicit. An agent with one surface behaves as before. Adding
+a second surface opts that same agent into multi surface operation. There is no
+mode or feature flag to enable, and removing surfaces until one remains opts it
+back out.
+
+The Discord service in `adapters/discord` is a real channel adapter. Discord
+Gateway events enter Curie's existing `/channels/turns` endpoint, and the
+worker sends neutral reply events back to the adapter's `/replies` endpoint.
+The agent id, active deployment, memory, and bundle are shared. Conversation
+state remains isolated by surface kind and Discord thread id.
+
+## 1. Configure the Discord application
+
+Create a Discord bot, enable the Message Content intent, and grant it these
+permissions in the target server:
+
+- view channels and read message history
+- send messages
+- create public threads
+- send messages in threads
+- manage its own messages
+
+The Discord bot token belongs only in the adapter process.
+
+## 2. Add the Discord surface
+
+Choose an adapter credential name and configure the worker with a JSON map:
+
+```bash
+export CURIE_ADAPTER_CREDENTIALS='{"discord-main":"replace-with-a-shared-reply-secret"}'
+```
+
+Add the Discord parent channel to the same Curie agent that already owns the
+Slack surface:
+
+```bash
+curie local surfaces acme-bot \
+  --add discord=111111111111111111 \
+  --endpoint https://discord-adapter.example.com/replies \
+  --adapter discord-main
+```
+
+The command returns all surfaces on the agent. Seeing both `slack` and
+`discord` under the same agent name proves this is one bot identity rather than
+two copies of its source.
+
+Mint a token scoped to the Discord binding using the existing channel-token
+endpoint, then configure the adapter:
+
+```bash
+export DISCORD_BOT_TOKEN='replace-with-the-discord-bot-token'
+export CURIE_DISCORD_ADAPTER_SECRET='replace-with-a-shared-reply-secret'
+export CURIE_API_URL='https://curie.example.com'
+export CURIE_DISCORD_BINDINGS='[{"parent_channel_id":"111111111111111111","address":"111111111111111111","token":"chn_example"}]'
+python -m curie_discord_adapter
+```
+
+For token rotation without reconnecting Discord, mount that JSON array as a
+file and set `CURIE_DISCORD_BINDINGS_PATH` instead. The adapter rereads it for
+each intake. Its SQLite state stores thread routing and delivery ids, never the
+scoped token.
+
+`CURIE_DISCORD_ADAPTER_SECRET` must equal the value selected by
+`discord-main` in `CURIE_ADAPTER_CREDENTIALS`. The scoped `chn_` token is sent
+only from the adapter to Curie's turn ingress.
+
+## 3. Verify one agent on both surfaces
+
+Run `curie local surfaces acme-bot --json` and capture the single agent plus
+its Slack and Discord pairs. Mention the bot in the configured Discord parent
+channel. The adapter creates a thread and placeholder, and Curie edits the
+placeholder with the response. Send a follow-up inside that thread without a
+new mention. Then mention the same agent in Slack and continue its Slack
+thread.
+
+The observable success conditions are:
+
+- both pairs belong to one Curie agent id
+- both turns resolve the same active deployment and bundle
+- the Discord response stays in its Discord thread
+- the Slack response stays in its Slack thread
+- a failure on either adapter never redirects the response to the other
+
+Discord v1 supports text, mentions, adapter-created threads, streamed text
+edits, and text fallbacks for platform posts. Direct messages, files, Discord
+buttons, and interactive approvals are outside this first adapter version.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "plugin-format",
     "curie-api",
     "curie-dispatcher",
+    "curie-discord-adapter",
     "curie-worker",
     "curie-runner",
 ]
@@ -24,6 +25,7 @@ members = [
     "packages/test-support",
     "apps/api",
     "apps/dispatcher",
+    "adapters/discord",
     "apps/worker",
     "runner",
     "tools/doclint",
@@ -37,6 +39,7 @@ plugin-format = { workspace = true }
 curie-test-support = { workspace = true }
 curie-api = { workspace = true }
 curie-dispatcher = { workspace = true }
+curie-discord-adapter = { workspace = true }
 curie-worker = { workspace = true }
 curie-runner = { workspace = true }
 curie-doclint = { workspace = true }
@@ -69,6 +72,7 @@ root_packages = [
     "curie_api",
     "curie_worker",
     "curie_dispatcher",
+    "curie_discord_adapter",
     "curie_runner",
     # The frozen contract packages (#961). Outside the graph, no contract could
     # ever fire on them, which left the worst possible place for an SDK import
@@ -87,7 +91,7 @@ include_external_packages = true
 # direction that is hardest to see in review.
 name = "The platform never imports a harness SDK"
 type = "forbidden"
-source_modules = ["curie_api", "curie_worker", "curie_dispatcher"]
+source_modules = ["curie_api", "curie_worker", "curie_dispatcher", "curie_discord_adapter"]
 forbidden_modules = ["claude_agent_sdk"]
 
 [[tool.importlinter.contracts]]
@@ -172,6 +176,7 @@ mypy_path = [
     "packages/test-support/src",
     "apps/api/src",
     "apps/dispatcher/src",
+    "adapters/discord/src",
     "apps/worker/src",
     "runner/src",
     "tools/doclint/src",
@@ -184,6 +189,7 @@ files = [
     "packages/test-support/src",
     "apps/api/src",
     "apps/dispatcher/src",
+    "adapters/discord/src",
     "apps/worker/src",
     "runner/src",
     "tools/doclint/src",

--- a/uv.lock
+++ b/uv.lock
@@ -14,6 +14,7 @@ members = [
     "aci-protocol",
     "curie-api",
     "curie-channel-protocol",
+    "curie-discord-adapter",
     "curie-dispatcher",
     "curie-doclint",
     "curie-runner",
@@ -265,6 +266,62 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
+name = "audioop-lts"
+version = "0.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/38/53/946db57842a50b2da2e0c1e34bd37f36f5aadba1a929a3971c5d7841dbca/audioop_lts-0.2.2.tar.gz", hash = "sha256:64d0c62d88e67b98a1a5e71987b7aa7b5bcffc7dcee65b635823dbdd0a8dbbd0", size = 30686, upload-time = "2025-08-05T16:43:17.409Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/d4/94d277ca941de5a507b07f0b592f199c22454eeaec8f008a286b3fbbacd6/audioop_lts-0.2.2-cp313-abi3-macosx_10_13_universal2.whl", hash = "sha256:fd3d4602dc64914d462924a08c1a9816435a2155d74f325853c1f1ac3b2d9800", size = 46523, upload-time = "2025-08-05T16:42:20.836Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/5a/656d1c2da4b555920ce4177167bfeb8623d98765594af59702c8873f60ec/audioop_lts-0.2.2-cp313-abi3-macosx_10_13_x86_64.whl", hash = "sha256:550c114a8df0aafe9a05442a1162dfc8fec37e9af1d625ae6060fed6e756f303", size = 27455, upload-time = "2025-08-05T16:42:22.283Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/83/ea581e364ce7b0d41456fb79d6ee0ad482beda61faf0cab20cbd4c63a541/audioop_lts-0.2.2-cp313-abi3-macosx_11_0_arm64.whl", hash = "sha256:9a13dc409f2564de15dd68be65b462ba0dde01b19663720c68c1140c782d1d75", size = 26997, upload-time = "2025-08-05T16:42:23.849Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/3b/e8964210b5e216e5041593b7d33e97ee65967f17c282e8510d19c666dab4/audioop_lts-0.2.2-cp313-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:51c916108c56aa6e426ce611946f901badac950ee2ddaf302b7ed35d9958970d", size = 85844, upload-time = "2025-08-05T16:42:25.208Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/2e/0a1c52faf10d51def20531a59ce4c706cb7952323b11709e10de324d6493/audioop_lts-0.2.2-cp313-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:47eba38322370347b1c47024defbd36374a211e8dd5b0dcbce7b34fdb6f8847b", size = 85056, upload-time = "2025-08-05T16:42:26.559Z" },
+    { url = "https://files.pythonhosted.org/packages/75/e8/cd95eef479656cb75ab05dfece8c1f8c395d17a7c651d88f8e6e291a63ab/audioop_lts-0.2.2-cp313-abi3-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ba7c3a7e5f23e215cb271516197030c32aef2e754252c4c70a50aaff7031a2c8", size = 93892, upload-time = "2025-08-05T16:42:27.902Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/1e/a0c42570b74f83efa5cca34905b3eef03f7ab09fe5637015df538a7f3345/audioop_lts-0.2.2-cp313-abi3-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:def246fe9e180626731b26e89816e79aae2276f825420a07b4a647abaa84becc", size = 96660, upload-time = "2025-08-05T16:42:28.9Z" },
+    { url = "https://files.pythonhosted.org/packages/50/d5/8a0ae607ca07dbb34027bac8db805498ee7bfecc05fd2c148cc1ed7646e7/audioop_lts-0.2.2-cp313-abi3-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e160bf9df356d841bb6c180eeeea1834085464626dc1b68fa4e1d59070affdc3", size = 79143, upload-time = "2025-08-05T16:42:29.929Z" },
+    { url = "https://files.pythonhosted.org/packages/12/17/0d28c46179e7910bfb0bb62760ccb33edb5de973052cb2230b662c14ca2e/audioop_lts-0.2.2-cp313-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:4b4cd51a57b698b2d06cb9993b7ac8dfe89a3b2878e96bc7948e9f19ff51dba6", size = 84313, upload-time = "2025-08-05T16:42:30.949Z" },
+    { url = "https://files.pythonhosted.org/packages/84/ba/bd5d3806641564f2024e97ca98ea8f8811d4e01d9b9f9831474bc9e14f9e/audioop_lts-0.2.2-cp313-abi3-musllinux_1_2_ppc64le.whl", hash = "sha256:4a53aa7c16a60a6857e6b0b165261436396ef7293f8b5c9c828a3a203147ed4a", size = 93044, upload-time = "2025-08-05T16:42:31.959Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/5e/435ce8d5642f1f7679540d1e73c1c42d933331c0976eb397d1717d7f01a3/audioop_lts-0.2.2-cp313-abi3-musllinux_1_2_riscv64.whl", hash = "sha256:3fc38008969796f0f689f1453722a0f463da1b8a6fbee11987830bfbb664f623", size = 78766, upload-time = "2025-08-05T16:42:33.302Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3b/b909e76b606cbfd53875693ec8c156e93e15a1366a012f0b7e4fb52d3c34/audioop_lts-0.2.2-cp313-abi3-musllinux_1_2_s390x.whl", hash = "sha256:15ab25dd3e620790f40e9ead897f91e79c0d3ce65fe193c8ed6c26cffdd24be7", size = 87640, upload-time = "2025-08-05T16:42:34.854Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e7/8f1603b4572d79b775f2140d7952f200f5e6c62904585d08a01f0a70393a/audioop_lts-0.2.2-cp313-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:03f061a1915538fd96272bac9551841859dbb2e3bf73ebe4a23ef043766f5449", size = 86052, upload-time = "2025-08-05T16:42:35.839Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/96/c37846df657ccdda62ba1ae2b6534fa90e2e1b1742ca8dcf8ebd38c53801/audioop_lts-0.2.2-cp313-abi3-win32.whl", hash = "sha256:3bcddaaf6cc5935a300a8387c99f7a7fbbe212a11568ec6cf6e4bc458c048636", size = 26185, upload-time = "2025-08-05T16:42:37.04Z" },
+    { url = "https://files.pythonhosted.org/packages/34/a5/9d78fdb5b844a83da8a71226c7bdae7cc638861085fff7a1d707cb4823fa/audioop_lts-0.2.2-cp313-abi3-win_amd64.whl", hash = "sha256:a2c2a947fae7d1062ef08c4e369e0ba2086049a5e598fda41122535557012e9e", size = 30503, upload-time = "2025-08-05T16:42:38.427Z" },
+    { url = "https://files.pythonhosted.org/packages/34/25/20d8fde083123e90c61b51afb547bb0ea7e77bab50d98c0ab243d02a0e43/audioop_lts-0.2.2-cp313-abi3-win_arm64.whl", hash = "sha256:5f93a5db13927a37d2d09637ccca4b2b6b48c19cd9eda7b17a2e9f77edee6a6f", size = 24173, upload-time = "2025-08-05T16:42:39.704Z" },
+    { url = "https://files.pythonhosted.org/packages/58/a7/0a764f77b5c4ac58dc13c01a580f5d32ae8c74c92020b961556a43e26d02/audioop_lts-0.2.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:73f80bf4cd5d2ca7814da30a120de1f9408ee0619cc75da87d0641273d202a09", size = 47096, upload-time = "2025-08-05T16:42:40.684Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/ed/ebebedde1a18848b085ad0fa54b66ceb95f1f94a3fc04f1cd1b5ccb0ed42/audioop_lts-0.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:106753a83a25ee4d6f473f2be6b0966fc1c9af7e0017192f5531a3e7463dce58", size = 27748, upload-time = "2025-08-05T16:42:41.992Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/6e/11ca8c21af79f15dbb1c7f8017952ee8c810c438ce4e2b25638dfef2b02c/audioop_lts-0.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:fbdd522624141e40948ab3e8cdae6e04c748d78710e9f0f8d4dae2750831de19", size = 27329, upload-time = "2025-08-05T16:42:42.987Z" },
+    { url = "https://files.pythonhosted.org/packages/84/52/0022f93d56d85eec5da6b9da6a958a1ef09e80c39f2cc0a590c6af81dcbb/audioop_lts-0.2.2-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:143fad0311e8209ece30a8dbddab3b65ab419cbe8c0dde6e8828da25999be911", size = 92407, upload-time = "2025-08-05T16:42:44.336Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1d/48a889855e67be8718adbc7a01f3c01d5743c325453a5e81cf3717664aad/audioop_lts-0.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dfbbc74ec68a0fd08cfec1f4b5e8cca3d3cd7de5501b01c4b5d209995033cde9", size = 91811, upload-time = "2025-08-05T16:42:45.325Z" },
+    { url = "https://files.pythonhosted.org/packages/98/a6/94b7213190e8077547ffae75e13ed05edc488653c85aa5c41472c297d295/audioop_lts-0.2.2-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cfcac6aa6f42397471e4943e0feb2244549db5c5d01efcd02725b96af417f3fe", size = 100470, upload-time = "2025-08-05T16:42:46.468Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/e9/78450d7cb921ede0cfc33426d3a8023a3bda755883c95c868ee36db8d48d/audioop_lts-0.2.2-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:752d76472d9804ac60f0078c79cdae8b956f293177acd2316cd1e15149aee132", size = 103878, upload-time = "2025-08-05T16:42:47.576Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/e2/cd5439aad4f3e34ae1ee852025dc6aa8f67a82b97641e390bf7bd9891d3e/audioop_lts-0.2.2-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:83c381767e2cc10e93e40281a04852facc4cd9334550e0f392f72d1c0a9c5753", size = 84867, upload-time = "2025-08-05T16:42:49.003Z" },
+    { url = "https://files.pythonhosted.org/packages/68/4b/9d853e9076c43ebba0d411e8d2aa19061083349ac695a7d082540bad64d0/audioop_lts-0.2.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c0022283e9556e0f3643b7c3c03f05063ca72b3063291834cca43234f20c60bb", size = 90001, upload-time = "2025-08-05T16:42:50.038Z" },
+    { url = "https://files.pythonhosted.org/packages/58/26/4bae7f9d2f116ed5593989d0e521d679b0d583973d203384679323d8fa85/audioop_lts-0.2.2-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:a2d4f1513d63c795e82948e1305f31a6d530626e5f9f2605408b300ae6095093", size = 99046, upload-time = "2025-08-05T16:42:51.111Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/67/a9f4fb3e250dda9e9046f8866e9fa7d52664f8985e445c6b4ad6dfb55641/audioop_lts-0.2.2-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:c9c8e68d8b4a56fda8c025e538e639f8c5953f5073886b596c93ec9b620055e7", size = 84788, upload-time = "2025-08-05T16:42:52.198Z" },
+    { url = "https://files.pythonhosted.org/packages/70/f7/3de86562db0121956148bcb0fe5b506615e3bcf6e63c4357a612b910765a/audioop_lts-0.2.2-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:96f19de485a2925314f5020e85911fb447ff5fbef56e8c7c6927851b95533a1c", size = 94472, upload-time = "2025-08-05T16:42:53.59Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/32/fd772bf9078ae1001207d2df1eef3da05bea611a87dd0e8217989b2848fa/audioop_lts-0.2.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:e541c3ef484852ef36545f66209444c48b28661e864ccadb29daddb6a4b8e5f5", size = 92279, upload-time = "2025-08-05T16:42:54.632Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/41/affea7181592ab0ab560044632571a38edaf9130b84928177823fbf3176a/audioop_lts-0.2.2-cp313-cp313t-win32.whl", hash = "sha256:d5e73fa573e273e4f2e5ff96f9043858a5e9311e94ffefd88a3186a910c70917", size = 26568, upload-time = "2025-08-05T16:42:55.627Z" },
+    { url = "https://files.pythonhosted.org/packages/28/2b/0372842877016641db8fc54d5c88596b542eec2f8f6c20a36fb6612bf9ee/audioop_lts-0.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:9191d68659eda01e448188f60364c7763a7ca6653ed3f87ebb165822153a8547", size = 30942, upload-time = "2025-08-05T16:42:56.674Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ca/baf2b9cc7e96c179bb4a54f30fcd83e6ecb340031bde68f486403f943768/audioop_lts-0.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:c174e322bb5783c099aaf87faeb240c8d210686b04bd61dfd05a8e5a83d88969", size = 24603, upload-time = "2025-08-05T16:42:57.571Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/73/413b5a2804091e2c7d5def1d618e4837f1cb82464e230f827226278556b7/audioop_lts-0.2.2-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:f9ee9b52f5f857fbaf9d605a360884f034c92c1c23021fb90b2e39b8e64bede6", size = 47104, upload-time = "2025-08-05T16:42:58.518Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/8c/daa3308dc6593944410c2c68306a5e217f5c05b70a12e70228e7dd42dc5c/audioop_lts-0.2.2-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:49ee1a41738a23e98d98b937a0638357a2477bc99e61b0f768a8f654f45d9b7a", size = 27754, upload-time = "2025-08-05T16:43:00.132Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/86/c2e0f627168fcf61781a8f72cab06b228fe1da4b9fa4ab39cfb791b5836b/audioop_lts-0.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5b00be98ccd0fc123dcfad31d50030d25fcf31488cde9e61692029cd7394733b", size = 27332, upload-time = "2025-08-05T16:43:01.666Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/bd/35dce665255434f54e5307de39e31912a6f902d4572da7c37582809de14f/audioop_lts-0.2.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:a6d2e0f9f7a69403e388894d4ca5ada5c47230716a03f2847cfc7bd1ecb589d6", size = 92396, upload-time = "2025-08-05T16:43:02.991Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/d2/deeb9f51def1437b3afa35aeb729d577c04bcd89394cb56f9239a9f50b6f/audioop_lts-0.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f9b0b8a03ef474f56d1a842af1a2e01398b8f7654009823c6d9e0ecff4d5cfbf", size = 91811, upload-time = "2025-08-05T16:43:04.096Z" },
+    { url = "https://files.pythonhosted.org/packages/76/3b/09f8b35b227cee28cc8231e296a82759ed80c1a08e349811d69773c48426/audioop_lts-0.2.2-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2b267b70747d82125f1a021506565bdc5609a2b24bcb4773c16d79d2bb260bbd", size = 100483, upload-time = "2025-08-05T16:43:05.085Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/15/05b48a935cf3b130c248bfdbdea71ce6437f5394ee8533e0edd7cfd93d5e/audioop_lts-0.2.2-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:0337d658f9b81f4cd0fdb1f47635070cc084871a3d4646d9de74fdf4e7c3d24a", size = 103885, upload-time = "2025-08-05T16:43:06.197Z" },
+    { url = "https://files.pythonhosted.org/packages/83/80/186b7fce6d35b68d3d739f228dc31d60b3412105854edb975aa155a58339/audioop_lts-0.2.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:167d3b62586faef8b6b2275c3218796b12621a60e43f7e9d5845d627b9c9b80e", size = 84899, upload-time = "2025-08-05T16:43:07.291Z" },
+    { url = "https://files.pythonhosted.org/packages/49/89/c78cc5ac6cb5828f17514fb12966e299c850bc885e80f8ad94e38d450886/audioop_lts-0.2.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:0d9385e96f9f6da847f4d571ce3cb15b5091140edf3db97276872647ce37efd7", size = 89998, upload-time = "2025-08-05T16:43:08.335Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/4b/6401888d0c010e586c2ca50fce4c903d70a6bb55928b16cfbdfd957a13da/audioop_lts-0.2.2-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:48159d96962674eccdca9a3df280e864e8ac75e40a577cc97c5c42667ffabfc5", size = 99046, upload-time = "2025-08-05T16:43:09.367Z" },
+    { url = "https://files.pythonhosted.org/packages/de/f8/c874ca9bb447dae0e2ef2e231f6c4c2b0c39e31ae684d2420b0f9e97ee68/audioop_lts-0.2.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:8fefe5868cd082db1186f2837d64cfbfa78b548ea0d0543e9b28935ccce81ce9", size = 84843, upload-time = "2025-08-05T16:43:10.749Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/c0/0323e66f3daebc13fd46b36b30c3be47e3fc4257eae44f1e77eb828c703f/audioop_lts-0.2.2-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:58cf54380c3884fb49fdd37dfb7a772632b6701d28edd3e2904743c5e1773602", size = 94490, upload-time = "2025-08-05T16:43:12.131Z" },
+    { url = "https://files.pythonhosted.org/packages/98/6b/acc7734ac02d95ab791c10c3f17ffa3584ccb9ac5c18fd771c638ed6d1f5/audioop_lts-0.2.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:088327f00488cdeed296edd9215ca159f3a5a5034741465789cad403fcf4bec0", size = 92297, upload-time = "2025-08-05T16:43:13.139Z" },
+    { url = "https://files.pythonhosted.org/packages/13/c3/c3dc3f564ce6877ecd2a05f8d751b9b27a8c320c2533a98b0c86349778d0/audioop_lts-0.2.2-cp314-cp314t-win32.whl", hash = "sha256:068aa17a38b4e0e7de771c62c60bbca2455924b67a8814f3b0dee92b5820c0b3", size = 27331, upload-time = "2025-08-05T16:43:14.19Z" },
+    { url = "https://files.pythonhosted.org/packages/72/bb/b4608537e9ffcb86449091939d52d24a055216a36a8bf66b936af8c3e7ac/audioop_lts-0.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:a5bf613e96f49712073de86f20dbdd4014ca18efd4d34ed18c75bd808337851b", size = 31697, upload-time = "2025-08-05T16:43:15.193Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/22/91616fe707a5c5510de2cac9b046a30defe7007ba8a0c04f9c08f27df312/audioop_lts-0.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:b492c3b040153e68b9fdaff5913305aaaba5bb433d8a7f73d5cf6a64ed3cc1dd", size = 25206, upload-time = "2025-08-05T16:43:16.444Z" },
 ]
 
 [[package]]
@@ -580,6 +637,29 @@ dependencies = [
 requires-dist = [{ name = "pydantic", specifier = ">=2.9" }]
 
 [[package]]
+name = "curie-discord-adapter"
+version = "0.1.0"
+source = { editable = "adapters/discord" }
+dependencies = [
+    { name = "curie-channel-protocol" },
+    { name = "discord-py" },
+    { name = "fastapi" },
+    { name = "httpx" },
+    { name = "pydantic-settings" },
+    { name = "uvicorn" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "curie-channel-protocol", editable = "packages/channel-protocol" },
+    { name = "discord-py", specifier = ">=2.6,<3" },
+    { name = "fastapi", specifier = ">=0.135" },
+    { name = "httpx", specifier = ">=0.28" },
+    { name = "pydantic-settings", specifier = ">=2.15" },
+    { name = "uvicorn", specifier = ">=0.41" },
+]
+
+[[package]]
 name = "curie-dispatcher"
 version = "0.0.0"
 source = { editable = "apps/dispatcher" }
@@ -709,6 +789,7 @@ dependencies = [
     { name = "aci-protocol" },
     { name = "curie-api" },
     { name = "curie-channel-protocol" },
+    { name = "curie-discord-adapter" },
     { name = "curie-dispatcher" },
     { name = "curie-runner" },
     { name = "curie-worker" },
@@ -735,6 +816,7 @@ requires-dist = [
     { name = "aci-protocol", editable = "packages/aci-protocol" },
     { name = "curie-api", editable = "apps/api" },
     { name = "curie-channel-protocol", editable = "packages/channel-protocol" },
+    { name = "curie-discord-adapter", editable = "adapters/discord" },
     { name = "curie-dispatcher", editable = "apps/dispatcher" },
     { name = "curie-runner", editable = "runner" },
     { name = "curie-worker", editable = "apps/worker" },
@@ -754,6 +836,19 @@ dev = [
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "ruff", specifier = ">=0.16.2" },
     { name = "types-pyyaml", specifier = ">=6.0" },
+]
+
+[[package]]
+name = "discord-py"
+version = "2.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "audioop-lts" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ef/57/9a2d9abdabdc9db8ef28ce0cf4129669e1c8717ba28d607b5ba357c4de3b/discord_py-2.7.1.tar.gz", hash = "sha256:24d5e6a45535152e4b98148a9dd6b550d25dc2c9fb41b6d670319411641249da", size = 1106326, upload-time = "2026-03-03T18:40:46.24Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/a7/17208c3b3f92319e7fad259f1c6d5a5baf8fd0654c54846ced329f83c3eb/discord_py-2.7.1-py3-none-any.whl", hash = "sha256:849dca2c63b171146f3a7f3f8acc04248098e9e6203412ce3cf2745f284f7439", size = 1227550, upload-time = "2026-03-03T18:40:44.492Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Split out of #1803 (task/1525-multi-surface), which this PR stacks on
top of: a real Discord Gateway and reply adapter, the public second
adapter proving ADR-0116's decision 6 that the core stays adapter
neutral. Discord Gateway events enter Curie's existing
`/channels/turns` endpoint over a per-binding scoped `chn` token; the
worker sends neutral reply events back to the adapter's `/replies`
endpoint over a shared per-adapter secret. It owns the Discord bot
token, never the Slack token, platform key, model credentials, or
queue credentials.

The split has no functional dependency in either direction: this
adapter posts turns for whatever binding it is configured with,
whether that binding is an agent's only one or its fifth, so it needs
none of #1803's cardinality change to work. #1803 needs no adapter
beyond Slack to exercise multi-surface. Splitting them keeps that
independence real rather than merely stated, and lets each be reviewed
on its own terms.

Two bugs surfaced by live-testing this exact code against a real
Discord app and a real Slack app (details below) are fixed here on top
of the adapter as originally built:

- **Reply auth header name mismatch.** The worker sends the per-adapter
  secret as `X-Curie-Adapter-Secret`; this adapter's own `/replies`
  handler read `X-Curie-Adapter-Key`. Every reply delivery 401'd
  unconditionally. Each side's own unit tests passed in isolation
  because each asserted its own (different) name -- only a genuine
  cross-service round trip ever exercised both at once.
- **Mention-only messages silently dropped.** `build_turn` refused to
  build a turn at all when the text was empty after stripping the
  bot's own mention, so a bare `@mention` created no thread and never
  reached Curie's ingress -- stronger, and inconsistent, than Slack's
  ingress, which forwards the same empty text unconditionally. Whether
  "nothing to say" is itself meaningful is the agent's call, not this
  adapter's.

## Related issue

Ref #1525 (the issue's demo criteria name Discord specifically; #1803
is what closes it, this PR completes the demo).

## Fix pin verification

Fix pin: adapters/discord/tests/test_ingress.py::test_a_mention_with_nothing_else_still_becomes_a_turn_with_empty_text

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | No bundle or skill execution semantics changed. | n/a | n/a |
| local | required | Proves the adapter round-trips through the real local API/worker. | live | Local core stack up (`curie local up --minimal`), a real model-free test agent bound to two Slack channels and two Discord channels on one agent id, `memory=true`. `curie local surfaces <agent>` showed all four bindings on one agent. |
| local-release | n/a | No release artifact or bootstrap path changed. | n/a | n/a |
| cluster | n/a | No cluster-only implementation path; the adapter is substrate-agnostic. | n/a | n/a |
| live provider | required | The whole point of this PR. | live | Ran this adapter's code against a real Discord application (Gateway Socket connected, `on_message` handling real Gateway events) and a real Slack app (real Socket Mode dispatcher). Observed: a message in Discord channel A creates a thread and gets a real reply; a mention-only message in Discord channel B (after the empty-text fix) also creates a thread and replies; a value pushed via Discord is later popped via Slack and vice versa, proving one agent id/deployment answering across both platforms, not two copies. Both live bugs above were found and fixed during this exact session. |
| external integration | n/a | Discord and Slack are the live-provider tier above. | n/a | n/a |

- [x] Every completed required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path (cross-platform pop failed closed under `memory=false`, succeeded under `memory=true`, on the companion PR's toggle).
- [ ] No required tier is left unproved; any blocked tier names its blocker in the table.
- [ ] Or: this change is not behavior-bearing, so no tier applies, and the summary says why.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed.
- [x] ADR-0116 (in the base PR) already records this adapter as its public proof; no new ADR needed here.