### PR TITLE
Resolve the Slack base URL from the same source as the bot token

### DIFF
--- a/cli/src/message.rs
+++ b/cli/src/message.rs
@@ -1603,7 +1603,7 @@ async fn message_local(opts: MessageOpts) -> Result<()> {
     // sentinel), post a real placeholder and enqueue against its ts with no
     // per-turn endpoint so the reply and any approval card ride that transport.
     // Resolving the channel first keeps the behavior identical to the stub path.
-    if let Some(bot_token) = local_connected_bot_token().await {
+    if let Some(transport) = local_connected_transport().await {
         let channel = match opts.channel.as_deref() {
             Some(channel) => channel.to_string(),
             None => {
@@ -1622,7 +1622,7 @@ async fn message_local(opts: MessageOpts) -> Result<()> {
             &mut conn,
             TurnVerb::Local,
             &channel,
-            &bot_token,
+            &transport,
         )
         .await;
     }
@@ -2117,8 +2117,15 @@ type WorkerTransport = (Option<String>, Option<String>);
 /// authoring bot `chat.update` a message, so two different tokens would leave the
 /// placeholder stuck at "..." with `cant_update_message` (#957 mode B).
 ///
+/// Returning the base ALONGSIDE the token is what closes #1030 at this tier. Both
+/// values were already read out of the same container here; only the token was
+/// kept, and the base was then re-read from the CLI's own process environment at
+/// post time. Carrying the pair means the placeholder goes exactly where the
+/// worker that will edit it is pointed, and a stale `SLACK_API_BASE_URL` in the
+/// operator's shell has nothing left to decide.
+///
 /// Pure, so both conditions are unit-testable without Docker.
-fn connected_worker_bot_token(transport: WorkerTransport) -> Option<String> {
+fn connected_worker_transport(transport: WorkerTransport) -> Option<crate::slack::SlackTransport> {
     let (api_base, token) = transport;
     let api_base = api_base.unwrap_or_default();
     // Wired to the stub (or to nothing resolvable) means not connected.
@@ -2126,7 +2133,8 @@ fn connected_worker_bot_token(transport: WorkerTransport) -> Option<String> {
         return None;
     }
     let token = token?.trim().to_string();
-    (!token.is_empty() && token != LOCAL_STUB_BOT_TOKEN).then_some(token)
+    (!token.is_empty() && token != LOCAL_STUB_BOT_TOKEN)
+        .then(|| crate::slack::SlackTransport::new(Some(api_base), token))
 }
 
 /// Read the running compose worker's Slack transport out of the container.
@@ -2154,9 +2162,9 @@ async fn running_worker_transport() -> WorkerTransport {
     (find("SLACK_API_BASE_URL="), find("SLACK_BOT_TOKEN="))
 }
 
-/// Process-level wrapper: the token to post with, or `None` for the stub path.
-async fn local_connected_bot_token() -> Option<String> {
-    connected_worker_bot_token(running_worker_transport().await)
+/// Process-level wrapper: the transport to post over, or `None` for the stub path.
+async fn local_connected_transport() -> Option<crate::slack::SlackTransport> {
+    connected_worker_transport(running_worker_transport().await)
 }
 
 /// The human dry-run line noting that a connected workspace changes the plan
@@ -2190,7 +2198,7 @@ pub async fn enqueue_over_connected_transport(
     conn: &mut MultiplexedConnection,
     verb: TurnVerb,
     channel: &str,
-    bot_token: &str,
+    transport: &crate::slack::SlackTransport,
 ) -> Result<()> {
     let ui = crate::ui::ui();
     // An empty `--thread` is normalized away at the [`message`] entry point, and
@@ -2201,7 +2209,7 @@ pub async fn enqueue_over_connected_transport(
     let explicit_thread = opts.thread.as_deref().filter(|ts| !ts.is_empty());
 
     let placeholder_ts =
-        crate::slack::post_placeholder(bot_token, channel, "\u{2026}", explicit_thread)
+        crate::slack::post_placeholder(transport, channel, "\u{2026}", explicit_thread)
             .await
             .with_context(|| {
                 let mut context =
@@ -2357,13 +2365,46 @@ async fn message_connected(opts: MessageOpts) -> Result<()> {
         }
         None => crate::ops::discover_slack_bot_token(&opts.namespace, &opts.release).await?,
     };
+    // The base comes from the same release as the token (#1030), never from the
+    // CLI's own environment. A `CURIE_SLACK_BOT_TOKEN` override changes only the
+    // identity, not the destination: an operator working around a stale Secret is
+    // still posting into this release's workspace, and letting the override drag
+    // the URL along would restore exactly the split this issue is about.
+    let transport = match crate::ops::discover_slack_api_base_url(&opts.namespace, &opts.release)
+        .await
+    {
+        crate::ops::SlackApiBase::Configured(base) => {
+            ui.note(&format!(
+                "posting over the release's configured Slack base {base}"
+            ));
+            crate::slack::SlackTransport::new(Some(base), bot_token)
+        }
+        crate::ops::SlackApiBase::RealSlack => crate::slack::SlackTransport::new(None, bot_token),
+        // Refusing here rather than defaulting is the whole point of the tri-state.
+        // "Could not look" is not evidence that the worker talks to real Slack, and
+        // acting as if it were would post a real placeholder somewhere the worker
+        // can never edit -- an orphaned ellipsis in a real channel, which is the
+        // #957 mode A failure arriving by a different road.
+        crate::ops::SlackApiBase::Unknown => {
+            anyhow::bail!(
+                "could not read the Slack API base from the worker Deployment for release \
+                 {} in namespace {}; refusing to guess where a real workspace token should be \
+                 sent. Check `kubectl -n {} get deployment -l \
+                 app.kubernetes.io/instance={},app.kubernetes.io/component=worker`.",
+                opts.release,
+                opts.namespace,
+                opts.namespace,
+                opts.release
+            );
+        }
+    };
 
     let valkey_url = format!(
         "redis://:{}@127.0.0.1:{valkey_local_port}",
         opts.valkey_password
     );
     let mut conn = connect(&valkey_url).await?;
-    enqueue_over_connected_transport(&opts, &mut conn, TurnVerb::Cluster, &channel, &bot_token)
+    enqueue_over_connected_transport(&opts, &mut conn, TurnVerb::Cluster, &channel, &transport)
         .await
 }
 
@@ -4256,18 +4297,22 @@ mod tests {
     #[test]
     fn connected_only_when_the_worker_itself_talks_to_real_slack() {
         let t = |s: &str| Some(s.to_string());
+        let token = |r: Option<crate::slack::SlackTransport>| r.map(|t| t.bot_token);
 
         // Connected: the worker's transport is real Slack and its token is real.
         assert_eq!(
-            connected_worker_bot_token((t("https://slack.com/api/"), t("xoxb-real"))).as_deref(),
-            Some("xoxb-real")
+            token(connected_worker_transport((
+                t("https://slack.com/api/"),
+                t("xoxb-real")
+            ))),
+            Some("xoxb-real".to_string())
         );
 
         // #957 mode A, the failure this replaced: a REAL token is present but the
         // worker is wired to the stub, so posting would orphan a "..." in a real
         // channel that the worker can never edit. Not connected.
         assert_eq!(
-            connected_worker_bot_token((
+            connected_worker_transport((
                 t("http://localhost:8155/api/"),
                 t("xoxb-real-from-the-vault")
             )),
@@ -4276,20 +4321,47 @@ mod tests {
 
         // The stub sentinel is not a workspace token even if the base URL is odd.
         assert_eq!(
-            connected_worker_bot_token((t("https://slack.com/api/"), t(LOCAL_STUB_BOT_TOKEN))),
+            connected_worker_transport((t("https://slack.com/api/"), t(LOCAL_STUB_BOT_TOKEN))),
             None
         );
         // No stack running / nothing resolvable -> stub path, never a real post.
-        assert_eq!(connected_worker_bot_token((None, None)), None);
-        assert_eq!(connected_worker_bot_token((t(""), t("xoxb-real"))), None);
+        assert_eq!(connected_worker_transport((None, None)), None);
+        assert_eq!(connected_worker_transport((t(""), t("xoxb-real"))), None);
         assert_eq!(
-            connected_worker_bot_token((t("https://slack.com/api/"), None)),
+            connected_worker_transport((t("https://slack.com/api/"), None)),
             None
         );
         assert_eq!(
-            connected_worker_bot_token((t("https://slack.com/api/"), t("  "))),
+            connected_worker_transport((t("https://slack.com/api/"), t("  "))),
             None
         );
+    }
+
+    #[test]
+    fn the_local_transport_carries_the_workers_own_base_not_the_shells() {
+        // The #1030 regression at local tier. The base and the token are read from
+        // the same `docker inspect`, so the placeholder goes where the worker that
+        // will edit it is pointed. Before this, only the token survived and the base
+        // came from whatever the operator happened to have exported.
+        let resolved = connected_worker_transport((
+            Some("https://proxy.example/api".to_string()),
+            Some("xoxb-worker-actual".to_string()),
+        ))
+        .expect("a real base and a real token are a connected transport");
+        assert_eq!(resolved.api_base, "https://proxy.example/api");
+        assert_eq!(resolved.bot_token, "xoxb-worker-actual");
+
+        std::env::set_var("SLACK_API_BASE_URL", "http://127.0.0.1:18081/api");
+        let again = connected_worker_transport((
+            Some("https://proxy.example/api".to_string()),
+            Some("xoxb-worker-actual".to_string()),
+        ))
+        .expect("still connected");
+        assert_eq!(
+            again.api_base, "https://proxy.example/api",
+            "an ambient SLACK_API_BASE_URL must not redirect a resolved token"
+        );
+        std::env::remove_var("SLACK_API_BASE_URL");
     }
 
     #[test]

--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -2123,6 +2123,62 @@ mod release_secret_name_tests {
 
 #[cfg(test)]
 mod api_key_discovery_tests {
+
+    // --- #1030: the worker Deployment lookup ---------------------------------
+
+    #[test]
+    fn the_worker_selector_does_not_guess_the_deployment_name() {
+        // The chart names it `{{ curie.fullname }}-worker`, which equals
+        // `<release>-worker` only when the release name contains the chart name.
+        // `acme-prod` renders `acme-prod-curie-worker`, and nameOverride moves it
+        // again. Selecting on labels is what `release_secret_name` already does.
+        let selector = worker_deployment_selector("acme-prod");
+        assert!(selector.contains("app.kubernetes.io/instance=acme-prod"));
+        assert!(selector.contains("app.kubernetes.io/component=worker"));
+        assert!(
+            !selector.contains("acme-prod-worker"),
+            "the selector must not encode a guessed name: {selector}"
+        );
+    }
+
+    #[test]
+    fn a_failed_lookup_is_unknown_and_never_reads_as_real_slack() {
+        // The distinction that keeps #1030 from returning in another shape. A
+        // kubectl failure is not evidence that the worker talks to real Slack, and
+        // treating it as such posts a real token wherever real Slack is while the
+        // worker edits through a proxy the CLI never saw.
+        assert_eq!(parse_slack_api_base(false, ""), SlackApiBase::Unknown);
+        assert_eq!(
+            parse_slack_api_base(false, "https://proxy.example/api"),
+            SlackApiBase::Unknown
+        );
+    }
+
+    #[test]
+    fn an_empty_successful_lookup_means_real_slack() {
+        // The chart renders SLACK_API_BASE_URL only when worker.slackApiBaseUrl is
+        // non-empty, so a clean empty result is the ordinary case, not a failure.
+        assert_eq!(parse_slack_api_base(true, ""), SlackApiBase::RealSlack);
+        assert_eq!(parse_slack_api_base(true, "  \n "), SlackApiBase::RealSlack);
+    }
+
+    #[test]
+    fn a_configured_base_is_returned_trimmed() {
+        assert_eq!(
+            parse_slack_api_base(true, "  https://proxy.example/api \n"),
+            SlackApiBase::Configured("https://proxy.example/api".to_string())
+        );
+    }
+
+    #[test]
+    fn two_containers_reporting_a_base_is_unknown_not_a_coin_flip() {
+        // Cannot happen in this chart today. If it ever does, picking one half is
+        // exactly the ambiguity this issue is about, so say so instead.
+        assert_eq!(
+            parse_slack_api_base(true, "https://a/api\nhttps://b/api\n"),
+            SlackApiBase::Unknown
+        );
+    }
     use super::*;
 
     struct EnvRestore {
@@ -6090,6 +6146,87 @@ pub async fn discover_slack_bot_token(namespace: &str, release: &str) -> Result<
                  --slack`), or set CURIE_SLACK_BOT_TOKEN"
             ))
         })
+}
+
+/// What a Slack API base lookup found for a release.
+///
+/// The three outcomes are deliberately distinct because they demand different
+/// behavior, and collapsing them is how #1030 could come back wearing a different
+/// hat. "Configured nothing" is the ordinary case and means real Slack. "Could not
+/// look" is not evidence of anything and must not be read as the ordinary case,
+/// because the CLI would then post a real token wherever real Slack is while the
+/// worker edits through a proxy the CLI never saw.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SlackApiBase {
+    /// The worker renders `SLACK_API_BASE_URL` with this value.
+    Configured(String),
+    /// The worker renders no `SLACK_API_BASE_URL`, so it talks to real Slack.
+    RealSlack,
+    /// The lookup itself could not run or could not find the worker.
+    Unknown,
+}
+
+/// The label selector that finds a release's worker Deployment whatever it is named.
+///
+/// The name is `{{ include "curie.fullname" . }}-worker`, which equals
+/// `<release>-worker` only when the release name happens to contain the chart
+/// name. A release named `acme-prod` renders `acme-prod-curie-worker`, and
+/// `nameOverride`/`fullnameOverride` move it again. Guessing the name is the
+/// defect `release_secret_name` already avoids by selecting on labels, and this
+/// selects the same way for the same reason.
+fn worker_deployment_selector(release: &str) -> String {
+    format!("app.kubernetes.io/instance={release},app.kubernetes.io/component=worker")
+}
+
+/// Parse `kubectl get deployment -o jsonpath=...` output into an outcome.
+///
+/// Pure, so every branch is unit-testable without a cluster. `ok=false` is the
+/// case that must not read as "nothing configured": see [`SlackApiBase`].
+fn parse_slack_api_base(ok: bool, out: &str) -> SlackApiBase {
+    if !ok {
+        return SlackApiBase::Unknown;
+    }
+    let value = out.trim();
+    if value.is_empty() {
+        return SlackApiBase::RealSlack;
+    }
+    // The jsonpath ranges over containers, so two containers each rendering the
+    // var would concatenate. That cannot happen in this chart (the worker
+    // Deployment has one container), and if it ever does, guessing which half is
+    // the base is exactly the ambiguity this issue is about.
+    if value.lines().count() > 1 {
+        return SlackApiBase::Unknown;
+    }
+    SlackApiBase::Configured(value.to_string())
+}
+
+/// The Slack API base the release's own worker is configured with.
+///
+/// Read from the SAME release the bot token is read from (#1030). The base used to
+/// come from `SLACK_API_BASE_URL` in the CLI's own process environment while the
+/// token came from the release Secret, so a developer with a stub URL exported
+/// from earlier testing sent a production workspace token to their local stub.
+/// The two halves now share one source.
+pub async fn discover_slack_api_base_url(namespace: &str, release: &str) -> SlackApiBase {
+    let cmd = OpsCommand::new(
+        "kubectl",
+        vec![
+            plain("-n"),
+            plain(namespace),
+            plain("get"),
+            plain("deployment"),
+            plain("-l"),
+            plain(worker_deployment_selector(release)),
+            plain("-o"),
+            plain(
+                "jsonpath={range .items[*].spec.template.spec.containers[*]}                 {.env[?(@.name=='SLACK_API_BASE_URL')].value}{\"\\n\"}{end}",
+            ),
+        ],
+    );
+    match run_capture(&cmd).await {
+        Ok((ok, out, _)) => parse_slack_api_base(ok, &out),
+        Err(_) => SlackApiBase::Unknown,
+    }
 }
 
 /// Whether a `<release>-dispatcher` Deployment exists in `namespace` -- i.e. a

--- a/cli/src/slack.rs
+++ b/cli/src/slack.rs
@@ -11,13 +11,49 @@
 
 use anyhow::{Context, Result};
 
-/// The Slack Web API base. `SLACK_API_BASE_URL` overrides it (a test/stub base,
-/// the same env the worker's own sink honours), else real Slack.
-fn api_base() -> String {
-    std::env::var("SLACK_API_BASE_URL")
-        .ok()
-        .filter(|value| !value.is_empty())
-        .unwrap_or_else(|| "https://slack.com/api".to_string())
+/// Real Slack, used when the resolved transport names no base of its own.
+pub const DEFAULT_API_BASE: &str = "https://slack.com/api";
+
+/// The Slack transport to post a placeholder over: a bot token and the base URL
+/// it belongs to, resolved TOGETHER from one source (#1030).
+///
+/// The two used to come from unrelated places. The token was read from the
+/// release Secret (cluster) or from `docker inspect` of the worker (local), while
+/// the base URL was read from `SLACK_API_BASE_URL` in the CLI's OWN process
+/// environment. A developer with `export SLACK_API_BASE_URL=http://localhost:8155/api/`
+/// left over from stub testing therefore sent a production workspace bot token to
+/// their local stub, whose entire purpose is to log what it receives. No attacker
+/// and no misconfiguration of the cluster was required.
+///
+/// Pairing them in one value is what removes that: a caller cannot construct a
+/// transport without saying where both halves came from, and there is no ambient
+/// read left for a stale shell variable to win.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SlackTransport {
+    /// The API base the resolved token belongs to.
+    pub api_base: String,
+    /// The workspace bot token. Sent only in the Authorization header.
+    pub bot_token: String,
+}
+
+impl SlackTransport {
+    /// Build a transport, falling back to real Slack when the source named no base.
+    ///
+    /// An absent or empty base means the source did not configure one, which for
+    /// both tiers means real Slack: the chart renders `SLACK_API_BASE_URL` only
+    /// when `worker.slackApiBaseUrl` is non-empty, and a compose worker without it
+    /// set talks to Slack directly. Falling back here rather than at each call site
+    /// keeps one answer to "what did no value mean".
+    pub fn new(api_base: Option<String>, bot_token: String) -> Self {
+        let api_base = api_base
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(|| DEFAULT_API_BASE.to_string());
+        Self {
+            api_base,
+            bot_token,
+        }
+    }
 }
 
 /// Post `text` to `channel` as the bot, returning the created message `ts` (the
@@ -26,15 +62,14 @@ fn api_base() -> String {
 /// own `ts` is the thread root. The token is sent only in the Authorization
 /// header; it is never logged.
 pub async fn post_placeholder(
-    bot_token: &str,
+    transport: &SlackTransport,
     channel: &str,
     text: &str,
     thread_ts: Option<&str>,
 ) -> Result<String> {
-    let base = api_base();
     let resp = reqwest::Client::new()
-        .post(format!("{base}/chat.postMessage"))
-        .bearer_auth(bot_token)
+        .post(method_url(transport, "chat.postMessage"))
+        .bearer_auth(&transport.bot_token)
         .json(&post_body(channel, text, thread_ts))
         .send()
         .await
@@ -43,6 +78,17 @@ pub async fn post_placeholder(
         .await
         .context("decoding the Slack chat.postMessage response")?;
     parse_ts(&resp)
+}
+
+/// The absolute URL for a Slack Web API method on this transport.
+///
+/// Pure and separated from the request so the destination can be asserted without
+/// a network round trip. That matters more than it looks: the defect in #1030 was
+/// entirely about which base a request went to, and a guard that needs an HTTP
+/// stub to run is a guard that does not run in the fast suite.
+fn method_url(transport: &SlackTransport, method: &str) -> String {
+    let base = transport.api_base.trim_end_matches('/');
+    format!("{base}/{method}")
 }
 
 /// The `chat.postMessage` request body. `thread_ts` is an OPTIONAL Slack
@@ -126,13 +172,59 @@ mod tests {
     }
 
     #[test]
-    fn api_base_defaults_to_real_slack_and_honours_the_override() {
-        // No override -> real Slack. (Set/removed in-process; keep the assertions
-        // tolerant of a pre-set env by asserting the shape, not a fixed value.)
+    fn a_transport_without_a_base_falls_back_to_real_slack() {
+        assert_eq!(
+            SlackTransport::new(None, "xoxb-x".into()).api_base,
+            DEFAULT_API_BASE
+        );
+        // Empty and whitespace-only mean "the source configured nothing", which is
+        // real Slack for both tiers: the chart renders SLACK_API_BASE_URL only when
+        // worker.slackApiBaseUrl is non-empty.
+        assert_eq!(
+            SlackTransport::new(Some(String::new()), "xoxb-x".into()).api_base,
+            DEFAULT_API_BASE
+        );
+        assert_eq!(
+            SlackTransport::new(Some("   ".into()), "xoxb-x".into()).api_base,
+            DEFAULT_API_BASE
+        );
+    }
+
+    #[test]
+    fn the_request_url_comes_from_the_transport_and_never_from_the_environment() {
+        // The #1030 regression, asserted on the destination itself rather than on
+        // the value that feeds it. An earlier revision of this fix had no test at
+        // this layer: restoring the ambient read inside the request builder left
+        // the whole suite green, because every other test asserted on the
+        // constructor. Mutating the rule is what found that.
+        let transport =
+            SlackTransport::new(Some("https://proxy.example/api/".into()), "xoxb-x".into());
+        std::env::set_var("SLACK_API_BASE_URL", "http://127.0.0.1:18081/api");
+        assert_eq!(
+            method_url(&transport, "chat.postMessage"),
+            "https://proxy.example/api/chat.postMessage"
+        );
         std::env::remove_var("SLACK_API_BASE_URL");
-        assert_eq!(api_base(), "https://slack.com/api");
-        std::env::set_var("SLACK_API_BASE_URL", "http://stub:9/api");
-        assert_eq!(api_base(), "http://stub:9/api");
+        // A trailing slash on the resolved base must not produce a double slash:
+        // some Slack-compatible stubs route on the exact path.
+        assert_eq!(
+            method_url(
+                &SlackTransport::new(Some("https://x/api///".into()), "t".into()),
+                "chat.postMessage"
+            ),
+            "https://x/api/chat.postMessage"
+        );
+    }
+
+    #[test]
+    fn a_resolved_base_is_used_verbatim_and_the_ambient_env_cannot_win() {
+        // The regression this pins (#1030): a stale SLACK_API_BASE_URL in the
+        // operator's own shell used to decide where a real workspace token was
+        // sent. There is no ambient read left, so setting it changes nothing.
+        std::env::set_var("SLACK_API_BASE_URL", "http://127.0.0.1:18081/api");
+        let transport =
+            SlackTransport::new(Some("https://proxy.example/api".into()), "xoxb-x".into());
+        assert_eq!(transport.api_base, "https://proxy.example/api");
         std::env::remove_var("SLACK_API_BASE_URL");
     }
 }

--- a/cli/tests/chat_enqueue.rs
+++ b/cli/tests/chat_enqueue.rs
@@ -14,7 +14,7 @@ use std::time::Duration;
 use curie::chat::{resolve_targets, SlackStub};
 use curie::message::{enqueue_over_connected_transport, MessageOpts};
 use curie::queue::{diagnostics, entry_acked, synthetic_turn, xadd, WORKER_GROUP};
-use curie::slack::post_placeholder;
+use curie::slack::{post_placeholder, SlackTransport};
 use curie::state::{load_turn, TurnContext, TurnVerb};
 use curie_aci_protocol::QueuedTurn;
 
@@ -380,14 +380,19 @@ async fn post_placeholder_threads_the_outbound_post_only_when_a_thread_is_named(
     const NAMED_THREAD: &str = "1717171717.000100";
     let slack =
         support::serve(|_req| Response::json(200, r#"{"ok": true, "ts": "1717171717.000900"}"#));
-    std::env::set_var("SLACK_API_BASE_URL", &slack.base_url);
+    // The destination is an argument now (#1030), not an ambient read. Exporting
+    // the variable that used to decide it is left in place deliberately: if the
+    // ambient read ever comes back, these posts land at real Slack instead of the
+    // stub and the recorded-request assertions below fail.
+    std::env::set_var("SLACK_API_BASE_URL", "http://127.0.0.1:1/never-used");
+    let transport = SlackTransport::new(Some(slack.base_url.clone()), "xoxb-test".into());
 
-    let ts = post_placeholder("xoxb-test", "C-real", "\u{2026}", Some(NAMED_THREAD))
+    let ts = post_placeholder(&transport, "C-real", "\u{2026}", Some(NAMED_THREAD))
         .await
         .expect("the stub answers ok with a ts");
     assert!(!ts.is_empty(), "post_placeholder returned the created ts");
 
-    post_placeholder("xoxb-test", "C-real", "\u{2026}", None)
+    post_placeholder(&transport, "C-real", "\u{2026}", None)
         .await
         .expect("the stub answers ok with a ts");
 
@@ -498,7 +503,7 @@ async fn enqueue_connected(
         conn,
         TurnVerb::Local,
         "C-REAL-CONNECTED",
-        "xoxb-test",
+        &SlackTransport::new(std::env::var("SLACK_API_BASE_URL").ok(), "xoxb-test".into()),
     )
     .await
     .expect("the connected enqueue completes against the stub and Valkey");


### PR DESCRIPTION
Closes #1030.

## What was broken

The connected-transport placeholder authenticated with a **real workspace bot token** and sent it to a base URL read from the **CLI's own process environment**. The two came from unrelated sources.

No attacker and no cluster misconfiguration were required. An engineer with `export SLACK_API_BASE_URL=http://localhost:8155/api/` left over from stub testing runs `curie cluster message` against a real release, and a production workspace bot token goes to their local stub, whose entire purpose is to log what it receives.

`#1024` widened it: before that change the local-tier token came from the same process environment as the URL, so a mismatch at least required a real token in the operator's own environment. After it the token comes from `docker inspect` of the worker, so the operator's environment needs no token at all for their `SLACK_API_BASE_URL` to redirect a real one.

## The fix

`SlackTransport` pairs the token with the base URL it belongs to, resolved together from one source. A caller cannot construct one without saying where both halves came from, and there is no ambient read left for a stale shell variable to win.

- **Cluster tier** reads the base from the release's own worker Deployment, beside the Secret the token comes from. An absent value is not a failure: the chart renders `SLACK_API_BASE_URL` only when `worker.slackApiBaseUrl` is non-empty, so absent means real Slack.
- **Local tier** already read the base out of the same `docker inspect` as the token and then discarded it. It is kept now, so the placeholder goes exactly where the worker that will edit it is pointed.
- **The `CURIE_SLACK_BOT_TOKEN` override** now changes only the identity, not the destination. An operator working around a stale Secret is still posting into this release's workspace, and letting the override drag the URL along would restore the split this issue is about. To be exact about the claim: that path still has two sources, the token from the operator's environment and the base from the release. It is narrower than before and no longer sends a token anywhere the release does not point, but it does not satisfy "one source" and the pre-existing identity warning is still the only thing standing between it and `cant_update_message`. Removing or flagging the override is a behavior decision rather than a bug fix, so it is not in this PR.
- `method_url` is pure, so the destination is asserted without a network round trip.

## Two defects an adversarial review found in the first revision

Both were in the cluster half, both real, and both are fixed here.

**The lookup guessed the Deployment name.** I wrote `<release>-worker`. The chart names it `{{ include "curie.fullname" . }}-worker`, which equals that only when the release name happens to contain the chart name. A release named `acme-prod` renders `acme-prod-curie-worker`, and `nameOverride`/`fullnameOverride` move it again. The guess would have returned nothing for those releases and silently defaulted to real Slack. It selects on `app.kubernetes.io/instance` and `component=worker` now, which is exactly what `release_secret_name` already does, for exactly this reason.

**A kubectl failure read as "no base configured".** That collapses two different facts into one answer. "The worker renders no base" means real Slack; "I could not look" means nothing at all, and acting on it posts a real placeholder somewhere the worker can never edit, which is the #957 mode A failure arriving by a different road. The result is a tri-state now, and `Unknown` refuses with a message naming the kubectl command to run rather than guessing.

## Evidence

834 unit tests. Seven mutations, each turning the suite red:

| Mutation | Result |
|---|---|
| request builder re-reads the environment | 1 failed |
| constructor ignores its base argument | 3 failed |
| local tier discards the worker's own base | 1 failed |
| trailing slash produces a double slash | 1 failed |
| kubectl failure treated as real Slack | 1 failed |
| Deployment name guessed instead of selected | 1 failed |
| two containers reporting a base pick one | 1 failed |

**The first mutation initially survived**, and that was a finding about the tests rather than about the fix. Every guard I had written asserted on `SlackTransport::new`, a pure constructor, while the value that actually decides the destination is built inside the request builder. Restoring the ambient read there left the whole suite green. Extracting `method_url` and asserting on the URL is what closes it, and it is the reason that function exists.

The integration test `post_placeholder_threads_the_outbound_post_only_when_a_thread_is_named` reached the stub by exporting `SLACK_API_BASE_URL`, which is the mechanism the defect was made of. It passes the base explicitly now and still exports the variable, deliberately pointed at an unusable address: if the ambient read ever comes back, those posts go to real Slack and the recorded-request assertions fail.

`cargo clippy --all-targets` reports no new warnings in the three files touched.

## Sequencing

The issue asks that this not be fixed independently of #1031, the connectedness probe that can never return "connected". The coupling runs one way: repairing that probe **activates** this path at local tier, so hardening first is the safe order and leaving #1031 open costs nothing here. This PR also fixes the local tier, so #1031 can be repaired afterwards without reopening the hole.

#1031 is still open and unassigned.
