### PR TITLE
Publish ADR-0112 as Accepted

### DIFF
--- a/docs/adr/0079-inbound-triggers-as-a-new-event-kind.md
+++ b/docs/adr/0079-inbound-triggers-as-a-new-event-kind.md
@@ -3,6 +3,11 @@
 Date: 2026-07-10
 Status: Accepted
 
+**Superseded in part by
+[ADR-0112](0112-a-turn-source-names-what-caused-the-turn.md)**: decision 2's
+`source` value vocabulary changes from `slack | webhook | cron` to
+`message | webhook | cron`. Everything else in this decision stands.
+
 Proposes how "triggers beyond chat" (issue
 [#29](https://github.com/curie-eng/curie/issues/29)) enter the system: which
 service accepts a non-Slack trigger, and how a triggered turn produces output

--- a/docs/adr/0112-a-turn-source-names-what-caused-the-turn.md
+++ b/docs/adr/0112-a-turn-source-names-what-caused-the-turn.md
@@ -2,7 +2,7 @@
 
 Date: 2026-08-18
 
-Status: Draft
+Status: Accepted
 
 Supersedes the value vocabulary of decision 2 in
 [ADR-0079](0079-inbound-triggers-as-a-new-event-kind.md). Everything else ADR-0079

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -141,7 +141,7 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0109 | [Retention, capacity, and back pressure are one policy: a claim is admitted, not discovered](0109-retention-capacity-and-back-pressure-are-one-policy.md) | Draft |
 | 0110 | [Deterministic security posture classification distinguishes manifest declarations from operator gates](0110-deterministic-security-posture-classification.md) | Draft |
 | 0111 | [The default memory compaction algorithm](0111-the-default-memory-compaction-algorithm.md) | Draft |
-| 0112 | [A turn source names what caused the turn, not the channel it arrived on](0112-a-turn-source-names-what-caused-the-turn.md) | Draft |
+| 0112 | [A turn source names what caused the turn, not the channel it arrived on](0112-a-turn-source-names-what-caused-the-turn.md) | Accepted |
 | 0113 | [Bundles declare connector build inputs and tiers deliver pinned images](0113-bundles-declare-connector-build-inputs-and-tiers-deliver-pinned-images.md) | Accepted |
 | 0114 | [Managed repository workspaces and approval-gated publication are platform capabilities](0114-managed-repository-workspaces-and-approval-gated-publication.md) | Accepted |
 | 0115 | [Runtime repository selection is sticky authorized thread state](0115-runtime-repository-selection-is-sticky-authorized-thread-state.md) | Accepted |


### PR DESCRIPTION
## What

- Publish ADR-0112 as Accepted.
- Add the reciprocal partial-supersession backlink to ADR-0079.
- Regenerate the ADR index.

## Why

The turn-source naming decision was prototyped before publication and received maintainer approval in #1672. Acceptance records that authority; implementation remains separate frozen-contract work.

## Verification

- `bash scripts/check-docs.sh`

Refs #1672
