### PR TITLE
Refuse an undo when the world has moved

### DIFF
--- a/apps/api/alembic/versions/0030_action_post_state.py
+++ b/apps/api/alembic/versions/0030_action_post_state.py
@@ -1,0 +1,44 @@
+"""What an action left behind, so a restore can tell whether the world moved.
+
+Revision ID: 0030
+Revises: 0029
+Create Date: 2026-08-25
+
+ADR-0117 decision 4 refuses a restore when the resource no longer looks like what
+the action left. Nothing recorded that: 0029 holds ``prior_state`` (where the
+resource came FROM) and ``result``, and neither answers where the action PUT it.
+
+Deriving it from ``arguments`` is not available, and not merely inconvenient: a
+PATCH's result is not its request body, and deriving a reversal from the forward
+call's arguments is the mapping-DSL alternative ADR-0117 rejects. It comes from
+the connector's reply, like the prior state.
+
+Nullable with no backfill. Rows written before a connector reports a post-state
+have none, and an undo on such a row is refused for want of something to compare
+against -- deny-by-default, the same posture the rest of the ledger takes.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0030"
+down_revision: str | None = "0029"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+SCHEMA = "curie"
+
+
+def upgrade() -> None:
+    op.add_column(
+        "agent_actions",
+        sa.Column("post_state", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        schema=SCHEMA,
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("agent_actions", "post_state", schema=SCHEMA)

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -1,6 +1,90 @@
 {
   "components": {
     "schemas": {
+      "ActionAuditOut": {
+        "description": "One entry in an action's audit trail: an authorized undo, or a refused one.",
+        "properties": {
+          "action": {
+            "title": "Action",
+            "type": "string"
+          },
+          "action_id": {
+            "format": "uuid",
+            "title": "Action Id",
+            "type": "string"
+          },
+          "actor": {
+            "title": "Actor",
+            "type": "string"
+          },
+          "actor_channel": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Actor Channel"
+          },
+          "authorized": {
+            "title": "Authorized",
+            "type": "boolean"
+          },
+          "authorizer": {
+            "title": "Authorizer",
+            "type": "string"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "evidence": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Evidence"
+          },
+          "id": {
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reason"
+          }
+        },
+        "required": [
+          "id",
+          "action_id",
+          "action",
+          "actor",
+          "actor_channel",
+          "authorizer",
+          "authorized",
+          "reason",
+          "evidence",
+          "created_at"
+        ],
+        "title": "ActionAuditOut",
+        "type": "object"
+      },
       "ActionComplete": {
         "description": "The closing frame: what came back, and what it takes to put it back.\n\n``prior_state`` and ``target`` are what a restore replays. Both are optional\nbecause a connector that answers in prose reports neither, and a record that\nholds neither is not undoable -- which is the honest answer rather than a\nmissing one.",
         "properties": {
@@ -19,6 +103,18 @@
             "default": false,
             "title": "Failed",
             "type": "boolean"
+          },
+          "post_state": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Post State"
           },
           "prior_state": {
             "anyOf": [
@@ -131,6 +227,18 @@
             "title": "Id",
             "type": "string"
           },
+          "post_state": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Post State"
+          },
           "prior_state": {
             "anyOf": [
               {
@@ -212,6 +320,7 @@
           "arguments",
           "result",
           "prior_state",
+          "post_state",
           "target",
           "detail",
           "status",
@@ -287,6 +396,81 @@
           "dedupe_key"
         ],
         "title": "ActionRecord",
+        "type": "object"
+      },
+      "ActionRestore": {
+        "description": "The call an authorized undo permits: put this state back on that target.",
+        "properties": {
+          "prior_state": {
+            "additionalProperties": true,
+            "title": "Prior State",
+            "type": "object"
+          },
+          "target": {
+            "additionalProperties": true,
+            "title": "Target",
+            "type": "object"
+          }
+        },
+        "required": [
+          "target",
+          "prior_state"
+        ],
+        "title": "ActionRestore",
+        "type": "object"
+      },
+      "ActionUndo": {
+        "description": "A request to put back what an action changed.\n\n``observed_state`` is the resource as it looks NOW, read by whoever will\nperform the restore. The platform cannot read it itself -- nothing here can\nreach a connector -- and it will not assume: an absent observation is refused\nrather than treated as \"unchanged\".",
+        "properties": {
+          "actor": {
+            "title": "Actor",
+            "type": "string"
+          },
+          "actor_channel": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Actor Channel"
+          },
+          "observed_state": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Observed State"
+          }
+        },
+        "required": [
+          "actor"
+        ],
+        "title": "ActionUndo",
+        "type": "object"
+      },
+      "ActionUndoOut": {
+        "description": "An authorization, not a receipt.\n\nThe API rules and returns; something else performs the restore (ADR-0117\nleaves where that executor lives undecided). So this names the call to make\nrather than claiming it was made.",
+        "properties": {
+          "action": {
+            "$ref": "#/components/schemas/ActionOut"
+          },
+          "restore": {
+            "$ref": "#/components/schemas/ActionRestore"
+          }
+        },
+        "required": [
+          "action",
+          "restore"
+        ],
+        "title": "ActionUndoOut",
         "type": "object"
       },
       "AgentCreate": {
@@ -3917,6 +4101,70 @@
         ]
       }
     },
+    "/actions/{action_id}/audit": {
+      "get": {
+        "description": "The action's audit trail, oldest first.\n\nA refused undo leaves no trace anywhere else -- the world did not change and\nthe record did not move -- so this is the only place the reason survives.",
+        "operationId": "get_action_audit_actions__action_id__audit_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "action_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Action Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/ActionAuditOut"
+                  },
+                  "title": "Response Get Action Audit Actions  Action Id  Audit Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Action Audit",
+        "tags": [
+          "actions"
+        ]
+      }
+    },
     "/actions/{action_id}/complete": {
       "post": {
         "description": "Record what the tool answered.\n\n``prior_state`` and ``target`` are what a restore replays. A completion that\ncarries neither produces a record that is not undoable, which is the honest\nanswer for a connector that replied in prose -- nothing has to declare it.",
@@ -3982,6 +4230,76 @@
           }
         },
         "summary": "Complete Action",
+        "tags": [
+          "actions"
+        ]
+      }
+    },
+    "/actions/{action_id}/undo": {
+      "post": {
+        "description": "Rule on putting back what this action changed.\n\nA 200 authorizes a restore and names the call that performs it; every other\noutcome is a refusal that changed nothing. The refusals are ordered from the\nrecord's own state outward to the world, so the most specific true reason is\nthe one the operator is told.\n\nWho may undo is not decided here yet. ADR-0117 decision 3 makes an undo\nrequire the authorization the forward action required and no more, which\nneeds the gating approval recorded on the action; that lands separately.\nUntil then this endpoint is authenticated like every other router and gated\nby the conflict rule alone.",
+        "operationId": "undo_action_actions__action_id__undo_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "action_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Action Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ActionUndo"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActionUndoOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Undo Action",
         "tags": [
           "actions"
         ]

--- a/apps/api/src/curie_api/crud.py
+++ b/apps/api/src/curie_api/crud.py
@@ -14,6 +14,7 @@ from sqlalchemy.orm import selectinload
 
 from .config import get_settings
 from .models import (
+    ActionAuditEntry,
     ActionStatus,
     Agent,
     AgentAction,
@@ -776,12 +777,42 @@ async def complete_action(
     action.status = ActionStatus.failed if data.failed else ActionStatus.succeeded
     action.result = data.result
     action.prior_state = data.prior_state
+    action.post_state = data.post_state
     action.target = data.target
     if data.detail is not None:
         action.detail = data.detail
     action.completed_at = datetime.now(UTC).replace(tzinfo=None)
     await session.commit()
     await session.refresh(action)
+    return action
+
+
+async def list_action_audit(
+    session: AsyncSession, action_id: uuid.UUID
+) -> list[ActionAuditEntry]:
+    result = await session.execute(
+        select(ActionAuditEntry)
+        .where(ActionAuditEntry.action_id == action_id)
+        .order_by(ActionAuditEntry.created_at)
+    )
+    return list(result.scalars().all())
+
+
+async def claim_action_undo(
+    session: AsyncSession, action: AgentAction, *, actor: str
+) -> AgentAction:
+    """Mark the undo claimed so a second ruling cannot authorize a second restore.
+
+    Claimed at ruling time rather than on completion, because nothing reports
+    completion yet: the executor ADR-0117 leaves undecided is what would. The
+    honest consequence is that a restore which never runs leaves a record saying
+    it was, and closing that is the executor's job -- authorizing two restores of
+    one action is the worse failure of the two.
+    """
+
+    action.undone_at = datetime.now(UTC).replace(tzinfo=None)
+    action.undone_by = actor
+    session.add(action)
     return action
 
 

--- a/apps/api/src/curie_api/models.py
+++ b/apps/api/src/curie_api/models.py
@@ -563,6 +563,13 @@ class AgentAction(Base):
     # nothing to put back or nowhere to put it.
     prior_state: Mapped[dict[str, Any] | None] = mapped_column(JSONB, default=None)
     target: Mapped[dict[str, Any] | None] = mapped_column(JSONB, default=None)
+    # What the call LEFT, reported by the same reply that reported what it read.
+    # The world-moved check compares the live resource against this, never
+    # against ``prior_state`` -- that is where the resource came from, not where
+    # the action put it. It cannot be derived from ``arguments``: a PATCH's
+    # result is not its request body, and deriving it is the mapping-DSL
+    # approach ADR-0117 rejects.
+    post_state: Mapped[dict[str, Any] | None] = mapped_column(JSONB, default=None)
     # The frame's human-readable note. On a record that is not undoable this is
     # the stated reason the receipt shows instead of a control.
     detail: Mapped[str | None] = mapped_column(default=None)

--- a/apps/api/src/curie_api/routers/actions.py
+++ b/apps/api/src/curie_api/routers/actions.py
@@ -12,8 +12,12 @@ second one matters more than it looks: the prior state on a record is what a
 restore replays, so a completion allowed to rewrite it moves the target of an
 undo that has already been offered to a human.
 
-Ruling on an undo is NOT here. It is its own decision, with its own two refusal
-rules, and it lands separately.
+Ruling on an undo IS here, and executing one is not. Nothing in the platform can
+reach a connector, so this decides whether a restore is permitted and hands back
+the call to make. Keeping the ruling and the execution apart is what makes
+deferring the executor safe: a refusal is recorded and returned before anything
+could act on it, so whichever executor lands cannot bypass the check by holding
+the connector's address.
 """
 
 import logging
@@ -25,7 +29,16 @@ from sqlalchemy.exc import IntegrityError
 from .. import crud
 from ..auth import require_api_key
 from ..deps import SessionDep
-from ..schemas import ActionComplete, ActionOut, ActionRecord
+from ..models import ActionAuditEntry, ActionStatus, AgentAction
+from ..schemas import (
+    ActionAuditOut,
+    ActionComplete,
+    ActionOut,
+    ActionRecord,
+    ActionRestore,
+    ActionUndo,
+    ActionUndoOut,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -98,3 +111,165 @@ async def complete_action(
         raise HTTPException(status.HTTP_404_NOT_FOUND, "action not found")
     completed = await crud.complete_action(session, action, data)
     return ActionOut.model_validate(completed)
+
+
+@router.get("/{action_id}/audit", response_model=list[ActionAuditOut])
+async def get_action_audit(action_id: uuid.UUID, session: SessionDep) -> list[ActionAuditOut]:
+    """The action's audit trail, oldest first.
+
+    A refused undo leaves no trace anywhere else -- the world did not change and
+    the record did not move -- so this is the only place the reason survives.
+    """
+
+    action = await crud.get_action(session, action_id)
+    if action is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "action not found")
+    entries = await crud.list_action_audit(session, action_id)
+    return [ActionAuditOut.model_validate(e) for e in entries]
+
+
+async def _refuse(
+    session: SessionDep,
+    action: AgentAction,
+    data: ActionUndo,
+    *,
+    kind: str,
+    reason: str,
+    code: int,
+    evidence: dict[str, object] | None = None,
+) -> None:
+    """Record the refusal, then raise it.
+
+    Committed before the exception, so the reason outlives the HTTP response
+    that carried it. An operator who pressed undo and saw a red message has
+    somewhere to look; an operator who never saw the message still does.
+    """
+
+    session.add(
+        ActionAuditEntry(
+            action_id=action.id,
+            action=kind,
+            actor=data.actor,
+            actor_channel=data.actor_channel,
+            authorizer="conflict-check",
+            authorized=False,
+            reason=reason,
+            evidence=evidence,
+        )
+    )
+    await session.commit()
+    raise HTTPException(code, reason)
+
+
+@router.post("/{action_id}/undo", response_model=ActionUndoOut)
+async def undo_action(
+    action_id: uuid.UUID, data: ActionUndo, session: SessionDep
+) -> ActionUndoOut:
+    """Rule on putting back what this action changed.
+
+    A 200 authorizes a restore and names the call that performs it; every other
+    outcome is a refusal that changed nothing. The refusals are ordered from the
+    record's own state outward to the world, so the most specific true reason is
+    the one the operator is told.
+
+    Who may undo is not decided here yet. ADR-0117 decision 3 makes an undo
+    require the authorization the forward action required and no more, which
+    needs the gating approval recorded on the action; that lands separately.
+    Until then this endpoint is authenticated like every other router and gated
+    by the conflict rule alone.
+    """
+
+    action = await crud.get_action(session, action_id)
+    if action is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "action not found")
+
+    if action.undone_at is not None:
+        await _refuse(
+            session,
+            action,
+            data,
+            kind="refused_already_undone",
+            reason="this action was already undone",
+            code=status.HTTP_409_CONFLICT,
+        )
+    if action.status != ActionStatus.succeeded:
+        await _refuse(
+            session,
+            action,
+            data,
+            kind="refused_unsuccessful",
+            reason=(
+                f"the call did not succeed (status {action.status}), so there is nothing "
+                "known to reverse"
+            ),
+            code=status.HTTP_409_CONFLICT,
+        )
+    if action.prior_state is None or action.target is None:
+        # The stated reason and the receipt's reason are the same sentence: the
+        # connector's own words when it had them, and an honest fallback when it
+        # did not.
+        await _refuse(
+            session,
+            action,
+            data,
+            kind="refused_irreversible",
+            reason=action.detail or "no recorded prior state, so this cannot be undone",
+            code=status.HTTP_409_CONFLICT,
+        )
+    if data.observed_state is None:
+        # Not an assumption of "unchanged". The platform cannot read the resource
+        # itself, and a restore performed without looking is the blind restore
+        # decision 4 exists to prevent.
+        await _refuse(
+            session,
+            action,
+            data,
+            kind="refused_unobserved",
+            reason="refusing to restore without the live state to compare against",
+            code=status.HTTP_412_PRECONDITION_FAILED,
+        )
+    if action.post_state is None:
+        await _refuse(
+            session,
+            action,
+            data,
+            kind="refused_uncomparable",
+            reason=(
+                "this call never reported what it left, so whether the world has moved "
+                "since cannot be determined"
+            ),
+            code=status.HTTP_409_CONFLICT,
+        )
+    if data.observed_state != action.post_state:
+        # The rule the feature lives on. Naming both states matters as much as
+        # refusing: the operator has to see that their own fix is what stopped
+        # this, rather than reading it as a platform malfunction.
+        await _refuse(
+            session,
+            action,
+            data,
+            kind="refused_conflict",
+            reason="the target changed after this action; refusing to restore over it",
+            code=status.HTTP_409_CONFLICT,
+            evidence={"left": action.post_state, "observed": data.observed_state},
+        )
+
+    assert action.target is not None and action.prior_state is not None  # narrowed above
+    claimed = await crud.claim_action_undo(session, action, actor=data.actor)
+    session.add(
+        ActionAuditEntry(
+            action_id=action.id,
+            action="authorized",
+            actor=data.actor,
+            actor_channel=data.actor_channel,
+            authorizer="conflict-check",
+            authorized=True,
+            evidence={"restoring": action.prior_state},
+        )
+    )
+    await session.commit()
+    await session.refresh(claimed)
+    return ActionUndoOut(
+        action=ActionOut.model_validate(claimed),
+        restore=ActionRestore(target=action.target, prior_state=action.prior_state),
+    )

--- a/apps/api/src/curie_api/schemas.py
+++ b/apps/api/src/curie_api/schemas.py
@@ -1256,6 +1256,7 @@ class ActionComplete(BaseModel):
     failed: bool = False
     result: dict[str, Any] | None = None
     prior_state: dict[str, Any] | None = None
+    post_state: dict[str, Any] | None = None
     target: dict[str, Any] | None = None
     detail: str | None = None
 
@@ -1271,6 +1272,7 @@ class ActionOut(BaseModel):
     arguments: dict[str, Any] | None
     result: dict[str, Any] | None
     prior_state: dict[str, Any] | None
+    post_state: dict[str, Any] | None
     target: dict[str, Any] | None
     detail: str | None
     status: str
@@ -1282,6 +1284,56 @@ class ActionOut(BaseModel):
     # Derived on the model, never stored, so a record cannot claim a
     # reversibility nothing captured the state for (ADR-0117).
     undoable: bool
+
+
+class ActionUndo(BaseModel):
+    """A request to put back what an action changed.
+
+    ``observed_state`` is the resource as it looks NOW, read by whoever will
+    perform the restore. The platform cannot read it itself -- nothing here can
+    reach a connector -- and it will not assume: an absent observation is refused
+    rather than treated as "unchanged".
+    """
+
+    actor: str
+    actor_channel: str | None = None
+    observed_state: dict[str, Any] | None = None
+
+
+class ActionRestore(BaseModel):
+    """The call an authorized undo permits: put this state back on that target."""
+
+    target: dict[str, Any]
+    prior_state: dict[str, Any]
+
+
+class ActionUndoOut(BaseModel):
+    """An authorization, not a receipt.
+
+    The API rules and returns; something else performs the restore (ADR-0117
+    leaves where that executor lives undecided). So this names the call to make
+    rather than claiming it was made.
+    """
+
+    action: ActionOut
+    restore: ActionRestore
+
+
+class ActionAuditOut(BaseModel):
+    """One entry in an action's audit trail: an authorized undo, or a refused one."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    action_id: uuid.UUID
+    action: str
+    actor: str
+    actor_channel: str | None
+    authorizer: str
+    authorized: bool
+    reason: str | None
+    evidence: dict[str, Any] | None
+    created_at: datetime
 
 
 class ApprovalAuditOut(BaseModel):

--- a/apps/api/tests/test_action_undo.py
+++ b/apps/api/tests/test_action_undo.py
@@ -1,0 +1,207 @@
+"""Ruling on an undo (ADR-0117 decision 4), against real Postgres.
+
+The API rules; it does not execute. Nothing in the platform can reach a connector
+today, so this endpoint decides whether a restore is permitted and hands back the
+call to make. Keeping the two apart is what makes deferring the executor safe: a
+refusal is recorded and returned before anything could act on it.
+
+The rule this file exists for is the one ADR-0117 says the feature lives or dies
+on. A blind restore silently reverts a human's manual fix, which turns an undo
+button into a way for the platform to fight the operator. So a restore is refused
+whenever the world no longer looks like what the action left -- and, just as
+importantly, whenever the platform cannot tell.
+
+Every refusal writes an audit entry before it raises. A refusal nobody can read
+afterwards is a bug report the operator never gets.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+import pytest
+
+pytestmark = pytest.mark.usefixtures("clean_db")
+
+LEFT = {"spec": {"replicas": 10}}
+PRIOR = {"spec": {"replicas": 3}}
+TARGET = {"kind": "Deployment", "namespace": "public", "name": "api"}
+
+
+def _record(client: Any, headers: Any, **complete: Any) -> dict[str, Any]:
+    """One recorded call, completed however the caller says."""
+
+    opened = client.post(
+        "/actions",
+        json={
+            "conversation_id": "C1",
+            "call_id": "toolu_01",
+            "tool": "scale_deployment",
+            "arguments": {"name": "api", "replicas": 10},
+            "detail": "non-idempotent tool executed",
+            "dedupe_key": f"event-{uuid.uuid4()}:toolu_01",
+        },
+        headers=headers,
+    ).json()
+    body: dict[str, Any] = {
+        "failed": False,
+        "result": {"ok": True},
+        "prior_state": PRIOR,
+        "post_state": LEFT,
+        "target": TARGET,
+        "detail": "non-idempotent tool completed",
+    }
+    body.update(complete)
+    return dict(client.post(f"/actions/{opened['id']}/complete", json=body, headers=headers).json())
+
+
+def _undo(client: Any, headers: Any, action_id: str, **body: Any) -> Any:
+    payload: dict[str, Any] = {"actor": "U-operator", "observed_state": LEFT}
+    payload.update(body)
+    return client.post(f"/actions/{action_id}/undo", json=payload, headers=headers)
+
+
+def _audit(client: Any, headers: Any, action_id: str) -> list[dict[str, Any]]:
+    return list(client.get(f"/actions/{action_id}/audit", headers=headers).json())
+
+
+def test_an_untouched_world_authorizes_the_restore(client: Any, auth_headers: Any) -> None:
+    """The live state still matches what the action left, so putting it back is safe."""
+
+    action = _record(client, auth_headers)
+
+    response = _undo(client, auth_headers, action["id"])
+
+    assert response.status_code == 200
+    ruling = response.json()
+    # The ruling hands back the call to make. The API cannot reach a connector,
+    # so naming the restore IS the output.
+    assert ruling["restore"]["target"] == TARGET
+    assert ruling["restore"]["prior_state"] == PRIOR
+    assert [e["action"] for e in _audit(client, auth_headers, action["id"])] == ["authorized"]
+
+
+def test_a_moved_world_is_refused_with_both_states_named(
+    client: Any, auth_headers: Any
+) -> None:
+    """The rule the feature lives on: a human set it to 7 by hand after the agent acted."""
+
+    action = _record(client, auth_headers)
+
+    response = _undo(client, auth_headers, action["id"], observed_state={"spec": {"replicas": 7}})
+
+    assert response.status_code == 409
+    entry = _audit(client, auth_headers, action["id"])[0]
+    assert entry["action"] == "refused_conflict"
+    assert entry["authorized"] is False
+    # Both states, because an operator has to see that their own fix is what
+    # stopped it -- not a platform malfunction.
+    assert entry["evidence"] == {"left": LEFT, "observed": {"spec": {"replicas": 7}}}
+
+
+def test_a_refused_undo_changes_nothing(client: Any, auth_headers: Any) -> None:
+    """`an undo either restores the recorded state or changes nothing at all`."""
+
+    action = _record(client, auth_headers)
+
+    refused = _undo(
+        client, auth_headers, action["id"], observed_state={"spec": {"replicas": 7}}
+    )
+
+    # Assert the refusal happened before asserting nothing moved -- otherwise
+    # this passes against an API with no undo endpoint at all.
+    assert refused.status_code == 409
+    after = client.get(f"/actions/{action['id']}", headers=auth_headers).json()
+    assert after["undone_at"] is None
+    assert after["undoable"] is True
+    assert after["prior_state"] == PRIOR
+
+
+def test_an_unseen_world_is_refused_rather_than_assumed(
+    client: Any, auth_headers: Any
+) -> None:
+    """No live state supplied means the platform cannot tell, which is not consent.
+
+    412 rather than 400: the caller's request is well formed, the precondition
+    the rule needs is simply absent.
+    """
+
+    action = _record(client, auth_headers)
+
+    response = _undo(client, auth_headers, action["id"], observed_state=None)
+
+    assert response.status_code == 412
+    assert _audit(client, auth_headers, action["id"])[0]["action"] == "refused_unobserved"
+
+
+def test_a_call_that_never_reported_what_it_left_is_refused(
+    client: Any, auth_headers: Any
+) -> None:
+    """Deny-by-default reaches the comparison too, not just the snapshot.
+
+    A connector that reports `prior` but not `post` leaves the platform holding a
+    state to restore and no way to know whether restoring it is safe.
+    """
+
+    action = _record(client, auth_headers, post_state=None)
+
+    response = _undo(client, auth_headers, action["id"])
+
+    assert response.status_code == 409
+    assert _audit(client, auth_headers, action["id"])[0]["action"] == "refused_uncomparable"
+
+
+def test_a_prose_reply_is_refused_with_the_reason_it_carried(
+    client: Any, auth_headers: Any
+) -> None:
+    """The receipt's stated reason and the refusal's reason are the same sentence."""
+
+    action = _record(
+        client,
+        auth_headers,
+        prior_state=None,
+        post_state=None,
+        target=None,
+        result=None,
+        detail="restarting pods cannot be undone",
+    )
+
+    response = _undo(client, auth_headers, action["id"])
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "restarting pods cannot be undone"
+
+
+def test_a_failed_call_is_refused(client: Any, auth_headers: Any) -> None:
+    """Undoing a call that did not happen would be a write, not a restore."""
+
+    action = _record(client, auth_headers, failed=True)
+
+    assert _undo(client, auth_headers, action["id"]).status_code == 409
+
+
+def test_an_undo_is_authorized_once(client: Any, auth_headers: Any) -> None:
+    """A second ruling on a claimed record must not authorize a second restore."""
+
+    action = _record(client, auth_headers)
+    _undo(client, auth_headers, action["id"])
+
+    second = _undo(client, auth_headers, action["id"])
+
+    assert second.status_code == 409
+    assert [e["action"] for e in _audit(client, auth_headers, action["id"])] == [
+        "authorized",
+        "refused_already_undone",
+    ]
+
+
+def test_an_unknown_action_is_a_404(client: Any, auth_headers: Any) -> None:
+    response = _undo(client, auth_headers, str(uuid.uuid4()))
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "action not found"
+
+
+def test_undoing_requires_the_api_key(client: Any) -> None:
+    assert client.post(f"/actions/{uuid.uuid4()}/undo", json={"actor": "U1"}).status_code == 401

--- a/apps/api/tests/test_actions_worker_contract.py
+++ b/apps/api/tests/test_actions_worker_contract.py
@@ -57,6 +57,7 @@ async def _round_trip(app: Any) -> dict[str, Any]:
                 result={
                     "ok": True,
                     "prior": {"spec": {"replicas": 3}},
+                    "post": {"spec": {"replicas": 10}},
                     "target": {"kind": "Deployment", "name": "api"},
                 },
                 detail="non-idempotent tool completed",
@@ -84,6 +85,7 @@ def test_a_recorded_call_survives_the_worker_to_api_hop(client: Any, anyio_backe
     # `target` inside its reply, and the row has to hold them as the columns a
     # restore replays.
     assert row["prior_state"] == {"spec": {"replicas": 3}}
+    assert row["post_state"] == {"spec": {"replicas": 10}}
     assert row["target"] == {"kind": "Deployment", "name": "api"}
     assert row["status"] == "succeeded"
     assert row["undoable"] is True

--- a/apps/api/tests/test_migration_0029_agent_actions.py
+++ b/apps/api/tests/test_migration_0029_agent_actions.py
@@ -51,6 +51,9 @@ ALEMBIC_DIR = Path(__file__).resolve().parents[1] / "alembic"
 # this file would go green while proving nothing (#1391).
 BELOW = "0028"
 
+# The revision immediately below 0030, which adds ``post_state``.
+BELOW_0030 = "0029"
+
 
 def _sql(statement: str, params: dict[str, Any] | None = None) -> list[Any]:
     async def _go() -> list[Any]:
@@ -147,3 +150,22 @@ def test_audit_rows_die_with_the_action_they_audit(isolated_migration_db: None) 
     _sql("DELETE FROM curie.agent_actions WHERE id = :id", {"id": action_id})
 
     assert _sql("SELECT 1 FROM curie.action_audit_entries") == []
+
+
+def test_0030_round_trips_the_post_state_column(isolated_migration_db: None) -> None:
+    """A column-add has to undo cleanly too.
+
+    A downgrade that leaves the column behind passes a shape check on the way
+    down and fails the re-upgrade with "column already exists", which is the
+    state an operator rolling back an incident discovers at the worst moment.
+    """
+
+    cfg = _alembic_config()
+    command.upgrade(cfg, "head")
+    assert "post_state" in _columns("agent_actions")
+
+    command.downgrade(cfg, BELOW_0030)
+    assert "post_state" not in _columns("agent_actions")
+
+    command.upgrade(cfg, "head")
+    assert "post_state" in _columns("agent_actions")

--- a/apps/worker/src/curie_worker/actions.py
+++ b/apps/worker/src/curie_worker/actions.py
@@ -29,6 +29,7 @@ logger = logging.getLogger(__name__)
 # rename would turn every reversible tool in the fleet irreversible with nothing
 # failing.
 PRIOR_KEY = "prior"
+POST_KEY = "post"
 TARGET_KEY = "target"
 
 
@@ -57,25 +58,31 @@ class ActionRecorder(Protocol):
     async def complete(self, action_id: str, frame: SideEffectFlag) -> None: ...
 
 
-def _snapshot(frame: SideEffectFlag) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
-    """The prior state and target a restore replays, out of the tool's reply.
+def _snapshot(
+    frame: SideEffectFlag,
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None, dict[str, Any] | None]:
+    """What the call read, what it left, and what it acted on -- from its reply.
+
+    ``prior`` is what a restore puts back and ``post`` is what a restore is
+    checked against, so the two are not interchangeable: comparing the live
+    resource to ``prior`` would refuse every undo that is actually safe and
+    permit exactly the one that is not.
 
     A connector that answered in prose carries no structured result and lands
-    here as ``(None, None)``, which downstream means not undoable. So does one
-    that returned JSON without reporting what it overwrote. Neither is an error
-    and neither is inferred: an inferred prior state is a guess a restore would
-    act on.
+    here as all-None, which downstream means not undoable. So does one that
+    returned JSON without reporting these. Neither is an error and neither is
+    inferred: an inferred state is a guess a restore would act on.
     """
 
     result = frame.result
     if not isinstance(result, dict):
-        return None, None
-    prior = result.get(PRIOR_KEY)
-    target = result.get(TARGET_KEY)
-    return (
-        prior if isinstance(prior, dict) else None,
-        target if isinstance(target, dict) else None,
-    )
+        return None, None, None
+
+    def _obj(key: str) -> dict[str, Any] | None:
+        value = result.get(key)
+        return value if isinstance(value, dict) else None
+
+    return _obj(PRIOR_KEY), _obj(POST_KEY), _obj(TARGET_KEY)
 
 
 class ActionClient:
@@ -122,13 +129,14 @@ class ActionClient:
     async def complete(self, action_id: str, frame: SideEffectFlag) -> None:
         """Close the record with what came back."""
 
-        prior, target = _snapshot(frame)
+        prior, post, target = _snapshot(frame)
         await self._post(
             f"{self._url}/{action_id}/complete",
             {
                 "failed": bool(frame.failed),
                 "result": frame.result,
                 "prior_state": prior,
+                "post_state": post,
                 "target": target,
                 "detail": frame.detail,
             },

--- a/apps/worker/tests/test_action_client.py
+++ b/apps/worker/tests/test_action_client.py
@@ -101,6 +101,7 @@ async def test_completing_a_call_forwards_the_prior_state_a_restore_replays() ->
                 result={
                     "ok": True,
                     "prior": {"spec": {"replicas": 3}},
+                    "post": {"spec": {"replicas": 10}},
                     "target": {"kind": "Deployment", "name": "api"},
                 },
                 detail="non-idempotent tool completed",
@@ -109,6 +110,10 @@ async def test_completing_a_call_forwards_the_prior_state_a_restore_replays() ->
 
     assert seen[0]["path"] == "/actions/a1/complete"
     assert seen[0]["body"]["prior_state"] == {"spec": {"replicas": 3}}
+    # What the call LEFT, which is what a conflict check compares the live
+    # resource against. It cannot be derived from `replicas=10`: a PATCH's
+    # result is not its request body.
+    assert seen[0]["body"]["post_state"] == {"spec": {"replicas": 10}}
     assert seen[0]["body"]["target"] == {"kind": "Deployment", "name": "api"}
     assert seen[0]["body"]["failed"] is False
 
@@ -126,6 +131,7 @@ async def test_a_prose_reply_completes_with_nothing_to_restore() -> None:
 
     assert seen[0]["body"]["result"] is None
     assert seen[0]["body"]["prior_state"] is None
+    assert seen[0]["body"]["post_state"] is None
     assert seen[0]["body"]["target"] is None
 
 

--- a/docs/interfaces/relational-db/INTERFACE.md
+++ b/docs/interfaces/relational-db/INTERFACE.md
@@ -66,12 +66,13 @@ is a judgement call, not something derivable from the tree.
    column is a native Postgres `Enum(Environment, name="environment", schema=SCHEMA)`
    (`apps/api/src/curie_api/models.py::Deployment`), which materializes as a `CREATE TYPE` in the `curie` schema.
 3. **`JSONB` column type** — `apps/api/src/curie_api/models.py::JSONB` is imported from
-   `sqlalchemy.dialects.postgresql` on the same line as `UUID` and used on **twelve** columns:
+   `sqlalchemy.dialects.postgresql` on the same line as `UUID` and used on **thirteen** columns:
    `behavior_packs`, `approval_required_tools`, `approval_routes` and `secrets` on
    `apps/api/src/curie_api/models.py::Agent`, `evidence` on
    `apps/api/src/curie_api/models.py::ApprovalAuditEntry`, `value` on
    `apps/api/src/curie_api/models.py::WorkflowStateEntry`, `arguments`, `result`,
-   `prior_state` and `target` on `apps/api/src/curie_api/models.py::AgentAction`, and
+   `prior_state`, `post_state` and `target` on
+   `apps/api/src/curie_api/models.py::AgentAction`, and
    `evidence` on `apps/api/src/curie_api/models.py::ActionAuditEntry`. Two of them are
    load-bearing rather than incidental: the workflow-state store exists precisely because
    Postgres JSONB meant no new datastore was needed (see that class's docstring), and the


### PR DESCRIPTION
ADR-0117 decision 4 — the rule the ADR says the feature lives or dies on. Part of #1864, slice 3b of #1861.

`POST /actions/{id}/undo` **rules; it does not execute.** Nothing in the platform can reach a connector, so a 200 authorizes a restore and names the call that performs it, and every other outcome is a refusal that changed nothing. That separation is what makes deferring the executor (#1867) safe: a refusal is recorded and returned before anything could act on it.

## The comparison needed a state nothing recorded

0029 holds `prior_state` — where the resource came *from*. Comparing the live resource against that would refuse every undo that is safe and permit exactly the one that isn't. So 0030 adds `post_state`, reported by the same reply that reports the prior state, and the worker forwards it.

**It cannot be derived from the arguments, and the prototype's apparent version of this rule was fabricated.** Its demo built the value as `{"spec": {"replicas": arguments["replicas"]}}` — tool-specific, and the mapping-DSL alternative the ADR rejects in its Alternatives. It worked because the demo knew it was demoing `scale_deployment`.

Until a connector reports `post` (#1865), every undo is refused for want of something to compare against. That's deny-by-default reaching the *comparison* rather than only the snapshot, and it's the correct failure: holding a state to restore is not the same as knowing that restoring it is safe.

## The refusal ladder

Ordered from the record's own state outward to the world, so the most specific true reason is the one the operator is told:

| | | |
| --- | --- | --- |
| `refused_already_undone` | 409 | one record, one restore |
| `refused_unsuccessful` | 409 | undoing a call that didn't happen is a write, not a restore |
| `refused_irreversible` | 409 | nothing captured — reason is the connector's own sentence when it had one |
| `refused_unobserved` | 412 | no live state supplied |
| `refused_uncomparable` | 409 | the call never reported what it left |
| `refused_conflict` | 409 | **the world moved** — evidence names both states |

`refused_unobserved` is deliberately a refusal rather than a default: the platform cannot read the resource itself, and treating an absent observation as "unchanged" is exactly the blind restore this rule prevents.

**Every refusal writes an audit entry and commits it before raising**, so the reason outlives the response that carried it. A refused undo leaves no trace anywhere else — the world didn't change and the record didn't move. The conflict entry names both states because an operator has to see that their *own* fix is what stopped it, not a platform malfunction. `GET /actions/{id}/audit` reads them back.

## One honest compromise

The undo is **claimed at ruling time**. Nothing reports completion yet, so a restore that never runs leaves a record saying it was. Authorizing two restores of one action is the worse failure of the two, and the executor is what closes this.

## What is deliberately not here

**Who may undo.** Decision 3 requires the authorization the forward action required *and no more*, which needs the gating approval recorded on the action — a kernel change, landing separately. The prototype never implemented this rule at all (zero authorizer references in its undo router), so it's new work rather than a port.

## Verification

```
apps/api                     989 passed, 10 skipped
  test_action_undo.py         10 passed  (real Postgres)
  0030 round-trip              1 passed  — mutation-checked: dropping the
                                           downgrade's drop_column makes it fail
worker ledger tests          12 passed
ruff / mypy                  clean (202 source files)
check-contracts / check-docs clean; openapi regenerated
```

`test_control_integration.py::test_cost_composes_metrics_for_the_agent` fails locally and on an untouched checkout alike — needs Langfuse, which `--minimal` skips.
