### PR TITLE
Read the version the agent is serving, not the newest row

### DIFF
--- a/examples/sre-bot/self-upgrade/redeploy.py
+++ b/examples/sre-bot/self-upgrade/redeploy.py
@@ -153,35 +153,54 @@ def _api(
 
 
 def deployed_commit(api_url: str, api_key: str, agent: str) -> tuple[str, str | None, str | None]:
-    """``(agent_id, commit_sha, version_id)`` for the agent's newest version.
+    """``(agent_id, commit_sha, version_id)`` for the version this agent is SERVING.
 
-    ``None`` for the sha when the newest version records none -- a version
+    The active deployment, not the newest version row. Those are different facts
+    and confusing them is how this job read a version that was created and never
+    deployed -- then tried to read a connector surface out of it and got "no
+    bundle stored for this version", which reads like a broken agent rather than
+    like a question asked about the wrong row.
+
+    ``None`` for the sha when the deployed version records none: a version
     deployed by hand from a working copy has no commit, and that must read as
     "unknown", never as "up to date".
     """
 
-    request = urllib.request.Request(
-        f"{api_url.rstrip('/')}/agents", headers={"X-API-Key": api_key}
-    )
-    with urllib.request.urlopen(request, timeout=60) as response:
-        agents = json.load(response)
+    def get(path: str) -> list[dict[str, object]]:
+        request = urllib.request.Request(
+            f"{api_url.rstrip('/')}{path}", headers={"X-API-Key": api_key}
+        )
+        with urllib.request.urlopen(request, timeout=60) as response:
+            payload: list[dict[str, object]] = json.load(response)
+        return payload
+
+    agents = get("/agents")
     match = next((a for a in agents if a.get("name") == agent), None)
     if match is None:
         raise SelfUpgradeError(
             f"no agent named {agent!r} on {api_url}; this job redeploys an agent "
             f"that already exists rather than creating one"
         )
-    agent_id = match["id"]
-    request = urllib.request.Request(
-        f"{api_url.rstrip('/')}/agents/{agent_id}/versions",
-        headers={"X-API-Key": api_key},
-    )
-    with urllib.request.urlopen(request, timeout=60) as response:
-        versions = json.load(response)
-    if not versions:
+    agent_id = str(match["id"])
+
+    active = [
+        d
+        for d in get("/deployments")
+        if d.get("agent_id") == agent_id and d.get("status") == "active"
+    ]
+    if not active:
         return agent_id, None, None
-    newest = sorted(versions, key=lambda v: v["created_at"])[-1]
-    return agent_id, newest.get("commit_sha"), newest.get("id")
+    deployment = sorted(active, key=lambda d: str(d["deployed_at"]))[-1]
+    version_id = deployment.get("version_id")
+
+    versions = get(f"/agents/{agent_id}/versions")
+    row = next((v for v in versions if v.get("id") == version_id), None)
+    if row is None:
+        return agent_id, None, None
+    # The deployment carries a commit too; prefer the version's own, and fall
+    # back rather than reporting "unknown" when only the deployment recorded it.
+    commit = row.get("commit_sha") or deployment.get("commit_sha")
+    return agent_id, str(commit) if commit else None, str(version_id)
 
 
 def _wanted(name: str) -> bool:

--- a/examples/tests/test_self_upgrade_detection.py
+++ b/examples/tests/test_self_upgrade_detection.py
@@ -11,6 +11,7 @@ Both are cheap to get subtly wrong in the direction that reports success:
 """
 
 import io
+import json
 import sys
 import tarfile
 from pathlib import Path
@@ -24,6 +25,7 @@ from redeploy import (  # noqa: E402
     BUNDLE_PREFIX,
     SelfUpgradeError,
     bundle_from_repo_tarball,
+    deployed_commit,
     member_of,
     pin_build_connectors,
     replace_member,
@@ -192,3 +194,79 @@ def test_replacing_one_member_leaves_the_others_byte_for_byte() -> None:
 def test_a_missing_member_is_an_error_rather_than_an_empty_file() -> None:
     with pytest.raises(SelfUpgradeError):
         member_of(_bundle({"skills/sre-bot/SKILL.md": b"x"}), "connectors.yaml")
+
+
+# --- the version being SERVED, not the newest row -----------------------------
+#
+# Those are different facts. A version can be created and never deployed, and
+# reading that one made the job ask for a connector surface that does not exist
+# -- "no bundle stored for this version", which reads like a broken agent rather
+# than a question asked about the wrong row.
+
+
+class _FakeApi:
+    """Answers the three GETs deployed_commit makes, in order."""
+
+    def __init__(self, deployments: list[dict], versions: list[dict]) -> None:
+        self.routes = {
+            "/agents": [{"id": "agent-1", "name": "sre-bot"}],
+            "/deployments": deployments,
+            "/agents/agent-1/versions": versions,
+        }
+
+    def __call__(self, request, timeout=0):  # noqa: ANN001 - urlopen's shape
+        path = request.full_url.replace("http://api", "")
+        import io as _io
+
+        return _io.BytesIO(json.dumps(self.routes[path]).encode())
+
+
+def _patched(monkeypatch: pytest.MonkeyPatch, api: _FakeApi) -> None:
+    import redeploy
+
+    class _Ctx:
+        def __init__(self, body):
+            self.body = body
+
+        def __enter__(self):
+            return self.body
+
+        def __exit__(self, *_):
+            return False
+
+    monkeypatch.setattr(redeploy.urllib.request, "urlopen", lambda r, timeout=0: _Ctx(api(r)))
+
+
+def test_the_served_version_wins_over_a_newer_undeployed_one(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api = _FakeApi(
+        deployments=[
+            {
+                "agent_id": "agent-1",
+                "version_id": "served",
+                "status": "active",
+                "deployed_at": "2026-01-01T00:00:00",
+                "commit_sha": None,
+            }
+        ],
+        versions=[
+            {"id": "served", "commit_sha": "a" * 40, "created_at": "2026-01-01T00:00:00"},
+            # Newer, and never deployed: exactly the row that used to win.
+            {"id": "never-deployed", "commit_sha": "b" * 40, "created_at": "2026-06-01T00:00:00"},
+        ],
+    )
+    _patched(monkeypatch, api)
+
+    agent_id, commit, version_id = deployed_commit("http://api", "k", "sre-bot")
+
+    assert version_id == "served"
+    assert commit == "a" * 40
+
+
+def test_no_active_deployment_reads_as_unknown(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Never "up to date". A job that cannot tell must not report success.
+    api = _FakeApi(deployments=[], versions=[{"id": "v", "commit_sha": "c" * 40}])
+    _patched(monkeypatch, api)
+    _agent, commit, version_id = deployed_commit("http://api", "k", "sre-bot")
+    assert commit is None and version_id is None


### PR DESCRIPTION
Found on the live install, running the job end to end for the first time.

`deployed_commit` took the **newest version by `created_at`**. That is not the same fact as **the version being served** — a version can be created and never deployed. When that happened, the job read a connector surface out of it:

```
HTTP 404: {"detail":"no bundle stored for this version"}
```

which reads like a broken agent rather than a question asked about the wrong row.

And the failure mode is not symmetric only in that direction: had the never-deployed row carried the repository tip's commit, the job would have concluded **"already up to date"** and gone quiet, from a version nobody is running. That is the silent half, and it is the one this job exists to prevent.

## Fix

Read the **active deployment**, then look the version up from it.

If the version row records no commit but the deployment does, the deployment's is used rather than reporting "unknown" — either one answers "am I behind".

No active deployment still reads as unknown, never as up to date.

## Tests

Two, against a fake API: a newer undeployed version does not win over the served one, and an empty deployment list reads as unknown. Load-bearing — putting the newest-row lookup back fails the first and leaves the other ten green.

Local: ruff, mypy clean; 11 tests pass.
