### PR TITLE
Follow the 307 a server mounted at /mcp/ answers /mcp with

### DIFF
--- a/examples/tests/test_gates_are_live_tools.py
+++ b/examples/tests/test_gates_are_live_tools.py
@@ -288,3 +288,54 @@ def test_a_rejected_host_says_so_instead_of_reading_as_unreachable(
     assert r.returncode == 2
     assert "rejected the Host it was sent" in r.stderr
     assert "--host k8s-write=<host:port>" in r.stderr
+
+
+# --- a server mounted at /mcp/ answers /mcp with a 307 ------------------------
+#
+# urllib does not follow a redirect for a POST, so the connector read as
+# unreachable -- and this script treats unreachable as fatal, so one missing
+# slash failed the whole check with a message naming the wrong cause. Measured on
+# a live pair: two connectors from the same bundle differed, because their
+# FastMCP versions did.
+
+
+class _RedirectingHandler(_Handler):
+    """Serves only `/mcp/`, and 307s `/mcp` to it."""
+
+    def do_POST(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler's spelling
+        if self.path == "/mcp":
+            self.send_response(307)
+            self.send_header("Location", "/mcp/")
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+            return
+        super().do_POST()
+
+
+@pytest.fixture
+def redirecting_connector() -> Iterator[Callable[[list[dict[str, object]]], str]]:
+    servers: list[http.server.HTTPServer] = []
+
+    def start(tools: list[dict[str, object]]) -> str:
+        handler = type("Handler", (_RedirectingHandler,), {"tools": tools})
+        server = http.server.HTTPServer(("127.0.0.1", 0), handler)
+        servers.append(server)
+        threading.Thread(target=server.serve_forever, daemon=True).start()
+        return f"http://127.0.0.1:{server.server_address[1]}/mcp"
+
+    yield start
+    for server in servers:
+        server.shutdown()
+        server.server_close()
+
+
+def test_a_307_to_the_trailing_slash_is_followed(
+    tmp_path: Path, redirecting_connector: Callable[[list[dict[str, object]]], str]
+) -> None:
+    url = redirecting_connector([WRITE_TOOL])
+    b = bundle(tmp_path, ["mcp__k8s-write__restart_deployment"])
+
+    r = run(b, f"k8s-write={url}")
+
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert "all 1 gate(s) match a live tool" in r.stdout

--- a/scripts/assert-gates-are-live-tools.py
+++ b/scripts/assert-gates-are-live-tools.py
@@ -66,6 +66,7 @@ import sys
 import urllib.error
 import urllib.parse
 import urllib.request
+from typing import Any
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent
 
@@ -88,6 +89,46 @@ def with_url_port(host: str, url: str) -> str:
         return host
     port = urllib.parse.urlsplit(url).port
     return f"{host}:{port}" if port else host
+
+
+class _KeepMethodRedirect(urllib.request.HTTPRedirectHandler):
+    """Follow 307/308 for a POST, which urllib will not do on its own.
+
+    A streamable-HTTP server mounted at `/mcp/` answers `/mcp` with a 307. urllib
+    raises rather than re-issuing the POST, so the connector reads as unreachable
+    -- and this script treats unreachable as fatal, so one missing slash fails the
+    whole check with a message naming the wrong cause. Measured on a live pair:
+    two connectors from the same bundle differed, because their FastMCP versions
+    did.
+
+    Only 307 and 308, which are defined to preserve the method and body. A 301 or
+    302 would turn this POST into a GET, and silently checking a different request
+    than the one asked for is worse than failing.
+    """
+
+    def redirect_request(
+        self,
+        req: urllib.request.Request,
+        fp: Any,
+        code: int,
+        msg: str,
+        headers: Any,
+        newurl: str,
+    ) -> urllib.request.Request | None:
+        if code not in (307, 308):
+            redirected: urllib.request.Request | None = super().redirect_request(
+                req, fp, code, msg, headers, newurl
+            )
+            return redirected
+        return urllib.request.Request(
+            newurl,
+            data=req.data,
+            headers=dict(req.header_items()),
+            method=req.get_method(),
+        )
+
+
+_OPENER = urllib.request.build_opener(_KeepMethodRedirect)
 
 
 def list_tools(url: str, timeout: float, host: str | None = None) -> list[tuple[str, bool]]:
@@ -123,7 +164,7 @@ def list_tools(url: str, timeout: float, host: str | None = None) -> list[tuple[
             headers["Host"] = host
         headers.update(session)
         req = urllib.request.Request(url, data=json.dumps(payload).encode(), headers=headers)
-        with urllib.request.urlopen(req, timeout=timeout) as r:
+        with _OPENER.open(req, timeout=timeout) as r:
             sid = r.headers.get("Mcp-Session-Id")
             if sid:
                 session["Mcp-Session-Id"] = sid


### PR DESCRIPTION
Found running the check against a live install.

Two connectors from the **same bundle** behaved differently: one served `/mcp`, the other answered it with a **307 to `/mcp/`** — because their FastMCP versions did. urllib does not follow a redirect for a POST, so the second read as an unreachable connector.

This script treats unreachable as fatal, and correctly so. But that means **one missing slash failed the entire gate check with a message naming the wrong cause** — it reported a healthy connector as unreachable, which sends the reader hunting a dead pod.

## Fix

A redirect handler that re-issues the POST for **307 and 308 only** — the two that are defined to preserve the method and body.

A 301 or 302 is left to the default handler, which turns the POST into a GET. Silently checking a different request than the one asked for is worse than failing, and a gate check quietly verifying the wrong thing is exactly the failure this script exists to prevent.

## Test

A stub that serves only `/mcp/` and 307s `/mcp`. Load-bearing — putting the plain `urlopen` back fails it and leaves the other nine green.

With this, all five connectors on the live install answer, and the check passes as it should:

```
kubernetes  13 tools (0 write)
grafana     48 tools (0 write)
tempo        4 tools (0 write)
k8s-write    1 tools (1 write)
k8s-scale    1 tools (1 write)
all 2 gate(s) match a live tool; all 2 write tool(s) are gated
```
