### PR TITLE
Publish ADR-0122 as Accepted

### DIFF
--- a/docs/adr/0116-session-identity-arrives-over-the-aci-so-a-sandbox-can-be-pre-bound.md
+++ b/docs/adr/0116-session-identity-arrives-over-the-aci-so-a-sandbox-can-be-pre-bound.md
@@ -4,6 +4,11 @@ Date: 2026-08-20
 
 Status: Accepted
 
+**Superseded in part by
+[ADR-0122](0122-a-warm-pools-runner-token-is-per-version-not-per-pod.md)**:
+decision 2's per-pod runner token becomes one token per immutable agent version.
+The session-identity half of that decision and every other decision stand.
+
 Extends [ADR-0059](0059-sandbox-is-a-bounded-resource-envelope.md) into the
 dimension it deliberately left out of scope -- **throughput and the wall-clock
 deadline on the claim path** -- and revisits the resume framing of

--- a/docs/adr/0122-a-warm-pools-runner-token-is-per-version-not-per-pod.md
+++ b/docs/adr/0122-a-warm-pools-runner-token-is-per-version-not-per-pod.md
@@ -2,13 +2,12 @@
 
 Date: 2026-08-25
 
-Status: Draft
+Status: Accepted
 
-**Supersedes in part, when accepted,
+**Supersedes in part
 [ADR-0116](0116-session-identity-arrives-over-the-aci-so-a-sandbox-can-be-pre-bound.md)**,
 whose decision 2 says the pool "mints one per pod at creation". It cannot. While
-this record is Draft it replaces nothing; ADR-0116's clause stands until this one
-is Accepted. Everything else in ADR-0116 is unaffected either way, including the
+Everything else in ADR-0116 is unaffected, including the
 half of decision 2 that moves session identity onto the ACI `Event` frame, and
 including the ordering that puts the token before decision 3's warm pool.
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -151,7 +151,7 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0119 | [A resumed thread rebuilds its prefix so the prompt cache still hits](0119-a-resumed-thread-rebuilds-its-prefix-so-the-prompt-cache-still-hits.md) | Draft |
 | 0120 | [First-party email delivery state is local durable single-writer state](0120-durable-first-party-email-state.md) | Accepted |
 | 0121 | [A restore is the connector's own verb, run under the same pinned connector](0121-a-restore-is-the-connectors-own-verb-run-under-the-same-pinned-connector.md) | Draft |
-| 0122 | [A warm pool's runner token is per version, not per pod](0122-a-warm-pools-runner-token-is-per-version-not-per-pod.md) | Draft |
+| 0122 | [A warm pool's runner token is per version, not per pod](0122-a-warm-pools-runner-token-is-per-version-not-per-pod.md) | Accepted |
 | 0124 | [A snapshot is sealed to the connector that wrote it](0124-a-snapshot-is-sealed-to-the-connector-that-wrote-it.md) | Draft |
 | 0127 | [An inbound ACP client admits any ACP harness behind the harness port](0127-an-inbound-acp-client-admits-any-acp-harness.md) | Draft |
 | 0128 | [An installation owns the model gateway and operator bindings select its aliases](0128-install-owned-model-gateway-and-agent-aliases.md) | Draft |


### PR DESCRIPTION
## What

- Publish ADR-0122 as Accepted.
- Record ADR-0116 decision 2's partial supersession.
- Regenerate the ADR index.

## Why

The per-version runner-token decision was revised against security and lifecycle review, backed by measured probes, and received maintainer approval in #1911.

## Verification

- `bash scripts/check-docs.sh`

Refs #1911
