### PR TITLE
Refuse to boot a gate the bundle's own skill permissions would bypass

### DIFF
--- a/runner/src/curie_runner/__main__.py
+++ b/runner/src/curie_runner/__main__.py
@@ -20,6 +20,7 @@ from .adapter import ClaudeAgentSession, ModelSession, build_options
 from .approval import (
     APPROVAL_SERVER_NAME,
     ApprovalPolicyError,
+    assert_gates_not_shadowed,
     build_approval_gate,
     build_approval_server,
     build_can_use_tool,
@@ -183,6 +184,13 @@ def build_runner(
             mcp_servers=resolution.mcp_servers,
             connector_servers=resolution.connector_servers,
         )
+        # The third fail-closed boot check (#1852). The two above refuse a policy
+        # that cannot be armed as declared; this one refuses a policy that WOULD
+        # arm and then be bypassed, because the bundle's own skill permissions
+        # preauthorize a gated tool before can_use_tool is ever consulted. It sits
+        # here rather than in build_approval_gate because only this scope holds
+        # both the assembled gate and the bundle directory.
+        assert_gates_not_shadowed(config.session.plugin_dir, approval_gate, resolution)
     except ApprovalPolicyError as exc:
         # Log then re-raise, matching the module's other two fatal boot paths
         # (credential resolution, session start): a bare traceback is the one
@@ -261,9 +269,7 @@ def build_runner(
                     namespace=config.connector_namespace,
                 ),
             ),
-            can_use_tool=(
-                build_can_use_tool(approval_gate) if approval_gate is not None else None
-            ),
+            can_use_tool=(build_can_use_tool(approval_gate) if approval_gate is not None else None),
         )
         return ClaudeAgentSession(options)
 
@@ -313,9 +319,7 @@ def _load_memory(config: RunnerConfig) -> tuple[MemoryStore, str | None]:
             exc,
         )
         return store, None
-    logger.info(
-        "memory loaded session=%s records=%d", config.session.session_id, len(records)
-    )
+    logger.info("memory loaded session=%s records=%d", config.session.session_id, len(records))
     return store, format_memory_preamble(records)
 
 
@@ -359,9 +363,7 @@ def _load_history(config: RunnerConfig) -> tuple[TranscriptStore, str | None]:
             exc,
         )
         return store, None
-    logger.info(
-        "history loaded session=%s turns=%d", config.session.session_id, len(turns)
-    )
+    logger.info("history loaded session=%s turns=%d", config.session.session_id, len(turns))
     return store, format_conversation_preamble(turns, max_turns=max_turns, max_bytes=max_bytes)
 
 

--- a/runner/src/curie_runner/approval.py
+++ b/runner/src/curie_runner/approval.py
@@ -35,8 +35,9 @@ import logging
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
 
+import yaml
 from claude_agent_sdk import create_sdk_mcp_server, tool
 from claude_agent_sdk.types import (
     CanUseTool,
@@ -331,14 +332,11 @@ def resolve_policy_route(
     return (
         True,
         None,
-        f"Rejected: unknown approval route {route!r};"
-        f" pass route as one of: {', '.join(declared)}.",
+        f"Rejected: unknown approval route {route!r}; pass route as one of: {', '.join(declared)}.",
     )
 
 
-def process_approval_request(
-    gate: ApprovalGate | None, args: dict[str, Any]
-) -> dict[str, Any]:
+def process_approval_request(gate: ApprovalGate | None, args: dict[str, Any]) -> dict[str, Any]:
     """Apply one ``request_approval`` call to ``gate`` and return the model result.
 
     The single source of truth for the approval-request outcome, invoked from
@@ -418,6 +416,7 @@ def guard_reserved_summary(summary: str) -> str:
     if summary.startswith(APPROVAL_SUMMARY_PREFIX):
         return f"{_RESERVED_SUMMARY_MARKER}{summary}"
     return summary
+
 
 # What the denied model is told. It must steer the model to end the turn (so
 # the session can emit the awaiting-approval final and the platform can
@@ -711,9 +710,7 @@ def resolve_approval_policy(plugin_dir: str | None) -> ApprovalPolicyResolution:
     # Compare DISTINCT declared names against armed names, not counts: two
     # entries for one tool are a last-wins duplicate that validate_bundle
     # accepts, and rejecting them here would crash-loop a deploy-valid bundle.
-    declared_names = {
-        gate.gate.strip() for gate in policy.gates if isinstance(gate.gate, str)
-    }
+    declared_names = {gate.gate.strip() for gate in policy.gates if isinstance(gate.gate, str)}
     unarmed = declared_names - set(routes)
     if unarmed:
         raise ApprovalPolicyError(
@@ -869,3 +866,274 @@ def build_approval_gate(
         grant_tool=grant_tool,
         grantable_by_route=grantable_by_route or {},
     )
+
+
+# --- Bundle permissions that would bypass a gate (#1852) ------------------------
+#
+# A skill's ``allowed-tools`` frontmatter becomes a Claude Code permission rule,
+# and a permission rule is applied BEFORE the SDK consults ``can_use_tool``. A
+# bundle that gates Bash and also ships a skill declaring ``allowed-tools: [Bash]``
+# therefore arms a gate the callback never sees: the tool runs, no approval record
+# is created, and ``curie <tier> approvals`` still reports the gate as active. A
+# gate that reports itself armed while executing silently is worse than no gate,
+# because it is the one an operator trusts.
+#
+# The SDK does warn about this, but only for entries in
+# ``ClaudeAgentOptions.allowed_tools``. Skill frontmatter never appears there --
+# the CLI reads it out of the bundle -- so the SDK's own warning is structurally
+# unable to fire for this case, which is why it went unnoticed.
+
+
+class ShadowedGate(NamedTuple):
+    """One skill permission rule that preauthorizes an approval-gated tool.
+
+    Attributes:
+        skill: The SKILL.md path relative to the bundle root, so the message names
+            the file to edit rather than only the conflict.
+        entry: The verbatim ``allowed-tools`` entry, so the author can find the
+            line instead of guessing which entry matched.
+        tool: The gated runtime tool name the entry preauthorizes.
+        whole: True when the entry allows the tool outright (``Bash``, ``Bash()``,
+            ``Bash(*)``); False when it allows only matching invocations
+            (``Bash(ls:*)``). Both defeat a gate, the second for exactly the calls
+            it matches, and naming which one was found keeps the message concrete.
+    """
+
+    skill: str
+    entry: str
+    tool: str
+    whole: bool
+
+
+def _whole_tool_allowed(entry: str) -> str | None:
+    """Return the tool an ``allowed-tools`` entry allows OUTRIGHT, else None.
+
+    Mirrors the CLI rule parser, which is also what the SDK implements for its own
+    shadowing warning: an entry allows a whole tool when it carries no ``(...)``
+    specifier (``Read``), or when the specifier is empty or a lone wildcard
+    (``Read()``, ``Read(*)``). A real specifier (``Bash(ls:*)``) allows only
+    matching invocations. A malformed entry is read as a bare tool name by the
+    CLI, so it matches nothing.
+
+    A test pins this against the SDK's implementation, because the CLI applies the
+    SDK's reading and not ours: a divergence in either direction is a fail-open or
+    a false refusal.
+    """
+
+    if not entry.strip():
+        return None
+    open_index = entry.find("(")
+    if open_index == -1:
+        return entry
+    if open_index == 0 or not entry.endswith(")"):
+        return None
+    return entry[:open_index] if entry[open_index + 1 : -1] in ("", "*") else None
+
+
+def _entry_tool(entry: str) -> str | None:
+    """Return the tool an entry names, specifier or not.
+
+    ``_whole_tool_allowed`` answers "does this allow the whole tool"; a gate needs
+    the broader "which tool is this about". Gating ``Bash`` means every Bash call
+    is approval-required, so ``Bash(ls:*)`` still preauthorizes part of what the
+    gate claims to cover.
+    """
+
+    if not entry.strip():
+        return None
+    open_index = entry.find("(")
+    if open_index == -1:
+        return entry
+    if open_index == 0 or not entry.endswith(")"):
+        return None
+    return entry[:open_index]
+
+
+def _skill_allowed_tools(root: Path) -> list[tuple[str, list[str]]]:
+    """Read every skill's ``allowed-tools`` list from a bundle directory.
+
+    Deliberately tolerant: a skill whose frontmatter is missing, unterminated,
+    unparseable, or not a mapping contributes nothing. ``validate_bundle`` already
+    reports those, and failing the gate check on a malformed skill would report
+    the wrong defect and hide the real one.
+
+    Args:
+        root: The bundle root directory.
+
+    Returns:
+        ``(skill_path_relative_to_root, entries)`` per skill that declares a list,
+        sorted by path so output is deterministic.
+    """
+
+    skills_dir = root / "skills"
+    if not skills_dir.is_dir():
+        return []
+    found: list[tuple[str, list[str]]] = []
+    for skill_file in sorted(skills_dir.rglob("SKILL.md")):
+        try:
+            text = skill_file.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        if not text.startswith("---"):
+            continue
+        parts = text.split("---", 2)
+        if len(parts) < 3:
+            continue
+        try:
+            loaded = yaml.safe_load(parts[1])
+        except yaml.YAMLError:
+            continue
+        if not isinstance(loaded, dict):
+            continue
+        entries = loaded.get("allowed-tools")
+        if not isinstance(entries, list):
+            continue
+        found.append(
+            (
+                str(skill_file.relative_to(root)),
+                [entry for entry in entries if isinstance(entry, str)],
+            )
+        )
+    return found
+
+
+def _gated_names_for_entry(
+    tool: str,
+    required: frozenset[str],
+    resolution: ApprovalPolicyResolution | None,
+) -> str | None:
+    """Return the gated runtime name a skill entry would preauthorize, else None.
+
+    Direct equality answers the built-in case (``Bash`` gated, ``Bash`` allowed).
+    It does NOT answer the MCP case, and that gap is a fail-open rather than a
+    cosmetic one: ``build_approval_gate`` arms an MCP gate under its live name
+    (``mcp__plugin_<bundle>_<server>__<tool>``), while a skill author writes the
+    natural ``mcp__<server>__<tool>`` shorthand. Compared raw, those two strings
+    never match and the conflict is missed entirely.
+
+    So a non-matching entry is run through ``effective_operator_gates`` -- the SAME
+    normalization ``build_approval_gate`` applies to an operator's shorthand -- and
+    the result is intersected with the armed set. Reusing that function rather than
+    writing a second shorthand parser is deliberate: two parsers for one naming
+    rule is the defect #1495 and #1564 were both about.
+
+    Args:
+        tool: The tool name the entry names.
+        required: The armed runtime tool names.
+        resolution: The bundle's resolved identity, or None when unavailable, in
+            which case only direct equality is possible.
+
+    Returns:
+        The armed name this entry preauthorizes, or None.
+    """
+
+    if tool in required:
+        return tool
+    if resolution is None:
+        return None
+    effective = effective_operator_gates(
+        resolution.bundle_name,
+        resolution.mcp_servers,
+        tool,
+        connector_servers=resolution.connector_servers,
+    )
+    if effective is None:
+        return None
+    overlap = sorted(effective & required)
+    return overlap[0] if overlap else None
+
+
+def shadowed_gates(
+    plugin_dir: str | Path,
+    required: frozenset[str],
+    resolution: ApprovalPolicyResolution | None = None,
+) -> tuple[ShadowedGate, ...]:
+    """Find skill permission rules that preauthorize an approval-gated tool.
+
+    Args:
+        plugin_dir: The bundle root directory.
+        required: The runtime tool names the gate arms.
+        resolution: The bundle identity used to normalize an MCP shorthand.
+
+    Returns:
+        Every conflict found, ordered by skill path then entry so the message is
+        stable across runs. Empty when the bundle preauthorizes nothing gated.
+    """
+
+    if not required:
+        return ()
+    conflicts: list[ShadowedGate] = []
+    for skill, entries in _skill_allowed_tools(Path(plugin_dir)):
+        for entry in entries:
+            named = _entry_tool(entry)
+            if named is None:
+                continue
+            gated = _gated_names_for_entry(named, required, resolution)
+            if gated is None:
+                continue
+            conflicts.append(
+                ShadowedGate(
+                    skill=skill,
+                    entry=entry,
+                    tool=gated,
+                    whole=_whole_tool_allowed(entry) is not None,
+                )
+            )
+    return tuple(conflicts)
+
+
+def describe_shadowed_gates(conflicts: Sequence[ShadowedGate]) -> str:
+    """Render conflicts as an operator-facing message that names the fix.
+
+    The message has to survive being read from a pod log by someone who did not
+    write the bundle, so it names the file, the entry, the tool, and the edit --
+    not merely that a conflict exists.
+    """
+
+    lines = [
+        "approval gate defeated by the bundle's own skill permissions: a skill"
+        " 'allowed-tools' entry preauthorizes a tool the approval policy gates, and a"
+        " permission rule is applied before the approval callback runs, so the gate"
+        " would be armed but never consulted.",
+    ]
+    for conflict in sorted(conflicts):
+        how = "allows the whole tool" if conflict.whole else "allows matching calls"
+        lines.append(
+            f"  {conflict.skill}: allowed-tools entry {conflict.entry!r} {how}"
+            f" {conflict.tool!r}, which is approval-required"
+        )
+    lines.append(
+        "Remove those entries from the skill frontmatter, or stop gating the tool."
+        " Narrowing an entry does not help: a narrowed rule still preauthorizes the"
+        " calls it matches."
+    )
+    return "\n".join(lines)
+
+
+def assert_gates_not_shadowed(
+    plugin_dir: str | None,
+    gate: ApprovalGate | None,
+    resolution: ApprovalPolicyResolution | None = None,
+) -> None:
+    """Refuse to boot when the bundle preauthorizes a tool the gate arms (#1852).
+
+    This runs at session boot rather than at deploy time on purpose. Deploy-time
+    validation can only see gates the BUNDLE declares; an operator who arms a gate
+    afterwards with ``curie cluster approvals --gate`` never re-runs it. Boot sees
+    both halves of the union, so it is the only place the whole conflict is
+    visible, which is also what the issue's acceptance criteria require.
+
+    Args:
+        plugin_dir: The mounted bundle root, or None when no bundle is mounted.
+        gate: The assembled gate, or None when nothing is gated.
+        resolution: The bundle identity used to normalize an MCP shorthand.
+
+    Raises:
+        ApprovalPolicyError: When any skill permission rule names a gated tool.
+    """
+
+    if gate is None or plugin_dir is None:
+        return
+    conflicts = shadowed_gates(plugin_dir, gate.required, resolution)
+    if conflicts:
+        raise ApprovalPolicyError(describe_shadowed_gates(conflicts))

--- a/runner/tests/test_gate_shadowing.py
+++ b/runner/tests/test_gate_shadowing.py
@@ -1,0 +1,265 @@
+"""Boot refuses a gate the bundle's own skill permissions would bypass (#1852).
+
+The defect: a skill's ``allowed-tools`` frontmatter becomes a Claude Code
+permission rule, and a permission rule is applied BEFORE the SDK consults
+``can_use_tool``. Curie printed the gate as armed while the tool executed with no
+approval record.
+
+Enforcement lives at session boot rather than at deploy time because only boot
+sees BOTH halves of the gated-tool union: the bundle manifest's ``approvalPolicy``
+and the operator's ``CURIE_APPROVAL_REQUIRED_TOOLS``. A deploy-time validator
+never re-runs when an operator arms a gate afterwards, which is the case the
+issue's acceptance criteria call out by name.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from curie_runner.approval import (
+    ApprovalGate,
+    ApprovalPolicyError,
+    ApprovalPolicyResolution,
+    _entry_tool,
+    _whole_tool_allowed,
+    assert_gates_not_shadowed,
+    build_approval_gate,
+    describe_shadowed_gates,
+    shadowed_gates,
+)
+
+
+def _bundle(
+    root: Path,
+    *,
+    skills: dict[str, list[str] | None],
+    gates: list[str],
+    mcp: dict[str, dict[str, object]] | None = None,
+) -> str:
+    """Write a bundle whose skills, approvalPolicy, and MCP servers are under test.
+
+    Args:
+        root: Directory to build in.
+        skills: Skill name to its ``allowed-tools`` list, or None to omit the key.
+        gates: Tool names the manifest's approvalPolicy gates.
+        mcp: Optional ``.mcp.json`` server map.
+
+    Returns:
+        The bundle root as a string path.
+    """
+    (root / ".claude-plugin").mkdir(parents=True, exist_ok=True)
+    (root / ".claude-plugin" / "plugin.json").write_text(
+        json.dumps(
+            {
+                "name": "demo",
+                "version": "0.1.0",
+                "description": "A bundle for the shadowing tests.",
+                "approvalPolicy": {"gates": [{"gate": g, "route": "ops"} for g in gates]},
+            }
+        ),
+        encoding="utf-8",
+    )
+    if mcp is not None:
+        (root / ".mcp.json").write_text(json.dumps({"mcpServers": mcp}), encoding="utf-8")
+    for name, allowed in skills.items():
+        skill_dir = root / "skills" / name
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        lines = ["---", f"name: {name}", "description: A skill."]
+        if allowed is not None:
+            lines.append("allowed-tools:")
+            lines.extend(f"  - {entry}" for entry in allowed)
+        lines += ["---", "", f"# {name}", ""]
+        (skill_dir / "SKILL.md").write_text("\n".join(lines), encoding="utf-8")
+    return str(root)
+
+
+# The table the SDK's own rule parser documents. Ours has to agree with it,
+# because the CLI applies the SDK's reading and not ours: a disagreement in either
+# direction is a fail-open (a real shadow missed) or a false refusal (a working
+# bundle blocked).
+@pytest.mark.parametrize(
+    ("entry", "whole", "named"),
+    [
+        ("Bash", "Bash", "Bash"),
+        ("Bash()", "Bash", "Bash"),
+        ("Bash(*)", "Bash", "Bash"),
+        ("Bash(ls:*)", None, "Bash"),
+        ("mcp__gh__create_issue", "mcp__gh__create_issue", "mcp__gh__create_issue"),
+        ("(oops)", None, None),
+        ("Bash(unterminated", None, None),
+        ("", None, None),
+        ("   ", None, None),
+    ],
+)
+def test_entry_parsing_matches_the_cli_rule(
+    entry: str, whole: str | None, named: str | None
+) -> None:
+    assert _whole_tool_allowed(entry) == whole
+    assert _entry_tool(entry) == named
+
+
+def test_our_parser_agrees_with_the_sdk_on_whole_tool_allowances() -> None:
+    """Pin against the SDK rather than against our own reading of the docs.
+
+    The SDK ships the same parser for its shadowing warning. Importing it is the
+    only way to notice an upstream change in what counts as a whole-tool
+    allowance; a hand-copied table would keep passing while the meaning moved.
+    """
+    sdk = pytest.importorskip("claude_agent_sdk.types")
+    reference = getattr(sdk, "_whole_tool_allowed", None)
+    if reference is None:
+        pytest.skip("SDK no longer exposes the reference rule parser")
+    for entry in ("Bash", "Bash()", "Bash(*)", "Bash( )", "Bash(ls:*)", "(x)", "Bash(", "", " "):
+        assert _whole_tool_allowed(entry) == reference(entry), entry
+
+
+def test_boot_refuses_when_a_skill_preauthorizes_a_manifest_gated_tool(tmp_path: Path) -> None:
+    plugin_dir = _bundle(tmp_path, skills={"demo": ["Bash"]}, gates=["Bash"])
+    gate = build_approval_gate(operator_tools=None, policy_routes={"Bash": "ops"})
+    assert gate is not None
+    with pytest.raises(ApprovalPolicyError) as exc:
+        assert_gates_not_shadowed(plugin_dir, gate)
+    assert "skills/demo/SKILL.md" in str(exc.value)
+
+
+def test_boot_refuses_an_operator_gate_armed_after_the_bundle_shipped(tmp_path: Path) -> None:
+    """The case a deploy-time validator structurally cannot catch.
+
+    The bundle declares no approvalPolicy, so a bundle validator sees nothing to
+    check. The operator arms the gate later with
+    ``curie cluster approvals --gate Bash``, against a bundle whose skill has
+    always allowed Bash. Only boot holds both facts at once.
+    """
+    plugin_dir = _bundle(tmp_path, skills={"demo": ["Bash"]}, gates=[])
+    gate = build_approval_gate(operator_tools=["Bash"], policy_routes={})
+    assert gate is not None
+    with pytest.raises(ApprovalPolicyError) as exc:
+        assert_gates_not_shadowed(plugin_dir, gate)
+    assert "Bash" in str(exc.value)
+
+
+def test_an_mcp_shorthand_in_a_skill_matches_the_armed_runtime_name(tmp_path: Path) -> None:
+    """The conflict raw string equality cannot see, and it is a fail-open.
+
+    ``build_approval_gate`` arms an MCP gate under its live name
+    ``mcp__plugin_demo_crm__send``, while a skill author writes the natural
+    ``mcp__crm__send``. Compared raw those never match, so the shadow would be
+    missed entirely. The entry is normalized through the SAME function that
+    normalizes an operator's shorthand, so one naming rule keeps one parser.
+    """
+    plugin_dir = _bundle(
+        tmp_path,
+        skills={"demo": ["mcp__crm__send"]},
+        gates=[],
+        mcp={"crm": {"command": "run-crm"}},
+    )
+    resolution = ApprovalPolicyResolution(
+        route_by_tool={},
+        grantable_by_route={},
+        bundle_name="demo",
+        mcp_servers={"crm"},
+        connector_servers=set(),
+    )
+    gate = build_approval_gate(
+        operator_tools=["mcp__crm__send"],
+        policy_routes={},
+        bundle_name="demo",
+        mcp_servers={"crm"},
+        connector_servers=set(),
+    )
+    assert gate is not None
+    assert gate.required == frozenset({"mcp__plugin_demo_crm__send"})
+    # Without the resolution there is nothing to normalize against, so the
+    # conflict is invisible. That asymmetry is the whole point of this test.
+    assert shadowed_gates(plugin_dir, gate.required) == ()
+    with pytest.raises(ApprovalPolicyError) as exc:
+        assert_gates_not_shadowed(plugin_dir, gate, resolution)
+    assert "mcp__plugin_demo_crm__send" in str(exc.value)
+
+
+def test_boot_accepts_a_bundle_whose_skills_allow_only_ungated_tools(tmp_path: Path) -> None:
+    plugin_dir = _bundle(tmp_path, skills={"demo": ["Read", "Write(docs/*)"]}, gates=["Bash"])
+    gate = build_approval_gate(operator_tools=None, policy_routes={"Bash": "ops"})
+    assert gate is not None
+    assert_gates_not_shadowed(plugin_dir, gate)
+
+
+def test_no_gate_and_no_bundle_are_both_no_ops(tmp_path: Path) -> None:
+    plugin_dir = _bundle(tmp_path, skills={"demo": ["Bash"]}, gates=["Bash"])
+    assert_gates_not_shadowed(plugin_dir, None)
+    assert_gates_not_shadowed(None, ApprovalGate(required=frozenset({"Bash"}), route_by_tool={}))
+
+
+def test_a_narrowed_allowance_still_refuses_boot(tmp_path: Path) -> None:
+    """Narrowing preauthorizes the calls it matches, which is the same defect.
+
+    The SDK's advisory warning reports only whole-tool allowances, and suggests
+    narrowing so calls "fall through to can_use_tool". That advice is for a
+    callback used to decide; it is not sound for an approval GATE, whose claim is
+    that every call to the tool needs a human. ``Bash(ls:*)`` leaves every
+    matching call ungated, so accepting it would ship a partial gate that reports
+    as whole. The message says narrowing is not the remedy, so an author does not
+    discover this by being breached.
+    """
+    plugin_dir = _bundle(tmp_path, skills={"demo": ["Bash(ls:*)"]}, gates=["Bash"])
+    gate = build_approval_gate(operator_tools=None, policy_routes={"Bash": "ops"})
+    assert gate is not None
+    with pytest.raises(ApprovalPolicyError) as exc:
+        assert_gates_not_shadowed(plugin_dir, gate)
+    assert "Narrowing an entry does not help" in str(exc.value)
+
+
+def test_every_conflicting_skill_is_named_not_only_the_first(tmp_path: Path) -> None:
+    """An operator fixing one file and redeploying must not find a second wall.
+
+    Reporting only the first conflict turns one edit into N deploys, and each
+    redeploy of a security-relevant bundle is a chance to give up and remove the
+    gate instead.
+    """
+    plugin_dir = _bundle(
+        tmp_path,
+        skills={"alpha": ["Bash"], "beta": ["Bash(*)"], "gamma": ["Read"]},
+        gates=["Bash"],
+    )
+    conflicts = shadowed_gates(plugin_dir, frozenset({"Bash"}))
+    assert [c.skill for c in conflicts] == ["skills/alpha/SKILL.md", "skills/beta/SKILL.md"]
+
+
+def test_matching_is_exact_so_a_near_miss_is_not_a_hit(tmp_path: Path) -> None:
+    """``BashTool`` is not ``Bash``, in either direction.
+
+    ``can_use_tool`` compares by exact string equality, so anything looser would
+    report conflicts the runtime does not have, and anything that stripped
+    prefixes would miss the ones it does.
+    """
+    plugin_dir = _bundle(tmp_path, skills={"demo": ["BashTool"]}, gates=["Bash"])
+    assert shadowed_gates(plugin_dir, frozenset({"Bash"})) == ()
+    assert shadowed_gates(plugin_dir, frozenset({"BashTool"}))[0].tool == "BashTool"
+
+
+def test_a_malformed_skill_is_left_to_the_frontmatter_validator(tmp_path: Path) -> None:
+    """Reporting the wrong defect hides the real one.
+
+    A skill with unparseable frontmatter already fails ``validate_bundle`` with a
+    frontmatter error. Failing the gate check on it as well would tell an operator
+    their approval policy is broken when their YAML is.
+    """
+    plugin_dir = _bundle(tmp_path, skills={"demo": ["Bash"]}, gates=["Bash"])
+    broken = Path(plugin_dir) / "skills" / "broken"
+    broken.mkdir(parents=True)
+    (broken / "SKILL.md").write_text("no frontmatter here", encoding="utf-8")
+    conflicts = shadowed_gates(plugin_dir, frozenset({"Bash"}))
+    assert [c.skill for c in conflicts] == ["skills/demo/SKILL.md"]
+
+
+def test_the_message_names_the_file_the_entry_and_the_remedy(tmp_path: Path) -> None:
+    plugin_dir = _bundle(tmp_path, skills={"demo": ["Bash"]}, gates=["Bash"])
+    message = describe_shadowed_gates(shadowed_gates(plugin_dir, frozenset({"Bash"})))
+    assert "skills/demo/SKILL.md" in message
+    assert "'Bash'" in message
+    assert "Remove those entries" in message
+    # The reason has to travel with the message: read from a pod log by someone
+    # who did not write the bundle, "conflict" alone is not actionable.
+    assert "before the approval callback runs" in message


### PR DESCRIPTION
Refs #1852. This addresses the shadowing half; two of the issue's acceptance criteria are deliberately left open and named at the bottom.

## What was broken

A skill's `allowed-tools` frontmatter becomes a Claude Code permission rule, and a permission rule is applied **before** the SDK consults `can_use_tool`. So a bundle that gates `Bash` and also ships a skill declaring `allowed-tools: [Bash]` armed a gate the callback never saw. The tool executed, no approval record was created, and `curie <tier> approvals` still printed the gate as active.

A gate that reports itself armed while executing silently is worse than no gate, because it is the one an operator trusts.

The SDK does warn about this condition, but only for entries in `ClaudeAgentOptions.allowed_tools`. Skill frontmatter never appears there, since the CLI reads it out of the bundle. The SDK's warning is therefore structurally unable to fire for this case, which is why it went unnoticed.

## The fix

`assert_gates_not_shadowed` is a third fail-closed boot check, alongside the two that already refuse a policy which cannot be armed as declared.

**It runs at boot, not at deploy.** Only boot sees both halves of the gated-tool union. An operator who runs `curie cluster approvals --gate Bash` after deployment never re-runs a deploy-time validator, which is the case acceptance criterion 6 names explicitly.

Two decisions worth reviewing:

**MCP names are normalized, not compared raw.** `build_approval_gate` arms an MCP gate under its live name `mcp__plugin_demo_crm__send`, while a skill author writes the natural `mcp__crm__send`. Compared as strings those never match and the conflict is invisible. The entry is normalized through `effective_operator_gates`, the same function that normalizes an operator's shorthand, so one naming rule keeps one parser. That is the defect #1495 and #1564 were both about.

**A narrowed entry is refused too.** The SDK's advisory warning reports only whole-tool allowances and suggests narrowing so calls "fall through to `can_use_tool`". That advice is sound for a callback used to decide; it is not sound for an approval gate, whose claim is that *every* call to the tool needs a human. `Bash(ls:*)` leaves every matching call ungated, so accepting it would ship a partial gate that reports as whole. The refusal message says narrowing is not the remedy, so an author does not discover it by being breached. If you would rather match the SDK's narrower definition, that is a one-line change and a deliberate weakening, so it should be your call rather than mine.

**`packages/plugin-format` is untouched.** An earlier revision of this branch put the helper there so the deploy-time validator could share it. That was the wrong call twice over: it changes a frozen interface from a dependent lane, and with one implementation there is no second path to disagree with, so the shared-helper argument does not yet apply. A friendlier `curie skill validate` error covering the bundle-only half would be a plugin-format change and belongs in its own reviewed PR.

## Evidence

20 tests. Seven mutations, each one turning the suite red:

| Mutation | Result |
|---|---|
| boot check becomes a no-op | 4 failed |
| narrowed entries ignored | 1 failed |
| specifier treated as a whole-tool allowance | 2 failed |
| only the first conflict reported | 1 failed |
| MCP normalization removed | 1 failed |
| exact matching relaxed to substring | 1 failed |
| remedy dropped from the message | 1 failed |

The entry parser is pinned against the SDK's own implementation, so an upstream change in what counts as a whole-tool allowance fails a test rather than silently diverging.

Full suites: `runner` 579 passed, `packages/plugin-format` 322 passed, `scripts/check-contracts.sh` reports no drift, `packages/` is byte-identical to `main`.

## A second bypass this does NOT close

An adversarial review pass turned up a related hole that is not the reported defect and should not ride in on this PR.

`build_options` never sets `ClaudeAgentOptions.setting_sources`. The SDK documents `None` as "all sources are loaded (matches CLI defaults)": `~/.claude/settings.json`, `.claude/settings.json`, and `.claude/settings.local.json`. A `permissions.allow` entry in any of those shadows `can_use_tool` exactly as a skill's `allowed-tools` does, and it does not have to be in the bundle at all.

That is a wider surface than the one this PR closes and its remedy is a real decision, not a bug fix: passing `setting_sources=[]` whenever a gate is armed would isolate the session but also stop CLAUDE.md and legitimate project settings from loading. Happy to file it as its own issue if you want it tracked separately.

## Other acceptance criteria left open

- **The hang.** The negative control in the issue removed `allowed-tools` and drove Bash from a system prompt; the runner logged the tool call but the turn never finalized as `awaiting-approval` and `cluster message` timed out with the stream entry pending. That is a separate defect on the live path. I could not reproduce it without a live OpenRouter cluster run, and guessing at it would be worse than leaving it named.
- **The release-channel regression** (criterion 5) asks for a disposable real-provider test through the realistic plugin bundle path. This PR adds unit and boot coverage only.

One observation while running the suite: `runner/tests/test_live.py::test_live_permission_gate_pauses_awaiting_approval` fails on clean `main` in my environment with `'list' object has no attribute 'type'`. It fails identically before this branch, so it is not caused by these changes, but it is the very test the issue calls out as unable to reach this path, and it appears to be broken independently.
