### PR TITLE
Stop an unrelated log line deciding a throttling test

### DIFF
--- a/apps/api/tests/test_commitpoller.py
+++ b/apps/api/tests/test_commitpoller.py
@@ -682,13 +682,31 @@ def test_sustained_throttling_is_reported_above_a_per_branch_warning(monkeypatch
 
     tip = GitHubBranchTip(Settings(), Creds())
     with caplog.at_level(logging.WARNING, logger="curie_api.commitpoller"):
+        # The noise that actually broke this test in CI, kept as a fixture. It
+        # is what makes the assertion below a claim about THIS logger rather
+        # than about whatever happened to log first.
+        logging.getLogger("asyncio").error(
+            "Future exception was never retrieved: ConnectionError"
+        )
         for _ in range(3):
             with pytest.raises(RateLimited):
                 tip.sha_for(REPO, "dev")
 
-    errors = [r for r in caplog.records if r.levelno >= logging.ERROR]
+    # Filtered by logger and searched rather than indexed. `caplog.at_level`
+    # raises the level for ONE logger but `caplog.records` holds everything the
+    # root handler captured, so an unrelated ERROR from elsewhere in the process
+    # lands in this list too -- asyncio's "Future exception was never retrieved"
+    # is the one that actually did it, and `errors[0]` then decides the outcome
+    # of a test about GitHub throttling.
+    errors = [
+        r
+        for r in caplog.records
+        if r.levelno >= logging.ERROR and r.name == "curie_api.commitpoller"
+    ]
     assert errors, "sustained throttling must escalate above a per-branch warning"
-    assert "NOT happening" in errors[0].getMessage()
+    assert any("NOT happening" in r.getMessage() for r in errors), [
+        r.getMessage() for r in errors
+    ]
 
 
 def test_a_throttled_repository_does_not_stop_the_others(monkeypatch) -> None:


### PR DESCRIPTION
`test_sustained_throttling_is_reported_above_a_per_branch_warning` failed on a **docs-only PR** (#1893), which is the tell — it does not depend on the change under test.

## Two layers

`caplog.at_level(..., logger="curie_api.commitpoller")` raises the level for **one** logger, but `caplog.records` holds everything the root handler captured. So an ERROR logged anywhere else in the process lands in the list too. Then `errors[0]` assumes the first one is ours.

In CI it was asyncio's `Future exception was never retrieved: ConnectionError('unexpected connection_lost() call')` — so a test about GitHub throttling failed on a dropped socket.

```
assert 'NOT happening' in errors[0].getMessage()
E  assert 'NOT happening' in 'Future exception was never retrieved: ConnectionError'
```

**The expected message was present the whole time.** It just was not at index zero — the ERROR line is right there in the CI log, one line below the assertion failure.

## The fix

Filter by logger name, search instead of index, and print what was found on failure so the next person sees the mismatch rather than an assertion about a string they did not write.

**The noise that broke it is kept in the test as a fixture.** That is what makes the assertion a claim about *this* logger rather than about whatever happened to log first. Verified both ways: with the noise present and the fix reverted it fails (reproduced the CI failure exactly); with the fix it passes.

```
apps/api/tests/test_commitpoller.py   40 passed
same file, fix reverted                1 failed  <- the CI failure, deterministically
ruff                                   clean
```

Test-only. No product code.