### PR TITLE
Require of an undo what the forward action required

### DIFF
--- a/apps/api/alembic/versions/0031_action_gate_approval.py
+++ b/apps/api/alembic/versions/0031_action_gate_approval.py
@@ -1,0 +1,44 @@
+"""Which approval gated a recorded call, so an undo can require the same route.
+
+Revision ID: 0031
+Revises: 0030
+Create Date: 2026-08-25
+
+ADR-0117 decision 3: an undo requires the authorization the forward action
+required, and no more. Answering that needs to know whether the call was gated at
+all, and by which route -- which the approval row holds.
+
+Deliberately NOT a foreign key. This column is the record of what authorization
+the forward action required; an ON DELETE SET NULL would let the approval
+sweeper silently downgrade a gated action to an ungated one, which is a
+permission check quietly deleting itself. Stored as a bare id, so an approval
+that can no longer be read fails the undo closed instead.
+
+Nullable with no backfill: rows written before this, and calls that were never
+gated, both carry NULL, and NULL means ungated.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0031"
+down_revision: str | None = "0030"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+SCHEMA = "curie"
+
+
+def upgrade() -> None:
+    op.add_column(
+        "agent_actions",
+        sa.Column("gate_approval_id", postgresql.UUID(as_uuid=True), nullable=True),
+        schema=SCHEMA,
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("agent_actions", "gate_approval_id", schema=SCHEMA)

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -222,6 +222,18 @@
             ],
             "title": "Detail"
           },
+          "gate_approval_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Gate Approval Id"
+          },
           "id": {
             "format": "uuid",
             "title": "Id",
@@ -323,6 +335,7 @@
           "post_state",
           "target",
           "detail",
+          "gate_approval_id",
           "status",
           "dedupe_key",
           "created_at",
@@ -383,6 +396,18 @@
               }
             ],
             "title": "Detail"
+          },
+          "gate_approval_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Gate Approval Id"
           },
           "tool": {
             "title": "Tool",
@@ -4237,7 +4262,7 @@
     },
     "/actions/{action_id}/undo": {
       "post": {
-        "description": "Rule on putting back what this action changed.\n\nA 200 authorizes a restore and names the call that performs it; every other\noutcome is a refusal that changed nothing. The refusals are ordered from the\nrecord's own state outward to the world, so the most specific true reason is\nthe one the operator is told.\n\nWho may undo is not decided here yet. ADR-0117 decision 3 makes an undo\nrequire the authorization the forward action required and no more, which\nneeds the gating approval recorded on the action; that lands separately.\nUntil then this endpoint is authenticated like every other router and gated\nby the conflict rule alone.",
+        "description": "Rule on putting back what this action changed.\n\nA 200 authorizes a restore and names the call that performs it; every other\noutcome is a refusal that changed nothing. The refusals are ordered from the\nrecord's own state outward to the world, so the most specific true reason is\nthe one the operator is told.\n\nAuthorization runs first, before any of the record's own state is examined:\nwhether an actor may undo at all precedes whether this particular undo is\nsafe, and it keeps a refused actor from learning the resource's state through\na conflict message.",
         "operationId": "undo_action_actions__action_id__undo_post",
         "parameters": [
           {

--- a/apps/api/src/curie_api/crud.py
+++ b/apps/api/src/curie_api/crud.py
@@ -724,6 +724,7 @@ async def create_action(session: AsyncSession, data: ActionRecord) -> AgentActio
         tool=data.tool,
         arguments=data.arguments,
         detail=data.detail,
+        gate_approval_id=data.gate_approval_id,
         dedupe_key=data.dedupe_key,
         status=ActionStatus.pending,
     )

--- a/apps/api/src/curie_api/models.py
+++ b/apps/api/src/curie_api/models.py
@@ -573,6 +573,16 @@ class AgentAction(Base):
     # The frame's human-readable note. On a record that is not undoable this is
     # the stated reason the receipt shows instead of a control.
     detail: Mapped[str | None] = mapped_column(default=None)
+    # The approval that gated the call, when one did (ADR-0117 decision 3). NULL
+    # means the tool was not gated, and an undo is then not gated either.
+    #
+    # Deliberately NOT a foreign key. This is the record of what authorization
+    # the forward action required, and a sweeper deleting the approval row must
+    # not silently downgrade a gated action to an ungated one. An id whose
+    # approval can no longer be read fails closed at the undo instead.
+    gate_approval_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), default=None
+    )
     status: Mapped[str] = mapped_column(server_default=ActionStatus.pending, index=True)
     dedupe_key: Mapped[str] = mapped_column(unique=True)
     created_at: Mapped[datetime] = mapped_column(server_default=func.now())

--- a/apps/api/src/curie_api/routers/actions.py
+++ b/apps/api/src/curie_api/routers/actions.py
@@ -28,8 +28,8 @@ from sqlalchemy.exc import IntegrityError
 
 from .. import crud
 from ..auth import require_api_key
-from ..deps import SessionDep
-from ..models import ActionAuditEntry, ActionStatus, AgentAction
+from ..deps import ApproverSetSelectorDep, SessionDep
+from ..models import ActionAuditEntry, ActionStatus, AgentAction, Approval
 from ..schemas import (
     ActionAuditOut,
     ActionComplete,
@@ -128,6 +128,55 @@ async def get_action_audit(action_id: uuid.UUID, session: SessionDep) -> list[Ac
     return [ActionAuditOut.model_validate(e) for e in entries]
 
 
+# The authorizer name recorded when nothing gated the forward call. Not "none":
+# the audit row is read by a human asking who permitted a write into their
+# infrastructure, and "ungated" answers that question where a blank does not.
+UNGATED = "ungated"
+
+
+async def _authorize_undo(
+    session: SessionDep,
+    action: AgentAction,
+    data: ActionUndo,
+    approver_sets: ApproverSetSelectorDep,
+) -> tuple[str, bool, str]:
+    """Decide whether ``data.actor`` may undo ``action`` (ADR-0117 decision 3).
+
+    Symmetry, in both directions. A call nobody had to approve is not gated on
+    the way back: the state being restored is one the cluster was already in, and
+    it got there without anyone approving it. A call that WAS gated needs an
+    authorizer of that same route, resolved against membership the way ADR-0034
+    resolves an approver -- someone who could have permitted the change.
+
+    The self-approval refusal (#246) is deliberately not inherited. It stops a
+    requester approving their own REQUEST; an undo is not a request, so applying
+    it here would demand MORE authorization than the forward action needed, which
+    decision 3 rules out in the same sentence that requires the route.
+    """
+
+    if action.gate_approval_id is None:
+        return UNGATED, True, ""
+
+    approval = await session.get(Approval, action.gate_approval_id)
+    if approval is None:
+        # The gate is unreadable, not absent. Treating it as absent would let a
+        # deleted approval turn a gated action into a freely undoable one.
+        return UNGATED, False, "the approval that gated this action can no longer be read"
+
+    binding = await crud.get_approval_route_binding(session, approval)
+    approver_set = approver_sets(approval, binding)
+    verdict = await approver_set.contains(data.actor, data.actor_channel)
+    if verdict.undetermined:
+        # `member` is meaningless here. Failing open would let an outage at the
+        # membership provider authorize a write into a customer's cluster.
+        return (
+            approver_set.audit_name,
+            False,
+            verdict.reason or "could not establish whether the actor may undo this",
+        )
+    return approver_set.audit_name, verdict.member, verdict.reason
+
+
 async def _refuse(
     session: SessionDep,
     action: AgentAction,
@@ -136,6 +185,7 @@ async def _refuse(
     kind: str,
     reason: str,
     code: int,
+    authorizer: str = "conflict-check",
     evidence: dict[str, object] | None = None,
 ) -> None:
     """Record the refusal, then raise it.
@@ -151,7 +201,7 @@ async def _refuse(
             action=kind,
             actor=data.actor,
             actor_channel=data.actor_channel,
-            authorizer="conflict-check",
+            authorizer=authorizer,
             authorized=False,
             reason=reason,
             evidence=evidence,
@@ -163,7 +213,10 @@ async def _refuse(
 
 @router.post("/{action_id}/undo", response_model=ActionUndoOut)
 async def undo_action(
-    action_id: uuid.UUID, data: ActionUndo, session: SessionDep
+    action_id: uuid.UUID,
+    data: ActionUndo,
+    session: SessionDep,
+    approver_sets: ApproverSetSelectorDep,
 ) -> ActionUndoOut:
     """Rule on putting back what this action changed.
 
@@ -172,16 +225,27 @@ async def undo_action(
     record's own state outward to the world, so the most specific true reason is
     the one the operator is told.
 
-    Who may undo is not decided here yet. ADR-0117 decision 3 makes an undo
-    require the authorization the forward action required and no more, which
-    needs the gating approval recorded on the action; that lands separately.
-    Until then this endpoint is authenticated like every other router and gated
-    by the conflict rule alone.
+    Authorization runs first, before any of the record's own state is examined:
+    whether an actor may undo at all precedes whether this particular undo is
+    safe, and it keeps a refused actor from learning the resource's state through
+    a conflict message.
     """
 
     action = await crud.get_action(session, action_id)
     if action is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "action not found")
+
+    authorizer, allowed, reason = await _authorize_undo(session, action, data, approver_sets)
+    if not allowed:
+        await _refuse(
+            session,
+            action,
+            data,
+            kind="refused_unauthorized",
+            reason=reason or "not authorized to undo this action",
+            code=status.HTTP_403_FORBIDDEN,
+            authorizer=authorizer,
+        )
 
     if action.undone_at is not None:
         await _refuse(
@@ -262,7 +326,7 @@ async def undo_action(
             action="authorized",
             actor=data.actor,
             actor_channel=data.actor_channel,
-            authorizer="conflict-check",
+            authorizer=authorizer,
             authorized=True,
             evidence={"restoring": action.prior_state},
         )

--- a/apps/api/src/curie_api/schemas.py
+++ b/apps/api/src/curie_api/schemas.py
@@ -1241,6 +1241,9 @@ class ActionRecord(BaseModel):
     tool: str
     arguments: dict[str, Any] | None = None
     detail: str | None = None
+    # The approval that gated this call, when one did. The worker knows it
+    # because a gated call only executes on an approval-resume turn.
+    gate_approval_id: uuid.UUID | None = None
     dedupe_key: str
 
 
@@ -1275,6 +1278,7 @@ class ActionOut(BaseModel):
     post_state: dict[str, Any] | None
     target: dict[str, Any] | None
     detail: str | None
+    gate_approval_id: uuid.UUID | None
     status: str
     dedupe_key: str
     created_at: datetime

--- a/apps/api/tests/test_action_undo_authorization.py
+++ b/apps/api/tests/test_action_undo_authorization.py
@@ -1,0 +1,231 @@
+"""Who may undo (ADR-0117 decision 3), against real Postgres.
+
+"An undo requires the authorization the forward action required, and no more."
+
+Both halves of that sentence are load-bearing and this file tests both. An action
+whose tool was gated by an approval policy needs an authorizer of that same
+route, resolved against membership the way ADR-0034 resolves an approver. An
+action nobody had to approve is not gated on the way back either -- the state
+being restored is one the cluster was already in, and it got there without anyone
+approving it.
+
+What is deliberately NOT inherited is the self-approval refusal (#246). That rule
+stops a requester approving their own REQUEST. An undo is not a request: the
+actor is putting back a state that predates it, so requiring them not to be the
+turn's author would be MORE authorization than the forward action needed, which
+is the half of decision 3 that says "and no more".
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+import pytest
+from curie_api.approvers import MembershipVerdict
+from curie_api.deps import get_approver_sets
+from curie_api.main import create_app
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.usefixtures("clean_db")
+
+LEFT = {"spec": {"replicas": 10}}
+PRIOR = {"spec": {"replicas": 3}}
+TARGET = {"kind": "Deployment", "namespace": "public", "name": "api"}
+
+
+class _Set:
+    """An approver set that answers however the test says."""
+
+    def __init__(self, verdict: MembershipVerdict, name: str = "explicit-users") -> None:
+        self._verdict = verdict
+        self._name = name
+
+    @property
+    def audit_name(self) -> str:
+        return self._name
+
+    async def contains(self, actor: str, actor_channel: str | None) -> MembershipVerdict:
+        return self._verdict
+
+
+@pytest.fixture
+def gated_client(_disposable_db: Any, request: Any) -> Any:
+    """A client whose approver set is whatever the test parametrized."""
+
+    verdict = getattr(request, "param", MembershipVerdict(member=True))
+    app = create_app()
+    app.dependency_overrides[get_approver_sets] = lambda: (lambda approval, binding: _Set(verdict))
+    with TestClient(app) as client:
+        yield client
+
+
+def _seed_approval(client: Any, headers: Any) -> str:
+    """A real approval to gate against.
+
+    Not a made-up id: an unreadable gate is its own refusal path (see
+    ``test_a_deleted_gate_fails_closed``), so the member/non-member tests have to
+    exercise a gate that genuinely resolves.
+    """
+
+    created = client.post(
+        "/approvals",
+        json={
+            "conversation_id": f"th-{uuid.uuid4().hex[:8]}",
+            "author": "U-author",
+            "summary": "scale public/api to 10",
+            "reply_kind": "slack",
+            "reply_channel": "C1",
+            "reply_placeholder": "p-1",
+            "dedupe_key": uuid.uuid4().hex,
+        },
+        headers=headers,
+    )
+    assert created.status_code == 201, created.text
+    return str(created.json()["id"])
+
+
+def _gated_action(client: Any, headers: Any, approval_id: str | None) -> dict[str, Any]:
+    opened = client.post(
+        "/actions",
+        json={
+            "conversation_id": "C1",
+            "call_id": "toolu_01",
+            "tool": "scale_deployment",
+            "arguments": {"replicas": 10},
+            "gate_approval_id": approval_id,
+            "dedupe_key": f"event-{uuid.uuid4()}:toolu_01",
+        },
+        headers=headers,
+    ).json()
+    return dict(
+        client.post(
+            f"/actions/{opened['id']}/complete",
+            json={
+                "failed": False,
+                "result": {"ok": True},
+                "prior_state": PRIOR,
+                "post_state": LEFT,
+                "target": TARGET,
+            },
+            headers=headers,
+        ).json()
+    )
+
+
+def _undo(client: Any, headers: Any, action_id: str, actor: str = "U-operator") -> Any:
+    return client.post(
+        f"/actions/{action_id}/undo",
+        json={"actor": actor, "observed_state": LEFT},
+        headers=headers,
+    )
+
+
+def test_an_ungated_action_is_not_gated_on_the_way_back(
+    client: Any, auth_headers: Any
+) -> None:
+    """Nobody approved the change, so nobody has to approve putting it back."""
+
+    action = _gated_action(client, auth_headers, None)
+
+    response = _undo(client, auth_headers, action["id"])
+
+    assert response.status_code == 200
+    audit = client.get(f"/actions/{action['id']}/audit", headers=auth_headers).json()
+    assert audit[0]["authorizer"] == "ungated"
+    assert audit[0]["authorized"] is True
+
+
+@pytest.mark.parametrize("gated_client", [MembershipVerdict(member=True)], indirect=True)
+def test_a_member_of_the_gating_route_may_undo(
+    gated_client: Any, auth_headers: Any
+) -> None:
+    """Someone who could have permitted the change may put it back."""
+
+    action = _gated_action(gated_client, auth_headers, _seed_approval(gated_client, auth_headers))
+
+    response = _undo(gated_client, auth_headers, action["id"])
+
+    assert response.status_code == 200
+    audit = gated_client.get(f"/actions/{action['id']}/audit", headers=auth_headers).json()
+    assert audit[0]["authorizer"] == "explicit-users"
+
+
+@pytest.mark.parametrize(
+    "gated_client", [MembershipVerdict(member=False, reason="not in #sre")], indirect=True
+)
+def test_a_non_member_is_refused_with_the_set_s_own_reason(
+    gated_client: Any, auth_headers: Any
+) -> None:
+    """The set explains itself: only it knows whether it refused on a list or a group."""
+
+    action = _gated_action(gated_client, auth_headers, _seed_approval(gated_client, auth_headers))
+
+    response = _undo(gated_client, auth_headers, action["id"])
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "not in #sre"
+    entry = gated_client.get(f"/actions/{action['id']}/audit", headers=auth_headers).json()[0]
+    assert entry["action"] == "refused_unauthorized"
+    assert entry["authorized"] is False
+
+
+@pytest.mark.parametrize(
+    "gated_client",
+    [MembershipVerdict(member=True, undetermined=True, reason="Slack unreachable")],
+    indirect=True,
+)
+def test_an_undetermined_set_fails_closed(gated_client: Any, auth_headers: Any) -> None:
+    """`member` is meaningless when the set could not establish membership.
+
+    Failing open here would let a Slack outage authorize a write into a
+    customer's infrastructure.
+    """
+
+    action = _gated_action(gated_client, auth_headers, _seed_approval(gated_client, auth_headers))
+
+    assert _undo(gated_client, auth_headers, action["id"]).status_code == 403
+
+
+@pytest.mark.parametrize("gated_client", [MembershipVerdict(member=True)], indirect=True)
+def test_a_refused_authorization_leaves_the_record_untouched(
+    gated_client: Any, auth_headers: Any
+) -> None:
+    """Same invariant as the conflict rule: a refusal changes nothing."""
+
+    action = _gated_action(gated_client, auth_headers, _seed_approval(gated_client, auth_headers))
+    gated_client.app.dependency_overrides[get_approver_sets] = lambda: (
+        lambda approval, binding: _Set(MembershipVerdict(member=False, reason="no"))
+    )
+
+    _undo(gated_client, auth_headers, action["id"])
+
+    after = gated_client.get(f"/actions/{action['id']}", headers=auth_headers).json()
+    assert after["undone_at"] is None
+
+
+def test_the_gating_approval_is_recorded_from_the_worker(
+    client: Any, auth_headers: Any
+) -> None:
+    """The record carries which approval gated the call, or None when none did."""
+
+    approval_id = str(uuid.uuid4())
+
+    action = _gated_action(client, auth_headers, approval_id)
+
+    assert action["gate_approval_id"] == approval_id
+
+
+def test_a_gate_that_cannot_be_read_fails_closed(client: Any, auth_headers: Any) -> None:
+    """A deleted approval is an unreadable gate, not an absent one.
+
+    Reading it as absent would let the approval sweeper turn a gated action into
+    a freely undoable one -- a permission check quietly deleting itself.
+    """
+
+    action = _gated_action(client, auth_headers, str(uuid.uuid4()))
+
+    response = _undo(client, auth_headers, action["id"])
+
+    assert response.status_code == 403
+    assert "can no longer be read" in response.json()["detail"]

--- a/apps/api/tests/test_migration_0029_agent_actions.py
+++ b/apps/api/tests/test_migration_0029_agent_actions.py
@@ -54,6 +54,9 @@ BELOW = "0028"
 # The revision immediately below 0030, which adds ``post_state``.
 BELOW_0030 = "0029"
 
+# The revision immediately below 0031, which adds ``gate_approval_id``.
+BELOW_0031 = "0030"
+
 
 def _sql(statement: str, params: dict[str, Any] | None = None) -> list[Any]:
     async def _go() -> list[Any]:
@@ -169,3 +172,22 @@ def test_0030_round_trips_the_post_state_column(isolated_migration_db: None) -> 
 
     command.upgrade(cfg, "head")
     assert "post_state" in _columns("agent_actions")
+
+
+def test_0031_round_trips_the_gate_column(isolated_migration_db: None) -> None:
+    """The gate column undoes cleanly too.
+
+    Worth its own assertion rather than trusting the 0030 pattern: this column is
+    a permission input, and a downgrade that leaves it behind fails the
+    re-upgrade at exactly the moment an operator is rolling back.
+    """
+
+    cfg = _alembic_config()
+    command.upgrade(cfg, "head")
+    assert "gate_approval_id" in _columns("agent_actions")
+
+    command.downgrade(cfg, BELOW_0031)
+    assert "gate_approval_id" not in _columns("agent_actions")
+
+    command.upgrade(cfg, "head")
+    assert "gate_approval_id" in _columns("agent_actions")

--- a/apps/worker/src/curie_worker/actions.py
+++ b/apps/worker/src/curie_worker/actions.py
@@ -53,6 +53,7 @@ class ActionRecorder(Protocol):
         event_id: str,
         conversation_id: str,
         agent_id: str | None,
+        gate_approval_id: str | None = None,
     ) -> RecordedAction: ...
 
     async def complete(self, action_id: str, frame: SideEffectFlag) -> None: ...
@@ -106,6 +107,7 @@ class ActionClient:
         event_id: str,
         conversation_id: str,
         agent_id: str | None,
+        gate_approval_id: str | None = None,
     ) -> RecordedAction:
         """Open the record for a call that was just made.
 
@@ -121,6 +123,9 @@ class ActionClient:
             "tool": frame.tool or "unknown",
             "arguments": frame.arguments,
             "detail": frame.detail,
+            # What authorized the forward call, so an undo can require the same
+            # and no more (ADR-0117 decision 3). None means nothing gated it.
+            "gate_approval_id": gate_approval_id,
             "dedupe_key": f"{event_id}:{frame.call_id}",
         }
         payload = await self._post(self._url, body, "action record")

--- a/apps/worker/src/curie_worker/kernel.py
+++ b/apps/worker/src/curie_worker/kernel.py
@@ -2520,6 +2520,12 @@ class Kernel:
                 event_id=qevent.event_id,
                 conversation_id=qevent.conversation_id,
                 agent_id=str(agent_id) if agent_id is not None else None,
+                # A gated tool only ever executes on the resume turn its approval
+                # created, and that turn's event id IS the approval's key. So what
+                # authorized this call is already in hand -- the same string the
+                # card teardown reads -- and an ordinary turn yields None, which
+                # is exactly "nothing gated it".
+                gate_approval_id=_approval_id_from_resume_event(qevent.event_id),
             )
             acc.open_actions[frame.call_id] = recorded.id
             return

--- a/apps/worker/tests/kernel/test_action_ledger.py
+++ b/apps/worker/tests/kernel/test_action_ledger.py
@@ -48,6 +48,7 @@ class FakeRecorder:
         event_id: str,
         conversation_id: str,
         agent_id: str | None,
+        gate_approval_id: str | None = None,
     ) -> RecordedAction:
         if self.fail_on_record:
             raise ActionBackendError("ledger down")
@@ -57,6 +58,7 @@ class FakeRecorder:
                 "event_id": event_id,
                 "conversation_id": conversation_id,
                 "agent_id": agent_id,
+                "gate_approval_id": gate_approval_id,
             }
         )
         return RecordedAction(id=f"a{len(self.recorded)}", status="pending")
@@ -196,5 +198,42 @@ def test_a_ledger_that_refuses_the_write_fails_the_turn(make_harness) -> None:
             # exactly one attempt was made.
             assert await h.async_redis.exists(h.config.side_effect_key(event.event_id))
             assert h.runner.opened == ["scale it"]
+
+    asyncio.run(go())
+
+
+def test_a_call_that_ran_under_an_approval_records_which_one(make_harness) -> None:
+    """ADR-0117 decision 3 needs to know what authorized the forward call.
+
+    A gated tool only ever executes on the resume turn an approval created, and
+    that turn's event id is the approval's own deterministic key. So the gate is
+    already in the kernel's hand -- it is the same string ``_is_approval_resume``
+    reads for card teardown -- and recording it costs a lookup of nothing.
+    """
+
+    async def go() -> None:
+        recorder = FakeRecorder()
+        approval_id = "3f1b9c22-0000-4000-8000-000000000001"
+        async with make_harness(actions=recorder) as h:
+            h.runner.default_script = [*_call("toolu_01"), Final(text="done", status=DONE)]
+            await h.kernel.process_event(
+                _qevent("scale it", event_id=f"approval-{approval_id}-resolved")
+            )
+
+            assert recorder.recorded[0]["gate_approval_id"] == approval_id
+
+    asyncio.run(go())
+
+
+def test_an_ordinary_turn_records_no_gate(make_harness) -> None:
+    """NULL means ungated, so an ordinary turn must not invent one."""
+
+    async def go() -> None:
+        recorder = FakeRecorder()
+        async with make_harness(actions=recorder) as h:
+            h.runner.default_script = [*_call("toolu_01"), Final(text="done", status=DONE)]
+            await h.kernel.process_event(_qevent("scale it"))
+
+            assert recorder.recorded[0]["gate_approval_id"] is None
 
     asyncio.run(go())


### PR DESCRIPTION
Closes #1864. Completes ADR-0117's undo ruling — both refusal rules now hold.

> An undo requires the authorization the forward action required, **and no more.**

Both halves of that sentence are load-bearing.

## The gate was already in the kernel's hand

A gated tool only ever executes on the resume turn its approval created, and that turn's event id **is** the approval's deterministic key (`approval-<id>-resolved`) — the same string the card teardown already reads. So recording which approval authorized a call costs a parse of something the kernel is holding. An ordinary turn yields `None`, which is exactly "nothing gated it".

## Three ways this fails closed

| | |
| --- | --- |
| **`gate_approval_id` is not a foreign key** | It records what authorization the forward action required. `ON DELETE SET NULL` would let the approval sweeper silently downgrade a gated action to an ungated one — a permission check quietly deleting itself. |
| **An unreadable gate refuses** | A deleted approval is an unreadable gate, not an absent one. Own tested path. |
| **An undetermined verdict refuses** | `member` is meaningless when the set couldn't establish membership. Failing open would let an outage at the membership provider authorize a write into a customer's cluster. |

## What is deliberately not inherited

**The self-approval refusal (#246).** It stops a requester approving their own *request*. An undo is not a request — the actor is putting back a state that predates it — so applying it here would demand *more* authorization than the forward action needed, which decision 3 rules out in the same sentence that requires the route.

## Ordering

Authorization runs before any of the record's own state is examined. Whether an actor may undo at all precedes whether this particular undo is safe, and it keeps a refused actor from learning the resource's state through a conflict message.

## Verification

```
apps/api                  997 passed, 10 skipped
  undo authorization        8 passed  (real Postgres, real approver-set seam)
  undo conflict rule       10 passed
  0031 round-trip           1 passed
worker ledger + client     14 passed
ruff / mypy                clean
check-contracts/docs       clean; openapi regenerated
```

`test_cost_composes_metrics_for_the_agent` fails locally and on an untouched checkout alike — needs Langfuse, which `--minimal` skips.
