### PR TITLE
Publish ADR-0123 as Accepted

### DIFF
--- a/docs/adr/0123-a-pending-approvals-approver-set-does-not-follow-its-route-binding.md
+++ b/docs/adr/0123-a-pending-approvals-approver-set-does-not-follow-its-route-binding.md
@@ -2,7 +2,7 @@
 
 Date: 2026-08-25
 
-Status: Draft
+Status: Accepted
 
 Raised by [#1081](https://github.com/curie-eng/curie/issues/1081).
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -144,5 +144,5 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0113 | [Bundles declare connector build inputs and tiers deliver pinned images](0113-bundles-declare-connector-build-inputs-and-tiers-deliver-pinned-images.md) | Accepted |
 | 0114 | [Cluster up infers detected install facts](0114-cluster-up-infers-detected-install-facts.md) | Accepted |
 | 0115 | [Agents call each other directly, with no third party in the path](0115-agents-call-each-other-with-no-third-party.md) | Draft |
-| 0123 | [A pending approval's approver set does not follow its route binding](0123-a-pending-approvals-approver-set-does-not-follow-its-route-binding.md) | Draft |
+| 0123 | [A pending approval's approver set does not follow its route binding](0123-a-pending-approvals-approver-set-does-not-follow-its-route-binding.md) | Accepted |
 <!-- END GENERATED: adr-index -->


### PR DESCRIPTION
Refs #1081.

You approved and merged ADR-0123 on #1924, and confirmed in Slack that I can read that as acceptance. This is the status line, which is the other half: only `Accepted` authorizes implementation under ADR-0085, so #1081 stays blocked while it says `Draft`.

The body is untouched. ADR-0045 makes the status line the mutable part of an otherwise immutable record, so this is the one edit an Accepted ADR permits.

Once this lands, #1081 is unblocked and the implementation is: split `SlackApproverSetSelector`'s no-approvers case on whether the approval named a route, fail closed for a named route whose binding is gone, and keep the channel-members fallback only for routeless approvals.
