### PR TITLE
Add the surface the ledger is written through

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -1,6 +1,294 @@
 {
   "components": {
     "schemas": {
+      "ActionComplete": {
+        "description": "The closing frame: what came back, and what it takes to put it back.\n\n``prior_state`` and ``target`` are what a restore replays. Both are optional\nbecause a connector that answers in prose reports neither, and a record that\nholds neither is not undoable -- which is the honest answer rather than a\nmissing one.",
+        "properties": {
+          "detail": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Detail"
+          },
+          "failed": {
+            "default": false,
+            "title": "Failed",
+            "type": "boolean"
+          },
+          "prior_state": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Prior State"
+          },
+          "result": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Result"
+          },
+          "target": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Target"
+          }
+        },
+        "title": "ActionComplete",
+        "type": "object"
+      },
+      "ActionOut": {
+        "properties": {
+          "agent_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agent Id"
+          },
+          "arguments": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Arguments"
+          },
+          "call_id": {
+            "title": "Call Id",
+            "type": "string"
+          },
+          "completed_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Completed At"
+          },
+          "conversation_id": {
+            "title": "Conversation Id",
+            "type": "string"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "dedupe_key": {
+            "title": "Dedupe Key",
+            "type": "string"
+          },
+          "detail": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Detail"
+          },
+          "id": {
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "prior_state": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Prior State"
+          },
+          "result": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Result"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          },
+          "target": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Target"
+          },
+          "tool": {
+            "title": "Tool",
+            "type": "string"
+          },
+          "undoable": {
+            "title": "Undoable",
+            "type": "boolean"
+          },
+          "undone_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Undone At"
+          },
+          "undone_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Undone By"
+          }
+        },
+        "required": [
+          "id",
+          "agent_id",
+          "conversation_id",
+          "call_id",
+          "tool",
+          "arguments",
+          "result",
+          "prior_state",
+          "target",
+          "detail",
+          "status",
+          "dedupe_key",
+          "created_at",
+          "completed_at",
+          "undone_at",
+          "undone_by",
+          "undoable"
+        ],
+        "title": "ActionOut",
+        "type": "object"
+      },
+      "ActionRecord": {
+        "description": "The opening frame of a side-effecting call, as the worker forwards it.\n\n``dedupe_key`` is the triggering event id and the call id. The worker\nredelivers at least once (ADR-0013), so a replayed turn must adopt the record\nit already wrote rather than mint a second account of one call.",
+        "properties": {
+          "agent_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agent Id"
+          },
+          "arguments": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Arguments"
+          },
+          "call_id": {
+            "title": "Call Id",
+            "type": "string"
+          },
+          "conversation_id": {
+            "title": "Conversation Id",
+            "type": "string"
+          },
+          "dedupe_key": {
+            "title": "Dedupe Key",
+            "type": "string"
+          },
+          "detail": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Detail"
+          },
+          "tool": {
+            "title": "Tool",
+            "type": "string"
+          }
+        },
+        "required": [
+          "conversation_id",
+          "call_id",
+          "tool",
+          "dedupe_key"
+        ],
+        "title": "ActionRecord",
+        "type": "object"
+      },
       "AgentCreate": {
         "properties": {
           "approval_required_tools": {
@@ -3415,6 +3703,290 @@
   },
   "openapi": "3.1.0",
   "paths": {
+    "/actions": {
+      "get": {
+        "description": "A conversation's actions, oldest first -- the order a receipt lists them.",
+        "operationId": "list_actions_actions_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "conversation_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Conversation Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "agent_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Agent Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/ActionOut"
+                  },
+                  "title": "Response List Actions Actions Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Actions",
+        "tags": [
+          "actions"
+        ]
+      },
+      "post": {
+        "description": "Record a side-effecting call; idempotent on ``dedupe_key``.\n\nCreated ``pending``: the call was made and nothing has come back to say what\nit did, which is also the state a turn that dies mid-call leaves behind.",
+        "operationId": "record_action_actions_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ActionRecord"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActionOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Record Action",
+        "tags": [
+          "actions"
+        ]
+      }
+    },
+    "/actions/{action_id}": {
+      "get": {
+        "operationId": "get_action_actions__action_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "action_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Action Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActionOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Action",
+        "tags": [
+          "actions"
+        ]
+      }
+    },
+    "/actions/{action_id}/complete": {
+      "post": {
+        "description": "Record what the tool answered.\n\n``prior_state`` and ``target`` are what a restore replays. A completion that\ncarries neither produces a record that is not undoable, which is the honest\nanswer for a connector that replied in prose -- nothing has to declare it.",
+        "operationId": "complete_action_actions__action_id__complete_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "action_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Action Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ActionComplete"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActionOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Complete Action",
+        "tags": [
+          "actions"
+        ]
+      }
+    },
     "/agents": {
       "get": {
         "operationId": "list_agents_agents_get",

--- a/apps/api/src/curie_api/crud.py
+++ b/apps/api/src/curie_api/crud.py
@@ -14,7 +14,9 @@ from sqlalchemy.orm import selectinload
 
 from .config import get_settings
 from .models import (
+    ActionStatus,
     Agent,
+    AgentAction,
     AgentChannel,
     AgentVersion,
     Approval,
@@ -28,6 +30,8 @@ from .models import (
     ThreadWorkspace,
 )
 from .schemas import (
+    ActionComplete,
+    ActionRecord,
     AgentCreate,
     ApprovalRequest,
     ChannelBindingWrite,
@@ -703,6 +707,82 @@ async def reap_terminal_publication_patches(
     )
     await session.commit()
     return len(ids)
+
+
+async def create_action(session: AsyncSession, data: ActionRecord) -> AgentAction:
+    """Insert a pending action record.
+
+    Raises IntegrityError on a ``dedupe_key`` replay; the router maps that to the
+    existing record, so a redelivered turn adopts what it already wrote.
+    """
+
+    action = AgentAction(
+        agent_id=data.agent_id,
+        conversation_id=data.conversation_id,
+        call_id=data.call_id,
+        tool=data.tool,
+        arguments=data.arguments,
+        detail=data.detail,
+        dedupe_key=data.dedupe_key,
+        status=ActionStatus.pending,
+    )
+    session.add(action)
+    await session.commit()
+    await session.refresh(action)
+    return action
+
+
+async def get_action(session: AsyncSession, action_id: uuid.UUID) -> AgentAction | None:
+    return await session.get(AgentAction, action_id)
+
+
+async def get_action_by_dedupe_key(session: AsyncSession, key: str) -> AgentAction | None:
+    result = await session.execute(select(AgentAction).where(AgentAction.dedupe_key == key))
+    return result.scalar_one_or_none()
+
+
+async def list_actions(
+    session: AsyncSession,
+    *,
+    conversation_id: str | None = None,
+    agent_id: uuid.UUID | None = None,
+    limit: int = 50,
+) -> list[AgentAction]:
+    """A conversation's actions, oldest first -- the order a receipt lists them."""
+
+    query = select(AgentAction)
+    if conversation_id is not None:
+        query = query.where(AgentAction.conversation_id == conversation_id)
+    if agent_id is not None:
+        query = query.where(AgentAction.agent_id == agent_id)
+    query = query.order_by(AgentAction.created_at, AgentAction.call_id).limit(limit)
+    result = await session.execute(query)
+    return list(result.scalars().all())
+
+
+async def complete_action(
+    session: AsyncSession, action: AgentAction, data: ActionComplete
+) -> AgentAction:
+    """Record what came back, once.
+
+    A completion that arrives for an already-completed record is a redelivery,
+    not a correction: the first account of a call is the one that was true when
+    it happened, and overwriting it with a second would silently move a prior
+    state a restore is about to replay. Returned unchanged.
+    """
+
+    if action.status != ActionStatus.pending:
+        return action
+    action.status = ActionStatus.failed if data.failed else ActionStatus.succeeded
+    action.result = data.result
+    action.prior_state = data.prior_state
+    action.target = data.target
+    if data.detail is not None:
+        action.detail = data.detail
+    action.completed_at = datetime.now(UTC).replace(tzinfo=None)
+    await session.commit()
+    await session.refresh(action)
+    return action
 
 
 async def create_approval(session: AsyncSession, data: "ApprovalRequest") -> Approval:

--- a/apps/api/src/curie_api/main.py
+++ b/apps/api/src/curie_api/main.py
@@ -27,6 +27,7 @@ from .langfuse import LangfuseClient
 from .resumequeue import ResumeQueue
 from .resumereconciler import ResumeReconciler
 from .routers import (
+    actions,
     agents,
     approvals,
     bundles,
@@ -278,6 +279,7 @@ def create_app() -> FastAPI:
     app.include_router(state.router)
     app.include_router(memory.router)
     app.include_router(approvals.router)
+    app.include_router(actions.router)
     app.include_router(publications.router)
     app.include_router(publications.internal_router)
     app.include_router(workspaces.router)

--- a/apps/api/src/curie_api/routers/actions.py
+++ b/apps/api/src/curie_api/routers/actions.py
@@ -1,0 +1,100 @@
+"""The action ledger: record what an agent did, and read it back (ADR-0117).
+
+The worker has no database of its own -- it persists an approval by POSTing to
+this API, and it records an action the same way. So the two ACI frames of one
+side-effecting call arrive here as two requests: a create when the call was made,
+and a completion when its result came back.
+
+Both are idempotent, because the worker redelivers at least once (ADR-0013). A
+replayed create adopts the record it already wrote; a replayed completion is
+returned unchanged rather than overwriting the first account of the call. That
+second one matters more than it looks: the prior state on a record is what a
+restore replays, so a completion allowed to rewrite it moves the target of an
+undo that has already been offered to a human.
+
+Ruling on an undo is NOT here. It is its own decision, with its own two refusal
+rules, and it lands separately.
+"""
+
+import logging
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from sqlalchemy.exc import IntegrityError
+
+from .. import crud
+from ..auth import require_api_key
+from ..deps import SessionDep
+from ..schemas import ActionComplete, ActionOut, ActionRecord
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/actions", tags=["actions"], dependencies=[Depends(require_api_key)])
+
+
+@router.post("", response_model=ActionOut, status_code=status.HTTP_201_CREATED)
+async def record_action(
+    data: ActionRecord, session: SessionDep, response: Response
+) -> ActionOut:
+    """Record a side-effecting call; idempotent on ``dedupe_key``.
+
+    Created ``pending``: the call was made and nothing has come back to say what
+    it did, which is also the state a turn that dies mid-call leaves behind.
+    """
+
+    try:
+        action = await crud.create_action(session, data)
+    except IntegrityError as exc:
+        await session.rollback()
+        existing = await crud.get_action_by_dedupe_key(session, data.dedupe_key)
+        if existing is None:  # raced with a delete; surface the conflict as-is
+            raise HTTPException(
+                status.HTTP_409_CONFLICT, "action violates a uniqueness constraint"
+            ) from exc
+        response.status_code = status.HTTP_200_OK
+        return ActionOut.model_validate(existing)
+    return ActionOut.model_validate(action)
+
+
+@router.get("", response_model=list[ActionOut])
+async def list_actions(
+    session: SessionDep,
+    conversation_id: str | None = None,
+    agent_id: uuid.UUID | None = None,
+    limit: int = 50,
+) -> list[ActionOut]:
+    """A conversation's actions, oldest first -- the order a receipt lists them."""
+
+    actions = await crud.list_actions(
+        session,
+        conversation_id=conversation_id,
+        agent_id=agent_id,
+        limit=min(max(limit, 1), 200),
+    )
+    return [ActionOut.model_validate(a) for a in actions]
+
+
+@router.get("/{action_id}", response_model=ActionOut)
+async def get_action(action_id: uuid.UUID, session: SessionDep) -> ActionOut:
+    action = await crud.get_action(session, action_id)
+    if action is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "action not found")
+    return ActionOut.model_validate(action)
+
+
+@router.post("/{action_id}/complete", response_model=ActionOut)
+async def complete_action(
+    action_id: uuid.UUID, data: ActionComplete, session: SessionDep
+) -> ActionOut:
+    """Record what the tool answered.
+
+    ``prior_state`` and ``target`` are what a restore replays. A completion that
+    carries neither produces a record that is not undoable, which is the honest
+    answer for a connector that replied in prose -- nothing has to declare it.
+    """
+
+    action = await crud.get_action(session, action_id)
+    if action is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "action not found")
+    completed = await crud.complete_action(session, action, data)
+    return ActionOut.model_validate(completed)

--- a/apps/api/src/curie_api/schemas.py
+++ b/apps/api/src/curie_api/schemas.py
@@ -1227,6 +1227,63 @@ class ApprovalOut(BaseModel):
     resolved_at: datetime | None
 
 
+class ActionRecord(BaseModel):
+    """The opening frame of a side-effecting call, as the worker forwards it.
+
+    ``dedupe_key`` is the triggering event id and the call id. The worker
+    redelivers at least once (ADR-0013), so a replayed turn must adopt the record
+    it already wrote rather than mint a second account of one call.
+    """
+
+    agent_id: uuid.UUID | None = None
+    conversation_id: str
+    call_id: str
+    tool: str
+    arguments: dict[str, Any] | None = None
+    detail: str | None = None
+    dedupe_key: str
+
+
+class ActionComplete(BaseModel):
+    """The closing frame: what came back, and what it takes to put it back.
+
+    ``prior_state`` and ``target`` are what a restore replays. Both are optional
+    because a connector that answers in prose reports neither, and a record that
+    holds neither is not undoable -- which is the honest answer rather than a
+    missing one.
+    """
+
+    failed: bool = False
+    result: dict[str, Any] | None = None
+    prior_state: dict[str, Any] | None = None
+    target: dict[str, Any] | None = None
+    detail: str | None = None
+
+
+class ActionOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    agent_id: uuid.UUID | None
+    conversation_id: str
+    call_id: str
+    tool: str
+    arguments: dict[str, Any] | None
+    result: dict[str, Any] | None
+    prior_state: dict[str, Any] | None
+    target: dict[str, Any] | None
+    detail: str | None
+    status: str
+    dedupe_key: str
+    created_at: datetime
+    completed_at: datetime | None
+    undone_at: datetime | None
+    undone_by: str | None
+    # Derived on the model, never stored, so a record cannot claim a
+    # reversibility nothing captured the state for (ADR-0117).
+    undoable: bool
+
+
 class ApprovalAuditOut(BaseModel):
     """One audit entry (#247): who attempted what, and the authorizer snapshot
     that counted (or refused) them."""

--- a/apps/api/tests/test_actions.py
+++ b/apps/api/tests/test_actions.py
@@ -1,0 +1,186 @@
+"""Recording what an agent did to the world (ADR-0117), against real Postgres.
+
+The worker has no database of its own -- it persists an approval by POSTing to
+this API, and it records an action the same way. So this is the surface the
+kernel writes through, and the two ACI frames of one call arrive here as two
+requests: a create when the call was made, and a completion when its result
+came back.
+
+What this file holds:
+
+1. **One call is one row, under redelivery.** The worker redelivers at least
+   once (ADR-0013), so a replayed turn must adopt the record it already wrote.
+2. **Reversibility is deny-by-default.** ``undoable`` is derived from what the
+   record actually holds, so a completion that carried no prior state produces a
+   record that says it cannot be undone, with no connector declaring anything.
+3. **A completion lands once.** Recording the same result twice must not
+   overwrite a record with a second, later account of the same call.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+import pytest
+
+pytestmark = pytest.mark.usefixtures("clean_db")
+
+
+def _open_body(**overrides: Any) -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "conversation_id": "C1",
+        "call_id": "toolu_01",
+        "tool": "scale_deployment",
+        "arguments": {"name": "api", "replicas": 10},
+        "detail": "non-idempotent tool executed",
+        "dedupe_key": f"event-{uuid.uuid4()}:toolu_01",
+    }
+    body.update(overrides)
+    return body
+
+
+def _complete_body(**overrides: Any) -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "failed": False,
+        "result": {"ok": True, "summary": "scaled 3 to 10"},
+        "prior_state": {"spec": {"replicas": 3}},
+        "target": {"kind": "Deployment", "namespace": "public", "name": "api"},
+        "detail": "non-idempotent tool completed",
+    }
+    body.update(overrides)
+    return body
+
+
+def test_recording_a_call_creates_a_pending_record(client: Any, auth_headers: Any) -> None:
+    response = client.post("/actions", json=_open_body(), headers=auth_headers)
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["status"] == "pending"
+    assert body["arguments"] == {"name": "api", "replicas": 10}
+    # Nothing has come back yet, so there is nothing to put back.
+    assert body["undoable"] is False
+
+
+def test_a_redelivered_turn_adopts_the_record_it_already_wrote(
+    client: Any, auth_headers: Any
+) -> None:
+    body = _open_body()
+
+    first = client.post("/actions", json=body, headers=auth_headers)
+    second = client.post("/actions", json=body, headers=auth_headers)
+
+    assert first.status_code == 201
+    assert second.status_code == 200
+    assert second.json()["id"] == first.json()["id"]
+    listed = client.get("/actions", params={"conversation_id": "C1"}, headers=auth_headers)
+    assert len(listed.json()) == 1
+
+
+def test_a_completed_call_that_captured_its_prior_state_is_undoable(
+    client: Any, auth_headers: Any
+) -> None:
+    action_id = client.post("/actions", json=_open_body(), headers=auth_headers).json()["id"]
+
+    response = client.post(
+        f"/actions/{action_id}/complete", json=_complete_body(), headers=auth_headers
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "succeeded"
+    assert body["prior_state"] == {"spec": {"replicas": 3}}
+    assert body["completed_at"] is not None
+    assert body["undoable"] is True
+
+
+def test_a_call_that_reported_no_prior_state_is_not_undoable(
+    client: Any, auth_headers: Any
+) -> None:
+    """The connector answered in prose. Deny-by-default, with a stated reason."""
+
+    action_id = client.post("/actions", json=_open_body(), headers=auth_headers).json()["id"]
+
+    response = client.post(
+        f"/actions/{action_id}/complete",
+        json=_complete_body(result=None, prior_state=None, target=None, detail="restarted"),
+        headers=auth_headers,
+    )
+
+    assert response.json()["status"] == "succeeded"
+    assert response.json()["undoable"] is False
+    assert response.json()["detail"] == "restarted"
+
+
+def test_a_failed_call_is_not_undoable(client: Any, auth_headers: Any) -> None:
+    """Undoing a call that did not happen would be a write, not a restore."""
+
+    action_id = client.post("/actions", json=_open_body(), headers=auth_headers).json()["id"]
+
+    response = client.post(
+        f"/actions/{action_id}/complete",
+        json=_complete_body(failed=True),
+        headers=auth_headers,
+    )
+
+    assert response.json()["status"] == "failed"
+    assert response.json()["undoable"] is False
+
+
+def test_a_completion_lands_once(client: Any, auth_headers: Any) -> None:
+    """A redelivered completion must not rewrite the account of a call."""
+
+    action_id = client.post("/actions", json=_open_body(), headers=auth_headers).json()["id"]
+    client.post(f"/actions/{action_id}/complete", json=_complete_body(), headers=auth_headers)
+
+    second = client.post(
+        f"/actions/{action_id}/complete",
+        json=_complete_body(prior_state={"spec": {"replicas": 99}}),
+        headers=auth_headers,
+    )
+
+    assert second.status_code == 200
+    assert second.json()["prior_state"] == {"spec": {"replicas": 3}}
+
+
+def test_a_conversation_reads_back_its_actions_in_order(
+    client: Any, auth_headers: Any
+) -> None:
+    """The receipt is per turn, so the listing is what renders it."""
+
+    client.post("/actions", json=_open_body(call_id="toolu_01"), headers=auth_headers)
+    client.post("/actions", json=_open_body(call_id="toolu_02"), headers=auth_headers)
+    client.post(
+        "/actions", json=_open_body(conversation_id="C2", call_id="toolu_03"), headers=auth_headers
+    )
+
+    listed = client.get(
+        "/actions", params={"conversation_id": "C1"}, headers=auth_headers
+    ).json()
+
+    assert [a["call_id"] for a in listed] == ["toolu_01", "toolu_02"]
+
+
+def test_an_unknown_action_is_a_404(client: Any, auth_headers: Any) -> None:
+    """Asserts the MESSAGE, not just the code.
+
+    An unrouted path is also a 404, so a status-only assertion here would pass
+    against an API that has no actions surface at all.
+    """
+
+    missing = uuid.uuid4()
+
+    fetched = client.get(f"/actions/{missing}", headers=auth_headers)
+    completed = client.post(
+        f"/actions/{missing}/complete", json=_complete_body(), headers=auth_headers
+    )
+
+    assert fetched.status_code == 404
+    assert fetched.json()["detail"] == "action not found"
+    assert completed.status_code == 404
+    assert completed.json()["detail"] == "action not found"
+
+
+def test_recording_requires_the_api_key(client: Any) -> None:
+    assert client.post("/actions", json=_open_body()).status_code == 401


### PR DESCRIPTION
**Stacked on #1871** (base is `task/1863-agent-actions-tables`; it retargets to `next` when that merges). Part of #1864, slice 3a of #1861.

## Why this comes before the kernel

The worker has no database of its own — it persists an approval by POSTing to this API. So [#1872](https://github.com/curie-eng/curie/issues/1872), the kernel write path, has nothing to write to until this exists. The prototype hid the dependency: its demo called `POST /actions` itself, standing in for the kernel.

## The two frames, as two requests

| | |
| --- | --- |
| `POST /actions` | the call was made — `pending`, carrying its arguments |
| `POST /actions/{id}/complete` | what came back — outcome, result, and the `prior_state` + `target` a restore replays |
| `GET /actions?conversation_id=` | oldest first, the order a receipt lists them |
| `GET /actions/{id}` | one record |

## Both idempotent, and the second one matters more

The worker redelivers at least once (ADR-0013). A replayed create adopting its own row is bookkeeping. **A replayed completion returning unchanged is a safety property**: `prior_state` is the thing an undo replays, so a completion allowed to rewrite it moves the target of a restore that may already have been offered to a human. The first account of a call is the one that was true when it happened.

## Deny-by-default falls out, again

A completion carrying no prior state and no target produces a record that is not undoable, and says why in `detail`. Nothing declares that — it's `undoable` being derived (#1871). A connector answering in prose lands there on its own, and so does a third-party MCP tool nobody wrote a connector for.

## What is deliberately not here

**Ruling on an undo.** It has its own two refusal rules — authorization symmetry and the conflict check — and they deserve a diff of their own rather than arriving under CRUD. Recording is authenticated by the shared API key like every other router; *who may undo* is the authorizer question, and it lands with the ruling.

## Verification

```
apps/api           975 passed, 10 skipped
  test_actions.py    9 passed   (real Postgres)
ruff check .       All checks passed
mypy               no issues in 201 source files
check-contracts    current
check-docs         drift-free, every citation resolves
openapi.json       regenerated
```

`test_control_integration.py::test_cost_composes_metrics_for_the_agent` fails locally and on an untouched checkout alike — needs Langfuse, which `--minimal` skips.
