### PR TITLE
Give four agent-facing refusals a fix and the right exit class

### DIFF
--- a/cli/src/docker.rs
+++ b/cli/src/docker.rs
@@ -603,6 +603,57 @@ pub fn missing_local_model_assets_message(
     lines.join("\n")
 }
 
+/// The ADR-0093 refusal as a tagged [`crate::exit::CliError`], so the runnable
+/// fetch command reaches an agent in the ADR-0021 `fix` field instead of only
+/// inside the prose (#1261). A bare `bail!` classified as Failure with a null
+/// `fix`, which is exactly the shape an agent consumer cannot branch on.
+///
+/// The class stays [`crate::exit::ExitClass::Failure`] (exit 1): the argv was
+/// well-formed and `--local-model <m>` is a legitimate request, so this is a
+/// machine-state failure and not a usage error -- re-running the same argv after
+/// the fetch succeeds, which is the opposite of what exit 2 promises.
+///
+/// Pure and synchronous on purpose: [`preflight_local_model`] shells out to
+/// docker and so is not unit-testable, while this guard -- the part that
+/// carries the contract -- is. It also owns the `image_missing || model_missing`
+/// decision itself, not just the error shape, so `preflight_local_model` has no
+/// refusal branch of its own left to revert to a bare `bail!`: the async docker
+/// probing stays there, but everything that carries the ADR-0021 contract lives
+/// in this pure, testable function.
+///
+/// Args:
+///   image: the pinned Ollama image, named when it is the missing one.
+///   image_missing: whether the image has to be downloaded.
+///   model: the requested model reference, named when it is the missing one.
+///   model_missing: whether the model has to be downloaded.
+///   fetch_hint: the exact `curie` command that fetches what is missing.
+///
+/// Returns:
+///   `Ok(())` when neither asset is missing; otherwise an `Err` whose message
+///   is [`missing_local_model_assets_message`] and whose `fix` is `fetch_hint`
+///   alone -- the command, not the prose around it.
+pub fn refuse_missing_local_model_assets(
+    image: &str,
+    image_missing: bool,
+    model: &str,
+    model_missing: bool,
+    fetch_hint: &str,
+) -> anyhow::Result<()> {
+    if !image_missing && !model_missing {
+        return Ok(());
+    }
+    Err(anyhow::Error::from(
+        crate::exit::CliError::failure(missing_local_model_assets_message(
+            image,
+            image_missing,
+            model,
+            model_missing,
+            fetch_hint,
+        ))
+        .with_fix(fetch_hint),
+    ))
+}
+
 /// Refuse a `--local-model` run whose assets are not already on the machine
 /// (ADR 0093). Shared by `skill up` and `local up` so the two tiers answer the
 /// verb the same way (ADR 0041); only the volume and the fix hint differ.
@@ -618,8 +669,9 @@ pub fn missing_local_model_assets_message(
 ///   fetch_hint: the exact `curie` command that provisions what is missing.
 ///
 /// Returns:
-///   `Ok(())` when both assets are present; otherwise an error whose message is
-///   `missing_local_model_assets_message`.
+///   `Ok(())` when both assets are present; otherwise whatever
+///   [`refuse_missing_local_model_assets`] returns -- exit 1 with the fetch
+///   command in the ADR-0021 `fix` field.
 pub async fn preflight_local_model(
     image: &str,
     volume: &str,
@@ -635,16 +687,7 @@ pub async fn preflight_local_model(
     } else {
         !model_present_in_volume(volume, image, model).await?
     };
-    if image_missing || model_missing {
-        bail!(missing_local_model_assets_message(
-            image,
-            image_missing,
-            model,
-            model_missing,
-            fetch_hint
-        ));
-    }
-    Ok(())
+    refuse_missing_local_model_assets(image, image_missing, model, model_missing, fetch_hint)
 }
 
 /// The `docker run` argument vector (after the `docker` executable) that boots
@@ -1487,6 +1530,56 @@ mod tests {
         );
         assert!(!msg.contains("docker pull"), "{msg}");
         assert!(!msg.contains("docker run"), "{msg}");
+    }
+
+    // The prose satisfies a human; an agent branches on the ADR-0021 `fix`
+    // field, which a bare `bail!` leaves null (#1261). Asserting on Some(fix)
+    // is what arms this test: reverting this guard's body to
+    // `bail!(missing_local_model_assets_message(...))` makes `classify` return
+    // (Failure, None) and the `expect` below fails.
+    #[test]
+    fn the_missing_assets_refusal_carries_the_fetch_command_as_its_fix() {
+        let hint = "curie local up --local-model qwen3:4b --pull-model";
+        let err =
+            refuse_missing_local_model_assets("ollama/ollama:0.24.0", true, "qwen3:4b", true, hint)
+                .unwrap_err();
+        let (class, fix) = crate::exit::classify(&err);
+        // Exit 1, not 2: the argv was well-formed and re-running it after the
+        // fetch succeeds, which exit 2 would deny.
+        assert_eq!(class, crate::exit::ExitClass::Failure);
+        let fix = fix.expect("the refusal must carry a fix, not a null one");
+        assert!(fix.contains(hint), "the fix must be runnable: {fix}");
+        // Separate from the prose: dumping the whole message into `fix` would
+        // also contain the hint, so pin that the lead-in is NOT in there.
+        assert!(
+            !fix.contains("local model assets are not on this machine"),
+            "the fix must be the command alone, not the prose: {fix}"
+        );
+
+        let json = crate::exit::error_json(&err);
+        assert!(
+            json["fix"] != serde_json::Value::Null,
+            "the rendered payload must not have a null fix: {json}"
+        );
+        assert!(
+            json["error"]
+                .as_str()
+                .expect("error is a string")
+                .contains("does not download them implicitly"),
+            "the prose still rides the error field: {json}"
+        );
+
+        // Positive control: an always-Err guard would also pass every
+        // assertion above, so pin that the guard refuses ONLY when something
+        // is actually missing.
+        assert!(refuse_missing_local_model_assets(
+            "ollama/ollama:0.24.0",
+            false,
+            "qwen3:4b",
+            false,
+            hint,
+        )
+        .is_ok());
     }
 
     #[test]

--- a/cli/src/github_app.rs
+++ b/cli/src/github_app.rs
@@ -9,7 +9,7 @@
 //! chart that can mint tokens for every repository in the installation, so it
 //! is the one that most deserves never being in a process list.
 
-use anyhow::{bail, Result};
+use anyhow::Result;
 
 use crate::ops::{plain, require_on_path, run_step, CommonOpts, OpsCommand};
 
@@ -192,24 +192,39 @@ pub async fn github_app(opts: GithubAppOpts, clone_base: &str) -> Result<GithubA
     })
 }
 
+/// All three refusals here are deterministic input errors, so they exit 2
+/// (ADR-0021 Usage) with a non-null `fix` naming the flag to correct (#1261).
+/// A bare `bail!` classified them as exit 1 with a null fix -- indistinguishable
+/// to an agent from the helm upgrade itself failing, which is retryable and
+/// these are not. clap gives both flags `default_value = ""`, so clap never
+/// raises its own exit 2 for them and this is the only place the class is set.
 pub fn require_connect_inputs(disconnect: bool, app_id: &str, key_path: &str) -> Result<()> {
     if disconnect {
         return Ok(());
     }
     if app_id.trim().is_empty() {
-        bail!(
-            "--app-id is required. Find it on the App's settings page \
-             (Settings -> Developer settings -> GitHub Apps -> your app)."
-        );
+        return Err(anyhow::Error::from(
+            crate::exit::CliError::usage(
+                "--app-id is required. Find it on the App's settings page \
+                 (Settings -> Developer settings -> GitHub Apps -> your app).",
+            )
+            .with_fix("rerun with --app-id <numeric app id from the App's settings page>"),
+        ));
     }
     if key_path.trim().is_empty() {
-        bail!(
-            "--private-key is required: the path to the App's PEM file, \
-             downloaded from the App's settings page under 'Private keys'."
-        );
+        return Err(anyhow::Error::from(
+            crate::exit::CliError::usage(
+                "--private-key is required: the path to the App's PEM file, \
+                 downloaded from the App's settings page under 'Private keys'.",
+            )
+            .with_fix("rerun with --private-key <path to the App's PEM file>"),
+        ));
     }
     if !std::path::Path::new(key_path).is_file() {
-        bail!("--private-key: no such file: {key_path}");
+        return Err(anyhow::Error::from(
+            crate::exit::CliError::usage(format!("--private-key: no such file: {key_path}"))
+                .with_fix("rerun with --private-key pointing at an existing PEM file"),
+        ));
     }
     Ok(())
 }
@@ -374,6 +389,38 @@ mod tests {
         // upgrade has already started.
         let err = require_connect_inputs(false, "1", "/nope/missing.pem").unwrap_err();
         assert!(err.to_string().contains("no such file"));
+    }
+
+    // Each of the three arms is a deterministic input error: the same argv fails
+    // identically, so it is exit 2 and must name the flag to fix (#1261). Both
+    // halves arm the test against a revert to `bail!`, which classifies as
+    // (Failure, None): the class assertion fails and so does the `expect`.
+    #[test]
+    fn each_missing_input_is_a_usage_error_with_a_flag_naming_fix() {
+        for (app_id, key_path, flag) in [
+            ("", "/tmp/app.pem", "--app-id"),
+            ("1", "", "--private-key"),
+            ("1", "/nope/missing.pem", "--private-key"),
+        ] {
+            let err = require_connect_inputs(false, app_id, key_path).unwrap_err();
+            let (class, fix) = crate::exit::classify(&err);
+            assert_eq!(
+                class,
+                crate::exit::ExitClass::Usage,
+                "a deterministic input error must exit 2: {err:#}"
+            );
+            let fix = fix.expect("a usage refusal must carry a fix, not a null one");
+            assert!(!fix.trim().is_empty(), "the fix must not be empty");
+            assert!(
+                fix.contains(flag),
+                "the fix must name the offending flag {flag}: {fix}"
+            );
+            let json = crate::exit::error_json(&err);
+            assert!(
+                json["fix"] != serde_json::Value::Null,
+                "the rendered payload must not have a null fix: {json}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Closes #1261.

Four refusals added recently exited 1 with a null `fix`, against the CLI's own ADR-0021 contract. An agent branching on exit codes read "the operation failed" (retry-ish) for cases whose only remedy is changed argv, and found nothing in the field the contract reserves for remediation.

**`--local-model` preflight (ADR-0093)** keeps exit 1 — the argv was well-formed and the same argv succeeds once the assets are fetched, which is the opposite of what exit 2 promises. What changes is that the runnable `curie ... --pull-model` command now rides the `fix` field alone, instead of only being buried in an embedded newline inside the prose. The refusal decision and its error move into `refuse_missing_local_model_assets`, a pure guard that `preflight_local_model` tail-calls, so the part carrying the contract is unit-testable while the docker probing stays async. `skill up --local-model` shares that guard, so both tiers are fixed together.

**The three `cluster github-app` input refusals** become exit 2 (Usage) with a `fix` naming the flag to correct. clap gives both flags `default_value = ""`, so this hand-check is the only place their class is ever set.

The human-rendered prose is byte-identical, so `docs/local-model.md:46-51` still matches.

## Verification

All four refusals executed against the built binary:

| command | exit | fix |
|---|---|---|
| `local up --local-model qwen3:4b --json` | 1 | `curie local up --local-model qwen3:4b --pull-model` |
| `cluster github-app --json` | 2 | populated |
| `cluster github-app --app-id 123456 --dry-run --json` | 2 | populated |
| `cluster github-app --app-id 123456 --private-key /tmp/nope.pem --dry-run --json` | 2 | populated |

Red-on-revert (AC3) demonstrated: restoring `bail!` in the local-model guard fails on `the refusal must carry a fix, not a null one`; restoring it in the github-app arms fails on `a deterministic input error must exit 2 ... left: Failure right: Usage`.

Full cli suite 1502 passed / 61 suites; rustfmt clean; clippy emits no diagnostic on either changed file.

Out of scope, as the issue notes: the same inherited pattern at `cli/src/comms.rs:209,218`.