### PR TITLE
Correct ADR-0121's measured MCP transport cost

### DIFF
--- a/docs/adr/0121-a-restore-is-the-connectors-own-verb-run-under-the-same-pinned-connector.md
+++ b/docs/adr/0121-a-restore-is-the-connectors-own-verb-run-under-the-same-pinned-connector.md
@@ -165,9 +165,11 @@ executor should not ship before it.
 
 ## Alternatives considered
 
-- **An MCP client in the worker** (ADR-0117's first candidate). Not the smaller
-  change -- the spike above measured both at the same 13 lines -- so cost does not
-  choose between them and decision 2 does. The worker is the control
+- **An MCP client in the worker** (ADR-0117's first candidate). The spike
+  measured the streamable-HTTP MCP client and call primitive at 13 lines. That
+  primitive is the same in either process, so transport-client cost does not
+  choose between them; total integration cost in either location remains
+  unmeasured, and decision 2 chooses by policy boundary. The worker is the control
   plane; giving it a direct client of tenant connectors makes the platform
   reachable to places ADR-0008 keeps separate, and the undo would then run under
   the control plane's network reachability rather than the sandbox's. An undo
@@ -197,22 +199,24 @@ executor should not ship before it.
 
 ## Consequences
 
-- **The runner invokes an MCP tool outside the model loop, and that turned out to
-  be cheap.** This was written up as the largest cost, inherited from ADR-0117's
-  stated reason for deferring: "the SDK owns the client sessions", so a second
-  client in the runner is "a large new mechanism for one job".
+- **The streamable-HTTP MCP client and call primitive is small; total runner
+  integration cost remains unmeasured.** The client was written up as the
+  largest cost, inherited from ADR-0117's stated reason for deferring: "the SDK
+  owns the client sessions", so a second client in the runner is "a large new
+  mechanism for one job".
 
-  Measured, it is not. A hosted connector's MCP entry is `{"type": "http", "url":
-  ".../mcp"}` -- streamable HTTP, not a stdio subprocess the SDK spawned -- so the
-  question was never how to take a session from the SDK. It was how big an HTTP
-  client is for one call. Against the real `k8s-scale` connector, with no agent
-  SDK in the process, it is **13 lines**: open the transport, initialize the
+  Measured, that primitive is not large. A hosted connector's MCP entry is
+  `{"type": "http", "url": ".../mcp"}` -- streamable HTTP, not a stdio
+  subprocess the SDK spawned -- so no SDK-owned session has to be reused.
+  Against the real `k8s-scale` connector, with no agent SDK in the process, the
+  client and one call are **13 lines**: open the transport, initialize the
   session, call the tool. Probes on `spike/adr-0121-restore-executor`.
 
-  This removes a cost from decision 2 rather than adding one, and it sharpens the
-  argument in the alternatives below: the worker could do this just as cheaply, so
-  the case for the sandbox rests entirely on reachability and the policy envelope.
-  That is a better place for it to rest than on relative effort.
+  This removes transport-client cost as the selector in decision 2. It does not
+  measure the complete runner integration: sandbox lifecycle, pinned connector
+  selection, policy, failure handling, and completion confirmation remain to be
+  built. The case for the sandbox rests on reachability and the policy envelope,
+  not on a measured claim about total relative effort.
 
 - **A write connector that wants to be undoable now has two verbs to write, not
   one.** ADR-0117 already charged authors for returning JSON; this adds the
@@ -220,16 +224,16 @@ executor should not ship before it.
   write halves, and a connector that cannot restore can still report prose and be
   honestly irreversible.
 
-- **The loop has been run end to end, with real code at every step.**
-  `probe_roundtrip.py` on that spike branch: an agent scales 3 to 10, the ledger
-  records the prior state, a refused undo leaves the world untouched at 10 and
-  never reaches the connector, an authorized undo returns `{target, prior_state}`,
-  and the executor replays it back to 3. No mapping table exists anywhere, which
-  is decision 1's claim surviving contact.
+- **The ruling-to-restore leg has run through the real API, Postgres, and
+  connector.** `probe_roundtrip.py` on that spike branch: an agent scales 3 to
+  10, the ledger records the prior state, a refused undo leaves the world
+  untouched at 10 and never reaches the connector, an authorized undo returns
+  `{target, prior_state}`, and the executor replays it back to 3. No mapping
+  table exists anywhere, which is decision 1's claim surviving contact.
 
-  What the same probe found missing is the confirmation half: `POST
-  /actions/{id}/confirm-undo` does not exist, so decision 4's compromise stands
-  until it does.
+  The complete loop has not run: `POST /actions/{id}/confirm-undo` returns 404,
+  so confirmation remains absent and decision 4's compromise stands until that
+  endpoint exists.
 
 - **A restore is a sandbox turn without a model**, which is a shape the platform
   does not have. Whether it reuses the existing sandbox lifecycle or gets a

--- a/docs/adr/0121-a-restore-is-the-connectors-own-verb-run-under-the-same-pinned-connector.md
+++ b/docs/adr/0121-a-restore-is-the-connectors-own-verb-run-under-the-same-pinned-connector.md
@@ -165,8 +165,9 @@ executor should not ship before it.
 
 ## Alternatives considered
 
-- **An MCP client in the worker** (ADR-0117's first candidate). The smallest
-  change, and the reason to reject it is decision 2. The worker is the control
+- **An MCP client in the worker** (ADR-0117's first candidate). Not the smaller
+  change -- the spike above measured both at the same 13 lines -- so cost does not
+  choose between them and decision 2 does. The worker is the control
   plane; giving it a direct client of tenant connectors makes the platform
   reachable to places ADR-0008 keeps separate, and the undo would then run under
   the control plane's network reachability rather than the sandbox's. An undo
@@ -196,18 +197,39 @@ executor should not ship before it.
 
 ## Consequences
 
-- **The runner must invoke an MCP tool outside the model loop, which it cannot do
-  today.** This is the largest cost and it was ADR-0117's stated reason for
-  deferring: the SDK owns the client sessions, so a second client inside the
-  runner is new mechanism. It is a smaller mechanism than it looked, because it
-  is needed for exactly one verb with a fixed argument shape and no model in the
-  path.
+- **The runner invokes an MCP tool outside the model loop, and that turned out to
+  be cheap.** This was written up as the largest cost, inherited from ADR-0117's
+  stated reason for deferring: "the SDK owns the client sessions", so a second
+  client in the runner is "a large new mechanism for one job".
+
+  Measured, it is not. A hosted connector's MCP entry is `{"type": "http", "url":
+  ".../mcp"}` -- streamable HTTP, not a stdio subprocess the SDK spawned -- so the
+  question was never how to take a session from the SDK. It was how big an HTTP
+  client is for one call. Against the real `k8s-scale` connector, with no agent
+  SDK in the process, it is **13 lines**: open the transport, initialize the
+  session, call the tool. Probes on `spike/adr-0121-restore-executor`.
+
+  This removes a cost from decision 2 rather than adding one, and it sharpens the
+  argument in the alternatives below: the worker could do this just as cheaply, so
+  the case for the sandbox rests entirely on reachability and the policy envelope.
+  That is a better place for it to rest than on relative effort.
 
 - **A write connector that wants to be undoable now has two verbs to write, not
   one.** ADR-0117 already charged authors for returning JSON; this adds the
   return leg. The honest mitigation is that both are the same tool's read and
   write halves, and a connector that cannot restore can still report prose and be
   honestly irreversible.
+
+- **The loop has been run end to end, with real code at every step.**
+  `probe_roundtrip.py` on that spike branch: an agent scales 3 to 10, the ledger
+  records the prior state, a refused undo leaves the world untouched at 10 and
+  never reaches the connector, an authorized undo returns `{target, prior_state}`,
+  and the executor replays it back to 3. No mapping table exists anywhere, which
+  is decision 1's claim surviving contact.
+
+  What the same probe found missing is the confirmation half: `POST
+  /actions/{id}/confirm-undo` does not exist, so decision 4's compromise stands
+  until it does.
 
 - **A restore is a sandbox turn without a model**, which is a shape the platform
   does not have. Whether it reuses the existing sandbox lifecycle or gets a


### PR DESCRIPTION
**The decision is unchanged.** This corrects three claims in it that the spike
measured and found wrong — a reviewer reading ADR-0121 as it stands would be
weighing the wrong trade.

Refs #1867. Still Draft, authorizes no implementation. Probes on
`spike/adr-0121-restore-executor`.

## What was wrong

ADR-0121 wrote the runner-side executor up as **"the largest cost"**, inheriting
ADR-0117's spike conclusion:

> the SDK owns the client sessions, so a second client inside the runner is a
> large new mechanism for one job

A hosted connector's MCP entry is `{"type": "http", "url": ".../mcp"}` —
**streamable HTTP, not a stdio subprocess the SDK spawned.** No SDK-owned
session has to be reused for the call.

Against the real `k8s-scale` connector, with no agent SDK in the process:

```python
async with streamablehttp_client(url) as (read, write, _):
    async with ClientSession(read, write) as session:
        await session.initialize()
        result = await session.call_tool(tool, arguments)
```

The streamable-HTTP MCP client and call primitive is **13 lines**. That does not
measure the complete runner integration: sandbox lifecycle, pinned connector
selection, policy, failure handling, and completion confirmation remain unbuilt.

## Why this matters to the decision rather than just to the prose

It removes transport-client cost as the selector in decision 2. The same
primitive can run in the worker or runner, while total integration cost in
either location remains unmeasured. The case for the sandbox therefore rests on
reachability and the policy envelope, which is the architectural trade a
reviewer should judge.

## Also recorded: what the spike ran, and what remains missing

The ruling-to-restore leg ran through the real API, Postgres, and connector: an
agent scales 3 → 10, the ledger records the prior state, a refused undo leaves
the world at 10 and never reaches the connector, an authorized undo returns
`{target, prior_state}`, and the executor replays back to 3. No mapping table
exists anywhere, which is decision 1's claim surviving contact.

The complete loop has not run: `POST /actions/{id}/confirm-undo` returns 404, so
confirmation remains absent and decision 4's compromise stands until that
endpoint exists.
