### PR TITLE
Let the fake model answer its own tool calls

### DIFF
--- a/runner/src/curie_runner/fake.py
+++ b/runner/src/curie_runner/fake.py
@@ -9,6 +9,7 @@ spawns the CLI or touches the network. ``aci-protocol`` is never mocked.
 
 from __future__ import annotations
 
+import json
 import re
 from collections.abc import AsyncIterator, Callable
 from typing import Any
@@ -17,7 +18,9 @@ from claude_agent_sdk import (
     AssistantMessage,
     ResultMessage,
     TextBlock,
+    ToolResultBlock,
     ToolUseBlock,
+    UserMessage,
 )
 from claude_agent_sdk.types import CanUseTool, ToolPermissionContext
 
@@ -47,14 +50,76 @@ def _result(
     )
 
 
+def _tool_result(tool_use_id: str, content: Any, *, is_error: bool = False) -> UserMessage:
+    """A tool's answer, on the message the SDK actually delivers it on.
+
+    Tool results arrive on a ``UserMessage``, not on the assistant turn, which is
+    why forwarding them is a separate branch in translation. A fake that skips
+    this message leaves that branch unreachable offline.
+    """
+
+    return UserMessage(
+        content=[ToolResultBlock(tool_use_id=tool_use_id, content=content, is_error=is_error)]
+    )
+
+
 def default_turn() -> list[Any]:
-    """A representative successful turn: text, a side-effecting tool, then done."""
+    """A representative successful turn: text, a side-effecting tool, then done.
+
+    The tool answers in prose, because ``echo hi`` has nothing else to say. That
+    is the honest default and it is also the not-undoable path: no structured
+    reply means no prior state, so a recorded action reports that it cannot be
+    put back rather than claiming it can.
+    """
 
     return [
         _assistant(TextBlock(text="Looking into it")),
         _assistant(ToolUseBlock(id="t1", name="Bash", input={"command": "echo hi"})),
+        _tool_result("t1", "hi\n"),
         _assistant(TextBlock(text="all done"), usage={"input_tokens": 20, "output_tokens": 8}),
         _result(text="all done", usage={"input_tokens": 20, "output_tokens": 8}),
+    ]
+
+
+# The other half of a write connector's contract: a reply that reports what it
+# read and what it left, so an offline run can exercise a reversible action end
+# to end (ADR-0117). Selected by marker like the approval turn below, because the
+# default turn's honest answer is prose and both paths need to exist offline.
+REVERSIBLE_MARKER = "[fake:reversible-tool]"
+
+_REVERSIBLE_REPLY = {
+    "ok": True,
+    "summary": "scaled public/api from 3 to 10",
+    # What a restore puts back, and what it is checked against. Not
+    # interchangeable: comparing the live resource to ``prior`` would refuse
+    # every safe undo and permit the one that is not.
+    "prior": {"spec": {"replicas": 3}},
+    "post": {"spec": {"replicas": 10}},
+    "target": {"kind": "Deployment", "namespace": "public", "name": "api"},
+}
+
+
+def reversible_turn() -> list[Any]:
+    """A turn whose side-effecting call reports a state that can be restored."""
+
+    return [
+        _assistant(TextBlock(text="Scaling it")),
+        _assistant(
+            ToolUseBlock(
+                id="t1",
+                name="scale_deployment",
+                input={"namespace": "public", "name": "api", "replicas": 10},
+            )
+        ),
+        _tool_result("t1", json.dumps(_REVERSIBLE_REPLY)),
+        _assistant(
+            TextBlock(text="scaled public/api from 3 to 10"),
+            usage={"input_tokens": 20, "output_tokens": 8},
+        ),
+        _result(
+            text="scaled public/api from 3 to 10",
+            usage={"input_tokens": 20, "output_tokens": 8},
+        ),
     ]
 
 
@@ -144,6 +209,8 @@ class FakeModelSession:
         if match:
             summary = last[match.end() :].strip() or "unspecified request"
             return approval_turn(summary, route=match.group(1))
+        if REVERSIBLE_MARKER in last:
+            return reversible_turn()
         return default_turn()
 
     async def connect(self) -> None:

--- a/runner/tests/test_fake_tool_result.py
+++ b/runner/tests/test_fake_tool_result.py
@@ -1,0 +1,115 @@
+"""The fake model returns tool results, so the offline path can carry them.
+
+The fake is the mock at the adapter seam: everything above it runs unmodified.
+That is only true for the parts of the SDK's message stream it actually
+produces, and it produced no tool result at all -- so
+``translate.py::_translate_user``, the whole closing half of a side-effecting
+call, was unreachable in every offline run. It stopped being a cosmetic gap when
+the ACI began carrying a call's result (ADR-0117): the field an undo acts on
+arrives only on a tool result, and nothing offline could produce one.
+
+Two shapes, because a connector's reply has two honest outcomes and they take
+different paths through the platform: prose (nothing to restore) and a structured
+reply that reports what it read and what it left.
+"""
+
+from __future__ import annotations
+
+import json
+
+from aci_protocol import SideEffectFlag
+from claude_agent_sdk import ToolResultBlock, UserMessage
+from curie_runner import SideEffectClassifier
+from curie_runner.fake import (
+    REVERSIBLE_MARKER,
+    FakeModelSession,
+    default_turn,
+    reversible_turn,
+)
+from curie_runner.translate import TurnState, translate_message
+
+
+def _tool_results(script: list[object]) -> list[ToolResultBlock]:
+    return [
+        block
+        for message in script
+        if isinstance(message, UserMessage) and not isinstance(message.content, str)
+        for block in message.content
+        if isinstance(block, ToolResultBlock)
+    ]
+
+
+def _frames(script: list[object]) -> list[SideEffectFlag]:
+    state = TurnState()
+    frames: list[SideEffectFlag] = []
+    for message in script:
+        for event in translate_message(message, state, SideEffectClassifier(), None):
+            if isinstance(event, SideEffectFlag):
+                frames.append(event)
+    return frames
+
+
+def test_the_default_turn_answers_its_own_tool_call() -> None:
+    """A call with no result is a turn that died mid-call, not a normal one."""
+
+    results = _tool_results(default_turn())
+
+    assert [r.tool_use_id for r in results] == ["t1"]
+    assert results[0].is_error is False
+
+
+def test_the_default_turn_closes_its_side_effecting_call() -> None:
+    """Two frames, joined -- the shape a ledger records as one completed action."""
+
+    frames = _frames(default_turn())
+
+    assert len(frames) == 2
+    assert {f.call_id for f in frames} == {"t1"}
+    assert frames[0].arguments == {"command": "echo hi"}
+    # Bash answering in prose is the not-undoable path, and it is the honest
+    # default: `echo hi` has no prior state to report.
+    assert frames[1].result is None
+    assert frames[1].failed is False
+
+
+def test_the_reversible_turn_reports_what_it_read_and_what_it_left() -> None:
+    """The undoable path, offline: the reply carries prior, post and target."""
+
+    frames = _frames(reversible_turn())
+
+    assert len(frames) == 2
+    closing = frames[1]
+    assert closing.result is not None
+    assert closing.result["prior"] == {"spec": {"replicas": 3}}
+    assert closing.result["post"] == {"spec": {"replicas": 10}}
+    assert closing.result["target"]["name"] == "api"
+
+
+def test_the_marker_selects_the_reversible_turn() -> None:
+    """Selected the way the approval marker is, so one fake serves both paths."""
+
+    session = FakeModelSession()
+
+    async def _drive() -> list[object]:
+        await session.query(f"scale it {REVERSIBLE_MARKER}")
+        return [message async for message in session.receive_turn()]
+
+    import asyncio
+
+    script = asyncio.run(_drive())
+    results = _tool_results(script)
+    assert results, "the reversible turn must answer its own call"
+    assert json.loads(str(results[0].content))["ok"] is True
+
+
+def test_an_unmarked_query_still_gets_the_default_turn() -> None:
+    session = FakeModelSession()
+
+    async def _drive() -> list[object]:
+        await session.query("just do it")
+        return [message async for message in session.receive_turn()]
+
+    import asyncio
+
+    script = asyncio.run(_drive())
+    assert str(_tool_results(script)[0].content).strip() == "hi"


### PR DESCRIPTION
Closes #1880.

The fake is the mock at the adapter seam — everything above it runs unmodified. That is only true for the parts of the SDK's message stream it actually produces, and it produced **no tool result at all**. So `translate.py::_translate_user`, the whole closing half of a side-effecting call, was unreachable in every offline run.

Invisible while the side-effect frame carried a tool name and a constant string. Not invisible since #1869: the field an undo acts on arrives *only* on a tool result, and nothing offline could produce one. The e2e ladder inherits the hole — all three rungs drive the fake — which is how a real turn through a local stack left an action record stuck at `pending` while validating #1877. Correctly stuck: no result ever came back.

## Two shapes, because a connector's reply has two honest outcomes

**The default turn answers in prose**, because `echo hi` has nothing else to say. That's the not-undoable path: no structured reply means no prior state, so a recorded action reports it cannot be put back rather than claiming it can.

**`[fake:reversible-tool]` selects a connector-shaped reply** reporting what it read, what it left, and what it acted on — so the undoable path exists offline too. Marker-selected in the style of `[fake:request-approval]` rather than replacing the default, because both are real outcomes and a fake that only produced the interesting one would misrepresent which is common.

`prior` and `post` are deliberately **different values** in that fixture. They aren't interchangeable: comparing a live resource against `prior` would refuse every undo that's safe and permit exactly the one that isn't, and a fixture where they matched would let that bug through.

## Verification

```
runner              604 passed, 4 skipped
aci-protocol        178 passed
apps/worker         12 failures, all in the pre-existing set (diffed, no regressions)
ruff / mypy         clean
```

The interesting check is CI's e2e ladder: all three rungs drive this fake, so if an extra frame per side-effecting call disturbs anything downstream, they are what says so.
