### PR TITLE
Upload the bundle as a form, because that endpoint is an upload

### DIFF
--- a/examples/sre-bot/self-upgrade/redeploy.py
+++ b/examples/sre-bot/self-upgrade/redeploy.py
@@ -59,6 +59,7 @@ it will redeploy the bundle afterwards.
 
 from __future__ import annotations
 
+import hashlib
 import io
 import json
 import os
@@ -425,13 +426,24 @@ def deploy(
         )
     )
     version_id = str(created["id"])
+    # A multipart form with a `file` part, not a raw body. The endpoint is an
+    # upload rather than a document write, and a raw PUT is refused with a 422
+    # naming a field the caller never knew about:
+    #     {"loc": ["body", "file"], "msg": "Field required"}
+    boundary = "----curie" + hashlib.sha256(bundle).hexdigest()[:24]
+    form = (
+        f"--{boundary}\r\n"
+        'Content-Disposition: form-data; name="file"; filename="bundle.tar.gz"\r\n'
+        "Content-Type: application/gzip\r\n\r\n"
+    ).encode()
+    form += bundle + f"\r\n--{boundary}--\r\n".encode()
     _api(
         api_url,
         api_key,
         f"/agents/{agent_id}/versions/{version_id}/bundle",
         method="PUT",
-        body=bundle,
-        content_type="application/gzip",
+        body=form,
+        content_type=f"multipart/form-data; boundary={boundary}",
     )
     _api(
         api_url,

--- a/examples/tests/test_self_upgrade_detection.py
+++ b/examples/tests/test_self_upgrade_detection.py
@@ -22,10 +22,10 @@ import yaml
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "sre-bot" / "self-upgrade"))
 
 from redeploy import (  # noqa: E402
-    deploy,
     BUNDLE_PREFIX,
     SelfUpgradeError,
     bundle_from_repo_tarball,
+    deploy,
     deployed_commit,
     member_of,
     pin_build_connectors,

--- a/examples/tests/test_self_upgrade_detection.py
+++ b/examples/tests/test_self_upgrade_detection.py
@@ -22,6 +22,7 @@ import yaml
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "sre-bot" / "self-upgrade"))
 
 from redeploy import (  # noqa: E402
+    deploy,
     BUNDLE_PREFIX,
     SelfUpgradeError,
     bundle_from_repo_tarball,
@@ -270,3 +271,42 @@ def test_no_active_deployment_reads_as_unknown(monkeypatch: pytest.MonkeyPatch) 
     _patched(monkeypatch, api)
     _agent, commit, version_id = deployed_commit("http://api", "k", "sre-bot")
     assert commit is None and version_id is None
+
+
+# --- the bundle upload is a form, not a body ---------------------------------
+#
+# The endpoint is an upload rather than a document write. A raw PUT is refused
+# with a 422 naming a field the caller never knew about:
+#     {"loc": ["body", "file"], "msg": "Field required"}
+# It failed exactly there on the live install, after the job had already fetched
+# the bundle, resolved three image digests and created the version -- so the cost
+# of getting this wrong is a version row with no bundle behind it.
+
+
+def test_the_bundle_is_uploaded_as_a_multipart_file(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import redeploy
+
+    seen: list[dict] = []
+
+    def _fake(api_url, api_key, path, *, method="GET", body=None, content_type="application/json"):
+        seen.append({"path": path, "method": method, "body": body, "content_type": content_type})
+        if path.endswith("/versions"):
+            return json.dumps({"id": "v-1"}).encode()
+        return b"{}"
+
+    monkeypatch.setattr(redeploy, "_api", _fake)
+    deploy("http://api", "k", "agent-1", b"BUNDLEBYTES", "d" * 40)
+
+    upload = next(c for c in seen if c["path"].endswith("/bundle"))
+    assert upload["content_type"].startswith("multipart/form-data; boundary=")
+    boundary = upload["content_type"].split("boundary=", 1)[1]
+    assert upload["body"].startswith(f"--{boundary}\r\n".encode())
+    assert b'name="file"; filename="bundle.tar.gz"' in upload["body"]
+    assert b"BUNDLEBYTES" in upload["body"], "the bundle itself must survive the framing"
+    assert upload["body"].endswith(f"\r\n--{boundary}--\r\n".encode())
+
+    # And the order still holds: create, upload, then deploy -- so a failure
+    # never leaves a version marked active with no bundle behind it.
+    assert [c["path"].rsplit("/", 1)[-1] for c in seen] == ["versions", "bundle", "deployments"]


### PR DESCRIPTION
The job reached the end of its work on the live install and failed on the last call:

```
PUT /agents/<id>/versions/<id>/bundle -> HTTP 422
{"loc": ["body", "file"], "msg": "Field required"}
```

That endpoint takes a **multipart form with a `file` part**, not a raw body.

Getting it wrong is expensive rather than merely wrong. By the time it fires, the job has fetched the repository tarball, resolved three image digests, read the running ceilings and created the version — so the failure leaves **a version row with no bundle behind it**, which is also the row a later run would read as "deployed". That is how the previous bug in this file compounded, and it is why the ordering assertion is in the test too.

## Test

Pins the shape rather than the fact that it did not throw: the upload is multipart, the boundary matches the content type, the bundle bytes survive the framing, and the three calls stay in the order (`versions` → `bundle` → `deployments`) that keeps a half-finished deploy from being marked active.

Load-bearing — putting the raw-body upload back fails it and leaves the other eleven green.

## Where this sits

Third fix to this job, and all three were found by running it against a real install rather than by testing:

1. #1992 — it carried forward a `connectors.yaml` the platform does not store.
2. #1993 — it read the newest version row instead of the one being served.
3. this — it uploaded a raw body to a form endpoint.

Each unit test passed against a fixture I had written myself. The pattern is clear enough to name: for a script whose whole job is talking to an API, the fixtures were describing my expectations of that API rather than its behaviour.
