### PR TITLE
Renumber and accept the agent delegation ADR

### DIFF
--- a/docs/adr/0132-agents-call-each-other-with-no-third-party.md
+++ b/docs/adr/0132-agents-call-each-other-with-no-third-party.md
@@ -1,8 +1,8 @@
-# 115. Agents call each other directly, with no third party in the path
+# 132. Agents call each other directly, with no third party in the path
 
 Date: 2026-08-20
 
-Status: Draft
+Status: Accepted
 
 ## Context
 
@@ -365,8 +365,10 @@ spreading calls across targets.
   for the tokens.
 - **ADR-0044's phase 1 becomes buildable**, and the external-workflow caller
   reaches the same surface with a scoped token instead of the delegate tool.
-- **This is a Draft.** Per [ADR-0085](0085-acceptance-not-implementation-authorizes-an-adr.md)
-  it authorizes no implementation until a maintainer accepts it.
+- **This ADR is Accepted.** Per
+  [ADR-0085](0085-acceptance-not-implementation-authorizes-an-adr.md), the
+  recorded maintainer approval authorizes implementation; implementation remains
+  separate work.
 
 ## Alternatives considered
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -143,6 +143,6 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0111 | [The default memory compaction algorithm](0111-the-default-memory-compaction-algorithm.md) | Draft |
 | 0113 | [Bundles declare connector build inputs and tiers deliver pinned images](0113-bundles-declare-connector-build-inputs-and-tiers-deliver-pinned-images.md) | Accepted |
 | 0114 | [Cluster up infers detected install facts](0114-cluster-up-infers-detected-install-facts.md) | Accepted |
-| 0115 | [Agents call each other directly, with no third party in the path](0115-agents-call-each-other-with-no-third-party.md) | Draft |
 | 0123 | [A pending approval's approver set does not follow its route binding](0123-a-pending-approvals-approver-set-does-not-follow-its-route-binding.md) | Accepted |
+| 0132 | [Agents call each other directly, with no third party in the path](0132-agents-call-each-other-with-no-third-party.md) | Accepted |
 <!-- END GENERATED: adr-index -->


### PR DESCRIPTION
## What

- Renumber the main-only agent-to-agent Draft from ADR-0115 to ADR-0132.
- Publish it as Accepted.
- Regenerate the ADR index.

## Why

`next` already owns ADR-0115 for the Accepted runtime repository-selection decision. ADR-0132 is the first globally free number after the next release train and current ADR reservations. The agent-to-agent boundary received explicit maintainer direction and approval in #1793.

## Verification

- `bash scripts/check-docs.sh`

Refs #1793
