### PR TITLE
Pin the self-upgrade's connector images from the commit it deploys

### DIFF
--- a/examples/sre-bot/self-upgrade/cronjob.yaml
+++ b/examples/sre-bot/self-upgrade/cronjob.yaml
@@ -12,17 +12,19 @@
 # `state`-scoped token and nothing else, deliberately. So the work sits outside
 # the sandbox, and the bot's own authority is unchanged by this file.
 #
-# WHY IT ONLY REPORTS. See redeploy.py's header: the bundle in the repository
-# declares `build:` for three connectors, and a cluster deploy is refused for an
-# image that exists only in a local Docker daemon. Deploying the repository copy
-# verbatim would create a version whose connectors cannot start -- a redeploy
-# that reports success and leaves the bot with no tools. The missing step is
-# digest resolution, which needs those connectors published first (curie#1945).
+# HOW IT DEPLOYS SAFELY. The bundle in the repository declares `build:` for its
+# connectors, which records a LOCAL image id the cluster tier refuses, and it
+# ships PLACEHOLDER allowlists. Deploying it verbatim would produce a bot whose
+# connectors cannot start, or one that refuses every write and looks like it
+# simply chose not to act. So the job pins each `build:` connector to the image
+# `release.yaml` published for THIS commit (`sha-<commit>`, so the images can
+# only ever be the ones built from the bundle being deployed), and carries the
+# ceilings the install is actually running across from the rendered objects.
 #
-# THE TOKEN. `GITHUB_TOKEN` needs `contents: read` on the repository and nothing
-# else. Without it the job exits non-zero and says so: a job that cannot tell
-# whether it is behind must not report success, because a silent "nothing to do"
-# is indistinguishable from "up to date" and can stay that way for months.
+# THE TOKEN. Optional while the repository is public. On a private one
+# `GITHUB_TOKEN` needs `contents: read` and nothing else; without it the job
+# exits non-zero and says so, because a silent "nothing to do" is
+# indistinguishable from "up to date" and can stay that way for months.
 ---
 apiVersion: batch/v1
 kind: CronJob
@@ -49,9 +51,12 @@ spec:
             seccompProfile: { type: RuntimeDefault }
           containers:
             - name: check
-              # Any image with a python3 and no extra packages: the script is
-              # stdlib only, on purpose, so this needs no build of its own.
-              image: python:3.13-alpine
+              # The platform's own API image, because the script needs a YAML
+              # parser to rewrite the connector declaration and this image
+              # already carries one. A bare `python:` image plus a pip install
+              # would put a package download in the deploy path.
+              # CHANGE ME to match the release's version.
+              image: ghcr.io/curie-eng/curie-api:0.7.0
               command: ["python3", "/opt/self-upgrade/redeploy.py"]
               env:
                 - name: CURIE_API_URL
@@ -63,6 +68,12 @@ spec:
                   value: main
                 - name: CURIE_SELF_UPGRADE_AGENT
                   value: sre-bot
+                # The rendered connector objects are namespaced by the release
+                # that owns them, so reading the running ceilings needs both.
+                - name: CURIE_SELF_UPGRADE_RELEASE
+                  value: curie
+                - name: CURIE_SELF_UPGRADE_NAMESPACE
+                  value: curie
                 - name: CURIE_API_KEY
                   valueFrom:
                     secretKeyRef:

--- a/examples/sre-bot/self-upgrade/redeploy.py
+++ b/examples/sre-bot/self-upgrade/redeploy.py
@@ -235,65 +235,144 @@ def bundle_from_repo_tarball(archive: bytes, prefix: str = BUNDLE_PREFIX) -> byt
     return out.getvalue()
 
 
-def paths_changed(repo: str, base: str, head: str, token: str | None) -> set[str]:
-    """Repository paths that differ between two commits.
+def resolve_digest(connector: str, commit: str) -> str:
+    """The published image digest for one connector at one commit.
 
-    One API call, and it replaces the thing this job cannot do: parse
-    `connectors.yaml`. The runtime image is `python:3.13-alpine` with the standard
-    library and no YAML parser, and adding one to install a dependency at job time
-    would buy a parser in exchange for a network dependency in the deploy path.
+    `release.yaml` publishes every example connector on each push to a release
+    branch, tagged `sha-<commit>`. So the images that belong with a bundle are
+    derivable from the bundle's own commit -- no constant to keep in step, and a
+    deploy of commit X can only ever run images built from commit X.
+
+    Anonymous: the packages are public, like the repository. Verified against the
+    live registry rather than assumed.
     """
 
-    body = _get(
-        f"https://api.github.com/repos/{repo}/compare/{base}...{head}",
-        token,
-        "application/vnd.github+json",
+    repository = f"curie-eng/curie-sre-bot-{connector}"
+    token = json.loads(
+        _get(
+            f"https://ghcr.io/token?service=ghcr.io&scope=repository:{repository}:pull",
+            None,
+            "application/json",
+        )
+    ).get("token")
+    if not token:
+        raise SelfUpgradeError(f"ghcr.io issued no pull token for {repository}")
+    request = urllib.request.Request(
+        f"https://ghcr.io/v2/{repository}/manifests/sha-{commit}",
+        headers={
+            "Authorization": f"Bearer {token}",
+            # An index, not a single manifest: the cluster is arm64 here and
+            # amd64 elsewhere, and pinning one architecture's manifest would
+            # deploy an image that cannot run on the other.
+            "Accept": (
+                "application/vnd.oci.image.index.v1+json, "
+                "application/vnd.docker.distribution.manifest.list.v2+json"
+            ),
+            "User-Agent": "curie-sre-bot-self-upgrade",
+        },
+        method="HEAD",
     )
-    files = json.loads(body).get("files") or []
-    return {entry.get("filename", "") for entry in files}
+    try:
+        with urllib.request.urlopen(request, timeout=60) as response:
+            digest = response.headers.get("Docker-Content-Digest")
+    except urllib.error.HTTPError as exc:
+        raise SelfUpgradeError(
+            f"no published image for {connector} at commit {commit[:12]} "
+            f"(HTTP {exc.code}). Every release-branch push publishes one, so a "
+            f"missing image means this commit's release build has not finished "
+            f"or did not run."
+        ) from exc
+    if not digest:
+        raise SelfUpgradeError(f"{repository} returned no digest header")
+    return str(digest)
 
 
-def deployed_bundle_file(
-    api_url: str, api_key: str, agent_id: str, version_id: str, path: str
+def pin_build_connectors(
+    declaration: bytes, commit: str, carried: dict[str, dict[str, str]]
 ) -> bytes:
-    """One file out of the version that is currently deployed."""
+    """Turn every `build:` connector into a digest-pinned `image:`.
 
-    body = _api(api_url, api_key, f"/agents/{agent_id}/versions/{version_id}/files")
-    for entry in json.loads(body).get("files") or []:
-        if entry.get("path") == path:
-            return str(entry.get("content", "")).encode()
-    raise SelfUpgradeError(
-        f"the deployed version carries no {path}; this job reuses it rather than "
-        f"resolving connector images itself, so it cannot proceed without it"
-    )
-
-
-def with_connectors_from(bundle: bytes, connectors: bytes) -> bytes:
-    """The new bundle, but keeping the deployed `connectors.yaml`.
-
-    The repository's copy declares `build:`, which records a LOCAL image id that
-    the cluster tier refuses -- a cluster cannot pull an image that exists only in
-    one machine's Docker daemon. Resolving those to published digests is the
-    installer's job and it needs a registry conversation this job has no business
-    having. The deployed copy already carries resolved digests, so the safe move
-    is to carry it forward unchanged.
-
-    Only sound while the declaration itself has not changed, which the caller
-    checks first and refuses on.
+    Two substitutions, and the second is the one that is easy to forget. A
+    `build:` block records a LOCAL image id, which the cluster tier refuses. And
+    the declaration in the repository ships PLACEHOLDER allowlists -- deploying
+    those verbatim would leave every write connector refusing every call, which
+    reads exactly like a working bot that has decided not to act. So the ceilings
+    the install is actually running are carried across.
     """
+
+    import yaml
+
+    parsed = yaml.safe_load(declaration)
+    for name, spec in (parsed.get("connectors") or {}).items():
+        if "build" in spec:
+            spec.pop("build")
+            spec["image"] = f"ghcr.io/curie-eng/curie-sre-bot-{name}@{resolve_digest(name, commit)}"
+        for key, value in (carried.get(name) or {}).items():
+            spec.setdefault("env", {})[key] = value
+    return yaml.safe_dump(parsed, sort_keys=False).encode()
+
+
+def running_connector_env(
+    api_url: str,
+    api_key: str,
+    agent_id: str,
+    version_id: str,
+    release: str,
+    namespace: str,
+) -> dict[str, dict[str, str]]:
+    """The env each connector is running with, read off the rendered objects.
+
+    The SOURCE `connectors.yaml` is not retrievable -- a version's file listing
+    carries the authored text (skill, manifest, eval cases) and not the connector
+    declaration. The RENDERED objects are, and they carry the resolved values,
+    which is what has to survive an upgrade.
+    """
+
+    query = f"?release={release}&namespace={namespace}&app_name=curie"
+    rendered = json.loads(
+        _api(api_url, api_key, f"/agents/{agent_id}/versions/{version_id}/connectors{query}")
+    )
+    out: dict[str, dict[str, str]] = {}
+    for manifest in rendered.get("manifests") or []:
+        if manifest.get("kind") != "Deployment":
+            continue
+        name = manifest["metadata"]["name"].rsplit("-mcp-", 1)[-1]
+        container = manifest["spec"]["template"]["spec"]["containers"][0]
+        out[name] = {
+            entry["name"]: entry["value"]
+            for entry in container.get("env") or []
+            if "value" in entry
+        }
+    return out
+
+
+def member_of(bundle: bytes, name: str) -> bytes:
+    """One file out of a bundle tarball."""
+
+    with tarfile.open(fileobj=io.BytesIO(bundle), mode="r:gz") as tar:
+        try:
+            extracted = tar.extractfile(name)
+        except KeyError:
+            extracted = None
+        if extracted is None:
+            raise SelfUpgradeError(f"the bundle carries no {name}")
+        return extracted.read()
+
+
+def replace_member(bundle: bytes, name: str, body: bytes) -> bytes:
+    """The same bundle with one file swapped, everything else byte for byte."""
 
     out = io.BytesIO()
     source = tarfile.open(fileobj=io.BytesIO(bundle), mode="r:gz")
     with source, tarfile.open(fileobj=out, mode="w:gz") as target:
         for member in source.getmembers():
-            if member.name == "connectors.yaml":
-                replacement = tarfile.TarInfo("connectors.yaml")
-                replacement.size = len(connectors)
+            if member.name == name:
+                replacement = tarfile.TarInfo(name)
+                replacement.size = len(body)
                 replacement.mode = member.mode
-                target.addfile(replacement, io.BytesIO(connectors))
+                target.addfile(replacement, io.BytesIO(body))
                 continue
-            extracted = source.extractfile(member)
-            target.addfile(member, extracted)
+            target.addfile(member, source.extractfile(member))
     return out.getvalue()
 
 
@@ -360,6 +439,10 @@ def main() -> int:
     api_key = os.environ.get("CURIE_API_KEY")
     token = os.environ.get("GITHUB_TOKEN") or None
     dry_run = os.environ.get("CURIE_SELF_UPGRADE_DRY_RUN", "").lower() in ("1", "true")
+    # The rendered connector objects are namespaced by the release that owns
+    # them, so the lookup needs both. Defaults match the chart's own.
+    release = os.environ.get("CURIE_SELF_UPGRADE_RELEASE", "curie")
+    namespace = os.environ.get("CURIE_SELF_UPGRADE_NAMESPACE", "curie")
 
     if not api_url or not api_key:
         print("CURIE_API_URL and CURIE_API_KEY are required", flush=True)
@@ -393,27 +476,18 @@ def main() -> int:
         return 1
 
     try:
-        # The one thing this job will not do. Resolving `build:` connectors to
-        # published digests is the installer's work; carrying the deployed
-        # declaration forward is only sound while that declaration has not moved.
-        if f"{BUNDLE_PREFIX}/connectors.yaml" in paths_changed(repo, current, tip, token):
-            print(
-                "connectors.yaml changed between the deployed commit and the tip. "
-                "This job carries the deployed connector declaration forward rather "
-                "than resolving images itself, so it refuses instead of deploying a "
-                "bundle whose connectors it cannot vouch for. Run the installer.",
-                flush=True,
-            )
-            return 1
-
         archive = _get(
             f"https://api.github.com/repos/{repo}/tarball/{tip}",
             token,
             "application/vnd.github+json",
         )
         bundle = bundle_from_repo_tarball(archive)
-        connectors = deployed_bundle_file(api_url, api_key, agent_id, version_id, "connectors.yaml")
-        bundle = with_connectors_from(bundle, connectors)
+        carried = running_connector_env(api_url, api_key, agent_id, version_id, release, namespace)
+        bundle = replace_member(
+            bundle,
+            "connectors.yaml",
+            pin_build_connectors(member_of(bundle, "connectors.yaml"), tip, carried),
+        )
         new_version = deploy(api_url, api_key, agent_id, bundle, tip)
     except SelfUpgradeError as exc:
         print(f"deploy failed: {exc}", flush=True)

--- a/examples/tests/test_self_upgrade_detection.py
+++ b/examples/tests/test_self_upgrade_detection.py
@@ -16,6 +16,7 @@ import tarfile
 from pathlib import Path
 
 import pytest
+import yaml
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "sre-bot" / "self-upgrade"))
 
@@ -23,8 +24,9 @@ from redeploy import (  # noqa: E402
     BUNDLE_PREFIX,
     SelfUpgradeError,
     bundle_from_repo_tarball,
-    deployed_bundle_file,
-    with_connectors_from,
+    member_of,
+    pin_build_connectors,
+    replace_member,
 )
 
 
@@ -107,13 +109,17 @@ def test_a_symlink_inside_the_bundle_is_dropped() -> None:
     assert _names(bundle_from_repo_tarball(out.getvalue())) == [".claude-plugin/plugin.json"]
 
 
-# --- carrying the deployed connector declaration forward ----------------------
+# --- pinning images from the commit being deployed ---------------------------
 #
-# The repository's `connectors.yaml` declares `build:`, which records a LOCAL
-# image id the cluster tier refuses. Resolving those to published digests is the
-# installer's job. This job carries the DEPLOYED declaration forward instead,
-# which is only sound while that declaration has not changed -- checked by the
-# caller, and refused rather than guessed.
+# The repository declares `build:` for its connectors, which records a LOCAL
+# image id the cluster tier refuses. `release.yaml` publishes each connector on
+# every release-branch push tagged `sha-<commit>`, so the images that belong with
+# a bundle are derivable from the bundle's own commit.
+#
+# The second substitution is the one that is easy to forget: the declaration in
+# the repository ships PLACEHOLDER allowlists, and deploying those verbatim would
+# leave every write connector refusing every call -- which reads exactly like a
+# working bot that has decided not to act.
 
 
 def _bundle(files: dict[str, bytes]) -> bytes:
@@ -135,49 +141,54 @@ def _read(bundle: bytes) -> dict[str, bytes]:
         }
 
 
-def test_only_the_connector_declaration_is_carried_forward() -> None:
-    new = _bundle(
-        {
-            "connectors.yaml": b"connectors:\n  tempo:\n    build: connectors/tempo\n",
-            "skills/sre-bot/SKILL.md": b"the new skill",
-            ".claude-plugin/plugin.json": b'{"name":"sre-bot"}',
-        }
-    )
-    deployed = b"connectors:\n  tempo:\n    image: ghcr.io/x@sha256:deadbeef\n"
-
-    merged = _read(with_connectors_from(new, deployed))
-
-    assert merged["connectors.yaml"] == deployed, "the resolved declaration must win"
-    assert merged["skills/sre-bot/SKILL.md"] == b"the new skill", (
-        "everything else must come from the new bundle -- carrying the whole "
-        "deployed bundle forward would make the upgrade a no-op"
-    )
-    assert merged[".claude-plugin/plugin.json"] == b'{"name":"sre-bot"}'
+DECLARATION = b"""connectors:
+  kubernetes:
+    image: ghcr.io/containers/kubernetes-mcp-server@sha256:aaa
+  k8s-write:
+    build:
+      context: connectors/k8s-write
+    env:
+      K8S_WRITE_ALLOWLIST: <namespace>/<deployment>
+"""
 
 
-def test_a_bundle_with_no_connector_declaration_still_round_trips() -> None:
-    # `build:`-free bundles exist (the weather example), and the substitution must
-    # not invent a file that was never there.
-    new = _bundle({"skills/sre-bot/SKILL.md": b"only a skill"})
-    merged = _read(with_connectors_from(new, b"unused"))
-    assert merged == {"skills/sre-bot/SKILL.md": b"only a skill"}
-
-
-def test_a_missing_deployed_declaration_is_an_error_not_a_default() -> None:
-    # Falling back to the repository's `build:` copy here would deploy a bundle
-    # whose connectors cannot start, and report success doing it.
-    class _Stub:
-        @staticmethod
-        def urlopen(*_args, **_kwargs):  # pragma: no cover - not reached
-            raise AssertionError("no network in this test")
-
+@pytest.fixture
+def offline_registry(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No registry in a unit test; the resolution itself is exercised live."""
     import redeploy
 
-    original = redeploy._api
-    redeploy._api = lambda *_a, **_k: b'{"files": [{"path": "skills/sre-bot/SKILL.md"}]}'
-    try:
-        with pytest.raises(SelfUpgradeError) as excinfo:
-            deployed_bundle_file("http://api", "k", "agent", "version", "connectors.yaml")
-    finally:
-        redeploy._api = original
-    assert "connectors.yaml" in str(excinfo.value)
+    monkeypatch.setattr(redeploy, "resolve_digest", lambda _c, _commit: "sha256:fixture")
+
+
+def test_a_build_connector_is_pinned_to_the_commits_published_image(
+    offline_registry: None,
+) -> None:
+    parsed = yaml.safe_load(pin_build_connectors(DECLARATION, "c" * 40, {"k8s-write": {}}))
+    write = parsed["connectors"]["k8s-write"]
+    assert "build" not in write, "a build declaration cannot reach a cluster deploy"
+    assert write["image"] == ("ghcr.io/curie-eng/curie-sre-bot-k8s-write@sha256:fixture")
+    # An already-pinned connector is left alone rather than re-resolved.
+    assert parsed["connectors"]["kubernetes"]["image"].endswith("@sha256:aaa")
+
+
+def test_the_running_ceiling_survives_the_upgrade(offline_registry: None) -> None:
+    # The placeholder in the repository would refuse every call, and a bot that
+    # refuses everything looks exactly like a bot that chose not to act.
+    parsed = yaml.safe_load(
+        pin_build_connectors(
+            DECLARATION, "c" * 40, {"k8s-write": {"K8S_WRITE_ALLOWLIST": "ns/one,ns/two"}}
+        )
+    )
+    assert parsed["connectors"]["k8s-write"]["env"]["K8S_WRITE_ALLOWLIST"] == "ns/one,ns/two"
+
+
+def test_replacing_one_member_leaves_the_others_byte_for_byte() -> None:
+    original = _bundle({"connectors.yaml": b"old", "skills/sre-bot/SKILL.md": b"the skill"})
+    swapped = _read(replace_member(original, "connectors.yaml", b"new"))
+    assert swapped["connectors.yaml"] == b"new"
+    assert swapped["skills/sre-bot/SKILL.md"] == b"the skill"
+
+
+def test_a_missing_member_is_an_error_rather_than_an_empty_file() -> None:
+    with pytest.raises(SelfUpgradeError):
+        member_of(_bundle({"skills/sre-bot/SKILL.md": b"x"}), "connectors.yaml")


### PR DESCRIPTION
#1991's approach does not work, and the cluster is what said so.

It carried the **deployed** `connectors.yaml` forward, on the grounds that it already holds resolved digests. **The platform does not store that file.** A version's file listing carries the authored text — skill, manifest, eval cases — and not the connector declaration. So there was nothing to carry, and the job failed on the first real install it met:

```
SelfUpgradeError: the deployed version carries no connectors.yaml
```

My unit tests passed because they fed it a tarball I had built myself. I never asked the API whether it would hand that file back.

## The right source is the commit

`release.yaml` publishes every example connector on each push to a release branch, tagged `sha-<commit>`. So the images that belong with a bundle are **derivable from the bundle's own commit** — a deploy of commit X can only ever run images built from commit X. Nothing to keep in step, which is also better than the fixed tag the installer uses.

Verified against the live registry rather than assumed. The anonymous pull token and the index HEAD both answer, and the digest returned for `k8s-scale` at the current tip matches what `ctr` resolved on the cluster byte for byte:

```
sha256:bcb90d40c163a8310a7825fff5aae1b30f514395a3ede4a9331cf203c0895235
```

## The substitution that is easy to forget

The declaration in the repository ships **placeholder allowlists**. Deploying those verbatim would leave every write connector refusing every call — which reads exactly like a working bot that has decided not to act, and is the worse of the two failures because nothing looks wrong.

So the ceilings the install is actually running are read off the **rendered** connector objects, which the API does return, and carried across.

## Runtime image

The job now runs on the platform's own API image. Rewriting the declaration needs a YAML parser and that image already carries one; a bare `python:` image plus a `pip install` would put a package download in the deploy path.

## Tests

Four replace the three that pinned the old design: a `build:` connector is pinned and an already-pinned one is left alone, the running ceiling survives the upgrade, one member is replaced byte for byte, and a missing member is an error rather than an empty file. The registry call is stubbed in the unit tests and exercised live instead — which is the lesson from the failure above.

Also corrects the CronJob's header, which still claimed the job only reports.

Local: ruff, mypy clean; `examples/tests` 57 passed.
