### PR TITLE
Share one docker build function between curie build and local up --build

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ multi-step setup, add or extend a `curie` subcommand instead — a single,
 discoverable surface beats a scatter of scripts. The script or tool call can
 stay the *implementation*; it just isn't the interface.
 
-- Building the runner image → `curie build` (not a copy-pasted `docker build -f runner/Dockerfile ...`).
+- Building the runner image → `curie build` (not a copy-pasted `docker build -f runner/Dockerfile ...`). That tags both `curie-runner` (what `curie skill up` runs) and `ghcr.io/curie-eng/curie-runner:dev` (what `curie local up --build` runs), so `curie update --image` refreshes a `--build` stack's runner.
 - First-run dev bootstrap → `curie install` (or `./get-curie.sh` from a source checkout, which also puts `curie` on PATH the first time by building it).
 - Refresh the on-PATH CLI after a code change → `curie update` (rebuilds and `cargo install`s the CLI to `~/.cargo/bin`; `--image` also rebuilds the runner). The per-change loop, so you never re-run the bootstrap script.
 - Run the local stack on YOUR checkout → `curie local up --build`. `curie update` covers the CLI and the runner image; the stack's api, worker, dispatcher and ui otherwise come from the registry, so a source-built CLI ends up talking to whatever was last published. That skew does not announce itself — it surfaces as a serde error about a field name, or a missing Python module from inside a container (#1915).

--- a/cli/README.md
+++ b/cli/README.md
@@ -706,7 +706,7 @@ teardown failures. Inline tests in product files are not inferred.
 
 | Command | What it does |
 |---|---|
-| `curie build` | Build the runner image locally: `docker build -f runner/Dockerfile -t curie-runner .` from the repo root (found by walking up to `runner/Dockerfile`). `--tag` overrides the tag. Prints a clear error if Docker is not installed or if run outside a source checkout -- a release binary pulls the pinned runner image from GHCR automatically and never needs to build. |
+| `curie build` | Build the runner image locally from `runner/Dockerfile` at the repo root. Default tag is `curie-runner`; the same image is also tagged `ghcr.io/curie-eng/curie-runner:dev` so a `curie local up --build` stack sees it. `--tag` overrides the primary tag (a custom tag is not also applied as `:dev`). Prints a clear error if Docker is not installed or if run outside a source checkout -- a release binary pulls the pinned runner image from GHCR automatically and never needs to build. |
 
 ### Prototyping agents in a source checkout
 

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -587,11 +587,32 @@ pub async fn try_first_run(keep: bool, image: String) -> Result<()> {
     Ok(())
 }
 
-/// `curie build`: build the runner image locally from the repo's Dockerfile.
-/// The one-command equivalent of `docker build -f runner/Dockerfile -t <tag> .`
-/// run from the repo root. Errors clearly when Docker is missing or when run
-/// outside a source checkout (a release binary pulls the image from GHCR).
-pub async fn build(tag: &str) -> Result<()> {
+/// Tags `docker build` applies for one platform image.
+///
+/// The runner has two identities: the short name [`crate::docker::RUNNER_IMAGE`]
+/// (`curie skill up`, `curie update --image`) and the ghcr `:dev` ref a
+/// `--build` stack runs. Building either also tags the other, so the two
+/// paths share one image (#1931). A custom `curie build --tag` is left alone.
+pub(crate) fn platform_image_tags(dockerfile: &str, tag: &str) -> Vec<String> {
+    let mut tags = vec![tag.to_string()];
+    if dockerfile == "runner/Dockerfile" {
+        let short = crate::docker::RUNNER_IMAGE;
+        let qualified = crate::local::source_image_ref(short);
+        if tag == short || tag == qualified {
+            if tag != short {
+                tags.push(short.to_string());
+            }
+            if tag != qualified {
+                tags.push(qualified);
+            }
+        }
+    }
+    tags
+}
+
+/// Build one platform image. The single `docker build` invocation for Curie
+/// images: `curie build` and `curie local up --build` both route here (#1931).
+pub(crate) async fn build_image(dockerfile: &str, tag: &str) -> Result<()> {
     let ui = crate::ui::ui();
     if !on_path("docker") {
         bail!(
@@ -600,26 +621,90 @@ pub async fn build(tag: &str) -> Result<()> {
         );
     }
     let root = find_repo_root().context(
-        "runner/Dockerfile not found here or in any parent directory. Run `curie build` \
-         from a curie repo checkout -- a release binary pulls the runner image from GHCR \
-         automatically and never needs to build.",
+        "runner/Dockerfile not found here or in any parent directory. Run this from a \
+         curie repo checkout -- a release binary pulls published images and never needs to build.",
     )?;
+    let tags = platform_image_tags(dockerfile, tag);
+    let mut args = vec![
+        "build".to_string(),
+        "-f".to_string(),
+        dockerfile.to_string(),
+    ];
+    for image_tag in &tags {
+        args.push("-t".to_string());
+        args.push(image_tag.clone());
+    }
+    args.push(".".to_string());
+    let rendered = tags
+        .iter()
+        .map(|image_tag| format!("-t {image_tag}"))
+        .collect::<Vec<_>>()
+        .join(" ");
     ui.note(&format!(
-        "=== docker build -f runner/Dockerfile -t {tag} . (in {}) ===",
+        "=== docker build -f {dockerfile} {rendered} . (in {}) ===",
         root.display()
     ));
     // Inherit stdio so the build log streams to the terminal like a hand-run build.
     let status = tokio::process::Command::new("docker")
-        .args(["build", "-f", "runner/Dockerfile", "-t", tag, "."])
+        .args(&args)
         .current_dir(&root)
         .status()
         .await
         .context("failed to invoke docker")?;
     if !status.success() {
-        bail!("docker build failed ({status})");
+        bail!("docker build failed for {dockerfile} ({status})");
     }
+    Ok(())
+}
+
+/// `curie build`: build the runner image locally from the repo's Dockerfile.
+/// The one-command equivalent of `docker build -f runner/Dockerfile -t <tag> .`
+/// run from the repo root. Errors clearly when Docker is missing or when run
+/// outside a source checkout (a release binary pulls the image from GHCR).
+///
+/// When `tag` is the default short name, the same image is also tagged
+/// [`crate::local::source_image_ref`] so a `--build` stack sees it.
+pub async fn build(tag: &str) -> Result<()> {
+    let ui = crate::ui::ui();
+    build_image("runner/Dockerfile", tag).await?;
     ui.success(&format!("built runner image '{tag}'"));
     Ok(())
+}
+
+#[cfg(test)]
+mod platform_image_tags_tests {
+    use super::platform_image_tags;
+    use crate::docker::RUNNER_IMAGE;
+    use crate::local::source_image_ref;
+
+    #[test]
+    fn runner_short_name_also_tags_the_build_stack_ref() {
+        let tags = platform_image_tags("runner/Dockerfile", RUNNER_IMAGE);
+        assert_eq!(
+            tags,
+            vec![RUNNER_IMAGE.to_string(), source_image_ref(RUNNER_IMAGE),]
+        );
+    }
+
+    #[test]
+    fn runner_build_stack_ref_also_tags_the_short_name() {
+        let qualified = source_image_ref(RUNNER_IMAGE);
+        let tags = platform_image_tags("runner/Dockerfile", &qualified);
+        assert_eq!(tags, vec![qualified, RUNNER_IMAGE.to_string()]);
+    }
+
+    #[test]
+    fn custom_runner_tag_is_left_alone() {
+        let tags = platform_image_tags("runner/Dockerfile", "my-runner");
+        assert_eq!(tags, vec!["my-runner".to_string()]);
+    }
+
+    #[test]
+    fn non_runner_image_keeps_its_single_tag() {
+        let tag = source_image_ref("curie-api");
+        let tags = platform_image_tags("apps/api/Dockerfile", &tag);
+        assert_eq!(tags, vec![tag]);
+    }
 }
 
 /// `curie install`: from-a-checkout dev bootstrap/update -- install deps and
@@ -1267,9 +1352,10 @@ fn on_path(bin: &str) -> bool {
 /// Walk up from the current directory to the repo root: the nearest ancestor
 /// that contains `runner/Dockerfile`.
 ///
-/// `pub(crate)` for `local::build_source_images` (#1915), which builds the dev
-/// stack's images from the same root and wants the same "are we in a checkout"
-/// answer rather than a second walk with its own anchor file.
+/// `pub(crate)` for `build_image` and `local::build_source_images` (#1915),
+/// which build the dev stack's images from the same root and want the same
+/// "are we in a checkout" answer rather than a second walk with its own
+/// anchor file.
 pub(crate) fn find_repo_root() -> Option<PathBuf> {
     let mut dir = std::env::current_dir().ok()?;
     loop {

--- a/cli/src/local.rs
+++ b/cli/src/local.rs
@@ -253,6 +253,14 @@ pub struct LocalOpts {
 /// silent one, and a fixed name keeps `docker images` readable.
 pub const SOURCE_IMAGE_TAG: &str = "dev";
 
+/// The ghcr ref `--build` writes and the stack runs, for one published image.
+///
+/// Named once so `build_source_images` and `compose_model_env` cannot drift:
+/// the tag a `--build` stack runs is the tag it just built (#1931).
+pub fn source_image_ref(image: &str) -> String {
+    format!("ghcr.io/curie-eng/{image}:{SOURCE_IMAGE_TAG}")
+}
+
 /// One published image the dev stack can run, and where its source lives.
 pub struct SourceImage {
     /// The ghcr repository name, matching `compose.dev.yaml`.
@@ -424,10 +432,7 @@ fn compose_model_env(o: &LocalOpts, model: Option<&str>) -> Vec<(String, String)
         env.push(("CURIE_BASE_TAG".into(), SOURCE_IMAGE_TAG.into()));
         for image in source_images(o) {
             if let Some(name) = image.env {
-                env.push((
-                    name.into(),
-                    format!("ghcr.io/curie-eng/{}:{SOURCE_IMAGE_TAG}", image.image),
-                ));
+                env.push((name.into(), source_image_ref(image.image)));
             }
         }
     }
@@ -651,6 +656,9 @@ pub fn apply_credential_plan(
 /// missing field, or `No module named` from inside a container.
 async fn build_source_images(o: &LocalOpts) -> Result<()> {
     let ui = crate::ui::ui();
+    // Same checkout sentinel `curie build` uses: a release binary has nothing
+    // to build. Keep the `--build`-specific error here rather than inside the
+    // shared builder, which both verbs call.
     let root = crate::commands::find_repo_root().context(
         "not inside a curie source checkout. `--build` builds the stack's images from \
          source; a release binary runs the published images and has nothing to build.",
@@ -662,21 +670,8 @@ async fn build_source_images(o: &LocalOpts) -> Result<()> {
         root.display()
     ));
     for image in &images {
-        let tag = format!("ghcr.io/curie-eng/{}:{SOURCE_IMAGE_TAG}", image.image);
-        ui.note(&format!(
-            "=== docker build -f {} -t {tag} . ===",
-            image.dockerfile
-        ));
-        // Inherit stdio so the build log streams, matching `curie build`.
-        let status = tokio::process::Command::new("docker")
-            .args(["build", "-f", image.dockerfile, "-t", &tag, "."])
-            .current_dir(&root)
-            .status()
-            .await
-            .context("failed to invoke docker")?;
-        if !status.success() {
-            bail!("docker build failed for {} ({status})", image.image);
-        }
+        let tag = source_image_ref(image.image);
+        crate::commands::build_image(image.dockerfile, &tag).await?;
     }
     ui.success(&format!(
         "built {} image(s) as :{SOURCE_IMAGE_TAG}; the stack below runs them",
@@ -2109,7 +2104,8 @@ mod tests {
 
         assert!(
             display.contains(&format!(
-                "CURIE_RUNNER_IMAGE=ghcr.io/curie-eng/curie-runner:{SOURCE_IMAGE_TAG}"
+                "CURIE_RUNNER_IMAGE={}",
+                source_image_ref("curie-runner")
             )),
             "got: {display}"
         );

--- a/cli/tests/platform_image_builder.rs
+++ b/cli/tests/platform_image_builder.rs
@@ -1,0 +1,365 @@
+//! #1931: exactly one CLI function invokes `docker build` for a platform image,
+//! and the two runner identities (`curie-runner` and the `--build` ghcr `:dev`
+//! ref) are produced together.
+//!
+//! Connector image builds (`connector_build.rs`) are a different product
+//! surface and are excluded. This gate is about Curie platform images.
+
+use std::path::{Path, PathBuf};
+
+fn cli_src_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src")
+}
+
+fn production_src_files() -> Vec<(String, String)> {
+    let dir = cli_src_dir();
+    let mut out = Vec::new();
+    for entry in
+        std::fs::read_dir(&dir).unwrap_or_else(|e| panic!("read_dir {}: {e}", dir.display()))
+    {
+        let entry = entry.unwrap_or_else(|e| panic!("read_dir entry: {e}"));
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("rs") {
+            continue;
+        }
+        let name = path
+            .file_name()
+            .and_then(|n| n.to_string_lossy().into_owned().into())
+            .unwrap_or_default();
+        if name == "connector_build.rs" {
+            continue;
+        }
+        let text = std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+        out.push((name, strip_cfg_test_modules(&text)));
+    }
+    assert!(
+        !out.is_empty(),
+        "expected cli/src/*.rs files; glob is misconfigured"
+    );
+    out
+}
+
+/// Drop `#[cfg(test)]` modules so fixtures cannot satisfy or violate the gate.
+fn strip_cfg_test_modules(src: &str) -> String {
+    let chars: Vec<char> = src.chars().collect();
+    let mut out = String::new();
+    let mut i = 0;
+    while i < chars.len() {
+        if starts_with_at(&chars, i, "#[cfg(test)]") {
+            i += "#[cfg(test)]".len();
+            while i < chars.len() && chars[i].is_whitespace() {
+                i += 1;
+            }
+            // Skip an annotated `mod ... { ... }` or a single `fn` item.
+            if starts_with_at(&chars, i, "mod ") || starts_with_at(&chars, i, "pub mod ") {
+                while i < chars.len() && chars[i] != '{' {
+                    i += 1;
+                }
+                if i < chars.len() && chars[i] == '{' {
+                    i = skip_brace_block(&chars, i);
+                }
+                continue;
+            }
+            continue;
+        }
+        out.push(chars[i]);
+        i += 1;
+    }
+    out
+}
+
+fn starts_with_at(chars: &[char], i: usize, needle: &str) -> bool {
+    let n: Vec<char> = needle.chars().collect();
+    chars.get(i..i + n.len()) == Some(n.as_slice())
+}
+
+fn skip_brace_block(chars: &[char], mut i: usize) -> usize {
+    let mut depth = 0;
+    let mut in_str = false;
+    let mut in_char = false;
+    let mut escaped = false;
+    while i < chars.len() {
+        let c = chars[i];
+        if in_str {
+            if escaped {
+                escaped = false;
+            } else if c == '\\' {
+                escaped = true;
+            } else if c == '"' {
+                in_str = false;
+            }
+            i += 1;
+            continue;
+        }
+        if in_char {
+            if escaped {
+                escaped = false;
+            } else if c == '\\' {
+                escaped = true;
+            } else if c == '\'' {
+                in_char = false;
+            }
+            i += 1;
+            continue;
+        }
+        match c {
+            '"' => in_str = true,
+            '\'' => in_char = true,
+            '{' => depth += 1,
+            '}' => {
+                depth -= 1;
+                i += 1;
+                if depth == 0 {
+                    return i;
+                }
+                continue;
+            }
+            '/' if chars.get(i + 1) == Some(&'/') => {
+                while i < chars.len() && chars[i] != '\n' {
+                    i += 1;
+                }
+                continue;
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    i
+}
+
+fn function_items(src: &str) -> Vec<(String, String)> {
+    let chars: Vec<char> = src.chars().collect();
+    let mut items = Vec::new();
+    let mut i = 0;
+    while i < chars.len() {
+        if let Some((name, start)) = match_fn_at(&chars, i) {
+            let mut j = start;
+            while j < chars.len() && chars[j] != '{' && chars[j] != ';' {
+                j += 1;
+            }
+            if j < chars.len() && chars[j] == '{' {
+                let end = skip_brace_block(&chars, j);
+                items.push((name, chars[j..end].iter().collect()));
+                i = end;
+                continue;
+            }
+        }
+        i += 1;
+    }
+    items
+}
+
+fn match_fn_at(chars: &[char], i: usize) -> Option<(String, usize)> {
+    // Accept `fn name`, `pub fn`, `pub(crate) fn`, `pub(crate) async fn`, `async fn`.
+    let rest: String = chars[i..].iter().take(80).collect();
+    let trimmed = rest.trim_start();
+    let skipped = rest.len() - trimmed.len();
+    let mut s = trimmed;
+    if let Some(x) = s.strip_prefix("pub(crate) ") {
+        s = x;
+    } else if let Some(x) = s.strip_prefix("pub ") {
+        s = x;
+    }
+    if let Some(x) = s.strip_prefix("async ") {
+        s = x;
+    }
+    let after = s.strip_prefix("fn ")?;
+    // Must be a real item, not `fn` inside a comment we failed to skip. The
+    // start index `i` should sit at a token boundary.
+    if i > 0 {
+        let prev = chars[i - 1];
+        if prev.is_ascii_alphanumeric() || prev == '_' {
+            return None;
+        }
+    }
+    let name: String = after
+        .chars()
+        .take_while(|c| c.is_ascii_alphanumeric() || *c == '_')
+        .collect();
+    if name.is_empty() {
+        return None;
+    }
+    let start = i + skipped + (trimmed.len() - after.len());
+    Some((name, start))
+}
+
+fn is_platform_docker_build(body: &str) -> bool {
+    if !body.contains(r#"Command::new("docker")"#) && !body.contains("Command::new(\"docker\")") {
+        return false;
+    }
+    // The docker *subcommand* `build` plus a Dockerfile `-f`, which is how
+    // both current platform-image sites invoke it. `docker image inspect`
+    // and `docker run` do not match.
+    let has_build_arg = body.contains(r#""build""#) || body.contains("\"build\",");
+    let has_file_flag = body.contains(r#""-f""#) || body.contains("\"-f\",");
+    has_build_arg && has_file_flag
+}
+
+fn platform_docker_build_functions() -> Vec<(String, String)> {
+    let mut found = Vec::new();
+    for (file, src) in production_src_files() {
+        for (name, body) in function_items(&src) {
+            if is_platform_docker_build(&body) {
+                found.push((file.clone(), name));
+            }
+        }
+    }
+    found.sort();
+    found.dedup();
+    found
+}
+
+fn file_src(name: &str) -> String {
+    production_src_files()
+        .into_iter()
+        .find(|(n, _)| n == name)
+        .unwrap_or_else(|| panic!("missing {name}"))
+        .1
+}
+
+fn function_body(file: &str, fn_name: &str) -> String {
+    let src = file_src(file);
+    function_items(&src)
+        .into_iter()
+        .find(|(n, _)| n == fn_name)
+        .unwrap_or_else(|| panic!("{file} has no fn {fn_name}"))
+        .1
+}
+
+/// Adding a second `docker build` for a platform image must go red.
+#[test]
+fn exactly_one_function_invokes_docker_build_for_a_platform_image() {
+    let found = platform_docker_build_functions();
+    assert_eq!(
+        found,
+        vec![("commands.rs".to_string(), "build_image".to_string())],
+        "exactly one function may shell `docker build` for a platform image; \
+         found {found:?}. Extract new sites into `commands::build_image`."
+    );
+}
+
+/// Both product paths must call that function, not shell docker themselves.
+#[test]
+fn curie_build_and_local_up_build_route_through_build_image() {
+    let build = function_body("commands.rs", "build");
+    assert!(
+        build.contains("build_image("),
+        "`curie build` must call build_image; body was: {build}"
+    );
+    assert!(
+        !is_platform_docker_build(&build),
+        "`curie build` must not invoke docker build itself"
+    );
+
+    let source = function_body("local.rs", "build_source_images");
+    assert!(
+        source.contains("build_image("),
+        "`local up --build` must call build_image; body was: {source}"
+    );
+    assert!(
+        !is_platform_docker_build(&source),
+        "`build_source_images` must not invoke docker build itself"
+    );
+}
+
+/// Changing the tag on one path without the other must go red.
+///
+/// The ghcr `:dev` ref is defined once (`source_image_ref`) and both the
+/// compose env `--build` exports and the images `--build` builds must call it.
+/// `build_image` must also tag the short `RUNNER_IMAGE` name when it builds
+/// the runner, so `curie build` refreshes what a `--build` stack runs.
+#[test]
+fn runner_tags_are_one_identity_across_both_paths() {
+    let local = file_src("local.rs");
+    assert!(
+        local.contains("fn source_image_ref"),
+        "the ghcr source-image ref must be a named function so both paths share it"
+    );
+
+    let compose_env = function_body("local.rs", "compose_model_env");
+    assert!(
+        compose_env.contains("source_image_ref("),
+        "compose_model_env must use source_image_ref so the stack runs what --build built; body: {compose_env}"
+    );
+    assert!(
+        !compose_env.contains("ghcr.io/curie-eng/"),
+        "compose_model_env must not inline a second copy of the ghcr ref; body: {compose_env}"
+    );
+
+    let source_builds = function_body("local.rs", "build_source_images");
+    assert!(
+        source_builds.contains("source_image_ref("),
+        "build_source_images must use source_image_ref so the tag it builds matches compose; body: {source_builds}"
+    );
+    assert!(
+        !source_builds.contains("ghcr.io/curie-eng/"),
+        "build_source_images must not inline a second copy of the ghcr ref; body: {source_builds}"
+    );
+
+    let builder = function_body("commands.rs", "build_image");
+    assert!(
+        builder.contains("RUNNER_IMAGE") || builder.contains("platform_image_tags("),
+        "build_image must reconcile the short runner name; body: {builder}"
+    );
+    assert!(
+        builder.contains("source_image_ref(")
+            || builder.contains("SOURCE_IMAGE_TAG")
+            || builder.contains("platform_image_tags("),
+        "build_image must reconcile the --build ghcr runner ref; body: {builder}"
+    );
+
+    // The relationship itself: building the runner Dockerfile under either
+    // identity applies both tags. platform_image_tags is the named decision.
+    let tags_fn = function_body("commands.rs", "platform_image_tags");
+    assert!(
+        tags_fn.contains("RUNNER_IMAGE"),
+        "platform_image_tags must name the short runner identity"
+    );
+    assert!(
+        tags_fn.contains("source_image_ref(") || tags_fn.contains("SOURCE_IMAGE_TAG"),
+        "platform_image_tags must name the --build runner identity"
+    );
+}
+
+/// Sanity: the scanner still sees the files it claims to police.
+#[test]
+fn scanner_sees_the_two_callers() {
+    let names: Vec<String> = function_items(&file_src("commands.rs"))
+        .into_iter()
+        .map(|(n, _)| n)
+        .collect();
+    assert!(
+        names.contains(&"build".to_string()),
+        "commands.rs must still define build; scanner broken if not"
+    );
+    let local_names: Vec<String> = function_items(&file_src("local.rs"))
+        .into_iter()
+        .map(|(n, _)| n)
+        .collect();
+    assert!(
+        local_names.contains(&"build_source_images".to_string()),
+        "local.rs must still define build_source_images; scanner broken if not"
+    );
+}
+
+/// CLAUDE.md must keep `curie build` as the runner-image entry point (the
+/// line the issue cites) and must not describe a second builder.
+#[test]
+fn claude_md_names_curie_build_as_the_runner_image_loop() {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("../CLAUDE.md");
+    let text =
+        std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    let runner_line = text
+        .lines()
+        .find(|l| l.contains("Building the runner image"))
+        .unwrap_or("");
+    assert!(
+        runner_line.contains("`curie build`"),
+        "CLAUDE.md must name curie build as the runner-image command; got: {runner_line}"
+    );
+    assert!(
+        !text.contains("two independent") && !text.contains("its own `docker build`"),
+        "CLAUDE.md must not document a second builder; that alternative was rejected"
+    );
+}


### PR DESCRIPTION
## Summary

`curie build` and `curie local up --build` no longer shell `docker build` independently. Both route through `commands::build_image`, which is the one function that invokes `docker build` for a platform image. Building the runner under either identity (`curie-runner` or `ghcr.io/curie-eng/curie-runner:dev`) also tags the other, so `curie update --image` refreshes a `--build` stack's runner. The `curie build` verb is unchanged: this is the builder underneath it, not a wider command surface.

## Related issue

Closes #1931

## Fix pin verification

Fix pin: cli/tests/platform_image_builder.rs::exactly_one_function_invokes_docker_build_for_a_platform_image

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | Does not change plugin packaging, the runner turn loop, ACI events, or skill eval/check. | | |
| local | required | Changes `curie build` and `curie local up --build` so they share one docker build function and one runner identity. | fake | Against `d493876d`. `PATH=<fake-docker>:$PATH curie build` logged `build -f runner/Dockerfile -t curie-runner -t ghcr.io/curie-eng/curie-runner:dev .` then `built runner image 'curie-runner'`. `curie build --tag my-runner` logged only `-t my-runner`. `curie local up --build --dry-run -f compose.dev.yaml` still exports `CURIE_BASE_TAG=dev`, `CURIE_RUNNER_IMAGE=ghcr.io/curie-eng/curie-runner:dev`, `CURIE_UI_IMAGE=...:dev`, `CURIE_DISPATCHER_IMAGE=...:dev`. |
| local-release | n/a | Does not change released binary identity, install path, version pins, or release compose. | | |
| cluster | n/a | Does not touch chart templates, RBAC, securityContext, NetworkPolicy, sandbox claims, or init containers. | | |
| live provider | n/a | Does not change model routing, credential resolution, provider auth, or token/cost accounting. | | |
| external integration | n/a | Does not reach Slack, git push webhooks, connector OAuth, or other third-party APIs. | | |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.

Positive proof: the commands above, plus `cargo test --test platform_image_builder` (5 passed) and `cargo test --lib platform_image_tags` (4 passed).

Falsifiable negatives (run, then restored): inserting a second `Command::new("docker").args(["build", "-f", ...])` in `build_source_images` failed `exactly_one_function_invokes_docker_build_for_a_platform_image` (found `build_image` and `build_source_images`). Inlining `ghcr.io/curie-eng/{}:latest` in `compose_model_env` instead of `source_image_ref` failed `runner_tags_are_one_identity_across_both_paths`.

Full CLI debug suite: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test --all-targets` in debug. Two `verify_fix_pin` tests fail on this tree and on unmodified `origin/next` (`be73a055`) with the same error; they are a baseline failure, not this change.

Not in this PR: #1925, #1926, #1927. Not in this PR: growing `curie build` to five services, or documenting two builders in CLAUDE.md (both rejected).

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed.
- [ ] An ADR is added under `docs/adr/` if this is an architectural decision.
