### PR TITLE
Harden the OTEL Collector destination and durable delivery

### DIFF
--- a/charts/curie/README.md
+++ b/charts/curie/README.md
@@ -152,39 +152,34 @@ API, dispatcher, worker, and runner emit OTLP traces, correlated logs, and
 low-cardinality metrics to the **collector**, never directly to Langfuse or a
 log/metrics backend. The in-chart collector receives gRPC on
 `curie-otel-collector:4317` and HTTP on `:4318`. Applications use standard
-`OTEL_EXPORTER_OTLP_*` settings; with `otelCollector.deploy: false`, the chart
-omits its in-cluster endpoint and the operator supplies an external collector
-endpoint through the application's normal OTEL environment configuration.
-The four workload override paths are `api.extraEnv`, `dispatcher.extraEnv`,
-`worker.extraEnv`, and `agentSandbox.runner.extraEnv`. They accept complete
-Kubernetes `EnvVar` entries, including `valueFrom`, so an external endpoint can
-use standard OTEL configuration without copying authentication headers into
-Helm values:
+`OTEL_EXPORTER_OTLP_*` settings. The chart owns one destination for every
+instrumented workload:
+
+- `otelCollector.deploy: true` (default) wires the in-cluster collector.
+- `otelCollector.deploy: false` plus `otelCollector.endpoint` wires an
+  external collector, with optional `protocol`, `headers`, or
+  `headersExistingSecret`.
+- `otelCollector.telemetryDisabled: true` is the explicit no-OTLP
+  acknowledgement. `security.checkDefaultCredentials` refuses a production
+  render that has neither a chart collector nor an external endpoint unless
+  this flag is set.
+- Outside that production gate, `deploy: false` with an empty endpoint remains
+  the supported local/offline no-endpoint mode: SDK export stays inert while
+  stderr diagnostics remain available.
+
+`api.extraEnv`, `dispatcher.extraEnv`, `worker.extraEnv`, and
+`agentSandbox.runner.extraEnv` remain per-workload overrides, including
+`valueFrom`. They do not satisfy the production availability gate, because the
+four services can drift.
 
 ```yaml
 otelCollector:
   deploy: false
-
-api:
-  extraEnv: &externalOtel
-    - {name: OTEL_EXPORTER_OTLP_ENDPOINT, value: https://otel.example.com:4318}
-    - {name: OTEL_EXPORTER_OTLP_PROTOCOL, value: http/protobuf}
-    - name: OTEL_EXPORTER_OTLP_HEADERS
-      valueFrom:
-        secretKeyRef: {name: acme-otel-auth, key: headers}
-dispatcher:
-  extraEnv: *externalOtel
-worker:
-  extraEnv: *externalOtel
-agentSandbox:
-  runner:
-    extraEnv: *externalOtel
+  endpoint: https://otel.example.com:4318
+  protocol: http/protobuf
+  headersExistingSecret: acme-otel-auth
+  headersSecretKey: headers
 ```
-
-When the in-chart collector is disabled, no workload receives a synthesized
-`<release>-otel-collector` endpoint. Leaving these override paths empty is the
-supported no-endpoint mode: SDK export stays inert while stderr diagnostics
-remain available.
 
 Langfuse ingest is HTTP-only, so the collector forwards traces to Langfuse over
 HTTP. Logs and metrics retain explicit collector pipelines. Their destinations
@@ -406,7 +401,9 @@ postgres:
 Toggles (all default `true`): `langfuse.deploy`, `postgres.deploy`,
 `valkey.deploy`, `clickhouse.deploy`, `rustfs.deploy`, `otelCollector.deploy`.
 Flipping any to `false` removes its resources from the render; consumers
-(Langfuse env, the collector config) repoint at the BYO host automatically.
+(Langfuse env, the collector config, application OTEL env) repoint at the BYO
+fields on the same block (`host`/`port` for stores, `otelCollector.endpoint`
+for an external collector).
 
 Secrets: all credentials are written to one `<release>-secrets` Secret. A sealed
 `helm install` (the default) generates strong random values for all eleven
@@ -462,8 +459,11 @@ is the published dev header `Basic cGstbGYtY3VyaWUtZGV2OnNrLWxmLWN1cmllLWRldg==`
 whether `otelCollector.otlpAuthHeader` is set to it directly or the chart
 composed it from the `langfuse.init` keys; `langfuse.existingSecret` does not
 clear it, because that header is what the collector sends regardless of where the
-Langfuse credential comes from. It is off by default so the zero-secret bare
-install stays green.
+Langfuse credential comes from. The same flag also refuses a render that disables
+the chart collector without setting `otelCollector.endpoint` or
+`otelCollector.telemetryDisabled=true`, so a production install cannot silently
+drop every workload's OTLP destination. It is off by default so the zero-secret
+bare install stays green.
 
 ### Key-free object store auth
 
@@ -862,8 +862,10 @@ to install only the control plane + backing stores without the runner substrate.
   the substrate's resume path can inject `CURIE_HISTORY_REF` /
   `CURIE_SESSION_ID` per claim. Claims carrying env bind a fresh sandbox
   rather than a pre-warmed one; the fast path (no env) binds warm.
-- Traces flow to `<release>-otel-collector:4318` (HTTP), per the collector
-  rule above; the env block is omitted when `otelCollector.deploy: false`.
+- Traces flow to `<release>-otel-collector:4318` (HTTP) when the chart collector
+  is deployed, or to `otelCollector.endpoint` when that BYO field is set. The
+  env block is omitted only for explicit `telemetryDisabled` or local/offline
+  no-endpoint mode.
 
 ## Deploying without inbound access
 

--- a/charts/curie/ci/otel-collector-durability-assertions.sh
+++ b/charts/curie/ci/otel-collector-durability-assertions.sh
@@ -158,6 +158,94 @@ agentSandbox:
         value: grpc
 YAML
 
+cat > "$TMP/chart-owned-external.yaml" <<'YAML'
+otelCollector:
+  deploy: false
+  endpoint: https://otel.example.com:4318
+  protocol: http/protobuf
+  headersExistingSecret: acme-otel-auth
+  headersSecretKey: headers
+dispatcher:
+  deploy: true
+  slack:
+    appToken: placeholder-app-token
+    botToken: placeholder-bot-token
+YAML
+
+cat > "$TMP/chart-owned-external-literal-headers.yaml" <<'YAML'
+otelCollector:
+  deploy: false
+  endpoint: https://otel.example.com:4318
+  headers: "x-scope-orgid=acme"
+dispatcher:
+  deploy: true
+  slack:
+    appToken: placeholder-app-token
+    botToken: placeholder-bot-token
+YAML
+
+cat > "$TMP/explicit-disable.yaml" <<'YAML'
+security:
+  checkDefaultCredentials: true
+otelCollector:
+  deploy: false
+  telemetryDisabled: true
+langfuse:
+  existingSecret: my-langfuse
+dispatcher:
+  deploy: true
+  slack:
+    appToken: placeholder-app-token
+    botToken: placeholder-bot-token
+YAML
+
+cat > "$TMP/chart-owned-external-plus-extraenv-override.yaml" <<'YAML'
+otelCollector:
+  deploy: false
+  endpoint: https://otel.example.com:4318
+  protocol: http/protobuf
+dispatcher:
+  deploy: true
+  slack:
+    appToken: placeholder-app-token
+    botToken: placeholder-bot-token
+agentSandbox:
+  runner:
+    extraEnv:
+      - name: OTEL_EXPORTER_OTLP_ENDPOINT
+        value: https://otel-override.example.com:4318
+      - name: OTEL_EXPORTER_OTLP_PROTOCOL
+        value: grpc
+YAML
+
+cat > "$TMP/both-header-sources.yaml" <<'YAML'
+otelCollector:
+  deploy: false
+  endpoint: https://otel.example.com:4318
+  headers: "x-scope-orgid=acme"
+  headersExistingSecret: acme-otel-auth
+YAML
+
+cat > "$TMP/disabled-with-endpoint.yaml" <<'YAML'
+otelCollector:
+  deploy: false
+  telemetryDisabled: true
+  endpoint: https://otel.example.com:4318
+YAML
+
+cat > "$TMP/disabled-with-deploy.yaml" <<'YAML'
+otelCollector:
+  deploy: true
+  telemetryDisabled: true
+YAML
+
+cat > "$TMP/literal-sensitive-workload-headers.yaml" <<'YAML'
+otelCollector:
+  deploy: false
+  endpoint: https://otel.example.com:4318
+  headers: "Authorization=Basic placeholder-not-a-credential"
+YAML
+
 render "$TMP/default.yaml"
 render "$TMP/workload-wiring.yaml" \
   --set dispatcher.deploy=true \
@@ -184,6 +272,15 @@ render "$TMP/external-otel-workload-env.yaml.out" \
   -f "$TMP/external-otel-workload-env.yaml"
 render "$TMP/internal-runner-otel-override.yaml.out" \
   -f "$TMP/internal-runner-otel-override.yaml"
+render "$TMP/chart-owned-external.yaml.out" \
+  -f "$TMP/chart-owned-external.yaml"
+render "$TMP/chart-owned-external-literal-headers.yaml.out" \
+  -f "$TMP/chart-owned-external-literal-headers.yaml"
+render "$TMP/explicit-disable.yaml.out" \
+  -f "$TMP/explicit-disable.yaml" \
+  --set-string otelCollector.otlpAuthHeader='Basic cGstbGYtb3duZWQ6c2stbGYtb3duZWQ='
+render "$TMP/chart-owned-external-plus-extraenv-override.yaml.out" \
+  -f "$TMP/chart-owned-external-plus-extraenv-override.yaml"
 
 expect_render_failure() {
   local label="$1" expected="$2"
@@ -300,6 +397,22 @@ expect_render_failure wildcard-pod-metrics-peer metricsIngress \
 expect_render_failure wildcard-namespace-metrics-peer metricsIngress \
   -f "$TMP/wildcard-namespace-metrics-peer.yaml"
 
+# Production-hardening gate: deploy=false without a chart-owned endpoint or an
+# explicit disable is accidental missing, not an implied external collector.
+expect_render_failure accidental-missing-external-endpoint telemetryDisabled \
+  --set security.checkDefaultCredentials=true \
+  --set otelCollector.deploy=false \
+  --set langfuse.existingSecret=my-langfuse \
+  --set-string otelCollector.otlpAuthHeader='Basic cGstbGYtb3duZWQ6c2stbGYtb3duZWQ='
+expect_render_failure both-header-sources headersExistingSecret \
+  -f "$TMP/both-header-sources.yaml"
+expect_render_failure disabled-with-endpoint telemetryDisabled \
+  -f "$TMP/disabled-with-endpoint.yaml"
+expect_render_failure disabled-with-deploy telemetryDisabled \
+  -f "$TMP/disabled-with-deploy.yaml"
+expect_render_failure literal-sensitive-workload-headers headersExistingSecret \
+  -f "$TMP/literal-sensitive-workload-headers.yaml"
+
 python3 - \
   "$TMP/default.yaml" "$TMP/dev.yaml" "$TMP/ephemeral.yaml" \
   "$TMP/storage-class.yaml" "$TMP/external.yaml" "$TMP/extra.yaml" \
@@ -308,7 +421,11 @@ python3 - \
   "$TMP/network-policy-disabled.yaml" \
   "$TMP/external-otel-workload-env.yaml.out" \
   "$TMP/secret-backed-extra-exporter.yaml.out" \
-  "$TMP/internal-runner-otel-override.yaml.out" <<'PY'
+  "$TMP/internal-runner-otel-override.yaml.out" \
+  "$TMP/chart-owned-external.yaml.out" \
+  "$TMP/chart-owned-external-literal-headers.yaml.out" \
+  "$TMP/explicit-disable.yaml.out" \
+  "$TMP/chart-owned-external-plus-extraenv-override.yaml.out" <<'PY'
 import re
 import sys
 
@@ -441,6 +558,10 @@ def quantity_is_finite(value):
     external_otel_workload_env_path,
     secret_backed_extra_exporter_path,
     internal_runner_otel_override_path,
+    chart_owned_external_path,
+    chart_owned_external_literal_headers_path,
+    explicit_disable_path,
+    chart_owned_external_plus_extraenv_override_path,
 ) = sys.argv[1:]
 
 
@@ -552,6 +673,85 @@ for role, container in workload_containers(external_otel_workload_env_path).item
     assert not any(
         "curie-otel-collector" in str(entry.get("value", "")) for entry in entries
     ), f"{role}: otelCollector.deploy=false synthesized the absent internal endpoint"
+
+chart_owned_endpoint = "https://otel.example.com:4318"
+chart_owned_headers_ref = {
+    "secretKeyRef": {"name": "acme-otel-auth", "key": "headers"}
+}
+for role, container in workload_containers(chart_owned_external_path).items():
+    entries = container.get("env", [])
+    otel_entries = {
+        name: [entry for entry in entries if entry.get("name") == name]
+        for name in (
+            "OTEL_EXPORTER_OTLP_ENDPOINT",
+            "OTEL_EXPORTER_OTLP_PROTOCOL",
+            "OTEL_EXPORTER_OTLP_HEADERS",
+        )
+    }
+    for name, matches in otel_entries.items():
+        assert len(matches) == 1, (
+            f"{role}: chart-owned external Collector must render {name} exactly once, "
+            f"got {matches!r}"
+        )
+    assert otel_entries["OTEL_EXPORTER_OTLP_ENDPOINT"][0].get("value") == chart_owned_endpoint, (
+        f"{role}: chart-owned external endpoint was {otel_entries['OTEL_EXPORTER_OTLP_ENDPOINT'][0].get('value')!r}"
+    )
+    assert otel_entries["OTEL_EXPORTER_OTLP_PROTOCOL"][0].get("value") == "http/protobuf", (
+        f"{role}: chart-owned external protocol was {otel_entries['OTEL_EXPORTER_OTLP_PROTOCOL'][0].get('value')!r}"
+    )
+    assert otel_entries["OTEL_EXPORTER_OTLP_HEADERS"][0].get("valueFrom") == chart_owned_headers_ref, (
+        f"{role}: chart-owned headersExistingSecret was dropped or rewritten: "
+        f"{otel_entries['OTEL_EXPORTER_OTLP_HEADERS'][0]!r}"
+    )
+    assert not any(
+        "curie-otel-collector" in str(entry.get("value", "")) for entry in entries
+    ), f"{role}: chart-owned external mode synthesized the absent internal endpoint"
+assert not collector_documents(chart_owned_external_path), (
+    "chart-owned external: otelCollector.deploy=false rendered chart-owned Collector resources"
+)
+
+for role, container in workload_containers(chart_owned_external_literal_headers_path).items():
+    entries = container.get("env", [])
+    header_matches = [entry for entry in entries if entry.get("name") == "OTEL_EXPORTER_OTLP_HEADERS"]
+    assert header_matches == [
+        {"name": "OTEL_EXPORTER_OTLP_HEADERS", "value": "x-scope-orgid=acme"}
+    ], f"{role}: chart-owned literal headers were {header_matches!r}"
+
+for role, container in workload_containers(explicit_disable_path).items():
+    env = environment(container)
+    for name in (
+        "OTEL_EXPORTER_OTLP_ENDPOINT",
+        "OTEL_EXPORTER_OTLP_PROTOCOL",
+        "OTEL_EXPORTER_OTLP_HEADERS",
+    ):
+        assert name not in env, (
+            f"{role}: explicit telemetryDisabled still injected {name}={env[name]!r}"
+        )
+assert not collector_documents(explicit_disable_path), (
+    "explicit disable: otelCollector.deploy=false rendered chart-owned Collector resources"
+)
+
+override_workloads = workload_containers(chart_owned_external_plus_extraenv_override_path)
+for role, container in override_workloads.items():
+    env = environment(container)
+    if role == "runner":
+        assert env.get("OTEL_EXPORTER_OTLP_ENDPOINT") == "https://otel-override.example.com:4318", (
+            f"runner: extraEnv override lost to chart-owned endpoint {env.get('OTEL_EXPORTER_OTLP_ENDPOINT')!r}"
+        )
+        assert env.get("OTEL_EXPORTER_OTLP_PROTOCOL") == "grpc", (
+            f"runner: extraEnv protocol override lost: {env.get('OTEL_EXPORTER_OTLP_PROTOCOL')!r}"
+        )
+        assert sum(
+            entry.get("name") == "OTEL_EXPORTER_OTLP_ENDPOINT"
+            for entry in container.get("env", [])
+        ) == 1, "runner: chart-owned endpoint must not duplicate an extraEnv override"
+    else:
+        assert env.get("OTEL_EXPORTER_OTLP_ENDPOINT") == chart_owned_endpoint, (
+            f"{role}: chart-owned external endpoint was {env.get('OTEL_EXPORTER_OTLP_ENDPOINT')!r}"
+        )
+        assert env.get("OTEL_EXPORTER_OTLP_PROTOCOL") == "http/protobuf", (
+            f"{role}: chart-owned external protocol was {env.get('OTEL_EXPORTER_OTLP_PROTOCOL')!r}"
+        )
 
 default_docs = collector_documents(default_path)
 default_config = collector_config(default_path, "default")

--- a/charts/curie/ci/otel-collector-langfuse-secret-assertions.sh
+++ b/charts/curie/ci/otel-collector-langfuse-secret-assertions.sh
@@ -341,7 +341,9 @@ grep -qF 'otelCollector.otlpAuthHeader' "$TMP/dev-header-interior-space.stderr" 
 # message claiming a header "the OTel Collector would send" describes something
 # the operator cannot find. Asserting on the wording is what stops a future edit
 # from silently reintroducing that false claim.
-rc="$(gate_rc dev-header-no-collector --set security.checkDefaultCredentials=true --set otelCollector.deploy=false --set langfuse.existingSecret='my-langfuse' --set-string 'otelCollector.otlpAuthHeader=Basic cGstbGYtY3VyaWUtZGV2OnNrLWxmLWN1cmllLWRldg==')"
+# telemetryDisabled isolates this header check from #1819's availability gate,
+# which otherwise refuses deploy=false with no chart-owned endpoint.
+rc="$(gate_rc dev-header-no-collector --set security.checkDefaultCredentials=true --set otelCollector.deploy=false --set otelCollector.telemetryDisabled=true --set langfuse.existingSecret='my-langfuse' --set-string 'otelCollector.otlpAuthHeader=Basic cGstbGYtY3VyaWUtZGV2OnNrLWxmLWN1cmllLWRldg==')"
 [[ "$rc" != "0" ]] || fail "T14: security.checkDefaultCredentials=true rendered successfully with otelCollector.deploy=false and the published dev header. The chart still writes that credential into its Secret whether or not this release runs a collector, so the gate must still refuse"
 grep -qF 'as the OTel Collector auth credential in its Secret' "$TMP/dev-header-no-collector.stderr" || fail "T14: the render failed but its message does not say the credential is what the chart ships in its Secret, which is the part that is true whether or not a collector is deployed. stderr was: $(cat "$TMP/dev-header-no-collector.stderr")"
 if grep -qF 'header the OTel Collector would send to Langfuse' "$TMP/dev-header-no-collector.stderr"; then

--- a/charts/curie/templates/NOTES.txt
+++ b/charts/curie/templates/NOTES.txt
@@ -25,7 +25,13 @@ Components deployed:
   - S3: BYO at {{ .Values.rustfs.host }}:{{ .Values.rustfs.port }}
 {{- end }}
 {{- if .Values.otelCollector.deploy }}
-  - OTel Collector ({{ .Values.otelCollector.image }})
+  - OTel Collector ({{ .Values.otelCollector.image }}) at http://{{ include "curie.fullname" . }}-otel-collector:{{ .Values.otelCollector.service.httpPort }}
+{{- else if .Values.otelCollector.telemetryDisabled }}
+  - OTel: telemetry explicitly disabled (no OTLP endpoint on instrumented workloads)
+{{- else if .Values.otelCollector.endpoint }}
+  - OTel: external collector at {{ .Values.otelCollector.endpoint }} ({{ .Values.otelCollector.protocol }})
+{{- else }}
+  - OTel: no endpoint (SDK export inert; stderr diagnostics remain)
 {{- end }}
 
 App services:

--- a/charts/curie/templates/_helpers.tpl
+++ b/charts/curie/templates/_helpers.tpl
@@ -403,6 +403,90 @@ service:
       exporters: [nop/metrics{{- if $debugEnabled }}, debug{{- end }}{{- range .Values.otelCollector.extraMetricPipelineExporters }}, {{ . }}{{- end }}]
 {{- end }}
 
+{{/* Chart-owned OTLP destination (#1819). In-cluster Service while deploy is
+     true; otelCollector.endpoint when the operator brings their own collector.
+     Empty when telemetry is explicitly disabled or when no-endpoint mode is
+     valid (gate off, deploy false, endpoint empty). */}}
+{{- define "curie.otel.endpoint" -}}
+{{- if .Values.otelCollector.deploy -}}
+http://{{ include "curie.fullname" . }}-otel-collector:{{ .Values.otelCollector.service.httpPort }}
+{{- else if not .Values.otelCollector.telemetryDisabled -}}
+{{- .Values.otelCollector.endpoint | default "" -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Fail closed on contradictory OTEL values always. Fail closed on accidental
+     missing only when security.checkDefaultCredentials is on: local/offline
+     no-endpoint remains valid outside that gate. extraEnv-only does not satisfy
+     the production gate because the four workloads can drift. */}}
+{{- define "curie.otel.validate" -}}
+{{- $otel := .Values.otelCollector -}}
+{{- if and $otel.telemetryDisabled $otel.deploy -}}
+{{- fail "otelCollector.telemetryDisabled cannot be true while otelCollector.deploy is true. Deploy the chart-managed collector, or set deploy to false and keep telemetryDisabled true." -}}
+{{- end -}}
+{{- if and $otel.telemetryDisabled (not (empty $otel.endpoint)) -}}
+{{- fail "otelCollector.telemetryDisabled cannot be true while otelCollector.endpoint is set. Set one destination or acknowledge that telemetry is disabled." -}}
+{{- end -}}
+{{- if and $otel.telemetryDisabled (not (empty $otel.headers)) -}}
+{{- fail "otelCollector.telemetryDisabled cannot be true while otelCollector.headers is set." -}}
+{{- end -}}
+{{- if and $otel.telemetryDisabled (not (empty $otel.headersExistingSecret)) -}}
+{{- fail "otelCollector.telemetryDisabled cannot be true while otelCollector.headersExistingSecret is set." -}}
+{{- end -}}
+{{- if and (not (empty $otel.headers)) (not (empty $otel.headersExistingSecret)) -}}
+{{- fail "otelCollector.headers and otelCollector.headersExistingSecret cannot both be set. Use headersExistingSecret for credentials." -}}
+{{- end -}}
+{{- $sensitiveHeaderPattern := "(?i)(^|[,;\\s])(authorization|token|api[-_]?key|secret|password|credential)=" -}}
+{{- if and (not (empty $otel.headers)) (regexMatch $sensitiveHeaderPattern (toString $otel.headers)) -}}
+{{- fail "otelCollector.headers is sensitive and must use headersExistingSecret so the value never enters Helm values or the rendered workload env as a literal." -}}
+{{- end -}}
+{{- $protocol := $otel.protocol | default "http/protobuf" -}}
+{{- if and (not (empty $protocol)) (not (or (eq $protocol "http/protobuf") (eq $protocol "grpc") (eq $protocol "http/json"))) -}}
+{{- fail "otelCollector.protocol must be grpc, http/protobuf, or http/json." -}}
+{{- end -}}
+{{- if and .Values.security.checkDefaultCredentials (not $otel.deploy) (not $otel.telemetryDisabled) (empty $otel.endpoint) -}}
+{{- fail "security.checkDefaultCredentials is on but neither a chart-managed collector nor otelCollector.endpoint is configured. Set otelCollector.endpoint to the external collector, keep otelCollector.deploy true, or set otelCollector.telemetryDisabled=true to acknowledge that telemetry is disabled." -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Standard OTEL_EXPORTER_OTLP_* env for every instrumented workload. extraEnv
+     still wins per variable. Include with nindent 12. Call with
+     dict "root" $ "extraEnv" .Values.<workload>.extraEnv */}}
+{{- define "curie.env.otel" -}}
+{{- include "curie.otel.validate" .root -}}
+{{- $extra := .extraEnv | default list -}}
+{{- $hasEndpoint := false -}}
+{{- $hasProtocol := false -}}
+{{- $hasHeaders := false -}}
+{{- range $extra -}}
+{{- if eq .name "OTEL_EXPORTER_OTLP_ENDPOINT" -}}{{- $hasEndpoint = true -}}{{- end -}}
+{{- if eq .name "OTEL_EXPORTER_OTLP_PROTOCOL" -}}{{- $hasProtocol = true -}}{{- end -}}
+{{- if eq .name "OTEL_EXPORTER_OTLP_HEADERS" -}}{{- $hasHeaders = true -}}{{- end -}}
+{{- end -}}
+{{- $endpoint := include "curie.otel.endpoint" .root | trim -}}
+{{- $protocol := .root.Values.otelCollector.protocol | default "http/protobuf" -}}
+{{- if and (not $hasEndpoint) (ne $endpoint "") }}
+- name: OTEL_EXPORTER_OTLP_ENDPOINT
+  value: {{ $endpoint | quote }}
+{{- end }}
+{{- if and (not $hasProtocol) (ne $endpoint "") }}
+- name: OTEL_EXPORTER_OTLP_PROTOCOL
+  value: {{ $protocol | quote }}
+{{- end }}
+{{- if and (not $hasHeaders) (not .root.Values.otelCollector.deploy) (not .root.Values.otelCollector.telemetryDisabled) (ne $endpoint "") }}
+{{- if not (empty .root.Values.otelCollector.headersExistingSecret) }}
+- name: OTEL_EXPORTER_OTLP_HEADERS
+  valueFrom:
+    secretKeyRef:
+      name: {{ .root.Values.otelCollector.headersExistingSecret | quote }}
+      key: {{ .root.Values.otelCollector.headersSecretKey | default "headers" | quote }}
+{{- else if not (empty .root.Values.otelCollector.headers) }}
+- name: OTEL_EXPORTER_OTLP_HEADERS
+  value: {{ .root.Values.otelCollector.headers | quote }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
 {{/* ---- Default-credential gate (issue #198) ----
      When security.checkDefaultCredentials is on, refuse to render if a Langfuse
      chart input for a bootstrap identity still carries the published dev default
@@ -502,6 +586,7 @@ service:
 {{- fail "security.checkDefaultCredentials is on but the chart would ship the published dev header \"Basic cGstbGYtY3VyaWUtZGV2OnNrLWxmLWN1cmllLWRldg==\" as the OTel Collector auth credential in its Secret (auth scheme spelling, whitespace and base64 padding aside), which the collector authenticates with when deployed. That is the dev project key pk-lf-curie-dev:sk-lf-curie-dev, which anyone reading this repository holds. That header arrives either from otelCollector.otlpAuthHeader set to it directly, or from the chart composing it out of langfuse.init.projectPublicKey and langfuse.init.projectSecretKey when the chart-managed Secret is the one the collector reads. Set otelCollector.otlpAuthHeader from your own project keys, override those two langfuse.init values, or point langfuse.existingSecret at your own Secret and supply otlpAuthHeader there." -}}
 {{- end -}}
 {{- end -}}
+{{- include "curie.otel.validate" . -}}
 {{- end -}}
 
 {{/* ---- Auto-generated per-release chart credential (issue #195) ----

--- a/charts/curie/templates/agent-sandbox.yaml
+++ b/charts/curie/templates/agent-sandbox.yaml
@@ -135,16 +135,6 @@ roleRef:
 {{- $runner := .Values.agentSandbox.runner }}
 {{- $bf := $runner.bundleFetch }}
 {{- $wf := $runner.workspace }}
-{{- $hasRunnerOtelEndpoint := false }}
-{{- $hasRunnerOtelProtocol := false }}
-{{- range $runner.extraEnv }}
-{{- if eq .name "OTEL_EXPORTER_OTLP_ENDPOINT" }}
-{{- $hasRunnerOtelEndpoint = true }}
-{{- end }}
-{{- if eq .name "OTEL_EXPORTER_OTLP_PROTOCOL" }}
-{{- $hasRunnerOtelProtocol = true }}
-{{- end }}
-{{- end }}
 {{- $templateName := printf "%s-runner" (include "curie.fullname" .) }}
 {{- $poolName := printf "%s-runner-pool" (include "curie.fullname" .) }}
 {{- if $agent }}
@@ -634,14 +624,7 @@ spec:
             - name: GIT_CONFIG_VALUE_0
               value: {{ $wf.mountPath | quote }}
             {{- end }}
-            {{- if and .Values.otelCollector.deploy (not $hasRunnerOtelEndpoint) }}
-            - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              value: http://{{ include "curie.fullname" . }}-otel-collector:{{ .Values.otelCollector.service.httpPort }}
-            {{- end }}
-            {{- if and .Values.otelCollector.deploy (not $hasRunnerOtelProtocol) }}
-            - name: OTEL_EXPORTER_OTLP_PROTOCOL
-              value: http/protobuf
-            {{- end }}
+            {{- include "curie.env.otel" (dict "root" . "extraEnv" $runner.extraEnv) | nindent 12 }}
             {{- with $runner.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/curie/templates/api.yaml
+++ b/charts/curie/templates/api.yaml
@@ -43,16 +43,6 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- $hasApiOtelEndpoint := false }}
-      {{- $hasApiOtelProtocol := false }}
-      {{- range .Values.api.extraEnv }}
-      {{- if eq .name "OTEL_EXPORTER_OTLP_ENDPOINT" }}
-      {{- $hasApiOtelEndpoint = true }}
-      {{- end }}
-      {{- if eq .name "OTEL_EXPORTER_OTLP_PROTOCOL" }}
-      {{- $hasApiOtelProtocol = true }}
-      {{- end }}
-      {{- end }}
       {{- if .Values.api.migrate.enabled }}
       # Bring the schema to head before the server boots. The init container
       # re-runs until it succeeds, so it also serves as a wait-for-Postgres gate
@@ -109,16 +99,7 @@ spec:
                   key: githubToken
             - name: GITHUB_REPO_ALLOWLIST
               value: {{ .Values.api.githubRepoAllowlist | toJson | quote }}
-            {{- if and .Values.otelCollector.deploy (not $hasApiOtelEndpoint) }}
-            # Standard OTLP/HTTP reception is chart-owned only while the chart
-            # also owns the endpoint. External-Collector installs stay inert.
-            - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              value: http://{{ include "curie.fullname" . }}-otel-collector:{{ .Values.otelCollector.service.httpPort }}
-            {{- end }}
-            {{- if and .Values.otelCollector.deploy (not $hasApiOtelProtocol) }}
-            - name: OTEL_EXPORTER_OTLP_PROTOCOL
-              value: http/protobuf
-            {{- end }}
+            {{- include "curie.env.otel" (dict "root" . "extraEnv" .Values.api.extraEnv) | nindent 12 }}
             # GitHub App identity (ADR-0092). When both are set the platform
             # mints a one-hour token scoped to the single repository it is
             # cloning, instead of using GITHUB_TOKEN above. Both empty is fine:

--- a/charts/curie/templates/dispatcher.yaml
+++ b/charts/curie/templates/dispatcher.yaml
@@ -32,16 +32,6 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- $hasDispatcherOtelEndpoint := false }}
-      {{- $hasDispatcherOtelProtocol := false }}
-      {{- range .Values.dispatcher.extraEnv }}
-      {{- if eq .name "OTEL_EXPORTER_OTLP_ENDPOINT" }}
-      {{- $hasDispatcherOtelEndpoint = true }}
-      {{- end }}
-      {{- if eq .name "OTEL_EXPORTER_OTLP_PROTOCOL" }}
-      {{- $hasDispatcherOtelProtocol = true }}
-      {{- end }}
-      {{- end }}
       containers:
         - name: dispatcher
           image: {{ include "curie.image" (dict "repository" .Values.dispatcher.image.repository "tag" .Values.dispatcher.image.tag "digest" .Values.dispatcher.image.digest "defaultTag" .Chart.AppVersion) | quote }}
@@ -67,16 +57,7 @@ spec:
                   name: {{ include "curie.secretName" . }}
                   key: slackSigningSecret
             {{- include "curie.env.api" . | nindent 12 }}
-            {{- if and .Values.otelCollector.deploy (not $hasDispatcherOtelEndpoint) }}
-            # Do not synthesize an endpoint when the operator uses an external
-            # Collector; absent configuration keeps SDK export disabled.
-            - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              value: http://{{ include "curie.fullname" . }}-otel-collector:{{ .Values.otelCollector.service.httpPort }}
-            {{- end }}
-            {{- if and .Values.otelCollector.deploy (not $hasDispatcherOtelProtocol) }}
-            - name: OTEL_EXPORTER_OTLP_PROTOCOL
-              value: http/protobuf
-            {{- end }}
+            {{- include "curie.env.otel" (dict "root" . "extraEnv" .Values.dispatcher.extraEnv) | nindent 12 }}
             # Heartbeat file a background daemon thread in the dispatcher touches
             # each tick; the exec probes below read this same path so template and
             # app cannot drift.

--- a/charts/curie/templates/worker.yaml
+++ b/charts/curie/templates/worker.yaml
@@ -144,20 +144,12 @@ spec:
       {{- end }}
       {{- $hasWorkerApiUrl := false }}
       {{- $hasWorkerApiKey := false }}
-      {{- $hasWorkerOtelEndpoint := false }}
-      {{- $hasWorkerOtelProtocol := false }}
       {{- range .Values.worker.extraEnv }}
       {{- if eq .name "CURIE_API_URL" }}
       {{- $hasWorkerApiUrl = true }}
       {{- end }}
       {{- if eq .name "CURIE_API_KEY" }}
       {{- $hasWorkerApiKey = true }}
-      {{- end }}
-      {{- if eq .name "OTEL_EXPORTER_OTLP_ENDPOINT" }}
-      {{- $hasWorkerOtelEndpoint = true }}
-      {{- end }}
-      {{- if eq .name "OTEL_EXPORTER_OTLP_PROTOCOL" }}
-      {{- $hasWorkerOtelProtocol = true }}
       {{- end }}
       {{- end }}
       containers:
@@ -255,14 +247,7 @@ spec:
               value: {{ index .Values.worker.publication.resources.requests "ephemeral-storage" | quote }}
             - name: CURIE_PUBLICATION_EPHEMERAL_LIMIT
               value: {{ index .Values.worker.publication.resources.limits "ephemeral-storage" | quote }}
-            {{- if and .Values.otelCollector.deploy (not $hasWorkerOtelEndpoint) }}
-            - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              value: http://{{ include "curie.fullname" . }}-otel-collector:{{ .Values.otelCollector.service.httpPort }}
-            {{- end }}
-            {{- if and .Values.otelCollector.deploy (not $hasWorkerOtelProtocol) }}
-            - name: OTEL_EXPORTER_OTLP_PROTOCOL
-              value: http/protobuf
-            {{- end }}
+            {{- include "curie.env.otel" (dict "root" . "extraEnv" .Values.worker.extraEnv) | nindent 12 }}
             - name: SLACK_BOT_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -478,12 +478,29 @@ inference:
 # ---------------------------------------------------------------------------
 # OTel Collector. Receives traces, logs, and metrics over OTLP (gRPC 4317 / HTTP
 # 4318). Traces go to Langfuse over HTTP; logs and metrics retain explicit nop
-# defaults until #1765 supplies their backends. Deploy false to send application
-# telemetry to an external collector.
+# defaults until #1765 supplies their backends. Deploy false and set endpoint to
+# send application telemetry to an external collector. Deploy false with an
+# empty endpoint is no-endpoint mode (SDK export stays inert) unless
+# security.checkDefaultCredentials is on, in which case set telemetryDisabled
+# to acknowledge that this install emits no OTLP.
 # ---------------------------------------------------------------------------
 otelCollector:
   deploy: true
   image: otel/opentelemetry-collector-contrib:0.119.0
+  # Chart-owned external OTLP endpoint used when deploy is false. Wired to API,
+  # dispatcher, worker, and runner. Ignored while deploy is true (in-cluster
+  # collector wins). extraEnv remains a per-workload override.
+  endpoint: ""
+  protocol: http/protobuf
+  # Optional OTEL_EXPORTER_OTLP_HEADERS. Prefer headersExistingSecret for
+  # credentials so they never enter Helm values. The two sources are mutually
+  # exclusive; a literal is only for non-sensitive values such as a tenant id.
+  headers: ""
+  headersExistingSecret: ""
+  headersSecretKey: headers
+  # Explicit acknowledgement that this install emits no OTLP. Required by
+  # security.checkDefaultCredentials when deploy is false and endpoint is empty.
+  telemetryDisabled: false
   # Full `Authorization` header, `Basic <base64(publicKey:secretKey)>`, in three
   # branches. Set here, it always wins and is stored in the chart-managed Secret.
   # Left empty with chart managed init credentials, it is derived from the
@@ -751,9 +768,8 @@ api:
   # which were silently dropped before. WARNING to quieten it.
   logLevel: INFO
   # Extra env for the API container. Full Kubernetes EnvVar entries are
-  # accepted, including valueFrom. When supplying an external Collector with
-  # otelCollector.deploy=false, set the standard OTEL_EXPORTER_OTLP_* variables
-  # here; the chart will not invent an in-cluster endpoint in that mode.
+  # accepted, including valueFrom. Per-workload OTEL_EXPORTER_OTLP_* overrides
+  # still win over the chart-owned collector endpoint.
   extraEnv: []
   service:
     type: ClusterIP
@@ -862,8 +878,8 @@ dispatcher:
     requests: { cpu: 50m, memory: 128Mi }
     limits: { cpu: 500m, memory: 256Mi }
   # Extra env for the dispatcher container. Full Kubernetes EnvVar entries are
-  # accepted, including valueFrom. This is also the external-Collector override
-  # surface when otelCollector.deploy=false.
+  # accepted, including valueFrom. Per-workload OTEL_EXPORTER_OTLP_* overrides
+  # still win over the chart-owned collector endpoint.
   extraEnv: []
   # Container securityContext (issue #67). Image runs as non-root uid 1000 (see
   # apps/dispatcher/Dockerfile). readOnlyRootFilesystem stays false -- the
@@ -1243,7 +1259,9 @@ worker:
   adapterCredentials: {}
   # Extra env for the worker container, list of {name, value}. For SLACK_API_BASE_URL
   # prefer the first-class slackApiBaseUrl above; use extraEnv for any other
-  # worker override the fixed env block does not cover.
+  # worker override the fixed env block does not cover. Per-workload
+  # OTEL_EXPORTER_OTLP_* overrides still win over the chart-owned collector
+  # endpoint.
   extraEnv: []
   resources:
     requests: { cpu: 500m, memory: 512Mi, ephemeral-storage: 2Gi }
@@ -1494,6 +1512,8 @@ agentSandbox:
       fetchTimeoutSeconds: 45
       extractTimeoutSeconds: 45
     # Extra env for the runner container, list of {name, value}.
+    # Per-workload OTEL_EXPORTER_OTLP_* overrides still win over the
+    # chart-owned collector endpoint.
     extraEnv: []
     # --- BYO model: LiteLLM Anthropic-format sidecar (part of #24) ---
     # Off by default. Enable ONLY for genuine multi-model routing/fallback: a

--- a/compose/tests/test_collector_durability.py
+++ b/compose/tests/test_collector_durability.py
@@ -1,0 +1,74 @@
+"""Lock the Compose collector's production-grade delivery contract (#1819).
+
+Helm owns the cluster PVC and BYO endpoint wiring. Compose is the local sibling:
+the same memory limiter, bounded persistent queue, non-root writable storage,
+and self-metrics must remain on every enabled signal. Debug export stays on
+because this file is the development stack.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+COLLECTOR_CONFIG = REPO_ROOT / "otel" / "collector-config.yaml"
+COMPOSE_DEV = REPO_ROOT / "compose.dev.yaml"
+
+
+def test_compose_collector_limits_and_persists_every_enabled_signal() -> None:
+    config = yaml.safe_load(COLLECTOR_CONFIG.read_text())
+    pipelines = config["service"]["pipelines"]
+    assert set(pipelines) == {"traces", "logs", "metrics"}
+
+    processors = config["processors"]
+    assert "memory_limiter" in processors
+    assert "batch" in processors
+    limiter = processors["memory_limiter"]
+    assert limiter["limit_percentage"] == 75
+    assert limiter["spike_limit_percentage"] == 20
+
+    for signal, pipeline in pipelines.items():
+        names = pipeline["processors"]
+        assert names.index("memory_limiter") < names.index("batch"), (
+            f"{signal} batches before memory limiting: {names!r}"
+        )
+
+    for name, exporter in config["exporters"].items():
+        if name.split("/", 1)[0] not in {"otlp", "otlphttp"}:
+            continue
+        retry = exporter["retry_on_failure"]
+        assert retry["enabled"] is True
+        assert retry["max_elapsed_time"] not in (None, "0", "0s")
+        queue = exporter["sending_queue"]
+        assert queue["enabled"] is True
+        assert queue["storage"] == "file_storage"
+        assert isinstance(queue["queue_size"], int) and 0 < queue["queue_size"] <= 100_000
+
+    extensions = config["extensions"]
+    assert "file_storage" in extensions
+    assert "file_storage" in config["service"]["extensions"]
+    directory = extensions["file_storage"]["directory"]
+    assert directory == "/var/lib/otelcol/storage"
+    telemetry = config["service"]["telemetry"]["metrics"]
+    assert telemetry["level"] != "none"
+    assert telemetry["address"] == "0.0.0.0:8888"
+    assert "debug" in config["exporters"]
+
+
+def test_compose_collector_volume_is_writable_by_non_root() -> None:
+    compose = yaml.safe_load(COMPOSE_DEV.read_text())
+    collector = compose["services"]["otel-collector"]
+    perms = compose["services"]["otel-collector-perms"]
+    assert collector["user"] == "10001:10001"
+    assert collector["mem_limit"] == "256m"
+    assert str(collector["stop_grace_period"]) in {"60s", "1m"}
+    assert "otel_collector_storage:/var/lib/otelcol/storage" in collector["volumes"]
+    assert "otel_collector_storage:/var/lib/otelcol/storage" in perms["volumes"]
+    assert perms["user"] == "0"
+    assert "otel_collector_storage" in compose["volumes"]
+    published = {entry.split(":")[0] for entry in collector["ports"]}
+    assert "127.0.0.1:28888" in published or any(
+        entry.endswith(":8888") for entry in collector["ports"]
+    )

--- a/docs/interfaces/telemetry-otel/INTERFACE.md
+++ b/docs/interfaces/telemetry-otel/INTERFACE.md
@@ -151,7 +151,10 @@ that directory on a PVC by default, so queued trace batches survive a Collector 
 restart. Any operator-supplied network exporter is rejected at render time unless it
 also enables finite retry and a finite file-backed queue. Logs and metrics deliberately
 use explicit no-op exporters until an operator configures their backends, avoiding scope
-overlap with #1765.
+overlap with #1765. Instrumented workloads take a single chart-owned OTLP destination:
+the in-cluster collector while `otelCollector.deploy` is true, `otelCollector.endpoint`
+when the operator brings an external collector, or no endpoint when telemetry is
+explicitly disabled. The production credential gate refuses a missing destination.
 
 Collector self-metrics remain enabled on the chart's internal metrics port, including
 queue size/capacity and exporter accepted, sent, failed, and enqueue-failed counters used
@@ -170,9 +173,11 @@ create a recursive failure loop.
 
 One trace backend: Langfuse, reached through the OTel Collector (which authenticates and
 forwards over HTTP because Langfuse OTLP ingest is HTTP-only). Every producer knows only
-OTLP. The chart injects the Collector endpoint into the API, dispatcher, worker, eval
-worker, and sandbox runner; the local Compose profiles do the same for the services they
-start. The read side (trace list and tree reconstruction) remains a separate API concern.
+OTLP. The chart injects one destination into the API, dispatcher, worker, eval worker,
+and sandbox runner: the in-cluster collector, a chart-owned external endpoint, or nothing
+when telemetry is explicitly disabled. The local Compose profiles do the same for the
+services they start. The read side (trace list and tree reconstruction) remains a
+separate API concern.
 
 The default chart intentionally has no log or metric storage implementation: those
 pipelines terminate in named no-op exporters unless the operator adds durable backends.


### PR DESCRIPTION
## Summary

Make the shipped OTEL Collector truthful about its destination and keep the production-grade delivery already on `next` from #1818. `otelCollector.deploy=false` no longer pretends to mean "send to an external collector" while dropping every workload endpoint. The chart now owns one BYO endpoint/protocol/header block, wires it to API, dispatcher, worker, and runner, and fails a production-hardening render that has neither a chart collector nor an external endpoint unless the operator sets `telemetryDisabled`.

Default chosen: extraEnv-only does not satisfy `security.checkDefaultCredentials`. The four workloads can drift, which is the bug the issue comment named. extraEnv remains a per-workload override.

## Related issue

Closes #1819

## End-to-end verification

Candidate commit: `5d129933e89b6fb7e802320cfa3082c62387715d`

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | Does not reach plugin packaging, the runner turn loop, ACI events, or skill eval/check. | | |
| local | required | Compose collector-config.yaml and compose.dev.yaml are the local collector surface. | fake | `uv run pytest -q compose/tests/test_collector_durability.py` -> `2 passed`. Negative: Helm accidental-missing render with `security.checkDefaultCredentials=true` and empty endpoint fails naming `telemetryDisabled`. |
| local-release | n/a | No released binary, image identity, install path, version pin, or release compose generator transform. | | |
| cluster | required | Chart templates, collector PVC/securityContext, endpoint wiring, and the outage/restart/recovery/overflow ACs. | fake | `curie dev chart-runtime-e2e` against `5d129933` on k8scratch. Observed: `healthy path: all three signals accepted and sent; refused and send-failed stayed observable at zero`; `sustained outage: Collector remained Ready without restart/OOM for 60s; queue<=6.0, pvc-used=84..84Ki/131072Ki`; `restart path: new pod UID retained claim e2eharness-curie-otel-collector and its non-empty queue`; `recovery path: uniquely named queued trace, log record, and metric point delivered once; queue drained`; `overflow path: enqueue_failed metrics moved, per-signal capacity stayed 2, and excess was observably lost`; `PASS`. Teardown deleted namespace `curie-e2eharness`. |
| live provider | n/a | Does not change model routing, credential resolution, provider auth, or token/cost accounting. | | |
| external integration | n/a | Does not change Slack, git webhooks, connector OAuth, or a third-party API shape. | | |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.

Render contract (package/chart checks):

```
bash charts/curie/ci/otel-collector-durability-assertions.sh
PASS: durable three-signal Collector render contract

bash charts/curie/ci/otel-collector-langfuse-secret-assertions.sh
Collector follows langfuse.existingSecret, the chart Secret ships no stale dev header, the override still wins, and the default-credential gate refuses the published dev header: OK

helm lint charts/curie
1 chart(s) linted, 0 chart(s) failed
```

Positive/negative pairs:

- Internal collector: default render injects `http://curie-otel-collector:4318` once on API, dispatcher, worker, and runner.
- External: `otelCollector.deploy=false` plus `endpoint`/`headersExistingSecret` wires that destination to all four; no in-chart collector resources.
- Explicit disable: `telemetryDisabled=true` under `security.checkDefaultCredentials` renders with no OTEL env.
- Accidental missing: same production gate with empty endpoint fails rather than dropping telemetry silently.
- Overflow: tiny `queue_size=2` makes `enqueue_failed_*` move and does not claim losslessness.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed.
- [ ] An ADR is added under `docs/adr/` if this is an architectural decision.

No ADR: this keeps the existing OTLP collector as the only backend adapter and does not close a new architectural door.
