### PR TITLE
Scope connector secrets to immutable cluster targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,11 @@ oauth.env
 # a render-assertion script, not secret material. Without this the `*secret*`
 # rule drops it and the CI step that runs it goes red on a missing file.
 !charts/curie/ci/direct-passthrough-existing-secret-assertions.sh
+# Exception: CLI tests that prove connector-secret cluster scoping (#1913). They
+# assert names, scopes, and versions and never embed credential values. Without
+# this the `*secret*` rule drops them and the red-on-revert coverage is untracked.
+!cli/tests/cluster_secret_scope.rs
+!cli/tests/cluster_secret_scope_kind.rs
 
 # Python
 __pycache__/

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -188,7 +188,9 @@ contexts: [{name: prod, context: {cluster: prod, user: sre-bot-reader}}]
 current-context: prod
 YAML
 )"
-curie secrets set K8S_READONLY_KUBECONFIG --from-env K8S_READONLY_KUBECONFIG
+CURIE_CLUSTER_ID="ca:$(kubectl config view --minify --raw -o json | jq -r '.clusters[0].cluster | ((.server // "") + "\\n" + (."certificate-authority-data" // ."certificate-authority" // ""))' | sha256sum | awk '{print $1}')"
+curie secrets set K8S_READONLY_KUBECONFIG --from-env K8S_READONLY_KUBECONFIG \
+  --cluster-identity "$CURIE_CLUSTER_ID" --release curie --namespace curie
 
 # 4. Deploy the bundle. This is also what provisions the secret from step 3
 #    into the namespace; nothing else does.

--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -4018,6 +4018,38 @@ export const commandManifest = {
               "long": "from-env",
               "positional": false,
               "required": false
+            },
+            {
+              "global": false,
+              "help": "Cluster identity fingerprint from `kubectl config view`. Required with --release and --namespace to scope a connector secret to one cluster",
+              "id": "cluster_identity",
+              "long": "cluster-identity",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Helm release the secret may be injected into",
+              "id": "release",
+              "long": "release",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Kubernetes namespace the secret may be injected into",
+              "id": "namespace",
+              "long": "namespace",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Compare-and-set version from `curie secrets list --json`. Required to replace an existing cluster-scoped secret",
+              "id": "expected_version",
+              "long": "expected-version",
+              "positional": false,
+              "required": false
             }
           ],
           "hidden": false,
@@ -4037,6 +4069,30 @@ export const commandManifest = {
               "id": "name",
               "positional": true,
               "required": true
+            },
+            {
+              "global": false,
+              "help": "Cluster identity fingerprint. Required with --release and --namespace to remove one scoped entry without deleting the unscoped value",
+              "id": "cluster_identity",
+              "long": "cluster-identity",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Helm release of the scoped entry to remove",
+              "id": "release",
+              "long": "release",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Kubernetes namespace of the scoped entry to remove",
+              "id": "namespace",
+              "long": "namespace",
+              "positional": false,
+              "required": false
             }
           ],
           "hidden": false,

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -49,6 +49,7 @@ serde_urlencoded = "0.7"
 sha2 = "0.11"
 signal-hook = "0.4"
 tar = "0.4"
+tempfile = "3"
 time = { version = "0.3", features = ["formatting", "parsing"] }
 uuid = { version = "1", features = ["v4"] }
 # OS CSPRNG for generating strong per-release chart secrets (cluster up). Same
@@ -80,7 +81,6 @@ crypto_box = { version = "0.9.1", features = ["seal", "std"] }
 base64 = "0.23.1"
 
 [dev-dependencies]
-tempfile = "3"
 # The frozen ACI types are a normal dependency of the lib, but integration test
 # crates need them by name to build a SessionStatus for the status_json contract.
 curie-aci-protocol = { path = "../packages/aci-protocol/generated/rust" }

--- a/cli/README.md
+++ b/cli/README.md
@@ -575,11 +575,25 @@ variable instead of prompting:
 curie secrets set GITHUB_PERSONAL_ACCESS_TOKEN --from-env GITHUB_PAT
 ```
 
-During cluster deploy, Curie resolves every connector secret name from the
-environment first and then the host secret store, and delivers the owned keys
-to the agent Kubernetes Secret. This includes connector `secrets` and
-`secret_files`. The host store is install global, so agents using the same
-secret name share one stored value and can collide. Issue #440 tracks the future
+Connector secrets that `curie cluster deploy` writes into a target namespace
+must be scoped to that cluster identity, Helm release, and namespace. A name
+saved for one cluster is refused on another instead of being silently reused.
+`curie secrets list` prints the scope and version, never the value. Replacing a
+scoped value requires `--expected-version` from that listing.
+
+```bash
+curie secrets set K8S_WRITE_KUBECONFIG --from-env K8S_WRITE_KUBECONFIG \
+  --cluster-identity ca:0123abcd --release curie --namespace curie-test
+curie secrets set K8S_WRITE_KUBECONFIG --from-env K8S_WRITE_KUBECONFIG \
+  --cluster-identity ca:0123abcd --release curie --namespace curie-test \
+  --expected-version 1
+```
+
+Unscoped names remain for skill/local credentials (model keys, Slack tokens).
+During cluster deploy, Curie resolves owned connector keys against the target
+scope, prints the names it is about to write, and warns when it is replacing a
+non-empty key in the live Secret. Process environment is a first-run fallback
+only when the store has no entry for that name. Issue #440 tracks the future
 per agent delivery path.
 
 `curie skill up --secret <NAME>` first uses a real environment variable when

--- a/cli/README.md
+++ b/cli/README.md
@@ -582,8 +582,9 @@ saved for one cluster is refused on another instead of being silently reused.
 scoped value requires `--expected-version` from that listing.
 
 ```bash
+CURIE_CLUSTER_ID="ca:$(kubectl config view --minify --raw -o json | jq -r '.clusters[0].cluster | ((.server // "") + "\\n" + (."certificate-authority-data" // ."certificate-authority" // ""))' | sha256sum | awk '{print $1}')"
 curie secrets set K8S_WRITE_KUBECONFIG --from-env K8S_WRITE_KUBECONFIG \
-  --cluster-identity ca:0123abcd --release curie --namespace curie-test
+  --cluster-identity "$CURIE_CLUSTER_ID" --release curie --namespace curie-test
 curie secrets set K8S_WRITE_KUBECONFIG --from-env K8S_WRITE_KUBECONFIG \
   --cluster-identity ca:0123abcd --release curie --namespace curie-test \
   --expected-version 1

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -4015,6 +4015,38 @@
               "long": "from-env",
               "positional": false,
               "required": false
+            },
+            {
+              "global": false,
+              "help": "Cluster identity fingerprint from `kubectl config view`. Required with --release and --namespace to scope a connector secret to one cluster",
+              "id": "cluster_identity",
+              "long": "cluster-identity",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Helm release the secret may be injected into",
+              "id": "release",
+              "long": "release",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Kubernetes namespace the secret may be injected into",
+              "id": "namespace",
+              "long": "namespace",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Compare-and-set version from `curie secrets list --json`. Required to replace an existing cluster-scoped secret",
+              "id": "expected_version",
+              "long": "expected-version",
+              "positional": false,
+              "required": false
             }
           ],
           "hidden": false,
@@ -4034,6 +4066,30 @@
               "id": "name",
               "positional": true,
               "required": true
+            },
+            {
+              "global": false,
+              "help": "Cluster identity fingerprint. Required with --release and --namespace to remove one scoped entry without deleting the unscoped value",
+              "id": "cluster_identity",
+              "long": "cluster-identity",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Helm release of the scoped entry to remove",
+              "id": "release",
+              "long": "release",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Kubernetes namespace of the scoped entry to remove",
+              "id": "namespace",
+              "long": "namespace",
+              "positional": false,
+              "required": false
             }
           ],
           "hidden": false,

--- a/cli/schema/baseline/secrets.schema.json
+++ b/cli/schema/baseline/secrets.schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://schemas.curietech.ai/cli/secrets/v1.json",
+  "$id": "https://schemas.curietech.ai/cli/secrets/v1.1.json",
   "title": "curie secrets list --json",
-  "description": "The agent-facing payload of `curie secrets list`: the names of the secrets stored for the bundle. Only the names are ever emitted -- never a secret value.",
+  "description": "The agent-facing payload of `curie secrets list`: stored secret names and cluster-scope metadata. Values are never emitted.",
   "type": "object",
   "additionalProperties": false,
   "properties": {
@@ -10,6 +10,28 @@
       "type": "array",
       "items": {
         "type": "string"
+      }
+    },
+    "entries": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "name": { "type": "string" },
+          "scope": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "cluster_identity": { "type": "string" },
+              "release": { "type": "string" },
+              "namespace": { "type": "string" }
+            },
+            "required": ["cluster_identity", "release", "namespace"]
+          },
+          "version": { "type": ["integer", "null"], "minimum": 1 }
+        },
+        "required": ["name", "scope", "version"]
       }
     }
   },

--- a/cli/schema/index.json
+++ b/cli/schema/index.json
@@ -217,7 +217,7 @@
       "result": "SecretsListOutput",
       "kind": "CliOutput",
       "schema": "secrets.schema.json",
-      "version": "1.0"
+      "version": "1.1"
     },
     {
       "result": "SkillApprovalsOutput",

--- a/cli/schema/secrets.schema.json
+++ b/cli/schema/secrets.schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://schemas.curietech.ai/cli/secrets/v1.json",
+  "$id": "https://schemas.curietech.ai/cli/secrets/v1.1.json",
   "title": "curie secrets list --json",
-  "description": "The agent-facing payload of `curie secrets list`: the names of the secrets stored for the bundle. Only the names are ever emitted -- never a secret value.",
+  "description": "The agent-facing payload of `curie secrets list`: stored secret names and cluster-scope metadata. Values are never emitted.",
   "type": "object",
   "additionalProperties": false,
   "properties": {
@@ -10,6 +10,28 @@
       "type": "array",
       "items": {
         "type": "string"
+      }
+    },
+    "entries": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "name": { "type": "string" },
+          "scope": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "cluster_identity": { "type": "string" },
+              "release": { "type": "string" },
+              "namespace": { "type": "string" }
+            },
+            "required": ["cluster_identity", "release", "namespace"]
+          },
+          "version": { "type": ["integer", "null"], "minimum": 1 }
+        },
+        "required": ["name", "scope", "version"]
       }
     }
   },

--- a/cli/src/connectors.rs
+++ b/cli/src/connectors.rs
@@ -15,6 +15,8 @@
 //! nobody notices because nothing breaks.
 
 use std::collections::{BTreeMap, BTreeSet};
+use std::io::Write;
+use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use serde_json::Value;
@@ -199,6 +201,36 @@ pub fn get_secret_args(namespace: &str, name: &str) -> Vec<String> {
         "-o".into(),
         "json".into(),
     ]
+}
+
+/// A captured kubeconfig target. Connector reads and writes always name this
+/// snapshot explicitly, never a subsequently changed ambient context.
+#[derive(Clone, Debug)]
+pub struct ClusterTarget {
+    pub scope: SecretScope,
+    kubeconfig: Arc<tempfile::NamedTempFile>,
+}
+
+impl ClusterTarget {
+    fn args(&self, argv: &[String]) -> Vec<String> {
+        let mut result = vec![
+            "kubectl".into(),
+            "--kubeconfig".into(),
+            self.kubeconfig.path().display().to_string(),
+        ];
+        result.extend(argv.iter().skip(1).cloned());
+        result
+    }
+
+    async fn revalidate_ambient_binding(&self) -> Result<()> {
+        if discover_cluster_identity().await? != self.scope.cluster_identity {
+            anyhow::bail!(
+                "current kubectl context no longer matches the connector target {}; refusing to mutate the captured target",
+                self.scope.describe()
+            );
+        }
+        Ok(())
+    }
 }
 
 /// Fingerprint of the kube-apiserver this kubeconfig currently points at.
@@ -563,15 +595,25 @@ pub struct ConnectorSync {
 }
 
 /// Discover the release's rendered app name (the chart's nameOverride).
-pub async fn discover_app_name(namespace: &str, release: &str) -> Result<String> {
-    let (ok, out, err) = run(&app_name_args(namespace, release), None).await?;
+pub async fn discover_app_name(target: &ClusterTarget) -> Result<String> {
+    let (ok, out, err) = run(
+        &target.args(&app_name_args(
+            &target.scope.namespace,
+            &target.scope.release,
+        )),
+        None,
+    )
+    .await?;
     let name = out.trim();
     if !ok || name.is_empty() {
         anyhow::bail!(
-            "could not read the app name for release {release} in namespace {namespace}: no \
-             Deployment carries app.kubernetes.io/instance={release}. Connectors need it to \
+            "could not read the app name for release {} in namespace {}: no \
+             Deployment carries app.kubernetes.io/instance={}. Connectors need it to \
              target the sandbox pods Rail 1 denies by default. Confirm the release is installed \
              with `curie cluster status`.{}",
+            target.scope.release,
+            target.scope.namespace,
+            target.scope.release,
             if err.trim().is_empty() {
                 String::new()
             } else {
@@ -631,9 +673,18 @@ pub struct PreparedConnectorSync {
     secret_keys: Vec<String>,
     secret_sources: BTreeMap<String, String>,
     target: SecretScope,
+    bound_target: Option<ClusterTarget>,
 }
 
 impl PreparedConnectorSync {
+    pub fn bind_target(mut self, target: ClusterTarget) -> Result<Self> {
+        if self.target != target.scope {
+            anyhow::bail!("prepared connector scope does not match captured Kubernetes target");
+        }
+        self.bound_target = Some(target);
+        Ok(self)
+    }
+
     pub fn write_intent(&self) -> Option<String> {
         let secret_name = self.secret_name.as_deref()?;
         Some(write_intent_line(
@@ -663,6 +714,30 @@ pub async fn discover_cluster_identity() -> Result<String> {
     let view: Value = serde_json::from_str(&out)
         .context("parsing `kubectl config view --minify --raw -o json`")?;
     cluster_identity_from_kubeconfig_view(&view)
+}
+
+/// Snapshot the selected kubeconfig at prepare time. The private temporary file
+/// lives exactly as long as the connector plan that consumes it.
+pub async fn bind_current_cluster(namespace: &str, release: &str) -> Result<ClusterTarget> {
+    let (ok, out, err) = run(&kubeconfig_view_args(), None).await?;
+    if !ok {
+        anyhow::bail!("could not capture the current kubeconfig: {}", err.trim());
+    }
+    let view: Value = serde_json::from_str(&out)
+        .context("parsing `kubectl config view --minify --raw -o json`")?;
+    let cluster_identity = cluster_identity_from_kubeconfig_view(&view)?;
+    let mut kubeconfig = tempfile::NamedTempFile::new()
+        .context("creating private kubeconfig snapshot for connector deploy")?;
+    kubeconfig.write_all(out.as_bytes())?;
+    kubeconfig.flush()?;
+    Ok(ClusterTarget {
+        scope: SecretScope {
+            cluster_identity,
+            release: release.into(),
+            namespace: namespace.into(),
+        },
+        kubeconfig: Arc::new(kubeconfig),
+    })
 }
 
 /// Resolve and render an agent's connector objects without writing to kubectl.
@@ -716,6 +791,7 @@ pub fn prepare(
         secret_keys,
         secret_sources,
         target: target.clone(),
+        bound_target: None,
     })
 }
 
@@ -735,14 +811,16 @@ pub async fn sync(prepared: PreparedConnectorSync) -> Result<ConnectorSync> {
         secret_keys,
         secret_sources,
         target,
+        bound_target,
     } = prepared;
+    let bound_target = bound_target.context("connector sync has no captured Kubernetes target")?;
 
     if let Some(name) = secret_name.as_deref() {
         ui.note(&write_intent_line(name, &secret_keys, &target));
         for (key, source) in &secret_sources {
             ui.note(&format!("{key}: {source}"));
         }
-        let existing = inspect_secret_keys(&namespace, name).await;
+        let existing = inspect_secret_keys(&bound_target, &namespace, name).await?;
         let replaced = keys_being_replaced(&existing, &secret_keys);
         if !replaced.is_empty() {
             ui.warn(&replacement_warning_line(name, &replaced));
@@ -751,7 +829,8 @@ pub async fn sync(prepared: PreparedConnectorSync) -> Result<ConnectorSync> {
     }
 
     if let Some(doc) = apply_document {
-        let (ok, _out, err) = run(&apply_args(&namespace), Some(&doc)).await?;
+        bound_target.revalidate_ambient_binding().await?;
+        let (ok, _out, err) = run(&bound_target.args(&apply_args(&namespace)), Some(&doc)).await?;
         if !ok {
             anyhow::bail!("applying connectors failed: {}", err.trim());
         }
@@ -764,7 +843,12 @@ pub async fn sync(prepared: PreparedConnectorSync) -> Result<ConnectorSync> {
 
     // Runs even with nothing declared -- that is the case where a connector was
     // REMOVED, and the whole reason this is not a bare `kubectl apply`.
-    let (ok, _out, err) = run(&prune_args(&namespace, &agent_name, &keep), None).await?;
+    bound_target.revalidate_ambient_binding().await?;
+    let (ok, _out, err) = run(
+        &bound_target.args(&prune_args(&namespace, &agent_name, &keep)),
+        None,
+    )
+    .await?;
     if !ok {
         ui.warn(&format!(
             "connectors: pruning stale objects for {agent_name} failed: {}",
@@ -774,16 +858,22 @@ pub async fn sync(prepared: PreparedConnectorSync) -> Result<ConnectorSync> {
     Ok(result)
 }
 
-async fn inspect_secret_keys(namespace: &str, name: &str) -> BTreeSet<String> {
-    let (ok, out, _err) = match run(&get_secret_args(namespace, name), None).await {
-        Ok(result) => result,
-        Err(_) => return BTreeSet::new(),
-    };
+async fn inspect_secret_keys(
+    target: &ClusterTarget,
+    namespace: &str,
+    name: &str,
+) -> Result<BTreeSet<String>> {
+    let (ok, out, err) = run(&target.args(&get_secret_args(namespace, name)), None).await?;
     if !ok {
-        return BTreeSet::new();
+        if err.contains("NotFound") || err.contains("not found") {
+            return Ok(BTreeSet::new());
+        }
+        anyhow::bail!(
+            "could not inspect existing connector Secret {name}: {}; refusing to overwrite it",
+            err.trim()
+        );
     }
-    match serde_json::from_str::<Value>(&out) {
-        Ok(obj) => secret_key_names(&obj),
-        Err(_) => BTreeSet::new(),
-    }
+    let obj = serde_json::from_str::<Value>(&out)
+        .context("parsing existing connector Secret JSON; refusing to overwrite it")?;
+    Ok(secret_key_names(&obj))
 }

--- a/cli/src/connectors.rs
+++ b/cli/src/connectors.rs
@@ -14,8 +14,15 @@
 //! with a credential mounted and nothing referencing it -- the kind of leak
 //! nobody notices because nothing breaks.
 
+use std::collections::{BTreeMap, BTreeSet};
+
 use anyhow::{Context, Result};
 use serde_json::Value;
+use sha2::{Digest, Sha256};
+
+use crate::secrets::{
+    keys_being_replaced, replacement_warning_line, write_intent_line, SecretScope,
+};
 
 /// Marks every object this command owns, so pruning can find them again.
 pub const OWNER_LABEL: &str = "curie.dev/connector-owner";
@@ -165,6 +172,84 @@ pub fn app_name_args(namespace: &str, release: &str) -> Vec<String> {
         "-o".into(),
         r"jsonpath={.items[0].metadata.labels.app\.kubernetes\.io/name}".into(),
     ]
+}
+
+/// `kubectl` argv for the current kubeconfig's cluster identity material.
+pub fn kubeconfig_view_args() -> Vec<String> {
+    vec![
+        "kubectl".into(),
+        "config".into(),
+        "view".into(),
+        "--minify".into(),
+        "--raw".into(),
+        "-o".into(),
+        "json".into(),
+    ]
+}
+
+/// `kubectl` argv that lists a Secret without decoding its values on this side.
+pub fn get_secret_args(namespace: &str, name: &str) -> Vec<String> {
+    vec![
+        "kubectl".into(),
+        "-n".into(),
+        namespace.into(),
+        "get".into(),
+        "secret".into(),
+        name.into(),
+        "-o".into(),
+        "json".into(),
+    ]
+}
+
+/// Fingerprint of the kube-apiserver this kubeconfig currently points at.
+///
+/// SHA-256 of `server` plus CA material so two clusters with the same release
+/// name still differ. The digest is the stored identity; the raw CA PEM is never
+/// retained as the key.
+pub fn cluster_identity_from_kubeconfig_view(view: &Value) -> Result<String> {
+    let cluster = view
+        .get("clusters")
+        .and_then(|clusters| clusters.as_array())
+        .and_then(|clusters| clusters.first())
+        .and_then(|entry| entry.get("cluster"))
+        .ok_or_else(|| {
+            crate::exit::usage(
+                "kubectl config view returned no cluster; cannot scope connector secrets",
+            )
+        })?;
+    let server = cluster.get("server").and_then(Value::as_str).unwrap_or("");
+    let ca = cluster
+        .get("certificate-authority-data")
+        .and_then(Value::as_str)
+        .or_else(|| cluster.get("certificate-authority").and_then(Value::as_str))
+        .unwrap_or("");
+    if server.is_empty() && ca.is_empty() {
+        return Err(crate::exit::usage(
+            "kubectl config view has no server or certificate authority; cannot scope connector secrets",
+        ));
+    }
+    let mut hasher = Sha256::new();
+    hasher.update(server.as_bytes());
+    hasher.update(b"\n");
+    hasher.update(ca.as_bytes());
+    let digest = hasher
+        .finalize()
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect::<String>();
+    Ok(format!("ca:{digest}"))
+}
+
+/// Key names present on a live Secret object. Values (base64 or plaintext) are
+/// discarded so replacement detection cannot leak them into logs.
+pub fn secret_key_names(obj: &Value) -> BTreeSet<String> {
+    let mut keys = BTreeSet::new();
+    for field in ["data", "stringData"] {
+        if let Some(map) = obj.get(field).and_then(Value::as_object) {
+            keys.extend(map.keys().cloned());
+        }
+    }
+    keys
 }
 
 /// Serialize a manifest list as a single JSON `List` for one apply invocation.
@@ -326,6 +411,107 @@ mod tests {
         let args = apply_args("ns");
         assert_eq!(args.last().unwrap(), "-");
     }
+
+    #[test]
+    fn cluster_identity_changes_when_the_ca_changes() {
+        let a = json!({
+            "clusters": [{"cluster": {
+                "server": "https://cluster-a.example.com",
+                "certificate-authority-data": "Y2EtYQ=="
+            }}]
+        });
+        let b = json!({
+            "clusters": [{"cluster": {
+                "server": "https://cluster-b.example.com",
+                "certificate-authority-data": "Y2EtYg=="
+            }}]
+        });
+        let id_a = cluster_identity_from_kubeconfig_view(&a).unwrap();
+        let id_b = cluster_identity_from_kubeconfig_view(&b).unwrap();
+        assert!(id_a.starts_with("ca:"));
+        assert_ne!(id_a, id_b);
+        assert!(!id_a.contains("example.com"));
+        assert!(!id_a.contains("Y2Et"));
+    }
+
+    #[test]
+    fn secret_key_names_ignore_values() {
+        let obj = json!({
+            "data": {"K8S_WRITE_KUBECONFIG": "dG9rZW4tYQ=="},
+            "stringData": {"OTHER": "should-not-appear-as-a-logged-value"}
+        });
+        let keys = secret_key_names(&obj);
+        assert!(keys.contains("K8S_WRITE_KUBECONFIG"));
+        assert!(keys.contains("OTHER"));
+        let rendered = format!("{keys:?}");
+        assert!(!rendered.contains("dG9rZW4"));
+        assert!(!rendered.contains("should-not-appear"));
+    }
+
+    #[test]
+    fn get_secret_args_do_not_decode_values() {
+        let args = get_secret_args("curie", "acme-bot-connector-secrets");
+        assert!(args.contains(&"json".to_string()));
+        assert!(!args.iter().any(|a| a.contains("go-template")));
+    }
+
+    fn with_isolated_store<T>(body: impl FnOnce() -> T) -> T {
+        let _lock = crate::PROCESS_ENV_LOCK.lock().expect("env lock");
+        let dir = tempfile::tempdir().unwrap();
+        let previous = std::env::var_os("CURIE_CONFIG_DIR");
+        std::env::set_var("CURIE_CONFIG_DIR", dir.path());
+        let result = body();
+        match previous {
+            Some(value) => std::env::set_var("CURIE_CONFIG_DIR", value),
+            None => std::env::remove_var("CURIE_CONFIG_DIR"),
+        }
+        result
+    }
+
+    #[test]
+    fn prepare_writes_the_matching_cluster_secret_and_refuses_the_other() {
+        with_isolated_store(|| {
+            let a = SecretScope {
+                cluster_identity: "ca:a".into(),
+                release: "curie".into(),
+                namespace: "curie-test".into(),
+            };
+            let b = SecretScope {
+                cluster_identity: "ca:b".into(),
+                release: "curie".into(),
+                namespace: "curie".into(),
+            };
+            crate::secrets::save_scoped_value("K8S_WRITE_KUBECONFIG", &a, "token-a", None).unwrap();
+            let prepared = prepare(
+                &[],
+                &BTreeMap::new(),
+                "acme-bot-connector-secrets",
+                &["K8S_WRITE_KUBECONFIG".to_string()],
+                &a,
+                "acme-bot",
+            )
+            .unwrap();
+            let intent = prepared.write_intent().unwrap();
+            assert!(intent.contains("K8S_WRITE_KUBECONFIG"));
+            assert!(!intent.contains("token-a"));
+            assert_eq!(
+                prepared.source_lines(),
+                vec!["K8S_WRITE_KUBECONFIG: scoped stored secret (version 1)".to_string()]
+            );
+            let err = prepare(
+                &[],
+                &BTreeMap::new(),
+                "acme-bot-connector-secrets",
+                &["K8S_WRITE_KUBECONFIG".to_string()],
+                &b,
+                "acme-bot",
+            )
+            .unwrap_err()
+            .to_string();
+            assert!(err.contains("refusing to inject"));
+            assert!(!err.contains("token-a"));
+        });
+    }
 }
 
 // --------------------------------------------------------------------------- #
@@ -369,7 +555,11 @@ async fn run(argv: &[String], stdin: Option<&str>) -> Result<(bool, String, Stri
 #[derive(Debug, Default)]
 pub struct ConnectorSync {
     pub applied: Vec<String>,
-    pub urls: std::collections::BTreeMap<String, String>,
+    pub urls: BTreeMap<String, String>,
+    /// Connector secret keys this deploy wrote. Names only, never values.
+    pub written_keys: Vec<String>,
+    /// Live Secret keys this deploy is replacing. Names only, never values.
+    pub replaced_keys: Vec<String>,
 }
 
 /// Discover the release's rendered app name (the chart's nameOverride).
@@ -392,62 +582,116 @@ pub async fn discover_app_name(namespace: &str, release: &str) -> Result<String>
     Ok(name.to_string())
 }
 
-/// Resolve each declared credential: environment first, then the host vault.
+/// Resolve each declared credential against the cluster target.
 ///
-/// Fails naming every gap at once rather than one per run. A connector that
-/// starts without its credential does not fail at apply -- it comes up and
-/// returns 401s to the agent, which reads as "the tool is broken".
-fn resolve_secret_values(keys: &[String]) -> Result<std::collections::BTreeMap<String, String>> {
-    let mut values = std::collections::BTreeMap::new();
+/// A matching scoped store entry is required once anything is stored under that
+/// name. Process environment is a first-run fallback only when the store has no
+/// entry at all, and the source is returned so deploy can say so without printing
+/// the value. Fails naming every gap at once rather than one per run.
+fn resolve_secret_values(
+    keys: &[String],
+    target: &SecretScope,
+) -> Result<(BTreeMap<String, String>, BTreeMap<String, String>)> {
+    let mut values = BTreeMap::new();
+    let mut sources = BTreeMap::new();
     let mut missing = Vec::new();
     for k in keys {
-        match crate::secrets::resolve_env_or_saved(k)? {
-            Some(v) => {
-                values.insert(k.clone(), v);
+        match crate::secrets::resolve_cluster_secret(k, target)? {
+            Some(resolved) => {
+                sources.insert(k.clone(), resolved.source_label());
+                values.insert(k.clone(), resolved.value);
             }
             None => missing.push(k.clone()),
         }
     }
     if !missing.is_empty() {
         return Err(crate::exit::usage(format!(
-            "connectors.yaml declares secret(s) with no value available: {}. Export each in the \
-             environment, or store it once with `curie secrets set <NAME>`.",
-            missing.join(", ")
+            "connectors.yaml declares secret(s) with no value available for {}: {}. Export each in \
+             the environment, or store it for this target with `curie secrets set <NAME> \
+             --from-env <NAME> --cluster-identity {} --release {} --namespace {}`.",
+            target.describe(),
+            missing.join(", "),
+            target.cluster_identity,
+            target.release,
+            target.namespace
         )));
     }
-    Ok(values)
+    Ok((values, sources))
 }
 
 /// An agent's fully resolved connector synchronization plan.
+#[derive(Debug)]
 pub struct PreparedConnectorSync {
     namespace: String,
     agent_name: String,
     keep: Vec<String>,
     apply_document: Option<String>,
     result: ConnectorSync,
+    secret_name: Option<String>,
+    secret_keys: Vec<String>,
+    secret_sources: BTreeMap<String, String>,
+    target: SecretScope,
+}
+
+impl PreparedConnectorSync {
+    pub fn write_intent(&self) -> Option<String> {
+        let secret_name = self.secret_name.as_deref()?;
+        Some(write_intent_line(
+            secret_name,
+            &self.secret_keys,
+            &self.target,
+        ))
+    }
+
+    pub fn source_lines(&self) -> Vec<String> {
+        self.secret_sources
+            .iter()
+            .map(|(key, source)| format!("{key}: {source}"))
+            .collect()
+    }
+}
+
+/// Discover the current kubeconfig's cluster identity.
+pub async fn discover_cluster_identity() -> Result<String> {
+    let (ok, out, err) = run(&kubeconfig_view_args(), None).await?;
+    if !ok {
+        anyhow::bail!(
+            "could not read the current kubeconfig cluster identity: {}",
+            err.trim()
+        );
+    }
+    let view: Value = serde_json::from_str(&out)
+        .context("parsing `kubectl config view --minify --raw -o json`")?;
+    cluster_identity_from_kubeconfig_view(&view)
 }
 
 /// Resolve and render an agent's connector objects without writing to kubectl.
 pub fn prepare(
     manifests: &[Value],
-    mcp_entries: &std::collections::BTreeMap<String, Value>,
+    mcp_entries: &BTreeMap<String, Value>,
     owned_secret_name: &str,
     owned_secret_keys: &[String],
-    namespace: &str,
+    target: &SecretScope,
     agent_name: &str,
 ) -> Result<PreparedConnectorSync> {
     let mut objects = Vec::new();
+    let mut secret_name = None;
+    let mut secret_keys = Vec::new();
+    let mut secret_sources = BTreeMap::new();
 
-    if let Some((secret_name, keys)) = owned_secret(owned_secret_name, owned_secret_keys) {
-        objects.push(render_secret(
-            &secret_name,
-            namespace,
-            &resolve_secret_values(&keys)?,
-        ));
+    if let Some((name, keys)) = owned_secret(owned_secret_name, owned_secret_keys) {
+        let (values, sources) = resolve_secret_values(&keys, target)?;
+        objects.push(render_secret(&name, &target.namespace, &values));
+        secret_name = Some(name);
+        secret_keys = keys;
+        secret_sources = sources;
     }
     objects.extend_from_slice(manifests);
 
-    let mut result = ConnectorSync::default();
+    let mut result = ConnectorSync {
+        written_keys: secret_keys.clone(),
+        ..Default::default()
+    };
     for (name, entry) in mcp_entries {
         if let Some(url) = entry.get("url").and_then(|u| u.as_str()) {
             result.urls.insert(name.clone(), url.to_string());
@@ -463,11 +707,15 @@ pub fn prepare(
     };
 
     Ok(PreparedConnectorSync {
-        namespace: namespace.to_string(),
+        namespace: target.namespace.clone(),
         agent_name: agent_name.to_string(),
         keep,
         apply_document,
         result,
+        secret_name,
+        secret_keys,
+        secret_sources,
+        target: target.clone(),
     })
 }
 
@@ -483,7 +731,24 @@ pub async fn sync(prepared: PreparedConnectorSync) -> Result<ConnectorSync> {
         keep,
         apply_document,
         mut result,
+        secret_name,
+        secret_keys,
+        secret_sources,
+        target,
     } = prepared;
+
+    if let Some(name) = secret_name.as_deref() {
+        ui.note(&write_intent_line(name, &secret_keys, &target));
+        for (key, source) in &secret_sources {
+            ui.note(&format!("{key}: {source}"));
+        }
+        let existing = inspect_secret_keys(&namespace, name).await;
+        let replaced = keys_being_replaced(&existing, &secret_keys);
+        if !replaced.is_empty() {
+            ui.warn(&replacement_warning_line(name, &replaced));
+        }
+        result.replaced_keys = replaced;
+    }
 
     if let Some(doc) = apply_document {
         let (ok, _out, err) = run(&apply_args(&namespace), Some(&doc)).await?;
@@ -507,4 +772,18 @@ pub async fn sync(prepared: PreparedConnectorSync) -> Result<ConnectorSync> {
         ));
     }
     Ok(result)
+}
+
+async fn inspect_secret_keys(namespace: &str, name: &str) -> BTreeSet<String> {
+    let (ok, out, _err) = match run(&get_secret_args(namespace, name), None).await {
+        Ok(result) => result,
+        Err(_) => return BTreeSet::new(),
+    };
+    if !ok {
+        return BTreeSet::new();
+    }
+    match serde_json::from_str::<Value>(&out) {
+        Ok(obj) => secret_key_names(&obj),
+        Err(_) => BTreeSet::new(),
+    }
 }

--- a/cli/src/interactive.rs
+++ b/cli/src/interactive.rs
@@ -449,8 +449,8 @@ fn run_tui_action(
             if confirm != name {
                 return Ok("Remove secret canceled.".to_string());
             }
-            crate::secrets::remove_value(&name)?;
-            Ok(format!("Removed {name}."))
+            crate::secrets::remove_all_values(&name)?;
+            Ok(format!("Removed all stored entries for {name}."))
         }
     }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -119,7 +119,8 @@ async fn sync_connectors(
     agent_name: &str,
     version_id: &str,
 ) -> anyhow::Result<()> {
-    let app_name = curie::connectors::discover_app_name(namespace, release).await?;
+    let target = curie::connectors::bind_current_cluster(namespace, release).await?;
+    let app_name = curie::connectors::discover_app_name(&target).await?;
     let connector_version = ConnectorVersion {
         agent_id,
         agent_name,
@@ -132,21 +133,10 @@ async fn sync_connectors(
         release,
         &app_name,
         connector_version,
+        target,
     )
     .await?;
     apply_connectors(prepared).await
-}
-
-fn cluster_secret_scope(
-    namespace: &str,
-    release: &str,
-    cluster_identity: String,
-) -> secrets::SecretScope {
-    secrets::SecretScope {
-        cluster_identity,
-        release: release.to_string(),
-        namespace: namespace.to_string(),
-    }
 }
 
 struct ConnectorVersion<'a> {
@@ -162,9 +152,8 @@ async fn prepare_connectors(
     release: &str,
     app_name: &str,
     connector_version: ConnectorVersion<'_>,
+    target: curie::connectors::ClusterTarget,
 ) -> anyhow::Result<curie::connectors::PreparedConnectorSync> {
-    let cluster_identity = curie::connectors::discover_cluster_identity().await?;
-    let target = cluster_secret_scope(namespace, release, cluster_identity);
     let client = curie::api::ApiClient::new(api_url, api_key)?;
     let rendered = client
         .version_connectors(
@@ -180,9 +169,10 @@ async fn prepare_connectors(
         &rendered.mcp_entries,
         &rendered.owned_secret_name,
         &rendered.owned_secret_keys,
-        &target,
+        &target.scope,
         connector_version.agent_name,
-    )
+    )?
+    .bind_target(target)
 }
 
 async fn apply_connectors(
@@ -3302,8 +3292,21 @@ async fn run(command: Option<Command>) -> Result<()> {
                         .cloned()
                         .flatten()
                         .expect("all target entries always have a target name");
+                    let connector_target =
+                        match curie::connectors::bind_current_cluster(&namespace, &release).await {
+                            Ok(target) => target,
+                            Err(err) => {
+                                let payload = commands::all_targets_deploy_failure_json(
+                                    &first_target,
+                                    &[],
+                                    None,
+                                    &err,
+                                );
+                                return Err(curie::exit::with_json_payload(err, payload));
+                            }
+                        };
                     let app_name =
-                        match curie::connectors::discover_app_name(&namespace, &release).await {
+                        match curie::connectors::discover_app_name(&connector_target).await {
                             Ok(app_name) => app_name,
                             Err(err) => {
                                 let payload = commands::all_targets_deploy_failure_json(
@@ -3361,6 +3364,7 @@ async fn run(command: Option<Command>) -> Result<()> {
                             &release,
                             &app_name,
                             connector_version,
+                            connector_target.clone(),
                         )
                         .await
                         {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -137,6 +137,18 @@ async fn sync_connectors(
     apply_connectors(prepared).await
 }
 
+fn cluster_secret_scope(
+    namespace: &str,
+    release: &str,
+    cluster_identity: String,
+) -> secrets::SecretScope {
+    secrets::SecretScope {
+        cluster_identity,
+        release: release.to_string(),
+        namespace: namespace.to_string(),
+    }
+}
+
 struct ConnectorVersion<'a> {
     agent_id: &'a str,
     agent_name: &'a str,
@@ -151,6 +163,8 @@ async fn prepare_connectors(
     app_name: &str,
     connector_version: ConnectorVersion<'_>,
 ) -> anyhow::Result<curie::connectors::PreparedConnectorSync> {
+    let cluster_identity = curie::connectors::discover_cluster_identity().await?;
+    let target = cluster_secret_scope(namespace, release, cluster_identity);
     let client = curie::api::ApiClient::new(api_url, api_key)?;
     let rendered = client
         .version_connectors(
@@ -166,7 +180,7 @@ async fn prepare_connectors(
         &rendered.mcp_entries,
         &rendered.owned_secret_name,
         &rendered.owned_secret_keys,
-        namespace,
+        &target,
         connector_version.agent_name,
     )
 }
@@ -678,6 +692,20 @@ enum SecretsAction {
         /// Read the value from another environment variable instead of prompting.
         #[arg(long)]
         from_env: Option<String>,
+        /// Cluster identity fingerprint from `kubectl config view`. Required with
+        /// --release and --namespace to scope a connector secret to one cluster.
+        #[arg(long)]
+        cluster_identity: Option<String>,
+        /// Helm release the secret may be injected into.
+        #[arg(long)]
+        release: Option<String>,
+        /// Kubernetes namespace the secret may be injected into.
+        #[arg(long)]
+        namespace: Option<String>,
+        /// Compare-and-set version from `curie secrets list --json`. Required to
+        /// replace an existing cluster-scoped secret.
+        #[arg(long)]
+        expected_version: Option<u64>,
     },
     /// List saved Curie secret names. Values are never printed.
     List,
@@ -685,6 +713,16 @@ enum SecretsAction {
     Unset {
         /// Environment-variable-style secret name.
         name: String,
+        /// Cluster identity fingerprint. Required with --release and --namespace
+        /// to remove one scoped entry without deleting the unscoped value.
+        #[arg(long)]
+        cluster_identity: Option<String>,
+        /// Helm release of the scoped entry to remove.
+        #[arg(long)]
+        release: Option<String>,
+        /// Kubernetes namespace of the scoped entry to remove.
+        #[arg(long)]
+        namespace: Option<String>,
     },
 }
 
@@ -2149,11 +2187,33 @@ async fn run(command: Option<Command>) -> Result<()> {
         Some(Command::Update { image }) => commands::update(image).await,
         Some(Command::Interactive) => curie::interactive::run().await,
         Some(Command::Secrets { action }) => match action {
-            SecretsAction::Set { name, from_env } => {
-                secrets::set(secrets::SetSecretOpts { name, from_env })
-            }
+            SecretsAction::Set {
+                name,
+                from_env,
+                cluster_identity,
+                release,
+                namespace,
+                expected_version,
+            } => secrets::set(secrets::SetSecretOpts {
+                name,
+                from_env,
+                cluster_identity,
+                namespace,
+                release,
+                expected_version,
+            }),
             SecretsAction::List => secrets::list(),
-            SecretsAction::Unset { name } => secrets::unset(secrets::UnsetSecretOpts { name }),
+            SecretsAction::Unset {
+                name,
+                cluster_identity,
+                release,
+                namespace,
+            } => secrets::unset(secrets::UnsetSecretOpts {
+                name,
+                cluster_identity,
+                namespace,
+                release,
+            }),
         },
         Some(Command::Dev { action }) => match action {
             DevAction::Contracts => commands::dev_script("scripts/check-contracts.sh", &[]).await,
@@ -4124,6 +4184,33 @@ mod tests {
             cli.command,
             Some(Command::Secrets {
                 action: SecretsAction::Unset { .. }
+            })
+        ));
+        let cli = Cli::try_parse_from([
+            "curie",
+            "secrets",
+            "set",
+            "K8S_WRITE_KUBECONFIG",
+            "--from-env",
+            "K8S_WRITE_KUBECONFIG",
+            "--cluster-identity",
+            "ca:a",
+            "--release",
+            "curie",
+            "--namespace",
+            "curie-test",
+            "--expected-version",
+            "1",
+        ])
+        .expect("scoped secrets set should parse");
+        assert!(matches!(
+            cli.command,
+            Some(Command::Secrets {
+                action: SecretsAction::Set {
+                    cluster_identity: Some(_),
+                    expected_version: Some(1),
+                    ..
+                }
             })
         ));
     }

--- a/cli/src/secrets.rs
+++ b/cli/src/secrets.rs
@@ -443,6 +443,11 @@ fn conflict(message: String, fix: &str) -> anyhow::Error {
 }
 
 impl SecretVault {
+    fn remove_all(&mut self, name: &str) {
+        self.values.remove(name);
+        self.scoped.remove(name);
+    }
+
     fn has_name(&self, name: &str) -> bool {
         self.values.contains_key(name)
             || self
@@ -648,6 +653,16 @@ pub fn delete_value(name: &str) -> Result<()> {
 pub fn remove_value(name: &str) -> Result<()> {
     validate_name(name)?;
     delete_value(name)?;
+    remove_from_index(name)
+}
+
+/// Remove every scope for a name. The interactive TUI has no scope picker, so
+/// it must remove all matching entries rather than claim a partial success.
+pub fn remove_all_values(name: &str) -> Result<()> {
+    validate_name(name)?;
+    let mut credentials = read_credentials()?;
+    credentials.remove_all(name);
+    write_credentials(&credentials)?;
     remove_from_index(name)
 }
 
@@ -1114,6 +1129,22 @@ mod tests {
             serde_json::from_str(r#"{"values":{"ANTHROPIC_API_KEY":"x"}}"#).unwrap();
         assert_eq!(decoded.values.get("ANTHROPIC_API_KEY").unwrap(), "x");
         assert!(decoded.scoped.is_empty());
+    }
+
+    #[test]
+    fn tui_all_scope_removal_cannot_leave_a_scoped_entry() {
+        let mut vault = SecretVault::default();
+        let scope = SecretScope {
+            cluster_identity: "ca:a".into(),
+            release: "curie".into(),
+            namespace: "curie-test".into(),
+        };
+        vault
+            .save_scoped("K8S_WRITE_KUBECONFIG", &scope, "token-a", None)
+            .unwrap();
+        vault.remove_all("K8S_WRITE_KUBECONFIG");
+        assert!(!vault.has_name("K8S_WRITE_KUBECONFIG"));
+        assert!(vault.scoped_entries("K8S_WRITE_KUBECONFIG").is_empty());
     }
 
     #[cfg(unix)]

--- a/cli/src/secrets.rs
+++ b/cli/src/secrets.rs
@@ -20,11 +20,64 @@ const VAULT_ACCOUNT: &str = "curie:global:vault";
 pub struct SetSecretOpts {
     pub name: String,
     pub from_env: Option<String>,
+    pub cluster_identity: Option<String>,
+    pub namespace: Option<String>,
+    pub release: Option<String>,
+    pub expected_version: Option<u64>,
 }
 
 #[derive(Clone, Debug)]
 pub struct UnsetSecretOpts {
     pub name: String,
+    pub cluster_identity: Option<String>,
+    pub namespace: Option<String>,
+    pub release: Option<String>,
+}
+
+/// The cluster target a stored connector secret is allowed to be injected into.
+///
+/// Issue #1913: name-only storage lets `curie cluster deploy` reuse cluster A's
+/// credential on cluster B. Identity is a fingerprint of the kube-apiserver URL
+/// plus CA material, not a human cluster name.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct SecretScope {
+    pub cluster_identity: String,
+    pub release: String,
+    pub namespace: String,
+}
+
+impl SecretScope {
+    pub fn describe(&self) -> String {
+        format!(
+            "cluster {} release {} namespace {}",
+            self.cluster_identity, self.release, self.namespace
+        )
+    }
+}
+
+/// How a cluster-deploy secret was resolved. Never carries the value in
+/// operator-facing descriptions.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ClusterSecretSource {
+    Scoped { version: u64 },
+    Environment,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ResolvedClusterSecret {
+    pub value: String,
+    pub source: ClusterSecretSource,
+}
+
+impl ResolvedClusterSecret {
+    pub fn source_label(&self) -> String {
+        match self.source {
+            ClusterSecretSource::Scoped { version } => {
+                format!("scoped stored secret (version {version})")
+            }
+            ClusterSecretSource::Environment => "process environment".to_string(),
+        }
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]
@@ -39,8 +92,29 @@ struct SecretIndex {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]
+struct ScopedSecret {
+    cluster_identity: String,
+    release: String,
+    namespace: String,
+    value: String,
+    version: u64,
+}
+
+impl ScopedSecret {
+    fn scope(&self) -> SecretScope {
+        SecretScope {
+            cluster_identity: self.cluster_identity.clone(),
+            release: self.release.clone(),
+            namespace: self.namespace.clone(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
 struct SecretVault {
     values: BTreeMap<String, String>,
+    #[serde(default)]
+    scoped: BTreeMap<String, Vec<ScopedSecret>>,
 }
 
 #[derive(Default)]
@@ -58,44 +132,144 @@ pub fn set(opts: SetSecretOpts) -> Result<()> {
             .with_context(|| format!("{var} is not set; cannot save {}", opts.name))?,
         None => prompt_secret(&opts.name)?,
     };
-    save_value(&opts.name, &value)?;
-    crate::ui::ui().success(&format!("saved {} in Curie private storage", opts.name));
+    match optional_scope(
+        opts.cluster_identity,
+        opts.release,
+        opts.namespace,
+        "secrets set",
+    )? {
+        Some(scope) => {
+            let version = save_scoped_value(&opts.name, &scope, &value, opts.expected_version)?;
+            crate::ui::ui().success(&format!(
+                "saved {} for {} (version {version})",
+                opts.name,
+                scope.describe()
+            ));
+        }
+        None => {
+            if opts.expected_version.is_some() {
+                return Err(crate::exit::usage(
+                    "--expected-version applies to cluster-scoped secrets; pass --cluster-identity, --release, and --namespace",
+                ));
+            }
+            save_value(&opts.name, &value)?;
+            crate::ui::ui().success(&format!("saved {} in Curie private storage", opts.name));
+        }
+    }
     Ok(())
 }
 
 pub fn list() -> Result<()> {
-    crate::ui::ui().emit(&SecretsListOutput {
-        names: list_names()?,
-    });
+    crate::ui::ui().emit(&list_output()?);
     Ok(())
 }
 
-/// Output of `secrets list` (#474): the saved secret NAMEs. Routes through the
-/// one `Ui::emit` point rather than an inline `if json()` branch. Public so the
-/// schema contract test (#634) can build one and validate `to_json` against
-/// `cli/schema/secrets.schema.json`.
+/// Output of `secrets list` (#474): the saved secret NAMEs plus cluster scope
+/// metadata. Values are never emitted. Routes through the one `Ui::emit` point.
 pub struct SecretsListOutput {
     pub names: Vec<String>,
+    pub entries: Vec<SecretListEntry>,
+}
+
+/// One stored secret listing. `scope` is absent for install-global (skill/local)
+/// values; cluster-scoped entries carry identity/release/namespace and version.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SecretListEntry {
+    pub name: String,
+    pub scope: Option<SecretScope>,
+    pub version: Option<u64>,
 }
 
 impl crate::ui::CliOutput for SecretsListOutput {
     fn to_json(&self) -> serde_json::Value {
-        serde_json::json!({ "secrets": self.names })
+        serde_json::json!({
+            "secrets": self.names,
+            "entries": self.entries.iter().map(|entry| {
+                match &entry.scope {
+                    Some(scope) => serde_json::json!({
+                        "name": entry.name,
+                        "scope": {
+                            "cluster_identity": scope.cluster_identity,
+                            "release": scope.release,
+                            "namespace": scope.namespace,
+                        },
+                        "version": entry.version,
+                    }),
+                    None => serde_json::json!({
+                        "name": entry.name,
+                        "scope": null,
+                        "version": null,
+                    }),
+                }
+            }).collect::<Vec<_>>(),
+        })
     }
 
     fn render(&self, ui: &crate::ui::Ui) {
-        if self.names.is_empty() {
+        if self.entries.is_empty() {
             ui.note("no Curie secrets saved");
-        } else {
-            ui.payload_plain(&self.names.join("\n"));
+            return;
         }
+        let lines: Vec<String> = self
+            .entries
+            .iter()
+            .map(|entry| match &entry.scope {
+                Some(scope) => format!(
+                    "{}  {}  version {}",
+                    entry.name,
+                    scope.describe(),
+                    entry.version.unwrap_or(0)
+                ),
+                None => format!("{}  (unscoped)", entry.name),
+            })
+            .collect();
+        ui.payload_plain(&lines.join("\n"));
     }
 }
 
 pub fn unset(opts: UnsetSecretOpts) -> Result<()> {
-    remove_value(&opts.name)?;
-    crate::ui::ui().success(&format!("removed {}", opts.name));
+    match optional_scope(
+        opts.cluster_identity,
+        opts.release,
+        opts.namespace,
+        "secrets unset",
+    )? {
+        Some(scope) => {
+            remove_scoped_value(&opts.name, &scope)?;
+            crate::ui::ui().success(&format!("removed {} for {}", opts.name, scope.describe()));
+        }
+        None => {
+            remove_value(&opts.name)?;
+            crate::ui::ui().success(&format!("removed {}", opts.name));
+        }
+    }
     Ok(())
+}
+
+fn optional_scope(
+    cluster_identity: Option<String>,
+    release: Option<String>,
+    namespace: Option<String>,
+    verb: &str,
+) -> Result<Option<SecretScope>> {
+    match (cluster_identity, release, namespace) {
+        (None, None, None) => Ok(None),
+        (Some(cluster_identity), Some(release), Some(namespace)) => {
+            if cluster_identity.is_empty() || release.is_empty() || namespace.is_empty() {
+                return Err(crate::exit::usage(format!(
+                    "{verb} cluster scope requires non-empty --cluster-identity, --release, and --namespace"
+                )));
+            }
+            Ok(Some(SecretScope {
+                cluster_identity,
+                release,
+                namespace,
+            }))
+        }
+        _ => Err(crate::exit::usage(format!(
+            "{verb} cluster scope requires --cluster-identity, --release, and --namespace together"
+        ))),
+    }
 }
 
 pub fn get_value(name: &str) -> Result<Option<String>> {
@@ -201,6 +375,267 @@ pub fn save_value(name: &str, value: &str) -> Result<()> {
     add_to_index(name)
 }
 
+pub fn save_scoped_value(
+    name: &str,
+    scope: &SecretScope,
+    value: &str,
+    expected_version: Option<u64>,
+) -> Result<u64> {
+    validate_name(name)?;
+    if value.is_empty() {
+        bail!("refusing to store an empty secret for {name}");
+    }
+    let mut credentials = read_credentials()?;
+    let version = credentials.save_scoped(name, scope, value, expected_version)?;
+    write_credentials(&credentials)?;
+    add_to_index(name)?;
+    Ok(version)
+}
+
+pub fn remove_scoped_value(name: &str, scope: &SecretScope) -> Result<()> {
+    validate_name(name)?;
+    let mut credentials = read_credentials()?;
+    credentials.remove_scoped(name, scope);
+    write_credentials(&credentials)?;
+    if !credentials.has_name(name) {
+        remove_from_index(name)?;
+    }
+    Ok(())
+}
+
+/// Resolve a connector secret for a cluster deploy target.
+///
+/// A matching scoped store entry wins. A stored entry for this name that does
+/// not match the target (including an unscoped value) is a refusal, not a
+/// fallback. Process environment is used only when the store has no entry for
+/// the name at all, and the caller must surface that source.
+pub fn resolve_cluster_secret(
+    name: &str,
+    target: &SecretScope,
+) -> Result<Option<ResolvedClusterSecret>> {
+    validate_name(name)?;
+    let credentials = match config_dir() {
+        Ok(_) => read_credentials()?,
+        // A deploy with only process-environment values (CI, HOME unset) has no
+        // host vault to consult. An absent config dir is an empty store, not a
+        // failure to resolve the env fallback.
+        Err(_) => SecretVault::default(),
+    };
+    match credentials.resolve_cluster(name, target)? {
+        Some(resolved) => Ok(Some(resolved)),
+        None => Ok(std::env::var(name)
+            .ok()
+            .filter(|value| !value.is_empty())
+            .map(|value| ResolvedClusterSecret {
+                value,
+                source: ClusterSecretSource::Environment,
+            })),
+    }
+}
+
+pub fn list_output() -> Result<SecretsListOutput> {
+    let credentials = read_credentials()?;
+    Ok(credentials.list_output())
+}
+
+fn conflict(message: String, fix: &str) -> anyhow::Error {
+    anyhow::Error::from(crate::exit::CliError::failure(message).with_fix(fix.to_string()))
+}
+
+impl SecretVault {
+    fn has_name(&self, name: &str) -> bool {
+        self.values.contains_key(name)
+            || self
+                .scoped
+                .get(name)
+                .is_some_and(|entries| !entries.is_empty())
+    }
+
+    fn scoped_entries(&self, name: &str) -> &[ScopedSecret] {
+        self.scoped.get(name).map(Vec::as_slice).unwrap_or(&[])
+    }
+
+    fn lookup_scoped(&self, name: &str, target: &SecretScope) -> Option<&ScopedSecret> {
+        self.scoped_entries(name)
+            .iter()
+            .find(|entry| entry.scope() == *target)
+    }
+
+    fn other_scopes(&self, name: &str, target: &SecretScope) -> Vec<SecretScope> {
+        self.scoped_entries(name)
+            .iter()
+            .map(ScopedSecret::scope)
+            .filter(|scope| scope != target)
+            .collect()
+    }
+
+    fn resolve_cluster(
+        &self,
+        name: &str,
+        target: &SecretScope,
+    ) -> Result<Option<ResolvedClusterSecret>> {
+        if let Some(entry) = self.lookup_scoped(name, target) {
+            return Ok(Some(ResolvedClusterSecret {
+                value: entry.value.clone(),
+                source: ClusterSecretSource::Scoped {
+                    version: entry.version,
+                },
+            }));
+        }
+        let others = self.other_scopes(name, target);
+        if !others.is_empty() {
+            return Err(mismatch_error(name, target, &others));
+        }
+        if self.values.contains_key(name) {
+            return Err(unscoped_error(name, target));
+        }
+        Ok(None)
+    }
+
+    fn save_scoped(
+        &mut self,
+        name: &str,
+        scope: &SecretScope,
+        value: &str,
+        expected_version: Option<u64>,
+    ) -> Result<u64> {
+        let entries = self.scoped.entry(name.to_string()).or_default();
+        let existing = entries.iter().position(|entry| entry.scope() == *scope);
+        match existing {
+            Some(index) => {
+                let stored = entries[index].version;
+                if expected_version != Some(stored) {
+                    return Err(conflict(
+                        format!(
+                            "version mismatch: expected {}, stored {stored}",
+                            expected_version
+                                .map(|v| v.to_string())
+                                .unwrap_or_else(|| "none".to_string())
+                        ),
+                        "re-run `curie secrets list --json` and pass the stored version as --expected-version",
+                    ));
+                }
+                entries[index].value = value.to_string();
+                entries[index].version = stored + 1;
+                Ok(entries[index].version)
+            }
+            None => {
+                if expected_version.is_some() {
+                    return Err(conflict(
+                        "version mismatch: entry does not exist yet".to_string(),
+                        "omit --expected-version when saving a secret for a new cluster target",
+                    ));
+                }
+                entries.push(ScopedSecret {
+                    cluster_identity: scope.cluster_identity.clone(),
+                    release: scope.release.clone(),
+                    namespace: scope.namespace.clone(),
+                    value: value.to_string(),
+                    version: 1,
+                });
+                Ok(1)
+            }
+        }
+    }
+
+    fn remove_scoped(&mut self, name: &str, scope: &SecretScope) {
+        if let Some(entries) = self.scoped.get_mut(name) {
+            entries.retain(|entry| entry.scope() != *scope);
+            if entries.is_empty() {
+                self.scoped.remove(name);
+            }
+        }
+    }
+
+    fn list_output(&self) -> SecretsListOutput {
+        let mut names = BTreeSet::new();
+        let mut entries = Vec::new();
+        for name in self.values.keys() {
+            names.insert(name.clone());
+            entries.push(SecretListEntry {
+                name: name.clone(),
+                scope: None,
+                version: None,
+            });
+        }
+        for (name, scoped) in &self.scoped {
+            names.insert(name.clone());
+            for entry in scoped {
+                entries.push(SecretListEntry {
+                    name: name.clone(),
+                    scope: Some(entry.scope()),
+                    version: Some(entry.version),
+                });
+            }
+        }
+        entries.sort_by(|a, b| {
+            a.name.cmp(&b.name).then_with(|| {
+                a.scope
+                    .as_ref()
+                    .map(SecretScope::describe)
+                    .cmp(&b.scope.as_ref().map(SecretScope::describe))
+            })
+        });
+        SecretsListOutput {
+            names: names.into_iter().collect(),
+            entries,
+        }
+    }
+}
+
+pub fn mismatch_error(name: &str, target: &SecretScope, existing: &[SecretScope]) -> anyhow::Error {
+    let recorded = existing
+        .iter()
+        .map(SecretScope::describe)
+        .collect::<Vec<_>>()
+        .join("; ");
+    crate::exit::usage(format!(
+        "stored secret {name} is scoped to {recorded}; refusing to inject it into {}. Save a value for this target with `curie secrets set {name} --from-env {name} --cluster-identity {} --release {} --namespace {}`",
+        target.describe(),
+        target.cluster_identity,
+        target.release,
+        target.namespace
+    ))
+}
+
+pub fn unscoped_error(name: &str, target: &SecretScope) -> anyhow::Error {
+    crate::exit::usage(format!(
+        "stored secret {name} has no cluster scope; refusing to inject it into {}. Re-save it with --cluster-identity {} --release {} --namespace {}",
+        target.describe(),
+        target.cluster_identity,
+        target.release,
+        target.namespace
+    ))
+}
+
+/// Names of incoming keys that already exist on the live connector Secret.
+/// Values are never inspected; presence of the key is the replacement signal.
+pub fn keys_being_replaced(
+    existing_keys: &BTreeSet<String>,
+    incoming_keys: &[String],
+) -> Vec<String> {
+    incoming_keys
+        .iter()
+        .filter(|key| existing_keys.contains(*key))
+        .cloned()
+        .collect()
+}
+
+pub fn write_intent_line(secret_name: &str, keys: &[String], target: &SecretScope) -> String {
+    format!(
+        "writing stored connector secrets into {secret_name} for {}: {}",
+        target.describe(),
+        keys.join(", ")
+    )
+}
+
+pub fn replacement_warning_line(secret_name: &str, keys: &[String]) -> String {
+    format!(
+        "replacing non-empty connector secret keys in {secret_name}: {} (values not shown)",
+        keys.join(", ")
+    )
+}
+
 pub fn delete_value(name: &str) -> Result<()> {
     validate_name(name)?;
     let mut credentials = read_credentials()?;
@@ -218,14 +653,16 @@ pub fn remove_value(name: &str) -> Result<()> {
 
 pub fn list_names() -> Result<Vec<String>> {
     let index = read_index()?;
-    Ok(index
+    let mut names = index
         .names
         .into_iter()
         .chain(index.legacy_names)
         .chain(index.file_names)
-        .collect::<BTreeSet<_>>()
-        .into_iter()
-        .collect())
+        .collect::<BTreeSet<_>>();
+    for name in read_credentials()?.list_output().names {
+        names.insert(name);
+    }
+    Ok(names.into_iter().collect())
 }
 
 pub fn validate_name(name: &str) -> Result<()> {
@@ -401,6 +838,7 @@ fn config_dir() -> Result<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ui::CliOutput;
 
     #[test]
     fn validates_env_like_names() {
@@ -474,12 +912,208 @@ mod tests {
                     "github-secret".to_string(),
                 ),
             ]),
+            scoped: BTreeMap::new(),
         };
         let raw = serde_json::to_string(&vault).unwrap();
         let decoded: SecretVault = serde_json::from_str(&raw).unwrap();
 
         assert_eq!(decoded.values, vault.values);
         assert_eq!(VAULT_ACCOUNT, "curie:global:vault");
+    }
+
+    #[test]
+    fn same_name_secrets_are_distinct_across_cluster_identities() {
+        let mut vault = SecretVault::default();
+        let a = SecretScope {
+            cluster_identity: "ca:a".into(),
+            release: "curie".into(),
+            namespace: "curie-test".into(),
+        };
+        let b = SecretScope {
+            cluster_identity: "ca:b".into(),
+            release: "curie".into(),
+            namespace: "curie".into(),
+        };
+        vault
+            .save_scoped("K8S_WRITE_KUBECONFIG", &a, "token-a", None)
+            .unwrap();
+        vault
+            .save_scoped("K8S_WRITE_KUBECONFIG", &b, "token-b", None)
+            .unwrap();
+
+        let resolved_a = vault
+            .resolve_cluster("K8S_WRITE_KUBECONFIG", &a)
+            .unwrap()
+            .unwrap();
+        let resolved_b = vault
+            .resolve_cluster("K8S_WRITE_KUBECONFIG", &b)
+            .unwrap()
+            .unwrap();
+        assert_eq!(resolved_a.value, "token-a");
+        assert_eq!(resolved_b.value, "token-b");
+        assert_ne!(resolved_a.value, resolved_b.value);
+    }
+
+    #[test]
+    fn cluster_deploy_refuses_a_mismatched_scope() {
+        let mut vault = SecretVault::default();
+        let a = SecretScope {
+            cluster_identity: "ca:a".into(),
+            release: "curie".into(),
+            namespace: "curie-test".into(),
+        };
+        let b = SecretScope {
+            cluster_identity: "ca:b".into(),
+            release: "curie".into(),
+            namespace: "curie".into(),
+        };
+        vault
+            .save_scoped("K8S_WRITE_KUBECONFIG", &a, "token-a", None)
+            .unwrap();
+
+        let err = vault
+            .resolve_cluster("K8S_WRITE_KUBECONFIG", &b)
+            .unwrap_err();
+        let message = err.to_string();
+        assert!(
+            message.contains("refusing to inject"),
+            "mismatch must refuse, got {message}"
+        );
+        assert!(message.contains("ca:a"), "must name the stored scope");
+        assert!(message.contains("ca:b"), "must name the requested scope");
+        assert!(
+            !message.contains("token-a"),
+            "refusal must not leak the stored value"
+        );
+    }
+
+    #[test]
+    fn cluster_deploy_refuses_unscoped_reuse() {
+        let mut vault = SecretVault::default();
+        vault
+            .values
+            .insert("K8S_WRITE_KUBECONFIG".into(), "token-unscoped".into());
+        let target = SecretScope {
+            cluster_identity: "ca:b".into(),
+            release: "curie".into(),
+            namespace: "curie".into(),
+        };
+        let err = vault
+            .resolve_cluster("K8S_WRITE_KUBECONFIG", &target)
+            .unwrap_err();
+        let message = err.to_string();
+        assert!(message.contains("no cluster scope"));
+        assert!(
+            !message.contains("token-unscoped"),
+            "refusal must not leak the stored value"
+        );
+    }
+
+    #[test]
+    fn replacing_a_scoped_secret_requires_the_stored_version() {
+        let mut vault = SecretVault::default();
+        let target = SecretScope {
+            cluster_identity: "ca:a".into(),
+            release: "curie".into(),
+            namespace: "curie-test".into(),
+        };
+        assert_eq!(
+            vault
+                .save_scoped("K8S_WRITE_KUBECONFIG", &target, "token-1", None)
+                .unwrap(),
+            1
+        );
+        let stale = vault
+            .save_scoped("K8S_WRITE_KUBECONFIG", &target, "token-2", None)
+            .unwrap_err()
+            .to_string();
+        assert!(stale.contains("version mismatch"));
+        assert!(
+            !stale.contains("token-1") && !stale.contains("token-2"),
+            "conflict must not leak secret values"
+        );
+        assert_eq!(
+            vault
+                .save_scoped("K8S_WRITE_KUBECONFIG", &target, "token-2", Some(1))
+                .unwrap(),
+            2
+        );
+        assert_eq!(
+            vault
+                .resolve_cluster("K8S_WRITE_KUBECONFIG", &target)
+                .unwrap()
+                .unwrap()
+                .value,
+            "token-2"
+        );
+    }
+
+    #[test]
+    fn expected_version_cannot_create_a_missing_scoped_entry() {
+        let mut vault = SecretVault::default();
+        let target = SecretScope {
+            cluster_identity: "ca:a".into(),
+            release: "curie".into(),
+            namespace: "curie-test".into(),
+        };
+        let err = vault
+            .save_scoped("K8S_WRITE_KUBECONFIG", &target, "token", Some(1))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("does not exist yet"));
+    }
+
+    #[test]
+    fn list_output_exposes_scope_and_version_never_values() {
+        let mut vault = SecretVault::default();
+        vault
+            .values
+            .insert("ANTHROPIC_API_KEY".into(), "sk-ant-never-print".into());
+        let target = SecretScope {
+            cluster_identity: "ca:a".into(),
+            release: "curie".into(),
+            namespace: "curie-test".into(),
+        };
+        vault
+            .save_scoped("K8S_WRITE_KUBECONFIG", &target, "token-a", None)
+            .unwrap();
+        let out = vault.list_output();
+        let json = out.to_json().to_string();
+        assert!(json.contains("K8S_WRITE_KUBECONFIG"));
+        assert!(json.contains("ca:a"));
+        assert!(json.contains("\"version\":1"));
+        assert!(!json.contains("token-a"));
+        assert!(!json.contains("sk-ant-never-print"));
+    }
+
+    #[test]
+    fn replacement_visibility_names_keys_not_values() {
+        let existing = BTreeSet::from(["K8S_WRITE_KUBECONFIG".to_string()]);
+        let incoming = vec!["K8S_WRITE_KUBECONFIG".to_string(), "OTHER".to_string()];
+        let replaced = keys_being_replaced(&existing, &incoming);
+        assert_eq!(replaced, vec!["K8S_WRITE_KUBECONFIG".to_string()]);
+        let warning = replacement_warning_line("acme-bot-connector-secrets", &replaced);
+        assert!(warning.contains("K8S_WRITE_KUBECONFIG"));
+        assert!(warning.contains("values not shown"));
+        let intent = write_intent_line(
+            "acme-bot-connector-secrets",
+            &incoming,
+            &SecretScope {
+                cluster_identity: "ca:a".into(),
+                release: "curie".into(),
+                namespace: "curie-test".into(),
+            },
+        );
+        assert!(intent.contains("K8S_WRITE_KUBECONFIG"));
+        assert!(!intent.contains("token"));
+    }
+
+    #[test]
+    fn legacy_credentials_json_without_scoped_still_parses() {
+        let decoded: SecretVault =
+            serde_json::from_str(r#"{"values":{"ANTHROPIC_API_KEY":"x"}}"#).unwrap();
+        assert_eq!(decoded.values.get("ANTHROPIC_API_KEY").unwrap(), "x");
+        assert!(decoded.scoped.is_empty());
     }
 
     #[cfg(unix)]

--- a/cli/tests/cluster_secret_scope.rs
+++ b/cli/tests/cluster_secret_scope.rs
@@ -1,0 +1,151 @@
+//! Binary proof that cluster-scoped secrets refuse mismatch, require CAS
+//! versions to replace, and never print values (#1913).
+
+use std::fs;
+use std::process::Command;
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_curie")
+}
+
+fn isolated_config() -> tempfile::TempDir {
+    tempfile::tempdir().expect("config dir")
+}
+
+fn secrets_cmd(config: &tempfile::TempDir) -> Command {
+    let mut command = Command::new(bin());
+    command
+        .env("CURIE_CONFIG_DIR", config.path())
+        .env_remove("HOME");
+    command
+}
+
+#[test]
+fn scoped_set_list_and_stale_replace_never_print_values() {
+    let config = isolated_config();
+    let status = secrets_cmd(&config)
+        .args([
+            "secrets",
+            "set",
+            "K8S_WRITE_KUBECONFIG",
+            "--from-env",
+            "K8S_WRITE_KUBECONFIG",
+            "--cluster-identity",
+            "ca:a",
+            "--release",
+            "curie",
+            "--namespace",
+            "curie-test",
+        ])
+        .env("K8S_WRITE_KUBECONFIG", "token-cluster-a")
+        .status()
+        .expect("secrets set");
+    assert!(status.success(), "first scoped set must succeed");
+
+    let listed = secrets_cmd(&config)
+        .args(["--json", "secrets", "list"])
+        .output()
+        .expect("secrets list");
+    assert!(listed.status.success());
+    let stdout = String::from_utf8_lossy(&listed.stdout);
+    let stderr = String::from_utf8_lossy(&listed.stderr);
+    assert!(stdout.contains("K8S_WRITE_KUBECONFIG"));
+    assert!(stdout.contains("ca:a"));
+    assert!(stdout.contains("\"version\":1"));
+    assert!(!stdout.contains("token-cluster-a"));
+    assert!(!stderr.contains("token-cluster-a"));
+
+    let stale = secrets_cmd(&config)
+        .args([
+            "secrets",
+            "set",
+            "K8S_WRITE_KUBECONFIG",
+            "--from-env",
+            "K8S_WRITE_KUBECONFIG",
+            "--cluster-identity",
+            "ca:a",
+            "--release",
+            "curie",
+            "--namespace",
+            "curie-test",
+        ])
+        .env("K8S_WRITE_KUBECONFIG", "token-cluster-a-replaced")
+        .output()
+        .expect("stale secrets set");
+    assert!(!stale.status.success(), "replace without version must fail");
+    let stale_out = format!(
+        "{}{}",
+        String::from_utf8_lossy(&stale.stdout),
+        String::from_utf8_lossy(&stale.stderr)
+    );
+    assert!(stale_out.contains("version mismatch"));
+    assert!(!stale_out.contains("token-cluster-a"));
+
+    let replaced = secrets_cmd(&config)
+        .args([
+            "secrets",
+            "set",
+            "K8S_WRITE_KUBECONFIG",
+            "--from-env",
+            "K8S_WRITE_KUBECONFIG",
+            "--cluster-identity",
+            "ca:a",
+            "--release",
+            "curie",
+            "--namespace",
+            "curie-test",
+            "--expected-version",
+            "1",
+        ])
+        .env("K8S_WRITE_KUBECONFIG", "token-cluster-a-replaced")
+        .output()
+        .expect("cas secrets set");
+    assert!(replaced.status.success(), "matching version must replace");
+    let replaced_out = format!(
+        "{}{}",
+        String::from_utf8_lossy(&replaced.stdout),
+        String::from_utf8_lossy(&replaced.stderr)
+    );
+    assert!(!replaced_out.contains("token-cluster-a"));
+
+    let stored = fs::read_to_string(config.path().join("credentials.json")).unwrap();
+    assert!(stored.contains("token-cluster-a-replaced"));
+    assert!(!stored.contains("token-cluster-a\"") || stored.contains("token-cluster-a-replaced"));
+}
+
+#[test]
+fn same_name_can_exist_for_two_cluster_identities() {
+    let config = isolated_config();
+    for (identity, namespace, value) in [
+        ("ca:a", "curie-test", "token-cluster-a"),
+        ("ca:b", "curie", "token-cluster-b"),
+    ] {
+        let status = secrets_cmd(&config)
+            .args([
+                "secrets",
+                "set",
+                "K8S_WRITE_KUBECONFIG",
+                "--from-env",
+                "K8S_WRITE_KUBECONFIG",
+                "--cluster-identity",
+                identity,
+                "--release",
+                "curie",
+                "--namespace",
+                namespace,
+            ])
+            .env("K8S_WRITE_KUBECONFIG", value)
+            .status()
+            .expect("secrets set");
+        assert!(status.success());
+    }
+    let listed = secrets_cmd(&config)
+        .args(["--json", "secrets", "list"])
+        .output()
+        .expect("secrets list");
+    let stdout = String::from_utf8_lossy(&listed.stdout);
+    assert!(stdout.contains("ca:a"));
+    assert!(stdout.contains("ca:b"));
+    assert!(!stdout.contains("token-cluster-a"));
+    assert!(!stdout.contains("token-cluster-b"));
+}

--- a/cli/tests/cluster_secret_scope_kind.rs
+++ b/cli/tests/cluster_secret_scope_kind.rs
@@ -123,6 +123,39 @@ async fn two_disposable_clusters_refuse_mismatch_and_warn_on_replace() {
     assert!(!intent.contains("token-cluster-a"));
 
     std::env::set_var("KUBECONFIG", &kube_a);
+    let captured_a = connectors::bind_current_cluster(ns_a, "acme")
+        .await
+        .unwrap();
+    let prepared_a = prepared_a.bind_target(captured_a).unwrap();
+    // A switch after prepare must refuse before it can apply A's credential.
+    std::env::set_var("KUBECONFIG", &kube_b);
+    let switched = sync(prepared_a).await.unwrap_err().to_string();
+    assert!(switched.contains("no longer matches"));
+    let (ok, _, _) = kubectl(
+        &kube_b,
+        &["-n", ns_b, "get", "secret", "acme-bot-connector-secrets"],
+    );
+    assert!(
+        !ok,
+        "context switch must not write the captured credential to B"
+    );
+
+    std::env::set_var("KUBECONFIG", &kube_a);
+    let prepared_a = prepare(
+        &[],
+        &BTreeMap::new(),
+        "acme-bot-connector-secrets",
+        &["K8S_WRITE_KUBECONFIG".to_string()],
+        &scope_a,
+        "acme-bot",
+    )
+    .unwrap()
+    .bind_target(
+        connectors::bind_current_cluster(ns_a, "acme")
+            .await
+            .unwrap(),
+    )
+    .unwrap();
     let first = sync(prepared_a).await.unwrap();
     assert!(
         first.replaced_keys.is_empty(),
@@ -139,7 +172,17 @@ async fn two_disposable_clusters_refuse_mismatch_and_warn_on_replace() {
         "acme-bot",
     )
     .unwrap();
-    let replaced = sync(prepared_again).await.unwrap();
+    let replaced = sync(
+        prepared_again
+            .bind_target(
+                connectors::bind_current_cluster(ns_a, "acme")
+                    .await
+                    .unwrap(),
+            )
+            .unwrap(),
+    )
+    .await
+    .unwrap();
     assert_eq!(
         replaced.replaced_keys,
         vec!["K8S_WRITE_KUBECONFIG".to_string()]

--- a/cli/tests/cluster_secret_scope_kind.rs
+++ b/cli/tests/cluster_secret_scope_kind.rs
@@ -1,0 +1,166 @@
+//! Real two-cluster proof for #1913. Skips unless CURIE_E2E_TWO_CLUSTER=1
+//! and KUBECONFIG_A / KUBECONFIG_B point at disposable kubeconfigs.
+
+use std::collections::BTreeMap;
+use std::process::Command;
+
+use curie::connectors::{self, prepare, sync};
+use curie::secrets::{self, SecretScope};
+use curie::ui::CliOutput;
+
+fn required_env(name: &str) -> Option<String> {
+    match std::env::var(name) {
+        Ok(value) if !value.is_empty() => Some(value),
+        _ => None,
+    }
+}
+
+fn kubectl(kubeconfig: &str, args: &[&str]) -> (bool, String, String) {
+    let output = Command::new("kubectl")
+        .args(args)
+        .env("KUBECONFIG", kubeconfig)
+        .output()
+        .expect("kubectl");
+    (
+        output.status.success(),
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+    )
+}
+
+async fn identity_for(kubeconfig: &str) -> String {
+    let previous = std::env::var_os("KUBECONFIG");
+    std::env::set_var("KUBECONFIG", kubeconfig);
+    let identity = connectors::discover_cluster_identity()
+        .await
+        .expect("cluster identity");
+    match previous {
+        Some(value) => std::env::set_var("KUBECONFIG", value),
+        None => std::env::remove_var("KUBECONFIG"),
+    }
+    identity
+}
+
+#[tokio::test]
+async fn two_disposable_clusters_refuse_mismatch_and_warn_on_replace() {
+    let Some(kube_a) = required_env("KUBECONFIG_A") else {
+        eprintln!("skipping: set CURIE_E2E_TWO_CLUSTER=1 KUBECONFIG_A KUBECONFIG_B");
+        return;
+    };
+    if required_env("CURIE_E2E_TWO_CLUSTER").as_deref() != Some("1") {
+        eprintln!("skipping: CURIE_E2E_TWO_CLUSTER is not 1");
+        return;
+    }
+    let kube_b = required_env("KUBECONFIG_B").expect("KUBECONFIG_B");
+
+    let config = tempfile::tempdir().expect("config");
+    std::env::set_var("CURIE_CONFIG_DIR", config.path());
+
+    let id_a = identity_for(&kube_a).await;
+    let id_b = identity_for(&kube_b).await;
+    assert_ne!(
+        id_a, id_b,
+        "disposable clusters must have distinct identities"
+    );
+    assert!(id_a.starts_with("ca:"));
+    assert!(id_b.starts_with("ca:"));
+
+    let ns_a = "acme-1913-a";
+    let ns_b = "acme-1913-b";
+    let (ok, _, err) = kubectl(
+        &kube_a,
+        &[
+            "create",
+            "namespace",
+            ns_a,
+            "--dry-run=client",
+            "-o",
+            "name",
+        ],
+    );
+    assert!(ok, "kubectl A reachable: {err}");
+    let (ok, _, err) = kubectl(&kube_a, &["create", "namespace", ns_a]);
+    assert!(ok || err.contains("AlreadyExists"), "create ns A: {err}");
+    let (ok, _, err) = kubectl(&kube_b, &["create", "namespace", ns_b]);
+    assert!(ok || err.contains("AlreadyExists"), "create ns B: {err}");
+
+    let scope_a = SecretScope {
+        cluster_identity: id_a,
+        release: "acme".into(),
+        namespace: ns_a.into(),
+    };
+    let scope_b = SecretScope {
+        cluster_identity: id_b,
+        release: "acme".into(),
+        namespace: ns_b.into(),
+    };
+    secrets::save_scoped_value("K8S_WRITE_KUBECONFIG", &scope_a, "token-cluster-a", None).unwrap();
+
+    let mismatch = prepare(
+        &[],
+        &BTreeMap::new(),
+        "acme-bot-connector-secrets",
+        &["K8S_WRITE_KUBECONFIG".to_string()],
+        &scope_b,
+        "acme-bot",
+    )
+    .unwrap_err()
+    .to_string();
+    assert!(mismatch.contains("refusing to inject"));
+    assert!(!mismatch.contains("token-cluster-a"));
+
+    let prepared_a = prepare(
+        &[],
+        &BTreeMap::new(),
+        "acme-bot-connector-secrets",
+        &["K8S_WRITE_KUBECONFIG".to_string()],
+        &scope_a,
+        "acme-bot",
+    )
+    .unwrap();
+    let intent = prepared_a.write_intent().unwrap();
+    assert!(intent.contains("K8S_WRITE_KUBECONFIG"));
+    assert!(!intent.contains("token-cluster-a"));
+
+    std::env::set_var("KUBECONFIG", &kube_a);
+    let first = sync(prepared_a).await.unwrap();
+    assert!(
+        first.replaced_keys.is_empty(),
+        "first write is not a replace"
+    );
+    assert_eq!(first.written_keys, vec!["K8S_WRITE_KUBECONFIG".to_string()]);
+
+    let prepared_again = prepare(
+        &[],
+        &BTreeMap::new(),
+        "acme-bot-connector-secrets",
+        &["K8S_WRITE_KUBECONFIG".to_string()],
+        &scope_a,
+        "acme-bot",
+    )
+    .unwrap();
+    let replaced = sync(prepared_again).await.unwrap();
+    assert_eq!(
+        replaced.replaced_keys,
+        vec!["K8S_WRITE_KUBECONFIG".to_string()]
+    );
+
+    let (ok, secret_json, err) = kubectl(
+        &kube_a,
+        &[
+            "-n",
+            ns_a,
+            "get",
+            "secret",
+            "acme-bot-connector-secrets",
+            "-o",
+            "json",
+        ],
+    );
+    assert!(ok, "secret exists on A: {err}");
+    assert!(secret_json.contains("K8S_WRITE_KUBECONFIG"));
+    // The live Secret holds base64, but our operator notes must not.
+    let listed = secrets::list_output().unwrap().to_json().to_string();
+    assert!(!listed.contains("token-cluster-a"));
+    let _ = kube_b;
+}

--- a/cli/tests/json_contract.rs
+++ b/cli/tests/json_contract.rs
@@ -1462,12 +1462,39 @@ fn guide_output_validates() {
 fn secrets_list_output_validates() {
     let out = SecretsListOutput {
         names: vec!["ANTHROPIC_API_KEY".to_string()],
+        entries: vec![curie::secrets::SecretListEntry {
+            name: "ANTHROPIC_API_KEY".to_string(),
+            scope: None,
+            version: None,
+        }],
     };
     assert_valid("secrets.schema.json", &out.to_json());
     assert_valid(
         "secrets.schema.json",
-        &SecretsListOutput { names: vec![] }.to_json(),
+        &SecretsListOutput {
+            names: vec![],
+            entries: vec![],
+        }
+        .to_json(),
     );
+    let scoped = SecretsListOutput {
+        names: vec!["K8S_WRITE_KUBECONFIG".to_string()],
+        entries: vec![curie::secrets::SecretListEntry {
+            name: "K8S_WRITE_KUBECONFIG".to_string(),
+            scope: Some(curie::secrets::SecretScope {
+                cluster_identity:
+                    "ca:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                        .to_string(),
+                release: "curie".to_string(),
+                namespace: "curie-test".to_string(),
+            }),
+            version: Some(1),
+        }],
+    };
+    assert_valid("secrets.schema.json", &scoped.to_json());
+    let rendered = scoped.to_json().to_string();
+    assert!(!rendered.contains("token"));
+    assert!(!rendered.contains("kubeconfig"));
 }
 
 #[test]

--- a/cli/tests/json_emit_contract.rs
+++ b/cli/tests/json_emit_contract.rs
@@ -1553,6 +1553,13 @@ fn write_kubectl_stub(dir: &Path) -> PathBuf {
         &path,
         r#"#!/bin/sh
 case "$*" in
+  *"config view"*)
+    printf '%s' '{"clusters":[{"cluster":{"server":"https://cluster-a.example.com","certificate-authority-data":"Y2EtYQ=="}}]}'
+    ;;
+  *"get secret"*)
+    printf '%s\n' 'Error from server (NotFound): secrets "missing" not found' >&2
+    exit 1
+    ;;
   *"get deployment"*)
     if [ "${CURIE_TEST_KUBECTL_FAILURE:-}" = discovery ]; then
       printf '%s\n' 'app discovery exploded' >&2

--- a/docs/your-first-slack-agent.md
+++ b/docs/your-first-slack-agent.md
@@ -123,7 +123,9 @@ connectors:
 `secrets` are **names only** — the value never enters your repository:
 
 ```bash
-curie secrets set GRAFANA_SERVICE_ACCOUNT_TOKEN --from-env GRAFANA_SERVICE_ACCOUNT_TOKEN
+CURIE_CLUSTER_ID="ca:$(kubectl config view --minify --raw -o json | jq -r '.clusters[0].cluster | ((.server // "") + "\\n" + (."certificate-authority-data" // ."certificate-authority" // ""))' | sha256sum | awk '{print $1}')"
+curie secrets set GRAFANA_SERVICE_ACCOUNT_TOKEN --from-env GRAFANA_SERVICE_ACCOUNT_TOKEN \
+  --cluster-identity "$CURIE_CLUSTER_ID" --release curie --namespace curie
 ```
 
 At cluster deploy time, Curie delivers both connector `secrets` and

--- a/docs/your-first-slack-agent.md
+++ b/docs/your-first-slack-agent.md
@@ -127,9 +127,10 @@ curie secrets set GRAFANA_SERVICE_ACCOUNT_TOKEN --from-env GRAFANA_SERVICE_ACCOU
 ```
 
 At cluster deploy time, Curie delivers both connector `secrets` and
-`secret_files` values into the agent's Kubernetes Secret. The host secret store
-is install global, so agents that use the same secret name share one stored
-value and can collide. Issue #440 tracks the future per agent delivery path.
+`secret_files` values into the agent's Kubernetes Secret. Those stored values
+must be scoped to the target cluster identity, release, and namespace; a
+mismatch is refused rather than silently reused. Unscoped names remain for
+skill/local credentials. Issue #440 tracks the future per agent delivery path.
 
 ---
 

--- a/examples/sre-bot/README.md
+++ b/examples/sre-bot/README.md
@@ -145,7 +145,9 @@ current-context: prod
 YAML
 
 export K8S_READONLY_KUBECONFIG="$(cat /tmp/sre-bot.kubeconfig)"
-curie secrets set K8S_READONLY_KUBECONFIG --from-env K8S_READONLY_KUBECONFIG
+CURIE_CLUSTER_ID="ca:$(kubectl config view --minify --raw -o json | jq -r '.clusters[0].cluster | ((.server // "") + "\\n" + (."certificate-authority-data" // ."certificate-authority" // ""))' | sha256sum | awk '{print $1}')"
+curie secrets set K8S_READONLY_KUBECONFIG --from-env K8S_READONLY_KUBECONFIG \
+  --cluster-identity "$CURIE_CLUSTER_ID" --release curie --namespace curie
 shred -u /tmp/sre-bot.kubeconfig /tmp/sre-token 2>/dev/null || rm -f /tmp/sre-bot.kubeconfig /tmp/sre-token
 ```
 
@@ -278,7 +280,9 @@ contexts: [{name: prod, context: {cluster: prod, user: sre-bot-writer}}]
 current-context: prod
 YAML
 )"
-curie secrets set K8S_WRITE_KUBECONFIG --from-env K8S_WRITE_KUBECONFIG
+CURIE_CLUSTER_ID="ca:$(kubectl config view --minify --raw -o json | jq -r '.clusters[0].cluster | ((.server // "") + "\\n" + (."certificate-authority-data" // ."certificate-authority" // ""))' | sha256sum | awk '{print $1}')"
+curie secrets set K8S_WRITE_KUBECONFIG --from-env K8S_WRITE_KUBECONFIG \
+  --cluster-identity "$CURIE_CLUSTER_ID" --release curie --namespace curie
 ```
 
 Prove the ceiling before wiring it up. The second and third must fail:


### PR DESCRIPTION
Closes #1913

## Summary
- bind connector discovery, inspection, apply, and prune to a captured private kubeconfig; revalidate the ambient selection before each mutation
- fail closed when existing connector Secret inspection fails or returns malformed JSON; only NotFound is treated as absent
- scope every documented cluster connector secret setup to the current cluster identity, release, and namespace
- make TUI secret removal remove all scopes for the chosen name rather than claim partial success

## Verification
- `cd cli && cargo fmt --check && cargo clippy -- -D warnings && cargo test`
- `cd cli && bash scripts/refresh-schema-baseline.sh --check`
- `pnpm gen:manifest` in `apps/ui`
- `curie dev docs-lint`
- disposable two-kind-cluster E2E: with A prepared then ambient context switched to B, sync refused before mutation and B had no connector Secret; with A restored, apply succeeded and the second apply reported the existing key replacement. Both clusters and kubeconfigs were deleted afterward.

## Tier classification
- skill: not applicable (no plugin or runner loop change)
- local: not applicable (no compose/API/worker wiring change)
- local-release: not applicable (no release artifact identity change)
- cluster: required and passed via the disposable two-cluster CLI/connector path
- live provider: not applicable (no model routing or provider credential change)
- external integration: not applicable (no third-party integration change)