### PR TITLE
Let a stored binding serialize without re-passing the write rule

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -647,7 +647,7 @@
           },
           "channels": {
             "items": {
-              "$ref": "#/components/schemas/ChannelBinding"
+              "$ref": "#/components/schemas/ChannelBindingOut"
             },
             "title": "Channels",
             "type": "array"
@@ -1530,9 +1530,9 @@
         "title": "BundleOut",
         "type": "object"
       },
-      "ChannelBinding": {
+      "ChannelBindingOut": {
         "additionalProperties": false,
-        "description": "Where one agent listens: a channel KIND and an ADDRESS (ADR-0096, #1459).\n\nAn agent holds ONE OR MORE of these (ADR-0118, #1525, amending ADR-0089's\nsingular clause). `AgentCreate` still carries one `channel` OBJECT -- the\nfirst binding, required, since an agent with none cannot receive a turn --\n`AgentOut` carries the `channels` LIST, and every write after the create\ngoes through the `/agents/{id}/channels` subresource. `AgentUpdate` carries\nno binding key at all.\n\n`kind` names the adapter that owns the binding, selects the address-shape\ncheck, AND routes: since ADR-0096 phase 2 the worker resolves on the\n`(kind, address)` PAIR, so the two together are the routing key the worker\nmatches on equality (a Slack channel id for `kind=\"slack\"`). One address can\ntherefore be bound twice under two different kinds.",
+        "description": "The READ side of a binding: the stored pair, serialized as it is stored.\n\nDeliberately NOT a subclass of `ChannelBinding`, and that is the whole point.\n`ChannelBinding` carries the address-shape rule three write paths inherit\n(`ChannelBindingWrite`, `ChannelTokenRequest`, `TurnIn`), and it used to be\nthe element type of `AgentOut.channels` as well -- so the rule that guards a\nBIND also ran when an existing row was READ, and one row it rejected failed\nthe whole response for every agent in it (#1914).\n\nAn install reaches that state by upgrading: migration 0021 backfills\n`agent_channels.address` from `agents.slack_channel` verbatim, and that column\nis exactly where a literal `#name` from before the validator lived. So an\ninstall that was merely mis-routed became one whose agent list was\nunavailable, reporting a Pydantic error instead of the bad value.\n\nSerializing a stored row must not re-litigate whether it should have been\nstored. Showing the bad address is also the more useful outcome: an operator\ncannot fix a value the API refuses to tell them.\n\nThe shape stays `{kind, address}`, identical to what `ChannelBinding`\nserialized, so this is not a wire change -- `ChannelBindingWrite`'s docstring\nalready describes that as the read contract.",
         "properties": {
           "address": {
             "title": "Address",
@@ -1547,7 +1547,7 @@
           "kind",
           "address"
         ],
-        "title": "ChannelBinding",
+        "title": "ChannelBindingOut",
         "type": "object"
       },
       "ChannelBindingPatch": {

--- a/apps/api/src/curie_api/schemas.py
+++ b/apps/api/src/curie_api/schemas.py
@@ -676,6 +676,37 @@ class ChannelBinding(BaseModel):
         return self
 
 
+class ChannelBindingOut(BaseModel):
+    """The READ side of a binding: the stored pair, serialized as it is stored.
+
+    Deliberately NOT a subclass of `ChannelBinding`, and that is the whole point.
+    `ChannelBinding` carries the address-shape rule three write paths inherit
+    (`ChannelBindingWrite`, `ChannelTokenRequest`, `TurnIn`), and it used to be
+    the element type of `AgentOut.channels` as well -- so the rule that guards a
+    BIND also ran when an existing row was READ, and one row it rejected failed
+    the whole response for every agent in it (#1914).
+
+    An install reaches that state by upgrading: migration 0021 backfills
+    `agent_channels.address` from `agents.slack_channel` verbatim, and that column
+    is exactly where a literal `#name` from before the validator lived. So an
+    install that was merely mis-routed became one whose agent list was
+    unavailable, reporting a Pydantic error instead of the bad value.
+
+    Serializing a stored row must not re-litigate whether it should have been
+    stored. Showing the bad address is also the more useful outcome: an operator
+    cannot fix a value the API refuses to tell them.
+
+    The shape stays `{kind, address}`, identical to what `ChannelBinding`
+    serialized, so this is not a wire change -- `ChannelBindingWrite`'s docstring
+    already describes that as the read contract.
+    """
+
+    model_config = ConfigDict(extra="forbid", from_attributes=True)
+
+    kind: str
+    address: str
+
+
 class ChannelBindingWrite(ChannelBinding):
     """The WRITE side of a binding: the public pair plus its reply ROUTE.
 
@@ -886,7 +917,7 @@ class AgentOut(BaseModel):
     # has no `created_at` and an unordered list makes two identical GETs differ
     # -- which re-renders the console's rows on every poll. The LOADING strategy
     # lives on the relationship too (`models.Agent.channels`, lazy="selectin").
-    channels: list[ChannelBinding]
+    channels: list[ChannelBindingOut]
     repo_full_name: str | None
     behavior_packs: dict[str, Any] | None
     model: str | None

--- a/apps/api/tests/test_agent_read_tolerates_legacy_bindings.py
+++ b/apps/api/tests/test_agent_read_tolerates_legacy_bindings.py
@@ -1,0 +1,150 @@
+"""Serializing a stored binding must not re-litigate whether it should exist.
+
+`ChannelBinding` carries the address-shape rule that #143 established, and it is
+the base class three write paths inherit it from. It was also the element type of
+`AgentOut.channels`, so the rule ran again every time an existing row was READ --
+and a row the rule rejects made the whole listing fail, for every agent, not just
+the one holding it.
+
+There is a production path to such a row and it is an upgrade: migration 0021
+backfills `agent_channels.address` from `agents.slack_channel` verbatim, and that
+column is exactly where a literal `#name` from before the validator lived. So an
+install that was merely mis-routed became an install whose agent list is
+unavailable, reporting a Pydantic error rather than the bad value.
+
+Reads now use a model with no shape rule. Writes keep it -- that is the other
+half, and it is asserted here too, because a fix that made reads tolerant by
+making writes tolerant would re-open #143.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from typing import Any
+
+import pytest
+from curie_api.config import get_settings
+from sqlalchemy import text as sql_text
+from sqlalchemy.ext.asyncio import create_async_engine
+
+pytestmark = pytest.mark.usefixtures("clean_db")
+
+# What #143 stored: the channel NAME, which the worker never routes on.
+LEGACY_ADDRESS = "#sre-alerts"
+
+# The allowlisted placeholder form. This repo is public and `.gitleaks.toml` has
+# its own `slack-conversation-id` rule, because a real channel id committed as a
+# test fixture is a permanent disclosure that cannot be rotated away. Any other
+# id-shaped string fails that gate -- which it did, on the first push.
+
+
+def _seed_legacy_binding(client: Any, headers: Any, name: str) -> str:
+    """An agent whose binding predates the address rule, written past the API.
+
+    Raw SQL on purpose: the point is a row the current write path would refuse,
+    which is what an upgraded install holds and what no API call can create.
+    """
+
+    created = client.post(
+        "/agents",
+        json={"name": name, "channel": {"kind": "slack", "address": "C0EXAMPLE7"}},
+        headers=headers,
+    )
+    assert created.status_code == 201, created.text
+    agent_id = str(created.json()["id"])
+
+    async def _write() -> None:
+        # Fresh engine per query, following test_agents.py's `_binding_row`:
+        # keeps the write off the TestClient's portal loop.
+        engine = create_async_engine(get_settings().database_url)
+        try:
+            async with engine.begin() as conn:
+                await conn.execute(
+                    sql_text(
+                        "UPDATE curie.agent_channels SET address = :addr "
+                        "WHERE agent_id = :aid"
+                    ),
+                    {"addr": LEGACY_ADDRESS, "aid": agent_id},
+                )
+        finally:
+            await engine.dispose()
+
+    asyncio.run(_write())
+    return agent_id
+
+
+def test_a_legacy_binding_serializes_instead_of_failing(
+    client: Any, auth_headers: Any
+) -> None:
+    """The bad value is shown, not hidden behind a 500.
+
+    Showing it is the more useful outcome: an operator cannot fix an address the
+    API refuses to tell them.
+    """
+
+    agent_id = _seed_legacy_binding(client, auth_headers, f"legacy-{uuid.uuid4().hex[:8]}")
+
+    response = client.get(f"/agents/{agent_id}", headers=auth_headers)
+
+    assert response.status_code == 200, response.text
+    assert response.json()["channels"] == [{"kind": "slack", "address": LEGACY_ADDRESS}]
+
+
+def test_one_bad_row_does_not_take_the_listing_down(client: Any, auth_headers: Any) -> None:
+    """The failure this fixes: a neighbour's row hid every other agent."""
+
+    _seed_legacy_binding(client, auth_headers, f"legacy-{uuid.uuid4().hex[:8]}")
+    healthy = f"healthy-{uuid.uuid4().hex[:8]}"
+    client.post(
+        "/agents",
+        json={"name": healthy, "channel": {"kind": "slack", "address": "C0EXAMPLE8"}},
+        headers=auth_headers,
+    )
+
+    listed = client.get("/agents", headers=auth_headers)
+
+    assert listed.status_code == 200, listed.text
+    assert healthy in [a["name"] for a in listed.json()]
+
+
+def test_binding_a_bad_address_is_still_refused(client: Any, auth_headers: Any) -> None:
+    """The other half. Tolerant reads must not become tolerant writes (#143)."""
+
+    response = client.post(
+        "/agents",
+        json={
+            "name": f"reject-{uuid.uuid4().hex[:8]}",
+            "channel": {"kind": "slack", "address": LEGACY_ADDRESS},
+        },
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 422
+    assert "is not a Slack channel ID" in response.text
+
+
+def test_rebinding_to_a_bad_address_is_still_refused(client: Any, auth_headers: Any) -> None:
+    """The binding endpoints inherit the same rule and must keep it.
+
+    `PATCH /agents/{id}/channels` is where an address is rebound -- `AgentUpdate`
+    deliberately refuses a `channels` field -- and it takes the write model, so
+    tolerant reads must not reach it.
+    """
+
+    name = f"rebind-{uuid.uuid4().hex[:8]}"
+    created = client.post(
+        "/agents",
+        json={"name": name, "channel": {"kind": "slack", "address": "C0EXAMPLE9"}},
+        headers=auth_headers,
+    )
+    agent_id = created.json()["id"]
+
+    response = client.patch(
+        f"/agents/{agent_id}/channels",
+        json={"kind": "slack", "address": LEGACY_ADDRESS},
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 422
+    assert "is not a Slack channel ID" in response.text

--- a/cli/api-mirrors.json
+++ b/cli/api-mirrors.json
@@ -28,7 +28,7 @@
     },
     {
       "struct": "ChannelBinding",
-      "schema": "ChannelBinding",
+      "schema": "ChannelBindingOut",
       "omissions": []
     },
     {

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -69,6 +69,11 @@ pub struct ConnectorManifests {
 /// ingress (`"slack"` today) and `address` is the kind-specific identifier the
 /// worker resolver matches turns against. An agent holds one or more, so the
 /// pair -- never the address alone -- identifies a binding.
+///
+/// Mirrors the API's `ChannelBindingOut`, which is the READ shape and carries no
+/// address-shape rule (#1914): an upgraded install can hold an address the write
+/// path would now refuse, and the CLI has to be able to PRINT that value rather
+/// than fail to parse the agent it belongs to.
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct ChannelBinding {
     pub kind: String,


### PR DESCRIPTION
Closes #1914.

One `agent_channels` row holding an address the current rule rejects made `GET /agents` fail for **every** agent. Nineteen agents, one bad neighbour, and the whole listing answered 500 with a Pydantic error rather than a value.

## Why a write rule ran on reads

`ChannelBinding` carries the address-shape rule from #143, and **three write paths inherit it** — `ChannelBindingWrite`, `ChannelTokenRequest`, `TurnIn`. It was *also* the element type of `AgentOut.channels`, so the rule that guards a bind ran again every time an existing row was serialized.

The file was already alert to this class of mistake: `ChannelBindingWrite` was split out precisely so write-only fields would not *"422 valid reads and leak a write rule into a read contract"*. The address **shape** rule stayed on the shared model, and it's the one that leaked.

## There is a production path, and it is an upgrade

`0021_agent_channels.py` backfills with no validation:

```sql
INSERT INTO curie.agent_channels (id, agent_id, kind, address)
SELECT gen_random_uuid(), id, 'slack', slack_channel FROM curie.agents
```

`agents.slack_channel` is exactly where a literal `#name` from before the validator lived — the value #143 describes as *reporting success and never routing*. So an install that was merely **mis-routed** before the upgrade became an install whose agent list is **entirely unavailable** after it.

## The fix

Reads get their own model. `ChannelBindingOut` is **deliberately not a subclass** — inheriting from `ChannelBinding` is what caused this.

Writes keep the rule untouched, and that half is tested too: a fix that made reads tolerant by making writes tolerant would re-open #143.

| test | asserts |
| --- | --- |
| `test_a_legacy_binding_serializes_instead_of_failing` | the bad value is **shown**, not hidden behind a 500 |
| `test_one_bad_row_does_not_take_the_listing_down` | a neighbour's row no longer hides other agents |
| `test_binding_a_bad_address_is_still_refused` | create still 422s (#143 intact) |
| `test_rebinding_to_a_bad_address_is_still_refused` | `PATCH /agents/{id}/channels` still 422s |

Showing the bad address is also the better outcome — an operator cannot fix a value the API refuses to tell them.

## Not a wire change

The shape stays `{kind, address}`, exactly what `ChannelBinding` serialized, so no generated client sees a different response. Only the component *name* moved — which the **CLI field-parity gate caught**, working as designed. `api-mirrors.json` now names `ChannelBindingOut`, and the Rust mirror documents why it deserializes the read shape.

## Verification

```
apps/api                        1056 passed, 10 skipped
  the four above                   4 passed  (real Postgres, legacy row written past the API)
cli field-parity / emit-parity   clean
cli api_deploy                  16 passed
ruff / mypy                     clean (229 source files)
check-contracts / check-docs    clean; openapi regenerated
```

Two pre-existing failures, both confirmed identical on a clean `next` checkout: `test_cost_composes_metrics_for_the_agent` (needs Langfuse) and `chart_check_passes_on_the_unmodified_chart`.
