### PR TITLE
Order the SRE bot's writer identity around the deploy, and pin --write-allowlist end to end

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -211,6 +211,17 @@ jobs:
         run: cargo clippy --locked --all-targets -- -D warnings
       - name: Schema baseline
         run: bash scripts/refresh-schema-baseline.sh --check
+      # write_allowlist_bundle_passes_the_real_bundle_validator (AC3) shells out
+      # to `uv run --frozen python -c ...` to hand the uploaded bundle to the
+      # real `plugin_format.validate_bundle`, and SKIPS instead of failing when
+      # `uv` is not on PATH -- without this step that gate is a silent no-op,
+      # not a passing check. No separate `uv sync` is needed: `uv run --frozen`
+      # syncs the environment itself, and the test invokes it with an explicit
+      # repo-root `current_dir`.
+      - name: Install uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        with:
+          python-version: "3.13"
       - name: Test
         run: cargo test --locked
       - name: Generated ACI protocol crate compiles

--- a/cli/src/examples.rs
+++ b/cli/src/examples.rs
@@ -505,7 +505,13 @@ pub async fn install_sre_bot(opts: SreBotInstallOpts) -> Result<SreBotInstallRes
         }
         lines.push(deploy);
         if write_targets.is_some() {
-            lines.push(write_role_command.display(&chart));
+            lines.push(format!(
+                "{} -- applied HERE only on a fresh install; when ServiceAccount \
+                 {WRITER_IDENTITY} already exists in namespace {} the same apply runs BEFORE the \
+                 deploy above, so a narrowed allowlist is in force before the new version activates",
+                write_role_command.display(&chart),
+                identity.namespace
+            ));
             lines.push(format!(
                 "kubectl wait --namespace {} --for=jsonpath={{.data.token}} secret/{WRITER_TOKEN_SECRET} --timeout={READER_TOKEN_TIMEOUT}",
                 identity.namespace
@@ -550,15 +556,19 @@ pub async fn install_sre_bot(opts: SreBotInstallOpts) -> Result<SreBotInstallRes
 
     let bundle_dir = workspace.bundle_dir();
     let connection = resolve_embedded_cluster_connection(&identity).await?;
-    let deployed =
-        deploy_embedded_sre_bot(&bundle_dir, &connection, opts.slack_channel.as_deref()).await?;
-    // The writer identity is minted HERE, after the deploy succeeded, and not
-    // earlier: it is a NON-EXPIRING ServiceAccount token, and with named targets
-    // it carries get,patch on apps/deployments. Nothing between the workspace
-    // render and this line needs it -- the only consumer is
-    // sync_deployed_version just below -- so creating it any sooner buys nothing
-    // and leaves a live write credential in the cluster for the whole length of
-    // the deploy.
+    // The write Role and the writer kubeconfig are ordered around the deploy by
+    // PRIVILEGE DIRECTION, keyed on whether the writer identity already exists:
+    //
+    //     never create a NEW privileged identity before the deploy;
+    //     always tighten an EXISTING one before the deploy.
+    //
+    // FRESH INSTALL -- no `sre-bot-writer` ServiceAccount in the namespace, so
+    // the apply is DEFERRED to after the deploy succeeds. The identity it mints
+    // is a NON-EXPIRING ServiceAccount token, and with named targets it carries
+    // get,patch on apps/deployments. Nothing between the workspace render and
+    // the deploy needs it -- the only consumer is sync_deployed_version below --
+    // so creating it any sooner buys nothing and leaves a live write credential
+    // in the cluster for the whole length of the deploy.
     //
     // Deferred rather than rolled back. A rollback would need the same cluster
     // API call that just failed: if the deploy died because the API server is
@@ -568,17 +578,41 @@ pub async fn install_sre_bot(opts: SreBotInstallOpts) -> Result<SreBotInstallRes
     // means the exposure window does not exist, rather than merely being
     // shorter, and it adds no new failure path of its own.
     //
-    // What this does NOT cover: a failure between this apply and
+    // What this does NOT cover: a failure between that apply and
     // sync_deployed_version still strands the identity, now with a deployed bot
     // in front of it. That residual window is one API call wide, and it is the
     // price of declining a rollback path.
-    let write_kubeconfig = match write_targets {
-        Some(_) => {
-            run_install_command(&write_role_command, &workspace, &chart).await?;
-            Some(write_connector_kubeconfig(&identity.namespace).await?)
-        }
-        None => None,
+    //
+    // RE-INSTALL / UPGRADE -- the ServiceAccount is already there, so the same
+    // apply runs BEFORE the deploy. Applying early strands nothing, because
+    // every object it names already exists; and it is the only ordering that
+    // fails CLOSED when an operator NARROWS the allowlist. sync_deployed_version
+    // reconciles the connector Deployment's K8S_WRITE_ALLOWLIST only AFTER the
+    // new version is activated, so deferring the Role on an upgrade leaves the
+    // activation-to-sync window with the OLD wide Role still on the API server
+    // AND the OLD wide env still on the running connector pod: both halves
+    // permit, and an approved call can patch a target the operator just removed.
+    // That is the #1886 class -- the two allowlists disagreeing in the dangerous
+    // direction. Tightening the Role first makes that same window 403 instead.
+    let writer_identity_present = match write_targets {
+        Some(_) => writer_identity_exists(&identity.namespace).await?,
+        None => false,
     };
+    let mut write_kubeconfig = None;
+    if writer_identity_present {
+        write_kubeconfig = Some(
+            apply_write_access(&write_role_command, &workspace, &chart, &identity.namespace)
+                .await?,
+        );
+    }
+    let deployed =
+        deploy_embedded_sre_bot(&bundle_dir, &connection, opts.slack_channel.as_deref()).await?;
+    if write_targets.is_some() && !writer_identity_present {
+        write_kubeconfig = Some(
+            apply_write_access(&write_role_command, &workspace, &chart, &identity.namespace)
+                .await?,
+        );
+    }
     let mut secret_overrides = BTreeMap::from([(KUBECONFIG_SECRET_KEY.to_string(), kubeconfig)]);
     if let Some(write_kubeconfig) = write_kubeconfig {
         secret_overrides.insert(WRITE_KUBECONFIG_SECRET_KEY.to_string(), write_kubeconfig);
@@ -1100,6 +1134,61 @@ async fn read_only_connector_kubeconfig(namespace: &str) -> Result<String> {
 
 async fn write_connector_kubeconfig(namespace: &str) -> Result<String> {
     connector_kubeconfig(WRITER_IDENTITY, WRITER_TOKEN_SECRET, namespace).await
+}
+
+/// Apply the rendered write Role and mint the writer identity's kubeconfig.
+///
+/// One helper because the install issues this from two places -- before the
+/// deploy on an upgrade, after it on a fresh install -- and the two orderings
+/// must stay identical in what they apply and what they hand back.
+async fn apply_write_access(
+    write_role_command: &InstallCommand,
+    workspace: &EmbeddedWorkspace,
+    chart: &Path,
+    namespace: &str,
+) -> Result<String> {
+    run_install_command(write_role_command, workspace, chart).await?;
+    write_connector_kubeconfig(namespace).await
+}
+
+/// Does the gated write ServiceAccount already exist in `namespace`?
+///
+/// This is what picks the ordering of the write Role apply around the deploy, so
+/// it must not confuse "absent" with "could not tell". `--ignore-not-found`
+/// makes absence an exit-0 with empty stdout, which separates the two cleanly
+/// without parsing stderr: any nonzero exit is a real probe failure and is
+/// surfaced as an error. Reporting an unreadable cluster as a fresh install
+/// would pick the deferred ordering on an upgrade and re-open exactly the
+/// fail-open window this probe exists to close.
+async fn writer_identity_exists(namespace: &str) -> Result<bool> {
+    let args = [
+        "get",
+        "serviceaccount",
+        WRITER_IDENTITY,
+        "--namespace",
+        namespace,
+        "--ignore-not-found",
+        "-o",
+        "name",
+    ];
+    crate::ui::ui().plumbing(&format!("+ kubectl {}", args.join(" ")));
+    let output = tokio::process::Command::new("kubectl")
+        .args(args)
+        .output()
+        .await
+        .context("probing for the gated write ServiceAccount")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!(
+            "could not determine whether ServiceAccount {WRITER_IDENTITY} already exists in namespace {namespace}, and the write Role apply is ordered on that answer; check the cluster with `kubectl get serviceaccount {WRITER_IDENTITY} -n {namespace}` and retry: {}",
+            if stderr.trim().is_empty() {
+                "kubectl exited nonzero"
+            } else {
+                stderr.trim()
+            }
+        );
+    }
+    Ok(!String::from_utf8_lossy(&output.stdout).trim().is_empty())
 }
 
 /// Build one connector's in-memory kubeconfig from a ServiceAccount token Secret.

--- a/cli/src/examples.rs
+++ b/cli/src/examples.rs
@@ -495,6 +495,16 @@ pub async fn install_sre_bot(opts: SreBotInstallOpts) -> Result<SreBotInstallRes
                     write_allowlist_value(targets)
                 ));
             }
+        }
+        let mut deploy = format!(
+            "curie cluster deploy --plugin-dir embedded:examples/sre-bot --namespace {} --release {}",
+            identity.namespace, identity.release
+        );
+        if let Some(channel) = &opts.slack_channel {
+            deploy.push_str(&format!(" --slack-channel {channel}"));
+        }
+        lines.push(deploy);
+        if write_targets.is_some() {
             lines.push(write_role_command.display(&chart));
             lines.push(format!(
                 "kubectl wait --namespace {} --for=jsonpath={{.data.token}} secret/{WRITER_TOKEN_SECRET} --timeout={READER_TOKEN_TIMEOUT}",
@@ -505,14 +515,6 @@ pub async fn install_sre_bot(opts: SreBotInstallOpts) -> Result<SreBotInstallRes
                     .to_string(),
             );
         }
-        let mut deploy = format!(
-            "curie cluster deploy --plugin-dir embedded:examples/sre-bot --namespace {} --release {}",
-            identity.namespace, identity.release
-        );
-        if let Some(channel) = &opts.slack_channel {
-            deploy.push_str(&format!(" --slack-channel {channel}"));
-        }
-        lines.push(deploy);
         lines.push(
             "render and reconcile the deployed version connectors with the owned Kubernetes kubeconfig Secret override"
                 .to_string(),
@@ -545,6 +547,31 @@ pub async fn install_sre_bot(opts: SreBotInstallOpts) -> Result<SreBotInstallRes
     run_install_command(&integration_command, &workspace, &chart).await?;
     run_install_command(&read_access_command, &workspace, &chart).await?;
     let kubeconfig = read_only_connector_kubeconfig(&identity.namespace).await?;
+
+    let bundle_dir = workspace.bundle_dir();
+    let connection = resolve_embedded_cluster_connection(&identity).await?;
+    let deployed =
+        deploy_embedded_sre_bot(&bundle_dir, &connection, opts.slack_channel.as_deref()).await?;
+    // The writer identity is minted HERE, after the deploy succeeded, and not
+    // earlier: it is a NON-EXPIRING ServiceAccount token, and with named targets
+    // it carries get,patch on apps/deployments. Nothing between the workspace
+    // render and this line needs it -- the only consumer is
+    // sync_deployed_version just below -- so creating it any sooner buys nothing
+    // and leaves a live write credential in the cluster for the whole length of
+    // the deploy.
+    //
+    // Deferred rather than rolled back. A rollback would need the same cluster
+    // API call that just failed: if the deploy died because the API server is
+    // unreachable, the RBAC write is being throttled, or the port-forward
+    // dropped, the compensating delete fails too and the credential is still
+    // standing -- now behind a log line claiming it was cleaned up. Deferring
+    // means the exposure window does not exist, rather than merely being
+    // shorter, and it adds no new failure path of its own.
+    //
+    // What this does NOT cover: a failure between this apply and
+    // sync_deployed_version still strands the identity, now with a deployed bot
+    // in front of it. That residual window is one API call wide, and it is the
+    // price of declining a rollback path.
     let write_kubeconfig = match write_targets {
         Some(_) => {
             run_install_command(&write_role_command, &workspace, &chart).await?;
@@ -552,11 +579,6 @@ pub async fn install_sre_bot(opts: SreBotInstallOpts) -> Result<SreBotInstallRes
         }
         None => None,
     };
-
-    let bundle_dir = workspace.bundle_dir();
-    let connection = resolve_embedded_cluster_connection(&identity).await?;
-    let deployed =
-        deploy_embedded_sre_bot(&bundle_dir, &connection, opts.slack_channel.as_deref()).await?;
     let mut secret_overrides = BTreeMap::from([(KUBECONFIG_SECRET_KEY.to_string(), kubeconfig)]);
     if let Some(write_kubeconfig) = write_kubeconfig {
         secret_overrides.insert(WRITE_KUBECONFIG_SECRET_KEY.to_string(), write_kubeconfig);

--- a/cli/tests/example_sre_bot_install.rs
+++ b/cli/tests/example_sre_bot_install.rs
@@ -12,6 +12,8 @@ use std::io::{Cursor, Read};
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 
 use flate2::read::GzDecoder;
 use serde_json::{json, Value};
@@ -77,6 +79,11 @@ struct Fixture {
     api: MockServer,
     registry: MockServer,
     registry_endpoint: String,
+    /// Flips `POST /deployments` to a 500. Shared with the mock API's handler
+    /// closure rather than baked in at construction, because the server thread
+    /// is already running by the time a builder method is called -- the handler
+    /// reads it per request, and the CLI is not launched until `run()`.
+    deploy_fails: Arc<AtomicBool>,
 }
 
 impl Fixture {
@@ -200,9 +207,15 @@ case " $* " in
         esac
         ;;
     # The write identity is part of the DEFAULT install now, so the stub answers
-    # for it the way it does for the reader. Keyed on the same mode variable: the
-    # writer is only reached after the reader succeeds, so one switch still
-    # describes the whole token path.
+    # for it the way it does for the reader. The writer is reached only after the
+    # DEPLOY succeeds -- the identity is minted last on purpose, so a failed
+    # install cannot strand a live write credential (#1946).
+    #
+    # Keyed on the same mode variable regardless: a reader-token timeout or read
+    # failure aborts before the deploy is ever attempted, so there is no reachable
+    # run in which the reader path fails and the writer path is still consulted.
+    # One switch still describes the whole token path, and a second knob would
+    # only be able to express states the installer cannot produce.
     *" wait "*" secret/sre-bot-writer-token "*)
         case "$CURIE_TEST_READER_TOKEN_MODE" in
             success|read-failure) exit 0 ;;
@@ -337,8 +350,10 @@ exit 64
 "#,
         );
 
+        let deploy_fails = Arc::new(AtomicBool::new(false));
+        let handler_deploy_fails = Arc::clone(&deploy_fails);
         let api = serve(
-            |request| match (request.method.as_str(), request.path.as_str()) {
+            move |request| match (request.method.as_str(), request.path.as_str()) {
                 ("GET", "/agents") => Response::json(200, "[]"),
                 ("POST", "/agents") => Response::json(
                     201,
@@ -361,6 +376,17 @@ exit 64
                             r#"{{"version_id":"{VERSION_ID}","bundle_ref":"bundles/sre-bot.tar.gz","bundle_sha256":"fixture-digest","size_bytes":512}}"#
                         ),
                     )
+                }
+                // The deploy-failure knob fails HERE and nowhere earlier. This
+                // leg runs after agent creation, version creation, and the
+                // bundle upload, so the fixture reproduces the case the ticket
+                // describes: a genuine deploy failure with the bundle already
+                // on the platform. Failing the upload instead would also make
+                // the test pass while proving far less -- an abort that early
+                // never reaches the window where a write credential could be
+                // stranded.
+                ("POST", "/deployments") if handler_deploy_fails.load(Ordering::SeqCst) => {
+                    Response::json(500, r#"{"error":"fixture deploy failure"}"#)
                 }
                 ("POST", "/deployments") => Response::json(
                     201,
@@ -443,6 +469,7 @@ exit 64
             api,
             registry,
             registry_endpoint,
+            deploy_fails,
         }
     }
 
@@ -463,6 +490,13 @@ exit 64
 
     fn with_reader_token_mode(mut self, mode: &'static str) -> Self {
         self.reader_token_mode = mode;
+        self
+    }
+
+    /// Make the platform API refuse the deployment after it has accepted the
+    /// agent, the version, and the uploaded bundle.
+    fn with_deploy_failure(self) -> Self {
+        self.deploy_fails.store(true, Ordering::SeqCst);
         self
     }
 
@@ -594,7 +628,13 @@ fn expected_tempo_digest() -> String {
     format!("sha256:{hex}")
 }
 
-fn uploaded_bundle_file(fixture: &Fixture, wanted: &str) -> Vec<u8> {
+/// The gzip stream out of the recorded multipart bundle upload.
+///
+/// Extracted so the whole-archive readers below locate the upload exactly the
+/// way `uploaded_bundle_file` always has -- one place that knows the upload is
+/// a multipart body with the archive somewhere inside it, so a change to the
+/// wire shape breaks every reader at once instead of one of them.
+fn uploaded_bundle_archive(fixture: &Fixture) -> Vec<u8> {
     let upload = fixture
         .api
         .recorded()
@@ -606,7 +646,57 @@ fn uploaded_bundle_file(fixture: &Fixture, wanted: &str) -> Vec<u8> {
         .windows(2)
         .position(|window| window == [0x1f, 0x8b])
         .expect("multipart upload must contain a gzip archive");
-    let decoder = GzDecoder::new(Cursor::new(&upload.body[gzip_start..]));
+    upload.body[gzip_start..].to_vec()
+}
+
+/// Every path the uploaded archive carries, in archive order.
+///
+/// The absence of a file is as much a bundle property as its contents -- a
+/// `connectors.lock.yaml` that should not exist cannot be asserted by reading
+/// one named entry.
+fn uploaded_bundle_paths(fixture: &Fixture) -> Vec<String> {
+    let decoder = GzDecoder::new(Cursor::new(uploaded_bundle_archive(fixture)));
+    let mut archive = tar::Archive::new(decoder);
+    archive
+        .entries()
+        .expect("read uploaded bundle archive")
+        .map(|entry| {
+            let entry = entry.expect("read uploaded bundle entry");
+            entry.path().expect("bundle path").display().to_string()
+        })
+        .collect()
+}
+
+/// Unpack the WHOLE uploaded archive into a temporary directory.
+///
+/// The bundle validator takes a bundle DIRECTORY, not a file: it cross-checks
+/// the manifest against the skills, the connectors, and the deploy targets
+/// beside it, so no single-file read can stand in for it. The returned
+/// `TempDir` owns the directory, so callers must hold it for as long as they
+/// read the path.
+fn unpacked_uploaded_bundle(fixture: &Fixture) -> tempfile::TempDir {
+    let directory = tempfile::tempdir().expect("temporary directory for the uploaded bundle");
+    let decoder = GzDecoder::new(Cursor::new(uploaded_bundle_archive(fixture)));
+    let mut archive = tar::Archive::new(decoder);
+    archive
+        .unpack(directory.path())
+        .expect("unpack the uploaded bundle archive");
+    directory
+}
+
+/// Parse a rendered multi-document manifest into its documents.
+fn manifest_documents(rendered: &str) -> Vec<Value> {
+    serde_norway::Deserializer::from_str(rendered)
+        .into_iter()
+        .map(|document| -> Value {
+            serde::Deserialize::deserialize(document)
+                .unwrap_or_else(|error| panic!("rendered manifest must be valid YAML: {error}"))
+        })
+        .collect()
+}
+
+fn uploaded_bundle_file(fixture: &Fixture, wanted: &str) -> Vec<u8> {
+    let decoder = GzDecoder::new(Cursor::new(uploaded_bundle_archive(fixture)));
     let mut archive = tar::Archive::new(decoder);
     for entry in archive.entries().expect("read uploaded bundle archive") {
         let mut entry = entry.expect("read uploaded bundle entry");
@@ -2351,5 +2441,479 @@ fn helm_timeout_recovery_names_the_selected_observability_namespace() {
             "kubectl delete secret -n observability -l owner=helm,name=grafana,status=pending-upgrade"
         ),
         "timeout recovery must not name the default observability namespace: {text}"
+    );
+}
+
+/// AC3: the `--write-allowlist` path must upload a bundle the CLUSTER tier will
+/// accept, and it must mint its write identity only after the deploy landed.
+///
+/// Issue #1946's evidence block is this bundle being refused: a connector that
+/// declares only `build:` records a LOCAL image id, and `BUNDLE_FILES` carries
+/// no `connectors/` build context, so the cluster preflight had nothing to pull
+/// and nothing to build. Nothing pinned that, which is why it regressed once and
+/// could regress again the next time a connector is added.
+///
+/// This is the assertion that NEVER SKIPS. It is a pure-Rust mirror of what
+/// `lock_preflight` enforces at `DeployTier::Cluster`, so it holds the same
+/// property as the bundle validator below without needing `uv` on PATH -- and
+/// the validator test does not run in the `rust:` CI job at all.
+///
+/// The connector properties are asserted by ITERATING the uploaded declaration
+/// rather than by naming `k8s-write`. A per-connector assertion is what makes a
+/// future connector fail this test instead of slipping past it; naming the one
+/// we already know about would pin the incident and not the class.
+#[test]
+fn write_allowlist_install_uploads_a_bundle_the_cluster_tier_accepts() {
+    let fixture = Fixture::with_modes(
+        nodes(vec![node("node-a", "4Gi", true)]),
+        pods(vec![]),
+        "success",
+        "success",
+        "success",
+    );
+    let output = fixture.run(&["--write-allowlist", "prod/api"]);
+    let text = shown(&output);
+    assert!(
+        output.status.success(),
+        "the named-target write install must complete: {text}"
+    );
+
+    let connectors_yaml = String::from_utf8(uploaded_bundle_file(&fixture, "connectors.yaml"))
+        .expect("uploaded connectors are UTF-8");
+    let declaration: Value = serde_norway::from_str(&connectors_yaml)
+        .expect("uploaded connectors must remain valid YAML");
+    let connectors = declaration["connectors"].as_object().unwrap_or_else(|| {
+        panic!("the uploaded bundle must declare connectors: {connectors_yaml}")
+    });
+    assert!(
+        !connectors.is_empty(),
+        "an empty connector map would satisfy every loop below vacuously: {connectors_yaml}"
+    );
+    for (name, connector) in connectors {
+        assert!(
+            connector.get("build").is_none(),
+            "connector {name} still asks the cluster deploy path to build it; a `build:` \
+             declaration records a local image id the cluster tier refuses, and the bundle \
+             carries no build context to fall back on: {connector:?}"
+        );
+        if let Some(image) = connector.get("image") {
+            let image = image
+                .as_str()
+                .unwrap_or_else(|| panic!("connector {name} image must be a string: {image:?}"));
+            assert!(
+                image.contains("@sha256:"),
+                "connector {name} must be pinned by digest rather than by a mutable tag, got \
+                 {image}"
+            );
+        }
+    }
+    let write = &declaration["connectors"]["k8s-write"];
+    let write_image = write["image"]
+        .as_str()
+        .unwrap_or_else(|| panic!("the write connector must carry a resolved image: {write:?}"));
+    assert!(
+        write_image.starts_with("ghcr.io/curie-eng/curie-sre-bot-k8s-write@sha256:"),
+        "the write connector must run the PUBLISHED image, pinned by digest, got {write_image}"
+    );
+    assert_eq!(
+        write["env"]["K8S_WRITE_ALLOWLIST"], "prod/api",
+        "the connector-side ceiling must state exactly the targets named at install time"
+    );
+    // Correct precisely BECAUSE no connector declares `build:`: a lock file
+    // exists to record the image id of something that had to be built, so a
+    // fully digest-pinned declaration needs none. If one ever appears here it
+    // means a build declaration came back with it.
+    let paths = uploaded_bundle_paths(&fixture);
+    assert!(
+        !paths.iter().any(|path| path == "connectors.lock.yaml"),
+        "a fully digest-pinned declaration needs no connector lock: {paths:?}"
+    );
+
+    // The API-server-side half of the ceiling. #1886's incident was these two
+    // allowlists drifting apart, which is a 403 AFTER a human approved the call.
+    let write_role = fixture.applied_file("write-role.yaml");
+    let documents = manifest_documents(&write_role);
+    let role = documents
+        .iter()
+        .find(|document| document["kind"] == "Role")
+        .unwrap_or_else(|| panic!("named targets must render a Role: {write_role}"));
+    assert_eq!(
+        role["metadata"]["namespace"], "prod",
+        "the Role must live in the target's namespace: {write_role}"
+    );
+    assert_eq!(
+        role["rules"][0]["resourceNames"],
+        json!(["api"]),
+        "the Role must be scoped to exactly the named Deployment: {write_role}"
+    );
+    let binding = documents
+        .iter()
+        .find(|document| document["kind"] == "RoleBinding")
+        .unwrap_or_else(|| panic!("named targets must render a RoleBinding: {write_role}"));
+    assert_eq!(binding["metadata"]["namespace"], "prod");
+    assert_eq!(binding["roleRef"]["name"], "sre-bot-writer");
+    assert_eq!(binding["subjects"][0]["name"], "sre-bot-writer");
+    // The occurrence the shipped manifest's own comment warns is easy to miss:
+    // a RoleBinding whose subject namespace is wrong still applies cleanly and
+    // grants nothing.
+    assert_eq!(
+        binding["subjects"][0]["namespace"], "curie",
+        "the RoleBinding must bind the ServiceAccount in the Curie namespace: {write_role}"
+    );
+
+    // AC2, pinned in one log. The writer is a NON-EXPIRING ServiceAccount token
+    // carrying `get,patch` on `apps/deployments`, so it must not exist until the
+    // deploy it belongs to has landed. Before #1946 the apply ran before the
+    // release API key was even discovered, which put the whole deploy inside the
+    // window where a failure stranded a live write credential.
+    let kubectl = fixture.kubectl_calls();
+    let write_role_apply = kubectl
+        .iter()
+        .position(|call| {
+            call.starts_with("apply -f ") && call.ends_with("manifests/write-role.yaml")
+        })
+        .unwrap_or_else(|| {
+            panic!("the installer must apply the rendered write identity: {kubectl:?}")
+        });
+    let api_key_discovery = kubectl
+        .iter()
+        .rposition(|call| {
+            call.contains("get secret") && call.contains("app.kubernetes.io/instance=curie")
+        })
+        .unwrap_or_else(|| panic!("the deploy must discover the release API key: {kubectl:?}"));
+    let reader_token_read = kubectl
+        .iter()
+        .position(|call| call.contains("get secret sre-bot-reader-token"))
+        .unwrap_or_else(|| panic!("the installer must read the reader token: {kubectl:?}"));
+    assert!(
+        write_role_apply > api_key_discovery && write_role_apply > reader_token_read,
+        "the write identity must be minted AFTER the deploy: write-role apply at \
+         {write_role_apply}, API key discovery at {api_key_discovery}, reader token read at \
+         {reader_token_read}: {kubectl:?}"
+    );
+}
+
+/// AC3, the bundle-validator leg: hand the uploaded bundle to the authoritative
+/// `plugin_format.validate_bundle` and take its verdict rather than a
+/// re-derivation of it.
+///
+/// SKIPS WHEN `uv` IS ABSENT, and one thing differs from the `chart_check.rs`
+/// precedent this posture is borrowed from, so it is stated rather than
+/// implied: `chart_check.rs` skips locally but its assertions are guaranteed to
+/// run in `helm-ci`, which installs `uv` and runs `uv sync`. The `rust:` job in
+/// `.github/workflows/ci.yaml` does NOT install `uv`, so this test skips in CI
+/// today and gates nothing there. It is a local-developer check.
+///
+/// `write_allowlist_install_uploads_a_bundle_the_cluster_tier_accepts` above is
+/// the assertion that GATES, and its properties are written to stand alone
+/// without Python for exactly that reason. Installing `uv` in the `rust:` job is
+/// a deferred follow-up: it is a workflow edit, which pulls in the workflow-path
+/// gate and a full-suite requirement, and that is a different review than this
+/// one.
+///
+/// Negative control, recorded so the skip is not mistaken for a test that
+/// cannot bite: if `build:` survived into the uploaded bundle, this validator
+/// reports `connectors.build_context_missing`, because the bundle allowlist
+/// carries no `connectors/` directory. That is issue #1946's own evidence
+/// block.
+#[test]
+fn write_allowlist_bundle_passes_the_real_bundle_validator() {
+    if Command::new("uv").arg("--version").output().is_err() {
+        eprintln!(
+            "skipping write_allowlist_bundle_passes_the_real_bundle_validator: uv is not on PATH"
+        );
+        return;
+    }
+
+    let fixture = Fixture::with_modes(
+        nodes(vec![node("node-a", "4Gi", true)]),
+        pods(vec![]),
+        "success",
+        "success",
+        "success",
+    );
+    let output = fixture.run(&["--write-allowlist", "prod/api"]);
+    let text = shown(&output);
+    assert!(
+        output.status.success(),
+        "the named-target write install must complete: {text}"
+    );
+
+    let bundle = unpacked_uploaded_bundle(&fixture);
+    let validation = Command::new("uv")
+        .current_dir(repo_root())
+        .args([
+            "run",
+            "--frozen",
+            "python",
+            "-c",
+            "import sys\n\
+             from plugin_format import validate_bundle\n\
+             print(validate_bundle(sys.argv[1]).model_dump_json())\n",
+        ])
+        .arg(bundle.path())
+        .output()
+        .expect("run the bundle validator");
+    let stdout = String::from_utf8_lossy(&validation.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&validation.stderr).to_string();
+    assert!(
+        validation.status.success(),
+        "the bundle validator must run: stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    let reported = stdout
+        .lines()
+        .rev()
+        .find(|line| !line.trim().is_empty())
+        .unwrap_or_else(|| panic!("the validator must report a result: stderr:\n{stderr}"));
+    let result: Value = serde_json::from_str(reported)
+        .unwrap_or_else(|error| panic!("validator output must be JSON ({error}): {reported}"));
+    assert_eq!(
+        result["errors"],
+        json!([]),
+        "the uploaded bundle must carry no validation errors: {reported}"
+    );
+    assert_eq!(
+        result["valid"],
+        json!(true),
+        "the uploaded bundle must be valid: {reported}"
+    );
+}
+
+/// AC2: a failed deploy must leave NO write RBAC and NO writer token behind.
+///
+/// The writer identity is a non-expiring `kubernetes.io/service-account-token`
+/// plus, with named targets, `get,patch` on `apps/deployments` -- and `patch` on
+/// a Deployment is `set image` and `set env`, not just a restart. Creating it
+/// before the deploy meant any failure in between (unreachable API server,
+/// rate-limited RBAC, a dead port-forward) left that credential standing with no
+/// bot attached and no teardown path.
+///
+/// The remedy is DEFERRAL, not rollback, so this test looks for the apply never
+/// having happened rather than for a compensating delete: a rollback needs the
+/// same cluster API call that just failed.
+#[test]
+fn a_failed_deploy_leaves_no_write_rbac_or_writer_token_behind() {
+    let fixture = Fixture::with_modes(
+        nodes(vec![node("node-a", "4Gi", true)]),
+        pods(vec![]),
+        "success",
+        "success",
+        "success",
+    )
+    .with_deploy_failure();
+    let output = fixture.run(&["--write-allowlist", "prod/api"]);
+    let text = shown(&output);
+    assert!(
+        !output.status.success(),
+        "a refused deployment must fail the install: {text}"
+    );
+
+    let kubectl = fixture.kubectl_calls();
+    assert!(
+        !kubectl
+            .iter()
+            .any(|call| call.contains("manifests/write-role.yaml")),
+        "a failed deploy must not have applied the write RBAC: {kubectl:?}"
+    );
+    assert!(
+        !kubectl
+            .iter()
+            .any(|call| call.contains("sre-bot-writer-token")),
+        "a failed deploy must neither wait for nor read the writer token: {kubectl:?}"
+    );
+    // Asserted as an absent file rather than through `applied_file`, which
+    // panics on a miss and would report the wrong thing.
+    assert!(
+        !fixture.applied_dir.join("write-role.yaml").exists(),
+        "a failed deploy must leave no rendered write identity behind: {:?}",
+        fs::read_dir(&fixture.applied_dir).map(|entries| entries
+            .flatten()
+            .map(|entry| entry.file_name())
+            .collect::<Vec<_>>())
+    );
+
+    // ANTI-VACUITY. Without this the test passes trivially on any early abort --
+    // a capacity refusal, a registry failure, a reader-token timeout -- which is
+    // exactly how a reordering bug would hide behind a green run. The assertions
+    // above only mean something if this run really did get as far as the deploy.
+    assert!(
+        fixture.applied_dir.join("read-access.yaml").exists(),
+        "the run must have reached the reader RBAC apply"
+    );
+    assert!(
+        kubectl
+            .iter()
+            .any(|call| call.contains("get secret sre-bot-reader-token")),
+        "the run must have read the reader token: {kubectl:?}"
+    );
+    let requests = fixture.api.recorded();
+    let version = requests
+        .iter()
+        .position(|request| {
+            request.method == "POST" && request.path == format!("/agents/{AGENT_ID}/versions")
+        })
+        .unwrap_or_else(|| panic!("the run must have created a version: {requests:?}"));
+    let upload = requests
+        .iter()
+        .position(|request| request.method == "PUT" && request.path.ends_with("/bundle"))
+        .unwrap_or_else(|| panic!("the run must have uploaded the bundle: {requests:?}"));
+    let deployment = requests
+        .iter()
+        .position(|request| request.method == "POST" && request.path == "/deployments")
+        .unwrap_or_else(|| panic!("the run must have attempted the deployment: {requests:?}"));
+    assert!(
+        version < upload && upload < deployment,
+        "the failure must be the DEPLOY, reached after the bundle was already uploaded: \
+         version at {version}, upload at {upload}, deployment at {deployment}"
+    );
+}
+
+/// AC4a: `--no-write` stays behaviourally read only, asserted on the wire.
+///
+/// `read_only_install_is_unchanged_by_the_new_flag` and
+/// `opting_out_leaves_the_write_connector_absent` prove this at helper level;
+/// both stay, because they are cheaper and they localise a failure. This lifts
+/// the same property to what the platform actually receives, which is where a
+/// regression would be visible to an operator.
+#[test]
+fn no_write_install_stays_behaviourally_read_only() {
+    let fixture = Fixture::with_modes(
+        nodes(vec![node("node-a", "4Gi", true)]),
+        pods(vec![]),
+        "success",
+        "success",
+        "success",
+    );
+    let output = fixture.run(&["--no-write"]);
+    let text = shown(&output);
+    assert!(
+        output.status.success(),
+        "the read only install must complete: {text}"
+    );
+
+    let connectors_yaml = String::from_utf8(uploaded_bundle_file(&fixture, "connectors.yaml"))
+        .expect("uploaded connectors are UTF-8");
+    let declaration: Value = serde_norway::from_str(&connectors_yaml)
+        .expect("uploaded connectors must remain valid YAML");
+    let connectors = declaration["connectors"].as_object().unwrap_or_else(|| {
+        panic!("the uploaded bundle must declare connectors: {connectors_yaml}")
+    });
+    for absent in ["k8s-write", "k8s-scale"] {
+        assert!(
+            !connectors.contains_key(absent),
+            "the read only install must not ship connector {absent}: {connectors_yaml}"
+        );
+    }
+
+    let plugin: Value = serde_json::from_slice(&uploaded_bundle_file(
+        &fixture,
+        ".claude-plugin/plugin.json",
+    ))
+    .expect("uploaded plugin manifest must remain valid JSON");
+    // A gate naming a connector this install removed fails bundle validation for
+    // everyone, so the policy leaves WITH the connectors it guards.
+    assert!(
+        plugin.get("approvalPolicy").is_none(),
+        "a bundle with no write verbs must declare no approval policy: {plugin}"
+    );
+
+    assert!(
+        !fixture.applied_dir.join("write-role.yaml").exists(),
+        "the read only install must render and apply no write identity"
+    );
+    let kubectl = fixture.kubectl_calls();
+    assert!(
+        !kubectl
+            .iter()
+            .any(|call| call.contains("sre-bot-writer-token")),
+        "the read only install must never touch the writer token: {kubectl:?}"
+    );
+
+    // The registry count is the observable proof that the connector was dropped
+    // BEFORE its image was resolved -- a `--no-write` install must make no
+    // registry call for an image it will never run. Counted rather than merely
+    // absent, and asserted here rather than by relaxing the count in
+    // `successful_install_uploads_only_the_resolved_tempo_index_digest`, which
+    // pins the four-request default.
+    let registry = fixture.registry.recorded();
+    assert_eq!(
+        registry.len(),
+        2,
+        "only Tempo may be resolved, at one scoped token plus one index request: {:?}",
+        registry
+            .iter()
+            .map(|request| request.path.clone())
+            .collect::<Vec<_>>()
+    );
+    assert!(
+        !registry
+            .iter()
+            .any(|request| request.path.contains("curie-sre-bot-k8s-write")),
+        "the read only install must make no registry request for the write image: {:?}",
+        registry
+            .iter()
+            .map(|request| request.path.clone())
+            .collect::<Vec<_>>()
+    );
+}
+
+/// AC4b: the no-flag default keeps the connector with an EMPTY ceiling and
+/// renders NO Role.
+///
+/// This is #1886's load-bearing invariant and no integration test pinned it. An
+/// RBAC rule whose `resourceNames` is empty or absent does not grant nothing --
+/// it grants the verb on EVERY resource of that type. So the empty case must
+/// OMIT the Role rather than render one with no names, and a nameless Role would
+/// hand the bot patch on every Deployment in the namespace: the opposite of what
+/// an empty allowlist reads like, and it would look correct in review.
+///
+/// The identity is still minted, because bring-up refuses without
+/// `K8S_WRITE_KUBECONFIG`; an identity that can do nothing is what makes
+/// "installed, ceiling empty" a state the platform can boot.
+#[test]
+fn default_install_keeps_the_empty_ceiling_and_renders_no_role() {
+    let fixture = Fixture::with_modes(
+        nodes(vec![node("node-a", "4Gi", true)]),
+        pods(vec![]),
+        "success",
+        "success",
+        "success",
+    );
+    let output = fixture.run(&[]);
+    let text = shown(&output);
+    assert!(
+        output.status.success(),
+        "the default install must complete: {text}"
+    );
+
+    let connectors_yaml = String::from_utf8(uploaded_bundle_file(&fixture, "connectors.yaml"))
+        .expect("uploaded connectors are UTF-8");
+    let declaration: Value = serde_norway::from_str(&connectors_yaml)
+        .expect("uploaded connectors must remain valid YAML");
+    assert_eq!(
+        declaration["connectors"]["k8s-write"]["env"]["K8S_WRITE_ALLOWLIST"], "",
+        "with no targets named the connector-side ceiling must be empty, so every call is \
+         refused: {connectors_yaml}"
+    );
+
+    let write_role = fixture.applied_file("write-role.yaml");
+    let kinds: Vec<String> = manifest_documents(&write_role)
+        .iter()
+        .filter_map(|document| document["kind"].as_str().map(str::to_string))
+        .collect();
+    assert!(
+        kinds.iter().any(|kind| kind == "ServiceAccount"),
+        "the identity is minted either way: {write_role}"
+    );
+    assert!(
+        kinds.iter().any(|kind| kind == "Secret"),
+        "the non-expiring token Secret rides with the ServiceAccount: {write_role}"
+    );
+    assert!(
+        !kinds
+            .iter()
+            .any(|kind| kind == "Role" || kind == "RoleBinding"),
+        "an empty ceiling must render NO Role -- an empty resourceNames grants every \
+         Deployment, not none: {kinds:?} in {write_role}"
     );
 }

--- a/cli/tests/example_sre_bot_install.rs
+++ b/cli/tests/example_sre_bot_install.rs
@@ -687,7 +687,6 @@ fn unpacked_uploaded_bundle(fixture: &Fixture) -> tempfile::TempDir {
 /// Parse a rendered multi-document manifest into its documents.
 fn manifest_documents(rendered: &str) -> Vec<Value> {
     serde_norway::Deserializer::from_str(rendered)
-        .into_iter()
         .map(|document| -> Value {
             serde::Deserialize::deserialize(document)
                 .unwrap_or_else(|error| panic!("rendered manifest must be valid YAML: {error}"))

--- a/cli/tests/example_sre_bot_install.rs
+++ b/cli/tests/example_sre_bot_install.rs
@@ -75,6 +75,9 @@ struct Fixture {
     helm_mode: &'static str,
     grafana_secret_mode: &'static str,
     reader_token_mode: &'static str,
+    /// Whether the `sre-bot-writer` ServiceAccount already exists, i.e. fresh
+    /// install (`absent`, the default) versus re-install (`existing`).
+    writer_identity_mode: &'static str,
     helm_values: String,
     api: MockServer,
     registry: MockServer,
@@ -157,6 +160,23 @@ case " $* " in
         exit 0
         ;;
     *" get priorityclass "*|*" get priorityclasses "*)
+        exit 0
+        ;;
+    # Existence probe for the writer identity, which is what decides the ORDER of
+    # the write-RBAC apply relative to the deploy. Absent (the default) means a
+    # fresh install and the deferred, post-deploy ordering every other test in
+    # this file asserts; `existing` means a re-install, where the ceiling must be
+    # tightened BEFORE the new version activates.
+    #
+    # Mirrors `--ignore-not-found`: absent is empty stdout and exit 0, never a
+    # NotFound failure. Deliberately placed ABOVE every `get secret` arm, and
+    # keyed on a token none of those arms contain, so neither group can shadow
+    # the other in either direction.
+    *" get serviceaccount "*)
+        case "$CURIE_TEST_WRITER_IDENTITY_MODE" in
+            existing) printf '%s\n' 'serviceaccount/sre-bot-writer' ;;
+            absent) ;;
+        esac
         exit 0
         ;;
     *" get secret grafana-admin "*)
@@ -465,6 +485,9 @@ exit 64
             helm_mode,
             grafana_secret_mode: "existing",
             reader_token_mode: "success",
+            // Fresh install by default, so every existing test keeps asserting
+            // the deferred post-deploy ordering it was written against.
+            writer_identity_mode: "absent",
             helm_values: "absent".to_string(),
             api,
             registry,
@@ -490,6 +513,13 @@ exit 64
 
     fn with_reader_token_mode(mut self, mode: &'static str) -> Self {
         self.reader_token_mode = mode;
+        self
+    }
+
+    /// Present the cluster as one where the writer identity already exists, i.e.
+    /// a RE-INSTALL rather than a first install.
+    fn with_writer_identity_mode(mut self, mode: &'static str) -> Self {
+        self.writer_identity_mode = mode;
         self
     }
 
@@ -550,6 +580,7 @@ exit 64
             .env("CURIE_TEST_HELM_VALUES", &self.helm_values)
             .env("CURIE_TEST_GRAFANA_SECRET_MODE", self.grafana_secret_mode)
             .env("CURIE_TEST_READER_TOKEN_MODE", self.reader_token_mode)
+            .env("CURIE_TEST_WRITER_IDENTITY_MODE", self.writer_identity_mode)
             .env(
                 "CURIE_TEST_SRE_BOT_REGISTRY_ENDPOINT",
                 &self.registry_endpoint,
@@ -2454,8 +2485,8 @@ fn helm_timeout_recovery_names_the_selected_observability_namespace() {
 ///
 /// This is the assertion that NEVER SKIPS. It is a pure-Rust mirror of what
 /// `lock_preflight` enforces at `DeployTier::Cluster`, so it holds the same
-/// property as the bundle validator below without needing `uv` on PATH -- and
-/// the validator test does not run in the `rust:` CI job at all.
+/// property as the bundle validator below without needing `uv` on PATH -- so the
+/// property stays gated on a local run where that validator test skips.
 ///
 /// The connector properties are asserted by ITERATING the uploaded declaration
 /// rather than by naming `k8s-write`. A per-connector assertion is what makes a
@@ -2592,23 +2623,131 @@ fn write_allowlist_install_uploads_a_bundle_the_cluster_tier_accepts() {
     );
 }
 
+/// The MIRROR IMAGE of the ordering above, for the re-install path.
+///
+/// The incident this pins: an operator NARROWS the allowlist on a re-install
+/// (`prod/admin` -> `prod/api`). `sync_deployed_version` reconciles the connector
+/// Deployment and its kubeconfig Secret only after the deploy has ACTIVATED the
+/// new version, so if the write RBAC were also deferred past the deploy there
+/// would be a window in which the new version is live while BOTH the old, wider
+/// Role and the old connector's wider env are still in force. A `patch` on
+/// `prod/admin` succeeds in that window -- the install fails OPEN on precisely
+/// the change an operator made to close something down.
+///
+/// So the ordering is keyed on whether the writer identity already exists, and
+/// the invariant has two halves: never create a NEW privileged identity before
+/// the deploy, and always tighten an EXISTING one before the deploy. This test
+/// and `a_failed_deploy_leaves_no_write_rbac_or_writer_token_behind` are THE SAME
+/// SCENARIO -- `--write-allowlist prod/api` against a deploy the platform
+/// refuses -- differing in exactly one input, whether the writer
+/// ServiceAccount already existed. The opposite outcomes ARE the invariant:
+/// there the apply must be absent, here it must be present.
+///
+/// Why the oracle is a failed deploy rather than a position in the kubectl log.
+/// `deploy_embedded_sre_bot` is API-driven and emits no kubectl calls at all, so
+/// the log has no marker for "the deploy happened". On BOTH orderings the
+/// write-role apply lands after the connection-setup lookups (API key discovery
+/// belongs to `resolve_embedded_cluster_connection`, which is setup, not
+/// activation) and before the post-deploy connector sync. Any index comparison
+/// therefore either passes on both paths or fails on both, and proves nothing.
+/// Failing the deploy makes the causal relationship itself observable: the apply
+/// can only appear in the log of a run whose deploy failed if it ran BEFORE that
+/// deploy. Nothing is stranded by applying early on this path, because every
+/// object the apply touches already exists.
+#[test]
+fn an_existing_writer_identity_is_tightened_before_the_deploy_that_can_fail() {
+    let fixture = Fixture::with_modes(
+        nodes(vec![node("node-a", "4Gi", true)]),
+        pods(vec![]),
+        "success",
+        "success",
+        "success",
+    )
+    .with_writer_identity_mode("existing")
+    .with_deploy_failure();
+    let output = fixture.run(&["--write-allowlist", "prod/api"]);
+    let text = shown(&output);
+    assert!(
+        !output.status.success(),
+        "a refused deployment must fail the install: {text}"
+    );
+
+    let kubectl = fixture.kubectl_calls();
+    assert!(
+        kubectl.iter().any(|call| {
+            call.contains("get serviceaccount sre-bot-writer")
+                && call.contains("--ignore-not-found")
+        }),
+        "the ordering can only be chosen if the installer probes for the existing writer \
+         identity: {kubectl:?}"
+    );
+    // THE LOAD-BEARING ASSERTION. The deploy failed, so this call exists only if
+    // the narrowed ceiling was applied before it -- the exact call the
+    // fresh-install twin proves is absent under the same failure.
+    assert!(
+        kubectl.iter().any(|call| {
+            call.starts_with("apply -f ") && call.ends_with("manifests/write-role.yaml")
+        }),
+        "on a re-install the narrowed ceiling must land BEFORE the deploy, so a FAILED deploy \
+         must still have applied it: {kubectl:?}"
+    );
+    // `apply_write_access` mints the kubeconfig in the same step, so the token
+    // half of the identity moves with the RBAC half and is asserted with it.
+    assert!(
+        kubectl
+            .iter()
+            .any(|call| call.contains("wait") && call.contains("secret/sre-bot-writer-token")),
+        "the tightening step must have waited for the writer token: {kubectl:?}"
+    );
+    assert!(
+        kubectl
+            .iter()
+            .any(|call| call.contains("get secret sre-bot-writer-token")),
+        "the tightening step must have read the writer token: {kubectl:?}"
+    );
+
+    // ANTI-VACUITY. "The apply is present in a failed run" is only evidence of
+    // ordering if the run actually reached and attempted the deploy. Without
+    // this the test would pass on any earlier abort -- a capacity refusal, a
+    // registry failure -- which is how a reordering bug would hide behind green.
+    let requests = fixture.api.recorded();
+    let version = requests
+        .iter()
+        .position(|request| {
+            request.method == "POST" && request.path == format!("/agents/{AGENT_ID}/versions")
+        })
+        .unwrap_or_else(|| panic!("the run must have created a version: {requests:?}"));
+    let upload = requests
+        .iter()
+        .position(|request| request.method == "PUT" && request.path.ends_with("/bundle"))
+        .unwrap_or_else(|| panic!("the run must have uploaded the bundle: {requests:?}"));
+    let deployment = requests
+        .iter()
+        .position(|request| request.method == "POST" && request.path == "/deployments")
+        .unwrap_or_else(|| panic!("the run must have attempted the deployment: {requests:?}"));
+    assert!(
+        version < upload && upload < deployment,
+        "the failure must be the DEPLOY, reached after the bundle was already uploaded: \
+         version at {version}, upload at {upload}, deployment at {deployment}"
+    );
+}
+
 /// AC3, the bundle-validator leg: hand the uploaded bundle to the authoritative
 /// `plugin_format.validate_bundle` and take its verdict rather than a
 /// re-derivation of it.
 ///
-/// SKIPS WHEN `uv` IS ABSENT, and one thing differs from the `chart_check.rs`
-/// precedent this posture is borrowed from, so it is stated rather than
-/// implied: `chart_check.rs` skips locally but its assertions are guaranteed to
-/// run in `helm-ci`, which installs `uv` and runs `uv sync`. The `rust:` job in
-/// `.github/workflows/ci.yaml` does NOT install `uv`, so this test skips in CI
-/// today and gates nothing there. It is a local-developer check.
+/// SKIPS WHEN `uv` IS ABSENT, which now follows the same posture as the
+/// `chart_check.rs` precedent it is borrowed from rather than diverging from it:
+/// `chart_check.rs` skips locally but its assertions run in `helm-ci`, which
+/// installs `uv`. The `rust:` job in `.github/workflows/ci.yaml` now installs
+/// `uv` too, so this test RUNS in CI and its verdict gates there; the skip is
+/// left in place only for a local developer who has no `uv` on PATH.
 ///
+/// The skip branch is still a real hole in local runs, so it is not the only
+/// thing standing behind this property.
 /// `write_allowlist_install_uploads_a_bundle_the_cluster_tier_accepts` above is
-/// the assertion that GATES, and its properties are written to stand alone
-/// without Python for exactly that reason. Installing `uv` in the `rust:` job is
-/// a deferred follow-up: it is a workflow edit, which pulls in the workflow-path
-/// gate and a full-suite requirement, and that is a different review than this
-/// one.
+/// the backstop: its properties are written to stand alone without Python for
+/// exactly that reason, so they never skip anywhere.
 ///
 /// Negative control, recorded so the skip is not mistaken for a test that
 /// cannot bite: if `build:` survived into the uploaded bundle, this validator


### PR DESCRIPTION
Closes #1946

## What the ticket asked, and what the base already had

The issue was filed against a base that has since moved. **AC1 was already implemented on `next`** by 89972aeb ("Install the SRE bot's gated write connector by default, ceiling empty"): `K8S_WRITE_IMAGE_REPOSITORY`/`K8S_WRITE_IMAGE_TAG` exist, the digest is resolved only when the connector is kept, and `runtime_connector_declaration` swaps `build:` for a digest-pinned `image:` exactly as it does for tempo. I verified the consequence directly rather than by reading: reconstructing the `--write-allowlist` bundle and running the real `plugin_format.validate_bundle` returns **`valid=True`**, and the pinned tag is live on GHCR (anonymous manifest fetch, HTTP 200).

So AC1 is **not re-implemented here** — it is pinned by a test, because nothing drove that path. This PR delivers AC2, AC3 and AC4.

## AC2 — the writer identity is ordered by privilege direction

The write RBAC was applied and the writer token read *before* the deploy, while the kubeconfig they produce is not consumed until `sync_deployed_version` several calls later. Every failed install left an `sre-bot-writer` ServiceAccount, a non-expiring token Secret and (with named targets) a Role granting `get,patch` on `apps/deployments`, with no bot in front of it.

Deferring past the deploy fixes that — **but the adversarial security review caught that a naive deferral opens a worse hole on re-install.** `sync_deployed_version` reconciles the connector's `K8S_WRITE_ALLOWLIST` only *after* activation, so when an operator narrows the allowlist, the activation→sync window holds the OLD wide Role *and* the OLD wide connector env. Both halves permit; an approved call can patch a target that was just removed. That window used to fail closed. It is the #1886 class — the two allowlists disagreeing, in the dangerous direction.

The ordering is therefore keyed on whether the identity already exists:

> never create a NEW privileged identity before the deploy; always tighten an EXISTING one before the deploy.

Fresh install defers; re-install applies first, stranding nothing because every object already exists. The probe distinguishes absent from unreadable and refuses to guess — reporting an unreadable cluster as fresh would pick the deferred ordering on an upgrade and re-open the window.

**Deferred rather than rolled back**, stated in a source comment with the reason: a rollback needs the same cluster API call that just failed, so the compensating delete can fail too and leave the credential behind a log line claiming cleanup. The comment is also honest that a one-API-call residual window remains.

The `--dry-run` plan moves with the live path, so it does not describe an order the installer no longer takes.

## AC3 / AC4 — coverage

`grep "write.allowlist" cli/tests/` returned nothing before this PR. Six tests now drive the real installer binary against the fake kubectl/helm shims and mock API/registry:

| Test | Covers |
|---|---|
| `write_allowlist_install_uploads_a_bundle_the_cluster_tier_accepts` | AC3 — asserts over **every** connector that none declares `build:` and each image is digest-pinned: the property `lock_preflight` enforces at `DeployTier::Cluster`. Never skips. |
| `write_allowlist_bundle_passes_the_real_bundle_validator` | AC3 — runs the authoritative `plugin_format.validate_bundle` over the bundle actually uploaded. |
| `a_failed_deploy_leaves_no_write_rbac_or_writer_token_behind` | AC2, fresh install |
| `an_existing_writer_identity_is_tightened_before_the_deploy_that_can_fail` | AC2, re-install |
| `no_write_install_stays_behaviourally_read_only` | AC4 (`--no-write`) |
| `default_install_keeps_the_empty_ceiling_and_renders_no_role` | AC4 (no-flag), pins #1886's "empty `resourceNames` grants everything" invariant |

The two AC2 tests are a **matched pair**: same scenario, differing only in whether the identity pre-existed, asserting opposite outcomes under the same failed deploy. A positional assertion cannot express this — `deploy_embedded_sre_bot` is API-driven and emits no kubectl calls, so an index comparison passes or fails identically on both paths. Both carry anti-vacuity assertions proving the run actually reached the deploy.

AC4 is discharged against **both** readings of "the read only default", because 89972aeb split one state into three (`--no-write` → absent; no flag → present with an empty ceiling; `--write-allowlist` → named targets).

## CI

`.github/workflows/ci.yaml` now installs `uv` in the `rust:` job. Without it the validator test skipped on every CI run and AC3 was gated by nothing — `AGENTS.md` ("Guards are outcome-tested") requires the regression test to assert through the real consumer path.

## Reviews

Three adversarial reviews (code, scope, security) ran on an alternative provider. Two P1s were found and **both are fixed** — the upgrade-narrowing window above, and the CI gap. The scope review's five findings were all rejected with written reasons (one was factually wrong; the rest read AC3's first clause without its second, "fails if the rendered bundle would be refused at the cluster tier").

## Validation

- `cargo test --locked` for the `cli` crate in **debug**: **1809 passed, 69 suites, 0 failed**; the SRE-bot suite is 37 passed.
- `cargo fmt --check` and `cargo clippy --locked --all-targets -- -D warnings`: clean.
- `scripts/check-docs.sh`: passes.

## Not done

- **No live-cluster E2E.** Fake `kubectl` cannot show what a cluster is left holding. The kubectl-call log is the substitute and the matched pair asserts the causal ordering directly, but confirming `kubectl get sa,secret,role,rolebinding -A | grep sre-bot-writer` is empty after a forced-failed real install is still worth doing before release.
- **Consolidation pass incomplete.** Its reviewers were repeatedly killed by the environment. One minor finding surfaced (a test gunzips the same archive twice) and was deliberately skipped as not worth a revalidation cycle.
