### PR TITLE
Prove the connector ingress deny leg on the namespace axis

### DIFF
--- a/examples/tests/test_netpol_enforcement.py
+++ b/examples/tests/test_netpol_enforcement.py
@@ -36,6 +36,17 @@ def _run_gate(
     sandbox_to_deny_target_reachable: bool = False,
     outside_to_deny_target_reachable: bool = True,
     connector_not_ready: tuple[str, ...] = (),
+    foreign_reachable: tuple[str, ...] = (),
+    foreign_dns_unreachable: bool = False,
+    foreign_to_deny_target_reachable: bool = True,
+    foreign_namespace_uncreatable: bool = False,
+    foreign_namespace_policies: tuple[str, ...] = (),
+    foreign_namespace_policies_unreadable: bool = False,
+    foreign_pod_labels: str | None = None,
+    foreign_fqdn_unresolvable: tuple[str, ...] = (),
+    foreign_namespace_env: str | None = None,
+    foreign_namespace_exists: bool = False,
+    foreign_namespace_create_races: bool = False,
 ) -> GateRun:
     fake = tmp_path / "kubectl"
     log = tmp_path / "kubectl.jsonl"
@@ -68,6 +79,54 @@ outside_to_deny_target_reachable = (
 connector_not_ready = set(
     filter(None, os.environ.get("FAKE_CONNECTOR_NOT_READY", "").split(","))
 )
+foreign_reachable = set(
+    filter(None, os.environ.get("FAKE_FOREIGN_REACHABLE", "").split(","))
+)
+foreign_dns_unreachable = os.environ.get("FAKE_FOREIGN_DNS_UNREACHABLE") == "1"
+foreign_to_deny_target_reachable = (
+    os.environ.get("FAKE_FOREIGN_TO_DENY_TARGET_REACHABLE") == "1"
+)
+foreign_namespace_uncreatable = (
+    os.environ.get("FAKE_FOREIGN_NAMESPACE_UNCREATABLE") == "1"
+)
+foreign_namespace_policies = tuple(
+    filter(None, os.environ.get("FAKE_FOREIGN_NAMESPACE_POLICIES", "").split(","))
+)
+foreign_namespace_policies_unreadable = (
+    os.environ.get("FAKE_FOREIGN_NAMESPACE_POLICIES_UNREADABLE") == "1"
+)
+foreign_pod_labels = os.environ.get("FAKE_FOREIGN_POD_LABELS", "")
+foreign_fqdn_unresolvable = set(
+    filter(None, os.environ.get("FAKE_FOREIGN_FQDN_UNRESOLVABLE", "").split(","))
+)
+foreign_namespace_exists = os.environ.get("FAKE_FOREIGN_NAMESPACE_EXISTS") == "1"
+foreign_namespace_create_races = (
+    os.environ.get("FAKE_FOREIGN_NAMESPACE_CREATE_RACES") == "1"
+)
+# Derived exactly as the script derives it, so the fake answers as the CLUSTER
+# would rather than as the script hopes. A script that talked to some other
+# namespace would reach no modelled arm and exit 90 instead of quietly passing.
+foreign_ns = os.environ.get("CURIE_NETPOL_FOREIGN_NS") or "curie-netpol-foreign"
+
+GENERIC_DNS_CONTROL = "kubernetes.default.svc.cluster.local"
+
+
+def namespace() -> str | None:
+    return args[args.index("-n") + 1] if "-n" in args else None
+
+
+def namespace_get_ordinal() -> int:
+    # This invocation is already in the log, so the first `get namespace` sees 1.
+    # The ensure path is get -> create -> get, and only the SECOND get may answer
+    # differently from the first; without an ordinal a create race and a plain
+    # unreachable namespace are the same fake, and the race arm would be untested.
+    seen = 0
+    with open(os.environ["FAKE_KUBECTL_LOG"], encoding="utf-8") as stream:
+        for line in stream:
+            call = json.loads(line)
+            if "get" in call and "namespace" in call:
+                seen += 1
+    return seen
 
 
 def connector_deployment() -> str | None:
@@ -80,6 +139,18 @@ def connector_deployment() -> str | None:
                     return connector
     return None
 
+
+def service_name(host: str) -> str:
+    # The foreign probe addresses a connector by FQDN -- e.g.
+    # curie-mcp-alpha.curie.svc.cluster.local -- because the short Service name
+    # does not resolve from another namespace. If this fake did not strip the
+    # .<ns>.svc.cluster.local suffix, that host would match no connector, the
+    # fake would invent a denial of its own, every foreign leg would "pass"
+    # regardless of what the policy says, and the widening could never be shown
+    # red. That is a test proving nothing -- the exact defect class #1502 was
+    # filed about, one level up.
+    return host.split(".")[0]
+
 if "delete" in args or "apply" in args:
     raise SystemExit(0)
 
@@ -90,11 +161,50 @@ if "wait" in args or ("rollout" in args and "status" in args):
     raise SystemExit(0)
 
 if "get" in args and "networkpolicy" in args:
+    # Two different questions share this verb, and answering both with a silent
+    # exit 0 is what makes the policy-vacuum check untestable: the listing would
+    # report "no policies" no matter what the namespace held. The named get is
+    # the chart-installed check in $NS; the -o jsonpath listing is the vacuum
+    # check in $FOREIGN_NS, and only the latter has an answer worth faking.
+    if "-o" in args and namespace() == foreign_ns:
+        if foreign_namespace_policies_unreadable:
+            raise SystemExit(1)
+        for name in foreign_namespace_policies:
+            print(name, end=" ")
+        raise SystemExit(0)
+    if "-o" not in args:
+        raise SystemExit(0)
+
+# Both namespace verbs are matched BEFORE the looser get/pod and get/svc
+# branches so `get namespace` is never swallowed by one of them.
+if "get" in args and "namespace" in args:
+    # Absent by default: that is the honest first-run state, and it is the only
+    # arm that exercises `create namespace`, so a script that assumes the
+    # namespace already exists cannot pass here.
+    if foreign_namespace_exists:
+        raise SystemExit(0)
+    if foreign_namespace_create_races and namespace_get_ordinal() >= 2:
+        raise SystemExit(0)
+    raise SystemExit(1)
+
+if "create" in args and "namespace" in args:
+    if foreign_namespace_uncreatable or foreign_namespace_create_races:
+        raise SystemExit(1)
     raise SystemExit(0)
 
 if "get" in args and "pod" in args:
-    print("192.0.2.10", end="")
-    raise SystemExit(0)
+    # The deny target is read for its pod IP and the foreign probe for its
+    # labels. One arm answering both would hand the label check an IP address,
+    # so the label comparison could never be satisfied -- and the test that says
+    # a stripped label is fatal would go red for the wrong reason, which is the
+    # same thing as not testing it at all.
+    pod_name = args[args.index("pod") + 1]
+    if pod_name == "netpol-probe-deny-target":
+        print("192.0.2.10", end="")
+        raise SystemExit(0)
+    if pod_name == "netpol-probe-foreign":
+        print(foreign_pod_labels, end="")
+        raise SystemExit(0)
 
 if "get" in args and "svc" in args:
     if "-l" in args:
@@ -109,26 +219,44 @@ if "exec" in args:
     pod = args[exec_index + 1]
     command = args[args.index("--") + 1 :]
     if command and command[0] == "getent":
+        resolved = command[-1]
         if pod == "netpol-probe-sandbox":
             raise SystemExit(1 if sandbox_dns_unreachable else 0)
         if pod == "netpol-probe-outside":
             raise SystemExit(1 if outside_dns_unreachable else 0)
+        if pod == "netpol-probe-foreign":
+            # Keyed on the NAME asked about, not just the pod. The generic
+            # control and the per-connector FQDN check are separate hazards: a
+            # CoreDNS view or a Cilium FQDN policy can serve kubernetes.default
+            # and refuse one connector, so a fake that answers both from one
+            # switch cannot show the per-connector check failing on its own.
+            if resolved == GENERIC_DNS_CONTROL:
+                raise SystemExit(1 if foreign_dns_unreachable else 0)
+            raise SystemExit(1 if service_name(resolved) in foreign_fqdn_unresolvable else 0)
         raise SystemExit(1)
     urls = [value for value in command if value.startswith("http://")]
     if urls:
-        service = urlparse(urls[0]).hostname or ""
-        if service == "192.0.2.10":
+        host = urlparse(urls[0]).hostname or ""
+        # The deny target is addressed by raw pod IP, so it must be matched
+        # BEFORE the FQDN suffix is stripped -- 192.0.2.10 would otherwise
+        # normalize to "192" and fall through to the connector arms.
+        if host == "192.0.2.10":
             if pod == "netpol-probe-sandbox":
                 raise SystemExit(0 if sandbox_to_deny_target_reachable else 1)
             if pod == "netpol-probe-outside":
                 raise SystemExit(0 if outside_to_deny_target_reachable else 1)
+            if pod == "netpol-probe-foreign":
+                raise SystemExit(0 if foreign_to_deny_target_reachable else 1)
             raise SystemExit(1)
+        service = service_name(host)
         if service not in connectors:
             raise SystemExit(1)
         if pod == "netpol-probe-sandbox":
             raise SystemExit(1 if service in sandbox_unreachable else 0)
         if pod == "netpol-probe-outside":
             raise SystemExit(0 if service in outside_reachable else 1)
+        if pod == "netpol-probe-foreign":
+            raise SystemExit(0 if service in foreign_reachable else 1)
 
 print(f"unexpected kubectl invocation: {args!r}", file=sys.stderr)
 raise SystemExit(90)
@@ -158,8 +286,41 @@ raise SystemExit(90)
                 "1" if outside_to_deny_target_reachable else "0"
             ),
             "FAKE_CONNECTOR_NOT_READY": ",".join(connector_not_ready),
+            "FAKE_FOREIGN_REACHABLE": ",".join(foreign_reachable),
+            "FAKE_FOREIGN_DNS_UNREACHABLE": (
+                "1" if foreign_dns_unreachable else "0"
+            ),
+            "FAKE_FOREIGN_TO_DENY_TARGET_REACHABLE": (
+                "1" if foreign_to_deny_target_reachable else "0"
+            ),
+            "FAKE_FOREIGN_NAMESPACE_UNCREATABLE": (
+                "1" if foreign_namespace_uncreatable else "0"
+            ),
+            "FAKE_FOREIGN_NAMESPACE_POLICIES": ",".join(foreign_namespace_policies),
+            "FAKE_FOREIGN_NAMESPACE_POLICIES_UNREADABLE": (
+                "1" if foreign_namespace_policies_unreadable else "0"
+            ),
+            # Default to the labels a correct apply produces, so every other test
+            # exercises the read-back on its passing path rather than skipping it.
+            "FAKE_FOREIGN_POD_LABELS": (
+                "curie curie runner-sandbox"
+                if foreign_pod_labels is None
+                else foreign_pod_labels
+            ),
+            "FAKE_FOREIGN_FQDN_UNRESOLVABLE": ",".join(foreign_fqdn_unresolvable),
+            "FAKE_FOREIGN_NAMESPACE_EXISTS": ("1" if foreign_namespace_exists else "0"),
+            "FAKE_FOREIGN_NAMESPACE_CREATE_RACES": (
+                "1" if foreign_namespace_create_races else "0"
+            ),
         }
     )
+    # Popped rather than left alone: an ambient CURIE_NETPOL_FOREIGN_NS on the
+    # developer's shell would silently move the probe's namespace for every test
+    # in this file, and the override tests would then prove nothing.
+    if foreign_namespace_env is None:
+        env.pop("CURIE_NETPOL_FOREIGN_NS", None)
+    else:
+        env["CURIE_NETPOL_FOREIGN_NS"] = foreign_namespace_env
     result = subprocess.run(
         ["bash", str(SCRIPT), "curie", "curie", "curie"],
         cwd=REPO_ROOT,
@@ -173,16 +334,37 @@ raise SystemExit(90)
     return GateRun(result.stdout, result.stderr, result.returncode, calls)
 
 
+def _service_name(host: str) -> str:
+    # The foreign probe must use the FQDN (a short Service name does not resolve
+    # from another namespace), while the same-namespace probes use the short
+    # name. Both must bucket to the same connector key here, or a foreign
+    # attempt would be counted as a different target than the sandbox and
+    # outside attempts against the very same Service.
+    return host.split(".")[0]
+
+
+def _probe_exec_calls(calls: list[list[str]], pod: str) -> list[list[str]]:
+    return [
+        call
+        for call in calls
+        if "exec" in call and "--" in call and call[call.index("exec") + 1] == pod
+    ]
+
+
+def _exec_urls(call: list[str]) -> list[str]:
+    command = call[call.index("--") + 1 :]
+    return [value for value in command if value.startswith("http://")]
+
+
 def _connector_curl_calls(calls: list[list[str]]) -> set[tuple[str, str]]:
     attempts: set[tuple[str, str]] = set()
     for call in calls:
         if "exec" not in call or "--" not in call:
             continue
-        command = call[call.index("--") + 1 :]
-        urls = [value for value in command if value.startswith("http://")]
+        urls = _exec_urls(call)
         if not urls:
             continue
-        service = urlparse(urls[0]).hostname or ""
+        service = _service_name(urlparse(urls[0]).hostname or "")
         if "-mcp-" in service:
             attempts.add((call[call.index("exec") + 1], service))
     return attempts
@@ -193,31 +375,42 @@ def _curl_events(calls: list[list[str]]) -> list[tuple[int, str, str]]:
     probe_roles = {
         "netpol-probe-sandbox": "sandbox",
         "netpol-probe-outside": "outside",
+        "netpol-probe-foreign": "foreign",
     }
     for index, call in enumerate(calls):
         if "exec" not in call or "--" not in call:
             continue
-        command = call[call.index("--") + 1 :]
-        urls = [value for value in command if value.startswith("http://")]
+        urls = _exec_urls(call)
         if not urls:
             continue
         pod = call[call.index("exec") + 1]
         role = probe_roles.get(pod, pod)
         host = urlparse(urls[0]).hostname or ""
-        target = "deny_target" if host == "192.0.2.10" else host
+        target = "deny_target" if host == "192.0.2.10" else _service_name(host)
         events.append((index, role, target))
     return events
 
 
-def _dns_events(calls: list[list[str]]) -> list[tuple[int, str]]:
-    events: list[tuple[int, str]] = []
+def _resolution_events(calls: list[list[str]]) -> list[tuple[int, str, str]]:
+    # Keeps the NAME asked about, not just the pod. The ordering pin needs to
+    # know which resolution preceded which curl, and every foreign getent looks
+    # identical without the name.
+    events: list[tuple[int, str, str]] = []
     for index, call in enumerate(calls):
         if "exec" not in call or "--" not in call:
             continue
         command = call[call.index("--") + 1 :]
         if command[:2] == ["getent", "hosts"]:
-            events.append((index, call[call.index("exec") + 1]))
+            events.append((index, call[call.index("exec") + 1], command[-1]))
     return events
+
+
+def _dns_events(calls: list[list[str]]) -> list[tuple[int, str]]:
+    return [(index, pod) for index, pod, _ in _resolution_events(calls)]
+
+
+def _namespace_verb_calls(calls: list[list[str]], verb: str) -> list[list[str]]:
+    return [call for call in calls if verb in call and "namespace" in call]
 
 
 def _deployment_readiness_events(
@@ -312,7 +505,13 @@ def test_outside_probe_must_resolve_dns_before_connector_denial(tmp_path: Path) 
     assert outside_connector_curls == []
 
 
-def test_every_connector_checks_sandbox_allow_and_outside_deny(tmp_path: Path) -> None:
+def test_every_connector_checks_sandbox_allow_outside_deny_and_foreign_deny(
+    tmp_path: Path,
+) -> None:
+    # An exact set, not a subset: a connector silently skipped by one of the
+    # three legs is the failure this catches. Two connectors is what makes
+    # "asserted per connector" testable at all -- with one, a leg run once for
+    # the whole run is indistinguishable from a leg run per connector.
     connectors = ("curie-mcp-alpha", "curie-mcp-beta")
     result = _run_gate(tmp_path, connectors=connectors)
 
@@ -321,8 +520,10 @@ def test_every_connector_checks_sandbox_allow_and_outside_deny(tmp_path: Path) -
     assert _connector_curl_calls(result.kubectl_calls) == {
         ("netpol-probe-sandbox", "curie-mcp-alpha"),
         ("netpol-probe-outside", "curie-mcp-alpha"),
+        ("netpol-probe-foreign", "curie-mcp-alpha"),
         ("netpol-probe-sandbox", "curie-mcp-beta"),
         ("netpol-probe-outside", "curie-mcp-beta"),
+        ("netpol-probe-foreign", "curie-mcp-beta"),
     }
 
 
@@ -388,3 +589,328 @@ def test_sandbox_access_loss_fails(tmp_path: Path) -> None:
 
     assert result.returncode != 0
     assert "sandbox cannot reach connector Service curie-mcp-beta:8000" in result.stderr
+
+
+def test_foreign_probe_runs_in_a_different_namespace_than_the_connectors(
+    tmp_path: Path,
+) -> None:
+    # The foreign probe earns its keep by differing from the sandbox on the
+    # NAMESPACE axis and nothing else. Move it back into the connectors' own
+    # namespace -- an easy "simplification", since it would then need no
+    # namespace RBAC and no second apply -- and it silently degrades into a
+    # second copy of the outside probe, observing only the pod axis that is
+    # already covered. The gate would stay green while #1502's widening walked
+    # straight back in.
+    result = _run_gate(tmp_path, connectors=("curie-mcp-alpha", "curie-mcp-beta"))
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    foreign_calls = _probe_exec_calls(result.kubectl_calls, "netpol-probe-foreign")
+    assert foreign_calls, "the foreign probe never ran"
+    for call in foreign_calls:
+        assert "-n" in call, f"foreign exec carries no namespace flag: {call!r}"
+        namespace = call[call.index("-n") + 1]
+        assert namespace != "curie", (
+            "the foreign probe executed in the connectors' own namespace; it then "
+            "differs from the sandbox on the pod axis only and cannot observe a "
+            f"namespace-axis widening: {call!r}"
+        )
+
+
+def test_foreign_probe_addresses_the_connector_by_fqdn(tmp_path: Path) -> None:
+    # A short Service name resolves only inside the Service's own namespace.
+    # From the foreign namespace it fails DNS, curl exits non-zero, and the
+    # script reads that as "policy denied me" -- a green leg that never
+    # attempted the connection at all. The FQDN forces the connection to be
+    # made, so its failure is attributable to the ingress policy.
+    result = _run_gate(tmp_path, connectors=("curie-mcp-alpha", "curie-mcp-beta"))
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    hosts = [
+        urlparse(url).hostname or ""
+        for call in _probe_exec_calls(result.kubectl_calls, "netpol-probe-foreign")
+        for url in _exec_urls(call)
+    ]
+    connector_hosts = [host for host in hosts if "-mcp-" in host]
+    assert connector_hosts, "the foreign probe never curled a connector"
+    for host in connector_hosts:
+        assert host.endswith(".curie.svc.cluster.local"), (
+            "the foreign probe must address the connector by FQDN; the short name "
+            f"does not resolve from another namespace: {host!r}"
+        )
+
+
+def test_foreign_probe_reaching_a_connector_fails_the_gate(tmp_path: Path) -> None:
+    # The harness-level analogue of the live widening: `namespaceSelector: {}`
+    # merged into the ingress `from` peer admits sandbox-labelled pods from
+    # every namespace while still denying the unlabelled same-namespace outside
+    # probe. Before the foreign leg existed this run was green (#1502).
+    connectors = ("curie-mcp-alpha", "curie-mcp-beta")
+    result = _run_gate(
+        tmp_path,
+        connectors=connectors,
+        foreign_reachable=("curie-mcp-beta",),
+    )
+
+    assert result.returncode != 0
+    lowered = result.stderr.lower()
+    assert "reached connector service curie-mcp-beta:8000" in lowered
+    assert "every namespace" in lowered, (
+        "the failure must say what the widening IS -- an ingress peer admitting "
+        "sandbox-labelled pods in every namespace -- not merely that a curl "
+        f"worked: {result.stderr!r}"
+    )
+    assert "1502" in result.stderr
+
+
+def test_foreign_probe_must_reach_deny_target_before_connector_denial(
+    tmp_path: Path,
+) -> None:
+    # Sibling of test_outside_probe_must_reach_known_listener_before_connector_denial.
+    # A foreign probe with no working cross-namespace network denies every
+    # connector for reasons that have nothing to do with the ingress policy, so
+    # its denial certifies nothing. That must be fatal, and it must be caught
+    # before any connector is curled from it.
+    connector = "curie-mcp-alpha"
+    result = _run_gate(
+        tmp_path,
+        connectors=(connector,),
+        foreign_to_deny_target_reachable=False,
+    )
+
+    assert result.returncode != 0
+    assert "foreign" in result.stderr.lower()
+    assert "deny target" in result.stderr
+    events = {(role, target) for _, role, target in _curl_events(result.kubectl_calls)}
+    assert ("foreign", "deny_target") in events
+    assert ("foreign", connector) not in events
+
+
+def test_foreign_probe_must_resolve_dns_before_connector_denial(tmp_path: Path) -> None:
+    # Sibling of test_outside_probe_must_resolve_dns_before_connector_denial,
+    # and the sharper hazard of the two here: the foreign probe reaches the
+    # connector by NAME, so broken DNS makes every foreign denial vacuous while
+    # looking exactly like enforcement.
+    connector = "curie-mcp-alpha"
+    result = _run_gate(
+        tmp_path,
+        connectors=(connector,),
+        foreign_dns_unreachable=True,
+    )
+
+    assert result.returncode != 0
+    lowered = result.stderr.lower()
+    assert "foreign" in lowered
+    assert "resolve dns" in lowered
+    dns_events = _dns_events(result.kubectl_calls)
+    assert any(pod == "netpol-probe-foreign" for _, pod in dns_events)
+    foreign_connector_curls = [
+        index
+        for index, role, target in _curl_events(result.kubectl_calls)
+        if role == "foreign" and target == connector
+    ]
+    assert foreign_connector_curls == []
+
+
+def test_foreign_namespace_creation_failure_is_fatal(tmp_path: Path) -> None:
+    # A skipped deny leg is worse than no deny leg, because a green run reads as
+    # proof. If the foreign namespace cannot be created the script must stop,
+    # not carry on with two legs and print the same banner -- and the message
+    # must hand the operator the way out, since a restricted kubectl context
+    # with no cluster-scoped namespace RBAC is a legitimate way to arrive here.
+    result = _run_gate(
+        tmp_path,
+        connectors=("curie-mcp-alpha", "curie-mcp-beta"),
+        foreign_namespace_uncreatable=True,
+    )
+
+    assert result.returncode != 0
+    assert "CURIE_NETPOL_FOREIGN_NS" in result.stderr, (
+        "the failure must name the override an operator without namespace-create "
+        f"RBAC needs: {result.stderr!r}"
+    )
+    assert "RBAC" in result.stderr
+    assert _connector_curl_calls(result.kubectl_calls) == set(), (
+        "no connector was probed at all, so no leg may be reported as having passed"
+    )
+
+
+def test_foreign_namespace_carrying_a_networkpolicy_is_fatal(tmp_path: Path) -> None:
+    # A denial observed from a namespace that has policies of its own is
+    # unattributable. An injected egress policy allowing the pod CIDR and DNS but
+    # not the Service CIDR leaves BOTH foreign positive controls passing -- they
+    # use a pod IP and DNS -- while the connector curl fails on the probe's own
+    # egress. The leg would print ok with connector ingress wide open.
+    result = _run_gate(
+        tmp_path,
+        connectors=("curie-mcp-alpha", "curie-mcp-beta"),
+        foreign_namespace_policies=("injected-egress",),
+    )
+
+    assert result.returncode != 0
+    assert "curie-netpol-foreign" in result.stderr
+    assert "injected-egress" in result.stderr, (
+        "the failure must name the policy that made the namespace unusable, or an "
+        f"operator cannot tell what to remove: {result.stderr!r}"
+    )
+    assert _connector_curl_calls(result.kubectl_calls) == set(), (
+        "no connector was probed at all, so no leg may be reported as having passed"
+    )
+
+
+def test_foreign_namespace_policy_list_failure_is_fatal(tmp_path: Path) -> None:
+    # Unreadable is not the same as empty. Treating a failed listing as "no
+    # policies" would restore exactly the vacuum assumption the listing exists to
+    # replace, and would do it silently on any context lacking the read.
+    result = _run_gate(
+        tmp_path,
+        connectors=("curie-mcp-alpha", "curie-mcp-beta"),
+        foreign_namespace_policies_unreadable=True,
+    )
+
+    assert result.returncode != 0
+    assert "NetworkPolicies" in result.stderr
+    assert "curie-netpol-foreign" in result.stderr
+    assert _connector_curl_calls(result.kubectl_calls) == set()
+
+
+def test_foreign_probe_without_sandbox_labels_is_fatal(tmp_path: Path) -> None:
+    # Wearing the three runner-sandbox labels is the entire reason this probe can
+    # see the namespace axis. A mutating webhook that strips
+    # app.kubernetes.io/component leaves an UNLABELLED probe, which a correct
+    # connector policy and a namespace-widened one deny alike -- so the leg goes
+    # green while the widening stays invisible. That is #1502 one level up: a
+    # check that cannot fail.
+    result = _run_gate(
+        tmp_path,
+        connectors=("curie-mcp-alpha", "curie-mcp-beta"),
+        foreign_pod_labels="curie curie something-else",
+    )
+
+    assert result.returncode != 0
+    assert "runner-sandbox" in result.stderr
+    assert "curie curie something-else" in result.stderr, (
+        "the failure must show the labels actually read back off the live object, "
+        f"not merely say they were wrong: {result.stderr!r}"
+    )
+    assert ("netpol-probe-foreign", "curie-mcp-alpha") not in _connector_curl_calls(
+        result.kubectl_calls
+    )
+
+
+def test_foreign_probe_must_resolve_each_connector_fqdn(tmp_path: Path) -> None:
+    # A DNS failure inside the curl is indistinguishable from a policy denial:
+    # curl exits non-zero either way and the script reads that as enforcement.
+    # The generic kubernetes.default control does not cover this -- a Cilium FQDN
+    # policy or a CoreDNS view can serve that name and refuse this one -- so the
+    # connector's own FQDN must be proven resolvable before its unreachability
+    # means anything.
+    connectors = ("curie-mcp-alpha", "curie-mcp-beta")
+    result = _run_gate(
+        tmp_path,
+        connectors=connectors,
+        foreign_fqdn_unresolvable=("curie-mcp-beta",),
+    )
+
+    assert result.returncode != 0
+    assert "curie-mcp-beta.curie.svc.cluster.local" in result.stderr, (
+        f"the failure must name the FQDN that would not resolve: {result.stderr!r}"
+    )
+    assert ("netpol-probe-foreign", "curie-mcp-beta") not in _connector_curl_calls(
+        result.kubectl_calls
+    ), "the denial curl ran anyway, so an unresolvable name would still read as enforcement"
+
+
+def test_explicit_foreign_namespace_makes_no_cluster_scoped_calls(tmp_path: Path) -> None:
+    # The documented escape hatch is for the operator who lacks cluster-scoped
+    # namespace RBAC. A guard that trips on the very permission it is escaping is
+    # a guard in name only, so this asserts the override is real: not created,
+    # not even read, and the probe genuinely lands in the supplied namespace.
+    foreign_ns = "preprovisioned-probe-ns"
+    result = _run_gate(
+        tmp_path,
+        connectors=("curie-mcp-alpha", "curie-mcp-beta"),
+        foreign_namespace_env=foreign_ns,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert _namespace_verb_calls(result.kubectl_calls, "get") == [], (
+        "`kubectl get namespace` is cluster-scoped; calling it defeats the override"
+    )
+    assert _namespace_verb_calls(result.kubectl_calls, "create") == []
+    foreign_applies = [
+        call
+        for call in result.kubectl_calls
+        if "apply" in call and "-n" in call and call[call.index("-n") + 1] == foreign_ns
+    ]
+    assert foreign_applies, (
+        "the foreign probe was never applied into the supplied namespace, so the "
+        "override changed the message and nothing else"
+    )
+
+
+def test_existing_foreign_namespace_is_reused_not_created(tmp_path: Path) -> None:
+    # The steady state after the first run. A script that created unconditionally
+    # would fail on AlreadyExists on every subsequent run, and a script that
+    # treated that failure as fatal would take the whole deny leg down with it.
+    result = _run_gate(
+        tmp_path,
+        connectors=("curie-mcp-alpha", "curie-mcp-beta"),
+        foreign_namespace_exists=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert _namespace_verb_calls(result.kubectl_calls, "create") == [], (
+        "an existing namespace was created again rather than reused"
+    )
+
+
+def test_foreign_namespace_create_race_is_survivable(tmp_path: Path) -> None:
+    # Two runs against one cluster both miss on `get`, one create wins and the
+    # loser sees AlreadyExists -- for a namespace that by then exists and is
+    # perfectly usable. Trusting the create's exit status turns that race into a
+    # dropped deny leg, which reads as proof that ingress is narrow.
+    result = _run_gate(
+        tmp_path,
+        connectors=("curie-mcp-alpha", "curie-mcp-beta"),
+        foreign_namespace_create_races=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert len(_namespace_verb_calls(result.kubectl_calls, "get")) >= 2, (
+        "the create failure was not re-checked, so the run survived by luck"
+    )
+
+
+def test_foreign_connector_denial_follows_its_own_controls(tmp_path: Path) -> None:
+    # Sibling of test_connector_denials_follow_outside_control_and_deployment_readiness,
+    # for the foreign leg. Every one of these orderings is load-bearing: a
+    # reordered script still exits 0 on a healthy cluster, so nothing but an
+    # ordering pin catches a control that has drifted BEHIND the denial it is
+    # supposed to qualify.
+    connectors = ("curie-mcp-alpha", "curie-mcp-beta")
+    result = _run_gate(tmp_path, connectors=connectors)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    curl_indexes = {
+        (role, target): index for index, role, target in _curl_events(result.kubectl_calls)
+    }
+    readiness_indexes = {
+        connector: index
+        for index, connector in _deployment_readiness_events(result.kubectl_calls, connectors)
+    }
+    fqdn_indexes = {
+        host: index
+        for index, pod, host in _resolution_events(result.kubectl_calls)
+        if pod == "netpol-probe-foreign"
+    }
+    assert ("foreign", "deny_target") in curl_indexes
+    for connector in connectors:
+        denial = curl_indexes[("foreign", connector)]
+        fqdn = f"{connector}.curie.svc.cluster.local"
+        assert fqdn in fqdn_indexes, (
+            f"the foreign probe never proved {fqdn} resolves, so its denial of "
+            "that connector could be a DNS failure"
+        )
+        assert fqdn_indexes[fqdn] < denial
+        assert curl_indexes[("foreign", "deny_target")] < denial
+        assert readiness_indexes[connector] < denial

--- a/packages/plugin-format/tests/test_connector_render.py
+++ b/packages/plugin-format/tests/test_connector_render.py
@@ -724,6 +724,58 @@ def test_connector_accepts_traffic_only_from_the_sandbox() -> None:
     assert src[0]["podSelector"]["matchLabels"] == r.sandbox_selector("release-r", "app-name")
 
 
+# This sits BESIDE the test above, which already goes red on the same mutation
+# via its `set(src[0]) == {"podSelector"}` line. That coverage is incidental:
+# it lives inside a test named for pod-scope narrowness, and its failure points
+# a reader at label identity, not at namespace scope. A future edit could
+# reasonably relax or split it without any signal that one line of it was the
+# only thing standing between the repo and the #1502 widening. This test's
+# whole stated purpose IS the namespace axis, so it cannot be relaxed by
+# accident. Keep both; they are complements, not duplicates (#1450, #1502).
+def test_ingress_source_peer_is_namespace_scoped_by_omission() -> None:
+    """The ingress `from` peer must stay a BARE podSelector -- no namespaceSelector.
+
+    The widening this exists to catch is `namespaceSelector: {}` merged INTO
+    the existing peer, rather than added as a second peer:
+
+        from:
+          - podSelector: {matchLabels: {...sandbox labels...}}
+            namespaceSelector: {}            # <-- the mutation
+
+    A bare podSelector peer is implicitly scoped to the policy's own namespace,
+    so this merge relaxes the NAMESPACE axis while leaving the pod axis exactly
+    as narrow as it was: every sandbox-labelled pod in EVERY namespace is then
+    admitted to a connector that holds a production credential and
+    authenticates nobody.
+
+    The cluster gate cannot see it. `scripts/check-netpol-enforcement.sh`'s
+    deny prober `netpol-probe-outside` is unlabelled and lives in the
+    connectors' own namespace, so it differs from a sandbox on the POD axis
+    only -- the merged peer still denies it and the gate stays green while the
+    boundary is gone. That script's `netpol-probe-foreign` (sandbox labels,
+    different namespace) is the cluster-side complement; this test needs no
+    cluster at all.
+    """
+    src = _ingress_np(_objs(release="release-r", app="app-name"))["spec"]["ingress"][0]["from"]
+    assert len(src) == 1, (
+        "exactly one source peer; a second peer widens the source set as surely "
+        "as widening this one does"
+    )
+    assert set(src[0]) == {"podSelector"}, (
+        "the peer must carry podSelector and NOTHING else: a bare podSelector peer is "
+        "namespace-local, and any sibling key here widens the source beyond this namespace"
+    )
+    assert "namespaceSelector" not in src[0], (
+        "a bare podSelector peer is namespace-local; a namespaceSelector here would admit "
+        "sandbox-labelled pods in EVERY namespace, which the unlabelled same-namespace "
+        "cluster probe cannot observe (#1502)"
+    )
+    assert src[0]["podSelector"]["matchLabels"] == r.sandbox_selector("release-r", "app-name"), (
+        "the peer must still name exactly this release's sandbox on the pod axis; "
+        "the namespace axis is held closed by omission, not by these labels"
+    )
+
+
 def test_ingress_policy_selects_the_connector_not_the_sandbox() -> None:
     # Getting this backwards yields a policy that parses, applies, and protects
     # the wrong pod -- the sandbox gains an ingress restriction it does not need

--- a/scripts/check-netpol-enforcement.sh
+++ b/scripts/check-netpol-enforcement.sh
@@ -20,6 +20,20 @@ set -euo pipefail
 NS="${1:-${CURIE_NETPOL_NS:-curie}}"
 RELEASE="${2:-${CURIE_NETPOL_RELEASE:-curie}}"
 APP="${3:-${CURIE_NETPOL_APP:-curie}}"
+# The namespace-axis probe needs a namespace that is NOT the connectors'. A
+# namespace this script creates carries no NetworkPolicy of its own, so a denial
+# observed from it is attributable to the connector's ingress policy and not to a
+# neighbour's egress default-deny. `default` was rejected for exactly that
+# reason: it always exists, but on a real operator cluster it may already carry
+# an egress default-deny, which would make the foreign denial pass vacuously.
+#
+# "Carries no policy" is an assumption, not a fact -- the namespace is reused
+# across runs, an admission webhook can inject a policy into a namespace it did
+# not create, and the override hands the choice to an operator -- so it is
+# VERIFIED below rather than trusted. The two sources also get different
+# treatment: only the derived default is ours to create, so an explicitly
+# supplied namespace is never created here.
+FOREIGN_NS="${CURIE_NETPOL_FOREIGN_NS:-${NS}-netpol-foreign}"
 PROBE_IMAGE="${CURIE_NETPOL_PROBE_IMAGE:-curlimages/curl:8.10.1}"
 # The deny target must actually LISTEN, so a blocked attempt is a timeout rather
 # than an ambiguous connection-refused that a missing listener would also give.
@@ -28,10 +42,19 @@ TARGET_IMAGE="${CURIE_NETPOL_TARGET_IMAGE:-hashicorp/http-echo:1.0}"
 SANDBOX_POD="netpol-probe-sandbox"
 OUTSIDE_POD="netpol-probe-outside"
 DENY_TARGET_POD="netpol-probe-deny-target"
+FOREIGN_POD="netpol-probe-foreign"
 
 # Non-blocking on the way out: the run is over, nothing waits on the pods.
+# The pod is deleted; $FOREIGN_NS itself deliberately is NOT. Deleting a
+# namespace from a non-blocking trap leaves it Terminating for tens of seconds,
+# and a Terminating namespace REJECTS creates -- so the next run would fail on
+# namespace creation for reasons that have nothing to do with policy. That is
+# the same race cleanup_and_settle exists to avoid, one level up. An empty
+# namespace is inert; the pod is the thing that must not leak.
 cleanup() {
   kubectl -n "$NS" delete pod "$SANDBOX_POD" "$OUTSIDE_POD" "$DENY_TARGET_POD" \
+    --ignore-not-found --wait=false >/dev/null 2>&1 || true
+  kubectl -n "$FOREIGN_NS" delete pod "$FOREIGN_POD" \
     --ignore-not-found --wait=false >/dev/null 2>&1 || true
 }
 # BLOCKING before the apply. A previous run's pod may still be terminating, and
@@ -40,6 +63,8 @@ cleanup() {
 # after it fails for reasons that have nothing to do with policy.
 cleanup_and_settle() {
   kubectl -n "$NS" delete pod "$SANDBOX_POD" "$OUTSIDE_POD" "$DENY_TARGET_POD" \
+    --ignore-not-found --wait=true --timeout=90s >/dev/null 2>&1 || true
+  kubectl -n "$FOREIGN_NS" delete pod "$FOREIGN_POD" \
     --ignore-not-found --wait=true --timeout=90s >/dev/null 2>&1 || true
 }
 trap cleanup EXIT
@@ -54,6 +79,81 @@ kubectl -n "$NS" get networkpolicy "${RELEASE}-runner-default-deny-egress" >/dev
 # The sandbox probe wears exactly the labels Rail 1 selects, so the policies
 # under test apply to it. The outside probe and deny target wear none of the
 # runner sandbox labels.
+#
+# The foreign probe is the third shape, and the one that covers the second axis.
+# The connector ingress `from` block is a single bare podSelector peer, which is
+# implicitly scoped to the policy's own namespace, so it can be widened two
+# independent ways: on the POD axis (a second peer, an empty podSelector, an
+# ipBlock), which the unlabelled same-namespace outside probe catches; and on the
+# NAMESPACE axis (a namespaceSelector: {} merged INTO that peer), which admits
+# sandbox-labelled pods in every namespace while leaving the unlabelled probe
+# denied. The foreign probe wears the SAME labels as the sandbox probe and sits
+# in a DIFFERENT namespace -- it differs from the sandbox on exactly the axis the
+# other two probes hold constant, which is the only reason it can see that
+# widening (#1502).
+if [ -n "${CURIE_NETPOL_FOREIGN_NS:-}" ]; then
+  # Operator-supplied: neither created nor even read. `get namespace` and
+  # `create namespace` are BOTH cluster-scoped, and this override exists
+  # precisely for the operator who lacks that RBAC -- an escape hatch that trips
+  # on the same permission it is escaping is a guard in name only. If the
+  # namespace is actually missing, the policy listing, the pod apply and the
+  # Ready wait below all fail loudly, so nothing passes vacuously by skipping it.
+  echo "  ok  foreign namespace $FOREIGN_NS supplied by CURIE_NETPOL_FOREIGN_NS (not created here)"
+else
+  # Re-check existence after a failed create rather than trusting the create's
+  # exit status: two first runs against one cluster both miss on `get`, one
+  # create wins, and the loser hard-fails on AlreadyExists for a namespace that
+  # by then exists and is perfectly usable.
+  kubectl get namespace "$FOREIGN_NS" >/dev/null 2>&1 \
+    || kubectl create namespace "$FOREIGN_NS" >/dev/null 2>&1 \
+    || kubectl get namespace "$FOREIGN_NS" >/dev/null 2>&1 \
+    || fail "could not create namespace $FOREIGN_NS for the namespace-axis ingress probe.
+
+Creating it needs cluster-scoped RBAC to get and create namespaces, because the
+foreign probe must run somewhere other than $NS. Grant that, or set
+CURIE_NETPOL_FOREIGN_NS to an existing namespace that carries no NetworkPolicy
+of its own -- when it is set this script neither gets nor creates the namespace,
+so no cluster-scoped permission is required at all.
+
+Skipping the leg is not an option here. A green run missing a deny leg reads as
+proof that connector ingress is narrow when in fact nothing checked it, which is
+worse than no check at all (#1502)."
+fi
+
+# $FOREIGN_NS has to be a policy VACUUM or a denial observed from it is
+# unattributable, and nothing so far establishes that. Concretely: an admission
+# webhook (Kyverno, Gatekeeper, Rancher) injects an egress policy into the
+# namespace that allows the pod CIDR and DNS but not the Service CIDR. Both
+# foreign positive controls below still pass -- they use a pod IP and DNS -- the
+# connector curl then fails on the PROBE'S OWN EGRESS, and the leg prints ok
+# while connector ingress is wide open. Listing policies is namespaced, so it
+# still works for an operator who supplied $FOREIGN_NS without cluster-scoped
+# rights.
+if ! FOREIGN_POLICIES="$(kubectl -n "$FOREIGN_NS" get networkpolicy \
+     -o jsonpath='{range .items[*]}{.metadata.name}{" "}{end}' 2>/dev/null)"; then
+  fail "could not list NetworkPolicies in $FOREIGN_NS.
+
+Either that namespace does not exist, or this context cannot read
+NetworkPolicies in it. The listing cannot be skipped: the foreign probe's
+denial is only attributable to connector ingress if its own namespace carries no
+policy of its own. Reading NetworkPolicies is a namespaced permission, not a
+cluster-scoped one -- grant it in $FOREIGN_NS, or point CURIE_NETPOL_FOREIGN_NS
+at an existing policy-free namespace you can read (#1502)."
+fi
+if [ -n "$FOREIGN_POLICIES" ]; then
+  fail "namespace $FOREIGN_NS carries NetworkPolicies of its own: $FOREIGN_POLICIES
+
+A denial observed from that namespace is then unattributable -- it could be the
+connector's ingress policy, or it could be an egress rule applying to the probe
+itself. An injected egress policy that allows the pod CIDR and DNS but not the
+Service CIDR leaves both foreign positive controls passing, so this leg would
+print ok while connector ingress is in fact wide open.
+
+Point CURIE_NETPOL_FOREIGN_NS at a namespace that carries no NetworkPolicy, or
+remove the policies from $FOREIGN_NS (#1502)."
+fi
+echo "  ok  foreign namespace $FOREIGN_NS carries no NetworkPolicy of its own"
+
 cleanup_and_settle
 kubectl -n "$NS" apply -f - >/dev/null <<YAML
 apiVersion: v1
@@ -98,9 +198,57 @@ spec:
       args: ["-listen=:8000", "-text=reachable"]
 YAML
 
+# Label-for-label identical to $SANDBOX_POD. Any difference here would make a
+# foreign denial ambiguous -- it could be the namespace axis or it could be the
+# labels -- and the whole point is that the namespace is the only variable.
+kubectl -n "$FOREIGN_NS" apply -f - >/dev/null <<YAML
+apiVersion: v1
+kind: Pod
+metadata:
+  name: $FOREIGN_POD
+  labels:
+    app.kubernetes.io/name: $APP
+    app.kubernetes.io/instance: $RELEASE
+    app.kubernetes.io/component: runner-sandbox
+spec:
+  restartPolicy: Never
+  containers:
+    - name: probe
+      image: $PROBE_IMAGE
+      command: ["sleep", "600"]
+YAML
+
 kubectl -n "$NS" wait --for=condition=Ready \
   "pod/$SANDBOX_POD" "pod/$OUTSIDE_POD" "pod/$DENY_TARGET_POD" --timeout=180s >/dev/null \
   || fail "probe pods did not become ready"
+
+# Separate call: `wait` is namespace-scoped, so the foreign pod cannot join the
+# list above. A pod that never came up would silently curl nothing, and this
+# fail() is what stops that from reading as a denial.
+kubectl -n "$FOREIGN_NS" wait --for=condition=Ready \
+  "pod/$FOREIGN_POD" --timeout=180s >/dev/null \
+  || fail "the foreign-namespace probe pod did not become ready in $FOREIGN_NS"
+
+# The labels are read back off the LIVE object, never assumed from the apply. A
+# mutating webhook can strip or rewrite app.kubernetes.io/component on a pod it
+# did not create, and a future edit to the YAML above has the identical effect.
+# Neither shows up anywhere else: the pod still goes Ready and both foreign
+# positive controls still pass, because neither depends on labels.
+FOREIGN_LABELS="$(kubectl -n "$FOREIGN_NS" get pod "$FOREIGN_POD" \
+  -o jsonpath='{.metadata.labels.app\.kubernetes\.io/name} {.metadata.labels.app\.kubernetes\.io/instance} {.metadata.labels.app\.kubernetes\.io/component}' 2>/dev/null || true)"
+if [ "$FOREIGN_LABELS" != "$APP $RELEASE runner-sandbox" ]; then
+  fail "the foreign probe in $FOREIGN_NS is not wearing the runner-sandbox labels.
+
+  expected  $APP $RELEASE runner-sandbox
+  read back $FOREIGN_LABELS
+
+Wearing them is the entire reason this probe can see the namespace axis. An
+unlabelled pod is denied by a correct connector policy and by a
+namespace-widened one alike, so this leg would degrade into a second copy of the
+same-namespace outside probe -- green, and blind to the widening it exists to
+catch (#1502)."
+fi
+echo "  ok  foreign probe wears the runner-sandbox labels"
 
 DENY_TARGET_IP="$(kubectl -n "$NS" get pod "$DENY_TARGET_POD" -o jsonpath='{.status.podIP}')"
 [ -n "$DENY_TARGET_IP" ] || fail "could not read the deny target's pod IP"
@@ -148,6 +296,31 @@ if ! kubectl -n "$NS" exec "$OUTSIDE_POD" -- \
 fi
 echo "  ok  outside positive control resolves DNS"
 
+# The foreign probe carries its own pair of positive controls, for the same
+# reason the outside probe does: without them its denial could be caused by the
+# prober rather than by the policy, and a vacuous deny leg is the defect this
+# whole script exists to prevent.
+#
+# Both controls MUST pass on a correct cluster, and that is provable rather than
+# hopeful. NetworkPolicy is namespace-scoped, so nothing in $NS restricts egress
+# from a pod in $FOREIGN_NS; and the deny target is selected by no ingress
+# policy at all, so its ingress is unrestricted. A failure here therefore means
+# the prober is broken, NOT that policy is working.
+if ! kubectl -n "$FOREIGN_NS" exec "$FOREIGN_POD" -- \
+      curl -s -m 8 -o /dev/null "http://${DENY_TARGET_IP}:8000/" 2>/dev/null; then
+  fail "the foreign probe in $FOREIGN_NS cannot reach the deny target cross-namespace; a broken cross-namespace network cannot certify connector ingress"
+fi
+echo "  ok  foreign positive control reaches the deny target cross-namespace"
+
+# Sharper here than for the outside probe: the foreign probe reaches connectors
+# by NAME, so broken DNS would make every foreign denial vacuous while looking
+# exactly like enforcement.
+if ! kubectl -n "$FOREIGN_NS" exec "$FOREIGN_POD" -- \
+      getent hosts kubernetes.default.svc.cluster.local >/dev/null 2>&1; then
+  fail "the foreign probe cannot resolve DNS; connector ingress denial from $FOREIGN_NS would be vacuous"
+fi
+echo "  ok  foreign positive control resolves DNS"
+
 # DNS is the allow every sandbox depends on (curie-runner-allow-dns); without it
 # a sandbox cannot resolve any Service name, which surfaces as a confusing
 # connection failure rather than a policy error.
@@ -191,6 +364,43 @@ NetworkPolicy is evaluated, so such a rule can never match (ADR-0086)."
     fail "the outside probe reached connector Service $svc:$PORT; connector ingress is not restricted to runner sandboxes"
   fi
   echo "  ok  outside probe cannot reach connector $svc:$PORT"
+
+  # This connector's exact FQDN must resolve from $FOREIGN_NS before its
+  # unreachability can mean anything. The generic control above proves only that
+  # kubernetes.default resolves, and a Cilium FQDN policy or a CoreDNS view can
+  # permit that name while refusing this one -- curl would exit non-zero without
+  # ever attempting the connection and the denial below would read as
+  # enforcement.
+  if ! kubectl -n "$FOREIGN_NS" exec "$FOREIGN_POD" -- \
+        getent hosts "${svc}.${NS}.svc.cluster.local" >/dev/null 2>&1; then
+    fail "the foreign probe cannot resolve ${svc}.${NS}.svc.cluster.local from $FOREIGN_NS.
+
+Its failure to reach $svc would then be a DNS failure, not a policy denial, and
+this leg would certify connector ingress as narrow without a single packet ever
+having been sent to it (#1502)."
+  fi
+  echo "  ok  foreign probe resolves ${svc}.${NS}.svc.cluster.local"
+
+  # By FQDN, never the short name. $svc resolves only inside $NS; from
+  # $FOREIGN_NS it would fail DNS, curl would exit non-zero, and this leg would
+  # read that as "policy denied me" without ever attempting the connection --
+  # a false green of the worst kind. The FQDN forces the connection to be made
+  # so that its failure is attributable to the ingress policy.
+  if kubectl -n "$FOREIGN_NS" exec "$FOREIGN_POD" -- \
+       curl -s -m 10 -o /dev/null "http://${svc}.${NS}.svc.cluster.local:${PORT}/" 2>/dev/null; then
+    fail "a sandbox-labelled pod in $FOREIGN_NS reached connector Service $svc:$PORT.
+
+The ingress 'from' peer has been widened on the NAMESPACE axis: a
+namespaceSelector: {} merged into the existing peer makes it admit
+sandbox-labelled pods in every namespace instead of only $NS. Any pod anyone can
+schedule anywhere in this cluster can now wear those three labels and talk to a
+connector holding a production credential.
+
+The unlabelled same-namespace outside probe stays DENIED under this widening,
+which is why it reports green and why this probe exists at all (#1502,
+ADR-0086)."
+  fi
+  echo "  ok  foreign sandbox-labelled probe cannot reach connector $svc:$PORT"
 done
 
-echo "== Rail 1, connector egress, and connector ingress enforce =="
+echo "== Rail 1, connector egress, and connector ingress enforce; connector ingress proven narrow on BOTH axes (pod labels and namespace) =="


### PR DESCRIPTION
Closes #1502

## The gap

The connector ingress NetworkPolicy's `from` block is a single bare `podSelector` on the
runner-sandbox labels, which is implicitly namespace-local. The cluster gate's only deny
prober was `netpol-probe-outside` — **unlabelled, same namespace** — so it could observe
widenings of the *pod* axis only. Merging `namespaceSelector: {}` INTO that existing peer
relaxes the *namespace* axis instead: it admits sandbox-labelled pods in every namespace
while the unlabelled same-namespace probe stays denied, so the ladder stayed green.

Confirmed on kind + Calico **before** the change: with that mutation applied to the live
policy the gate printed every `ok` and exited 0, while a sandbox-labelled pod in another
namespace read the connector successfully.

## The change

`netpol-probe-foreign` — the same three sandbox labels, in a different namespace,
addressing each connector by FQDN and required to be denied per connector. It differs from
the sandbox probe on exactly the axis the existing probes hold constant, which is what
makes the widening observable.

A denial is only evidence when it is attributable, so the new leg carries its own
non-vacuity guards: the foreign namespace must carry no NetworkPolicy of its own, the
probe's labels are read back off the live object, and the probe must resolve each
connector's FQDN before its failure to reach it counts. A missing namespace is a hard
failure, never a skip. `CURIE_NETPOL_FOREIGN_NS` lets an operator supply the namespace, and
that path makes no cluster-scoped call at all.

**No production source changed.** `render_ingress_networkpolicy` is already correct; this
closes a coverage gap.

## Acceptance criteria

| AC | Evidence |
|---|---|
| 1. Sandbox-labelled probe in another namespace denied, per connector | Live on kind+Calico: `ok foreign sandbox-labelled probe cannot reach connector <svc>:8000`; harness pins the exact six-attempt set for two connectors |
| 2. Merging `namespaceSelector: {}` makes a named test go red | `test_ingress_source_peer_is_namespace_scoped_by_omission` fails naming the namespace axis; live gate goes `EXIT=1` on the foreign leg **while the outside leg still prints `ok`** |
| 3. Unit test pins the `from` block, no cluster needed | Same named test: one peer, key set exactly `{"podSelector"}`, `"namespaceSelector" not in src[0]` |

## Verification

- Live, correct policy → `EXIT=0`; mutated policy → `EXIT=1` on the foreign leg.
- The denial is a policy drop, not a missing listener: curl exit 28 at **10.18s** (the full
  `-m 10` timeout) vs **0.13s** when admitted. Matches the 10.06s #1482 recorded.
- Every new guard was demonstrated rejecting a violating input by execution, and each was
  proved able to go red by neutralising it in a scratch copy of the script.
- Back-to-back runs idempotent, including the prior-pod-`Terminating` race.
- `ruff check .` clean · `mypy` clean (191 files) · 355 tests pass.

## Review findings addressed

Independent code, scope, and security review passes returned no blocking findings, and
converged on one residual class: the *new* leg could itself report a false green. Five
holes were closed in response — unchecked namespace policy vacuum, unread probe labels, a
DNS control resolving the wrong name, a `CURIE_NETPOL_FOREIGN_NS` escape hatch that did not
actually avoid cluster-scoped RBAC, and a namespace-create race. A follow-up consolidation
pass was re-reviewed and confirmed behaviour-preserving.

## Out of scope

- A **second, additive NetworkPolicy** selecting the connector pods and adding a broader
  `from` is invisible to any prober (policies are additive — ADR-0067). It needs an
  object-count assertion, not a probe. Outside #1502's ACs; worth a follow-up issue.
- `curie dev netpol-check` can now hard-fail on a kubectl context lacking cluster-scoped
  namespace RBAC. `cli/src/main.rs`'s help text does not mention it (`cli/` was out of
  scope for this change).
- Scope review flagged the extended banner line as a passenger. Kept deliberately: it is
  the gate's own summary of what it proved and would otherwise under-report the new leg.
