### PR TITLE
Wait for Postgres before starting Langfuse web

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -954,8 +954,9 @@ jobs:
       # GHA-layer-cached builds via a named buildx builder that is NOT made the
       # default (`use: false`), same mechanism the `e2e-ladder` job documents.
       # `load: true` exports each image into the local daemon store so `kind
-      # load` picks it up with no registry round trip. Only the four images the
-      # cluster round trip actually needs; the dispatcher is not deployed.
+      # load` picks it up with no registry round trip. The four product images
+      # drive the cluster round trip; a fifth fixture image delays Postgres for
+      # the Langfuse startup regression. The dispatcher is not deployed.
       - name: Set up a cache-only buildx builder (named, NOT the default)
         id: clustercache
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
@@ -1005,6 +1006,17 @@ jobs:
           load: true
           cache-from: type=gha,scope=ladder-runner
           cache-to: type=gha,mode=max,scope=ladder-runner
+      - name: Build the delayed Postgres readiness fixture locally
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: charts/curie/ci
+          file: charts/curie/ci/postgres-readiness-delay.Dockerfile
+          builder: ${{ steps.clustercache.outputs.name }}
+          tags: curie-postgres-readiness:${{ github.sha }}
+          push: false
+          load: true
+          cache-from: type=gha,scope=langfuse-postgres-readiness
+          cache-to: type=gha,mode=max,scope=langfuse-postgres-readiness
       # kind config: map the UI NodePort (chart default 30080) to the host so
       # `cluster deploy`'s UI `/api` NodePort discovery -- which resolves the
       # loopback kubeconfig host (127.0.0.1) -- reaches the in-cluster API.
@@ -1074,14 +1086,30 @@ jobs:
           kubectl apply -f https://raw.githubusercontent.com/projectcalico/calico/v3.28.2/manifests/calico.yaml
           kubectl -n kube-system rollout status daemonset/calico-node --timeout=300s
           kubectl wait --for=condition=Ready node --all --timeout=300s
-      # Load the four locally-built images into the node store so the install's
-      # pullPolicy Never overrides bind them with no registry pull.
+      # Load the locally-built product images and uniquely tagged Postgres delay
+      # fixture into the node store with no registry round trip.
       - name: Load images into the kind cluster
         run: |
           set -euo pipefail
-          for img in curie-api:local curie-worker:local curie-ui:local curie-runner:latest; do
+          for img in \
+            curie-api:local \
+            curie-worker:local \
+            curie-ui:local \
+            curie-runner:latest \
+            "curie-postgres-readiness:${GITHUB_SHA}"; do
             kind load docker-image "$img" --name curie-e2e
           done
+      - name: Langfuse web waits for delayed Postgres without restarting
+        env:
+          READINESS_NAMESPACE: curie-1853-${{ github.run_id }}-${{ github.run_attempt }}
+          READINESS_RELEASE: curie-1853-${{ github.run_id }}-${{ github.run_attempt }}
+          READINESS_POSTGRES_IMAGE: curie-postgres-readiness:${{ github.sha }}
+        run: |
+          set -euo pipefail
+          bash charts/curie/ci/runtime/langfuse-postgres-readiness-runtime.sh \
+            --namespace "$READINESS_NAMESPACE" \
+            --release "$READINESS_RELEASE" \
+            --postgres-image "$READINESS_POSTGRES_IMAGE"
       # The pod-reachable host for the reply stub: the kind Docker network
       # gateway. Every node container sits on this bridge, so a pod egressing
       # through its node reaches the host here; the stub binds 0.0.0.0 and answers

--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -178,6 +178,14 @@ jobs:
           set -euo pipefail
           bash charts/curie/ci/langfuse-runasuser-assertions.sh
 
+      # Prove the web-only Postgres readiness gate is ordered before Langfuse,
+      # credential-free, bounded/tunable, hardened like the web container, and
+      # removable through its explicit values switch. Includes a red mutation.
+      - name: helm render assertions (langfuse postgres readiness)
+        run: |
+          set -euo pipefail
+          bash charts/curie/ci/langfuse-postgres-readiness-assertions.sh
+
       # Prove the controller NetworkPolicy RBAC split (issue #350): exactly one
       # read-only cluster grant (get/list/watch) so the informer syncs, no
       # cluster-wide mutate anywhere (#66 guarded), namespaced mutate intact, and

--- a/charts/curie/README.md
+++ b/charts/curie/README.md
@@ -228,6 +228,24 @@ Toggles (all default `true`): `langfuse.deploy`, `postgres.deploy`,
 Flipping any to `false` removes its resources from the render; consumers
 (Langfuse env, the collector config) repoint at the BYO host automatically.
 
+### Langfuse Postgres startup readiness
+
+`langfuse.web.postgresReadiness` is enabled by default. Before Langfuse web
+starts, its `wait-for-postgres` init container makes a credential-free
+`pg_isready` protocol-readiness check only; it does not validate authentication
+or run migrations. Its `image` is empty by default and falls back to
+`postgres.image`; override it for a BYO Postgres/private registry when the
+default image is unavailable there.
+
+Defaults are `attempts: 60`, `intervalSeconds: 2`, and
+`probeTimeoutSeconds: 2`: the wait is bounded to approximately 2--4 minutes,
+depending on how quickly each probe fails. While the Pod remains in `Init`, use
+`kubectl logs <langfuse-web-pod> -c wait-for-postgres` and check the Postgres
+endpoint, DNS, and network path. Exhaustion fails the init container so
+Kubernetes restarts it. After a successful protocol check, Langfuse web owns
+authentication and migrations: bad credentials and permanent migration failures
+are terminal there and are not retried by this gate.
+
 Secrets: all credentials are written to one `<release>-secrets` Secret. A sealed
 `helm install` (the default) generates strong random values for all eleven
 chart owned credentials: the backing store passwords, Langfuse

--- a/charts/curie/ci/langfuse-postgres-readiness-assertions.sh
+++ b/charts/curie/ci/langfuse-postgres-readiness-assertions.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Fast render contract for the Langfuse web Postgres readiness gate (#1853).
-# The live delayed-start regression is the non-executable sibling in this
-# directory; this executable script is the chart-check/helm-ci fast pin.
+# The executable live delayed-start regression is nested under ci/runtime so
+# chart-check keeps discovering only the fast top-level assertion scripts.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -22,6 +22,9 @@ render() {
 render default
 render disabled --set langfuse.web.postgresReadiness.enabled=false
 render blank-security --set-json 'langfuse.web.containerSecurityContext=null'
+render root-web-security \
+  --set langfuse.web.containerSecurityContext.runAsNonRoot=false \
+  --set langfuse.web.containerSecurityContext.runAsUser=0
 render tuned \
   --set-string langfuse.web.postgresReadiness.image=registry.example.com/postgres-readiness:test \
   --set langfuse.web.postgresReadiness.attempts=7 \
@@ -74,7 +77,7 @@ if wait.get("image") != expected_image:
 web_main = next(item for item in web_spec["containers"] if item.get("name") == "langfuse-web")
 wait_sc = wait.get("securityContext") or {}
 web_sc = web_main.get("securityContext") or {}
-if mode != "blank-security" and wait_sc != web_sc:
+if mode not in ("blank-security", "root-web-security") and wait_sc != web_sc:
     raise SystemExit(f"wait-for-postgres securityContext differs from langfuse-web: {wait_sc!r} != {web_sc!r}")
 uid = wait_sc.get("runAsUser")
 if type(uid) is not int or uid < 1:
@@ -83,6 +86,9 @@ if wait_sc.get("runAsNonRoot") is not True:
     raise SystemExit("wait-for-postgres must retain runAsNonRoot=true")
 if mode == "blank-security" and (uid != 1001 or web_sc):
     raise SystemExit(f"blank web securityContext must leave the init at its 1001 non-root floor, got wait={wait_sc!r} web={web_sc!r}")
+if mode == "root-web-security":
+    if uid != 1001 or web_sc.get("runAsUser") != 0 or web_sc.get("runAsNonRoot") is not False:
+        raise SystemExit(f"root web override must leave the readiness init at its 1001 non-root floor, got wait={wait_sc!r} web={web_sc!r}")
 
 env_items = wait.get("env", [])
 env = {item.get("name"): item for item in env_items}
@@ -125,6 +131,7 @@ PY
 python3 "$TMP/assert.py" "$TMP/default.yaml" default postgres:16-alpine 60 2 2
 python3 "$TMP/assert.py" "$TMP/tuned.yaml" tuned registry.example.com/postgres-readiness:test 7 3 4
 python3 "$TMP/assert.py" "$TMP/blank-security.yaml" blank-security postgres:16-alpine 60 2 2
+python3 "$TMP/assert.py" "$TMP/root-web-security.yaml" root-web-security postgres:16-alpine 60 2 2
 python3 "$TMP/assert.py" "$TMP/disabled.yaml" disabled ignored 0 0 0
 
 assert_refused() {

--- a/charts/curie/ci/langfuse-postgres-readiness-assertions.sh
+++ b/charts/curie/ci/langfuse-postgres-readiness-assertions.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+# Fast render contract for the Langfuse web Postgres readiness gate (#1853).
+# The live delayed-start regression is the non-executable sibling in this
+# directory; this executable script is the chart-check/helm-ci fast pin.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART="$(cd "$SCRIPT_DIR/.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+render() {
+  local name="$1"
+  shift
+  if ! helm template curie "$CHART" --show-only templates/langfuse.yaml "$@" >"$TMP/$name.yaml"; then
+    fail "$name render failed"
+  fi
+}
+
+render default
+render disabled --set langfuse.web.postgresReadiness.enabled=false
+render blank-security --set-json 'langfuse.web.containerSecurityContext=null'
+render tuned \
+  --set-string langfuse.web.postgresReadiness.image=registry.example.com/postgres-readiness:test \
+  --set langfuse.web.postgresReadiness.attempts=7 \
+  --set langfuse.web.postgresReadiness.intervalSeconds=3 \
+  --set langfuse.web.postgresReadiness.probeTimeoutSeconds=4
+
+cat >"$TMP/assert.py" <<'PY'
+import sys
+import yaml
+
+path, mode, expected_image, attempts, interval, timeout = sys.argv[1:]
+docs = [doc for doc in yaml.safe_load_all(open(path)) if doc]
+
+def deployment_with_container(name):
+    matches = []
+    for doc in docs:
+        if doc.get("kind") != "Deployment":
+            continue
+        containers = doc.get("spec", {}).get("template", {}).get("spec", {}).get("containers", [])
+        if any(container.get("name") == name for container in containers):
+            matches.append(doc)
+    if len(matches) != 1:
+        raise SystemExit(f"expected one Deployment containing {name}, got {len(matches)}")
+    return matches[0]
+
+web = deployment_with_container("langfuse-web")
+worker = deployment_with_container("langfuse-worker")
+web_spec = web["spec"]["template"]["spec"]
+worker_spec = worker["spec"]["template"]["spec"]
+web_inits = web_spec.get("initContainers", [])
+worker_waits = [item for item in worker_spec.get("initContainers", []) if item.get("name") == "wait-for-postgres"]
+if worker_waits:
+    raise SystemExit("wait-for-postgres must be absent from the Langfuse worker Deployment")
+
+waits = [item for item in web_inits if item.get("name") == "wait-for-postgres"]
+if mode == "disabled":
+    if waits:
+        raise SystemExit("wait-for-postgres rendered while postgresReadiness.enabled=false")
+    print("  ok: enabled=false removes the web readiness init and worker remains unchanged")
+    raise SystemExit(0)
+
+if len(waits) != 1:
+    raise SystemExit(f"web must render exactly one wait-for-postgres init, got {len(waits)}")
+wait = waits[0]
+if not web_inits or web_inits[0].get("name") != "wait-for-postgres":
+    raise SystemExit("wait-for-postgres must be the first web init container")
+if wait.get("image") != expected_image:
+    raise SystemExit(f"wait-for-postgres image is {wait.get('image')!r}, expected {expected_image!r}")
+
+web_main = next(item for item in web_spec["containers"] if item.get("name") == "langfuse-web")
+wait_sc = wait.get("securityContext") or {}
+web_sc = web_main.get("securityContext") or {}
+if mode != "blank-security" and wait_sc != web_sc:
+    raise SystemExit(f"wait-for-postgres securityContext differs from langfuse-web: {wait_sc!r} != {web_sc!r}")
+uid = wait_sc.get("runAsUser")
+if type(uid) is not int or uid < 1:
+    raise SystemExit(f"wait-for-postgres runAsUser must be a numeric non-root uid, got {uid!r}")
+if wait_sc.get("runAsNonRoot") is not True:
+    raise SystemExit("wait-for-postgres must retain runAsNonRoot=true")
+if mode == "blank-security" and (uid != 1001 or web_sc):
+    raise SystemExit(f"blank web securityContext must leave the init at its 1001 non-root floor, got wait={wait_sc!r} web={web_sc!r}")
+
+env_items = wait.get("env", [])
+env = {item.get("name"): item for item in env_items}
+expected_names = {
+    "POSTGRES_HOST",
+    "POSTGRES_PORT",
+    "POSTGRES_USER",
+    "POSTGRES_DATABASE",
+    "POSTGRES_READINESS_ATTEMPTS",
+    "POSTGRES_READINESS_INTERVAL_SECONDS",
+    "POSTGRES_READINESS_PROBE_TIMEOUT_SECONDS",
+}
+if set(env) != expected_names:
+    raise SystemExit(f"wait-for-postgres env names are {sorted(env)}, expected {sorted(expected_names)}")
+for name, item in env.items():
+    if "valueFrom" in item:
+        raise SystemExit(f"credential-free readiness env {name} unexpectedly uses valueFrom")
+    upper = name.upper()
+    if any(token in upper for token in ("PASSWORD", "TOKEN", "SECRET", "CREDENTIAL")):
+        raise SystemExit(f"credential-like env {name} reached wait-for-postgres")
+
+expected_tuning = {
+    "POSTGRES_READINESS_ATTEMPTS": attempts,
+    "POSTGRES_READINESS_INTERVAL_SECONDS": interval,
+    "POSTGRES_READINESS_PROBE_TIMEOUT_SECONDS": timeout,
+}
+for name, expected in expected_tuning.items():
+    actual = str(env[name].get("value"))
+    if actual != expected:
+        raise SystemExit(f"{name} rendered {actual!r}, expected {expected!r}")
+
+command = "\n".join(str(part) for part in wait.get("command", []))
+for needle in ("pg_isready", 'while [ "$attempt" -le "$POSTGRES_READINESS_ATTEMPTS" ]', "Postgres readiness exhausted", "exit 1"):
+    if needle not in command:
+        raise SystemExit(f"wait-for-postgres command is missing bounded-gate contract {needle!r}")
+
+print(f"  ok: {mode} web init is first, credential-free, hardened, image={expected_image}, tuning={attempts}/{interval}/{timeout}")
+PY
+
+python3 "$TMP/assert.py" "$TMP/default.yaml" default postgres:16-alpine 60 2 2
+python3 "$TMP/assert.py" "$TMP/tuned.yaml" tuned registry.example.com/postgres-readiness:test 7 3 4
+python3 "$TMP/assert.py" "$TMP/blank-security.yaml" blank-security postgres:16-alpine 60 2 2
+python3 "$TMP/assert.py" "$TMP/disabled.yaml" disabled ignored 0 0 0
+
+assert_refused() {
+  local field="$1" flag="$2" value="$3" output rc
+  set +e
+  output="$(helm template curie "$CHART" --show-only templates/langfuse.yaml \
+    "$flag" "langfuse.web.postgresReadiness.${field}=${value}" 2>&1)"
+  rc=$?
+  set -e
+  [[ "$rc" -ne 0 ]] || fail "invalid ${field}=${value} rendered successfully"
+  [[ "$output" == *"langfuse.web.postgresReadiness.${field}"* ]] || \
+    fail "invalid ${field}=${value} failed without naming the knob: $output"
+}
+
+for field in attempts intervalSeconds probeTimeoutSeconds; do
+  assert_refused "$field" --set 0
+  assert_refused "$field" --set -1
+  assert_refused "$field" --set-json 2.5
+done
+echo "  ok: every bounded tuning knob rejects zero, negative, and fractional values"
+
+# Red-on-revert control: remove the init from a real default render, then prove
+# the same consumer assertion rejects it for the intended reason.
+python3 - "$TMP/default.yaml" "$TMP/missing-init.yaml" <<'PY'
+import sys
+import yaml
+
+source, target = sys.argv[1:]
+docs = [doc for doc in yaml.safe_load_all(open(source)) if doc]
+for doc in docs:
+    if doc.get("kind") != "Deployment":
+        continue
+    spec = doc.get("spec", {}).get("template", {}).get("spec", {})
+    if any(item.get("name") == "langfuse-web" for item in spec.get("containers", [])):
+        spec["initContainers"] = [
+            item for item in spec.get("initContainers", [])
+            if item.get("name") != "wait-for-postgres"
+        ]
+with open(target, "w") as output:
+    yaml.safe_dump_all(docs, output)
+PY
+
+set +e
+negative_output="$(python3 "$TMP/assert.py" "$TMP/missing-init.yaml" negative postgres:16-alpine 60 2 2 2>&1)"
+negative_rc=$?
+set -e
+[[ "$negative_rc" -ne 0 ]] || fail "negative control passed after wait-for-postgres was removed"
+[[ "$negative_output" == *"wait-for-postgres"* ]] || fail "negative control failed for an unrelated reason: $negative_output"
+echo "  ok: removing the rendered web readiness init is rejected"
+
+python3 - "$TMP/default.yaml" "$TMP/unbounded-init.yaml" <<'PY'
+import sys
+import yaml
+
+source, target = sys.argv[1:]
+docs = [doc for doc in yaml.safe_load_all(open(source)) if doc]
+for doc in docs:
+    if doc.get("kind") != "Deployment":
+        continue
+    spec = doc.get("spec", {}).get("template", {}).get("spec", {})
+    for item in spec.get("initContainers", []):
+        if item.get("name") == "wait-for-postgres":
+            item["command"][-1] = item["command"][-1].replace(
+                'while [ "$attempt" -le "$POSTGRES_READINESS_ATTEMPTS" ]; do',
+                "while true; do",
+            )
+with open(target, "w") as output:
+    yaml.safe_dump_all(docs, output)
+PY
+
+set +e
+negative_output="$(python3 "$TMP/assert.py" "$TMP/unbounded-init.yaml" negative postgres:16-alpine 60 2 2 2>&1)"
+negative_rc=$?
+set -e
+[[ "$negative_rc" -ne 0 ]] || fail "negative control passed after the readiness loop was made unbounded"
+[[ "$negative_output" == *"bounded-gate contract"* ]] || fail "unbounded-loop control failed for an unrelated reason: $negative_output"
+echo "  ok: stripping the loop bound from the rendered init is rejected"
+
+echo "PASS: Langfuse web Postgres readiness render contract and red negative control"

--- a/charts/curie/ci/langfuse-runasuser-assertions.sh
+++ b/charts/curie/ci/langfuse-runasuser-assertions.sh
@@ -8,10 +8,10 @@
 # which the kubelet cannot resolve to a number, so `runAsNonRoot: true` with no
 # numeric `runAsUser` makes the kubelet refuse to create the container.
 #
-# This asserts that BOTH the langfuse-web and langfuse-worker containers carry a
-# numeric `runAsUser` (>= 1, pinned to the verified image uid 1001) alongside
-# `runAsNonRoot: true`, so the pods actually start on an enforcing cluster. It
-# fails loudly, naming the container, if `runAsUser` is absent while
+# This asserts that the langfuse-web and langfuse-worker containers AND the web
+# wait-for-postgres init container carry a numeric `runAsUser` (>= 1, pinned to
+# the verified image uid 1001) alongside `runAsNonRoot: true`, so the pods
+# actually start on an enforcing cluster. It fails loudly, naming the container, if `runAsUser` is absent while
 # `runAsNonRoot: true` -- that is the exact #351 regression.
 #
 # Runnable locally (from anywhere) and from CI.
@@ -33,13 +33,14 @@ fail() {
 echo "=== Rendering templates/langfuse.yaml ==="
 helm template "$CHART" --show-only templates/langfuse.yaml > "$RENDER"
 
-# Assert the securityContext of one Langfuse Deployment's first container.
+# Assert the securityContext of one named container in a Langfuse Deployment.
 # $1 = rendered multi-doc YAML file, $2 = deployment name suffix
-# (-langfuse-web / -langfuse-worker), $3 = expected numeric runAsUser.
+# (-langfuse-web / -langfuse-worker), $3 = expected numeric runAsUser,
+# $4 = containers/initContainers, $5 = container name.
 assert_container() {
   python3 -c '
 import sys, yaml
-path, suffix, want = sys.argv[1], sys.argv[2], int(sys.argv[3])
+path, suffix, want, collection, target = sys.argv[1], sys.argv[2], int(sys.argv[3]), sys.argv[4], sys.argv[5]
 
 dep = None
 for doc in yaml.safe_load_all(open(path)):
@@ -52,7 +53,14 @@ if dep is None:
     sys.stderr.write("no Deployment ending in %r found in rendered langfuse.yaml\n" % suffix)
     sys.exit(2)
 
-container = dep["spec"]["template"]["spec"]["containers"][0]
+matches = [
+    item for item in dep["spec"]["template"]["spec"].get(collection, [])
+    if item.get("name") == target
+]
+if len(matches) != 1:
+    sys.stderr.write("deployment %r: expected one %s named %r, got %d\n" % (suffix, collection, target, len(matches)))
+    sys.exit(3)
+container = matches[0]
 name = container.get("name")
 sc = container.get("securityContext") or {}
 
@@ -76,14 +84,17 @@ if uid != want:
     sys.exit(3)
 
 sys.stdout.write("  ok: %s carries runAsNonRoot: true + runAsUser: %d\n" % (name, uid))
-' "$1" "$2" "$3" || fail "container assertion failed for deployment suffix '$2' (see message above)"
+' "$1" "$2" "$3" "$4" "$5" || fail "container assertion failed for deployment suffix '$2' / '$5' (see message above)"
 }
 
 echo "=== Assertion: langfuse-web carries a numeric runAsUser (== 1001) ==="
-assert_container "$RENDER" "-langfuse-web" 1001
+assert_container "$RENDER" "-langfuse-web" 1001 containers langfuse-web
+
+echo "=== Assertion: wait-for-postgres carries a numeric runAsUser (== 1001) ==="
+assert_container "$RENDER" "-langfuse-web" 1001 initContainers wait-for-postgres
 
 echo "=== Assertion: langfuse-worker carries a numeric runAsUser (== 1001) ==="
-assert_container "$RENDER" "-langfuse-worker" 1001
+assert_container "$RENDER" "-langfuse-worker" 1001 containers langfuse-worker
 
 echo
-echo "PASS: both langfuse-web and langfuse-worker pin runAsUser: 1001 alongside runAsNonRoot: true (issue #351); the kubelet can verify non-root and the pods start."
+echo "PASS: langfuse-web, wait-for-postgres, and langfuse-worker pin runAsUser: 1001 alongside runAsNonRoot: true (issue #351); the kubelet can verify non-root and the pods start."

--- a/charts/curie/ci/postgres-readiness-delay.Dockerfile
+++ b/charts/curie/ci/postgres-readiness-delay.Dockerfile
@@ -1,0 +1,14 @@
+ARG POSTGRES_BASE_IMAGE=postgres:16-alpine
+FROM ${POSTGRES_BASE_IMAGE}
+
+# Give the Langfuse pod a deterministic window in which to prove that its web
+# process remains behind the chart's readiness gate. Keep this at 20 seconds:
+# the chart's Postgres liveness probe starts at 20 seconds, runs every 10 seconds,
+# and restarts after its third failure (roughly 40 seconds). A longer artificial
+# entrypoint delay can therefore turn the dependency fixture itself into a
+# restart loop. Kubernetes `command`
+# on the gate overrides this entrypoint, so only the real Postgres container
+# pays the proven-safe delay.
+ENV POSTGRES_READINESS_DELAY_SECONDS=20
+ENTRYPOINT ["sh", "-ec", "sleep \"${POSTGRES_READINESS_DELAY_SECONDS}\"; exec /usr/local/bin/docker-entrypoint.sh \"$@\"", "--"]
+CMD ["postgres"]

--- a/charts/curie/ci/runtime/langfuse-postgres-readiness-runtime.sh
+++ b/charts/curie/ci/runtime/langfuse-postgres-readiness-runtime.sh
@@ -1,0 +1,551 @@
+#!/usr/bin/env bash
+# Runtime regression for #1853. It lives below charts/curie/ci/runtime because
+# chart-check discovers only top-level assertion scripts, while this script
+# creates and removes a real Helm release. Its nested chart-CI path still lets
+# curie dev verify-fix-pin route it as a chart runtime selector.
+set -euo pipefail
+
+NAMESPACE="${LANGFUSE_POSTGRES_NAMESPACE:-}"
+RELEASE="${LANGFUSE_POSTGRES_RELEASE:-}"
+POSTGRES_IMAGE="${LANGFUSE_POSTGRES_IMAGE:-}"
+CHART=""
+OBSERVE_SECONDS="${LANGFUSE_POSTGRES_OBSERVE_SECONDS:-10}"
+POLL_SECONDS=2
+NAMESPACE_CREATED=0
+CLEANUP_STARTED=0
+FORCE=0
+HELM_INSTALL_PID=0
+INVALID_PASSWORD="curie-readiness-intentional-invalid-password"
+TMP_DIR="$(mktemp -d)"
+
+usage() {
+  cat <<'EOF'
+Usage: bash charts/curie/ci/runtime/langfuse-postgres-readiness-runtime.sh \
+  --namespace <unique-ns> --release <unique-release> \
+  --postgres-image <distinct-delayed-image> [--chart <path>] [--force]
+
+Installs the real chart into a namespace that must not already exist. The
+Postgres image must be a caller-built, uniquely tagged image from
+postgres-readiness-delay.Dockerfile and must already be available to the
+cluster. LANGFUSE_POSTGRES_NAMESPACE, LANGFUSE_POSTGRES_RELEASE, and
+LANGFUSE_POSTGRES_IMAGE provide equivalent defaults for verify-fix-pin. The
+harness normally accepts only kind-*, k3d-*, and minikube contexts and always
+tears its namespace down. --force overrides only the context-name check; an
+existing namespace is still refused.
+EOF
+}
+
+need_value() {
+  [[ $# -ge 2 && -n "$2" ]] || {
+    echo "missing value for $1" >&2
+    usage >&2
+    exit 2
+  }
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --namespace) need_value "$@"; NAMESPACE="$2"; shift 2 ;;
+    --release) need_value "$@"; RELEASE="$2"; shift 2 ;;
+    --postgres-image) need_value "$@"; POSTGRES_IMAGE="$2"; shift 2 ;;
+    --chart) need_value "$@"; CHART="$2"; shift 2 ;;
+    --force) FORCE=1; shift ;;
+    --help|-h) usage; exit 0 ;;
+    *) echo "unknown flag: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+[[ -n "$NAMESPACE" && -n "$RELEASE" && -n "$POSTGRES_IMAGE" ]] || {
+  usage >&2
+  exit 2
+}
+[[ "$NAMESPACE" =~ ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ && ${#NAMESPACE} -le 63 ]] || {
+  echo "namespace must be a DNS label of at most 63 characters" >&2
+  exit 2
+}
+[[ "$RELEASE" =~ ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ && ${#RELEASE} -le 53 ]] || {
+  echo "release must be a lowercase Helm name of at most 53 characters" >&2
+  exit 2
+}
+[[ "$POSTGRES_IMAGE" != "postgres:16-alpine" && "$POSTGRES_IMAGE" != *:latest ]] || {
+  echo "--postgres-image must be a distinct, non-latest delayed fixture tag" >&2
+  exit 2
+}
+[[ "$OBSERVE_SECONDS" =~ ^[1-9][0-9]*$ ]] || {
+  echo "LANGFUSE_POSTGRES_OBSERVE_SECONDS must be a positive integer" >&2
+  exit 2
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ -z "$CHART" ]]; then
+  CHART="$(cd "$SCRIPT_DIR/../.." && pwd)"
+elif [[ "$CHART" != /* ]]; then
+  CHART="$(cd "$CHART" && pwd)"
+fi
+
+banner() { echo; echo "== $* =="; }
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+sanitize() {
+  sed -E \
+    -e 's#(postgres(ql)?://[^:/@[:space:]]+:)[^@[:space:]]+@#\1<redacted>@#g' \
+    -e 's#(([Pp][Aa][Ss][Ss][Ww][Oo][Rr][Dd]|[Tt][Oo][Kk][Ee][Nn]|[Ss][Ee][Cc][Rr][Ee][Tt]|[Aa][Pp][Ii][_-]?[Kk][Ee][Yy]|[Aa][Cc][Cc][Ee][Ss][Ss][_-]?[Kk][Ee][Yy])=)[^[:space:],;]+#\1<redacted>#g' \
+    -e "s/${INVALID_PASSWORD}/<redacted>/g"
+}
+
+component_pod() {
+  local component="$1" excluded_uid="${2:-}" pods_json
+  if ! pods_json="$(kubectl get pods -n "$NAMESPACE" \
+    -l "app.kubernetes.io/component=$component" -o json)"; then
+    echo "kubectl failed listing component=$component pods in namespace $NAMESPACE" >&2
+    return 2
+  fi
+  printf '%s' "$pods_json" | python3 /dev/fd/3 "$excluded_uid" 3<<'PY'
+import json
+import sys
+
+excluded = sys.argv[1]
+items = json.load(sys.stdin).get("items", [])
+items.sort(key=lambda item: item.get("metadata", {}).get("creationTimestamp", ""), reverse=True)
+for item in items:
+    meta = item.get("metadata", {})
+    if meta.get("deletionTimestamp") or meta.get("uid") == excluded:
+        continue
+    print(f"{meta.get('name', '')}|{meta.get('uid', '')}")
+    break
+PY
+}
+
+wait_for_component_pod() {
+  local component="$1" excluded_uid="${2:-}" timeout="${3:-240}" waited=0 found rc
+  while (( waited < timeout )); do
+    set +e
+    found="$(component_pod "$component" "$excluded_uid")"
+    rc=$?
+    set -e
+    (( rc == 0 )) || return "$rc"
+    if [[ "$found" == *"|"* && -n "${found%%|*}" && -n "${found#*|}" ]]; then
+      printf '%s\n' "$found"
+      return 0
+    fi
+    sleep "$POLL_SECONDS"
+    waited=$((waited + POLL_SECONDS))
+  done
+  return 1
+}
+
+component_deployment() {
+  local pod="$1" replica_set
+  if ! replica_set="$(kubectl get pod "$pod" -n "$NAMESPACE" \
+    -o jsonpath='{.metadata.ownerReferences[?(@.kind=="ReplicaSet")].name}')"; then
+    echo "kubectl failed reading owner of pod $NAMESPACE/$pod" >&2
+    return 2
+  fi
+  [[ -n "$replica_set" ]] || return 1
+  if ! kubectl get replicaset "$replica_set" -n "$NAMESPACE" \
+    -o jsonpath='{.metadata.ownerReferences[?(@.kind=="Deployment")].name}'; then
+    echo "kubectl failed reading owner of ReplicaSet $NAMESPACE/$replica_set" >&2
+    return 2
+  fi
+}
+
+pod_snapshot() {
+  local pod="$1" pod_json
+  if ! pod_json="$(kubectl get pod "$pod" -n "$NAMESPACE" -o json)"; then
+    echo "kubectl failed fetching pod snapshot for $NAMESPACE/$pod" >&2
+    return 2
+  fi
+  printf '%s' "$pod_json" | python3 /dev/fd/3 3<<'PY'
+import json
+import sys
+
+pod = json.load(sys.stdin)
+spec = pod.get("spec", {})
+status = pod.get("status", {})
+
+def container_status(statuses, name):
+    entry = next((item for item in statuses or [] if item.get("name") == name), {})
+    state = entry.get("state", {})
+    state_name = next((key for key in ("waiting", "running", "terminated") if key in state), "missing")
+    terminated = state.get("terminated", {}) or entry.get("lastState", {}).get("terminated", {})
+    exit_code = terminated.get("exitCode", "")
+    return str(entry.get("restartCount", "")), state_name, str(exit_code), str(entry.get("ready", False)).lower()
+
+init_names = {item.get("name") for item in spec.get("initContainers", [])}
+init_restart, init_state, init_exit, _ = container_status(
+    status.get("initContainerStatuses"), "wait-for-postgres"
+)
+web_restart, web_state, web_exit, web_ready = container_status(
+    status.get("containerStatuses"), "langfuse-web"
+)
+fields = [
+    "yes" if "wait-for-postgres" in init_names else "no",
+    init_restart,
+    init_state,
+    init_exit,
+    web_restart,
+    web_state,
+    web_exit,
+    web_ready,
+]
+print("|".join(fields))
+PY
+}
+
+read_snapshot() {
+  local pod="$1" snapshot
+  if ! snapshot="$(pod_snapshot "$pod")"; then
+    fail "could not read pod status for $NAMESPACE/$pod"
+  fi
+  IFS='|' read -r INIT_PRESENT INIT_RESTART INIT_STATE INIT_EXIT \
+    WEB_RESTART WEB_STATE WEB_EXIT WEB_READY <<<"$snapshot"
+}
+
+pod_ready() {
+  local pod="$1" ready
+  if ! ready="$(kubectl get pod "$pod" -n "$NAMESPACE" \
+    -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')"; then
+    echo "kubectl failed reading Ready condition for $NAMESPACE/$pod" >&2
+    return 2
+  fi
+  printf '%s' "$ready"
+}
+
+assert_no_backoff() {
+  local pod="$1" count events_json
+  if ! events_json="$(kubectl get events -n "$NAMESPACE" -o json)"; then
+    echo "kubectl failed listing events in namespace $NAMESPACE while checking pod $pod" >&2
+    return 2
+  fi
+  count="$(printf '%s' "$events_json" | python3 /dev/fd/3 "$pod" 3<<'PY'
+import json
+import sys
+
+pod = sys.argv[1]
+events = json.load(sys.stdin).get("items", [])
+print(sum(
+    1 for event in events
+    if event.get("reason") == "BackOff"
+    and event.get("involvedObject", {}).get("kind") == "Pod"
+    and event.get("involvedObject", {}).get("name") == pod
+))
+PY
+)"
+  [[ "$count" == "0" ]] || fail "pod $pod emitted $count BackOff event(s)"
+}
+
+safe_pod_logs() {
+  local pod="$1" container="$2"
+  echo "--- $pod/$container current logs (sanitized)"
+  kubectl logs "$pod" -n "$NAMESPACE" -c "$container" --tail=120 2>&1 | sanitize || true
+  echo "--- $pod/$container previous logs (sanitized)"
+  kubectl logs "$pod" -n "$NAMESPACE" -c "$container" --previous --tail=120 2>&1 | sanitize || true
+}
+
+diagnostics() {
+  banner "DIAGNOSTICS (credentials redacted)"
+  if [[ -n "${HELM_INSTALL_LOG:-}" && -f "$HELM_INSTALL_LOG" ]]; then
+    echo "--- helm install output (sanitized)"
+    tail -120 "$HELM_INSTALL_LOG" | sanitize || true
+  fi
+  kubectl get pods -n "$NAMESPACE" -o wide 2>&1 | sanitize || true
+  kubectl get events -n "$NAMESPACE" --sort-by=.lastTimestamp 2>&1 | tail -80 | sanitize || true
+  local pod
+  pod="$(component_pod langfuse-web | cut -d'|' -f1 || true)"
+  [[ -z "$pod" ]] || {
+    kubectl describe pod "$pod" -n "$NAMESPACE" 2>&1 | sanitize || true
+    safe_pod_logs "$pod" langfuse-web
+    safe_pod_logs "$pod" wait-for-postgres
+  }
+  pod="$(component_pod langfuse-worker | cut -d'|' -f1 || true)"
+  [[ -z "$pod" ]] || safe_pod_logs "$pod" langfuse-worker
+}
+
+cleanup() {
+  local rc="${1:-$?}" cleanup_failed=0
+  (( CLEANUP_STARTED == 0 )) || return
+  CLEANUP_STARTED=1
+  trap - EXIT INT TERM
+  set +e
+  if (( rc != 0 && NAMESPACE_CREATED == 1 )); then
+    diagnostics
+  fi
+  if (( HELM_INSTALL_PID > 0 )) && kill -0 "$HELM_INSTALL_PID" >/dev/null 2>&1; then
+    kill "$HELM_INSTALL_PID" >/dev/null 2>&1 || true
+    wait "$HELM_INSTALL_PID" >/dev/null 2>&1 || true
+  fi
+  if (( NAMESPACE_CREATED == 1 )); then
+    banner "TEARDOWN namespace=$NAMESPACE release=$RELEASE"
+    helm uninstall "$RELEASE" -n "$NAMESPACE" --no-hooks >/dev/null 2>&1 || true
+    kubectl delete namespace "$NAMESPACE" --wait=true --timeout=180s >/dev/null 2>&1
+    if kubectl get namespace "$NAMESPACE" >/dev/null 2>&1; then
+      echo "FAIL: disposable namespace $NAMESPACE still exists after teardown" >&2
+      cleanup_failed=1
+    else
+      echo "teardown confirmed: namespace $NAMESPACE is absent"
+    fi
+  fi
+  rm -rf "$TMP_DIR"
+  if (( cleanup_failed == 1 && rc == 0 )); then
+    rc=1
+  fi
+  exit "$rc"
+}
+trap 'cleanup $?' EXIT
+trap 'cleanup 130' INT
+trap 'cleanup 143' TERM
+
+CURRENT_CONTEXT="$(kubectl config current-context 2>/dev/null || true)"
+[[ -n "$CURRENT_CONTEXT" ]] || fail "kubectl has no current context"
+[[ "$CURRENT_CONTEXT" != "k8scratch" ]] || fail "refusing shared k8scratch even with --force"
+case "$CURRENT_CONTEXT" in
+  kind-*|k3d-*|minikube|minikube-*) ;;
+  *)
+    (( FORCE == 1 )) || fail "context '$CURRENT_CONTEXT' is not an explicitly disposable kind-*/k3d-*/minikube context (override with --force)"
+    ;;
+esac
+
+banner "PRECHECK context=$CURRENT_CONTEXT namespace=$NAMESPACE release=$RELEASE image=$POSTGRES_IMAGE"
+if kubectl get namespace "$NAMESPACE" >/dev/null 2>&1; then
+  fail "namespace $NAMESPACE already exists; choose a new isolated namespace"
+fi
+if kubectl create namespace "$NAMESPACE" >/dev/null; then
+  NAMESPACE_CREATED=1
+else
+  fail "could not atomically create namespace $NAMESPACE"
+fi
+kubectl label namespace "$NAMESPACE" curie-readiness-harness=owned >/dev/null
+
+CHART_VALUES=(
+  --set-string postgres.image="$POSTGRES_IMAGE"
+  --set global.imagePullPolicy=IfNotPresent
+  --set security.allowDevDefaults=true
+  --set postgres.persistence.enabled=false
+  --set valkey.persistence.enabled=false
+  --set clickhouse.persistence.enabled=false
+  --set rustfs.persistence.enabled=false
+  --set api.deploy=false
+  --set dispatcher.deploy=false
+  --set worker.deploy=false
+  --set ui.deploy=false
+  --set otelCollector.deploy=false
+  --set inference.deploy=false
+  --set agentSandbox.deploy=false
+  --set agentSandbox.controller.deploy=false
+  --set langfuse.modelPricing.enabled=false
+  --set preflights.avxCheck.enabled=false
+  --set preflights.networkPolicyProbe.enabled=false
+  --set preflights.controllerReady.enabled=false
+  --set priorityClasses.platform.create=false
+  --set-string priorityClasses.platform.name=
+  --set priorityClasses.sandbox.create=false
+  --set-string priorityClasses.sandbox.name=
+)
+
+banner "INSTALL real chart consumer with delayed Postgres"
+HELM_INSTALL_LOG="$TMP_DIR/helm-install.log"
+helm install "$RELEASE" "$CHART" -n "$NAMESPACE" --skip-crds "${CHART_VALUES[@]}" \
+  >"$HELM_INSTALL_LOG" 2>&1 &
+HELM_INSTALL_PID=$!
+
+WEB_REF="$(wait_for_component_pod langfuse-web "" 300)" || fail "Langfuse web pod was not created"
+WEB_POD="${WEB_REF%%|*}"
+WEB_UID="${WEB_REF#*|}"
+POSTGRES_REF="$(wait_for_component_pod postgres "" 180)" || fail "Postgres pod was not created"
+POSTGRES_POD="${POSTGRES_REF%%|*}"
+
+banner "ASSERT bounded gate is running while Postgres is unavailable"
+waited=0
+while (( waited < 180 )); do
+  read_snapshot "$WEB_POD"
+  if [[ "$INIT_PRESENT" == "no" ]]; then
+    fail "live Langfuse web pod has no wait-for-postgres init container"
+  fi
+  if [[ "$INIT_STATE" == "running" && "$(pod_ready "$POSTGRES_POD")" != "True" ]]; then
+    break
+  fi
+  sleep "$POLL_SECONDS"
+  waited=$((waited + POLL_SECONDS))
+done
+[[ "$INIT_STATE" == "running" ]] || fail "wait-for-postgres never reached Running before Postgres readiness"
+[[ "$(pod_ready "$POSTGRES_POD")" != "True" ]] || fail "delayed fixture became ready before the observation window"
+
+MIN_PRE_READY_SAMPLES=3
+PRE_READY_SAMPLES=0
+OBSERVE_STARTED=$SECONDS
+while (( SECONDS - OBSERVE_STARTED < OBSERVE_SECONDS )); do
+  current_ref="$(component_pod langfuse-web)"
+  [[ "${current_ref#*|}" == "$WEB_UID" ]] || fail "Langfuse web pod was replaced before Postgres readiness"
+  if [[ "$(pod_ready "$POSTGRES_POD")" == "True" ]]; then
+    break
+  fi
+  read_snapshot "$WEB_POD"
+  [[ "$INIT_PRESENT" == "yes" && "$INIT_STATE" == "running" ]] || fail "readiness init stopped waiting before Postgres was ready"
+  [[ "${INIT_RESTART:-0}" == "0" ]] || fail "readiness init restarted before Postgres readiness"
+  [[ "${WEB_RESTART:-0}" == "0" ]] || fail "Langfuse web restarted before Postgres readiness"
+  [[ "$WEB_STATE" == "waiting" || "$WEB_STATE" == "missing" ]] || fail "Langfuse web started before its readiness init completed"
+  PRE_READY_SAMPLES=$((PRE_READY_SAMPLES + 1))
+  echo "pre-ready sample $PRE_READY_SAMPLES: init=running initRestarts=0 web=${WEB_STATE} webRestarts=0"
+  sleep "$POLL_SECONDS"
+done
+(( PRE_READY_SAMPLES >= MIN_PRE_READY_SAMPLES )) || \
+  fail "collected only $PRE_READY_SAMPLES pre-ready samples; need at least $MIN_PRE_READY_SAMPLES"
+assert_no_backoff "$WEB_POD"
+echo "pre-ready observation: samples=$PRE_READY_SAMPLES BackOff=0"
+
+if ! wait "$HELM_INSTALL_PID"; then
+  tail -120 "$HELM_INSTALL_LOG" | sanitize >&2
+  HELM_INSTALL_PID=0
+  fail "helm install failed while the readiness window was being observed"
+fi
+HELM_INSTALL_PID=0
+echo "helm install and normal post-install hooks completed"
+
+banner "WAIT for Postgres and Langfuse web readiness"
+kubectl wait pod "$POSTGRES_POD" -n "$NAMESPACE" --for=condition=Ready --timeout=300s
+POSTGRES_RESTART="$(kubectl get pod "$POSTGRES_POD" -n "$NAMESPACE" \
+  -o jsonpath='{.status.containerStatuses[?(@.name=="postgres")].restartCount}')" || \
+  fail "kubectl failed reading Postgres restartCount for $NAMESPACE/$POSTGRES_POD"
+[[ "$POSTGRES_RESTART" == "0" ]] || fail "delayed Postgres restarted $POSTGRES_RESTART time(s); fixture exceeded its liveness budget"
+WEB_DEPLOYMENT="$(component_deployment "$WEB_POD")"
+[[ -n "$WEB_DEPLOYMENT" ]] || fail "Langfuse web Deployment not found"
+kubectl rollout status deployment/"$WEB_DEPLOYMENT" -n "$NAMESPACE" --timeout=360s
+current_ref="$(component_pod langfuse-web)"
+[[ "${current_ref#*|}" == "$WEB_UID" ]] || fail "Langfuse web pod was replaced while recovering"
+read_snapshot "$WEB_POD"
+[[ "$INIT_STATE" == "terminated" && "$INIT_EXIT" == "0" && "${INIT_RESTART:-0}" == "0" ]] || \
+  fail "readiness init did not complete once with exit 0"
+[[ "$WEB_READY" == "true" && "${WEB_RESTART:-0}" == "0" ]] || \
+  fail "Langfuse web did not become Ready with zero restarts"
+assert_no_backoff "$WEB_POD"
+echo "positive: postgres=Ready postgresRestarts=0 initExit=0 initRestarts=0 web=Ready webRestarts=0 BackOff=0"
+
+WORKER_REF="$(component_pod langfuse-worker || true)"
+if [[ "$WORKER_REF" == *"|"* ]]; then
+  WORKER_POD="${WORKER_REF%%|*}"
+  WORKER_RESTART="$(kubectl get pod "$WORKER_POD" -n "$NAMESPACE" -o jsonpath='{.status.containerStatuses[?(@.name=="langfuse-worker")].restartCount}' 2>/dev/null || true)"
+  WORKER_REASON="$(kubectl get pod "$WORKER_POD" -n "$NAMESPACE" -o jsonpath='{.status.containerStatuses[?(@.name=="langfuse-worker")].state.waiting.reason}' 2>/dev/null || true)"
+  echo "informational sibling: langfuse-worker restarts=${WORKER_RESTART:-unknown} waitingReason=${WORKER_REASON:-none}"
+fi
+
+banner "NEGATIVE invalid credentials pass readiness and fail in real Langfuse web"
+SECRET_NAME="$(kubectl get deployment "$WEB_DEPLOYMENT" -n "$NAMESPACE" -o json |
+  python3 /dev/fd/3 3<<'PY'
+import json
+import sys
+
+deployment = json.load(sys.stdin)
+containers = deployment["spec"]["template"]["spec"]["containers"]
+web = next(container for container in containers if container.get("name") == "langfuse-web")
+password = next(item for item in web.get("env", []) if item.get("name") == "POSTGRES_PASSWORD")
+print(password["valueFrom"]["secretKeyRef"]["name"])
+PY
+)"
+helm upgrade "$RELEASE" "$CHART" -n "$NAMESPACE" --reuse-values \
+  --set-string postgres.auth.password="$INVALID_PASSWORD"
+EXPECTED_SECRET="$INVALID_PASSWORD" kubectl get secret "$SECRET_NAME" -n "$NAMESPACE" -o json |
+  EXPECTED_SECRET="$INVALID_PASSWORD" python3 /dev/fd/3 3<<'PY'
+import base64
+import json
+import os
+import sys
+
+secret = json.load(sys.stdin)
+actual = base64.b64decode(secret["data"]["postgresPassword"]).decode()
+if actual != os.environ["EXPECTED_SECRET"]:
+    print("rotated Postgres Secret did not contain the intentional invalid credential", file=sys.stderr)
+    sys.exit(1)
+print("negative armed: Postgres Secret changed (value redacted), running database retained its original credential")
+PY
+
+kubectl delete pod "$WEB_POD" -n "$NAMESPACE" --wait=true >/dev/null
+NEGATIVE_REF="$(wait_for_component_pod langfuse-web "$WEB_UID" 180)" || fail "replacement Langfuse web pod was not created"
+NEGATIVE_POD="${NEGATIVE_REF%%|*}"
+
+waited=0
+while (( waited < 180 )); do
+  read_snapshot "$NEGATIVE_POD"
+  [[ "$INIT_PRESENT" == "yes" ]] || fail "negative pod has no readiness init"
+  [[ "${INIT_RESTART:-0}" == "0" ]] || fail "negative readiness init restarted"
+  if [[ "$INIT_STATE" == "terminated" && "$INIT_EXIT" == "0" ]]; then
+    break
+  fi
+  [[ -z "$INIT_EXIT" || "$INIT_EXIT" == "0" ]] || fail "negative readiness init exited nonzero instead of handing off"
+  sleep "$POLL_SECONDS"
+  waited=$((waited + POLL_SECONDS))
+done
+[[ "$INIT_STATE" == "terminated" && "$INIT_EXIT" == "0" ]] || fail "invalid credentials remained hidden behind the readiness init"
+
+waited=0
+while (( waited < 180 )); do
+  read_snapshot "$NEGATIVE_POD"
+  if [[ "${WEB_RESTART:-0}" =~ ^[1-9][0-9]*$ && -n "$WEB_EXIT" && "$WEB_EXIT" != "0" ]]; then
+    break
+  fi
+  sleep "$POLL_SECONDS"
+  waited=$((waited + POLL_SECONDS))
+done
+[[ "${WEB_RESTART:-0}" =~ ^[1-9][0-9]*$ && -n "$WEB_EXIT" && "$WEB_EXIT" != "0" ]] || \
+  fail "real Langfuse web did not exit nonzero after the invalid credential was supplied"
+[[ "$WEB_READY" != "true" ]] || fail "invalid-credential Langfuse web unexpectedly became Ready"
+
+AUTH_LOG="$TMP_DIR/langfuse-auth.log"
+kubectl logs "$NEGATIVE_POD" -n "$NAMESPACE" -c langfuse-web >"$AUTH_LOG" 2>&1 || true
+kubectl logs "$NEGATIVE_POD" -n "$NAMESPACE" -c langfuse-web --previous >>"$AUTH_LOG" 2>&1 || true
+if ! grep -Eiq 'P1000|authentication failed|password authentication failed|database credentials.+not valid|provided database credentials' "$AUTH_LOG"; then
+  tail -80 "$AUTH_LOG" | sanitize >&2
+  fail "Langfuse exited nonzero, but its previous log did not identify an authentication/migration failure"
+fi
+grep -Ei 'P1000|authentication failed|password authentication failed|database credentials.+not valid|provided database credentials' "$AUTH_LOG" |
+  tail -5 | sanitize
+echo "negative: initExit=0 initRestarts=0 webExit=$WEB_EXIT webRestarts=$WEB_RESTART authFailure=observed"
+
+banner "NEGATIVE unreachable Postgres exhausts the bounded readiness gate"
+EXHAUSTION_OLD_UID="${NEGATIVE_REF#*|}"
+helm upgrade "$RELEASE" "$CHART" -n "$NAMESPACE" --reuse-values \
+  --set postgres.deploy=false \
+  --set-string postgres.host=postgres-readiness.invalid \
+  --set langfuse.web.postgresReadiness.attempts=2 \
+  --set langfuse.web.postgresReadiness.intervalSeconds=1 \
+  --set langfuse.web.postgresReadiness.probeTimeoutSeconds=1
+
+EXHAUSTION_REF="$(wait_for_component_pod langfuse-web "$EXHAUSTION_OLD_UID" 30 || true)"
+if [[ "$EXHAUSTION_REF" != *"|"* ]]; then
+  kubectl delete pod "$NEGATIVE_POD" -n "$NAMESPACE" --wait=true >/dev/null 2>&1 || true
+  EXHAUSTION_REF="$(wait_for_component_pod langfuse-web "$EXHAUSTION_OLD_UID" 120)" || \
+    fail "fresh Langfuse web pod was not created for readiness exhaustion"
+fi
+EXHAUSTION_POD="${EXHAUSTION_REF%%|*}"
+
+waited=0
+while (( waited < 45 )); do
+  read_snapshot "$EXHAUSTION_POD"
+  [[ "$INIT_PRESENT" == "yes" ]] || fail "exhaustion pod has no readiness init"
+  [[ "$WEB_STATE" == "waiting" || "$WEB_STATE" == "missing" ]] || \
+    fail "Langfuse web started while its readiness gate was exhausting"
+  [[ "${WEB_RESTART:-0}" == "0" && -z "$WEB_EXIT" && "$WEB_READY" != "true" ]] || \
+    fail "Langfuse web ran before the unreachable-Postgres gate completed"
+  if [[ -n "$INIT_EXIT" && "$INIT_EXIT" != "0" ]]; then
+    break
+  fi
+  sleep 1
+  waited=$((waited + 1))
+done
+[[ -n "$INIT_EXIT" && "$INIT_EXIT" != "0" ]] || \
+  fail "wait-for-postgres did not exit nonzero within the 45s exhaustion deadline"
+[[ "$WEB_STATE" == "waiting" || "$WEB_STATE" == "missing" ]] || \
+  fail "Langfuse web started after readiness exhaustion"
+[[ "${WEB_RESTART:-0}" == "0" && -z "$WEB_EXIT" && "$WEB_READY" != "true" ]] || \
+  fail "Langfuse web process started during readiness exhaustion"
+
+EXHAUSTION_LOG="$TMP_DIR/postgres-readiness-exhaustion.log"
+kubectl logs "$EXHAUSTION_POD" -n "$NAMESPACE" -c wait-for-postgres >"$EXHAUSTION_LOG" 2>&1 || true
+kubectl logs "$EXHAUSTION_POD" -n "$NAMESPACE" -c wait-for-postgres --previous >>"$EXHAUSTION_LOG" 2>&1 || true
+if ! grep -Eq '^Postgres readiness exhausted for .+ after 2 attempts: pg_isready=[0-3] ' "$EXHAUSTION_LOG"; then
+  tail -40 "$EXHAUSTION_LOG" | sanitize >&2
+  fail "readiness init exited nonzero without the credential-free exhaustion diagnostic"
+fi
+grep -E '^Postgres readiness exhausted for .+ after 2 attempts: pg_isready=[0-3] ' "$EXHAUSTION_LOG" | tail -1 | sanitize
+echo "exhaustion negative: initExit=$INIT_EXIT webState=$WEB_STATE webRestarts=0 webStarted=false"
+
+banner "PASS delayed Postgres caused no Langfuse web restart/BackOff; readiness recovered; invalid credentials remained terminal; unreachable Postgres exhausted the bounded gate"

--- a/charts/curie/ci/runtime/langfuse-postgres-readiness-runtime.sh
+++ b/charts/curie/ci/runtime/langfuse-postgres-readiness-runtime.sh
@@ -9,7 +9,7 @@ NAMESPACE="${LANGFUSE_POSTGRES_NAMESPACE:-}"
 RELEASE="${LANGFUSE_POSTGRES_RELEASE:-}"
 POSTGRES_IMAGE="${LANGFUSE_POSTGRES_IMAGE:-}"
 CHART=""
-OBSERVE_SECONDS="${LANGFUSE_POSTGRES_OBSERVE_SECONDS:-10}"
+OBSERVE_SECONDS="${LANGFUSE_POSTGRES_OBSERVE_SECONDS:-20}"
 POLL_SECONDS=2
 NAMESPACE_CREATED=0
 CLEANUP_STARTED=0
@@ -373,11 +373,13 @@ done
 MIN_PRE_READY_SAMPLES=3
 PRE_READY_SAMPLES=0
 OBSERVE_STARTED=$SECONDS
-while (( SECONDS - OBSERVE_STARTED < OBSERVE_SECONDS )); do
+while (( PRE_READY_SAMPLES < MIN_PRE_READY_SAMPLES )); do
+  (( SECONDS - OBSERVE_STARTED < OBSERVE_SECONDS )) || \
+    fail "pre-ready sampling exceeded ${OBSERVE_SECONDS}s after $PRE_READY_SAMPLES samples"
   current_ref="$(component_pod langfuse-web)"
   [[ "${current_ref#*|}" == "$WEB_UID" ]] || fail "Langfuse web pod was replaced before Postgres readiness"
   if [[ "$(pod_ready "$POSTGRES_POD")" == "True" ]]; then
-    break
+    fail "delayed fixture became ready after only $PRE_READY_SAMPLES pre-ready samples"
   fi
   read_snapshot "$WEB_POD"
   [[ "$INIT_PRESENT" == "yes" && "$INIT_STATE" == "running" ]] || fail "readiness init stopped waiting before Postgres was ready"
@@ -386,10 +388,10 @@ while (( SECONDS - OBSERVE_STARTED < OBSERVE_SECONDS )); do
   [[ "$WEB_STATE" == "waiting" || "$WEB_STATE" == "missing" ]] || fail "Langfuse web started before its readiness init completed"
   PRE_READY_SAMPLES=$((PRE_READY_SAMPLES + 1))
   echo "pre-ready sample $PRE_READY_SAMPLES: init=running initRestarts=0 web=${WEB_STATE} webRestarts=0"
-  sleep "$POLL_SECONDS"
+  if (( PRE_READY_SAMPLES < MIN_PRE_READY_SAMPLES )); then
+    sleep "$POLL_SECONDS"
+  fi
 done
-(( PRE_READY_SAMPLES >= MIN_PRE_READY_SAMPLES )) || \
-  fail "collected only $PRE_READY_SAMPLES pre-ready samples; need at least $MIN_PRE_READY_SAMPLES"
 assert_no_backoff "$WEB_POD"
 echo "pre-ready observation: samples=$PRE_READY_SAMPLES BackOff=0"
 

--- a/charts/curie/templates/langfuse.yaml
+++ b/charts/curie/templates/langfuse.yaml
@@ -44,6 +44,68 @@ spec:
       {{- with (include "curie.placement.spec" .Values.placement.platform) }}
       {{- . | nindent 6 }}
       {{- end }}
+      {{- if .Values.langfuse.web.postgresReadiness.enabled }}
+      {{- $postgresReadiness := .Values.langfuse.web.postgresReadiness }}
+      {{- $readinessSecurityContext := deepCopy (.Values.langfuse.web.containerSecurityContext | default dict) }}
+      {{- $_ := set $readinessSecurityContext "runAsNonRoot" true }}
+      {{- if not (hasKey $readinessSecurityContext "runAsUser") }}
+      {{- $_ := set $readinessSecurityContext "runAsUser" 1001 }}
+      {{- end }}
+      {{- range $field := list "attempts" "intervalSeconds" "probeTimeoutSeconds" }}
+      {{- $value := index $postgresReadiness $field }}
+      {{- $integerKind := or (kindIs "int" $value) (kindIs "int64" $value) (kindIs "float64" $value) }}
+      {{- if or (not $integerKind) (not (regexMatch "^[0-9]+$" (printf "%v" $value))) (lt (int64 $value) 1) }}
+      {{- fail (printf "langfuse.web.postgresReadiness.%s must be an integer >= 1" $field) }}
+      {{- end }}
+      {{- end }}
+      initContainers:
+        - name: wait-for-postgres
+          image: {{ $postgresReadiness.image | default .Values.postgres.image | quote }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          securityContext:
+            {{- toYaml $readinessSecurityContext | nindent 12 }}
+          command:
+            - sh
+            - -ec
+            - |
+              echo "waiting for Postgres readiness"
+              attempt=1
+              last_exit_code=1
+              while [ "$attempt" -le "$POSTGRES_READINESS_ATTEMPTS" ]; do
+                if pg_isready \
+                  -h "$POSTGRES_HOST" \
+                  -p "$POSTGRES_PORT" \
+                  -U "$POSTGRES_USER" \
+                  -d "$POSTGRES_DATABASE" \
+                  -t "$POSTGRES_READINESS_PROBE_TIMEOUT_SECONDS" \
+                  >/dev/null 2>&1; then
+                  exit 0
+                else
+                  last_exit_code=$?
+                fi
+                if [ "$attempt" -lt "$POSTGRES_READINESS_ATTEMPTS" ]; then
+                  sleep "$POSTGRES_READINESS_INTERVAL_SECONDS"
+                fi
+                attempt=$((attempt + 1))
+              done
+              echo "Postgres readiness exhausted for ${POSTGRES_HOST}:${POSTGRES_PORT} after ${POSTGRES_READINESS_ATTEMPTS} attempts: pg_isready=${last_exit_code} (0=accepting, 1=rejecting, 2=no-response, 3=no-attempt)" >&2
+              exit 1
+          env:
+            - name: POSTGRES_HOST
+              value: {{ include "curie.postgres.host" . | quote }}
+            - name: POSTGRES_PORT
+              value: {{ .Values.postgres.port | quote }}
+            - name: POSTGRES_USER
+              value: {{ .Values.postgres.auth.username | quote }}
+            - name: POSTGRES_DATABASE
+              value: {{ .Values.postgres.auth.database | quote }}
+            - name: POSTGRES_READINESS_ATTEMPTS
+              value: {{ .Values.langfuse.web.postgresReadiness.attempts | quote }}
+            - name: POSTGRES_READINESS_INTERVAL_SECONDS
+              value: {{ .Values.langfuse.web.postgresReadiness.intervalSeconds | quote }}
+            - name: POSTGRES_READINESS_PROBE_TIMEOUT_SECONDS
+              value: {{ .Values.langfuse.web.postgresReadiness.probeTimeoutSeconds | quote }}
+      {{- end }}
       containers:
         - name: langfuse-web
           image: "{{ .Values.langfuse.image.web }}:{{ .Values.langfuse.image.tag }}"

--- a/charts/curie/templates/langfuse.yaml
+++ b/charts/curie/templates/langfuse.yaml
@@ -50,6 +50,8 @@ spec:
       {{- $_ := set $readinessSecurityContext "runAsNonRoot" true }}
       {{- if not (hasKey $readinessSecurityContext "runAsUser") }}
       {{- $_ := set $readinessSecurityContext "runAsUser" 1001 }}
+      {{- else if eq (int64 (get $readinessSecurityContext "runAsUser")) 0 }}
+      {{- $_ := set $readinessSecurityContext "runAsUser" 1001 }}
       {{- end }}
       {{- range $field := list "attempts" "intervalSeconds" "probeTimeoutSeconds" }}
       {{- $value := index $postgresReadiness $field }}

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -174,6 +174,16 @@ langfuse:
     # cap (~512Mi) OOM-crashes under a tight container limit; raise it in step
     # with the memory limit. Empty = leave the image default.
     nodeOptions: "--max-old-space-size=1024"
+    # Credential-free protocol readiness gate before Langfuse web starts its
+    # own migrations. Authentication and migration failures remain owned by
+    # the unmodified Langfuse entrypoint after this bounded wait succeeds.
+    postgresReadiness:
+      enabled: true
+      # Empty reuses postgres.image; override for BYO Postgres when needed.
+      image: ""
+      attempts: 60
+      intervalSeconds: 2
+      probeTimeoutSeconds: 2
     resources:
       requests: { cpu: 150m, memory: 384Mi }
       limits: { cpu: "1", memory: 1536Mi }

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -180,6 +180,8 @@ langfuse:
     postgresReadiness:
       enabled: true
       # Empty reuses postgres.image; override for BYO Postgres when needed.
+      # This probe always runs as non-root, independently of a web image's
+      # containerSecurityContext override, because it uses the Postgres image.
       image: ""
       attempts: 60
       intervalSeconds: 2


### PR DESCRIPTION
## Summary

Langfuse web now waits in one bounded, credential-free `pg_isready` init-container execution while Postgres is transiently unavailable. The unmodified Langfuse entrypoint still owns authentication and Prisma migration failures, so permanent failures remain terminal. A real-chart cluster regression delays Postgres, asserts zero web/init restarts and zero BackOff before readiness, proves recovery, exercises invalid credentials and bounded exhaustion, and tears down its isolated namespace.

## Related issue

Closes #1853

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | No plugin, skill packaging, runner loop, or ACI event changed. | n/a | n/a |
| local | n/a | No Compose service, API, worker, dispatcher, console, or CLI behavior changed. | n/a | n/a |
| local-release | n/a | No released binary/image identity, install path, version pin, or release Compose changed. | n/a | n/a |
| cluster | required | The chart adds a web init container and changes runtime ordering. | live kind cluster | At `17dc3dec`, `bash charts/curie/ci/runtime/langfuse-postgres-readiness-runtime.sh --namespace curie-1853-final-17dc3d --release curie-1853-final-17dc3d --postgres-image curie-postgres-readiness:1853-17dc3dec` collected 3 pre-ready samples with init/web restarts 0 and BackOff 0, then observed Postgres Ready and Langfuse web Ready with restartCount 0. P1000 followed init exit 0 for invalid credentials; an unreachable host produced init exit 1 after 2 attempts and never started web. The namespace was absent afterward and the disposable cluster was deleted. |
| live provider | n/a | No model routing, provider credentials, tokens, or cost accounting changed. | n/a | n/a |
| external integration | n/a | No Slack, webhook, OAuth, or third-party API contract changed. | n/a | n/a |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.
- [ ] Or: this change is not behavior-bearing, so no tier applies, and the summary says why.

Additional falsifiability: at `42d5c504`, `LANGFUSE_POSTGRES_NAMESPACE=curie-1853-pin-42d5c5 LANGFUSE_POSTGRES_RELEASE=curie-1853-pin-42d5c5 LANGFUSE_POSTGRES_IMAGE=curie-postgres-readiness:1853-42d5c504 curie dev verify-fix-pin 42d5c504 charts/curie/ci/runtime/langfuse-postgres-readiness-runtime.sh` returned `PINNED`: the baseline passed and the reversed product failed because the live web pod had no readiness init. Both baseline and reversed namespaces were absent afterward.

Focused checks:

- `cargo test --manifest-path cli/Cargo.toml --test chart_check` — 7 passed; the real 25-script chart check passed.
- `bash charts/curie/ci/langfuse-postgres-readiness-assertions.sh` — default/tuned/disabled/security-context renders passed; removing the init and making its loop unbounded each failed the consumer assertion.
- `bash charts/curie/ci/langfuse-runasuser-assertions.sh` — web, worker, and readiness init retain numeric UID 1001.
- `helm lint` and default/dev/no-gvisor template renders passed; docs and workflow YAML checks passed.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed.
- [x] No ADR is needed; this applies the existing bounded startup-readiness pattern to Langfuse web without changing a contract.
