### PR TITLE
Name the colliding files when two migrations share a revision id

### DIFF
--- a/apps/api/tests/test_alembic_revision_gate.py
+++ b/apps/api/tests/test_alembic_revision_gate.py
@@ -143,6 +143,33 @@ def test_multi_letter_suffixed_revision_filename_is_rejected(tmp_path: Path) -> 
     assert "0001ab_bad.py" in result.stderr
 
 
+def test_duplicate_revision_ids_fail_and_name_the_colliding_files(
+    tmp_path: Path,
+) -> None:
+    _write_revision(tmp_path, "0001_base.py", "base", None)
+    _write_revision(tmp_path, "0002_first.py", "collision", "base")
+    _write_revision(tmp_path, "0003_second.py", "collision", "base")
+
+    result = _run_gate(tmp_path)
+
+    assert result.returncode == 1, result.stderr
+    assert "duplicate revision id" in result.stderr.lower()
+    assert "collision" in result.stderr
+    assert "0002_first.py" in result.stderr
+    assert "0003_second.py" in result.stderr
+
+
+def test_duplicate_revision_ids_fail_before_graph_validation(tmp_path: Path) -> None:
+    _write_revision(tmp_path, "0001_base.py", "base", None)
+    _write_revision(tmp_path, "0002_first.py", "collision", "base")
+    _write_revision(tmp_path, "0003_second.py", "collision", "base")
+
+    result = _run_gate(tmp_path)
+
+    assert result.returncode == 1, result.stderr
+    assert "expected exactly one alembic head" not in result.stderr.lower()
+
+
 def test_unique_numbered_sibling_revisions_fail_with_both_heads(tmp_path: Path) -> None:
     _write_revision(tmp_path, "0001_base.py", "base", None)
     _write_revision(tmp_path, "0002_left.py", "left_branch", "base")

--- a/scripts/check-alembic-revisions.py
+++ b/scripts/check-alembic-revisions.py
@@ -1,4 +1,5 @@
 import argparse
+import ast
 import re
 import sys
 from collections import defaultdict
@@ -10,6 +11,35 @@ FILENAME_PATTERN = re.compile(r"^(\d+[a-z]?)_.+\.py$")
 DEFAULT_SCRIPT_LOCATION = (
     Path(__file__).resolve().parents[1] / "apps" / "api" / "alembic"
 )
+
+
+def _revision_id(path: Path) -> str | None:
+    """Return a migration's module-level ``revision`` value.
+
+    Reads the value statically so a duplicate is reported without importing
+    (and therefore executing) the migration module. Returns None when the value
+    is absent or not a literal string; the graph load below reports those.
+    """
+    try:
+        module = ast.parse(path.read_text(encoding="utf-8"))
+    except (OSError, SyntaxError, ValueError):
+        return None
+    for node in module.body:
+        if isinstance(node, ast.AnnAssign):
+            targets: list[ast.expr] = [node.target]
+        elif isinstance(node, ast.Assign):
+            targets = list(node.targets)
+        else:
+            continue
+        if not any(
+            isinstance(target, ast.Name) and target.id == "revision"
+            for target in targets
+        ):
+            continue
+        value = node.value
+        if isinstance(value, ast.Constant) and isinstance(value.value, str):
+            return value.value
+    return None
 
 
 def main() -> int:
@@ -98,6 +128,36 @@ def main() -> int:
             )
         print(
             "Rename migrations so every leading revision token is unique.",
+            file=sys.stderr,
+        )
+        return 1
+
+    filenames_by_revision: dict[str, list[str]] = defaultdict(list)
+    for filenames in filenames_by_token.values():
+        for filename in filenames:
+            revision_id = _revision_id(versions / filename)
+            if revision_id is not None:
+                filenames_by_revision[revision_id].append(filename)
+
+    duplicate_revisions = {
+        revision_id: sorted(filenames)
+        for revision_id, filenames in filenames_by_revision.items()
+        if len(filenames) > 1
+    }
+    if duplicate_revisions:
+        print(
+            "Alembic revision gate failed: duplicate revision ids found:",
+            file=sys.stderr,
+        )
+        for revision_id in sorted(duplicate_revisions):
+            print(
+                f"  {revision_id}: "
+                f"{', '.join(duplicate_revisions[revision_id])}",
+                file=sys.stderr,
+            )
+        print(
+            "Give every migration a unique revision id, then repoint the "
+            "down_revision of whatever followed it.",
             file=sys.stderr,
         )
         return 1


### PR DESCRIPTION
## Why

The Alembic gate already refused a forked graph, but only through its head
count. A duplicate `revision` id therefore reported itself as:

```
Alembic revision gate failed: expected exactly one Alembic head, found 3: 0030, 0031, 0031
Create a merge revision so the migration tree has one head.
```

A head list with a repeated entry, naming neither the duplicated id nor the
files that hold it — and the suggested remedy (a merge revision) is the wrong
fix for a duplicate id. Alembic itself downgrades the collision to a
`UserWarning` and keeps building the map, so nothing upstream names it either.

This came out of the fork that recently blocked every PR based on the feature
branch: two migrations claimed `0030` and two claimed `0031`. The gate's message
named only the filename collision, so the second collision at `0031` was
invisible until someone read the files. The graph itself is already repaired;
this is the gate hardening that would have named it directly.

Follow-up to #1627, which introduced the gate.

## What

- Check that every migration's `revision` value is unique, between the existing
  filename-token check and the graph load, so the collision is reported before
  the head count turns it into a confusing head list.
- Read the value with `ast` rather than a regex or an import. `0029_agent_actions.py`
  has a docstring whose line 10 begins with the word `revision`, which a naive
  pattern would pick up; and a gate has no business executing migration modules
  to read a constant.
- Report every colliding id together with the files that share it.

On the same broken tree, the gate now says:

```
Alembic revision gate failed: duplicate revision ids found:
  0030: 0030_agent_channels_multi_binding.py, 0032_action_post_state.py
  0031: 0031_agent_memory_and_state_binding_scope.py, 0033_action_gate_approval.py
Give every migration a unique revision id, then repoint the down_revision of whatever followed it.
```

## Testing

Two tests added to `apps/api/tests/test_alembic_revision_gate.py`, both written
first and watched fail against the old gate (they failed on the old
`found 2: collision, collision` message):

- `test_duplicate_revision_ids_fail_and_name_the_colliding_files`
- `test_duplicate_revision_ids_fail_before_graph_validation`

Verified:

- `uv run pytest -q apps/api/tests/test_alembic_revision_gate.py` — 15 passed
  (13 pre-existing plus the 2 new).
- `uv run ruff check .` — clean; `uv run mypy` — clean, 190 files.
- Gate still passes on this branch's tree (head `0027`) and on the feature
  branch's tree (head `0033`), including the `0029` docstring case.