### PR TITLE
Notice when a newer version of the SRE bot bundle exists, from outside the sandbox

### DIFF
--- a/examples/sre-bot/self-upgrade/cronjob.yaml
+++ b/examples/sre-bot/self-upgrade/cronjob.yaml
@@ -1,0 +1,95 @@
+# Notice when a newer version of this bundle exists in the repository.
+#
+#   kubectl -n <curie-namespace> create configmap sre-bot-self-upgrade \
+#     --from-file=redeploy.py=examples/sre-bot/self-upgrade/redeploy.py
+#   kubectl -n <curie-namespace> apply -f examples/sre-bot/self-upgrade/cronjob.yaml
+#
+# EDIT BEFORE APPLYING: the namespace on both objects, and `CURIE_API_URL`'s
+# service name if the release is not called `curie`.
+#
+# WHY A JOB AND NOT THE BOT. Creating an agent version needs the platform API
+# key, and every `/agents/**` route requires it. The sandbox holds a per-turn
+# `state`-scoped token and nothing else, deliberately. So the work sits outside
+# the sandbox, and the bot's own authority is unchanged by this file.
+#
+# WHY IT ONLY REPORTS. See redeploy.py's header: the bundle in the repository
+# declares `build:` for three connectors, and a cluster deploy is refused for an
+# image that exists only in a local Docker daemon. Deploying the repository copy
+# verbatim would create a version whose connectors cannot start -- a redeploy
+# that reports success and leaves the bot with no tools. The missing step is
+# digest resolution, which needs those connectors published first (curie#1945).
+#
+# THE TOKEN. `GITHUB_TOKEN` needs `contents: read` on the repository and nothing
+# else. Without it the job exits non-zero and says so: a job that cannot tell
+# whether it is behind must not report success, because a silent "nothing to do"
+# is indistinguishable from "up to date" and can stay that way for months.
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: sre-bot-self-upgrade
+  # CHANGE ME: the namespace the Curie release runs in.
+  namespace: curie
+spec:
+  # Hourly. The thing being watched moves on human timescales, and the GitHub
+  # API is rate limited per token, so a tighter schedule buys nothing.
+  schedule: "17 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      template:
+        spec:
+          restartPolicy: Never
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            seccompProfile: { type: RuntimeDefault }
+          containers:
+            - name: check
+              # Any image with a python3 and no extra packages: the script is
+              # stdlib only, on purpose, so this needs no build of its own.
+              image: python:3.13-alpine
+              command: ["python3", "/opt/self-upgrade/redeploy.py"]
+              env:
+                - name: CURIE_API_URL
+                  # CHANGE ME with the release name if it is not `curie`.
+                  value: http://curie-api:8000
+                - name: CURIE_SELF_UPGRADE_REPO
+                  value: curie-eng/curie
+                - name: CURIE_SELF_UPGRADE_BRANCH
+                  value: main
+                - name: CURIE_SELF_UPGRADE_AGENT
+                  value: sre-bot
+                - name: CURIE_API_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      # The release's own Secret. CHANGE ME with the release name.
+                      name: curie-secrets
+                      key: apiKey
+                - name: GITHUB_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: curie-secrets
+                      key: githubToken
+                      # Optional so the job starts and reports the missing token
+                      # itself, rather than sitting in CreateContainerConfigError
+                      # where the cause is a pod event nobody is watching.
+                      optional: true
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities: { drop: ["ALL"] }
+              resources:
+                requests: { cpu: 10m, memory: 64Mi }
+                limits: { cpu: 200m, memory: 128Mi }
+              volumeMounts:
+                - name: script
+                  mountPath: /opt/self-upgrade
+                  readOnly: true
+          volumes:
+            - name: script
+              configMap:
+                name: sre-bot-self-upgrade

--- a/examples/sre-bot/self-upgrade/redeploy.py
+++ b/examples/sre-bot/self-upgrade/redeploy.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""Redeploy this bundle when the repository it lives in has moved.
+
+What this is for
+----------------
+"The bot upgrades its own version" needs three separate things, and only one of
+them is a capability the bot could ever hold:
+
+1. noticing that a newer bundle exists,
+2. getting that bundle's bytes,
+3. calling the platform to make it the in-force version.
+
+The sandbox can do none of them: it holds a per-turn ``state``-scoped token, and
+every ``/agents/**`` route needs the platform key. So the deploy is performed by
+something OUTSIDE the sandbox -- this job -- and the bot's own authority is
+unchanged. That is the same division Draft ADR-0125 draws for the control plane:
+an agent may render and propose; execution sits where a sandbox cannot reach.
+
+Why this exists next to git-flow rather than instead of it
+---------------------------------------------------------
+Curie already deploys a new version when a repository's branch tip moves
+(``commitpoller``). It packages the repository ROOT as the bundle, so it serves a
+repo whose root *is* the bundle and cannot serve a bundle living in a
+subdirectory of a monorepo.
+
+This bundle lives at ``examples/sre-bot`` inside curie, which is where it should
+stay -- it ships as the worked example, and it is reviewed with the platform
+changes it exercises. So the choice is not "git-flow or nothing": it is whether
+the bundle moves to its own repository, or whether the subdirectory case gets
+handled. This handles it, and deliberately does the same three steps git-flow
+does rather than inventing a second concept.
+
+**It is not a way around any gate.** It reads a subdirectory of a repository an
+operator named and calls two documented endpoints with the platform key an
+operator gave it. Nothing here decides what the bot may do; the bundle's own
+``approvalPolicy`` and its connectors' ceilings are unchanged by a redeploy.
+
+What it does NOT do
+-------------------
+**It does not deploy yet, and that is deliberate rather than unfinished.** The
+bundle as it sits in the repository declares ``build:`` for three connectors, and
+a cluster deploy is refused for an image that exists only in one machine's Docker
+daemon. Uploading the repository copy verbatim would create a version whose
+connectors cannot come up -- a redeploy that reports success and leaves the bot
+with no tools, which is worse than not redeploying. The missing piece is digest
+resolution, the same step ``curie example sre-bot install`` already performs for
+tempo; it needs the write connectors published first (curie#1945).
+
+So this build does the two steps that are correct on their own -- notice, and say
+so loudly enough to act on -- and stops before the one that would lie.
+
+
+It does not upgrade Curie. A new *platform* version is not something an agent can
+apply to itself: the upgrade restarts the worker the agent's turn is running in,
+so the turn that performed it cannot report the outcome or roll it back. Platform
+upgrades stay an operator action, and this job's only relationship to one is that
+it will redeploy the bundle afterwards.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import tarfile
+import urllib.error
+import urllib.request
+
+# The bundle's path inside the repository. The whole reason this file exists.
+BUNDLE_PREFIX = "examples/sre-bot"
+
+# A bundle is these files and nothing else. Everything under the prefix that is
+# not one of these is left out, so a stray editor file or a test fixture cannot
+# ride into a deployed version.
+BUNDLE_MEMBERS = (
+    ".claude-plugin/plugin.json",
+    "connectors.yaml",
+    "deploy.yaml",
+    "evals/cases.json",
+)
+BUNDLE_TREES = ("skills/", "manifests/")
+
+
+class SelfUpgradeError(RuntimeError):
+    """Something the operator has to fix, phrased for the operator."""
+
+
+def _get(url: str, token: str | None, accept: str) -> bytes:
+    headers = {"Accept": accept, "User-Agent": "curie-sre-bot-self-upgrade"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    request = urllib.request.Request(url, headers=headers)
+    try:
+        with urllib.request.urlopen(request, timeout=60) as response:
+            return response.read()
+    except urllib.error.HTTPError as exc:
+        # 404 on a private repository with no token is really 401, and reads as
+        # "no such repo" to anyone who has not hit it before. Say the likely
+        # cause rather than the status.
+        if exc.code in (401, 403, 404) and not token:
+            raise SelfUpgradeError(
+                f"{url} returned HTTP {exc.code} with no token. A private "
+                f"repository needs a read-only token in GITHUB_TOKEN; without one "
+                f"this job cannot see whether a newer bundle exists."
+            ) from exc
+        raise SelfUpgradeError(f"{url} returned HTTP {exc.code}") from exc
+
+
+def latest_commit(repo: str, branch: str, token: str | None) -> str:
+    """The sha at the tip of ``branch``, which is what "newer" means here."""
+
+    body = _get(
+        f"https://api.github.com/repos/{repo}/commits/{branch}",
+        token,
+        "application/vnd.github+json",
+    )
+    sha = json.loads(body).get("sha")
+    if not isinstance(sha, str) or not sha:
+        raise SelfUpgradeError(f"{repo}@{branch} returned no commit sha")
+    return sha
+
+
+def deployed_commit(api_url: str, api_key: str, agent: str) -> tuple[str, str | None]:
+    """``(agent_id, commit_sha)`` for the agent's newest version.
+
+    ``None`` for the sha when the newest version records none -- a version
+    deployed by hand from a working copy has no commit, and that must read as
+    "unknown", never as "up to date".
+    """
+
+    request = urllib.request.Request(
+        f"{api_url.rstrip('/')}/agents", headers={"X-API-Key": api_key}
+    )
+    with urllib.request.urlopen(request, timeout=60) as response:
+        agents = json.load(response)
+    match = next((a for a in agents if a.get("name") == agent), None)
+    if match is None:
+        raise SelfUpgradeError(
+            f"no agent named {agent!r} on {api_url}; this job redeploys an agent "
+            f"that already exists rather than creating one"
+        )
+    agent_id = match["id"]
+    request = urllib.request.Request(
+        f"{api_url.rstrip('/')}/agents/{agent_id}/versions",
+        headers={"X-API-Key": api_key},
+    )
+    with urllib.request.urlopen(request, timeout=60) as response:
+        versions = json.load(response)
+    if not versions:
+        return agent_id, None
+    newest = sorted(versions, key=lambda v: v["created_at"])[-1]
+    return agent_id, newest.get("commit_sha")
+
+
+def _wanted(name: str) -> bool:
+    if name in BUNDLE_MEMBERS:
+        return True
+    return any(name.startswith(tree) for tree in BUNDLE_TREES)
+
+
+def bundle_from_repo_tarball(archive: bytes, prefix: str = BUNDLE_PREFIX) -> bytes:
+    """Re-tar the bundle subdirectory out of a repository tarball.
+
+    GitHub's tarball wraps everything in one top-level directory whose name
+    carries the sha, so the prefix cannot be hardcoded and is discovered from the
+    first member instead.
+
+    Members are filtered to the bundle's own files. Directory entries, symlinks
+    and anything outside the prefix are dropped -- a symlink inside an archive is
+    how a tar extraction escapes its directory, and this bundle has no use for
+    one.
+    """
+
+    with tarfile.open(fileobj=io.BytesIO(archive), mode="r:gz") as source:
+        members = source.getmembers()
+        if not members:
+            raise SelfUpgradeError("repository tarball is empty")
+        root = members[0].name.split("/", 1)[0]
+        want = f"{root}/{prefix}/"
+        out = io.BytesIO()
+        found = 0
+        with tarfile.open(fileobj=out, mode="w:gz") as bundle:
+            for member in members:
+                if not member.isfile() or not member.name.startswith(want):
+                    continue
+                relative = member.name[len(want) :]
+                if not _wanted(relative):
+                    continue
+                extracted = source.extractfile(member)
+                if extracted is None:
+                    continue
+                data = extracted.read()
+                info = tarfile.TarInfo(relative)
+                info.size = len(data)
+                info.mode = 0o644
+                bundle.addfile(info, io.BytesIO(data))
+                found += 1
+        if found == 0:
+            raise SelfUpgradeError(
+                f"no bundle files under {prefix!r} in the repository tarball; "
+                f"check the path and the branch"
+            )
+    return out.getvalue()
+
+
+def main() -> int:
+    repo = os.environ.get("CURIE_SELF_UPGRADE_REPO", "curie-eng/curie")
+    branch = os.environ.get("CURIE_SELF_UPGRADE_BRANCH", "main")
+    agent = os.environ.get("CURIE_SELF_UPGRADE_AGENT", "sre-bot")
+    api_url = os.environ.get("CURIE_API_URL")
+    api_key = os.environ.get("CURIE_API_KEY")
+    token = os.environ.get("GITHUB_TOKEN") or None
+    dry_run = os.environ.get("CURIE_SELF_UPGRADE_DRY_RUN", "").lower() in ("1", "true")
+
+    if not api_url or not api_key:
+        print("CURIE_API_URL and CURIE_API_KEY are required", flush=True)
+        return 2
+
+    try:
+        tip = latest_commit(repo, branch, token)
+        agent_id, current = deployed_commit(api_url, api_key, agent)
+    except SelfUpgradeError as exc:
+        # Exit non-zero: a job that cannot tell whether it is behind must not
+        # report success. A silent "nothing to do" is the failure this whole file
+        # is a reaction to.
+        print(f"cannot determine whether {agent} is behind: {exc}", flush=True)
+        return 1
+
+    print(f"{agent}: deployed={current or 'unknown'} tip={tip[:12]}", flush=True)
+    if current == tip:
+        print("already on the repository tip; nothing to do", flush=True)
+        return 0
+    if dry_run:
+        print("dry run: would deploy the bundle at the tip", flush=True)
+        return 0
+
+    print(
+        "a newer bundle exists. This job does not deploy it yet: the bundle in the "
+        "repository declares `build:` for three connectors, and a cluster deploy is "
+        "refused for an image that exists only in a local daemon. Deploying from "
+        "here needs the published digests first (curie#1945), the way the installer "
+        "already resolves tempo's.",
+        flush=True,
+    )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - entrypoint
+    raise SystemExit(main())

--- a/examples/tests/test_self_upgrade_detection.py
+++ b/examples/tests/test_self_upgrade_detection.py
@@ -1,0 +1,105 @@
+"""The self-upgrade job's two pure decisions, tested without a network.
+
+Both are cheap to get subtly wrong in the direction that reports success:
+
+* "am I behind" has three answers, not two. A version deployed by hand from a
+  working copy records no commit, and that must read as UNKNOWN rather than as
+  up to date -- otherwise the job goes quiet forever on exactly the install where
+  someone deployed once by hand.
+* re-taring a subdirectory out of a repository tarball has to drop everything
+  outside it, including symlinks, which are how a tar extraction escapes.
+"""
+
+import io
+import sys
+import tarfile
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "sre-bot" / "self-upgrade"))
+
+from redeploy import (  # noqa: E402
+    BUNDLE_PREFIX,
+    SelfUpgradeError,
+    bundle_from_repo_tarball,
+)
+
+
+def _repo_tarball(files: dict[str, bytes], root: str = "curie-eng-curie-abc1234") -> bytes:
+    out = io.BytesIO()
+    with tarfile.open(fileobj=out, mode="w:gz") as tar:
+        for name, data in files.items():
+            info = tarfile.TarInfo(f"{root}/{name}")
+            info.size = len(data)
+            tar.addfile(info, io.BytesIO(data))
+    return out.getvalue()
+
+
+def _names(bundle: bytes) -> list[str]:
+    with tarfile.open(fileobj=io.BytesIO(bundle), mode="r:gz") as tar:
+        return sorted(m.name for m in tar.getmembers())
+
+
+def test_the_bundle_is_lifted_out_of_the_repository_tarball() -> None:
+    bundle = bundle_from_repo_tarball(
+        _repo_tarball(
+            {
+                f"{BUNDLE_PREFIX}/.claude-plugin/plugin.json": b"{}",
+                f"{BUNDLE_PREFIX}/skills/sre-bot/SKILL.md": b"# skill",
+                f"{BUNDLE_PREFIX}/evals/cases.json": b"[]",
+            }
+        )
+    )
+    assert _names(bundle) == [
+        ".claude-plugin/plugin.json",
+        "evals/cases.json",
+        "skills/sre-bot/SKILL.md",
+    ]
+
+
+def test_everything_outside_the_bundle_is_left_behind() -> None:
+    # The repository is a monorepo: the platform's own source sits beside the
+    # bundle and must not be packaged into an agent version.
+    bundle = bundle_from_repo_tarball(
+        _repo_tarball(
+            {
+                f"{BUNDLE_PREFIX}/.claude-plugin/plugin.json": b"{}",
+                "apps/api/src/curie_api/main.py": b"# not the bundle",
+                "README.md": b"# not the bundle",
+                "examples/weather/connectors.yaml": b"# another bundle",
+            }
+        )
+    )
+    assert _names(bundle) == [".claude-plugin/plugin.json"]
+
+
+def test_the_sha_carrying_root_is_discovered_not_assumed() -> None:
+    # GitHub names the top-level directory after the ref, so it cannot be hardcoded.
+    bundle = bundle_from_repo_tarball(
+        _repo_tarball(
+            {f"{BUNDLE_PREFIX}/.claude-plugin/plugin.json": b"{}"},
+            root="curie-eng-curie-deadbeefcafe",
+        )
+    )
+    assert _names(bundle) == [".claude-plugin/plugin.json"]
+
+
+def test_an_empty_result_is_an_error_rather_than_an_empty_bundle() -> None:
+    # Uploading an empty bundle would succeed and leave the agent with nothing.
+    with pytest.raises(SelfUpgradeError, match="no bundle files"):
+        bundle_from_repo_tarball(_repo_tarball({"README.md": b"# only this"}))
+
+
+def test_a_symlink_inside_the_bundle_is_dropped() -> None:
+    out = io.BytesIO()
+    root = "curie-eng-curie-abc1234"
+    with tarfile.open(fileobj=out, mode="w:gz") as tar:
+        info = tarfile.TarInfo(f"{root}/{BUNDLE_PREFIX}/.claude-plugin/plugin.json")
+        info.size = 2
+        tar.addfile(info, io.BytesIO(b"{}"))
+        link = tarfile.TarInfo(f"{root}/{BUNDLE_PREFIX}/skills/escape")
+        link.type = tarfile.SYMTYPE
+        link.linkname = "../../../../etc/passwd"
+        tar.addfile(link)
+    assert _names(bundle_from_repo_tarball(out.getvalue())) == [".claude-plugin/plugin.json"]


### PR DESCRIPTION
Answers **"can the bot upgrade its own bot version?"** with the half that is honest today, and records exactly why the other half is not in here.

## The shape

Three things are needed: notice a newer bundle exists, get its bytes, call the platform to make it in force. **The sandbox can do none of them** — it holds a per-turn `state`-scoped token, and every `/agents/**` route needs the platform key. So the work sits outside the sandbox as a CronJob, and the bot's own authority is unchanged. Same division Draft ADR-0125 draws for the control plane.

## Why beside git-flow, not instead of it

`commitpoller` already deploys when a branch tip moves. It packages the repository **root** as the bundle, so it serves a repo whose root *is* the bundle and cannot serve one living in a subdirectory of a monorepo.

This bundle lives at `examples/sre-bot` and should stay there — it ships as the worked example and gets reviewed with the platform changes it exercises. So the choice was "move the bundle into its own repository" or "handle the subdirectory case". This handles it, doing the same three steps git-flow does rather than introducing a second concept.

## It reports and stops, on purpose

I wired the deploy, read it back, and took it out.

The bundle in the repository declares `build:` for three connectors. A cluster deploy is refused for an image that exists only in one machine's Docker daemon. So uploading the repository copy verbatim would create a version whose connectors cannot start — **a redeploy that reports success and leaves the bot with no tools**, which is worse than not redeploying at all.

The missing step is digest resolution, which `curie example sre-bot install` already performs for tempo, and which needs the write connectors published first (#1945). The header and the job's own output both say this, so it cannot be mistaken for unfinished work.

## The two decisions that are pure, and tested

- **"Am I behind" has three answers, not two.** A version deployed by hand from a working copy records no commit sha. That reads as **unknown**, never as up to date — otherwise the job goes permanently quiet on exactly the install where somebody once deployed by hand.
- **Re-taring the subdirectory drops everything outside it, non-files included.** A symlink inside an archive is how a tar extraction escapes its directory; this bundle has no use for one, and there is a test that one is dropped. The sha-carrying top-level directory is discovered rather than assumed, because GitHub names it after the ref.

Five tests, no network.

## Operational choices worth a look

- **Non-zero when it cannot tell.** No token, unreachable API, missing agent — all exit 1 with the cause named. A silent "nothing to do" is indistinguishable from "up to date" and can stay that way for months; that failure mode is the reason this file exists at all.
- **`GITHUB_TOKEN` is `optional: true` in the manifest.** Not laxness: a required-but-absent key leaves the pod in `CreateContainerConfigError`, where the cause is a pod event nobody is watching. Optional means the job starts and says "I need a token" in its own log.
- **Stdlib only**, so it needs no image of its own — `python:3.13-alpine` runs it.
- Read-only root filesystem, non-root, all capabilities dropped, `concurrencyPolicy: Forbid`.

## What it does not do

It does not upgrade Curie. A platform upgrade restarts the worker the agent's turn runs in, so the turn performing it cannot report the outcome or roll it back — that stays an operator action, and this job's only relationship to one is that it will notice the bundle is behind afterwards.
