### PR TITLE
Harden cluster message rollout recovery

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1123,11 +1123,10 @@ jobs:
       # overrides repoint every first-party image at the just-loaded local tags
       # with pullPolicy Never (the runner AND its prewarm DaemonSet), force gVisor
       # off (no runsc on kind nodes), and drop the dispatcher (no Slack; its
-      # presence would trip the `cluster message` reply-hijack guard).
-      # worker.slackTrustedOrigins is a CI only widening that lets the worker
-      # answer the host side reply stub on any kernel assigned port on this
-      # host. The portless origin is intentional because `cluster message`
-      # requests an ephemeral port; the chart default stays empty and fail closed.
+      # presence would trip the `cluster message` reply-hijack guard). The worker
+      # is deliberately installed with the chart's empty/default trusted-origin
+      # posture: the rollout-recovery regression below must exercise the first
+      # `cluster message` command's temporary trust rollout from that cold state.
       - name: Install the platform (curie cluster up)
         env:
           CURIE_BIN: cli/target/release/curie
@@ -1139,7 +1138,6 @@ jobs:
             --fake-model \
             --set security.gvisor.mode=off \
             --set dispatcher.deploy=false \
-            --set worker.slackTrustedOrigins="http://${CURIE_E2E_LISTEN_HOST}" \
             --set api.image.repository=curie-api --set api.image.tag=local --set api.image.pullPolicy=Never \
             --set worker.image.repository=curie-worker --set worker.image.tag=local --set worker.image.pullPolicy=Never \
             --set ui.image.repository=curie-ui --set ui.image.tag=local --set ui.image.pullPolicy=Never \
@@ -1158,6 +1156,18 @@ jobs:
           kubectl rollout status deploy/curie-worker -n curie --timeout=300s
           kubectl rollout status deploy/curie-ui -n curie --timeout=300s
           kubectl rollout status daemonset/curie-runner-prewarm -n curie --timeout=300s
+      # QA4-02: drive the first no-Slack invocation from the default/untrusted
+      # install through its real Deployment rollout and prove the outgoing
+      # worker never claims it. Then kill a real PEL owner while its sandbox
+      # is held Pending by a namespaced, sandbox-only node selector and require
+      # the same CLI process to transfer the PEL entry and recover its reply in
+      # under three minutes. The shared agent-sandbox controller stays Ready and
+      # untouched throughout. Red-on-revert binaries/images are opt-in harness
+      # knobs; CI deliberately exercises only the current branch.
+      - name: First invocation rollout and dead-consumer recovery
+        env:
+          CURIE_BIN: cli/target/release/curie
+        run: bash cli/scripts/e2e-cluster-rollout-recovery.sh
       # The cluster rung only: `cluster status` gate -> `cluster deploy` ->
       # `cluster message` (reply asserted). Fake model, credential-free.
       - name: Parity ladder (cluster rung, fake model, credential-free)
@@ -1184,6 +1194,14 @@ jobs:
           kubectl get events -n curie --sort-by=.lastTimestamp | tail -50 || true
           kubectl describe pods -n curie -l app.kubernetes.io/component=runner-sandbox || true
           kubectl logs -n curie -l app.kubernetes.io/component=worker --tail=100 || true
+      # Delete only this job's namespaced release resources. Do not uninstall or
+      # delete the shared controller namespace: the pinned kind action owns final
+      # disposal of the whole single-use cluster. This still runs after failure.
+      - name: Tear down the disposable cluster release
+        if: always()
+        run: |
+          kubectl delete namespace curie \
+            --ignore-not-found --wait=false 2>/dev/null || true
 
   e2e-required:
     name: E2E required

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -236,7 +236,14 @@ Each has an integration test under `apps/worker/tests/`:
 1. **One live session per thread.** A Valkey thread lock (`SET NX PX`) is the routing CAS (compare-and-swap) ([`apps/worker/src/curie_worker/threadlock.py::ThreadLock`](apps/worker/src/curie_worker/threadlock.py)).
 2. **The finish race.** A follow-up during a live turn is a steer; if the turn finished first, the runner returns 409 and the kernel opens a fresh turn on the same idle sandbox ([`apps/worker/src/curie_worker/kernel.py::Kernel._route_and_start`](apps/worker/src/curie_worker/kernel.py)).
 3. **No auto-retry after a side-effectful failure.** If a prior attempt flagged a side effect, the kernel escalates to a human instead of retrying ([`apps/worker/src/curie_worker/kernel.py::Kernel.process_event`](apps/worker/src/curie_worker/kernel.py)).
-4. **Crash recovery.** Pending stream entries are reclaimed with `XAUTOCLAIM` ([`apps/worker/src/curie_worker/stream_consumer.py::StreamConsumer._reclaim_once`](apps/worker/src/curie_worker/stream_consumer.py)). The runs consumer group is created at `$`, so a cold worker never replays ancient backlog ([`apps/worker/src/curie_worker/consumer.py::Consumer.ensure_group`](apps/worker/src/curie_worker/consumer.py)).
+4. **Crash recovery.** A capable dead consumer's pending entries are transferred
+   after sustained renewable-lease absence, with one Valkey arbitration lease
+   preventing replacement replicas from racing through the delivery budget;
+   unknown older consumers retain `XAUTOCLAIM` as the compatibility backstop
+   ([`apps/worker/src/curie_worker/stream_consumer.py::StreamConsumer._reclaim_once`](apps/worker/src/curie_worker/stream_consumer.py)).
+   A restarted generation first recovers rows under its own stable consumer name.
+   The runs consumer group is created at `$`, so a cold worker never replays ancient
+   backlog ([`apps/worker/src/curie_worker/consumer.py::Consumer.ensure_group`](apps/worker/src/curie_worker/consumer.py)).
 
 Beyond these four invariants, a **kill switch** — a Valkey pub/sub channel
 `curie:kill-events` plus per-agent kill keys — gates and interrupts live runs

--- a/apps/worker/CLAUDE.md
+++ b/apps/worker/CLAUDE.md
@@ -52,6 +52,13 @@ simplification.
   claim; the pre-claim value is the budget already spent. Cap at `>=`. Keep the
   `IDLE` filter equal to `XAUTOCLAIM`'s `min_idle_time`, and keep the
   `_inflight_ids` skip ahead of the cap check.
+- **Narrow prompt-reclaim exception:** the normal heavy-maintenance pass keeps
+  that equal-`IDLE` rule. A younger at/over-cap row may instead be
+  dead-lettered directly only after the owning consumer has advertised
+  capability *and* its independent alive lease has remained absent for the
+  sustained-absence proof. That path still reads pre-claim `XPENDING` metadata
+  and applies the local `_inflight_ids` skip before either a direct
+  dead-letter or an `XCLAIM`; it never charges a live peer another delivery.
 - **`XADD` before `XACK`, never the reverse.** A crash between them costs a
   duplicate graveyard row; the reverse costs the entry.
 - **`max_delivery` is not `max_attempts`.** The latter is the kernel's
@@ -80,6 +87,49 @@ simplification.
   validation.** `XADD` precedes `XACK`, so a self-targeting graveyard re-queues
   failures onto the stream they came from and hot-loops. Do not soften that
   validator into a warning.
+
+## Consumer liveness and prompt recovery (#1532)
+
+`XINFO CONSUMERS` idle is an observation filter, not a process-health signal:
+it grows while a worker drains an in-flight turn or waits on a saturated local
+semaphore. Runs and eval consumers therefore use the same
+`ConsumerLivenessStore`
+(`apps/worker/src/curie_worker/consumer_liveness.py::ConsumerLivenessStore`)
+beside the stream broker, rather than widening `StreamBroker` with generic
+string-key verbs.
+
+- **Publish before reading.** A generation writes its renewable short `alive`
+  lease before its renewable `capability` marker, and does not issue
+  `XREADGROUP` until that ordered publication succeeds. Both markers refresh
+  for the consumer lifetime, including graceful in-flight drain. On graceful
+  exit only the short alive lease is removed; the longer capability marker
+  remains long enough for a replacement to recognize a departed capable peer.
+- **Prompt reclaim needs positive proof of death.** The dedicated liveness
+  cadence considers only a consumer that is idle enough to be a candidate,
+  has a capability marker, and has an absent alive lease on two observations
+  separated by at least one heartbeat TTL. A restored lease, a missing
+  consumer, a liveness-store error, or a generation restart clears that proof.
+  This protects live, draining, and saturated peers from duplicate dispatch.
+- **One replacement owns the transfer.** After the death proof, a short Valkey
+  `SET NX PX` arbitration lease per dead consumer selects one replacement. That
+  prevents replicas crossing the proof threshold together from issuing racing
+  `XCLAIM`s and consuming several delivery attempts. A generation restarted
+  under the same stable consumer name first recovers its own canceled PEL rows
+  through the same pre-claim cap path before it reads new entries.
+- **Terminal teardown is joined, not instantaneous.** A renewal timeout that can
+  no longer be retried safely stops new reads and joins canceled handlers before
+  resetting generation state. Thread-backed work may delay that join; peers
+  still require the full sustained-absence proof and arbitration before transfer.
+- **Mixed-version compatibility is intentional.** An unknown or pre-marker
+  consumer is not guessed dead by the prompt path; its PEL entries stay on the
+  existing 900-second `XAUTOCLAIM` backstop. The prompt path is additional
+  recovery for a proven-dead capable peer, not a shorter global idle timeout.
+- **Runs/eval parity is mandatory.** Both
+  `apps/worker/src/curie_worker/consumer.py::Consumer` and
+  `apps/worker/src/curie_worker/eval/stream.py::EvalStreamConsumer` use the shared
+  `apps/worker/src/curie_worker/stream_consumer.py::StreamConsumer` lifecycle, selection,
+  cap, and sustained-absence rules. Do not give either lane a private reclaim
+  shortcut.
 
 ## The sandbox substrate (`curie_worker.sandbox`)
 

--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -120,8 +120,11 @@ Runtime rules (each has a provoking integration test in `tests/eval/test_stream.
   down in a `finally`. A provisioning failure is a failed run reported and acked.
 - **XACK only after the report POST attempt completes** (success, or terminally failed
   after bounded retries and logged). A worker crash before that leaves the entry
-  pending; a background reclaim loop (`XAUTOCLAIM` past an idle timeout, mirroring the
-  runs consumer) re-runs it, so delivery is **at-least-once** with a best-effort
+  pending. The shared runs/eval liveness path promptly transfers a capable dead
+  consumer's PEL after two lease-absence observations; unknown older consumers
+  retain the 15-minute `XAUTOCLAIM` fallback. A restarted generation first
+  recovers rows under its own stable consumer name. The entry is re-run, so
+  delivery is **at-least-once** with a best-effort
   report. A malformed payload cannot be processed on any redelivery, so it is logged
   and acked (a poison-pill drop). A failing eval case is a failed COUNT in the report,
   not a consumer crash.
@@ -183,8 +186,12 @@ Rules (detailed-architecture 2b), each with an integration test that provokes it
   `budget-exceeded` and everything else escalate.
 - **Idempotency + crash recovery.** The Slack event id gates a `done` marker, so
   a redelivered or reclaimed entry that already finished is skipped.
-  `XAUTOCLAIM` reclaims entries a dead consumer took but never acked and
-  reprocesses them; the markers make that safe.
+  A renewable worker lease distinguishes process death from ordinary consumer
+  idle. After two absent observations, one replacement wins a Valkey arbitration
+  lease and transfers the dead consumer's pending entries without racing other
+  replicas through the delivery budget. Unknown older consumers retain the
+  15-minute `XAUTOCLAIM` fallback; a restarted generation also recovers pending
+  rows left under its own stable consumer name. The markers make reprocessing safe.
 - **Bounded delivery + a dead-letter graveyard** (ADR-0039, an Architecture
   Decision Record; #505). Reclaim is
   capped, not infinite. An entry already delivered `max_delivery` times

--- a/apps/worker/src/curie_worker/config.py
+++ b/apps/worker/src/curie_worker/config.py
@@ -474,14 +474,42 @@ class WorkerConfig(BaseSettings):
     # crash recovery.
     reclaim_min_idle_ms: int = 900000
     reclaim_interval_s: float = 30.0
-    # Prompt reclaim for a consumer that has stopped interacting with the
-    # group (#1532). Entry idle is the wrong signal: a live replica's
-    # in-flight turn is pending for the whole runner timeout, so a short
-    # XAUTOCLAIM threshold would steal it. Consumer idle is the right one:
-    # the read loop keeps issuing XREADGROUP every ``read_block_ms`` even
-    # while a turn is in flight, so a peer idle longer than a few block
-    # intervals is dead, not mid-turn. Default is 3x ``read_block_ms``.
+    # A cheap observation threshold for prompt peer recovery (#1532), not a
+    # liveness proof. XINFO consumer idle also rises while a live worker drains
+    # an in-flight turn or waits at its concurrency limit, so prompt reclaim is
+    # gated by the independent renewable lease below. Default is 3x
+    # ``read_block_ms`` to avoid probing peers during ordinary read blocking.
     dead_consumer_idle_ms: int = Field(default=15000, ge=0)
+    # Independent stream-consumer liveness. A capable worker publishes the
+    # short alive lease before it reads and refreshes it throughout graceful
+    # in-flight drain. A replacement requires two absent observations separated
+    # by a full heartbeat TTL before prompt claim, so neither consumer idle nor
+    # one transient Redis read can manufacture process death.
+    consumer_heartbeat_ttl_ms: int = Field(
+        default=15000,
+        gt=0,
+        validation_alias="CURIE_CONSUMER_HEARTBEAT_TTL_MS",
+    )
+    # The capability marker outlives the 15-minute compatibility backstop. It
+    # proves the departed consumer knew how to publish alive leases; an old
+    # unmarked worker stays exclusively on XAUTOCLAIM rather than being guessed
+    # dead. This TTL is renewed beside alive for the process lifetime.
+    consumer_capability_ttl_ms: int = Field(
+        default=1800000,
+        gt=0,
+        validation_alias="CURIE_CONSUMER_CAPABILITY_TTL_MS",
+    )
+
+    @model_validator(mode="after")
+    def _capability_outlives_reclaim_backstop(self) -> WorkerConfig:
+        if self.consumer_capability_ttl_ms <= self.reclaim_min_idle_ms:
+            raise ValueError(
+                "CURIE_CONSUMER_CAPABILITY_TTL_MS must be greater than "
+                "reclaim_min_idle_ms so a hard-killed capable consumer remains "
+                "distinguishable from a pre-marker worker through the long "
+                "XAUTOCLAIM compatibility window"
+            )
+        return self
 
     # Slack placeholder edits are throttled to avoid rate limits while streaming.
     slack_edit_min_interval_s: float = 0.7

--- a/apps/worker/src/curie_worker/consumer.py
+++ b/apps/worker/src/curie_worker/consumer.py
@@ -44,6 +44,7 @@ from curie_dispatcher.queue import from_stream_fields
 from redis.asyncio import Redis
 
 from .config import WorkerConfig
+from .consumer_liveness import ConsumerLivenessStore
 from .kernel import Kernel
 from .stream_consumer import DeliverySpec, ReadLoopSpec, StreamConsumer
 
@@ -109,7 +110,7 @@ class Consumer(StreamConsumer):
         config: WorkerConfig,
         max_concurrency: int = 16,
     ) -> None:
-        super().__init__(redis)
+        super().__init__(redis, liveness_store=ConsumerLivenessStore(redis))
         # The base class narrows self._redis to the StreamBroker port (stream
         # verbs only, by design -- a second broker implementation need not
         # support anything else). The thread-reset drain (#713) needs a plain
@@ -119,6 +120,7 @@ class Consumer(StreamConsumer):
         self._valkey: Redis = redis
         self._kernel = kernel
         self._config = config
+        self._max_concurrency = max_concurrency
         self._sem = asyncio.Semaphore(max_concurrency)
         self._inflight: set[asyncio.Task[None]] = set()
         # The reclaim/dead-letter knobs the shared base machinery reads. Built
@@ -137,6 +139,8 @@ class Consumer(StreamConsumer):
             dead_letter_maxlen=config.dead_letter_maxlen,
             reclaim_min_idle_ms=config.reclaim_min_idle_ms,
             dead_consumer_idle_ms=config.dead_consumer_idle_ms,
+            heartbeat_ttl_ms=config.consumer_heartbeat_ttl_ms,
+            capability_ttl_ms=config.consumer_capability_ttl_ms,
             read_count=config.read_count,
             cap_scan_page=_CAP_SCAN_PAGE,
             handler=self._dispatch,
@@ -174,13 +178,22 @@ class Consumer(StreamConsumer):
         # it here made a healthy worker's ability to read turns at all wait on
         # the recovery of the thing that broke. Owed completions are recovered on
         # their own timeline; live traffic does not queue behind them.
-        await asyncio.gather(
-            self._startup_completion_sweep(),
-            self._read_loop(),
-            self._maintenance_loop(),
+        await self._run_consumer_generation(
+            {
+                "startup-completion-sweep": self._startup_completion_sweep,
+                "read": self._read_loop,
+                "maintenance": self._maintenance_loop,
+                "prompt-reclaim": self._prompt_reclaim_loop,
+            },
+            may_complete=frozenset({"startup-completion-sweep"}),
         )
-        if self._inflight:
-            await asyncio.gather(*self._inflight, return_exceptions=True)
+
+    def _generation_inflight_tasks(self) -> set[asyncio.Task[None]]:
+        return set(self._inflight)
+
+    def _reset_generation_resources(self) -> None:
+        self._inflight.clear()
+        self._sem = asyncio.Semaphore(self._max_concurrency)
 
     async def _startup_completion_sweep(self) -> None:
         try:
@@ -214,6 +227,9 @@ class Consumer(StreamConsumer):
         # claiming the whole backlog into this consumer's local queue (which would
         # starve other replicas and make a crash wait out the reclaim window).
         await self._sem.acquire()
+        if self._should_stop():
+            self._sem.release()
+            return
         self._inflight_ids.add(entry_id)
         task = asyncio.create_task(self._handle(entry_id, fields))
         self._inflight.add(task)
@@ -283,7 +299,7 @@ class Consumer(StreamConsumer):
     # -- maintenance loop -----------------------------------------------------
 
     async def _maintenance_loop(self) -> None:
-        while not self._stop.is_set():
+        while not self._should_stop():
             try:
                 await self._reclaim_once()
                 await self._kernel.reap_orphans()

--- a/apps/worker/src/curie_worker/consumer_liveness.py
+++ b/apps/worker/src/curie_worker/consumer_liveness.py
@@ -1,0 +1,156 @@
+"""Renewable Valkey leases for stream-consumer process liveness.
+
+Stream consumer idle time is not process liveness: it grows while a worker is
+draining a turn or waiting for local capacity.  This module deliberately keeps
+the independent liveness signal outside :class:`StreamBroker`.  The broker port
+remains stream-only; the one Redis implementation used by the worker gets this
+small string-key adapter alongside it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+
+from redis.asyncio import Redis
+
+
+def consumer_heartbeat_key(stream: str, group: str, consumer: str) -> str:
+    """The renewable alive lease for one stream consumer."""
+
+    return f"{stream}:consumer-heartbeat:{group}:{consumer}"
+
+
+def consumer_heartbeat_capable_key(stream: str, group: str, consumer: str) -> str:
+    """The compatibility marker proving a consumer publishes alive leases."""
+
+    return f"{stream}:consumer-heartbeat-capable:{group}:{consumer}"
+
+
+def consumer_reclaim_lock_key(stream: str, group: str, consumer: str) -> str:
+    """The short arbitration lease for transferring one dead peer's PEL."""
+
+    return f"{stream}:consumer-reclaim-lock:{group}:{consumer}"
+
+
+class ConsumerLivenessStore:
+    """The narrow Redis string-key surface used by consumer liveness.
+
+    Publication and renewal are ordered transactions: the alive lease is
+    written before the capability marker.  Therefore observing capability can
+    never race ahead of the first alive lease.  The capability marker is not
+    deleted at shutdown; its longer TTL lets a replacement distinguish a dead
+    capable process from a pre-marker worker during a rolling upgrade.
+    """
+
+    def __init__(self, redis: Redis) -> None:
+        self._redis = redis
+
+    async def publish(
+        self,
+        *,
+        stream: str,
+        group: str,
+        consumer: str,
+        heartbeat_ttl_ms: int,
+        capability_ttl_ms: int,
+    ) -> None:
+        """Publish alive first, then capability, in one ordered transaction."""
+
+        async with self._redis.pipeline(transaction=True) as pipe:
+            pipe.set(
+                consumer_heartbeat_key(stream, group, consumer),
+                "alive",
+                px=heartbeat_ttl_ms,
+            )
+            pipe.set(
+                consumer_heartbeat_capable_key(stream, group, consumer),
+                "1",
+                px=capability_ttl_ms,
+            )
+            await pipe.execute()
+
+    async def renew(
+        self,
+        *,
+        stream: str,
+        group: str,
+        consumer: str,
+        heartbeat_ttl_ms: int,
+        capability_ttl_ms: int,
+    ) -> None:
+        """Renew both markers together, preserving their publication order."""
+
+        await self.publish(
+            stream=stream,
+            group=group,
+            consumer=consumer,
+            heartbeat_ttl_ms=heartbeat_ttl_ms,
+            capability_ttl_ms=capability_ttl_ms,
+        )
+
+    async def is_alive(self, *, stream: str, group: str, consumer: str) -> bool:
+        return bool(
+            await self._redis.exists(consumer_heartbeat_key(stream, group, consumer))
+        )
+
+    async def is_capable(self, *, stream: str, group: str, consumer: str) -> bool:
+        return bool(
+            await self._redis.exists(
+                consumer_heartbeat_capable_key(stream, group, consumer)
+            )
+        )
+
+    async def cleanup_alive(
+        self,
+        *,
+        stream: str,
+        group: str,
+        consumer: str,
+        timeout_s: float,
+    ) -> None:
+        """Best-effort bounded removal of the short alive lease only."""
+
+        async with asyncio.timeout(timeout_s):
+            await self._redis.delete(consumer_heartbeat_key(stream, group, consumer))
+
+    async def try_acquire_reclaim(
+        self,
+        *,
+        stream: str,
+        group: str,
+        consumer: str,
+        ttl_ms: int,
+    ) -> str | None:
+        """Acquire one dead peer's prompt-reclaim lease, returning its token."""
+
+        token = uuid.uuid4().hex
+        acquired = await self._redis.set(
+            consumer_reclaim_lock_key(stream, group, consumer),
+            token,
+            nx=True,
+            px=ttl_ms,
+        )
+        return token if acquired else None
+
+    async def release_reclaim(
+        self,
+        *,
+        stream: str,
+        group: str,
+        consumer: str,
+        token: str,
+    ) -> None:
+        """Release an arbitration lease only when this caller still owns it."""
+
+        await self._redis.eval(
+            """
+            if redis.call('GET', KEYS[1]) == ARGV[1] then
+              return redis.call('DEL', KEYS[1])
+            end
+            return 0
+            """,
+            1,
+            consumer_reclaim_lock_key(stream, group, consumer),
+            token,
+        )

--- a/apps/worker/src/curie_worker/eval/stream.py
+++ b/apps/worker/src/curie_worker/eval/stream.py
@@ -65,6 +65,7 @@ from ..binding import (
 )
 from ..bundle_store import BundleReader
 from ..config import WorkerConfig
+from ..consumer_liveness import ConsumerLivenessStore
 from ..sandbox import SandboxSubstrate
 from ..sandbox.types import SandboxError
 from ..stream_consumer import DeliverySpec, ReadLoopSpec, StreamConsumer
@@ -256,7 +257,7 @@ class EvalStreamConsumer(StreamConsumer):
         recorder: LangfuseEvalRecorder,
         repo_lookup: Any,
     ) -> None:
-        super().__init__(redis)
+        super().__init__(redis, liveness_store=ConsumerLivenessStore(redis))
         self._config = config
         self._bundles = bundle_store
         self._substrate = substrate
@@ -271,9 +272,11 @@ class EvalStreamConsumer(StreamConsumer):
         # many claims are being created/bound at the same time (default 1: the
         # next claim waits until the current one binds -- sequential-with-
         # backpressure), so a suite completes on one node instead of flooding it.
+        self._max_concurrent_claims = config.eval_max_concurrent_claims
         self._claim_slots = asyncio.Semaphore(config.eval_max_concurrent_claims)
+        self._inflight: set[asyncio.Task[None]] = set()
         # The reclaim/dead-letter knobs the shared base machinery reads; handler
-        # is the bound self._handle. The eval-specific dead_letter_log/logger stay
+        # is the tracked/shielded self._dispatch. The eval-specific log strings stay
         # eval-specific (logger curie_worker.eval.stream) so eval dead-letters
         # remain alert-free -- they are NOT unified with the runs-lane strings.
         self._delivery = DeliverySpec(
@@ -285,15 +288,15 @@ class EvalStreamConsumer(StreamConsumer):
             max_delivery=config.max_delivery,
             dead_letter_maxlen=config.dead_letter_maxlen,
             reclaim_min_idle_ms=config.reclaim_min_idle_ms,
-            # The eval read loop awaits ``_handle`` inline, so XINFO CONSUMERS
-            # idle tracks in-flight suite runtime rather than process liveness.
-            # Prompt reclaim here would steal a live eval after 15s. Use the
-            # entry-idle window instead; the shared helper still runs, and tests
-            # that need the fast path replace this field.
-            dead_consumer_idle_ms=config.reclaim_min_idle_ms,
+            # Eval can use the same prompt threshold as runs now that consumer
+            # idle is only a candidate filter and the independent alive lease is
+            # the liveness proof. Its lease refreshes through inline suite drain.
+            dead_consumer_idle_ms=config.dead_consumer_idle_ms,
+            heartbeat_ttl_ms=config.consumer_heartbeat_ttl_ms,
+            capability_ttl_ms=config.consumer_capability_ttl_ms,
             read_count=config.read_count,
             cap_scan_page=_EVAL_CAP_SCAN_PAGE,
-            handler=self._handle,
+            handler=self._dispatch,
             logger=logger,
             dead_letter_log="dead-lettered eval entry %s after %d deliveries (reason=%s) -> %s",
             dead_letter_fail_log="dead-lettering eval entry %s failed; left pending, not re-run",
@@ -324,7 +327,20 @@ class EvalStreamConsumer(StreamConsumer):
 
     async def run(self) -> None:
         await self.ensure_group()
-        await asyncio.gather(self._read_loop(), self._reclaim_loop())
+        await self._run_consumer_generation(
+            {
+                "read": self._read_loop,
+                "maintenance": self._reclaim_loop,
+                "prompt-reclaim": self._prompt_reclaim_loop,
+            }
+        )
+
+    def _generation_inflight_tasks(self) -> set[asyncio.Task[None]]:
+        return set(self._inflight)
+
+    def _reset_generation_resources(self) -> None:
+        self._inflight.clear()
+        self._claim_slots = asyncio.Semaphore(self._max_concurrent_claims)
 
     async def _read_loop(self) -> None:
         # count=1 is load-bearing, not a tunable: this consumer handles an entry
@@ -345,7 +361,7 @@ class EvalStreamConsumer(StreamConsumer):
                 connection_msg="eval stream read failed transiently; retrying: %s",
                 logger=logger,
             ),
-            self._handle,
+            self._dispatch,
         )
 
     async def _reclaim_loop(self) -> None:
@@ -353,12 +369,28 @@ class EvalStreamConsumer(StreamConsumer):
         them. Without this, an entry left pending by a crash before ``_ack``
         would sit in the group's PEL forever -- the at-least-once promise the
         ``_handle`` pending path relies on lives here."""
-        while not self._stop.is_set():
+        while not self._should_stop():
             try:
                 await self._reclaim_once()
             except Exception:
                 logger.exception("eval reclaim tick failed")
             await self._sleep_or_stop(self._config.reclaim_interval_s)
+
+    async def _dispatch(self, entry_id: str, fields: dict[str, str]) -> None:
+        """Track the inline eval handler so graceful stop can drain it alive."""
+
+        if entry_id in self._inflight_ids:
+            return
+        # Reserve before spawning so the read and reclaim producers cannot both
+        # pass the duplicate check in the same event-loop turn.
+        self._inflight_ids.add(entry_id)
+        task = asyncio.create_task(self._handle(entry_id, fields))
+        self._inflight.add(task)
+        task.add_done_callback(self._inflight.discard)
+        # The read/reclaim producer may be cancelled to stop new ownership, but
+        # graceful shutdown keeps this handler alive and the lifecycle drains it
+        # before deleting the consumer lease.
+        await asyncio.shield(task)
 
     async def _handle(self, entry_id: str, fields: dict[str, str]) -> None:
         self._inflight_ids.add(entry_id)

--- a/apps/worker/src/curie_worker/stream_consumer.py
+++ b/apps/worker/src/curie_worker/stream_consumer.py
@@ -14,10 +14,11 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import Awaitable, Callable
+import time
+from collections.abc import Awaitable, Callable, Coroutine
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import cast
+from typing import Any, cast
 
 from redis.exceptions import (
     ConnectionError as RedisConnectionError,
@@ -30,6 +31,7 @@ from redis.exceptions import (
 )
 
 from .broker import StreamBroker
+from .consumer_liveness import ConsumerLivenessStore
 
 # One stream entry as redis returns it with decode_responses=True.
 StreamEntry = tuple[str, dict[str, str]]
@@ -72,12 +74,18 @@ class DeliverySpec:
     dead_letter_maxlen: int
     reclaim_min_idle_ms: int
     dead_consumer_idle_ms: int
+    heartbeat_ttl_ms: int
+    capability_ttl_ms: int
     read_count: int
     cap_scan_page: int
     handler: EntryHandler
     logger: logging.Logger
     dead_letter_log: str
     dead_letter_fail_log: str
+
+
+class ConsumerLivenessExpired(RuntimeError):
+    """The local consumer could no longer renew its alive lease safely."""
 
 
 class StreamConsumer:
@@ -90,13 +98,24 @@ class StreamConsumer:
     business logic.
     """
 
-    def __init__(self, redis: StreamBroker, delivery: DeliverySpec | None = None) -> None:
+    def __init__(
+        self,
+        redis: StreamBroker,
+        delivery: DeliverySpec | None = None,
+        *,
+        liveness_store: ConsumerLivenessStore | None = None,
+    ) -> None:
         # The stream broker behind the port (#284). ``redis.asyncio.Redis`` is the
         # one backing today and structurally satisfies ``StreamBroker``; a second
         # broker is a drop-in. Named ``_redis`` still so the sacred consumer.py
         # subclass (which reads ``self._redis`` for XAUTOCLAIM) is untouched.
         self._redis: StreamBroker = redis
+        # Process stop is permanent (SIGTERM/operator shutdown). Generation stop
+        # is replaced for every supervised ``run()`` so a terminal lease failure
+        # can tear one generation down and restart cleanly without making the
+        # process look gracefully stopped.
         self._stop = asyncio.Event()
+        self._generation_stop = asyncio.Event()
         # Entry ids currently being handled by THIS consumer. XAUTOCLAIM would
         # otherwise reclaim our own long-running (still-pending) entries and
         # re-dispatch a duplicate handler that steers the same prompt into its
@@ -105,6 +124,14 @@ class StreamConsumer:
         # The reclaim/dead-letter knobs, or None for a base-only reader that
         # exercises just ``_consume`` (no reclaim machinery).
         self._delivery = delivery
+        self._liveness_store = liveness_store
+        # The first absent observation for each capable peer. It is scoped to a
+        # run generation and cleared on restoration/disappearance/restart.
+        self._peer_absent_since: dict[str, float] = {}
+        # Prompt and 15-minute recovery both select PEL ownership through this
+        # lock. It never covers handler execution or a capacity-semaphore wait.
+        self._reclaim_lock = asyncio.Lock()
+        self._last_liveness_renewal: float | None = None
 
     @property
     def _spec(self) -> DeliverySpec:
@@ -115,6 +142,9 @@ class StreamConsumer:
 
     def request_stop(self) -> None:
         self._stop.set()
+
+    def _should_stop(self) -> bool:
+        return self._stop.is_set() or self._generation_stop.is_set()
 
     async def _ensure_group(self, stream: str, group: str, *, start_id: str) -> None:
         """Create the consumer group (and the stream) if it does not exist.
@@ -132,7 +162,7 @@ class StreamConsumer:
     async def _consume(self, spec: ReadLoopSpec, handler: EntryHandler) -> None:
         """Blocking-read loop: read the group, dispatch each entry to ``handler``,
         and survive transient transport faults until stop is requested."""
-        while not self._stop.is_set():
+        while not self._should_stop():
             try:
                 resp = await self._redis.xreadgroup(
                     spec.group,
@@ -185,10 +215,247 @@ class StreamConsumer:
                         )
 
     async def _sleep_or_stop(self, seconds: float) -> None:
+        """Sleep until the process/generation stops or the timeout elapses."""
+
+        process_stop = asyncio.create_task(self._stop.wait())
+        generation_stop = asyncio.create_task(self._generation_stop.wait())
         try:
-            await asyncio.wait_for(self._stop.wait(), timeout=seconds)
+            await asyncio.wait(
+                {process_stop, generation_stop},
+                timeout=seconds,
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+        finally:
+            for task in (process_stop, generation_stop):
+                if not task.done():
+                    task.cancel()
+            await asyncio.gather(process_stop, generation_stop, return_exceptions=True)
+
+    async def _sleep_generation(self, seconds: float) -> None:
+        """Sleep for a lease cadence, ignoring process stop during drain."""
+
+        try:
+            await asyncio.wait_for(self._generation_stop.wait(), timeout=seconds)
         except TimeoutError:
             pass
+
+    # -- consumer liveness + structured run generations ---------------------
+
+    def _generation_inflight_tasks(self) -> set[asyncio.Task[None]]:
+        """Tasks whose handlers own PEL entries in this generation."""
+
+        return set()
+
+    def _reset_generation_resources(self) -> None:
+        """Subclass hook for semaphore/accounting reset after forced teardown."""
+
+    def _reset_generation(self) -> None:
+        self._generation_stop = asyncio.Event()
+        self._peer_absent_since.clear()
+        self._inflight_ids.clear()
+        self._last_liveness_renewal = None
+
+    def _liveness_timeout_s(self) -> float:
+        # One renewal attempt may consume at most one sixth of the lease, so a
+        # timed-out attempt plus a retry still fit before the pre-expiry guard.
+        # The
+        # 1ms floor keeps deliberately tiny integration-test leases usable.
+        return max(0.001, self._spec.heartbeat_ttl_ms / 6000)
+
+    async def _publish_liveness(self) -> None:
+        if self._liveness_store is None:
+            raise RuntimeError("consumer generation has no liveness store")
+        async with asyncio.timeout(self._liveness_timeout_s()):
+            await self._liveness_store.publish(
+                stream=self._spec.stream,
+                group=self._spec.group,
+                consumer=self._spec.consumer,
+                heartbeat_ttl_ms=self._spec.heartbeat_ttl_ms,
+                capability_ttl_ms=self._spec.capability_ttl_ms,
+            )
+        self._last_liveness_renewal = time.monotonic()
+
+    async def _liveness_refresh_loop(self) -> None:
+        """Renew alive/capability until this run generation ends.
+
+        One transient failure is not terminal. What matters is monotonic time
+        since the last confirmed renewal: before the alive lease can silently
+        expire, this task raises and structured teardown leaves owned entries in
+        the PEL for a replacement generation/process.
+        """
+
+        assert self._liveness_store is not None
+        ttl_s = self._spec.heartbeat_ttl_ms / 1000
+        refresh_s = ttl_s / 3
+        expiry_guard_s = max(0.001, ttl_s - refresh_s)
+        retry_s = max(0.001, min(refresh_s / 4, 0.25))
+
+        await self._sleep_generation(refresh_s)
+        while not self._generation_stop.is_set():
+            try:
+                async with asyncio.timeout(self._liveness_timeout_s()):
+                    await self._liveness_store.renew(
+                        stream=self._spec.stream,
+                        group=self._spec.group,
+                        consumer=self._spec.consumer,
+                        heartbeat_ttl_ms=self._spec.heartbeat_ttl_ms,
+                        capability_ttl_ms=self._spec.capability_ttl_ms,
+                    )
+            except Exception as exc:
+                # ``CancelledError`` remains a BaseException and propagates.
+                last = self._last_liveness_renewal
+                elapsed = float("inf") if last is None else time.monotonic() - last
+                if elapsed >= expiry_guard_s:
+                    raise ConsumerLivenessExpired(
+                        "consumer liveness renewal could not be confirmed before "
+                        f"lease expiry for {self._spec.consumer}"
+                    ) from exc
+                self._spec.logger.warning(
+                    "consumer liveness renewal failed transiently for %s; retrying",
+                    self._spec.consumer,
+                    exc_info=True,
+                )
+                await self._sleep_generation(retry_s)
+                continue
+            self._last_liveness_renewal = time.monotonic()
+            await self._sleep_generation(refresh_s)
+
+    async def _cleanup_alive(self) -> None:
+        if self._liveness_store is None:
+            return
+        try:
+            await self._liveness_store.cleanup_alive(
+                stream=self._spec.stream,
+                group=self._spec.group,
+                consumer=self._spec.consumer,
+                timeout_s=self._liveness_timeout_s(),
+            )
+        except Exception:
+            # Cleanup is best effort. The short TTL remains the authoritative
+            # bound if Valkey is unavailable while this generation terminates.
+            self._spec.logger.warning(
+                "consumer alive-lease cleanup failed for %s; awaiting TTL",
+                self._spec.consumer,
+                exc_info=True,
+            )
+
+    async def _cancel_and_join(self, tasks: set[asyncio.Task[None]]) -> None:
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+    async def _run_consumer_generation(
+        self,
+        factories: dict[str, Callable[[], Coroutine[Any, Any, None]]],
+        *,
+        may_complete: frozenset[str] = frozenset(),
+    ) -> None:
+        """Run one supervised consumer generation with structured teardown.
+
+        ``request_stop`` is graceful: stop/cancel new-work loops, drain existing
+        handlers while the lease refresher stays alive, then remove the alive
+        lease. A child/refresher failure is terminal: cancel and join every loop
+        and handler, reset generation-local ownership/accounting, and re-raise so
+        the process supervisor starts exactly one clean generation.
+        """
+
+        self._reset_generation()
+        await self._publish_liveness()  # ordered publication precedes every read
+        reserved = factories.keys() & {"bootstrap", "liveness"}
+        if reserved:
+            raise ValueError(f"consumer generation factories use reserved names: {reserved}")
+
+        # A prior generation in this same pod can have been canceled after its
+        # alive lease became unverifiable. Recover rows still owned by this
+        # stable consumer name before reading new work. The refresher is already
+        # running while eval's inline handler drains this bootstrap.
+        tasks: dict[str, asyncio.Task[None]] = {}
+        tasks["liveness"] = asyncio.create_task(
+            self._liveness_refresh_loop(), name="consumer:liveness"
+        )
+        tasks["bootstrap"] = asyncio.create_task(
+            self._recover_local_pending_once(), name="consumer:bootstrap"
+        )
+        stop_waiter = asyncio.create_task(self._stop.wait(), name="consumer:process-stop")
+
+        failure: BaseException | None = None
+        graceful = False
+        try:
+            while tasks:
+                done, _pending = await asyncio.wait(
+                    {*tasks.values(), stop_waiter},
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+                if stop_waiter in done:
+                    graceful = True
+                    break
+                for name, task in list(tasks.items()):
+                    if task not in done:
+                        continue
+                    del tasks[name]
+                    try:
+                        task.result()
+                    except BaseException as exc:
+                        failure = exc
+                        break
+                    if name == "bootstrap":
+                        tasks.update(
+                            {
+                                child_name: asyncio.create_task(
+                                    factory(), name=f"consumer:{child_name}"
+                                )
+                                for child_name, factory in factories.items()
+                            }
+                        )
+                        continue
+                    if name not in may_complete:
+                        failure = RuntimeError(
+                            f"consumer generation task {name!r} exited unexpectedly"
+                        )
+                        break
+                if failure is not None:
+                    break
+
+            if graceful:
+                # No new ownership after this point. Eval dispatch shields its
+                # inline handler; runs handlers already live in the in-flight set.
+                background = {
+                    task for name, task in tasks.items() if name != "liveness"
+                }
+                await self._cancel_and_join(background)
+
+                # Snapshot after producer loops are joined, so no new handler can
+                # appear while graceful drain is in progress.
+                inflight = self._generation_inflight_tasks()
+                if inflight:
+                    await asyncio.gather(*inflight, return_exceptions=True)
+
+                self._generation_stop.set()
+                liveness = tasks.get("liveness")
+                if liveness is not None:
+                    await asyncio.gather(liveness, return_exceptions=True)
+                return
+
+            # A terminal liveness or child failure must leave no zombie loop or
+            # handler that could race the replacement generation.
+            self._generation_stop.set()
+            await self._cancel_and_join(set(tasks.values()))
+            await self._cancel_and_join(self._generation_inflight_tasks())
+            self._reset_generation_resources()
+            # All old-generation work is joined. Replace the event and clear
+            # ownership/absence state before the supervisor's restart backoff so
+            # the next ``run()`` cannot inherit a terminal generation.
+            self._reset_generation()
+            if failure is None:
+                failure = RuntimeError("consumer generation exited without a terminal cause")
+            raise failure
+        finally:
+            if not stop_waiter.done():
+                stop_waiter.cancel()
+            await asyncio.gather(stop_waiter, return_exceptions=True)
+            await self._cleanup_alive()
 
     async def _xack(self, stream: str, group: str, entry_id: str) -> None:
         await self._redis.xack(stream, group, entry_id)
@@ -345,48 +612,141 @@ class StreamConsumer:
             cursor = f"({pending[-1]['message_id']}"
         return over_cap
 
-    async def _reclaim_dead_consumers(self, over_cap: set[str]) -> int:
-        """Claim pending entries from consumers that have gone quiet.
+    async def _select_dead_consumer_entries(
+        self, over_cap: set[str]
+    ) -> list[StreamEntry]:
+        """Select/transfer entries only after sustained lease absence.
 
-        ``reclaim_min_idle_ms`` is an *entry* idle and must stay long enough
-        that a healthy in-flight turn is not stolen from a live replica.
-        Consumer idle is independent: a live worker keeps issuing XREADGROUP
-        every ``read_block_ms`` while its handler runs, so a peer whose last
-        group interaction is older than ``dead_consumer_idle_ms`` is gone, and
-        its PEL can be taken without waiting the 15-minute entry window
-        (#1532).
+        Caller holds ``_reclaim_lock``. Consumer idle is merely a cheap
+        candidate threshold. A peer is proven dead only when it advertised the
+        liveness protocol and its alive lease is absent on two observations at
+        least one full heartbeat TTL apart. Unknown/pre-marker peers remain on
+        the unchanged XAUTOCLAIM backstop.
         """
+
+        if self._liveness_store is None:
+            return []
         try:
-            consumers = await self._redis.xinfo_consumers(self._spec.stream, self._spec.group)
+            consumers = await self._redis.xinfo_consumers(
+                self._spec.stream, self._spec.group
+            )
         except ResponseError:
-            return 0
-        reclaimed = 0
+            self._peer_absent_since.clear()
+            return []
+
+        current_names = {str(info["name"]) for info in consumers}
+        for missing in self._peer_absent_since.keys() - current_names:
+            self._peer_absent_since.pop(missing, None)
+
+        now = time.monotonic()
+        required_absence_s = self._spec.heartbeat_ttl_ms / 1000
+        selected: list[StreamEntry] = []
         for info in consumers:
-            if self._stop.is_set():
+            if self._should_stop():
                 break
             name = str(info["name"])
-            if name == self._spec.consumer:
+            if (
+                name == self._spec.consumer
+                or int(info.get("pending") or 0) <= 0
+                or int(info.get("idle") or 0) < self._spec.dead_consumer_idle_ms
+            ):
+                self._peer_absent_since.pop(name, None)
                 continue
-            if int(info.get("pending") or 0) <= 0:
-                continue
-            if int(info.get("idle") or 0) < self._spec.dead_consumer_idle_ms:
-                continue
+
             try:
-                reclaimed += await self._claim_consumer_pending(name, over_cap)
+                capable = await self._liveness_store.is_capable(
+                    stream=self._spec.stream,
+                    group=self._spec.group,
+                    consumer=name,
+                )
+                if not capable:
+                    self._peer_absent_since.pop(name, None)
+                    continue
+                alive = await self._liveness_store.is_alive(
+                    stream=self._spec.stream,
+                    group=self._spec.group,
+                    consumer=name,
+                )
+            except Exception:
+                # An uncertain observation cannot contribute to proof of death.
+                self._peer_absent_since.pop(name, None)
+                self._spec.logger.warning(
+                    "consumer liveness observation failed for %s; prompt reclaim skipped",
+                    name,
+                    exc_info=True,
+                )
+                continue
+
+            if alive:
+                self._peer_absent_since.pop(name, None)
+                continue
+            first_absent = self._peer_absent_since.setdefault(name, now)
+            if now - first_absent < required_absence_s:
+                continue
+            token: str | None = None
+            try:
+                # Every surviving replica reaches this proof point at roughly
+                # the same time. A Valkey NX lease chooses one transfer owner so
+                # racing XCLAIM calls cannot burn several delivery attempts.
+                token = await self._liveness_store.try_acquire_reclaim(
+                    stream=self._spec.stream,
+                    group=self._spec.group,
+                    consumer=name,
+                    ttl_ms=max(self._spec.heartbeat_ttl_ms * 2, 60_000),
+                )
+                if token is None:
+                    continue
+                selected.extend(
+                    await self._claim_consumer_pending_locked(name, over_cap)
+                )
             except Exception:
                 self._spec.logger.exception(
                     "dead-consumer reclaim failed for %s on stream %s; left pending",
                     name,
                     self._spec.stream,
                 )
-        return reclaimed
+            finally:
+                if token is not None:
+                    try:
+                        await self._liveness_store.release_reclaim(
+                            stream=self._spec.stream,
+                            group=self._spec.group,
+                            consumer=name,
+                            token=token,
+                        )
+                    except Exception:
+                        # The lease TTL is authoritative. Never discard entries
+                        # already transferred merely because release failed.
+                        self._spec.logger.warning(
+                            "dead-consumer reclaim lease release failed for %s",
+                            name,
+                            exc_info=True,
+                        )
+        return selected
 
-    async def _claim_consumer_pending(self, name: str, over_cap: set[str]) -> int:
-        """XCLAIM one dead consumer's pending page and dispatch each entry."""
-        reclaimed = 0
+    async def _recover_local_pending_once(self) -> None:
+        """Recover rows canceled by an earlier generation with this same name."""
+
+        async with self._reclaim_lock:
+            entries = await self._claim_consumer_pending_locked(
+                self._spec.consumer, set()
+            )
+        await self._dispatch_reclaimed(entries)
+
+    async def _claim_consumer_pending_locked(
+        self, name: str, over_cap: set[str]
+    ) -> list[StreamEntry]:
+        """Transfer one proven-dead peer's PEL, enforcing cap before XCLAIM.
+
+        Caller holds ``_reclaim_lock``. At/over-cap entries are dead-lettered
+        directly without XCLAIM's delivery-count increment. Handler dispatch is
+        returned to the caller and always occurs after the lock is released.
+        """
+
+        selected: list[StreamEntry] = []
         cursor = "-"
         page_size = self._spec.read_count
-        while not self._stop.is_set():
+        while not self._should_stop():
             rows = await self._redis.xpending_range(
                 self._spec.stream,
                 self._spec.group,
@@ -397,29 +757,83 @@ class StreamConsumer:
             )
             if not rows:
                 break
-            ids = [
-                str(row["message_id"])
-                for row in rows
-                if str(row["message_id"]) not in self._inflight_ids
-                and str(row["message_id"]) not in over_cap
-            ]
-            if ids:
+
+            claim_ids: list[str] = []
+            for row in rows:
+                entry_id = str(row["message_id"])
+                if entry_id in self._inflight_ids or entry_id in over_cap:
+                    continue
+                delivered = int(row["times_delivered"])
+                if delivered >= self._spec.max_delivery:
+                    over_cap.add(entry_id)
+                    try:
+                        await self._dead_letter(
+                            entry_id,
+                            await self._entry_fields(entry_id),
+                            reason=self._spec.over_cap_reason,
+                            delivery_count=delivered,
+                        )
+                    except Exception:
+                        self._spec.logger.exception(
+                            self._spec.dead_letter_fail_log,
+                            entry_id,
+                        )
+                    continue
+                claim_ids.append(entry_id)
+
+            if claim_ids:
                 claimed = await self._redis.xclaim(
                     self._spec.stream,
                     self._spec.group,
                     self._spec.consumer,
                     0,
-                    ids,
+                    claim_ids,
                 )
                 for entry_id, fields in cast("list[StreamEntry]", claimed or []):
                     if entry_id in self._inflight_ids or entry_id in over_cap:
                         continue
-                    reclaimed += 1
-                    await self._spec.handler(entry_id, dict(fields))
+                    selected.append((entry_id, dict(fields)))
             if len(rows) < page_size:
                 break
             cursor = f"({rows[-1]['message_id']}"
-        return reclaimed
+        return selected
+
+    async def _dispatch_reclaimed(self, entries: list[StreamEntry]) -> int:
+        dispatched = 0
+        for entry_id, fields in entries:
+            if self._should_stop():
+                break
+            if entry_id in self._inflight_ids:
+                continue
+            await self._spec.handler(entry_id, fields)
+            dispatched += 1
+        return dispatched
+
+    async def _reclaim_dead_consumers(self) -> int:
+        """Prompt-only compatible-peer reclaim, with dispatch outside lock."""
+
+        async with self._reclaim_lock:
+            entries = await self._select_dead_consumer_entries(set())
+        return await self._dispatch_reclaimed(entries)
+
+    async def _prompt_reclaim_once(self) -> int:
+        """Observe capable peers and promptly recover only proven-dead owners."""
+
+        return await self._reclaim_dead_consumers()
+
+    async def _prompt_reclaim_loop(self) -> None:
+        """Dedicated lease-observation cadence, isolated from heavy maintenance."""
+
+        interval_s = self._spec.heartbeat_ttl_ms / 3000
+        while not self._should_stop():
+            try:
+                await self._prompt_reclaim_once()
+            except Exception:
+                self._spec.logger.exception(
+                    "prompt consumer reclaim tick failed on stream %s",
+                    self._spec.stream,
+                )
+            await self._sleep_or_stop(interval_s)
 
     async def _reclaim_once(self) -> int:
         """Reclaim entries pending too long from any (dead) consumer and retry.
@@ -430,30 +844,31 @@ class StreamConsumer:
         still pending), so the ids it reports are skipped rather than dispatched:
         the cap binds even when the graveyard is unwritable.
 
-        Dead consumers are claimed by consumer idle first so a rollout that
-        strands a PEL does not wait ``reclaim_min_idle_ms``.
+        The prompt capable-peer path shares this selection lock, while unknown
+        peers retain this 15-minute compatibility backstop unchanged.
         """
-        over_cap = await self._dead_letter_over_cap()
-        reclaimed = await self._reclaim_dead_consumers(over_cap)
-        cursor: str = "0-0"
-        while not self._stop.is_set():
-            raw = await self._redis.xautoclaim(
-                self._spec.stream,
-                self._spec.group,
-                self._spec.consumer,
-                min_idle_time=self._spec.reclaim_min_idle_ms,
-                start_id=cursor,
-                count=self._spec.read_count,
-            )
-            cursor = str(raw[0])
-            entries = cast("list[StreamEntry]", raw[1])
-            for entry_id, fields in entries:
-                if entry_id in self._inflight_ids:
-                    continue  # still being processed here; not an orphan
-                if entry_id in over_cap:
-                    continue  # budget spent; never dispatch it again
-                reclaimed += 1
-                await self._spec.handler(entry_id, fields)
-            if cursor in ("0-0", "0"):
-                break
-        return reclaimed
+        selected: list[StreamEntry] = []
+        async with self._reclaim_lock:
+            over_cap = await self._dead_letter_over_cap()
+            selected.extend(await self._select_dead_consumer_entries(over_cap))
+            cursor: str = "0-0"
+            while not self._should_stop():
+                raw = await self._redis.xautoclaim(
+                    self._spec.stream,
+                    self._spec.group,
+                    self._spec.consumer,
+                    min_idle_time=self._spec.reclaim_min_idle_ms,
+                    start_id=cursor,
+                    count=self._spec.read_count,
+                )
+                cursor = str(raw[0])
+                entries = cast("list[StreamEntry]", raw[1])
+                for entry_id, fields in entries:
+                    if entry_id in self._inflight_ids:
+                        continue  # still being processed here; not an orphan
+                    if entry_id in over_cap:
+                        continue  # budget spent; never dispatch it again
+                    selected.append((entry_id, fields))
+                if cursor in ("0-0", "0"):
+                    break
+        return await self._dispatch_reclaimed(selected)

--- a/apps/worker/src/curie_worker/stream_consumer.py
+++ b/apps/worker/src/curie_worker/stream_consumer.py
@@ -362,10 +362,10 @@ class StreamConsumer:
         """
 
         self._reset_generation()
-        await self._publish_liveness()  # ordered publication precedes every read
         reserved = factories.keys() & {"bootstrap", "liveness"}
         if reserved:
             raise ValueError(f"consumer generation factories use reserved names: {reserved}")
+        await self._publish_liveness()  # ordered publication precedes every read
 
         # A prior generation in this same pod can have been canceled after its
         # alive lease became unverifiable. Recover rows still owned by this
@@ -696,6 +696,16 @@ class StreamConsumer:
                 )
                 if token is None:
                     continue
+                # The alive lease can be republished between the observation
+                # above and winning arbitration. Re-check inside the lease so a
+                # stale absence never transfers work from a restarted owner.
+                if await self._liveness_store.is_alive(
+                    stream=self._spec.stream,
+                    group=self._spec.group,
+                    consumer=name,
+                ):
+                    self._peer_absent_since.pop(name, None)
+                    continue
                 selected.extend(
                     await self._claim_consumer_pending_locked(name, over_cap)
                 )
@@ -727,11 +737,48 @@ class StreamConsumer:
     async def _recover_local_pending_once(self) -> None:
         """Recover rows canceled by an earlier generation with this same name."""
 
-        async with self._reclaim_lock:
-            entries = await self._claim_consumer_pending_locked(
-                self._spec.consumer, set()
-            )
-        await self._dispatch_reclaimed(entries)
+        if self._liveness_store is None:
+            raise RuntimeError("consumer liveness store is required")
+        retry_s = min(max(0.001, self._spec.heartbeat_ttl_ms / 3000), 1.0)
+        while not self._should_stop():
+            token: str | None = None
+            entries: list[StreamEntry] = []
+            async with self._reclaim_lock:
+                try:
+                    # A peer can begin transferring this stable consumer name
+                    # while the local supervisor is between generations.
+                    # Bootstrap must contend on the same distributed lease or
+                    # both XCLAIM calls can dispatch the row and spend two
+                    # delivery attempts.
+                    token = await self._liveness_store.try_acquire_reclaim(
+                        stream=self._spec.stream,
+                        group=self._spec.group,
+                        consumer=self._spec.consumer,
+                        ttl_ms=max(self._spec.heartbeat_ttl_ms * 2, 60_000),
+                    )
+                    if token is not None:
+                        entries = await self._claim_consumer_pending_locked(
+                            self._spec.consumer, set()
+                        )
+                finally:
+                    if token is not None:
+                        try:
+                            await self._liveness_store.release_reclaim(
+                                stream=self._spec.stream,
+                                group=self._spec.group,
+                                consumer=self._spec.consumer,
+                                token=token,
+                            )
+                        except Exception:
+                            self._spec.logger.warning(
+                                "local pending recovery lease release failed for %s",
+                                self._spec.consumer,
+                                exc_info=True,
+                            )
+            if token is not None:
+                await self._dispatch_reclaimed(entries)
+                return
+            await self._sleep_generation(retry_s)
 
     async def _claim_consumer_pending_locked(
         self, name: str, over_cap: set[str]

--- a/apps/worker/tests/binding/test_boot_env_single_declaration.py
+++ b/apps/worker/tests/binding/test_boot_env_single_declaration.py
@@ -91,6 +91,8 @@ _NON_BOOT_ALLOWLIST: frozenset[str] = frozenset(
         # from the WORKER's env at worker startup. Never a sandbox boot key.
         "CURIE_BOOTING_TEXT",
         "CURIE_CONSUMER_GROUP",
+        "CURIE_CONSUMER_CAPABILITY_TTL_MS",
+        "CURIE_CONSUMER_HEARTBEAT_TTL_MS",
         "CURIE_CONSUMER_NAME",
         "CURIE_DEAD_LETTER_MAXLEN",
         "CURIE_MAX_ATTEMPTS",

--- a/apps/worker/tests/eval/conftest.py
+++ b/apps/worker/tests/eval/conftest.py
@@ -10,6 +10,7 @@ and Langfuse are always real."""
 
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import io
 import os
@@ -70,6 +71,10 @@ class FakeEvalRunner:
             ]
         )
         self.responses: dict[str, str] = {}
+        # Inputs held in-flight until the test releases the event. This drives
+        # lifecycle assertions across a real inline eval handler without
+        # replacing the runner HTTP path.
+        self.hold_inputs: dict[str, asyncio.Event] = {}
         self.fail_inputs: set[str] = set()
         # Inputs whose turn ends with a classified-failure final (budget/model
         # error) while still carrying text in responses[input].
@@ -120,6 +125,9 @@ class FakeEvalRunner:
         body = await request.json()
         self.seen.append(body)
         text = body["text"]
+        hold = self.hold_inputs.get(text)
+        if hold is not None:
+            await hold.wait()
         if text in self.fail_inputs:
             return web.json_response({"error": "boom"}, status=500)
         # A recall input answers from the conversation so far (the history that a

--- a/apps/worker/tests/eval/test_stream.py
+++ b/apps/worker/tests/eval/test_stream.py
@@ -41,6 +41,11 @@ from curie_test_support.valkey import (
 from curie_worker.binding import BUDGET_ENV, BUNDLE_REF_ENV, MODEL_ENV, THINKING_ENV
 from curie_worker.bundle_store import BundleStore
 from curie_worker.config import WorkerConfig
+from curie_worker.consumer_liveness import (
+    ConsumerLivenessStore,
+    consumer_heartbeat_capable_key,
+    consumer_heartbeat_key,
+)
 from curie_worker.eval import (
     EvalCase,
     EvalJob,
@@ -305,6 +310,93 @@ def test_eval_read_loop_demotes_idle_timeout_to_debug(make_eval_harness, bundles
                 assert conn_recs and all(r.levelno == logging.WARNING for r in conn_recs)
 
             await client.delete(cfg.eval_stream)
+            await client.aclose()
+
+    asyncio.run(go())
+
+
+def test_eval_consumer_publishes_and_renews_shared_liveness_lifecycle(
+    make_eval_harness, bundles
+) -> None:
+    store, upload = bundles
+
+    async def go() -> None:
+        async with make_eval_harness() as (base_url, fake, _client):
+            token = uuid.uuid4().hex[:8]
+            cfg = _cfg(
+                f"test:evals:{token}",
+                f"g-{token}",
+                reclaim_min_idle_ms=300,
+                consumer_heartbeat_ttl_ms=150,
+                consumer_capability_ttl_ms=450,
+                read_block_ms=10,
+            )
+            client = AsyncRedis(host=_VH, port=_VP, password=_VPW, decode_responses=True)
+            reports: list[dict[str, Any]] = []
+            async with httpx.AsyncClient(timeout=30.0) as lf_client:
+                consumer = _build_consumer(
+                    redis_client=client,
+                    cfg=cfg,
+                    bundle_store=store,
+                    substrate=_UnusedSubstrate(),
+                    reports=reports,
+                    lf_client=lf_client,
+                )
+                alive = consumer_heartbeat_key(
+                    cfg.eval_stream, cfg.eval_consumer_group, cfg.eval_consumer_name
+                )
+                capable = consumer_heartbeat_capable_key(
+                    cfg.eval_stream, cfg.eval_consumer_group, cfg.eval_consumer_name
+                )
+                release = asyncio.Event()
+                fake.responses["held-eval"] = "done"
+                fake.hold_inputs["held-eval"] = release
+                bundle_ref = upload(
+                    EvalSuite(
+                        name="liveness",
+                        cases=[
+                            EvalCase(
+                                id="held",
+                                input="held-eval",
+                                grader=Grader(kind=CONTAINS, expected="done"),
+                            )
+                        ],
+                    )
+                )
+                await consumer.ensure_group()
+                await client.xadd(
+                    cfg.eval_stream,
+                    {
+                        "payload": _item(
+                            suite="liveness",
+                            sha=f"sha-{token}",
+                            bundle_ref=bundle_ref,
+                            target_url=base_url,
+                        ).model_dump_json()
+                    },
+                )
+                task = asyncio.create_task(consumer.run())
+                deadline = time.monotonic() + 2
+                while time.monotonic() < deadline:
+                    if await client.exists(alive) and await client.exists(capable):
+                        break
+                    await asyncio.sleep(0.005)
+                assert await client.exists(alive)
+                assert await client.exists(capable)
+
+                await _wait_until(lambda: bool(fake.seen))
+                consumer.request_stop()
+                await asyncio.sleep(0.35)
+                assert not task.done(), "graceful stop must drain the inline eval handler"
+                assert await client.pttl(alive) > 0
+                assert await client.pttl(capable) > 0
+                release.set()
+                await task
+                assert reports and reports[0]["passed_count"] == 1
+                assert not await client.exists(alive)
+                assert await client.exists(capable)
+
+            await client.delete(cfg.eval_stream, alive, capable)
             await client.aclose()
 
     asyncio.run(go())
@@ -865,8 +957,10 @@ def test_pending_entry_from_a_dead_consumer_is_reclaimed_without_waiting_min_idl
             cfg = _cfg(
                 f"test:evals:{token}",
                 f"g-{token}",
-                reclaim_min_idle_ms=900000,
+                reclaim_min_idle_ms=5000,
                 reclaim_interval_s=0.05,
+                consumer_heartbeat_ttl_ms=30,
+                consumer_capability_ttl_ms=6000,
             )
             client = AsyncRedis(host=_VH, port=_VP, password=_VPW, decode_responses=True)
             reports: list[dict[str, Any]] = []
@@ -879,9 +973,8 @@ def test_pending_entry_from_a_dead_consumer_is_reclaimed_without_waiting_min_idl
                     reports=reports,
                     lf_client=lf_client,
                 )
-                # Production eval pins this to reclaim_min_idle_ms because its
-                # read loop is inline. Pin 0 here so this sibling proves the
-                # shared helper, not XAUTOCLAIM.
+                # Force only the prompt candidate observation threshold; the
+                # shared heartbeat proof and delivery bound remain unchanged.
                 consumer._delivery = replace(consumer._delivery, dead_consumer_idle_ms=0)
                 await consumer.ensure_group()
                 sha = f"sha-{token}"
@@ -896,7 +989,23 @@ def test_pending_entry_from_a_dead_consumer_is_reclaimed_without_waiting_min_idl
                 pending = await client.xpending(cfg.eval_stream, cfg.eval_consumer_group)
                 assert pending["pending"] == 1
 
-                await _drain_one(consumer, reports)
+                liveness = ConsumerLivenessStore(client)
+                await liveness.publish(
+                    stream=cfg.eval_stream,
+                    group=cfg.eval_consumer_group,
+                    consumer="dead-consumer",
+                    heartbeat_ttl_ms=1,
+                    capability_ttl_ms=cfg.consumer_capability_ttl_ms,
+                )
+                await asyncio.sleep(0.01)
+                assert not await client.exists(
+                    consumer_heartbeat_key(
+                        cfg.eval_stream, cfg.eval_consumer_group, "dead-consumer"
+                    )
+                )
+                assert await consumer._prompt_reclaim_once() == 0
+                await asyncio.sleep(cfg.consumer_heartbeat_ttl_ms / 1000 + 0.015)
+                assert await consumer._prompt_reclaim_once() == 1
 
                 assert reports[0]["sha"] == sha
                 assert reports[0]["passed_count"] == 1
@@ -904,6 +1013,79 @@ def test_pending_entry_from_a_dead_consumer_is_reclaimed_without_waiting_min_idl
                 assert summary["pending"] == 0
 
             await client.delete(cfg.eval_stream)
+            await client.aclose()
+
+    asyncio.run(go())
+
+
+def test_eval_prompt_path_dead_letters_proven_dead_at_cap_without_redelivery(
+    make_eval_harness, bundles
+) -> None:
+    """The eval sibling inherits the shared prompt-path delivery ceiling."""
+    store, _upload = bundles
+
+    async def go() -> None:
+        async with make_eval_harness() as (_base_url, _fake, _client):
+            token = uuid.uuid4().hex[:8]
+            cfg = _cfg(
+                f"test:evals:{token}",
+                f"g-{token}",
+                max_delivery=2,
+                reclaim_min_idle_ms=5000,
+                consumer_heartbeat_ttl_ms=30,
+                consumer_capability_ttl_ms=6000,
+            )
+            client = AsyncRedis(host=_VH, port=_VP, password=_VPW, decode_responses=True)
+            reports: list[dict[str, Any]] = []
+            async with httpx.AsyncClient(timeout=30.0) as lf_client:
+                consumer = _build_consumer(
+                    redis_client=client,
+                    cfg=cfg,
+                    bundle_store=store,
+                    substrate=_UnusedSubstrate(),
+                    reports=reports,
+                    lf_client=lf_client,
+                )
+                consumer._delivery = replace(consumer._delivery, dead_consumer_idle_ms=0)
+                await consumer.ensure_group()
+                entry_id = await client.xadd(cfg.eval_stream, {"payload": "never-evaluated"})
+                assert await client.xreadgroup(
+                    cfg.eval_consumer_group,
+                    "dead-eval-peer",
+                    {cfg.eval_stream: ">"},
+                    count=1,
+                )
+                await client.xclaim(
+                    cfg.eval_stream,
+                    cfg.eval_consumer_group,
+                    "dead-eval-peer",
+                    0,
+                    [entry_id],
+                )
+                liveness = ConsumerLivenessStore(client)
+                await liveness.publish(
+                    stream=cfg.eval_stream,
+                    group=cfg.eval_consumer_group,
+                    consumer="dead-eval-peer",
+                    heartbeat_ttl_ms=1,
+                    capability_ttl_ms=cfg.consumer_capability_ttl_ms,
+                )
+                await asyncio.sleep(0.01)
+
+                assert await consumer._prompt_reclaim_once() == 0
+                await asyncio.sleep(cfg.consumer_heartbeat_ttl_ms / 1000 + 0.015)
+                assert await consumer._prompt_reclaim_once() == 0
+
+                assert (await client.xpending(cfg.eval_stream, cfg.eval_consumer_group))[
+                    "pending"
+                ] == 0
+                grave = await client.xrange(cfg.eval_dead_letter_stream_name())
+                assert len(grave) == 1
+                assert grave[0][1]["dl_original_id"] == entry_id
+                assert grave[0][1]["dl_delivery_count"] == "2"
+                assert reports == []
+
+            await client.delete(cfg.eval_stream, cfg.eval_dead_letter_stream_name())
             await client.aclose()
 
     asyncio.run(go())

--- a/apps/worker/tests/kernel/test_consumer.py
+++ b/apps/worker/tests/kernel/test_consumer.py
@@ -464,6 +464,86 @@ def test_prompt_reclaim_arbitrates_across_replicas_without_burning_delivery_budg
     asyncio.run(go())
 
 
+def test_local_generation_bootstrap_contends_with_peer_transfer_lease(
+    make_harness,
+) -> None:
+    async def go() -> None:
+        async with make_harness(
+            reclaim_min_idle_ms=5000,
+            dead_consumer_idle_ms=0,
+            consumer_heartbeat_ttl_ms=30,
+            consumer_capability_ttl_ms=6000,
+        ) as h:
+            h.runner.default_script = [Final(text="done", status=DONE)]
+            owner_config = h.config.model_copy(update={"consumer_name": "restart-owner"})
+            peer_config = h.config.model_copy(update={"consumer_name": "replacement-peer"})
+            owner = Consumer(redis=h.async_redis, kernel=h.kernel, config=owner_config)
+            peer = Consumer(redis=h.async_redis, kernel=h.kernel, config=peer_config)
+            owner._liveness_store = ConsumerLivenessStore(h.async_redis)
+            peer._liveness_store = ConsumerLivenessStore(h.async_redis)
+            await owner.ensure_group()
+
+            entry_id = await h.async_redis.xadd(
+                h.config.stream,
+                to_stream_fields(
+                    _qevent("bootstrap-race", thread="tr-bootstrap", event_id="r-bootstrap")
+                ),
+            )
+            assert await h.async_redis.xreadgroup(
+                h.config.consumer_group,
+                owner_config.consumer_name,
+                {h.config.stream: ">"},
+                count=1,
+            )
+
+            # Model a peer that has already won the transfer lease while the
+            # stable-name consumer starts its replacement generation.
+            token = await peer._liveness_store.try_acquire_reclaim(
+                stream=h.config.stream,
+                group=h.config.consumer_group,
+                consumer=owner_config.consumer_name,
+                ttl_ms=60_000,
+            )
+            assert token is not None
+            bootstrap = asyncio.create_task(owner._recover_local_pending_once())
+            try:
+                await asyncio.sleep(0.03)
+                assert not bootstrap.done()
+                rows = await h.async_redis.xpending_range(
+                    h.config.stream,
+                    h.config.consumer_group,
+                    min=entry_id,
+                    max=entry_id,
+                    count=1,
+                )
+                assert len(rows) == 1
+                assert rows[0]["consumer"] == owner_config.consumer_name
+                assert int(rows[0]["times_delivered"]) == 1
+                assert h.runner.opened == []
+
+                async with peer._reclaim_lock:
+                    entries = await peer._claim_consumer_pending_locked(
+                        owner_config.consumer_name, set()
+                    )
+                assert await peer._dispatch_reclaimed(entries) == 1
+            finally:
+                await peer._liveness_store.release_reclaim(
+                    stream=h.config.stream,
+                    group=h.config.consumer_group,
+                    consumer=owner_config.consumer_name,
+                    token=token,
+                )
+
+            await asyncio.wait_for(bootstrap, timeout=1)
+            await _wait_until(lambda: h.runner.opened == ["bootstrap-race"])
+            await asyncio.gather(*list(peer._inflight))
+            assert (await h.async_redis.xpending(h.config.stream, h.config.consumer_group))[
+                "pending"
+            ] == 0
+
+    asyncio.run(go())
+
+
 def test_reclaim_does_not_promptly_steal_from_unknown_peer_without_heartbeat_capability(
     make_harness,
 ) -> None:

--- a/apps/worker/tests/kernel/test_consumer.py
+++ b/apps/worker/tests/kernel/test_consumer.py
@@ -5,11 +5,14 @@ against the real Valkey stream + consumer group.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import time
 import uuid
 from collections.abc import Callable
+from typing import Any
 
+import pytest
 import redis.exceptions
 from aci_protocol import Final, QueuedTurn, ReplyHandle, SessionStatus, TextDelta
 from curie_dispatcher.queue import to_stream_fields
@@ -20,9 +23,98 @@ from curie_worker.consumer import (
     THREAD_RESET_SET,
     Consumer,
 )
+from curie_worker.consumer_liveness import (
+    ConsumerLivenessStore,
+    consumer_heartbeat_capable_key,
+    consumer_heartbeat_key,
+)
 from curie_worker.sandbox import QuotaRejection
+from curie_worker.stream_consumer import ConsumerLivenessExpired
+from redis.asyncio import Redis as AsyncRedis
 
 DONE = SessionStatus.DONE
+
+HEARTBEAT_TTL_MS = 15_000
+
+
+async def _wait_consumer_idle(
+    redis: AsyncRedis, stream: str, group: str, consumer: str, idle_ms: int
+) -> None:
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        rows = await redis.xinfo_consumers(stream, group)
+        if any(
+            str(row["name"]) == consumer and int(row.get("idle") or 0) >= idle_ms for row in rows
+        ):
+            return
+        await asyncio.sleep(0.01)
+    raise AssertionError("consumer did not become idle")
+
+
+async def _deliveries(redis: AsyncRedis, stream: str, group: str) -> dict[str, int]:
+    rows = await redis.xpending_range(stream, group, min="-", max="+", count=100)
+    return {str(row["message_id"]): int(row["times_delivered"]) for row in rows}
+
+
+async def _wait_key(redis: AsyncRedis, key: str, *, present: bool = True) -> None:
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        if bool(await redis.exists(key)) is present:
+            return
+        await asyncio.sleep(0.005)
+    raise AssertionError(f"key {key!r} did not become {'present' if present else 'absent'}")
+
+
+async def _pending_owner(redis: AsyncRedis, stream: str, group: str, entry_id: str) -> str | None:
+    rows = await redis.xpending_range(stream, group, min=entry_id, max=entry_id, count=1)
+    return str(rows[0]["consumer"]) if rows else None
+
+
+class _RenewalProbeStore:
+    """Fault injector around the real liveness adapter, never around Valkey."""
+
+    def __init__(
+        self,
+        delegate: ConsumerLivenessStore,
+        *,
+        fail_renewals: int = 0,
+        timeout_renewals: int = 0,
+        hang_renewals: bool = False,
+    ) -> None:
+        self._delegate = delegate
+        self._fail_renewals = fail_renewals
+        self._timeout_renewals = timeout_renewals
+        self._hang_renewals = hang_renewals
+        self.renew_calls = 0
+        self._never = asyncio.Event()
+
+    async def publish(self, **kwargs: Any) -> None:
+        await self._delegate.publish(**kwargs)
+
+    async def renew(self, **kwargs: Any) -> None:
+        self.renew_calls += 1
+        if self.renew_calls <= self._fail_renewals:
+            raise redis.exceptions.ConnectionError("injected transient renewal failure")
+        if self.renew_calls <= self._fail_renewals + self._timeout_renewals:
+            await self._never.wait()
+        if self._hang_renewals:
+            await self._never.wait()
+        await self._delegate.renew(**kwargs)
+
+    async def is_alive(self, **kwargs: Any) -> bool:
+        return await self._delegate.is_alive(**kwargs)
+
+    async def is_capable(self, **kwargs: Any) -> bool:
+        return await self._delegate.is_capable(**kwargs)
+
+    async def cleanup_alive(self, **kwargs: Any) -> None:
+        await self._delegate.cleanup_alive(**kwargs)
+
+    async def try_acquire_reclaim(self, **kwargs: Any) -> str | None:
+        return await self._delegate.try_acquire_reclaim(**kwargs)
+
+    async def release_reclaim(self, **kwargs: Any) -> None:
+        await self._delegate.release_reclaim(**kwargs)
 
 
 def _qevent(text: str, *, thread: str = "th-1", event_id: str | None = None) -> QueuedTurn:
@@ -243,7 +335,12 @@ def test_reclaims_a_dead_consumers_pending_entry_without_waiting_min_idle(
     """
 
     async def go() -> None:
-        async with make_harness(reclaim_min_idle_ms=900000, dead_consumer_idle_ms=0) as h:
+        async with make_harness(
+            reclaim_min_idle_ms=5000,
+            dead_consumer_idle_ms=0,
+            consumer_heartbeat_ttl_ms=30,
+            consumer_capability_ttl_ms=6000,
+        ) as h:
             h.runner.default_script = [Final(text="recovered", status=DONE)]
             consumer = Consumer(redis=h.async_redis, kernel=h.kernel, config=h.config)
             await consumer.ensure_group()
@@ -254,16 +351,174 @@ def test_reclaims_a_dead_consumers_pending_entry_without_waiting_min_idle(
                 h.config.consumer_group, "dead-consumer", {h.config.stream: ">"}, count=1
             )
             assert dead
+            store = ConsumerLivenessStore(h.async_redis)
+            await store.publish(
+                stream=h.config.stream,
+                group=h.config.consumer_group,
+                consumer="dead-consumer",
+                heartbeat_ttl_ms=1,
+                capability_ttl_ms=h.config.consumer_capability_ttl_ms,
+            )
+            capable_key = consumer_heartbeat_capable_key(
+                h.config.stream, h.config.consumer_group, "dead-consumer"
+            )
+            key = consumer_heartbeat_key(h.config.stream, h.config.consumer_group, "dead-consumer")
+            await _wait_key(h.async_redis, key, present=False)
+            assert not await h.async_redis.exists(key)
+            await _wait_consumer_idle(
+                h.async_redis,
+                h.config.stream,
+                h.config.consumer_group,
+                "dead-consumer",
+                h.config.dead_consumer_idle_ms,
+            )
             summary = await h.async_redis.xpending(h.config.stream, h.config.consumer_group)
             assert summary["pending"] == 1
 
-            reclaimed = await consumer._reclaim_once()
+            # One missing lease can be a Valkey blip; prompt reclaim requires a
+            # second absence at least one complete heartbeat TTL later.
+            assert await consumer._prompt_reclaim_once() == 0
+            await asyncio.sleep(h.config.consumer_heartbeat_ttl_ms / 1000 + 0.015)
+            pending = await h.async_redis.xpending_range(
+                h.config.stream, h.config.consumer_group, min="-", max="+", count=1
+            )
+            assert int(pending[0]["time_since_delivered"]) < h.config.reclaim_min_idle_ms
+            reclaimed = await consumer._prompt_reclaim_once()
             assert reclaimed == 1
             await _wait_until(lambda: h.sink.last_text == "recovered")
             await asyncio.gather(*list(consumer._inflight))
             assert h.runner.opened == ["orphan"]
             summary = await h.async_redis.xpending(h.config.stream, h.config.consumer_group)
             assert summary["pending"] == 0
+            await h.async_redis.delete(capable_key)
+
+    asyncio.run(go())
+
+
+def test_prompt_reclaim_arbitrates_across_replicas_without_burning_delivery_budget(
+    make_harness,
+) -> None:
+    async def go() -> None:
+        async with make_harness(
+            reclaim_min_idle_ms=5000,
+            dead_consumer_idle_ms=0,
+            consumer_heartbeat_ttl_ms=30,
+            consumer_capability_ttl_ms=6000,
+        ) as h:
+            hold = asyncio.Event()
+            h.runner.hold = hold
+            h.runner.default_script = [TextDelta(text="reclaimed")]
+            h.runner.tail = [Final(text="done", status=DONE)]
+            first_config = h.config.model_copy(update={"consumer_name": "replacement-a"})
+            second_config = h.config.model_copy(update={"consumer_name": "replacement-b"})
+            first = Consumer(redis=h.async_redis, kernel=h.kernel, config=first_config)
+            second = Consumer(redis=h.async_redis, kernel=h.kernel, config=second_config)
+            await first.ensure_group()
+
+            entry_id = await h.async_redis.xadd(
+                h.config.stream,
+                to_stream_fields(_qevent("race", thread="tr-race", event_id="r-race")),
+            )
+            assert await h.async_redis.xreadgroup(
+                h.config.consumer_group,
+                "dead-race-peer",
+                {h.config.stream: ">"},
+                count=1,
+            )
+            await h.async_redis.set(
+                consumer_heartbeat_capable_key(
+                    h.config.stream, h.config.consumer_group, "dead-race-peer"
+                ),
+                "1",
+                px=h.config.consumer_capability_ttl_ms,
+            )
+
+            assert await asyncio.gather(
+                first._prompt_reclaim_once(), second._prompt_reclaim_once()
+            ) == [0, 0]
+            await asyncio.sleep(h.config.consumer_heartbeat_ttl_ms / 1000 + 0.015)
+            results = await asyncio.gather(
+                first._prompt_reclaim_once(), second._prompt_reclaim_once()
+            )
+            assert sum(results) == 1
+            await _wait_until(lambda: h.runner.turn_active)
+
+            rows = await h.async_redis.xpending_range(
+                h.config.stream,
+                h.config.consumer_group,
+                min=entry_id,
+                max=entry_id,
+                count=1,
+            )
+            assert len(rows) == 1
+            assert rows[0]["consumer"] in {"replacement-a", "replacement-b"}
+            assert int(rows[0]["times_delivered"]) == 2
+            assert h.runner.opened == ["race"]
+
+            hold.set()
+            await asyncio.gather(*list(first._inflight | second._inflight))
+            assert (await h.async_redis.xpending(h.config.stream, h.config.consumer_group))[
+                "pending"
+            ] == 0
+
+    asyncio.run(go())
+
+
+def test_reclaim_does_not_promptly_steal_from_unknown_peer_without_heartbeat_capability(
+    make_harness,
+) -> None:
+    """A pre-marker worker stays on the long XAUTOCLAIM backstop."""
+
+    async def go() -> None:
+        async with make_harness(
+            reclaim_min_idle_ms=5000,
+            dead_consumer_idle_ms=0,
+            consumer_heartbeat_ttl_ms=30,
+            consumer_capability_ttl_ms=6000,
+        ) as h:
+            consumer = Consumer(redis=h.async_redis, kernel=h.kernel, config=h.config)
+            await consumer.ensure_group()
+
+            qe = _qevent("unknown", thread="tr-unknown", event_id="r-unknown")
+            entry_id = await h.async_redis.xadd(h.config.stream, to_stream_fields(qe))
+            claimed = await h.async_redis.xreadgroup(
+                h.config.consumer_group, "unknown-peer", {h.config.stream: ">"}, count=1
+            )
+            assert claimed
+            capable_key = consumer_heartbeat_capable_key(
+                h.config.stream, h.config.consumer_group, "unknown-peer"
+            )
+            heartbeat_key = consumer_heartbeat_key(
+                h.config.stream, h.config.consumer_group, "unknown-peer"
+            )
+            assert not await h.async_redis.exists(capable_key)
+            assert not await h.async_redis.exists(heartbeat_key)
+            await _wait_consumer_idle(
+                h.async_redis,
+                h.config.stream,
+                h.config.consumer_group,
+                "unknown-peer",
+                h.config.dead_consumer_idle_ms,
+            )
+            before = await _deliveries(h.async_redis, h.config.stream, h.config.consumer_group)
+            assert before == {entry_id: 1}
+
+            assert await consumer._prompt_reclaim_once() == 0
+            await asyncio.sleep(h.config.consumer_heartbeat_ttl_ms / 1000 + 0.015)
+            assert await consumer._prompt_reclaim_once() == 0
+            assert (
+                await _deliveries(h.async_redis, h.config.stream, h.config.consumer_group) == before
+            )
+            pending = await h.async_redis.xpending_range(
+                h.config.stream,
+                h.config.consumer_group,
+                min="-",
+                max="+",
+                count=10,
+                consumername="unknown-peer",
+            )
+            assert [str(row["message_id"]) for row in pending] == [entry_id]
+            assert h.runner.opened == []
 
     asyncio.run(go())
 
@@ -278,7 +533,12 @@ def test_reclaim_does_not_steal_from_a_fresh_live_peer_when_min_idle_is_high(
     """
 
     async def go() -> None:
-        async with make_harness(reclaim_min_idle_ms=900000, dead_consumer_idle_ms=15000) as h:
+        async with make_harness(
+            reclaim_min_idle_ms=5000,
+            dead_consumer_idle_ms=0,
+            consumer_heartbeat_ttl_ms=30,
+            consumer_capability_ttl_ms=6000,
+        ) as h:
             consumer = Consumer(redis=h.async_redis, kernel=h.kernel, config=h.config)
             await consumer.ensure_group()
 
@@ -288,11 +548,685 @@ def test_reclaim_does_not_steal_from_a_fresh_live_peer_when_min_idle_is_high(
                 h.config.consumer_group, "live-peer", {h.config.stream: ">"}, count=1
             )
             assert live
-            reclaimed = await consumer._reclaim_once()
+            capable_key = consumer_heartbeat_capable_key(
+                h.config.stream, h.config.consumer_group, "live-peer"
+            )
+            await h.async_redis.set(capable_key, "1")
+            key = consumer_heartbeat_key(h.config.stream, h.config.consumer_group, "live-peer")
+            await h.async_redis.set(key, "alive", px=HEARTBEAT_TTL_MS)
+            await _wait_consumer_idle(
+                h.async_redis,
+                h.config.stream,
+                h.config.consumer_group,
+                "live-peer",
+                h.config.dead_consumer_idle_ms,
+            )
+            before = await _deliveries(h.async_redis, h.config.stream, h.config.consumer_group)
+            assert await consumer._prompt_reclaim_once() == 0
+            await asyncio.sleep(h.config.consumer_heartbeat_ttl_ms / 1000 + 0.015)
+            reclaimed = await consumer._prompt_reclaim_once()
             assert reclaimed == 0
+            assert (
+                await _deliveries(h.async_redis, h.config.stream, h.config.consumer_group) == before
+            )
             summary = await h.async_redis.xpending(h.config.stream, h.config.consumer_group)
             assert summary["pending"] == 1
             assert h.runner.opened == []
+            await h.async_redis.delete(key, capable_key)
+
+    asyncio.run(go())
+
+
+def test_reclaim_does_not_steal_from_a_live_saturated_peer(make_harness) -> None:
+    async def go() -> None:
+        async with make_harness(
+            reclaim_min_idle_ms=5000,
+            dead_consumer_idle_ms=0,
+            consumer_heartbeat_ttl_ms=30,
+            consumer_capability_ttl_ms=6000,
+        ) as h:
+            consumer = Consumer(redis=h.async_redis, kernel=h.kernel, config=h.config)
+            await consumer.ensure_group()
+            ids = []
+            for text in ("busy", "queued"):
+                ids.append(
+                    await h.async_redis.xadd(h.config.stream, to_stream_fields(_qevent(text)))
+                )
+            claimed = await h.async_redis.xreadgroup(
+                h.config.consumer_group, "saturated-peer", {h.config.stream: ">"}, count=2
+            )
+            assert claimed
+            capable_key = consumer_heartbeat_capable_key(
+                h.config.stream, h.config.consumer_group, "saturated-peer"
+            )
+            await h.async_redis.set(capable_key, "1")
+            key = consumer_heartbeat_key(h.config.stream, h.config.consumer_group, "saturated-peer")
+            await h.async_redis.set(key, "alive", px=HEARTBEAT_TTL_MS)
+            await _wait_consumer_idle(
+                h.async_redis,
+                h.config.stream,
+                h.config.consumer_group,
+                "saturated-peer",
+                h.config.dead_consumer_idle_ms,
+            )
+            before = await _deliveries(h.async_redis, h.config.stream, h.config.consumer_group)
+            assert set(before) == set(ids)
+            assert await consumer._prompt_reclaim_once() == 0
+            await asyncio.sleep(h.config.consumer_heartbeat_ttl_ms / 1000 + 0.015)
+            assert await consumer._prompt_reclaim_once() == 0
+            assert (
+                await _deliveries(h.async_redis, h.config.stream, h.config.consumer_group) == before
+            )
+            assert h.runner.opened == []
+            await h.async_redis.delete(key, capable_key)
+
+    asyncio.run(go())
+
+
+def test_consumer_publishes_before_reads_and_renews_alive_and_capability(
+    make_harness,
+) -> None:
+    async def go() -> None:
+        async with make_harness(
+            reclaim_min_idle_ms=300,
+            consumer_heartbeat_ttl_ms=150,
+            consumer_capability_ttl_ms=3000,
+            read_block_ms=10,
+        ) as h:
+            consumer = Consumer(redis=h.async_redis, kernel=h.kernel, config=h.config)
+            alive = consumer_heartbeat_key(
+                h.config.stream, h.config.consumer_group, h.config.consumer_name
+            )
+            capable = consumer_heartbeat_capable_key(
+                h.config.stream, h.config.consumer_group, h.config.consumer_name
+            )
+            read_observations: list[tuple[bool, bool]] = []
+            real_read = consumer._redis.xreadgroup
+
+            async def observe_first_read(*args: Any, **kwargs: Any) -> Any:
+                read_observations.append(
+                    (
+                        bool(await h.async_redis.exists(alive)),
+                        bool(await h.async_redis.exists(capable)),
+                    )
+                )
+                return await real_read(*args, **kwargs)
+
+            consumer._redis.xreadgroup = observe_first_read  # type: ignore[method-assign,assignment]
+
+            task = asyncio.create_task(consumer.run())
+            await _wait_key(h.async_redis, alive)
+            await _wait_key(h.async_redis, capable)
+            # Live longer than the capability marker's original TTL. Both keys
+            # surviving proves the refresher renews capability as well as alive.
+            await asyncio.sleep(0.55)
+            assert await h.async_redis.pttl(alive) > 0
+            assert await h.async_redis.pttl(capable) > 0
+            assert read_observations and read_observations[0] == (True, True)
+
+            consumer.request_stop()
+            await task
+            assert not await h.async_redis.exists(alive)
+            assert await h.async_redis.exists(capable)
+
+    asyncio.run(go())
+
+
+def test_graceful_stop_keeps_lease_through_two_ttls_of_inflight_drain(
+    make_harness,
+) -> None:
+    async def go() -> None:
+        async with make_harness(
+            reclaim_min_idle_ms=300,
+            consumer_heartbeat_ttl_ms=150,
+            consumer_capability_ttl_ms=450,
+            read_block_ms=10,
+        ) as h:
+            hold = asyncio.Event()
+            h.runner.hold = hold
+            h.runner.default_script = [TextDelta(text="working")]
+            h.runner.tail = [Final(text="done", status=DONE)]
+            consumer = Consumer(redis=h.async_redis, kernel=h.kernel, config=h.config)
+            await consumer.ensure_group()
+            await h.async_redis.xadd(
+                h.config.stream,
+                to_stream_fields(_qevent("drain", thread="th-drain", event_id="drain")),
+            )
+            alive = consumer_heartbeat_key(
+                h.config.stream, h.config.consumer_group, h.config.consumer_name
+            )
+
+            task = asyncio.create_task(consumer.run())
+            await _wait_until(lambda: h.runner.turn_active)
+            await _wait_key(h.async_redis, alive)
+            consumer.request_stop()
+            await asyncio.sleep(0.32)
+            assert await h.async_redis.exists(alive), (
+                "graceful stop dropped liveness while the owned handler still drained"
+            )
+            assert not task.done()
+
+            hold.set()
+            await task
+            assert not await h.async_redis.exists(alive)
+
+    asyncio.run(go())
+
+
+def test_real_saturated_consumer_renews_lease_and_peer_cannot_prompt_claim(
+    make_harness,
+) -> None:
+    async def go() -> None:
+        async with make_harness(
+            reclaim_min_idle_ms=5000,
+            dead_consumer_idle_ms=0,
+            consumer_heartbeat_ttl_ms=150,
+            consumer_capability_ttl_ms=6000,
+            read_block_ms=10,
+        ) as h:
+            hold = asyncio.Event()
+            h.runner.hold = hold
+            h.runner.default_script = [TextDelta(text="busy")]
+            h.runner.tail = [Final(text="done", status=DONE)]
+            peer = Consumer(
+                redis=h.async_redis, kernel=h.kernel, config=h.config, max_concurrency=1
+            )
+            await peer.ensure_group()
+            ids = [
+                await h.async_redis.xadd(
+                    h.config.stream,
+                    to_stream_fields(_qevent(text, event_id=f"sat-{text}")),
+                )
+                for text in ("held", "semaphore-blocked")
+            ]
+            alive = consumer_heartbeat_key(
+                h.config.stream, h.config.consumer_group, h.config.consumer_name
+            )
+
+            peer_task = asyncio.create_task(peer.run())
+            await _wait_until(lambda: h.runner.turn_active)
+            deadline = time.monotonic() + 5
+            while time.monotonic() < deadline:
+                if set(
+                    await _deliveries(h.async_redis, h.config.stream, h.config.consumer_group)
+                ) == set(ids):
+                    break
+                await asyncio.sleep(0.005)
+            before = await _deliveries(h.async_redis, h.config.stream, h.config.consumer_group)
+            assert before == {ids[0]: 1, ids[1]: 1}
+            await asyncio.sleep(0.32)
+            assert await h.async_redis.exists(alive)
+
+            replacement_config = h.config.model_copy(update={"consumer_name": "replacement"})
+            replacement = Consumer(redis=h.async_redis, kernel=h.kernel, config=replacement_config)
+            assert await replacement._prompt_reclaim_once() == 0
+            await asyncio.sleep(h.config.consumer_heartbeat_ttl_ms / 1000 + 0.015)
+            assert await replacement._prompt_reclaim_once() == 0
+            assert (
+                await _deliveries(h.async_redis, h.config.stream, h.config.consumer_group) == before
+            )
+
+            peer.request_stop()
+            hold.set()
+            await peer_task
+
+    asyncio.run(go())
+
+
+def test_alive_restoration_resets_two_absence_proof(make_harness) -> None:
+    async def go() -> None:
+        async with make_harness(
+            reclaim_min_idle_ms=5000,
+            dead_consumer_idle_ms=0,
+            consumer_heartbeat_ttl_ms=30,
+            consumer_capability_ttl_ms=6000,
+        ) as h:
+            consumer = Consumer(redis=h.async_redis, kernel=h.kernel, config=h.config)
+            await consumer.ensure_group()
+            entry_id = await h.async_redis.xadd(
+                h.config.stream, to_stream_fields(_qevent("restored", event_id="restored"))
+            )
+            assert await h.async_redis.xreadgroup(
+                h.config.consumer_group, "peer", {h.config.stream: ">"}, count=1
+            )
+            store = ConsumerLivenessStore(h.async_redis)
+            await store.publish(
+                stream=h.config.stream,
+                group=h.config.consumer_group,
+                consumer="peer",
+                heartbeat_ttl_ms=1,
+                capability_ttl_ms=h.config.consumer_capability_ttl_ms,
+            )
+            await _wait_key(
+                h.async_redis,
+                consumer_heartbeat_key(h.config.stream, h.config.consumer_group, "peer"),
+                present=False,
+            )
+            assert await consumer._prompt_reclaim_once() == 0
+
+            await store.renew(
+                stream=h.config.stream,
+                group=h.config.consumer_group,
+                consumer="peer",
+                heartbeat_ttl_ms=100,
+                capability_ttl_ms=h.config.consumer_capability_ttl_ms,
+            )
+            await asyncio.sleep(h.config.consumer_heartbeat_ttl_ms / 1000 + 0.015)
+            assert await consumer._prompt_reclaim_once() == 0
+            assert "peer" not in consumer._peer_absent_since
+            assert (
+                await _pending_owner(
+                    h.async_redis, h.config.stream, h.config.consumer_group, entry_id
+                )
+                == "peer"
+            )
+
+            await h.async_redis.delete(
+                consumer_heartbeat_key(h.config.stream, h.config.consumer_group, "peer")
+            )
+            assert await consumer._prompt_reclaim_once() == 0
+            assert (
+                await _pending_owner(
+                    h.async_redis, h.config.stream, h.config.consumer_group, entry_id
+                )
+                == "peer"
+            )
+
+    asyncio.run(go())
+
+
+def test_disappeared_consumer_invalidates_first_absence_observation(make_harness) -> None:
+    async def go() -> None:
+        async with make_harness(
+            reclaim_min_idle_ms=5000,
+            dead_consumer_idle_ms=0,
+            consumer_heartbeat_ttl_ms=30,
+            consumer_capability_ttl_ms=6000,
+        ) as h:
+            consumer = Consumer(redis=h.async_redis, kernel=h.kernel, config=h.config)
+            await consumer.ensure_group()
+            entry_id = await h.async_redis.xadd(
+                h.config.stream, to_stream_fields(_qevent("gone", event_id="gone"))
+            )
+            assert await h.async_redis.xreadgroup(
+                h.config.consumer_group, "vanished-peer", {h.config.stream: ">"}, count=1
+            )
+            await h.async_redis.set(
+                consumer_heartbeat_capable_key(
+                    h.config.stream, h.config.consumer_group, "vanished-peer"
+                ),
+                "1",
+                px=h.config.consumer_capability_ttl_ms,
+            )
+            assert await consumer._prompt_reclaim_once() == 0
+            assert "vanished-peer" in consumer._peer_absent_since
+
+            await h.async_redis.xack(h.config.stream, h.config.consumer_group, entry_id)
+            await h.async_redis.xgroup_delconsumer(
+                h.config.stream, h.config.consumer_group, "vanished-peer"
+            )
+            assert await consumer._prompt_reclaim_once() == 0
+            assert "vanished-peer" not in consumer._peer_absent_since
+
+    asyncio.run(go())
+
+
+def test_live_at_cap_peer_is_not_dead_lettered_by_prompt_path(make_harness) -> None:
+    async def go() -> None:
+        async with make_harness(
+            max_delivery=2,
+            reclaim_min_idle_ms=5000,
+            dead_consumer_idle_ms=0,
+            consumer_heartbeat_ttl_ms=30,
+            consumer_capability_ttl_ms=6000,
+        ) as h:
+            consumer = Consumer(redis=h.async_redis, kernel=h.kernel, config=h.config)
+            await consumer.ensure_group()
+            entry_id = await h.async_redis.xadd(
+                h.config.stream, to_stream_fields(_qevent("live-cap", event_id="live-cap"))
+            )
+            assert await h.async_redis.xreadgroup(
+                h.config.consumer_group, "live-cap-peer", {h.config.stream: ">"}, count=1
+            )
+            await h.async_redis.xclaim(
+                h.config.stream,
+                h.config.consumer_group,
+                "live-cap-peer",
+                0,
+                [entry_id],
+            )
+            store = ConsumerLivenessStore(h.async_redis)
+            await store.publish(
+                stream=h.config.stream,
+                group=h.config.consumer_group,
+                consumer="live-cap-peer",
+                heartbeat_ttl_ms=100,
+                capability_ttl_ms=h.config.consumer_capability_ttl_ms,
+            )
+            before = await _deliveries(h.async_redis, h.config.stream, h.config.consumer_group)
+            assert before == {entry_id: 2}
+            assert await consumer._prompt_reclaim_once() == 0
+            await asyncio.sleep(h.config.consumer_heartbeat_ttl_ms / 1000 + 0.015)
+            assert await consumer._prompt_reclaim_once() == 0
+            assert (
+                await _deliveries(h.async_redis, h.config.stream, h.config.consumer_group) == before
+            )
+            assert await h.async_redis.xlen(h.config.dead_letter_stream_name()) == 0
+
+    asyncio.run(go())
+
+
+def test_proven_dead_at_cap_peer_is_dead_lettered_without_xclaim(make_harness) -> None:
+    async def go() -> None:
+        async with make_harness(
+            max_delivery=2,
+            reclaim_min_idle_ms=5000,
+            dead_consumer_idle_ms=0,
+            consumer_heartbeat_ttl_ms=30,
+            consumer_capability_ttl_ms=6000,
+        ) as h:
+            consumer = Consumer(redis=h.async_redis, kernel=h.kernel, config=h.config)
+            await consumer.ensure_group()
+            entry_id = await h.async_redis.xadd(
+                h.config.stream, to_stream_fields(_qevent("dead-cap", event_id="dead-cap"))
+            )
+            assert await h.async_redis.xreadgroup(
+                h.config.consumer_group, "dead-cap-peer", {h.config.stream: ">"}, count=1
+            )
+            await h.async_redis.xclaim(
+                h.config.stream,
+                h.config.consumer_group,
+                "dead-cap-peer",
+                0,
+                [entry_id],
+            )
+            store = ConsumerLivenessStore(h.async_redis)
+            await store.publish(
+                stream=h.config.stream,
+                group=h.config.consumer_group,
+                consumer="dead-cap-peer",
+                heartbeat_ttl_ms=1,
+                capability_ttl_ms=h.config.consumer_capability_ttl_ms,
+            )
+            await _wait_key(
+                h.async_redis,
+                consumer_heartbeat_key(h.config.stream, h.config.consumer_group, "dead-cap-peer"),
+                present=False,
+            )
+            assert await consumer._prompt_reclaim_once() == 0
+            await asyncio.sleep(h.config.consumer_heartbeat_ttl_ms / 1000 + 0.015)
+            assert await consumer._prompt_reclaim_once() == 0
+
+            assert (await h.async_redis.xpending(h.config.stream, h.config.consumer_group))[
+                "pending"
+            ] == 0
+            rows = await h.async_redis.xrange(h.config.dead_letter_stream_name())
+            assert len(rows) == 1
+            assert rows[0][1]["dl_original_id"] == entry_id
+            # A prompt XCLAIM would increment this to 3. Direct dead-lettering
+            # preserves the durable count at the configured cap.
+            assert rows[0][1]["dl_delivery_count"] == "2"
+            assert h.runner.opened == []
+
+    asyncio.run(go())
+
+
+def test_transient_liveness_renewal_failure_recovers_before_lease_expiry(
+    make_harness,
+) -> None:
+    async def go() -> None:
+        async with make_harness(
+            reclaim_min_idle_ms=300,
+            consumer_heartbeat_ttl_ms=150,
+            consumer_capability_ttl_ms=450,
+            read_block_ms=10,
+        ) as h:
+            consumer = Consumer(redis=h.async_redis, kernel=h.kernel, config=h.config)
+            probe = _RenewalProbeStore(ConsumerLivenessStore(h.async_redis), fail_renewals=1)
+            consumer._liveness_store = probe  # type: ignore[assignment]
+            alive = consumer_heartbeat_key(
+                h.config.stream, h.config.consumer_group, h.config.consumer_name
+            )
+
+            task = asyncio.create_task(consumer.run())
+            deadline = time.monotonic() + 2
+            while probe.renew_calls < 2 and time.monotonic() < deadline:
+                await asyncio.sleep(0.005)
+            assert probe.renew_calls >= 2
+            assert not task.done()
+            assert await h.async_redis.exists(alive)
+
+            consumer.request_stop()
+            await task
+
+    asyncio.run(go())
+
+
+def test_timed_out_liveness_renewal_retries_before_lease_expiry(make_harness) -> None:
+    async def go() -> None:
+        async with make_harness(
+            reclaim_min_idle_ms=300,
+            consumer_heartbeat_ttl_ms=150,
+            consumer_capability_ttl_ms=450,
+            read_block_ms=10,
+        ) as h:
+            consumer = Consumer(redis=h.async_redis, kernel=h.kernel, config=h.config)
+            probe = _RenewalProbeStore(
+                ConsumerLivenessStore(h.async_redis), timeout_renewals=1
+            )
+            consumer._liveness_store = probe  # type: ignore[assignment]
+
+            task = asyncio.create_task(consumer.run())
+            deadline = time.monotonic() + 2
+            while probe.renew_calls < 2 and time.monotonic() < deadline:
+                await asyncio.sleep(0.005)
+            assert probe.renew_calls >= 2
+            assert not task.done()
+
+            consumer.request_stop()
+            await task
+
+    asyncio.run(go())
+
+
+def test_terminal_liveness_failure_cancels_generation_and_clean_restart_recovers_pel(
+    make_harness,
+) -> None:
+    async def go() -> None:
+        async with make_harness(
+            reclaim_min_idle_ms=300,
+            reclaim_interval_s=0.02,
+            dead_consumer_idle_ms=0,
+            consumer_heartbeat_ttl_ms=150,
+            consumer_capability_ttl_ms=3000,
+            read_block_ms=10,
+        ) as h:
+            hold = asyncio.Event()
+            h.runner.hold = hold
+            h.runner.default_script = [TextDelta(text="started")]
+            h.runner.tail = [Final(text="recovered", status=DONE)]
+            consumer = Consumer(
+                redis=h.async_redis, kernel=h.kernel, config=h.config, max_concurrency=1
+            )
+            consumer._liveness_store = _RenewalProbeStore(  # type: ignore[assignment]
+                ConsumerLivenessStore(h.async_redis), hang_renewals=True
+            )
+            await consumer.ensure_group()
+            entry_id = await h.async_redis.xadd(
+                h.config.stream,
+                to_stream_fields(_qevent("restart", thread="th-restart", event_id="restart")),
+            )
+
+            first = asyncio.create_task(consumer.run())
+            await _wait_until(lambda: h.runner.turn_active)
+            consumer._peer_absent_since["stale-generation-peer"] = time.monotonic()
+            with pytest.raises(ConsumerLivenessExpired):
+                await asyncio.wait_for(first, timeout=2)
+
+            assert (
+                await _pending_owner(
+                    h.async_redis, h.config.stream, h.config.consumer_group, entry_id
+                )
+                == h.config.consumer_name
+            )
+            assert not consumer._inflight_ids
+            assert not consumer._inflight
+            assert not consumer._peer_absent_since
+            assert consumer._sem._value == 1  # noqa: SLF001 - generation accounting invariant
+            assert not [
+                task
+                for task in asyncio.all_tasks()
+                if task is not asyncio.current_task()
+                and not task.done()
+                and task.get_name().startswith("consumer:")
+            ]
+
+            # This models the top-level supervisor's clean retry generation. It
+            # must recover the row canceled under its own stable consumer name;
+            # otherwise the prompt path skips that name and the row waits for
+            # the 15-minute XAUTOCLAIM fallback.
+            hold.set()
+            h.runner.hold = None
+            # The canceled aiohttp stream can die before FakeRunner's normal
+            # epilogue clears this test-only flag. A replacement sandbox starts
+            # idle, so reset the fake's process-local state explicitly.
+            h.runner.turn_active = False
+            h.runner.tail = []
+            h.runner.default_script = [Final(text="recovered", status=DONE)]
+            consumer._liveness_store = ConsumerLivenessStore(h.async_redis)
+            second = asyncio.create_task(consumer.run())
+            await _wait_until(
+                lambda: h.runner.opened.count("restart") == 2, timeout=3
+            )
+            deadline = time.monotonic() + 3
+            while time.monotonic() < deadline:
+                summary = await h.async_redis.xpending(
+                    h.config.stream, h.config.consumer_group
+                )
+                if summary["pending"] == 0:
+                    break
+                await asyncio.sleep(0.01)
+            else:
+                raise AssertionError("restart generation did not ack its own reclaimed entry")
+            consumer.request_stop()
+            await second
+
+            assert h.runner.opened.count("restart") == 2
+            assert await _deliveries(
+                h.async_redis, h.config.stream, h.config.consumer_group
+            ) == {}
+            assert (await h.async_redis.xpending(h.config.stream, h.config.consumer_group))[
+                "pending"
+            ] == 0
+
+    asyncio.run(go())
+
+
+def test_prompt_selection_stays_timely_while_heavy_reclaim_waits_for_capacity(
+    make_harness,
+) -> None:
+    async def go() -> None:
+        async with make_harness(
+            reclaim_min_idle_ms=80,
+            dead_consumer_idle_ms=0,
+            consumer_heartbeat_ttl_ms=30,
+            consumer_capability_ttl_ms=160,
+        ) as h:
+            hold = asyncio.Event()
+            h.runner.hold = hold
+            h.runner.default_script = [TextDelta(text="held")]
+            h.runner.tail = [Final(text="done", status=DONE)]
+            consumer = Consumer(
+                redis=h.async_redis, kernel=h.kernel, config=h.config, max_concurrency=1
+            )
+            await consumer.ensure_group()
+
+            # Occupy the only handler slot. Reclaimed handlers will block in
+            # _dispatch after ownership transfer; that wait must not retain the
+            # shared selection lock.
+            await consumer._dispatch(
+                "local-only",
+                to_stream_fields(_qevent("local", event_id="local-only")),
+            )
+            await _wait_until(lambda: h.runner.turn_active)
+
+            old_id = await h.async_redis.xadd(
+                h.config.stream, to_stream_fields(_qevent("old", event_id="old"))
+            )
+            assert await h.async_redis.xreadgroup(
+                h.config.consumer_group, "backstop-peer", {h.config.stream: ">"}, count=1
+            )
+            await asyncio.sleep(0.09)
+
+            prompt_id = await h.async_redis.xadd(
+                h.config.stream, to_stream_fields(_qevent("prompt", event_id="prompt"))
+            )
+            assert await h.async_redis.xreadgroup(
+                h.config.consumer_group, "prompt-peer", {h.config.stream: ">"}, count=1
+            )
+            store = ConsumerLivenessStore(h.async_redis)
+            await store.publish(
+                stream=h.config.stream,
+                group=h.config.consumer_group,
+                consumer="prompt-peer",
+                heartbeat_ttl_ms=1,
+                capability_ttl_ms=h.config.consumer_capability_ttl_ms,
+            )
+            await _wait_key(
+                h.async_redis,
+                consumer_heartbeat_key(h.config.stream, h.config.consumer_group, "prompt-peer"),
+                present=False,
+            )
+
+            heavy = asyncio.create_task(consumer._reclaim_once())
+            deadline = time.monotonic() + 1
+            while time.monotonic() < deadline:
+                if (
+                    await _pending_owner(
+                        h.async_redis, h.config.stream, h.config.consumer_group, old_id
+                    )
+                    == h.config.consumer_name
+                ):
+                    break
+                await asyncio.sleep(0.005)
+            assert (
+                await _pending_owner(
+                    h.async_redis, h.config.stream, h.config.consumer_group, old_id
+                )
+                == h.config.consumer_name
+            )
+            assert not heavy.done(), "heavy dispatch should be blocked on the occupied semaphore"
+
+            assert await consumer._prompt_reclaim_once() == 0
+            await asyncio.sleep(h.config.consumer_heartbeat_ttl_ms / 1000 + 0.015)
+            prompt = asyncio.create_task(consumer._prompt_reclaim_once())
+            deadline = time.monotonic() + 0.25
+            while time.monotonic() < deadline:
+                if (
+                    await _pending_owner(
+                        h.async_redis, h.config.stream, h.config.consumer_group, prompt_id
+                    )
+                    == h.config.consumer_name
+                ):
+                    break
+                await asyncio.sleep(0.005)
+            assert (
+                await _pending_owner(
+                    h.async_redis, h.config.stream, h.config.consumer_group, prompt_id
+                )
+                == h.config.consumer_name
+            )
+            assert not prompt.done(), "prompt dispatch should now wait outside the selection lock"
+
+            for task in (heavy, prompt):
+                task.cancel()
+            await asyncio.gather(heavy, prompt, return_exceptions=True)
+            hold.set()
+            with contextlib.suppress(asyncio.TimeoutError):
+                await asyncio.wait_for(
+                    asyncio.gather(*list(consumer._inflight), return_exceptions=True),
+                    timeout=1,
+                )
 
     asyncio.run(go())
 

--- a/apps/worker/tests/test_config.py
+++ b/apps/worker/tests/test_config.py
@@ -234,6 +234,8 @@ def test_defaults_parity_with_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
     assert config.reclaim_min_idle_ms == 900000
     assert config.reclaim_interval_s == 30.0
     assert config.dead_consumer_idle_ms == 15000
+    assert config.consumer_heartbeat_ttl_ms == 15000
+    assert config.consumer_capability_ttl_ms == 1800000
     # Slack edit throttle
     assert config.slack_edit_min_interval_s == 0.7
     # Runner HTTP timeouts
@@ -270,6 +272,44 @@ def test_defaults_parity_with_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
     expected_consumer = f"{socket.gethostname()}-{os.getpid()}"
     assert config.consumer_name == expected_consumer
     assert config.eval_consumer_name == expected_consumer
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"consumer_heartbeat_ttl_ms": 0},
+        {"consumer_capability_ttl_ms": 0},
+    ],
+)
+def test_consumer_liveness_ttls_must_be_positive(
+    overrides: dict[str, object],
+) -> None:
+    with pytest.raises(ValueError):
+        WorkerConfig.model_validate(overrides)
+
+
+def test_consumer_capability_ttl_must_outlive_reclaim_backstop() -> None:
+    with pytest.raises(ValueError, match="must be greater than reclaim_min_idle_ms"):
+        WorkerConfig(reclaim_min_idle_ms=50, consumer_capability_ttl_ms=50)
+
+    config = WorkerConfig(reclaim_min_idle_ms=50, consumer_capability_ttl_ms=51)
+    assert config.consumer_capability_ttl_ms == 51
+
+
+def test_consumer_liveness_ttls_read_only_their_curie_aliases(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_all_config_env(monkeypatch)
+    monkeypatch.setenv("CONSUMER_HEARTBEAT_TTL_MS", "999")
+    monkeypatch.setenv("CONSUMER_CAPABILITY_TTL_MS", "999999")
+    monkeypatch.setenv("CURIE_CONSUMER_HEARTBEAT_TTL_MS", "25")
+    monkeypatch.setenv("CURIE_CONSUMER_CAPABILITY_TTL_MS", "5001")
+    monkeypatch.setenv("RECLAIM_MIN_IDLE_MS", "5000")
+
+    config = WorkerConfig()
+
+    assert config.consumer_heartbeat_ttl_ms == 25
+    assert config.consumer_capability_ttl_ms == 5001
 
 
 def test_overrides_parity_with_from_env(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/cli/scripts/e2e-cluster-rollout-recovery.sh
+++ b/cli/scripts/e2e-cluster-rollout-recovery.sh
@@ -1,0 +1,774 @@
+#!/usr/bin/env bash
+# QA4-02: first-message rollout ordering plus dead-consumer PEL recovery.
+#
+# This deployed test drives the public CLI, worker Deployment, a namespaced
+# SandboxTemplate/SandboxClaim, Valkey PEL, and the reply stub. It never mutates
+# the shared agent-sandbox controller.
+#
+# This is intentionally a CI-owned script rather than another public `curie
+# dev` verb: it requires a preinstalled disposable release plus test-only live
+# Deployment/SandboxTemplate mutations. `curie dev e2e-ladder` remains the
+# stable contributor-facing cluster surface and CI owns this narrow phase.
+#
+# Optional red-on-revert knobs (normal CI leaves these unset):
+#   CURIE_E2E_BASE_REF               diagnostic source ref (default origin/main)
+#   CURIE_E2E_PRE_FIX_CLI_BIN        pre-fix CLI used only by phase 1
+#   CURIE_E2E_PRE_FIX_WORKER_IMAGE   pre-fix worker repository for phase 2
+#   CURIE_E2E_PRE_FIX_WORKER_TAG     pre-fix worker tag for phase 2
+# A pre-fix phase must make this script non-zero at its named assertion.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+NAMESPACE="${CURIE_E2E_NAMESPACE:-curie}"
+RELEASE="${CURIE_E2E_RELEASE:-curie}"
+BASE_REF="${CURIE_E2E_BASE_REF:-origin/main}"
+PRE_FIX_CLI_BIN="${CURIE_E2E_PRE_FIX_CLI_BIN:-}"
+PRE_FIX_WORKER_IMAGE="${CURIE_E2E_PRE_FIX_WORKER_IMAGE:-}"
+PRE_FIX_WORKER_TAG="${CURIE_E2E_PRE_FIX_WORKER_TAG:-}"
+STREAM="curie:runs"
+GROUP="curie-workers"
+WORKER_DEPLOYMENT="${RELEASE}-worker"
+VALKEY_STATEFULSET="${RELEASE}-valkey"
+SANDBOX_TEMPLATE="${CURIE_E2E_SANDBOX_TEMPLATE:-${RELEASE}-runner}"
+CONTROLLER_NAMESPACE="agent-sandbox-system"
+CONTROLLER_DEPLOYMENT="agent-sandbox-controller"
+GATE_CONFIGMAP="${RELEASE}-rollout-recovery-gate"
+SANDBOX_HOLD_KEY="curie-e2e.invalid/sandbox-rollout-recovery"
+SANDBOX_HOLD_VALUE="blocked"
+STAGING_BUDGET_SECONDS=120
+MESSAGE_TIMEOUT_SECONDS=300
+RECOVERY_BUDGET_SECONDS=180
+PRE_ENQUEUE_OBSERVATION_SECONDS=20
+WORKDIR="$(mktemp -d)"
+ORIGINAL_TEMPLATE_FILE="$WORKDIR/sandbox-template.original.json"
+CLAIMS_BEFORE_FILE="$WORKDIR/claims.before"
+SANDBOXES_BEFORE_FILE="$WORKDIR/sandboxes.before"
+FIRST_PID=""
+SECOND_PID=""
+GATEKEEPER_PID=""
+TRANSFER_WATCHER_PID=""
+BLOCKED_CLAIM=""
+DEPLOYMENT_PATCHED=0
+TEMPLATE_PATCHED=0
+ORIGINAL_REVISION=""
+
+if [[ -z "${CURIE_BIN:-}" || ! -x "${CURIE_BIN:-}" ]]; then
+    echo "error: CURIE_BIN must name an executable curie binary" >&2
+    exit 1
+fi
+if [[ -z "${CURIE_E2E_LISTEN_HOST:-}" ]]; then
+    echo "error: CURIE_E2E_LISTEN_HOST must name the pod-reachable callback host" >&2
+    exit 1
+fi
+if [[ -n "$PRE_FIX_CLI_BIN" && ! -x "$PRE_FIX_CLI_BIN" ]]; then
+    echo "error: CURIE_E2E_PRE_FIX_CLI_BIN must name an executable pre-fix CLI" >&2
+    exit 1
+fi
+if [[ -n "$PRE_FIX_WORKER_IMAGE" || -n "$PRE_FIX_WORKER_TAG" ]]; then
+    if [[ -z "$PRE_FIX_WORKER_IMAGE" || -z "$PRE_FIX_WORKER_TAG" ]]; then
+        echo "error: CURIE_E2E_PRE_FIX_WORKER_IMAGE and CURIE_E2E_PRE_FIX_WORKER_TAG must be set together" >&2
+        exit 1
+    fi
+fi
+BIN="$(cd "$(dirname "$CURIE_BIN")" && pwd)/$(basename "$CURIE_BIN")"
+PHASE1_BIN="$BIN"
+if [[ -n "$PRE_FIX_CLI_BIN" ]]; then
+    PHASE1_BIN="$(cd "$(dirname "$PRE_FIX_CLI_BIN")" && pwd)/$(basename "$PRE_FIX_CLI_BIN")"
+fi
+
+stop_pid() {
+    local pid="$1"
+    [[ -n "$pid" ]] || return 0
+    kill -0 "$pid" 2>/dev/null || { wait "$pid" 2>/dev/null || true; return 0; }
+    kill "$pid" 2>/dev/null || true
+    for _ in $(seq 1 40); do
+        kill -0 "$pid" 2>/dev/null || break
+        sleep 0.25
+    done
+    if kill -0 "$pid" 2>/dev/null; then
+        kill -9 "$pid" 2>/dev/null || true
+    fi
+    wait "$pid" 2>/dev/null || true
+}
+
+worker_pods_json() {
+    kubectl -n "$NAMESPACE" get pods \
+        -l "app.kubernetes.io/instance=$RELEASE,app.kubernetes.io/component=worker" -o json
+}
+
+restore_sandbox_template() {
+    local current patch expected actual
+    (( TEMPLATE_PATCHED )) || return 0
+    current="$(kubectl -n "$NAMESPACE" get sandboxtemplate "$SANDBOX_TEMPLATE" -o json)"
+    patch="$(python3 - "$ORIGINAL_TEMPLATE_FILE" "$current" <<'PY'
+import json, pathlib, sys
+original = json.loads(pathlib.Path(sys.argv[1]).read_text())
+current = json.loads(sys.argv[2])
+path = "/spec/podTemplate/spec/nodeSelector"
+original_spec = original["spec"]["podTemplate"]["spec"]
+current_spec = current["spec"]["podTemplate"]["spec"]
+if "nodeSelector" in original_spec:
+    op = "replace" if "nodeSelector" in current_spec else "add"
+    print(json.dumps([{"op": op, "path": path, "value": original_spec["nodeSelector"]}]))
+elif "nodeSelector" in current_spec:
+    print(json.dumps([{"op": "remove", "path": path}]))
+else:
+    print("[]")
+PY
+)"
+    if [[ "$patch" != "[]" ]]; then
+        kubectl -n "$NAMESPACE" patch sandboxtemplate "$SANDBOX_TEMPLATE" \
+            --type=json -p "$patch" >/dev/null
+    fi
+    expected="$(python3 - "$ORIGINAL_TEMPLATE_FILE" <<'PY'
+import json, pathlib, sys
+spec = json.loads(pathlib.Path(sys.argv[1]).read_text())["spec"]["podTemplate"]["spec"]
+print(json.dumps({"present": "nodeSelector" in spec, "value": spec.get("nodeSelector")}, sort_keys=True))
+PY
+)"
+    actual="$(kubectl -n "$NAMESPACE" get sandboxtemplate "$SANDBOX_TEMPLATE" -o json | python3 -c '
+import json,sys
+spec=json.load(sys.stdin)["spec"]["podTemplate"]["spec"]
+print(json.dumps({"present": "nodeSelector" in spec, "value": spec.get("nodeSelector")}, sort_keys=True))
+')"
+    [[ "$actual" == "$expected" ]] || {
+        echo "error: SandboxTemplate nodeSelector did not restore exactly" >&2
+        return 1
+    }
+    TEMPLATE_PATCHED=0
+}
+
+restore_worker_deployment() {
+    local pod
+    (( DEPLOYMENT_PATCHED )) || return 0
+    [[ -n "$ORIGINAL_REVISION" ]] || {
+        echo "error: cannot restore worker Deployment without its original revision" >&2
+        return 1
+    }
+    # Make rollback safe even when failure happened before the gatekeeper was
+    # started. Touching is immediate; opening the ConfigMap is the fallback for
+    # a pod that is not exec-able yet and will see the projected update later.
+    kubectl -n "$NAMESPACE" patch configmap "$GATE_CONFIGMAP" --type=merge \
+        -p '{"data":{"ready":"open","stop":"open"}}' >/dev/null 2>&1 || true
+    while read -r pod; do
+        kubectl -n "$NAMESPACE" exec "$pod" -- \
+            touch /tmp/curie-e2e-ready /tmp/curie-e2e-stop >/dev/null 2>&1 || true
+    done < <(kubectl -n "$NAMESPACE" get pods \
+        -l "app.kubernetes.io/instance=$RELEASE,app.kubernetes.io/component=worker" \
+        -o name 2>/dev/null | sed 's#^pod/##')
+    stop_pid "$GATEKEEPER_PID"
+    GATEKEEPER_PID=""
+    kubectl -n "$NAMESPACE" rollout undo "deployment/$WORKER_DEPLOYMENT" \
+        --to-revision="$ORIGINAL_REVISION" >/dev/null
+    kubectl -n "$NAMESPACE" rollout status "deployment/$WORKER_DEPLOYMENT" \
+        --timeout=300s >/dev/null
+    DEPLOYMENT_PATCHED=0
+}
+
+assert_release_healthy() {
+    local component
+    for component in api worker ui; do
+        kubectl -n "$NAMESPACE" rollout status "deployment/${RELEASE}-${component}" \
+            --timeout=300s >/dev/null
+    done
+    kubectl -n "$NAMESPACE" rollout status "statefulset/$VALKEY_STATEFULSET" \
+        --timeout=300s >/dev/null
+    kubectl -n "$NAMESPACE" rollout status "daemonset/${RELEASE}-runner-prewarm" \
+        --timeout=300s >/dev/null
+    # Read-only health proof: this harness never mutates the shared controller.
+    kubectl -n "$CONTROLLER_NAMESPACE" rollout status \
+        "deployment/$CONTROLLER_DEPLOYMENT" --timeout=300s >/dev/null
+    worker_pods_json | python3 -c '
+import json,sys
+pods=json.load(sys.stdin).get("items", [])
+if not pods:
+    raise SystemExit("worker release has no pods")
+for pod in pods:
+    name=pod.get("metadata",{}).get("name")
+    if pod.get("metadata",{}).get("deletionTimestamp"):
+        raise SystemExit("terminating worker remains: {}".format(name))
+    if not any(c.get("type") == "Ready" and c.get("status") == "True"
+               for c in pod.get("status",{}).get("conditions",[])):
+        raise SystemExit("worker not Ready: {}".format(name))
+'
+    echo "release health: app rollouts, Valkey, runner prewarm, and shared controller are Ready"
+}
+
+cleanup() {
+    local code=$?
+    trap - EXIT INT TERM
+    set +e
+    stop_pid "$FIRST_PID"
+    stop_pid "$SECOND_PID"
+    stop_pid "$TRANSFER_WATCHER_PID"
+    restore_sandbox_template || true
+    if [[ -n "$BLOCKED_CLAIM" ]]; then
+        kubectl -n "$NAMESPACE" delete sandboxclaim "$BLOCKED_CLAIM" \
+            --ignore-not-found --wait=false >/dev/null 2>&1 || true
+    fi
+    restore_worker_deployment || true
+    stop_pid "$GATEKEEPER_PID"
+    kubectl -n "$NAMESPACE" delete configmap "$GATE_CONFIGMAP" \
+        --ignore-not-found >/dev/null 2>&1 || true
+    rm -rf -- "$WORKDIR"
+    exit "$code"
+}
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+valkey_json() {
+    # The secret expands only inside the pod; it never enters host argv/state.
+    # shellcheck disable=SC2016
+    kubectl -n "$NAMESPACE" exec "statefulset/$VALKEY_STATEFULSET" -- \
+        sh -c 'REDISCLI_AUTH="$VALKEY_PASSWORD" exec valkey-cli --json "$@"' sh "$@"
+}
+
+json_int() { python3 -c 'import json,sys; print(int(json.load(sys.stdin)))'; }
+pending_rows() { valkey_json XPENDING "$STREAM" "$GROUP" - + 100; }
+xinfo_consumers() { valkey_json XINFO CONSUMERS "$STREAM" "$GROUP"; }
+
+consumer_info_pending() {
+    local consumer="$1"
+    xinfo_consumers | python3 -c '
+import json,sys
+consumer=sys.argv[1]
+for row in json.load(sys.stdin):
+    data=row if isinstance(row,dict) else dict(zip(row[0::2],row[1::2]))
+    if data.get("name") == consumer:
+        print(int(data.get("pending",-1)))
+        break
+else:
+    print("missing")
+' "$consumer"
+}
+
+consumer_for_pod() {
+    local pod="$1"
+    xinfo_consumers | python3 -c '
+import json,sys
+pod=sys.argv[1]
+names=[]
+for row in json.load(sys.stdin):
+    data=row if isinstance(row,dict) else dict(zip(row[0::2],row[1::2]))
+    name=data.get("name")
+    if isinstance(name,str) and name.startswith(pod + "-"):
+        names.append(name)
+if len(names) == 1:
+    print(names[0])
+elif len(names) > 1:
+    raise SystemExit("multiple XINFO consumers match pod {}: {}".format(pod,names))
+' "$pod"
+}
+
+wait_consumer_for_pod() {
+    local pod="$1" budget="$2" started=$SECONDS consumer
+    while (( SECONDS - started < budget )); do
+        consumer="$(consumer_for_pod "$pod")"
+        if [[ -n "$consumer" ]]; then
+            printf '%s\n' "$consumer"
+            return 0
+        fi
+        sleep 0.25
+    done
+    echo "error: XINFO never reported a consumer belonging to worker pod $pod" >&2
+    xinfo_consumers >&2 || true
+    return 1
+}
+
+pending_for_consumer() {
+    local consumer="$1"
+    pending_rows | python3 -c '
+import json,sys
+consumer=sys.argv[1]
+rows=[r for r in json.load(sys.stdin) if len(r)>=4 and r[1] == consumer]
+if len(rows) == 1:
+    row=rows[0]
+    print("{}\t{}\t{}\t{}".format(row[0],row[1],int(row[2]),int(row[3])))
+elif len(rows) > 1:
+    raise SystemExit("consumer {} owns multiple unexpected PEL rows: {}".format(consumer,rows))
+' "$consumer"
+}
+
+assert_pel_empty() {
+    local label="$1" old_consumer="$2" rows total old info_old
+    rows="$(pending_rows)"
+    total="$(printf '%s' "$rows" | python3 -c 'import json,sys; print(len(json.load(sys.stdin)))')"
+    old="$(printf '%s' "$rows" | python3 -c '
+import json,sys
+name=sys.argv[1]
+print(sum(1 for row in json.load(sys.stdin) if len(row)>1 and row[1] == name))
+' "$old_consumer")"
+    info_old="$(consumer_info_pending "$old_consumer")"
+    if [[ "$total" != "0" || "$old" != "0" || \
+          ( "$info_old" != "0" && "$info_old" != "missing" ) ]]; then
+        echo "$label: PEL not empty (total=$total, old=$old, xinfo=$info_old)" >&2
+        printf '%s\n' "$rows" >&2
+        xinfo_consumers >&2 || true
+        return 1
+    fi
+    echo "$label: XPENDING empty; XINFO reports $old_consumer pending=0 or absent"
+}
+
+ready_worker() {
+    worker_pods_json | python3 -c '
+import json,sys
+for pod in json.load(sys.stdin).get("items",[]):
+    if pod.get("metadata",{}).get("deletionTimestamp"):
+        continue
+    if any(c.get("type") == "Ready" and c.get("status") == "True"
+           for c in pod.get("status",{}).get("conditions",[])):
+        print(pod["metadata"]["name"])
+        break
+'
+}
+
+wait_ready_worker_other_than() {
+    local old="$1" budget="$2" started=$SECONDS pod
+    while (( SECONDS - started < budget )); do
+        pod="$(worker_pods_json | python3 -c '
+import json,sys
+old=sys.argv[1]
+for pod in json.load(sys.stdin).get("items",[]):
+    name=pod["metadata"]["name"]
+    if name == old or pod["metadata"].get("deletionTimestamp"):
+        continue
+    if any(c.get("type") == "Ready" and c.get("status") == "True"
+           for c in pod.get("status",{}).get("conditions",[])):
+        print(name); break
+' "$old")"
+        if [[ -n "$pod" ]]; then printf '%s\n' "$pod"; return 0; fi
+        sleep 0.25
+    done
+    echo "error: no Ready replacement worker appeared for $old" >&2
+    return 1
+}
+
+wait_for_new_worker_pod() {
+    local old="$1" budget="$2" started=$SECONDS pod
+    while (( SECONDS - started < budget )); do
+        pod="$(worker_pods_json | python3 -c '
+import json,sys
+old=sys.argv[1]
+for pod in json.load(sys.stdin).get("items",[]):
+    name=pod["metadata"]["name"]
+    if name != old and not pod["metadata"].get("deletionTimestamp"):
+        print(name); break
+' "$old")"
+        if [[ -n "$pod" ]]; then printf '%s\n' "$pod"; return 0; fi
+        sleep 0.25
+    done
+    echo "error: cluster message did not trigger a worker Deployment rollout" >&2
+    return 1
+}
+
+wait_exec_touch() {
+    local pod="$1" path="$2" budget="$3" started=$SECONDS
+    while (( SECONDS - started < budget )); do
+        if kubectl -n "$NAMESPACE" exec "$pod" -- touch "$path" >/dev/null 2>&1; then return 0; fi
+        sleep 0.25
+    done
+    echo "error: worker pod $pod never accepted gate file $path" >&2
+    return 1
+}
+
+wait_for_pid() {
+    local pid="$1" budget="$2" started=$SECONDS
+    while kill -0 "$pid" 2>/dev/null; do
+        if (( SECONDS - started >= budget )); then return 124; fi
+        sleep 0.25
+    done
+    wait "$pid"
+}
+
+assert_reply() {
+    local label="$1" path="$2"
+    python3 - "$label" "$path" <<'PY'
+import json, pathlib, sys
+label,path=sys.argv[1:]
+raw=pathlib.Path(path).read_text()
+try:
+    value=json.loads(raw)
+except Exception as exc:
+    raise SystemExit(f"{label}: unparseable CLI JSON: {exc}: {raw[:500]}")
+if value.get("finalized") is not True:
+    raise SystemExit(f"{label}: turn did not finalize: {value}")
+reply=value.get("reply")
+if not isinstance(reply,str) or not reply.strip():
+    raise SystemExit(f"{label}: finalized reply was empty: {value}")
+print(f"{label}: same CLI process returned a finalized nonempty reply")
+PY
+}
+
+snapshot_resource_names() {
+    local resource="$1" path="$2"
+    kubectl -n "$NAMESPACE" get "$resource" -o json | python3 -c '
+import json,sys
+for item in json.load(sys.stdin).get("items",[]):
+    print(item["metadata"]["name"])
+' >"$path"
+}
+
+new_resource_name() {
+    local resource="$1" baseline="$2" exclude="${3:-}"
+    kubectl -n "$NAMESPACE" get "$resource" -o json | python3 -c '
+import json,pathlib,sys
+baseline=set(pathlib.Path(sys.argv[1]).read_text().splitlines())
+exclude=sys.argv[2]
+items=[item for item in json.load(sys.stdin).get("items",[])
+       if item["metadata"]["name"] not in baseline
+       and item["metadata"]["name"] != exclude]
+if items:
+    items.sort(key=lambda item: item["metadata"].get("creationTimestamp",""))
+    print(items[-1]["metadata"]["name"])
+' "$baseline" "$exclude"
+}
+
+patch_sandbox_template_unschedulable() {
+    local current patch
+    kubectl -n "$NAMESPACE" get sandboxtemplate "$SANDBOX_TEMPLATE" -o json \
+        >"$ORIGINAL_TEMPLATE_FILE"
+    current="$(<"$ORIGINAL_TEMPLATE_FILE")"
+    patch="$(python3 - "$current" "$SANDBOX_HOLD_KEY" "$SANDBOX_HOLD_VALUE" <<'PY'
+import json,sys
+obj=json.loads(sys.argv[1]); key,value=sys.argv[2:]
+spec=obj["spec"]["podTemplate"]["spec"]
+selector=dict(spec.get("nodeSelector") or {}); selector[key]=value
+op="replace" if "nodeSelector" in spec else "add"
+print(json.dumps([{"op":op,"path":"/spec/podTemplate/spec/nodeSelector","value":selector}]))
+PY
+)"
+    kubectl -n "$NAMESPACE" patch sandboxtemplate "$SANDBOX_TEMPLATE" \
+        --type=json -p "$patch" >/dev/null
+    TEMPLATE_PATCHED=1
+}
+
+assert_unschedulable_sandbox_pod() {
+    local sandbox="$1"
+    kubectl -n "$NAMESPACE" get pod "$sandbox" -o json | python3 -c '
+import json,sys
+pod=json.load(sys.stdin); key,value=sys.argv[1:]
+selector=pod.get("spec",{}).get("nodeSelector",{})
+if selector.get(key) != value:
+    raise SystemExit("sandbox pod lacks test-only nodeSelector: {}".format(selector))
+if pod.get("spec",{}).get("nodeName"):
+    raise SystemExit("sandbox unexpectedly scheduled on {}".format(pod["spec"]["nodeName"]))
+if pod.get("status",{}).get("phase") != "Pending":
+    raise SystemExit("sandbox phase is not Pending: {}".format(pod.get("status",{}).get("phase")))
+' "$SANDBOX_HOLD_KEY" "$SANDBOX_HOLD_VALUE"
+}
+
+watch_pel_transfer() {
+    local entry_id="$1" old_consumer="$2" old_deliveries="$3"
+    # Poll beside Valkey so a fast completion cannot hide the transient row.
+    # shellcheck disable=SC2016
+    kubectl -n "$NAMESPACE" exec "statefulset/$VALKEY_STATEFULSET" -- sh -c '
+set -eu
+stream=$1; group=$2; entry_id=$3; old_consumer=$4; old_deliveries=$5
+deadline=$(( $(date +%s) + 190 ))
+while [ "$(date +%s)" -lt "$deadline" ]; do
+    raw="$(REDISCLI_AUTH="$VALKEY_PASSWORD" valkey-cli --raw XPENDING \
+        "$stream" "$group" "$entry_id" "$entry_id" 1 2>/dev/null || true)"
+    # shellcheck disable=SC2086
+    set -- $raw
+    if [ "$#" -ge 4 ] && [ "$1" = "$entry_id" ] && \
+       [ "$2" != "$old_consumer" ] && [ "$4" -gt "$old_deliveries" ]; then
+        printf "%s\t%s\t%s\t%s\n" "$1" "$2" "$3" "$4"
+        exit 0
+    fi
+    sleep 0.05
+done
+exit 124
+' sh "$STREAM" "$GROUP" "$entry_id" "$old_consumer" "$old_deliveries"
+}
+
+claim_created_after() {
+    local claim="$1" instant="$2"
+    kubectl -n "$NAMESPACE" get sandboxclaim "$claim" -o json | python3 -c '
+import datetime,json,sys
+created=json.load(sys.stdin)["metadata"]["creationTimestamp"]
+instant=sys.argv[1]
+parse=lambda value: datetime.datetime.fromisoformat(value.replace("Z","+00:00"))
+if parse(created) < parse(instant):
+    raise SystemExit("claim {} predates termination {}".format(created,instant))
+' "$instant"
+}
+
+echo "red-on-revert base ref: $BASE_REF"
+if [[ -n "$PRE_FIX_CLI_BIN" ]]; then echo "phase 1 uses pre-fix CLI $PHASE1_BIN"; fi
+if [[ -n "$PRE_FIX_WORKER_IMAGE" ]]; then
+    echo "phase 2 uses pre-fix worker ${PRE_FIX_WORKER_IMAGE}:${PRE_FIX_WORKER_TAG}"
+fi
+
+echo "=== deploy examples/weather through the real cluster CLI ==="
+cp -a "$REPO_ROOT/examples/weather" "$WORKDIR/weather"
+"$BIN" --json cluster deploy --plugin-dir "$WORKDIR/weather" \
+    --namespace "$NAMESPACE" --release "$RELEASE" >"$WORKDIR/deploy.json"
+python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); assert d["deployment"]["status"] == "active"' \
+    "$WORKDIR/deploy.json"
+
+ORIGINAL_REVISION="$(kubectl -n "$NAMESPACE" get deployment "$WORKER_DEPLOYMENT" \
+    -o jsonpath='{.metadata.annotations.deployment\.kubernetes\.io/revision}')"
+
+echo "=== install TEST-ONLY deterministic worker rollout gate ==="
+kubectl -n "$NAMESPACE" create configmap "$GATE_CONFIGMAP" \
+    --from-literal=ready=open --from-literal=stop=open >/dev/null
+kubectl -n "$NAMESPACE" patch deployment "$WORKER_DEPLOYMENT" --type=strategic -p "$(python3 - "$GATE_CONFIGMAP" <<'PY'
+import json,sys
+name=sys.argv[1]
+print(json.dumps({"spec":{"template":{"spec":{
+    "volumes":[{"name":"rollout-recovery-gate","configMap":{"name":name}}],
+    "containers":[{"name":"worker","command":["/bin/sh","-ec"],
+        "args":["exec python -m curie_worker"],
+        "volumeMounts":[{"name":"rollout-recovery-gate","mountPath":"/var/run/curie-e2e-gate","readOnly":True}],
+        "readinessProbe":{"exec":{"command":["/bin/sh","-ec","test -e /tmp/curie-e2e-ready || grep -qx open /var/run/curie-e2e-gate/ready"]},"initialDelaySeconds":1,"periodSeconds":1,"timeoutSeconds":1,"failureThreshold":1},
+        "lifecycle":{"preStop":{"exec":{"command":["/bin/sh","-ec","until test -e /tmp/curie-e2e-stop || grep -qx open /var/run/curie-e2e-gate/stop; do sleep 0.2; done"]}}}
+    }]}}}}))
+PY
+)" >/dev/null
+DEPLOYMENT_PATCHED=1
+kubectl -n "$NAMESPACE" rollout status "deployment/$WORKER_DEPLOYMENT" --timeout=300s
+OLD_POD="$(ready_worker)"
+[[ -n "$OLD_POD" ]] || { echo "error: no Ready baseline worker" >&2; exit 1; }
+OLD_CONSUMER="$(wait_consumer_for_pod "$OLD_POD" 60)"
+wait_exec_touch "$OLD_POD" /tmp/curie-e2e-ready 30
+kubectl -n "$NAMESPACE" patch configmap "$GATE_CONFIGMAP" --type=merge \
+    -p '{"data":{"ready":"hold","stop":"hold"}}' >/dev/null
+for _ in $(seq 1 360); do
+    if kubectl -n "$NAMESPACE" exec "$OLD_POD" -- \
+        grep -qx hold /var/run/curie-e2e-gate/ready 2>/dev/null; then break; fi
+    sleep 0.5
+done
+kubectl -n "$NAMESPACE" exec "$OLD_POD" -- grep -qx hold /var/run/curie-e2e-gate/ready
+BASE_XLEN="$(valkey_json XLEN "$STREAM" | json_int)"
+
+echo "=== first invocation: rollout must finish before enqueue ==="
+"$PHASE1_BIN" --json cluster message "What is the weather?" \
+    --namespace "$NAMESPACE" --release "$RELEASE" \
+    --listen-host "$CURIE_E2E_LISTEN_HOST" --timeout-secs "$MESSAGE_TIMEOUT_SECONDS" \
+    >"$WORKDIR/first.json" 2>"$WORKDIR/first.err" &
+FIRST_PID=$!
+NEW_POD="$(wait_for_new_worker_pod "$OLD_POD" "$STAGING_BUDGET_SECONDS")"
+echo "observed outgoing worker $OLD_POD and rollout worker $NEW_POD"
+wait_exec_touch "$NEW_POD" /tmp/curie-e2e-ready 60
+kubectl -n "$NAMESPACE" wait --for=condition=Ready "pod/$NEW_POD" --timeout=60s >/dev/null
+for _ in $(seq 1 480); do
+    deleting="$(kubectl -n "$NAMESPACE" get pod "$OLD_POD" \
+        -o jsonpath='{.metadata.deletionTimestamp}' 2>/dev/null || true)"
+    [[ -n "$deleting" ]] && break
+    kill -0 "$FIRST_PID" 2>/dev/null || break
+    sleep 0.25
+done
+[[ -n "${deleting:-}" ]] || {
+    cat "$WORKDIR/first.err" >&2 || true
+    echo "error: old worker never entered outgoing termination" >&2
+    exit 1
+}
+OBSERVATION_STARTED=$SECONDS
+while (( SECONDS - OBSERVATION_STARTED < PRE_ENQUEUE_OBSERVATION_SECONDS )); do
+    kill -0 "$FIRST_PID" 2>/dev/null || {
+        cat "$WORKDIR/first.err" >&2 || true
+        echo "error: phase 1 invocation returned while outgoing worker $OLD_POD was still held in preStop" >&2
+        exit 1
+    }
+    if [[ "$(valkey_json XLEN "$STREAM" | json_int)" != "$BASE_XLEN" ]]; then
+        echo "error: phase 1 red-on-revert assertion failed against $BASE_REF: invocation enqueued while outgoing worker $OLD_POD existed" >&2
+        exit 1
+    fi
+    old_pending="$(consumer_info_pending "$OLD_CONSUMER")"
+    if [[ "$old_pending" != "0" && "$old_pending" != "missing" ]]; then
+        echo "error: phase 1 red-on-revert assertion failed against $BASE_REF: outgoing XINFO consumer $OLD_CONSUMER claimed the invocation" >&2
+        exit 1
+    fi
+    sleep 0.25
+done
+echo "outgoing worker held in preStop for ${PRE_ENQUEUE_OBSERVATION_SECONDS}s; stream stayed unchanged and exact XINFO consumer $OLD_CONSUMER owned no PEL entry"
+
+(
+    while true; do
+        while read -r pod; do
+            kubectl -n "$NAMESPACE" exec "$pod" -- \
+                touch /tmp/curie-e2e-ready /tmp/curie-e2e-stop >/dev/null 2>&1 || true
+        done < <(kubectl -n "$NAMESPACE" get pods \
+            -l "app.kubernetes.io/instance=$RELEASE,app.kubernetes.io/component=worker" \
+            -o name 2>/dev/null | sed 's#^pod/##')
+        sleep 0.25
+    done
+) &
+GATEKEEPER_PID=$!
+wait_exec_touch "$OLD_POD" /tmp/curie-e2e-stop 30
+kubectl -n "$NAMESPACE" wait --for=delete "pod/$OLD_POD" --timeout=120s >/dev/null
+if wait_for_pid "$FIRST_PID" "$MESSAGE_TIMEOUT_SECONDS"; then
+    :
+else
+    status=$?
+    cat "$WORKDIR/first.err" >&2 || true
+    echo "error: first cluster message failed or exceeded ${MESSAGE_TIMEOUT_SECONDS}s (status $status)" >&2
+    exit 1
+fi
+FIRST_PID=""
+kubectl -n "$NAMESPACE" rollout status "deployment/$WORKER_DEPLOYMENT" --timeout=300s >/dev/null
+assert_reply "first invocation" "$WORKDIR/first.json"
+assert_pel_empty "first invocation" "$OLD_CONSUMER"
+
+echo "=== deliberate termination: recover a real PEL entry promptly ==="
+TRUST_ORIGIN="http://${CURIE_E2E_LISTEN_HOST}"
+kubectl -n "$NAMESPACE" set env "deployment/$WORKER_DEPLOYMENT" \
+    "CURIE_SLACK_TRUSTED_ORIGINS=$TRUST_ORIGIN" >/dev/null
+kubectl -n "$NAMESPACE" rollout status "deployment/$WORKER_DEPLOYMENT" --timeout=300s >/dev/null
+if [[ -n "$PRE_FIX_WORKER_IMAGE" ]]; then
+    kubectl -n "$NAMESPACE" set image "deployment/$WORKER_DEPLOYMENT" \
+        "worker=${PRE_FIX_WORKER_IMAGE}:${PRE_FIX_WORKER_TAG}" >/dev/null
+    kubectl -n "$NAMESPACE" rollout status "deployment/$WORKER_DEPLOYMENT" --timeout=300s >/dev/null
+fi
+RECOVERY_POD="$(ready_worker)"
+[[ -n "$RECOVERY_POD" ]] || { echo "error: no Ready worker for termination phase" >&2; exit 1; }
+RECOVERY_CONSUMER="$(wait_consumer_for_pod "$RECOVERY_POD" 60)"
+patch_sandbox_template_unschedulable
+snapshot_resource_names sandboxclaims "$CLAIMS_BEFORE_FILE"
+snapshot_resource_names sandboxes "$SANDBOXES_BEFORE_FILE"
+
+SECOND_STARTED=$SECONDS
+"$BIN" --json cluster message "Give me a fresh weather reply after recovery." \
+    --namespace "$NAMESPACE" --release "$RELEASE" \
+    --listen-host "$CURIE_E2E_LISTEN_HOST" --timeout-secs "$MESSAGE_TIMEOUT_SECONDS" \
+    >"$WORKDIR/second.json" 2>"$WORKDIR/second.err" &
+SECOND_PID=$!
+STAGING_STARTED=$SECONDS
+PEL_ROW=""
+BLOCKED_SANDBOX=""
+while (( SECONDS - STAGING_STARTED < STAGING_BUDGET_SECONDS )); do
+    PEL_ROW="$(pending_for_consumer "$RECOVERY_CONSUMER")"
+    BLOCKED_CLAIM="$(new_resource_name sandboxclaims "$CLAIMS_BEFORE_FILE")"
+    BLOCKED_SANDBOX="$(new_resource_name sandboxes "$SANDBOXES_BEFORE_FILE")"
+    if [[ -n "$PEL_ROW" && -n "$BLOCKED_CLAIM" && -n "$BLOCKED_SANDBOX" ]] && \
+       kubectl -n "$NAMESPACE" get pod "$BLOCKED_SANDBOX" >/dev/null 2>&1 && \
+       assert_unschedulable_sandbox_pod "$BLOCKED_SANDBOX" 2>/dev/null; then
+        break
+    fi
+    kill -0 "$SECOND_PID" 2>/dev/null || break
+    sleep 0.25
+done
+STAGING_SECONDS=$((SECONDS - STAGING_STARTED))
+if [[ -z "$PEL_ROW" || -z "$BLOCKED_CLAIM" || -z "$BLOCKED_SANDBOX" ]]; then
+    cat "$WORKDIR/second.err" >&2 || true
+    echo "error: staging did not produce a consumer-owned PEL row plus unschedulable SandboxClaim/Sandbox within ${STAGING_BUDGET_SECONDS}s" >&2
+    pending_rows >&2 || true
+    kubectl -n "$NAMESPACE" get sandboxclaims,sandboxes,pods -o wide >&2 || true
+    exit 1
+fi
+assert_unschedulable_sandbox_pod "$BLOCKED_SANDBOX"
+if ! kill -0 "$SECOND_PID" 2>/dev/null; then
+    if wait "$SECOND_PID"; then status=0; else status=$?; fi
+    SECOND_PID=""
+    cat "$WORKDIR/second.err" >&2 || true
+    cat "$WORKDIR/second.json" >&2 || true
+    echo "error: phase 2 CLI returned early (status $status) while its real Sandbox remained unschedulable; a capacity reply or early acknowledgement is not recovery proof" >&2
+    exit 1
+fi
+IFS=$'\t' read -r ENTRY_ID ENTRY_OWNER ENTRY_IDLE ENTRY_DELIVERIES <<<"$PEL_ROW"
+[[ "$ENTRY_OWNER" == "$RECOVERY_CONSUMER" && "$ENTRY_DELIVERIES" == "1" ]] || {
+    echo "error: staged PEL row is not delivery 1 owned by $RECOVERY_CONSUMER: $PEL_ROW" >&2
+    exit 1
+}
+[[ "$(consumer_info_pending "$RECOVERY_CONSUMER")" == "1" ]] || {
+    echo "error: XINFO does not report one pending entry for exact consumer $RECOVERY_CONSUMER" >&2
+    exit 1
+}
+(( STAGING_SECONDS <= STAGING_BUDGET_SECONDS )) || {
+    echo "error: staging took ${STAGING_SECONDS}s, above ${STAGING_BUDGET_SECONDS}s" >&2
+    exit 1
+}
+echo "staged in ${STAGING_SECONDS}s: entry $ENTRY_ID idle=${ENTRY_IDLE}ms delivery=$ENTRY_DELIVERIES belongs to $RECOVERY_CONSUMER while Sandbox $BLOCKED_SANDBOX is Pending"
+
+watch_pel_transfer "$ENTRY_ID" "$RECOVERY_CONSUMER" "$ENTRY_DELIVERIES" \
+    >"$WORKDIR/transfer.tsv" &
+TRANSFER_WATCHER_PID=$!
+TERMINATED_RFC3339="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+TERMINATED_AT=$SECONDS
+kubectl -n "$NAMESPACE" delete pod "$RECOVERY_POD" \
+    --force --grace-period=0 --wait=true --timeout=60s >/dev/null
+restore_sandbox_template
+HEARTBEAT_KEY="${STREAM}:consumer-heartbeat:${GROUP}:${RECOVERY_CONSUMER}"
+ABSENCE_WAIT_STARTED=$SECONDS
+while [[ "$(valkey_json EXISTS "$HEARTBEAT_KEY" | json_int)" != "0" ]]; do
+    (( SECONDS - ABSENCE_WAIT_STARTED < 60 )) || {
+        echo "error: terminated consumer alive lease remained present for 60s" >&2
+        exit 1
+    }
+    sleep 0.1
+done
+FIRST_ABSENCE_AT=$SECONDS
+echo "first confirmed alive-lease absence observed ${FIRST_ABSENCE_AT}s after harness start; prompt claim still requires the independent second observation"
+REPLACEMENT_POD="$(wait_ready_worker_other_than "$RECOVERY_POD" 120)"
+REPLACEMENT_CONSUMER="$(wait_consumer_for_pod "$REPLACEMENT_POD" 60)"
+
+remaining=$((RECOVERY_BUDGET_SECONDS - (SECONDS - TERMINATED_AT)))
+if (( remaining <= 0 )) || ! wait_for_pid "$TRANSFER_WATCHER_PID" "$remaining"; then
+    stop_pid "$TRANSFER_WATCHER_PID"
+    TRANSFER_WATCHER_PID=""
+    if [[ -n "$PRE_FIX_WORKER_IMAGE" ]]; then
+        echo "error: phase 2 red-on-revert assertion failed against $BASE_REF: pre-fix worker ${PRE_FIX_WORKER_IMAGE}:${PRE_FIX_WORKER_TAG} did not transfer the PEL entry within ${RECOVERY_BUDGET_SECONDS}s" >&2
+    else
+        echo "error: PEL ownership did not transfer with incremented times_delivered within ${RECOVERY_BUDGET_SECONDS}s" >&2
+    fi
+    exit 1
+fi
+TRANSFER_WATCHER_PID=""
+IFS=$'\t' read -r TRANSFER_ID TRANSFER_OWNER TRANSFER_IDLE TRANSFER_DELIVERIES \
+    <"$WORKDIR/transfer.tsv"
+[[ "$TRANSFER_ID" == "$ENTRY_ID" && "$TRANSFER_OWNER" == "$REPLACEMENT_CONSUMER" && \
+   "$TRANSFER_DELIVERIES" -gt "$ENTRY_DELIVERIES" ]] || {
+    echo "error: transfer does not match replacement consumer or increment times_delivered: $(<"$WORKDIR/transfer.tsv")" >&2
+    echo "replacement pod=$REPLACEMENT_POD consumer=$REPLACEMENT_CONSUMER" >&2
+    exit 1
+}
+echo "observed PEL transfer before clear: owner $RECOVERY_CONSUMER -> $TRANSFER_OWNER, idle reset to ${TRANSFER_IDLE}ms, times_delivered $ENTRY_DELIVERIES -> $TRANSFER_DELIVERIES"
+DETECT_TO_TRANSFER_SECONDS=$((SECONDS - FIRST_ABSENCE_AT))
+echo "detect-to-transfer=${DETECT_TO_TRANSFER_SECONDS}s from first confirmed lease absence"
+
+REOPENED_CLAIM=""
+while (( SECONDS - TERMINATED_AT < RECOVERY_BUDGET_SECONDS )); do
+    REOPENED_CLAIM="$(new_resource_name sandboxclaims "$CLAIMS_BEFORE_FILE" "$BLOCKED_CLAIM")"
+    [[ -n "$REOPENED_CLAIM" ]] && break
+    sleep 0.25
+done
+[[ -n "$REOPENED_CLAIM" ]] || {
+    echo "error: replacement delivery never opened a fresh post-termination SandboxClaim" >&2
+    exit 1
+}
+claim_created_after "$REOPENED_CLAIM" "$TERMINATED_RFC3339"
+echo "post-termination reopen transition: replacement created SandboxClaim $REOPENED_CLAIM"
+
+remaining=$((RECOVERY_BUDGET_SECONDS - (SECONDS - TERMINATED_AT)))
+status=0
+if (( remaining <= 0 )); then
+    status=124
+elif wait_for_pid "$SECOND_PID" "$remaining"; then
+    :
+else
+    status=$?
+fi
+if (( status != 0 )); then
+    cat "$WORKDIR/second.err" >&2 || true
+    echo "error: terminated-consumer message failed or exceeded ${RECOVERY_BUDGET_SECONDS}s after termination (status $status)" >&2
+    exit 1
+fi
+SECOND_PID=""
+RECOVERY_SECONDS=$((SECONDS - TERMINATED_AT))
+TOTAL_SECONDS=$((SECONDS - SECOND_STARTED))
+(( RECOVERY_SECONDS < RECOVERY_BUDGET_SECONDS )) || {
+    echo "error: recovery took ${RECOVERY_SECONDS}s after termination, not <${RECOVERY_BUDGET_SECONDS}s" >&2
+    exit 1
+}
+assert_reply "deliberate termination" "$WORKDIR/second.json"
+assert_pel_empty "deliberate termination" "$RECOVERY_CONSUMER"
+echo "deliberate termination recovered in ${RECOVERY_SECONDS}s (${TOTAL_SECONDS}s total), below ${RECOVERY_BUDGET_SECONDS}s and far below 900s"
+
+kubectl -n "$NAMESPACE" delete sandboxclaim "$BLOCKED_CLAIM" \
+    --ignore-not-found --wait=false >/dev/null
+BLOCKED_CLAIM=""
+restore_worker_deployment
+kubectl -n "$NAMESPACE" delete configmap "$GATE_CONFIGMAP" --ignore-not-found >/dev/null
+assert_release_healthy
+echo "QA4-02 ROLLOUT/PEL RECOVERY PASS"

--- a/cli/scripts/e2e-cluster-rollout-recovery.sh
+++ b/cli/scripts/e2e-cluster-rollout-recovery.sh
@@ -178,6 +178,21 @@ assert_release_healthy() {
     # Read-only health proof: this harness never mutates the shared controller.
     kubectl -n "$CONTROLLER_NAMESPACE" rollout status \
         "deployment/$CONTROLLER_DEPLOYMENT" --timeout=300s >/dev/null
+    # A Deployment can report complete while the replaced pod is still serving
+    # its termination grace period.  Give that pod the same bounded opportunity
+    # to disappear that the product gives it before making the final hygiene
+    # assertion below.
+    local terminating_deadline=$((SECONDS + 60))
+    while (( SECONDS < terminating_deadline )); do
+        if ! worker_pods_json | python3 -c '
+import json,sys
+pods=json.load(sys.stdin).get("items", [])
+raise SystemExit(0 if any(p.get("metadata",{}).get("deletionTimestamp") for p in pods) else 1)
+'; then
+            break
+        fi
+        sleep 1
+    done
     worker_pods_json | python3 -c '
 import json,sys
 pods=json.load(sys.stdin).get("items", [])

--- a/cli/src/message.rs
+++ b/cli/src/message.rs
@@ -440,6 +440,11 @@ struct TrustCleanupSpec {
 
 struct ClusterStubTrust {
     cleanup: TrustCleanupSpec,
+    /// The temporary-trust rollout can leave the prior worker in its graceful
+    /// drain period.  This is deliberately derived from the selected
+    /// Deployment rather than from `--timeout-secs`: the latter starts only
+    /// after the eventual queue entry is enqueued.
+    prevention_wait_budget: Duration,
     armed: bool,
 }
 
@@ -452,6 +457,7 @@ struct WorkerTrustView {
     env_present: bool,
     env: Vec<serde_json::Value>,
     trust: Option<String>,
+    termination_grace_period: Duration,
 }
 
 #[cfg(unix)]
@@ -494,6 +500,7 @@ impl ClusterStubTrust {
     async fn install(namespace: &str, release: &str, advertise_host: &str) -> Result<Self> {
         let deployment = format!("{release}-worker");
         let view = read_worker_trust(namespace, &deployment).await?;
+        let prevention_wait_budget = worker_prevention_wait_budget(&view);
         let host = if advertise_host.contains(':') && !advertise_host.starts_with('[') {
             format!("[{advertise_host}]")
         } else {
@@ -519,6 +526,7 @@ impl ClusterStubTrust {
                     original: view.trust,
                     mode: TrustMutationMode::Legacy,
                 },
+                prevention_wait_budget,
                 armed: false,
             });
         }
@@ -556,8 +564,13 @@ impl ClusterStubTrust {
         // API accepted the mutation must run restoration.
         let guard = Self {
             cleanup,
+            prevention_wait_budget,
             armed: true,
         };
+        crate::ui::ui().note(&format!(
+            "temporarily updating worker reply trust; allowing up to {}s for the worker rollout and prior worker drain before enqueue (separate from --timeout-secs)",
+            guard.prevention_wait_budget.as_secs()
+        ));
         let (ok, _, err) = run_capture(&apply).await?;
         if !ok {
             bail!(
@@ -566,9 +579,16 @@ impl ClusterStubTrust {
             );
         }
 
-        let rollout = guard.rollout_command();
+        let rollout = guard.prevention_rollout_command();
         let (ok, _, err) = run_capture(&rollout).await?;
         if !ok {
+            if rollout_timed_out(&err) {
+                return Err(worker_prevention_timeout_error(
+                    release,
+                    namespace,
+                    guard.prevention_wait_budget,
+                ));
+            }
             bail!(
                 "waiting for the worker to trust cluster-message stub origin {origin}: {}",
                 err.trim()
@@ -577,7 +597,11 @@ impl ClusterStubTrust {
         // rollout status returns once the new replica is Ready. The outgoing
         // pod can still be Terminating and still blocked in XREADGROUP, which
         // is how the first cluster message strands its own turn (#1532).
-        wait_for_worker_pods_to_release_claimers(namespace, release).await?;
+        crate::ui::ui().note(
+            "worker replacement is ready; waiting for every prior worker to stop claiming before enqueue",
+        );
+        wait_for_worker_pods_to_release_claimers(namespace, release, guard.prevention_wait_budget)
+            .await?;
         Ok(guard)
     }
 
@@ -586,7 +610,7 @@ impl ClusterStubTrust {
             return Ok(());
         }
         restore_cluster_trust(&self.cleanup).await?;
-        let (ok, _, err) = run_capture(&self.rollout_command()).await?;
+        let (ok, _, err) = run_capture(&self.restore_rollout_command()).await?;
         if !ok {
             bail!(
                 "waiting for the worker to restore its prior Slack trust: {}",
@@ -598,23 +622,76 @@ impl ClusterStubTrust {
         Ok(())
     }
 
-    fn rollout_command(&self) -> OpsCommand {
-        OpsCommand::new(
-            "kubectl",
-            vec![
-                plain("-n"),
-                plain(&self.cleanup.namespace),
-                plain("rollout"),
-                plain("status"),
-                plain(format!("deployment/{}", self.cleanup.deployment)),
-                plain("--timeout=120s"),
-            ],
+    fn prevention_rollout_command(&self) -> OpsCommand {
+        worker_rollout_command(
+            &self.cleanup.namespace,
+            &self.cleanup.deployment,
+            self.prevention_wait_budget,
+        )
+    }
+
+    /// Restoring operator state is cleanup, not part of the no-lost-turn gate.
+    /// Keep it short so a completed message never blocks for a full graceful
+    /// drain interval while the deployment rolls back its temporary trust.
+    fn restore_rollout_command(&self) -> OpsCommand {
+        worker_rollout_command(
+            &self.cleanup.namespace,
+            &self.cleanup.deployment,
+            WORKER_TRUST_RESTORE_ROLLOUT_TIMEOUT,
         )
     }
 }
 
-const WORKER_POD_SETTLE_TIMEOUT: Duration = Duration::from_secs(120);
+const DEFAULT_WORKER_TERMINATION_GRACE_PERIOD: Duration = Duration::from_secs(30);
+const WORKER_PREVENTION_MARGIN: Duration = Duration::from_secs(30);
+const WORKER_TRUST_RESTORE_ROLLOUT_TIMEOUT: Duration = Duration::from_secs(120);
 const WORKER_POD_SETTLE_POLL: Duration = Duration::from_millis(500);
+
+/// The safe pre-enqueue budget covers the Deployment's own configured drain
+/// window plus scheduling/control-plane slack. Kubernetes defaults an omitted
+/// `terminationGracePeriodSeconds` to 30 seconds, but a chart/operator value
+/// (notably Curie's 1800 second default) wins when present.
+fn worker_prevention_wait_budget(view: &WorkerTrustView) -> Duration {
+    view.termination_grace_period
+        .saturating_add(WORKER_PREVENTION_MARGIN)
+}
+
+fn worker_rollout_command(namespace: &str, deployment: &str, timeout: Duration) -> OpsCommand {
+    let timeout_secs = timeout.as_secs().max(1);
+    OpsCommand::new(
+        "kubectl",
+        vec![
+            plain("-n"),
+            plain(namespace),
+            plain("rollout"),
+            plain("status"),
+            plain(format!("deployment/{deployment}")),
+            plain(format!("--timeout={timeout_secs}s")),
+        ],
+    )
+}
+
+fn rollout_timed_out(stderr: &str) -> bool {
+    stderr
+        .to_ascii_lowercase()
+        .contains("timed out waiting for the condition")
+}
+
+fn worker_prevention_timeout_error(
+    release: &str,
+    namespace: &str,
+    budget: Duration,
+) -> anyhow::Error {
+    anyhow::Error::from(
+        crate::exit::CliError::transient(format!(
+            "worker rollout or prior worker drain for release {release} in namespace {namespace} did not settle within {}s; no turn was enqueued, so retry is safe",
+            budget.as_secs()
+        ))
+        .with_fix(format!(
+            "wait for `kubectl -n {namespace} get pods -l app.kubernetes.io/instance={release},app.kubernetes.io/component=worker` to show only Ready, non-terminating pods, then retry `curie cluster message`"
+        )),
+    )
+}
 
 fn worker_pods_command(namespace: &str, release: &str) -> OpsCommand {
     OpsCommand::new(
@@ -676,8 +753,12 @@ fn worker_pods_allow_enqueue(pods_json: &str) -> Result<bool> {
     Ok(true)
 }
 
-async fn wait_for_worker_pods_to_release_claimers(namespace: &str, release: &str) -> Result<()> {
-    let deadline = Instant::now() + WORKER_POD_SETTLE_TIMEOUT;
+async fn wait_for_worker_pods_to_release_claimers(
+    namespace: &str,
+    release: &str,
+    budget: Duration,
+) -> Result<()> {
+    let deadline = Instant::now() + budget;
     loop {
         let (ok, out, err) = run_capture(&worker_pods_command(namespace, release)).await?;
         if !ok {
@@ -690,11 +771,7 @@ async fn wait_for_worker_pods_to_release_claimers(namespace: &str, release: &str
             return Ok(());
         }
         if Instant::now() >= deadline {
-            bail!(
-                "the previous worker pod for release {release} was still terminating after \
-                 {WORKER_POD_SETTLE_TIMEOUT:?}; retry cluster message once that pod is gone so \
-                 it cannot claim the turn"
-            );
+            return Err(worker_prevention_timeout_error(release, namespace, budget));
         }
         tokio::time::sleep(WORKER_POD_SETTLE_POLL).await;
     }
@@ -709,7 +786,7 @@ impl Drop for ClusterStubTrust {
             crate::ui::ui().warn("could not restore the worker's prior Slack trust");
             return;
         }
-        let rollout = self.rollout_command();
+        let rollout = self.restore_rollout_command();
         let rollout = std::process::Command::new(&rollout.program)
             .args(rollout.argv())
             .output();
@@ -754,6 +831,11 @@ fn worker_trust_view(deployment_json: &str) -> Result<WorkerTrustView> {
         None => None,
     };
     let annotations = deployment.pointer("/metadata/annotations");
+    let termination_grace_period = deployment
+        .pointer("/spec/template/spec/terminationGracePeriodSeconds")
+        .and_then(serde_json::Value::as_u64)
+        .map(Duration::from_secs)
+        .unwrap_or(DEFAULT_WORKER_TERMINATION_GRACE_PERIOD);
     Ok(WorkerTrustView {
         resource_version: deployment
             .pointer("/metadata/resourceVersion")
@@ -768,6 +850,7 @@ fn worker_trust_view(deployment_json: &str) -> Result<WorkerTrustView> {
         env_present,
         env,
         trust,
+        termination_grace_period,
     })
 }
 
@@ -4748,6 +4831,26 @@ mod tests {
                 }
             })]))
             .unwrap()
+        );
+    }
+
+    #[test]
+    fn worker_pod_settle_budget_covers_chart_default_termination_grace() {
+        let chart_grace = Duration::from_secs(1800);
+        let view = WorkerTrustView {
+            resource_version: None,
+            annotations_present: false,
+            holder: None,
+            worker_index: 0,
+            env_present: false,
+            env: Vec::new(),
+            trust: None,
+            termination_grace_period: chart_grace,
+        };
+        assert_eq!(
+            worker_prevention_wait_budget(&view),
+            chart_grace + WORKER_PREVENTION_MARGIN,
+            "the CLI settle wait must cover worker.terminationGracePeriodSeconds=1800"
         );
     }
 

--- a/docs/interfaces/queue-stream/INTERFACE.md
+++ b/docs/interfaces/queue-stream/INTERFACE.md
@@ -69,6 +69,31 @@ A second broker must honor the stream key, the payload encoding, and the Stream 
   the group. The target stream is `WorkerConfig.dead_letter_stream`
   (`apps/worker/src/curie_worker/config.py::WorkerConfig`), defaulting to
   `"<stream>:dead"`.
+- **Consumer liveness and prompt reclaim** (#1532) — `XINFO CONSUMERS` idle is
+  only a cheap candidate filter: it rises while a worker drains a turn or waits
+  at its local concurrency limit. Before either lane reads, the narrow
+  `ConsumerLivenessStore`
+  (`apps/worker/src/curie_worker/consumer_liveness.py::ConsumerLivenessStore`)
+  writes a renewable alive lease, then a renewable capability marker, and
+  refreshes both throughout its lifetime, including graceful handler drain.
+  The prompt path may transfer a pending entry only after a peer's capability
+  marker is present and its alive lease is absent on two observations separated
+  by a full heartbeat TTL. Alive restoration, missing peers, store errors, and
+  a new consumer generation reset that proof. A live, draining, or saturated
+  peer is consequently not reclaimed merely because its stream-consumer idle
+  value is high.
+- **Recovery ownership** — a short per-dead-consumer `SET NX PX` lease in the
+  adjacent liveness store selects one replacement before `XCLAIM`, preventing
+  replicas from racing through the delivery budget. A restarted generation
+  also recovers rows under its own stable consumer name through the same
+  pre-claim cap check before it reads new entries.
+- **Compatibility and the prompt cap rule** — an unknown/pre-marker peer keeps
+  the unchanged 900-second `XAUTOCLAIM` backstop. For a proven-dead capable
+  peer, the prompt path first reads `XPENDING` metadata and skips local
+  in-flight IDs; it directly dead-letters an at/over-cap row before `XCLAIM`,
+  even when the row is younger than the heavy reclaim window. A below-cap row
+  is claimed only after the same proof. This narrow exception preserves the
+  delivery bound without treating idle alone as liveness.
 
 Idempotency lives beside the stream, not in it: `claim_event` does a
 `SET <dedupe_key> 1 NX EX <ttl>` before `XADD` (`apps/dispatcher/src/curie_dispatcher/queue.py::claim_event`).
@@ -78,9 +103,13 @@ Idempotency lives beside the stream, not in it: `claim_event` does a
 One, redis-py against Valkey. The dispatcher `XADD`s
 (`apps/dispatcher/src/curie_dispatcher/queue.py::enqueue`); the worker runs
 a consumer group with `XREADGROUP`/`XACK`, crash-recovery `XAUTOCLAIM`,
-dead-consumer prompt reclaim `XINFO CONSUMERS`/`XCLAIM` (#1532), and the
-delivery-cap dead-letter path's `XPENDING`/`XRANGE`/`XADD`. All of those verbs are
-issued from the shared base (`apps/worker/src/curie_worker/stream_consumer.py::StreamConsumer`);
+capable-peer prompt reclaim `XINFO CONSUMERS`/`XCLAIM` (#1532), and the
+delivery-cap dead-letter path's `XPENDING`/`XRANGE`/`XADD`. The runs and eval
+lanes share the ordered liveness publication, sustained-absence proof, and cap
+enforcement in `apps/worker/src/curie_worker/stream_consumer.py::StreamConsumer`;
+an unmarked peer remains on the 900-second `XAUTOCLAIM` fallback. All stream
+verbs are issued from that shared base
+(`apps/worker/src/curie_worker/stream_consumer.py::StreamConsumer`);
 the sacred `apps/worker/src/curie_worker/consumer.py::Consumer` subclass supplies the
 specs and handlers and issues only its own pre-claim `xpending_range`
 (`apps/worker/src/curie_worker/consumer.py::Consumer._pending_delivery_count`). A second, sibling stream
@@ -103,6 +132,14 @@ is not touched:
   dead-consumer prompt reclaim (#1532) — `xinfo_consumers`/`xclaim`. The non-sacred `StreamConsumer`
   base (`apps/worker/src/curie_worker/stream_consumer.py`) holds a `StreamBroker`; the sacred `consumer.py` subclass
   inherits it unchanged (its `XAUTOCLAIM` reclaim now targets the port by inheritance).
+- **Consumer liveness store** — `ConsumerLivenessStore`
+  (`apps/worker/src/curie_worker/consumer_liveness.py::ConsumerLivenessStore`)
+  is deliberately a separate, narrow Redis string-key adapter for ordered
+  alive/capability publication, renewal, observation, alive-lease cleanup, and
+  token-checked prompt-reclaim arbitration.
+  It is not an expansion of the stream-only `StreamBroker`: a different stream
+  broker must either supply this limited liveness boundary or explicitly retain
+  the long `XAUTOCLAIM` compatibility behavior.
 
 The verbs return a bare `Awaitable`/value matching redis-py's own typing, so
 `redis.asyncio.Redis` / `redis.Redis` satisfy the ports structurally with no adapter.
@@ -127,6 +164,13 @@ The verbs return a bare `Awaitable`/value matching redis-py's own typing, so
   `apps/api/src/curie_api/threadreset.py::ThreadResetRequests`. A second broker that
   implements only the two stream Protocols would leave this feature unbacked; it is a
   Valkey dependency, not a stream-contract one, and no port names it today.
+- **Liveness string keys are another intentionally narrow adjacent dependency.**
+  `ConsumerLivenessStore` uses the worker's concrete async Redis client for its
+  renewable alive/capability markers and short token-checked arbitration lease;
+  generic `SET`/`EXISTS`/`DELETE` were
+  not added to `StreamBroker`. The independent marker protocol is what lets
+  prompt recovery protect a live consumer whose `XINFO` idle time is high while
+  retaining a 900-second fallback for a pre-marker peer.
 - **The API both writes the runs stream and reads the graveyard outside the ports.**
   Correcting an earlier claim that the API's redis only backs the kill-switch /
   eval-queue: the approval-resume path enqueues resume turns directly onto the same


### PR DESCRIPTION
## Summary

Hardens the QA4-02 rollout fix after #1961: `cluster message` now waits until the temporary-trust worker rollout has no terminating claimers before enqueueing, while runs and eval consumers publish renewable liveness and promptly reclaim a proven-dead consumer's PEL entry without changing the 900-second compatibility backstop or delivery cap. Adds a CI-owned deployed regression through the real CLI, Deployment rollout, worker, Valkey PEL, Sandbox reply path, and red-on-revert controls.

## Related issue

Follow-up to #1961. Ref #1532.

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | No plugin packaging, runner turn loop, ACI events, or skill eval/check change. | n/a | n/a |
| local | required | Worker stream-consumer liveness, recovery, and delivery accounting changed. | fake services / real Valkey | `uv run pytest -q apps/worker/tests` on the implementation tree: `900 passed, 7 skipped`; after the final lease-arbitration fix, `uv run pytest -q apps/worker/tests/kernel/test_consumer.py apps/worker/tests/test_config.py`: `80 passed`; `uv run ruff check .` and `uv run mypy`: clean. |
| local-release | n/a | No released-image identity, installer, version-pin, or release-compose behavior changed by this diff. | n/a | n/a |
| cluster | required | The defect is the first `curie cluster message` racing its own worker rollout. | fake model / live disposable k3s | At candidate `badd87c1`, `CURIE_BIN=/tmp/curie-1532-final-cargo/debug/curie CURIE_E2E_NAMESPACE=curie-1532-final2 CURIE_E2E_RELEASE=curie1532g CURIE_E2E_LISTEN_HOST=192.168.86.37 bash cli/scripts/e2e-cluster-rollout-recovery.sh`: outgoing worker held terminating for 20s with unchanged stream and no PEL ownership; first reply finalized; terminated-consumer PEL transferred in 20s with deliveries `1 -> 2`; same CLI finalized in 126s; PEL empty; release health passed; `QA4-02 ROLLOUT/PEL RECOVERY PASS`. |
| live provider | n/a | Model routing, provider credentials, and accounting are untouched; fake-model mode isolates the rollout race. | n/a | n/a |
| external integration | n/a | No Slack, webhook, OAuth, or third-party API shape changed. | n/a | n/a |

- [x] Every required tier above names its exact command, candidate/source commit, mode, and observed outcome.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or second path: pre-fix CLI claimed the first entry; pre-fix worker retained its PEL entry for the full 180-second budget; the final candidate passed both phases.
- [x] No required tier is left unproved.
- [ ] Or: this change is not behavior-bearing, so no tier applies, and the summary says why. (Not applicable: this is behavior-bearing.)

## `/implement` done-check

- [x] Failing tests and both deployed red controls were exercised before the corresponding production fixes were accepted; the final branch consolidates the reviewed result.
- [x] Production edits were performed in the delegated CLI, worker-liveness, and documentation streams; no frozen package was changed.
- [x] No public return type was broadened.
- [x] Adversarial spec/prior-intent review approved the implementation; the old-worker red transcript clears its evidence caveat.
- [x] Adversarial scope review traced the diff to #1532; its evidence gates are cleared by the two recorded red runs and the sacred-consumer side-effects review.
- [x] Sibling parity is by construction in the shared `StreamConsumer`; runs and eval both publish and renew liveness, and eval has secondary-path drain/cap coverage.
- [x] Guard demonstration is live: the pre-fix CLI claimed under the outgoing consumer, while the candidate refused to enqueue for a 20-second held-termination window.
- [x] Consolidation folded lifecycle/reclaim logic into the shared base; post-review validation and exact-candidate E2E remained green.
- [x] Security review is n/a: no auth, PII, tenant boundary, payment, or credential surface changed.
- [x] Driver observed every user-facing change through the actual CLI and reply path.
- [x] Deployed E2E passed on disposable namespace/release `curie-1532-final2` / `curie1532g`; the release, namespace, and test images were removed afterward.
- [x] Full affected validation passed: worker `900 passed, 7 skipped`; CLI formatting, clippy, and full tests passed; docs, Ruff, mypy, Bash syntax, and ShellCheck passed.

## Checklist

- [x] Tests pass for the area I touched.
- [x] Docs updated for the changed behavior.
- [x] ADR not added: this preserves the existing delivery-cap/backstop contract and documents the bounded liveness optimization at the queue seam.
