### PR TITLE
Release eval-owned sandboxes and fail quota claims promptly

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -335,6 +335,12 @@ Known seam pairs:
   `APPROVE_ACTION_ID_PREFIX` (`cli/src/chat.rs`) can't share code across
   Python/Rust, so they are frozen together in
   `tests/vectors/approval-action-ids.json`.
+- API vs worker vs CLI thread-reset SET -- `THREAD_RESET_SET` /
+  `THREAD_RESET_INFLIGHT_SET` (`apps/api/src/curie_api/threadreset.py`,
+  `apps/worker/src/curie_worker/consumer.py`) and the CLI's `THREAD_RESET_SET`
+  (`cli/src/queue.rs`) can't share code across Python/Rust. Operator
+  `reset-thread` and `local`/`cluster` eval (#1534) both SADD the same set.
+  Frozen in `tests/vectors/thread-reset-set.json`.
 - real SDK vs fake model session in the runner (`FakeModelSession`, `runner/src/curie_runner/fake.py`).
 - runs lane vs eval lane stream consumers (`apps/worker/src/curie_worker/consumer.py` vs `eval/stream.py`, both on the shared `stream_consumer.py`).
 - CLI-side vs API-side input validation (validate at the API/persistence boundary, mirror in the CLI).

--- a/apps/api/src/curie_api/threadreset.py
+++ b/apps/api/src/curie_api/threadreset.py
@@ -30,6 +30,7 @@ before -- and independent of whether -- the release actually completed.
 
 import redis.asyncio as redis
 
+# Frozen with the worker and CLI copies in tests/vectors/thread-reset-set.json.
 THREAD_RESET_SET = "curie:thread-reset-requests"
 
 # Claimed-but-not-yet-released requests (#812). The worker SPOPs a request off

--- a/apps/api/tests/test_thread_reset_vector.py
+++ b/apps/api/tests/test_thread_reset_vector.py
@@ -1,0 +1,25 @@
+"""API half of the frozen thread-reset SET vector (#1534)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from curie_api.threadreset import THREAD_RESET_INFLIGHT_SET, THREAD_RESET_SET
+
+_VECTOR = (
+    Path(__file__).resolve().parents[3] / "tests" / "vectors" / "thread-reset-set.json"
+)
+_EXPECTED_KEYS = {"comment", "thread_reset_set", "thread_reset_inflight_set"}
+
+
+def test_thread_reset_keys_match_the_frozen_vector() -> None:
+    parsed = json.loads(_VECTOR.read_text())
+    unknown = set(parsed) - _EXPECTED_KEYS
+    assert not unknown, (
+        f"unknown keys in tests/vectors/thread-reset-set.json: {sorted(unknown)}. "
+        "Teach them to this test, apps/worker/tests/test_thread_reset_vector.py, "
+        "and the CLI queue.rs vector test."
+    )
+    assert parsed["thread_reset_set"] == THREAD_RESET_SET
+    assert parsed["thread_reset_inflight_set"] == THREAD_RESET_INFLIGHT_SET

--- a/apps/worker/src/curie_worker/consumer.py
+++ b/apps/worker/src/curie_worker/consumer.py
@@ -64,9 +64,13 @@ _CAP_SCAN_PAGE = 1000
 
 # An operator-requested thread reset (#713): the API SADDs a thread_key here
 # (`apps/api/src/curie_api/threadreset.py`) and the maintenance tick SPOPs
-# it to force-release that thread's sandbox. Not a stream -- a one-shot
-# administrative signal has no ordering/redelivery/dead-letter needs, so a
-# plain Valkey SET is enough.
+# it to force-release that thread's sandbox. `curie local eval` /
+# `curie cluster eval` SADDs each eval-owned conversation_id onto the same
+# set (#1534) so the next turn's `_handle` (and the tick) release that
+# case's sandbox instead of pinning quota until routeTtlSeconds. Frozen
+# with the CLI copy in tests/vectors/thread-reset-set.json. Not a stream --
+# a one-shot administrative signal has no ordering/redelivery/dead-letter
+# needs, so a plain Valkey SET is enough.
 THREAD_RESET_SET = "curie:thread-reset-requests"
 
 # Claimed-but-not-yet-released thread-reset requests (#812). The drain SPOPs a
@@ -228,6 +232,21 @@ class Consumer(StreamConsumer):
                 )
                 return
             try:
+                # Eval (and operator reset-thread) SADDs onto THREAD_RESET_SET
+                # when a sandbox should be released. Drain those before this
+                # turn claims so a following eval case or cluster message does
+                # not wait the 30s maintenance tick with the quota already
+                # full (#1534). A failed drain (including SCARD) must not fail
+                # the turn; remaining keys are picked up by the next _handle
+                # or the maintenance tick.
+                try:
+                    if await self._valkey.scard(THREAD_RESET_SET):
+                        await self._drain_thread_reset_requests()
+                except Exception:
+                    logger.exception(
+                        "thread-reset drain before turn %s failed; continuing",
+                        entry_id,
+                    )
                 await self._kernel.process_event(qevent)
             except Exception:
                 # Leave the entry pending: XAUTOCLAIM will reclaim and retry.

--- a/apps/worker/src/curie_worker/sandbox/substrate.py
+++ b/apps/worker/src/curie_worker/sandbox/substrate.py
@@ -346,10 +346,21 @@ class SandboxSubstrate:
     def _await_bound(self, claim_name: str, deadline: float) -> str:
         last_quota_rejection = None
         last_ready_condition: tuple[str | None, str | None] | None = None
+        consecutive_quota = 0
         while time.monotonic() < deadline:
             claim = self._k8s.get_claim(claim_name)
             if claim is not None:
                 last_quota_rejection = claim.quota_rejection
+                if claim.quota_rejection is not None:
+                    consecutive_quota += 1
+                    # Two observations is the debounce: a single-poll blip can
+                    # still bind (#1572 transient-clear), but a persisting
+                    # ResourceQuota rejection is terminal now rather than after
+                    # claim_timeout_seconds (#1534).
+                    if consecutive_quota >= 2:
+                        raise CapacityExhaustedError(claim.quota_rejection)
+                else:
+                    consecutive_quota = 0
                 if claim.ready_reason is not None or claim.ready_message is not None:
                     last_ready_condition = (claim.ready_reason, claim.ready_message)
                 if claim.ready and claim.sandbox_name:

--- a/apps/worker/tests/kernel/test_consumer.py
+++ b/apps/worker/tests/kernel/test_consumer.py
@@ -20,6 +20,7 @@ from curie_worker.consumer import (
     THREAD_RESET_SET,
     Consumer,
 )
+from curie_worker.sandbox import QuotaRejection
 
 DONE = SessionStatus.DONE
 
@@ -228,6 +229,76 @@ def test_reclaims_and_reprocesses_a_dead_consumers_pending_entry(make_harness) -
             assert h.runner.opened == ["orphan"]
             summary = await h.async_redis.xpending(h.config.stream, h.config.consumer_group)
             assert summary["pending"] == 0  # reclaimed entry acked after reprocessing
+
+    asyncio.run(go())
+
+
+def test_next_turn_drains_queued_eval_reset_before_claiming(make_harness) -> None:
+    """#1534: eval-owned sandboxes are SADDed onto THREAD_RESET_SET after each
+    case. The next runs-lane turn must release them before it claims, so a
+    following eval case or cluster message does not wait for the 30s
+    maintenance tick (or the 90s claim timeout) with the quota already full.
+    """
+
+    async def go() -> None:
+        async with make_harness() as h:
+            h.runner.default_script = [Final(text="hi", status=DONE)]
+            await h.kernel.process_event(_qevent("eval-case-1", thread="tEval1"))
+            assert h.substrate.lookup("tEval1") is not None
+
+            await h.async_redis.sadd(THREAD_RESET_SET, "tEval1")
+            consumer = Consumer(redis=h.async_redis, kernel=h.kernel, config=h.config)
+            await consumer.ensure_group()
+            nxt = _qevent("eval-case-2", thread="tEval2", event_id="eval-2")
+            entry_id = await h.async_redis.xadd(h.config.stream, to_stream_fields(nxt))
+            await consumer._sem.acquire()
+            await consumer._handle(entry_id, to_stream_fields(nxt))
+
+            assert h.substrate.lookup("tEval1") is None
+            assert h.substrate.lookup("tEval2") is not None
+            assert await h.async_redis.scard(THREAD_RESET_SET) == 0
+            assert not await h.async_redis.sismember(THREAD_RESET_INFLIGHT_SET, "tEval1")
+
+    asyncio.run(go())
+
+
+def test_next_turn_drains_reset_before_claiming_when_quota_is_full(make_harness) -> None:
+    """#1534: drain must run BEFORE the follow-up claim. If it ran after
+    process_event, tEval2 would see ResourceQuota still full (tEval1 still
+    holding the slot), raise CapacityExhaustedError, and never bind.
+    """
+
+    async def go() -> None:
+        async with make_harness(claim_timeout_seconds=0.2) as h:
+            h.runner.default_script = [Final(text="hi", status=DONE)]
+            await h.kernel.process_event(_qevent("eval-case-1", thread="tEval1"))
+            assert h.substrate.lookup("tEval1") is not None
+
+            h.fake_k8s.quota_rejection = QuotaRejection(
+                quota_name="curie-sandbox-quota",
+                resource="limits.cpu",
+                requested="1",
+                used="8",
+                hard="8",
+            )
+            original_delete = h.fake_k8s.delete_claim
+
+            def delete_and_free(name: str) -> None:
+                original_delete(name)
+                h.fake_k8s.quota_rejection = None
+
+            h.fake_k8s.delete_claim = delete_and_free  # type: ignore[method-assign]
+
+            await h.async_redis.sadd(THREAD_RESET_SET, "tEval1")
+            consumer = Consumer(redis=h.async_redis, kernel=h.kernel, config=h.config)
+            await consumer.ensure_group()
+            nxt = _qevent("eval-case-2", thread="tEval2", event_id="eval-2-quota")
+            entry_id = await h.async_redis.xadd(h.config.stream, to_stream_fields(nxt))
+            await consumer._sem.acquire()
+            await consumer._handle(entry_id, to_stream_fields(nxt))
+
+            assert h.substrate.lookup("tEval1") is None
+            assert h.substrate.lookup("tEval2") is not None
 
     asyncio.run(go())
 

--- a/apps/worker/tests/sandbox/test_substrate.py
+++ b/apps/worker/tests/sandbox/test_substrate.py
@@ -89,9 +89,14 @@ def test_claim_timeout_cleans_up_claim(
     assert affinity.get("T1") is None
 
 
-def test_quota_rejection_waits_for_deadline_and_cleans_up_claim(
+def test_quota_rejection_fails_promptly_and_cleans_up_claim(
     fake_k8s: FakeSandboxClient, affinity: AffinityStore, config: SubstrateConfig
 ) -> None:
+    """#1534: a persisting ResourceQuota rejection is terminal at the next
+    poll, not after claim_timeout_seconds. One extra poll is the debounce so a
+    single-blip rejection can still bind (see
+    test_transient_quota_rejection_can_clear_before_claim_binds)."""
+
     rejection = QuotaRejection(
         quota_name="curie-sandbox-quota",
         resource="limits.cpu",
@@ -117,15 +122,14 @@ def test_quota_rejection_waits_for_deadline_and_cleans_up_claim(
         return view
 
     fake_k8s.get_claim = get_claim_with_updated_rejection  # type: ignore[method-assign]
-    short_config = replace(config, claim_timeout_seconds=0.05)
-    substrate = SandboxSubstrate(fake_k8s, affinity, short_config)
+    substrate = SandboxSubstrate(fake_k8s, affinity, config)
 
     started = time.monotonic()
     with pytest.raises(CapacityExhaustedError) as excinfo:
         substrate.claim("T1")
     elapsed = time.monotonic() - started
 
-    assert elapsed >= short_config.claim_timeout_seconds
+    assert elapsed < 20 * config.poll_interval_seconds
     assert excinfo.value.rejection == rejection
     assert excinfo.value.rejection.quota_name == "curie-sandbox-quota"
     assert excinfo.value.rejection.resource == "limits.cpu"

--- a/apps/worker/tests/test_thread_reset_vector.py
+++ b/apps/worker/tests/test_thread_reset_vector.py
@@ -1,0 +1,25 @@
+"""Worker half of the frozen thread-reset SET vector (#1534)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from curie_worker.consumer import THREAD_RESET_INFLIGHT_SET, THREAD_RESET_SET
+
+_VECTOR = (
+    Path(__file__).resolve().parents[3] / "tests" / "vectors" / "thread-reset-set.json"
+)
+_EXPECTED_KEYS = {"comment", "thread_reset_set", "thread_reset_inflight_set"}
+
+
+def test_thread_reset_keys_match_the_frozen_vector() -> None:
+    parsed = json.loads(_VECTOR.read_text())
+    unknown = set(parsed) - _EXPECTED_KEYS
+    assert not unknown, (
+        f"unknown keys in tests/vectors/thread-reset-set.json: {sorted(unknown)}. "
+        "Teach them to this test, apps/api/tests/test_thread_reset_vector.py, "
+        "and the CLI queue.rs vector test."
+    )
+    assert parsed["thread_reset_set"] == THREAD_RESET_SET
+    assert parsed["thread_reset_inflight_set"] == THREAD_RESET_INFLIGHT_SET

--- a/cli/scripts/e2e-ladder.sh
+++ b/cli/scripts/e2e-ladder.sh
@@ -1136,12 +1136,12 @@ print("yes" if isinstance(d, dict) and d.get("release_found") is True else "no")
 
     echo
     echo "=== curie cluster eval --dry-run (suite parity) ==="
-    # ONE array feeding BOTH cluster eval calls (this dry-run plan and the live
-    # grade below), so `--listen-host` cannot reach one and be forgotten on the
-    # other. `--json` is deliberately NOT in the array: both call sites need it
-    # for DIFFERENT reasons -- a machine-readable `--dry-run` plan here, an
-    # auditable green on the live grade below -- and passing it once per call site
-    # is what keeps it from being passed twice at either.
+    # ONE array feeding every cluster eval call (the dry-run plan, the live
+    # grade, and the #1534 retention pair), so `--listen-host` cannot reach one
+    # and be forgotten on another. `--json` is deliberately NOT in the array:
+    # call sites need it for DIFFERENT reasons -- a machine-readable `--dry-run`
+    # plan here, an auditable green on the live/retention grades -- and passing
+    # it once per call site is what keeps it from being passed twice at any.
     local eval_args=(cluster eval)
     if [[ ! -f "$WORKDIR/bundle/evals/trajectory.json" ]]; then
         eval_args+=(--cases "$WORKDIR/bundle/evals/cases.json")
@@ -1178,6 +1178,35 @@ print("yes" if isinstance(d, dict) and d.get("release_found") is True else "no")
             echo "cluster: eval reported a failing case. Not failing the rung: this rung's grade is report only (#1603)." >&2
         fi
     fi
+
+    echo
+    echo "=== #1534 repeated cluster eval then message still claims ==="
+    # Eval-owned sandboxes must be released on every suite path so a second
+    # suite, then an ordinary message, can still claim against the default
+    # 8-CPU ResourceQuota instead of waiting the 90s claim timeout.
+    local eval_i
+    for eval_i in 1 2; do
+        echo "=== curie cluster eval (retention suite $eval_i of 2; report only) ==="
+        if ! (cd "$WORKDIR/bundle" && "$BIN" --json "${eval_args[@]}"); then
+            echo "cluster: retention eval suite $eval_i reported a failing case. Not failing the rung: this rung's grade is report only (#1603)." >&2
+        fi
+    done
+    local retention_args=(--json cluster message "$PROMPT")
+    if [[ -n "${CURIE_E2E_LISTEN_HOST:-}" ]]; then
+        retention_args+=(--listen-host "$CURIE_E2E_LISTEN_HOST")
+    fi
+    echo "=== curie cluster message after repeated eval ==="
+    local retention_out retention_rc
+    set +e
+    retention_out="$(timeout 45 "$BIN" "${retention_args[@]}")"
+    retention_rc=$?
+    set -e
+    printf '%s\n' "$retention_out"
+    if [[ "$retention_rc" -eq 124 ]]; then
+        echo "cluster: message after repeated eval timed out at 45s; eval-owned sandboxes likely still hold the quota (#1534)." >&2
+        return 1
+    fi
+    assert_finalized_reply "cluster" "$retention_out"
 
     assert_bundle_identity "cluster" "$digest"
 }

--- a/cli/src/message.rs
+++ b/cli/src/message.rs
@@ -39,7 +39,7 @@ use crate::chat::{
 };
 use crate::evals::{EvalCase, EvalSuite, ExpectedStatus, LoadedEval};
 use crate::ops::{plain, require_on_path, run_capture, OpsCommand};
-use crate::queue::{self, connect, diagnostics, synthetic_turn, xadd};
+use crate::queue::{self, connect, diagnostics, queue_thread_reset, synthetic_turn, xadd};
 use crate::state::{save_turn, TurnContext, TurnVerb};
 
 pub const DEFAULT_STREAM: &str = queue::DEFAULT_STREAM;
@@ -2907,56 +2907,71 @@ async fn run_eval_turns(
     let total = suite.cases.len();
     let bar = ui.progress_bar(total as u64, "running evals");
     let mut results: Vec<crate::commands::EvalRow> = Vec::with_capacity(total);
-    for case in &suite.cases {
-        // Each case is its own thread so turns never cross-talk on the stub.
-        let (channel_id, thread_ts, placeholder_ts) = resolve_targets(Some(channel), None);
-        let reply_endpoint = stub.base_api_url().to_string();
-        let event = synthetic_turn(
-            "slack",
-            &channel_id,
-            &opts.user,
-            &case.input,
-            &thread_ts,
-            &placeholder_ts,
-            Some(reply_endpoint),
-        );
-        let started = Instant::now();
-        let stream_id = xadd(conn, &opts.stream, &event).await?;
-        let outcome = await_reply(
-            stub,
-            conn,
-            &opts.stream,
-            &stream_id,
-            &placeholder_ts,
-            Duration::from_secs(opts.timeout_secs),
-        )
-        .await;
-        let elapsed = started.elapsed().as_secs_f64();
-        // Carry the reply text (#548) so a red case is diagnosable from --json /
-        // the human summary; a non-Replied outcome has no gradeable text.
-        let output = match &outcome {
-            Outcome::Replied(reply) => reply.clone(),
-            Outcome::AwaitingApproval(reply) => reply.clone().unwrap_or_default(),
-            Outcome::CompletedNoEdit => String::new(),
-            // A timed-out case surfaces the stream/consumer diagnostics the same
-            // way the non-eval message path does (#706), so the failure is not a
-            // silent empty string but the stream state that explains it.
-            Outcome::TimedOut => diagnostics(conn, &opts.stream, &stream_id).await,
-        };
-        results.push((
-            case.id.clone(),
-            if reply_passes(case, &outcome) {
-                crate::evals::CaseOutcome::Pass
-            } else {
-                crate::evals::CaseOutcome::Fail
-            },
-            elapsed,
-            output,
-        ));
-        bar.inc(1);
+    let mut eval_threads: Vec<String> = Vec::with_capacity(total);
+    let run = async {
+        for case in &suite.cases {
+            // Each case is its own thread so turns never cross-talk on the stub.
+            let (channel_id, thread_ts, placeholder_ts) = resolve_targets(Some(channel), None);
+            eval_threads.push(thread_ts.clone());
+            let reply_endpoint = stub.base_api_url().to_string();
+            let event = synthetic_turn(
+                "slack",
+                &channel_id,
+                &opts.user,
+                &case.input,
+                &thread_ts,
+                &placeholder_ts,
+                Some(reply_endpoint),
+            );
+            let started = Instant::now();
+            let stream_id = xadd(conn, &opts.stream, &event).await?;
+            let outcome = await_reply(
+                stub,
+                conn,
+                &opts.stream,
+                &stream_id,
+                &placeholder_ts,
+                Duration::from_secs(opts.timeout_secs),
+            )
+            .await;
+            // Release this case's sandbox on every completed/red/timed-out
+            // path so a three-case suite run twice cannot pin eight
+            // curie-thread-* claims against the default ResourceQuota (#1534).
+            queue_thread_reset(conn, &thread_ts).await?;
+            let elapsed = started.elapsed().as_secs_f64();
+            // Carry the reply text (#548) so a red case is diagnosable from --json /
+            // the human summary; a non-Replied outcome has no gradeable text.
+            let output = match &outcome {
+                Outcome::Replied(reply) => reply.clone(),
+                Outcome::AwaitingApproval(reply) => reply.clone().unwrap_or_default(),
+                Outcome::CompletedNoEdit => String::new(),
+                // A timed-out case surfaces the stream/consumer diagnostics the same
+                // way the non-eval message path does (#706), so the failure is not a
+                // silent empty string but the stream state that explains it.
+                Outcome::TimedOut => diagnostics(conn, &opts.stream, &stream_id).await,
+            };
+            results.push((
+                case.id.clone(),
+                if reply_passes(case, &outcome) {
+                    crate::evals::CaseOutcome::Pass
+                } else {
+                    crate::evals::CaseOutcome::Fail
+                },
+                elapsed,
+                output,
+            ));
+            bar.inc(1);
+        }
+        anyhow::Ok(crate::commands::EvalReport::from_rows(results))
+    };
+    let result = run.await;
+    // Suite error/cancel: still queue every case we enqueued, including the
+    // in-flight one, so an abandoned retry cannot bind a late sandbox.
+    for thread_ts in &eval_threads {
+        let _ = queue_thread_reset(conn, thread_ts).await;
     }
     bar.finish();
-    Ok(crate::commands::EvalReport::from_rows(results))
+    result
 }
 
 /// The shared `eval` handler: run the bundle's `evals/cases.json` through the
@@ -3790,6 +3805,21 @@ mod tests {
     #[test]
     fn an_empty_thread_normalizes_to_no_thread() {
         assert_eq!(normalize_thread(Some(String::new())), None);
+    }
+
+    #[test]
+    fn eval_turns_queue_thread_reset_on_case_and_suite_paths() {
+        // AC1 is the SADD sites in run_eval_turns, not queue_thread_reset
+        // itself. Deleting either call keeps the helper test green.
+        let src = include_str!("message.rs");
+        assert!(
+            src.contains("queue_thread_reset(conn, &thread_ts)"),
+            "each eval case must queue its conversation_id for sandbox release"
+        );
+        assert!(
+            src.contains("for thread_ts in &eval_threads"),
+            "suite error/cancel must still queue every enqueued eval thread"
+        );
     }
 
     /// The filter must not eat a real thread ts, and an already-absent thread

--- a/cli/src/queue.rs
+++ b/cli/src/queue.rs
@@ -29,6 +29,9 @@ pub const DEFAULT_VALKEY_URL: &str = "redis://:valkeypass@localhost:26379";
 /// The worker's consumer group (CURIE_CONSUMER_GROUP default); used to detect
 /// completion (the worker acks an entry only after the turn finalizes).
 pub const WORKER_GROUP: &str = WORKER_GROUP_DEFAULT;
+/// Valkey SET the API, worker, and CLI share for thread-reset requests.
+/// Frozen in `tests/vectors/thread-reset-set.json` (#1534).
+pub const THREAD_RESET_SET: &str = "curie:thread-reset-requests";
 
 /// Prefix on the synthetic event id so dedupe can never collide with a real
 /// Slack event id (which are `Ev...`, not `EvSIM-...`).
@@ -135,6 +138,22 @@ pub async fn xadd(
         .await
         .with_context(|| format!("XADD onto {stream}"))?;
     Ok(stream_id)
+}
+
+/// Queue `thread_key` for a forced sandbox release on the worker's next drain
+/// (`THREAD_RESET_SET`, the same SET `reset-thread` uses). Idempotent.
+///
+/// `curie local eval` / `curie cluster eval` call this after every case so
+/// eval-owned `curie-thread-*` sandboxes do not pin quota until
+/// `routeTtlSeconds` (#1534).
+pub async fn queue_thread_reset(conn: &mut MultiplexedConnection, thread_key: &str) -> Result<()> {
+    let _: i32 = redis::cmd("SADD")
+        .arg(THREAD_RESET_SET)
+        .arg(thread_key)
+        .query_async(conn)
+        .await
+        .with_context(|| format!("SADD {THREAD_RESET_SET} {thread_key}"))?;
+    Ok(())
 }
 
 /// The Valkey stream id of the first entry whose decoded `QueuedTurn` carries
@@ -561,5 +580,32 @@ mod tests {
         assert!(!id_ge("4-9", "5-0"));
         // Unparseable compares false (not-yet-delivered).
         assert!(!id_ge("0-0", "not-an-id"));
+    }
+
+    #[derive(serde::Deserialize)]
+    #[serde(deny_unknown_fields)]
+    struct ThreadResetVector {
+        #[serde(rename = "comment")]
+        _comment: String,
+        thread_reset_set: String,
+        thread_reset_inflight_set: String,
+    }
+
+    #[test]
+    fn thread_reset_set_matches_the_frozen_vector() {
+        let raw = include_str!("../../tests/vectors/thread-reset-set.json");
+        let parsed: ThreadResetVector = serde_json::from_str(raw).unwrap_or_else(|err| {
+            panic!(
+                "parse tests/vectors/thread-reset-set.json: {err}\n\
+                 An unknown field is rejected on purpose: a key this lane cannot see \
+                 would pass vacuously. Teach the new key to ThreadResetVector here \
+                 and to _EXPECTED_KEYS in the API and worker vector tests."
+            )
+        });
+        assert_eq!(parsed.thread_reset_set, THREAD_RESET_SET);
+        assert_eq!(
+            parsed.thread_reset_inflight_set,
+            "curie:thread-reset-inflight"
+        );
     }
 }

--- a/cli/tests/eval_thread_reset.rs
+++ b/cli/tests/eval_thread_reset.rs
@@ -1,0 +1,36 @@
+//! Integration: eval-owned sandbox release queues onto the frozen thread-reset
+//! SET against real Valkey (#1534).
+
+use curie::queue::{queue_thread_reset, THREAD_RESET_SET};
+
+mod support;
+use support::{unique_stream, valkey_or_skip};
+
+#[tokio::test]
+async fn queue_thread_reset_sadds_the_frozen_set() {
+    let Some(mut conn) = valkey_or_skip("queue_thread_reset_sadds_the_frozen_set").await else {
+        return;
+    };
+    let thread_key = unique_stream("eval-thread-");
+    queue_thread_reset(&mut conn, &thread_key)
+        .await
+        .expect("SADD thread-reset request");
+
+    let is_member: bool = redis::cmd("SISMEMBER")
+        .arg(THREAD_RESET_SET)
+        .arg(&thread_key)
+        .query_async(&mut conn)
+        .await
+        .expect("SISMEMBER");
+    assert!(
+        is_member,
+        "eval-owned conversation {thread_key} must land on {THREAD_RESET_SET}"
+    );
+
+    let _: i32 = redis::cmd("SREM")
+        .arg(THREAD_RESET_SET)
+        .arg(&thread_key)
+        .query_async(&mut conn)
+        .await
+        .expect("cleanup SREM");
+}

--- a/cli/tests/nightly_graded_ladder.rs
+++ b/cli/tests/nightly_graded_ladder.rs
@@ -405,6 +405,28 @@ fn live_cluster_rung_emits_the_graded_reply_for_passing_cases() {
     );
 }
 
+#[test]
+fn cluster_rung_repeats_eval_then_messages_inside_claim_timeout() {
+    let text = ladder();
+    assert!(
+        text.contains("#1534 repeated cluster eval then message still claims"),
+        "the cluster rung must run repeated eval suites then a message so \
+         retained eval sandboxes cannot exhaust the default ResourceQuota; \
+         ladder contents:\n{text}"
+    );
+    assert!(
+        text.contains(r#"timeout 45 "$BIN" "${retention_args[@]}""#),
+        "the post-eval message must be bounded well inside the 90s claim \
+         timeout; a hang until ClaimTimeoutError is the #1534 failure; \
+         ladder contents:\n{text}"
+    );
+    assert!(
+        text.contains(r#"assert_finalized_reply "cluster" "$retention_out""#),
+        "the post-eval message must still finalize a reply, proving a normal \
+         turn can claim after repeated evals; ladder contents:\n{text}"
+    );
+}
+
 // --- Assertion group 6: the EXECUTING parity controls -----------------------
 //
 // Everything below runs the real `cli/scripts/e2e-ladder.sh` against a stub
@@ -938,7 +960,7 @@ fn ladder_selects_platform_trajectory_eval_without_overriding_deployed_cases() {
         .lines()
         .filter(|line| line.contains("local eval") || line.contains("cluster eval"))
         .collect::<Vec<_>>();
-    assert_eq!(trajectory_evals.len(), 4, "{trajectory_invocations}");
+    assert_eq!(trajectory_evals.len(), 6, "{trajectory_invocations}");
     assert!(
         trajectory_evals
             .iter()
@@ -979,7 +1001,7 @@ fn ladder_selects_platform_trajectory_eval_without_overriding_deployed_cases() {
         .lines()
         .filter(|line| line.contains("local eval") || line.contains("cluster eval"))
         .collect::<Vec<_>>();
-    assert_eq!(ordinary_evals.len(), 4, "{ordinary_invocations}");
+    assert_eq!(ordinary_evals.len(), 6, "{ordinary_invocations}");
     assert!(
         ordinary_evals.iter().all(|line| line.contains("--cases")),
         "ordinary eval must retain its explicit cases path: {ordinary_invocations}"

--- a/tests/vectors/thread-reset-set.json
+++ b/tests/vectors/thread-reset-set.json
@@ -1,0 +1,5 @@
+{
+  "comment": "Single source of truth for the thread-reset Valkey SET the API, worker, and CLI share. The API SADDs an operator reset (`apps/api/src/curie_api/threadreset.py`), the worker drains it (`apps/worker/src/curie_worker/consumer.py`), and `curie local eval` / `curie cluster eval` SADDs each eval-owned conversation_id onto the same set so the next turn (or the maintenance tick) releases that case's sandbox (#1534). The three lanes cannot share code across Python/Rust, so the literals are frozen here: changing one language without this file fails that language's test. Read by apps/api/tests/test_thread_reset_vector.py, apps/worker/tests/test_thread_reset_vector.py, and the test module in cli/src/queue.rs. Both keys are asserted; an unknown top-level key is rejected so a new key one lane cannot see cannot pass vacuously.",
+  "thread_reset_set": "curie:thread-reset-requests",
+  "thread_reset_inflight_set": "curie:thread-reset-inflight"
+}


### PR DESCRIPTION
## Summary

Repeated `curie cluster eval` cases each kept a `curie-thread-*` sandbox for the full route TTL, so a few suites filled the default 8-CPU ResourceQuota. Later evals and `cluster message` then waited the full 90-second claim timeout, and a quota refusal that was already visible on the claim could still retry into a late sandbox after old claims were deleted.

This change does three things, without implementing Draft ADR-0109 (no admission queue, no idle-route reclaim, no ACI field):

- Fail a claim as soon as ResourceQuota rejection persists for two polls, instead of after `claimTimeoutSeconds`.
- Have `local`/`cluster` eval SADD each case's conversation id onto the existing thread-reset SET, and drain that set before the next runs-lane turn claims.
- Repeat cluster eval in the parity ladder, then bound the follow-up message well inside the 90s timeout.

Ordinary `CapacityExhaustedError` turns were already `terminal_ok=True` (acked, not pending). That path is unchanged in `kernel.py`.

## Related issue

Closes #1534

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | skill eval drives the local runner over ACI HTTP and does not create thread SandboxClaims or hit ResourceQuota | | |
| local | required | `local eval` shares `run_eval_turns` with cluster eval | fake | `cargo test --test eval_thread_reset` at a4af4f04: `queue_thread_reset_sadds_the_frozen_set ... ok`. Negative: omitting the SADD sites fails `eval_turns_queue_thread_reset_on_case_and_suite_paths`. |
| local-release | n/a | no released binary, image identity, install path, or release-compose change | | |
| cluster | required | the defect is cluster ResourceQuota exhaustion from retained `curie-thread-*` claims | fake | `uv run pytest -q apps/worker/tests/kernel/test_consumer.py::test_next_turn_drains_reset_before_claiming_when_quota_is_full` at a4af4f04: pass. Quota stays full until tEval1 is deleted, then tEval2 binds. Negative: drain-after-claim would leave tEval2 unbound. Live cluster deploy of this worker image onto the shared k8scratch release was not run. |
| live provider | n/a | does not touch model routing, credential resolution, provider auth, or token/cost accounting | | |
| external integration | n/a | does not touch Slack, git webhooks, connector OAuth, or third-party API shape | | |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.

### Acceptance criteria

1. Eval-owned sandboxes released on completed/red/canceled suite paths. Positive: CLI SADDs each case onto `THREAD_RESET_SET`; next `_handle` drains before claim. Negative: `test_next_turn_drains_reset_before_claiming_when_quota_is_full` fails if drain runs after claim.
2. Observed quota rejection returns promptly. Positive: `test_quota_rejection_fails_promptly_and_cleans_up_claim` elapsed `< 20 * poll_interval` (was a full 2.0s deadline). Negative: `test_transient_quota_rejection_can_clear_before_claim_binds` still binds after a single-poll blip.
3. Terminal quota failures do not remain pending. Positive: existing `test_quota_capacity_is_terminal_without_retry_or_runner_turn` (`done_key` exists, no retry). Prompt-fail keeps raising `CapacityExhaustedError` so that path still acks.
4. Repeated eval then a message can still claim. Positive: e2e-ladder cluster rung runs two evals then `timeout 45` message. Negative: the quota-full drain-before-claim test is the economics proof; weather is one case so the live ladder cannot fill 8 CPU by itself.

## Bounded defaults

- Two consecutive quota observations (one poll interval) is "prompt", not a 90s wait and not fail-on-first-poll.
- The last eval sandbox is released on the next runs-lane turn or the 30s maintenance tick, not by a new pubsub.
- No `TurnSource.EVAL` (frozen contract). No `kernel.py` edit. ADR-0109 stays Draft.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed.
- [ ] An ADR is added under `docs/adr/` if this is an architectural decision.

A general fix on `main`. After merge, a forward-merge PR of `main` into `next` is the usual follow-up; this PR does not cherry-pick.
