### PR TITLE
Publish the sre-bot's write connectors, so its write verbs can actually be deployed

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -456,6 +456,12 @@ jobs:
           - name: sre-bot-tempo
             context: examples/sre-bot/connectors/tempo
             dockerfile: examples/sre-bot/connectors/tempo/Dockerfile
+          - name: sre-bot-k8s-write
+            context: examples/sre-bot/connectors/k8s-write
+            dockerfile: examples/sre-bot/connectors/k8s-write/Dockerfile
+          - name: sre-bot-k8s-scale
+            context: examples/sre-bot/connectors/k8s-scale
+            dockerfile: examples/sre-bot/connectors/k8s-scale/Dockerfile
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -106,7 +106,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        name: [runner, api, dispatcher, mail-adapter, worker, ui, sre-bot-tempo]
+        name: [runner, api, dispatcher, mail-adapter, worker, ui, sre-bot-tempo, sre-bot-k8s-write, sre-bot-k8s-scale]
         platform: [linux/amd64, linux/arm64]
         include:
           - name: runner
@@ -130,6 +130,18 @@ jobs:
           - name: sre-bot-tempo
             context: examples/sre-bot/connectors/tempo
             dockerfile: examples/sre-bot/connectors/tempo/Dockerfile
+          # The bundle's two write connectors. Without a published image a
+          # `build:`-declaring connector is refused at the cluster tier (a
+          # cluster cannot pull an image that exists only in one machine's
+          # Docker daemon), so an unpublished write connector is a write verb
+          # the live bot cannot have -- which is how `k8s-scale` came to be
+          # merged, reviewed, and undeployable.
+          - name: sre-bot-k8s-write
+            context: examples/sre-bot/connectors/k8s-write
+            dockerfile: examples/sre-bot/connectors/k8s-write/Dockerfile
+          - name: sre-bot-k8s-scale
+            context: examples/sre-bot/connectors/k8s-scale
+            dockerfile: examples/sre-bot/connectors/k8s-scale/Dockerfile
           - platform: linux/amd64
             runner: ubuntu-latest
             arch: amd64
@@ -226,7 +238,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        name: [runner, api, dispatcher, mail-adapter, worker, ui, sre-bot-tempo]
+        name: [runner, api, dispatcher, mail-adapter, worker, ui, sre-bot-tempo, sre-bot-k8s-write, sre-bot-k8s-scale]
     steps:
       - name: Download digests
         id: download_digests

--- a/examples/tests/test_build_connectors_are_published.py
+++ b/examples/tests/test_build_connectors_are_published.py
@@ -1,0 +1,86 @@
+"""Every ``build:``-declaring connector in an example bundle has a publish job.
+
+The failure this exists to stop, from the install it actually happened on:
+
+A connector that declares ``build:`` and nothing else has no published image. At
+the skill and local tiers that is fine -- ``curie build`` records a local image id
+and the local daemon has it. At the **cluster** tier it is refused, because a
+cluster cannot pull an image that exists only in one machine's Docker daemon. So
+an unpublished connector is a connector the live bot cannot have, and if that
+connector carries the bundle's write verb, it is a *write verb* the live bot
+cannot have.
+
+``examples/sre-bot``'s ``k8s-scale`` reached `next` merged and reviewed in exactly
+that state: the source, the Dockerfile, the tests and the gate all landed, no
+image was ever published, and the deployed bot answered `restart_deployment`
+alone. Nothing reported it -- a bundle validates, a connector is healthy, and the
+absent second verb looks like a design choice rather than a missing pipeline.
+
+The check is deliberately shallow and cheap: it reads the declaration and the
+release workflow, not a registry. It cannot tell you whether a published image is
+*current*; it tells you whether anything will ever publish one at all, which is
+the failure that stayed invisible.
+
+Naming: connector ``tempo`` in bundle ``sre-bot`` publishes as ``sre-bot-tempo``,
+the convention ``release.yaml``'s matrix already uses.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO = Path(__file__).resolve().parents[2]
+EXAMPLES = REPO / "examples"
+RELEASE_WORKFLOW = REPO / ".github" / "workflows" / "release.yaml"
+
+
+def _published_image_names() -> set[str]:
+    """The image names ``release.yaml`` builds and pushes.
+
+    Read off the matrix's ``include`` entries rather than the ``name:`` list,
+    because an entry in the list with no ``include`` has no build context and so
+    publishes nothing -- the list alone would pass a half-wired addition.
+    """
+
+    workflow = yaml.safe_load(RELEASE_WORKFLOW.read_text(encoding="utf-8"))
+    names: set[str] = set()
+    for job in (workflow.get("jobs") or {}).values():
+        include = (((job.get("strategy") or {}).get("matrix") or {}).get("include")) or []
+        for entry in include:
+            if isinstance(entry, dict) and entry.get("dockerfile") and entry.get("name"):
+                names.add(str(entry["name"]))
+    return names
+
+
+def _build_connectors() -> list[tuple[str, str]]:
+    """``(bundle, connector)`` for every connector declaring ``build:``."""
+
+    found: list[tuple[str, str]] = []
+    for declaration in sorted(EXAMPLES.glob("*/connectors.yaml")):
+        bundle = declaration.parent.name
+        parsed = yaml.safe_load(declaration.read_text(encoding="utf-8")) or {}
+        for name, spec in (parsed.get("connectors") or {}).items():
+            if isinstance(spec, dict) and "build" in spec:
+                found.append((bundle, str(name)))
+    return found
+
+
+def test_the_declaration_and_the_workflow_are_both_readable() -> None:
+    # A guard that silently finds nothing passes vacuously, which is the failure
+    # mode of every check that reads files by glob.
+    assert _build_connectors(), "no build-declaring connectors found: check the glob"
+    assert _published_image_names(), "no publishable images found in release.yaml"
+
+
+@pytest.mark.parametrize("bundle,connector", _build_connectors())
+def test_a_build_declaring_connector_has_a_publish_job(bundle: str, connector: str) -> None:
+    expected = f"{bundle}-{connector}"
+    published = _published_image_names()
+    assert expected in published, (
+        f"{bundle}'s '{connector}' connector declares build: but nothing publishes "
+        f"'{expected}'. Without a published image it cannot be deployed at the "
+        f"cluster tier, so it is a capability the live bot cannot have. Add it to "
+        f"release.yaml's image matrix (both the name list and an include entry "
+        f"naming its context and dockerfile), or drop the connector."
+    )


### PR DESCRIPTION
Answers the **"seems like it has very limited write capabilities"** half of the SRE bot review, and the answer turned out not to be about the bundle.

## What actually limits it

Both write connectors already exist here — `connectors/k8s-write` and `connectors/k8s-scale` — with source, Dockerfile, tests, and declared gates. **Neither has ever been published.**

A connector declaring `build:` and nothing else records a local image id. That is usable at the skill and local tiers and **refused at the cluster tier**, because a cluster cannot pull an image that exists only in one machine's Docker daemon. So an unpublished connector is a capability the live bot cannot have — and when it carries the bundle's write verb, it is a *write verb* the live bot cannot have.

`k8s-scale` reached `next` merged and reviewed in that state. The deployed bot answers `restart_deployment` alone while its second verb sits in the tree, complete and undeployable. Nothing reported it, because there is nothing to report: the bundle validates, the remaining connector is healthy, and the absent verb reads as a design choice rather than a missing pipeline. That is what "very limited write capabilities" was actually looking at.

## The change

`sre-bot-k8s-write` and `sre-bot-k8s-scale` join `release.yaml`'s two image matrices, beside the tempo connector that already publishes, and `ci.yaml`'s build-only validation so a broken Dockerfile fails on the PR instead of at release time.

## And the guard that would have caught it

`examples/tests/test_build_connectors_are_published.py` reads every example bundle's `connectors.yaml` and asserts each `build:`-declaring connector has a publish job.

Two details that make it a guard rather than a formality:

- It matches on the matrix's **`include` entries**, not the `name:` list. An entry in the list with no include has no build context and publishes nothing, so matching the list alone would pass a half-wired addition.
- It fails if the glob finds nothing. A file-discovery check that silently matches zero files passes vacuously, which is how this class of guard usually dies.

It reads files, never a registry, so it cannot tell you whether a published image is *current*. It tells you whether anything will ever publish one at all — which is the part that stayed invisible for both connectors.

Load-bearing: reverting the matrix change fails exactly the two new connectors and leaves the other two assertions green.

## What this does not do, stated so it is not assumed

- **It adds no write verb.** Both verbs were already written; this makes them deployable. A *new* verb (rollback is the obvious next one) needs its own gate, its own allowlist, and its own decision, per `manifests/write-role.yaml`'s reasoning about what `patch` on a Deployment actually grants.
- **It does not make `--write-allowlist` deploy at the cluster tier by itself.** That path (merged in #1923) keeps the connector but leaves its `build:` declaration alone, so the installer still has to resolve a digest the way it already does for tempo. I found that gap while writing this and it is real. It follows once a release has published these images, because a digest cannot be resolved for an image nobody has pushed.
- **It does not answer "can it fully manage the cluster."** That is not a switch; each verb is a connector tool with a constant patch body, its own gate and its own ceiling. Draft ADR-0126 (#1942) proposes making that cost sublinear; this PR is inside today's pattern, which is correct while that ADR is Draft.

Local: ruff and mypy clean, both workflow files parse, `examples/tests` 25 passed.
