### PR TITLE
Publish ADR-0124 as Accepted

### DIFF
--- a/docs/adr/0124-a-snapshot-is-sealed-to-the-connector-that-wrote-it.md
+++ b/docs/adr/0124-a-snapshot-is-sealed-to-the-connector-that-wrote-it.md
@@ -2,7 +2,7 @@
 
 Date: 2026-08-25
 
-Status: Draft
+Status: Accepted
 
 Answers the exposure question [ADR-0117](0117-a-tool-that-changes-the-world-reports-what-it-changed.md)
 left to the connector author and

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -152,7 +152,7 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0120 | [First-party email delivery state is local durable single-writer state](0120-durable-first-party-email-state.md) | Accepted |
 | 0121 | [A restore is the connector's own verb, run under the same pinned connector](0121-a-restore-is-the-connectors-own-verb-run-under-the-same-pinned-connector.md) | Draft |
 | 0122 | [A warm pool's runner token is per version, not per pod](0122-a-warm-pools-runner-token-is-per-version-not-per-pod.md) | Draft |
-| 0124 | [A snapshot is sealed to the connector that wrote it](0124-a-snapshot-is-sealed-to-the-connector-that-wrote-it.md) | Draft |
+| 0124 | [A snapshot is sealed to the connector that wrote it](0124-a-snapshot-is-sealed-to-the-connector-that-wrote-it.md) | Accepted |
 | 0127 | [An inbound ACP client admits any ACP harness behind the harness port](0127-an-inbound-acp-client-admits-any-acp-harness.md) | Draft |
 | 0128 | [An installation owns the model gateway and operator bindings select its aliases](0128-install-owned-model-gateway-and-agent-aliases.md) | Draft |
 | 0129 | [One release owns a cluster's shared singletons; every other release declares what it needs from them](0129-one-release-owns-a-clusters-shared-singletons.md) | Draft |


### PR DESCRIPTION
## What

- Publish ADR-0124 as Accepted.
- Regenerate the ADR index.

## Why

The connector-owned snapshot-sealing decision was revised against measured restore and sealing probes and received explicit maintainer approval in #1919.

## Verification

- `bash scripts/check-docs.sh`

Refs #1919
