### PR TITLE
Add a cluster rollback verb that skips failed revisions

### DIFF
--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -2150,6 +2150,80 @@ export const commandManifest = {
           "name": "down"
         },
         {
+          "about": "Roll the release back to the newest revision that is actually known good",
+          "args": [
+            {
+              "global": false,
+              "help": "Roll back to this exact revision instead of the newest safe one. A revision that is not `deployed` or `superseded` is refused unless --allow-failed-revision is also passed",
+              "id": "revision",
+              "long": "revision",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Permit --revision to name a revision helm never finished applying (`failed`, `pending-*`, `uninstalling`). Off by default. Requires --revision -- auto-select never chooses an ineligible revision, so this flag alone would otherwise be a silent no-op",
+              "id": "allow_failed_revision",
+              "long": "allow-failed-revision",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "default_values": [
+                "curie"
+              ],
+              "global": false,
+              "help": "Kubernetes namespace",
+              "id": "namespace",
+              "long": "namespace",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "curie"
+              ],
+              "global": false,
+              "help": "Helm release name",
+              "id": "release",
+              "long": "release",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Skip the interactive confirmation prompt",
+              "id": "yes",
+              "long": "yes",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Print the commands that would run and exit without executing",
+              "id": "dry_run",
+              "long": "dry-run",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "long_about": "Roll the release back to the newest revision that is actually known good.\n\nA bare `helm rollback` targets the immediately preceding revision. On a cluster with no `runsc` RuntimeClass that is the wrong one: `cluster up` records a FAILED revision before its successful gVisor-off retry, so the history alternates failed/superseded and the preceding revision is a failed one -- a manifest helm never finished applying.\n\nThis verb skips every revision whose status is not `deployed` or `superseded` and rolls back to the newest one below the current revision that is, printing which revisions it passed over. See issue #1899.",
+          "name": "rollback"
+        },
+        {
           "about": "Carry bundle objects across a chart upgrade that renames the object store (issue #1324)",
           "args": [
             {

--- a/cli/README.md
+++ b/cli/README.md
@@ -149,8 +149,8 @@ parsing output:
 | 4    | unsupported | The verb was understood, but the concept it inspects does not exist at this tier by construction (`curie skill versions`, `curie skill memory`). No input and no retry changes that -- the same argv never succeeds here; the `fix` hint names the tier that does answer it. |
 
 **Non-interactive by default.** Every mutating command has a non-interactive
-path (`--yes` on `cluster down`/`kill`/`delete`/`reset-thread`, `local
-reset-thread`, and `local down --wipe`); none block on stdin. A confirmation
+path (`--yes` on `cluster down`/`rollback`/`kill`/`delete`/`reset-thread`,
+`local reset-thread`, and `local down --wipe`); none block on stdin. A confirmation
 prompt that would otherwise read stdin refuses
 with a usage error (exit 2) when the session is not a terminal, rather than
 hanging.
@@ -407,6 +407,7 @@ Wraps the umbrella Helm chart and the deployed release, the way `linkerd` or
 |---|---|
 | `curie cluster up` | Install or upgrade the release (`helm upgrade --install`).<br>• Exposes the UI and Langfuse on node ports; `--no-expose` keeps them ClusterIP-only.<br>• Set `CURIE_CREDENTIALS` (deprecated alias `CURIE_MODEL_CREDENTIALS`) for a real model, or install sealed with canned replies.<br>• A shell `CURIE_MODEL` defaults the sandbox runner model (`agentSandbox.runner.model`) for cross-tier parity with `local up`, unless an explicit `--set agentSandbox.runner.model=` is passed; a shell `CURIE_MODEL` that disagrees with such an explicit `--set` fails loud.<br>• `--github-token` (or `CURIE_GITHUB_TOKEN`) supplies the API's GitHub credential for private-repo git-flow clones; the CLI passes it to helm through a private 0600 values file rather than as a command-line argument, so it does not appear in the helm command, the printed plan, or that plan's JSON.<br>• Prefer the `CURIE_GITHUB_TOKEN` environment variable: a token typed after the flag sits in `curie`'s own argv, so it still lands in your shell history and in `ps`.<br>• Omitting both preserves whatever the release already recorded, and `--clear-github-token` removes it. Passing the token alongside `--set api.githubToken=` fails loud. |
 | `curie cluster down` | Uninstall the release and sweep its runtime namespaces (`helm uninstall` + `kubectl delete namespace`); prompts unless `--yes`. |
+| `curie cluster rollback` | Roll the release back to a prior Helm revision (`helm rollback`); prompts unless `--yes`.<br>• With no `--revision`, auto-selects the newest revision whose status is `deployed` or `superseded`, skipping any `failed`/`pending-*`/`uninstalling` revision in between.<br>• `--revision <n>` targets an exact revision instead; one that is not `deployed`/`superseded` is refused unless `--allow-failed-revision` is also passed (requires `--revision`). |
 | `curie cluster status` | Report release health, pod readiness, and access URLs (read-only). |
 | `curie cluster observability` | Report the release's observability surfaces (Curie Console, Langfuse UI, Curie API base), using the same NodePort discovery as `cluster status`.<br>• Degrades a missing, ClusterIP, or unresolvable surface to a note instead of failing.<br>• URLs are printed only; pass `--open` to also open the browsable ones (Console, Langfuse) in a browser. `--json` never opens a browser.<br>• `--dry-run` prints the read-only discovery commands. |
 | `curie cluster comms --slack` | Connect or disconnect a real Slack workspace with a thin `helm upgrade --reuse-values`; env-backed tokens are masked in dry-run output. |

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -2147,6 +2147,80 @@
           "name": "down"
         },
         {
+          "about": "Roll the release back to the newest revision that is actually known good",
+          "args": [
+            {
+              "global": false,
+              "help": "Roll back to this exact revision instead of the newest safe one. A revision that is not `deployed` or `superseded` is refused unless --allow-failed-revision is also passed",
+              "id": "revision",
+              "long": "revision",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Permit --revision to name a revision helm never finished applying (`failed`, `pending-*`, `uninstalling`). Off by default. Requires --revision -- auto-select never chooses an ineligible revision, so this flag alone would otherwise be a silent no-op",
+              "id": "allow_failed_revision",
+              "long": "allow-failed-revision",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "default_values": [
+                "curie"
+              ],
+              "global": false,
+              "help": "Kubernetes namespace",
+              "id": "namespace",
+              "long": "namespace",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "curie"
+              ],
+              "global": false,
+              "help": "Helm release name",
+              "id": "release",
+              "long": "release",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Skip the interactive confirmation prompt",
+              "id": "yes",
+              "long": "yes",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Print the commands that would run and exit without executing",
+              "id": "dry_run",
+              "long": "dry-run",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "long_about": "Roll the release back to the newest revision that is actually known good.\n\nA bare `helm rollback` targets the immediately preceding revision. On a cluster with no `runsc` RuntimeClass that is the wrong one: `cluster up` records a FAILED revision before its successful gVisor-off retry, so the history alternates failed/superseded and the preceding revision is a failed one -- a manifest helm never finished applying.\n\nThis verb skips every revision whose status is not `deployed` or `superseded` and rolls back to the newest one below the current revision that is, printing which revisions it passed over. See issue #1899.",
+          "name": "rollback"
+        },
+        {
           "about": "Carry bundle objects across a chart upgrade that renames the object store (issue #1324)",
           "args": [
             {

--- a/cli/schema/baseline/cluster-rollback.schema.json
+++ b/cli/schema/baseline/cluster-rollback.schema.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.curietech.ai/cli/cluster-rollback/v1.json",
+  "title": "curie cluster rollback --json",
+  "description": "The agent-facing payload of `curie cluster rollback`: the dry-run plan, an operator abort, or the completed rollback. `skipped` lists only the revisions passed over that were ineligible (status not `deployed`/`superseded`); an explicit `--revision` can step over eligible revisions too, and those are deliberately not listed here. `forced` is true only when `--allow-failed-revision` admitted the target.",
+  "$defs": {
+    "dryRun": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "dry_run": {
+          "const": true
+        },
+        "plan": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "dry_run",
+        "plan"
+      ]
+    }
+  },
+  "oneOf": [
+    {
+      "$ref": "#/$defs/dryRun"
+    },
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "rolled_back": {
+          "const": false
+        },
+        "aborted": {
+          "const": true
+        }
+      },
+      "required": [
+        "rolled_back",
+        "aborted"
+      ]
+    },
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "rolled_back": {
+          "const": true
+        },
+        "from_revision": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "to_revision": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "skipped": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "minimum": 0
+          }
+        },
+        "forced": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "rolled_back",
+        "from_revision",
+        "to_revision",
+        "skipped",
+        "forced"
+      ]
+    }
+  ]
+}

--- a/cli/schema/cluster-rollback.schema.json
+++ b/cli/schema/cluster-rollback.schema.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.curietech.ai/cli/cluster-rollback/v1.json",
+  "title": "curie cluster rollback --json",
+  "description": "The agent-facing payload of `curie cluster rollback`: the dry-run plan, an operator abort, or the completed rollback. `skipped` lists only the revisions passed over that were ineligible (status not `deployed`/`superseded`); an explicit `--revision` can step over eligible revisions too, and those are deliberately not listed here. `forced` is true only when `--allow-failed-revision` admitted the target.",
+  "$defs": {
+    "dryRun": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "dry_run": {
+          "const": true
+        },
+        "plan": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "dry_run",
+        "plan"
+      ]
+    }
+  },
+  "oneOf": [
+    {
+      "$ref": "#/$defs/dryRun"
+    },
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "rolled_back": {
+          "const": false
+        },
+        "aborted": {
+          "const": true
+        }
+      },
+      "required": [
+        "rolled_back",
+        "aborted"
+      ]
+    },
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "rolled_back": {
+          "const": true
+        },
+        "from_revision": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "to_revision": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "skipped": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "minimum": 0
+          }
+        },
+        "forced": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "rolled_back",
+        "from_revision",
+        "to_revision",
+        "skipped",
+        "forced"
+      ]
+    }
+  ]
+}

--- a/cli/schema/index.json
+++ b/cli/schema/index.json
@@ -52,6 +52,12 @@
       "version": "1.0"
     },
     {
+      "result": "ClusterRollbackOutput",
+      "kind": "CliOutput",
+      "schema": "cluster-rollback.schema.json",
+      "version": "1.0"
+    },
+    {
       "result": "ClusterStatusOutput",
       "kind": "CliOutput",
       "schema": "cluster-status.schema.json",

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -18,7 +18,7 @@ use curie::docker;
 use curie::github_app as crate_github_app;
 use curie::local::{self, LocalDownOpts, LocalOpts};
 use curie::message::{self, MessageOpts};
-use curie::ops::{self, CommonOpts, DownOpts, UpOpts};
+use curie::ops::{self, CommonOpts, DownOpts, RollbackOpts, UpOpts};
 use curie::secrets;
 use curie::state::{apply_continue, load_turn, CliTurnArgs, TurnVerb};
 use curie::ui::{self, ColorFlag, Ui};
@@ -1538,6 +1538,42 @@ enum ClusterAction {
         #[arg(long)]
         dry_run: bool,
     },
+    /// Roll the release back to the newest revision that is actually known good.
+    ///
+    /// A bare `helm rollback` targets the immediately preceding revision. On a
+    /// cluster with no `runsc` RuntimeClass that is the wrong one: `cluster up`
+    /// records a FAILED revision before its successful gVisor-off retry, so the
+    /// history alternates failed/superseded and the preceding revision is a
+    /// failed one -- a manifest helm never finished applying.
+    ///
+    /// This verb skips every revision whose status is not `deployed` or
+    /// `superseded` and rolls back to the newest one below the current revision
+    /// that is, printing which revisions it passed over. See issue #1899.
+    Rollback {
+        /// Roll back to this exact revision instead of the newest safe one. A
+        /// revision that is not `deployed` or `superseded` is refused unless
+        /// --allow-failed-revision is also passed.
+        #[arg(long)]
+        revision: Option<u32>,
+        /// Permit --revision to name a revision helm never finished applying
+        /// (`failed`, `pending-*`, `uninstalling`). Off by default. Requires
+        /// --revision -- auto-select never chooses an ineligible revision, so
+        /// this flag alone would otherwise be a silent no-op.
+        #[arg(long, requires = "revision")]
+        allow_failed_revision: bool,
+        /// Kubernetes namespace.
+        #[arg(long, default_value = "curie")]
+        namespace: String,
+        /// Helm release name.
+        #[arg(long, default_value = "curie")]
+        release: String,
+        /// Skip the interactive confirmation prompt.
+        #[arg(long)]
+        yes: bool,
+        /// Print the commands that would run and exit without executing.
+        #[arg(long)]
+        dry_run: bool,
+    },
     /// Carry bundle objects across a chart upgrade that renames the object
     /// store (issue #1324).
     ///
@@ -2851,6 +2887,26 @@ async fn run(command: Option<Command>) -> Result<()> {
                         release,
                         dry_run,
                     },
+                    yes,
+                })
+                .await?,
+            ),
+            ClusterAction::Rollback {
+                revision,
+                allow_failed_revision,
+                namespace,
+                release,
+                yes,
+                dry_run,
+            } => emit(
+                ops::rollback(RollbackOpts {
+                    common: CommonOpts {
+                        namespace,
+                        release,
+                        dry_run,
+                    },
+                    revision,
+                    allow_failed_revision,
                     yes,
                 })
                 .await?,

--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -1,4 +1,4 @@
-//! `curie cluster up | cluster status | cluster down`: the operator
+//! `curie cluster up | cluster status | cluster rollback | cluster down`: the operator
 //! day-1 lifecycle, wrapping the Helm chart and `kubectl` the way linkerd or
 //! cilium wrap theirs -- a deliberately thin CLI over the chart, which stays the
 //! source of truth. Every verb shells out to the `helm`/`kubectl` binaries; the
@@ -534,6 +534,18 @@ impl UpOpts {
 
 pub struct DownOpts {
     pub common: CommonOpts,
+    pub yes: bool,
+}
+
+pub struct RollbackOpts {
+    pub common: CommonOpts,
+    /// An operator-named revision. `None` lets [`select_rollback_revision`] pick
+    /// the newest `deployed`/`superseded` revision below the current one, which
+    /// is the whole point of the verb (#1899).
+    pub revision: Option<u32>,
+    /// Admit a `--revision` whose status is not `deployed`/`superseded`. Refused
+    /// without this flag, since helm never finished applying such a revision.
+    pub allow_failed_revision: bool,
     pub yes: bool,
 }
 
@@ -5770,6 +5782,541 @@ pub async fn down(opts: DownOpts) -> Result<ClusterDownOutput> {
         &sweep_err,
         &opts.common,
     )
+}
+
+// ---------------------------------------------------------------------------
+// `cluster rollback` (#1899)
+// ---------------------------------------------------------------------------
+
+/// One row of `helm history -o json`. Only the fields the rollback decision
+/// needs are modelled; helm adds others (`updated`, `app_version`) that are
+/// deliberately ignored so a helm version bump cannot break parsing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HelmRevision {
+    pub revision: u32,
+    pub status: String,
+    pub chart: String,
+    pub description: String,
+}
+
+/// The revision statuses it is safe to roll back TO. Everything else
+/// (`failed`, the four `pending-*` states, `uninstalling`, `uninstalled`,
+/// `unknown`) names a revision helm never finished putting on the cluster, so
+/// rolling back to it re-applies a manifest that was never known good.
+const ROLLBACK_ELIGIBLE_STATUSES: [&str; 2] = ["deployed", "superseded"];
+
+fn is_eligible_rollback_status(status: &str) -> bool {
+    ROLLBACK_ELIGIBLE_STATUSES.contains(&status.trim().to_ascii_lowercase().as_str())
+}
+
+/// The revision the release is on right now.
+///
+/// Normally that is the one helm marks `deployed`. The fallback to the highest
+/// revision is the real recovery case this verb exists for: when the newest
+/// revision FAILED there is no `deployed` row at all, and treating the failed
+/// revision as "current" is what lets the selector look below it.
+fn current_revision(history: &[HelmRevision]) -> Option<u32> {
+    history
+        .iter()
+        .filter(|r| r.status.trim().eq_ignore_ascii_case("deployed"))
+        .map(|r| r.revision)
+        .max()
+        .or_else(|| history.iter().map(|r| r.revision).max())
+}
+
+/// [`current_revision`], or the error every entry point owes an operator whose
+/// history came back empty. One copy on purpose: the wording here has already
+/// been reworked twice, and a second hand-written copy would silently keep the
+/// old text the next time it changes.
+fn require_current_revision(history: &[HelmRevision]) -> Result<u32> {
+    match current_revision(history) {
+        Some(current) => Ok(current),
+        None => Err(crate::exit::CliError::failure(
+            "`helm history` returned no revisions for this release, so there is nothing to roll back to",
+        )
+        .with_fix("confirm the release name and namespace with `helm list -n <namespace>`")
+        .into()),
+    }
+}
+
+/// The INELIGIBLE revisions between `to` and `from`. The status filter is not
+/// redundant: it is only the auto-select path that leaves nothing eligible in
+/// the gap. An operator-named `--revision` can step over revisions that were
+/// perfectly good, and reporting those as "not deployed/superseded" is a false
+/// claim in both the note and the `--json` `skipped` field, so the list is
+/// computed rather than assumed. Reporting the rest is the whole point of AC2.
+///
+/// Deduplicated defensively: [`parse_helm_history`] already collapses a corrupt
+/// history to one row per revision, but this is pure over any slice a caller
+/// hands it, and a number must never surface twice in the report.
+fn skipped_between(history: &[HelmRevision], to: u32, from: u32) -> Vec<u32> {
+    let mut skipped: Vec<u32> = history
+        .iter()
+        .filter(|r| r.revision > to && r.revision < from)
+        .filter(|r| !is_eligible_rollback_status(&r.status))
+        .map(|r| r.revision)
+        .collect();
+    skipped.sort_unstable();
+    skipped.dedup();
+    skipped
+}
+
+/// A resolved rollback: where the release is now, where it is going, and what
+/// was stepped over on the way.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RollbackChoice {
+    pub from_revision: u32,
+    pub to_revision: u32,
+    pub skipped: Vec<u32>,
+    /// True only when `--allow-failed-revision` admitted a revision whose status
+    /// is not `deployed`/`superseded`.
+    pub forced: bool,
+}
+
+/// The outcome of the pure selection. `NoEligible` is a legitimate reading of a
+/// real history (a first install, or a release whose every prior revision
+/// failed), not a parse error, so it is carried as a value and turned into the
+/// operator-facing refusal by [`RollbackTarget::require_eligible`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RollbackTarget {
+    Eligible(RollbackChoice),
+    NoEligible { current: u32, skipped: Vec<u32> },
+}
+
+impl RollbackTarget {
+    /// The chosen revision, or the AC4 refusal: never a silent no-op, and never
+    /// a rollback to a revision helm never finished applying.
+    pub fn require_eligible(self) -> Result<RollbackChoice> {
+        match self {
+            RollbackTarget::Eligible(choice) => Ok(choice),
+            RollbackTarget::NoEligible { current, skipped } => {
+                let detail = if skipped.is_empty() {
+                    format!("revision {current} is the only revision in its history")
+                } else {
+                    format!(
+                        "every revision below {current} ({}) has a status helm never finished applying",
+                        skipped
+                            .iter()
+                            .map(u32::to_string)
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    )
+                };
+                // The next step rides in the message as well as the fix: a bare
+                // `CliError` shows only its message to a human presenter, so an
+                // operator on a TTY would otherwise never learn there is one.
+                Err(crate::exit::CliError::failure(format!(
+                    "no revision is safe to roll back to: {detail}; inspect \
+                     `helm history <release> -n <namespace>` and, if you accept the risk, name one \
+                     explicitly with --revision <n> --allow-failed-revision"
+                ))
+                .with_fix(
+                    "inspect `helm history <release> -n <namespace>` and, if you accept the risk, \
+                     name one explicitly with --revision <n> --allow-failed-revision",
+                )
+                .into())
+            }
+        }
+    }
+}
+
+/// Pick the rollback target: the NEWEST revision strictly below the current one
+/// whose status is `deployed` or `superseded`.
+///
+/// This is the whole fix for #1899. A `cluster up` against a cluster with no
+/// `runsc` RuntimeClass records a FAILED revision before its successful retry,
+/// so the history alternates failed/superseded and the immediately preceding
+/// revision -- the one bare `helm rollback` targets -- is a failed one. Skipping
+/// ineligible statuses is what stops an operator having to know that.
+///
+/// Pure by construction so the decision is unit-testable with no cluster.
+pub fn select_rollback_revision(history: &[HelmRevision]) -> Result<RollbackTarget> {
+    let current = require_current_revision(history)?;
+
+    match history
+        .iter()
+        .filter(|r| r.revision < current && is_eligible_rollback_status(&r.status))
+        .map(|r| r.revision)
+        .max()
+    {
+        Some(to_revision) => Ok(RollbackTarget::Eligible(RollbackChoice {
+            from_revision: current,
+            to_revision,
+            skipped: skipped_between(history, to_revision, current),
+            forced: false,
+        })),
+        None => Ok(RollbackTarget::NoEligible {
+            current,
+            skipped: skipped_between(history, 0, current),
+        }),
+    }
+}
+
+/// Validate an operator-named `--revision`. A revision that is not in the
+/// history is always refused (helm would otherwise fail obscurely mid-rollback);
+/// an ineligible status is refused unless `allow_failed` was passed, and the
+/// refusal names both the status and the override so the operator does not have
+/// to guess (AC3).
+pub fn resolve_explicit_revision(
+    history: &[HelmRevision],
+    revision: u32,
+    allow_failed: bool,
+) -> Result<RollbackChoice> {
+    let current = require_current_revision(history)?;
+
+    let row = history.iter().find(|r| r.revision == revision).ok_or_else(|| {
+        let known: Vec<String> = history.iter().map(|r| r.revision.to_string()).collect();
+        crate::exit::CliError::usage(format!(
+            "revision {revision} is not in this release's Helm history (it has {})",
+            known.join(", ")
+        ))
+        .with_fix("run `curie cluster rollback` with no --revision to let it pick the newest safe revision")
+    })?;
+
+    let eligible = is_eligible_rollback_status(&row.status);
+    if !eligible && !allow_failed {
+        return Err(crate::exit::CliError::usage(format!(
+            "revision {revision} has status `{}`, not `deployed` or `superseded`; \
+             helm never finished applying it, so rolling back to it re-applies a manifest \
+             that was never known good; pass --allow-failed-revision to roll back to it anyway, \
+             or omit --revision to let Curie pick the newest safe one",
+            row.status
+        ))
+        .with_fix("pass --allow-failed-revision to roll back to it anyway, or omit --revision to let Curie pick the newest safe one")
+        .into());
+    }
+
+    Ok(RollbackChoice {
+        from_revision: current,
+        to_revision: revision,
+        skipped: skipped_between(history, revision, current),
+        forced: !eligible,
+    })
+}
+
+/// Parse `helm history -o json`: an array of objects. Unknown fields are
+/// tolerated (helm adds them across versions) and `revision` is accepted as a
+/// JSON number or a string, since that shape has moved between helm releases.
+/// Never panics on operator-visible input -- a malformed payload becomes a
+/// `CliError` naming the command to run by hand.
+pub fn parse_helm_history(json: &str) -> Result<Vec<HelmRevision>> {
+    let malformed = |detail: String| {
+        crate::exit::CliError::failure(format!(
+            "could not read `helm history -o json` output: {detail}"
+        ))
+        .with_fix(
+            "run `helm history <release> -n <namespace> -o json` by hand to see what helm returned",
+        )
+    };
+
+    let rows: serde_json::Value =
+        serde_json::from_str(json).map_err(|e| malformed(e.to_string()))?;
+    let rows = rows
+        .as_array()
+        .ok_or_else(|| malformed("expected a JSON array of revisions".to_string()))?;
+
+    let mut out = Vec::with_capacity(rows.len());
+    for row in rows {
+        let revision = row
+            .get("revision")
+            .and_then(|v| {
+                v.as_u64()
+                    .or_else(|| v.as_str().and_then(|s| s.trim().parse::<u64>().ok()))
+            })
+            .and_then(|n| u32::try_from(n).ok())
+            .ok_or_else(|| {
+                malformed(format!("a revision has no usable `revision` field: {row}"))
+            })?;
+        let field = |name: &str| {
+            row.get(name)
+                .and_then(|v| v.as_str())
+                .unwrap_or_default()
+                .to_string()
+        };
+        // A row with no `status` is treated as `unknown`, which is ineligible:
+        // the safe reading of a field we could not see is "not known good".
+        let status = match field("status").as_str() {
+            "" => "unknown".to_string(),
+            s => s.to_string(),
+        };
+        out.push(HelmRevision {
+            revision,
+            status,
+            chart: field("chart"),
+            description: field("description"),
+        });
+    }
+    // The invariant every consumer below relies on: ascending by revision, and
+    // exactly ONE row per revision number. Eligibility is a property of the
+    // REVISION, not of a row, so both the auto-selector (which filters rows by
+    // status) and `--revision` (which looks a row up) must read the same answer
+    // for the same number. A truncated or corrupt helm secret can yield two
+    // rows for one revision that disagree -- say 20 `superseded` and 20
+    // `failed` -- and before collapsing them the two paths contradicted each
+    // other: `--revision 20` refused it as failed while a bare rollback happily
+    // picked it. A revision whose own history contradicts itself was never
+    // known good, so it collapses to its ineligible reading: sort ineligible
+    // first within a revision number (`false` orders before `true`), then keep
+    // the first row of each run.
+    out.sort_by_key(|r| (r.revision, is_eligible_rollback_status(&r.status)));
+    out.dedup_by_key(|r| r.revision);
+    Ok(out)
+}
+
+/// `helm history` for the release, as JSON. `--max 256` because helm's default
+/// of 10 silently truncates the history, and a truncated history would make the
+/// selector pick a revision that merely looks like the newest safe one.
+pub fn helm_history_cmd(o: &CommonOpts) -> OpsCommand {
+    OpsCommand::new(
+        "helm",
+        vec![
+            plain("history"),
+            plain(&o.release),
+            plain("-n"),
+            plain(&o.namespace),
+            plain("-o"),
+            plain("json"),
+            plain("--max"),
+            plain("256"),
+        ],
+    )
+}
+
+/// `helm rollback` to an explicit revision. Always explicit: the whole point of
+/// the verb is that helm's own default target (the immediately preceding
+/// revision) is the wrong one on a failed/superseded history.
+pub fn helm_rollback_cmd(o: &CommonOpts, revision: u32) -> OpsCommand {
+    helm_rollback_cmd_to(o, revision.to_string())
+}
+
+/// The revision slot of the rollback argv, as printed by `--dry-run` before the
+/// history that decides it has been read.
+const SELECTED_REVISION: &str = "<selected-revision>";
+
+/// [`helm_rollback_cmd`] with the revision slot left as text, so the plan a dry
+/// run prints and the command a live run executes are built by one function
+/// rather than a builder and a `format!` that drift apart.
+fn helm_rollback_cmd_to(o: &CommonOpts, revision: String) -> OpsCommand {
+    OpsCommand::new(
+        "helm",
+        vec![
+            plain("rollback"),
+            plain(&o.release),
+            plain(revision),
+            plain("-n"),
+            plain(&o.namespace),
+        ],
+    )
+}
+
+/// The commands `curie cluster rollback` runs (and prints under `--dry-run`):
+/// the history read that decides the target, then the rollback itself. A `None`
+/// revision is one the caller has not resolved yet, and stands in the argv as
+/// [`SELECTED_REVISION`].
+pub fn rollback_commands(o: &CommonOpts, revision: Option<u32>) -> Vec<OpsCommand> {
+    let target = revision.map_or_else(|| SELECTED_REVISION.to_string(), |r| r.to_string());
+    vec![helm_history_cmd(o), helm_rollback_cmd_to(o, target)]
+}
+
+/// One printed plan line. `display()` everywhere, except that it shell-quotes
+/// [`SELECTED_REVISION`] (the angle brackets are not shell-safe) into something
+/// that reads like a literal argument. The placeholder is a prompt to the
+/// reader, not a value, so it is unquoted back out; everything else in the line
+/// keeps `display()`'s quoting and masking.
+fn plan_line(cmd: &OpsCommand) -> String {
+    cmd.display()
+        .replace(&shell_quote(SELECTED_REVISION), SELECTED_REVISION)
+}
+
+/// Output of `cluster rollback`: the dry-run plan, an operator abort, or the
+/// completed rollback. `skipped` is carried into `--json` so an agent sees the
+/// revisions bare `helm rollback` would have landed on.
+#[derive(Debug)]
+pub enum ClusterRollbackOutput {
+    DryRun(crate::ui::DryRunPlan),
+    Aborted,
+    RolledBack {
+        from_revision: u32,
+        to_revision: u32,
+        skipped: Vec<u32>,
+        forced: bool,
+    },
+}
+
+impl crate::ui::CliOutput for ClusterRollbackOutput {
+    fn to_json(&self) -> serde_json::Value {
+        match self {
+            ClusterRollbackOutput::DryRun(plan) => plan.to_json(),
+            ClusterRollbackOutput::Aborted => {
+                serde_json::json!({"rolled_back": false, "aborted": true})
+            }
+            ClusterRollbackOutput::RolledBack {
+                from_revision,
+                to_revision,
+                skipped,
+                forced,
+            } => serde_json::json!({
+                "rolled_back": true,
+                "from_revision": from_revision,
+                "to_revision": to_revision,
+                "skipped": skipped,
+                "forced": forced,
+            }),
+        }
+    }
+
+    fn render(&self, ui: &crate::ui::Ui) {
+        match self {
+            ClusterRollbackOutput::DryRun(plan) => plan.render(ui),
+            ClusterRollbackOutput::Aborted => ui.note("aborted"),
+            ClusterRollbackOutput::RolledBack {
+                from_revision,
+                to_revision,
+                skipped,
+                forced,
+            } => {
+                ui.payload(&format!(
+                    "curie rolled back from revision {from_revision} to revision {to_revision}"
+                ));
+                if let Some(note) = skipped_note(skipped, *from_revision) {
+                    ui.note(&note);
+                }
+                if *forced {
+                    ui.warn(&format!(
+                        "revision {to_revision} was admitted by --allow-failed-revision; helm never finished applying it, so verify the release with `curie cluster status`"
+                    ));
+                }
+            }
+        }
+    }
+}
+
+/// The AC2 line: which revisions were passed over, and -- only when it is
+/// actually so -- which of them a bare `helm rollback` would have targeted.
+///
+/// helm's own default target is always the revision immediately below `from`,
+/// so that half of the sentence is true only when the highest skipped revision
+/// IS `from - 1`. On an explicit `--revision` the gap can contain eligible
+/// revisions that are not in this list, and naming the highest ineligible one
+/// as helm's target would be a fabrication. `None` when nothing was skipped, so
+/// the common case stays quiet.
+fn skipped_note(skipped: &[u32], from: u32) -> Option<String> {
+    let highest = *skipped.iter().max()?;
+    let list = skipped
+        .iter()
+        .map(u32::to_string)
+        .collect::<Vec<_>>()
+        .join(", ");
+    Some(if from.checked_sub(1) == Some(highest) {
+        format!(
+            "skipped revision(s) {list} (not deployed/superseded); a bare `helm rollback` would have targeted {highest}"
+        )
+    } else {
+        format!("skipped revision(s) {list} (not deployed/superseded)")
+    })
+}
+
+pub async fn rollback(opts: RollbackOpts) -> Result<ClusterRollbackOutput> {
+    let ui = crate::ui::ui();
+    let history_cmd = helm_history_cmd(&opts.common);
+
+    if opts.common.dry_run {
+        // The target revision is a function of the live history, so a dry run
+        // that has not read it can only name the revision when the operator did.
+        return Ok(ClusterRollbackOutput::DryRun(crate::ui::DryRunPlan {
+            lines: rollback_commands(&opts.common, opts.revision)
+                .iter()
+                .map(plan_line)
+                .collect(),
+        }));
+    }
+    require_on_path("helm")?;
+
+    ui.plumbing(&format!("+ {}", history_cmd.display()));
+    let (ok, history_out, history_err) = run_capture(&history_cmd).await?;
+    if !ok {
+        // A missing release fails HERE, with helm's own words, rather than
+        // downstream as a misleading "no eligible revision" (AC6).
+        let detail = history_err
+            .trim()
+            .lines()
+            .next()
+            .unwrap_or("helm exited nonzero with no message");
+        return Err(crate::exit::CliError::failure(format!(
+            "could not read the Helm history of release '{}' in namespace '{}': {detail}",
+            opts.common.release, opts.common.namespace
+        ))
+        .with_fix(format!(
+            "confirm the release exists with `helm list -n {}`",
+            opts.common.namespace
+        ))
+        .into());
+    }
+    let history = parse_helm_history(&history_out)?;
+
+    let choice = match opts.revision {
+        Some(revision) => {
+            resolve_explicit_revision(&history, revision, opts.allow_failed_revision)?
+        }
+        None => select_rollback_revision(&history)?.require_eligible()?,
+    };
+
+    // Disclosed BEFORE the prompt, and on stderr like `cluster down` does it:
+    // the operator confirms knowing both the target and what was passed over,
+    // which is the difference this verb exists to make. It cannot go through
+    // `payload` -- ADR-0021 (#474) reserves that channel for `CliOutput::render`,
+    // and routing it here told an operator who then declined the prompt that the
+    // release was rolling back, on stdout, while printing it twice on success.
+    ui.note(&format!(
+        "rolling release '{}' back from revision {} to revision {}",
+        opts.common.release, choice.from_revision, choice.to_revision
+    ));
+    if let Some(note) = skipped_note(&choice.skipped, choice.from_revision) {
+        ui.warn(&note);
+    }
+
+    if !opts.yes
+        && !confirm(&format!(
+            "This rolls back release '{}' in namespace '{}' from revision {} to revision {}. Continue? [y/N] ",
+            opts.common.release, opts.common.namespace, choice.from_revision, choice.to_revision
+        ))?
+    {
+        return Ok(ClusterRollbackOutput::Aborted);
+    }
+
+    let cl = ui.checklist();
+    let rollback_cmd = helm_rollback_cmd(&opts.common, choice.to_revision);
+    ui.plumbing(&format!("+ {}", rollback_cmd.display()));
+    let step = cl.step("rolling back release");
+    let (ok, out, err) = run_capture(&rollback_cmd).await?;
+    for line in out.lines().chain(err.lines()) {
+        ui.plumbing(line);
+    }
+    if !ok {
+        step.fail("failed");
+        let detail = err
+            .trim()
+            .lines()
+            .next()
+            .unwrap_or("helm exited nonzero with no message");
+        return Err(crate::exit::CliError::failure(format!(
+            "helm could not roll release '{}' back to revision {}: {detail}",
+            opts.common.release, choice.to_revision
+        ))
+        .with_fix(format!(
+            "inspect the release with `curie cluster status --release {} --namespace {}`",
+            opts.common.release, opts.common.namespace
+        ))
+        .into());
+    }
+    step.done("rolled back");
+
+    Ok(ClusterRollbackOutput::RolledBack {
+        from_revision: choice.from_revision,
+        to_revision: choice.to_revision,
+        skipped: choice.skipped,
+        forced: choice.forced,
+    })
 }
 
 /// Read a y/N confirmation from stderr/stdin for `down` when `--yes` is absent.

--- a/cli/tests/cli_output_variants.rs
+++ b/cli/tests/cli_output_variants.rs
@@ -48,7 +48,9 @@ use curie::local::{
 use curie::message::MessageOutcomeOutput;
 use curie::migrate_store::MigrateStoreOutput;
 use curie::observability::{Endpoint, ObservabilityOutput};
-use curie::ops::{ClusterDownOutput, ClusterStatus, ClusterStatusOutput, ClusterUpOutput};
+use curie::ops::{
+    ClusterDownOutput, ClusterRollbackOutput, ClusterStatus, ClusterStatusOutput, ClusterUpOutput,
+};
 use curie::ui::{CliOutput, DryRunPlan};
 
 #[path = "support/enum_variants.rs"]
@@ -450,6 +452,19 @@ fn registry() -> BTreeMap<&'static str, Vec<VariantJson>> {
             "DryRun" => ClusterDownOutput::DryRun(plan()),
             "Aborted" => ClusterDownOutput::Aborted,
             "Down" => ClusterDownOutput::Down { release_was_absent: false },
+        ],
+    );
+    m.insert(
+        "ClusterRollbackOutput",
+        samples![
+            "DryRun" => ClusterRollbackOutput::DryRun(plan()),
+            "Aborted" => ClusterRollbackOutput::Aborted,
+            "RolledBack" => ClusterRollbackOutput::RolledBack {
+                from_revision: 21,
+                to_revision: 19,
+                skipped: vec![20],
+                forced: false,
+            },
         ],
     );
 

--- a/cli/tests/cluster_rollback.rs
+++ b/cli/tests/cluster_rollback.rs
@@ -1,0 +1,755 @@
+//! `curie cluster rollback` (#1899): a bare `helm rollback` targets the
+//! immediately preceding revision, and on a cluster with no `runsc`
+//! RuntimeClass that is a FAILED one -- `cluster up` records a failed revision
+//! before its successful gVisor-off retry, so the history alternates
+//! failed/superseded. This file pins both halves of the fix:
+//!
+//! 1. The PURE selection (`select_rollback_revision`, `resolve_explicit_revision`,
+//!    `parse_helm_history`), which needs no cluster and no PATH games, so those
+//!    are plain `#[test]`s.
+//! 2. The WIRING: that the selected revision is the one actually handed to
+//!    `helm rollback`. A pure selector that is never plumbed through would pass
+//!    every test in layer 1 and still ship the bug.
+//!
+//! EVERY PATH-dependent assertion lives in ONE `#[tokio::test]`. `rollback()`
+//! resolves `helm` off the process PATH, so that test mutates process-global
+//! PATH (and env vars the fake `helm` reads); a second parallel test touching
+//! PATH in this file would race it. Each `tests/*.rs` file is its own test
+//! binary, so one such test here is race-free, and it saves and restores the
+//! original PATH. The pure tests below never touch PATH, so they cannot race it.
+
+use std::ffi::OsString;
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+
+use curie::exit::classify;
+use curie::ops::{
+    parse_helm_history, resolve_explicit_revision, rollback, select_rollback_revision,
+    ClusterRollbackOutput, CommonOpts, HelmRevision, RollbackChoice, RollbackOpts, RollbackTarget,
+};
+
+fn revision(revision: u32, status: &str) -> HelmRevision {
+    HelmRevision {
+        revision,
+        status: status.to_string(),
+        chart: "curie-0.7.3".to_string(),
+        description: "Upgrade complete".to_string(),
+    }
+}
+
+/// The exact history from issue #1899: eight alternating superseded/failed
+/// revisions from the runsc-less install loop, topped by the successful retry.
+fn issue_1899_history() -> Vec<HelmRevision> {
+    vec![
+        revision(13, "superseded"),
+        revision(14, "failed"),
+        revision(15, "superseded"),
+        revision(16, "failed"),
+        revision(17, "superseded"),
+        revision(18, "failed"),
+        revision(19, "superseded"),
+        revision(20, "failed"),
+        revision(21, "deployed"),
+    ]
+}
+
+fn eligible(history: &[HelmRevision]) -> RollbackChoice {
+    select_rollback_revision(history)
+        .expect("a non-empty history is selectable")
+        .require_eligible()
+        .expect("this history has an eligible revision")
+}
+
+// ---------------------------------------------------------------------------
+// Layer 1: the pure selection.
+// ---------------------------------------------------------------------------
+
+/// THE REGRESSION TEST for #1899. On the issue's own history the verb must land
+/// on 19, the newest `superseded` revision, and report that it stepped over 20 --
+/// which is precisely where a bare `helm rollback` would have gone.
+#[test]
+fn rollback_skips_the_failed_revision_bare_helm_would_target() {
+    let choice = eligible(&issue_1899_history());
+
+    assert_eq!(
+        choice.to_revision, 19,
+        "the newest deployed/superseded revision below the current one is 19"
+    );
+    assert_ne!(
+        choice.to_revision, 20,
+        "bare `helm rollback` would target 20, which helm marks failed"
+    );
+    assert_eq!(choice.from_revision, 21, "21 is the deployed revision");
+    assert!(
+        choice.skipped.contains(&20),
+        "the operator must be told 20 was passed over: {:?}",
+        choice.skipped
+    );
+    assert!(
+        !choice.forced,
+        "no override was needed for a superseded target"
+    );
+}
+
+/// The real recovery case: the newest revision FAILED, so helm marks nothing
+/// `deployed` at all. The current revision falls back to the highest one, and
+/// the selection still walks down to the newest superseded revision below it.
+/// Without that fallback the verb would refuse exactly when it is needed most.
+#[test]
+fn rollback_falls_back_to_the_highest_revision_when_none_is_deployed() {
+    let history = vec![
+        revision(1, "superseded"),
+        revision(2, "superseded"),
+        revision(3, "failed"),
+    ];
+
+    let choice = eligible(&history);
+
+    assert_eq!(
+        choice.from_revision, 3,
+        "the failed newest revision is current"
+    );
+    assert_eq!(choice.to_revision, 2);
+}
+
+#[test]
+fn a_single_revision_release_is_refused_rather_than_silently_doing_nothing() {
+    let target = select_rollback_revision(&[revision(1, "deployed")])
+        .expect("one revision is still a readable history");
+    assert!(matches!(
+        target,
+        RollbackTarget::NoEligible { current: 1, .. }
+    ));
+
+    let err = target
+        .require_eligible()
+        .expect_err("there is nothing below revision 1 to roll back to");
+    let shown = err.to_string();
+    assert!(
+        shown.contains("only revision"),
+        "the operator must be told why, not get a no-op: {shown}"
+    );
+}
+
+#[test]
+fn a_history_whose_every_prior_revision_failed_is_refused() {
+    let history = vec![
+        revision(1, "failed"),
+        revision(2, "failed"),
+        revision(3, "deployed"),
+    ];
+
+    let err = select_rollback_revision(&history)
+        .expect("a readable history")
+        .require_eligible()
+        .expect_err("no revision below 3 was ever known good");
+    let shown = err.to_string();
+    assert!(
+        shown.contains('1') && shown.contains('2'),
+        "the refusal must name the revisions it rejected: {shown}"
+    );
+    let (_class, fix) = classify(&err);
+    let fix = fix.unwrap_or_default();
+    assert!(
+        fix.contains("--allow-failed-revision"),
+        "the refusal must name the override that would proceed anyway: {fix}"
+    );
+}
+
+/// The four pending states, `uninstalling` and `unknown` are as ineligible as
+/// `failed`: helm never finished putting any of them on the cluster.
+#[test]
+fn only_deployed_and_superseded_revisions_are_eligible() {
+    let history = vec![
+        revision(1, "superseded"),
+        revision(2, "pending-upgrade"),
+        revision(3, "pending-rollback"),
+        revision(4, "uninstalling"),
+        revision(5, "unknown"),
+        revision(6, "deployed"),
+    ];
+
+    let choice = eligible(&history);
+
+    assert_eq!(choice.to_revision, 1);
+    assert_eq!(choice.skipped, vec![2, 3, 4, 5]);
+}
+
+#[test]
+fn an_explicit_revision_that_is_not_in_the_history_is_refused() {
+    let err = resolve_explicit_revision(&issue_1899_history(), 99, false)
+        .expect_err("helm would fail obscurely on a revision it does not have");
+    let shown = err.to_string();
+    assert!(
+        shown.contains("99") && shown.contains("13"),
+        "the refusal must say which revisions do exist: {shown}"
+    );
+}
+
+#[test]
+fn an_explicit_failed_revision_is_refused_until_the_override_is_passed() {
+    let err = resolve_explicit_revision(&issue_1899_history(), 20, false)
+        .expect_err("20 is failed, so it needs the explicit override");
+    let shown = err.to_string();
+    assert!(
+        shown.contains("failed"),
+        "the refusal must name the status it read: {shown}"
+    );
+    let (_class, fix) = classify(&err);
+    assert!(
+        fix.unwrap_or_default().contains("--allow-failed-revision"),
+        "the refusal must name the override"
+    );
+
+    let forced = resolve_explicit_revision(&issue_1899_history(), 20, true)
+        .expect("--allow-failed-revision admits it");
+    assert_eq!(forced.to_revision, 20);
+    assert!(
+        forced.forced,
+        "the output must record that it was overridden"
+    );
+}
+
+/// A real-shaped `helm history -o json` payload, extra fields and all.
+#[test]
+fn parse_helm_history_reads_a_real_helm_payload() {
+    let payload = r#"[
+      {"revision":19,"updated":"2026-08-20T09:11:02.1Z","status":"superseded","chart":"curie-0.7.3","app_version":"0.7.3","description":"Upgrade complete"},
+      {"revision":20,"updated":"2026-08-20T09:14:41.7Z","status":"failed","chart":"curie-0.7.3","app_version":"0.7.3","description":"failed to create resource: RuntimeClass \"gvisor\" not found"},
+      {"revision":21,"updated":"2026-08-20T09:14:58.3Z","status":"deployed","chart":"curie-0.7.3","app_version":"0.7.3","description":"Upgrade complete"}
+    ]"#;
+
+    let history = parse_helm_history(payload).expect("a real helm payload parses");
+
+    assert_eq!(history.len(), 3);
+    assert_eq!(history[1].status, "failed");
+    assert!(history[1].description.contains("gvisor"));
+    assert_eq!(eligible(&history).to_revision, 19);
+}
+
+/// A `revision` arriving as a string has to keep working: the shape has moved
+/// between helm releases, and a hard failure here would take the verb down on a
+/// cluster whose helm is a version older or newer than the one we tested on.
+#[test]
+fn parse_helm_history_tolerates_a_string_revision() {
+    let history = parse_helm_history(r#"[{"revision":"7","status":"deployed"}]"#)
+        .expect("a string revision is still a revision");
+    assert_eq!(history[0].revision, 7);
+}
+
+#[test]
+fn parse_helm_history_refuses_malformed_output_without_panicking() {
+    let err =
+        parse_helm_history("Error: release: not found").expect_err("helm prose is not a history");
+    let (_class, fix) = classify(&err);
+    assert!(
+        fix.unwrap_or_default().contains("helm history"),
+        "a parse failure must tell the operator what to run by hand"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Layer 2: the wiring, through a fake `helm` on PATH.
+// ---------------------------------------------------------------------------
+
+/// Write `body` to `dir/name` and mark it executable (0o755).
+fn write_exec(dir: &Path, name: &str, body: &str) {
+    let path = dir.join(name);
+    fs::write(&path, body).expect("write fake executable");
+    let mut perms = fs::metadata(&path).expect("stat fake").permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&path, perms).expect("chmod fake executable");
+}
+
+/// Prepend `dir` to the current process PATH so its fake binaries win resolution.
+fn prepend_path(dir: &Path) {
+    let existing = std::env::var_os("PATH").unwrap_or_default();
+    let mut paths = vec![dir.to_path_buf()];
+    paths.extend(std::env::split_paths(&existing));
+    let joined = std::env::join_paths(paths).expect("join PATH");
+    std::env::set_var("PATH", joined);
+}
+
+/// Restore PATH to the exact value captured at the start of the test.
+fn restore_path(original: &Option<OsString>) {
+    match original {
+        Some(p) => std::env::set_var("PATH", p),
+        None => std::env::remove_var("PATH"),
+    }
+}
+
+/// A release whose name differs from its namespace, so an assertion on the
+/// recorded argv unambiguously locks each token to the flag it came from.
+fn rollback_opts(revision: Option<u32>, allow_failed_revision: bool) -> RollbackOpts {
+    RollbackOpts {
+        common: CommonOpts {
+            namespace: "agent-ns".into(),
+            release: "prod-release".into(),
+            dry_run: false,
+        },
+        revision,
+        allow_failed_revision,
+        // Always: an unanswered prompt would hang the test binary.
+        yes: true,
+    }
+}
+
+#[tokio::test]
+async fn rollback_hands_helm_the_selected_revision() {
+    let original_path = std::env::var_os("PATH");
+    let dir = tempfile::tempdir().expect("tempdir");
+
+    // The issue's history, served by the fake `helm history`.
+    let history_json = dir.path().join("history.json");
+    fs::write(
+        &history_json,
+        r#"[
+          {"revision":13,"status":"superseded","chart":"curie-0.7.3","description":"Upgrade complete"},
+          {"revision":14,"status":"failed","chart":"curie-0.7.3","description":"RuntimeClass \"gvisor\" not found"},
+          {"revision":15,"status":"superseded","chart":"curie-0.7.3","description":"Upgrade complete"},
+          {"revision":16,"status":"failed","chart":"curie-0.7.3","description":"RuntimeClass \"gvisor\" not found"},
+          {"revision":17,"status":"superseded","chart":"curie-0.7.3","description":"Upgrade complete"},
+          {"revision":18,"status":"failed","chart":"curie-0.7.3","description":"RuntimeClass \"gvisor\" not found"},
+          {"revision":19,"status":"superseded","chart":"curie-0.7.3","description":"Upgrade complete"},
+          {"revision":20,"status":"failed","chart":"curie-0.7.3","description":"RuntimeClass \"gvisor\" not found"},
+          {"revision":21,"status":"deployed","chart":"curie-0.7.3","description":"Upgrade complete"}
+        ]"#,
+    )
+    .expect("write fake history");
+
+    // Records the FULL argv of every `helm rollback`, one invocation per line:
+    // the argv is the user-visible contract this whole verb exists to change.
+    let rollback_log = dir.path().join("rollback-argv.log");
+    std::env::set_var("FAKE_HELM_HISTORY", &history_json);
+    std::env::set_var("FAKE_HELM_ROLLBACK_LOG", &rollback_log);
+    write_exec(
+        dir.path(),
+        "helm",
+        "#!/bin/sh\n\
+         case \"$1\" in\n\
+         history) cat \"$FAKE_HELM_HISTORY\" ;;\n\
+         rollback) echo \"$*\" >> \"$FAKE_HELM_ROLLBACK_LOG\"; echo 'Rollback was a success.' ;;\n\
+         *) echo \"unexpected helm verb: $1\" >&2; exit 1 ;;\n\
+         esac\n",
+    );
+    prepend_path(dir.path());
+
+    // ----- The default path: no --revision -----
+    let out = rollback(rollback_opts(None, false))
+        .await
+        .expect("the issue's history has an eligible revision");
+    match out {
+        ClusterRollbackOutput::RolledBack {
+            from_revision,
+            to_revision,
+            skipped,
+            forced,
+        } => {
+            assert_eq!(from_revision, 21);
+            assert_eq!(to_revision, 19);
+            assert_eq!(
+                skipped,
+                vec![20],
+                "AC2: the passed-over revision is reported"
+            );
+            assert!(!forced);
+        }
+        other => panic!("expected a completed rollback, got {other:?}"),
+    }
+    // The end-to-end proof: the selector is genuinely wired to the invocation.
+    let logged = fs::read_to_string(&rollback_log).expect("helm rollback ran");
+    assert_eq!(
+        logged.trim(),
+        "rollback prod-release 19 -n agent-ns",
+        "helm must be handed revision 19, not the 20 a bare `helm rollback` would take"
+    );
+
+    // ----- AC3: an explicit failed revision is refused, by execution -----
+    let err = rollback(rollback_opts(Some(20), false))
+        .await
+        .expect_err("20 is failed, so it must not go through without the override");
+    let shown = err.to_string();
+    assert!(
+        shown.contains("failed"),
+        "the operator must read the status that blocked it: {shown}"
+    );
+    let (_class, fix) = classify(&err);
+    assert!(
+        fix.unwrap_or_default().contains("--allow-failed-revision"),
+        "the refusal must name the override"
+    );
+    assert_eq!(
+        fs::read_to_string(&rollback_log).unwrap().lines().count(),
+        1,
+        "the refused run must not have invoked helm rollback at all"
+    );
+
+    // ----- AC3: with the override, the same revision proceeds -----
+    let out = rollback(rollback_opts(Some(20), true))
+        .await
+        .expect("--allow-failed-revision admits revision 20");
+    match out {
+        ClusterRollbackOutput::RolledBack {
+            to_revision,
+            forced,
+            ..
+        } => {
+            assert_eq!(to_revision, 20);
+            assert!(forced, "the output must record the override");
+        }
+        other => panic!("expected a completed rollback, got {other:?}"),
+    }
+    let logged = fs::read_to_string(&rollback_log).expect("helm rollback ran again");
+    assert_eq!(
+        logged.lines().last().unwrap(),
+        "rollback prod-release 20 -n agent-ns"
+    );
+
+    // ----- AC6: a release helm cannot find fails HERE, not as "no eligible revision" -----
+    write_exec(
+        dir.path(),
+        "helm",
+        "#!/bin/sh\necho 'Error: release: not found' >&2\nexit 1\n",
+    );
+    let err = rollback(rollback_opts(None, false))
+        .await
+        .expect_err("an unreadable history is a hard failure");
+    let shown = err.to_string();
+    assert!(
+        shown.contains("release: not found") && shown.contains("prod-release"),
+        "the operator must see helm's own reason and the release name: {shown}"
+    );
+    assert!(
+        !shown.contains("no revision is safe"),
+        "a missing release must never be reported as an ineligible history: {shown}"
+    );
+
+    // Restore PATH so nothing else in this process observes the fakes.
+    restore_path(&original_path);
+}
+
+// ---------------------------------------------------------------------------
+// Layer 1 (continued): the gaps an adversarial read of the above found.
+// ---------------------------------------------------------------------------
+
+/// The bug this pins was real: `skipped_between` had no status filter, so an
+/// explicit `--revision 15` on the issue's history reported every revision in
+/// the gap -- including 17 and 19, which are `superseded` -- and labelled them
+/// "not deployed/superseded". `skipped` is an operator-facing claim about
+/// WHY a revision was passed over, so a perfectly good revision must never
+/// appear in it.
+#[test]
+fn skipped_lists_only_ineligible_revisions_not_every_revision_stepped_over() {
+    let choice = resolve_explicit_revision(&issue_1899_history(), 15, false)
+        .expect("15 is superseded, so no override is needed");
+
+    assert_eq!(choice.to_revision, 15);
+    assert_eq!(choice.from_revision, 21);
+    assert_eq!(
+        choice.skipped,
+        vec![16, 18, 20],
+        "only the failed revisions in the gap were passed over for a reason"
+    );
+    assert!(
+        !choice.skipped.contains(&17) && !choice.skipped.contains(&19),
+        "17 and 19 are superseded; calling them not deployed/superseded is a false claim: {:?}",
+        choice.skipped
+    );
+    assert!(!choice.forced, "a superseded target needs no override");
+}
+
+/// `helm history` can return an empty array (a release mid-uninstall). Both
+/// entry points must refuse it with the operator's next step, not panic on the
+/// `max()` of an empty iterator.
+#[test]
+fn an_empty_history_is_refused_rather_than_panicking() {
+    let err = select_rollback_revision(&[]).expect_err("there is nothing to roll back to");
+    let shown = err.to_string();
+    assert!(
+        shown.contains("no revisions"),
+        "the operator must be told the history was empty: {shown}"
+    );
+    let (_class, fix) = classify(&err);
+    assert!(
+        fix.unwrap_or_default().contains("helm list"),
+        "the refusal must name how to check the release exists"
+    );
+
+    let err = resolve_explicit_revision(&[], 3, false)
+        .expect_err("an explicit revision cannot be resolved against an empty history");
+    assert!(err.to_string().contains("no revisions"));
+}
+
+/// The current revision is the `deployed` one, NOT the highest one: a
+/// `pending-upgrade` row sits ABOVE `deployed` while a helm upgrade is in
+/// flight. Selecting from the top of the history instead would step the release
+/// back to where it already is and report the in-flight revision as skipped.
+#[test]
+fn the_deployed_revision_is_current_even_when_a_newer_revision_sits_above_it() {
+    let history = vec![
+        revision(1, "superseded"),
+        revision(2, "superseded"),
+        revision(3, "deployed"),
+        revision(4, "pending-upgrade"),
+    ];
+
+    let choice = eligible(&history);
+
+    assert_eq!(
+        choice.from_revision, 3,
+        "3 is deployed; 4 is still in flight"
+    );
+    assert_eq!(choice.to_revision, 2, "selection happens below the current");
+    assert!(
+        choice.skipped.is_empty(),
+        "4 is above the current revision, so it was never stepped over: {:?}",
+        choice.skipped
+    );
+}
+
+/// A history can carry more than one `deployed` row -- helm has left them
+/// behind after an interrupted upgrade. Pin the reading rather than leaving it
+/// incidental: the NEWEST deployed revision is where the release is now.
+#[test]
+fn more_than_one_deployed_row_resolves_to_the_newest_of_them() {
+    let history = vec![
+        revision(1, "superseded"),
+        revision(2, "deployed"),
+        revision(3, "failed"),
+        revision(4, "deployed"),
+    ];
+
+    let choice = eligible(&history);
+
+    assert_eq!(
+        choice.from_revision, 4,
+        "the newest deployed row is current"
+    );
+    assert_eq!(choice.to_revision, 2);
+    assert_eq!(choice.skipped, vec![3]);
+}
+
+/// Naming the revision the release is already on is resolved, not refused, and
+/// reports nothing skipped -- there is no gap to step over. Pinned because an
+/// off-by-one in the `< current` filters would show up here first.
+#[test]
+fn an_explicit_revision_equal_to_the_current_one_skips_nothing() {
+    let choice = resolve_explicit_revision(&issue_1899_history(), 21, false)
+        .expect("21 is the deployed revision");
+
+    assert_eq!(choice.from_revision, 21);
+    assert_eq!(choice.to_revision, 21);
+    assert!(
+        choice.skipped.is_empty(),
+        "nothing lies between 21 and itself: {:?}",
+        choice.skipped
+    );
+    assert!(!choice.forced);
+}
+
+/// A truncated or corrupt helm secret can yield two rows for one revision.
+/// `parse_helm_history` sorts the INELIGIBLE row first so the `find` in
+/// `resolve_explicit_revision` reads the worse of the two: a revision whose
+/// history disagrees with itself must refuse rather than roll back to a
+/// manifest that may never have been applied. The skipped list must not report
+/// the same number twice either.
+#[test]
+fn duplicate_revision_rows_refuse_rather_than_admitting_the_eligible_twin() {
+    let payload = r#"[
+      {"revision":19,"status":"superseded","chart":"curie-0.7.3","description":"Upgrade complete"},
+      {"revision":20,"status":"superseded","chart":"curie-0.7.3","description":"Upgrade complete"},
+      {"revision":20,"status":"failed","chart":"curie-0.7.3","description":"RuntimeClass \"gvisor\" not found"},
+      {"revision":21,"status":"deployed","chart":"curie-0.7.3","description":"Upgrade complete"}
+    ]"#;
+    let history = parse_helm_history(payload).expect("a duplicated revision still parses");
+
+    let err = resolve_explicit_revision(&history, 20, false)
+        .expect_err("a revision whose history disagrees with itself must not go through");
+    let shown = err.to_string();
+    assert!(
+        shown.contains("failed"),
+        "the refusal must read the ineligible twin, not the flattering one: {shown}"
+    );
+
+    let choice = eligible(&history);
+    assert_eq!(choice.to_revision, 19, "20 is not trustworthy, 19 is");
+    assert_eq!(
+        choice.skipped,
+        vec![20],
+        "one revision passed over is reported once, not once per row: {:?}",
+        choice.skipped
+    );
+}
+
+/// The `fix` hint only reaches an agent under `--json`; a human on a TTY sees
+/// the message alone. The override has to be named in the sentence the operator
+/// actually reads, or the refusal is a dead end for them.
+#[test]
+fn the_ineligible_status_refusal_names_the_override_in_its_own_message() {
+    let err =
+        resolve_explicit_revision(&issue_1899_history(), 18, false).expect_err("18 is failed");
+    let shown = err.to_string();
+    assert!(
+        shown.contains("--allow-failed-revision"),
+        "a human never sees the --json fix hint, so the message must carry it: {shown}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Layer 3: the binary, with a fake `helm` on the CHILD's PATH only.
+// ---------------------------------------------------------------------------
+//
+// These run `curie cluster rollback` as a subprocess, so PATH is set per child
+// via `Command::env` and this process's own PATH is never touched -- they
+// cannot race the one PATH-mutating test above. That is also the only way to
+// assert the operator-visible stderr notes, which no in-process test can read.
+
+/// Install a fake `helm` in `dir` that serves `history_json` and appends every
+/// invocation's argv to `dir/helm-argv.log`.
+fn fake_helm_dir(history_json: &str) -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let history = dir.path().join("history.json");
+    fs::write(&history, history_json).expect("write fake history");
+    write_exec(
+        dir.path(),
+        "helm",
+        &format!(
+            "#!/bin/sh\n\
+             echo \"$*\" >> '{log}'\n\
+             case \"$1\" in\n\
+             history) cat '{history}' ;;\n\
+             rollback) echo 'Rollback was a success.' ;;\n\
+             *) echo \"unexpected helm verb: $1\" >&2; exit 1 ;;\n\
+             esac\n",
+            log = dir.path().join("helm-argv.log").display(),
+            history = history.display(),
+        ),
+    );
+    dir
+}
+
+/// `curie cluster rollback` against that fake helm, with PATH scoped to the
+/// child process.
+fn run_rollback(dir: &Path, args: &[&str]) -> std::process::Output {
+    let existing = std::env::var_os("PATH").unwrap_or_default();
+    let mut paths = vec![dir.to_path_buf()];
+    paths.extend(std::env::split_paths(&existing));
+    std::process::Command::new(env!("CARGO_BIN_EXE_curie"))
+        .args(["cluster", "rollback"])
+        .args(["--namespace", "agent-ns", "--release", "prod-release"])
+        .args(args)
+        .env("PATH", std::env::join_paths(paths).expect("join PATH"))
+        // Plain text, and never an unanswered prompt in a test binary.
+        .env("NO_COLOR", "1")
+        .output()
+        .expect("run curie cluster rollback")
+}
+
+fn helm_log(dir: &Path) -> String {
+    fs::read_to_string(dir.join("helm-argv.log")).unwrap_or_default()
+}
+
+/// The AC2 note claims "a bare `helm rollback` would have targeted N" -- and
+/// helm's own default target is always `from - 1`. On an explicit `--revision`
+/// the highest SKIPPED revision need not be that one, and naming it as helm's
+/// target would be a fabrication printed to an operator mid-incident. Both
+/// branches, because a note that always claimed it would pass a test of only
+/// the first.
+#[test]
+fn the_bare_helm_claim_is_made_only_when_the_skipped_revision_is_the_one_helm_would_target() {
+    // Auto-select on the issue's history: 20 is skipped AND is 21 - 1.
+    let dir = fake_helm_dir(
+        r#"[
+          {"revision":19,"status":"superseded","chart":"curie-0.7.3","description":"Upgrade complete"},
+          {"revision":20,"status":"failed","chart":"curie-0.7.3","description":"RuntimeClass \"gvisor\" not found"},
+          {"revision":21,"status":"deployed","chart":"curie-0.7.3","description":"Upgrade complete"}
+        ]"#,
+    );
+    let out = run_rollback(dir.path(), &["--yes"]);
+    let shown = String::from_utf8_lossy(&out.stderr).to_string();
+    assert!(out.status.success(), "rollback failed: {shown}");
+    assert!(
+        shown.contains("skipped revision(s) 20") && shown.contains("would have targeted 20"),
+        "the operator must be told bare helm would have landed on the failed 20: {shown}"
+    );
+
+    // Explicit --revision 17: the only INELIGIBLE skipped revision is 18, while
+    // helm's own target would have been 20 -- which is superseded and fine.
+    let dir = fake_helm_dir(
+        r#"[
+          {"revision":17,"status":"superseded","chart":"curie-0.7.3","description":"Upgrade complete"},
+          {"revision":18,"status":"failed","chart":"curie-0.7.3","description":"RuntimeClass \"gvisor\" not found"},
+          {"revision":19,"status":"superseded","chart":"curie-0.7.3","description":"Upgrade complete"},
+          {"revision":20,"status":"superseded","chart":"curie-0.7.3","description":"Upgrade complete"},
+          {"revision":21,"status":"deployed","chart":"curie-0.7.3","description":"Upgrade complete"}
+        ]"#,
+    );
+    let out = run_rollback(dir.path(), &["--yes", "--revision", "17"]);
+    let shown = String::from_utf8_lossy(&out.stderr).to_string();
+    assert!(out.status.success(), "rollback failed: {shown}");
+    assert!(
+        shown.contains("skipped revision(s) 18"),
+        "18 is the one revision passed over for a reason: {shown}"
+    );
+    assert!(
+        !shown.contains("would have targeted"),
+        "bare helm would have targeted 20, which is superseded, so the claim is false here: {shown}"
+    );
+    assert!(
+        helm_log(dir.path()).contains("rollback prod-release 17 -n agent-ns"),
+        "the explicit revision must be the one handed to helm"
+    );
+}
+
+/// `--dry-run` prints the plan and runs NOTHING: not even the `helm history`
+/// read, since the fake helm records every invocation it receives. Both
+/// spellings, because the plan can only name the target revision when the
+/// operator did -- deleting either half of the early return leaves the fake
+/// helm's log non-empty.
+#[test]
+fn dry_run_names_the_plan_and_runs_no_helm_command_at_all() {
+    let history = r#"[
+      {"revision":19,"status":"superseded","chart":"curie-0.7.3","description":"Upgrade complete"},
+      {"revision":20,"status":"failed","chart":"curie-0.7.3","description":"RuntimeClass \"gvisor\" not found"},
+      {"revision":21,"status":"deployed","chart":"curie-0.7.3","description":"Upgrade complete"}
+    ]"#;
+
+    // ----- No --revision: the target is a function of a history it has not read -----
+    let dir = fake_helm_dir(history);
+    let out = run_rollback(dir.path(), &["--dry-run"]);
+    let plan = String::from_utf8_lossy(&out.stdout).to_string();
+    assert!(
+        out.status.success(),
+        "a dry run must exit clean: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        plan.contains("helm history prod-release -n agent-ns -o json --max 256"),
+        "the plan must name the history read: {plan}"
+    );
+    assert!(
+        plan.contains("helm rollback prod-release <selected-revision> -n agent-ns"),
+        "with no --revision the plan cannot name a revision it never read: {plan}"
+    );
+    assert_eq!(
+        helm_log(dir.path()),
+        "",
+        "a dry run must not invoke helm even to read the history"
+    );
+
+    // ----- With --revision: the plan names the exact revision, still runs nothing -----
+    let dir = fake_helm_dir(history);
+    let out = run_rollback(dir.path(), &["--dry-run", "--revision", "19"]);
+    let plan = String::from_utf8_lossy(&out.stdout).to_string();
+    assert!(out.status.success());
+    assert!(
+        plan.contains("helm rollback prod-release 19 -n agent-ns"),
+        "an operator-named revision belongs in the plan: {plan}"
+    );
+    assert_eq!(
+        helm_log(dir.path()),
+        "",
+        "a dry run must mutate nothing, --revision or not"
+    );
+}

--- a/cli/tests/json_contract.rs
+++ b/cli/tests/json_contract.rs
@@ -884,7 +884,10 @@ use curie::comms::CommsOutput;
 use curie::local::{
     LocalDownOutput, LocalRebuildOutput, LocalStatusOutput, LocalUpOutput, ModelMode,
 };
-use curie::ops::{ClusterDownOutput, ClusterStatus, ClusterStatusOutput, ClusterUpOutput, PodRow};
+use curie::ops::{
+    ClusterDownOutput, ClusterRollbackOutput, ClusterStatus, ClusterStatusOutput, ClusterUpOutput,
+    PodRow,
+};
 use curie::secrets::SecretsListOutput;
 
 fn assert_valid(schema_file: &str, value: &serde_json::Value) {
@@ -1852,6 +1855,32 @@ fn cluster_down_output_validates_all_variants() {
         lines: vec!["helm uninstall".to_string()],
     });
     assert_valid("cluster-down.schema.json", &dry.to_json());
+}
+
+#[test]
+fn cluster_rollback_output_validates_all_variants() {
+    let dry = ClusterRollbackOutput::DryRun(DryRunPlan {
+        lines: vec!["helm rollback".to_string()],
+    });
+    assert_valid("cluster-rollback.schema.json", &dry.to_json());
+    assert_valid(
+        "cluster-rollback.schema.json",
+        &ClusterRollbackOutput::Aborted.to_json(),
+    );
+    let rolled_back = ClusterRollbackOutput::RolledBack {
+        from_revision: 4,
+        to_revision: 3,
+        skipped: vec![],
+        forced: false,
+    };
+    assert_valid("cluster-rollback.schema.json", &rolled_back.to_json());
+    let forced = ClusterRollbackOutput::RolledBack {
+        from_revision: 5,
+        to_revision: 2,
+        skipped: vec![4, 3],
+        forced: true,
+    };
+    assert_valid("cluster-rollback.schema.json", &forced.to_json());
 }
 
 #[test]

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -29,7 +29,7 @@ is documentation of where the code already draws the line, not a new abstraction
 | Memory | CLEAN | 1 loader (StateApiMemoryStore) | not separately graded | #28 | [Memory](interfaces/memory/INTERFACE.md) |
 | Conversation history | CLEAN | 1 loader (StateApiTranscriptStore) | not separately graded | #20 | [Conversation history](interfaces/conversation-history/INTERFACE.md) |
 | Triggers | SOFT | 3 hardcoded (Slack, GH push, commit poll) | not separately graded | #29 | [Triggers](interfaces/triggers/INTERFACE.md) |
-| CLI output (agent-facing `--json`) | CLEAN | 40 outputs behind one trait | not separately graded | #456 | [CLI output (agent-facing `--json`)](interfaces/cli-output/INTERFACE.md) |
+| CLI output (agent-facing `--json`) | CLEAN | 41 outputs behind one trait | not separately graded | #456 | [CLI output (agent-facing `--json`)](interfaces/cli-output/INTERFACE.md) |
 | Harness package (declared contribution) | CLEAN | 1 (built-in Claude) behind the entry-point registry | not separately graded | #844 | [Harness package (declared contribution)](interfaces/harness-package/INTERFACE.md) |
 | Connector host (bundle-declared MCP servers) | CLEAN | 1 (Kubernetes) + in-memory fake | not separately graded | #1063, #1184 | [Connector host (bundle-declared MCP servers)](interfaces/connector-host/INTERFACE.md) |
 | Sealed credential (cluster-sealed connector secrets) | SOFT | 2 halves (Rust sealer, Python opener) over one frozen wire | not separately graded | #1240 | [Sealed credential (cluster-sealed connector secrets)](interfaces/sealed-credential/INTERFACE.md) |

--- a/docs/interfaces/cli-output/INTERFACE.md
+++ b/docs/interfaces/cli-output/INTERFACE.md
@@ -1,7 +1,7 @@
 ---
 seam: CLI output (agent-facing `--json`)
 kind: CLEAN
-impls: 40 outputs behind one trait
+impls: 41 outputs behind one trait
 grade: not separately graded
 epics:
   - "#456"
@@ -13,7 +13,7 @@ order: 18
 > Part of the Curie swappable-seam catalog — see the [seam index](../../interfaces.md).
 
 <!-- BEGIN GENERATED: header (curie dev docs-lint) -->
-> **Kind:** CLEAN &nbsp;·&nbsp; **Implementations today:** 40 outputs behind one trait &nbsp;·&nbsp; **Swap-readiness grade:** not separately graded
+> **Kind:** CLEAN &nbsp;·&nbsp; **Implementations today:** 41 outputs behind one trait &nbsp;·&nbsp; **Swap-readiness grade:** not separately graded
 <!-- END GENERATED: header -->
 
 **Kind legend:** CLEAN = a real `Protocol`/typed port class · SOFT = swap via env/URL/prefix/wire, no code interface · NONE = not built yet.
@@ -65,7 +65,7 @@ This is the catalog's first **Rust** seam. It is listed here because the agent-f
 
 ## Implementations today
 
-40 `CliOutput` implementations, all in the CLI crate, grouped by owning module:
+41 `CliOutput` implementations, all in the CLI crate, grouped by owning module:
 
 - **`DryRunPlan`** (`cli/src/ui.rs`) — the generic `--dry-run` plan; JSON is
   `{"dry_run":true,"plan":[lines]}` and the human render is the same lines verbatim,
@@ -83,7 +83,8 @@ This is the catalog's first **Rust** seam. It is listed here because the agent-f
   `SkillApprovalsOutput`, `OverridesOutput`.
 - **`cli/src/local.rs`** and **`cli/src/ops.rs`**, the operator verbs, one output per
   verb per tier: `LocalUpOutput`, `LocalRebuildOutput`, `LocalStatusOutput`,
-  `LocalDownOutput`; `ClusterUpOutput`, `ClusterStatusOutput`, `ClusterDownOutput`.
+  `LocalDownOutput`; `ClusterUpOutput`, `ClusterStatusOutput`, `ClusterDownOutput`,
+  `ClusterRollbackOutput`.
 - **`cli/src/message.rs`**: `MessageDryRunOutput` and `MessageOutcomeOutput`, the
   multi-variant outcome whose covered variant set the enum-variant walk derives (see
   Known leakage).
@@ -115,10 +116,10 @@ That set is not hand-maintained prose: `cli/schema/index.json` carries one
   syntactic call-site inventory, not a type-level proof that *every* verb returns
   a `CliOutput`.
 - **Committed JSON Schemas with a drift gate (since #841).** Each `to_json` is no
-  longer schema-free: there are 40 committed schemas under `cli/schema/` with an
+  longer schema-free: there are 41 committed schemas under `cli/schema/` with an
   index (`cli/schema/index.json`), a `syn`-based inventory gate over every `impl
-  CliOutput`, and per-family output validation — all 40 are validated against real
-  `to_json()` output across 66 tests in `cli/tests/json_contract.rs`. Those tests
+  CliOutput`, and per-family output validation — all 41 are validated against real
+  `to_json()` output across 67 tests in `cli/tests/json_contract.rs`. Those tests
   drive each output type's `to_json()` once per output variant rather than calling
   the pure builder functions behind it, so a variant whose `to_json()` arm drifts
   from the schema is caught even when the builder it delegates to still validates.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -199,6 +199,44 @@ once the cluster is reachable again. See ADR-0064 (Architecture Decision
 Record; `docs/adr/0064-fail-forward-cluster-teardown.md`) for the full
 fail-forward design.
 
+### `curie cluster rollback`
+
+```bash
+curie cluster rollback
+```
+
+| Flag | What it does |
+|---|---|
+| `--revision <n>` | Roll back to this exact revision instead of the newest safe one. |
+| `--allow-failed-revision` | Permit a `--revision` that Helm never finished applying. |
+| `--yes` | Skip the confirmation prompt. |
+| `--dry-run` | Print the commands that would run and exit. |
+
+`curie cluster rollback` puts the release back on the newest revision that
+Helm actually finished applying.
+
+That is not what a bare `helm rollback` does, and the difference bites on a
+cluster without gVisor. `cluster up` tries the install with the chart's
+gVisor default first; if the cluster has no `runsc` RuntimeClass, that attempt
+is recorded as a **failed** Helm revision before the successful retry with
+gVisor off. Do that a few times and the release history alternates
+failed/superseded/failed/superseded. `helm rollback` with no revision targets
+the immediately preceding revision -- which, on that history, is a failed one:
+a manifest Helm never finished putting on the cluster. Rolling back to it does
+not restore a working release, it re-applies a broken one.
+
+So this verb reads the history first, skips every revision whose status is not
+`deployed` or `superseded`, and rolls back to the newest one that is. It prints
+which revisions it passed over, so you can see exactly what a bare
+`helm rollback` would have landed on instead.
+
+If you know which revision you want, `--revision <n>` takes it. A revision that
+isn't in the history is refused, and so is one Helm never finished applying --
+unless you also pass `--allow-failed-revision` to say you accept that. If no
+revision is safe to roll back to (a first install, or a release whose every
+prior revision failed), the command tells you so rather than doing nothing or
+rolling back to something broken. See issue #1899 for the original report.
+
 ## Deploying your plugin bundle onto the Curie platform
 
 ### Manually, with `curie cluster deploy`


### PR DESCRIPTION
## Summary

On a cluster with no `runsc` RuntimeClass, `curie cluster up` records a **failed** Helm revision before its successful retry, so the release history alternates failed/superseded. `curie cluster` exposed no rollback verb, so the reflex during an incident is a bare `helm rollback <release>` — which targets the immediately preceding revision, a `failed` one whose manifest helm never finished applying.

This adds `curie cluster rollback`. It reads `helm history` and targets the newest revision below the current one whose status is `deployed` or `superseded`, naming on stderr every revision it passed over and what a bare rollback would have hit instead. `--revision` targets one explicitly and refuses a status helm never finished applying unless `--allow-failed-revision` admits it; that refusal names the override in the sentence a human reads, since the `fix` hint only reaches `--json`. Eligibility is a property of the revision rather than of a history row, so a revision whose rows contradict each other resolves to its ineligible reading on both the auto-select and explicit paths.

## Related issue

Ref #1899

This is issue #1899's suggestion (3). **It does not close the issue.** Suggestion (1) — preserve the inferred `security.gvisor.mode` — already landed on `main` as `resolve_preserved_gvisor_mode_value` (e43deb66). Suggestion (2), moving the admission probe before the first `helm upgrade` so the inference costs no revision, is still open and is deliberately not attempted here: it would redesign the documented gVisor admission/retry flow, which is a maintainer decision. Preservation stops *new* failed revisions from being recorded; it cannot repair a history that already alternates, which is what this verb is for.

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | The verb wraps Helm on a cluster release; the skill tier has no Helm release. | — | — |
| local | n/a | Compose stack has no Helm release either. | — | — |
| local-release | n/a | Same. | — | — |
| cluster | Blocked | No runsc-less cluster with an alternating release history was available to this run. Substituted the strongest available proof: the real `curie` binary driven against a fake `helm` on PATH that returns issue #1899's exact 13–21 history, asserting the argv actually handed to helm. | fake helm, real binary | `curie cluster rollback --yes --json` → `{"forced":false,"from_revision":21,"rolled_back":true,"skipped":[20],"to_revision":19}`, and the recorded helm argv was `rollback curie 19 -n curie`. A bare `helm rollback` would have targeted 20, which helm marks `failed`. |
| live provider | n/a | No model call on this path. | — | — |
| external integration | n/a | No external service. | — | — |

Guards demonstrated by execution, not by reading code (same fake-helm harness, real binary):

- `curie cluster rollback --revision 20` → refused, exit 2: ``revision 20 has status `failed`, not `deployed` or `superseded`; … pass --allow-failed-revision to roll back to it anyway``
- `curie cluster rollback --revision 20 --allow-failed-revision` → proceeds, argv `rollback curie 20 -n curie`, with a warning that helm never finished applying it
- `curie cluster rollback --revision 99` → refused, exit 2, listing the revisions the history actually has
- Every prior revision failed → refused, exit 1, rather than a silent no-op
- `helm history` failing → reported with helm's own words, not as a misleading "no eligible revision"
- `curie cluster rollback --dry-run` → prints the plan and invokes no helm command at all (asserted by an empty invocation log)
- `curie cluster rollback --allow-failed-revision` without `--revision` → rejected at parse time rather than silently ignored

Falsifiable negative: reverting the eligibility filter in `select_rollback_revision` (the one-line mutation `.filter(|r| r.revision < current)`) turns **8 of the 20** tests in `cli/tests/cluster_rollback.rs` red, including `rollback_skips_the_failed_revision_bare_helm_would_target` and the argv-level wiring test.

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [ ] No required tier is left unproved; the cluster tier names its blocker in the table above and substitutes an argv-level proof against the real binary.
- [ ] Or: this change is not behavior-bearing, so no tier applies, and the summary says why.

## Checklist

- [x] Tests pass for the area I touched: `cargo test --locked` — 1521 passed, 0 failed, 62 suites. Also `cargo fmt --check`, `cargo clippy --locked -- -D warnings`, `bash cli/scripts/refresh-schema-baseline.sh --check`, and `bash scripts/check-docs.sh`, all clean.
- [x] Docs updated: `docs/operations.md` gains a `curie cluster rollback` section, `cli/README.md` gains the verb and adds it to the `--yes` non-interactive inventory, and `docs/interfaces/cli-output/INTERFACE.md` records the new `ClusterRollbackOutput` family.
- [x] No ADR: this adds an operator verb at the same altitude as its `cluster up`/`down`/`status` siblings and changes no existing behavior or contract.

## Notes for the reviewer

Two things surfaced during review and were deliberately left as-is rather than expanded into scope:

- `--revision` equal to the current revision is accepted. `helm rollback` to the live revision is effectively a no-op deploy that still burns a revision; it may deserve a refusal.
- `helm_rollback_cmd` passes no `--wait`/`--timeout`, so the command can report success while pods are still rolling.
