### PR TITLE
Narrate automatic gVisor recovery as retrying, not failed

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,9 +186,9 @@ before running it: getting it wrong means deleting the agent and recreating it. 
 
 Plain `cluster up` infers Anthropic or OpenRouter egress from an unambiguous
 credential prefix. On minikube, the first admission attempt reports that its
-`gvisor` RuntimeClass is absent, so Curie applies
-`security.gvisor.mode=off` and retries once. Each inference is printed with the
-equivalent override. Ambiguous credential shapes still need an explicit
+`gvisor` RuntimeClass is absent, so Curie shows that attempt as retrying,
+applies `security.gvisor.mode=off`, and retries once. Each inference is printed
+with the equivalent override. Ambiguous credential shapes still need an explicit
 `--allow-egress-host`, and explicit values that contradict detected facts are
 errors.
 

--- a/cli/src/guide.rs
+++ b/cli/src/guide.rs
@@ -314,7 +314,7 @@ pub fn primer() -> Primer {
             },
             Landmine {
                 title: "Missing gVisor is inferred only from admission",
-                detail: "A real model install first keeps the gVisor chart default. When admission reports exactly that RuntimeClass gvisor is not found, direct `curie cluster up` applies security.gvisor.mode=off, prints the override, and retries once. Other failures remain closed. Explicit auto or require modes contradict the detected result and are errors.",
+                detail: "A real model install first keeps the gVisor chart default. When admission reports exactly that RuntimeClass gvisor is not found, direct `curie cluster up` shows that attempt as retrying, applies security.gvisor.mode=off, prints the override, and retries once. Other failures remain closed. Explicit auto or require modes contradict the detected result and are errors.",
             },
         ],
         recovery: vec![

--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -4850,7 +4850,10 @@ enum GvisorInstallRace {
 
 enum GvisorInstallOutcome {
     Installed,
-    RuntimeClassRejected(String),
+    RuntimeClassRejected {
+        rejection: String,
+        step: crate::ui::Step,
+    },
 }
 
 async fn run_install_with_gvisor_observer(
@@ -4990,8 +4993,7 @@ async fn run_install_with_gvisor_observer(
                 let _ = terminate_process(&mut watch.child).await;
             }
             install.terminate().await;
-            step.fail("failed");
-            Ok(GvisorInstallOutcome::RuntimeClassRejected(rejection))
+            Ok(GvisorInstallOutcome::RuntimeClassRejected { rejection, step })
         }
     }
 }
@@ -5426,10 +5428,11 @@ async fn run_prepared_up(
             .await?;
             match outcome {
                 GvisorInstallOutcome::Installed => {}
-                GvisorInstallOutcome::RuntimeClassRejected(rejection) if detect_facts => {
+                GvisorInstallOutcome::RuntimeClassRejected { rejection, step } if detect_facts => {
                     if let Some(mode @ ("auto" | "require")) =
                         final_operator_value(&opts, GVISOR_MODE_KEY)
                     {
+                        step.fail("failed");
                         let assignment = format!("{GVISOR_MODE_KEY}={mode}");
                         let fix = format!(
                             "remove the explicit `{assignment}` setting and rerun to accept the inferred gVisor posture"
@@ -5440,6 +5443,7 @@ async fn run_prepared_up(
                         .with_fix(fix)
                         .into());
                     }
+                    step.warn("retrying");
                     value_plan.set(GVISOR_MODE_KEY, "off");
                     ClusterUpInference::GvisorOff.render(ui);
                     let retry = up_commands_with_plan(&opts, &value_plan)
@@ -5448,7 +5452,8 @@ async fn run_prepared_up(
                         .expect("cluster up always has one Helm command");
                     run_step(&cl, &label, "installed", &retry).await?;
                 }
-                GvisorInstallOutcome::RuntimeClassRejected(rejection) => {
+                GvisorInstallOutcome::RuntimeClassRejected { rejection, step } => {
+                    step.fail("failed");
                     let fix = "curie cluster up --set security.gvisor.mode=off";
                     return Err(crate::exit::CliError::failure(format!(
                         "gVisor preflight Job `{job}` could not create its pod: {rejection}. To install without gVisor isolation, run `{fix}`."

--- a/cli/src/ui.rs
+++ b/cli/src/ui.rs
@@ -442,11 +442,11 @@ impl Ui {
     }
 
     /// The frozen, styled line a finished interactive step commits.
-    fn step_line(&self, ok: bool, label: &str, detail: &str, elapsed: &str) -> String {
-        let (glyph, style) = if ok {
-            (self.ok_glyph(), self.green())
-        } else {
-            (self.fail_glyph(), self.red())
+    fn step_line(&self, status: StepStatus, label: &str, detail: &str, elapsed: &str) -> String {
+        let (glyph, style) = match status {
+            StepStatus::Ok => (self.ok_glyph(), self.green()),
+            StepStatus::Fail => (self.fail_glyph(), self.red()),
+            StepStatus::Warn => (self.warn_glyph(), self.amber()),
         };
         let mut left = format!("{} {label}", self.paint_err(style, glyph));
         if !detail.is_empty() {
@@ -584,6 +584,12 @@ pub struct Step {
     label: String,
 }
 
+enum StepStatus {
+    Ok,
+    Fail,
+    Warn,
+}
+
 impl Step {
     /// Update the live spinner's "why still waiting" suffix.
     pub fn tick_detail(&self, detail: &str) {
@@ -599,12 +605,18 @@ impl Step {
 
     /// Freeze the step to a success line with an optional detail.
     pub fn done(self, detail: &str) {
-        self.finish(true, detail);
+        self.finish(StepStatus::Ok, detail);
     }
 
     /// Freeze the step to a failure line (also used for timeouts).
     pub fn fail(self, detail: &str) {
-        self.finish(false, detail);
+        self.finish(StepStatus::Fail, detail);
+    }
+
+    /// Freeze the step to an amber recovery line. Used when the first attempt
+    /// is a planned retry rather than a terminal failure.
+    pub fn warn(self, detail: &str) {
+        self.finish(StepStatus::Warn, detail);
     }
 
     /// Clear the step's spinner without committing any line. Used when a spinner
@@ -615,7 +627,7 @@ impl Step {
         }
     }
 
-    fn finish(self, ok: bool, detail: &str) {
+    fn finish(self, status: StepStatus, detail: &str) {
         let elapsed = fmt_elapsed(self.start.elapsed());
         if self.ui.quiet {
             if let Some(pb) = self.pb {
@@ -625,17 +637,19 @@ impl Step {
         }
         match self.pb {
             Some(pb) => {
-                let line = self.ui.step_line(ok, &self.label, detail, &elapsed);
+                let line = self.ui.step_line(status, &self.label, detail, &elapsed);
                 if let Ok(style) = ProgressStyle::with_template("{msg}") {
                     pb.set_style(style);
                 }
                 pb.finish_with_message(line);
             }
             None => {
-                let line = if ok {
-                    format!("{}: ok ({elapsed})", self.label)
-                } else {
-                    format!("{}: failed ({detail}) ({elapsed})", self.label)
+                let line = match status {
+                    StepStatus::Ok => format!("{}: ok ({elapsed})", self.label),
+                    StepStatus::Fail => {
+                        format!("{}: failed ({detail}) ({elapsed})", self.label)
+                    }
+                    StepStatus::Warn => format!("{}: retrying ({elapsed})", self.label),
                 };
                 let _ = writeln!(anstream::stderr(), "{line}");
             }

--- a/cli/tests/cluster_up_gvisor_preflight.rs
+++ b/cli/tests/cluster_up_gvisor_preflight.rs
@@ -591,6 +591,55 @@ fn assert_inference_once(shown: &str, applied_override: &str) {
     );
 }
 
+fn failed_install_line(shown: &str) -> bool {
+    shown
+        .lines()
+        .any(|line| line.contains(&format!("installing release {TARGET_RELEASE}: failed")))
+}
+
+fn retrying_install_line(shown: &str) -> bool {
+    shown
+        .lines()
+        .any(|line| line.contains(&format!("installing release {TARGET_RELEASE}: retrying")))
+}
+
+fn ok_install_line(shown: &str) -> bool {
+    shown
+        .lines()
+        .any(|line| line.contains(&format!("installing release {TARGET_RELEASE}: ok")))
+}
+
+/// Issue #1906: automatic gVisor recovery must narrate the first attempt as
+/// retrying, not as a terminal red failure, and must leave one successful
+/// install result after the retry.
+fn assert_automatic_gvisor_recovery_narration(shown: &str) {
+    assert!(
+        !failed_install_line(shown),
+        "automatic gVisor recovery must not freeze the first install attempt as a terminal failure:\n{shown}"
+    );
+    assert!(
+        retrying_install_line(shown),
+        "the first install attempt must render as retrying after admission rejects gVisor:\n{shown}"
+    );
+    assert_eq!(
+        shown
+            .lines()
+            .filter(|line| line.contains(&format!("installing release {TARGET_RELEASE}: retrying")))
+            .count(),
+        1,
+        "exactly one retrying install attempt:\n{shown}"
+    );
+    assert!(
+        ok_install_line(shown),
+        "the retry must leave one unambiguous installed result:\n{shown}"
+    );
+    assert!(
+        shown.contains("inferred that the cluster has no `gvisor` RuntimeClass from admission")
+            && shown.contains("--set security.gvisor.mode=off"),
+        "recovery must announce the gVisor admission retry with the inferred override:\n{shown}"
+    );
+}
+
 #[test]
 fn bare_cluster_up_infers_all_detected_facts_and_retries_once() {
     let fixture = Fixture::new("matching", "foreign", OPENROUTER_CREDENTIAL);
@@ -619,6 +668,7 @@ fn bare_cluster_up_infers_all_detected_facts_and_retries_once() {
     ] {
         assert_inference_once(&shown, applied);
     }
+    assert_automatic_gvisor_recovery_narration(&shown);
     assert!(
         !shown.contains("DeadlineExceeded"),
         "the later Helm timeout must not become the diagnosis:\n{shown}"
@@ -686,6 +736,7 @@ fn fresh_namespace_rejection_is_observed_after_helm_creates_the_namespace() {
         "the post Helm namespace retry must still beat the fake deadline, elapsed {elapsed:?}\nstderr:\n{shown}"
     );
     assert_inference_once(&shown, "--set security.gvisor.mode=off");
+    assert_automatic_gvisor_recovery_narration(&shown);
     assert!(
         !shown.contains("DeadlineExceeded"),
         "the Helm deadline must not replace the fresh namespace diagnosis:\n{shown}"
@@ -771,6 +822,7 @@ fn bare_cluster_up_json_keeps_inferences_on_stderr_and_one_success_on_stdout() {
     ] {
         assert_inference_once(&shown, applied);
     }
+    assert_automatic_gvisor_recovery_narration(&shown);
     assert_eq!(fixture.upgrade_count(), 2);
     fixture.assert_event_was_observed_for_rendered_job();
     fixture.assert_graceful_helm_interruption();
@@ -805,6 +857,14 @@ fn explicit_gvisor_mode_contradicting_admission_is_rejected_before_retry() {
             !shown.contains("--set security.gvisor.mode=off"),
             "the explicit value must not be silently overridden: {shown}"
         );
+        assert!(
+            failed_install_line(&shown),
+            "an explicit contradiction is a terminal failure, not recovery:\n{shown}"
+        );
+        assert!(
+            !retrying_install_line(&shown),
+            "an explicit contradiction must not narrate a retry:\n{shown}"
+        );
         fixture.assert_graceful_helm_interruption();
         fixture.assert_children_stopped();
     }
@@ -831,6 +891,14 @@ fn prepared_apply_keeps_the_exact_gvisor_rejection_fail_closed() {
     assert!(
         !shown.contains("inferred that the cluster has no"),
         "prepared apply must not infer a posture: {shown}"
+    );
+    assert!(
+        failed_install_line(&shown),
+        "prepared apply must keep the first attempt as a terminal failure:\n{shown}"
+    );
+    assert!(
+        !retrying_install_line(&shown),
+        "prepared apply must not narrate automatic recovery:\n{shown}"
     );
     assert_eq!(fixture.upgrade_count(), 1, "prepared apply must not retry");
     fixture.assert_graceful_helm_interruption();

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -18,7 +18,7 @@ Targets, see the target comparison table in the
 |---|---|
 | `kubectl` and `helm` on PATH | Every `cluster` verb wraps one or both of them. |
 | A reachable cluster | Every verb talks to the cluster's Kubernetes API server directly -- there's nothing to install onto or inspect without one. The chart's own preflights additionally need the `agents.x-k8s.io` Agent Sandbox CRDs (Custom Resource Definitions) installable and a NetworkPolicy-enforcing CNI (Container Network Interface) already present; see `charts/curie/README.md`. |
-| `runsc` (gVisor) on every node for full kernel isolation | A real model first installs with gVisor enabled. If admission reports exactly that the `gvisor` RuntimeClass is absent, plain `cluster up` applies `security.gvisor.mode=off` and retries once. Other preflight failures remain closed. Fake model installs do not need it. |
+| `runsc` (gVisor) on every node for full kernel isolation | A real model first installs with gVisor enabled. If admission reports exactly that the `gvisor` RuntimeClass is absent, plain `cluster up` shows that attempt as retrying, applies `security.gvisor.mode=off`, and retries once. Other preflight failures remain closed. Fake model installs do not need it. |
 
 **For testing**, pick between **k3s**, **kind**, and **minikube** based on
 your host and how disposable the cluster needs to be. A single-node **k3s**
@@ -151,11 +151,13 @@ the detected owner is a usage error.
 
 The first gVisor preflight keeps the chart default. Only the exact admission
 result `RuntimeClass "gvisor" not found` authorizes
-`security.gvisor.mode=off` and one retry. An explicit `auto` or `require` mode
-contradicts that result and errors. Other admission failures and an unavailable
-event watch remain closed. Curie prints one standard error line for every
-inference, including the equivalent override. Prepared `apply` and `diff`
-paths do not infer live cluster facts.
+`security.gvisor.mode=off` and one retry. That first attempt renders as
+retrying, not as a failed install; the retry is the one installed or failed
+result. An explicit `auto` or `require` mode contradicts that result and
+errors. Other admission failures and an unavailable event watch remain closed.
+Curie prints one standard error line for every inference, including the
+equivalent override. Prepared `apply` and `diff` paths do not infer live
+cluster facts.
 
 ### `curie cluster status`
 

--- a/docs/your-first-slack-agent.md
+++ b/docs/your-first-slack-agent.md
@@ -74,7 +74,8 @@ curie cluster deploy --plugin-dir . --namespace my-agent --release my-agent \
 
 The plain install reads the exported `sk-ant-` credential and infers Anthropic
 egress. If admission reports that the cluster has no `gvisor` RuntimeClass,
-Curie applies `security.gvisor.mode=off` and retries once. It also reuses
+Curie shows that attempt as retrying, applies `security.gvisor.mode=off`, and
+retries once. It also reuses
 PriorityClasses and the sandbox controller when their complete Helm ownership
 metadata names an existing release. Every applied inference is printed with
 its equivalent override.


### PR DESCRIPTION
## Summary

`curie cluster up` still infers `security.gvisor.mode=off` from the exact gVisor RuntimeClass admission rejection and retries once. The first attempt no longer freezes as a red terminal Helm failure. It renders as retrying, then the existing inference line, then one installed or failed result.

Fail-closed paths stay failures: prepared `apply` and an explicit `auto`/`require` still freeze `failed` and do not retry.

## Related issue

Closes #1906

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | Does not reach plugin packaging, the runner turn loop, ACI events, skill eval, or skill check. | | |
| local | n/a | Does not reach compose services, dispatcher, worker, API wiring, console UI, or a `--json` stdout shape. `cluster up --json` success remains `{status, namespace, release}`. | | |
| local-release | n/a | Does not change released binary identity, the install path, version pins, or release compose. | | |
| cluster | required | The change is `curie cluster up` Helm-install recovery narration on the cluster operator verb. | fake | `cd cli && cargo test --test cluster_up_gvisor_preflight` at `ca9b86d0`. Observed: installing release target-release: retrying (0.2s); inferred that the cluster has no gvisor RuntimeClass from admission; applying --set security.gvisor.mode=off; installing release target-release: ok (1.0s). Suite 9 passed. |
| live provider | n/a | Does not reach model routing, credential resolution, provider auth, or token/cost accounting. | | |
| external integration | n/a | Does not reach Slack, git push webhooks, connector OAuth, or a third-party API shape. | | |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.

Positive proof: the PATH-stubbed `curie cluster up` binary test (real CLI, fake helm/kubectl) shows retrying then the inference then ok.

Falsifiable negative: `prepared_apply_keeps_the_exact_gvisor_rejection_fail_closed` and `explicit_gvisor_mode_contradicting_admission_is_rejected_before_retry` still emit `installing release target-release: failed` and do not emit `: retrying`.

Red-on-revert: `curie dev verify-fix-pin HEAD cli/tests/cluster_up_gvisor_preflight.rs::bare_cluster_up_infers_all_detected_facts_and_retries_once` printed `PINNED` (baseline green; reversing product files restored `installing release target-release: failed (failed) (0.2s)`).

Sibling paths: automatic recovery (`detect_facts`) vs prepared apply vs `--json` stderr. JSON keeps inferences on stderr and one success object on stdout.

No frozen-contract, schema, or ADR change. ADR 0114 still owns the retry; this only changes the first-attempt checklist status. #1815 preserved-mode wording is unchanged.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed.
- [ ] An ADR is added under `docs/adr/` if this is an architectural decision.

Validation:
- `cd cli && cargo fmt --check && cargo clippy -- -D warnings`
- `cd cli && cargo test --test cluster_up_gvisor_preflight`
- `cd cli && cargo test --test cluster_up_inference`
- `cd cli && cargo test --test guide`
- `bash scripts/check-docs.sh`
- `scripts/check-commit-messages.sh origin/main..HEAD`
