### PR TITLE
Validate the example connector images on arm64, where they are published

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -477,16 +477,24 @@ jobs:
           - name: sre-bot-tempo
             context: examples/sre-bot/connectors/tempo
             dockerfile: examples/sre-bot/connectors/tempo/Dockerfile
+            platforms: linux/amd64,linux/arm64
           - name: sre-bot-k8s-write
             context: examples/sre-bot/connectors/k8s-write
             dockerfile: examples/sre-bot/connectors/k8s-write/Dockerfile
+            platforms: linux/amd64,linux/arm64
           - name: sre-bot-k8s-scale
             context: examples/sre-bot/connectors/k8s-scale
             dockerfile: examples/sre-bot/connectors/k8s-scale/Dockerfile
+            platforms: linux/amd64,linux/arm64
     steps:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
+      # Only reached by the entries that ask for a foreign architecture; a
+      # native-only build does not need the emulator and does not pay for it.
+      - name: Set up QEMU
+        if: matrix.platforms
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
       - name: Set up Buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
       - name: Build (no push)
@@ -494,6 +502,12 @@ jobs:
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
+          # Empty for the platform images, which build for the runner's own
+          # architecture. The example connectors set both, because release.yaml
+          # publishes both and validating only amd64 leaves an arm64-only
+          # Dockerfile failure to appear for the first time during a release --
+          # failing the release rather than the pull request that caused it.
+          platforms: ${{ matrix.platforms }}
           push: false
           load: false
           cache-from: type=gha

--- a/release/tests/test_authorize.py
+++ b/release/tests/test_authorize.py
@@ -971,12 +971,22 @@ class TestReleaseWorkflowContract:
                 "name": "sre-bot-tempo",
                 "context": "examples/sre-bot/connectors/tempo",
                 "dockerfile": "examples/sre-bot/connectors/tempo/Dockerfile",
+                # release.yaml publishes every image for both architectures, so
+                # CI validates the example connectors on both. Without this the
+                # first place an arm64-only Dockerfile failure could appear was a
+                # release, where it fails the release rather than the pull
+                # request that introduced it.
+                "platforms": "linux/amd64,linux/arm64",
             }
         ]
         build_step = next(
             step for step in image_job["steps"] if step.get("name") == "Build (no push)"
         )
         assert build_step["with"]["context"] == "${{ matrix.context }}"
+        assert build_step["with"]["platforms"] == "${{ matrix.platforms }}", (
+            "the build step must read the per-entry platforms, so the platform "
+            "images keep building natively while the connectors cross-build"
+        )
         assert "Build sre-bot-tempo image (no push)" in authorize_module.REQUIRED_CHECK_NAMES
 
     def test_observability_stack_assertions_run_in_helm_ci(self):


### PR DESCRIPTION
`release.yaml` publishes every image for **linux/amd64 and linux/arm64**. The CI build-only job set no `platforms`, so it validated the runner's own architecture alone.

So an arm64-only Dockerfile failure had nowhere to surface before a release — and would fail **the release**, not the pull request that introduced it.

That gap arrived with the two write connectors #1945 added, and it matters more than usual right now: the write path's remaining work (#1988, and the digest step behind it) is waiting on one release to publish those images. A release failing on an arm64 build is the expensive way to learn this.

## Scope

Per-entry `platforms`, set only on the three example connectors:

```
runner / api / dispatcher / mail-adapter / worker / ui   → native (unchanged)
sre-bot-tempo / -k8s-write / -k8s-scale                  → linux/amd64,linux/arm64
```

The platform images keep building natively on purpose. Emulating a Rust or Node build under QEMU costs far more than it buys, and those images are exercised by the parity ladder besides. The connectors are `pip install` on a slim base, so the emulated build is cheap.

QEMU is set up behind `if: matrix.platforms`, so a native-only entry does not pay for an emulator it never uses.
