### PR TITLE
Renumber the ledger migrations off a collision on next

### DIFF
--- a/apps/api/alembic/versions/0032_action_post_state.py
+++ b/apps/api/alembic/versions/0032_action_post_state.py
@@ -1,8 +1,14 @@
 """What an action left behind, so a restore can tell whether the world moved.
 
-Revision ID: 0030
-Revises: 0029
+Revision ID: 0032
+Revises: 0031
 Create Date: 2026-08-25
+
+Renumbered from 0030 after the fact. `0030` and `0031` were taken concurrently by
+the multi-surface work (#1803), which was written before this chain existed and
+merged between its two parts, so both branches were individually correct and the
+tree was not. See the renumbering commit for why this chain moved rather than
+that one.
 
 ADR-0117 decision 4 refuses a restore when the resource no longer looks like what
 the action left. Nothing recorded that: 0029 holds ``prior_state`` (where the
@@ -24,8 +30,8 @@ import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql
 
-revision: str = "0030"
-down_revision: str | None = "0029"
+revision: str = "0032"
+down_revision: str | None = "0031"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/apps/api/alembic/versions/0033_action_gate_approval.py
+++ b/apps/api/alembic/versions/0033_action_gate_approval.py
@@ -1,8 +1,10 @@
 """Which approval gated a recorded call, so an undo can require the same route.
 
-Revision ID: 0031
-Revises: 0030
+Revision ID: 0033
+Revises: 0032
 Create Date: 2026-08-25
+
+Renumbered from 0031 with its sibling; see 0032_action_post_state.py.
 
 ADR-0117 decision 3: an undo requires the authorization the forward action
 required, and no more. Answering that needs to know whether the call was gated at
@@ -24,8 +26,8 @@ import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql
 
-revision: str = "0031"
-down_revision: str | None = "0030"
+revision: str = "0033"
+down_revision: str | None = "0032"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/apps/api/tests/test_migration_0029_agent_actions.py
+++ b/apps/api/tests/test_migration_0029_agent_actions.py
@@ -51,11 +51,11 @@ ALEMBIC_DIR = Path(__file__).resolve().parents[1] / "alembic"
 # this file would go green while proving nothing (#1391).
 BELOW = "0028"
 
-# The revision immediately below 0030, which adds ``post_state``.
-BELOW_0030 = "0029"
+# The revision immediately below 0032, which adds ``post_state``.
+BELOW_0032 = "0031"
 
-# The revision immediately below 0031, which adds ``gate_approval_id``.
-BELOW_0031 = "0030"
+# The revision immediately below 0033, which adds ``gate_approval_id``.
+BELOW_0033 = "0032"
 
 
 def _sql(statement: str, params: dict[str, Any] | None = None) -> list[Any]:
@@ -155,7 +155,7 @@ def test_audit_rows_die_with_the_action_they_audit(isolated_migration_db: None) 
     assert _sql("SELECT 1 FROM curie.action_audit_entries") == []
 
 
-def test_0030_round_trips_the_post_state_column(isolated_migration_db: None) -> None:
+def test_0032_round_trips_the_post_state_column(isolated_migration_db: None) -> None:
     """A column-add has to undo cleanly too.
 
     A downgrade that leaves the column behind passes a shape check on the way
@@ -167,14 +167,14 @@ def test_0030_round_trips_the_post_state_column(isolated_migration_db: None) -> 
     command.upgrade(cfg, "head")
     assert "post_state" in _columns("agent_actions")
 
-    command.downgrade(cfg, BELOW_0030)
+    command.downgrade(cfg, BELOW_0032)
     assert "post_state" not in _columns("agent_actions")
 
     command.upgrade(cfg, "head")
     assert "post_state" in _columns("agent_actions")
 
 
-def test_0031_round_trips_the_gate_column(isolated_migration_db: None) -> None:
+def test_0033_round_trips_the_gate_column(isolated_migration_db: None) -> None:
     """The gate column undoes cleanly too.
 
     Worth its own assertion rather than trusting the 0030 pattern: this column is
@@ -186,7 +186,7 @@ def test_0031_round_trips_the_gate_column(isolated_migration_db: None) -> None:
     command.upgrade(cfg, "head")
     assert "gate_approval_id" in _columns("agent_actions")
 
-    command.downgrade(cfg, BELOW_0031)
+    command.downgrade(cfg, BELOW_0033)
     assert "gate_approval_id" not in _columns("agent_actions")
 
     command.upgrade(cfg, "head")


### PR DESCRIPTION
**`next` cannot migrate right now.** Two files declare `revision = "0030"` and two declare `"0031"`. Alembic refuses a duplicate revision id outright, so this is not a filename-tidiness problem — it is a database that cannot reach head.

```
0030: 0030_action_post_state.py, 0030_agent_channels_multi_binding.py
0031: 0031_action_gate_approval.py, 0031_agent_memory_and_state_binding_scope.py
```

## Nobody did anything wrong

The multi-surface work (#1803) was written before the action-ledger chain existed and took the next free numbers at the time. Merge order interleaved them: ledger #1881 took 0030 and merged first, #1803 merged second, ledger #1883 took 0031 and merged third. Git saw four unrelated new files and merged them clean.

It's the ADR-number hazard #521 already gates for, in a directory where the consequence is worse: two ADRs sharing a number make a citation ambiguous; two migrations sharing a revision id make an install impossible.

## The gate exists and could not have caught it

`scripts/check-alembic-revisions.py` runs per PR, and neither branch ever contained the other's file — so both went green and the tree they merged into did not. **A gate that only ever sees one side of a collision cannot see a collision.** Worth a follow-up: this check belongs on the merge result, not only on the branch.

## Why the ledger chain moves

Both chains are equally "correct". This one moves because renumbering it is a two-file rename plus two test constants, while the other pair is referenced from binding and memory tests across two apps. Cost, not merit — had it been the other way round, the other should have moved.

```
0029 → 0030_agent_channels_multi_binding → 0031_agent_memory_and_state_binding_scope
     → 0032_action_post_state → 0033_action_gate_approval
```

No database can have been stamped at the old ids, because none could migrate past the duplicate in the first place.

## Verification

```
check-alembic-revisions.py   passed with head 0033
migration tests              12 passed (round-trips both renumbered revisions
                             against real Postgres, plus the v0.6.x reconcile)
apps/api                     1040 passed, 10 skipped
ruff                         clean
```

Also unblocks #1884 and #1885, which fail this gate purely by inheriting `next`'s broken state.
