### PR TITLE
Tell the person who asked what the turn changed

### DIFF
--- a/apps/worker/src/curie_worker/actions.py
+++ b/apps/worker/src/curie_worker/actions.py
@@ -56,7 +56,7 @@ class ActionRecorder(Protocol):
         gate_approval_id: str | None = None,
     ) -> RecordedAction: ...
 
-    async def complete(self, action_id: str, frame: SideEffectFlag) -> None: ...
+    async def complete(self, action_id: str, frame: SideEffectFlag) -> dict[str, Any]: ...
 
 
 def _snapshot(
@@ -131,11 +131,17 @@ class ActionClient:
         payload = await self._post(self._url, body, "action record")
         return RecordedAction(id=str(payload["id"]), status=str(payload["status"]))
 
-    async def complete(self, action_id: str, frame: SideEffectFlag) -> None:
-        """Close the record with what came back."""
+    async def complete(self, action_id: str, frame: SideEffectFlag) -> dict[str, Any]:
+        """Close the record with what came back, and return the row as stored.
+
+        Returned rather than discarded because the receipt is rendered from what
+        the LEDGER holds, not from what the worker sent: ``undoable`` is derived
+        on the record, so reading it back is what keeps a receipt from claiming a
+        reversibility the row does not have.
+        """
 
         prior, post, target = _snapshot(frame)
-        await self._post(
+        return await self._post(
             f"{self._url}/{action_id}/complete",
             {
                 "failed": bool(frame.failed),

--- a/apps/worker/src/curie_worker/kernel.py
+++ b/apps/worker/src/curie_worker/kernel.py
@@ -90,6 +90,7 @@ from .config import WorkerConfig
 from .killswitch import KillSwitch
 from .markers import CompletionRecord, MalformedCompletionError, Markers
 from .publication_validation import validate_snapshot_against_base
+from .receipt import render_receipt
 from .reply_sink import ReplySink, TargetRoute
 from .runner_client import (
     RunnerClient,
@@ -396,9 +397,29 @@ class _StreamAccumulator:
     # than minting a second. A turn that calls the same tool twice is only
     # distinguishable here by the call id.
     open_actions: dict[str, str] = field(default_factory=dict)
+    # Completed ledger rows, in the order their calls closed -- the receipt
+    # (ADR-0117 decision 7). Read back from the ledger rather than assembled
+    # here, because ``undoable`` is derived on the record and a receipt built
+    # from what the worker SENT could claim a reversibility the row lacks.
+    receipt_rows: list[dict[str, Any]] = field(default_factory=list)
 
     def rendered(self) -> str:
         return self.final_text if self.final_text is not None else "".join(self.text_parts)
+
+    def rendered_with_receipt(self) -> str:
+        """The turn's answer, then what it did to the world.
+
+        Appended rather than replacing: the model's answer is what the person
+        asked for, and the receipt is the platform's own account beneath it. A
+        turn that changed nothing adds nothing, because most turns are reads and
+        a receipt on every one of them is noise.
+        """
+
+        text = self.rendered()
+        receipt = render_receipt(self.receipt_rows)
+        if receipt is None:
+            return text
+        return f"{text}\n\n{receipt}" if text else receipt
 
 
 class _ThrottledReply:
@@ -2588,11 +2609,13 @@ class Kernel:
             )
             acc.open_actions[frame.call_id] = recorded.id
             return
-        await self._actions.complete(opened, frame)
+        completed = await self._actions.complete(opened, frame)
+        if completed:
+            acc.receipt_rows.append(completed)
 
     async def _finish(self, acc: _StreamAccumulator, reply: _ThrottledReply) -> TurnOutcome:
         if acc.status in (SessionStatus.DONE, SessionStatus.IDLE_AWAITING_INPUT):
-            text = acc.rendered()
+            text = acc.rendered_with_receipt()
             await reply.finalize(text)
             return TurnOutcome(
                 terminal_ok=True,

--- a/apps/worker/src/curie_worker/receipt.py
+++ b/apps/worker/src/curie_worker/receipt.py
@@ -1,0 +1,81 @@
+"""What a turn tells the person who asked that it did to the world (ADR-0117).
+
+Curie already classified every tool absent from a read-only allowlist as
+side-effecting and recorded what each call did. This is the half that gets that
+back to a human: a turn that changed anything ends by listing each action and
+whether the platform can put it back.
+
+Channel-neutral, and appended to the turn's reply rather than posted as a card.
+A card carrying a working undo control needs an interaction type on the channel
+protocol AND something able to perform a restore, and neither belongs in a change
+that has nothing for the control to do -- a button that authorizes a restore
+which never runs is the platform telling a user an action was put back when it
+was not.
+
+The line still says which actions could be put back. That is the thing an
+operator is buying: not a bot that cannot make mistakes, but a platform that
+knows which mistakes it can take back.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# A connector's summary is not a size this platform controls, and a receipt is
+# read in a chat client beneath an answer someone actually asked for.
+_SUMMARY_MAX = 160
+
+_HEADER = "_What I changed:_"
+
+# Said when an action reported nothing at all. Deliberately distinct from a
+# connector's own sentence: an undeclared third-party tool and a tool that
+# explained itself are both not-undoable, and flattening them to one line would
+# hide which happened.
+_UNDECLARED = "cannot be undone: nothing reported a prior state"
+
+
+def _clamp(text: str) -> str:
+    text = " ".join(str(text).split())
+    return text if len(text) <= _SUMMARY_MAX else text[: _SUMMARY_MAX - 1].rstrip() + "…"
+
+
+def _described(action: dict[str, Any]) -> str:
+    """The connector's own summary, or the tool's name when it offered none."""
+
+    result = action.get("result")
+    summary = result.get("summary") if isinstance(result, dict) else None
+    if isinstance(summary, str) and summary.strip():
+        return _clamp(summary)
+    return f"called `{action.get('tool') or 'a tool'}`"
+
+
+def _verdict(action: dict[str, Any]) -> str:
+    if action.get("status") == "failed":
+        # "It may have happened" is the state a human most needs told: the call
+        # reported failure, and a failed write is not the same as no write.
+        return "failed — check before retrying"
+    if action.get("undoable"):
+        return "can be undone"
+    detail = action.get("detail")
+    if isinstance(detail, str) and detail.strip():
+        return _clamp(detail)
+    return _UNDECLARED
+
+
+def render_receipt(actions: list[dict[str, Any]]) -> str | None:
+    """One line per action, or None when the turn changed nothing.
+
+    Most turns are reads, and a receipt on every one of them is noise. This
+    returns None rather than an empty section so the caller has nothing to
+    decide.
+
+    Both kinds of line are here on purpose. A receipt listing only the undoable
+    actions would hide the ones that matter most: the value of showing
+    "restarting pods cannot be undone" beside "scaled 3 to 10, can be undone" is
+    that an operator sees the system knows the difference.
+    """
+
+    if not actions:
+        return None
+    lines = [f"• {_described(action)} — {_verdict(action)}" for action in actions]
+    return "\n".join([_HEADER, *lines])

--- a/apps/worker/tests/kernel/test_action_ledger.py
+++ b/apps/worker/tests/kernel/test_action_ledger.py
@@ -63,8 +63,15 @@ class FakeRecorder:
         )
         return RecordedAction(id=f"a{len(self.recorded)}", status="pending")
 
-    async def complete(self, action_id: str, frame: SideEffectFlag) -> None:
+    async def complete(self, action_id: str, frame: SideEffectFlag) -> dict[str, Any]:
         self.completed.append((action_id, frame))
+        return {
+            "tool": frame.tool,
+            "result": frame.result,
+            "detail": frame.detail,
+            "status": "failed" if frame.failed else "succeeded",
+            "undoable": bool(frame.result and frame.result.get("prior")),
+        }
 
 
 def _call(call_id: str, tool: str = "scale_deployment") -> list[SideEffectFlag]:
@@ -235,5 +242,63 @@ def test_an_ordinary_turn_records_no_gate(make_harness) -> None:
             await h.kernel.process_event(_qevent("scale it"))
 
             assert recorder.recorded[0]["gate_approval_id"] is None
+
+    asyncio.run(go())
+
+
+def test_a_turn_that_changed_the_world_says_so_in_its_reply(make_harness) -> None:
+    """ADR-0117 decision 7: the person who asked gets an account of what happened.
+
+    Before this, the platform's entire account of an agent changing production
+    was prose the model wrote about itself.
+    """
+
+    async def go() -> None:
+        recorder = FakeRecorder()
+        async with make_harness(actions=recorder) as h:
+            h.runner.default_script = [*_call("toolu_01"), Final(text="done", status=DONE)]
+            await h.kernel.process_event(_qevent("scale it"))
+
+            assert h.sink.last_text is not None
+            assert "What I changed" in h.sink.last_text
+            assert "can be undone" in h.sink.last_text
+            # The model's own answer is still the answer; the receipt is added to
+            # it rather than replacing it.
+            assert h.sink.last_text.startswith("done")
+
+    asyncio.run(go())
+
+
+def test_a_read_only_turn_gets_no_receipt(make_harness) -> None:
+    """Most turns are reads, and a receipt on every one of them is noise."""
+
+    async def go() -> None:
+        recorder = FakeRecorder()
+        async with make_harness(actions=recorder) as h:
+            h.runner.default_script = [Final(text="nothing to do", status=DONE)]
+            await h.kernel.process_event(_qevent("how are things"))
+
+            assert h.sink.last_text == "nothing to do"
+
+    asyncio.run(go())
+
+
+def test_a_call_that_never_came_back_is_not_on_the_receipt(make_harness) -> None:
+    """An open record is an attempt, not an account of what changed.
+
+    Its result never arrived, so there is nothing truthful to say about what it
+    did; the row stands in the ledger and a human reads it there.
+    """
+
+    async def go() -> None:
+        recorder = FakeRecorder()
+        async with make_harness(actions=recorder) as h:
+            h.runner.default_script = [
+                _call("toolu_01")[0],
+                Final(text="done", status=DONE),
+            ]
+            await h.kernel.process_event(_qevent("scale it"))
+
+            assert h.sink.last_text == "done"
 
     asyncio.run(go())

--- a/apps/worker/tests/test_receipt.py
+++ b/apps/worker/tests/test_receipt.py
@@ -1,0 +1,121 @@
+"""What a turn tells you it did to the world (ADR-0117 decision 7).
+
+A turn that changed anything ends with a receipt listing each action, each
+carrying either an undo control or the stated reason it has none.
+
+The control is not here, and its absence is deliberate rather than unfinished.
+Nothing in the platform can reach a connector yet, so a button would authorize a
+restore that never runs -- the platform telling a user an action was put back
+when it was not, which is the failure ADR-0117 exists to prevent. The line still
+says which actions COULD be put back, because that is the thing an operator is
+actually buying: not a bot that cannot make mistakes, but a platform that knows
+which mistakes it can take back.
+
+Channel-neutral on purpose. A Slack card carrying a working undo control needs an
+interaction type on the channel protocol, and that belongs in the change that has
+something for the control to do.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from curie_worker.receipt import render_receipt
+
+
+def _action(**overrides: Any) -> dict[str, Any]:
+    row: dict[str, Any] = {
+        "tool": "scale_deployment",
+        "result": {"summary": "scaled public/api from 3 to 10"},
+        "undoable": True,
+        "detail": "non-idempotent tool completed",
+        "status": "succeeded",
+    }
+    row.update(overrides)
+    return row
+
+
+def test_a_turn_that_changed_nothing_has_no_receipt() -> None:
+    """Most turns are reads. A receipt on every one of them is noise."""
+
+    assert render_receipt([]) is None
+
+
+def test_an_undoable_action_says_it_can_be_put_back() -> None:
+    receipt = render_receipt([_action()])
+
+    assert receipt is not None
+    assert "scaled public/api from 3 to 10" in receipt
+    assert "can be undone" in receipt
+
+
+def test_an_irreversible_action_states_its_own_reason() -> None:
+    """The connector's sentence, not a generic one.
+
+    "restarting pods cannot be undone" is the connector explaining itself; a
+    platform-authored "not undoable" would be the platform guessing on its
+    behalf.
+    """
+
+    receipt = render_receipt(
+        [_action(undoable=False, detail="restarting pods cannot be undone", result=None)]
+    )
+
+    assert receipt is not None
+    assert "restarting pods cannot be undone" in receipt
+
+
+def test_an_action_that_explained_nothing_still_appears() -> None:
+    """An undeclared third-party tool is not the same as one that explained itself.
+
+    Both are not-undoable, and flattening them to one sentence would hide which
+    happened. An action nobody can describe is still an action that happened.
+    """
+
+    receipt = render_receipt([_action(undoable=False, detail=None, result=None)])
+
+    assert receipt is not None
+    assert "scale_deployment" in receipt
+    assert "nothing reported a prior state" in receipt
+
+
+def test_both_kinds_appear_together() -> None:
+    """The honest half sells as well as the undoable half.
+
+    A receipt listing only the reversible actions would hide the ones that matter
+    most.
+    """
+
+    receipt = render_receipt(
+        [
+            _action(),
+            _action(
+                tool="restart_deployment",
+                undoable=False,
+                detail="restarting pods cannot be undone",
+                result=None,
+            ),
+        ]
+    )
+
+    assert receipt is not None
+    assert "can be undone" in receipt
+    assert "restarting pods cannot be undone" in receipt
+
+
+def test_a_failed_call_is_reported_as_maybe_rather_than_done() -> None:
+    """"It may have happened" is the state a human most needs told."""
+
+    receipt = render_receipt([_action(status="failed", undoable=False, result=None)])
+
+    assert receipt is not None
+    assert "failed" in receipt.lower()
+
+
+def test_a_long_summary_is_clamped() -> None:
+    """A connector's summary is not a size the platform controls."""
+
+    receipt = render_receipt([_action(result={"summary": "x" * 5000})])
+
+    assert receipt is not None
+    assert len(receipt) < 1000


### PR DESCRIPTION
Closes #1866. ADR-0117 decision 7.

Before this, the platform's entire account of an agent changing production was prose the model wrote about itself. The ledger fixed what is *recorded*; nothing carried it back to the person who asked.

A turn that changed anything now ends with a line per action — the connector's own summary, and either that it can be put back or the reason it cannot.

```
done

_What I changed:_
• scaled public/api from 3 to 10 — can be undone
• restarted public/api — restarting pods cannot be undone
```

Both kinds are there on purpose. A receipt listing only the reversible actions would hide the ones that matter most: the value of those two lines together is that an operator sees the system knows the difference.

## Why there is no undo button

**Deliberately absent, not unfinished.** Nothing in the platform can reach a connector yet (#1867), so a button would authorize a restore that never runs — the platform telling someone an action was put back when it was not, which is the failure this whole design exists to prevent. A Slack card carrying a working control also needs an interaction type on `channel_protocol`, and that belongs in the change that has something for the control to *do*.

What the line can honestly say today is which actions **could** be put back, and that's most of the value: not a bot that cannot make mistakes, but a platform that knows which mistakes it can take back.

So the receipt is channel-neutral and appended to the reply. The model's answer is what the person asked for; the receipt is the platform's own account beneath it.

## Rendered from the ledger, not from the worker's own send

`undoable` is derived on the record, so reading the row back is what stops a receipt claiming a reversibility the record doesn't have. That's why `complete()` now returns the stored row instead of discarding it.

## Three distinctions the lines keep rather than flatten

| | |
| --- | --- |
| explained vs. silent | a connector saying "restarting pods cannot be undone" is not an undeclared third-party tool. Both are not-undoable; the receipt says which |
| failed vs. done | a failed call reads "failed — check before retrying". *It may have happened* is the state a human most needs told |
| never returned | a call whose result never came back is not on the receipt at all — its record stands in the ledger as an honest account of an attempt, but there's nothing truthful to say about what it did |

A turn that changed nothing adds nothing. Most turns are reads, and a receipt on every one is noise — the ADR's own warning about this surface being verbose.

## Verification

```
receipt renderer        7 passed
kernel ledger tests    11 passed
apps/worker            29 failures before my change, the same 29 after
                       (clean-tree baseline at this commit, diffed — no regressions;
                        they are pre-existing on next, largely binding/test_resolver)
mypy                   clean, 211 source files
check-docs             clean
```
