### PR TITLE
Add targeting flags to the SRE bot example installer

### DIFF
--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -4601,6 +4601,40 @@ export const commandManifest = {
                   "long": "write-allowlist",
                   "positional": false,
                   "required": false
+                },
+                {
+                  "default_values": [
+                    "curie"
+                  ],
+                  "env": "CURIE_NAMESPACE",
+                  "global": false,
+                  "help": "Kubernetes namespace of the Curie release. Default: curie",
+                  "id": "namespace",
+                  "long": "namespace",
+                  "positional": false,
+                  "required": false
+                },
+                {
+                  "default_values": [
+                    "curie"
+                  ],
+                  "global": false,
+                  "help": "Helm release name of the Curie install. Default: curie",
+                  "id": "release",
+                  "long": "release",
+                  "positional": false,
+                  "required": false
+                },
+                {
+                  "default_values": [
+                    "observability"
+                  ],
+                  "global": false,
+                  "help": "Kubernetes namespace of the retained observability stack. Default: observability",
+                  "id": "observability_namespace",
+                  "long": "observability-namespace",
+                  "positional": false,
+                  "required": false
                 }
               ],
               "hidden": false,

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -4598,6 +4598,40 @@
                   "long": "write-allowlist",
                   "positional": false,
                   "required": false
+                },
+                {
+                  "default_values": [
+                    "curie"
+                  ],
+                  "env": "CURIE_NAMESPACE",
+                  "global": false,
+                  "help": "Kubernetes namespace of the Curie release. Default: curie",
+                  "id": "namespace",
+                  "long": "namespace",
+                  "positional": false,
+                  "required": false
+                },
+                {
+                  "default_values": [
+                    "curie"
+                  ],
+                  "global": false,
+                  "help": "Helm release name of the Curie install. Default: curie",
+                  "id": "release",
+                  "long": "release",
+                  "positional": false,
+                  "required": false
+                },
+                {
+                  "default_values": [
+                    "observability"
+                  ],
+                  "global": false,
+                  "help": "Kubernetes namespace of the retained observability stack. Default: observability",
+                  "id": "observability_namespace",
+                  "long": "observability-namespace",
+                  "positional": false,
+                  "required": false
                 }
               ],
               "hidden": false,

--- a/cli/src/examples.rs
+++ b/cli/src/examples.rs
@@ -21,6 +21,7 @@ use crate::ui::DryRunPlan;
 
 const OBSERVABILITY_NAMESPACE: &str = "observability";
 const CURIE_NAMESPACE: &str = "curie";
+#[allow(dead_code)] // clap --release default; kept beside the other identity names
 const CURIE_RELEASE: &str = "curie";
 // The issue text says 1248Mi, but its seven exact appendix requests total
 // 1312Mi on one node once the enabled 64Mi kube-state-metrics request is
@@ -121,6 +122,25 @@ pub struct SreBotInstallOpts {
     pub slack_channel: Option<String>,
     /// `ns/name[,ns/name]`. Absent keeps the install read only.
     pub write_allowlist: Option<String>,
+    pub namespace: String,
+    pub release: String,
+    pub observability_namespace: String,
+}
+
+struct InstallIdentity {
+    namespace: String,
+    release: String,
+    observability_namespace: String,
+}
+
+impl InstallIdentity {
+    fn from_opts(opts: &SreBotInstallOpts) -> Self {
+        Self {
+            namespace: opts.namespace.clone(),
+            release: opts.release.clone(),
+            observability_namespace: opts.observability_namespace.clone(),
+        }
+    }
 }
 
 pub enum SreBotInstallResult {
@@ -180,8 +200,8 @@ impl InstallCommand {
 
 #[derive(Clone)]
 struct HelmTarget {
-    release: &'static str,
-    namespace: &'static str,
+    release: String,
+    namespace: String,
 }
 
 fn plain(value: impl Into<String>) -> CommandArg {
@@ -242,6 +262,7 @@ fn upstream_upgrade(
     chart: &'static str,
     version: &'static str,
     values: &'static str,
+    observability_namespace: &str,
 ) -> InstallCommand {
     InstallCommand {
         program: "helm",
@@ -253,7 +274,7 @@ fn upstream_upgrade(
             plain("--version"),
             plain(version),
             plain("--namespace"),
-            plain(OBSERVABILITY_NAMESPACE),
+            plain(observability_namespace),
             plain("--create-namespace"),
             plain("-f"),
             CommandArg::ObservabilityFile(values),
@@ -262,13 +283,13 @@ fn upstream_upgrade(
             plain(HELM_TIMEOUT),
         ],
         helm_target: Some(HelmTarget {
-            release,
-            namespace: OBSERVABILITY_NAMESPACE,
+            release: release.to_string(),
+            namespace: observability_namespace.to_string(),
         }),
     }
 }
 
-fn stack_install_commands() -> Vec<InstallCommand> {
+fn stack_install_commands(observability_namespace: &str) -> Vec<InstallCommand> {
     let mut commands = helm_repo_commands();
     commands.extend([
         upstream_upgrade(
@@ -276,26 +297,35 @@ fn stack_install_commands() -> Vec<InstallCommand> {
             "grafana-community/grafana",
             "12.11.1",
             "grafana-values.yaml",
+            observability_namespace,
         ),
         upstream_upgrade(
             "loki",
             "grafana-community/loki",
             "18.10.1",
             "loki-values.yaml",
+            observability_namespace,
         ),
-        upstream_upgrade("alloy", "grafana/alloy", "1.11.1", "alloy-values.yaml"),
+        upstream_upgrade(
+            "alloy",
+            "grafana/alloy",
+            "1.11.1",
+            "alloy-values.yaml",
+            observability_namespace,
+        ),
         upstream_upgrade(
             "prometheus",
             "prometheus-community/prometheus",
             "29.27.0",
             "prometheus-values.yaml",
+            observability_namespace,
         ),
         InstallCommand {
             program: "kubectl",
             args: vec![
                 plain("apply"),
                 plain("--namespace"),
-                plain(OBSERVABILITY_NAMESPACE),
+                plain(observability_namespace),
                 plain("-f"),
                 CommandArg::ObservabilityFile("tempo.yaml"),
             ],
@@ -308,7 +338,7 @@ fn stack_install_commands() -> Vec<InstallCommand> {
                 plain("status"),
                 plain("statefulset/tempo"),
                 plain("--namespace"),
-                plain(OBSERVABILITY_NAMESPACE),
+                plain(observability_namespace),
                 plain(format!("--timeout={HELM_TIMEOUT}")),
             ],
             helm_target: None,
@@ -317,15 +347,15 @@ fn stack_install_commands() -> Vec<InstallCommand> {
     commands
 }
 
-fn curie_integration_command() -> InstallCommand {
+fn curie_integration_command(identity: &InstallIdentity) -> InstallCommand {
     InstallCommand {
         program: "helm",
         args: vec![
             plain("upgrade"),
-            plain(CURIE_RELEASE),
+            plain(&identity.release),
             CommandArg::CurieChart,
             plain("--namespace"),
-            plain(CURIE_NAMESPACE),
+            plain(&identity.namespace),
             plain("--reuse-values"),
             plain("-f"),
             CommandArg::ObservabilityFile("curie-values.yaml"),
@@ -334,8 +364,8 @@ fn curie_integration_command() -> InstallCommand {
             plain(HELM_TIMEOUT),
         ],
         helm_target: Some(HelmTarget {
-            release: CURIE_RELEASE,
-            namespace: CURIE_NAMESPACE,
+            release: identity.release.clone(),
+            namespace: identity.namespace.clone(),
         }),
     }
 }
@@ -376,8 +406,9 @@ pub async fn install_sre_bot(opts: SreBotInstallOpts) -> Result<SreBotInstallRes
         None => None,
     };
     let write_targets = write_targets.as_deref();
+    let identity = InstallIdentity::from_opts(&opts);
 
-    preflight_capacity().await?;
+    preflight_capacity(&identity.observability_namespace).await?;
 
     let resolved_chart = crate::artifacts::resolve_chart(
         None,
@@ -386,8 +417,8 @@ pub async fn install_sre_bot(opts: SreBotInstallOpts) -> Result<SreBotInstallRes
         crate::artifacts::cache_root,
         Path::new("charts/curie").is_dir(),
     )?;
-    let stack_commands = stack_install_commands();
-    let integration_command = curie_integration_command();
+    let stack_commands = stack_install_commands(&identity.observability_namespace);
+    let integration_command = curie_integration_command(&identity);
     let read_access_command = read_access_command();
     let write_role_command = write_role_command();
 
@@ -397,14 +428,16 @@ pub async fn install_sre_bot(opts: SreBotInstallOpts) -> Result<SreBotInstallRes
             "resolve {TEMPO_TAGGED_IMAGE} to its immutable OCI image index digest before cluster mutation"
         )];
         lines.push(format!(
-            "preserve or create Secret {GRAFANA_ADMIN_SECRET} in namespace {OBSERVABILITY_NAMESPACE} without exposing its generated password"
+            "preserve or create Secret {GRAFANA_ADMIN_SECRET} in namespace {} without exposing its generated password",
+            identity.observability_namespace
         ));
         lines.extend(stack_commands.iter().map(|command| command.display(&chart)));
-        lines.extend(apply_curie_platform(&chart, true).await?);
+        lines.extend(apply_curie_platform(&chart, true, &identity).await?);
         lines.push(integration_command.display(&chart));
         lines.push(read_access_command.display(&chart));
         lines.push(format!(
-            "kubectl wait --namespace {CURIE_NAMESPACE} --for=jsonpath={{.data.token}} secret/{READER_TOKEN_SECRET} --timeout={READER_TOKEN_TIMEOUT}"
+            "kubectl wait --namespace {} --for=jsonpath={{.data.token}} secret/{READER_TOKEN_SECRET} --timeout={READER_TOKEN_TIMEOUT}",
+            identity.namespace
         ));
         lines.push(
             "build the read only Kubernetes connector kubeconfig in memory from the ServiceAccount token"
@@ -418,14 +451,18 @@ pub async fn install_sre_bot(opts: SreBotInstallOpts) -> Result<SreBotInstallRes
             ));
             lines.push(write_role_command.display(&chart));
             lines.push(format!(
-                "kubectl wait --namespace {CURIE_NAMESPACE} --for=jsonpath={{.data.token}} secret/{WRITER_TOKEN_SECRET} --timeout={READER_TOKEN_TIMEOUT}"
+                "kubectl wait --namespace {} --for=jsonpath={{.data.token}} secret/{WRITER_TOKEN_SECRET} --timeout={READER_TOKEN_TIMEOUT}",
+                identity.namespace
             ));
             lines.push(
                 "build the gated write Kubernetes connector kubeconfig in memory from the ServiceAccount token"
                     .to_string(),
             );
         }
-        let mut deploy = "curie cluster deploy --plugin-dir embedded:examples/sre-bot --namespace curie --release curie".to_string();
+        let mut deploy = format!(
+            "curie cluster deploy --plugin-dir embedded:examples/sre-bot --namespace {} --release {}",
+            identity.namespace, identity.release
+        );
         if let Some(channel) = &opts.slack_channel {
             deploy.push_str(&format!(" --slack-channel {channel}"));
         }
@@ -440,25 +477,25 @@ pub async fn install_sre_bot(opts: SreBotInstallOpts) -> Result<SreBotInstallRes
     let tempo_digest = resolve_tempo_index_digest().await?;
     let chart = crate::artifacts::ensure_cached(&resolved_chart).await?;
     crate::ops::require_on_path("helm")?;
-    let workspace = EmbeddedWorkspace::create(&tempo_digest, write_targets)?;
-    ensure_grafana_admin_secret().await?;
+    let workspace = EmbeddedWorkspace::create(&tempo_digest, write_targets, &identity)?;
+    ensure_grafana_admin_secret(&identity.observability_namespace).await?;
     for command in &stack_commands {
         run_install_command(command, &workspace, &chart).await?;
     }
-    apply_curie_platform(&chart, false).await?;
+    apply_curie_platform(&chart, false, &identity).await?;
     run_install_command(&integration_command, &workspace, &chart).await?;
     run_install_command(&read_access_command, &workspace, &chart).await?;
-    let kubeconfig = read_only_connector_kubeconfig().await?;
+    let kubeconfig = read_only_connector_kubeconfig(&identity.namespace).await?;
     let write_kubeconfig = match write_targets {
         Some(_) => {
             run_install_command(&write_role_command, &workspace, &chart).await?;
-            Some(write_connector_kubeconfig().await?)
+            Some(write_connector_kubeconfig(&identity.namespace).await?)
         }
         None => None,
     };
 
     let bundle_dir = workspace.bundle_dir();
-    let connection = resolve_embedded_cluster_connection().await?;
+    let connection = resolve_embedded_cluster_connection(&identity).await?;
     let deployed =
         deploy_embedded_sre_bot(&bundle_dir, &connection, opts.slack_channel.as_deref()).await?;
     let mut secret_overrides = BTreeMap::from([(KUBECONFIG_SECRET_KEY.to_string(), kubeconfig)]);
@@ -468,8 +505,8 @@ pub async fn install_sre_bot(opts: SreBotInstallOpts) -> Result<SreBotInstallRes
     crate::connectors::sync_deployed_version(
         &connection.api_url,
         &connection.api_key,
-        CURIE_NAMESPACE,
-        CURIE_RELEASE,
+        &identity.namespace,
+        &identity.release,
         &deployed,
         &secret_overrides,
     )
@@ -477,12 +514,16 @@ pub async fn install_sre_bot(opts: SreBotInstallOpts) -> Result<SreBotInstallRes
     Ok(SreBotInstallResult::Installed(Box::new(deployed)))
 }
 
-async fn apply_curie_platform(chart: &Path, dry_run: bool) -> Result<Vec<String>> {
+async fn apply_curie_platform(
+    chart: &Path,
+    dry_run: bool,
+    identity: &InstallIdentity,
+) -> Result<Vec<String>> {
     let installation = crate::installation::Installation {
         version: crate::installation::SUPPORTED_VERSION,
         install: crate::installation::Install {
-            namespace: CURIE_NAMESPACE.to_string(),
-            release: CURIE_RELEASE.to_string(),
+            namespace: identity.namespace.clone(),
+            release: identity.release.clone(),
         },
         platform: crate::installation::Platform::default(),
         credentials: crate::installation::Credentials::default(),
@@ -607,15 +648,15 @@ fn validate_sha256_digest(digest: &str) -> Result<()> {
     Ok(())
 }
 
-async fn ensure_grafana_admin_secret() -> Result<()> {
-    ensure_observability_namespace().await?;
+async fn ensure_grafana_admin_secret(observability_namespace: &str) -> Result<()> {
+    ensure_observability_namespace(observability_namespace).await?;
     let inspect = tokio::process::Command::new("kubectl")
         .args([
             "get",
             "secret",
             GRAFANA_ADMIN_SECRET,
             "--namespace",
-            OBSERVABILITY_NAMESPACE,
+            observability_namespace,
             "-o",
             "json",
         ])
@@ -629,13 +670,13 @@ async fn ensure_grafana_admin_secret() -> Result<()> {
     let lower = stderr.to_ascii_lowercase();
     if !lower.contains("notfound") && !lower.contains("not found") {
         bail!(
-            "could not inspect Secret {GRAFANA_ADMIN_SECRET} in namespace {OBSERVABILITY_NAMESPACE} with `kubectl get secret {GRAFANA_ADMIN_SECRET} -n {OBSERVABILITY_NAMESPACE}`: {}",
+            "could not inspect Secret {GRAFANA_ADMIN_SECRET} in namespace {observability_namespace} with `kubectl get secret {GRAFANA_ADMIN_SECRET} -n {observability_namespace}`: {}",
             stderr.trim()
         );
     }
 
-    if grafana_release_exists().await? {
-        return migrate_grafana_admin_secret().await;
+    if grafana_release_exists(observability_namespace).await? {
+        return migrate_grafana_admin_secret(observability_namespace).await;
     }
 
     let password = random_hex(32)?;
@@ -644,7 +685,7 @@ async fn ensure_grafana_admin_secret() -> Result<()> {
         "kind": "Secret",
         "metadata": {
             "name": GRAFANA_ADMIN_SECRET,
-            "namespace": OBSERVABILITY_NAMESPACE,
+            "namespace": observability_namespace,
         },
         "type": "Opaque",
         "stringData": {
@@ -652,16 +693,16 @@ async fn ensure_grafana_admin_secret() -> Result<()> {
             "admin-password": password,
         },
     }))?;
-    apply_private_manifest(&manifest, "Grafana admin Secret").await
+    apply_private_manifest(&manifest, "Grafana admin Secret", observability_namespace).await
 }
 
-async fn grafana_release_exists() -> Result<bool> {
+async fn grafana_release_exists(observability_namespace: &str) -> Result<bool> {
     let output = tokio::process::Command::new("helm")
         .args([
             "status",
             GRAFANA_RELEASE,
             "--namespace",
-            OBSERVABILITY_NAMESPACE,
+            observability_namespace,
             "-o",
             "json",
         ])
@@ -676,7 +717,7 @@ async fn grafana_release_exists() -> Result<bool> {
         return Ok(false);
     }
     bail!(
-        "could not determine whether Grafana is already installed; run `helm status {GRAFANA_RELEASE} -n {OBSERVABILITY_NAMESPACE}` and retry"
+        "could not determine whether Grafana is already installed; run `helm status {GRAFANA_RELEASE} -n {observability_namespace}` and retry"
     )
 }
 
@@ -686,13 +727,13 @@ struct SecretKeyReference {
     key: String,
 }
 
-async fn migrate_grafana_admin_secret() -> Result<()> {
+async fn migrate_grafana_admin_secret(observability_namespace: &str) -> Result<()> {
     let output = tokio::process::Command::new("kubectl")
         .args([
             "get",
             "deployment,statefulset",
             "--namespace",
-            OBSERVABILITY_NAMESPACE,
+            observability_namespace,
             "-l",
             "app.kubernetes.io/instance=grafana",
             "-o",
@@ -720,7 +761,7 @@ async fn migrate_grafana_admin_secret() -> Result<()> {
                 "secret",
                 source_name,
                 "--namespace",
-                OBSERVABILITY_NAMESPACE,
+                observability_namespace,
                 "-o",
                 "json",
             ])
@@ -742,7 +783,7 @@ async fn migrate_grafana_admin_secret() -> Result<()> {
         "kind": "Secret",
         "metadata": {
             "name": GRAFANA_ADMIN_SECRET,
-            "namespace": OBSERVABILITY_NAMESPACE,
+            "namespace": observability_namespace,
         },
         "type": "Opaque",
         "data": {
@@ -750,7 +791,7 @@ async fn migrate_grafana_admin_secret() -> Result<()> {
             "admin-password": password_data,
         },
     }))?;
-    apply_private_manifest(&manifest, "Grafana admin Secret").await
+    apply_private_manifest(&manifest, "Grafana admin Secret", observability_namespace).await
 }
 
 fn find_grafana_secret_reference(
@@ -828,9 +869,9 @@ fn secret_data_value(
     Ok(encoded.to_string())
 }
 
-async fn ensure_observability_namespace() -> Result<()> {
+async fn ensure_observability_namespace(observability_namespace: &str) -> Result<()> {
     let inspect = tokio::process::Command::new("kubectl")
-        .args(["get", "namespace", OBSERVABILITY_NAMESPACE, "-o", "json"])
+        .args(["get", "namespace", observability_namespace, "-o", "json"])
         .output()
         .await
         .context("inspecting the observability namespace")?;
@@ -841,24 +882,28 @@ async fn ensure_observability_namespace() -> Result<()> {
     let lower = stderr.to_ascii_lowercase();
     if !lower.contains("notfound") && !lower.contains("not found") {
         bail!(
-            "could not inspect namespace {OBSERVABILITY_NAMESPACE} with `kubectl get namespace {OBSERVABILITY_NAMESPACE}`: {}",
+            "could not inspect namespace {observability_namespace} with `kubectl get namespace {observability_namespace}`: {}",
             stderr.trim()
         );
     }
     let output = tokio::process::Command::new("kubectl")
-        .args(["create", "namespace", OBSERVABILITY_NAMESPACE])
+        .args(["create", "namespace", observability_namespace])
         .output()
         .await
         .context("creating the observability namespace")?;
     if !output.status.success() {
         bail!(
-            "could not create namespace {OBSERVABILITY_NAMESPACE}; run `kubectl create namespace {OBSERVABILITY_NAMESPACE}` and retry"
+            "could not create namespace {observability_namespace}; run `kubectl create namespace {observability_namespace}` and retry"
         );
     }
     Ok(())
 }
 
-async fn apply_private_manifest(manifest: &[u8], description: &str) -> Result<()> {
+async fn apply_private_manifest(
+    manifest: &[u8],
+    description: &str,
+    observability_namespace: &str,
+) -> Result<()> {
     let mut child = tokio::process::Command::new("kubectl")
         .args(["apply", "-f", "-"])
         .stdin(Stdio::piped())
@@ -881,7 +926,7 @@ async fn apply_private_manifest(manifest: &[u8], description: &str) -> Result<()
         .with_context(|| format!("waiting for kubectl to apply {description}"))?;
     if !output.status.success() {
         bail!(
-            "could not apply {description} {GRAFANA_ADMIN_SECRET} in namespace {OBSERVABILITY_NAMESPACE}; inspect access with `kubectl auth can-i create secret -n {OBSERVABILITY_NAMESPACE}`"
+            "could not apply {description} {GRAFANA_ADMIN_SECRET} in namespace {observability_namespace}; inspect access with `kubectl auth can-i create secret -n {observability_namespace}`"
         );
     }
     Ok(())
@@ -954,12 +999,12 @@ fn helm_pending_upgrade_recovery(target: &HelmTarget) -> String {
     )
 }
 
-async fn read_only_connector_kubeconfig() -> Result<String> {
-    connector_kubeconfig(READER_IDENTITY, READER_TOKEN_SECRET).await
+async fn read_only_connector_kubeconfig(namespace: &str) -> Result<String> {
+    connector_kubeconfig(READER_IDENTITY, READER_TOKEN_SECRET, namespace).await
 }
 
-async fn write_connector_kubeconfig() -> Result<String> {
-    connector_kubeconfig(WRITER_IDENTITY, WRITER_TOKEN_SECRET).await
+async fn write_connector_kubeconfig(namespace: &str) -> Result<String> {
+    connector_kubeconfig(WRITER_IDENTITY, WRITER_TOKEN_SECRET, namespace).await
 }
 
 /// Build one connector's in-memory kubeconfig from a ServiceAccount token Secret.
@@ -967,11 +1012,15 @@ async fn write_connector_kubeconfig() -> Result<String> {
 /// Shared by the read and write identities so they cannot drift in how they
 /// verify the token: both refuse an absent, malformed, or empty token rather
 /// than emitting a kubeconfig the connector would only fail on later.
-async fn connector_kubeconfig(identity: &str, token_secret: &str) -> Result<String> {
+async fn connector_kubeconfig(
+    identity: &str,
+    token_secret: &str,
+    namespace: &str,
+) -> Result<String> {
     let wait_args = [
         "wait",
         "--namespace",
-        CURIE_NAMESPACE,
+        namespace,
         "--for=jsonpath={.data.token}",
         &format!("secret/{token_secret}"),
         &format!("--timeout={READER_TOKEN_TIMEOUT}"),
@@ -985,7 +1034,7 @@ async fn connector_kubeconfig(identity: &str, token_secret: &str) -> Result<Stri
     if !wait.status.success() {
         let stderr = String::from_utf8_lossy(&wait.stderr);
         bail!(
-            "the connector token {token_secret} was not populated within {READER_TOKEN_TIMEOUT}: {}. Inspect it with `kubectl get secret {token_secret} -n {CURIE_NAMESPACE}` and retry",
+            "the connector token {token_secret} was not populated within {READER_TOKEN_TIMEOUT}: {}. Inspect it with `kubectl get secret {token_secret} -n {namespace}` and retry",
             if stderr.trim().is_empty() {
                 "kubectl wait exited nonzero"
             } else {
@@ -999,7 +1048,7 @@ async fn connector_kubeconfig(identity: &str, token_secret: &str) -> Result<Stri
         "secret",
         token_secret,
         "--namespace",
-        CURIE_NAMESPACE,
+        namespace,
         "-o",
         "json",
     ];
@@ -1010,7 +1059,7 @@ async fn connector_kubeconfig(identity: &str, token_secret: &str) -> Result<Stri
         .context("reading the SRE bot ServiceAccount token")?;
     if !output.status.success() {
         bail!(
-            "could not read Secret {token_secret} in namespace {CURIE_NAMESPACE}; inspect it with `kubectl get secret {token_secret} -n {CURIE_NAMESPACE}` and retry"
+            "could not read Secret {token_secret} in namespace {namespace}; inspect it with `kubectl get secret {token_secret} -n {namespace}` and retry"
         );
     }
     let secret: serde_json::Value = serde_json::from_slice(&output.stdout)
@@ -1068,16 +1117,18 @@ struct EmbeddedClusterConnection {
     _port_forward: Option<tokio::process::Child>,
 }
 
-async fn resolve_embedded_cluster_connection() -> Result<EmbeddedClusterConnection> {
-    let api_key = crate::ops::discover_api_key(CURIE_NAMESPACE, CURIE_RELEASE).await?;
+async fn resolve_embedded_cluster_connection(
+    identity: &InstallIdentity,
+) -> Result<EmbeddedClusterConnection> {
+    let api_key = crate::ops::discover_api_key(&identity.namespace, &identity.release).await?;
     let explicit_api_url = std::env::var("CURIE_API_URL")
         .ok()
         .filter(|value| !value.trim().is_empty());
     let local_port = crate::message::DEFAULT_API_LOCAL_PORT;
     let (api_url, port_forward) = match commands::deploy_port_forward(
         explicit_api_url.as_deref(),
-        CURIE_NAMESPACE,
-        CURIE_RELEASE,
+        &identity.namespace,
+        &identity.release,
         local_port,
         crate::message::API_REMOTE_PORT,
     ) {
@@ -1138,7 +1189,11 @@ struct EmbeddedWorkspace {
 }
 
 impl EmbeddedWorkspace {
-    fn create(tempo_digest: &str, write_targets: Option<&[WriteTarget]>) -> Result<Self> {
+    fn create(
+        tempo_digest: &str,
+        write_targets: Option<&[WriteTarget]>,
+        identity: &InstallIdentity,
+    ) -> Result<Self> {
         let root = std::env::temp_dir().join(format!(
             "curie-sre-bot-install-{}-{}",
             std::process::id(),
@@ -1148,11 +1203,18 @@ impl EmbeddedWorkspace {
             .with_context(|| format!("creating embedded SRE bot workspace {}", root.display()))?;
         let workspace = Self { root };
         for (name, contents) in OBSERVABILITY_FILES {
-            workspace.write(&Path::new("observability").join(name), contents)?;
+            let rendered =
+                rewrite_observability_namespace(contents, &identity.observability_namespace);
+            workspace.write(&Path::new("observability").join(name), &rendered)?;
         }
         for (name, contents) in BUNDLE_FILES {
             if *name == "connectors.yaml" {
-                let runtime = runtime_connector_declaration(contents, tempo_digest, write_targets)?;
+                let runtime = runtime_connector_declaration(
+                    contents,
+                    tempo_digest,
+                    write_targets,
+                    &identity.observability_namespace,
+                )?;
                 workspace.write(&Path::new("bundle").join(name), &runtime)?;
             } else if *name == ".claude-plugin/plugin.json" {
                 let runtime = runtime_plugin_manifest(contents, write_targets.is_some())?;
@@ -1165,11 +1227,14 @@ impl EmbeddedWorkspace {
                 // effect, when every consumer of it was stripped above.
                 match write_targets {
                     Some(targets) => {
-                        let rendered = render_write_role(contents, targets)?;
+                        let rendered = render_write_role(contents, targets, &identity.namespace)?;
                         workspace.write(&Path::new("bundle").join(name), &rendered)?;
                     }
                     None => continue,
                 }
+            } else if *name == "manifests/read-access.yaml" {
+                let rendered = render_read_access(contents, &identity.namespace)?;
+                workspace.write(&Path::new("bundle").join(name), &rendered)?;
             } else {
                 workspace.write(&Path::new("bundle").join(name), contents)?;
             }
@@ -1276,7 +1341,76 @@ fn write_allowlist_value(targets: &[WriteTarget]) -> String {
 /// RoleBinding back to that one ServiceAccount. The verb set is read from
 /// `manifests/write-role.yaml` and asserted against what this build knows how to
 /// grant, so widening that file stops the install rather than shipping in it.
-fn render_write_role(source: &[u8], targets: &[WriteTarget]) -> Result<Vec<u8>> {
+fn rewrite_observability_namespace(contents: &[u8], observability_namespace: &str) -> Vec<u8> {
+    if observability_namespace == OBSERVABILITY_NAMESPACE {
+        return contents.to_vec();
+    }
+    let text = String::from_utf8_lossy(contents);
+    text.replace(
+        &format!(".{OBSERVABILITY_NAMESPACE}.svc.cluster.local"),
+        &format!(".{observability_namespace}.svc.cluster.local"),
+    )
+    .replace(
+        &format!("namespace: {OBSERVABILITY_NAMESPACE}"),
+        &format!("namespace: {observability_namespace}"),
+    )
+    .into_bytes()
+}
+
+fn rewrite_manifest_namespace(value: &mut serde_json::Value, namespace: &str) {
+    if let Some(metadata) = value
+        .get_mut("metadata")
+        .and_then(serde_json::Value::as_object_mut)
+    {
+        if metadata.contains_key("namespace") {
+            metadata.insert(
+                "namespace".to_string(),
+                serde_json::Value::String(namespace.to_string()),
+            );
+        }
+    }
+    if let Some(subjects) = value
+        .get_mut("subjects")
+        .and_then(serde_json::Value::as_array_mut)
+    {
+        for subject in subjects {
+            if let Some(object) = subject.as_object_mut() {
+                if object.contains_key("namespace") {
+                    object.insert(
+                        "namespace".to_string(),
+                        serde_json::Value::String(namespace.to_string()),
+                    );
+                }
+            }
+        }
+    }
+}
+
+fn render_read_access(source: &[u8], namespace: &str) -> Result<Vec<u8>> {
+    if namespace == CURIE_NAMESPACE {
+        return Ok(source.to_vec());
+    }
+    let source =
+        std::str::from_utf8(source).context("embedded SRE bot read-access.yaml is not UTF-8")?;
+    let mut rendered = String::new();
+    for document in serde_norway::Deserializer::from_str(source) {
+        let mut value: serde_json::Value = serde::Deserialize::deserialize(document)
+            .context("parsing embedded SRE bot read-access.yaml")?;
+        rewrite_manifest_namespace(&mut value, namespace);
+        rendered.push_str("---\n");
+        rendered.push_str(
+            &serde_norway::to_string(&value)
+                .context("serializing the rendered SRE bot read identity")?,
+        );
+    }
+    Ok(rendered.into_bytes())
+}
+
+fn render_write_role(
+    source: &[u8],
+    targets: &[WriteTarget],
+    curie_namespace: &str,
+) -> Result<Vec<u8>> {
     let source =
         std::str::from_utf8(source).context("embedded SRE bot write-role.yaml is not UTF-8")?;
     let mut rule: Option<serde_json::Value> = None;
@@ -1321,14 +1455,14 @@ fn render_write_role(source: &[u8], targets: &[WriteTarget]) -> Result<Vec<u8>> 
         serde_json::json!({
             "apiVersion": "v1",
             "kind": "ServiceAccount",
-            "metadata": {"name": WRITER_IDENTITY, "namespace": CURIE_NAMESPACE},
+            "metadata": {"name": WRITER_IDENTITY, "namespace": curie_namespace},
         }),
         serde_json::json!({
             "apiVersion": "v1",
             "kind": "Secret",
             "metadata": {
                 "name": WRITER_TOKEN_SECRET,
-                "namespace": CURIE_NAMESPACE,
+                "namespace": curie_namespace,
                 "annotations": {"kubernetes.io/service-account.name": WRITER_IDENTITY},
             },
             "type": "kubernetes.io/service-account-token",
@@ -1365,7 +1499,7 @@ fn render_write_role(source: &[u8], targets: &[WriteTarget]) -> Result<Vec<u8>> 
             "subjects": [{
                 "kind": "ServiceAccount",
                 "name": WRITER_IDENTITY,
-                "namespace": CURIE_NAMESPACE,
+                "namespace": curie_namespace,
             }],
         }));
     }
@@ -1384,6 +1518,7 @@ fn runtime_connector_declaration(
     source: &[u8],
     tempo_digest: &str,
     write_targets: Option<&[WriteTarget]>,
+    observability_namespace: &str,
 ) -> Result<Vec<u8>> {
     let source =
         std::str::from_utf8(source).context("embedded SRE bot connectors.yaml is not UTF-8")?;
@@ -1453,9 +1588,12 @@ fn runtime_connector_declaration(
         "image".to_string(),
         serde_json::Value::String(format!("{TEMPO_IMAGE_REPOSITORY}@{tempo_digest}")),
     );
-    serde_norway::to_string(&declaration)
-        .map(String::into_bytes)
-        .context("serializing the immutable SRE bot connector declaration")
+    let serialized = serde_norway::to_string(&declaration)
+        .context("serializing the immutable SRE bot connector declaration")?;
+    Ok(rewrite_observability_namespace(
+        serialized.as_bytes(),
+        observability_namespace,
+    ))
 }
 
 fn runtime_plugin_manifest(source: &[u8], write_enabled: bool) -> Result<Vec<u8>> {
@@ -1590,7 +1728,7 @@ struct ResourceRequirements {
     requests: BTreeMap<String, String>,
 }
 
-async fn preflight_capacity() -> Result<()> {
+async fn preflight_capacity(observability_namespace: &str) -> Result<()> {
     crate::ops::require_on_path("kubectl")?;
     let node_command = "kubectl get nodes -o json";
     let nodes: KubeList<Node> = read_kubernetes_json(
@@ -1641,7 +1779,7 @@ async fn preflight_capacity() -> Result<()> {
         if matches!(pod.status.phase.as_str(), "Succeeded" | "Failed") {
             continue;
         }
-        if is_managed_observability_pod(&pod) {
+        if is_managed_observability_pod(&pod, observability_namespace) {
             continue;
         }
         let Some(node_name) = pod.spec.node_name.as_deref() else {
@@ -1680,8 +1818,8 @@ async fn preflight_capacity() -> Result<()> {
     Ok(())
 }
 
-fn is_managed_observability_pod(pod: &Pod) -> bool {
-    if pod.metadata.namespace != OBSERVABILITY_NAMESPACE {
+fn is_managed_observability_pod(pod: &Pod, observability_namespace: &str) -> bool {
+    if pod.metadata.namespace != observability_namespace {
         return false;
     }
     let labels = &pod.metadata.labels;
@@ -1858,8 +1996,12 @@ mod tests {
     #[test]
     fn one_allowlist_renders_both_ceilings_identically() {
         let parsed = targets("curie/curie-api,other/web");
-        let role = render_write_role(bundle_file("manifests/write-role.yaml"), &parsed)
-            .expect("write role renders");
+        let role = render_write_role(
+            bundle_file("manifests/write-role.yaml"),
+            &parsed,
+            CURIE_NAMESPACE,
+        )
+        .expect("write role renders");
         let role = String::from_utf8(role).expect("rendered role is UTF-8");
         let mut granted: Vec<String> = Vec::new();
         for document in serde_norway::Deserializer::from_str(&role) {
@@ -1879,6 +2021,7 @@ mod tests {
             bundle_file("connectors.yaml"),
             "sha256:fixture",
             Some(&parsed),
+            OBSERVABILITY_NAMESPACE,
         )
         .expect("connector declaration renders");
         let declaration: serde_json::Value =
@@ -1899,9 +2042,52 @@ mod tests {
     #[test]
     fn rendered_write_role_refuses_a_widened_grant() {
         let widened = b"---\napiVersion: rbac.authorization.k8s.io/v1\nkind: Role\nmetadata:\n  name: sre-bot-writer\n  namespace: curie\nrules:\n  - apiGroups: [apps]\n    resources: [deployments]\n    resourceNames: [my-app]\n    verbs: [get, patch, delete]\n";
-        let error = render_write_role(widened, &targets("curie/api"))
+        let error = render_write_role(widened, &targets("curie/api"), CURIE_NAMESPACE)
             .expect_err("a widened verb set must stop the install");
         assert!(error.to_string().contains("verbs"), "{error:#}");
+    }
+
+    #[test]
+    fn write_role_identity_uses_the_selected_curie_namespace() {
+        let rendered = render_write_role(
+            bundle_file("manifests/write-role.yaml"),
+            &targets("apps/api"),
+            "soak",
+        )
+        .expect("write role renders");
+        let text = String::from_utf8(rendered).expect("rendered role is UTF-8");
+        let mut sa_ns = Vec::new();
+        let mut role_ns = Vec::new();
+        let mut subject_ns = Vec::new();
+        for document in serde_norway::Deserializer::from_str(&text) {
+            let value: serde_json::Value =
+                serde::Deserialize::deserialize(document).expect("rendered document parses");
+            match value.get("kind").and_then(serde_json::Value::as_str) {
+                Some("ServiceAccount") | Some("Secret") => {
+                    sa_ns.push(value["metadata"]["namespace"].as_str().unwrap().to_string());
+                }
+                Some("Role") => {
+                    role_ns.push(value["metadata"]["namespace"].as_str().unwrap().to_string());
+                }
+                Some("RoleBinding") => {
+                    subject_ns.push(
+                        value["subjects"][0]["namespace"]
+                            .as_str()
+                            .unwrap()
+                            .to_string(),
+                    );
+                    role_ns.push(value["metadata"]["namespace"].as_str().unwrap().to_string());
+                }
+                _ => {}
+            }
+        }
+        assert_eq!(sa_ns, vec!["soak", "soak"]);
+        assert_eq!(subject_ns, vec!["soak"]);
+        assert_eq!(role_ns, vec!["apps", "apps"]);
+        assert!(
+            !text.contains("namespace: curie"),
+            "selected Curie identity must replace the shipped default: {text}"
+        );
     }
 
     #[test]
@@ -1924,6 +2110,7 @@ mod tests {
             bundle_file("connectors.yaml"),
             "sha256:fixture",
             Some(&parsed),
+            OBSERVABILITY_NAMESPACE,
         )
         .expect("connector declaration renders");
         let declaration: serde_json::Value = serde_norway::from_slice(&connectors).unwrap();
@@ -1949,9 +2136,13 @@ mod tests {
 
     #[test]
     fn read_only_install_is_unchanged_by_the_new_flag() {
-        let connectors =
-            runtime_connector_declaration(bundle_file("connectors.yaml"), "sha256:fixture", None)
-                .expect("read only declaration renders");
+        let connectors = runtime_connector_declaration(
+            bundle_file("connectors.yaml"),
+            "sha256:fixture",
+            None,
+            OBSERVABILITY_NAMESPACE,
+        )
+        .expect("read only declaration renders");
         let declaration: serde_json::Value = serde_norway::from_slice(&connectors).unwrap();
         let connectors = declaration["connectors"].as_object().unwrap();
         assert!(!connectors.contains_key("k8s-write"));
@@ -1966,17 +2157,22 @@ mod tests {
     #[test]
     fn write_opt_in_still_refuses_an_unknown_connector() {
         let source = b"connectors:\n  kubernetes: {}\n  grafana: {}\n  tempo:\n    build:\n      context: connectors/tempo\n  k8s-write: {}\n  k8s-scale: {}\n  mystery: {}\n";
-        let error =
-            runtime_connector_declaration(source, "sha256:fixture", Some(&targets("curie/api")))
-                .expect_err("an unclassified connector must stop the install");
+        let error = runtime_connector_declaration(
+            source,
+            "sha256:fixture",
+            Some(&targets("curie/api")),
+            OBSERVABILITY_NAMESPACE,
+        )
+        .expect_err("an unclassified connector must stop the install");
         assert!(error.to_string().contains("mystery"), "{error:#}");
     }
 
     #[test]
     fn runtime_connector_transform_requires_the_declared_write_connector() {
         let source = b"connectors:\n  tempo:\n    build:\n      context: connectors/tempo\n      platforms: [linux/amd64]\n";
-        let error = runtime_connector_declaration(source, "sha256:fixture", None)
-            .expect_err("missing k8s-write must be refused");
+        let error =
+            runtime_connector_declaration(source, "sha256:fixture", None, OBSERVABILITY_NAMESPACE)
+                .expect_err("missing k8s-write must be refused");
         assert!(
             error
                 .to_string()

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -809,6 +809,15 @@ enum SreBotAction {
         /// Omit to install read only.
         #[arg(long, value_name = "NS/NAME[,NS/NAME]")]
         write_allowlist: Option<String>,
+        /// Kubernetes namespace of the Curie release. Default: curie.
+        #[arg(long, default_value = "curie", env = "CURIE_NAMESPACE")]
+        namespace: String,
+        /// Helm release name of the Curie install. Default: curie.
+        #[arg(long, default_value = "curie")]
+        release: String,
+        /// Kubernetes namespace of the retained observability stack. Default: observability.
+        #[arg(long, default_value = "observability")]
+        observability_namespace: String,
     },
 }
 
@@ -2471,6 +2480,9 @@ async fn run(command: Option<Command>) -> Result<()> {
                             dry_run,
                             slack_channel,
                             write_allowlist,
+                            namespace,
+                            release,
+                            observability_namespace,
                         },
                 },
         }) => match curie::examples::install_sre_bot(curie::examples::SreBotInstallOpts {
@@ -2478,6 +2490,9 @@ async fn run(command: Option<Command>) -> Result<()> {
             dry_run,
             slack_channel,
             write_allowlist,
+            namespace,
+            release,
+            observability_namespace,
         })
         .await?
         {

--- a/cli/tests/example_sre_bot_install.rs
+++ b/cli/tests/example_sre_bot_install.rs
@@ -59,6 +59,8 @@ struct Fixture {
     action_log: PathBuf,
     grafana_stdin: PathBuf,
     connector_stdin: PathBuf,
+    applied_dir: PathBuf,
+    helm_values_dir: PathBuf,
     nodes: String,
     pods: String,
     nodes_mode: &'static str,
@@ -92,6 +94,10 @@ impl Fixture {
         let action_log = temp.path().join("actions.log");
         let grafana_stdin = temp.path().join("grafana.stdin");
         let connector_stdin = temp.path().join("connector.stdin");
+        let applied_dir = temp.path().join("applied");
+        let helm_values_dir = temp.path().join("helm-values");
+        fs::create_dir(&applied_dir).expect("create applied-file capture directory");
+        fs::create_dir(&helm_values_dir).expect("create helm-values capture directory");
 
         write_exec(
             &bin_dir,
@@ -99,6 +105,14 @@ impl Fixture {
             r#"#!/bin/sh
 printf '%s\n' "$*" >> "$CURIE_TEST_KUBECTL_LOG"
 printf 'KUBECTL %s\n' "$*" >> "$CURIE_TEST_ACTION_LOG"
+
+prev=""
+for arg in "$@"; do
+    if [ "$prev" = "-f" ] && [ "$arg" != "-" ] && [ -f "$arg" ]; then
+        cp "$arg" "$CURIE_TEST_APPLIED_DIR/$(basename "$arg")"
+    fi
+    prev=$arg
+done
 
 case " $* " in
     *" get nodes "*|*" get node "*)
@@ -180,12 +194,12 @@ case " $* " in
                 ;;
         esac
         ;;
-    *" -n curie apply -f - "*)
-        cat > "$CURIE_TEST_CONNECTOR_STDIN"
-        printf '%s\n' 'connector objects configured'
-        exit 0
-        ;;
     *" apply -f - "*)
+        if printf ' %s ' "$*" | grep -q ' -n '; then
+            cat > "$CURIE_TEST_CONNECTOR_STDIN"
+            printf '%s\n' 'connector objects configured'
+            exit 0
+        fi
         cat > "$CURIE_TEST_GRAFANA_STDIN"
         if [ "$CURIE_TEST_GRAFANA_SECRET_MODE" = "apply-failure" ]; then
             printf '%s\n' 'Error from server (Forbidden): cannot apply grafana-admin' >&2
@@ -194,17 +208,17 @@ case " $* " in
         printf '%s\n' 'secret/grafana-admin configured'
         exit 0
         ;;
-    *" -n curie get deployment "*" app.kubernetes.io/instance=curie "*)
+    *" get deployment "*" app.kubernetes.io/instance="*)
         printf '%s\n' 'curie'
         exit 0
         ;;
-    *" -n curie delete deployment,service,networkpolicy,secret "*)
+    *" delete deployment,service,networkpolicy,secret "*)
         exit 0
         ;;
     *" apply "*|*" rollout status "*)
         exit 0
         ;;
-    *" get secret "*" app.kubernetes.io/instance=curie "*)
+    *" get secret "*" app.kubernetes.io/instance="*)
         printf '%s\n' 'curie-secrets'
         exit 0
         ;;
@@ -229,6 +243,14 @@ exit 64
             r#"#!/bin/sh
 printf '%s\n' "$*" >> "$CURIE_TEST_HELM_LOG"
 printf 'HELM %s\n' "$*" >> "$CURIE_TEST_ACTION_LOG"
+
+prev=""
+for arg in "$@"; do
+    if [ "$prev" = "-f" ] && [ -f "$arg" ]; then
+        cp "$arg" "$CURIE_TEST_HELM_VALUES_DIR/$(basename "$arg")"
+    fi
+    prev=$arg
+done
 
 if [ "$1" = "get" ] && [ "$2" = "values" ]; then
     if [ "${CURIE_TEST_HELM_VALUES:-absent}" = "absent" ]; then
@@ -276,7 +298,7 @@ if [ "$1" = "upgrade" ] && [ "$2" = "--install" ]; then
     esac
 fi
 
-if [ "$1" = "upgrade" ] && [ "$2" = "curie" ]; then
+if [ "$1" = "upgrade" ] && [ "$2" != "--install" ]; then
     exit 0
 fi
 
@@ -364,6 +386,8 @@ exit 64
             action_log,
             grafana_stdin,
             connector_stdin,
+            applied_dir,
+            helm_values_dir,
             nodes: nodes.to_string(),
             pods: pods.to_string(),
             nodes_mode,
@@ -438,6 +462,8 @@ exit 64
             .env("CURIE_TEST_ACTION_LOG", &self.action_log)
             .env("CURIE_TEST_GRAFANA_STDIN", &self.grafana_stdin)
             .env("CURIE_TEST_CONNECTOR_STDIN", &self.connector_stdin)
+            .env("CURIE_TEST_APPLIED_DIR", &self.applied_dir)
+            .env("CURIE_TEST_HELM_VALUES_DIR", &self.helm_values_dir)
             .env("CURIE_TEST_NODES_JSON", &self.nodes)
             .env("CURIE_TEST_PODS_JSON", &self.pods)
             .env("CURIE_TEST_NODES_MODE", self.nodes_mode)
@@ -451,6 +477,8 @@ exit 64
                 &self.registry_endpoint,
             )
             .env_remove("CURIE_API_KEY")
+            .env_remove("CURIE_NAMESPACE")
+            .env_remove("CURIE_RELEASE")
             .env_remove("CURIE_CREDENTIALS")
             .env_remove("CURIE_MODEL_CREDENTIALS")
             .env_remove("CURIE_GITHUB_TOKEN")
@@ -481,6 +509,16 @@ exit 64
 
     fn connector_stdin(&self) -> Vec<u8> {
         fs::read(&self.connector_stdin).unwrap_or_default()
+    }
+
+    fn applied_file(&self, name: &str) -> String {
+        fs::read_to_string(self.applied_dir.join(name))
+            .unwrap_or_else(|error| panic!("read applied {name}: {error}"))
+    }
+
+    fn helm_values_file(&self, name: &str) -> String {
+        fs::read_to_string(self.helm_values_dir.join(name))
+            .unwrap_or_else(|error| panic!("read helm values {name}: {error}"))
     }
 
     fn actions(&self) -> Vec<String> {
@@ -695,11 +733,15 @@ fn clap_routes_the_one_command_and_exposes_no_operator_configuration_or_credenti
         text.contains("--slack-channel"),
         "the install surface must permit the optional Slack binding: {text}"
     );
+    for required in ["--namespace", "--release", "--observability-namespace"] {
+        assert!(
+            text.contains(required),
+            "the install surface must expose targeting flag {required}: {text}"
+        );
+    }
     for forbidden in [
         "--values",
         "--file",
-        "--namespace",
-        "--release",
         "--api-key",
         "--grafana-token",
         "--service-account-token",
@@ -1819,5 +1861,405 @@ fn all_capacity_reads_are_cluster_wide_and_json_shaped() {
         (pod_read.contains("--all-namespaces") || pod_read.contains(" -A"))
             && (pod_read.contains("-o json") || pod_read.contains("--output json")),
         "pod request accounting must be cluster wide structured JSON: {pod_read}"
+    );
+}
+
+const CUSTOM_NAMESPACE: &str = "soak";
+const CUSTOM_RELEASE: &str = "soak-rel";
+const CUSTOM_OBS_NAMESPACE: &str = "soak-obs";
+
+fn custom_target_args() -> [&'static str; 6] {
+    [
+        "--namespace",
+        CUSTOM_NAMESPACE,
+        "--release",
+        CUSTOM_RELEASE,
+        "--observability-namespace",
+        CUSTOM_OBS_NAMESPACE,
+    ]
+}
+
+fn dry_run_plan_lines(output: &Output) -> Vec<String> {
+    let documents: Vec<Value> = serde_json::Deserializer::from_slice(&output.stdout)
+        .into_iter::<Value>()
+        .collect::<Result<_, _>>()
+        .unwrap_or_else(|error| panic!("dry run stdout must contain only JSON: {error}"));
+    assert_eq!(
+        documents.len(),
+        1,
+        "dry run must emit exactly one JSON object"
+    );
+    documents[0]["plan"]
+        .as_array()
+        .expect("dry run object must carry its ordered plan")
+        .iter()
+        .map(|line| line.as_str().expect("plan entries are strings").to_string())
+        .collect()
+}
+
+fn assert_no_default_curie_or_observability_targets(lines: &[String]) {
+    let plan = lines.join("\n");
+    for forbidden in [
+        "--namespace observability",
+        "--namespace curie",
+        " -n curie ",
+        "helm upgrade --install curie ",
+        "helm upgrade curie ",
+        "curie cluster deploy --plugin-dir embedded:examples/sre-bot --namespace curie --release curie",
+        "in namespace observability",
+        "kubectl wait --namespace curie ",
+    ] {
+        assert!(
+            !plan.contains(forbidden),
+            "custom targeting must not retain default identity `{forbidden}`: {lines:?}"
+        );
+    }
+}
+
+#[test]
+fn no_flag_dry_run_preserves_curie_and_observability_defaults() {
+    let fixture = Fixture::new(nodes(vec![node("node-a", "4Gi", true)]), pods(vec![]));
+    let output = fixture.run(&["--dry-run", "--json"]);
+    let text = shown(&output);
+    assert!(
+        output.status.success(),
+        "default dry run must succeed: {text}"
+    );
+    let lines = dry_run_plan_lines(&output);
+    assert!(
+        lines.iter().any(|line| {
+            line.contains("helm upgrade --install grafana ")
+                && line.contains("--namespace observability")
+        }),
+        "no-flag plan must keep the observability namespace default: {lines:?}"
+    );
+    assert!(
+        lines.iter().any(|line| {
+            line.contains("helm upgrade --install curie") && line.contains(" -n curie ")
+        }),
+        "no-flag plan must keep the Curie namespace and release defaults: {lines:?}"
+    );
+    assert!(
+        lines.iter().any(|line| line.contains(
+            "curie cluster deploy --plugin-dir embedded:examples/sre-bot --namespace curie --release curie"
+        )),
+        "no-flag deploy must keep the Curie identity defaults: {lines:?}"
+    );
+    assert!(
+        lines.iter().any(|line| {
+            line.contains("preserve or create Secret grafana-admin in namespace observability")
+        }),
+        "no-flag plan must keep the Grafana Secret in observability: {lines:?}"
+    );
+    assert!(
+        lines.iter().any(|line| {
+            line.contains("kubectl wait --namespace curie ")
+                && line.contains("secret/sre-bot-reader-token")
+        }),
+        "no-flag token wait must keep the Curie namespace: {lines:?}"
+    );
+}
+
+#[test]
+fn custom_target_dry_run_reports_and_uses_only_the_selected_identities() {
+    let fixture = Fixture::new(nodes(vec![node("node-a", "4Gi", true)]), pods(vec![]));
+    let mut args = custom_target_args().to_vec();
+    args.extend(["--dry-run", "--json"]);
+    let output = fixture.run(&args);
+    let text = shown(&output);
+    assert!(
+        output.status.success(),
+        "custom-target dry run must succeed: {text}"
+    );
+    let lines = dry_run_plan_lines(&output);
+    assert_no_default_curie_or_observability_targets(&lines);
+    assert!(
+        lines.iter().any(|line| {
+            line.contains("preserve or create Secret grafana-admin in namespace soak-obs")
+        }),
+        "Grafana Secret plan must name the selected observability namespace: {lines:?}"
+    );
+    for release in ["grafana", "loki", "alloy", "prometheus"] {
+        assert!(
+            lines.iter().any(|line| {
+                line.contains(&format!("helm upgrade --install {release} "))
+                    && line.contains("--namespace soak-obs")
+            }),
+            "upstream {release} must target soak-obs: {lines:?}"
+        );
+    }
+    assert!(
+        lines.iter().any(|line| {
+            line.contains("kubectl apply")
+                && line.contains("--namespace soak-obs")
+                && line.contains("tempo.yaml")
+        }),
+        "Tempo apply must target soak-obs: {lines:?}"
+    );
+    assert!(
+        lines.iter().any(|line| {
+            line.contains("helm upgrade --install soak-rel") && line.contains(" -n soak ")
+        }),
+        "guarded Curie apply must use the selected release and namespace: {lines:?}"
+    );
+    assert!(
+        lines.iter().any(|line| {
+            line.contains("helm upgrade soak-rel")
+                && !line.contains("--install")
+                && line.contains("--namespace soak")
+                && line.contains("--reuse-values")
+                && line.contains("curie-values.yaml")
+        }),
+        "integration upgrade must use the selected Curie identity: {lines:?}"
+    );
+    assert!(
+        lines.iter().any(|line| {
+            line.contains("kubectl wait --namespace soak ")
+                && line.contains("secret/sre-bot-reader-token")
+        }),
+        "reader token wait must use the selected Curie namespace: {lines:?}"
+    );
+    assert!(
+        lines.iter().any(|line| line.contains(
+            "curie cluster deploy --plugin-dir embedded:examples/sre-bot --namespace soak --release soak-rel"
+        )),
+        "deploy plan must report the selected Curie identity: {lines:?}"
+    );
+}
+
+#[test]
+fn custom_targets_thread_through_helm_kubectl_manifests_secret_discovery_and_connectors() {
+    let fixture = Fixture::with_modes(
+        nodes(vec![node("node-a", "4Gi", true)]),
+        pods(vec![]),
+        "success",
+        "success",
+        "success",
+    )
+    .with_grafana_secret_mode("absent");
+    let output = fixture.run(&custom_target_args());
+    let text = shown(&output);
+    assert!(
+        output.status.success(),
+        "custom-target install must succeed: {text}"
+    );
+
+    let helm = fixture.helm_calls();
+    assert!(
+        helm.iter().any(|call| {
+            call.starts_with("upgrade --install grafana ") && call.contains("--namespace soak-obs")
+        }),
+        "Grafana Helm must target soak-obs: {helm:?}"
+    );
+    assert!(
+        helm.iter().any(
+            |call| call.starts_with("status grafana ") && call.contains("--namespace soak-obs")
+        ),
+        "Grafana status must inspect soak-obs: {helm:?}"
+    );
+    assert!(
+        helm.iter().any(|call| {
+            call.starts_with("upgrade --install soak-rel ") && call.contains(" -n soak ")
+        }),
+        "guarded Curie apply must target soak/soak-rel: {helm:?}"
+    );
+    assert!(
+        helm.iter().any(|call| {
+            call.starts_with("upgrade soak-rel ")
+                && call.contains("--namespace soak")
+                && call.contains("--reuse-values")
+        }),
+        "integration upgrade must target soak/soak-rel: {helm:?}"
+    );
+    assert!(
+        helm.iter().all(|call| {
+            !call.contains("--namespace observability")
+                && !call.contains(" -n curie ")
+                && !call.contains("--namespace curie")
+                && !call.starts_with("upgrade --install curie ")
+                && !call.starts_with("upgrade curie ")
+        }),
+        "Helm must not retain default Curie or observability identities: {helm:?}"
+    );
+
+    let kubectl = fixture.kubectl_calls();
+    assert!(
+        kubectl.iter().any(|call| {
+            call.contains("get secret grafana-admin") && call.contains("--namespace soak-obs")
+        }),
+        "Grafana admin inspect must use soak-obs: {kubectl:?}"
+    );
+    assert!(
+        kubectl.iter().any(|call| {
+            call.contains("apply")
+                && call.contains("--namespace soak-obs")
+                && call.contains("tempo.yaml")
+        }),
+        "Tempo apply must use soak-obs: {kubectl:?}"
+    );
+    assert!(
+        kubectl.iter().any(|call| {
+            call.contains("wait")
+                && call.contains("--namespace soak")
+                && call.contains("secret/sre-bot-reader-token")
+        }),
+        "reader token wait must use soak: {kubectl:?}"
+    );
+    assert!(
+        kubectl.iter().any(|call| {
+            call.contains("get secret sre-bot-reader-token") && call.contains("--namespace soak")
+        }),
+        "reader token read must use soak: {kubectl:?}"
+    );
+    assert!(
+        kubectl.iter().any(|call| call.contains("get secret")
+            && call.contains("app.kubernetes.io/instance=soak-rel")
+            && (call.contains("-n soak") || call.contains("--namespace soak"))),
+        "API key discovery must use the selected Curie identity: {kubectl:?}"
+    );
+    assert!(
+        kubectl.iter().any(|call| call == "-n soak apply -f -"),
+        "connector reconciliation must apply in soak: {kubectl:?}"
+    );
+    assert!(
+        kubectl.iter().any(|call| {
+            call.starts_with("-n soak delete deployment,service,networkpolicy,secret ")
+        }),
+        "stale connector objects must be deleted from soak: {kubectl:?}"
+    );
+    assert!(
+        kubectl.iter().all(|call| {
+            !call.contains("--namespace observability")
+                && !call.contains("-n curie")
+                && !call.contains("--namespace curie")
+                && !call.contains("instance=curie")
+        }),
+        "kubectl must not retain default Curie or observability identities: {kubectl:?}"
+    );
+
+    let grafana: Value = serde_json::from_slice(&fixture.kubectl_stdin())
+        .expect("Grafana admin Secret stdin must be JSON");
+    assert_eq!(grafana["kind"], "Secret");
+    assert_eq!(grafana["metadata"]["namespace"], CUSTOM_OBS_NAMESPACE);
+
+    let read_access = fixture.applied_file("read-access.yaml");
+    assert!(
+        read_access.contains("namespace: soak"),
+        "read-access must render the selected Curie namespace: {read_access}"
+    );
+    assert!(
+        !read_access.contains("namespace: curie"),
+        "read-access must not retain the default Curie namespace: {read_access}"
+    );
+
+    let tempo = fixture.applied_file("tempo.yaml");
+    assert!(
+        tempo.contains("namespace: soak-obs"),
+        "Tempo must render the selected observability namespace: {tempo}"
+    );
+    assert!(
+        !tempo.contains("namespace: observability"),
+        "Tempo must not retain the default observability namespace: {tempo}"
+    );
+
+    let grafana_values = fixture.helm_values_file("grafana-values.yaml");
+    assert!(
+        grafana_values.contains("loki.soak-obs.svc.cluster.local"),
+        "Grafana values must point at soak-obs: {grafana_values}"
+    );
+    assert!(
+        !grafana_values.contains(".observability.svc.cluster.local"),
+        "Grafana values must not retain observability DNS: {grafana_values}"
+    );
+
+    let alloy_values = fixture.helm_values_file("alloy-values.yaml");
+    assert!(
+        alloy_values.contains("loki.soak-obs.svc.cluster.local"),
+        "Alloy values must point at soak-obs: {alloy_values}"
+    );
+    assert!(
+        !alloy_values.contains(".observability.svc.cluster.local"),
+        "Alloy values must not retain observability DNS: {alloy_values}"
+    );
+
+    let curie_values = fixture.helm_values_file("curie-values.yaml");
+    assert!(
+        curie_values.contains("tempo.soak-obs.svc.cluster.local")
+            && curie_values.contains("grafana.soak-obs.svc.cluster.local")
+            && curie_values.contains("namespace: soak-obs"),
+        "Curie integration values must point at soak-obs: {curie_values}"
+    );
+    assert!(
+        !curie_values.contains(".observability.svc.cluster.local")
+            && !curie_values.contains("namespace: observability"),
+        "Curie integration values must not retain observability: {curie_values}"
+    );
+
+    let connectors = String::from_utf8(uploaded_bundle_file(&fixture, "connectors.yaml"))
+        .expect("uploaded connectors are UTF-8");
+    assert!(
+        connectors.contains("grafana.soak-obs.svc.cluster.local"),
+        "runtime connectors must point Grafana at soak-obs: {connectors}"
+    );
+    assert!(
+        !connectors.contains("grafana.observability.svc.cluster.local"),
+        "runtime connectors must not retain observability DNS: {connectors}"
+    );
+}
+
+#[test]
+fn selected_observability_namespace_is_the_only_managed_capacity_namespace() {
+    let mut items = managed_stack_pods("node-a");
+    items.push(labeled_pod(
+        "unrelated",
+        "node-a",
+        OBSERVABILITY_NAMESPACE,
+        json!({"app.kubernetes.io/instance": "other"}),
+        "64Mi",
+    ));
+    let fixture = Fixture::new(
+        nodes(vec![node("node-a", "1376Mi", true)]),
+        pods(items.clone()),
+    );
+    let default_output = fixture.run(&[]);
+    assert_reached_helm_upgrade(&fixture, &default_output);
+
+    let custom = Fixture::new(nodes(vec![node("node-a", "1376Mi", true)]), pods(items));
+    let output = custom.run(&custom_target_args());
+    let text = assert_refused_before_helm(&custom, &output);
+    assert!(
+        text.contains("required 1312Mi"),
+        "load in the default observability namespace must count when targeting soak-obs: {text}"
+    );
+}
+
+#[test]
+fn helm_timeout_recovery_names_the_selected_observability_namespace() {
+    let fixture = Fixture::with_modes(
+        nodes(vec![node("node-a", "8Gi", true)]),
+        pods(vec![]),
+        "success",
+        "success",
+        "timeout",
+    );
+    let output = fixture.run(&custom_target_args());
+    let text = shown(&output);
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "Helm timeout must fail: {text}"
+    );
+    let recovery =
+        "kubectl delete secret -n soak-obs -l owner=helm,name=grafana,status=pending-upgrade";
+    let normalized = text.replace(['\'', '"'], "");
+    assert!(
+        normalized.contains(recovery),
+        "timeout recovery must name soak-obs, not observability: {text}"
+    );
+    assert!(
+        !normalized.contains(
+            "kubectl delete secret -n observability -l owner=helm,name=grafana,status=pending-upgrade"
+        ),
+        "timeout recovery must not name the default observability namespace: {text}"
     );
 }

--- a/examples/sre-bot/README.md
+++ b/examples/sre-bot/README.md
@@ -89,7 +89,22 @@ curie example sre-bot install --observability
 ```
 
 This installs the bot and its self referential observability stack with no
-values files. The installer makes a read only runtime copy of the checked in
+values files. With no targeting flags, Curie lands as release `curie` in
+namespace `curie`, and the retained Grafana/Loki/Alloy/Tempo/Prometheus stack
+lands in namespace `observability`. To install beside an existing release, pass
+the same identity the rest of the cluster CLI uses:
+
+```bash
+curie example sre-bot install --observability \
+  --namespace soak \
+  --release soak \
+  --observability-namespace soak-obs
+```
+
+`--namespace` also reads `CURIE_NAMESPACE`. The installer threads those three
+values through every Helm, kubectl, manifest, secret-discovery, connector, and
+deploy step, including the embedded `read-access.yaml` and observability
+service DNS. The installer makes a read only runtime copy of the checked in
 bundle by removing the write connector and its matching approval gate together.
 The declared write path remains in the source bundle for the explicit Level up
 build and deploy flow below.


### PR DESCRIPTION
## Summary

`curie example sre-bot install` could only target release `curie` in namespace `curie` and observability namespace `observability`. This adds `--namespace`, `--release`, and `--observability-namespace`, keeps those three names as the no-flag defaults, and threads the selected identity through Helm, kubectl, embedded manifests, secret discovery, connectors, capacity accounting, and deploy.

## Related issue

Closes #1930

## Fix pin verification

Fix pin: cli/tests/example_sre_bot_install.rs::custom_target_dry_run_reports_and_uses_only_the_selected_identities

Verified with `bash cli/scripts/verify-fix-pin.sh 9ab49e1af273fbda662e3f87654a7cf51f8f4521 cli/tests/example_sre_bot_install.rs::custom_target_dry_run_reports_and_uses_only_the_selected_identities`. Baseline passed; reversing product hunks failed with `unexpected argument '--namespace' found`; the script printed `PINNED`.

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | Does not reach plugin packaging, the runner turn loop, ACI events, or skill eval/check. | | |
| local | n/a | Does not reach compose services, dispatcher, worker, API wiring, or the console UI. | | |
| local-release | n/a | Does not change released image identity, the install path, version pins, or release compose. | | |
| cluster | required | Installer Helm, kubectl, manifests, secret discovery, connector apply, capacity, and deploy all target Kubernetes namespace and release identity. | fake recording plus live kind dry-run | `cargo test --test example_sre_bot_install` on 9ab49e1a: 31 passed, including custom-target argv/manifest proofs and the no-flag default test. Live: kind cluster `curie-1930-targets`, then `/home/theconnman/.cargo/shared-targets/agentos/debug/curie --json example sre-bot install --observability --namespace soak --release soak-rel --observability-namespace soak-obs --dry-run` observed `curie cluster deploy --plugin-dir embedded:examples/sre-bot --namespace soak --release soak-rel` and `helm upgrade --install grafana ... --namespace soak-obs`. Same cluster with no targeting flags observed `--namespace curie --release curie` and `--namespace observability`. Kind cluster deleted afterward; only leftover kind cluster is the pre-existing `tui-proto`. |
| live provider | n/a | Does not reach model routing, credential resolution, provider auth, or token accounting. | | |
| external integration | n/a | Does not change Slack, git webhooks, connector OAuth, or third-party API shape. | | |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.

Positive plus falsifiable-negative:

- Custom flags plan uses soak / soak-rel / soak-obs (positive). Same plan must not contain `--namespace observability`, ` -n curie `, or `helm upgrade --install curie` (negative).
- No-flag plan still uses curie / curie / observability (second path).
- Capacity: managed stack pods in default `observability` are excluded on the no-flag path and counted as load when `--observability-namespace soak-obs` is set.
- Helm timeout recovery names `soak-obs` and not `observability`.
- Applied `read-access.yaml`, `tempo.yaml`, Grafana/Alloy/Curie values, and connectors.yaml rewrite off the default namespaces.

## Checklist

- [x] Tests pass for the area I touched (`cargo test --test example_sre_bot_install`, `cargo test --lib examples`, `cargo test --test command_surface`, `cargo clippy -- -D warnings`).
- [x] Docs updated if behavior changed (`examples/sre-bot/README.md` Quick deploy).
- [ ] An ADR is added under `docs/adr/` if this is an architectural decision.

Command-manifest and UI generated manifest regenerated for the new flags.
