### PR TITLE
Write a ledger record for every side-effecting call

### DIFF
--- a/apps/api/tests/test_actions_worker_contract.py
+++ b/apps/api/tests/test_actions_worker_contract.py
@@ -1,0 +1,89 @@
+"""The worker's ledger client against the real API, in process (ADR-0117).
+
+`apps/worker/tests/test_action_client.py` drives the client against a mock
+transport; `apps/api/tests/test_actions.py` drives the API against its own
+schema. Both pass while disagreeing about the body: rename a field on one side
+and each suite still goes green, because neither has ever seen the other.
+
+That seam is not on the ACI -- the ACI carries what the RUNNER emits, and this is
+the worker-to-platform hop -- so nothing else pins it. The e2e ladder does not
+close the gap either: it asserts plumbing, never reply content (ADR-0055), and a
+refused ledger write surfaces as an escalation that still finalizes with a reply.
+
+So this drives the real ActionClient over ASGI into the real router and the real
+database, and asserts what the row ends up holding.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+from aci_protocol import SideEffectFlag
+from curie_worker.actions import ActionClient
+
+pytestmark = pytest.mark.usefixtures("clean_db")
+
+
+async def _round_trip(app: Any) -> dict[str, Any]:
+    """One side-effecting call, both frames, through the real stack."""
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://api"
+    ) as http:
+        from curie_api.config import get_settings
+
+        recorder = ActionClient(
+            api_base_url="http://api", api_key=get_settings().api_key, client=http
+        )
+        recorded = await recorder.record(
+            SideEffectFlag(
+                tool="scale_deployment",
+                call_id="toolu_01",
+                arguments={"name": "api", "replicas": 10},
+                detail="non-idempotent tool executed",
+            ),
+            event_id="event-1",
+            conversation_id="C-contract",
+            agent_id=None,
+        )
+        await recorder.complete(
+            recorded.id,
+            SideEffectFlag(
+                tool="scale_deployment",
+                call_id="toolu_01",
+                failed=False,
+                result={
+                    "ok": True,
+                    "prior": {"spec": {"replicas": 3}},
+                    "target": {"kind": "Deployment", "name": "api"},
+                },
+                detail="non-idempotent tool completed",
+            ),
+        )
+        fetched = await http.get(
+            f"/actions/{recorded.id}", headers={"X-API-Key": get_settings().api_key}
+        )
+    body: dict[str, Any] = fetched.json()
+    return body
+
+
+def test_a_recorded_call_survives_the_worker_to_api_hop(client: Any, anyio_backend: Any) -> None:
+    """Every field the worker sends is a field the API stores, under that name."""
+
+    import anyio
+
+    row = anyio.run(_round_trip, client.app)
+
+    assert row["tool"] == "scale_deployment"
+    assert row["call_id"] == "toolu_01"
+    assert row["arguments"] == {"name": "api", "replicas": 10}
+    assert row["dedupe_key"] == "event-1:toolu_01"
+    # The half a rename would silently break: the connector reported `prior` and
+    # `target` inside its reply, and the row has to hold them as the columns a
+    # restore replays.
+    assert row["prior_state"] == {"spec": {"replicas": 3}}
+    assert row["target"] == {"kind": "Deployment", "name": "api"}
+    assert row["status"] == "succeeded"
+    assert row["undoable"] is True

--- a/apps/worker/src/curie_worker/actions.py
+++ b/apps/worker/src/curie_worker/actions.py
@@ -1,0 +1,149 @@
+"""Recording what a turn did to the world (ADR-0117).
+
+The worker has no database of its own -- it persists an approval by POSTing to
+the platform API, and it records an action the same way. So the two ACI frames of
+one side-effecting call become two calls here: ``record`` when the call was made,
+``complete`` when its result came back.
+
+The connector's reply is the only declaration of reversibility (decision 1), and
+this module is where that convention is read: ``prior`` and ``target`` out of the
+tool's structured reply. Nothing else can supply them -- no function of
+``scale_deployment(replicas=10)``'s arguments produces the replica count from
+before the call, which is why snapshot-restore is not the safer mechanism but the
+only one that knows the answer.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+import httpx
+from aci_protocol import SideEffectFlag
+
+logger = logging.getLogger(__name__)
+
+# The keys a reporting connector answers with. Named here rather than inline
+# because this pair IS the contract a connector author writes to, and a silent
+# rename would turn every reversible tool in the fleet irreversible with nothing
+# failing.
+PRIOR_KEY = "prior"
+TARGET_KEY = "target"
+
+
+class ActionBackendError(RuntimeError):
+    """The ledger could not be written."""
+
+
+@dataclass(frozen=True)
+class RecordedAction:
+    id: str
+    status: str
+
+
+class ActionRecorder(Protocol):
+    """The kernel's whole view of the ledger: open a record, then close it."""
+
+    async def record(
+        self,
+        frame: SideEffectFlag,
+        *,
+        event_id: str,
+        conversation_id: str,
+        agent_id: str | None,
+    ) -> RecordedAction: ...
+
+    async def complete(self, action_id: str, frame: SideEffectFlag) -> None: ...
+
+
+def _snapshot(frame: SideEffectFlag) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+    """The prior state and target a restore replays, out of the tool's reply.
+
+    A connector that answered in prose carries no structured result and lands
+    here as ``(None, None)``, which downstream means not undoable. So does one
+    that returned JSON without reporting what it overwrote. Neither is an error
+    and neither is inferred: an inferred prior state is a guess a restore would
+    act on.
+    """
+
+    result = frame.result
+    if not isinstance(result, dict):
+        return None, None
+    prior = result.get(PRIOR_KEY)
+    target = result.get(TARGET_KEY)
+    return (
+        prior if isinstance(prior, dict) else None,
+        target if isinstance(target, dict) else None,
+    )
+
+
+class ActionClient:
+    """HTTP implementation against the platform API's /actions endpoint."""
+
+    def __init__(
+        self,
+        *,
+        api_base_url: str,
+        api_key: str,
+        client: httpx.AsyncClient,
+    ) -> None:
+        self._url = f"{api_base_url.rstrip('/')}/actions"
+        self._headers = {"X-API-Key": api_key} if api_key else {}
+        self._client = client
+
+    async def record(
+        self,
+        frame: SideEffectFlag,
+        *,
+        event_id: str,
+        conversation_id: str,
+        agent_id: str | None,
+    ) -> RecordedAction:
+        """Open the record for a call that was just made.
+
+        ``dedupe_key`` is the event id AND the call id. The event id alone would
+        collapse a turn that called the same tool twice into one record; the call
+        id alone would not survive a redelivery of that turn.
+        """
+
+        body = {
+            "agent_id": agent_id,
+            "conversation_id": conversation_id,
+            "call_id": frame.call_id,
+            "tool": frame.tool or "unknown",
+            "arguments": frame.arguments,
+            "detail": frame.detail,
+            "dedupe_key": f"{event_id}:{frame.call_id}",
+        }
+        payload = await self._post(self._url, body, "action record")
+        return RecordedAction(id=str(payload["id"]), status=str(payload["status"]))
+
+    async def complete(self, action_id: str, frame: SideEffectFlag) -> None:
+        """Close the record with what came back."""
+
+        prior, target = _snapshot(frame)
+        await self._post(
+            f"{self._url}/{action_id}/complete",
+            {
+                "failed": bool(frame.failed),
+                "result": frame.result,
+                "prior_state": prior,
+                "target": target,
+                "detail": frame.detail,
+            },
+            "action complete",
+        )
+
+    async def _post(self, url: str, body: dict[str, Any], what: str) -> dict[str, Any]:
+        try:
+            response = await self._client.post(url, json=body, headers=self._headers)
+        except httpx.HTTPError as exc:
+            raise ActionBackendError(f"{what} failed: {exc}") from exc
+        # 201 is a fresh record; 200 is the idempotent replay of either call.
+        if response.status_code not in (200, 201):
+            raise ActionBackendError(
+                f"{what} failed: HTTP {response.status_code}: {response.text}"
+            )
+        payload: dict[str, Any] = response.json()
+        return payload

--- a/apps/worker/src/curie_worker/kernel.py
+++ b/apps/worker/src/curie_worker/kernel.py
@@ -65,6 +65,7 @@ from channel_protocol.reply import (
 )
 from pydantic import ValidationError
 
+from .actions import ActionBackendError, ActionRecorder
 from .approval_cards import ApprovalCardStore
 from .approvals import (
     ApprovalBackendError,
@@ -356,6 +357,11 @@ class _StreamAccumulator:
     approval_route: str | None = None
     approval_gate_kind: str | None = None
     approval_granted_tool: str | None = None
+    # Call id -> the ledger record it opened. One CALL produces two ACI frames
+    # (ADR-0117): the first opens a record, the second closes THAT record rather
+    # than minting a second. A turn that calls the same tool twice is only
+    # distinguishable here by the call id.
+    open_actions: dict[str, str] = field(default_factory=dict)
 
     def rendered(self) -> str:
         return self.final_text if self.final_text is not None else "".join(self.text_parts)
@@ -496,6 +502,7 @@ class Kernel:
         # read method it never calls. In production both are the one
         # ``ApprovalClient``.
         approval_reader: ApprovalReader | None = None,
+        actions: ActionRecorder | None = None,
         card_store: ApprovalCardStore | None = None,
         route_ttl_seconds: int = 3600,
         suspended_route_ttl_seconds: int = 86400,
@@ -522,6 +529,11 @@ class Kernel:
         self._approvals = approvals
         self._publication_creator = publication_creator
         self._approval_reader = approval_reader
+        # The action ledger (ADR-0117). Optional like the approval backend: an
+        # unwired deployment records nothing rather than failing every turn that
+        # touches the world. Where it IS wired, a write it refuses fails the turn
+        # -- see _apply_frame.
+        self._actions = actions
         # Remembers where each suspended thread's approval card was posted so an
         # EXPIRY can disable it (#419); absent (unwired tests) simply skips the
         # card teardown -- the resolve-click path still heals a card on click.
@@ -1557,7 +1569,7 @@ class Kernel:
                 and await self._killswitch.is_killed(agent_id)
             ):
                 await self.interrupt_thread(thread, f"agent {agent_id} killed by operator")
-            outcome = await self._consume(qevent, route, routed.turn, nav)
+            outcome = await self._consume(qevent, route, routed.turn, nav, agent_id)
             if (
                 outcome.status is SessionStatus.AWAITING_APPROVAL
                 and _is_publish_provenance(
@@ -2388,6 +2400,7 @@ class Kernel:
         route: TargetRoute,
         turn: TurnStream,
         nav: NavAffordance | None = None,
+        agent_id: uuid.UUID | None = None,
     ) -> TurnOutcome:
         acc = _StreamAccumulator()
         reply = _ThrottledReply(
@@ -2417,7 +2430,7 @@ class Kernel:
             # the connection is never leaked.
             async with turn:
                 async for frame in turn:
-                    await self._apply_frame(frame, acc, reply, qevent.event_id)
+                    await self._apply_frame(frame, acc, reply, qevent, agent_id)
         except (aiohttp.ClientError, TimeoutError) as exc:
             # Stream dropped mid-run (sandbox killed, network fault). No final.
             logger.warning("turn stream dropped for %s: %s", qevent.event_id, exc)
@@ -2425,6 +2438,21 @@ class Kernel:
                 terminal_ok=False,
                 saw_side_effect=acc.saw_side_effect,
                 classification=acc.classification or "runner-error",
+                text=acc.rendered(),
+            )
+        except ActionBackendError as exc:
+            # The ledger refused a write (ADR-0117). The change to the world has
+            # already happened and the platform has no account of it, so this
+            # ends the turn rather than completing one whose receipt would be a
+            # lie. "ledger-error" is deliberately absent from
+            # RETRYABLE_CLASSIFICATIONS: a retry would re-execute a side effect,
+            # which is the rule ADR-0013 already holds, and escalation puts a
+            # human in front of the gap.
+            logger.error("action ledger write failed for %s: %s", qevent.event_id, exc)
+            return TurnOutcome(
+                terminal_ok=False,
+                saw_side_effect=acc.saw_side_effect,
+                classification="ledger-error",
                 text=acc.rendered(),
             )
 
@@ -2435,7 +2463,8 @@ class Kernel:
         frame: OutboundEvent,
         acc: _StreamAccumulator,
         reply: _ThrottledReply,
-        event_id: str,
+        qevent: QueuedTurn,
+        agent_id: uuid.UUID | None = None,
     ) -> None:
         if isinstance(frame, TextDelta):
             acc.text_parts.append(frame.text)
@@ -2447,7 +2476,11 @@ class Kernel:
         elif isinstance(frame, SideEffectFlag):
             acc.saw_side_effect = True
             # Persist immediately so a crash before done still blocks auto-retry.
-            await self._markers.mark_side_effect(event_id)
+            # Unchanged by ADR-0117: this latches on the FIRST frame and the rule
+            # reads presence, so a stream carrying one frame per call rather than
+            # one per turn is the same signal to it.
+            await self._markers.mark_side_effect(qevent.event_id)
+            await self._record_action(frame, acc, qevent, agent_id)
         elif isinstance(frame, ErrorEvent):
             acc.classification = frame.classification or acc.classification
         elif isinstance(frame, Final):
@@ -2457,6 +2490,40 @@ class Kernel:
             acc.approval_route = frame.approval_route
             acc.approval_gate_kind = frame.approval_gate_kind
             acc.approval_granted_tool = frame.approval_granted_tool
+
+    async def _record_action(
+        self,
+        frame: SideEffectFlag,
+        acc: _StreamAccumulator,
+        qevent: QueuedTurn,
+        agent_id: uuid.UUID | None,
+    ) -> None:
+        """Open a record for a call, or close the one it already opened.
+
+        Deliberately NOT best-effort. A change to the world the platform has no
+        record of is not a success, and the branch this sits in already fails the
+        turn when the no-retry marker cannot be persisted; losing the account of
+        WHAT changed is not the lesser failure. An ActionBackendError propagates
+        out of the frame loop exactly as a marker failure does.
+        """
+
+        if self._actions is None or frame.call_id is None:
+            # No ledger wired, or a producer that predates ADR-0117. The frame
+            # still carries presence, which is all the no-retry rule reads; there
+            # is nothing to record without a call id, because two such frames
+            # cannot be told apart.
+            return
+        opened = acc.open_actions.get(frame.call_id)
+        if opened is None:
+            recorded = await self._actions.record(
+                frame,
+                event_id=qevent.event_id,
+                conversation_id=qevent.conversation_id,
+                agent_id=str(agent_id) if agent_id is not None else None,
+            )
+            acc.open_actions[frame.call_id] = recorded.id
+            return
+        await self._actions.complete(opened, frame)
 
     async def _finish(self, acc: _StreamAccumulator, reply: _ThrottledReply) -> TurnOutcome:
         if acc.status in (SessionStatus.DONE, SessionStatus.IDLE_AWAITING_INPUT):

--- a/apps/worker/src/curie_worker/run.py
+++ b/apps/worker/src/curie_worker/run.py
@@ -24,6 +24,7 @@ from aci_protocol.s3 import build_s3_client
 from redis.asyncio import Redis as AsyncRedis
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 
+from .actions import ActionClient
 from .approval_cards import ApprovalCardStore
 from .approvals import ApprovalClient
 from .binding import BindingResolver
@@ -339,6 +340,14 @@ def build(config: WorkerConfig, env: Mapping[str, str]) -> Runtime:
         client=eval_http,
         worker_token=config.internal_worker_token,
     )
+    # The action ledger (ADR-0117), on the same API lane. Wired unconditionally:
+    # an unwired ledger records nothing, and a deployment that can create an
+    # approval can record what a turn did.
+    action_client = ActionClient(
+        api_base_url=config.api_base_url,
+        api_key=config.api_key,
+        client=eval_http,
+    )
     sink = build_reply_sink(config)
     card_store = ApprovalCardStore(async_redis, config)
     kernel = Kernel(
@@ -369,6 +378,7 @@ def build(config: WorkerConfig, env: Mapping[str, str]) -> Runtime:
         # (#1084). Two parameters rather than one so a test can fake the create
         # half without also implementing a read it never exercises.
         approval_reader=approval_client,
+        actions=action_client,
         card_store=card_store,
         route_ttl_seconds=sub_config.route_ttl_seconds,
         suspended_route_ttl_seconds=sub_config.suspended_route_ttl_seconds,

--- a/apps/worker/tests/kernel/conftest.py
+++ b/apps/worker/tests/kernel/conftest.py
@@ -513,7 +513,8 @@ def make_harness(
 
     Closes over the per-test names and the sync Valkey client so tests need no
     conftest import (which importlib mode makes fragile). Optional kwargs:
-    ``binding`` (a resolver injected into the kernel), ``with_killswitch``
+    ``binding`` (a resolver injected into the kernel), ``actions`` (an action
+    ledger recorder), ``with_killswitch``
     (build a real KillSwitch wired to the kernel) and ``sink`` (any ``ReplySink``
     -- a real ``ReplySinkRouter`` for the adapter-selection tests, T-B3/T-B4);
     the rest are config overrides."""
@@ -533,6 +534,7 @@ async def kernel_harness(
     with_killswitch: bool = False,
     approvals: object | None = None,
     approval_reader: object | None = None,
+    actions: object | None = None,
     publication_creator: object | None = None,
     sink: object | None = None,
     claim_timeout_seconds: float = 3.0,
@@ -581,6 +583,7 @@ async def kernel_harness(
         binding=binding,  # type: ignore[arg-type]
         approvals=approvals,  # type: ignore[arg-type]
         approval_reader=approval_reader,  # type: ignore[arg-type]
+        actions=actions,  # type: ignore[arg-type]
         publication_creator=publication_creator,  # type: ignore[arg-type]
         card_store=card_store,
     )

--- a/apps/worker/tests/kernel/test_action_ledger.py
+++ b/apps/worker/tests/kernel/test_action_ledger.py
@@ -1,0 +1,200 @@
+"""The kernel records what a turn did to the world (ADR-0117).
+
+The branch under test is the one that already existed: a ``side_effect_flag``
+sets ``saw_side_effect`` and persists the no-retry marker. It now also writes a
+record, and the constraints on that are as much about what must NOT change.
+
+`kernel.py` is sacred under ADR-0013, so every test here that is not about the
+ledger is about the signal the ledger must not disturb.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from dataclasses import dataclass, field
+from typing import Any
+
+from aci_protocol import Final, QueuedTurn, ReplyHandle, SessionStatus, SideEffectFlag, TurnSource
+from curie_worker.actions import ActionBackendError, RecordedAction
+
+DONE = SessionStatus.DONE
+
+
+def _qevent(text: str, *, thread: str = "th-1", event_id: str | None = None) -> QueuedTurn:
+    return QueuedTurn(
+        event_id=event_id or uuid.uuid4().hex,
+        conversation_id=thread,
+        author="U1",
+        text=text,
+        reply_handle=ReplyHandle(kind="slack", channel="C1", placeholder="p-1"),
+        received_at="2026-07-05T00:00:00+00:00",
+        source=TurnSource.SLACK,
+    )
+
+
+@dataclass
+class FakeRecorder:
+    """Records the calls the kernel makes, and can refuse one."""
+
+    fail_on_record: bool = False
+    recorded: list[dict[str, Any]] = field(default_factory=list)
+    completed: list[tuple[str, SideEffectFlag]] = field(default_factory=list)
+
+    async def record(
+        self,
+        frame: SideEffectFlag,
+        *,
+        event_id: str,
+        conversation_id: str,
+        agent_id: str | None,
+    ) -> RecordedAction:
+        if self.fail_on_record:
+            raise ActionBackendError("ledger down")
+        self.recorded.append(
+            {
+                "frame": frame,
+                "event_id": event_id,
+                "conversation_id": conversation_id,
+                "agent_id": agent_id,
+            }
+        )
+        return RecordedAction(id=f"a{len(self.recorded)}", status="pending")
+
+    async def complete(self, action_id: str, frame: SideEffectFlag) -> None:
+        self.completed.append((action_id, frame))
+
+
+def _call(call_id: str, tool: str = "scale_deployment") -> list[SideEffectFlag]:
+    """The two frames one side-effecting call produces."""
+
+    return [
+        SideEffectFlag(
+            tool=tool,
+            call_id=call_id,
+            arguments={"replicas": 10},
+            detail="non-idempotent tool executed",
+        ),
+        SideEffectFlag(
+            tool=tool,
+            call_id=call_id,
+            failed=False,
+            result={"ok": True, "prior": {"spec": {"replicas": 3}}},
+            detail="non-idempotent tool completed",
+        ),
+    ]
+
+
+def test_each_call_becomes_one_record(make_harness) -> None:
+    """Two calls, two records. The turn is not the unit; the action is."""
+
+    async def go() -> None:
+        recorder = FakeRecorder()
+        async with make_harness(actions=recorder) as h:
+            h.runner.default_script = [
+                *_call("toolu_01"),
+                *_call("toolu_02", tool="restart_deployment"),
+                Final(text="done", status=DONE),
+            ]
+            await h.kernel.process_event(_qevent("scale it"))
+
+            assert [r["frame"].call_id for r in recorder.recorded] == ["toolu_01", "toolu_02"]
+            assert [action_id for action_id, _ in recorder.completed] == ["a1", "a2"]
+
+    asyncio.run(go())
+
+
+def test_a_record_carries_the_turn_it_belongs_to(make_harness) -> None:
+    async def go() -> None:
+        recorder = FakeRecorder()
+        async with make_harness(actions=recorder) as h:
+            h.runner.default_script = [*_call("toolu_01"), Final(text="done", status=DONE)]
+            event = _qevent("scale it", thread="th-9")
+            await h.kernel.process_event(event)
+
+            assert recorder.recorded[0]["conversation_id"] == "th-9"
+            assert recorder.recorded[0]["event_id"] == event.event_id
+
+    asyncio.run(go())
+
+
+def test_the_completion_carries_what_the_connector_reported(make_harness) -> None:
+    async def go() -> None:
+        recorder = FakeRecorder()
+        async with make_harness(actions=recorder) as h:
+            h.runner.default_script = [*_call("toolu_01"), Final(text="done", status=DONE)]
+            await h.kernel.process_event(_qevent("scale it"))
+
+            _, frame = recorder.completed[0]
+            assert frame.result == {"ok": True, "prior": {"spec": {"replicas": 3}}}
+
+    asyncio.run(go())
+
+
+def test_a_frame_without_a_call_id_records_nothing_and_still_blocks_retry(
+    make_harness,
+) -> None:
+    """A producer that predates ADR-0117 emits the old frame, and must still work.
+
+    ADR-0036's reader policy cuts both ways: the platform tolerates the older
+    producer. There is nothing to record without a call id -- two such frames
+    cannot be told apart -- but the no-retry rule reads presence, and presence is
+    exactly what this frame still carries.
+    """
+
+    async def go() -> None:
+        recorder = FakeRecorder()
+        async with make_harness(actions=recorder) as h:
+            h.runner.default_script = [
+                SideEffectFlag(tool="deploy"),
+                Final(text="done", status=DONE),
+            ]
+            event = _qevent("deploy")
+            await h.kernel.process_event(event)
+
+            assert recorder.recorded == []
+            assert await h.async_redis.exists(h.config.side_effect_key(event.event_id))
+
+    asyncio.run(go())
+
+
+def test_an_unwired_ledger_does_not_break_a_turn(make_harness) -> None:
+    """Every existing test builds a kernel with no recorder, and must keep passing."""
+
+    async def go() -> None:
+        async with make_harness() as h:
+            h.runner.default_script = [*_call("toolu_01"), Final(text="done", status=DONE)]
+            await h.kernel.process_event(_qevent("scale it"))
+
+            assert h.sink.last_text == "done"
+
+    asyncio.run(go())
+
+
+def test_a_ledger_that_refuses_the_write_fails_the_turn(make_harness) -> None:
+    """A change to the world the platform has no record of is not a success.
+
+    This same branch already fails the turn when the no-retry marker cannot be
+    persisted. Losing the record of WHAT changed is not the lesser failure, and a
+    turn that reports success while the ledger silently missed an action is how
+    an operator learns to distrust the receipt.
+    """
+
+    async def go() -> None:
+        recorder = FakeRecorder(fail_on_record=True)
+        async with make_harness(actions=recorder) as h:
+            h.runner.default_script = [*_call("toolu_01"), Final(text="done", status=DONE)]
+            event = _qevent("scale it")
+            await h.kernel.process_event(event)
+
+            # Escalated, not completed: the turn does not report the work done
+            # when the platform cannot say what it did.
+            assert h.sink.last_text is not None
+            assert "human" in h.sink.last_text.lower()
+            assert "done" not in h.sink.last_text
+            # The side effect still happened, so no retry may follow it, and
+            # exactly one attempt was made.
+            assert await h.async_redis.exists(h.config.side_effect_key(event.event_id))
+            assert h.runner.opened == ["scale it"]
+
+    asyncio.run(go())

--- a/apps/worker/tests/test_action_client.py
+++ b/apps/worker/tests/test_action_client.py
@@ -1,0 +1,163 @@
+"""The worker's client for the action ledger (ADR-0117).
+
+The worker has no database of its own, so recording what a turn did to the world
+is an HTTP call to the platform API, exactly as creating an approval is. This
+covers the two calls one side-effecting tool call produces and the failure that
+must not be swallowed.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+import pytest
+from aci_protocol import SideEffectFlag
+from curie_worker.actions import ActionBackendError, ActionClient
+
+pytestmark = pytest.mark.anyio
+
+
+def _client(handler: Any) -> tuple[httpx.AsyncClient, list[dict[str, Any]]]:
+    seen: list[dict[str, Any]] = []
+
+    def wrapped(request: httpx.Request) -> httpx.Response:
+        seen.append(
+            {
+                "method": request.method,
+                "path": request.url.path,
+                "body": json.loads(request.content) if request.content else None,
+                "api_key": request.headers.get("X-API-Key"),
+            }
+        )
+        return handler(request)
+
+    return httpx.AsyncClient(transport=httpx.MockTransport(wrapped)), seen
+
+
+async def test_recording_a_call_sends_its_arguments_and_a_dedupe_key() -> None:
+    client, seen = _client(lambda _r: httpx.Response(201, json={"id": "a1", "status": "pending"}))
+
+    async with client:
+        recorded = await ActionClient(
+            api_base_url="http://api", api_key="k", client=client
+        ).record(
+            SideEffectFlag(
+                tool="scale_deployment",
+                call_id="toolu_01",
+                arguments={"replicas": 10},
+                detail="non-idempotent tool executed",
+            ),
+            event_id="event-1",
+            conversation_id="C1",
+            agent_id=None,
+        )
+
+    assert recorded.id == "a1"
+    assert seen[0]["method"] == "POST"
+    assert seen[0]["path"] == "/actions"
+    assert seen[0]["api_key"] == "k"
+    # The event id AND the call id: one turn can call the same tool twice, and a
+    # redelivery of that turn must adopt both rows rather than collapse them.
+    assert seen[0]["body"]["dedupe_key"] == "event-1:toolu_01"
+    assert seen[0]["body"]["arguments"] == {"replicas": 10}
+
+
+async def test_a_redelivered_record_is_not_an_error() -> None:
+    """200 is the API's idempotent replay; only a non-2xx is a failure."""
+
+    client, _ = _client(lambda _r: httpx.Response(200, json={"id": "a1", "status": "pending"}))
+
+    async with client:
+        recorded = await ActionClient(
+            api_base_url="http://api", api_key="k", client=client
+        ).record(
+            SideEffectFlag(tool="t", call_id="c", arguments={}),
+            event_id="e",
+            conversation_id="C1",
+            agent_id=None,
+        )
+
+    assert recorded.id == "a1"
+
+
+async def test_completing_a_call_forwards_the_prior_state_a_restore_replays() -> None:
+    """`prior` and `target` come out of the CONNECTOR's reply, not the arguments.
+
+    No function of `replicas=10` can produce the replica count from before the
+    call. That is why the reply is the declaration (ADR-0117 decision 1).
+    """
+
+    client, seen = _client(lambda _r: httpx.Response(200, json={"id": "a1", "status": "succeeded"}))
+
+    async with client:
+        await ActionClient(api_base_url="http://api", api_key="k", client=client).complete(
+            "a1",
+            SideEffectFlag(
+                tool="scale_deployment",
+                call_id="toolu_01",
+                failed=False,
+                result={
+                    "ok": True,
+                    "prior": {"spec": {"replicas": 3}},
+                    "target": {"kind": "Deployment", "name": "api"},
+                },
+                detail="non-idempotent tool completed",
+            ),
+        )
+
+    assert seen[0]["path"] == "/actions/a1/complete"
+    assert seen[0]["body"]["prior_state"] == {"spec": {"replicas": 3}}
+    assert seen[0]["body"]["target"] == {"kind": "Deployment", "name": "api"}
+    assert seen[0]["body"]["failed"] is False
+
+
+async def test_a_prose_reply_completes_with_nothing_to_restore() -> None:
+    """The connector answered in a sentence, so the result is absent entirely."""
+
+    client, seen = _client(lambda _r: httpx.Response(200, json={"id": "a1", "status": "succeeded"}))
+
+    async with client:
+        await ActionClient(api_base_url="http://api", api_key="k", client=client).complete(
+            "a1",
+            SideEffectFlag(tool="restart", call_id="c", failed=False, detail="restarted"),
+        )
+
+    assert seen[0]["body"]["result"] is None
+    assert seen[0]["body"]["prior_state"] is None
+    assert seen[0]["body"]["target"] is None
+
+
+async def test_a_structured_reply_without_a_prior_is_still_not_undoable() -> None:
+    """A connector may return JSON and still not report what it overwrote."""
+
+    client, seen = _client(lambda _r: httpx.Response(200, json={"id": "a1", "status": "succeeded"}))
+
+    async with client:
+        await ActionClient(api_base_url="http://api", api_key="k", client=client).complete(
+            "a1",
+            SideEffectFlag(tool="t", call_id="c", failed=False, result={"ok": True}),
+        )
+
+    assert seen[0]["body"]["result"] == {"ok": True}
+    assert seen[0]["body"]["prior_state"] is None
+
+
+async def test_a_refused_write_is_raised_not_swallowed() -> None:
+    """A record the platform failed to write is a hole in its account of a change.
+
+    The same branch already fails the turn when the no-retry marker cannot be
+    persisted; losing the record of WHAT changed is not the lesser failure.
+    """
+
+    client, _ = _client(lambda _r: httpx.Response(500, text="nope"))
+
+    async with client:
+        with pytest.raises(ActionBackendError):
+            await ActionClient(api_base_url="http://api", api_key="k", client=client).record(
+                SideEffectFlag(tool="t", call_id="c"),
+                event_id="e",
+                conversation_id="C1",
+                agent_id=None,
+            )


### PR DESCRIPTION
Slice 2b of #1861. Closes #1872, and closes #1863 together with #1871.

The ledger now fills on its own. This is the last piece before an undo can be ruled on.

## The change to `kernel.py`

**71 added lines, 4 removed**, in the branch that already existed — a `side_effect_flag` sets `saw_side_effect` and persists the no-retry marker. It now also records what the call did.

`kernel.py` is sacred under ADR-0013, so what did *not* change matters as much: the marker still latches on the first frame, so the no-retry rule and the false-completion check read exactly the signal they read before. Two signature changes (`_consume` and `_apply_frame` take the turn and the agent id rather than the event id alone) exist because a record belongs to a conversation and an agent, and threading three scalars would have been worse.

## One call is one row

The opening frame creates the record; the closing frame, matched on `call_id` through the accumulator, completes **that** record rather than minting a second.

`dedupe_key` is the event id **and** the call id together — the event id alone collapses a turn that called the same tool twice, and the call id alone doesn't survive a redelivery of that turn.

`prior_state` and `target` come out of the connector's structured reply, not the arguments, and `curie_worker/actions.py` is the one place that convention is read. No function of `scale_deployment(replicas=10)`'s arguments can produce the replica count from *before* the call — which is the whole reason the reply is the declaration (ADR-0117 decision 1).

## A refused write ends the turn

`ledger-error`, deliberately absent from `RETRYABLE_CLASSIFICATIONS`. The change to the world has already happened, so a retry would re-execute a side effect — the rule ADR-0013 already holds — and completing the turn would hand back a receipt the platform can't stand behind. The user sees "The run hit an error (ledger-error) after starting an action; not retrying automatically. Flagging for a human."

This is the judgement call in the PR, so it's worth stating plainly: **not best-effort.** A change the platform has no account of is not a success, and this same branch already fails the turn when the no-retry marker can't be persisted. Losing the record of *what* changed isn't the lesser failure.

## Two deliberate tolerances

| | |
| --- | --- |
| a frame with no `call_id` | a producer predating ADR-0117. Nothing recorded — two such frames can't be told apart — but the no-retry rule reads presence, which the frame still carries. ADR-0036's reader policy cuts both ways. |
| no recorder wired | records nothing rather than failing every turn that touches the world, exactly as an unwired approval backend degrades. Every existing kernel test builds one this way. |

## Verification

Baselined rather than asserted — the worker suite has pre-existing failures on this machine:

```
apps/worker (this branch)   27 failed, 981 passed, 7 skipped
apps/worker (clean stash)   27 failed, 977 passed, 7 skipped
regressions                 none — identical failure lists, diffed
```

The 27 are eval-stream and dead-letter-alerting tests that need services this machine isn't running. New coverage: 6 kernel tests, 6 client tests.

```
ruff check .      All checks passed
mypy              no issues in 202 source files
check-contracts   current
check-docs        drift-free, every citation resolves
```
