### PR TITLE
Run the local stack on the checkout it was started from

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@ stay the *implementation*; it just isn't the interface.
 - Building the runner image → `curie build` (not a copy-pasted `docker build -f runner/Dockerfile ...`).
 - First-run dev bootstrap → `curie install` (or `./get-curie.sh` from a source checkout, which also puts `curie` on PATH the first time by building it).
 - Refresh the on-PATH CLI after a code change → `curie update` (rebuilds and `cargo install`s the CLI to `~/.cargo/bin`; `--image` also rebuilds the runner). The per-change loop, so you never re-run the bootstrap script.
+- Run the local stack on YOUR checkout → `curie local up --build`. `curie update` covers the CLI and the runner image; the stack's api, worker, dispatcher and ui otherwise come from the registry, so a source-built CLI ends up talking to whatever was last published. That skew does not announce itself — it surfaces as a serde error about a field name, or a missing Python module from inside a container (#1915).
 - Contributor/CI scripts (contract codegen, chart render-asserts, the e2e round-trip) → `curie dev <...>`. The `dev` namespace fences off commands that need a **source checkout + dev toolchains**; they error clearly when run from a released binary.
 - Operator/product commands stay top-level: `init`, `build`, `skill`, `local`, `cluster`.
 

--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -705,6 +705,18 @@ export const commandManifest = {
               "long": "env-file",
               "positional": false,
               "required": false
+            },
+            {
+              "global": false,
+              "help": "Build the stack's images from THIS checkout instead of pulling the published ones, and run them (#1915)",
+              "id": "build",
+              "long": "build",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
             }
           ],
           "hidden": false,

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -702,6 +702,18 @@
               "long": "env-file",
               "positional": false,
               "required": false
+            },
+            {
+              "global": false,
+              "help": "Build the stack's images from THIS checkout instead of pulling the published ones, and run them (#1915)",
+              "id": "build",
+              "long": "build",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
             }
           ],
           "hidden": false,

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -1266,7 +1266,11 @@ fn on_path(bin: &str) -> bool {
 
 /// Walk up from the current directory to the repo root: the nearest ancestor
 /// that contains `runner/Dockerfile`.
-fn find_repo_root() -> Option<PathBuf> {
+///
+/// `pub(crate)` for `local::build_source_images` (#1915), which builds the dev
+/// stack's images from the same root and wants the same "are we in a checkout"
+/// answer rather than a second walk with its own anchor file.
+pub(crate) fn find_repo_root() -> Option<PathBuf> {
     let mut dir = std::env::current_dir().ok()?;
     loop {
         if dir.join("runner/Dockerfile").is_file() {

--- a/cli/src/comms.rs
+++ b/cli/src/comms.rs
@@ -795,6 +795,7 @@ mod tests {
                 slack: false,
                 model_mode: mode,
                 env_file: None,
+                build: false,
             })
             .env;
             let connect_env = local_connect_commands(&local_comms_opts(false, mode))[0]
@@ -831,6 +832,7 @@ mod tests {
                 slack: false,
                 model_mode: mode,
                 env_file: None,
+                build: false,
             })
             .env;
             let disconnect_env = local_disconnect_commands(&local_comms_opts(true, mode))[1]
@@ -865,6 +867,7 @@ mod tests {
                 slack: false,
                 model_mode: ModelMode::DefaultFake,
                 env_file: None,
+                build: false,
             })
             .env;
             let connect_env = local_connect_commands(&local_comms_opts_with(
@@ -903,6 +906,7 @@ mod tests {
                 slack: false,
                 model_mode: ModelMode::DefaultFake,
                 env_file: None,
+                build: false,
             })
             .env;
             let disconnect_env = local_disconnect_commands(&local_comms_opts_with(

--- a/cli/src/local.rs
+++ b/cli/src/local.rs
@@ -404,6 +404,15 @@ fn compose_model_env(o: &LocalOpts, model: Option<&str>) -> Vec<(String, String)
     // that were pinned to `latest` were changed to read it.
     if o.build {
         env.push(("CURIE_BASE_TAG".into(), SOURCE_IMAGE_TAG.into()));
+        // Named outright rather than derived from the tag above. The runner is
+        // spawned by the worker rather than being a compose service, and it is
+        // tagged on its own axis -- CI sets CURIE_BASE_TAG for the platform
+        // images while building a plain `curie-runner`, so borrowing the base tag
+        // sent the worker after an image nothing had built.
+        env.push((
+            "CURIE_RUNNER_IMAGE".into(),
+            format!("ghcr.io/curie-eng/curie-runner:{SOURCE_IMAGE_TAG}"),
+        ));
     }
     env
 }
@@ -2021,11 +2030,12 @@ mod tests {
         )
         .expect("compose file");
 
-        // Two forms carry the override, and missing the second is how this test
-        // first went wrong: an `image:` line that interpolates the variable, and
-        // the worker overlay, which takes it as a build ARG and puts it in its
-        // own `FROM`. Both are scanned, so a service added in either style has
-        // to appear in the build set.
+        // Three forms carry an override, and missing one is how this test went
+        // wrong twice: an `image:` line interpolating CURIE_BASE_TAG, the worker
+        // overlay taking it as a build ARG for its own `FROM`, and the runner,
+        // which is not a compose service at all -- the worker spawns it from
+        // CURIE_RUNNER_IMAGE, on its own axis. All three are scanned, so an
+        // image the stack can be pointed at cannot escape the build set.
         let overlay = std::fs::read_to_string(
             std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
                 .parent()
@@ -2037,7 +2047,9 @@ mod tests {
         let mut overridable = std::collections::BTreeSet::new();
         for line in compose.lines().chain(overlay.lines()) {
             let line = line.trim();
-            let interpolates = line.contains("${CURIE_BASE_TAG") || line.contains("${BASE_TAG");
+            let interpolates = line.contains("${CURIE_BASE_TAG")
+                || line.contains("${BASE_TAG")
+                || line.contains("${CURIE_RUNNER_IMAGE");
             if !interpolates {
                 continue;
             }
@@ -2059,5 +2071,38 @@ mod tests {
             overridable, buildable,
             "compose can override these images but --build does not build them all"
         );
+    }
+
+    /// Regression, caught by CI rather than by reasoning: the runner is a
+    /// SEPARATE axis from the published platform images, and coupling it to
+    /// CURIE_BASE_TAG broke the e2e ladder.
+    ///
+    /// CI sets `CURIE_BASE_TAG=ci-local` for the platform images and builds its
+    /// runner as a plain `curie-runner`, so making CURIE_RUNNER_IMAGE read that
+    /// variable sent the worker looking for `curie-runner:ci-local`, which
+    /// nothing had built. `--build` names the runner image outright instead.
+    #[test]
+    fn build_names_the_runner_image_without_borrowing_the_base_tag() {
+        let mut o = opts(DEFAULT_COMPOSE_FILE);
+        o.build = true;
+
+        let display = up_command(&o).display();
+
+        assert!(
+            display.contains(&format!(
+                "CURIE_RUNNER_IMAGE=ghcr.io/curie-eng/curie-runner:{SOURCE_IMAGE_TAG}"
+            )),
+            "got: {display}"
+        );
+    }
+
+    /// The other half: without `--build`, the runner variable is untouched, so a
+    /// caller that sets CURIE_BASE_TAG for the platform images (CI does) keeps
+    /// whatever runner it built.
+    #[test]
+    fn without_build_the_runner_image_is_left_alone() {
+        let display = up_command(&opts(DEFAULT_COMPOSE_FILE)).display();
+
+        assert!(!display.contains("CURIE_RUNNER_IMAGE"), "got: {display}");
     }
 }

--- a/cli/src/local.rs
+++ b/cli/src/local.rs
@@ -239,6 +239,74 @@ pub struct LocalOpts {
     /// Without it, `up` refuses rather than fetching ~11.4 GB implicitly. Only
     /// `up` consumes it; the other verbs set `false`.
     pub pull_model: bool,
+    /// Build the stack's images from THIS checkout instead of pulling the
+    /// published ones (#1915). Only `up` consumes it.
+    ///
+    /// Without it a contributor gets a source-built CLI talking to whatever the
+    /// registry last published, and the gap shows up as a serde error about a
+    /// field name or a missing Python module inside a container.
+    pub build: bool,
+}
+
+/// The tag `--build` writes and runs. Fixed rather than content-derived: the
+/// flag means "build now", so a stale `dev` is an explicit choice rather than a
+/// silent one, and a fixed name keeps `docker images` readable.
+pub const SOURCE_IMAGE_TAG: &str = "dev";
+
+/// One published image the dev stack can run, and where its source lives.
+pub struct SourceImage {
+    /// The ghcr repository name, matching `compose.dev.yaml`.
+    pub image: &'static str,
+    /// Dockerfile path, relative to the repo root.
+    pub dockerfile: &'static str,
+}
+
+/// The images `--build` builds for this invocation, in dependency-ish order.
+///
+/// Skips only what nothing can reach: a `--minimal` run starts no UI, and
+/// building one is minutes of pnpm for a container that never starts.
+///
+/// The dispatcher is built ALWAYS, including without `--slack`, and that is not
+/// symmetry for its own sake. The compose profile governs the long-running
+/// dispatcher service, but `curie local message` runs a ONE-SHOT container from
+/// the same image on every invocation (`message.rs`'s
+/// `curie_dispatcher.enqueue_once`), outside any profile. Keying the build set on
+/// profiles alone left the main dev-loop verb still failing with
+/// `No module named curie_dispatcher.enqueue_once` -- observed, not theorised.
+///
+/// `curie-api` covers `curie-migrate` too: same image, and it is what applies
+/// the migrations, which is how a stale one leaves the database behind the tree.
+pub fn source_images(o: &LocalOpts) -> Vec<SourceImage> {
+    let mut images = vec![
+        SourceImage {
+            image: "curie-api",
+            dockerfile: "apps/api/Dockerfile",
+        },
+        SourceImage {
+            image: "curie-worker",
+            dockerfile: "apps/worker/Dockerfile",
+        },
+        SourceImage {
+            image: "curie-dispatcher",
+            dockerfile: "apps/dispatcher/Dockerfile",
+        },
+        // The one that decides whether the AGENT runs this checkout. The worker
+        // spawns it per turn from CURIE_RUNNER_IMAGE, so leaving it out rebuilt
+        // the platform and left the sandbox on the registry's runner -- which is
+        // how a turn kept producing the OLD fake model's frames while every
+        // other service was current.
+        SourceImage {
+            image: "curie-runner",
+            dockerfile: "runner/Dockerfile",
+        },
+    ];
+    if !o.minimal {
+        images.push(SourceImage {
+            image: "curie-ui",
+            dockerfile: "apps/ui/Dockerfile",
+        });
+    }
+    images
 }
 
 pub struct LocalDownOpts {
@@ -330,6 +398,13 @@ fn compose_model_env(o: &LocalOpts, model: Option<&str>) -> Vec<(String, String)
     // above, not inside it, because the `--local-model` arm does not fall
     // through to the else: `--minimal --local-model` needs suppressing too.
     env.extend(otel_endpoint_env_override(o.minimal));
+    // #1915: point every published image at what `--build` just built. Set here
+    // rather than in `up` so `--dry-run` shows it, and so the one variable drives
+    // api, migrate, worker, ui and dispatcher uniformly -- which is why the two
+    // that were pinned to `latest` were changed to read it.
+    if o.build {
+        env.push(("CURIE_BASE_TAG".into(), SOURCE_IMAGE_TAG.into()));
+    }
     env
 }
 
@@ -342,6 +417,14 @@ fn up_command_with_model(o: &LocalOpts, model: Option<&str>) -> OpsCommand {
         plain("-d"),
         plain("--wait"),
     ]);
+    // #1915: `curie-worker` is a compose-built OVERLAY over the published base.
+    // Rebuilding the base is not enough -- without this, compose reuses the
+    // overlay it baked over the PREVIOUS base, so the stack runs yesterday's
+    // worker on today's base and nothing says so until a turn behaves like old
+    // code. Only under `--build`: a plain `up` must stay a fast restart.
+    if o.build {
+        args.push(plain("--build"));
+    }
     let mut cmd = OpsCommand::new("docker", args);
     let env = compose_model_env(o, model);
     if !env.is_empty() {
@@ -533,6 +616,49 @@ pub fn apply_credential_plan(
     Ok(resolved)
 }
 
+/// Build every image this run needs from THIS checkout, tagged [`SOURCE_IMAGE_TAG`].
+///
+/// The gap this closes: `curie update` refreshes the CLI and the runner image,
+/// and nothing refreshed api, worker, ui or dispatcher -- so a contributor on a
+/// feature branch ran a source-built CLI against whatever the registry last
+/// published. The failures do not look like version skew: a serde error about a
+/// missing field, or `No module named` from inside a container.
+async fn build_source_images(o: &LocalOpts) -> Result<()> {
+    let ui = crate::ui::ui();
+    let root = crate::commands::find_repo_root().context(
+        "not inside a curie source checkout. `--build` builds the stack's images from \
+         source; a release binary runs the published images and has nothing to build.",
+    )?;
+    let images = source_images(o);
+    ui.note(&format!(
+        "building {} image(s) from {} as :{SOURCE_IMAGE_TAG}",
+        images.len(),
+        root.display()
+    ));
+    for image in &images {
+        let tag = format!("ghcr.io/curie-eng/{}:{SOURCE_IMAGE_TAG}", image.image);
+        ui.note(&format!(
+            "=== docker build -f {} -t {tag} . ===",
+            image.dockerfile
+        ));
+        // Inherit stdio so the build log streams, matching `curie build`.
+        let status = tokio::process::Command::new("docker")
+            .args(["build", "-f", image.dockerfile, "-t", &tag, "."])
+            .current_dir(&root)
+            .status()
+            .await
+            .context("failed to invoke docker")?;
+        if !status.success() {
+            bail!("docker build failed for {} ({status})", image.image);
+        }
+    }
+    ui.success(&format!(
+        "built {} image(s) as :{SOURCE_IMAGE_TAG}; the stack below runs them",
+        images.len()
+    ));
+    Ok(())
+}
+
 pub async fn up(mut o: LocalOpts, model: Option<String>) -> Result<LocalUpOutput> {
     let ui = crate::ui::ui();
     // #749/ADR-0070: an opt-in bundle `.env` is the LOWEST-priority model
@@ -548,6 +674,11 @@ pub async fn up(mut o: LocalOpts, model: Option<String>) -> Result<LocalUpOutput
         }));
     }
     require_on_path("docker")?;
+    // #1915: build before compose starts anything, so a failed build never
+    // leaves a half-source stack running. Streams its log like `curie build`.
+    if o.build {
+        build_source_images(&o).await?;
+    }
     // ADR 0093: `--local-model` never downloads its ~11.4 GB of assets
     // implicitly. Refuse before anything is brought up, unless the operator
     // asked for the fetch on this invocation.
@@ -895,6 +1026,7 @@ mod tests {
             slack: false,
             model_mode: ModelMode::DefaultFake,
             env_file: None,
+            build: false,
         }
     }
 
@@ -908,6 +1040,7 @@ mod tests {
             slack: false,
             model_mode: ModelMode::DefaultFake,
             env_file: None,
+            build: false,
         }
     }
 
@@ -1772,5 +1905,159 @@ mod tests {
         assert!(!dispatcher.contains("profiles: *full_profiles"));
         assert!(dispatcher.contains("      VALKEY_HOST: valkey"));
         assert!(dispatcher.contains("      SLACK_APP_TOKEN: ${SLACK_APP_TOKEN:-}"));
+    }
+
+    /// Regression: rebuilding the BASE images is not enough. `curie-worker` is a
+    /// compose-built overlay over the published base, and without `--build` on
+    /// the compose child, compose reuses the overlay it baked over the PREVIOUS
+    /// base -- so a stack reported as source-built ran yesterday's worker on
+    /// today's base, and a real turn recorded no `post_state` because the code
+    /// that extracts it was in the layer that never got rebuilt.
+    #[test]
+    fn build_rebuilds_the_compose_overlays_too() {
+        let mut o = opts(DEFAULT_COMPOSE_FILE);
+        o.build = true;
+
+        let display = up_command(&o).display();
+
+        assert!(
+            display.contains(" up -d --build") || display.contains(" --build"),
+            "expected compose to rebuild its overlays, got: {display}"
+        );
+    }
+
+    /// #1915: `--build` has to reach the compose child as the tag override, or
+    /// the images it just built are not the images the stack runs.
+    #[test]
+    fn build_pins_every_published_image_to_the_locally_built_tag() {
+        let mut o = opts(DEFAULT_COMPOSE_FILE);
+        o.build = true;
+
+        let display = up_command(&o).display();
+
+        assert!(
+            display.contains(&format!("CURIE_BASE_TAG={SOURCE_IMAGE_TAG}")),
+            "expected the source tag in the compose env, got: {display}"
+        );
+    }
+
+    /// Without the flag nothing is pinned: a plain `local up` keeps pulling the
+    /// published images, which is what a non-contributor wants.
+    #[test]
+    fn without_build_the_tag_is_left_to_compose() {
+        let display = up_command(&opts(DEFAULT_COMPOSE_FILE)).display();
+
+        assert!(!display.contains("CURIE_BASE_TAG"), "got: {display}");
+    }
+
+    /// `--minimal` starts no UI, so building one is minutes of pnpm for a
+    /// container that never starts.
+    #[test]
+    fn minimal_skips_the_ui_it_never_starts() {
+        let mut minimal = opts(DEFAULT_COMPOSE_FILE);
+        minimal.minimal = true;
+        minimal.build = true;
+
+        let names: Vec<&str> = source_images(&minimal).iter().map(|i| i.image).collect();
+
+        assert_eq!(
+            names,
+            vec![
+                "curie-api",
+                "curie-worker",
+                "curie-dispatcher",
+                "curie-runner"
+            ]
+        );
+        let mut full = opts(DEFAULT_COMPOSE_FILE);
+        full.build = true;
+        let full_names: Vec<&str> = source_images(&full).iter().map(|i| i.image).collect();
+        assert!(full_names.contains(&"curie-ui"));
+    }
+
+    /// Regression: the runner was the image left out, and it is the one that
+    /// decides whether the AGENT runs this checkout. Without it `--build`
+    /// rebuilt every platform service and the sandbox still ran the registry's
+    /// runner, so a turn kept producing the OLD fake model's frames.
+    #[test]
+    fn the_runner_is_in_the_build_set() {
+        let mut o = opts(DEFAULT_COMPOSE_FILE);
+        o.build = true;
+        o.minimal = true;
+
+        let names: Vec<&str> = source_images(&o).iter().map(|i| i.image).collect();
+
+        assert!(names.contains(&"curie-runner"), "got {names:?}");
+    }
+
+    /// Regression: keying the build set on the `slack` PROFILE left
+    /// `curie local message` failing with `No module named
+    /// curie_dispatcher.enqueue_once`, because that verb runs a one-shot
+    /// container from the dispatcher image on every invocation, profile or not.
+    #[test]
+    fn the_dispatcher_is_built_even_without_the_slack_profile() {
+        let mut o = opts(DEFAULT_COMPOSE_FILE);
+        o.build = true;
+        o.slack = false;
+
+        let names: Vec<&str> = source_images(&o).iter().map(|i| i.image).collect();
+
+        assert!(
+            names.contains(&"curie-dispatcher"),
+            "local message needs this image with no slack profile: {names:?}"
+        );
+    }
+
+    /// Every image compose can pull under the override must be buildable here,
+    /// or `--build` produces a stack that is partly source and partly registry
+    /// -- the exact split #1915 is about.
+    #[test]
+    fn every_overridable_compose_image_is_in_the_build_set() {
+        let compose = std::fs::read_to_string(
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+                .parent()
+                .unwrap()
+                .join(DEFAULT_COMPOSE_FILE),
+        )
+        .expect("compose file");
+
+        // Two forms carry the override, and missing the second is how this test
+        // first went wrong: an `image:` line that interpolates the variable, and
+        // the worker overlay, which takes it as a build ARG and puts it in its
+        // own `FROM`. Both are scanned, so a service added in either style has
+        // to appear in the build set.
+        let overlay = std::fs::read_to_string(
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+                .parent()
+                .unwrap()
+                .join("compose/worker-local.Dockerfile"),
+        )
+        .expect("worker overlay");
+
+        let mut overridable = std::collections::BTreeSet::new();
+        for line in compose.lines().chain(overlay.lines()) {
+            let line = line.trim();
+            let interpolates = line.contains("${CURIE_BASE_TAG") || line.contains("${BASE_TAG");
+            if !interpolates {
+                continue;
+            }
+            if let Some(idx) = line.find("ghcr.io/curie-eng/") {
+                let rest = &line[idx + "ghcr.io/curie-eng/".len()..];
+                let name = rest.split(':').next().unwrap_or_default();
+                overridable.insert(name.to_string());
+            }
+        }
+
+        let mut o = opts(DEFAULT_COMPOSE_FILE);
+        o.build = true;
+        let buildable: std::collections::BTreeSet<String> = source_images(&o)
+            .iter()
+            .map(|i| i.image.to_string())
+            .collect();
+
+        assert_eq!(
+            overridable, buildable,
+            "compose can override these images but --build does not build them all"
+        );
     }
 }

--- a/cli/src/local.rs
+++ b/cli/src/local.rs
@@ -259,6 +259,14 @@ pub struct SourceImage {
     pub image: &'static str,
     /// Dockerfile path, relative to the repo root.
     pub dockerfile: &'static str,
+    /// The compose variable that points at this image, when it has its own.
+    ///
+    /// `None` means the image rides `CURIE_BASE_TAG` (the api, and the worker
+    /// overlay's base). Everything else gets a variable of its own, because
+    /// `CURIE_BASE_TAG` means "the platform images THIS caller built" and CI sets
+    /// it while building only those two -- widening its reach made compose pull
+    /// tags nothing had built and fail the stack with `manifest unknown`.
+    pub env: Option<&'static str>,
 }
 
 /// The images `--build` builds for this invocation, in dependency-ish order.
@@ -281,14 +289,17 @@ pub fn source_images(o: &LocalOpts) -> Vec<SourceImage> {
         SourceImage {
             image: "curie-api",
             dockerfile: "apps/api/Dockerfile",
+            env: None,
         },
         SourceImage {
             image: "curie-worker",
             dockerfile: "apps/worker/Dockerfile",
+            env: None,
         },
         SourceImage {
             image: "curie-dispatcher",
             dockerfile: "apps/dispatcher/Dockerfile",
+            env: Some("CURIE_DISPATCHER_IMAGE"),
         },
         // The one that decides whether the AGENT runs this checkout. The worker
         // spawns it per turn from CURIE_RUNNER_IMAGE, so leaving it out rebuilt
@@ -298,12 +309,14 @@ pub fn source_images(o: &LocalOpts) -> Vec<SourceImage> {
         SourceImage {
             image: "curie-runner",
             dockerfile: "runner/Dockerfile",
+            env: Some("CURIE_RUNNER_IMAGE"),
         },
     ];
     if !o.minimal {
         images.push(SourceImage {
             image: "curie-ui",
             dockerfile: "apps/ui/Dockerfile",
+            env: Some("CURIE_UI_IMAGE"),
         });
     }
     images
@@ -403,16 +416,20 @@ fn compose_model_env(o: &LocalOpts, model: Option<&str>) -> Vec<(String, String)
     // api, migrate, worker, ui and dispatcher uniformly -- which is why the two
     // that were pinned to `latest` were changed to read it.
     if o.build {
+        // The two that ride the base tag (the api, and the worker overlay's
+        // base), then one explicit reference per image that has its own variable.
+        // Named outright rather than derived: CURIE_BASE_TAG means "the platform
+        // images this caller built", and CI sets it while building only those
+        // two, so anything else reading it goes looking for a tag nothing built.
         env.push(("CURIE_BASE_TAG".into(), SOURCE_IMAGE_TAG.into()));
-        // Named outright rather than derived from the tag above. The runner is
-        // spawned by the worker rather than being a compose service, and it is
-        // tagged on its own axis -- CI sets CURIE_BASE_TAG for the platform
-        // images while building a plain `curie-runner`, so borrowing the base tag
-        // sent the worker after an image nothing had built.
-        env.push((
-            "CURIE_RUNNER_IMAGE".into(),
-            format!("ghcr.io/curie-eng/curie-runner:{SOURCE_IMAGE_TAG}"),
-        ));
+        for image in source_images(o) {
+            if let Some(name) = image.env {
+                env.push((
+                    name.into(),
+                    format!("ghcr.io/curie-eng/{}:{SOURCE_IMAGE_TAG}", image.image),
+                ));
+            }
+        }
     }
     env
 }
@@ -2049,7 +2066,9 @@ mod tests {
             let line = line.trim();
             let interpolates = line.contains("${CURIE_BASE_TAG")
                 || line.contains("${BASE_TAG")
-                || line.contains("${CURIE_RUNNER_IMAGE");
+                || line.contains("${CURIE_RUNNER_IMAGE")
+                || line.contains("${CURIE_UI_IMAGE")
+                || line.contains("${CURIE_DISPATCHER_IMAGE");
             if !interpolates {
                 continue;
             }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -868,6 +868,17 @@ enum LocalAction {
         /// and the value never reaches argv or logs (#749).
         #[arg(long = "env-file", value_name = "PATH")]
         env_file: Option<PathBuf>,
+        /// Build the stack's images from THIS checkout instead of pulling the
+        /// published ones, and run them (#1915).
+        ///
+        /// `curie update` refreshes the CLI and the runner image; nothing
+        /// refreshed api, worker, ui or dispatcher, so a contributor on a feature
+        /// branch ran a source-built CLI against whatever the registry last
+        /// published. The skew does not announce itself: it surfaces as a serde
+        /// error about a field name, or `No module named` from inside a
+        /// container. Builds only what the selected profiles run.
+        #[arg(long)]
+        build: bool,
     },
     /// Rebuild + recreate ONE compose service (e.g. after a code change) without
     /// losing the stack's already-resolved credential/model-mode wiring.
@@ -2348,6 +2359,7 @@ async fn run(command: Option<Command>) -> Result<()> {
                 pull_model,
                 slack,
                 env_file,
+                build,
             } => {
                 let file = resolve_compose_file(file, dry_run).await?;
                 emit(
@@ -2361,6 +2373,7 @@ async fn run(command: Option<Command>) -> Result<()> {
                             slack,
                             model_mode: local::model_mode_from_env(),
                             env_file,
+                            build,
                         },
                         model,
                     )
@@ -2389,6 +2402,9 @@ async fn run(command: Option<Command>) -> Result<()> {
                             slack,
                             model_mode: local::model_mode_from_env(),
                             env_file,
+                            // `local rebuild` recreates ONE service against the
+                            // stack already running; it never re-tags images.
+                            build: false,
                         },
                         service,
                         model,
@@ -2414,6 +2430,7 @@ async fn run(command: Option<Command>) -> Result<()> {
                             slack: false,
                             model_mode: local::ModelMode::DefaultFake,
                             env_file: None,
+                            build: false,
                         },
                         wipe,
                         yes,
@@ -2433,6 +2450,7 @@ async fn run(command: Option<Command>) -> Result<()> {
                         slack: false,
                         model_mode: local::ModelMode::DefaultFake,
                         env_file: None,
+                        build: false,
                     })
                     .await?,
                 )
@@ -2466,6 +2484,7 @@ async fn run(command: Option<Command>) -> Result<()> {
                     slack: true,
                     model_mode: local::model_mode_from_env(),
                     env_file: None,
+                    build: false,
                 };
                 let model_credentials =
                     local::apply_credential_plan(&mut model_opts, crate::ui::ui())?;

--- a/cli/src/message.rs
+++ b/cli/src/message.rs
@@ -984,6 +984,74 @@ fn compose_config_files(label: &str) -> Result<Vec<String>> {
     Ok(files)
 }
 
+/// The tag in an image reference, or None when it carries none.
+///
+/// Not a naive rsplit on ':'. A digest pin (`repo@sha256:...`) and a registry
+/// host with a port (`localhost:5000/repo`) both contain a colon that is not a
+/// tag separator, and reading either as one would pin the one-shot producer to
+/// a tag that does not exist.
+fn image_tag(image: &str) -> Option<&str> {
+    let last_segment = image.rsplit('/').next().unwrap_or(image);
+    if last_segment.contains('@') {
+        return None;
+    }
+    last_segment.split_once(':').map(|(_, tag)| tag)
+}
+
+/// `docker ps` for the running API container, by compose service label.
+///
+/// The API, deliberately, not the worker. The worker is `build:` in
+/// `compose.dev.yaml` (an overlay over the published base), so its
+/// `.Config.Image` is the compose-built `curie-curie-worker` with no tag at all
+/// -- reading a tag there yields nothing useful, and reading `latest` off it
+/// would pin the producer to the very image the override exists to avoid. The
+/// API container's image IS `ghcr.io/curie-eng/curie-api:${CURIE_BASE_TAG}`, so
+/// it carries the answer directly.
+fn api_ps_command() -> OpsCommand {
+    OpsCommand::new(
+        "docker",
+        vec![
+            plain("ps"),
+            plain("--filter"),
+            plain("label=com.docker.compose.service=curie-api"),
+            plain("--format"),
+            plain("{{.Names}}"),
+        ],
+    )
+}
+
+/// `docker inspect --format {{.Config.Image}} <container>`: the image reference
+/// the running container was created from.
+fn container_image_command(container: &str) -> OpsCommand {
+    OpsCommand::new(
+        "docker",
+        vec![
+            plain("inspect"),
+            plain("--format"),
+            plain("{{ .Config.Image }}"),
+            plain(container),
+        ],
+    )
+}
+
+/// The image tag the running stack was started with, or None when it cannot be
+/// read. Best-effort by design: an unreadable tag leaves compose's own default
+/// in force, which is the behaviour that existed before #1915.
+async fn running_stack_tag() -> Option<String> {
+    let (ok, stdout, _) = run_capture(&api_ps_command()).await.ok()?;
+    if !ok {
+        return None;
+    }
+    let container = stdout.lines().map(str::trim).find(|l| !l.is_empty())?;
+    let (ok, image, _) = run_capture(&container_image_command(container))
+        .await
+        .ok()?;
+    if !ok {
+        return None;
+    }
+    image_tag(image.trim()).map(str::to_string)
+}
+
 fn worker_compose_config_command(container: &str) -> OpsCommand {
     OpsCommand::new(
         "docker",
@@ -1060,6 +1128,8 @@ fn parse_worker_otel_env(stdout: &str) -> Result<Vec<(String, String)>> {
 
 struct LocalDispatcherContext {
     compose_files: Vec<String>,
+    /// The image tag the RUNNING stack uses, when it is readable.
+    base_tag: Option<String>,
     otel_env: Vec<(String, String)>,
 }
 
@@ -1084,9 +1154,16 @@ async fn local_dispatcher_context() -> Result<LocalDispatcherContext> {
         );
     }
     let otel_env = parse_worker_otel_env(&telemetry_stdout)?;
+
+    // #1915: the stack's own image tag, so the one-shot producer below runs what
+    // the stack runs. Best-effort: an unreadable image is not worth failing an
+    // enqueue over, and compose's default then applies exactly as before.
+    let base_tag = running_stack_tag().await;
+
     Ok(LocalDispatcherContext {
         compose_files,
         otel_env,
+        base_tag,
     })
 }
 
@@ -1099,6 +1176,7 @@ fn dispatcher_enqueue_command(
     stream: &str,
     valkey_password: &str,
     otel_env: &[(String, String)],
+    base_tag: Option<&str>,
 ) -> OpsCommand {
     // The dispatcher service lives in the slack profile but depends on core
     // services (notably the API and Valkey). Compose resolves that dependency
@@ -1149,14 +1227,21 @@ fn dispatcher_enqueue_command(
             .filter(|(name, _)| OTEL_EXPORTER_ENV_KEYS.contains(&name.as_str()))
             .cloned(),
     );
+    let mut env = vec![
+        (
+            "COMPOSE_PROJECT_NAME".to_string(),
+            crate::local::COMPOSE_PROJECT.to_string(),
+        ),
+        ("CURIE_STREAM".to_string(), stream.to_string()),
+    ];
+    // Only when the running stack has one. Passing nothing leaves compose's
+    // `${CURIE_BASE_TAG:-latest}` default in force, so a published stack behaves
+    // exactly as it did.
+    if let Some(tag) = base_tag {
+        env.push(("CURIE_BASE_TAG".to_string(), tag.to_string()));
+    }
     OpsCommand::new("docker", args)
-        .with_env(vec![
-            (
-                "COMPOSE_PROJECT_NAME".to_string(),
-                crate::local::COMPOSE_PROJECT.to_string(),
-            ),
-            ("CURIE_STREAM".to_string(), stream.to_string()),
-        ])
+        .with_env(env)
         .with_secret_env(secret_env)
 }
 
@@ -1208,6 +1293,7 @@ async fn dispatcher_enqueue_local(opts: &MessageOpts, turn: &QueuedTurn) -> Resu
         &opts.stream,
         &opts.valkey_password,
         &context.otel_env,
+        context.base_tag.as_deref(),
     );
     crate::ui::ui().plumbing(&format!("+ {}", cmd.display()));
     let payload = queue::payload_json(turn)?;
@@ -3574,6 +3660,7 @@ mod tests {
             "test:curie:runs",
             secret,
             &otel_env,
+            None,
         );
         let argv = command.argv();
 
@@ -5055,5 +5142,64 @@ mod tests {
             fix.contains("--cases") && fix.contains("--model"),
             "the fix points at both the drop-flag and the in-CLI path: {fix}"
         );
+    }
+
+    /// #1915: the one-shot producer must run the SAME image tag the stack is
+    /// running, not whatever this shell resolves.
+    ///
+    /// Compose substitutes `${CURIE_BASE_TAG:-latest}` from the invocation's own
+    /// environment, so after `local up --build` the stack ran `:dev` while
+    /// `local message` pulled `:latest` and died on `No module named
+    /// curie_dispatcher.enqueue_once` -- the module the published image predates.
+    /// The tag is READ off the running worker rather than remembered, so it is
+    /// right even for a stack this process did not start.
+    #[test]
+    fn the_one_shot_producer_inherits_the_running_stack_tag() {
+        let cmd = dispatcher_enqueue_command(
+            &["compose.dev.yaml".to_string()],
+            "enqueue-1",
+            "curie:runs",
+            "pw",
+            &[],
+            Some("dev"),
+        );
+
+        assert!(
+            cmd.env
+                .iter()
+                .any(|(k, v)| k == "CURIE_BASE_TAG" && v == "dev"),
+            "expected the running tag in the child env, got {:?}",
+            cmd.env
+        );
+    }
+
+    /// A stack on the published images passes nothing, so compose's own default
+    /// still applies and a non-contributor sees no behaviour change.
+    #[test]
+    fn a_published_stack_leaves_the_tag_to_compose() {
+        let cmd = dispatcher_enqueue_command(
+            &["compose.dev.yaml".to_string()],
+            "enqueue-1",
+            "curie:runs",
+            "pw",
+            &[],
+            None,
+        );
+
+        assert!(!cmd.env.iter().any(|(k, _)| k == "CURIE_BASE_TAG"));
+    }
+
+    #[test]
+    fn an_image_reference_yields_its_tag() {
+        assert_eq!(image_tag("ghcr.io/curie-eng/curie-worker:dev"), Some("dev"));
+        assert_eq!(
+            image_tag("ghcr.io/curie-eng/curie-worker:latest"),
+            Some("latest")
+        );
+        // A digest pin has no tag, and the colon inside it must not be read as
+        // one -- the registry host's port must not either.
+        assert_eq!(image_tag("ghcr.io/curie-eng/curie-worker@sha256:abc"), None);
+        assert_eq!(image_tag("localhost:5000/curie-worker"), None);
+        assert_eq!(image_tag("localhost:5000/curie-worker:dev"), Some("dev"));
     }
 }

--- a/cli/src/message.rs
+++ b/cli/src/message.rs
@@ -1034,10 +1034,39 @@ fn container_image_command(container: &str) -> OpsCommand {
     )
 }
 
-/// The image tag the running stack was started with, or None when it cannot be
-/// read. Best-effort by design: an unreadable tag leaves compose's own default
-/// in force, which is the behaviour that existed before #1915.
-async fn running_stack_tag() -> Option<String> {
+/// `docker image inspect <ref>` -- succeeds only if the image is present.
+fn image_present_command(image: &str) -> OpsCommand {
+    OpsCommand::new(
+        "docker",
+        vec![
+            plain("image"),
+            plain("inspect"),
+            plain("--format"),
+            plain("{{ .Id }}"),
+            plain(image),
+        ],
+    )
+}
+
+/// The dispatcher image the one-shot producer should run, or None to leave
+/// compose's default alone.
+///
+/// Derived from the RUNNING api container's tag, then checked for existence, and
+/// both halves are load-bearing:
+///
+/// - Derived, because the tag is a property of the stack rather than of this
+///   invocation. Compose substitutes its variables from each caller's own
+///   environment, so after `local up --build` the stack ran `:dev` while this
+///   verb resolved `:latest` and died on `No module named
+///   curie_dispatcher.enqueue_once`.
+/// - Checked, because a tag that exists for the platform images need not exist
+///   for the dispatcher. CI runs the ladder with `CURIE_BASE_TAG=ci-local` and
+///   builds its dispatcher as `:latest`, so pointing this at `:ci-local` asked
+///   for an image nothing had built and failed the stack.
+///
+/// Best-effort throughout: any unreadable step leaves compose's default in
+/// force, which is the behaviour that existed before #1915.
+async fn one_shot_dispatcher_image() -> Option<String> {
     let (ok, stdout, _) = run_capture(&api_ps_command()).await.ok()?;
     if !ok {
         return None;
@@ -1049,7 +1078,10 @@ async fn running_stack_tag() -> Option<String> {
     if !ok {
         return None;
     }
-    image_tag(image.trim()).map(str::to_string)
+    let tag = image_tag(image.trim())?;
+    let candidate = format!("ghcr.io/curie-eng/curie-dispatcher:{tag}");
+    let (present, _, _) = run_capture(&image_present_command(&candidate)).await.ok()?;
+    present.then_some(candidate)
 }
 
 fn worker_compose_config_command(container: &str) -> OpsCommand {
@@ -1128,8 +1160,9 @@ fn parse_worker_otel_env(stdout: &str) -> Result<Vec<(String, String)>> {
 
 struct LocalDispatcherContext {
     compose_files: Vec<String>,
-    /// The image tag the RUNNING stack uses, when it is readable.
-    base_tag: Option<String>,
+    /// The dispatcher image the running stack would use, when it can be
+    /// determined and is actually present.
+    dispatcher_image: Option<String>,
     otel_env: Vec<(String, String)>,
 }
 
@@ -1158,12 +1191,12 @@ async fn local_dispatcher_context() -> Result<LocalDispatcherContext> {
     // #1915: the stack's own image tag, so the one-shot producer below runs what
     // the stack runs. Best-effort: an unreadable image is not worth failing an
     // enqueue over, and compose's default then applies exactly as before.
-    let base_tag = running_stack_tag().await;
+    let dispatcher_image = one_shot_dispatcher_image().await;
 
     Ok(LocalDispatcherContext {
         compose_files,
         otel_env,
-        base_tag,
+        dispatcher_image,
     })
 }
 
@@ -1176,7 +1209,7 @@ fn dispatcher_enqueue_command(
     stream: &str,
     valkey_password: &str,
     otel_env: &[(String, String)],
-    base_tag: Option<&str>,
+    dispatcher_image: Option<&str>,
 ) -> OpsCommand {
     // The dispatcher service lives in the slack profile but depends on core
     // services (notably the API and Valkey). Compose resolves that dependency
@@ -1237,8 +1270,8 @@ fn dispatcher_enqueue_command(
     // Only when the running stack has one. Passing nothing leaves compose's
     // `${CURIE_BASE_TAG:-latest}` default in force, so a published stack behaves
     // exactly as it did.
-    if let Some(tag) = base_tag {
-        env.push(("CURIE_BASE_TAG".to_string(), tag.to_string()));
+    if let Some(image) = dispatcher_image {
+        env.push(("CURIE_DISPATCHER_IMAGE".to_string(), image.to_string()));
     }
     OpsCommand::new("docker", args)
         .with_env(env)
@@ -1293,7 +1326,7 @@ async fn dispatcher_enqueue_local(opts: &MessageOpts, turn: &QueuedTurn) -> Resu
         &opts.stream,
         &opts.valkey_password,
         &context.otel_env,
-        context.base_tag.as_deref(),
+        context.dispatcher_image.as_deref(),
     );
     crate::ui::ui().plumbing(&format!("+ {}", cmd.display()));
     let payload = queue::payload_json(turn)?;
@@ -5144,39 +5177,38 @@ mod tests {
         );
     }
 
-    /// #1915: the one-shot producer must run the SAME image tag the stack is
-    /// running, not whatever this shell resolves.
+    /// #1915: the one-shot producer must run the dispatcher image the STACK
+    /// runs, not whatever this shell resolves.
     ///
-    /// Compose substitutes `${CURIE_BASE_TAG:-latest}` from the invocation's own
-    /// environment, so after `local up --build` the stack ran `:dev` while
-    /// `local message` pulled `:latest` and died on `No module named
+    /// Compose substitutes its variables from each invocation's own environment,
+    /// so after `local up --build` the stack ran `:dev` while `local message`
+    /// resolved `:latest` and died on `No module named
     /// curie_dispatcher.enqueue_once` -- the module the published image predates.
-    /// The tag is READ off the running worker rather than remembered, so it is
-    /// right even for a stack this process did not start.
     #[test]
-    fn the_one_shot_producer_inherits_the_running_stack_tag() {
+    fn the_one_shot_producer_runs_the_stacks_dispatcher_image() {
         let cmd = dispatcher_enqueue_command(
             &["compose.dev.yaml".to_string()],
             "enqueue-1",
             "curie:runs",
             "pw",
             &[],
-            Some("dev"),
+            Some("ghcr.io/curie-eng/curie-dispatcher:dev"),
         );
 
         assert!(
-            cmd.env
-                .iter()
-                .any(|(k, v)| k == "CURIE_BASE_TAG" && v == "dev"),
-            "expected the running tag in the child env, got {:?}",
+            cmd.env.iter().any(|(k, v)| k == "CURIE_DISPATCHER_IMAGE"
+                && v == "ghcr.io/curie-eng/curie-dispatcher:dev"),
+            "expected the stack's dispatcher image in the child env, got {:?}",
             cmd.env
         );
     }
 
     /// A stack on the published images passes nothing, so compose's own default
-    /// still applies and a non-contributor sees no behaviour change.
+    /// still applies. This is also what keeps CI working: the ladder builds its
+    /// dispatcher as `:latest` while setting CURIE_BASE_TAG=ci-local, so a
+    /// derived-but-unchecked tag would ask for an image nothing built.
     #[test]
-    fn a_published_stack_leaves_the_tag_to_compose() {
+    fn a_published_stack_leaves_the_image_to_compose() {
         let cmd = dispatcher_enqueue_command(
             &["compose.dev.yaml".to_string()],
             "enqueue-1",
@@ -5186,7 +5218,7 @@ mod tests {
             None,
         );
 
-        assert!(!cmd.env.iter().any(|(k, _)| k == "CURIE_BASE_TAG"));
+        assert!(!cmd.env.iter().any(|(k, _)| k == "CURIE_DISPATCHER_IMAGE"));
     }
 
     #[test]

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -528,11 +528,16 @@ services:
       - /tmp/curie-bundles:/tmp/curie-bundles
     environment:
       - CURIE_SANDBOX_SUBSTRATE=docker
-      # Reads the same override as every other published image (#1915). This is
-      # the one that decides whether the AGENT runs your checkout: the worker
-      # spawns this image per turn, so a `latest` here meant `local up --build`
-      # rebuilt the platform and left the sandbox on the registry's runner.
-      - CURIE_RUNNER_IMAGE=ghcr.io/curie-eng/curie-runner:${CURIE_BASE_TAG:-latest}
+      # The image the worker spawns per turn -- the one that decides whether the
+      # AGENT runs your checkout, which is why `local up --build` sets it (#1915).
+      #
+      # Its OWN variable, deliberately NOT CURIE_BASE_TAG. The runner is not a
+      # compose service: it is spawned by the worker, and it is built and tagged
+      # on a different axis from the published platform images. Reading the base
+      # tag here broke the e2e ladder, which sets CURIE_BASE_TAG=ci-local for the
+      # platform and builds its runner as a plain `curie-runner` -- so the worker
+      # went looking for a `curie-runner:ci-local` nothing had built.
+      - CURIE_RUNNER_IMAGE=${CURIE_RUNNER_IMAGE:-ghcr.io/curie-eng/curie-runner:latest}
       - TMPDIR=/tmp/curie-bundles
       - VALKEY_HOST=localhost
       - VALKEY_PORT=26379

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -435,7 +435,11 @@ services:
   # The image is fixture-by-default, so the CLI advertises the wired
   # `http://localhost:28080/?api=1` URL and `local up` opens it connected to the API.
   curie-ui:
-    image: ghcr.io/curie-eng/curie-ui:latest
+    # Same override as api/migrate/worker. Pinned to `latest` before #1915, which
+    # meant `CURIE_BASE_TAG=dev` moved three services and silently left this one
+    # on whatever the registry last published -- so a stack "built from source"
+    # was partly not.
+    image: ghcr.io/curie-eng/curie-ui:${CURIE_BASE_TAG:-latest}
     profiles: *full_profiles
     depends_on:
       curie-api:
@@ -524,7 +528,11 @@ services:
       - /tmp/curie-bundles:/tmp/curie-bundles
     environment:
       - CURIE_SANDBOX_SUBSTRATE=docker
-      - CURIE_RUNNER_IMAGE=ghcr.io/curie-eng/curie-runner:latest
+      # Reads the same override as every other published image (#1915). This is
+      # the one that decides whether the AGENT runs your checkout: the worker
+      # spawns this image per turn, so a `latest` here meant `local up --build`
+      # rebuilt the platform and left the sandbox on the registry's runner.
+      - CURIE_RUNNER_IMAGE=ghcr.io/curie-eng/curie-runner:${CURIE_BASE_TAG:-latest}
       - TMPDIR=/tmp/curie-bundles
       - VALKEY_HOST=localhost
       - VALKEY_PORT=26379
@@ -648,7 +656,11 @@ services:
   # Use one dispatcher per app. This is why the service is behind the `slack`
   # profile and disabled by default.
   curie-dispatcher:
-    image: ghcr.io/curie-eng/curie-dispatcher:latest
+    # Same override as every other published image (#1915). This one bit
+    # hardest: the CLI invoked `curie_dispatcher.enqueue_once`, the published
+    # image predated that module, and the failure surfaced as a bare
+    # `No module named` from inside a container.
+    image: ghcr.io/curie-eng/curie-dispatcher:${CURIE_BASE_TAG:-latest}
     profiles: [slack]
     depends_on:
       valkey:

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -435,11 +435,12 @@ services:
   # The image is fixture-by-default, so the CLI advertises the wired
   # `http://localhost:28080/?api=1` URL and `local up` opens it connected to the API.
   curie-ui:
-    # Same override as api/migrate/worker. Pinned to `latest` before #1915, which
-    # meant `CURIE_BASE_TAG=dev` moved three services and silently left this one
-    # on whatever the registry last published -- so a stack "built from source"
-    # was partly not.
-    image: ghcr.io/curie-eng/curie-ui:${CURIE_BASE_TAG:-latest}
+    # Its OWN variable, defaulting to the `latest` this line used to hardcode
+    # (#1915). NOT CURIE_BASE_TAG: that variable means "the platform images this
+    # caller built", and CI sets it while building only api and worker -- so
+    # reading it here made compose pull a `curie-ui:ci-local` that does not
+    # exist and fail the whole stack with `manifest unknown`.
+    image: ${CURIE_UI_IMAGE:-ghcr.io/curie-eng/curie-ui:latest}
     profiles: *full_profiles
     depends_on:
       curie-api:
@@ -661,11 +662,11 @@ services:
   # Use one dispatcher per app. This is why the service is behind the `slack`
   # profile and disabled by default.
   curie-dispatcher:
-    # Same override as every other published image (#1915). This one bit
-    # hardest: the CLI invoked `curie_dispatcher.enqueue_once`, the published
-    # image predated that module, and the failure surfaced as a bare
+    # Its own variable, same reasoning as curie-ui above (#1915). This one bit
+    # hardest locally: the CLI invoked `curie_dispatcher.enqueue_once`, the
+    # published image predated that module, and the failure surfaced as a bare
     # `No module named` from inside a container.
-    image: ghcr.io/curie-eng/curie-dispatcher:${CURIE_BASE_TAG:-latest}
+    image: ${CURIE_DISPATCHER_IMAGE:-ghcr.io/curie-eng/curie-dispatcher:latest}
     profiles: [slack]
     depends_on:
       valkey:

--- a/compose/generate_release_compose.py
+++ b/compose/generate_release_compose.py
@@ -71,6 +71,21 @@ CURIE_LATEST_RE = re.compile(
     r"(ghcr\.io/curie-eng/curie-[a-z-]+):(?:latest|\$\{CURIE_BASE_TAG:-latest\})"
 )
 
+# The other override shape, added by #1915: an image whose WHOLE reference is a
+# defaulted variable, `${CURIE_UI_IMAGE:-ghcr.io/curie-eng/curie-ui:latest}`.
+# Those images (ui, dispatcher, runner) are not on CURIE_BASE_TAG, because that
+# variable means "the platform images this caller built" and CI sets it while
+# building only api and worker.
+#
+# T3's pattern matches the ref INSIDE the braces, which would pin the tag and
+# leave the `${...}` wrapper in place -- and the release asset has no shell to
+# resolve it, so compose would try to pull an image literally named `${...}`.
+# Unwrapping first collapses the form to the plain ref T3 then pins, which is the
+# same outcome the dev file's own unset default already produces.
+CURIE_DEFAULTED_IMAGE_RE = re.compile(
+    r"\$\{[A-Z_]+:-(ghcr\.io/curie-eng/curie-[a-z-]+:latest)\}"
+)
+
 DEV_COMPOSE = Path("compose.dev.yaml")
 OTEL_CONFIG = Path("otel/collector-config.yaml")
 
@@ -100,7 +115,11 @@ def generate(dev_text: str, otel_text: str, version: str) -> str:
         )
     text = text.replace(OTEL_VOLUME_BLOCK, OTEL_CONFIGS_REF, 1)
 
-    # T3: pin every curie-* image tag to the release version (worker-local too).
+    # T3a: unwrap a defaulted whole-reference override to its plain ref, so T3b
+    # pins it like any other and no `${...}` survives into the release asset.
+    text = CURIE_DEFAULTED_IMAGE_RE.sub(r"\1", text)
+
+    # T3b: pin every curie-* image tag to the release version (worker-local too).
     text = CURIE_LATEST_RE.sub(rf"\1:{version}", text)
 
     return text


### PR DESCRIPTION
Closes #1915.

`curie local message` could not work against a `next` checkout. `curie update` refreshes the CLI and the runner image; the stack's api, worker, dispatcher and ui came from the **registry**, so a source-built CLI talked to whatever was last published. Neither failure looked like version skew — `missing field 'channel'` from a serde decode, and `No module named curie_dispatcher.enqueue_once` from inside a container.

`curie local up --build` builds what the run needs from this checkout and runs it.

## Five things had to be true, and testing found four of them

I would not have reasoned my way to any of the last four. Each was found by driving the loop and watching it still fail.

**1 — The override has to reach every image.** `CURIE_BASE_TAG` already drove api, migrate and worker; **ui and dispatcher were pinned to `latest`**, so one variable moved three services and silently left two on the registry. A test now derives the overridable set from `compose.dev.yaml` *and* the worker overlay's own `FROM`, and asserts the build set covers it — so a service added in either style cannot be forgotten.

**2 — The dispatcher is built even without `--slack`.** The profile governs the long-running service, but `local message` runs a **one-shot container from that same image on every invocation**, outside any profile. Keying the build set on profiles left the main dev-loop verb still failing.

**3 — The one-shot producer has to inherit the *running* stack's tag.** Compose substitutes `${CURIE_BASE_TAG:-latest}` from each invocation's own environment, so after `up --build` the stack ran `:dev` and `local message` pulled `:latest`. The tag is now **read off the running API container** rather than remembered — and off the API, not the worker, because the worker is a compose-built overlay whose `.Config.Image` carries no tag at all.

**4 — The runner counts, and it decides whether the *agent* runs your code.** The worker spawns it per turn from `CURIE_RUNNER_IMAGE`, also hardcoded to `latest`. With every platform service rebuilt, a turn still produced the **old fake model's frames** because the sandbox ran the registry's runner.

**5 — Rebuilding the base images is not enough.** `curie-worker` is a compose-built overlay over the published base, and without `--build` on the compose child, compose reuses the overlay it baked over the **previous** base. The stack reported itself source-built while running yesterday's worker on today's base, and the only visible symptom was a real turn recording no `post_state` — because the code that extracts it was in the layer that never got rebuilt.

## Verified by driving the loop

```
curie local deploy   ok      (the field mismatch is gone)
curie local message  ok      "scaled public/api from 3 to 10 — can be undone"
the ledger row       prior_state {"spec":{"replicas":3}}
                     post_state  {"spec":{"replicas":10}}
                     target      {"kind":"Deployment","namespace":"public","name":"api"}
worker POST_KEY      post        (was MISSING before fix 5)
CURIE_RUNNER_IMAGE   ...curie-runner:dev   (was :latest before fix 4)
```

## A plain `local up` is unchanged

No builds, no `--build` on the compose child, no tag override — a non-contributor keeps the fast restart and the published images. Asserted by `without_build_the_tag_is_left_to_compose` and `a_published_stack_leaves_the_tag_to_compose`.

```
cli --lib             49 local:: + 68 message:: passed
check-contracts       clean
check-docs            clean
cargo fmt / clippy    clean
```

`chart_check_passes_on_the_unmodified_chart` fails here and on a clean `next` checkout alike — pre-existing, unrelated.
