### PR TITLE
Reap cluster eval port-forwards before a red exit

### DIFF
--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -2658,10 +2658,10 @@ export const commandManifest = {
             },
             {
               "default_values": [
-                "8155"
+                "0"
               ],
               "global": false,
-              "help": "Port the stub binds (0.0.0.0); the worker posts here",
+              "help": "Port the stub binds (0.0.0.0); the worker posts here. Default 0 lets the kernel assign an ephemeral port",
               "id": "listen_port",
               "long": "listen-port",
               "positional": false,
@@ -2669,10 +2669,10 @@ export const commandManifest = {
             },
             {
               "default_values": [
-                "56381"
+                "0"
               ],
               "global": false,
-              "help": "Local port the Valkey port-forward binds",
+              "help": "Local port the Valkey port-forward binds. Default 0 lets kubectl assign an ephemeral local port",
               "id": "valkey_local_port",
               "long": "valkey-local-port",
               "positional": false,
@@ -2689,10 +2689,10 @@ export const commandManifest = {
             },
             {
               "default_values": [
-                "8123"
+                "0"
               ],
               "global": false,
-              "help": "Local port the API port-forward binds (default-channel lookup)",
+              "help": "Local port the API port-forward binds (default-channel lookup). Default 0 is kernel-assigned, matching `cluster message`",
               "id": "api_local_port",
               "long": "api-local-port",
               "positional": false,

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -2655,10 +2655,10 @@
             },
             {
               "default_values": [
-                "8155"
+                "0"
               ],
               "global": false,
-              "help": "Port the stub binds (0.0.0.0); the worker posts here",
+              "help": "Port the stub binds (0.0.0.0); the worker posts here. Default 0 lets the kernel assign an ephemeral port",
               "id": "listen_port",
               "long": "listen-port",
               "positional": false,
@@ -2666,10 +2666,10 @@
             },
             {
               "default_values": [
-                "56381"
+                "0"
               ],
               "global": false,
-              "help": "Local port the Valkey port-forward binds",
+              "help": "Local port the Valkey port-forward binds. Default 0 lets kubectl assign an ephemeral local port",
               "id": "valkey_local_port",
               "long": "valkey-local-port",
               "positional": false,
@@ -2686,10 +2686,10 @@
             },
             {
               "default_values": [
-                "8123"
+                "0"
               ],
               "global": false,
-              "help": "Local port the API port-forward binds (default-channel lookup)",
+              "help": "Local port the API port-forward binds (default-channel lookup). Default 0 is kernel-assigned, matching `cluster message`",
               "id": "api_local_port",
               "long": "api-local-port",
               "positional": false,

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -2629,7 +2629,7 @@ pub async fn eval(
     .await?;
     bar.finish();
 
-    report_eval(&results, bundle_digest.as_deref())
+    report_eval(&results, bundle_digest.as_deref(), ())
 }
 
 /// Whether the runner `skill eval` is about to drive is the fake. Learned from
@@ -3247,7 +3247,12 @@ pub fn report_sweep(rows: &[SweepRow], bundle_digest: Option<&str>) -> Result<()
 /// graded is confirmable from the machine surface. Callers pass `None` when no
 /// locally snapshotted bundle applies (the local/cluster tiers grade a deployed
 /// version), never a digest they did not observe.
-pub fn report_eval(report: &EvalReport, bundle_digest: Option<&str>) -> Result<()> {
+///
+/// `guards` are dropped before a red eval's non-unwinding `process::exit`
+/// (#1908). `std::process::exit` does not run Drop, so a `kubectl port-forward`
+/// child or Slack stub still in the caller's scope would otherwise be orphaned
+/// onto PID 1. Callers with no such resource pass `()`.
+pub fn report_eval<G>(report: &EvalReport, bundle_digest: Option<&str>, guards: G) -> Result<()> {
     let (_passed, failed, _plumbing_ok) = eval_counts(&report.rows);
     // Emit through the one success point (#474), then apply the exit-code side
     // effect for BOTH paths -- the json path had it inline, the human path after.
@@ -3258,7 +3263,7 @@ pub fn report_eval(report: &EvalReport, bundle_digest: Option<&str>) -> Result<(
         bundle_digest,
     });
     if failed > 0 {
-        std::process::exit(crate::exit::ExitClass::Failure.code());
+        crate::exit::exit_after_drop(crate::exit::ExitClass::Failure, guards);
     }
     Ok(())
 }

--- a/cli/src/exit.rs
+++ b/cli/src/exit.rs
@@ -43,6 +43,17 @@ impl ExitClass {
     }
 }
 
+/// Exit the process with `class` after dropping `guards` first.
+///
+/// `std::process::exit` does not unwind the stack, so any `Drop` impl still in
+/// scope at the call site -- a `kubectl port-forward` child, a Slack stub
+/// listener -- would otherwise never run. Taking `guards` by value makes the
+/// drop-then-exit ordering structural (#751, #766, #1908).
+pub fn exit_after_drop<T>(class: ExitClass, guards: T) -> ! {
+    drop(guards);
+    std::process::exit(class.code());
+}
+
 /// A tagged CLI error: a message, an optional actionable fix hint, and the exit
 /// class it maps to. Carried through `anyhow`'s chain so [`classify`] can recover
 /// the class even when the error was wrapped in later context.

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1729,10 +1729,12 @@ enum ClusterAction {
         #[arg(long)]
         listen_host: Option<String>,
         /// Port the stub binds (0.0.0.0); the worker posts here.
-        #[arg(long, default_value_t = message::DEFAULT_LISTEN_PORT)]
+        /// Default 0 lets the kernel assign an ephemeral port.
+        #[arg(long, default_value_t = 0)]
         listen_port: u16,
         /// Local port the Valkey port-forward binds.
-        #[arg(long, default_value_t = message::DEFAULT_VALKEY_LOCAL_PORT)]
+        /// Default 0 lets kubectl assign an ephemeral local port.
+        #[arg(long, default_value_t = 0)]
         valkey_local_port: u16,
         /// Valkey password. Omit to read the release's own password from its
         /// chart Secret. Prefer the CURIE_VALKEY_PASSWORD env var over passing
@@ -1746,7 +1748,8 @@ enum ClusterAction {
         )]
         valkey_password: Option<String>,
         /// Local port the API port-forward binds (default-channel lookup).
-        #[arg(long, default_value_t = message::DEFAULT_API_LOCAL_PORT)]
+        /// Default 0 is kernel-assigned, matching `cluster message`.
+        #[arg(long, default_value_t = 0)]
         api_local_port: u16,
         /// Platform API key for the default-channel lookup. Omit to read the
         /// release's own key from its chart Secret.
@@ -4287,6 +4290,70 @@ mod tests {
             }) => {
                 assert_eq!(api_key, Some("K".to_string()));
                 assert_eq!(valkey_password, Some("P".to_string()));
+            }
+            _ => panic!("expected cluster eval command"),
+        }
+    }
+
+    /// #1908: a red cluster eval used to leak a kubectl child bound to the
+    /// fixed 56381 default, so the next eval selected that same occupied port.
+    /// Omitted eval ports must request kernel-assigned 0, matching `cluster
+    /// message` (#1652 / #1740).
+    #[test]
+    fn cluster_eval_omitted_ports_default_to_ephemeral() {
+        let cli =
+            Cli::try_parse_from(["curie", "cluster", "eval"]).expect("cluster eval should parse");
+        match cli.command {
+            Some(Command::Cluster {
+                action:
+                    ClusterAction::Eval {
+                        listen_port,
+                        valkey_local_port,
+                        api_local_port,
+                        ..
+                    },
+            }) => {
+                assert_eq!(listen_port, 0, "an omitted --listen-port must request 0");
+                assert_eq!(
+                    valkey_local_port, 0,
+                    "an omitted --valkey-local-port must request 0"
+                );
+                assert_eq!(
+                    api_local_port, 0,
+                    "an omitted --api-local-port must request 0"
+                );
+            }
+            _ => panic!("expected cluster eval command"),
+        }
+    }
+
+    #[test]
+    fn cluster_eval_preserves_explicit_port_overrides() {
+        let cli = Cli::try_parse_from([
+            "curie",
+            "cluster",
+            "eval",
+            "--listen-port",
+            "18155",
+            "--valkey-local-port",
+            "18156",
+            "--api-local-port",
+            "18157",
+        ])
+        .expect("cluster eval with explicit ports should parse");
+        match cli.command {
+            Some(Command::Cluster {
+                action:
+                    ClusterAction::Eval {
+                        listen_port,
+                        valkey_local_port,
+                        api_local_port,
+                        ..
+                    },
+            }) => {
+                assert_eq!(listen_port, 18155);
+                assert_eq!(valkey_local_port, 18156);
+                assert_eq!(api_local_port, 18157);
             }
             _ => panic!("expected cluster eval command"),
         }

--- a/cli/src/message.rs
+++ b/cli/src/message.rs
@@ -1761,7 +1761,7 @@ async fn message_local(opts: MessageOpts) -> Result<()> {
                         // listener is torn down before exit rather than leaked
                         // (#751).
                         ResumeExit::Transient => {
-                            exit_after_drop(crate::exit::ExitClass::Transient, stub);
+                            crate::exit::exit_after_drop(crate::exit::ExitClass::Transient, stub);
                         }
                     }
                 }
@@ -1781,7 +1781,7 @@ async fn message_local(opts: MessageOpts) -> Result<()> {
                     persist_and_hint(&opts, TurnVerb::Local, &channel, &thread_ts);
                     // Drop the Slack stub first so its listener is not leaked past
                     // this non-unwinding exit (#751).
-                    exit_after_drop(crate::exit::ExitClass::Transient, stub);
+                    crate::exit::exit_after_drop(crate::exit::ExitClass::Transient, stub);
                 }
             }
         }
@@ -1886,28 +1886,6 @@ enum ResumeExit {
     /// is retryable: the caller drops its port-forward guards and exits with the
     /// transient class.
     Transient,
-}
-
-/// Exit the process with `class`, after dropping `guards` first.
-///
-/// `std::process::exit` does not unwind the stack, so any `Drop` impl still in
-/// scope at the call site -- the Slack stub's listener/server task
-/// ([`SlackStub`](crate::chat::SlackStub)), a `kubectl port-forward` child --
-/// would otherwise never run, leaking whatever it holds (#751: a timed-out
-/// `local message`/`cluster message` used to leak the stub's bound port this
-/// way, wedging every subsequent turn with "Address already in use").
-///
-/// Every exit site in this module that needs to tear down a guard before
-/// exiting routes through here instead of calling `std::process::exit`
-/// directly: `guards` is taken BY VALUE, so the compiler forces the caller to
-/// move ownership in (a `SlackStub`, a `tokio::process::Child`, or a tuple of
-/// several) rather than merely borrowing it, and this function drops it before
-/// the process actually exits. That makes the guard-then-exit ordering
-/// structural rather than something a future call site has to remember to do
-/// by hand.
-fn exit_after_drop<T>(class: crate::exit::ExitClass, guards: T) -> ! {
-    drop(guards);
-    std::process::exit(class.code());
 }
 
 /// Keep the reply stub alive after a turn parked awaiting approval and wait for
@@ -2596,7 +2574,7 @@ pub async fn message(mut opts: MessageOpts) -> Result<()> {
                             // orphaning the `kubectl port-forward` child to init
                             // (#766).
                             stub_trust.restore().await?;
-                            exit_after_drop(
+                            crate::exit::exit_after_drop(
                                 crate::exit::ExitClass::Transient,
                                 (stub, _valkey_pf, stub_trust),
                             );
@@ -2619,7 +2597,7 @@ pub async fn message(mut opts: MessageOpts) -> Result<()> {
                     });
                     persist_and_hint(&opts, TurnVerb::Cluster, &channel, &thread_ts);
                     stub_trust.restore().await?;
-                    exit_after_drop(
+                    crate::exit::exit_after_drop(
                         crate::exit::ExitClass::Transient,
                         (stub, _valkey_pf, stub_trust),
                     );
@@ -2649,7 +2627,10 @@ pub async fn message(mut opts: MessageOpts) -> Result<()> {
             // failure. Drop the Valkey port-forward now, for the same
             // non-unwinding reason as the stub above (#766).
             stub_trust.restore().await?;
-            exit_after_drop(crate::exit::ExitClass::Transient, (_valkey_pf, stub_trust));
+            crate::exit::exit_after_drop(
+                crate::exit::ExitClass::Transient,
+                (_valkey_pf, stub_trust),
+            );
         }
     }
 }
@@ -3460,7 +3441,7 @@ async fn eval_trajectory_platform(opts: EvalOpts, suite: EvalSuite) -> Result<()
         if let Some(report) =
             trajectory_matrix_report(&matrix, &triggered.sha, &triggered.stream_id)?
         {
-            return crate::commands::report_eval(&report, None);
+            return crate::commands::report_eval(&report, None, _api_pf);
         }
         if Instant::now() >= deadline {
             bail!(
@@ -3679,7 +3660,7 @@ async fn eval_local(opts: EvalOpts, suite: EvalSuite) -> Result<()> {
     ui.note(&format!("routing to channel {channel}"));
 
     let results = run_eval_turns(&opts, &channel, &suite, &mut conn, &mut stub).await?;
-    crate::commands::report_eval(&results, None)
+    crate::commands::report_eval(&results, None, stub)
 }
 
 /// Whether a surfaced enqueue/await error looks like a timeout or a stalled
@@ -3790,7 +3771,9 @@ async fn eval_cluster(opts: EvalOpts, suite: EvalSuite) -> Result<()> {
         Ok(results) => results,
         Err(err) => return Err(enrich_cluster_enqueue_timeout(err).await),
     };
-    crate::commands::report_eval(&results, None)
+    // report_eval process::exits on a red suite without unwinding, so the
+    // Valkey forward and stub must move in as guards (#1908).
+    crate::commands::report_eval(&results, None, (_valkey_pf, stub))
 }
 
 #[cfg(test)]

--- a/cli/tests/eval_portforward_cleanup.rs
+++ b/cli/tests/eval_portforward_cleanup.rs
@@ -1,0 +1,159 @@
+//! #1908: a red `cluster eval` must reap its kubectl Valkey port-forward
+//! before `report_eval` takes the non-unwinding Failure exit.
+//!
+//! `std::process::exit` skips Drop, so a live `kill_on_drop` child left in
+//! scope at that call is orphaned onto PID 1 and keeps its local port. The
+//! next eval then selects the leaked port and fails before it can run. This
+//! regression drives the real red-eval exit through a fake kubectl subprocess
+//! and asserts the child is gone and its port is immediately reusable.
+
+use std::fs;
+use std::net::TcpListener;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+use curie::commands::{report_eval, EvalReport};
+use curie::evals::CaseOutcome;
+use curie::message::{port_forward_command, start_port_forward};
+
+const CHILD_FLAG: &str = "CURIE_TEST_RED_EVAL_REAP";
+const META_FLAG: &str = "CURIE_TEST_RED_EVAL_META";
+const KUBECTL_FLAG: &str = "CURIE_TEST_RED_EVAL_KUBECTL";
+
+fn write_fake_kubectl(dir: &Path) -> PathBuf {
+    let path = dir.join("kubectl");
+    let body = r#"#!/usr/bin/env python3
+import socket
+import sys
+
+mapping = sys.argv[-1]
+requested, remote = mapping.split(":", 1)
+listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+listener.bind(("127.0.0.1", int(requested)))
+listener.listen()
+assigned = listener.getsockname()[1]
+print(f"Forwarding from 127.0.0.1:{assigned} -> {remote}", flush=True)
+while True:
+    connection, _ = listener.accept()
+    connection.close()
+"#;
+    fs::write(&path, body).expect("write fake kubectl");
+    let mut permissions = fs::metadata(&path)
+        .expect("read fake kubectl metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&path, permissions).expect("make fake kubectl executable");
+    path
+}
+
+fn wait_until_released(port: u16) {
+    let deadline = Instant::now() + Duration::from_secs(3);
+    loop {
+        if let Ok(listener) = TcpListener::bind(("127.0.0.1", port)) {
+            drop(listener);
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "the red-eval Failure exit must release assigned port {port}"
+        );
+        std::thread::sleep(Duration::from_millis(25));
+    }
+}
+
+fn pid_is_alive(pid: u32) -> bool {
+    let Ok(status) = std::fs::read_to_string(format!("/proc/{pid}/status")) else {
+        return false;
+    };
+    status.lines().any(|line| {
+        line.starts_with("State:") && (line.contains("(running)") || line.contains("(sleeping)"))
+    })
+}
+
+fn wait_until_dead(pid: u32) {
+    let deadline = Instant::now() + Duration::from_secs(3);
+    loop {
+        if !pid_is_alive(pid) {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "the kubectl child {pid} must be reaped, not orphaned onto PID 1"
+        );
+        std::thread::sleep(Duration::from_millis(25));
+    }
+}
+
+async fn run_red_eval_child() {
+    let kubectl = PathBuf::from(std::env::var(KUBECTL_FLAG).expect("child kubectl path"));
+    let meta = PathBuf::from(std::env::var(META_FLAG).expect("child meta path"));
+    let mut cmd = port_forward_command("acme-system", "acme-release", "valkey", 0, 6379);
+    cmd.program = kubectl.to_string_lossy().into_owned();
+    let (child, port) = start_port_forward(&cmd, 0, "valkey")
+        .await
+        .expect("start fake kubectl port-forward");
+    let pid = child.id().expect("kubectl child pid");
+    fs::write(&meta, format!("pid={pid}\nport={port}\n")).expect("write child meta");
+    let report = EvalReport::from_rows(vec![("one".into(), CaseOutcome::Fail, 0.1, "red".into())]);
+    // The production red-eval path: emit the completed report, then Failure-exit
+    // while this function still owns the kubectl child. Passing the child in is
+    // what makes Drop run before process::exit.
+    let _ = report_eval(&report, None, child);
+    panic!("report_eval must process::exit on a red eval");
+}
+
+#[tokio::test]
+async fn red_cluster_eval_exit_reaps_kubectl_child_and_frees_its_port() {
+    if std::env::var(CHILD_FLAG).as_deref() == Ok("1") {
+        run_red_eval_child().await;
+        panic!("child must process::exit");
+    }
+
+    let dir = tempfile::tempdir().expect("create fake kubectl directory");
+    let kubectl = write_fake_kubectl(dir.path());
+    let meta = dir.path().join("meta.txt");
+    let exe = std::env::current_exe().expect("test executable");
+    let output = Command::new(&exe)
+        .args([
+            "--exact",
+            "red_cluster_eval_exit_reaps_kubectl_child_and_frees_its_port",
+        ])
+        .env(CHILD_FLAG, "1")
+        .env(META_FLAG, &meta)
+        .env(KUBECTL_FLAG, &kubectl)
+        .output()
+        .expect("run red-eval child");
+    assert_eq!(
+        output.status.code(),
+        Some(curie::exit::ExitClass::Failure.code()),
+        "a red eval must still exit Failure; stdout: {}; stderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let meta_text = fs::read_to_string(&meta).expect("child must record pid and port before exit");
+    let mut pid = None;
+    let mut port = None;
+    for line in meta_text.lines() {
+        if let Some(value) = line.strip_prefix("pid=") {
+            pid = Some(value.parse::<u32>().expect("pid"));
+        }
+        if let Some(value) = line.strip_prefix("port=") {
+            port = Some(value.parse::<u16>().expect("port"));
+        }
+    }
+    let pid = pid.expect("child meta pid");
+    let port = port.expect("child meta port");
+    assert_ne!(port, 0, "kubectl must report its assigned port");
+    wait_until_dead(pid);
+    wait_until_released(port);
+}
+
+#[test]
+fn a_green_eval_report_returns_ok_without_exiting() {
+    let report = EvalReport::from_rows(vec![("one".into(), CaseOutcome::Pass, 0.1, "ok".into())]);
+    report_eval(&report, None, ()).expect("a green eval must return Ok rather than process::exit");
+}

--- a/cli/tests/message_ephemeral_ports.rs
+++ b/cli/tests/message_ephemeral_ports.rs
@@ -30,6 +30,45 @@ fn cluster_message_dry_run(extra: &[&str]) -> String {
     format!("{stdout}\n{stderr}")
 }
 
+fn write_eval_cases(dir: &Path) -> PathBuf {
+    let path = dir.join("cases.json");
+    fs::write(
+        &path,
+        r#"{"name":"smoke","cases":[{"id":"one","input":"hi","grader":{"kind":"contains","expected":"hi"}}]}"#,
+    )
+    .expect("write eval cases");
+    path
+}
+
+fn cluster_eval_dry_run(extra: &[&str]) -> String {
+    let dir = tempfile::tempdir().expect("create eval cases directory");
+    let cases = write_eval_cases(dir.path());
+    let output = Command::new(bin())
+        .args(["cluster", "eval"])
+        .args(extra)
+        .args([
+            "--cases",
+            cases.to_str().expect("cases path is utf-8"),
+            "--listen-host",
+            "127.0.0.1",
+            "--channel",
+            "C0EXAMPLE1",
+            "--dry-run",
+        ])
+        .current_dir(concat!(env!("CARGO_MANIFEST_DIR"), "/.."))
+        .env_remove("CURIE_API_KEY")
+        .env_remove("CURIE_VALKEY_PASSWORD")
+        .output()
+        .expect("run cluster eval dry run");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "cluster eval dry run must succeed; stdout: {stdout}; stderr: {stderr}"
+    );
+    format!("{stdout}\n{stderr}")
+}
+
 fn write_fake_kubectl(dir: &Path, name: &str, readiness_host: &str) -> PathBuf {
     let path = dir.join(name);
     let body = r#"#!/usr/bin/env python3
@@ -142,6 +181,43 @@ fn cluster_message_preserves_explicit_port_overrides() {
     assert!(
         plan.contains("kubectl -n curie port-forward svc/curie-api 18157:8000"),
         "the explicit API local port must remain exact: {plan}"
+    );
+    assert!(
+        plan.contains("stub advertised at http://127.0.0.1:18155/api/"),
+        "the explicit listen port must remain exact: {plan}"
+    );
+}
+
+#[test]
+fn cluster_eval_uses_ephemeral_defaults() {
+    let plan = cluster_eval_dry_run(&[]);
+    assert!(
+        plan.contains("kubectl -n curie port-forward svc/curie-valkey 0:6379"),
+        "an omitted Valkey local port must request zero: {plan}"
+    );
+    assert!(
+        !plan.contains("56381:6379"),
+        "cluster eval must not select the historical fixed Valkey port: {plan}"
+    );
+    assert!(
+        plan.contains("stub advertised at http://127.0.0.1:0/api/"),
+        "an omitted listen port must request zero: {plan}"
+    );
+}
+
+#[test]
+fn cluster_eval_preserves_explicit_port_overrides() {
+    let plan = cluster_eval_dry_run(&[
+        "--listen-port",
+        "18155",
+        "--valkey-local-port",
+        "18156",
+        "--api-local-port",
+        "18157",
+    ]);
+    assert!(
+        plan.contains("kubectl -n curie port-forward svc/curie-valkey 18156:6379"),
+        "the explicit Valkey local port must remain exact: {plan}"
     );
     assert!(
         plan.contains("stub advertised at http://127.0.0.1:18155/api/"),


### PR DESCRIPTION
## Summary

A red `cluster eval` used to call `report_eval`, which `process::exit`s on any failed case without unwinding. That skipped Drop on the Valkey `kubectl port-forward` child, orphaned it onto PID 1, and left the next eval to select the leaked port (historically 56381) and fail before running.

`report_eval` now takes Drop guards and routes the Failure exit through the same `exit_after_drop` helper the message path already uses, so the Valkey child (and the Slack stub) are reaped before the process exits. `cluster eval` omitted listen/Valkey/API ports now request kernel-assigned 0, matching `cluster message`. Explicit port flags stay exact. A red eval still prints its completed results and exits Failure.

## Related issue

Closes #1908

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | No plugin packaging, runner turn loop, ACI, or skill eval/check change. skill eval only passes `()` into `report_eval`. | | |
| local | required | `curie cluster eval` CLI verb: dry-run port defaults, and red-eval kubectl child lifecycle. | fake | Commit `b63e86a715c0157e9304e4f00056b6787151ce5b`. `cargo test --test eval_portforward_cleanup -- --exact red_cluster_eval_exit_reaps_kubectl_child_and_frees_its_port` passed: Failure exit 1, fake kubectl PID gone, port reusable. Green path `a_green_eval_report_returns_ok_without_exiting` returned Ok. `cargo run -- cluster eval --cases <tmp>/cases.json --listen-host 127.0.0.1 --channel C0EXAMPLE1 --dry-run` printed `kubectl -n curie port-forward svc/curie-valkey 0:6379`. |
| local-release | n/a | No released binary identity, install path, version pin, or release compose. | | |
| cluster | n/a | No chart, RBAC, sandbox claim, or init-container change. The ticket specifies a fake kubectl subprocess. | | |
| live provider | n/a | No model routing, credentials, or token accounting. | | |
| external integration | n/a | No Slack, git webhook, or third-party API shape. | | |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.

Positive / negative per AC:

- Red eval still prints results and exits Failure: subprocess test observed exit code 1 and the eval table; green `report_eval` returns Ok without exiting.
- Port-forward child reaped before that exit: fake kubectl PID left the running state and its port bound immediately; the pre-fix path left PPID 1 holding 56381 forever.
- Default port is kernel-assigned: dry-run omitted ports print `0:6379` and listen `:0`; `--valkey-local-port 18156` still prints `18156:6379`.

## Checklist

- [x] Tests pass for the area I touched (`cd cli && cargo fmt --check && cargo clippy -- -D warnings && cargo test --lib --bin curie --test eval_portforward_cleanup --test message_ephemeral_ports --test command_surface --test json_emit_contract`).
- [x] Docs updated if behavior changed. Clap help and the committed command manifest / UI mirror were regenerated. No ADR.
- [x] An ADR is added under `docs/adr/` if this is an architectural decision. Not applicable: this reuses the existing guard-before-exit invariant.
