### PR TITLE
Bound successful runner stream cleanup

### DIFF
--- a/apps/worker/src/curie_worker/kernel.py
+++ b/apps/worker/src/curie_worker/kernel.py
@@ -1792,17 +1792,31 @@ class Kernel:
         # turns per thread across workers). Then release the order lock so the
         # next same-thread event can route, and release the Valkey lock before
         # streaming so a follow-up can steer.
+        routed: _RouteResult | None = None
+
+        def close_routed_turn() -> None:
+            if routed is not None and routed.turn is not None:
+                routed.turn.close()
+
         try:
-            async with self._lock.hold(self._config.lock_key(thread_key)):
-                routed = await self._route_and_start(
-                    thread_key,
-                    event,
-                    boot_env,
-                    packs,
-                    workspace_deployment_id=workspace_deployment_id,
-                    agent_name=agent_name,
-                    source=qevent.source,
-                )
+            try:
+                async with self._lock.hold(self._config.lock_key(thread_key)):
+                    routed = await self._route_and_start(
+                        thread_key,
+                        event,
+                        boot_env,
+                        packs,
+                        workspace_deployment_id=workspace_deployment_id,
+                        agent_name=agent_name,
+                        source=qevent.source,
+                    )
+            except BaseException:
+                # start_turn owns a live response as soon as it returns, which
+                # is before the route lock's async exit has finished. Preserve
+                # cancellation and every existing error policy, but release the
+                # response first if lock cleanup itself fails or is cancelled.
+                close_routed_turn()
+                raise
         except CapacityExhaustedError as exc:
             release_order()
             rejection = exc.rejection
@@ -1850,13 +1864,21 @@ class Kernel:
             release_order()
             logger.warning("turn start failed for %s: %r", qevent.event_id, exc)
             return TurnOutcome(terminal_ok=False, classification="runner-error")
-        release_order()
+        assert routed is not None
+        try:
+            release_order()
+        except BaseException:
+            close_routed_turn()
+            raise
 
         if not self._config.slack_no_edit_streaming and defer_job_booting:
             try:
                 # Routing succeeded, so this delivery owns a real turn. Adopt the
                 # minted ref before streaming so every later update edits it.
                 await self._reply_for(qevent, route, self._config.booting_text)
+            except asyncio.CancelledError:
+                close_routed_turn()
+                raise
             except Exception:
                 logger.warning("booting-state update failed for %s", qevent.event_id)
 
@@ -1883,6 +1905,7 @@ class Kernel:
             return TurnOutcome(terminal_ok=True, steered=True)
 
         assert routed.handle is not None and routed.turn is not None
+        turn = routed.turn
         # Register this owner turn so a kill for its agent interrupts it, then
         # stream; unregister when the turn ends.
         self._register_run(agent_id, thread_key)
@@ -1896,7 +1919,7 @@ class Kernel:
                 and await self._killswitch.is_killed(agent_id)
             ):
                 await self.interrupt_thread(thread_key, f"agent {agent_id} killed by operator")
-            outcome = await self._consume(qevent, route, routed.turn, nav, agent_id)
+            outcome = await self._consume(qevent, route, turn, nav, agent_id)
             if (
                 outcome.status is SessionStatus.AWAITING_APPROVAL
                 and _is_publish_provenance(
@@ -1938,6 +1961,11 @@ class Kernel:
             return outcome
         finally:
             self._unregister_run(agent_id, thread_key)
+            # _consume owns bounded post-Final drain and normally releases the
+            # response itself. This idempotent backstop covers cancellation or
+            # an unexpected failure after start_turn but before _consume enters
+            # its response context.
+            turn.close()
 
     async def _route_and_start(
         self,

--- a/apps/worker/src/curie_worker/runner_client.py
+++ b/apps/worker/src/curie_worker/runner_client.py
@@ -15,6 +15,7 @@ follow-up can only steer the live turn and never fork a second one.
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import binascii
 import json
@@ -25,7 +26,7 @@ from types import TracebackType
 from typing import TypeVar
 
 import aiohttp
-from aci_protocol import Event, Interrupt, OutboundEvent, parse_ndjson_line
+from aci_protocol import Event, Final, Interrupt, OutboundEvent, parse_ndjson_line
 from curie_telemetry import inject_trace_context, operation_span, record_metric
 from opentelemetry.trace import SpanKind, StatusCode
 
@@ -42,6 +43,8 @@ from opentelemetry.trace import SpanKind, StatusCode
 # going) instead of re-deriving the bound -- or a coupling to this client's
 # other timeouts -- at each call site.
 _DEFAULT_INTERRUPT_TIMEOUT_S = 5.0
+_POST_FINAL_CLEANUP_TIMEOUT_S = 1.0
+_POST_FINAL_DISCARD_CHUNK_BYTES = 64 * 1024
 _T = TypeVar("_T")
 
 
@@ -79,13 +82,49 @@ class TurnStream:
 
     def __init__(self, response: aiohttp.ClientResponse) -> None:
         self._response = response
+        self._saw_final = False
 
     async def __aiter__(self) -> AsyncIterator[OutboundEvent]:
         async for raw in self._response.content:
             line = raw.decode("utf-8").strip()
             if not line:
                 continue
-            yield parse_ndjson_line(line)
+            frame = parse_ndjson_line(line)
+            if isinstance(frame, Final):
+                self._saw_final = True
+            yield frame
+            if isinstance(frame, Final):
+                # Final is terminal for every consumer, including evals that
+                # naturally iterate to stream end. Bytes after it belong only
+                # to the bounded transport cleanup in __aexit__; they must not
+                # be parsed, applied, or allowed to occupy the 600s turn budget.
+                return
+
+    async def _discard_post_final(self) -> None:
+        """Briefly keep the transport open while discarding bytes through EOF.
+
+        ``Kernel._consume`` stops applying frames at ``Final`` so a late line
+        cannot overwrite the outcome. Releasing at that moment closes the
+        socket while the runner is still recording the turn and calling
+        ``write_eof`` (issue #1958). The runner-controlled tail is read in
+        fixed-size chunks and given its own short bound rather than the normal
+        600-second stream timeout. Once a valid Final was observed, cleanup is
+        best-effort and cannot turn that successful result into a retry.
+        """
+        if not self._saw_final or self._response.content.at_eof():
+            return
+        try:
+            async with asyncio.timeout(_POST_FINAL_CLEANUP_TIMEOUT_S):
+                while not self._response.content.at_eof():
+                    chunk = await self._response.content.read(
+                        _POST_FINAL_DISCARD_CHUNK_BYTES
+                    )
+                    if not chunk:
+                        break
+        except TimeoutError:
+            return
+        except Exception:  # noqa: BLE001 - post-Final cleanup is best-effort
+            return
 
     def close(self) -> None:
         self._response.release()
@@ -99,7 +138,11 @@ class TurnStream:
         exc: BaseException | None,
         tb: TracebackType | None,
     ) -> None:
-        self.close()
+        try:
+            if exc_type is None:
+                await self._discard_post_final()
+        finally:
+            self.close()
 
 
 class RunnerClient:

--- a/apps/worker/tests/eval/conftest.py
+++ b/apps/worker/tests/eval/conftest.py
@@ -10,6 +10,7 @@ and Langfuse are always real."""
 
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import io
 import os
@@ -105,6 +106,13 @@ class FakeEvalRunner:
         # When True, /v1/reset answers 500 -- models a runner that could not
         # establish per-case isolation.
         self.fail_reset = False
+        # Inputs that keep the HTTP handler open after a valid Final. This is a
+        # real transport-boundary probe for consumers that naturally iterate to
+        # stream end instead of breaking at Final themselves.
+        self.post_final_stall_inputs: set[str] = set()
+        self.post_final_started = asyncio.Event()
+        self.post_final_unblock = asyncio.Event()
+        self.post_final_handler_done = asyncio.Event()
 
     async def _status(self, _request: web.Request) -> web.Response:
         return web.json_response({"status": "done", "turn_active": False})
@@ -156,6 +164,18 @@ class FakeEvalRunner:
             output_tokens=usage[1] if usage else None,
         )
         await resp.write((frame.model_dump_json() + "\n").encode("utf-8"))
+        if text in self.post_final_stall_inputs:
+            self.post_final_started.set()
+            try:
+                await self.post_final_unblock.wait()
+                await resp.write_eof()
+            except (ConnectionError, OSError):
+                # The client's bounded cleanup deliberately releases a peer
+                # that remains stalled after its terminal frame.
+                pass
+            finally:
+                self.post_final_handler_done.set()
+            return resp
         await resp.write_eof()
         return resp
 

--- a/apps/worker/tests/eval/test_runner.py
+++ b/apps/worker/tests/eval/test_runner.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Sequence
+from typing import Any
 
 import pytest
 from curie_worker.eval import (
@@ -21,6 +22,56 @@ from curie_worker.eval import (
 )
 
 CONTAINS = GraderKind.CONTAINS
+
+
+def test_eval_stops_at_final_and_bounds_a_stalled_http_tail(make_eval_harness) -> None:
+    async def go() -> None:
+        async with make_eval_harness() as (base_url, fake, client):
+            fake.responses = {"q": "answer"}
+            fake.post_final_stall_inputs = {"q"}
+            suite = EvalSuite(
+                name="post-final-stall",
+                cases=[
+                    EvalCase(
+                        id="c",
+                        input="q",
+                        grader=Grader(kind=CONTAINS, expected="answer"),
+                    )
+                ],
+            )
+            release_calls: list[dict[str, int]] = []
+            real_start_turn = client.start_turn
+
+            async def start_turn(*args: Any, **kwargs: Any) -> Any:
+                turn = await real_start_turn(*args, **kwargs)
+                calls = {"n": 0}
+                real_release = turn._response.release
+
+                def release() -> Any:
+                    calls["n"] += 1
+                    return real_release()
+
+                turn._response.release = release
+                release_calls.append(calls)
+                return turn
+
+            client.start_turn = start_turn  # type: ignore[method-assign]
+            task = asyncio.create_task(
+                EvalRunner(client).run(suite, base_url=base_url, version="v1")
+            )
+            try:
+                await asyncio.wait_for(fake.post_final_started.wait(), timeout=1.0)
+                result = await asyncio.wait_for(task, timeout=2.0)
+                assert result.summary() == "1/1 passed"
+                assert result.results[0].output == "answer"
+                assert release_calls == [{"n": 1}]
+            finally:
+                fake.post_final_unblock.set()
+                if not task.done():
+                    task.cancel()
+                await asyncio.wait_for(fake.post_final_handler_done.wait(), timeout=1.0)
+
+    asyncio.run(go())
 
 
 def test_runs_and_grades_a_mixed_suite(make_eval_harness) -> None:

--- a/apps/worker/tests/kernel/test_kernel.py
+++ b/apps/worker/tests/kernel/test_kernel.py
@@ -11,8 +11,10 @@ import logging
 import threading
 import time
 import uuid
-from collections.abc import Callable
+from collections.abc import AsyncIterator, Callable
+from contextlib import asynccontextmanager
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 from aci_protocol import (
@@ -31,7 +33,7 @@ from curie_worker import kernel as kernel_module
 from curie_worker.behaviorpacks import BehaviorPacks
 from curie_worker.kernel import ThreadBusyError
 from curie_worker.reply_sink import TargetRoute
-from curie_worker.runner_client import RunnerError
+from curie_worker.runner_client import RunnerError, TurnStream
 from curie_worker.sandbox import QuotaRejection
 from curie_worker.workspace import WorkspaceSelectionRefused
 
@@ -75,6 +77,25 @@ async def _wait_until(pred: Callable[[], bool], timeout: float = 5.0) -> None:
     raise AssertionError("condition not met within timeout")
 
 
+def _spy_next_turn_release(kernel: Any) -> dict[str, int]:
+    calls = {"n": 0}
+    real_start_turn = kernel._runner.start_turn
+
+    async def start_turn(*args: Any, **kwargs: Any) -> TurnStream:
+        turn = await real_start_turn(*args, **kwargs)
+        real_release = turn._response.release
+
+        def release() -> Any:
+            calls["n"] += 1
+            return real_release()
+
+        turn._response.release = release
+        return turn
+
+    kernel._runner.start_turn = start_turn
+    return calls
+
+
 def test_new_turn_streams_to_slack_and_acks(make_harness) -> None:
     async def go() -> None:
         async with make_harness() as h:
@@ -89,6 +110,152 @@ def test_new_turn_streams_to_slack_and_acks(make_harness) -> None:
             assert h.runner.opened == ["hi"]
             assert h.sink.last_text == "Hello world"
             assert await h.async_redis.exists(h.config.done_key(ev.event_id))
+
+    asyncio.run(go())
+
+
+def test_post_final_stall_does_not_reclassify_or_retry_success(make_harness) -> None:
+    async def go() -> None:
+        async with make_harness(max_attempts=3) as h:
+            hold = asyncio.Event()
+            h.runner.default_script = [Final(text="answer", status=DONE)]
+            h.runner.hold = hold
+            event = _qevent("hi")
+            try:
+                await asyncio.wait_for(h.kernel.process_event(event), timeout=2.0)
+                assert h.runner.opened == ["hi"]
+                assert h.sink.last_text == "answer"
+                assert await h.async_redis.exists(h.config.done_key(event.event_id))
+            finally:
+                hold.set()
+
+    asyncio.run(go())
+
+
+def test_cancellation_while_route_lock_exits_releases_open_runner_response(
+    make_harness,
+) -> None:
+    class BlockingExitLock:
+        def __init__(self, inner: object) -> None:
+            self._inner = inner
+            self.exit_started = asyncio.Event()
+            self.unblock = asyncio.Event()
+
+        @asynccontextmanager
+        async def hold(self, key: str) -> AsyncIterator[object]:
+            async with self._inner.hold(key) as lease:  # type: ignore[attr-defined]
+                yield lease
+                self.exit_started.set()
+                await self.unblock.wait()
+
+    async def go() -> None:
+        async with make_harness() as h:
+            runner_hold = asyncio.Event()
+            h.runner.hold = runner_hold
+            h.runner.default_script = [Final(text="answer", status=DONE)]
+            lock = BlockingExitLock(h.kernel._lock)
+            h.kernel._lock = lock  # type: ignore[assignment]
+            release_calls = _spy_next_turn_release(h.kernel)
+            task = asyncio.create_task(h.kernel.process_event(_qevent("hi", thread="tCancel")))
+            try:
+                await asyncio.wait_for(lock.exit_started.wait(), timeout=1.0)
+                task.cancel()
+                with pytest.raises(asyncio.CancelledError):
+                    await task
+                assert release_calls["n"] >= 1
+            finally:
+                lock.unblock.set()
+                runner_hold.set()
+                if not task.done():
+                    task.cancel()
+                await _wait_until(lambda: not h.runner.turn_active)
+
+    asyncio.run(go())
+
+
+def test_cancellation_during_registered_kill_recheck_releases_runner_response(
+    make_harness,
+) -> None:
+    class BlockingSecondKillCheck:
+        def __init__(self) -> None:
+            self.calls = 0
+            self.entered = asyncio.Event()
+            self.unblock = asyncio.Event()
+
+        async def is_killed(self, _agent_id: uuid.UUID) -> bool:
+            self.calls += 1
+            if self.calls == 1:
+                return False
+            self.entered.set()
+            await self.unblock.wait()
+            return False
+
+    async def go() -> None:
+        agent_id = uuid.uuid4()
+        binding = _TokenBinding("", agent_id)
+        async with make_harness(binding=binding) as h:
+            runner_hold = asyncio.Event()
+            h.runner.hold = runner_hold
+            h.runner.default_script = [Final(text="answer", status=DONE)]
+            killswitch = BlockingSecondKillCheck()
+            h.kernel.attach_killswitch(killswitch)  # type: ignore[arg-type]
+            release_calls = _spy_next_turn_release(h.kernel)
+            task = asyncio.create_task(h.kernel.process_event(_qevent("hi", thread="tRegistered")))
+            try:
+                await asyncio.wait_for(killswitch.entered.wait(), timeout=1.0)
+                task.cancel()
+                with pytest.raises(asyncio.CancelledError):
+                    await task
+                assert release_calls["n"] >= 1
+            finally:
+                killswitch.unblock.set()
+                runner_hold.set()
+                if not task.done():
+                    task.cancel()
+                await _wait_until(lambda: not h.runner.turn_active)
+
+    asyncio.run(go())
+
+
+def test_cancellation_during_deferred_job_boot_reply_releases_runner_response(
+    make_harness,
+) -> None:
+    async def go() -> None:
+        async with make_harness() as h:
+            runner_hold = asyncio.Event()
+            h.runner.hold = runner_hold
+            h.runner.default_script = [Final(text="answer", status=DONE)]
+            reply_started = asyncio.Event()
+            reply_unblock = asyncio.Event()
+
+            async def blocking_reply(*_args: Any, **_kwargs: Any) -> None:
+                reply_started.set()
+                await reply_unblock.wait()
+
+            h.kernel._reply_for = blocking_reply  # type: ignore[method-assign]
+            release_calls = _spy_next_turn_release(h.kernel)
+            task = asyncio.create_task(
+                h.kernel.process_event(
+                    _qevent(
+                        "digest",
+                        thread="tDeferred",
+                        placeholder=None,
+                        source=TurnSource.CRON,
+                    )
+                )
+            )
+            try:
+                await asyncio.wait_for(reply_started.wait(), timeout=1.0)
+                task.cancel()
+                with pytest.raises(asyncio.CancelledError):
+                    await task
+                assert release_calls["n"] >= 1
+            finally:
+                reply_unblock.set()
+                runner_hold.set()
+                if not task.done():
+                    task.cancel()
+                await _wait_until(lambda: not h.runner.turn_active)
 
     asyncio.run(go())
 

--- a/apps/worker/tests/kernel/test_runner_client.py
+++ b/apps/worker/tests/kernel/test_runner_client.py
@@ -7,12 +7,17 @@ is what TurnStream.close (called from __aexit__) invokes."""
 from __future__ import annotations
 
 import asyncio
+import tracemalloc
 from typing import Any
 
 import pytest
 from aci_protocol import Event, Final, SessionStatus, TextDelta
 from aiohttp import web
 from aiohttp.test_utils import TestServer
+from curie_runner import RunTracer, SideEffectClassifier, create_app
+from curie_runner import server as runner_server
+from curie_runner.fake import FakeModelSession
+from curie_runner.session import SessionRunner
 from curie_worker.runner_client import RunnerClient, RunnerError
 
 DONE = SessionStatus.DONE
@@ -238,6 +243,248 @@ def test_snapshot_refuses_an_oversized_body_before_json_decoding() -> None:
                     f"http://127.0.0.1:{server.port}", token="runner-token"
                 )
         finally:
+            await client.close()
+            await server.close()
+
+    asyncio.run(go())
+
+
+# --- Successful Final must not RST the runner before write_eof (issue #1958) --
+# Kernel._consume stops applying frames at Final, then TurnStream.__aexit__
+# releases the aiohttp response. Against the real runner HTTP stream that
+# races server._event's write_eof (after aclosing teardown) and logs
+# ClientConnectionResetError on a completed turn. Drain the rest of the body
+# before release so write_eof still sees an open transport.
+
+
+def test_kernel_final_break_closes_real_runner_stream_without_write_eof_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    handler_errors: list[BaseException] = []
+    write_eof_errors: list[BaseException] = []
+    real_write_eof = web.StreamResponse.write_eof
+    original_event = runner_server._event
+
+    async def spy_write_eof(self: web.StreamResponse, data: bytes = b"") -> None:
+        try:
+            await real_write_eof(self, data)
+        except BaseException as exc:
+            write_eof_errors.append(exc)
+            raise
+
+    monkeypatch.setattr(web.StreamResponse, "write_eof", spy_write_eof)
+
+    async def go() -> None:
+        handler_done = asyncio.Event()
+
+        async def wrapped_event(request: web.Request) -> web.StreamResponse:
+            try:
+                return await original_event(request)
+            except BaseException as exc:
+                handler_errors.append(exc)
+                raise
+            finally:
+                handler_done.set()
+
+        monkeypatch.setattr(runner_server, "_event", wrapped_event)
+        fake = FakeModelSession()
+        runner = SessionRunner(
+            session_factory=lambda: fake,
+            ceiling=0,
+            tracer=RunTracer(None),
+            classifier=SideEffectClassifier(),
+            trace_name="t",
+        )
+        original_record = runner._record_turn
+
+        async def delayed_record(*args: Any, **kwargs: Any) -> Any:
+            # Production posts the transcript after yielding Final and before
+            # the generator ends. That is the window _consume uses to break
+            # and release, which then cancels _event before write_eof.
+            await asyncio.sleep(0.05)
+            return await original_record(*args, **kwargs)
+
+        runner._record_turn = delayed_record  # type: ignore[method-assign]
+        await runner.start()
+        server = TestServer(create_app(runner))
+        await server.start_server()
+        base_url = f"http://127.0.0.1:{server.port}"
+        client = RunnerClient(total_timeout_s=30.0)
+        saw_final = False
+        try:
+            turn = await client.start_turn(base_url, _event())
+            release_calls = _spy_release(turn)
+            async with turn:
+                async for frame in turn:
+                    if isinstance(frame, Final):
+                        assert frame.status == DONE
+                        saw_final = True
+                        break
+            await asyncio.wait_for(handler_done.wait(), timeout=5.0)
+            assert saw_final
+            assert handler_errors == [], (
+                f"successful Final produced a runner handler error: {handler_errors!r}"
+            )
+            assert write_eof_errors == [], (
+                "successful Final closed the runner transport before write_eof: "
+                f"{write_eof_errors!r}"
+            )
+            assert release_calls["n"] >= 1
+        finally:
+            await client.close()
+            await server.close()
+            await runner.close()
+
+    asyncio.run(go())
+
+
+class _PostFinalRunner:
+    """Real HTTP peer with controllable behavior after a valid Final."""
+
+    def __init__(self, *, stall: bool = False, tail_bytes: int = 0) -> None:
+        self.app = web.Application()
+        self.app.add_routes([web.post("/v1/event", self._event)])
+        self.stall = stall
+        self.tail_bytes = tail_bytes
+        self.after_final = asyncio.Event()
+        self.unblock = asyncio.Event()
+        self.handler_done = asyncio.Event()
+        self.handler_errors: list[BaseException] = []
+
+    async def _event(self, request: web.Request) -> web.StreamResponse:
+        response = web.StreamResponse(
+            status=200, headers={"Content-Type": "application/x-ndjson"}
+        )
+        await response.prepare(request)
+        try:
+            await response.write(
+                (Final(text="done", status=DONE).model_dump_json() + "\n").encode()
+            )
+            self.after_final.set()
+            if self.stall:
+                await self.unblock.wait()
+            chunk = b"x" * (64 * 1024)
+            remaining = self.tail_bytes
+            while remaining:
+                size = min(remaining, len(chunk))
+                await response.write(chunk[:size])
+                remaining -= size
+            await response.write_eof()
+        except asyncio.CancelledError:
+            raise
+        except (ConnectionError, OSError) as exc:
+            # Expected only when a timeout/cancellation test deliberately
+            # releases the client response before unblocking this handler.
+            self.handler_errors.append(exc)
+        finally:
+            self.handler_done.set()
+        return response
+
+
+async def _break_after_final(turn: Any, final_seen: asyncio.Event | None = None) -> None:
+    async with turn:
+        async for frame in turn:
+            if isinstance(frame, Final):
+                if final_seen is not None:
+                    final_seen.set()
+                break
+
+
+def test_post_final_stall_has_a_short_cleanup_bound_and_releases_response() -> None:
+    async def go() -> None:
+        runner = _PostFinalRunner(stall=True)
+        server = TestServer(runner.app)
+        await server.start_server()
+        client = RunnerClient(total_timeout_s=30.0)
+        turn = await client.start_turn(f"http://127.0.0.1:{server.port}", _event())
+        release_calls = _spy_release(turn)
+        loop = asyncio.get_running_loop()
+        started = loop.time()
+        try:
+            await asyncio.wait_for(_break_after_final(turn), timeout=2.0)
+            assert loop.time() - started < 2.0
+            assert release_calls["n"] >= 1
+        finally:
+            runner.unblock.set()
+            await client.close()
+            await server.close()
+
+    asyncio.run(go())
+
+
+def test_cancellation_during_post_final_drain_propagates_and_releases_response() -> None:
+    async def go() -> None:
+        runner = _PostFinalRunner(stall=True)
+        server = TestServer(runner.app)
+        await server.start_server()
+        client = RunnerClient(total_timeout_s=30.0)
+        turn = await client.start_turn(f"http://127.0.0.1:{server.port}", _event())
+        release_calls = _spy_release(turn)
+        final_seen = asyncio.Event()
+        task = asyncio.create_task(_break_after_final(turn, final_seen))
+        try:
+            await asyncio.wait_for(final_seen.wait(), timeout=1.0)
+            await asyncio.sleep(0.05)
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+            assert release_calls["n"] >= 1
+        finally:
+            runner.unblock.set()
+            if not task.done():
+                task.cancel()
+            await client.close()
+            await server.close()
+
+    asyncio.run(go())
+
+
+def test_unexpected_post_final_cleanup_error_is_ignored_and_releases_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def go() -> None:
+        runner = _PostFinalRunner(stall=True)
+        server = TestServer(runner.app)
+        await server.start_server()
+        client = RunnerClient(total_timeout_s=30.0)
+        turn = await client.start_turn(f"http://127.0.0.1:{server.port}", _event())
+        release_calls = _spy_release(turn)
+
+        async def cleanup_boom(_reader: Any, _size: int) -> bytes:
+            raise RuntimeError("unexpected cleanup failure")
+
+        try:
+            monkeypatch.setattr(type(turn._response.content), "read", cleanup_boom)
+            await _break_after_final(turn)
+            assert release_calls["n"] >= 1
+        finally:
+            runner.unblock.set()
+            await client.close()
+            await server.close()
+
+    asyncio.run(go())
+
+
+def test_large_post_final_tail_is_discarded_without_aggregation() -> None:
+    async def go() -> None:
+        runner = _PostFinalRunner(tail_bytes=32 * 1024 * 1024)
+        server = TestServer(runner.app)
+        await server.start_server()
+        client = RunnerClient(total_timeout_s=30.0)
+        turn = await client.start_turn(f"http://127.0.0.1:{server.port}", _event())
+        release_calls = _spy_release(turn)
+        tracemalloc.start()
+        tracemalloc.reset_peak()
+        try:
+            baseline, _ = tracemalloc.get_traced_memory()
+            await asyncio.wait_for(_break_after_final(turn), timeout=5.0)
+            _current, peak = tracemalloc.get_traced_memory()
+            assert peak - baseline < 8 * 1024 * 1024
+            assert release_calls["n"] >= 1
+            await asyncio.wait_for(runner.handler_done.wait(), timeout=1.0)
+            assert runner.handler_errors == []
+        finally:
+            tracemalloc.stop()
             await client.close()
             await server.close()
 


### PR DESCRIPTION
## Summary

Keep a successful worker-to-runner stream open briefly after its terminal `Final`, discard any remaining runner-controlled bytes incrementally under a one-second cleanup bound, and release the response on every cleanup and cancellation path. `Final` is now terminal for every `TurnStream` consumer, preventing evals or other consumers from applying or waiting on a post-terminal tail.

## Related issue

Closes #1958

## Fix pin verification

Fix pin: apps/worker/tests/kernel/test_runner_client.py::test_kernel_final_break_closes_real_runner_stream_without_write_eof_error

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | No plugin packaging, runner turn-loop, ACI event, skill eval, or skill-check behavior changed. | n/a | n/a |
| local | required | Worker HTTP stream ownership and the worker-to-runner path changed. | fake | `CURIE_E2E_TIERS=local CURIE_BIN=/tmp/curie-1958-cargo-target/debug/curie CURIE_BASE_TAG=dev CURIE_DISPATCHER_IMAGE=ghcr.io/curie-eng/curie-dispatcher:dev CURIE_RUNNER_IMAGE=ghcr.io/curie-eng/curie-runner:dev CURIE_FAKE_MODEL=1 /tmp/curie-1958-cargo-target/debug/curie dev e2e-ladder` on `6637ce1c`: `LADDER PASS (tiers: local)`; the real queue → worker → Docker runner path finalized a reply, the injected runner failure was observed and recovery finalized, and teardown removed 4 runner containers with no Curie containers left. |
| local-release | n/a | No released binary/image identity, install path, version pin, or release compose changed. | n/a | n/a |
| cluster | n/a | No chart, RBAC, securityContext, NetworkPolicy, sandbox claim, or init-container surface changed. | n/a | n/a |
| live provider | n/a | No model routing, provider credentials/auth, token, or cost accounting changed. | n/a | n/a |
| external integration | n/a | No Slack, webhook, connector OAuth, or third-party API shape changed. | n/a | n/a |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.
- [ ] Or: this change is not behavior-bearing, so no tier applies, and the summary says why.

Positive and falsifiable evidence on `6637ce1c`:

- `uv run pytest apps/worker/tests/kernel -q` — `247 passed in 18.29s` against a real reachable Valkey. This includes prompt EOF with no runner handler traceback, a one-second stalled-tail bound with one opened turn/no retry/done marker, post-Final drain cancellation, cancellation before `_consume`, unexpected cleanup failure, and a 32 MiB tail below the 8 MiB traced-memory ceiling.
- `uv run pytest apps/worker/tests/eval/test_runner.py -q` — `27 passed in 1.08s`; an eval consumer that does not explicitly break completes successfully through the shared terminal boundary despite a stalled HTTP tail.
- `uv run pytest runner/tests/test_server.py runner/tests/test_session.py -q` — `39 passed in 0.72s`.
- `/tmp/curie-1958-cargo-target/debug/curie dev verify-fix-pin HEAD apps/worker/tests/kernel/test_runner_client.py::test_kernel_final_break_closes_real_runner_stream_without_write_eof_error` — candidate passed; reversing only product hunks failed because the real runner handler was cancelled after `Final`; result `PINNED`.
- `uv run ruff check .`, `uv run mypy`, and `uv run lint-imports` — all passed; 229 source files typed and all 3 import contracts kept.
- Independent adversarial review: code quality `APPROVE`; security/resource lifecycle `SECURE`; focused QA passed with asyncio debug/ResourceWarning enforcement and five repeated 32 MiB-tail runs.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed. (No public command or contract documentation changed; the internal ownership contract is documented in code.)
- [x] An ADR is added under `docs/adr/` if this is an architectural decision. (Not applicable; no architecture decision or frozen contract changed.)
