### PR TITLE
Refuse --migrate-store removals the migration cannot carry

### DIFF
--- a/cli/src/installation.rs
+++ b/cli/src/installation.rs
@@ -871,6 +871,17 @@ async fn guard_stateful_removal(
     Ok(GuardVerdict::WouldRemove(removed))
 }
 
+/// The one rendering of a component the target chart does not render at all.
+/// Both refusals show this line, and an operator matching what one message
+/// said against what the other says needs them identical, so the phrasing
+/// lives once (#1501).
+fn component_gone_line(removal: &crate::ops::StatefulRemoval) -> String {
+    format!(
+        "{} ({}, not rendered at all)",
+        removal.name, removal.component
+    )
+}
+
 /// The refusal text, factored out so its ordering is testable with no cluster.
 ///
 /// Branches on the CAUSE, because the two causes need opposite advice and a
@@ -885,9 +896,7 @@ fn stateful_removal_message(removed: &[crate::ops::StatefulRemoval]) -> String {
     let listed = removed
         .iter()
         .map(|r| match &r.cause {
-            RemovalCause::ComponentGone => {
-                format!("{} ({}, not rendered at all)", r.name, r.component)
-            }
+            RemovalCause::ComponentGone => component_gone_line(r),
             RemovalCause::RenamedTo(to) => format!("{} -> {}", r.name, to),
         })
         .collect::<Vec<_>>()
@@ -1017,13 +1026,32 @@ pub async fn apply(opts: ApplyOpts) -> Result<ApplyOutput> {
         // the private values file.
         match guard_stateful_removal(&up, &up_values).await? {
             GuardVerdict::Clear => false,
+            // All-ComponentGone was the whole bypass condition, and it is only
+            // HALF the question. `--migrate-store` carries the OBJECT STORE and
+            // nothing else -- `migrate_store::detect_store` knows `minio` and
+            // `rustfs` -- so a batch of {minio gone, postgres gone} (postgres
+            // goes ComponentGone the moment target values set
+            // `postgres.deploy=false`) passed the check, and apply migrated the
+            // store while silently DELETING the database beside it, exit 0
+            // (#1501). The cause says the data must be carried; only the
+            // COMPONENT says whether this flag can carry it.
             GuardVerdict::WouldRemove(removed)
                 if migrate_store
                     && removed.iter().all(|removal| {
                         matches!(&removal.cause, crate::ops::RemovalCause::ComponentGone)
                     }) =>
             {
-                true
+                let uncarriable: Vec<&crate::ops::StatefulRemoval> = removed
+                    .iter()
+                    .filter(|removal| {
+                        !crate::migrate_store::is_object_store_component(&removal.component)
+                    })
+                    .collect();
+                if uncarriable.is_empty() {
+                    true
+                } else {
+                    bail!("{}", uncarriable_removal_message(&uncarriable))
+                }
             }
             GuardVerdict::WouldRemove(removed) => {
                 bail!("{}", stateful_removal_message(&removed))
@@ -1034,7 +1062,20 @@ pub async fn apply(opts: ApplyOpts) -> Result<ApplyOutput> {
     // Stage BEFORE the upgrade deletes the old store. A failure here leaves the
     // cluster untouched.
     if migrating {
-        crate::migrate_store::run_export(&up.common, &up.chart, BUNDLE_BUCKET).await?;
+        // Same values the guard rendered with, and the same values the upgrade
+        // below will apply. Rendering the export's copy of the chart with NO
+        // values made the two halves plan different upgrades: the guard saw the
+        // store removed and waved the migration through, the export saw a store
+        // to migrate INTO, and the disagreement only surfaced after the
+        // irreversible upgrade had run (#1501). Borrowed here, before
+        // `up_prepared` takes ownership.
+        crate::migrate_store::run_export_with_values(
+            &up.common,
+            &up.chart,
+            BUNDLE_BUCKET,
+            &up_values,
+        )
+        .await?;
     }
 
     let up_out = crate::ops::up_prepared(up, up_values, live, github_token).await?;
@@ -1095,6 +1136,34 @@ pub async fn apply(opts: ApplyOpts) -> Result<ApplyOutput> {
         release: cfg.install.release,
         comms: configured_comms,
     })
+}
+
+/// The refusal for removals `--migrate-store` cannot carry.
+///
+/// Separate from [`stateful_removal_message`] rather than a branch inside it,
+/// because the operator is in a different position: they already reached for
+/// the flag that keeps data, and the answer is that this flag's reach stops at
+/// the object store. So it names the COMPONENTS -- "some component" would be a
+/// wall, and their next move is finding which of their values drops this one --
+/// and it does not re-offer `--migrate-store`, which is what sent them here.
+fn uncarriable_removal_message(uncarriable: &[&crate::ops::StatefulRemoval]) -> String {
+    let listed = uncarriable
+        .iter()
+        .map(|r| component_gone_line(r))
+        .collect::<Vec<_>>()
+        .join("\n  ");
+
+    format!(
+        "refusing to apply: --migrate-store carries the OBJECT STORE and nothing else, \
+         and this apply would also DELETE {} stateful component(s) it cannot carry, \
+         with the persistent data in them:\n  {listed}\n\n\
+         A component the target chart does not render at all is usually a values \
+         difference -- a `<component>.deploy=false` in the file, or a chart version \
+         that dropped it. Fix the values so these components are still rendered, then \
+         re-run with --migrate-store to carry the store across.\n\n\
+         Use --allow-stateful-removal only to proceed WITHOUT their data.",
+        uncarriable.len(),
+    )
 }
 
 /// The bundle bucket the platform reads, mirroring the chart's `BUNDLE_BUCKET`.

--- a/cli/src/migrate_store.rs
+++ b/cli/src/migrate_store.rs
@@ -81,6 +81,17 @@ pub fn detect_store(components: &[String]) -> Option<StoreKind> {
         .find(|kind| components.iter().any(|c| c == kind.suffix()))
 }
 
+/// Is this stateful COMPONENT something `--migrate-store` can carry?
+///
+/// The guard's bypass has to ask this question, and it has to ask it HERE: the
+/// migration can carry exactly the stores `StoreKind` knows, so a second list
+/// of names living in the caller would go stale the moment a chart renames a
+/// store again -- and the failure mode of a stale copy is that apply DELETES a
+/// component it believed it was migrating (#1501).
+pub(crate) fn is_object_store_component(component: &str) -> bool {
+    StoreKind::from_suffix(component).is_some()
+}
+
 /// What a migration would do.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MigrationPlan {
@@ -887,13 +898,41 @@ fn standalone_import_dry_run_plan(
 }
 
 /// Phase one: stage every object while the old store is still up.
+///
+/// The standalone `curie cluster migrate-store --phase export` verb has no
+/// installation file behind it, so it renders the chart with no values -- which
+/// is exactly what this wrapper passes. `apply` must NOT reuse that: see
+/// [`run_export_with_values`].
 pub async fn run_export(o: &CommonOpts, chart: &str, bucket: &str) -> Result<MigrateStoreOutput> {
-    let (from, to) = resolve_store_migration(o, chart).await?;
+    run_export_with_values(o, chart, bucket, &crate::ops::UpValuePlan::default()).await
+}
+
+/// Phase one, rendering the target chart with the SAME values the caller's
+/// upgrade will apply.
+///
+/// The value plan is threaded rather than defaulted because the two halves of
+/// one `apply` disagreeing about what the chart renders is not a cosmetic
+/// difference: the guard rendered with the effective values and saw the store
+/// gone, the export rendered with none and saw a store to migrate INTO, so the
+/// migration staged, the irreversible upgrade ran, and only then did the run
+/// fail -- telling the operator to re-run the upgrade that had already deleted
+/// the source store (#1501). Same values, one answer, before the mutation.
+pub(crate) async fn run_export_with_values(
+    o: &CommonOpts,
+    chart: &str,
+    bucket: &str,
+    value_plan: &crate::ops::UpValuePlan,
+) -> Result<MigrateStoreOutput> {
+    let (from, to) = resolve_store_migration(o, chart, value_plan).await?;
 
     run_export_with_plan(o, from, to, bucket).await
 }
 
-async fn resolve_store_migration(o: &CommonOpts, chart: &str) -> Result<(StoreKind, StoreKind)> {
+async fn resolve_store_migration(
+    o: &CommonOpts,
+    chart: &str,
+    value_plan: &crate::ops::UpValuePlan,
+) -> Result<(StoreKind, StoreKind)> {
     let live: Vec<String> = crate::ops::live_stateful_components(o)
         .await?
         .into_iter()
@@ -901,12 +940,11 @@ async fn resolve_store_migration(o: &CommonOpts, chart: &str) -> Result<(StoreKi
         .collect();
     // migrate_store reasons about COMPONENTS only (which store is which); the
     // resource names the guard also needs are irrelevant here.
-    let rendered: Vec<String> =
-        crate::ops::chart_stateful_components(chart, o, &crate::ops::UpValuePlan::default())
-            .await?
-            .into_iter()
-            .map(|(component, _)| component)
-            .collect();
+    let rendered: Vec<String> = crate::ops::chart_stateful_components(chart, o, value_plan)
+        .await?
+        .into_iter()
+        .map(|(component, _)| component)
+        .collect();
     let (from, to) = ensure_migratable(&plan(&live, &rendered)?)?;
 
     Ok((from, to))
@@ -1217,7 +1255,10 @@ impl Drop for ValuesFileCleanup {
 /// staged it itself moments earlier. Making an operator bypass a safety check
 /// as a routine step teaches them to bypass it.
 pub async fn run_auto(o: &CommonOpts, chart: &str, bucket: &str) -> Result<MigrateStoreOutput> {
-    let (from, to) = resolve_store_migration(o, chart).await?;
+    // The standalone verb carries no installation file, so there is no value
+    // plan to render with -- unchanged behaviour, stated explicitly rather than
+    // defaulted somewhere deeper where `apply` could inherit it again (#1501).
+    let (from, to) = resolve_store_migration(o, chart, &crate::ops::UpValuePlan::default()).await?;
 
     let image = "amazon/aws-cli:2.32.6";
     let secret = crate::ops::release_secret_name_or_default(&o.namespace, &o.release).await;

--- a/cli/tests/installation_plan_parity.rs
+++ b/cli/tests/installation_plan_parity.rs
@@ -174,6 +174,26 @@ YAML
             esac
             exit 0
             ;;
+        *" --set-string rustfs.host=s3.example.com "*)
+            # #1501: the file points the object store at an external instance
+            # (the BYO block every store carries in values.yaml), so the render
+            # has NO in-cluster store. Keyed on the VALUE rather than on a mode
+            # env var deliberately: the stub can then only diverge when the two
+            # callers really do pass different values, which is the whole defect
+            # -- the guard rendered with the effective values and saw no store,
+            # the export rendered with none at all and saw rustfs.
+            cat <<'YAML'
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: parity-curie-postgres
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: postgres
+YAML
+            exit 0
+            ;;
     esac
     if [ "${CURIE_TEST_HELM_MIXED_STATEFULSETS:-}" = 1 ]; then
         cat <<'YAML'
@@ -885,6 +905,42 @@ fn live_mixed_store_statefulsets() -> String {
         ]
     })
     .to_string()
+}
+
+/// A live release running a `minio` object store BESIDE a `postgres` one: the
+/// two-component batch #1501 is about. Against a chart render that has neither,
+/// BOTH are `ComponentGone`, which used to be the entire `--migrate-store`
+/// bypass condition -- and only one of the two is something the migration can
+/// actually carry.
+fn live_minio_and_postgres_statefulsets() -> String {
+    json!({
+        "apiVersion": "v1",
+        "kind": "List",
+        "items": [
+            {
+                "metadata": {"name": "parity-minio"},
+                "spec": {"selector": {"matchLabels": {"app.kubernetes.io/component": "minio"}}}
+            },
+            {
+                "metadata": {"name": "parity-postgres"},
+                "spec": {"selector": {"matchLabels": {"app.kubernetes.io/component": "postgres"}}}
+            }
+        ]
+    })
+    .to_string()
+}
+
+/// The stateful-guard installation with the object store pointed at an EXTERNAL
+/// instance in the file's own values, so the target chart renders no in-cluster
+/// store. `rustfs.deploy: "false"` is the other half of that BYO block, but a
+/// `set:` map refuses boolean-shaped values by design (every `--set` is a
+/// string, and Helm reads every nonempty string as true), so the host key alone
+/// carries the intent here. The guard renders WITH these values; before #1501
+/// the export rendered with NONE, so the two halves of the same apply planned
+/// different upgrades and the disagreement only surfaced once the irreversible
+/// half had run.
+fn installation_that_turns_the_store_off() -> &'static str {
+    "version: 1\ninstall:\n  namespace: parity\n  release: parity\nset:\n  rustfs.host: s3.example.com\n"
 }
 
 fn live_rustfs_statefulset() -> String {
@@ -2027,6 +2083,149 @@ fn migrate_store_refuses_a_live_store_that_disagrees_with_the_planned_target() {
     assert!(
         !calls[upgrade..].contains("KUBECTL_CALL: delete pod"),
         "a target disagreement must retain the staged copy:\n{calls}"
+    );
+}
+
+#[test]
+fn migrate_store_refuses_a_component_it_cannot_carry() {
+    // AC1 (#1501): the bypass may only wave through removals the migration can
+    // actually carry, and it carries the OBJECT STORE alone -- `detect_store`
+    // knows `minio` and `rustfs` and nothing else. A batch of {minio gone,
+    // postgres gone} satisfied the old all-ComponentGone condition, so apply
+    // migrated the store, DELETED the database beside it, and exited 0. The
+    // refusal has to land before the export as well as before the upgrade: a
+    // staged copy is worthless once the postgres volume is orphaned.
+    let fixture = HelmFixture::new(
+        installation_for_the_stateful_guard(),
+        HelmValuesResponse::Absent,
+    );
+    let live_before = live_minio_and_postgres_statefulsets();
+
+    let output = fixture.apply(
+        &["--migrate-store"],
+        &[("CURIE_TEST_KUBECTL_STS", live_before.as_str())],
+    );
+
+    let calls = fixture.calls();
+    assert!(
+        !output.status.success(),
+        "--migrate-store must refuse a batch holding a component it cannot carry; stdout:\n{}\nstderr:\n{}\ncalls:\n{calls}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !calls.contains("HELM_CALL: upgrade"),
+        "the refusal must precede the irreversible upgrade:\n{calls}"
+    );
+    assert!(
+        !calls.contains("aws s3 sync s3://curie-bundles /stage"),
+        "nothing may be staged for a migration that will not run:\n{calls}"
+    );
+    // The fixture runs with `--json`, so the refusal is the error payload on
+    // stdout. Assert the COMPONENT name: "some component" would be a wall, and
+    // the operator's next move is to find which of their values drops it.
+    let reported = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        reported.contains("postgres"),
+        "the refusal must name the component it cannot carry; stdout:\n{reported}"
+    );
+    // The bare "postgres" substring is not enough on its own: it also matches
+    // the live resource name `parity-postgres`, so it stays green even if the
+    // bypass falls through to the PRE-EXISTING `stateful_removal_message`.
+    // That message ends by telling the operator to "re-run with --migrate-store
+    // and apply will carry the data across itself" -- sending them straight
+    // back to the flag that just refused them, which is exactly the
+    // operator-recruitment loop #1501 is about. So pin both halves: that the
+    // refusal is the uncarriable one, and that it does NOT re-offer the flag.
+    assert!(
+        reported.contains("cannot carry"),
+        "the refusal must say --migrate-store cannot carry these component(s); stdout:\n{reported}"
+    );
+    assert!(
+        !reported.contains("apply will carry the data across itself"),
+        "the refusal must not re-offer the flag that just refused them (#1501); stdout:\n{reported}"
+    );
+}
+
+#[test]
+fn migrate_store_refuses_a_values_file_that_turns_the_store_off() {
+    // AC2 (#1501): the guard and the export must render the SAME chart. The
+    // guard renders with the effective values, so a file that points the store
+    // at an external instance over a live minio release reads as "the store is
+    // gone" and the bypass accepts it. The export used to render with `UpValuePlan::default()`, saw the
+    // rustfs the values had switched off, and planned minio -> rustfs -- so the
+    // staging pod went up, the upgrade DELETED minio, and only then did the
+    // run fail, telling the operator to re-run the upgrade that had already
+    // happened. The refusal has to come first, while it is still reversible.
+    let fixture = HelmFixture::new(
+        installation_that_turns_the_store_off(),
+        HelmValuesResponse::Absent,
+    );
+    let live_before = live_minio_statefulset();
+
+    let output = fixture.apply(
+        &["--migrate-store"],
+        &[("CURIE_TEST_KUBECTL_STS", live_before.as_str())],
+    );
+
+    let calls = fixture.calls();
+    assert!(
+        !output.status.success(),
+        "a values file that leaves no target store cannot be migrated into; stdout:\n{}\nstderr:\n{}\ncalls:\n{calls}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !calls.contains("HELM_CALL: upgrade"),
+        "the refusal must precede the irreversible upgrade:\n{calls}"
+    );
+    assert!(
+        !calls.contains("KUBECTL_CALL: run"),
+        "no staging pod may be created for a migration that cannot complete:\n{calls}"
+    );
+    assert!(
+        !calls.contains("aws s3 sync s3://curie-bundles /stage"),
+        "nothing may be staged for a migration that will not run:\n{calls}"
+    );
+    let reported = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        reported.contains("renders no known object store"),
+        "the refusal must say the target chart has no store to migrate into; stdout:\n{reported}"
+    );
+    // The direct AC2 assertion (#1501): the guard and the export must render
+    // the chart with the SAME values. Pinning one `--set-string` would survive
+    // a mutation that threads only that value and drops the rest of the plan,
+    // and a real chart could then again disagree about which StatefulSets
+    // exist. Both halves build the command identically -- `helm template
+    // <release> <chart> -n <namespace> <value-plan args>` -- so the two
+    // full-chart renders must be byte-identical. `--show-only` renders are the
+    // priorityclass/preflight probes, not stateful-component detection. The one
+    // provably incidental difference is the per-call temp values file, whose
+    // name carries a fresh uuid, so that token alone is normalised.
+    let full_chart_renders: Vec<String> = calls
+        .lines()
+        .filter(|line| line.starts_with("HELM_CALL: template "))
+        .filter(|line| !line.contains("--show-only"))
+        .map(|line| {
+            line.split_whitespace()
+                .map(|token| {
+                    if token.starts_with("/tmp/curie-helm-values-") {
+                        "<values-file>"
+                    } else {
+                        token
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join(" ")
+        })
+        .collect();
+    assert!(
+        full_chart_renders.len() >= 2,
+        "the guard and the export must each render the full chart:\n{calls}"
+    );
+    assert_eq!(
+        full_chart_renders[0], full_chart_renders[1],
+        "the guard and the export must render the chart with the SAME values:\n{calls}"
     );
 }
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -376,12 +376,15 @@ swap it would be.
 
 `curie apply` refuses outright when the upgrade would delete a StatefulSet the
 release is running, and names it. `--migrate-store` is the option to reach
-for: apply stages every object, upgrades, loads them back, and verifies per
-object, all in one command, so the data survives. It is opt-in rather than
-automatic because the migration has a window where the store is empty and the
-bot cannot answer, so an apply that only changes a log level must never
-silently start moving data. `--allow-stateful-removal` proceeds WITHOUT the
-data instead, for a store you genuinely intend to discard. The two flags are
+for: apply stages the object store, upgrades, loads it back, and verifies it,
+all in one command, so the store's data survives. It carries the object store
+only; if the same upgrade would also delete another stateful component, apply
+still refuses and names that component, since `--migrate-store` gives it no
+way to carry that data too. It is opt-in rather than automatic because the
+migration has a window where the store is empty and the bot cannot answer, so
+an apply that only changes a log level must never silently start moving data.
+`--allow-stateful-removal` proceeds WITHOUT the data instead, for a store you
+genuinely intend to discard. The two flags are
 mutually exclusive: passing both is rejected by the parser with a nonzero
 exit, never silently resolved by picking one.
 


### PR DESCRIPTION
`--migrate-store` carries the object store and nothing else, but the guard bypass was keyed on the removal CAUSE alone: any batch where every removal was `ComponentGone` was waved through. A `<component>.deploy=false` pointing a second store at a managed service classifies as `ComponentGone`, so an upgrade that both renamed the object store and dropped, say, postgres migrated the store, silently DELETED the database beside it, and exited 0. The bypass now asks the second half of the question — is this component one the migration can actually carry — and refuses the batch by name before anything is staged or upgraded. The store-name list stays in `migrate_store`, where `StoreKind` already owns it, so a future chart rename cannot leave a stale copy behind in the guard.

The same apply also rendered the chart twice with different values: the guard used the effective values, `run_export` used none. A values file that leaves no store in the target read as "the store is gone" to the guard, which accepted, and as "there is a store to migrate into" to the export, which staged. The irreversible upgrade then ran and the run failed afterwards, telling the operator to run the upgrade that had just deleted the source store. The export now renders with the same value plan the guard and the upgrade use, so that disagreement is caught while it is still reversible. The standalone `cluster migrate-store` verb has no installation file behind it and keeps rendering with no values.

`docs/operations.md` promised `--migrate-store` "stages every object ... so the data survives"; that is now scoped to the object store, with the refusal for anything else stated.

## Done-check

- [x] Failing tests committed before implementation — **N/A (quick tier)**
- [x] All production-code edits performed by the delegated executor; driver ran only git, tests and bookkeeping
- [x] Broadened return types — none; `run_export` keeps its exact public signature as a wrapper
- [x] Code review completed (routed to an alternative provider): **no blocking findings**; 5 advisory, 3 applied
- [x] Scope review completed: every hunk traced to AC1/AC2 or a mechanical consequence. Two flagged passengers: the `pub(crate)` bump was reverted; the separate refusal message was kept — reusing the existing message would satisfy AC1's substring while telling the operator to "re-run with --migrate-store", i.e. sending them back to the flag that just refused them
- [x] Sibling-path parity: the sibling of the guard's render is the export's render, and closing that divergence is AC2 itself. `run_auto` and the standalone export verb are the other `resolve_store_migration` callers; both keep their existing no-values render, stated explicitly rather than defaulted
- [x] Guard demonstration: both refusals executed against a violating input, with the call log asserted — no `HELM_CALL: upgrade`, no staging pod, no `aws s3 sync`
- [x] Consolidation pass ran; `/simplify` applied one reuse fix (shared `component_gone_line`), full suite re-validated, and the applied diff re-reviewed with no blocking findings
- [x] Security review — **N/A**, not flagged
- [x] Observable verification / deployed E2E — **N/A**: correctness is decided by CLI argv and call ordering, which the parity harness drives at the real `curie apply` entry point
- [x] Full affected suite passes; fmt clean

## Evidence

Positive: 43/43 `installation_plan_parity`, 1502/1502 cli tests, `cargo fmt --check` clean. Clippy's `await_holding_lock` errors are pre-existing `PROCESS_ENV_LOCK` test helpers, none in this diff.

Negative (red-on-revert, verified by hand): reverting the guard fix makes `migrate_store_refuses_a_component_it_cannot_carry` fail with `HELM_CALL: upgrade` in the log — the outage reproduced. Reverting the values-threading makes `migrate_store_refuses_a_values_file_that_turns_the_store_off` fail at the upgrade assertion, with the staging pod created first — the irreversible ordering reproduced.

## Follow-ups, deliberately not in this PR

- `apply --migrate-store` now runs `helm template` and `kubectl get statefulset` twice. Computing them once and handing them to both the guard and the migration is the deeper fix, but it changes `guard_stateful_removal`'s signature and three call paths on a patch-line fix to a destructive operator path.
- The first refusal (no flag passed) still offers `--migrate-store` for any `ComponentGone`, including components it cannot carry. It no longer deletes anything, but it still points the operator at a flag that will refuse them.

Closes #1501
