### PR TITLE
A triggered turn's conversation id is not a Slack thread ts, so its reply is never delivered

### DIFF
--- a/apps/worker/src/curie_worker/slack_sink.py
+++ b/apps/worker/src/curie_worker/slack_sink.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 from collections.abc import Awaitable, Callable, Sequence
 from typing import TYPE_CHECKING, Any, TypeVar, cast
 from urllib.parse import urlsplit
@@ -68,6 +69,35 @@ _DEFAULT_PORTS = {"http": 80, "https": 443}
 # ``None``, which matches ANY port on that scheme+host (the dev/CLI stub's
 # ephemeral port, see ``_configured_origins``).
 _TrustedOrigin = tuple[str, str, int | None]
+
+
+# Slack names a thread by its parent message's timestamp: `<seconds>.<micros>`.
+_SLACK_TS = re.compile(r"^\d+\.\d+$")
+
+
+def _thread_ts(conversation_id: str | None) -> str | None:
+    """The Slack thread this conversation id names, or None when it names none.
+
+    ``ReplyTarget.conversation_id`` is "in the channel's own terms"
+    (``channel_protocol.reply``), and for a Slack-ingress turn those terms are the
+    parent message's ts -- which is why it used to be passed straight through as
+    ``thread_ts``.
+
+    A TRIGGERED turn's conversation id is not a ts. ``POST /hooks/{agent}/{name}``
+    mints ``hook:<agent>:<name>``, deliberately disjoint from Slack thread ids so a
+    hook can never land inside a human conversation. Sent as ``thread_ts`` that
+    string makes Slack refuse the entire delivery with ``invalid_thread_ts``, and it
+    does so AFTER the turn has run: the work is done, the money is spent, and the
+    answer is dropped on the floor.
+
+    So anything that is not a timestamp names no thread. The reply then posts at
+    channel level and the ts it mints becomes the ``reply_ref`` the rest of the turn
+    edits, which is the placeholder-less path ADR-0079 already describes.
+    """
+
+    if conversation_id is None or not _SLACK_TS.match(conversation_id):
+        return None
+    return conversation_id
 
 
 class UntrustedSlackEndpointError(RuntimeError):
@@ -235,7 +265,7 @@ class SlackReplyAdapter:
         if isinstance(event, TurnStatus):
             await self._set_status(
                 channel=target.address,
-                thread_ts=target.conversation_id or "",
+                thread_ts=_thread_ts(target.conversation_id) or "",
                 status=event.status,
                 endpoint=endpoint,
             )
@@ -274,7 +304,7 @@ class SlackReplyAdapter:
                 # placeholder-less turn into a silent delivery failure.
                 ref = await self._post_text(
                     channel=target.address,
-                    thread_ts=target.conversation_id,
+                    thread_ts=_thread_ts(target.conversation_id),
                     text=event.text or "",
                     nav=event.nav,
                     endpoint=endpoint,
@@ -295,7 +325,7 @@ class SlackReplyAdapter:
                 channel=target.address,
                 message=event.message,
                 requested_by=event.requested_by,
-                thread_ts=target.conversation_id,
+                thread_ts=_thread_ts(target.conversation_id),
                 endpoint=endpoint,
             )
             return ReplyAck(ref=ref)
@@ -611,9 +641,7 @@ class SlackReplyAdapter:
         # expiry notice still beats leaving live-looking buttons.
         async def op(client: AsyncWebClient) -> None:
             try:
-                await client.chat_update(
-                    channel=channel, ts=ts, text=text, blocks=blocks
-                )
+                await client.chat_update(channel=channel, ts=ts, text=text, blocks=blocks)
             except SlackApiError:
                 logger.warning(
                     "card chat_update with blocks rejected for %s; retrying text-only",
@@ -621,9 +649,7 @@ class SlackReplyAdapter:
                 )
                 await client.chat_update(channel=channel, ts=ts, text=text)
 
-        await self._with_transport_fallback(
-            endpoint, op, describe="chat_update(card)"
-        )
+        await self._with_transport_fallback(endpoint, op, describe="chat_update(card)")
 
     async def _set_status(
         self, *, channel: str, thread_ts: str, status: str, endpoint: str | None = None

--- a/apps/worker/tests/test_slack_sink.py
+++ b/apps/worker/tests/test_slack_sink.py
@@ -56,9 +56,7 @@ _ELSEWHERE = "https://slack.com/elsewhere/"
 def _target(
     *, channel: str = "C1", ts: str | None = "1.1", thread: str | None = None
 ) -> ReplyTarget:
-    return ReplyTarget(
-        kind="slack", address=channel, conversation_id=thread, reply_ref=ts
-    )
+    return ReplyTarget(kind="slack", address=channel, conversation_id=thread, reply_ref=ts)
 
 
 def _update(
@@ -274,9 +272,9 @@ def test_update_renders_status_and_link_blocks_for_a_reply() -> None:
     sink._client_for(None).chat_update = _fake_chat_update  # type: ignore[method-assign]
 
     text = (
-        '```curie-reply\n'
+        "```curie-reply\n"
         '{"status": "Working", "text": "body", "links": [["Docs", "https://x/y"]]}\n'
-        '```'
+        "```"
     )
     asyncio.run(_update(sink, text=text))
 
@@ -284,9 +282,7 @@ def test_update_renders_status_and_link_blocks_for_a_reply() -> None:
     assert isinstance(blocks, list)
     assert blocks[0]["type"] == "context"  # status context leads  # type: ignore[index]
     link_actions = [
-        b
-        for b in blocks
-        if b["type"] == "actions" and any("url" in e for e in b["elements"])
+        b for b in blocks if b["type"] == "actions" and any("url" in e for e in b["elements"])
     ]
     assert link_actions, "expected an actions block of URL link buttons"
     assert link_actions[0]["elements"][0]["url"] == "https://x/y"
@@ -305,9 +301,7 @@ def test_update_falls_back_to_text_only_on_slack_api_error() -> None:
     async def _fake_chat_update(**kwargs: object) -> None:
         calls.append(kwargs)
         if "blocks" in kwargs:  # the first (with-blocks) call is rejected
-            raise SlackApiError(
-                "invalid_blocks", {"ok": False, "error": "invalid_blocks"}
-            )
+            raise SlackApiError("invalid_blocks", {"ok": False, "error": "invalid_blocks"})
 
     sink._client_for(None).chat_update = _fake_chat_update  # type: ignore[method-assign]
 
@@ -508,9 +502,7 @@ def test_slack_api_error_not_swallowed_even_with_best_effort() -> None:
     sink._client_for(None).chat_update = _record_call(default_hits, "default")  # type: ignore[method-assign]
 
     with pytest.raises(SlackApiError):
-        asyncio.run(
-            _update(sink, text="hi", endpoint=_STUB, best_effort_unreachable=True)
-        )
+        asyncio.run(_update(sink, text="hi", endpoint=_STUB, best_effort_unreachable=True))
     assert default_hits == [], (
         "a SlackApiError must not fall back to the default, best-effort or not"
     )
@@ -592,13 +584,16 @@ def test_post_renders_the_approval_card_from_a_confirm_intent() -> None:
             channel="C1",
             message=_approval_message("appr-1", "Give ACME a 20% discount"),
             requested_by="U_AE",
-            thread="th-card",
+            # A ts Slack could actually mint. It used to read "th-card", which no
+            # real thread is named; the adapter now refuses a conversation id that
+            # is not a timestamp, because a hook mints one that is not.
+            thread="1787792627.881000",
         )
     )
 
     assert ack.ref == "9.9"
     assert captured["channel"] == "C1"
-    assert captured["thread_ts"] == "th-card"
+    assert captured["thread_ts"] == "1787792627.881000"
     assert "Give ACME a 20% discount" in captured["text"]  # accessibility fallback
     blocks = captured["blocks"]
     assert isinstance(blocks, list)
@@ -665,9 +660,7 @@ def test_update_message_renders_the_expired_card() -> None:
                 version=REPLY_WIRE_VERSION,
                 event="reply.update",
                 target=_target(ts="9.9"),
-                message=OutboundMessage(
-                    version=MESSAGE_VERSION, text="Give ACME a 20% discount"
-                ),
+                message=OutboundMessage(version=MESSAGE_VERSION, text="Give ACME a 20% discount"),
             ),
             route=TargetRoute(),
         )
@@ -727,3 +720,86 @@ def test_best_effort_still_falls_back_to_default_when_present() -> None:
 
     asyncio.run(_update(sink, text="hi", endpoint=_STUB, best_effort_unreachable=True))
     assert landed == ["default"], "the flag must not bypass the #530 default-transport fallback"
+
+
+# --- A triggered turn's conversation id is not a Slack thread (hook delivery) ---
+#
+# `POST /hooks/{agent}/{name}` mints `hook:<agent>:<name>` as the conversation id,
+# deliberately disjoint from Slack thread ids so a hook can never land inside a
+# human conversation. Passing it through as `thread_ts` made Slack refuse the
+# delivery with `invalid_thread_ts` AFTER the turn had already run: the whole
+# investigation happened, cost real money, and the answer was dropped.
+
+
+def _hook_update(sink: SlackReplyAdapter, *, conversation: str | None) -> object:
+    """A placeholder-less reply.update, the shape a triggered turn produces."""
+    return sink.emit(
+        ReplyUpdate(
+            version=REPLY_WIRE_VERSION,
+            event="reply.update",
+            target=ReplyTarget(
+                kind="slack", address="C1", conversation_id=conversation, reply_ref=None
+            ),
+            text="what I found",
+        ),
+        route=TargetRoute(endpoint=None),
+    )
+
+
+def _record_post(sink: SlackReplyAdapter, seen: dict[str, object]) -> None:
+    async def _fake_post(**kwargs: object) -> dict[str, object]:
+        seen.update(kwargs)
+        return {"ts": "9.9"}
+
+    sink._client_for(None).chat_postMessage = _fake_post  # type: ignore[method-assign]
+
+
+@pytest.mark.anyio
+async def test_a_hook_conversation_id_posts_at_channel_level() -> None:
+    sink = SlackReplyAdapter("xoxb-test", base_url=_DEFAULT)
+    seen: dict[str, object] = {}
+    _record_post(sink, seen)
+
+    ack = await _hook_update(sink, conversation="hook:ede69396-9917-4a30-b0af-6a65ccc7b297:alert")
+
+    assert seen["thread_ts"] is None, seen
+    # The minted ts still comes back, so the rest of the turn edits one message.
+    assert ack.ref == "9.9"
+
+
+@pytest.mark.anyio
+async def test_a_slack_thread_ts_still_threads() -> None:
+    sink = SlackReplyAdapter("xoxb-test", base_url=_DEFAULT)
+    seen: dict[str, object] = {}
+    _record_post(sink, seen)
+
+    await _hook_update(sink, conversation="1787792627.881000")
+
+    assert seen["thread_ts"] == "1787792627.881000", seen
+
+
+@pytest.mark.anyio
+async def test_a_hook_conversation_id_does_not_thread_an_approval_card() -> None:
+    # The same coercion sits on the ReplyPost path, which is how an approval card
+    # posts. A hook-triggered gated call would fail to raise its card at all.
+    sink = SlackReplyAdapter("xoxb-test", base_url=_DEFAULT)
+    seen: dict[str, object] = {}
+    _record_post(sink, seen)
+
+    await sink.emit(
+        ReplyPost(
+            version=REPLY_WIRE_VERSION,
+            event="reply.post",
+            target=ReplyTarget(
+                kind="slack",
+                address="C1",
+                conversation_id="hook:ede69396-9917-4a30-b0af-6a65ccc7b297:alert",
+                reply_ref=None,
+            ),
+            message=OutboundMessage(version=MESSAGE_VERSION, text="approve?"),
+            requested_by="U_AE",
+        ),
+        route=TargetRoute(endpoint=None),
+    )
+
+    assert seen["thread_ts"] is None, seen


### PR DESCRIPTION
Found by firing a real hook at a deployed agent, so this starts with what happened rather than with the code.

## The failure

`POST /hooks/{agent_id}/alert` with a Grafana-alert-shaped body was accepted (`200`, `duplicate: false`). The turn then ran a full autonomous investigation — 77 seconds, 24 tool calls across Grafana, Prometheus, Loki and the Kubernetes API — and the answer was dropped:

```
WARNING:curie_worker.kernel:booting-state update failed for hook-<agent>-alert-<digest>
INFO:curie_worker.kernel:claim latency for hook:<agent>:alert: 12329 ms
ERROR:curie_worker.consumer:processing failed for entry <id>; left pending
slack_sdk.errors.SlackApiError: chat.postMessage
  {'ok': False, 'error': 'invalid_thread_ts',
   'messages': ['[ERROR] ... is not a valid thread_ts']}
```

**The work is done and the money is spent before the delivery is attempted**, and the entry is left pending, so a redelivery repeats the whole investigation and fails the same way.

## Cause

`SlackReplyAdapter.emit` passed `ReplyTarget.conversation_id` straight through as `thread_ts`, at three sites.

For a Slack-ingress turn that is correct — the conversation id *is* the parent message's ts, which is why it was written that way. A hook turn's is not. `routers/hooks.py::_conversation_id` mints `hook:<agent>:<name>` and its docstring says why: it is "disjoint from the agent's Slack thread ids, so a hook can never land in the middle of a human conversation."

So the one ingress with no placeholder to edit — the placeholder-less turn the branch's own comment describes and ADR-0079 exists for — is also the one whose reply cannot be posted.

## Fix

Anything that is not a `<seconds>.<micros>` timestamp names no Slack thread. The reply then posts at channel level and the ts it mints becomes the `reply_ref` the rest of the turn edits, which is exactly the path already documented three lines above the call. Applied at all three coercion sites, including the status update that failed on the same delivery with `booting-state update failed`.

Three tests: a hook conversation id posts channel-level and still returns its ts; a real ts still threads; and the `ReplyPost` path gets the same treatment, because a gated call raised *by a hook* would otherwise fail to post its approval card at all. Load-bearing — reverting the guard fails the first and third and leaves the other thirty green.

## Two things worth a reviewer's eye

**I changed an existing fixture.** `test_post_renders_the_approval_card_from_a_confirm_intent` threaded on `"th-card"`, which no real Slack thread is named. It now uses a ts Slack could mint and asserts exactly what it asserted before — same assertion, valid input. I am flagging it because "the test changed" is the shape of a weakened assertion even when it isn't one.

**The discriminator is syntactic, and a semantic one exists.** The real distinction is which ingress minted the id — hook turns already carry `source=WEBHOOK`. The sink cannot see it: `ReplyTarget` carries only kind/address/conversation_id/reply_ref, so threading source through would change `channel-protocol`. The deeper reading is that `conversation_id` is serving two purposes at once — the worker-side thread key that serialises repeat firings, and the channel-side reply target — and only one of them is "in the channel's own terms". If you would rather split that field than shape-check the string, say so and I will do it that way; this fix is the one that does not touch a wire contract.

Base is `main` because the bug is identical on both trains (`hooks.py` and the same three call sites are on `main` and `next`).

Local: ruff and mypy clean, `apps/worker/tests/test_slack_sink.py` 32 passed. Full worker suite 12 failed / 850 passed, against 12 failed / 847 passed on clean `origin/main` — same failures (Valkey-dependent stream tests, dead-letter alerting), plus the three added here.
